### PR TITLE
perf: cross-zone lease-based cache invalidation (replace best-effort pub/sub)

### DIFF
--- a/src/nexus/bricks/rebac/cache/channel_codec.py
+++ b/src/nexus/bricks/rebac/cache/channel_codec.py
@@ -1,0 +1,42 @@
+"""Shared channel key encoder/decoder for invalidation channels.
+
+Provides a consistent, safe encoding for channel names used by both
+PubSub (fire-and-forget) and DurableInvalidationStream (Redis Streams).
+
+Uses pipe '|' as delimiter instead of ':' to avoid ambiguity when
+zone_id contains colons (e.g. 'us-east-1:partition-2').
+
+Related: Issue #3396
+"""
+
+from __future__ import annotations
+
+# Delimiter chosen to avoid conflict with zone_id colons and Redis key conventions.
+_DELIM = "|"
+
+
+def encode_channel(prefix: str, zone_id: str, layer: str) -> str:
+    """Encode a channel name from components.
+
+    Args:
+        prefix: Channel prefix (e.g. 'rebac:invalidation' or 'rebac:durable')
+        zone_id: Zone identifier (may contain colons)
+        layer: Cache layer name (e.g. 'boundary', 'all')
+
+    Returns:
+        Encoded channel string safe for Redis key usage.
+    """
+    return f"{prefix}{_DELIM}{zone_id}{_DELIM}{layer}"
+
+
+def decode_channel(channel: str) -> tuple[str, str, str] | None:
+    """Decode a channel name into (prefix, zone_id, layer).
+
+    Returns:
+        Tuple of (prefix, zone_id, layer) or None if the channel
+        doesn't match the expected format.
+    """
+    parts = channel.split(_DELIM)
+    if len(parts) != 3:
+        return None
+    return parts[0], parts[1], parts[2]

--- a/src/nexus/bricks/rebac/cache/coordinator.py
+++ b/src/nexus/bricks/rebac/cache/coordinator.py
@@ -394,6 +394,8 @@ class CacheCoordinator:
         subject: tuple[str, str],
         relation: str,
         object: tuple[str, str],  # noqa: A002
+        *,
+        local_only: bool = False,
     ) -> None:
         """Invalidate all caches after a permission write.
 
@@ -405,6 +407,9 @@ class CacheCoordinator:
             subject: (subject_type, subject_id)
             relation: Relation that was written
             object: (object_type, object_id)
+            local_only: If True, skip cross-zone publishing (steps 9-10).
+                Used by the durable stream consumer handler to avoid
+                re-broadcasting received invalidations (ping-pong loop).
         """
         self._invalidation_count += 1
         subject_type, subject_id = subject
@@ -448,33 +453,36 @@ class CacheCoordinator:
                 object_id=object_id,
             )
 
-        # 9. Pub/Sub: Publish cross-zone hint (Issue #3192)
-        if self._pubsub:
-            self._pubsub.publish_invalidation(
-                zone_id=zone_id,
-                layer="all",
-                payload={
-                    "subject_type": subject_type,
-                    "subject_id": subject_id,
-                    "relation": relation,
-                    "object_type": object_type,
-                    "object_id": object_id,
-                },
-            )
+        # Steps 9-10: Cross-zone publishing — skipped when local_only=True
+        # to prevent ping-pong loops when the consumer handler re-enters.
+        if not local_only:
+            # 9. Pub/Sub: Publish cross-zone hint (Issue #3192)
+            if self._pubsub:
+                self._pubsub.publish_invalidation(
+                    zone_id=zone_id,
+                    layer="all",
+                    payload={
+                        "subject_type": subject_type,
+                        "subject_id": subject_id,
+                        "relation": relation,
+                        "object_type": object_type,
+                        "object_id": object_id,
+                    },
+                )
 
-        # 10. Durable Stream: Publish cross-zone guaranteed delivery (Issue #3396)
-        if self._durable_stream:
-            self._durable_stream.publish(
-                target_zone_id=zone_id,
-                payload={
-                    "source_zone": zone_id,
-                    "subject_type": subject_type,
-                    "subject_id": subject_id,
-                    "relation": relation,
-                    "object_type": object_type,
-                    "object_id": object_id,
-                },
-            )
+            # 10. Durable Stream: Publish cross-zone guaranteed delivery (Issue #3396)
+            if self._durable_stream:
+                self._durable_stream.publish(
+                    target_zone_id=zone_id,
+                    payload={
+                        "source_zone": zone_id,
+                        "subject_type": subject_type,
+                        "subject_id": subject_id,
+                        "relation": relation,
+                        "object_type": object_type,
+                        "object_id": object_id,
+                    },
+                )
 
     def invalidate_zone_graph(self, zone_id: str | None = None) -> None:
         """Invalidate zone graph cache.

--- a/src/nexus/bricks/rebac/cache/coordinator.py
+++ b/src/nexus/bricks/rebac/cache/coordinator.py
@@ -1281,7 +1281,7 @@ class CacheCoordinator:
 
     def get_stats(self) -> dict[str, Any]:
         """Get coordinator statistics."""
-        stats = {
+        stats: dict[str, Any] = {
             "total_invalidations": self._invalidation_count,
             "zone_graph_invalidations": self._zone_graph_invalidations,
             "l1_invalidations": self._l1_invalidations,

--- a/src/nexus/bricks/rebac/cache/coordinator.py
+++ b/src/nexus/bricks/rebac/cache/coordinator.py
@@ -7,21 +7,24 @@ When a permission tuple is written/deleted, the coordinator ensures
 all affected caches are properly invalidated in the correct order:
 1. Zone graph cache (in-memory tuple cache)
 2. L1 permission check cache (targeted by subject + object)
-3. Permission leases — zone-wide clear (Issue #3394)
-4. Boundary cache (permission inheritance boundaries)
-5. Directory visibility cache (dir listing optimization)
-6. Iterator cache (pagination cursors)
+3. Tiger L2 (Dragonfly) cache — explicit delete (Issue #3395)
+4. Permission leases — zone-wide clear (Issue #3394)
+5. Boundary cache (permission inheritance boundaries)
+6. Directory visibility cache (dir listing optimization)
 7. Namespace cache — dcache + mount table (Issue #1244)
-8. Leopard cache (transitive group closure) - via callbacks
-9. Tiger cache (materialized bitmaps) - via callbacks
+8. Iterator cache (pagination cursors)
+9. DT_STREAM — intra-zone ordered invalidation (Issue #3192)
+10. Pub/Sub — cross-zone fire-and-forget hints (Issue #3192)
+11. Durable Stream — cross-zone guaranteed delivery (Issue #3396)
 
 Also handles:
 - L2 (database) cache invalidation with precise targeting (Issue #2179 Step 2.5)
 - Eager cache recomputation for simple direct relations (PR #969)
 - Expired tuple/cache cleanup (maintenance)
 - Cache statistics (monitoring)
+- Read fence watermark advancement (Issue #3396)
 
-Related: Issue #1459 (decomposition), Issue #2179 (rebac-brick), Issue #1244, Issue #1077
+Related: Issue #1459, #2179, #1244, #1077, #3396
 """
 
 import concurrent.futures
@@ -30,6 +33,12 @@ import time as time_module
 from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
+from nexus.bricks.rebac.cache.coordinator_config import (
+    CoordinatorConfig,
+    DatabaseCallbacks,
+    InvalidationChannels,
+    RecomputeCallbacks,
+)
 from nexus.bricks.rebac.cache.invalidation_stream import (
     InvalidationEventType,
     InvalidationStream,
@@ -42,7 +51,9 @@ if TYPE_CHECKING:
     from collections.abc import Callable, MutableMapping
 
     from nexus.bricks.rebac.cache.boundary import PermissionBoundaryCache
+    from nexus.bricks.rebac.cache.durable_stream import DurableInvalidationStream
     from nexus.bricks.rebac.cache.iterator import IteratorCache
+    from nexus.bricks.rebac.cache.read_fence import ReadFence
     from nexus.bricks.rebac.cache.result_cache import ReBACPermissionCache
     from nexus.bricks.rebac.domain import Entity
 
@@ -78,72 +89,85 @@ class CacheCoordinator:
         iterator_cache: "IteratorCache | None" = None,
         zone_graph_cache: "MutableMapping[str, Any] | None" = None,
         *,
-        # Database access callbacks (Issue #2179 Step 2.5)
+        # Grouped config (Issue #3396) — preferred
+        config: CoordinatorConfig | None = None,
+        # Legacy individual params (backward compat — used if config is None)
         connection_factory: "Callable[..., Any] | None" = None,
         get_connection: "Callable[[], Any] | None" = None,
         close_connection: "Callable[[Any], None] | None" = None,
         create_cursor: "Callable[[Any], Any] | None" = None,
         fix_sql: "Callable[[str], str] | None" = None,
-        # Eager recompute callbacks
         get_namespace_cb: "Callable[[str], Any] | None" = None,
         compute_permission_cb: "Callable[..., bool] | None" = None,
         cache_check_result_cb: "Callable[..., None] | None" = None,
-        # DT_STREAM for intra-zone invalidation (Issue #3192)
         invalidation_stream: "InvalidationStream | None" = None,
-        # Pub/Sub for cross-zone invalidation hints (Issue #3192)
         pubsub: "PubSubInvalidation | None" = None,
-        # Async eager recompute — disable for SQLite/StaticPool where
-        # background threads share the same DBAPI connection (segfault).
         enable_async_recompute: bool = True,
-        # Stats / cleanup
         cache_ttl_seconds: int = 300,
         get_tuple_version: "Callable[[], int] | None" = None,
         set_tuple_version: "Callable[[int], None] | None" = None,
     ) -> None:
         """Initialize the coordinator.
 
-        Args:
-            l1_cache: L1 in-memory permission check cache
-            boundary_cache: Permission boundary cache
-            iterator_cache: Paginated query iterator cache
-            zone_graph_cache: Zone tuple graph cache dict (shared reference)
-            connection_factory: Context manager for database connections
-            get_connection: Get a raw DBAPI connection
-            close_connection: Close a raw DBAPI connection
-            create_cursor: Create a cursor from a connection
-            fix_sql: Adapt SQL placeholders for the DB dialect
-            get_namespace_cb: Lookup namespace config by object type
-            compute_permission_cb: Compute a permission (for eager recompute)
-            cache_check_result_cb: Store a check result in cache
-            cache_ttl_seconds: L2 cache TTL for stats reporting
-            get_tuple_version: Get current tuple version counter
-            set_tuple_version: Set tuple version counter
+        Accepts either a ``CoordinatorConfig`` (preferred) or individual
+        keyword arguments (backward compat).  If ``config`` is provided,
+        individual channel/db/recompute params are ignored.
         """
         self._l1_cache = l1_cache
         self._boundary_cache = boundary_cache
         self._iterator_cache = iterator_cache
         self._zone_graph_cache = zone_graph_cache
 
-        # Database access
-        self._connection_factory = connection_factory
-        self._get_connection = get_connection
-        self._close_connection = close_connection
-        self._create_cursor = create_cursor
-        self._fix_sql = fix_sql
+        # Resolve config — prefer grouped, fall back to individual params
+        if config is not None:
+            channels = config.channels
+            db = config.database
+            rc = config.recompute
+            _enable_async = config.enable_async_recompute
+            _ttl = config.cache_ttl_seconds
+            _get_tv = config.get_tuple_version
+            _set_tv = config.set_tuple_version
+        else:
+            channels = InvalidationChannels(stream=invalidation_stream, pubsub=pubsub)
+            db = DatabaseCallbacks(
+                connection_factory=connection_factory,
+                get_connection=get_connection,
+                close_connection=close_connection,
+                create_cursor=create_cursor,
+                fix_sql=fix_sql,
+            )
+            rc = RecomputeCallbacks(
+                get_namespace=get_namespace_cb,
+                compute_permission=compute_permission_cb,
+                cache_check_result=cache_check_result_cb,
+            )
+            _enable_async = enable_async_recompute
+            _ttl = cache_ttl_seconds
+            _get_tv = get_tuple_version
+            _set_tv = set_tuple_version
 
-        # DT_STREAM + Pub/Sub (Issue #3192)
-        self._stream = invalidation_stream
-        self._pubsub = pubsub
+        # Database access
+        self._connection_factory = db.connection_factory
+        self._get_connection = db.get_connection
+        self._close_connection = db.close_connection
+        self._create_cursor = db.create_cursor
+        self._fix_sql = db.fix_sql
+
+        # Channels (Issue #3192, #3396)
+        self._stream = channels.stream
+        self._pubsub = channels.pubsub
+        self._durable_stream: DurableInvalidationStream | None = channels.durable_stream
+        self._read_fence: ReadFence | None = channels.read_fence
 
         # Eager recompute
-        self._get_namespace_cb = get_namespace_cb
-        self._compute_permission_cb = compute_permission_cb
-        self._cache_check_result_cb = cache_check_result_cb
+        self._get_namespace_cb = rc.get_namespace
+        self._compute_permission_cb = rc.compute_permission
+        self._cache_check_result_cb = rc.cache_check_result
 
         # Stats / cleanup
-        self._cache_ttl_seconds = cache_ttl_seconds
-        self._get_tuple_version = get_tuple_version
-        self._set_tuple_version = set_tuple_version
+        self._cache_ttl_seconds = _ttl
+        self._get_tuple_version = _get_tv
+        self._set_tuple_version = _set_tv
 
         # Callback registries for external caches (boundary, visibility, etc.)
         self._boundary_invalidators: list[
@@ -163,7 +187,7 @@ class CacheCoordinator:
 
         # Async eager recompute (Issue #3192)
         self._recompute_executor: concurrent.futures.ThreadPoolExecutor | None = None
-        self._async_recompute_enabled = enable_async_recompute
+        self._async_recompute_enabled = _enable_async
         self._recompute_submitted = 0
         self._recompute_completed = 0
         self._recompute_failed = 0
@@ -213,6 +237,14 @@ class CacheCoordinator:
     def set_pubsub(self, pubsub: "PubSubInvalidation") -> None:
         """Set the Pub/Sub for cross-zone invalidation hints."""
         self._pubsub = pubsub
+
+    def set_durable_stream(self, durable: "DurableInvalidationStream") -> None:
+        """Set the durable cross-zone invalidation stream (Issue #3396)."""
+        self._durable_stream = durable
+
+    def set_read_fence(self, fence: "ReadFence") -> None:
+        """Set the read fence for cross-zone staleness detection (Issue #3396)."""
+        self._read_fence = fence
 
     # ------------------------------------------------------------------
     # Callback registration
@@ -422,6 +454,20 @@ class CacheCoordinator:
                 zone_id=zone_id,
                 layer="all",
                 payload={
+                    "subject_type": subject_type,
+                    "subject_id": subject_id,
+                    "relation": relation,
+                    "object_type": object_type,
+                    "object_id": object_id,
+                },
+            )
+
+        # 10. Durable Stream: Publish cross-zone guaranteed delivery (Issue #3396)
+        if self._durable_stream:
+            self._durable_stream.publish(
+                target_zone_id=zone_id,
+                payload={
+                    "source_zone": zone_id,
                     "subject_type": subject_type,
                     "subject_id": subject_id,
                     "relation": relation,
@@ -905,6 +951,55 @@ class CacheCoordinator:
             logger.info("Cache statistics reset")
 
     # ------------------------------------------------------------------
+    # Generic dispatch helper (Issue #3396 decision 5A — DRY)
+    # ------------------------------------------------------------------
+
+    def _dispatch_to_layer(
+        self,
+        event_type: InvalidationEventType,
+        zone_id: str,
+        callbacks: "list[tuple[str, Callable[..., None]]]",
+        callback_invoker: "Callable[[Callable[..., None]], None]",
+        *,
+        stream_payload: dict[str, Any] | None = None,
+        metric_attr: str | None = None,
+    ) -> None:
+        """Dispatch an invalidation event to stream consumers or callbacks.
+
+        Consolidates the repeated pattern: if DT_STREAM → append to stream,
+        else → loop callbacks with try/except isolation.
+
+        Args:
+            event_type: InvalidationEventType for stream dispatch.
+            zone_id: Zone where the invalidation occurred.
+            callbacks: List of (callback_id, callback_fn) pairs.
+            callback_invoker: Closure that calls a single callback with the
+                right arguments (varies per layer).
+            stream_payload: Payload dict for stream.append() (if stream active).
+            metric_attr: Optional attribute name to increment (e.g. '_boundary_invalidations').
+        """
+        if not callbacks and not self._stream:
+            return
+
+        if metric_attr:
+            setattr(self, metric_attr, getattr(self, metric_attr, 0) + 1)
+
+        if self._stream and stream_payload is not None:
+            self._stream.append(event_type, zone_id, **stream_payload)
+        else:
+            for callback_id, callback in callbacks:
+                try:
+                    callback_invoker(callback)
+                except Exception:
+                    self._callback_failure_count += 1
+                    logger.warning(
+                        "[CacheCoordinator] Callback %s failed for %s",
+                        callback_id,
+                        event_type.value,
+                        exc_info=True,
+                    )
+
+    # ------------------------------------------------------------------
     # Internal helpers (L1 + zone graph)
     # ------------------------------------------------------------------
 
@@ -1085,34 +1180,25 @@ class CacheCoordinator:
         # Map relation to permissions
         permissions = RELATION_TO_PERMISSIONS.get(relation, [relation])
 
-        self._boundary_invalidations += 1
+        def _invoke_boundary(cb: "Callable[..., None]") -> None:
+            for permission in permissions:
+                cb(zone_id, subject_type, subject_id, permission, object_id)
 
-        # When DT_STREAM is active, publish to stream (consumers handle dispatch).
-        # Otherwise fall back to legacy callback loop. (Issue #3192)
-        if self._stream:
-            self._stream.append(
-                InvalidationEventType.BOUNDARY,
-                zone_id,
-                subject_type=subject_type,
-                subject_id=subject_id,
-                relation=relation,
-                object_type=object_type,
-                object_id=object_id,
-                permissions=permissions,
-            )
-        else:
-            for callback_id, callback in self._boundary_invalidators:
-                for permission in permissions:
-                    try:
-                        callback(zone_id, subject_type, subject_id, permission, object_id)
-                    except Exception:
-                        self._callback_failure_count += 1
-                        logger.warning(
-                            "[CacheCoordinator] Boundary invalidator %s failed for %s",
-                            callback_id,
-                            permission,
-                            exc_info=True,
-                        )
+        self._dispatch_to_layer(
+            InvalidationEventType.BOUNDARY,
+            zone_id,
+            self._boundary_invalidators,
+            _invoke_boundary,
+            stream_payload={
+                "subject_type": subject_type,
+                "subject_id": subject_id,
+                "relation": relation,
+                "object_type": object_type,
+                "object_id": object_id,
+                "permissions": permissions,
+            },
+            metric_attr="_boundary_invalidations",
+        )
 
         # Always invalidate the internal boundary cache directly
         if self._boundary_cache:
@@ -1135,27 +1221,14 @@ class CacheCoordinator:
         if object_type not in ("file", "memory", "resource"):
             return
 
-        self._visibility_invalidations += 1
-
-        if self._stream:
-            self._stream.append(
-                InvalidationEventType.VISIBILITY,
-                zone_id,
-                object_type=object_type,
-                object_id=object_id,
-            )
-        else:
-            for callback_id, callback in self._visibility_invalidators:
-                try:
-                    callback(zone_id, object_id)
-                except Exception:
-                    self._callback_failure_count += 1
-                    logger.warning(
-                        "[CacheCoordinator] Visibility invalidator %s failed for %s",
-                        callback_id,
-                        object_id,
-                        exc_info=True,
-                    )
+        self._dispatch_to_layer(
+            InvalidationEventType.VISIBILITY,
+            zone_id,
+            self._visibility_invalidators,
+            lambda cb: cb(zone_id, object_id),
+            stream_payload={"object_type": object_type, "object_id": object_id},
+            metric_attr="_visibility_invalidations",
+        )
 
     def notify_namespace_invalidators(
         self,
@@ -1177,28 +1250,14 @@ class CacheCoordinator:
         if not self._namespace_invalidators and not self._stream:
             return
 
-        self._namespace_invalidations += 1
-
-        if self._stream:
-            self._stream.append(
-                InvalidationEventType.NAMESPACE,
-                zone_id,
-                subject_type=subject_type,
-                subject_id=subject_id,
-            )
-        else:
-            for callback_id, callback in self._namespace_invalidators:
-                try:
-                    callback(subject_type, subject_id, zone_id)
-                except Exception:
-                    self._callback_failure_count += 1
-                    logger.warning(
-                        "[CacheCoordinator] Namespace invalidator %s failed for %s:%s",
-                        callback_id,
-                        subject_type,
-                        subject_id,
-                        exc_info=True,
-                    )
+        self._dispatch_to_layer(
+            InvalidationEventType.NAMESPACE,
+            zone_id,
+            self._namespace_invalidators,
+            lambda cb: cb(subject_type, subject_id, zone_id),
+            stream_payload={"subject_type": subject_type, "subject_id": subject_id},
+            metric_attr="_namespace_invalidations",
+        )
 
     def _invalidate_iterator(self, zone_id: str) -> None:
         """Invalidate iterator cache for a zone."""
@@ -1214,7 +1273,7 @@ class CacheCoordinator:
 
     def get_stats(self) -> dict[str, Any]:
         """Get coordinator statistics."""
-        return {
+        stats = {
             "total_invalidations": self._invalidation_count,
             "zone_graph_invalidations": self._zone_graph_invalidations,
             "l1_invalidations": self._l1_invalidations,
@@ -1235,7 +1294,14 @@ class CacheCoordinator:
             "async_recompute_failed": self._recompute_failed,
             "stream_enabled": self._stream is not None,
             "pubsub_enabled": self._pubsub is not None,
+            "durable_stream_enabled": self._durable_stream is not None,
+            "read_fence_enabled": self._read_fence is not None,
         }
+        if self._durable_stream:
+            stats["durable_stream"] = self._durable_stream.stats()
+        if self._read_fence:
+            stats["read_fence"] = self._read_fence.stats()
+        return stats
 
     def reset_stats(self) -> None:
         """Reset metrics counters."""

--- a/src/nexus/bricks/rebac/cache/coordinator_config.py
+++ b/src/nexus/bricks/rebac/cache/coordinator_config.py
@@ -1,0 +1,104 @@
+"""Config dataclasses for CacheCoordinator constructor (Issue #3396).
+
+Groups related parameters into semantic units to reduce constructor
+parameter count from 15+ to ~6-7 top-level arguments.
+
+Related: Issue #3396, Issue #1459
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from collections.abc import Callable
+
+    from nexus.bricks.rebac.cache.durable_stream import DurableInvalidationStream
+    from nexus.bricks.rebac.cache.invalidation_stream import InvalidationStream
+    from nexus.bricks.rebac.cache.pubsub_invalidation import PubSubInvalidation
+    from nexus.bricks.rebac.cache.read_fence import ReadFence
+
+
+@dataclass(frozen=True, slots=True)
+class InvalidationChannels:
+    """All cross-process / cross-zone invalidation channels.
+
+    Groups DT_STREAM (intra-zone), Pub/Sub (cross-zone hints), and
+    DurableStream (cross-zone guaranteed delivery) into one config.
+    """
+
+    stream: InvalidationStream | None = None
+    """Intra-zone ordered invalidation stream (DT_STREAM)."""
+
+    pubsub: PubSubInvalidation | None = None
+    """Cross-zone fire-and-forget invalidation hints."""
+
+    durable_stream: DurableInvalidationStream | None = None
+    """Cross-zone durable invalidation via Redis Streams (Issue #3396)."""
+
+    read_fence: ReadFence | None = None
+    """Per-zone watermark for read-path staleness detection."""
+
+
+@dataclass(frozen=True, slots=True)
+class DatabaseCallbacks:
+    """Database access callbacks for L2 cache invalidation.
+
+    Used by eager recompute and deep invalidation (Issue #2179 Step 2.5).
+    """
+
+    connection_factory: Callable[..., Any] | None = None
+    """Context manager for database connections."""
+
+    get_connection: Callable[[], Any] | None = None
+    """Get a raw DBAPI connection."""
+
+    close_connection: Callable[[Any], None] | None = None
+    """Close a raw DBAPI connection."""
+
+    create_cursor: Callable[[Any], Any] | None = None
+    """Create a cursor from a connection."""
+
+    fix_sql: Callable[[str], str] | None = None
+    """Adapt SQL placeholders for the DB dialect."""
+
+
+@dataclass(frozen=True, slots=True)
+class RecomputeCallbacks:
+    """Eager cache recomputation callbacks (PR #969).
+
+    For simple direct relations, recompute the permission check
+    result instead of just invalidating the cache.
+    """
+
+    get_namespace: Callable[[str], Any] | None = None
+    """Lookup namespace config by object type."""
+
+    compute_permission: Callable[..., bool] | None = None
+    """Compute a permission check result."""
+
+    cache_check_result: Callable[..., None] | None = None
+    """Store a check result in the L1 cache."""
+
+
+@dataclass(slots=True)
+class CoordinatorConfig:
+    """Top-level configuration for CacheCoordinator.
+
+    Bundles all sub-configs and flags into a single init object.
+    Mutable (not frozen) so tests can easily override individual fields.
+    """
+
+    channels: InvalidationChannels = field(default_factory=InvalidationChannels)
+    database: DatabaseCallbacks = field(default_factory=DatabaseCallbacks)
+    recompute: RecomputeCallbacks = field(default_factory=RecomputeCallbacks)
+
+    enable_async_recompute: bool = True
+    """Disable for SQLite/StaticPool where background threads share DBAPI connection."""
+
+    cache_ttl_seconds: int = 300
+    """L2 cache TTL for stats reporting."""
+
+    get_tuple_version: Callable[[], int] | None = None
+    set_tuple_version: Callable[[int], None] | None = None

--- a/src/nexus/bricks/rebac/cache/durable_stream.py
+++ b/src/nexus/bricks/rebac/cache/durable_stream.py
@@ -262,11 +262,27 @@ class DurableInvalidationStream:
     # -- consumer loop (async background) -------------------------------------
 
     async def _consume_loop(self) -> None:
-        """Background task: read from Redis Streams and process events."""
+        """Background task: read from Redis Streams and process events.
+
+        Periodically reclaims failed messages from the PEL (every
+        _RECLAIM_INTERVAL iterations) so transient handler failures
+        are retried instead of stranded forever.
+        """
         sem = asyncio.Semaphore(self._consumer_concurrency)
+        iterations_since_reclaim = 0
+        _RECLAIM_EVERY = 30  # Reclaim PEL every ~30 read cycles (~60s at 2s block)
 
         while not self._closed:
             try:
+                # Periodically reclaim stranded messages from PEL
+                iterations_since_reclaim += 1
+                if iterations_since_reclaim >= _RECLAIM_EVERY:
+                    iterations_since_reclaim = 0
+                    try:
+                        await self.reclaim_pending()
+                    except Exception:
+                        logger.debug("[DurableStream] Reclaim cycle failed", exc_info=True)
+
                 stream_key = encode_channel(self._stream_prefix, self._zone_id, "all")
                 # XREADGROUP GROUP <group> <consumer> COUNT <n> BLOCK <ms> STREAMS <key> >
                 results = await self._client.xreadgroup(

--- a/src/nexus/bricks/rebac/cache/durable_stream.py
+++ b/src/nexus/bricks/rebac/cache/durable_stream.py
@@ -1,0 +1,549 @@
+"""Durable cross-zone invalidation stream via Redis Streams.
+
+Replaces fire-and-forget Pub/Sub with guaranteed delivery using
+Redis/Dragonfly Streams (XADD/XREADGROUP/XACK).  Provides:
+
+- Persistent offsets via consumer groups (catch-up on zone restart)
+- Acknowledgment per message (XACK)
+- Bounded stream size (MAXLEN ~ 100000)
+- Pipelined XADD for invalidation storms (batch up to 100)
+- Concurrent consumer with asyncio.Semaphore
+
+Architecture:
+    Publisher side (sync):
+        invalidate_for_write() → queue.put_nowait() → background drain → XADD pipeline
+    Consumer side (async):
+        XREADGROUP BLOCK → process batch → XACK → advance read fence watermark
+
+The sync publish preserves the synchronous invalidate_for_write() contract.
+The small window between queue-append and XADD is covered by the read fence
+(cached results are compared against the watermark, not the stream directly).
+
+Related: Issue #3396 (decisions 1A, 6A, 14A, 15A, 16A)
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+from collections import deque
+from typing import TYPE_CHECKING, Any
+
+from nexus.bricks.rebac.cache.channel_codec import encode_channel
+
+if TYPE_CHECKING:
+    from nexus.bricks.rebac.cache.read_fence import ReadFence
+
+logger = logging.getLogger(__name__)
+
+# Defaults
+_STREAM_PREFIX = "rebac:durable"
+_MAX_STREAM_LEN = 100_000  # MAXLEN ~ for XADD
+_DRAIN_BATCH_SIZE = 100  # Pipeline up to N events per drain cycle
+_CONSUMER_BATCH_SIZE = 10  # XREADGROUP COUNT per call
+_CONSUMER_BLOCK_MS = 2000  # XREADGROUP BLOCK timeout
+_CONSUMER_CONCURRENCY = 10  # Max concurrent event processing
+_QUEUE_MAXSIZE = 10_000  # Bounded in-process publish queue
+_DRAIN_INTERVAL_S = 0.05  # 50ms drain loop interval (idle)
+_MAX_DELIVERY_ATTEMPTS = 5  # Max retries before DLQ
+_CLAIM_MIN_IDLE_MS = 30_000  # XCLAIM: reclaim messages idle > 30s
+_DLQ_SUFFIX = ":dlq"  # Dead-letter queue stream suffix
+
+
+class DurableInvalidationStream:
+    """Cross-zone durable invalidation via Redis Streams.
+
+    Publisher API is synchronous (queue.put_nowait) to preserve the
+    sync invalidate_for_write() contract.  A background asyncio task
+    drains the queue and calls XADD with pipeline batching.
+
+    Consumer API is async — reads from a consumer group with XREADGROUP
+    BLOCK, processes events concurrently, and XACKs on completion.
+
+    Example::
+
+        stream = DurableInvalidationStream(
+            redis_client=async_redis,
+            zone_id="us-east-1",
+            read_fence=fence,
+        )
+        await stream.start()
+
+        # Publish (sync, from invalidate_for_write):
+        stream.publish("zone-b", {"subject_type": "user", ...})
+
+        # Consumer runs in background, updating read_fence watermarks.
+        await stream.stop()
+    """
+
+    def __init__(
+        self,
+        redis_client: Any = None,
+        *,
+        zone_id: str = "root",
+        read_fence: ReadFence | None = None,
+        stream_prefix: str = _STREAM_PREFIX,
+        max_stream_len: int = _MAX_STREAM_LEN,
+        drain_batch_size: int = _DRAIN_BATCH_SIZE,
+        consumer_batch_size: int = _CONSUMER_BATCH_SIZE,
+        consumer_block_ms: int = _CONSUMER_BLOCK_MS,
+        consumer_concurrency: int = _CONSUMER_CONCURRENCY,
+        queue_maxsize: int = _QUEUE_MAXSIZE,
+    ) -> None:
+        self._client = redis_client
+        self._zone_id = zone_id
+        self._read_fence = read_fence
+        self._stream_prefix = stream_prefix
+        self._max_stream_len = max_stream_len
+        self._drain_batch_size = drain_batch_size
+        self._consumer_batch_size = consumer_batch_size
+        self._consumer_block_ms = consumer_block_ms
+        self._consumer_concurrency = consumer_concurrency
+
+        self._enabled = redis_client is not None
+
+        # Sync publish queue — bounded to prevent OOM if drain stalls
+        self._queue: deque[tuple[str, dict[str, Any]]] = deque(maxlen=queue_maxsize)
+
+        # Background tasks
+        self._drain_task: asyncio.Task[None] | None = None
+        self._consumer_task: asyncio.Task[None] | None = None
+        self._closed = False
+
+        # Consumer group name = zone_id, consumer name = zone_id:consumer
+        self._group_name = f"zone:{zone_id}"
+        self._consumer_name = f"{zone_id}:consumer"
+
+        # Event handlers: list of async callables
+        self._handlers: list[tuple[str, Any]] = []
+
+        # Metrics
+        self._published = 0
+        self._drained = 0
+        self._drain_errors = 0
+        self._consumed = 0
+        self._consume_errors = 0
+        self._queue_drops = 0
+
+    # -- lifecycle ------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Start background drain and consumer tasks."""
+        if not self._enabled:
+            return
+
+        # Ensure consumer group exists for all subscribed streams
+        await self._ensure_consumer_groups()
+
+        self._drain_task = asyncio.create_task(self._drain_loop(), name="durable-stream-drain")
+        self._consumer_task = asyncio.create_task(
+            self._consume_loop(), name="durable-stream-consumer"
+        )
+        logger.info(
+            "[DurableStream] Started for zone %s (group=%s)",
+            self._zone_id,
+            self._group_name,
+        )
+
+    async def stop(self) -> None:
+        """Stop background tasks. Idempotent."""
+        self._closed = True
+        for task in (self._drain_task, self._consumer_task):
+            if task and not task.done():
+                task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await task
+        # Final drain of remaining queued events
+        if self._enabled:
+            await self._drain_batch()
+        logger.info("[DurableStream] Stopped for zone %s", self._zone_id)
+
+    # -- publish (sync) -------------------------------------------------------
+
+    def publish(self, target_zone_id: str, payload: dict[str, Any]) -> bool:
+        """Enqueue an invalidation event for durable delivery.
+
+        Synchronous — appends to an in-process deque. The background
+        drain task sends to Redis Streams asynchronously.
+
+        Args:
+            target_zone_id: Zone the invalidation targets.
+            payload: Invalidation details (subject, relation, object, etc.)
+
+        Returns:
+            True if enqueued, False if queue is full (event dropped).
+        """
+        if not self._enabled:
+            return False
+
+        if len(self._queue) >= (self._queue.maxlen or _QUEUE_MAXSIZE):
+            self._queue_drops += 1
+            logger.warning(
+                "[DurableStream] Queue full, dropping event for zone %s",
+                target_zone_id,
+            )
+            return False
+
+        self._queue.append((target_zone_id, payload))
+        self._published += 1
+        return True
+
+    # -- handler registration -------------------------------------------------
+
+    def register_handler(
+        self,
+        handler_id: str,
+        handler: Any,  # async callable(zone_id: str, payload: dict) -> None
+    ) -> None:
+        """Register an async handler for incoming durable stream events."""
+        for hid, _ in self._handlers:
+            if hid == handler_id:
+                return
+        self._handlers.append((handler_id, handler))
+
+    def unregister_handler(self, handler_id: str) -> bool:
+        """Unregister a handler."""
+        for i, (hid, _) in enumerate(self._handlers):
+            if hid == handler_id:
+                self._handlers.pop(i)
+                return True
+        return False
+
+    # -- drain loop (async background) ----------------------------------------
+
+    async def _drain_loop(self) -> None:
+        """Background task: drain the publish queue to Redis Streams."""
+        while not self._closed:
+            try:
+                if self._queue:
+                    await self._drain_batch()
+                else:
+                    await asyncio.sleep(_DRAIN_INTERVAL_S)
+            except asyncio.CancelledError:
+                return
+            except Exception:
+                self._drain_errors += 1
+                logger.warning("[DurableStream] Drain error", exc_info=True)
+                await asyncio.sleep(_DRAIN_INTERVAL_S)
+
+    async def _drain_batch(self) -> None:
+        """Drain up to drain_batch_size events using a Redis pipeline."""
+        if not self._queue:
+            return
+
+        batch: list[tuple[str, dict[str, Any]]] = []
+        while self._queue and len(batch) < self._drain_batch_size:
+            batch.append(self._queue.popleft())
+
+        if not batch:
+            return
+
+        try:
+            pipe = self._client.pipeline(transaction=False)
+            for target_zone_id, payload in batch:
+                stream_key = encode_channel(self._stream_prefix, target_zone_id, "all")
+                pipe.xadd(
+                    stream_key,
+                    {"data": json.dumps(payload)},
+                    maxlen=self._max_stream_len,
+                    approximate=True,
+                )
+            await pipe.execute()
+            self._drained += len(batch)
+        except Exception:
+            # Put failed events back at the front of the queue
+            for item in reversed(batch):
+                self._queue.appendleft(item)
+            self._drain_errors += 1
+            raise
+
+    # -- consumer loop (async background) -------------------------------------
+
+    async def _consume_loop(self) -> None:
+        """Background task: read from Redis Streams and process events."""
+        sem = asyncio.Semaphore(self._consumer_concurrency)
+
+        while not self._closed:
+            try:
+                stream_key = encode_channel(self._stream_prefix, self._zone_id, "all")
+                # XREADGROUP GROUP <group> <consumer> COUNT <n> BLOCK <ms> STREAMS <key> >
+                results = await self._client.xreadgroup(
+                    groupname=self._group_name,
+                    consumername=self._consumer_name,
+                    streams={stream_key: ">"},
+                    count=self._consumer_batch_size,
+                    block=self._consumer_block_ms,
+                )
+
+                if not results:
+                    continue
+
+                # results: list of [stream_key, [(msg_id, fields), ...]]
+                tasks = []
+                for _stream, messages in results:
+                    for msg_id, fields in messages:
+                        tasks.append(self._process_message(sem, stream_key, msg_id, fields))
+
+                if tasks:
+                    await asyncio.gather(*tasks, return_exceptions=True)
+
+            except asyncio.CancelledError:
+                return
+            except Exception:
+                self._consume_errors += 1
+                logger.warning("[DurableStream] Consumer error", exc_info=True)
+                await asyncio.sleep(1.0)
+
+    async def _process_message(
+        self,
+        sem: asyncio.Semaphore,
+        stream_key: str,
+        msg_id: bytes | str,
+        fields: dict[bytes | str, bytes | str],
+    ) -> None:
+        """Process a single message with concurrency control."""
+        async with sem:
+            try:
+                raw = fields.get(b"data") or fields.get("data")
+                if raw is None:
+                    logger.warning("[DurableStream] Message %s has no data field", msg_id)
+                    await self._client.xack(stream_key, self._group_name, msg_id)
+                    return
+
+                payload = json.loads(raw if isinstance(raw, str) else raw.decode())
+
+                # Extract source zone from payload or stream key
+                source_zone = payload.get("source_zone", self._zone_id)
+
+                # Invoke handlers
+                for handler_id, handler in self._handlers:
+                    try:
+                        await handler(source_zone, payload)
+                    except Exception:
+                        self._consume_errors += 1
+                        logger.warning(
+                            "[DurableStream] Handler %s failed for %s",
+                            handler_id,
+                            msg_id,
+                            exc_info=True,
+                        )
+
+                # ACK the message
+                await self._client.xack(stream_key, self._group_name, msg_id)
+                self._consumed += 1
+
+                # Advance read fence watermark
+                if self._read_fence:
+                    # Use the stream message ID's timestamp portion as sequence
+                    seq = self._extract_sequence(msg_id)
+                    if seq is not None:
+                        self._read_fence.advance(source_zone, seq)
+
+            except Exception:
+                self._consume_errors += 1
+                logger.warning("[DurableStream] Failed to process %s", msg_id, exc_info=True)
+
+    # -- helpers --------------------------------------------------------------
+
+    @staticmethod
+    def _extract_sequence(msg_id: bytes | str) -> int | None:
+        """Extract the timestamp portion of a Redis Stream message ID.
+
+        Redis Stream IDs are formatted as '<timestamp_ms>-<seq>'.
+        We use the timestamp as the monotonic sequence for the read fence.
+        """
+        try:
+            id_str = msg_id.decode() if isinstance(msg_id, bytes) else msg_id
+            ts_part = id_str.split("-")[0]
+            return int(ts_part)
+        except (ValueError, IndexError, AttributeError):
+            return None
+
+    async def _ensure_consumer_groups(self) -> None:
+        """Create consumer groups if they don't exist."""
+        stream_key = encode_channel(self._stream_prefix, self._zone_id, "all")
+        try:
+            # XGROUP CREATE <key> <group> <id> MKSTREAM
+            await self._client.xgroup_create(
+                stream_key,
+                self._group_name,
+                id="0",
+                mkstream=True,
+            )
+        except Exception as e:
+            # BUSYGROUP = group already exists (expected on restart)
+            if "BUSYGROUP" in str(e):
+                logger.debug(
+                    "[DurableStream] Consumer group %s already exists",
+                    self._group_name,
+                )
+            else:
+                raise
+
+    # -- dead-letter queue (Issue #3396) --------------------------------------
+
+    async def reclaim_pending(self) -> int:
+        """Reclaim and retry messages stuck in the Pending Entries List.
+
+        Uses XAUTOCLAIM to reclaim messages idle longer than CLAIM_MIN_IDLE_MS,
+        then reprocesses them. Messages that exceed MAX_DELIVERY_ATTEMPTS are
+        moved to the dead-letter queue stream.
+
+        Returns:
+            Number of messages reclaimed and reprocessed.
+        """
+        if not self._enabled:
+            return 0
+
+        stream_key = encode_channel(self._stream_prefix, self._zone_id, "all")
+        reclaimed = 0
+
+        try:
+            # XAUTOCLAIM: reclaim idle messages from the consumer group
+            # Returns: [new_start_id, [(msg_id, fields), ...], [deleted_ids]]
+            result = await self._client.xautoclaim(
+                stream_key,
+                self._group_name,
+                self._consumer_name,
+                min_idle_time=_CLAIM_MIN_IDLE_MS,
+                start_id="0-0",
+                count=50,
+            )
+
+            if not result or len(result) < 2:
+                return 0
+
+            messages = result[1]
+            sem = asyncio.Semaphore(self._consumer_concurrency)
+
+            for msg_id, fields in messages:
+                # Check delivery count via XPENDING (approximation: check if
+                # the message has been delivered too many times)
+                try:
+                    pending_info = await self._client.xpending_range(
+                        stream_key,
+                        self._group_name,
+                        min=msg_id,
+                        max=msg_id,
+                        count=1,
+                    )
+                    delivery_count = 1
+                    if pending_info:
+                        entry = pending_info[0]
+                        # entry format varies by client, but typically includes delivery count
+                        if isinstance(entry, dict):
+                            delivery_count = int(entry.get("times_delivered", 1))
+                        elif isinstance(entry, (list, tuple)) and len(entry) >= 4:
+                            delivery_count = int(entry[3])
+                except Exception:
+                    delivery_count = 1
+
+                if delivery_count >= _MAX_DELIVERY_ATTEMPTS:
+                    # Move to DLQ
+                    await self._move_to_dlq(stream_key, msg_id, fields)
+                    await self._client.xack(stream_key, self._group_name, msg_id)
+                    logger.warning(
+                        "[DurableStream] Message %s moved to DLQ after %d attempts",
+                        msg_id,
+                        delivery_count,
+                    )
+                else:
+                    # Retry processing
+                    await self._process_message(sem, stream_key, msg_id, fields)
+                    reclaimed += 1
+
+        except Exception:
+            logger.warning("[DurableStream] Reclaim failed", exc_info=True)
+
+        return reclaimed
+
+    async def _move_to_dlq(
+        self,
+        stream_key: str,
+        msg_id: bytes | str,
+        fields: dict[bytes | str, bytes | str],
+    ) -> None:
+        """Move a failed message to the dead-letter queue stream."""
+        dlq_key = stream_key + _DLQ_SUFFIX
+        try:
+            # Preserve original message ID and add metadata
+            dlq_fields = dict(fields)
+            id_str = msg_id.decode() if isinstance(msg_id, bytes) else msg_id
+            dlq_fields[b"original_id" if isinstance(msg_id, bytes) else "original_id"] = id_str
+            await self._client.xadd(
+                dlq_key,
+                dlq_fields,
+                maxlen=1000,  # Keep last 1000 DLQ entries
+                approximate=True,
+            )
+        except Exception:
+            logger.warning("[DurableStream] Failed to write to DLQ %s", dlq_key, exc_info=True)
+
+    # -- diagnostics ----------------------------------------------------------
+
+    def stats(self) -> dict[str, Any]:
+        """Return operational metrics."""
+        return {
+            "enabled": self._enabled,
+            "zone_id": self._zone_id,
+            "published": self._published,
+            "drained": self._drained,
+            "drain_errors": self._drain_errors,
+            "consumed": self._consumed,
+            "consume_errors": self._consume_errors,
+            "queue_drops": self._queue_drops,
+            "queue_size": len(self._queue),
+            "handler_count": len(self._handlers),
+        }
+
+    async def health_check(self) -> dict[str, Any]:
+        """Health check including PEL monitoring (Issue #3396 decision 15A).
+
+        Queries XINFO GROUPS to detect stuck consumers with growing
+        Pending Entries List (PEL). A PEL > 1000 indicates the consumer
+        is falling behind.
+
+        Returns:
+            Health status dict with PEL size and consumer lag.
+        """
+        if not self._enabled:
+            return {"status": "disabled"}
+
+        try:
+            stream_key = encode_channel(self._stream_prefix, self._zone_id, "all")
+            groups = await self._client.xinfo_groups(stream_key)
+
+            pel_size = 0
+            for group in groups:
+                # group is a dict or list depending on Redis client version
+                if isinstance(group, dict):
+                    name = (
+                        group.get("name", b"").decode()
+                        if isinstance(group.get("name"), bytes)
+                        else group.get("name", "")
+                    )
+                    if name == self._group_name:
+                        pel_size = int(group.get("pending", 0))
+                        break
+
+            status = "healthy"
+            if pel_size > 1000:
+                status = "degraded"
+                logger.warning(
+                    "[DurableStream] PEL size %d for group %s — consumer falling behind",
+                    pel_size,
+                    self._group_name,
+                )
+
+            return {
+                "status": status,
+                "pel_size": pel_size,
+                "group": self._group_name,
+                "consumed": self._consumed,
+                "consume_errors": self._consume_errors,
+                "drain_errors": self._drain_errors,
+            }
+        except Exception as e:
+            return {"status": "error", "error": str(e)}

--- a/src/nexus/bricks/rebac/cache/durable_stream.py
+++ b/src/nexus/bricks/rebac/cache/durable_stream.py
@@ -317,20 +317,29 @@ class DurableInvalidationStream:
                 # Extract source zone from payload or stream key
                 source_zone = payload.get("source_zone", self._zone_id)
 
-                # Invoke handlers
+                # Invoke handlers — all must succeed before ACK.
+                # If any handler fails, the message stays in the PEL and will
+                # be redelivered by reclaim_pending() (DLQ after max retries).
+                handler_failed = False
                 for handler_id, handler in self._handlers:
                     try:
                         await handler(source_zone, payload)
                     except Exception:
                         self._consume_errors += 1
+                        handler_failed = True
                         logger.warning(
-                            "[DurableStream] Handler %s failed for %s",
+                            "[DurableStream] Handler %s failed for %s — not ACKing",
                             handler_id,
                             msg_id,
                             exc_info=True,
                         )
+                        break  # Don't run remaining handlers on partial failure
 
-                # ACK the message
+                if handler_failed:
+                    # Leave in PEL for redelivery via reclaim_pending()
+                    return
+
+                # All handlers succeeded — ACK and advance fence
                 await self._client.xack(stream_key, self._group_name, msg_id)
                 self._consumed += 1
 

--- a/src/nexus/bricks/rebac/cache/durable_stream.py
+++ b/src/nexus/bricks/rebac/cache/durable_stream.py
@@ -334,32 +334,16 @@ class DurableInvalidationStream:
                 await self._client.xack(stream_key, self._group_name, msg_id)
                 self._consumed += 1
 
-                # Advance read fence watermark
+                # Advance read fence generation — signals to the L1 cache that
+                # any entries stamped before this generation are stale.
                 if self._read_fence:
-                    # Use the stream message ID's timestamp portion as sequence
-                    seq = self._extract_sequence(msg_id)
-                    if seq is not None:
-                        self._read_fence.advance(source_zone, seq)
+                    self._read_fence.advance(source_zone)
 
             except Exception:
                 self._consume_errors += 1
                 logger.warning("[DurableStream] Failed to process %s", msg_id, exc_info=True)
 
     # -- helpers --------------------------------------------------------------
-
-    @staticmethod
-    def _extract_sequence(msg_id: bytes | str) -> int | None:
-        """Extract the timestamp portion of a Redis Stream message ID.
-
-        Redis Stream IDs are formatted as '<timestamp_ms>-<seq>'.
-        We use the timestamp as the monotonic sequence for the read fence.
-        """
-        try:
-            id_str = msg_id.decode() if isinstance(msg_id, bytes) else msg_id
-            ts_part = id_str.split("-")[0]
-            return int(ts_part)
-        except (ValueError, IndexError, AttributeError):
-            return None
 
     async def _ensure_consumer_groups(self) -> None:
         """Create consumer groups if they don't exist."""

--- a/src/nexus/bricks/rebac/cache/pubsub_invalidation.py
+++ b/src/nexus/bricks/rebac/cache/pubsub_invalidation.py
@@ -4,18 +4,20 @@ Best-effort invalidation for cross-zone scenarios. Unlike DT_STREAM
 (which provides ordered, reliable intra-zone invalidation), Pub/Sub
 provides fire-and-forget hints to other zones.
 
-Channels: rebac:invalidation:{zone_id}:{layer}
+Channels: rebac:invalidation|{zone_id}|{layer}
 
 Messages are hints, not commands — a missed message means slightly
 stale cache that will self-correct on TTL expiry.
 
-Related: Issue #3192
+Related: Issue #3192, #3396 (ChannelCodec)
 """
 
 import json
 import logging
 from collections.abc import Callable
 from typing import Any
+
+from nexus.bricks.rebac.cache.channel_codec import decode_channel, encode_channel
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +72,7 @@ class PubSubInvalidation:
         if not self._enabled:
             return False
 
-        channel = f"{self._channel_prefix}:{zone_id}:{layer}"
+        channel = encode_channel(self._channel_prefix, zone_id, layer)
         message = json.dumps(payload)
 
         try:
@@ -103,7 +105,7 @@ class PubSubInvalidation:
         Returns:
             Subscription ID for unsubscribe
         """
-        channel = f"{self._channel_prefix}:{zone_id}:{layer}"
+        channel = encode_channel(self._channel_prefix, zone_id, layer)
         sub_id = f"{zone_id}:{layer}"
         self._subscribers[sub_id] = callback
         logger.info("[PUBSUB] Subscribed to %s", channel)
@@ -130,11 +132,10 @@ class PubSubInvalidation:
 
         self._received += 1
 
-        # Extract zone and layer from channel
-        parts = channel.split(":")
-        if len(parts) >= 4:
-            zone_id = parts[2]
-            layer = parts[3]
+        # Extract zone and layer from channel using ChannelCodec
+        decoded = decode_channel(channel)
+        if decoded is not None:
+            _prefix, zone_id, layer = decoded
             sub_id = f"{zone_id}:{layer}"
 
             callback = self._subscribers.get(sub_id)

--- a/src/nexus/bricks/rebac/cache/read_fence.py
+++ b/src/nexus/bricks/rebac/cache/read_fence.py
@@ -1,13 +1,16 @@
-"""Read fence — per-zone watermark for cross-zone staleness detection.
+"""Read fence — per-zone generation counter for cross-zone staleness detection.
 
-Each zone maintains a local watermark (monotonic sequence number from the
-durable invalidation stream).  On every permission read, the fence checks
-whether the cached result was computed before the latest revocation.
+Each zone maintains a local generation counter that increments whenever the
+durable stream consumer processes a cross-zone invalidation event.  The L1
+cache stamps each entry with the fence generation at write time.  At read
+time, if the fence generation has advanced past the entry's stamp, the entry
+is stale and must be re-checked.
+
+This avoids the clock-domain mismatch of comparing Redis Stream timestamps
+against zone revisions — the generation is a single self-contained counter
+that both the fence and the cache use.
 
 Cost: one dict lookup + one int comparison per read (~50-100ns).
-
-The watermark is updated asynchronously by the durable stream consumer.
-Reads never block on I/O.
 
 Related: Issue #3396 (decisions 2A, 13A)
 """
@@ -21,82 +24,93 @@ logger = logging.getLogger(__name__)
 
 
 class ReadFence:
-    """Per-zone watermark for cache staleness detection.
+    """Per-zone generation counter for cache staleness detection.
 
-    Thread-safety: CPython's GIL protects dict reads/writes.
-    Worst case for a concurrent read during a write is reading
-    a stale watermark (one event behind), which is safe — the
-    next read will pick up the updated watermark.
+    Thread-safety: CPython's GIL protects dict reads/writes and int
+    increments.  Worst case for a concurrent read during an increment
+    is reading the old generation (one event behind), which is safe —
+    the next read will see the new generation.
 
-    Example::
+    Usage::
 
         fence = ReadFence()
-        fence.advance("zone-a", 42)
 
-        # On read path:
-        if fence.is_stale("zone-a", cached_sequence=40):
-            # Re-check permission — cache is behind the revocation
+        # Consumer receives cross-zone invalidation:
+        gen = fence.advance("zone-a")  # returns new generation
+
+        # Cache stores entries with the generation at write time:
+        entry.fence_generation = fence.generation("zone-a")
+
+        # Read path checks:
+        if fence.is_stale("zone-a", entry.fence_generation):
+            # Re-check permission — a cross-zone revocation arrived
             ...
     """
 
     def __init__(self) -> None:
-        # zone_id -> latest known durable stream sequence
-        self._watermarks: dict[str, int] = {}
+        # zone_id -> monotonically increasing generation counter
+        self._generations: dict[str, int] = {}
 
         # Metrics
         self._advances = 0
         self._stale_hits = 0
         self._fresh_hits = 0
 
-    def advance(self, zone_id: str, sequence: int) -> None:
-        """Advance the watermark for a zone.
+    def advance(self, zone_id: str) -> int:
+        """Increment the generation for a zone.
 
-        Called by the durable stream consumer when it processes an event.
-        Only advances forward — never goes backward.
+        Called by the durable stream consumer when it processes a
+        cross-zone invalidation event.  Always increments by 1.
 
-        Args:
-            zone_id: Zone whose watermark to advance.
-            sequence: Durable stream sequence number.
+        Returns:
+            The new generation value.
         """
-        current = self._watermarks.get(zone_id, 0)
-        if sequence > current:
-            self._watermarks[zone_id] = sequence
-            self._advances += 1
+        gen = self._generations.get(zone_id, 0) + 1
+        self._generations[zone_id] = gen
+        self._advances += 1
+        return gen
 
-    def is_stale(self, zone_id: str, cached_sequence: int) -> bool:
-        """Check if a cached result is stale relative to the zone watermark.
+    def generation(self, zone_id: str) -> int:
+        """Get the current generation for a zone.
+
+        Used by the L1 cache to stamp entries at write time.
+        Returns 0 if no invalidations have been received for this zone.
+        """
+        return self._generations.get(zone_id, 0)
+
+    def is_stale(self, zone_id: str, cached_generation: int) -> bool:
+        """Check if a cached result is stale relative to the zone generation.
 
         Args:
             zone_id: Zone to check.
-            cached_sequence: Sequence number at which the cached result
-                was computed (e.g. from the zone's revision/zookie).
+            cached_generation: Generation at which the cache entry was written.
 
         Returns:
-            True if the cached result is behind the latest known
-            revocation for this zone (should re-check).
-            False if the cached result is fresh.
+            True if a cross-zone invalidation has been received since
+            the entry was cached (generation advanced).
+            False if no invalidations since the entry was cached.
         """
-        watermark = self._watermarks.get(zone_id, 0)
-        if cached_sequence < watermark:
+        current = self._generations.get(zone_id, 0)
+        if cached_generation < current:
             self._stale_hits += 1
             return True
         self._fresh_hits += 1
         return False
 
     def watermark(self, zone_id: str) -> int:
-        """Get the current watermark for a zone (diagnostics)."""
-        return self._watermarks.get(zone_id, 0)
+        """Get the current generation for a zone (diagnostics alias)."""
+        return self._generations.get(zone_id, 0)
 
     def reset_zone(self, zone_id: str) -> None:
-        """Reset watermark for a zone (e.g. on zone leave)."""
-        self._watermarks.pop(zone_id, None)
+        """Reset generation for a zone (e.g. on zone leave)."""
+        self._generations.pop(zone_id, None)
 
     def stats(self) -> dict[str, Any]:
         """Return operational metrics."""
         return {
-            "zones_tracked": len(self._watermarks),
+            "zones_tracked": len(self._generations),
             "advances": self._advances,
             "stale_hits": self._stale_hits,
             "fresh_hits": self._fresh_hits,
-            "watermarks": dict(self._watermarks),
+            "watermarks": dict(self._generations),
         }

--- a/src/nexus/bricks/rebac/cache/read_fence.py
+++ b/src/nexus/bricks/rebac/cache/read_fence.py
@@ -1,0 +1,102 @@
+"""Read fence — per-zone watermark for cross-zone staleness detection.
+
+Each zone maintains a local watermark (monotonic sequence number from the
+durable invalidation stream).  On every permission read, the fence checks
+whether the cached result was computed before the latest revocation.
+
+Cost: one dict lookup + one int comparison per read (~50-100ns).
+
+The watermark is updated asynchronously by the durable stream consumer.
+Reads never block on I/O.
+
+Related: Issue #3396 (decisions 2A, 13A)
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+class ReadFence:
+    """Per-zone watermark for cache staleness detection.
+
+    Thread-safety: CPython's GIL protects dict reads/writes.
+    Worst case for a concurrent read during a write is reading
+    a stale watermark (one event behind), which is safe — the
+    next read will pick up the updated watermark.
+
+    Example::
+
+        fence = ReadFence()
+        fence.advance("zone-a", 42)
+
+        # On read path:
+        if fence.is_stale("zone-a", cached_sequence=40):
+            # Re-check permission — cache is behind the revocation
+            ...
+    """
+
+    def __init__(self) -> None:
+        # zone_id -> latest known durable stream sequence
+        self._watermarks: dict[str, int] = {}
+
+        # Metrics
+        self._advances = 0
+        self._stale_hits = 0
+        self._fresh_hits = 0
+
+    def advance(self, zone_id: str, sequence: int) -> None:
+        """Advance the watermark for a zone.
+
+        Called by the durable stream consumer when it processes an event.
+        Only advances forward — never goes backward.
+
+        Args:
+            zone_id: Zone whose watermark to advance.
+            sequence: Durable stream sequence number.
+        """
+        current = self._watermarks.get(zone_id, 0)
+        if sequence > current:
+            self._watermarks[zone_id] = sequence
+            self._advances += 1
+
+    def is_stale(self, zone_id: str, cached_sequence: int) -> bool:
+        """Check if a cached result is stale relative to the zone watermark.
+
+        Args:
+            zone_id: Zone to check.
+            cached_sequence: Sequence number at which the cached result
+                was computed (e.g. from the zone's revision/zookie).
+
+        Returns:
+            True if the cached result is behind the latest known
+            revocation for this zone (should re-check).
+            False if the cached result is fresh.
+        """
+        watermark = self._watermarks.get(zone_id, 0)
+        if cached_sequence < watermark:
+            self._stale_hits += 1
+            return True
+        self._fresh_hits += 1
+        return False
+
+    def watermark(self, zone_id: str) -> int:
+        """Get the current watermark for a zone (diagnostics)."""
+        return self._watermarks.get(zone_id, 0)
+
+    def reset_zone(self, zone_id: str) -> None:
+        """Reset watermark for a zone (e.g. on zone leave)."""
+        self._watermarks.pop(zone_id, None)
+
+    def stats(self) -> dict[str, Any]:
+        """Return operational metrics."""
+        return {
+            "zones_tracked": len(self._watermarks),
+            "advances": self._advances,
+            "stale_hits": self._stale_hits,
+            "fresh_hits": self._fresh_hits,
+            "watermarks": dict(self._watermarks),
+        }

--- a/src/nexus/bricks/rebac/cache/result_cache.py
+++ b/src/nexus/bricks/rebac/cache/result_cache.py
@@ -1148,6 +1148,19 @@ class ReBACPermissionCache:
             if result is None:
                 result = self._denial_cache.get(key)
 
+            # Issue #3396: Read fence staleness check (same as get()).
+            # Must be applied here too since this is the main permission-check
+            # fast path used by ReBACManager.check().
+            if result is not None and self._read_fence is not None:
+                zone_part = zone_id if zone_id else ROOT_ZONE_ID
+                entry_gen = self._fence_stamps.get(key, 0)
+                if self._read_fence.is_stale(zone_part, entry_gen):
+                    self._grant_cache.pop(key, None)
+                    self._denial_cache.pop(key, None)
+                    self._fence_stamps.pop(key, None)
+                    result = None
+                    is_grant_hit = False
+
             # Track metrics
             if self._enable_metrics:
                 elapsed_ms = (time.perf_counter() - start_time) * 1000
@@ -1213,6 +1226,8 @@ class ReBACPermissionCache:
             if key in self._denial_cache:
                 del self._denial_cache[key]
                 count += 1
+            # Issue #3396: clean up fence stamps to prevent memory leak
+            self._fence_stamps.pop(key, None)
         return count
 
     def _collect_matching_keys(
@@ -1533,6 +1548,8 @@ class ReBACPermissionCache:
             self._object_index.clear()
             self._path_prefix_index.clear()
             self._entry_metadata.clear()
+            # Issue #3396: Clear fence stamps to prevent memory leak
+            self._fence_stamps.clear()
             if self._enable_metrics:
                 logger.info("L1 cache cleared (grant, denial caches, and indexes)")
 

--- a/src/nexus/bricks/rebac/cache/result_cache.py
+++ b/src/nexus/bricks/rebac/cache/result_cache.py
@@ -136,6 +136,11 @@ class ReBACPermissionCache:
         # When set, revision updates are read from mmap instead of DB queries.
         self._revision_ring_buffer: Any = None  # SharedRingBuffer | None
 
+        # Read fence for cross-zone staleness detection (Issue #3396)
+        # When set, cache hits are checked against per-zone watermarks.
+        # A cached result from before the watermark is treated as a miss.
+        self._read_fence: Any = None  # ReadFence | None
+
         # Split caches for grants and denials (Issue #877)
         # Denials use shorter TTL for security - revoked access should be reflected quickly
         # Key format: "subject_type:subject_id:permission:object_type:object_id:zone_id:r{revision_bucket}"
@@ -633,6 +638,17 @@ class ReBACPermissionCache:
             True/False if cached, None if not cached or expired
         """
         start_time = time.perf_counter()
+
+        # Read fence check (Issue #3396): if the zone's cache has been invalidated
+        # by a cross-zone event more recent than our cached revision, treat as miss.
+        # Cost: ~50-100ns (one dict lookup + one int comparison).
+        if self._read_fence is not None and zone_id is not None:
+            cached_rev = self._get_current_revision(zone_id)
+            if cached_rev > 0 and self._read_fence.is_stale(zone_id, cached_rev):
+                if self._enable_metrics:
+                    self._misses += 1
+                return None
+
         key = self._make_key(subject_type, subject_id, permission, object_type, object_id, zone_id)
 
         with self._lock:

--- a/src/nexus/bricks/rebac/cache/result_cache.py
+++ b/src/nexus/bricks/rebac/cache/result_cache.py
@@ -137,9 +137,12 @@ class ReBACPermissionCache:
         self._revision_ring_buffer: Any = None  # SharedRingBuffer | None
 
         # Read fence for cross-zone staleness detection (Issue #3396)
-        # When set, cache hits are checked against per-zone watermarks.
-        # A cached result from before the watermark is treated as a miss.
+        # When set, cache hits are checked against per-zone generation counters.
+        # An entry cached before the latest cross-zone invalidation is treated as miss.
         self._read_fence: Any = None  # ReadFence | None
+        # Per-key fence generation at cache write time: key -> generation
+        # Evicted naturally when the TTLCache evicts the corresponding entry.
+        self._fence_stamps: dict[str, int] = {}
 
         # Split caches for grants and denials (Issue #877)
         # Denials use shorter TTL for security - revoked access should be reflected quickly
@@ -639,16 +642,6 @@ class ReBACPermissionCache:
         """
         start_time = time.perf_counter()
 
-        # Read fence check (Issue #3396): if the zone's cache has been invalidated
-        # by a cross-zone event more recent than our cached revision, treat as miss.
-        # Cost: ~50-100ns (one dict lookup + one int comparison).
-        if self._read_fence is not None and zone_id is not None:
-            cached_rev = self._get_current_revision(zone_id)
-            if cached_rev > 0 and self._read_fence.is_stale(zone_id, cached_rev):
-                if self._enable_metrics:
-                    self._misses += 1
-                return None
-
         key = self._make_key(subject_type, subject_id, permission, object_type, object_id, zone_id)
 
         with self._lock:
@@ -659,6 +652,20 @@ class ReBACPermissionCache:
             # If not in grant cache, check denial cache
             if result is None:
                 result = self._denial_cache.get(key)
+
+            # Issue #3396: Read fence staleness check.
+            # If the entry was cached before the latest cross-zone invalidation
+            # for this zone, treat it as a miss.  Cost: ~50ns (dict lookup + int cmp).
+            if result is not None and self._read_fence is not None:
+                zone_part = zone_id if zone_id else ROOT_ZONE_ID
+                entry_gen = self._fence_stamps.get(key, 0)
+                if self._read_fence.is_stale(zone_part, entry_gen):
+                    # Evict the stale entry
+                    self._grant_cache.pop(key, None)
+                    self._denial_cache.pop(key, None)
+                    self._fence_stamps.pop(key, None)
+                    result = None
+                    is_grant_hit = False
 
             # Track metrics
             if self._enable_metrics:
@@ -851,6 +858,12 @@ class ReBACPermissionCache:
                 zone_part,
                 path_prefixes or None,
             )
+
+            # Issue #3396: Stamp entry with fence generation at write time.
+            # On read, entries from before the latest cross-zone invalidation
+            # are treated as misses.
+            if self._read_fence is not None:
+                self._fence_stamps[key] = self._read_fence.generation(zone_part)
 
             if self._enable_metrics:
                 self._sets += 1

--- a/src/nexus/bricks/rebac/cache/result_cache.py
+++ b/src/nexus/bricks/rebac/cache/result_cache.py
@@ -34,14 +34,20 @@ import random
 import threading
 import time
 from collections.abc import Callable
-from typing import Any
 
 # Issue #3192: Using cachebox (Rust-backed) TTLCache for lock-free cache internals.
 # The RLock is retained for Python-side secondary index consistency.
-try:
-    from cachebox import TTLCache
-except ImportError:
-    from cachetools import TTLCache  # type: ignore[assignment]  # fallback
+# Runtime: prefer cachebox, fall back to cachetools.
+# Type-checking: use cachetools (broader stubs available).
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from cachetools import TTLCache
+else:
+    try:
+        from cachebox import TTLCache
+    except ImportError:
+        from cachetools import TTLCache
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 
@@ -141,7 +147,6 @@ class ReBACPermissionCache:
         # An entry cached before the latest cross-zone invalidation is treated as miss.
         self._read_fence: Any = None  # ReadFence | None
         # Per-key fence generation at cache write time: key -> generation
-        # Evicted naturally when the TTLCache evicts the corresponding entry.
         self._fence_stamps: dict[str, int] = {}
 
         # Split caches for grants and denials (Issue #877)
@@ -641,12 +646,11 @@ class ReBACPermissionCache:
             True/False if cached, None if not cached or expired
         """
         start_time = time.perf_counter()
-
         key = self._make_key(subject_type, subject_id, permission, object_type, object_id, zone_id)
 
         with self._lock:
             # Check grant cache first (Issue #877)
-            result = self._grant_cache.get(key)
+            result: bool | None = self._grant_cache.get(key)
             is_grant_hit = result is not None
 
             # If not in grant cache, check denial cache
@@ -654,13 +658,10 @@ class ReBACPermissionCache:
                 result = self._denial_cache.get(key)
 
             # Issue #3396: Read fence staleness check.
-            # If the entry was cached before the latest cross-zone invalidation
-            # for this zone, treat it as a miss.  Cost: ~50ns (dict lookup + int cmp).
             if result is not None and self._read_fence is not None:
                 zone_part = zone_id if zone_id else ROOT_ZONE_ID
                 entry_gen = self._fence_stamps.get(key, 0)
                 if self._read_fence.is_stale(zone_part, entry_gen):
-                    # Evict the stale entry
                     self._grant_cache.pop(key, None)
                     self._denial_cache.pop(key, None)
                     self._fence_stamps.pop(key, None)
@@ -860,8 +861,6 @@ class ReBACPermissionCache:
             )
 
             # Issue #3396: Stamp entry with fence generation at write time.
-            # On read, entries from before the latest cross-zone invalidation
-            # are treated as misses.
             if self._read_fence is not None:
                 self._fence_stamps[key] = self._read_fence.generation(zone_part)
 
@@ -1142,15 +1141,13 @@ class ReBACPermissionCache:
 
         with self._lock:
             # Get cached value (existing logic)
-            result = self._grant_cache.get(key)
+            result: bool | None = self._grant_cache.get(key)
             is_grant_hit = result is not None
 
             if result is None:
                 result = self._denial_cache.get(key)
 
             # Issue #3396: Read fence staleness check (same as get()).
-            # Must be applied here too since this is the main permission-check
-            # fast path used by ReBACManager.check().
             if result is not None and self._read_fence is not None:
                 zone_part = zone_id if zone_id else ROOT_ZONE_ID
                 entry_gen = self._fence_stamps.get(key, 0)

--- a/src/nexus/lib/distributed_lease.py
+++ b/src/nexus/lib/distributed_lease.py
@@ -1,0 +1,504 @@
+"""Distributed lease manager — Dragonfly-backed LeaseManagerProtocol.
+
+Implements ``LeaseManagerProtocol`` with Dragonfly/Redis as the shared
+state store, enabling cross-zone lease coordination.
+
+Lease state is stored as Redis hashes with TTL:
+    Key: ``lease:{zone_id}:{resource_id}:{holder_id}``
+    Fields: state, generation, granted_at, expires_at
+
+Atomic acquire uses a Lua script that checks compatibility, revokes
+conflicts, and grants in a single round-trip.
+
+References:
+    - DFUSE paper: https://arxiv.org/abs/2503.18191
+    - Issue #3396: Cross-zone lease-based cache invalidation
+    - Issue #3407: Common LeaseManager utility
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import logging
+import time
+from typing import Any
+
+from nexus.contracts.protocols.lease import (
+    Lease,
+    LeaseState,
+    RevocationCallback,
+)
+
+logger = logging.getLogger(__name__)
+
+_CALLBACK_TIMEOUT_S = 5.0
+
+
+# ---------------------------------------------------------------------------
+# Lua scripts for atomic operations
+# ---------------------------------------------------------------------------
+
+# Atomic acquire: check compatibility, revoke conflicts, grant.
+# KEYS[1] = resource index key (hash: holder_id -> lease JSON)
+# ARGV[1] = holder_id
+# ARGV[2] = requested state ("shared" or "exclusive")
+# ARGV[3] = ttl (seconds, float)
+# ARGV[4] = now (monotonic, float — but stored as wall clock for TTL)
+# ARGV[5] = generation (pre-computed by caller)
+# ARGV[6] = resource_id
+#
+# Returns: JSON array of [granted_lease_json, [revoked_lease_json, ...]]
+#          or nil if conflict with timeout=0 semantics (caller handles)
+_LUA_ACQUIRE = """
+local rkey = KEYS[1]
+local holder_id = ARGV[1]
+local req_state = ARGV[2]
+local ttl = tonumber(ARGV[3])
+local now = tonumber(ARGV[4])
+local generation = tonumber(ARGV[5])
+local resource_id = ARGV[6]
+
+-- Get all current holders
+local holders = redis.call('HGETALL', rkey)
+local conflicts = {}
+local existing_same = nil
+
+for i = 1, #holders, 2 do
+    local hid = holders[i]
+    local lease_json = holders[i + 1]
+    local lease = cjson.decode(lease_json)
+
+    -- Skip expired leases (clean up lazily)
+    if tonumber(lease.expires_at) <= now then
+        redis.call('HDEL', rkey, hid)
+    elseif hid == holder_id then
+        existing_same = lease
+    else
+        -- Check compatibility
+        local compat = (lease.state == 'shared' and req_state == 'shared')
+        if not compat then
+            table.insert(conflicts, {hid, lease_json})
+        end
+    end
+end
+
+-- Same holder, same state: extend TTL (idempotent)
+if existing_same and existing_same.state == req_state then
+    existing_same.expires_at = now + ttl
+    local updated_json = cjson.encode(existing_same)
+    redis.call('HSET', rkey, holder_id, updated_json)
+    redis.call('EXPIRE', rkey, math.ceil(ttl) + 5)
+    return cjson.encode({updated_json, {}})
+end
+
+-- Same holder, different state: remove old (upgrade/downgrade)
+if existing_same then
+    redis.call('HDEL', rkey, holder_id)
+end
+
+-- Revoke conflicts
+local revoked = {}
+for _, conflict in ipairs(conflicts) do
+    local hid = conflict[1]
+    local lease_json = conflict[2]
+    redis.call('HDEL', rkey, hid)
+    table.insert(revoked, lease_json)
+end
+
+-- Grant new lease
+local new_lease = {
+    resource_id = resource_id,
+    holder_id = holder_id,
+    state = req_state,
+    generation = generation,
+    granted_at = now,
+    expires_at = now + ttl
+}
+local new_json = cjson.encode(new_lease)
+redis.call('HSET', rkey, holder_id, new_json)
+redis.call('EXPIRE', rkey, math.ceil(ttl) + 5)
+
+return cjson.encode({new_json, revoked})
+"""
+
+
+class DistributedLeaseManager:
+    """Dragonfly-backed distributed lease manager.
+
+    Provides cross-zone lease coordination via shared Redis/Dragonfly state.
+    Implements ``LeaseManagerProtocol``.
+
+    zone_id is bound at construction — callers never pass it per-method.
+
+    Example::
+
+        mgr = DistributedLeaseManager(
+            redis_client=async_redis,
+            zone_id="us-east-1",
+        )
+        lease = await mgr.acquire("file:123", "agent-A", LeaseState.SHARED_READ)
+    """
+
+    DEFAULT_TTL = 30.0
+    DEFAULT_TIMEOUT = 30.0
+
+    def __init__(
+        self,
+        redis_client: Any,
+        *,
+        zone_id: str = "root",
+        key_prefix: str = "lease",
+        callback_timeout: float = _CALLBACK_TIMEOUT_S,
+    ) -> None:
+        self._client = redis_client
+        self._zone_id = zone_id
+        self._key_prefix = key_prefix
+        self._callback_timeout = callback_timeout
+
+        # Revocation callbacks
+        self._callbacks: list[tuple[str, RevocationCallback]] = []
+
+        # Per-resource generation counter (cached locally, authoritative in Redis)
+        self._generation_cache: dict[str, int] = {}
+
+        # Stats
+        self._acquire_count = 0
+        self._revoke_count = 0
+        self._extend_count = 0
+        self._timeout_count = 0
+        self._callback_error_count = 0
+
+        # Lua script SHA (cached after first SCRIPT LOAD)
+        self._acquire_sha: str | None = None
+
+    # -- key helpers ----------------------------------------------------------
+
+    def _resource_key(self, resource_id: str) -> str:
+        """Redis key for a resource's lease holders."""
+        return f"{self._key_prefix}:{self._zone_id}:{resource_id}"
+
+    def _generation_key(self, resource_id: str) -> str:
+        """Redis key for a resource's generation counter."""
+        return f"{self._key_prefix}:gen:{self._zone_id}:{resource_id}"
+
+    async def _next_generation(self, resource_id: str) -> int:
+        """Atomically increment and return the generation for a resource."""
+        gen_key = self._generation_key(resource_id)
+        gen = await self._client.incr(gen_key)
+        return int(gen)
+
+    # -- Lua script management ------------------------------------------------
+
+    async def _load_scripts(self) -> None:
+        """Load Lua scripts into Redis (cached by SHA)."""
+        if self._acquire_sha is None:
+            self._acquire_sha = await self._client.script_load(_LUA_ACQUIRE)
+
+    # -- public API -----------------------------------------------------------
+
+    async def acquire(
+        self,
+        resource_id: str,
+        holder_id: str,
+        state: LeaseState,
+        *,
+        ttl: float = DEFAULT_TTL,
+        timeout: float = DEFAULT_TIMEOUT,
+    ) -> Lease | None:
+        """Acquire a lease via atomic Lua script."""
+        await self._load_scripts()
+
+        rkey = self._resource_key(resource_id)
+        deadline = time.monotonic() + timeout
+        retry_interval = 0.05
+
+        while True:
+            now = time.monotonic()
+            if timeout > 0 and now >= deadline:
+                self._timeout_count += 1
+                return None
+
+            generation = await self._next_generation(resource_id)
+
+            try:
+                result = await self._client.evalsha(
+                    self._acquire_sha,
+                    1,
+                    rkey,
+                    holder_id,
+                    state.value,
+                    str(ttl),
+                    str(now),
+                    str(generation),
+                    resource_id,
+                )
+            except Exception:
+                logger.warning(
+                    "[DistributedLease] Acquire script failed for %s",
+                    resource_id,
+                    exc_info=True,
+                )
+                if timeout <= 0:
+                    return None
+                await asyncio.sleep(retry_interval)
+                retry_interval = min(retry_interval * 2, 1.0)
+                continue
+
+            if result is None:
+                if timeout <= 0:
+                    self._timeout_count += 1
+                    return None
+                await asyncio.sleep(retry_interval)
+                retry_interval = min(retry_interval * 2, 1.0)
+                continue
+
+            parsed = json.loads(result if isinstance(result, str) else result.decode())
+            granted_json, revoked_jsons = parsed
+
+            # Parse granted lease
+            granted_data = (
+                json.loads(granted_json) if isinstance(granted_json, str) else granted_json
+            )
+            lease = Lease(
+                resource_id=granted_data["resource_id"],
+                holder_id=granted_data["holder_id"],
+                state=LeaseState(granted_data["state"]),
+                generation=int(granted_data["generation"]),
+                granted_at=float(granted_data["granted_at"]),
+                expires_at=float(granted_data["expires_at"]),
+            )
+
+            # Invoke revocation callbacks for conflicts
+            revoked_leases = []
+            for rj in revoked_jsons:
+                rd = json.loads(rj) if isinstance(rj, str) else rj
+                revoked_leases.append(
+                    Lease(
+                        resource_id=rd.get("resource_id", resource_id),
+                        holder_id=rd["holder_id"],
+                        state=LeaseState(rd["state"]),
+                        generation=int(rd["generation"]),
+                        granted_at=float(rd["granted_at"]),
+                        expires_at=float(rd["expires_at"]),
+                    )
+                )
+
+            if revoked_leases:
+                await self._invoke_callbacks(revoked_leases, "conflict")
+                self._revoke_count += len(revoked_leases)
+
+            self._acquire_count += 1
+            return lease
+
+    async def validate(
+        self,
+        resource_id: str,
+        holder_id: str,
+    ) -> Lease | None:
+        """Check if a lease is still valid."""
+        rkey = self._resource_key(resource_id)
+        raw = await self._client.hget(rkey, holder_id)
+        if raw is None:
+            return None
+
+        data = json.loads(raw if isinstance(raw, str) else raw.decode())
+        now = time.monotonic()
+        if float(data["expires_at"]) <= now:
+            # Expired — clean up lazily
+            await self._client.hdel(rkey, holder_id)
+            return None
+
+        return Lease(
+            resource_id=data["resource_id"],
+            holder_id=data["holder_id"],
+            state=LeaseState(data["state"]),
+            generation=int(data["generation"]),
+            granted_at=float(data["granted_at"]),
+            expires_at=float(data["expires_at"]),
+        )
+
+    async def revoke(
+        self,
+        resource_id: str,
+        *,
+        holder_id: str | None = None,
+    ) -> list[Lease]:
+        """Revoke leases on a resource."""
+        rkey = self._resource_key(resource_id)
+        revoked: list[Lease] = []
+
+        if holder_id is not None:
+            raw = await self._client.hget(rkey, holder_id)
+            if raw:
+                data = json.loads(raw if isinstance(raw, str) else raw.decode())
+                revoked.append(self._parse_lease(data, resource_id))
+                await self._client.hdel(rkey, holder_id)
+        else:
+            all_holders = await self._client.hgetall(rkey)
+            for _hid, raw in all_holders.items():
+                data = json.loads(raw if isinstance(raw, str) else raw.decode())
+                revoked.append(self._parse_lease(data, resource_id))
+            if revoked:
+                await self._client.delete(rkey)
+
+        if revoked:
+            self._revoke_count += len(revoked)
+            await self._invoke_callbacks(revoked, "explicit")
+
+        return revoked
+
+    async def revoke_holder(self, holder_id: str) -> list[Lease]:
+        """Revoke all leases owned by a holder.
+
+        Note: This requires scanning — use sparingly (e.g. on disconnect).
+        """
+        pattern = f"{self._key_prefix}:{self._zone_id}:*"
+        revoked: list[Lease] = []
+
+        async for key in self._client.scan_iter(match=pattern, count=100):
+            key_str = key.decode() if isinstance(key, bytes) else key
+            raw = await self._client.hget(key_str, holder_id)
+            if raw:
+                data = json.loads(raw if isinstance(raw, str) else raw.decode())
+                resource_id = data.get("resource_id", key_str.split(":", 2)[-1])
+                revoked.append(self._parse_lease(data, resource_id))
+                await self._client.hdel(key_str, holder_id)
+
+        if revoked:
+            self._revoke_count += len(revoked)
+            await self._invoke_callbacks(revoked, "explicit")
+
+        return revoked
+
+    async def extend(
+        self,
+        resource_id: str,
+        holder_id: str,
+        *,
+        ttl: float = DEFAULT_TTL,
+    ) -> Lease | None:
+        """Extend an existing lease's TTL."""
+        rkey = self._resource_key(resource_id)
+        raw = await self._client.hget(rkey, holder_id)
+        if raw is None:
+            return None
+
+        data = json.loads(raw if isinstance(raw, str) else raw.decode())
+        now = time.monotonic()
+        if float(data["expires_at"]) <= now:
+            await self._client.hdel(rkey, holder_id)
+            return None
+
+        data["expires_at"] = now + ttl
+        await self._client.hset(rkey, holder_id, json.dumps(data))
+        await self._client.expire(rkey, int(ttl) + 5)
+
+        self._extend_count += 1
+        return self._parse_lease(data, resource_id)
+
+    async def leases_for_resource(self, resource_id: str) -> list[Lease]:
+        """Return all active leases for a resource."""
+        rkey = self._resource_key(resource_id)
+        all_holders = await self._client.hgetall(rkey)
+        now = time.monotonic()
+        result: list[Lease] = []
+        for _hid, raw in all_holders.items():
+            data = json.loads(raw if isinstance(raw, str) else raw.decode())
+            if float(data["expires_at"]) > now:
+                result.append(self._parse_lease(data, resource_id))
+        return result
+
+    async def stats(self) -> dict[str, Any]:
+        """Return operational statistics."""
+        return {
+            "acquire_count": self._acquire_count,
+            "revoke_count": self._revoke_count,
+            "extend_count": self._extend_count,
+            "timeout_count": self._timeout_count,
+            "callback_error_count": self._callback_error_count,
+            "zone_id": self._zone_id,
+        }
+
+    async def force_revoke(self, resource_id: str) -> list[Lease]:
+        """Force-revoke all holders without invoking callbacks."""
+        rkey = self._resource_key(resource_id)
+        all_holders = await self._client.hgetall(rkey)
+        revoked: list[Lease] = []
+        for _hid, raw in all_holders.items():
+            data = json.loads(raw if isinstance(raw, str) else raw.decode())
+            revoked.append(self._parse_lease(data, resource_id))
+        if revoked:
+            await self._client.delete(rkey)
+            self._revoke_count += len(revoked)
+        return revoked
+
+    async def close(self) -> None:
+        """No-op for distributed manager (no background tasks)."""
+        pass
+
+    # -- callback registration ------------------------------------------------
+
+    def register_revocation_callback(
+        self,
+        callback_id: str,
+        callback: RevocationCallback,
+    ) -> None:
+        """Register an async callback invoked on lease revocation."""
+        for cid, _ in self._callbacks:
+            if cid == callback_id:
+                return
+        self._callbacks.append((callback_id, callback))
+
+    def unregister_revocation_callback(self, callback_id: str) -> bool:
+        """Remove a previously registered callback."""
+        for i, (cid, _) in enumerate(self._callbacks):
+            if cid == callback_id:
+                self._callbacks.pop(i)
+                return True
+        return False
+
+    # -- internal helpers -----------------------------------------------------
+
+    @staticmethod
+    def _parse_lease(data: dict[str, Any], resource_id: str) -> Lease:
+        """Parse a Lease from a Redis hash value."""
+        return Lease(
+            resource_id=data.get("resource_id", resource_id),
+            holder_id=data["holder_id"],
+            state=LeaseState(data["state"]),
+            generation=int(data["generation"]),
+            granted_at=float(data["granted_at"]),
+            expires_at=float(data["expires_at"]),
+        )
+
+    async def _invoke_callbacks(self, leases: list[Lease], reason: str) -> None:
+        """Invoke all registered callbacks concurrently with per-callback timeout."""
+        if not self._callbacks or not leases:
+            return
+
+        async def _safe_invoke(cb_id: str, cb: RevocationCallback, lease: Lease) -> None:
+            try:
+                await asyncio.wait_for(cb(lease, reason), timeout=self._callback_timeout)
+            except TimeoutError:
+                self._callback_error_count += 1
+                logger.warning(
+                    "[DistributedLease] Callback %s timed out for %s:%s",
+                    cb_id,
+                    lease.resource_id,
+                    lease.holder_id,
+                )
+            except Exception:
+                self._callback_error_count += 1
+                logger.warning(
+                    "[DistributedLease] Callback %s failed for %s:%s",
+                    cb_id,
+                    lease.resource_id,
+                    lease.holder_id,
+                    exc_info=True,
+                )
+
+        tasks = [
+            _safe_invoke(cb_id, cb, lease) for cb_id, cb in self._callbacks for lease in leases
+        ]
+        await asyncio.gather(*tasks)

--- a/src/nexus/server/api/core/health.py
+++ b/src/nexus/server/api/core/health.py
@@ -200,6 +200,24 @@ async def health_check_detailed(request: Request) -> dict[str, Any]:
         if health["components"]["resiliency"]["status"] == "degraded":
             health["status"] = "degraded"
 
+    # Durable invalidation stream health + PEL monitoring (Issue #3396)
+    _durable = getattr(state, "durable_stream", None)
+    if _durable is not None:
+        try:
+            durable_health = await _durable.health_check()
+            health["components"]["durable_invalidation"] = durable_health
+            if durable_health.get("status") == "degraded":
+                health["status"] = "degraded"
+        except Exception as e:
+            health["components"]["durable_invalidation"] = {"status": "error", "error": str(e)}
+    else:
+        health["components"]["durable_invalidation"] = {"status": "disabled"}
+
+    # Read fence stats (Issue #3396)
+    _fence = getattr(state, "read_fence", None)
+    if _fence is not None:
+        health["components"]["read_fence"] = _fence.stats()
+
     return health
 
 

--- a/src/nexus/server/lifespan/__init__.py
+++ b/src/nexus/server/lifespan/__init__.py
@@ -224,6 +224,12 @@ async def lifespan(app: "FastAPI") -> AsyncIterator[None]:
     await shutdown_services(app, svc)
     await shutdown_realtime(app, svc)
 
+    # Stop durable invalidation stream (Issue #3396) — before NexusFS close
+    _durable = getattr(app.state, "durable_stream", None)
+    if _durable is not None:
+        await _durable.stop()
+        logger.debug("Durable invalidation stream stopped")
+
     # Close NexusFS kernel (async shutdown for PersistentService + hooks)
     if app.state.nexus_fs:
         if hasattr(app.state.nexus_fs, "aclose"):

--- a/src/nexus/server/lifespan/permissions.py
+++ b/src/nexus/server/lifespan/permissions.py
@@ -32,6 +32,7 @@ async def startup_permissions(app: "FastAPI", svc: "LifespanServices") -> list[a
 
     await _startup_async_rebac(app, svc)
     await _startup_cache_brick(app, svc)
+    await _startup_durable_invalidation(app, svc)  # Issue #3396
     bg_tasks.extend(await _startup_tiger_cache(app, svc))
     bg_tasks.extend(_startup_backfill(app, svc))
     _startup_cache_warmup(app, svc)
@@ -141,6 +142,120 @@ async def _startup_cache_brick(app: "FastAPI", svc: "LifespanServices") -> None:
                 )
     except Exception as e:
         logger.warning("Failed to initialize cache: %s", e, exc_info=True)
+
+
+async def _startup_durable_invalidation(app: "FastAPI", svc: "LifespanServices") -> None:
+    """Initialize cross-zone durable invalidation stream and read fence (Issue #3396).
+
+    Creates DurableInvalidationStream + ReadFence backed by the CacheBrick's
+    Dragonfly client, wires them into the ReBACManager's CacheCoordinator,
+    and registers a consumer-side handler that triggers local cache invalidation
+    when cross-zone events arrive.
+
+    Must be called AFTER _startup_cache_brick (needs Dragonfly client) and
+    AFTER _startup_async_rebac (needs ReBACManager).
+    """
+    try:
+        cache_brick = getattr(app.state, "cache_brick", None)
+        if cache_brick is None or not cache_brick.has_cache_store:
+            logger.debug("[DurableStream] No cache store — durable invalidation disabled")
+            return
+
+        rebac = svc.rebac_manager
+        if rebac is None:
+            logger.debug("[DurableStream] No ReBACManager — durable invalidation disabled")
+            return
+
+        # Get the async Redis/Dragonfly client from CacheBrick
+        cache_store = cache_brick.cache_store
+        redis_client = getattr(cache_store, "_client", None)
+        if redis_client is None:
+            logger.debug("[DurableStream] No Redis client on cache store — skipping")
+            return
+
+        from nexus.bricks.rebac.cache.durable_stream import DurableInvalidationStream
+        from nexus.bricks.rebac.cache.read_fence import ReadFence
+        from nexus.contracts.constants import ROOT_ZONE_ID
+
+        zone_id = getattr(svc.nexus_fs, "_zone_id", ROOT_ZONE_ID) if svc.nexus_fs else ROOT_ZONE_ID
+
+        read_fence = ReadFence()
+        durable_stream = DurableInvalidationStream(
+            redis_client=redis_client,
+            zone_id=zone_id,
+            read_fence=read_fence,
+        )
+
+        # Register consumer-side handler: incoming cross-zone events trigger
+        # local cache invalidation via the CacheCoordinator.
+        coordinator = getattr(rebac, "_cache_coordinator", None)
+        if coordinator is not None:
+
+            async def _on_cross_zone_invalidation(source_zone: str, payload: dict) -> None:
+                """Handle incoming durable stream event by invalidating local caches."""
+                coordinator.invalidate_for_write(
+                    zone_id=source_zone,
+                    subject=(payload.get("subject_type", ""), payload.get("subject_id", "")),
+                    relation=payload.get("relation", ""),
+                    object=(payload.get("object_type", ""), payload.get("object_id", "")),
+                )
+
+            durable_stream.register_handler("local-cache-invalidate", _on_cross_zone_invalidation)
+
+            # Wire into coordinator
+            coordinator.set_durable_stream(durable_stream)
+            coordinator.set_read_fence(read_fence)
+
+            # Wire read fence into L1 cache (for staleness detection on read path)
+            l1_cache = getattr(rebac, "_l1_cache", None)
+            if l1_cache is not None:
+                l1_cache._read_fence = read_fence
+
+        # Wire DistributedLeaseManager for cross-zone lease coordination (Issue #3396)
+        try:
+            from nexus.lib.distributed_lease import DistributedLeaseManager
+
+            distributed_lease_mgr = DistributedLeaseManager(
+                redis_client=redis_client,
+                zone_id=zone_id,
+            )
+
+            # Register as a lease invalidator: on permission mutation,
+            # force-revoke all distributed leases for the affected zone.
+            if coordinator is not None:
+
+                def _distributed_lease_invalidate(affected_zone_id: str) -> None:
+                    """Zone-wide distributed lease revocation on permission change."""
+                    # This is sync context — schedule async revocation as fire-and-forget.
+                    # The local PermissionLeaseTable already handles the fast path;
+                    # this ensures cross-zone lease state is eventually consistent.
+                    pass  # Distributed lease cleanup is handled via durable stream events
+
+                coordinator.register_lease_invalidator(
+                    "distributed_lease", _distributed_lease_invalidate
+                )
+
+            app.state.distributed_lease_manager = distributed_lease_mgr
+        except Exception as e:
+            logger.debug("[DurableStream] DistributedLeaseManager init skipped: %s", e)
+
+        # Start background drain + consumer tasks
+        await durable_stream.start()
+
+        # Store on app.state for health checks and shutdown
+        app.state.durable_stream = durable_stream
+        app.state.read_fence = read_fence
+
+        logger.info(
+            "[DurableStream] Cross-zone durable invalidation started for zone %s",
+            zone_id,
+        )
+    except Exception as e:
+        logger.warning(
+            "[DurableStream] Failed to initialize durable invalidation: %s",
+            e,
+            exc_info=True,
+        )
 
 
 async def _startup_tiger_cache(app: "FastAPI", svc: "LifespanServices") -> list[asyncio.Task]:

--- a/src/nexus/server/lifespan/permissions.py
+++ b/src/nexus/server/lifespan/permissions.py
@@ -192,12 +192,18 @@ async def _startup_durable_invalidation(app: "FastAPI", svc: "LifespanServices")
         if coordinator is not None:
 
             async def _on_cross_zone_invalidation(source_zone: str, payload: dict) -> None:
-                """Handle incoming durable stream event by invalidating local caches."""
+                """Handle incoming durable stream event by invalidating local caches.
+
+                Uses local_only=True to prevent re-broadcasting: the invalidation
+                was already published by the originating zone — this zone only needs
+                to invalidate its own caches, not relay to other zones.
+                """
                 coordinator.invalidate_for_write(
                     zone_id=source_zone,
                     subject=(payload.get("subject_type", ""), payload.get("subject_id", "")),
                     relation=payload.get("relation", ""),
                     object=(payload.get("object_type", ""), payload.get("object_id", "")),
+                    local_only=True,
                 )
 
             durable_stream.register_handler("local-cache-invalidate", _on_cross_zone_invalidation)
@@ -223,13 +229,38 @@ async def _startup_durable_invalidation(app: "FastAPI", svc: "LifespanServices")
             # Register as a lease invalidator: on permission mutation,
             # force-revoke all distributed leases for the affected zone.
             if coordinator is not None:
+                _dlm = distributed_lease_mgr  # capture for closure
 
                 def _distributed_lease_invalidate(affected_zone_id: str) -> None:
-                    """Zone-wide distributed lease revocation on permission change."""
-                    # This is sync context — schedule async revocation as fire-and-forget.
-                    # The local PermissionLeaseTable already handles the fast path;
-                    # this ensures cross-zone lease state is eventually consistent.
-                    pass  # Distributed lease cleanup is handled via durable stream events
+                    """Zone-wide distributed lease revocation on permission change.
+
+                    This runs in sync context (from invalidate_for_write).
+                    Schedules the async revocation as fire-and-forget on the
+                    running event loop. If no loop is running (e.g. during
+                    tests), the revocation is skipped — TTL expiry is the
+                    safety net.
+                    """
+                    import asyncio
+
+                    try:
+                        loop = asyncio.get_running_loop()
+                    except RuntimeError:
+                        return  # No event loop — skip (TTL fallback)
+
+                    async def _revoke() -> None:
+                        try:
+                            # Scan and revoke all leases in this zone
+                            pattern = f"lease:{affected_zone_id}:*"
+                            async for key in _dlm._client.scan_iter(match=pattern, count=100):
+                                await _dlm._client.delete(key)
+                        except Exception:
+                            logger.debug(
+                                "[DistributedLease] Zone-wide revoke failed for %s",
+                                affected_zone_id,
+                                exc_info=True,
+                            )
+
+                    loop.create_task(_revoke(), name=f"dlm-revoke-{affected_zone_id}")
 
                 coordinator.register_lease_invalidator(
                     "distributed_lease", _distributed_lease_invalidate

--- a/src/nexus/server/lifespan/permissions.py
+++ b/src/nexus/server/lifespan/permissions.py
@@ -158,20 +158,53 @@ async def _startup_durable_invalidation(app: "FastAPI", svc: "LifespanServices")
     try:
         cache_brick = getattr(app.state, "cache_brick", None)
         if cache_brick is None or not cache_brick.has_cache_store:
-            logger.debug("[DurableStream] No cache store — durable invalidation disabled")
+            logger.info("[DurableStream] No cache store — durable invalidation disabled")
             return
 
+        # Try multiple paths to find the ReBACManager.
+        # In some profiles (cluster), it lives inside a ReBACService wrapper
+        # registered via the factory, not as a direct named service.
         rebac = svc.rebac_manager
+        if rebac is None and svc.nexus_fs is not None:
+            # Direct attribute on NexusFS
+            rebac = getattr(svc.nexus_fs, "_rebac_manager", None)
+        if rebac is None and svc.nexus_fs is not None:
+            # Inside ReBACService wrapper (registered as "rebac" in cluster profile).
+            # ServiceRef.__getattr__ transparently delegates to the underlying instance.
+            _svc_fn = getattr(svc.nexus_fs, "service", None)
+            if _svc_fn:
+                for svc_name in ("rebac", "rebac_service", "rebac_manager"):
+                    rebac_svc = _svc_fn(svc_name)
+                    if rebac_svc is not None:
+                        rebac = getattr(rebac_svc, "_rebac_manager", None)
+                        if rebac is not None:
+                            logger.debug(
+                                "[DurableStream] Found ReBACManager via service '%s'", svc_name
+                            )
+                            break
         if rebac is None:
-            logger.debug("[DurableStream] No ReBACManager — durable invalidation disabled")
+            # From AsyncReBACManager on app.state
+            async_rebac = getattr(app.state, "async_rebac_manager", None)
+            if async_rebac is not None:
+                rebac = getattr(async_rebac, "_sync_manager", None)
+        if rebac is None:
+            logger.info("[DurableStream] No ReBACManager — durable invalidation disabled")
             return
 
-        # Get the async Redis/Dragonfly client from CacheBrick
+        # Get a raw redis.asyncio.Redis client for Streams API.
+        # CacheBrick wraps Dragonfly in a DragonflyClient that exposes only
+        # high-level methods (get/set/publish).  We need the raw Redis client
+        # for XADD/XREADGROUP/XACK.  Create one from the existing connection pool.
         cache_store = cache_brick.cache_store
-        redis_client = getattr(cache_store, "_client", None)
-        if redis_client is None:
-            logger.debug("[DurableStream] No Redis client on cache store — skipping")
+        dragonfly_client = getattr(cache_store, "_client", None)
+        connection_pool = getattr(dragonfly_client, "_pool", None)
+        if connection_pool is None:
+            logger.debug("[DurableStream] No connection pool on cache store — skipping")
             return
+
+        import redis.asyncio as aioredis
+
+        redis_client = aioredis.Redis(connection_pool=connection_pool)
 
         from nexus.bricks.rebac.cache.durable_stream import DurableInvalidationStream
         from nexus.bricks.rebac.cache.read_fence import ReadFence

--- a/tests/benchmarks/test_rebac_latency.py
+++ b/tests/benchmarks/test_rebac_latency.py
@@ -499,12 +499,13 @@ class TestCrossZoneInvalidationLatency:
         from nexus.bricks.rebac.cache.read_fence import ReadFence
 
         fence = ReadFence()
-        # Simulate 10 zones with watermarks
+        # Simulate 10 zones with different generation counts
         for i in range(10):
-            fence.advance(f"zone-{i}", 1000 + i * 100)
+            for _ in range(10 + i):
+                fence.advance(f"zone-{i}")
 
         def check():
-            return fence.is_stale("zone-5", 900)
+            return fence.is_stale("zone-5", 0)  # gen 0 is always stale after advance
 
         result = benchmark(check)
         assert result is True
@@ -517,11 +518,9 @@ class TestCrossZoneInvalidationLatency:
         from nexus.bricks.rebac.cache.read_fence import ReadFence
 
         fence = ReadFence()
-        seq = [0]
 
         def advance():
-            seq[0] += 1
-            fence.advance("zone-a", seq[0])
+            fence.advance("zone-a")
 
         benchmark(advance)
 

--- a/tests/benchmarks/test_rebac_latency.py
+++ b/tests/benchmarks/test_rebac_latency.py
@@ -477,3 +477,104 @@ class TestCachedConsistencyLatency:
             zone_id=ZONE_ID,
         )
         assert result is True
+
+
+# ---------------------------------------------------------------------------
+# Cross-zone invalidation latency (Issue #3396)
+# ---------------------------------------------------------------------------
+
+
+class TestCrossZoneInvalidationLatency:
+    """Benchmark cross-zone invalidation components.
+
+    Measures latency of the read fence check and the full invalidation
+    pipeline with durable stream publish.
+    """
+
+    def test_read_fence_check_latency(self, benchmark):
+        """Read fence is_stale() should be <1μs (dict lookup + int compare).
+
+        Target: p50 <0.001ms (1μs), p99 <0.01ms (10μs)
+        """
+        from nexus.bricks.rebac.cache.read_fence import ReadFence
+
+        fence = ReadFence()
+        # Simulate 10 zones with watermarks
+        for i in range(10):
+            fence.advance(f"zone-{i}", 1000 + i * 100)
+
+        def check():
+            return fence.is_stale("zone-5", 900)
+
+        result = benchmark(check)
+        assert result is True
+
+    def test_read_fence_advance_latency(self, benchmark):
+        """ReadFence.advance() should be <1μs.
+
+        Target: p50 <0.001ms (1μs)
+        """
+        from nexus.bricks.rebac.cache.read_fence import ReadFence
+
+        fence = ReadFence()
+        seq = [0]
+
+        def advance():
+            seq[0] += 1
+            fence.advance("zone-a", seq[0])
+
+        benchmark(advance)
+
+    def test_durable_stream_publish_latency(self, benchmark):
+        """Sync publish (queue append) should be <10μs.
+
+        This is the in-process deque append, not the Redis round-trip.
+        Target: p50 <0.01ms (10μs)
+        """
+        from unittest.mock import MagicMock
+
+        from nexus.bricks.rebac.cache.durable_stream import DurableInvalidationStream
+
+        stream = DurableInvalidationStream(redis_client=MagicMock(), zone_id="bench")
+
+        payload = {
+            "subject_type": "user",
+            "subject_id": "alice",
+            "relation": "editor",
+            "object_type": "file",
+            "object_id": "/doc.txt",
+        }
+
+        result = benchmark(stream.publish, "zone-target", payload)
+        assert result is True
+
+    def test_invalidation_pipeline_with_durable_stream(self, benchmark, seeded_manager):
+        """Full invalidation pipeline including durable stream publish step.
+
+        Measures the overhead of adding the durable stream publish to the
+        existing invalidation pipeline.
+        Target: <2x overhead vs pipeline without durable stream
+        """
+        from unittest.mock import MagicMock
+
+        from nexus.bricks.rebac.cache.durable_stream import DurableInvalidationStream
+        from nexus.bricks.rebac.cache.read_fence import ReadFence
+
+        m = seeded_manager
+        coord = m._cache_coordinator
+
+        # Wire mock durable stream + read fence
+        mock_durable = DurableInvalidationStream(redis_client=MagicMock(), zone_id=ZONE_ID)
+        fence = ReadFence()
+        coord.set_durable_stream(mock_durable)
+        coord.set_read_fence(fence)
+
+        def invalidate():
+            coord.invalidate_for_write(
+                zone_id=ZONE_ID,
+                subject=SUBJECT_ALICE,
+                relation="editor",
+                object=("file", "/workspace/file_0.txt"),
+            )
+
+        benchmark(invalidate)

--- a/tests/e2e/docker/test_federation_e2e.py
+++ b/tests/e2e/docker/test_federation_e2e.py
@@ -409,20 +409,28 @@ class TestMountTopology:
 
     def test_mount_crosslink(self, cluster, api_key):
         """Mount corp zone again at /family/work (cross-link)."""
-        grpc1 = cluster["grpc1"]
-
-        mk = _grpc_call(grpc1, "mkdir", {"path": "/family/work", "parents": True}, api_key=api_key)
+        mk = _grpc_call(
+            cluster["grpc1"], "mkdir", {"path": "/family/work", "parents": True}, api_key=api_key
+        )
         assert "error" not in mk, f"mkdir /family/work failed: {mk}"
 
-        r = _grpc_call(
-            grpc1,
-            "federation_mount",
-            {"parent_zone": "family", "path": "/family/work", "target_zone": "corp"},
-            api_key=api_key,
+        # Retry on both nodes (leader for 'family' zone may differ)
+        r = None
+        for target in [cluster["grpc1"], cluster["grpc2"]]:
+            r = _grpc_call(
+                target,
+                "federation_mount",
+                {"parent_zone": "family", "path": "/family/work", "target_zone": "corp"},
+                api_key=api_key,
+            )
+            if "error" not in r:
+                break
+            err_msg = str(r.get("error", {}).get("message", ""))
+            if "already a DT_MOUNT" in err_msg:
+                break
+        assert r is not None and ("error" not in r or "already a DT_MOUNT" in str(r)), (
+            f"mount cross-link failed on both nodes: {r}"
         )
-        # Already mounted is fine (idempotent)
-        err_msg = str(r.get("error", {}).get("message", ""))
-        assert "error" not in r or "already a DT_MOUNT" in err_msg, f"mount cross-link failed: {r}"
 
     def test_unmount_remount_cycle(self, cluster, api_key):
         """Unmount corp-sales, verify inaccessible, remount, verify accessible."""

--- a/tests/e2e/docker/test_federation_e2e.py
+++ b/tests/e2e/docker/test_federation_e2e.py
@@ -434,27 +434,40 @@ class TestMountTopology:
         w = _grpc_call(grpc1, "write", {"path": path, "content": f"before-{uid}"}, api_key=api_key)
         assert "error" not in w, f"Pre-unmount write failed: {w}"
 
-        # Unmount corp-sales
-        um = _grpc_call(
-            grpc1,
-            "federation_unmount",
-            {"parent_zone": "corp", "path": "/corp/sales"},
-            api_key=api_key,
-        )
-        assert "error" not in um, f"Unmount failed: {um}"
+        # Unmount corp-sales — retry on both nodes (leader may differ per zone)
+        um = None
+        for target in [cluster["grpc1"], cluster["grpc2"]]:
+            um = _grpc_call(
+                target,
+                "federation_unmount",
+                {"parent_zone": "corp", "path": "/corp/sales"},
+                api_key=api_key,
+            )
+            if "error" not in um:
+                break
+        assert um is not None and "error" not in um, f"Unmount failed on both nodes: {um}"
 
         # File should be inaccessible through mount path
         r = _grpc_call(grpc1, "read", {"path": path}, api_key=api_key)
         assert "error" in r, "File should be inaccessible after unmount"
 
-        # Remount
-        rm = _grpc_call(
-            grpc1,
-            "federation_mount",
-            {"parent_zone": "corp", "path": "/corp/sales", "target_zone": "corp-sales"},
-            api_key=api_key,
+        # Remount — retry on both nodes
+        rm = None
+        for target in [cluster["grpc1"], cluster["grpc2"]]:
+            rm = _grpc_call(
+                target,
+                "federation_mount",
+                {"parent_zone": "corp", "path": "/corp/sales", "target_zone": "corp-sales"},
+                api_key=api_key,
+            )
+            if "error" not in rm:
+                break
+            err_msg = str(rm.get("error", {}).get("message", ""))
+            if "already a DT_MOUNT" in err_msg:
+                break
+        assert rm is not None and ("error" not in rm or "already a DT_MOUNT" in str(rm)), (
+            f"Remount failed: {rm}"
         )
-        assert "error" not in rm, f"Remount failed: {rm}"
 
         # File should be accessible again
         r2 = _grpc_call(grpc1, "read", {"path": path}, api_key=api_key)

--- a/tests/e2e/docker/test_federation_e2e.py
+++ b/tests/e2e/docker/test_federation_e2e.py
@@ -955,23 +955,25 @@ class TestFederationCacheCoherence:
         grpc2 = cluster["grpc2"]
 
         # Write a unique file on node-1
-        unique_name = f"coherence-{_uid()}.txt"
-        content = f"cross-zone-coherence-{_uid()}"
+        uid = _uid()
+        file_path = f"/corp/eng/coherence-{uid}.txt"
+        content = f"cross-zone-coherence-{uid}"
         write_result = _grpc_call(
             grpc1,
             "write",
-            {"path": f"/corp/eng/{unique_name}", "content": content},
+            {"path": file_path, "content": content},
             api_key=api_key,
         )
 
         if "error" in write_result:
             pytest.skip(f"Write failed (may not have perms): {write_result}")
 
-        # Read back from node-2 — should eventually succeed via Raft replication
+        # Read back from node-2 — should eventually succeed via Raft replication.
+        # _wait_replicated checks full paths from list(), so pass the full path.
         _wait_replicated(
             grpc2,
             "/corp/eng/",
-            unique_name,
+            file_path,
             api_key,
             msg="Cross-zone write not propagated to node-2",
             timeout=30,

--- a/tests/e2e/docker/test_federation_e2e.py
+++ b/tests/e2e/docker/test_federation_e2e.py
@@ -882,3 +882,75 @@ class TestLeaderFailover:
             h = _health(url)
             assert h is not None, f"{url} not healthy after recovery"
             assert h["status"] == "healthy"
+
+
+# ---------------------------------------------------------------------------
+# Step 26: Cross-zone cache coherence (Issue #3396)
+# ---------------------------------------------------------------------------
+
+
+class TestFederationCacheCoherence:
+    """Verify that durable invalidation propagates across zones.
+
+    These tests check that:
+    1. The durable invalidation stream is reported in health checks
+    2. Permission changes on one node are reflected on the other
+    """
+
+    @pytest.mark.order(after="TestFederationE2E::test_25_leader_failure_recovery")
+    def test_26_durable_invalidation_health(self, cluster, api_key):
+        """Durable invalidation stream should appear in detailed health.
+
+        If Dragonfly is not configured, the component reports as disabled
+        (graceful degradation). If configured, it reports healthy or degraded.
+        """
+        for url in [cluster["node1"], cluster["node2"]]:
+            resp = httpx.get(
+                f"{url}/health/detailed",
+                headers={"Authorization": f"Bearer {api_key}"},
+                timeout=10,
+            )
+            if resp.status_code == 200:
+                data = resp.json()
+                components = data.get("components", {})
+                # Durable invalidation should be present (enabled or disabled)
+                if "durable_invalidation" in components:
+                    status = components["durable_invalidation"]["status"]
+                    assert status in ("healthy", "degraded", "disabled", "error"), (
+                        f"Unexpected durable_invalidation status: {status}"
+                    )
+
+    @pytest.mark.order(after="TestFederationE2E::test_26_durable_invalidation_health")
+    def test_27_cross_zone_write_propagation(self, cluster, api_key):
+        """A file written on node-1 should be readable on node-2.
+
+        This is an implicit cache coherence test: if node-2's cache
+        was stale and not invalidated, the read would fail or return
+        stale data. The durable stream ensures node-2 invalidates its
+        cache when node-1 writes.
+        """
+        grpc1 = cluster["grpc1"]
+        grpc2 = cluster["grpc2"]
+
+        # Write a unique file on node-1
+        unique_name = f"coherence_test_{uuid.uuid4().hex[:8]}.txt"
+        content = f"cross-zone-coherence-{time.time()}"
+        write_result = _grpc_call(
+            grpc1,
+            "write",
+            {"path": f"/corp/eng/{unique_name}", "data": content},
+            api_key=api_key,
+        )
+
+        if "error" in write_result:
+            pytest.skip(f"Write failed (may not have perms): {write_result}")
+
+        # Read back from node-2 — should eventually succeed
+        _wait_replicated(
+            grpc2,
+            "/corp/eng/",
+            unique_name,
+            api_key,
+            msg="Cross-zone write not propagated to node-2",
+            timeout=15,
+        )

--- a/tests/e2e/docker/test_federation_e2e.py
+++ b/tests/e2e/docker/test_federation_e2e.py
@@ -382,7 +382,9 @@ class TestMountTopology:
             assert "error" not in mk, f"mkdir {mount_path} failed: {mk}"
 
             # Mount zone — retry on both nodes (mkdir commit may not have
-            # replicated to the node handling this request yet)
+            # replicated to the node handling this request yet).
+            # Treat "already a DT_MOUNT" as success (idempotent — zone may have
+            # been auto-mounted during Raft zone join on node-2).
             mounted = False
             for target in [cluster["grpc1"], cluster["grpc2"]]:
                 r = _grpc_call(
@@ -396,6 +398,11 @@ class TestMountTopology:
                     api_key=api_key,
                 )
                 if "error" not in r:
+                    mounted = True
+                    break
+                # Already mounted is fine — Raft replication may have auto-mounted
+                err_msg = str(r.get("error", {}).get("message", ""))
+                if "already a DT_MOUNT" in err_msg:
                     mounted = True
                     break
             assert mounted, f"mount {target_zone} at {mount_path} failed on both nodes: {r}"
@@ -413,7 +420,9 @@ class TestMountTopology:
             {"parent_zone": "family", "path": "/family/work", "target_zone": "corp"},
             api_key=api_key,
         )
-        assert "error" not in r, f"mount cross-link failed: {r}"
+        # Already mounted is fine (idempotent)
+        err_msg = str(r.get("error", {}).get("message", ""))
+        assert "error" not in r or "already a DT_MOUNT" in err_msg, f"mount cross-link failed: {r}"
 
     def test_unmount_remount_cycle(self, cluster, api_key):
         """Unmount corp-sales, verify inaccessible, remount, verify accessible."""

--- a/tests/e2e/docker/test_federation_e2e.py
+++ b/tests/e2e/docker/test_federation_e2e.py
@@ -933,24 +933,24 @@ class TestFederationCacheCoherence:
         grpc2 = cluster["grpc2"]
 
         # Write a unique file on node-1
-        unique_name = f"coherence_test_{uuid.uuid4().hex[:8]}.txt"
-        content = f"cross-zone-coherence-{time.time()}"
+        unique_name = f"coherence-{_uid()}.txt"
+        content = f"cross-zone-coherence-{_uid()}"
         write_result = _grpc_call(
             grpc1,
             "write",
-            {"path": f"/corp/eng/{unique_name}", "data": content},
+            {"path": f"/corp/eng/{unique_name}", "content": content},
             api_key=api_key,
         )
 
         if "error" in write_result:
             pytest.skip(f"Write failed (may not have perms): {write_result}")
 
-        # Read back from node-2 — should eventually succeed
+        # Read back from node-2 — should eventually succeed via Raft replication
         _wait_replicated(
             grpc2,
             "/corp/eng/",
             unique_name,
             api_key,
             msg="Cross-zone write not propagated to node-2",
-            timeout=15,
+            timeout=30,
         )

--- a/tests/unit/core/test_cache_coordinator.py
+++ b/tests/unit/core/test_cache_coordinator.py
@@ -314,7 +314,11 @@ class TestCacheCoordinatorCriticalPaths:
                 object=("file", "/doc.txt"),
             )
 
-        ns_messages = [r for r in caplog.records if "Namespace invalidator" in r.message]
+        ns_messages = [
+            r
+            for r in caplog.records
+            if "Callback" in r.message and "namespace" in r.message.lower()
+        ]
         assert len(ns_messages) > 0
 
 
@@ -496,3 +500,179 @@ class TestCacheCoordinatorRegistration:
         coordinator.register_boundary_invalidator("b1", cb)
 
         assert coordinator.get_stats()["registered_boundary_invalidators"] == 1
+
+
+# ---------------------------------------------------------------------------
+# Tests — DT_STREAM integration (Issue #3396 decision 11A)
+# ---------------------------------------------------------------------------
+
+
+class TestCacheCoordinatorStreamIntegration:
+    """Tests for coordinator with DT_STREAM enabled.
+
+    When a stream is active, boundary/visibility/namespace dispatch
+    to the stream instead of looping callbacks directly.
+    """
+
+    @pytest.fixture
+    def stream(self):
+        from nexus.bricks.rebac.cache.invalidation_stream import InvalidationStream
+
+        return InvalidationStream(max_size=1000)
+
+    @pytest.fixture
+    def coordinator_with_stream(self, l1_cache, boundary_cache, iterator_cache, stream):
+        coord = CacheCoordinator(
+            l1_cache=l1_cache,
+            boundary_cache=boundary_cache,
+            iterator_cache=iterator_cache,
+            zone_graph_cache={"zone-a": {"tuples": []}},
+            invalidation_stream=stream,
+        )
+        return coord
+
+    def test_boundary_dispatches_to_stream(self, coordinator_with_stream, stream):
+        """With DT_STREAM active, boundary events go to stream, not callbacks."""
+        direct_calls = []
+        coordinator_with_stream.register_boundary_invalidator(
+            "b1", lambda *a: direct_calls.append(a)
+        )
+
+        coordinator_with_stream.invalidate_for_write(
+            zone_id="zone-a",
+            subject=("user", "alice"),
+            relation="direct_editor",
+            object=("file", "/doc.txt"),
+        )
+
+        # Direct callbacks should NOT be called (stream handles dispatch)
+        assert len(direct_calls) == 0
+        # Stream should have at least 1 event (the L1_CACHE event from step 8)
+        stats = stream.get_stats()
+        assert stats["total_events"] >= 1
+
+    def test_stream_events_contain_correct_payload(self, coordinator_with_stream, stream):
+        """Stream events must contain the invalidation payload."""
+        received = []
+        stream.register_consumer("test", received.append)
+
+        coordinator_with_stream.invalidate_for_write(
+            zone_id="zone-a",
+            subject=("user", "alice"),
+            relation="direct_viewer",
+            object=("file", "/doc.txt"),
+        )
+
+        # Should have L1_CACHE event from step 8
+        l1_events = [e for e in received if e.event_type.value == "l1_cache"]
+        assert len(l1_events) >= 1
+        event = l1_events[0]
+        assert event.zone_id == "zone-a"
+        assert event.payload["subject_type"] == "user"
+        assert event.payload["subject_id"] == "alice"
+
+    def test_l1_and_iterator_always_called_directly(
+        self, coordinator_with_stream, l1_cache, iterator_cache
+    ):
+        """L1 and iterator caches are always invalidated directly, not via stream."""
+        coordinator_with_stream.invalidate_for_write(
+            zone_id="zone-a",
+            subject=("user", "alice"),
+            relation="editor",
+            object=("file", "/doc.txt"),
+        )
+
+        l1_cache.invalidate_subject.assert_called()
+        l1_cache.invalidate_object.assert_called()
+        iterator_cache.invalidate_zone.assert_called_with("zone-a")
+
+    def test_stats_include_stream_enabled(self, coordinator_with_stream):
+        """Stats should report stream_enabled: True."""
+        stats = coordinator_with_stream.get_stats()
+        assert stats["stream_enabled"] is True
+
+
+# ---------------------------------------------------------------------------
+# Tests — Durable stream + read fence integration (Issue #3396)
+# ---------------------------------------------------------------------------
+
+
+class TestCacheCoordinatorDurableStream:
+    """Tests for durable stream publish in the invalidation pipeline."""
+
+    def test_durable_stream_publish_called_in_pipeline(self, l1_cache, iterator_cache):
+        """Durable stream publish is step 10 in the pipeline."""
+        mock_durable = MagicMock()
+        mock_durable.publish = MagicMock(return_value=True)
+
+        from nexus.bricks.rebac.cache.coordinator_config import (
+            CoordinatorConfig,
+            InvalidationChannels,
+        )
+
+        config = CoordinatorConfig(channels=InvalidationChannels(durable_stream=mock_durable))
+
+        coordinator = CacheCoordinator(
+            l1_cache=l1_cache,
+            iterator_cache=iterator_cache,
+            zone_graph_cache={"zone-a": {}},
+            config=config,
+        )
+
+        coordinator.invalidate_for_write(
+            zone_id="zone-a",
+            subject=("user", "alice"),
+            relation="editor",
+            object=("file", "/doc.txt"),
+        )
+
+        mock_durable.publish.assert_called_once()
+        call_args = mock_durable.publish.call_args
+        # publish(target_zone_id=..., payload=...) — keyword args
+        assert call_args.kwargs["target_zone_id"] == "zone-a"
+        payload = call_args.kwargs["payload"]
+        assert payload["subject_type"] == "user"
+        assert payload["relation"] == "editor"
+
+    def test_stats_include_durable_and_fence(self, l1_cache):
+        """Stats should report durable_stream_enabled and read_fence_enabled."""
+        from nexus.bricks.rebac.cache.coordinator_config import (
+            CoordinatorConfig,
+            InvalidationChannels,
+        )
+        from nexus.bricks.rebac.cache.read_fence import ReadFence
+
+        mock_durable = MagicMock()
+        mock_durable.stats.return_value = {"published": 0}
+        fence = ReadFence()
+
+        config = CoordinatorConfig(
+            channels=InvalidationChannels(
+                durable_stream=mock_durable,
+                read_fence=fence,
+            )
+        )
+
+        coordinator = CacheCoordinator(l1_cache=l1_cache, config=config)
+        stats = coordinator.get_stats()
+
+        assert stats["durable_stream_enabled"] is True
+        assert stats["read_fence_enabled"] is True
+        assert "durable_stream" in stats
+        assert "read_fence" in stats
+
+    def test_config_backward_compat(self, l1_cache, boundary_cache, iterator_cache):
+        """Legacy individual params still work when config is not provided."""
+        coordinator = CacheCoordinator(
+            l1_cache=l1_cache,
+            boundary_cache=boundary_cache,
+            iterator_cache=iterator_cache,
+            zone_graph_cache={"z": {}},
+            enable_async_recompute=False,
+        )
+
+        stats = coordinator.get_stats()
+        assert stats["stream_enabled"] is False
+        assert stats["pubsub_enabled"] is False
+        assert stats["durable_stream_enabled"] is False
+        assert stats["read_fence_enabled"] is False

--- a/tests/unit/core/test_cross_zone_invalidation.py
+++ b/tests/unit/core/test_cross_zone_invalidation.py
@@ -215,31 +215,31 @@ class TestCrossZoneInvalidation:
         assert fence_b.watermark("zone-a") > 0
 
     def test_read_fence_detects_stale_cache(self, fence_b):
-        """A cached result from before the watermark is detected as stale."""
-        # Cache was populated at sequence 5
-        cached_sequence = 5
+        """A cached result from before a fence advance is detected as stale."""
+        # Cache was populated at generation 0 (no invalidations yet)
+        cached_gen = fence_b.generation("zone-a")  # 0
+        assert fence_b.is_stale("zone-a", cached_gen) is False
 
-        # No revocation yet — cache is fresh
-        assert fence_b.is_stale("zone-a", cached_sequence) is False
+        # Zone B receives a cross-zone invalidation → generation advances to 1
+        fence_b.advance("zone-a")
 
-        # Zone B receives a revocation at sequence 10
-        fence_b.advance("zone-a", 10)
-
-        # Now the cache is stale
-        assert fence_b.is_stale("zone-a", cached_sequence) is True
-        # A fresh cache entry at sequence 10 or later is not stale
-        assert fence_b.is_stale("zone-a", 10) is False
-        assert fence_b.is_stale("zone-a", 15) is False
+        # Entry cached at gen 0 is now stale (current gen is 1)
+        assert fence_b.is_stale("zone-a", cached_gen) is True
+        # An entry cached at gen 1 (current) is fresh
+        assert fence_b.is_stale("zone-a", fence_b.generation("zone-a")) is False
 
     def test_read_fence_independent_per_zone(self, fence_b):
-        """Watermarks are tracked independently per zone."""
-        fence_b.advance("zone-a", 10)
-        fence_b.advance("zone-c", 5)
+        """Generations are tracked independently per zone."""
+        fence_b.advance("zone-a")  # zone-a gen = 1
+        fence_b.advance("zone-a")  # zone-a gen = 2
+        fence_b.advance("zone-c")  # zone-c gen = 1
 
-        # zone-a watermark doesn't affect zone-c check
-        assert fence_b.is_stale("zone-a", 7) is True
-        assert fence_b.is_stale("zone-c", 7) is False
-        assert fence_b.is_stale("zone-c", 3) is True
+        # Entry cached at gen 1 for zone-a is stale (current = 2)
+        assert fence_b.is_stale("zone-a", 1) is True
+        # Entry cached at gen 1 for zone-c is fresh (current = 1)
+        assert fence_b.is_stale("zone-c", 1) is False
+        # Entry cached at gen 0 for zone-c is stale (current = 1)
+        assert fence_b.is_stale("zone-c", 0) is True
 
     def test_coordinator_publishes_to_durable_stream(self):
         """CacheCoordinator.invalidate_for_write() publishes to durable stream."""
@@ -349,8 +349,8 @@ class TestCrossZoneInvalidation:
         assert len(zone_b_invalidated) == 1
         assert zone_b_invalidated[0]["subject_id"] == "alice"
 
-        # Verify: Zone B's read fence was advanced
-        assert fence_b.watermark("zone-b") > 0
+        # Verify: Zone B's read fence generation was advanced
+        assert fence_b.generation("zone-b") > 0
 
-        # Verify: A cached result from before the watermark is stale
+        # Verify: An entry cached at generation 0 (before the invalidation) is stale
         assert fence_b.is_stale("zone-b", 0) is True

--- a/tests/unit/core/test_cross_zone_invalidation.py
+++ b/tests/unit/core/test_cross_zone_invalidation.py
@@ -1,0 +1,356 @@
+"""Cross-zone cache invalidation coherence tests.
+
+Simulates a 2-zone topology with mock Dragonfly to verify:
+1. Zone A grants permission → publishes to durable stream
+2. Zone B's consumer processes event → read fence watermark advances
+3. Zone B's cache is correctly detected as stale
+
+No Docker required — uses in-process mocking.
+
+Related: Issue #3396 (decision 10A)
+"""
+
+import asyncio
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.bricks.rebac.cache.coordinator import CacheCoordinator
+from nexus.bricks.rebac.cache.coordinator_config import (
+    CoordinatorConfig,
+    InvalidationChannels,
+)
+from nexus.bricks.rebac.cache.durable_stream import DurableInvalidationStream
+from nexus.bricks.rebac.cache.read_fence import ReadFence
+
+pytest.importorskip("pyroaring")
+
+
+class MockRedisStream:
+    """In-memory mock of async Redis client supporting Streams API."""
+
+    def __init__(self):
+        self._streams: dict[str, list[tuple[str, dict]]] = {}
+        self._groups: dict[str, dict[str, str]] = {}  # stream -> {group: last_id}
+        self._seq = 0
+
+    async def xadd(self, name, fields, maxlen=None, approximate=False):
+        self._seq += 1
+        msg_id = f"{self._seq}-0"
+        if name not in self._streams:
+            self._streams[name] = []
+        self._streams[name].append((msg_id, fields))
+        return msg_id
+
+    async def xreadgroup(self, groupname, consumername, streams, count=1, block=0):
+        results = []
+        for stream_key, _last_id in streams.items():
+            if stream_key not in self._streams:
+                continue
+            group_key = f"{stream_key}:{groupname}"
+            offset = int(self._groups.get(group_key, "0").split("-")[0])
+            messages = [
+                (mid, fields)
+                for mid, fields in self._streams[stream_key]
+                if int(mid.split("-")[0]) > offset
+            ][:count]
+            if messages:
+                results.append((stream_key, messages))
+                # Advance group offset
+                self._groups[group_key] = messages[-1][0]
+        return results if results else None
+
+    async def xack(self, name, groupname, *ids):
+        return len(ids)
+
+    async def xgroup_create(self, name, groupname, id="0", mkstream=False):
+        if mkstream and name not in self._streams:
+            self._streams[name] = []
+        group_key = f"{name}:{groupname}"
+        self._groups[group_key] = id
+
+    def pipeline(self, transaction=False):
+        return MockPipeline(self)
+
+
+class MockPipeline:
+    """Mock Redis pipeline that collects commands and executes sequentially."""
+
+    def __init__(self, client):
+        self._client = client
+        self._commands = []
+
+    def xadd(self, name, fields, maxlen=None, approximate=False):
+        self._commands.append(("xadd", name, fields, maxlen))
+        return self
+
+    async def execute(self):
+        results = []
+        for cmd in self._commands:
+            if cmd[0] == "xadd":
+                result = await self._client.xadd(cmd[1], cmd[2], maxlen=cmd[3])
+                results.append(result)
+        self._commands.clear()
+        return results
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+class TestCrossZoneInvalidation:
+    """Simulated 2-zone topology tests."""
+
+    @pytest.fixture
+    def mock_redis(self):
+        return MockRedisStream()
+
+    @pytest.fixture
+    def fence_a(self):
+        return ReadFence()
+
+    @pytest.fixture
+    def fence_b(self):
+        return ReadFence()
+
+    @pytest.fixture
+    def zone_a_stream(self, mock_redis, fence_a):
+        return DurableInvalidationStream(
+            redis_client=mock_redis,
+            zone_id="zone-a",
+            read_fence=fence_a,
+        )
+
+    @pytest.fixture
+    def zone_b_stream(self, mock_redis, fence_b):
+        return DurableInvalidationStream(
+            redis_client=mock_redis,
+            zone_id="zone-b",
+            read_fence=fence_b,
+        )
+
+    def test_zone_a_publish_enqueues_event(self, zone_a_stream):
+        """Zone A publishing enqueues an event in the local deque."""
+        result = zone_a_stream.publish(
+            "zone-b",
+            {"subject_type": "user", "subject_id": "alice", "relation": "editor"},
+        )
+        assert result is True
+        assert zone_a_stream.stats()["published"] == 1
+        assert zone_a_stream.stats()["queue_size"] == 1
+
+    @pytest.mark.asyncio
+    async def test_zone_a_drain_writes_to_redis_stream(self, zone_a_stream, mock_redis):
+        """Draining Zone A's queue writes events to Redis Streams."""
+        zone_a_stream.publish(
+            "zone-b",
+            {"subject_type": "user", "subject_id": "alice", "relation": "editor"},
+        )
+
+        await zone_a_stream._drain_batch()
+
+        assert zone_a_stream.stats()["drained"] == 1
+        assert zone_a_stream.stats()["queue_size"] == 0
+        # Verify Redis stream has the event
+        from nexus.bricks.rebac.cache.channel_codec import encode_channel
+
+        stream_key = encode_channel("rebac:durable", "zone-b", "all")
+        assert len(mock_redis._streams.get(stream_key, [])) == 1
+
+    @pytest.mark.asyncio
+    async def test_zone_b_consumer_processes_event_and_advances_fence(
+        self, zone_a_stream, zone_b_stream, mock_redis, fence_b
+    ):
+        """Zone B consumer reads Zone A's event and advances the read fence."""
+        # Zone A publishes an invalidation
+        zone_a_stream.publish(
+            "zone-b",
+            {
+                "source_zone": "zone-a",
+                "subject_type": "user",
+                "subject_id": "alice",
+                "relation": "editor",
+                "object_type": "file",
+                "object_id": "/doc.txt",
+            },
+        )
+        await zone_a_stream._drain_batch()
+
+        # Set up consumer group for Zone B
+        from nexus.bricks.rebac.cache.channel_codec import encode_channel
+
+        stream_key = encode_channel("rebac:durable", "zone-b", "all")
+        await mock_redis.xgroup_create(stream_key, "zone:zone-b", id="0")
+
+        # Register a handler on Zone B
+        handler_calls = []
+
+        async def test_handler(zone_id, payload):
+            handler_calls.append((zone_id, payload))
+
+        zone_b_stream.register_handler("test", test_handler)
+
+        # Manually read and process (simulating one iteration of consume loop)
+        results = await mock_redis.xreadgroup(
+            groupname="zone:zone-b",
+            consumername="zone-b:consumer",
+            streams={stream_key: ">"},
+            count=10,
+        )
+
+        assert results is not None
+        # Process messages
+        sem = asyncio.Semaphore(10)
+        for _stream, messages in results:
+            for msg_id, fields in messages:
+                await zone_b_stream._process_message(sem, stream_key, msg_id, fields)
+
+        # Handler was called
+        assert len(handler_calls) == 1
+        assert handler_calls[0][0] == "zone-a"
+        assert handler_calls[0][1]["subject_id"] == "alice"
+
+        # Read fence was advanced
+        assert fence_b.watermark("zone-a") > 0
+
+    def test_read_fence_detects_stale_cache(self, fence_b):
+        """A cached result from before the watermark is detected as stale."""
+        # Cache was populated at sequence 5
+        cached_sequence = 5
+
+        # No revocation yet — cache is fresh
+        assert fence_b.is_stale("zone-a", cached_sequence) is False
+
+        # Zone B receives a revocation at sequence 10
+        fence_b.advance("zone-a", 10)
+
+        # Now the cache is stale
+        assert fence_b.is_stale("zone-a", cached_sequence) is True
+        # A fresh cache entry at sequence 10 or later is not stale
+        assert fence_b.is_stale("zone-a", 10) is False
+        assert fence_b.is_stale("zone-a", 15) is False
+
+    def test_read_fence_independent_per_zone(self, fence_b):
+        """Watermarks are tracked independently per zone."""
+        fence_b.advance("zone-a", 10)
+        fence_b.advance("zone-c", 5)
+
+        # zone-a watermark doesn't affect zone-c check
+        assert fence_b.is_stale("zone-a", 7) is True
+        assert fence_b.is_stale("zone-c", 7) is False
+        assert fence_b.is_stale("zone-c", 3) is True
+
+    def test_coordinator_publishes_to_durable_stream(self):
+        """CacheCoordinator.invalidate_for_write() publishes to durable stream."""
+        mock_durable = MagicMock()
+        mock_durable.publish = MagicMock(return_value=True)
+        fence = ReadFence()
+
+        config = CoordinatorConfig(
+            channels=InvalidationChannels(
+                durable_stream=mock_durable,
+                read_fence=fence,
+            )
+        )
+
+        l1 = MagicMock()
+        coordinator = CacheCoordinator(
+            l1_cache=l1,
+            zone_graph_cache={"zone-a": {}},
+            config=config,
+        )
+
+        coordinator.invalidate_for_write(
+            zone_id="zone-a",
+            subject=("user", "alice"),
+            relation="editor",
+            object=("file", "/doc.txt"),
+        )
+
+        mock_durable.publish.assert_called_once()
+        call_args = mock_durable.publish.call_args
+        assert call_args.kwargs["target_zone_id"] == "zone-a"
+        payload = call_args.kwargs["payload"]
+        assert payload["source_zone"] == "zone-a"
+        assert payload["subject_id"] == "alice"
+        assert payload["relation"] == "editor"
+
+    @pytest.mark.asyncio
+    async def test_full_cross_zone_flow(self, mock_redis):
+        """End-to-end: Zone A write → durable stream → Zone B fence updated."""
+        fence_a = ReadFence()
+        fence_b = ReadFence()
+
+        stream_a = DurableInvalidationStream(
+            redis_client=mock_redis,
+            zone_id="zone-a",
+            read_fence=fence_a,
+        )
+        stream_b = DurableInvalidationStream(
+            redis_client=mock_redis,
+            zone_id="zone-b",
+            read_fence=fence_b,
+        )
+
+        # Zone A coordinator publishes
+        config_a = CoordinatorConfig(
+            channels=InvalidationChannels(
+                durable_stream=stream_a,
+                read_fence=fence_a,
+            )
+        )
+        coord_a = CacheCoordinator(
+            l1_cache=MagicMock(),
+            zone_graph_cache={"zone-b": {}},
+            config=config_a,
+        )
+
+        # Zone B has a handler that invalidates its local cache
+        zone_b_invalidated = []
+
+        async def zone_b_handler(zone_id, payload):
+            zone_b_invalidated.append(payload)
+
+        stream_b.register_handler("cache-invalidate", zone_b_handler)
+
+        # Step 1: Zone A writes a permission
+        coord_a.invalidate_for_write(
+            zone_id="zone-b",
+            subject=("user", "alice"),
+            relation="editor",
+            object=("file", "/doc.txt"),
+        )
+
+        # Step 2: Drain Zone A's queue to Redis
+        await stream_a._drain_batch()
+
+        # Step 3: Create consumer group for Zone B
+        from nexus.bricks.rebac.cache.channel_codec import encode_channel
+
+        stream_key = encode_channel("rebac:durable", "zone-b", "all")
+        await mock_redis.xgroup_create(stream_key, "zone:zone-b", id="0")
+
+        # Step 4: Zone B consumes
+        results = await mock_redis.xreadgroup(
+            groupname="zone:zone-b",
+            consumername="zone-b:consumer",
+            streams={stream_key: ">"},
+            count=10,
+        )
+        assert results is not None
+
+        sem = asyncio.Semaphore(10)
+        for _stream, messages in results:
+            for msg_id, fields in messages:
+                await stream_b._process_message(sem, stream_key, msg_id, fields)
+
+        # Verify: Zone B handler was called
+        assert len(zone_b_invalidated) == 1
+        assert zone_b_invalidated[0]["subject_id"] == "alice"
+
+        # Verify: Zone B's read fence was advanced
+        assert fence_b.watermark("zone-b") > 0
+
+        # Verify: A cached result from before the watermark is stale
+        assert fence_b.is_stale("zone-b", 0) is True

--- a/tests/unit/core/test_invalidation_degradation.py
+++ b/tests/unit/core/test_invalidation_degradation.py
@@ -179,7 +179,7 @@ class TestConsumerAckFailure:
 
     @pytest.mark.asyncio
     async def test_handler_failure_does_not_ack(self):
-        """When a handler raises, the message should still be ACKed (fail-open)."""
+        """When a handler raises, the message is NOT ACKed — stays in PEL for retry."""
         mock_client = MagicMock()
         mock_client.xack = AsyncMock(return_value=1)
 
@@ -202,10 +202,11 @@ class TestConsumerAckFailure:
             {b"data": b'{"source_zone": "z", "key": "val"}'},
         )
 
-        # Message should still be ACKed (fail-open design)
-        # The handler error is logged but doesn't prevent ACK
+        # Message should NOT be ACKed — stays in PEL for redelivery
+        mock_client.xack.assert_not_called()
         stats = stream.stats()
         assert stats["consume_errors"] >= 1
+        assert stats["consumed"] == 0  # Not counted as consumed
 
     @pytest.mark.asyncio
     async def test_malformed_message_is_acked(self):

--- a/tests/unit/core/test_invalidation_degradation.py
+++ b/tests/unit/core/test_invalidation_degradation.py
@@ -272,7 +272,7 @@ class TestFullDegradation:
         l1.invalidate_object.assert_called()
 
     def test_read_fence_frozen_when_stream_down(self):
-        """When no events are consumed, the read fence watermark stays frozen.
+        """When no events are consumed, the read fence generation stays frozen.
 
         Cached results eventually expire via TTL — the read fence doesn't
         block reads when the stream is down, it just can't detect staleness
@@ -280,39 +280,41 @@ class TestFullDegradation:
         """
         fence = ReadFence()
 
-        # Initially, everything is "fresh" (watermark is 0)
+        # Initially, everything is "fresh" (generation is 0)
         assert fence.is_stale("zone-a", 0) is False
-        assert fence.is_stale("zone-a", 100) is False
 
-        # Simulate: stream was working, advanced to 50
-        fence.advance("zone-a", 50)
+        # Simulate: stream was working, 3 invalidation events consumed
+        fence.advance("zone-a")  # gen = 1
+        fence.advance("zone-a")  # gen = 2
+        fence.advance("zone-a")  # gen = 3
 
         # Now stream goes down — no more advances
-        # Cached results from before 50 are detected as stale
-        assert fence.is_stale("zone-a", 30) is True
-        # Cached results from 50+ are still "fresh" (best available info)
-        assert fence.is_stale("zone-a", 50) is False
-        assert fence.is_stale("zone-a", 100) is False
+        # Entries cached at gen < 3 are detected as stale
+        assert fence.is_stale("zone-a", 1) is True
+        assert fence.is_stale("zone-a", 2) is True
+        # Entry cached at current gen (3) is fresh
+        assert fence.is_stale("zone-a", 3) is False
 
         stats = fence.stats()
         assert stats["zones_tracked"] == 1
-        assert stats["watermarks"]["zone-a"] == 50
+        assert stats["watermarks"]["zone-a"] == 3
 
-    def test_read_fence_watermark_never_goes_backward(self):
-        """Watermark monotonically increases even with out-of-order events."""
+    def test_read_fence_generation_always_increments(self):
+        """Generation monotonically increases by 1 per advance."""
         fence = ReadFence()
-        fence.advance("zone-a", 100)
-        fence.advance("zone-a", 50)  # Out-of-order (ignored)
-        fence.advance("zone-a", 150)
+        fence.advance("zone-a")
+        fence.advance("zone-a")
+        fence.advance("zone-a")
 
-        assert fence.watermark("zone-a") == 150
+        assert fence.watermark("zone-a") == 3
 
     def test_read_fence_reset_zone(self):
-        """Reset clears the watermark for a zone."""
+        """Reset clears the generation for a zone."""
         fence = ReadFence()
-        fence.advance("zone-a", 100)
-        fence.advance("zone-b", 200)
+        fence.advance("zone-a")
+        fence.advance("zone-a")
+        fence.advance("zone-b")
 
         fence.reset_zone("zone-a")
         assert fence.watermark("zone-a") == 0
-        assert fence.watermark("zone-b") == 200
+        assert fence.watermark("zone-b") == 1

--- a/tests/unit/core/test_invalidation_degradation.py
+++ b/tests/unit/core/test_invalidation_degradation.py
@@ -1,0 +1,318 @@
+"""Failure injection tests for the invalidation pipeline.
+
+Tests 4 degradation modes:
+1. Durable stream unavailable at startup
+2. Durable stream fails mid-operation
+3. Consumer fails to ACK (messages re-delivered)
+4. Full degradation (Dragonfly down)
+
+Related: Issue #3396 (decision 12A)
+"""
+
+import asyncio
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nexus.bricks.rebac.cache.coordinator import CacheCoordinator
+from nexus.bricks.rebac.cache.coordinator_config import (
+    CoordinatorConfig,
+    InvalidationChannels,
+)
+from nexus.bricks.rebac.cache.durable_stream import DurableInvalidationStream
+from nexus.bricks.rebac.cache.read_fence import ReadFence
+
+pytest.importorskip("pyroaring")
+
+
+# ---------------------------------------------------------------------------
+# Failure Mode 1: Durable stream unavailable at startup
+# ---------------------------------------------------------------------------
+
+
+class TestDurableStreamUnavailableAtStartup:
+    """When durable stream is None, coordinator falls back gracefully."""
+
+    def test_coordinator_works_without_durable_stream(self):
+        """Invalidation pipeline completes even without durable stream."""
+        l1 = MagicMock()
+        mock_pubsub = MagicMock()
+        mock_pubsub.publish_invalidation = MagicMock(return_value=True)
+
+        config = CoordinatorConfig(channels=InvalidationChannels(pubsub=mock_pubsub))
+
+        coordinator = CacheCoordinator(
+            l1_cache=l1,
+            zone_graph_cache={"z": {}},
+            config=config,
+        )
+
+        # Should not raise
+        coordinator.invalidate_for_write(
+            zone_id="z",
+            subject=("user", "alice"),
+            relation="editor",
+            object=("file", "/doc.txt"),
+        )
+
+        # Pub/Sub still fires as fallback
+        mock_pubsub.publish_invalidation.assert_called_once()
+        # L1 still invalidated
+        l1.invalidate_subject.assert_called()
+
+    def test_disabled_durable_stream_publish_returns_false(self):
+        """A durable stream with no Redis client returns False on publish."""
+        stream = DurableInvalidationStream(redis_client=None)
+        result = stream.publish("zone-a", {"key": "val"})
+        assert result is False
+        assert stream.stats()["published"] == 0
+
+    def test_stats_reflect_disabled_state(self):
+        """Stats correctly report disabled components."""
+        config = CoordinatorConfig(
+            channels=InvalidationChannels()  # all None
+        )
+        coordinator = CacheCoordinator(config=config)
+        stats = coordinator.get_stats()
+
+        assert stats["durable_stream_enabled"] is False
+        assert stats["read_fence_enabled"] is False
+        assert stats["stream_enabled"] is False
+        assert stats["pubsub_enabled"] is False
+
+
+# ---------------------------------------------------------------------------
+# Failure Mode 2: Durable stream fails mid-operation
+# ---------------------------------------------------------------------------
+
+
+class TestDurableStreamMidOperationFailure:
+    """Queue buffers events when drain fails; recovers when stream comes back."""
+
+    def test_publish_succeeds_even_when_drain_will_fail(self):
+        """Sync publish to queue always succeeds (independent of Redis health)."""
+        mock_client = MagicMock()
+        stream = DurableInvalidationStream(redis_client=mock_client, zone_id="z")
+
+        result = stream.publish("zone-a", {"key": "val"})
+        assert result is True
+        assert stream.stats()["queue_size"] == 1
+
+    @pytest.mark.asyncio
+    async def test_drain_failure_requeues_events(self):
+        """When pipeline.execute() fails, events go back to front of queue."""
+        mock_client = MagicMock()
+        mock_pipe = MagicMock()
+        mock_pipe.xadd = MagicMock(return_value=mock_pipe)
+        mock_pipe.execute = AsyncMock(side_effect=ConnectionError("Dragonfly down"))
+        mock_client.pipeline = MagicMock(return_value=mock_pipe)
+
+        stream = DurableInvalidationStream(redis_client=mock_client, zone_id="z")
+        stream.publish("zone-a", {"key": "val1"})
+        stream.publish("zone-a", {"key": "val2"})
+
+        assert stream.stats()["queue_size"] == 2
+
+        with pytest.raises(ConnectionError):
+            await stream._drain_batch()
+
+        # Events should be re-queued
+        assert stream.stats()["queue_size"] == 2
+        assert stream.stats()["drain_errors"] == 1
+
+    @pytest.mark.asyncio
+    async def test_recovery_after_drain_failure(self):
+        """After Dragonfly recovers, queued events are drained successfully."""
+        call_count = 0
+
+        mock_client = MagicMock()
+
+        def make_pipeline(transaction=False):
+            nonlocal call_count
+            call_count += 1
+            pipe = MagicMock()
+            pipe.xadd = MagicMock(return_value=pipe)
+            if call_count == 1:
+                pipe.execute = AsyncMock(side_effect=ConnectionError("down"))
+            else:
+                pipe.execute = AsyncMock(return_value=["1-0"])
+            return pipe
+
+        mock_client.pipeline = make_pipeline
+
+        stream = DurableInvalidationStream(redis_client=mock_client, zone_id="z")
+        stream.publish("zone-a", {"key": "val"})
+
+        # First drain fails
+        with pytest.raises(ConnectionError):
+            await stream._drain_batch()
+        assert stream.stats()["queue_size"] == 1
+
+        # Second drain succeeds (Dragonfly recovered)
+        await stream._drain_batch()
+        assert stream.stats()["queue_size"] == 0
+        assert stream.stats()["drained"] == 1
+
+    def test_queue_full_drops_events_gracefully(self):
+        """When queue is full, new events are dropped with a warning."""
+        stream = DurableInvalidationStream(
+            redis_client=MagicMock(),
+            zone_id="z",
+            queue_maxsize=3,
+        )
+
+        for i in range(5):
+            stream.publish("zone-a", {"idx": i})
+
+        stats = stream.stats()
+        assert stats["queue_size"] == 3  # maxlen=3
+        assert stats["queue_drops"] >= 1  # At least some dropped
+
+
+# ---------------------------------------------------------------------------
+# Failure Mode 3: Consumer ACK failure
+# ---------------------------------------------------------------------------
+
+
+class TestConsumerAckFailure:
+    """Events stay in pending list when ACK fails; re-delivered on next read."""
+
+    @pytest.mark.asyncio
+    async def test_handler_failure_does_not_ack(self):
+        """When a handler raises, the message should still be ACKed (fail-open)."""
+        mock_client = MagicMock()
+        mock_client.xack = AsyncMock(return_value=1)
+
+        stream = DurableInvalidationStream(
+            redis_client=mock_client,
+            zone_id="z",
+        )
+
+        async def failing_handler(zone_id, payload):
+            raise RuntimeError("handler boom")
+
+        stream.register_handler("failing", failing_handler)
+
+        sem = asyncio.Semaphore(10)
+        # Process a message with failing handler
+        await stream._process_message(
+            sem,
+            "test-stream",
+            "1-0",
+            {b"data": b'{"source_zone": "z", "key": "val"}'},
+        )
+
+        # Message should still be ACKed (fail-open design)
+        # The handler error is logged but doesn't prevent ACK
+        stats = stream.stats()
+        assert stats["consume_errors"] >= 1
+
+    @pytest.mark.asyncio
+    async def test_malformed_message_is_acked(self):
+        """Messages with no data field are ACKed and skipped."""
+        mock_client = MagicMock()
+        mock_client.xack = AsyncMock(return_value=1)
+
+        stream = DurableInvalidationStream(
+            redis_client=mock_client,
+            zone_id="z",
+        )
+
+        sem = asyncio.Semaphore(10)
+        await stream._process_message(
+            sem,
+            "test-stream",
+            "1-0",
+            {b"wrong_field": b"val"},
+        )
+
+        mock_client.xack.assert_called_once()
+
+
+# ---------------------------------------------------------------------------
+# Failure Mode 4: Full degradation (Dragonfly completely down)
+# ---------------------------------------------------------------------------
+
+
+class TestFullDegradation:
+    """When both durable stream and pub/sub fail, TTL-based expiry is the safety net."""
+
+    def test_coordinator_completes_when_all_channels_fail(self):
+        """Pipeline completes even when durable stream and pub/sub both fail."""
+        mock_durable = MagicMock()
+        mock_durable.publish = MagicMock(return_value=False)  # Queue full
+
+        mock_pubsub = MagicMock()
+        mock_pubsub.publish_invalidation = MagicMock(return_value=False)  # Redis down
+
+        config = CoordinatorConfig(
+            channels=InvalidationChannels(
+                durable_stream=mock_durable,
+                pubsub=mock_pubsub,
+            )
+        )
+
+        l1 = MagicMock()
+        coordinator = CacheCoordinator(
+            l1_cache=l1,
+            zone_graph_cache={"z": {}},
+            config=config,
+        )
+
+        # Should not raise — pipeline completes for local caches
+        coordinator.invalidate_for_write(
+            zone_id="z",
+            subject=("user", "alice"),
+            relation="editor",
+            object=("file", "/doc.txt"),
+        )
+
+        # Local caches still invalidated (critical path)
+        l1.invalidate_subject.assert_called()
+        l1.invalidate_object.assert_called()
+
+    def test_read_fence_frozen_when_stream_down(self):
+        """When no events are consumed, the read fence watermark stays frozen.
+
+        Cached results eventually expire via TTL — the read fence doesn't
+        block reads when the stream is down, it just can't detect staleness
+        for new revocations until the stream recovers.
+        """
+        fence = ReadFence()
+
+        # Initially, everything is "fresh" (watermark is 0)
+        assert fence.is_stale("zone-a", 0) is False
+        assert fence.is_stale("zone-a", 100) is False
+
+        # Simulate: stream was working, advanced to 50
+        fence.advance("zone-a", 50)
+
+        # Now stream goes down — no more advances
+        # Cached results from before 50 are detected as stale
+        assert fence.is_stale("zone-a", 30) is True
+        # Cached results from 50+ are still "fresh" (best available info)
+        assert fence.is_stale("zone-a", 50) is False
+        assert fence.is_stale("zone-a", 100) is False
+
+        stats = fence.stats()
+        assert stats["zones_tracked"] == 1
+        assert stats["watermarks"]["zone-a"] == 50
+
+    def test_read_fence_watermark_never_goes_backward(self):
+        """Watermark monotonically increases even with out-of-order events."""
+        fence = ReadFence()
+        fence.advance("zone-a", 100)
+        fence.advance("zone-a", 50)  # Out-of-order (ignored)
+        fence.advance("zone-a", 150)
+
+        assert fence.watermark("zone-a") == 150
+
+    def test_read_fence_reset_zone(self):
+        """Reset clears the watermark for a zone."""
+        fence = ReadFence()
+        fence.advance("zone-a", 100)
+        fence.advance("zone-b", 200)
+
+        fence.reset_zone("zone-a")
+        assert fence.watermark("zone-a") == 0
+        assert fence.watermark("zone-b") == 200

--- a/tests/unit/core/test_invalidation_stream.py
+++ b/tests/unit/core/test_invalidation_stream.py
@@ -1,0 +1,239 @@
+"""Foundation tests for InvalidationStream (DT_STREAM).
+
+Establishes behavioral baseline before the durable channel refactor.
+Covers: append ordering, consumer offsets, replay, concurrent access,
+deque overflow, and failure isolation.
+
+Related: Issue #3396 (decision 9A)
+"""
+
+import threading
+
+from nexus.bricks.rebac.cache.invalidation_stream import (
+    InvalidationEventType,
+    InvalidationStream,
+)
+
+
+class TestInvalidationStreamBasic:
+    """Basic stream operations."""
+
+    def test_append_returns_monotonic_sequences(self):
+        stream = InvalidationStream(max_size=100)
+        s1 = stream.append(InvalidationEventType.L1_CACHE, "zone-a", key="val1")
+        s2 = stream.append(InvalidationEventType.BOUNDARY, "zone-a", key="val2")
+        s3 = stream.append(InvalidationEventType.VISIBILITY, "zone-b", key="val3")
+        assert s1 == 1
+        assert s2 == 2
+        assert s3 == 3
+
+    def test_append_creates_event_with_correct_fields(self):
+        stream = InvalidationStream(max_size=100)
+        received = []
+        stream.register_consumer("c1", received.append)
+        stream.append(InvalidationEventType.NAMESPACE, "zone-x", foo="bar", baz=42)
+
+        assert len(received) == 1
+        event = received[0]
+        assert event.event_type == InvalidationEventType.NAMESPACE
+        assert event.zone_id == "zone-x"
+        assert event.payload == {"foo": "bar", "baz": 42}
+        assert event.sequence == 1
+        assert event.timestamp > 0
+
+    def test_empty_stream_stats(self):
+        stream = InvalidationStream(max_size=50)
+        stats = stream.get_stats()
+        assert stats["total_events"] == 0
+        assert stats["stream_size"] == 0
+        assert stats["max_size"] == 50
+        assert stats["current_sequence"] == 0
+        assert stats["consumer_count"] == 0
+
+
+class TestInvalidationStreamConsumers:
+    """Consumer registration, dispatch, and offset tracking."""
+
+    def test_consumer_receives_events_in_order(self):
+        stream = InvalidationStream(max_size=100)
+        events = []
+        stream.register_consumer("c1", events.append)
+
+        stream.append(InvalidationEventType.L1_CACHE, "z", seq=1)
+        stream.append(InvalidationEventType.BOUNDARY, "z", seq=2)
+        stream.append(InvalidationEventType.VISIBILITY, "z", seq=3)
+
+        assert len(events) == 3
+        assert [e.payload["seq"] for e in events] == [1, 2, 3]
+
+    def test_multiple_consumers_all_receive_events(self):
+        stream = InvalidationStream(max_size=100)
+        c1_events, c2_events = [], []
+        stream.register_consumer("c1", c1_events.append)
+        stream.register_consumer("c2", c2_events.append)
+
+        stream.append(InvalidationEventType.L1_CACHE, "z", key="v")
+
+        assert len(c1_events) == 1
+        assert len(c2_events) == 1
+
+    def test_consumer_offset_tracks_last_processed(self):
+        stream = InvalidationStream(max_size=100)
+        stream.register_consumer("c1", lambda e: None)
+
+        stream.append(InvalidationEventType.L1_CACHE, "z")
+        stream.append(InvalidationEventType.L1_CACHE, "z")
+
+        stats = stream.get_stats()
+        assert stats["consumer_offsets"]["c1"] == 2
+
+    def test_unregister_consumer_stops_delivery(self):
+        stream = InvalidationStream(max_size=100)
+        events = []
+        stream.register_consumer("c1", events.append)
+        stream.append(InvalidationEventType.L1_CACHE, "z")
+        assert len(events) == 1
+
+        stream.unregister_consumer("c1")
+        stream.append(InvalidationEventType.L1_CACHE, "z")
+        assert len(events) == 1  # No new events
+
+    def test_consumer_failure_isolation(self):
+        """One failing consumer doesn't block others."""
+        stream = InvalidationStream(max_size=100)
+        good_events = []
+
+        def bad_consumer(event):
+            raise RuntimeError("boom")
+
+        stream.register_consumer("bad", bad_consumer)
+        stream.register_consumer("good", good_events.append)
+
+        stream.append(InvalidationEventType.L1_CACHE, "z", key="v")
+
+        assert len(good_events) == 1
+        assert stream.get_stats()["consumer_errors"] == 1
+
+    def test_late_consumer_starts_at_current_sequence(self):
+        """Consumer registered after events only gets future events."""
+        stream = InvalidationStream(max_size=100)
+        stream.append(InvalidationEventType.L1_CACHE, "z")  # seq 1
+        stream.append(InvalidationEventType.L1_CACHE, "z")  # seq 2
+
+        events = []
+        stream.register_consumer("late", events.append)
+
+        stream.append(InvalidationEventType.L1_CACHE, "z")  # seq 3
+        assert len(events) == 1
+        assert events[0].sequence == 3
+
+
+class TestInvalidationStreamReplay:
+    """Replay capability for failure recovery."""
+
+    def test_replay_from_sequence(self):
+        stream = InvalidationStream(max_size=100)
+        events = []
+        stream.register_consumer("c1", events.append)
+
+        # Append 5 events
+        for i in range(5):
+            stream.append(InvalidationEventType.L1_CACHE, "z", idx=i)
+
+        assert len(events) == 5
+        events.clear()
+
+        # Replay from sequence 2 (should replay 3, 4, 5)
+        replayed = stream.replay_from("c1", 2)
+        assert replayed == 3
+        assert len(events) == 3
+        assert [e.payload["idx"] for e in events] == [2, 3, 4]
+
+    def test_replay_stops_on_consumer_error(self):
+        stream = InvalidationStream(max_size=100)
+        call_count = 0
+
+        def failing_after_2(event):
+            nonlocal call_count
+            call_count += 1
+            if call_count > 2:
+                raise RuntimeError("replay fail")
+
+        stream.register_consumer("c1", failing_after_2)
+
+        for i in range(5):
+            stream.append(InvalidationEventType.L1_CACHE, "z", idx=i)
+
+        call_count = 0  # Reset for replay
+        replayed = stream.replay_from("c1", 0)
+        assert replayed == 2  # Stopped after error on 3rd
+
+    def test_replay_unknown_consumer_returns_zero(self):
+        stream = InvalidationStream(max_size=100)
+        assert stream.replay_from("unknown", 0) == 0
+
+
+class TestInvalidationStreamOverflow:
+    """Deque maxlen trimming behavior."""
+
+    def test_old_events_trimmed_when_maxlen_exceeded(self):
+        stream = InvalidationStream(max_size=3)
+
+        stream.register_consumer("c1", lambda e: None)
+
+        for i in range(5):
+            stream.append(InvalidationEventType.L1_CACHE, "z", idx=i)
+
+        stats = stream.get_stats()
+        assert stats["stream_size"] == 3  # Only last 3 retained
+        assert stats["total_events"] == 5  # 5 total appended
+        assert stats["current_sequence"] == 5
+
+    def test_replay_limited_to_retained_events(self):
+        stream = InvalidationStream(max_size=3)
+        events = []
+        stream.register_consumer("c1", events.append)
+
+        for i in range(5):
+            stream.append(InvalidationEventType.L1_CACHE, "z", idx=i)
+
+        events.clear()
+        replayed = stream.replay_from("c1", 0)
+        # Only events with sequence 3, 4, 5 are retained (maxlen=3)
+        assert replayed == 3
+
+
+class TestInvalidationStreamConcurrency:
+    """Thread-safety of concurrent append and consume."""
+
+    def test_concurrent_appends(self):
+        stream = InvalidationStream(max_size=10_000)
+        events = []
+        lock = threading.Lock()
+
+        def safe_append(event):
+            with lock:
+                events.append(event)
+
+        stream.register_consumer("c1", safe_append)
+
+        threads = []
+        n_per_thread = 100
+        n_threads = 10
+
+        def producer(thread_id):
+            for i in range(n_per_thread):
+                stream.append(InvalidationEventType.L1_CACHE, "z", tid=thread_id, idx=i)
+
+        for t in range(n_threads):
+            threads.append(threading.Thread(target=producer, args=(t,)))
+
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(events) == n_threads * n_per_thread
+        # Sequences should be unique
+        sequences = {e.sequence for e in events}
+        assert len(sequences) == n_threads * n_per_thread

--- a/tests/unit/core/test_pubsub_invalidation.py
+++ b/tests/unit/core/test_pubsub_invalidation.py
@@ -1,0 +1,185 @@
+"""Foundation tests for PubSubInvalidation.
+
+Establishes behavioral baseline before the durable channel refactor.
+Covers: publish/receive round-trip, ChannelCodec integration, subscriber
+failure isolation, disabled-mode behavior, and stats accuracy.
+
+Related: Issue #3396 (decision 9A)
+"""
+
+from unittest.mock import MagicMock
+
+from nexus.bricks.rebac.cache.channel_codec import decode_channel, encode_channel
+from nexus.bricks.rebac.cache.pubsub_invalidation import PubSubInvalidation
+
+
+class TestPubSubPublish:
+    """Publishing invalidation hints."""
+
+    def test_publish_calls_redis_with_encoded_channel(self):
+        mock_client = MagicMock()
+        ps = PubSubInvalidation(redis_client=mock_client)
+
+        ps.publish_invalidation("zone-a", "boundary", {"key": "val"})
+
+        mock_client.publish.assert_called_once()
+        call_args = mock_client.publish.call_args
+        channel = call_args[0][0]
+        # Should use ChannelCodec pipe delimiter, not colons
+        assert "|" in channel
+        assert "zone-a" in channel
+        assert "boundary" in channel
+
+    def test_publish_returns_true_on_success(self):
+        mock_client = MagicMock()
+        ps = PubSubInvalidation(redis_client=mock_client)
+        assert ps.publish_invalidation("z", "l", {"k": "v"}) is True
+
+    def test_publish_returns_false_when_disabled(self):
+        ps = PubSubInvalidation(redis_client=None)
+        assert ps.publish_invalidation("z", "l", {"k": "v"}) is False
+
+    def test_publish_returns_false_on_error(self):
+        mock_client = MagicMock()
+        mock_client.publish.side_effect = ConnectionError("down")
+        ps = PubSubInvalidation(redis_client=mock_client)
+
+        result = ps.publish_invalidation("z", "l", {"k": "v"})
+        assert result is False
+
+    def test_publish_increments_error_counter_on_failure(self):
+        mock_client = MagicMock()
+        mock_client.publish.side_effect = ConnectionError("down")
+        ps = PubSubInvalidation(redis_client=mock_client)
+
+        ps.publish_invalidation("z", "l", {"k": "v"})
+
+        stats = ps.get_stats()
+        assert stats["publish_errors"] == 1
+        assert stats["published"] == 0
+
+    def test_publish_increments_published_counter(self):
+        mock_client = MagicMock()
+        ps = PubSubInvalidation(redis_client=mock_client)
+
+        ps.publish_invalidation("z", "l", {"k": "v"})
+        ps.publish_invalidation("z", "l", {"k": "v2"})
+
+        assert ps.get_stats()["published"] == 2
+
+
+class TestPubSubSubscribe:
+    """Subscribing and receiving invalidation hints."""
+
+    def test_subscribe_returns_sub_id(self):
+        ps = PubSubInvalidation(redis_client=MagicMock())
+        sub_id = ps.subscribe("zone-a", "boundary", lambda p: None)
+        assert sub_id == "zone-a:boundary"
+
+    def test_handle_message_dispatches_to_subscriber(self):
+        ps = PubSubInvalidation(redis_client=MagicMock())
+        received = []
+        ps.subscribe("zone-a", "boundary", received.append)
+
+        channel = encode_channel("rebac:invalidation", "zone-a", "boundary")
+        ps.handle_message(channel, '{"key": "val"}')
+
+        assert len(received) == 1
+        assert received[0] == {"key": "val"}
+
+    def test_handle_message_increments_received_counter(self):
+        ps = PubSubInvalidation(redis_client=MagicMock())
+        ps.subscribe("z", "l", lambda p: None)
+
+        channel = encode_channel("rebac:invalidation", "z", "l")
+        ps.handle_message(channel, '{"k": "v"}')
+
+        assert ps.get_stats()["received"] == 1
+
+    def test_handle_message_ignores_invalid_json(self):
+        ps = PubSubInvalidation(redis_client=MagicMock())
+        ps.subscribe("z", "l", lambda p: None)
+
+        channel = encode_channel("rebac:invalidation", "z", "l")
+        ps.handle_message(channel, "not-json{{{")
+
+        assert ps.get_stats()["received"] == 0
+
+    def test_handle_message_ignores_unknown_channel(self):
+        ps = PubSubInvalidation(redis_client=MagicMock())
+        received = []
+        ps.subscribe("zone-a", "boundary", received.append)
+
+        # Message for different zone
+        channel = encode_channel("rebac:invalidation", "zone-b", "boundary")
+        ps.handle_message(channel, '{"k": "v"}')
+
+        assert len(received) == 0
+
+    def test_subscriber_failure_does_not_crash(self):
+        ps = PubSubInvalidation(redis_client=MagicMock())
+
+        def bad_callback(payload):
+            raise RuntimeError("boom")
+
+        ps.subscribe("z", "l", bad_callback)
+
+        channel = encode_channel("rebac:invalidation", "z", "l")
+        # Should not raise
+        ps.handle_message(channel, '{"k": "v"}')
+
+    def test_unsubscribe_stops_delivery(self):
+        ps = PubSubInvalidation(redis_client=MagicMock())
+        received = []
+        sub_id = ps.subscribe("z", "l", received.append)
+
+        channel = encode_channel("rebac:invalidation", "z", "l")
+        ps.handle_message(channel, '{"k": "v1"}')
+        assert len(received) == 1
+
+        ps.unsubscribe(sub_id)
+        ps.handle_message(channel, '{"k": "v2"}')
+        assert len(received) == 1
+
+
+class TestPubSubStats:
+    """Stats and disabled mode."""
+
+    def test_disabled_stats(self):
+        ps = PubSubInvalidation(redis_client=None)
+        stats = ps.get_stats()
+        assert stats["enabled"] is False
+        assert stats["published"] == 0
+        assert stats["subscriber_count"] == 0
+
+    def test_enabled_stats(self):
+        ps = PubSubInvalidation(redis_client=MagicMock())
+        ps.subscribe("z", "l", lambda p: None)
+        stats = ps.get_stats()
+        assert stats["enabled"] is True
+        assert stats["subscriber_count"] == 1
+
+
+class TestChannelCodec:
+    """ChannelCodec encode/decode round-trips."""
+
+    def test_basic_round_trip(self):
+        encoded = encode_channel("prefix", "zone-a", "boundary")
+        decoded = decode_channel(encoded)
+        assert decoded == ("prefix", "zone-a", "boundary")
+
+    def test_zone_id_with_colons(self):
+        """Zone IDs containing colons should be preserved."""
+        encoded = encode_channel("pfx", "us-east-1:partition-2", "all")
+        decoded = decode_channel(encoded)
+        assert decoded == ("pfx", "us-east-1:partition-2", "all")
+
+    def test_invalid_channel_returns_none(self):
+        assert decode_channel("no-delimiters") is None
+        assert decode_channel("too|many|pipe|delimiters") is None
+        assert decode_channel("") is None
+
+    def test_empty_components(self):
+        encoded = encode_channel("", "", "")
+        decoded = decode_channel(encoded)
+        assert decoded == ("", "", "")

--- a/tests/unit/core/test_rebac_revision_cache.py
+++ b/tests/unit/core/test_rebac_revision_cache.py
@@ -25,6 +25,7 @@ from sqlalchemy import create_engine, text
 from nexus.bricks.rebac.consistency.metastore_namespace_store import (
     MetastoreNamespaceStore,
 )
+from nexus.bricks.rebac.consistency.metastore_version_store import MetastoreVersionStore
 from nexus.bricks.rebac.manager import ReBACManager
 from nexus.storage.models import Base
 from tests.helpers.dict_metastore import DictMetastore
@@ -90,6 +91,7 @@ def manager(engine, test_zone):
         engine=engine,
         is_postgresql=True,
         namespace_store=MetastoreNamespaceStore(DictMetastore()),
+        version_store=MetastoreVersionStore(DictMetastore()),
     )
     yield manager
 


### PR DESCRIPTION
## Summary

Closes #3396. Replaces fire-and-forget pub/sub cross-zone cache invalidation with a durable, lease-based protocol inspired by DFUSE (arXiv:2503.18191), closing the **5-minute stale cache window** for cross-zone permission changes.

### New components
- **`DurableInvalidationStream`** — Redis Streams (`XADD`/`XREADGROUP`/`XACK`) with pipelined drain (batch 100), bounded queue (10K), concurrent consumer (`Semaphore(10)`), dead-letter queue (`XAUTOCLAIM` + DLQ stream), and PEL health monitoring
- **`ReadFence`** — Per-zone monotonic watermark on the **read path** (~50-100ns overhead) that detects stale cached results without blocking the write path
- **`DistributedLeaseManager`** — Dragonfly-backed `LeaseManagerProtocol` with Lua atomic acquire for cross-zone lease coordination
- **`ChannelCodec`** — Shared pipe-delimited key encoder replacing fragile colon-split parsing (handles zone IDs with colons)
- **`CoordinatorConfig`** — Dataclasses grouping 15+ constructor params into 6-7 (`InvalidationChannels`, `DatabaseCallbacks`, `RecomputeCallbacks`)

### Refactors
- **CacheCoordinator**: `_dispatch_to_layer()` DRY helper consolidates 3 identical callback/stream dispatch patterns; constructor accepts `CoordinatorConfig` with backward-compat for legacy params
- **PubSubInvalidation**: migrated to `ChannelCodec`
- **ReBACPermissionCache.get()**: read fence staleness check before cache lookup

### Integration
- **Server lifecycle**: `_startup_durable_invalidation()` in `permissions.py` creates and starts durable stream + read fence, registers consumer-side handler that triggers local cache invalidation on cross-zone events, wires `DistributedLeaseManager`
- **Health endpoint**: `/health/detailed` includes PEL monitoring via `XINFO GROUPS` and read fence stats
- **Shutdown**: durable stream stopped before NexusFS close

### Architecture decisions (16 decisions reviewed interactively)
| Area | Decision |
|------|----------|
| Durable channel | Redis Streams via Dragonfly (zero new deps) |
| Revocation model | Async + read fence (write path stays fast) |
| Distributed leases | Dragonfly-backed with Lua atomic acquire |
| Phase ordering | Durable channel + read fence first (front-loads HIGH-severity fix) |
| DRY dispatch | `_dispatch_to_layer()` generic helper |
| Sync/async bridge | Fire-and-queue with async drain |
| Constructor bloat | Config dataclasses |
| Channel parsing | Shared `ChannelCodec` |
| Read fence overhead | In-process atomic watermark per zone (~50-100ns) |
| XADD throughput | Pipelined drain (batch 100) |
| Memory growth | Bounded queue + MAXLEN + PEL monitoring |
| Consumer latency | Concurrent consumer with semaphore |

## Test plan

- [x] 76 unit tests passing (foundation tests for InvalidationStream + PubSub, stream-enabled coordinator tests, cross-zone coherence tests, 4 failure injection modes)
- [x] 4 cross-zone latency benchmarks (read fence check, advance, publish, full pipeline)
- [x] 7 integration tests passing (namespace event invalidation)
- [x] 10 cache concurrency tests passing
- [x] 2 federation e2e cache coherence assertions added
- [x] All pre-commit hooks passing (ruff, mypy, format)
- [ ] Docker federation e2e (requires Docker compose — manual verification)