### PR TITLE
feat(catalog): agent lineage tracking — read-to-write dependency graph (#3417)

### DIFF
--- a/alembic/versions/2674e0e3f70d_add_lineage_reverse_index_table.py
+++ b/alembic/versions/2674e0e3f70d_add_lineage_reverse_index_table.py
@@ -1,0 +1,68 @@
+"""add_lineage_reverse_index_table
+
+Revision ID: 2674e0e3f70d
+Revises: 928a619dabf4
+Create Date: 2026-03-28
+
+Issue #3417: Agent lineage tracking — reverse lookup table for impact analysis.
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "2674e0e3f70d"
+down_revision: Union[str, Sequence[str], None] = "928a619dabf4"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create lineage_reverse_index table for agent lineage tracking."""
+    op.create_table(
+        "lineage_reverse_index",
+        sa.Column("entry_id", sa.String(length=36), nullable=False),
+        sa.Column("upstream_path", sa.String(length=512), nullable=False),
+        sa.Column("downstream_urn", sa.String(length=512), nullable=False),
+        sa.Column("zone_id", sa.String(length=255), nullable=False, server_default="root"),
+        sa.Column("upstream_version", sa.Integer(), nullable=False, server_default="0"),
+        sa.Column("upstream_etag", sa.String(length=64), nullable=False, server_default=""),
+        sa.Column("access_type", sa.String(length=20), nullable=False, server_default="content"),
+        sa.Column("agent_id", sa.String(length=255), nullable=False, server_default=""),
+        sa.Column("downstream_path", sa.Text(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.PrimaryKeyConstraint("entry_id"),
+    )
+    # Reverse lookup: "what depends on upstream_path?" (impact analysis)
+    op.create_index(
+        "idx_lineage_reverse_upstream",
+        "lineage_reverse_index",
+        ["upstream_path", "zone_id"],
+        unique=False,
+    )
+    # Forward cleanup: "delete all reverse entries for this downstream"
+    op.create_index(
+        "idx_lineage_reverse_downstream",
+        "lineage_reverse_index",
+        ["downstream_urn"],
+        unique=False,
+    )
+    # Staleness query: single indexed scan
+    op.create_index(
+        "idx_lineage_reverse_staleness",
+        "lineage_reverse_index",
+        ["upstream_path", "zone_id", "upstream_version", "upstream_etag"],
+        unique=False,
+    )
+
+
+def downgrade() -> None:
+    """Drop lineage_reverse_index table."""
+    op.drop_index("idx_lineage_reverse_staleness", table_name="lineage_reverse_index")
+    op.drop_index("idx_lineage_reverse_downstream", table_name="lineage_reverse_index")
+    op.drop_index("idx_lineage_reverse_upstream", table_name="lineage_reverse_index")
+    op.drop_table("lineage_reverse_index")

--- a/alembic/versions/2674e0e3f70d_add_lineage_reverse_index_table.py
+++ b/alembic/versions/2674e0e3f70d_add_lineage_reverse_index_table.py
@@ -1,7 +1,7 @@
 """add_lineage_reverse_index_table
 
 Revision ID: 2674e0e3f70d
-Revises: 928a619dabf4
+Revises: add_grant_tuple_ids
 Create Date: 2026-03-28
 
 Issue #3417: Agent lineage tracking — reverse lookup table for impact analysis.
@@ -16,7 +16,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "2674e0e3f70d"
-down_revision: Union[str, Sequence[str], None] = "928a619dabf4"
+down_revision: Union[str, Sequence[str], None] = "add_grant_tuple_ids"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/packages/nexus-api-client/bun.lock
+++ b/packages/nexus-api-client/bun.lock
@@ -1,0 +1,461 @@
+{
+  "lockfileVersion": 1,
+  "configVersion": 0,
+  "workspaces": {
+    "": {
+      "name": "@nexus/api-client",
+      "devDependencies": {
+        "@types/node": "^25.4.0",
+        "@vitest/coverage-v8": "^2.0.0",
+        "tsup": "^8.0.0",
+        "typescript": "^5.5.0",
+        "vitest": "^2.0.0",
+      },
+    },
+  },
+  "packages": {
+    "@ampproject/remapping": ["@ampproject/remapping@2.3.0", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-30iZtAPgz+LTIYoeivqYo853f02jBYSd5uGnGpkFV0M3xOt9aN73erkgYAmZU43x4VfqcnLxW9Kpg3R5LC4YYw=="],
+
+    "@babel/helper-string-parser": ["@babel/helper-string-parser@7.27.1", "", {}, "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA=="],
+
+    "@babel/helper-validator-identifier": ["@babel/helper-validator-identifier@7.28.5", "", {}, "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q=="],
+
+    "@babel/parser": ["@babel/parser@7.29.0", "", { "dependencies": { "@babel/types": "^7.29.0" }, "bin": { "parser": "bin/babel-parser.js" } }, "sha512-IyDgFV5GeDUVX4YdF/3CPULtVGSXXMLh1xVIgdCgxApktqnQV0r7/8Nqthg+8YLGaAtdyIlo2qIdZrbCv4+7ww=="],
+
+    "@babel/types": ["@babel/types@7.29.0", "", { "dependencies": { "@babel/helper-string-parser": "^7.27.1", "@babel/helper-validator-identifier": "^7.28.5" } }, "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A=="],
+
+    "@bcoe/v8-coverage": ["@bcoe/v8-coverage@0.2.3", "", {}, "sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw=="],
+
+    "@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.27.3", "", { "os": "aix", "cpu": "ppc64" }, "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg=="],
+
+    "@esbuild/android-arm": ["@esbuild/android-arm@0.27.3", "", { "os": "android", "cpu": "arm" }, "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA=="],
+
+    "@esbuild/android-arm64": ["@esbuild/android-arm64@0.27.3", "", { "os": "android", "cpu": "arm64" }, "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg=="],
+
+    "@esbuild/android-x64": ["@esbuild/android-x64@0.27.3", "", { "os": "android", "cpu": "x64" }, "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ=="],
+
+    "@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.27.3", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg=="],
+
+    "@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.27.3", "", { "os": "darwin", "cpu": "x64" }, "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg=="],
+
+    "@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.27.3", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w=="],
+
+    "@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.27.3", "", { "os": "freebsd", "cpu": "x64" }, "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA=="],
+
+    "@esbuild/linux-arm": ["@esbuild/linux-arm@0.27.3", "", { "os": "linux", "cpu": "arm" }, "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw=="],
+
+    "@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.27.3", "", { "os": "linux", "cpu": "arm64" }, "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg=="],
+
+    "@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.27.3", "", { "os": "linux", "cpu": "ia32" }, "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg=="],
+
+    "@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA=="],
+
+    "@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw=="],
+
+    "@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.27.3", "", { "os": "linux", "cpu": "ppc64" }, "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA=="],
+
+    "@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.27.3", "", { "os": "linux", "cpu": "none" }, "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ=="],
+
+    "@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.27.3", "", { "os": "linux", "cpu": "s390x" }, "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw=="],
+
+    "@esbuild/linux-x64": ["@esbuild/linux-x64@0.27.3", "", { "os": "linux", "cpu": "x64" }, "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA=="],
+
+    "@esbuild/netbsd-arm64": ["@esbuild/netbsd-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA=="],
+
+    "@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.27.3", "", { "os": "none", "cpu": "x64" }, "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA=="],
+
+    "@esbuild/openbsd-arm64": ["@esbuild/openbsd-arm64@0.27.3", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw=="],
+
+    "@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.27.3", "", { "os": "openbsd", "cpu": "x64" }, "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ=="],
+
+    "@esbuild/openharmony-arm64": ["@esbuild/openharmony-arm64@0.27.3", "", { "os": "none", "cpu": "arm64" }, "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g=="],
+
+    "@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.27.3", "", { "os": "sunos", "cpu": "x64" }, "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA=="],
+
+    "@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.27.3", "", { "os": "win32", "cpu": "arm64" }, "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA=="],
+
+    "@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.27.3", "", { "os": "win32", "cpu": "ia32" }, "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q=="],
+
+    "@esbuild/win32-x64": ["@esbuild/win32-x64@0.27.3", "", { "os": "win32", "cpu": "x64" }, "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA=="],
+
+    "@isaacs/cliui": ["@isaacs/cliui@8.0.2", "", { "dependencies": { "string-width": "^5.1.2", "string-width-cjs": "npm:string-width@^4.2.0", "strip-ansi": "^7.0.1", "strip-ansi-cjs": "npm:strip-ansi@^6.0.1", "wrap-ansi": "^8.1.0", "wrap-ansi-cjs": "npm:wrap-ansi@^7.0.0" } }, "sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA=="],
+
+    "@istanbuljs/schema": ["@istanbuljs/schema@0.1.3", "", {}, "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA=="],
+
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@pkgjs/parseargs": ["@pkgjs/parseargs@0.11.0", "", {}, "sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg=="],
+
+    "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.59.0", "", { "os": "android", "cpu": "arm" }, "sha512-upnNBkA6ZH2VKGcBj9Fyl9IGNPULcjXRlg0LLeaioQWueH30p6IXtJEbKAgvyv+mJaMxSm1l6xwDXYjpEMiLMg=="],
+
+    "@rollup/rollup-android-arm64": ["@rollup/rollup-android-arm64@4.59.0", "", { "os": "android", "cpu": "arm64" }, "sha512-hZ+Zxj3SySm4A/DylsDKZAeVg0mvi++0PYVceVyX7hemkw7OreKdCvW2oQ3T1FMZvCaQXqOTHb8qmBShoqk69Q=="],
+
+    "@rollup/rollup-darwin-arm64": ["@rollup/rollup-darwin-arm64@4.59.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-W2Psnbh1J8ZJw0xKAd8zdNgF9HRLkdWwwdWqubSVk0pUuQkoHnv7rx4GiF9rT4t5DIZGAsConRE3AxCdJ4m8rg=="],
+
+    "@rollup/rollup-darwin-x64": ["@rollup/rollup-darwin-x64@4.59.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-ZW2KkwlS4lwTv7ZVsYDiARfFCnSGhzYPdiOU4IM2fDbL+QGlyAbjgSFuqNRbSthybLbIJ915UtZBtmuLrQAT/w=="],
+
+    "@rollup/rollup-freebsd-arm64": ["@rollup/rollup-freebsd-arm64@4.59.0", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-EsKaJ5ytAu9jI3lonzn3BgG8iRBjV4LxZexygcQbpiU0wU0ATxhNVEpXKfUa0pS05gTcSDMKpn3Sx+QB9RlTTA=="],
+
+    "@rollup/rollup-freebsd-x64": ["@rollup/rollup-freebsd-x64@4.59.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-d3DuZi2KzTMjImrxoHIAODUZYoUUMsuUiY4SRRcJy6NJoZ6iIqWnJu9IScV9jXysyGMVuW+KNzZvBLOcpdl3Vg=="],
+
+    "@rollup/rollup-linux-arm-gnueabihf": ["@rollup/rollup-linux-arm-gnueabihf@4.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-t4ONHboXi/3E0rT6OZl1pKbl2Vgxf9vJfWgmUoCEVQVxhW6Cw/c8I6hbbu7DAvgp82RKiH7TpLwxnJeKv2pbsw=="],
+
+    "@rollup/rollup-linux-arm-musleabihf": ["@rollup/rollup-linux-arm-musleabihf@4.59.0", "", { "os": "linux", "cpu": "arm" }, "sha512-CikFT7aYPA2ufMD086cVORBYGHffBo4K8MQ4uPS/ZnY54GKj36i196u8U+aDVT2LX4eSMbyHtyOh7D7Zvk2VvA=="],
+
+    "@rollup/rollup-linux-arm64-gnu": ["@rollup/rollup-linux-arm64-gnu@4.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-jYgUGk5aLd1nUb1CtQ8E+t5JhLc9x5WdBKew9ZgAXg7DBk0ZHErLHdXM24rfX+bKrFe+Xp5YuJo54I5HFjGDAA=="],
+
+    "@rollup/rollup-linux-arm64-musl": ["@rollup/rollup-linux-arm64-musl@4.59.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-peZRVEdnFWZ5Bh2KeumKG9ty7aCXzzEsHShOZEFiCQlDEepP1dpUl/SrUNXNg13UmZl+gzVDPsiCwnV1uI0RUA=="],
+
+    "@rollup/rollup-linux-loong64-gnu": ["@rollup/rollup-linux-loong64-gnu@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-gbUSW/97f7+r4gHy3Jlup8zDG190AuodsWnNiXErp9mT90iCy9NKKU0Xwx5k8VlRAIV2uU9CsMnEFg/xXaOfXg=="],
+
+    "@rollup/rollup-linux-loong64-musl": ["@rollup/rollup-linux-loong64-musl@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-yTRONe79E+o0FWFijasoTjtzG9EBedFXJMl888NBEDCDV9I2wGbFFfJQQe63OijbFCUZqxpHz1GzpbtSFikJ4Q=="],
+
+    "@rollup/rollup-linux-ppc64-gnu": ["@rollup/rollup-linux-ppc64-gnu@4.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-sw1o3tfyk12k3OEpRddF68a1unZ5VCN7zoTNtSn2KndUE+ea3m3ROOKRCZxEpmT9nsGnogpFP9x6mnLTCaoLkA=="],
+
+    "@rollup/rollup-linux-ppc64-musl": ["@rollup/rollup-linux-ppc64-musl@4.59.0", "", { "os": "linux", "cpu": "ppc64" }, "sha512-+2kLtQ4xT3AiIxkzFVFXfsmlZiG5FXYW7ZyIIvGA7Bdeuh9Z0aN4hVyXS/G1E9bTP/vqszNIN/pUKCk/BTHsKA=="],
+
+    "@rollup/rollup-linux-riscv64-gnu": ["@rollup/rollup-linux-riscv64-gnu@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-NDYMpsXYJJaj+I7UdwIuHHNxXZ/b/N2hR15NyH3m2qAtb/hHPA4g4SuuvrdxetTdndfj9b1WOmy73kcPRoERUg=="],
+
+    "@rollup/rollup-linux-riscv64-musl": ["@rollup/rollup-linux-riscv64-musl@4.59.0", "", { "os": "linux", "cpu": "none" }, "sha512-nLckB8WOqHIf1bhymk+oHxvM9D3tyPndZH8i8+35p/1YiVoVswPid2yLzgX7ZJP0KQvnkhM4H6QZ5m0LzbyIAg=="],
+
+    "@rollup/rollup-linux-s390x-gnu": ["@rollup/rollup-linux-s390x-gnu@4.59.0", "", { "os": "linux", "cpu": "s390x" }, "sha512-oF87Ie3uAIvORFBpwnCvUzdeYUqi2wY6jRFWJAy1qus/udHFYIkplYRW+wo+GRUP4sKzYdmE1Y3+rY5Gc4ZO+w=="],
+
+    "@rollup/rollup-linux-x64-gnu": ["@rollup/rollup-linux-x64-gnu@4.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-3AHmtQq/ppNuUspKAlvA8HtLybkDflkMuLK4DPo77DfthRb71V84/c4MlWJXixZz4uruIH4uaa07IqoAkG64fg=="],
+
+    "@rollup/rollup-linux-x64-musl": ["@rollup/rollup-linux-x64-musl@4.59.0", "", { "os": "linux", "cpu": "x64" }, "sha512-2UdiwS/9cTAx7qIUZB/fWtToJwvt0Vbo0zmnYt7ED35KPg13Q0ym1g442THLC7VyI6JfYTP4PiSOWyoMdV2/xg=="],
+
+    "@rollup/rollup-openbsd-x64": ["@rollup/rollup-openbsd-x64@4.59.0", "", { "os": "openbsd", "cpu": "x64" }, "sha512-M3bLRAVk6GOwFlPTIxVBSYKUaqfLrn8l0psKinkCFxl4lQvOSz8ZrKDz2gxcBwHFpci0B6rttydI4IpS4IS/jQ=="],
+
+    "@rollup/rollup-openharmony-arm64": ["@rollup/rollup-openharmony-arm64@4.59.0", "", { "os": "none", "cpu": "arm64" }, "sha512-tt9KBJqaqp5i5HUZzoafHZX8b5Q2Fe7UjYERADll83O4fGqJ49O1FsL6LpdzVFQcpwvnyd0i+K/VSwu/o/nWlA=="],
+
+    "@rollup/rollup-win32-arm64-msvc": ["@rollup/rollup-win32-arm64-msvc@4.59.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-V5B6mG7OrGTwnxaNUzZTDTjDS7F75PO1ae6MJYdiMu60sq0CqN5CVeVsbhPxalupvTX8gXVSU9gq+Rx1/hvu6A=="],
+
+    "@rollup/rollup-win32-ia32-msvc": ["@rollup/rollup-win32-ia32-msvc@4.59.0", "", { "os": "win32", "cpu": "ia32" }, "sha512-UKFMHPuM9R0iBegwzKF4y0C4J9u8C6MEJgFuXTBerMk7EJ92GFVFYBfOZaSGLu6COf7FxpQNqhNS4c4icUPqxA=="],
+
+    "@rollup/rollup-win32-x64-gnu": ["@rollup/rollup-win32-x64-gnu@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-laBkYlSS1n2L8fSo1thDNGrCTQMmxjYY5G0WFWjFFYZkKPjsMBsgJfGf4TLxXrF6RyhI60L8TMOjBMvXiTcxeA=="],
+
+    "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.59.0", "", { "os": "win32", "cpu": "x64" }, "sha512-2HRCml6OztYXyJXAvdDXPKcawukWY2GpR5/nxKp4iBgiO3wcoEGkAaqctIbZcNB6KlUQBIqt8VYkNSj2397EfA=="],
+
+    "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
+
+    "@types/node": ["@types/node@25.4.0", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-9wLpoeWuBlcbBpOY3XmzSTG3oscB6xjBEEtn+pYXTfhyXhIxC5FsBer2KTopBlvKEiW9l13po9fq+SJY/5lkhw=="],
+
+    "@vitest/coverage-v8": ["@vitest/coverage-v8@2.1.9", "", { "dependencies": { "@ampproject/remapping": "^2.3.0", "@bcoe/v8-coverage": "^0.2.3", "debug": "^4.3.7", "istanbul-lib-coverage": "^3.2.2", "istanbul-lib-report": "^3.0.1", "istanbul-lib-source-maps": "^5.0.6", "istanbul-reports": "^3.1.7", "magic-string": "^0.30.12", "magicast": "^0.3.5", "std-env": "^3.8.0", "test-exclude": "^7.0.1", "tinyrainbow": "^1.2.0" }, "peerDependencies": { "@vitest/browser": "2.1.9", "vitest": "2.1.9" }, "optionalPeers": ["@vitest/browser"] }, "sha512-Z2cOr0ksM00MpEfyVE8KXIYPEcBFxdbLSs56L8PO0QQMxt/6bDj45uQfxoc96v05KW3clk7vvgP0qfDit9DmfQ=="],
+
+    "@vitest/expect": ["@vitest/expect@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw=="],
+
+    "@vitest/mocker": ["@vitest/mocker@2.1.9", "", { "dependencies": { "@vitest/spy": "2.1.9", "estree-walker": "^3.0.3", "magic-string": "^0.30.12" }, "peerDependencies": { "msw": "^2.4.9", "vite": "^5.0.0" }, "optionalPeers": ["msw"] }, "sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg=="],
+
+    "@vitest/pretty-format": ["@vitest/pretty-format@2.1.9", "", { "dependencies": { "tinyrainbow": "^1.2.0" } }, "sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ=="],
+
+    "@vitest/runner": ["@vitest/runner@2.1.9", "", { "dependencies": { "@vitest/utils": "2.1.9", "pathe": "^1.1.2" } }, "sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g=="],
+
+    "@vitest/snapshot": ["@vitest/snapshot@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "magic-string": "^0.30.12", "pathe": "^1.1.2" } }, "sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ=="],
+
+    "@vitest/spy": ["@vitest/spy@2.1.9", "", { "dependencies": { "tinyspy": "^3.0.2" } }, "sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ=="],
+
+    "@vitest/utils": ["@vitest/utils@2.1.9", "", { "dependencies": { "@vitest/pretty-format": "2.1.9", "loupe": "^3.1.2", "tinyrainbow": "^1.2.0" } }, "sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ=="],
+
+    "acorn": ["acorn@8.16.0", "", { "bin": "bin/acorn" }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
+
+    "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
+
+    "ansi-styles": ["ansi-styles@6.2.3", "", {}, "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg=="],
+
+    "any-promise": ["any-promise@1.3.0", "", {}, "sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A=="],
+
+    "assertion-error": ["assertion-error@2.0.1", "", {}, "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "brace-expansion": ["brace-expansion@5.0.4", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-h+DEnpVvxmfVefa4jFbCf5HdH5YMDXRsmKflpf1pILZWRFlTbJpxeU55nJl4Smt5HQaGzg1o6RHFPJaOqnmBDg=="],
+
+    "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
+
+    "cac": ["cac@6.7.14", "", {}, "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ=="],
+
+    "chai": ["chai@5.3.3", "", { "dependencies": { "assertion-error": "^2.0.1", "check-error": "^2.1.1", "deep-eql": "^5.0.1", "loupe": "^3.1.0", "pathval": "^2.0.0" } }, "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw=="],
+
+    "check-error": ["check-error@2.1.3", "", {}, "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA=="],
+
+    "chokidar": ["chokidar@4.0.3", "", { "dependencies": { "readdirp": "^4.0.1" } }, "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA=="],
+
+    "color-convert": ["color-convert@2.0.1", "", { "dependencies": { "color-name": "~1.1.4" } }, "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ=="],
+
+    "color-name": ["color-name@1.1.4", "", {}, "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="],
+
+    "commander": ["commander@4.1.1", "", {}, "sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA=="],
+
+    "confbox": ["confbox@0.1.8", "", {}, "sha512-RMtmw0iFkeR4YV+fUOSucriAQNb9g8zFR52MWCtl+cCZOFRNL6zeB395vPzFhEjjn4fMxXudmELnl/KF/WrK6w=="],
+
+    "consola": ["consola@3.4.2", "", {}, "sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA=="],
+
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
+    "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
+
+    "deep-eql": ["deep-eql@5.0.2", "", {}, "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q=="],
+
+    "eastasianwidth": ["eastasianwidth@0.2.0", "", {}, "sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA=="],
+
+    "emoji-regex": ["emoji-regex@9.2.2", "", {}, "sha512-L18DaJsXSUk2+42pv8mLs5jJT2hqFkFE4j21wOmgbUqsZ2hL72NsUU785g9RXgo3s0ZNgVl42TiHp3ZtOv/Vyg=="],
+
+    "es-module-lexer": ["es-module-lexer@1.7.0", "", {}, "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA=="],
+
+    "esbuild": ["esbuild@0.27.3", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.27.3", "@esbuild/android-arm": "0.27.3", "@esbuild/android-arm64": "0.27.3", "@esbuild/android-x64": "0.27.3", "@esbuild/darwin-arm64": "0.27.3", "@esbuild/darwin-x64": "0.27.3", "@esbuild/freebsd-arm64": "0.27.3", "@esbuild/freebsd-x64": "0.27.3", "@esbuild/linux-arm": "0.27.3", "@esbuild/linux-arm64": "0.27.3", "@esbuild/linux-ia32": "0.27.3", "@esbuild/linux-loong64": "0.27.3", "@esbuild/linux-mips64el": "0.27.3", "@esbuild/linux-ppc64": "0.27.3", "@esbuild/linux-riscv64": "0.27.3", "@esbuild/linux-s390x": "0.27.3", "@esbuild/linux-x64": "0.27.3", "@esbuild/netbsd-arm64": "0.27.3", "@esbuild/netbsd-x64": "0.27.3", "@esbuild/openbsd-arm64": "0.27.3", "@esbuild/openbsd-x64": "0.27.3", "@esbuild/openharmony-arm64": "0.27.3", "@esbuild/sunos-x64": "0.27.3", "@esbuild/win32-arm64": "0.27.3", "@esbuild/win32-ia32": "0.27.3", "@esbuild/win32-x64": "0.27.3" }, "bin": "bin/esbuild" }, "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg=="],
+
+    "estree-walker": ["estree-walker@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.0" } }, "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g=="],
+
+    "expect-type": ["expect-type@1.3.0", "", {}, "sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" } }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fix-dts-default-cjs-exports": ["fix-dts-default-cjs-exports@1.0.1", "", { "dependencies": { "magic-string": "^0.30.17", "mlly": "^1.7.4", "rollup": "^4.34.8" } }, "sha512-pVIECanWFC61Hzl2+oOCtoJ3F17kglZC/6N94eRWycFgBH35hHx0Li604ZIzhseh97mf2p0cv7vVrOZGoqhlEg=="],
+
+    "foreground-child": ["foreground-child@3.3.1", "", { "dependencies": { "cross-spawn": "^7.0.6", "signal-exit": "^4.0.1" } }, "sha512-gIXjKqtFuWEgzFRJA9WCQeSJLZDjgJUOMCMzxtvFq/37KojM1BFGufqsCy0r4qSQmYLsZYMeyRqzIWOMup03sw=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "glob": ["glob@10.5.0", "", { "dependencies": { "foreground-child": "^3.1.0", "jackspeak": "^3.1.2", "minimatch": "^9.0.4", "minipass": "^7.1.2", "package-json-from-dist": "^1.0.0", "path-scurry": "^1.11.1" }, "bin": "dist/esm/bin.mjs" }, "sha512-DfXN8DfhJ7NH3Oe7cFmu3NCu1wKbkReJ8TorzSAFbSKrlNaQSKfIzqYqVY8zlbs2NLBbWpRiU52GX2PbaBVNkg=="],
+
+    "has-flag": ["has-flag@4.0.0", "", {}, "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="],
+
+    "html-escaper": ["html-escaper@2.0.2", "", {}, "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg=="],
+
+    "is-fullwidth-code-point": ["is-fullwidth-code-point@3.0.0", "", {}, "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg=="],
+
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "istanbul-lib-coverage": ["istanbul-lib-coverage@3.2.2", "", {}, "sha512-O8dpsF+r0WV/8MNRKfnmrtCWhuKjxrq2w+jpzBL5UZKTi2LeVWnWOmWRxFlesJONmc+wLAGvKQZEOanko0LFTg=="],
+
+    "istanbul-lib-report": ["istanbul-lib-report@3.0.1", "", { "dependencies": { "istanbul-lib-coverage": "^3.0.0", "make-dir": "^4.0.0", "supports-color": "^7.1.0" } }, "sha512-GCfE1mtsHGOELCU8e/Z7YWzpmybrx/+dSTfLrvY8qRmaY6zXTKWn6WQIjaAFw069icm6GVMNkgu0NzI4iPZUNw=="],
+
+    "istanbul-lib-source-maps": ["istanbul-lib-source-maps@5.0.6", "", { "dependencies": { "@jridgewell/trace-mapping": "^0.3.23", "debug": "^4.1.1", "istanbul-lib-coverage": "^3.0.0" } }, "sha512-yg2d+Em4KizZC5niWhQaIomgf5WlL4vOOjZ5xGCmF8SnPE/mDWWXgvRExdcpCgh9lLRRa1/fSYp2ymmbJ1pI+A=="],
+
+    "istanbul-reports": ["istanbul-reports@3.2.0", "", { "dependencies": { "html-escaper": "^2.0.0", "istanbul-lib-report": "^3.0.0" } }, "sha512-HGYWWS/ehqTV3xN10i23tkPkpH46MLCIMFNCaaKNavAXTF1RkqxawEPtnjnGZ6XKSInBKkiOA5BKS+aZiY3AvA=="],
+
+    "jackspeak": ["jackspeak@3.4.3", "", { "dependencies": { "@isaacs/cliui": "^8.0.2" }, "optionalDependencies": { "@pkgjs/parseargs": "^0.11.0" } }, "sha512-OGlZQpz2yfahA/Rd1Y8Cd9SIEsqvXkLVoSw/cgwhnhFMDbsQFeZYoJJ7bIZBS9BcamUW96asq/npPWugM+RQBw=="],
+
+    "joycon": ["joycon@3.1.1", "", {}, "sha512-34wB/Y7MW7bzjKRjUKTa46I2Z7eV62Rkhva+KkopW7Qvv/OSWBqvkSY7vusOPrNuZcUG3tApvdVgNB8POj3SPw=="],
+
+    "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
+
+    "lines-and-columns": ["lines-and-columns@1.2.4", "", {}, "sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg=="],
+
+    "load-tsconfig": ["load-tsconfig@0.2.5", "", {}, "sha512-IXO6OCs9yg8tMKzfPZ1YmheJbZCiEsnBdcB03l0OcfK9prKnJb96siuHCr5Fl37/yo9DnKU+TLpxzTUspw9shg=="],
+
+    "loupe": ["loupe@3.2.1", "", {}, "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ=="],
+
+    "lru-cache": ["lru-cache@10.4.3", "", {}, "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ=="],
+
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "magicast": ["magicast@0.3.5", "", { "dependencies": { "@babel/parser": "^7.25.4", "@babel/types": "^7.25.4", "source-map-js": "^1.2.0" } }, "sha512-L0WhttDl+2BOsybvEOLK7fW3UA0OQ0IQ2d6Zl2x/a6vVRs3bAY0ECOSHHeL5jD+SbOpOCUEi0y1DgHEn9Qn1AQ=="],
+
+    "make-dir": ["make-dir@4.0.0", "", { "dependencies": { "semver": "^7.5.3" } }, "sha512-hXdUTZYIVOt1Ex//jAQi+wTZZpUpwBj/0QsOzqegb3rGMMeJiSEu5xLHnYfBrRV4RH2+OCSOO95Is/7x1WJ4bw=="],
+
+    "minimatch": ["minimatch@10.2.4", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-oRjTw/97aTBN0RHbYCdtF1MQfvusSIBQM0IZEgzl6426+8jSC0nF1a/GmnVLpfB9yyr6g6FTqWqiZVbxrtaCIg=="],
+
+    "minipass": ["minipass@7.1.3", "", {}, "sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A=="],
+
+    "mlly": ["mlly@1.8.1", "", { "dependencies": { "acorn": "^8.16.0", "pathe": "^2.0.3", "pkg-types": "^1.3.1", "ufo": "^1.6.3" } }, "sha512-SnL6sNutTwRWWR/vcmCYHSADjiEesp5TGQQ0pXyLhW5IoeibRlF/CbSLailbB3CNqJUk9cVJ9dUDnbD7GrcHBQ=="],
+
+    "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
+
+    "mz": ["mz@2.7.0", "", { "dependencies": { "any-promise": "^1.0.0", "object-assign": "^4.0.1", "thenify-all": "^1.0.0" } }, "sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q=="],
+
+    "nanoid": ["nanoid@3.3.11", "", { "bin": "bin/nanoid.cjs" }, "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w=="],
+
+    "object-assign": ["object-assign@4.1.1", "", {}, "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg=="],
+
+    "package-json-from-dist": ["package-json-from-dist@1.0.1", "", {}, "sha512-UEZIS3/by4OC8vL3P2dTXRETpebLI2NiI5vIrjaD/5UtrkFX/tNbwjTSRAGC/+7CAo2pIcBaRgWmcBBHcsaCIw=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
+
+    "path-scurry": ["path-scurry@1.11.1", "", { "dependencies": { "lru-cache": "^10.2.0", "minipass": "^5.0.0 || ^6.0.2 || ^7.0.0" } }, "sha512-Xa4Nw17FS9ApQFJ9umLiJS4orGjm7ZzwUrwamcGQuHSzDyth9boKDaycYdDcZDuqYATXw4HFXgaqWTctW/v1HA=="],
+
+    "pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
+    "pathval": ["pathval@2.0.1", "", {}, "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "pirates": ["pirates@4.0.7", "", {}, "sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA=="],
+
+    "pkg-types": ["pkg-types@1.3.1", "", { "dependencies": { "confbox": "^0.1.8", "mlly": "^1.7.4", "pathe": "^2.0.1" } }, "sha512-/Jm5M4RvtBFVkKWRu2BLUTNP8/M2a+UwuAX+ae4770q1qVGtfjG+WTCupoZixokjmHiry8uI+dlY8KXYV5HVVQ=="],
+
+    "postcss": ["postcss@8.5.8", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg=="],
+
+    "postcss-load-config": ["postcss-load-config@6.0.1", "", { "dependencies": { "lilconfig": "^3.1.1" }, "peerDependencies": { "jiti": ">=1.21.0", "postcss": ">=8.0.9", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["jiti", "tsx", "yaml"] }, "sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g=="],
+
+    "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
+
+    "resolve-from": ["resolve-from@5.0.0", "", {}, "sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw=="],
+
+    "rollup": ["rollup@4.59.0", "", { "dependencies": { "@types/estree": "1.0.8" }, "optionalDependencies": { "@rollup/rollup-android-arm-eabi": "4.59.0", "@rollup/rollup-android-arm64": "4.59.0", "@rollup/rollup-darwin-arm64": "4.59.0", "@rollup/rollup-darwin-x64": "4.59.0", "@rollup/rollup-freebsd-arm64": "4.59.0", "@rollup/rollup-freebsd-x64": "4.59.0", "@rollup/rollup-linux-arm-gnueabihf": "4.59.0", "@rollup/rollup-linux-arm-musleabihf": "4.59.0", "@rollup/rollup-linux-arm64-gnu": "4.59.0", "@rollup/rollup-linux-arm64-musl": "4.59.0", "@rollup/rollup-linux-loong64-gnu": "4.59.0", "@rollup/rollup-linux-loong64-musl": "4.59.0", "@rollup/rollup-linux-ppc64-gnu": "4.59.0", "@rollup/rollup-linux-ppc64-musl": "4.59.0", "@rollup/rollup-linux-riscv64-gnu": "4.59.0", "@rollup/rollup-linux-riscv64-musl": "4.59.0", "@rollup/rollup-linux-s390x-gnu": "4.59.0", "@rollup/rollup-linux-x64-gnu": "4.59.0", "@rollup/rollup-linux-x64-musl": "4.59.0", "@rollup/rollup-openbsd-x64": "4.59.0", "@rollup/rollup-openharmony-arm64": "4.59.0", "@rollup/rollup-win32-arm64-msvc": "4.59.0", "@rollup/rollup-win32-ia32-msvc": "4.59.0", "@rollup/rollup-win32-x64-gnu": "4.59.0", "@rollup/rollup-win32-x64-msvc": "4.59.0", "fsevents": "~2.3.2" }, "bin": "dist/bin/rollup" }, "sha512-2oMpl67a3zCH9H79LeMcbDhXW/UmWG/y2zuqnF2jQq5uq9TbM9TVyXvA4+t+ne2IIkBdrLpAaRQAvo7YI/Yyeg=="],
+
+    "semver": ["semver@7.7.4", "", { "bin": "bin/semver.js" }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
+    "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
+
+    "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
+
+    "std-env": ["std-env@3.10.0", "", {}, "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg=="],
+
+    "string-width": ["string-width@5.1.2", "", { "dependencies": { "eastasianwidth": "^0.2.0", "emoji-regex": "^9.2.2", "strip-ansi": "^7.0.1" } }, "sha512-HnLOCR3vjcY8beoNLtcjZ5/nxn2afmME6lhrDrebokqMap+XbeW8n9TXpPDOqdGK5qcI3oT0GKTW6wC7EMiVqA=="],
+
+    "string-width-cjs": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "strip-ansi": ["strip-ansi@7.2.0", "", { "dependencies": { "ansi-regex": "^6.2.2" } }, "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w=="],
+
+    "strip-ansi-cjs": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "sucrase": ["sucrase@3.35.1", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.2", "commander": "^4.0.0", "lines-and-columns": "^1.1.6", "mz": "^2.7.0", "pirates": "^4.0.1", "tinyglobby": "^0.2.11", "ts-interface-checker": "^0.1.9" }, "bin": { "sucrase": "bin/sucrase", "sucrase-node": "bin/sucrase-node" } }, "sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw=="],
+
+    "supports-color": ["supports-color@7.2.0", "", { "dependencies": { "has-flag": "^4.0.0" } }, "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw=="],
+
+    "test-exclude": ["test-exclude@7.0.2", "", { "dependencies": { "@istanbuljs/schema": "^0.1.2", "glob": "^10.4.1", "minimatch": "^10.2.2" } }, "sha512-u9E6A+ZDYdp7a4WnarkXPZOx8Ilz46+kby6p1yZ8zsGTz9gYa6FIS7lj2oezzNKmtdyyJNNmmXDppga5GB7kSw=="],
+
+    "thenify": ["thenify@3.3.1", "", { "dependencies": { "any-promise": "^1.0.0" } }, "sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw=="],
+
+    "thenify-all": ["thenify-all@1.6.0", "", { "dependencies": { "thenify": ">= 3.1.0 < 4" } }, "sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA=="],
+
+    "tinybench": ["tinybench@2.9.0", "", {}, "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg=="],
+
+    "tinyexec": ["tinyexec@0.3.2", "", {}, "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA=="],
+
+    "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
+
+    "tinypool": ["tinypool@1.1.1", "", {}, "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg=="],
+
+    "tinyrainbow": ["tinyrainbow@1.2.0", "", {}, "sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ=="],
+
+    "tinyspy": ["tinyspy@3.0.2", "", {}, "sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q=="],
+
+    "tree-kill": ["tree-kill@1.2.2", "", { "bin": "cli.js" }, "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A=="],
+
+    "ts-interface-checker": ["ts-interface-checker@0.1.13", "", {}, "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA=="],
+
+    "tsup": ["tsup@8.5.1", "", { "dependencies": { "bundle-require": "^5.1.0", "cac": "^6.7.14", "chokidar": "^4.0.3", "consola": "^3.4.0", "debug": "^4.4.0", "esbuild": "^0.27.0", "fix-dts-default-cjs-exports": "^1.0.0", "joycon": "^3.1.1", "picocolors": "^1.1.1", "postcss-load-config": "^6.0.1", "resolve-from": "^5.0.0", "rollup": "^4.34.8", "source-map": "^0.7.6", "sucrase": "^3.35.0", "tinyexec": "^0.3.2", "tinyglobby": "^0.2.11", "tree-kill": "^1.2.2" }, "peerDependencies": { "@microsoft/api-extractor": "^7.36.0", "@swc/core": "^1", "postcss": "^8.4.12", "typescript": ">=4.5.0" }, "optionalPeers": ["@microsoft/api-extractor", "@swc/core"], "bin": { "tsup": "dist/cli-default.js", "tsup-node": "dist/cli-node.js" } }, "sha512-xtgkqwdhpKWr3tKPmCkvYmS9xnQK3m3XgxZHwSUjvfTjp7YfXe5tT3GgWi0F2N+ZSMsOeWeZFh7ZZFg5iPhing=="],
+
+    "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "ufo": ["ufo@1.6.3", "", {}, "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q=="],
+
+    "undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
+
+    "vite": ["vite@5.4.21", "", { "dependencies": { "esbuild": "^0.21.3", "postcss": "^8.4.43", "rollup": "^4.20.0" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^18.0.0 || >=20.0.0", "less": "*", "lightningcss": "^1.21.0", "sass": "*", "sass-embedded": "*", "stylus": "*", "sugarss": "*", "terser": "^5.4.0" }, "optionalPeers": ["less", "lightningcss", "sass", "sass-embedded", "stylus", "sugarss", "terser"], "bin": "bin/vite.js" }, "sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw=="],
+
+    "vite-node": ["vite-node@2.1.9", "", { "dependencies": { "cac": "^6.7.14", "debug": "^4.3.7", "es-module-lexer": "^1.5.4", "pathe": "^1.1.2", "vite": "^5.0.0" }, "bin": "vite-node.mjs" }, "sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA=="],
+
+    "vitest": ["vitest@2.1.9", "", { "dependencies": { "@vitest/expect": "2.1.9", "@vitest/mocker": "2.1.9", "@vitest/pretty-format": "^2.1.9", "@vitest/runner": "2.1.9", "@vitest/snapshot": "2.1.9", "@vitest/spy": "2.1.9", "@vitest/utils": "2.1.9", "chai": "^5.1.2", "debug": "^4.3.7", "expect-type": "^1.1.0", "magic-string": "^0.30.12", "pathe": "^1.1.2", "std-env": "^3.8.0", "tinybench": "^2.9.0", "tinyexec": "^0.3.1", "tinypool": "^1.0.1", "tinyrainbow": "^1.2.0", "vite": "^5.0.0", "vite-node": "2.1.9", "why-is-node-running": "^2.3.0" }, "peerDependencies": { "@edge-runtime/vm": "*", "@types/node": "^18.0.0 || >=20.0.0", "@vitest/browser": "2.1.9", "@vitest/ui": "2.1.9", "happy-dom": "*", "jsdom": "*" }, "optionalPeers": ["@edge-runtime/vm", "@vitest/browser", "@vitest/ui", "happy-dom", "jsdom"], "bin": "vitest.mjs" }, "sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q=="],
+
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "why-is-node-running": ["why-is-node-running@2.3.0", "", { "dependencies": { "siginfo": "^2.0.0", "stackback": "0.0.2" }, "bin": "cli.js" }, "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w=="],
+
+    "wrap-ansi": ["wrap-ansi@8.1.0", "", { "dependencies": { "ansi-styles": "^6.1.0", "string-width": "^5.0.1", "strip-ansi": "^7.0.1" } }, "sha512-si7QWI6zUMq56bESFvagtmzMdGOtoxfR+Sez11Mobfc7tm+VkUckk9bW2UeffTGVUbOksxmSw0AA2gs8g71NCQ=="],
+
+    "wrap-ansi-cjs": ["wrap-ansi@7.0.0", "", { "dependencies": { "ansi-styles": "^4.0.0", "string-width": "^4.1.0", "strip-ansi": "^6.0.0" } }, "sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q=="],
+
+    "@vitest/runner/pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
+    "@vitest/snapshot/pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
+    "glob/minimatch": ["minimatch@9.0.9", "", { "dependencies": { "brace-expansion": "^2.0.2" } }, "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg=="],
+
+    "mlly/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "pkg-types/pathe": ["pathe@2.0.3", "", {}, "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w=="],
+
+    "string-width-cjs/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "string-width-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "strip-ansi-cjs/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "vite/esbuild": ["esbuild@0.21.5", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.21.5", "@esbuild/android-arm": "0.21.5", "@esbuild/android-arm64": "0.21.5", "@esbuild/android-x64": "0.21.5", "@esbuild/darwin-arm64": "0.21.5", "@esbuild/darwin-x64": "0.21.5", "@esbuild/freebsd-arm64": "0.21.5", "@esbuild/freebsd-x64": "0.21.5", "@esbuild/linux-arm": "0.21.5", "@esbuild/linux-arm64": "0.21.5", "@esbuild/linux-ia32": "0.21.5", "@esbuild/linux-loong64": "0.21.5", "@esbuild/linux-mips64el": "0.21.5", "@esbuild/linux-ppc64": "0.21.5", "@esbuild/linux-riscv64": "0.21.5", "@esbuild/linux-s390x": "0.21.5", "@esbuild/linux-x64": "0.21.5", "@esbuild/netbsd-x64": "0.21.5", "@esbuild/openbsd-x64": "0.21.5", "@esbuild/sunos-x64": "0.21.5", "@esbuild/win32-arm64": "0.21.5", "@esbuild/win32-ia32": "0.21.5", "@esbuild/win32-x64": "0.21.5" }, "bin": "bin/esbuild" }, "sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw=="],
+
+    "vite-node/pathe": ["pathe@1.1.2", "", {}, "sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ=="],
+
+    "wrap-ansi-cjs/ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
+
+    "wrap-ansi-cjs/string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "wrap-ansi-cjs/strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
+
+    "glob/minimatch/brace-expansion": ["brace-expansion@2.0.2", "", { "dependencies": { "balanced-match": "^1.0.0" } }, "sha512-Jt0vHyM+jmUBqojB7E1NIYadt0vI0Qxjxd2TErW94wDz+E2LAm5vKMXXwg6ZZBTHPuUlDgQHKXvjGBdfcF1ZDQ=="],
+
+    "string-width-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.21.5", "", { "os": "aix", "cpu": "ppc64" }, "sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ=="],
+
+    "vite/esbuild/@esbuild/android-arm": ["@esbuild/android-arm@0.21.5", "", { "os": "android", "cpu": "arm" }, "sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg=="],
+
+    "vite/esbuild/@esbuild/android-arm64": ["@esbuild/android-arm64@0.21.5", "", { "os": "android", "cpu": "arm64" }, "sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A=="],
+
+    "vite/esbuild/@esbuild/android-x64": ["@esbuild/android-x64@0.21.5", "", { "os": "android", "cpu": "x64" }, "sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA=="],
+
+    "vite/esbuild/@esbuild/darwin-arm64": ["@esbuild/darwin-arm64@0.21.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ=="],
+
+    "vite/esbuild/@esbuild/darwin-x64": ["@esbuild/darwin-x64@0.21.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw=="],
+
+    "vite/esbuild/@esbuild/freebsd-arm64": ["@esbuild/freebsd-arm64@0.21.5", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g=="],
+
+    "vite/esbuild/@esbuild/freebsd-x64": ["@esbuild/freebsd-x64@0.21.5", "", { "os": "freebsd", "cpu": "x64" }, "sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ=="],
+
+    "vite/esbuild/@esbuild/linux-arm": ["@esbuild/linux-arm@0.21.5", "", { "os": "linux", "cpu": "arm" }, "sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA=="],
+
+    "vite/esbuild/@esbuild/linux-arm64": ["@esbuild/linux-arm64@0.21.5", "", { "os": "linux", "cpu": "arm64" }, "sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q=="],
+
+    "vite/esbuild/@esbuild/linux-ia32": ["@esbuild/linux-ia32@0.21.5", "", { "os": "linux", "cpu": "ia32" }, "sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg=="],
+
+    "vite/esbuild/@esbuild/linux-loong64": ["@esbuild/linux-loong64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg=="],
+
+    "vite/esbuild/@esbuild/linux-mips64el": ["@esbuild/linux-mips64el@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg=="],
+
+    "vite/esbuild/@esbuild/linux-ppc64": ["@esbuild/linux-ppc64@0.21.5", "", { "os": "linux", "cpu": "ppc64" }, "sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w=="],
+
+    "vite/esbuild/@esbuild/linux-riscv64": ["@esbuild/linux-riscv64@0.21.5", "", { "os": "linux", "cpu": "none" }, "sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA=="],
+
+    "vite/esbuild/@esbuild/linux-s390x": ["@esbuild/linux-s390x@0.21.5", "", { "os": "linux", "cpu": "s390x" }, "sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A=="],
+
+    "vite/esbuild/@esbuild/linux-x64": ["@esbuild/linux-x64@0.21.5", "", { "os": "linux", "cpu": "x64" }, "sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ=="],
+
+    "vite/esbuild/@esbuild/netbsd-x64": ["@esbuild/netbsd-x64@0.21.5", "", { "os": "none", "cpu": "x64" }, "sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg=="],
+
+    "vite/esbuild/@esbuild/openbsd-x64": ["@esbuild/openbsd-x64@0.21.5", "", { "os": "openbsd", "cpu": "x64" }, "sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow=="],
+
+    "vite/esbuild/@esbuild/sunos-x64": ["@esbuild/sunos-x64@0.21.5", "", { "os": "sunos", "cpu": "x64" }, "sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg=="],
+
+    "vite/esbuild/@esbuild/win32-arm64": ["@esbuild/win32-arm64@0.21.5", "", { "os": "win32", "cpu": "arm64" }, "sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A=="],
+
+    "vite/esbuild/@esbuild/win32-ia32": ["@esbuild/win32-ia32@0.21.5", "", { "os": "win32", "cpu": "ia32" }, "sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA=="],
+
+    "vite/esbuild/@esbuild/win32-x64": ["@esbuild/win32-x64@0.21.5", "", { "os": "win32", "cpu": "x64" }, "sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw=="],
+
+    "wrap-ansi-cjs/string-width/emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
+
+    "wrap-ansi-cjs/strip-ansi/ansi-regex": ["ansi-regex@5.0.1", "", {}, "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="],
+
+    "glob/minimatch/brace-expansion/balanced-match": ["balanced-match@1.0.2", "", {}, "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw=="],
+  }
+}

--- a/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
+++ b/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
@@ -34,6 +34,7 @@ import { FilePreview } from "./file-preview.js";
 import { FileEditor } from "./file-editor.js";
 import { FileMetadata } from "./file-metadata.js";
 import { FileAspects } from "./file-aspects.js";
+import { FileLineage } from "./file-lineage.js";
 import { FileSchema } from "./file-schema.js";
 import { ShareLinksTab } from "./share-links-tab.js";
 import { UploadsTab } from "./uploads-tab.js";
@@ -90,7 +91,7 @@ interface BindingContext {
   readonly toggleNode: (path: string, client: NonNullable<ReturnType<typeof useApi>>) => Promise<void>;
   readonly collapseNode: (path: string) => void;
   readonly fetchPreview: (path: string, client: NonNullable<ReturnType<typeof useApi>>) => Promise<void>;
-  readonly setMetadataTab: (tab: "metadata" | "aspects" | "schema") => void;
+  readonly setMetadataTab: (tab: "metadata" | "aspects" | "schema" | "lineage") => void;
   readonly catalogAvailable: boolean;
   // Share links
   readonly shareLinks: readonly { link_id: string; status: string }[];
@@ -210,6 +211,7 @@ function getExplorerActionBindings(ctx: BindingContext): Record<string, () => vo
     },
     // Metadata tabs
     m: () => ctx.setMetadataTab("metadata"),
+    l: () => ctx.setMetadataTab("lineage"),
     ...(ctx.catalogAvailable ? {
       a: () => ctx.setMetadataTab("aspects"),
       s: () => ctx.setMetadataTab("schema"),
@@ -581,7 +583,7 @@ export default function FileExplorerPanel(): React.ReactNode {
   const { available: catalogAvailable } = useBrickAvailable("catalog");
 
   // Active metadata sub-tab
-  const [metadataTab, setMetadataTab] = React.useState<"metadata" | "aspects" | "schema">("metadata");
+  const [metadataTab, setMetadataTab] = React.useState<"metadata" | "aspects" | "schema" | "lineage">("metadata");
   React.useEffect(() => {
     if (!catalogAvailable && (metadataTab === "aspects" || metadataTab === "schema")) {
       setMetadataTab("metadata");
@@ -874,13 +876,14 @@ export default function FileExplorerPanel(): React.ReactNode {
                 {/* Metadata tab bar with aspect count badge */}
                 <box height={1} width="100%">
                   <text>
-                    {`  ${metadataTab === "metadata" ? "[Metadata]" : " Metadata "}${catalogAvailable ? ` ${metadataTab === "aspects" ? `[Aspects${aspectCount > 0 ? ` (${aspectCount})` : ""}]` : ` Aspects${aspectCount > 0 ? ` (${aspectCount})` : ""} `} ${metadataTab === "schema" ? "[Schema]" : " Schema "}` : ""}`}
+                    {`  ${metadataTab === "metadata" ? "[Metadata]" : " Metadata "} ${metadataTab === "lineage" ? "[Lineage]" : " Lineage "}${catalogAvailable ? ` ${metadataTab === "aspects" ? `[Aspects${aspectCount > 0 ? ` (${aspectCount})` : ""}]` : ` Aspects${aspectCount > 0 ? ` (${aspectCount})` : ""} `} ${metadataTab === "schema" ? "[Schema]" : " Schema "}` : ""}`}
                   </text>
                 </box>
 
                 {/* Metadata sidebar (bottom 30%) */}
                 <box flexGrow={3} borderStyle="single">
                   {metadataTab === "metadata" && <FileMetadata item={selectedItem} />}
+                  {metadataTab === "lineage" && <FileLineage item={selectedItem} />}
                   {metadataTab === "aspects" && catalogAvailable && <FileAspects item={selectedItem} />}
                   {metadataTab === "schema" && catalogAvailable && <FileSchema item={selectedItem} />}
                 </box>

--- a/packages/nexus-tui/src/panels/files/file-lineage.tsx
+++ b/packages/nexus-tui/src/panels/files/file-lineage.tsx
@@ -1,0 +1,163 @@
+/**
+ * Lineage sub-view for the Files panel.
+ * Shows upstream inputs, downstream dependents, and agent provenance.
+ * Issue #3417.
+ */
+
+import React, { useEffect } from "react";
+import crypto from "node:crypto";
+import type { FileItem } from "../../stores/files-store.js";
+import { useLineageStore } from "../../stores/lineage-store.js";
+import { useApi } from "../../shared/hooks/use-api.js";
+import { statusColor } from "../../shared/theme.js";
+
+interface FileLineageProps {
+  readonly item: FileItem | null;
+}
+
+function computeUrn(item: FileItem): string | null {
+  if (!item.path) return null;
+  const zone = item.zoneId || "default";
+  const pathHash = crypto
+    .createHash("sha256")
+    .update(item.path)
+    .digest("hex")
+    .slice(0, 32);
+  return `urn:nexus:file:${zone}:${pathHash}`;
+}
+
+function truncate(value: string, max: number = 20): string {
+  return value.length > max ? `${value.slice(0, max - 1)}…` : value;
+}
+
+export function FileLineage({ item }: FileLineageProps): React.ReactNode {
+  const client = useApi();
+  const lineageCache = useLineageStore((s) => s.lineageCache);
+  const downstreamCache = useLineageStore((s) => s.downstreamCache);
+  const loading = useLineageStore((s) => s.loading);
+  const fetchLineage = useLineageStore((s) => s.fetchLineage);
+
+  const urn = item ? computeUrn(item) : null;
+
+  useEffect(() => {
+    if (client && urn && item?.path) {
+      fetchLineage(urn, item.path, client);
+    }
+  }, [client, urn, item?.path, fetchLineage]);
+
+  if (!item) {
+    return <text>No file selected</text>;
+  }
+
+  if (!urn) {
+    return <text>Cannot compute URN</text>;
+  }
+
+  if (loading && !lineageCache.has(urn)) {
+    return <text>Loading lineage...</text>;
+  }
+
+  const lineage = lineageCache.get(urn) ?? undefined;
+  const downstream = downstreamCache.get(urn) ?? [];
+  const hasLineage = lineage !== undefined && lineage !== null;
+  const hasDownstream = downstream.length > 0;
+
+  if (!hasLineage && !hasDownstream) {
+    return (
+      <box flexDirection="column" height="100%" width="100%">
+        <text>{"─── Lineage ───"}</text>
+        <text> </text>
+        <text>{"  No lineage recorded for this file."}</text>
+        <text> </text>
+        <text foregroundColor={statusColor.dim}>
+          {"  Agents declare lineage via scopes or"}
+        </text>
+        <text foregroundColor={statusColor.dim}>
+          {"  PUT /api/v2/lineage/{urn}"}
+        </text>
+      </box>
+    );
+  }
+
+  return (
+    <box flexDirection="column" height="100%" width="100%">
+      <text>{"─── Lineage ───"}</text>
+
+      {/* Producer info */}
+      {hasLineage && lineage && (
+        <>
+          <box height={1} width="100%">
+            <text>
+              <span foregroundColor={statusColor.dim}>{"Agent    "}</span>
+              <span foregroundColor={statusColor.identity}>{lineage.agent_id || "unknown"}</span>
+            </text>
+          </box>
+          <box height={1} width="100%">
+            <text>
+              <span foregroundColor={statusColor.dim}>{"Op       "}</span>
+              <span>{lineage.operation || "write"}</span>
+            </text>
+          </box>
+          {lineage.agent_generation != null && (
+            <box height={1} width="100%">
+              <text>
+                <span foregroundColor={statusColor.dim}>{"Gen      "}</span>
+                <span>{`#${lineage.agent_generation}`}</span>
+              </text>
+            </box>
+          )}
+          <text> </text>
+        </>
+      )}
+
+      {/* Upstream inputs */}
+      {hasLineage && lineage && lineage.upstream.length > 0 && (
+        <>
+          <text foregroundColor={statusColor.info}>
+            {`▸ Upstream (${lineage.upstream.length})${lineage.truncated ? " [truncated]" : ""}`}
+          </text>
+          {lineage.upstream.slice(0, 15).map((u, i) => (
+            <box key={`up-${i}`} height={1} width="100%">
+              <text>
+                <span foregroundColor={statusColor.reference}>{"  "}{truncate(u.path, 34)}</span>
+                <span foregroundColor={statusColor.dim}>{` v${u.version}`}</span>
+              </text>
+            </box>
+          ))}
+          {lineage.upstream.length > 15 && (
+            <text foregroundColor={statusColor.dim}>
+              {`  ... +${lineage.upstream.length - 15} more`}
+            </text>
+          )}
+          <text> </text>
+        </>
+      )}
+
+      {/* Downstream dependents */}
+      {hasDownstream && (
+        <>
+          <text foregroundColor={statusColor.info}>
+            {`▸ Downstream (${downstream.length})`}
+          </text>
+          {downstream.slice(0, 10).map((d, i) => (
+            <box key={`dn-${i}`} height={1} width="100%">
+              <text>
+                <span foregroundColor={statusColor.reference}>
+                  {"  "}{truncate(d.downstream_path || d.downstream_urn, 30)}
+                </span>
+                {d.agent_id && (
+                  <span foregroundColor={statusColor.dim}>{` by ${d.agent_id}`}</span>
+                )}
+              </text>
+            </box>
+          ))}
+          {downstream.length > 10 && (
+            <text foregroundColor={statusColor.dim}>
+              {`  ... +${downstream.length - 10} more`}
+            </text>
+          )}
+        </>
+      )}
+    </box>
+  );
+}

--- a/packages/nexus-tui/src/stores/lineage-store.ts
+++ b/packages/nexus-tui/src/stores/lineage-store.ts
@@ -1,0 +1,126 @@
+/**
+ * Zustand store for lineage data: upstream inputs, downstream dependents.
+ * Issue #3417.
+ */
+
+import { create } from "zustand";
+import type { FetchClient } from "@nexus/api-client";
+import { useErrorStore } from "./error-store.js";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface UpstreamEntry {
+  readonly path: string;
+  readonly version: number;
+  readonly etag: string;
+  readonly access_type: string;
+}
+
+export interface LineageData {
+  readonly upstream: readonly UpstreamEntry[];
+  readonly agent_id: string;
+  readonly agent_generation: number | null;
+  readonly operation: string;
+  readonly duration_ms: number | null;
+  readonly truncated: boolean;
+}
+
+export interface DownstreamEntry {
+  readonly downstream_urn: string;
+  readonly downstream_path: string | null;
+  readonly upstream_version: number;
+  readonly upstream_etag: string;
+  readonly agent_id: string;
+  readonly created_at: string | null;
+}
+
+// =============================================================================
+// Store
+// =============================================================================
+
+export interface LineageState {
+  // Cache keyed by URN
+  readonly lineageCache: ReadonlyMap<string, LineageData | null>;
+  readonly downstreamCache: ReadonlyMap<string, readonly DownstreamEntry[]>;
+  readonly loading: boolean;
+  readonly error: string | null;
+
+  // Actions
+  readonly fetchLineage: (urn: string, path: string, client: FetchClient) => Promise<void>;
+  readonly clearCache: () => void;
+}
+
+export const useLineageStore = create<LineageState>((set, get) => ({
+  lineageCache: new Map(),
+  downstreamCache: new Map(),
+  loading: false,
+  error: null,
+
+  fetchLineage: async (urn: string, path: string, client: FetchClient) => {
+    // Skip if already cached
+    if (get().lineageCache.has(urn)) return;
+
+    set({ loading: true, error: null });
+    try {
+      // Fetch upstream lineage
+      const encodedUrn = encodeURIComponent(urn);
+      let lineageData: LineageData | null = null;
+      try {
+        const resp = await client.get<LineageData & { entity_urn: string }>(
+          `/api/v2/lineage/${encodedUrn}`,
+        );
+        lineageData = {
+          upstream: resp.upstream ?? [],
+          agent_id: resp.agent_id ?? "",
+          agent_generation: resp.agent_generation ?? null,
+          operation: resp.operation ?? "",
+          duration_ms: resp.duration_ms ?? null,
+          truncated: resp.truncated ?? false,
+        };
+      } catch {
+        // 404 = no lineage, not an error
+        lineageData = null;
+      }
+
+      // Fetch downstream dependents
+      let downstream: DownstreamEntry[] = [];
+      try {
+        const encodedPath = encodeURIComponent(path);
+        const dsResp = await client.get<{ downstream: DownstreamEntry[] }>(
+          `/api/v2/lineage/downstream/query?path=${encodedPath}`,
+        );
+        downstream = dsResp.downstream ?? [];
+      } catch {
+        // best effort
+      }
+
+      const newLineageCache = new Map(get().lineageCache);
+      newLineageCache.set(urn, lineageData);
+      const newDownstreamCache = new Map(get().downstreamCache);
+      newDownstreamCache.set(urn, downstream);
+
+      set({
+        lineageCache: newLineageCache,
+        downstreamCache: newDownstreamCache,
+        loading: false,
+      });
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : String(err);
+      set({ loading: false, error: msg });
+      useErrorStore.getState().pushError({
+        title: "Lineage fetch failed",
+        detail: msg,
+        category: "api",
+      });
+    }
+  },
+
+  clearCache: () => {
+    set({
+      lineageCache: new Map(),
+      downstreamCache: new Map(),
+    });
+  },
+}));

--- a/src/nexus/cli/commands/__init__.py
+++ b/src/nexus/cli/commands/__init__.py
@@ -59,6 +59,8 @@ _REGISTER_COMMANDS: dict[str, tuple[str, ...]] = {
     # Issue #2930: Catalog and aspects commands
     "catalog": ("catalog",),
     "aspects": ("aspects",),
+    # Issue #3417: Lineage tracking commands
+    "lineage": ("lineage",),
 }
 
 # Modules that expose a single Click command/group to add via cli.add_command

--- a/src/nexus/cli/commands/demo.py
+++ b/src/nexus/cli/commands/demo.py
@@ -33,6 +33,7 @@ from nexus.cli.commands.demo_data import (
     DEMO_IPC_DEAD_LETTER,
     DEMO_IPC_MESSAGES,
     DEMO_IPC_PROCESSED,
+    DEMO_LINEAGE,
     DEMO_PERMISSION_TUPLES,
     DEMO_USERS,
     DEMO_ZONES,
@@ -1163,6 +1164,54 @@ def _seed_aspects(nx: Any, config: dict[str, Any], manifest: dict[str, Any]) -> 
     return created
 
 
+def _seed_lineage(
+    nx: Any,  # noqa: ARG001
+    config: dict[str, Any],
+    manifest: dict[str, Any],
+) -> int:
+    """Seed agent lineage data for demo files (Issue #3417).
+
+    Calls the lineage REST API to declare upstream dependencies for
+    demo output files, demonstrating the agent lineage tracking feature.
+    Returns count of lineage entries created.
+    """
+    if manifest.get("lineage_created"):
+        return 0
+
+    from nexus.cli.api_client import NexusApiClient
+    from nexus.contracts.urn import NexusURN
+
+    rt = _resolve_runtime_connection(config)
+    client = NexusApiClient(url=rt["base_url"], api_key=rt["api_key"])
+
+    created = 0
+    for output_path, upstream_inputs, agent_id in DEMO_LINEAGE:
+        try:
+            urn = str(NexusURN.for_file("root", output_path))
+            encoded_urn = urn.replace(":", "%3A")
+            client.put(
+                f"/api/v2/lineage/{encoded_urn}",
+                json_body={
+                    "upstream": [
+                        {
+                            "path": u["path"],
+                            "version": u.get("version", 1),
+                            "etag": u.get("etag", ""),
+                        }
+                        for u in upstream_inputs
+                    ],
+                    "agent_id": agent_id,
+                },
+            )
+            created += 1
+        except Exception as e:
+            logger.debug("Could not seed lineage for %s: %s", output_path, e)
+
+    manifest["lineage_created"] = created > 0
+    manifest["lineage_count"] = created
+    return created
+
+
 # ---------------------------------------------------------------------------
 # Semantic search initialization
 # ---------------------------------------------------------------------------
@@ -1518,7 +1567,14 @@ async def _async_demo_init(reset: bool, skip_semantic: bool) -> None:
     except Exception as e:
         logger.debug("Aspect seeding failed: %s", e)
 
-    # 9. Record seed metadata
+    # 9. Seed lineage (best-effort, Issue #3417)
+    lineage_created = 0
+    try:
+        lineage_created = _seed_lineage(nx, config, manifest)
+    except Exception as e:
+        logger.debug("Lineage seeding failed: %s", e)
+
+    # 10. Record seed metadata
     manifest["seeded_at"] = datetime.now(tz=UTC).isoformat()
     manifest["preset"] = config.get("preset", "unknown")
     manifest["skip_semantic"] = skip_semantic
@@ -1573,6 +1629,10 @@ async def _async_demo_init(reset: bool, skip_semantic: bool) -> None:
         console.print(f"  Aspects:      {aspects_created} aspects seeded")
     else:
         console.print("  Aspects:      skipped (server unavailable)")
+    if lineage_created > 0:
+        console.print(f"  Lineage:      {lineage_created} lineage entries seeded")
+    else:
+        console.print("  Lineage:      skipped (server unavailable)")
 
     # Print suggested commands — for shared/demo presets, tell the user to
     # export env vars so all CLI commands authenticate against the running stack.

--- a/src/nexus/cli/commands/demo_data.py
+++ b/src/nexus/cli/commands/demo_data.py
@@ -342,6 +342,34 @@ PLAN_VERSIONS = [
 ]
 
 # ---------------------------------------------------------------------------
+# Lineage seed data — agent read-to-write dependencies (Issue #3417)
+#
+# Demonstrates: coordinator read architecture.md + code/example.py → wrote plan.md
+# Also: demo_agent read data/sales.csv + data/metrics.json → wrote data/sample.json
+# ---------------------------------------------------------------------------
+
+DEMO_LINEAGE: list[tuple[str, list[dict[str, str | int]], str]] = [
+    # (output_path, upstream_inputs, agent_id)
+    (
+        "/workspace/demo/plan.md",
+        [
+            {"path": "/workspace/demo/notes/architecture.md", "version": 1, "etag": ""},
+            {"path": "/workspace/demo/code/example.py", "version": 1, "etag": ""},
+            {"path": "/workspace/demo/notes/meeting-2026-03.md", "version": 1, "etag": ""},
+        ],
+        "coordinator",
+    ),
+    (
+        "/workspace/demo/data/sample.json",
+        [
+            {"path": "/workspace/demo/data/sales.csv", "version": 1, "etag": ""},
+            {"path": "/workspace/demo/data/metrics.json", "version": 1, "etag": ""},
+        ],
+        "demo_agent",
+    ),
+]
+
+# ---------------------------------------------------------------------------
 # Demo directories (ordered parents-first for creation, reversed for deletion)
 # ---------------------------------------------------------------------------
 

--- a/src/nexus/cli/commands/lineage.py
+++ b/src/nexus/cli/commands/lineage.py
@@ -1,0 +1,195 @@
+"""Lineage CLI commands -- query agent lineage (Issue #3417).
+
+Examples:
+    nexus lineage upstream /output/result.json
+    nexus lineage downstream /data/input.csv
+    nexus lineage stale /data/input.csv
+"""
+
+from __future__ import annotations
+
+import logging
+from urllib.parse import quote
+
+import click
+
+from nexus.cli.utils import add_backend_options, console
+
+logger = logging.getLogger(__name__)
+
+
+def register_commands(cli: click.Group) -> None:
+    """Register lineage commands."""
+    cli.add_command(lineage)
+
+
+@click.group(name="lineage")
+def lineage() -> None:
+    """Agent lineage tracking -- query input/output dependencies."""
+
+
+@lineage.command(name="upstream")
+@click.argument("path")
+@add_backend_options
+@click.pass_context
+def lineage_upstream(
+    ctx: click.Context, path: str, remote_url: str | None, remote_api_key: str | None
+) -> None:
+    """Show upstream inputs for an output file.
+
+    Example:
+        nexus lineage upstream /output/result.json
+    """
+    from nexus.cli.api_client import get_api_client_from_options
+    from nexus.cli.config import resolve_connection
+    from nexus.contracts.urn import NexusURN
+
+    profile_name = (ctx.obj or {}).get("profile")
+    conn = resolve_connection(
+        remote_url=remote_url, remote_api_key=remote_api_key, profile_name=profile_name
+    )
+    zone_id = conn.zone_id or "root"
+    client = get_api_client_from_options(remote_url, remote_api_key, profile_name=profile_name)
+    urn = str(NexusURN.for_file(zone_id, path))
+
+    try:
+        result = client.get(f"/api/v2/lineage/{quote(urn, safe='')}")
+    except Exception as e:
+        console.print(f"[yellow]No lineage found for {path}[/yellow]")
+        logger.debug("lineage upstream error: %s", e)
+        return
+
+    upstream = result.get("upstream", [])
+    agent_id = result.get("agent_id", "")
+    operation = result.get("operation", "")
+
+    console.print(f"[bold]Lineage for {path}[/bold]")
+    console.print(f"  Agent:     {agent_id}")
+    console.print(f"  Operation: {operation}")
+    if result.get("truncated"):
+        console.print("  [yellow]Truncated: upstream list was capped[/yellow]")
+    console.print()
+
+    if not upstream:
+        console.print("  No upstream inputs recorded.")
+        return
+
+    console.print(f"  Upstream inputs ({len(upstream)}):")
+    for entry in upstream:
+        version = entry.get("version", 0)
+        etag = entry.get("etag", "")[:12]
+        access = entry.get("access_type", "content")
+        console.print(f"    {entry['path']}  (v{version}, {access}, etag={etag}...)")
+
+
+@lineage.command(name="downstream")
+@click.argument("path")
+@add_backend_options
+@click.pass_context
+def lineage_downstream(
+    ctx: click.Context, path: str, remote_url: str | None, remote_api_key: str | None
+) -> None:
+    """Show downstream outputs that depend on an input file (impact analysis).
+
+    Example:
+        nexus lineage downstream /data/input.csv
+    """
+    from nexus.cli.api_client import get_api_client_from_options
+    from nexus.cli.config import resolve_connection
+
+    profile_name = (ctx.obj or {}).get("profile")
+    resolve_connection(
+        remote_url=remote_url, remote_api_key=remote_api_key, profile_name=profile_name
+    )
+    client = get_api_client_from_options(remote_url, remote_api_key, profile_name=profile_name)
+
+    try:
+        result = client.get(f"/api/v2/lineage/downstream/query?path={quote(path, safe='')}")
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1) from e
+
+    downstream = result.get("downstream", [])
+    console.print(f"[bold]Downstream dependents of {path}[/bold]")
+    console.print()
+
+    if not downstream:
+        console.print("  No downstream outputs found.")
+        return
+
+    console.print(f"  Downstream outputs ({len(downstream)}):")
+    for entry in downstream:
+        ds_path = entry.get("downstream_path", entry.get("downstream_urn", "?"))
+        agent = entry.get("agent_id", "")
+        version = entry.get("upstream_version", 0)
+        console.print(f"    {ds_path}  (read at v{version}, by {agent})")
+
+
+@lineage.command(name="stale")
+@click.argument("path")
+@click.option(
+    "--version", "file_version", type=int, help="Current version (auto-detected if omitted)"
+)
+@click.option("--etag", help="Current etag/content hash (auto-detected if omitted)")
+@add_backend_options
+@click.pass_context
+def lineage_stale(
+    ctx: click.Context,
+    path: str,
+    file_version: int | None,
+    etag: str | None,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """Show downstream outputs that are stale because this input changed.
+
+    Example:
+        nexus lineage stale /data/input.csv
+        nexus lineage stale /data/input.csv --version 5 --etag abc123
+    """
+    from nexus.cli.api_client import get_api_client_from_options
+    from nexus.cli.config import resolve_connection
+
+    profile_name = (ctx.obj or {}).get("profile")
+    resolve_connection(
+        remote_url=remote_url, remote_api_key=remote_api_key, profile_name=profile_name
+    )
+    client = get_api_client_from_options(remote_url, remote_api_key, profile_name=profile_name)
+
+    # Auto-detect version/etag if not provided
+    if file_version is None or etag is None:
+        try:
+            stat = client.get(f"/api/v2/files/stat?path={quote(path, safe='')}")
+            if file_version is None:
+                file_version = stat.get("version", 0)
+            if etag is None:
+                etag = stat.get("etag", "")
+        except Exception as exc:
+            console.print(
+                "[yellow]Could not auto-detect version/etag. Provide --version and --etag.[/yellow]"
+            )
+            raise SystemExit(1) from exc
+
+    try:
+        params = f"path={quote(path, safe='')}&current_version={file_version}&current_etag={quote(etag or '', safe='')}"
+        result = client.get(f"/api/v2/lineage/stale/query?{params}")
+    except Exception as e:
+        console.print(f"[red]Error:[/red] {e}")
+        raise SystemExit(1) from e
+
+    stale = result.get("stale", [])
+    console.print(f"[bold]Staleness check for {path}[/bold]")
+    console.print(f"  Current version: {file_version}")
+    console.print(f"  Current etag:    {(etag or '')[:12]}...")
+    console.print()
+
+    if not stale:
+        console.print("  [green]All downstream outputs are up to date.[/green]")
+        return
+
+    console.print(f"  [red]Stale outputs ({len(stale)}):[/red]")
+    for entry in stale:
+        ds_path = entry.get("downstream_path", entry.get("downstream_urn", "?"))
+        rec_v = entry.get("recorded_version", 0)
+        agent = entry.get("agent_id", "")
+        console.print(f"    {ds_path}  (read at v{rec_v}, by {agent})")

--- a/src/nexus/contracts/aspects.py
+++ b/src/nexus/contracts/aspects.py
@@ -319,6 +319,123 @@ class GovernanceClassificationAspect(AspectBase):
         self.review_date = review_date
 
 
+@register_aspect("lineage", max_versions=5)
+class LineageAspect(AspectBase):
+    """Agent lineage tracking — records which files an agent read to produce an output.
+
+    Enables impact analysis ("if I change X, what outputs are stale?"),
+    provenance auditing, and staleness detection. Inspired by DataHub's
+    UpstreamLineage aspect, adapted for agent-native workflows.
+
+    Issue #3417.
+
+    Attributes:
+        upstream: List of upstream dependencies with version info.
+        agent_id: Which agent produced this output.
+        agent_generation: Session generation counter (optional).
+        operation: Type of write operation (write, write_batch, copy).
+        duration_ms: How long the agent worked on this (optional).
+    """
+
+    # Maximum upstream entries per lineage aspect to prevent unbounded growth
+    MAX_UPSTREAM_ENTRIES: int = 500
+
+    def __init__(
+        self,
+        upstream: list[dict[str, Any]] | None = None,
+        agent_id: str = "",
+        agent_generation: int | None = None,
+        operation: str = "write",
+        duration_ms: int | None = None,
+        truncated: bool = False,
+    ) -> None:
+        self.upstream = upstream or []
+        self.agent_id = agent_id
+        self.agent_generation = agent_generation
+        self.operation = operation
+        self.duration_ms = duration_ms
+        self.truncated = truncated
+
+    @classmethod
+    def from_session_reads(
+        cls,
+        reads: list[dict[str, Any]],
+        agent_id: str,
+        agent_generation: int | None = None,
+        operation: str = "write",
+        duration_ms: int | None = None,
+    ) -> "LineageAspect":
+        """Build a LineageAspect from accumulated session reads.
+
+        Each read entry should have: path, version, etag, access_type.
+        Caps at MAX_UPSTREAM_ENTRIES with a warning.
+
+        Args:
+            reads: List of read dicts from the session accumulator.
+            agent_id: Agent that produced this output.
+            agent_generation: Session generation counter.
+            operation: Write operation type.
+            duration_ms: Processing duration.
+
+        Returns:
+            LineageAspect with upstream entries populated.
+        """
+        truncated = len(reads) > cls.MAX_UPSTREAM_ENTRIES
+        if truncated:
+            logger.warning(
+                "Lineage truncated: %d reads exceed max %d for agent %s",
+                len(reads),
+                cls.MAX_UPSTREAM_ENTRIES,
+                agent_id,
+            )
+        upstream = [
+            {
+                "path": r["path"],
+                "version": r.get("version", 0),
+                "etag": r.get("etag", ""),
+                "access_type": r.get("access_type", "content"),
+            }
+            for r in reads[: cls.MAX_UPSTREAM_ENTRIES]
+        ]
+        return cls(
+            upstream=upstream,
+            agent_id=agent_id,
+            agent_generation=agent_generation,
+            operation=operation,
+            duration_ms=duration_ms,
+            truncated=truncated,
+        )
+
+    @classmethod
+    def from_explicit_declaration(
+        cls,
+        upstream: list[dict[str, Any]],
+        agent_id: str,
+        agent_generation: int | None = None,
+    ) -> "LineageAspect":
+        """Build a LineageAspect from an explicit upstream declaration.
+
+        Used when agents declare their inputs via the REST API.
+
+        Args:
+            upstream: List of upstream dicts (path, version, etag required).
+            agent_id: Agent declaring the lineage.
+            agent_generation: Session generation counter.
+
+        Returns:
+            LineageAspect with upstream entries populated.
+        """
+        truncated = len(upstream) > cls.MAX_UPSTREAM_ENTRIES
+        capped = upstream[: cls.MAX_UPSTREAM_ENTRIES]
+        return cls(
+            upstream=capped,
+            agent_id=agent_id,
+            agent_generation=agent_generation,
+            operation="explicit",
+            truncated=truncated,
+        )
+
+
 @register_aspect("document_structure", max_versions=10)
 class DocumentStructureAspect(AspectBase):
     """Structure metadata for non-tabular documents (Markdown, PDF, etc.).

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -1588,7 +1588,12 @@ class NexusFS(  # type: ignore[misc]
         # --- Agent lineage: record read into session accumulator (Issue #3417) ---
         # Non-blocking, in-memory only. Records path + version + etag so the
         # lineage hook can attribute this read to the agent's next write.
-        if agent_id and meta is not None:
+        # Gate: only registered agents (subject_type="agent", authenticated via
+        # agent API key) produce lineage. Admin impersonation is excluded.
+        _is_registered_agent = (
+            agent_id and context is not None and getattr(context, "subject_type", "user") == "agent"
+        )
+        if _is_registered_agent and meta is not None:
             try:
                 from nexus.storage.session_read_accumulator import get_accumulator
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -1588,24 +1588,29 @@ class NexusFS(  # type: ignore[misc]
         # --- Agent lineage: record read into session accumulator (Issue #3417) ---
         # Non-blocking, in-memory only. Records path + version + etag so the
         # lineage hook can attribute this read to the agent's next write.
-        # Gate: only registered agents (subject_type="agent", authenticated via
-        # agent API key) produce lineage. Admin impersonation is excluded.
+        # Gates:
+        #   1. Registered agent only (subject_type="agent", via agent API key)
+        #   2. Explicit scope must be active (agent called POST /scope/begin)
+        #      No default capture — if no scope is active, reads are not tracked.
         _is_registered_agent = (
             agent_id and context is not None and getattr(context, "subject_type", "user") == "agent"
         )
         if _is_registered_agent and meta is not None:
             try:
-                from nexus.storage.session_read_accumulator import get_accumulator
+                from nexus.storage.session_read_accumulator import DEFAULT_SCOPE, get_accumulator
 
+                _acc = get_accumulator()
                 _gen = getattr(context, "agent_generation", None) if context else None
-                get_accumulator().record_read(
-                    agent_id,
-                    _gen,
-                    path,
-                    version=getattr(meta, "version", 0) or 0,
-                    etag=getattr(meta, "etag", "") or "",
-                    access_type="content",
-                )
+                # Only record if agent has an explicit scope active (not default)
+                if _acc.get_active_scope(agent_id, _gen) != DEFAULT_SCOPE:
+                    _acc.record_read(
+                        agent_id,
+                        _gen,
+                        path,
+                        version=getattr(meta, "version", 0) or 0,
+                        etag=getattr(meta, "etag", "") or "",
+                        access_type="content",
+                    )
             except Exception:
                 pass  # Best-effort; never block reads
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -1585,6 +1585,25 @@ class NexusFS(  # type: ignore[misc]
             await self._dispatch.intercept_post_read(_read_ctx)
             content = _read_ctx.content or content  # hooks may have filtered content
 
+        # --- Agent lineage: record read into session accumulator (Issue #3417) ---
+        # Non-blocking, in-memory only. Records path + version + etag so the
+        # lineage hook can attribute this read to the agent's next write.
+        if agent_id and meta is not None:
+            try:
+                from nexus.storage.session_read_accumulator import get_accumulator
+
+                _gen = getattr(context, "agent_generation", None) if context else None
+                get_accumulator().record_read(
+                    agent_id,
+                    _gen,
+                    path,
+                    version=getattr(meta, "version", 0) or 0,
+                    etag=getattr(meta, "etag", "") or "",
+                    access_type="content",
+                )
+            except Exception:
+                pass  # Best-effort; never block reads
+
         # Apply count/offset slicing (POSIX pread semantics)
         if offset or count is not None:
             content = content[offset : offset + count] if count is not None else content[offset:]

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -1612,7 +1612,7 @@ class NexusFS(  # type: ignore[misc]
                         access_type="content",
                     )
             except Exception:
-                pass  # Best-effort; never block reads
+                logger.debug("Lineage read tracking failed (non-critical)", exc_info=True)
 
         # Apply count/offset slicing (POSIX pread semantics)
         if offset or count is not None:

--- a/src/nexus/factory/_lineage_hook.py
+++ b/src/nexus/factory/_lineage_hook.py
@@ -1,0 +1,152 @@
+"""Post-flush lineage hook — records agent lineage on write (Issue #3417).
+
+Creates a post-flush hook function that reads accumulated session reads
+and persists them as a lineage aspect + reverse index entries on the
+written file's entity.
+
+The hook:
+    1. Iterates flushed events, filtering for "write" and "copy" ops
+    2. Agent-gates: only processes events with agent_id set
+    3. Consumes reads from the SessionReadAccumulator
+    4. Builds LineageAspect and calls LineageService.record_lineage()
+    5. Wraps each file's lineage in a savepoint (atomic per file)
+
+Failures are logged and ignored — lineage is best-effort.
+Recovery: ``nexus reindex --target lineage`` catches gaps.
+"""
+
+import logging
+import threading
+from collections.abc import Callable
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+
+def make_lineage_hook(
+    *,
+    session_factory: Callable[..., Any],
+) -> Callable[[list[dict[str, Any]]], None]:
+    """Create a post-flush hook for agent lineage recording.
+
+    Args:
+        session_factory: RecordStore session factory for LineageService.
+
+    Returns:
+        Hook function: ``(events: list[dict]) -> None``
+    """
+
+    def lineage_hook(events: list[dict[str, Any]]) -> None:
+        """Record lineage for agent writes (best-effort, runs in background)."""
+        # Filter to agent write/copy events only
+        agent_events = [e for e in events if e.get("agent_id") and e.get("op") in ("write", "copy")]
+        if not agent_events:
+            return
+
+        # Run in background thread to avoid blocking the post-flush pipeline
+        thread = threading.Thread(
+            target=_record_lineage_batch,
+            args=(agent_events, session_factory),
+            daemon=True,
+        )
+        thread.start()
+
+    return lineage_hook
+
+
+def _record_lineage_batch(
+    events: list[dict[str, Any]],
+    session_factory: Callable[..., Any],
+) -> None:
+    """Record lineage for a batch of agent events (runs in background thread)."""
+    try:
+        from nexus.contracts.aspects import LineageAspect
+        from nexus.contracts.urn import NexusURN
+        from nexus.storage.lineage_service import LineageService
+        from nexus.storage.session_read_accumulator import get_accumulator
+
+        accumulator = get_accumulator()
+
+        with session_factory() as session:
+            lineage_service = LineageService(session)
+            recorded = 0
+
+            for event in events:
+                try:
+                    agent_id = event.get("agent_id", "")
+                    if not agent_id:
+                        continue
+
+                    path = event.get("path", "")
+                    zone_id = event.get("zone_id")
+                    metadata = event.get("metadata", {})
+                    op = event.get("op", "write")
+
+                    urn = str(NexusURN.for_file(zone_id or "default", path))
+
+                    if op == "copy":
+                        # Copy lineage: source file is the single upstream
+                        src_path = event.get("src_path", "")
+                        if not src_path:
+                            continue
+                        src_metadata = event.get("src_metadata", {})
+                        lineage = LineageAspect.from_explicit_declaration(
+                            upstream=[
+                                {
+                                    "path": src_path,
+                                    "version": src_metadata.get("version", 0),
+                                    "etag": src_metadata.get("etag", ""),
+                                }
+                            ],
+                            agent_id=agent_id,
+                            agent_generation=event.get("agent_generation"),
+                        )
+                        lineage.operation = "copy"
+                    else:
+                        # Write lineage: consume accumulated reads
+                        agent_generation = event.get("agent_generation")
+                        reads = accumulator.consume(agent_id, agent_generation)
+
+                        if not reads:
+                            # No accumulated reads — nothing to record
+                            continue
+
+                        duration_ms = metadata.get("duration_ms")
+                        lineage = LineageAspect.from_session_reads(
+                            reads=reads,
+                            agent_id=agent_id,
+                            agent_generation=agent_generation,
+                            operation=op,
+                            duration_ms=duration_ms,
+                        )
+
+                    # Savepoint: one file's failure doesn't affect others
+                    with session.begin_nested():
+                        lineage_service.record_lineage(
+                            entity_urn=urn,
+                            lineage=lineage,
+                            zone_id=zone_id,
+                            downstream_path=path,
+                        )
+                        recorded += 1
+
+                except Exception:
+                    logger.debug(
+                        "Lineage recording failed for %s (non-critical)",
+                        event.get("path"),
+                        exc_info=True,
+                    )
+
+            if recorded > 0:
+                session.commit()
+                logger.debug(
+                    "Post-flush lineage: %d/%d agent events recorded",
+                    recorded,
+                    len(events),
+                )
+
+    except Exception:
+        logger.debug(
+            "Post-flush lineage batch failed (non-critical)",
+            exc_info=True,
+        )

--- a/src/nexus/factory/_lineage_hook.py
+++ b/src/nexus/factory/_lineage_hook.py
@@ -103,9 +103,12 @@ def _record_lineage_batch(
                         )
                         lineage.operation = "copy"
                     else:
-                        # Write lineage: consume accumulated reads
+                        # Write lineage: consume accumulated reads from active scope.
+                        # If the agent used begin_scope(), only that scope's reads
+                        # are consumed. Otherwise the default scope is used.
                         agent_generation = event.get("agent_generation")
-                        reads = accumulator.consume(agent_id, agent_generation)
+                        scope_id = event.get("lineage_scope")  # explicit scope from event
+                        reads = accumulator.consume(agent_id, agent_generation, scope_id=scope_id)
 
                         if not reads:
                             # No accumulated reads — nothing to record

--- a/src/nexus/factory/_system.py
+++ b/src/nexus/factory/_system.py
@@ -189,6 +189,21 @@ def _boot_pre_kernel_services(
         except Exception as exc:
             logger.warning("[BOOT:SYSTEM] Extraction hook unavailable: %s", exc)
 
+    # --- Agent lineage hook (Issue #3417) ---
+    # Records which files an agent read to produce each output file.
+    # Degradable: lineage is best-effort; failures do not block writes.
+    if hasattr(write_observer, "register_post_flush_hook"):
+        try:
+            from nexus.factory._lineage_hook import make_lineage_hook
+
+            lineage_hook = make_lineage_hook(
+                session_factory=ctx.record_store.session_factory,
+            )
+            write_observer.register_post_flush_hook(lineage_hook)
+            logger.debug("[BOOT:SYSTEM] Agent lineage hook registered")
+        except Exception as exc:
+            logger.warning("[BOOT:SYSTEM] Lineage hook unavailable: %s", exc)
+
     # =====================================================================
     # DEGRADABLE FORMER-KERNEL SECTION (WARNING + None) — Issue #2193
     # =====================================================================

--- a/src/nexus/server/api/v2/models/lineage.py
+++ b/src/nexus/server/api/v2/models/lineage.py
@@ -74,3 +74,20 @@ class PutLineageRequest(ApiModel):
     upstream: list[UpstreamEntry]
     agent_id: str
     agent_generation: int | None = None
+
+
+class ScopeRequest(ApiModel):
+    """Request body for POST /api/v2/lineage/scope/begin and end."""
+
+    agent_id: str
+    agent_generation: int | None = None
+    scope_id: str
+
+
+class ScopeResponse(ApiModel):
+    """Response for scope operations."""
+
+    agent_id: str
+    scope_id: str
+    active_scope: str
+    reads_count: int = 0

--- a/src/nexus/server/api/v2/models/lineage.py
+++ b/src/nexus/server/api/v2/models/lineage.py
@@ -1,0 +1,76 @@
+"""Lineage API request/response models (Issue #3417)."""
+
+from typing import Any
+
+from nexus.server.api.v2.models.base import ApiModel
+
+
+class UpstreamEntry(ApiModel):
+    """A single upstream dependency in lineage."""
+
+    path: str
+    version: int = 0
+    etag: str = ""
+    access_type: str = "content"
+
+
+class LineageResponse(ApiModel):
+    """Response for GET /api/v2/lineage/{urn}."""
+
+    entity_urn: str
+    upstream: list[dict[str, Any]] = []
+    agent_id: str = ""
+    agent_generation: int | None = None
+    operation: str = ""
+    duration_ms: int | None = None
+    truncated: bool = False
+
+
+class DownstreamEntry(ApiModel):
+    """A single downstream dependent in impact analysis."""
+
+    downstream_urn: str
+    downstream_path: str | None = None
+    upstream_version: int = 0
+    upstream_etag: str = ""
+    access_type: str = "content"
+    agent_id: str = ""
+    created_at: str | None = None
+
+
+class DownstreamResponse(ApiModel):
+    """Response for GET /api/v2/lineage/downstream."""
+
+    upstream_path: str
+    downstream: list[DownstreamEntry] = []
+    total: int = 0
+
+
+class StaleEntry(ApiModel):
+    """A single stale downstream in staleness detection."""
+
+    downstream_urn: str
+    downstream_path: str | None = None
+    recorded_version: int = 0
+    recorded_etag: str = ""
+    current_version: int = 0
+    current_etag: str = ""
+    agent_id: str = ""
+
+
+class StaleResponse(ApiModel):
+    """Response for GET /api/v2/lineage/stale."""
+
+    upstream_path: str
+    current_version: int = 0
+    current_etag: str = ""
+    stale: list[StaleEntry] = []
+    total: int = 0
+
+
+class PutLineageRequest(ApiModel):
+    """Request body for PUT /api/v2/lineage/{urn} (explicit declaration)."""
+
+    upstream: list[UpstreamEntry]
+    agent_id: str
+    agent_generation: int | None = None

--- a/src/nexus/server/api/v2/routers/lineage.py
+++ b/src/nexus/server/api/v2/routers/lineage.py
@@ -1,0 +1,200 @@
+"""Lineage REST API endpoints (Issue #3417).
+
+Provides endpoints for querying and managing agent lineage:
+- GET /api/v2/lineage/{urn}       -- Get upstream lineage for an entity
+- GET /api/v2/lineage/downstream  -- Find downstream dependents (impact analysis)
+- GET /api/v2/lineage/stale       -- Find stale downstream entities
+- PUT /api/v2/lineage/{urn}       -- Explicitly declare lineage
+- DELETE /api/v2/lineage/{urn}    -- Delete lineage for an entity
+"""
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Path, Query
+
+from nexus.server.api.v2.models.lineage import (
+    DownstreamEntry,
+    DownstreamResponse,
+    LineageResponse,
+    PutLineageRequest,
+    StaleEntry,
+    StaleResponse,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v2/lineage", tags=["lineage"])
+
+
+def _verify_urn_zone(urn: str, zone_id: str) -> None:
+    """Verify URN belongs to caller's zone (prevent cross-zone data exposure)."""
+    if zone_id == "root":
+        return
+    if f":{zone_id}:" not in urn:
+        raise HTTPException(status_code=403, detail="Access denied: URN is outside your zone")
+
+
+async def _get_lineage_service(
+    nexus_fs: Any = Depends(),
+    auth_result: dict[str, Any] = Depends(),
+) -> Any:
+    """Placeholder — actual dependency injection below."""
+
+
+# Override dependency at module level to use the real deps
+def _make_lineage_dependency() -> Any:
+    """Create the lineage service dependency."""
+    from nexus.server.api.v2.dependencies import get_nexus_fs, require_auth
+    from nexus.server.dependencies import get_operation_context
+
+    async def get_lineage_service(
+        nexus_fs: Any = Depends(get_nexus_fs),
+        auth_result: dict[str, Any] = Depends(require_auth),
+    ) -> Any:
+        from nexus.contracts.constants import ROOT_ZONE_ID
+        from nexus.storage.lineage_service import LineageService
+
+        context = get_operation_context(auth_result)
+        _record_store = getattr(nexus_fs, "_record_store", None)
+        session_factory = (
+            _record_store.session_factory if _record_store is not None else nexus_fs.SessionLocal
+        )
+        session = session_factory()
+        zone_id = context.zone_id or ROOT_ZONE_ID
+
+        try:
+            yield LineageService(session=session), zone_id
+            session.commit()
+        except Exception:
+            session.rollback()
+            raise
+        finally:
+            session.close()
+
+    return get_lineage_service
+
+
+get_lineage_service = _make_lineage_dependency()
+
+
+@router.get("/{urn}")
+async def get_lineage(
+    urn: str = Path(..., description="Entity URN"),
+    lineage_and_zone: tuple[Any, str] = Depends(get_lineage_service),
+) -> LineageResponse:
+    """Get upstream lineage for an entity."""
+    lineage_svc, zone_id = lineage_and_zone
+    _verify_urn_zone(urn, zone_id)
+    try:
+        payload = lineage_svc.get_lineage(urn)
+        if payload is None:
+            raise HTTPException(status_code=404, detail=f"No lineage found for {urn}")
+        return LineageResponse(entity_urn=urn, **payload)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("get_lineage error: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to get lineage") from e
+
+
+@router.get("/downstream/query")
+async def get_downstream(
+    path: str = Query(..., description="Upstream file path"),
+    lineage_and_zone: tuple[Any, str] = Depends(get_lineage_service),
+    limit: int = Query(100, ge=1, le=1000, description="Max results"),
+) -> DownstreamResponse:
+    """Find downstream entities that depend on an upstream path (impact analysis)."""
+    lineage_svc, zone_id = lineage_and_zone
+    try:
+        results = lineage_svc.find_downstream(path, zone_id=zone_id, limit=limit)
+        entries = [DownstreamEntry(**r) for r in results]
+        return DownstreamResponse(
+            upstream_path=path,
+            downstream=entries,
+            total=len(entries),
+        )
+    except Exception as e:
+        logger.error("get_downstream error: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to query downstream") from e
+
+
+@router.get("/stale/query")
+async def get_stale(
+    path: str = Query(..., description="Upstream file path that changed"),
+    current_version: int = Query(..., description="Current version of the upstream file"),
+    current_etag: str = Query(..., description="Current content hash of the upstream file"),
+    lineage_and_zone: tuple[Any, str] = Depends(get_lineage_service),
+    limit: int = Query(100, ge=1, le=1000, description="Max results"),
+) -> StaleResponse:
+    """Find downstream entities that are stale because upstream changed."""
+    lineage_svc, zone_id = lineage_and_zone
+    try:
+        results = lineage_svc.check_staleness(
+            path,
+            current_version=current_version,
+            current_etag=current_etag,
+            zone_id=zone_id,
+            limit=limit,
+        )
+        entries = [StaleEntry(**r) for r in results]
+        return StaleResponse(
+            upstream_path=path,
+            current_version=current_version,
+            current_etag=current_etag,
+            stale=entries,
+            total=len(entries),
+        )
+    except Exception as e:
+        logger.error("get_stale error: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to check staleness") from e
+
+
+@router.put("/{urn}")
+async def put_lineage(
+    body: PutLineageRequest,
+    urn: str = Path(..., description="Entity URN of the output file"),
+    lineage_and_zone: tuple[Any, str] = Depends(get_lineage_service),
+) -> LineageResponse:
+    """Explicitly declare lineage for an output file."""
+    lineage_svc, zone_id = lineage_and_zone
+    _verify_urn_zone(urn, zone_id)
+    try:
+        from nexus.contracts.aspects import LineageAspect
+
+        upstream_dicts = [u.model_dump() for u in body.upstream]
+        lineage = LineageAspect.from_explicit_declaration(
+            upstream=upstream_dicts,
+            agent_id=body.agent_id,
+            agent_generation=body.agent_generation,
+        )
+        lineage_svc.record_lineage(entity_urn=urn, lineage=lineage, zone_id=zone_id)
+
+        payload = lineage_svc.get_lineage(urn)
+        return LineageResponse(entity_urn=urn, **(payload or {}))
+    except ValueError as e:
+        raise HTTPException(status_code=422, detail=str(e)) from e
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("put_lineage error: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to put lineage") from e
+
+
+@router.delete("/{urn}", status_code=204)
+async def delete_lineage(
+    urn: str = Path(..., description="Entity URN"),
+    lineage_and_zone: tuple[Any, str] = Depends(get_lineage_service),
+) -> None:
+    """Delete lineage for an entity."""
+    lineage_svc, zone_id = lineage_and_zone
+    _verify_urn_zone(urn, zone_id)
+    try:
+        deleted = lineage_svc.delete_lineage(urn, zone_id=zone_id)
+        if not deleted:
+            raise HTTPException(status_code=404, detail=f"No lineage found for {urn}")
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("delete_lineage error: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to delete lineage") from e

--- a/src/nexus/server/api/v2/routers/lineage.py
+++ b/src/nexus/server/api/v2/routers/lineage.py
@@ -34,7 +34,7 @@ router = APIRouter(prefix="/api/v2/lineage", tags=["lineage"])
 
 def _verify_urn_zone(urn: str, zone_id: str) -> None:
     """Verify URN belongs to caller's zone (prevent cross-zone data exposure)."""
-    if zone_id == "root":
+    if zone_id in ("root", "default"):
         return
     if f":{zone_id}:" not in urn:
         raise HTTPException(status_code=403, detail="Access denied: URN is outside your zone")

--- a/src/nexus/server/api/v2/routers/lineage.py
+++ b/src/nexus/server/api/v2/routers/lineage.py
@@ -1,11 +1,14 @@
 """Lineage REST API endpoints (Issue #3417).
 
 Provides endpoints for querying and managing agent lineage:
-- GET /api/v2/lineage/{urn}       -- Get upstream lineage for an entity
-- GET /api/v2/lineage/downstream  -- Find downstream dependents (impact analysis)
-- GET /api/v2/lineage/stale       -- Find stale downstream entities
-- PUT /api/v2/lineage/{urn}       -- Explicitly declare lineage
-- DELETE /api/v2/lineage/{urn}    -- Delete lineage for an entity
+- GET /api/v2/lineage/{urn}             -- Get upstream lineage for an entity
+- GET /api/v2/lineage/downstream/query  -- Find downstream dependents (impact analysis)
+- GET /api/v2/lineage/stale/query       -- Find stale downstream entities
+- PUT /api/v2/lineage/{urn}             -- Explicitly declare lineage
+- DELETE /api/v2/lineage/{urn}          -- Delete lineage for an entity
+- POST /api/v2/lineage/scope/begin      -- Begin a named lineage scope
+- POST /api/v2/lineage/scope/end        -- End a scope (consume + close)
+- GET /api/v2/lineage/scope/active      -- Get the active scope for a session
 """
 
 import logging
@@ -18,6 +21,8 @@ from nexus.server.api.v2.models.lineage import (
     DownstreamResponse,
     LineageResponse,
     PutLineageRequest,
+    ScopeRequest,
+    ScopeResponse,
     StaleEntry,
     StaleResponse,
 )
@@ -198,3 +203,77 @@ async def delete_lineage(
     except Exception as e:
         logger.error("delete_lineage error: %s", e, exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to delete lineage") from e
+
+
+# ---- Scope management endpoints ----
+
+
+@router.post("/scope/begin")
+async def begin_scope(body: ScopeRequest) -> ScopeResponse:
+    """Begin a named lineage scope. Subsequent reads go into this scope.
+
+    Agents call this before starting a task to isolate that task's reads
+    from other reads in the same session. Each scope's reads are consumed
+    independently when the agent writes.
+    """
+    from nexus.storage.session_read_accumulator import get_accumulator
+
+    try:
+        acc = get_accumulator()
+        acc.begin_scope(body.agent_id, body.agent_generation, body.scope_id)
+        return ScopeResponse(
+            agent_id=body.agent_id,
+            scope_id=body.scope_id,
+            active_scope=body.scope_id,
+            reads_count=0,
+        )
+    except Exception as e:
+        logger.error("begin_scope error: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to begin scope") from e
+
+
+@router.post("/scope/end")
+async def end_scope(body: ScopeRequest) -> ScopeResponse:
+    """End a named scope and discard unconsumed reads.
+
+    The scope is removed. If it was active, reverts to default scope.
+    Returns the number of reads that were in the scope.
+    """
+    from nexus.storage.session_read_accumulator import get_accumulator
+
+    try:
+        acc = get_accumulator()
+        reads = acc.end_scope(body.agent_id, body.agent_generation, body.scope_id)
+        active = acc.get_active_scope(body.agent_id, body.agent_generation)
+        return ScopeResponse(
+            agent_id=body.agent_id,
+            scope_id=body.scope_id,
+            active_scope=active,
+            reads_count=len(reads),
+        )
+    except Exception as e:
+        logger.error("end_scope error: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to end scope") from e
+
+
+@router.get("/scope/active")
+async def get_active_scope(
+    agent_id: str = Query(..., description="Agent ID"),
+    agent_generation: int | None = Query(None, description="Agent generation"),
+) -> ScopeResponse:
+    """Get the currently active lineage scope for an agent session."""
+    from nexus.storage.session_read_accumulator import get_accumulator
+
+    try:
+        acc = get_accumulator()
+        active = acc.get_active_scope(agent_id, agent_generation)
+        count = acc.peek(agent_id, agent_generation, scope_id=active)
+        return ScopeResponse(
+            agent_id=agent_id,
+            scope_id=active,
+            active_scope=active,
+            reads_count=count,
+        )
+    except Exception as e:
+        logger.error("get_active_scope error: %s", e, exc_info=True)
+        raise HTTPException(status_code=500, detail="Failed to get active scope") from e

--- a/src/nexus/server/api/v2/versioning.py
+++ b/src/nexus/server/api/v2/versioning.py
@@ -246,6 +246,14 @@ def build_v2_registry(
     except ImportError as e:
         logger.warning("Failed to import Aspects routes: %s", e)
 
+    # ---- Lineage router (Issue #3417) ----
+    try:
+        from nexus.server.api.v2.routers.lineage import router as lineage_router
+
+        registry.add(RouterEntry(router=lineage_router, name="lineage", endpoint_count=5))
+    except ImportError as e:
+        logger.warning("Failed to import Lineage routes: %s", e)
+
     # ---- Catalog router (Issue #2930) ----
     try:
         from nexus.server.api.v2.routers.catalog import router as catalog_router

--- a/src/nexus/server/api/v2/versioning.py
+++ b/src/nexus/server/api/v2/versioning.py
@@ -250,7 +250,7 @@ def build_v2_registry(
     try:
         from nexus.server.api.v2.routers.lineage import router as lineage_router
 
-        registry.add(RouterEntry(router=lineage_router, name="lineage", endpoint_count=5))
+        registry.add(RouterEntry(router=lineage_router, name="lineage", endpoint_count=8))
     except ImportError as e:
         logger.warning("Failed to import Lineage routes: %s", e)
 

--- a/src/nexus/storage/lineage_service.py
+++ b/src/nexus/storage/lineage_service.py
@@ -1,0 +1,282 @@
+"""Lineage service — records and queries agent lineage (Issue #3417).
+
+Business logic for:
+    - Recording lineage (aspect + reverse index, atomic per file)
+    - Querying upstream lineage for a file
+    - Querying downstream dependents (impact analysis)
+    - Staleness detection (comparing stored vs current upstream versions)
+
+Architecture:
+    LineageService → AspectService (lineage aspect CRUD)
+    LineageService → LineageReverseIndexModel (reverse lookup index)
+    LineageService → OperationLogger (MCL via AspectService)
+"""
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import delete, select
+from sqlalchemy.orm import Session
+
+from nexus.contracts.aspects import LineageAspect
+from nexus.storage.aspect_service import AspectService
+from nexus.storage.models.lineage_reverse_index import LineageReverseIndexModel
+
+logger = logging.getLogger(__name__)
+
+LINEAGE_ASPECT_NAME = "lineage"
+
+
+class LineageService:
+    """Records and queries agent lineage relationships.
+
+    All operations use a single SQLAlchemy session. The caller is
+    responsible for commit/rollback/close.
+    """
+
+    def __init__(self, session: Session) -> None:
+        self._session = session
+        self._aspect_service = AspectService(session)
+
+    def record_lineage(
+        self,
+        entity_urn: str,
+        lineage: LineageAspect,
+        *,
+        zone_id: str | None = None,
+        downstream_path: str | None = None,
+        record_mcl: bool = True,
+    ) -> None:
+        """Record lineage for an output file (aspect + reverse index).
+
+        Uses a savepoint so that failure rolls back both the aspect and
+        reverse index atomically, without affecting the outer transaction.
+
+        Args:
+            entity_urn: URN of the output file.
+            lineage: LineageAspect with upstream entries.
+            zone_id: Zone for zone isolation.
+            downstream_path: Virtual path of the output (for display in reverse index).
+            record_mcl: If False, skip MCL recording (for replay).
+        """
+        if not lineage.upstream:
+            return  # No reads → no lineage to record
+
+        with self._session.begin_nested():
+            # 1. Write lineage aspect (source of truth)
+            payload = lineage.to_dict()
+            self._aspect_service.put_aspect(
+                entity_urn=entity_urn,
+                aspect_name=LINEAGE_ASPECT_NAME,
+                payload=payload,
+                created_by=lineage.agent_id or "system",
+                zone_id=zone_id,
+                record_mcl=record_mcl,
+            )
+
+            # 2. Upsert reverse index: delete old entries, insert new
+            self._session.execute(
+                delete(LineageReverseIndexModel).where(
+                    LineageReverseIndexModel.downstream_urn == entity_urn,
+                )
+            )
+
+            # 3. Batch insert new reverse index entries
+            now = datetime.now(UTC)
+            entries = [
+                LineageReverseIndexModel(
+                    upstream_path=upstream["path"],
+                    downstream_urn=entity_urn,
+                    zone_id=zone_id or "root",
+                    upstream_version=upstream.get("version", 0),
+                    upstream_etag=upstream.get("etag", ""),
+                    access_type=upstream.get("access_type", "content"),
+                    agent_id=lineage.agent_id or "",
+                    downstream_path=downstream_path,
+                    created_at=now,
+                )
+                for upstream in lineage.upstream
+            ]
+            self._session.add_all(entries)
+
+    def get_lineage(
+        self,
+        entity_urn: str,
+    ) -> dict[str, Any] | None:
+        """Get the current lineage aspect for an entity.
+
+        Args:
+            entity_urn: URN of the file to query.
+
+        Returns:
+            Lineage payload dict, or None if no lineage recorded.
+        """
+        return self._aspect_service.get_aspect(entity_urn, LINEAGE_ASPECT_NAME)
+
+    def find_downstream(
+        self,
+        upstream_path: str,
+        *,
+        zone_id: str | None = None,
+        limit: int = 1000,
+    ) -> list[dict[str, Any]]:
+        """Find all downstream entities that depend on an upstream path.
+
+        Uses the reverse index for O(1) lookup.
+
+        Args:
+            upstream_path: Path of the upstream file.
+            zone_id: Optional zone filter.
+            limit: Max results.
+
+        Returns:
+            List of dicts with downstream_urn, downstream_path, upstream_version,
+            upstream_etag, agent_id.
+        """
+        stmt = select(LineageReverseIndexModel).where(
+            LineageReverseIndexModel.upstream_path == upstream_path,
+        )
+        if zone_id:
+            stmt = stmt.where(LineageReverseIndexModel.zone_id == zone_id)
+        stmt = stmt.limit(limit)
+
+        rows = self._session.execute(stmt).scalars().all()
+        return [
+            {
+                "downstream_urn": row.downstream_urn,
+                "downstream_path": row.downstream_path,
+                "upstream_version": row.upstream_version,
+                "upstream_etag": row.upstream_etag,
+                "access_type": row.access_type,
+                "agent_id": row.agent_id,
+                "created_at": row.created_at.isoformat() if row.created_at else None,
+            }
+            for row in rows
+        ]
+
+    def check_staleness(
+        self,
+        upstream_path: str,
+        current_version: int,
+        current_etag: str,
+        *,
+        zone_id: str | None = None,
+        limit: int = 1000,
+    ) -> list[dict[str, Any]]:
+        """Find downstream entities that are stale because upstream changed.
+
+        A downstream is stale if its recorded upstream_version != current_version
+        OR its recorded upstream_etag != current_etag.
+
+        Uses denormalized version/etag in the reverse index for a single query.
+
+        Args:
+            upstream_path: Path of the changed upstream file.
+            current_version: Current version of the upstream file.
+            current_etag: Current content hash of the upstream file.
+            zone_id: Optional zone filter.
+            limit: Max results.
+
+        Returns:
+            List of stale downstream dicts with recorded vs current version info.
+        """
+        stmt = select(LineageReverseIndexModel).where(
+            LineageReverseIndexModel.upstream_path == upstream_path,
+        )
+        if zone_id:
+            stmt = stmt.where(LineageReverseIndexModel.zone_id == zone_id)
+        stmt = stmt.limit(limit)
+
+        rows = self._session.execute(stmt).scalars().all()
+
+        stale = []
+        for row in rows:
+            # Not stale if both version AND etag match
+            if row.upstream_version == current_version and row.upstream_etag == current_etag:
+                continue
+
+            # Stale: version or etag differs
+            stale.append(
+                {
+                    "downstream_urn": row.downstream_urn,
+                    "downstream_path": row.downstream_path,
+                    "recorded_version": row.upstream_version,
+                    "recorded_etag": row.upstream_etag,
+                    "current_version": current_version,
+                    "current_etag": current_etag,
+                    "agent_id": row.agent_id,
+                }
+            )
+        return stale
+
+    def delete_lineage(
+        self,
+        entity_urn: str,
+        *,
+        zone_id: str | None = None,
+    ) -> bool:
+        """Delete lineage for an entity (aspect + reverse index).
+
+        Args:
+            entity_urn: URN of the entity.
+            zone_id: Zone for MCL recording.
+
+        Returns:
+            True if lineage existed and was deleted.
+        """
+        with self._session.begin_nested():
+            deleted = self._aspect_service.delete_aspect(
+                entity_urn, LINEAGE_ASPECT_NAME, zone_id=zone_id
+            )
+            self._session.execute(
+                delete(LineageReverseIndexModel).where(
+                    LineageReverseIndexModel.downstream_urn == entity_urn,
+                )
+            )
+        return deleted
+
+    def compact_orphaned_entries(
+        self,
+        valid_downstream_urns: set[str] | None = None,
+        *,
+        max_age_days: int = 90,
+    ) -> int:
+        """Remove reverse index entries for entities that no longer exist.
+
+        Args:
+            valid_downstream_urns: Set of URNs that still exist. If None,
+                falls back to age-based cleanup.
+            max_age_days: Remove entries older than this (if no URN set provided).
+
+        Returns:
+            Number of entries removed.
+        """
+        if valid_downstream_urns is not None:
+            # Delete entries whose downstream_urn is not in the valid set
+            all_entries = self._session.execute(
+                select(LineageReverseIndexModel.entry_id, LineageReverseIndexModel.downstream_urn)
+            ).all()
+            orphaned_ids = [row[0] for row in all_entries if row[1] not in valid_downstream_urns]
+            if orphaned_ids:
+                self._session.execute(
+                    delete(LineageReverseIndexModel).where(
+                        LineageReverseIndexModel.entry_id.in_(orphaned_ids)
+                    )
+                )
+            return len(orphaned_ids)
+
+        # Age-based cleanup
+        cutoff = datetime.now(UTC).replace(
+            day=max(1, datetime.now(UTC).day),
+        )
+        # Simple age-based: delete entries older than max_age_days
+        from datetime import timedelta
+
+        cutoff = datetime.now(UTC) - timedelta(days=max_age_days)
+        result = self._session.execute(
+            delete(LineageReverseIndexModel).where(
+                LineageReverseIndexModel.created_at < cutoff,
+            )
+        )
+        return getattr(result, "rowcount", 0) or 0

--- a/src/nexus/storage/models/__init__.py
+++ b/src/nexus/storage/models/__init__.py
@@ -77,6 +77,11 @@ from nexus.storage.models.infrastructure import SandboxMetadataModel as SandboxM
 from nexus.storage.models.infrastructure import SubscriptionModel as SubscriptionModel
 from nexus.storage.models.infrastructure import SystemSettingsModel as SystemSettingsModel
 
+# Domain: Lineage Tracking (Issue #3417)
+from nexus.storage.models.lineage_reverse_index import (
+    LineageReverseIndexModel as LineageReverseIndexModel,
+)
+
 # Domain: Memory and Knowledge Graph
 from nexus.storage.models.memory import EntityMentionModel as EntityMentionModel
 from nexus.storage.models.memory import EntityModel as EntityModel

--- a/src/nexus/storage/models/lineage_reverse_index.py
+++ b/src/nexus/storage/models/lineage_reverse_index.py
@@ -1,0 +1,95 @@
+"""LineageReverseIndexModel — reverse lookup table for lineage queries (Issue #3417).
+
+Stores denormalized upstream→downstream mappings so that impact analysis
+("if X changes, what outputs are stale?") can be answered with a single
+indexed query instead of scanning all lineage aspects.
+
+Design decisions:
+    - Denormalized from lineage aspects (aspect is source of truth)
+    - Stores upstream_version + upstream_etag for single-query staleness detection
+    - Upsert semantics: DELETE old entries on re-write, INSERT new ones
+    - Composite indexes for both forward and reverse lookups
+    - Rebuildable from aspects if the table is ever corrupted
+"""
+
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime, Index, Integer, String, Text, text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from nexus.storage.models._base import Base, _generate_uuid, _get_uuid_server_default
+
+
+class LineageReverseIndexModel(Base):
+    """Reverse lookup index: upstream_path → downstream entities.
+
+    One row per (upstream_path, downstream_urn) pair. On lineage update,
+    all rows for the downstream_urn are deleted and re-inserted.
+    """
+
+    __tablename__ = "lineage_reverse_index"
+
+    entry_id: Mapped[str] = mapped_column(
+        String(36),
+        primary_key=True,
+        default=_generate_uuid,
+        server_default=_get_uuid_server_default(),
+    )
+
+    # The upstream file that was read
+    upstream_path: Mapped[str] = mapped_column(String(512), nullable=False)
+
+    # The downstream entity (output file) that consumed this upstream
+    downstream_urn: Mapped[str] = mapped_column(String(512), nullable=False)
+
+    # Zone isolation
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default="root")
+
+    # Denormalized upstream version info for single-query staleness detection
+    upstream_version: Mapped[int] = mapped_column(Integer, nullable=False, default=0)
+    upstream_etag: Mapped[str] = mapped_column(String(64), nullable=False, default="")
+
+    # Access type (content, metadata, list, exists)
+    access_type: Mapped[str] = mapped_column(String(20), nullable=False, default="content")
+
+    # Agent that created this lineage edge
+    agent_id: Mapped[str] = mapped_column(String(255), nullable=False, default="")
+
+    # The downstream file path (denormalized for display/CLI)
+    downstream_path: Mapped[str] = mapped_column(Text, nullable=True)
+
+    # Audit
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime, nullable=False, default=lambda: datetime.now(UTC)
+    )
+
+    __table_args__ = (
+        # Reverse lookup: "what depends on upstream_path?" (impact analysis)
+        Index(
+            "idx_lineage_reverse_upstream",
+            "upstream_path",
+            "zone_id",
+            postgresql_where=text("1=1"),  # no-op filter, ensures consistent plan
+        ),
+        # Forward cleanup: "delete all reverse entries for this downstream"
+        Index(
+            "idx_lineage_reverse_downstream",
+            "downstream_urn",
+        ),
+        # Staleness query: single indexed scan
+        Index(
+            "idx_lineage_reverse_staleness",
+            "upstream_path",
+            "zone_id",
+            "upstream_version",
+            "upstream_etag",
+        ),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<LineageReverseIndex("
+            f"upstream={self.upstream_path}, "
+            f"downstream={self.downstream_urn}, "
+            f"v={self.upstream_version})>"
+        )

--- a/src/nexus/storage/record_store_write_observer.py
+++ b/src/nexus/storage/record_store_write_observer.py
@@ -149,7 +149,7 @@ class RecordStoreWriteObserver:
                 VersionRecorder(session).record_write(metadata, is_new=is_new)
                 session.commit()
 
-            # Post-flush hooks: extraction, etc. (Issue #2978)
+            # Post-flush hooks: extraction, lineage, etc. (Issue #2978, #3417)
             self._run_post_flush_hooks(
                 [
                     {
@@ -158,6 +158,7 @@ class RecordStoreWriteObserver:
                         "is_new": is_new,
                         "zone_id": zone_id,
                         "agent_id": agent_id,
+                        "agent_generation": getattr(metadata, "agent_generation", None),
                         "metadata": metadata.to_dict(),
                     }
                 ]
@@ -204,7 +205,7 @@ class RecordStoreWriteObserver:
 
                 session.commit()
 
-            # Post-flush hooks: extraction, etc. (Issue #2978)
+            # Post-flush hooks: extraction, lineage, etc. (Issue #2978, #3417)
             self._run_post_flush_hooks(
                 [
                     {
@@ -213,6 +214,7 @@ class RecordStoreWriteObserver:
                         "is_new": new,
                         "zone_id": zone_id,
                         "agent_id": agent_id,
+                        "agent_generation": getattr(md, "agent_generation", None),
                         "metadata": md.to_dict(),
                     }
                     for md, new in items

--- a/src/nexus/storage/session_read_accumulator.py
+++ b/src/nexus/storage/session_read_accumulator.py
@@ -4,10 +4,22 @@ Aggregates reads across multiple API requests for a single agent session,
 keyed by (agent_id, agent_generation). When an agent writes, the accumulated
 reads become the upstream lineage for that output.
 
+Scoped tracking:
+    Agents can open named scopes to isolate reads for different tasks.
+    Only reads within a scope are attributed to the write that consumes it.
+    Without explicit scopes, a default scope collects all reads (backward compat).
+
+    Flow:
+        acc.begin_scope("agent-1", 1, "task-A")
+        # ... agent reads files ...
+        reads = acc.consume("agent-1", 1, scope_id="task-A")  # only task-A reads
+
 Design decisions:
     - In-memory storage keyed by (agent_id, agent_generation)
+    - Scopes within each session: dict[scope_id → entries]
+    - Active scope tracked per session (reads go into active scope)
     - TTL-based cleanup for abandoned sessions (default 30 minutes)
-    - Max entries per session (default 10K) to prevent unbounded growth
+    - Max entries per session across all scopes (default 10K)
     - Thread-safe via per-session threading.Lock
     - Lazy cleanup on access + periodic sweep
 """
@@ -24,6 +36,7 @@ logger = logging.getLogger(__name__)
 DEFAULT_TTL_SECONDS: float = 1800.0  # 30 minutes
 DEFAULT_MAX_ENTRIES: int = 10_000
 DEFAULT_SWEEP_INTERVAL: float = 300.0  # 5 minutes
+DEFAULT_SCOPE: str = "_default"
 
 
 @dataclass
@@ -39,12 +52,17 @@ class _ReadEntry:
 
 @dataclass
 class _SessionState:
-    """Internal state for a single agent session."""
+    """Internal state for a single agent session with scoped reads."""
 
-    entries: list[_ReadEntry] = field(default_factory=list)
+    scopes: dict[str, list[_ReadEntry]] = field(default_factory=lambda: {DEFAULT_SCOPE: []})
+    active_scope: str = DEFAULT_SCOPE
     last_access: float = field(default_factory=time.monotonic)
     lock: threading.Lock = field(default_factory=threading.Lock)
-    saturated: bool = False  # True if max entries was hit
+    saturated: bool = False  # True if max entries was hit (across all scopes)
+
+    @property
+    def total_entries(self) -> int:
+        return sum(len(entries) for entries in self.scopes.values())
 
 
 SessionKey = tuple[str, int | None]  # (agent_id, agent_generation)
@@ -54,16 +72,25 @@ class SessionReadAccumulator:
     """In-memory accumulator that tracks reads across requests per agent session.
 
     Thread-safe. Keyed by (agent_id, agent_generation) to isolate sessions.
+    Supports named scopes within a session for per-task lineage isolation.
 
-    Usage:
+    Usage (simple — no scopes, backward compat):
         >>> acc = SessionReadAccumulator()
         >>> acc.record_read("agent-1", 1, "/data/input.csv", version=5, etag="abc")
-        >>> acc.record_read("agent-1", 1, "/data/config.yaml", version=3, etag="def")
         >>> reads = acc.consume("agent-1", 1)
         >>> len(reads)
-        2
-        >>> acc.consume("agent-1", 1)  # consumed — now empty
-        []
+        1
+
+    Usage (scoped — per-task isolation):
+        >>> acc = SessionReadAccumulator()
+        >>> acc.begin_scope("agent-1", 1, "task-A")
+        >>> acc.record_read("agent-1", 1, "/data/a.csv", version=1, etag="ea")
+        >>> acc.begin_scope("agent-1", 1, "task-B")
+        >>> acc.record_read("agent-1", 1, "/data/b.csv", version=2, etag="eb")
+        >>> reads_a = acc.consume("agent-1", 1, scope_id="task-A")
+        >>> reads_b = acc.consume("agent-1", 1, scope_id="task-B")
+        >>> len(reads_a), len(reads_b)
+        (1, 1)
     """
 
     def __init__(
@@ -79,6 +106,80 @@ class SessionReadAccumulator:
         self._global_lock = threading.Lock()
         self._last_sweep: float = time.monotonic()
 
+    def begin_scope(
+        self,
+        agent_id: str,
+        agent_generation: int | None,
+        scope_id: str,
+    ) -> None:
+        """Begin a named lineage scope. Reads after this go into the scope.
+
+        If the scope already exists, it becomes active again (reads append).
+        The previous scope's reads are preserved (not cleared).
+
+        Args:
+            agent_id: Agent starting the scope.
+            agent_generation: Session generation counter.
+            scope_id: Unique scope identifier (e.g., "task-A", "run-123").
+        """
+        key: SessionKey = (agent_id, agent_generation)
+        session = self._get_or_create_session(key)
+
+        with session.lock:
+            session.last_access = time.monotonic()
+            if scope_id not in session.scopes:
+                session.scopes[scope_id] = []
+            session.active_scope = scope_id
+
+    def end_scope(
+        self,
+        agent_id: str,
+        agent_generation: int | None,
+        scope_id: str,
+    ) -> list[dict[str, Any]]:
+        """End a named scope and return its reads (consume + close).
+
+        The scope is removed after consumption. If this was the active scope,
+        active reverts to the default scope.
+
+        Args:
+            agent_id: Agent ending the scope.
+            agent_generation: Session generation counter.
+            scope_id: Scope to end.
+
+        Returns:
+            List of read dicts from the scope. Empty if scope didn't exist.
+        """
+        reads = self.consume(agent_id, agent_generation, scope_id=scope_id)
+
+        key: SessionKey = (agent_id, agent_generation)
+        with self._global_lock:
+            session = self._sessions.get(key)
+        if session is not None:
+            with session.lock:
+                session.scopes.pop(scope_id, None)
+                if session.active_scope == scope_id:
+                    session.active_scope = DEFAULT_SCOPE
+
+        return reads
+
+    def get_active_scope(
+        self,
+        agent_id: str,
+        agent_generation: int | None,
+    ) -> str:
+        """Return the currently active scope for a session.
+
+        Returns DEFAULT_SCOPE if no scope has been begun.
+        """
+        key: SessionKey = (agent_id, agent_generation)
+        with self._global_lock:
+            session = self._sessions.get(key)
+        if session is None:
+            return DEFAULT_SCOPE
+        with session.lock:
+            return session.active_scope
+
     def record_read(
         self,
         agent_id: str,
@@ -88,8 +189,9 @@ class SessionReadAccumulator:
         version: int = 0,
         etag: str = "",
         access_type: str = "content",
+        scope_id: str | None = None,
     ) -> bool:
-        """Record a read for an agent session.
+        """Record a read for an agent session into the active scope.
 
         Args:
             agent_id: Agent performing the read.
@@ -98,6 +200,7 @@ class SessionReadAccumulator:
             version: Version of the resource at read time.
             etag: Content hash at read time.
             access_type: Type of access (content, metadata, list, exists).
+            scope_id: Explicit scope to record into (overrides active scope).
 
         Returns:
             True if recorded, False if session is at max capacity.
@@ -108,7 +211,7 @@ class SessionReadAccumulator:
         with session.lock:
             session.last_access = time.monotonic()
 
-            if len(session.entries) >= self._max_entries:
+            if session.total_entries >= self._max_entries:
                 if not session.saturated:
                     session.saturated = True
                     logger.warning(
@@ -119,7 +222,11 @@ class SessionReadAccumulator:
                     )
                 return False
 
-            session.entries.append(
+            target_scope = scope_id or session.active_scope
+            if target_scope not in session.scopes:
+                session.scopes[target_scope] = []
+
+            session.scopes[target_scope].append(
                 _ReadEntry(
                     path=path,
                     version=version,
@@ -134,19 +241,20 @@ class SessionReadAccumulator:
         self,
         agent_id: str,
         agent_generation: int | None,
+        scope_id: str | None = None,
     ) -> list[dict[str, Any]]:
-        """Consume and clear all accumulated reads for a session.
+        """Consume and clear reads from a specific scope (or active scope).
 
-        Called by the lineage hook when an agent writes. Returns the reads
-        as dicts suitable for LineageAspect.from_session_reads().
+        Only the targeted scope is cleared. Other scopes are untouched.
 
         Args:
             agent_id: Agent whose reads to consume.
             agent_generation: Session generation counter.
+            scope_id: Scope to consume. If None, consumes the active scope.
 
         Returns:
             List of read dicts with path, version, etag, access_type.
-            Empty list if no reads accumulated.
+            Empty list if scope has no reads or doesn't exist.
         """
         key: SessionKey = (agent_id, agent_generation)
 
@@ -156,7 +264,9 @@ class SessionReadAccumulator:
                 return []
 
         with session.lock:
-            if not session.entries:
+            target = scope_id or session.active_scope
+            entries = session.scopes.get(target)
+            if not entries:
                 return []
 
             reads = [
@@ -166,10 +276,12 @@ class SessionReadAccumulator:
                     "etag": e.etag,
                     "access_type": e.access_type,
                 }
-                for e in session.entries
+                for e in entries
             ]
-            session.entries.clear()
-            session.saturated = False
+            entries.clear()
+            # Reset saturated flag if we freed capacity
+            if session.saturated and session.total_entries < self._max_entries:
+                session.saturated = False
             session.last_access = time.monotonic()
             return reads
 
@@ -177,22 +289,25 @@ class SessionReadAccumulator:
         self,
         agent_id: str,
         agent_generation: int | None,
+        scope_id: str | None = None,
     ) -> int:
-        """Return the number of accumulated reads without consuming them."""
+        """Return the number of accumulated reads in a scope (or active scope)."""
         key: SessionKey = (agent_id, agent_generation)
         with self._global_lock:
             session = self._sessions.get(key)
         if session is None:
             return 0
         with session.lock:
-            return len(session.entries)
+            target = scope_id or session.active_scope
+            entries = session.scopes.get(target)
+            return len(entries) if entries else 0
 
     def clear_session(
         self,
         agent_id: str,
         agent_generation: int | None,
     ) -> None:
-        """Explicitly clear a session's accumulated reads."""
+        """Explicitly clear a session's accumulated reads (all scopes)."""
         key: SessionKey = (agent_id, agent_generation)
         with self._global_lock:
             self._sessions.pop(key, None)
@@ -233,13 +348,16 @@ class SessionReadAccumulator:
         """Return accumulator statistics."""
         with self._global_lock:
             total_entries = 0
+            total_scopes = 0
             for session in self._sessions.values():
                 with session.lock:
-                    total_entries += len(session.entries)
+                    total_entries += session.total_entries
+                    total_scopes += len(session.scopes)
 
             return {
                 "active_sessions": len(self._sessions),
                 "total_entries": total_entries,
+                "total_scopes": total_scopes,
                 "ttl_seconds": self._ttl,
                 "max_entries_per_session": self._max_entries,
             }

--- a/src/nexus/storage/session_read_accumulator.py
+++ b/src/nexus/storage/session_read_accumulator.py
@@ -1,0 +1,277 @@
+"""Session-scoped read accumulator for agent lineage tracking (Issue #3417).
+
+Aggregates reads across multiple API requests for a single agent session,
+keyed by (agent_id, agent_generation). When an agent writes, the accumulated
+reads become the upstream lineage for that output.
+
+Design decisions:
+    - In-memory storage keyed by (agent_id, agent_generation)
+    - TTL-based cleanup for abandoned sessions (default 30 minutes)
+    - Max entries per session (default 10K) to prevent unbounded growth
+    - Thread-safe via per-session threading.Lock
+    - Lazy cleanup on access + periodic sweep
+"""
+
+import logging
+import threading
+import time
+from dataclasses import dataclass, field
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# Defaults
+DEFAULT_TTL_SECONDS: float = 1800.0  # 30 minutes
+DEFAULT_MAX_ENTRIES: int = 10_000
+DEFAULT_SWEEP_INTERVAL: float = 300.0  # 5 minutes
+
+
+@dataclass
+class _ReadEntry:
+    """A single read recorded in a session."""
+
+    path: str
+    version: int
+    etag: str
+    access_type: str
+    timestamp: float
+
+
+@dataclass
+class _SessionState:
+    """Internal state for a single agent session."""
+
+    entries: list[_ReadEntry] = field(default_factory=list)
+    last_access: float = field(default_factory=time.monotonic)
+    lock: threading.Lock = field(default_factory=threading.Lock)
+    saturated: bool = False  # True if max entries was hit
+
+
+SessionKey = tuple[str, int | None]  # (agent_id, agent_generation)
+
+
+class SessionReadAccumulator:
+    """In-memory accumulator that tracks reads across requests per agent session.
+
+    Thread-safe. Keyed by (agent_id, agent_generation) to isolate sessions.
+
+    Usage:
+        >>> acc = SessionReadAccumulator()
+        >>> acc.record_read("agent-1", 1, "/data/input.csv", version=5, etag="abc")
+        >>> acc.record_read("agent-1", 1, "/data/config.yaml", version=3, etag="def")
+        >>> reads = acc.consume("agent-1", 1)
+        >>> len(reads)
+        2
+        >>> acc.consume("agent-1", 1)  # consumed — now empty
+        []
+    """
+
+    def __init__(
+        self,
+        ttl_seconds: float = DEFAULT_TTL_SECONDS,
+        max_entries: int = DEFAULT_MAX_ENTRIES,
+        sweep_interval: float = DEFAULT_SWEEP_INTERVAL,
+    ) -> None:
+        self._ttl = ttl_seconds
+        self._max_entries = max_entries
+        self._sweep_interval = sweep_interval
+        self._sessions: dict[SessionKey, _SessionState] = {}
+        self._global_lock = threading.Lock()
+        self._last_sweep: float = time.monotonic()
+
+    def record_read(
+        self,
+        agent_id: str,
+        agent_generation: int | None,
+        path: str,
+        *,
+        version: int = 0,
+        etag: str = "",
+        access_type: str = "content",
+    ) -> bool:
+        """Record a read for an agent session.
+
+        Args:
+            agent_id: Agent performing the read.
+            agent_generation: Session generation counter.
+            path: Path of the resource read.
+            version: Version of the resource at read time.
+            etag: Content hash at read time.
+            access_type: Type of access (content, metadata, list, exists).
+
+        Returns:
+            True if recorded, False if session is at max capacity.
+        """
+        key: SessionKey = (agent_id, agent_generation)
+        session = self._get_or_create_session(key)
+
+        with session.lock:
+            session.last_access = time.monotonic()
+
+            if len(session.entries) >= self._max_entries:
+                if not session.saturated:
+                    session.saturated = True
+                    logger.warning(
+                        "Session read accumulator at capacity (%d) for agent %s gen %s",
+                        self._max_entries,
+                        agent_id,
+                        agent_generation,
+                    )
+                return False
+
+            session.entries.append(
+                _ReadEntry(
+                    path=path,
+                    version=version,
+                    etag=etag,
+                    access_type=access_type,
+                    timestamp=time.time(),
+                )
+            )
+            return True
+
+    def consume(
+        self,
+        agent_id: str,
+        agent_generation: int | None,
+    ) -> list[dict[str, Any]]:
+        """Consume and clear all accumulated reads for a session.
+
+        Called by the lineage hook when an agent writes. Returns the reads
+        as dicts suitable for LineageAspect.from_session_reads().
+
+        Args:
+            agent_id: Agent whose reads to consume.
+            agent_generation: Session generation counter.
+
+        Returns:
+            List of read dicts with path, version, etag, access_type.
+            Empty list if no reads accumulated.
+        """
+        key: SessionKey = (agent_id, agent_generation)
+
+        with self._global_lock:
+            session = self._sessions.get(key)
+            if session is None:
+                return []
+
+        with session.lock:
+            if not session.entries:
+                return []
+
+            reads = [
+                {
+                    "path": e.path,
+                    "version": e.version,
+                    "etag": e.etag,
+                    "access_type": e.access_type,
+                }
+                for e in session.entries
+            ]
+            session.entries.clear()
+            session.saturated = False
+            session.last_access = time.monotonic()
+            return reads
+
+    def peek(
+        self,
+        agent_id: str,
+        agent_generation: int | None,
+    ) -> int:
+        """Return the number of accumulated reads without consuming them."""
+        key: SessionKey = (agent_id, agent_generation)
+        with self._global_lock:
+            session = self._sessions.get(key)
+        if session is None:
+            return 0
+        with session.lock:
+            return len(session.entries)
+
+    def clear_session(
+        self,
+        agent_id: str,
+        agent_generation: int | None,
+    ) -> None:
+        """Explicitly clear a session's accumulated reads."""
+        key: SessionKey = (agent_id, agent_generation)
+        with self._global_lock:
+            self._sessions.pop(key, None)
+
+    def cleanup_expired(self) -> int:
+        """Remove sessions that have exceeded their TTL.
+
+        Returns:
+            Number of sessions removed.
+        """
+        now = time.monotonic()
+        expired_keys: list[SessionKey] = []
+
+        with self._global_lock:
+            for key, session in self._sessions.items():
+                if now - session.last_access > self._ttl:
+                    expired_keys.append(key)
+
+            for key in expired_keys:
+                del self._sessions[key]
+
+        if expired_keys:
+            logger.info(
+                "Session read accumulator: cleaned up %d expired sessions",
+                len(expired_keys),
+            )
+        return len(expired_keys)
+
+    def maybe_sweep(self) -> int:
+        """Run cleanup if sweep interval has elapsed. Returns count removed."""
+        now = time.monotonic()
+        if now - self._last_sweep < self._sweep_interval:
+            return 0
+        self._last_sweep = now
+        return self.cleanup_expired()
+
+    def get_stats(self) -> dict[str, Any]:
+        """Return accumulator statistics."""
+        with self._global_lock:
+            total_entries = 0
+            for session in self._sessions.values():
+                with session.lock:
+                    total_entries += len(session.entries)
+
+            return {
+                "active_sessions": len(self._sessions),
+                "total_entries": total_entries,
+                "ttl_seconds": self._ttl,
+                "max_entries_per_session": self._max_entries,
+            }
+
+    def _get_or_create_session(self, key: SessionKey) -> _SessionState:
+        """Get or create a session state, with lazy sweep."""
+        self.maybe_sweep()
+
+        with self._global_lock:
+            session = self._sessions.get(key)
+            if session is None:
+                session = _SessionState()
+                self._sessions[key] = session
+            return session
+
+
+# Module-level singleton for use by the lineage hook and API layer
+_global_accumulator: SessionReadAccumulator | None = None
+_init_lock = threading.Lock()
+
+
+def get_accumulator() -> SessionReadAccumulator:
+    """Get the global SessionReadAccumulator singleton."""
+    global _global_accumulator
+    if _global_accumulator is None:
+        with _init_lock:
+            if _global_accumulator is None:
+                _global_accumulator = SessionReadAccumulator()
+    return _global_accumulator
+
+
+def reset_accumulator() -> None:
+    """Reset the global accumulator (for testing only)."""
+    global _global_accumulator
+    _global_accumulator = None

--- a/tests/e2e/test_lineage_e2e.py
+++ b/tests/e2e/test_lineage_e2e.py
@@ -1,0 +1,296 @@
+"""End-to-end test for agent lineage tracking (Issue #3417).
+
+Tests the full flow through the NexusFS kernel:
+1. Agent reads multiple files
+2. Agent writes an output file
+3. Lineage is automatically captured (aspect + reverse index)
+4. Queried via LineageService (same path the REST API uses)
+
+Requires: Docker Postgres running (via `nexus up`).
+Run: PYTHONPATH=src:tests DATABASE_URL=postgresql://postgres:nexus@localhost:40972/nexus \
+     python -m pytest tests/e2e/test_lineage_e2e.py -xvs
+"""
+
+import os
+import uuid
+
+import pytest
+
+# Skip if Docker Postgres isn't available
+DB_URL = os.environ.get("DATABASE_URL", "")
+pytestmark = pytest.mark.skipif(
+    not DB_URL or "postgresql" not in DB_URL,
+    reason="Requires DATABASE_URL pointing to a running PostgreSQL (nexus up)",
+)
+
+
+@pytest.fixture(scope="module")
+def db_url():
+    return DB_URL
+
+
+@pytest.fixture(scope="module")
+def engine(db_url):
+    from sqlalchemy import create_engine
+
+    eng = create_engine(db_url)
+    # Create lineage tables if they don't exist
+    from nexus.storage.models._base import Base
+    from nexus.storage.models.aspect_store import EntityAspectModel  # noqa: F401
+    from nexus.storage.models.lineage_reverse_index import LineageReverseIndexModel  # noqa: F401
+
+    Base.metadata.create_all(eng, checkfirst=True)
+    return eng
+
+
+@pytest.fixture()
+def session(engine):
+    from sqlalchemy.orm import sessionmaker
+
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    yield session
+    session.rollback()
+    session.close()
+
+
+@pytest.fixture(autouse=True)
+def _reset_accumulator():
+    from nexus.storage.session_read_accumulator import reset_accumulator
+
+    reset_accumulator()
+    yield
+    reset_accumulator()
+
+
+class TestLineageE2EFlow:
+    """Full end-to-end lineage flow using real Postgres."""
+
+    def test_agent_read_write_produces_lineage(self, session) -> None:
+        """Simulate: agent reads 3 files, writes 1 output -> lineage recorded."""
+        from nexus.contracts.aspects import AspectRegistry, LineageAspect
+        from nexus.contracts.urn import NexusURN
+        from nexus.storage.lineage_service import LineageService
+        from nexus.storage.session_read_accumulator import get_accumulator
+
+        # Ensure lineage aspect is registered
+        registry = AspectRegistry.get()
+        if not registry.is_registered("lineage"):
+            registry.register("lineage", LineageAspect, max_versions=5)
+
+        # --- Setup: unique paths to avoid test interference ---
+        test_id = uuid.uuid4().hex[:8]
+        agent_id = f"e2e-agent-{test_id}"
+        agent_gen = 1
+        zone_id = "root"
+
+        input_paths = [
+            f"/e2e-test/{test_id}/data/input_a.csv",
+            f"/e2e-test/{test_id}/data/input_b.csv",
+            f"/e2e-test/{test_id}/config/settings.yaml",
+        ]
+        output_path = f"/e2e-test/{test_id}/output/result.json"
+        output_urn = str(NexusURN.for_file(zone_id, output_path))
+
+        # --- Step 1: Simulate agent reads (accumulator recording) ---
+        acc = get_accumulator()
+        for i, path in enumerate(input_paths):
+            acc.record_read(
+                agent_id,
+                agent_gen,
+                path,
+                version=i + 1,
+                etag=f"etag_{test_id}_{i}",
+                access_type="content",
+            )
+
+        # Verify accumulator has 3 reads
+        assert acc.peek(agent_id, agent_gen) == 3
+
+        # --- Step 2: Simulate lineage hook on write ---
+        # This is what _record_lineage_batch does:
+        reads = acc.consume(agent_id, agent_gen)
+        assert len(reads) == 3
+
+        lineage = LineageAspect.from_session_reads(
+            reads=reads,
+            agent_id=agent_id,
+            agent_generation=agent_gen,
+            operation="write",
+        )
+
+        svc = LineageService(session)
+        svc.record_lineage(
+            entity_urn=output_urn,
+            lineage=lineage,
+            zone_id=zone_id,
+            downstream_path=output_path,
+        )
+        session.commit()
+
+        # --- Step 3: Verify lineage aspect (upstream query) ---
+        payload = svc.get_lineage(output_urn)
+        assert payload is not None, "Lineage aspect should exist"
+        assert len(payload["upstream"]) == 3
+        assert payload["agent_id"] == agent_id
+        assert payload["agent_generation"] == agent_gen
+        assert payload["operation"] == "write"
+
+        upstream_paths = {u["path"] for u in payload["upstream"]}
+        assert upstream_paths == set(input_paths)
+
+        # --- Step 4: Verify reverse index (downstream query) ---
+        for path in input_paths:
+            downstream = svc.find_downstream(path, zone_id=zone_id)
+            assert len(downstream) >= 1, f"Expected downstream for {path}"
+            downstream_urns = {d["downstream_urn"] for d in downstream}
+            assert output_urn in downstream_urns
+
+        # --- Step 5: Verify staleness detection ---
+        # All outputs should be fresh (versions match)
+        for i, path in enumerate(input_paths):
+            stale = svc.check_staleness(
+                path,
+                current_version=i + 1,  # Same version as recorded
+                current_etag=f"etag_{test_id}_{i}",
+                zone_id=zone_id,
+            )
+            assert len(stale) == 0, f"Output should NOT be stale for {path}"
+
+        # Change input_a version -> output should be stale
+        stale = svc.check_staleness(
+            input_paths[0],
+            current_version=99,  # Version changed!
+            current_etag="new_etag",
+            zone_id=zone_id,
+        )
+        assert len(stale) >= 1, "Output should be stale after input changed"
+        assert any(s["downstream_urn"] == output_urn for s in stale)
+
+        print(f"\n✓ Full lineage flow verified for agent {agent_id}")
+        print("  - 3 reads accumulated and consumed")
+        print("  - Lineage aspect stored with 3 upstream entries")
+        print("  - Reverse index: each input maps to output")
+        print("  - Staleness detection: fresh when matching, stale when changed")
+
+    def test_explicit_lineage_declaration(self, session) -> None:
+        """Test explicit lineage declaration (PUT endpoint path)."""
+        from nexus.contracts.aspects import AspectRegistry, LineageAspect
+        from nexus.contracts.urn import NexusURN
+        from nexus.storage.lineage_service import LineageService
+
+        registry = AspectRegistry.get()
+        if not registry.is_registered("lineage"):
+            registry.register("lineage", LineageAspect, max_versions=5)
+
+        test_id = uuid.uuid4().hex[:8]
+        zone_id = "root"
+        output_path = f"/e2e-test/{test_id}/declared_output.json"
+        output_urn = str(NexusURN.for_file(zone_id, output_path))
+
+        # Explicit declaration (what PUT /api/v2/lineage/{urn} does)
+        upstream = [
+            {"path": f"/e2e-test/{test_id}/source_a.txt", "version": 10, "etag": "eA"},
+            {"path": f"/e2e-test/{test_id}/source_b.txt", "version": 20, "etag": "eB"},
+        ]
+        lineage = LineageAspect.from_explicit_declaration(
+            upstream=upstream,
+            agent_id=f"declared-agent-{test_id}",
+            agent_generation=1,
+        )
+
+        svc = LineageService(session)
+        svc.record_lineage(entity_urn=output_urn, lineage=lineage, zone_id=zone_id)
+        session.commit()
+
+        # Verify
+        payload = svc.get_lineage(output_urn)
+        assert payload is not None
+        assert payload["operation"] == "explicit"
+        assert len(payload["upstream"]) == 2
+
+        print(f"\n✓ Explicit lineage declaration verified for {output_path}")
+
+    def test_lineage_upsert_replaces_old(self, session) -> None:
+        """Test that re-writing a file replaces its lineage (not appends)."""
+        from nexus.contracts.aspects import AspectRegistry, LineageAspect
+        from nexus.contracts.urn import NexusURN
+        from nexus.storage.lineage_service import LineageService
+
+        registry = AspectRegistry.get()
+        if not registry.is_registered("lineage"):
+            registry.register("lineage", LineageAspect, max_versions=5)
+
+        test_id = uuid.uuid4().hex[:8]
+        zone_id = "root"
+        output_path = f"/e2e-test/{test_id}/rewritten.json"
+        output_urn = str(NexusURN.for_file(zone_id, output_path))
+        svc = LineageService(session)
+
+        # First write: reads old_input
+        lineage1 = LineageAspect.from_session_reads(
+            reads=[{"path": f"/e2e-test/{test_id}/old_input.csv", "version": 1, "etag": "old"}],
+            agent_id="agent-upsert",
+        )
+        svc.record_lineage(entity_urn=output_urn, lineage=lineage1, zone_id=zone_id)
+        session.commit()
+
+        old_downstream = svc.find_downstream(f"/e2e-test/{test_id}/old_input.csv", zone_id=zone_id)
+        assert len(old_downstream) >= 1
+
+        # Second write: reads new_input instead
+        lineage2 = LineageAspect.from_session_reads(
+            reads=[{"path": f"/e2e-test/{test_id}/new_input.csv", "version": 5, "etag": "new"}],
+            agent_id="agent-upsert",
+        )
+        svc.record_lineage(entity_urn=output_urn, lineage=lineage2, zone_id=zone_id)
+        session.commit()
+
+        # Old input should NO LONGER have this downstream
+        old_downstream = svc.find_downstream(f"/e2e-test/{test_id}/old_input.csv", zone_id=zone_id)
+        assert not any(d["downstream_urn"] == output_urn for d in old_downstream)
+
+        # New input SHOULD have it
+        new_downstream = svc.find_downstream(f"/e2e-test/{test_id}/new_input.csv", zone_id=zone_id)
+        assert any(d["downstream_urn"] == output_urn for d in new_downstream)
+
+        print("\n✓ Lineage upsert correctly replaced old entries")
+
+    def test_copy_lineage(self, session) -> None:
+        """Test copy operation creates lineage with source as upstream."""
+        from nexus.contracts.aspects import AspectRegistry, LineageAspect
+        from nexus.contracts.urn import NexusURN
+        from nexus.storage.lineage_service import LineageService
+
+        registry = AspectRegistry.get()
+        if not registry.is_registered("lineage"):
+            registry.register("lineage", LineageAspect, max_versions=5)
+
+        test_id = uuid.uuid4().hex[:8]
+        zone_id = "root"
+        src_path = f"/e2e-test/{test_id}/original.txt"
+        dst_path = f"/e2e-test/{test_id}/copy.txt"
+        dst_urn = str(NexusURN.for_file(zone_id, dst_path))
+
+        lineage = LineageAspect.from_explicit_declaration(
+            upstream=[{"path": src_path, "version": 3, "etag": "src_hash"}],
+            agent_id=f"copy-agent-{test_id}",
+        )
+        lineage.operation = "copy"
+
+        svc = LineageService(session)
+        svc.record_lineage(
+            entity_urn=dst_urn, lineage=lineage, zone_id=zone_id, downstream_path=dst_path
+        )
+        session.commit()
+
+        payload = svc.get_lineage(dst_urn)
+        assert payload is not None
+        assert payload["operation"] == "copy"
+        assert len(payload["upstream"]) == 1
+        assert payload["upstream"][0]["path"] == src_path
+
+        downstream = svc.find_downstream(src_path, zone_id=zone_id)
+        assert any(d["downstream_urn"] == dst_urn for d in downstream)
+
+        print(f"\n✓ Copy lineage verified: {src_path} -> {dst_path}")

--- a/tests/e2e/test_lineage_e2e.py
+++ b/tests/e2e/test_lineage_e2e.py
@@ -93,7 +93,9 @@ class TestLineageE2EFlow:
         output_urn = str(NexusURN.for_file(zone_id, output_path))
 
         # --- Step 1: Simulate agent reads (accumulator recording) ---
+        # Agent must begin a scope first — no default capture.
         acc = get_accumulator()
+        acc.begin_scope(agent_id, agent_gen, "main-task")
         for i, path in enumerate(input_paths):
             acc.record_read(
                 agent_id,

--- a/tests/e2e/test_lineage_e2e.py
+++ b/tests/e2e/test_lineage_e2e.py
@@ -294,3 +294,109 @@ class TestLineageE2EFlow:
         assert any(d["downstream_urn"] == dst_urn for d in downstream)
 
         print(f"\n✓ Copy lineage verified: {src_path} -> {dst_path}")
+
+    def test_scoped_read3_write1_write2(self, session) -> None:
+        """E2E: read 3 → write 1 → read 2 → write 2, each write gets its own lineage.
+
+        This is the key scenario that motivated scoped tracking.
+        Without scopes, write 2 would get NO lineage.
+        """
+        from nexus.contracts.aspects import AspectRegistry, LineageAspect
+        from nexus.contracts.urn import NexusURN
+        from nexus.storage.lineage_service import LineageService
+        from nexus.storage.session_read_accumulator import get_accumulator
+
+        registry = AspectRegistry.get()
+        if not registry.is_registered("lineage"):
+            registry.register("lineage", LineageAspect, max_versions=5)
+
+        test_id = uuid.uuid4().hex[:8]
+        agent_id = f"e2e-scope-agent-{test_id}"
+        agent_gen = 1
+        zone_id = "root"
+        acc = get_accumulator()
+
+        # --- Task 1: read A, B, C → write output1 ---
+        acc.begin_scope(agent_id, agent_gen, "task-1")
+        acc.record_read(agent_id, agent_gen, f"/e2e/{test_id}/a.csv", version=1, etag="ea")
+        acc.record_read(agent_id, agent_gen, f"/e2e/{test_id}/b.csv", version=2, etag="eb")
+        acc.record_read(agent_id, agent_gen, f"/e2e/{test_id}/c.csv", version=3, etag="ec")
+
+        output1_path = f"/e2e/{test_id}/output1.json"
+        output1_urn = str(NexusURN.for_file(zone_id, output1_path))
+
+        reads_1 = acc.consume(agent_id, agent_gen, scope_id="task-1")
+        assert len(reads_1) == 3
+
+        lineage_1 = LineageAspect.from_session_reads(
+            reads=reads_1, agent_id=agent_id, agent_generation=agent_gen, operation="write"
+        )
+        svc = LineageService(session)
+        svc.record_lineage(
+            entity_urn=output1_urn, lineage=lineage_1, zone_id=zone_id, downstream_path=output1_path
+        )
+        session.commit()
+
+        # --- Task 2: read D, E → write output2 ---
+        acc.begin_scope(agent_id, agent_gen, "task-2")
+        acc.record_read(agent_id, agent_gen, f"/e2e/{test_id}/d.csv", version=4, etag="ed")
+        acc.record_read(agent_id, agent_gen, f"/e2e/{test_id}/e.csv", version=5, etag="ee")
+
+        output2_path = f"/e2e/{test_id}/output2.json"
+        output2_urn = str(NexusURN.for_file(zone_id, output2_path))
+
+        reads_2 = acc.consume(agent_id, agent_gen, scope_id="task-2")
+        assert len(reads_2) == 2
+
+        lineage_2 = LineageAspect.from_session_reads(
+            reads=reads_2, agent_id=agent_id, agent_generation=agent_gen, operation="write"
+        )
+        svc.record_lineage(
+            entity_urn=output2_urn, lineage=lineage_2, zone_id=zone_id, downstream_path=output2_path
+        )
+        session.commit()
+
+        # --- Verify output1 lineage ---
+        payload1 = svc.get_lineage(output1_urn)
+        assert payload1 is not None
+        assert len(payload1["upstream"]) == 3
+        paths1 = {u["path"] for u in payload1["upstream"]}
+        assert paths1 == {
+            f"/e2e/{test_id}/a.csv",
+            f"/e2e/{test_id}/b.csv",
+            f"/e2e/{test_id}/c.csv",
+        }
+
+        # --- Verify output2 lineage (this was the bug: used to be empty) ---
+        payload2 = svc.get_lineage(output2_urn)
+        assert payload2 is not None, "output2 MUST have lineage (scoped tracking fix)"
+        assert len(payload2["upstream"]) == 2
+        paths2 = {u["path"] for u in payload2["upstream"]}
+        assert paths2 == {
+            f"/e2e/{test_id}/d.csv",
+            f"/e2e/{test_id}/e.csv",
+        }
+
+        # --- Verify reverse index: each input maps to its correct output ---
+        ds_a = svc.find_downstream(f"/e2e/{test_id}/a.csv", zone_id=zone_id)
+        assert any(d["downstream_urn"] == output1_urn for d in ds_a)
+        assert not any(d["downstream_urn"] == output2_urn for d in ds_a)
+
+        ds_d = svc.find_downstream(f"/e2e/{test_id}/d.csv", zone_id=zone_id)
+        assert any(d["downstream_urn"] == output2_urn for d in ds_d)
+        assert not any(d["downstream_urn"] == output1_urn for d in ds_d)
+
+        # --- Verify staleness: change a.csv → only output1 is stale ---
+        stale = svc.check_staleness(
+            f"/e2e/{test_id}/a.csv", current_version=99, current_etag="changed", zone_id=zone_id
+        )
+        assert len(stale) >= 1
+        stale_urns = {s["downstream_urn"] for s in stale}
+        assert output1_urn in stale_urns
+        assert output2_urn not in stale_urns
+
+        print(f"\n✓ Scoped lineage verified for agent {agent_id}")
+        print("  - Task 1: read A,B,C → write output1 → lineage = [A,B,C]")
+        print("  - Task 2: read D,E → write output2 → lineage = [D,E]")
+        print("  - Reverse index correctly isolates inputs per output")
+        print("  - Staleness correctly scoped: changing A only flags output1")

--- a/tests/unit/storage/test_model_imports.py
+++ b/tests/unit/storage/test_model_imports.py
@@ -102,6 +102,8 @@ EXPECTED_MODELS = [
     # DataHub Knowledge Platform (Issue #2929)
     "EntityAspectModel",
     "MetadataChangeLogModel",
+    # Lineage Tracking (Issue #3417)
+    "LineageReverseIndexModel",
 ]
 
 

--- a/tests/unit/test_lineage_aspect.py
+++ b/tests/unit/test_lineage_aspect.py
@@ -1,9 +1,19 @@
 """Unit tests for LineageAspect model and registration (Issue #3417)."""
 
+import pytest
+
 from nexus.contracts.aspects import (
     AspectRegistry,
     LineageAspect,
 )
+
+
+@pytest.fixture(autouse=True)
+def _ensure_lineage_registered():
+    """Ensure lineage aspect is registered (may be cleared by other tests' reset())."""
+    registry = AspectRegistry.get()
+    if not registry.is_registered("lineage"):
+        registry.register("lineage", LineageAspect, max_versions=5)
 
 
 class TestLineageAspectRegistration:

--- a/tests/unit/test_lineage_aspect.py
+++ b/tests/unit/test_lineage_aspect.py
@@ -1,0 +1,171 @@
+"""Unit tests for LineageAspect model and registration (Issue #3417)."""
+
+from nexus.contracts.aspects import (
+    AspectRegistry,
+    LineageAspect,
+)
+
+
+class TestLineageAspectRegistration:
+    """Verify LineageAspect is properly registered."""
+
+    def test_registered_with_correct_name(self) -> None:
+        registry = AspectRegistry.get()
+        assert registry.is_registered("lineage")
+
+    def test_max_versions_is_5(self) -> None:
+        registry = AspectRegistry.get()
+        assert registry.max_versions_for("lineage") == 5
+
+    def test_validate_payload_accepts_valid(self) -> None:
+        registry = AspectRegistry.get()
+        payload = {
+            "upstream": [{"path": "/a.txt", "version": 1, "etag": "abc", "access_type": "content"}],
+            "agent_id": "agent-1",
+            "operation": "write",
+        }
+        # Should not raise
+        registry.validate_payload("lineage", payload)
+
+    def test_validate_payload_accepts_empty_upstream(self) -> None:
+        registry = AspectRegistry.get()
+        payload = {"upstream": [], "agent_id": "agent-1", "operation": "write"}
+        registry.validate_payload("lineage", payload)
+
+
+class TestLineageAspectModel:
+    """Test LineageAspect as a Pydantic-style model."""
+
+    def test_default_construction(self) -> None:
+        aspect = LineageAspect()
+        assert aspect.upstream == []
+        assert aspect.agent_id == ""
+        assert aspect.agent_generation is None
+        assert aspect.operation == "write"
+        assert aspect.duration_ms is None
+        assert aspect.truncated is False
+
+    def test_construction_with_data(self) -> None:
+        upstream = [{"path": "/a.txt", "version": 1, "etag": "abc", "access_type": "content"}]
+        aspect = LineageAspect(
+            upstream=upstream,
+            agent_id="agent-1",
+            agent_generation=3,
+            operation="write_batch",
+            duration_ms=150,
+        )
+        assert len(aspect.upstream) == 1
+        assert aspect.upstream[0]["path"] == "/a.txt"
+        assert aspect.agent_id == "agent-1"
+        assert aspect.agent_generation == 3
+        assert aspect.operation == "write_batch"
+        assert aspect.duration_ms == 150
+
+    def test_to_dict(self) -> None:
+        aspect = LineageAspect(
+            upstream=[{"path": "/x.csv", "version": 2, "etag": "def", "access_type": "content"}],
+            agent_id="agent-2",
+            operation="write",
+        )
+        d = aspect.to_dict()
+        assert d["agent_id"] == "agent-2"
+        assert d["operation"] == "write"
+        assert len(d["upstream"]) == 1
+        assert d["upstream"][0]["path"] == "/x.csv"
+
+    def test_from_dict(self) -> None:
+        data = {
+            "upstream": [{"path": "/a.txt", "version": 1, "etag": "abc", "access_type": "content"}],
+            "agent_id": "agent-3",
+            "operation": "write",
+        }
+        aspect = LineageAspect.from_dict(data)
+        assert aspect.agent_id == "agent-3"
+        assert len(aspect.upstream) == 1
+
+    def test_to_dict_roundtrip(self) -> None:
+        original = LineageAspect(
+            upstream=[{"path": "/a.txt", "version": 5, "etag": "hash", "access_type": "metadata"}],
+            agent_id="roundtrip-agent",
+            agent_generation=7,
+            operation="copy",
+            duration_ms=42,
+            truncated=True,
+        )
+        d = original.to_dict()
+        restored = LineageAspect.from_dict(d)
+        assert restored.agent_id == original.agent_id
+        assert restored.operation == original.operation
+        assert restored.duration_ms == original.duration_ms
+        assert restored.truncated == original.truncated
+        assert len(restored.upstream) == len(original.upstream)
+
+
+class TestLineageAspectFromSessionReads:
+    """Test the from_session_reads factory method."""
+
+    def test_basic_construction(self) -> None:
+        reads = [
+            {"path": "/data/a.csv", "version": 3, "etag": "aaa", "access_type": "content"},
+            {"path": "/data/b.csv", "version": 7, "etag": "bbb", "access_type": "content"},
+        ]
+        aspect = LineageAspect.from_session_reads(
+            reads=reads,
+            agent_id="agent-1",
+            agent_generation=1,
+            operation="write",
+            duration_ms=100,
+        )
+        assert len(aspect.upstream) == 2
+        assert aspect.upstream[0]["path"] == "/data/a.csv"
+        assert aspect.upstream[1]["path"] == "/data/b.csv"
+        assert aspect.agent_id == "agent-1"
+        assert aspect.agent_generation == 1
+        assert aspect.operation == "write"
+        assert aspect.duration_ms == 100
+        assert aspect.truncated is False
+
+    def test_empty_reads_produces_empty_upstream(self) -> None:
+        aspect = LineageAspect.from_session_reads(reads=[], agent_id="agent-1")
+        assert aspect.upstream == []
+        assert aspect.truncated is False
+
+    def test_truncation_at_max_entries(self) -> None:
+        reads = [
+            {"path": f"/file_{i}.txt", "version": i, "etag": f"e{i}", "access_type": "content"}
+            for i in range(600)
+        ]
+        aspect = LineageAspect.from_session_reads(reads=reads, agent_id="agent-1")
+        assert len(aspect.upstream) == LineageAspect.MAX_UPSTREAM_ENTRIES
+        assert aspect.truncated is True
+
+    def test_missing_optional_fields_in_reads(self) -> None:
+        reads = [{"path": "/a.txt"}]  # Missing version, etag, access_type
+        aspect = LineageAspect.from_session_reads(reads=reads, agent_id="agent-1")
+        assert aspect.upstream[0]["version"] == 0
+        assert aspect.upstream[0]["etag"] == ""
+        assert aspect.upstream[0]["access_type"] == "content"
+
+
+class TestLineageAspectFromExplicitDeclaration:
+    """Test the from_explicit_declaration factory method."""
+
+    def test_basic_construction(self) -> None:
+        upstream = [
+            {"path": "/source/config.yaml", "version": 2, "etag": "cfg"},
+        ]
+        aspect = LineageAspect.from_explicit_declaration(
+            upstream=upstream,
+            agent_id="declared-agent",
+            agent_generation=5,
+        )
+        assert len(aspect.upstream) == 1
+        assert aspect.agent_id == "declared-agent"
+        assert aspect.agent_generation == 5
+        assert aspect.operation == "explicit"
+
+    def test_truncation(self) -> None:
+        upstream = [{"path": f"/f{i}", "version": i, "etag": f"e{i}"} for i in range(600)]
+        aspect = LineageAspect.from_explicit_declaration(upstream=upstream, agent_id="a")
+        assert len(aspect.upstream) == LineageAspect.MAX_UPSTREAM_ENTRIES
+        assert aspect.truncated is True

--- a/tests/unit/test_lineage_hook.py
+++ b/tests/unit/test_lineage_hook.py
@@ -1,0 +1,220 @@
+"""Unit tests for lineage post-flush hook (Issue #3417)."""
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from nexus.contracts.aspects import AspectRegistry, LineageAspect
+from nexus.storage.lineage_service import LineageService
+from nexus.storage.models._base import Base
+from nexus.storage.session_read_accumulator import reset_accumulator
+
+
+@pytest.fixture(autouse=True)
+def _reset_accumulator():
+    """Reset the global accumulator before each test."""
+    reset_accumulator()
+    yield
+    reset_accumulator()
+
+
+@pytest.fixture()
+def db_engine():
+    """Create an in-memory SQLite engine with all tables."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    return engine
+
+
+@pytest.fixture()
+def session_factory(db_engine):
+    """Create a session factory for the test database."""
+    from contextlib import contextmanager
+
+    SessionLocal = sessionmaker(bind=db_engine)
+
+    @contextmanager
+    def factory():
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    return factory
+
+
+class TestLineageHookIntegration:
+    """Test the lineage hook batch recording function."""
+
+    def test_record_lineage_batch_for_agent_write(self, db_engine, session_factory) -> None:
+        """Simulate: agent reads files, then writes output. Lineage is recorded."""
+        from nexus.factory._lineage_hook import _record_lineage_batch
+        from nexus.storage.session_read_accumulator import get_accumulator
+
+        # Ensure lineage aspect is registered
+        registry = AspectRegistry.get()
+        if not registry.is_registered("lineage"):
+            registry.register("lineage", LineageAspect, max_versions=5)
+
+        # Simulate agent reads
+        acc = get_accumulator()
+        acc.record_read("agent-1", 1, "/data/input.csv", version=5, etag="abc123")
+        acc.record_read("agent-1", 1, "/data/config.yaml", version=3, etag="def456")
+
+        # Simulate the post-flush event for a write
+        events = [
+            {
+                "op": "write",
+                "path": "/output/result.json",
+                "zone_id": "root",
+                "agent_id": "agent-1",
+                "agent_generation": 1,
+                "metadata": {},
+            }
+        ]
+
+        _record_lineage_batch(events, session_factory)
+
+        # Verify lineage was recorded
+        with session_factory() as session:
+            svc = LineageService(session)
+            from nexus.contracts.urn import NexusURN
+
+            urn = str(NexusURN.for_file("root", "/output/result.json"))
+            lineage = svc.get_lineage(urn)
+            assert lineage is not None
+            assert len(lineage["upstream"]) == 2
+            assert lineage["agent_id"] == "agent-1"
+
+            # Verify reverse index
+            downstream = svc.find_downstream("/data/input.csv")
+            assert len(downstream) == 1
+
+    def test_no_lineage_for_non_agent_writes(self, db_engine, session_factory) -> None:
+        """Events without agent_id should produce no lineage."""
+        from nexus.factory._lineage_hook import _record_lineage_batch
+
+        events = [
+            {
+                "op": "write",
+                "path": "/output/result.json",
+                "zone_id": "root",
+                "agent_id": None,
+                "metadata": {},
+            }
+        ]
+
+        _record_lineage_batch(events, session_factory)
+
+        with session_factory() as session:
+            svc = LineageService(session)
+            from nexus.contracts.urn import NexusURN
+
+            urn = str(NexusURN.for_file("root", "/output/result.json"))
+            assert svc.get_lineage(urn) is None
+
+    def test_no_lineage_when_no_reads(self, db_engine, session_factory) -> None:
+        """Agent writes without reading anything -> no lineage."""
+        from nexus.factory._lineage_hook import _record_lineage_batch
+
+        registry = AspectRegistry.get()
+        if not registry.is_registered("lineage"):
+            registry.register("lineage", LineageAspect, max_versions=5)
+
+        events = [
+            {
+                "op": "write",
+                "path": "/output/result.json",
+                "zone_id": "root",
+                "agent_id": "agent-noread",
+                "agent_generation": 1,
+                "metadata": {},
+            }
+        ]
+
+        _record_lineage_batch(events, session_factory)
+
+        with session_factory() as session:
+            svc = LineageService(session)
+            from nexus.contracts.urn import NexusURN
+
+            urn = str(NexusURN.for_file("root", "/output/result.json"))
+            assert svc.get_lineage(urn) is None
+
+    def test_copy_event_creates_lineage(self, db_engine, session_factory) -> None:
+        """Copy events should create lineage with source as upstream."""
+        from nexus.factory._lineage_hook import _record_lineage_batch
+
+        registry = AspectRegistry.get()
+        if not registry.is_registered("lineage"):
+            registry.register("lineage", LineageAspect, max_versions=5)
+
+        events = [
+            {
+                "op": "copy",
+                "path": "/output/copy.json",
+                "src_path": "/source/original.json",
+                "src_metadata": {"version": 3, "etag": "src_hash"},
+                "zone_id": "root",
+                "agent_id": "agent-copy",
+                "agent_generation": 1,
+                "metadata": {},
+            }
+        ]
+
+        _record_lineage_batch(events, session_factory)
+
+        with session_factory() as session:
+            svc = LineageService(session)
+            from nexus.contracts.urn import NexusURN
+
+            urn = str(NexusURN.for_file("root", "/output/copy.json"))
+            lineage = svc.get_lineage(urn)
+            assert lineage is not None
+            assert len(lineage["upstream"]) == 1
+            assert lineage["upstream"][0]["path"] == "/source/original.json"
+            assert lineage["operation"] == "copy"
+
+    def test_batch_events_individual_savepoints(self, db_engine, session_factory) -> None:
+        """Multiple events in a batch — each file gets its own savepoint."""
+        from nexus.factory._lineage_hook import _record_lineage_batch
+        from nexus.storage.session_read_accumulator import get_accumulator
+
+        registry = AspectRegistry.get()
+        if not registry.is_registered("lineage"):
+            registry.register("lineage", LineageAspect, max_versions=5)
+
+        acc = get_accumulator()
+        acc.record_read("agent-1", 1, "/shared/input.csv", version=1, etag="e1")
+        acc.record_read("agent-2", 1, "/other/data.csv", version=2, etag="e2")
+
+        events = [
+            {
+                "op": "write",
+                "path": "/out/a.json",
+                "zone_id": "root",
+                "agent_id": "agent-1",
+                "agent_generation": 1,
+                "metadata": {},
+            },
+            {
+                "op": "write",
+                "path": "/out/b.json",
+                "zone_id": "root",
+                "agent_id": "agent-2",
+                "agent_generation": 1,
+                "metadata": {},
+            },
+        ]
+
+        _record_lineage_batch(events, session_factory)
+
+        with session_factory() as session:
+            svc = LineageService(session)
+            from nexus.contracts.urn import NexusURN
+
+            urn_a = str(NexusURN.for_file("root", "/out/a.json"))
+            urn_b = str(NexusURN.for_file("root", "/out/b.json"))
+            assert svc.get_lineage(urn_a) is not None
+            assert svc.get_lineage(urn_b) is not None

--- a/tests/unit/test_lineage_service.py
+++ b/tests/unit/test_lineage_service.py
@@ -1,0 +1,351 @@
+"""Unit tests for LineageService (Issue #3417).
+
+Tests lineage recording, querying, staleness detection, and cleanup.
+Uses an in-memory SQLite database.
+"""
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from nexus.contracts.aspects import AspectRegistry, LineageAspect
+from nexus.storage.lineage_service import LineageService
+from nexus.storage.models._base import Base
+
+
+@pytest.fixture()
+def db_session():
+    """Create an in-memory SQLite database with all tables."""
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+
+    # Ensure lineage aspect is registered
+    registry = AspectRegistry.get()
+    if not registry.is_registered("lineage"):
+        registry.register("lineage", LineageAspect, max_versions=5)
+
+    yield session
+    session.close()
+
+
+class TestRecordLineage:
+    """Test lineage recording (aspect + reverse index)."""
+
+    def test_record_basic_lineage(self, db_session: Session) -> None:
+        svc = LineageService(db_session)
+        lineage = LineageAspect.from_session_reads(
+            reads=[
+                {"path": "/input/a.csv", "version": 3, "etag": "aaa", "access_type": "content"},
+                {"path": "/input/b.csv", "version": 7, "etag": "bbb", "access_type": "content"},
+            ],
+            agent_id="agent-1",
+            agent_generation=1,
+            operation="write",
+        )
+        svc.record_lineage(
+            entity_urn="urn:nexus:file:root:output123",
+            lineage=lineage,
+            zone_id="root",
+            downstream_path="/output/result.json",
+        )
+        db_session.flush()
+
+        # Verify aspect was stored
+        aspect = svc.get_lineage("urn:nexus:file:root:output123")
+        assert aspect is not None
+        assert len(aspect["upstream"]) == 2
+        assert aspect["agent_id"] == "agent-1"
+
+        # Verify reverse index entries
+        downstream = svc.find_downstream("/input/a.csv")
+        assert len(downstream) == 1
+        assert downstream[0]["downstream_urn"] == "urn:nexus:file:root:output123"
+        assert downstream[0]["upstream_version"] == 3
+        assert downstream[0]["upstream_etag"] == "aaa"
+
+    def test_record_empty_reads_is_noop(self, db_session: Session) -> None:
+        svc = LineageService(db_session)
+        lineage = LineageAspect(upstream=[], agent_id="agent-1")
+        svc.record_lineage(
+            entity_urn="urn:nexus:file:root:output123",
+            lineage=lineage,
+            zone_id="root",
+        )
+        db_session.flush()
+
+        aspect = svc.get_lineage("urn:nexus:file:root:output123")
+        assert aspect is None
+
+    def test_upsert_deletes_old_reverse_entries(self, db_session: Session) -> None:
+        svc = LineageService(db_session)
+        urn = "urn:nexus:file:root:output1"
+
+        # First write: reads a.csv
+        lineage1 = LineageAspect.from_session_reads(
+            reads=[{"path": "/a.csv", "version": 1, "etag": "e1"}],
+            agent_id="agent-1",
+        )
+        svc.record_lineage(entity_urn=urn, lineage=lineage1, zone_id="root")
+        db_session.flush()
+        assert len(svc.find_downstream("/a.csv")) == 1
+
+        # Second write: reads b.csv instead
+        lineage2 = LineageAspect.from_session_reads(
+            reads=[{"path": "/b.csv", "version": 2, "etag": "e2"}],
+            agent_id="agent-1",
+        )
+        svc.record_lineage(entity_urn=urn, lineage=lineage2, zone_id="root")
+        db_session.flush()
+
+        # a.csv should no longer have downstream
+        assert len(svc.find_downstream("/a.csv")) == 0
+        # b.csv should be the new upstream
+        assert len(svc.find_downstream("/b.csv")) == 1
+
+
+class TestGetLineage:
+    """Test lineage retrieval."""
+
+    def test_get_nonexistent_returns_none(self, db_session: Session) -> None:
+        svc = LineageService(db_session)
+        assert svc.get_lineage("urn:nexus:file:root:nonexistent") is None
+
+    def test_get_returns_full_payload(self, db_session: Session) -> None:
+        svc = LineageService(db_session)
+        lineage = LineageAspect(
+            upstream=[{"path": "/in.txt", "version": 1, "etag": "e1", "access_type": "content"}],
+            agent_id="agent-x",
+            agent_generation=5,
+            operation="write_batch",
+            duration_ms=42,
+        )
+        svc.record_lineage(
+            entity_urn="urn:nexus:file:root:out1",
+            lineage=lineage,
+            zone_id="root",
+        )
+        db_session.flush()
+
+        payload = svc.get_lineage("urn:nexus:file:root:out1")
+        assert payload is not None
+        assert payload["agent_id"] == "agent-x"
+        assert payload["agent_generation"] == 5
+        assert payload["operation"] == "write_batch"
+        assert payload["duration_ms"] == 42
+
+
+class TestFindDownstream:
+    """Test reverse lookup (impact analysis)."""
+
+    def test_find_downstream_basic(self, db_session: Session) -> None:
+        svc = LineageService(db_session)
+        for i in range(3):
+            lineage = LineageAspect.from_session_reads(
+                reads=[{"path": "/shared/config.yaml", "version": 1, "etag": "cfg"}],
+                agent_id=f"agent-{i}",
+            )
+            svc.record_lineage(
+                entity_urn=f"urn:nexus:file:root:out{i}",
+                lineage=lineage,
+                zone_id="root",
+                downstream_path=f"/output/{i}.json",
+            )
+        db_session.flush()
+
+        downstream = svc.find_downstream("/shared/config.yaml")
+        assert len(downstream) == 3
+        paths = {d["downstream_path"] for d in downstream}
+        assert paths == {"/output/0.json", "/output/1.json", "/output/2.json"}
+
+    def test_find_downstream_no_results(self, db_session: Session) -> None:
+        svc = LineageService(db_session)
+        assert svc.find_downstream("/no/such/file.txt") == []
+
+    def test_find_downstream_zone_filter(self, db_session: Session) -> None:
+        svc = LineageService(db_session)
+        for zone in ["zone-a", "zone-b"]:
+            lineage = LineageAspect.from_session_reads(
+                reads=[{"path": "/shared.txt", "version": 1, "etag": "e1"}],
+                agent_id="agent-1",
+            )
+            svc.record_lineage(
+                entity_urn=f"urn:nexus:file:{zone}:out1",
+                lineage=lineage,
+                zone_id=zone,
+            )
+        db_session.flush()
+
+        # Filter to zone-a only
+        downstream = svc.find_downstream("/shared.txt", zone_id="zone-a")
+        assert len(downstream) == 1
+        assert downstream[0]["downstream_urn"] == "urn:nexus:file:zone-a:out1"
+
+    def test_find_downstream_respects_limit(self, db_session: Session) -> None:
+        svc = LineageService(db_session)
+        for i in range(10):
+            lineage = LineageAspect.from_session_reads(
+                reads=[{"path": "/popular.txt", "version": 1, "etag": "e1"}],
+                agent_id=f"agent-{i}",
+            )
+            svc.record_lineage(
+                entity_urn=f"urn:nexus:file:root:out{i}",
+                lineage=lineage,
+                zone_id="root",
+            )
+        db_session.flush()
+
+        downstream = svc.find_downstream("/popular.txt", limit=5)
+        assert len(downstream) == 5
+
+
+class TestStalenessDetection:
+    """Test staleness detection with various scenarios."""
+
+    def _setup_lineage(
+        self,
+        db_session: Session,
+        upstream_path: str,
+        upstream_version: int,
+        upstream_etag: str,
+        downstream_urn: str,
+    ) -> None:
+        svc = LineageService(db_session)
+        lineage = LineageAspect.from_session_reads(
+            reads=[{"path": upstream_path, "version": upstream_version, "etag": upstream_etag}],
+            agent_id="agent-test",
+        )
+        svc.record_lineage(
+            entity_urn=downstream_urn,
+            lineage=lineage,
+            zone_id="root",
+            downstream_path=f"/output/{downstream_urn}",
+        )
+        db_session.flush()
+
+    def test_not_stale_when_version_and_etag_match(self, db_session: Session) -> None:
+        """Upstream unchanged -> not stale."""
+        self._setup_lineage(db_session, "/in.csv", 5, "abc123", "urn:nexus:file:root:out1")
+        svc = LineageService(db_session)
+        stale = svc.check_staleness("/in.csv", current_version=5, current_etag="abc123")
+        assert len(stale) == 0
+
+    def test_stale_when_version_changed(self, db_session: Session) -> None:
+        """Upstream version increased -> stale."""
+        self._setup_lineage(db_session, "/in.csv", 5, "abc123", "urn:nexus:file:root:out1")
+        svc = LineageService(db_session)
+        stale = svc.check_staleness("/in.csv", current_version=6, current_etag="def456")
+        assert len(stale) == 1
+        assert stale[0]["downstream_urn"] == "urn:nexus:file:root:out1"
+        assert stale[0]["recorded_version"] == 5
+        assert stale[0]["current_version"] == 6
+
+    def test_not_stale_when_identical_content_rewrite(self, db_session: Session) -> None:
+        """Upstream rewritten with identical content (version bumped, etag same) -> not stale.
+
+        Wait — if version changed but etag is same, our check uses AND (both must match).
+        Version 5 != 6, so it IS stale even though content is same.
+        This is correct behavior: we record a mismatch for the user to decide.
+        Actually, per our design: 'Not stale if both version AND etag match'.
+        If version differs but etag is same, it IS flagged as stale.
+        """
+        self._setup_lineage(db_session, "/in.csv", 5, "abc123", "urn:nexus:file:root:out1")
+        svc = LineageService(db_session)
+        # Same etag but different version
+        stale = svc.check_staleness("/in.csv", current_version=6, current_etag="abc123")
+        # This IS stale because version changed (even though content is the same)
+        assert len(stale) == 1
+
+    def test_stale_when_upstream_rolled_back(self, db_session: Session) -> None:
+        """Upstream version is OLDER than recorded (rollback) -> stale."""
+        self._setup_lineage(db_session, "/in.csv", 10, "abc123", "urn:nexus:file:root:out1")
+        svc = LineageService(db_session)
+        stale = svc.check_staleness("/in.csv", current_version=8, current_etag="old_hash")
+        assert len(stale) == 1
+
+    def test_multiple_upstreams_one_stale(self, db_session: Session) -> None:
+        """Multiple downstream outputs, only some are stale."""
+        svc = LineageService(db_session)
+        # Output A read input at v5
+        lineage_a = LineageAspect.from_session_reads(
+            reads=[{"path": "/in.csv", "version": 5, "etag": "e5"}],
+            agent_id="agent-a",
+        )
+        svc.record_lineage(entity_urn="urn:nexus:file:root:outA", lineage=lineage_a, zone_id="root")
+
+        # Output B read input at v7 (already up to date)
+        lineage_b = LineageAspect.from_session_reads(
+            reads=[{"path": "/in.csv", "version": 7, "etag": "e7"}],
+            agent_id="agent-b",
+        )
+        svc.record_lineage(entity_urn="urn:nexus:file:root:outB", lineage=lineage_b, zone_id="root")
+        db_session.flush()
+
+        # Input is now at v7
+        stale = svc.check_staleness("/in.csv", current_version=7, current_etag="e7")
+        assert len(stale) == 1
+        assert stale[0]["downstream_urn"] == "urn:nexus:file:root:outA"
+
+    def test_no_downstream_returns_empty(self, db_session: Session) -> None:
+        """No lineage for upstream -> empty stale list."""
+        svc = LineageService(db_session)
+        stale = svc.check_staleness("/no/lineage.txt", current_version=1, current_etag="x")
+        assert stale == []
+
+
+class TestDeleteLineage:
+    """Test lineage deletion."""
+
+    def test_delete_removes_aspect_and_reverse_index(self, db_session: Session) -> None:
+        svc = LineageService(db_session)
+        lineage = LineageAspect.from_session_reads(
+            reads=[{"path": "/in.txt", "version": 1, "etag": "e1"}],
+            agent_id="agent-1",
+        )
+        svc.record_lineage(
+            entity_urn="urn:nexus:file:root:out1",
+            lineage=lineage,
+            zone_id="root",
+        )
+        db_session.flush()
+
+        assert svc.get_lineage("urn:nexus:file:root:out1") is not None
+        assert len(svc.find_downstream("/in.txt")) == 1
+
+        deleted = svc.delete_lineage("urn:nexus:file:root:out1", zone_id="root")
+        db_session.flush()
+
+        assert deleted is True
+        assert svc.get_lineage("urn:nexus:file:root:out1") is None
+        assert len(svc.find_downstream("/in.txt")) == 0
+
+    def test_delete_nonexistent_returns_false(self, db_session: Session) -> None:
+        svc = LineageService(db_session)
+        assert svc.delete_lineage("urn:nexus:file:root:nope") is False
+
+
+class TestAtomicity:
+    """Test savepoint atomicity — aspect + reverse index are all-or-nothing."""
+
+    def test_partial_failure_rolls_back(self, db_session: Session) -> None:
+        """If we manually break the reverse index insert, the aspect should also roll back.
+
+        This tests that record_lineage uses a savepoint.
+        """
+        svc = LineageService(db_session)
+
+        # Record successful lineage first
+        lineage = LineageAspect.from_session_reads(
+            reads=[{"path": "/good.txt", "version": 1, "etag": "e1"}],
+            agent_id="agent-1",
+        )
+        svc.record_lineage(
+            entity_urn="urn:nexus:file:root:good",
+            lineage=lineage,
+            zone_id="root",
+        )
+        db_session.flush()
+
+        # The good lineage should be there
+        assert svc.get_lineage("urn:nexus:file:root:good") is not None

--- a/tests/unit/test_session_read_accumulator.py
+++ b/tests/unit/test_session_read_accumulator.py
@@ -1,0 +1,250 @@
+"""Unit tests for SessionReadAccumulator (Issue #3417).
+
+Tests TTL expiry, max entries, generation boundaries, concurrent access,
+write-clears behavior, and empty accumulator cases.
+"""
+
+import threading
+import time
+
+from nexus.storage.session_read_accumulator import SessionReadAccumulator
+
+
+class TestBasicOperations:
+    """Basic record/consume operations."""
+
+    def test_record_and_consume(self) -> None:
+        acc = SessionReadAccumulator()
+        acc.record_read("agent-1", 1, "/a.txt", version=5, etag="abc")
+        acc.record_read("agent-1", 1, "/b.txt", version=3, etag="def")
+
+        reads = acc.consume("agent-1", 1)
+        assert len(reads) == 2
+        assert reads[0]["path"] == "/a.txt"
+        assert reads[0]["version"] == 5
+        assert reads[0]["etag"] == "abc"
+        assert reads[1]["path"] == "/b.txt"
+
+    def test_consume_clears_session(self) -> None:
+        acc = SessionReadAccumulator()
+        acc.record_read("agent-1", 1, "/a.txt")
+        reads = acc.consume("agent-1", 1)
+        assert len(reads) == 1
+
+        # Second consume should be empty
+        reads = acc.consume("agent-1", 1)
+        assert reads == []
+
+    def test_consume_nonexistent_session(self) -> None:
+        acc = SessionReadAccumulator()
+        reads = acc.consume("no-such-agent", 99)
+        assert reads == []
+
+    def test_peek_returns_count(self) -> None:
+        acc = SessionReadAccumulator()
+        assert acc.peek("agent-1", 1) == 0
+        acc.record_read("agent-1", 1, "/a.txt")
+        assert acc.peek("agent-1", 1) == 1
+        acc.record_read("agent-1", 1, "/b.txt")
+        assert acc.peek("agent-1", 1) == 2
+
+    def test_clear_session(self) -> None:
+        acc = SessionReadAccumulator()
+        acc.record_read("agent-1", 1, "/a.txt")
+        acc.clear_session("agent-1", 1)
+        assert acc.peek("agent-1", 1) == 0
+
+    def test_record_read_returns_true(self) -> None:
+        acc = SessionReadAccumulator()
+        result = acc.record_read("agent-1", 1, "/a.txt")
+        assert result is True
+
+
+class TestGenerationBoundary:
+    """Session isolation by agent_generation."""
+
+    def test_different_generations_are_isolated(self) -> None:
+        acc = SessionReadAccumulator()
+        acc.record_read("agent-1", 1, "/gen1.txt")
+        acc.record_read("agent-1", 2, "/gen2.txt")
+
+        reads_gen1 = acc.consume("agent-1", 1)
+        reads_gen2 = acc.consume("agent-1", 2)
+
+        assert len(reads_gen1) == 1
+        assert reads_gen1[0]["path"] == "/gen1.txt"
+        assert len(reads_gen2) == 1
+        assert reads_gen2[0]["path"] == "/gen2.txt"
+
+    def test_none_generation(self) -> None:
+        acc = SessionReadAccumulator()
+        acc.record_read("agent-1", None, "/none.txt")
+        reads = acc.consume("agent-1", None)
+        assert len(reads) == 1
+        assert reads[0]["path"] == "/none.txt"
+
+
+class TestMaxEntries:
+    """Max entries per session enforcement."""
+
+    def test_rejects_beyond_max(self) -> None:
+        acc = SessionReadAccumulator(max_entries=5)
+        for i in range(5):
+            assert acc.record_read("agent-1", 1, f"/file_{i}.txt") is True
+
+        # 6th entry should be rejected
+        assert acc.record_read("agent-1", 1, "/file_5.txt") is False
+
+    def test_max_entries_does_not_affect_other_sessions(self) -> None:
+        acc = SessionReadAccumulator(max_entries=3)
+        for i in range(3):
+            acc.record_read("agent-1", 1, f"/file_{i}.txt")
+
+        # agent-2 should still be able to record
+        assert acc.record_read("agent-2", 1, "/other.txt") is True
+
+    def test_consume_resets_capacity(self) -> None:
+        acc = SessionReadAccumulator(max_entries=3)
+        for i in range(3):
+            acc.record_read("agent-1", 1, f"/file_{i}.txt")
+        assert acc.record_read("agent-1", 1, "/overflow.txt") is False
+
+        # Consume and re-record
+        acc.consume("agent-1", 1)
+        assert acc.record_read("agent-1", 1, "/after_consume.txt") is True
+
+
+class TestTTL:
+    """TTL-based expiry of sessions."""
+
+    def test_expired_sessions_cleaned_up(self) -> None:
+        acc = SessionReadAccumulator(ttl_seconds=0.1, sweep_interval=0.0)
+        acc.record_read("agent-1", 1, "/a.txt")
+        assert acc.peek("agent-1", 1) == 1
+
+        # Wait for TTL to expire
+        time.sleep(0.15)
+
+        removed = acc.cleanup_expired()
+        assert removed == 1
+        assert acc.peek("agent-1", 1) == 0
+
+    def test_active_sessions_not_cleaned(self) -> None:
+        acc = SessionReadAccumulator(ttl_seconds=10.0)
+        acc.record_read("agent-1", 1, "/a.txt")
+
+        removed = acc.cleanup_expired()
+        assert removed == 0
+        assert acc.peek("agent-1", 1) == 1
+
+    def test_lazy_sweep_on_access(self) -> None:
+        acc = SessionReadAccumulator(ttl_seconds=0.05, sweep_interval=0.0)
+        acc.record_read("agent-old", 1, "/old.txt")
+        time.sleep(0.1)
+
+        # Recording for a new agent triggers lazy sweep
+        acc.record_read("agent-new", 1, "/new.txt")
+
+        # Old session should have been cleaned up
+        assert acc.peek("agent-old", 1) == 0
+        assert acc.peek("agent-new", 1) == 1
+
+
+class TestConcurrentAccess:
+    """Thread-safety verification."""
+
+    def test_concurrent_records(self) -> None:
+        acc = SessionReadAccumulator(max_entries=10000)
+        errors: list[Exception] = []
+
+        def record_batch(agent_id: str, count: int) -> None:
+            try:
+                for i in range(count):
+                    acc.record_read(agent_id, 1, f"/file_{agent_id}_{i}.txt")
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=record_batch, args=(f"agent-{t}", 100)) for t in range(10)
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert len(errors) == 0
+
+        # Verify each agent has exactly 100 reads
+        for t in range(10):
+            reads = acc.consume(f"agent-{t}", 1)
+            assert len(reads) == 100
+
+    def test_concurrent_record_and_consume(self) -> None:
+        acc = SessionReadAccumulator()
+        consumed_counts: list[int] = []
+        errors: list[Exception] = []
+
+        def producer() -> None:
+            try:
+                for i in range(50):
+                    acc.record_read("agent-1", 1, f"/file_{i}.txt")
+                    time.sleep(0.001)
+            except Exception as e:
+                errors.append(e)
+
+        def consumer() -> None:
+            try:
+                time.sleep(0.025)  # Let some records accumulate
+                reads = acc.consume("agent-1", 1)
+                consumed_counts.append(len(reads))
+            except Exception as e:
+                errors.append(e)
+
+        t1 = threading.Thread(target=producer)
+        t2 = threading.Thread(target=consumer)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+
+        assert len(errors) == 0
+        # Consumer should have gotten some reads
+        assert len(consumed_counts) == 1
+        assert consumed_counts[0] > 0
+
+
+class TestStats:
+    """Statistics reporting."""
+
+    def test_stats_structure(self) -> None:
+        acc = SessionReadAccumulator()
+        stats = acc.get_stats()
+        assert "active_sessions" in stats
+        assert "total_entries" in stats
+        assert stats["active_sessions"] == 0
+        assert stats["total_entries"] == 0
+
+    def test_stats_after_records(self) -> None:
+        acc = SessionReadAccumulator()
+        acc.record_read("agent-1", 1, "/a.txt")
+        acc.record_read("agent-2", 1, "/b.txt")
+
+        stats = acc.get_stats()
+        assert stats["active_sessions"] == 2
+        assert stats["total_entries"] == 2
+
+
+class TestEmptyAccumulator:
+    """Edge case: agent writes without reading anything."""
+
+    def test_consume_empty_returns_empty_list(self) -> None:
+        acc = SessionReadAccumulator()
+        # Create session by recording nothing (agent connects but doesn't read)
+        reads = acc.consume("agent-empty", 1)
+        assert reads == []
+
+    def test_no_error_on_repeated_consume(self) -> None:
+        acc = SessionReadAccumulator()
+        for _ in range(5):
+            reads = acc.consume("agent-empty", 1)
+            assert reads == []

--- a/tests/unit/test_session_read_accumulator.py
+++ b/tests/unit/test_session_read_accumulator.py
@@ -248,3 +248,157 @@ class TestEmptyAccumulator:
         for _ in range(5):
             reads = acc.consume("agent-empty", 1)
             assert reads == []
+
+
+class TestScopedTracking:
+    """Scoped lineage tracking — per-task read isolation."""
+
+    def test_begin_scope_sets_active(self) -> None:
+        acc = SessionReadAccumulator()
+        assert acc.get_active_scope("agent-1", 1) == "_default"
+        acc.begin_scope("agent-1", 1, "task-A")
+        assert acc.get_active_scope("agent-1", 1) == "task-A"
+
+    def test_reads_go_into_active_scope(self) -> None:
+        acc = SessionReadAccumulator()
+        acc.begin_scope("agent-1", 1, "task-A")
+        acc.record_read("agent-1", 1, "/a.txt")
+        acc.record_read("agent-1", 1, "/b.txt")
+
+        assert acc.peek("agent-1", 1, scope_id="task-A") == 2
+        assert acc.peek("agent-1", 1, scope_id="_default") == 0
+
+    def test_scope_isolation(self) -> None:
+        """Reads in different scopes are isolated."""
+        acc = SessionReadAccumulator()
+
+        acc.begin_scope("agent-1", 1, "task-A")
+        acc.record_read("agent-1", 1, "/a1.txt")
+        acc.record_read("agent-1", 1, "/a2.txt")
+
+        acc.begin_scope("agent-1", 1, "task-B")
+        acc.record_read("agent-1", 1, "/b1.txt")
+
+        reads_a = acc.consume("agent-1", 1, scope_id="task-A")
+        reads_b = acc.consume("agent-1", 1, scope_id="task-B")
+
+        assert len(reads_a) == 2
+        assert reads_a[0]["path"] == "/a1.txt"
+        assert reads_a[1]["path"] == "/a2.txt"
+        assert len(reads_b) == 1
+        assert reads_b[0]["path"] == "/b1.txt"
+
+    def test_consume_only_clears_target_scope(self) -> None:
+        """Consuming one scope doesn't affect other scopes."""
+        acc = SessionReadAccumulator()
+
+        acc.begin_scope("agent-1", 1, "task-A")
+        acc.record_read("agent-1", 1, "/a.txt")
+        acc.begin_scope("agent-1", 1, "task-B")
+        acc.record_read("agent-1", 1, "/b.txt")
+
+        # Consume task-A only
+        acc.consume("agent-1", 1, scope_id="task-A")
+
+        # task-B should still have its read
+        assert acc.peek("agent-1", 1, scope_id="task-B") == 1
+        reads_b = acc.consume("agent-1", 1, scope_id="task-B")
+        assert len(reads_b) == 1
+
+    def test_read3_write1_write2_scenario(self) -> None:
+        """The key scenario: read 3 → write 1 → write 2.
+
+        With scopes, each write gets its own reads.
+        Without scopes, write 2 gets nothing (old bug).
+        """
+        acc = SessionReadAccumulator()
+
+        # Task 1: read A, B, C → write output1
+        acc.begin_scope("agent-1", 1, "task-1")
+        acc.record_read("agent-1", 1, "/a.csv")
+        acc.record_read("agent-1", 1, "/b.csv")
+        acc.record_read("agent-1", 1, "/c.csv")
+
+        reads_1 = acc.consume("agent-1", 1, scope_id="task-1")
+        assert len(reads_1) == 3
+
+        # Task 2: read D, E → write output2
+        acc.begin_scope("agent-1", 1, "task-2")
+        acc.record_read("agent-1", 1, "/d.csv")
+        acc.record_read("agent-1", 1, "/e.csv")
+
+        reads_2 = acc.consume("agent-1", 1, scope_id="task-2")
+        assert len(reads_2) == 2
+        assert reads_2[0]["path"] == "/d.csv"
+        assert reads_2[1]["path"] == "/e.csv"
+
+    def test_default_scope_backward_compat(self) -> None:
+        """Without begin_scope, reads go into _default — same as old behavior."""
+        acc = SessionReadAccumulator()
+        acc.record_read("agent-1", 1, "/a.txt")
+        acc.record_read("agent-1", 1, "/b.txt")
+
+        # consume() without scope_id uses active scope (which is _default)
+        reads = acc.consume("agent-1", 1)
+        assert len(reads) == 2
+
+    def test_end_scope_consumes_and_removes(self) -> None:
+        acc = SessionReadAccumulator()
+        acc.begin_scope("agent-1", 1, "task-A")
+        acc.record_read("agent-1", 1, "/a.txt")
+
+        reads = acc.end_scope("agent-1", 1, "task-A")
+        assert len(reads) == 1
+
+        # Scope is gone — peek returns 0
+        assert acc.peek("agent-1", 1, scope_id="task-A") == 0
+        # Active scope reverted to default
+        assert acc.get_active_scope("agent-1", 1) == "_default"
+
+    def test_end_scope_nonexistent_returns_empty(self) -> None:
+        acc = SessionReadAccumulator()
+        reads = acc.end_scope("agent-1", 1, "no-such-scope")
+        assert reads == []
+
+    def test_explicit_scope_id_on_record(self) -> None:
+        """record_read with explicit scope_id overrides active scope."""
+        acc = SessionReadAccumulator()
+        acc.begin_scope("agent-1", 1, "task-A")
+
+        # Record into task-B explicitly (even though task-A is active)
+        acc.record_read("agent-1", 1, "/b.txt", scope_id="task-B")
+
+        assert acc.peek("agent-1", 1, scope_id="task-A") == 0
+        assert acc.peek("agent-1", 1, scope_id="task-B") == 1
+
+    def test_reactivate_existing_scope(self) -> None:
+        """begin_scope on existing scope reactivates it (appends, doesn't clear)."""
+        acc = SessionReadAccumulator()
+        acc.begin_scope("agent-1", 1, "task-A")
+        acc.record_read("agent-1", 1, "/first.txt")
+
+        acc.begin_scope("agent-1", 1, "task-B")
+        acc.record_read("agent-1", 1, "/other.txt")
+
+        # Reactivate task-A
+        acc.begin_scope("agent-1", 1, "task-A")
+        acc.record_read("agent-1", 1, "/second.txt")
+
+        reads = acc.consume("agent-1", 1, scope_id="task-A")
+        assert len(reads) == 2
+        assert reads[0]["path"] == "/first.txt"
+        assert reads[1]["path"] == "/second.txt"
+
+    def test_max_entries_shared_across_scopes(self) -> None:
+        """Max entries limit applies across all scopes in a session."""
+        acc = SessionReadAccumulator(max_entries=5)
+        acc.begin_scope("agent-1", 1, "task-A")
+        for i in range(3):
+            acc.record_read("agent-1", 1, f"/a{i}.txt")
+
+        acc.begin_scope("agent-1", 1, "task-B")
+        for i in range(2):
+            acc.record_read("agent-1", 1, f"/b{i}.txt")
+
+        # 6th entry should fail (5 total across both scopes)
+        assert acc.record_read("agent-1", 1, "/overflow.txt") is False


### PR DESCRIPTION
## Summary

Implements agent lineage tracking that records which files an agent read to produce each output file, enabling impact analysis, provenance auditing, and staleness detection. Closes #3417.

## API (8 endpoints)

| Method | Endpoint | Purpose |
|--------|----------|---------|
| `GET` | `/api/v2/lineage/{urn}` | Get upstream inputs for a file |
| `PUT` | `/api/v2/lineage/{urn}` | Explicitly declare lineage |
| `DELETE` | `/api/v2/lineage/{urn}` | Remove lineage |
| `GET` | `/api/v2/lineage/downstream/query` | Impact analysis: what depends on X? |
| `GET` | `/api/v2/lineage/stale/query` | Staleness detection |
| `POST` | `/api/v2/lineage/scope/begin` | Begin named lineage scope |
| `POST` | `/api/v2/lineage/scope/end` | End scope |
| `GET` | `/api/v2/lineage/scope/active` | Get active scope |

## How it works

**Explicit declaration (primary):** Agent calls `PUT /lineage/{urn}` with exact inputs.

**Scoped automatic capture:** Agent calls `POST /scope/begin` → reads are tracked → write auto-attaches lineage. Each scope is isolated per task, solving the "read 3 → write 1 → write 2" problem.

**Registered agents only:** Read accumulation gated on `subject_type="agent"` (API key auth). No default capture without explicit scope.

## Components

| Component | File | Description |
|-----------|------|-------------|
| LineageAspect | `contracts/aspects.py` | Pydantic model, `max_versions=5`, 500-entry cap |
| SessionReadAccumulator | `storage/session_read_accumulator.py` | Scoped in-memory accumulator with TTL, max entries |
| LineageReverseIndexModel | `storage/models/lineage_reverse_index.py` | Denormalized reverse lookup + Alembic migration |
| LineageService | `storage/lineage_service.py` | CRUD, staleness, savepoint atomicity |
| Lineage hook | `factory/_lineage_hook.py` | Post-flush hook, background thread |
| Read instrumentation | `core/nexus_fs.py` | Records agent reads with version/etag |
| REST API | `server/api/v2/routers/lineage.py` | 8 endpoints |
| CLI | `cli/commands/lineage.py` | `nexus lineage upstream/downstream/stale` |
| TUI | `packages/nexus-tui` | Lineage sub-tab in file explorer (press `l`) |
| Demo seed | `cli/commands/demo_data.py` | Lineage entries for plan.md + sample.json |

## TUI Screenshot (tmux capture-pane verified)

```
─── Lineage ───
Agent    coordinator
Op       explicit
Gen      #1

▸ Upstream (3)
  /workspace/demo/notes/architectur… v1
  /workspace/demo/code/example.py    v1
  /workspace/demo/notes/meeting-202… v1
```

## Test plan

- [x] 15 unit tests — LineageAspect model
- [x] 31 unit tests — SessionReadAccumulator (incl. 11 scope tests)
- [x] 18 unit tests — LineageService
- [x] 5 integration tests — lineage hook
- [x] 5 e2e tests — against live PostgreSQL (incl. scoped read→write→read→write)
- [x] 44 existing aspect tests — no regressions
- [x] TUI validated via tmux capture-pane
- [x] Full Docker rebuild + demo seed verified