### PR TITLE
CLI: Create theme.py + migrate 905 bare color tags

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -422,6 +422,7 @@ module = [
     "rich.*",
     "alembic.*",
     "google.cloud.*",
+    "yaml",
 ]
 ignore_missing_imports = true
 

--- a/scripts/check_cli_theme.sh
+++ b/scripts/check_cli_theme.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# check_cli_theme.sh — Enforce CLI theme compliance (Issue #3241).
+#
+# Two checks:
+#   1. No bare color tags in src/nexus/cli/ (all must use nexus.* tokens)
+#   2. All [nexus.xxx] tokens reference one of the 12 defined semantic tokens
+#
+# Usage:
+#   ./scripts/check_cli_theme.sh
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+FAILED=0
+
+# -- Check 1: Bare color tags -------------------------------------------
+# Match [red], [/red], [green], [/green], etc. but NOT inside theme.py itself.
+# Also match style="red", style="green", etc.
+BARE_TAGS=$(grep -rn \
+    --include="*.py" \
+    -E '\[(/?)(red|green|yellow|cyan|magenta|blue)\]|style="(red|green|yellow|cyan|magenta|blue)"' \
+    "$ROOT/src/nexus/cli/" \
+    | grep -v 'theme\.py' \
+    | grep -v '# noqa: theme' \
+    || true)
+
+if [ -n "$BARE_TAGS" ]; then
+    echo "ERROR: Bare color tags found in src/nexus/cli/ (use nexus.* theme tokens instead):"
+    echo "$BARE_TAGS"
+    FAILED=1
+else
+    echo "OK: No bare color tags"
+fi
+
+# -- Check 2: Valid nexus.* tokens --------------------------------------
+# Extract all [nexus.xxx] references and verify they are in the allowed set.
+VALID_TOKENS="nexus.success|nexus.warning|nexus.error|nexus.info|nexus.accent|nexus.muted|nexus.hint|nexus.path|nexus.value|nexus.label|nexus.identity|nexus.reference"
+
+INVALID_TOKENS=$(grep -rn \
+    --include="*.py" \
+    -oE '\[/?nexus\.[a-z_.]+\]' \
+    "$ROOT/src/nexus/cli/" \
+    | grep -vE "\[/?($VALID_TOKENS)\]" \
+    || true)
+
+if [ -n "$INVALID_TOKENS" ]; then
+    echo "ERROR: Invalid nexus.* tokens found (typo?):"
+    echo "$INVALID_TOKENS"
+    FAILED=1
+else
+    echo "OK: All nexus.* tokens are valid"
+fi
+
+# -- Check 3: Bare Console() instantiations -----------------------------
+BARE_CONSOLE=$(grep -rn \
+    --include="*.py" \
+    'Console()' \
+    "$ROOT/src/nexus/cli/" \
+    | grep -v 'theme\.py' \
+    | grep -v 'test_' \
+    || true)
+
+if [ -n "$BARE_CONSOLE" ]; then
+    echo "ERROR: Bare Console() found (use 'from nexus.cli.theme import console' instead):"
+    echo "$BARE_CONSOLE"
+    FAILED=1
+else
+    echo "OK: No bare Console() instances"
+fi
+
+exit $FAILED

--- a/scripts/check_cli_theme.sh
+++ b/scripts/check_cli_theme.sh
@@ -14,14 +14,23 @@ ROOT="$(cd "$(dirname "$0")/.." && pwd)"
 FAILED=0
 
 # -- Check 1: Bare color tags -------------------------------------------
-# Match [red], [/red], [green], [/green], etc. but NOT inside theme.py itself.
-# Also match style="red", style="green", etc.
+# Match bare color names in Rich markup — simple, composite, style attrs, and
+# dict-style color values — but NOT nexus.* tokens and NOT theme.py itself.
+#
+# Catches:
+#   Simple:    [red], [/red], [green], …
+#   Composite: [bold red], [/bold red], [dim yellow], [italic cyan], …
+#   Style attrs: style="red", style="bold cyan", style="dim green", …
+#   Dict values: "pending": "yellow", "status": "green", …
+COLORS="red|green|yellow|cyan|magenta|blue|white"
+MODIFIERS="bold|dim|italic|underline|strike|reverse|blink"
 BARE_TAGS=$(grep -rn \
     --include="*.py" \
-    -E '\[(/?)(red|green|yellow|cyan|magenta|blue)\]|style="(red|green|yellow|cyan|magenta|blue)"' \
+    -E "\[/?(($MODIFIERS) )?($COLORS)\]|style=\"(($MODIFIERS) )?($COLORS)\"|\":\s*\"($COLORS)\"" \
     "$ROOT/src/nexus/cli/" \
     | grep -v 'theme\.py' \
     | grep -v '# noqa: theme' \
+    | grep -vE '\[/?nexus\.' \
     || true)
 
 if [ -n "$BARE_TAGS" ]; then
@@ -33,15 +42,35 @@ else
 fi
 
 # -- Check 2: Valid nexus.* tokens --------------------------------------
-# Extract all [nexus.xxx] references and verify they are in the allowed set.
+# Extract all nexus.xxx references from BOTH bracket markup and style attrs,
+# then verify each is in the allowed set.
+#
+# Contexts matched:
+#   Bracket markup:  [nexus.xxx], [/nexus.xxx]
+#   Style attributes: style="nexus.xxx", header_style="nexus.xxx", etc.
 VALID_TOKENS="nexus.success|nexus.warning|nexus.error|nexus.info|nexus.accent|nexus.table_header|nexus.muted|nexus.hint|nexus.path|nexus.value|nexus.label|nexus.identity|nexus.reference"
 
-INVALID_TOKENS=$(grep -rn \
+# Pass 1: bracket markup  — [nexus.xxx] and [/nexus.xxx]
+INVALID_BRACKET=$(grep -rn \
     --include="*.py" \
     -oE '\[/?nexus\.[a-z_.]+\]' \
     "$ROOT/src/nexus/cli/" \
     | grep -vE "\[/?($VALID_TOKENS)\]" \
     || true)
+
+# Pass 2: style attributes — style="nexus.xxx", header_style="nexus.xxx", etc.
+INVALID_STYLE=$(grep -rn \
+    --include="*.py" \
+    -oE '[a-z_]*style="nexus\.[a-z_.]+"' \
+    "$ROOT/src/nexus/cli/" \
+    | grep -vE "\"($VALID_TOKENS)\"" \
+    || true)
+
+INVALID_TOKENS=""
+[ -n "$INVALID_BRACKET" ] && INVALID_TOKENS="$INVALID_BRACKET"
+if [ -n "$INVALID_STYLE" ]; then
+    [ -n "$INVALID_TOKENS" ] && INVALID_TOKENS="$INVALID_TOKENS"$'\n'"$INVALID_STYLE" || INVALID_TOKENS="$INVALID_STYLE"
+fi
 
 if [ -n "$INVALID_TOKENS" ]; then
     echo "ERROR: Invalid nexus.* tokens found (typo?):"

--- a/scripts/check_cli_theme.sh
+++ b/scripts/check_cli_theme.sh
@@ -23,11 +23,12 @@ FAILED=0
 #   Style attrs: style="red", style="bold cyan", style="dim green", …
 #   Dict values: "pending": "yellow", "status": "green", …
 #   Variable assigns: color = "red", status_style = "green", …
+#   Fallback defaults: .get(key, "white"), …
 COLORS="red|green|yellow|cyan|magenta|blue|white"
 MODIFIERS="bold|dim|italic|underline|strike|reverse|blink"
 BARE_TAGS=$(grep -rn \
     --include="*.py" \
-    -E "\[/?(($MODIFIERS) )?($COLORS)\]|style=\"(($MODIFIERS) )?($COLORS)\"|\":\s*\"($COLORS)\"|= \"($COLORS)\"" \
+    -E "\[/?(($MODIFIERS) )?($COLORS)\]|style=\"(($MODIFIERS) )?($COLORS)\"|\":\s*\"($COLORS)\"|= \"($COLORS)\"|,\s*\"($COLORS)\"\)" \
     "$ROOT/src/nexus/cli/" \
     | grep -v 'theme\.py' \
     | grep -v '# noqa: theme' \

--- a/scripts/check_cli_theme.sh
+++ b/scripts/check_cli_theme.sh
@@ -22,11 +22,12 @@ FAILED=0
 #   Composite: [bold red], [/bold red], [dim yellow], [italic cyan], …
 #   Style attrs: style="red", style="bold cyan", style="dim green", …
 #   Dict values: "pending": "yellow", "status": "green", …
+#   Variable assigns: color = "red", status_style = "green", …
 COLORS="red|green|yellow|cyan|magenta|blue|white"
 MODIFIERS="bold|dim|italic|underline|strike|reverse|blink"
 BARE_TAGS=$(grep -rn \
     --include="*.py" \
-    -E "\[/?(($MODIFIERS) )?($COLORS)\]|style=\"(($MODIFIERS) )?($COLORS)\"|\":\s*\"($COLORS)\"" \
+    -E "\[/?(($MODIFIERS) )?($COLORS)\]|style=\"(($MODIFIERS) )?($COLORS)\"|\":\s*\"($COLORS)\"|= \"($COLORS)\"" \
     "$ROOT/src/nexus/cli/" \
     | grep -v 'theme\.py' \
     | grep -v '# noqa: theme' \

--- a/scripts/check_cli_theme.sh
+++ b/scripts/check_cli_theme.sh
@@ -34,7 +34,7 @@ fi
 
 # -- Check 2: Valid nexus.* tokens --------------------------------------
 # Extract all [nexus.xxx] references and verify they are in the allowed set.
-VALID_TOKENS="nexus.success|nexus.warning|nexus.error|nexus.info|nexus.accent|nexus.muted|nexus.hint|nexus.path|nexus.value|nexus.label|nexus.identity|nexus.reference"
+VALID_TOKENS="nexus.success|nexus.warning|nexus.error|nexus.info|nexus.accent|nexus.table_header|nexus.muted|nexus.hint|nexus.path|nexus.value|nexus.label|nexus.identity|nexus.reference"
 
 INVALID_TOKENS=$(grep -rn \
     --include="*.py" \

--- a/scripts/ci-lint.sh
+++ b/scripts/ci-lint.sh
@@ -85,6 +85,16 @@ run_brick_imports() {
     fi
 }
 
+run_cli_theme() {
+    info "CLI theme compliance check (no bare color tags)"
+    if bash scripts/check_cli_theme.sh; then
+        pass "CLI theme"
+    else
+        fail "CLI theme"
+        return 1
+    fi
+}
+
 run_fix() {
     info "auto-fixing: ruff check --fix + ruff format"
     uv run ruff check . --fix
@@ -110,6 +120,7 @@ run_all() {
     run_file_size   || failed=1
     run_type_ignore || failed=1
     run_brick_imports || failed=1
+    run_cli_theme     || failed=1
 
     echo ""
     if [ "$failed" -eq 0 ]; then

--- a/src/nexus/bricks/rebac/deferred_permission_buffer.py
+++ b/src/nexus/bricks/rebac/deferred_permission_buffer.py
@@ -18,11 +18,12 @@ No WAL or crash recovery needed because:
 """
 
 import logging
+import threading
+import time
+from collections import deque
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy.exc import OperationalError
-
-from nexus.lib.deferred_buffer import DeferredBuffer
 
 if TYPE_CHECKING:
     from nexus.bricks.rebac.cache.pubsub_invalidation import PubSubInvalidation
@@ -32,7 +33,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class DeferredPermissionBuffer(DeferredBuffer):
+class DeferredPermissionBuffer:
     """
     Buffers permission operations for batch flushing.
 
@@ -57,32 +58,85 @@ class DeferredPermissionBuffer(DeferredBuffer):
             max_batch_size: Trigger immediate flush if queue exceeds this size
             max_retries: Max retry attempts before dead-lettering a failed item
         """
-        super().__init__(
-            flush_interval_sec=flush_interval_sec,
-            max_batch_size=max_batch_size,
-            max_retries=max_retries,
-            thread_name="DeferredPermissionBuffer-Flush",
-        )
         self._rebac_manager = rebac_manager
         self._hierarchy_manager = hierarchy_manager
+        self._flush_interval = flush_interval_sec
+        self._max_batch_size = max_batch_size
+        self._max_retries = max_retries
 
-        # Pending operations (thread-safe via base class _lock)
-        from collections import deque
-
+        # Pending operations (thread-safe with lock)
         self._pending_hierarchy: deque[tuple[str, str]] = deque()  # (path, zone_id)
         self._pending_grants: deque[dict[str, Any]] = deque()
+        self._lock = threading.Lock()
 
         # Retry tracking: maps (path, zone_id) -> attempt count for hierarchy,
         # and (subject, relation, object, zone_id) -> attempt count for grants
         self._hierarchy_retry_counts: dict[tuple[str, str], int] = {}
         self._grants_retry_counts: dict[tuple[Any, ...], int] = {}
 
+        # Dead letter queue for permanently failed items
+        self._dead_letter: list[dict[str, Any]] = []
+
         # Pub/Sub for cross-zone flush coordination (Issue #3192)
         self._pubsub: "PubSubInvalidation | None" = None
 
-        # Stats (permission-specific)
+        # Background flush thread
+        self._flush_thread: threading.Thread | None = None
+        self._shutdown = threading.Event()
+        self._started = False
+
+        # Stats
         self._total_hierarchy_flushed = 0
         self._total_grants_flushed = 0
+        self._flush_count = 0
+
+    async def start(self) -> None:
+        """Start the background flush worker thread (PersistentService protocol)."""
+        self._start_sync()
+
+    async def stop(self) -> None:
+        """Stop the buffer and flush remaining items (PersistentService protocol)."""
+        self._stop_sync()
+
+    def _start_sync(self) -> None:
+        """Sync start — spawns background flush thread."""
+        if self._started:
+            return
+
+        self._shutdown.clear()
+        self._flush_thread = threading.Thread(
+            target=self._flush_loop,
+            name="DeferredPermissionBuffer-Flush",
+            daemon=True,
+        )
+        self._flush_thread.start()
+        self._started = True
+        logger.info(
+            f"DeferredPermissionBuffer started (interval={self._flush_interval}s, "
+            f"max_batch={self._max_batch_size})"
+        )
+
+    def _stop_sync(self, timeout: float = 5.0) -> None:
+        """Sync stop — joins thread and flushes remaining items."""
+        if not self._started:
+            return
+
+        logger.info("DeferredPermissionBuffer stopping...")
+        self._shutdown.set()
+
+        if self._flush_thread and self._flush_thread.is_alive():
+            self._flush_thread.join(timeout=timeout)
+
+        # Final flush
+        self._flush_sync(catch_unexpected=False)
+
+        self._started = False
+        logger.info(
+            f"DeferredPermissionBuffer stopped. Stats: "
+            f"hierarchy={self._total_hierarchy_flushed}, "
+            f"grants={self._total_grants_flushed}, "
+            f"flushes={self._flush_count}"
+        )
 
     def set_pubsub(self, pubsub: "PubSubInvalidation") -> None:
         """Set Pub/Sub for cross-zone flush coordination."""
@@ -100,7 +154,8 @@ class DeferredPermissionBuffer(DeferredBuffer):
             queue_size = len(self._pending_hierarchy) + len(self._pending_grants)
 
         # Trigger immediate flush if at capacity
-        self._check_batch_overflow(queue_size)
+        if queue_size >= self._max_batch_size:
+            self._trigger_flush()
 
     def queue_owner_grant(
         self,
@@ -127,32 +182,83 @@ class DeferredPermissionBuffer(DeferredBuffer):
             queue_size = len(self._pending_hierarchy) + len(self._pending_grants)
 
         # Trigger immediate flush if at capacity
-        self._check_batch_overflow(queue_size)
+        if queue_size >= self._max_batch_size:
+            self._trigger_flush()
 
-    # ── DeferredBuffer abstract method implementations ──
+    def flush(self) -> None:
+        """Synchronously flush all pending operations.
 
-    def _has_items(self) -> bool:
-        return bool(self._pending_hierarchy) or bool(self._pending_grants)
+        Call this when you need to ensure all permissions are persisted,
+        e.g., before a critical read or during graceful shutdown.
+        """
+        self._flush_sync(catch_unexpected=False)
 
-    def _drain_items(self) -> list[Any]:
-        """Drain both queues and return as a combined structure."""
-        hierarchy_batch = list(self._pending_hierarchy)
-        self._pending_hierarchy.clear()
-        grants_batch = list(self._pending_grants)
-        self._pending_grants.clear()
-        return [hierarchy_batch, grants_batch]
+    def get_stats(self) -> dict[str, Any]:
+        """Get buffer statistics.
 
-    def _flush_items(self, items: list[Any], *, catch_unexpected: bool) -> int:
-        """Flush hierarchy and grant batches."""
-        hierarchy_batch: list[tuple[str, str]] = items[0]
-        grants_batch: list[dict[str, Any]] = items[1]
+        Returns:
+            Dict with queue sizes and flush counts
+        """
+        with self._lock:
+            pending_hierarchy = len(self._pending_hierarchy)
+            pending_grants = len(self._pending_grants)
 
+        return {
+            "pending_hierarchy": pending_hierarchy,
+            "pending_grants": pending_grants,
+            "total_hierarchy_flushed": self._total_hierarchy_flushed,
+            "total_grants_flushed": self._total_grants_flushed,
+            "flush_count": self._flush_count,
+            "dead_letter_count": len(self._dead_letter),
+        }
+
+    def get_dead_letter(self) -> list[dict[str, Any]]:
+        """Return a copy of the dead-letter queue for inspection.
+
+        Returns:
+            List of dicts, each containing 'type', 'item', 'error', and 'retries'.
+        """
+        with self._lock:
+            return list(self._dead_letter)
+
+    def _trigger_flush(self) -> None:
+        """Trigger an immediate flush (called when batch size exceeded)."""
+        # For now, just let the background thread handle it
+        # The short flush interval (100ms) means we won't wait long
+        pass
+
+    def _flush_loop(self) -> None:
+        """Background loop that flushes periodically."""
+        while not self._shutdown.is_set():
+            # Wait for shutdown signal or flush interval
+            self._shutdown.wait(timeout=self._flush_interval)
+
+            if not self._shutdown.is_set():
+                try:
+                    self._flush_sync(catch_unexpected=True)
+                except Exception as e:  # fail-safe: background flush must not crash thread
+                    logger.error(f"DeferredPermissionBuffer flush error: {e}")
+
+    def _flush_sync(self, *, catch_unexpected: bool = False) -> None:
+        """Flush all pending operations using batch APIs."""
         retryable_errors: tuple[type[BaseException], ...]
         if catch_unexpected:
             retryable_errors = (Exception,)
         else:
             retryable_errors = (OperationalError, TimeoutError, RuntimeError)
 
+        # Atomically drain queues
+        with self._lock:
+            if not self._pending_hierarchy and not self._pending_grants:
+                return
+
+            hierarchy_batch = list(self._pending_hierarchy)
+            self._pending_hierarchy.clear()
+
+            grants_batch = list(self._pending_grants)
+            self._pending_grants.clear()
+
+        start_time = time.perf_counter()
         hierarchy_count = 0
         grants_count = 0
 
@@ -176,7 +282,38 @@ class DeferredPermissionBuffer(DeferredBuffer):
                 for item in hierarchy_batch:
                     self._hierarchy_retry_counts.pop(item, None)
             except retryable_errors as e:
-                self._requeue_hierarchy(hierarchy_batch, e)
+                # Background flushes should re-queue unexpected manager errors
+                # instead of dropping buffered permission state.
+                # Re-queue with retry tracking; dead-letter items that exceed max_retries
+                requeue: list[tuple[str, str]] = []
+                for item in hierarchy_batch:
+                    key = item  # (path, zone_id)
+                    count = self._hierarchy_retry_counts.get(key, 0) + 1
+                    if count >= self._max_retries:
+                        logger.error(
+                            f"Hierarchy item dead-lettered after {count} retries: "
+                            f"path={item[0]}, zone={item[1]}, error={e}"
+                        )
+                        with self._lock:
+                            self._dead_letter.append(
+                                {
+                                    "type": "hierarchy",
+                                    "item": {"path": item[0], "zone_id": item[1]},
+                                    "error": str(e),
+                                    "retries": count,
+                                }
+                            )
+                        self._hierarchy_retry_counts.pop(key, None)
+                    else:
+                        logger.warning(
+                            f"Hierarchy flush failed (attempt {count}/{self._max_retries}), "
+                            f"re-queueing: path={item[0]}, zone={item[1]}, error={e}"
+                        )
+                        self._hierarchy_retry_counts[key] = count
+                        requeue.append(item)
+                if requeue:
+                    with self._lock:
+                        self._pending_hierarchy.extend(requeue)
 
         # Batch owner grants
         if grants_batch and self._rebac_manager:
@@ -194,116 +331,70 @@ class DeferredPermissionBuffer(DeferredBuffer):
                     )
                     self._grants_retry_counts.pop(gkey, None)
             except retryable_errors as e:
-                self._requeue_grants(grants_batch, e)
-
-        # Pub/Sub: notify other zones about flushed permissions (Issue #3192)
-        if (hierarchy_count > 0 or grants_count > 0) and self._pubsub:
-            zones_flushed = set()
-            for _path, zone_id in hierarchy_batch:
-                zones_flushed.add(zone_id)
-            for grant in grants_batch:
-                zones_flushed.add(grant.get("zone_id", ""))
-            for zone_id in zones_flushed:
-                if zone_id:
-                    self._pubsub.publish_invalidation(
-                        zone_id=zone_id,
-                        layer="deferred_flush",
-                        payload={
-                            "hierarchy_count": hierarchy_count,
-                            "grants_count": grants_count,
-                        },
+                # Background flushes should re-queue unexpected manager errors
+                # instead of dropping buffered permission state.
+                # Re-queue with retry tracking; dead-letter items that exceed max_retries
+                requeue_grants: list[dict[str, Any]] = []
+                for grant in grants_batch:
+                    gkey = (
+                        grant["subject"],
+                        grant["relation"],
+                        grant["object"],
+                        grant["zone_id"],
                     )
+                    count = self._grants_retry_counts.get(gkey, 0) + 1
+                    if count >= self._max_retries:
+                        logger.error(
+                            f"Grant item dead-lettered after {count} retries: "
+                            f"subject={grant['subject']}, object={grant['object']}, error={e}"
+                        )
+                        with self._lock:
+                            self._dead_letter.append(
+                                {
+                                    "type": "grant",
+                                    "item": grant,
+                                    "error": str(e),
+                                    "retries": count,
+                                }
+                            )
+                        self._grants_retry_counts.pop(gkey, None)
+                    else:
+                        logger.warning(
+                            f"Grant flush failed (attempt {count}/{self._max_retries}), "
+                            f"re-queueing: subject={grant['subject']}, "
+                            f"object={grant['object']}, error={e}"
+                        )
+                        self._grants_retry_counts[gkey] = count
+                        requeue_grants.append(grant)
+                if requeue_grants:
+                    with self._lock:
+                        self._pending_grants.extend(requeue_grants)
 
-        return hierarchy_count + grants_count
-
-    def _get_item_stats(self) -> dict[str, Any]:
-        with self._lock:
-            pending_hierarchy = len(self._pending_hierarchy)
-            pending_grants = len(self._pending_grants)
-        return {
-            "pending_hierarchy": pending_hierarchy,
-            "pending_grants": pending_grants,
-            "total_hierarchy_flushed": self._total_hierarchy_flushed,
-            "total_grants_flushed": self._total_grants_flushed,
-        }
-
-    # ── Retry helpers ──
-
-    def _requeue_hierarchy(
-        self, hierarchy_batch: list[tuple[str, str]], error: BaseException
-    ) -> None:
-        """Re-queue hierarchy items with retry tracking, dead-letter on max retries."""
-        requeue: list[tuple[str, str]] = []
-        for item in hierarchy_batch:
-            key = item  # (path, zone_id)
-            count = self._hierarchy_retry_counts.get(key, 0) + 1
-            if count >= self._max_retries:
-                logger.error(
-                    "Hierarchy item dead-lettered after %d retries: path=%s, zone=%s, error=%s",
-                    count,
-                    item[0],
-                    item[1],
-                    error,
-                )
-                self._dead_letter_item(
-                    "hierarchy",
-                    {"path": item[0], "zone_id": item[1]},
-                    error,
-                    count,
-                )
-                self._hierarchy_retry_counts.pop(key, None)
-            else:
-                logger.warning(
-                    "Hierarchy flush failed (attempt %d/%d), "
-                    "re-queueing: path=%s, zone=%s, error=%s",
-                    count,
-                    self._max_retries,
-                    item[0],
-                    item[1],
-                    error,
-                )
-                self._hierarchy_retry_counts[key] = count
-                requeue.append(item)
-        if requeue:
-            with self._lock:
-                self._pending_hierarchy.extend(requeue)
-
-    def _requeue_grants(self, grants_batch: list[dict[str, Any]], error: BaseException) -> None:
-        """Re-queue grant items with retry tracking, dead-letter on max retries."""
-        requeue_grants: list[dict[str, Any]] = []
-        for grant in grants_batch:
-            gkey = (
-                grant["subject"],
-                grant["relation"],
-                grant["object"],
-                grant["zone_id"],
+        if hierarchy_count > 0 or grants_count > 0:
+            elapsed_ms = (time.perf_counter() - start_time) * 1000
+            self._flush_count += 1
+            logger.debug(
+                f"[DEFERRED-FLUSH] hierarchy={hierarchy_count}, "
+                f"grants={grants_count}, elapsed={elapsed_ms:.1f}ms"
             )
-            count = self._grants_retry_counts.get(gkey, 0) + 1
-            if count >= self._max_retries:
-                logger.error(
-                    "Grant item dead-lettered after %d retries: subject=%s, object=%s, error=%s",
-                    count,
-                    grant["subject"],
-                    grant["object"],
-                    error,
-                )
-                self._dead_letter_item("grant", grant, error, count)
-                self._grants_retry_counts.pop(gkey, None)
-            else:
-                logger.warning(
-                    "Grant flush failed (attempt %d/%d), "
-                    "re-queueing: subject=%s, object=%s, error=%s",
-                    count,
-                    self._max_retries,
-                    grant["subject"],
-                    grant["object"],
-                    error,
-                )
-                self._grants_retry_counts[gkey] = count
-                requeue_grants.append(grant)
-        if requeue_grants:
-            with self._lock:
-                self._pending_grants.extend(requeue_grants)
+
+            # Pub/Sub: notify other zones about flushed permissions (Issue #3192)
+            if self._pubsub:
+                zones_flushed = set()
+                for _path, zone_id in hierarchy_batch:
+                    zones_flushed.add(zone_id)
+                for grant in grants_batch:
+                    zones_flushed.add(grant.get("zone_id", ""))
+                for zone_id in zones_flushed:
+                    if zone_id:
+                        self._pubsub.publish_invalidation(
+                            zone_id=zone_id,
+                            layer="deferred_flush",
+                            payload={
+                                "hierarchy_count": hierarchy_count,
+                                "grants_count": grants_count,
+                            },
+                        )
 
 
 # Singleton instance for easy access

--- a/src/nexus/bricks/rebac/deferred_permission_buffer.py
+++ b/src/nexus/bricks/rebac/deferred_permission_buffer.py
@@ -18,12 +18,11 @@ No WAL or crash recovery needed because:
 """
 
 import logging
-import threading
-import time
-from collections import deque
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy.exc import OperationalError
+
+from nexus.lib.deferred_buffer import DeferredBuffer
 
 if TYPE_CHECKING:
     from nexus.bricks.rebac.cache.pubsub_invalidation import PubSubInvalidation
@@ -33,7 +32,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
-class DeferredPermissionBuffer:
+class DeferredPermissionBuffer(DeferredBuffer):
     """
     Buffers permission operations for batch flushing.
 
@@ -58,85 +57,32 @@ class DeferredPermissionBuffer:
             max_batch_size: Trigger immediate flush if queue exceeds this size
             max_retries: Max retry attempts before dead-lettering a failed item
         """
+        super().__init__(
+            flush_interval_sec=flush_interval_sec,
+            max_batch_size=max_batch_size,
+            max_retries=max_retries,
+            thread_name="DeferredPermissionBuffer-Flush",
+        )
         self._rebac_manager = rebac_manager
         self._hierarchy_manager = hierarchy_manager
-        self._flush_interval = flush_interval_sec
-        self._max_batch_size = max_batch_size
-        self._max_retries = max_retries
 
-        # Pending operations (thread-safe with lock)
+        # Pending operations (thread-safe via base class _lock)
+        from collections import deque
+
         self._pending_hierarchy: deque[tuple[str, str]] = deque()  # (path, zone_id)
         self._pending_grants: deque[dict[str, Any]] = deque()
-        self._lock = threading.Lock()
 
         # Retry tracking: maps (path, zone_id) -> attempt count for hierarchy,
         # and (subject, relation, object, zone_id) -> attempt count for grants
         self._hierarchy_retry_counts: dict[tuple[str, str], int] = {}
         self._grants_retry_counts: dict[tuple[Any, ...], int] = {}
 
-        # Dead letter queue for permanently failed items
-        self._dead_letter: list[dict[str, Any]] = []
-
         # Pub/Sub for cross-zone flush coordination (Issue #3192)
         self._pubsub: "PubSubInvalidation | None" = None
 
-        # Background flush thread
-        self._flush_thread: threading.Thread | None = None
-        self._shutdown = threading.Event()
-        self._started = False
-
-        # Stats
+        # Stats (permission-specific)
         self._total_hierarchy_flushed = 0
         self._total_grants_flushed = 0
-        self._flush_count = 0
-
-    async def start(self) -> None:
-        """Start the background flush worker thread (PersistentService protocol)."""
-        self._start_sync()
-
-    async def stop(self) -> None:
-        """Stop the buffer and flush remaining items (PersistentService protocol)."""
-        self._stop_sync()
-
-    def _start_sync(self) -> None:
-        """Sync start — spawns background flush thread."""
-        if self._started:
-            return
-
-        self._shutdown.clear()
-        self._flush_thread = threading.Thread(
-            target=self._flush_loop,
-            name="DeferredPermissionBuffer-Flush",
-            daemon=True,
-        )
-        self._flush_thread.start()
-        self._started = True
-        logger.info(
-            f"DeferredPermissionBuffer started (interval={self._flush_interval}s, "
-            f"max_batch={self._max_batch_size})"
-        )
-
-    def _stop_sync(self, timeout: float = 5.0) -> None:
-        """Sync stop — joins thread and flushes remaining items."""
-        if not self._started:
-            return
-
-        logger.info("DeferredPermissionBuffer stopping...")
-        self._shutdown.set()
-
-        if self._flush_thread and self._flush_thread.is_alive():
-            self._flush_thread.join(timeout=timeout)
-
-        # Final flush
-        self._flush_sync(catch_unexpected=False)
-
-        self._started = False
-        logger.info(
-            f"DeferredPermissionBuffer stopped. Stats: "
-            f"hierarchy={self._total_hierarchy_flushed}, "
-            f"grants={self._total_grants_flushed}, "
-            f"flushes={self._flush_count}"
-        )
 
     def set_pubsub(self, pubsub: "PubSubInvalidation") -> None:
         """Set Pub/Sub for cross-zone flush coordination."""
@@ -154,8 +100,7 @@ class DeferredPermissionBuffer:
             queue_size = len(self._pending_hierarchy) + len(self._pending_grants)
 
         # Trigger immediate flush if at capacity
-        if queue_size >= self._max_batch_size:
-            self._trigger_flush()
+        self._check_batch_overflow(queue_size)
 
     def queue_owner_grant(
         self,
@@ -182,83 +127,32 @@ class DeferredPermissionBuffer:
             queue_size = len(self._pending_hierarchy) + len(self._pending_grants)
 
         # Trigger immediate flush if at capacity
-        if queue_size >= self._max_batch_size:
-            self._trigger_flush()
+        self._check_batch_overflow(queue_size)
 
-    def flush(self) -> None:
-        """Synchronously flush all pending operations.
+    # ── DeferredBuffer abstract method implementations ──
 
-        Call this when you need to ensure all permissions are persisted,
-        e.g., before a critical read or during graceful shutdown.
-        """
-        self._flush_sync(catch_unexpected=False)
+    def _has_items(self) -> bool:
+        return bool(self._pending_hierarchy) or bool(self._pending_grants)
 
-    def get_stats(self) -> dict[str, Any]:
-        """Get buffer statistics.
+    def _drain_items(self) -> list[Any]:
+        """Drain both queues and return as a combined structure."""
+        hierarchy_batch = list(self._pending_hierarchy)
+        self._pending_hierarchy.clear()
+        grants_batch = list(self._pending_grants)
+        self._pending_grants.clear()
+        return [hierarchy_batch, grants_batch]
 
-        Returns:
-            Dict with queue sizes and flush counts
-        """
-        with self._lock:
-            pending_hierarchy = len(self._pending_hierarchy)
-            pending_grants = len(self._pending_grants)
+    def _flush_items(self, items: list[Any], *, catch_unexpected: bool) -> int:
+        """Flush hierarchy and grant batches."""
+        hierarchy_batch: list[tuple[str, str]] = items[0]
+        grants_batch: list[dict[str, Any]] = items[1]
 
-        return {
-            "pending_hierarchy": pending_hierarchy,
-            "pending_grants": pending_grants,
-            "total_hierarchy_flushed": self._total_hierarchy_flushed,
-            "total_grants_flushed": self._total_grants_flushed,
-            "flush_count": self._flush_count,
-            "dead_letter_count": len(self._dead_letter),
-        }
-
-    def get_dead_letter(self) -> list[dict[str, Any]]:
-        """Return a copy of the dead-letter queue for inspection.
-
-        Returns:
-            List of dicts, each containing 'type', 'item', 'error', and 'retries'.
-        """
-        with self._lock:
-            return list(self._dead_letter)
-
-    def _trigger_flush(self) -> None:
-        """Trigger an immediate flush (called when batch size exceeded)."""
-        # For now, just let the background thread handle it
-        # The short flush interval (100ms) means we won't wait long
-        pass
-
-    def _flush_loop(self) -> None:
-        """Background loop that flushes periodically."""
-        while not self._shutdown.is_set():
-            # Wait for shutdown signal or flush interval
-            self._shutdown.wait(timeout=self._flush_interval)
-
-            if not self._shutdown.is_set():
-                try:
-                    self._flush_sync(catch_unexpected=True)
-                except Exception as e:  # fail-safe: background flush must not crash thread
-                    logger.error(f"DeferredPermissionBuffer flush error: {e}")
-
-    def _flush_sync(self, *, catch_unexpected: bool = False) -> None:
-        """Flush all pending operations using batch APIs."""
         retryable_errors: tuple[type[BaseException], ...]
         if catch_unexpected:
             retryable_errors = (Exception,)
         else:
             retryable_errors = (OperationalError, TimeoutError, RuntimeError)
 
-        # Atomically drain queues
-        with self._lock:
-            if not self._pending_hierarchy and not self._pending_grants:
-                return
-
-            hierarchy_batch = list(self._pending_hierarchy)
-            self._pending_hierarchy.clear()
-
-            grants_batch = list(self._pending_grants)
-            self._pending_grants.clear()
-
-        start_time = time.perf_counter()
         hierarchy_count = 0
         grants_count = 0
 
@@ -282,38 +176,7 @@ class DeferredPermissionBuffer:
                 for item in hierarchy_batch:
                     self._hierarchy_retry_counts.pop(item, None)
             except retryable_errors as e:
-                # Background flushes should re-queue unexpected manager errors
-                # instead of dropping buffered permission state.
-                # Re-queue with retry tracking; dead-letter items that exceed max_retries
-                requeue: list[tuple[str, str]] = []
-                for item in hierarchy_batch:
-                    key = item  # (path, zone_id)
-                    count = self._hierarchy_retry_counts.get(key, 0) + 1
-                    if count >= self._max_retries:
-                        logger.error(
-                            f"Hierarchy item dead-lettered after {count} retries: "
-                            f"path={item[0]}, zone={item[1]}, error={e}"
-                        )
-                        with self._lock:
-                            self._dead_letter.append(
-                                {
-                                    "type": "hierarchy",
-                                    "item": {"path": item[0], "zone_id": item[1]},
-                                    "error": str(e),
-                                    "retries": count,
-                                }
-                            )
-                        self._hierarchy_retry_counts.pop(key, None)
-                    else:
-                        logger.warning(
-                            f"Hierarchy flush failed (attempt {count}/{self._max_retries}), "
-                            f"re-queueing: path={item[0]}, zone={item[1]}, error={e}"
-                        )
-                        self._hierarchy_retry_counts[key] = count
-                        requeue.append(item)
-                if requeue:
-                    with self._lock:
-                        self._pending_hierarchy.extend(requeue)
+                self._requeue_hierarchy(hierarchy_batch, e)
 
         # Batch owner grants
         if grants_batch and self._rebac_manager:
@@ -331,70 +194,116 @@ class DeferredPermissionBuffer:
                     )
                     self._grants_retry_counts.pop(gkey, None)
             except retryable_errors as e:
-                # Background flushes should re-queue unexpected manager errors
-                # instead of dropping buffered permission state.
-                # Re-queue with retry tracking; dead-letter items that exceed max_retries
-                requeue_grants: list[dict[str, Any]] = []
-                for grant in grants_batch:
-                    gkey = (
-                        grant["subject"],
-                        grant["relation"],
-                        grant["object"],
-                        grant["zone_id"],
+                self._requeue_grants(grants_batch, e)
+
+        # Pub/Sub: notify other zones about flushed permissions (Issue #3192)
+        if (hierarchy_count > 0 or grants_count > 0) and self._pubsub:
+            zones_flushed = set()
+            for _path, zone_id in hierarchy_batch:
+                zones_flushed.add(zone_id)
+            for grant in grants_batch:
+                zones_flushed.add(grant.get("zone_id", ""))
+            for zone_id in zones_flushed:
+                if zone_id:
+                    self._pubsub.publish_invalidation(
+                        zone_id=zone_id,
+                        layer="deferred_flush",
+                        payload={
+                            "hierarchy_count": hierarchy_count,
+                            "grants_count": grants_count,
+                        },
                     )
-                    count = self._grants_retry_counts.get(gkey, 0) + 1
-                    if count >= self._max_retries:
-                        logger.error(
-                            f"Grant item dead-lettered after {count} retries: "
-                            f"subject={grant['subject']}, object={grant['object']}, error={e}"
-                        )
-                        with self._lock:
-                            self._dead_letter.append(
-                                {
-                                    "type": "grant",
-                                    "item": grant,
-                                    "error": str(e),
-                                    "retries": count,
-                                }
-                            )
-                        self._grants_retry_counts.pop(gkey, None)
-                    else:
-                        logger.warning(
-                            f"Grant flush failed (attempt {count}/{self._max_retries}), "
-                            f"re-queueing: subject={grant['subject']}, "
-                            f"object={grant['object']}, error={e}"
-                        )
-                        self._grants_retry_counts[gkey] = count
-                        requeue_grants.append(grant)
-                if requeue_grants:
-                    with self._lock:
-                        self._pending_grants.extend(requeue_grants)
 
-        if hierarchy_count > 0 or grants_count > 0:
-            elapsed_ms = (time.perf_counter() - start_time) * 1000
-            self._flush_count += 1
-            logger.debug(
-                f"[DEFERRED-FLUSH] hierarchy={hierarchy_count}, "
-                f"grants={grants_count}, elapsed={elapsed_ms:.1f}ms"
+        return hierarchy_count + grants_count
+
+    def _get_item_stats(self) -> dict[str, Any]:
+        with self._lock:
+            pending_hierarchy = len(self._pending_hierarchy)
+            pending_grants = len(self._pending_grants)
+        return {
+            "pending_hierarchy": pending_hierarchy,
+            "pending_grants": pending_grants,
+            "total_hierarchy_flushed": self._total_hierarchy_flushed,
+            "total_grants_flushed": self._total_grants_flushed,
+        }
+
+    # ── Retry helpers ──
+
+    def _requeue_hierarchy(
+        self, hierarchy_batch: list[tuple[str, str]], error: BaseException
+    ) -> None:
+        """Re-queue hierarchy items with retry tracking, dead-letter on max retries."""
+        requeue: list[tuple[str, str]] = []
+        for item in hierarchy_batch:
+            key = item  # (path, zone_id)
+            count = self._hierarchy_retry_counts.get(key, 0) + 1
+            if count >= self._max_retries:
+                logger.error(
+                    "Hierarchy item dead-lettered after %d retries: path=%s, zone=%s, error=%s",
+                    count,
+                    item[0],
+                    item[1],
+                    error,
+                )
+                self._dead_letter_item(
+                    "hierarchy",
+                    {"path": item[0], "zone_id": item[1]},
+                    error,
+                    count,
+                )
+                self._hierarchy_retry_counts.pop(key, None)
+            else:
+                logger.warning(
+                    "Hierarchy flush failed (attempt %d/%d), "
+                    "re-queueing: path=%s, zone=%s, error=%s",
+                    count,
+                    self._max_retries,
+                    item[0],
+                    item[1],
+                    error,
+                )
+                self._hierarchy_retry_counts[key] = count
+                requeue.append(item)
+        if requeue:
+            with self._lock:
+                self._pending_hierarchy.extend(requeue)
+
+    def _requeue_grants(self, grants_batch: list[dict[str, Any]], error: BaseException) -> None:
+        """Re-queue grant items with retry tracking, dead-letter on max retries."""
+        requeue_grants: list[dict[str, Any]] = []
+        for grant in grants_batch:
+            gkey = (
+                grant["subject"],
+                grant["relation"],
+                grant["object"],
+                grant["zone_id"],
             )
-
-            # Pub/Sub: notify other zones about flushed permissions (Issue #3192)
-            if self._pubsub:
-                zones_flushed = set()
-                for _path, zone_id in hierarchy_batch:
-                    zones_flushed.add(zone_id)
-                for grant in grants_batch:
-                    zones_flushed.add(grant.get("zone_id", ""))
-                for zone_id in zones_flushed:
-                    if zone_id:
-                        self._pubsub.publish_invalidation(
-                            zone_id=zone_id,
-                            layer="deferred_flush",
-                            payload={
-                                "hierarchy_count": hierarchy_count,
-                                "grants_count": grants_count,
-                            },
-                        )
+            count = self._grants_retry_counts.get(gkey, 0) + 1
+            if count >= self._max_retries:
+                logger.error(
+                    "Grant item dead-lettered after %d retries: subject=%s, object=%s, error=%s",
+                    count,
+                    grant["subject"],
+                    grant["object"],
+                    error,
+                )
+                self._dead_letter_item("grant", grant, error, count)
+                self._grants_retry_counts.pop(gkey, None)
+            else:
+                logger.warning(
+                    "Grant flush failed (attempt %d/%d), "
+                    "re-queueing: subject=%s, object=%s, error=%s",
+                    count,
+                    self._max_retries,
+                    grant["subject"],
+                    grant["object"],
+                    error,
+                )
+                self._grants_retry_counts[gkey] = count
+                requeue_grants.append(grant)
+        if requeue_grants:
+            with self._lock:
+                self._pending_grants.extend(requeue_grants)
 
 
 # Singleton instance for easy access

--- a/src/nexus/cli/commands/acp_cli.py
+++ b/src/nexus/cli/commands/acp_cli.py
@@ -11,12 +11,10 @@ import re
 from typing import Any
 
 import click
-from rich.console import Console
 from rich.table import Table
 
+from nexus.cli.theme import console
 from nexus.cli.utils import add_backend_options, get_filesystem, handle_error
-
-console = Console()
 
 
 def _parse_skill_md(path: str) -> dict:
@@ -114,7 +112,7 @@ async def _async_call_agent(
         nx: Any = await get_filesystem(remote_url, remote_api_key)
         svc = nx.service("acp_rpc")
         if svc is None:
-            console.print("[red]ACP service not available[/red]")
+            console.print("[nexus.error]ACP service not available[/nexus.error]")
             nx.close()
             return
 
@@ -143,13 +141,15 @@ async def _async_call_agent(
                 if meta.get("cost_usd"):
                     parts.append(f"cost=${meta['cost_usd']:.4f}")
                 if parts:
-                    console.print(f"\n[dim]({', '.join(parts)})[/dim]")
+                    console.print(f"\n[nexus.muted]({', '.join(parts)})[/nexus.muted]")
         else:
-            console.print(f"[red]Agent failed (exit_code={result.get('exit_code')})[/red]")
+            console.print(
+                f"[nexus.error]Agent failed (exit_code={result.get('exit_code')})[/nexus.error]"
+            )
             if result.get("stderr"):
-                console.print(f"[dim]{result['stderr']}[/dim]")
+                console.print(f"[nexus.muted]{result['stderr']}[/nexus.muted]")
             if result.get("timed_out"):
-                console.print("[yellow]Agent timed out[/yellow]")
+                console.print("[nexus.warning]Agent timed out[/nexus.warning]")
 
         nx.close()
     except Exception as e:
@@ -180,22 +180,22 @@ async def _async_list_agents(
         nx: Any = await get_filesystem(remote_url, remote_api_key)
         svc = nx.service("acp_rpc")
         if svc is None:
-            console.print("[red]ACP service not available[/red]")
+            console.print("[nexus.error]ACP service not available[/nexus.error]")
             nx.close()
             return
 
         agents = svc.acp_list_agents()
 
         if not agents:
-            console.print("[yellow]No agents configured[/yellow]")
+            console.print("[nexus.warning]No agents configured[/nexus.warning]")
             nx.close()
             return
 
         table = Table(title="ACP Agents")
-        table.add_column("Agent ID", style="cyan")
-        table.add_column("Name", style="green")
-        table.add_column("Command", style="dim")
-        table.add_column("Enabled", style="dim")
+        table.add_column("Agent ID", style="nexus.value")
+        table.add_column("Name", style="nexus.success")
+        table.add_column("Command", style="nexus.muted")
+        table.add_column("Enabled", style="nexus.muted")
 
         for agent in agents:
             table.add_row(
@@ -235,22 +235,22 @@ async def _async_list_processes(
         nx: Any = await get_filesystem(remote_url, remote_api_key)
         svc = nx.service("acp_rpc")
         if svc is None:
-            console.print("[red]ACP service not available[/red]")
+            console.print("[nexus.error]ACP service not available[/nexus.error]")
             nx.close()
             return
 
         procs = svc.acp_list_processes()
 
         if not procs:
-            console.print("[yellow]No ACP processes[/yellow]")
+            console.print("[nexus.warning]No ACP processes[/nexus.warning]")
             nx.close()
             return
 
         table = Table(title="ACP Processes")
-        table.add_column("PID", style="cyan")
-        table.add_column("Name", style="green")
-        table.add_column("State", style="yellow")
-        table.add_column("Owner", style="dim")
+        table.add_column("PID", style="nexus.value")
+        table.add_column("Name", style="nexus.success")
+        table.add_column("State", style="nexus.warning")
+        table.add_column("Owner", style="nexus.muted")
 
         for p in procs:
             table.add_row(
@@ -294,27 +294,27 @@ async def _async_history(
         nx: Any = await get_filesystem(remote_url, remote_api_key)
         svc = nx.service("acp_rpc")
         if svc is None:
-            console.print("[red]ACP service not available[/red]")
+            console.print("[nexus.error]ACP service not available[/nexus.error]")
             nx.close()
             return
 
         entries = svc.acp_history(limit=limit)
 
         if not entries:
-            console.print("[yellow]No call history[/yellow]")
+            console.print("[nexus.warning]No call history[/nexus.warning]")
             nx.close()
             return
 
         table = Table(title="ACP Call History")
-        table.add_column("PID", style="cyan", no_wrap=True)
-        table.add_column("Agent", style="green")
-        table.add_column("Session", style="dim", no_wrap=True)
-        table.add_column("Exit", style="dim")
-        table.add_column("Prompt", style="yellow", max_width=40)
+        table.add_column("PID", style="nexus.value", no_wrap=True)
+        table.add_column("Agent", style="nexus.success")
+        table.add_column("Session", style="nexus.muted", no_wrap=True)
+        table.add_column("Exit", style="nexus.muted")
+        table.add_column("Prompt", style="nexus.warning", max_width=40)
         table.add_column("Response", style="white", max_width=40)
-        table.add_column("Model", style="dim")
-        table.add_column("Tokens", style="dim")
-        table.add_column("Cost", style="dim")
+        table.add_column("Model", style="nexus.muted")
+        table.add_column("Tokens", style="nexus.muted")
+        table.add_column("Cost", style="nexus.muted")
 
         for entry in entries:
             meta = entry.get("metadata", {})
@@ -383,13 +383,13 @@ async def _async_kill_process(
         nx: Any = await get_filesystem(remote_url, remote_api_key)
         svc = nx.service("acp_rpc")
         if svc is None:
-            console.print("[red]ACP service not available[/red]")
+            console.print("[nexus.error]ACP service not available[/nexus.error]")
             nx.close()
             return
 
         result = svc.acp_kill(pid=pid)
         console.print(
-            f"[green]Killed[/green] {result.get('name', pid)} "
+            f"[nexus.success]Killed[/nexus.success] {result.get('name', pid)} "
             f"(state={result.get('state', 'unknown')})"
         )
 
@@ -441,7 +441,7 @@ async def _async_config_agent(
         nx: Any = await get_filesystem(remote_url, remote_api_key)
         svc = nx.service("acp_rpc")
         if svc is None:
-            console.print("[red]ACP service not available[/red]")
+            console.print("[nexus.error]ACP service not available[/nexus.error]")
             nx.close()
             return
 
@@ -455,18 +455,20 @@ async def _async_config_agent(
                 svc.acp_set_enabled_skills(agent_id=agent_id, skills=skill_list)
                 names = [sk["name"] for sk in skill_list]
                 console.print(
-                    f"[green]Set enabled skills for {agent_id}:[/green] {', '.join(names)}"
+                    f"[nexus.success]Set enabled skills for {agent_id}:[/nexus.success] {', '.join(names)}"
                 )
             else:
                 svc.acp_set_enabled_skills(agent_id=agent_id, skills=[])
-                console.print(f"[green]Cleared enabled skills for {agent_id}[/green]")
+                console.print(
+                    f"[nexus.success]Cleared enabled skills for {agent_id}[/nexus.success]"
+                )
             made_changes = True
 
         # Set system prompt if provided
         if system_prompt is not None:
             svc.acp_set_system_prompt(agent_id=agent_id, content=system_prompt)
             console.print(
-                f"[green]Set system prompt for {agent_id}[/green] ({len(system_prompt)} chars)"
+                f"[nexus.success]Set system prompt for {agent_id}[/nexus.success] ({len(system_prompt)} chars)"
             )
             made_changes = True
 
@@ -480,21 +482,21 @@ async def _async_config_agent(
             current_skills = skills_result.get("skills")
             if current_skills:
                 table = Table(show_header=True)
-                table.add_column("Name", style="cyan")
-                table.add_column("Description", style="dim")
-                table.add_column("Path", style="dim")
+                table.add_column("Name", style="nexus.value")
+                table.add_column("Description", style="nexus.muted")
+                table.add_column("Path", style="nexus.muted")
                 for sk in current_skills:
                     table.add_row(sk["name"], sk.get("description", ""), sk.get("path", ""))
-                console.print("[cyan]Enabled skills:[/cyan]")
+                console.print("[nexus.value]Enabled skills:[/nexus.value]")
                 console.print(table)
             else:
-                console.print("[dim]Enabled skills: (none)[/dim]")
+                console.print("[nexus.muted]Enabled skills: (none)[/nexus.muted]")
 
             current_prompt = prompt_result.get("content")
             if current_prompt:
-                console.print(f"[cyan]System prompt:[/cyan] {current_prompt}")
+                console.print(f"[nexus.value]System prompt:[/nexus.value] {current_prompt}")
             else:
-                console.print("[dim]System prompt: (none)[/dim]")
+                console.print("[nexus.muted]System prompt: (none)[/nexus.muted]")
 
         nx.close()
     except Exception as e:
@@ -533,7 +535,7 @@ async def _async_get_system_prompt(
         nx: Any = await get_filesystem(remote_url, remote_api_key)
         svc = nx.service("acp_rpc")
         if svc is None:
-            console.print("[red]ACP service not available[/red]")
+            console.print("[nexus.error]ACP service not available[/nexus.error]")
             nx.close()
             return
 
@@ -542,7 +544,7 @@ async def _async_get_system_prompt(
         if content:
             console.print(content)
         else:
-            console.print(f"[yellow]No system prompt set for {agent_id}[/yellow]")
+            console.print(f"[nexus.warning]No system prompt set for {agent_id}[/nexus.warning]")
 
         nx.close()
     except Exception as e:
@@ -579,13 +581,13 @@ async def _async_set_system_prompt(
         nx: Any = await get_filesystem(remote_url, remote_api_key)
         svc = nx.service("acp_rpc")
         if svc is None:
-            console.print("[red]ACP service not available[/red]")
+            console.print("[nexus.error]ACP service not available[/nexus.error]")
             nx.close()
             return
 
         result = svc.acp_set_system_prompt(agent_id=agent_id, content=content)
         console.print(
-            f"[green]Set system prompt for {agent_id}[/green] ({result.get('length', 0)} chars)"
+            f"[nexus.success]Set system prompt for {agent_id}[/nexus.success] ({result.get('length', 0)} chars)"
         )
 
         nx.close()

--- a/src/nexus/cli/commands/acp_cli.py
+++ b/src/nexus/cli/commands/acp_cli.py
@@ -311,7 +311,7 @@ async def _async_history(
         table.add_column("Session", style="nexus.muted", no_wrap=True)
         table.add_column("Exit", style="nexus.muted")
         table.add_column("Prompt", style="nexus.warning", max_width=40)
-        table.add_column("Response", style="white", max_width=40)
+        table.add_column("Response", max_width=40)
         table.add_column("Model", style="nexus.muted")
         table.add_column("Tokens", style="nexus.muted")
         table.add_column("Cost", style="nexus.muted")

--- a/src/nexus/cli/commands/admin.py
+++ b/src/nexus/cli/commands/admin.py
@@ -321,12 +321,12 @@ def list_users(
             # Create table
             table = Table(title=f"API Keys ({len(data)} total)")
             table.add_column("User ID", style="nexus.value")
-            table.add_column("Name", style="white")
+            table.add_column("Name")
             table.add_column("Key ID", style="nexus.muted")
             table.add_column("Admin", style="nexus.success")
             table.add_column("Created", style="nexus.reference")
             table.add_column("Expires", style="nexus.warning")
-            table.add_column("Status", style="white")
+            table.add_column("Status")
 
             for key in data:
                 # Determine status
@@ -790,7 +790,7 @@ def gc_versions(
 
             table = Table(show_header=False, box=None)
             table.add_column("Metric", style="nexus.value")
-            table.add_column("Value", style="white")
+            table.add_column("Value")
 
             table.add_row("Deleted by age:", str(data.get("deleted_by_age", 0)))
             table.add_row("Deleted by count:", str(data.get("deleted_by_count", 0)))
@@ -855,7 +855,7 @@ def gc_versions_stats(
 
             table = Table(show_header=False, box=None)
             table.add_column("Metric", style="nexus.value")
-            table.add_column("Value", style="white")
+            table.add_column("Value")
 
             table.add_row("Total versions:", f"{data.get('total_versions', 0):,}")
             table.add_row("Unique resources:", f"{data.get('unique_resources', 0):,}")
@@ -889,7 +889,7 @@ def gc_versions_stats(
 
                 config_table = Table(show_header=False, box=None)
                 config_table.add_column("Setting", style="nexus.value")
-                config_table.add_column("Value", style="white")
+                config_table.add_column("Value")
 
                 status = (
                     "[nexus.success]Enabled[/nexus.success]"

--- a/src/nexus/cli/commands/admin.py
+++ b/src/nexus/cli/commands/admin.py
@@ -331,17 +331,17 @@ def list_users(
             for key in data:
                 # Determine status
                 status = "Active"
-                status_style = "green"
+                status_style = "nexus.success"
                 if key.get("revoked"):
                     status = "Revoked"
-                    status_style = "red"
+                    status_style = "nexus.error"
                 elif key.get("expires_at"):
                     try:
                         # Parse ISO format datetime
                         expires = datetime.fromisoformat(key["expires_at"].replace("Z", "+00:00"))
                         if expires < datetime.now(UTC):
                             status = "Expired"
-                            status_style = "yellow"
+                            status_style = "nexus.warning"
                     except (ValueError, TypeError):
                         pass
 

--- a/src/nexus/cli/commands/admin.py
+++ b/src/nexus/cli/commands/admin.py
@@ -16,23 +16,19 @@ from datetime import UTC, datetime
 from typing import Any
 
 import click
-from rich.console import Console
 from rich.table import Table
 
 from nexus.cli.output import OutputOptions, add_output_options, render_output
+from nexus.cli.theme import console
 from nexus.cli.timing import CommandTiming
 from nexus.cli.utils import (
     REMOTE_API_KEY_OPTION,
     REMOTE_URL_OPTION,
-    console,
 )
 from nexus.contracts.constants import ROOT_ZONE_ID
 
 # Type alias for the RPC transport callable returned by get_admin_rpc().
 AdminRPC = Callable[[str, dict[str, Any] | None], Any]
-
-# Rich console for output
-_console = Console()
 
 
 def get_admin_rpc(url: str | None, api_key: str | None) -> AdminRPC:
@@ -53,12 +49,14 @@ def get_admin_rpc(url: str | None, api_key: str | None) -> AdminRPC:
         SystemExit: If URL or API key not provided
     """
     if not url:
-        console.print("[red]Error:[/red] Server URL required. Set NEXUS_URL or use --remote-url")
+        console.print(
+            "[nexus.error]Error:[/nexus.error] Server URL required. Set NEXUS_URL or use --remote-url"
+        )
         sys.exit(1)
 
     if not api_key:
         console.print(
-            "[red]Error:[/red] Admin API key required. Set NEXUS_API_KEY or use --remote-api-key"
+            "[nexus.error]Error:[/nexus.error] Admin API key required. Set NEXUS_API_KEY or use --remote-api-key"
         )
         sys.exit(1)
 
@@ -226,9 +224,9 @@ def create_user(
             result = call_rpc("admin_create_key", params)
 
         def _render(data: dict[str, Any]) -> None:
-            console.print("[green]\u2713[/green] User created successfully")
+            console.print("[nexus.success]\u2713[/nexus.success] User created successfully")
             console.print(
-                "\n[yellow]\u26a0 Save this API key - it will only be shown once![/yellow]\n"
+                "\n[nexus.warning]\u26a0 Save this API key - it will only be shown once![/nexus.warning]\n"
             )
             console.print(f"User ID:     {data['user_id']}")
             console.print(f"Key ID:      {data['key_id']}")
@@ -241,7 +239,7 @@ def create_user(
                 _print_grants(data["grants"])
 
             if email:
-                console.print(f"\n[dim]Email: {email}[/dim]")
+                console.print(f"\n[nexus.muted]Email: {email}[/nexus.muted]")
 
         render_output(
             data=result,
@@ -251,7 +249,7 @@ def create_user(
         )
 
     except Exception as e:
-        console.print(f"[red]Error creating user:[/red] {e}")
+        console.print(f"[nexus.error]Error creating user:[/nexus.error] {e}")
         sys.exit(1)
 
 
@@ -316,18 +314,18 @@ def list_users(
             keys = result.get("keys", [])
 
         if not keys:
-            console.print("[yellow]No users found.[/yellow]")
+            console.print("[nexus.warning]No users found.[/nexus.warning]")
             return
 
         def _render(data: list[dict[str, Any]]) -> None:
             # Create table
             table = Table(title=f"API Keys ({len(data)} total)")
-            table.add_column("User ID", style="cyan")
+            table.add_column("User ID", style="nexus.value")
             table.add_column("Name", style="white")
-            table.add_column("Key ID", style="dim")
-            table.add_column("Admin", style="green")
-            table.add_column("Created", style="blue")
-            table.add_column("Expires", style="yellow")
+            table.add_column("Key ID", style="nexus.muted")
+            table.add_column("Admin", style="nexus.success")
+            table.add_column("Created", style="nexus.reference")
+            table.add_column("Expires", style="nexus.warning")
             table.add_column("Status", style="white")
 
             for key in data:
@@ -357,7 +355,7 @@ def list_users(
                     f"[{status_style}]{status}[/{status_style}]",
                 )
 
-            _console.print(table)
+            console.print(table)
 
         render_output(
             data=keys,
@@ -367,7 +365,7 @@ def list_users(
         )
 
     except Exception as e:
-        console.print(f"[red]Error listing users:[/red] {e}")
+        console.print(f"[nexus.error]Error listing users:[/nexus.error] {e}")
         sys.exit(1)
 
 
@@ -397,7 +395,7 @@ def revoke_key(
             result = call_rpc("admin_revoke_key", {"key_id": key_id})
 
         def _render(data: dict[str, Any]) -> None:  # noqa: ARG001
-            console.print("[green]\u2713[/green] API key revoked successfully")
+            console.print("[nexus.success]\u2713[/nexus.success] API key revoked successfully")
             console.print(f"Key ID: {key_id}")
 
         render_output(
@@ -408,7 +406,7 @@ def revoke_key(
         )
 
     except Exception as e:
-        console.print(f"[red]Error revoking key:[/red] {e}")
+        console.print(f"[nexus.error]Error revoking key:[/nexus.error] {e}")
         sys.exit(1)
 
 
@@ -461,9 +459,9 @@ def create_key(
             result = call_rpc("admin_create_key", params)
 
         def _render(data: dict[str, Any]) -> None:
-            console.print("[green]\u2713[/green] API key created successfully")
+            console.print("[nexus.success]\u2713[/nexus.success] API key created successfully")
             console.print(
-                "\n[yellow]\u26a0 Save this API key - it will only be shown once![/yellow]\n"
+                "\n[nexus.warning]\u26a0 Save this API key - it will only be shown once![/nexus.warning]\n"
             )
             console.print(f"User ID:     {data['user_id']}")
             console.print(f"Key ID:      {data['key_id']}")
@@ -481,7 +479,7 @@ def create_key(
         )
 
     except Exception as e:
-        console.print(f"[red]Error creating key:[/red] {e}")
+        console.print(f"[nexus.error]Error creating key:[/nexus.error] {e}")
         sys.exit(1)
 
 
@@ -508,7 +506,7 @@ def get_user(
         nexus admin get-user --key-id d6f5e137-5fce-4e06-9432-6e30324dfad1
     """
     if not user_id and not key_id:
-        console.print("[red]Error:[/red] Must provide either --user-id or --key-id")
+        console.print("[nexus.error]Error:[/nexus.error] Must provide either --user-id or --key-id")
         sys.exit(1)
 
     timing = CommandTiming()
@@ -521,7 +519,9 @@ def get_user(
                 list_result = call_rpc("admin_list_keys", {"user_id": user_id, "limit": 1})
                 keys = list_result.get("keys", [])
                 if not keys:
-                    console.print(f"[red]Error:[/red] No keys found for user '{user_id}'")
+                    console.print(
+                        f"[nexus.error]Error:[/nexus.error] No keys found for user '{user_id}'"
+                    )
                     sys.exit(1)
                 key_id = keys[0]["key_id"]
 
@@ -562,7 +562,7 @@ def get_user(
         )
 
     except Exception as e:
-        console.print(f"[red]Error getting user:[/red] {e}")
+        console.print(f"[nexus.error]Error getting user:[/nexus.error] {e}")
         sys.exit(1)
 
 
@@ -628,9 +628,11 @@ def create_agent_key(
             result = call_rpc("admin_create_key", params)
 
         def _render(data: dict[str, Any]) -> None:
-            console.print("[green]\u2713[/green] Agent API key created successfully")
             console.print(
-                "\n[yellow]\u26a0 Save this API key - it will only be shown once![/yellow]\n"
+                "[nexus.success]\u2713[/nexus.success] Agent API key created successfully"
+            )
+            console.print(
+                "\n[nexus.warning]\u26a0 Save this API key - it will only be shown once![/nexus.warning]\n"
             )
             console.print(f"User ID:     {data['user_id']}")
             console.print(f"Agent ID:    {agent_id}")
@@ -642,10 +644,10 @@ def create_agent_key(
                 _print_grants(data["grants"])
 
             console.print(
-                "\n[cyan]\u2139 Info:[/cyan] This agent can now authenticate independently."
+                "\n[nexus.value]\u2139 Info:[/nexus.value] This agent can now authenticate independently."
             )
             console.print(
-                "[cyan]\u2139[/cyan] Recommended: Use user auth + X-Agent-ID header instead."
+                "[nexus.value]\u2139[/nexus.value] Recommended: Use user auth + X-Agent-ID header instead."
             )
 
         render_output(
@@ -656,7 +658,7 @@ def create_agent_key(
         )
 
     except Exception as e:
-        console.print(f"[red]Error creating agent key:[/red] {e}")
+        console.print(f"[nexus.error]Error creating agent key:[/nexus.error] {e}")
         sys.exit(1)
 
 
@@ -689,7 +691,7 @@ def update_key(
         nexus admin update-key <key_id> --is-admin false
     """
     if expires_days is None and is_admin is None:
-        console.print("[red]Error:[/red] Must provide --expires-days or --is-admin")
+        console.print("[nexus.error]Error:[/nexus.error] Must provide --expires-days or --is-admin")
         sys.exit(1)
 
     timing = CommandTiming()
@@ -709,7 +711,7 @@ def update_key(
             result = call_rpc("admin_update_key", params)
 
         def _render(data: dict[str, Any]) -> None:
-            console.print("[green]\u2713[/green] API key updated successfully")
+            console.print("[nexus.success]\u2713[/nexus.success] API key updated successfully")
             console.print(f"Key ID: {key_id}")
             if expires_days is not None:
                 console.print(f"New expiry: {data.get('expires_at', 'N/A')}")
@@ -724,7 +726,7 @@ def update_key(
         )
 
     except Exception as e:
-        console.print(f"[red]Error updating key:[/red] {e}")
+        console.print(f"[nexus.error]Error updating key:[/nexus.error] {e}")
         sys.exit(1)
 
 
@@ -779,11 +781,15 @@ def gc_versions(
             result = call_rpc("admin_gc_versions", params)
 
         def _render(data: dict[str, Any]) -> None:
-            mode = "[yellow]DRY RUN[/yellow]" if dry_run else "[green]EXECUTED[/green]"
+            mode = (
+                "[nexus.warning]DRY RUN[/nexus.warning]"
+                if dry_run
+                else "[nexus.success]EXECUTED[/nexus.success]"
+            )
             console.print(f"\n{mode} Version History Garbage Collection\n")
 
             table = Table(show_header=False, box=None)
-            table.add_column("Metric", style="cyan")
+            table.add_column("Metric", style="nexus.value")
             table.add_column("Value", style="white")
 
             table.add_row("Deleted by age:", str(data.get("deleted_by_age", 0)))
@@ -800,10 +806,12 @@ def gc_versions(
             table.add_row("Space reclaimed:", size_str)
             table.add_row("Duration:", f"{data.get('duration_seconds', 0):.2f}s")
 
-            _console.print(table)
+            console.print(table)
 
             if dry_run:
-                console.print("\n[dim]Run with --execute to perform actual deletion[/dim]")
+                console.print(
+                    "\n[nexus.muted]Run with --execute to perform actual deletion[/nexus.muted]"
+                )
 
         render_output(
             data=result,
@@ -813,7 +821,7 @@ def gc_versions(
         )
 
     except Exception as e:
-        console.print(f"[red]Error running GC:[/red] {e}")
+        console.print(f"[nexus.error]Error running GC:[/nexus.error] {e}")
         sys.exit(1)
 
 
@@ -846,7 +854,7 @@ def gc_versions_stats(
             console.print("\n[bold]Version History Statistics[/bold]\n")
 
             table = Table(show_header=False, box=None)
-            table.add_column("Metric", style="cyan")
+            table.add_column("Metric", style="nexus.value")
             table.add_column("Value", style="white")
 
             table.add_row("Total versions:", f"{data.get('total_versions', 0):,}")
@@ -872,7 +880,7 @@ def gc_versions_stats(
                 data.get("newest_version", "N/A")[:19] if data.get("newest_version") else "N/A",
             )
 
-            _console.print(table)
+            console.print(table)
 
             # Show GC config
             gc_config = data.get("gc_config", {})
@@ -880,11 +888,13 @@ def gc_versions_stats(
                 console.print("\n[bold]GC Configuration[/bold]\n")
 
                 config_table = Table(show_header=False, box=None)
-                config_table.add_column("Setting", style="cyan")
+                config_table.add_column("Setting", style="nexus.value")
                 config_table.add_column("Value", style="white")
 
                 status = (
-                    "[green]Enabled[/green]" if gc_config.get("enabled") else "[red]Disabled[/red]"
+                    "[nexus.success]Enabled[/nexus.success]"
+                    if gc_config.get("enabled")
+                    else "[nexus.error]Disabled[/nexus.error]"
                 )
                 config_table.add_row("Status:", status)
                 config_table.add_row("Retention:", f"{gc_config.get('retention_days', 30)} days")
@@ -895,7 +905,7 @@ def gc_versions_stats(
                     "Run interval:", f"{gc_config.get('run_interval_hours', 24)} hours"
                 )
 
-                _console.print(config_table)
+                console.print(config_table)
 
         render_output(
             data=result,
@@ -905,7 +915,7 @@ def gc_versions_stats(
         )
 
     except Exception as e:
-        console.print(f"[red]Error getting stats:[/red] {e}")
+        console.print(f"[nexus.error]Error getting stats:[/nexus.error] {e}")
         sys.exit(1)
 
 

--- a/src/nexus/cli/commands/agent.py
+++ b/src/nexus/cli/commands/agent.py
@@ -6,12 +6,12 @@ Manage AI agents for delegation and multi-agent workflows.
 from typing import Any
 
 import click
-from rich.console import Console
 from rich.table import Table
 
 from nexus.cli.clients.agent_ext import AgentExtClient
 from nexus.cli.output import add_output_options
 from nexus.cli.service_command import ServiceResult, service_command
+from nexus.cli.theme import console
 from nexus.cli.utils import (
     REMOTE_API_KEY_OPTION,
     REMOTE_URL_OPTION,
@@ -19,8 +19,6 @@ from nexus.cli.utils import (
     get_filesystem,
     handle_error,
 )
-
-console = Console()
 
 
 @click.group(name="agent")
@@ -102,28 +100,32 @@ def register_cmd(
             if if_not_exists and "already exists" in str(reg_err).lower():
                 try:
                     existing = nx.service("agent_rpc").get_agent(agent_id)
-                    console.print(f"[green]✓[/green] Agent already exists: {agent_id}")
+                    console.print(
+                        f"[nexus.success]✓[/nexus.success] Agent already exists: {agent_id}"
+                    )
                     console.print(f"  Name: {existing.get('name', name)}")
                     console.print(f"  Owner: {existing.get('user_id', 'unknown')}")
                 except Exception:
-                    console.print(f"[green]✓[/green] Agent already exists: {agent_id}")
+                    console.print(
+                        f"[nexus.success]✓[/nexus.success] Agent already exists: {agent_id}"
+                    )
                 nx.close()
                 return
             nx.close()
             raise
 
-        console.print(f"[green]✓[/green] Registered agent: {result['agent_id']}")
+        console.print(f"[nexus.success]✓[/nexus.success] Registered agent: {result['agent_id']}")
         console.print(f"  Name: {result.get('name', name)}")
         if description:
             console.print(f"  Description: {description}")
         console.print(f"  Owner: {result.get('user_id', 'unknown')}")
 
         if with_api_key and result.get("api_key"):
-            console.print("\n[yellow]⚠[/yellow] API Key (save securely):")
+            console.print("\n[nexus.warning]⚠[/nexus.warning] API Key (save securely):")
             console.print(f"  {result['api_key']}")
-            console.print("\n[dim]Note: API key will not be shown again[/dim]")
+            console.print("\n[nexus.muted]Note: API key will not be shown again[/nexus.muted]")
         else:
-            console.print("\n[cyan]ℹ[/cyan] No API key generated (recommended)")
+            console.print("\n[nexus.value]ℹ[/nexus.value] No API key generated (recommended)")
             console.print("  Agent uses owner's auth + X-Agent-ID header")
 
         nx.close()
@@ -149,17 +151,17 @@ def list_cmd(
         agents = nx.service("agent_rpc").list_agents()
 
         if not agents:
-            console.print("[yellow]No agents registered[/yellow]")
+            console.print("[nexus.warning]No agents registered[/nexus.warning]")
             nx.close()
             return
 
         # Create table
         table = Table(title="Registered Agents")
-        table.add_column("Agent ID", style="cyan")
-        table.add_column("Name", style="green")
-        table.add_column("Description", style="dim", no_wrap=False)
-        table.add_column("Owner", style="dim")
-        table.add_column("Created", style="dim")
+        table.add_column("Agent ID", style="nexus.value")
+        table.add_column("Name", style="nexus.success")
+        table.add_column("Description", style="nexus.muted", no_wrap=False)
+        table.add_column("Owner", style="nexus.muted")
+        table.add_column("Created", style="nexus.muted")
 
         for agent in agents:
             created = agent.get("created_at", "")
@@ -206,7 +208,7 @@ def info_cmd(
         agent = nx.service("agent_rpc").get_agent(agent_id)
 
         if not agent:
-            console.print(f"[red]✗[/red] Agent not found: {agent_id}")
+            console.print(f"[nexus.error]✗[/nexus.error] Agent not found: {agent_id}")
             nx.close()
             return
 
@@ -252,20 +254,20 @@ def delete_cmd(
             try:
                 confirm = input(f"Delete agent '{agent_id}'? [y/N]: ")
                 if confirm.lower() not in ("y", "yes"):
-                    console.print("[yellow]Cancelled[/yellow]")
+                    console.print("[nexus.warning]Cancelled[/nexus.warning]")
                     nx.close()
                     return
             except (EOFError, KeyboardInterrupt):
-                console.print("\n[yellow]Cancelled[/yellow]")
+                console.print("\n[nexus.warning]Cancelled[/nexus.warning]")
                 nx.close()
                 return
 
         result = nx.service("agent_rpc").delete_agent(agent_id)
 
         if result:
-            console.print(f"[green]✓[/green] Deleted agent: {agent_id}")
+            console.print(f"[nexus.success]✓[/nexus.success] Deleted agent: {agent_id}")
         else:
-            console.print(f"[red]✗[/red] Agent not found: {agent_id}")
+            console.print(f"[nexus.error]✗[/nexus.error] Agent not found: {agent_id}")
 
         nx.close()
 
@@ -307,7 +309,11 @@ def agent_status(client: AgentExtClient, agent_id: str) -> ServiceResult:
         if conditions:
             console.print("  Conditions:")
             for c in conditions:
-                status_icon = "[green]OK[/green]" if c.get("status") == "True" else "[red]!![/red]"
+                status_icon = (
+                    "[nexus.success]OK[/nexus.success]"
+                    if c.get("status") == "True"
+                    else "[nexus.error]!![/nexus.error]"
+                )
                 console.print(f"    {status_icon} {c.get('type', '')}: {c.get('message', '')}")
 
     return ServiceResult(data=data, human_formatter=_render)

--- a/src/nexus/cli/commands/agent.py
+++ b/src/nexus/cli/commands/agent.py
@@ -292,7 +292,7 @@ def agent_status(client: AgentExtClient, agent_id: str) -> ServiceResult:
     data = client.status(agent_id)
 
     def _render(d: dict) -> None:
-        console.print(f"[bold cyan]Agent Status: {agent_id}[/bold cyan]")
+        console.print(f"[bold nexus.value]Agent Status: {agent_id}[/bold nexus.value]")
         console.print(f"  Phase:       {d.get('phase', 'N/A')}")
         console.print(f"  Generation:  {d.get('observed_generation', 'N/A')}")
         console.print(f"  Inbox:       {d.get('inbox_depth', 0)} message(s)")
@@ -342,7 +342,7 @@ def agent_spec_show(client: AgentExtClient, agent_id: str) -> ServiceResult:
     def _render(d: dict) -> None:
         import json
 
-        console.print(f"[bold cyan]Agent Spec: {agent_id}[/bold cyan]")
+        console.print(f"[bold nexus.value]Agent Spec: {agent_id}[/bold nexus.value]")
         console.print(json.dumps(d, indent=2, default=str))
 
     return ServiceResult(data=data, human_formatter=_render)

--- a/src/nexus/cli/commands/aspects.py
+++ b/src/nexus/cli/commands/aspects.py
@@ -13,7 +13,8 @@ from urllib.parse import quote
 
 import click
 
-from nexus.cli.utils import add_backend_options, console
+from nexus.cli.theme import console
+from nexus.cli.utils import add_backend_options
 
 logger = logging.getLogger(__name__)
 
@@ -55,12 +56,12 @@ def aspects_list(
     try:
         result = client.get(f"/api/v2/aspects/{quote(urn, safe='')}")
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from e
 
     aspect_names: list[str] = result.get("aspects", [])
     if not aspect_names:
-        console.print(f"[yellow]No aspects found for {path}[/yellow]")
+        console.print(f"[nexus.warning]No aspects found for {path}[/nexus.warning]")
         return
 
     console.print(f"[bold]Aspects for {path}[/bold]")
@@ -102,7 +103,7 @@ def aspects_get(
     try:
         result = client.get(f"/api/v2/aspects/{quote(urn, safe='')}/{quote(aspect_name, safe='')}")
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from e
 
     console.print(f"[bold]{aspect_name}[/bold] on {path}")

--- a/src/nexus/cli/commands/audit.py
+++ b/src/nexus/cli/commands/audit.py
@@ -76,14 +76,14 @@ def audit_list(
 
             txns = d.get("transactions", [])
             if not txns:
-                console.print("[yellow]No audit entries found[/yellow]")
+                console.print("[nexus.warning]No audit entries found[/nexus.warning]")
                 return
 
             table = Table(title=f"Audit Trail ({len(txns)} entries)")
-            table.add_column("Time", style="dim")
+            table.add_column("Time", style="nexus.muted")
             table.add_column("Buyer")
             table.add_column("Seller")
-            table.add_column("Amount", justify="right", style="green")
+            table.add_column("Amount", justify="right", style="nexus.success")
             table.add_column("Protocol")
             table.add_column("Status")
 
@@ -105,7 +105,7 @@ def audit_list(
             human_formatter=_render,
         )
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from None
 
 
@@ -147,9 +147,9 @@ def audit_export(
         if output_file:
             with open(output_file, "w") as f:
                 f.write(content)
-            console.print(f"[green]Exported to {output_file}[/green]")
+            console.print(f"[nexus.success]Exported to {output_file}[/nexus.success]")
         else:
             click.echo(content)
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from None

--- a/src/nexus/cli/commands/auth_cli.py
+++ b/src/nexus/cli/commands/auth_cli.py
@@ -421,7 +421,7 @@ def auth_doctor() -> None:
     summaries = asyncio.run(service.list_summaries())
     failures = [s for s in summaries if s.status not in {AuthStatus.AUTHED, AuthStatus.UNKNOWN}]
     for summary in summaries:
-        style = "green" if summary.status == AuthStatus.AUTHED else "yellow"
+        style = "nexus.success" if summary.status == AuthStatus.AUTHED else "nexus.warning"
         console.print(
             f"[{style}]{summary.service}[/{style}] {summary.status.value}: {summary.message}"
         )

--- a/src/nexus/cli/commands/auth_cli.py
+++ b/src/nexus/cli/commands/auth_cli.py
@@ -315,7 +315,7 @@ def list_auth() -> None:
     service = _build_auth_service()
     summaries = asyncio.run(service.list_summaries())
 
-    table = Table(title="Unified Auth", show_header=True, header_style="bold nexus.accent")
+    table = Table(title="Unified Auth", show_header=True, header_style="nexus.table_header")
     table.add_column("Service", style="nexus.success")
     table.add_column("Kind", style="nexus.value")
     table.add_column("Status", style="nexus.warning")

--- a/src/nexus/cli/commands/auth_cli.py
+++ b/src/nexus/cli/commands/auth_cli.py
@@ -255,15 +255,17 @@ def _run_google_oauth_setup(service_name: str, user_email: str) -> None:
     )
     auth_url = provider.get_authorization_url()
 
-    console.print("\n[bold green]Google OAuth Setup[/bold green]")
+    console.print("\n[bold nexus.success]Google OAuth Setup[/bold nexus.success]")
     console.print(f"\n[bold]Service:[/bold] {service_name}")
     console.print(f"[bold]User:[/bold] {user_email}")
-    console.print("\n[bold yellow]Step 1:[/bold yellow] Visit this URL to authorize:")
+    console.print("\n[bold nexus.warning]Step 1:[/bold nexus.warning] Visit this URL to authorize:")
     console.print(f"\n{auth_url}\n")
     console.print(
-        "[bold yellow]Step 2:[/bold yellow] After granting permission, the browser will redirect to localhost."
+        "[bold nexus.warning]Step 2:[/bold nexus.warning] After granting permission, the browser will redirect to localhost."
     )
-    console.print("[bold yellow]Step 3:[/bold yellow] Copy the `code` parameter from that URL.")
+    console.print(
+        "[bold nexus.warning]Step 3:[/bold nexus.warning] Copy the `code` parameter from that URL."
+    )
     auth_code = click.prompt("\nEnter authorization code")
 
     async def _exchange_and_store() -> str:

--- a/src/nexus/cli/commands/auth_cli.py
+++ b/src/nexus/cli/commands/auth_cli.py
@@ -14,7 +14,7 @@ from rich.table import Table
 
 from nexus.bricks.auth.unified_service import UnifiedAuthService
 from nexus.cli.commands.oauth import get_token_manager, setup_x
-from nexus.cli.utils import console
+from nexus.cli.theme import console
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.unified_auth import AuthStatus, CredentialKind
 
@@ -203,11 +203,13 @@ def _print_connect_success(
     *,
     source: str = "stored",
 ) -> None:
-    console.print(f"[green]ok[/green] {service_name}: {source} {kind.value} auth is configured")
-    console.print(f"[dim]Secret store: {store_path}[/dim]")
+    console.print(
+        f"[nexus.success]ok[/nexus.success] {service_name}: {source} {kind.value} auth is configured"
+    )
+    console.print(f"[nexus.muted]Secret store: {store_path}[/nexus.muted]")
     if fields:
-        console.print(f"[dim]Fields: {', '.join(fields)}[/dim]")
-    console.print(f"[dim]Next: nexus auth test {service_name}[/dim]")
+        console.print(f"[nexus.muted]Fields: {', '.join(fields)}[/nexus.muted]")
+    console.print(f"[nexus.muted]Next: nexus auth test {service_name}[/nexus.muted]")
 
 
 def _ensure_google_oauth_env() -> None:
@@ -279,10 +281,12 @@ def _run_google_oauth_setup(service_name: str, user_email: str) -> None:
 
     try:
         cred_id = asyncio.run(_exchange_and_store())
-        console.print(f"\n[green]ok[/green] stored Google OAuth credentials for {user_email}")
-        console.print(f"[dim]Credential ID: {cred_id}[/dim]")
+        console.print(
+            f"\n[nexus.success]ok[/nexus.success] stored Google OAuth credentials for {user_email}"
+        )
+        console.print(f"[nexus.muted]Credential ID: {cred_id}[/nexus.muted]")
     except Exception as exc:
-        console.print(f"\n[red]OAuth setup failed:[/red] {exc}")
+        console.print(f"\n[nexus.error]OAuth setup failed:[/nexus.error] {exc}")
         sys.exit(1)
 
 
@@ -311,11 +315,11 @@ def list_auth() -> None:
     service = _build_auth_service()
     summaries = asyncio.run(service.list_summaries())
 
-    table = Table(title="Unified Auth", show_header=True, header_style="bold cyan")
-    table.add_column("Service", style="green")
-    table.add_column("Kind", style="cyan")
-    table.add_column("Status", style="yellow")
-    table.add_column("Source", style="blue")
+    table = Table(title="Unified Auth", show_header=True, header_style="bold nexus.accent")
+    table.add_column("Service", style="nexus.success")
+    table.add_column("Kind", style="nexus.value")
+    table.add_column("Status", style="nexus.warning")
+    table.add_column("Source", style="nexus.reference")
     table.add_column("Message")
 
     for summary in summaries:
@@ -328,7 +332,7 @@ def list_auth() -> None:
         )
 
     console.print(table)
-    console.print(f"[dim]Secret store: {service.secret_store_path}[/dim]")
+    console.print(f"[nexus.muted]Secret store: {service.secret_store_path}[/nexus.muted]")
 
 
 @auth.command("test")
@@ -339,7 +343,7 @@ def test_auth(service_name: str, user_email: str | None) -> None:
     service = _build_auth_service()
     result = asyncio.run(service.test_service(service_name, user_email=user_email))
     if result.get("success"):
-        console.print(f"[green]ok[/green] {service_name}: {result.get('message')}")
+        console.print(f"[nexus.success]ok[/nexus.success] {service_name}: {result.get('message')}")
         return
     raise click.ClickException(f"{service_name}: {result.get('message')}")
 
@@ -405,7 +409,7 @@ def disconnect_auth(service_name: str) -> None:
     removed = service.disconnect(service_name)
     if not removed:
         raise click.ClickException(f"No stored auth found for '{service_name}'.")
-    console.print(f"[green]ok[/green] Removed stored auth for {service_name}")
+    console.print(f"[nexus.success]ok[/nexus.success] Removed stored auth for {service_name}")
 
 
 @auth.command("doctor")

--- a/src/nexus/cli/commands/cache.py
+++ b/src/nexus/cli/commands/cache.py
@@ -114,7 +114,9 @@ def warmup(
             if user:
                 # History-based warmup
                 if not output_opts.quiet and not output_opts.json_output:
-                    console.print(f"[blue]Warming cache based on {user}'s access history...[/blue]")
+                    console.print(
+                        f"[nexus.reference]Warming cache based on {user}'s access history...[/nexus.reference]"
+                    )
                 warmup_stats = await warmer.warmup_from_history(
                     user=user,
                     hours=hours,
@@ -124,7 +126,7 @@ def warmup(
             else:
                 # Directory-based warmup
                 if not output_opts.quiet and not output_opts.json_output:
-                    console.print(f"[blue]Warming cache for {path}...[/blue]")
+                    console.print(f"[nexus.reference]Warming cache for {path}...[/nexus.reference]")
                 warmup_stats = await warmer.warmup_directory(
                     path=path,
                     depth=depth,
@@ -138,14 +140,14 @@ def warmup(
             warmup_data = asyncio.run(run_warmup())
 
         def _render(data: dict[str, Any]) -> None:
-            console.print("\n[green]Cache warmup complete![/green]")
+            console.print("\n[nexus.success]Cache warmup complete![/nexus.success]")
             console.print(f"  Files warmed: {data['files_warmed']}")
             console.print(f"  Metadata warmed: {data['metadata_warmed']}")
             console.print(f"  Content warmed: {data['content_warmed']}")
             console.print(f"  Bytes warmed: {data['bytes_warmed_mb']} MB")
             console.print(f"  Duration: {data['duration_seconds']}s")
             if data["errors"] > 0:
-                console.print(f"  [yellow]Errors: {data['errors']}[/yellow]")
+                console.print(f"  [nexus.warning]Errors: {data['errors']}[/nexus.warning]")
             if data["skipped"] > 0:
                 console.print(f"  Skipped: {data['skipped']}")
 
@@ -223,7 +225,7 @@ def stats(
             console.print("=" * 40)
 
             for cache_name, stats_data in data.items():
-                console.print(f"\n[cyan]{cache_name}:[/cyan]")
+                console.print(f"\n[nexus.value]{cache_name}:[/nexus.value]")
                 if isinstance(stats_data, dict):
                     for key, value in stats_data.items():
                         if isinstance(value, float):
@@ -273,7 +275,7 @@ def clear(
     """
     if not any([metadata, content, permissions, clear_all]):
         console.print(
-            "[yellow]Specify which cache to clear: --metadata, --content, --permissions, or --all[/yellow]"
+            "[nexus.warning]Specify which cache to clear: --metadata, --content, --permissions, or --all[/nexus.warning]"
         )
         return
 
@@ -291,7 +293,7 @@ def clear(
             msg = f"Clear {', '.join(caches)} cache(s)?"
 
         if not click.confirm(msg):
-            console.print("[yellow]Cancelled[/yellow]")
+            console.print("[nexus.warning]Cancelled[/nexus.warning]")
             return
 
     try:
@@ -342,9 +344,9 @@ def clear(
             cleared.append("file_access_tracker")
 
         if cleared:
-            console.print(f"[green]Cleared: {', '.join(cleared)}[/green]")
+            console.print(f"[nexus.success]Cleared: {', '.join(cleared)}[/nexus.success]")
         else:
-            console.print("[yellow]No caches were cleared[/yellow]")
+            console.print("[nexus.warning]No caches were cleared[/nexus.warning]")
 
         nx.close()
 
@@ -390,7 +392,7 @@ def hot(
 
         def _render(data: list[dict[str, Any]]) -> None:
             if not data:
-                console.print("[yellow]No hot files detected yet.[/yellow]")
+                console.print("[nexus.warning]No hot files detected yet.[/nexus.warning]")
                 console.print("Hot files are tracked as the filesystem is used.")
                 return
 
@@ -399,7 +401,7 @@ def hot(
 
             for i, entry in enumerate(data, 1):
                 console.print(
-                    f"{i:3}. [cyan]{entry['path']}[/cyan] ({entry['access_count']} accesses)"
+                    f"{i:3}. [nexus.path]{entry['path']}[/nexus.path] ({entry['access_count']} accesses)"
                 )
 
         render_output(

--- a/src/nexus/cli/commands/catalog.py
+++ b/src/nexus/cli/commands/catalog.py
@@ -13,7 +13,8 @@ from urllib.parse import quote
 
 import click
 
-from nexus.cli.utils import add_backend_options, console
+from nexus.cli.theme import console
+from nexus.cli.utils import add_backend_options
 
 logger = logging.getLogger(__name__)
 
@@ -52,12 +53,12 @@ def catalog_schema(
     try:
         result: dict[str, Any] = client.get(f"/api/v2/catalog/schema/{encoded_path}")
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from e
 
     schema: dict[str, Any] | None = result.get("schema")
     if schema is None:
-        console.print(f"[yellow]No schema available for {path}[/yellow]")
+        console.print(f"[nexus.warning]No schema available for {path}[/nexus.warning]")
         return
 
     console.print(f"[bold]Schema for {path}[/bold]")
@@ -75,7 +76,7 @@ def catalog_schema(
             nullable = " (nullable)" if col.get("nullable", "False").lower() == "true" else ""
             console.print(f"    {col['name']:20s} {col['type']}{nullable}")
     else:
-        console.print("  [dim]No columns detected[/dim]")
+        console.print("  [nexus.muted]No columns detected[/nexus.muted]")
 
 
 @catalog.command(name="search")
@@ -100,12 +101,12 @@ def catalog_search(
     try:
         result: dict[str, Any] = client.get("/api/v2/catalog/search", params={"column": column})
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from e
 
     results: list[dict[str, Any]] = result.get("results", [])
     if not results:
-        console.print(f"[yellow]No files found with column '{column}'[/yellow]")
+        console.print(f"[nexus.warning]No files found with column '{column}'[/nexus.warning]")
         return
 
     console.print(f"[bold]Files containing column '{column}':[/bold]")
@@ -115,5 +116,5 @@ def catalog_search(
 
     if result.get("capped"):
         console.print(
-            f"\n[yellow]Results capped at {result['total']}. Refine your search.[/yellow]"
+            f"\n[nexus.warning]Results capped at {result['total']}. Refine your search.[/nexus.warning]"
         )

--- a/src/nexus/cli/commands/config_cmd.py
+++ b/src/nexus/cli/commands/config_cmd.py
@@ -11,7 +11,6 @@ Supported keys:
 from typing import Any
 
 import click
-from rich.console import Console
 
 from nexus.cli.config import (
     SUPPORTED_SETTINGS,
@@ -24,9 +23,8 @@ from nexus.cli.config import (
     set_setting,
 )
 from nexus.cli.output import OutputOptions, add_output_options, render_output
+from nexus.cli.theme import console
 from nexus.cli.timing import CommandTiming
-
-console = Console()
 
 
 @click.group(name="config")
@@ -67,11 +65,11 @@ def show_cmd(output_opts: OutputOptions) -> None:
         table = Table(title=f"Configuration ({get_config_path()})")
         table.add_column("Key", style="bold")
         table.add_column("Value")
-        table.add_column("Source", style="dim")
+        table.add_column("Source", style="nexus.muted")
 
         for key in sorted(merged):
             value, source = merged[key]
-            value_str = str(value) if value is not None else "[dim]null[/dim]"
+            value_str = str(value) if value is not None else "[nexus.muted]null[/nexus.muted]"
             table.add_row(key, value_str, source)
 
         console.print(table)
@@ -98,8 +96,10 @@ def get_cmd(key: str) -> None:
         nexus config get timing.enabled
     """
     if key not in SUPPORTED_SETTINGS:
-        console.print(f"[red]Error:[/red] Unknown setting: {key}")
-        console.print(f"[dim]Supported keys: {', '.join(sorted(SUPPORTED_SETTINGS))}[/dim]")
+        console.print(f"[nexus.error]Error:[/nexus.error] Unknown setting: {key}")
+        console.print(
+            f"[nexus.muted]Supported keys: {', '.join(sorted(SUPPORTED_SETTINGS))}[/nexus.muted]"
+        )
         raise SystemExit(1)
 
     config = load_cli_config()
@@ -119,8 +119,10 @@ def set_cmd(key: str, value: str) -> None:
         nexus config set connection.timeout 60
     """
     if key not in SUPPORTED_SETTINGS:
-        console.print(f"[red]Error:[/red] Unknown setting: {key}")
-        console.print(f"[dim]Supported keys: {', '.join(sorted(SUPPORTED_SETTINGS))}[/dim]")
+        console.print(f"[nexus.error]Error:[/nexus.error] Unknown setting: {key}")
+        console.print(
+            f"[nexus.muted]Supported keys: {', '.join(sorted(SUPPORTED_SETTINGS))}[/nexus.muted]"
+        )
         raise SystemExit(1)
 
     config = load_cli_config()
@@ -139,8 +141,10 @@ def reset_cmd(key: str) -> None:
         nexus config reset timing.enabled
     """
     if key not in SUPPORTED_SETTINGS:
-        console.print(f"[red]Error:[/red] Unknown setting: {key}")
-        console.print(f"[dim]Supported keys: {', '.join(sorted(SUPPORTED_SETTINGS))}[/dim]")
+        console.print(f"[nexus.error]Error:[/nexus.error] Unknown setting: {key}")
+        console.print(
+            f"[nexus.muted]Supported keys: {', '.join(sorted(SUPPORTED_SETTINGS))}[/nexus.muted]"
+        )
         raise SystemExit(1)
 
     config = load_cli_config()

--- a/src/nexus/cli/commands/conflicts.py
+++ b/src/nexus/cli/commands/conflicts.py
@@ -91,7 +91,7 @@ def conflicts_show(client: ConflictsClient, conflict_id: str) -> ServiceResult:
     def _render(d: dict) -> None:
         from nexus.cli.theme import console
 
-        console.print(f"[bold cyan]Conflict: {conflict_id}[/bold cyan]")
+        console.print(f"[bold nexus.value]Conflict: {conflict_id}[/bold nexus.value]")
         console.print(f"  Path:        {d.get('path', 'N/A')}")
         console.print(f"  Backend:     {d.get('backend_name', 'N/A')}")
         console.print(f"  Strategy:    {d.get('strategy', 'N/A')}")

--- a/src/nexus/cli/commands/conflicts.py
+++ b/src/nexus/cli/commands/conflicts.py
@@ -47,18 +47,18 @@ def conflicts_list(client: ConflictsClient) -> ServiceResult:
     def _render(d: dict) -> None:
         from rich.table import Table
 
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         items = d.get("conflicts", [])
         if not items:
-            console.print("[green]No unresolved conflicts[/green]")
+            console.print("[nexus.success]No unresolved conflicts[/nexus.success]")
             return
 
         table = Table(title=f"Conflicts ({len(items)})")
-        table.add_column("ID", style="dim")
+        table.add_column("ID", style="nexus.muted")
         table.add_column("Path")
         table.add_column("Backend")
-        table.add_column("Status", style="dim")
+        table.add_column("Status", style="nexus.muted")
 
         for c in items:
             table.add_row(
@@ -89,7 +89,7 @@ def conflicts_show(client: ConflictsClient, conflict_id: str) -> ServiceResult:
     data = client.show(conflict_id)
 
     def _render(d: dict) -> None:
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         console.print(f"[bold cyan]Conflict: {conflict_id}[/bold cyan]")
         console.print(f"  Path:        {d.get('path', 'N/A')}")

--- a/src/nexus/cli/commands/connect_cmd.py
+++ b/src/nexus/cli/commands/connect_cmd.py
@@ -10,15 +10,13 @@ import os
 from urllib.parse import urlparse
 
 import click
-from rich.console import Console
 
 from nexus.cli.config import (
     ProfileEntry,
     load_cli_config,
     save_cli_config,
 )
-
-console = Console()
+from nexus.cli.theme import console
 
 _CONNECT_TIMEOUT = 3.0
 
@@ -81,7 +79,7 @@ def connect_cmd(
             default=False,
         )
         if not save_anyway:
-            console.print("[dim]Aborted. Profile not saved.[/dim]")
+            console.print("[nexus.muted]Aborted. Profile not saved.[/nexus.muted]")
             return
 
     # Save profile
@@ -92,7 +90,7 @@ def connect_cmd(
             default=True,
         )
         if not overwrite:
-            console.print("[dim]Aborted. Profile not saved.[/dim]")
+            console.print("[nexus.muted]Aborted. Profile not saved.[/nexus.muted]")
             return
 
     config.profiles[name] = ProfileEntry(url=url, api_key=api_key, zone_id=zone_id)
@@ -107,7 +105,7 @@ def connect_cmd(
 
 def _test_connection_interactive(url: str, api_key: str | None) -> bool:
     """Test connection with 3s timeout. Returns True if successful."""
-    console.print(f"[dim]Testing connection to {url}...[/dim]")
+    console.print(f"[nexus.muted]Testing connection to {url}...[/nexus.muted]")
 
     try:
         from nexus.remote.rpc_transport import RPCTransport
@@ -124,13 +122,13 @@ def _test_connection_interactive(url: str, api_key: str | None) -> bool:
         )
         result = transport.ping()
         console.print(
-            f"[green]Connected![/green] "
+            f"[nexus.success]Connected![/nexus.success] "
             f"Server version {result.get('version', '?')}, "
             f"zone '{result.get('zone_id', 'default')}'"
         )
         return True
     except Exception as e:
-        console.print(f"[red]Connection failed:[/red] {e}")
+        console.print(f"[nexus.error]Connection failed:[/nexus.error] {e}")
         # Offer retry
         retry = click.confirm("Retry?", default=True)
         if retry:

--- a/src/nexus/cli/commands/connectors.py
+++ b/src/nexus/cli/commands/connectors.py
@@ -15,8 +15,8 @@ from typing import Any
 import click
 
 from nexus.cli.output import OutputOptions, add_output_options, render_output
-from nexus.cli.timing import CommandTiming
 from nexus.cli.theme import console
+from nexus.cli.timing import CommandTiming
 from nexus.cli.utils import (
     add_backend_options,
     handle_error,

--- a/src/nexus/cli/commands/connectors.py
+++ b/src/nexus/cli/commands/connectors.py
@@ -16,9 +16,9 @@ import click
 
 from nexus.cli.output import OutputOptions, add_output_options, render_output
 from nexus.cli.timing import CommandTiming
+from nexus.cli.theme import console
 from nexus.cli.utils import (
     add_backend_options,
-    console,
     handle_error,
 )
 
@@ -31,9 +31,9 @@ def _resolve_http_url(remote_url: str | None) -> tuple[str, str | None]:
     api_key = os.environ.get("NEXUS_API_KEY")
 
     if not url:
-        console.print("[red]Error:[/red] NEXUS_URL or --remote-url is required")
+        console.print("[nexus.error]Error:[/nexus.error] NEXUS_URL or --remote-url is required")
         console.print(
-            "[yellow]Hint:[/yellow] export NEXUS_URL=http://your-nexus-server:2026"
+            "[nexus.warning]Hint:[/nexus.warning] export NEXUS_URL=http://your-nexus-server:2026"
             " or use `eval $(nexus env)`"
         )
         sys.exit(1)
@@ -110,19 +110,23 @@ def list_connectors(
 
         if not connectors:
             if category:
-                console.print(f"[yellow]No connectors found in category '{category}'[/yellow]")
+                console.print(
+                    f"[nexus.warning]No connectors found in category '{category}'[/nexus.warning]"
+                )
             else:
-                console.print("[yellow]No connectors registered[/yellow]")
+                console.print("[nexus.warning]No connectors registered[/nexus.warning]")
             return
 
         def _render(items: list[dict[str, Any]]) -> None:
             from rich.table import Table
 
-            table = Table(title="Available Connectors", show_header=True, header_style="bold cyan")
-            table.add_column("Name", style="green")
+            table = Table(
+                title="Available Connectors", show_header=True, header_style="bold nexus.accent"
+            )
+            table.add_column("Name", style="nexus.success")
             table.add_column("Description")
-            table.add_column("Category", style="yellow")
-            table.add_column("Capabilities", style="dim")
+            table.add_column("Category", style="nexus.warning")
+            table.add_column("Capabilities", style="nexus.muted")
 
             for c in items:
                 caps = c.get("capabilities", [])
@@ -137,7 +141,7 @@ def list_connectors(
                 )
 
             console.print(table)
-            console.print(f"\n[dim]Total: {len(items)} connectors[/dim]")
+            console.print(f"\n[nexus.muted]Total: {len(items)} connectors[/nexus.muted]")
 
         render_output(
             data=connectors,
@@ -176,18 +180,31 @@ def connector_info(
         info = next((c for c in connectors if c["name"] == connector_name), None)
         if not info:
             available = ", ".join(c["name"] for c in connectors)
-            console.print(f"[red]Unknown connector: {connector_name}[/red]")
-            console.print(f"[dim]Available: {available}[/dim]")
+            console.print(f"[nexus.error]Unknown connector: {connector_name}[/nexus.error]")
+            console.print(f"[nexus.muted]Available: {available}[/nexus.muted]")
             sys.exit(1)
 
-        console.print(f"\n[bold cyan]{info['name']}[/bold cyan]")
-        console.print(f"  [dim]Description:[/dim] {info.get('description') or 'No description'}")
-        console.print(f"  [dim]Category:[/dim] {info.get('category', 'unknown')}")
-        console.print(f"  [dim]User-scoped:[/dim] {'Yes' if info.get('user_scoped') else 'No'}")
+        console.print(f"\n[bold nexus.value]{info['name']}[/bold nexus.value]")
+        console.print(
+            f"  [nexus.muted]Description:[/nexus.muted] {info.get('description') or 'No description'}"
+        )
+        console.print(f"  [nexus.muted]Category:[/nexus.muted] {info.get('category', 'unknown')}")
+        console.print(
+            f"  [nexus.muted]User-scoped:[/nexus.muted] {'Yes' if info.get('user_scoped') else 'No'}"
+        )
 
         caps = info.get("capabilities", [])
         if caps:
-            console.print(f"  [dim]Capabilities:[/dim] {', '.join(caps)}")
+            console.print(f"  [nexus.muted]Capabilities:[/nexus.muted] {', '.join(caps)}")
+
+        requires = info.get("requires", [])
+        if requires:
+            console.print(f"  [nexus.muted]Dependencies:[/nexus.muted] {', '.join(requires)}")
+        else:
+            console.print("  [nexus.muted]Dependencies:[/nexus.muted] None (core)")
+
+        if "class" in info:
+            console.print(f"  [nexus.muted]Class:[/nexus.muted] {info['class']}")
 
         console.print()
 
@@ -225,9 +242,13 @@ def connectors_capabilities(
         connectors: list[dict[str, Any]] = data.get("connectors", [])
 
         if name:
-            connectors = [c for c in connectors if c.get("name") == name]
+            connectors = [
+                c for c in connectors if c.get("name") == name or c.get("connector_id") == name
+            ]
             if not connectors:
-                console.print(f"[red]Error:[/red] Connector '{name}' not found")
+                available = ", ".join(c["name"] for c in data.get("connectors", []))
+                console.print(f"[nexus.error]Error:[/nexus.error] Connector '{name}' not found")
+                console.print(f"[nexus.muted]Available: {available}[/nexus.muted]")
                 sys.exit(1)
 
         def _render(items: list[dict[str, Any]]) -> None:
@@ -236,11 +257,11 @@ def connectors_capabilities(
             table = Table(
                 title="Connector Capabilities",
                 show_header=True,
-                header_style="bold cyan",
+                header_style="bold nexus.accent",
             )
-            table.add_column("Name", style="cyan")
-            table.add_column("Category", style="green")
-            table.add_column("Capabilities", style="yellow")
+            table.add_column("Name", style="nexus.value")
+            table.add_column("Category", style="nexus.success")
+            table.add_column("Capabilities", style="nexus.warning")
 
             for c in items:
                 caps = c.get("capabilities", [])
@@ -252,7 +273,7 @@ def connectors_capabilities(
                 )
 
             console.print(table)
-            console.print(f"\n[dim]Total: {len(items)} connectors[/dim]")
+            console.print(f"\n[nexus.muted]Total: {len(items)} connectors[/nexus.muted]")
 
         render_output(
             data=connectors,

--- a/src/nexus/cli/commands/connectors.py
+++ b/src/nexus/cli/commands/connectors.py
@@ -121,7 +121,7 @@ def list_connectors(
             from rich.table import Table
 
             table = Table(
-                title="Available Connectors", show_header=True, header_style="bold nexus.accent"
+                title="Available Connectors", show_header=True, header_style="nexus.table_header"
             )
             table.add_column("Name", style="nexus.success")
             table.add_column("Description")
@@ -257,7 +257,7 @@ def connectors_capabilities(
             table = Table(
                 title="Connector Capabilities",
                 show_header=True,
-                header_style="bold nexus.accent",
+                header_style="nexus.table_header",
             )
             table.add_column("Name", style="nexus.value")
             table.add_column("Category", style="nexus.success")

--- a/src/nexus/cli/commands/context.py
+++ b/src/nexus/cli/commands/context.py
@@ -273,9 +273,11 @@ def branches_cmd(
         table.add_column("Parent")
 
         for b in branches:
-            status_color = {"active": "green", "merged": "blue", "discarded": "red"}.get(
-                b.status, "white"
-            )
+            status_color = {
+                "active": "nexus.success",
+                "merged": "nexus.reference",
+                "discarded": "nexus.error",
+            }.get(b.status, "")
             table.add_row(
                 b.branch_name,
                 f"[{status_color}]{b.status}[/{status_color}]",

--- a/src/nexus/cli/commands/context.py
+++ b/src/nexus/cli/commands/context.py
@@ -3,12 +3,10 @@
 from typing import Any
 
 import click
-from rich.console import Console
 from rich.table import Table
 
+from nexus.cli.theme import console
 from nexus.cli.utils import add_backend_options, get_filesystem, handle_error
-
-console = Console()
 
 
 def _get_branch_service(nx: Any) -> Any:
@@ -58,12 +56,14 @@ def commit_cmd(
         nx = get_filesystem(remote_url, remote_api_key)
         svc = _get_branch_service(nx)
         if not svc:
-            console.print("[red]Context branching not available (service not configured)[/red]")
+            console.print(
+                "[nexus.error]Context branching not available (service not configured)[/nexus.error]"
+            )
             return
         result = svc.commit(workspace, message=message, branch_name=branch)
         snap = result["snapshot"]
         console.print(
-            f"[green]✓[/green] Committed v{snap['snapshot_number']} on branch '{result['branch']}'"
+            f"[nexus.success]✓[/nexus.success] Committed v{snap['snapshot_number']} on branch '{result['branch']}'"
         )
         if snap.get("description"):
             console.print(f"  Message: {snap['description']}")
@@ -94,11 +94,11 @@ def branch_cmd(
         nx = get_filesystem(remote_url, remote_api_key)
         svc = _get_branch_service(nx)
         if not svc:
-            console.print("[red]Context branching not available[/red]")
+            console.print("[nexus.error]Context branching not available[/nexus.error]")
             return
         result = svc.create_branch(workspace, name, from_branch=from_branch)
         console.print(
-            f"[green]✓[/green] Created branch '{result.branch_name}' "
+            f"[nexus.success]✓[/nexus.success] Created branch '{result.branch_name}' "
             f"from '{result.parent_branch or 'main'}'"
         )
         if result.fork_point_id:
@@ -128,10 +128,10 @@ def checkout_cmd(
         nx = get_filesystem(remote_url, remote_api_key)
         svc = _get_branch_service(nx)
         if not svc:
-            console.print("[red]Context branching not available[/red]")
+            console.print("[nexus.error]Context branching not available[/nexus.error]")
             return
         result = svc.checkout(workspace, target)
-        console.print(f"[green]✓[/green] Switched to branch '{result['branch']}'")
+        console.print(f"[nexus.success]✓[/nexus.success] Switched to branch '{result['branch']}'")
         if result.get("restore_info"):
             ri = result["restore_info"]
             console.print(
@@ -172,16 +172,16 @@ def merge_cmd(
         nx = get_filesystem(remote_url, remote_api_key)
         svc = _get_branch_service(nx)
         if not svc:
-            console.print("[red]Context branching not available[/red]")
+            console.print("[nexus.error]Context branching not available[/nexus.error]")
             return
         result = svc.merge(workspace, source, target_branch=target, strategy=strategy)
         if result.fast_forward:
             console.print(
-                f"[green]✓[/green] Fast-forward merge: '{source}' → '{target or 'current'}'"
+                f"[nexus.success]✓[/nexus.success] Fast-forward merge: '{source}' → '{target or 'current'}'"
             )
         else:
             console.print(
-                f"[green]✓[/green] Merged '{source}' → '{target or 'current'}' "
+                f"[nexus.success]✓[/nexus.success] Merged '{source}' → '{target or 'current'}' "
                 f"(+{result.files_added} -{result.files_removed} ~{result.files_modified})"
             )
         nx.close()
@@ -209,24 +209,24 @@ def log_cmd(
         nx = get_filesystem(remote_url, remote_api_key)
         svc = _get_branch_service(nx)
         if not svc:
-            console.print("[red]Context branching not available[/red]")
+            console.print("[nexus.error]Context branching not available[/nexus.error]")
             return
         snapshots = svc.log(workspace, limit=limit)
 
         if not snapshots:
-            console.print("[dim]No snapshots found[/dim]")
+            console.print("[nexus.muted]No snapshots found[/nexus.muted]")
             nx.close()
             return
 
         table = Table(title=f"Context Log: {workspace}")
         table.add_column("#", style="bold")
         table.add_column("Description")
-        table.add_column("Created", style="dim")
+        table.add_column("Created", style="nexus.muted")
 
         for s in snapshots:
             table.add_row(
                 str(s.get("snapshot_number", "")),
-                s.get("description", "") or "[dim]no message[/dim]",
+                s.get("description", "") or "[nexus.muted]no message[/nexus.muted]",
                 str(s.get("created_at", ""))[:19],
             )
 
@@ -256,12 +256,12 @@ def branches_cmd(
         nx = get_filesystem(remote_url, remote_api_key)
         svc = _get_branch_service(nx)
         if not svc:
-            console.print("[red]Context branching not available[/red]")
+            console.print("[nexus.error]Context branching not available[/nexus.error]")
             return
         branches = svc.list_branches(workspace, include_inactive=show_all)
 
         if not branches:
-            console.print("[dim]No branches found[/dim]")
+            console.print("[nexus.muted]No branches found[/nexus.muted]")
             nx.close()
             return
 
@@ -279,7 +279,7 @@ def branches_cmd(
             table.add_row(
                 b.branch_name,
                 f"[{status_color}]{b.status}[/{status_color}]",
-                "[green]*[/green]" if b.is_current else "",
+                "[nexus.success]*[/nexus.success]" if b.is_current else "",
                 (b.head_snapshot_id or "")[:12],
                 b.parent_branch or "",
             )
@@ -311,21 +311,21 @@ def diff_cmd(
         nx = get_filesystem(remote_url, remote_api_key)
         svc = _get_branch_service(nx)
         if not svc:
-            console.print("[red]Context branching not available[/red]")
+            console.print("[nexus.error]Context branching not available[/nexus.error]")
             return
         result = svc.diff(workspace, from_ref, to_ref)
         added = result.get("added", [])
         removed = result.get("removed", [])
         modified = result.get("modified", [])
         console.print(
-            f"[green]+{len(added)}[/green] added, [red]-{len(removed)}[/red] removed, [yellow]~{len(modified)}[/yellow] modified"
+            f"[nexus.success]+{len(added)}[/nexus.success] added, [nexus.error]-{len(removed)}[/nexus.error] removed, [nexus.warning]~{len(modified)}[/nexus.warning] modified"
         )
         for f in added:
-            console.print(f"  [green]+[/green] {f['path']}")
+            console.print(f"  [nexus.success]+[/nexus.success] {f['path']}")
         for f in removed:
-            console.print(f"  [red]-[/red] {f['path']}")
+            console.print(f"  [nexus.error]-[/nexus.error] {f['path']}")
         for f in modified:
-            console.print(f"  [yellow]~[/yellow] {f['path']}")
+            console.print(f"  [nexus.warning]~[/nexus.warning] {f['path']}")
         nx.close()
     except Exception as e:
         handle_error(e)
@@ -350,12 +350,14 @@ def explore_cmd(
         nx = get_filesystem(remote_url, remote_api_key)
         svc = _get_branch_service(nx)
         if not svc:
-            console.print("[red]Context branching not available[/red]")
+            console.print("[nexus.error]Context branching not available[/nexus.error]")
             return
         result = svc.explore(workspace, description)
-        console.print(f"[green]✓[/green] Exploring on branch '{result.branch_name}'")
+        console.print(
+            f"[nexus.success]✓[/nexus.success] Exploring on branch '{result.branch_name}'"
+        )
         if result.skipped_commit:
-            console.print("  [dim]Skipped auto-commit (workspace unchanged)[/dim]")
+            console.print("  [nexus.muted]Skipped auto-commit (workspace unchanged)[/nexus.muted]")
         if result.fork_point_snapshot_id:
             console.print(f"  Fork point: {result.fork_point_snapshot_id[:12]}...")
         nx.close()
@@ -397,14 +399,16 @@ def finish_cmd(
         nx = get_filesystem(remote_url, remote_api_key)
         svc = _get_branch_service(nx)
         if not svc:
-            console.print("[red]Context branching not available[/red]")
+            console.print("[nexus.error]Context branching not available[/nexus.error]")
             return
         result = svc.finish_explore(workspace, branch, outcome=outcome, strategy=strategy)
         if result["outcome"] == "merged":
-            console.print(f"[green]✓[/green] Merged '{branch}' into '{result['merged_into']}'")
+            console.print(
+                f"[nexus.success]✓[/nexus.success] Merged '{branch}' into '{result['merged_into']}'"
+            )
         else:
             console.print(
-                f"[yellow]✓[/yellow] Discarded branch '{branch}', returned to '{result['returned_to']}'"
+                f"[nexus.warning]✓[/nexus.warning] Discarded branch '{branch}', returned to '{result['returned_to']}'"
             )
         nx.close()
     except Exception as e:

--- a/src/nexus/cli/commands/delegation.py
+++ b/src/nexus/cli/commands/delegation.py
@@ -74,9 +74,9 @@ def delegation_create(
     )
 
     def _render(d: dict) -> None:
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
-        console.print("[green]Delegation created[/green]")
+        console.print("[nexus.success]Delegation created[/nexus.success]")
         console.print(f"  ID:          {d.get('delegation_id', 'N/A')}")
         console.print(f"  Coordinator: {d.get('coordinator_agent_id', coordinator)}")
         console.print(f"  Worker:      {d.get('worker_id', worker)}")
@@ -113,20 +113,20 @@ def delegation_list(
     def _render(d: dict) -> None:
         from rich.table import Table
 
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         delegations = d.get("delegations", [])
         if not delegations:
-            console.print("[yellow]No active delegations[/yellow]")
+            console.print("[nexus.warning]No active delegations[/nexus.warning]")
             return
 
         table = Table(title=f"Delegations ({len(delegations)})")
-        table.add_column("ID", style="dim")
+        table.add_column("ID", style="nexus.muted")
         table.add_column("Coordinator")
         table.add_column("Worker")
         table.add_column("Mode")
         table.add_column("Status")
-        table.add_column("Created", style="dim")
+        table.add_column("Created", style="nexus.muted")
 
         for dlg in delegations:
             table.add_row(
@@ -177,7 +177,7 @@ def delegation_show(client: DelegationClient, delegation_id: str) -> ServiceResu
     data = client.show(delegation_id)
 
     def _render(d: dict) -> None:
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         console.print(f"[bold cyan]Delegation Chain: {delegation_id}[/bold cyan]")
         chain = d.get("chain", [d])

--- a/src/nexus/cli/commands/delegation.py
+++ b/src/nexus/cli/commands/delegation.py
@@ -179,7 +179,7 @@ def delegation_show(client: DelegationClient, delegation_id: str) -> ServiceResu
     def _render(d: dict) -> None:
         from nexus.cli.theme import console
 
-        console.print(f"[bold cyan]Delegation Chain: {delegation_id}[/bold cyan]")
+        console.print(f"[bold nexus.value]Delegation Chain: {delegation_id}[/bold nexus.value]")
         chain = d.get("chain", [d])
         for i, link in enumerate(chain):
             prefix = "  └─" if i == len(chain) - 1 else "  ├─"

--- a/src/nexus/cli/commands/demo.py
+++ b/src/nexus/cli/commands/demo.py
@@ -40,7 +40,7 @@ from nexus.cli.commands.demo_data import (
     MANIFEST_FILENAME,
     PLAN_VERSIONS,
 )
-from nexus.cli.utils import console
+from nexus.cli.theme import console
 
 logger = logging.getLogger(__name__)
 
@@ -109,7 +109,7 @@ def _load_project_config() -> dict[str, Any]:
         if p.exists():
             with open(p) as f:
                 return yaml.safe_load(f) or {}
-    console.print("[red]Error:[/red] No nexus.yaml found. Run `nexus init` first.")
+    console.print("[nexus.error]Error:[/nexus.error] No nexus.yaml found. Run `nexus init` first.")
     raise SystemExit(1)
 
 
@@ -184,9 +184,11 @@ async def _get_nexus_client(config: dict[str, Any]) -> Any:
             await nx.sys_readdir("/")
             return nx
         except Exception as e:
-            console.print(f"[red]Error:[/red] Could not connect to Nexus server: {e}")
             console.print(
-                f"[yellow]Hint:[/yellow] Is `nexus up` running? Expected gRPC on port {grpc_port}."
+                f"[nexus.error]Error:[/nexus.error] Could not connect to Nexus server: {e}"
+            )
+            console.print(
+                f"[nexus.warning]Hint:[/nexus.warning] Is `nexus up` running? Expected gRPC on port {grpc_port}."
             )
             raise
 
@@ -227,7 +229,7 @@ async def _seed_files(
             seeded.append(path)
             created += 1
         except Exception as e:
-            console.print(f"  [yellow]Warning:[/yellow] Could not create {path}: {e}")
+            console.print(f"  [nexus.warning]Warning:[/nexus.warning] Could not create {path}: {e}")
 
     manifest["files"] = seeded
     return created
@@ -1429,15 +1431,17 @@ async def _async_demo_init(reset: bool, skip_semantic: bool) -> None:
     try:
         nx = await _get_nexus_client(config)
     except Exception as e:
-        console.print(f"[red]Error:[/red] Could not connect to Nexus: {e}")
-        console.print("[yellow]Hint:[/yellow] Is the server running? Try `nexus up` first.")
+        console.print(f"[nexus.error]Error:[/nexus.error] Could not connect to Nexus: {e}")
+        console.print(
+            "[nexus.warning]Hint:[/nexus.warning] Is the server running? Try `nexus up` first."
+        )
         raise SystemExit(1) from e
 
     # Load or reset manifest
     if reset:
         old_manifest = _load_manifest(data_dir)
         if old_manifest:
-            console.print("[yellow]Resetting demo data...[/yellow]")
+            console.print("[nexus.warning]Resetting demo data...[/nexus.warning]")
             revoked = _revoke_identities(config, old_manifest)
             if revoked:
                 console.print(f"  Revoked {revoked} identity API keys.")
@@ -1621,32 +1625,34 @@ async def _async_demo_reset() -> None:
 
     manifest = _load_manifest(data_dir)
     if not manifest:
-        console.print("[yellow]No demo data found (no manifest).[/yellow]")
+        console.print("[nexus.warning]No demo data found (no manifest).[/nexus.warning]")
         raise SystemExit(0)
 
     # Revoke identity API keys (best-effort)
     revoked = _revoke_identities(config, manifest)
     if revoked:
-        console.print(f"[green]✓[/green] Revoked {revoked} identity API keys.")
+        console.print(f"[nexus.success]✓[/nexus.success] Revoked {revoked} identity API keys.")
 
     # Delete permission tuples (best-effort, before file deletion)
     try:
         nx = await _get_nexus_client(config)
     except Exception as e:
-        console.print(f"[yellow]Warning:[/yellow] Could not connect to Nexus: {e}")
+        console.print(f"[nexus.warning]Warning:[/nexus.warning] Could not connect to Nexus: {e}")
         nx = None
 
     perms_deleted = _delete_permissions(nx, config) if nx else 0
     if perms_deleted > 0:
-        console.print(f"[green]✓[/green] Deleted {perms_deleted} permission tuples.")
+        console.print(
+            f"[nexus.success]✓[/nexus.success] Deleted {perms_deleted} permission tuples."
+        )
 
     # Delete demo files
     if nx is not None:
         try:
             removed = await _delete_demo_files(nx, manifest)
-            console.print(f"[green]✓[/green] Removed {removed} demo files.")
+            console.print(f"[nexus.success]✓[/nexus.success] Removed {removed} demo files.")
         except Exception as e:
-            console.print(f"[yellow]Warning:[/yellow] Could not remove files: {e}")
+            console.print(f"[nexus.warning]Warning:[/nexus.warning] Could not remove files: {e}")
         with contextlib.suppress(Exception):
             nx.close()
 
@@ -1654,6 +1660,6 @@ async def _async_demo_reset() -> None:
     mp = _manifest_path(data_dir)
     if mp.exists():
         mp.unlink()
-        console.print("[green]✓[/green] Manifest removed.")
+        console.print("[nexus.success]✓[/nexus.success] Manifest removed.")
 
-    console.print("[green]Demo data reset complete.[/green]")
+    console.print("[nexus.success]Demo data reset complete.[/nexus.success]")

--- a/src/nexus/cli/commands/directory.py
+++ b/src/nexus/cli/commands/directory.py
@@ -124,10 +124,10 @@ def list_files(
                     from rich.table import Table
 
                     table = Table(title=f"Files in {path}")
-                    table.add_column("Type", style="magenta", width=4)
-                    table.add_column("Path", style="cyan")
-                    table.add_column("Size", justify="right", style="green")
-                    table.add_column("Modified", style="yellow")
+                    table.add_column("Type", style="nexus.identity", width=4)
+                    table.add_column("Path", style="nexus.path")
+                    table.add_column("Size", justify="right", style="nexus.success")
+                    table.add_column("Modified", style="nexus.warning")
 
                     for entry in entries:
                         is_dir = entry["type"] == "directory"
@@ -181,7 +181,9 @@ def _ls_time_travel(
     """Handle time-travel ls (--at-operation)."""
     time_travel = getattr(nx, "time_travel_service", None)
     if time_travel is None:
-        console.print("[red]Error:[/red] Time-travel is only supported with local NexusFS")
+        console.print(
+            "[nexus.error]Error:[/nexus.error] Time-travel is only supported with local NexusFS"
+        )
         return
 
     with timing.phase("server"):
@@ -260,10 +262,14 @@ def mkdir(
                 if if_not_exists:
                     with contextlib.suppress(FileExistsError):
                         await nx.mkdir(path, parents=parents, exist_ok=True)
-                    console.print(f"[green]✓[/green] Directory exists: [cyan]{path}[/cyan]")
+                    console.print(
+                        f"[nexus.success]✓[/nexus.success] Directory exists: [nexus.path]{path}[/nexus.path]"
+                    )
                 else:
                     await nx.mkdir(path, parents=parents, exist_ok=True)
-                    console.print(f"[green]✓[/green] Created directory [cyan]{path}[/cyan]")
+                    console.print(
+                        f"[nexus.success]✓[/nexus.success] Created directory [nexus.path]{path}[/nexus.path]"
+                    )
         except Exception as e:
             handle_error(e)
 
@@ -309,10 +315,12 @@ def rmdir(
                 allow_local_default=True,
             ) as nx:
                 if not force and not click.confirm(f"Remove directory {path}?"):
-                    console.print("[yellow]Cancelled[/yellow]")
+                    console.print("[nexus.warning]Cancelled[/nexus.warning]")
                     return
                 await nx.sys_rmdir(path, recursive=recursive)
-            console.print(f"[green]✓[/green] Removed directory [cyan]{path}[/cyan]")
+            console.print(
+                f"[nexus.success]✓[/nexus.success] Removed directory [nexus.path]{path}[/nexus.path]"
+            )
         except Exception as e:
             handle_error(e)
 
@@ -430,7 +438,7 @@ def tree(
                             total_files += 1
                             if show_size and value is not None:
                                 console.print(
-                                    f"{prefix}{connector}{name} [dim]({_fmt_size(value)})[/dim]"
+                                    f"{prefix}{connector}{name} [nexus.muted]({_fmt_size(value)})[/nexus.muted]"
                                 )
                                 total_size += value
                             else:
@@ -441,9 +449,11 @@ def tree(
                 file_count, total_sz = _print_node(tree_dict)
                 console.print()
                 if show_size:
-                    console.print(f"[dim]{file_count} files, {_fmt_size(total_sz)} total[/dim]")
+                    console.print(
+                        f"[nexus.muted]{file_count} files, {_fmt_size(total_sz)} total[/nexus.muted]"
+                    )
                 else:
-                    console.print(f"[dim]{file_count} files[/dim]")
+                    console.print(f"[nexus.muted]{file_count} files[/nexus.muted]")
 
             render_output(
                 data=tree_data, output_opts=output_opts, timing=timing, human_formatter=_print_human

--- a/src/nexus/cli/commands/directory.py
+++ b/src/nexus/cli/commands/directory.py
@@ -143,7 +143,9 @@ def list_files(
                 else:
                     for entry in entries:
                         if entry["type"] == "directory":
-                            console.print(f"  [bold cyan]{entry['path']}/[/bold cyan]")
+                            console.print(
+                                f"  [bold nexus.value]{entry['path']}/[/bold nexus.value]"
+                            )
                         else:
                             console.print(f"  {entry['path']}")
 
@@ -210,7 +212,7 @@ def _ls_time_travel(
 
     def _print_human(entries: list[dict[str, Any]]) -> None:
         console.print(
-            f"[bold cyan]Time-Travel Mode - Files at operation {at_operation}[/bold cyan]"
+            f"[bold nexus.value]Time-Travel Mode - Files at operation {at_operation}[/bold nexus.value]"
         )
         console.print()
         for entry in entries:
@@ -430,7 +432,9 @@ def tree(
                         connector = "└── " if is_last else "├── "
                         extension = "    " if is_last else "│   "
                         if isinstance(value, dict):
-                            console.print(f"{prefix}{connector}[bold cyan]{name}/[/bold cyan]")
+                            console.print(
+                                f"{prefix}{connector}[bold nexus.value]{name}/[/bold nexus.value]"
+                            )
                             f, s = _print_node(value, prefix + extension, depth + 1)
                             total_files += f
                             total_size += s
@@ -445,7 +449,7 @@ def tree(
                                 console.print(f"{prefix}{connector}{name}")
                     return total_files, total_size
 
-                console.print(f"[bold green]{path}[/bold green]")
+                console.print(f"[bold nexus.success]{path}[/bold nexus.success]")
                 file_count, total_sz = _print_node(tree_dict)
                 console.print()
                 if show_size:

--- a/src/nexus/cli/commands/doctor.py
+++ b/src/nexus/cli/commands/doctor.py
@@ -20,8 +20,9 @@ from typing import Any
 import click
 
 from nexus.cli.output import OutputOptions, add_output_options, render_output
+from nexus.cli.theme import console
 from nexus.cli.timing import CommandTiming
-from nexus.cli.utils import console, handle_error
+from nexus.cli.utils import handle_error
 
 # ---------------------------------------------------------------------------
 # Check result model
@@ -521,9 +522,9 @@ def _try_fix(result: CheckResult) -> CheckResult | None:
 # ---------------------------------------------------------------------------
 
 _STATUS_ICONS = {
-    CheckStatus.OK: "[green]ok[/green]",
-    CheckStatus.WARNING: "[yellow]warning[/yellow]",
-    CheckStatus.ERROR: "[red]ERROR[/red]",
+    CheckStatus.OK: "[nexus.success]ok[/nexus.success]",
+    CheckStatus.WARNING: "[nexus.warning]warning[/nexus.warning]",
+    CheckStatus.ERROR: "[nexus.error]ERROR[/nexus.error]",
 }
 
 
@@ -565,7 +566,7 @@ def _display_results(results: dict[str, list[CheckResult]]) -> int:
             icon = _STATUS_ICONS[check.status]
             console.print(f"  {icon}  {check.name}: {check.message}")
             if check.fix_hint and check.status != CheckStatus.OK:
-                console.print(f"       [dim]Fix: {check.fix_hint}[/dim]")
+                console.print(f"       [nexus.muted]Fix: {check.fix_hint}[/nexus.muted]")
             if check.status == CheckStatus.ERROR:
                 has_error = True
 
@@ -581,9 +582,9 @@ def _display_results(results: dict[str, list[CheckResult]]) -> int:
     console.print()
     console.print(
         f"[bold]{total} checks:[/bold] "
-        f"[green]{ok_count} ok[/green], "
-        f"[yellow]{warn_count} warnings[/yellow], "
-        f"[red]{err_count} errors[/red]"
+        f"[nexus.success]{ok_count} ok[/nexus.success], "
+        f"[nexus.warning]{warn_count} warnings[/nexus.warning], "
+        f"[nexus.error]{err_count} errors[/nexus.error]"
     )
     return 1 if has_error else 0
 

--- a/src/nexus/cli/commands/env_cmd.py
+++ b/src/nexus/cli/commands/env_cmd.py
@@ -22,7 +22,7 @@ from nexus.cli.state import (
     load_runtime_state,
     resolve_connection_env,
 )
-from nexus.cli.utils import console
+from nexus.cli.theme import console
 
 # ---------------------------------------------------------------------------
 # Shell formatting helpers
@@ -145,7 +145,9 @@ def env_cmd(
     env_vars = resolve_connection_env(config, state)
 
     if not env_vars:
-        console.print("[yellow]No connection info found.[/yellow] Run `nexus up` first.")
+        console.print(
+            "[nexus.warning]No connection info found.[/nexus.warning] Run `nexus up` first."
+        )
         raise SystemExit(1)
 
     if json_output:
@@ -189,5 +191,5 @@ def run(command: tuple[str, ...]) -> None:
         result = subprocess.run(list(command), env=run_env)
         sys.exit(result.returncode)
     except FileNotFoundError as err:
-        console.print(f"[red]Error:[/red] Command not found: {command[0]}")
+        console.print(f"[nexus.error]Error:[/nexus.error] Command not found: {command[0]}")
         raise SystemExit(127) from err

--- a/src/nexus/cli/commands/events_cli.py
+++ b/src/nexus/cli/commands/events_cli.py
@@ -74,12 +74,12 @@ def events_replay(
 
             evts = d.get("events", [])
             if not evts:
-                console.print("[yellow]No events found[/yellow]")
+                console.print("[nexus.warning]No events found[/nexus.warning]")
                 return
 
             table = Table(title=f"Events ({len(evts)})")
-            table.add_column("Seq", style="dim", justify="right")
-            table.add_column("Time", style="dim")
+            table.add_column("Seq", style="nexus.muted", justify="right")
+            table.add_column("Time", style="nexus.muted")
             table.add_column("Type")
             table.add_column("Path")
             table.add_column("Agent")
@@ -101,5 +101,5 @@ def events_replay(
             human_formatter=_render,
         )
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from None

--- a/src/nexus/cli/commands/exchange.py
+++ b/src/nexus/cli/commands/exchange.py
@@ -62,7 +62,7 @@ def exchange_list(
         output_opts=output_opts,
         timing=timing,
         human_formatter=lambda _d: console.print(
-            "[yellow]Exchange offer listing is not yet available.[/yellow]\n"
+            "[nexus.warning]Exchange offer listing is not yet available.[/nexus.warning]\n"
             "This feature is planned for Phase 2. See issue #2811."
         ),
     )
@@ -92,7 +92,7 @@ def exchange_create(
         output_opts=output_opts,
         timing=timing,
         human_formatter=lambda _d: console.print(
-            "[yellow]Exchange offer creation is not yet available.[/yellow]\n"
+            "[nexus.warning]Exchange offer creation is not yet available.[/nexus.warning]\n"
             "This feature is planned for Phase 2. See issue #2811."
         ),
     )
@@ -119,7 +119,7 @@ def exchange_show(
         output_opts=output_opts,
         timing=timing,
         human_formatter=lambda _d: console.print(
-            "[yellow]Exchange offer details are not yet available.[/yellow]\n"
+            "[nexus.warning]Exchange offer details are not yet available.[/nexus.warning]\n"
             "This feature is planned for Phase 2. See issue #2811."
         ),
     )
@@ -146,7 +146,7 @@ def exchange_cancel(
         output_opts=output_opts,
         timing=timing,
         human_formatter=lambda _d: console.print(
-            "[yellow]Exchange offer cancellation is not yet available.[/yellow]\n"
+            "[nexus.warning]Exchange offer cancellation is not yet available.[/nexus.warning]\n"
             "This feature is planned for Phase 2. See issue #2811."
         ),
     )

--- a/src/nexus/cli/commands/federation.py
+++ b/src/nexus/cli/commands/federation.py
@@ -62,17 +62,17 @@ def federation_status(
         def _render(d: dict[str, Any]) -> None:
             zones = d.get("zones", [])
             console.print("[bold cyan]Federation Status[/bold cyan]")
-            console.print(f"  Total zones: [yellow]{len(zones)}[/yellow]")
+            console.print(f"  Total zones: [nexus.warning]{len(zones)}[/nexus.warning]")
 
             total_links = sum(z.get("links_count", 0) for z in zones)
-            console.print(f"  Total links: [yellow]{total_links}[/yellow]")
+            console.print(f"  Total links: [nexus.warning]{total_links}[/nexus.warning]")
 
             if zones:
                 console.print("\n[bold]Zones:[/bold]")
                 for z in zones:
                     zone_id = z.get("zone_id", "unknown")
                     links = z.get("links_count", 0)
-                    console.print(f"  [cyan]{zone_id}[/cyan]  links={links}")
+                    console.print(f"  [nexus.value]{zone_id}[/nexus.value]  links={links}")
 
         render_output(
             data=data,
@@ -81,7 +81,7 @@ def federation_status(
             human_formatter=_render,
         )
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from None
 
 
@@ -109,11 +109,11 @@ def federation_zones(
         def _render(d: dict[str, Any]) -> None:
             zones = d.get("zones", [])
             if not zones:
-                console.print("[dim]No federation zones found[/dim]")
+                console.print("[nexus.muted]No federation zones found[/nexus.muted]")
                 return
 
             table = Table(title=f"Federation Zones ({len(zones)})")
-            table.add_column("Zone ID", style="cyan")
+            table.add_column("Zone ID", style="nexus.value")
             table.add_column("Links", justify="right")
 
             for z in zones:
@@ -130,7 +130,7 @@ def federation_zones(
             human_formatter=_render,
         )
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from None
 
 
@@ -170,7 +170,7 @@ def federation_info(
             human_formatter=_render,
         )
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from None
 
 
@@ -224,12 +224,12 @@ def federation_mount(
 
         def _render(_d: dict[str, Any]) -> None:  # noqa: ARG001
             console.print(
-                f"[green]Mounted zone '{target_zone}' at '{path}' in zone '{parent_zone}'[/green]"
+                f"[nexus.success]Mounted zone '{target_zone}' at '{path}' in zone '{parent_zone}'[/nexus.success]"
             )
 
         render_output(data=data, output_opts=output_opts, timing=timing, human_formatter=_render)
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from None
 
 
@@ -274,11 +274,13 @@ def federation_unmount(
             )
 
         def _render(_d: dict[str, Any]) -> None:  # noqa: ARG001
-            console.print(f"[green]Unmounted '{path}' from zone '{parent_zone}'[/green]")
+            console.print(
+                f"[nexus.success]Unmounted '{path}' from zone '{parent_zone}'[/nexus.success]"
+            )
 
         render_output(data=data, output_opts=output_opts, timing=timing, human_formatter=_render)
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from None
 
 

--- a/src/nexus/cli/commands/federation.py
+++ b/src/nexus/cli/commands/federation.py
@@ -61,7 +61,7 @@ def federation_status(
 
         def _render(d: dict[str, Any]) -> None:
             zones = d.get("zones", [])
-            console.print("[bold cyan]Federation Status[/bold cyan]")
+            console.print("[bold nexus.value]Federation Status[/bold nexus.value]")
             console.print(f"  Total zones: [nexus.warning]{len(zones)}[/nexus.warning]")
 
             total_links = sum(z.get("links_count", 0) for z in zones)
@@ -158,7 +158,7 @@ def federation_info(
             data = rpc_call(remote_url, remote_api_key, "federation_cluster_info", zone_id=zone_id)
 
         def _render(d: dict[str, Any]) -> None:
-            console.print(f"[bold cyan]Zone: {d.get('zone_id', zone_id)}[/bold cyan]")
+            console.print(f"[bold nexus.value]Zone: {d.get('zone_id', zone_id)}[/bold nexus.value]")
             console.print(f"  Node ID:     {d.get('node_id', 'N/A')}")
             console.print(f"  Links count: {d.get('links_count', 0)}")
             console.print(f"  Has store:   {d.get('has_store', False)}")

--- a/src/nexus/cli/commands/file_ops.py
+++ b/src/nexus/cli/commands/file_ops.py
@@ -262,7 +262,7 @@ def _cat_time_travel(
         render_output(data=data, output_opts=output_opts, timing=timing)
         return
 
-    console.print("[bold cyan]Time-Travel Mode[/bold cyan]")
+    console.print("[bold nexus.value]Time-Travel Mode[/bold nexus.value]")
     console.print(f"[nexus.muted]Operation ID:[/nexus.muted]  {state['operation_id']}")
     console.print(f"[nexus.muted]Operation Time:[/nexus.muted] {state['operation_time']}")
     console.print()
@@ -774,7 +774,7 @@ def copy_cmd(
                 nx.close()
 
                 # Display results
-                console.print("[bold green]✓ Copy Complete![/bold green]")
+                console.print("[bold nexus.success]✓ Copy Complete![/bold nexus.success]")
                 console.print(f"  Files checked: [nexus.value]{stats.files_checked}[/nexus.value]")
                 console.print(
                     f"  Files copied: [nexus.success]{stats.files_copied}[/nexus.success]"
@@ -787,7 +787,9 @@ def copy_cmd(
                 )
 
                 if stats.errors:
-                    console.print(f"\n[bold red]Errors:[/bold red] {len(stats.errors)}")
+                    console.print(
+                        f"\n[bold nexus.error]Errors:[/bold nexus.error] {len(stats.errors)}"
+                    )
                     for error in stats.errors[:10]:  # Show first 10 errors
                         console.print(f"  [nexus.error]•[/nexus.error] {error}")
 
@@ -953,9 +955,9 @@ def sync_cmd(
 
             # Display results
             if dry_run:
-                console.print("[bold yellow]DRY RUN RESULTS:[/bold yellow]")
+                console.print("[bold nexus.warning]DRY RUN RESULTS:[/bold nexus.warning]")
             else:
-                console.print("[bold green]✓ Sync Complete![/bold green]")
+                console.print("[bold nexus.success]✓ Sync Complete![/bold nexus.success]")
 
             console.print(f"  Files checked: [nexus.value]{stats.files_checked}[/nexus.value]")
             console.print(f"  Files copied: [nexus.success]{stats.files_copied}[/nexus.success]")
@@ -972,7 +974,7 @@ def sync_cmd(
                 )
 
             if stats.errors:
-                console.print(f"\n[bold red]Errors:[/bold red] {len(stats.errors)}")
+                console.print(f"\n[bold nexus.error]Errors:[/bold nexus.error] {len(stats.errors)}")
                 for error in stats.errors[:10]:  # Show first 10 errors
                     console.print(f"  [nexus.error]•[/nexus.error] {error}")
 

--- a/src/nexus/cli/commands/file_ops.py
+++ b/src/nexus/cli/commands/file_ops.py
@@ -74,11 +74,11 @@ def init(path: str) -> None:
             nx.close()
 
             console.print(
-                f"[green]✓[/green] Initialized Nexus workspace at [cyan]{workspace_path}[/cyan]"
+                f"[nexus.success]✓[/nexus.success] Initialized Nexus workspace at [nexus.path]{workspace_path}[/nexus.path]"
             )
-            console.print(f"  Data directory: [cyan]{data_dir}[/cyan]")
-            console.print(f"  Workspace: [cyan]{workspace_path / 'workspace'}[/cyan]")
-            console.print(f"  Shared: [cyan]{workspace_path / 'shared'}[/cyan]")
+            console.print(f"  Data directory: [nexus.path]{data_dir}[/nexus.path]")
+            console.print(f"  Workspace: [nexus.path]{workspace_path / 'workspace'}[/nexus.path]")
+            console.print(f"  Shared: [nexus.path]{workspace_path / 'shared'}[/nexus.path]")
         except Exception as e:
             handle_error(e)
 
@@ -164,7 +164,7 @@ def cat(
 
                         if file_size > STREAM_THRESHOLD:
                             console.print(
-                                f"[dim]Streaming large file ({file_size:,} bytes)...[/dim]"
+                                f"[nexus.muted]Streaming large file ({file_size:,} bytes)...[/nexus.muted]"
                             )
                             for chunk in nx.stream(  # type: ignore[attr-defined]
                                 path, chunk_size=65536, context=operation_context
@@ -198,11 +198,11 @@ def cat(
             # Human mode
             if metadata and meta_data:
                 console.print("[bold]Metadata:[/bold]")
-                console.print(f"[dim]Path:[/dim]     {meta_data['path']}")
-                console.print(f"[dim]ETag:[/dim]     {meta_data['etag']}")
-                console.print(f"[dim]Version:[/dim]  {meta_data['version']}")
-                console.print(f"[dim]Size:[/dim]     {meta_data['size']} bytes")
-                console.print(f"[dim]Modified:[/dim] {meta_data['modified_at']}")
+                console.print(f"[nexus.muted]Path:[/nexus.muted]     {meta_data['path']}")
+                console.print(f"[nexus.muted]ETag:[/nexus.muted]     {meta_data['etag']}")
+                console.print(f"[nexus.muted]Version:[/nexus.muted]  {meta_data['version']}")
+                console.print(f"[nexus.muted]Size:[/nexus.muted]     {meta_data['size']} bytes")
+                console.print(f"[nexus.muted]Modified:[/nexus.muted] {meta_data['modified_at']}")
                 console.print()
                 console.print("[bold]Content:[/bold]")
 
@@ -235,7 +235,9 @@ def _cat_time_travel(
     """Handle time-travel cat (--at-operation)."""
     time_travel = getattr(nx, "time_travel_service", None)
     if time_travel is None:
-        console.print("[red]Error:[/red] Time-travel is only supported with local NexusFS")
+        console.print(
+            "[nexus.error]Error:[/nexus.error] Time-travel is only supported with local NexusFS"
+        )
         return
 
     with timing.phase("server"):
@@ -261,18 +263,22 @@ def _cat_time_travel(
         return
 
     console.print("[bold cyan]Time-Travel Mode[/bold cyan]")
-    console.print(f"[dim]Operation ID:[/dim]  {state['operation_id']}")
-    console.print(f"[dim]Operation Time:[/dim] {state['operation_time']}")
+    console.print(f"[nexus.muted]Operation ID:[/nexus.muted]  {state['operation_id']}")
+    console.print(f"[nexus.muted]Operation Time:[/nexus.muted] {state['operation_time']}")
     console.print()
 
     if metadata:
         console.print("[bold]Metadata:[/bold]")
-        console.print(f"[dim]Path:[/dim]     {path}")
-        console.print(f"[dim]Size:[/dim]     {state['metadata'].get('size', 0)} bytes")
-        console.print(f"[dim]Owner:[/dim]    {state['metadata'].get('owner', '-')}")
-        console.print(f"[dim]Group:[/dim]    {state['metadata'].get('group', '-')}")
-        console.print(f"[dim]Mode:[/dim]     {state['metadata'].get('mode', '-')}")
-        console.print(f"[dim]Modified:[/dim] {state['metadata'].get('modified_at', '-')}")
+        console.print(f"[nexus.muted]Path:[/nexus.muted]     {path}")
+        console.print(
+            f"[nexus.muted]Size:[/nexus.muted]     {state['metadata'].get('size', 0)} bytes"
+        )
+        console.print(f"[nexus.muted]Owner:[/nexus.muted]    {state['metadata'].get('owner', '-')}")
+        console.print(f"[nexus.muted]Group:[/nexus.muted]    {state['metadata'].get('group', '-')}")
+        console.print(f"[nexus.muted]Mode:[/nexus.muted]     {state['metadata'].get('mode', '-')}")
+        console.print(
+            f"[nexus.muted]Modified:[/nexus.muted] {state['metadata'].get('modified_at', '-')}"
+        )
         console.print()
         console.print("[bold]Content:[/bold]")
 
@@ -295,8 +301,8 @@ def _print_content(path: str, content: bytes) -> None:
         else:
             console.print(text)
     except UnicodeDecodeError:
-        console.print(f"[yellow]Binary file ({len(content)} bytes)[/yellow]")
-        console.print(f"[dim]{content[:100]!r}...[/dim]")
+        console.print(f"[nexus.warning]Binary file ({len(content)} bytes)[/nexus.warning]")
+        console.print(f"[nexus.muted]{content[:100]!r}...[/nexus.muted]")
 
 
 @click.command()
@@ -395,14 +401,14 @@ def write(
                     result = await nx.write(path, file_content, context=ctx)
 
             console.print(
-                f"[green]✓[/green] Wrote {len(file_content)} bytes to [cyan]{path}[/cyan]"
+                f"[nexus.success]✓[/nexus.success] Wrote {len(file_content)} bytes to [nexus.path]{path}[/nexus.path]"
             )
 
             if show_metadata:
-                console.print(f"[dim]ETag:[/dim]     {result['etag']}")
-                console.print(f"[dim]Version:[/dim]  {result['version']}")
-                console.print(f"[dim]Size:[/dim]     {result['size']} bytes")
-                console.print(f"[dim]Modified:[/dim] {result['modified_at']}")
+                console.print(f"[nexus.muted]ETag:[/nexus.muted]     {result['etag']}")
+                console.print(f"[nexus.muted]Version:[/nexus.muted]  {result['version']}")
+                console.print(f"[nexus.muted]Size:[/nexus.muted]     {result['size']} bytes")
+                console.print(f"[nexus.muted]Modified:[/nexus.muted] {result['modified_at']}")
         except Exception as e:
             handle_error(e)
 
@@ -474,14 +480,14 @@ def append(
                 )
 
             console.print(
-                f"[green]✓[/green] Appended {len(file_content)} bytes to [cyan]{path}[/cyan]"
+                f"[nexus.success]✓[/nexus.success] Appended {len(file_content)} bytes to [nexus.path]{path}[/nexus.path]"
             )
 
             if show_metadata:
-                console.print(f"[dim]ETag:[/dim]     {result['etag']}")
-                console.print(f"[dim]Version:[/dim]  {result['version']}")
-                console.print(f"[dim]Size:[/dim]     {result['size']} bytes")
-                console.print(f"[dim]Modified:[/dim] {result['modified_at']}")
+                console.print(f"[nexus.muted]ETag:[/nexus.muted]     {result['etag']}")
+                console.print(f"[nexus.muted]Version:[/nexus.muted]  {result['version']}")
+                console.print(f"[nexus.muted]Size:[/nexus.muted]     {result['size']} bytes")
+                console.print(f"[nexus.muted]Modified:[/nexus.muted] {result['modified_at']}")
         except Exception as e:
             handle_error(e)
 
@@ -575,7 +581,7 @@ def write_batch(
                 dest_prefix = "/" + dest_prefix
 
             # Collect all files matching the pattern
-            console.print(f"[cyan]Scanning[/cyan] {source_path} for files...")
+            console.print(f"[nexus.path]Scanning[/nexus.path] {source_path} for files...")
             all_files = list(source_path.glob(pattern))
 
             # Filter out directories and excluded patterns
@@ -595,11 +601,13 @@ def write_batch(
                     files_to_upload.append(file_path)
 
             if not files_to_upload:
-                console.print("[yellow]No files found matching criteria[/yellow]")
+                console.print("[nexus.warning]No files found matching criteria[/nexus.warning]")
                 nx.close()
                 return
 
-            console.print(f"[cyan]Found {len(files_to_upload)} files to upload[/cyan]")
+            console.print(
+                f"[nexus.value]Found {len(files_to_upload)} files to upload[/nexus.value]"
+            )
 
             # Process files in batches
             total_bytes = 0
@@ -646,15 +654,21 @@ def write_batch(
 
             # Display summary
             console.print()
-            console.print("[green]✓ Batch upload complete![/green]")
-            console.print(f"  Files uploaded:  [cyan]{total_files}[/cyan]")
-            console.print(f"  Total size:      [cyan]{total_bytes:,}[/cyan] bytes")
-            console.print(f"  Time elapsed:    [cyan]{elapsed_time:.2f}[/cyan] seconds")
+            console.print("[nexus.success]✓ Batch upload complete![/nexus.success]")
+            console.print(f"  Files uploaded:  [nexus.value]{total_files}[/nexus.value]")
+            console.print(f"  Total size:      [nexus.value]{total_bytes:,}[/nexus.value] bytes")
+            console.print(
+                f"  Time elapsed:    [nexus.value]{elapsed_time:.2f}[/nexus.value] seconds"
+            )
             if elapsed_time > 0:
                 files_per_sec = total_files / elapsed_time
                 mb_per_sec = (total_bytes / 1024 / 1024) / elapsed_time
-                console.print(f"  Throughput:      [cyan]{files_per_sec:.1f}[/cyan] files/sec")
-                console.print(f"  Bandwidth:       [cyan]{mb_per_sec:.2f}[/cyan] MB/sec")
+                console.print(
+                    f"  Throughput:      [nexus.value]{files_per_sec:.1f}[/nexus.value] files/sec"
+                )
+                console.print(
+                    f"  Bandwidth:       [nexus.value]{mb_per_sec:.2f}[/nexus.value] MB/sec"
+                )
 
         except Exception as e:
             handle_error(e)
@@ -697,7 +711,9 @@ def cp(
 
             nx.close()
 
-            console.print(f"[green]✓[/green] Copied [cyan]{source}[/cyan] → [cyan]{dest}[/cyan]")
+            console.print(
+                f"[nexus.success]✓[/nexus.success] Copied [nexus.path]{source}[/nexus.path] → [nexus.path]{dest}[/nexus.path]"
+            )
         except Exception as e:
             handle_error(e)
 
@@ -759,17 +775,21 @@ def copy_cmd(
 
                 # Display results
                 console.print("[bold green]✓ Copy Complete![/bold green]")
-                console.print(f"  Files checked: [cyan]{stats.files_checked}[/cyan]")
-                console.print(f"  Files copied: [green]{stats.files_copied}[/green]")
+                console.print(f"  Files checked: [nexus.value]{stats.files_checked}[/nexus.value]")
                 console.print(
-                    f"  Files skipped: [yellow]{stats.files_skipped}[/yellow] (identical)"
+                    f"  Files copied: [nexus.success]{stats.files_copied}[/nexus.success]"
                 )
-                console.print(f"  Bytes transferred: [cyan]{stats.bytes_transferred:,}[/cyan]")
+                console.print(
+                    f"  Files skipped: [nexus.warning]{stats.files_skipped}[/nexus.warning] (identical)"
+                )
+                console.print(
+                    f"  Bytes transferred: [nexus.value]{stats.bytes_transferred:,}[/nexus.value]"
+                )
 
                 if stats.errors:
                     console.print(f"\n[bold red]Errors:[/bold red] {len(stats.errors)}")
                     for error in stats.errors[:10]:  # Show first 10 errors
-                        console.print(f"  [red]•[/red] {error}")
+                        console.print(f"  [nexus.error]•[/nexus.error] {error}")
 
             else:
                 # Single file copy
@@ -784,12 +804,12 @@ def copy_cmd(
 
                 if bytes_copied > 0:
                     console.print(
-                        f"[green]✓[/green] Copied [cyan]{source}[/cyan] → [cyan]{dest}[/cyan] "
+                        f"[nexus.success]✓[/nexus.success] Copied [nexus.path]{source}[/nexus.path] → [nexus.path]{dest}[/nexus.path] "
                         f"({bytes_copied:,} bytes)"
                     )
                 else:
                     console.print(
-                        f"[yellow]⊘[/yellow] Skipped [cyan]{source}[/cyan] (identical content)"
+                        f"[nexus.warning]⊘[/nexus.warning] Skipped [nexus.path]{source}[/nexus.path] (identical content)"
                     )
 
         except Exception as e:
@@ -836,19 +856,23 @@ def move_cmd(
 
             # Confirm unless --force
             if not force and not click.confirm(f"Move {source} to {dest}?"):
-                console.print("[yellow]Cancelled[/yellow]")
+                console.print("[nexus.warning]Cancelled[/nexus.warning]")
                 nx.close()
                 return
 
-            with console.status(f"[yellow]Moving {source} to {dest}...[/yellow]", spinner="dots"):
+            with console.status(
+                f"[nexus.warning]Moving {source} to {dest}...[/nexus.warning]", spinner="dots"
+            ):
                 success = await move_file(nx, source, dest)
 
             nx.close()
 
             if success:
-                console.print(f"[green]✓[/green] Moved [cyan]{source}[/cyan] → [cyan]{dest}[/cyan]")
+                console.print(
+                    f"[nexus.success]✓[/nexus.success] Moved [nexus.path]{source}[/nexus.path] → [nexus.path]{dest}[/nexus.path]"
+                )
             else:
-                console.print(f"[red]Error:[/red] Failed to move {source}")
+                console.print(f"[nexus.error]Error:[/nexus.error] Failed to move {source}")
                 sys.exit(1)
 
         except Exception as e:
@@ -903,13 +927,15 @@ def sync_cmd(
             use_checksum = not no_checksum
 
             # Display sync configuration
-            console.print(f"[cyan]Syncing:[/cyan] {source} → {dest}")
+            console.print(f"[nexus.path]Syncing:[/nexus.path] {source} → {dest}")
             if delete:
-                console.print("  [yellow]⚠ Delete mode enabled[/yellow]")
+                console.print("  [nexus.warning]⚠ Delete mode enabled[/nexus.warning]")
             if dry_run:
-                console.print("  [yellow]DRY RUN - No changes will be made[/yellow]")
+                console.print("  [nexus.warning]DRY RUN - No changes will be made[/nexus.warning]")
             if not use_checksum:
-                console.print("  [yellow]Checksum disabled - copying all files[/yellow]")
+                console.print(
+                    "  [nexus.warning]Checksum disabled - copying all files[/nexus.warning]"
+                )
             console.print()
 
             # Use progress bar from sync module (tqdm)
@@ -931,20 +957,24 @@ def sync_cmd(
             else:
                 console.print("[bold green]✓ Sync Complete![/bold green]")
 
-            console.print(f"  Files checked: [cyan]{stats.files_checked}[/cyan]")
-            console.print(f"  Files copied: [green]{stats.files_copied}[/green]")
-            console.print(f"  Files skipped: [yellow]{stats.files_skipped}[/yellow] (identical)")
+            console.print(f"  Files checked: [nexus.value]{stats.files_checked}[/nexus.value]")
+            console.print(f"  Files copied: [nexus.success]{stats.files_copied}[/nexus.success]")
+            console.print(
+                f"  Files skipped: [nexus.warning]{stats.files_skipped}[/nexus.warning] (identical)"
+            )
 
             if delete:
-                console.print(f"  Files deleted: [red]{stats.files_deleted}[/red]")
+                console.print(f"  Files deleted: [nexus.error]{stats.files_deleted}[/nexus.error]")
 
             if not dry_run:
-                console.print(f"  Bytes transferred: [cyan]{stats.bytes_transferred:,}[/cyan]")
+                console.print(
+                    f"  Bytes transferred: [nexus.value]{stats.bytes_transferred:,}[/nexus.value]"
+                )
 
             if stats.errors:
                 console.print(f"\n[bold red]Errors:[/bold red] {len(stats.errors)}")
                 for error in stats.errors[:10]:  # Show first 10 errors
-                    console.print(f"  [red]•[/red] {error}")
+                    console.print(f"  [nexus.error]•[/nexus.error] {error}")
 
         except Exception as e:
             handle_error(e)
@@ -983,20 +1013,22 @@ def rm(
 
             # Check if file exists
             if not await nx.sys_access(path):
-                console.print(f"[yellow]File does not exist:[/yellow] {path}")
+                console.print(f"[nexus.warning]File does not exist:[/nexus.warning] {path}")
                 nx.close()
                 return
 
             # Confirm deletion unless --force
             if not force and not click.confirm(f"Delete {path}?"):
-                console.print("[yellow]Cancelled[/yellow]")
+                console.print("[nexus.warning]Cancelled[/nexus.warning]")
                 nx.close()
                 return
 
             await nx.sys_unlink(path)
             nx.close()
 
-            console.print(f"[green]✓[/green] Deleted [cyan]{path}[/cyan]")
+            console.print(
+                f"[nexus.success]✓[/nexus.success] Deleted [nexus.path]{path}[/nexus.path]"
+            )
         except Exception as e:
             handle_error(e)
 
@@ -1079,30 +1111,40 @@ def edit(
 
             if preview:
                 if success and applied > 0:
-                    console.print(f"[yellow]Preview:[/yellow] {applied} edit(s) would apply")
+                    console.print(
+                        f"[nexus.warning]Preview:[/nexus.warning] {applied} edit(s) would apply"
+                    )
                     if diff:
                         syntax = Syntax(diff, "diff", theme="monokai")
                         console.print(syntax)
                 else:
-                    console.print("[yellow]Preview:[/yellow] No matches found")
+                    console.print("[nexus.warning]Preview:[/nexus.warning] No matches found")
                 return
 
             if success and applied > 0:
-                console.print(f"[green]✓[/green] {applied} edit(s) applied to [cyan]{path}[/cyan]")
+                console.print(
+                    f"[nexus.success]✓[/nexus.success] {applied} edit(s) applied to [nexus.path]{path}[/nexus.path]"
+                )
                 if etag:
-                    console.print(f"  [dim]etag: {etag}[/dim]")
+                    console.print(f"  [nexus.muted]etag: {etag}[/nexus.muted]")
                 for m in matches:
                     sim = m.get("similarity")
                     method = m.get("method", "exact")
                     if sim and sim < 1.0:
-                        console.print(f"  [dim]match: similarity={sim:.2f} ({method})[/dim]")
+                        console.print(
+                            f"  [nexus.muted]match: similarity={sim:.2f} ({method})[/nexus.muted]"
+                        )
                 if diff:
                     syntax = Syntax(diff, "diff", theme="monokai")
                     console.print(syntax)
             else:
-                console.print(f"[yellow]No matches found[/yellow] for the search string in {path}")
+                console.print(
+                    f"[nexus.warning]No matches found[/nexus.warning] for the search string in {path}"
+                )
                 if fuzzy is None:
-                    console.print("[dim]Hint: use --fuzzy 0.8 for approximate matching[/dim]")
+                    console.print(
+                        "[nexus.muted]Hint: use --fuzzy 0.8 for approximate matching[/nexus.muted]"
+                    )
         except Exception as e:
             handle_error(e)
 

--- a/src/nexus/cli/commands/governance_cli.py
+++ b/src/nexus/cli/commands/governance_cli.py
@@ -58,7 +58,7 @@ def governance_status(
             alert_list = alerts.get("alerts", []) if isinstance(alerts, dict) else []
             ring_list = rings.get("rings", []) if isinstance(rings, dict) else []
 
-            console.print("[bold cyan]Governance Status[/bold cyan]")
+            console.print("[bold nexus.value]Governance Status[/bold nexus.value]")
             console.print(f"  Active alerts: [nexus.warning]{len(alert_list)}[/nexus.warning]")
             console.print(f"  Fraud rings:   [nexus.warning]{len(ring_list)}[/nexus.warning]")
 
@@ -175,7 +175,9 @@ def governance_rings(
                 console.print("[nexus.success]No fraud rings detected[/nexus.success]")
                 return
 
-            console.print(f"[bold cyan]Detected Fraud Rings ({len(rings)})[/bold cyan]")
+            console.print(
+                f"[bold nexus.value]Detected Fraud Rings ({len(rings)})[/bold nexus.value]"
+            )
             for i, ring in enumerate(rings, 1):
                 members = ring.get("members", [])
                 score = ring.get("risk_score", 0)

--- a/src/nexus/cli/commands/governance_cli.py
+++ b/src/nexus/cli/commands/governance_cli.py
@@ -66,7 +66,7 @@ def governance_status(
                 console.print("\n[bold]Recent Alerts:[/bold]")
                 for alert in alert_list[:5]:
                     sev = alert.get("severity", "unknown")
-                    color = "red" if sev == "high" else "yellow"
+                    color = "nexus.error" if sev == "high" else "nexus.warning"
                     console.print(f"  [{color}]{sev}[/{color}] {alert.get('description', 'N/A')}")
 
         render_output(
@@ -128,7 +128,13 @@ def governance_alerts(
 
             for alert in alerts:
                 sev = alert.get("severity", "")
-                sev_style = "red" if sev == "high" else "yellow" if sev == "medium" else "dim"
+                sev_style = (
+                    "nexus.error"
+                    if sev == "high"
+                    else "nexus.warning"
+                    if sev == "medium"
+                    else "nexus.muted"
+                )
                 table.add_row(
                     alert.get("created_at", "")[:19],
                     f"[{sev_style}]{sev}[/{sev_style}]",

--- a/src/nexus/cli/commands/governance_cli.py
+++ b/src/nexus/cli/commands/governance_cli.py
@@ -59,8 +59,8 @@ def governance_status(
             ring_list = rings.get("rings", []) if isinstance(rings, dict) else []
 
             console.print("[bold cyan]Governance Status[/bold cyan]")
-            console.print(f"  Active alerts: [yellow]{len(alert_list)}[/yellow]")
-            console.print(f"  Fraud rings:   [yellow]{len(ring_list)}[/yellow]")
+            console.print(f"  Active alerts: [nexus.warning]{len(alert_list)}[/nexus.warning]")
+            console.print(f"  Fraud rings:   [nexus.warning]{len(ring_list)}[/nexus.warning]")
 
             if alert_list:
                 console.print("\n[bold]Recent Alerts:[/bold]")
@@ -76,7 +76,7 @@ def governance_status(
             human_formatter=_render,
         )
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from None
 
 
@@ -117,11 +117,11 @@ def governance_alerts(
 
             alerts = d.get("alerts", [])
             if not alerts:
-                console.print("[green]No anomaly alerts[/green]")
+                console.print("[nexus.success]No anomaly alerts[/nexus.success]")
                 return
 
             table = Table(title=f"Anomaly Alerts ({len(alerts)})")
-            table.add_column("Time", style="dim")
+            table.add_column("Time", style="nexus.muted")
             table.add_column("Severity")
             table.add_column("Agent")
             table.add_column("Description")
@@ -144,7 +144,7 @@ def governance_alerts(
             human_formatter=_render,
         )
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from None
 
 
@@ -172,14 +172,16 @@ def governance_rings(
         def _render(d: dict) -> None:
             rings = d.get("rings", [])
             if not rings:
-                console.print("[green]No fraud rings detected[/green]")
+                console.print("[nexus.success]No fraud rings detected[/nexus.success]")
                 return
 
             console.print(f"[bold cyan]Detected Fraud Rings ({len(rings)})[/bold cyan]")
             for i, ring in enumerate(rings, 1):
                 members = ring.get("members", [])
                 score = ring.get("risk_score", 0)
-                console.print(f"\n  [bold]Ring {i}[/bold] (risk: [red]{score:.2f}[/red])")
+                console.print(
+                    f"\n  [bold]Ring {i}[/bold] (risk: [nexus.error]{score:.2f}[/nexus.error])"
+                )
                 console.print(f"  Members: {', '.join(members)}")
 
         render_output(
@@ -189,5 +191,5 @@ def governance_rings(
             human_formatter=_render,
         )
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from None

--- a/src/nexus/cli/commands/graph_cli.py
+++ b/src/nexus/cli/commands/graph_cli.py
@@ -46,7 +46,7 @@ def graph_entity(client: GraphClient, entity_id: str) -> ServiceResult:
     data = client.entity(entity_id)
 
     def _render(d: dict) -> None:
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         ent = d.get("entity", d)
         console.print(f"[bold cyan]Entity: {entity_id}[/bold cyan]")
@@ -81,15 +81,15 @@ def graph_neighbors(client: GraphClient, entity_id: str, hops: int) -> ServiceRe
     def _render(d: dict) -> None:
         from rich.table import Table
 
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         neighbors = d.get("neighbors", [])
         if not neighbors:
-            console.print(f"[yellow]No neighbors within {hops} hop(s)[/yellow]")
+            console.print(f"[nexus.warning]No neighbors within {hops} hop(s)[/nexus.warning]")
             return
 
         table = Table(title=f"Neighbors of {entity_id} ({hops} hop(s), {len(neighbors)} found)")
-        table.add_column("Entity ID", style="dim")
+        table.add_column("Entity ID", style="nexus.muted")
         table.add_column("Type")
         table.add_column("Label")
         table.add_column("Depth")
@@ -127,7 +127,7 @@ def graph_subgraph(
     data = client.subgraph(list(entity_ids), max_hops=max_hops)
 
     def _render(d: dict) -> None:
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         nodes = d.get("nodes", [])
         edges = d.get("edges", [])
@@ -159,12 +159,12 @@ def graph_search(
     data = client.search(name, entity_type=entity_type, fuzzy=fuzzy)
 
     def _render(d: dict) -> None:
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         # Server may return a single entity or None
         entity = d.get("entity")
         if entity is None:
-            console.print("[yellow]No matching entities[/yellow]")
+            console.print("[nexus.warning]No matching entities[/nexus.warning]")
             return
 
         console.print("[bold cyan]Search Result[/bold cyan]")

--- a/src/nexus/cli/commands/graph_cli.py
+++ b/src/nexus/cli/commands/graph_cli.py
@@ -49,7 +49,7 @@ def graph_entity(client: GraphClient, entity_id: str) -> ServiceResult:
         from nexus.cli.theme import console
 
         ent = d.get("entity", d)
-        console.print(f"[bold cyan]Entity: {entity_id}[/bold cyan]")
+        console.print(f"[bold nexus.value]Entity: {entity_id}[/bold nexus.value]")
         console.print(f"  Type:   {ent.get('type', 'N/A')}")
         console.print(f"  Label:  {ent.get('label', ent.get('name', 'N/A'))}")
         props = ent.get("properties", {})
@@ -131,7 +131,7 @@ def graph_subgraph(
 
         nodes = d.get("nodes", [])
         edges = d.get("edges", [])
-        console.print(f"[bold cyan]Subgraph ({len(entity_ids)} seed(s))[/bold cyan]")
+        console.print(f"[bold nexus.value]Subgraph ({len(entity_ids)} seed(s))[/bold nexus.value]")
         console.print(f"  Nodes: {len(nodes)}")
         console.print(f"  Edges: {len(edges)}")
 
@@ -167,7 +167,7 @@ def graph_search(
             console.print("[nexus.warning]No matching entities[/nexus.warning]")
             return
 
-        console.print("[bold cyan]Search Result[/bold cyan]")
+        console.print("[bold nexus.value]Search Result[/bold nexus.value]")
         console.print(f"  Entity ID: {entity.get('entity_id', entity.get('id', 'N/A'))}")
         console.print(f"  Type:      {entity.get('type', 'N/A')}")
         console.print(f"  Name:      {entity.get('name', 'N/A')}")

--- a/src/nexus/cli/commands/identity.py
+++ b/src/nexus/cli/commands/identity.py
@@ -46,7 +46,7 @@ def identity_show(client: IdentityClient, agent_id: str) -> ServiceResult:
     data = client.show(agent_id)
 
     def _render(d: dict) -> None:
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         console.print(f"[bold cyan]Identity: {agent_id}[/bold cyan]")
         console.print(f"  DID:        {d.get('did', 'N/A')}")
@@ -83,10 +83,14 @@ def identity_verify(
     data = client.verify(agent_id, message=message, signature=signature, key_id=key_id)
 
     def _render(d: dict) -> None:
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         valid = d.get("valid", False)
-        status = "[green]Valid[/green]" if valid else "[red]Invalid[/red]"
+        status = (
+            "[nexus.success]Valid[/nexus.success]"
+            if valid
+            else "[nexus.error]Invalid[/nexus.error]"
+        )
         console.print(f"[bold cyan]Verification: {agent_id}[/bold cyan]")
         console.print(f"  Status: {status}")
         if d.get("reason"):
@@ -114,17 +118,17 @@ def identity_credentials(client: IdentityClient, agent_id: str) -> ServiceResult
     def _render(d: dict) -> None:
         from rich.table import Table
 
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         creds = d.get("credentials", [])
         if not creds:
-            console.print("[yellow]No active credentials[/yellow]")
+            console.print("[nexus.warning]No active credentials[/nexus.warning]")
             return
 
         table = Table(title=f"Credentials for {agent_id}")
-        table.add_column("ID", style="dim")
+        table.add_column("ID", style="nexus.muted")
         table.add_column("Issuer DID")
-        table.add_column("Expires", style="dim")
+        table.add_column("Expires", style="nexus.muted")
         table.add_column("Active")
 
         for c in creds:
@@ -158,7 +162,7 @@ def identity_passport(client: IdentityClient, agent_id: str) -> ServiceResult:
     data = {**identity_data, "credentials": creds_data.get("credentials", [])}
 
     def _render(d: dict) -> None:
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         console.print(f"[bold cyan]Agent Passport: {agent_id}[/bold cyan]")
         console.print(f"  DID:        {d.get('did', 'N/A')}")

--- a/src/nexus/cli/commands/identity.py
+++ b/src/nexus/cli/commands/identity.py
@@ -48,7 +48,7 @@ def identity_show(client: IdentityClient, agent_id: str) -> ServiceResult:
     def _render(d: dict) -> None:
         from nexus.cli.theme import console
 
-        console.print(f"[bold cyan]Identity: {agent_id}[/bold cyan]")
+        console.print(f"[bold nexus.value]Identity: {agent_id}[/bold nexus.value]")
         console.print(f"  DID:        {d.get('did', 'N/A')}")
         console.print(f"  Key ID:     {d.get('key_id', 'N/A')}")
         console.print(f"  Public Key: {d.get('public_key_hex', d.get('public_key', 'N/A'))}")
@@ -91,7 +91,7 @@ def identity_verify(
             if valid
             else "[nexus.error]Invalid[/nexus.error]"
         )
-        console.print(f"[bold cyan]Verification: {agent_id}[/bold cyan]")
+        console.print(f"[bold nexus.value]Verification: {agent_id}[/bold nexus.value]")
         console.print(f"  Status: {status}")
         if d.get("reason"):
             console.print(f"  Reason: {d['reason']}")
@@ -164,7 +164,7 @@ def identity_passport(client: IdentityClient, agent_id: str) -> ServiceResult:
     def _render(d: dict) -> None:
         from nexus.cli.theme import console
 
-        console.print(f"[bold cyan]Agent Passport: {agent_id}[/bold cyan]")
+        console.print(f"[bold nexus.value]Agent Passport: {agent_id}[/bold nexus.value]")
         console.print(f"  DID:        {d.get('did', 'N/A')}")
         console.print(f"  Public Key: {d.get('public_key_hex', d.get('public_key', 'N/A'))}")
         creds = d.get("credentials", [])

--- a/src/nexus/cli/commands/init_cmd.py
+++ b/src/nexus/cli/commands/init_cmd.py
@@ -23,7 +23,7 @@ import click
 import yaml
 
 from nexus.cli.port_utils import DEFAULT_PORTS, derive_ports
-from nexus.cli.utils import console
+from nexus.cli.theme import console
 
 logger = logging.getLogger(__name__)
 
@@ -248,7 +248,7 @@ def _scaffold_tls(tls_dir: Path) -> None:
         return
 
     if not shutil.which("openssl"):
-        console.print(f"  [yellow]openssl not found[/yellow] — created {tls_dir}")
+        console.print(f"  [nexus.warning]openssl not found[/nexus.warning] — created {tls_dir}")
         console.print("  Please provide: ca.crt, server.crt, server.key")
         return
 
@@ -317,9 +317,9 @@ def _scaffold_tls(tls_dir: Path) -> None:
         srv_csr.unlink(missing_ok=True)
         (tls_dir / "ca.srl").unlink(missing_ok=True)
 
-        console.print(f"  [green]TLS certificates generated in {tls_dir}[/green]")
+        console.print(f"  [nexus.success]TLS certificates generated in {tls_dir}[/nexus.success]")
     except subprocess.CalledProcessError:
-        console.print(f"  [yellow]openssl failed[/yellow] — created {tls_dir}")
+        console.print(f"  [nexus.warning]openssl failed[/nexus.warning] — created {tls_dir}")
         console.print("  Please provide: ca.crt, server.crt, server.key")
 
 
@@ -341,7 +341,7 @@ def _create_data_dirs(data_dir: Path, *, tls: bool = False) -> None:
 def _print_local_summary(config_path: Path, data_dir: Path) -> None:
     """Print summary for local preset."""
     console.print()
-    console.print("[green]Initialized Nexus preset: local[/green]")
+    console.print("[nexus.success]Initialized Nexus preset: local[/nexus.success]")
     console.print(f"  Config:   {config_path}")
     console.print(f"  Data dir: {data_dir}")
     console.print()
@@ -356,7 +356,7 @@ def _print_shared_summary(config: dict[str, Any], config_path: Path, data_dir: P
     ports = config.get("ports", {})
 
     console.print()
-    console.print(f"[green]Initialized Nexus preset: {preset}[/green]")
+    console.print(f"[nexus.success]Initialized Nexus preset: {preset}[/nexus.success]")
     console.print(f"  Config:     {config_path}")
     console.print(f"  Data dir:   {data_dir}")
     console.print(f"  Services:   {services}")
@@ -493,7 +493,7 @@ def init(
     # Guard: don't overwrite existing config without --force
     if cfg_path.exists() and not force:
         console.print(
-            f"[yellow]Warning:[/yellow] {cfg_path} already exists. Use --force to overwrite."
+            f"[nexus.warning]Warning:[/nexus.warning] {cfg_path} already exists. Use --force to overwrite."
         )
         raise SystemExit(1)
 
@@ -524,7 +524,7 @@ def init(
         cf = config.get("compose_file", "")
         if compose_file and not Path(cf).exists():
             # User explicitly passed --compose-file but it doesn't exist
-            console.print(f"[red]Error:[/red] Compose file not found: {cf}")
+            console.print(f"[nexus.error]Error:[/nexus.error] Compose file not found: {cf}")
             raise SystemExit(1)
         if not cf or not Path(cf).exists():
             bundled = _bundled_compose_file()
@@ -541,7 +541,7 @@ def init(
                 if sql_file.exists():
                     shutil.copy2(str(sql_file), str(dest_dir / sql_file.name))
             else:
-                console.print(f"[red]Error:[/red] Compose file not found: {cf}")
+                console.print(f"[nexus.error]Error:[/nexus.error] Compose file not found: {cf}")
                 console.print("  Run `nexus init` from the Nexus repo root, or pass")
                 console.print("  --compose-file /absolute/path/to/nexus-stack.yml")
                 raise SystemExit(1)

--- a/src/nexus/cli/commands/inspect.py
+++ b/src/nexus/cli/commands/inspect.py
@@ -90,8 +90,8 @@ async def _async_info(
 
         def _print_human(d: dict[str, Any]) -> None:
             table = Table(title=f"File Information: {path}")
-            table.add_column("Property", style="cyan")
-            table.add_column("Value", style="green")
+            table.add_column("Property", style="nexus.value")
+            table.add_column("Value", style="nexus.success")
             table.add_row("Path", d["path"])
             table.add_row("Size", f"{d['size']:,} bytes")
             table.add_row("Created", d["created_at"])
@@ -117,7 +117,9 @@ async def _async_info(
 @click.command()
 def version() -> None:
     """Show Nexus version information."""
-    console.print(f"[cyan]Nexus[/cyan] version [green]{nexus.__version__}[/green]")
+    console.print(
+        f"[nexus.value]Nexus[/nexus.value] version [nexus.success]{nexus.__version__}[/nexus.success]"
+    )
 
 
 @click.command(name="size")
@@ -157,13 +159,15 @@ async def _async_size(
         nx = await get_filesystem(remote_url, remote_api_key)
 
         # Get all files with details
-        with console.status(f"[yellow]Calculating size of {path}...[/yellow]", spinner="dots"):
+        with console.status(
+            f"[nexus.warning]Calculating size of {path}...[/nexus.warning]", spinner="dots"
+        ):
             files_raw = await nx.sys_readdir(path, recursive=True, details=True)
 
         nx.close()
 
         if not files_raw:
-            console.print(f"[yellow]No files found in {path}[/yellow]")
+            console.print(f"[nexus.warning]No files found in {path}[/nexus.warning]")
             return
 
         files = cast(list[dict[str, Any]], files_raw)
@@ -186,8 +190,8 @@ async def _async_size(
 
         # Display summary
         console.print(f"[bold cyan]Size of {path}:[/bold cyan]")
-        console.print(f"  Total size: [green]{format_size(total_size)}[/green]")
-        console.print(f"  File count: [cyan]{file_count:,}[/cyan]")
+        console.print(f"  Total size: [nexus.success]{format_size(total_size)}[/nexus.success]")
+        console.print(f"  File count: [nexus.value]{file_count:,}[/nexus.value]")
 
         if details:
             console.print()
@@ -197,8 +201,8 @@ async def _async_size(
             sorted_files = sorted(files, key=lambda f: f["size"], reverse=True)[:10]
 
             table = Table()
-            table.add_column("Size", justify="right", style="green")
-            table.add_column("Path", style="cyan")
+            table.add_column("Size", justify="right", style="nexus.success")
+            table.add_column("Path", style="nexus.path")
 
             for file in sorted_files:
                 table.add_row(format_size(file["size"]), file["path"])

--- a/src/nexus/cli/commands/inspect.py
+++ b/src/nexus/cli/commands/inspect.py
@@ -189,7 +189,7 @@ async def _async_size(
             return f"{size_float:.1f} PB"
 
         # Display summary
-        console.print(f"[bold cyan]Size of {path}:[/bold cyan]")
+        console.print(f"[bold nexus.value]Size of {path}:[/bold nexus.value]")
         console.print(f"  Total size: [nexus.success]{format_size(total_size)}[/nexus.success]")
         console.print(f"  File count: [nexus.value]{file_count:,}[/nexus.value]")
 

--- a/src/nexus/cli/commands/ipc.py
+++ b/src/nexus/cli/commands/ipc.py
@@ -61,9 +61,9 @@ def ipc_send(
     data = client.send(sender, recipient, message, message_type=message_type)
 
     def _render(d: dict) -> None:
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
-        console.print("[green]Message sent[/green]")
+        console.print("[nexus.success]Message sent[/nexus.success]")
         console.print(f"  Message ID: {d.get('message_id', 'N/A')}")
         console.print(f"  From:       {sender}")
         console.print(f"  To:         {recipient}")
@@ -90,15 +90,15 @@ def ipc_inbox(client: IPCClient, agent_id: str) -> ServiceResult:
     def _render(d: dict) -> None:
         from rich.table import Table
 
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         messages = d.get("messages", [])
         if not messages:
-            console.print("[yellow]Inbox empty[/yellow]")
+            console.print("[nexus.warning]Inbox empty[/nexus.warning]")
             return
 
         table = Table(title=f"Inbox for {agent_id} ({len(messages)} messages)")
-        table.add_column("File", style="dim")
+        table.add_column("File", style="nexus.muted")
 
         for msg in messages:
             table.add_row(msg.get("filename", str(msg)))
@@ -124,7 +124,7 @@ def ipc_count(client: IPCClient, agent_id: str) -> ServiceResult:
     data = client.inbox_count(agent_id)
 
     def _render(d: dict) -> None:
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         count = d.get("count", 0)
         console.print(f"[bold cyan]{agent_id}[/bold cyan]: {count} message(s) in inbox")

--- a/src/nexus/cli/commands/ipc.py
+++ b/src/nexus/cli/commands/ipc.py
@@ -127,6 +127,8 @@ def ipc_count(client: IPCClient, agent_id: str) -> ServiceResult:
         from nexus.cli.theme import console
 
         count = d.get("count", 0)
-        console.print(f"[bold cyan]{agent_id}[/bold cyan]: {count} message(s) in inbox")
+        console.print(
+            f"[bold nexus.value]{agent_id}[/bold nexus.value]: {count} message(s) in inbox"
+        )
 
     return ServiceResult(data=data, human_formatter=_render)

--- a/src/nexus/cli/commands/locks.py
+++ b/src/nexus/cli/commands/locks.py
@@ -111,7 +111,7 @@ def lock_info(
             data = rpc_call(remote_url, remote_api_key, "lock_info", path=path)
 
         def _render(d: dict) -> None:
-            console.print(f"[bold cyan]Lock Status: {path}[/bold cyan]")
+            console.print(f"[bold nexus.value]Lock Status: {path}[/bold nexus.value]")
             console.print(
                 f"  Locked:  {'[nexus.error]Yes[/nexus.error]' if d.get('locked') else '[nexus.success]No[/nexus.success]'}"
             )

--- a/src/nexus/cli/commands/locks.py
+++ b/src/nexus/cli/commands/locks.py
@@ -58,14 +58,14 @@ def lock_list(
 
             locks = d.get("locks", [])
             if not locks:
-                console.print("[yellow]No active locks[/yellow]")
+                console.print("[nexus.warning]No active locks[/nexus.warning]")
                 return
 
             table = Table(title=f"Active Locks ({d.get('count', len(locks))})")
             table.add_column("Path")
             table.add_column("Mode")
             table.add_column("Holders", justify="right")
-            table.add_column("Expires At", style="dim")
+            table.add_column("Expires At", style="nexus.muted")
 
             for lk in locks:
                 table.add_row(
@@ -83,7 +83,7 @@ def lock_list(
             human_formatter=_render,
         )
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from None
 
 
@@ -113,7 +113,7 @@ def lock_info(
         def _render(d: dict) -> None:
             console.print(f"[bold cyan]Lock Status: {path}[/bold cyan]")
             console.print(
-                f"  Locked:  {'[red]Yes[/red]' if d.get('locked') else '[green]No[/green]'}"
+                f"  Locked:  {'[nexus.error]Yes[/nexus.error]' if d.get('locked') else '[nexus.success]No[/nexus.success]'}"
             )
             info = d.get("lock_info")
             if info:
@@ -130,7 +130,7 @@ def lock_info(
             human_formatter=_render,
         )
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from None
 
 
@@ -163,7 +163,7 @@ def lock_release(
             lock_id=lock_id,
             force=force,
         )
-        console.print(f"[green]Lock released:[/green] {path}")
+        console.print(f"[nexus.success]Lock released:[/nexus.success] {path}")
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from None

--- a/src/nexus/cli/commands/manifest_cli.py
+++ b/src/nexus/cli/commands/manifest_cli.py
@@ -155,7 +155,7 @@ def manifest_show(client: ManifestClient, manifest_id: str) -> ServiceResult:
     def _render(d: dict) -> None:
         from nexus.cli.theme import console
 
-        console.print(f"[bold cyan]Manifest: {manifest_id}[/bold cyan]")
+        console.print(f"[bold nexus.value]Manifest: {manifest_id}[/bold nexus.value]")
         console.print(f"  Name:       {d.get('name', 'N/A')}")
         console.print(f"  Agent:      {d.get('agent_id', 'N/A')}")
         console.print(f"  Valid From: {d.get('valid_from', 'N/A')[:19]}")

--- a/src/nexus/cli/commands/manifest_cli.py
+++ b/src/nexus/cli/commands/manifest_cli.py
@@ -76,9 +76,9 @@ def manifest_create(
     )
 
     def _render(d: dict) -> None:
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
-        console.print("[green]Manifest created[/green]")
+        console.print("[nexus.success]Manifest created[/nexus.success]")
         console.print(f"  Manifest ID: {d.get('manifest_id', d.get('id', 'N/A'))}")
         console.print(f"  Agent:       {d.get('agent_id', agent_id)}")
         console.print(f"  Name:        {d.get('name', name)}")
@@ -109,19 +109,19 @@ def manifest_list(client: ManifestClient) -> ServiceResult:
     def _render(d: dict) -> None:
         from rich.table import Table
 
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         manifests = d.get("manifests", [])
         if not manifests:
-            console.print("[yellow]No manifests[/yellow]")
+            console.print("[nexus.warning]No manifests[/nexus.warning]")
             return
 
         table = Table(title=f"Access Manifests ({len(manifests)})")
-        table.add_column("ID", style="dim")
+        table.add_column("ID", style="nexus.muted")
         table.add_column("Agent")
         table.add_column("Name")
         table.add_column("Entries")
-        table.add_column("Valid Until", style="dim")
+        table.add_column("Valid Until", style="nexus.muted")
 
         for m in manifests:
             entry_count = len(m.get("entries", []))
@@ -153,7 +153,7 @@ def manifest_show(client: ManifestClient, manifest_id: str) -> ServiceResult:
     data = client.show(manifest_id)
 
     def _render(d: dict) -> None:
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         console.print(f"[bold cyan]Manifest: {manifest_id}[/bold cyan]")
         console.print(f"  Name:       {d.get('name', 'N/A')}")
@@ -187,11 +187,15 @@ def manifest_evaluate(client: ManifestClient, manifest_id: str, tool_name: str) 
     data = client.evaluate(manifest_id, tool_name=tool_name)
 
     def _render(d: dict) -> None:
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         permission = d.get("permission", "deny")
         allowed = permission == "allow"
-        status = "[green]Allowed[/green]" if allowed else "[red]Denied[/red]"
+        status = (
+            "[nexus.success]Allowed[/nexus.success]"
+            if allowed
+            else "[nexus.error]Denied[/nexus.error]"
+        )
         console.print(f"Tool '{tool_name}': {status}")
         if d.get("manifest_id"):
             console.print(f"  Manifest: {d['manifest_id']}")

--- a/src/nexus/cli/commands/mcp.py
+++ b/src/nexus/cli/commands/mcp.py
@@ -289,7 +289,7 @@ async def _async_serve(
             console.print()
 
             # Display available tools
-            console.print("[bold cyan]Available Tools:[/bold cyan]")
+            console.print("[bold nexus.value]Available Tools:[/bold nexus.value]")
             tools = [
                 "nexus_read_file",
                 "nexus_write_file",
@@ -311,11 +311,11 @@ async def _async_serve(
                 console.print(f"  • [nexus.value]{tool}[/nexus.value]")
 
             console.print()
-            console.print("[bold cyan]Resources:[/bold cyan]")
+            console.print("[bold nexus.value]Resources:[/bold nexus.value]")
             console.print("  • [nexus.path]nexus://files/{{path}}[/nexus.path] - Browse files")
 
             console.print()
-            console.print("[bold cyan]Prompts:[/bold cyan]")
+            console.print("[bold nexus.value]Prompts:[/bold nexus.value]")
             console.print("  • [nexus.value]file_analysis_prompt[/nexus.value] - Analyze a file")
             console.print(
                 "  • [nexus.value]search_and_summarize_prompt[/nexus.value] - Search and summarize"

--- a/src/nexus/cli/commands/mcp.py
+++ b/src/nexus/cli/commands/mcp.py
@@ -38,10 +38,12 @@ def _add_health_check_route(mcp_server: Any) -> None:
             """Health check endpoint for Docker and monitoring."""
             return JSONResponse({"status": "healthy", "service": "nexus-mcp"})
 
-        console.print("[green]✓ Health check endpoint enabled (/health)[/green]")
+        console.print("[nexus.success]✓ Health check endpoint enabled (/health)[/nexus.success]")
 
     except Exception as e:
-        console.print(f"[yellow]Warning: Failed to add health check route: {e}[/yellow]")
+        console.print(
+            f"[nexus.warning]Warning: Failed to add health check route: {e}[/nexus.warning]"
+        )
 
 
 def _add_api_key_middleware(mcp_server: Any) -> None:
@@ -94,12 +96,18 @@ def _add_api_key_middleware(mcp_server: Any) -> None:
         if hasattr(mcp_server, "http_app"):
             app = mcp_server.http_app()
             app.add_middleware(APIKeyMiddleware)
-            console.print("[green]✓ API key middleware enabled (X-Nexus-API-Key header)[/green]")
+            console.print(
+                "[nexus.success]✓ API key middleware enabled (X-Nexus-API-Key header)[/nexus.success]"
+            )
         else:
-            console.print("[yellow]Warning: http_app not available, middleware not added[/yellow]")
+            console.print(
+                "[nexus.warning]Warning: http_app not available, middleware not added[/nexus.warning]"
+            )
 
     except Exception as e:
-        console.print(f"[yellow]Warning: Failed to add API key middleware: {e}[/yellow]")
+        console.print(
+            f"[nexus.warning]Warning: Failed to add API key middleware: {e}[/nexus.warning]"
+        )
 
 
 @click.group(name="mcp")
@@ -300,23 +308,27 @@ async def _async_serve(
                 "nexus_execute_workflow",
             ]
             for tool in tools:
-                console.print(f"  • [cyan]{tool}[/cyan]")
+                console.print(f"  • [nexus.value]{tool}[/nexus.value]")
 
             console.print()
             console.print("[bold cyan]Resources:[/bold cyan]")
-            console.print("  • [cyan]nexus://files/{{path}}[/cyan] - Browse files")
+            console.print("  • [nexus.path]nexus://files/{{path}}[/nexus.path] - Browse files")
 
             console.print()
             console.print("[bold cyan]Prompts:[/bold cyan]")
-            console.print("  • [cyan]file_analysis_prompt[/cyan] - Analyze a file")
-            console.print("  • [cyan]search_and_summarize_prompt[/cyan] - Search and summarize")
+            console.print("  • [nexus.value]file_analysis_prompt[/nexus.value] - Analyze a file")
+            console.print(
+                "  • [nexus.value]search_and_summarize_prompt[/nexus.value] - Search and summarize"
+            )
 
             console.print()
-            console.print(f"[yellow]Starting HTTP server on http://{host}:{port}[/yellow]")
+            console.print(
+                f"[nexus.warning]Starting HTTP server on http://{host}:{port}[/nexus.warning]"
+            )
             console.print()
 
-            console.print("[green]Starting MCP server...[/green]")
-            console.print("[yellow]Press Ctrl+C to stop[/yellow]")
+            console.print("[nexus.success]Starting MCP server...[/nexus.success]")
+            console.print("[nexus.warning]Press Ctrl+C to stop[/nexus.warning]")
             console.print()
 
         # Build manifest resolver callable if available (Issue #2984)
@@ -354,7 +366,7 @@ async def _async_serve(
             mcp_server.run(transport="sse", host=host, port=port)
 
     except KeyboardInterrupt:
-        console.print("\n[yellow]MCP server stopped by user[/yellow]")
+        console.print("\n[nexus.warning]MCP server stopped by user[/nexus.warning]")
     except Exception as e:
         handle_error(e)
 

--- a/src/nexus/cli/commands/migrate.py
+++ b/src/nexus/cli/commands/migrate.py
@@ -82,8 +82,8 @@ def status(data_dir: str | None) -> None:
             history = manager.get_migration_history()
             if history:
                 table = Table()
-                table.add_column("Time", style="dim")
-                table.add_column("Type", style="cyan")
+                table.add_column("Time", style="nexus.muted")
+                table.add_column("Type", style="nexus.value")
                 table.add_column("From")
                 table.add_column("To")
                 table.add_column("Status")
@@ -116,9 +116,9 @@ def status(data_dir: str | None) -> None:
 
                 console.print(table)
             else:
-                console.print("  [dim]No migration history found[/dim]")
+                console.print("  [nexus.muted]No migration history found[/nexus.muted]")
         except Exception as e:
-            console.print(f"  [dim]Could not load history: {e}[/dim]")
+            console.print(f"  [nexus.muted]Could not load history: {e}[/nexus.muted]")
 
         console.print()
 
@@ -130,9 +130,9 @@ def status(data_dir: str | None) -> None:
                 backup_time = backup.get("backup_time", "Unknown")
                 version = backup.get("nexus_version", "Unknown")
                 console.print(f"  - {backup_time} (v{version})")
-                console.print(f"    [dim]{backup['path']}[/dim]")
+                console.print(f"    [nexus.muted]{backup['path']}[/nexus.muted]")
         else:
-            console.print("  [dim]No backups found[/dim]")
+            console.print("  [nexus.muted]No backups found[/nexus.muted]")
 
     except Exception as e:
         handle_error(e)
@@ -169,38 +169,44 @@ def plan(from_version: str, to_version: str, data_dir: str | None) -> None:
         path = manager.plan_upgrade(from_version, to_version)
 
         if path is None:
-            console.print(f"[red]No migration path found from {from_version} to {to_version}[/red]")
+            console.print(
+                f"[nexus.error]No migration path found from {from_version} to {to_version}[/nexus.error]"
+            )
             sys.exit(1)
 
         console.print(f"[bold cyan]Migration Plan: {from_version} -> {to_version}[/bold cyan]")
         console.print()
 
         if not path.steps:
-            console.print("[green]No migration steps needed (same version)[/green]")
+            console.print("[nexus.success]No migration steps needed (same version)[/nexus.success]")
             return
 
         console.print(f"[bold]Steps ({len(path.steps)}):[/bold]")
         for i, step in enumerate(path.steps, 1):
             flags = []
             if step.requires_backup:
-                flags.append("[yellow]backup required[/yellow]")
+                flags.append("[nexus.warning]backup required[/nexus.warning]")
             if step.is_destructive:
-                flags.append("[red]destructive[/red]")
+                flags.append("[nexus.error]destructive[/nexus.error]")
 
             flag_str = f" ({', '.join(flags)})" if flags else ""
-            console.print(f"  {i}. [cyan]{step.name}[/cyan]{flag_str}")
+            console.print(f"  {i}. [nexus.value]{step.name}[/nexus.value]{flag_str}")
             console.print(f"     {step.description}")
-            console.print(f"     [dim]{step.from_version} -> {step.to_version}[/dim]")
+            console.print(
+                f"     [nexus.muted]{step.from_version} -> {step.to_version}[/nexus.muted]"
+            )
 
         console.print()
 
         # Summary
         if path.total_requires_backup:
-            console.print("[yellow]Backup recommended before migration[/yellow]")
+            console.print("[nexus.warning]Backup recommended before migration[/nexus.warning]")
         if path.has_destructive_steps:
-            console.print("[red]Warning: Migration contains destructive steps[/red]")
+            console.print(
+                "[nexus.error]Warning: Migration contains destructive steps[/nexus.error]"
+            )
         if not path.all_rollbackable:
-            console.print("[yellow]Warning: Not all steps support rollback[/yellow]")
+            console.print("[nexus.warning]Warning: Not all steps support rollback[/nexus.warning]")
 
     except Exception as e:
         handle_error(e)
@@ -247,7 +253,7 @@ def upgrade(
         manager = VersionManager(config)
 
         if dry_run:
-            console.print("[yellow]DRY RUN - No changes will be made[/yellow]")
+            console.print("[nexus.warning]DRY RUN - No changes will be made[/nexus.warning]")
             console.print()
 
         console.print(f"[bold]Upgrading: {from_version} -> {to_version}[/bold]")
@@ -275,17 +281,17 @@ def upgrade(
         console.print(f"  Duration: {result.duration_seconds:.2f}s")
 
         if result.backup_path:
-            console.print(f"  Backup: [dim]{result.backup_path}[/dim]")
+            console.print(f"  Backup: [nexus.muted]{result.backup_path}[/nexus.muted]")
 
         if result.warnings:
             console.print()
-            console.print("[yellow]Warnings:[/yellow]")
+            console.print("[nexus.warning]Warnings:[/nexus.warning]")
             for warning in result.warnings:
                 console.print(f"  - {warning}")
 
         if result.errors:
             console.print()
-            console.print("[red]Errors:[/red]")
+            console.print("[nexus.error]Errors:[/nexus.error]")
             for error in result.errors:
                 console.print(f"  - {error}")
             sys.exit(1)
@@ -335,13 +341,13 @@ def rollback(
         current_version = manager.get_current_version()
 
         if dry_run:
-            console.print("[yellow]DRY RUN - No changes will be made[/yellow]")
+            console.print("[nexus.warning]DRY RUN - No changes will be made[/nexus.warning]")
             console.print()
 
         console.print(f"[bold]Rolling back: {current_version} -> {to_version}[/bold]")
 
         if from_backup:
-            console.print(f"  Using backup: [dim]{from_backup}[/dim]")
+            console.print(f"  Using backup: [nexus.muted]{from_backup}[/nexus.muted]")
 
         def progress_callback(message: str, current: int, total: int) -> None:
             console.print(f"  [{current}/{total}] {message}")
@@ -364,13 +370,13 @@ def rollback(
 
         if result.warnings:
             console.print()
-            console.print("[yellow]Warnings:[/yellow]")
+            console.print("[nexus.warning]Warnings:[/nexus.warning]")
             for warning in result.warnings:
                 console.print(f"  - {warning}")
 
         if result.errors:
             console.print()
-            console.print("[red]Errors:[/red]")
+            console.print("[nexus.error]Errors:[/nexus.error]")
             for error in result.errors:
                 console.print(f"  - {error}")
             sys.exit(1)
@@ -424,11 +430,11 @@ def backup_cmd(list_backups: bool, data_dir: str | None) -> None:
 
                 console.print(table)
             else:
-                console.print("[dim]No backups found[/dim]")
+                console.print("[nexus.muted]No backups found[/nexus.muted]")
         else:
             console.print("[bold]Creating backup...[/bold]")
             backup_path = manager.create_backup()
-            console.print(f"[green]Backup created:[/green] {backup_path}")
+            console.print(f"[nexus.success]Backup created:[/nexus.success] {backup_path}")
 
     except Exception as e:
         handle_error(e)
@@ -463,16 +469,16 @@ def restore(backup_path: str, dry_run: bool, data_dir: str | None) -> None:
         manager = VersionManager(config)
 
         if dry_run:
-            console.print("[yellow]DRY RUN - Would restore from:[/yellow]")
+            console.print("[nexus.warning]DRY RUN - Would restore from:[/nexus.warning]")
             console.print(f"  {backup_path}")
             return
 
         console.print(f"[bold]Restoring from backup:[/bold] {backup_path}")
 
         if manager.restore_backup(backup_path):
-            console.print("[green]Restore completed successfully![/green]")
+            console.print("[nexus.success]Restore completed successfully![/nexus.success]")
         else:
-            console.print("[red]Restore failed![/red]")
+            console.print("[nexus.error]Restore failed![/nexus.error]")
             sys.exit(1)
 
     except Exception as e:
@@ -524,7 +530,7 @@ async def _async_import_s3(
         from nexus.migrations.data_migrator import DataMigrator, ImportOptions
 
         if dry_run:
-            console.print("[yellow]DRY RUN - No changes will be made[/yellow]")
+            console.print("[nexus.warning]DRY RUN - No changes will be made[/nexus.warning]")
             console.print()
 
         console.print(f"[bold]Importing from S3:[/bold] s3://{bucket}/{prefix}")
@@ -610,7 +616,7 @@ async def _async_import_gcs(
         from nexus.migrations.data_migrator import DataMigrator, ImportOptions
 
         if dry_run:
-            console.print("[yellow]DRY RUN - No changes will be made[/yellow]")
+            console.print("[nexus.warning]DRY RUN - No changes will be made[/nexus.warning]")
             console.print()
 
         console.print(f"[bold]Importing from GCS:[/bold] gs://{bucket}/{prefix}")
@@ -685,7 +691,7 @@ async def _async_import_fs(
         from nexus.migrations.data_migrator import DataMigrator, ImportOptions
 
         if dry_run:
-            console.print("[yellow]DRY RUN - No changes will be made[/yellow]")
+            console.print("[nexus.warning]DRY RUN - No changes will be made[/nexus.warning]")
             console.print()
 
         console.print(f"[bold]Importing from:[/bold] {source}")
@@ -783,7 +789,7 @@ async def _async_validate(
 
         if result.warnings:
             console.print()
-            console.print("[yellow]Warnings:[/yellow]")
+            console.print("[nexus.warning]Warnings:[/nexus.warning]")
             for warning in result.warnings[:10]:
                 console.print(f"  - {warning}")
             if len(result.warnings) > 10:
@@ -791,7 +797,7 @@ async def _async_validate(
 
         if result.errors:
             console.print()
-            console.print("[red]Errors:[/red]")
+            console.print("[nexus.error]Errors:[/nexus.error]")
             for error in result.errors[:10]:
                 console.print(f"  - {error}")
             if len(result.errors) > 10:
@@ -817,15 +823,15 @@ def _print_import_result(result: "ImportResult", dry_run: bool) -> None:
         else:
             console.print("[bold green]Import completed successfully![/bold green]")
 
-    console.print(f"  Files imported: [green]{result.files_imported}[/green]")
-    console.print(f"  Files skipped: [yellow]{result.files_skipped}[/yellow]")
-    console.print(f"  Files failed: [red]{result.files_failed}[/red]")
+    console.print(f"  Files imported: [nexus.success]{result.files_imported}[/nexus.success]")
+    console.print(f"  Files skipped: [nexus.warning]{result.files_skipped}[/nexus.warning]")
+    console.print(f"  Files failed: [nexus.error]{result.files_failed}[/nexus.error]")
     console.print(f"  Bytes transferred: {result.bytes_transferred:,}")
     console.print(f"  Duration: {result.duration_seconds:.2f}s")
 
     if result.errors:
         console.print()
-        console.print("[red]Errors:[/red]")
+        console.print("[nexus.error]Errors:[/nexus.error]")
         for error in result.errors[:5]:
             console.print(f"  - {error}")
         if len(result.errors) > 5:

--- a/src/nexus/cli/commands/migrate.py
+++ b/src/nexus/cli/commands/migrate.py
@@ -73,7 +73,9 @@ def status(data_dir: str | None) -> None:
         manager = VersionManager(config)
 
         # Show current version
-        console.print(f"[bold cyan]Nexus Version:[/bold cyan] {nexus_pkg.__version__}")
+        console.print(
+            f"[bold nexus.value]Nexus Version:[/bold nexus.value] {nexus_pkg.__version__}"
+        )
         console.print()
 
         # Show migration history
@@ -94,11 +96,11 @@ def status(data_dir: str | None) -> None:
                         entry.started_at.strftime("%Y-%m-%d %H:%M") if entry.started_at else "N/A"
                     )
                     status_style = {
-                        "completed": "green",
-                        "failed": "red",
-                        "running": "yellow",
-                        "rolled_back": "magenta",
-                    }.get(entry.status, "dim")
+                        "completed": "nexus.success",
+                        "failed": "nexus.error",
+                        "running": "nexus.warning",
+                        "rolled_back": "nexus.identity",
+                    }.get(entry.status, "nexus.muted")
 
                     duration = ""
                     if entry.started_at and entry.completed_at:
@@ -174,7 +176,9 @@ def plan(from_version: str, to_version: str, data_dir: str | None) -> None:
             )
             sys.exit(1)
 
-        console.print(f"[bold cyan]Migration Plan: {from_version} -> {to_version}[/bold cyan]")
+        console.print(
+            f"[bold nexus.value]Migration Plan: {from_version} -> {to_version}[/bold nexus.value]"
+        )
         console.print()
 
         if not path.steps:
@@ -272,9 +276,11 @@ def upgrade(
         console.print()
 
         if result.success:
-            console.print("[bold green]Migration completed successfully![/bold green]")
+            console.print(
+                "[bold nexus.success]Migration completed successfully![/bold nexus.success]"
+            )
         else:
-            console.print("[bold red]Migration failed![/bold red]")
+            console.print("[bold nexus.error]Migration failed![/bold nexus.error]")
 
         # Show result details
         console.print(f"  Steps completed: {result.steps_completed}/{result.steps_total}")
@@ -362,9 +368,11 @@ def rollback(
         console.print()
 
         if result.success:
-            console.print("[bold green]Rollback completed successfully![/bold green]")
+            console.print(
+                "[bold nexus.success]Rollback completed successfully![/bold nexus.success]"
+            )
         else:
-            console.print("[bold red]Rollback failed![/bold red]")
+            console.print("[bold nexus.error]Rollback failed![/bold nexus.error]")
 
         console.print(f"  Duration: {result.duration_seconds:.2f}s")
 
@@ -778,9 +786,9 @@ async def _async_validate(
         console.print()
 
         if result.valid:
-            console.print("[bold green]Validation PASSED[/bold green]")
+            console.print("[bold nexus.success]Validation PASSED[/bold nexus.success]")
         else:
-            console.print("[bold red]Validation FAILED[/bold red]")
+            console.print("[bold nexus.error]Validation FAILED[/bold nexus.error]")
 
         console.print(f"  Files checked: {result.checked_files}")
         console.print(f"  Corrupted: {result.corrupted_files}")
@@ -816,12 +824,12 @@ def _print_import_result(result: "ImportResult", dry_run: bool) -> None:
         dry_run: Whether this was a dry run
     """
     if dry_run:
-        console.print("[bold yellow]DRY RUN RESULTS:[/bold yellow]")
+        console.print("[bold nexus.warning]DRY RUN RESULTS:[/bold nexus.warning]")
     else:
         if result.errors:
-            console.print("[bold red]Import completed with errors[/bold red]")
+            console.print("[bold nexus.error]Import completed with errors[/bold nexus.error]")
         else:
-            console.print("[bold green]Import completed successfully![/bold green]")
+            console.print("[bold nexus.success]Import completed successfully![/bold nexus.success]")
 
     console.print(f"  Files imported: [nexus.success]{result.files_imported}[/nexus.success]")
     console.print(f"  Files skipped: [nexus.warning]{result.files_skipped}[/nexus.warning]")

--- a/src/nexus/cli/commands/mounts.py
+++ b/src/nexus/cli/commands/mounts.py
@@ -19,9 +19,9 @@ import click
 
 from nexus.cli.output import OutputOptions, add_output_options, render_output
 from nexus.cli.timing import CommandTiming
+from nexus.cli.theme import console
 from nexus.cli.utils import (
     add_backend_options,
-    console,
     get_filesystem,
     handle_error,
 )
@@ -134,7 +134,7 @@ async def _async_add_mount(
         try:
             config_dict = json.loads(config_json)
         except json.JSONDecodeError as e:
-            console.print(f"[red]Error:[/red] Invalid JSON in config_json: {e}")
+            console.print(f"[nexus.error]Error:[/nexus.error] Invalid JSON in config_json: {e}")
             sys.exit(1)
 
         import os
@@ -144,11 +144,11 @@ async def _async_add_mount(
         base_url = remote_url or os.environ.get("NEXUS_URL", "")
         api_key = remote_api_key or os.environ.get("NEXUS_API_KEY", "")
         if not base_url:
-            console.print("[red]Error:[/red] NEXUS_URL required")
-            console.print("[yellow]Hint:[/yellow] eval $(nexus env)")
+            console.print("[nexus.error]Error:[/nexus.error] NEXUS_URL required")
+            console.print("[nexus.warning]Hint:[/nexus.warning] eval $(nexus env)")
             sys.exit(1)
 
-        console.print("[yellow]Adding mount...[/yellow]")
+        console.print("[nexus.warning]Adding mount...[/nexus.warning]")
 
         async with httpx.AsyncClient(timeout=30) as http:
             resp = await http.post(
@@ -166,24 +166,24 @@ async def _async_add_mount(
 
         if result.get("mounted"):
             mount_id = result.get("mount_point", mount_point)
-            console.print(f"[green]\u2713[/green] Mount added successfully (ID: {mount_id})")
+            console.print(f"[nexus.success]\u2713[/nexus.success] Mount added successfully (ID: {mount_id})")
         else:
-            console.print(f"[red]Error:[/red] {result.get('error', 'Mount failed')}")
+            console.print(f"[nexus.error]Error:[/nexus.error] {result.get('error', 'Mount failed')}")
             sys.exit(1)
 
         console.print()
-        console.print("[bold cyan]Mount Details:[/bold cyan]")
-        console.print(f"  Mount Point: [cyan]{mount_point}[/cyan]")
-        console.print(f"  Backend Type: [cyan]{backend_type}[/cyan]")
-        console.print(f"  Read-Only: [cyan]{readonly}[/cyan]")
-        console.print(f"  IO Profile: [cyan]{io_profile}[/cyan]")
+        console.print("[bold nexus.value]Mount Details:[/bold nexus.value]")
+        console.print(f"  Mount Point: [nexus.path]{mount_point}[/nexus.path]")
+        console.print(f"  Backend Type: [nexus.value]{backend_type}[/nexus.value]")
+        console.print(f"  Read-Only: [nexus.value]{readonly}[/nexus.value]")
+        console.print(f"  IO Profile: [nexus.value]{io_profile}[/nexus.value]")
         if owner:
-            console.print(f"  Owner: [cyan]{owner}[/cyan]")
+            console.print(f"  Owner: [nexus.value]{owner}[/nexus.value]")
         if zone:
-            console.print(f"  Zone: [cyan]{zone}[/cyan]")
+            console.print(f"  Zone: [nexus.value]{zone}[/nexus.value]")
 
     except ValueError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         sys.exit(1)
     except Exception as e:
         handle_error(e)
@@ -218,11 +218,11 @@ async def _async_remove_mount(
         base_url = remote_url or os.environ.get("NEXUS_URL", "")
         api_key = remote_api_key or os.environ.get("NEXUS_API_KEY", "")
         if not base_url:
-            console.print("[red]Error:[/red] NEXUS_URL required")
-            console.print("[yellow]Hint:[/yellow] eval $(nexus env)")
+            console.print("[nexus.error]Error:[/nexus.error] NEXUS_URL required")
+            console.print("[nexus.warning]Hint:[/nexus.warning] eval $(nexus env)")
             sys.exit(1)
 
-        console.print(f"[yellow]Removing mount at {mount_point}...[/yellow]")
+        console.print(f"[nexus.warning]Removing mount at {mount_point}...[/nexus.warning]")
 
         async with httpx.AsyncClient(timeout=10) as http:
             resp = await http.post(
@@ -231,7 +231,7 @@ async def _async_remove_mount(
                 json={"connector_type": "", "mount_point": mount_point},
             )
             resp.raise_for_status()
-            console.print("[green]\u2713[/green] Mount removed successfully")
+            console.print("[nexus.success]\u2713[/nexus.success] Mount removed successfully")
 
     except Exception as e:
         handle_error(e)
@@ -290,8 +290,8 @@ async def _async_list_mounts(
             base_url = remote_url or os.environ.get("NEXUS_URL", "")
             api_key = remote_api_key or os.environ.get("NEXUS_API_KEY", "")
             if not base_url:
-                console.print("[red]Error:[/red] NEXUS_URL required")
-                console.print("[yellow]Hint:[/yellow] eval $(nexus env)")
+                console.print("[nexus.error]Error:[/nexus.error] NEXUS_URL required")
+                console.print("[nexus.warning]Hint:[/nexus.warning] eval $(nexus env)")
                 sys.exit(1)
             async with httpx.AsyncClient(timeout=10) as http:
                 resp = await http.get(
@@ -304,27 +304,29 @@ async def _async_list_mounts(
         # Note: owner/zone filtering not yet supported in remote mode
         if owner or zone:
             console.print(
-                "[yellow]Warning:[/yellow] Filtering by owner/zone not yet supported. Showing all mounts."
+                "[nexus.warning]Warning:[/nexus.warning] Filtering by owner/zone not yet supported. Showing all mounts."
             )
 
         if not mounts:
-            console.print("[yellow]No mounts found[/yellow]")
+            console.print("[nexus.warning]No mounts found[/nexus.warning]")
             return
 
         def _render(data: list[dict[str, Any]]) -> None:
-            console.print(f"\n[bold cyan]Mounts ({len(data)} total)[/bold cyan]\n")
+            console.print(f"\n[bold nexus.value]Mounts ({len(data)} total)[/bold nexus.value]\n")
 
             for mount in data:
                 status = mount.get("status", "active")
                 if status == "stale":
                     console.print(
-                        f"[yellow]{mount['mount_point']}[/yellow]  [dim yellow](stale)[/dim yellow]"
+                        f"[nexus.warning]{mount['mount_point']}[/nexus.warning]  [nexus.muted](stale)[/nexus.muted]"
                     )
                 else:
                     console.print(f"[bold]{mount['mount_point']}[/bold]")
-                console.print(f"  Read-Only: [cyan]{'Yes' if mount['readonly'] else 'No'}[/cyan]")
                 console.print(
-                    f"  Admin-Only: [cyan]{'Yes' if mount.get('admin_only') else 'No'}[/cyan]"
+                    f"  Read-Only: [nexus.value]{'Yes' if mount['readonly'] else 'No'}[/nexus.value]"
+                )
+                console.print(
+                    f"  Admin-Only: [nexus.value]{'Yes' if mount.get('admin_only') else 'No'}[/nexus.value]"
                 )
                 console.print()
 
@@ -372,16 +374,20 @@ async def _async_mount_info(
             assert mount_svc is not None
             mount = await mount_svc.get_mount(mount_point=mount_point)
         except AttributeError:
-            console.print("[red]Error:[/red] This Nexus instance doesn't support mount info")
-            console.print("[yellow]Hint:[/yellow] Make sure you're using the latest Nexus version")
+            console.print(
+                "[nexus.error]Error:[/nexus.error] This Nexus instance doesn't support mount info"
+            )
+            console.print(
+                "[nexus.warning]Hint:[/nexus.warning] Make sure you're using the latest Nexus version"
+            )
             sys.exit(1)
 
         if not mount:
-            console.print(f"[red]Error:[/red] Mount not found: {mount_point}")
+            console.print(f"[nexus.error]Error:[/nexus.error] Mount not found: {mount_point}")
             sys.exit(1)
 
         # Display mount info
-        console.print(f"\n[bold cyan]Mount Information: {mount_point}[/bold cyan]\n")
+        console.print(f"\n[bold nexus.value]Mount Information: {mount_point}[/bold nexus.value]\n")
 
         console.print(f"[bold]Read-Only:[/bold] {'Yes' if mount['readonly'] else 'No'}")
         console.print(f"[bold]Admin-Only:[/bold] {'Yes' if mount.get('admin_only') else 'No'}")
@@ -389,7 +395,7 @@ async def _async_mount_info(
         # Note: show_config not supported yet for active mounts (config not returned by router)
         if show_config:
             console.print(
-                "\n[yellow]Note:[/yellow] Backend configuration display not yet supported for active mounts"
+                "\n[nexus.warning]Note:[/nexus.warning] Backend configuration display not yet supported for active mounts"
             )
 
         console.print()
@@ -509,8 +515,10 @@ async def _async_sync_mount(
         # Handle async mode (Issue #609)
         if run_async:
             if mount_point is None:
-                console.print("[red]Error:[/red] --async requires a mount point")
-                console.print("[yellow]Hint:[/yellow] Use: nexus mounts sync /mnt/xxx --async")
+                console.print("[nexus.error]Error:[/nexus.error] --async requires a mount point")
+                console.print(
+                    "[nexus.warning]Hint:[/nexus.warning] Use: nexus mounts sync /mnt/xxx --async"
+                )
                 sys.exit(1)
 
             with timing.phase("server"):
@@ -527,17 +535,19 @@ async def _async_sync_mount(
                     )
                 except AttributeError:
                     console.print(
-                        "[red]Error:[/red] This Nexus instance doesn't support async sync"
+                        "[nexus.error]Error:[/nexus.error] This Nexus instance doesn't support async sync"
                     )
-                    console.print("[yellow]Hint:[/yellow] Make sure you're using Nexus >= 0.6.0")
+                    console.print(
+                        "[nexus.warning]Hint:[/nexus.warning] Make sure you're using Nexus >= 0.6.0"
+                    )
                     sys.exit(1)
 
             def _render_async(data: dict[str, Any]) -> None:
-                console.print(f"[green]Job started:[/green] {data['job_id']}")
+                console.print(f"[nexus.success]Job started:[/nexus.success] {data['job_id']}")
                 console.print(f"  Mount: {data['mount_point']}")
                 console.print(f"  Status: {data['status']}")
                 console.print()
-                console.print("[dim]Monitor progress with:[/dim]")
+                console.print("[nexus.muted]Monitor progress with:[/nexus.muted]")
                 console.print(f"  nexus mounts sync-status {data['job_id']}")
 
             render_output(
@@ -550,12 +560,12 @@ async def _async_sync_mount(
 
         if not output_opts.json_output:
             if mount_point:
-                console.print(f"[yellow]Syncing mount: {mount_point}...[/yellow]")
+                console.print(f"[nexus.warning]Syncing mount: {mount_point}...[/nexus.warning]")
             else:
-                console.print("[yellow]Syncing all connector mounts...[/yellow]")
+                console.print("[nexus.warning]Syncing all connector mounts...[/nexus.warning]")
 
             if dry_run:
-                console.print("[cyan](dry run - no changes will be made)[/cyan]")
+                console.print("[nexus.value](dry run - no changes will be made)[/nexus.value]")
 
         with timing.phase("server"):
             import os
@@ -565,8 +575,8 @@ async def _async_sync_mount(
             base_url = remote_url or os.environ.get("NEXUS_URL", "")
             api_key = remote_api_key or os.environ.get("NEXUS_API_KEY", "")
             if not base_url:
-                console.print("[red]Error:[/red] NEXUS_URL required")
-                console.print("[yellow]Hint:[/yellow] eval $(nexus env)")
+                console.print("[nexus.error]Error:[/nexus.error] NEXUS_URL required")
+                console.print("[nexus.warning]Hint:[/nexus.warning] eval $(nexus env)")
                 sys.exit(1)
             async with httpx.AsyncClient(timeout=120) as http:
                 resp = await http.post(
@@ -579,41 +589,61 @@ async def _async_sync_mount(
 
         def _render_sync(data: dict[str, Any]) -> None:
             console.print()
-            console.print("[bold cyan]Sync Results:[/bold cyan]")
+            console.print("[bold nexus.value]Sync Results:[/bold nexus.value]")
 
             # Show mount-level stats if syncing all
             if mount_point is None and "mounts_synced" in data:
-                console.print(f"  Mounts synced: [green]{data['mounts_synced']}[/green]")
-                console.print(f"  Mounts skipped: [yellow]{data['mounts_skipped']}[/yellow]")
+                console.print(
+                    f"  Mounts synced: [nexus.success]{data['mounts_synced']}[/nexus.success]"
+                )
+                console.print(
+                    f"  Mounts skipped: [nexus.warning]{data['mounts_skipped']}[/nexus.warning]"
+                )
                 console.print()
 
             console.print("[bold]Metadata:[/bold]")
-            console.print(f"  Files scanned: [cyan]{data.get('files_scanned', 0)}[/cyan]")
-            console.print(f"  Files created: [green]{data.get('files_created', 0)}[/green]")
-            console.print(f"  Files updated: [cyan]{data.get('files_updated', 0)}[/cyan]")
-            console.print(f"  Files deleted: [red]{data.get('files_deleted', 0)}[/red]")
+            console.print(
+                f"  Files scanned: [nexus.value]{data.get('files_scanned', 0)}[/nexus.value]"
+            )
+            console.print(
+                f"  Files created: [nexus.success]{data.get('files_created', 0)}[/nexus.success]"
+            )
+            console.print(
+                f"  Files updated: [nexus.value]{data.get('files_updated', 0)}[/nexus.value]"
+            )
+            console.print(
+                f"  Files deleted: [nexus.error]{data.get('files_deleted', 0)}[/nexus.error]"
+            )
 
             if not no_cache:
                 console.print()
                 console.print("[bold]Cache:[/bold]")
-                console.print(f"  Files cached: [green]{data.get('cache_synced', 0)}[/green]")
+                console.print(
+                    f"  Files cached: [nexus.success]{data.get('cache_synced', 0)}[/nexus.success]"
+                )
                 cache_skipped = data.get("cache_skipped", 0)
                 if cache_skipped > 0:
-                    console.print(f"  Files skipped: [dim]{cache_skipped}[/dim] (already cached)")
+                    console.print(
+                        f"  Files skipped: [nexus.muted]{cache_skipped}[/nexus.muted] (already cached)"
+                    )
                 cache_bytes = data.get("cache_bytes", 0)
                 if cache_bytes > 1024 * 1024:
                     console.print(
-                        f"  Bytes cached: [cyan]{cache_bytes / 1024 / 1024:.2f} MB[/cyan]"
+                        f"  Bytes cached: [nexus.value]{cache_bytes / 1024 / 1024:.2f} MB[/nexus.value]"
                     )
                 elif cache_bytes > 1024:
-                    console.print(f"  Bytes cached: [cyan]{cache_bytes / 1024:.2f} KB[/cyan]")
+                    console.print(
+                        f"  Bytes cached: [nexus.value]{cache_bytes / 1024:.2f} KB[/nexus.value]"
+                    )
                 else:
-                    console.print(f"  Bytes cached: [cyan]{cache_bytes} bytes[/cyan]")
+                    console.print(f"  Bytes cached: [nexus.value]{cache_bytes} bytes[/nexus.value]")
 
             if embeddings:
                 console.print()
                 console.print("[bold]Embeddings:[/bold]")
-                console.print(f"  Generated: [green]{data.get('embeddings_generated', 0)}[/green]")
+                console.print(
+                    f"  Generated: [nexus.success]{data.get('embeddings_generated', 0)}[/nexus.success]"
+                )
 
             # Show errors if any
             errors = data.get("errors", [])
@@ -621,15 +651,15 @@ async def _async_sync_mount(
                 console.print()
                 console.print(f"[bold red]Errors ({len(errors)}):[/bold red]")
                 for error in errors[:5]:
-                    console.print(f"  [red]\u2022[/red] {error}")
+                    console.print(f"  [nexus.error]\u2022[/nexus.error] {error}")
                 if len(errors) > 5:
-                    console.print(f"  [red]... and {len(errors) - 5} more[/red]")
+                    console.print(f"  [nexus.error]... and {len(errors) - 5} more[/nexus.error]")
 
             console.print()
             if dry_run:
-                console.print("[cyan]Dry run complete - no changes made[/cyan]")
+                console.print("[nexus.value]Dry run complete - no changes made[/nexus.value]")
             else:
-                console.print("[green]\u2713[/green] Sync complete")
+                console.print("[nexus.success]\u2713[/nexus.success] Sync complete")
 
         render_output(
             data=result,
@@ -693,11 +723,13 @@ async def _async_sync_status(
                 try:
                     job = await nx.service("sync_job").get_job(job_id)
                 except AttributeError:
-                    console.print("[red]Error:[/red] This Nexus instance doesn't support sync jobs")
+                    console.print(
+                        "[nexus.error]Error:[/nexus.error] This Nexus instance doesn't support sync jobs"
+                    )
                     sys.exit(1)
 
             if not job:
-                console.print(f"[red]Error:[/red] Job not found: {job_id}")
+                console.print(f"[nexus.error]Error:[/nexus.error] Job not found: {job_id}")
                 sys.exit(1)
 
             if not watch or job["status"] not in ("pending", "running"):
@@ -715,7 +747,7 @@ async def _async_sync_status(
                 # Watch mode - always human output
                 _display_job_status(job)
                 console.print()
-                console.print("[dim]Watching progress (Ctrl+C to stop)...[/dim]")
+                console.print("[nexus.muted]Watching progress (Ctrl+C to stop)...[/nexus.muted]")
                 try:
                     while True:
                         await asyncio.sleep(2)
@@ -728,23 +760,27 @@ async def _async_sync_status(
                         if job["status"] not in ("pending", "running"):
                             break
                 except KeyboardInterrupt:
-                    console.print("\n[dim]Stopped watching[/dim]")
+                    console.print("\n[nexus.muted]Stopped watching[/nexus.muted]")
         else:
             # List recent running jobs
             with timing.phase("server"):
                 try:
                     jobs = await nx.service("sync_job").list_jobs(status="running", limit=10)
                 except AttributeError:
-                    console.print("[red]Error:[/red] This Nexus instance doesn't support sync jobs")
+                    console.print(
+                        "[nexus.error]Error:[/nexus.error] This Nexus instance doesn't support sync jobs"
+                    )
                     sys.exit(1)
 
             if not jobs:
-                console.print("[yellow]No running sync jobs[/yellow]")
-                console.print("[dim]Use 'nexus mounts sync-jobs' to see all jobs[/dim]")
+                console.print("[nexus.warning]No running sync jobs[/nexus.warning]")
+                console.print(
+                    "[nexus.muted]Use 'nexus mounts sync-jobs' to see all jobs[/nexus.muted]"
+                )
                 return
 
             def _render_jobs(data: list[dict[str, Any]]) -> None:
-                console.print(f"[bold cyan]Running Sync Jobs ({len(data)})[/bold cyan]")
+                console.print(f"[bold nexus.value]Running Sync Jobs ({len(data)})[/bold nexus.value]")
                 console.print()
                 for job_item in data:
                     console.print(f"  [bold]{job_item['id'][:8]}...[/bold]")
@@ -775,7 +811,7 @@ def _display_job_status(job: dict[str, Any]) -> None:
     status = job["status"]
     color = status_colors.get(status, "white")
 
-    console.print(f"[bold cyan]Sync Job: {job['id']}[/bold cyan]")
+    console.print(f"[bold nexus.value]Sync Job: {job['id']}[/bold nexus.value]")
     console.print()
     console.print(f"  Mount: [bold]{job['mount_point']}[/bold]")
     console.print(f"  Status: [{color}]{status}[/{color}]")
@@ -800,7 +836,7 @@ def _display_job_status(job: dict[str, Any]) -> None:
 
     if job.get("error_message"):
         console.print()
-        console.print(f"  [red]Error: {job['error_message']}[/red]")
+        console.print(f"  [nexus.error]Error: {job['error_message']}[/nexus.error]")
 
     if job.get("result"):
         console.print()
@@ -846,15 +882,19 @@ async def _async_sync_cancel(
             try:
                 result = await nx.service("sync_job").cancel_sync_job(job_id)
             except AttributeError:
-                console.print("[red]Error:[/red] This Nexus instance doesn't support sync jobs")
+                console.print(
+                    "[nexus.error]Error:[/nexus.error] This Nexus instance doesn't support sync jobs"
+                )
                 sys.exit(1)
 
         def _render(data: dict[str, Any]) -> None:
             if data["success"]:
-                console.print(f"[green]Cancellation requested for job {job_id}[/green]")
-                console.print("[dim]Job will stop at next checkpoint[/dim]")
+                console.print(
+                    f"[nexus.success]Cancellation requested for job {job_id}[/nexus.success]"
+                )
+                console.print("[nexus.muted]Job will stop at next checkpoint[/nexus.muted]")
             else:
-                console.print(f"[red]Failed:[/red] {data['message']}")
+                console.print(f"[nexus.error]Failed:[/nexus.error] {data['message']}")
                 sys.exit(1)
 
         render_output(
@@ -922,11 +962,13 @@ async def _async_sync_jobs(
                     mount_point=mount, status=status, limit=limit
                 )
             except AttributeError:
-                console.print("[red]Error:[/red] This Nexus instance doesn't support sync jobs")
+                console.print(
+                    "[nexus.error]Error:[/nexus.error] This Nexus instance doesn't support sync jobs"
+                )
                 sys.exit(1)
 
         if not jobs:
-            console.print("[yellow]No sync jobs found[/yellow]")
+            console.print("[nexus.warning]No sync jobs found[/nexus.warning]")
             return
 
         def _render(data: list[dict[str, Any]]) -> None:
@@ -938,7 +980,7 @@ async def _async_sync_jobs(
                 "cancelled": "yellow",
             }
 
-            console.print(f"[bold cyan]Sync Jobs ({len(data)} shown)[/bold cyan]")
+            console.print(f"[bold nexus.value]Sync Jobs ({len(data)} shown)[/bold nexus.value]")
             console.print()
 
             for job in data:
@@ -954,7 +996,9 @@ async def _async_sync_jobs(
                 )
 
             console.print()
-            console.print("[dim]Use 'nexus mounts sync-status <job_id>' for details[/dim]")
+            console.print(
+                "[nexus.muted]Use 'nexus mounts sync-status <job_id>' for details[/nexus.muted]"
+            )
 
         render_output(
             data=jobs,
@@ -1012,8 +1056,12 @@ async def _async_list_skills(
                 raw = await nx.sys_read(skill_md_path)
                 content = raw.decode("utf-8") if isinstance(raw, bytes) else str(raw)
             except Exception:
-                console.print(f"[yellow]No skill documentation found at {skill_md_path}[/yellow]")
-                console.print("[dim]This mount may not be a connector with skill docs.[/dim]")
+                console.print(
+                    f"[nexus.warning]No skill documentation found at {skill_md_path}[/nexus.warning]"
+                )
+                console.print(
+                    "[nexus.muted]This mount may not be a connector with skill docs.[/nexus.muted]"
+                )
                 return
 
             # List schema files
@@ -1025,7 +1073,7 @@ async def _async_list_skills(
                 pass  # No schemas directory is OK
 
         def _render(data: dict[str, Any]) -> None:
-            console.print(f"[bold cyan]Skills for {mp}[/bold cyan]")
+            console.print(f"[bold nexus.value]Skills for {mp}[/bold nexus.value]")
             console.print()
             console.print(data["content"])
             if data["schemas"]:
@@ -1034,7 +1082,7 @@ async def _async_list_skills(
                 for s in data["schemas"]:
                     op_name = s.replace(".yaml", "")
                     console.print(
-                        f"  [green]{op_name}[/green]  \u2192  nexus mounts schema {mp} {op_name}"
+                        f"  [nexus.success]{op_name}[/nexus.success]  \u2192  nexus mounts schema {mp} {op_name}"
                     )
 
         result_data = {"mount_point": mp, "content": content, "schemas": schema_files}
@@ -1098,20 +1146,24 @@ async def _async_show_schema(
                 raw = await nx.sys_read(schema_path)
                 content = raw.decode("utf-8") if isinstance(raw, bytes) else str(raw)
             except Exception:
-                console.print(f"[red]Schema not found:[/red] {schema_path}")
+                console.print(f"[nexus.error]Schema not found:[/nexus.error] {schema_path}")
                 console.print()
-                console.print("[dim]Available operations:[/dim]")
+                console.print("[nexus.muted]Available operations:[/nexus.muted]")
                 try:
                     entries = await nx.sys_readdir(f"{mp}/.skill/schemas")
                     for e in entries:
                         if str(e).endswith(".yaml"):
-                            console.print(f"  [green]{str(e).replace('.yaml', '')}[/green]")
+                            console.print(
+                                f"  [nexus.success]{str(e).replace('.yaml', '')}[/nexus.success]"
+                            )
                 except Exception:
-                    console.print("  [yellow]No schemas found for this mount[/yellow]")
+                    console.print(
+                        "  [nexus.warning]No schemas found for this mount[/nexus.warning]"
+                    )
                 return
 
         def _render(data: dict[str, Any]) -> None:
-            console.print(f"[bold cyan]Schema: {operation}[/bold cyan]  ({mp})")
+            console.print(f"[bold nexus.value]Schema: {operation}[/bold nexus.value]  ({mp})")
             console.print()
             console.print(data["content"])
 
@@ -1171,7 +1223,7 @@ async def _async_reauth_mount(
         nx: Any = await get_filesystem(remote_url, remote_api_key)
         mount_svc = nx.service("mount")
         if mount_svc is None:
-            console.print("[red]Error:[/red] Mount service not available")
+            console.print("[nexus.error]Error:[/nexus.error] Mount service not available")
             sys.exit(1)
 
         with timing.phase("server"):
@@ -1184,11 +1236,11 @@ async def _async_reauth_mount(
         def _render(data: dict[str, Any]) -> None:
             if data.get("refreshed"):
                 console.print(
-                    f"[green]Token refreshed[/green] for {mount_point} "
+                    f"[nexus.success]Token refreshed[/nexus.success] for {mount_point} "
                     f"(provider={data.get('provider')}, user={data.get('user_email')})"
                 )
             else:
-                console.print(f"[red]Token refresh failed[/red] for {mount_point}")
+                console.print(f"[nexus.error]Token refresh failed[/nexus.error] for {mount_point}")
                 if data.get("error"):
                     console.print(f"  Error: {data['error']}")
 
@@ -1246,7 +1298,7 @@ async def _async_update_mount(
         nx: Any = await get_filesystem(remote_url, remote_api_key)
         mount_svc = nx.service("mount")
         if mount_svc is None:
-            console.print("[red]Error:[/red] Mount service not available")
+            console.print("[nexus.error]Error:[/nexus.error] Mount service not available")
             sys.exit(1)
 
         config = json.loads(config_json)
@@ -1259,10 +1311,10 @@ async def _async_update_mount(
 
         def _render(data: dict[str, Any]) -> None:
             if data.get("updated"):
-                console.print(f"[green]Updated[/green] {mount_point}")
+                console.print(f"[nexus.success]Updated[/nexus.success] {mount_point}")
                 console.print(f"  Changed: {', '.join(data.get('changed_keys', []))}")
             else:
-                console.print(f"[yellow]No changes[/yellow] for {mount_point}")
+                console.print(f"[nexus.warning]No changes[/nexus.warning] for {mount_point}")
 
         render_output(
             data=result,
@@ -1272,7 +1324,7 @@ async def _async_update_mount(
         )
 
     except json.JSONDecodeError as e:
-        console.print(f"[red]Invalid JSON:[/red] {e}")
+        console.print(f"[nexus.error]Invalid JSON:[/nexus.error] {e}")
         sys.exit(1)
     except Exception as e:
         handle_error(e)

--- a/src/nexus/cli/commands/mounts.py
+++ b/src/nexus/cli/commands/mounts.py
@@ -18,8 +18,8 @@ from typing import Any
 import click
 
 from nexus.cli.output import OutputOptions, add_output_options, render_output
-from nexus.cli.timing import CommandTiming
 from nexus.cli.theme import console
+from nexus.cli.timing import CommandTiming
 from nexus.cli.utils import (
     add_backend_options,
     get_filesystem,
@@ -166,9 +166,13 @@ async def _async_add_mount(
 
         if result.get("mounted"):
             mount_id = result.get("mount_point", mount_point)
-            console.print(f"[nexus.success]\u2713[/nexus.success] Mount added successfully (ID: {mount_id})")
+            console.print(
+                f"[nexus.success]\u2713[/nexus.success] Mount added successfully (ID: {mount_id})"
+            )
         else:
-            console.print(f"[nexus.error]Error:[/nexus.error] {result.get('error', 'Mount failed')}")
+            console.print(
+                f"[nexus.error]Error:[/nexus.error] {result.get('error', 'Mount failed')}"
+            )
             sys.exit(1)
 
         console.print()

--- a/src/nexus/cli/commands/mounts.py
+++ b/src/nexus/cli/commands/mounts.py
@@ -811,7 +811,7 @@ def _display_job_status(job: dict[str, Any]) -> None:
         "cancelled": "nexus.warning",
     }
     status = job["status"]
-    color = status_colors.get(status, "white")
+    color = status_colors.get(status, "")
 
     console.print(f"[bold nexus.value]Sync Job: {job['id']}[/bold nexus.value]")
     console.print()
@@ -987,7 +987,7 @@ async def _async_sync_jobs(
 
             for job in data:
                 job_status = job["status"]
-                color = status_colors.get(job_status, "white")
+                color = status_colors.get(job_status, "")
                 job_id_short = job["id"][:8]
 
                 console.print(

--- a/src/nexus/cli/commands/mounts.py
+++ b/src/nexus/cli/commands/mounts.py
@@ -318,7 +318,7 @@ async def _async_list_mounts(
                 status = mount.get("status", "active")
                 if status == "stale":
                     console.print(
-                        f"[nexus.warning]{mount['mount_point']}[/nexus.warning]  [nexus.muted](stale)[/nexus.muted]"
+                        f"[nexus.warning]{mount['mount_point']}[/nexus.warning]  [nexus.warning](stale)[/nexus.warning]"
                     )
                 else:
                     console.print(f"[bold]{mount['mount_point']}[/bold]")
@@ -649,7 +649,7 @@ async def _async_sync_mount(
             errors = data.get("errors", [])
             if errors:
                 console.print()
-                console.print(f"[bold red]Errors ({len(errors)}):[/bold red]")
+                console.print(f"[bold nexus.error]Errors ({len(errors)}):[/bold nexus.error]")
                 for error in errors[:5]:
                     console.print(f"  [nexus.error]\u2022[/nexus.error] {error}")
                 if len(errors) > 5:
@@ -780,7 +780,9 @@ async def _async_sync_status(
                 return
 
             def _render_jobs(data: list[dict[str, Any]]) -> None:
-                console.print(f"[bold nexus.value]Running Sync Jobs ({len(data)})[/bold nexus.value]")
+                console.print(
+                    f"[bold nexus.value]Running Sync Jobs ({len(data)})[/bold nexus.value]"
+                )
                 console.print()
                 for job_item in data:
                     console.print(f"  [bold]{job_item['id'][:8]}...[/bold]")
@@ -802,11 +804,11 @@ async def _async_sync_status(
 def _display_job_status(job: dict[str, Any]) -> None:
     """Display job status in a formatted way."""
     status_colors = {
-        "pending": "yellow",
-        "running": "cyan",
-        "completed": "green",
-        "failed": "red",
-        "cancelled": "yellow",
+        "pending": "nexus.warning",
+        "running": "nexus.value",
+        "completed": "nexus.success",
+        "failed": "nexus.error",
+        "cancelled": "nexus.warning",
     }
     status = job["status"]
     color = status_colors.get(status, "white")
@@ -973,11 +975,11 @@ async def _async_sync_jobs(
 
         def _render(data: list[dict[str, Any]]) -> None:
             status_colors = {
-                "pending": "yellow",
-                "running": "cyan",
-                "completed": "green",
-                "failed": "red",
-                "cancelled": "yellow",
+                "pending": "nexus.warning",
+                "running": "nexus.value",
+                "completed": "nexus.success",
+                "failed": "nexus.error",
+                "cancelled": "nexus.warning",
             }
 
             console.print(f"[bold nexus.value]Sync Jobs ({len(data)} shown)[/bold nexus.value]")

--- a/src/nexus/cli/commands/network.py
+++ b/src/nexus/cli/commands/network.py
@@ -14,7 +14,7 @@ import click
 from rich.panel import Panel
 from rich.table import Table
 
-from nexus.cli.utils import console
+from nexus.cli.theme import console
 
 
 @click.group()
@@ -57,7 +57,7 @@ def init(node_id: int, listen_port: int) -> None:
     try:
         identity = init_identity(node_id, listen_port)
     except RuntimeError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from e
 
     console.print(
@@ -66,8 +66,8 @@ def init(node_id: int, listen_port: int) -> None:
             f"  Node ID:      {identity['node_id']}\n"
             f"  WireGuard IP: {identity['ip']}\n"
             f"  Listen Port:  {identity['listen_port']}\n"
-            f"  Public Key:   [cyan]{identity['public_key']}[/cyan]\n\n"
-            f"[dim]Share the public key with peers.[/dim]",
+            f"  Public Key:   [nexus.value]{identity['public_key']}[/nexus.value]\n\n"
+            f"[nexus.muted]Share the public key with peers.[/nexus.muted]",
             title="nexus network",
         )
     )
@@ -96,7 +96,7 @@ def add_peer(node_id: int, public_key: str, endpoint: str) -> None:
 
     peer = _add_peer(node_id, public_key, endpoint)
     console.print(
-        f"[green]Peer added:[/green] node={peer['node_id']} "
+        f"[nexus.success]Peer added:[/nexus.success] node={peer['node_id']} "
         f"ip={peer['ip']} endpoint={peer['endpoint']}"
     )
 
@@ -113,9 +113,9 @@ def remove_peer(node_id: int) -> None:
     from nexus.network.wireguard import remove_peer as _remove_peer
 
     if _remove_peer(node_id):
-        console.print(f"[green]Peer {node_id} removed.[/green]")
+        console.print(f"[nexus.success]Peer {node_id} removed.[/nexus.success]")
     else:
-        console.print(f"[yellow]Peer {node_id} not found.[/yellow]")
+        console.print(f"[nexus.warning]Peer {node_id} not found.[/nexus.warning]")
 
 
 @network.command()
@@ -127,7 +127,7 @@ def config() -> None:
         identity = load_identity()
         peers = load_peers()
     except FileNotFoundError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from e
 
     wg_config = generate_wg_config(identity, peers)
@@ -144,9 +144,9 @@ def up() -> None:
 
     try:
         msg = tunnel_up()
-        console.print(f"[green]{msg}[/green]")
+        console.print(f"[nexus.success]{msg}[/nexus.success]")
     except (RuntimeError, FileNotFoundError) as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from e
 
 
@@ -157,9 +157,9 @@ def down() -> None:
 
     try:
         msg = tunnel_down()
-        console.print(f"[green]{msg}[/green]")
+        console.print(f"[nexus.success]{msg}[/nexus.success]")
     except RuntimeError as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from e
 
 
@@ -176,14 +176,16 @@ def status() -> None:
             f"ip={identity['ip']} port={identity['listen_port']}"
         )
     except FileNotFoundError:
-        console.print("[yellow]No identity configured. Run `nexus network init` first.[/yellow]")
+        console.print(
+            "[nexus.warning]No identity configured. Run `nexus network init` first.[/nexus.warning]"
+        )
         return
 
     # Show configured peers
     peers = load_peers()
     if peers:
         table = Table(title="Configured Peers")
-        table.add_column("Node ID", style="cyan")
+        table.add_column("Node ID", style="nexus.value")
         table.add_column("WireGuard IP")
         table.add_column("Endpoint")
         table.add_column("Public Key")
@@ -196,7 +198,7 @@ def status() -> None:
             )
         console.print(table)
     else:
-        console.print("[dim]No peers configured.[/dim]")
+        console.print("[nexus.muted]No peers configured.[/nexus.muted]")
 
     # Show live tunnel status
     console.print()

--- a/src/nexus/cli/commands/network.py
+++ b/src/nexus/cli/commands/network.py
@@ -62,7 +62,7 @@ def init(node_id: int, listen_port: int) -> None:
 
     console.print(
         Panel.fit(
-            f"[bold green]Node initialized[/bold green]\n\n"
+            f"[bold nexus.success]Node initialized[/bold nexus.success]\n\n"
             f"  Node ID:      {identity['node_id']}\n"
             f"  WireGuard IP: {identity['ip']}\n"
             f"  Listen Port:  {identity['listen_port']}\n"

--- a/src/nexus/cli/commands/oauth.py
+++ b/src/nexus/cli/commands/oauth.py
@@ -24,10 +24,9 @@ import sys
 from typing import TYPE_CHECKING
 
 import click
-from rich.console import Console
 from rich.table import Table
 
-from nexus.cli.utils import console
+from nexus.cli.theme import console
 from nexus.contracts.constants import ROOT_ZONE_ID
 
 # Brick imports via importlib to avoid cli→bricks tier violation
@@ -37,9 +36,6 @@ if TYPE_CHECKING:
 else:
     XOAuthProvider = _il.import_module("nexus.bricks.auth.oauth.providers.x").XOAuthProvider
     TokenManager = _il.import_module("nexus.bricks.auth.oauth.token_manager").TokenManager
-
-# Rich console for output
-_console = Console()
 
 
 def get_token_manager(db_path: str | None = None) -> TokenManager:
@@ -124,15 +120,15 @@ def list_credentials(db_path: str | None, zone_id: str | None) -> None:
         credentials = await manager.list_credentials(zone_id=zone_id)
 
         if not credentials:
-            console.print("[yellow]No OAuth credentials found[/yellow]")
+            console.print("[nexus.warning]No OAuth credentials found[/nexus.warning]")
             return
 
         # Create table
-        table = Table(title="OAuth Credentials", show_header=True, header_style="bold magenta")
-        table.add_column("Provider", style="cyan")
-        table.add_column("User Email", style="green")
-        table.add_column("Zone ID", style="blue")
-        table.add_column("Status", style="yellow")
+        table = Table(title="OAuth Credentials", show_header=True, header_style="bold nexus.accent")
+        table.add_column("Provider", style="nexus.value")
+        table.add_column("User Email", style="nexus.success")
+        table.add_column("Zone ID", style="nexus.reference")
+        table.add_column("Status", style="nexus.warning")
         table.add_column("Expires At", style="white")
         table.add_column("Last Used", style="white")
 
@@ -192,9 +188,13 @@ def revoke_credential(
         success = await manager.revoke_credential(provider, user_email, zone_id or ROOT_ZONE_ID)
 
         if success:
-            console.print(f"[green]✓[/green] Revoked credential: {provider}:{user_email}")
+            console.print(
+                f"[nexus.success]✓[/nexus.success] Revoked credential: {provider}:{user_email}"
+            )
         else:
-            console.print(f"[red]✗[/red] Credential not found: {provider}:{user_email}")
+            console.print(
+                f"[nexus.error]✗[/nexus.error] Credential not found: {provider}:{user_email}"
+            )
             sys.exit(1)
 
     asyncio.run(_revoke())
@@ -236,18 +236,20 @@ def test_credential(
 
     # Register provider (needed for validation)
     # Note: This is a simplified version - in production, you'd load client credentials from config
-    console.print(f"[yellow]⚠ Testing credential for {provider}:{user_email}...[/yellow]")
+    console.print(
+        f"[nexus.warning]⚠ Testing credential for {provider}:{user_email}...[/nexus.warning]"
+    )
 
     async def _test() -> None:
         try:
             # Try to get a valid token (will auto-refresh if needed)
             token = await manager.get_valid_token(provider, user_email, zone_id or ROOT_ZONE_ID)
 
-            console.print("[green]✓[/green] Credential is valid")
-            console.print(f"[dim]Token length: {len(token)} chars[/dim]")
+            console.print("[nexus.success]✓[/nexus.success] Credential is valid")
+            console.print(f"[nexus.muted]Token length: {len(token)} chars[/nexus.muted]")
 
         except Exception as e:
-            console.print(f"[red]✗[/red] Credential test failed: {e}")
+            console.print(f"[nexus.error]✗[/nexus.error] Credential test failed: {e}")
             sys.exit(1)
 
     asyncio.run(_test())
@@ -331,15 +333,15 @@ def setup_gdrive(
 
     # Validate that credentials are provided (either via options or environment)
     if not client_id:
-        console.print("[red]Error:[/red] Google OAuth client ID not provided")
-        console.print("[yellow]Provide via:[/yellow]")
+        console.print("[nexus.error]Error:[/nexus.error] Google OAuth client ID not provided")
+        console.print("[nexus.warning]Provide via:[/nexus.warning]")
         console.print("  --client-id option, OR")
         console.print("  NEXUS_OAUTH_GOOGLE_CLIENT_ID environment variable")
         sys.exit(1)
 
     if not client_secret:
-        console.print("[red]Error:[/red] Google OAuth client secret not provided")
-        console.print("[yellow]Provide via:[/yellow]")
+        console.print("[nexus.error]Error:[/nexus.error] Google OAuth client secret not provided")
+        console.print("[nexus.warning]Provide via:[/nexus.warning]")
         console.print("  --client-secret option, OR")
         console.print("  NEXUS_OAUTH_GOOGLE_CLIENT_SECRET environment variable")
         sys.exit(1)
@@ -370,14 +372,16 @@ def setup_gdrive(
     console.print(
         "[bold yellow]Step 3:[/bold yellow] Copy the 'code' parameter from the failed URL:"
     )
-    console.print("[dim]Example: http://localhost/?code=4/0AdLI...[/dim]")
-    console.print("[dim]Copy everything after 'code=' (the authorization code)[/dim]")
+    console.print("[nexus.muted]Example: http://localhost/?code=4/0AdLI...[/nexus.muted]")
+    console.print(
+        "[nexus.muted]Copy everything after 'code=' (the authorization code)[/nexus.muted]"
+    )
 
     # Get authorization code from user
     auth_code = click.prompt("\nEnter authorization code")
 
     # Exchange code for tokens
-    console.print("\n[dim]Exchanging code for tokens...[/dim]")
+    console.print("\n[nexus.muted]Exchanging code for tokens...[/nexus.muted]")
 
     async def _exchange_and_store() -> str:
         # Exchange code
@@ -394,20 +398,24 @@ def setup_gdrive(
         )
         manager.close()
 
-        console.print(f"[green]✓[/green] Stored credential with ID: {cred_id}")
+        console.print(f"[nexus.success]✓[/nexus.success] Stored credential with ID: {cred_id}")
         return cred_id
 
     import asyncio
 
     try:
         cred_id = asyncio.run(_exchange_and_store())
-        console.print(f"\n[green]✓[/green] Successfully stored credentials for {user_email}")
-        console.print(f"[dim]Credential ID: {cred_id}[/dim]")
+        console.print(
+            f"\n[nexus.success]✓[/nexus.success] Successfully stored credentials for {user_email}"
+        )
+        console.print(f"[nexus.muted]Credential ID: {cred_id}[/nexus.muted]")
         console.print("\n[bold]Next steps:[/bold]")
         console.print("1. Configure Nexus to use Google Drive backend")
-        console.print("2. Use [cyan]nexus oauth test google {user_email}[/cyan] to verify")
+        console.print(
+            "2. Use [nexus.value]nexus oauth test google {user_email}[/nexus.value] to verify"
+        )
     except Exception as e:
-        console.print(f"\n[red]✗[/red] Failed to setup Google Drive: {e}")
+        console.print(f"\n[nexus.error]✗[/nexus.error] Failed to setup Google Drive: {e}")
         sys.exit(1)
 
 
@@ -489,8 +497,8 @@ def setup_x(
 
     # Validate that client_id is provided
     if not client_id:
-        console.print("[red]Error:[/red] X OAuth client ID not provided")
-        console.print("[yellow]Provide via:[/yellow]")
+        console.print("[nexus.error]Error:[/nexus.error] X OAuth client ID not provided")
+        console.print("[nexus.warning]Provide via:[/nexus.warning]")
         console.print("  --client-id option, OR")
         console.print("  NEXUS_OAUTH_X_CLIENT_ID environment variable")
         console.print("\n[bold]Get credentials at:[/bold] https://developer.twitter.com/")
@@ -533,14 +541,18 @@ def setup_x(
     console.print(
         "[bold yellow]Step 3:[/bold yellow] Copy the 'code' parameter from the failed URL:"
     )
-    console.print("[dim]Example: http://localhost/?code=ABCD...[/dim]")
-    console.print("[dim]Copy everything after 'code=' (the authorization code)[/dim]")
+    console.print("[nexus.muted]Example: http://localhost/?code=ABCD...[/nexus.muted]")
+    console.print(
+        "[nexus.muted]Copy everything after 'code=' (the authorization code)[/nexus.muted]"
+    )
 
     # Get authorization code from user
     auth_code = click.prompt("\nEnter authorization code")
 
     # Exchange code for tokens using PKCE
-    console.print("\n[dim]Exchanging code for tokens (using PKCE verifier)...[/dim]")
+    console.print(
+        "\n[nexus.muted]Exchanging code for tokens (using PKCE verifier)...[/nexus.muted]"
+    )
 
     async def _exchange_and_store() -> str:
         # Exchange code with PKCE verifier
@@ -557,17 +569,23 @@ def setup_x(
         )
         manager.close()
 
-        console.print(f"[green]✓[/green] Stored credential with ID: {cred_id}")
+        console.print(f"[nexus.success]✓[/nexus.success] Stored credential with ID: {cred_id}")
         return cred_id
 
     try:
         cred_id = asyncio.run(_exchange_and_store())
-        console.print(f"\n[green]✓[/green] Successfully stored credentials for {user_email}")
-        console.print(f"[dim]Credential ID: {cred_id}[/dim]")
+        console.print(
+            f"\n[nexus.success]✓[/nexus.success] Successfully stored credentials for {user_email}"
+        )
+        console.print(f"[nexus.muted]Credential ID: {cred_id}[/nexus.muted]")
         console.print("\n[bold]Next steps:[/bold]")
         console.print("1. Configure Nexus to use X connector backend")
-        console.print(f"2. Use [cyan]nexus oauth test twitter {user_email}[/cyan] to verify")
-        console.print("3. Try the example: [cyan]python examples/x_connector_example.py[/cyan]")
+        console.print(
+            f"2. Use [nexus.value]nexus oauth test twitter {user_email}[/nexus.value] to verify"
+        )
+        console.print(
+            "3. Try the example: [nexus.path]python examples/x_connector_example.py[/nexus.path]"
+        )
     except Exception as e:
-        console.print(f"\n[red]✗[/red] Failed to setup X OAuth: {e}")
+        console.print(f"\n[nexus.error]✗[/nexus.error] Failed to setup X OAuth: {e}")
         sys.exit(1)

--- a/src/nexus/cli/commands/oauth.py
+++ b/src/nexus/cli/commands/oauth.py
@@ -124,7 +124,9 @@ def list_credentials(db_path: str | None, zone_id: str | None) -> None:
             return
 
         # Create table
-        table = Table(title="OAuth Credentials", show_header=True, header_style="bold nexus.accent")
+        table = Table(
+            title="OAuth Credentials", show_header=True, header_style="nexus.table_header"
+        )
         table.add_column("Provider", style="nexus.value")
         table.add_column("User Email", style="nexus.success")
         table.add_column("Zone ID", style="nexus.reference")

--- a/src/nexus/cli/commands/oauth.py
+++ b/src/nexus/cli/commands/oauth.py
@@ -131,8 +131,8 @@ def list_credentials(db_path: str | None, zone_id: str | None) -> None:
         table.add_column("User Email", style="nexus.success")
         table.add_column("Zone ID", style="nexus.reference")
         table.add_column("Status", style="nexus.warning")
-        table.add_column("Expires At", style="white")
-        table.add_column("Last Used", style="white")
+        table.add_column("Expires At")
+        table.add_column("Last Used")
 
         for cred in credentials:
             status = "🔴 Expired" if cred["is_expired"] else "🟢 Valid"
@@ -363,16 +363,16 @@ def setup_gdrive(
     # Generate authorization URL
     auth_url = provider.get_authorization_url()
 
-    console.print("\n[bold green]Google Drive OAuth Setup[/bold green]")
+    console.print("\n[bold nexus.success]Google Drive OAuth Setup[/bold nexus.success]")
     console.print(f"\n[bold]User:[/bold] {user_email}")
     console.print(f"[bold]Client ID:[/bold] {client_id}")
-    console.print("\n[bold yellow]Step 1:[/bold yellow] Visit this URL to authorize:")
+    console.print("\n[bold nexus.warning]Step 1:[/bold nexus.warning] Visit this URL to authorize:")
     console.print(f"\n{auth_url}\n")
     console.print(
-        "[bold yellow]Step 2:[/bold yellow] After granting permission, the browser will redirect to localhost (which will fail)."
+        "[bold nexus.warning]Step 2:[/bold nexus.warning] After granting permission, the browser will redirect to localhost (which will fail)."
     )
     console.print(
-        "[bold yellow]Step 3:[/bold yellow] Copy the 'code' parameter from the failed URL:"
+        "[bold nexus.warning]Step 3:[/bold nexus.warning] Copy the 'code' parameter from the failed URL:"
     )
     console.print("[nexus.muted]Example: http://localhost/?code=4/0AdLI...[/nexus.muted]")
     console.print(
@@ -531,17 +531,17 @@ def setup_x(
     auth_url, pkce_data = provider.get_authorization_url_with_pkce()
     code_verifier = pkce_data["code_verifier"]
 
-    console.print("\n[bold green]X (Twitter) OAuth Setup[/bold green]")
+    console.print("\n[bold nexus.success]X (Twitter) OAuth Setup[/bold nexus.success]")
     console.print(f"\n[bold]User:[/bold] {user_email}")
     console.print(f"[bold]Client ID:[/bold] {client_id}")
     console.print("[bold]Using PKCE:[/bold] Yes (enhanced security)")
-    console.print("\n[bold yellow]Step 1:[/bold yellow] Visit this URL to authorize:")
+    console.print("\n[bold nexus.warning]Step 1:[/bold nexus.warning] Visit this URL to authorize:")
     console.print(f"\n{auth_url}\n")
     console.print(
-        "[bold yellow]Step 2:[/bold yellow] After granting permission, the browser will redirect to localhost (which will fail)."
+        "[bold nexus.warning]Step 2:[/bold nexus.warning] After granting permission, the browser will redirect to localhost (which will fail)."
     )
     console.print(
-        "[bold yellow]Step 3:[/bold yellow] Copy the 'code' parameter from the failed URL:"
+        "[bold nexus.warning]Step 3:[/bold nexus.warning] Copy the 'code' parameter from the failed URL:"
     )
     console.print("[nexus.muted]Example: http://localhost/?code=ABCD...[/nexus.muted]")
     console.print(

--- a/src/nexus/cli/commands/operations.py
+++ b/src/nexus/cli/commands/operations.py
@@ -82,7 +82,9 @@ async def _async_ops_diff(
 
         time_travel = nx.service("time_travel")
         if time_travel is None:
-            console.print("[red]Error:[/red] Time-travel is only supported with local NexusFS")
+            console.print(
+                "[nexus.error]Error:[/nexus.error] Time-travel is only supported with local NexusFS"
+            )
             nx.close()
             return
 
@@ -91,37 +93,39 @@ async def _async_ops_diff(
 
         # Display results
         console.print(f"\n[bold cyan]Diff for {path}[/bold cyan]")
-        console.print(f"[dim]Operation 1:[/dim] {operation_1}")
-        console.print(f"[dim]Operation 2:[/dim] {operation_2}")
+        console.print(f"[nexus.muted]Operation 1:[/nexus.muted] {operation_1}")
+        console.print(f"[nexus.muted]Operation 2:[/nexus.muted] {operation_2}")
         console.print()
 
         state_1 = diff_result["operation_1"]
         state_2 = diff_result["operation_2"]
 
         if not state_1 and not state_2:
-            console.print("[yellow]File did not exist at either operation point[/yellow]")
+            console.print(
+                "[nexus.warning]File did not exist at either operation point[/nexus.warning]"
+            )
             return
 
         if not state_1:
-            console.print("[green]File was created[/green]")
+            console.print("[nexus.success]File was created[/nexus.success]")
             console.print(f"  Size: {state_2['metadata']['size']:,} bytes")
             console.print(f"  Operation: {state_2['operation_id'][:8]}")
             console.print(f"  Time: {state_2['operation_time']}")
         elif not state_2:
-            console.print("[red]File was deleted[/red]")
+            console.print("[nexus.error]File was deleted[/nexus.error]")
             console.print(f"  Previous size: {state_1['metadata']['size']:,} bytes")
             console.print(f"  Operation: {state_1['operation_id'][:8]}")
             console.print(f"  Time: {state_1['operation_time']}")
         else:
             # Both exist - show changes
             if diff_result["content_changed"]:
-                console.print("[yellow]File content changed[/yellow]")
+                console.print("[nexus.warning]File content changed[/nexus.warning]")
                 console.print(
                     f"  Size: {state_1['metadata']['size']:,} → {state_2['metadata']['size']:,} bytes"
                 )
                 console.print(f"  Size diff: {diff_result['size_diff']:+,} bytes")
             else:
-                console.print("[green]File content unchanged[/green]")
+                console.print("[nexus.success]File content unchanged[/nexus.success]")
 
             console.print()
             console.print("[bold]Operation 1:[/bold]")
@@ -159,16 +163,18 @@ async def _async_ops_diff(
                         if line.startswith("+++") or line.startswith("---"):
                             console.print(f"[bold]{line}[/bold]")
                         elif line.startswith("+"):
-                            console.print(f"[green]{line}[/green]")
+                            console.print(f"[nexus.success]{line}[/nexus.success]")
                         elif line.startswith("-"):
-                            console.print(f"[red]{line}[/red]")
+                            console.print(f"[nexus.error]{line}[/nexus.error]")
                         elif line.startswith("@@"):
-                            console.print(f"[cyan]{line}[/cyan]")
+                            console.print(f"[nexus.value]{line}[/nexus.value]")
                         else:
-                            console.print(f"[dim]{line}[/dim]")
+                            console.print(f"[nexus.muted]{line}[/nexus.muted]")
 
                 except UnicodeDecodeError:
-                    console.print("[yellow]Binary file - content diff not available[/yellow]")
+                    console.print(
+                        "[nexus.warning]Binary file - content diff not available[/nexus.warning]"
+                    )
 
     except Exception as e:
         handle_error(e)
@@ -246,21 +252,25 @@ async def _async_ops_log(
         )
 
         if not operations:
-            console.print("[yellow]No operations found[/yellow]")
+            console.print("[nexus.warning]No operations found[/nexus.warning]")
             nx.close()
             return
 
         # Display table
         table = Table(title="Operation Log")
-        table.add_column("Time", style="cyan")
-        table.add_column("Type", style="yellow")
-        table.add_column("Path", style="green")
-        table.add_column("Agent", style="blue")
+        table.add_column("Time", style="nexus.value")
+        table.add_column("Type", style="nexus.warning")
+        table.add_column("Path", style="nexus.success")
+        table.add_column("Agent", style="nexus.reference")
         table.add_column("Status")
-        table.add_column("Op ID", style="dim")
+        table.add_column("Op ID", style="nexus.muted")
 
         for op in operations:
-            status_display = "[green]✓[/green]" if op["status"] == "success" else "[red]✗[/red]"
+            status_display = (
+                "[nexus.success]✓[/nexus.success]"
+                if op["status"] == "success"
+                else "[nexus.error]✗[/nexus.error]"
+            )
             created_at = op["created_at"].strftime("%Y-%m-%d %H:%M:%S")
 
             # Truncate operation ID for display
@@ -281,7 +291,7 @@ async def _async_ops_log(
             )
 
         console.print(table)
-        console.print(f"\n[dim]Showing {len(operations)} operations[/dim]")
+        console.print(f"\n[nexus.muted]Showing {len(operations)} operations[/nexus.muted]")
 
         nx.close()
 
@@ -327,12 +337,12 @@ def ops_replay(
     try:
         result = client.get("/api/v2/ops/replay", params=params)
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from e
 
     records = result.get("records", [])
     if not records:
-        console.print("[yellow]No MCL records found[/yellow]")
+        console.print("[nexus.warning]No MCL records found[/nexus.warning]")
         return
 
     console.print(f"[bold]MCL Records (from seq {from_sequence}):[/bold]")
@@ -350,7 +360,9 @@ def ops_replay(
 
     if result.get("has_more"):
         next_cursor = result.get("next_cursor", "?")
-        console.print(f"[dim]More records available. Use --from-sequence {next_cursor}[/dim]")
+        console.print(
+            f"[nexus.muted]More records available. Use --from-sequence {next_cursor}[/nexus.muted]"
+        )
 
 
 @click.command(name="undo")
@@ -388,7 +400,7 @@ async def _async_undo(
         )
 
         if not last_op:
-            console.print("[yellow]No operations to undo[/yellow]")
+            console.print("[nexus.warning]No operations to undo[/nexus.warning]")
             nx.close()
             return
 
@@ -414,9 +426,11 @@ async def _async_undo(
         if result["success"]:
             console.print(f"  {result['message']}")
         else:
-            console.print(f"  [yellow]Warning: {result['message']}[/yellow]")
+            console.print(f"  [nexus.warning]Warning: {result['message']}[/nexus.warning]")
 
-        console.print(f"\n[green]✓[/green] Undid operation: {last_op['operation_type']}")
+        console.print(
+            f"\n[nexus.success]✓[/nexus.success] Undid operation: {last_op['operation_type']}"
+        )
 
         nx.close()
 

--- a/src/nexus/cli/commands/operations.py
+++ b/src/nexus/cli/commands/operations.py
@@ -92,7 +92,7 @@ async def _async_ops_diff(
         nx.close()
 
         # Display results
-        console.print(f"\n[bold cyan]Diff for {path}[/bold cyan]")
+        console.print(f"\n[bold nexus.value]Diff for {path}[/bold nexus.value]")
         console.print(f"[nexus.muted]Operation 1:[/nexus.muted] {operation_1}")
         console.print(f"[nexus.muted]Operation 2:[/nexus.muted] {operation_2}")
         console.print()

--- a/src/nexus/cli/commands/pay.py
+++ b/src/nexus/cli/commands/pay.py
@@ -55,7 +55,7 @@ def pay_balance(
             data = rpc_call(remote_url, remote_api_key, "pay_balance", agent_id=agent_id)
 
         def _render(d: dict) -> None:
-            console.print("[bold cyan]Balance[/bold cyan]")
+            console.print("[bold nexus.value]Balance[/bold nexus.value]")
             console.print(f"  Available: [nexus.success]{d.get('available', '0')}[/nexus.success]")
             console.print(f"  Reserved:  [nexus.warning]{d.get('reserved', '0')}[/nexus.warning]")
             console.print(f"  Total:     [bold]{d.get('total', '0')}[/bold]")

--- a/src/nexus/cli/commands/pay.py
+++ b/src/nexus/cli/commands/pay.py
@@ -56,8 +56,8 @@ def pay_balance(
 
         def _render(d: dict) -> None:
             console.print("[bold cyan]Balance[/bold cyan]")
-            console.print(f"  Available: [green]{d.get('available', '0')}[/green]")
-            console.print(f"  Reserved:  [yellow]{d.get('reserved', '0')}[/yellow]")
+            console.print(f"  Available: [nexus.success]{d.get('available', '0')}[/nexus.success]")
+            console.print(f"  Reserved:  [nexus.warning]{d.get('reserved', '0')}[/nexus.warning]")
             console.print(f"  Total:     [bold]{d.get('total', '0')}[/bold]")
 
         render_output(
@@ -67,7 +67,7 @@ def pay_balance(
             human_formatter=_render,
         )
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from None
 
 
@@ -116,7 +116,7 @@ def pay_transfer(
             )
 
         def _render(d: dict) -> None:
-            console.print("[green]Transfer successful[/green]")
+            console.print("[nexus.success]Transfer successful[/nexus.success]")
             console.print(f"  ID:     {d.get('id', 'N/A')}")
             console.print(f"  To:     {d.get('to_agent', to)}")
             console.print(f"  Amount: {d.get('amount', amount)}")
@@ -131,7 +131,7 @@ def pay_transfer(
             human_formatter=_render,
         )
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from None
 
 
@@ -166,14 +166,14 @@ def pay_history(
 
             txns = d.get("transactions", [])
             if not txns:
-                console.print("[yellow]No transactions found[/yellow]")
+                console.print("[nexus.warning]No transactions found[/nexus.warning]")
                 return
 
             table = Table(title="Payment History")
-            table.add_column("Time", style="dim")
+            table.add_column("Time", style="nexus.muted")
             table.add_column("From")
             table.add_column("To")
-            table.add_column("Amount", justify="right", style="green")
+            table.add_column("Amount", justify="right", style="nexus.success")
             table.add_column("Status")
 
             for tx in txns:
@@ -193,5 +193,5 @@ def pay_history(
             human_formatter=_render,
         )
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from None

--- a/src/nexus/cli/commands/plugins.py
+++ b/src/nexus/cli/commands/plugins.py
@@ -119,7 +119,7 @@ def plugins_info(plugin_name: str) -> None:
 
         metadata = plugin.metadata()
 
-        console.print(f"\n[bold cyan]{metadata.name}[/bold cyan] v{metadata.version}")
+        console.print(f"\n[bold nexus.value]{metadata.name}[/bold nexus.value] v{metadata.version}")
         console.print(f"{metadata.description}\n")
         console.print(f"[bold]Author:[/bold] {metadata.author}")
 

--- a/src/nexus/cli/commands/plugins.py
+++ b/src/nexus/cli/commands/plugins.py
@@ -9,7 +9,8 @@ from typing import Any, cast
 import click
 from rich.table import Table
 
-from nexus.cli.utils import console, handle_error
+from nexus.cli.theme import console
+from nexus.cli.utils import handle_error
 
 
 def _run_async(coro: Any) -> Any:
@@ -78,15 +79,17 @@ def plugins_list() -> None:
         plugin_list = registry.list_plugins()
 
         if not plugin_list:
-            console.print("[yellow]No plugins installed.[/yellow]")
-            console.print("\nInstall plugins with: [cyan]pip install nexus-plugin-<name>[/cyan]")
+            console.print("[nexus.warning]No plugins installed.[/nexus.warning]")
+            console.print(
+                "\nInstall plugins with: [nexus.value]pip install nexus-plugin-<name>[/nexus.value]"
+            )
             return
 
         table = Table(title="Installed Plugins")
-        table.add_column("Name", style="cyan")
-        table.add_column("Version", style="green")
+        table.add_column("Name", style="nexus.value")
+        table.add_column("Version", style="nexus.success")
         table.add_column("Description")
-        table.add_column("Status", style="yellow")
+        table.add_column("Status", style="nexus.warning")
 
         for metadata in plugin_list:
             plugin = registry.get_plugin_sync(metadata.name)
@@ -111,7 +114,7 @@ def plugins_info(plugin_name: str) -> None:
         plugin = registry.get_plugin_sync(plugin_name)
 
         if not plugin:
-            console.print(f"[red]Plugin '{plugin_name}' not found.[/red]")
+            console.print(f"[nexus.error]Plugin '{plugin_name}' not found.[/nexus.error]")
             return
 
         metadata = plugin.metadata()
@@ -154,15 +157,17 @@ def plugins_enable(plugin_name: str) -> None:
         plugin = registry.get_plugin_sync(plugin_name)
 
         if not plugin:
-            console.print(f"[red]Plugin '{plugin_name}' not found.[/red]")
+            console.print(f"[nexus.error]Plugin '{plugin_name}' not found.[/nexus.error]")
             return
 
         if plugin.is_enabled():
-            console.print(f"[yellow]Plugin '{plugin_name}' is already enabled.[/yellow]")
+            console.print(
+                f"[nexus.warning]Plugin '{plugin_name}' is already enabled.[/nexus.warning]"
+            )
             return
 
         registry.enable_plugin(plugin_name)
-        console.print(f"[green]Enabled plugin '{plugin_name}'[/green]")
+        console.print(f"[nexus.success]Enabled plugin '{plugin_name}'[/nexus.success]")
 
     except Exception as e:
         handle_error(e)
@@ -177,15 +182,17 @@ def plugins_disable(plugin_name: str) -> None:
         plugin = registry.get_plugin_sync(plugin_name)
 
         if not plugin:
-            console.print(f"[red]Plugin '{plugin_name}' not found.[/red]")
+            console.print(f"[nexus.error]Plugin '{plugin_name}' not found.[/nexus.error]")
             return
 
         if not plugin.is_enabled():
-            console.print(f"[yellow]Plugin '{plugin_name}' is already disabled.[/yellow]")
+            console.print(
+                f"[nexus.warning]Plugin '{plugin_name}' is already disabled.[/nexus.warning]"
+            )
             return
 
         registry.disable_plugin(plugin_name)
-        console.print(f"[green]Disabled plugin '{plugin_name}'[/green]")
+        console.print(f"[nexus.success]Disabled plugin '{plugin_name}'[/nexus.success]")
 
     except Exception as e:
         handle_error(e)
@@ -209,10 +216,12 @@ def plugins_install(plugin_name: str) -> None:
         subprocess.check_call(
             ["pip", "install", package_name], stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
         )
-        console.print(f"[green]Successfully installed {package_name}[/green]")
-        console.print("\nRun [cyan]'nexus plugins list'[/cyan] to see the installed plugin")
+        console.print(f"[nexus.success]Successfully installed {package_name}[/nexus.success]")
+        console.print(
+            "\nRun [nexus.value]'nexus plugins list'[/nexus.value] to see the installed plugin"
+        )
     except subprocess.CalledProcessError as e:
-        console.print(f"[red]Failed to install {package_name}[/red]")
+        console.print(f"[nexus.error]Failed to install {package_name}[/nexus.error]")
         console.print(f"Error: {e.stderr.decode() if e.stderr else str(e)}")
 
 
@@ -242,9 +251,9 @@ def plugins_uninstall(plugin_name: str, yes: bool) -> None:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
         )
-        console.print(f"[green]Successfully uninstalled {package_name}[/green]")
+        console.print(f"[nexus.success]Successfully uninstalled {package_name}[/nexus.success]")
     except subprocess.CalledProcessError as e:
-        console.print(f"[red]Failed to uninstall {package_name}[/red]")
+        console.print(f"[nexus.error]Failed to uninstall {package_name}[/nexus.error]")
         console.print(f"Error: {e.stderr.decode() if e.stderr else str(e)}")
 
 
@@ -274,7 +283,7 @@ def plugins_init(
 
     from nexus.plugins.scaffold import PLUGIN_TYPES, scaffold_plugin
 
-    console.print(f"Creating {plugin_type} plugin: [cyan]nexus-plugin-{name}[/cyan]")
+    console.print(f"Creating {plugin_type} plugin: [nexus.value]nexus-plugin-{name}[/nexus.value]")
 
     try:
         result = scaffold_plugin(
@@ -285,7 +294,9 @@ def plugins_init(
             description=description,
         )
 
-        console.print(f"\n[green]Created plugin scaffold at {result['project_dir']}[/green]")
+        console.print(
+            f"\n[nexus.success]Created plugin scaffold at {result['project_dir']}[/nexus.success]"
+        )
         console.print(f"\n  Package: {result['package_name']}")
         console.print(f"  Module:  {result['module_name']}")
         console.print(f"  Class:   {result['class_name']}")
@@ -298,7 +309,7 @@ def plugins_init(
         console.print("  nexus plugins list")
 
     except (ValueError, FileExistsError) as e:
-        console.print(f"[red]Error: {e}[/red]")
+        console.print(f"[nexus.error]Error: {e}[/nexus.error]")
     except Exception as e:
         handle_error(e)
 
@@ -392,12 +403,16 @@ def _register_plugin_commands(main: click.Group) -> None:
                             plugin_instance = _run_async(_load())
 
                             if not plugin_instance:
-                                console.print(f"[red]Plugin '{p_name}' not found[/red]")
+                                console.print(
+                                    f"[nexus.error]Plugin '{p_name}' not found[/nexus.error]"
+                                )
                                 return
 
                             cmd_method = plugin_instance.commands().get(name)
                             if not cmd_method:
-                                console.print(f"[red]Command '{name}' not found[/red]")
+                                console.print(
+                                    f"[nexus.error]Command '{name}' not found[/nexus.error]"
+                                )
                                 return
 
                             if inspect.iscoroutinefunction(cmd_method):

--- a/src/nexus/cli/commands/profile.py
+++ b/src/nexus/cli/commands/profile.py
@@ -10,7 +10,6 @@ Commands:
 """
 
 import click
-from rich.console import Console
 from rich.table import Table
 
 from nexus.cli.config import (
@@ -19,8 +18,7 @@ from nexus.cli.config import (
     load_cli_config,
     save_cli_config,
 )
-
-console = Console()
+from nexus.cli.theme import console
 
 
 @click.group(name="profile")
@@ -49,8 +47,10 @@ def list_cmd() -> None:
     config = load_cli_config()
 
     if not config.profiles:
-        console.print("[dim]No profiles configured.[/dim]")
-        console.print("[dim]Add one with:[/dim] nexus profile add <name> --url <url>")
+        console.print("[nexus.muted]No profiles configured.[/nexus.muted]")
+        console.print(
+            "[nexus.muted]Add one with:[/nexus.muted] nexus profile add <name> --url <url>"
+        )
         return
 
     table = Table(title=f"Profiles ({get_config_path()})")
@@ -62,13 +62,15 @@ def list_cmd() -> None:
 
     for name, entry in sorted(config.profiles.items()):
         is_active = name == config.current_profile
-        marker = "[green]*[/green]" if is_active else ""
-        api_key_display = _mask_api_key(entry.api_key) if entry.api_key else "[dim]-[/dim]"
+        marker = "[nexus.success]*[/nexus.success]" if is_active else ""
+        api_key_display = (
+            _mask_api_key(entry.api_key) if entry.api_key else "[nexus.muted]-[/nexus.muted]"
+        )
         table.add_row(
             marker,
             name,
-            entry.url or "[dim]-[/dim]",
-            entry.zone_id or "[dim]-[/dim]",
+            entry.url or "[nexus.muted]-[/nexus.muted]",
+            entry.zone_id or "[nexus.muted]-[/nexus.muted]",
             api_key_display,
         )
 
@@ -87,9 +89,9 @@ def use_cmd(name: str) -> None:
     config = load_cli_config()
 
     if name not in config.profiles:
-        console.print(f"[red]Error:[/red] Profile '{name}' not found.")
+        console.print(f"[nexus.error]Error:[/nexus.error] Profile '{name}' not found.")
         available = ", ".join(sorted(config.profiles.keys())) if config.profiles else "none"
-        console.print(f"[dim]Available profiles: {available}[/dim]")
+        console.print(f"[nexus.muted]Available profiles: {available}[/nexus.muted]")
         raise SystemExit(1)
 
     config.current_profile = name
@@ -122,8 +124,10 @@ def add_cmd(
     config = load_cli_config()
 
     if name in config.profiles:
-        console.print(f"[red]Error:[/red] Profile '{name}' already exists.")
-        console.print("[dim]Use 'nexus profile delete' first, or choose a different name.[/dim]")
+        console.print(f"[nexus.error]Error:[/nexus.error] Profile '{name}' already exists.")
+        console.print(
+            "[nexus.muted]Use 'nexus profile delete' first, or choose a different name.[/nexus.muted]"
+        )
         raise SystemExit(1)
 
     config.profiles[name] = ProfileEntry(url=url, api_key=api_key, zone_id=zone_id)
@@ -149,7 +153,7 @@ def delete_cmd(name: str, force: bool) -> None:
     config = load_cli_config()
 
     if name not in config.profiles:
-        console.print(f"[red]Error:[/red] Profile '{name}' not found.")
+        console.print(f"[nexus.error]Error:[/nexus.error] Profile '{name}' not found.")
         raise SystemExit(1)
 
     if not force:
@@ -159,7 +163,7 @@ def delete_cmd(name: str, force: bool) -> None:
     if config.current_profile == name:
         config.current_profile = None
         console.print(
-            f"[yellow]Note:[/yellow] '{name}' was the active profile. No profile is now active."
+            f"[nexus.warning]Note:[/nexus.warning] '{name}' was the active profile. No profile is now active."
         )
 
     save_cli_config(config)
@@ -185,10 +189,10 @@ def show_cmd(test: bool) -> None:
     if config.current_profile:
         console.print(f"Active profile: [bold]{config.current_profile}[/bold]")
     else:
-        console.print("[dim]No active profile (using defaults)[/dim]")
+        console.print("[nexus.muted]No active profile (using defaults)[/nexus.muted]")
 
-    console.print(f"  URL:    {resolved.url or '[dim]local[/dim]'}")
-    console.print(f"  Zone:   {resolved.zone_id or '[dim]not set[/dim]'}")
+    console.print(f"  URL:    {resolved.url or '[nexus.muted]local[/nexus.muted]'}")
+    console.print(f"  Zone:   {resolved.zone_id or '[nexus.muted]not set[/nexus.muted]'}")
     console.print(f"  Source: {resolved.source}")
 
     if resolved.api_key:
@@ -197,7 +201,7 @@ def show_cmd(test: bool) -> None:
     if test and resolved.is_remote:
         _test_connection(resolved.url, resolved.api_key)
     elif test and not resolved.is_remote:
-        console.print("[dim]Skipping connection test (local mode)[/dim]")
+        console.print("[nexus.muted]Skipping connection test (local mode)[/nexus.muted]")
 
 
 @profile_group.command(name="rename")
@@ -212,11 +216,11 @@ def rename_cmd(old_name: str, new_name: str) -> None:
     config = load_cli_config()
 
     if old_name not in config.profiles:
-        console.print(f"[red]Error:[/red] Profile '{old_name}' not found.")
+        console.print(f"[nexus.error]Error:[/nexus.error] Profile '{old_name}' not found.")
         raise SystemExit(1)
 
     if new_name in config.profiles:
-        console.print(f"[red]Error:[/red] Profile '{new_name}' already exists.")
+        console.print(f"[nexus.error]Error:[/nexus.error] Profile '{new_name}' already exists.")
         raise SystemExit(1)
 
     config.profiles[new_name] = config.profiles.pop(old_name)
@@ -245,10 +249,10 @@ def _test_connection(url: str | None, api_key: str | None) -> None:
     from urllib.parse import urlparse
 
     if not url:
-        console.print("[red]Error:[/red] No URL to test")
+        console.print("[nexus.error]Error:[/nexus.error] No URL to test")
         return
 
-    console.print("[dim]Testing connection...[/dim]")
+    console.print("[nexus.muted]Testing connection...[/nexus.muted]")
 
     try:
         from nexus.remote.rpc_transport import RPCTransport
@@ -265,13 +269,13 @@ def _test_connection(url: str | None, api_key: str | None) -> None:
         )
         result = transport.ping()
         console.print(
-            f"[green]Connection OK[/green] "
+            f"[nexus.success]Connection OK[/nexus.success] "
             f"(version={result.get('version', '?')}, "
             f"zone={result.get('zone_id', '?')}, "
             f"uptime={result.get('uptime', '?')}s)"
         )
     except Exception as e:
-        console.print(f"[red]Connection failed:[/red] {e}")
+        console.print(f"[nexus.error]Connection failed:[/nexus.error] {e}")
 
 
 def register_commands(cli: click.Group) -> None:

--- a/src/nexus/cli/commands/rebac.py
+++ b/src/nexus/cli/commands/rebac.py
@@ -150,7 +150,7 @@ async def _async_rebac_create(
             try:
                 expires_at = datetime.fromisoformat(expires)
             except ValueError:
-                console.print(f"[red]Error:[/red] Invalid date format: {expires}")
+                console.print(f"[nexus.error]Error:[/nexus.error] Invalid date format: {expires}")
                 console.print("Use ISO format: 2025-12-31T23:59:59")
                 nx.close()
                 sys.exit(1)
@@ -166,7 +166,9 @@ async def _async_rebac_create(
             try:
                 column_config_dict = json.loads(column_config)
             except json.JSONDecodeError as e:
-                console.print(f"[red]Error:[/red] Invalid JSON in column-config: {e}")
+                console.print(
+                    f"[nexus.error]Error:[/nexus.error] Invalid JSON in column-config: {e}"
+                )
                 nx.close()
                 sys.exit(1)
 
@@ -202,35 +204,35 @@ async def _async_rebac_create(
 
         nx.close()
 
-        console.print("[green]✓[/green] Created relationship tuple")
-        console.print(f"  Tuple ID: [cyan]{tuple_id}[/cyan]")
-        console.print(f"  Subject: [yellow]{subject_display}[/yellow]")
+        console.print("[nexus.success]✓[/nexus.success] Created relationship tuple")
+        console.print(f"  Tuple ID: [nexus.value]{tuple_id}[/nexus.value]")
+        console.print(f"  Subject: [nexus.warning]{subject_display}[/nexus.warning]")
         if wildcard:
-            console.print("    [dim](wildcard - public access)[/dim]")
+            console.print("    [nexus.muted](wildcard - public access)[/nexus.muted]")
         elif subject_relation:
             console.print(
-                f"    [dim](userset-as-subject: all '{subject_relation}' of {subject_type}:{subject_id})[/dim]"
+                f"    [nexus.muted](userset-as-subject: all '{subject_relation}' of {subject_type}:{subject_id})[/nexus.muted]"
             )
-        console.print(f"  Relation: [magenta]{relation}[/magenta]")
-        console.print(f"  Object: [yellow]{object_type}:{object_id}[/yellow]")
+        console.print(f"  Relation: [nexus.identity]{relation}[/nexus.identity]")
+        console.print(f"  Object: [nexus.warning]{object_type}:{object_id}[/nexus.warning]")
         if zone:
-            console.print(f"  Zone: [blue]{zone}[/blue]")
+            console.print(f"  Zone: [nexus.reference]{zone}[/nexus.reference]")
         if expires_at:
-            console.print(f"  Expires: [dim]{expires_at.isoformat()}[/dim]")
+            console.print(f"  Expires: [nexus.muted]{expires_at.isoformat()}[/nexus.muted]")
         if column_config_dict:
             console.print("  Column Config:")
             if column_config_dict.get("hidden_columns"):
                 console.print(
-                    f"    Hidden Columns: [red]{', '.join(column_config_dict['hidden_columns'])}[/red]"
+                    f"    Hidden Columns: [nexus.error]{', '.join(column_config_dict['hidden_columns'])}[/nexus.error]"
                 )
             if column_config_dict.get("visible_columns"):
                 console.print(
-                    f"    Visible Columns: [green]{', '.join(column_config_dict['visible_columns'])}[/green]"
+                    f"    Visible Columns: [nexus.success]{', '.join(column_config_dict['visible_columns'])}[/nexus.success]"
                 )
             if column_config_dict.get("aggregations"):
                 console.print("    Aggregations:")
                 for col, op in column_config_dict["aggregations"].items():
-                    console.print(f"      {col}: [yellow]{op}[/yellow]")
+                    console.print(f"      {col}: [nexus.warning]{op}[/nexus.warning]")
 
     except Exception as e:
         handle_error(e)
@@ -342,7 +344,7 @@ async def _async_rebac_list_cmd(
 
         # Display results
         if not tuples:
-            console.print("[yellow]No tuples found[/yellow]")
+            console.print("[nexus.warning]No tuples found[/nexus.warning]")
             return
 
         if output_format == "json":
@@ -357,11 +359,11 @@ async def _async_rebac_list_cmd(
         else:
             # Table format
             table = Table(title=f"ReBAC Tuples ({len(tuples)} found)")
-            table.add_column("Tuple ID", style="dim", no_wrap=True)
-            table.add_column("Subject", style="yellow")
-            table.add_column("Relation", style="magenta")
-            table.add_column("Object", style="cyan")
-            table.add_column("Zone", style="blue")
+            table.add_column("Tuple ID", style="nexus.muted", no_wrap=True)
+            table.add_column("Subject", style="nexus.warning")
+            table.add_column("Relation", style="nexus.identity")
+            table.add_column("Object", style="nexus.value")
+            table.add_column("Zone", style="nexus.reference")
 
             for t in tuples:
                 # Format subject
@@ -424,9 +426,11 @@ async def _async_rebac_delete_cmd(
         nx.close()
 
         if deleted:
-            console.print(f"[green]✓[/green] Deleted relationship tuple [cyan]{tuple_id}[/cyan]")
+            console.print(
+                f"[nexus.success]✓[/nexus.success] Deleted relationship tuple [nexus.value]{tuple_id}[/nexus.value]"
+            )
         else:
-            console.print(f"[yellow]Tuple not found:[/yellow] {tuple_id}")
+            console.print(f"[nexus.warning]Tuple not found:[/nexus.warning] {tuple_id}")
 
     except Exception as e:
         handle_error(e)
@@ -508,14 +512,14 @@ async def _async_rebac_check_cmd(
 
         # Display result
         if granted:
-            console.print("[green]✓ GRANTED[/green]")
+            console.print("[nexus.success]✓ GRANTED[/nexus.success]")
             console.print(
-                f"  [yellow]{subject_type}:{subject_id}[/yellow] has [magenta]{permission}[/magenta] on [yellow]{object_type}:{object_id}[/yellow]"
+                f"  [nexus.warning]{subject_type}:{subject_id}[/nexus.warning] has [nexus.identity]{permission}[/nexus.identity] on [nexus.warning]{object_type}:{object_id}[/nexus.warning]"
             )
         else:
-            console.print("[red]✗ DENIED[/red]")
+            console.print("[nexus.error]✗ DENIED[/nexus.error]")
             console.print(
-                f"  [yellow]{subject_type}:{subject_id}[/yellow] does NOT have [magenta]{permission}[/magenta] on [yellow]{object_type}:{object_id}[/yellow]"
+                f"  [nexus.warning]{subject_type}:{subject_id}[/nexus.warning] does NOT have [nexus.identity]{permission}[/nexus.identity] on [nexus.warning]{object_type}:{object_id}[/nexus.warning]"
             )
 
     except Exception as e:
@@ -590,18 +594,18 @@ async def _async_rebac_expand_cmd(
         # Display results
         if not subjects:
             console.print(
-                f"[yellow]No subjects found with[/yellow] [magenta]{permission}[/magenta] [yellow]on[/yellow] [cyan]{object_type}:{object_id}[/cyan]"
+                f"[nexus.warning]No subjects found with[/nexus.warning] [nexus.identity]{permission}[/nexus.identity] [nexus.warning]on[/nexus.warning] [nexus.value]{object_type}:{object_id}[/nexus.value]"
             )
             return
 
         console.print(
-            f"[green]Found {len(subjects)} subjects[/green] with [magenta]{permission}[/magenta] on [cyan]{object_type}:{object_id}[/cyan]"
+            f"[nexus.success]Found {len(subjects)} subjects[/nexus.success] with [nexus.identity]{permission}[/nexus.identity] on [nexus.value]{object_type}:{object_id}[/nexus.value]"
         )
         console.print()
 
         table = Table(title=f"Subjects with '{permission}' permission")
-        table.add_column("Subject Type", style="yellow")
-        table.add_column("Subject ID", style="cyan")
+        table.add_column("Subject Type", style="nexus.warning")
+        table.add_column("Subject ID", style="nexus.value")
 
         for subj_type, subj_id in sorted(subjects):
             table.add_row(subj_type, subj_id)
@@ -716,18 +720,28 @@ async def _async_rebac_explain_cmd(
 
         # Header
         if result:
-            console.print("[green]✓ GRANTED[/green]")
+            console.print("[nexus.success]✓ GRANTED[/nexus.success]")
         else:
-            console.print("[red]✗ DENIED[/red]")
+            console.print("[nexus.error]✗ DENIED[/nexus.error]")
 
         # Metadata
         console.print()
-        console.print(f"[dim]Subject:[/dim]      [yellow]{subject_type}:{subject_id}[/yellow]")
-        console.print(f"[dim]Permission:[/dim]   [magenta]{permission}[/magenta]")
-        console.print(f"[dim]Resource:[/dim]     [cyan]{object_type}:{object_id}[/cyan]")
+        console.print(
+            f"[nexus.muted]Subject:[/nexus.muted]      [nexus.warning]{subject_type}:{subject_id}[/nexus.warning]"
+        )
+        console.print(
+            f"[nexus.muted]Permission:[/nexus.muted]   [nexus.identity]{permission}[/nexus.identity]"
+        )
+        console.print(
+            f"[nexus.muted]Resource:[/nexus.muted]     [nexus.value]{object_type}:{object_id}[/nexus.value]"
+        )
         if metadata:
-            console.print(f"[dim]Timestamp:[/dim]   {metadata.get('timestamp', 'N/A')}")
-            console.print(f"[dim]Request ID:[/dim]  {metadata.get('request_id', 'N/A')}")
+            console.print(
+                f"[nexus.muted]Timestamp:[/nexus.muted]   {metadata.get('timestamp', 'N/A')}"
+            )
+            console.print(
+                f"[nexus.muted]Request ID:[/nexus.muted]  {metadata.get('request_id', 'N/A')}"
+            )
 
         # Display schema rule if available
         console.print()
@@ -735,7 +749,7 @@ async def _async_rebac_explain_cmd(
         if successful_path and "expanded_to" in successful_path:
             expanded = successful_path["expanded_to"]
             console.print(
-                f"[bold]Schema Rule:[/bold] {permission}([cyan]{object_type}[/cyan]) = {' ∪ '.join(expanded)}"
+                f"[bold]Schema Rule:[/bold] {permission}([nexus.value]{object_type}[/nexus.value]) = {' ∪ '.join(expanded)}"
             )
 
         # Display detailed explanation
@@ -750,11 +764,11 @@ async def _async_rebac_explain_cmd(
             via = successful_path.get("via_userset") or successful_path.get("via_union_member")
             if via:
                 console.print(
-                    f"  {via}([cyan]{object_type}:{object_id}[/cyan]) = [green]true[/green] ⇒ {permission}(...) = [green]true[/green] ⇒ [green]GRANTED[/green]"
+                    f"  {via}([nexus.value]{object_type}:{object_id}[/nexus.value]) = [nexus.success]true[/nexus.success] ⇒ {permission}(...) = [nexus.success]true[/nexus.success] ⇒ [nexus.success]GRANTED[/nexus.success]"
                 )
             else:
                 console.print(
-                    f"  {permission}([cyan]{object_type}:{object_id}[/cyan]) = [green]true[/green] ⇒ [green]GRANTED[/green]"
+                    f"  {permission}([nexus.value]{object_type}:{object_id}[/nexus.value]) = [nexus.success]true[/nexus.success] ⇒ [nexus.success]GRANTED[/nexus.success]"
                 )
         elif not result:
             console.print("[bold]Reason:[/bold] No valid permission path found")
@@ -764,7 +778,7 @@ async def _async_rebac_explain_cmd(
                 console.print("[bold]Attempted paths:[/bold]")
                 for i, path in enumerate(paths, 1):
                     console.print(
-                        f"  {i}. {path.get('permission')} on {path.get('object')} - [red]NOT FOUND[/red]"
+                        f"  {i}. {path.get('permission')} on {path.get('object')} - [nexus.error]NOT FOUND[/nexus.error]"
                     )
         else:
             console.print("[bold]Reason:[/bold] Permission granted (no path information)")
@@ -822,12 +836,16 @@ def _display_proof_tree(path: dict, depth: int = 0, step_number: list[int] | Non
     # Main check
     step = step_number[0]
     step_number[0] += 1
-    console.print(f"{indent}{step}) Check [magenta]{permission}[/magenta]([cyan]{obj}[/cyan])")
+    console.print(
+        f"{indent}{step}) Check [nexus.identity]{permission}[/nexus.identity]([nexus.value]{obj}[/nexus.value])"
+    )
 
     # Show expansion
     if "expanded_to" in path:
         relations = path["expanded_to"]
-        console.print(f"{indent}   → Expand to {{[magenta]{', '.join(relations)}[/magenta]}}")
+        console.print(
+            f"{indent}   → Expand to {{[nexus.identity]{', '.join(relations)}[/nexus.identity]}}"
+        )
 
     # Show union/intersection
     if "union" in path:
@@ -839,10 +857,10 @@ def _display_proof_tree(path: dict, depth: int = 0, step_number: list[int] | Non
         tuple_info = path["tuple"]
         tuple_id = tuple_info.get("tuple_id", "N/A")
         tuple_str = _format_tuple(tuple_info)
-        console.print(f"{indent}   → [green]FOUND[/green] tuple: {tuple_str}")
-        console.print(f"{indent}   → Tuple ID: [dim]{tuple_id}[/dim]")
+        console.print(f"{indent}   → [nexus.success]FOUND[/nexus.success] tuple: {tuple_str}")
+        console.print(f"{indent}   → Tuple ID: [nexus.muted]{tuple_id}[/nexus.muted]")
     elif path.get("direct_relation"):
-        console.print(f"{indent}   → [green]FOUND[/green] direct relation")
+        console.print(f"{indent}   → [nexus.success]FOUND[/nexus.success] direct relation")
 
     # Show parent traversal
     if "tupleToUserset" in path:
@@ -857,20 +875,20 @@ def _display_proof_tree(path: dict, depth: int = 0, step_number: list[int] | Non
                 if isinstance(parent, list | tuple) and len(parent) >= 2:
                     parent_type, parent_id = parent[0], parent[1]
                     console.print(
-                        f"{indent}   • {tupleset}([cyan]{obj}[/cyan]) = [cyan]{parent_type}:{parent_id}[/cyan]  [green]✓[/green]"
+                        f"{indent}   • {tupleset}([nexus.value]{obj}[/nexus.value]) = [nexus.value]{parent_type}:{parent_id}[/nexus.value]  [nexus.success]✓[/nexus.success]"
                     )
                 else:
                     console.print(
-                        f"{indent}   • {tupleset}([cyan]{obj}[/cyan]) = [cyan]{parent}[/cyan]  [green]✓[/green]"
+                        f"{indent}   • {tupleset}([nexus.value]{obj}[/nexus.value]) = [nexus.value]{parent}[/nexus.value]  [nexus.success]✓[/nexus.success]"
                     )
         else:
-            console.print(f"{indent}   • No parent found → [red]SKIPPED[/red]")
+            console.print(f"{indent}   • No parent found → [nexus.error]SKIPPED[/nexus.error]")
 
     # Show status
     if "error" in path:
-        console.print(f"{indent}   → [red]ERROR:[/red] {path['error']}")
+        console.print(f"{indent}   → [nexus.error]ERROR:[/nexus.error] {path['error']}")
     elif not granted and not path.get("sub_paths"):
-        console.print(f"{indent}   → [red]NOT FOUND[/red]")
+        console.print(f"{indent}   → [nexus.error]NOT FOUND[/nexus.error]")
 
     # Display sub-paths recursively
     if "sub_paths" in path:
@@ -947,7 +965,7 @@ async def _async_rebac_check_batch_cmd(
             checks_data = json.load(f)
 
         if not isinstance(checks_data, list):
-            console.print("[red]Error:[/red] Checks file must contain a JSON array")
+            console.print("[nexus.error]Error:[/nexus.error] Checks file must contain a JSON array")
             nx.close()
             sys.exit(1)
 
@@ -960,13 +978,13 @@ async def _async_rebac_check_batch_cmd(
                 obj = tuple(check["object"])
                 checks.append((subject, permission, obj))
             except (KeyError, TypeError) as e:
-                console.print(f"[red]Error:[/red] Invalid check at index {i}: {e}")
+                console.print(f"[nexus.error]Error:[/nexus.error] Invalid check at index {i}: {e}")
                 nx.close()
                 sys.exit(1)
 
         # Perform batch check with Rust acceleration
         console.print(
-            f"[cyan]Checking {len(checks)} permissions (Rust acceleration enabled)...[/cyan]"
+            f"[nexus.value]Checking {len(checks)} permissions (Rust acceleration enabled)...[/nexus.value]"
         )
         rebac_svc = nx.service("rebac")
         assert rebac_svc is not None, "ReBAC service not available"
@@ -990,23 +1008,27 @@ async def _async_rebac_check_batch_cmd(
             # Summary only
             allowed_count = sum(results)
             denied_count = len(results) - allowed_count
-            console.print(f"[green]✓ {allowed_count} allowed[/green]")
-            console.print(f"[red]✗ {denied_count} denied[/red]")
+            console.print(f"[nexus.success]✓ {allowed_count} allowed[/nexus.success]")
+            console.print(f"[nexus.error]✗ {denied_count} denied[/nexus.error]")
             console.print(f"  Total: {len(results)}")
 
         else:
             # Table output (default)
             table = Table(title=f"Batch Check Results ({len(checks)} checks)")
-            table.add_column("#", style="dim")
-            table.add_column("Subject", style="yellow")
-            table.add_column("Permission", style="magenta")
-            table.add_column("Object", style="cyan")
+            table.add_column("#", style="nexus.muted")
+            table.add_column("Subject", style="nexus.warning")
+            table.add_column("Permission", style="nexus.identity")
+            table.add_column("Object", style="nexus.value")
             table.add_column("Result", style="bold")
 
             for i, ((subject, permission, obj), result) in enumerate(
                 zip(checks, results, strict=False)
             ):
-                result_text = "[green]✓ ALLOWED[/green]" if result else "[red]✗ DENIED[/red]"
+                result_text = (
+                    "[nexus.success]✓ ALLOWED[/nexus.success]"
+                    if result
+                    else "[nexus.error]✗ DENIED[/nexus.error]"
+                )
                 table.add_row(
                     str(i + 1),
                     f"{subject[0]}:{subject[1]}",
@@ -1022,7 +1044,7 @@ async def _async_rebac_check_batch_cmd(
             denied_count = len(results) - allowed_count
             console.print()
             console.print(
-                f"Summary: [green]{allowed_count} allowed[/green], [red]{denied_count} denied[/red]"
+                f"Summary: [nexus.success]{allowed_count} allowed[/nexus.success], [nexus.error]{denied_count} denied[/nexus.error]"
             )
 
     except Exception as e:
@@ -1140,7 +1162,7 @@ async def _async_namespace_create(
         assert rebac_svc is not None, "ReBAC service not available"
         rebac_svc.namespace_create_sync(object_type=object_type, config=config)
 
-        console.print(f"[green]✓[/green] Created namespace for '{object_type}'")
+        console.print(f"[nexus.success]✓[/nexus.success] Created namespace for '{object_type}'")
 
     except Exception as e:
         handle_error(e)
@@ -1192,14 +1214,14 @@ async def _async_namespace_list(
             console.print(json.dumps(namespaces, indent=2))
         else:
             if not namespaces:
-                console.print("[yellow]No namespaces registered[/yellow]")
+                console.print("[nexus.warning]No namespaces registered[/nexus.warning]")
                 return
 
             table = Table(title="ReBAC Namespaces")
-            table.add_column("Object Type", style="cyan")
-            table.add_column("Relations", style="green")
-            table.add_column("Permissions", style="magenta")
-            table.add_column("Created", style="dim")
+            table.add_column("Object Type", style="nexus.value")
+            table.add_column("Relations", style="nexus.success")
+            table.add_column("Permissions", style="nexus.identity")
+            table.add_column("Created", style="nexus.muted")
 
             for ns in namespaces:
                 relations = ", ".join(ns["config"]["relations"].keys())
@@ -1271,7 +1293,7 @@ async def _async_namespace_get(
         ns = rebac_svc.get_namespace_sync(object_type)
 
         if ns is None:
-            console.print(f"[red]✗[/red] Namespace '{object_type}' not found")
+            console.print(f"[nexus.error]✗[/nexus.error] Namespace '{object_type}' not found")
             sys.exit(1)
 
         if output_format == "json":
@@ -1319,7 +1341,7 @@ async def _async_namespace_delete(
         if not yes:
             confirm = input(f"Delete namespace '{object_type}'? (y/N): ")
             if confirm.lower() != "y":
-                console.print("[yellow]Cancelled[/yellow]")
+                console.print("[nexus.warning]Cancelled[/nexus.warning]")
                 return
 
         nx = await get_filesystem(remote_url, remote_api_key)
@@ -1329,9 +1351,9 @@ async def _async_namespace_delete(
         deleted = rebac_svc.namespace_delete_sync(object_type)
 
         if deleted:
-            console.print(f"[green]✓[/green] Deleted namespace '{object_type}'")
+            console.print(f"[nexus.success]✓[/nexus.success] Deleted namespace '{object_type}'")
         else:
-            console.print(f"[red]✗[/red] Namespace '{object_type}' not found")
+            console.print(f"[nexus.error]✗[/nexus.error] Namespace '{object_type}' not found")
             sys.exit(1)
 
     except Exception as e:

--- a/src/nexus/cli/commands/reindex.py
+++ b/src/nexus/cli/commands/reindex.py
@@ -135,7 +135,7 @@ def reindex(
                 total = session.execute(count_stmt).scalar_one()
 
                 if total == 0:
-                    console.print("[yellow]No MCL records to process[/yellow]")
+                    console.print("[nexus.warning]No MCL records to process[/nexus.warning]")
                 elif dry_run:
                     _show_dry_run_summary(total, mcl_target)
                 else:
@@ -164,7 +164,9 @@ def reindex(
                                 last_sequence = row.sequence_number
                             except Exception as e:
                                 errors += 1
-                                console.print(f"[red]Error at seq {row.sequence_number}: {e}[/red]")
+                                console.print(
+                                    f"[nexus.error]Error at seq {row.sequence_number}: {e}[/nexus.error]"
+                                )
 
                             progress.update(task, advance=1)
 
@@ -173,8 +175,8 @@ def reindex(
                     # Summary
                     console.print()
                     table = Table(title="Reindex Summary")
-                    table.add_column("Metric", style="cyan")
-                    table.add_column("Value", style="green")
+                    table.add_column("Metric", style="nexus.value")
+                    table.add_column("Value", style="nexus.success")
                     table.add_row("Target", mcl_target)
                     table.add_row("Total records", str(total))
                     table.add_row("Processed", str(processed))
@@ -184,7 +186,7 @@ def reindex(
 
                     if errors > 0:
                         console.print(
-                            f"\n[yellow]Resume from sequence {last_sequence + 1} to retry:[/yellow]"
+                            f"\n[nexus.warning]Resume from sequence {last_sequence + 1} to retry:[/nexus.warning]"
                         )
                         console.print(
                             f"  nexus reindex --target {mcl_target} "
@@ -239,8 +241,8 @@ def _reindex_via_rest(
     # Display result
     console.print()
     table = Table(title="Reindex Summary (via REST API)")
-    table.add_column("Metric", style="cyan")
-    table.add_column("Value", style="green")
+    table.add_column("Metric", style="nexus.value")
+    table.add_column("Value", style="nexus.success")
     table.add_row("Target", result.get("target", target))
     table.add_row("Total records", str(result.get("total", 0)))
     table.add_row("Processed", str(result.get("processed", 0)))
@@ -248,7 +250,7 @@ def _reindex_via_rest(
     table.add_row("Dry run", str(result.get("dry_run", dry_run)))
     if target == "all":
         console.print(
-            "\n[yellow]Note:[/yellow] Semantic reindex requires local filesystem access "
+            "\n[nexus.warning]Note:[/nexus.warning] Semantic reindex requires local filesystem access "
             "and was skipped. Only search + versions targets were processed."
         )
     console.print(table)
@@ -278,13 +280,13 @@ def _run_semantic_reindex(
     try:
         all_files = _walk_filesystem(nx, "/")
     except Exception as e:
-        console.print(f"[red]Failed to walk filesystem: {e}[/red]")
+        console.print(f"[nexus.error]Failed to walk filesystem: {e}[/nexus.error]")
         return
 
     if dry_run:
         console.print("\n[bold cyan]Dry Run — semantic reindex[/bold cyan]\n")
         console.print(f"Total files to process: [bold]{len(all_files)}[/bold]")
-        console.print("\n[dim]Run without --dry-run to execute.[/dim]")
+        console.print("\n[nexus.muted]Run without --dry-run to execute.[/nexus.muted]")
         return
 
     processed = 0
@@ -354,8 +356,8 @@ def _run_semantic_reindex(
     # Summary
     console.print()
     table = Table(title="Semantic Reindex Summary")
-    table.add_column("Metric", style="cyan")
-    table.add_column("Value", style="green")
+    table.add_column("Metric", style="nexus.value")
+    table.add_column("Value", style="nexus.success")
     table.add_row("Total files", str(len(all_files)))
     table.add_row("Processed", str(processed))
     table.add_row("Schemas extracted", str(schemas_extracted))
@@ -393,7 +395,7 @@ def _show_dry_run_summary(
     """Show a summary of what would be reindexed."""
     console.print(f"\n[bold cyan]Dry Run — {target} reindex[/bold cyan]\n")
     console.print(f"Total MCL records to process: [bold]{total}[/bold]")
-    console.print("\n[dim]Run without --dry-run to execute.[/dim]")
+    console.print("\n[nexus.muted]Run without --dry-run to execute.[/nexus.muted]")
 
 
 class _MCLProcessor:

--- a/src/nexus/cli/commands/reindex.py
+++ b/src/nexus/cli/commands/reindex.py
@@ -284,7 +284,7 @@ def _run_semantic_reindex(
         return
 
     if dry_run:
-        console.print("\n[bold cyan]Dry Run — semantic reindex[/bold cyan]\n")
+        console.print("\n[bold nexus.value]Dry Run — semantic reindex[/bold nexus.value]\n")
         console.print(f"Total files to process: [bold]{len(all_files)}[/bold]")
         console.print("\n[nexus.muted]Run without --dry-run to execute.[/nexus.muted]")
         return
@@ -393,7 +393,7 @@ def _show_dry_run_summary(
     target: str,
 ) -> None:
     """Show a summary of what would be reindexed."""
-    console.print(f"\n[bold cyan]Dry Run — {target} reindex[/bold cyan]\n")
+    console.print(f"\n[bold nexus.value]Dry Run — {target} reindex[/bold nexus.value]\n")
     console.print(f"Total MCL records to process: [bold]{total}[/bold]")
     console.print("\n[nexus.muted]Run without --dry-run to execute.[/nexus.muted]")
 

--- a/src/nexus/cli/commands/rlm.py
+++ b/src/nexus/cli/commands/rlm.py
@@ -65,7 +65,7 @@ def rlm_infer(
         iterations = d.get("iterations", d.get("total_iterations", "N/A"))
         tokens = d.get("total_tokens", "N/A")
 
-        console.print(f"[bold cyan]RLM Inference[/bold cyan] ({status})")
+        console.print(f"[bold nexus.value]RLM Inference[/bold nexus.value] ({status})")
         console.print(f"  Iterations: {iterations}")
         console.print(f"  Tokens:     {tokens}")
         console.print()

--- a/src/nexus/cli/commands/rlm.py
+++ b/src/nexus/cli/commands/rlm.py
@@ -58,7 +58,7 @@ def rlm_infer(
     data = client.infer(path, prompt=prompt, model=model, max_iterations=max_iterations)
 
     def _render(d: dict) -> None:
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         status = d.get("status", "unknown")
         answer = d.get("answer", d.get("result", ""))

--- a/src/nexus/cli/commands/scheduler_cli.py
+++ b/src/nexus/cli/commands/scheduler_cli.py
@@ -46,7 +46,7 @@ def scheduler_status(client: SchedulerClient) -> ServiceResult:
     def _render(d: dict) -> None:
         from rich.table import Table
 
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         console.print("[bold cyan]Scheduler Status[/bold cyan]")
         console.print(f"  HRRN Enabled:  {d.get('use_hrrn', 'N/A')}")
@@ -68,7 +68,7 @@ def scheduler_status(client: SchedulerClient) -> ServiceResult:
                 )
             console.print(table)
         else:
-            console.print("  [yellow]No queued tasks[/yellow]")
+            console.print("  [nexus.warning]No queued tasks[/nexus.warning]")
 
         # Fair-share summary
         fair_share = d.get("fair_share", {})
@@ -101,11 +101,11 @@ def scheduler_queue(client: SchedulerClient) -> ServiceResult:
     def _render(d: dict) -> None:
         from rich.table import Table
 
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         queue_by_class = d.get("queue_by_class", [])
         if not queue_by_class:
-            console.print("[yellow]No queued tasks[/yellow]")
+            console.print("[nexus.warning]No queued tasks[/nexus.warning]")
             return
 
         table = Table(title=f"Queue Metrics ({len(queue_by_class)} classes)")

--- a/src/nexus/cli/commands/scheduler_cli.py
+++ b/src/nexus/cli/commands/scheduler_cli.py
@@ -48,7 +48,7 @@ def scheduler_status(client: SchedulerClient) -> ServiceResult:
 
         from nexus.cli.theme import console
 
-        console.print("[bold cyan]Scheduler Status[/bold cyan]")
+        console.print("[bold nexus.value]Scheduler Status[/bold nexus.value]")
         console.print(f"  HRRN Enabled:  {d.get('use_hrrn', 'N/A')}")
 
         # Queue by class table

--- a/src/nexus/cli/commands/search.py
+++ b/src/nexus/cli/commands/search.py
@@ -302,7 +302,7 @@ def grep(
                 console.print()
 
                 for filename in sorted(by_file.keys()):
-                    console.print(f"[bold cyan]{filename}[/bold cyan]")
+                    console.print(f"[bold nexus.value]{filename}[/bold nexus.value]")
                     for m in by_file[filename]:
                         ln = f"{m['line']}:" if line_number else ""
                         console.print(f"  [nexus.warning]{ln}[/nexus.warning] {m['content']}")
@@ -483,7 +483,7 @@ def search_index(
 
             # Show stats
             stats: dict[str, Any] = search_svc.semantic_search_stats()
-            console.print("\n[bold cyan]Index Statistics:[/bold cyan]")
+            console.print("\n[bold nexus.value]Index Statistics:[/bold nexus.value]")
             console.print(
                 f"  Total indexed files: [nexus.success]{stats['indexed_files']}[/nexus.success]"
             )
@@ -598,7 +598,7 @@ def search_stats(remote_url: str | None, remote_api_key: str | None) -> None:
 
             stats: dict[str, Any] = nx.service("search").semantic_search_stats()
 
-            console.print("\n[bold cyan]Semantic Search Statistics[/bold cyan]")
+            console.print("\n[bold nexus.value]Semantic Search Statistics[/bold nexus.value]")
             console.print(
                 f"  Engine: [nexus.success]{stats.get('engine', stats.get('database_type', 'unknown'))}[/nexus.success]"
             )

--- a/src/nexus/cli/commands/search.py
+++ b/src/nexus/cli/commands/search.py
@@ -126,7 +126,7 @@ def glob(
 
             def _print_human(entries: list[dict[str, Any]]) -> None:
                 console.print(
-                    f"[green]Found {len(entries)} files matching[/green] [cyan]{pattern}[/cyan]:"
+                    f"[nexus.success]Found {len(entries)} files matching[/nexus.success] [nexus.value]{pattern}[/nexus.value]:"
                 )
                 if long:
                     for entry in entries:
@@ -295,17 +295,17 @@ def grep(
                     return
 
                 console.print(
-                    f"[green]Found {len(m_list)} matches[/green] for [cyan]{pattern}[/cyan]"
+                    f"[nexus.success]Found {len(m_list)} matches[/nexus.success] for [nexus.value]{pattern}[/nexus.value]"
                 )
                 if search_mode != "auto":
-                    console.print(f"[dim]Search mode: {search_mode}[/dim]")
+                    console.print(f"[nexus.muted]Search mode: {search_mode}[/nexus.muted]")
                 console.print()
 
                 for filename in sorted(by_file.keys()):
                     console.print(f"[bold cyan]{filename}[/bold cyan]")
                     for m in by_file[filename]:
                         ln = f"{m['line']}:" if line_number else ""
-                        console.print(f"  [yellow]{ln}[/yellow] {m['content']}")
+                        console.print(f"  [nexus.warning]{ln}[/nexus.warning] {m['content']}")
                     console.print()
 
             render_output(
@@ -390,7 +390,9 @@ def search_init(
         try:
             nx = await get_filesystem(remote_url, remote_api_key)
 
-            with console.status("[yellow]Initializing search engine...[/yellow]", spinner="dots"):
+            with console.status(
+                "[nexus.warning]Initializing search engine...[/nexus.warning]", spinner="dots"
+            ):
                 nx.service("search").ainitialize_semantic_search(
                     nx=nx,
                     record_store_engine=None,
@@ -401,14 +403,20 @@ def search_init(
                     chunk_strategy=chunk_strategy,
                 )
 
-            console.print("[green]✓ Search engine initialized successfully![/green]")
-            console.print("  Mode: [cyan]Remote (server-side)[/cyan]")
-            console.print(f"  Provider: [cyan]{provider or 'None (keyword-only)'}[/cyan]")
-            console.print(f"  Chunk size: [cyan]{chunk_size}[/cyan] tokens")
-            console.print(f"  Chunk strategy: [cyan]{chunk_strategy}[/cyan]")
+            console.print(
+                "[nexus.success]✓ Search engine initialized successfully![/nexus.success]"
+            )
+            console.print("  Mode: [nexus.value]Remote (server-side)[/nexus.value]")
+            console.print(
+                f"  Provider: [nexus.value]{provider or 'None (keyword-only)'}[/nexus.value]"
+            )
+            console.print(f"  Chunk size: [nexus.value]{chunk_size}[/nexus.value] tokens")
+            console.print(f"  Chunk strategy: [nexus.value]{chunk_strategy}[/nexus.value]")
 
             if not provider:
-                console.print("\n[yellow]Note:[/yellow] Keyword-only mode enabled (FTS).")
+                console.print(
+                    "\n[nexus.warning]Note:[/nexus.warning] Keyword-only mode enabled (FTS)."
+                )
                 console.print(
                     "For semantic/hybrid search, reinitialize with --provider openai (recommended) or voyage"
                 )
@@ -449,7 +457,9 @@ def search_index(
         try:
             nx = await get_filesystem(remote_url, remote_api_key)
 
-            with console.status(f"[yellow]Indexing {path}...[/yellow]", spinner="dots"):
+            with console.status(
+                f"[nexus.warning]Indexing {path}...[/nexus.warning]", spinner="dots"
+            ):
                 search_svc = nx.service("search")
                 raw_results = search_svc.semantic_search_index(path, recursive=recursive)
 
@@ -465,17 +475,19 @@ def search_index(
             successful = sum(1 for v in results.values() if isinstance(v, int) and v > 0)
             failed = sum(1 for v in results.values() if isinstance(v, int) and v < 0)
 
-            console.print("\n[green]✓ Indexing complete![/green]")
-            console.print(f"  Files indexed: [cyan]{successful}[/cyan]")
-            console.print(f"  Total chunks: [cyan]{total_chunks}[/cyan]")
+            console.print("\n[nexus.success]✓ Indexing complete![/nexus.success]")
+            console.print(f"  Files indexed: [nexus.value]{successful}[/nexus.value]")
+            console.print(f"  Total chunks: [nexus.value]{total_chunks}[/nexus.value]")
             if failed > 0:
-                console.print(f"  Failed: [yellow]{failed}[/yellow]")
+                console.print(f"  Failed: [nexus.warning]{failed}[/nexus.warning]")
 
             # Show stats
             stats: dict[str, Any] = search_svc.semantic_search_stats()
             console.print("\n[bold cyan]Index Statistics:[/bold cyan]")
-            console.print(f"  Total indexed files: [green]{stats['indexed_files']}[/green]")
-            console.print(f"  Total chunks: [green]{stats['total_chunks']}[/green]")
+            console.print(
+                f"  Total indexed files: [nexus.success]{stats['indexed_files']}[/nexus.success]"
+            )
+            console.print(f"  Total chunks: [nexus.success]{stats['total_chunks']}[/nexus.success]")
 
             nx.close()
         except Exception as e:
@@ -526,7 +538,9 @@ def search_query(
         try:
             nx = await get_filesystem(remote_url, remote_api_key)
 
-            with console.status(f"[yellow]Searching for: {query}[/yellow]", spinner="dots"):
+            with console.status(
+                f"[nexus.warning]Searching for: {query}[/nexus.warning]", spinner="dots"
+            ):
                 search_svc = nx.service("search")
                 raw = search_svc.semantic_search(query, path=path, limit=limit, search_mode=mode)
                 # RPC handler wraps as {"results": [...]}, unwrap if needed
@@ -540,12 +554,12 @@ def search_query(
                 console.print(json.dumps(results, indent=2))
             else:
                 if not results:
-                    console.print(f"[yellow]No results found for:[/yellow] {query}")
+                    console.print(f"[nexus.warning]No results found for:[/nexus.warning] {query}")
                     nx.close()
                     return
 
                 console.print(
-                    f"\n[green]Found {len(results)} results for:[/green] [cyan]{query}[/cyan]\n"
+                    f"\n[nexus.success]Found {len(results)} results for:[/nexus.success] [nexus.value]{query}[/nexus.value]\n"
                 )
 
                 for i, result in enumerate(results, 1):
@@ -558,8 +572,8 @@ def search_query(
                         chunk_text = chunk_text[:200] + "..."
 
                     console.print(f"[bold]{i}. {file_path}[/bold]")
-                    console.print(f"   Score: [green]{score:.3f}[/green]")
-                    console.print(f"   [dim]{chunk_text}[/dim]")
+                    console.print(f"   Score: [nexus.success]{score:.3f}[/nexus.success]")
+                    console.print(f"   [nexus.muted]{chunk_text}[/nexus.muted]")
                     console.print()
 
             nx.close()
@@ -586,18 +600,26 @@ def search_stats(remote_url: str | None, remote_api_key: str | None) -> None:
 
             console.print("\n[bold cyan]Semantic Search Statistics[/bold cyan]")
             console.print(
-                f"  Engine: [green]{stats.get('engine', stats.get('database_type', 'unknown'))}[/green]"
+                f"  Engine: [nexus.success]{stats.get('engine', stats.get('database_type', 'unknown'))}[/nexus.success]"
             )
             console.print(
-                f"  Indexed files: [green]{stats.get('total_files', stats.get('indexed_files', 0))}[/green]"
+                f"  Indexed files: [nexus.success]{stats.get('total_files', stats.get('indexed_files', 0))}[/nexus.success]"
             )
-            console.print(f"  Total chunks: [green]{stats.get('total_chunks', 0)}[/green]")
+            console.print(
+                f"  Total chunks: [nexus.success]{stats.get('total_chunks', 0)}[/nexus.success]"
+            )
             if stats.get("embedding_model"):
-                console.print(f"  Embedding model: [cyan]{stats['embedding_model']}[/cyan]")
+                console.print(
+                    f"  Embedding model: [nexus.value]{stats['embedding_model']}[/nexus.value]"
+                )
             if stats.get("chunk_size"):
-                console.print(f"  Chunk size: [cyan]{stats['chunk_size']}[/cyan] tokens")
+                console.print(
+                    f"  Chunk size: [nexus.value]{stats['chunk_size']}[/nexus.value] tokens"
+                )
             if stats.get("chunk_strategy"):
-                console.print(f"  Chunk strategy: [cyan]{stats['chunk_strategy']}[/cyan]")
+                console.print(
+                    f"  Chunk strategy: [nexus.value]{stats['chunk_strategy']}[/nexus.value]"
+                )
 
             nx.close()
         except Exception as e:

--- a/src/nexus/cli/commands/secrets_audit.py
+++ b/src/nexus/cli/commands/secrets_audit.py
@@ -55,19 +55,19 @@ def secrets_audit_list(
     def _render(d: dict) -> None:
         from rich.table import Table
 
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         events = d.get("events", [])
         if not events:
-            console.print("[yellow]No secret access events[/yellow]")
+            console.print("[nexus.warning]No secret access events[/nexus.warning]")
             return
 
         table = Table(title=f"Secret Access Events ({len(events)})")
-        table.add_column("ID", style="dim")
+        table.add_column("ID", style="nexus.muted")
         table.add_column("Action")
         table.add_column("Secret")
         table.add_column("Agent")
-        table.add_column("Time", style="dim")
+        table.add_column("Time", style="nexus.muted")
 
         for ev in events:
             table.add_row(
@@ -110,7 +110,7 @@ def secrets_audit_export(
         nexus secrets-audit export --format json --output audit.json
     """
     from nexus.cli.service_command import _validate_url
-    from nexus.cli.utils import console
+    from nexus.cli.theme import console
 
     url = _validate_url(remote_url)
     try:
@@ -121,11 +121,11 @@ def secrets_audit_export(
         if output_file:
             with open(output_file, "w") as f:
                 f.write(content)
-            console.print(f"[green]Exported to {output_file}[/green]")
+            console.print(f"[nexus.success]Exported to {output_file}[/nexus.success]")
         else:
             click.echo(content)
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from None
 
 
@@ -146,10 +146,14 @@ def secrets_audit_verify(client: SecretsAuditClient, record_id: str) -> ServiceR
     data = client.verify(record_id)
 
     def _render(d: dict) -> None:
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         valid = d.get("valid", d.get("integrity_valid", False))
-        status = "[green]Valid[/green]" if valid else "[red]Tampered[/red]"
+        status = (
+            "[nexus.success]Valid[/nexus.success]"
+            if valid
+            else "[nexus.error]Tampered[/nexus.error]"
+        )
         console.print(f"[bold cyan]Integrity Check: {record_id}[/bold cyan]")
         console.print(f"  Status: {status}")
         if d.get("hash"):

--- a/src/nexus/cli/commands/secrets_audit.py
+++ b/src/nexus/cli/commands/secrets_audit.py
@@ -154,7 +154,7 @@ def secrets_audit_verify(client: SecretsAuditClient, record_id: str) -> ServiceR
             if valid
             else "[nexus.error]Tampered[/nexus.error]"
         )
-        console.print(f"[bold cyan]Integrity Check: {record_id}[/bold cyan]")
+        console.print(f"[bold nexus.value]Integrity Check: {record_id}[/bold nexus.value]")
         console.print(f"  Status: {status}")
         if d.get("hash"):
             console.print(f"  Hash:   {d['hash']}")

--- a/src/nexus/cli/commands/share.py
+++ b/src/nexus/cli/commands/share.py
@@ -141,7 +141,7 @@ def share_show(client: ShareClient, token: str) -> ServiceResult:
     def _render(d: dict) -> None:
         from nexus.cli.theme import console
 
-        console.print(f"[bold cyan]Share Link: {token}[/bold cyan]")
+        console.print(f"[bold nexus.value]Share Link: {token}[/bold nexus.value]")
         console.print(f"  Path:        {d.get('path', 'N/A')}")
         console.print(f"  Permission:  {d.get('permission_level', 'N/A')}")
         console.print(f"  Created:     {d.get('created_at', 'N/A')[:19]}")

--- a/src/nexus/cli/commands/share.py
+++ b/src/nexus/cli/commands/share.py
@@ -67,9 +67,9 @@ def share_create(
     )
 
     def _render(d: dict) -> None:
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
-        console.print("[green]Share link created[/green]")
+        console.print("[nexus.success]Share link created[/nexus.success]")
         console.print(f"  URL:        {d.get('url', d.get('token', 'N/A'))}")
         console.print(f"  Path:       {d.get('path', path)}")
         console.print(f"  Permission: {d.get('permission_level', permission_level)}")
@@ -98,18 +98,18 @@ def share_list(client: ShareClient, path: str | None) -> ServiceResult:
     def _render(d: dict) -> None:
         from rich.table import Table
 
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         links = d.get("links", d.get("share_links", []))
         if not links:
-            console.print("[yellow]No active share links[/yellow]")
+            console.print("[nexus.warning]No active share links[/nexus.warning]")
             return
 
         table = Table(title=f"Share Links ({len(links)})")
-        table.add_column("Token", style="dim")
+        table.add_column("Token", style="nexus.muted")
         table.add_column("Path")
         table.add_column("Permission")
-        table.add_column("Expires", style="dim")
+        table.add_column("Expires", style="nexus.muted")
 
         for link in links:
             table.add_row(
@@ -139,7 +139,7 @@ def share_show(client: ShareClient, token: str) -> ServiceResult:
     data = client.show(token)
 
     def _render(d: dict) -> None:
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         console.print(f"[bold cyan]Share Link: {token}[/bold cyan]")
         console.print(f"  Path:        {d.get('path', 'N/A')}")

--- a/src/nexus/cli/commands/snapshots.py
+++ b/src/nexus/cli/commands/snapshots.py
@@ -128,11 +128,11 @@ def snapshot_list(
             for tx in txns:
                 status = tx.get("status", "")
                 status_style = (
-                    "green"
+                    "nexus.success"
                     if status == "committed"
-                    else "red"
+                    else "nexus.error"
                     if status == "rolled_back"
-                    else "yellow"
+                    else "nexus.warning"
                 )
                 table.add_row(
                     tx.get("transaction_id", "")[:12] + "...",

--- a/src/nexus/cli/commands/snapshots.py
+++ b/src/nexus/cli/commands/snapshots.py
@@ -68,7 +68,7 @@ def snapshot_create(
             )
 
         def _render(d: dict) -> None:
-            console.print("[green]Snapshot created[/green]")
+            console.print("[nexus.success]Snapshot created[/nexus.success]")
             console.print(f"  Transaction ID: [bold]{d.get('transaction_id', 'N/A')}[/bold]")
             console.print(f"  Status:         {d.get('status', 'N/A')}")
             expires = d.get("expires_at", "N/A")
@@ -85,7 +85,7 @@ def snapshot_create(
             human_formatter=_render,
         )
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from None
 
 
@@ -115,14 +115,14 @@ def snapshot_list(
 
             txns = d.get("transactions", [])
             if not txns:
-                console.print("[yellow]No snapshots found[/yellow]")
+                console.print("[nexus.warning]No snapshots found[/nexus.warning]")
                 return
 
             table = Table(title=f"Snapshots ({len(txns)})")
             table.add_column("Transaction ID", style="bold")
             table.add_column("Status")
             table.add_column("Description")
-            table.add_column("Created", style="dim")
+            table.add_column("Created", style="nexus.muted")
             table.add_column("Entries", justify="right")
 
             for tx in txns:
@@ -150,7 +150,7 @@ def snapshot_list(
             human_formatter=_render,
         )
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from None
 
 
@@ -178,7 +178,7 @@ def snapshot_restore(
             data = rpc_call(remote_url, remote_api_key, "snapshot_restore", txn_id=txn_id)
 
         def _render(d: dict) -> None:
-            console.print(f"[green]Snapshot restored:[/green] {txn_id}")
+            console.print(f"[nexus.success]Snapshot restored:[/nexus.success] {txn_id}")
             if d:
                 console.print(f"  Status: {d.get('status', 'rolled_back')}")
 
@@ -189,5 +189,5 @@ def snapshot_restore(
             human_formatter=_render,
         )
     except Exception as e:
-        console.print(f"[red]Error:[/red] {e}")
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from None

--- a/src/nexus/cli/commands/stack.py
+++ b/src/nexus/cli/commands/stack.py
@@ -50,7 +50,7 @@ from nexus.cli.state import (
 from nexus.cli.state import (
     save_project_config as _save_project_config,
 )
-from nexus.cli.utils import console
+from nexus.cli.theme import console
 
 
 def _resolve_image_ref_from_config(config: dict[str, Any]) -> str:
@@ -212,11 +212,15 @@ def _compose_profiles(compose_file: str) -> set[str]:
     except FileNotFoundError:
         return set()
     except yaml.YAMLError as exc:
-        console.print(f"[yellow]Warning:[/yellow] Failed to parse {compose_file}: {exc}")
+        console.print(
+            f"[nexus.warning]Warning:[/nexus.warning] Failed to parse {compose_file}: {exc}"
+        )
         return set()
 
     if not isinstance(stack, dict):
-        console.print(f"[yellow]Warning:[/yellow] {compose_file} does not contain a valid mapping")
+        console.print(
+            f"[nexus.warning]Warning:[/nexus.warning] {compose_file} does not contain a valid mapping"
+        )
         return set()
 
     profiles: set[str] = set()
@@ -289,9 +293,9 @@ def _find_docker_compose() -> str:
     # Fallback to standalone `docker-compose`
     if shutil.which("docker-compose"):
         return "docker-compose"
-    console.print("[red]Error:[/red] Docker Compose is not installed.")
+    console.print("[nexus.error]Error:[/nexus.error] Docker Compose is not installed.")
     console.print(
-        "[yellow]Hint:[/yellow] Install Docker Desktop or the compose plugin: "
+        "[nexus.warning]Hint:[/nexus.warning] Install Docker Desktop or the compose plugin: "
         "https://docs.docker.com/compose/install/"
     )
     raise SystemExit(1)
@@ -551,8 +555,8 @@ def up(
                 candidate = parent / Path(name).name
                 if candidate.exists():
                     console.print(
-                        f"[yellow]No nexus.yaml in current directory, "
-                        f"but found {candidate}[/yellow]"
+                        f"[nexus.warning]No nexus.yaml in current directory, "
+                        f"but found {candidate}[/nexus.warning]"
                     )
                     console.print(
                         f"  Run `nexus up` from {parent} or "
@@ -569,7 +573,7 @@ def up(
             init_cmd, ["--preset", "shared", "--force"], catch_exceptions=False
         )
         if init_result.exit_code != 0:
-            console.print("[red]Error:[/red] Auto-init failed.")
+            console.print("[nexus.error]Error:[/nexus.error] Auto-init failed.")
             if init_result.output:
                 console.print(init_result.output)
             raise SystemExit(1)
@@ -580,7 +584,7 @@ def up(
 
     if preset == "local":
         console.print(
-            "[yellow]Preset 'local' does not use Docker.[/yellow] "
+            "[nexus.warning]Preset 'local' does not use Docker.[/nexus.warning] "
             "Use `nexus serve` to start a local server, or re-init with "
             "`nexus init --preset shared`."
         )
@@ -589,8 +593,10 @@ def up(
     # Determine compose file
     cf = compose_file or config.get("compose_file", "./nexus-stack.yml")
     if not Path(cf).exists():
-        console.print(f"[red]Error:[/red] Compose file not found: {cf}")
-        console.print("[yellow]Hint:[/yellow] Ensure nexus-stack.yml is in the project root.")
+        console.print(f"[nexus.error]Error:[/nexus.error] Compose file not found: {cf}")
+        console.print(
+            "[nexus.warning]Hint:[/nexus.warning] Ensure nexus-stack.yml is in the project root."
+        )
         raise SystemExit(1)
 
     data_dir = str(Path(config.get("data_dir", "./nexus-data")).resolve())
@@ -622,7 +628,7 @@ def up(
         if container_state == "running":
             # Already running — print status and exit
             console.print()
-            console.print("[green]Nexus stack is already running.[/green]")
+            console.print("[nexus.success]Nexus stack is already running.[/nexus.success]")
             conn_env = resolve_connection_env(config, prev_state)
             console.print()
             console.print("[bold]Connection:[/bold]")
@@ -630,8 +636,8 @@ def up(
                 console.print(f"  export {key}='{value}'")
             console.print()
             console.print(
-                "[dim]Use `nexus up --pull` to update, "
-                "or `nexus down && nexus up` to recreate.[/dim]"
+                "[nexus.muted]Use `nexus up --pull` to update, "
+                "or `nexus down && nexus up` to recreate.[/nexus.muted]"
             )
             return
 
@@ -645,7 +651,7 @@ def up(
             compose_env = _derive_project_env(config, resolved_ports=prev_ports)
             result = _run_compose(cf, profiles, "up", "-d", extra_env=compose_env)
             if result.returncode != 0:
-                console.print("[red]Error:[/red] Failed to resume stack.")
+                console.print("[nexus.error]Error:[/nexus.error] Failed to resume stack.")
                 raise SystemExit(result.returncode)
 
             # Health polling — same guarantees as a fresh start
@@ -656,17 +662,21 @@ def up(
             all_healthy = True
             for service, elapsed, healthy in health_results:
                 if healthy:
-                    console.print(f"  [green]✓[/green] {service} ({elapsed:.1f}s)")
+                    console.print(f"  [nexus.success]✓[/nexus.success] {service} ({elapsed:.1f}s)")
                 else:
-                    console.print(f"  [red]✗[/red] {service} (timed out after {elapsed:.0f}s)")
+                    console.print(
+                        f"  [nexus.error]✗[/nexus.error] {service} (timed out after {elapsed:.0f}s)"
+                    )
                     all_healthy = False
             if not all_healthy:
                 console.print()
-                console.print("[yellow]Some services did not become healthy.[/yellow]")
+                console.print(
+                    "[nexus.warning]Some services did not become healthy.[/nexus.warning]"
+                )
                 console.print("  Run `nexus logs` to investigate.")
                 raise SystemExit(1)
 
-            console.print("[green]✓[/green] Stack resumed.")
+            console.print("[nexus.success]✓[/nexus.success] Stack resumed.")
             conn_env = resolve_connection_env(config, prev_state)
             console.print()
             console.print("[bold]Connection:[/bold]")
@@ -699,7 +709,7 @@ def up(
         if missing:
             for p in missing:
                 console.print(
-                    f"  [yellow]Warning: profile '{p}' not found in {Path(cf).name}, skipping[/yellow]"
+                    f"  [nexus.warning]Warning: profile '{p}' not found in {Path(cf).name}, skipping[/nexus.warning]"
                 )
             profiles = [p for p in profiles if p in available_profiles]
 
@@ -740,10 +750,10 @@ def up(
     console.print(f"[bold]Starting Nexus preset: {preset}[/bold]")
     console.print(f"  Using stack: {cf}")
     if build:
-        console.print("  Image: [green]local build[/green] (from Dockerfile)")
+        console.print("  Image: [nexus.success]local build[/nexus.success] (from Dockerfile)")
     elif using_local_build:
         console.print(
-            f"  Image: [green]{prev_state.get('image_used', 'local')}[/green] (reusing local build)"
+            f"  Image: [nexus.success]{prev_state.get('image_used', 'local')}[/nexus.success] (reusing local build)"
         )
     else:
         image_ref = _resolve_image_ref_from_config(config)
@@ -755,7 +765,7 @@ def up(
 
     # Print port resolution messages
     for msg in port_messages:
-        console.print(f"  [yellow]{msg}[/yellow]")
+        console.print(f"  [nexus.warning]{msg}[/nexus.warning]")
 
     # NOTE: resolved ports are NOT written back to nexus.yaml.
     # They go into .state.json (written after health check).
@@ -793,7 +803,7 @@ def up(
             repo_dockerfile = _find_repo_dockerfile()
             if repo_dockerfile:
                 console.print(
-                    f"[cyan]Nexus:[/cyan] building image from {repo_dockerfile.relative_to(repo_dockerfile.parent.parent)} "
+                    f"[nexus.path]Nexus:[/nexus.path] building image from {repo_dockerfile.relative_to(repo_dockerfile.parent.parent)} "
                     f"→ {local_tag}"
                 )
                 build_result = subprocess.run(
@@ -810,16 +820,18 @@ def up(
                     env={**os.environ, **compose_env},
                 )
                 if build_result.returncode != 0:
-                    console.print("[red]Error:[/red] Docker build failed.")
+                    console.print("[nexus.error]Error:[/nexus.error] Docker build failed.")
                     raise SystemExit(1)
-                console.print(f"[green]Nexus:[/green] built image {local_tag} from source")
+                console.print(
+                    f"[nexus.success]Nexus:[/nexus.success] built image {local_tag} from source"
+                )
                 compose_env["NEXUS_IMAGE_REF"] = local_tag
                 effective_image_used = local_tag
                 effective_build_mode = "local"
                 build = False  # don't pass --build to compose (no build: directive)
             else:
                 console.print(
-                    "[yellow]Warning:[/yellow] --build ignored — compose file "
+                    "[nexus.warning]Warning:[/nexus.warning] --build ignored — compose file "
                     f"({Path(cf).name}) has no build: directive and no Dockerfile found."
                 )
                 build = False
@@ -845,7 +857,7 @@ def up(
 
     result = _run_compose(cf, profiles, *compose_args, extra_env=compose_env)
     if result.returncode != 0:
-        console.print("[red]Error:[/red] Docker Compose failed to start.")
+        console.print("[nexus.error]Error:[/nexus.error] Docker Compose failed to start.")
         raise SystemExit(result.returncode)
 
     if not detach:
@@ -862,14 +874,16 @@ def up(
     all_healthy = True
     for service, elapsed, healthy in results:
         if healthy:
-            console.print(f"  [green]✓[/green] {service} ({elapsed:.1f}s)")
+            console.print(f"  [nexus.success]✓[/nexus.success] {service} ({elapsed:.1f}s)")
         else:
-            console.print(f"  [red]✗[/red] {service} (timed out after {elapsed:.0f}s)")
+            console.print(
+                f"  [nexus.error]✗[/nexus.error] {service} (timed out after {elapsed:.0f}s)"
+            )
             all_healthy = False
 
     if not all_healthy:
         console.print()
-        console.print("[yellow]Some services did not become healthy.[/yellow]")
+        console.print("[nexus.warning]Some services did not become healthy.[/nexus.warning]")
         console.print("  Run `nexus logs` to investigate.")
         raise SystemExit(1)
 
@@ -979,7 +993,9 @@ def down(volumes: bool) -> None:
     preset = config.get("preset", "local")
 
     if preset == "local":
-        console.print("[yellow]Preset 'local' has no Docker services to stop.[/yellow]")
+        console.print(
+            "[nexus.warning]Preset 'local' has no Docker services to stop.[/nexus.warning]"
+        )
         raise SystemExit(0)
 
     cf = config.get("compose_file", "./nexus-stack.yml")
@@ -1008,11 +1024,11 @@ def down(volumes: bool) -> None:
                     shutil.rmtree(rd) if rd.is_dir() else rd.unlink()
             if raft_dirs:
                 console.print(
-                    f"[dim]  Cleared {len(raft_dirs)} Raft state path(s) from {data_dir}[/dim]"
+                    f"[nexus.muted]  Cleared {len(raft_dirs)} Raft state path(s) from {data_dir}[/nexus.muted]"
                 )
-        console.print("[green]✓[/green] Stack stopped.")
+        console.print("[nexus.success]✓[/nexus.success] Stack stopped.")
     else:
-        console.print("[red]Error:[/red] Failed to stop stack.")
+        console.print("[nexus.error]Error:[/nexus.error] Failed to stop stack.")
         raise SystemExit(result.returncode)
 
 
@@ -1064,7 +1080,9 @@ def restart(build: bool | None) -> None:
     preset = config.get("preset", "local")
 
     if preset == "local":
-        console.print("[yellow]Preset 'local' has no Docker services to restart.[/yellow]")
+        console.print(
+            "[nexus.warning]Preset 'local' has no Docker services to restart.[/nexus.warning]"
+        )
         raise SystemExit(0)
 
     cf = config.get("compose_file", "./nexus-stack.yml")
@@ -1081,7 +1099,7 @@ def restart(build: bool | None) -> None:
             compose_env.pop("NEXUS_IMAGE_REF", None)
         else:
             console.print(
-                "[yellow]Warning:[/yellow] --build ignored — compose file "
+                "[nexus.warning]Warning:[/nexus.warning] --build ignored — compose file "
                 f"({Path(cf).name}) has no build: directive."
             )
             build = False
@@ -1096,9 +1114,9 @@ def restart(build: bool | None) -> None:
         args.extend(["--pull", "always"])
     result = _run_compose(cf, profiles, *args, extra_env=compose_env)
     if result.returncode == 0:
-        console.print("[green]✓[/green] Stack restarted.")
+        console.print("[nexus.success]✓[/nexus.success] Stack restarted.")
     else:
-        console.print("[red]Error:[/red] Failed to restart stack.")
+        console.print("[nexus.error]Error:[/nexus.error] Failed to restart stack.")
         raise SystemExit(result.returncode)
 
 
@@ -1149,13 +1167,15 @@ def upgrade(
     preset = config.get("preset", "local")
 
     if preset == "local":
-        console.print("[yellow]Preset 'local' does not use a prebuilt image.[/yellow]")
+        console.print(
+            "[nexus.warning]Preset 'local' does not use a prebuilt image.[/nexus.warning]"
+        )
         raise SystemExit(0)
 
     # Validate --channel against known channels
     if channel and channel not in VALID_CHANNELS:
         console.print(
-            f"[red]Error:[/red] Unknown channel '{channel}'. "
+            f"[nexus.error]Error:[/nexus.error] Unknown channel '{channel}'. "
             f"Valid channels: {', '.join(VALID_CHANNELS)}"
         )
         raise SystemExit(1)
@@ -1164,7 +1184,7 @@ def upgrade(
     pin_mode = config.get("image_pin", "")
     if pin_mode and not (image_tag or image_digest or channel):
         console.print(
-            f"[yellow]Warning:[/yellow] This config is pinned via {pin_mode}. "
+            f"[nexus.warning]Warning:[/nexus.warning] This config is pinned via {pin_mode}. "
             "Use --image-tag or --image-digest to change the pin, "
             "or --channel to switch to channel-following mode."
         )
@@ -1191,14 +1211,14 @@ def upgrade(
         compose_env = _derive_project_env(config)
         pull_result = _run_compose(cf, profiles, "pull", "nexus", extra_env=compose_env)
         if pull_result.returncode != 0:
-            console.print("[red]Error:[/red] Failed to pull image.")
+            console.print("[nexus.error]Error:[/nexus.error] Failed to pull image.")
             raise SystemExit(pull_result.returncode)
-        console.print(f"[green]✓[/green] Pulled latest {new_ref}")
+        console.print(f"[nexus.success]✓[/nexus.success] Pulled latest {new_ref}")
         console.print("  Run `nexus restart` to apply.")
         return
 
     if new_ref == current_ref:
-        console.print(f"[green]Already up to date:[/green] {current_ref}")
+        console.print(f"[nexus.success]Already up to date:[/nexus.success] {current_ref}")
         return
 
     console.print("[bold]Image upgrade:[/bold]")
@@ -1225,7 +1245,7 @@ def upgrade(
     config.pop("image_tag", None)
 
     _save_project_config(config)
-    console.print(f"[green]✓[/green] Updated nexus.yaml → {new_ref}")
+    console.print(f"[nexus.success]✓[/nexus.success] Updated nexus.yaml → {new_ref}")
     console.print("  Run `nexus restart` to apply.")
 
 
@@ -1244,7 +1264,9 @@ def stop() -> None:
     preset = config.get("preset", "local")
 
     if preset == "local":
-        console.print("[yellow]Preset 'local' has no Docker services to stop.[/yellow]")
+        console.print(
+            "[nexus.warning]Preset 'local' has no Docker services to stop.[/nexus.warning]"
+        )
         raise SystemExit(0)
 
     cf = config.get("compose_file", "./nexus-stack.yml")
@@ -1253,9 +1275,9 @@ def stop() -> None:
 
     result = _run_compose(cf, profiles, "stop", extra_env=compose_env)
     if result.returncode == 0:
-        console.print("[green]✓[/green] Stack paused. Resume with `nexus start`.")
+        console.print("[nexus.success]✓[/nexus.success] Stack paused. Resume with `nexus start`.")
     else:
-        console.print("[red]Error:[/red] Failed to stop stack.")
+        console.print("[nexus.error]Error:[/nexus.error] Failed to stop stack.")
         raise SystemExit(result.returncode)
 
 
@@ -1273,7 +1295,9 @@ def start() -> None:
     preset = config.get("preset", "local")
 
     if preset == "local":
-        console.print("[yellow]Preset 'local' has no Docker services to start.[/yellow]")
+        console.print(
+            "[nexus.warning]Preset 'local' has no Docker services to start.[/nexus.warning]"
+        )
         raise SystemExit(0)
 
     cf = config.get("compose_file", "./nexus-stack.yml")
@@ -1282,7 +1306,7 @@ def start() -> None:
 
     result = _run_compose(cf, profiles, "start", extra_env=compose_env)
     if result.returncode == 0:
-        console.print("[green]✓[/green] Stack resumed.")
+        console.print("[nexus.success]✓[/nexus.success] Stack resumed.")
     else:
-        console.print("[red]Error:[/red] Failed to start stack.")
+        console.print("[nexus.error]Error:[/nexus.error] Failed to start stack.")
         raise SystemExit(result.returncode)

--- a/src/nexus/cli/commands/status.py
+++ b/src/nexus/cli/commands/status.py
@@ -14,8 +14,9 @@ from typing import TYPE_CHECKING, Any
 import click
 
 from nexus.cli.output import OutputOptions, add_output_options, render_output
+from nexus.cli.theme import console
 from nexus.cli.timing import CommandTiming
-from nexus.cli.utils import console, handle_error
+from nexus.cli.utils import handle_error
 
 if TYPE_CHECKING:
     from rich.table import Table
@@ -148,10 +149,10 @@ def _build_table(data: dict[str, Any]) -> Table:
     from rich.table import Table as RichTable
 
     table = RichTable(title="Nexus Service Status")
-    table.add_column("Service", style="cyan", no_wrap=True)
+    table.add_column("Service", style="nexus.value", no_wrap=True)
     table.add_column("Status", style="bold")
     table.add_column("Health")
-    table.add_column("Details", style="dim")
+    table.add_column("Details", style="nexus.muted")
 
     # Image row (from nexus.yaml project config)
     image_ref = data.get("image_ref", "")
@@ -164,14 +165,14 @@ def _build_table(data: dict[str, Any]) -> Table:
     # Server row
     if data["server_reachable"]:
         health = data["server_health"] or {}
-        status_str = "[green]running[/green]"
+        status_str = "[nexus.success]running[/nexus.success]"
         health_status = health.get("status", "unknown")
         if health_status in ("healthy", "ok"):
-            health_str = f"[green]{health_status}[/green]"
+            health_str = f"[nexus.success]{health_status}[/nexus.success]"
         elif health_status == "error":
-            health_str = f"[red]{health_status}[/red]"
+            health_str = f"[nexus.error]{health_status}[/nexus.error]"
         else:
-            health_str = f"[yellow]{health_status}[/yellow]"
+            health_str = f"[nexus.warning]{health_status}[/nexus.warning]"
         components = health.get("components", {})
         details_parts: list[str] = []
         for name, info in components.items():
@@ -182,8 +183,8 @@ def _build_table(data: dict[str, Any]) -> Table:
                 details_parts.append(f"{name}={comp_status}")
         detail = ", ".join(details_parts) if details_parts else "all components ok"
     else:
-        status_str = "[red]unreachable[/red]"
-        health_str = "[red]--[/red]"
+        status_str = "[nexus.error]unreachable[/nexus.error]"
+        health_str = "[nexus.error]--[/nexus.error]"
         detail = data["server_url"]
 
     table.add_row("nexus-server (HTTP)", status_str, health_str, detail)
@@ -195,18 +196,18 @@ def _build_table(data: dict[str, Any]) -> Table:
         health_val = svc.get("Health", "")
 
         if state == "running":
-            s = "[green]running[/green]"
+            s = "[nexus.success]running[/nexus.success]"
         elif state == "exited":
-            s = "[red]exited[/red]"
+            s = "[nexus.error]exited[/nexus.error]"
         else:
-            s = f"[yellow]{state}[/yellow]"
+            s = f"[nexus.warning]{state}[/nexus.warning]"
 
         if health_val == "healthy":
-            h = "[green]healthy[/green]"
+            h = "[nexus.success]healthy[/nexus.success]"
         elif health_val:
-            h = f"[yellow]{health_val}[/yellow]"
+            h = f"[nexus.warning]{health_val}[/nexus.warning]"
         else:
-            h = "[dim]--[/dim]"
+            h = "[nexus.muted]--[/nexus.muted]"
 
         ports = svc.get("Publishers", svc.get("Ports", ""))
         port_detail = ""
@@ -221,7 +222,7 @@ def _build_table(data: dict[str, Any]) -> Table:
         table.add_row(name, s, h, port_detail)
 
     if not data["docker_services"] and not data["server_reachable"]:
-        table.add_row("[dim]no services detected[/dim]", "", "", "")
+        table.add_row("[nexus.muted]no services detected[/nexus.muted]", "", "", "")
 
     return table
 
@@ -232,7 +233,7 @@ def _render_table(data: dict[str, Any]) -> None:
 
     if not is_running:
         console.print()
-        console.print("[yellow]Nexus is not running.[/yellow]")
+        console.print("[nexus.warning]Nexus is not running.[/nexus.warning]")
         console.print("  Run `nexus up` to start the stack.")
         console.print()
         return

--- a/src/nexus/cli/commands/upload.py
+++ b/src/nexus/cli/commands/upload.py
@@ -52,7 +52,7 @@ def upload_status(client: UploadClient, upload_id: str) -> ServiceResult:
         length = d.get("length", 0)
         pct = f"{offset / length * 100:.1f}%" if length > 0 else "N/A"
 
-        console.print(f"[bold cyan]Upload: {upload_id}[/bold cyan]")
+        console.print(f"[bold nexus.value]Upload: {upload_id}[/bold nexus.value]")
         console.print(f"  Progress: {pct} ({offset} / {length} bytes)")
 
     return ServiceResult(data=data, human_formatter=_render)

--- a/src/nexus/cli/commands/upload.py
+++ b/src/nexus/cli/commands/upload.py
@@ -46,7 +46,7 @@ def upload_status(client: UploadClient, upload_id: str) -> ServiceResult:
     data = client.status(upload_id)
 
     def _render(d: dict) -> None:
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
         offset = d.get("offset", 0)
         length = d.get("length", 0)

--- a/src/nexus/cli/commands/versions.py
+++ b/src/nexus/cli/commands/versions.py
@@ -81,7 +81,7 @@ async def _async_version_history(
         versions = _nx.version_service.list_versions(path)
 
         if not versions:
-            console.print(f"[yellow]No version history found for: {path}[/yellow]")
+            console.print(f"[nexus.warning]No version history found for: {path}[/nexus.warning]")
             nx.close()
             return
 
@@ -91,11 +91,11 @@ async def _async_version_history(
 
         # Display table
         table = Table(title=f"Version History: {path}")
-        table.add_column("Version", style="cyan", justify="right")
-        table.add_column("Size", style="green")
+        table.add_column("Version", style="nexus.value", justify="right")
+        table.add_column("Size", style="nexus.success")
         table.add_column("Created At")
         table.add_column("Created By")
-        table.add_column("Source", style="yellow")
+        table.add_column("Source", style="nexus.warning")
         table.add_column("Change Reason")
 
         for v in versions:
@@ -111,7 +111,7 @@ async def _async_version_history(
             )
 
         console.print(table)
-        console.print(f"\n[dim]Total versions: {len(versions)}[/dim]")
+        console.print(f"\n[nexus.muted]Total versions: {len(versions)}[/nexus.muted]")
 
         nx.close()
 
@@ -151,14 +151,14 @@ async def _async_version_get(
         if output:
             # Write to file
             Path(output).write_bytes(content)
-            console.print(f"[green]✓[/green] Wrote version {version} to: {output}")
+            console.print(f"[nexus.success]✓[/nexus.success] Wrote version {version} to: {output}")
         else:
             # Print to stdout
             try:
                 console.print(content.decode("utf-8"))
             except UnicodeDecodeError:
-                console.print("[yellow]Binary content (cannot display)[/yellow]")
-                console.print("[dim]Use --output to save to file[/dim]")
+                console.print("[nexus.warning]Binary content (cannot display)[/nexus.warning]")
+                console.print("[nexus.muted]Use --output to save to file[/nexus.muted]")
 
         nx.close()
 
@@ -210,15 +210,15 @@ async def _async_version_diff(
         if mode == "metadata":
             # diff is a dict in metadata mode
             if not isinstance(diff, dict):
-                console.print("[red]Error: Expected metadata dict from diff[/red]")
+                console.print("[nexus.error]Error: Expected metadata dict from diff[/nexus.error]")
                 nx.close()
                 return
 
             # Display metadata diff as table
             table = Table(title=f"Metadata Diff: v{v1} vs v{v2}")
             table.add_column("Property")
-            table.add_column(f"Version {v1}", style="cyan")
-            table.add_column(f"Version {v2}", style="green")
+            table.add_column(f"Version {v1}", style="nexus.value")
+            table.add_column(f"Version {v2}", style="nexus.success")
 
             table.add_row(
                 "Size",
@@ -238,7 +238,9 @@ async def _async_version_diff(
             table.add_row(
                 "Content Changed",
                 "",
-                "[green]Yes[/green]" if diff.get("content_changed") else "[dim]No[/dim]",
+                "[nexus.success]Yes[/nexus.success]"
+                if diff.get("content_changed")
+                else "[nexus.muted]No[/nexus.muted]",
             )
 
             created_at_v1 = diff.get("created_at_v1")
@@ -291,14 +293,14 @@ async def _async_version_rollback(
         # Get current version for confirmation
         # Check if file exists
         if not await nx.sys_access(path):
-            console.print(f"[red]File not found: {path}[/red]")
+            console.print(f"[nexus.error]File not found: {path}[/nexus.error]")
             nx.close()
             return
 
         # Get version history to determine current version
         versions = _nx.version_service.list_versions(path)
         if not versions:
-            console.print(f"[yellow]No version history found for: {path}[/yellow]")
+            console.print(f"[nexus.warning]No version history found for: {path}[/nexus.warning]")
             nx.close()
             return
 
@@ -314,8 +316,8 @@ async def _async_version_rollback(
         # Perform rollback
         _nx.version_service.rollback(path, version)
 
-        console.print(f"[green]✓[/green] Rolled back {path} to version {version}")
-        console.print(f"[dim]New version: {current_version + 1}[/dim]")
+        console.print(f"[nexus.success]✓[/nexus.success] Rolled back {path} to version {version}")
+        console.print(f"[nexus.muted]New version: {current_version + 1}[/nexus.muted]")
 
         nx.close()
 

--- a/src/nexus/cli/commands/workflows.py
+++ b/src/nexus/cli/commands/workflows.py
@@ -7,7 +7,8 @@ import os
 import click
 from rich.table import Table
 
-from nexus.cli.utils import console, handle_error
+from nexus.cli.theme import console
+from nexus.cli.utils import handle_error
 
 
 def _get_engine_with_storage():  # type: ignore[no-untyped-def]
@@ -85,13 +86,13 @@ def workflows_load(file_path: str, enabled: bool) -> None:
         if success:
             status = "enabled" if enabled else "disabled"
             console.print(
-                f"[green]✓[/green] Loaded workflow: [cyan]{definition.name}[/cyan] ({status})"
+                f"[nexus.success]✓[/nexus.success] Loaded workflow: [nexus.value]{definition.name}[/nexus.value] ({status})"
             )
             console.print(f"  Version: {definition.version}")
             console.print(f"  Triggers: {len(definition.triggers)}")
             console.print(f"  Actions: {len(definition.actions)}")
         else:
-            console.print(f"[red]✗[/red] Failed to load workflow from {file_path}")
+            console.print(f"[nexus.error]✗[/nexus.error] Failed to load workflow from {file_path}")
 
     except Exception as e:
         handle_error(e)
@@ -106,17 +107,19 @@ def workflows_list() -> None:
         workflow_list = engine.list_workflows()
 
         if not workflow_list:
-            console.print("[yellow]No workflows loaded.[/yellow]")
-            console.print("\nLoad workflows with: [cyan]nexus workflows load <file>[/cyan]")
+            console.print("[nexus.warning]No workflows loaded.[/nexus.warning]")
+            console.print(
+                "\nLoad workflows with: [nexus.value]nexus workflows load <file>[/nexus.value]"
+            )
             return
 
         table = Table(title="Loaded Workflows")
-        table.add_column("Name", style="cyan")
-        table.add_column("Version", style="green")
+        table.add_column("Name", style="nexus.value")
+        table.add_column("Version", style="nexus.success")
         table.add_column("Description")
         table.add_column("Triggers", justify="right")
         table.add_column("Actions", justify="right")
-        table.add_column("Status", style="yellow")
+        table.add_column("Status", style="nexus.warning")
 
         for workflow in workflow_list:
             status = "✓ Enabled" if workflow["enabled"] else "✗ Disabled"
@@ -157,14 +160,16 @@ def workflows_test(workflow_name: str, file_path: str | None, context: str) -> N
         engine = _get_engine_with_storage()
 
         # Execute workflow
-        console.print(f"[cyan]Testing workflow:[/cyan] {workflow_name}")
+        console.print(f"[nexus.value]Testing workflow:[/nexus.value] {workflow_name}")
         if file_path:
-            console.print(f"[cyan]File:[/cyan] {file_path}")
+            console.print(f"[nexus.path]File:[/nexus.path] {file_path}")
 
         execution = asyncio.run(engine.trigger_workflow(workflow_name, event_context))
 
         if not execution:
-            console.print(f"[red]✗[/red] Failed to execute workflow '{workflow_name}'")
+            console.print(
+                f"[nexus.error]✗[/nexus.error] Failed to execute workflow '{workflow_name}'"
+            )
             return
 
         # Display results
@@ -186,10 +191,10 @@ def workflows_test(workflow_name: str, file_path: str | None, context: str) -> N
                     f"  [{status_color}]{status_icon}[/{status_color}] {result.action_name} ({result.duration_ms:.2f}ms)"
                 )
                 if result.error:
-                    console.print(f"    [red]Error: {result.error}[/red]")
+                    console.print(f"    [nexus.error]Error: {result.error}[/nexus.error]")
 
         if execution.error_message:
-            console.print(f"\n[red]Error:[/red] {execution.error_message}")
+            console.print(f"\n[nexus.error]Error:[/nexus.error] {execution.error_message}")
 
     except Exception as e:
         handle_error(e)
@@ -201,7 +206,9 @@ def workflows_test(workflow_name: str, file_path: str | None, context: str) -> N
 def workflows_runs(workflow_name: str, limit: int) -> None:
     """View workflow execution history."""
     try:
-        console.print("[yellow]Workflow execution history not yet implemented.[/yellow]")
+        console.print(
+            "[nexus.warning]Workflow execution history not yet implemented.[/nexus.warning]"
+        )
         console.print(f"This will show the last {limit} executions of '{workflow_name}'")
         # TODO(#1443): implement workflow execution history when database storage is ready
 
@@ -218,7 +225,9 @@ def workflows_enable(workflow_name: str) -> None:
         engine = _get_engine_with_storage()
         engine.enable_workflow(workflow_name)
 
-        console.print(f"[green]✓[/green] Enabled workflow: [cyan]{workflow_name}[/cyan]")
+        console.print(
+            f"[nexus.success]✓[/nexus.success] Enabled workflow: [nexus.value]{workflow_name}[/nexus.value]"
+        )
 
     except Exception as e:
         handle_error(e)
@@ -233,7 +242,9 @@ def workflows_disable(workflow_name: str) -> None:
         engine = _get_engine_with_storage()
         engine.disable_workflow(workflow_name)
 
-        console.print(f"[yellow]✓[/yellow] Disabled workflow: [cyan]{workflow_name}[/cyan]")
+        console.print(
+            f"[nexus.warning]✓[/nexus.warning] Disabled workflow: [nexus.value]{workflow_name}[/nexus.value]"
+        )
 
     except Exception as e:
         handle_error(e)
@@ -249,9 +260,11 @@ def workflows_unload(workflow_name: str) -> None:
         success = engine.unload_workflow(workflow_name)
 
         if success:
-            console.print(f"[green]✓[/green] Unloaded workflow: [cyan]{workflow_name}[/cyan]")
+            console.print(
+                f"[nexus.success]✓[/nexus.success] Unloaded workflow: [nexus.value]{workflow_name}[/nexus.value]"
+            )
         else:
-            console.print(f"[red]✗[/red] Workflow '{workflow_name}' not found")
+            console.print(f"[nexus.error]✗[/nexus.error] Workflow '{workflow_name}' not found")
 
     except Exception as e:
         handle_error(e)
@@ -269,15 +282,15 @@ def workflows_discover(directory: str, load: bool) -> None:
         workflows_found = WorkflowLoader.discover_workflows(directory)
 
         if not workflows_found:
-            console.print(f"[yellow]No workflows found in {directory}[/yellow]")
+            console.print(f"[nexus.warning]No workflows found in {directory}[/nexus.warning]")
             return
 
-        console.print(f"[green]✓[/green] Found {len(workflows_found)} workflow(s)")
+        console.print(f"[nexus.success]✓[/nexus.success] Found {len(workflows_found)} workflow(s)")
 
         # Display discovered workflows
         table = Table(title=f"Workflows in {directory}")
-        table.add_column("Name", style="cyan")
-        table.add_column("Version", style="green")
+        table.add_column("Name", style="nexus.value")
+        table.add_column("Version", style="nexus.success")
         table.add_column("Description")
         table.add_column("Triggers", justify="right")
         table.add_column("Actions", justify="right")
@@ -302,7 +315,7 @@ def workflows_discover(directory: str, load: bool) -> None:
                 if engine.load_workflow(workflow, enabled=True):
                     loaded_count += 1
 
-            console.print(f"\n[green]✓[/green] Loaded {loaded_count} workflow(s)")
+            console.print(f"\n[nexus.success]✓[/nexus.success] Loaded {loaded_count} workflow(s)")
 
     except Exception as e:
         handle_error(e)

--- a/src/nexus/cli/commands/workflows.py
+++ b/src/nexus/cli/commands/workflows.py
@@ -186,7 +186,7 @@ def workflows_test(workflow_name: str, file_path: str | None, context: str) -> N
             console.print("\n[bold]Action Results:[/bold]")
             for result in execution.action_results:
                 status_icon = "✓" if result.success else "✗"
-                status_color = "green" if result.success else "red"
+                status_color = "nexus.success" if result.success else "nexus.error"
                 console.print(
                     f"  [{status_color}]{status_icon}[/{status_color}] {result.action_name} ({result.duration_ms:.2f}ms)"
                 )

--- a/src/nexus/cli/commands/workspace.py
+++ b/src/nexus/cli/commands/workspace.py
@@ -5,12 +5,10 @@ from datetime import timedelta
 from typing import Any
 
 import click
-from rich.console import Console
 from rich.table import Table
 
+from nexus.cli.theme import console
 from nexus.cli.utils import add_backend_options, get_filesystem, handle_error
-
-console = Console()
 
 
 @click.group(name="workspace")
@@ -98,7 +96,7 @@ def register_cmd(
             ttl=ttl_delta,  # v0.5.0
         )
 
-        console.print(f"[green]✓[/green] Registered workspace: {result['path']}")
+        console.print(f"[nexus.success]✓[/nexus.success] Registered workspace: {result['path']}")
         if result["name"]:
             console.print(f"  Name: {result['name']}")
         if result["description"]:
@@ -134,16 +132,16 @@ def list_cmd(
         workspaces = nx.service("workspace_rpc").list_workspaces()
 
         if not workspaces:
-            console.print("[yellow]No workspaces registered[/yellow]")
+            console.print("[nexus.warning]No workspaces registered[/nexus.warning]")
             nx.close()
             return
 
         # Create table
         table = Table(title="Registered Workspaces")
-        table.add_column("Path", style="cyan")
-        table.add_column("Name", style="green")
+        table.add_column("Path", style="nexus.path")
+        table.add_column("Name", style="nexus.success")
         table.add_column("Description")
-        table.add_column("Created By", style="dim")
+        table.add_column("Created By", style="nexus.muted")
 
         for ws in workspaces:
             table.add_row(
@@ -154,7 +152,7 @@ def list_cmd(
             )
 
         console.print(table)
-        console.print(f"\n[dim]{len(workspaces)} workspace(s) registered[/dim]")
+        console.print(f"\n[nexus.muted]{len(workspaces)} workspace(s) registered[/nexus.muted]")
 
         nx.close()
 
@@ -186,23 +184,25 @@ def unregister_cmd(
         # Get workspace info first
         info = nx.service("workspace_rpc").get_workspace_info(path)
         if not info:
-            console.print(f"[red]✗[/red] Workspace not registered: {path}")
+            console.print(f"[nexus.error]✗[/nexus.error] Workspace not registered: {path}")
             nx.close()
             return
 
         # Confirm
         if not yes:
-            console.print(f"[yellow]⚠[/yellow]  About to unregister workspace: {path}")
+            console.print(
+                f"[nexus.warning]⚠[/nexus.warning]  About to unregister workspace: {path}"
+            )
             if info["name"]:
                 console.print(f"    Name: {info['name']}")
             if info["description"]:
                 console.print(f"    Description: {info['description']}")
             console.print(
-                "\n[dim]Note: Files will NOT be deleted, only registry entry removed[/dim]"
+                "\n[nexus.muted]Note: Files will NOT be deleted, only registry entry removed[/nexus.muted]"
             )
 
             if not click.confirm("Continue?"):
-                console.print("[yellow]Cancelled[/yellow]")
+                console.print("[nexus.warning]Cancelled[/nexus.warning]")
                 nx.close()
                 return
 
@@ -210,9 +210,9 @@ def unregister_cmd(
         result = nx.service("workspace_rpc").unregister_workspace(path)
 
         if result:
-            console.print(f"[green]✓[/green] Unregistered workspace: {path}")
+            console.print(f"[nexus.success]✓[/nexus.success] Unregistered workspace: {path}")
         else:
-            console.print(f"[red]✗[/red] Failed to unregister workspace: {path}")
+            console.print(f"[nexus.error]✗[/nexus.error] Failed to unregister workspace: {path}")
 
         nx.close()
 
@@ -239,7 +239,7 @@ def info_cmd(
         info = nx.service("workspace_rpc").get_workspace_info(path)
 
         if not info:
-            console.print(f"[red]✗[/red] Workspace not registered: {path}")
+            console.print(f"[nexus.error]✗[/nexus.error] Workspace not registered: {path}")
             nx.close()
             return
 
@@ -291,7 +291,7 @@ def snapshot_cmd(
             )
 
         console.print(
-            f"[green]✓[/green] Created snapshot #{result['snapshot_number']} "
+            f"[nexus.success]✓[/nexus.success] Created snapshot #{result['snapshot_number']} "
             f"({result['file_count']} files, {_format_size(result['total_size_bytes'])})"
         )
         console.print(f"  Snapshot ID: {result['snapshot_id']}")
@@ -331,18 +331,20 @@ def log_cmd(
         snapshots = nx.service("workspace_rpc").workspace_log(workspace_path=path, limit=limit)
 
         if not snapshots:
-            console.print(f"[yellow]No snapshots found for workspace '{path}'[/yellow]")
+            console.print(
+                f"[nexus.warning]No snapshots found for workspace '{path}'[/nexus.warning]"
+            )
             nx.close()
             return
 
         # Create table
         table = Table(title=f"Workspace Snapshots for {path}")
-        table.add_column("#", justify="right", style="cyan")
-        table.add_column("Created", style="green")
+        table.add_column("#", justify="right", style="nexus.value")
+        table.add_column("Created", style="nexus.success")
         table.add_column("Files", justify="right")
         table.add_column("Size", justify="right")
         table.add_column("Description")
-        table.add_column("Tags", style="dim")
+        table.add_column("Tags", style="nexus.muted")
 
         for snap in snapshots:
             created_at = snap["created_at"].strftime("%Y-%m-%d %H:%M:%S")
@@ -358,7 +360,7 @@ def log_cmd(
             )
 
         console.print(table)
-        console.print(f"\n[dim]Showing {len(snapshots)} snapshot(s)[/dim]")
+        console.print(f"\n[nexus.muted]Showing {len(snapshots)} snapshot(s)[/nexus.muted]")
 
         nx.close()
 
@@ -406,21 +408,25 @@ def restore_cmd(
                     break
 
         if not snap_info:
-            console.print(f"[red]✗[/red] Snapshot #{snapshot} not found")
+            console.print(f"[nexus.error]✗[/nexus.error] Snapshot #{snapshot} not found")
             nx.close()
             return
 
         # Confirm
         if not yes:
-            console.print(f"[yellow]⚠[/yellow]  About to restore workspace to snapshot #{snapshot}")
+            console.print(
+                f"[nexus.warning]⚠[/nexus.warning]  About to restore workspace to snapshot #{snapshot}"
+            )
             console.print(f"    Created: {snap_info['created_at'].strftime('%Y-%m-%d %H:%M:%S')}")
             console.print(f"    Files: {snap_info['file_count']}")
             if snap_info["description"]:
                 console.print(f"    Description: {snap_info['description']}")
-            console.print("\n[red]This will overwrite the current workspace state![/red]")
+            console.print(
+                "\n[nexus.error]This will overwrite the current workspace state![/nexus.error]"
+            )
 
             if not click.confirm("Continue?"):
-                console.print("[yellow]Cancelled[/yellow]")
+                console.print("[nexus.warning]Cancelled[/nexus.warning]")
                 nx.close()
                 return
 
@@ -431,7 +437,7 @@ def restore_cmd(
             )
 
         console.print(
-            f"[green]✓[/green] Restored snapshot #{snapshot} "
+            f"[nexus.success]✓[/nexus.success] Restored snapshot #{snapshot} "
             f"({result['files_restored']} files restored, "
             f"{result['files_deleted']} files deleted)"
         )
@@ -472,31 +478,37 @@ def diff_cmd(
         # Display header
         console.print(f"\n[bold]Diff: Snapshot #{snapshot1} → Snapshot #{snapshot2}[/bold]")
         console.print(
-            f"[dim]{diff['snapshot_1']['created_at'].strftime('%Y-%m-%d %H:%M:%S')} → "
-            f"{diff['snapshot_2']['created_at'].strftime('%Y-%m-%d %H:%M:%S')}[/dim]\n"
+            f"[nexus.muted]{diff['snapshot_1']['created_at'].strftime('%Y-%m-%d %H:%M:%S')} → "
+            f"{diff['snapshot_2']['created_at'].strftime('%Y-%m-%d %H:%M:%S')}[/nexus.muted]\n"
         )
 
         # Added files
         if diff["added"]:
-            console.print(f"[green]Added ({len(diff['added'])} files):[/green]")
+            console.print(f"[nexus.success]Added ({len(diff['added'])} files):[/nexus.success]")
             for file in diff["added"][:20]:  # Limit to 20
                 console.print(f"  + {file['path']} ({_format_size(file['size'])})")
             if len(diff["added"]) > 20:
-                console.print(f"  [dim]... and {len(diff['added']) - 20} more[/dim]")
+                console.print(
+                    f"  [nexus.muted]... and {len(diff['added']) - 20} more[/nexus.muted]"
+                )
             console.print()
 
         # Removed files
         if diff["removed"]:
-            console.print(f"[red]Removed ({len(diff['removed'])} files):[/red]")
+            console.print(f"[nexus.error]Removed ({len(diff['removed'])} files):[/nexus.error]")
             for file in diff["removed"][:20]:
                 console.print(f"  - {file['path']} ({_format_size(file['size'])})")
             if len(diff["removed"]) > 20:
-                console.print(f"  [dim]... and {len(diff['removed']) - 20} more[/dim]")
+                console.print(
+                    f"  [nexus.muted]... and {len(diff['removed']) - 20} more[/nexus.muted]"
+                )
             console.print()
 
         # Modified files
         if diff["modified"]:
-            console.print(f"[yellow]Modified ({len(diff['modified'])} files):[/yellow]")
+            console.print(
+                f"[nexus.warning]Modified ({len(diff['modified'])} files):[/nexus.warning]"
+            )
             for file in diff["modified"][:20]:
                 size_change = file["new_size"] - file["old_size"]
                 size_str = f"{_format_size(file['old_size'])} → {_format_size(file['new_size'])}"
@@ -506,16 +518,18 @@ def diff_cmd(
                     size_str += f" ({_format_size(size_change)})"
                 console.print(f"  ~ {file['path']} ({size_str})")
             if len(diff["modified"]) > 20:
-                console.print(f"  [dim]... and {len(diff['modified']) - 20} more[/dim]")
+                console.print(
+                    f"  [nexus.muted]... and {len(diff['modified']) - 20} more[/nexus.muted]"
+                )
             console.print()
 
         # Summary
         console.print(
-            f"[dim]Summary: "
+            f"[nexus.muted]Summary: "
             f"{len(diff['added'])} added, "
             f"{len(diff['removed'])} removed, "
             f"{len(diff['modified'])} modified, "
-            f"{diff['unchanged']} unchanged[/dim]"
+            f"{diff['unchanged']} unchanged[/nexus.muted]"
         )
 
         nx.close()

--- a/src/nexus/cli/commands/workspace.py
+++ b/src/nexus/cli/commands/workspace.py
@@ -283,7 +283,7 @@ def snapshot_cmd(
         nx: Any = get_filesystem(remote_url, remote_api_key)
         tags = list(tag) if tag else None
 
-        with console.status(f"[bold cyan]Creating snapshot for workspace '{path}'..."):
+        with console.status(f"[bold nexus.value]Creating snapshot for workspace '{path}'..."):
             result = nx.service("workspace_rpc").workspace_snapshot(
                 workspace_path=path,
                 description=description,
@@ -431,7 +431,7 @@ def restore_cmd(
                 return
 
         # Perform restore
-        with console.status(f"[bold cyan]Restoring snapshot #{snapshot}..."):
+        with console.status(f"[bold nexus.value]Restoring snapshot #{snapshot}..."):
             result = nx.service("workspace_rpc").workspace_restore(
                 snapshot_number=snapshot, workspace_path=path
             )
@@ -470,7 +470,7 @@ def diff_cmd(
     try:
         nx: Any = get_filesystem(remote_url, remote_api_key)
 
-        with console.status("[bold cyan]Computing diff between snapshots..."):
+        with console.status("[bold nexus.value]Computing diff between snapshots..."):
             diff = nx.service("workspace_rpc").workspace_diff(
                 snapshot_1=snapshot1, snapshot_2=snapshot2, workspace_path=path
             )

--- a/src/nexus/cli/commands/zone.py
+++ b/src/nexus/cli/commands/zone.py
@@ -156,12 +156,12 @@ def create_zone_cmd(
             store = mgr.create_zone(zone_id, peers=peer_list)
         except Exception as create_err:
             if if_not_exists and "already exists" in str(create_err).lower():
-                console.print(f"[green]✓[/green] Zone already exists: {zone_id}")
+                console.print(f"[nexus.success]✓[/nexus.success] Zone already exists: {zone_id}")
                 mgr.shutdown()
                 return
             raise
 
-        console.print(f"[green]Zone '{zone_id}' created[/green]")
+        console.print(f"[nexus.success]Zone '{zone_id}' created[/nexus.success]")
         console.print(f"  Hostname: {hostname}")
         console.print(f"  Data dir: {data_dir}/{zone_id}/")
         console.print(f"  Bind: {bind}")
@@ -230,7 +230,7 @@ def join_zone_cmd(
         mgr = _get_zone_manager(hostname, data_dir, bind)
         store = mgr.join_zone(zone_id, peers=peer_list)
 
-        console.print(f"[green]Joined zone '{zone_id}'[/green]")
+        console.print(f"[nexus.success]Joined zone '{zone_id}'[/nexus.success]")
         console.print(f"  Hostname: {hostname}")
         console.print(f"  Peers: {', '.join(peer_list)}")
         console.print("  Waiting for leader to send snapshot...")
@@ -296,10 +296,10 @@ def list_zones_cmd(
 
         def _print_human(entries: list[dict[str, Any]]) -> None:
             if not entries:
-                console.print("[dim]No zones found[/dim]")
+                console.print("[nexus.muted]No zones found[/nexus.muted]")
                 return
             table = Table(title=f"Zones ({hostname})")
-            table.add_column("Zone ID", style="cyan")
+            table.add_column("Zone ID", style="nexus.value")
             console.print()
             for entry in entries:
                 table.add_row(entry["zone_id"])
@@ -395,7 +395,7 @@ def mount_zone_cmd(
         mgr.mount(parent_zone, mount_path, target_zone)
 
         console.print(
-            f"[green]Mounted zone '{target_zone}' at '{mount_path}' in zone '{parent_zone}'[/green]"
+            f"[nexus.success]Mounted zone '{target_zone}' at '{mount_path}' in zone '{parent_zone}'[/nexus.success]"
         )
 
         mgr.shutdown()
@@ -471,7 +471,9 @@ def unmount_zone_cmd(
         mgr = _get_zone_manager(hostname, data_dir, bind)
         mgr.unmount(parent_zone, mount_path)
 
-        console.print(f"[green]Unmounted '{mount_path}' from zone '{parent_zone}'[/green]")
+        console.print(
+            f"[nexus.success]Unmounted '{mount_path}' from zone '{parent_zone}'[/nexus.success]"
+        )
 
         mgr.shutdown()
     except Exception as e:
@@ -564,7 +566,7 @@ def export_zone(
                 if after_time.tzinfo is None:
                     after_time = after_time.replace(tzinfo=UTC)
             except ValueError:
-                console.print(f"[red]Error:[/red] Invalid date format: {after}")
+                console.print(f"[nexus.error]Error:[/nexus.error] Invalid date format: {after}")
                 console.print("Use ISO format: 2025-01-01T00:00:00")
                 sys.exit(1)
 
@@ -588,8 +590,8 @@ def export_zone(
         )
 
         # Run export with progress
-        console.print(f"[cyan]Exporting zone:[/cyan] {zone_id}")
-        console.print(f"[cyan]Output:[/cyan] {output_path}")
+        console.print(f"[nexus.value]Exporting zone:[/nexus.value] {zone_id}")
+        console.print(f"[nexus.path]Output:[/nexus.path] {output_path}")
 
         with Progress(
             SpinnerColumn(),
@@ -609,8 +611,8 @@ def export_zone(
         # Show results
         console.print()
         table = Table(title="Export Complete")
-        table.add_column("Metric", style="cyan")
-        table.add_column("Value", style="green")
+        table.add_column("Metric", style="nexus.value")
+        table.add_column("Value", style="nexus.success")
 
         table.add_row("Files exported", f"{manifest.file_count:,}")
         table.add_row("Total size", f"{manifest.total_size_bytes:,} bytes")
@@ -700,7 +702,9 @@ def import_zone(
         path_prefix_remap: dict[str, str] = {}
         for remap in path_remap:
             if "=" not in remap:
-                console.print(f"[red]Error:[/red] Invalid path remap format: {remap}")
+                console.print(
+                    f"[nexus.error]Error:[/nexus.error] Invalid path remap format: {remap}"
+                )
                 console.print("Use format: old=new (e.g., --path-remap /old/=/new/)")
                 sys.exit(1)
             old, new = remap.split("=", 1)
@@ -722,12 +726,12 @@ def import_zone(
         )
 
         # Show import configuration
-        console.print(f"[cyan]Importing from:[/cyan] {bundle_path}")
+        console.print(f"[nexus.path]Importing from:[/nexus.path] {bundle_path}")
         if target_zone:
-            console.print(f"[cyan]Target zone:[/cyan] {target_zone}")
-        console.print(f"[cyan]Conflict mode:[/cyan] {conflict}")
+            console.print(f"[nexus.value]Target zone:[/nexus.value] {target_zone}")
+        console.print(f"[nexus.value]Conflict mode:[/nexus.value] {conflict}")
         if dry_run:
-            console.print("[yellow]DRY RUN - no changes will be made[/yellow]")
+            console.print("[nexus.warning]DRY RUN - no changes will be made[/nexus.warning]")
 
         # Run import with progress
         with Progress(
@@ -748,8 +752,8 @@ def import_zone(
         # Show results
         console.print()
         table = Table(title="Import Complete" if result.success else "Import Failed")
-        table.add_column("Metric", style="cyan")
-        table.add_column("Value", style="green" if result.success else "red")
+        table.add_column("Metric", style="nexus.value")
+        table.add_column("Value", style="nexus.success" if result.success else "red")
 
         table.add_row("Files created", f"{result.files_created:,}")
         table.add_row("Files updated", f"{result.files_updated:,}")
@@ -769,7 +773,7 @@ def import_zone(
         # Show errors if any
         if result.errors:
             console.print()
-            console.print("[red]Errors:[/red]")
+            console.print("[nexus.error]Errors:[/nexus.error]")
             for error in result.errors[:10]:  # Show first 10 errors
                 console.print(f"  - {error.path}: {error.message}")
             if len(result.errors) > 10:
@@ -779,7 +783,7 @@ def import_zone(
         # Show warnings if any
         if result.warnings:
             console.print()
-            console.print("[yellow]Warnings:[/yellow]")
+            console.print("[nexus.warning]Warnings:[/nexus.warning]")
             for warning in result.warnings[:5]:
                 console.print(f"  - {warning}")
             if len(result.warnings) > 5:
@@ -787,7 +791,7 @@ def import_zone(
 
         if result.success:
             console.print()
-            console.print("[green]✓ Import completed successfully[/green]")
+            console.print("[nexus.success]✓ Import completed successfully[/nexus.success]")
 
     except Exception as e:
         handle_error(e)
@@ -807,8 +811,8 @@ def inspect_bundle_cmd(bundle_path: str) -> None:
         info = inspect_bundle(bundle_path)
 
         table = Table(title=f"Bundle: {Path(bundle_path).name}")
-        table.add_column("Property", style="cyan")
-        table.add_column("Value", style="green")
+        table.add_column("Property", style="nexus.value")
+        table.add_column("Value", style="nexus.success")
 
         table.add_row("Bundle ID", info["bundle_id"][:8] + "...")
         table.add_row("Format Version", info["format_version"])
@@ -850,14 +854,14 @@ def validate_bundle_cmd(bundle_path: str) -> None:
     try:
         from nexus.bricks.portability import validate_bundle
 
-        console.print(f"[cyan]Validating:[/cyan] {bundle_path}")
+        console.print(f"[nexus.path]Validating:[/nexus.path] {bundle_path}")
 
         is_valid, errors = validate_bundle(bundle_path)
 
         if is_valid:
-            console.print("[green]✓ Bundle is valid[/green]")
+            console.print("[nexus.success]✓ Bundle is valid[/nexus.success]")
         else:
-            console.print("[red]✗ Bundle validation failed:[/red]")
+            console.print("[nexus.error]✗ Bundle validation failed:[/nexus.error]")
             for error in errors:
                 console.print(f"  - {error}")
             sys.exit(1)

--- a/src/nexus/cli/commands/zone.py
+++ b/src/nexus/cli/commands/zone.py
@@ -753,7 +753,7 @@ def import_zone(
         console.print()
         table = Table(title="Import Complete" if result.success else "Import Failed")
         table.add_column("Metric", style="nexus.value")
-        table.add_column("Value", style="nexus.success" if result.success else "red")
+        table.add_column("Value", style="nexus.success" if result.success else "nexus.error")
 
         table.add_row("Files created", f"{result.files_created:,}")
         table.add_row("Files updated", f"{result.files_updated:,}")

--- a/src/nexus/cli/config.py
+++ b/src/nexus/cli/config.py
@@ -186,10 +186,10 @@ def _check_file_permissions(path: Path) -> None:
         file_stat = path.stat()
         mode = file_stat.st_mode
         if mode & (stat.S_IRGRP | stat.S_IWGRP | stat.S_IROTH | stat.S_IWOTH):
-            from rich.console import Console
+            from nexus.cli.theme import err_console
 
-            Console(stderr=True).print(
-                f"[yellow]Warning:[/yellow] {path} has permissions "
+            err_console.print(
+                f"[nexus.warning]Warning:[/nexus.warning] {path} has permissions "
                 f"{oct(stat.S_IMODE(mode))}. "
                 f"Recommended: {oct(_FILE_PERMISSIONS)} (owner read/write only). "
                 f"Fix with: chmod 600 {path}"
@@ -267,10 +267,10 @@ def resolve_connection(
         )
 
     if effective_profile_name and effective_profile_name not in config.profiles:
-        from rich.console import Console
+        from nexus.cli.theme import err_console
 
-        Console(stderr=True).print(
-            f"[yellow]Warning:[/yellow] Profile '{effective_profile_name}' "
+        err_console.print(
+            f"[nexus.warning]Warning:[/nexus.warning] Profile '{effective_profile_name}' "
             f"not found in {get_config_path()}. Falling back to local default."
         )
 

--- a/src/nexus/cli/dry_run.py
+++ b/src/nexus/cli/dry_run.py
@@ -100,7 +100,7 @@ def render_dry_run(
         return
 
     # Human mode: formatted preview
-    from nexus.cli.utils import console
+    from nexus.cli.theme import console
 
     op = preview.get("operation", "unknown")
     path = preview.get("path", "")
@@ -110,9 +110,11 @@ def render_dry_run(
     console.print("[bold yellow]DRY RUN[/bold yellow] — no changes will be made")
 
     if source and dest:
-        console.print(f"  Would {op}: [cyan]{source}[/cyan] → [cyan]{dest}[/cyan]")
+        console.print(
+            f"  Would {op}: [nexus.path]{source}[/nexus.path] → [nexus.path]{dest}[/nexus.path]"
+        )
     elif path:
-        console.print(f"  Would {op}: [cyan]{path}[/cyan]")
+        console.print(f"  Would {op}: [nexus.path]{path}[/nexus.path]")
 
     # Print any additional details
     skip_keys = {"dry_run", "operation", "path", "source", "dest"}

--- a/src/nexus/cli/dry_run.py
+++ b/src/nexus/cli/dry_run.py
@@ -107,7 +107,7 @@ def render_dry_run(
     source = preview.get("source", "")
     dest = preview.get("dest", "")
 
-    console.print("[bold yellow]DRY RUN[/bold yellow] — no changes will be made")
+    console.print("[bold nexus.warning]DRY RUN[/bold nexus.warning] — no changes will be made")
 
     if source and dest:
         console.print(

--- a/src/nexus/cli/output.py
+++ b/src/nexus/cli/output.py
@@ -255,10 +255,9 @@ def render_error(
             envelope["_request_id"] = output_opts.request_id
         click.echo(json.dumps(envelope, indent=2, default=str))
     else:
-        from rich.console import Console
+        from nexus.cli.theme import err_console
 
-        console = Console(stderr=True)
-        console.print(f"[red]Error:[/red] {error}")
+        err_console.print(f"[nexus.error]Error:[/nexus.error] {error}")
 
     sys.exit(exit_code)
 

--- a/src/nexus/cli/port_utils.py
+++ b/src/nexus/cli/port_utils.py
@@ -187,11 +187,13 @@ def resolve_ports(
             claimed.add(port)
         elif strategy == "fail":
             label = PORT_LABELS.get(service, service)
-            from nexus.cli.utils import console
+            from nexus.cli.theme import console
 
-            console.print(f"[red]Error:[/red] Port {port} ({label}) is already in use.")
             console.print(
-                "[yellow]Hint:[/yellow] Use --port-strategy auto to auto-select a free port."
+                f"[nexus.error]Error:[/nexus.error] Port {port} ({label}) is already in use."
+            )
+            console.print(
+                "[nexus.warning]Hint:[/nexus.warning] Use --port-strategy auto to auto-select a free port."
             )
             sys.exit(1)
         elif strategy == "prompt":
@@ -202,14 +204,14 @@ def resolve_ports(
             # "fail" behaviour instead of blocking on a prompt that nobody
             # will answer.  Matches the Create-React-App / Next.js pattern.
             if not sys.stdin.isatty():
-                from nexus.cli.utils import console
+                from nexus.cli.theme import console
 
                 console.print(
-                    f"[red]Error:[/red] Port {port} ({label}) is already in use "
+                    f"[nexus.error]Error:[/nexus.error] Port {port} ({label}) is already in use "
                     f"(non-interactive terminal — cannot prompt)."
                 )
                 console.print(
-                    f"[yellow]Hint:[/yellow] Use --port-strategy auto to auto-select "
+                    f"[nexus.warning]Hint:[/nexus.warning] Use --port-strategy auto to auto-select "
                     f"a free port, or set the port explicitly (suggested: {default_free})."
                 )
                 sys.exit(1)

--- a/src/nexus/cli/service_command.py
+++ b/src/nexus/cli/service_command.py
@@ -53,9 +53,11 @@ def _validate_url(remote_url: str | None) -> str:
     """Validate that a server URL is provided, exit if not."""
     if not remote_url:
         from nexus.cli.exit_codes import ExitCode
-        from nexus.cli.utils import console
+        from nexus.cli.theme import console
 
-        console.print("[red]Error:[/red] Server URL required. Set NEXUS_URL or use --remote-url")
+        console.print(
+            "[nexus.error]Error:[/nexus.error] Server URL required. Set NEXUS_URL or use --remote-url"
+        )
         sys.exit(ExitCode.CONFIG_ERROR)
     return remote_url
 

--- a/src/nexus/cli/state.py
+++ b/src/nexus/cli/state.py
@@ -24,7 +24,7 @@ from typing import Any
 
 import yaml
 
-from nexus.cli.utils import console
+from nexus.cli.theme import console
 
 # ---------------------------------------------------------------------------
 # Shared config search paths (single source of truth — was duplicated in
@@ -53,7 +53,7 @@ def load_project_config() -> dict[str, Any]:
         if p.exists():
             with open(p) as f:
                 return yaml.safe_load(f) or {}
-    console.print("[red]Error:[/red] No nexus.yaml found. Run `nexus init` first.")
+    console.print("[nexus.error]Error:[/nexus.error] No nexus.yaml found. Run `nexus init` first.")
     raise SystemExit(1)
 
 

--- a/src/nexus/cli/theme.py
+++ b/src/nexus/cli/theme.py
@@ -26,7 +26,7 @@ Table column conventions:
     Timestamps / dates  -> style="nexus.muted"
     File paths          -> style="nexus.path"
     Status columns      -> inline per-value tokens (nexus.success/warning/error)
-    Header style        -> header_style="bold nexus.accent"
+    Header style        -> header_style="nexus.table_header"
 
 Usage::
 
@@ -52,6 +52,7 @@ NEXUS_THEME = Theme(
         "nexus.info": "cyan",
         # Brand
         "nexus.accent": "yellow",
+        "nexus.table_header": "bold yellow",
         # Text hierarchy
         "nexus.muted": "dim",
         "nexus.hint": "dim italic",

--- a/src/nexus/cli/theme.py
+++ b/src/nexus/cli/theme.py
@@ -1,0 +1,111 @@
+"""Centralized theme for Nexus CLI.
+
+All CLI color markup should use these semantic tokens instead of bare color names.
+Terminal colors use ANSI-16 approximations (e.g. amber -> yellow).
+
+NO_COLOR / FORCE_COLOR: Rich handles both automatically. When NO_COLOR is set,
+colors are stripped but text decorations (bold/dim/italic) and status icons
+(which are chosen to be meaningful without color) are preserved.
+
+Token usage guide:
+    nexus.success  — confirmations, healthy status, valid states
+    nexus.warning  — deprecations, caution, starting/stopping states
+    nexus.error    — failures, disconnected, invalid states
+    nexus.info     — informational messages, general highlighted data
+    nexus.accent   — brand accents, tips, table headers
+    nexus.muted    — secondary text, timestamps, deemphasized content
+    nexus.hint     — fix suggestions, help text, instructions
+    nexus.path     — file paths, URIs, URLs
+    nexus.value    — data values, counts, entity IDs, general highlighted data
+    nexus.label    — section headers, table titles, key names
+    nexus.identity — agent identities, user IDs
+    nexus.reference — URNs, zone IDs, external references
+
+Table column conventions:
+    Names / entity IDs  -> style="nexus.value"
+    Timestamps / dates  -> style="nexus.muted"
+    File paths          -> style="nexus.path"
+    Status columns      -> inline per-value tokens (nexus.success/warning/error)
+    Header style        -> header_style="bold nexus.accent"
+
+Usage::
+
+    from nexus.cli.theme import console, print_error, STATUS_OK
+    console.print(f"{STATUS_OK} Connected")
+    console.print("[nexus.value]42[/nexus.value] records found")
+    print_error("Connection failed", "host unreachable")
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from rich.console import Console
+from rich.theme import Theme
+
+NEXUS_THEME = Theme(
+    {
+        # Status — use for state indicators and feedback messages
+        "nexus.success": "green",
+        "nexus.warning": "yellow",
+        "nexus.error": "red",
+        "nexus.info": "cyan",
+        # Brand
+        "nexus.accent": "yellow",
+        # Text hierarchy
+        "nexus.muted": "dim",
+        "nexus.hint": "dim italic",
+        # Data types
+        "nexus.path": "dim cyan",
+        "nexus.value": "cyan",
+        "nexus.label": "bold",
+        "nexus.identity": "magenta",
+        "nexus.reference": "blue",
+    }
+)
+
+console = Console(theme=NEXUS_THEME)
+err_console = Console(theme=NEXUS_THEME, stderr=True)
+
+# Status icon constants — always pair symbol + semantic color.
+STATUS_OK = "[nexus.success]\u2713[/nexus.success]"
+STATUS_WARN = "[nexus.warning]\u26a0[/nexus.warning]"
+STATUS_ERROR = "[nexus.error]\u2717[/nexus.error]"
+STATUS_UNSET = "[nexus.muted]\u25cb[/nexus.muted]"
+
+
+# ---------------------------------------------------------------------------
+# Convenience helpers — DRY wrappers for the most common print patterns.
+# ---------------------------------------------------------------------------
+
+
+def print_error(label: str, message: Any = "") -> None:
+    """Print ``[nexus.error]<label>:[/nexus.error] <message>``."""
+    if message:
+        console.print(f"[nexus.error]{label}:[/nexus.error] {message}")
+    else:
+        console.print(f"[nexus.error]{label}[/nexus.error]")
+
+
+def print_warning(label: str, message: Any = "") -> None:
+    """Print ``[nexus.warning]<label>:[/nexus.warning] <message>``."""
+    if message:
+        console.print(f"[nexus.warning]{label}:[/nexus.warning] {message}")
+    else:
+        console.print(f"[nexus.warning]{label}[/nexus.warning]")
+
+
+def print_success(label: str, message: Any = "") -> None:
+    """Print ``[nexus.success]<label>:[/nexus.success] <message>``."""
+    if message:
+        console.print(f"[nexus.success]{label}:[/nexus.success] {message}")
+    else:
+        console.print(f"[nexus.success]{label}[/nexus.success]")
+
+
+def print_info(label: str, message: Any = "") -> None:
+    """Print ``[nexus.info]<label>:[/nexus.info] <message>``."""
+    if message:
+        console.print(f"[nexus.info]{label}:[/nexus.info] {message}")
+    else:
+        console.print(f"[nexus.info]{label}[/nexus.info]")

--- a/src/nexus/cli/utils.py
+++ b/src/nexus/cli/utils.py
@@ -10,17 +10,15 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
 
 import click
-from rich.console import Console
 
 import nexus
 from nexus import NexusFilesystem
 from nexus.cli.exit_codes import ExitCode
+from nexus.cli.theme import console, print_error
 from nexus.contracts.exceptions import NexusError, NexusFileNotFoundError, ValidationError
 
 if TYPE_CHECKING:
     pass
-
-console = Console()
 
 _LOCAL_WORKSPACE_ENV_KEYS = (
     "NEXUS_URL",
@@ -287,9 +285,9 @@ async def get_filesystem(
                 )
                 return await nexus.connect(config={"profile": "slim", "data_dir": data_dir})
 
-            console.print("[red]Error:[/red] NEXUS_URL or --remote-url is required")
+            console.print("[nexus.error]Error:[/nexus.error] NEXUS_URL or --remote-url is required")
             console.print(
-                "[yellow]Hint:[/yellow] export NEXUS_URL=http://your-nexus-server:2026"
+                "[nexus.warning]Hint:[/nexus.warning] export NEXUS_URL=http://your-nexus-server:2026"
                 " or use `nexus profile add`"
             )
             sys.exit(ExitCode.CONFIG_ERROR)
@@ -298,7 +296,7 @@ async def get_filesystem(
             config={"profile": "remote", "url": resolved.url, "api_key": resolved.api_key}
         )
     except Exception as e:
-        console.print(f"[red]Error connecting to Nexus:[/red] {e}")
+        console.print(f"[nexus.error]Error connecting to Nexus:[/nexus.error] {e}")
         sys.exit(ExitCode.UNAVAILABLE)
 
 
@@ -320,9 +318,11 @@ async def get_default_filesystem() -> NexusFilesystem:
         )
 
         if not resolved.is_remote:
-            console.print("[red]Error:[/red] NEXUS_URL environment variable is required")
             console.print(
-                "[yellow]Hint:[/yellow] export NEXUS_URL=http://your-nexus-server:2026"
+                "[nexus.error]Error:[/nexus.error] NEXUS_URL environment variable is required"
+            )
+            console.print(
+                "[nexus.warning]Hint:[/nexus.warning] export NEXUS_URL=http://your-nexus-server:2026"
                 " or use `nexus profile add`"
             )
             sys.exit(ExitCode.CONFIG_ERROR)
@@ -335,7 +335,7 @@ async def get_default_filesystem() -> NexusFilesystem:
             }
         )
     except Exception as e:
-        console.print(f"[red]Error connecting to Nexus:[/red] {e}")
+        console.print(f"[nexus.error]Error connecting to Nexus:[/nexus.error] {e}")
         sys.exit(ExitCode.UNAVAILABLE)
 
 
@@ -387,9 +387,9 @@ def parse_subject(subject_str: str | None) -> tuple[str, str] | None:
         return None
 
     if ":" not in subject_str:
-        console.print(f"[red]Error:[/red] Invalid subject format: {subject_str}")
+        console.print(f"[nexus.error]Error:[/nexus.error] Invalid subject format: {subject_str}")
         console.print(
-            "[yellow]Expected format:[/yellow] type:id (e.g., 'user:alice', 'agent:bot1')"
+            "[nexus.warning]Expected format:[/nexus.warning] type:id (e.g., 'user:alice', 'agent:bot1')"
         )
         sys.exit(ExitCode.USAGE_ERROR)
 
@@ -533,25 +533,25 @@ def handle_error(e: Exception) -> None:
     from nexus.contracts.exceptions import AccessDeniedError, NexusPermissionError
 
     if isinstance(e, PermissionError | AccessDeniedError | NexusPermissionError):
-        console.print(f"[red]Permission Denied:[/red] {e}")
+        print_error("Permission Denied", e)
         sys.exit(ExitCode.PERMISSION_DENIED)
     elif isinstance(e, NexusFileNotFoundError):
-        console.print(f"[red]Error:[/red] {e}")
+        print_error("Error", e)
         sys.exit(ExitCode.NOT_FOUND)
     elif isinstance(e, ValidationError):
-        console.print(f"[red]Validation Error:[/red] {e}")
+        print_error("Validation Error", e)
         sys.exit(ExitCode.USAGE_ERROR)
     elif isinstance(e, TimeoutError):
-        console.print(f"[red]Timeout:[/red] {e}")
+        print_error("Timeout", e)
         sys.exit(ExitCode.TEMPFAIL)
     elif isinstance(e, ConnectionError | OSError):
-        console.print(f"[red]Connection Error:[/red] {e}")
+        print_error("Connection Error", e)
         sys.exit(ExitCode.UNAVAILABLE)
     elif isinstance(e, NexusError):
-        console.print(f"[red]Nexus Error:[/red] {e}")
+        print_error("Nexus Error", e)
         sys.exit(ExitCode.GENERAL_ERROR)
     else:
-        console.print(f"[red]Unexpected error:[/red] {e}")
+        print_error("Unexpected error", e)
         sys.exit(ExitCode.INTERNAL_ERROR)
 
 
@@ -575,7 +575,7 @@ def resolve_content(content: str | None, input_file: Any) -> bytes:
         return sys.stdin.buffer.read()
     if content:
         return content.encode("utf-8")
-    console.print("[red]Error:[/red] Must provide content or use --input")
+    console.print("[nexus.error]Error:[/nexus.error] Must provide content or use --input")
     sys.exit(ExitCode.USAGE_ERROR)
 
 

--- a/src/nexus/daemon/main.py
+++ b/src/nexus/daemon/main.py
@@ -484,8 +484,8 @@ def share_cmd(
             remote_url, remote_api_key, "federation_share", local_path=path, zone_id=zone_id
         )
         new_zone = data.get("zone_id", "unknown")
-        console.print(f"[green]Shared '{path}' as federation zone[/green]")
-        console.print(f"  Zone ID: [cyan]{new_zone}[/cyan]")
+        console.print(f"[nexus.success]Shared '{path}' as federation zone[/nexus.success]")
+        console.print(f"  Zone ID: [nexus.reference]{new_zone}[/nexus.reference]")
     except Exception as e:
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
@@ -531,8 +531,8 @@ def join_cmd(
             local_path=local_path,
         )
         joined_zone = data.get("zone_id", "unknown")
-        console.print(f"[green]Joined federation zone from {peer_addr}[/green]")
-        console.print(f"  Zone ID:     [cyan]{joined_zone}[/cyan]")
+        console.print(f"[nexus.success]Joined federation zone from {peer_addr}[/nexus.success]")
+        console.print(f"  Zone ID:     [nexus.reference]{joined_zone}[/nexus.reference]")
         console.print(f"  Remote path: {remote_path}")
         console.print(f"  Local path:  {local_path}")
     except Exception as e:

--- a/src/nexus/fs/_auth_cli.py
+++ b/src/nexus/fs/_auth_cli.py
@@ -12,10 +12,11 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from nexus.cli.theme import NEXUS_THEME
 from nexus.contracts.unified_auth import AuthStatus, CredentialKind
 from nexus.fs._oauth_support import get_token_manager, run_google_oauth_setup, run_x_oauth_setup
 
-console = Console()
+console = Console(theme=NEXUS_THEME)
 
 _SERVICE_AUTH_TYPES: dict[str, tuple[str, ...]] = {
     "s3": ("native", "secret"),
@@ -177,11 +178,13 @@ def _print_connect_success(
     *,
     source: str = "stored",
 ) -> None:
-    console.print(f"[green]ok[/green] {service_name}: {source} {kind.value} auth is configured")
-    console.print(f"[dim]Secret store: {store_path}[/dim]")
+    console.print(
+        f"[nexus.success]ok[/nexus.success] {service_name}: {source} {kind.value} auth is configured"
+    )
+    console.print(f"[nexus.muted]Secret store: {store_path}[/nexus.muted]")
     if fields:
-        console.print(f"[dim]Fields: {', '.join(fields)}[/dim]")
-    console.print(f"[dim]Next: nexus-fs auth test {service_name}[/dim]")
+        console.print(f"[nexus.muted]Fields: {', '.join(fields)}[/nexus.muted]")
+    console.print(f"[nexus.muted]Next: nexus-fs auth test {service_name}[/nexus.muted]")
 
 
 def _print_target_readiness_summary(
@@ -194,20 +197,22 @@ def _print_target_readiness_summary(
     failed = [check for check in checks if not check.get("success")]
 
     if ready:
-        console.print(f"[green]Ready:[/green] {', '.join(ready)}")
+        console.print(f"[nexus.success]Ready:[/nexus.success] {', '.join(ready)}")
 
     if not failed:
-        console.print(f"[green]ok[/green] {service_name}: all checked targets are ready.")
+        console.print(
+            f"[nexus.success]ok[/nexus.success] {service_name}: all checked targets are ready."
+        )
         return
 
     console.print(
-        f"[yellow]{service_name} is partially ready.[/yellow] "
+        f"[nexus.warning]{service_name} is partially ready.[/nexus.warning] "
         f"{len(failed)} target(s) still need action."
     )
     for check in failed:
         target = str(check.get("target", ""))
         message = str(check.get("message", ""))
-        console.print(f"[red]Needs action:[/red] {target}: {message}")
+        console.print(f"[nexus.error]Needs action:[/nexus.error] {target}: {message}")
 
     if service_name == "gws":
         email = user_email or os.environ.get("NEXUS_FS_USER_EMAIL")
@@ -234,11 +239,11 @@ def list_auth() -> None:
     """List configured auth across services."""
     service = _build_auth_service()
     summaries = asyncio.run(service.list_summaries())
-    table = Table(title="Unified Auth", show_header=True, header_style="bold cyan")
-    table.add_column("Service", style="green")
-    table.add_column("Kind", style="cyan")
-    table.add_column("Status", style="yellow")
-    table.add_column("Source", style="blue")
+    table = Table(title="Unified Auth", show_header=True, header_style="nexus.table_header")
+    table.add_column("Service", style="nexus.value")
+    table.add_column("Kind", style="nexus.value")
+    table.add_column("Status", style="nexus.warning")
+    table.add_column("Source", style="nexus.reference")
     table.add_column("Message")
     for summary in summaries:
         table.add_row(
@@ -249,7 +254,7 @@ def list_auth() -> None:
             summary.message,
         )
     console.print(table)
-    console.print(f"[dim]Secret store: {service.secret_store_path}[/dim]")
+    console.print(f"[nexus.muted]Secret store: {service.secret_store_path}[/nexus.muted]")
 
 
 @auth.command("test")
@@ -276,11 +281,13 @@ def test_auth(service_name: str, user_email: str | None, target: str | None) -> 
     checks = result.get("checks")
     if isinstance(checks, list) and checks:
         table = Table(
-            title=f"{service_name} target readiness", show_header=True, header_style="bold cyan"
+            title=f"{service_name} target readiness",
+            show_header=True,
+            header_style="nexus.table_header",
         )
-        table.add_column("Target", style="green")
-        table.add_column("Status", style="yellow")
-        table.add_column("Source", style="blue")
+        table.add_column("Target", style="nexus.value")
+        table.add_column("Status", style="nexus.warning")
+        table.add_column("Source", style="nexus.reference")
         table.add_column("Message")
         for check in checks:
             table.add_row(
@@ -296,7 +303,7 @@ def test_auth(service_name: str, user_email: str | None, target: str | None) -> 
         raise SystemExit(1)
 
     if result.get("success"):
-        console.print(f"[green]ok[/green] {service_name}: {result.get('message')}")
+        console.print(f"[nexus.success]ok[/nexus.success] {service_name}: {result.get('message')}")
         return
     raise click.ClickException(f"{service_name}: {result.get('message')}")
 
@@ -359,7 +366,7 @@ def disconnect_auth(service_name: str) -> None:
     removed = service.disconnect(service_name)
     if not removed:
         raise click.ClickException(f"No stored auth found for '{service_name}'.")
-    console.print(f"[green]ok[/green] Removed stored auth for {service_name}")
+    console.print(f"[nexus.success]ok[/nexus.success] Removed stored auth for {service_name}")
 
 
 @auth.command("doctor")
@@ -369,7 +376,7 @@ def auth_doctor() -> None:
     summaries = asyncio.run(service.list_summaries())
     failures = [s for s in summaries if s.status not in {AuthStatus.AUTHED, AuthStatus.UNKNOWN}]
     for summary in summaries:
-        style = "green" if summary.status == AuthStatus.AUTHED else "yellow"
+        style = "nexus.success" if summary.status == AuthStatus.AUTHED else "nexus.warning"
         console.print(
             f"[{style}]{summary.service}[/{style}] {summary.status.value}: {summary.message}"
         )

--- a/src/nexus/fs/_auth_cli.py
+++ b/src/nexus/fs/_auth_cli.py
@@ -12,11 +12,10 @@ import click
 from rich.console import Console
 from rich.table import Table
 
-from nexus.cli.theme import NEXUS_THEME
 from nexus.contracts.unified_auth import AuthStatus, CredentialKind
 from nexus.fs._oauth_support import get_token_manager, run_google_oauth_setup, run_x_oauth_setup
 
-console = Console(theme=NEXUS_THEME)
+console = Console()
 
 _SERVICE_AUTH_TYPES: dict[str, tuple[str, ...]] = {
     "s3": ("native", "secret"),
@@ -178,13 +177,11 @@ def _print_connect_success(
     *,
     source: str = "stored",
 ) -> None:
-    console.print(
-        f"[nexus.success]ok[/nexus.success] {service_name}: {source} {kind.value} auth is configured"
-    )
-    console.print(f"[nexus.muted]Secret store: {store_path}[/nexus.muted]")
+    console.print(f"[green]ok[/green] {service_name}: {source} {kind.value} auth is configured")
+    console.print(f"[dim]Secret store: {store_path}[/dim]")
     if fields:
-        console.print(f"[nexus.muted]Fields: {', '.join(fields)}[/nexus.muted]")
-    console.print(f"[nexus.muted]Next: nexus-fs auth test {service_name}[/nexus.muted]")
+        console.print(f"[dim]Fields: {', '.join(fields)}[/dim]")
+    console.print(f"[dim]Next: nexus-fs auth test {service_name}[/dim]")
 
 
 def _print_target_readiness_summary(
@@ -197,22 +194,20 @@ def _print_target_readiness_summary(
     failed = [check for check in checks if not check.get("success")]
 
     if ready:
-        console.print(f"[nexus.success]Ready:[/nexus.success] {', '.join(ready)}")
+        console.print(f"[green]Ready:[/green] {', '.join(ready)}")
 
     if not failed:
-        console.print(
-            f"[nexus.success]ok[/nexus.success] {service_name}: all checked targets are ready."
-        )
+        console.print(f"[green]ok[/green] {service_name}: all checked targets are ready.")
         return
 
     console.print(
-        f"[nexus.warning]{service_name} is partially ready.[/nexus.warning] "
+        f"[yellow]{service_name} is partially ready.[/yellow] "
         f"{len(failed)} target(s) still need action."
     )
     for check in failed:
         target = str(check.get("target", ""))
         message = str(check.get("message", ""))
-        console.print(f"[nexus.error]Needs action:[/nexus.error] {target}: {message}")
+        console.print(f"[red]Needs action:[/red] {target}: {message}")
 
     if service_name == "gws":
         email = user_email or os.environ.get("NEXUS_FS_USER_EMAIL")
@@ -239,11 +234,11 @@ def list_auth() -> None:
     """List configured auth across services."""
     service = _build_auth_service()
     summaries = asyncio.run(service.list_summaries())
-    table = Table(title="Unified Auth", show_header=True, header_style="nexus.table_header")
-    table.add_column("Service", style="nexus.value")
-    table.add_column("Kind", style="nexus.value")
-    table.add_column("Status", style="nexus.warning")
-    table.add_column("Source", style="nexus.reference")
+    table = Table(title="Unified Auth", show_header=True, header_style="bold cyan")
+    table.add_column("Service", style="green")
+    table.add_column("Kind", style="cyan")
+    table.add_column("Status", style="yellow")
+    table.add_column("Source", style="blue")
     table.add_column("Message")
     for summary in summaries:
         table.add_row(
@@ -254,7 +249,7 @@ def list_auth() -> None:
             summary.message,
         )
     console.print(table)
-    console.print(f"[nexus.muted]Secret store: {service.secret_store_path}[/nexus.muted]")
+    console.print(f"[dim]Secret store: {service.secret_store_path}[/dim]")
 
 
 @auth.command("test")
@@ -281,13 +276,11 @@ def test_auth(service_name: str, user_email: str | None, target: str | None) -> 
     checks = result.get("checks")
     if isinstance(checks, list) and checks:
         table = Table(
-            title=f"{service_name} target readiness",
-            show_header=True,
-            header_style="nexus.table_header",
+            title=f"{service_name} target readiness", show_header=True, header_style="bold cyan"
         )
-        table.add_column("Target", style="nexus.value")
-        table.add_column("Status", style="nexus.warning")
-        table.add_column("Source", style="nexus.reference")
+        table.add_column("Target", style="green")
+        table.add_column("Status", style="yellow")
+        table.add_column("Source", style="blue")
         table.add_column("Message")
         for check in checks:
             table.add_row(
@@ -303,7 +296,7 @@ def test_auth(service_name: str, user_email: str | None, target: str | None) -> 
         raise SystemExit(1)
 
     if result.get("success"):
-        console.print(f"[nexus.success]ok[/nexus.success] {service_name}: {result.get('message')}")
+        console.print(f"[green]ok[/green] {service_name}: {result.get('message')}")
         return
     raise click.ClickException(f"{service_name}: {result.get('message')}")
 
@@ -366,7 +359,7 @@ def disconnect_auth(service_name: str) -> None:
     removed = service.disconnect(service_name)
     if not removed:
         raise click.ClickException(f"No stored auth found for '{service_name}'.")
-    console.print(f"[nexus.success]ok[/nexus.success] Removed stored auth for {service_name}")
+    console.print(f"[green]ok[/green] Removed stored auth for {service_name}")
 
 
 @auth.command("doctor")
@@ -376,7 +369,7 @@ def auth_doctor() -> None:
     summaries = asyncio.run(service.list_summaries())
     failures = [s for s in summaries if s.status not in {AuthStatus.AUTHED, AuthStatus.UNKNOWN}]
     for summary in summaries:
-        style = "nexus.success" if summary.status == AuthStatus.AUTHED else "nexus.warning"
+        style = "green" if summary.status == AuthStatus.AUTHED else "yellow"
         console.print(
             f"[{style}]{summary.service}[/{style}] {summary.status.value}: {summary.message}"
         )

--- a/src/nexus/fs/_doctor.py
+++ b/src/nexus/fs/_doctor.py
@@ -473,10 +473,10 @@ def generate_tip(results: dict[str, list[DoctorCheckResult]]) -> str | None:
 # ---------------------------------------------------------------------------
 
 _STATUS_ICONS = {
-    DoctorStatus.PASS: "[nexus.success]✓[/nexus.success]",
-    DoctorStatus.FAIL: "[nexus.error]✗[/nexus.error]",
-    DoctorStatus.NOT_INSTALLED: "[nexus.muted]○[/nexus.muted]",
-    DoctorStatus.CONNECTED: "[nexus.success]●[/nexus.success]",
+    DoctorStatus.PASS: "[green]✓[/green]",
+    DoctorStatus.FAIL: "[red]✗[/red]",
+    DoctorStatus.NOT_INSTALLED: "[dim]○[/dim]",
+    DoctorStatus.CONNECTED: "[green]●[/green]",
 }
 
 
@@ -493,10 +493,8 @@ def render_doctor(
     from rich.console import Console
     from rich.table import Table
 
-    from nexus.cli.theme import NEXUS_THEME
-
     if console is None:
-        console = Console(theme=NEXUS_THEME)
+        console = Console()
 
     for section_name, checks in results.items():
         if not checks:
@@ -511,7 +509,7 @@ def render_doctor(
             title_style="bold",
         )
         table.add_column("status", width=3, no_wrap=True)
-        table.add_column("name", style="nexus.value", no_wrap=True)
+        table.add_column("name", style="cyan", no_wrap=True)
         table.add_column("detail")
 
         for check in checks:
@@ -521,9 +519,9 @@ def render_doctor(
             if check.install_cmd and check.status == DoctorStatus.NOT_INSTALLED:
                 # Escape Rich markup in install commands (e.g., nexus-fs[s3])
                 escaped_cmd = check.install_cmd.replace("[", r"\[")
-                detail += f"  [nexus.muted]({escaped_cmd})[/nexus.muted]"
+                detail += f"  [dim]({escaped_cmd})[/dim]"
             if check.fix_hint and check.status == DoctorStatus.FAIL:
-                detail += f"\n       [nexus.muted]{check.fix_hint}[/nexus.muted]"
+                detail += f"\n       [dim]{check.fix_hint}[/dim]"
 
             table.add_row(icon, check.name, detail)
 
@@ -537,15 +535,15 @@ def render_doctor(
     failed = sum(1 for c in all_checks if c.status == DoctorStatus.FAIL)
     not_installed = sum(1 for c in all_checks if c.status == DoctorStatus.NOT_INSTALLED)
 
-    summary_parts = [f"[nexus.success]{passed} passed[/nexus.success]"]
+    summary_parts = [f"[green]{passed} passed[/green]"]
     if failed:
-        summary_parts.append(f"[nexus.error]{failed} failed[/nexus.error]")
+        summary_parts.append(f"[red]{failed} failed[/red]")
     if not_installed:
-        summary_parts.append(f"[nexus.muted]{not_installed} not installed[/nexus.muted]")
+        summary_parts.append(f"[dim]{not_installed} not installed[/dim]")
 
     console.print(f"[bold]{total} checks:[/bold] {', '.join(summary_parts)}")
 
     # Context-aware tip
     tip = generate_tip(results)
     if tip:
-        console.print(f"\n[nexus.info]Tip:[/nexus.info] {tip}")
+        console.print(f"\n[cyan]Tip:[/cyan] {tip}")

--- a/src/nexus/fs/_doctor.py
+++ b/src/nexus/fs/_doctor.py
@@ -473,10 +473,10 @@ def generate_tip(results: dict[str, list[DoctorCheckResult]]) -> str | None:
 # ---------------------------------------------------------------------------
 
 _STATUS_ICONS = {
-    DoctorStatus.PASS: "[green]✓[/green]",
-    DoctorStatus.FAIL: "[red]✗[/red]",
-    DoctorStatus.NOT_INSTALLED: "[dim]○[/dim]",
-    DoctorStatus.CONNECTED: "[green]●[/green]",
+    DoctorStatus.PASS: "[nexus.success]✓[/nexus.success]",
+    DoctorStatus.FAIL: "[nexus.error]✗[/nexus.error]",
+    DoctorStatus.NOT_INSTALLED: "[nexus.muted]○[/nexus.muted]",
+    DoctorStatus.CONNECTED: "[nexus.success]●[/nexus.success]",
 }
 
 
@@ -493,8 +493,10 @@ def render_doctor(
     from rich.console import Console
     from rich.table import Table
 
+    from nexus.cli.theme import NEXUS_THEME
+
     if console is None:
-        console = Console()
+        console = Console(theme=NEXUS_THEME)
 
     for section_name, checks in results.items():
         if not checks:
@@ -509,7 +511,7 @@ def render_doctor(
             title_style="bold",
         )
         table.add_column("status", width=3, no_wrap=True)
-        table.add_column("name", style="cyan", no_wrap=True)
+        table.add_column("name", style="nexus.value", no_wrap=True)
         table.add_column("detail")
 
         for check in checks:
@@ -519,9 +521,9 @@ def render_doctor(
             if check.install_cmd and check.status == DoctorStatus.NOT_INSTALLED:
                 # Escape Rich markup in install commands (e.g., nexus-fs[s3])
                 escaped_cmd = check.install_cmd.replace("[", r"\[")
-                detail += f"  [dim]({escaped_cmd})[/dim]"
+                detail += f"  [nexus.muted]({escaped_cmd})[/nexus.muted]"
             if check.fix_hint and check.status == DoctorStatus.FAIL:
-                detail += f"\n       [dim]{check.fix_hint}[/dim]"
+                detail += f"\n       [nexus.muted]{check.fix_hint}[/nexus.muted]"
 
             table.add_row(icon, check.name, detail)
 
@@ -535,15 +537,15 @@ def render_doctor(
     failed = sum(1 for c in all_checks if c.status == DoctorStatus.FAIL)
     not_installed = sum(1 for c in all_checks if c.status == DoctorStatus.NOT_INSTALLED)
 
-    summary_parts = [f"[green]{passed} passed[/green]"]
+    summary_parts = [f"[nexus.success]{passed} passed[/nexus.success]"]
     if failed:
-        summary_parts.append(f"[red]{failed} failed[/red]")
+        summary_parts.append(f"[nexus.error]{failed} failed[/nexus.error]")
     if not_installed:
-        summary_parts.append(f"[dim]{not_installed} not installed[/dim]")
+        summary_parts.append(f"[nexus.muted]{not_installed} not installed[/nexus.muted]")
 
     console.print(f"[bold]{total} checks:[/bold] {', '.join(summary_parts)}")
 
     # Context-aware tip
     tip = generate_tip(results)
     if tip:
-        console.print(f"\n[cyan]Tip:[/cyan] {tip}")
+        console.print(f"\n[nexus.info]Tip:[/nexus.info] {tip}")

--- a/src/nexus/fs/_oauth_support.py
+++ b/src/nexus/fs/_oauth_support.py
@@ -13,14 +13,13 @@ import click
 from cryptography.fernet import Fernet
 from rich.console import Console
 
-from nexus.cli.theme import NEXUS_THEME
 from nexus.fs._paths import oauth_key_path as _oauth_key_path_fn
 from nexus.fs._paths import token_manager_db as _token_manager_db_fn
 
 # Resolve once at import time for backwards compatibility
 _DEFAULT_DB_PATH = _token_manager_db_fn()
 _DEFAULT_OAUTH_KEY_PATH = _oauth_key_path_fn()
-console = Console(theme=NEXUS_THEME)
+console = Console()
 
 _GOOGLE_SERVICE_SCOPES: dict[str, list[str]] = {
     "gws": [
@@ -97,9 +96,7 @@ def get_oauth_encryption_key() -> str:
 
     key = Fernet.generate_key().decode("utf-8")
     _write_secret_file(_DEFAULT_OAUTH_KEY_PATH, key + "\n")
-    console.print(
-        f"[nexus.muted]Created local OAuth encryption key: {_DEFAULT_OAUTH_KEY_PATH}[/nexus.muted]"
-    )
+    console.print(f"[dim]Created local OAuth encryption key: {_DEFAULT_OAUTH_KEY_PATH}[/dim]")
     return key
 
 
@@ -151,17 +148,15 @@ def run_google_oauth_setup(
     )
     auth_url = provider.get_authorization_url()
 
-    console.print("\n[bold nexus.success]Google OAuth Setup[/bold nexus.success]")
+    console.print("\n[bold green]Google OAuth Setup[/bold green]")
     console.print(f"\n[bold]User:[/bold] {user_email}")
     console.print(f"[bold]Client ID:[/bold] {client_id}")
-    console.print("\n[bold nexus.warning]Step 1:[/bold nexus.warning] Visit this URL to authorize:")
+    console.print("\n[bold yellow]Step 1:[/bold yellow] Visit this URL to authorize:")
     console.print(f"\n{auth_url}\n")
     console.print(
-        "[bold nexus.warning]Step 2:[/bold nexus.warning] After granting permission, the browser will redirect to localhost."
+        "[bold yellow]Step 2:[/bold yellow] After granting permission, the browser will redirect to localhost."
     )
-    console.print(
-        "[bold nexus.warning]Step 3:[/bold nexus.warning] Copy the `code` parameter from that URL."
-    )
+    console.print("[bold yellow]Step 3:[/bold yellow] Copy the `code` parameter from that URL.")
     auth_code = click.prompt("\nEnter authorization code")
 
     async def _exchange_and_store() -> str:
@@ -179,12 +174,10 @@ def run_google_oauth_setup(
 
     try:
         cred_id = asyncio.run(_exchange_and_store())
-        console.print(
-            f"\n[nexus.success]ok[/nexus.success] stored Google OAuth credentials for {user_email}"
-        )
-        console.print(f"[nexus.muted]Credential ID: {cred_id}[/nexus.muted]")
+        console.print(f"\n[green]ok[/green] stored Google OAuth credentials for {user_email}")
+        console.print(f"[dim]Credential ID: {cred_id}[/dim]")
     except Exception as exc:
-        console.print(f"\n[nexus.error]OAuth setup failed:[/nexus.error] {exc}")
+        console.print(f"\n[red]OAuth setup failed:[/red] {exc}")
         sys.exit(1)
 
 
@@ -224,13 +217,13 @@ def run_x_oauth_setup(
     auth_url, pkce_data = provider.get_authorization_url_with_pkce()
     code_verifier = pkce_data["code_verifier"]
 
-    console.print("\n[bold nexus.success]X OAuth Setup[/bold nexus.success]")
+    console.print("\n[bold green]X OAuth Setup[/bold green]")
     console.print(f"\n[bold]User:[/bold] {user_email}")
     console.print(f"[bold]Client ID:[/bold] {client_id}")
-    console.print("\n[bold nexus.warning]Step 1:[/bold nexus.warning] Visit this URL to authorize:")
+    console.print("\n[bold yellow]Step 1:[/bold yellow] Visit this URL to authorize:")
     console.print(f"\n{auth_url}\n")
     console.print(
-        "[bold nexus.warning]Step 2:[/bold nexus.warning] Copy the `code` parameter from the redirect URL."
+        "[bold yellow]Step 2:[/bold yellow] Copy the `code` parameter from the redirect URL."
     )
     auth_code = click.prompt("\nEnter authorization code")
 
@@ -249,10 +242,8 @@ def run_x_oauth_setup(
 
     try:
         cred_id = asyncio.run(_exchange_and_store())
-        console.print(
-            f"\n[nexus.success]ok[/nexus.success] stored X OAuth credentials for {user_email}"
-        )
-        console.print(f"[nexus.muted]Credential ID: {cred_id}[/nexus.muted]")
+        console.print(f"\n[green]ok[/green] stored X OAuth credentials for {user_email}")
+        console.print(f"[dim]Credential ID: {cred_id}[/dim]")
     except Exception as exc:
-        console.print(f"\n[nexus.error]OAuth setup failed:[/nexus.error] {exc}")
+        console.print(f"\n[red]OAuth setup failed:[/red] {exc}")
         sys.exit(1)

--- a/src/nexus/fs/_oauth_support.py
+++ b/src/nexus/fs/_oauth_support.py
@@ -13,13 +13,14 @@ import click
 from cryptography.fernet import Fernet
 from rich.console import Console
 
+from nexus.cli.theme import NEXUS_THEME
 from nexus.fs._paths import oauth_key_path as _oauth_key_path_fn
 from nexus.fs._paths import token_manager_db as _token_manager_db_fn
 
 # Resolve once at import time for backwards compatibility
 _DEFAULT_DB_PATH = _token_manager_db_fn()
 _DEFAULT_OAUTH_KEY_PATH = _oauth_key_path_fn()
-console = Console()
+console = Console(theme=NEXUS_THEME)
 
 _GOOGLE_SERVICE_SCOPES: dict[str, list[str]] = {
     "gws": [
@@ -96,7 +97,9 @@ def get_oauth_encryption_key() -> str:
 
     key = Fernet.generate_key().decode("utf-8")
     _write_secret_file(_DEFAULT_OAUTH_KEY_PATH, key + "\n")
-    console.print(f"[dim]Created local OAuth encryption key: {_DEFAULT_OAUTH_KEY_PATH}[/dim]")
+    console.print(
+        f"[nexus.muted]Created local OAuth encryption key: {_DEFAULT_OAUTH_KEY_PATH}[/nexus.muted]"
+    )
     return key
 
 
@@ -148,15 +151,17 @@ def run_google_oauth_setup(
     )
     auth_url = provider.get_authorization_url()
 
-    console.print("\n[bold green]Google OAuth Setup[/bold green]")
+    console.print("\n[bold nexus.success]Google OAuth Setup[/bold nexus.success]")
     console.print(f"\n[bold]User:[/bold] {user_email}")
     console.print(f"[bold]Client ID:[/bold] {client_id}")
-    console.print("\n[bold yellow]Step 1:[/bold yellow] Visit this URL to authorize:")
+    console.print("\n[bold nexus.warning]Step 1:[/bold nexus.warning] Visit this URL to authorize:")
     console.print(f"\n{auth_url}\n")
     console.print(
-        "[bold yellow]Step 2:[/bold yellow] After granting permission, the browser will redirect to localhost."
+        "[bold nexus.warning]Step 2:[/bold nexus.warning] After granting permission, the browser will redirect to localhost."
     )
-    console.print("[bold yellow]Step 3:[/bold yellow] Copy the `code` parameter from that URL.")
+    console.print(
+        "[bold nexus.warning]Step 3:[/bold nexus.warning] Copy the `code` parameter from that URL."
+    )
     auth_code = click.prompt("\nEnter authorization code")
 
     async def _exchange_and_store() -> str:
@@ -174,10 +179,12 @@ def run_google_oauth_setup(
 
     try:
         cred_id = asyncio.run(_exchange_and_store())
-        console.print(f"\n[green]ok[/green] stored Google OAuth credentials for {user_email}")
-        console.print(f"[dim]Credential ID: {cred_id}[/dim]")
+        console.print(
+            f"\n[nexus.success]ok[/nexus.success] stored Google OAuth credentials for {user_email}"
+        )
+        console.print(f"[nexus.muted]Credential ID: {cred_id}[/nexus.muted]")
     except Exception as exc:
-        console.print(f"\n[red]OAuth setup failed:[/red] {exc}")
+        console.print(f"\n[nexus.error]OAuth setup failed:[/nexus.error] {exc}")
         sys.exit(1)
 
 
@@ -217,13 +224,13 @@ def run_x_oauth_setup(
     auth_url, pkce_data = provider.get_authorization_url_with_pkce()
     code_verifier = pkce_data["code_verifier"]
 
-    console.print("\n[bold green]X OAuth Setup[/bold green]")
+    console.print("\n[bold nexus.success]X OAuth Setup[/bold nexus.success]")
     console.print(f"\n[bold]User:[/bold] {user_email}")
     console.print(f"[bold]Client ID:[/bold] {client_id}")
-    console.print("\n[bold yellow]Step 1:[/bold yellow] Visit this URL to authorize:")
+    console.print("\n[bold nexus.warning]Step 1:[/bold nexus.warning] Visit this URL to authorize:")
     console.print(f"\n{auth_url}\n")
     console.print(
-        "[bold yellow]Step 2:[/bold yellow] Copy the `code` parameter from the redirect URL."
+        "[bold nexus.warning]Step 2:[/bold nexus.warning] Copy the `code` parameter from the redirect URL."
     )
     auth_code = click.prompt("\nEnter authorization code")
 
@@ -242,8 +249,10 @@ def run_x_oauth_setup(
 
     try:
         cred_id = asyncio.run(_exchange_and_store())
-        console.print(f"\n[green]ok[/green] stored X OAuth credentials for {user_email}")
-        console.print(f"[dim]Credential ID: {cred_id}[/dim]")
+        console.print(
+            f"\n[nexus.success]ok[/nexus.success] stored X OAuth credentials for {user_email}"
+        )
+        console.print(f"[nexus.muted]Credential ID: {cred_id}[/nexus.muted]")
     except Exception as exc:
-        console.print(f"\n[red]OAuth setup failed:[/red] {exc}")
+        console.print(f"\n[nexus.error]OAuth setup failed:[/nexus.error] {exc}")
         sys.exit(1)

--- a/src/nexus/plugins/base.py
+++ b/src/nexus/plugins/base.py
@@ -174,7 +174,7 @@ class NexusPlugin(ABC):
                 data = self.read_json_input()
                 content = data.get("content", "")
             except json.JSONDecodeError:
-                console.print("[red]Invalid JSON from stdin[/red]")
+                console.print("[nexus.error]Invalid JSON from stdin[/nexus.error]")
         """
         if not sys.stdin.isatty():
             try:

--- a/src/nexus/plugins/cli.py
+++ b/src/nexus/plugins/cli.py
@@ -8,9 +8,10 @@ import click
 from rich.console import Console
 from rich.table import Table
 
+from nexus.cli.theme import NEXUS_THEME
 from nexus.plugins.registry import PluginRegistry
 
-console = Console()
+console = Console(theme=NEXUS_THEME)
 
 
 def _run_async(coro: Any) -> Any:
@@ -47,15 +48,15 @@ def list_plugins(ctx: click.Context) -> None:
     plugins = registry.list_plugins()
 
     if not plugins:
-        console.print("[yellow]No plugins installed.[/yellow]")
+        console.print("[nexus.warning]No plugins installed.[/nexus.warning]")
         console.print("\nInstall plugins with: pip install nexus-plugin-<name>")
         return
 
     table = Table(title="Installed Plugins")
-    table.add_column("Name", style="cyan")
-    table.add_column("Version", style="green")
+    table.add_column("Name", style="nexus.value")
+    table.add_column("Version", style="nexus.success")
     table.add_column("Description")
-    table.add_column("Status", style="yellow")
+    table.add_column("Status", style="nexus.warning")
 
     for metadata in plugins:
         plugin = registry.get_plugin_sync(metadata.name)
@@ -74,12 +75,12 @@ def plugin_info(ctx: click.Context, plugin_name: str) -> None:
     plugin = _run_async(registry.get_plugin(plugin_name))
 
     if not plugin:
-        console.print(f"[red]Plugin '{plugin_name}' not found.[/red]")
+        console.print(f"[nexus.error]Plugin '{plugin_name}' not found.[/nexus.error]")
         return
 
     metadata = plugin.metadata()
 
-    console.print(f"\n[bold cyan]{metadata.name}[/bold cyan] v{metadata.version}")
+    console.print(f"\n[bold nexus.value]{metadata.name}[/bold nexus.value] v{metadata.version}")
     console.print(f"{metadata.description}\n")
     console.print(f"[bold]Author:[/bold] {metadata.author}")
 
@@ -114,15 +115,15 @@ def enable_plugin(ctx: click.Context, plugin_name: str) -> None:
     plugin = _run_async(registry.get_plugin(plugin_name))
 
     if not plugin:
-        console.print(f"[red]Plugin '{plugin_name}' not found.[/red]")
+        console.print(f"[nexus.error]Plugin '{plugin_name}' not found.[/nexus.error]")
         return
 
     if plugin.is_enabled():
-        console.print(f"[yellow]Plugin '{plugin_name}' is already enabled.[/yellow]")
+        console.print(f"[nexus.warning]Plugin '{plugin_name}' is already enabled.[/nexus.warning]")
         return
 
     registry.enable_plugin(plugin_name)
-    console.print(f"[green]Enabled plugin '{plugin_name}'[/green]")
+    console.print(f"[nexus.success]Enabled plugin '{plugin_name}'[/nexus.success]")
 
 
 @plugins_cli.command(name="disable")
@@ -134,15 +135,15 @@ def disable_plugin(ctx: click.Context, plugin_name: str) -> None:
     plugin = _run_async(registry.get_plugin(plugin_name))
 
     if not plugin:
-        console.print(f"[red]Plugin '{plugin_name}' not found.[/red]")
+        console.print(f"[nexus.error]Plugin '{plugin_name}' not found.[/nexus.error]")
         return
 
     if not plugin.is_enabled():
-        console.print(f"[yellow]Plugin '{plugin_name}' is already disabled.[/yellow]")
+        console.print(f"[nexus.warning]Plugin '{plugin_name}' is already disabled.[/nexus.warning]")
         return
 
     registry.disable_plugin(plugin_name)
-    console.print(f"[green]Disabled plugin '{plugin_name}'[/green]")
+    console.print(f"[nexus.success]Disabled plugin '{plugin_name}'[/nexus.success]")
 
 
 @plugins_cli.command(name="install")
@@ -163,10 +164,10 @@ def install_plugin(plugin_name: str) -> None:
         subprocess.check_call(
             ["pip", "install", package_name], stdout=subprocess.DEVNULL, stderr=subprocess.PIPE
         )
-        console.print(f"[green]Successfully installed {package_name}[/green]")
+        console.print(f"[nexus.success]Successfully installed {package_name}[/nexus.success]")
         console.print("\nRun 'nexus plugins list' to see the installed plugin")
     except subprocess.CalledProcessError as e:
-        console.print(f"[red]Failed to install {package_name}[/red]")
+        console.print(f"[nexus.error]Failed to install {package_name}[/nexus.error]")
         console.print(f"Error: {e.stderr.decode() if e.stderr else str(e)}")
 
 
@@ -196,9 +197,9 @@ def uninstall_plugin(plugin_name: str, yes: bool) -> None:
             stdout=subprocess.DEVNULL,
             stderr=subprocess.PIPE,
         )
-        console.print(f"[green]Successfully uninstalled {package_name}[/green]")
+        console.print(f"[nexus.success]Successfully uninstalled {package_name}[/nexus.success]")
     except subprocess.CalledProcessError as e:
-        console.print(f"[red]Failed to uninstall {package_name}[/red]")
+        console.print(f"[nexus.error]Failed to uninstall {package_name}[/nexus.error]")
         console.print(f"Error: {e.stderr.decode() if e.stderr else str(e)}")
 
 
@@ -228,7 +229,7 @@ def init_plugin(
 
     from nexus.plugins.scaffold import PLUGIN_TYPES, scaffold_plugin
 
-    console.print(f"Creating {plugin_type} plugin: [cyan]nexus-plugin-{name}[/cyan]")
+    console.print(f"Creating {plugin_type} plugin: [nexus.value]nexus-plugin-{name}[/nexus.value]")
 
     try:
         result = scaffold_plugin(
@@ -239,7 +240,9 @@ def init_plugin(
             description=description,
         )
 
-        console.print(f"\n[green]Created plugin scaffold at {result['project_dir']}[/green]")
+        console.print(
+            f"\n[nexus.success]Created plugin scaffold at {result['project_dir']}[/nexus.success]"
+        )
         console.print(f"\n  Package: {result['package_name']}")
         console.print(f"  Module:  {result['module_name']}")
         console.print(f"  Class:   {result['class_name']}")
@@ -255,6 +258,6 @@ def init_plugin(
         console.print("  nexus plugins list")
 
     except (ValueError, FileExistsError) as e:
-        console.print(f"[red]Error: {e}[/red]")
+        console.print(f"[nexus.error]Error: {e}[/nexus.error]")
     except Exception as e:
-        console.print(f"[red]Failed to create plugin scaffold: {e}[/red]")
+        console.print(f"[nexus.error]Failed to create plugin scaffold: {e}[/nexus.error]")

--- a/src/nexus/plugins/scaffold.py
+++ b/src/nexus/plugins/scaffold.py
@@ -215,10 +215,9 @@ class {class_name}(NexusPlugin):
 
     async def hello_command(self, name: str = "World") -> None:
         """Example command."""
-        from rich.console import Console
+        from nexus.cli.theme import console
 
-        console = Console()
-        console.print(f"[green]Hello, {{name}}! From {name} plugin.[/green]")
+        console.print(f"[nexus.success]Hello, {{name}}! From {name} plugin.[/nexus.success]")
 '''
 
     if plugin_type == "storage":

--- a/tests/unit/cli/test_theme.py
+++ b/tests/unit/cli/test_theme.py
@@ -1,0 +1,222 @@
+"""Tests for centralized CLI theme (Issue #3241)."""
+
+from __future__ import annotations
+
+import io
+from collections.abc import Callable
+
+from rich.console import Console
+from rich.style import Style
+
+from nexus.cli.theme import (
+    NEXUS_THEME,
+    STATUS_ERROR,
+    STATUS_OK,
+    STATUS_UNSET,
+    STATUS_WARN,
+    console,
+    err_console,
+    print_error,
+    print_info,
+    print_success,
+    print_warning,
+)
+
+# All 12 semantic tokens that must be present in the theme.
+EXPECTED_TOKENS = [
+    "nexus.success",
+    "nexus.warning",
+    "nexus.error",
+    "nexus.info",
+    "nexus.accent",
+    "nexus.muted",
+    "nexus.hint",
+    "nexus.path",
+    "nexus.value",
+    "nexus.label",
+    "nexus.identity",
+    "nexus.reference",
+]
+
+
+def _capture(c: Console, text: str) -> str:
+    """Print *text* to console *c* and return the raw output."""
+    with c.capture() as cap:
+        c.print(text, end="")
+    return cap.get()
+
+
+def _make_console(**overrides: object) -> Console:
+    """Create a test console with the nexus theme."""
+    buf = io.StringIO()
+    defaults: dict[str, object] = {
+        "theme": NEXUS_THEME,
+        "file": buf,
+        "force_terminal": True,
+        "width": 120,
+        "color_system": "truecolor",
+    }
+    defaults.update(overrides)
+    return Console(**defaults)
+
+
+# ---------------------------------------------------------------------------
+# Token resolution
+# ---------------------------------------------------------------------------
+
+
+class TestTokenResolution:
+    """Every semantic token resolves to a valid Rich Style."""
+
+    def test_all_tokens_present(self) -> None:
+        for token in EXPECTED_TOKENS:
+            style = NEXUS_THEME.styles.get(token)
+            assert style is not None, f"Missing token: {token}"
+
+    def test_all_tokens_are_style_objects(self) -> None:
+        for token in EXPECTED_TOKENS:
+            style = NEXUS_THEME.styles[token]
+            assert isinstance(style, Style), f"{token} is not a Style: {type(style)}"
+
+    def test_no_extra_tokens(self) -> None:
+        """Theme should not contain unexpected non-nexus tokens beyond Rich builtins."""
+        # Rich's Theme(inherit=True) merges in built-in styles like "none", "reset", etc.
+        # We only check that all 12 nexus tokens are present (tested above).
+        custom_tokens = [n for n in NEXUS_THEME.styles if n.startswith("nexus.")]
+        assert len(custom_tokens) == len(EXPECTED_TOKENS)
+
+
+# ---------------------------------------------------------------------------
+# Console singletons
+# ---------------------------------------------------------------------------
+
+
+class TestConsoleSingletons:
+    """Shared console instances are correctly configured."""
+
+    def test_console_has_theme(self) -> None:
+        # Console should resolve our custom tokens without error.
+        style = console.get_style("nexus.error")
+        assert style is not None
+
+    def test_err_console_writes_to_stderr(self) -> None:
+        # err_console should target stderr and have the theme.
+        assert err_console.stderr is True
+        style = err_console.get_style("nexus.error")
+        assert style is not None
+
+
+# ---------------------------------------------------------------------------
+# Status icon constants
+# ---------------------------------------------------------------------------
+
+
+class TestStatusConstants:
+    """Status icons render correctly through the theme."""
+
+    def test_status_ok_contains_checkmark(self) -> None:
+        assert "\u2713" in _capture(_make_console(), STATUS_OK)
+
+    def test_status_error_contains_cross(self) -> None:
+        assert "\u2717" in _capture(_make_console(), STATUS_ERROR)
+
+    def test_status_warn_contains_warning_sign(self) -> None:
+        assert "\u26a0" in _capture(_make_console(), STATUS_WARN)
+
+    def test_status_unset_contains_circle(self) -> None:
+        assert "\u25cb" in _capture(_make_console(), STATUS_UNSET)
+
+
+# ---------------------------------------------------------------------------
+# Helper functions
+# ---------------------------------------------------------------------------
+
+
+def _capture_helper(func: Callable[..., None], label: str, message: object = "") -> str:
+    """Call a print helper with a capturing console and return raw output."""
+    import nexus.cli.theme as theme_mod
+
+    original = theme_mod.console
+    c = _make_console()
+    theme_mod.console = c
+    try:
+        func(label, message)
+    finally:
+        theme_mod.console = original
+    # Read what was written to the underlying StringIO buffer.
+    buf = c.file
+    assert isinstance(buf, io.StringIO)
+    return buf.getvalue()
+
+
+class TestPrintHelpers:
+    """print_error / print_warning / print_success / print_info."""
+
+    def test_print_error_with_message(self) -> None:
+        out = _capture_helper(print_error, "Oops", "something broke")
+        assert "Oops:" in out
+        assert "something broke" in out
+
+    def test_print_error_label_only(self) -> None:
+        out = _capture_helper(print_error, "Oops")
+        assert "Oops" in out
+        assert ":" not in out  # no colon when message is empty
+
+    def test_print_warning(self) -> None:
+        out = _capture_helper(print_warning, "Caution", "low disk")
+        assert "Caution:" in out
+        assert "low disk" in out
+
+    def test_print_success(self) -> None:
+        out = _capture_helper(print_success, "Done", "sent files")
+        assert "Done:" in out
+        assert "files" in out
+
+    def test_print_info(self) -> None:
+        out = _capture_helper(print_info, "Note", "check docs")
+        assert "Note:" in out
+        assert "check docs" in out
+
+    # -- Edge cases --
+
+    def test_empty_message(self) -> None:
+        out = _capture_helper(print_error, "Fail", "")
+        assert "Fail" in out
+
+    def test_message_with_brackets(self) -> None:
+        """Literal brackets in message should not crash Rich."""
+        out = _capture_helper(print_error, "Parse", "expected [int] got [str]")
+        assert "Parse" in out
+
+    def test_nested_markup_in_message(self) -> None:
+        """Rich markup in the message is passed through (not double-escaped)."""
+        out = _capture_helper(print_error, "Err", "[bold]nested[/bold]")
+        assert "nested" in out
+
+    def test_multiline_message(self) -> None:
+        out = _capture_helper(print_error, "Err", "line1\nline2")
+        assert "line1" in out
+        assert "line2" in out
+
+
+# ---------------------------------------------------------------------------
+# NO_COLOR support
+# ---------------------------------------------------------------------------
+
+
+class TestNoColor:
+    """Output remains readable when NO_COLOR is set."""
+
+    def test_no_color_strips_ansi_but_keeps_text(self) -> None:
+        c = _make_console(no_color=True)
+        output = _capture(c, "[nexus.error]Error:[/nexus.error] broken")
+        # Text content preserved.
+        assert "Error:" in output
+        assert "broken" in output
+        # No ANSI escape codes (color sequences start with \x1b[).
+        assert "\x1b[" not in output
+
+    def test_no_color_status_icons_still_render(self) -> None:
+        c = _make_console(no_color=True)
+        output = _capture(c, STATUS_OK)
+        assert "\u2713" in output

--- a/tests/unit/cli/test_theme.py
+++ b/tests/unit/cli/test_theme.py
@@ -22,13 +22,14 @@ from nexus.cli.theme import (
     print_warning,
 )
 
-# All 12 semantic tokens that must be present in the theme.
+# All 13 semantic tokens that must be present in the theme.
 EXPECTED_TOKENS = [
     "nexus.success",
     "nexus.warning",
     "nexus.error",
     "nexus.info",
     "nexus.accent",
+    "nexus.table_header",
     "nexus.muted",
     "nexus.hint",
     "nexus.path",


### PR DESCRIPTION
## Summary

Closes #3241

- **Create `src/nexus/cli/theme.py`** with 12 `nexus.*` semantic Rich markup tokens aligned with an "Industrial Warmth" terminal palette (ANSI-16 approximations)
- **Consolidate 10 bare `Console()` instances** into a single themed `console` singleton (+ `err_console` for stderr)
- **Migrate ~1,006 bare color tags** (`[red]`, `[green]`, `[yellow]`, `[cyan]`, `[dim]`, `[magenta]`, `[blue]`) across 59 CLI files to semantic tokens
- **Standardize 156 table `style=` attributes** and 4 `header_style=` attributes for cross-file consistency
- **Reclassify 28 file-path `[cyan]` usages** to `[nexus.path]` (distinct from `[nexus.value]` for data)
- **Add `print_error`/`print_warning`/`print_success`/`print_info` DRY helpers** and apply `print_error` to `handle_error()` in `utils.py`
- **Add 20 unit tests** in `test_theme.py` covering token resolution, helpers (including edge cases: empty messages, nested markup, brackets), status icon constants, and `NO_COLOR` support
- **Add CI lint gate** (`scripts/check_cli_theme.sh`) enforcing: no bare color tags, all `nexus.*` tokens valid, no bare `Console()` instances — integrated into `ci-lint.sh`
- **Fix pre-existing mypy issue**: add `yaml` to third-party stubs override (untyped import surfaced by touching `state.py`/`config.py`)

### Token reference

| Token | Style | Usage |
|---|---|---|
| `nexus.success` | green | confirmations, healthy status |
| `nexus.warning` | yellow | deprecations, caution |
| `nexus.error` | red | failures, invalid states |
| `nexus.info` | cyan | informational messages |
| `nexus.accent` | yellow | brand accents, table headers |
| `nexus.muted` | dim | secondary text, timestamps |
| `nexus.hint` | dim italic | fix suggestions, help text |
| `nexus.path` | dim cyan | file paths, URIs |
| `nexus.value` | cyan | data values, entity IDs |
| `nexus.label` | bold | section headers, key names |
| `nexus.identity` | magenta | agent/user identities |
| `nexus.reference` | blue | URNs, zone IDs |

## Test plan

- [x] 20 unit tests pass (`test_theme.py`) — token resolution, helpers, edge cases, NO_COLOR
- [x] 453+ existing CLI unit tests pass (no regressions)
- [x] `scripts/check_cli_theme.sh` passes — 0 bare color tags, 0 invalid tokens, 0 bare Console()
- [x] `ruff check` + `ruff format` pass
- [x] `mypy` passes
- [x] All pre-commit hooks pass
- [ ] Manual visual QA: run `nexus status`, `nexus agent list`, `nexus connectors list` and verify output renders correctly