### PR TITLE
release: prep nexus-ai-fs v0.9.15

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -285,7 +285,42 @@ jobs:
           /tmp/nexus-fs-release-test/bin/python -c "import nexus.fs; print(f'nexus-fs v{nexus.fs.__version__}')"
           /tmp/nexus-fs-release-test/bin/nexus-fs --help
 
+      - name: Detect existing nexus-fs PyPI version
+        id: nexus-fs-pypi
+        run: |
+          NEXUS_FS_VERSION=$(grep '^version = ' packages/nexus-fs/pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          echo "version=$NEXUS_FS_VERSION" >> "$GITHUB_OUTPUT"
+          export NEXUS_FS_VERSION
+          python - <<'PY'
+          import json
+          import os
+          import urllib.error
+          import urllib.request
+
+          version = os.environ["NEXUS_FS_VERSION"]
+          url = "https://pypi.org/pypi/nexus-fs/json"
+          exists = False
+
+          try:
+              with urllib.request.urlopen(url) as response:
+                  payload = json.load(response)
+          except urllib.error.HTTPError as exc:
+              if exc.code != 404:
+                  raise
+          else:
+              exists = version in payload.get("releases", {})
+
+          with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as fh:
+              fh.write(f"exists={'true' if exists else 'false'}\n")
+          print(f"nexus-fs version {version} exists on PyPI: {exists}")
+          PY
+
+      - name: Skip nexus-fs PyPI publish
+        if: ${{ steps.nexus-fs-pypi.outputs.exists == 'true' }}
+        run: echo "nexus-fs v${{ steps.nexus-fs-pypi.outputs.version }} already exists on PyPI; skipping publish."
+
       - name: Publish nexus-fs to PyPI
+        if: ${{ steps.nexus-fs-pypi.outputs.exists != 'true' }}
         uses: pypa/gh-action-pypi-publish@release/v1
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.14"
+version = "0.9.15"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/nexus_pyo3/Cargo.toml
+++ b/rust/nexus_pyo3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus_pyo3"
-version = "0.9.14"
+version = "0.9.15"
 edition = "2021"
 
 [lib]

--- a/rust/nexus_pyo3/pyproject.toml
+++ b/rust/nexus_pyo3/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-fast"
-version = "0.9.14"
+version = "0.9.15"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
 requires-python = ">=3.12"
 classifiers = [

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -48,7 +48,7 @@ import logging
 import os as _os
 from typing import TYPE_CHECKING, Any, cast
 
-__version__ = "0.9.6"  # release version
+__version__ = "0.9.15"  # release version
 __author__ = "Nexi Lab Team"
 __license__ = "Apache-2.0"
 

--- a/uv.lock
+++ b/uv.lock
@@ -3407,7 +3407,7 @@ wheels = [
 
 [[package]]
 name = "nexus-ai-fs"
-version = "0.9.14"
+version = "0.9.15"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- bump `nexus-ai-fs` from `0.9.14` to `0.9.15`
- align runtime package version metadata to `0.9.15`
- keep `nexus-fs` on `0.1.0` and skip republishing it when that version already exists on PyPI

## Verification
- repo pre-commit hooks passed during commit
- verified `pyproject.toml` is `0.9.15`
- verified `packages/nexus-fs/pyproject.toml` remains `0.1.0`