### PR TITLE
refactor: GDrive → DriveTransport + PathGDriveBackend composition

### DIFF
--- a/src/nexus/backends/__init__.py
+++ b/src/nexus/backends/__init__.py
@@ -34,9 +34,9 @@ _OPTIONAL_BACKENDS: dict[str, tuple[str, str]] = {
     "CASLocalBackend": ("nexus.backends.storage.cas_local", "CASLocalBackend"),
     "PathLocalBackend": ("nexus.backends.storage.path_local", "PathLocalBackend"),
     "CASGCSBackend": ("nexus.backends.storage.cas_gcs", "CASGCSBackend"),
-    "GoogleDriveConnectorBackend": (
+    "PathGDriveBackend": (
         "nexus.backends.connectors.gdrive.connector",
-        "GoogleDriveConnectorBackend",
+        "PathGDriveBackend",
     ),
     "PathGCSBackend": ("nexus.backends.storage.path_gcs", "PathGCSBackend"),
     "PathS3Backend": ("nexus.backends.storage.path_s3", "PathS3Backend"),
@@ -222,7 +222,7 @@ __all__ = [
     "CASLocalBackend",
     "PathLocalBackend",
     "CASGCSBackend",
-    "GoogleDriveConnectorBackend",
+    "PathGDriveBackend",
     "PathGCSBackend",
     "PathS3Backend",
     "XConnectorBackend",

--- a/src/nexus/backends/connectors/gdrive/connector.py
+++ b/src/nexus/backends/connectors/gdrive/connector.py
@@ -1,42 +1,34 @@
-"""Google Drive connector backend with OAuth 2.0 authentication.
+"""Google Drive connector — PathAddressingEngine + DriveTransport composition.
 
-This is a connector backend that maps files directly to Google Drive using OAuth,
-making it a user-scoped backend (each user has their own Drive).
+Architecture (Transport x Addressing):
+    PathGDriveBackend(PathAddressingEngine)
+        +-- DriveTransport(Transport)
+              +-- Drive API calls (I/O)
+              +-- OAuth token from OperationContext
+              +-- Folder ID caching + resolution
 
-Use case: Personal Google Drive integration where users mount their own Drive
-folders into Nexus workspace.
+This follows the same pattern as PathGmailBackend and PathCalendarBackend:
+Transport handles raw I/O; PathAddressingEngine handles addressing,
+path security, and content operations.
 
 Storage structure:
     Google Drive/
-    ├── nexus-data/           # Root folder (configurable)
-    │   ├── workspace/
-    │   │   ├── file.txt      # Stored at actual path in Drive
-    │   │   └── data/
-    │   │       └── output.json
-    │   └── reports/
-    │       └── report.gdoc   # Google Docs file
-
-Key features:
-- OAuth 2.0 authentication (user-scoped)
-- Direct path mapping (files stored at actual paths)
-- Automatic token refresh via TokenManager
-- Google Docs/Sheets/Slides export support
-- Folder hierarchy maintained
-- Shared Drive support (optional)
-
-Authentication:
-    Uses OAuth 2.0 flow via TokenManager:
-    - User authorizes via browser
-    - Tokens stored encrypted in database
-    - Automatic refresh when expired
+    +-- nexus-data/           # Root folder (configurable)
+    |   +-- workspace/
+    |   |   +-- file.txt      # Stored at actual path in Drive
+    |   |   +-- data/
+    |   |       +-- output.json
+    |   +-- reports/
+    |       +-- report.gdoc   # Google Docs file (auto-exported)
 """
 
-import io
-import logging
-import mimetypes
-from typing import TYPE_CHECKING, Any
+from __future__ import annotations
 
-from nexus.backends.base.backend import Backend, HandlerStatusResponse
+import logging
+from typing import TYPE_CHECKING, ClassVar
+
+from nexus.backends.base.backend import HandlerStatusResponse
+from nexus.backends.base.path_addressing_engine import PathAddressingEngine
 from nexus.backends.base.registry import ArgType, ConnectionArg, register_connector
 from nexus.backends.connectors.base import (
     ConfirmLevel,
@@ -48,6 +40,7 @@ from nexus.backends.connectors.base import (
     ValidatedMixin,
 )
 from nexus.backends.connectors.base_errors import TRAIT_ERRORS
+from nexus.backends.connectors.gdrive.transport import DriveTransport
 from nexus.backends.connectors.gws.schemas import (
     DeleteFileSchema,
     UpdateFileSchema,
@@ -55,52 +48,14 @@ from nexus.backends.connectors.gws.schemas import (
 )
 from nexus.backends.connectors.oauth import OAuthConnectorMixin
 from nexus.contracts.backend_features import OAUTH_BACKEND_FEATURES, BackendFeature
-from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
+from nexus.contracts.exceptions import BackendError
 from nexus.core.hash_fast import hash_content
 from nexus.core.object_store import WriteResult
 
 if TYPE_CHECKING:
-    from googleapiclient.discovery import Resource
-
     from nexus.contracts.types import OperationContext
 
 logger = logging.getLogger(__name__)
-
-
-# Google Drive MIME types
-GOOGLE_MIME_TYPES = {
-    "application/vnd.google-apps.document": "Google Docs",
-    "application/vnd.google-apps.spreadsheet": "Google Sheets",
-    "application/vnd.google-apps.presentation": "Google Slides",
-    "application/vnd.google-apps.drawing": "Google Drawings",
-    "application/vnd.google-apps.form": "Google Forms",
-    "application/vnd.google-apps.folder": "Folder",
-}
-
-# Export formats for Google Workspace files
-EXPORT_FORMATS = {
-    "application/vnd.google-apps.document": {
-        "pdf": "application/pdf",
-        "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
-        "odt": "application/vnd.oasis.opendocument.text",
-        "html": "text/html",
-        "txt": "text/plain",
-        "markdown": "text/markdown",  # Custom conversion
-    },
-    "application/vnd.google-apps.spreadsheet": {
-        "pdf": "application/pdf",
-        "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
-        "ods": "application/vnd.oasis.opendocument.spreadsheet",
-        "csv": "text/csv",
-        "tsv": "text/tab-separated-values",
-    },
-    "application/vnd.google-apps.presentation": {
-        "pdf": "application/pdf",
-        "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
-        "odp": "application/vnd.oasis.opendocument.presentation",
-        "txt": "text/plain",
-    },
-}
 
 
 @register_connector(
@@ -110,30 +65,25 @@ EXPORT_FORMATS = {
     requires=["google-api-python-client", "google-auth-oauthlib"],
     service_name="google-drive",
 )
-class GoogleDriveConnectorBackend(
-    Backend, OAuthConnectorMixin, SkillDocMixin, ValidatedMixin, TraitBasedMixin
+class PathGDriveBackend(
+    PathAddressingEngine,
+    OAuthConnectorMixin,
+    SkillDocMixin,
+    ValidatedMixin,
+    TraitBasedMixin,
 ):
-    """
-    Google Drive connector backend with OAuth 2.0 authentication.
-
-    This backend stores files at their actual paths in Google Drive, making it
-    user-scoped (each user has their own Drive access).
+    """Google Drive connector: PathAddressingEngine + DriveTransport composition.
 
     Features:
     - OAuth 2.0 authentication (per-user credentials)
-    - Direct path mapping (file.txt → file.txt in Drive)
+    - Direct path mapping (files stored at actual paths in Drive)
     - Google Workspace file export (Docs/Sheets/Slides)
-    - Folder hierarchy maintained
+    - Folder hierarchy maintained via DriveTransport
     - Automatic token refresh
     - Shared Drive support (optional)
-
-    Limitations:
-    - No automatic deduplication (Drive handles this)
-    - Requires OAuth tokens for each user
-    - Rate limited by Google Drive API quotas
     """
 
-    _BACKEND_FEATURES = OAUTH_BACKEND_FEATURES | frozenset(
+    _BACKEND_FEATURES: ClassVar[frozenset[BackendFeature]] = OAUTH_BACKEND_FEATURES | frozenset(
         {
             BackendFeature.SKILL_DOC,
             BackendFeature.WRITE_BACK,
@@ -188,6 +138,7 @@ class GoogleDriveConnectorBackend(
 
     user_scoped = True
 
+    # Connection arguments for registry-based instantiation
     CONNECTION_ARGS: dict[str, ConnectionArg] = {
         "token_manager_db": ConnectionArg(
             type=ArgType.PATH,
@@ -233,86 +184,96 @@ class GoogleDriveConnectorBackend(
         shared_drive_id: str | None = None,
         provider: str = "google-drive",
     ):
-        """
-        Initialize Google Drive connector backend.
-
-        Args:
-            token_manager_db: Path to TokenManager database (e.g., ~/.nexus/nexus.db)
-            user_email: Optional user email for OAuth lookup. If None, uses authenticated
-                       user from OperationContext (recommended for multi-user scenarios)
-            root_folder: Root folder name in Drive (default: "nexus-data")
-            use_shared_drives: Whether to use shared drives
-            shared_drive_id: Shared drive ID (if use_shared_drives=True)
-            provider: OAuth provider name from config (default: "google-drive")
-
-        Note:
-            For single-user scenarios (demos), set user_email explicitly.
-            For multi-user production, leave user_email=None to auto-detect from context.
-            This ensures each user accesses their own Drive.
-        """
+        # 1. Initialize OAuth (sets self.token_manager, self.provider, etc.)
         self._init_oauth(token_manager_db, user_email=user_email, provider=provider)
+
+        # 2. Create DriveTransport with the token manager
+        drive_transport = DriveTransport(
+            token_manager=self.token_manager,
+            provider=provider,
+            user_email=user_email,
+            root_folder=root_folder,
+            use_shared_drives=use_shared_drives,
+            shared_drive_id=shared_drive_id,
+        )
+        self._drive_transport = drive_transport
+
+        # 3. Initialize PathAddressingEngine (no prefix — key IS the path)
+        PathAddressingEngine.__init__(
+            self,
+            transport=drive_transport,
+            backend_name="gdrive",
+        )
+
+        # 4. Store config for check_connection and other uses
         self.root_folder = root_folder
         self.use_shared_drives = use_shared_drives
         self.shared_drive_id = shared_drive_id
 
-        # Register OAuth provider using factory (loads from config)
+        # 5. Register OAuth provider using factory
         self._register_oauth_provider()
 
-        # Cache for folder IDs (path -> Drive folder ID)
-        self._folder_cache: dict[str, str] = {}
+    # -- Properties --
 
-        # Lazy import Google Drive API (only when needed)
-        self._drive_service = None
+    @property
+    def has_token_manager(self) -> bool:
+        """GDrive connector manages OAuth tokens."""
+        return True
+
+    # -- OAuth provider registration --
+
+    _PROVIDER_ALIASES: dict[str, list[str]] = {
+        "google": ["gmail", "gcalendar", "google-drive", "google-cloud-storage"],
+    }
 
     def _register_oauth_provider(self) -> None:
-        """Register OAuth provider with TokenManager using OAuthProviderFactory."""
-        import logging
-        import traceback
-
-        logger = logging.getLogger(__name__)
-
         try:
-            import importlib as _il_oauth
+            import importlib as _il
 
-            OAuthProviderFactory = _il_oauth.import_module(
+            OAuthProviderFactory = _il.import_module(
                 "nexus.bricks.auth.oauth.factory"
             ).OAuthProviderFactory
 
-            # Create factory (loads from oauth.yaml config)
             factory = OAuthProviderFactory()
+            candidates = [self.provider]
+            backend_name = getattr(self, "name", "")
+            if backend_name and backend_name != self.provider:
+                candidates.append(backend_name)
+            for alias, targets in self._PROVIDER_ALIASES.items():
+                if self.provider == alias:
+                    candidates.extend(targets)
 
-            # Create provider instance from config
-            try:
-                provider_instance = factory.create_provider(
-                    name=self.provider,
-                )
-                # Register with TokenManager using the provider name from config
-                self.token_manager.register_provider(self.provider, provider_instance)
-                logger.info(
-                    f"✓ Registered OAuth provider '{self.provider}' for Google Drive backend"
-                )
-            except ValueError as e:
-                # Provider not found in config or credentials not set
-                logger.warning(
-                    f"OAuth provider '{self.provider}' not available: {e}. "
-                    "OAuth flow must be initiated manually via the Integrations page."
-                )
+            for candidate in candidates:
+                try:
+                    provider_instance = factory.create_provider(name=candidate)
+                    self.token_manager.register_provider(self.provider, provider_instance)
+                    logger.info(
+                        "Registered OAuth provider '%s' (resolved from '%s') for %s backend",
+                        candidate,
+                        self.provider,
+                        self.name,
+                    )
+                    return
+                except ValueError:
+                    continue
+
+            logger.warning(
+                "OAuth provider '%s' not available (tried: %s). "
+                "OAuth flow must be initiated manually via the Integrations page.",
+                self.provider,
+                ", ".join(candidates),
+            )
         except Exception as e:
-            error_msg = f"Failed to register OAuth provider: {e}\n{traceback.format_exc()}"
-            logger.error(error_msg)
+            logger.error("Failed to register OAuth provider: %s", e)
+
+    # =================================================================
+    # Health check
+    # =================================================================
 
     def check_connection(self, context: "OperationContext | None" = None) -> HandlerStatusResponse:
-        """
-        Verify Google Drive connection is healthy.
+        """Verify Google Drive connection is healthy.
 
         Checks that OAuth tokens are valid and the Drive API is accessible.
-        For user-scoped backends, this verifies the specific user's credentials.
-
-        Args:
-            context: Operation context with user_id for OAuth lookup
-
-        Returns:
-            HandlerStatusResponse with health status and latency
         """
         import time
 
@@ -332,7 +293,6 @@ class GoogleDriveConnectorBackend(
             )
 
         try:
-            # Check if we have a valid token
             from nexus.lib.sync_bridge import run_sync
 
             zone_id = (
@@ -340,8 +300,6 @@ class GoogleDriveConnectorBackend(
                 if context and hasattr(context, "zone_id") and context.zone_id
                 else "root"
             )
-
-            # Try to get a valid token (will refresh if needed)
             access_token = run_sync(
                 self.token_manager.get_valid_token(
                     provider=self.provider,
@@ -362,7 +320,7 @@ class GoogleDriveConnectorBackend(
                     },
                 )
 
-            # Optionally verify by calling Drive API (lightweight about() call)
+            # Verify by calling Drive API (lightweight about() call)
             try:
                 from google.oauth2.credentials import Credentials
                 from googleapiclient.discovery import build
@@ -405,327 +363,17 @@ class GoogleDriveConnectorBackend(
                 details={"backend": self.name, "user_email": user_email},
             )
 
-    @property
-    def name(self) -> str:
-        """Backend identifier name."""
-        return "gdrive"
+    # =================================================================
+    # Transport context binding
+    # =================================================================
 
-    # --- Capability flags ---
+    def _bind_transport(self, context: "OperationContext | None") -> None:
+        """Bind the transport to the current request context (OAuth token)."""
+        self._transport = self._drive_transport.with_context(context)
 
-    @property
-    def has_token_manager(self) -> bool:
-        """GDrive connector manages OAuth tokens."""
-        return True
-
-    def _get_drive_service(self, context: "OperationContext | None" = None) -> "Resource":
-        """Get Google Drive service with user's OAuth credentials.
-
-        Args:
-            context: Operation context (provides user_id if user_email not configured)
-
-        Returns:
-            Google Drive service instance
-
-        Raises:
-            BackendError: If credentials not found or user not authenticated
-        """
-        # Import here to avoid dependency if not using Drive
-        try:
-            from googleapiclient.discovery import build
-        except ImportError:
-            raise BackendError(
-                "google-api-python-client not installed. "
-                "Install with: pip install google-api-python-client",
-                backend="gdrive",
-            ) from None
-
-        # Determine which user's tokens to use
-        if self.user_email:
-            # Explicit user_email configured (single-user/demo mode)
-            user_email = self.user_email
-        elif context and context.user_id:
-            # Multi-user mode: use authenticated user from API key
-            user_email = context.user_id
-        else:
-            raise BackendError(
-                "Google Drive backend requires either configured user_email "
-                "or authenticated user in OperationContext",
-                backend="gdrive",
-            )
-
-        # Get valid access token from TokenManager (auto-refreshes if expired)
-        from nexus.lib.sync_bridge import run_sync
-
-        try:
-            # Default to 'root' zone if not specified to match mount configurations
-            zone_id = (
-                context.zone_id
-                if context and hasattr(context, "zone_id") and context.zone_id
-                else "root"
-            )
-            access_token = run_sync(
-                self.token_manager.get_valid_token(
-                    provider=self.provider,
-                    user_email=user_email,
-                    zone_id=zone_id,
-                )
-            )
-        except Exception as e:
-            raise BackendError(
-                f"Failed to get valid OAuth token for user {user_email}: {e}",
-                backend="gdrive",
-            ) from e
-
-        # Build Drive service with OAuth token
-        from google.oauth2.credentials import Credentials
-
-        creds = Credentials(token=access_token)
-        return build("drive", "v3", credentials=creds)
-
-    def _get_or_create_root_folder(
-        self,
-        service: "Resource",
-        context: "OperationContext | str | None",
-    ) -> str:
-        """Get or create root folder in Drive.
-
-        Args:
-            service: Google Drive service
-            context: Operation context
-
-        Returns:
-            Root folder ID
-
-        Raises:
-            BackendError: If folder operations fail
-        """
-        # Check cache first
-        if context is not None and not isinstance(context, str):
-            cache_key = f"root:{context.user_id}:{context.zone_id}"
-        else:
-            cache_key = "root::"
-
-        if cache_key in self._folder_cache:
-            return self._folder_cache[cache_key]
-
-        try:
-            # Search for existing root folder
-            query = f"name='{self.root_folder}' and mimeType='application/vnd.google-apps.folder' and trashed=false"
-
-            if self.use_shared_drives and self.shared_drive_id:
-                results = (
-                    service.files()
-                    .list(
-                        q=query,
-                        spaces="drive",
-                        fields="files(id, name)",
-                        corpora="drive",
-                        driveId=self.shared_drive_id,
-                        includeItemsFromAllDrives=True,
-                        supportsAllDrives=True,
-                    )
-                    .execute()
-                )
-            else:
-                results = (
-                    service.files()
-                    .list(q=query, spaces="drive", fields="files(id, name)")
-                    .execute()
-                )
-
-            files = results.get("files", [])
-
-            if files:
-                # Root folder exists
-                folder_id = str(files[0]["id"])
-            else:
-                # Create root folder
-                file_metadata: dict[str, Any] = {
-                    "name": self.root_folder,
-                    "mimeType": "application/vnd.google-apps.folder",
-                }
-
-                if self.use_shared_drives and self.shared_drive_id:
-                    file_metadata["parents"] = [self.shared_drive_id]
-
-                folder = (
-                    service.files()
-                    .create(body=file_metadata, fields="id", supportsAllDrives=True)
-                    .execute()
-                )
-                folder_id = str(folder["id"])
-                logger.info(f"Created root folder '{self.root_folder}' with ID: {folder_id}")
-
-            # Cache it
-            self._folder_cache[cache_key] = folder_id
-            return folder_id
-
-        except Exception as e:
-            raise BackendError(
-                f"Failed to get/create root folder '{self.root_folder}': {e}",
-                backend="gdrive",
-            ) from e
-
-    def _get_or_create_folder(
-        self,
-        service: "Resource",
-        path: str,
-        parent_id: str,
-        context: "OperationContext | str | None",
-    ) -> str:
-        """Get or create a folder by path.
-
-        Args:
-            service: Google Drive service
-            path: Folder path (relative to root)
-            parent_id: Parent folder ID
-            context: Operation context
-
-        Returns:
-            Folder ID
-
-        Raises:
-            BackendError: If folder operations fail
-        """
-        # Check cache
-        if isinstance(context, str):
-            # context is actually the parent_id in some calls
-            cache_key = f":{path}"
-        elif context is not None:
-            cache_key = f"{context.user_id}:{context.zone_id}:{path}"
-        else:
-            cache_key = f":{path}"
-
-        if cache_key in self._folder_cache:
-            return self._folder_cache[cache_key]
-
-        try:
-            # Search for existing folder
-            query = f"name='{path}' and '{parent_id}' in parents and mimeType='application/vnd.google-apps.folder' and trashed=false"
-
-            if self.use_shared_drives:
-                results = (
-                    service.files()
-                    .list(
-                        q=query,
-                        spaces="drive",
-                        fields="files(id, name)",
-                        includeItemsFromAllDrives=True,
-                        supportsAllDrives=True,
-                    )
-                    .execute()
-                )
-            else:
-                results = (
-                    service.files()
-                    .list(q=query, spaces="drive", fields="files(id, name)")
-                    .execute()
-                )
-
-            files = results.get("files", [])
-
-            if files:
-                folder_id = str(files[0]["id"])
-            else:
-                # Create folder
-                file_metadata: dict[str, Any] = {
-                    "name": path,
-                    "mimeType": "application/vnd.google-apps.folder",
-                    "parents": [parent_id],
-                }
-
-                folder = (
-                    service.files()
-                    .create(body=file_metadata, fields="id", supportsAllDrives=True)
-                    .execute()
-                )
-                folder_id = str(folder["id"])
-                logger.info(f"Created folder '{path}' with ID: {folder_id}")
-
-            # Cache it
-            self._folder_cache[cache_key] = folder_id
-            return folder_id
-
-        except Exception as e:
-            raise BackendError(
-                f"Failed to get/create folder '{path}': {e}", backend="gdrive"
-            ) from e
-
-    def _find_folder(
-        self,
-        service: "Resource",
-        name: str,
-        parent_id: str,
-    ) -> str | None:
-        """Find an existing folder by name under a parent (read-only, never creates).
-
-        Args:
-            service: Google Drive service
-            name: Folder name to find
-            parent_id: Parent folder ID
-
-        Returns:
-            Folder ID if found, None if not found
-        """
-        query = (
-            f"name='{name}' and '{parent_id}' in parents "
-            f"and mimeType='application/vnd.google-apps.folder' and trashed=false"
-        )
-        if self.use_shared_drives:
-            results = (
-                service.files()
-                .list(
-                    q=query,
-                    spaces="drive",
-                    fields="files(id, name)",
-                    includeItemsFromAllDrives=True,
-                    supportsAllDrives=True,
-                )
-                .execute()
-            )
-        else:
-            results = (
-                service.files().list(q=query, spaces="drive", fields="files(id, name)").execute()
-            )
-
-        files = results.get("files", [])
-        if files:
-            return str(files[0]["id"])
-        return None
-
-    def _resolve_path_to_folder_id(
-        self, service: "Resource", backend_path: str, context: "OperationContext | str | None"
-    ) -> tuple[str, str]:
-        """Resolve a backend path to parent folder ID and filename.
-
-        Args:
-            service: Google Drive service
-            backend_path: Backend path (e.g., "/workspace/data/file.txt")
-            context: Operation context
-
-        Returns:
-            Tuple of (parent_folder_id, filename)
-
-        Raises:
-            BackendError: If path resolution fails
-        """
-        # Get root folder
-        root_id = self._get_or_create_root_folder(service, context)
-
-        # Split path into parts
-        parts = backend_path.strip("/").split("/")
-        if not parts or parts == [""]:
-            raise BackendError("Invalid backend path", backend="gdrive", path=backend_path)
-
-        filename = parts[-1]
-        folder_parts = parts[:-1]
-
-        # Navigate to parent folder
-        parent_id = root_id
-        for folder_name in folder_parts:
-            parent_id = self._get_or_create_folder(service, folder_name, parent_id, context)
-
-        return parent_id, filename
+    # =================================================================
+    # Content operations — override PathAddressingEngine
+    # =================================================================
 
     def write_content(
         self,
@@ -735,21 +383,10 @@ class GoogleDriveConnectorBackend(
         offset: int = 0,
         context: "OperationContext | None" = None,
     ) -> WriteResult:
-        """
-        Write content to Google Drive and return its content hash.
+        """Write content to Google Drive.
 
-        For connector backends, this writes to a temporary location indexed by hash.
-        The actual file path is determined later via backend_path in context.
-
-        Args:
-            content: File content as bytes
-            context: Operation context with user_id and backend_path
-
-        Returns:
-            Content hash (SHA-256 as hex string)
-
-        Raises:
-            BackendError: If context is missing or write fails
+        Delegates to DriveTransport which handles folder resolution,
+        file upsert (create or update), and shared drive support.
         """
         if context is None or not hasattr(context, "backend_path") or context.backend_path is None:
             raise BackendError(
@@ -757,84 +394,20 @@ class GoogleDriveConnectorBackend(
                 backend="gdrive",
             )
 
-        backend_path = context.backend_path
+        self._bind_transport(context)
 
-        # Calculate content hash (BLAKE3, Rust-accelerated)
+        # Delegate to PathAddressingEngine which calls transport.store
+        super().write_content(content, content_id, offset=offset, context=context)
+
+        # Return hash-based result (Drive doesn't expose version IDs)
         content_hash = hash_content(content)
-
-        service = self._get_drive_service(context)
-
-        # Resolve path to parent folder and filename
-        parent_id, filename = self._resolve_path_to_folder_id(service, backend_path, context)
-
-        # Check if file already exists
-        query = f"name='{filename}' and '{parent_id}' in parents and trashed=false"
-
-        if self.use_shared_drives:
-            results = (
-                service.files()
-                .list(
-                    q=query,
-                    spaces="drive",
-                    fields="files(id, name)",
-                    includeItemsFromAllDrives=True,
-                    supportsAllDrives=True,
-                )
-                .execute()
-            )
-        else:
-            results = (
-                service.files().list(q=query, spaces="drive", fields="files(id, name)").execute()
-            )
-
-        files = results.get("files", [])
-
-        # Guess MIME type
-        mime_type, _ = mimetypes.guess_type(filename)
-        if mime_type is None:
-            mime_type = "application/octet-stream"
-
-        from googleapiclient.http import MediaIoBaseUpload
-
-        media = MediaIoBaseUpload(io.BytesIO(content), mimetype=mime_type, resumable=True)
-
-        if files:
-            # Update existing file
-            file_id = files[0]["id"]
-            service.files().update(
-                fileId=file_id, media_body=media, supportsAllDrives=True
-            ).execute()
-            logger.info(f"Updated file '{filename}' in Drive (ID: {file_id})")
-        else:
-            # Create new file
-            file_metadata = {"name": filename, "parents": [parent_id]}
-
-            file = (
-                service.files()
-                .create(body=file_metadata, media_body=media, fields="id", supportsAllDrives=True)
-                .execute()
-            )
-            file_id = file["id"]
-            logger.info(f"Created file '{filename}' in Drive (ID: {file_id})")
-
         return WriteResult(content_id=content_hash, version=content_hash, size=len(content))
 
     def read_content(self, content_id: str, context: "OperationContext | None" = None) -> bytes:
-        """
-        Read content from Google Drive by path (not hash).
+        """Read content from Google Drive by path.
 
-        For connector backends, content_hash is ignored - we use backend_path instead.
-
-        Args:
-            content_hash: Ignored for connector backends
-            context: Operation context with backend_path
-
-        Returns:
-            File content as bytes
-
-        Raises:
-            BackendError: If context is missing
-            NexusFileNotFoundError: If file does not exist at the given path
+        Binds transport to context for OAuth, then delegates to
+        PathAddressingEngine which calls transport.fetch.
         """
         if context is None or not hasattr(context, "backend_path") or context.backend_path is None:
             raise BackendError(
@@ -842,104 +415,14 @@ class GoogleDriveConnectorBackend(
                 backend="gdrive",
             )
 
-        backend_path = context.backend_path
-
-        service = self._get_drive_service(context)
-
-        # Resolve path to parent folder and filename
-        parent_id, filename = self._resolve_path_to_folder_id(service, backend_path, context)
-
-        # Find file by name in parent folder
-        query = f"name='{filename}' and '{parent_id}' in parents and trashed=false"
-
-        if self.use_shared_drives:
-            results = (
-                service.files()
-                .list(
-                    q=query,
-                    spaces="drive",
-                    fields="files(id, name, mimeType)",
-                    includeItemsFromAllDrives=True,
-                    supportsAllDrives=True,
-                )
-                .execute()
-            )
-        else:
-            results = (
-                service.files()
-                .list(q=query, spaces="drive", fields="files(id, name, mimeType)")
-                .execute()
-            )
-
-        files = results.get("files", [])
-
-        if not files:
-            raise NexusFileNotFoundError(backend_path)
-
-        file_id = files[0]["id"]
-        mime_type = files[0].get("mimeType", "")
-
-        # Check if it's a Google Workspace file
-        if mime_type in GOOGLE_MIME_TYPES:
-            # Export Google Workspace file
-            export_format = self._get_export_format(mime_type, filename)
-            request = service.files().export_media(fileId=file_id, mimeType=export_format)
-        else:
-            # Download regular file
-            request = service.files().get_media(fileId=file_id)
-
-        # Execute download
-        fh = io.BytesIO()
-        from googleapiclient.http import MediaIoBaseDownload
-
-        downloader = MediaIoBaseDownload(fh, request)
-        done = False
-        while not done:
-            status, done = downloader.next_chunk()
-
-        return fh.getvalue()
-
-    def _get_export_format(self, mime_type: str, filename: str) -> str:
-        """Get export MIME type for Google Workspace files.
-
-        Args:
-            mime_type: Google Workspace MIME type
-            filename: Filename (may contain format hint like .pdf, .docx)
-
-        Returns:
-            Export MIME type
-
-        Example:
-            >>> _get_export_format("application/vnd.google-apps.document", "report.pdf")
-            "application/pdf"
-        """
-        # Check if filename has export format hint
-        for ext, export_mime in EXPORT_FORMATS.get(mime_type, {}).items():
-            if filename.endswith(f".{ext}"):
-                return export_mime
-
-        # Default export formats
-        defaults = {
-            "application/vnd.google-apps.document": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",  # DOCX
-            "application/vnd.google-apps.spreadsheet": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",  # XLSX
-            "application/vnd.google-apps.presentation": "application/vnd.openxmlformats-officedocument.presentationml.presentation",  # PPTX
-        }
-
-        return defaults.get(mime_type, "application/pdf")
+        self._bind_transport(context)
+        return super().read_content(content_id, context)
 
     def delete_content(self, content_id: str, context: "OperationContext | None" = None) -> None:
-        """
-        Delete content from Google Drive by path.
+        """Delete content from Google Drive (move to trash).
 
-        For connector backends, content_hash is ignored - we use backend_path instead.
-
-        Args:
-            content_hash: Ignored for connector backends
-            context: Operation context with backend_path
-
-        Raises:
-            BackendError: If context is missing
-            NexusFileNotFoundError: If file does not exist at the given path
+        Binds transport to context for OAuth, then delegates to
+        PathAddressingEngine which calls transport.remove.
         """
         if context is None or not hasattr(context, "backend_path") or context.backend_path is None:
             raise BackendError(
@@ -947,122 +430,78 @@ class GoogleDriveConnectorBackend(
                 backend="gdrive",
             )
 
-        backend_path = context.backend_path
-
-        service = self._get_drive_service(context)
-
-        # Resolve path to parent folder and filename
-        parent_id, filename = self._resolve_path_to_folder_id(service, backend_path, context)
-
-        # Find file by name in parent folder
-        query = f"name='{filename}' and '{parent_id}' in parents and trashed=false"
-
-        if self.use_shared_drives:
-            results = (
-                service.files()
-                .list(
-                    q=query,
-                    spaces="drive",
-                    fields="files(id, name)",
-                    includeItemsFromAllDrives=True,
-                    supportsAllDrives=True,
-                )
-                .execute()
-            )
-        else:
-            results = (
-                service.files().list(q=query, spaces="drive", fields="files(id, name)").execute()
-            )
-
-        files = results.get("files", [])
-
-        if not files:
-            raise NexusFileNotFoundError(backend_path)
-
-        file_id = files[0]["id"]
-
-        # Move to trash
-        service.files().update(
-            fileId=file_id, body={"trashed": True}, supportsAllDrives=True
-        ).execute()
-
-        logger.info(f"Deleted file '{filename}' from Drive (ID: {file_id})")
+        self._bind_transport(context)
+        super().delete_content(content_id, context)
 
     def content_exists(self, content_id: str, context: "OperationContext | None" = None) -> bool:
-        """
-        Check if content exists in Google Drive by path.
-
-        For connector backends, content_hash is ignored - we use backend_path instead.
-
-        Args:
-            content_hash: Ignored for connector backends
-            context: Operation context with backend_path
-
-        Returns:
-            True if file exists, False otherwise
-        """
         if context is None or not hasattr(context, "backend_path"):
             return False
-
-        service = self._get_drive_service(context)
-
-        # Resolve path to parent folder and filename
-        parent_id, filename = self._resolve_path_to_folder_id(
-            service,
-            context.backend_path or "",
-            context,
-        )
-
-        # Find file by name in parent folder
-        query = f"name='{filename}' and '{parent_id}' in parents and trashed=false"
-
-        if self.use_shared_drives:
-            results = (
-                service.files()
-                .list(
-                    q=query,
-                    spaces="drive",
-                    fields="files(id)",
-                    includeItemsFromAllDrives=True,
-                    supportsAllDrives=True,
-                )
-                .execute()
-            )
-        else:
-            results = service.files().list(q=query, spaces="drive", fields="files(id)").execute()
-
-        files = results.get("files", [])
-
-        return len(files) > 0
+        self._bind_transport(context)
+        return super().content_exists(content_id, context)
 
     def get_content_size(self, content_id: str, context: "OperationContext | None" = None) -> int:
-        """Get content size from Google Drive.
+        if context is None or not hasattr(context, "backend_path"):
+            raise BackendError(
+                "Google Drive connector requires OperationContext with backend_path",
+                backend="gdrive",
+            )
+        self._bind_transport(context)
+        return super().get_content_size(content_id, context)
 
-        Args:
-            content_hash: Content hash (file ID in Drive)
-            context: Operation context (optional)
+    # =================================================================
+    # Directory operations — override for Drive folder semantics
+    # =================================================================
 
-        Returns:
-            Content size in bytes
+    def is_directory(self, path: str, context: "OperationContext | None" = None) -> bool:
+        """Check if path is a directory (folder) in Google Drive.
 
-        Raises:
-            NexusFileNotFoundError: If file does not exist
+        Uses DriveTransport.is_folder() which resolves the path through
+        the folder hierarchy.
+        """
+        bound = self._drive_transport.with_context(context)
+        return bound.is_folder(path)
+
+    def list_dir(self, path: str, context: "OperationContext | None" = None) -> list[str]:
+        """List directory contents from Google Drive.
+
+        Returns file names and folder names (with trailing '/').
         """
         try:
-            service = self._get_drive_service(context)
-            file_metadata = service.files().get(fileId=content_id, fields="size").execute()
+            path = path.strip("/")
+            self._bind_transport(context)
 
-            size = file_metadata.get("size")
-            if size is None:
-                # Google Workspace files don't have size
-                size = 0
+            blob_keys, common_prefixes = self._transport.list_keys(prefix=path, delimiter="/")
 
-            return int(size)
+            # Build entry list: folder names with trailing /, file names without
+            entries: list[str] = []
+            path_prefix = f"{path}/" if path else ""
 
-        except Exception as e:
-            if "File not found" in str(e):
-                raise NexusFileNotFoundError(content_id) from e
+            for prefix_path in common_prefixes:
+                name = (
+                    prefix_path[len(path_prefix) :].rstrip("/")
+                    if path_prefix
+                    else prefix_path.rstrip("/")
+                )
+                if name:
+                    entries.append(name + "/")
+
+            for blob_key in blob_keys:
+                name = blob_key[len(path_prefix) :] if path_prefix else blob_key
+                if name:
+                    entries.append(name)
+
+            return sorted(entries)
+
+        except FileNotFoundError:
             raise
+        except Exception as e:
+            if "not found" in str(e).lower():
+                raise FileNotFoundError(f"Directory not found: {path}") from e
+            raise BackendError(
+                f"Failed to list directory {path}: {e}",
+                backend="gdrive",
+                path=path,
+            ) from e
 
     def mkdir(
         self,
@@ -1073,85 +512,26 @@ class GoogleDriveConnectorBackend(
     ) -> None:
         """Create directory in Google Drive.
 
-        Args:
-            path: Directory path relative to backend root
-            parents: Create parent directories if needed
-            exist_ok: Don't raise error if directory exists
-            context: Operation context
-
-        Raises:
-            BackendError: If context is missing or directory already exists (when exist_ok=False)
-            NexusFileNotFoundError: If parent directory does not exist (when parents=False)
+        Delegates folder creation to DriveTransport.mkdir_path().
         """
         path = path.strip("/")
         if not path:
-            # Root always exists
-            return None
+            return
 
-        if context is None:
-            raise BackendError(
-                "Google Drive connector mkdir requires OperationContext",
-                backend="gdrive",
-            )
+        self._bind_transport(context)
 
-        service = self._get_drive_service(context)
-        root_folder_id = self._get_or_create_root_folder(service, context)
+        bound = self._drive_transport.with_context(context)
 
-        # Check if folder exists
-        if self.is_directory(path):
+        # Check if folder already exists
+        if bound.is_folder(path):
             if not exist_ok:
                 raise BackendError(
                     f"Directory already exists: {path}",
                     backend="gdrive",
                 )
-            return None
+            return
 
-        # Navigate through path components to create folder hierarchy
-        parts = path.split("/")
-        parent_id = root_folder_id
-
-        for i, folder_name in enumerate(parts):
-            if not folder_name:
-                continue
-
-            # Check if this is the last component (the folder we want to create)
-            is_last = i == len(parts) - 1
-
-            if not is_last:
-                # Intermediate folder - create if parents=True, otherwise fail if missing
-                if parents:
-                    parent_id = self._get_or_create_folder(service, folder_name, parent_id, context)
-                else:
-                    # Try to get existing folder
-                    query = f"name='{folder_name}' and '{parent_id}' in parents and mimeType='application/vnd.google-apps.folder' and trashed=false"
-                    if self.use_shared_drives:
-                        results = (
-                            service.files()
-                            .list(
-                                q=query,
-                                spaces="drive",
-                                fields="files(id)",
-                                includeItemsFromAllDrives=True,
-                                supportsAllDrives=True,
-                            )
-                            .execute()
-                        )
-                    else:
-                        results = (
-                            service.files()
-                            .list(q=query, spaces="drive", fields="files(id)")
-                            .execute()
-                        )
-
-                    files = results.get("files", [])
-                    if not files:
-                        raise NexusFileNotFoundError("/".join(parts[: i + 1]))
-                    parent_id = files[0]["id"]
-            else:
-                # Last folder - create it
-                parent_id = self._get_or_create_folder(service, folder_name, parent_id, context)
-
-        return None
+        bound.mkdir_path(path, parents=parents)
 
     def rmdir(
         self,
@@ -1159,221 +539,9 @@ class GoogleDriveConnectorBackend(
         recursive: bool = False,
         context: "OperationContext | None" = None,
     ) -> None:
-        """Remove directory from Google Drive.
+        """Remove directory from Google Drive (move to trash).
 
-        Args:
-            path: Directory path
-            recursive: Remove non-empty directory (moves to trash)
-            context: Operation context (not used, authentication handled internally)
-
-        Raises:
-            BackendError: If trying to remove root or non-empty directory
-            NexusFileNotFoundError: If directory does not exist
+        Delegates to DriveTransport.remove_folder().
         """
-        path = path.strip("/")
-        if not path:
-            raise BackendError(
-                "Cannot remove root directory",
-                backend="gdrive",
-            )
-
-        service = self._get_drive_service(None)
-        root_folder_id = self._get_or_create_root_folder(service, None)
-
-        # Navigate path to resolve the target folder ID (read-only)
-        parts = path.split("/")
-        current_id = root_folder_id
-        for part in parts:
-            if not part:
-                continue
-            found_id = self._find_folder(service, part, current_id)
-            if found_id is None:
-                raise NexusFileNotFoundError(path)
-            current_id = found_id
-        folder_id = current_id
-
-        if not recursive:
-            # Check if directory is empty
-            query = f"'{folder_id}' in parents and trashed=false"
-            results = service.files().list(q=query, fields="files(id)", pageSize=1).execute()
-            if results.get("files", []):
-                raise BackendError(
-                    f"Directory not empty: {path}",
-                    backend="gdrive",
-                )
-
-        # Move to trash (Google Drive doesn't permanently delete immediately)
-        service.files().update(fileId=folder_id, body={"trashed": True}).execute()
-
-    def is_directory(self, path: str, context: "OperationContext | None" = None) -> bool:
-        """Check if path is a directory in Google Drive.
-
-        Args:
-            path: Path to check
-
-        Returns:
-            True if path is a folder, False otherwise
-        """
-        try:
-            path = path.strip("/")
-            if not path:
-                # Root is always a directory
-                return True
-
-            service = self._get_drive_service(None)
-            root_folder_id = self._get_or_create_root_folder(service, None)
-
-            # Split path into parent and target name
-            parts = path.split("/")
-            target_name = parts[-1]
-            parent_parts = parts[:-1]
-
-            # Navigate to parent folder (without creating missing folders)
-            parent_id = root_folder_id
-            for part in parent_parts:
-                if not part:
-                    continue
-
-                # Try to find existing folder (don't create it)
-                query = f"name='{part}' and '{parent_id}' in parents and mimeType='application/vnd.google-apps.folder' and trashed=false"
-                if self.use_shared_drives:
-                    results = (
-                        service.files()
-                        .list(
-                            q=query,
-                            spaces="drive",
-                            fields="files(id)",
-                            includeItemsFromAllDrives=True,
-                            supportsAllDrives=True,
-                        )
-                        .execute()
-                    )
-                else:
-                    results = (
-                        service.files().list(q=query, spaces="drive", fields="files(id)").execute()
-                    )
-
-                files = results.get("files", [])
-                if not files:
-                    # Parent doesn't exist, so path doesn't exist
-                    return False
-                parent_id = files[0]["id"]
-
-            # Check if target exists as a folder
-            query = f"name='{target_name}' and '{parent_id}' in parents and mimeType='application/vnd.google-apps.folder' and trashed=false"
-
-            if self.use_shared_drives:
-                results = (
-                    service.files()
-                    .list(
-                        q=query,
-                        spaces="drive",
-                        fields="files(id)",
-                        includeItemsFromAllDrives=True,
-                        supportsAllDrives=True,
-                    )
-                    .execute()
-                )
-            else:
-                results = (
-                    service.files().list(q=query, spaces="drive", fields="files(id)").execute()
-                )
-
-            files = results.get("files", [])
-
-            return len(files) > 0
-
-        except Exception:
-            # On API errors, return False (can't verify = treat as not a directory)
-            return False
-
-    def list_dir(self, path: str, context: "OperationContext | None" = None) -> list[str]:
-        """
-        List directory contents from Google Drive.
-
-        Args:
-            path: Directory path to list (relative to backend root)
-            context: Operation context for authentication
-
-        Returns:
-            List of entry names (directories have trailing '/')
-
-        Raises:
-            FileNotFoundError: If directory doesn't exist
-            BackendError: If operation fails
-        """
-        try:
-            path = path.strip("/")
-
-            service = self._get_drive_service(context)
-            root_folder_id = self._get_or_create_root_folder(service, context)
-
-            # Navigate to target folder (read-only — never create missing folders)
-            if path:
-                # Split path and navigate
-                parts = path.split("/")
-                current_folder_id = root_folder_id
-                for part in parts:
-                    if not part:
-                        continue
-                    found_id = self._find_folder(service, part, current_folder_id)
-                    if found_id is None:
-                        raise FileNotFoundError(f"Directory not found: {path}")
-                    current_folder_id = found_id
-                folder_id = current_folder_id
-            else:
-                # List root folder
-                folder_id = root_folder_id
-
-            # Query all files/folders in this directory
-            query = f"'{folder_id}' in parents and trashed=false"
-
-            if self.use_shared_drives:
-                results = (
-                    service.files()
-                    .list(
-                        q=query,
-                        spaces="drive",
-                        fields="files(id, name, mimeType)",
-                        includeItemsFromAllDrives=True,
-                        supportsAllDrives=True,
-                        pageSize=1000,
-                    )
-                    .execute()
-                )
-            else:
-                results = (
-                    service.files()
-                    .list(
-                        q=query,
-                        spaces="drive",
-                        fields="files(id, name, mimeType)",
-                        pageSize=1000,
-                    )
-                    .execute()
-                )
-
-            files = results.get("files", [])
-
-            # Build list of entries
-            entries = []
-            for file in files:
-                name = file["name"]
-                mime_type = file.get("mimeType", "")
-
-                # Add trailing '/' for folders
-                if mime_type == "application/vnd.google-apps.folder":
-                    entries.append(name + "/")
-                else:
-                    entries.append(name)
-
-            return sorted(entries)
-
-        except Exception as e:
-            if "not found" in str(e).lower():
-                raise FileNotFoundError(f"Directory not found: {path}") from e
-            raise BackendError(
-                f"Failed to list directory {path}: {e}",
-                backend="gdrive",
-                path=path,
-            ) from e
+        bound = self._drive_transport.with_context(context)
+        bound.remove_folder(path, recursive=recursive)

--- a/src/nexus/backends/connectors/gdrive/transport.py
+++ b/src/nexus/backends/connectors/gdrive/transport.py
@@ -1,0 +1,821 @@
+"""Google Drive Transport — raw key→bytes I/O over the Drive API.
+
+Implements the Transport protocol for Google Drive, mapping:
+- store(key, data) → files.create / files.update (upsert by path)
+- fetch(key) → files.get_media / files.export_media → bytes
+- remove(key) → files.update(trashed=True)
+- list_keys(prefix) → files.list in resolved folder
+- exists(key) → files.list(q=name+parent)
+- get_size(key) → files.get(fields="size")
+
+Read-write: supports upload, download, delete, and directory operations.
+
+Auth: DriveTransport carries a TokenManager + provider.  Before each
+request the caller must bind an OperationContext via ``with_context()``
+so the transport can resolve the per-user OAuth token.
+
+Key schema (paths relative to root_folder):
+    "workspace/data/file.txt"   → file.txt in workspace/data/ folder
+    "report.pdf"                → report.pdf in root folder
+    list_keys("")               → root folder contents
+    list_keys("workspace/")     → workspace folder contents
+"""
+
+from __future__ import annotations
+
+import io
+import logging
+import mimetypes
+from collections.abc import Iterator
+from copy import copy
+from typing import TYPE_CHECKING, Any
+
+from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
+
+if TYPE_CHECKING:
+    from googleapiclient.discovery import Resource
+
+    from nexus.contracts.types import OperationContext
+
+logger = logging.getLogger(__name__)
+
+# Suppress noisy discovery-cache warnings from google-api-python-client.
+logging.getLogger("googleapiclient.discovery_cache").setLevel(logging.ERROR)
+
+
+# ---------------------------------------------------------------------------
+# Google Drive MIME type constants (Drive API concerns)
+# ---------------------------------------------------------------------------
+
+GOOGLE_MIME_TYPES = {
+    "application/vnd.google-apps.document": "Google Docs",
+    "application/vnd.google-apps.spreadsheet": "Google Sheets",
+    "application/vnd.google-apps.presentation": "Google Slides",
+    "application/vnd.google-apps.drawing": "Google Drawings",
+    "application/vnd.google-apps.form": "Google Forms",
+    "application/vnd.google-apps.folder": "Folder",
+}
+
+# Export formats for Google Workspace files
+EXPORT_FORMATS = {
+    "application/vnd.google-apps.document": {
+        "pdf": "application/pdf",
+        "docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+        "odt": "application/vnd.oasis.opendocument.text",
+        "html": "text/html",
+        "txt": "text/plain",
+        "markdown": "text/markdown",
+    },
+    "application/vnd.google-apps.spreadsheet": {
+        "pdf": "application/pdf",
+        "xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+        "ods": "application/vnd.oasis.opendocument.spreadsheet",
+        "csv": "text/csv",
+        "tsv": "text/tab-separated-values",
+    },
+    "application/vnd.google-apps.presentation": {
+        "pdf": "application/pdf",
+        "pptx": "application/vnd.openxmlformats-officedocument.presentationml.presentation",
+        "odp": "application/vnd.oasis.opendocument.presentation",
+        "txt": "text/plain",
+    },
+}
+
+
+class DriveTransport:
+    """Google Drive API transport implementing the Transport protocol.
+
+    Attributes:
+        transport_name: ``"gdrive"`` -- used by PathAddressingEngine to build
+            the backend name (``"path-gdrive"``).
+    """
+
+    transport_name: str = "gdrive"
+
+    def __init__(
+        self,
+        token_manager: Any,
+        provider: str = "google-drive",
+        user_email: str | None = None,
+        root_folder: str = "nexus-data",
+        use_shared_drives: bool = False,
+        shared_drive_id: str | None = None,
+    ) -> None:
+        self._token_manager = token_manager
+        self._provider = provider
+        self._user_email = user_email
+        self._root_folder = root_folder
+        self._use_shared_drives = use_shared_drives
+        self._shared_drive_id = shared_drive_id
+        self._context: OperationContext | None = None
+
+        # Cache for folder IDs (cache_key -> Drive folder ID)
+        self._folder_cache: dict[str, str] = {}
+
+    # ------------------------------------------------------------------
+    # Context binding (not part of Transport protocol; Drive-specific)
+    # ------------------------------------------------------------------
+
+    def with_context(self, context: OperationContext | None) -> DriveTransport:
+        """Return a shallow copy bound to *context* (for OAuth token resolution)."""
+        clone = copy(self)
+        clone._context = context
+        # Share folder cache across clones for efficiency
+        clone._folder_cache = self._folder_cache
+        return clone
+
+    # ------------------------------------------------------------------
+    # Internal helpers — OAuth / service building
+    # ------------------------------------------------------------------
+
+    def _get_drive_service(self) -> Resource:
+        """Build an authenticated Drive v3 ``Resource`` using the bound context."""
+        try:
+            from googleapiclient.discovery import build
+        except ImportError:
+            raise BackendError(
+                "google-api-python-client not installed. "
+                "Install with: pip install google-api-python-client",
+                backend="gdrive",
+            ) from None
+
+        # Resolve user email
+        if self._user_email:
+            user_email = self._user_email
+        elif self._context and self._context.user_id:
+            user_email = self._context.user_id
+        else:
+            raise BackendError(
+                "Google Drive transport requires either configured user_email "
+                "or authenticated user in OperationContext",
+                backend="gdrive",
+            )
+
+        from nexus.lib.sync_bridge import run_sync
+
+        try:
+            zone_id = (
+                self._context.zone_id
+                if self._context and hasattr(self._context, "zone_id") and self._context.zone_id
+                else "root"
+            )
+            access_token = run_sync(
+                self._token_manager.get_valid_token(
+                    provider=self._provider,
+                    user_email=user_email,
+                    zone_id=zone_id,
+                )
+            )
+        except Exception as e:
+            raise BackendError(
+                f"Failed to get valid OAuth token for user {user_email}: {e}",
+                backend="gdrive",
+            ) from e
+
+        from google.oauth2.credentials import Credentials
+
+        creds = Credentials(token=access_token)
+        return build("drive", "v3", credentials=creds)
+
+    # ------------------------------------------------------------------
+    # Internal helpers — folder resolution
+    # ------------------------------------------------------------------
+
+    def _list_files(
+        self,
+        service: Resource,
+        query: str,
+        fields: str = "files(id, name)",
+        page_size: int = 1000,
+    ) -> list[dict[str, Any]]:
+        """Execute files.list with shared drive support."""
+        if self._use_shared_drives and self._shared_drive_id:
+            results = (
+                service.files()
+                .list(
+                    q=query,
+                    spaces="drive",
+                    fields=fields,
+                    corpora="drive",
+                    driveId=self._shared_drive_id,
+                    includeItemsFromAllDrives=True,
+                    supportsAllDrives=True,
+                    pageSize=page_size,
+                )
+                .execute()
+            )
+        elif self._use_shared_drives:
+            results = (
+                service.files()
+                .list(
+                    q=query,
+                    spaces="drive",
+                    fields=fields,
+                    includeItemsFromAllDrives=True,
+                    supportsAllDrives=True,
+                    pageSize=page_size,
+                )
+                .execute()
+            )
+        else:
+            results = (
+                service.files()
+                .list(
+                    q=query,
+                    spaces="drive",
+                    fields=fields,
+                    pageSize=page_size,
+                )
+                .execute()
+            )
+        return list(results.get("files", []))
+
+    def _get_or_create_root_folder(self, service: Resource) -> str:
+        """Get or create root folder in Drive.
+
+        Returns:
+            Root folder ID
+        """
+        # Build cache key from context
+        if self._context is not None and hasattr(self._context, "user_id"):
+            zone_id = getattr(self._context, "zone_id", "") or ""
+            cache_key = f"root:{self._context.user_id}:{zone_id}"
+        else:
+            cache_key = "root::"
+
+        if cache_key in self._folder_cache:
+            return self._folder_cache[cache_key]
+
+        try:
+            query = (
+                f"name='{self._root_folder}' "
+                f"and mimeType='application/vnd.google-apps.folder' "
+                f"and trashed=false"
+            )
+            files = self._list_files(service, query)
+
+            if files:
+                folder_id = str(files[0]["id"])
+            else:
+                # Create root folder
+                file_metadata: dict[str, Any] = {
+                    "name": self._root_folder,
+                    "mimeType": "application/vnd.google-apps.folder",
+                }
+                if self._use_shared_drives and self._shared_drive_id:
+                    file_metadata["parents"] = [self._shared_drive_id]
+
+                folder = (
+                    service.files()
+                    .create(body=file_metadata, fields="id", supportsAllDrives=True)
+                    .execute()
+                )
+                folder_id = str(folder["id"])
+                logger.info("Created root folder '%s' with ID: %s", self._root_folder, folder_id)
+
+            self._folder_cache[cache_key] = folder_id
+            return folder_id
+
+        except Exception as e:
+            raise BackendError(
+                f"Failed to get/create root folder '{self._root_folder}': {e}",
+                backend="gdrive",
+            ) from e
+
+    def _get_or_create_folder(
+        self,
+        service: Resource,
+        name: str,
+        parent_id: str,
+    ) -> str:
+        """Get or create a folder by name under parent_id.
+
+        Returns:
+            Folder ID
+        """
+        if self._context is not None and hasattr(self._context, "user_id"):
+            zone_id = getattr(self._context, "zone_id", "") or ""
+            cache_key = f"{self._context.user_id}:{zone_id}:{parent_id}/{name}"
+        else:
+            cache_key = f"::{parent_id}/{name}"
+
+        if cache_key in self._folder_cache:
+            return self._folder_cache[cache_key]
+
+        try:
+            query = (
+                f"name='{name}' and '{parent_id}' in parents "
+                f"and mimeType='application/vnd.google-apps.folder' "
+                f"and trashed=false"
+            )
+            files = self._list_files(service, query)
+
+            if files:
+                folder_id = str(files[0]["id"])
+            else:
+                file_metadata: dict[str, Any] = {
+                    "name": name,
+                    "mimeType": "application/vnd.google-apps.folder",
+                    "parents": [parent_id],
+                }
+                folder = (
+                    service.files()
+                    .create(body=file_metadata, fields="id", supportsAllDrives=True)
+                    .execute()
+                )
+                folder_id = str(folder["id"])
+                logger.info("Created folder '%s' with ID: %s", name, folder_id)
+
+            self._folder_cache[cache_key] = folder_id
+            return folder_id
+
+        except Exception as e:
+            raise BackendError(
+                f"Failed to get/create folder '{name}': {e}",
+                backend="gdrive",
+            ) from e
+
+    def _find_folder(
+        self,
+        service: Resource,
+        name: str,
+        parent_id: str,
+    ) -> str | None:
+        """Find an existing folder by name under parent (read-only, never creates).
+
+        Returns:
+            Folder ID if found, None otherwise.
+        """
+        query = (
+            f"name='{name}' and '{parent_id}' in parents "
+            f"and mimeType='application/vnd.google-apps.folder' and trashed=false"
+        )
+        files = self._list_files(service, query)
+        if files:
+            return str(files[0]["id"])
+        return None
+
+    def _resolve_path_to_folder_id(
+        self,
+        service: Resource,
+        path: str,
+        *,
+        create_parents: bool = True,
+    ) -> tuple[str, str]:
+        """Resolve a path to (parent_folder_id, filename).
+
+        Args:
+            service: Drive API service
+            path: Path relative to root (e.g. "workspace/data/file.txt")
+            create_parents: If True, create missing parent folders; if False,
+                raise NexusFileNotFoundError on missing parents.
+
+        Returns:
+            Tuple of (parent_folder_id, filename)
+        """
+        root_id = self._get_or_create_root_folder(service)
+
+        parts = path.strip("/").split("/")
+        if not parts or parts == [""]:
+            raise BackendError("Invalid path", backend="gdrive", path=path)
+
+        filename = parts[-1]
+        folder_parts = parts[:-1]
+
+        parent_id = root_id
+        for folder_name in folder_parts:
+            if create_parents:
+                parent_id = self._get_or_create_folder(service, folder_name, parent_id)
+            else:
+                found = self._find_folder(service, folder_name, parent_id)
+                if found is None:
+                    raise NexusFileNotFoundError(
+                        path="/".join(parts[: folder_parts.index(folder_name) + 1]),
+                    )
+                parent_id = found
+
+        return parent_id, filename
+
+    def _find_file_in_parent(
+        self,
+        service: Resource,
+        filename: str,
+        parent_id: str,
+        fields: str = "files(id, name)",
+    ) -> list[dict[str, Any]]:
+        """Find files by name in a parent folder."""
+        query = f"name='{filename}' and '{parent_id}' in parents and trashed=false"
+        return self._list_files(service, query, fields=fields)
+
+    # ------------------------------------------------------------------
+    # Internal helpers — export format detection
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _get_export_format(mime_type: str, filename: str) -> str:
+        """Get export MIME type for Google Workspace files.
+
+        Checks filename extension for format hints, falls back to defaults.
+        """
+        for ext, export_mime in EXPORT_FORMATS.get(mime_type, {}).items():
+            if filename.endswith(f".{ext}"):
+                return export_mime
+
+        defaults = {
+            "application/vnd.google-apps.document": (
+                "application/vnd.openxmlformats-officedocument.wordprocessingml.document"
+            ),
+            "application/vnd.google-apps.spreadsheet": (
+                "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet"
+            ),
+            "application/vnd.google-apps.presentation": (
+                "application/vnd.openxmlformats-officedocument.presentationml.presentation"
+            ),
+        }
+        return defaults.get(mime_type, "application/pdf")
+
+    def _download_file(
+        self, service: Resource, file_id: str, mime_type: str, filename: str
+    ) -> bytes:
+        """Download a file from Drive, handling Google Workspace export."""
+        if mime_type in GOOGLE_MIME_TYPES:
+            export_format = self._get_export_format(mime_type, filename)
+            request = service.files().export_media(fileId=file_id, mimeType=export_format)
+        else:
+            request = service.files().get_media(fileId=file_id)
+
+        from googleapiclient.http import MediaIoBaseDownload
+
+        fh = io.BytesIO()
+        downloader = MediaIoBaseDownload(fh, request)
+        done = False
+        while not done:
+            _status, done = downloader.next_chunk()
+
+        return fh.getvalue()
+
+    # ------------------------------------------------------------------
+    # Transport protocol methods
+    # ------------------------------------------------------------------
+
+    def store(self, key: str, data: bytes, content_type: str = "") -> str | None:
+        """Upload or update a file in Drive.
+
+        - If a file with the same name exists in the parent folder, it is updated.
+        - Otherwise a new file is created.
+
+        Returns:
+            None (Drive does not expose version IDs in this flow).
+        """
+        service = self._get_drive_service()
+        parent_id, filename = self._resolve_path_to_folder_id(service, key, create_parents=True)
+
+        # Check if file already exists
+        existing = self._find_file_in_parent(service, filename, parent_id)
+
+        # Determine MIME type
+        mime_type = content_type or mimetypes.guess_type(filename)[0] or "application/octet-stream"
+
+        from googleapiclient.http import MediaIoBaseUpload
+
+        media = MediaIoBaseUpload(io.BytesIO(data), mimetype=mime_type, resumable=True)
+
+        if existing:
+            file_id = existing[0]["id"]
+            service.files().update(
+                fileId=file_id, media_body=media, supportsAllDrives=True
+            ).execute()
+            logger.info("Updated file '%s' in Drive (ID: %s)", filename, file_id)
+        else:
+            file_metadata: dict[str, Any] = {"name": filename, "parents": [parent_id]}
+            result = (
+                service.files()
+                .create(body=file_metadata, media_body=media, fields="id", supportsAllDrives=True)
+                .execute()
+            )
+            file_id = result["id"]
+            logger.info("Created file '%s' in Drive (ID: %s)", filename, file_id)
+
+        return None
+
+    def fetch(self, key: str, version_id: str | None = None) -> tuple[bytes, str | None]:
+        """Download a file from Drive by path.
+
+        Returns:
+            (content_bytes, None) -- Drive transport does not track versions.
+        """
+        service = self._get_drive_service()
+        parent_id, filename = self._resolve_path_to_folder_id(service, key, create_parents=False)
+
+        files = self._find_file_in_parent(
+            service, filename, parent_id, fields="files(id, name, mimeType)"
+        )
+        if not files:
+            raise NexusFileNotFoundError(key)
+
+        file_id = files[0]["id"]
+        mime_type = files[0].get("mimeType", "")
+
+        content = self._download_file(service, file_id, mime_type, filename)
+        return content, None
+
+    def remove(self, key: str) -> None:
+        """Move a file to trash in Drive."""
+        service = self._get_drive_service()
+        parent_id, filename = self._resolve_path_to_folder_id(service, key, create_parents=False)
+
+        files = self._find_file_in_parent(service, filename, parent_id)
+        if not files:
+            raise NexusFileNotFoundError(key)
+
+        file_id = files[0]["id"]
+        service.files().update(
+            fileId=file_id, body={"trashed": True}, supportsAllDrives=True
+        ).execute()
+        logger.info("Deleted file '%s' from Drive (ID: %s)", filename, file_id)
+
+    def exists(self, key: str) -> bool:
+        """Check whether a file exists at the given path in Drive."""
+        try:
+            service = self._get_drive_service()
+            parent_id, filename = self._resolve_path_to_folder_id(
+                service, key, create_parents=False
+            )
+            files = self._find_file_in_parent(service, filename, parent_id, fields="files(id)")
+            return len(files) > 0
+        except (NexusFileNotFoundError, BackendError):
+            return False
+        except Exception:
+            return False
+
+    def get_size(self, key: str) -> int:
+        """Return file size in bytes.
+
+        Note: Google Workspace files (Docs/Sheets/Slides) report size=0.
+        """
+        try:
+            service = self._get_drive_service()
+            parent_id, filename = self._resolve_path_to_folder_id(
+                service, key, create_parents=False
+            )
+            files = self._find_file_in_parent(
+                service, filename, parent_id, fields="files(id, size)"
+            )
+            if not files:
+                raise NexusFileNotFoundError(key)
+
+            size = files[0].get("size")
+            return int(size) if size is not None else 0
+
+        except NexusFileNotFoundError:
+            raise
+        except Exception as e:
+            raise NexusFileNotFoundError(key) from e
+
+    def list_keys(self, prefix: str, delimiter: str = "/") -> tuple[list[str], list[str]]:
+        """List files and folders under *prefix*.
+
+        - ``list_keys("")`` -> contents of root folder
+        - ``list_keys("workspace/")`` -> contents of workspace folder
+
+        Returns:
+            ``(blob_keys, common_prefixes)`` where folders are common_prefixes
+            with trailing ``/``, and files are blob_keys with full relative path.
+        """
+        service = self._get_drive_service()
+        prefix = prefix.strip("/")
+
+        # Resolve prefix to folder ID
+        if not prefix:
+            folder_id = self._get_or_create_root_folder(service)
+            path_prefix = ""
+        else:
+            root_id = self._get_or_create_root_folder(service)
+            parts = prefix.split("/")
+            current_id = root_id
+            for part in parts:
+                if not part:
+                    continue
+                found = self._find_folder(service, part, current_id)
+                if found is None:
+                    # Folder doesn't exist — return empty
+                    return [], []
+                current_id = found
+            folder_id = current_id
+            path_prefix = prefix + "/"
+
+        # Query all files/folders in this directory
+        query = f"'{folder_id}' in parents and trashed=false"
+        files = self._list_files(service, query, fields="files(id, name, mimeType)", page_size=1000)
+
+        blob_keys: list[str] = []
+        common_prefixes: list[str] = []
+
+        for file_entry in files:
+            name = file_entry["name"]
+            file_mime = file_entry.get("mimeType", "")
+
+            if file_mime == "application/vnd.google-apps.folder":
+                common_prefixes.append(f"{path_prefix}{name}/")
+            else:
+                blob_keys.append(f"{path_prefix}{name}")
+
+        return sorted(blob_keys), sorted(common_prefixes)
+
+    def copy_key(self, src_key: str, dst_key: str) -> None:
+        """Copy a file within Drive (server-side copy)."""
+        service = self._get_drive_service()
+
+        # Resolve source
+        src_parent_id, src_filename = self._resolve_path_to_folder_id(
+            service, src_key, create_parents=False
+        )
+        src_files = self._find_file_in_parent(service, src_filename, src_parent_id)
+        if not src_files:
+            raise NexusFileNotFoundError(src_key)
+
+        src_file_id = src_files[0]["id"]
+
+        # Resolve destination (create parent folders if needed)
+        dst_parent_id, dst_filename = self._resolve_path_to_folder_id(
+            service, dst_key, create_parents=True
+        )
+
+        # Perform server-side copy
+        copy_metadata: dict[str, Any] = {
+            "name": dst_filename,
+            "parents": [dst_parent_id],
+        }
+        service.files().copy(
+            fileId=src_file_id,
+            body=copy_metadata,
+            supportsAllDrives=True,
+        ).execute()
+
+    def create_dir(self, key: str) -> None:
+        """Create a folder in Drive.
+
+        The *key* should be a path like ``"workspace/reports/"``.
+        """
+        path = key.rstrip("/")
+        if not path:
+            return
+
+        service = self._get_drive_service()
+        root_id = self._get_or_create_root_folder(service)
+
+        parts = path.split("/")
+        parent_id = root_id
+        for folder_name in parts:
+            if folder_name:
+                parent_id = self._get_or_create_folder(service, folder_name, parent_id)
+
+    def stream(
+        self,
+        key: str,
+        chunk_size: int = 8192,
+        version_id: str | None = None,
+    ) -> Iterator[bytes]:
+        """Stream file content (download then chunk)."""
+        data, _ = self.fetch(key, version_id)
+        for i in range(0, len(data), chunk_size):
+            yield data[i : i + chunk_size]
+
+    def store_chunked(
+        self,
+        key: str,
+        chunks: Iterator[bytes],
+        content_type: str = "",
+    ) -> str | None:
+        """Write a file from an iterator of byte chunks."""
+        data = b"".join(chunks)
+        return self.store(key, data, content_type)
+
+    # ------------------------------------------------------------------
+    # Drive-specific helpers (not part of Transport protocol)
+    # ------------------------------------------------------------------
+
+    def resolve_folder_id(self, path: str) -> str | None:
+        """Resolve a directory path to its Drive folder ID (read-only).
+
+        Returns None if any part of the path does not exist.
+        """
+        service = self._get_drive_service()
+        root_id = self._get_or_create_root_folder(service)
+
+        path = path.strip("/")
+        if not path:
+            return root_id
+
+        parts = path.split("/")
+        current_id = root_id
+        for part in parts:
+            if not part:
+                continue
+            found = self._find_folder(service, part, current_id)
+            if found is None:
+                return None
+            current_id = found
+        return current_id
+
+    def is_folder(self, path: str) -> bool:
+        """Check whether a path is a folder in Drive."""
+        path = path.strip("/")
+        if not path:
+            return True
+
+        try:
+            service = self._get_drive_service()
+            root_id = self._get_or_create_root_folder(service)
+
+            parts = path.split("/")
+            current_id = root_id
+            for part in parts:
+                if not part:
+                    continue
+                found = self._find_folder(service, part, current_id)
+                if found is None:
+                    return False
+                current_id = found
+            return True
+        except Exception:
+            return False
+
+    def remove_folder(self, path: str, recursive: bool = False) -> None:
+        """Move a folder to trash in Drive.
+
+        Args:
+            path: Folder path relative to root
+            recursive: If False, raises error on non-empty folders
+        """
+        path = path.strip("/")
+        if not path:
+            raise BackendError("Cannot remove root directory", backend="gdrive")
+
+        service = self._get_drive_service()
+        root_id = self._get_or_create_root_folder(service)
+
+        # Resolve folder ID
+        parts = path.split("/")
+        current_id = root_id
+        for part in parts:
+            if not part:
+                continue
+            found = self._find_folder(service, part, current_id)
+            if found is None:
+                raise NexusFileNotFoundError(path)
+            current_id = found
+        folder_id = current_id
+
+        if not recursive:
+            # Check if directory is empty
+            query = f"'{folder_id}' in parents and trashed=false"
+            children = self._list_files(service, query, fields="files(id)", page_size=1)
+            if children:
+                raise BackendError(
+                    f"Directory not empty: {path}",
+                    backend="gdrive",
+                )
+
+        # Move to trash
+        service.files().update(
+            fileId=folder_id, body={"trashed": True}, supportsAllDrives=True
+        ).execute()
+
+    def mkdir_path(
+        self,
+        path: str,
+        parents: bool = False,
+    ) -> None:
+        """Create a folder at the given path.
+
+        Args:
+            path: Folder path relative to root
+            parents: If True, create intermediate folders; if False, fail on missing parents.
+        """
+        path = path.strip("/")
+        if not path:
+            return
+
+        service = self._get_drive_service()
+        root_id = self._get_or_create_root_folder(service)
+
+        parts = path.split("/")
+        parent_id = root_id
+
+        for i, folder_name in enumerate(parts):
+            if not folder_name:
+                continue
+
+            is_last = i == len(parts) - 1
+
+            if not is_last:
+                if parents:
+                    parent_id = self._get_or_create_folder(service, folder_name, parent_id)
+                else:
+                    found = self._find_folder(service, folder_name, parent_id)
+                    if found is None:
+                        raise NexusFileNotFoundError("/".join(parts[: i + 1]))
+                    parent_id = found
+            else:
+                parent_id = self._get_or_create_folder(service, folder_name, parent_id)

--- a/tests/integration/backends/connectors/gdrive/test_gdrive_schemas.py
+++ b/tests/integration/backends/connectors/gdrive/test_gdrive_schemas.py
@@ -1,7 +1,7 @@
 """Tests for Google Drive connector backend schemas and mixin integration.
 
 Covers:
-- GoogleDriveConnectorBackend has SCHEMAS, OPERATION_TRAITS, SKILL_NAME
+- PathGDriveBackend has SCHEMAS, OPERATION_TRAITS, SKILL_NAME
 - SKILL_DOC and WRITE_BACK capabilities are declared
 - Mixin class hierarchy is correct
 """
@@ -12,7 +12,7 @@ from nexus.backends.connectors.base import (
     TraitBasedMixin,
     ValidatedMixin,
 )
-from nexus.backends.connectors.gdrive.connector import GoogleDriveConnectorBackend
+from nexus.backends.connectors.gdrive.connector import PathGDriveBackend
 from nexus.backends.connectors.gws.schemas import (
     DeleteFileSchema,
     UpdateFileSchema,
@@ -21,14 +21,14 @@ from nexus.backends.connectors.gws.schemas import (
 from nexus.contracts.backend_features import BackendFeature
 
 
-class TestGoogleDriveConnectorBackendMixins:
+class TestPathGDriveBackendMixins:
     """Test that the connector has correct mixin configuration."""
 
     def test_has_skill_name(self) -> None:
-        assert GoogleDriveConnectorBackend.SKILL_NAME == "gdrive"
+        assert PathGDriveBackend.SKILL_NAME == "gdrive"
 
     def test_has_schemas(self) -> None:
-        schemas = GoogleDriveConnectorBackend.SCHEMAS
+        schemas = PathGDriveBackend.SCHEMAS
         assert "upload_file" in schemas
         assert "update_file" in schemas
         assert "delete_file" in schemas
@@ -37,7 +37,7 @@ class TestGoogleDriveConnectorBackendMixins:
         assert schemas["delete_file"] is DeleteFileSchema
 
     def test_has_operation_traits(self) -> None:
-        traits = GoogleDriveConnectorBackend.OPERATION_TRAITS
+        traits = PathGDriveBackend.OPERATION_TRAITS
         assert "upload_file" in traits
         assert "update_file" in traits
         assert "delete_file" in traits
@@ -46,40 +46,40 @@ class TestGoogleDriveConnectorBackendMixins:
         assert isinstance(traits["delete_file"], OpTraits)
 
     def test_upload_traits(self) -> None:
-        traits = GoogleDriveConnectorBackend.OPERATION_TRAITS["upload_file"]
+        traits = PathGDriveBackend.OPERATION_TRAITS["upload_file"]
         assert traits.reversibility == "full"
         assert traits.confirm == "intent"
         assert traits.checkpoint is True
 
     def test_update_traits(self) -> None:
-        traits = GoogleDriveConnectorBackend.OPERATION_TRAITS["update_file"]
+        traits = PathGDriveBackend.OPERATION_TRAITS["update_file"]
         assert traits.reversibility == "partial"
         assert traits.confirm == "explicit"
 
     def test_delete_traits(self) -> None:
-        traits = GoogleDriveConnectorBackend.OPERATION_TRAITS["delete_file"]
+        traits = PathGDriveBackend.OPERATION_TRAITS["delete_file"]
         assert traits.reversibility == "partial"
         assert traits.confirm == "user"
 
     def test_has_error_registry(self) -> None:
-        registry = GoogleDriveConnectorBackend.ERROR_REGISTRY
+        registry = PathGDriveBackend.ERROR_REGISTRY
         assert "MISSING_AGENT_INTENT" in registry
         assert "MISSING_FILE_ID" in registry
         assert "MISSING_CONFIRM" in registry
 
     def test_skill_doc_capability(self) -> None:
-        caps = GoogleDriveConnectorBackend._BACKEND_FEATURES
+        caps = PathGDriveBackend._BACKEND_FEATURES
         assert BackendFeature.SKILL_DOC in caps
 
     def test_write_back_capability(self) -> None:
-        caps = GoogleDriveConnectorBackend._BACKEND_FEATURES
+        caps = PathGDriveBackend._BACKEND_FEATURES
         assert BackendFeature.WRITE_BACK in caps
 
     def test_inherits_skill_doc_mixin(self) -> None:
-        assert issubclass(GoogleDriveConnectorBackend, SkillDocMixin)
+        assert issubclass(PathGDriveBackend, SkillDocMixin)
 
     def test_inherits_validated_mixin(self) -> None:
-        assert issubclass(GoogleDriveConnectorBackend, ValidatedMixin)
+        assert issubclass(PathGDriveBackend, ValidatedMixin)
 
     def test_inherits_trait_based_mixin(self) -> None:
-        assert issubclass(GoogleDriveConnectorBackend, TraitBasedMixin)
+        assert issubclass(PathGDriveBackend, TraitBasedMixin)


### PR DESCRIPTION
## Summary
- Extract `DriveTransport` implementing the Transport protocol for Google Drive API
- Folder ID caching, path→ID resolution, shared drive support, Google Workspace export — all in transport
- Refactor `GoogleDriveConnectorBackend` → `PathGDriveBackend(PathAddressingEngine)` composed with `DriveTransport`
- Same composition pattern as PathS3Backend/PathGCSBackend/PathGmailBackend/PathCalendarBackend
- No backward-compat alias — all references renamed clean

## Test plan
- [x] 12/12 existing GDrive tests pass
- [x] Ruff clean
- [x] Mypy clean
- [x] No new `type: ignore` comments
- [x] `isinstance(DriveTransport(), Transport)` → True
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)