### PR TITLE
refactor: LockManager → kernel owned (Phase 5 PR 1)

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -366,7 +366,7 @@ class NexusFS(  # type: ignore[misc]
         """Hot-swap a service — all quadrants supported (#1452)."""
         await self._service_registry.swap_service(name, new_instance, **kwargs)
 
-    def upgrade_lock_manager(self, lock_manager: Any) -> None:
+    def _upgrade_lock_manager(self, lock_manager: Any) -> None:
         """Hot-swap LocalLockManager → RaftLockManager at link time.
 
         Like FileWatcher.set_remote_watcher() — kernel owns the hook point,

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -168,9 +168,9 @@ class NexusFS(  # type: ignore[misc]
         # _permission_enforcer and _descendant_checker removed in Phase 4 PR 2.
         # overlay_resolver removed (Issue #2034) — always None, re-add when #1264 is implemented
         self._overlay_resolver = None
-        # Issue #1788: distributed lock manager removed — now routed through EventsService.
-        # In-process locks use _vfs_lock_manager (kernel owns); advisory locks use
-        # nx.service("events_service").lock() which auto-creates local fallback.
+        # Issue #1788: Advisory lock manager — kernel owned (like FileWatcher).
+        # Local: LocalLockManager (VFSSemaphore). Remote: RaftLockManager (kernel knows,
+        # federation inject via upgrade_lock_manager()). Constructed after _vfs_lock_manager.
         # Issue #1792: AgentRegistry accessed via ServiceRegistry (register_factory).
         # No kernel sentinel — no-agent profiles (REMOTE) never construct it.
         # Issue #1801: _flush_write_observer_fn and _overlay_config_fn closures removed —
@@ -190,6 +190,14 @@ class NexusFS(  # type: ignore[misc]
 
         self._vfs_lock_manager = create_vfs_lock_manager()
         logger.info("VFS lock manager initialized (%s)", type(self._vfs_lock_manager).__name__)
+
+        # Advisory lock manager — kernel owned (POSIX flock equivalent).
+        # Like FileWatcher: kernel-owned local + kernel-knows remote.
+        # Local: LocalLockManager (VFSSemaphore). Federation: upgrade to RaftLockManager.
+        from nexus.lib.distributed_lock import LocalLockManager
+        from nexus.lib.semaphore import create_vfs_semaphore
+
+        self._lock_manager: Any = LocalLockManager(create_vfs_semaphore(), zone_id=ROOT_ZONE_ID)
 
         # Kernel notification dispatch (INTERCEPT + OBSERVE).
         # Kernel owns dispatch infrastructure — creates empty callback lists.
@@ -357,6 +365,19 @@ class NexusFS(  # type: ignore[misc]
     async def swap_service(self, name: str, new_instance: Any, **kwargs: Any) -> None:
         """Hot-swap a service — all quadrants supported (#1452)."""
         await self._service_registry.swap_service(name, new_instance, **kwargs)
+
+    def upgrade_lock_manager(self, lock_manager: Any) -> None:
+        """Hot-swap LocalLockManager → RaftLockManager at link time.
+
+        Like FileWatcher.set_remote_watcher() — kernel owns the hook point,
+        federation injects the distributed implementation.
+        """
+        logger.info(
+            "Lock manager upgraded: %s → %s",
+            type(self._lock_manager).__name__,
+            type(lock_manager).__name__,
+        )
+        self._lock_manager = lock_manager
 
     @property
     def namespace_manager(self) -> Any | None:

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -155,7 +155,7 @@ async def _wire_services(
             from nexus.raft.lock_manager import RaftLockManager
 
             _raft_lm = RaftLockManager(nx.metadata, zone_id=zone_id or "root")
-            nx.upgrade_lock_manager(_raft_lm)
+            nx._upgrade_lock_manager(_raft_lm)
             logger.info("[LINK] RaftLockManager upgraded into kernel")
         except Exception as exc:
             logger.debug("[LINK] RaftLockManager upgrade skipped: %s", exc)

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -150,25 +150,21 @@ async def _wire_services(
         await nx.sys_setattr("/__sys__/services/federation", service=federation)
         logger.debug("[LINK] Federation service enlisted")
 
-        # Upgrade lock manager: LocalLockManager → RaftLockManager
+        # Upgrade lock manager: LocalLockManager → RaftLockManager (kernel owns)
         try:
             from nexus.raft.lock_manager import RaftLockManager
 
             _raft_lm = RaftLockManager(nx.metadata, zone_id=zone_id or "root")
-            # Find EventsService and upgrade its lock manager.
-            _events_ref = nx._service_registry.service("events_service")
-            _events_svc = _events_ref._service_instance if _events_ref is not None else None
-            if _events_svc is not None and hasattr(_events_svc, "upgrade_lock_manager"):
-                _events_svc.upgrade_lock_manager(_raft_lm)
-            logger.info("[LINK] RaftLockManager upgraded into EventsService")
+            nx.upgrade_lock_manager(_raft_lm)
+            logger.info("[LINK] RaftLockManager upgraded into kernel")
         except Exception as exc:
             logger.debug("[LINK] RaftLockManager upgrade skipped: %s", exc)
 
     # descendant_checker is now accessed via PermissionCheckHook (KernelDispatch INTERCEPT).
     # No kernel DI needed — PermissionCheckHook holds the reference internally.
 
-    # Issue #1788: Lock manager owned by EventsService (LocalLockManager by default).
-    # Upgraded to RaftLockManager above if federation is available.
+    # Issue #1788: Lock manager kernel-owned (NexusFS._lock_manager).
+    # LocalLockManager by default, upgraded to RaftLockManager above if federation available.
 
     # --- Register close callbacks (Issue #1793, #1789) ---
     # Services that need cleanup at close() register callbacks here.

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -260,8 +260,11 @@ async def _boot_post_kernel_services(
 
             events_service = EventsService(
                 file_watcher=nx._file_watcher,
+                lock_manager=nx._lock_manager,
             )
-            logger.debug("[BOOT:WIRED] EventsService created (delegates to kernel FileWatcher)")
+            logger.debug(
+                "[BOOT:WIRED] EventsService created (delegates to kernel FileWatcher + LockManager)"
+            )
         except Exception as exc:
             logger.debug("[BOOT:WIRED] EventsService unavailable: %s", exc)
     else:

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -350,9 +350,8 @@ def create_app(
 
             _rpc_sources.append(FederationRPCService(_fed))
         # --- Locks (Issue #1133) ---
-        # Lock manager lives on EventsService (moved in PR #3379).
-        _events_svc = nexus_fs.service("events") if hasattr(nexus_fs, "service") else None
-        _lock_mgr = getattr(_events_svc, "_lock_manager", None) if _events_svc else None
+        # Lock manager is kernel-owned (NexusFS._lock_manager).
+        _lock_mgr = getattr(nexus_fs, "_lock_manager", None)
         if _lock_mgr is not None:
             from nexus.server.rpc.services.locks_rpc import LocksRPCService
 

--- a/src/nexus/services/lifecycle/events_service.py
+++ b/src/nexus/services/lifecycle/events_service.py
@@ -42,25 +42,15 @@ class EventsService:
     def __init__(
         self,
         file_watcher: "FileWatcher",
+        lock_manager: "AdvisoryLockManager | None" = None,
         zone_id: str | None = None,
     ):
         self._file_watcher = file_watcher
-        # Always create LocalLockManager — may be upgraded to RaftLockManager
-        # at link time via upgrade_lock_manager().
-        try:
-            from nexus.lib.distributed_lock import LocalLockManager
-            from nexus.lib.semaphore import create_vfs_semaphore
-
-            self._lock_manager: "AdvisoryLockManager | None" = LocalLockManager(
-                create_vfs_semaphore(), zone_id=zone_id or ROOT_ZONE_ID
-            )
-            logger.debug("[EventsService] LocalLockManager created")
-        except Exception as exc:
-            logger.debug("[EventsService] LocalLockManager unavailable: %s", exc)
-            self._lock_manager = None
+        # Lock manager now kernel-owned — passed in from NexusFS._lock_manager.
+        self._lock_manager = lock_manager
         self._zone_id = zone_id
 
-        logger.info("[EventsService] Initialized (delegates to kernel FileWatcher)")
+        logger.info("[EventsService] Initialized (delegates to kernel FileWatcher + LockManager)")
 
     # =========================================================================
     # Infrastructure Detection
@@ -69,19 +59,6 @@ class EventsService:
     def _has_lock_manager(self) -> bool:
         """Check if advisory lock manager is available."""
         return self._lock_manager is not None
-
-    def upgrade_lock_manager(self, lock_manager: "AdvisoryLockManager") -> None:
-        """Hot-swap LocalLockManager → RaftLockManager at link time.
-
-        Safe because this runs during _do_link(), before bootstrap/serve —
-        no concurrent access to ``self._lock_manager``.
-        """
-        logger.info(
-            "[EventsService] Lock manager upgraded: %s → %s",
-            type(self._lock_manager).__name__,
-            type(lock_manager).__name__,
-        )
-        self._lock_manager = lock_manager
 
     def _get_zone_id(self, context: "OperationContext | None") -> str:
         """Get zone ID from context or default."""

--- a/tests/unit/services/test_events_service.py
+++ b/tests/unit/services/test_events_service.py
@@ -66,24 +66,21 @@ def _make_event(path: str = "/inbox/test.txt", event_type: str = "file_write") -
 class TestEventsServiceInit:
     """Tests for EventsService construction."""
 
-    def test_init_stores_file_watcher(self, file_watcher):
-        """Service stores file watcher dependency."""
+    def test_init_stores_file_watcher(self, file_watcher, mock_lock_manager):
+        """Service stores file watcher and lock manager dependencies."""
         svc = EventsService(
             file_watcher=file_watcher,
+            lock_manager=mock_lock_manager,
             zone_id="z1",
         )
         assert svc._file_watcher is file_watcher
-        assert svc._lock_manager is not None  # LocalLockManager auto-created
+        assert svc._lock_manager is mock_lock_manager
         assert svc._zone_id == "z1"
 
-    def test_upgrade_lock_manager(self, file_watcher, mock_lock_manager):
-        """upgrade_lock_manager() replaces the default LocalLockManager."""
+    def test_init_without_lock_manager(self, file_watcher):
+        """Lock manager is optional — None means locking disabled."""
         svc = EventsService(file_watcher=file_watcher)
-        original = svc._lock_manager
-        assert original is not None
-        svc.upgrade_lock_manager(mock_lock_manager)
-        assert svc._lock_manager is mock_lock_manager
-        assert svc._lock_manager is not original
+        assert svc._lock_manager is None
 
 
 # =============================================================================
@@ -94,16 +91,15 @@ class TestEventsServiceInit:
 class TestInfrastructureDetection:
     """Tests for layer detection methods."""
 
-    def test_has_lock_manager_true_after_upgrade(self, file_watcher, mock_lock_manager):
-        """Lock manager present after upgrade."""
-        svc = EventsService(file_watcher=file_watcher)
-        svc.upgrade_lock_manager(mock_lock_manager)
+    def test_has_lock_manager_true_when_passed(self, file_watcher, mock_lock_manager):
+        """Lock manager present when passed via constructor."""
+        svc = EventsService(file_watcher=file_watcher, lock_manager=mock_lock_manager)
         assert svc._has_lock_manager() is True
 
-    def test_has_lock_manager_always_true(self, file_watcher):
-        """EventsService auto-creates local fallback — always has lock manager."""
+    def test_has_lock_manager_false_without_lock_manager(self, file_watcher):
+        """No lock manager when none passed to constructor."""
         svc = EventsService(file_watcher=file_watcher)
-        assert svc._has_lock_manager() is True
+        assert svc._has_lock_manager() is False
 
 
 # =============================================================================
@@ -176,10 +172,8 @@ class TestDistributedLocking:
     """Tests for locking via upgraded (distributed) lock manager."""
 
     def _make_svc(self, file_watcher, mock_lock_manager):
-        """Create EventsService and upgrade to distributed lock manager."""
-        svc = EventsService(file_watcher=file_watcher)
-        svc.upgrade_lock_manager(mock_lock_manager)
-        return svc
+        """Create EventsService with distributed lock manager."""
+        return EventsService(file_watcher=file_watcher, lock_manager=mock_lock_manager)
 
     def test_lock_acquires_distributed(self, file_watcher, mock_lock_manager):
         """Lock uses distributed lock manager when available."""


### PR DESCRIPTION
## Summary

Move advisory lock manager from EventsService to NexusFS kernel — same pattern as FileWatcher (kernel-owned local + kernel-knows remote).

- NexusFS `__init__` constructs `LocalLockManager` (kernel owns, like FileWatcher)
- `NexusFS.upgrade_lock_manager()` for federation hot-swap (like `FileWatcher.set_remote_watcher()`)
- EventsService receives `lock_manager` via constructor param (no longer creates it)
- `_lifecycle.py` upgrades kernel `_lock_manager` directly (not EventsService)
- `fastapi_server.py` reads lock_manager from kernel `_lock_manager` (not EventsService)

Follow-up PRs (Phase 5 plan):
- PR 2: lock_fast mutex optimization + new syscalls (sys_lock/sys_unlock/sys_watch)
- PR 3: Delete EventsService + LocksRPCService + doc updates

## Test plan

- [x] `pytest tests/unit/core/test_factory_boot.py tests/unit/test_factory.py` — passed
- [x] `pytest tests/unit/lib/test_advisory_lock_manager.py` — passed
- [x] `pytest tests/unit/services/test_events_service.py` — passed (updated for new constructor)
- [x] All pre-commit hooks pass (ruff, mypy, brick boundary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)