### PR TITLE
refactor: CLI connector → CLITransport + PathCLIBackend composition

### DIFF
--- a/src/nexus/backends/__init__.py
+++ b/src/nexus/backends/__init__.py
@@ -167,7 +167,7 @@ def _register_optional_backends() -> None:
 
                         # Create a dedicated subclass with baked-in config
                         # so ConnectorRegistry gets a proper class, not a
-                        # generic CLIConnector that lost its config.
+                        # generic PathCLIBackend that lost its config.
                         connector_cls = create_connector_class_from_yaml(name, config)
                         ConnectorRegistry.register(
                             name=f"cli:{name}",

--- a/src/nexus/backends/connectors/cli/__init__.py
+++ b/src/nexus/backends/connectors/cli/__init__.py
@@ -1,7 +1,8 @@
 """CLI connector infrastructure — base classes, protocols, and configuration.
 
 Provides the foundation for CLI-backed connectors (gws, gh, etc.):
-- CLIConnector base class implementing ContentStoreProtocol
+- PathCLIBackend base class (PathAddressingEngine + CLITransport composition)
+- CLITransport implementing the Transport protocol via subprocess
 - ConnectorSyncProvider protocol for delta sync integration
 - CLISyncProvider bridging sync protocol to CLI list/fetch
 - CLIResult / CLIErrorMapper for structured subprocess error handling
@@ -32,8 +33,10 @@ from nexus.backends.connectors.cli.result import (
 )
 
 __all__ = [
-    # Base class
-    "CLIConnector",
+    # Base class (new name)
+    "PathCLIBackend",
+    # Transport
+    "CLITransport",
     # Sync
     "CLISyncProvider",
     "ConnectorSyncProvider",
@@ -61,10 +64,14 @@ __all__ = [
 
 def __getattr__(name: str) -> object:
     """Lazy-load heavy modules to keep import time low."""
-    if name == "CLIConnector":
-        from nexus.backends.connectors.cli.base import CLIConnector
+    if name == "PathCLIBackend":
+        from nexus.backends.connectors.cli.base import PathCLIBackend
 
-        return CLIConnector
+        return PathCLIBackend
+    if name == "CLITransport":
+        from nexus.backends.connectors.cli.transport import CLITransport
+
+        return CLITransport
     if name == "CLISyncProvider":
         from nexus.backends.connectors.cli.sync_provider import CLISyncProvider
 

--- a/src/nexus/backends/connectors/cli/base.py
+++ b/src/nexus/backends/connectors/cli/base.py
@@ -1,9 +1,17 @@
-"""CLIConnector — generic base class for CLI-backed connector backends.
+"""PathCLIBackend — PathAddressingEngine + CLITransport composition.
 
-Implements the ContentStoreProtocol via write_content(content, context)
-by delegating to external CLI tools (gws, gh, etc.). Each concrete
-connector provides a declarative YAML config that defines operations,
-schemas, commands, and traits.
+Refactored from the original CLIConnector to follow the same Transport x
+PathAddressingEngine composition pattern as PathGmailBackend, PathCalendarBackend,
+and PathGDriveBackend.
+
+Architecture:
+    PathCLIBackend(PathAddressingEngine)
+        +-- CLITransport(Transport)
+              +-- subprocess execution (CLI I/O)
+              +-- env-var auth (no OAuth)
+
+The CLITransport handles raw key->bytes I/O via CLI subprocess commands.
+PathAddressingEngine handles addressing, path security, and content operations.
 
 Design decisions (Issue #3148):
     - Implements write_content() with context.backend_path (same as Calendar)
@@ -14,7 +22,7 @@ Design decisions (Issue #3148):
     - CLIErrorMapper for structured error classification (Decision #6A)
     - Leans on TokenManager for caching/refresh (Decision #16A)
 
-Phase 2 deliverable — concrete connectors (Gmail, GitHub) come in Phase 3+.
+Phase 2 deliverable -- concrete connectors (Gmail, GitHub) come in Phase 3+.
 """
 
 from __future__ import annotations
@@ -25,7 +33,7 @@ from typing import TYPE_CHECKING, Any, ClassVar, cast
 
 import yaml
 
-from nexus.backends.base.backend import Backend, HandlerStatusResponse
+from nexus.backends.base.path_addressing_engine import PathAddressingEngine
 from nexus.backends.connectors.base import (
     CheckpointMixin,
     SkillDocMixin,
@@ -35,6 +43,7 @@ from nexus.backends.connectors.base import (
 from nexus.backends.connectors.cli.config import CLIConnectorConfig
 from nexus.backends.connectors.cli.display_path import DisplayPathMixin
 from nexus.backends.connectors.cli.result import CLIErrorMapper, CLIResult, CLIResultStatus
+from nexus.backends.connectors.cli.transport import CLITransport
 from nexus.contracts.backend_features import (
     CLI_BACKEND_FEATURES,
     OAUTH_BACKEND_FEATURES,
@@ -43,48 +52,44 @@ from nexus.contracts.backend_features import (
 from nexus.core.object_store import WriteResult
 
 if TYPE_CHECKING:
+    from nexus.backends.base.backend import HandlerStatusResponse
     from nexus.contracts.types import OperationContext
 
 logger = logging.getLogger(__name__)
 
 
-class CLIConnector(
-    Backend,
+class PathCLIBackend(
+    PathAddressingEngine,
     SkillDocMixin,
     ValidatedMixin,
     TraitBasedMixin,
     CheckpointMixin,
     DisplayPathMixin,
 ):
-    """Generic base class for CLI-backed connectors.
+    """PathAddressingEngine + CLITransport composition for CLI-backed connectors.
 
     Subclasses configure via class attributes or a ``CLIConnectorConfig``.
     The base class handles:
 
-    - ``write_content()``: YAML parse → schema validate → trait check → CLI exec
-    - ``connect()``: Verify CLI is installed and accessible
+    - ``write_content()``: YAML parse -> schema validate -> trait check -> CLI exec
+    - ``check_connection()``: Verify CLI is installed and accessible
     - ``list_dir()``: Delegate to CLI list command
-    - ``read_content()``: Delegate to CLI get command
+    - ``read_content()``: Delegate to CLI get command via transport
     - Skill doc generation (via SkillDocMixin)
     - Error mapping (via CLIErrorMapper)
     - Token resolution (via TokenManager + OperationContext)
 
     Subclasses must implement:
 
-    - ``_execute_cli(args, stdin, context) -> CLIResult``: Run the CLI
-    - ``name`` property: Backend identifier
+    - ``name`` property: Backend identifier (or rely on default)
 
     Example::
 
-        class GmailCLIConnector(CLIConnector):
+        class GmailCLIConnector(PathCLIBackend):
             SKILL_NAME = "gmail"
             CLI_NAME = "gws"
             CLI_SERVICE = "gmail"
             # ... SCHEMAS, OPERATION_TRAITS, etc.
-
-            def _execute_cli(self, args, stdin, context):
-                # subprocess implementation
-                ...
     """
 
     # --- Class-level configuration (override in subclasses) ---
@@ -110,10 +115,6 @@ class CLIConnector(
         token_manager_db: str | None = None,
         **kwargs: Any,
     ) -> None:
-        # Don't pass arbitrary kwargs to super — Backend/ObjectStoreABC/object
-        # don't accept them. Swallow unknown config keys from BackendFactory.
-        super().__init__()
-
         # Fall back to class-level _DEFAULT_CONFIG for subclasses created
         # by create_connector_class_from_yaml() (Phase 5 config dir loading).
         if config is None:
@@ -143,7 +144,7 @@ class CLIConnector(
             except Exception:
                 logger.debug("TokenManager not available for %s", self.CLI_NAME, exc_info=True)
 
-        # Error mapper — uses config's custom patterns if available
+        # Error mapper -- uses config's custom patterns if available
         extra_patterns = None
         if config and config.error_patterns:
             from nexus.backends.connectors.cli.result import ErrorMapping
@@ -157,13 +158,40 @@ class CLIConnector(
 
         # Apply config values only if the subclass didn't explicitly set them.
         # We check __dict__ to distinguish "subclass set CLI_SERVICE = ''" from
-        # "inherited the default ''" — GitHubConnector explicitly sets "" to mean
+        # "inherited the default ''" -- GitHubConnector explicitly sets "" to mean
         # "no service subcommand".
         if config:
             if "CLI_NAME" not in type(self).__dict__:
                 self.CLI_NAME = config.cli
             if "CLI_SERVICE" not in type(self).__dict__:
                 self.CLI_SERVICE = config.service
+
+        # Initialize CheckpointMixin state (cooperative __init__ is bypassed
+        # because we call PathAddressingEngine.__init__ explicitly below)
+        self._checkpoints: dict[str, Any] = {}
+
+        # Create CLITransport with our execution machinery
+        cli_transport = CLITransport(
+            cli_name=self.CLI_NAME,
+            cli_service=self.CLI_SERVICE,
+            config=config,
+            execute_cli_fn=self._execute_cli,
+            get_user_token_fn=self._get_user_token,
+            build_auth_env_fn=self._build_auth_env,
+        )
+        self._cli_transport = cli_transport
+
+        # Initialize PathAddressingEngine with the CLITransport
+        backend_name = (
+            f"cli:{self.CLI_NAME}:{self.CLI_SERVICE}"
+            if self.CLI_SERVICE
+            else f"cli:{self.CLI_NAME}"
+        )
+        PathAddressingEngine.__init__(
+            self,
+            transport=cli_transport,
+            backend_name=backend_name,
+        )
 
     # --- Sync provider (wires CLISyncProvider into mount sync) ---
 
@@ -172,12 +200,12 @@ class CLIConnector(
 
         Only used for connectors that rely on the generic YAML config for
         list/fetch. Connectors with custom list_dir (e.g., GmailConnector,
-        CalendarConnector) use the BFS path instead — their list_dir has
+        CalendarConnector) use the BFS path instead -- their list_dir has
         connector-specific logic that the generic provider can't replicate.
         """
         if self._config is None:
             return None
-        # If the subclass overrides list_dir, it has custom sync logic —
+        # If the subclass overrides list_dir, it has custom sync logic --
         # don't use the generic provider which builds wrong CLI commands.
         if "list_dir" in type(self).__dict__:
             return None
@@ -193,7 +221,7 @@ class CLIConnector(
     @property
     def name(self) -> str:
         """Backend identifier."""
-        return f"cli:{self.CLI_NAME}:{self.CLI_SERVICE}"
+        return self._backend_name
 
     @property
     def supports_external_content(self) -> bool:
@@ -201,9 +229,13 @@ class CLIConnector(
 
     # --- Connection lifecycle ---
 
-    def check_connection(self, context: "OperationContext | None" = None) -> HandlerStatusResponse:
+    def check_connection(
+        self, context: "OperationContext | None" = None
+    ) -> "HandlerStatusResponse":
         """Check if CLI is available."""
         import shutil
+
+        from nexus.backends.base.backend import HandlerStatusResponse
 
         if not self.CLI_NAME:
             return HandlerStatusResponse(
@@ -225,7 +257,7 @@ class CLIConnector(
 
     # --- Token resolution (Decision #16A: lean on TokenManager) ---
 
-    def _get_user_token(self, context: "OperationContext | None") -> str | None:
+    def _get_user_token(self, context: "OperationContext | None" = None) -> str | None:
         """Resolve per-user, per-zone OAuth token from TokenManager.
 
         Follows the same pattern as Gmail/Calendar connectors: resolve user
@@ -261,7 +293,7 @@ class CLIConnector(
 
         return None
 
-    # --- Write path: YAML → validate → traits → CLI exec ---
+    # --- Write path: YAML -> validate -> traits -> CLI exec ---
 
     def write_content(
         self,
@@ -276,8 +308,8 @@ class CLIConnector(
         Follows the same contract as Calendar/Gmail connectors:
         ``context.backend_path`` determines the operation.
 
-        Pipeline: parse YAML → resolve operation → validate schema →
-        check traits → get token → execute CLI → return result.
+        Pipeline: parse YAML -> resolve operation -> validate schema ->
+        check traits -> get token -> execute CLI -> return result.
         """
         # Backward compatibility: many existing call sites pass
         # write_content(content, context) positionally.
@@ -304,7 +336,7 @@ class CLIConnector(
                 backend=self.name,
             )
 
-        # Parse YAML — extract comment-based metadata from the header block only.
+        # Parse YAML -- extract comment-based metadata from the header block only.
         # Stop at the first non-comment, non-blank line to avoid matching
         # comments inside literal block scalars (e.g. body: |\n  # confirm: true).
         text = content.decode("utf-8") if isinstance(content, bytes) else content
@@ -321,7 +353,7 @@ class CLIConnector(
                         stripped.split(":", 1)[1].strip().lower() == "true"
                     )
             else:
-                break  # First non-comment line — stop scanning
+                break  # First non-comment line -- stop scanning
 
         data = yaml.safe_load(content)
         if not isinstance(data, dict):
@@ -354,7 +386,7 @@ class CLIConnector(
         # Build CLI command
         cli_args = self._build_cli_args(operation, validated, path)
 
-        # Prepare stdin payload — hookable so subclasses (e.g., GmailConnector)
+        # Prepare stdin payload -- hookable so subclasses (e.g., GmailConnector)
         # can return None to use flag-based args instead of stdin YAML.
         payload_yaml = self._prepare_stdin(operation, validated, data)
 
@@ -429,8 +461,8 @@ class CLIConnector(
         if self.CLI_SERVICE:
             args.append(self.CLI_SERVICE)
 
-        # Find the command from config — split multi-word commands into
-        # separate argv elements (e.g., "issue create" → ["issue", "create"])
+        # Find the command from config -- split multi-word commands into
+        # separate argv elements (e.g., "issue create" -> ["issue", "create"])
         if self._config:
             for write_op in self._config.write:
                 if write_op.operation == operation:
@@ -454,7 +486,7 @@ class CLIConnector(
     def _build_auth_env(self, token: str) -> dict[str, str]:
         """Build environment variables for CLI auth.
 
-        All auth is via environment variables — NEVER via CLI flags,
+        All auth is via environment variables -- NEVER via CLI flags,
         which would expose tokens in ``ps`` / ``/proc`` output.
 
         Known CLI env vars:
@@ -469,11 +501,11 @@ class CLIConnector(
             return {"GH_TOKEN": token}
         if cli == "gws":
             return {"GWS_ACCESS_TOKEN": token}
-        # Generic fallback — connector-specific env var
+        # Generic fallback -- connector-specific env var
         env_key = f"{self.CLI_NAME.upper().replace('-', '_')}_ACCESS_TOKEN"
         return {env_key: token}
 
-    # --- CLI execution (subclasses must implement) ---
+    # --- CLI execution (subclasses may override) ---
 
     def _execute_cli(
         self,
@@ -482,7 +514,7 @@ class CLIConnector(
         context: "OperationContext | None" = None,
         env: dict[str, str] | None = None,
     ) -> CLIResult:
-        """Execute a CLI command. Subclasses must override.
+        """Execute a CLI command.
 
         Default implementation uses subprocess. Override for testing
         or custom execution strategies.
@@ -496,6 +528,7 @@ class CLIConnector(
         Returns:
             CLIResult with status, stdout, stderr, exit code.
         """
+        import os
         import shutil
         import subprocess
         import time
@@ -518,8 +551,6 @@ class CLIConnector(
         # - Strip GOOGLE_APPLICATION_CREDENTIALS (breaks gws OAuth in Docker)
         # - Set HOME=/home/nexus for gws/gh (Docker runs as root)
         # - Merge caller-provided auth env vars
-        import os
-
         needs_custom_env = bool(env) or "GOOGLE_APPLICATION_CREDENTIALS" in os.environ
         _nexus_home = "/home/nexus"
         _cli_lower = (cli_binary or "").lower()
@@ -587,7 +618,7 @@ class CLIConnector(
                 stderr=str(e),
             )
 
-    # --- Read operations (delegate to CLI) ---
+    # --- Read operations (override PathAddressingEngine for CLI-specific behavior) ---
 
     def read_content(
         self,
@@ -596,7 +627,7 @@ class CLIConnector(
     ) -> bytes:
         """Read content via CLI get command.
 
-        Auth is via environment variables (never stdin/flags) — consistent
+        Auth is via environment variables (never stdin/flags) -- consistent
         with the write path security model.
         """
         if not context or not context.backend_path:
@@ -611,7 +642,7 @@ class CLIConnector(
         args.append(self._config.read.get_command)
         args.append(context.backend_path)
 
-        # Auth via env vars only (never stdin — tokens visible in /proc on some OS)
+        # Auth via env vars only (never stdin -- tokens visible in /proc on some OS)
         token = self._get_user_token(context)
         auth_env = self._build_auth_env(token) if token else None
         result = self._execute_cli(args, context=context, env=auth_env)
@@ -681,7 +712,7 @@ class CLIConnector(
         Calendar ``+agenda``).  Returns ``{filename: {metadata_dict}}``
         where ``filename`` matches the entries returned by ``list_dir()``.
 
-        Returns ``None`` when not implemented — the sync service falls
+        Returns ``None`` when not implemented -- the sync service falls
         back to per-file ``read_content`` for ``display_path`` resolution.
 
         Subclasses override this to eliminate N serial HTTP calls during
@@ -719,7 +750,7 @@ class CLIConnector(
         exist_ok: bool = False,
         context: "OperationContext | None" = None,
     ) -> None:
-        """Directories are virtual — no-op."""
+        """Directories are virtual -- no-op."""
 
     def rmdir(
         self,
@@ -727,7 +758,7 @@ class CLIConnector(
         recursive: bool = False,
         context: "OperationContext | None" = None,
     ) -> None:
-        """Directories are virtual — no-op."""
+        """Directories are virtual -- no-op."""
 
     def is_directory(
         self,

--- a/src/nexus/backends/connectors/cli/display_path.py
+++ b/src/nexus/backends/connectors/cli/display_path.py
@@ -9,7 +9,7 @@ Design decisions (Issue #3256):
       cap at 140 chars (rclone/eCryptfs safe limit).
     - Collision resolution: O(n) dict-based grouping, append ``_{hash[:8]}``
       only to duplicates (rclone issue #4412 / google-drive-ocamlfuse #390).
-    - DisplayPathMixin: opt-in mixin on CLIConnector, called from both
+    - DisplayPathMixin: opt-in mixin on PathCLIBackend, called from both
       CLISyncProvider and SyncPipelineService sync paths.
 """
 

--- a/src/nexus/backends/connectors/cli/loader.py
+++ b/src/nexus/backends/connectors/cli/loader.py
@@ -1,7 +1,7 @@
 """Declarative YAML config loader for CLI connectors.
 
 Loads CLIConnectorConfig from YAML files, validates at load time,
-and creates configured CLIConnector instances.
+and creates configured PathCLIBackend instances.
 
 Phase 2 deliverable (Issue #3148, Decision #12A).
 """
@@ -90,18 +90,18 @@ def create_connector_from_yaml(
     config: CLIConnectorConfig,
     token_manager_db: str | None = None,
 ) -> Any:
-    """Create a CLIConnector instance from a validated config.
+    """Create a PathCLIBackend instance from a validated config.
 
     Args:
         config: Validated connector configuration.
         token_manager_db: Database URL for TokenManager (optional).
 
     Returns:
-        Configured CLIConnector instance.
+        Configured PathCLIBackend instance.
     """
-    from nexus.backends.connectors.cli.base import CLIConnector
+    from nexus.backends.connectors.cli.base import PathCLIBackend
 
-    connector = CLIConnector(
+    connector = PathCLIBackend(
         config=config,
         token_manager_db=token_manager_db,
     )
@@ -142,7 +142,7 @@ def create_connector_class_from_yaml(
     name: str,
     config: CLIConnectorConfig,
 ) -> type:
-    """Create a dedicated CLIConnector subclass with baked-in config.
+    """Create a dedicated PathCLIBackend subclass with baked-in config.
 
     Unlike ``create_connector_from_yaml`` which returns an instance with
     instance-level attribute overrides, this creates a proper subclass
@@ -155,10 +155,10 @@ def create_connector_class_from_yaml(
         config: Validated connector configuration.
 
     Returns:
-        A new CLIConnector subclass with config baked into class attributes.
+        A new PathCLIBackend subclass with config baked into class attributes.
     """
     from nexus.backends.connectors.base import ConfirmLevel, OpTraits, Reversibility
-    from nexus.backends.connectors.cli.base import CLIConnector
+    from nexus.backends.connectors.cli.base import PathCLIBackend
 
     # Build SCHEMAS from config schema references
     schemas: dict[str, Any] = {}
@@ -183,12 +183,12 @@ def create_connector_class_from_yaml(
         )
 
     # Dynamically create a subclass with the config baked in.
-    # _DEFAULT_CONFIG is picked up by CLIConnector.__init__ as fallback
+    # _DEFAULT_CONFIG is picked up by PathCLIBackend.__init__ as fallback
     # when no explicit config= kwarg is provided.
-    cls_name = f"CLIConnector_{name.replace('-', '_').title()}"
+    cls_name = f"PathCLIBackend_{name.replace('-', '_').title()}"
     connector_cls: type = type(
         cls_name,
-        (CLIConnector,),
+        (PathCLIBackend,),
         {
             "SKILL_NAME": config.service,
             "CLI_NAME": config.cli,

--- a/src/nexus/backends/connectors/cli/sync_provider.py
+++ b/src/nexus/backends/connectors/cli/sync_provider.py
@@ -25,23 +25,23 @@ from nexus.backends.connectors.cli.protocol import (
 from nexus.backends.connectors.cli.result import CLIResult
 
 if TYPE_CHECKING:
-    from nexus.backends.connectors.cli.base import CLIConnector
+    from nexus.backends.connectors.cli.base import PathCLIBackend
 
 logger = logging.getLogger(__name__)
 
 
 class CLISyncProvider:
-    """Sync provider that delegates to a CLIConnector for list/fetch operations.
+    """Sync provider that delegates to a PathCLIBackend for list/fetch operations.
 
     Wraps the CLI connector's list_dir/read_content methods into the
     ConnectorSyncProvider protocol. The CLI's delta command (from config)
     is used for incremental sync when a state token is available.
 
     Args:
-        connector: The CLIConnector backend instance.
+        connector: The PathCLIBackend backend instance.
     """
 
-    def __init__(self, connector: "CLIConnector") -> None:
+    def __init__(self, connector: "PathCLIBackend") -> None:
         self._connector = connector
         self._config = connector._config
 

--- a/src/nexus/backends/connectors/cli/transport.py
+++ b/src/nexus/backends/connectors/cli/transport.py
@@ -1,0 +1,364 @@
+"""CLI Transport — raw key-based I/O over CLI subprocess commands.
+
+Implements the Transport protocol for CLI-backed connectors, mapping:
+- fetch(key) → CLI get command → bytes
+- list_keys(prefix) → CLI list command → keys
+- exists(key) → CLI get (check exit code)
+- store(key, data) → CLI write command → bytes on stdin
+- remove(key) → not supported (CLI connectors are typically read-only)
+
+The CLITransport wraps a CLIProtocol-compatible connector (any object with
+_execute_cli, CLI_NAME, CLI_SERVICE, _config, _get_user_token, _build_auth_env)
+and exposes Transport-protocol methods.
+
+Unlike OAuth transports (GmailTransport, CalendarTransport), CLITransport:
+- Does NOT use OAuth tokens — uses subprocess/CLI commands for I/O
+- Does NOT need with_context() — CLI auth is via env vars, not per-user OAuth
+- Delegates all subprocess execution to the existing _execute_cli machinery
+
+Key schema:
+    Keys are CLI-relative paths. The CLITransport maps them to CLI args
+    via the CLIConnectorConfig read/write configuration.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Iterator
+from typing import TYPE_CHECKING, Any
+
+import yaml
+
+from nexus.backends.connectors.cli.result import CLIResult, CLIResultStatus
+from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
+
+if TYPE_CHECKING:
+    from nexus.backends.connectors.cli.config import CLIConnectorConfig
+    from nexus.contracts.types import OperationContext
+
+logger = logging.getLogger(__name__)
+
+
+class CLITransport:
+    """CLI subprocess transport implementing the Transport protocol.
+
+    Wraps the CLI execution machinery (_execute_cli, config-based commands)
+    to expose a Transport-compatible interface for PathAddressingEngine.
+
+    Attributes:
+        transport_name: ``"cli"`` — used by PathAddressingEngine to build
+            the backend name (``"path-cli"`` or overridden by caller).
+    """
+
+    transport_name: str = "cli"
+
+    def __init__(
+        self,
+        cli_name: str,
+        cli_service: str = "",
+        config: "CLIConnectorConfig | None" = None,
+        execute_cli_fn: Any = None,
+        get_user_token_fn: Any = None,
+        build_auth_env_fn: Any = None,
+    ) -> None:
+        """Initialize CLITransport.
+
+        Args:
+            cli_name: CLI binary name (e.g., 'gws', 'gh').
+            cli_service: Service within the CLI (e.g., 'gmail', 'issue').
+            config: CLIConnectorConfig for command routing.
+            execute_cli_fn: Callable matching _execute_cli signature.
+            get_user_token_fn: Callable to resolve user token from context.
+            build_auth_env_fn: Callable to build auth env vars from token.
+        """
+        self.cli_name = cli_name
+        self.cli_service = cli_service
+        self._config = config
+        self._execute_cli = execute_cli_fn or self._default_execute_cli
+        self._get_user_token = get_user_token_fn
+        self._build_auth_env = build_auth_env_fn
+        self.transport_name = f"cli:{cli_name}:{cli_service}" if cli_service else f"cli:{cli_name}"
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    def _get_auth_env(self, context: "OperationContext | None" = None) -> dict[str, str] | None:
+        """Resolve auth env vars from context."""
+        if self._get_user_token and self._build_auth_env:
+            token = self._get_user_token(context)
+            if token:
+                return dict(self._build_auth_env(token))
+        return None
+
+    @staticmethod
+    def _default_execute_cli(
+        args: list[str],
+        stdin: str | None = None,
+        context: "OperationContext | None" = None,  # noqa: ARG004
+        env: dict[str, str] | None = None,
+    ) -> CLIResult:
+        """Default CLI execution via subprocess."""
+        import os
+        import shutil
+        import subprocess
+        import time
+
+        if not args:
+            return CLIResult(
+                status=CLIResultStatus.NOT_INSTALLED,
+                command=args,
+            )
+
+        cli_binary = args[0]
+        if shutil.which(cli_binary) is None:
+            return CLIResult(
+                status=CLIResultStatus.NOT_INSTALLED,
+                command=args,
+                stderr=f"CLI '{cli_binary}' not found in PATH",
+            )
+
+        needs_custom_env = bool(env) or "GOOGLE_APPLICATION_CREDENTIALS" in os.environ
+        _nexus_home = "/home/nexus"
+        _cli_lower = (cli_binary or "").lower()
+        if _cli_lower in ("gws", "gh") and os.path.isdir(f"{_nexus_home}/.config"):
+            needs_custom_env = True
+
+        run_env: dict[str, str] | None = None
+        if needs_custom_env:
+            run_env = {**os.environ}
+            run_env.pop("GOOGLE_APPLICATION_CREDENTIALS", None)
+            if env:
+                run_env.update(env)
+            if (
+                _cli_lower in ("gws", "gh")
+                and run_env.get("HOME") != _nexus_home
+                and os.path.isdir(f"{_nexus_home}/.config")
+            ):
+                run_env["HOME"] = _nexus_home
+
+        start = time.perf_counter()
+        try:
+            proc = subprocess.run(
+                args,
+                input=stdin,
+                capture_output=True,
+                text=True,
+                timeout=60,
+                env=run_env,
+            )
+            duration_ms = (time.perf_counter() - start) * 1000
+
+            if proc.returncode == 0:
+                return CLIResult(
+                    status=CLIResultStatus.SUCCESS,
+                    exit_code=0,
+                    stdout=proc.stdout,
+                    stderr=proc.stderr,
+                    command=args,
+                    duration_ms=duration_ms,
+                )
+            return CLIResult(
+                status=CLIResultStatus.EXIT_ERROR,
+                exit_code=proc.returncode,
+                stdout=proc.stdout,
+                stderr=proc.stderr,
+                command=args,
+                duration_ms=duration_ms,
+            )
+
+        except subprocess.TimeoutExpired:
+            duration_ms = (time.perf_counter() - start) * 1000
+            return CLIResult(
+                status=CLIResultStatus.TIMEOUT,
+                command=args,
+                duration_ms=duration_ms,
+                stderr="Command timed out after 60s",
+            )
+        except Exception as e:
+            duration_ms = (time.perf_counter() - start) * 1000
+            return CLIResult(
+                status=CLIResultStatus.EXIT_ERROR,
+                command=args,
+                duration_ms=duration_ms,
+                stderr=str(e),
+            )
+
+    # ------------------------------------------------------------------
+    # Transport protocol methods
+    # ------------------------------------------------------------------
+
+    def store(self, key: str, data: bytes, content_type: str = "") -> str | None:
+        """Store content via CLI write command.
+
+        Builds CLI args from config write operations, sends data as YAML
+        on stdin. Returns None (CLI doesn't provide version IDs).
+        """
+        if not self._config or not self._config.write:
+            raise BackendError(
+                "CLI transport has no write operations configured.",
+                backend=self.transport_name,
+            )
+
+        # Find the write operation matching the key path
+        operation = None
+        write_op = None
+        key_stripped = key.strip("/")
+        for wop in self._config.write:
+            if key_stripped.endswith(wop.path):
+                operation = wop.operation
+                write_op = wop
+                break
+
+        if operation is None or write_op is None:
+            raise BackendError(
+                f"No write operation mapped to key: {key}",
+                backend=self.transport_name,
+            )
+
+        args = [self.cli_name]
+        if self.cli_service:
+            args.append(self.cli_service)
+        args.extend(write_op.command.split())
+
+        # Send data as YAML on stdin
+        stdin_data: str | None = data.decode("utf-8") if isinstance(data, bytes) else str(data)
+
+        auth_env = self._get_auth_env()
+        result = self._execute_cli(args, stdin=stdin_data, env=auth_env)
+
+        if not result.ok:
+            raise BackendError(
+                f"CLI store failed: {result.summary()}",
+                backend=self.transport_name,
+            )
+
+        return None
+
+    def fetch(self, key: str, version_id: str | None = None) -> tuple[bytes, str | None]:
+        """Fetch content via CLI get command."""
+        if not self._config or not self._config.read:
+            raise NexusFileNotFoundError(key)
+
+        args = [self.cli_name]
+        if self.cli_service:
+            args.append(self.cli_service)
+        args.append(self._config.read.get_command)
+        args.append(key)
+
+        auth_env = self._get_auth_env()
+        result = self._execute_cli(args, env=auth_env)
+
+        if not result.ok:
+            raise NexusFileNotFoundError(key)
+
+        return result.stdout.encode("utf-8"), None
+
+    def remove(self, key: str) -> None:
+        """Remove content — not typically supported by CLI connectors."""
+        raise BackendError(
+            "CLI transport does not support content removal.",
+            backend=self.transport_name,
+        )
+
+    def exists(self, key: str) -> bool:
+        """Check whether a key exists by attempting to fetch it."""
+        if not self._config or not self._config.read:
+            return False
+
+        args = [self.cli_name]
+        if self.cli_service:
+            args.append(self.cli_service)
+        args.append(self._config.read.get_command)
+        args.append(key)
+
+        auth_env = self._get_auth_env()
+        result = self._execute_cli(args, env=auth_env)
+        return result.ok
+
+    def get_size(self, key: str) -> int:
+        """Return content size by fetching and measuring."""
+        content, _ = self.fetch(key)
+        return len(content)
+
+    def list_keys(self, prefix: str, delimiter: str = "/") -> tuple[list[str], list[str]]:
+        """List keys under prefix via CLI list command.
+
+        Returns (blob_keys, common_prefixes) following S3/GCS semantics.
+        """
+        if not self._config or not self._config.read:
+            return [], []
+
+        args = [self.cli_name]
+        if self.cli_service:
+            args.append(self.cli_service)
+        args.append(self._config.read.list_command)
+
+        prefix_stripped = prefix.strip("/") if prefix else ""
+        if prefix_stripped and prefix_stripped != "/":
+            args.append(prefix_stripped)
+
+        auth_env = self._get_auth_env()
+        result = self._execute_cli(args, env=auth_env)
+
+        if not result.ok:
+            return [], []
+
+        # Parse output based on config format
+        try:
+            fmt = self._config.read.format if self._config.read else "text"
+            if fmt == "json":
+                import json
+
+                data = json.loads(result.stdout)
+                if isinstance(data, list):
+                    return [str(item) for item in data], []
+                if isinstance(data, dict):
+                    return list(data.keys()), []
+                return [], []
+            elif fmt == "yaml":
+                data = yaml.safe_load(result.stdout)
+                if isinstance(data, list):
+                    return [str(item) for item in data], []
+                if isinstance(data, dict):
+                    return list(data.keys()), []
+                return [], []
+            else:
+                lines = [line for line in result.stdout.strip().split("\n") if line.strip()]
+                return lines, []
+        except Exception:
+            logger.debug("Failed to parse CLI list output", exc_info=True)
+            return [], []
+
+    def copy_key(self, src_key: str, dst_key: str) -> None:
+        """Copy a key — not supported by CLI transport."""
+        raise BackendError(
+            "CLI transport does not support copy.",
+            backend=self.transport_name,
+        )
+
+    def create_dir(self, key: str) -> None:
+        """Create directory — CLI connectors use virtual directories."""
+        # No-op: CLI connectors don't have real directories
+        pass
+
+    def stream(
+        self,
+        key: str,
+        chunk_size: int = 8192,
+        version_id: str | None = None,
+    ) -> Iterator[bytes]:
+        """Stream content (small payloads — fetch then chunk)."""
+        data, _ = self.fetch(key, version_id)
+        for i in range(0, len(data), chunk_size):
+            yield data[i : i + chunk_size]
+
+    def store_chunked(
+        self,
+        key: str,
+        chunks: Iterator[bytes],
+        content_type: str = "",
+    ) -> str | None:
+        """Write from chunks — assemble then store."""
+        data = b"".join(chunks)
+        return self.store(key, data, content_type)

--- a/src/nexus/backends/connectors/github/connector.py
+++ b/src/nexus/backends/connectors/github/connector.py
@@ -1,6 +1,6 @@
 """Concrete GitHub CLI connector class.
 
-CLIConnector subclass for GitHub operations via the ``gh`` CLI.
+PathCLIBackend subclass for GitHub operations via the ``gh`` CLI.
 Instantiate directly or via the declarative YAML config.
 
 Phase 6 (Issue #3148).
@@ -21,7 +21,7 @@ from nexus.backends.connectors.base import (
     Reversibility,
 )
 from nexus.backends.connectors.base_errors import TRAIT_ERRORS
-from nexus.backends.connectors.cli.base import CLIConnector
+from nexus.backends.connectors.cli.base import PathCLIBackend
 from nexus.backends.connectors.cli.config import CLIConnectorConfig
 from nexus.backends.connectors.cli.display_path import sanitize_filename
 from nexus.backends.connectors.github.schemas import (
@@ -40,7 +40,7 @@ logger = logging.getLogger(__name__)
     description="GitHub via gh CLI",
     category="cli",
 )
-class GitHubConnector(CLIConnector):
+class GitHubConnector(PathCLIBackend):
     """GitHub CLI connector via ``gh``."""
 
     SKILL_NAME = "github"

--- a/src/nexus/backends/connectors/gws/connector.py
+++ b/src/nexus/backends/connectors/gws/connector.py
@@ -1,6 +1,6 @@
 """Concrete Google Workspace CLI connector classes.
 
-Each class is a CLIConnector subclass with baked-in schemas, traits, and
+Each class is a PathCLIBackend subclass with baked-in schemas, traits, and
 CLI configuration. Instantiate directly or via ``create_connector_from_yaml()``
 with the corresponding YAML config.
 
@@ -30,7 +30,7 @@ from nexus.backends.connectors.calendar.schemas import (
     DeleteEventSchema,
     UpdateEventSchema,
 )
-from nexus.backends.connectors.cli.base import CLIConnector
+from nexus.backends.connectors.cli.base import PathCLIBackend
 from nexus.backends.connectors.cli.config import CLIConnectorConfig
 from nexus.backends.connectors.cli.display_path import sanitize_filename
 
@@ -85,7 +85,7 @@ def _load_gws_config(filename: str) -> CLIConnectorConfig | None:
     category="cli",
     service_name="gws",
 )
-class SheetsConnector(CLIConnector):
+class SheetsConnector(PathCLIBackend):
     """Google Sheets CLI connector via ``gws sheets``."""
 
     SKILL_NAME = "sheets"
@@ -170,7 +170,7 @@ class SheetsConnector(CLIConnector):
     category="cli",
     service_name="gws",
 )
-class DocsConnector(CLIConnector):
+class DocsConnector(PathCLIBackend):
     """Google Docs CLI connector via ``gws docs``."""
 
     SKILL_NAME = "docs"
@@ -353,7 +353,7 @@ class DocsConnector(CLIConnector):
     category="cli",
     service_name="gws",
 )
-class ChatConnector(CLIConnector):
+class ChatConnector(PathCLIBackend):
     """Google Chat CLI connector via ``gws chat``."""
 
     SKILL_NAME = "chat"
@@ -441,7 +441,7 @@ class ChatConnector(CLIConnector):
     category="cli",
     service_name="gws",
 )
-class DriveConnector(CLIConnector):
+class DriveConnector(PathCLIBackend):
     """Google Drive CLI connector via ``gws drive``."""
 
     SKILL_NAME = "drive"
@@ -557,7 +557,7 @@ def _gmail_category_from_labels(labels: list[str] | None) -> str:
     category="cli",
     service_name="gws",
 )
-class GmailConnector(CLIConnector):
+class GmailConnector(PathCLIBackend):
     """Gmail CLI connector via ``gws gmail``.
 
     CLI-backed alternative to the existing PathGmailBackend API connector.
@@ -1127,7 +1127,7 @@ class GmailConnector(CLIConnector):
     category="cli",
     service_name="gws",
 )
-class CalendarConnector(CLIConnector):
+class CalendarConnector(PathCLIBackend):
     """Calendar CLI connector via ``gws calendar``.
 
     CLI-backed alternative to the existing PathCalendarBackend.

--- a/src/nexus/backends/connectors/gws/schemas.py
+++ b/src/nexus/backends/connectors/gws/schemas.py
@@ -1,6 +1,6 @@
 """Pydantic schemas for Google Workspace CLI connectors (Sheets, Docs, Chat).
 
-Used by CLIConnector for write operation validation. Each schema defines
+Used by PathCLIBackend for write operation validation. Each schema defines
 the YAML structure an agent writes to trigger a CLI operation.
 
 Phase 3 (Issue #3148).

--- a/tests/integration/backends/connectors/cli/test_cli_connector.py
+++ b/tests/integration/backends/connectors/cli/test_cli_connector.py
@@ -22,7 +22,7 @@ from nexus.backends.connectors.base import (
     Reversibility,
     ValidationError,
 )
-from nexus.backends.connectors.cli.base import CLIConnector
+from nexus.backends.connectors.cli.base import PathCLIBackend
 from nexus.backends.connectors.cli.config import (
     AuthConfig,
     CLIConnectorConfig,
@@ -50,7 +50,7 @@ class CreateItemSchema(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-class FakeCLIConnector(CLIConnector):
+class FakeCLIBackend(PathCLIBackend):
     """Test connector with mocked CLI execution."""
 
     SKILL_NAME = "test-cli"
@@ -123,7 +123,7 @@ def _context(backend_path: str = "items/_new.yaml") -> MagicMock:
 
 class TestWriteContent:
     def test_successful_write(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         content = b"agent_intent: Testing create item for unit test\ntitle: Test Item\nbody: Hello"
         ctx = _context()
 
@@ -135,7 +135,7 @@ class TestWriteContent:
 
     def test_validated_payload_forwarded_to_cli(self) -> None:
         """Codex fix: verify the validated YAML payload is piped to CLI via stdin."""
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         content = b"agent_intent: Testing create item for unit test\ntitle: Test Item\nbody: Hello"
         ctx = _context()
 
@@ -150,7 +150,7 @@ class TestWriteContent:
 
     def test_auth_token_via_env_not_args(self) -> None:
         """Token goes via env var, never in CLI args (visible in ps)."""
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         # Simulate having a token
         connector._token_manager = type(
             "FakeTM", (), {"get_credentials": lambda self, **kw: {"access_token": "secret-tok-123"}}
@@ -170,13 +170,13 @@ class TestWriteContent:
         assert any("secret-tok-123" in v for v in connector._last_env.values())
 
     def test_missing_context_raises(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
 
         with pytest.raises(Exception, match="backend_path"):
             connector.write_content(b"data", None)
 
     def test_missing_backend_path_raises(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         ctx = MagicMock()
         ctx.backend_path = None
 
@@ -184,14 +184,14 @@ class TestWriteContent:
             connector.write_content(b"data", ctx)
 
     def test_invalid_yaml_raises(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         ctx = _context()
 
         with pytest.raises((yaml.YAMLError, ValueError)):
             connector.write_content(b"[not valid yaml: {{{", ctx)
 
     def test_schema_validation_failure(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         ctx = _context()
         # Missing required 'title' and 'agent_intent'
         content = b"body: just a body"
@@ -200,7 +200,7 @@ class TestWriteContent:
             connector.write_content(content, ctx)
 
     def test_trait_validation_failure(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         ctx = _context()
         # agent_intent too short
         content = b"title: Test\nagent_intent: short"
@@ -209,7 +209,7 @@ class TestWriteContent:
             connector.write_content(content, ctx)
 
     def test_cli_error_propagates(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         connector._mock_result = CLIResult(
             status=CLIResultStatus.EXIT_ERROR,
             exit_code=1,
@@ -223,7 +223,7 @@ class TestWriteContent:
             connector.write_content(content, ctx)
 
     def test_unknown_path_raises(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         ctx = _context(backend_path="unknown/path.yaml")
         content = b"agent_intent: Testing unknown path resolution\ntitle: Test"
 
@@ -238,15 +238,15 @@ class TestWriteContent:
 
 class TestOperationResolution:
     def test_resolve_from_config(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         assert connector._resolve_operation("items/_new.yaml") == "create_item"
 
     def test_resolve_unknown_path(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         assert connector._resolve_operation("unknown/path.yaml") is None
 
     def test_resolve_with_prefix(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         assert connector._resolve_operation("some/prefix/items/_new.yaml") == "create_item"
 
 
@@ -257,14 +257,14 @@ class TestOperationResolution:
 
 class TestConnectionLifecycle:
     def test_check_connection_cli_not_found(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         with patch("shutil.which", return_value=None):
             result = connector.check_connection()
         assert result.success is False
         assert "not found" in (result.error_message or "")
 
     def test_check_connection_cli_found(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         with patch("shutil.which", return_value="/usr/bin/test-cli"):
             result = connector.check_connection()
         assert result.success is True
@@ -278,23 +278,23 @@ class TestConnectionLifecycle:
 
 class TestCapabilities:
     def test_has_cli_backed(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         assert connector.has_feature(BackendFeature.CLI_BACKED)
 
     def test_has_skill_doc(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         assert connector.has_feature(BackendFeature.SKILL_DOC)
 
     def test_has_write_back(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         assert connector.has_feature(BackendFeature.WRITE_BACK)
 
     def test_has_sync(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         assert connector.has_feature(BackendFeature.SYNC)
 
     def test_name(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         assert connector.name == "cli:test-cli:items"
 
 
@@ -305,7 +305,7 @@ class TestCapabilities:
 
 class TestReadOperations:
     def test_list_dir_yaml_output(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         connector._mock_result = CLIResult(
             status=CLIResultStatus.SUCCESS,
             exit_code=0,
@@ -316,7 +316,7 @@ class TestReadOperations:
         assert result == ["item1", "item2", "item3"]
 
     def test_list_dir_cli_failure(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         connector._mock_result = CLIResult(
             status=CLIResultStatus.EXIT_ERROR,
             exit_code=1,
@@ -326,7 +326,7 @@ class TestReadOperations:
         assert result == []
 
     def test_read_content(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         connector._mock_result = CLIResult(
             status=CLIResultStatus.SUCCESS,
             exit_code=0,
@@ -338,7 +338,7 @@ class TestReadOperations:
         assert b"title: Test Item" in result
 
     def test_read_content_no_context(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         result = connector.read_content("hash", None)
         assert result == b""
 
@@ -350,24 +350,24 @@ class TestReadOperations:
 
 class TestStubs:
     def test_mkdir_noop(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         connector.mkdir("/test", parents=True, exist_ok=True)
 
     def test_rmdir_noop(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         connector.rmdir("/test")
 
     def test_is_directory(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         assert connector.is_directory("/items") is True
         assert connector.is_directory("/items/file.yaml") is False
 
     def test_content_exists(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         assert connector.content_exists("hash") is False
 
     def test_delete_content_noop(self) -> None:
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
         connector.delete_content("hash")  # Should not raise
 
 
@@ -385,14 +385,14 @@ class TestCLIEnvIsolation:
         """
         import os
 
-        connector = FakeCLIConnector()
+        connector = FakeCLIBackend()
 
         # Inject GOOGLE_APPLICATION_CREDENTIALS into the environment
         old = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS")
         os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = "/app/gcs-credentials.json"
         try:
             # Call the REAL _execute_cli (not the fake override)
-            result = CLIConnector._execute_cli(
+            result = PathCLIBackend._execute_cli(
                 connector, ["echo", "hello"], stdin=None, context=None, env=None
             )
         finally:
@@ -407,8 +407,8 @@ class TestCLIEnvIsolation:
 
     def test_auth_env_vars_passed_through(self) -> None:
         """Custom auth env vars (GH_TOKEN, GWS_ACCESS_TOKEN) must be passed."""
-        connector = FakeCLIConnector()
-        result = CLIConnector._execute_cli(
+        connector = FakeCLIBackend()
+        result = PathCLIBackend._execute_cli(
             connector,
             ["env"],
             stdin=None,

--- a/tests/integration/backends/connectors/cli/test_display_path.py
+++ b/tests/integration/backends/connectors/cli/test_display_path.py
@@ -242,10 +242,10 @@ class TestListDirMetadataDefault:
     """list_dir_metadata returns None by default (opt-in protocol)."""
 
     def test_base_returns_none(self) -> None:
-        from nexus.backends.connectors.cli.base import CLIConnector
+        from nexus.backends.connectors.cli.base import PathCLIBackend
 
         # Use a minimal subclass so we can call the default method.
-        class StubConnector(CLIConnector):
+        class StubConnector(PathCLIBackend):
             pass
 
         connector = StubConnector.__new__(StubConnector)


### PR DESCRIPTION
## Summary
- Extract `CLITransport` implementing the Transport protocol via subprocess commands
- Refactor `CLIConnector` → `PathCLIBackend(PathAddressingEngine)` composing `CLITransport`
- Update all 7 GWS + GitHub subclasses to extend `PathCLIBackend`
- No backward-compat alias — all references renamed clean

## Test plan
- [x] 213/213 CLI tests pass (excluding pre-existing metastore_first failures)
- [x] Ruff clean
- [x] Mypy clean
- [x] `isinstance(CLITransport(), Transport)` → True
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)