### PR TITLE
refactor(#1829): move consistency from sys_write to write() — SRP fix

### DIFF
--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -197,11 +197,9 @@ detail. Like HDFS separates ClientProtocol (NameNode, path-based) from
 DataTransferProtocol (DataNode, block-based). The metadata layer above ensures
 etag ownership and zone isolation.
 
-**Consistency** applies to metadata operations (metastore put): ``"sc"`` (strong
-consistency, default) or ``"ec"`` (eventually consistent, local-first with
-async replication). Content writes (CAS/backend) are always local. The kernel
-ABC defines the contract; drivers implement SC vs EC. Tier 2 `write()` composes
-content write + metadata update with consistency.
+**Consistency** applies to metadata operations only (not content writes).
+`sys_write` is content-only (SRP); `write(consistency=)` composes content write +
+metadata update. ``"sc"`` (strong, default) or ``"ec"`` (eventual, local-first).
 
 ### 2.4 Syscall Extension Model (VFS Dispatch)
 

--- a/src/nexus/contracts/filesystem/filesystem_abc.py
+++ b/src/nexus/contracts/filesystem/filesystem_abc.py
@@ -94,12 +94,11 @@ class NexusFilesystemABC(ABC):
         count: int | None = None,
         offset: int = 0,
         context: OperationContext | None = None,
-        consistency: str = "sc",
     ) -> dict[str, Any]:
         """Write content to a file (POSIX write(2)).
 
-        Tier 1 kernel primitive — file must exist. Use write() (Tier 2)
-        for create-on-write semantics.
+        Tier 1 kernel primitive — content-only (SRP). Metadata updates
+        are handled by sys_setattr or Tier 2 write(). File must exist.
 
         Args:
             path: Virtual file path.
@@ -107,8 +106,6 @@ class NexusFilesystemABC(ABC):
             count: Max bytes to write (None = len(buf)).
             offset: Byte offset to start writing at.
             context: Operation context.
-            consistency: Metastore consistency — ``"sc"`` (strong, default)
-                or ``"ec"`` (eventual, local-first). Issue #1828.
 
         Returns:
             Dict with path and bytes_written.
@@ -368,7 +365,7 @@ class NexusFilesystemABC(ABC):
     ) -> dict[str, Any]:
         """Write with metadata update (VFS convenience).
 
-        Composes sys_write + sys_setattr. POSIX pwrite + metadata update.
+        Composes content write + metadata update. POSIX pwrite + metadata.
         Override in NexusFS for driver-specific params (CAS/lock).
 
         Args:
@@ -378,14 +375,13 @@ class NexusFilesystemABC(ABC):
             offset: Byte offset to start writing at.
             context: Operation context.
             consistency: Metastore consistency — ``"sc"`` (strong, default)
-                or ``"ec"`` (eventual, local-first). Issue #1828.
+                or ``"ec"`` (eventual, local-first). Issue #1829.
 
         Returns:
             Dict with metadata (etag, version, modified_at, size).
         """
-        await self.sys_write(
-            path, buf, count=count, offset=offset, context=context, consistency=consistency
-        )
+        await self.sys_write(path, buf, count=count, offset=offset, context=context)
+        await self.sys_setattr(path, context=context, consistency=consistency)
         meta = await self.sys_stat(path, context=context)
         return meta or {}
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -2152,13 +2152,12 @@ class NexusFS(  # type: ignore[misc]
         count: int | None = None,
         offset: int = 0,
         context: OperationContext | None = None,
-        consistency: str = "sc",
         ttl: float | None = None,
     ) -> dict[str, Any]:
         """Write content to a file (POSIX write(2)).
 
-        Tier 1 kernel primitive — file must exist. Use write() (Tier 2)
-        for create-on-write semantics.
+        Tier 1 kernel primitive — content-only (SRP). Metadata consistency
+        is controlled by Tier 2 write(consistency=). File must exist.
 
         Args:
             path: Virtual path to write.
@@ -2166,8 +2165,6 @@ class NexusFS(  # type: ignore[misc]
             count: Max bytes to write (None = len(buf)).
             offset: Byte offset for partial write (POSIX pwrite semantics, 0=whole-file).
             context: Optional operation context for permission checks.
-            consistency: Metastore consistency — ``"sc"`` (strong, default)
-                or ``"ec"`` (eventual, local-first). Issue #1828.
             ttl: TTL in seconds for ephemeral content (Issue #3405).
                 Routes to TTL-bucketed volume; None = permanent.
 
@@ -2234,9 +2231,7 @@ class NexusFS(  # type: ignore[misc]
         # Thread TTL into context (Issue #3405)
         if ttl is not None and ttl > 0:
             context = self._ensure_context_ttl(context, ttl)
-        await self._write_internal(
-            path=path, content=buf, offset=offset, context=context, consistency=consistency
-        )
+        await self._write_internal(path=path, content=buf, offset=offset, context=context)
         return {"path": path, "bytes_written": len(buf)}
 
     # ── Tier 2 overrides (NexusFS-specific) ───────────────────────


### PR DESCRIPTION
## Summary
- Remove `consistency` from `sys_write` (Tier 1) — now content-only (SRP)
- `write(consistency=)` (Tier 2) passes consistency to `sys_setattr` for metadata
- ABC default: `write() = sys_write + sys_setattr(consistency=) + sys_stat`
- Content writes are always local; consistency only affects metadata persistence

## Design Rationale
POSIX `write(2)` is content-only. Metadata updates (etag, version, mtime) are a separate concern. In Nexus, `sys_write` should follow this SRP. Consistency (`"sc"` vs `"ec"`) only affects metadata (metastore → Raft), not content (CAS, always local).

## Changes (3 files)
- `contracts/filesystem/filesystem_abc.py`: Remove consistency from sys_write, ABC write() routes to sys_setattr
- `core/nexus_fs.py`: Remove consistency from sys_write signature
- `docs/architecture/KERNEL-ARCHITECTURE.md`: Clarify sys_write is content-only

## Test plan
- [ ] All pre-commit hooks pass
- [ ] CI green
- [ ] `grep "consistency" src/nexus/contracts/filesystem/filesystem_abc.py` — NOT on sys_write, ON write()
- [ ] Zero callers pass consistency to sys_write (verified: grep returns empty)

🤖 Generated with [Claude Code](https://claude.com/claude-code)