### PR TITLE
feat: sys_lock/sys_unlock/sys_watch syscalls + Tier 2 lock/unlock (Phase 5 PR 2)

### DIFF
--- a/src/nexus/contracts/filesystem/filesystem_abc.py
+++ b/src/nexus/contracts/filesystem/filesystem_abc.py
@@ -282,6 +282,84 @@ class NexusFilesystemABC(ABC):
         """
         ...
 
+    # ── Locking (POSIX flock equivalent) ────────────────────────────
+
+    @abstractmethod
+    async def sys_lock(
+        self,
+        path: str,
+        mode: str = "exclusive",
+        ttl: float = 30.0,
+        max_holders: int = 1,
+        *,
+        context: "OperationContext | None" = None,
+    ) -> str | None:
+        """Acquire advisory lock (POSIX flock(2)). Returns lock_id or None."""
+        ...
+
+    @abstractmethod
+    async def sys_unlock(
+        self, path: str, lock_id: str, *, context: "OperationContext | None" = None
+    ) -> bool:
+        """Release advisory lock. Returns True if released."""
+        ...
+
+    # ── Watch (inotify equivalent) ────────────────────────────────
+
+    @abstractmethod
+    async def sys_watch(
+        self,
+        path: str,
+        timeout: float = 30.0,
+        *,
+        recursive: bool = False,
+        context: "OperationContext | None" = None,
+    ) -> dict[str, Any] | None:
+        """Wait for file changes (inotify(7)). Returns FileEvent dict or None on timeout."""
+        ...
+
+    # ── Tier 2: Lock Convenience ──────────────────────────────────
+
+    async def lock(
+        self,
+        path: str,
+        mode: str = "exclusive",
+        timeout: float = 30.0,
+        ttl: float = 60.0,
+        max_holders: int = 1,
+        *,
+        context: "OperationContext | None" = None,
+    ) -> str | None:
+        """Acquire lock with blocking wait (Tier 2 over sys_lock).
+
+        Retries sys_lock() until acquired or timeout.
+        Like fcntl(F_SETLKW) — blocking variant of sys_lock (F_SETLK).
+        """
+        import asyncio
+        import time as _time
+
+        deadline = _time.monotonic() + timeout
+        while True:
+            lock_id = await self.sys_lock(
+                path,
+                mode=mode,
+                ttl=ttl,
+                max_holders=max_holders,
+                context=context,
+            )
+            if lock_id is not None:
+                return lock_id
+            remaining = deadline - _time.monotonic()
+            if remaining <= 0:
+                return None
+            await asyncio.sleep(min(0.05, remaining))
+
+    async def unlock(
+        self, lock_id: str, path: str, *, context: "OperationContext | None" = None
+    ) -> bool:
+        """Release lock (Tier 2 alias for sys_unlock)."""
+        return await self.sys_unlock(path, lock_id, context=context)
+
     # ── System Info + Lifecycle ────────────────────────────────────
 
     @abstractmethod

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -698,6 +698,140 @@ class NexusFS(  # type: ignore[misc]
         except (InvalidPathError, Exception):
             return False
 
+    # ── Locking (POSIX flock equivalent) ──────────────────────────
+
+    @rpc_expose(description="Acquire advisory lock on a path")
+    async def sys_lock(
+        self,
+        path: str,
+        mode: str = "exclusive",
+        ttl: float = 30.0,
+        max_holders: int = 1,
+        *,
+        context: OperationContext | None = None,
+    ) -> str | None:
+        """Acquire advisory lock (POSIX flock(2)). Returns lock_id or None.
+
+        Tier 1 syscall — single try-acquire, returns immediately.
+        Use Tier 2 ``lock()`` for blocking wait with retry.
+        """
+        path = self._validate_path(path)
+        return await self._lock_manager.acquire(
+            path,
+            mode=mode,
+            ttl=ttl,
+            max_holders=max_holders,
+            timeout=0,  # try-once, no blocking
+        )
+
+    @rpc_expose(description="Release advisory lock")
+    async def sys_unlock(
+        self,
+        path: str,
+        lock_id: str,
+        *,
+        context: OperationContext | None = None,
+    ) -> bool:
+        """Release advisory lock. Returns True if released."""
+        path = self._validate_path(path)
+        return await self._lock_manager.release(lock_id, path)
+
+    # ── Watch (inotify equivalent) ────────────────────────────────
+
+    @rpc_expose(description="Wait for file changes on a path")
+    async def sys_watch(
+        self,
+        path: str,
+        timeout: float = 30.0,
+        *,
+        recursive: bool = False,  # noqa: ARG002
+        context: OperationContext | None = None,
+    ) -> dict[str, Any] | None:
+        """Wait for file changes (inotify(7)). Returns FileEvent dict or None on timeout.
+
+        Delegates to kernel FileWatcher which races local OBSERVE + optional
+        remote watcher (federation) via FIRST_COMPLETED.
+        """
+        path = validate_path(path, allow_root=True)
+        ctx = self._resolve_cred(context)
+        zone_id = getattr(ctx, "zone_id", None) or ROOT_ZONE_ID
+        event = await self._file_watcher.wait(path, timeout=timeout, zone_id=zone_id)
+        if event is None:
+            return None
+        return event.to_dict()
+
+    @rpc_expose(description="Get advisory lock info for a path")
+    async def lock_info(
+        self,
+        path: str,
+        *,
+        context: OperationContext | None = None,  # noqa: ARG002
+    ) -> dict[str, Any] | None:
+        """Get lock info for path (Tier 2 admin query)."""
+        path = self._validate_path(path)
+        info = await self._lock_manager.get_lock_info(path)
+        if info is None:
+            return None
+        return {
+            "path": info.path,
+            "mode": info.mode,
+            "max_holders": info.max_holders,
+            "fence_token": info.fence_token,
+            "holders": [
+                {
+                    "lock_id": h.lock_id,
+                    "holder_info": h.holder_info,
+                    "acquired_at": h.acquired_at,
+                    "expires_at": h.expires_at,
+                }
+                for h in info.holders
+            ],
+        }
+
+    @rpc_expose(description="List active advisory locks")
+    async def lock_list(
+        self,
+        pattern: str = "",
+        limit: int = 100,
+        *,
+        context: OperationContext | None = None,  # noqa: ARG002
+    ) -> dict[str, Any]:
+        """List active advisory locks (Tier 2 admin query)."""
+        locks = await self._lock_manager.list_locks(pattern=pattern, limit=limit)
+        return {
+            "locks": [await self.lock_info(lk.path) for lk in locks],
+            "count": len(locks),
+        }
+
+    @rpc_expose(description="Extend advisory lock TTL (heartbeat)")
+    async def lock_extend(
+        self,
+        lock_id: str,
+        path: str,
+        ttl: float = 60.0,
+        *,
+        context: OperationContext | None = None,  # noqa: ARG002
+    ) -> dict[str, Any]:
+        """Extend lock TTL / heartbeat (Tier 2)."""
+        path = self._validate_path(path)
+        result = await self._lock_manager.extend(lock_id, path, ttl=ttl)
+        return {
+            "success": result.success,
+            "lock_info": (await self.lock_info(path)) if result.lock_info else None,
+        }
+
+    @rpc_expose(description="Force-release all holders of a lock (admin)")
+    async def lock_force_release(
+        self,
+        path: str,
+        *,
+        context: OperationContext | None = None,  # noqa: ARG002
+    ) -> dict[str, Any]:
+        """Force-release all holders (Tier 2 admin operation)."""
+        path = self._validate_path(path)
+        released = await self._lock_manager.force_release(path)
+        return {"released": released}
+
     @rpc_expose(description="Get available namespaces")
     def get_top_level_mounts(self, context: OperationContext | None = None) -> builtins.list[str]:
         """Return top-level mount names visible to the current user.

--- a/tests/unit/server/test_rpc_parity.py
+++ b/tests/unit/server/test_rpc_parity.py
@@ -115,6 +115,9 @@ def test_all_public_methods_are_exposed_or_excluded():
         "service_coordinator",  # ServiceRegistry lifecycle access — server-only (Issue #1452 Phase 3)
         "swap_service",  # Hot-swap via coordinator — server-only admin operation (Issue #1452 Phase 3)
         "load_all_saved_mounts",  # Internal initialization method - called automatically on startup
+        # Tier 2 convenience wrappers — delegate to sys_lock/sys_unlock which ARE @rpc_expose
+        "lock",  # Tier 2 blocking wait over sys_lock (defined in NexusFilesystemABC)
+        "unlock",  # Tier 2 alias for sys_unlock (defined in NexusFilesystemABC)
         # Server-side only methods (clients get this via HTTP headers)
         "get_etag",  # Returns ETag for early 304 check - clients receive ETags via HTTP headers on read
         # Async methods - TODO: Add async RPC support


### PR DESCRIPTION
## Summary

Add lock and watch as first-class kernel syscalls, replacing EventsService/LocksRPCService RPC methods.

### Tier 1 Syscalls (NexusFilesystemABC abstract)
- `sys_lock(path, mode, ttl, max_holders)` — try-acquire advisory lock (POSIX flock(2)), returns lock_id or None
- `sys_unlock(path, lock_id)` — release advisory lock
- `sys_watch(path, timeout)` — wait for file changes (inotify(7) equivalent)

### Tier 2 Convenient APIs (NexusFilesystemABC concrete)
- `lock(path, mode, timeout, ttl)` — blocking wait with retry loop (fcntl F_SETLKW)
- `unlock(lock_id, path)` — alias for sys_unlock

### Admin APIs (@rpc_expose on NexusFS)
- `lock_info(path)` — get lock status
- `lock_list(pattern, limit)` — list active locks
- `lock_extend(lock_id, path, ttl)` — heartbeat
- `lock_force_release(path)` — admin force-release

All auto-discovered by NexusVFSService Call() RPC via @rpc_expose.

Follow-up (Phase 5 PR 3): Delete EventsService lock methods + LocksRPCService + doc updates.

## Test plan

- [x] `pytest tests/unit/core/test_factory_boot.py tests/unit/test_factory.py` — 45 passed
- [x] `pytest tests/unit/services/test_events_service.py tests/unit/lib/test_advisory_lock_manager.py` — 35 passed
- [x] All pre-commit hooks pass (ruff, mypy, brick boundary)

🤖 Generated with [Claude Code](https://claude.com/claude-code)