### PR TITLE
fix: NodeAddress id@host:port parsing + mount robustness

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "nexus_pyo3"
-version = "0.9.14"
+version = "0.9.15"
 dependencies = [
  "ahash",
  "blake3",

--- a/rust/nexus_raft/src/transport/mod.rs
+++ b/rust/nexus_raft/src/transport/mod.rs
@@ -191,7 +191,7 @@ impl PeerAddress {
         }
     }
 
-    /// Parse from "host:port" format, deriving node_id from hostname.
+    /// Parse from "host:port" or "id@host:port" format, deriving node_id from hostname.
     #[cfg(feature = "grpc")]
     #[allow(clippy::result_large_err)]
     pub fn parse(s: &str, use_tls: bool) -> Result<Self> {
@@ -201,6 +201,12 @@ impl PeerAddress {
             .strip_prefix("http://")
             .or_else(|| s.strip_prefix("https://"))
             .unwrap_or(s);
+
+        // Strip "id@" prefix if present (e.g. "14044926161142285152@nexus-1:2126")
+        let addr = match addr.find('@') {
+            Some(pos) => &addr[pos + 1..],
+            None => addr,
+        };
 
         let parts: Vec<&str> = addr.rsplitn(2, ':').collect();
         if parts.len() != 2 {
@@ -282,6 +288,17 @@ mod tests {
     #[test]
     fn test_peer_address_parse() {
         let addr = PeerAddress::parse("nexus-1:2126", false).unwrap();
+        assert_eq!(addr.hostname, "nexus-1");
+        assert_eq!(addr.port, 2126);
+        assert_eq!(addr.id, hostname_to_node_id("nexus-1"));
+        assert_eq!(addr.endpoint, "http://nexus-1:2126");
+    }
+
+    #[cfg(feature = "grpc")]
+    #[test]
+    fn test_peer_address_parse_with_id_prefix() {
+        // "id@host:port" format — id prefix must be stripped, hostname used for node_id
+        let addr = PeerAddress::parse("14044926161142285152@nexus-1:2126", false).unwrap();
         assert_eq!(addr.hostname, "nexus-1");
         assert_eq!(addr.port, 2126);
         assert_eq!(addr.id, hostname_to_node_id("nexus-1"));

--- a/src/nexus/core/metastore.py
+++ b/src/nexus/core/metastore.py
@@ -95,6 +95,19 @@ class MetastoreABC(ABC):
         self._dcache.pop(path, None)
         return self._delete_raw(path, consistency=consistency)
 
+    def dcache_evict_prefix(self, prefix: str) -> int:
+        """Evict all dcache entries whose path starts with *prefix*.
+
+        Used by mount/unmount operations to invalidate stale cross-zone
+        cache entries that were resolved through a now-changed mount point.
+
+        Returns the number of entries evicted.
+        """
+        keys = [k for k in self._dcache if k.startswith(prefix)]
+        for k in keys:
+            del self._dcache[k]
+        return len(keys)
+
     def exists(self, path: str) -> bool:
         """Check if metadata exists for a path (dcache-accelerated)."""
         if path in self._dcache:

--- a/src/nexus/raft/federation.py
+++ b/src/nexus/raft/federation.py
@@ -224,6 +224,8 @@ class NexusFederation:
 
         assert zone_mgr is not None  # guaranteed by loop above
         metadata_store = FederatedMetadataProxy.from_zone_manager(zone_mgr)
+        # Wire dcache invalidation: mount/unmount evicts stale proxy entries
+        zone_mgr._dcache_proxy = metadata_store
         federation = cls(zone_manager=zone_mgr)
         return federation, metadata_store
 

--- a/src/nexus/raft/zone_manager.py
+++ b/src/nexus/raft/zone_manager.py
@@ -181,6 +181,10 @@ class ZoneManager:
         self._tls_ca_path = tls_ca_path
         self._pending_mounts: dict[str, str] | None = None
         self._topology_initialized = False
+        # Set by FederatedMetadataProxy after creation to receive dcache
+        # invalidation on mount/unmount (dcache entries under a changed
+        # mount point become stale).
+        self._dcache_proxy: Any | None = None
 
     @property
     def tls_config(self) -> "ZoneTlsConfig | None":
@@ -469,6 +473,14 @@ class ZoneManager:
                 f"'{parent_zone_id}'. Create the directory first (mkdir -p)."
             )
         if existing.is_mount:
+            if existing.target_zone_id == target_zone_id:
+                # Idempotent: already mounted to the same target — no-op
+                logger.debug(
+                    "Mount '%s' → '%s' already exists, skipping",
+                    mount_path,
+                    target_zone_id,
+                )
+                return
             raise ValueError(
                 f"Mount point '{mount_path}' is already a DT_MOUNT in zone "
                 f"'{parent_zone_id}'. Unmount first."
@@ -493,8 +505,25 @@ class ZoneManager:
         parent_store.put(mount_entry)
 
         # Increment target zone's i_links_count (POSIX: link() → nlink++)
+        # Best-effort: each zone has independent Raft leadership.
+        # If this node isn't leader for the target zone, the leader
+        # will eventually apply it via ensure_topology().
         if increment_links:
-            self._increment_links(target_store)
+            try:
+                self._increment_links(target_store)
+            except RuntimeError as e:
+                logger.warning(
+                    "Links increment deferred for zone '%s' (not leader): %s",
+                    target_zone_id,
+                    e,
+                )
+
+        # Invalidate proxy dcache — entries resolved through this mount point
+        # are now stale (the path prefix routes to a different zone).
+        # Clear entire dcache because mount_path is zone-relative but dcache
+        # keys are global paths; mounts are rare so full clear is fine.
+        if self._dcache_proxy is not None:
+            self._dcache_proxy._dcache.clear()
 
         logger.info(
             "Mounted zone '%s' at '%s' in zone '%s'",
@@ -546,6 +575,13 @@ class ZoneManager:
             target_store = self.get_store(target_zone_id)
             if target_store is not None:
                 self._decrement_links(target_store)
+
+        # Invalidate proxy dcache — entries cached through this mount point
+        # would still resolve into the now-unmounted zone.
+        # Clear entire dcache because mount_path is zone-relative but dcache
+        # keys are global paths; unmounts are rare so full clear is fine.
+        if self._dcache_proxy is not None:
+            self._dcache_proxy._dcache.clear()
 
         logger.info(
             "Unmounted '%s' from zone '%s' (target=%s)",


### PR DESCRIPTION
## Summary
- **NodeAddress::parse()**: Strip `id@` prefix from `id@host:port` format. Without this, the node ID derived from `"14044926161142285152@nexus-1"` differs from `hostname_to_node_id("nexus-1")`, preventing Raft cluster formation.
- **Dcache invalidation on mount/unmount**: `MetastoreABC.dcache_evict_prefix()` + ZoneManager clears proxy dcache on mount changes. After unmount, stale cross-zone entries in the proxy dcache caused reads to traverse into unmounted zones.
- **Mount idempotency**: `mount()` is now a no-op when the same target is already mounted (instead of raising "already a DT_MOUNT").
- **Cross-zone mount robustness**: Links increment in `mount()` is best-effort — handles independent Raft leadership across parent and target zones gracefully.

## Test plan
- [x] Rust `test_peer_address_parse_with_id_prefix` passes
- [x] All pre-commit hooks pass (ruff, mypy, rustfmt, clippy)
- [x] `tests/unit/server/` all pass
- [x] Docker E2E: 13 pass (up from 8), unmount/remount cycle fixed
- [ ] Remaining: `test_cross_zone_replication` still fails (PathNotMounted for nested mount writes — separate investigation needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)