### PR TITLE
docs: LockManager kernel owns + syscall table + NEXUS_DEBUG_LOCK_ORDER rename (Phase 5 PR 3)

### DIFF
--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -101,8 +101,8 @@ refcount drain → unhook old → replace → rehook new.
 
 | Pattern | Kernel `__init__` | Factory `_do_link()` | Example |
 |---------|-------------------|---------------------|---------|
-| **Kernel owns** | Creates instance | — | VFSLockManager, KernelDispatch, PipeManager, StreamManager, ServiceRegistry, DriverLifecycleCoordinator |
-| **Kernel knows** (sentinel) | `self._x = None` | Injects real value; `None` = graceful degrade | `_distributed_lock_manager`, `_agent_registry` |
+| **Kernel owns** | Creates instance | — | VFSLockManager, LockManager (advisory), KernelDispatch, PipeManager, StreamManager, FileWatcher, ServiceRegistry, DriverLifecycleCoordinator |
+| **Kernel knows** (sentinel) | `self._x = None` | Injects real value; `None` = graceful degrade | `_agent_registry` |
 
 "Kernel knows" follows the Linux LSM pattern: kernel declares a default (None),
 factory overrides at link-time. The kernel never imports service-layer modules.
@@ -158,12 +158,14 @@ program against the contract, kernel implements it.
 primitives (§4) into user-facing operations. NexusFS contains **no service
 business logic**.
 
-**10 kernel syscalls**, all POSIX-aligned, all path-addressed:
+**13 kernel syscalls**, all POSIX-aligned, all path-addressed:
 
 | Plane | Syscalls |
 |-------|----------|
 | **Metadata** (8) | `sys_stat`, `sys_setattr`, `sys_rmdir`, `sys_readdir`, `sys_access`, `sys_rename`, `sys_unlink`, `sys_is_directory` |
 | **Content** (2) | `sys_read` (pread), `sys_write` (pwrite) |
+| **Locking** (2) | `sys_lock` (flock), `sys_unlock` |
+| **Watch** (1) | `sys_watch` (inotify) |
 
 `sys_setattr` is the universal creation/management syscall:
 `mkdir` = `sys_setattr(entry_type=DT_DIR)`, `mount` = `sys_setattr(entry_type=DT_MOUNT, backend=...)`,
@@ -346,6 +348,7 @@ with them indirectly through syscalls. See §2.2 for per-syscall usage.
 | **DriverLifecycleCoordinator** | `core.driver_lifecycle_coordinator` | `register_filesystem` + `kern_mount` | Driver mount lifecycle: routing table + VFS hook registration + mount/unmount KernelDispatch notification. Orthogonal to ServiceRegistry (drivers vs services) |
 | **AgentRegistry** | `core.agent_registry` | `task_struct` list | In-memory agent process table. Sentinel — `None` in `__init__`, injected by factory. Details in §4.4 |
 | **FileWatcher + FileEvent** | `core.file_watcher` + `core.file_events` | `inotify(7)` + `fsnotify_event` | Kernel file change notification + immutable mutation records. FileWatcher: kernel-owned local OBSERVE waiters + kernel-knows `RemoteWatchProtocol`. FileEvent: frozen dataclass. Details in §4.3 |
+| **LockManager (advisory)** | `lib.distributed_lock` | `flock(2)` | Advisory lock manager. Kernel-owned local (LocalLockManager via VFSSemaphore) + kernel-knows remote (RaftLockManager via federation `_upgrade_lock_manager()`). Exposed via `sys_lock`/`sys_unlock` syscalls. Details in §4.5 |
 
 ### 4.1 VFSLockManager — Per-Path RW Lock
 
@@ -416,6 +419,22 @@ See `federation-memo.md` §7j for design rationale.
 
 In-memory registry of all active agent descriptors (spawn, status, close).
 Profiles without agents (e.g. REMOTE) operate without it.
+
+### 4.5 LockManager — Kernel Advisory Lock
+
+| Property | Value |
+|----------|-------|
+| Linux analogue | `flock(2)` / `fcntl(F_SETLK)` |
+| Package | `lib.distributed_lock` (LocalLockManager, RaftLockManager) |
+| Storage | `sm_locks` redb table (separate from FileMetadata) |
+| Lifecycle | Kernel-owned: LocalLockManager constructed in `__init__`; federation upgrades to RaftLockManager via `_upgrade_lock_manager()` |
+
+Same pattern as FileWatcher: kernel-owned local + kernel-knows remote.
+
+- **Local**: `LocalLockManager` wraps `VFSSemaphore` — exclusive (mutex), shared (RW), counting (semaphore)
+- **Remote**: `RaftLockManager` wraps `RaftMetadataStore.acquire_lock()` — strong consistency via Raft consensus
+- **Syscalls**: `sys_lock` (try-acquire, Tier 1), `sys_unlock` (release, Tier 1), `lock()` (blocking wait, Tier 2)
+- **Upgrade**: `_upgrade_lock_manager()` called by factory at link time when federation is available
 
 ---
 

--- a/docs/architecture/LOCK-ORDERING.md
+++ b/docs/architecture/LOCK-ORDERING.md
@@ -151,7 +151,7 @@ same pattern as Linux `i_rwsem` release before `fsnotify()`.
 
 ## 6. Debug Assertions
 
-When `NEXUS_LOCK_DEBUG=1` is set, Nexus tracks lock acquisition per-task
+When `NEXUS_DEBUG_LOCK_ORDER=1` is set, Nexus tracks lock acquisition per-task
 and asserts ordering constraints at runtime:
 
 - **Layer ordering**: acquiring L1 while holding L2 raises `LockOrderError`
@@ -163,7 +163,7 @@ See: `lib/lock_order.py` for implementation.
 Enable in development/CI:
 
 ```bash
-NEXUS_LOCK_DEBUG=1 pytest tests/
+NEXUS_DEBUG_LOCK_ORDER=1 pytest tests/
 ```
 
 ---

--- a/src/nexus/lib/lock_order.py
+++ b/src/nexus/lib/lock_order.py
@@ -1,14 +1,17 @@
-"""Debug-mode lock ordering assertions (Issue #3392).
+"""Debug-only lock ordering assertions (Issue #3392).
+
+**DEBUG TOOL ONLY** — for detecting potential deadlocks during development/CI.
+Production: ALWAYS disabled (zero overhead). Enable only for debugging.
 
 Tracks lock acquisition per-task (asyncio) or per-thread and asserts
 that the global lock ordering (L1 → L2 → L3 → L4) is never violated.
 
 Inspired by DFUSE (arXiv:2503.18191) §4.2: deadlock from reversed lock
-ordering in distributed filesystem I/O. This module detects violations
-at runtime so they surface during development/CI instead of production.
+ordering in distributed filesystem I/O. Correct lock design avoids
+deadlock; this module is an additional safety net for verification.
 
 Activation:
-    NEXUS_LOCK_DEBUG=1  — enable lock ordering assertions
+    NEXUS_DEBUG_LOCK_ORDER=1  — enable lock ordering assertions
     (Default: disabled — zero overhead in production)
 
 Lock layers:
@@ -37,7 +40,7 @@ logger = logging.getLogger(__name__)
 # Activation gate
 # ---------------------------------------------------------------------------
 
-LOCK_DEBUG_ENABLED: bool = os.environ.get("NEXUS_LOCK_DEBUG", "").lower() in (
+LOCK_DEBUG_ENABLED: bool = os.environ.get("NEXUS_DEBUG_LOCK_ORDER", "").lower() in (
     "1",
     "true",
     "yes",

--- a/tests/unit/core/test_lock_ordering.py
+++ b/tests/unit/core/test_lock_ordering.py
@@ -25,7 +25,7 @@ from nexus.core.lock_fast import PythonVFSLockManager
 
 def _enable_lock_debug(monkeypatch):
     """Enable lock debug mode and reload the module."""
-    monkeypatch.setenv("NEXUS_LOCK_DEBUG", "1")
+    monkeypatch.setenv("NEXUS_DEBUG_LOCK_ORDER", "1")
     import nexus.lib.lock_order as mod
 
     monkeypatch.setattr(mod, "LOCK_DEBUG_ENABLED", True)
@@ -80,7 +80,7 @@ class TestLockOrderingViolation:
         mod.mark_released(mod.L1_VFS)
 
     def test_noop_when_disabled(self, monkeypatch):
-        """Assertions are no-ops when NEXUS_LOCK_DEBUG is not set."""
+        """Assertions are no-ops when NEXUS_DEBUG_LOCK_ORDER is not set."""
         import nexus.lib.lock_order as mod
 
         monkeypatch.setattr(mod, "LOCK_DEBUG_ENABLED", False)


### PR DESCRIPTION
## Summary

- **KERNEL-ARCHITECTURE.md**: Add LockManager to kernel owns table, add §4.5 LockManager section, update syscall table (10 → 13 with sys_lock/sys_unlock/sys_watch), remove `_distributed_lock_manager` from kernel knows
- **LOCK-ORDERING.md**: Rename env var `NEXUS_LOCK_DEBUG` → `NEXUS_DEBUG_LOCK_ORDER`
- **lock_order.py**: Rename env var, clarify debug-only purpose in docstring
- Update test env var reference

Follow-up: Migrate EventsService lock callers → kernel syscalls, delete EventsService + LocksRPCService.

## Test plan

- [x] `pytest tests/unit/core/test_lock_ordering.py` — 11 passed
- [x] `pytest tests/unit/core/test_factory_boot.py` — 21 passed
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)