### PR TITLE
feat(profile): add federation to cluster profile

### DIFF
--- a/src/nexus/contracts/deployment_profile.py
+++ b/src/nexus/contracts/deployment_profile.py
@@ -173,6 +173,7 @@ _SLIM_BRICKS: frozenset[str] = frozenset(
 _CLUSTER_BRICKS: frozenset[str] = _SLIM_BRICKS | frozenset(
     {
         BRICK_IPC,
+        BRICK_FEDERATION,
     }
 )
 

--- a/tests/unit/core/test_deployment_profile.py
+++ b/tests/unit/core/test_deployment_profile.py
@@ -18,6 +18,7 @@ from nexus.contracts.deployment_profile import (
     ALL_BRICK_NAMES,
     BRICK_CACHE,
     BRICK_EVENTLOG,
+    BRICK_FEDERATION,
     BRICK_IPC,
     BRICK_LLM,
     BRICK_NAMESPACE,
@@ -68,8 +69,9 @@ class TestDefaultBrickSets:
         bricks = DeploymentProfile.CLUSTER.default_bricks()
         assert BRICK_STORAGE in bricks
         assert BRICK_IPC in bricks
+        assert BRICK_FEDERATION in bricks
         assert BRICK_EVENTLOG not in bricks  # No audit/events
-        assert len(bricks) == 2
+        assert len(bricks) == 3
 
     def test_embedded_minimal(self) -> None:
         bricks = DeploymentProfile.EMBEDDED.default_bricks()


### PR DESCRIPTION
## Summary
- Add `BRICK_FEDERATION` to `_CLUSTER_BRICKS` in `deployment_profile.py`
- Cluster profile becomes: `slim + ipc + federation`

## Why
The cluster profile is intended for multi-node deployments. Without federation, it only has local IPC — nodes cannot discover or communicate across the network, which defeats the purpose of a "cluster" profile.

## Consumer
Sudowork uses `--profile=cluster` for its embedded Nexus service. It needs federation for distributed IPC between agent processes.

## Test plan
- [ ] Verify `nexusd --profile=cluster` starts successfully
- [ ] Verify federation brick initializes alongside ipc
- [ ] Existing tests for slim/lite/full profiles unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)