### PR TITLE
feat: Gmail write operations — send, reply, forward, draft, trash

### DIFF
--- a/src/nexus/backends/connectors/gmail/connector.py
+++ b/src/nexus/backends/connectors/gmail/connector.py
@@ -13,10 +13,16 @@ path security, and content operations.
 Storage structure (2-level hierarchy):
     /
     ├── SENT/                          # Sent emails
-    │   └── {thread_id}-{msg_id}.yaml  # Email metadata + content
+    │   ├── {thread_id}-{msg_id}.yaml  # Email metadata + content
+    │   ├── _new.yaml                  # Write here to send new email
+    │   ├── _reply.yaml                # Write here to reply to thread
+    │   └── _forward.yaml              # Write here to forward message
     ├── STARRED/                       # Starred emails in INBOX
     ├── IMPORTANT/                     # Important emails in INBOX
-    └── INBOX/                         # Remaining inbox emails
+    ├── INBOX/                         # Remaining inbox emails
+    ├── DRAFTS/                        # Email drafts
+    │   └── _new.yaml                  # Write here to create draft
+    └── TRASH/                         # Trashed emails
 """
 
 from __future__ import annotations
@@ -36,11 +42,17 @@ from nexus.backends.connectors.base import (
     ValidatedMixin,
 )
 from nexus.backends.connectors.gmail.errors import ERROR_REGISTRY
+from nexus.backends.connectors.gmail.schemas import (
+    DraftEmailSchema,
+    ForwardEmailSchema,
+    ReplyEmailSchema,
+    SendEmailSchema,
+)
 from nexus.backends.connectors.gmail.transport import LABEL_FOLDERS, GmailTransport
 from nexus.backends.connectors.oauth import OAuthConnectorMixin
 from nexus.backends.wrappers.cache_mixin import IMMUTABLE_VERSION, CacheConnectorMixin
 from nexus.contracts.backend_features import OAUTH_BACKEND_FEATURES, BackendFeature
-from nexus.contracts.exceptions import BackendError
+from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.object_store import WriteResult
 
 if TYPE_CHECKING:
@@ -52,7 +64,7 @@ logger = logging.getLogger(__name__)
 
 @register_connector(
     "gmail_connector",
-    description="Gmail with OAuth 2.0 authentication (read-only)",
+    description="Gmail with OAuth 2.0 authentication (send, reply, forward, draft, trash)",
     category="oauth",
     requires=["google-api-python-client", "google-auth-oauthlib"],
     service_name="gmail",
@@ -80,6 +92,8 @@ class PathGmailBackend(
         {
             BackendFeature.CACHE_BULK_READ,
             BackendFeature.CACHE_SYNC,
+            BackendFeature.WRITE_BACK,
+            BackendFeature.SKILL_DOC,
         }
     )
 
@@ -88,6 +102,22 @@ class PathGmailBackend(
 
     # Skill documentation settings
     SKILL_NAME = "gmail"
+
+    # ValidatedMixin config — maps operation name → Pydantic schema
+    SCHEMAS = {
+        "send_email": SendEmailSchema,
+        "reply_email": ReplyEmailSchema,
+        "forward_email": ForwardEmailSchema,
+        "create_draft": DraftEmailSchema,
+    }
+
+    # Maps (label, sentinel) → operation name for path-based dispatch
+    _OPERATION_MAP: ClassVar[dict[tuple[str, str], str]] = {
+        ("SENT", "_new"): "send_email",
+        ("SENT", "_reply"): "reply_email",
+        ("SENT", "_forward"): "forward_email",
+        ("DRAFTS", "_new"): "create_draft",
+    }
 
     # Operation traits for trait-based validation
     OPERATION_TRAITS = {
@@ -289,6 +319,30 @@ class PathGmailBackend(
         """Bind the transport to the current request context (OAuth token)."""
         self._transport = self._gmail_transport.with_context(context)
 
+    def _resolve_operation(self, path: str) -> tuple[str, str, str]:
+        """Resolve a backend path to ``(operation_name, label, sentinel)``.
+
+        Raises BackendError if the path does not match any write operation.
+        """
+        label, _thread_id, sentinel = GmailTransport._parse_key(path)
+        if not label or not sentinel or not sentinel.startswith("_"):
+            raise BackendError(
+                f"Invalid write path: {path}. "
+                "Expected: SENT/_new.yaml, SENT/_reply.yaml, SENT/_forward.yaml, "
+                "or DRAFTS/_new.yaml",
+                backend="gmail",
+            )
+
+        operation = self._OPERATION_MAP.get((label, sentinel))
+        if operation is None:
+            raise BackendError(
+                f"No operation for path: {path}. "
+                "Supported write paths: SENT/_new.yaml, SENT/_reply.yaml, "
+                "SENT/_forward.yaml, DRAFTS/_new.yaml",
+                backend="gmail",
+            )
+        return operation, label, sentinel
+
     def write_content(
         self,
         content: bytes,
@@ -297,10 +351,59 @@ class PathGmailBackend(
         offset: int = 0,
         context: "OperationContext | None" = None,
     ) -> WriteResult:
-        raise BackendError(
-            "Gmail connector is read-only. Cannot write emails back to Gmail.",
-            backend="gmail",
-        )
+        """Handle send/reply/forward/draft with validation + checkpoints.
+
+        The write path is determined by ``context.backend_path``:
+        - ``SENT/_new.yaml``     → send_email
+        - ``SENT/_reply.yaml``   → reply_email
+        - ``SENT/_forward.yaml`` → forward_email
+        - ``DRAFTS/_new.yaml``   → create_draft
+        """
+        if not context or not context.backend_path:
+            raise BackendError(
+                "Gmail connector requires backend_path in OperationContext.",
+                backend="gmail",
+            )
+
+        self._bind_transport(context)
+
+        path = context.backend_path.strip("/")
+        operation, label, sentinel = self._resolve_operation(path)
+
+        # Parse YAML content for validation
+        data = GmailTransport._parse_yaml_content(content)
+
+        # Trait-based validation (intent, confirm)
+        warnings = self.validate_traits(operation, data)
+        for w in warnings:
+            logger.warning("Gmail %s warning: %s", operation, w)
+
+        # Schema validation
+        self.validate_schema(operation, data)
+
+        # Create checkpoint
+        checkpoint = self.create_checkpoint(operation, metadata={"path": path})
+
+        try:
+            blob_path = self._get_key_path(f"{label}/{sentinel}.yaml")
+            result_id = self._transport.store(blob_path, content) or ""
+
+            if checkpoint:
+                self.complete_checkpoint(
+                    checkpoint.checkpoint_id,
+                    {"message_id": result_id, "operation": operation},
+                )
+            logger.info("Gmail %s completed: %s", operation, result_id)
+            return WriteResult(content_id=result_id, version=result_id, size=len(content))
+        except Exception as e:
+            if checkpoint:
+                self.clear_checkpoint(checkpoint.checkpoint_id)
+            if isinstance(e, (BackendError, NexusFileNotFoundError)):
+                raise
+            raise BackendError(
+                f"Failed to execute {operation}: {e}",
+                backend="gmail",
+            ) from e
 
     def read_content(self, content_id: str, context: "OperationContext | None" = None) -> bytes:
         if not context or not context.backend_path:
@@ -338,10 +441,38 @@ class PathGmailBackend(
         return content
 
     def delete_content(self, content_id: str, context: "OperationContext | None" = None) -> None:
-        raise BackendError(
-            "Gmail connector is read-only. Cannot delete emails from Gmail.",
-            backend="gmail",
-        )
+        """Trash a Gmail message (recoverable — not permanent delete).
+
+        The message is moved to Gmail Trash and auto-deleted after 30 days.
+        """
+        if not context or not context.backend_path:
+            raise BackendError(
+                "Gmail connector requires backend_path in OperationContext.",
+                backend="gmail",
+            )
+
+        self._bind_transport(context)
+
+        path = context.backend_path.strip("/")
+        _label, _thread_id, message_id = GmailTransport._parse_key(path)
+
+        if not message_id or (message_id and message_id.startswith("_")):
+            raise BackendError(
+                f"Invalid path for trash: {path}. Expected LABEL/threadId-msgId.yaml",
+                backend="gmail",
+            )
+
+        blob_path = self._get_key_path(path)
+        try:
+            self._transport.remove(blob_path)
+            logger.info("Trashed Gmail message via connector: %s", message_id)
+        except Exception as e:
+            if isinstance(e, (BackendError, NexusFileNotFoundError)):
+                raise
+            raise BackendError(
+                f"Failed to trash message: {e}",
+                backend="gmail",
+            ) from e
 
     def content_exists(self, content_id: str, context: "OperationContext | None" = None) -> bool:
         if not context or not context.backend_path:

--- a/src/nexus/backends/connectors/gmail/transport.py
+++ b/src/nexus/backends/connectors/gmail/transport.py
@@ -2,11 +2,11 @@
 
 Implements the Transport protocol for Gmail, mapping:
 - fetch(key) → messages.get(id=msg_id) → YAML bytes
+- store(key, data) → messages.send / drafts.create
+- remove(key) → messages.trash (recoverable)
 - list_keys(prefix) → messages.list(labelIds=[prefix]) → file keys
 - exists(key) → messages.get(id=msg_id, fields="id")
 - get_size(key) → messages.get(fields="sizeEstimate")
-
-Read-only: store/remove/copy_key/create_dir raise BackendError.
 
 Auth: GmailTransport carries a TokenManager + provider.  Before each
 request the caller must bind an OperationContext via ``with_context()``
@@ -15,6 +15,10 @@ so the transport can resolve the per-user OAuth token.
 Key schema:
     "INBOX/threadAbc-msgXyz.yaml"   → label=INBOX, msg_id=msgXyz
     "SENT/threadAbc-msgXyz.yaml"    → label=SENT,  msg_id=msgXyz
+    "SENT/_new.yaml"                → send new email
+    "SENT/_reply.yaml"              → reply to thread
+    "SENT/_forward.yaml"            → forward message
+    "DRAFTS/_new.yaml"              → create draft
     list_keys("INBOX/")             → all message keys under INBOX
     list_keys("")                    → common_prefixes = ["SENT/", ...]
 """
@@ -27,6 +31,7 @@ from collections.abc import Iterator
 from contextlib import suppress
 from copy import copy
 from datetime import UTC, datetime
+from email.message import EmailMessage
 from typing import TYPE_CHECKING, Any
 
 import yaml
@@ -48,7 +53,7 @@ logger = logging.getLogger(__name__)
 logging.getLogger("googleapiclient.discovery_cache").setLevel(logging.ERROR)
 
 # Gmail system labels exposed as virtual directories (priority order).
-LABEL_FOLDERS = ["SENT", "STARRED", "IMPORTANT", "INBOX"]
+LABEL_FOLDERS = ["SENT", "STARRED", "IMPORTANT", "INBOX", "DRAFTS", "TRASH"]
 
 
 class GmailTransport:
@@ -142,9 +147,13 @@ class GmailTransport:
 
     @staticmethod
     def _parse_key(key: str) -> tuple[str | None, str | None, str | None]:
-        """Parse a transport key into ``(label, thread_id, message_id)``.
+        """Parse a transport key into ``(label, thread_id | None, message_id | sentinel)``.
 
-        Expected format: ``"LABEL/threadId-msgId.yaml"``
+        Expected formats:
+        - ``"LABEL/threadId-msgId.yaml"``  → ``(LABEL, threadId, msgId)``
+        - ``"LABEL/_new.yaml"``            → ``(LABEL, None, "_new")``  (write sentinel)
+        - ``"LABEL/_reply.yaml"``          → ``(LABEL, None, "_reply")``
+        - ``"LABEL/_forward.yaml"``        → ``(LABEL, None, "_forward")``
 
         Returns ``(None, None, None)`` for unparseable keys.
         """
@@ -162,6 +171,12 @@ class GmailTransport:
             return parts[0] if len(parts) == 2 else None, None, None
 
         base = filename.removesuffix(".yaml")
+
+        # Sentinel filenames for write operations (e.g. _new, _reply, _forward)
+        if base.startswith("_"):
+            label = parts[0] if len(parts) == 2 else None
+            return label, None, base
+
         if "-" not in base:
             return None, None, None
 
@@ -299,14 +314,366 @@ class GmailTransport:
             ) from e
 
     # ------------------------------------------------------------------
+    # YAML parsing
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _parse_yaml_content(data: bytes) -> dict[str, Any]:
+        """Parse YAML bytes, extracting ``agent_intent`` / ``confirm`` from comments."""
+        text = data.decode("utf-8")
+        result: dict[str, Any] = {}
+
+        for line in text.split("\n"):
+            line = line.strip()
+            if line.startswith("# agent_intent:"):
+                result["agent_intent"] = line.replace("# agent_intent:", "").strip()
+            elif line.startswith("# confirm:"):
+                result["confirm"] = line.replace("# confirm:", "").strip().lower() == "true"
+            elif line.startswith("# user_confirmed:"):
+                result["user_confirmed"] = (
+                    line.replace("# user_confirmed:", "").strip().lower() == "true"
+                )
+
+        yaml_content = yaml.safe_load(text) or {}
+        if isinstance(yaml_content, dict):
+            result.update(yaml_content)
+        return result
+
+    # ------------------------------------------------------------------
+    # MIME building helpers
+    # ------------------------------------------------------------------
+
+    def _resolve_from_address(self) -> str:
+        """Resolve the sender email address from config or context."""
+        if self._user_email:
+            return self._user_email
+        if self._context and self._context.user_id:
+            return self._context.user_id
+        return "me"
+
+    def _build_mime_message(self, data: dict[str, Any]) -> EmailMessage:
+        """Build a new MIME message from parsed YAML data.
+
+        Handles To, Cc, Bcc, Subject, plain-text body, and optional HTML alternative.
+        """
+        msg = EmailMessage()
+        msg["From"] = data.get("from", self._resolve_from_address())
+
+        # Recipients
+        to_list = data.get("to", [])
+        if isinstance(to_list, str):
+            to_list = [to_list]
+        msg["To"] = ", ".join(to_list)
+
+        cc_list = data.get("cc") or []
+        if isinstance(cc_list, str):
+            cc_list = [cc_list]
+        if cc_list:
+            msg["Cc"] = ", ".join(cc_list)
+
+        bcc_list = data.get("bcc") or []
+        if isinstance(bcc_list, str):
+            bcc_list = [bcc_list]
+        if bcc_list:
+            msg["Bcc"] = ", ".join(bcc_list)
+
+        msg["Subject"] = data.get("subject", "")
+
+        # Body
+        body_text = data.get("body", "")
+        html_body = data.get("html_body")
+
+        if html_body:
+            msg.make_alternative()
+            msg.add_alternative(body_text, subtype="plain")
+            msg.add_alternative(html_body, subtype="html")
+        else:
+            msg.set_content(body_text)
+
+        return msg
+
+    def _build_reply_mime(
+        self,
+        data: dict[str, Any],
+        original: dict[str, Any],
+    ) -> EmailMessage:
+        """Build a reply MIME message with proper threading headers.
+
+        Sets In-Reply-To, References, and ``Re:`` subject prefix.
+        Returns the message along with the threadId for Gmail API.
+        """
+        msg = EmailMessage()
+        msg["From"] = data.get("from", self._resolve_from_address())
+
+        # Determine reply recipients
+        reply_all = data.get("reply_all", False)
+        original_from = original.get("from", original.get("headers", {}).get("From", ""))
+        original_to = original.get("to", original.get("headers", {}).get("To", ""))
+        original_cc = original.get("cc", original.get("headers", {}).get("Cc", ""))
+
+        if reply_all:
+            # Reply-all: To = original From + original To, Cc = original Cc
+            all_to = [original_from]
+            if original_to:
+                to_parts = [t.strip() for t in original_to.split(",") if t.strip()]
+                all_to.extend(to_parts)
+            # Remove self from recipients
+            my_addr = self._resolve_from_address().lower()
+            all_to = [t for t in all_to if my_addr not in t.lower()]
+            msg["To"] = ", ".join(all_to) if all_to else original_from
+
+            if original_cc:
+                cc_parts = [c.strip() for c in original_cc.split(",") if c.strip()]
+                cc_parts = [c for c in cc_parts if my_addr not in c.lower()]
+                if cc_parts:
+                    msg["Cc"] = ", ".join(cc_parts)
+        else:
+            msg["To"] = original_from
+
+        # Additional recipients
+        additional_to = data.get("additional_to") or []
+        if isinstance(additional_to, str):
+            additional_to = [additional_to]
+        if additional_to:
+            existing_to = msg.get("To", "")
+            msg.replace_header("To", ", ".join([existing_to] + additional_to))
+
+        # Subject with Re: prefix
+        original_subject = original.get("subject", original.get("headers", {}).get("Subject", ""))
+        if not original_subject.startswith("Re: "):
+            msg["Subject"] = f"Re: {original_subject}"
+        else:
+            msg["Subject"] = original_subject
+
+        # Threading headers
+        original_message_id = original.get("headers", {}).get("Message-ID", "")
+        if original_message_id:
+            msg["In-Reply-To"] = original_message_id
+            msg["References"] = original_message_id
+
+        # Body
+        body_text = data.get("body", "")
+        html_body = data.get("html_body")
+
+        if html_body:
+            msg.make_alternative()
+            msg.add_alternative(body_text, subtype="plain")
+            msg.add_alternative(html_body, subtype="html")
+        else:
+            msg.set_content(body_text)
+
+        return msg
+
+    def _build_forward_mime(
+        self,
+        data: dict[str, Any],
+        original: dict[str, Any],
+    ) -> EmailMessage:
+        """Build a forward MIME message with quoted original content.
+
+        Prepends user comment (if any) and adds ``---------- Forwarded message ----------``
+        separator with original headers.
+        """
+        msg = EmailMessage()
+        msg["From"] = data.get("from", self._resolve_from_address())
+
+        # Recipients
+        to_list = data.get("to", [])
+        if isinstance(to_list, str):
+            to_list = [to_list]
+        msg["To"] = ", ".join(to_list)
+
+        cc_list = data.get("cc") or []
+        if isinstance(cc_list, str):
+            cc_list = [cc_list]
+        if cc_list:
+            msg["Cc"] = ", ".join(cc_list)
+
+        # Subject with Fwd: prefix
+        original_subject = original.get("subject", original.get("headers", {}).get("Subject", ""))
+        if not original_subject.startswith("Fwd: "):
+            msg["Subject"] = f"Fwd: {original_subject}"
+        else:
+            msg["Subject"] = original_subject
+
+        # Build forwarded body
+        comment = data.get("comment", "")
+        original_from = original.get("from", original.get("headers", {}).get("From", ""))
+        original_to = original.get("to", original.get("headers", {}).get("To", ""))
+        original_date = original.get("date", original.get("headers", {}).get("Date", ""))
+        original_body = original.get("body_text", "")
+
+        forward_separator = (
+            "\n---------- Forwarded message ----------\n"
+            f"From: {original_from}\n"
+            f"Date: {original_date}\n"
+            f"Subject: {original_subject}\n"
+            f"To: {original_to}\n\n"
+            f"{original_body}"
+        )
+
+        body = f"{comment}\n{forward_separator}" if comment else forward_separator
+
+        msg.set_content(body)
+        return msg
+
+    @staticmethod
+    def _encode_mime_raw(msg: EmailMessage) -> str:
+        """Base64url-encode a MIME message for the Gmail API ``raw`` field."""
+        raw_bytes = msg.as_bytes()
+        return base64.urlsafe_b64encode(raw_bytes).decode("ascii")
+
+    # ------------------------------------------------------------------
+    # Gmail write helpers
+    # ------------------------------------------------------------------
+
+    def _send_new_email(
+        self,
+        service: "Resource",
+        data: dict[str, Any],
+    ) -> str:
+        """Send a new email via messages.send()."""
+        msg = self._build_mime_message(data)
+        raw = self._encode_mime_raw(msg)
+        try:
+            result = service.users().messages().send(userId="me", body={"raw": raw}).execute()
+            return str(result.get("id", ""))
+        except Exception as e:
+            raise BackendError(
+                f"Failed to send email: {e}",
+                backend="gmail",
+            ) from e
+
+    def _send_reply(
+        self,
+        service: "Resource",
+        data: dict[str, Any],
+    ) -> str:
+        """Send a reply to an existing thread via messages.send() with threadId."""
+        message_id = data.get("message_id", "")
+        thread_id = data.get("thread_id", "")
+
+        if not message_id:
+            raise BackendError(
+                "Reply requires 'message_id' of the message to reply to.",
+                backend="gmail",
+            )
+        if not thread_id:
+            raise BackendError(
+                "Reply requires 'thread_id' of the thread to reply to.",
+                backend="gmail",
+            )
+
+        # Fetch original message for threading headers
+        original = self._fetch_email(service, message_id)
+        msg = self._build_reply_mime(data, original)
+        raw = self._encode_mime_raw(msg)
+
+        try:
+            result = (
+                service.users()
+                .messages()
+                .send(userId="me", body={"raw": raw, "threadId": thread_id})
+                .execute()
+            )
+            return str(result.get("id", ""))
+        except Exception as e:
+            raise BackendError(
+                f"Failed to send reply: {e}",
+                backend="gmail",
+            ) from e
+
+    def _send_forward(
+        self,
+        service: "Resource",
+        data: dict[str, Any],
+    ) -> str:
+        """Forward an email via messages.send()."""
+        message_id = data.get("message_id", "")
+        if not message_id:
+            raise BackendError(
+                "Forward requires 'message_id' of the message to forward.",
+                backend="gmail",
+            )
+
+        # Fetch original message for quoting
+        original = self._fetch_email(service, message_id)
+        msg = self._build_forward_mime(data, original)
+        raw = self._encode_mime_raw(msg)
+
+        try:
+            result = service.users().messages().send(userId="me", body={"raw": raw}).execute()
+            return str(result.get("id", ""))
+        except Exception as e:
+            raise BackendError(
+                f"Failed to forward email: {e}",
+                backend="gmail",
+            ) from e
+
+    def _create_draft(
+        self,
+        service: "Resource",
+        data: dict[str, Any],
+    ) -> str:
+        """Create a draft via drafts.create()."""
+        msg = self._build_mime_message(data)
+        raw = self._encode_mime_raw(msg)
+
+        draft_body: dict[str, Any] = {"message": {"raw": raw}}
+        # If this is a reply draft, include threadId
+        thread_id = data.get("thread_id")
+        if thread_id:
+            draft_body["message"]["threadId"] = thread_id
+
+        try:
+            result = service.users().drafts().create(userId="me", body=draft_body).execute()
+            return str(result.get("id", ""))
+        except Exception as e:
+            raise BackendError(
+                f"Failed to create draft: {e}",
+                backend="gmail",
+            ) from e
+
+    # ------------------------------------------------------------------
     # Transport protocol methods
     # ------------------------------------------------------------------
 
     def store(self, key: str, data: bytes, content_type: str = "") -> str | None:
-        raise BackendError(
-            "Gmail transport is read-only. Cannot store content.",
-            backend="gmail",
-        )
+        """Send, reply, forward, or draft an email based on the key sentinel.
+
+        Dispatch rules:
+        - ``SENT/_new.yaml``     → send new email
+        - ``SENT/_reply.yaml``   → reply to thread
+        - ``SENT/_forward.yaml`` → forward message
+        - ``DRAFTS/_new.yaml``   → create draft
+        """
+        label, _thread_id, sentinel = self._parse_key(key)
+        if not label or not sentinel or not sentinel.startswith("_"):
+            raise BackendError(
+                f"Invalid write key: {key}. "
+                "Use SENT/_new.yaml, SENT/_reply.yaml, SENT/_forward.yaml, or DRAFTS/_new.yaml",
+                backend="gmail",
+            )
+
+        parsed = self._parse_yaml_content(data)
+        service = self._get_gmail_service()
+
+        dispatch = {
+            ("SENT", "_new"): self._send_new_email,
+            ("SENT", "_reply"): self._send_reply,
+            ("SENT", "_forward"): self._send_forward,
+            ("DRAFTS", "_new"): self._create_draft,
+        }
+
+        handler = dispatch.get((label, sentinel))
+        if handler is None:
+            raise BackendError(
+                f"Unsupported write operation: label={label}, sentinel={sentinel}. "
+                "Supported: SENT/_new, SENT/_reply, SENT/_forward, DRAFTS/_new",
+                backend="gmail",
+            )
+
+        return handler(service, parsed)
 
     def fetch(self, key: str, version_id: str | None = None) -> tuple[bytes, str | None]:
         """Fetch a single email as YAML bytes by transport key."""
@@ -320,10 +687,27 @@ class GmailTransport:
         return content, None
 
     def remove(self, key: str) -> None:
-        raise BackendError(
-            "Gmail transport is read-only. Cannot remove content.",
-            backend="gmail",
-        )
+        """Trash a Gmail message (recoverable — not permanent delete).
+
+        Calls ``messages.trash(id=message_id)`` which moves the message
+        to the Trash label.  Messages in Trash are auto-deleted after 30 days.
+        """
+        _label, _thread_id, message_id = self._parse_key(key)
+        if not message_id or (message_id and message_id.startswith("_")):
+            raise BackendError(
+                f"Invalid key for trash: {key}. Expected LABEL/threadId-msgId.yaml",
+                backend="gmail",
+            )
+
+        service = self._get_gmail_service()
+        try:
+            service.users().messages().trash(userId="me", id=message_id).execute()
+            logger.info("Trashed Gmail message: %s", message_id)
+        except Exception as e:
+            raise BackendError(
+                f"Failed to trash message {message_id}: {e}",
+                backend="gmail",
+            ) from e
 
     def exists(self, key: str) -> bool:
         """Check whether a message key exists in Gmail."""
@@ -370,7 +754,49 @@ class GmailTransport:
         if not prefix:
             return [], [f"{label}/" for label in LABEL_FOLDERS]
 
-        # Label folder → list messages
+        # DRAFTS folder → use drafts.list API
+        if prefix == "DRAFTS":
+            service = self._get_gmail_service()
+            try:
+                result = (
+                    service.users()
+                    .drafts()
+                    .list(userId="me", maxResults=self._max_message_per_label)
+                    .execute()
+                )
+                keys = []
+                for draft in result.get("drafts", []):
+                    draft_id = draft.get("id", "")
+                    msg = draft.get("message", {})
+                    thread_id = msg.get("threadId", draft_id)
+                    msg_id = msg.get("id", draft_id)
+                    keys.append(f"DRAFTS/{thread_id}-{msg_id}.yaml")
+                return sorted(keys), []
+            except Exception as e:
+                logger.debug("Failed to list drafts: %s", e)
+                return [], []
+
+        # TRASH folder → use messages.list with TRASH label
+        if prefix == "TRASH":
+            service = self._get_gmail_service()
+            try:
+                result = (
+                    service.users()
+                    .messages()
+                    .list(userId="me", labelIds=["TRASH"], maxResults=self._max_message_per_label)
+                    .execute()
+                )
+                keys = []
+                for msg in result.get("messages", []):
+                    thread_id = msg.get("threadId", msg["id"])
+                    msg_id = msg["id"]
+                    keys.append(f"TRASH/{thread_id}-{msg_id}.yaml")
+                return sorted(keys), []
+            except Exception as e:
+                logger.debug("Failed to list trash: %s", e)
+                return [], []
+
+        # Other label folders → list messages via categorized listing
         if prefix in LABEL_FOLDERS:
             service = self._get_gmail_service()
             emails = list_emails_by_folder(

--- a/tests/e2e/self_contained/test_gmail_connector.py
+++ b/tests/e2e/self_contained/test_gmail_connector.py
@@ -6,15 +6,21 @@ Tests the Gmail connector end-to-end including:
 - Error formatting with SKILL.md references
 - SKILL.md auto-generation from static file
 - YAML parsing
+- Write operations (send, reply, forward, draft)
+- Delete operations (trash)
+- MIME message building
 
 Note: These tests mock the Gmail API since we can't
 use real OAuth tokens in CI. For full E2E testing with real
 Google API, use OAuth authentication via the integrations page.
 """
 
+import base64
+from email import message_from_bytes
 from unittest.mock import MagicMock, patch
 
 import pytest
+import yaml
 from pydantic import ValidationError as PydanticValidationError
 
 from nexus.backends.connectors.base import ValidationError
@@ -23,7 +29,9 @@ from nexus.backends.connectors.gmail.schemas import (
     ReplyEmailSchema,
     SendEmailSchema,
 )
+from nexus.backends.connectors.gmail.transport import LABEL_FOLDERS, GmailTransport
 from nexus.backends.storage.cas_local import CASLocalBackend
+from nexus.contracts.exceptions import BackendError
 from nexus.contracts.types import OperationContext
 from nexus.core.config import PermissionConfig
 from nexus.factory import create_nexus_fs
@@ -47,7 +55,7 @@ def mock_gmail_service():
         "labelIds": ["SENT"],
     }
 
-    # Mock messages().get()
+    # Mock messages().get() — includes Message-ID header for reply/forward tests
     service.users().messages().get().execute.return_value = {
         "id": "msg_123",
         "threadId": "thread_abc",
@@ -58,6 +66,7 @@ def mock_gmail_service():
                 {"name": "To", "value": "recipient@example.com"},
                 {"name": "Subject", "value": "Test Subject"},
                 {"name": "Date", "value": "Mon, 15 Jan 2024 09:00:00 -0800"},
+                {"name": "Message-ID", "value": "<original-msg-id@example.com>"},
             ],
             "body": {"data": "VGVzdCBlbWFpbCBib2R5"},  # Base64: "Test email body"
         },
@@ -72,10 +81,30 @@ def mock_gmail_service():
         ]
     }
 
+    # Mock messages().trash()
+    service.users().messages().trash().execute.return_value = {
+        "id": "msg_123",
+        "labelIds": ["TRASH"],
+    }
+
     # Mock drafts().create()
     service.users().drafts().create().execute.return_value = {
         "id": "draft_123",
         "message": {"id": "msg_draft_123", "threadId": "thread_draft"},
+    }
+
+    # Mock drafts().list()
+    service.users().drafts().list().execute.return_value = {
+        "drafts": [
+            {
+                "id": "draft_1",
+                "message": {"id": "msg_draft_1", "threadId": "thread_d1"},
+            },
+            {
+                "id": "draft_2",
+                "message": {"id": "msg_draft_2", "threadId": "thread_d2"},
+            },
+        ]
     }
 
     return service
@@ -480,3 +509,492 @@ class TestOperationTraits:
         assert traits is not None
         assert traits.reversibility == Reversibility.FULL  # Can delete draft
         assert traits.confirm == ConfirmLevel.INTENT  # Only needs intent
+
+
+# ============================================================================
+# WRITE OPERATIONS TESTS
+# ============================================================================
+
+
+class TestWriteOperations:
+    """Test Gmail write operations (send, reply, forward, draft)."""
+
+    def test_send_email(self, gmail_backend, mock_gmail_service, operation_context):
+        """Test sending a new email via write_content."""
+        content = yaml.dump(
+            {
+                "agent_intent": "User requested to send a project update to the team",
+                "to": ["alice@example.com"],
+                "subject": "Project Update",
+                "body": "Hi team, here is the update.",
+                "confirm": True,
+            }
+        ).encode("utf-8")
+
+        ctx = OperationContext(
+            user_id="test@example.com",
+            groups=[],
+            zone_id="root",
+            backend_path="SENT/_new.yaml",
+        )
+
+        result = gmail_backend.write_content(content, context=ctx)
+
+        assert result.content_id == "sent_msg_123"
+        assert result.size == len(content)
+        mock_gmail_service.users().messages().send.assert_called()
+
+    def test_reply_email(self, gmail_backend, mock_gmail_service, operation_context):
+        """Test replying to an email thread via write_content."""
+        content = yaml.dump(
+            {
+                "agent_intent": "User wants to reply to the project thread with feedback",
+                "thread_id": "thread_abc",
+                "message_id": "msg_123",
+                "body": "Thanks for the update! Looks good.",
+                "confirm": True,
+            }
+        ).encode("utf-8")
+
+        ctx = OperationContext(
+            user_id="test@example.com",
+            groups=[],
+            zone_id="root",
+            backend_path="SENT/_reply.yaml",
+        )
+
+        result = gmail_backend.write_content(content, context=ctx)
+
+        assert result.content_id == "sent_msg_123"
+        mock_gmail_service.users().messages().send.assert_called()
+
+    def test_forward_email(self, gmail_backend, mock_gmail_service, operation_context):
+        """Test forwarding an email via write_content."""
+        content = yaml.dump(
+            {
+                "agent_intent": "User wants to forward the report to the external partner",
+                "message_id": "msg_123",
+                "to": ["partner@external.com"],
+                "comment": "FYI - Here's the report we discussed.",
+                "confirm": True,
+            }
+        ).encode("utf-8")
+
+        ctx = OperationContext(
+            user_id="test@example.com",
+            groups=[],
+            zone_id="root",
+            backend_path="SENT/_forward.yaml",
+        )
+
+        result = gmail_backend.write_content(content, context=ctx)
+
+        assert result.content_id == "sent_msg_123"
+        mock_gmail_service.users().messages().send.assert_called()
+
+    def test_create_draft(self, gmail_backend, mock_gmail_service, operation_context):
+        """Test creating a draft via write_content."""
+        content = yaml.dump(
+            {
+                "agent_intent": "User wants to create a draft for later review and editing",
+                "to": ["client@example.com"],
+                "subject": "Re: Project Proposal",
+                "body": "Thank you for your proposal...",
+            }
+        ).encode("utf-8")
+
+        ctx = OperationContext(
+            user_id="test@example.com",
+            groups=[],
+            zone_id="root",
+            backend_path="DRAFTS/_new.yaml",
+        )
+
+        result = gmail_backend.write_content(content, context=ctx)
+
+        assert result.content_id == "draft_123"
+        mock_gmail_service.users().drafts().create.assert_called()
+
+    def test_invalid_write_path(self, gmail_backend, operation_context):
+        """Test that writing to an invalid path raises BackendError."""
+        content = yaml.dump(
+            {
+                "agent_intent": "This should fail because path is invalid for writing",
+                "body": "test",
+                "confirm": True,
+            }
+        ).encode("utf-8")
+
+        ctx = OperationContext(
+            user_id="test@example.com",
+            groups=[],
+            zone_id="root",
+            backend_path="INBOX/_new.yaml",  # INBOX doesn't support writes
+        )
+
+        with pytest.raises(BackendError):
+            gmail_backend.write_content(content, context=ctx)
+
+
+# ============================================================================
+# DELETE (TRASH) OPERATIONS TESTS
+# ============================================================================
+
+
+class TestDeleteOperations:
+    """Test Gmail delete (trash) operations."""
+
+    def test_trash_message(self, gmail_backend, mock_gmail_service, operation_context):
+        """Test trashing a message via delete_content."""
+        ctx = OperationContext(
+            user_id="test@example.com",
+            groups=[],
+            zone_id="root",
+            backend_path="INBOX/thread_abc-msg_123.yaml",
+        )
+
+        gmail_backend.delete_content("", context=ctx)
+
+        mock_gmail_service.users().messages().trash.assert_called()
+
+    def test_trash_invalid_path(self, gmail_backend, operation_context):
+        """Test that trashing with a sentinel path raises error."""
+        ctx = OperationContext(
+            user_id="test@example.com",
+            groups=[],
+            zone_id="root",
+            backend_path="SENT/_new.yaml",
+        )
+
+        with pytest.raises(BackendError):
+            gmail_backend.delete_content("", context=ctx)
+
+
+# ============================================================================
+# MIME BUILDING TESTS
+# ============================================================================
+
+
+class TestMimeBuilding:
+    """Test MIME message building helpers on GmailTransport."""
+
+    @pytest.fixture
+    def transport(self):
+        """Create a GmailTransport with test config (no real auth)."""
+        transport = GmailTransport(
+            token_manager=MagicMock(),
+            provider="gmail",
+            user_email="me@example.com",
+        )
+        return transport
+
+    def test_build_basic_mime(self, transport):
+        """Test basic MIME message structure."""
+        data = {
+            "to": ["alice@example.com", "bob@example.com"],
+            "subject": "Test Subject",
+            "body": "Hello, this is a test.",
+        }
+
+        msg = transport._build_mime_message(data)
+
+        assert msg["From"] == "me@example.com"
+        assert "alice@example.com" in msg["To"]
+        assert "bob@example.com" in msg["To"]
+        assert msg["Subject"] == "Test Subject"
+
+        # Verify body content
+        body = msg.get_content()
+        assert "Hello, this is a test." in body
+
+    def test_build_mime_with_cc_bcc(self, transport):
+        """Test MIME message with CC and BCC."""
+        data = {
+            "to": ["alice@example.com"],
+            "cc": ["cc@example.com"],
+            "bcc": ["bcc@example.com"],
+            "subject": "With CC/BCC",
+            "body": "Content",
+        }
+
+        msg = transport._build_mime_message(data)
+
+        assert "cc@example.com" in msg["Cc"]
+        assert "bcc@example.com" in msg["Bcc"]
+
+    def test_build_mime_with_html(self, transport):
+        """Test MIME message with HTML alternative."""
+        data = {
+            "to": ["alice@example.com"],
+            "subject": "HTML Email",
+            "body": "Plain text version",
+            "html_body": "<h1>HTML version</h1>",
+        }
+
+        msg = transport._build_mime_message(data)
+
+        # Should be multipart/alternative
+        assert msg.get_content_type() == "multipart/alternative"
+
+        # Verify both parts exist
+        parts = list(msg.iter_parts())
+        assert len(parts) == 2
+        assert parts[0].get_content_type() == "text/plain"
+        assert parts[1].get_content_type() == "text/html"
+
+    def test_build_reply_threading_headers(self, transport):
+        """Test reply MIME has correct threading headers."""
+        data = {
+            "body": "This is my reply.",
+        }
+        original = {
+            "from": "sender@example.com",
+            "to": "me@example.com",
+            "subject": "Original Subject",
+            "headers": {
+                "From": "sender@example.com",
+                "To": "me@example.com",
+                "Subject": "Original Subject",
+                "Message-ID": "<original-123@example.com>",
+            },
+        }
+
+        msg = transport._build_reply_mime(data, original)
+
+        assert msg["Subject"] == "Re: Original Subject"
+        assert msg["In-Reply-To"] == "<original-123@example.com>"
+        assert msg["References"] == "<original-123@example.com>"
+        assert "sender@example.com" in msg["To"]
+
+    def test_build_reply_already_re_prefix(self, transport):
+        """Test reply does not double the Re: prefix."""
+        data = {"body": "Reply text"}
+        original = {
+            "from": "sender@example.com",
+            "subject": "Re: Already replied",
+            "headers": {
+                "From": "sender@example.com",
+                "Subject": "Re: Already replied",
+            },
+        }
+
+        msg = transport._build_reply_mime(data, original)
+
+        assert msg["Subject"] == "Re: Already replied"
+        assert not msg["Subject"].startswith("Re: Re:")
+
+    def test_build_forward_separator(self, transport):
+        """Test forward message includes forwarded separator."""
+        data = {
+            "to": ["forward@example.com"],
+            "comment": "FYI - see below.",
+        }
+        original = {
+            "from": "sender@example.com",
+            "to": "me@example.com",
+            "subject": "Important Report",
+            "date": "2024-01-15T09:00:00-08:00",
+            "body_text": "Here is the report content.",
+            "headers": {
+                "From": "sender@example.com",
+                "To": "me@example.com",
+                "Subject": "Important Report",
+                "Date": "2024-01-15T09:00:00-08:00",
+            },
+        }
+
+        msg = transport._build_forward_mime(data, original)
+
+        assert msg["Subject"] == "Fwd: Important Report"
+        assert "forward@example.com" in msg["To"]
+
+        body = msg.get_content()
+        assert "---------- Forwarded message ----------" in body
+        assert "From: sender@example.com" in body
+        assert "FYI - see below." in body
+        assert "Here is the report content." in body
+
+    def test_encode_mime_raw(self, transport):
+        """Test base64url encoding of MIME message."""
+        data = {
+            "to": ["test@example.com"],
+            "subject": "Encoding Test",
+            "body": "Hello",
+        }
+
+        msg = transport._build_mime_message(data)
+        raw = GmailTransport._encode_mime_raw(msg)
+
+        # Should be valid base64url
+        decoded = base64.urlsafe_b64decode(raw)
+        parsed = message_from_bytes(decoded)
+        assert parsed["Subject"] == "Encoding Test"
+
+
+# ============================================================================
+# LIST DIR WITH DRAFTS / TRASH TESTS
+# ============================================================================
+
+
+class TestListDirWithDraftsTrash:
+    """Test that directory listing includes DRAFTS/ and TRASH/."""
+
+    def test_root_listing_includes_drafts_and_trash(self, gmail_backend, operation_context):
+        """Test that root listing includes DRAFTS/ and TRASH/ folders."""
+        dirs = gmail_backend.list_dir("/", context=operation_context)
+
+        assert "DRAFTS/" in dirs
+        assert "TRASH/" in dirs
+        assert "INBOX/" in dirs
+        assert "SENT/" in dirs
+
+    def test_label_folders_constant(self):
+        """Test LABEL_FOLDERS includes DRAFTS and TRASH."""
+        assert "DRAFTS" in LABEL_FOLDERS
+        assert "TRASH" in LABEL_FOLDERS
+        assert "INBOX" in LABEL_FOLDERS
+        assert "SENT" in LABEL_FOLDERS
+
+    def test_list_drafts_folder(self, gmail_backend, mock_gmail_service, operation_context):
+        """Test listing DRAFTS folder returns draft entries."""
+        dirs = gmail_backend.list_dir("DRAFTS", context=operation_context)
+
+        # Should have 2 drafts from mock
+        assert len(dirs) == 2
+        mock_gmail_service.users().drafts().list.assert_called()
+
+    def test_list_trash_folder(self, gmail_backend, mock_gmail_service, operation_context):
+        """Test listing TRASH folder returns trashed entries."""
+        dirs = gmail_backend.list_dir("TRASH", context=operation_context)
+
+        # Should have 2 messages from mock (messages.list with TRASH label)
+        assert len(dirs) == 2
+        mock_gmail_service.users().messages().list.assert_called()
+
+
+# ============================================================================
+# PARSE KEY TESTS (sentinel support)
+# ============================================================================
+
+
+class TestParseKey:
+    """Test _parse_key with sentinel filenames."""
+
+    def test_parse_standard_key(self):
+        """Test parsing standard message key."""
+        label, thread_id, msg_id = GmailTransport._parse_key("INBOX/thread123-msg456.yaml")
+
+        assert label == "INBOX"
+        assert thread_id == "thread123"
+        assert msg_id == "msg456"
+
+    def test_parse_sentinel_new(self):
+        """Test parsing _new sentinel key."""
+        label, thread_id, sentinel = GmailTransport._parse_key("SENT/_new.yaml")
+
+        assert label == "SENT"
+        assert thread_id is None
+        assert sentinel == "_new"
+
+    def test_parse_sentinel_reply(self):
+        """Test parsing _reply sentinel key."""
+        label, thread_id, sentinel = GmailTransport._parse_key("SENT/_reply.yaml")
+
+        assert label == "SENT"
+        assert thread_id is None
+        assert sentinel == "_reply"
+
+    def test_parse_sentinel_forward(self):
+        """Test parsing _forward sentinel key."""
+        label, thread_id, sentinel = GmailTransport._parse_key("SENT/_forward.yaml")
+
+        assert label == "SENT"
+        assert thread_id is None
+        assert sentinel == "_forward"
+
+    def test_parse_drafts_new(self):
+        """Test parsing DRAFTS/_new sentinel key."""
+        label, thread_id, sentinel = GmailTransport._parse_key("DRAFTS/_new.yaml")
+
+        assert label == "DRAFTS"
+        assert thread_id is None
+        assert sentinel == "_new"
+
+    def test_parse_invalid_key(self):
+        """Test parsing invalid key returns None tuple."""
+        label, thread_id, msg_id = GmailTransport._parse_key("invalid/path/too/deep.yaml")
+
+        assert label is None
+        assert thread_id is None
+        assert msg_id is None
+
+
+# ============================================================================
+# YAML PARSING TESTS
+# ============================================================================
+
+
+class TestYamlParsing:
+    """Test _parse_yaml_content with comment extraction."""
+
+    def test_parse_with_comments(self):
+        """Test parsing YAML with agent_intent and confirm in comments."""
+        content = (
+            b"# agent_intent: User wants to send an email update\n"
+            b"# confirm: true\n"
+            b"to:\n"
+            b"  - alice@example.com\n"
+            b"subject: Test\n"
+            b"body: Hello\n"
+        )
+
+        result = GmailTransport._parse_yaml_content(content)
+
+        assert result["agent_intent"] == "User wants to send an email update"
+        assert result["confirm"] is True
+        assert result["to"] == ["alice@example.com"]
+        assert result["subject"] == "Test"
+
+    def test_parse_without_comments(self):
+        """Test parsing YAML without comment metadata."""
+        content = yaml.dump(
+            {
+                "agent_intent": "Inline intent field",
+                "to": ["bob@example.com"],
+                "body": "Content",
+            }
+        ).encode("utf-8")
+
+        result = GmailTransport._parse_yaml_content(content)
+
+        assert result["agent_intent"] == "Inline intent field"
+        assert result["to"] == ["bob@example.com"]
+
+
+# ============================================================================
+# BACKEND FEATURES TESTS
+# ============================================================================
+
+
+class TestBackendFeatures:
+    """Test backend feature flags."""
+
+    def test_write_back_feature(self, gmail_backend):
+        """Test that Gmail connector has WRITE_BACK feature."""
+        from nexus.contracts.backend_features import BackendFeature
+
+        assert gmail_backend.has_feature(BackendFeature.WRITE_BACK)
+
+    def test_skill_doc_feature(self, gmail_backend):
+        """Test that Gmail connector has SKILL_DOC feature."""
+        from nexus.contracts.backend_features import BackendFeature
+
+        assert gmail_backend.has_feature(BackendFeature.SKILL_DOC)
+
+    def test_oauth_features(self, gmail_backend):
+        """Test that Gmail connector has OAuth features."""
+        from nexus.contracts.backend_features import BackendFeature
+
+        assert gmail_backend.has_feature(BackendFeature.USER_SCOPED)
+        assert gmail_backend.has_feature(BackendFeature.TOKEN_MANAGER)
+        assert gmail_backend.has_feature(BackendFeature.OAUTH)


### PR DESCRIPTION
## Summary
- Implement full Gmail CRUD, replacing read-only stubs
- **Send**: `write SENT/_new.yaml` → `messages.send()` with MIME construction
- **Reply**: `write SENT/_reply.yaml` → `messages.send()` with In-Reply-To/References threading
- **Forward**: `write SENT/_forward.yaml` → `messages.send()` with quoted original
- **Draft**: `write DRAFTS/_new.yaml` → `drafts.create()`
- **Trash**: `rm INBOX/{msg}.yaml` → `messages.trash()` (recoverable)
- Add DRAFTS/ and TRASH/ to virtual directory listing
- Wire existing Pydantic schemas + operation traits into write path
- Calendar-pattern validation: traits → schema → checkpoint → transport.store()

## Test plan
- [x] 55/55 tests pass (26 existing + 29 new)
- [x] Ruff + mypy clean
- [x] Pre-commit hooks pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)