### PR TITLE
refactor: add locked() Tier 2 context manager, migrate atomic_update from EventsService

### DIFF
--- a/src/nexus/contracts/filesystem/filesystem_abc.py
+++ b/src/nexus/contracts/filesystem/filesystem_abc.py
@@ -20,7 +20,9 @@ Two tiers:
 """
 
 import builtins
+import contextlib
 from abc import ABC, abstractmethod
+from collections.abc import AsyncIterator
 from typing import Any
 
 from nexus.contracts.types import OperationContext
@@ -363,6 +365,45 @@ class NexusFilesystemABC(ABC):
     ) -> bool:
         """Release lock (Tier 2 alias for sys_unlock)."""
         return await self.sys_unlock(path, lock_id, context=context)
+
+    @contextlib.asynccontextmanager
+    async def locked(
+        self,
+        path: str,
+        mode: str = "exclusive",
+        timeout: float = 30.0,
+        ttl: float = 30.0,
+        max_holders: int = 1,
+        *,
+        context: "OperationContext | None" = None,
+    ) -> "AsyncIterator[str]":
+        """Async context manager for advisory lock (Tier 2).
+
+        Acquires lock via lock() (blocking wait), yields lock_id,
+        releases on exit. Raises LockTimeout on failure.
+
+        Usage::
+
+            async with nx.locked("/shared/config.json", timeout=5.0) as lock_id:
+                content = await nx.sys_read("/shared/config.json")
+                await nx.write("/shared/config.json", new_content)
+        """
+        from nexus.contracts.exceptions import LockTimeout
+
+        lock_id = await self.lock(
+            path,
+            mode=mode,
+            timeout=timeout,
+            ttl=ttl,
+            max_holders=max_holders,
+            context=context,
+        )
+        if lock_id is None:
+            raise LockTimeout(path=path, timeout=timeout)
+        try:
+            yield lock_id
+        finally:
+            await self.unlock(lock_id, path, context=context)
 
     # ── System Info + Lifecycle ────────────────────────────────────
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -1241,7 +1241,7 @@ class NexusFS(  # type: ignore[misc]
         """Acquire advisory lock synchronously via EventsService.
 
         This method bridges sync write() with async lock operations.
-        For async contexts, use `async with events_service.locked()` instead.
+        For async contexts, use `async with nx.locked()` instead.
         """
         import asyncio
 
@@ -1258,7 +1258,7 @@ class NexusFS(  # type: ignore[misc]
             asyncio.get_running_loop()
             raise RuntimeError(
                 "write(lock=True) cannot be used from async context (event loop detected). "
-                "Use `async with nx.service('events_service').locked(path):` and `write(lock=False)` instead."
+                "Use `async with nx.locked(path):` and `write(lock=False)` instead."
             )
         except RuntimeError as e:
             if "event loop detected" in str(e):
@@ -2820,14 +2820,7 @@ class NexusFS(  # type: ignore[misc]
             ...     lambda c: json.dumps({**json.loads(c), "version": 2}).encode()
             ... )
         """
-        _events_ref = self.service("events_service") if hasattr(self, "service") else None
-        if _events_ref is None:
-            raise RuntimeError(
-                "atomic_update() requires EventsService. "
-                "Ensure NexusFS is initialized with services."
-            )
-
-        async with _events_ref.locked(path, timeout=timeout, ttl=ttl) as lock_id:  # noqa: F841
+        async with self.locked(path, timeout=timeout, ttl=ttl, context=context) as lock_id:  # noqa: F841
             content = await self.sys_read(path, context=context)
             new_content = update_fn(content)
             return await self.write(path, new_content, context=context)

--- a/src/nexus/factory/service_routing.py
+++ b/src/nexus/factory/service_routing.py
@@ -27,7 +27,7 @@ _CANONICAL_EXPORTS: dict[str, tuple[str, ...]] = {
         "federation_unmount",
     ),
     "rebac": ("rebac_check", "rebac_create", "rebac_list_tuples", "rebac_expand"),
-    "events": ("wait_for_changes", "locked"),
+    "events": ("wait_for_changes",),
     "mount": ("add_mount", "remove_mount", "list_mounts"),
     "gateway": (
         "mkdir",

--- a/tests/unit/server/test_rpc_parity.py
+++ b/tests/unit/server/test_rpc_parity.py
@@ -118,6 +118,7 @@ def test_all_public_methods_are_exposed_or_excluded():
         # Tier 2 convenience wrappers — delegate to sys_lock/sys_unlock which ARE @rpc_expose
         "lock",  # Tier 2 blocking wait over sys_lock (defined in NexusFilesystemABC)
         "unlock",  # Tier 2 alias for sys_unlock (defined in NexusFilesystemABC)
+        "locked",  # Tier 2 async context manager for lock/unlock (defined in NexusFilesystemABC)
         # Server-side only methods (clients get this via HTTP headers)
         "get_etag",  # Returns ETag for early 304 check - clients receive ETags via HTTP headers on read
         # Async methods - TODO: Add async RPC support
@@ -167,7 +168,7 @@ def test_all_public_methods_are_exposed_or_excluded():
         # Distributed Lock methods - async context managers require special handling
         # Tracked in Issue #1141
         "atomic_update",  # Async - read-modify-write with distributed lock
-        "locked",  # Async context manager - distributed lock acquisition
+        # Async context manager - distributed lock acquisition
         # Consistency migration - server-side orchestration only (Issue #1180)
         "migrate_consistency_mode",  # Internal - SC↔EC migration orchestrator, exposed via PATCH endpoint
         # KernelDispatch OBSERVE registration (Issue #900) - server-side observer registration


### PR DESCRIPTION
## Summary

- Add `locked()` async context manager to NexusFilesystemABC (Tier 2 convenience over `lock()`/`unlock()`)
- Migrate `atomic_update()` to use `self.locked()` instead of `EventsService.locked()`
- Remove `"locked"` from EventsService RPC exports
- Update docstrings: `events_service.locked()` → `nx.locked()`

EventsService lock methods (`lock`, `extend_lock`, `unlock`, `locked`) are now unused by kernel code. EventsService retains only `wait_for_changes()` for watch functionality.

## Test plan

- [x] `pytest tests/unit/core/test_factory_boot.py tests/unit/test_factory.py` — 45 passed
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)