### PR TITLE
feat(#3244): TUI EmptyState in all panels + Stack debug panel

### DIFF
--- a/packages/nexus-api-client/src/config.ts
+++ b/packages/nexus-api-client/src/config.ts
@@ -86,11 +86,10 @@ function readYamlConfig(): YamlConfig {
     const path = require("node:path") as typeof import("node:path");
 
     // Walk up from CWD looking for nexus.yaml or nexus.yml.
-    // Stops at the git/worktree root (.git file or directory) so we don't
-    // leak into a parent repository. This handles:
-    //   - Running from packages/nexus-tui/ → finds nexus.yaml at repo root
-    //   - Git worktrees (.git is a file) → finds config at worktree root
-    //   - Won't escape into the parent repo that contains the worktree
+    // Stops at the git root (.git file or directory) to avoid leaking
+    // into a parent repository. For git worktrees, this means the search
+    // stops at the worktree root — each worktree should have its own
+    // nexus.yaml (created via `nexus init` from the pre-connection screen).
     const candidates: string[] = [];
     let dir = path.resolve(".");
     for (let i = 0; i < 20; i++) {

--- a/packages/nexus-api-client/src/config.ts
+++ b/packages/nexus-api-client/src/config.ts
@@ -66,9 +66,13 @@ interface YamlConfig {
 
 /**
  * Minimal YAML reader matching the Python CLI search order:
- *   1. ./nexus.yaml
- *   2. ./nexus.yml
- *   3. ~/.nexus/config.yaml
+ *   1. Walk up from CWD looking for nexus.yaml / nexus.yml
+ *   2. ~/.nexus/config.yaml
+ *
+ * Walking up from CWD handles two important cases:
+ *   - Running the TUI from a subdirectory (e.g. packages/nexus-tui/)
+ *   - Running from a git worktree inside the main repo tree, where
+ *     nexus.yaml is gitignored and only exists in the original repo root
  *
  * Only reads top-level `url:` and `api_key:` fields via regex.
  * Avoids pulling in a full YAML parser dependency.
@@ -81,14 +85,27 @@ function readYamlConfig(): YamlConfig {
     const os = require("node:os") as typeof import("node:os");
     const path = require("node:path") as typeof import("node:path");
 
-    // Search order: CWD first, then home dir.
-    // Each TUI instance uses its own nexus.yaml in its CWD to avoid
-    // conflicts with other running Nexus stacks.
-    const candidates = [
-      path.resolve("nexus.yaml"),
-      path.resolve("nexus.yml"),
-      path.join(os.homedir(), ".nexus", "config.yaml"),
-    ];
+    // Walk up from CWD looking for nexus.yaml or nexus.yml.
+    // Stops at the git/worktree root (.git file or directory) so we don't
+    // leak into a parent repository. This handles:
+    //   - Running from packages/nexus-tui/ → finds nexus.yaml at repo root
+    //   - Git worktrees (.git is a file) → finds config at worktree root
+    //   - Won't escape into the parent repo that contains the worktree
+    const candidates: string[] = [];
+    let dir = path.resolve(".");
+    for (let i = 0; i < 20; i++) {
+      candidates.push(path.join(dir, "nexus.yaml"));
+      candidates.push(path.join(dir, "nexus.yml"));
+      // Stop after reaching a git root (both regular repos and worktrees)
+      try {
+        if (fs.existsSync(path.join(dir, ".git"))) break;
+      } catch { /* ignore */ }
+      const parent = path.dirname(dir);
+      if (parent === dir) break;
+      dir = parent;
+    }
+    // Fallback: home dir config
+    candidates.push(path.join(os.homedir(), ".nexus", "config.yaml"));
 
     for (const configPath of candidates) {
       try {

--- a/packages/nexus-tui/src/app.tsx
+++ b/packages/nexus-tui/src/app.tsx
@@ -35,6 +35,7 @@ const WorkflowsPanel = lazy(() => import("./panels/workflows/workflows-panel.js"
 const EventsPanel = lazy(() => import("./panels/events/events-panel.js"));
 const ApiConsolePanel = lazy(() => import("./panels/api-console/api-console-panel.js"));
 const ConnectorsPanel = lazy(() => import("./panels/connectors/connectors-panel.js"));
+const StackPanel = lazy(() => import("./panels/stack/stack-panel.js"));
 
 const TABS: readonly Tab[] = [
   { id: "files", label: "Files", shortcut: "1" },
@@ -48,6 +49,7 @@ const TABS: readonly Tab[] = [
   { id: "infrastructure", label: "Event", shortcut: "9" },
   { id: "console", label: "CLI", shortcut: "0" },
   { id: "connectors", label: "Conn", shortcut: "C" },
+  { id: "stack", label: "Stack", shortcut: "S" },
 ];
 
 function PanelRouter(): React.ReactNode {
@@ -76,6 +78,8 @@ function PanelRouter(): React.ReactNode {
       return <ApiConsolePanel />;
     case "connectors":
       return <ConnectorsPanel />;
+    case "stack":
+      return <StackPanel />;
     default:
       return (
         <box height="100%" width="100%" justifyContent="center" alignItems="center">
@@ -175,6 +179,7 @@ export function App(): React.ReactNode {
           "9": () => { if (!useUiStore.getState().fileEditorOpen) setActivePanel("infrastructure"); },
           "0": () => { if (!useUiStore.getState().fileEditorOpen) setActivePanel("console"); },
           "shift+c": () => { if (!useUiStore.getState().fileEditorOpen) setActivePanel("connectors"); },
+          "shift+s": () => { if (!useUiStore.getState().fileEditorOpen) setActivePanel("stack"); },
           "ctrl+i": toggleIdentitySwitcher,
           "ctrl+d": () => {
             // Disconnect and go back to setup menu

--- a/packages/nexus-tui/src/panels/access/alert-list.tsx
+++ b/packages/nexus-tui/src/panels/access/alert-list.tsx
@@ -4,6 +4,7 @@
 
 import React from "react";
 import type { GovernanceAlert } from "../../stores/access-store.js";
+import { EmptyState } from "../../shared/components/empty-state.js";
 
 interface AlertListProps {
   readonly alerts: readonly GovernanceAlert[];
@@ -35,11 +36,7 @@ export function AlertList({ alerts, selectedIndex, loading }: AlertListProps): R
   }
 
   if (alerts.length === 0) {
-    return (
-      <box height="100%" width="100%" justifyContent="center" alignItems="center">
-        <text>No governance alerts</text>
-      </box>
-    );
+    return <EmptyState message="No alerts found." />;
   }
 
   return (

--- a/packages/nexus-tui/src/panels/access/credential-list.tsx
+++ b/packages/nexus-tui/src/panels/access/credential-list.tsx
@@ -4,6 +4,7 @@
 
 import React from "react";
 import type { Credential } from "../../stores/access-store.js";
+import { EmptyState } from "../../shared/components/empty-state.js";
 
 interface CredentialListProps {
   readonly credentials: readonly Credential[];
@@ -37,11 +38,7 @@ export function CredentialList({
   }
 
   if (credentials.length === 0) {
-    return (
-      <box height="100%" width="100%" justifyContent="center" alignItems="center">
-        <text>No credentials found</text>
-      </box>
-    );
+    return <EmptyState message="No credentials found." hint="Press i to issue a credential." />;
   }
 
   return (

--- a/packages/nexus-tui/src/panels/access/delegation-list.tsx
+++ b/packages/nexus-tui/src/panels/access/delegation-list.tsx
@@ -5,6 +5,7 @@
 
 import React from "react";
 import type { DelegationItem } from "../../stores/access-store.js";
+import { EmptyState } from "../../shared/components/empty-state.js";
 
 interface DelegationListProps {
   readonly delegations: readonly DelegationItem[];
@@ -40,11 +41,7 @@ export function DelegationList({
   }
 
   if (delegations.length === 0) {
-    return (
-      <box height="100%" width="100%" justifyContent="center" alignItems="center">
-        <text>No delegations found</text>
-      </box>
-    );
+    return <EmptyState message="No delegations yet." hint="Press n to create one." />;
   }
 
   return (

--- a/packages/nexus-tui/src/panels/access/manifest-list.tsx
+++ b/packages/nexus-tui/src/panels/access/manifest-list.tsx
@@ -6,6 +6,7 @@
 
 import React from "react";
 import type { AccessManifest } from "../../stores/access-store.js";
+import { EmptyState } from "../../shared/components/empty-state.js";
 
 interface ManifestListProps {
   readonly manifests: readonly AccessManifest[];
@@ -40,11 +41,7 @@ export function ManifestList({
   }
 
   if (manifests.length === 0) {
-    return (
-      <box height="100%" width="100%" justifyContent="center" alignItems="center">
-        <text>No access manifests found</text>
-      </box>
-    );
+    return <EmptyState message="No manifests found." hint="Press c to create a manifest." />;
   }
 
   const selected = manifests[selectedIndex];

--- a/packages/nexus-tui/src/panels/api-console/endpoint-list.tsx
+++ b/packages/nexus-tui/src/panels/api-console/endpoint-list.tsx
@@ -4,6 +4,7 @@
 
 import React from "react";
 import { useApiConsoleStore, type EndpointInfo } from "../../stores/api-console-store.js";
+import { EmptyState } from "../../shared/components/empty-state.js";
 
 const METHOD_BADGE: Record<string, string> = {
   GET: "GET   ",
@@ -21,12 +22,9 @@ export function EndpointList(): React.ReactNode {
   const searchQuery = useApiConsoleStore((s) => s.searchQuery);
 
   if (endpoints.length === 0) {
-    const message = searchQuery ? "No endpoints match your search" : "No endpoints loaded";
-    return (
-      <box height="100%" width="100%">
-        <text>{message}</text>
-      </box>
-    );
+    return searchQuery
+      ? <EmptyState message="No endpoints match your search." />
+      : <EmptyState message="No endpoints available." hint="Check server connection." />;
   }
 
   return (

--- a/packages/nexus-tui/src/panels/payments/approval-list.tsx
+++ b/packages/nexus-tui/src/panels/payments/approval-list.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import type { ApprovalRequest } from "../../stores/payments-store.js";
 import { LoadingIndicator } from "../../shared/components/loading-indicator.js";
 import { statusColor } from "../../shared/theme.js";
+import { EmptyState } from "../../shared/components/empty-state.js";
 
 interface ApprovalListProps {
   readonly approvals: readonly ApprovalRequest[];
@@ -42,11 +43,7 @@ export function ApprovalList({
   }
 
   if (approvals.length === 0) {
-    return (
-      <box height="100%" width="100%" justifyContent="center" alignItems="center">
-        <text dimColor>No approval requests found</text>
-      </box>
-    );
+    return <EmptyState message="No approvals yet." hint="Press n to request approval." />;
   }
 
   return (

--- a/packages/nexus-tui/src/panels/payments/policy-list.tsx
+++ b/packages/nexus-tui/src/panels/payments/policy-list.tsx
@@ -5,6 +5,7 @@
 import React from "react";
 import type { PolicyRecord } from "../../stores/payments-store.js";
 import { LoadingIndicator } from "../../shared/components/loading-indicator.js";
+import { EmptyState } from "../../shared/components/empty-state.js";
 
 interface PolicyListProps {
   readonly policies: readonly PolicyRecord[];
@@ -27,11 +28,7 @@ export function PolicyList({
   }
 
   if (policies.length === 0) {
-    return (
-      <box height="100%" width="100%" justifyContent="center" alignItems="center">
-        <text>No spending policies found</text>
-      </box>
-    );
+    return <EmptyState message="No policies yet." hint="Press Shift+N to create a policy." />;
   }
 
   return (

--- a/packages/nexus-tui/src/panels/payments/reservation-list.tsx
+++ b/packages/nexus-tui/src/panels/payments/reservation-list.tsx
@@ -5,6 +5,7 @@
 import React from "react";
 import type { Reservation } from "../../stores/payments-store.js";
 import { LoadingIndicator } from "../../shared/components/loading-indicator.js";
+import { EmptyState } from "../../shared/components/empty-state.js";
 
 interface ReservationListProps {
   readonly reservations: readonly Reservation[];
@@ -42,11 +43,7 @@ export function ReservationList({
   }
 
   if (reservations.length === 0) {
-    return (
-      <box height="100%" width="100%" justifyContent="center" alignItems="center">
-        <text>No reservations found</text>
-      </box>
-    );
+    return <EmptyState message="No reservations yet." hint="Reservations are created during transfers." />;
   }
 
   return (

--- a/packages/nexus-tui/src/panels/payments/transaction-list.tsx
+++ b/packages/nexus-tui/src/panels/payments/transaction-list.tsx
@@ -6,6 +6,7 @@
 import React from "react";
 import type { TransactionRecord, IntegrityResult } from "../../stores/payments-store.js";
 import { LoadingIndicator } from "../../shared/components/loading-indicator.js";
+import { EmptyState } from "../../shared/components/empty-state.js";
 
 interface TransactionListProps {
   readonly transactions: readonly TransactionRecord[];
@@ -48,11 +49,7 @@ export function TransactionList({
   }
 
   if (transactions.length === 0) {
-    return (
-      <box height="100%" width="100%" justifyContent="center" alignItems="center">
-        <text>No transactions found</text>
-      </box>
-    );
+    return <EmptyState message="No transactions yet." hint="Press t to create a transfer." />;
   }
 
   const selectedTx = transactions[selectedIndex];

--- a/packages/nexus-tui/src/panels/stack/stack-panel.tsx
+++ b/packages/nexus-tui/src/panels/stack/stack-panel.tsx
@@ -65,7 +65,7 @@ function ContainerList({
   }
 
   if (containers.length === 0) {
-    return <EmptyState message="No containers found." hint="Press Shift+U to start the stack." />;
+    return <EmptyState message="No containers found." hint="Start the stack with: nexus up" />;
   }
 
   return (
@@ -118,7 +118,7 @@ function ConfigView({
   }
 
   if (!yaml) {
-    return <EmptyState message="No nexus.yaml found." hint="Press I to initialize." />;
+    return <EmptyState message="No nexus.yaml found." hint="Run: nexus init --preset shared" />;
   }
 
   const lines = yaml.split("\n");

--- a/packages/nexus-tui/src/panels/stack/stack-panel.tsx
+++ b/packages/nexus-tui/src/panels/stack/stack-panel.tsx
@@ -1,0 +1,474 @@
+/**
+ * Stack panel: Docker container status, nexus.yaml config, .state.json runtime,
+ * and server health — all in one place for debugging.
+ *
+ * Tabs: Containers | Config | State
+ * Keybindings: Tab to switch, r to refresh, j/k to scroll.
+ */
+
+import React, { useEffect, useState } from "react";
+import { useStackStore, type StackTab, type ContainerInfo, type StackPaths } from "../../stores/stack-store.js";
+import { useKeyboard } from "../../shared/hooks/use-keyboard.js";
+import { useApi } from "../../shared/hooks/use-api.js";
+import { useUiStore } from "../../stores/ui-store.js";
+import { useGlobalStore } from "../../stores/global-store.js";
+import { EmptyState } from "../../shared/components/empty-state.js";
+import { LoadingIndicator } from "../../shared/components/loading-indicator.js";
+import { statusColor } from "../../shared/theme.js";
+
+// =============================================================================
+// Tab definitions
+// =============================================================================
+
+const TAB_ORDER: readonly StackTab[] = ["containers", "config", "state"];
+
+const TAB_LABELS: Readonly<Record<StackTab, string>> = {
+  containers: "Containers",
+  config: "Config",
+  state: "State",
+};
+
+// =============================================================================
+// Container status colors
+// =============================================================================
+
+const CONTAINER_STATE_COLOR: Record<string, string> = {
+  running: statusColor.healthy,
+  exited: statusColor.error,
+  paused: statusColor.warning,
+  restarting: statusColor.warning,
+  dead: statusColor.error,
+  created: statusColor.dim,
+};
+
+const HEALTH_COLOR: Record<string, string> = {
+  healthy: statusColor.healthy,
+  unhealthy: statusColor.error,
+  starting: statusColor.warning,
+};
+
+// =============================================================================
+// Sub-components
+// =============================================================================
+
+function ContainerList({
+  containers,
+  loading,
+  selectedIndex,
+}: {
+  containers: readonly ContainerInfo[];
+  loading: boolean;
+  selectedIndex: number;
+}): React.ReactNode {
+  if (loading) {
+    return <LoadingIndicator message="Querying Docker..." />;
+  }
+
+  if (containers.length === 0) {
+    return <EmptyState message="No containers found." hint="Press Shift+U to start the stack." />;
+  }
+
+  return (
+    <scrollbox height="100%" width="100%">
+      {/* Header */}
+      <box height={1} width="100%">
+        <text>{"  CONTAINER NAME                      SERVICE       STATE       HEALTH      PORTS                    IMAGE"}</text>
+      </box>
+      <box height={1} width="100%">
+        <text>{"  ------------------------------------  -----------  ----------  ----------  -----------------------  -------------------------"}</text>
+      </box>
+
+      {/* Rows */}
+      {containers.map((c, i) => {
+        const isSelected = i === selectedIndex;
+        const prefix = isSelected ? "> " : "  ";
+        const stateColor = CONTAINER_STATE_COLOR[c.state] ?? statusColor.dim;
+        const hColor = HEALTH_COLOR[c.health] ?? statusColor.dim;
+        const name = c.name.length > 36 ? c.name.slice(0, 33) + "..." : c.name;
+        const image = c.image.length > 25 ? c.image.slice(0, 22) + "..." : c.image;
+        const ports = c.ports.length > 23 ? c.ports.slice(0, 20) + "..." : c.ports;
+
+        return (
+          <box key={c.name} height={1} width="100%">
+            <text>
+              {`${prefix}${name.padEnd(36)}  ${c.service.padEnd(11)}  `}
+              <span foregroundColor={stateColor}>{c.state.padEnd(10)}</span>
+              {"  "}
+              <span foregroundColor={hColor}>{(c.health || "-").padEnd(10)}</span>
+              {`  ${ports.padEnd(23)}  ${image}`}
+            </text>
+          </box>
+        );
+      })}
+    </scrollbox>
+  );
+}
+
+function ConfigView({
+  yaml,
+  loading,
+  scrollOffset,
+}: {
+  yaml: string;
+  loading: boolean;
+  scrollOffset: number;
+}): React.ReactNode {
+  if (loading) {
+    return <LoadingIndicator message="Reading nexus.yaml..." />;
+  }
+
+  if (!yaml) {
+    return <EmptyState message="No nexus.yaml found." hint="Press I to initialize." />;
+  }
+
+  const lines = yaml.split("\n");
+
+  return (
+    <scrollbox height="100%" width="100%">
+      <box height={1} width="100%">
+        <text foregroundColor={statusColor.info}>{"  nexus.yaml"}</text>
+      </box>
+      <box height={1} width="100%">
+        <text dimColor>{"  " + "─".repeat(60)}</text>
+      </box>
+      {lines.slice(scrollOffset).map((line, i) => (
+        <box key={i} height={1} width="100%">
+          <text>
+            <span dimColor>{`  ${String(scrollOffset + i + 1).padStart(3)}  `}</span>
+            {line}
+          </text>
+        </box>
+      ))}
+    </scrollbox>
+  );
+}
+
+function StateView({
+  stateJson,
+  loading,
+  projectName,
+  scrollOffset,
+}: {
+  stateJson: Record<string, unknown> | null;
+  loading: boolean;
+  projectName: string | null;
+  scrollOffset: number;
+}): React.ReactNode {
+  if (loading) {
+    return <LoadingIndicator message="Reading .state.json..." />;
+  }
+
+  if (!stateJson) {
+    return <EmptyState message="No .state.json found." hint="Start the stack first." />;
+  }
+
+  // Render key-value pairs with nested object support
+  const lines: { key: string; value: string; indent: number }[] = [];
+
+  function flatten(obj: Record<string, unknown>, indent: number): void {
+    for (const [key, val] of Object.entries(obj)) {
+      if (val && typeof val === "object" && !Array.isArray(val)) {
+        lines.push({ key, value: "", indent });
+        flatten(val as Record<string, unknown>, indent + 1);
+      } else {
+        lines.push({ key, value: String(val), indent });
+      }
+    }
+  }
+  flatten(stateJson, 0);
+
+  return (
+    <scrollbox height="100%" width="100%">
+      <box height={1} width="100%">
+        <text foregroundColor={statusColor.info}>{"  .state.json (runtime)"}</text>
+      </box>
+      {projectName && (
+        <box height={1} width="100%">
+          <text>
+            {"  project_name: "}
+            <span foregroundColor={statusColor.identity}>{projectName}</span>
+          </text>
+        </box>
+      )}
+      <box height={1} width="100%">
+        <text dimColor>{"  " + "─".repeat(60)}</text>
+      </box>
+      {lines.slice(scrollOffset).map((line, i) => {
+        const pad = "  ".repeat(line.indent);
+        return (
+          <box key={i} height={1} width="100%">
+            <text>
+              {"  "}{pad}
+              <span foregroundColor={statusColor.info}>{line.key}</span>
+              {line.value ? ": " : ""}
+              {line.value}
+            </text>
+          </box>
+        );
+      })}
+    </scrollbox>
+  );
+}
+
+function PathsBar({ paths }: { paths: StackPaths | null }): React.ReactNode {
+  if (!paths) return null;
+
+  return (
+    <box height={4} width="100%" flexDirection="column">
+      <box height={1} width="100%">
+        <text dimColor>{"  Paths:"}</text>
+      </box>
+      <box height={1} width="100%">
+        <text>
+          {"    nexus.yaml   "}
+          <span foregroundColor={statusColor.reference}>{paths.nexusYaml}</span>
+        </text>
+      </box>
+      <box height={1} width="100%">
+        <text>
+          {"    state.json   "}
+          <span foregroundColor={statusColor.reference}>{paths.stateJson}</span>
+        </text>
+      </box>
+      <box height={1} width="100%">
+        <text>
+          {"    compose      "}
+          <span foregroundColor={statusColor.reference}>{paths.composeFile}</span>
+          <span dimColor>{"  │  data: "}</span>
+          <span foregroundColor={statusColor.reference}>{paths.dataDir}</span>
+        </text>
+      </box>
+    </box>
+  );
+}
+
+function HealthSummary({
+  healthDetails,
+  uptime,
+  serverVersion,
+}: {
+  healthDetails: { status: string; components: Record<string, { status: string; detail?: string }> } | null;
+  uptime: number | null;
+  serverVersion: string | null;
+}): React.ReactNode {
+  if (!healthDetails) return null;
+
+  const color = healthDetails.status === "healthy"
+    ? statusColor.healthy
+    : healthDetails.status === "degraded"
+    ? statusColor.warning
+    : statusColor.error;
+
+  const uptimeStr = uptime != null
+    ? `${Math.floor(uptime / 3600)}h ${Math.floor((uptime % 3600) / 60)}m`
+    : "-";
+
+  const componentEntries = Object.entries(healthDetails.components);
+
+  return (
+    <box height={componentEntries.length > 0 ? componentEntries.length + 3 : 2} width="100%" flexDirection="column">
+      <box height={1} width="100%">
+        <text>
+          {"  Server: "}
+          <span foregroundColor={color}>{healthDetails.status}</span>
+          {"  │  uptime: "}{uptimeStr}
+          {serverVersion ? `  │  v${serverVersion}` : ""}
+        </text>
+      </box>
+      {componentEntries.length > 0 && (
+        <>
+          <box height={1} width="100%">
+            <text dimColor>{"  Components:"}</text>
+          </box>
+          {componentEntries.map(([name, comp]) => {
+            const cColor = comp.status === "healthy" || comp.status === "ok"
+              ? statusColor.healthy
+              : comp.status === "degraded"
+              ? statusColor.warning
+              : statusColor.error;
+            return (
+              <box key={name} height={1} width="100%">
+                <text>
+                  {"    "}
+                  <span foregroundColor={cColor}>{"●"}</span>
+                  {` ${name.padEnd(24)} `}
+                  <span foregroundColor={cColor}>{comp.status}</span>
+                  {comp.detail ? `  ${comp.detail}` : ""}
+                </text>
+              </box>
+            );
+          })}
+        </>
+      )}
+    </box>
+  );
+}
+
+// =============================================================================
+// Main panel
+// =============================================================================
+
+export default function StackPanel(): React.ReactNode {
+  const client = useApi();
+  const overlayActive = useUiStore((s) => s.overlayActive);
+  const serverVersion = useGlobalStore((s) => s.serverVersion);
+  const uptime = useGlobalStore((s) => s.uptime);
+
+  const activeTab = useStackStore((s) => s.activeTab);
+  const setActiveTab = useStackStore((s) => s.setActiveTab);
+  const containers = useStackStore((s) => s.containers);
+  const containersLoading = useStackStore((s) => s.containersLoading);
+  const configYaml = useStackStore((s) => s.configYaml);
+  const configLoading = useStackStore((s) => s.configLoading);
+  const stateJson = useStackStore((s) => s.stateJson);
+  const stateLoading = useStackStore((s) => s.stateLoading);
+  const healthDetails = useStackStore((s) => s.healthDetails);
+  const paths = useStackStore((s) => s.paths);
+  const error = useStackStore((s) => s.error);
+  const refreshAll = useStackStore((s) => s.refreshAll);
+
+  const [selectedIndex, setSelectedIndex] = useState(0);
+  const [scrollOffset, setScrollOffset] = useState(0);
+
+  // Derive project name from state.json
+  const projectName = stateJson?.project_name as string | null ?? null;
+
+  // Initial fetch
+  useEffect(() => {
+    refreshAll(client);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [client]);
+
+  // Reset selection/scroll on tab change
+  useEffect(() => {
+    setSelectedIndex(0);
+    setScrollOffset(0);
+  }, [activeTab]);
+
+  // List length for current tab
+  const listLength = activeTab === "containers"
+    ? containers.length
+    : activeTab === "config"
+    ? configYaml.split("\n").length
+    : stateJson
+    ? Object.keys(stateJson).length * 3 // approximate
+    : 0;
+
+  useKeyboard(
+    overlayActive
+      ? {}
+      : {
+          tab: () => {
+            const idx = TAB_ORDER.indexOf(activeTab);
+            const next = TAB_ORDER[(idx + 1) % TAB_ORDER.length]!;
+            setActiveTab(next);
+          },
+          j: () => {
+            if (activeTab === "containers") {
+              setSelectedIndex((i) => Math.min(i + 1, containers.length - 1));
+            } else {
+              setScrollOffset((o) => Math.min(o + 1, Math.max(listLength - 5, 0)));
+            }
+          },
+          down: () => {
+            if (activeTab === "containers") {
+              setSelectedIndex((i) => Math.min(i + 1, containers.length - 1));
+            } else {
+              setScrollOffset((o) => Math.min(o + 1, Math.max(listLength - 5, 0)));
+            }
+          },
+          k: () => {
+            if (activeTab === "containers") {
+              setSelectedIndex((i) => Math.max(i - 1, 0));
+            } else {
+              setScrollOffset((o) => Math.max(o - 1, 0));
+            }
+          },
+          up: () => {
+            if (activeTab === "containers") {
+              setSelectedIndex((i) => Math.max(i - 1, 0));
+            } else {
+              setScrollOffset((o) => Math.max(o - 1, 0));
+            }
+          },
+          r: () => {
+            refreshAll(client);
+          },
+          g: () => {
+            setSelectedIndex(0);
+            setScrollOffset(0);
+          },
+          "shift+g": () => {
+            if (activeTab === "containers") {
+              setSelectedIndex(Math.max(containers.length - 1, 0));
+            } else {
+              setScrollOffset(Math.max(listLength - 5, 0));
+            }
+          },
+        },
+  );
+
+  return (
+    <box height="100%" width="100%" flexDirection="column">
+      {/* Tab bar */}
+      <box height={1} width="100%">
+        <text>
+          {TAB_ORDER.map((tab) => {
+            const label = TAB_LABELS[tab];
+            return tab === activeTab ? `[${label}]` : ` ${label} `;
+          }).join(" ")}
+        </text>
+      </box>
+
+      {/* Error display */}
+      {error && (
+        <box height={1} width="100%">
+          <text foregroundColor={statusColor.error}>{`  Error: ${error}`}</text>
+        </box>
+      )}
+
+      {/* Health summary (always visible) */}
+      <HealthSummary
+        healthDetails={healthDetails}
+        uptime={uptime}
+        serverVersion={serverVersion}
+      />
+
+      {/* File paths */}
+      <PathsBar paths={paths} />
+
+      {/* Main content */}
+      <box flexGrow={1} borderStyle="single">
+        {activeTab === "containers" && (
+          <ContainerList
+            containers={containers}
+            loading={containersLoading}
+            selectedIndex={selectedIndex}
+          />
+        )}
+        {activeTab === "config" && (
+          <ConfigView
+            yaml={configYaml}
+            loading={configLoading}
+            scrollOffset={scrollOffset}
+          />
+        )}
+        {activeTab === "state" && (
+          <StateView
+            stateJson={stateJson}
+            loading={stateLoading}
+            projectName={projectName}
+            scrollOffset={scrollOffset}
+          />
+        )}
+      </box>
+
+      {/* Help bar */}
+      <box height={1} width="100%">
+        <text dimColor>
+          {"  j/k:navigate  Tab:switch tab  r:refresh  g/G:top/bottom  q:quit"}
+        </text>
+      </box>
+    </box>
+  );
+}

--- a/packages/nexus-tui/src/panels/zones/zone-list.tsx
+++ b/packages/nexus-tui/src/panels/zones/zone-list.tsx
@@ -6,6 +6,7 @@
 
 import React from "react";
 import type { ZoneResponse } from "../../stores/zones-store.js";
+import { EmptyState } from "../../shared/components/empty-state.js";
 
 interface ZoneListProps {
   readonly zones: readonly ZoneResponse[];
@@ -40,11 +41,7 @@ export function ZoneList({
   }
 
   if (zones.length === 0) {
-    return (
-      <box height="100%" width="100%" justifyContent="center" alignItems="center">
-        <text>No zones found</text>
-      </box>
-    );
+    return <EmptyState message="No zones found." hint="Press n to create a zone." />;
   }
 
   return (

--- a/packages/nexus-tui/src/services/command-runner.ts
+++ b/packages/nexus-tui/src/services/command-runner.ts
@@ -128,6 +128,24 @@ export function killAllProcesses(): void {
 // =============================================================================
 
 /**
+ * Find the project root by walking up from CWD looking for .git (file or dir).
+ * This resolves correctly for both normal repos and git worktrees.
+ * Falls back to CWD if not found.
+ */
+function findProjectRoot(): string {
+  const path = require("node:path");
+  const nodeFs = require("node:fs");
+  let dir = process.cwd();
+  for (let i = 0; i < 20; i++) {
+    if (nodeFs.existsSync(path.join(dir, ".git"))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return process.cwd();
+}
+
+/**
  * Execute a local nexus subcommand via Bun.spawn().
  *
  * Output is streamed into the CommandRunnerStore for rendering by CommandOutput.
@@ -148,6 +166,10 @@ export function executeLocalCommand(command: string, args: readonly string[]): v
     return;
   }
 
+  // Resolve project root (git/worktree root) so commands like `nexus init`
+  // create nexus.yaml at the right level, not inside packages/nexus-tui/.
+  const projectRoot = findProjectRoot();
+
   // Reset state
   useCommandRunnerStore.setState({
     ...INITIAL_STATE,
@@ -157,11 +179,11 @@ export function executeLocalCommand(command: string, args: readonly string[]): v
 
   // Prefer .venv/bin/nexus (project venv) over system PATH to avoid picking up
   // stale installs (e.g. /opt/anaconda3/bin/nexus which lacks the `up` command).
-  // Walk up from CWD to find .venv/bin/nexus (TUI may run from packages/nexus-tui/).
+  // Walk up from project root to find .venv/bin/nexus.
   const path = require("node:path");
   const nodeFs = require("node:fs");
   let nexusBin = "nexus";
-  let searchDir = process.cwd();
+  let searchDir = projectRoot;
   for (let i = 0; i < 5; i++) {
     const candidate = path.join(searchDir, ".venv", "bin", "nexus");
     if (nodeFs.existsSync(candidate)) {
@@ -174,12 +196,12 @@ export function executeLocalCommand(command: string, args: readonly string[]): v
   }
   const fullArgs = [nexusBin, command, ...args];
 
-  // Read the TUI's own nexus.yaml (in CWD) to pass NEXUS_URL and NEXUS_API_KEY
+  // Read nexus.yaml from project root to pass NEXUS_URL and NEXUS_API_KEY
   // to subcommands like `nexus demo init`.
   const spawnEnv = { ...process.env };
   try {
     const fs = require("node:fs");
-    const yaml = fs.readFileSync("nexus.yaml", "utf-8") as string;
+    const yaml = fs.readFileSync(path.join(projectRoot, "nexus.yaml"), "utf-8") as string;
     const portMatch = yaml.match(/ports:\s*\n(?:\s+\w+:[^\n]*\n)*?\s+http:\s*(\d+)/);
     const keyMatch = yaml.match(/^api_key:\s*["']?([^"'\n]+)["']?/m);
     if (portMatch?.[1] && !spawnEnv.NEXUS_URL) {
@@ -193,8 +215,9 @@ export function executeLocalCommand(command: string, args: readonly string[]): v
   }
 
   try {
-    // Commands run from CWD so each TUI instance gets its own nexus.yaml
+    // Commands run from project root so nexus.yaml is created at the right level
     const proc = Bun.spawn(fullArgs, {
+      cwd: projectRoot,
       stdout: "pipe",
       stderr: "pipe",
       env: spawnEnv,

--- a/packages/nexus-tui/src/stores/global-store.ts
+++ b/packages/nexus-tui/src/stores/global-store.ts
@@ -21,7 +21,8 @@ export type PanelId =
   | "workflows"
   | "infrastructure"
   | "console"
-  | "connectors";
+  | "connectors"
+  | "stack";
 
 /** Response from GET /api/v2/features */
 export interface FeaturesResponse {

--- a/packages/nexus-tui/src/stores/stack-store.ts
+++ b/packages/nexus-tui/src/stores/stack-store.ts
@@ -182,8 +182,17 @@ export const useStackStore = create<StackState>((set, get) => ({
         },
       );
 
-      const stdout = await new Response(proc.stdout).text();
-      await proc.exited;
+      const [stdout, stderr, exitCode] = await Promise.all([
+        new Response(proc.stdout).text(),
+        new Response(proc.stderr).text(),
+        proc.exited,
+      ]);
+
+      if (exitCode !== 0) {
+        const errMsg = stderr.trim() || `docker compose ps exited with code ${exitCode}`;
+        set({ containers: [], containersLoading: false, error: errMsg });
+        return;
+      }
 
       const containers = parseDockerPs(stdout);
       set({ containers, containersLoading: false });
@@ -231,7 +240,7 @@ export const useStackStore = create<StackState>((set, get) => ({
           },
         });
       } else {
-        set({ configYaml: "(nexus.yaml not found)", configLoading: false, paths: null });
+        set({ configYaml: "", configLoading: false, paths: null });
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : "Failed to read nexus.yaml";

--- a/packages/nexus-tui/src/stores/stack-store.ts
+++ b/packages/nexus-tui/src/stores/stack-store.ts
@@ -124,23 +124,49 @@ function formatPorts(publishers: { URL?: string; PublishedPort?: number; TargetP
   return parts.join(", ");
 }
 
+function containerFromObj(obj: Record<string, unknown>): ContainerInfo {
+  const publishers = obj.Publishers;
+  return {
+    name: (obj.Name ?? obj.Names ?? "") as string,
+    service: (obj.Service ?? "") as string,
+    state: (obj.State ?? "") as string,
+    health: (obj.Health ?? "") as string,
+    ports: Array.isArray(publishers)
+      ? formatPorts(publishers as { URL?: string; PublishedPort?: number; TargetPort?: number }[])
+      : (obj.Ports ?? "") as string,
+    image: (obj.Image ?? "") as string,
+  };
+}
+
+/**
+ * Parse `docker compose ps --format json` output.
+ * Handles both formats:
+ *   - NDJSON (one JSON object per line) — newer Compose versions
+ *   - JSON array (single `[...]` blob) — older Compose versions
+ */
 function parseDockerPs(output: string): ContainerInfo[] {
-  const containers: ContainerInfo[] = [];
-  for (const line of output.split("\n")) {
-    const trimmed = line.trim();
-    if (!trimmed || !trimmed.startsWith("{")) continue;
+  const trimmed = output.trim();
+  if (!trimmed) return [];
+
+  // Try JSON array first (older Compose: single [...] output)
+  if (trimmed.startsWith("[")) {
     try {
-      const obj = JSON.parse(trimmed);
-      containers.push({
-        name: obj.Name ?? obj.Names ?? "",
-        service: obj.Service ?? "",
-        state: obj.State ?? "",
-        health: obj.Health ?? "",
-        ports: Array.isArray(obj.Publishers)
-          ? formatPorts(obj.Publishers)
-          : obj.Ports ?? "",
-        image: obj.Image ?? "",
-      });
+      const arr = JSON.parse(trimmed);
+      if (Array.isArray(arr)) {
+        return arr.map(containerFromObj);
+      }
+    } catch {
+      // Fall through to NDJSON parsing
+    }
+  }
+
+  // NDJSON: one JSON object per line (newer Compose)
+  const containers: ContainerInfo[] = [];
+  for (const line of trimmed.split("\n")) {
+    const l = line.trim();
+    if (!l || !l.startsWith("{")) continue;
+    try {
+      containers.push(containerFromObj(JSON.parse(l)));
     } catch {
       // Skip non-JSON lines
     }

--- a/packages/nexus-tui/src/stores/stack-store.ts
+++ b/packages/nexus-tui/src/stores/stack-store.ts
@@ -1,0 +1,311 @@
+/**
+ * Zustand store for the Stack panel: Docker containers, nexus.yaml config,
+ * .state.json runtime state, and server health details.
+ *
+ * Reads local files via Bun.file() and runs `docker compose ps` via Bun.spawn().
+ * Server health is fetched via the FetchClient from the global store.
+ */
+
+import { create } from "zustand";
+import type { FetchClient } from "@nexus/api-client";
+import { useErrorStore } from "./error-store.js";
+import { categorizeError } from "./create-api-action.js";
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface ContainerInfo {
+  readonly name: string;
+  readonly service: string;
+  readonly state: string;
+  readonly health: string;
+  readonly ports: string;
+  readonly image: string;
+}
+
+export interface HealthComponent {
+  readonly name: string;
+  readonly status: string;
+  readonly detail: string;
+}
+
+export interface DetailedHealth {
+  readonly status: string;
+  readonly service: string;
+  readonly components: Record<string, { status: string; detail?: string }>;
+}
+
+export type StackTab = "containers" | "config" | "state";
+
+/** Paths to config/state files used by the stack. */
+export interface StackPaths {
+  readonly projectRoot: string;
+  readonly nexusYaml: string;
+  readonly stateJson: string;
+  readonly composeFile: string;
+  readonly dataDir: string;
+}
+
+export interface StackState {
+  // Tabs
+  readonly activeTab: StackTab;
+
+  // Docker containers
+  readonly containers: readonly ContainerInfo[];
+  readonly containersLoading: boolean;
+
+  // nexus.yaml raw content
+  readonly configYaml: string;
+  readonly configLoading: boolean;
+
+  // .state.json parsed
+  readonly stateJson: Record<string, unknown> | null;
+  readonly stateLoading: boolean;
+
+  // Server health details
+  readonly healthDetails: DetailedHealth | null;
+  readonly healthLoading: boolean;
+
+  // File paths
+  readonly paths: StackPaths | null;
+
+  // General
+  readonly error: string | null;
+  readonly lastRefreshed: number;
+
+  // Actions
+  readonly setActiveTab: (tab: StackTab) => void;
+  readonly fetchContainers: () => Promise<void>;
+  readonly fetchConfig: () => Promise<void>;
+  readonly fetchState: () => Promise<void>;
+  readonly fetchHealth: (client: FetchClient) => Promise<void>;
+  readonly refreshAll: (client: FetchClient | null) => Promise<void>;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+/**
+ * Find the project root by walking up from CWD looking for nexus.yaml.
+ * Walks up to 20 levels to handle git worktrees nested inside the main repo
+ * (e.g. .claude/worktrees/<name>/packages/nexus-tui/).
+ * Returns CWD if not found (commands will just fail gracefully).
+ */
+function findProjectRoot(): string {
+  const path = require("node:path");
+  const fs = require("node:fs");
+  let dir = process.cwd();
+  for (let i = 0; i < 20; i++) {
+    if (fs.existsSync(path.join(dir, "nexus.yaml"))) return dir;
+    const parent = path.dirname(dir);
+    if (parent === dir) break;
+    dir = parent;
+  }
+  return process.cwd();
+}
+
+/**
+ * Deduplicate port mappings from Docker Publishers array.
+ * Docker lists each mapping twice (IPv4 0.0.0.0 + IPv6 ::).
+ * Only show published (host-mapped) ports, skip unexposed ones.
+ */
+function formatPorts(publishers: { URL?: string; PublishedPort?: number; TargetPort?: number }[]): string {
+  const seen = new Set<string>();
+  const parts: string[] = [];
+  for (const p of publishers) {
+    if (!p.PublishedPort) continue; // skip unexposed ports
+    const key = `${p.PublishedPort}->${p.TargetPort}`;
+    if (seen.has(key)) continue;
+    seen.add(key);
+    parts.push(key);
+  }
+  return parts.join(", ");
+}
+
+function parseDockerPs(output: string): ContainerInfo[] {
+  const containers: ContainerInfo[] = [];
+  for (const line of output.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed || !trimmed.startsWith("{")) continue;
+    try {
+      const obj = JSON.parse(trimmed);
+      containers.push({
+        name: obj.Name ?? obj.Names ?? "",
+        service: obj.Service ?? "",
+        state: obj.State ?? "",
+        health: obj.Health ?? "",
+        ports: Array.isArray(obj.Publishers)
+          ? formatPorts(obj.Publishers)
+          : obj.Ports ?? "",
+        image: obj.Image ?? "",
+      });
+    } catch {
+      // Skip non-JSON lines
+    }
+  }
+  return containers;
+}
+
+// =============================================================================
+// Store
+// =============================================================================
+
+export const useStackStore = create<StackState>((set, get) => ({
+  activeTab: "containers",
+  containers: [],
+  containersLoading: false,
+  configYaml: "",
+  configLoading: false,
+  stateJson: null,
+  stateLoading: false,
+  healthDetails: null,
+  healthLoading: false,
+  paths: null,
+  error: null,
+  lastRefreshed: 0,
+
+  setActiveTab: (tab) => set({ activeTab: tab }),
+
+  fetchContainers: async () => {
+    set({ containersLoading: true, error: null });
+    try {
+      const projectRoot = findProjectRoot();
+      const proc = Bun.spawn(
+        ["docker", "compose", "ps", "--format", "json", "-a"],
+        {
+          cwd: projectRoot,
+          stdout: "pipe",
+          stderr: "pipe",
+          env: { ...process.env },
+        },
+      );
+
+      const stdout = await new Response(proc.stdout).text();
+      await proc.exited;
+
+      const containers = parseDockerPs(stdout);
+      set({ containers, containersLoading: false });
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to query Docker";
+      set({ containersLoading: false, error: message });
+    }
+  },
+
+  fetchConfig: async () => {
+    set({ configLoading: true });
+    try {
+      const projectRoot = findProjectRoot();
+      const path = require("node:path");
+      const fs = require("node:fs");
+      const yamlPath = path.join(projectRoot, "nexus.yaml");
+      const file = Bun.file(yamlPath);
+      const exists = await file.exists();
+      if (exists) {
+        const text = await file.text();
+
+        // Resolve all file paths from the config
+        let dataDir = path.join(projectRoot, "nexus-data");
+        let composeFile = path.join(projectRoot, "nexus-stack.yml");
+        const dataDirMatch = text.match(/^data_dir:\s*(.+)$/m);
+        if (dataDirMatch?.[1]) {
+          const parsed = dataDirMatch[1].trim().replace(/^["']|["']$/g, "");
+          dataDir = path.isAbsolute(parsed) ? parsed : path.join(projectRoot, parsed);
+        }
+        const composeMatch = text.match(/^compose_file:\s*(.+)$/m);
+        if (composeMatch?.[1]) {
+          const parsed = composeMatch[1].trim().replace(/^["']|["']$/g, "");
+          composeFile = path.isAbsolute(parsed) ? parsed : path.join(projectRoot, parsed);
+        }
+
+        set({
+          configYaml: text,
+          configLoading: false,
+          paths: {
+            projectRoot,
+            nexusYaml: yamlPath,
+            stateJson: path.join(dataDir, ".state.json"),
+            composeFile,
+            dataDir,
+          },
+        });
+      } else {
+        set({ configYaml: "(nexus.yaml not found)", configLoading: false, paths: null });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to read nexus.yaml";
+      set({ configYaml: `Error: ${message}`, configLoading: false });
+    }
+  },
+
+  fetchState: async () => {
+    set({ stateLoading: true });
+    try {
+      const projectRoot = findProjectRoot();
+      const path = require("node:path");
+      const fs = require("node:fs");
+
+      // Read nexus.yaml to find data_dir
+      let dataDir = path.join(projectRoot, "nexus-data");
+      try {
+        const yaml = fs.readFileSync(path.join(projectRoot, "nexus.yaml"), "utf-8") as string;
+        const match = yaml.match(/^data_dir:\s*(.+)$/m);
+        if (match?.[1]) {
+          const parsed = match[1].trim().replace(/^["']|["']$/g, "");
+          dataDir = path.isAbsolute(parsed) ? parsed : path.join(projectRoot, parsed);
+        }
+      } catch {
+        // Use default
+      }
+
+      const stateFile = Bun.file(path.join(dataDir, ".state.json"));
+      const exists = await stateFile.exists();
+      if (exists) {
+        const text = await stateFile.text();
+        const parsed = JSON.parse(text);
+        set({ stateJson: parsed, stateLoading: false });
+      } else {
+        set({ stateJson: null, stateLoading: false });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Failed to read .state.json";
+      set({ stateJson: null, stateLoading: false, error: message });
+    }
+  },
+
+  fetchHealth: async (client: FetchClient) => {
+    set({ healthLoading: true });
+    try {
+      const health = await client.get<DetailedHealth>("/health/detailed");
+      set({ healthDetails: health, healthLoading: false });
+    } catch {
+      // Fall back to basic health
+      try {
+        const basic = await client.get<{ status: string; service: string }>("/health");
+        set({
+          healthDetails: { status: basic.status, service: basic.service, components: {} },
+          healthLoading: false,
+        });
+      } catch (err) {
+        const message = err instanceof Error ? err.message : "Health check failed";
+        set({ healthDetails: null, healthLoading: false });
+        useErrorStore.getState().pushError({ message, category: categorizeError(message), source: "stack" });
+      }
+    }
+  },
+
+  refreshAll: async (client) => {
+    const { fetchContainers, fetchConfig, fetchState, fetchHealth } = get();
+    const promises: Promise<void>[] = [
+      fetchContainers(),
+      fetchConfig(),
+      fetchState(),
+    ];
+    if (client) {
+      promises.push(fetchHealth(client));
+    }
+    await Promise.allSettled(promises);
+    set({ lastRefreshed: Date.now() });
+  },
+}));

--- a/packages/nexus-tui/tests/stores/stack-store.test.ts
+++ b/packages/nexus-tui/tests/stores/stack-store.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Tests for stack-store — Docker container status, config/state file reading,
+ * and server health details.
+ */
+
+import { describe, it, expect, beforeEach, mock } from "bun:test";
+import { useStackStore } from "../../src/stores/stack-store.js";
+import type { FetchClient } from "@nexus/api-client";
+
+describe("StackStore", () => {
+  beforeEach(() => {
+    useStackStore.setState({
+      activeTab: "containers",
+      containers: [],
+      containersLoading: false,
+      configYaml: "",
+      configLoading: false,
+      stateJson: null,
+      stateLoading: false,
+      healthDetails: null,
+      healthLoading: false,
+      error: null,
+      lastRefreshed: 0,
+    });
+  });
+
+  // ===========================================================================
+  // Tab switching
+  // ===========================================================================
+
+  describe("setActiveTab", () => {
+    it("switches to config tab", () => {
+      useStackStore.getState().setActiveTab("config");
+      expect(useStackStore.getState().activeTab).toBe("config");
+    });
+
+    it("switches to state tab", () => {
+      useStackStore.getState().setActiveTab("state");
+      expect(useStackStore.getState().activeTab).toBe("state");
+    });
+
+    it("switches back to containers tab", () => {
+      useStackStore.getState().setActiveTab("state");
+      useStackStore.getState().setActiveTab("containers");
+      expect(useStackStore.getState().activeTab).toBe("containers");
+    });
+  });
+
+  // ===========================================================================
+  // fetchHealth
+  // ===========================================================================
+
+  describe("fetchHealth", () => {
+    it("sets healthDetails on success", async () => {
+      const mockHealth = {
+        status: "healthy",
+        service: "nexus-rpc",
+        components: {
+          search_daemon: { status: "healthy" },
+          rebac: { status: "healthy" },
+        },
+      };
+      const mockClient = {
+        get: mock(async () => mockHealth),
+      } as unknown as FetchClient;
+
+      await useStackStore.getState().fetchHealth(mockClient);
+      const state = useStackStore.getState();
+
+      expect(state.healthDetails).not.toBeNull();
+      expect(state.healthDetails!.status).toBe("healthy");
+      expect(state.healthDetails!.components.search_daemon.status).toBe("healthy");
+      expect(state.healthLoading).toBe(false);
+    });
+
+    it("falls back to basic health on detailed failure", async () => {
+      const callCount = { n: 0 };
+      const mockClient = {
+        get: mock(async (path: string) => {
+          callCount.n++;
+          if (path === "/health/detailed") throw new Error("Forbidden");
+          return { status: "healthy", service: "nexus-rpc" };
+        }),
+      } as unknown as FetchClient;
+
+      await useStackStore.getState().fetchHealth(mockClient);
+      const state = useStackStore.getState();
+
+      expect(state.healthDetails).not.toBeNull();
+      expect(state.healthDetails!.status).toBe("healthy");
+      expect(state.healthDetails!.components).toEqual({});
+      expect(state.healthLoading).toBe(false);
+    });
+
+    it("sets healthDetails to null on complete failure", async () => {
+      const mockClient = {
+        get: mock(async () => { throw new Error("Network error"); }),
+      } as unknown as FetchClient;
+
+      await useStackStore.getState().fetchHealth(mockClient);
+      const state = useStackStore.getState();
+
+      expect(state.healthDetails).toBeNull();
+      expect(state.healthLoading).toBe(false);
+    });
+
+    it("sets healthLoading during fetch", async () => {
+      let resolve: () => void;
+      const pending = new Promise<void>((r) => { resolve = r; });
+      const mockClient = {
+        get: mock(async () => {
+          await pending;
+          return { status: "healthy", service: "nexus-rpc", components: {} };
+        }),
+      } as unknown as FetchClient;
+
+      const promise = useStackStore.getState().fetchHealth(mockClient);
+      expect(useStackStore.getState().healthLoading).toBe(true);
+
+      resolve!();
+      await promise;
+      expect(useStackStore.getState().healthLoading).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // refreshAll
+  // ===========================================================================
+
+  describe("refreshAll", () => {
+    it("updates lastRefreshed timestamp", async () => {
+      const before = Date.now();
+      // refreshAll will call fetchContainers, fetchConfig, fetchState which may
+      // fail in test env (no Docker, no nexus.yaml), but that's fine — they
+      // handle errors gracefully and lastRefreshed should still be set.
+      await useStackStore.getState().refreshAll(null);
+      const after = Date.now();
+
+      const { lastRefreshed } = useStackStore.getState();
+      expect(lastRefreshed).toBeGreaterThanOrEqual(before);
+      expect(lastRefreshed).toBeLessThanOrEqual(after);
+    });
+
+    it("calls fetchHealth when client is provided", async () => {
+      const mockClient = {
+        get: mock(async () => ({
+          status: "healthy",
+          service: "nexus-rpc",
+          components: {},
+        })),
+      } as unknown as FetchClient;
+
+      await useStackStore.getState().refreshAll(mockClient);
+
+      // Should have called get at least once (for /health/detailed)
+      expect(mockClient.get).toHaveBeenCalled();
+      expect(useStackStore.getState().healthDetails).not.toBeNull();
+    });
+
+    it("skips fetchHealth when client is null", async () => {
+      await useStackStore.getState().refreshAll(null);
+      expect(useStackStore.getState().healthDetails).toBeNull();
+    });
+  });
+
+  // ===========================================================================
+  // Initial state
+  // ===========================================================================
+
+  describe("initial state", () => {
+    it("starts with containers tab active", () => {
+      expect(useStackStore.getState().activeTab).toBe("containers");
+    });
+
+    it("starts with empty containers", () => {
+      expect(useStackStore.getState().containers).toEqual([]);
+    });
+
+    it("starts with no health details", () => {
+      expect(useStackStore.getState().healthDetails).toBeNull();
+    });
+
+    it("starts with no state json", () => {
+      expect(useStackStore.getState().stateJson).toBeNull();
+    });
+
+    it("starts with no error", () => {
+      expect(useStackStore.getState().error).toBeNull();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- **EmptyState in all 10 panels** (#3244): Replace generic "No X found" text with shared `EmptyState` component showing warm messages + actionable hints (e.g. "No zones found. Press n to create a zone.")
- **New Stack panel** (Shift+S): Debug panel showing Docker containers (deduplicated ports), server health components, file paths (nexus.yaml, state.json, compose file, data dir), and raw Config/State tabs
- **Worktree DX fixes**: Config resolution walks up to git root (stops at `.git` boundary), command-runner spawns from project root — so `nexus init`/`up` from pre-connection screen works correctly from any subdirectory or git worktree

## Changes

| Area | Files | What |
|------|-------|------|
| EmptyState | 10 panel list files | Import `EmptyState`, replace generic `<box><text>` with `<EmptyState message hint>` |
| Stack panel | `stack-panel.tsx`, `stack-store.ts` | New panel with Containers/Config/State tabs, health summary, file paths |
| Panel registration | `app.tsx`, `global-store.ts` | Add `"stack"` to PanelId, lazy-load, Shift+S shortcut |
| Config resolution | `config.ts` (api-client) | Walk up from CWD to `.git` boundary looking for nexus.yaml |
| Command runner | `command-runner.ts` | Find git root, run commands from there instead of CWD |
| Tests | `stack-store.test.ts` | 15 tests for store state, health fetch, tab switching |

## Test plan

- [x] `bun test` — 849 pass, 0 fail (TUI), 106 pass, 0 fail (api-client)
- [ ] Manual: launch TUI from worktree subdirectory, verify pre-connection [S] creates nexus.yaml at worktree root
- [ ] Manual: Shift+S opens Stack panel with containers, deduplicated ports, file paths
- [ ] Manual: Navigate to empty panels (Zones, Access, Payments, API Console) to verify EmptyState messages