### PR TITLE
fix(cli): set ZOEKT_ENABLED=true when search profile is active

### DIFF
--- a/src/nexus/cli/commands/stack.py
+++ b/src/nexus/cli/commands/stack.py
@@ -152,6 +152,12 @@ def _derive_project_env(
         # port, so the server must not stay bound to container loopback.
         env["NEXUS_GRPC_BIND_ALL"] = "true"
 
+    # Enable zoekt integration when the search compose profile is active.
+    # The compose template defaults ZOEKT_ENABLED to false; override here
+    # so the nexus container connects to the zoekt sidecar container.
+    if "search" in config.get("compose_profiles", []):
+        env["ZOEKT_ENABLED"] = "true"
+
     return env
 
 

--- a/src/nexus/cli/commands/stack.py
+++ b/src/nexus/cli/commands/stack.py
@@ -89,6 +89,7 @@ def _resolve_image_ref_from_config(config: dict[str, Any]) -> str:
 def _derive_project_env(
     config: dict[str, Any],
     resolved_ports: dict[str, int] | None = None,
+    profiles: list[str] | None = None,
 ) -> dict[str, str]:
     """Build the compose environment from nexus.yaml config.
 
@@ -98,6 +99,10 @@ def _derive_project_env(
 
     When *resolved_ports* is provided (e.g. after conflict resolution),
     those values are used instead of config["ports"].
+
+    When *profiles* is provided (e.g. after compose-file validation),
+    those are used to decide profile-gated env vars like ZOEKT_ENABLED
+    instead of the raw config["compose_profiles"].
     """
     data_dir = str(Path(config.get("data_dir", "./nexus-data")).resolve())
     project_hash = hashlib.md5(data_dir.encode()).hexdigest()[:8]
@@ -155,7 +160,11 @@ def _derive_project_env(
     # Enable zoekt integration when the search compose profile is active.
     # The compose template defaults ZOEKT_ENABLED to false; override here
     # so the nexus container connects to the zoekt sidecar container.
-    if "search" in config.get("compose_profiles", []):
+    # Use validated profiles when available so a custom compose file that
+    # lacks the search profile doesn't leave ZOEKT_ENABLED=true with no
+    # zoekt container to talk to.
+    active_profiles = profiles if profiles is not None else config.get("compose_profiles", [])
+    if "search" in active_profiles:
         env["ZOEKT_ENABLED"] = "true"
 
     return env
@@ -776,8 +785,10 @@ def up(
     # NOTE: resolved ports are NOT written back to nexus.yaml.
     # They go into .state.json (written after health check).
 
-    # Build environment from config (project name, ports, data dir, auth, image, TLS)
-    compose_env = _derive_project_env(config, resolved_ports=resolved_ports)
+    # Build environment from config (project name, ports, data dir, auth, image, TLS).
+    # Pass validated profiles so profile-gated env vars (e.g. ZOEKT_ENABLED)
+    # reflect what the compose file actually supports.
+    compose_env = _derive_project_env(config, resolved_ports=resolved_ports, profiles=profiles)
     pgvector_init_sql = _resolve_pgvector_init_sql(cf)
     if pgvector_init_sql:
         compose_env["NEXUS_PGVECTOR_INIT_SQL"] = pgvector_init_sql

--- a/src/nexus/cli/data/nexus-stack.yml
+++ b/src/nexus/cli/data/nexus-stack.yml
@@ -96,7 +96,7 @@ services:
       NEXUS_GRPC_TLS: ${NEXUS_GRPC_TLS:-false}
       NEXUS_GRPC_BIND_ALL: ${NEXUS_GRPC_BIND_ALL:-true}
       # Zoekt (external container, not built-in sidecar)
-      ZOEKT_ENABLED: "false"
+      ZOEKT_ENABLED: ${ZOEKT_ENABLED:-false}
       ZOEKT_URL: ${ZOEKT_URL:-http://zoekt:6070}
     volumes:
       - ${NEXUS_HOST_DATA_DIR:-./nexus-data}:/app/data

--- a/tests/unit/cli/test_stack.py
+++ b/tests/unit/cli/test_stack.py
@@ -390,6 +390,22 @@ class TestDeriveProjectEnv:
         env = _derive_project_env(config)
         assert "ZOEKT_ENABLED" not in env
 
+    def test_validated_profiles_override_config(self, tmp_path: Path) -> None:
+        """Explicit profiles param wins over config compose_profiles.
+
+        When a custom compose file strips the search profile during
+        validation, ZOEKT_ENABLED must not be set even though the
+        raw config still lists search.
+        """
+        config = {
+            "data_dir": str(tmp_path / "data"),
+            "ports": {},
+            "compose_profiles": ["core", "cache", "search"],
+        }
+        # Simulate compose-file validation stripping search
+        env = _derive_project_env(config, profiles=["core", "cache"])
+        assert "ZOEKT_ENABLED" not in env
+
 
 class TestDockerBuildArgs:
     def test_api_embeddings_enabled_sets_build_arg(self) -> None:

--- a/tests/unit/cli/test_stack.py
+++ b/tests/unit/cli/test_stack.py
@@ -370,6 +370,26 @@ class TestDeriveProjectEnv:
         assert env["NEXUS_TXTAI_MODEL"] == "openai/text-embedding-3-small"
         assert env["NEXUS_TXTAI_USE_API_EMBEDDINGS"] == "true"
 
+    def test_search_profile_enables_zoekt(self, tmp_path: Path) -> None:
+        """ZOEKT_ENABLED=true when search compose profile is active."""
+        config = {
+            "data_dir": str(tmp_path / "data"),
+            "ports": {},
+            "compose_profiles": ["core", "cache", "search"],
+        }
+        env = _derive_project_env(config)
+        assert env["ZOEKT_ENABLED"] == "true"
+
+    def test_no_search_profile_omits_zoekt_enabled(self, tmp_path: Path) -> None:
+        """ZOEKT_ENABLED not set when search profile is absent."""
+        config = {
+            "data_dir": str(tmp_path / "data"),
+            "ports": {},
+            "compose_profiles": ["core", "cache"],
+        }
+        env = _derive_project_env(config)
+        assert "ZOEKT_ENABLED" not in env
+
 
 class TestDockerBuildArgs:
     def test_api_embeddings_enabled_sets_build_arg(self) -> None:


### PR DESCRIPTION
## Summary
- The compose template (`nexus-stack.yml`) hardcoded `ZOEKT_ENABLED: "false"`, ignoring the shell environment entirely
- `_derive_project_env()` in `stack.py` never set `ZOEKT_ENABLED` even when the search profile was active
- This meant the zoekt **container** started for shared/demo presets, but the nexus container never connected to it

## Changes
- `nexus-stack.yml`: changed `ZOEKT_ENABLED: "false"` → `${ZOEKT_ENABLED:-false}` so the env var is respected (consistent with `dockerfiles/compose.yaml`)
- `stack.py`: `_derive_project_env()` now sets `ZOEKT_ENABLED=true` when `"search"` is in the config's `compose_profiles`
- Added two unit tests covering both cases

## Test plan
- [x] All 59 existing `test_stack.py` tests pass
- [x] New tests: `test_search_profile_enables_zoekt` and `test_no_search_profile_omits_zoekt_enabled`
- [ ] Manual: `nexus init --preset demo && nexus up` → verify zoekt integration is active in nexus logs