### PR TITLE
fix: prevent bound keys from firing during playground command mode

### DIFF
--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -1388,6 +1388,17 @@ class PlaygroundApp(App[None]):
         """Toggle command input."""
         self.command_visible = not self.command_visible
 
+    def check_action(self, action: str, parameters: tuple[object, ...]) -> bool | None:  # noqa: ARG002
+        """Disable non-command actions when command mode is active."""
+        if self.command_visible:
+            return action in {
+                "toggle_command",
+                "submit_command",
+                "command_backspace",
+                "cancel_command",
+            }
+        return True
+
     async def action_show_connector_picker(self) -> None:
         """Open the interactive connector picker."""
         await self._show_connector_picker("Mount another connector")

--- a/tests/unit/fs/test_tui.py
+++ b/tests/unit/fs/test_tui.py
@@ -361,6 +361,36 @@ class TestPlaygroundApp:
             assert not app.command_visible
 
     @pytest.mark.asyncio
+    async def test_command_mode_blocks_other_bindings(self):
+        """Bound keys like 'b' should type into command buffer, not trigger actions."""
+        app = PlaygroundApp(uris=())
+
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(delay=0.3)
+            # Enter command mode
+            app.action_toggle_command()
+            assert app.command_visible
+
+            # check_action should block non-command actions
+            assert app.check_action("go_back", ()) is False
+            assert app.check_action("request_quit", ()) is False
+            assert app.check_action("copy_path", ()) is False
+
+            # check_action should allow command actions
+            assert app.check_action("toggle_command", ()) is True
+            assert app.check_action("submit_command", ()) is True
+            assert app.check_action("command_backspace", ()) is True
+
+            # Press 'b' — should add to buffer, not navigate back
+            await pilot.press("b")
+            assert "b" in app.command_buffer
+
+            # Exit command mode — actions should be re-enabled
+            app.action_toggle_command()
+            assert not app.command_visible
+            assert app.check_action("go_back", ()) is True
+
+    @pytest.mark.asyncio
     async def test_mount_uri_adds_local_mount(self, tmp_path):
         """The command-path mount helper adds a local mount and rebuilds the UI."""
         app = PlaygroundApp(uris=())


### PR DESCRIPTION
## Summary
- Override Textual's `check_action` to disable all non-command-mode bindings while the command bar is active
- Fixes all single-key bindings (`b`/`q`/`a`/`c`/`m`/`n`/`d`/`r`/`u`/`p`) stealing keypresses from the command buffer

## What this enables
Users can now type any command in playground command mode (`:`) without bound keys hijacking input. Previously, typing `/buckets` would trigger `go_back` on the `b`, and `/auth test` would misfire on `a` — making the command bar effectively unusable for any command containing a bound character. This unblocks all command-bar workflows: `/mount`, `/auth`, `/rm`, `/touch`, `/connectors`.

## Test plan
- [x] New test `test_command_mode_blocks_other_bindings` validates `check_action` gates and that `pilot.press("b")` lands in the command buffer
- [x] All existing TUI tests pass (75/75, excluding 1 pre-existing unrelated failure)

Closes #3504