### PR TITLE
cleanup: delete EventsService lock methods — lock via kernel syscalls

### DIFF
--- a/docs/architecture/lock-architecture.md
+++ b/docs/architecture/lock-architecture.md
@@ -15,7 +15,7 @@
 | **AdvisoryLockManager** | `lib/distributed_lock.py` | — | ABC: async advisory lock API (zone_id bound at construction) |
 | **LocalLockManager** | `lib/distributed_lock.py` | ~500ns–1μs | Standalone advisory locks via VFSSemaphore |
 | **RaftLockManager** | `raft/lock_manager.py` | ~5-10ms | Distributed advisory locks, zone-scoped |
-| **LockStoreProtocol** | `lib/distributed_lock.py` | — | Low-level store interface (MetastoreABC lock methods) |
+| ~~LockStoreProtocol~~ | deleted (Phase 2) | — | Was low-level store interface — only one implementer (RaftMetadataStore) |
 | ~12 `asyncio.Semaphore` | scattered | — | Ad-hoc concurrency bounding |
 
 **Resolved** (by PR #2732, #2733, #2734):
@@ -121,23 +121,23 @@ I/O locks have no TTL (kernel manages lifecycle in try/finally).
 **Restart behavior**: Advisory locks survive in redb. Dead holders stop renewing →
 TTL expires → auto-released. No orphans.
 
-### 3.3 DI Model
+### 3.3 Kernel Ownership Model
 
 ```python
-# EventsService.__init__ always creates LocalLockManager
+# NexusFS.__init__ creates LocalLockManager (kernel owns)
 from nexus.lib.distributed_lock import LocalLockManager
 from nexus.lib.semaphore import create_vfs_semaphore
 
-self._lock_manager = LocalLockManager(create_vfs_semaphore(), zone_id=zone_id)
+self._lock_manager = LocalLockManager(create_vfs_semaphore(), zone_id=ROOT_ZONE_ID)
 
-# Federation: RaftLockManager upgrade at link time
-if isinstance(nx.metadata, LockStoreProtocol):
-    raft_lm = RaftLockManager(nx.metadata, zone_id=zone_id)
-    events_service.upgrade_lock_manager(raft_lm)
+# Federation: RaftLockManager upgrade at link time (kernel knows)
+_raft_lm = RaftLockManager(nx.metadata, zone_id=zone_id)
+nx._upgrade_lock_manager(_raft_lm)
 ```
 
-Two paths only: EventsService always starts with `LocalLockManager`.
-Federation upgrades to `RaftLockManager` at link time via `upgrade_lock_manager()`.
+Same pattern as FileWatcher: kernel-owned local + kernel-knows remote.
+Exposed via kernel syscalls: `sys_lock`, `sys_unlock`, `lock()` (Tier 2 blocking wait),
+`locked()` (Tier 2 async context manager).
 
 | Profile | Metastore | lock_manager → |
 |---------|-----------|----------------|
@@ -164,20 +164,19 @@ Callers see only `AdvisoryLockManager`. Same async API regardless of backend.
 ## 5. Design Decisions
 
 **D1: Two locks, not one** — I/O lock (VFSLockManager, kernel-internal, ~200ns) and
-advisory lock (`LockStoreProtocol`, user-facing, TTL-based) are fundamentally different.
+advisory lock (user-facing, TTL-based) are fundamentally different.
 Like Linux `i_rwsem` vs `flock(2)`.
 
-**D2: Advisory locks are metadata** — stored via `LockStoreProtocol` (redb `TREE_LOCKS`),
-queryable, Raft-replicated in federation. Like HDFS leases in NameNode FSImage+EditLog.
-`LockStoreProtocol` is a capability protocol — MetastoreABC does NOT own lock methods.
+**D2: Advisory locks are metadata** — stored in redb `sm_locks` table (separate from
+FileMetadata), queryable, Raft-replicated in federation. Like HDFS leases in NameNode.
 
-**D3: Two paths, not runtime routing** — EventsService always starts with
-`LocalLockManager`. Federation upgrades to `RaftLockManager` at link time.
-No `_LockRouter`, no runtime auto-detect. Simpler, testable.
+**D3: Kernel-owned, not service-owned** — NexusFS.__init__ constructs LocalLockManager.
+Federation upgrades to RaftLockManager via `_upgrade_lock_manager()` at link time.
+Same pattern as FileWatcher (kernel-owned local + kernel-knows remote).
+Exposed via kernel syscalls: `sys_lock`/`sys_unlock` (Tier 1), `lock()`/`locked()` (Tier 2).
 
 **D4: PassthroughBackend.lock() deleted** — duplicated kernel lock logic.
 `_StripeLock` also deleted — CAS metadata RMW now uses `VFSSemaphore` directly.
-EventsService owns lock manager lifecycle (`LocalLockManager` → `RaftLockManager` upgrade).
 
 **D5: asyncio.Semaphore stays as-is** — internal concurrency limiters (not advisory
 locks). No names, TTL, or cross-node semantics needed.

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -260,11 +260,8 @@ async def _boot_post_kernel_services(
 
             events_service = EventsService(
                 file_watcher=nx._file_watcher,
-                lock_manager=nx._lock_manager,
             )
-            logger.debug(
-                "[BOOT:WIRED] EventsService created (delegates to kernel FileWatcher + LockManager)"
-            )
+            logger.debug("[BOOT:WIRED] EventsService created (delegates to kernel FileWatcher)")
         except Exception as exc:
             logger.debug("[BOOT:WIRED] EventsService unavailable: %s", exc)
     else:

--- a/src/nexus/services/lifecycle/events_service.py
+++ b/src/nexus/services/lifecycle/events_service.py
@@ -1,21 +1,17 @@
-"""Events Service — file watching RPC wrapper + advisory locking.
+"""Events Service — file watching RPC wrapper.
 
-Thin service-layer wrapper around kernel FileWatcher (§4.5).
-Exposes ``wait_for_changes()`` via RPC and manages advisory locks.
+Thin service-layer wrapper around kernel FileWatcher (§4.3).
+Exposes ``wait_for_changes()`` via RPC.
 
-Architecture:
-    - File watching delegated to kernel FileWatcher (local OBSERVE + optional remote)
-    - Advisory locking (flock-style) managed here (service-tier concern)
-    - ``@rpc_expose`` methods are the only service-layer additions
+Advisory locking moved to kernel syscalls (sys_lock/sys_unlock) in Phase 5.
+Lock methods deleted — use NexusFS.sys_lock()/sys_unlock()/locked() instead.
 
 Phase 2: Core Refactoring (Issue #1287)
 Extracted from: nexus_fs_events.py (836 lines)
 """
 
-import contextlib
 import logging
-from collections.abc import AsyncIterator
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.core.path_utils import validate_path
@@ -26,39 +22,28 @@ logger = logging.getLogger(__name__)
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext
     from nexus.core.file_watcher import FileWatcher
-    from nexus.lib.distributed_lock import AdvisoryLockManager
 
 
 class EventsService:
-    """Events service — RPC wrapper for kernel FileWatcher + advisory locking.
+    """Events service — RPC wrapper for kernel FileWatcher.
 
     File watching is fully delegated to the kernel FileWatcher primitive.
     This service adds:
     - ``@rpc_expose`` for gRPC/HTTP access
-    - Advisory locking (lock/unlock/extend_lock/locked)
     - Zone ID resolution from OperationContext
+
+    Advisory locking is now on NexusFS kernel (sys_lock/sys_unlock/locked).
     """
 
     def __init__(
         self,
         file_watcher: "FileWatcher",
-        lock_manager: "AdvisoryLockManager | None" = None,
         zone_id: str | None = None,
     ):
         self._file_watcher = file_watcher
-        # Lock manager now kernel-owned — passed in from NexusFS._lock_manager.
-        self._lock_manager = lock_manager
         self._zone_id = zone_id
 
-        logger.info("[EventsService] Initialized (delegates to kernel FileWatcher + LockManager)")
-
-    # =========================================================================
-    # Infrastructure Detection
-    # =========================================================================
-
-    def _has_lock_manager(self) -> bool:
-        """Check if advisory lock manager is available."""
-        return self._lock_manager is not None
+        logger.info("[EventsService] Initialized (delegates to kernel FileWatcher)")
 
     def _get_zone_id(self, context: "OperationContext | None") -> str:
         """Get zone ID from context or default."""
@@ -111,170 +96,3 @@ class EventsService:
         if event is None:
             return None
         return event.to_dict()
-
-    # =========================================================================
-    # Public API: Advisory Locking
-    # =========================================================================
-
-    @rpc_expose(description="Acquire advisory lock on a path")
-    async def lock(
-        self,
-        path: str,
-        mode: Literal["exclusive", "shared"] = "exclusive",
-        timeout: float = 30.0,
-        ttl: float = 30.0,
-        max_holders: int = 1,
-        _context: "OperationContext | None" = None,
-    ) -> str | None:
-        """Acquire an advisory lock on a path.
-
-        Supports exclusive (default), shared, and counting semaphore modes.
-
-        Args:
-            path: Virtual path to lock
-            mode: ``"exclusive"`` (default) or ``"shared"``
-            timeout: Maximum time to wait for lock in seconds
-            ttl: Lock TTL in seconds
-            max_holders: Maximum concurrent holders (1 = mutex)
-            _context: Operation context (optional)
-
-        Returns:
-            Lock ID if acquired, None if timeout
-        """
-        path = validate_path(path, allow_root=True)
-
-        if not self._has_lock_manager():
-            raise RuntimeError(
-                "No lock manager available. EventsService should always have a lock "
-                "manager (local fallback or distributed)."
-            )
-
-        desc = f"mode={mode}" if max_holders == 1 else f"semaphore({max_holders})"
-        logger.debug("Acquiring lock on %s (%s)", path, desc)
-        lock_id = await self._lock_manager.acquire(  # type: ignore[union-attr]
-            path=path,
-            mode=mode,
-            timeout=timeout,
-            ttl=ttl,
-            max_holders=max_holders,
-        )
-        if lock_id:
-            logger.debug("Lock acquired on %s: %s", path, lock_id)
-        else:
-            logger.warning("Lock timeout on %s after %ss", path, timeout)
-        return lock_id
-
-    @rpc_expose(description="Extend lock TTL (heartbeat)")
-    async def extend_lock(
-        self,
-        lock_id: str,
-        path: str,
-        ttl: float = 30.0,
-        _context: "OperationContext | None" = None,
-    ) -> bool:
-        """Extend a lock's TTL (heartbeat for long-running operations).
-
-        Args:
-            lock_id: Lock ID returned from lock()
-            path: Path that was locked
-            ttl: New TTL in seconds
-            _context: Operation context (optional)
-
-        Returns:
-            True if lock was extended, False if not found/owned
-        """
-        if not self._has_lock_manager():
-            raise RuntimeError("No lock manager available.")
-
-        path = validate_path(path, allow_root=True)
-        extended = await self._lock_manager.extend(  # type: ignore[union-attr]
-            lock_id=lock_id,
-            path=path,
-            ttl=ttl,
-        )
-        if extended.success:
-            logger.debug("Lock extended: %s (TTL: %ss)", lock_id, ttl)
-        else:
-            logger.warning("Lock extend failed (not owned or expired): %s", lock_id)
-        return extended.success
-
-    @rpc_expose(description="Release advisory lock")
-    async def unlock(
-        self,
-        lock_id: str,
-        path: str | None = None,
-        _context: "OperationContext | None" = None,
-    ) -> bool:
-        """Release an advisory lock.
-
-        Args:
-            lock_id: Lock ID returned from lock()
-            path: Path that was locked (required)
-            _context: Operation context (optional)
-
-        Returns:
-            True if lock was released, False if not found
-        """
-        if not self._has_lock_manager():
-            raise RuntimeError("No lock manager available.")
-
-        if path is None:
-            raise ValueError("path is required for unlock")
-        path = validate_path(path, allow_root=True)
-        released = await self._lock_manager.release(  # type: ignore[union-attr]
-            lock_id=lock_id,
-            path=path,
-        )
-        if released:
-            logger.debug("Lock released: %s", lock_id)
-        else:
-            logger.warning("Lock not found: %s", lock_id)
-        return released
-
-    # =========================================================================
-    # Lock Context Manager
-    # =========================================================================
-
-    @contextlib.asynccontextmanager
-    async def locked(
-        self,
-        path: str,
-        mode: Literal["exclusive", "shared"] = "exclusive",
-        timeout: float = 30.0,
-        ttl: float = 30.0,
-        max_holders: int = 1,
-        _context: "OperationContext | None" = None,
-    ) -> AsyncIterator[str]:
-        """Acquire an advisory lock as an async context manager.
-
-        Args:
-            path: Virtual path to lock
-            mode: ``"exclusive"`` (default) or ``"shared"``
-            timeout: Maximum time to wait for lock in seconds
-            ttl: Lock TTL in seconds
-            max_holders: Maximum concurrent holders (1 = mutex)
-            _context: Operation context (optional)
-
-        Yields:
-            lock_id: Lock identifier
-
-        Raises:
-            LockTimeout: If lock cannot be acquired within timeout
-        """
-        from nexus.contracts.exceptions import LockTimeout
-
-        lock_id = await self.lock(
-            path,
-            mode=mode,
-            timeout=timeout,
-            ttl=ttl,
-            max_holders=max_holders,
-            _context=_context,
-        )
-        if lock_id is None:
-            raise LockTimeout(path=path, timeout=timeout)
-
-        try:
-            yield lock_id
-        finally:
-            await self.unlock(lock_id, path, _context=_context)

--- a/tests/unit/services/test_events_service.py
+++ b/tests/unit/services/test_events_service.py
@@ -1,7 +1,6 @@
 """Unit tests for EventsService.
 
-Tests file watching (delegated to kernel FileWatcher), advisory locking,
-zone ID resolution, and infrastructure detection.
+Tests file watching (delegated to kernel FileWatcher) and zone ID resolution.
 
 Architecture: EventsService is a thin RPC wrapper around kernel FileWatcher.
 Local OBSERVE + remote watch logic lives in FileWatcher (tested separately
@@ -9,7 +8,6 @@ in tests/unit/core/test_file_watcher.py).
 """
 
 import asyncio
-from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
@@ -27,18 +25,6 @@ from nexus.services.lifecycle.events_service import EventsService
 def file_watcher():
     """Create a kernel FileWatcher instance."""
     return FileWatcher()
-
-
-@pytest.fixture
-def mock_lock_manager():
-    """Create a mock distributed lock manager."""
-    mgr = AsyncMock()
-    mgr.acquire = AsyncMock(return_value="dist-lock-456")
-    mgr.release = AsyncMock(return_value=True)
-    extend_result = MagicMock()
-    extend_result.success = True
-    mgr.extend = AsyncMock(return_value=extend_result)
-    return mgr
 
 
 @pytest.fixture
@@ -66,40 +52,14 @@ def _make_event(path: str = "/inbox/test.txt", event_type: str = "file_write") -
 class TestEventsServiceInit:
     """Tests for EventsService construction."""
 
-    def test_init_stores_file_watcher(self, file_watcher, mock_lock_manager):
-        """Service stores file watcher and lock manager dependencies."""
+    def test_init_stores_file_watcher(self, file_watcher):
+        """Service stores file watcher dependency."""
         svc = EventsService(
             file_watcher=file_watcher,
-            lock_manager=mock_lock_manager,
             zone_id="z1",
         )
         assert svc._file_watcher is file_watcher
-        assert svc._lock_manager is mock_lock_manager
         assert svc._zone_id == "z1"
-
-    def test_init_without_lock_manager(self, file_watcher):
-        """Lock manager is optional — None means locking disabled."""
-        svc = EventsService(file_watcher=file_watcher)
-        assert svc._lock_manager is None
-
-
-# =============================================================================
-# Infrastructure detection
-# =============================================================================
-
-
-class TestInfrastructureDetection:
-    """Tests for layer detection methods."""
-
-    def test_has_lock_manager_true_when_passed(self, file_watcher, mock_lock_manager):
-        """Lock manager present when passed via constructor."""
-        svc = EventsService(file_watcher=file_watcher, lock_manager=mock_lock_manager)
-        assert svc._has_lock_manager() is True
-
-    def test_has_lock_manager_false_without_lock_manager(self, file_watcher):
-        """No lock manager when none passed to constructor."""
-        svc = EventsService(file_watcher=file_watcher)
-        assert svc._has_lock_manager() is False
 
 
 # =============================================================================
@@ -161,50 +121,3 @@ class TestWaitForChanges:
         # Just verify it doesn't crash with context — zone routing tested in FileWatcher tests
         result = asyncio.run(svc.wait_for_changes("/data", timeout=0.05, _context=context))
         assert result is None
-
-
-# =============================================================================
-# Advisory Locking — Distributed
-# =============================================================================
-
-
-class TestDistributedLocking:
-    """Tests for locking via upgraded (distributed) lock manager."""
-
-    def _make_svc(self, file_watcher, mock_lock_manager):
-        """Create EventsService with distributed lock manager."""
-        return EventsService(file_watcher=file_watcher, lock_manager=mock_lock_manager)
-
-    def test_lock_acquires_distributed(self, file_watcher, mock_lock_manager):
-        """Lock uses distributed lock manager when available."""
-        svc = self._make_svc(file_watcher, mock_lock_manager)
-        lock_id = asyncio.run(svc.lock("/data/file.txt", timeout=5.0, ttl=10.0))
-        assert lock_id == "dist-lock-456"
-        mock_lock_manager.acquire.assert_called_once()
-
-    def test_lock_returns_none_on_timeout(self, file_watcher, mock_lock_manager):
-        """Lock returns None when distributed lock times out."""
-        mock_lock_manager.acquire = AsyncMock(return_value=None)
-        svc = self._make_svc(file_watcher, mock_lock_manager)
-        lock_id = asyncio.run(svc.lock("/data/file.txt", timeout=1.0))
-        assert lock_id is None
-
-    def test_unlock_releases_distributed(self, file_watcher, mock_lock_manager):
-        """Unlock releases distributed lock."""
-        svc = self._make_svc(file_watcher, mock_lock_manager)
-        result = asyncio.run(svc.unlock("dist-lock-456", path="/data/file.txt"))
-        assert result is True
-        mock_lock_manager.release.assert_called_once()
-
-    def test_unlock_requires_path_for_distributed(self, file_watcher, mock_lock_manager):
-        """Distributed unlock requires path parameter."""
-        svc = self._make_svc(file_watcher, mock_lock_manager)
-        with pytest.raises(ValueError, match="path is required"):
-            asyncio.run(svc.unlock("dist-lock-456", path=None))
-
-    def test_extend_lock_distributed(self, file_watcher, mock_lock_manager):
-        """Extend lock uses distributed lock manager."""
-        svc = self._make_svc(file_watcher, mock_lock_manager)
-        result = asyncio.run(svc.extend_lock("dist-lock-456", path="/data/file.txt", ttl=60.0))
-        assert result is True
-        mock_lock_manager.extend.assert_called_once()


### PR DESCRIPTION
## Summary

Strip EventsService to watch-only. All lock methods deleted — lock operations are kernel syscalls on NexusFS.

- Delete `lock()`, `unlock()`, `extend_lock()`, `locked()`, `_has_lock_manager()` from EventsService
- Remove `lock_manager` constructor param (no longer needed)
- Update `_wired.py` EventsService construction
- Delete lock tests from `test_events_service.py`
- Update `lock-architecture.md`: kernel ownership model, update D2/D3 decisions

EventsService now only provides `wait_for_changes()` (file watching RPC wrapper).
Lock operations: use `nx.sys_lock()`, `nx.sys_unlock()`, `nx.locked()` directly.

## Test plan

- [x] `pytest tests/unit/services/test_events_service.py` — 7 passed (watch tests only)
- [x] `pytest tests/unit/core/test_factory_boot.py tests/unit/test_factory.py` — 46 passed
- [x] All pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)