### PR TITLE
refactor: move metadata.put from kernel to driver (ext4 pattern)

### DIFF
--- a/src/nexus/backends/base/cas_addressing_engine.py
+++ b/src/nexus/backends/base/cas_addressing_engine.py
@@ -116,6 +116,7 @@ class CASAddressingEngine(Backend):
         meta_cache: Any | None = None,
         on_write_callback: Any | None = None,
         cdc_engine: "ChunkingStrategy | None" = None,
+        metastore: Any | None = None,
     ) -> None:
         self._transport = transport
         self._backend_name = backend_name or f"cas-{transport.transport_name}"
@@ -127,6 +128,7 @@ class CASAddressingEngine(Backend):
         self._meta_cache_misses = 0
         self._on_write_callback = on_write_callback
         self._cdc: ChunkingStrategy | None = cdc_engine
+        self._metastore = metastore
 
     @property
     def name(self) -> str:
@@ -242,6 +244,12 @@ class CASAddressingEngine(Backend):
             if self._cache is not None:
                 self._cache.put(content_hash, content)
 
+            # CAS metadata persistence (driver-owned, like ext4 inode update)
+            if self._metastore is not None and context is not None:
+                vpath = getattr(context, "virtual_path", None)
+                if vpath:
+                    self._commit_metadata(vpath, content_hash, len(content), context)
+
             return WriteResult(content_id=content_hash, version=content_hash, size=len(content))
 
         content_hash = hash_content(content)
@@ -274,6 +282,12 @@ class CASAddressingEngine(Backend):
             # Feature DI: Write callback (e.g. Zoekt reindex)
             if is_new and self._on_write_callback is not None:
                 self._on_write_callback(key)
+
+            # CAS metadata persistence (driver-owned, like ext4 inode update)
+            if self._metastore is not None and context is not None:
+                vpath = getattr(context, "virtual_path", None)
+                if vpath:
+                    self._commit_metadata(vpath, content_hash, len(content), context)
 
             return WriteResult(content_id=content_hash, version=content_hash, size=len(content))
 
@@ -329,6 +343,40 @@ class CASAddressingEngine(Backend):
 
         new_data = old_data[:offset] + buf + old_data[offset + len(buf) :]
         return self.write_content(new_data, context=context)
+
+    def _commit_metadata(
+        self, path: str, content_hash: str, size: int, context: "OperationContext"
+    ) -> None:
+        """Build and persist file metadata (CAS inode update, like ext4 write_iter)."""
+        from datetime import UTC, datetime
+
+        from nexus.contracts.metadata import FileMetadata
+
+        existing = getattr(context, "existing_metadata", None)
+        now = datetime.now(UTC)
+        zone_id = getattr(context, "zone_id", None) or "root"
+        owner_id = (
+            existing.owner_id
+            if existing and existing.owner_id
+            else getattr(context, "subject_id", None) or getattr(context, "user_id", None)
+        )
+
+        metadata = FileMetadata(
+            path=path,
+            backend_name=self.name,
+            physical_path=content_hash,
+            size=size,
+            etag=content_hash,
+            created_at=existing.created_at if existing else now,
+            modified_at=now,
+            version=(existing.version + 1) if existing else 1,
+            zone_id=zone_id,
+            owner_id=owner_id,
+        )
+
+        consistency = getattr(context, "consistency", "sc") if context else "sc"
+        if self._metastore is not None:
+            self._metastore.put(metadata, consistency=consistency)
 
     def read_content(self, content_id: str, context: "OperationContext | None" = None) -> bytes:
         content_hash = content_id  # CAS: content_id is a SHA-256 hash

--- a/src/nexus/backends/base/path_addressing_engine.py
+++ b/src/nexus/backends/base/path_addressing_engine.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import logging
 import mimetypes
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from nexus.backends.base.backend import Backend
 from nexus.backends.base.transport import Transport
@@ -62,12 +62,14 @@ class PathAddressingEngine(Backend):
         bucket_name: str = "",
         prefix: str = "",
         versioning_enabled: bool = False,
+        metastore: Any | None = None,
     ) -> None:
         self._transport = transport
         self._backend_name = backend_name or f"path-{transport.transport_name}"
         self.bucket_name = bucket_name
         self.prefix = prefix.rstrip("/")
         self.versioning_enabled = versioning_enabled
+        self._metastore = metastore
 
     @property
     def name(self) -> str:
@@ -136,6 +138,42 @@ class PathAddressingEngine(Backend):
                 pass
         return True  # Likely a version ID
 
+    # === Metadata Persistence (driver-owned, like ext4 inode update) ===
+
+    def _commit_metadata(
+        self, path: str, content_hash: str, size: int, context: "OperationContext"
+    ) -> None:
+        """Build and persist file metadata (PAS inode update, like ext4 write_iter)."""
+        from datetime import UTC, datetime
+
+        from nexus.contracts.metadata import FileMetadata
+
+        existing = getattr(context, "existing_metadata", None)
+        now = datetime.now(UTC)
+        zone_id = getattr(context, "zone_id", None) or "root"
+        owner_id = (
+            existing.owner_id
+            if existing and existing.owner_id
+            else getattr(context, "subject_id", None) or getattr(context, "user_id", None)
+        )
+
+        metadata = FileMetadata(
+            path=path,
+            backend_name=self.name,
+            physical_path=content_hash,
+            size=size,
+            etag=content_hash,
+            created_at=existing.created_at if existing else now,
+            modified_at=now,
+            version=(existing.version + 1) if existing else 1,
+            zone_id=zone_id,
+            owner_id=owner_id,
+        )
+
+        consistency = getattr(context, "consistency", "sc") if context else "sc"
+        if self._metastore is not None:
+            self._metastore.put(metadata, consistency=consistency)
+
     # === Content Operations (ObjectStoreABC) ===
 
     def write_content(
@@ -176,6 +214,12 @@ class PathAddressingEngine(Backend):
 
         # If versioning, store returns version_id; otherwise compute hash
         content_hash = result if result is not None else self._compute_hash(content)
+
+        # PAS metadata persistence (driver-owned, like ext4 inode update)
+        if self._metastore is not None and context is not None:
+            vpath = getattr(context, "virtual_path", None)
+            if vpath:
+                self._commit_metadata(vpath, content_hash, len(content), context)
 
         return WriteResult(content_id=content_hash, version=content_hash, size=len(content))
 

--- a/src/nexus/backends/storage/cas_local.py
+++ b/src/nexus/backends/storage/cas_local.py
@@ -257,7 +257,8 @@ class CASLocalBackend(CASAddressingEngine, MultipartUpload):
             logger.info("Cold tiering service scheduled to stop on unmount")
 
     def set_metastore(self, metastore: Any) -> None:
-        """Inject metastore reference for reachability-based GC."""
+        """Inject metastore reference for CAS metadata persistence + GC."""
+        self._metastore = metastore  # CASAddressingEngine metadata persistence
         self._gc.set_metastore(metastore)
 
     @property

--- a/src/nexus/contracts/types.py
+++ b/src/nexus/contracts/types.py
@@ -120,6 +120,7 @@ class OperationContext:
     # Backend path for path-based connectors (GCS, S3, etc.)
     backend_path: str | None = None
     virtual_path: str | None = None  # Full virtual path with mount prefix (for cache keys)
+    existing_metadata: Any = None  # Pre-write FileMetadata, kernel→driver
 
     # Read Set Tracking for Query Dependencies (Issue #1166)
     read_set: "ReadSet | None" = None

--- a/src/nexus/core/driver_lifecycle_coordinator.py
+++ b/src/nexus/core/driver_lifecycle_coordinator.py
@@ -45,12 +45,15 @@ class DriverLifecycleCoordinator:
     Parallel to ServiceRegistry lifecycle orchestration (services vs drivers).
     """
 
-    __slots__ = ("_router", "_dispatch", "_mount_specs")
+    __slots__ = ("_router", "_dispatch", "_mount_specs", "_metastore")
 
-    def __init__(self, router: "PathRouter", dispatch: "KernelDispatch") -> None:
+    def __init__(
+        self, router: "PathRouter", dispatch: "KernelDispatch", metastore: Any = None
+    ) -> None:
         self._router = router
         self._dispatch = dispatch
         self._mount_specs: dict[str, HookSpec] = {}
+        self._metastore = metastore
 
     def mount(
         self,
@@ -67,6 +70,13 @@ class DriverLifecycleCoordinator:
         2. Register VFS hooks from hook_spec (fixes CAS wiring bug #1320)
         3. Broadcast mount event via KernelDispatch
         """
+        # Wire metastore into backend (like Linux VFS setting sb->s_op at mount)
+        if self._metastore is not None:
+            if hasattr(backend, "set_metastore"):
+                backend.set_metastore(self._metastore)
+            elif hasattr(backend, "_metastore"):
+                backend._metastore = self._metastore
+
         # 1. Add to routing table
         self._router.add_mount(
             mount_point,

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -263,8 +263,16 @@ class NexusFS(  # type: ignore[misc]
         from nexus.core.driver_lifecycle_coordinator import DriverLifecycleCoordinator
 
         self._driver_coordinator: DriverLifecycleCoordinator = DriverLifecycleCoordinator(
-            self.router, self._dispatch
+            self.router, self._dispatch, metastore=metadata_store
         )
+
+        # Wire metastore into pre-existing mounts (added to router before __init__)
+        for _mp in self.router.get_mount_points():
+            _mi = self.router.get_mount(_mp)
+            if _mi is not None and hasattr(_mi.backend, "set_metastore"):
+                _mi.backend.set_metastore(metadata_store)
+            elif _mi is not None and hasattr(_mi.backend, "_metastore"):
+                _mi.backend._metastore = metadata_store
 
         # Lifecycle state — set by link() / initialize() / bootstrap()
         self._linked: bool = False
@@ -2624,6 +2632,7 @@ class NexusFS(  # type: ignore[misc]
             context = OperationContext(
                 user_id="anonymous", groups=[], backend_path=route.backend_path, virtual_path=path
             )
+        context = replace(context, existing_metadata=meta)
 
         # DT_EXTERNAL_STORAGE: backend manages own content storage.
         # Remote backends (RPC-based) also persist metadata on the remote server,
@@ -2673,19 +2682,16 @@ class NexusFS(  # type: ignore[misc]
                 # HDFS/GFS pattern: content cleanup is async via background GC.
                 # See: docs/architecture/federation-memo.md §7f Caveat 4.
 
-                metadata = self._build_write_metadata(
-                    path=path,
-                    backend_name=route.backend.name,
-                    content_hash=content_hash,
-                    size=_wr.size if offset > 0 else len(content),
-                    existing_meta=meta,
-                    now=now,
-                    zone_id=zone_id,
-                    context=context,
-                )
+                # Driver persists metadata inside write_content() (metastore
+                # injected at mount time via DLC).
+                _post_meta = self.metadata.get(path)
+                if _post_meta is None:
+                    raise BackendError(
+                        f"write_content() completed but metadata not found for {path}. "
+                        "Driver must persist metadata during write_content()."
+                    )
+                metadata = _post_meta
                 new_version = metadata.version
-
-                self.metadata.put(metadata, consistency=consistency)
 
         return _WriteContentResult(
             content_hash=content_hash,

--- a/tests/helpers/failing_backend.py
+++ b/tests/helpers/failing_backend.py
@@ -57,6 +57,11 @@ class FailingBackend(Backend):
         self._fail_permanently = fail_permanently
         self._call_count = 0
 
+    def set_metastore(self, metastore: "Any") -> None:
+        """Forward metastore injection to inner backend."""
+        if hasattr(self._inner, "set_metastore"):
+            self._inner.set_metastore(metastore)
+
     @property
     def name(self) -> str:
         return f"failing({self._inner.name})"


### PR DESCRIPTION
## Summary
Drivers now handle metadata.put() inside write_content(), like Linux ext4
updating inodes in write_iter() while VFS holds i_rwsem. Kernel just holds
VFS lock and calls backend — doesn't know about metadata.

## Design (Linux ext4 analogy)
```
Kernel: _vfs_locked(path, "write") → backend.write_content(content, context) → unlock → events
CAS:    write blob → _commit_metadata(hash, context) → metastore.put()  [inside driver]
PAS:    write file → _commit_metadata(path, context) → metastore.put()  [inside driver]
```

## Changes (7 files)
- `backends/base/cas_addressing_engine.py`: Inject metastore, `_commit_metadata()` after blob store
- `backends/base/path_addressing_engine.py`: Same pattern for PAS local backends
- `backends/storage/cas_local.py`: `set_metastore()` wires engine `_metastore`
- `core/driver_lifecycle_coordinator.py`: Auto-wire metastore at mount time
- `core/nexus_fs.py`: Remove kernel metadata.put from standard path, read-back driver metadata
- `contracts/types.py`: Add `existing_metadata` to OperationContext
- `tests/helpers/failing_backend.py`: Forward `set_metastore` to inner backend

## Test plan
- [x] All previously failing tests pass locally (68 tests)
- [x] Rename + write_batch + minimal_boot + mounts + integration tests pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)