### PR TITLE
fix: restore terminal state on fatal TUI startup errors

### DIFF
--- a/packages/nexus-tui/src/index.tsx
+++ b/packages/nexus-tui/src/index.tsx
@@ -108,6 +108,23 @@ async function main(): Promise<void> {
 }
 
 main().catch((err) => {
+  // Restore terminal state in case OpenTUI already enabled raw mode / alternate screen.
+  // These sequences are no-ops if the terminal was never switched, so always safe to write.
+  if (process.stdin.setRawMode) {
+    process.stdin.setRawMode(false);
+  }
+  process.stdin.pause();
+
+  const fs = require("fs");
+  const reset = [
+    "\x1b[?1003l", // disable all-motion mouse tracking
+    "\x1b[?1006l", // disable SGR mouse mode
+    "\x1b[?1000l", // disable normal mouse tracking
+    "\x1b[?1049l", // switch back to main screen
+    "\x1b[?25h",   // show cursor
+  ].join("");
+  fs.writeSync(1, reset);
+
   console.error("Fatal error:", err);
   process.exit(1);
 });


### PR DESCRIPTION
## Summary
- Fixes #3515 — if `main()` in the TUI entry point throws after OpenTUI enables alternate screen / raw mode, the terminal was left broken (no cursor, stuck in alternate screen)
- The `catch` handler now disables raw mode and writes the same ANSI reset sequences used by `shutdown()` before printing the error and exiting
- The sequences are no-ops when the terminal was never switched, so safe to run regardless of where the error occurred

## Test plan
- [ ] Simulate a startup error (e.g., corrupt config) and verify terminal is restored cleanly
- [ ] Normal startup and `q`-to-quit still works as before