### PR TITLE
feat: add --json flag to all nexus-fs CLI commands

### DIFF
--- a/src/nexus/fs/_auth_cli.py
+++ b/src/nexus/fs/_auth_cli.py
@@ -14,6 +14,7 @@ from rich.table import Table
 
 from nexus.contracts.unified_auth import AuthStatus, CredentialKind
 from nexus.fs._oauth_support import get_token_manager, run_google_oauth_setup, run_x_oauth_setup
+from nexus.fs._output import OutputOptions, add_output_options, render_output
 
 console = Console()
 
@@ -230,26 +231,46 @@ def auth() -> None:
 
 
 @auth.command("list")
-def list_auth() -> None:
+@add_output_options
+def list_auth(output_opts: OutputOptions) -> None:
     """List configured auth across services."""
     service = _build_auth_service()
     summaries = asyncio.run(service.list_summaries())
-    table = Table(title="Unified Auth", show_header=True, header_style="bold cyan")
-    table.add_column("Service", style="green")
-    table.add_column("Kind", style="cyan")
-    table.add_column("Status", style="yellow")
-    table.add_column("Source", style="blue")
-    table.add_column("Message")
-    for summary in summaries:
-        table.add_row(
-            summary.service,
-            summary.kind.value,
-            summary.status.value,
-            summary.source,
-            summary.message,
-        )
-    console.print(table)
-    console.print(f"[dim]Secret store: {service.secret_store_path}[/dim]")
+
+    data = [
+        {
+            "service": s.service,
+            "kind": s.kind.value,
+            "status": s.status.value,
+            "source": s.source,
+            "message": s.message,
+        }
+        for s in summaries
+    ]
+
+    def _human_display(_data: object) -> None:
+        table = Table(title="Unified Auth", show_header=True, header_style="bold cyan")
+        table.add_column("Service", style="green")
+        table.add_column("Kind", style="cyan")
+        table.add_column("Status", style="yellow")
+        table.add_column("Source", style="blue")
+        table.add_column("Message")
+        for summary in summaries:
+            table.add_row(
+                summary.service,
+                summary.kind.value,
+                summary.status.value,
+                summary.source,
+                summary.message,
+            )
+        console.print(table)
+        console.print(f"[dim]Secret store: {service.secret_store_path}[/dim]")
+
+    render_output(
+        data=data,
+        output_opts=output_opts,
+        human_formatter=_human_display,
+    )
 
 
 @auth.command("test")
@@ -263,7 +284,13 @@ def list_auth() -> None:
     default=None,
     help="Google Workspace target readiness check.",
 )
-def test_auth(service_name: str, user_email: str | None, target: str | None) -> None:
+@add_output_options
+def test_auth(
+    service_name: str,
+    user_email: str | None,
+    target: str | None,
+    output_opts: OutputOptions,
+) -> None:
     """Validate auth for a service."""
     service = _build_auth_service()
     try:
@@ -273,32 +300,46 @@ def test_auth(service_name: str, user_email: str | None, target: str | None) -> 
     except ValueError as exc:
         raise click.ClickException(str(exc)) from exc
 
-    checks = result.get("checks")
-    if isinstance(checks, list) and checks:
-        table = Table(
-            title=f"{service_name} target readiness", show_header=True, header_style="bold cyan"
-        )
-        table.add_column("Target", style="green")
-        table.add_column("Status", style="yellow")
-        table.add_column("Source", style="blue")
-        table.add_column("Message")
-        for check in checks:
-            table.add_row(
-                str(check.get("target", "")),
-                "ok" if check.get("success") else "error",
-                str(check.get("source", result.get("source", ""))),
-                str(check.get("message", "")),
-            )
-        console.print(table)
-        _print_target_readiness_summary(service_name, checks, user_email=user_email)
-        if result.get("success"):
-            return
-        raise SystemExit(1)
+    data = {"service": service_name, **result}
 
-    if result.get("success"):
-        console.print(f"[green]ok[/green] {service_name}: {result.get('message')}")
-        return
-    raise click.ClickException(f"{service_name}: {result.get('message')}")
+    def _human_display(_data: object) -> None:
+        checks = result.get("checks")
+        if isinstance(checks, list) and checks:
+            table = Table(
+                title=f"{service_name} target readiness",
+                show_header=True,
+                header_style="bold cyan",
+            )
+            table.add_column("Target", style="green")
+            table.add_column("Status", style="yellow")
+            table.add_column("Source", style="blue")
+            table.add_column("Message")
+            for check in checks:
+                table.add_row(
+                    str(check.get("target", "")),
+                    "ok" if check.get("success") else "error",
+                    str(check.get("source", result.get("source", ""))),
+                    str(check.get("message", "")),
+                )
+            console.print(table)
+            _print_target_readiness_summary(service_name, checks, user_email=user_email)
+            if not result.get("success"):
+                raise SystemExit(1)
+            return
+
+        if result.get("success"):
+            console.print(f"[green]ok[/green] {service_name}: {result.get('message')}")
+            return
+        raise click.ClickException(f"{service_name}: {result.get('message')}")
+
+    render_output(
+        data=data,
+        output_opts=output_opts,
+        human_formatter=_human_display,
+    )
+
+    if output_opts.json_output and not result.get("success"):
+        raise SystemExit(1)
 
 
 @auth.command("connect")

--- a/src/nexus/fs/_cli.py
+++ b/src/nexus/fs/_cli.py
@@ -13,10 +13,12 @@ from __future__ import annotations
 
 import asyncio
 import sys
+from dataclasses import asdict
 
 import click
 
 from nexus.fs._auth_cli import auth as auth_group
+from nexus.fs._output import OutputOptions, add_output_options, render_output
 
 
 @click.group(invoke_without_command=True)
@@ -36,7 +38,8 @@ def main(ctx: click.Context) -> None:
     multiple=True,
     help="URI to mount for connectivity checks (e.g., s3://bucket).",
 )
-def doctor(mount_uris: tuple[str, ...]) -> None:
+@add_output_options
+def doctor(mount_uris: tuple[str, ...], output_opts: OutputOptions) -> None:
     """Check environment, backends, and connectivity.
 
     Runs diagnostic checks across three sections:
@@ -50,9 +53,10 @@ def doctor(mount_uris: tuple[str, ...]) -> None:
 
     \b
       nexus-fs doctor
+      nexus-fs doctor --json
       nexus-fs doctor --mount s3://my-bucket --mount gcs://project/bucket
     """
-    from nexus.fs._doctor import render_doctor, run_all_checks
+    from nexus.fs._doctor import DoctorStatus, render_doctor, run_all_checks
 
     async def _run() -> dict:
         fs = None
@@ -81,15 +85,28 @@ def doctor(mount_uris: tuple[str, ...]) -> None:
         executor.shutdown(wait=False, cancel_futures=True)
         loop.close()
 
-    render_doctor(results)
-
-    # Exit with error code if any checks failed
-    from nexus.fs._doctor import DoctorStatus
+    # Serialize DoctorCheckResult dataclasses for JSON output
+    serializable = {
+        section: [{**asdict(r), "status": r.status.value} for r in checks]
+        for section, checks in results.items()
+    }
 
     has_failure = any(
         r.status == DoctorStatus.FAIL for section in results.values() for r in section
     )
-    if has_failure:
+
+    def _human_display(_data: object) -> None:
+        render_doctor(results)
+        if has_failure:
+            sys.exit(1)
+
+    render_output(
+        data=serializable,
+        output_opts=output_opts,
+        human_formatter=_human_display,
+    )
+
+    if output_opts.json_output and has_failure:
         sys.exit(1)
 
 
@@ -134,7 +151,8 @@ def playground(uris: tuple[str, ...]) -> None:
 @click.argument("source", type=str)
 @click.argument("dest", type=str)
 @click.argument("mount_uris", nargs=-1)
-def cp(source: str, dest: str, mount_uris: tuple[str, ...]) -> None:
+@add_output_options
+def cp(source: str, dest: str, mount_uris: tuple[str, ...], output_opts: OutputOptions) -> None:
     """Copy a file between any mounted backends.
 
     Uses backend-native server-side copy when source and destination are
@@ -149,13 +167,14 @@ def cp(source: str, dest: str, mount_uris: tuple[str, ...]) -> None:
 
     \b
       nexus-fs cp /s3/bucket/data.csv /s3/bucket/backup.csv
+      nexus-fs cp /s3/bucket/data.csv /s3/bucket/backup.csv --json
       nexus-fs cp /s3/bucket/file.parquet /gcs/bucket/file.parquet
       nexus-fs cp /local/data/report.pdf /s3/archive/report.pdf s3://archive
     """
     from nexus.fs._sync import run_sync
 
-    async def _run() -> None:
-        import json
+    async def _run() -> dict:
+        import json as json_mod
         import os
         import tempfile
 
@@ -170,8 +189,8 @@ def cp(source: str, dest: str, mount_uris: tuple[str, ...]) -> None:
         mounts_file = os.path.join(state_dir, "mounts.json")
         try:
             with open(mounts_file) as f:
-                persisted = json.load(f)
-        except (OSError, json.JSONDecodeError):
+                persisted = json_mod.load(f)
+        except (OSError, json_mod.JSONDecodeError):
             pass
 
         # Merge persisted + any extra URIs the user passed explicitly.
@@ -184,20 +203,29 @@ def cp(source: str, dest: str, mount_uris: tuple[str, ...]) -> None:
         fs = await mount(*all_uris)
 
         result = await fs.copy(source, dest)
-        size = result.get("size", 0)
+        return {"source": source, "dest": dest, **result}
+
+    try:
+        data = run_sync(_run())
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+    def _human_display(d: dict) -> None:
+        size = d.get("size", 0)
         if size >= 1024 * 1024:
             size_str = f"{size / (1024 * 1024):.1f} MB"
         elif size >= 1024:
             size_str = f"{size / 1024:.1f} KB"
         else:
             size_str = f"{size} B"
-        click.echo(f"Copied {source} → {dest} ({size_str})")
+        click.echo(f"Copied {d['source']} → {d['dest']} ({size_str})")
 
-    try:
-        run_sync(_run())
-    except Exception as e:
-        click.echo(f"Error: {e}", err=True)
-        sys.exit(1)
+    render_output(
+        data=data,
+        output_opts=output_opts,
+        human_formatter=_human_display,
+    )
 
 
 main.add_command(auth_group)

--- a/src/nexus/fs/_output.py
+++ b/src/nexus/fs/_output.py
@@ -1,0 +1,136 @@
+"""Standalone CLI output infrastructure for nexus-fs.
+
+Mirrors the ``nexus.cli.output`` interface so that nexus-fs commands get
+``--json``, ``--quiet``, ``-v``/``--verbose``, and ``--fields`` — without
+importing from ``nexus.cli`` (which is excluded from the slim wheel).
+
+The JSON envelope format is intentionally identical to the main CLI::
+
+    {"data": <payload>, "_request_id": "..."}
+"""
+
+from __future__ import annotations
+
+import functools
+import json
+import os
+import sys
+import uuid
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+import click
+
+
+@dataclass(frozen=True)
+class OutputOptions:
+    """Immutable bag of output-related CLI flags."""
+
+    json_output: bool
+    quiet: bool
+    verbosity: int  # 0=default, 1=-v, 2=-vv, 3=-vvv
+    fields: str | None
+    request_id: str
+
+
+def _auto_json() -> bool:
+    """Return True when stdout is not a TTY (piped)."""
+    if os.environ.get("NEXUS_NO_AUTO_JSON", ""):
+        return False
+    return not sys.stdout.isatty()
+
+
+def add_output_options(func: Callable[..., Any]) -> Callable[..., Any]:
+    """Decorator adding --json, --quiet, -v/--verbose, --fields to a command.
+
+    Injects an ``output_opts: OutputOptions`` keyword argument.
+    """
+
+    @click.option("--json", "json_output", is_flag=True, default=False, help="Output as JSON")
+    @click.option("--quiet", "-q", is_flag=True, default=False, help="Suppress non-error output")
+    @click.option(
+        "--verbose",
+        "-v",
+        "verbosity",
+        count=True,
+        help="Increase verbosity (-v timing, -vv debug, -vvv trace)",
+    )
+    @click.option(
+        "--fields",
+        type=str,
+        default=None,
+        help="Comma-separated fields to include in JSON output",
+    )
+    @functools.wraps(func)
+    def wrapper(
+        json_output: bool,
+        quiet: bool,
+        verbosity: int,
+        fields: str | None,
+        **kwargs: Any,
+    ) -> Any:
+        if not json_output and _auto_json():
+            json_output = True
+
+        request_id = uuid.uuid4().hex
+
+        output_opts = OutputOptions(
+            json_output=json_output,
+            quiet=quiet,
+            verbosity=verbosity,
+            fields=fields,
+            request_id=request_id,
+        )
+        return func(output_opts=output_opts, **kwargs)
+
+    return wrapper
+
+
+def _filter_fields(data: Any, fields: str) -> Any:
+    """Filter dict/list-of-dicts to only include specified fields."""
+    field_set = {f.strip() for f in fields.split(",")}
+    if isinstance(data, dict):
+        return {k: v for k, v in data.items() if k in field_set}
+    if isinstance(data, list):
+        return [
+            {k: v for k, v in item.items() if k in field_set}
+            for item in data
+            if isinstance(item, dict)
+        ]
+    return data
+
+
+def render_output(
+    *,
+    data: Any,
+    output_opts: OutputOptions,
+    human_formatter: Callable[[Any], None] | None = None,
+    message: str | None = None,
+) -> None:
+    """Render command output respecting output_opts.
+
+    Args:
+        data: The structured data to output (dict, list, or scalar).
+        output_opts: Output options from the decorator.
+        human_formatter: Callable that prints human-readable output. If None,
+            ``message`` is printed instead.
+        message: Simple message for human output when no formatter is provided.
+    """
+    if output_opts.quiet and not output_opts.json_output:
+        return
+
+    if output_opts.json_output:
+        if output_opts.fields and data is not None:
+            data = _filter_fields(data, output_opts.fields)
+
+        envelope: dict[str, Any] = {"data": data}
+        if output_opts.verbosity >= 3:
+            envelope["_request_id"] = output_opts.request_id
+
+        click.echo(json.dumps(envelope, indent=2, default=str))
+    else:
+        if human_formatter is not None:
+            human_formatter(data)
+        elif message is not None:
+            click.echo(message)

--- a/tests/unit/fs/test_auth_cli.py
+++ b/tests/unit/fs/test_auth_cli.py
@@ -115,6 +115,7 @@ def test_fs_auth_test_gws_prints_target_breakdown(monkeypatch) -> None:
             }
 
     monkeypatch.setattr("nexus.fs._auth_cli._build_auth_service", lambda: _Service())
+    monkeypatch.setenv("NEXUS_NO_AUTO_JSON", "1")
 
     runner = CliRunner()
     result = runner.invoke(auth, ["test", "gws"])


### PR DESCRIPTION
## Summary
- Adds `--json`, `--quiet`, `-v/--verbose`, and `--fields` output options to `nexus-fs doctor`, `auth list`, `auth test`, and `cp` commands
- Creates standalone `nexus.fs._output` module mirroring `nexus.cli.output` to respect the packaging boundary (nexus-fs wheel excludes `nexus.cli`)
- JSON envelope format matches the main Nexus CLI (`{"data": ...}`)

Closes #3510

## Test plan
- [x] All 43 `tests/unit/fs/` tests pass (boundary, doctor, auth CLI)
- [x] `nexus-fs doctor --json` produces valid JSON with Environment/Backends/Mounts sections
- [x] `nexus-fs auth list --json` returns array of service summaries
- [x] `nexus-fs auth list --json --fields service,status` filters correctly
- [x] `nexus-fs auth test s3 --json` returns structured result with success/message/source
- [x] `nexus-fs auth test gws --json` exits 1 on partial failure
- [x] `nexus-fs doctor --quiet` suppresses output
- [x] Human-mode output unchanged for all commands
- [x] Packaging boundary test passes (no `nexus.cli` imports from `nexus.fs`)