### PR TITLE
fix: resolve agent registry PID mismatch and missing wiring

### DIFF
--- a/src/nexus/core/agent_registry.py
+++ b/src/nexus/core/agent_registry.py
@@ -332,6 +332,7 @@ class AgentRegistry:
             owner_id,
             zone_id,
             kind=AgentKind.UNMANAGED,
+            pid=connection_id,
             parent_pid=parent_pid,
             external_info=ext_info,
             labels=labels,

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -328,6 +328,10 @@ async def _boot_post_kernel_services(
         except Exception as exc:
             logger.debug("[BOOT:WIRED] AgentRegistry unavailable: %s", exc)
 
+    # Late-bind AgentRegistry → AgentRPCService (Issue #3524)
+    if _agent_reg is not None and agent_rpc_service is not None:
+        agent_rpc_service._agent_registry = _agent_reg
+
     # EvictionManager (QoS-aware agent eviction)
     if _agent_reg is not None:
         try:


### PR DESCRIPTION
## Summary
- **PID mismatch**: `register_external()` now passes `connection_id` as `pid` to `spawn()`, so the agent is stored under the caller-provided ID instead of a generated UUID. This allows `agent_transition`, `heartbeat`, and `delete_agent` to find the agent by the same ID used at registration.
- **Missing wiring**: Late-bind `AgentRegistry` onto `AgentRPCService` after the registry is constructed in the wired boot sequence, fixing the `RuntimeError("AgentRegistry not available")`.

Closes #3524

## Test plan
- [x] `tests/unit/core/test_process_table.py` — 47 passed
- [x] `tests/unit/services/test_agent_registration.py` — 16 passed
- [x] `tests/unit/services/test_agent_warmup.py` — 19 passed