### PR TITLE
TUI: shared SubTabBar component replacing 9 ad-hoc implementations

### DIFF
--- a/packages/nexus-tui/src/panels/access/access-panel.tsx
+++ b/packages/nexus-tui/src/panels/access/access-panel.tsx
@@ -28,6 +28,9 @@ import { useConfirmStore } from "../../shared/hooks/use-confirm.js";
 import { useApi } from "../../shared/hooks/use-api.js";
 import { useUiStore } from "../../stores/ui-store.js";
 import { useVisibleTabs, type TabDef } from "../../shared/hooks/use-visible-tabs.js";
+import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
+import { subTabForward, subTabBackward } from "../../shared/components/sub-tab-bar-utils.js";
+import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
 import { LoadingIndicator } from "../../shared/components/loading-indicator.js";
 import { statusColor } from "../../shared/theme.js";
 import { ManifestList } from "./manifest-list.js";
@@ -51,14 +54,6 @@ const ALL_TABS: readonly TabDef<AccessTab>[] = [
   { id: "fraud", label: "Fraud", brick: "governance" },
   { id: "delegations", label: "Delegations", brick: "delegation" },
 ];
-const TAB_LABELS: Readonly<Record<AccessTab, string>> = {
-  manifests: "Manifests",
-  alerts: "Alerts",
-  credentials: "Credentials",
-  fraud: "Fraud",
-  delegations: "Delegations",
-};
-
 type OverlayMode =
   | "none"
   | "permissionChecker"
@@ -147,13 +142,7 @@ export default function AccessPanel(): React.ReactNode {
   // Delegation status filter
   const [delegationFilter, setDelegationFilter] = useState<string | null>(null);
 
-  // Fall back to first visible tab if the active tab becomes hidden
-  const visibleIds = visibleTabs.map((t) => t.id);
-  useEffect(() => {
-    if (visibleIds.length > 0 && !visibleIds.includes(activeTab)) {
-      setActiveTab(visibleIds[0]!);
-    }
-  }, [visibleIds.join(","), activeTab, setActiveTab]);
+  useTabFallback(visibleTabs, activeTab, setActiveTab);
 
   // Refresh current view based on active tab
   const refreshCurrentView = useCallback((): void => {
@@ -268,23 +257,9 @@ export default function AccessPanel(): React.ReactNode {
         setFraudFocus((f) => f === "scores" ? "constraints" : "scores");
         return;
       }
-      const ids = visibleTabs.map((t) => t.id);
-      const currentIdx = ids.indexOf(activeTab);
-      const nextIdx = (currentIdx + 1) % ids.length;
-      const nextTab = ids[nextIdx];
-      if (nextTab) {
-        setActiveTab(nextTab);
-      }
+      subTabForward(visibleTabs, activeTab, setActiveTab);
     },
-    "shift+tab": () => {
-      const ids = visibleTabs.map((t) => t.id);
-      const currentIdx = ids.indexOf(activeTab);
-      const nextIdx = (currentIdx + 1) % ids.length;
-      const nextTab = ids[nextIdx];
-      if (nextTab) {
-        setActiveTab(nextTab);
-      }
-    },
+    "shift+tab": () => subTabBackward(visibleTabs, activeTab, setActiveTab),
     return: () => {
       // Manifests: fetch detail to load tuple entries
       if (activeTab === "manifests" && client) {
@@ -519,13 +494,7 @@ export default function AccessPanel(): React.ReactNode {
   return (
     <box height="100%" width="100%" flexDirection="column">
       {/* Tab bar */}
-      <box height={1} width="100%">
-        <text>
-          {visibleTabs.map((tab) => {
-            return tab.id === activeTab ? `[${tab.label}]` : ` ${tab.label} `;
-          }).join(" ")}
-        </text>
-      </box>
+      <SubTabBar tabs={visibleTabs} activeTab={activeTab} />
 
       {/* Permission evaluation result */}
       {lastPermissionCheck && (

--- a/packages/nexus-tui/src/panels/access/access-panel.tsx
+++ b/packages/nexus-tui/src/panels/access/access-panel.tsx
@@ -29,7 +29,7 @@ import { useApi } from "../../shared/hooks/use-api.js";
 import { useUiStore } from "../../stores/ui-store.js";
 import { useVisibleTabs, type TabDef } from "../../shared/hooks/use-visible-tabs.js";
 import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
-import { subTabForward, subTabBackward } from "../../shared/components/sub-tab-bar-utils.js";
+import { subTabCycleBindings, subTabForward } from "../../shared/components/sub-tab-bar-utils.js";
 import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
 import { LoadingIndicator } from "../../shared/components/loading-indicator.js";
 import { statusColor } from "../../shared/theme.js";
@@ -252,6 +252,7 @@ export default function AccessPanel(): React.ReactNode {
         setSelectedDelegationIndex(Math.max(selectedDelegationIndex - 1, 0));
       }
     },
+    ...subTabCycleBindings(visibleTabs, activeTab, setActiveTab),
     tab: () => {
       if (activeTab === "fraud") {
         setFraudFocus((f) => f === "scores" ? "constraints" : "scores");
@@ -259,7 +260,6 @@ export default function AccessPanel(): React.ReactNode {
       }
       subTabForward(visibleTabs, activeTab, setActiveTab);
     },
-    "shift+tab": () => subTabBackward(visibleTabs, activeTab, setActiveTab),
     return: () => {
       // Manifests: fetch detail to load tuple entries
       if (activeTab === "manifests" && client) {

--- a/packages/nexus-tui/src/panels/agents/agents-panel.tsx
+++ b/packages/nexus-tui/src/panels/agents/agents-panel.tsx
@@ -24,6 +24,9 @@ import { useCommandRunnerStore, executeLocalCommand } from "../../services/comma
 import { useUiStore } from "../../stores/ui-store.js";
 import { agentStateColor, focusColor, statusColor } from "../../shared/theme.js";
 import { ScrollIndicator } from "../../shared/components/scroll-indicator.js";
+import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
+import { subTabForward } from "../../shared/components/sub-tab-bar-utils.js";
+import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
 
 const ALL_TABS: readonly TabDef<AgentTab>[] = [
   { id: "status", label: "Status", brick: "agent_runtime" },
@@ -31,12 +34,6 @@ const ALL_TABS: readonly TabDef<AgentTab>[] = [
   { id: "inbox", label: "Inbox", brick: "ipc" },
   { id: "trajectories", label: "Trajectories", brick: "agent_runtime" },
 ];
-const TAB_LABELS: Readonly<Record<AgentTab, string>> = {
-  status: "Status",
-  delegations: "Delegations",
-  inbox: "Inbox",
-  trajectories: "Trajectories",
-};
 
 export default function AgentsPanel(): React.ReactNode {
   const client = useApi();
@@ -119,13 +116,7 @@ export default function AgentsPanel(): React.ReactNode {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [client, effectiveZoneId]);
 
-  // Fall back to first visible tab if the active tab becomes hidden
-  const visibleIds = visibleTabs.map((t) => t.id);
-  useEffect(() => {
-    if (visibleIds.length > 0 && !visibleIds.includes(activeTab)) {
-      setActiveTab(visibleIds[0]!);
-    }
-  }, [visibleIds.join(","), activeTab, setActiveTab]);
+  useTabFallback(visibleTabs, activeTab, setActiveTab);
 
   // Refresh current view based on active tab
   const refreshCurrentView = (): void => {
@@ -215,15 +206,7 @@ export default function AgentsPanel(): React.ReactNode {
         if (agentId) setSelectedAgentId(agentId);
       }
     },
-    tab: () => {
-      const ids = visibleTabs.map((t) => t.id);
-      const currentIdx = ids.indexOf(activeTab);
-      const nextIdx = (currentIdx + 1) % ids.length;
-      const nextTab = ids[nextIdx];
-      if (nextTab) {
-        setActiveTab(nextTab);
-      }
-    },
+    tab: () => subTabForward(visibleTabs, activeTab, setActiveTab),
     "shift+tab": () => toggleFocus("agents"),
     r: () => refreshCurrentView(),
     d: async () => {
@@ -371,13 +354,7 @@ export default function AgentsPanel(): React.ReactNode {
         {/* Right pane: detail views (70%) */}
         <box width="70%" height="100%" borderStyle="single" borderColor={uiFocusPane === "right" ? focusColor.activeBorder : focusColor.inactiveBorder} flexDirection="column">
           {/* Tab bar */}
-          <box height={1} width="100%">
-            <text>
-              {visibleTabs.map((tab) => {
-                return tab.id === activeTab ? `[${tab.label}]` : ` ${tab.label} `;
-              }).join(" ")}
-            </text>
-          </box>
+          <SubTabBar tabs={visibleTabs} activeTab={activeTab} />
 
           {/* Operation in-progress feedback */}
           {operationLoading && (

--- a/packages/nexus-tui/src/panels/agents/agents-panel.tsx
+++ b/packages/nexus-tui/src/panels/agents/agents-panel.tsx
@@ -25,7 +25,7 @@ import { useUiStore } from "../../stores/ui-store.js";
 import { agentStateColor, focusColor, statusColor } from "../../shared/theme.js";
 import { ScrollIndicator } from "../../shared/components/scroll-indicator.js";
 import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
-import { subTabForward } from "../../shared/components/sub-tab-bar-utils.js";
+import { subTabCycleBindings } from "../../shared/components/sub-tab-bar-utils.js";
 import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
 
 const ALL_TABS: readonly TabDef<AgentTab>[] = [
@@ -206,7 +206,7 @@ export default function AgentsPanel(): React.ReactNode {
         if (agentId) setSelectedAgentId(agentId);
       }
     },
-    tab: () => subTabForward(visibleTabs, activeTab, setActiveTab),
+    ...subTabCycleBindings(visibleTabs, activeTab, setActiveTab),
     "shift+tab": () => toggleFocus("agents"),
     r: () => refreshCurrentView(),
     d: async () => {

--- a/packages/nexus-tui/src/panels/connectors/connectors-panel.tsx
+++ b/packages/nexus-tui/src/panels/connectors/connectors-panel.tsx
@@ -20,7 +20,7 @@ import { WriteTab } from "./write-tab.js";
 import { statusColor } from "../../shared/theme.js";
 import { useVisibleTabs, type TabDef } from "../../shared/hooks/use-visible-tabs.js";
 import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
-import { subTabForward, subTabBackward } from "../../shared/components/sub-tab-bar-utils.js";
+import { subTabCycleBindings } from "../../shared/components/sub-tab-bar-utils.js";
 import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
 
 // =============================================================================
@@ -53,8 +53,7 @@ export default function ConnectorsPanel(): React.ReactNode {
     overlayActive
       ? {}
       : {
-          tab: () => subTabForward(visibleTabs, activeTab, setActiveTab),
-          "shift+tab": () => subTabBackward(visibleTabs, activeTab, setActiveTab),
+          ...subTabCycleBindings(visibleTabs, activeTab, setActiveTab),
         },
   );
 

--- a/packages/nexus-tui/src/panels/connectors/connectors-panel.tsx
+++ b/packages/nexus-tui/src/panels/connectors/connectors-panel.tsx
@@ -18,24 +18,21 @@ import { MountedTab } from "./mounted-tab.js";
 import { SkillsTab } from "./skills-tab.js";
 import { WriteTab } from "./write-tab.js";
 import { statusColor } from "../../shared/theme.js";
+import { useVisibleTabs, type TabDef } from "../../shared/hooks/use-visible-tabs.js";
+import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
+import { subTabForward, subTabBackward } from "../../shared/components/sub-tab-bar-utils.js";
+import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
 
 // =============================================================================
 // Tab configuration
 // =============================================================================
 
-const TAB_ORDER: readonly ConnectorsTab[] = [
-  "available",
-  "mounted",
-  "skills",
-  "write",
+const ALL_TABS: readonly TabDef<ConnectorsTab>[] = [
+  { id: "available", label: "Available", brick: null },
+  { id: "mounted", label: "Mounted", brick: null },
+  { id: "skills", label: "Skills", brick: null },
+  { id: "write", label: "Write", brick: null },
 ];
-
-const TAB_LABELS: Readonly<Record<ConnectorsTab, string>> = {
-  available: "Available",
-  mounted: "Mounted",
-  skills: "Skills",
-  write: "Write",
-};
 
 // =============================================================================
 // Panel component
@@ -47,28 +44,17 @@ export default function ConnectorsPanel(): React.ReactNode {
   const activeTab = useConnectorsStore((s) => s.activeTab);
   const setActiveTab = useConnectorsStore((s) => s.setActiveTab);
 
+  const visibleTabs = useVisibleTabs(ALL_TABS);
+  useTabFallback(visibleTabs, activeTab, setActiveTab);
+
   // Only the panel root handles Tab key for sub-tab cycling.
   // All other keys are delegated to the active sub-tab component.
   useKeyboard(
     overlayActive
       ? {}
       : {
-          tab: () => {
-            const currentIdx = TAB_ORDER.indexOf(activeTab);
-            const nextIdx = (currentIdx + 1) % TAB_ORDER.length;
-            const nextTab = TAB_ORDER[nextIdx];
-            if (nextTab) {
-              setActiveTab(nextTab);
-            }
-          },
-          "shift+tab": () => {
-            const currentIdx = TAB_ORDER.indexOf(activeTab);
-            const prevIdx = (currentIdx - 1 + TAB_ORDER.length) % TAB_ORDER.length;
-            const prevTab = TAB_ORDER[prevIdx];
-            if (prevTab) {
-              setActiveTab(prevTab);
-            }
-          },
+          tab: () => subTabForward(visibleTabs, activeTab, setActiveTab),
+          "shift+tab": () => subTabBackward(visibleTabs, activeTab, setActiveTab),
         },
   );
 
@@ -80,14 +66,7 @@ export default function ConnectorsPanel(): React.ReactNode {
     <BrickGate brick="storage">
       <box height="100%" width="100%" flexDirection="column">
         {/* Sub-tab bar */}
-        <box height={1} width="100%">
-          <text>
-            {TAB_ORDER.map((tab) => {
-              const label = TAB_LABELS[tab];
-              return tab === activeTab ? `[${label}]` : ` ${label} `;
-            }).join(" ")}
-          </text>
-        </box>
+        <SubTabBar tabs={visibleTabs} activeTab={activeTab} />
 
         {/* Active tab content */}
         <box flexGrow={1}>

--- a/packages/nexus-tui/src/panels/events/events-panel.tsx
+++ b/packages/nexus-tui/src/panels/events/events-panel.tsx
@@ -32,6 +32,9 @@ import { useKnowledgeStore } from "../../stores/knowledge-store.js";
 import { EmptyState } from "../../shared/components/empty-state.js";
 import { ScrollIndicator } from "../../shared/components/scroll-indicator.js";
 import { Tooltip } from "../../shared/components/tooltip.js";
+import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
+import { subTabForward } from "../../shared/components/sub-tab-bar-utils.js";
+import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
 
 type FilterMode = "none" | "type" | "search" | "mcl_urn" | "mcl_aspect" | "acquire_path" | "secrets_filter" | "replay_filter";
 
@@ -49,17 +52,6 @@ const ALL_TABS: readonly TabDef<PanelTab>[] = [
   { id: "audit", label: "Audit", brick: "auth" },
 ];
 
-const TAB_LABELS: Readonly<Record<PanelTab, string>> = {
-  events: "Events",
-  mcl: "MCL",
-  replay: "Replay",
-  operations: "Operations",
-  connectors: "Connectors",
-  subscriptions: "Subscriptions",
-  locks: "Locks",
-  secrets: "Secrets",
-  audit: "Audit",
-};
 
 export default function EventsPanel(): React.ReactNode {
   const apiClient = useApi();
@@ -155,13 +147,7 @@ export default function EventsPanel(): React.ReactNode {
   // Track the combined active tab locally
   const [activeTab, setActiveTab] = React.useState<PanelTab>("events");
 
-  // Fall back to first visible tab if the active tab becomes hidden
-  const visibleIds = visibleTabs.map((t) => t.id);
-  useEffect(() => {
-    if (visibleIds.length > 0 && !visibleIds.includes(activeTab)) {
-      setActiveTab(visibleIds[0]!);
-    }
-  }, [visibleIds.join(","), activeTab]);
+  useTabFallback(visibleTabs, activeTab, setActiveTab);
 
   // Reset expanded event when events change (index may become stale after SSE adds/evicts)
   const eventsLength = events.length;
@@ -368,12 +354,7 @@ export default function EventsPanel(): React.ReactNode {
               setConnectorDetailView(false);
             }
           },
-          tab: () => {
-            const ids = visibleTabs.map((t) => t.id);
-            const idx = ids.indexOf(activeTab);
-            const next = ids[(idx + 1) % ids.length];
-            if (next) setActiveTab(next);
-          },
+          tab: () => subTabForward(visibleTabs, activeTab, setActiveTab),
           c: () => clearEvents(),
           r: () => refresh(),
           f: () => {
@@ -468,13 +449,7 @@ export default function EventsPanel(): React.ReactNode {
     <box height="100%" width="100%" flexDirection="column">
       <Tooltip tooltipKey="events-panel" message="Tip: Press ? for keybinding help" />
       {/* Tab bar */}
-      <box height={1} width="100%">
-        <text>
-          {visibleTabs.map((tab) => {
-            return tab.id === activeTab ? `[${tab.label}]` : ` ${tab.label} `;
-          }).join(" ")}
-        </text>
-      </box>
+      <SubTabBar tabs={visibleTabs} activeTab={activeTab} />
 
       {/* Filter bar (events tab) */}
       {activeTab === "events" && (

--- a/packages/nexus-tui/src/panels/events/events-panel.tsx
+++ b/packages/nexus-tui/src/panels/events/events-panel.tsx
@@ -33,7 +33,7 @@ import { EmptyState } from "../../shared/components/empty-state.js";
 import { ScrollIndicator } from "../../shared/components/scroll-indicator.js";
 import { Tooltip } from "../../shared/components/tooltip.js";
 import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
-import { subTabForward } from "../../shared/components/sub-tab-bar-utils.js";
+import { subTabCycleBindings } from "../../shared/components/sub-tab-bar-utils.js";
 import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
 
 type FilterMode = "none" | "type" | "search" | "mcl_urn" | "mcl_aspect" | "acquire_path" | "secrets_filter" | "replay_filter";
@@ -354,7 +354,7 @@ export default function EventsPanel(): React.ReactNode {
               setConnectorDetailView(false);
             }
           },
-          tab: () => subTabForward(visibleTabs, activeTab, setActiveTab),
+          ...subTabCycleBindings(visibleTabs, activeTab, setActiveTab),
           c: () => clearEvents(),
           r: () => refresh(),
           f: () => {

--- a/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
+++ b/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
@@ -48,7 +48,7 @@ import { useApi } from "../../shared/hooks/use-api.js";
 import { useBrickAvailable } from "../../shared/hooks/use-brick-available.js";
 import { useVisibleTabs, type TabDef } from "../../shared/hooks/use-visible-tabs.js";
 import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
-import { subTabForward } from "../../shared/components/sub-tab-bar-utils.js";
+import { subTabCycleBindings } from "../../shared/components/sub-tab-bar-utils.js";
 import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
 import { useKnowledgeStore } from "../../stores/knowledge-store.js";
 import { useUiStore } from "../../stores/ui-store.js";
@@ -190,7 +190,7 @@ function getTabNavBindings(ctx: BindingContext): Record<string, () => void> {
 /** Tab cycling (shared across all modes). */
 function getTabCycleBindings(ctx: BindingContext): Record<string, () => void> {
   return {
-    tab: () => subTabForward(ctx.visibleTabs, ctx.activeTab, ctx.setActiveTab),
+    ...subTabCycleBindings(ctx.visibleTabs, ctx.activeTab, ctx.setActiveTab),
     "shift+tab": () => ctx.toggleFocus("files"),
   };
 }

--- a/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
+++ b/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
@@ -47,6 +47,9 @@ import {
 import { useApi } from "../../shared/hooks/use-api.js";
 import { useBrickAvailable } from "../../shared/hooks/use-brick-available.js";
 import { useVisibleTabs, type TabDef } from "../../shared/hooks/use-visible-tabs.js";
+import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
+import { subTabForward } from "../../shared/components/sub-tab-bar-utils.js";
+import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
 import { useKnowledgeStore } from "../../stores/knowledge-store.js";
 import { useUiStore } from "../../stores/ui-store.js";
 import { focusColor } from "../../shared/theme.js";
@@ -187,12 +190,7 @@ function getTabNavBindings(ctx: BindingContext): Record<string, () => void> {
 /** Tab cycling (shared across all modes). */
 function getTabCycleBindings(ctx: BindingContext): Record<string, () => void> {
   return {
-    tab: () => {
-      const ids = ctx.visibleTabs.map((t) => t.id);
-      const idx = ids.indexOf(ctx.activeTab);
-      const next = ids[(idx + 1) % ids.length];
-      if (next) ctx.setActiveTab(next);
-    },
+    tab: () => subTabForward(ctx.visibleTabs, ctx.activeTab, ctx.setActiveTab),
     "shift+tab": () => ctx.toggleFocus("files"),
   };
 }
@@ -520,13 +518,7 @@ export default function FileExplorerPanel(): React.ReactNode {
   // Panel-level active tab
   const [activeTab, setActiveTab] = useState<FilesTab>("explorer");
 
-  // Fall back to first visible tab if the active tab becomes hidden
-  const visibleIds = visibleTabs.map((t) => t.id);
-  useEffect(() => {
-    if (visibleIds.length > 0 && !visibleIds.includes(activeTab)) {
-      setActiveTab(visibleIds[0]!);
-    }
-  }, [visibleIds.join(","), activeTab]);
+  useTabFallback(visibleTabs, activeTab, setActiveTab);
 
   // Files store
   const currentPath = useFilesStore((s) => s.currentPath);
@@ -794,13 +786,7 @@ export default function FileExplorerPanel(): React.ReactNode {
       ) : <>
 
       {/* Panel-level tab bar */}
-      <box height={1} width="100%">
-        <text>
-          {visibleTabs.map((tab) => {
-            return tab.id === activeTab ? `[${tab.label}]` : ` ${tab.label} `;
-          }).join(" ")}
-        </text>
-      </box>
+      <SubTabBar tabs={visibleTabs} activeTab={activeTab} />
 
       {/* Input bar for text modes */}
       {inputMode !== "none" && (

--- a/packages/nexus-tui/src/panels/payments/payments-panel.tsx
+++ b/packages/nexus-tui/src/panels/payments/payments-panel.tsx
@@ -14,7 +14,7 @@ import { useApi } from "../../shared/hooks/use-api.js";
 import { useUiStore } from "../../stores/ui-store.js";
 import { useVisibleTabs, type TabDef } from "../../shared/hooks/use-visible-tabs.js";
 import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
-import { subTabForward, subTabBackward } from "../../shared/components/sub-tab-bar-utils.js";
+import { subTabCycleBindings } from "../../shared/components/sub-tab-bar-utils.js";
 import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
 import { BrickGate } from "../../shared/components/brick-gate.js";
 import { LoadingIndicator } from "../../shared/components/loading-indicator.js";
@@ -272,7 +272,7 @@ export default function PaymentsPanel(): React.ReactNode {
               setSelectedApprovalIndex(Math.max(selectedApprovalIndex - 1, 0));
             }
           },
-          tab: () => subTabForward(visibleTabs, activeTab, setActiveTab),
+          ...subTabCycleBindings(visibleTabs, activeTab, setActiveTab),
           t: () => {
             setShowTransfer(true);
           },

--- a/packages/nexus-tui/src/panels/payments/payments-panel.tsx
+++ b/packages/nexus-tui/src/panels/payments/payments-panel.tsx
@@ -12,6 +12,10 @@ import { jumpToStart, jumpToEnd } from "../../shared/hooks/use-list-navigation.j
 import { useConfirmStore } from "../../shared/hooks/use-confirm.js";
 import { useApi } from "../../shared/hooks/use-api.js";
 import { useUiStore } from "../../stores/ui-store.js";
+import { useVisibleTabs, type TabDef } from "../../shared/hooks/use-visible-tabs.js";
+import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
+import { subTabForward, subTabBackward } from "../../shared/components/sub-tab-bar-utils.js";
+import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
 import { BrickGate } from "../../shared/components/brick-gate.js";
 import { LoadingIndicator } from "../../shared/components/loading-indicator.js";
 import { BalanceCard } from "./balance-card.js";
@@ -22,20 +26,13 @@ import { PolicyList } from "./policy-list.js";
 import { BudgetCard } from "./budget-card.js";
 import { ApprovalList } from "./approval-list.js";
 
-const TAB_ORDER: readonly PaymentsTab[] = [
-  "balance",
-  "reservations",
-  "transactions",
-  "policies",
-  "approvals",
+const ALL_TABS: readonly TabDef<PaymentsTab>[] = [
+  { id: "balance", label: "Balance", brick: null },
+  { id: "reservations", label: "Reservations", brick: null },
+  { id: "transactions", label: "Transactions", brick: null },
+  { id: "policies", label: "Policies", brick: null },
+  { id: "approvals", label: "Approvals", brick: null },
 ];
-const TAB_LABELS: Readonly<Record<PaymentsTab, string>> = {
-  balance: "Balance",
-  reservations: "Reservations",
-  transactions: "Transactions",
-  policies: "Policies",
-  approvals: "Approvals",
-};
 
 export default function PaymentsPanel(): React.ReactNode {
   const client = useApi();
@@ -93,6 +90,10 @@ export default function PaymentsPanel(): React.ReactNode {
   const rejectRequest = usePaymentsStore((s) => s.rejectRequest);
   const setSelectedApprovalIndex = usePaymentsStore((s) => s.setSelectedApprovalIndex);
   const setActiveTab = usePaymentsStore((s) => s.setActiveTab);
+
+  const visibleTabs = useVisibleTabs(ALL_TABS);
+  useTabFallback(visibleTabs, activeTab, setActiveTab);
+
   const setSelectedReservationIndex = usePaymentsStore(
     (s) => s.setSelectedReservationIndex,
   );
@@ -271,14 +272,7 @@ export default function PaymentsPanel(): React.ReactNode {
               setSelectedApprovalIndex(Math.max(selectedApprovalIndex - 1, 0));
             }
           },
-          tab: () => {
-            const currentIdx = TAB_ORDER.indexOf(activeTab);
-            const nextIdx = (currentIdx + 1) % TAB_ORDER.length;
-            const nextTab = TAB_ORDER[nextIdx];
-            if (nextTab) {
-              setActiveTab(nextTab);
-            }
-          },
+          tab: () => subTabForward(visibleTabs, activeTab, setActiveTab),
           t: () => {
             setShowTransfer(true);
           },
@@ -412,14 +406,7 @@ export default function PaymentsPanel(): React.ReactNode {
     <BrickGate brick="pay">
       <box height="100%" width="100%" flexDirection="column">
         {/* Tab bar */}
-        <box height={1} width="100%">
-          <text>
-            {TAB_ORDER.map((tab) => {
-              const label = TAB_LABELS[tab];
-              return tab === activeTab ? `[${label}]` : ` ${label} `;
-            }).join(" ")}
-          </text>
-        </box>
+        <SubTabBar tabs={visibleTabs} activeTab={activeTab} />
 
         {/* Afford check input */}
         {affordInputMode && (

--- a/packages/nexus-tui/src/panels/search/search-panel.tsx
+++ b/packages/nexus-tui/src/panels/search/search-panel.tsx
@@ -5,7 +5,7 @@
  * Press / to enter search input mode, type query, Enter to submit, Escape to cancel.
  */
 
-import React, { useState, useCallback, useEffect } from "react";
+import React, { useState, useCallback } from "react";
 import { useSearchStore } from "../../stores/search-store.js";
 import { useGlobalStore } from "../../stores/global-store.js";
 import type { SearchTab, SearchMode } from "../../stores/search-store.js";
@@ -15,6 +15,9 @@ import { useConfirmStore } from "../../shared/hooks/use-confirm.js";
 import { useApi } from "../../shared/hooks/use-api.js";
 import { useUiStore } from "../../stores/ui-store.js";
 import { useVisibleTabs, type TabDef } from "../../shared/hooks/use-visible-tabs.js";
+import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
+import { subTabForward } from "../../shared/components/sub-tab-bar-utils.js";
+import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
 import { SearchResults } from "./search-results.js";
 import { KnowledgeView } from "./knowledge-view.js";
 import { MemoryList } from "./memory-list.js";
@@ -32,14 +35,6 @@ const ALL_TABS: readonly TabDef<SearchTab>[] = [
   { id: "ask", label: "Ask", brick: "rlm" },
   { id: "columns", label: "Columns", brick: "catalog" },
 ];
-const TAB_LABELS: Readonly<Record<SearchTab, string>> = {
-  search: "Search",
-  knowledge: "Knowledge",
-  memories: "Memories",
-  playbooks: "Playbooks",
-  ask: "Ask",
-  columns: "Columns",
-};
 
 const MODE_LABELS: Readonly<Record<SearchMode, string>> = {
   keyword: "KW",
@@ -116,13 +111,7 @@ export default function SearchPanel(): React.ReactNode {
   const setSelectedMemoryIndex = useSearchStore((s) => s.setSelectedMemoryIndex);
   const setSearchQuery = useSearchStore((s) => s.setSearchQuery);
 
-  // Fall back to first visible tab if the active tab becomes hidden
-  const visibleIds = visibleTabs.map((t) => t.id);
-  useEffect(() => {
-    if (visibleIds.length > 0 && !visibleIds.includes(activeTab)) {
-      setActiveTab(visibleIds[0]!);
-    }
-  }, [visibleIds.join(","), activeTab, setActiveTab]);
+  useTabFallback(visibleTabs, activeTab, setActiveTab);
 
   const submitSearch = useCallback(
     (query: string) => {
@@ -253,15 +242,7 @@ export default function SearchPanel(): React.ReactNode {
               setSelectedPlaybookIndex(Math.max(selectedPlaybookIndex - 1, 0));
             }
           },
-          tab: () => {
-            const ids = visibleTabs.map((t) => t.id);
-            const currentIdx = ids.indexOf(activeTab);
-            const nextIdx = (currentIdx + 1) % ids.length;
-            const nextTab = ids[nextIdx];
-            if (nextTab) {
-              setActiveTab(nextTab);
-            }
-          },
+          tab: () => subTabForward(visibleTabs, activeTab, setActiveTab),
           r: () => refreshCurrentView(),
           m: () => cycleSearchMode(),
           "/": () => {
@@ -418,13 +399,7 @@ export default function SearchPanel(): React.ReactNode {
       </box>
 
       {/* Tab bar */}
-      <box height={1} width="100%">
-        <text>
-          {visibleTabs.map((tab) => {
-            return tab.id === activeTab ? `[${tab.label}]` : ` ${tab.label} `;
-          }).join(" ")}
-        </text>
-      </box>
+      <SubTabBar tabs={visibleTabs} activeTab={activeTab} />
 
       {/* Error display */}
       {error && (

--- a/packages/nexus-tui/src/panels/search/search-panel.tsx
+++ b/packages/nexus-tui/src/panels/search/search-panel.tsx
@@ -16,7 +16,7 @@ import { useApi } from "../../shared/hooks/use-api.js";
 import { useUiStore } from "../../stores/ui-store.js";
 import { useVisibleTabs, type TabDef } from "../../shared/hooks/use-visible-tabs.js";
 import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
-import { subTabForward } from "../../shared/components/sub-tab-bar-utils.js";
+import { subTabCycleBindings } from "../../shared/components/sub-tab-bar-utils.js";
 import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
 import { SearchResults } from "./search-results.js";
 import { KnowledgeView } from "./knowledge-view.js";
@@ -242,7 +242,7 @@ export default function SearchPanel(): React.ReactNode {
               setSelectedPlaybookIndex(Math.max(selectedPlaybookIndex - 1, 0));
             }
           },
-          tab: () => subTabForward(visibleTabs, activeTab, setActiveTab),
+          ...subTabCycleBindings(visibleTabs, activeTab, setActiveTab),
           r: () => refreshCurrentView(),
           m: () => cycleSearchMode(),
           "/": () => {

--- a/packages/nexus-tui/src/panels/workflows/workflows-panel.tsx
+++ b/packages/nexus-tui/src/panels/workflows/workflows-panel.tsx
@@ -12,7 +12,7 @@ import { useApi } from "../../shared/hooks/use-api.js";
 import { useUiStore } from "../../stores/ui-store.js";
 import { useVisibleTabs, type TabDef } from "../../shared/hooks/use-visible-tabs.js";
 import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
-import { subTabForward } from "../../shared/components/sub-tab-bar-utils.js";
+import { subTabCycleBindings } from "../../shared/components/sub-tab-bar-utils.js";
 import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
 import { BrickGate } from "../../shared/components/brick-gate.js";
 import { ConfirmDialog } from "../../shared/components/confirm-dialog.js";
@@ -151,7 +151,7 @@ export default function WorkflowsPanel(): React.ReactNode {
           up: () => {
             setCurrentIndex(Math.max(currentIndex() - 1, 0));
           },
-          tab: () => subTabForward(visibleTabs, activeTab, setActiveTab),
+          ...subTabCycleBindings(visibleTabs, activeTab, setActiveTab),
           r: () => refreshCurrentView(),
           e: () => {
             if (activeTab !== "workflows" || !client) return;

--- a/packages/nexus-tui/src/panels/workflows/workflows-panel.tsx
+++ b/packages/nexus-tui/src/panels/workflows/workflows-panel.tsx
@@ -10,6 +10,10 @@ import { useKeyboard } from "../../shared/hooks/use-keyboard.js";
 import { jumpToStart, jumpToEnd } from "../../shared/hooks/use-list-navigation.js";
 import { useApi } from "../../shared/hooks/use-api.js";
 import { useUiStore } from "../../stores/ui-store.js";
+import { useVisibleTabs, type TabDef } from "../../shared/hooks/use-visible-tabs.js";
+import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
+import { subTabForward } from "../../shared/components/sub-tab-bar-utils.js";
+import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
 import { BrickGate } from "../../shared/components/brick-gate.js";
 import { ConfirmDialog } from "../../shared/components/confirm-dialog.js";
 import { LoadingIndicator } from "../../shared/components/loading-indicator.js";
@@ -18,17 +22,11 @@ import { ExecutionList } from "./execution-list.js";
 import { SchedulerView } from "./scheduler-view.js";
 import { Tooltip } from "../../shared/components/tooltip.js";
 
-const TAB_ORDER: readonly WorkflowTab[] = [
-  "workflows",
-  "executions",
-  "scheduler",
+const ALL_TABS: readonly TabDef<WorkflowTab>[] = [
+  { id: "workflows", label: "Workflows", brick: null },
+  { id: "executions", label: "Executions", brick: null },
+  { id: "scheduler", label: "Scheduler", brick: null },
 ];
-
-const TAB_LABELS: Readonly<Record<WorkflowTab, string>> = {
-  workflows: "Workflows",
-  executions: "Executions",
-  scheduler: "Scheduler",
-};
 
 export default function WorkflowsPanel(): React.ReactNode {
   const client = useApi();
@@ -63,6 +61,9 @@ export default function WorkflowsPanel(): React.ReactNode {
   const setSelectedExecutionIndex = useWorkflowsStore((s) => s.setSelectedExecutionIndex);
 
   const overlayActive = useUiStore((s) => s.overlayActive);
+
+  const visibleTabs = useVisibleTabs(ALL_TABS);
+  useTabFallback(visibleTabs, activeTab, setActiveTab);
 
   // Track in-flight workflow execution
   const [executing, setExecuting] = useState(false);
@@ -150,14 +151,7 @@ export default function WorkflowsPanel(): React.ReactNode {
           up: () => {
             setCurrentIndex(Math.max(currentIndex() - 1, 0));
           },
-          tab: () => {
-            const currentIdx = TAB_ORDER.indexOf(activeTab);
-            const nextIdx = (currentIdx + 1) % TAB_ORDER.length;
-            const nextTab = TAB_ORDER[nextIdx];
-            if (nextTab) {
-              setActiveTab(nextTab);
-            }
-          },
+          tab: () => subTabForward(visibleTabs, activeTab, setActiveTab),
           r: () => refreshCurrentView(),
           e: () => {
             if (activeTab !== "workflows" || !client) return;
@@ -220,14 +214,7 @@ export default function WorkflowsPanel(): React.ReactNode {
       <box height="100%" width="100%" flexDirection="column">
         <Tooltip tooltipKey="workflows-panel" message="Tip: Press ? for keybinding help" />
         {/* Tab bar */}
-        <box height={1} width="100%">
-          <text>
-            {TAB_ORDER.map((tab) => {
-              const label = TAB_LABELS[tab];
-              return tab === activeTab ? `[${label}]` : ` ${label} `;
-            }).join(" ")}
-          </text>
-        </box>
+        <SubTabBar tabs={visibleTabs} activeTab={activeTab} />
 
         {/* Error display */}
         {error && (

--- a/packages/nexus-tui/src/panels/zones/zones-panel.tsx
+++ b/packages/nexus-tui/src/panels/zones/zones-panel.tsx
@@ -15,7 +15,7 @@ import { jumpToStart, jumpToEnd } from "../../shared/hooks/use-list-navigation.j
 import { useApi } from "../../shared/hooks/use-api.js";
 import { useVisibleTabs, type TabDef } from "../../shared/hooks/use-visible-tabs.js";
 import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
-import { subTabForward, subTabBackward } from "../../shared/components/sub-tab-bar-utils.js";
+import { subTabCycleBindings } from "../../shared/components/sub-tab-bar-utils.js";
 import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
 import { ZoneList } from "./zone-list.js";
 import { BrickList } from "./brick-list.js";
@@ -328,7 +328,7 @@ export default function ZonesPanel(): React.ReactNode {
             up: () => {
               setCurrentNavIndex(Math.max(currentNavIndex() - 1, 0));
             },
-            tab: () => subTabForward(visibleTabs, activeTab, setActiveTab),
+            ...subTabCycleBindings(visibleTabs, activeTab, setActiveTab),
             "shift+tab": () => toggleFocus("zones"),
             // n: Register workspace or mount MCP server
             n: () => {

--- a/packages/nexus-tui/src/panels/zones/zones-panel.tsx
+++ b/packages/nexus-tui/src/panels/zones/zones-panel.tsx
@@ -14,6 +14,9 @@ import { useKeyboard } from "../../shared/hooks/use-keyboard.js";
 import { jumpToStart, jumpToEnd } from "../../shared/hooks/use-list-navigation.js";
 import { useApi } from "../../shared/hooks/use-api.js";
 import { useVisibleTabs, type TabDef } from "../../shared/hooks/use-visible-tabs.js";
+import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
+import { subTabForward, subTabBackward } from "../../shared/components/sub-tab-bar-utils.js";
+import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
 import { ZoneList } from "./zone-list.js";
 import { BrickList } from "./brick-list.js";
 import { BrickDetail } from "./brick-detail.js";
@@ -37,16 +40,6 @@ const ALL_TABS: readonly TabDef<ZoneTab>[] = [
   { id: "mcp", label: "MCP", brick: "mcp" },
   { id: "cache", label: "Cache", brick: "cache" },
 ];
-const TAB_LABELS: Readonly<Record<ZoneTab, string>> = {
-  zones: "Zones",
-  bricks: "Bricks",
-  drift: "Drift",
-  reindex: "Reindex",
-  workspaces: "Workspaces",
-  mcp: "MCP",
-  cache: "Cache",
-};
-
 export default function ZonesPanel(): React.ReactNode {
   const client = useApi();
   const visibleTabs = useVisibleTabs(ALL_TABS);
@@ -108,13 +101,7 @@ export default function ZonesPanel(): React.ReactNode {
   const toggleFocus = useUiStore((s) => s.toggleFocusPane);
   const overlayActive = useUiStore((s) => s.overlayActive);
 
-  // Fall back to first visible tab if the active tab becomes hidden
-  const visibleIds = visibleTabs.map((t) => t.id);
-  useEffect(() => {
-    if (visibleIds.length > 0 && !visibleIds.includes(activeTab)) {
-      setActiveTab(visibleIds[0]!);
-    }
-  }, [visibleIds.join(","), activeTab, setActiveTab]);
+  useTabFallback(visibleTabs, activeTab, setActiveTab);
 
   // Track in-flight brick operations (mount, unmount, reset, etc.)
   const [operationInProgress, setOperationInProgress] = useState(false);
@@ -341,15 +328,7 @@ export default function ZonesPanel(): React.ReactNode {
             up: () => {
               setCurrentNavIndex(Math.max(currentNavIndex() - 1, 0));
             },
-            tab: () => {
-              const ids = visibleTabs.map((t) => t.id);
-              const currentIdx = ids.indexOf(activeTab);
-              const nextIdx = (currentIdx + 1) % ids.length;
-              const nextTab = ids[nextIdx];
-              if (nextTab) {
-                setActiveTab(nextTab);
-              }
-            },
+            tab: () => subTabForward(visibleTabs, activeTab, setActiveTab),
             "shift+tab": () => toggleFocus("zones"),
             // n: Register workspace or mount MCP server
             n: () => {
@@ -448,14 +427,7 @@ export default function ZonesPanel(): React.ReactNode {
 
   return (
     <box height="100%" width="100%" flexDirection="column">
-      {/* Tab bar */}
-      <box height={1} width="100%">
-        <text>
-          {visibleTabs.map((tab) => {
-            return tab.id === activeTab ? `[${tab.label}]` : ` ${tab.label} `;
-          }).join(" ")}
-        </text>
-      </box>
+      <SubTabBar tabs={visibleTabs} activeTab={activeTab} />
 
       {/* Multi-field input form for register/mount */}
       {inputMode !== "none" && (

--- a/packages/nexus-tui/src/shared/components/sub-tab-bar-utils.ts
+++ b/packages/nexus-tui/src/shared/components/sub-tab-bar-utils.ts
@@ -1,0 +1,78 @@
+/**
+ * Pure utility functions for sub-tab bar keyboard cycling.
+ *
+ * Separated from sub-tab-bar.tsx so tests can import without triggering
+ * JSX compilation (matching tab-bar-utils.ts pattern).
+ *
+ * @see Issue #3498
+ */
+
+// =============================================================================
+// Types
+// =============================================================================
+
+/** Minimal tab shape consumed by cycling helpers. */
+export interface SubTab {
+  readonly id: string;
+  readonly label: string;
+}
+
+// =============================================================================
+// Cycling helpers
+// =============================================================================
+
+/**
+ * Cycle forward to the next tab (wraps around).
+ *
+ * If activeTab is not found in tabs (e.g. brick just disabled it),
+ * defaults to the first tab to avoid undefined behavior.
+ */
+export function subTabForward<T extends string>(
+  tabs: readonly { readonly id: T }[],
+  activeTab: T,
+  setActiveTab: (tab: T) => void,
+): void {
+  if (tabs.length === 0) return;
+  const idx = tabs.findIndex((t) => t.id === activeTab);
+  // Guard: if activeTab not in list, jump to first tab
+  const nextIdx = idx === -1 ? 0 : (idx + 1) % tabs.length;
+  const next = tabs[nextIdx];
+  if (next) setActiveTab(next.id);
+}
+
+/**
+ * Cycle backward to the previous tab (wraps around).
+ *
+ * Same guard as subTabForward for missing activeTab.
+ */
+export function subTabBackward<T extends string>(
+  tabs: readonly { readonly id: T }[],
+  activeTab: T,
+  setActiveTab: (tab: T) => void,
+): void {
+  if (tabs.length === 0) return;
+  const idx = tabs.findIndex((t) => t.id === activeTab);
+  // Guard: if activeTab not in list, jump to first tab
+  const prevIdx = idx === -1 ? 0 : (idx - 1 + tabs.length) % tabs.length;
+  const prev = tabs[prevIdx];
+  if (prev) setActiveTab(prev.id);
+}
+
+// =============================================================================
+// Tab fallback logic
+// =============================================================================
+
+/**
+ * Determine if the active tab needs to fall back to the first visible tab.
+ *
+ * Returns the tab ID to switch to, or null if no switch is needed.
+ * Pure function — the hook (useTabFallback) wraps this in a useEffect.
+ */
+export function tabFallback<T extends string>(
+  visibleIds: readonly T[],
+  activeTab: T,
+): T | null {
+  if (visibleIds.length === 0) return null;
+  if (visibleIds.includes(activeTab)) return null;
+  return visibleIds[0]!;
+}

--- a/packages/nexus-tui/src/shared/components/sub-tab-bar-utils.ts
+++ b/packages/nexus-tui/src/shared/components/sub-tab-bar-utils.ts
@@ -59,6 +59,28 @@ export function subTabBackward<T extends string>(
 }
 
 // =============================================================================
+// Keyboard binding helper
+// =============================================================================
+
+/**
+ * Returns a keybinding object with `tab` (forward) and `shift+tab` (backward)
+ * entries that panels can spread into useKeyboard.
+ *
+ * Split-pane panels that need Shift+Tab for focus-toggle can override after
+ * spreading: `{ ...subTabCycleBindings(...), "shift+tab": () => toggleFocus("zones") }`
+ */
+export function subTabCycleBindings<T extends string>(
+  tabs: readonly { readonly id: T }[],
+  activeTab: T,
+  setActiveTab: (tab: T) => void,
+): Record<string, () => void> {
+  return {
+    tab: () => subTabForward(tabs, activeTab, setActiveTab),
+    "shift+tab": () => subTabBackward(tabs, activeTab, setActiveTab),
+  };
+}
+
+// =============================================================================
 // Tab fallback logic
 // =============================================================================
 

--- a/packages/nexus-tui/src/shared/components/sub-tab-bar.tsx
+++ b/packages/nexus-tui/src/shared/components/sub-tab-bar.tsx
@@ -1,0 +1,40 @@
+/**
+ * Shared sub-tab bar component for panel sub-navigation.
+ *
+ * Render-only — does NOT own keyboard bindings. Panels compose
+ * subTabForward/subTabBackward from sub-tab-bar-utils.ts into their
+ * own useKeyboard calls.
+ *
+ * @see Issue #3498
+ */
+
+import React from "react";
+import type { SubTab } from "./sub-tab-bar-utils.js";
+
+export interface SubTabBarProps {
+  /** Visible tabs to render (output of useVisibleTabs). */
+  readonly tabs: readonly SubTab[];
+  /** Currently active tab ID. */
+  readonly activeTab: string;
+}
+
+/**
+ * Renders a horizontal sub-tab bar with bracket notation for the active tab.
+ *
+ * Example output: `[Zones]  Bricks   Drift   Reindex`
+ */
+export function SubTabBar({ tabs, activeTab }: SubTabBarProps): React.ReactNode {
+  if (tabs.length === 0) return null;
+
+  return (
+    <box height={1} width="100%">
+      <text>
+        {tabs
+          .map((tab) =>
+            tab.id === activeTab ? `[${tab.label}]` : ` ${tab.label} `,
+          )
+          .join(" ")}
+      </text>
+    </box>
+  );
+}

--- a/packages/nexus-tui/src/shared/hooks/use-tab-fallback.ts
+++ b/packages/nexus-tui/src/shared/hooks/use-tab-fallback.ts
@@ -1,0 +1,32 @@
+/**
+ * Hook to fall back to the first visible tab when the active tab
+ * becomes hidden (e.g. its brick was disabled).
+ *
+ * Replaces the inline useEffect that was duplicated across 6+ panels
+ * with inconsistent dependency arrays.
+ *
+ * @see Issue #3498
+ */
+
+import { useEffect } from "react";
+import { tabFallback } from "../components/sub-tab-bar-utils.js";
+
+/**
+ * If activeTab is not in visibleTabs, switch to the first visible tab.
+ *
+ * Uses visibleIds.join(",") as the dependency key to match the established
+ * codebase convention (see zones-panel, events-panel, etc.).
+ */
+export function useTabFallback<T extends string>(
+  visibleTabs: readonly { readonly id: T }[],
+  activeTab: T,
+  setActiveTab: (tab: T) => void,
+): void {
+  const visibleIds = visibleTabs.map((t) => t.id);
+
+  useEffect(() => {
+    const target = tabFallback(visibleIds, activeTab);
+    if (target !== null) setActiveTab(target);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [visibleIds.join(","), activeTab]);
+}

--- a/packages/nexus-tui/tests/shared/sub-tab-bar-utils.test.ts
+++ b/packages/nexus-tui/tests/shared/sub-tab-bar-utils.test.ts
@@ -11,6 +11,7 @@ import { describe, it, expect } from "bun:test";
 import {
   subTabForward,
   subTabBackward,
+  subTabCycleBindings,
   tabFallback,
 } from "../../src/shared/components/sub-tab-bar-utils.js";
 
@@ -108,6 +109,44 @@ describe("subTabBackward", () => {
     let active: TestTab = "gamma";
     subTabBackward(TABS, active, (t) => { active = t; });
     expect(active).toBe("beta");
+  });
+});
+
+// =============================================================================
+// subTabCycleBindings
+// =============================================================================
+
+describe("subTabCycleBindings", () => {
+  it("returns tab and shift+tab bindings", () => {
+    const bindings = subTabCycleBindings(TABS, "alpha", () => {});
+    expect(bindings["tab"]).toBeDefined();
+    expect(bindings["shift+tab"]).toBeDefined();
+  });
+
+  it("tab binding cycles forward", () => {
+    let active: TestTab = "alpha";
+    const bindings = subTabCycleBindings(TABS, active, (t) => { active = t; });
+    bindings["tab"]!();
+    expect(active).toBe("beta");
+  });
+
+  it("shift+tab binding cycles backward", () => {
+    let active: TestTab = "beta";
+    const bindings = subTabCycleBindings(TABS, active, (t) => { active = t; });
+    bindings["shift+tab"]!();
+    expect(active).toBe("alpha");
+  });
+
+  it("can be spread and overridden for split-pane panels", () => {
+    let active: TestTab = "alpha";
+    let focusToggled = false;
+    const bindings = {
+      ...subTabCycleBindings(TABS, active, (t) => { active = t; }),
+      "shift+tab": () => { focusToggled = true; },
+    };
+    bindings["shift+tab"]!();
+    expect(focusToggled).toBe(true);
+    expect(active).toBe("alpha"); // tab cycling was overridden
   });
 });
 

--- a/packages/nexus-tui/tests/shared/sub-tab-bar-utils.test.ts
+++ b/packages/nexus-tui/tests/shared/sub-tab-bar-utils.test.ts
@@ -1,0 +1,143 @@
+/**
+ * Tests for sub-tab bar utility functions (#3498).
+ *
+ * Covers:
+ * - subTabForward: forward cycling with wrap, activeTab-not-in-list guard
+ * - subTabBackward: backward cycling with wrap, activeTab-not-in-list guard
+ * - tabFallback: fallback to first visible tab when active tab becomes hidden
+ */
+
+import { describe, it, expect } from "bun:test";
+import {
+  subTabForward,
+  subTabBackward,
+  tabFallback,
+} from "../../src/shared/components/sub-tab-bar-utils.js";
+
+// =============================================================================
+// Test data
+// =============================================================================
+
+const TABS = [
+  { id: "alpha", label: "Alpha" },
+  { id: "beta", label: "Beta" },
+  { id: "gamma", label: "Gamma" },
+  { id: "delta", label: "Delta" },
+] as const;
+
+type TestTab = (typeof TABS)[number]["id"];
+
+// =============================================================================
+// subTabForward
+// =============================================================================
+
+describe("subTabForward", () => {
+  it("cycles to the next tab", () => {
+    let active: TestTab = "alpha";
+    subTabForward(TABS, active, (t) => { active = t; });
+    expect(active).toBe("beta");
+  });
+
+  it("wraps from last to first", () => {
+    let active: TestTab = "delta";
+    subTabForward(TABS, active, (t) => { active = t; });
+    expect(active).toBe("alpha");
+  });
+
+  it("stays on same tab when only one tab", () => {
+    let active = "only";
+    subTabForward([{ id: "only", label: "Only" }], active, (t) => { active = t; });
+    expect(active).toBe("only");
+  });
+
+  it("does nothing with empty tabs", () => {
+    let active = "any";
+    subTabForward([], active, (t) => { active = t; });
+    expect(active).toBe("any");
+  });
+
+  it("defaults to first tab when activeTab not in list", () => {
+    let active = "missing" as string;
+    subTabForward(TABS, active, (t) => { active = t; });
+    expect(active).toBe("alpha");
+  });
+
+  it("cycles through middle tabs", () => {
+    let active: TestTab = "beta";
+    subTabForward(TABS, active, (t) => { active = t; });
+    expect(active).toBe("gamma");
+  });
+});
+
+// =============================================================================
+// subTabBackward
+// =============================================================================
+
+describe("subTabBackward", () => {
+  it("cycles to the previous tab", () => {
+    let active: TestTab = "beta";
+    subTabBackward(TABS, active, (t) => { active = t; });
+    expect(active).toBe("alpha");
+  });
+
+  it("wraps from first to last", () => {
+    let active: TestTab = "alpha";
+    subTabBackward(TABS, active, (t) => { active = t; });
+    expect(active).toBe("delta");
+  });
+
+  it("stays on same tab when only one tab", () => {
+    let active = "only";
+    subTabBackward([{ id: "only", label: "Only" }], active, (t) => { active = t; });
+    expect(active).toBe("only");
+  });
+
+  it("does nothing with empty tabs", () => {
+    let active = "any";
+    subTabBackward([], active, (t) => { active = t; });
+    expect(active).toBe("any");
+  });
+
+  it("defaults to first tab when activeTab not in list", () => {
+    let active = "missing" as string;
+    subTabBackward(TABS, active, (t) => { active = t; });
+    expect(active).toBe("alpha");
+  });
+
+  it("cycles through middle tabs", () => {
+    let active: TestTab = "gamma";
+    subTabBackward(TABS, active, (t) => { active = t; });
+    expect(active).toBe("beta");
+  });
+});
+
+// =============================================================================
+// tabFallback
+// =============================================================================
+
+describe("tabFallback", () => {
+  it("returns null when activeTab is visible", () => {
+    expect(tabFallback(["alpha", "beta", "gamma"], "beta")).toBeNull();
+  });
+
+  it("returns first visible tab when activeTab is not visible", () => {
+    expect(tabFallback(["beta", "gamma"], "alpha")).toBe("beta");
+  });
+
+  it("returns null for empty visible list", () => {
+    expect(tabFallback([], "alpha")).toBeNull();
+  });
+
+  it("returns the single visible tab when activeTab differs", () => {
+    expect(tabFallback(["beta"], "alpha")).toBe("beta");
+  });
+
+  it("returns null when single visible tab matches activeTab", () => {
+    expect(tabFallback(["alpha"], "alpha")).toBeNull();
+  });
+
+  it("returns first visible tab when activeTab was removed", () => {
+    // Simulates a brick being disabled that hides the active tab
+    expect(tabFallback(["gamma", "delta"], "beta")).toBe("gamma");
+  });
+});

--- a/packages/nexus-tui/tests/shared/sub-tab-bar.test.tsx
+++ b/packages/nexus-tui/tests/shared/sub-tab-bar.test.tsx
@@ -1,0 +1,104 @@
+/**
+ * Render tests for the SubTabBar component (#3498).
+ *
+ * Uses OpenTUI's testRender to verify actual terminal output.
+ *
+ * Covers:
+ * - Renders visible tabs with active bracket highlight
+ * - Empty tabs array renders nothing
+ * - Single tab renders correctly
+ * - Multiple tabs with spacing
+ */
+
+import { describe, it, expect, afterEach } from "bun:test";
+import React from "react";
+import { testRender } from "@opentui/react/test-utils";
+import { SubTabBar } from "../../src/shared/components/sub-tab-bar.js";
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+type TestSetup = Awaited<ReturnType<typeof testRender>>;
+
+let setup: TestSetup;
+
+async function renderSubTabBar(
+  tabs: Array<{ id: string; label: string }>,
+  activeTab: string,
+): Promise<string> {
+  setup = await testRender(
+    <SubTabBar tabs={tabs} activeTab={activeTab} />,
+    { width: 80, height: 3 },
+  );
+  await setup.renderOnce();
+  return setup.captureCharFrame();
+}
+
+afterEach(() => {
+  if (setup) {
+    setup.renderer.destroy();
+  }
+});
+
+// =============================================================================
+// Tests
+// =============================================================================
+
+describe("SubTabBar", () => {
+  it("renders active tab with brackets and inactive tabs with spaces", async () => {
+    const frame = await renderSubTabBar(
+      [
+        { id: "zones", label: "Zones" },
+        { id: "bricks", label: "Bricks" },
+        { id: "drift", label: "Drift" },
+      ],
+      "zones",
+    );
+    expect(frame).toContain("[Zones]");
+    expect(frame).toContain(" Bricks ");
+    expect(frame).toContain(" Drift ");
+  });
+
+  it("highlights the correct active tab when not first", async () => {
+    const frame = await renderSubTabBar(
+      [
+        { id: "alpha", label: "Alpha" },
+        { id: "beta", label: "Beta" },
+        { id: "gamma", label: "Gamma" },
+      ],
+      "beta",
+    );
+    expect(frame).toContain(" Alpha ");
+    expect(frame).toContain("[Beta]");
+    expect(frame).toContain(" Gamma ");
+  });
+
+  it("renders nothing for empty tabs", async () => {
+    const frame = await renderSubTabBar([], "any");
+    // Should be blank — no tabs rendered
+    expect(frame.trim()).toBe("");
+  });
+
+  it("renders single tab with brackets", async () => {
+    const frame = await renderSubTabBar(
+      [{ id: "only", label: "Only" }],
+      "only",
+    );
+    expect(frame).toContain("[Only]");
+  });
+
+  it("renders all tabs as inactive when activeTab not in list", async () => {
+    const frame = await renderSubTabBar(
+      [
+        { id: "alpha", label: "Alpha" },
+        { id: "beta", label: "Beta" },
+      ],
+      "missing",
+    );
+    // Neither should have brackets
+    expect(frame).toContain(" Alpha ");
+    expect(frame).toContain(" Beta ");
+    expect(frame).not.toContain("[");
+  });
+});

--- a/packages/nexus-tui/tests/shared/use-visible-tabs.test.ts
+++ b/packages/nexus-tui/tests/shared/use-visible-tabs.test.ts
@@ -470,8 +470,13 @@ describe("migrated TAB_ORDER panels", () => {
   });
 
   describe("files (mixed: explorer always visible, shareLinks/uploads gated)", () => {
-    it("shows all tabs under full profile", () => {
+    it("shows only explorer under full profile (share_link/uploads not in full)", () => {
       const result = filterTabs(FILES_TABS, bricks, true);
+      expect(result.map((t) => t.id)).toEqual(["explorer"]);
+    });
+
+    it("shows all tabs when share_link and uploads bricks enabled", () => {
+      const result = filterTabs(FILES_TABS, [...bricks, "share_link", "uploads"], true);
       expect(result.map((t) => t.id)).toEqual(["explorer", "shareLinks", "uploads"]);
     });
 

--- a/packages/nexus-tui/tests/shared/use-visible-tabs.test.ts
+++ b/packages/nexus-tui/tests/shared/use-visible-tabs.test.ts
@@ -84,6 +84,39 @@ const EVENT_TABS: readonly TabDef<EventTab>[] = [
   { id: "secrets", label: "Secrets", brick: "auth" },
 ];
 
+// Migrated panels: previously used TAB_ORDER, now use TabDef (#3498)
+
+type ConnectorsTab = "available" | "mounted" | "skills" | "write";
+const CONNECTORS_TABS: readonly TabDef<ConnectorsTab>[] = [
+  { id: "available", label: "Available", brick: null },
+  { id: "mounted", label: "Mounted", brick: null },
+  { id: "skills", label: "Skills", brick: null },
+  { id: "write", label: "Write", brick: null },
+];
+
+type PaymentsTab = "balance" | "reservations" | "transactions" | "policies" | "approvals";
+const PAYMENTS_TABS: readonly TabDef<PaymentsTab>[] = [
+  { id: "balance", label: "Balance", brick: null },
+  { id: "reservations", label: "Reservations", brick: null },
+  { id: "transactions", label: "Transactions", brick: null },
+  { id: "policies", label: "Policies", brick: null },
+  { id: "approvals", label: "Approvals", brick: null },
+];
+
+type WorkflowTab = "workflows" | "executions" | "scheduler";
+const WORKFLOW_TABS: readonly TabDef<WorkflowTab>[] = [
+  { id: "workflows", label: "Workflows", brick: null },
+  { id: "executions", label: "Executions", brick: null },
+  { id: "scheduler", label: "Scheduler", brick: null },
+];
+
+type FilesTab = "explorer" | "shareLinks" | "uploads";
+const FILES_TABS: readonly TabDef<FilesTab>[] = [
+  { id: "explorer", label: "Explorer", brick: null },
+  { id: "shareLinks", label: "Share Links", brick: "share_link" },
+  { id: "uploads", label: "Uploads", brick: "uploads" },
+];
+
 // =============================================================================
 // Tests
 // =============================================================================
@@ -390,5 +423,71 @@ describe("global store features integration", () => {
     const { enabledBricks, featuresLoaded } = useGlobalStore.getState();
     const result = filterTabs(ACCESS_TABS, enabledBricks, featuresLoaded);
     expect(result.map((t) => t.id)).toEqual(["credentials", "delegations"]);
+  });
+});
+
+// =============================================================================
+// Migrated panel regression tests (#3498)
+// =============================================================================
+
+describe("migrated TAB_ORDER panels", () => {
+  const bricks = PROFILE_BRICKS.full;
+  const minimalBricks = PROFILE_BRICKS.minimal;
+
+  describe("connectors (all brick: null)", () => {
+    it("shows all tabs regardless of enabled bricks", () => {
+      const result = filterTabs(CONNECTORS_TABS, [], true);
+      expect(result.map((t) => t.id)).toEqual(["available", "mounted", "skills", "write"]);
+    });
+
+    it("shows all tabs under minimal profile", () => {
+      const result = filterTabs(CONNECTORS_TABS, minimalBricks, true);
+      expect(result.map((t) => t.id)).toEqual(["available", "mounted", "skills", "write"]);
+    });
+  });
+
+  describe("payments (all brick: null)", () => {
+    it("shows all tabs regardless of enabled bricks", () => {
+      const result = filterTabs(PAYMENTS_TABS, [], true);
+      expect(result.map((t) => t.id)).toEqual([
+        "balance", "reservations", "transactions", "policies", "approvals",
+      ]);
+    });
+
+    it("shows all tabs under minimal profile", () => {
+      const result = filterTabs(PAYMENTS_TABS, minimalBricks, true);
+      expect(result.map((t) => t.id)).toEqual([
+        "balance", "reservations", "transactions", "policies", "approvals",
+      ]);
+    });
+  });
+
+  describe("workflows (all brick: null)", () => {
+    it("shows all tabs regardless of enabled bricks", () => {
+      const result = filterTabs(WORKFLOW_TABS, [], true);
+      expect(result.map((t) => t.id)).toEqual(["workflows", "executions", "scheduler"]);
+    });
+  });
+
+  describe("files (mixed: explorer always visible, shareLinks/uploads gated)", () => {
+    it("shows all tabs under full profile", () => {
+      const result = filterTabs(FILES_TABS, bricks, true);
+      expect(result.map((t) => t.id)).toEqual(["explorer", "shareLinks", "uploads"]);
+    });
+
+    it("shows only explorer under minimal profile", () => {
+      const result = filterTabs(FILES_TABS, minimalBricks, true);
+      expect(result.map((t) => t.id)).toEqual(["explorer"]);
+    });
+
+    it("shows explorer + shareLinks when share_link brick enabled", () => {
+      const result = filterTabs(FILES_TABS, ["share_link"], true);
+      expect(result.map((t) => t.id)).toEqual(["explorer", "shareLinks"]);
+    });
+
+    it("shows explorer + uploads when uploads brick enabled", () => {
+      const result = filterTabs(FILES_TABS, ["uploads"], true);
+      expect(result.map((t) => t.id)).toEqual(["explorer", "uploads"]);
+    });
   });
 });


### PR DESCRIPTION
## Summary

Closes #3498. Extracts a shared `SubTabBar` render component and cycling helpers from 9 panels that previously copy-pasted ~15 lines of tab bar rendering + ~15 lines of Tab/Shift+Tab keyboard handling with minor (and sometimes buggy) variations.

**New shared code (3 files):**
- `sub-tab-bar.tsx` — render-only component (`tabs` + `activeTab` props, bracket styling)
- `sub-tab-bar-utils.ts` — pure functions: `subTabForward()`, `subTabBackward()` (with indexOf guard for stale activeTab), `tabFallback()` 
- `use-tab-fallback.ts` — hook replacing 6 inline `useEffect` copies that had inconsistent dependency arrays

**Panel migrations (9 panels):**
- 5 panels already using `useVisibleTabs` (Zones, Events, Access, Agents, Search): replace inline tab bar/cycling/fallback; delete redundant `TAB_LABELS` objects
- 4 panels using `TAB_ORDER` (Connectors, Payments, Workflows, Files): convert to `TabDef[]` + `useVisibleTabs`; replace inline tab bar/cycling; add `useTabFallback`

**Bug fix:** Access panel `Shift+Tab` now correctly cycles backward (was a copy-paste of forward cycling: `+1` instead of `-1`).

**Tests (23 new):**
- `sub-tab-bar-utils.test.ts`: forward/backward cycling, wrap-around, empty tabs, single tab, activeTab-not-in-list guard, tabFallback logic
- `sub-tab-bar.test.tsx`: testRender terminal output verification (bracket styling, empty tabs, single tab)
- Extended `use-visible-tabs.test.ts` with regression coverage for 4 migrated TAB_ORDER panels

**Net effect:** -94 lines across 15 files (275 deleted, 181 added in source; new test/component files account for the rest).

## Test plan

- [x] All 23 new tests pass (18 pure function + 5 testRender)
- [x] All existing shared tests pass
- [x] No TypeScript errors in new/modified files
- [x] Pre-commit hooks pass
- [ ] CI full suite
- [ ] Manual TUI smoke test: verify tab bar renders correctly in all 9 panels
- [ ] Verify Shift+Tab in Access panel now cycles backward
- [ ] Verify Shift+Tab in split-pane panels (Zones, Agents, Files) still toggles focus