### PR TITLE
refactor: delete StreamRead RPC — superseded by ReadBlob scatter-gather

### DIFF
--- a/proto/nexus/grpc/vfs/vfs.proto
+++ b/proto/nexus/grpc/vfs/vfs.proto
@@ -2,10 +2,10 @@
 //
 // Phase 1 (PR #2667): Generic Call RPC — method name + JSON payload.
 // Phase 2: Typed RPCs for content ops (native bytes, no base64 overhead)
-//          + server-side streaming for large reads + Ping health check.
+//          + Ping health check.
 //
 // Generic Call stays for 25+ service proxy methods and metadata ops.
-// Typed RPCs only for content-heavy operations (Read/Write/Delete/StreamRead).
+// Typed RPCs only for content-heavy operations (Read/Write/Delete).
 //
 // Issue #1133: Unified gRPC transport.
 // Issue #1202: gRPC for REMOTE profile.
@@ -23,7 +23,6 @@ service NexusVFSService {
   rpc Read(ReadRequest) returns (ReadResponse);
   rpc Write(WriteRequest) returns (WriteResponse);
   rpc Delete(DeleteRequest) returns (DeleteResponse);
-  rpc StreamRead(StreamReadRequest) returns (stream ReadChunk);
 
   // CAS-level blob read by content hash — driver-to-driver protocol.
   // Used by federation chunk assembly (PeerBlobClient) and content replication.
@@ -86,20 +85,6 @@ message DeleteResponse {
   bool success = 1;
   bool is_error = 2;
   bytes error_payload = 3;
-}
-
-message StreamReadRequest {
-  string path = 1;
-  string auth_token = 2;
-  int64 chunk_size = 3;    // Bytes per chunk (default 1MB server-side)
-}
-
-message ReadChunk {
-  bytes data = 1;
-  int64 offset = 2;
-  bool is_last = 3;
-  bool is_error = 4;
-  bytes error_payload = 5;
 }
 
 // --- CAS-level blob messages (driver-to-driver) ---

--- a/src/nexus/grpc/servicer.py
+++ b/src/nexus/grpc/servicer.py
@@ -1,9 +1,9 @@
 """gRPC servicer — async handlers for NexusVFSService.
 
 Phase 1 (PR #2667): Generic ``Call`` RPC — method name + JSON payload.
-Phase 2: Typed RPCs for content ops (Read/Write/Delete/StreamRead) with
-native ``bytes`` fields (no base64), server-side streaming for large reads,
-and a ``Ping`` health check with server metadata.
+Phase 2: Typed RPCs for content ops (Read/Write/Delete) with
+native ``bytes`` fields (no base64) and a ``Ping`` health check with
+server metadata.
 
 Mirrors the HTTP ``rpc_endpoint()`` in ``server/api/core/rpc.py`` but over
 gRPC.  Reuses the same dispatch infrastructure: ``parse_method_params()``,
@@ -26,7 +26,6 @@ import dataclasses
 import hmac
 import logging
 import time
-from collections.abc import AsyncIterator
 from types import SimpleNamespace
 from typing import Any
 
@@ -503,98 +502,6 @@ class VFSServicer(vfs_pb2_grpc.NexusVFSServiceServicer):
                 is_error=True,
                 error_payload=_error_payload(RPCErrorCode.INTERNAL_ERROR, f"Internal error: {e}"),
             )
-
-    async def StreamRead(
-        self,
-        request: "vfs_pb2.StreamReadRequest",
-        context: grpc.aio.ServicerContext,
-    ) -> AsyncIterator["vfs_pb2.ReadChunk"]:
-        """Server-side streaming read — chunked delivery for large files.
-
-        Uses read_range() in a pread loop instead of loading the full file
-        into memory.  CAS backends with read_content_range() read only the
-        overlapping CDC chunks; other backends fall back to full-read + slice.
-        Memory usage: O(chunk_size) instead of O(file_size).  (Issue #1614)
-        """
-        _DEFAULT_CHUNK_SIZE = 1_048_576  # 1 MB
-        _LARGE_FILE_WARNING = 256 * 1_048_576  # 256 MB
-
-        try:
-            _, op_context = await self._auth_and_context(request.auth_token)
-            self._scope_path_for_zone(request, op_context.zone_id)
-
-            # Get file size via sys_stat — no content loaded.
-            stat = await self._nexus_fs.sys_stat(request.path, context=op_context)
-            if stat is None:
-                yield vfs_pb2.ReadChunk(
-                    is_error=True,
-                    error_payload=_error_payload(
-                        RPCErrorCode.FILE_NOT_FOUND, f"File not found: {request.path}"
-                    ),
-                )
-                return
-            file_size: int = stat.get("size", 0) or 0
-        except NexusPermissionError as e:
-            yield vfs_pb2.ReadChunk(
-                is_error=True,
-                error_payload=_error_payload(RPCErrorCode.PERMISSION_ERROR, str(e)),
-            )
-            return
-        except NexusFileNotFoundError as e:
-            yield vfs_pb2.ReadChunk(
-                is_error=True,
-                error_payload=_error_payload(RPCErrorCode.FILE_NOT_FOUND, str(e)),
-            )
-            return
-        except (InvalidPathError, NexusError) as e:
-            code = (
-                RPCErrorCode.INVALID_PATH
-                if isinstance(e, InvalidPathError)
-                else RPCErrorCode.INTERNAL_ERROR
-            )
-            yield vfs_pb2.ReadChunk(is_error=True, error_payload=_error_payload(code, str(e)))
-            return
-        except Exception as e:
-            logger.exception("Error in gRPC StreamRead %s", request.path)
-            yield vfs_pb2.ReadChunk(
-                is_error=True,
-                error_payload=_error_payload(RPCErrorCode.INTERNAL_ERROR, f"Internal error: {e}"),
-            )
-            return
-
-        # Empty file: yield a single empty chunk.
-        if file_size == 0:
-            yield vfs_pb2.ReadChunk(data=b"", offset=0, is_last=True)
-            return
-
-        chunk_size = request.chunk_size if request.chunk_size > 0 else _DEFAULT_CHUNK_SIZE
-        offset = 0
-
-        # Chunked pread loop — memory is O(chunk_size), not O(file_size).
-        # read_range() is sync; run each chunk in a thread to avoid blocking
-        # the gRPC event loop.
-        while offset < file_size:
-            if context.cancelled():
-                return
-            end = min(offset + chunk_size, file_size)
-            try:
-                chunk = await asyncio.to_thread(
-                    self._nexus_fs.read_range,
-                    request.path,
-                    offset,
-                    end,
-                    op_context,
-                )
-            except Exception as e:
-                logger.warning("StreamRead chunk error at offset %d: %s", offset, e)
-                yield vfs_pb2.ReadChunk(
-                    is_error=True,
-                    error_payload=_error_payload(RPCErrorCode.INTERNAL_ERROR, str(e)),
-                )
-                return
-            is_last = end >= file_size
-            yield vfs_pb2.ReadChunk(data=chunk, offset=offset, is_last=is_last)
-            offset = end
 
     # ------------------------------------------------------------------
     # CAS-level blob read — driver-to-driver protocol (Issue #1744)

--- a/src/nexus/raft/federation_content_resolver.py
+++ b/src/nexus/raft/federation_content_resolver.py
@@ -35,10 +35,6 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Files larger than this threshold use StreamRead instead of unary Read.
-# StreamRead keeps ~1MB in memory at a time; unary Read buffers entire file.
-_STREAMING_THRESHOLD = 1_048_576  # 1 MB
-
 
 class FederationContentResolver:
     """VFSPathResolver that dispatches reads and deletes to remote content owners.
@@ -169,17 +165,13 @@ class FederationContentResolver:
         raise NexusFileNotFoundError(path, f"All origins unreachable for {path}") from last_err
 
     def _read_from_origin_path(self, origin: str, path: str, file_size: int) -> bytes:
-        """Read content from a single origin via path-based gRPC (fallback)."""
-        use_streaming = file_size > _STREAMING_THRESHOLD
+        """Read content from a single origin via path-based unary Read RPC (fallback)."""
         logger.info(
-            "Federation read (path): %s -> %s (size=%d, streaming=%s)",
+            "Federation read (path): %s -> %s (size=%d)",
             path,
             origin,
             file_size,
-            use_streaming,
         )
-        if use_streaming:
-            return self._fetch_from_peer_streaming(origin, path)
         return self._fetch_from_peer(origin, path)
 
     def try_write(self, _path: str, _content: bytes) -> dict[str, Any] | None:
@@ -302,42 +294,6 @@ class FederationContentResolver:
             return bytes(response.content)
         except grpc.RpcError as exc:
             logger.warning("Federation Read RPC to %s failed: %s", address, exc)
-            raise NexusFileNotFoundError(
-                virtual_path,
-                f"Remote peer {address} unreachable: {exc}",
-            ) from exc
-        finally:
-            channel.close()
-
-    def _fetch_from_peer_streaming(self, address: str, virtual_path: str) -> bytes:
-        """Fetch via StreamRead RPC — backend-agnostic streaming.
-
-        The origin's StreamRead handler decides how to serve the file
-        (CAS chunk-aware streaming, PAS read-and-chunk, etc).
-        This method just collects the stream and returns assembled bytes.
-        """
-        import grpc
-
-        from nexus.grpc.channel_factory import build_peer_channel
-        from nexus.grpc.vfs import vfs_pb2, vfs_pb2_grpc
-
-        channel = build_peer_channel(address, self._tls_config)
-        try:
-            stub = vfs_pb2_grpc.NexusVFSServiceStub(channel)
-            request = vfs_pb2.StreamReadRequest(path=virtual_path, auth_token=self._auth_token)
-            chunks: list[bytes] = []
-            for chunk in stub.StreamRead(request, timeout=self._timeout):
-                if chunk.is_error:
-                    raise NexusFileNotFoundError(
-                        virtual_path,
-                        f"Remote peer {address} returned streaming error",
-                    )
-                chunks.append(bytes(chunk.data))
-                if chunk.is_last:
-                    break
-            return b"".join(chunks)
-        except grpc.RpcError as exc:
-            logger.warning("Federation StreamRead to %s failed: %s", address, exc)
             raise NexusFileNotFoundError(
                 virtual_path,
                 f"Remote peer {address} unreachable: {exc}",

--- a/src/nexus/remote/rpc_transport.py
+++ b/src/nexus/remote/rpc_transport.py
@@ -6,7 +6,7 @@ with a single gRPC channel.
 
 Phase 1 (PR #2667): Generic ``call_rpc()`` — method name + JSON payload.
 Phase 2: Typed methods (``read_file``, ``write_file``, ``delete_file``,
-``stream_read``, ``ping``) with native ``bytes`` fields — no JSON/base64
+``ping``) with native ``bytes`` fields — no JSON/base64
 overhead for content operations.
 
 Generic ``call_rpc()`` stays for 25+ service proxy methods and metadata ops.
@@ -268,31 +268,6 @@ class RPCTransport:
         if response.is_error:
             self._handle_typed_error(response.error_payload)
         return bool(response.success)
-
-    def stream_read(
-        self,
-        path: str,
-        chunk_size: int = 1_048_576,
-        read_timeout: float | None = None,
-    ) -> bytes:
-        """Read large file via streaming RPC — assembles chunks client-side.
-
-        Returns:
-            Complete file content as bytes.
-        """
-        request = vfs_pb2.StreamReadRequest(
-            path=path, auth_token=self._auth_token, chunk_size=chunk_size
-        )
-        timeout = read_timeout if read_timeout is not None else self._timeout
-        chunks: list[bytes] = []
-        try:
-            for chunk in self._stub.StreamRead(request, timeout=timeout):
-                if chunk.is_error:
-                    self._handle_typed_error(chunk.error_payload)
-                chunks.append(chunk.data)
-        except grpc.RpcError as exc:
-            self._raise_transport_error(exc, timeout, "StreamRead")
-        return b"".join(chunks)
 
     def ping(self) -> dict[str, Any]:
         """Ping server — returns version, zone_id, uptime."""

--- a/tests/unit/grpc/test_servicer.py
+++ b/tests/unit/grpc/test_servicer.py
@@ -280,7 +280,7 @@ def _make_typed_request(cls_name: str, **kwargs) -> MagicMock:
 
 
 class TestVFSServicerTypedRPCs:
-    """VFSServicer typed RPC handlers: Read, Write, Delete, StreamRead, Ping."""
+    """VFSServicer typed RPC handlers: Read, Write, Delete, Ping."""
 
     @pytest.mark.anyio
     async def test_read_success(self, servicer, mock_nexus_fs) -> None:
@@ -416,77 +416,6 @@ class TestVFSServicerTypedRPCs:
 
         assert response.success is True
         mock_nexus_fs.sys_rmdir.assert_called_once()
-
-    @pytest.mark.anyio
-    async def test_stream_read_chunks(self, servicer, mock_nexus_fs) -> None:
-        """StreamRead yields chunks via read_range pread loop (Issue #1614)."""
-        request = _make_typed_request(
-            "StreamReadRequest", path="/big.bin", auth_token="", chunk_size=5
-        )
-        context = MagicMock()
-        context.cancelled.return_value = False
-
-        # sys_stat returns file size (async)
-        mock_nexus_fs.sys_stat.return_value = {"size": 12}
-
-        # read_range is sync (called via asyncio.to_thread)
-        content = b"hello world!"
-        mock_nexus_fs.read_range = MagicMock(
-            side_effect=lambda path, start, end, ctx: content[start:end]
-        )
-
-        chunks = []
-        async for chunk in servicer.StreamRead(request, context):
-            chunks.append(chunk)
-
-        # 12 bytes / 5 chunk_size = 3 chunks (5 + 5 + 2)
-        assert len(chunks) == 3
-        assert chunks[0].data == b"hello"
-        assert chunks[0].offset == 0
-        assert chunks[0].is_last is False
-        assert chunks[1].data == b" worl"
-        assert chunks[2].data == b"d!"
-        assert chunks[2].is_last is True
-
-    @pytest.mark.anyio
-    async def test_stream_read_empty_file(self, servicer, mock_nexus_fs) -> None:
-        """StreamRead yields single empty chunk for empty file."""
-        request = _make_typed_request(
-            "StreamReadRequest", path="/empty.txt", auth_token="", chunk_size=0
-        )
-        context = MagicMock()
-        context.cancelled.return_value = False
-
-        # sys_stat returns size=0
-        mock_nexus_fs.sys_stat.return_value = {"size": 0}
-
-        chunks = []
-        async for chunk in servicer.StreamRead(request, context):
-            chunks.append(chunk)
-
-        assert len(chunks) == 1
-        assert chunks[0].data == b""
-        assert chunks[0].is_last is True
-
-    @pytest.mark.anyio
-    async def test_stream_read_error(self, servicer, mock_nexus_fs) -> None:
-        """StreamRead yields error chunk on file not found."""
-        request = _make_typed_request(
-            "StreamReadRequest", path="/missing.bin", auth_token="", chunk_size=0
-        )
-        context = MagicMock()
-
-        # sys_stat raises NexusFileNotFoundError
-        mock_nexus_fs.sys_stat.side_effect = NexusFileNotFoundError("/missing.bin")
-
-        chunks = []
-        async for chunk in servicer.StreamRead(request, context):
-            chunks.append(chunk)
-
-        assert len(chunks) == 1
-        assert chunks[0].is_error is True
-        payload = decode_rpc_message(chunks[0].error_payload)
-        assert payload["code"] == -32000
 
     @pytest.mark.anyio
     async def test_ping_response(self, servicer) -> None:

--- a/tests/unit/raft/test_federation_content_resolver.py
+++ b/tests/unit/raft/test_federation_content_resolver.py
@@ -131,33 +131,19 @@ class TestTryReadRemoteContent:
         assert result["version"] == 3
         assert result["size"] == 4
 
-    @patch.object(FederationContentResolver, "_fetch_from_peer_streaming")
-    def test_large_file_uses_streaming(self, mock_stream):
-        """Files > _STREAMING_THRESHOLD use StreamRead instead of unary Read."""
-        mock_stream.return_value = b"streamed content"
-        meta = _make_meta(f"local@{REMOTE_ADDR}", size=2_000_000)  # 2MB > 1MB threshold
+    @patch.object(FederationContentResolver, "_fetch_from_peer")
+    def test_large_file_uses_unary_read(self, mock_fetch):
+        """All files use unary Read RPC regardless of size."""
+        mock_fetch.return_value = b"large content"
+        meta = _make_meta(f"local@{REMOTE_ADDR}", size=2_000_000)  # 2MB
         metastore = MagicMock()
         metastore.get.return_value = meta
 
         resolver = _make_resolver(metastore=metastore)
         result = resolver.try_read("/test/large.bin")
 
-        assert result == b"streamed content"
-        mock_stream.assert_called_once_with(REMOTE_ADDR, "/test/large.bin")
-
-    @patch.object(FederationContentResolver, "_fetch_from_peer")
-    def test_small_file_uses_unary_read(self, mock_fetch):
-        """Files <= _STREAMING_THRESHOLD use unary Read RPC."""
-        mock_fetch.return_value = b"small"
-        meta = _make_meta(f"local@{REMOTE_ADDR}", size=500_000)  # 500KB < 1MB threshold
-        metastore = MagicMock()
-        metastore.get.return_value = meta
-
-        resolver = _make_resolver(metastore=metastore)
-        result = resolver.try_read("/test/small.txt")
-
-        assert result == b"small"
-        mock_fetch.assert_called_once_with(REMOTE_ADDR, "/test/small.txt")
+        assert result == b"large content"
+        mock_fetch.assert_called_once_with(REMOTE_ADDR, "/test/large.bin")
 
     def test_fetcher_receives_all_origins(self):
         """When RemoteContentFetcher is injected, it receives all origins at once."""

--- a/tests/unit/remote/test_rpc_transport.py
+++ b/tests/unit/remote/test_rpc_transport.py
@@ -202,7 +202,7 @@ class TestRPCTransportCallRPC:
 
 
 class TestRPCTransportTypedMethods:
-    """Typed RPC methods: read_file, write_file, delete_file, stream_read, ping."""
+    """Typed RPC methods: read_file, write_file, delete_file, ping."""
 
     def test_read_file_success(self, transport) -> None:
         """read_file returns raw bytes from ReadResponse.content."""
@@ -284,28 +284,6 @@ class TestRPCTransportTypedMethods:
 
         request = transport._mock_stub.Delete.call_args[0][0]
         assert request.recursive is True
-
-    def test_stream_read_assembles_chunks(self, transport) -> None:
-        """stream_read assembles multiple ReadChunks into bytes."""
-        chunk1 = MagicMock(data=b"aaa", is_error=False)
-        chunk2 = MagicMock(data=b"bbb", is_error=False)
-        chunk3 = MagicMock(data=b"ccc", is_error=False, is_last=True)
-        transport._mock_stub.StreamRead.return_value = iter([chunk1, chunk2, chunk3])
-
-        result = transport.stream_read("/big-file.bin", chunk_size=3)
-
-        assert result == b"aaabbbccc"
-
-    def test_stream_read_error_chunk(self, transport) -> None:
-        """stream_read raises on error chunk."""
-        error_chunk = MagicMock(
-            is_error=True,
-            error_payload=encode_rpc_message({"code": -32000, "message": "File not found"}),
-        )
-        transport._mock_stub.StreamRead.return_value = iter([error_chunk])
-
-        with pytest.raises(NexusFileNotFoundError):
-            transport.stream_read("/missing.bin")
 
     def test_ping_success(self, transport) -> None:
         """ping returns version/zone_id/uptime dict."""


### PR DESCRIPTION
## Summary
Delete StreamRead gRPC RPC — legacy, superseded by ReadBlob scatter-gather for all federation content reads.

## What was deleted (-301 lines)
- `StreamRead` RPC + messages from `vfs.proto`
- `StreamRead` handler from `servicer.py`
- `stream_read()` from `rpc_transport.py` (dead code)
- `_fetch_from_peer_streaming()` + `_STREAMING_THRESHOLD` from federation resolver
- 5 tests (3 servicer + 2 transport)

## Why safe to delete
- Single production caller: `FederationContentResolver._fetch_from_peer_streaming()`
- Only triggered when `_remote_content_fetcher is None` + file >1MB — edge case
- All normal files have etag → ReadBlob path handles them
- `RPCTransport.stream_read()` was completely dead code (never called)
- Path-based fallback now uses unary Read for all file sizes

## Test plan
- [x] All related tests pass locally
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)