### PR TITLE
refactor: rename delete_bulk/rename_bulk → delete_batch/rename_batch

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -4384,7 +4384,7 @@ class NexusFS(  # type: ignore[misc]
         return results
 
     @rpc_expose(description="Delete multiple files/directories")
-    async def delete_bulk(
+    async def delete_batch(
         self,
         paths: list[str],
         recursive: bool = False,
@@ -4406,7 +4406,7 @@ class NexusFS(  # type: ignore[misc]
                 {"success": True} or {"success": False, "error": "error message"}
 
         Example:
-            >>> results = nx.delete_bulk(['/a.txt', '/b.txt', '/folder'])
+            >>> results = nx.delete_batch(['/a.txt', '/b.txt', '/folder'])
             >>> for path, result in results.items():
             ...     if result['success']:
             ...         print(f"Deleted {path}")
@@ -4515,7 +4515,7 @@ class NexusFS(  # type: ignore[misc]
             self.metadata.delete(path)
 
     @rpc_expose(description="Rename/move multiple files")
-    async def rename_bulk(
+    async def rename_batch(
         self,
         renames: list[tuple[str, str]],
         context: OperationContext | None = None,
@@ -4535,7 +4535,7 @@ class NexusFS(  # type: ignore[misc]
                 {"success": True, "new_path": "..."} or {"success": False, "error": "..."}
 
         Example:
-            >>> results = nx.rename_bulk([
+            >>> results = nx.rename_batch([
             ...     ('/old1.txt', '/new1.txt'),
             ...     ('/old2.txt', '/new2.txt'),
             ... ])

--- a/src/nexus/server/_rpc_params_generated.py
+++ b/src/nexus/server/_rpc_params_generated.py
@@ -23,7 +23,7 @@ __all__ = [
     "CancelSyncJobParams",
     "CreateShareLinkParams",
     "DeleteAgentParams",
-    "DeleteBulkParams",
+    "DeleteBatchParams",
     "DeleteConnectorParams",
     "DeleteSavedMountParams",
     "DeprovisionUserParams",
@@ -79,7 +79,7 @@ __all__ = [
     "RegisterAgentParams",
     "RegisterWorkspaceParams",
     "RemoveMountParams",
-    "RenameBulkParams",
+    "RenameBatchParams",
     "RevokeShareByIdParams",
     "RevokeShareLinkParams",
     "RevokeShareParams",
@@ -204,8 +204,8 @@ class DeleteAgentParams:
 
 
 @dataclass
-class DeleteBulkParams:
-    """Parameters for delete_bulk(): Delete multiple files or directories in a single operation."""
+class DeleteBatchParams:
+    """Parameters for delete_batch(): Delete multiple files or directories in a single operation."""
 
     paths: list[str]
     recursive: bool = False
@@ -762,8 +762,8 @@ class RemoveMountParams:
 
 
 @dataclass
-class RenameBulkParams:
-    """Parameters for rename_bulk(): Rename/move multiple files in a single operation."""
+class RenameBatchParams:
+    """Parameters for rename_batch(): Rename/move multiple files in a single operation."""
 
     renames: list[tuple[str, str]]
 
@@ -1110,7 +1110,7 @@ METHOD_PARAMS: dict[str, type] = {
     "cancel_sync_job": CancelSyncJobParams,
     "create_share_link": CreateShareLinkParams,
     "delete_agent": DeleteAgentParams,
-    "delete_bulk": DeleteBulkParams,
+    "delete_batch": DeleteBatchParams,
     "delete_connector": DeleteConnectorParams,
     "delete_saved_mount": DeleteSavedMountParams,
     "deprovision_user": DeprovisionUserParams,
@@ -1166,7 +1166,7 @@ METHOD_PARAMS: dict[str, type] = {
     "register_agent": RegisterAgentParams,
     "register_workspace": RegisterWorkspaceParams,
     "remove_mount": RemoveMountParams,
-    "rename_bulk": RenameBulkParams,
+    "rename_batch": RenameBatchParams,
     "revoke_share": RevokeShareParams,
     "revoke_share_by_id": RevokeShareByIdParams,
     "revoke_share_link": RevokeShareLinkParams,

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -12,7 +12,7 @@ Provides file operations using NexusFS via asyncio.to_thread():
 - GET    /stream          - Stream file content
 - POST   /rename          - Rename/move file
 - POST   /copy            - Copy file
-- POST   /rename-bulk     - Bulk rename/move files
+- POST   /rename-batch     - Bulk rename/move files
 - POST   /copy-bulk       - Bulk copy files
 - GET    /glob            - Glob pattern search across files
 - GET    /grep            - Regex pattern search within files
@@ -303,7 +303,7 @@ class RenameOperation(BaseModel):
     destination: str = Field(..., description="Destination path to rename to")
 
 
-class RenameBulkRequest(BaseModel):
+class RenameBatchRequest(BaseModel):
     """Request model for bulk rename operations."""
 
     operations: list[RenameOperation] = Field(
@@ -320,7 +320,7 @@ class BulkRenameResult(BaseModel):
     error: str | None = None
 
 
-class RenameBulkResponse(BaseModel):
+class RenameBatchResponse(BaseModel):
     """Response model for bulk rename operations."""
 
     results: list[BulkRenameResult]
@@ -1241,11 +1241,11 @@ def create_async_files_router(
     # Bulk Rename Endpoint
     # =============================================================================
 
-    @router.post("/rename-bulk", response_model=RenameBulkResponse)
-    async def rename_bulk(
-        request: RenameBulkRequest,
+    @router.post("/rename-batch", response_model=RenameBatchResponse)
+    async def rename_batch(
+        request: RenameBatchRequest,
         context: Any = Depends(get_context),
-    ) -> RenameBulkResponse:
+    ) -> RenameBatchResponse:
         """
         Rename/move multiple files in a single request.
 
@@ -1255,7 +1255,7 @@ def create_async_files_router(
         try:
             fs = await _get_fs()
             renames = [(op.source, op.destination) for op in request.operations]
-            raw_results = await fs.rename_bulk(renames, context=context)
+            raw_results = await fs.rename_batch(renames, context=context)
 
             results: list[BulkRenameResult] = []
             for op in request.operations:
@@ -1269,7 +1269,7 @@ def create_async_files_router(
                     )
                 )
 
-            return RenameBulkResponse(results=results)
+            return RenameBatchResponse(results=results)
 
         except NexusPermissionError as e:
             raise HTTPException(status_code=403, detail=str(e)) from e

--- a/tests/integration/server/api/v2/routers/test_files_ops.py
+++ b/tests/integration/server/api/v2/routers/test_files_ops.py
@@ -1,4 +1,4 @@
-"""Tests for rename, copy, rename-bulk, and copy-bulk file operation endpoints."""
+"""Tests for rename, copy, rename-batch, and copy-batch file operation endpoints."""
 
 from unittest.mock import AsyncMock, MagicMock
 
@@ -29,8 +29,8 @@ def mock_fs() -> MagicMock:
     # sys_rename is async
     fs.sys_rename = AsyncMock(return_value={})
 
-    # rename_bulk is async
-    fs.rename_bulk = AsyncMock(return_value={})
+    # rename_batch is async
+    fs.rename_batch = AsyncMock(return_value={})
 
     # sys_stat is async, returns a dict
     fs.sys_stat = AsyncMock(
@@ -364,16 +364,16 @@ class TestCopy:
 
 
 # =============================================================================
-# POST /rename-bulk
+# POST /rename-batch
 # =============================================================================
 
 
-class TestRenameBulk:
-    """Tests for POST /rename-bulk endpoint."""
+class TestRenameBatch:
+    """Tests for POST /rename-batch endpoint."""
 
-    def test_rename_bulk_all_success(self, client: TestClient, mock_fs: MagicMock) -> None:
+    def test_rename_batch_all_success(self, client: TestClient, mock_fs: MagicMock) -> None:
         """All renames succeed."""
-        mock_fs.rename_bulk = AsyncMock(
+        mock_fs.rename_batch = AsyncMock(
             return_value={
                 "/a.txt": {"success": True, "new_path": "/b.txt"},
                 "/c.txt": {"success": True, "new_path": "/d.txt"},
@@ -381,7 +381,7 @@ class TestRenameBulk:
         )
 
         resp = client.post(
-            "/rename-bulk",
+            "/rename-batch",
             json={
                 "operations": [
                     {"source": "/a.txt", "destination": "/b.txt"},
@@ -396,9 +396,9 @@ class TestRenameBulk:
         assert body["results"][0]["source"] == "/a.txt"
         assert body["results"][0]["destination"] == "/b.txt"
 
-    def test_rename_bulk_partial_failure(self, client: TestClient, mock_fs: MagicMock) -> None:
+    def test_rename_batch_partial_failure(self, client: TestClient, mock_fs: MagicMock) -> None:
         """One rename fails, others succeed."""
-        mock_fs.rename_bulk = AsyncMock(
+        mock_fs.rename_batch = AsyncMock(
             return_value={
                 "/a.txt": {"success": True, "new_path": "/b.txt"},
                 "/missing.txt": {"success": False, "error": "Source not found"},
@@ -406,7 +406,7 @@ class TestRenameBulk:
         )
 
         resp = client.post(
-            "/rename-bulk",
+            "/rename-batch",
             json={
                 "operations": [
                     {"source": "/a.txt", "destination": "/b.txt"},
@@ -421,25 +421,25 @@ class TestRenameBulk:
         assert results[1]["success"] is False
         assert results[1]["error"] == "Source not found"
 
-    def test_rename_bulk_empty_operations(self, client: TestClient, mock_fs: MagicMock) -> None:
+    def test_rename_batch_empty_operations(self, client: TestClient, mock_fs: MagicMock) -> None:
         """Empty operations list returns empty results."""
-        mock_fs.rename_bulk = AsyncMock(return_value={})
+        mock_fs.rename_batch = AsyncMock(return_value={})
 
-        resp = client.post("/rename-bulk", json={"operations": []})
+        resp = client.post("/rename-batch", json={"operations": []})
         assert resp.status_code == 200
         assert resp.json()["results"] == []
 
-    def test_rename_bulk_exceeds_max(self, client: TestClient) -> None:
+    def test_rename_batch_exceeds_max(self, client: TestClient) -> None:
         """More than 50 operations returns 422 validation error."""
         ops = [{"source": f"/s{i}.txt", "destination": f"/d{i}.txt"} for i in range(51)]
-        resp = client.post("/rename-bulk", json={"operations": ops})
+        resp = client.post("/rename-batch", json={"operations": ops})
         assert resp.status_code == 422
 
-    def test_rename_bulk_permission_denied(self, client: TestClient, mock_fs: MagicMock) -> None:
+    def test_rename_batch_permission_denied(self, client: TestClient, mock_fs: MagicMock) -> None:
         """403 when entire bulk operation is denied."""
-        mock_fs.rename_bulk = AsyncMock(side_effect=NexusPermissionError("Access denied"))
+        mock_fs.rename_batch = AsyncMock(side_effect=NexusPermissionError("Access denied"))
         resp = client.post(
-            "/rename-bulk",
+            "/rename-batch",
             json={
                 "operations": [{"source": "/a.txt", "destination": "/b.txt"}],
             },

--- a/tests/unit/core/test_nexus_fs_core.py
+++ b/tests/unit/core/test_nexus_fs_core.py
@@ -61,8 +61,8 @@ ALL_CORE_METHODS = {
 BULK_METHODS = {
     "read_bulk": {"params": ["paths", "context", "return_metadata", "skip_errors"], "async": False},
     "write_batch": {"params": ["files", "context"], "async": True},
-    "delete_bulk": {"params": ["paths", "recursive", "context"], "async": True},
-    "rename_bulk": {"params": ["renames", "context"], "async": True},
+    "delete_batch": {"params": ["paths", "recursive", "context"], "async": True},
+    "rename_batch": {"params": ["renames", "context"], "async": True},
     "stat_bulk": {"params": ["paths", "context", "skip_errors"], "async": False},
     "exists_batch": {"params": ["paths", "context"], "async": True},
     "metadata_batch": {"params": ["paths", "context"], "async": True},


### PR DESCRIPTION
## Summary
BREAKING CHANGE: Unify batch operation naming in NexusFS + RPC layer.

- `delete_bulk` → `delete_batch`
- `rename_bulk` → `rename_batch`
- `/rename-bulk` → `/rename-batch` (HTTP endpoint)
- `DeleteBulkParams` → `DeleteBatchParams`, `RenameBulkParams` → `RenameBatchParams`

Now consistent with `write_batch`, `exists_batch`, `metadata_batch`.

## Test plan
- [x] Ruff + mypy clean
- [x] Pre-commit hooks pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)