### PR TITLE
refactor: revert driver _commit_metadata — kernel manages metadata (POSIX pattern)

### DIFF
--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -206,10 +206,9 @@ detail. Like HDFS separates ClientProtocol (NameNode, path-based) from
 DataTransferProtocol (DataNode, block-based). The metadata layer above ensures
 etag ownership and zone isolation.
 
-**Driver-managed metadata** (ext4 pattern): drivers persist metadata inside
-``write_content()`` while kernel holds VFS lock. Kernel calls ``write_content()``
-under lock, then reads back metadata for event dispatch. Metastore is injected
-into drivers at mount time via ``DriverLifecycleCoordinator``.
+**Kernel-managed metadata side effects** (POSIX ``generic_write_end`` pattern):
+kernel updates mtime, size, version, etag in VFS lock after
+``backend.write_content()``. Drivers only manage content.
 ``"sc"`` (strong, default) or ``"ec"`` (eventual, local-first) consistency.
 
 ### 2.4 VFS Dispatch (KernelDispatch)

--- a/src/nexus/backends/base/cas_addressing_engine.py
+++ b/src/nexus/backends/base/cas_addressing_engine.py
@@ -116,7 +116,6 @@ class CASAddressingEngine(Backend):
         meta_cache: Any | None = None,
         on_write_callback: Any | None = None,
         cdc_engine: "ChunkingStrategy | None" = None,
-        metastore: Any | None = None,
     ) -> None:
         self._transport = transport
         self._backend_name = backend_name or f"cas-{transport.transport_name}"
@@ -128,7 +127,6 @@ class CASAddressingEngine(Backend):
         self._meta_cache_misses = 0
         self._on_write_callback = on_write_callback
         self._cdc: ChunkingStrategy | None = cdc_engine
-        self._metastore = metastore
 
     @property
     def name(self) -> str:
@@ -244,12 +242,6 @@ class CASAddressingEngine(Backend):
             if self._cache is not None:
                 self._cache.put(content_hash, content)
 
-            # CAS metadata persistence (driver-owned, like ext4 inode update)
-            if self._metastore is not None and context is not None:
-                vpath = getattr(context, "virtual_path", None)
-                if vpath:
-                    self._commit_metadata(vpath, content_hash, len(content), context)
-
             return WriteResult(content_id=content_hash, version=content_hash, size=len(content))
 
         content_hash = hash_content(content)
@@ -282,12 +274,6 @@ class CASAddressingEngine(Backend):
             # Feature DI: Write callback (e.g. Zoekt reindex)
             if is_new and self._on_write_callback is not None:
                 self._on_write_callback(key)
-
-            # CAS metadata persistence (driver-owned, like ext4 inode update)
-            if self._metastore is not None and context is not None:
-                vpath = getattr(context, "virtual_path", None)
-                if vpath:
-                    self._commit_metadata(vpath, content_hash, len(content), context)
 
             return WriteResult(content_id=content_hash, version=content_hash, size=len(content))
 
@@ -343,40 +329,6 @@ class CASAddressingEngine(Backend):
 
         new_data = old_data[:offset] + buf + old_data[offset + len(buf) :]
         return self.write_content(new_data, context=context)
-
-    def _commit_metadata(
-        self, path: str, content_hash: str, size: int, context: "OperationContext"
-    ) -> None:
-        """Build and persist file metadata (CAS inode update, like ext4 write_iter)."""
-        from datetime import UTC, datetime
-
-        from nexus.contracts.metadata import FileMetadata
-
-        existing = getattr(context, "existing_metadata", None)
-        now = datetime.now(UTC)
-        zone_id = getattr(context, "zone_id", None) or "root"
-        owner_id = (
-            existing.owner_id
-            if existing and existing.owner_id
-            else getattr(context, "subject_id", None) or getattr(context, "user_id", None)
-        )
-
-        metadata = FileMetadata(
-            path=path,
-            backend_name=self.name,
-            physical_path=content_hash,
-            size=size,
-            etag=content_hash,
-            created_at=existing.created_at if existing else now,
-            modified_at=now,
-            version=(existing.version + 1) if existing else 1,
-            zone_id=zone_id,
-            owner_id=owner_id,
-        )
-
-        consistency = getattr(context, "consistency", "sc") if context else "sc"
-        if self._metastore is not None:
-            self._metastore.put(metadata, consistency=consistency)
 
     def read_content(self, content_id: str, context: "OperationContext | None" = None) -> bytes:
         content_hash = content_id  # CAS: content_id is a SHA-256 hash

--- a/src/nexus/backends/base/path_addressing_engine.py
+++ b/src/nexus/backends/base/path_addressing_engine.py
@@ -22,7 +22,7 @@ from __future__ import annotations
 import logging
 import mimetypes
 from collections.abc import Iterator
-from typing import TYPE_CHECKING, Any, ClassVar
+from typing import TYPE_CHECKING, ClassVar
 
 from nexus.backends.base.backend import Backend
 from nexus.backends.base.transport import Transport
@@ -62,14 +62,12 @@ class PathAddressingEngine(Backend):
         bucket_name: str = "",
         prefix: str = "",
         versioning_enabled: bool = False,
-        metastore: Any | None = None,
     ) -> None:
         self._transport = transport
         self._backend_name = backend_name or f"path-{transport.transport_name}"
         self.bucket_name = bucket_name
         self.prefix = prefix.rstrip("/")
         self.versioning_enabled = versioning_enabled
-        self._metastore = metastore
 
     @property
     def name(self) -> str:
@@ -138,42 +136,6 @@ class PathAddressingEngine(Backend):
                 pass
         return True  # Likely a version ID
 
-    # === Metadata Persistence (driver-owned, like ext4 inode update) ===
-
-    def _commit_metadata(
-        self, path: str, content_hash: str, size: int, context: "OperationContext"
-    ) -> None:
-        """Build and persist file metadata (PAS inode update, like ext4 write_iter)."""
-        from datetime import UTC, datetime
-
-        from nexus.contracts.metadata import FileMetadata
-
-        existing = getattr(context, "existing_metadata", None)
-        now = datetime.now(UTC)
-        zone_id = getattr(context, "zone_id", None) or "root"
-        owner_id = (
-            existing.owner_id
-            if existing and existing.owner_id
-            else getattr(context, "subject_id", None) or getattr(context, "user_id", None)
-        )
-
-        metadata = FileMetadata(
-            path=path,
-            backend_name=self.name,
-            physical_path=content_hash,
-            size=size,
-            etag=content_hash,
-            created_at=existing.created_at if existing else now,
-            modified_at=now,
-            version=(existing.version + 1) if existing else 1,
-            zone_id=zone_id,
-            owner_id=owner_id,
-        )
-
-        consistency = getattr(context, "consistency", "sc") if context else "sc"
-        if self._metastore is not None:
-            self._metastore.put(metadata, consistency=consistency)
-
     # === Content Operations (ObjectStoreABC) ===
 
     def write_content(
@@ -214,12 +176,6 @@ class PathAddressingEngine(Backend):
 
         # If versioning, store returns version_id; otherwise compute hash
         content_hash = result if result is not None else self._compute_hash(content)
-
-        # PAS metadata persistence (driver-owned, like ext4 inode update)
-        if self._metastore is not None and context is not None:
-            vpath = getattr(context, "virtual_path", None)
-            if vpath:
-                self._commit_metadata(vpath, content_hash, len(content), context)
 
         return WriteResult(content_id=content_hash, version=content_hash, size=len(content))
 

--- a/src/nexus/backends/storage/cas_local.py
+++ b/src/nexus/backends/storage/cas_local.py
@@ -257,8 +257,7 @@ class CASLocalBackend(CASAddressingEngine, MultipartUpload):
             logger.info("Cold tiering service scheduled to stop on unmount")
 
     def set_metastore(self, metastore: Any) -> None:
-        """Inject metastore reference for CAS metadata persistence + GC."""
-        self._metastore = metastore  # CASAddressingEngine metadata persistence
+        """Inject metastore reference for GC reachability scan."""
         self._gc.set_metastore(metastore)
 
     @property

--- a/src/nexus/contracts/filesystem/filesystem_abc.py
+++ b/src/nexus/contracts/filesystem/filesystem_abc.py
@@ -97,10 +97,9 @@ class NexusFilesystemABC(ABC):
         offset: int = 0,
         context: OperationContext | None = None,
     ) -> dict[str, Any]:
-        """Write content to a file (POSIX write(2)).
-
-        Tier 1 kernel primitive — content-only (SRP). Metadata updates
-        are handled by sys_setattr or Tier 2 write(). File must exist.
+        """Writes content with implicit metadata side effects (mtime, size, version, etag) —
+        like POSIX write(2) updating st_mtime/st_size. Metadata updates are kernel-managed
+        in VFS lock.
 
         Args:
             path: Virtual file path.

--- a/src/nexus/contracts/types.py
+++ b/src/nexus/contracts/types.py
@@ -120,7 +120,6 @@ class OperationContext:
     # Backend path for path-based connectors (GCS, S3, etc.)
     backend_path: str | None = None
     virtual_path: str | None = None  # Full virtual path with mount prefix (for cache keys)
-    existing_metadata: Any = None  # Pre-write FileMetadata, kernel→driver
 
     # Read Set Tracking for Query Dependencies (Issue #1166)
     read_set: "ReadSet | None" = None

--- a/src/nexus/core/driver_lifecycle_coordinator.py
+++ b/src/nexus/core/driver_lifecycle_coordinator.py
@@ -45,15 +45,12 @@ class DriverLifecycleCoordinator:
     Parallel to ServiceRegistry lifecycle orchestration (services vs drivers).
     """
 
-    __slots__ = ("_router", "_dispatch", "_mount_specs", "_metastore")
+    __slots__ = ("_router", "_dispatch", "_mount_specs")
 
-    def __init__(
-        self, router: "PathRouter", dispatch: "KernelDispatch", metastore: Any = None
-    ) -> None:
+    def __init__(self, router: "PathRouter", dispatch: "KernelDispatch") -> None:
         self._router = router
         self._dispatch = dispatch
         self._mount_specs: dict[str, HookSpec] = {}
-        self._metastore = metastore
 
     def mount(
         self,
@@ -70,13 +67,6 @@ class DriverLifecycleCoordinator:
         2. Register VFS hooks from hook_spec (fixes CAS wiring bug #1320)
         3. Broadcast mount event via KernelDispatch
         """
-        # Wire metastore into backend (like Linux VFS setting sb->s_op at mount)
-        if self._metastore is not None:
-            if hasattr(backend, "set_metastore"):
-                backend.set_metastore(self._metastore)
-            elif hasattr(backend, "_metastore"):
-                backend._metastore = self._metastore
-
         # 1. Add to routing table
         self._router.add_mount(
             mount_point,

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -226,7 +226,7 @@ class NexusFS(  # type: ignore[misc]
         from nexus.core.driver_lifecycle_coordinator import DriverLifecycleCoordinator
 
         self._driver_coordinator: DriverLifecycleCoordinator = DriverLifecycleCoordinator(
-            self.router, self._dispatch, metastore=metadata_store
+            self.router, self._dispatch
         )
 
         # ── Kernel-knows (sentinel None, injected by factory) ───────────
@@ -239,14 +239,6 @@ class NexusFS(  # type: ignore[misc]
         self._sandbox_manager: Any = None
         self._coordination_client: Any = None
         self._event_client: Any = None
-
-        # Wire metastore into pre-existing mounts (added to router before __init__)
-        for _mp in self.router.get_mount_points():
-            _mi = self.router.get_mount(_mp)
-            if _mi is not None and hasattr(_mi.backend, "set_metastore"):
-                _mi.backend.set_metastore(metadata_store)
-            elif _mi is not None and hasattr(_mi.backend, "_metastore"):
-                _mi.backend._metastore = metadata_store
 
         # Lifecycle state — set by link() / initialize() / bootstrap()
         self._linked: bool = False
@@ -2388,7 +2380,6 @@ class NexusFS(  # type: ignore[misc]
             context = OperationContext(
                 user_id="anonymous", groups=[], backend_path=route.backend_path, virtual_path=path
             )
-        context = replace(context, existing_metadata=meta)
 
         # DT_EXTERNAL_STORAGE: backend manages own content storage.
         # Remote backends (RPC-based) also persist metadata on the remote server,
@@ -2438,16 +2429,21 @@ class NexusFS(  # type: ignore[misc]
                 # HDFS/GFS pattern: content cleanup is async via background GC.
                 # See: docs/architecture/federation-memo.md §7f Caveat 4.
 
-                # Driver persists metadata inside write_content() (metastore
-                # injected at mount time via DLC).
-                _post_meta = self.metadata.get(path)
-                if _post_meta is None:
-                    raise BackendError(
-                        f"write_content() completed but metadata not found for {path}. "
-                        "Driver must persist metadata during write_content()."
-                    )
-                metadata = _post_meta
+                # Kernel-managed metadata (POSIX generic_write_end pattern):
+                # kernel updates mtime, size, version, etag in VFS lock
+                # after backend.write_content(). Drivers only manage content.
+                metadata = self._build_write_metadata(
+                    path=path,
+                    backend_name=route.backend.name,
+                    content_hash=content_hash,
+                    size=_wr.size if offset > 0 else len(content),
+                    existing_meta=meta,
+                    now=now,
+                    zone_id=zone_id,
+                    context=context,
+                )
                 new_version = metadata.version
+                self.metadata.put(metadata, consistency=consistency)
 
         return _WriteContentResult(
             content_hash=content_hash,

--- a/tests/helpers/failing_backend.py
+++ b/tests/helpers/failing_backend.py
@@ -57,11 +57,6 @@ class FailingBackend(Backend):
         self._fail_permanently = fail_permanently
         self._call_count = 0
 
-    def set_metastore(self, metastore: "Any") -> None:
-        """Forward metastore injection to inner backend."""
-        if hasattr(self._inner, "set_metastore"):
-            self._inner.set_metastore(metastore)
-
     @property
     def name(self) -> str:
         return f"failing({self._inner.name})"


### PR DESCRIPTION
## Summary
Revert #3521's driver _commit_metadata pattern. Kernel now manages metadata
side effects in VFS lock — POSIX generic_write_end pattern.

POSIX write(2) has implicit metadata side effects (st_mtime, st_size) managed
by VFS, not filesystem driver. Nexus follows the same pattern.

## Changes (9 files, -137 lines)
- Delete `_commit_metadata()` from CAS + PAS engines
- Restore `_build_write_metadata + metadata.put` in kernel standard write path
- Remove DLC metastore auto-wire + NexusFS.__init__ auto-wire
- Remove `existing_metadata` from OperationContext
- Update sys_write docstring + KERNEL-ARCHITECTURE.md

## Test plan
- [x] 458 tests pass locally, 0 failures
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)