### PR TITLE
refactor(#1826): kernel owned/knows sections + _event_bus rename + MessageBoundaryStrategy

### DIFF
--- a/src/nexus/backends/compute/message_chunking.py
+++ b/src/nexus/backends/compute/message_chunking.py
@@ -194,6 +194,23 @@ class MessageBoundaryStrategy:
         manifest = ChunkedReference.from_json(data)
         return manifest.total_size
 
+    def write_chunked_partial(
+        self,
+        old_manifest_hash: str,
+        buf: bytes,
+        offset: int,
+        context: "OperationContext | None" = None,
+    ) -> str:
+        """Partial write — not supported for message-boundary chunking.
+
+        LLM conversations are always written as complete message arrays.
+        Partial byte-offset writes don't map to message boundaries.
+        """
+        raise NotImplementedError(
+            "MessageBoundaryStrategy does not support partial writes. "
+            "LLM conversations must be written as complete message arrays."
+        )
+
     def delete_chunked(self, content_hash: str, context: "OperationContext | None" = None) -> None:
         """Delete manifest + all chunks unconditionally."""
         import contextlib

--- a/src/nexus/backends/compute/openai_compatible.py
+++ b/src/nexus/backends/compute/openai_compatible.py
@@ -141,6 +141,15 @@ class OpenAICompatibleBackend(CASAddressingEngine):
 
         super().__init__(transport, backend_name="openai_compatible")
 
+        # Wire message-boundary CDC for LLM conversation dedup (Issue #1826).
+        # Must be after super().__init__ since MessageBoundaryStrategy needs
+        # self as CASAddressingEngine.
+        from nexus.backends.compute.message_chunking import MessageBoundaryStrategy
+        from nexus.backends.engines.cdc import ChunkingStrategy
+
+        cdc: ChunkingStrategy = MessageBoundaryStrategy(self)
+        self._cdc = cdc
+
     @property
     def name(self) -> str:
         return "openai_compatible"

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -161,39 +161,14 @@ class NexusFS(  # type: ignore[misc]
         # operations. External callers should pass explicit context= to syscalls.
         self._init_cred: OperationContext | None = init_cred
 
-        # Permission enforcement is fully delegated to KernelDispatch INTERCEPT hooks.
-        # PermissionCheckHook (bricks/rebac) registers via enlist() → hook_spec().
-        # No hook registered = no check = zero overhead (like Linux without LSM modules).
-        # _permission_enforcer and _descendant_checker removed in Phase 4 PR 2.
-        # overlay_resolver removed (Issue #2034) — always None, re-add when #1264 is implemented
-        self._overlay_resolver = None
-        # Issue #1788: Advisory lock manager — kernel owned (like FileWatcher).
-        # Local: LocalLockManager (VFSSemaphore). Remote: RaftLockManager (kernel knows,
-        # federation inject via upgrade_lock_manager()). Constructed after _vfs_lock_manager.
-        # Issue #1792: AgentRegistry accessed via ServiceRegistry (register_factory).
-        # No kernel sentinel — no-agent profiles (REMOTE) never construct it.
-        # Issue #1801: _flush_write_observer_fn and _overlay_config_fn closures removed —
-        # kernel now reads services directly from service registry.
-        # Non-hot-path service attrs wired by factory._do_link() (Issue #1570)
+        # ── Kernel-owned primitives (always present, created here) ──────
+        # See KERNEL-ARCHITECTURE.md §1 DI patterns table.
 
-        # Lazy-init sentinels
-        self._token_manager = None
-        self._sandbox_manager: Any = None
-        self._coordination_client: Any = None
-        self._event_client: Any = None
-
-        # VFS lock manager — kernel-internal, NOT injected via DI.
-        # Analogous to Linux i_rwsem: always present, created by kernel at init.
-        # Protects same-process coroutine concurrency on sys_write/sys_read.
         from nexus.core.lock_fast import create_vfs_lock_manager
 
         self._vfs_lock_manager = create_vfs_lock_manager()
         logger.info("VFS lock manager initialized (%s)", type(self._vfs_lock_manager).__name__)
 
-        # Advisory lock manager — kernel owned (POSIX flock equivalent).
-        # Like FileWatcher: kernel-owned local + kernel-knows remote.
-        # Exclusive/shared use lock_fast RW lock (~200ns) when available.
-        # Counting (max_holders>1) falls back to VFSSemaphore.
         from nexus.lib.distributed_lock import LocalLockManager
         from nexus.lib.semaphore import create_vfs_semaphore
 
@@ -203,16 +178,10 @@ class NexusFS(  # type: ignore[misc]
             vfs_lock_manager=self._vfs_lock_manager,
         )
 
-        # Kernel notification dispatch (INTERCEPT + OBSERVE).
-        # Kernel owns dispatch infrastructure — creates empty callback lists.
-        # Factory registers hooks at boot (KERNEL-ARCHITECTURE §3).
         from nexus.core.kernel_dispatch import KernelDispatch
 
         self._dispatch: KernelDispatch = KernelDispatch()
 
-        # IPC primitives — kernel-internal, NOT injected via DI.
-        # Like VFSLockManager: always present, created by kernel at init.
-        # Both use ROOT_ZONE_ID (zone_id is a kernel namespace partition concept).
         import os as _os_ipc
 
         from nexus.core.pipe_manager import PipeManager
@@ -220,9 +189,6 @@ class NexusFS(  # type: ignore[misc]
 
         _ipc_self_addr = _os_ipc.environ.get("NEXUS_ADVERTISE_ADDR")
 
-        # PeerChannelPool for remote pipe/stream fast-path (persistent gRPC channels).
-        # Created when NEXUS_ADVERTISE_ADDR is set (federation mode); TLS config is
-        # deferred via set_tls_config() after federation bootstrap.
         from nexus.grpc.channel_pool import PeerChannelPool as _PeerChannelPool
 
         self._channel_pool: _PeerChannelPool | None = None
@@ -239,8 +205,7 @@ class NexusFS(  # type: ignore[misc]
             self_address=_ipc_self_addr,
             channel_pool=self._channel_pool,
         )
-        # FileWatcher — kernel file change notification (inotify equivalent, §4.3).
-        # Kernel-owned local OBSERVE waiters + optional kernel-knows remote watcher.
+
         from nexus.core.file_watcher import FileWatcher
 
         self._file_watcher = FileWatcher()
@@ -250,21 +215,26 @@ class NexusFS(  # type: ignore[misc]
             _ipc_self_addr or "none/single-node",
         )
 
-        # Service registry — /proc/modules of Nexus (Issue #1452).
-        # Populated by factory via enlist_wired_services() at link().
         from nexus.core.service_registry import ServiceRegistry
 
         self._service_registry: ServiceRegistry = ServiceRegistry(dispatch=self._dispatch)
 
-        # Driver lifecycle coordinator — /proc/mounts of Nexus (Issue #1811).
-        # Manages mount lifecycle: routing table + hook_spec registration +
-        # KernelDispatch mount/unmount notification. Kernel-owned, like
-        # ServiceRegistry. MountService and factory delegate to this.
         from nexus.core.driver_lifecycle_coordinator import DriverLifecycleCoordinator
 
         self._driver_coordinator: DriverLifecycleCoordinator = DriverLifecycleCoordinator(
             self.router, self._dispatch, metastore=metadata_store
         )
+
+        # ── Kernel-knows (sentinel None, injected by factory) ───────────
+        # See KERNEL-ARCHITECTURE.md §1 DI patterns table.
+        # None = graceful degrade (like Linux LSM: no module loaded = no check).
+
+        self._event_bus: Any = None
+        self._overlay_resolver = None
+        self._token_manager = None
+        self._sandbox_manager: Any = None
+        self._coordination_client: Any = None
+        self._event_client: Any = None
 
         # Wire metastore into pre-existing mounts (added to router before __init__)
         for _mp in self.router.get_mount_points():

--- a/src/nexus/factory/_system.py
+++ b/src/nexus/factory/_system.py
@@ -533,10 +533,9 @@ def _boot_pre_kernel_services(
         "context_branch_service": context_branch_service,
         "zone_lifecycle": zone_lifecycle,
         "scheduler_service": scheduler_service,
-        # Infrastructure: event_bus no longer in services dict.
-        # Stored on NexusFS as _event_bus (infra, not a service).
+        # Kernel-knows: event_bus stored on NexusFS._event_bus (not a service).
         # Wired into FileWatcher (remote_watcher) + EventBusObserver by orchestrator.
-        "_event_bus_infra": event_bus,
+        "_event_bus": event_bus,
     }
 
     elapsed = time.perf_counter() - t0

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -600,11 +600,11 @@ async def _register_vfs_hooks(
     # Remote watcher (EventBus) wired later by federation or other services.
     await _enlist("file_watcher", nx._file_watcher)
 
-    # EventBus: infrastructure (not a service). Stored on NexusFS, wired into
-    # FileWatcher (remote_watcher) + EventBusObserver (publish side).
-    _event_bus = _ss.pop("_event_bus_infra", None)
+    # EventBus: kernel-knows (not a service). Stored on NexusFS._event_bus,
+    # wired into FileWatcher (remote_watcher) + EventBusObserver (publish side).
+    _event_bus = _ss.pop("_event_bus", None)
     if _event_bus is not None:
-        nx._event_bus_infra = _event_bus  # store on NexusFS for lifecycle
+        nx._event_bus = _event_bus
         nx._file_watcher.set_remote_watcher(_event_bus)
 
     # EventBusObserver: forwards FileEvents to distributed EventBus (Redis/NATS).

--- a/src/nexus/server/lifespan/services_container.py
+++ b/src/nexus/server/lifespan/services_container.py
@@ -140,7 +140,7 @@ class LifespanServices:
             entity_registry=_svc("entity_registry"),
             permission_enforcer=(_svc("permission_enforcer") if nx else None),
             rebac_manager=_svc("rebac_manager"),
-            event_bus=getattr(nx, "_event_bus_infra", None) if nx else None,
+            event_bus=getattr(nx, "_event_bus", None) if nx else None,
             coordination_client=(getattr(nx, "_coordination_client", None) if nx else None),
             workflow_engine=(getattr(nx, "workflow_engine", None) if nx else None),
             snapshot_service=_svc("snapshot_service"),

--- a/tests/unit/core/test_factory_boot.py
+++ b/tests/unit/core/test_factory_boot.py
@@ -64,7 +64,7 @@ EXPECTED_SYSTEM_KEYS = frozenset(
         "scheduler_service",
         "event_signal",
         # Infrastructure (moved from bricks, event_bus stored on NexusFS as infra)
-        "_event_bus_infra",
+        "_event_bus",
     }
 )
 
@@ -216,7 +216,7 @@ class TestBootSystemServices:
             "observability_subsystem",
             "workspace_registry",  # degradable — None with mock session_factory
             "scheduler_service",  # degradable — None if SchedulerService unavailable
-            "_event_bus_infra",  # None when enable_events=False
+            "_event_bus",  # None when enable_events=False
         }
         for key, value in result.items():
             if key in _NULLABLE_KEYS:

--- a/tests/unit/server/lifespan/test_lifespan_services.py
+++ b/tests/unit/server/lifespan/test_lifespan_services.py
@@ -95,7 +95,7 @@ class TestFromAppExtraction:
             _coordination_client="coord_client",
             workflow_engine="wf_engine",
             config="nexus_cfg",
-            _event_bus_infra="event_bus",
+            _event_bus="event_bus",
             _service_map={
                 "entity_registry": "entity_reg",
                 "permission_enforcer": "perm_enf",

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -180,8 +180,8 @@ class TestBootSystemServices:
             "scheduler_service",
             # Issue #3193: shared notification signal
             "event_signal",
-            # Infrastructure (event_bus stored on NexusFS as infra, not in services)
-            "_event_bus_infra",
+            # Kernel-knows (event_bus stored on NexusFS, not in services)
+            "_event_bus",
         }
         assert expected_keys == set(result.keys())
 


### PR DESCRIPTION
## Summary
1. **NexusFS.__init__ section headers** — clear `kernel-owned` vs `kernel-knows` sections. Reorder scattered sentinels. No behavior change.
2. **Rename `_event_bus_infra` → `_event_bus`** — "infra" is not a recognized category. `_event_bus` is kernel-knows (sentinel None, injected by factory).
3. **Wire MessageBoundaryStrategy** (#1826) — enables per-message CAS dedup for LLM conversations in `OpenAICompatibleBackend`.

## Test plan
- [x] 111 tests pass, ruff clean, mypy clean, all pre-commit hooks pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)