### PR TITLE
docs: rewrite syscall-design.md to match current codebase

### DIFF
--- a/docs/architecture/syscall-design.md
+++ b/docs/architecture/syscall-design.md
@@ -1,8 +1,7 @@
-# Syscall Primitive Separation (#1316)
+# Syscall Design
 
-**Tasks**: #834 (sys_ prefix rename), #1316 (primitive separation)
-**Prerequisite for**: #1202 (gRPC transport), #1271 (FastAPI sunset)
-**Status**: Design complete. Implementation pending.
+**Status:** Implemented. Source of truth for syscall inventory and design rationale.
+**See also:** `KERNEL-ARCHITECTURE.md` §2 for the kernel-level view.
 
 ---
 
@@ -25,39 +24,47 @@ Nexus:   Client      → nx.read()    →                  → NexusFS.sys_read(
 
 ---
 
-## 2. Kernel Syscall Table (11 syscalls)
+## 2. Kernel Syscall Table
 
 All path-addressed. No hash-addressing (CAS is driver detail, not kernel concern).
 
-### Metadata Plane (8)
+### Tier 1 — Abstract Syscalls (11)
 
-| # | Syscall | Signature | POSIX Ref |
-|---|---------|-----------|-----------|
-| 1 | `sys_stat` | `(path) → FileMetadata \| None` | `stat(2)` |
-| 2 | `sys_setattr` | `(path, **attrs) → FileMetadata` | `chmod/chown/utimes` + `mknod` (DT_DIR, DT_PIPE, DT_STREAM) |
-| 3 | `sys_rmdir` | `(path, recursive=False) → None` | `rmdir(2)` |
-| 4 | `sys_readdir` | `(path, recursive=True) → list` | `readdir(3)` |
-| 5 | `sys_access` | `(path, mode=F_OK) → bool` | `access(2)` |
-| 6 | `sys_rename` | `(old, new) → None` | `rename(2)` |
-| 7 | `sys_unlink` | `(path) → None` | `unlink(2)` |
-| 8 | `sys_is_directory` | `(path) → bool` | `S_ISDIR` macro |
+| # | Plane | Syscall | Signature | POSIX Ref |
+|---|-------|---------|-----------|-----------|
+| 1 | Content | `sys_read` | `(path, count=None, offset=0) → bytes` | `pread(2)` |
+| 2 | Content | `sys_write` | `(path, buf, count=None, offset=0) → dict` | `write(2)` |
+| 3 | Metadata | `sys_stat` | `(path) → dict \| None` | `stat(2)` |
+| 4 | Metadata | `sys_setattr` | `(path, **attrs) → dict` | `chmod/chown/utimes` + `mknod` (DT_DIR, DT_PIPE, DT_STREAM, DT_MOUNT) |
+| 5 | Namespace | `sys_unlink` | `(path, recursive=False) → dict` | `unlink(2)` |
+| 6 | Namespace | `sys_rename` | `(old, new) → dict` | `rename(2)` |
+| 7 | Namespace | `sys_copy` | `(src, dst) → dict` | — (server-side copy, Issue #3329) |
+| 8 | Directory | `sys_readdir` | `(path, recursive=True, limit=None) → list` | `readdir(3)` |
+| 9 | Locking | `sys_lock` | `(path, mode, ttl, max_holders) → str \| None` | `flock(2)` |
+| 10 | Locking | `sys_unlock` | `(path, lock_id) → bool` | `flock(LOCK_UN)` |
+| 11 | Watch | `sys_watch` | `(path, timeout, recursive) → dict \| None` | `inotify(7)` |
 
-`mkdir(path, parents, exist_ok)` is Tier 2 convenience over `sys_setattr(path, entry_type=DT_DIR)`.
+### Tier 2 — Concrete Convenience (not abstract, composing Tier 1)
 
-### Content Plane (2)
+| Method | Tier | Composes | Notes |
+|--------|------|----------|-------|
+| `sys_rmdir` | 2 | `sys_unlink(recursive=)` | Thin delegation, overridable |
+| `access` | 2 | `sys_stat` | Returns `True` if stat succeeds |
+| `is_directory` | 2 | `sys_stat` | Checks `is_directory` field |
 
-| # | Syscall | Signature | POSIX Ref |
-|---|---------|-----------|-----------|
-| 10 | `sys_read` | `(path, count=None, offset=0) → bytes` | `pread(2)` |
-| 11 | `sys_write` | `(path, buf, count=None, offset=0) → int` | `pwrite(2)` |
+`sys_setattr` is the universal creation/management syscall:
+- `mkdir(path)` = `sys_setattr(path, entry_type=DT_DIR)` (Tier 2)
+- `mount` = `sys_setattr(path, entry_type=DT_MOUNT, backend=...)`
+- `mkpipe` = `sys_setattr(path, entry_type=DT_PIPE)`
+- `mkstream` = `sys_setattr(path, entry_type=DT_STREAM)`
+- `/__sys__/` paths = kernel management (service register/unregister)
 
 ### What's NOT a kernel syscall
 
-Hash-addressed content operations (`read_content`, `write_content`, `delete_content`,
-`get_content_size`) stay on **ObjectStoreABC** (driver level):
+Hash-addressed content operations (`read_content`, `write_content`, `stream`,
+`write_stream`) stay on **ObjectStoreABC** (driver level):
 
-- Hash-addressing implies CAS, but not all backends use CAS (S3Connector, PassthroughBackend
-  use path-addressing). Kernel must be backend-agnostic.
+- Hash-addressing implies CAS, but not all backends use CAS. Kernel is backend-agnostic.
 - Linux doesn't expose `sys_read_block(lba)` — that's the block device driver's concern.
 - HDFS separates: ClientProtocol (path-based, NameNode) vs DataTransferProtocol
   (block-based, DataNode). Our ObjectStoreABC = DataNode equivalent.
@@ -74,12 +81,17 @@ NexusFS inherits them — callers use `nx.read(path)` directly.
 | Method | Composes | Behavior |
 |--------|----------|----------|
 | `read(path, count, offset)` | `sys_stat` + `sys_read` | POSIX pread semantics |
-| `write(path, buf, count, offset)` | `sys_write` + `sys_setattr` | POSIX pwrite + metadata update |
-| `stat(path)` | `sys_stat` | Thin wrapper |
+| `write(path, buf, consistency=)` | `sys_write` + `sys_setattr` | Write + metadata update, consistency param |
 | `mkdir(path, parents, exist_ok)` | `sys_setattr(entry_type=DT_DIR)` | Directory creation with hooks + events |
-| `unlink(path)` | `sys_unlink` | Thin wrapper |
+| `rmdir(path, recursive)` | `sys_rmdir` | Lenient defaults (recursive=True) |
 | `append(path, content)` | `read` + `write` | Shell `>>` semantics |
 | `edit(path, edits)` | `read` + transform + `write` | Apply diffs |
+| `write_batch(files)` | N × `write()` | Batch file writes |
+| `access(path)` | `sys_stat` | Existence check |
+| `is_directory(path)` | `sys_stat` | Directory check |
+| `lock(path, mode, timeout)` | `sys_lock` (retry loop) | Blocking lock (like `fcntl(F_SETLKW)`) |
+| `unlock(lock_id, path)` | `sys_unlock` | Release lock |
+| `locked(path)` | `lock` + `unlock` | Async context manager |
 
 ### HDFS Half — Driver-level content access
 
@@ -87,6 +99,8 @@ NexusFS inherits them — callers use `nx.read(path)` directly.
 |--------|-------------|---------|
 | `read_content(hash)` | `ObjectStoreABC.read_content(hash)` | Direct blob access by hash |
 | `write_content(content)` | `ObjectStoreABC.write_content(content)` | Direct blob store, return hash |
+| `stream(hash)` | `ObjectStoreABC.stream(hash)` | Streaming blob read |
+| `write_stream(path)` | `ObjectStoreABC.write_stream(path)` | Streaming blob write |
 
 ### Higher-level
 
@@ -94,7 +108,6 @@ NexusFS inherits them — callers use `nx.read(path)` directly.
 |--------|----------|
 | `glob(pattern)` | `sys_readdir` + filter |
 | `grep(pattern, path)` | `sys_readdir` + `sys_read` + regex |
-| `write_batch(files)` | N × `write()` |
 
 ---
 
@@ -102,47 +115,47 @@ NexusFS inherits them — callers use `nx.read(path)` directly.
 
 ### 4.1 sys_read / sys_write: Content-only (POSIX pread/pwrite)
 
-| Aspect | Current | New (POSIX-aligned) |
-|--------|---------|---------------------|
-| Signature | `sys_write(path, content, if_match, force, lock) → dict` | `sys_write(path, buf, count, offset) → int` |
-| Content | Whole-file replacement | Partial write at offset |
-| Metadata | Updates etag/version/mtime | Does NOT update metadata |
-| Return | dict with etag/version/size | int (bytes written) |
-| CAS params | In signature (`if_match`, `force`) | In `OperationContext` or removed |
+`sys_write` is content-only (SRP). Metadata updates are handled by `sys_setattr`
+or Tier 2 `write()`. File must exist — `sys_write` to a non-existent path raises
+`NexusFileNotFoundError`. Creation goes through `sys_setattr`.
 
 CAS read-modify-write for offset writes is handled internally by the driver.
 Kernel does not know whether backend is CAS or path-addressed.
 
-### 4.2 sys_unlink: Metadata-only (HDFS/GFS GC pattern)
+### 4.2 sys_unlink: Unified delete (files + directories)
 
-Current: `sys_unlink` deletes metadata AND calls `backend.delete_content(hash)`.
-New: `sys_unlink` only deletes the directory entry. Content orphans cleaned by
-async `ContentGarbageCollector` (like HDFS BlockManager).
+`sys_unlink` handles both files and directories (with `recursive=` param).
+`sys_rmdir` is Tier 2 convenience that delegates to `sys_unlink(recursive=)`.
+CAS content is freed when refcount reaches zero.
 
-Rationale: HDFS/GFS standard pattern. See `federation-memo.md` §7f Caveat 4.
+### 4.3 sys_setattr: Universal creation/management
 
-### 4.3 sys_access: POSIX mode flags + DI PermissionChecker
+`sys_setattr` is the Swiss Army knife — creation, attribute updates, and special
+inode types all flow through it:
 
-```python
-F_OK = 0  # existence
-R_OK = 4  # read
-W_OK = 2  # write
-X_OK = 1  # execute
+- **Create**: `entry_type=DT_DIR/DT_PIPE/DT_STREAM/DT_MOUNT` creates the inode
+- **Update**: No `entry_type` updates mutable metadata fields
+- **Idempotent open**: Same `entry_type` on existing path recovers the buffer (pipes/streams)
+- **`/__sys__/`**: Kernel management namespace (service register, config, etc.)
 
-def sys_access(self, path, mode=F_OK, context=None) -> bool:
-    if mode == F_OK:
-        return self._metadata.exists(path)
-    return self._permission_checker.check(path, mode, context)
-```
+### 4.4 sys_lock / sys_unlock: Advisory locks (POSIX flock)
 
-`PermissionChecker` is DI'd. Default: `NoOpPermissionChecker` (allow all).
-Works with simple rwx, RBAC, ReBAC — all reduce to "can user do r/w/x on path?"
+Exposed as kernel syscalls (not service-layer). `sys_lock` is non-blocking
+(`F_SETLK`); Tier 2 `lock()` provides blocking retry (`F_SETLKW`); Tier 2
+`locked()` provides async context manager. See `lock-architecture.md` §3.
 
-**Future (privacy computing)**: rwx may be insufficient for fine-grained data access
-(e.g., "compute aggregate without reading raw data"). Extension path: capability-based
-model (like Linux `CAP_*` extending rwx to 40+ capabilities).
+### 4.5 sys_copy: Server-side copy (Issue #3329)
 
-### 4.4 Hash-addressed ops: Driver level, not kernel
+Uses backend-native server-side copy when available (GCS, S3), streaming for
+cross-backend, read+write as fallback. Holds VFS locks internally — callers
+must NOT hold locks when calling `sys_copy`.
+
+### 4.6 sys_watch: File change notification (inotify)
+
+Waits for file changes with timeout. Returns `FileEvent` dict or `None` on
+timeout. Supports recursive watching. Backed by `FileWatcher` kernel primitive.
+
+### 4.7 Hash-addressed ops: Driver level, not kernel
 
 ```
 Kernel:  sys_read(path)        → internal: path → metadata → hash → driver.read_content(hash)
@@ -161,22 +174,28 @@ between DataNodes — separate from NameNode API).
 | Syscall | Aligned? | Notes |
 |---------|----------|-------|
 | `sys_stat` | ✅ | dict vs struct stat (Pythonic) |
-| `sys_setattr` | ✅ | Bundles chmod/chown/utimes + mknod (DT_DIR, DT_PIPE, DT_STREAM) |
-| `sys_rmdir` | ✅ | `recursive` is extension |
-| `sys_readdir` | ✅ | No opendir/closedir (acceptable simplification) |
-| `sys_access` | ⚠️→✅ | Adding mode flags (F_OK/R_OK/W_OK/X_OK) |
+| `sys_setattr` | ✅ | Bundles chmod/chown/utimes + mknod (DT_DIR, DT_PIPE, DT_STREAM, DT_MOUNT) |
+| `sys_readdir` | ✅ | No opendir/closedir (acceptable simplification), supports pagination |
 | `sys_rename` | ✅ | — |
-| `sys_unlink` | ⚠️→✅ | Changing to metadata-only |
-| `sys_is_directory` | ✅ | Our extension (S_ISDIR macro equivalent) |
-| `sys_read` | ⚠️→✅ | Adding count/offset, content-only |
-| `sys_write` | ⚠️→✅ | Adding count/offset, content-only, return int |
+| `sys_unlink` | ✅ | Unified delete (files + dirs), metadata-only (CAS GC pattern) |
+| `sys_copy` | ✅ | No direct POSIX equivalent; server-side optimization |
+| `sys_read` | ✅ | count/offset (pread semantics) |
+| `sys_write` | ✅ | count/offset, content-only (SRP) |
+| `sys_lock` | ✅ | Non-blocking flock(F_SETLK) |
+| `sys_unlock` | ✅ | flock(LOCK_UN) |
+| `sys_watch` | ✅ | inotify(7) equivalent |
+
+Tier 2 demotions (no longer Tier 1):
+- `access` → Tier 2 (derives from `sys_stat`)
+- `is_directory` → Tier 2 (derives from `sys_stat`)
+- `sys_rmdir` → Tier 2 (delegates to `sys_unlink`)
 
 ---
 
 ## 6. Verification
 
 ```bash
-uv run pytest tests/ -x --timeout=60
+uv run pytest tests/ -x -o "addopts="
 uv run mypy src/nexus/contracts/filesystem/ src/nexus/core/nexus_fs.py
 uv run ruff check src/
 PYTHONPATH=src uv run lint-imports


### PR DESCRIPTION
## Summary
Full rewrite of `syscall-design.md` — the doc was stuck in "design pending" state while the codebase has moved far ahead.

Key changes:
- **Syscall table**: 11 Tier 1 abstract syscalls (add `sys_copy`, `sys_lock`, `sys_unlock`, `sys_watch`; demote `sys_rmdir`/`access`/`is_directory` to Tier 2)
- **Remove stale migration tables**: "Current vs New" comparison columns deleted (migration done long ago)
- **New design decision sections**: sys_copy (§4.5), sys_lock/unlock (§4.4), sys_watch (§4.6)
- **Fix Tier 2 VFS half**: add `write_batch`, `lock`, `unlock`, `locked`, `rmdir`; remove non-existent `stat`
- **Update POSIX alignment summary** for all 11 syscalls + Tier 2 demotions

Supersedes #3489 (which covers the same file with a different approach).

## Test plan
- [x] No code changes, docs only
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)