### PR TITLE
refactor: extract WatchMixin + LockMixin from NexusFS (Phase 6 PR 2a)

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -31,6 +31,7 @@ from nexus.core.config import (
 from nexus.core.file_events import FileEvent, FileEventType
 from nexus.core.hash_fast import hash_content
 from nexus.core.metastore import MetastoreABC
+from nexus.core.nexus_fs_watch import WatchMixin
 from nexus.core.router import PathRouter
 from nexus.lib.path_utils import validate_path
 from nexus.lib.rpc_decorator import rpc_expose
@@ -59,6 +60,7 @@ class _WriteContentResult(NamedTuple):
 
 
 class NexusFS(  # type: ignore[misc]
+    WatchMixin,
     NexusFilesystemABC,
 ):
     """
@@ -635,29 +637,7 @@ class NexusFS(  # type: ignore[misc]
         path = self._validate_path(path)
         return await self._lock_manager.release(lock_id, path)
 
-    # ── Watch (inotify equivalent) ────────────────────────────────
-
-    @rpc_expose(description="Wait for file changes on a path")
-    async def sys_watch(
-        self,
-        path: str,
-        timeout: float = 30.0,
-        *,
-        recursive: bool = False,  # noqa: ARG002
-        context: OperationContext | None = None,
-    ) -> dict[str, Any] | None:
-        """Wait for file changes (inotify(7)). Returns FileEvent dict or None on timeout.
-
-        Delegates to kernel FileWatcher which races local OBSERVE + optional
-        remote watcher (federation) via FIRST_COMPLETED.
-        """
-        path = validate_path(path, allow_root=True)
-        ctx = self._resolve_cred(context)
-        zone_id = getattr(ctx, "zone_id", None) or ROOT_ZONE_ID
-        event = await self._file_watcher.wait(path, timeout=timeout, zone_id=zone_id)
-        if event is None:
-            return None
-        return event.to_dict()
+    # sys_watch is in nexus_fs_watch.py (WatchMixin)
 
     @rpc_expose(description="Get advisory lock info for a path")
     async def lock_info(

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -31,6 +31,7 @@ from nexus.core.config import (
 from nexus.core.file_events import FileEvent, FileEventType
 from nexus.core.hash_fast import hash_content
 from nexus.core.metastore import MetastoreABC
+from nexus.core.nexus_fs_lock import LockMixin
 from nexus.core.nexus_fs_watch import WatchMixin
 from nexus.core.router import PathRouter
 from nexus.lib.path_utils import validate_path
@@ -60,6 +61,7 @@ class _WriteContentResult(NamedTuple):
 
 
 class NexusFS(  # type: ignore[misc]
+    LockMixin,
     WatchMixin,
     NexusFilesystemABC,
 ):
@@ -599,137 +601,8 @@ class NexusFS(  # type: ignore[misc]
         except Exception:
             return False
 
-    # ── Locking (POSIX flock equivalent) ──────────────────────────
-
-    @rpc_expose(description="Acquire advisory lock on a path")
-    async def sys_lock(
-        self,
-        path: str,
-        mode: str = "exclusive",
-        ttl: float = 30.0,
-        max_holders: int = 1,
-        *,
-        context: OperationContext | None = None,
-    ) -> str | None:
-        """Acquire advisory lock (POSIX flock(2)). Returns lock_id or None.
-
-        Tier 1 syscall — single try-acquire, returns immediately.
-        Use Tier 2 ``lock()`` for blocking wait with retry.
-        """
-        path = self._validate_path(path)
-        return await self._lock_manager.acquire(
-            path,
-            mode=mode,
-            ttl=ttl,
-            max_holders=max_holders,
-            timeout=0,  # try-once, no blocking
-        )
-
-    @rpc_expose(description="Release advisory lock")
-    async def sys_unlock(
-        self,
-        path: str,
-        lock_id: str,
-        *,
-        context: OperationContext | None = None,
-    ) -> bool:
-        """Release advisory lock. Returns True if released."""
-        path = self._validate_path(path)
-        return await self._lock_manager.release(lock_id, path)
-
+    # Lock methods in nexus_fs_lock.py (LockMixin)
     # sys_watch is in nexus_fs_watch.py (WatchMixin)
-
-    @rpc_expose(description="Get advisory lock info for a path")
-    async def lock_info(
-        self,
-        path: str,
-        *,
-        context: OperationContext | None = None,  # noqa: ARG002
-    ) -> dict[str, Any] | None:
-        """Get lock info for path (Tier 2 admin query)."""
-        path = self._validate_path(path)
-        info = await self._lock_manager.get_lock_info(path)
-        if info is None:
-            return None
-        return {
-            "path": info.path,
-            "mode": info.mode,
-            "max_holders": info.max_holders,
-            "fence_token": info.fence_token,
-            "holders": [
-                {
-                    "lock_id": h.lock_id,
-                    "holder_info": h.holder_info,
-                    "acquired_at": h.acquired_at,
-                    "expires_at": h.expires_at,
-                }
-                for h in info.holders
-            ],
-        }
-
-    @rpc_expose(description="List active advisory locks")
-    async def lock_list(
-        self,
-        pattern: str = "",
-        limit: int = 100,
-        *,
-        context: OperationContext | None = None,  # noqa: ARG002
-    ) -> dict[str, Any]:
-        """List active advisory locks (Tier 2 admin query)."""
-        locks = await self._lock_manager.list_locks(pattern=pattern, limit=limit)
-        return {
-            "locks": [await self.lock_info(lk.path) for lk in locks],
-            "count": len(locks),
-        }
-
-    @rpc_expose(description="Extend advisory lock TTL (heartbeat)")
-    async def lock_extend(
-        self,
-        lock_id: str,
-        path: str,
-        ttl: float = 60.0,
-        *,
-        context: OperationContext | None = None,  # noqa: ARG002
-    ) -> dict[str, Any]:
-        """Extend lock TTL / heartbeat (Tier 2)."""
-        path = self._validate_path(path)
-        result = await self._lock_manager.extend(lock_id, path, ttl=ttl)
-        return {
-            "success": result.success,
-            "lock_info": (await self.lock_info(path)) if result.lock_info else None,
-        }
-
-    @rpc_expose(description="Force-release all holders of a lock (admin)")
-    async def lock_force_release(
-        self,
-        path: str,
-        *,
-        context: OperationContext | None = None,  # noqa: ARG002
-    ) -> dict[str, Any]:
-        """Force-release all holders (Tier 2 admin operation)."""
-        path = self._validate_path(path)
-        released = await self._lock_manager.force_release(path)
-        return {"released": released}
-
-    @rpc_expose(description="Release a lock (normal or force)")
-    async def lock_release(
-        self,
-        path: str,
-        lock_id: str | None = None,
-        force: bool = False,
-        *,
-        context: OperationContext | None = None,  # noqa: ARG002
-    ) -> dict[str, Any]:
-        """Release a lock — dispatches to sys_unlock or lock_force_release.
-
-        CLI-friendly: single method handles both normal and force release.
-        """
-        if force:
-            return await self.lock_force_release(path)
-        if not lock_id:
-            raise ValueError("lock_id is required for non-force release")
-        released = await self.sys_unlock(path, lock_id)
-        return {"released": released}
 
     @rpc_expose(description="Get available namespaces")
     def get_top_level_mounts(self, context: OperationContext | None = None) -> builtins.list[str]:
@@ -1188,64 +1061,7 @@ class NexusFS(  # type: ignore[misc]
 
             mark_released(L1_VFS)
 
-    # ── Distributed lock helpers (sync bridge for write(lock=True)) ──
-
-    def _acquire_lock_sync(
-        self,
-        path: str,
-        timeout: float,
-        context: OperationContext | None,
-    ) -> str | None:
-        """Acquire advisory lock synchronously via kernel _lock_manager.
-
-        This method bridges sync write() with async lock operations.
-        For async contexts, use `async with nx.locked()` instead.
-        """
-        import asyncio
-
-        from nexus.contracts.exceptions import LockTimeout
-
-        try:
-            asyncio.get_running_loop()
-            raise RuntimeError(
-                "write(lock=True) cannot be used from async context (event loop detected). "
-                "Use `async with nx.locked(path):` and `write(lock=False)` instead."
-            )
-        except RuntimeError as e:
-            if "event loop detected" in str(e):
-                raise
-
-        async def acquire_lock() -> str | None:
-            return await self._lock_manager.acquire(path=path, timeout=timeout)
-
-        from nexus.lib.sync_bridge import run_sync
-
-        lock_id = run_sync(acquire_lock())
-
-        if lock_id is None:
-            raise LockTimeout(path=path, timeout=timeout)
-
-        return lock_id
-
-    def _release_lock_sync(
-        self,
-        lock_id: str,
-        path: str,
-        context: OperationContext | None,
-    ) -> None:
-        """Release advisory lock synchronously via kernel _lock_manager."""
-        if not lock_id:
-            return
-
-        async def release_lock() -> None:
-            await self._lock_manager.release(lock_id, path)
-
-        from nexus.lib.sync_bridge import run_sync
-
-        try:
-            run_sync(release_lock())
-        except Exception as e:
-            logger.error(f"Failed to release lock {lock_id} for {path}: {e}")
+    # _acquire_lock_sync / _release_lock_sync in nexus_fs_lock.py (LockMixin)
 
     async def _resolve_and_read(
         self,

--- a/src/nexus/core/nexus_fs_lock.py
+++ b/src/nexus/core/nexus_fs_lock.py
@@ -1,0 +1,220 @@
+"""LockMixin — Advisory locking syscalls (POSIX flock equivalent).
+
+Tier 1: sys_lock, sys_unlock (single try-acquire / release)
+Tier 2: lock_info, lock_list, lock_extend, lock_force_release, lock_release
+
+Delegates to kernel AdvisoryLockManager (local or Raft-backed).
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING, Any, Literal
+
+from nexus.lib.rpc_decorator import rpc_expose
+
+if TYPE_CHECKING:
+    from nexus.contracts.types import OperationContext
+    from nexus.lib.distributed_lock import AdvisoryLockManager
+
+logger = logging.getLogger(__name__)
+
+
+class LockMixin:
+    """Advisory locking: sys_lock / sys_unlock + Tier 2 helpers."""
+
+    # Provided by NexusFS.__init__
+    _lock_manager: "AdvisoryLockManager"
+
+    def _validate_path(self, path: str, allow_root: bool = False) -> str:  # noqa: ARG002
+        return path  # overridden by NexusFS
+
+    # ── Locking (POSIX flock equivalent) ──────────────────────────
+
+    @rpc_expose(description="Acquire advisory lock on a path")
+    async def sys_lock(
+        self,
+        path: str,
+        mode: str = "exclusive",
+        ttl: float = 30.0,
+        max_holders: int = 1,
+        *,
+        context: "OperationContext | None" = None,  # noqa: ARG002
+    ) -> str | None:
+        """Acquire advisory lock (POSIX flock(2)). Returns lock_id or None.
+
+        Tier 1 syscall — single try-acquire, returns immediately.
+        Use Tier 2 ``lock()`` for blocking wait with retry.
+        """
+        path = self._validate_path(path)
+        _mode: Literal["exclusive", "shared"] = "exclusive" if mode == "exclusive" else "shared"
+        return await self._lock_manager.acquire(
+            path,
+            mode=_mode,
+            ttl=ttl,
+            max_holders=max_holders,
+            timeout=0,  # try-once, no blocking
+        )
+
+    @rpc_expose(description="Release advisory lock")
+    async def sys_unlock(
+        self,
+        path: str,
+        lock_id: str,
+        *,
+        context: "OperationContext | None" = None,  # noqa: ARG002
+    ) -> bool:
+        """Release advisory lock. Returns True if released."""
+        path = self._validate_path(path)
+        return await self._lock_manager.release(lock_id, path)
+
+    @rpc_expose(description="Get advisory lock info for a path")
+    async def lock_info(
+        self,
+        path: str,
+        *,
+        context: "OperationContext | None" = None,  # noqa: ARG002
+    ) -> dict[str, Any] | None:
+        """Get lock info for path (Tier 2 admin query)."""
+        path = self._validate_path(path)
+        info = await self._lock_manager.get_lock_info(path)
+        if info is None:
+            return None
+        return {
+            "path": info.path,
+            "mode": info.mode,
+            "max_holders": info.max_holders,
+            "fence_token": info.fence_token,
+            "holders": [
+                {
+                    "lock_id": h.lock_id,
+                    "holder_info": h.holder_info,
+                    "acquired_at": h.acquired_at,
+                    "expires_at": h.expires_at,
+                }
+                for h in info.holders
+            ],
+        }
+
+    @rpc_expose(description="List active advisory locks")
+    async def lock_list(
+        self,
+        pattern: str = "",
+        limit: int = 100,
+        *,
+        context: "OperationContext | None" = None,  # noqa: ARG002
+    ) -> dict[str, Any]:
+        """List active advisory locks (Tier 2 admin query)."""
+        locks = await self._lock_manager.list_locks(pattern=pattern, limit=limit)
+        return {
+            "locks": [await self.lock_info(lk.path) for lk in locks],
+            "count": len(locks),
+        }
+
+    @rpc_expose(description="Extend advisory lock TTL (heartbeat)")
+    async def lock_extend(
+        self,
+        lock_id: str,
+        path: str,
+        ttl: float = 60.0,
+        *,
+        context: "OperationContext | None" = None,  # noqa: ARG002
+    ) -> dict[str, Any]:
+        """Extend lock TTL / heartbeat (Tier 2)."""
+        path = self._validate_path(path)
+        result = await self._lock_manager.extend(lock_id, path, ttl=ttl)
+        return {
+            "success": result.success,
+            "lock_info": (await self.lock_info(path)) if result.lock_info else None,
+        }
+
+    @rpc_expose(description="Force-release all holders of a lock (admin)")
+    async def lock_force_release(
+        self,
+        path: str,
+        *,
+        context: "OperationContext | None" = None,  # noqa: ARG002
+    ) -> dict[str, Any]:
+        """Force-release all holders (Tier 2 admin operation)."""
+        path = self._validate_path(path)
+        released = await self._lock_manager.force_release(path)
+        return {"released": released}
+
+    @rpc_expose(description="Release a lock (normal or force)")
+    async def lock_release(
+        self,
+        path: str,
+        lock_id: str | None = None,
+        force: bool = False,
+        *,
+        context: "OperationContext | None" = None,  # noqa: ARG002
+    ) -> dict[str, Any]:
+        """Release a lock — dispatches to sys_unlock or lock_force_release.
+
+        CLI-friendly: single method handles both normal and force release.
+        """
+        if force:
+            return await self.lock_force_release(path)
+        if not lock_id:
+            raise ValueError("lock_id is required for non-force release")
+        released = await self.sys_unlock(path, lock_id)
+        return {"released": released}
+
+    # ── Distributed lock helpers (sync bridge for write(lock=True)) ──
+
+    def _acquire_lock_sync(
+        self,
+        path: str,
+        timeout: float,
+        context: "OperationContext | None",  # noqa: ARG002
+    ) -> str | None:
+        """Acquire advisory lock synchronously via kernel _lock_manager.
+
+        This method bridges sync write() with async lock operations.
+        For async contexts, use `async with nx.locked()` instead.
+        """
+        import asyncio
+
+        from nexus.contracts.exceptions import LockTimeout
+
+        try:
+            asyncio.get_running_loop()
+            raise RuntimeError(
+                "write(lock=True) cannot be used from async context (event loop detected). "
+                "Use `async with nx.locked(path):` and `write(lock=False)` instead."
+            )
+        except RuntimeError as e:
+            if "event loop detected" in str(e):
+                raise
+
+        async def acquire_lock() -> str | None:
+            return await self._lock_manager.acquire(path=path, timeout=timeout)
+
+        from nexus.lib.sync_bridge import run_sync
+
+        lock_id = run_sync(acquire_lock())
+
+        if lock_id is None:
+            raise LockTimeout(path=path, timeout=timeout)
+
+        return lock_id
+
+    def _release_lock_sync(
+        self,
+        lock_id: str,
+        path: str,
+        context: "OperationContext | None",  # noqa: ARG002
+    ) -> None:
+        """Release advisory lock synchronously via kernel _lock_manager."""
+        if not lock_id:
+            return
+
+        async def release_lock() -> None:
+            await self._lock_manager.release(lock_id, path)
+
+        from nexus.lib.sync_bridge import run_sync
+
+        try:
+            run_sync(release_lock())
+        except Exception as e:
+            logger.error(f"Failed to release lock {lock_id} for {path}: {e}")

--- a/src/nexus/core/nexus_fs_watch.py
+++ b/src/nexus/core/nexus_fs_watch.py
@@ -1,0 +1,51 @@
+"""WatchMixin — File watching syscall (inotify equivalent).
+
+Tier 1: sys_watch (blocking wait for file changes)
+
+Delegates to kernel FileWatcher primitive which races local OBSERVE
+(in-memory futures, ~0µs) and optional remote watcher (federation).
+"""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.core.path_utils import validate_path
+from nexus.lib.rpc_decorator import rpc_expose
+
+if TYPE_CHECKING:
+    from nexus.contracts.types import OperationContext
+    from nexus.core.file_watcher import FileWatcher
+
+
+class WatchMixin:
+    """File watching: sys_watch → FileWatcher."""
+
+    # Provided by NexusFS.__init__
+    _file_watcher: "FileWatcher"
+
+    def _resolve_cred(self, context: Any) -> Any: ...
+
+    @rpc_expose(description="Wait for file changes on a path")
+    async def sys_watch(
+        self,
+        path: str,
+        timeout: float = 30.0,
+        *,
+        recursive: bool = False,  # noqa: ARG002
+        context: "OperationContext | None" = None,
+    ) -> dict[str, Any] | None:
+        """Wait for file changes (inotify(7)). Returns FileEvent dict or None on timeout.
+
+        Delegates to kernel FileWatcher which races local OBSERVE + optional
+        remote watcher (federation) via FIRST_COMPLETED.
+        """
+        path = validate_path(path, allow_root=True)
+        ctx = self._resolve_cred(context)
+        zone_id: str = getattr(ctx, "zone_id", None) or ROOT_ZONE_ID
+        event = await self._file_watcher.wait(path, timeout=timeout, zone_id=zone_id)
+        if event is None:
+            return None
+        result: dict[str, Any] = event.to_dict()
+        return result


### PR DESCRIPTION
## Summary

Begin NexusFS mixin split — extract Watch and Lock operations into separate files.

### New files
- `core/nexus_fs_watch.py` — **WatchMixin**: `sys_watch` (~50 lines)
- `core/nexus_fs_lock.py` — **LockMixin**: `sys_lock`, `sys_unlock`, `lock_info`, `lock_list`, `lock_extend`, `lock_force_release`, `lock_release`, `_acquire_lock_sync`, `_release_lock_sync` (~220 lines)

### Pattern
- Mixins are plain classes with `TYPE_CHECKING` stubs for kernel primitives
- Listed before `NexusFilesystemABC` in MRO (required for abstract method resolution)
- No `type: ignore` — proper typing via protocol stubs
- `@rpc_expose` decorators stay on mixin methods (auto-discovered)

### Follow-up
Remaining extractions (ContentMixin ~1200 lines, MetadataMixin ~1800 lines, IPCMixin ~200 lines, InternalMixin ~500 lines) will be done in subsequent PRs following the same pattern.

## Test plan

- [x] `pytest tests/unit/core/test_factory_boot.py tests/unit/test_factory.py` — 45 passed
- [x] `pytest tests/unit/lib/test_advisory_lock_manager.py` — 20 passed
- [x] All pre-commit hooks pass (ruff, mypy, brick boundary)
- [x] Import check: `from nexus.core.nexus_fs import NexusFS; NexusFS.sys_watch; NexusFS.sys_lock`

🤖 Generated with [Claude Code](https://claude.com/claude-code)