### PR TITLE
feat: add batch_write_content + batch_delete_content to ObjectStoreABC

### DIFF
--- a/src/nexus/backends/base/path_addressing_engine.py
+++ b/src/nexus/backends/base/path_addressing_engine.py
@@ -364,6 +364,79 @@ class PathAddressingEngine(Backend):
                 results[path] = None
         return results
 
+    def batch_write_content(
+        self,
+        items: list[tuple[str, bytes]],
+        context: "OperationContext | None" = None,
+        *,
+        contexts: "dict[str, OperationContext] | None" = None,
+    ) -> dict[str, "WriteResult | None"]:
+        if not items:
+            return {}
+
+        if len(items) == 1:
+            cid, data = items[0]
+            try:
+                return {cid: self.write_content(data, cid, context=context)}
+            except Exception:
+                return {cid: None}
+
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        def _write_one(cid: str, data: bytes) -> tuple[str, "WriteResult | None"]:
+            try:
+                ctx = contexts.get(cid, context) if contexts else context
+                return (cid, self.write_content(data, cid, context=ctx))
+            except Exception:
+                return (cid, None)
+
+        max_workers = min(8, len(items))
+        result: dict[str, WriteResult | None] = {}
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {executor.submit(_write_one, cid, data): cid for cid, data in items}
+            for future in as_completed(futures):
+                cid, wr = future.result()
+                result[cid] = wr
+
+        return result
+
+    def batch_delete_content(
+        self,
+        content_ids: list[str],
+        context: "OperationContext | None" = None,
+        *,
+        contexts: "dict[str, OperationContext] | None" = None,
+    ) -> dict[str, bool]:
+        if not content_ids:
+            return {}
+
+        if len(content_ids) == 1:
+            try:
+                self.delete_content(content_ids[0], context=context)
+                return {content_ids[0]: True}
+            except Exception:
+                return {content_ids[0]: False}
+
+        from concurrent.futures import ThreadPoolExecutor, as_completed
+
+        def _delete_one(cid: str) -> tuple[str, bool]:
+            try:
+                ctx = contexts.get(cid, context) if contexts else context
+                self.delete_content(cid, context=ctx)
+                return (cid, True)
+            except Exception:
+                return (cid, False)
+
+        max_workers = min(8, len(content_ids))
+        result: dict[str, bool] = {}
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
+            futures = {executor.submit(_delete_one, cid): cid for cid in content_ids}
+            for future in as_completed(futures):
+                cid, ok = future.result()
+                result[cid] = ok
+
+        return result
+
     # === Directory Operations ===
 
     def mkdir(

--- a/src/nexus/core/object_store.py
+++ b/src/nexus/core/object_store.py
@@ -284,6 +284,69 @@ class ObjectStoreABC(ABC):
                 result[content_id] = None
         return result
 
+    def batch_write_content(
+        self,
+        items: list[tuple[str, bytes]],
+        context: OperationContext | None = None,
+        *,
+        contexts: dict[str, OperationContext] | None = None,
+    ) -> dict[str, WriteResult | None]:
+        """Write multiple content items in a single batch.
+
+        Default implementation calls ``write_content()`` for each item.
+        Backends should override for better performance (e.g. batch RPCs).
+
+        Args:
+            items: List of ``(content_id, data)`` tuples. For CAS backends
+                content_id is ignored; for PAS backends it is the blob path.
+            context: Shared operation context (fallback).
+            contexts: Per-id operation contexts mapping
+                ``content_id -> OperationContext``.
+
+        Returns:
+            Dict mapping ``content_id -> WriteResult | None``.
+            ``None`` indicates a failed write for that item.
+        """
+        result: dict[str, WriteResult | None] = {}
+        for content_id, data in items:
+            ctx = contexts.get(content_id, context) if contexts else context
+            try:
+                result[content_id] = self.write_content(data, content_id, context=ctx)
+            except Exception:
+                result[content_id] = None
+        return result
+
+    def batch_delete_content(
+        self,
+        content_ids: list[str],
+        context: OperationContext | None = None,
+        *,
+        contexts: dict[str, OperationContext] | None = None,
+    ) -> dict[str, bool]:
+        """Delete multiple content items in a single batch.
+
+        Default implementation calls ``delete_content()`` for each id.
+        Backends should override for better performance (e.g. batch RPCs).
+
+        Args:
+            content_ids: List of opaque content identifiers.
+            context: Shared operation context (fallback).
+            contexts: Per-id operation contexts mapping
+                ``content_id -> OperationContext``.
+
+        Returns:
+            Dict mapping ``content_id -> bool`` (True = deleted, False = failed).
+        """
+        result: dict[str, bool] = {}
+        for content_id in content_ids:
+            ctx = contexts.get(content_id, context) if contexts else context
+            try:
+                self.delete_content(content_id, context=ctx)
+                result[content_id] = True
+            except Exception:
+                result[content_id] = False
+        return result
+
     # === Lifecycle ===
 
     def close(self) -> None:  # noqa: B027


### PR DESCRIPTION
## Summary
Add batch write and batch delete to ObjectStoreABC, completing the batch trio:

| Method | ObjectStoreABC (default) | PathAddressingEngine (override) |
|--------|------------------------|-------------------------------|
| `batch_read_content` | sequential loop | ThreadPool (existing) |
| `batch_write_content` | sequential loop (NEW) | ThreadPool (NEW) |
| `batch_delete_content` | sequential loop (NEW) | ThreadPool (NEW) |

Connectors can override for native batch APIs (e.g., Gmail batch API).

## Test plan
- [x] Ruff + mypy clean
- [x] Pre-commit hooks pass
- [x] Methods accessible on both ObjectStoreABC and PathAddressingEngine
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)