### PR TITLE
feat: Gmail inline base64 attachment support

### DIFF
--- a/src/nexus/backends/connectors/gmail/README.md
+++ b/src/nexus/backends/connectors/gmail/README.md
@@ -151,7 +151,7 @@ thread_id: "18c1234567890abc"  # Optional: for reply drafts
 
 Note: Drafts don't require `confirm: true` since they're not sent.
 
-### With Attachments
+### With Attachments (Inline Base64)
 
 ```yaml
 # agent_intent: User requested to send email with report attachment
@@ -165,11 +165,15 @@ body: |
 
   Best regards
 attachments:
-  - path: /mnt/storage/reports/q4-report.pdf
-    filename: Q4-Report-2024.pdf  # Optional: override filename
-    content_type: application/pdf  # Optional: auto-detected if not set
+  - data: JVBERi0xLjQK...  # base64-encoded file content
+    filename: Q4-Report-2024.pdf  # Required for inline attachments
+    content_type: application/pdf  # Optional: auto-detected from filename
 confirm: true
 ```
+
+Note: Attachments use inline base64 encoding. To attach a file, first read it
+and base64-encode the content into the `data` field. The `filename` field is
+required for inline attachments.
 
 ## Required Format
 

--- a/src/nexus/backends/connectors/gmail/schemas.py
+++ b/src/nexus/backends/connectors/gmail/schemas.py
@@ -42,19 +42,41 @@ class Recipient(BaseModel):
 
 
 class Attachment(BaseModel):
-    """Email attachment reference.
+    """Email attachment — inline base64 data or filesystem path reference.
 
-    For sending, attachments can reference files from the mounted filesystem.
+    Inline mode (preferred):
+        data: base64-encoded file content
+        filename: required when using data
+
+    Path mode (requires kernel VFS access — not yet supported):
+        path: VFS path to attachment file
     """
 
-    path: Annotated[str, Field(description="Path to attachment file in mounted filesystem")]
+    path: Annotated[
+        str | None,
+        Field(default=None, description="Path to attachment file in mounted filesystem (future)"),
+    ]
+    data: Annotated[
+        str | None,
+        Field(default=None, description="Base64-encoded file content (inline attachment)"),
+    ]
     filename: Annotated[
-        str | None, Field(default=None, description="Override filename (uses basename if not set)")
+        str | None,
+        Field(default=None, description="Filename (required for inline, optional for path)"),
     ]
     content_type: Annotated[
         str | None,
-        Field(default=None, description="MIME type (auto-detected if not set)"),
+        Field(default=None, description="MIME type (auto-detected from filename if not set)"),
     ]
+
+    @model_validator(mode="after")
+    def validate_attachment_source(self) -> "Attachment":
+        """Ensure either data or path is provided, and filename is set for inline."""
+        if not self.data and not self.path:
+            raise ValueError("Attachment requires either 'data' (base64) or 'path'")
+        if self.data and not self.filename:
+            raise ValueError("Attachment with inline 'data' requires 'filename'")
+        return self
 
 
 class SendEmailSchema(BaseModel):

--- a/src/nexus/backends/connectors/gmail/transport.py
+++ b/src/nexus/backends/connectors/gmail/transport.py
@@ -354,8 +354,11 @@ class GmailTransport:
     def _build_mime_message(self, data: dict[str, Any]) -> EmailMessage:
         """Build a new MIME message from parsed YAML data.
 
-        Handles To, Cc, Bcc, Subject, plain-text body, and optional HTML alternative.
+        Handles To, Cc, Bcc, Subject, plain-text body, optional HTML
+        alternative, and inline base64 attachments.
         """
+        import mimetypes as _mt
+
         msg = EmailMessage()
         msg["From"] = data.get("from", self._resolve_from_address())
 
@@ -389,6 +392,27 @@ class GmailTransport:
             msg.add_alternative(html_body, subtype="html")
         else:
             msg.set_content(body_text)
+
+        # Attachments (inline base64 data)
+        attachments = data.get("attachments") or []
+        for att in attachments:
+            if isinstance(att, dict):
+                att_data_b64 = att.get("data")
+                if not att_data_b64:
+                    continue  # path-based attachments not yet supported
+                file_bytes = base64.b64decode(att_data_b64)
+                filename = att.get("filename") or "attachment"
+                content_type = att.get("content_type")
+                if not content_type:
+                    content_type, _ = _mt.guess_type(filename)
+                    content_type = content_type or "application/octet-stream"
+                maintype, _, subtype = content_type.partition("/")
+                msg.add_attachment(
+                    file_bytes,
+                    maintype=maintype,
+                    subtype=subtype or "octet-stream",
+                    filename=filename,
+                )
 
         return msg
 

--- a/tests/e2e/self_contained/test_gmail_connector.py
+++ b/tests/e2e/self_contained/test_gmail_connector.py
@@ -830,6 +830,76 @@ class TestMimeBuilding:
         parsed = message_from_bytes(decoded)
         assert parsed["Subject"] == "Encoding Test"
 
+    def test_build_mime_with_inline_attachment(self, transport):
+        """Test MIME message with inline base64 attachment."""
+        file_content = b"Hello, this is a test file."
+        data = {
+            "to": ["test@example.com"],
+            "subject": "With Attachment",
+            "body": "See attached.",
+            "attachments": [
+                {
+                    "data": base64.b64encode(file_content).decode(),
+                    "filename": "test.txt",
+                    "content_type": "text/plain",
+                },
+            ],
+        }
+
+        msg = transport._build_mime_message(data)
+        raw_bytes = msg.as_bytes()
+        parsed = message_from_bytes(raw_bytes)
+
+        # Should be multipart/mixed (body + attachment)
+        assert parsed.is_multipart()
+        parts = list(parsed.walk())
+        # Find the attachment part
+        attachment_parts = [p for p in parts if p.get_filename() == "test.txt"]
+        assert len(attachment_parts) == 1
+        assert attachment_parts[0].get_payload(decode=True) == file_content
+
+    def test_build_mime_with_multiple_attachments(self, transport):
+        """Test MIME message with multiple attachments."""
+        data = {
+            "to": ["test@example.com"],
+            "subject": "Multi Attach",
+            "body": "Two files.",
+            "attachments": [
+                {
+                    "data": base64.b64encode(b"file1").decode(),
+                    "filename": "a.txt",
+                },
+                {
+                    "data": base64.b64encode(b"file2").decode(),
+                    "filename": "b.pdf",
+                    "content_type": "application/pdf",
+                },
+            ],
+        }
+
+        msg = transport._build_mime_message(data)
+        parts = list(msg.walk())
+        filenames = [p.get_filename() for p in parts if p.get_filename()]
+        assert "a.txt" in filenames
+        assert "b.pdf" in filenames
+
+    def test_build_mime_skips_path_only_attachment(self, transport):
+        """Test that path-only attachments (no data) are skipped gracefully."""
+        data = {
+            "to": ["test@example.com"],
+            "subject": "Path Only",
+            "body": "No inline data.",
+            "attachments": [
+                {"path": "/mnt/storage/file.pdf", "filename": "file.pdf"},
+            ],
+        }
+
+        msg = transport._build_mime_message(data)
+        # Should not crash, attachment skipped (path-based not yet supported)
+        parts = list(msg.walk())
+        filenames = [p.get_filename() for p in parts if p.get_filename()]
+        assert len(filenames) == 0
+
 
 # ============================================================================
 # LIST DIR WITH DRAFTS / TRASH TESTS
@@ -969,6 +1039,44 @@ class TestYamlParsing:
 
         assert result["agent_intent"] == "Inline intent field"
         assert result["to"] == ["bob@example.com"]
+
+
+# ============================================================================
+# ATTACHMENT SCHEMA TESTS
+# ============================================================================
+
+
+class TestAttachmentSchema:
+    """Test Attachment model validation."""
+
+    def test_inline_attachment_valid(self):
+        """Test valid inline attachment with data + filename."""
+        from nexus.backends.connectors.gmail.schemas import Attachment
+
+        att = Attachment(data="SGVsbG8=", filename="test.txt")
+        assert att.data == "SGVsbG8="
+        assert att.filename == "test.txt"
+
+    def test_inline_attachment_requires_filename(self):
+        """Test that inline data without filename raises."""
+        from nexus.backends.connectors.gmail.schemas import Attachment
+
+        with pytest.raises(PydanticValidationError):
+            Attachment(data="SGVsbG8=")
+
+    def test_path_attachment_valid(self):
+        """Test valid path-based attachment."""
+        from nexus.backends.connectors.gmail.schemas import Attachment
+
+        att = Attachment(path="/mnt/storage/file.pdf")
+        assert att.path == "/mnt/storage/file.pdf"
+
+    def test_no_source_raises(self):
+        """Test that attachment with neither data nor path raises."""
+        from nexus.backends.connectors.gmail.schemas import Attachment
+
+        with pytest.raises(PydanticValidationError):
+            Attachment(filename="orphan.txt")
 
 
 # ============================================================================


### PR DESCRIPTION
## Summary
- Extend `Attachment` schema: new `data` field for inline base64 content (alongside existing `path`)
- `GmailTransport._build_mime_message()` builds multipart/mixed MIME with attachments
- Auto-detects MIME type from filename, falls back to `application/octet-stream`
- Path-based attachments gracefully skipped (needs kernel VFS cross-mount access — future work)
- README.md updated with inline attachment example

## Test plan
- [x] 62/62 tests pass (55 existing + 7 new attachment tests)
- [x] Ruff + mypy clean
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)