### PR TITLE
fix: delete dead _vfs_revision counter and threading.Lock

### DIFF
--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -116,12 +116,6 @@ class NexusFS(  # type: ignore[misc]
         memory = memory or MemoryConfig()
         parsing = parsing or ParseConfig()
 
-        # Per-instance VFS revision counter (H21: must not be class-level)
-        import threading as _threading
-
-        self._vfs_revision: int = 0
-        self._vfs_revision_lock = _threading.Lock()
-
         self._cache_config = cache
         self._perm_config = permissions
         self._distributed_config = distributed


### PR DESCRIPTION
## Summary
- Delete `_vfs_revision` (int) and `_vfs_revision_lock` (threading.Lock) from NexusFS.__init__
- Dead code since Issue #1382 — replaced by RevisionTrackingObserver + RevisionNotifier

## Test plan
- [x] Pre-commit (mypy, ruff) pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)