### PR TITLE
refactor: add metadata routing to KernelDispatch (resolve_get/put/list)

### DIFF
--- a/src/nexus/contracts/vfs_hooks.py
+++ b/src/nexus/contracts/vfs_hooks.py
@@ -354,23 +354,11 @@ class VFSPathResolver(Protocol):
     def try_delete(self, path: str, *, context: Any = None) -> dict[str, Any] | None: ...
 
     # Metadata routing (Linux inode_operations.setattr analogue)
-    # Optional — resolvers that don't handle metadata return None (default).
-    def try_get(self, path: str) -> Any | None:  # noqa: ARG002
-        """Route metadata read to correct store. Returns FileMetadata or None."""
-        return None
-
-    def try_put(self, path: str, metadata: Any) -> int | None:  # noqa: ARG002
-        """Route metadata write to correct store. Returns write token or None."""
-        return None
-
-    def try_list(
-        self,
-        prefix: str,  # noqa: ARG002
-        recursive: bool = True,  # noqa: ARG002
-        **kwargs: Any,  # noqa: ARG002
-    ) -> list[Any] | None:
-        """Route metadata list to correct store(s). Returns list or None."""
-        return None
+    # Optional — resolvers that don't handle metadata can omit these.
+    # KernelDispatch uses getattr() with fallback, so missing methods = no-op.
+    def try_get(self, path: str) -> Any | None: ...
+    def try_put(self, path: str, metadata: Any) -> int | None: ...
+    def try_list(self, prefix: str, recursive: bool = True, **kwargs: Any) -> list[Any] | None: ...
 
 
 # ---------------------------------------------------------------------------

--- a/src/nexus/contracts/vfs_hooks.py
+++ b/src/nexus/contracts/vfs_hooks.py
@@ -353,12 +353,10 @@ class VFSPathResolver(Protocol):
     def try_write(self, path: str, content: bytes) -> dict[str, Any] | None: ...
     def try_delete(self, path: str, *, context: Any = None) -> dict[str, Any] | None: ...
 
-    # Metadata routing (Linux inode_operations.setattr analogue)
-    # Optional — resolvers that don't handle metadata can omit these.
-    # KernelDispatch uses getattr() with fallback, so missing methods = no-op.
-    def try_get(self, path: str) -> Any | None: ...
-    def try_put(self, path: str, metadata: Any) -> int | None: ...
-    def try_list(self, prefix: str, recursive: bool = True, **kwargs: Any) -> list[Any] | None: ...
+    # Metadata routing (Linux inode_operations.setattr analogue).
+    # Optional — resolvers that handle metadata implement try_get/try_put/try_list.
+    # KernelDispatch uses getattr() with lambda fallback, so missing = no-op.
+    # NOT declared here to avoid mypy treating them as abstract.
 
 
 # ---------------------------------------------------------------------------

--- a/src/nexus/contracts/vfs_hooks.py
+++ b/src/nexus/contracts/vfs_hooks.py
@@ -355,15 +355,20 @@ class VFSPathResolver(Protocol):
 
     # Metadata routing (Linux inode_operations.setattr analogue)
     # Optional — resolvers that don't handle metadata return None (default).
-    def try_get(self, path: str) -> Any | None:
+    def try_get(self, path: str) -> Any | None:  # noqa: ARG002
         """Route metadata read to correct store. Returns FileMetadata or None."""
         return None
 
-    def try_put(self, path: str, metadata: Any) -> int | None:
+    def try_put(self, path: str, metadata: Any) -> int | None:  # noqa: ARG002
         """Route metadata write to correct store. Returns write token or None."""
         return None
 
-    def try_list(self, prefix: str, recursive: bool = True, **kwargs: Any) -> list[Any] | None:
+    def try_list(
+        self,
+        prefix: str,  # noqa: ARG002
+        recursive: bool = True,  # noqa: ARG002
+        **kwargs: Any,  # noqa: ARG002
+    ) -> list[Any] | None:
         """Route metadata list to correct store(s). Returns list or None."""
         return None
 

--- a/src/nexus/contracts/vfs_hooks.py
+++ b/src/nexus/contracts/vfs_hooks.py
@@ -354,9 +354,23 @@ class VFSPathResolver(Protocol):
     def try_delete(self, path: str, *, context: Any = None) -> dict[str, Any] | None: ...
 
     # Metadata routing (Linux inode_operations.setattr analogue).
-    # Optional — resolvers that handle metadata implement try_get/try_put/try_list.
-    # KernelDispatch uses getattr() with lambda fallback, so missing = no-op.
-    # NOT declared here to avoid mypy treating them as abstract.
+    # Default returns None = "not handled, pass to next resolver".
+    def try_get(self, path: str) -> Any | None:  # noqa: ARG002
+        """Route metadata read to correct store. Returns FileMetadata or None."""
+        return None
+
+    def try_put(self, path: str, metadata: Any) -> int | None:  # noqa: ARG002
+        """Route metadata write to correct store. Returns write token or None."""
+        return None
+
+    def try_list(
+        self,
+        prefix: str,  # noqa: ARG002
+        recursive: bool = True,  # noqa: ARG002
+        **kwargs: Any,  # noqa: ARG002
+    ) -> list[Any] | None:
+        """Route metadata list to correct store(s). Returns list or None."""
+        return None
 
 
 # ---------------------------------------------------------------------------

--- a/src/nexus/contracts/vfs_hooks.py
+++ b/src/nexus/contracts/vfs_hooks.py
@@ -348,9 +348,24 @@ class VFSPathResolver(Protocol):
     chain = no-op = zero overhead when no resolvers registered.
     """
 
+    # Content I/O routing
     def try_read(self, path: str, *, context: Any = None) -> bytes | None: ...
     def try_write(self, path: str, content: bytes) -> dict[str, Any] | None: ...
     def try_delete(self, path: str, *, context: Any = None) -> dict[str, Any] | None: ...
+
+    # Metadata routing (Linux inode_operations.setattr analogue)
+    # Optional — resolvers that don't handle metadata return None (default).
+    def try_get(self, path: str) -> Any | None:
+        """Route metadata read to correct store. Returns FileMetadata or None."""
+        return None
+
+    def try_put(self, path: str, metadata: Any) -> int | None:
+        """Route metadata write to correct store. Returns write token or None."""
+        return None
+
+    def try_list(self, prefix: str, recursive: bool = True, **kwargs: Any) -> list[Any] | None:
+        """Route metadata list to correct store(s). Returns list or None."""
+        return None
 
 
 # ---------------------------------------------------------------------------

--- a/src/nexus/core/kernel_dispatch.py
+++ b/src/nexus/core/kernel_dispatch.py
@@ -345,7 +345,7 @@ class KernelDispatch:
         in federation mode. Non-federation = no resolvers = no-op.
         """
         for r in self._fallback_resolvers:
-            result = getattr(r, "try_get", lambda _p: None)(path)
+            result = r.try_get(path)
             if result is not None:
                 return True, result
         return False, None
@@ -357,7 +357,7 @@ class KernelDispatch:
         (True, write_token) when handled, (False, None) otherwise.
         """
         for r in self._fallback_resolvers:
-            result = getattr(r, "try_put", lambda _p, _m: None)(path, metadata)
+            result = r.try_put(path, metadata)
             if result is not None:
                 return True, result
         return False, None
@@ -370,9 +370,7 @@ class KernelDispatch:
         Routes metadata.list() across zone boundaries (BFS mount traversal).
         """
         for r in self._fallback_resolvers:
-            result = getattr(r, "try_list", lambda _p, **_kw: None)(
-                prefix, recursive=recursive, **kwargs
-            )
+            result = r.try_list(prefix, recursive=recursive, **kwargs)
             if result is not None:
                 return True, result
         return False, None

--- a/src/nexus/core/kernel_dispatch.py
+++ b/src/nexus/core/kernel_dispatch.py
@@ -345,7 +345,7 @@ class KernelDispatch:
         in federation mode. Non-federation = no resolvers = no-op.
         """
         for r in self._fallback_resolvers:
-            result = getattr(r, "try_get", lambda p: None)(path)
+            result = getattr(r, "try_get", lambda _p: None)(path)
             if result is not None:
                 return True, result
         return False, None
@@ -357,7 +357,7 @@ class KernelDispatch:
         (True, write_token) when handled, (False, None) otherwise.
         """
         for r in self._fallback_resolvers:
-            result = getattr(r, "try_put", lambda p, m: None)(path, metadata)
+            result = getattr(r, "try_put", lambda _p, _m: None)(path, metadata)
             if result is not None:
                 return True, result
         return False, None
@@ -370,7 +370,7 @@ class KernelDispatch:
         Routes metadata.list() across zone boundaries (BFS mount traversal).
         """
         for r in self._fallback_resolvers:
-            result = getattr(r, "try_list", lambda p, **kw: None)(
+            result = getattr(r, "try_list", lambda _p, **_kw: None)(
                 prefix, recursive=recursive, **kwargs
             )
             if result is not None:

--- a/src/nexus/core/kernel_dispatch.py
+++ b/src/nexus/core/kernel_dispatch.py
@@ -336,6 +336,47 @@ class KernelDispatch:
                 return True, result
         return False, None
 
+    # ── Metadata routing (Linux inode_operations.setattr analogue) ───
+
+    def resolve_get(self, path: str) -> tuple[bool, Any]:
+        """PRE-DISPATCH: first-match resolver for metadata read.
+
+        Used by MetastoreABC.get() to route to the correct zone store
+        in federation mode. Non-federation = no resolvers = no-op.
+        """
+        for r in self._fallback_resolvers:
+            result = getattr(r, "try_get", lambda p: None)(path)
+            if result is not None:
+                return True, result
+        return False, None
+
+    def resolve_put(self, path: str, metadata: Any) -> tuple[bool, Any]:
+        """PRE-DISPATCH: first-match resolver for metadata write.
+
+        Routes metadata.put() to the correct zone store. Returns
+        (True, write_token) when handled, (False, None) otherwise.
+        """
+        for r in self._fallback_resolvers:
+            result = getattr(r, "try_put", lambda p, m: None)(path, metadata)
+            if result is not None:
+                return True, result
+        return False, None
+
+    def resolve_list(
+        self, prefix: str, recursive: bool = True, **kwargs: Any
+    ) -> tuple[bool, list[Any] | None]:
+        """PRE-DISPATCH: first-match resolver for metadata list.
+
+        Routes metadata.list() across zone boundaries (BFS mount traversal).
+        """
+        for r in self._fallback_resolvers:
+            result = getattr(r, "try_list", lambda p, **kw: None)(
+                prefix, recursive=recursive, **kwargs
+            )
+            if result is not None:
+                return True, result
+        return False, None
+
     @property
     def resolver_count(self) -> int:
         return len(self._trie_resolvers) + len(self._fallback_resolvers)


### PR DESCRIPTION
## Summary
- Extend `VFSPathResolver` protocol with `try_get()`, `try_put()`, `try_list()` for metadata routing
- Add `resolve_get()`, `resolve_put()`, `resolve_list()` to `KernelDispatch`
- Linux analogue: `inode_operations.setattr` — metadata write hooks at dispatch layer

## Why
Prepares for FederatedMetadataProxy → FederationResolver merger. Currently zone routing for metadata writes lives in a MetastoreABC wrapper (FederatedMetadataProxy), while content routing lives in KernelDispatch resolvers. This PR adds the dispatch hooks so both can live in one place.

Non-federation mode: no resolvers = zero overhead (empty fallback list iteration).

## Test plan
- [x] Pre-commit hooks pass
- [ ] CI green — no behavior change (new methods unused until FederationResolver PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)