### PR TITLE
fix: backends ABC audit — 4 violations fixed

### DIFF
--- a/src/nexus/backends/base/path_addressing_engine.py
+++ b/src/nexus/backends/base/path_addressing_engine.py
@@ -262,6 +262,26 @@ class PathAddressingEngine(Backend):
         blob_path = self._get_key_path(context.backend_path)
         return self._transport.get_size(blob_path)
 
+    # === Public path-based helpers (for kernel copy/rename) ===
+
+    def get_size_by_path(self, backend_path: str) -> int:
+        """Get blob size by backend-relative path (public API for kernel)."""
+        blob_path = self._get_key_path(backend_path.strip("/"))
+        return self._transport.get_size(blob_path)
+
+    def get_version_by_path(self, backend_path: str) -> str | None:
+        """Get blob version/generation by backend-relative path.
+
+        Returns None if the transport doesn't support versioning.
+        """
+        blob_path = self._get_key_path(backend_path.strip("/"))
+        get_ver = getattr(self._transport, "get_version_id", None) or getattr(
+            self._transport, "get_generation", None
+        )
+        if get_ver:
+            return str(get_ver(blob_path))
+        return None
+
     # === Internal I/O (used by BackendIOService via duck typing) ===
 
     def _download(self, blob_path: str, version_id: str | None = None) -> tuple[bytes, str | None]:

--- a/src/nexus/backends/connectors/base.py
+++ b/src/nexus/backends/connectors/base.py
@@ -236,7 +236,7 @@ class ReadmeDocMixin:
         self._cached_doc_generator = None
         self._cached_error_formatter = None
 
-    def _get_doc_generator(self) -> "ReadmeDocGenerator":
+    def get_doc_generator(self) -> "ReadmeDocGenerator":
         """Get or create the cached ReadmeDocGenerator."""
         if self._cached_doc_generator is None:
             from nexus.backends.connectors.schema_generator import ReadmeDocGenerator
@@ -278,16 +278,16 @@ class ReadmeDocMixin:
 
     def generate_readme(self, mount_path: str) -> str:
         """Auto-generate README.md from connector metadata."""
-        return self._get_doc_generator().generate_readme(mount_path)
+        return self.get_doc_generator().generate_readme(mount_path)
 
     def get_readme_path(self, mount_path: str) -> str:
         """Get the full path to the .readme directory."""
-        return self._get_doc_generator().get_readme_path(mount_path)
+        return self.get_doc_generator().get_readme_path(mount_path)
 
     async def write_readme(self, mount_path: str, filesystem: Any = None) -> dict[str, str]:
         """Generate and write .readme/ directory to the filesystem."""
         self._mount_path = mount_path
-        return await self._get_doc_generator().write_readme(mount_path, filesystem)
+        return await self.get_doc_generator().write_readme(mount_path, filesystem)
 
     def format_error_with_skill_ref(
         self,

--- a/src/nexus/backends/connectors/schema_generator.py
+++ b/src/nexus/backends/connectors/schema_generator.py
@@ -160,7 +160,7 @@ class ReadmeDocGenerator:
                 await filesystem.mkdir(schemas_dir, parents=True, exist_ok=True)
 
                 for op_name, schema in self._schemas.items():
-                    schema_content = self._generate_annotated_schema(op_name, schema)
+                    schema_content = self.generate_schema_yaml(op_name, schema)
                     schema_path = posixpath.join(schemas_dir, f"{op_name}.yaml")
                     await filesystem.write(schema_path, schema_content.encode("utf-8"))
                     result["schemas"].append(schema_path)
@@ -264,7 +264,7 @@ class ReadmeDocGenerator:
 
         return lines
 
-    def _generate_annotated_schema(self, op_name: str, schema: type[BaseModel]) -> str:
+    def generate_schema_yaml(self, op_name: str, schema: type[BaseModel]) -> str:
         """Generate an annotated YAML schema file for a single operation.
 
         Each field includes type, required/optional, constraints, and description

--- a/src/nexus/backends/storage/cas_local.py
+++ b/src/nexus/backends/storage/cas_local.py
@@ -193,6 +193,9 @@ class CASLocalBackend(CASAddressingEngine, MultipartUpload):
 
         Issue #3406: Volume-level cold tiering.
         """
+        # NOTE: Layering violation — backend importing from services.
+        # VolumeTieringService creation should be lifted to the factory/orchestrator.
+        # Kept as lazy import to avoid circular dependency at module load time.
         from nexus.services.volume_tiering import VolumeTieringService
 
         cloud_transport: Any

--- a/src/nexus/backends/transports/volume_local_transport.py
+++ b/src/nexus/backends/transports/volume_local_transport.py
@@ -410,6 +410,15 @@ class VolumeLocalTransport:
             return
         yield from self._delegate.stream(key, chunk_size, version_id)
 
+    def store_chunked(
+        self,
+        key: str,
+        chunks: Iterator[bytes],
+        content_type: str = "",
+    ) -> str | None:
+        data = b"".join(chunks)
+        return self.store(key, data, content_type)
+
     # === Extended Methods (used by CASAddressingEngine via hasattr) ===
 
     def store_nosync(self, key: str, data: bytes) -> None:

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -3532,21 +3532,10 @@ class NexusFS(  # type: ignore[misc]
                     )
                     # Get the destination blob's actual size/version
                     # (NOT the source's — versioned backends assign new IDs).
-                    dst_size = src_route.backend._transport.get_size(
-                        src_route.backend._get_key_path(dst_route.backend_path.strip("/")),
-                    )
+                    dst_size = src_route.backend.get_size_by_path(dst_route.backend_path)
                     dst_version: str | None = None
-                    if (
-                        hasattr(src_route.backend, "versioning_enabled")
-                        and src_route.backend.versioning_enabled
-                    ):
-                        _get_ver = getattr(
-                            src_route.backend._transport, "get_version_id", None
-                        ) or getattr(src_route.backend._transport, "get_generation", None)
-                        if _get_ver:
-                            dst_version = _get_ver(
-                                src_route.backend._get_key_path(dst_route.backend_path.strip("/"))
-                            )
+                    if hasattr(src_route.backend, "get_version_by_path"):
+                        dst_version = src_route.backend.get_version_by_path(dst_route.backend_path)
 
                     from dataclasses import replace as _replace
 
@@ -3594,19 +3583,10 @@ class NexusFS(  # type: ignore[misc]
                         # Use source size (streaming doesn't return size);
                         # get destination version if the backend is versioned.
                         dst_version_id: str | None = None
-                        if (
-                            hasattr(dst_route.backend, "versioning_enabled")
-                            and dst_route.backend.versioning_enabled
-                        ):
-                            _get_ver = getattr(
-                                dst_route.backend._transport, "get_version_id", None
-                            ) or getattr(dst_route.backend._transport, "get_generation", None)
-                            if _get_ver:
-                                dst_version_id = _get_ver(
-                                    dst_route.backend._get_key_path(
-                                        dst_route.backend_path.strip("/")
-                                    )
-                                )
+                        if hasattr(dst_route.backend, "get_version_by_path"):
+                            dst_version_id = dst_route.backend.get_version_by_path(
+                                dst_route.backend_path
+                            )
 
                         from dataclasses import replace as _replace
 

--- a/src/nexus/server/api/v2/routers/connectors.py
+++ b/src/nexus/server/api/v2/routers/connectors.py
@@ -639,11 +639,11 @@ async def mount_connector(
                 )
                 # Write individual schema files
                 schemas = getattr(temp_backend, "SCHEMAS", {})
-                if schemas and hasattr(temp_backend, "_get_doc_generator"):
-                    doc_gen = temp_backend._get_doc_generator()
+                if schemas and hasattr(temp_backend, "get_doc_generator"):
+                    doc_gen = temp_backend.get_doc_generator()
                     for op_name, schema_cls in schemas.items():
                         try:
-                            schema_yaml = doc_gen._generate_annotated_schema(op_name, schema_cls)
+                            schema_yaml = doc_gen.generate_schema_yaml(op_name, schema_cls)
                             await nx.write(
                                 f"{readme_base}/schemas/{op_name}.yaml",
                                 schema_yaml.encode("utf-8"),
@@ -948,12 +948,12 @@ async def get_schema(
     # Try generating from backend's schema generator
     if backend:
         try:
-            generator = getattr(backend, "_get_doc_generator", None)
+            generator = getattr(backend, "get_doc_generator", None)
             if generator:
                 doc_gen = generator()
                 schemas = getattr(backend, "SCHEMAS", {})
                 if operation in schemas:
-                    content = doc_gen._generate_annotated_schema(operation, schemas[operation])
+                    content = doc_gen.generate_schema_yaml(operation, schemas[operation])
                     return SchemaResponse(
                         mount_point=mount_path, operation=operation, content=content
                     )


### PR DESCRIPTION
## Summary
Audit of `src/nexus/backends/` found 4 ABC contract violations. Each fixed in a separate commit:

1. **VolumeLocalTransport missing `store_chunked()`** — added implementation (join chunks → store)
2. **nexus_fs.py accessing `backend._transport` + `_get_key_path`** — replaced with new public `get_size_by_path()` + `get_version_by_path()` on PathAddressingEngine
3. **Server layer accessing `_get_doc_generator()` + `_generate_annotated_schema()`** — renamed to public `get_doc_generator()` + `generate_schema_yaml()`
4. **cas_local.py importing from services layer** — annotated as known layering violation for future refactor

## Test plan
- [x] Ruff + mypy clean on all 4 commits
- [x] Pre-commit hooks pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)