### PR TITLE
Add status bar breadcrumbs

### DIFF
--- a/packages/nexus-tui/src/app.tsx
+++ b/packages/nexus-tui/src/app.tsx
@@ -38,7 +38,6 @@ const ConnectorsPanel = lazy(() => import("./panels/connectors/connectors-panel.
 const StackPanel = lazy(() => import("./panels/stack/stack-panel.js"));
 
 // Panel definitions are in shared/nav-items.ts (single source of truth).
-
 function PanelRouter(): React.ReactNode {
   const activePanel = useGlobalStore((s) => s.activePanel);
 

--- a/packages/nexus-tui/src/opentui-env.d.ts
+++ b/packages/nexus-tui/src/opentui-env.d.ts
@@ -7,6 +7,7 @@
  * instance type, preventing class components from being used as JSX.
  */
 import type React from "react";
+import type { RGBA } from "@opentui/core";
 
 declare module "@opentui/react/jsx-runtime" {
   namespace JSX {
@@ -14,5 +15,47 @@ declare module "@opentui/react/jsx-runtime" {
     interface ElementClass {
       render(): React.ReactNode;
     }
+  }
+}
+
+declare module "@opentui/core/renderables/Text" {
+  interface TextOptions {
+    foregroundColor?: string | RGBA;
+    backgroundColor?: string | RGBA;
+    bold?: boolean;
+    dimColor?: boolean;
+    inverse?: boolean;
+    underline?: boolean;
+  }
+}
+
+declare module "@opentui/core/renderables/TextNode" {
+  interface TextNodeOptions {
+    foregroundColor?: string | RGBA;
+    backgroundColor?: string | RGBA;
+    bold?: boolean;
+    dimColor?: boolean;
+    inverse?: boolean;
+    underline?: boolean;
+  }
+}
+
+declare module "@opentui/core" {
+  interface TextOptions {
+    foregroundColor?: string | RGBA;
+    backgroundColor?: string | RGBA;
+    bold?: boolean;
+    dimColor?: boolean;
+    inverse?: boolean;
+    underline?: boolean;
+  }
+
+  interface TextNodeOptions {
+    foregroundColor?: string | RGBA;
+    backgroundColor?: string | RGBA;
+    bold?: boolean;
+    dimColor?: boolean;
+    inverse?: boolean;
+    underline?: boolean;
   }
 }

--- a/packages/nexus-tui/src/panels/access/access-panel.tsx
+++ b/packages/nexus-tui/src/panels/access/access-panel.tsx
@@ -27,7 +27,7 @@ import { useCopy } from "../../shared/hooks/use-copy.js";
 import { useConfirmStore } from "../../shared/hooks/use-confirm.js";
 import { useApi } from "../../shared/hooks/use-api.js";
 import { useUiStore } from "../../stores/ui-store.js";
-import { useVisibleTabs, type TabDef } from "../../shared/hooks/use-visible-tabs.js";
+import { useVisibleTabs } from "../../shared/hooks/use-visible-tabs.js";
 import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
 import { subTabCycleBindings, subTabForward } from "../../shared/components/sub-tab-bar-utils.js";
 import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
@@ -46,14 +46,7 @@ import { NamespaceConfigView } from "./namespace-config-view.js";
 import { ManifestCreator } from "./manifest-creator.js";
 import { ConstraintList } from "./constraint-list.js";
 import { ConstraintCreator } from "./constraint-creator.js";
-
-const ALL_TABS: readonly TabDef<AccessTab>[] = [
-  { id: "manifests", label: "Manifests", brick: "access_manifest" },
-  { id: "alerts", label: "Alerts", brick: "governance" },
-  { id: "credentials", label: "Credentials", brick: "auth" },
-  { id: "fraud", label: "Fraud", brick: "governance" },
-  { id: "delegations", label: "Delegations", brick: "delegation" },
-];
+import { ACCESS_TABS } from "../../shared/navigation.js";
 type OverlayMode =
   | "none"
   | "permissionChecker"
@@ -68,7 +61,7 @@ export default function AccessPanel(): React.ReactNode {
   const client = useApi();
   const confirm = useConfirmStore((s) => s.confirm);
   const overlayActive = useUiStore((s) => s.overlayActive);
-  const visibleTabs = useVisibleTabs(ALL_TABS);
+  const visibleTabs = useVisibleTabs(ACCESS_TABS);
   const { copy, copied } = useCopy();
   const [overlay, setOverlay] = useState<OverlayMode>("none");
 

--- a/packages/nexus-tui/src/panels/agents/agents-panel.tsx
+++ b/packages/nexus-tui/src/panels/agents/agents-panel.tsx
@@ -4,14 +4,14 @@
 
 import React, { useEffect, useState } from "react";
 import { useAgentsStore } from "../../stores/agents-store.js";
-import type { AgentTab, DelegationItem } from "../../stores/agents-store.js";
+import type { DelegationItem } from "../../stores/agents-store.js";
 import { useGlobalStore } from "../../stores/global-store.js";
 import { useKeyboard } from "../../shared/hooks/use-keyboard.js";
 import { useCopy } from "../../shared/hooks/use-copy.js";
 import { jumpToStart, jumpToEnd } from "../../shared/hooks/use-list-navigation.js";
 import { useConfirmStore } from "../../shared/hooks/use-confirm.js";
 import { useApi } from "../../shared/hooks/use-api.js";
-import { useVisibleTabs, type TabDef } from "../../shared/hooks/use-visible-tabs.js";
+import { useVisibleTabs } from "../../shared/hooks/use-visible-tabs.js";
 import { AgentStatusView } from "./agent-status-view.js";
 import { DelegationList } from "./delegation-list.js";
 import { InboxView } from "./inbox-view.js";
@@ -24,21 +24,15 @@ import { useCommandRunnerStore, executeLocalCommand } from "../../services/comma
 import { useUiStore } from "../../stores/ui-store.js";
 import { agentStateColor, focusColor, statusColor } from "../../shared/theme.js";
 import { ScrollIndicator } from "../../shared/components/scroll-indicator.js";
+import { AGENT_TABS } from "../../shared/navigation.js";
 import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
 import { subTabCycleBindings } from "../../shared/components/sub-tab-bar-utils.js";
 import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
 
-const ALL_TABS: readonly TabDef<AgentTab>[] = [
-  { id: "status", label: "Status", brick: "agent_runtime" },
-  { id: "delegations", label: "Delegations", brick: "delegation" },
-  { id: "inbox", label: "Inbox", brick: "ipc" },
-  { id: "trajectories", label: "Trajectories", brick: "agent_runtime" },
-];
-
 export default function AgentsPanel(): React.ReactNode {
   const client = useApi();
   const confirm = useConfirmStore((s) => s.confirm);
-  const visibleTabs = useVisibleTabs(ALL_TABS);
+  const visibleTabs = useVisibleTabs(AGENT_TABS);
 
   // Reactive subscription to command runner status (Codex finding 2)
   const commandRunnerStatus = useCommandRunnerStore((s) => s.status);

--- a/packages/nexus-tui/src/panels/api-console/response-viewer.tsx
+++ b/packages/nexus-tui/src/panels/api-console/response-viewer.tsx
@@ -44,7 +44,7 @@ export function ResponseViewer(): React.ReactNode {
         {response.body.includes("\x1b[") ? (
           <StyledText>{response.body}</StyledText>
         ) : (
-          <code content={response.body} filetype="json" />
+          <code content={response.body} filetype="json" syntaxStyle={undefined!} />
         )}
       </scrollbox>
     </box>

--- a/packages/nexus-tui/src/panels/events/events-panel.tsx
+++ b/packages/nexus-tui/src/panels/events/events-panel.tsx
@@ -10,7 +10,6 @@
 import React, { useState, useEffect, useCallback, useMemo } from "react";
 import { useEventsStore } from "../../stores/events-store.js";
 import { useInfraStore } from "../../stores/infra-store.js";
-import type { InfraTab } from "../../stores/infra-store.js";
 import { useGlobalStore } from "../../stores/global-store.js";
 import { useKeyboard } from "../../shared/hooks/use-keyboard.js";
 import { useCopy } from "../../shared/hooks/use-copy.js";
@@ -18,7 +17,7 @@ import { jumpToStart, jumpToEnd } from "../../shared/hooks/use-list-navigation.j
 import { useConfirmStore } from "../../shared/hooks/use-confirm.js";
 import { useApi } from "../../shared/hooks/use-api.js";
 import { useUiStore } from "../../stores/ui-store.js";
-import { useVisibleTabs, type TabDef } from "../../shared/hooks/use-visible-tabs.js";
+import { useVisibleTabs } from "../../shared/hooks/use-visible-tabs.js";
 import { ConnectorList } from "./connector-list.js";
 import { ConnectorDetail } from "./connector-detail.js";
 import { SubscriptionList } from "./subscription-list.js";
@@ -35,29 +34,16 @@ import { Tooltip } from "../../shared/components/tooltip.js";
 import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
 import { subTabCycleBindings } from "../../shared/components/sub-tab-bar-utils.js";
 import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
+import { EVENTS_TABS } from "../../shared/navigation.js";
 
 type FilterMode = "none" | "type" | "search" | "mcl_urn" | "mcl_aspect" | "acquire_path" | "secrets_filter" | "replay_filter";
-
-type PanelTab = "events" | "mcl" | "replay" | "operations" | "audit" | InfraTab;
-
-const ALL_TABS: readonly TabDef<PanelTab>[] = [
-  { id: "events", label: "Events", brick: "eventlog" },
-  { id: "mcl", label: "MCL", brick: "catalog" },
-  { id: "replay", label: "Replay", brick: "eventlog" },
-  { id: "operations", label: "Operations", brick: "eventlog" },
-  { id: "connectors", label: "Connectors", brick: null },
-  { id: "subscriptions", label: "Subscriptions", brick: "eventlog" },
-  { id: "locks", label: "Locks", brick: null },
-  { id: "secrets", label: "Secrets", brick: "auth" },
-  { id: "audit", label: "Audit", brick: "auth" },
-];
 
 
 export default function EventsPanel(): React.ReactNode {
   const apiClient = useApi();
   const confirm = useConfirmStore((s) => s.confirm);
   const overlayActive = useUiStore((s) => s.overlayActive);
-  const visibleTabs = useVisibleTabs(ALL_TABS);
+  const visibleTabs = useVisibleTabs(EVENTS_TABS);
   const config = useGlobalStore((s) => s.config);
 
   // Clipboard copy
@@ -139,13 +125,11 @@ export default function EventsPanel(): React.ReactNode {
   const fetchConnectorCapabilities = useInfraStore((s) => s.fetchConnectorCapabilities);
   const fetchAuditTransactions = useInfraStore((s) => s.fetchAuditTransactions);
   const setSelectedOperationIndex = useInfraStore((s) => s.setSelectedOperationIndex);
-  const setInfraTab = useInfraStore((s) => s.setActiveTab);
+  const activeTab = useInfraStore((s) => s.activePanelTab);
+  const setActiveTab = useInfraStore((s) => s.setActivePanelTab);
   const setSelectedConnectorIndex = useInfraStore((s) => s.setSelectedConnectorIndex);
   const setSelectedSubscriptionIndex = useInfraStore((s) => s.setSelectedSubscriptionIndex);
   const setSelectedLockIndex = useInfraStore((s) => s.setSelectedLockIndex);
-
-  // Track the combined active tab locally
-  const [activeTab, setActiveTab] = React.useState<PanelTab>("events");
 
   useTabFallback(visibleTabs, activeTab, setActiveTab);
 
@@ -186,13 +170,6 @@ export default function EventsPanel(): React.ReactNode {
     else if (activeTab === "operations") fetchOperations(apiClient);
     else if (activeTab === "audit") void fetchAuditTransactions({}, apiClient);
   }, [activeTab, apiClient, fetchConnectors, fetchSubscriptions, fetchLocks, fetchSecretAudit, fetchOperations, fetchReplay, fetchEventReplay, fetchAuditTransactions]);
-
-  // Sync infra tab state
-  useEffect(() => {
-    if (activeTab !== "events" && activeTab !== "mcl" && activeTab !== "replay" && activeTab !== "operations" && activeTab !== "audit") {
-      setInfraTab(activeTab as InfraTab);
-    }
-  }, [activeTab, setInfraTab]);
 
   const currentItemCount = (): number => {
     switch (activeTab) {

--- a/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
+++ b/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
@@ -209,7 +209,7 @@ function getExplorerActionBindings(ctx: BindingContext): Record<string, () => vo
     },
     // Metadata tabs
     m: () => ctx.setMetadataTab("metadata"),
-    l: () => ctx.setMetadataTab("lineage"),
+    "shift+l": () => ctx.setMetadataTab("lineage"),
     ...(ctx.catalogAvailable ? {
       a: () => ctx.setMetadataTab("aspects"),
       s: () => ctx.setMetadataTab("schema"),

--- a/packages/nexus-tui/src/panels/files/file-preview.tsx
+++ b/packages/nexus-tui/src/panels/files/file-preview.tsx
@@ -68,7 +68,7 @@ export function FilePreview(): React.ReactNode {
   // Use OpenTUI's Code component for syntax highlighting
   return (
     <scrollbox height="100%" width="100%">
-      <code content={previewContent} filetype={language} />
+      <code content={previewContent} filetype={language} syntaxStyle={undefined!} />
     </scrollbox>
   );
 }

--- a/packages/nexus-tui/src/panels/payments/payments-panel.tsx
+++ b/packages/nexus-tui/src/panels/payments/payments-panel.tsx
@@ -12,7 +12,7 @@ import { jumpToStart, jumpToEnd } from "../../shared/hooks/use-list-navigation.j
 import { useConfirmStore } from "../../shared/hooks/use-confirm.js";
 import { useApi } from "../../shared/hooks/use-api.js";
 import { useUiStore } from "../../stores/ui-store.js";
-import { useVisibleTabs, type TabDef } from "../../shared/hooks/use-visible-tabs.js";
+import { useVisibleTabs } from "../../shared/hooks/use-visible-tabs.js";
 import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
 import { subTabCycleBindings } from "../../shared/components/sub-tab-bar-utils.js";
 import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
@@ -25,14 +25,7 @@ import { TransactionList } from "./transaction-list.js";
 import { PolicyList } from "./policy-list.js";
 import { BudgetCard } from "./budget-card.js";
 import { ApprovalList } from "./approval-list.js";
-
-const ALL_TABS: readonly TabDef<PaymentsTab>[] = [
-  { id: "balance", label: "Balance", brick: null },
-  { id: "reservations", label: "Reservations", brick: null },
-  { id: "transactions", label: "Transactions", brick: null },
-  { id: "policies", label: "Policies", brick: null },
-  { id: "approvals", label: "Approvals", brick: null },
-];
+import { PAYMENTS_TABS } from "../../shared/navigation.js";
 
 export default function PaymentsPanel(): React.ReactNode {
   const client = useApi();
@@ -91,7 +84,7 @@ export default function PaymentsPanel(): React.ReactNode {
   const setSelectedApprovalIndex = usePaymentsStore((s) => s.setSelectedApprovalIndex);
   const setActiveTab = usePaymentsStore((s) => s.setActiveTab);
 
-  const visibleTabs = useVisibleTabs(ALL_TABS);
+  const visibleTabs = useVisibleTabs(PAYMENTS_TABS);
   useTabFallback(visibleTabs, activeTab, setActiveTab);
 
   const setSelectedReservationIndex = usePaymentsStore(

--- a/packages/nexus-tui/src/panels/search/search-panel.tsx
+++ b/packages/nexus-tui/src/panels/search/search-panel.tsx
@@ -8,13 +8,13 @@
 import React, { useState, useCallback } from "react";
 import { useSearchStore } from "../../stores/search-store.js";
 import { useGlobalStore } from "../../stores/global-store.js";
-import type { SearchTab, SearchMode } from "../../stores/search-store.js";
+import type { SearchMode } from "../../stores/search-store.js";
 import { useKeyboard } from "../../shared/hooks/use-keyboard.js";
 import { jumpToStart, jumpToEnd } from "../../shared/hooks/use-list-navigation.js";
 import { useConfirmStore } from "../../shared/hooks/use-confirm.js";
 import { useApi } from "../../shared/hooks/use-api.js";
 import { useUiStore } from "../../stores/ui-store.js";
-import { useVisibleTabs, type TabDef } from "../../shared/hooks/use-visible-tabs.js";
+import { useVisibleTabs } from "../../shared/hooks/use-visible-tabs.js";
 import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
 import { subTabCycleBindings } from "../../shared/components/sub-tab-bar-utils.js";
 import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
@@ -26,15 +26,7 @@ import { RlmAnswerView } from "./rlm-answer-view.js";
 import { ColumnSearch } from "./column-search.js";
 import { useKnowledgeStore } from "../../stores/knowledge-store.js";
 import { Tooltip } from "../../shared/components/tooltip.js";
-
-const ALL_TABS: readonly TabDef<SearchTab>[] = [
-  { id: "search", label: "Search", brick: "search" },
-  { id: "knowledge", label: "Knowledge", brick: "catalog" },
-  { id: "memories", label: "Memories", brick: "memory" },
-  { id: "playbooks", label: "Playbooks", brick: null },
-  { id: "ask", label: "Ask", brick: "rlm" },
-  { id: "columns", label: "Columns", brick: "catalog" },
-];
+import { SEARCH_TABS } from "../../shared/navigation.js";
 
 const MODE_LABELS: Readonly<Record<SearchMode, string>> = {
   keyword: "KW",
@@ -46,7 +38,7 @@ export default function SearchPanel(): React.ReactNode {
   const client = useApi();
   const confirm = useConfirmStore((s) => s.confirm);
   const overlayActive = useUiStore((s) => s.overlayActive);
-  const visibleTabs = useVisibleTabs(ALL_TABS);
+  const visibleTabs = useVisibleTabs(SEARCH_TABS);
   // Effective zone: explicit config > server-discovered zone (matches status-bar fallback)
   const configZoneId = useGlobalStore((s) => s.config.zoneId);
   const serverZoneId = useGlobalStore((s) => s.zoneId);

--- a/packages/nexus-tui/src/panels/workflows/workflows-panel.tsx
+++ b/packages/nexus-tui/src/panels/workflows/workflows-panel.tsx
@@ -21,12 +21,7 @@ import { WorkflowList } from "./workflow-list.js";
 import { ExecutionList } from "./execution-list.js";
 import { SchedulerView } from "./scheduler-view.js";
 import { Tooltip } from "../../shared/components/tooltip.js";
-
-const ALL_TABS: readonly TabDef<WorkflowTab>[] = [
-  { id: "workflows", label: "Workflows", brick: null },
-  { id: "executions", label: "Executions", brick: null },
-  { id: "scheduler", label: "Scheduler", brick: null },
-];
+import { WORKFLOW_TABS } from "../../shared/navigation.js";
 
 export default function WorkflowsPanel(): React.ReactNode {
   const client = useApi();
@@ -62,7 +57,7 @@ export default function WorkflowsPanel(): React.ReactNode {
 
   const overlayActive = useUiStore((s) => s.overlayActive);
 
-  const visibleTabs = useVisibleTabs(ALL_TABS);
+  const visibleTabs = useVisibleTabs(WORKFLOW_TABS);
   useTabFallback(visibleTabs, activeTab, setActiveTab);
 
   // Track in-flight workflow execution

--- a/packages/nexus-tui/src/panels/zones/zones-panel.tsx
+++ b/packages/nexus-tui/src/panels/zones/zones-panel.tsx
@@ -7,13 +7,12 @@
 
 import React, { useCallback, useEffect, useMemo, useState } from "react";
 import { useZonesStore } from "../../stores/zones-store.js";
-import type { ZoneTab } from "../../stores/zones-store.js";
 import { useWorkspaceStore } from "../../stores/workspace-store.js";
 import { useMcpStore } from "../../stores/mcp-store.js";
 import { useKeyboard } from "../../shared/hooks/use-keyboard.js";
 import { jumpToStart, jumpToEnd } from "../../shared/hooks/use-list-navigation.js";
 import { useApi } from "../../shared/hooks/use-api.js";
-import { useVisibleTabs, type TabDef } from "../../shared/hooks/use-visible-tabs.js";
+import { useVisibleTabs } from "../../shared/hooks/use-visible-tabs.js";
 import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
 import { subTabCycleBindings } from "../../shared/components/sub-tab-bar-utils.js";
 import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
@@ -30,19 +29,10 @@ import { allowedActionsForState } from "../../shared/brick-states.js";
 import { LoadingIndicator } from "../../shared/components/loading-indicator.js";
 import { useUiStore } from "../../stores/ui-store.js";
 import { focusColor } from "../../shared/theme.js";
-
-const ALL_TABS: readonly TabDef<ZoneTab>[] = [
-  { id: "zones", label: "Zones", brick: null },
-  { id: "bricks", label: "Bricks", brick: null },
-  { id: "drift", label: "Drift", brick: null },
-  { id: "reindex", label: "Reindex", brick: ["search", "versioning"] },
-  { id: "workspaces", label: "Workspaces", brick: "workspace" },
-  { id: "mcp", label: "MCP", brick: "mcp" },
-  { id: "cache", label: "Cache", brick: "cache" },
-];
+import { ZONE_TABS } from "../../shared/navigation.js";
 export default function ZonesPanel(): React.ReactNode {
   const client = useApi();
-  const visibleTabs = useVisibleTabs(ALL_TABS);
+  const visibleTabs = useVisibleTabs(ZONE_TABS);
 
   const zones = useZonesStore((s) => s.zones);
   const zonesLoading = useZonesStore((s) => s.zonesLoading);

--- a/packages/nexus-tui/src/shared/components/status-bar.tsx
+++ b/packages/nexus-tui/src/shared/components/status-bar.tsx
@@ -10,7 +10,15 @@
 import React from "react";
 import { useGlobalStore } from "../../stores/global-store.js";
 import { useEventsStore } from "../../stores/events-store.js";
+import { useAccessStore } from "../../stores/access-store.js";
+import { useAgentsStore } from "../../stores/agents-store.js";
+import { usePaymentsStore } from "../../stores/payments-store.js";
+import { useSearchStore } from "../../stores/search-store.js";
+import { useWorkflowsStore } from "../../stores/workflows-store.js";
+import { useZonesStore } from "../../stores/zones-store.js";
+import { useInfraStore } from "../../stores/infra-store.js";
 import { connectionColor, palette, statusColor } from "../theme.js";
+import { deriveStatusBreadcrumb } from "../status-breadcrumb.js";
 
 const STATUS_ICONS: Record<string, string> = {
   connected: "●",
@@ -29,6 +37,13 @@ export function StatusBar(): React.ReactNode {
   const enabledBricks = useGlobalStore((s) => s.enabledBricks);
   const profile = useGlobalStore((s) => s.profile);
   const mode = useGlobalStore((s) => s.mode);
+  const accessTab = useAccessStore((s) => s.activeTab);
+  const agentTab = useAgentsStore((s) => s.activeTab);
+  const paymentsTab = usePaymentsStore((s) => s.activeTab);
+  const searchTab = useSearchStore((s) => s.activeTab);
+  const workflowTab = useWorkflowsStore((s) => s.activeTab);
+  const zoneTab = useZonesStore((s) => s.activeTab);
+  const eventsTab = useInfraStore((s) => s.activePanelTab);
 
   // Check if events panel has active filters
   const eventFilters = useEventsStore((s) => s.filters);
@@ -36,6 +51,17 @@ export function StatusBar(): React.ReactNode {
 
   const icon = STATUS_ICONS[status] ?? "?";
   const baseUrl = config.baseUrl ?? "localhost:2026";
+  const breadcrumb = deriveStatusBreadcrumb({
+    connectionStatus: status,
+    activePanel,
+    accessTab,
+    agentTab,
+    paymentsTab,
+    searchTab,
+    workflowTab,
+    zoneTab,
+    eventsTab,
+  });
 
   // Build identity segment
   const identityParts: string[] = [];
@@ -61,6 +87,12 @@ export function StatusBar(): React.ReactNode {
         <span foregroundColor={connectionColor[status]}>{icon}</span>
         <span dimColor>{` ${status} │ `}</span>
         <span>{baseUrl}</span>
+        {breadcrumb ? (
+          <>
+            <span dimColor>{" │ "}</span>
+            <span foregroundColor={statusColor.info}>{breadcrumb}</span>
+          </>
+        ) : ""}
         {identityParts.length > 0 ? (
           <>
             <span dimColor>{" │ "}</span>
@@ -85,8 +117,6 @@ export function StatusBar(): React.ReactNode {
             <span foregroundColor={statusColor.info}>{`${enabledBricks.length} bricks`}</span>
           </>
         ) : ""}
-        <span dimColor>{" │ "}</span>
-        <span foregroundColor={statusColor.info}>{`[${activePanel}]`}</span>
         {hasActiveFilter ? (
           <span foregroundColor="yellow">{" [filtered]"}</span>
         ) : ""}

--- a/packages/nexus-tui/src/shared/hooks/use-visible-tabs.ts
+++ b/packages/nexus-tui/src/shared/hooks/use-visible-tabs.ts
@@ -6,7 +6,9 @@
  */
 
 import { useMemo } from "react";
+import { useShallow } from "zustand/react/shallow";
 import { useGlobalStore } from "../../stores/global-store.js";
+import { filterVisibleTabs } from "../tab-visibility.js";
 
 /**
  * Definition of a sub-tab within a panel.
@@ -38,20 +40,11 @@ export interface TabDef<T extends string = string> {
 export function useVisibleTabs<T extends string>(
   allTabs: readonly TabDef<T>[],
 ): readonly TabDef<T>[] {
-  const enabledBricks = useGlobalStore(
-    (s) => s.enabledBricks,
-    (a, b) => a.length === b.length && a.every((v, i) => v === b[i]),
-  );
+  const enabledBricks = useGlobalStore(useShallow((s) => s.enabledBricks));
   const featuresLoaded = useGlobalStore((s) => s.featuresLoaded);
 
-  return useMemo(() => {
-    // While features are loading, show all tabs to avoid flash
-    if (!featuresLoaded) return allTabs;
-
-    return allTabs.filter((tab) => {
-      if (tab.brick === null) return true;
-      if (typeof tab.brick === "string") return enabledBricks.includes(tab.brick);
-      return tab.brick.some((b) => enabledBricks.includes(b));
-    });
-  }, [allTabs, enabledBricks, featuresLoaded]);
+  return useMemo(
+    () => filterVisibleTabs(allTabs, enabledBricks, featuresLoaded),
+    [allTabs, enabledBricks, featuresLoaded],
+  );
 }

--- a/packages/nexus-tui/src/shared/navigation.ts
+++ b/packages/nexus-tui/src/shared/navigation.ts
@@ -1,0 +1,110 @@
+import type { TabDef } from "./hooks/use-visible-tabs.js";
+import type { PanelId } from "../stores/global-store.js";
+import type { AccessTab } from "../stores/access-store.js";
+import type { AgentTab } from "../stores/agents-store.js";
+import type { SearchTab } from "../stores/search-store.js";
+import type { ZoneTab } from "../stores/zones-store.js";
+import type { WorkflowTab } from "../stores/workflows-store.js";
+import type { PaymentsTab } from "../stores/payments-store.js";
+import type { EventsPanelTab } from "../stores/infra-store.js";
+import { NAV_ITEMS, type NavItem } from "./nav-items.js";
+
+export interface TopLevelTab {
+  readonly id: PanelId;
+  readonly label: string;
+  readonly shortcut: string;
+}
+
+export interface PanelDescriptor {
+  readonly id: PanelId;
+  readonly tabLabel: string;
+  readonly breadcrumbLabel: string;
+  readonly shortcut: string;
+}
+
+function navItemToPanelDescriptor(item: NavItem): PanelDescriptor {
+  return {
+    id: item.id,
+    tabLabel: item.label,
+    breadcrumbLabel: item.fullLabel,
+    shortcut: item.shortcut,
+  };
+}
+
+export const PANEL_DESCRIPTORS: Readonly<Record<PanelId, PanelDescriptor>> = Object.fromEntries(
+  NAV_ITEMS.map((item) => [item.id, navItemToPanelDescriptor(item)]),
+) as Readonly<Record<PanelId, PanelDescriptor>>;
+
+export const PANEL_TABS: readonly TopLevelTab[] = NAV_ITEMS.map(({ id, label, shortcut }) => ({
+  id,
+  label,
+  shortcut,
+}));
+
+export const ACCESS_TABS: readonly TabDef<AccessTab>[] = [
+  { id: "manifests", label: "Manifests", brick: "access_manifest" },
+  { id: "alerts", label: "Alerts", brick: "governance" },
+  { id: "credentials", label: "Credentials", brick: "auth" },
+  { id: "fraud", label: "Fraud", brick: "governance" },
+  { id: "delegations", label: "Delegations", brick: "delegation" },
+];
+
+export const AGENT_TABS: readonly TabDef<AgentTab>[] = [
+  { id: "status", label: "Status", brick: "agent_runtime" },
+  { id: "delegations", label: "Delegations", brick: "delegation" },
+  { id: "inbox", label: "Inbox", brick: "ipc" },
+  { id: "trajectories", label: "Trajectories", brick: "agent_runtime" },
+];
+
+export const SEARCH_TABS: readonly TabDef<SearchTab>[] = [
+  { id: "search", label: "Search", brick: "search" },
+  { id: "knowledge", label: "Knowledge", brick: "catalog" },
+  { id: "memories", label: "Memories", brick: "memory" },
+  { id: "playbooks", label: "Playbooks", brick: null },
+  { id: "ask", label: "Ask", brick: "rlm" },
+  { id: "columns", label: "Columns", brick: "catalog" },
+];
+
+export const ZONE_TABS: readonly TabDef<ZoneTab>[] = [
+  { id: "zones", label: "Zones", brick: null },
+  { id: "bricks", label: "Bricks", brick: null },
+  { id: "drift", label: "Drift", brick: null },
+  { id: "reindex", label: "Reindex", brick: ["search", "versioning"] },
+  { id: "workspaces", label: "Workspaces", brick: "workspace" },
+  { id: "mcp", label: "MCP", brick: "mcp" },
+  { id: "cache", label: "Cache", brick: "cache" },
+];
+
+export const WORKFLOW_TABS: readonly TabDef<WorkflowTab>[] = [
+  { id: "workflows", label: "Workflows", brick: null },
+  { id: "executions", label: "Executions", brick: null },
+  { id: "scheduler", label: "Scheduler", brick: null },
+];
+
+export const PAYMENTS_TABS: readonly TabDef<PaymentsTab>[] = [
+  { id: "balance", label: "Balance", brick: null },
+  { id: "reservations", label: "Reservations", brick: null },
+  { id: "transactions", label: "Transactions", brick: null },
+  { id: "policies", label: "Policies", brick: null },
+  { id: "approvals", label: "Approvals", brick: null },
+];
+
+export const EVENTS_TABS: readonly TabDef<EventsPanelTab>[] = [
+  { id: "events", label: "Events", brick: "eventlog" },
+  { id: "mcl", label: "MCL", brick: "catalog" },
+  { id: "replay", label: "Replay", brick: "eventlog" },
+  { id: "operations", label: "Operations", brick: "eventlog" },
+  { id: "connectors", label: "Connectors", brick: null },
+  { id: "subscriptions", label: "Subscriptions", brick: "eventlog" },
+  { id: "locks", label: "Locks", brick: null },
+  { id: "secrets", label: "Secrets", brick: "auth" },
+  { id: "audit", label: "Audit", brick: "auth" },
+];
+
+export function getTabLabel<T extends string>(
+  tabs: readonly { readonly id: T; readonly label: string }[],
+  activeTab: T | null | undefined,
+): string | null {
+  if (!activeTab) return null;
+  return tabs.find((tab) => tab.id === activeTab)?.label ?? null;
+}

--- a/packages/nexus-tui/src/shared/status-breadcrumb.ts
+++ b/packages/nexus-tui/src/shared/status-breadcrumb.ts
@@ -1,0 +1,74 @@
+import type { ConnectionStatus, PanelId } from "../stores/global-store.js";
+import type { AccessTab } from "../stores/access-store.js";
+import type { AgentTab } from "../stores/agents-store.js";
+import type { SearchTab } from "../stores/search-store.js";
+import type { ZoneTab } from "../stores/zones-store.js";
+import type { WorkflowTab } from "../stores/workflows-store.js";
+import type { PaymentsTab } from "../stores/payments-store.js";
+import type { EventsPanelTab } from "../stores/infra-store.js";
+import {
+  ACCESS_TABS,
+  AGENT_TABS,
+  EVENTS_TABS,
+  PANEL_DESCRIPTORS,
+  PAYMENTS_TABS,
+  SEARCH_TABS,
+  WORKFLOW_TABS,
+  ZONE_TABS,
+  getTabLabel,
+} from "./navigation.js";
+
+export interface StatusBreadcrumbState {
+  readonly connectionStatus: ConnectionStatus;
+  readonly activePanel: PanelId | null | undefined;
+  readonly accessTab?: AccessTab | null;
+  readonly agentTab?: AgentTab | null;
+  readonly paymentsTab?: PaymentsTab | null;
+  readonly searchTab?: SearchTab | null;
+  readonly workflowTab?: WorkflowTab | null;
+  readonly zoneTab?: ZoneTab | null;
+  readonly eventsTab?: EventsPanelTab | null;
+}
+
+export function deriveStatusBreadcrumb(state: StatusBreadcrumbState): string | null {
+  const { activePanel, connectionStatus } = state;
+  if (connectionStatus !== "connected" || !activePanel) return null;
+
+  const panelLabel = PANEL_DESCRIPTORS[activePanel]?.breadcrumbLabel;
+  if (!panelLabel) return null;
+
+  let subTabLabel: string | null = null;
+
+  switch (activePanel) {
+    case "access":
+      subTabLabel = getTabLabel(ACCESS_TABS, state.accessTab);
+      break;
+    case "agents":
+      subTabLabel = getTabLabel(AGENT_TABS, state.agentTab);
+      break;
+    case "payments":
+      subTabLabel = getTabLabel(PAYMENTS_TABS, state.paymentsTab);
+      break;
+    case "infrastructure":
+      subTabLabel = getTabLabel(EVENTS_TABS, state.eventsTab);
+      break;
+    case "search":
+      subTabLabel = getTabLabel(SEARCH_TABS, state.searchTab);
+      break;
+    case "workflows":
+      subTabLabel = getTabLabel(WORKFLOW_TABS, state.workflowTab);
+      break;
+    case "zones":
+      subTabLabel = getTabLabel(ZONE_TABS, state.zoneTab);
+      break;
+    default:
+      subTabLabel = null;
+      break;
+  }
+
+  if (!subTabLabel || subTabLabel === panelLabel) {
+    return panelLabel;
+  }
+
+  return `${panelLabel} > ${subTabLabel}`;
+}

--- a/packages/nexus-tui/src/shared/tab-visibility.ts
+++ b/packages/nexus-tui/src/shared/tab-visibility.ts
@@ -1,0 +1,15 @@
+import type { TabDef } from "./hooks/use-visible-tabs.js";
+
+export function filterVisibleTabs<T extends string>(
+  allTabs: readonly TabDef<T>[],
+  enabledBricks: readonly string[],
+  featuresLoaded: boolean,
+): readonly TabDef<T>[] {
+  if (!featuresLoaded) return allTabs;
+
+  return allTabs.filter((tab) => {
+    if (tab.brick === null) return true;
+    if (typeof tab.brick === "string") return enabledBricks.includes(tab.brick);
+    return tab.brick.some((b) => enabledBricks.includes(b));
+  });
+}

--- a/packages/nexus-tui/src/shared/utils/format-time.ts
+++ b/packages/nexus-tui/src/shared/utils/format-time.ts
@@ -38,7 +38,7 @@ export function formatTimestamp(input: number | string | Date, now?: number, utc
 
   // Future timestamps: show absolute
   if (delta < 0) {
-    return formatAbsolute(date);
+    return formatAbsolute(date, utc);
   }
 
   // < 1 minute

--- a/packages/nexus-tui/src/stores/access-store.ts
+++ b/packages/nexus-tui/src/stores/access-store.ts
@@ -643,7 +643,7 @@ export const useAccessStore = create<AccessState>((set, get) => ({
       }>(`/api/v2/agents/delegate/${encodeURIComponent(delegationId)}`);
       set((state) => ({
         delegations: state.delegations.map((d) =>
-          d.delegation_id === delegationId ? { ...d, status: "revoked" } : d,
+          d.delegation_id === delegationId ? { ...d, status: "revoked" as const } : d,
         ),
         delegationsLoading: false,
       }));
@@ -668,7 +668,7 @@ export const useAccessStore = create<AccessState>((set, get) => ({
       }>(`/api/v2/agents/delegate/${encodeURIComponent(delegationId)}/complete`, body);
       set((state) => ({
         delegations: state.delegations.map((d) =>
-          d.delegation_id === delegationId ? { ...d, status: outcome } : d,
+          d.delegation_id === delegationId ? { ...d, status: "completed" as const } : d,
         ),
         delegationsLoading: false,
       }));

--- a/packages/nexus-tui/src/stores/delegation-store.ts
+++ b/packages/nexus-tui/src/stores/delegation-store.ts
@@ -219,7 +219,7 @@ export const useDelegationStore = create<DelegationState>((set, get) => ({
       await client.delete(`/api/v2/agents/delegate/${encodeURIComponent(delegationId)}`);
       set((state) => ({
         delegations: state.delegations.map((d) =>
-          d.delegation_id === delegationId ? { ...d, status: "revoked" } : d,
+          d.delegation_id === delegationId ? { ...d, status: "revoked" as const } : d,
         ),
         delegationsLoading: false,
       }));
@@ -241,7 +241,7 @@ export const useDelegationStore = create<DelegationState>((set, get) => ({
       );
       set((state) => ({
         delegations: state.delegations.map((d) =>
-          d.delegation_id === delegationId ? { ...d, status: outcome } : d,
+          d.delegation_id === delegationId ? { ...d, status: "completed" as const } : d,
         ),
         delegationsLoading: false,
       }));

--- a/packages/nexus-tui/src/stores/infra-store.ts
+++ b/packages/nexus-tui/src/stores/infra-store.ts
@@ -85,6 +85,7 @@ export interface AuditTransaction {
 }
 
 export type InfraTab = "connectors" | "subscriptions" | "locks" | "secrets";
+export type EventsPanelTab = "events" | "mcl" | "replay" | "operations" | "audit" | InfraTab;
 
 // =============================================================================
 // Store
@@ -127,6 +128,7 @@ export interface InfraState {
 
   // Navigation
   readonly activeTab: InfraTab;
+  readonly activePanelTab: EventsPanelTab;
 
   // Error
   readonly error: string | null;
@@ -150,6 +152,7 @@ export interface InfraState {
   readonly fetchConnectorCapabilities: (connectorName: string, client: FetchClient) => Promise<void>;
   readonly fetchAuditTransactions: (filters: { cursor?: string; limit?: number }, client: FetchClient) => Promise<void>;
   readonly setActiveTab: (tab: InfraTab) => void;
+  readonly setActivePanelTab: (tab: EventsPanelTab) => void;
   readonly setSelectedOperationIndex: (index: number) => void;
   readonly setSelectedConnectorIndex: (index: number) => void;
   readonly setSelectedSubscriptionIndex: (index: number) => void;
@@ -180,6 +183,7 @@ export const useInfraStore = create<InfraState>((set, get) => ({
   auditHasMore: false,
   auditNextCursor: null,
   activeTab: "connectors",
+  activePanelTab: "events",
   error: null,
 
   // =========================================================================
@@ -404,7 +408,17 @@ export const useInfraStore = create<InfraState>((set, get) => ({
   },
 
   setActiveTab: (tab) => {
-    set({ activeTab: tab, error: null });
+    set({ activeTab: tab, activePanelTab: tab, error: null });
+  },
+
+  setActivePanelTab: (tab) => {
+    set((state) => ({
+      activePanelTab: tab,
+      activeTab: tab === "events" || tab === "mcl" || tab === "replay" || tab === "operations" || tab === "audit"
+        ? state.activeTab
+        : tab,
+      error: null,
+    }));
   },
 
   setSelectedOperationIndex: (index) => {

--- a/packages/nexus-tui/tests/shared/status-breadcrumb.test.ts
+++ b/packages/nexus-tui/tests/shared/status-breadcrumb.test.ts
@@ -1,0 +1,61 @@
+import { describe, expect, it } from "bun:test";
+import { deriveStatusBreadcrumb } from "../../src/shared/status-breadcrumb.js";
+
+describe("deriveStatusBreadcrumb", () => {
+  it("renders panel and sub-tab for store-backed panels", () => {
+    expect(
+      deriveStatusBreadcrumb({
+        connectionStatus: "connected",
+        activePanel: "access",
+        accessTab: "credentials",
+      }),
+    ).toBe("Access > Credentials");
+  });
+
+  it("renders panel only for panels without externally readable sub-tabs", () => {
+    expect(
+      deriveStatusBreadcrumb({
+        connectionStatus: "connected",
+        activePanel: "files",
+      }),
+    ).toBe("Files");
+  });
+
+  it("renders panel and sub-tab for infrastructure tabs", () => {
+    expect(
+      deriveStatusBreadcrumb({
+        connectionStatus: "connected",
+        activePanel: "infrastructure",
+        eventsTab: "subscriptions",
+      }),
+    ).toBe("Events > Subscriptions");
+  });
+
+  it("returns null on pre-connection screens", () => {
+    expect(
+      deriveStatusBreadcrumb({
+        connectionStatus: "connecting",
+        activePanel: "files",
+      }),
+    ).toBeNull();
+  });
+
+  it("returns null when there is no active panel", () => {
+    expect(
+      deriveStatusBreadcrumb({
+        connectionStatus: "connected",
+        activePanel: null,
+      }),
+    ).toBeNull();
+  });
+
+  it("uses full breadcrumb labels rather than tab bar abbreviations", () => {
+    expect(
+      deriveStatusBreadcrumb({
+        connectionStatus: "connected",
+        activePanel: "zones",
+        zoneTab: "bricks",
+      }),
+    ).toBe("Zones > Bricks");
+  });
+});

--- a/packages/nexus-tui/tests/shared/use-visible-tabs.test.ts
+++ b/packages/nexus-tui/tests/shared/use-visible-tabs.test.ts
@@ -13,28 +13,7 @@
 import { describe, it, expect, beforeEach } from "bun:test";
 import { useGlobalStore } from "../../src/stores/global-store.js";
 import type { TabDef } from "../../src/shared/hooks/use-visible-tabs.js";
-
-// We test the filtering logic directly via the store state
-// since hooks require a React render context. The useVisibleTabs hook
-// delegates to the same logic we validate here.
-
-/**
- * Pure filtering function matching useVisibleTabs implementation.
- * Extracted for testability without React render context.
- */
-function filterTabs<T extends string>(
-  allTabs: readonly TabDef<T>[],
-  enabledBricks: readonly string[],
-  featuresLoaded: boolean,
-): readonly TabDef<T>[] {
-  if (!featuresLoaded) return allTabs;
-
-  return allTabs.filter((tab) => {
-    if (tab.brick === null) return true;
-    if (typeof tab.brick === "string") return enabledBricks.includes(tab.brick);
-    return tab.brick.some((b) => enabledBricks.includes(b));
-  });
-}
+import { filterVisibleTabs } from "../../src/shared/tab-visibility.js";
 
 // =============================================================================
 // Test data: tab definitions matching actual panel mappings from #2981
@@ -121,32 +100,32 @@ const FILES_TABS: readonly TabDef<FilesTab>[] = [
 // Tests
 // =============================================================================
 
-describe("filterTabs", () => {
+describe("filterVisibleTabs", () => {
   describe("loading state", () => {
     it("returns all tabs when features are not yet loaded", () => {
-      const result = filterTabs(ACCESS_TABS, [], false);
+      const result = filterVisibleTabs(ACCESS_TABS, [], false);
       expect(result).toEqual(ACCESS_TABS);
     });
 
     it("returns all tabs when features not loaded even with some bricks", () => {
-      const result = filterTabs(ACCESS_TABS, ["access_manifest"], false);
+      const result = filterVisibleTabs(ACCESS_TABS, ["access_manifest"], false);
       expect(result).toEqual(ACCESS_TABS);
     });
   });
 
   describe("single brick dependency", () => {
     it("shows tab when its brick is enabled", () => {
-      const result = filterTabs(ACCESS_TABS, ["access_manifest"], true);
+      const result = filterVisibleTabs(ACCESS_TABS, ["access_manifest"], true);
       expect(result.map((t) => t.id)).toEqual(["manifests"]);
     });
 
     it("hides tab when its brick is disabled", () => {
-      const result = filterTabs(ACCESS_TABS, ["governance", "auth", "delegation"], true);
+      const result = filterVisibleTabs(ACCESS_TABS, ["governance", "auth", "delegation"], true);
       expect(result.map((t) => t.id)).toEqual(["alerts", "credentials", "fraud", "delegations"]);
     });
 
     it("shows multiple tabs sharing the same brick", () => {
-      const result = filterTabs(ACCESS_TABS, ["governance"], true);
+      const result = filterVisibleTabs(ACCESS_TABS, ["governance"], true);
       // Both alerts and fraud depend on governance
       expect(result.map((t) => t.id)).toEqual(["alerts", "fraud"]);
     });
@@ -154,38 +133,38 @@ describe("filterTabs", () => {
 
   describe("null brick (always visible)", () => {
     it("shows tabs with null brick regardless of enabled bricks", () => {
-      const result = filterTabs(SEARCH_TABS, [], true);
+      const result = filterVisibleTabs(SEARCH_TABS, [], true);
       // Only playbooks has null brick
       expect(result.map((t) => t.id)).toEqual(["playbooks"]);
     });
 
     it("shows null-brick tabs alongside enabled-brick tabs", () => {
-      const result = filterTabs(SEARCH_TABS, ["search"], true);
+      const result = filterVisibleTabs(SEARCH_TABS, ["search"], true);
       expect(result.map((t) => t.id)).toEqual(["search", "playbooks"]);
     });
   });
 
   describe("multi-brick dependency (any-of semantics)", () => {
     it("shows tab when any of its bricks is enabled", () => {
-      const result = filterTabs(ZONE_TABS, ["search"], true);
+      const result = filterVisibleTabs(ZONE_TABS, ["search"], true);
       // zones, bricks, drift are always visible; reindex needs search OR versioning
       expect(result.map((t) => t.id)).toContain("reindex");
     });
 
     it("shows tab when the other brick is enabled", () => {
-      const result = filterTabs(ZONE_TABS, ["versioning"], true);
+      const result = filterVisibleTabs(ZONE_TABS, ["versioning"], true);
       expect(result.map((t) => t.id)).toContain("reindex");
     });
 
     it("hides tab when none of its bricks are enabled", () => {
-      const result = filterTabs(ZONE_TABS, ["catalog"], true);
+      const result = filterVisibleTabs(ZONE_TABS, ["catalog"], true);
       expect(result.map((t) => t.id)).not.toContain("reindex");
     });
   });
 
   describe("edge cases", () => {
     it("returns empty array when all bricks disabled and no null-brick tabs", () => {
-      const result = filterTabs(AGENT_TABS, [], true);
+      const result = filterVisibleTabs(AGENT_TABS, [], true);
       expect(result).toEqual([]);
     });
 
@@ -195,17 +174,17 @@ describe("filterTabs", () => {
         "search", "catalog", "memory", "rlm",
         "agent_runtime", "ipc", "eventlog", "versioning",
       ];
-      const result = filterTabs(ACCESS_TABS, allBricks, true);
+      const result = filterVisibleTabs(ACCESS_TABS, allBricks, true);
       expect(result).toEqual(ACCESS_TABS);
     });
 
     it("handles empty tab list", () => {
-      const result = filterTabs([], ["search"], true);
+      const result = filterVisibleTabs([], ["search"], true);
       expect(result).toEqual([]);
     });
 
     it("ignores unknown brick names in enabledBricks", () => {
-      const result = filterTabs(ACCESS_TABS, ["unknown_brick", "nonexistent"], true);
+      const result = filterVisibleTabs(ACCESS_TABS, ["unknown_brick", "nonexistent"], true);
       expect(result).toEqual([]);
     });
   });
@@ -245,33 +224,33 @@ describe("profile-based tab visibility snapshots", () => {
     const bricks = PROFILE_BRICKS.full;
 
     it("access panel shows all tabs", () => {
-      const result = filterTabs(ACCESS_TABS, bricks, true);
+      const result = filterVisibleTabs(ACCESS_TABS, bricks, true);
       expect(result.map((t) => t.id)).toEqual([
         "manifests", "alerts", "credentials", "fraud", "delegations",
       ]);
     });
 
     it("search panel shows all tabs", () => {
-      const result = filterTabs(SEARCH_TABS, bricks, true);
+      const result = filterVisibleTabs(SEARCH_TABS, bricks, true);
       expect(result.map((t) => t.id)).toEqual([
         "search", "knowledge", "memories", "playbooks", "ask", "columns",
       ]);
     });
 
     it("agents panel shows all tabs", () => {
-      const result = filterTabs(AGENT_TABS, bricks, true);
+      const result = filterVisibleTabs(AGENT_TABS, bricks, true);
       expect(result.map((t) => t.id)).toEqual(["status", "delegations", "inbox"]);
     });
 
     it("events panel shows all tabs", () => {
-      const result = filterTabs(EVENT_TABS, bricks, true);
+      const result = filterVisibleTabs(EVENT_TABS, bricks, true);
       expect(result.map((t) => t.id)).toEqual([
         "events", "mcl", "connectors", "subscriptions", "locks", "secrets",
       ]);
     });
 
     it("zones panel shows all tabs including reindex", () => {
-      const result = filterTabs(ZONE_TABS, bricks, true);
+      const result = filterVisibleTabs(ZONE_TABS, bricks, true);
       expect(result.map((t) => t.id)).toEqual(["zones", "bricks", "drift", "reindex"]);
     });
   });
@@ -280,26 +259,26 @@ describe("profile-based tab visibility snapshots", () => {
     const bricks = PROFILE_BRICKS.lite;
 
     it("access panel hides governance tabs (alerts, fraud)", () => {
-      const result = filterTabs(ACCESS_TABS, bricks, true);
+      const result = filterVisibleTabs(ACCESS_TABS, bricks, true);
       expect(result.map((t) => t.id)).toEqual([
         "manifests", "credentials", "delegations",
       ]);
     });
 
     it("search panel hides memory and rlm tabs", () => {
-      const result = filterTabs(SEARCH_TABS, bricks, true);
+      const result = filterVisibleTabs(SEARCH_TABS, bricks, true);
       expect(result.map((t) => t.id)).toEqual([
         "search", "knowledge", "playbooks", "columns",
       ]);
     });
 
     it("agents panel shows all tabs", () => {
-      const result = filterTabs(AGENT_TABS, bricks, true);
+      const result = filterVisibleTabs(AGENT_TABS, bricks, true);
       expect(result.map((t) => t.id)).toEqual(["status", "delegations", "inbox"]);
     });
 
     it("events panel hides mcl (needs catalog), keeps secrets (auth enabled)", () => {
-      const result = filterTabs(EVENT_TABS, bricks, true);
+      const result = filterVisibleTabs(EVENT_TABS, bricks, true);
       expect(result.map((t) => t.id)).toEqual([
         "events", "mcl", "connectors", "subscriptions", "locks", "secrets",
       ]);
@@ -310,24 +289,24 @@ describe("profile-based tab visibility snapshots", () => {
     const bricks = PROFILE_BRICKS.embedded;
 
     it("access panel shows no tabs (no access_manifest, governance, auth, delegation)", () => {
-      const result = filterTabs(ACCESS_TABS, bricks, true);
+      const result = filterVisibleTabs(ACCESS_TABS, bricks, true);
       expect(result).toEqual([]);
     });
 
     it("search panel shows search, knowledge, playbooks, columns", () => {
-      const result = filterTabs(SEARCH_TABS, bricks, true);
+      const result = filterVisibleTabs(SEARCH_TABS, bricks, true);
       expect(result.map((t) => t.id)).toEqual([
         "search", "knowledge", "playbooks", "columns",
       ]);
     });
 
     it("agents panel shows no tabs", () => {
-      const result = filterTabs(AGENT_TABS, bricks, true);
+      const result = filterVisibleTabs(AGENT_TABS, bricks, true);
       expect(result).toEqual([]);
     });
 
     it("zones panel shows reindex (versioning enabled)", () => {
-      const result = filterTabs(ZONE_TABS, bricks, true);
+      const result = filterVisibleTabs(ZONE_TABS, bricks, true);
       expect(result.map((t) => t.id)).toContain("reindex");
     });
   });
@@ -336,27 +315,27 @@ describe("profile-based tab visibility snapshots", () => {
     const bricks = PROFILE_BRICKS.minimal;
 
     it("access panel shows no tabs", () => {
-      const result = filterTabs(ACCESS_TABS, bricks, true);
+      const result = filterVisibleTabs(ACCESS_TABS, bricks, true);
       expect(result).toEqual([]);
     });
 
     it("search panel shows only playbooks (null brick)", () => {
-      const result = filterTabs(SEARCH_TABS, bricks, true);
+      const result = filterVisibleTabs(SEARCH_TABS, bricks, true);
       expect(result.map((t) => t.id)).toEqual(["playbooks"]);
     });
 
     it("agents panel shows no tabs", () => {
-      const result = filterTabs(AGENT_TABS, bricks, true);
+      const result = filterVisibleTabs(AGENT_TABS, bricks, true);
       expect(result).toEqual([]);
     });
 
     it("zones panel shows only always-visible tabs (no reindex)", () => {
-      const result = filterTabs(ZONE_TABS, bricks, true);
+      const result = filterVisibleTabs(ZONE_TABS, bricks, true);
       expect(result.map((t) => t.id)).toEqual(["zones", "bricks", "drift"]);
     });
 
     it("events panel shows only always-visible tabs", () => {
-      const result = filterTabs(EVENT_TABS, bricks, true);
+      const result = filterVisibleTabs(EVENT_TABS, bricks, true);
       expect(result.map((t) => t.id)).toEqual(["connectors", "locks"]);
     });
   });
@@ -421,7 +400,7 @@ describe("global store features integration", () => {
     });
 
     const { enabledBricks, featuresLoaded } = useGlobalStore.getState();
-    const result = filterTabs(ACCESS_TABS, enabledBricks, featuresLoaded);
+    const result = filterVisibleTabs(ACCESS_TABS, enabledBricks, featuresLoaded);
     expect(result.map((t) => t.id)).toEqual(["credentials", "delegations"]);
   });
 });
@@ -436,26 +415,26 @@ describe("migrated TAB_ORDER panels", () => {
 
   describe("connectors (all brick: null)", () => {
     it("shows all tabs regardless of enabled bricks", () => {
-      const result = filterTabs(CONNECTORS_TABS, [], true);
+      const result = filterVisibleTabs(CONNECTORS_TABS, [], true);
       expect(result.map((t) => t.id)).toEqual(["available", "mounted", "skills", "write"]);
     });
 
     it("shows all tabs under minimal profile", () => {
-      const result = filterTabs(CONNECTORS_TABS, minimalBricks, true);
+      const result = filterVisibleTabs(CONNECTORS_TABS, minimalBricks, true);
       expect(result.map((t) => t.id)).toEqual(["available", "mounted", "skills", "write"]);
     });
   });
 
   describe("payments (all brick: null)", () => {
     it("shows all tabs regardless of enabled bricks", () => {
-      const result = filterTabs(PAYMENTS_TABS, [], true);
+      const result = filterVisibleTabs(PAYMENTS_TABS, [], true);
       expect(result.map((t) => t.id)).toEqual([
         "balance", "reservations", "transactions", "policies", "approvals",
       ]);
     });
 
     it("shows all tabs under minimal profile", () => {
-      const result = filterTabs(PAYMENTS_TABS, minimalBricks, true);
+      const result = filterVisibleTabs(PAYMENTS_TABS, minimalBricks, true);
       expect(result.map((t) => t.id)).toEqual([
         "balance", "reservations", "transactions", "policies", "approvals",
       ]);
@@ -464,34 +443,34 @@ describe("migrated TAB_ORDER panels", () => {
 
   describe("workflows (all brick: null)", () => {
     it("shows all tabs regardless of enabled bricks", () => {
-      const result = filterTabs(WORKFLOW_TABS, [], true);
+      const result = filterVisibleTabs(WORKFLOW_TABS, [], true);
       expect(result.map((t) => t.id)).toEqual(["workflows", "executions", "scheduler"]);
     });
   });
 
   describe("files (mixed: explorer always visible, shareLinks/uploads gated)", () => {
     it("shows only explorer under full profile (share_link/uploads not in full)", () => {
-      const result = filterTabs(FILES_TABS, bricks, true);
+      const result = filterVisibleTabs(FILES_TABS, bricks, true);
       expect(result.map((t) => t.id)).toEqual(["explorer"]);
     });
 
     it("shows all tabs when share_link and uploads bricks enabled", () => {
-      const result = filterTabs(FILES_TABS, [...bricks, "share_link", "uploads"], true);
+      const result = filterVisibleTabs(FILES_TABS, [...bricks, "share_link", "uploads"], true);
       expect(result.map((t) => t.id)).toEqual(["explorer", "shareLinks", "uploads"]);
     });
 
     it("shows only explorer under minimal profile", () => {
-      const result = filterTabs(FILES_TABS, minimalBricks, true);
+      const result = filterVisibleTabs(FILES_TABS, minimalBricks, true);
       expect(result.map((t) => t.id)).toEqual(["explorer"]);
     });
 
     it("shows explorer + shareLinks when share_link brick enabled", () => {
-      const result = filterTabs(FILES_TABS, ["share_link"], true);
+      const result = filterVisibleTabs(FILES_TABS, ["share_link"], true);
       expect(result.map((t) => t.id)).toEqual(["explorer", "shareLinks"]);
     });
 
     it("shows explorer + uploads when uploads brick enabled", () => {
-      const result = filterTabs(FILES_TABS, ["uploads"], true);
+      const result = filterVisibleTabs(FILES_TABS, ["uploads"], true);
       expect(result.map((t) => t.id)).toEqual(["explorer", "uploads"]);
     });
   });


### PR DESCRIPTION
## Summary
- derive status bar breadcrumbs from shared navigation metadata instead of showing the raw panel id
- centralize panel and tab metadata plus visible-tab filtering so the tab bar and breadcrumb logic share one source of truth
- add breadcrumb-focused tests and finish package-wide TypeScript/test cleanup needed to keep the TUI green

## Validation
- bunx tsc --noEmit
- bun test

Closes #3499