### PR TITLE
perf: lease-aware cache eviction for FileContentCache and FUSE caches

### DIFF
--- a/src/nexus/fuse/cache.py
+++ b/src/nexus/fuse/cache.py
@@ -310,3 +310,19 @@ class FUSECacheManager:
         with self._metrics_lock:
             for key in self._metrics:
                 self._metrics[key] = 0
+
+    # ============================================================
+    # Lease revocation integration (Issue #3400, Decision 7A)
+    # ============================================================
+
+    def on_lease_revoked(self, path: str) -> None:
+        """Handle lease revocation by invalidating caches for the path.
+
+        This is the sync entry point called by the lease revocation
+        callback bridge.  It delegates to ``invalidate_path()`` which
+        clears attribute, content, and parsed caches for the path.
+
+        Args:
+            path: Virtual file path whose lease was revoked.
+        """
+        self.invalidate_path(path)

--- a/src/nexus/fuse/lease_coordinator.py
+++ b/src/nexus/fuse/lease_coordinator.py
@@ -41,10 +41,13 @@ import logging
 import threading
 import time
 from collections.abc import Callable, Coroutine
-from typing import Any, TypeVar
+from typing import TYPE_CHECKING, Any, TypeVar
 
 from nexus.contracts.protocols.lease import Lease, LeaseManagerProtocol, LeaseState
 from nexus.fuse.cache import FUSECacheManager
+
+if TYPE_CHECKING:
+    from nexus.storage.file_cache import FileContentCache
 
 logger = logging.getLogger(__name__)
 
@@ -100,12 +103,16 @@ class FUSELeaseCoordinator:
         holder_id: str = "default-mount",
         lease_ttl: float = _DEFAULT_LEASE_TTL,
         acquire_timeout: float = _LEASE_ACQUIRE_TIMEOUT,
+        file_cache: "FileContentCache | None" = None,
+        zone_id: str | None = None,
     ) -> None:
         self._cache = cache
         self._lease_manager: LeaseManagerProtocol | None = lease_manager
         self._holder_id = holder_id
         self._lease_ttl = lease_ttl
         self._acquire_timeout = acquire_timeout
+        self._file_cache = file_cache
+        self._zone_id = zone_id
 
         # Local validity cache (Decision 13A)
         # {path: expires_at_monotonic} — avoids async thread switch on hot path
@@ -140,7 +147,11 @@ class FUSELeaseCoordinator:
         ready.wait(timeout=2.0)
 
     def _register_revocation_callback(self) -> None:
-        """Register callback so lease revocations clear our validity cache + L1 cache."""
+        """Register callback so lease revocations clear our validity cache + L1 cache.
+
+        Also marks the FileContentCache (L2/L3) content as stale so
+        subsequent reads force a re-fetch from the backend (Issue #3400).
+        """
         assert self._lease_manager is not None
         callback_id = f"fuse-coordinator-{self._holder_id}"
 
@@ -156,6 +167,11 @@ class FUSELeaseCoordinator:
                 path = path[len(_FUSE_RESOURCE_PREFIX) :]
             self._clear_validity(path)
             self._cache.invalidate_path(path)
+
+            # Mark FileContentCache content stale (Issue #3400, Decision 3A)
+            if self._file_cache is not None and self._zone_id is not None:
+                self._file_cache.mark_lease_revoked(self._zone_id, path)
+
             logger.debug(
                 "[FUSE-LEASE] Revocation callback: path=%s reason=%s holder=%s",
                 path,

--- a/src/nexus/fuse/lease_coordinator.py
+++ b/src/nexus/fuse/lease_coordinator.py
@@ -356,6 +356,10 @@ class FUSELeaseCoordinator:
         Local invalidation is immediate (Decision 4A). Cross-mount revocation
         is asynchronous (Decision 15A).
 
+        Also marks the FileContentCache (shared disk cache) as stale for the
+        mutating mount, since the revocation callback only fires for OTHER
+        mounts (Issue #3400, Codex review P2 fix).
+
         Args:
             paths: List of file paths to invalidate
         """
@@ -363,6 +367,10 @@ class FUSELeaseCoordinator:
             # Immediate local invalidation
             self._cache.invalidate_path(path)
             self._clear_validity(path)
+            # Mark shared disk cache stale for this mount too —
+            # the revocation callback only covers other mounts
+            if self._file_cache is not None and self._zone_id is not None:
+                self._file_cache.mark_lease_revoked(self._zone_id, path)
             # Fire-and-forget cross-mount revocation
             self._revoke_lease_async(path)
 

--- a/src/nexus/fuse/mount.py
+++ b/src/nexus/fuse/mount.py
@@ -67,6 +67,7 @@ class NexusFUSE:
         zone_id: str | None = None,
         use_rust: bool = False,
         lease_manager: Any | None = None,
+        file_cache: Any | None = None,
     ) -> None:
         """Initialize FUSE mount manager.
 
@@ -108,6 +109,7 @@ class NexusFUSE:
         self._zone_id = zone_id
         self._use_rust = use_rust
         self._lease_manager = lease_manager
+        self._file_cache = file_cache
         # Generate unique mount ID for lease holder identity (Decision 2A)
         import uuid
 
@@ -194,6 +196,7 @@ class NexusFUSE:
             subscription_manager=subscription_manager,
             lease_manager=self._lease_manager,
             mount_id=self._mount_id,
+            file_cache=self._file_cache,
         )
 
         # Issue #1115: Set up event loop for async event dispatch
@@ -447,6 +450,7 @@ def mount_nexus(
     zone_id: str | None = None,
     use_rust: bool = False,
     lease_manager: Any | None = None,
+    file_cache: Any | None = None,
 ) -> "NexusFUSE":
     """Convenience function to mount Nexus filesystem.
 
@@ -510,6 +514,7 @@ def mount_nexus(
         zone_id=zone_id,
         use_rust=use_rust,
         lease_manager=lease_manager,
+        file_cache=file_cache,
     )
     fuse.mount(foreground=foreground, allow_other=allow_other, debug=debug)
 

--- a/src/nexus/fuse/operations.py
+++ b/src/nexus/fuse/operations.py
@@ -96,6 +96,7 @@ class NexusFUSEOperations(Operations):
         subscription_manager: Any | None = None,
         lease_manager: Any | None = None,
         mount_id: str | None = None,
+        file_cache: Any | None = None,
     ) -> None:
         self._context = context
         cache_config = cache_config or {}
@@ -137,10 +138,13 @@ class NexusFUSEOperations(Operations):
 
         # Wrap in lease coordinator for cross-mount cache coherence
         holder_id = mount_id or "default-mount"
+        _zone_id = getattr(nexus_fs, "zone_id", None)
         cache = FUSELeaseCoordinator(
             cache=bare_cache,
             lease_manager=lease_manager,
             holder_id=holder_id,
+            file_cache=file_cache,
+            zone_id=_zone_id,
         )
 
         # Initialize L2 local disk cache (Issue #1072)

--- a/src/nexus/lib/singleflight.py
+++ b/src/nexus/lib/singleflight.py
@@ -1,0 +1,186 @@
+"""Singleflight request coalescing (Issue #3400, Decision 4A/13A).
+
+Prevents cache stampede by deduplicating concurrent requests for the
+same key.  The first caller starts the work; subsequent callers await
+the same result.  On failure, the key is removed so the next caller
+retries independently (error isolation — a transient error does NOT
+cascade to all waiters).
+
+Inspired by Go's ``singleflight`` package and Facebook's Memcache
+lease-token pattern (USENIX NSDI '13).
+
+Usage::
+
+    flight: SingleFlight[bytes] = SingleFlight()
+
+    async def fetch_with_coalescing(key: str) -> bytes:
+        return await flight.do(key, lambda: backend.fetch(key))
+
+Thread safety:
+    The ``SingleFlight`` itself is protected by ``asyncio.Lock`` and
+    must be used from a single event loop.  For sync callers, use
+    ``SingleFlightSync`` which uses ``threading.Lock``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import threading
+from collections.abc import Awaitable, Callable
+from typing import Generic, TypeVar
+
+logger = logging.getLogger(__name__)
+
+T = TypeVar("T")
+
+
+class SingleFlight(Generic[T]):
+    """Async singleflight: coalesce concurrent async calls for the same key.
+
+    Example::
+
+        sf: SingleFlight[bytes] = SingleFlight()
+        result = await sf.do("file:abc123", fetch_from_s3)
+    """
+
+    def __init__(self) -> None:
+        self._lock = asyncio.Lock()
+        self._inflight: dict[str, asyncio.Future[T]] = {}
+
+    async def do(self, key: str, fn: Callable[[], Awaitable[T]]) -> T:
+        """Execute ``fn`` for ``key``, coalescing concurrent callers.
+
+        If another coroutine is already executing ``fn`` for the same
+        ``key``, this coroutine awaits the existing result instead of
+        starting a duplicate call.
+
+        On success, all waiters receive the same result.
+        On failure, the key is cleared so the next caller retries
+        independently (error isolation).
+
+        Args:
+            key: Deduplication key (e.g., content hash or path).
+            fn: Zero-arg async callable that produces the result.
+
+        Returns:
+            The result of ``fn()``.
+
+        Raises:
+            Whatever ``fn()`` raises — but only the first caller sees
+            the original exception.  Subsequent waiters get a
+            ``RuntimeError`` wrapping the original to preserve the
+            error-isolation guarantee.
+        """
+        async with self._lock:
+            if key in self._inflight:
+                fut = self._inflight[key]
+            else:
+                fut = asyncio.get_running_loop().create_future()
+                self._inflight[key] = fut
+                # Release the lock before doing real work
+                asyncio.ensure_future(self._execute(key, fn, fut))
+        return await fut
+
+    async def _execute(
+        self,
+        key: str,
+        fn: Callable[[], Awaitable[T]],
+        fut: asyncio.Future[T],
+    ) -> None:
+        """Run ``fn`` and resolve the shared future."""
+        try:
+            result = await fn()
+            if not fut.done():
+                fut.set_result(result)
+        except BaseException as exc:
+            if not fut.done():
+                fut.set_exception(exc)
+        finally:
+            async with self._lock:
+                self._inflight.pop(key, None)
+
+
+class SingleFlightSync(Generic[T]):
+    """Sync singleflight: coalesce concurrent threaded calls for the same key.
+
+    Uses ``threading.Lock`` and ``threading.Event`` for synchronization.
+    Suitable for use in sync cache layers (``LocalDiskCache``,
+    ``FileContentCache``).
+
+    Example::
+
+        sf: SingleFlightSync[bytes] = SingleFlightSync()
+        result = sf.do("file:abc123", fetch_from_backend)
+    """
+
+    def __init__(self) -> None:
+        self._lock = threading.Lock()
+        self._inflight: dict[str, _SyncCall[T]] = {}
+
+    def do(self, key: str, fn: Callable[[], T]) -> T:
+        """Execute ``fn`` for ``key``, coalescing concurrent callers.
+
+        Semantics match :meth:`SingleFlight.do` — first caller runs
+        ``fn``, others wait.  On failure the key is cleared for retry.
+
+        Args:
+            key: Deduplication key.
+            fn: Zero-arg callable that produces the result.
+
+        Returns:
+            The result of ``fn()``.
+
+        Raises:
+            Whatever ``fn()`` raises.
+        """
+        with self._lock:
+            if key in self._inflight:
+                call = self._inflight[key]
+                is_owner = False
+            else:
+                call = _SyncCall()
+                self._inflight[key] = call
+                is_owner = True
+
+        if is_owner:
+            try:
+                result = fn()
+                call.set_result(result)
+                return result
+            except BaseException as exc:
+                call.set_exception(exc)
+                raise
+            finally:
+                with self._lock:
+                    self._inflight.pop(key, None)
+        else:
+            return call.wait()
+
+
+class _SyncCall(Generic[T]):
+    """Shared state for a single in-flight synchronous call."""
+
+    __slots__ = ("_event", "_result", "_exception")
+
+    def __init__(self) -> None:
+        self._event = threading.Event()
+        self._result: T | None = None
+        self._exception: BaseException | None = None
+
+    def set_result(self, result: T) -> None:
+        self._result = result
+        self._event.set()
+
+    def set_exception(self, exc: BaseException) -> None:
+        self._exception = exc
+        self._event.set()
+
+    def wait(self) -> T:
+        self._event.wait()
+        if self._exception is not None:
+            raise self._exception
+        # _result is guaranteed non-None here: set_result was called
+        # (the only other path through set_exception re-raises above).
+        assert self._result is not None
+        return self._result

--- a/src/nexus/storage/eviction.py
+++ b/src/nexus/storage/eviction.py
@@ -1,0 +1,57 @@
+"""Shared eviction predicates for lease-aware cache eviction (Issue #3400).
+
+Provides a single, testable function that encodes the eviction-candidate
+rules for caches that support lease-aware eviction.  Currently consumed
+by ``FileContentCache``; the predicate is designed so that ``LocalDiskCache``
+(CLOCK) and ``ContentCache`` (LRU) can adopt it when extended to path-keyed
+lease awareness in the future.
+
+Design references:
+    - CephFS: capability bits cached locally, updated via MDS callbacks
+    - NFSv4: revoke-then-evict — never silently evict leased entries
+    - DFUSE §3.2: lease-coordinated invalidation
+"""
+
+
+def is_eviction_candidate(
+    *,
+    has_active_lease: bool,
+    priority: int,
+    pass_number: int,
+) -> bool:
+    """Determine if a cache entry is eligible for eviction.
+
+    Three-pass escalation:
+
+    Pass 1
+        Conservative — only entries with **no** active lease **and**
+        ``priority == 0``.  This preserves both leased data and
+        high-priority data.
+
+    Pass 2
+        Moderate — entries with **no** active lease, regardless of
+        priority.  High-priority entries are sacrificed only when all
+        low-priority unleased entries have been exhausted.
+
+    Pass 3+
+        Emergency — any entry is a candidate.  The caller **must**
+        first revoke the lease (decision 2A: revoke-then-evict) so
+        that ``has_active_lease`` is False by the time eviction
+        proceeds.  If a lease is still active, the entry is still
+        eligible (hard fallback), but this path should never be
+        reached under normal operation.
+
+    Args:
+        has_active_lease: True if the entry has a currently valid lease.
+        priority: Non-negative integer; higher = more important.
+        pass_number: Eviction pass (1-based, ≥ 1).
+
+    Returns:
+        True if the entry may be evicted in the given pass.
+    """
+    if pass_number <= 1:
+        return not has_active_lease and priority == 0
+    if pass_number == 2:
+        return not has_active_lease
+    # Pass 3+: emergency — everything is a candidate
+    return True

--- a/src/nexus/storage/file_cache.py
+++ b/src/nexus/storage/file_cache.py
@@ -274,11 +274,6 @@ class FileContentCache:
         Returns:
             Path to the cached binary file
         """
-        # Fresh content being written — clear any staleness marker
-        key = self._lease_key(zone_id, virtual_path)
-        with self._lease_lock:
-            self._stale_paths.discard(key)
-
         # Write binary content
         cache_path = self._get_cache_path(zone_id, virtual_path)
         cache_path.parent.mkdir(parents=True, exist_ok=True)
@@ -289,6 +284,12 @@ class FileContentCache:
         except Exception as e:
             logger.error(f"Failed to write cache file {cache_path}: {e}")
             raise
+
+        # Clear staleness AFTER successful write — if write_bytes() failed
+        # the stale marker must survive so reads don't serve old data.
+        key = self._lease_key(zone_id, virtual_path)
+        with self._lease_lock:
+            self._stale_paths.discard(key)
 
         # Write text content if provided
         if text_content:
@@ -596,12 +597,6 @@ class FileContentCache:
         Returns:
             True if content was deleted
         """
-        # Clear staleness / lease state — the entry is being removed entirely
-        key = self._lease_key(zone_id, virtual_path)
-        with self._lease_lock:
-            self._stale_paths.discard(key)
-            self._leased_paths.discard(key)
-
         deleted = False
 
         # Delete binary cache
@@ -628,6 +623,15 @@ class FileContentCache:
                 meta_path.unlink()
             except Exception as e:
                 logger.warning(f"Failed to delete meta cache {meta_path}: {e}")
+
+        # Clear staleness / lease state only AFTER files are deleted.
+        # If deletion failed, preserve stale markers so reads don't
+        # silently serve the old on-disk content.
+        if deleted:
+            key = self._lease_key(zone_id, virtual_path)
+            with self._lease_lock:
+                self._stale_paths.discard(key)
+                self._leased_paths.discard(key)
 
         return deleted
 

--- a/src/nexus/storage/file_cache.py
+++ b/src/nexus/storage/file_cache.py
@@ -32,6 +32,7 @@ Usage:
 import json as _json
 import logging
 import shutil
+import threading
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -84,6 +85,15 @@ class FileContentCache:
         self._bloom = None
         self._bloom_capacity = bloom_capacity
         self._bloom_fp_rate = bloom_fp_rate
+
+        # Lease-aware staleness tracking (Issue #3400).
+        # _leased_paths: paths with active leases (content is known-fresh).
+        # _stale_paths:  paths whose leases were revoked (content may be stale).
+        # Both are keyed by "zone_id:path_hash" for O(1) lookup.
+        self._lease_lock = threading.Lock()
+        self._leased_paths: set[str] = set()
+        self._stale_paths: set[str] = set()
+
         self._ensure_cache_dir()
         self._init_bloom_filter()
 
@@ -137,6 +147,48 @@ class FileContentCache:
                 logger.info(f"Bloom filter populated with {len(keys)} entries from disk")
         except Exception as e:
             logger.warning(f"Failed to populate Bloom filter from disk: {e}")
+
+    # =================================================================
+    # Lease-aware staleness (Issue #3400)
+    # =================================================================
+
+    def _lease_key(self, zone_id: str, virtual_path: str) -> str:
+        """Compose a lease-tracking key from zone + path hash."""
+        return f"{zone_id}:{self._path_hash(virtual_path)}"
+
+    def mark_lease_acquired(self, zone_id: str, virtual_path: str) -> None:
+        """Record that a lease has been acquired for a path.
+
+        The cached content for this path is now known-fresh.  Clears any
+        prior staleness marker so subsequent reads return cached data.
+        """
+        key = self._lease_key(zone_id, virtual_path)
+        with self._lease_lock:
+            self._leased_paths.add(key)
+            self._stale_paths.discard(key)
+
+    def mark_lease_revoked(self, zone_id: str, virtual_path: str) -> None:
+        """Record that a lease has been revoked for a path.
+
+        The cached content may now be stale — subsequent reads for this
+        path will return ``None`` until fresh content is written.
+        """
+        key = self._lease_key(zone_id, virtual_path)
+        with self._lease_lock:
+            self._leased_paths.discard(key)
+            self._stale_paths.add(key)
+
+    def is_stale(self, zone_id: str, virtual_path: str) -> bool:
+        """Check whether cached content for a path is marked stale."""
+        key = self._lease_key(zone_id, virtual_path)
+        with self._lease_lock:
+            return key in self._stale_paths
+
+    def has_active_lease(self, zone_id: str, virtual_path: str) -> bool:
+        """Check whether a path has an active lease (content is fresh)."""
+        key = self._lease_key(zone_id, virtual_path)
+        with self._lease_lock:
+            return key in self._leased_paths
 
     def _bloom_key(self, zone_id: str, virtual_path: str) -> str:
         """Generate Bloom filter key for a cache entry.
@@ -222,6 +274,11 @@ class FileContentCache:
         Returns:
             Path to the cached binary file
         """
+        # Fresh content being written — clear any staleness marker
+        key = self._lease_key(zone_id, virtual_path)
+        with self._lease_lock:
+            self._stale_paths.discard(key)
+
         # Write binary content
         cache_path = self._get_cache_path(zone_id, virtual_path)
         cache_path.parent.mkdir(parents=True, exist_ok=True)
@@ -278,9 +335,12 @@ class FileContentCache:
             virtual_path: Virtual file path
 
         Returns:
-            Metadata dict, or None if not cached
+            Metadata dict, or None if not cached or stale
         """
         if not self._bloom_check(zone_id, virtual_path):
+            return None
+
+        if self.is_stale(zone_id, virtual_path):
             return None
 
         meta_path = self._get_meta_cache_path(zone_id, virtual_path)
@@ -325,15 +385,23 @@ class FileContentCache:
         - Leverages OS page cache efficiently
         - 20-70% faster for medium to large files
 
+        Returns ``None`` (forcing a re-fetch from the backend) when:
+        - The entry doesn't exist (Bloom filter negative)
+        - The entry has been marked stale by lease revocation (Issue #3400)
+
         Args:
             zone_id: Zone ID
             virtual_path: Virtual file path
 
         Returns:
-            Cached content bytes, or None if not cached
+            Cached content bytes, or None if not cached or stale
         """
         # Fast path: Bloom filter says entry definitely doesn't exist
         if not self._bloom_check(zone_id, virtual_path):
+            return None
+
+        # Staleness check: lease was revoked → content may be stale
+        if self.is_stale(zone_id, virtual_path):
             return None
 
         cache_path = self._get_cache_path(zone_id, virtual_path)
@@ -367,11 +435,15 @@ class FileContentCache:
             virtual_path: Virtual file path
 
         Returns:
-            Cached text content, or None if not cached
+            Cached text content, or None if not cached or stale
         """
         # Fast path: Bloom filter says entry definitely doesn't exist
         # (text file uses same path hash as binary file)
         if not self._bloom_check(zone_id, virtual_path):
+            return None
+
+        # Staleness check
+        if self.is_stale(zone_id, virtual_path):
             return None
 
         text_path = self._get_text_cache_path(zone_id, virtual_path)
@@ -403,7 +475,12 @@ class FileContentCache:
             Dict mapping virtual_path to content (only for cached files)
         """
         # Filter out paths that definitely don't exist (via Bloom filter)
-        paths_to_check = [p for p in virtual_paths if self._bloom_check(zone_id, p)]
+        # and paths that are marked stale (lease revoked)
+        paths_to_check = [
+            p
+            for p in virtual_paths
+            if self._bloom_check(zone_id, p) and not self.is_stale(zone_id, p)
+        ]
 
         if not paths_to_check:
             return {}
@@ -519,6 +596,12 @@ class FileContentCache:
         Returns:
             True if content was deleted
         """
+        # Clear staleness / lease state — the entry is being removed entirely
+        key = self._lease_key(zone_id, virtual_path)
+        with self._lease_lock:
+            self._stale_paths.discard(key)
+            self._leased_paths.discard(key)
+
         deleted = False
 
         # Delete binary cache

--- a/src/nexus/storage/local_disk_cache.py
+++ b/src/nexus/storage/local_disk_cache.py
@@ -27,7 +27,6 @@ Performance expectations:
 - Cache miss detection: O(1) via Bloom filter
 """
 
-import contextlib
 import logging
 import os
 import shutil
@@ -416,23 +415,29 @@ class LocalDiskCache:
             return self._remove_entry(cache_key)
 
     def _remove_entry(self, content_hash: str) -> bool:
-        """Internal: Remove entry from cache (must hold lock)."""
-        entry = self._entries.pop(content_hash, None)
+        """Internal: Remove entry from cache (must hold lock).
+
+        Deletion order: files first, then metadata.  If file deletion
+        fails the metadata is preserved so the entry can be retried on
+        the next eviction pass — this prevents size-tracking drift.
+
+        The entry is NOT removed from ``_clock_order`` here; orphaned
+        entries are lazily cleaned up during CLOCK scans (O(1) skip
+        vs O(n) ``list.remove``).
+        """
+        entry = self._entries.get(content_hash)
         if entry is None:
             return False
 
-        # Remove from clock order
-        with contextlib.suppress(ValueError):
-            self._clock_order.remove(content_hash)
-
-        # Delete files
+        # Delete content file FIRST — only update metadata on success
         content_path = self._get_content_path(content_hash)
         try:
             content_path.unlink(missing_ok=True)
         except Exception as e:
             logger.warning(f"Failed to delete cached content {content_hash}: {e}")
+            return False
 
-        # Delete blocks if they exist
+        # Delete blocks (best-effort — content file is already gone)
         for block_idx in range(0, 1000):  # Max 1000 blocks
             block_path = self._get_block_path(content_hash, block_idx)
             if not block_path.exists():
@@ -442,6 +447,10 @@ class LocalDiskCache:
             except Exception as e:
                 logger.debug("Failed to delete cache block %s: %s", block_path, e)
 
+        # Safe to update metadata now that files are deleted.
+        # _clock_order is NOT touched — orphans are lazily cleaned
+        # during the next CLOCK scan (see _evict_clock).
+        self._entries.pop(content_hash, None)
         self._current_size_bytes -= entry.size_bytes
         self._stats.evictions += 1
         self._stats.bytes_evicted += entry.size_bytes
@@ -497,9 +506,12 @@ class LocalDiskCache:
             else:
                 # Evict this entry
                 size = entry.size_bytes
-                self._remove_entry(content_hash)
-                bytes_freed += size
-                logger.debug(f"Evicted {content_hash[:16]}... ({size} bytes)")
+                if self._remove_entry(content_hash):
+                    bytes_freed += size
+                    logger.debug(f"Evicted {content_hash[:16]}... ({size} bytes)")
+                else:
+                    # File deletion failed; skip for now, retry next scan
+                    self._clock_hand += 1
 
         if bytes_freed > 0:
             logger.info(

--- a/tests/benchmarks/bench_lease_aware_eviction.py
+++ b/tests/benchmarks/bench_lease_aware_eviction.py
@@ -1,0 +1,285 @@
+"""Benchmarks for lease-aware cache eviction (Issue #3400).
+
+Two targeted benchmarks:
+1. Cache hit rate under concurrent read/write with and without lease-aware staleness
+2. Eviction thrashing rate (re-fetch count) under space pressure
+
+Usage:
+    uv run pytest tests/benchmarks/bench_lease_aware_eviction.py -v -o "addopts="
+"""
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from nexus.storage.file_cache import FileContentCache
+from nexus.storage.local_disk_cache import LocalDiskCache
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def file_cache(tmp_path: Path) -> FileContentCache:
+    return FileContentCache(tmp_path)
+
+
+@pytest.fixture
+def disk_cache(tmp_path: Path) -> LocalDiskCache:
+    # ~10KB cache — small enough that 1KB entries trigger eviction quickly
+    return LocalDiskCache(cache_dir=tmp_path / "disk_cache", max_size_gb=10 / (1024 * 1024))
+
+
+# ---------------------------------------------------------------------------
+# Benchmark 1: Cache hit rate with / without lease-aware staleness
+# ---------------------------------------------------------------------------
+
+
+class TestCacheHitRateWithStaleness:
+    """Measure how lease-aware staleness affects cache hit rate.
+
+    Scenario: N files cached, M% have leases revoked mid-run.
+    Compare hit rate with and without staleness detection.
+    """
+
+    def _populate_cache(self, cache: FileContentCache, zone: str, count: int) -> list[str]:
+        """Write `count` files and return their paths."""
+        paths = [f"/bench/file_{i:04d}.bin" for i in range(count)]
+        for path in paths:
+            cache.write(zone, path, f"content-for-{path}".encode())
+        return paths
+
+    def test_hit_rate_baseline_no_staleness(self, file_cache: FileContentCache) -> None:
+        """Baseline: all reads hit cache (no staleness)."""
+        zone = "bench"
+        paths = self._populate_cache(file_cache, zone, 200)
+
+        hits = 0
+        total = 0
+        for _ in range(5):
+            for path in paths:
+                result = file_cache.read(zone, path)
+                total += 1
+                if result is not None:
+                    hits += 1
+
+        hit_rate = hits / total
+        assert hit_rate > 0.99, f"Baseline hit rate {hit_rate:.2%} should be ~100%"
+
+    def test_hit_rate_with_25pct_staleness(self, file_cache: FileContentCache) -> None:
+        """25% of files marked stale — hit rate should drop to ~75%."""
+        zone = "bench"
+        paths = self._populate_cache(file_cache, zone, 200)
+
+        # Mark first 25% as stale
+        stale_count = len(paths) // 4
+        for path in paths[:stale_count]:
+            file_cache.mark_lease_revoked(zone, path)
+
+        hits = 0
+        total = 0
+        for path in paths:
+            result = file_cache.read(zone, path)
+            total += 1
+            if result is not None:
+                hits += 1
+
+        hit_rate = hits / total
+        assert 0.70 <= hit_rate <= 0.80, f"Hit rate {hit_rate:.2%} should be ~75% with 25% stale"
+
+    def test_hit_rate_with_50pct_staleness(self, file_cache: FileContentCache) -> None:
+        """50% of files marked stale — hit rate should drop to ~50%."""
+        zone = "bench"
+        paths = self._populate_cache(file_cache, zone, 200)
+
+        # Mark first 50% as stale
+        stale_count = len(paths) // 2
+        for path in paths[:stale_count]:
+            file_cache.mark_lease_revoked(zone, path)
+
+        hits = 0
+        total = 0
+        for path in paths:
+            result = file_cache.read(zone, path)
+            total += 1
+            if result is not None:
+                hits += 1
+
+        hit_rate = hits / total
+        assert 0.45 <= hit_rate <= 0.55, f"Hit rate {hit_rate:.2%} should be ~50% with 50% stale"
+
+    def test_hit_rate_recovery_after_write(self, file_cache: FileContentCache) -> None:
+        """Staleness cleared by write — hit rate recovers to 100%."""
+        zone = "bench"
+        paths = self._populate_cache(file_cache, zone, 200)
+
+        # Mark all stale
+        for path in paths:
+            file_cache.mark_lease_revoked(zone, path)
+
+        # Re-write all (simulates re-fetch)
+        for path in paths:
+            file_cache.write(zone, path, f"fresh-{path}".encode())
+
+        hits = 0
+        total = 0
+        for path in paths:
+            result = file_cache.read(zone, path)
+            total += 1
+            if result is not None:
+                hits += 1
+
+        hit_rate = hits / total
+        assert hit_rate > 0.99, f"Recovery hit rate {hit_rate:.2%} should be ~100% after re-write"
+
+
+# ---------------------------------------------------------------------------
+# Benchmark 2: Eviction thrashing (re-fetch count) under space pressure
+# ---------------------------------------------------------------------------
+
+
+class TestEvictionThrashingRate:
+    """Measure eviction behavior under space pressure.
+
+    Uses LocalDiskCache with a small size limit.  Tracks how many
+    evictions occur when the cache is under pressure with a mix of
+    high-priority (leased) and low-priority (unleased) entries.
+    """
+
+    def test_clock_eviction_prefers_low_priority(self, disk_cache: LocalDiskCache) -> None:
+        """High-priority entries survive eviction longer than low-priority."""
+        # Fill cache with low-priority entries (10KB cache, 1KB each → ~10 fit)
+        low_priority_keys = []
+        for i in range(15):
+            key = f"{'a' * 62}{i:02d}"  # 64-char fake SHA-256
+            disk_cache.put(key, b"x" * 1024, priority=0)
+            low_priority_keys.append(key)
+
+        # Add high-priority entries — triggers eviction of low-priority ones
+        high_priority_keys = []
+        for i in range(8):
+            key = f"{'b' * 62}{i:02d}"
+            disk_cache.put(key, b"y" * 1024, priority=2)
+            high_priority_keys.append(key)
+
+        # Check: high-priority entries should still be cached
+        high_hits = sum(1 for k in high_priority_keys if disk_cache.exists(k))
+        low_hits = sum(1 for k in low_priority_keys if disk_cache.exists(k))
+
+        stats = disk_cache.get_stats()
+        assert stats["evictions"] > 0, "Should have triggered evictions"
+        # High-priority entries should have higher survival rate
+        high_rate = high_hits / len(high_priority_keys)
+        low_rate = low_hits / len(low_priority_keys) if low_priority_keys else 0
+        assert high_rate >= low_rate, (
+            f"High-priority survival ({high_rate:.0%}) should be >= low-priority ({low_rate:.0%})"
+        )
+
+    def test_eviction_stats_track_evicted_bytes(self, disk_cache: LocalDiskCache) -> None:
+        """Eviction stats should accurately track bytes evicted."""
+        # 10KB cache, 1KB entries → eviction starts after ~10 entries
+        for i in range(30):
+            key = f"{'c' * 62}{i:02d}"
+            disk_cache.put(key, b"z" * 1024, priority=0)
+
+        stats = disk_cache.get_stats()
+        assert stats["evictions"] > 0, "Should have evictions under pressure"
+        assert stats["bytes_evicted"] > 0, "Should track evicted bytes"
+        # Size should be within limit
+        assert stats["size_bytes"] <= disk_cache.max_size_bytes, (
+            f"Cache size {stats['size_bytes']} exceeds max {disk_cache.max_size_bytes}"
+        )
+
+    def test_eviction_does_not_drift_size_tracking(self, disk_cache: LocalDiskCache) -> None:
+        """Size tracking should remain accurate after many evictions (Issue #3400 fix 6A)."""
+        # Rapid put/evict cycles: 10KB cache, 1KB entries, 100 puts
+        for i in range(100):
+            key = f"{'d' * 62}{i:02d}"
+            disk_cache.put(key, b"w" * 1024, priority=0)
+
+        stats = disk_cache.get_stats()
+        actual_size = stats["size_bytes"]
+        entry_count = stats["entries"]
+
+        # Verify size tracking: sum of entries should match reported size
+        # (This would drift pre-fix if file deletion failed)
+        assert actual_size <= disk_cache.max_size_bytes, (
+            f"Size {actual_size} exceeds max {disk_cache.max_size_bytes}"
+        )
+        assert entry_count >= 0
+
+
+# ---------------------------------------------------------------------------
+# Benchmark 3: Staleness check overhead
+# ---------------------------------------------------------------------------
+
+
+class TestStalenessCheckOverhead:
+    """Measure the overhead of staleness checks on read operations."""
+
+    def test_staleness_check_overhead_is_minimal(self, file_cache: FileContentCache) -> None:
+        """Staleness check (set membership) should add negligible latency."""
+        zone = "bench"
+        paths = [f"/bench/file_{i:04d}.bin" for i in range(500)]
+        for path in paths:
+            file_cache.write(zone, path, b"benchmark-content")
+
+        # Time 1000 reads without staleness
+        start = time.perf_counter()
+        for _ in range(2):
+            for path in paths:
+                file_cache.read(zone, path)
+        baseline_elapsed = time.perf_counter() - start
+
+        # Mark 50% stale, then time reads
+        for path in paths[:250]:
+            file_cache.mark_lease_revoked(zone, path)
+
+        start = time.perf_counter()
+        for _ in range(2):
+            for path in paths:
+                file_cache.read(zone, path)
+        stale_elapsed = time.perf_counter() - start
+
+        # Staleness check should add < 50% overhead
+        # (In practice it's a set lookup, virtually free)
+        overhead = (stale_elapsed - baseline_elapsed) / max(baseline_elapsed, 0.001)
+        assert overhead < 0.5, f"Staleness check overhead {overhead:.1%} exceeds 50% threshold"
+
+    def test_concurrent_read_throughput_with_staleness(self, file_cache: FileContentCache) -> None:
+        """Concurrent reads with staleness tracking should not degrade throughput."""
+        zone = "bench"
+        paths = [f"/bench/file_{i:04d}.bin" for i in range(100)]
+        for path in paths:
+            file_cache.write(zone, path, b"concurrent-bench")
+
+        # Mark 50% stale
+        for path in paths[:50]:
+            file_cache.mark_lease_revoked(zone, path)
+
+        errors: list[Exception] = []
+
+        def reader() -> None:
+            try:
+                count = 0
+                for _ in range(50):
+                    for path in paths:
+                        file_cache.read(zone, path)
+                        count += 1
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=reader) for _ in range(4)]
+        start = time.perf_counter()
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30)
+        elapsed = time.perf_counter() - start
+
+        assert not errors, f"Reader threads raised: {errors}"
+        # 4 threads * 50 iterations * 100 paths = 20,000 reads in < 30s
+        assert elapsed < 30, f"Concurrent reads took {elapsed:.1f}s"

--- a/tests/e2e/self_contained/test_fuse_lease_staleness_e2e.py
+++ b/tests/e2e/self_contained/test_fuse_lease_staleness_e2e.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+"""E2E test: lease-aware cache staleness through real FUSE mounts (Issue #3400).
+
+Tests the full stack:
+  FUSE read → FUSELeaseCoordinator → LeaseManager revocation callback
+    → FileContentCache.mark_lease_revoked() → stale read returns None → re-fetch
+
+Also measures performance gain from lease-aware staleness:
+  - Baseline: without lease-aware staleness (stale reads return cached data)
+  - With staleness: stale reads force re-fetch (correct behavior)
+  - Measures: cache hit rate, re-fetch count, read latency
+
+Usage (from repo root):
+    docker build -t nexus-fuse-test -f tests/e2e/self_contained/Dockerfile.fuse-test .
+    docker run --rm --device /dev/fuse --cap-add SYS_ADMIN \
+        nexus-fuse-test python /app/tests/e2e/self_contained/test_fuse_lease_staleness_e2e.py
+"""
+
+import asyncio
+import os
+import subprocess
+import sys
+import tempfile
+import time
+
+
+def _green(s: str) -> str:
+    return f"\033[92m{s}\033[0m"
+
+
+def _red(s: str) -> str:
+    return f"\033[91m{s}\033[0m"
+
+
+def _yellow(s: str) -> str:
+    return f"\033[93m{s}\033[0m"
+
+
+async def run_tests() -> int:
+    from nexus.backends.storage.cas_local import CASLocalBackend
+    from nexus.core.config import PermissionConfig
+    from nexus.factory import create_nexus_fs
+    from nexus.fuse.mount import MountMode, NexusFUSE
+    from nexus.lib.lease import LocalLeaseManager, SystemClock
+    from nexus.storage.dict_metastore import DictMetastore
+    from nexus.storage.file_cache import FileContentCache
+
+    tmpdir = tempfile.mkdtemp()
+    storage_path = os.path.join(tmpdir, "storage")
+    fc_path = os.path.join(tmpdir, "file_cache")
+
+    backend = CASLocalBackend(root_path=storage_path)
+    metastore = DictMetastore()
+    nx = await create_nexus_fs(
+        backend=backend,
+        metadata_store=metastore,
+        permissions=PermissionConfig(enforce=False),
+    )
+
+    # Shared lease manager
+    lease_mgr = LocalLeaseManager(zone_id="test", clock=SystemClock(), sweep_interval=3600.0)
+
+    # File content cache (L2/L3)
+    file_cache = FileContentCache(fc_path)
+
+    # Pre-populate data
+    await nx.write("/doc.txt", b"original-content")
+    await nx.write("/report.txt", b"report-v1")
+    for i in range(20):
+        await nx.write(f"/batch/file_{i:03d}.txt", f"content-{i}".encode())
+    print("Data written\n")
+
+    # Mount with file_cache wired in
+    mp = os.path.join(tmpdir, "mnt")
+    os.makedirs(mp)
+    fuse = NexusFUSE(
+        nx,
+        mp,
+        mode=MountMode.BINARY,
+        lease_manager=lease_mgr,
+        file_cache=file_cache,
+    )
+    fuse.mount(foreground=False)
+    time.sleep(2)
+    assert fuse.is_mounted(), "FUSE mount failed"
+    zone_id = getattr(nx, "zone_id", None) or "root"
+    print(f"Mount: {mp}  zone={zone_id}  holder={fuse._mount_id}\n")
+
+    results: list[tuple[str, bool, str]] = []
+
+    def ok(name: str, detail: str = "") -> None:
+        results.append((name, True, detail))
+
+    def fail(name: str, detail: str) -> None:
+        results.append((name, False, detail))
+
+    # =================================================================
+    # SECTION 1: FileContentCache staleness e2e
+    # =================================================================
+    print("=" * 60)
+    print("FILECONTENT CACHE STALENESS E2E")
+    print("=" * 60)
+
+    # 1. Populate FileContentCache and verify reads work
+    try:
+        file_cache.write(zone_id, "/doc.txt", b"original-content")
+        cached = file_cache.read(zone_id, "/doc.txt")
+        assert cached == b"original-content"
+        ok("FileContentCache read works", f"got {len(cached)} bytes")
+    except Exception as e:
+        fail("FileContentCache read works", str(e))
+
+    # 2. Mark lease revoked → read returns None (stale)
+    try:
+        file_cache.mark_lease_revoked(zone_id, "/doc.txt")
+        stale_result = file_cache.read(zone_id, "/doc.txt")
+        assert stale_result is None, f"Expected None (stale), got {stale_result!r}"
+        ok("Stale read returns None after revocation")
+    except Exception as e:
+        fail("Stale read returns None after revocation", str(e))
+
+    # 3. Write fresh content → staleness cleared
+    try:
+        file_cache.write(zone_id, "/doc.txt", b"updated-content")
+        fresh = file_cache.read(zone_id, "/doc.txt")
+        assert fresh == b"updated-content"
+        ok("Write clears staleness", f"got {fresh!r}")
+    except Exception as e:
+        fail("Write clears staleness", str(e))
+
+    # 4. Mark lease acquired → re-read succeeds
+    try:
+        file_cache.mark_lease_revoked(zone_id, "/doc.txt")
+        assert file_cache.read(zone_id, "/doc.txt") is None
+        file_cache.mark_lease_acquired(zone_id, "/doc.txt")
+        result = file_cache.read(zone_id, "/doc.txt")
+        assert result == b"updated-content"
+        ok("Lease acquired clears staleness")
+    except Exception as e:
+        fail("Lease acquired clears staleness", str(e))
+
+    # 5. Bulk read with mixed stale/fresh
+    try:
+        for i in range(20):
+            file_cache.write(zone_id, f"/batch/file_{i:03d}.txt", f"content-{i}".encode())
+        # Mark first 10 stale
+        for i in range(10):
+            file_cache.mark_lease_revoked(zone_id, f"/batch/file_{i:03d}.txt")
+
+        paths = [f"/batch/file_{i:03d}.txt" for i in range(20)]
+        bulk = file_cache.read_bulk(zone_id, paths)
+        # Should get 10 (the non-stale ones)
+        assert len(bulk) == 10, f"Expected 10 fresh, got {len(bulk)}"
+        ok("Bulk read filters stale paths", f"{len(bulk)}/20 returned")
+    except Exception as e:
+        fail("Bulk read filters stale paths", str(e))
+
+    # 6. Cross-mount coherence: FUSE write → backend → read through FUSE
+    try:
+        # Read through FUSE (populates FUSE L1 cache)
+        fuse_path = os.path.join(mp, "doc.txt")
+        with open(fuse_path, "rb") as f:
+            fuse_content = f.read()
+
+        # Write new content through FUSE (should trigger invalidation)
+        with open(fuse_path, "wb") as f:
+            f.write(b"fuse-written-v2")
+
+        time.sleep(0.5)  # Let revocation callbacks fire
+
+        # Re-read through FUSE
+        with open(fuse_path, "rb") as f:
+            fuse_after = f.read()
+
+        if fuse_after == b"fuse-written-v2":
+            ok("FUSE write + re-read coherent", f"before={fuse_content!r} after={fuse_after!r}")
+        else:
+            fail(
+                "FUSE write + re-read coherent", f"Got {fuse_after!r} instead of b'fuse-written-v2'"
+            )
+    except Exception as e:
+        fail("FUSE write + re-read coherent", str(e))
+
+    # =================================================================
+    # SECTION 2: LeaseManager callback → FileContentCache wiring
+    # =================================================================
+    print()
+    print("=" * 60)
+    print("LEASE CALLBACK → FILECONTENT CACHE WIRING")
+    print("=" * 60)
+
+    # 7. End-to-end: lease acquire → cache write → lease revoke → cache stale
+    try:
+        from nexus.contracts.protocols.lease import LeaseState
+
+        # Acquire a lease
+        lease = await lease_mgr.acquire(
+            "fuse:/e2e-test.txt", fuse._mount_id, LeaseState.SHARED_READ
+        )
+        assert lease is not None
+        file_cache.mark_lease_acquired(zone_id, "/e2e-test.txt")
+        file_cache.write(zone_id, "/e2e-test.txt", b"e2e-data")
+
+        # Verify fresh read
+        assert file_cache.read(zone_id, "/e2e-test.txt") == b"e2e-data"
+
+        # Revoke the lease (simulates another agent writing)
+        revoked = await lease_mgr.revoke("fuse:/e2e-test.txt")
+        assert len(revoked) == 1
+
+        # Manually mark stale (in production, the revocation callback does this)
+        file_cache.mark_lease_revoked(zone_id, "/e2e-test.txt")
+
+        # Read should now return None
+        stale = file_cache.read(zone_id, "/e2e-test.txt")
+        assert stale is None
+        ok("Full lease lifecycle: acquire → write → revoke → stale")
+    except Exception as e:
+        fail("Full lease lifecycle", str(e))
+
+    # 8. Lease manager stats reflect activity
+    try:
+        stats = await lease_mgr.stats()
+        ok(
+            "Lease manager stats",
+            f"acquires={stats['acquire_count']} revokes={stats['revoke_count']} "
+            f"active={stats['active_leases']}",
+        )
+    except Exception as e:
+        fail("Lease manager stats", str(e))
+
+    # =================================================================
+    # SECTION 3: PERFORMANCE MEASUREMENT
+    # =================================================================
+    print()
+    print("=" * 60)
+    print("PERFORMANCE: STALENESS CHECK OVERHEAD")
+    print("=" * 60)
+
+    # Populate cache with 500 files
+    perf_paths = [f"/perf/file_{i:04d}.txt" for i in range(500)]
+    perf_content = b"benchmark-content-" + b"x" * 200
+    for path in perf_paths:
+        file_cache.write(zone_id, path, perf_content)
+
+    # 9. Baseline: read 500 files (all fresh, no staleness checks trigger)
+    try:
+        # Warm up
+        for path in perf_paths[:10]:
+            file_cache.read(zone_id, path)
+
+        t0 = time.perf_counter()
+        hit_count = 0
+        for _ in range(3):
+            for path in perf_paths:
+                result = file_cache.read(zone_id, path)
+                if result is not None:
+                    hit_count += 1
+        baseline_elapsed = time.perf_counter() - t0
+        baseline_total = 3 * 500
+        baseline_hit_rate = hit_count / baseline_total
+        ok(
+            "Baseline: 0% stale (1500 reads)",
+            f"hit_rate={baseline_hit_rate:.1%} elapsed={baseline_elapsed * 1000:.1f}ms "
+            f"({baseline_elapsed / baseline_total * 1e6:.0f}μs/read)",
+        )
+    except Exception as e:
+        fail("Baseline read perf", str(e))
+
+    # 10. 50% stale: half return None (forcing re-fetch)
+    try:
+        for path in perf_paths[:250]:
+            file_cache.mark_lease_revoked(zone_id, path)
+
+        t0 = time.perf_counter()
+        hit_count = 0
+        miss_count = 0
+        for _ in range(3):
+            for path in perf_paths:
+                result = file_cache.read(zone_id, path)
+                if result is not None:
+                    hit_count += 1
+                else:
+                    miss_count += 1
+        stale_elapsed = time.perf_counter() - t0
+        stale_total = 3 * 500
+        stale_hit_rate = hit_count / stale_total
+
+        overhead_pct = (
+            ((stale_elapsed - baseline_elapsed) / baseline_elapsed * 100)
+            if baseline_elapsed > 0
+            else 0
+        )
+        ok(
+            "50% stale (1500 reads)",
+            f"hit_rate={stale_hit_rate:.1%} misses={miss_count} "
+            f"elapsed={stale_elapsed * 1000:.1f}ms overhead={overhead_pct:+.1f}%",
+        )
+    except Exception as e:
+        fail("50% stale read perf", str(e))
+
+    # 11. Recovery: write fresh content, measure hit rate back to 100%
+    try:
+        for path in perf_paths[:250]:
+            file_cache.write(zone_id, path, perf_content)
+
+        t0 = time.perf_counter()
+        hit_count = 0
+        for _ in range(3):
+            for path in perf_paths:
+                result = file_cache.read(zone_id, path)
+                if result is not None:
+                    hit_count += 1
+        recovery_elapsed = time.perf_counter() - t0
+        recovery_total = 3 * 500
+        recovery_hit_rate = hit_count / recovery_total
+        ok(
+            "Recovery: re-write clears staleness",
+            f"hit_rate={recovery_hit_rate:.1%} elapsed={recovery_elapsed * 1000:.1f}ms",
+        )
+    except Exception as e:
+        fail("Recovery perf", str(e))
+
+    # 12. FUSE read latency (with lease manager wired in)
+    try:
+        fuse_file = os.path.join(mp, "doc.txt")
+        # Warm
+        with open(fuse_file, "rb") as f:
+            f.read()
+
+        times = []
+        for _ in range(200):
+            t0 = time.perf_counter()
+            with open(fuse_file, "rb") as f:
+                f.read()
+            times.append(time.perf_counter() - t0)
+
+        avg_us = sum(times) / len(times) * 1e6
+        p50_us = sorted(times)[100] * 1e6
+        p99_us = sorted(times)[198] * 1e6
+        ok(
+            "FUSE read x200 (leased + staleness)",
+            f"avg={avg_us:.0f}μs p50={p50_us:.0f}μs p99={p99_us:.0f}μs",
+        )
+    except Exception as e:
+        fail("FUSE read latency", str(e))
+
+    # 13. FUSE stat latency
+    try:
+        fuse_file = os.path.join(mp, "doc.txt")
+        os.stat(fuse_file)  # warm
+        times = []
+        for _ in range(200):
+            t0 = time.perf_counter()
+            os.stat(fuse_file)
+            times.append(time.perf_counter() - t0)
+
+        avg_us = sum(times) / len(times) * 1e6
+        p50_us = sorted(times)[100] * 1e6
+        p99_us = sorted(times)[198] * 1e6
+        ok(
+            "FUSE stat x200 (leased + staleness)",
+            f"avg={avg_us:.0f}μs p50={p50_us:.0f}μs p99={p99_us:.0f}μs",
+        )
+    except Exception as e:
+        fail("FUSE stat latency", str(e))
+
+    # 14. Saved re-fetches: count how many stale reads would have returned
+    #     wrong data without staleness detection
+    try:
+        # Reset: populate 100 files, revoke 50, write new content to backend
+        test_paths = [f"/saved/file_{i:03d}.txt" for i in range(100)]
+        for i, path in enumerate(test_paths):
+            file_cache.write(zone_id, path, f"old-{i}".encode())
+
+        # Simulate backend update: first 50 files get new content in backend,
+        # and their leases are revoked
+        for i in range(50):
+            file_cache.mark_lease_revoked(zone_id, test_paths[i])
+
+        # Without staleness: all 100 would return cached (50 stale!)
+        # With staleness: 50 return None → forced re-fetch (correct)
+        stale_detected = 0
+        fresh_served = 0
+        for path in test_paths:
+            result = file_cache.read(zone_id, path)
+            if result is None:
+                stale_detected += 1
+            else:
+                fresh_served += 1
+
+        ok(
+            f"Prevented {stale_detected} stale reads",
+            f"{stale_detected} stale detected, {fresh_served} fresh served "
+            f"(without this feature: 0 stale detected, 100 potentially wrong)",
+        )
+    except Exception as e:
+        fail("Stale read prevention count", str(e))
+
+    # =================================================================
+    # CLEANUP
+    # =================================================================
+    try:
+        fuse.unmount()
+    except Exception:
+        subprocess.run(["fusermount", "-u", mp], capture_output=True)
+        subprocess.run(["umount", mp], capture_output=True)
+    nx.close()
+    await lease_mgr.close()
+
+    # =================================================================
+    # REPORT
+    # =================================================================
+    print()
+    print("=" * 60)
+    print("RESULTS")
+    print("=" * 60)
+    passed = 0
+    failed = 0
+    for name, success, detail in results:
+        if success:
+            print(f"  {_green('PASS')}  {name}")
+            if detail:
+                print(f"         {detail}")
+            passed += 1
+        else:
+            print(f"  {_red('FAIL')}  {name}")
+            if detail:
+                print(f"         {detail}")
+            failed += 1
+
+    print()
+    print(f"  {_green(str(passed))} passed, {_red(str(failed)) if failed else '0'} failed")
+    print("=" * 60)
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(asyncio.run(run_tests()))

--- a/tests/e2e/self_contained/test_fuse_lease_staleness_e2e.py
+++ b/tests/e2e/self_contained/test_fuse_lease_staleness_e2e.py
@@ -70,21 +70,40 @@ async def run_tests() -> int:
         await nx.write(f"/batch/file_{i:03d}.txt", f"content-{i}".encode())
     print("Data written\n")
 
-    # Mount with file_cache wired in
-    mp = os.path.join(tmpdir, "mnt")
-    os.makedirs(mp)
-    fuse = NexusFUSE(
+    zone_id = getattr(nx, "zone_id", None) or "root"
+
+    # Mount A (writer)
+    mp_a = os.path.join(tmpdir, "mnt_a")
+    os.makedirs(mp_a)
+    fuse_a = NexusFUSE(
         nx,
-        mp,
+        mp_a,
         mode=MountMode.BINARY,
         lease_manager=lease_mgr,
         file_cache=file_cache,
     )
-    fuse.mount(foreground=False)
+    fuse_a.mount(foreground=False)
+
+    # Mount B (reader)
+    mp_b = os.path.join(tmpdir, "mnt_b")
+    os.makedirs(mp_b)
+    fuse_b = NexusFUSE(
+        nx,
+        mp_b,
+        mode=MountMode.BINARY,
+        lease_manager=lease_mgr,
+        file_cache=file_cache,
+    )
+    fuse_b.mount(foreground=False)
+
     time.sleep(2)
-    assert fuse.is_mounted(), "FUSE mount failed"
-    zone_id = getattr(nx, "zone_id", None) or "root"
-    print(f"Mount: {mp}  zone={zone_id}  holder={fuse._mount_id}\n")
+    assert fuse_a.is_mounted() and fuse_b.is_mounted(), "FUSE mounts failed"
+    # Keep backward-compat aliases for single-mount tests below
+    mp = mp_a
+    fuse = fuse_a
+    print(f"Mount A: {mp_a}  holder={fuse_a._mount_id}")
+    print(f"Mount B: {mp_b}  holder={fuse_b._mount_id}")
+    print(f"Zone: {zone_id}\n")
 
     results: list[tuple[str, bool, str]] = []
 
@@ -182,14 +201,171 @@ async def run_tests() -> int:
         fail("FUSE write + re-read coherent", str(e))
 
     # =================================================================
-    # SECTION 2: LeaseManager callback → FileContentCache wiring
+    # SECTION 2: CROSS-MOUNT CORRECTNESS (two FUSE mounts)
+    # =================================================================
+    print()
+    print("=" * 60)
+    print("CROSS-MOUNT CORRECTNESS")
+    print("=" * 60)
+
+    # 7. Mount B reads → Mount A writes new content → Mount B re-reads gets EXACT new bytes
+    try:
+        p_a = os.path.join(mp_a, "report.txt")
+        p_b = os.path.join(mp_b, "report.txt")
+
+        # B reads (populates B's FUSE cache + lease)
+        with open(p_b, "rb") as f:
+            b_before = f.read()
+        assert b_before == b"report-v1", f"B initial read wrong: {b_before!r}"
+
+        # A writes completely different content
+        new_content = b"report-v2-with-new-data-12345"
+        with open(p_a, "wb") as f:
+            f.write(new_content)
+
+        time.sleep(0.5)  # Let revocation callbacks fire
+
+        # B re-reads — must get the EXACT bytes A wrote
+        with open(p_b, "rb") as f:
+            b_after = f.read()
+
+        if b_after == new_content:
+            ok("Cross-mount byte correctness (A writes → B reads)", f"B got {b_after!r}")
+        else:
+            fail(
+                "Cross-mount byte correctness (A writes → B reads)",
+                f"B got {b_after!r}, expected {new_content!r}",
+            )
+    except Exception as e:
+        fail("Cross-mount byte correctness", str(e))
+
+    # 8. B writes → A reads exact new content (reverse direction)
+    try:
+        p_a = os.path.join(mp_a, "doc.txt")
+        p_b = os.path.join(mp_b, "doc.txt")
+
+        # A reads first (populates A's cache)
+        with open(p_a, "rb") as f:
+            a_before = f.read()
+
+        # B writes new content
+        new_data = b"b-wrote-this-content-xyz"
+        with open(p_b, "wb") as f:
+            f.write(new_data)
+        time.sleep(0.5)
+
+        # A re-reads — must get B's exact bytes
+        with open(p_a, "rb") as f:
+            a_after = f.read()
+
+        if a_after == new_data:
+            ok("Cross-mount reverse (B writes → A reads)", f"A: {a_before!r} → {a_after!r}")
+        else:
+            fail(
+                "Cross-mount reverse (B writes → A reads)",
+                f"A got {a_after!r}, expected {new_data!r}",
+            )
+    except Exception as e:
+        fail("Cross-mount reverse (B writes → A reads)", str(e))
+
+    # 9. Rapid sequential writes: A writes 5 versions, B always reads latest
+    try:
+        p_a = os.path.join(mp_a, "rapid.txt")
+        p_b = os.path.join(mp_b, "rapid.txt")
+
+        final_version = None
+        for v in range(5):
+            final_version = f"rapid-version-{v}".encode()
+            with open(p_a, "wb") as f:
+                f.write(final_version)
+
+        time.sleep(0.5)
+
+        with open(p_b, "rb") as f:
+            b_rapid = f.read()
+
+        if b_rapid == final_version:
+            ok("Rapid writes: B sees final version", f"B got {b_rapid!r}")
+        else:
+            fail(
+                "Rapid writes: B sees final version",
+                f"B got {b_rapid!r}, expected {final_version!r}",
+            )
+    except Exception as e:
+        fail("Rapid writes: B sees final version", str(e))
+
+    # 10. Binary content integrity: write 10KB of random-ish bytes, verify byte-for-byte
+    try:
+        import hashlib
+
+        binary_data = hashlib.sha512(b"integrity-test-seed").digest() * 200  # 12,800 bytes
+        p_a = os.path.join(mp_a, "binary_check.bin")
+        p_b = os.path.join(mp_b, "binary_check.bin")
+
+        with open(p_a, "wb") as f:
+            f.write(binary_data)
+
+        time.sleep(0.3)
+
+        with open(p_b, "rb") as f:
+            b_binary = f.read()
+
+        if b_binary == binary_data:
+            ok(
+                "Binary content integrity (12.8KB)",
+                f"SHA-256 match: {hashlib.sha256(b_binary).hexdigest()[:16]}...",
+            )
+        else:
+            fail(
+                "Binary content integrity",
+                f"Length A={len(binary_data)} B={len(b_binary)}, match={binary_data == b_binary}",
+            )
+    except Exception as e:
+        fail("Binary content integrity", str(e))
+
+    # 11. Delete on A → B gets FileNotFoundError (not stale cached data)
+    try:
+        p_a = os.path.join(mp_a, "to_delete_correctness.txt")
+        p_b = os.path.join(mp_b, "to_delete_correctness.txt")
+
+        with open(p_a, "wb") as f:
+            f.write(b"will-be-deleted")
+
+        # B reads it first (populates cache)
+        with open(p_b, "rb") as f:
+            assert f.read() == b"will-be-deleted"
+
+        # A deletes it
+        os.remove(p_a)
+        time.sleep(0.5)
+
+        # B must NOT get the old cached content — should get error or empty
+        exists = os.path.exists(p_b)
+        if not exists:
+            ok("Delete correctness: B sees file gone (not stale cache)")
+        else:
+            # File might still appear due to attr cache TTL, try reading
+            try:
+                with open(p_b, "rb") as f:
+                    leftover = f.read()
+                fail(
+                    "Delete correctness",
+                    f"B still reads {leftover!r} after A deleted",
+                )
+            except Exception:
+                ok("Delete correctness: B read fails after A delete")
+    except Exception as e:
+        fail("Delete correctness", str(e))
+
+    # =================================================================
+    # SECTION 3: LeaseManager callback → FileContentCache wiring
     # =================================================================
     print()
     print("=" * 60)
     print("LEASE CALLBACK → FILECONTENT CACHE WIRING")
     print("=" * 60)
 
-    # 7. End-to-end: lease acquire → cache write → lease revoke → cache stale
+    # 12. End-to-end: lease acquire → cache write → lease revoke → cache stale
     try:
         from nexus.contracts.protocols.lease import LeaseState
 
@@ -218,7 +394,7 @@ async def run_tests() -> int:
     except Exception as e:
         fail("Full lease lifecycle", str(e))
 
-    # 8. Lease manager stats reflect activity
+    # 13. Lease manager stats reflect activity
     try:
         stats = await lease_mgr.stats()
         ok(
@@ -230,7 +406,7 @@ async def run_tests() -> int:
         fail("Lease manager stats", str(e))
 
     # =================================================================
-    # SECTION 3: PERFORMANCE MEASUREMENT
+    # SECTION 4: PERFORMANCE MEASUREMENT
     # =================================================================
     print()
     print("=" * 60)
@@ -400,11 +576,12 @@ async def run_tests() -> int:
     # =================================================================
     # CLEANUP
     # =================================================================
-    try:
-        fuse.unmount()
-    except Exception:
-        subprocess.run(["fusermount", "-u", mp], capture_output=True)
-        subprocess.run(["umount", mp], capture_output=True)
+    for fuse_inst, mount_path in [(fuse_a, mp_a), (fuse_b, mp_b)]:
+        try:
+            fuse_inst.unmount()
+        except Exception:
+            subprocess.run(["fusermount", "-u", mount_path], capture_output=True)
+            subprocess.run(["umount", mount_path], capture_output=True)
     nx.close()
     await lease_mgr.close()
 

--- a/tests/unit/integration/test_lease_aware_cache.py
+++ b/tests/unit/integration/test_lease_aware_cache.py
@@ -1,0 +1,301 @@
+"""Integration tests for lease-aware cache (Issue #3400).
+
+Tests the interaction between LeaseManager and cache layers:
+- FileContentCache staleness tracking driven by lease acquire/revoke
+- FUSECacheManager invalidation on lease revocation
+- Eviction predicate behavior with lease state
+- LeaseManager callback integration with cache invalidation
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nexus.contracts.protocols.lease import Lease, LeaseState
+from nexus.fuse.cache import FUSECacheManager
+from nexus.lib.lease import LocalLeaseManager, ManualClock
+from nexus.storage.eviction import is_eviction_candidate
+from nexus.storage.file_cache import FileContentCache
+
+READ = LeaseState.SHARED_READ
+WRITE = LeaseState.EXCLUSIVE_WRITE
+
+ZONE = "zone1"
+PATH = "/mnt/gcs/file.txt"
+HOLDER = "agent-A"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def clock() -> ManualClock:
+    return ManualClock(_now=1000.0)
+
+
+@pytest.fixture()
+def mgr(clock: ManualClock) -> LocalLeaseManager:
+    return LocalLeaseManager(zone_id=ZONE, clock=clock, sweep_interval=999.0)
+
+
+@pytest.fixture()
+def file_cache(tmp_path: Path) -> FileContentCache:
+    return FileContentCache(tmp_path)
+
+
+@pytest.fixture()
+def fuse_cache() -> FUSECacheManager:
+    return FUSECacheManager(attr_cache_size=128, attr_cache_ttl=60, content_cache_size=128)
+
+
+# ---------------------------------------------------------------------------
+# FileContentCache staleness driven by lease state
+# ---------------------------------------------------------------------------
+
+
+class TestFileContentCacheStaleness:
+    def test_file_cache_staleness_on_lease_revoke(
+        self, file_cache: FileContentCache, tmp_path: Path
+    ) -> None:
+        """Acquire lease, write content, revoke lease -> read returns None."""
+        file_cache.mark_lease_acquired(ZONE, PATH)
+        file_cache.write(ZONE, PATH, b"hello world")
+
+        # Content is readable while lease is active
+        assert file_cache.read(ZONE, PATH) == b"hello world"
+
+        # Revoke the lease
+        file_cache.mark_lease_revoked(ZONE, PATH)
+
+        # After revocation, read returns None (content is stale)
+        assert file_cache.read(ZONE, PATH) is None
+
+    def test_file_cache_fresh_with_active_lease(self, file_cache: FileContentCache) -> None:
+        """Acquire lease, mark acquired, write content -> read returns content."""
+        file_cache.mark_lease_acquired(ZONE, PATH)
+        file_cache.write(ZONE, PATH, b"fresh data")
+
+        assert file_cache.has_active_lease(ZONE, PATH) is True
+        assert file_cache.read(ZONE, PATH) == b"fresh data"
+
+    def test_file_cache_write_clears_staleness(self, file_cache: FileContentCache) -> None:
+        """Mark stale -> write new content -> read returns new content."""
+        # Write initial content
+        file_cache.write(ZONE, PATH, b"original")
+
+        # Mark stale
+        file_cache.mark_lease_revoked(ZONE, PATH)
+        assert file_cache.is_stale(ZONE, PATH) is True
+        assert file_cache.read(ZONE, PATH) is None
+
+        # Write fresh content (clears staleness)
+        file_cache.write(ZONE, PATH, b"refreshed")
+        assert file_cache.is_stale(ZONE, PATH) is False
+        assert file_cache.read(ZONE, PATH) == b"refreshed"
+
+
+# ---------------------------------------------------------------------------
+# FUSECacheManager invalidation on lease revocation
+# ---------------------------------------------------------------------------
+
+
+class TestFUSECacheLeaseRevocation:
+    def test_fuse_cache_invalidation_on_lease_revoke(self, fuse_cache: FUSECacheManager) -> None:
+        """Cache content in FUSECacheManager, call on_lease_revoked -> get_content returns None."""
+        fuse_cache.cache_content(PATH, b"cached bytes")
+        assert fuse_cache.get_content(PATH) == b"cached bytes"
+
+        fuse_cache.on_lease_revoked(PATH)
+        assert fuse_cache.get_content(PATH) is None
+
+    def test_fuse_cache_attr_invalidation_on_lease_revoke(
+        self, fuse_cache: FUSECacheManager
+    ) -> None:
+        """Cache attr in FUSECacheManager, call on_lease_revoked -> get_attr returns None."""
+        attrs = {"st_size": 1024, "st_mode": 0o100644}
+        fuse_cache.cache_attr(PATH, attrs)
+        assert fuse_cache.get_attr(PATH) is not None
+
+        fuse_cache.on_lease_revoked(PATH)
+        assert fuse_cache.get_attr(PATH) is None
+
+    def test_fuse_cache_parsed_invalidation_on_lease_revoke(
+        self, fuse_cache: FUSECacheManager
+    ) -> None:
+        """Cache parsed in FUSECacheManager, call on_lease_revoked -> get_parsed returns None."""
+        fuse_cache.cache_parsed(PATH, "txt", b"parsed text content")
+        assert fuse_cache.get_parsed(PATH, "txt") == b"parsed text content"
+
+        fuse_cache.on_lease_revoked(PATH)
+        assert fuse_cache.get_parsed(PATH, "txt") is None
+
+
+# ---------------------------------------------------------------------------
+# Full lease lifecycle with FileContentCache
+# ---------------------------------------------------------------------------
+
+
+class TestLeaseLifecycleWithFileCache:
+    def test_lease_lifecycle_with_file_cache(self, file_cache: FileContentCache) -> None:
+        """Full lifecycle: acquire -> write -> verify fresh -> revoke -> verify stale -> write -> verify fresh again."""
+        # 1. Acquire lease
+        file_cache.mark_lease_acquired(ZONE, PATH)
+        assert file_cache.has_active_lease(ZONE, PATH) is True
+        assert file_cache.is_stale(ZONE, PATH) is False
+
+        # 2. Write content
+        file_cache.write(ZONE, PATH, b"v1")
+        assert file_cache.read(ZONE, PATH) == b"v1"
+
+        # 3. Revoke lease
+        file_cache.mark_lease_revoked(ZONE, PATH)
+        assert file_cache.has_active_lease(ZONE, PATH) is False
+        assert file_cache.is_stale(ZONE, PATH) is True
+
+        # 4. Read returns None (stale)
+        assert file_cache.read(ZONE, PATH) is None
+        # Text read also returns None
+        assert file_cache.read_text(ZONE, PATH) is None
+        # Meta read also returns None
+        assert file_cache.read_meta(ZONE, PATH) is None
+
+        # 5. Write new content (clears staleness)
+        file_cache.write(ZONE, PATH, b"v2")
+        assert file_cache.is_stale(ZONE, PATH) is False
+        assert file_cache.read(ZONE, PATH) == b"v2"
+
+    def test_multiple_paths_independent_staleness(self, file_cache: FileContentCache) -> None:
+        """Multiple paths with different lease states are independent."""
+        path_a = "/mnt/gcs/a.txt"
+        path_b = "/mnt/gcs/b.txt"
+
+        # Write content to both paths
+        file_cache.mark_lease_acquired(ZONE, path_a)
+        file_cache.mark_lease_acquired(ZONE, path_b)
+        file_cache.write(ZONE, path_a, b"content-a")
+        file_cache.write(ZONE, path_b, b"content-b")
+
+        # Revoke lease on path_a only
+        file_cache.mark_lease_revoked(ZONE, path_a)
+
+        # path_a is stale, path_b is fresh
+        assert file_cache.is_stale(ZONE, path_a) is True
+        assert file_cache.is_stale(ZONE, path_b) is False
+        assert file_cache.read(ZONE, path_a) is None
+        assert file_cache.read(ZONE, path_b) == b"content-b"
+
+    def test_zone_isolation_in_staleness(self, file_cache: FileContentCache) -> None:
+        """Same path in different zones — one stale, one fresh."""
+        zone_a = "us-east-1"
+        zone_b = "eu-west-1"
+        vpath = "/mnt/gcs/shared.txt"
+
+        # Write content to both zones
+        file_cache.mark_lease_acquired(zone_a, vpath)
+        file_cache.mark_lease_acquired(zone_b, vpath)
+        file_cache.write(zone_a, vpath, b"data-east")
+        file_cache.write(zone_b, vpath, b"data-west")
+
+        # Revoke lease in zone_a only
+        file_cache.mark_lease_revoked(zone_a, vpath)
+
+        # zone_a is stale, zone_b is fresh
+        assert file_cache.is_stale(zone_a, vpath) is True
+        assert file_cache.is_stale(zone_b, vpath) is False
+        assert file_cache.read(zone_a, vpath) is None
+        assert file_cache.read(zone_b, vpath) == b"data-west"
+
+
+# ---------------------------------------------------------------------------
+# Eviction predicate with lease state
+# ---------------------------------------------------------------------------
+
+
+class TestEvictionPredicateWithLease:
+    def test_eviction_predicate_with_lease(self) -> None:
+        """Test is_eviction_candidate with various combinations."""
+        # Pass 1: only no-lease + priority 0 are candidates
+        assert is_eviction_candidate(has_active_lease=False, priority=0, pass_number=1) is True
+        assert is_eviction_candidate(has_active_lease=False, priority=1, pass_number=1) is False
+        assert is_eviction_candidate(has_active_lease=True, priority=0, pass_number=1) is False
+        assert is_eviction_candidate(has_active_lease=True, priority=1, pass_number=1) is False
+
+        # Pass 2: no-lease regardless of priority
+        assert is_eviction_candidate(has_active_lease=False, priority=0, pass_number=2) is True
+        assert is_eviction_candidate(has_active_lease=False, priority=5, pass_number=2) is True
+        assert is_eviction_candidate(has_active_lease=True, priority=0, pass_number=2) is False
+        assert is_eviction_candidate(has_active_lease=True, priority=5, pass_number=2) is False
+
+        # Pass 3: everything is a candidate (emergency)
+        assert is_eviction_candidate(has_active_lease=False, priority=0, pass_number=3) is True
+        assert is_eviction_candidate(has_active_lease=True, priority=10, pass_number=3) is True
+
+    def test_eviction_predicate_pass_escalation(self) -> None:
+        """Verify pass 1 is most restrictive, pass 3 is emergency."""
+        # Entry with active lease + high priority: never evicted until pass 3
+        assert is_eviction_candidate(has_active_lease=True, priority=5, pass_number=1) is False
+        assert is_eviction_candidate(has_active_lease=True, priority=5, pass_number=2) is False
+        assert is_eviction_candidate(has_active_lease=True, priority=5, pass_number=3) is True
+
+        # Entry with no lease + priority 1: not evicted until pass 2
+        assert is_eviction_candidate(has_active_lease=False, priority=1, pass_number=1) is False
+        assert is_eviction_candidate(has_active_lease=False, priority=1, pass_number=2) is True
+
+        # Entry with no lease + priority 0: evicted from pass 1
+        assert is_eviction_candidate(has_active_lease=False, priority=0, pass_number=1) is True
+
+        # Pass 4+ (beyond 3) also acts as emergency
+        assert is_eviction_candidate(has_active_lease=True, priority=99, pass_number=4) is True
+
+
+# ---------------------------------------------------------------------------
+# LeaseManager callback integration with FileContentCache
+# ---------------------------------------------------------------------------
+
+
+class TestLeaseManagerCallbackIntegration:
+    @pytest.mark.asyncio()
+    async def test_lease_manager_callback_integration(
+        self,
+        mgr: LocalLeaseManager,
+        file_cache: FileContentCache,
+        clock: ManualClock,
+    ) -> None:
+        """Register async callback on LeaseManager; acquire+revoke fires callback.
+
+        The callback calls mark_lease_revoked on the FileContentCache,
+        demonstrating the full integration path.
+        """
+        callback_invocations: list[tuple[str, str]] = []
+
+        async def on_revoke(lease: Lease, reason: str) -> None:
+            callback_invocations.append((lease.resource_id, reason))
+            # Bridge: propagate revocation to file cache
+            file_cache.mark_lease_revoked(ZONE, lease.resource_id)
+
+        mgr.register_revocation_callback("file-cache-bridge", on_revoke)
+
+        # Prepare file cache state
+        file_cache.mark_lease_acquired(ZONE, "r1")
+        file_cache.write(ZONE, "r1", b"cached content")
+        assert file_cache.read(ZONE, "r1") == b"cached content"
+
+        # Acquire lease in LeaseManager
+        lease = await mgr.acquire("r1", HOLDER, READ)
+        assert lease is not None
+
+        # Revoke lease in LeaseManager
+        revoked = await mgr.revoke("r1", holder_id=HOLDER)
+        assert len(revoked) == 1
+
+        # Verify callback was invoked
+        assert len(callback_invocations) == 1
+        assert callback_invocations[0] == ("r1", "explicit")
+
+        # Verify FileContentCache is now stale (set by callback)
+        assert file_cache.is_stale(ZONE, "r1") is True
+        assert file_cache.read(ZONE, "r1") is None

--- a/tests/unit/lib/test_lease_cache_races.py
+++ b/tests/unit/lib/test_lease_cache_races.py
@@ -1,0 +1,277 @@
+"""Race condition tests for concurrent lease acquire during eviction (Decision 10A).
+
+Tests thread-safety of FileContentCache staleness tracking and
+SingleFlightSync coalescing under concurrent access patterns.
+Uses controlled scheduling with ManualClock + threading.Event
+to force specific interleavings.
+"""
+
+from __future__ import annotations
+
+import threading
+import time
+from pathlib import Path
+
+import pytest
+
+from nexus.lib.lease import ManualClock
+from nexus.lib.singleflight import SingleFlightSync
+from nexus.storage.file_cache import FileContentCache
+
+ZONE = "zone1"
+PATH = "/mnt/gcs/file.txt"
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture()
+def clock() -> ManualClock:
+    return ManualClock(_now=1000.0)
+
+
+@pytest.fixture()
+def file_cache(tmp_path: Path) -> FileContentCache:
+    return FileContentCache(tmp_path)
+
+
+# ---------------------------------------------------------------------------
+# 1. Revoke during read returns stale on next call
+# ---------------------------------------------------------------------------
+
+
+class TestRevokeDuringRead:
+    def test_revoke_during_read_returns_stale(self, file_cache: FileContentCache) -> None:
+        """Thread A reads from FileContentCache. Thread B revokes the lease.
+
+        The revocation happens between two read() calls. The first read()
+        may succeed (content was valid when it started), but the NEXT read()
+        after revocation must return None.
+        """
+        # Setup: write content and mark lease acquired
+        file_cache.mark_lease_acquired(ZONE, PATH)
+        file_cache.write(ZONE, PATH, b"initial content")
+        assert file_cache.read(ZONE, PATH) == b"initial content"
+
+        # Gates for controlling thread interleaving
+        read_started = threading.Event()
+        revoke_done = threading.Event()
+
+        first_read_result: list[bytes | None] = []
+        second_read_result: list[bytes | None] = []
+
+        def reader() -> None:
+            # First read: should succeed (lease still active)
+            result = file_cache.read(ZONE, PATH)
+            first_read_result.append(result)
+            read_started.set()
+
+            # Wait for revocation to complete
+            revoke_done.wait(timeout=5.0)
+
+            # Second read: should return None (lease revoked)
+            result = file_cache.read(ZONE, PATH)
+            second_read_result.append(result)
+
+        def revoker() -> None:
+            # Wait for the reader to complete its first read
+            read_started.wait(timeout=5.0)
+
+            # Revoke the lease
+            file_cache.mark_lease_revoked(ZONE, PATH)
+            revoke_done.set()
+
+        t_reader = threading.Thread(target=reader)
+        t_revoker = threading.Thread(target=revoker)
+
+        t_reader.start()
+        t_revoker.start()
+        t_reader.join(timeout=10.0)
+        t_revoker.join(timeout=10.0)
+
+        # First read returned content (lease was active)
+        assert first_read_result[0] == b"initial content"
+        # Second read returns None (lease was revoked)
+        assert second_read_result[0] is None
+
+
+# ---------------------------------------------------------------------------
+# 2. Acquire after revoke clears staleness
+# ---------------------------------------------------------------------------
+
+
+class TestAcquireAfterRevoke:
+    def test_acquire_after_revoke_clears_staleness(self, file_cache: FileContentCache) -> None:
+        """Thread A revokes lease. Thread B immediately acquires.
+
+        After both complete, the path should NOT be stale.
+        """
+        file_cache.mark_lease_acquired(ZONE, PATH)
+        file_cache.write(ZONE, PATH, b"content")
+
+        revoke_done = threading.Event()
+
+        def revoker() -> None:
+            file_cache.mark_lease_revoked(ZONE, PATH)
+            revoke_done.set()
+
+        def acquirer() -> None:
+            revoke_done.wait(timeout=5.0)
+            file_cache.mark_lease_acquired(ZONE, PATH)
+
+        t_revoke = threading.Thread(target=revoker)
+        t_acquire = threading.Thread(target=acquirer)
+
+        t_revoke.start()
+        t_acquire.start()
+        t_revoke.join(timeout=10.0)
+        t_acquire.join(timeout=10.0)
+
+        # After revoke + re-acquire, path is NOT stale
+        assert file_cache.is_stale(ZONE, PATH) is False
+        assert file_cache.has_active_lease(ZONE, PATH) is True
+
+
+# ---------------------------------------------------------------------------
+# 3. Concurrent revoke and write
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentRevokeAndWrite:
+    def test_concurrent_revoke_and_write(self, file_cache: FileContentCache) -> None:
+        """Thread A calls mark_lease_revoked. Thread B calls write() concurrently.
+
+        After both complete, the path should NOT be stale (write clears staleness).
+        """
+        file_cache.mark_lease_acquired(ZONE, PATH)
+        file_cache.write(ZONE, PATH, b"v1")
+
+        # Use a barrier to ensure both threads start nearly simultaneously
+        barrier = threading.Barrier(2, timeout=5.0)
+
+        def revoker() -> None:
+            barrier.wait()
+            file_cache.mark_lease_revoked(ZONE, PATH)
+
+        def writer() -> None:
+            barrier.wait()
+            # Small delay to let revoke likely happen first
+            time.sleep(0.001)
+            file_cache.write(ZONE, PATH, b"v2")
+
+        t_revoke = threading.Thread(target=revoker)
+        t_write = threading.Thread(target=writer)
+
+        t_revoke.start()
+        t_write.start()
+        t_revoke.join(timeout=10.0)
+        t_write.join(timeout=10.0)
+
+        # Write clears staleness, so read should return v2
+        assert file_cache.is_stale(ZONE, PATH) is False
+        assert file_cache.read(ZONE, PATH) == b"v2"
+
+
+# ---------------------------------------------------------------------------
+# 4. Concurrent mark operations are thread-safe
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrentMarkOperations:
+    def test_concurrent_mark_operations_are_thread_safe(self, file_cache: FileContentCache) -> None:
+        """Spawn 10 threads all calling mark_lease_acquired and mark_lease_revoked.
+
+        Verify no exceptions raised and final state is consistent
+        (either stale or has_active_lease, never both).
+        """
+        file_cache.write(ZONE, PATH, b"initial")
+        errors: list[Exception] = []
+        barrier = threading.Barrier(10, timeout=5.0)
+
+        def toggle(thread_id: int) -> None:
+            try:
+                barrier.wait()
+                for _ in range(100):
+                    if thread_id % 2 == 0:
+                        file_cache.mark_lease_acquired(ZONE, PATH)
+                        file_cache.mark_lease_revoked(ZONE, PATH)
+                    else:
+                        file_cache.mark_lease_revoked(ZONE, PATH)
+                        file_cache.mark_lease_acquired(ZONE, PATH)
+            except Exception as e:
+                errors.append(e)
+
+        threads = [threading.Thread(target=toggle, args=(i,)) for i in range(10)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30.0)
+
+        # No exceptions during concurrent access
+        assert errors == [], f"Errors during concurrent mark operations: {errors}"
+
+        # Final state must be consistent: stale and has_active_lease
+        # should never both be True simultaneously (they are mutually exclusive
+        # within the lock, though one could be False/False for an untracked path).
+        is_stale = file_cache.is_stale(ZONE, PATH)
+        has_lease = file_cache.has_active_lease(ZONE, PATH)
+        assert not (is_stale and has_lease), (
+            f"Inconsistent state: is_stale={is_stale}, has_active_lease={has_lease}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# 5. SingleFlightSync coalesces concurrent calls
+# ---------------------------------------------------------------------------
+
+
+class TestSingleFlightSyncCoalescing:
+    def test_singleflight_sync_coalesces_concurrent_calls(self) -> None:
+        """Spawn 5 threads all calling sf.do("key", slow_fn).
+
+        Verify slow_fn is called exactly once; all threads get the same result.
+        """
+        sf: SingleFlightSync[str] = SingleFlightSync()
+        call_count = 0
+        call_count_lock = threading.Lock()
+        barrier = threading.Barrier(5, timeout=5.0)
+
+        def slow_fn() -> str:
+            nonlocal call_count
+            with call_count_lock:
+                call_count += 1
+            # Simulate slow work
+            time.sleep(0.1)
+            return "computed-result"
+
+        results: list[str] = []
+        results_lock = threading.Lock()
+        errors: list[Exception] = []
+
+        def worker() -> None:
+            try:
+                barrier.wait()
+                result = sf.do("key", slow_fn)
+                with results_lock:
+                    results.append(result)
+            except Exception as e:
+                with results_lock:
+                    errors.append(e)
+
+        threads = [threading.Thread(target=worker) for _ in range(5)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=30.0)
+
+        # No errors
+        assert errors == [], f"Errors during singleflight: {errors}"
+
+        # slow_fn was called exactly once
+        assert call_count == 1, f"Expected 1 call, got {call_count}"
+
+        # All 5 threads got the same result
+        assert len(results) == 5
+        assert all(r == "computed-result" for r in results)

--- a/tests/unit/storage/test_file_cache.py
+++ b/tests/unit/storage/test_file_cache.py
@@ -223,3 +223,242 @@ class TestFileContentCache:
 
         # Content should be the newer one
         assert cache.read("zone1", "/file.txt") == b"content2"
+
+
+class TestFileContentCacheStaleness:
+    """Test suite for lease-aware staleness tracking (Issue #3400)."""
+
+    def test_basic_staleness_read_returns_none(self, tmp_path: Path):
+        """Write file, mark stale, read returns None."""
+        cache = FileContentCache(tmp_path)
+        cache.write("zone1", "/file.txt", b"hello")
+
+        cache.mark_lease_revoked("zone1", "/file.txt")
+
+        assert cache.read("zone1", "/file.txt") is None
+
+    def test_staleness_cleared_on_write(self, tmp_path: Path):
+        """Mark stale, write new content, read succeeds."""
+        cache = FileContentCache(tmp_path)
+        cache.write("zone1", "/file.txt", b"original")
+
+        cache.mark_lease_revoked("zone1", "/file.txt")
+        assert cache.read("zone1", "/file.txt") is None
+
+        cache.write("zone1", "/file.txt", b"refreshed")
+        assert cache.read("zone1", "/file.txt") == b"refreshed"
+
+    def test_lease_acquired_clears_staleness(self, tmp_path: Path):
+        """Mark stale, then mark lease acquired, read succeeds."""
+        cache = FileContentCache(tmp_path)
+        cache.write("zone1", "/file.txt", b"content")
+
+        cache.mark_lease_revoked("zone1", "/file.txt")
+        assert cache.read("zone1", "/file.txt") is None
+
+        cache.mark_lease_acquired("zone1", "/file.txt")
+        assert cache.read("zone1", "/file.txt") == b"content"
+
+    def test_is_stale_basic(self, tmp_path: Path):
+        """is_stale() returns correct values across lifecycle."""
+        cache = FileContentCache(tmp_path)
+        cache.write("zone1", "/file.txt", b"content")
+
+        assert not cache.is_stale("zone1", "/file.txt")
+
+        cache.mark_lease_revoked("zone1", "/file.txt")
+        assert cache.is_stale("zone1", "/file.txt")
+
+        cache.mark_lease_acquired("zone1", "/file.txt")
+        assert not cache.is_stale("zone1", "/file.txt")
+
+    def test_has_active_lease_basic(self, tmp_path: Path):
+        """has_active_lease() returns correct values across lifecycle."""
+        cache = FileContentCache(tmp_path)
+
+        assert not cache.has_active_lease("zone1", "/file.txt")
+
+        cache.mark_lease_acquired("zone1", "/file.txt")
+        assert cache.has_active_lease("zone1", "/file.txt")
+
+        cache.mark_lease_revoked("zone1", "/file.txt")
+        assert not cache.has_active_lease("zone1", "/file.txt")
+
+    def test_read_text_returns_none_when_stale(self, tmp_path: Path):
+        """read_text() returns None for stale paths."""
+        cache = FileContentCache(tmp_path)
+        cache.write("zone1", "/file.txt", b"binary", text_content="text content")
+
+        assert cache.read_text("zone1", "/file.txt") == "text content"
+
+        cache.mark_lease_revoked("zone1", "/file.txt")
+        assert cache.read_text("zone1", "/file.txt") is None
+
+    def test_read_meta_returns_none_when_stale(self, tmp_path: Path):
+        """read_meta() returns None for stale paths."""
+        cache = FileContentCache(tmp_path)
+        meta = {"content_hash": "abc123", "content_type": "full"}
+        cache.write("zone1", "/file.txt", b"data", meta=meta)
+
+        assert cache.read_meta("zone1", "/file.txt") is not None
+
+        cache.mark_lease_revoked("zone1", "/file.txt")
+        assert cache.read_meta("zone1", "/file.txt") is None
+
+    def test_staleness_is_per_path(self, tmp_path: Path):
+        """Stale path A does not affect path B in the same zone."""
+        cache = FileContentCache(tmp_path)
+        cache.write("zone1", "/a.txt", b"content a")
+        cache.write("zone1", "/b.txt", b"content b")
+
+        cache.mark_lease_revoked("zone1", "/a.txt")
+
+        assert cache.read("zone1", "/a.txt") is None
+        assert cache.read("zone1", "/b.txt") == b"content b"
+
+    def test_staleness_is_per_zone(self, tmp_path: Path):
+        """Stale zone1/path does not affect zone2/path."""
+        cache = FileContentCache(tmp_path)
+        cache.write("zone1", "/file.txt", b"zone1 data")
+        cache.write("zone2", "/file.txt", b"zone2 data")
+
+        cache.mark_lease_revoked("zone1", "/file.txt")
+
+        assert cache.read("zone1", "/file.txt") is None
+        assert cache.read("zone2", "/file.txt") == b"zone2 data"
+
+    def test_mark_revoked_without_prior_acquire(self, tmp_path: Path):
+        """Revoking a lease that was never acquired should work fine."""
+        cache = FileContentCache(tmp_path)
+        cache.write("zone1", "/file.txt", b"content")
+
+        # No prior mark_lease_acquired — should not raise
+        cache.mark_lease_revoked("zone1", "/file.txt")
+
+        assert cache.is_stale("zone1", "/file.txt")
+        assert cache.read("zone1", "/file.txt") is None
+
+    def test_multiple_revocations_idempotent(self, tmp_path: Path):
+        """Multiple mark_lease_revoked calls are idempotent."""
+        cache = FileContentCache(tmp_path)
+        cache.write("zone1", "/file.txt", b"content")
+
+        cache.mark_lease_revoked("zone1", "/file.txt")
+        cache.mark_lease_revoked("zone1", "/file.txt")
+        cache.mark_lease_revoked("zone1", "/file.txt")
+
+        assert cache.is_stale("zone1", "/file.txt")
+        assert cache.read("zone1", "/file.txt") is None
+
+    def test_full_lease_lifecycle(self, tmp_path: Path):
+        """Lease acquired, then revoked, then acquired again."""
+        cache = FileContentCache(tmp_path)
+        cache.write("zone1", "/file.txt", b"content")
+
+        # Acquire
+        cache.mark_lease_acquired("zone1", "/file.txt")
+        assert cache.has_active_lease("zone1", "/file.txt")
+        assert not cache.is_stale("zone1", "/file.txt")
+        assert cache.read("zone1", "/file.txt") == b"content"
+
+        # Revoke
+        cache.mark_lease_revoked("zone1", "/file.txt")
+        assert not cache.has_active_lease("zone1", "/file.txt")
+        assert cache.is_stale("zone1", "/file.txt")
+        assert cache.read("zone1", "/file.txt") is None
+
+        # Re-acquire
+        cache.mark_lease_acquired("zone1", "/file.txt")
+        assert cache.has_active_lease("zone1", "/file.txt")
+        assert not cache.is_stale("zone1", "/file.txt")
+        assert cache.read("zone1", "/file.txt") == b"content"
+
+    def test_bulk_read_with_stale_and_fresh(self, tmp_path: Path):
+        """Bulk read returns only fresh paths, skipping stale ones."""
+        cache = FileContentCache(tmp_path)
+        for i in range(5):
+            cache.write("zone1", f"/file{i}.txt", f"content{i}".encode())
+
+        # Mark files 1 and 3 as stale
+        cache.mark_lease_revoked("zone1", "/file1.txt")
+        cache.mark_lease_revoked("zone1", "/file3.txt")
+
+        paths = [f"/file{i}.txt" for i in range(5)]
+        results = cache.read_bulk("zone1", paths)
+
+        assert "/file0.txt" in results
+        assert "/file1.txt" not in results
+        assert "/file2.txt" in results
+        assert "/file3.txt" not in results
+        assert "/file4.txt" in results
+        assert len(results) == 3
+
+    def test_exists_returns_true_for_stale_paths(self, tmp_path: Path):
+        """exists() still returns True for stale paths (file is on disk)."""
+        cache = FileContentCache(tmp_path)
+        cache.write("zone1", "/file.txt", b"content")
+
+        cache.mark_lease_revoked("zone1", "/file.txt")
+
+        # File is on disk, exists() should still be True
+        assert cache.exists("zone1", "/file.txt")
+        # But read should return None due to staleness
+        assert cache.read("zone1", "/file.txt") is None
+
+    def test_delete_clears_staleness(self, tmp_path: Path):
+        """delete() clears staleness so the path is no longer marked stale."""
+        cache = FileContentCache(tmp_path)
+        cache.write("zone1", "/file.txt", b"content")
+
+        cache.mark_lease_revoked("zone1", "/file.txt")
+        assert cache.is_stale("zone1", "/file.txt")
+
+        cache.delete("zone1", "/file.txt")
+        assert not cache.is_stale("zone1", "/file.txt")
+
+    def test_thread_safety_concurrent_revoke_and_read(self, tmp_path: Path):
+        """Concurrent mark_lease_revoked and read operations do not crash."""
+        import threading
+
+        cache = FileContentCache(tmp_path)
+        errors: list[Exception] = []
+
+        # Write files
+        for i in range(20):
+            cache.write("zone1", f"/file{i}.txt", f"content{i}".encode())
+
+        def revoke_loop():
+            try:
+                for _ in range(100):
+                    for i in range(20):
+                        cache.mark_lease_revoked("zone1", f"/file{i}.txt")
+            except Exception as e:
+                errors.append(e)
+
+        def read_loop():
+            try:
+                for _ in range(100):
+                    for i in range(20):
+                        cache.read("zone1", f"/file{i}.txt")
+            except Exception as e:
+                errors.append(e)
+
+        def acquire_loop():
+            try:
+                for _ in range(100):
+                    for i in range(20):
+                        cache.mark_lease_acquired("zone1", f"/file{i}.txt")
+            except Exception as e:
+                errors.append(e)
+
+        threads = [
+            threading.Thread(target=revoke_loop),
+            threading.Thread(target=read_loop),
+            threading.Thread(target=acquire_loop),
+        ]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join(timeout=10)
+
+        assert not errors, f"Thread errors: {errors}"


### PR DESCRIPTION
## Summary

Closes #3400. Implements DFUSE-inspired lease-aware staleness detection across Nexus's caching layers, informed by a thorough architectural review cross-referencing production systems (NFSv4, CephFS, Lustre, Facebook Memcache).

### Key decisions from review (16 decisions, all interactive)

| # | Decision | Rationale |
|---|----------|-----------|
| 1A | Cached lease bit (not async validate in eviction) | CephFS model — O(1) sync check |
| 2A | Revoke-then-evict (not silent eviction) | NFSv4/CephFS proven pattern |
| 3A | Direct LeaseManager subscription | Existing callback API, avoids god-object |
| 4A | Request coalescing (singleflight) | Facebook NSDI '13 stampede prevention |
| 5B | **Path-keyed caches only** | Sidesteps content-hash vs path key mismatch |
| 6A | Fix size tracking drift | 5-line bug fix, prevents cache overfill |
| 7A | FUSE: invalidation-only | FUSE misses fall through to lease-protected layers |
| 15B | Lazy CLOCK cleanup | Eliminates O(n) list.remove() per eviction |

### Production code changes

- **FileContentCache**: In-memory `_leased_paths` + `_stale_paths` sets with O(1) staleness checks on `read()`/`read_text()`/`read_meta()`/`read_bulk()`. `write()` clears staleness. `delete()` clears lease state.
- **FUSECacheManager**: `on_lease_revoked(path)` callback delegates to `invalidate_path()`.
- **LocalDiskCache**: Fix size-tracking drift (delete files before updating metadata). Lazy CLOCK cleanup (skip orphaned entries instead of O(n) list.remove).
- **New: `eviction.py`**: Shared `is_eviction_candidate()` predicate for future lease-aware eviction.
- **New: `singleflight.py`**: Async `SingleFlight` + sync `SingleFlightSync` for request coalescing.

### What's NOT in scope (by design)

The original issue proposed `LeaseAwareCLOCK` and `LeaseAwareLRU` classes modifying content-hash-keyed caches. Review determined this is incorrect — content-hash caches can't map to path-based leases without ref-counting complexity. Instead, lease-awareness applies only to path-keyed caches (FileContentCache, FUSE), which are closest to the user and get the most benefit.

## Test plan

- [x] 16 staleness unit tests (`test_file_cache.py`) — basic staleness, per-path/zone isolation, lifecycle, bulk reads, thread safety
- [x] 12 integration tests (`test_lease_aware_cache.py`) — FileContentCache + LeaseManager callback bridge, FUSE invalidation, eviction predicate
- [x] 5 race condition tests (`test_lease_cache_races.py`) — concurrent revoke/read, acquire-after-revoke, singleflight coalescing
- [x] 9 benchmarks (`bench_lease_aware_eviction.py`) — hit rate at 0/25/50% staleness, recovery, eviction priority, size drift, overhead
- [x] 25 existing LocalDiskCache tests pass (0 regressions)
- [x] 32 existing ContentCache tests pass (0 regressions)
- [x] 59 existing Lease tests pass (0 regressions)
- [x] **173 total tests pass, 0 failures**