### PR TITLE
feat(playground): add ? help overlay showing all keyboard shortcuts

### DIFF
--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -1681,6 +1681,12 @@ class PlaygroundApp(App[None]):
                 event.prevent_default()
                 return
 
+        if event.key in {"question_mark", "?"} and event.character == "?":
+            focused = self.focused
+            if not isinstance(focused, Input):
+                self.push_screen(HelpOverlay())
+                event.prevent_default()
+                return
         if event.key == ":":
             focused = self.focused
             if not isinstance(focused, Input):

--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -22,6 +22,7 @@ from textual.widgets import DataTable, Footer, Header, Input, Static
 from nexus.fs._tui.auth_guidance import auth_guidance, format_runtime_error
 from nexus.fs._tui.file_browser import FileBrowser
 from nexus.fs._tui.file_preview import FilePreview
+from nexus.fs._tui.help_overlay import HelpOverlay
 from nexus.fs._tui.mount_panel import MountPanel
 
 MIN_WIDTH = 80
@@ -333,6 +334,7 @@ class PlaygroundApp(App[None]):
 
     BINDINGS = [
         Binding("q", "request_quit", "Quit", priority=True),
+        Binding("question_mark", "show_help", "Help", key_display="?"),
         Binding("b", "go_back", "Back"),
         Binding("/", "toggle_search", "Search", key_display="/"),
         Binding(":", "toggle_command", "Command", key_display=":", priority=True),
@@ -1331,6 +1333,12 @@ class PlaygroundApp(App[None]):
     def action_request_quit(self) -> None:
         """Quit immediately without confirmation dialog."""
         self.exit()
+
+    def action_show_help(self) -> None:
+        """Show the keybinding help overlay."""
+        if isinstance(self.focused, Input):
+            return
+        self.push_screen(HelpOverlay())
 
     def action_new_file(self) -> None:
         """Create a new empty file in the current directory."""

--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -334,7 +334,7 @@ class PlaygroundApp(App[None]):
 
     BINDINGS = [
         Binding("q", "request_quit", "Quit", priority=True),
-        Binding("question_mark", "show_help", "Help", key_display="?"),
+        Binding("question_mark", "show_help", "Help", key_display="?", priority=True),
         Binding("b", "go_back", "Back"),
         Binding("/", "toggle_search", "Search", key_display="/"),
         Binding(":", "toggle_command", "Command", key_display=":", priority=True),

--- a/src/nexus/fs/_tui/help_overlay.py
+++ b/src/nexus/fs/_tui/help_overlay.py
@@ -67,7 +67,7 @@ def _render_help_text() -> str:
         for key, action in bindings:
             lines.append(f"  [bold cyan]{key:<12}[/bold cyan] {action}")
         lines.append("")
-    lines.append("[dim]Press any key to dismiss[/dim]")
+    lines.append("[dim]Scroll: \u2191\u2193 PgUp/PgDn  Dismiss: any other key[/dim]")
     return "\n".join(lines)
 
 
@@ -97,7 +97,23 @@ class HelpOverlay(ModalScreen[None]):
         with VerticalScroll(id="help-container"):
             yield Static(_render_help_text(), id="help-text")
 
+    # Keys that scroll the VerticalScroll container instead of dismissing.
+    _SCROLL_KEYS = frozenset(
+        {
+            "up",
+            "down",
+            "pageup",
+            "pagedown",
+            "home",
+            "end",
+            "scroll_up",
+            "scroll_down",
+        }
+    )
+
     def on_key(self, event: Key) -> None:
-        """Dismiss on any keypress."""
+        """Dismiss on most keys; let scroll keys pass through."""
+        if event.key in self._SCROLL_KEYS:
+            return  # let VerticalScroll handle it
         event.stop()
         self.dismiss()

--- a/src/nexus/fs/_tui/help_overlay.py
+++ b/src/nexus/fs/_tui/help_overlay.py
@@ -1,0 +1,103 @@
+"""Help overlay — full-screen keybinding reference for the playground TUI.
+
+Activated with ``?`` key. Shows all keybindings grouped by intent.
+Press any key to dismiss.
+
+See Issue #3508.
+"""
+
+from __future__ import annotations
+
+from textual.app import ComposeResult
+from textual.containers import VerticalScroll
+from textual.events import Key
+from textual.screen import ModalScreen
+from textual.widgets import Static
+
+# ---------------------------------------------------------------------------
+# Keybinding definitions (canonical source for the help overlay)
+# ---------------------------------------------------------------------------
+
+GLOBAL_BINDINGS: list[tuple[str, str]] = [
+    ("?", "Help overlay"),
+    ("q", "Quit"),
+    ("b", "Back"),
+]
+
+NAVIGATION_BINDINGS: list[tuple[str, str]] = [
+    ("Tab", "Switch panel"),
+    ("\u2191/\u2193", "Move up/down"),
+    ("Enter", "Select / open"),
+    ("Esc", "Cancel / close"),
+    ("m", "Focus mount panel"),
+]
+
+FILE_OPERATION_BINDINGS: list[tuple[str, str]] = [
+    ("n", "New file"),
+    ("N", "New directory"),
+    ("d", "Delete"),
+    ("r", "Rename"),
+    ("p", "Preview file"),
+    ("c", "Copy path"),
+]
+
+MOUNT_AND_SEARCH_BINDINGS: list[tuple[str, str]] = [
+    ("a", "Add mount"),
+    ("u", "Unmount"),
+    ("/", "Search"),
+    (":", "Command mode"),
+]
+
+ALL_GROUPS: list[tuple[str, list[tuple[str, str]]]] = [
+    ("Global", GLOBAL_BINDINGS),
+    ("Navigation", NAVIGATION_BINDINGS),
+    ("File Operations", FILE_OPERATION_BINDINGS),
+    ("Mount & Search", MOUNT_AND_SEARCH_BINDINGS),
+]
+
+# Flat set of keys in the help overlay (used by drift tests).
+ALL_HELP_KEYS: set[str] = {key for _, bindings in ALL_GROUPS for key, _ in bindings}
+
+
+def _render_help_text() -> str:
+    """Build Rich-markup text for all binding groups."""
+    lines: list[str] = ["[bold]Keybinding Reference[/bold]", ""]
+    for group_name, bindings in ALL_GROUPS:
+        lines.append(f"[bold cyan]\u2500\u2500\u2500 {group_name} \u2500\u2500\u2500[/bold cyan]")
+        for key, action in bindings:
+            lines.append(f"  [bold cyan]{key:<12}[/bold cyan] {action}")
+        lines.append("")
+    lines.append("[dim]Press any key to dismiss[/dim]")
+    return "\n".join(lines)
+
+
+# ---------------------------------------------------------------------------
+# Modal screen
+# ---------------------------------------------------------------------------
+
+
+class HelpOverlay(ModalScreen[None]):
+    """Full-screen keybinding reference overlay, dismissed on any key."""
+
+    DEFAULT_CSS = """
+    HelpOverlay {
+        align: center middle;
+    }
+    #help-container {
+        width: 70%;
+        max-width: 80;
+        height: 80%;
+        background: $surface;
+        border: heavy $primary;
+        padding: 1 2;
+    }
+    """
+
+    def compose(self) -> ComposeResult:
+        with VerticalScroll(id="help-container"):
+            yield Static(_render_help_text(), id="help-text")
+
+    def on_key(self, event: Key) -> None:
+        """Dismiss on any keypress."""
+        event.stop()
+        self.dismiss()

--- a/tests/unit/fs/test_tui.py
+++ b/tests/unit/fs/test_tui.py
@@ -978,3 +978,105 @@ class TestAccessibility:
             # _update_status_bar should not crash
             app._update_status_bar(announce=True)
             app._update_status_bar(announce=False)
+
+
+# ---------------------------------------------------------------------------
+# Help overlay tests (Issue #3508)
+# ---------------------------------------------------------------------------
+
+
+from nexus.fs._tui.help_overlay import (  # noqa: E402
+    ALL_GROUPS,
+    ALL_HELP_KEYS,
+    HelpOverlay,
+    _render_help_text,
+)
+
+
+class TestHelpOverlay:
+    """Tests for the ? help overlay."""
+
+    @pytest.mark.asyncio
+    async def test_question_mark_opens_help_overlay(self):
+        """Pressing ? pushes the HelpOverlay modal screen."""
+        app = PlaygroundApp(uris=())
+
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(delay=0.3)
+            await pilot.press("question_mark")
+            await pilot.pause(delay=0.2)
+            assert isinstance(app.screen, HelpOverlay)
+
+    @pytest.mark.asyncio
+    async def test_any_key_dismisses_help_overlay(self):
+        """Pressing any key after opening the overlay should dismiss it."""
+        app = PlaygroundApp(uris=())
+
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(delay=0.3)
+            await pilot.press("question_mark")
+            await pilot.pause(delay=0.2)
+            assert isinstance(app.screen, HelpOverlay)
+            # Dismiss with Escape
+            await pilot.press("escape")
+            await pilot.pause(delay=0.2)
+            assert not isinstance(app.screen, HelpOverlay)
+
+    @pytest.mark.asyncio
+    async def test_help_not_opened_when_search_input_focused(self):
+        """Pressing ? while typing in search should not open the overlay."""
+        app = PlaygroundApp(uris=())
+
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(delay=0.3)
+            # Activate search
+            await pilot.press("/")
+            await pilot.pause(delay=0.1)
+            # Press ? while in search input
+            await pilot.press("question_mark")
+            await pilot.pause(delay=0.2)
+            assert not isinstance(app.screen, HelpOverlay)
+
+    @pytest.mark.asyncio
+    async def test_help_overlay_shows_all_groups(self):
+        """The overlay content includes all 4 binding group headers."""
+        app = PlaygroundApp(uris=())
+
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(delay=0.3)
+            await pilot.press("question_mark")
+            await pilot.pause(delay=0.2)
+            assert isinstance(app.screen, HelpOverlay)
+            text = str(app.screen.query_one("#help-text").render())
+            for group_name, _ in ALL_GROUPS:
+                assert group_name in text, f"Group '{group_name}' missing from help overlay"
+
+    def test_help_overlay_has_minimum_bindings(self):
+        """The overlay should contain at least 18 keybinding entries."""
+        total = sum(len(bindings) for _, bindings in ALL_GROUPS)
+        assert total >= 18, f"Expected >= 18 bindings, got {total}"
+
+    def test_render_help_text_contains_dismiss_hint(self):
+        """The rendered help text includes a dismiss instruction."""
+        text = _render_help_text()
+        assert "Press any key to dismiss" in text
+
+
+class TestHelpOverlayDrift:
+    """Drift detection: every shown BINDINGS entry must appear in the help overlay."""
+
+    def test_bindings_covered_by_help_overlay(self):
+        """Every visible PlaygroundApp binding key is present in the help overlay dict."""
+        # Map Textual internal key names to the display keys used in the overlay.
+        key_display_map: dict[str, str] = {
+            "question_mark": "?",
+        }
+        for binding in PlaygroundApp.BINDINGS:
+            if not binding.show:
+                continue
+            key = binding.key
+            display_key = key_display_map.get(key, binding.key_display or key)
+            assert display_key in ALL_HELP_KEYS, (
+                f"Binding '{key}' (display: '{display_key}') is in PlaygroundApp.BINDINGS "
+                f"but missing from help overlay. Add it to the appropriate group in help_overlay.py."
+            )

--- a/tests/unit/fs/test_tui.py
+++ b/tests/unit/fs/test_tui.py
@@ -1059,7 +1059,7 @@ class TestHelpOverlay:
     def test_render_help_text_contains_dismiss_hint(self):
         """The rendered help text includes a dismiss instruction."""
         text = _render_help_text()
-        assert "Press any key to dismiss" in text
+        assert "Dismiss" in text
 
 
 class TestHelpOverlayDrift:


### PR DESCRIPTION
## Summary
- Adds a `?` keybinding to the playground TUI that opens a full-screen help overlay listing all keyboard shortcuts grouped by intent (Global, Navigation, File Operations, Mount & Search)
- Mirrors the nexus-tui `HelpOverlay` pattern using Textual's `ModalScreen` — press any key to dismiss
- Includes an Input guard so `?` types normally when focus is on search/command/CRUD inputs

Closes #3508

## Test plan
- [x] 7 new tests added (all passing):
  - Pilot test: `?` opens `HelpOverlay` modal screen
  - Pilot test: any key dismisses the overlay
  - Pilot test: `?` does not open overlay when typing in search Input
  - Content test: all 4 group headers render in overlay
  - Sanity check: >= 18 bindings defined
  - Render test: dismiss hint present in rendered text
  - Drift test: every visible `BINDINGS` entry has a matching key in help overlay dict
- [ ] Manual TUI test: `nexus-fs playground local://./data` → press `?`