### PR TITLE
Fix TUI package DX and unify npm release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -31,11 +31,15 @@ jobs:
           PKG_VERSION=$(grep '^version = ' pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
           RUST_PKG_VERSION=$(grep '^version = ' rust/nexus_pyo3/pyproject.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
           RUST_CARGO_VERSION=$(grep '^version = ' rust/nexus_pyo3/Cargo.toml | head -1 | sed 's/version = "\(.*\)"/\1/')
+          API_CLIENT_VERSION=$(node -p "require('./packages/nexus-api-client/package.json').version")
+          TUI_VERSION=$(node -p "require('./packages/nexus-tui/package.json').version")
           echo "Tag version: $TAG_VERSION"
           echo "Package version: $PKG_VERSION"
           echo "Rust package version: $RUST_PKG_VERSION"
           echo "Rust Cargo version: $RUST_CARGO_VERSION"
-          if [ "$TAG_VERSION" != "$PKG_VERSION" ] || [ "$TAG_VERSION" != "$RUST_PKG_VERSION" ] || [ "$TAG_VERSION" != "$RUST_CARGO_VERSION" ]; then
+          echo "API client version: $API_CLIENT_VERSION"
+          echo "TUI version: $TUI_VERSION"
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ] || [ "$TAG_VERSION" != "$RUST_PKG_VERSION" ] || [ "$TAG_VERSION" != "$RUST_CARGO_VERSION" ] || [ "$TAG_VERSION" != "$API_CLIENT_VERSION" ] || [ "$TAG_VERSION" != "$TUI_VERSION" ]; then
             echo "❌ Version mismatch! Tag is v$TAG_VERSION but package metadata is inconsistent"
             exit 1
           fi
@@ -335,6 +339,83 @@ jobs:
           path: dist-nexus-fs/*
           retention-days: 90
 
+  publish-ts-packages:
+    name: Publish TypeScript packages to npm
+    needs: [verify-version]
+    runs-on: ubuntu-latest
+    env:
+      NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Skip when NPM token is not configured
+        if: ${{ env.NODE_AUTH_TOKEN == '' }}
+        run: echo "NPM_TOKEN not configured; skipping TypeScript package publish."
+
+      - name: Set up Node
+        if: ${{ env.NODE_AUTH_TOKEN != '' }}
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          registry-url: "https://registry.npmjs.org"
+
+      - name: Set up Bun
+        if: ${{ env.NODE_AUTH_TOKEN != '' }}
+        uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Build and test api-client
+        if: ${{ env.NODE_AUTH_TOKEN != '' }}
+        working-directory: packages/nexus-api-client
+        run: |
+          npm install
+          npm run build
+          npm test
+
+      - name: Publish @nexus/api-client
+        if: ${{ env.NODE_AUTH_TOKEN != '' }}
+        run: |
+          VERSION="$(node -p "require('./packages/nexus-api-client/package.json').version")"
+          if npm view "@nexus/api-client@${VERSION}" version >/dev/null 2>&1; then
+            echo "@nexus/api-client@${VERSION} already published"
+          else
+            cd packages/nexus-api-client
+            npm publish --access public
+          fi
+
+      - name: Test TUI
+        if: ${{ env.NODE_AUTH_TOKEN != '' }}
+        working-directory: packages/nexus-tui
+        run: |
+          bun install
+          bun test
+
+      - name: Prepare TUI manifest for publish
+        if: ${{ env.NODE_AUTH_TOKEN != '' }}
+        run: |
+          API_VERSION="$(node -p "require('./packages/nexus-api-client/package.json').version")"
+          API_VERSION="$API_VERSION" node <<'EOF'
+          const fs = require("fs");
+          const path = "packages/nexus-tui/package.json";
+          const pkg = JSON.parse(fs.readFileSync(path, "utf8"));
+          pkg.dependencies["@nexus/api-client"] = `^${process.env.API_VERSION}`;
+          fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + "\n");
+          EOF
+
+      - name: Publish @nexus/tui
+        if: ${{ env.NODE_AUTH_TOKEN != '' }}
+        run: |
+          VERSION="$(node -p "require('./packages/nexus-tui/package.json').version")"
+          if npm view "@nexus/tui@${VERSION}" version >/dev/null 2>&1; then
+            echo "@nexus/tui@${VERSION} already published"
+          else
+            cd packages/nexus-tui
+            npm publish --access public
+          fi
+
   # Docker build, smoke test, and GHCR push — inline in release.yml so
   # create-release can depend on it directly (Issue #2946 atomic release).
   # docker-publish.yml handles branch pushes (develop/main) separately.
@@ -463,7 +544,7 @@ jobs:
   # doesn't appear on the releases page or trigger notifications.
   create-release:
     name: Create GitHub Release
-    needs: [publish-pypi, publish-rust, publish-nexus-fs, build-docker]
+    needs: [publish-pypi, publish-rust, publish-nexus-fs, publish-ts-packages, build-docker]
     runs-on: ubuntu-latest
 
     steps:

--- a/README.md
+++ b/README.md
@@ -101,7 +101,8 @@ The TUI is a separate TypeScript package built on OpenTUI:
 ```bash
 bunx @nexus/tui                                        # published package, connects to localhost:2026
 bunx @nexus/tui --url http://remote:2026 --api-key KEY # connect to remote instance
-cd packages/nexus-tui && bun install && bun run src/index.tsx  # local development from this repo
+cd packages/nexus-api-client && npm install && npm run build && cd -  # build sibling dependency once in a fresh checkout
+cd packages/nexus-tui && bun install && bun run src/index.tsx          # local development from this repo
 ```
 
 File explorer, API inspector, monitoring dashboard, agent lifecycle management, and more — all from your terminal.

--- a/README.md
+++ b/README.md
@@ -99,8 +99,9 @@ nexus versions history /hello.txt
 The TUI is a separate TypeScript package built on OpenTUI:
 
 ```bash
-bunx nexus-tui                                         # connects to localhost:2026
-bunx nexus-tui --url http://remote:2026 --api-key KEY  # connect to remote instance
+bunx @nexus/tui                                        # published package, connects to localhost:2026
+bunx @nexus/tui --url http://remote:2026 --api-key KEY # connect to remote instance
+cd packages/nexus-tui && bun install && bun run src/index.tsx  # local development from this repo
 ```
 
 File explorer, API inspector, monitoring dashboard, agent lifecycle management, and more — all from your terminal.

--- a/packages/nexus-api-client/README.md
+++ b/packages/nexus-api-client/README.md
@@ -1,0 +1,12 @@
+# @nexus/api-client
+
+Shared HTTP client for Nexus APIs.
+
+## Local Development
+
+```bash
+cd packages/nexus-api-client
+npm install
+npm run build
+npm test
+```

--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus/api-client",
-  "version": "0.1.0",
+  "version": "0.9.16",
   "description": "Shared HTTP client for Nexus APIs — retry, auth, error mapping, case transform",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -46,6 +46,9 @@
     "client",
     "sdk"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/nexus-tui/README.md
+++ b/packages/nexus-tui/README.md
@@ -20,6 +20,10 @@ nexus-tui
 ## Local Development
 
 ```bash
+cd packages/nexus-api-client
+npm install
+npm run build
+
 cd packages/nexus-tui
 bun install
 bun run src/index.tsx

--- a/packages/nexus-tui/README.md
+++ b/packages/nexus-tui/README.md
@@ -1,0 +1,26 @@
+# @nexus/tui
+
+Terminal UI for Nexus.
+
+## Usage
+
+Run the published package with Bun:
+
+```bash
+bunx @nexus/tui
+bunx @nexus/tui --url http://remote:2026 --api-key KEY
+```
+
+The installed binary name is:
+
+```bash
+nexus-tui
+```
+
+## Local Development
+
+```bash
+cd packages/nexus-tui
+bun install
+bun run src/index.tsx
+```

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus/tui",
-  "version": "0.1.0",
+  "version": "0.9.16",
   "description": "Terminal UI for Nexus — file explorer, API inspector, and monitoring dashboard",
   "type": "module",
   "bin": {

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -6,6 +6,10 @@
   "bin": {
     "nexus-tui": "./src/index.tsx"
   },
+  "files": [
+    "src",
+    "README.md"
+  ],
   "scripts": {
     "dev": "bun run src/index.tsx",
     "start": "bun run src/index.tsx",
@@ -32,6 +36,9 @@
     "terminal",
     "opentui"
   ],
+  "publishConfig": {
+    "access": "public"
+  },
   "license": "MIT",
   "repository": {
     "type": "git",

--- a/packages/nexus-tui/src/index.tsx
+++ b/packages/nexus-tui/src/index.tsx
@@ -5,9 +5,9 @@
  * Parses CLI args, resolves config, and renders the TUI via OpenTUI.
  *
  * Usage:
- *   bunx nexus-tui
- *   bunx nexus-tui --url http://remote:2026 --api-key nx_live_myagent
- *   bunx nexus-tui --agent-id bot-worker-1 --zone-id org_acme
+ *   bunx @nexus/tui
+ *   bunx @nexus/tui --url http://remote:2026 --api-key nx_live_myagent
+ *   bunx @nexus/tui --agent-id bot-worker-1 --zone-id org_acme
  */
 
 import { createCliRenderer } from "@opentui/core";
@@ -55,6 +55,9 @@ nexus-tui — Terminal UI for Nexus
 Usage:
   nexus-tui [options]
 
+Published package:
+  bunx @nexus/tui [options]
+
 Options:
   --url, -u <url>        Nexus server URL (default: NEXUS_URL or http://localhost:2026)
   --api-key, -k <key>    API key (default: NEXUS_API_KEY env var)
@@ -72,6 +75,9 @@ Environment Variables:
 
 Config File:
   ~/.nexus/config.yaml   Auto-discovered (same as nexus CLI)
+
+Local development:
+  cd packages/nexus-tui && bun install && bun run src/index.tsx
 `.trim());
       process.exit(0);
     }

--- a/packages/nexus-tui/src/index.tsx
+++ b/packages/nexus-tui/src/index.tsx
@@ -77,6 +77,7 @@ Config File:
   ~/.nexus/config.yaml   Auto-discovered (same as nexus CLI)
 
 Local development:
+  cd packages/nexus-api-client && npm install && npm run build
   cd packages/nexus-tui && bun install && bun run src/index.tsx
 `.trim());
       process.exit(0);

--- a/src/nexus/cli/main.py
+++ b/src/nexus/cli/main.py
@@ -42,14 +42,17 @@ def _exec_tui(extra_args: list[str] | None = None) -> None:
     """
     args = extra_args or []
 
-    # Repo-local dev path: walk up from CWD looking for packages/nexus-tui
-    # so `nexus` works directly from a source checkout.
+    # Repo-local dev path: walk up from CWD looking for a runnable TS workspace.
+    # The TUI depends on the sibling api-client package, which currently exports
+    # built dist/ artifacts. In a fresh checkout, prefer the local workspace
+    # only when both the TUI entrypoint and api-client build output exist.
     bun = shutil.which("bun")
     if bun is not None:
         cwd = Path.cwd()
         for candidate_root in (cwd, *cwd.parents):
             local_entry = candidate_root / "packages" / "nexus-tui" / "src" / "index.tsx"
-            if local_entry.exists():
+            api_client_dist = candidate_root / "packages" / "nexus-api-client" / "dist" / "index.js"
+            if local_entry.exists() and api_client_dist.exists():
                 os.execvp(bun, ["bun", "run", str(local_entry), *args])
                 # execvp does not return
 

--- a/src/nexus/cli/main.py
+++ b/src/nexus/cli/main.py
@@ -10,6 +10,7 @@ import os
 import shutil
 import sys
 import warnings
+from pathlib import Path
 
 import click
 
@@ -34,9 +35,10 @@ setup_uvloop()
 def _exec_tui(extra_args: list[str] | None = None) -> None:
     """Replace the current process with the TUI.
 
-    Prefers a locally-installed ``nexus-tui`` binary (faster startup) and
-    falls back to ``bunx nexus-tui``.  If neither is available, prints a
-    helpful error and exits with code 1.
+    Order of preference:
+      1. ``nexus-tui`` already on PATH
+      2. repo-local ``packages/nexus-tui/src/index.tsx`` via ``bun run``
+      3. published ``@nexus/tui`` via ``bunx``
     """
     args = extra_args or []
 
@@ -46,16 +48,27 @@ def _exec_tui(extra_args: list[str] | None = None) -> None:
         os.execvp(nexus_tui, ["nexus-tui", *args])
         # execvp does not return
 
-    # Fallback: use bunx (Bun's npx equivalent)
+    # Repo-local dev path: walk up from CWD looking for packages/nexus-tui
+    # so `nexus` works directly from a source checkout.
+    bun = shutil.which("bun")
+    if bun is not None:
+        cwd = Path.cwd()
+        for candidate_root in (cwd, *cwd.parents):
+            local_entry = candidate_root / "packages" / "nexus-tui" / "src" / "index.tsx"
+            if local_entry.exists():
+                os.execvp(bun, ["bun", "run", str(local_entry), *args])
+                # execvp does not return
+
+    # Fallback: use bunx (Bun's npx equivalent) against the scoped package.
     bunx = shutil.which("bunx")
     if bunx is not None:
-        os.execvp(bunx, ["bunx", "nexus-tui", *args])
+        os.execvp(bunx, ["bunx", "@nexus/tui", *args])
         # execvp does not return
 
     # Neither found – give the user actionable guidance.
-    click.secho("Error: could not find nexus-tui or bunx on PATH.", fg="red", err=True)
+    click.secho("Error: could not find nexus-tui, bun, or bunx on PATH.", fg="red", err=True)
     click.echo(
-        "Install the TUI with:\n  npm install -g nexus-tui   # or\n  bun install -g nexus-tui\n",
+        "Install the TUI with:\n  bunx @nexus/tui   # or\n  bun install -g @nexus/tui\n",
         err=True,
     )
     sys.exit(1)

--- a/src/nexus/cli/main.py
+++ b/src/nexus/cli/main.py
@@ -43,16 +43,26 @@ def _exec_tui(extra_args: list[str] | None = None) -> None:
     args = extra_args or []
 
     # Repo-local dev path: walk up from CWD looking for a runnable TS workspace.
-    # The TUI depends on the sibling api-client package, which currently exports
-    # built dist/ artifacts. In a fresh checkout, prefer the local workspace
-    # only when both the TUI entrypoint and api-client build output exist.
+    # The TUI depends on:
+    #   - the sibling api-client package having been built, and
+    #   - the TUI workspace itself having been installed (`bun install`)
+    # In a partial setup, fall back to the installed binary or bunx.
     bun = shutil.which("bun")
     if bun is not None:
         cwd = Path.cwd()
         for candidate_root in (cwd, *cwd.parents):
             local_entry = candidate_root / "packages" / "nexus-tui" / "src" / "index.tsx"
             api_client_dist = candidate_root / "packages" / "nexus-api-client" / "dist" / "index.js"
-            if local_entry.exists() and api_client_dist.exists():
+            tui_workspace_dep = (
+                candidate_root
+                / "packages"
+                / "nexus-tui"
+                / "node_modules"
+                / "@nexus"
+                / "api-client"
+                / "package.json"
+            )
+            if local_entry.exists() and api_client_dist.exists() and tui_workspace_dep.exists():
                 os.execvp(bun, ["bun", "run", str(local_entry), *args])
                 # execvp does not return
 

--- a/src/nexus/cli/main.py
+++ b/src/nexus/cli/main.py
@@ -36,17 +36,11 @@ def _exec_tui(extra_args: list[str] | None = None) -> None:
     """Replace the current process with the TUI.
 
     Order of preference:
-      1. ``nexus-tui`` already on PATH
-      2. repo-local ``packages/nexus-tui/src/index.tsx`` via ``bun run``
+      1. repo-local ``packages/nexus-tui/src/index.tsx`` via ``bun run``
+      2. ``nexus-tui`` already on PATH
       3. published ``@nexus/tui`` via ``bunx``
     """
     args = extra_args or []
-
-    # Fast path: nexus-tui already on PATH
-    nexus_tui = shutil.which("nexus-tui")
-    if nexus_tui is not None:
-        os.execvp(nexus_tui, ["nexus-tui", *args])
-        # execvp does not return
 
     # Repo-local dev path: walk up from CWD looking for packages/nexus-tui
     # so `nexus` works directly from a source checkout.
@@ -58,6 +52,12 @@ def _exec_tui(extra_args: list[str] | None = None) -> None:
             if local_entry.exists():
                 os.execvp(bun, ["bun", "run", str(local_entry), *args])
                 # execvp does not return
+
+    # Fast path outside a checkout: use installed nexus-tui on PATH.
+    nexus_tui = shutil.which("nexus-tui")
+    if nexus_tui is not None:
+        os.execvp(nexus_tui, ["nexus-tui", *args])
+        # execvp does not return
 
     # Fallback: use bunx (Bun's npx equivalent) against the scoped package.
     bunx = shutil.which("bunx")


### PR DESCRIPTION
## Summary
- make `nexus` prefer local repo TUI, then installed binary, then `bunx @nexus/tui`
- switch docs/help away from the conflicting `bunx nexus-tui` path and add package READMEs
- publish `@nexus/api-client` and `@nexus/tui` from the main `v*` release workflow so Python and npm releases stay in sync

## Testing
- `python -m py_compile src/nexus/cli/main.py`
- `cd packages/nexus-tui && bun test`
- `cd packages/nexus-tui && bun run src/index.tsx --help`
- pre-commit hooks via `git commit`