### PR TITLE
perf(pipe_manager): replace dict-of-locks with VFSLockManager (#3198)

### DIFF
--- a/src/nexus/core/pipe_manager.py
+++ b/src/nexus/core/pipe_manager.py
@@ -1,14 +1,17 @@
 """PipeManager — VFS named pipe manager (fs/pipe.c equivalent).
 
 Kernel primitive (§4.2) managing DT_PIPE lifecycle and buffer registry
-with per-pipe locking for MPMC.
+with VFSLockManager-backed per-pipe locking for MPMC.
 
     core/pipe.py         = kfifo     (include/linux/kfifo.h + lib/kfifo.c)
     core/pipe_manager.py = fs/pipe.c (VFS named pipe with per-pipe lock)
 
 Concurrency model (aligned with Linux pipe(7)):
   - RingBuffer (kfifo) is SPSC, no internal lock.
-  - PipeManager (mkfifo) adds per-pipe asyncio.Lock for MPMC safety.
+  - PipeManager (mkfifo) adds per-pipe VFSLockManager locks for MPMC safety
+    (Issue #3198). Replaces dict[str, asyncio.Lock] with Rust-backed
+    VFSLockManager (~100-200ns per acquire) for hierarchical awareness,
+    crash-safe release, and observability via holders().
     Async methods use Linux-style lock→try_nowait→unlock→wait→retry
     to avoid holding the lock during blocking waits (deadlock-free).
   - Sync methods (pipe_write_nowait) are atomic under asyncio event loop
@@ -20,9 +23,15 @@ See: core/pipe.py for RingBuffer, federation-memo.md §7j
 import asyncio
 import logging
 import time
+from concurrent.futures import ThreadPoolExecutor
 from typing import TYPE_CHECKING
 
 from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.core.lock_fast import (
+    PythonVFSLockManager,
+    RustVFSLockManager,
+    create_vfs_lock_manager,
+)
 from nexus.core.pipe import (
     PipeBackend,
     PipeClosedError,
@@ -74,12 +83,25 @@ class PipeManager:
         metastore: "MetastoreABC",
         self_address: str | None = None,
         channel_pool: "PeerChannelPool | None" = None,
+        vfs_lock_manager: "RustVFSLockManager | PythonVFSLockManager | None" = None,
     ) -> None:
         self._metastore = metastore
         self._self_address = self_address
         self._channel_pool = channel_pool
         self._buffers: dict[str, PipeBackend] = {}
-        self._locks: dict[str, asyncio.Lock] = {}
+        # Issue #3198: VFSLockManager replaces dict[str, asyncio.Lock] for
+        # per-pipe MPMC locking — Rust-backed (~100-200ns), hierarchical
+        # awareness, crash-safe release, and observability via holders().
+        # Dedicated instance (not shared with NexusFS) so pipe lock
+        # contention cannot interfere with filesystem locks that may
+        # block for up to 5s on rename/move operations.
+        self._vfs_lock: RustVFSLockManager | PythonVFSLockManager = (
+            vfs_lock_manager or create_vfs_lock_manager()
+        )
+        # Dedicated 2-thread executor for lock contention fallback so
+        # pipe waits don't consume the default asyncio executor used by
+        # asyncio.to_thread() and FastAPI sync endpoints.
+        self._lock_executor = ThreadPoolExecutor(max_workers=2, thread_name_prefix="pipe-lock")
         # Backpressure counters — track blocking events on the MPMC async path.
         # Only incremented in pipe_write/pipe_read (not the lock-free nowait path).
         self._write_blocks: int = 0
@@ -313,7 +335,6 @@ class PipeManager:
         if buf is None:
             raise PipeNotFoundError(f"no pipe at: {path}")
         buf.close()
-        self._locks.pop(path, None)
         logger.debug("pipe closed: %s", path)
 
     def destroy(self, path: str) -> None:
@@ -325,7 +346,6 @@ class PipeManager:
         buf = self._buffers.pop(path, None)
         if buf is not None:
             buf.close()
-        self._locks.pop(path, None)
 
         metadata = self._metastore.get(path)
         if metadata is None:
@@ -343,33 +363,56 @@ class PipeManager:
             raise PipeNotFoundError(f"no pipe at: {path}")
         return buf
 
-    def _get_lock(self, path: str) -> asyncio.Lock:
-        """Get or create per-pipe lock for MPMC safety."""
-        lock = self._locks.get(path)
-        if lock is None:
-            lock = asyncio.Lock()
-            self._locks[path] = lock
-        return lock
+    # Timeout for blocking VFS lock acquire in the thread-pool fallback.
+    # Kept short — the lock is only held for a single nowait buffer op (~200ns).
+    _VFS_LOCK_CONTENTION_TIMEOUT_MS = 10
+
+    async def _acquire_vfs_lock_async(self, path: str) -> int:
+        """Acquire VFSLockManager write lock, async-safe.
+
+        Fast path: non-blocking try (timeout_ms=0), no thread pool overhead.
+        Slow path (contention): delegates to a **dedicated** 2-thread
+        executor with a blocking timeout so the coroutine suspends
+        properly without consuming the default asyncio executor.
+        """
+        # Fast path — uncontended (~100-200ns, no thread dispatch)
+        handle = self._vfs_lock.acquire(path, "write", timeout_ms=0)
+        if handle:
+            return handle
+        # Slow path — suspend coroutine on dedicated executor
+        loop = asyncio.get_running_loop()
+        while True:
+            handle = await loop.run_in_executor(
+                self._lock_executor,
+                self._vfs_lock.acquire,
+                path,
+                "write",
+                self._VFS_LOCK_CONTENTION_TIMEOUT_MS,
+            )
+            if handle:
+                return handle
 
     # ------------------------------------------------------------------
     # Data path — MPMC-safe read/write
     # ------------------------------------------------------------------
 
     async def pipe_write(self, path: str, data: bytes, *, blocking: bool = True) -> int:
-        """Write to a named pipe. MPMC-safe (per-pipe asyncio.Lock).
+        """Write to a named pipe. MPMC-safe (VFSLockManager write lock).
 
         Uses Linux pipe_write pattern: lock → try_nowait → unlock → wait → retry.
         Lock is never held during blocking waits (deadlock-free).
         """
         buf = self._get_buffer(path)
-        lock = self._get_lock(path)
         while True:
-            async with lock:
+            handle = await self._acquire_vfs_lock_async(path)
+            try:
                 try:
                     return buf.write_nowait(data)
                 except PipeFullError:
                     if not blocking:
                         raise
+            finally:
+                self._vfs_lock.release(handle)
             # Full and blocking: wait for space without holding lock
             self._write_blocks += 1
             t0 = time.perf_counter_ns()
@@ -377,20 +420,22 @@ class PipeManager:
             self._total_write_wait_ns += time.perf_counter_ns() - t0
 
     async def pipe_read(self, path: str, *, blocking: bool = True) -> bytes:
-        """Read from a named pipe. MPMC-safe (per-pipe asyncio.Lock).
+        """Read from a named pipe. MPMC-safe (VFSLockManager write lock).
 
         Uses Linux pipe_read pattern: lock → try_nowait → unlock → wait → retry.
         Lock is never held during blocking waits (deadlock-free).
         """
         buf = self._get_buffer(path)
-        lock = self._get_lock(path)
         while True:
-            async with lock:
+            handle = await self._acquire_vfs_lock_async(path)
+            try:
                 try:
                     return buf.read_nowait()
                 except PipeEmptyError:
                     if not blocking:
                         raise
+            finally:
+                self._vfs_lock.release(handle)
             # Empty and blocking: wait for data without holding lock
             self._read_blocks += 1
             t0 = time.perf_counter_ns()
@@ -457,4 +502,4 @@ class PipeManager:
             buf.close()
             logger.debug("pipe closed (shutdown): %s", path)
         self._buffers.clear()
-        self._locks.clear()
+        self._lock_executor.shutdown(wait=False)

--- a/tests/benchmarks/test_rebac_latency.py
+++ b/tests/benchmarks/test_rebac_latency.py
@@ -17,6 +17,8 @@ Run with:
     pytest tests/benchmarks/test_rebac_latency.py -v --benchmark-only
 """
 
+import time
+
 import pytest
 from sqlalchemy import create_engine
 
@@ -27,6 +29,23 @@ from nexus.storage.models import Base
 from tests.helpers.dict_metastore import DictMetastore
 
 ZONE_ID = "bench_zone"
+
+
+def _get_median_ms(benchmark) -> float | None:
+    """Return benchmark median in ms, or None if stats unavailable (xdist)."""
+    if benchmark.stats is not None:
+        return benchmark.stats["median"] * 1000
+    return None
+
+
+def _measure_single_ms(func, *args, **kwargs):
+    """Manual single-iteration timing fallback when benchmark stats are disabled."""
+    t0 = time.perf_counter()
+    result = func(*args, **kwargs)
+    elapsed_ms = (time.perf_counter() - t0) * 1000
+    return result, elapsed_ms
+
+
 SUBJECT_ALICE = ("agent", "alice")
 SUBJECT_BOB = ("agent", "bob")
 
@@ -197,7 +216,11 @@ class TestL1CacheHit:
         assert result is True
 
         # SLA: p50 < 2ms (generous for CI machines)
-        median_ms = benchmark.stats["median"] * 1000
+        median_ms = _get_median_ms(benchmark)
+        if median_ms is None:
+            _, median_ms = _measure_single_ms(
+                m.rebac_check, subject=subject, permission="read", object=obj, zone_id=ZONE_ID
+            )
         assert median_ms < 2.0, f"L1 cache hit too slow: p50={median_ms:.3f}ms (target <2ms)"
 
 
@@ -232,7 +255,15 @@ class TestBoundaryCacheHit:
         )
         assert result is True
 
-        median_ms = benchmark.stats["median"] * 1000
+        median_ms = _get_median_ms(benchmark)
+        if median_ms is None:
+            _, median_ms = _measure_single_ms(
+                m.rebac_check,
+                subject=SUBJECT_ALICE,
+                permission="read",
+                object=("file", "/workspace/project/file_0.txt"),
+                zone_id=ZONE_ID,
+            )
         assert median_ms < 5.0, f"Boundary cache hit too slow: p50={median_ms:.3f}ms (target <5ms)"
 
 
@@ -277,7 +308,15 @@ class TestLeopardIndexHit:
         )
         assert result is True
 
-        median_ms = benchmark.stats["median"] * 1000
+        median_ms = _get_median_ms(benchmark)
+        if median_ms is None:
+            _, median_ms = _measure_single_ms(
+                m.rebac_check,
+                subject=SUBJECT_ALICE,
+                permission="read",
+                object=("file", "/workspace/"),
+                zone_id=ZONE_ID,
+            )
         assert median_ms < 10.0, (
             f"Leopard group check too slow: p50={median_ms:.3f}ms (target <10ms)"
         )
@@ -309,7 +348,17 @@ class TestDirectGrantTraversal:
         )
         assert result is True
 
-        median_ms = benchmark.stats["median"] * 1000
+        median_ms = _get_median_ms(benchmark)
+        if median_ms is None:
+            if m._l1_cache is not None:
+                m._l1_cache.clear()
+            _, median_ms = _measure_single_ms(
+                m.rebac_check,
+                subject=SUBJECT_ALICE,
+                permission="read",
+                object=("file", "/workspace/project/file_0.txt"),
+                zone_id=ZONE_ID,
+            )
         assert median_ms < 20.0, (
             f"Direct grant traversal too slow: p50={median_ms:.3f}ms (target <20ms)"
         )
@@ -341,7 +390,17 @@ class TestDeepInheritanceTraversal:
         )
         assert result is True
 
-        median_ms = benchmark.stats["median"] * 1000
+        median_ms = _get_median_ms(benchmark)
+        if median_ms is None:
+            if m._l1_cache is not None:
+                m._l1_cache.clear()
+            _, median_ms = _measure_single_ms(
+                m.rebac_check,
+                subject=SUBJECT_ALICE,
+                permission="read",
+                object=("file", "/workspace/deep/l1/l2/l3/l4/l5/file_deep.txt"),
+                zone_id=ZONE_ID,
+            )
         assert median_ms < 200.0, (
             f"Deep inheritance too slow: p50={median_ms:.3f}ms (target <200ms)"
         )
@@ -374,7 +433,15 @@ class TestBulkPermissionCheck:
         assert len(results) == 100
         assert all(results.values()), "Not all bulk checks returned True"
 
-        median_ms = benchmark.stats["median"] * 1000
+        median_ms = _get_median_ms(benchmark)
+        if median_ms is None:
+            checks_repeat = [
+                (SUBJECT_BOB, "read", ("file", f"/workspace/bulk/file_{i:04d}.txt"))
+                for i in range(100)
+            ]
+            _, median_ms = _measure_single_ms(
+                m.rebac_check_bulk, checks=checks_repeat, zone_id=ZONE_ID
+            )
         assert median_ms < 500.0, (
             f"Bulk check (100 objects) too slow: p50={median_ms:.3f}ms (target <500ms)"
         )
@@ -444,7 +511,15 @@ class TestDenialLatency:
         )
         assert result is False
 
-        median_ms = benchmark.stats["median"] * 1000
+        median_ms = _get_median_ms(benchmark)
+        if median_ms is None:
+            _, median_ms = _measure_single_ms(
+                m.rebac_check,
+                subject=("agent", "unknown_user"),
+                permission="write",
+                object=("file", "/workspace/project/file_0.txt"),
+                zone_id=ZONE_ID,
+            )
         assert median_ms < 50.0, f"Denial check too slow: p50={median_ms:.3f}ms (target <50ms)"
 
 

--- a/tests/benchmarks/test_search_protocol_benchmark.py
+++ b/tests/benchmarks/test_search_protocol_benchmark.py
@@ -21,45 +21,37 @@ class FastMockSearchBrick:
 
     _results: list[dict[str, Any]] = [{"path": "/test.py", "chunk_text": "match", "score": 0.9}]
 
-    async def search(
-        self,
-        query: str,
-        *,
-        limit: int = 10,
-        path_filter: str | None = None,
-        search_mode: str = "hybrid",
-    ) -> list[Any]:
-        return self._results
+    @property
+    def is_initialized(self) -> bool:
+        return True
 
-    async def index_document(
-        self,
-        path: str,
-        content: str,
-        *,
-        zone_id: str | None = None,
-    ) -> int:
-        return 1
-
-    async def index_directory(self, path: str = "/") -> dict[str, int]:
-        return {"/test.py": 1}
-
-    async def delete_document_index(self, path: str) -> None:
-        pass
-
-    async def get_index_stats(self) -> dict[str, Any]:
-        return {"total_chunks": 100}
-
-    async def get_stats(self) -> dict[str, Any]:
-        return {"total_chunks": 100}
-
-    async def initialize(self) -> None:
+    async def startup(self) -> None:
         pass
 
     async def shutdown(self) -> None:
         pass
 
-    def verify_imports(self) -> dict[str, bool]:
-        return {"nexus.bricks.search.semantic": True}
+    async def search(
+        self,
+        query: str,
+        search_type: str = "hybrid",
+        limit: int = 10,
+        path_filter: str | None = None,
+        alpha: float = 0.5,
+        fusion_method: str = "rrf",
+        adaptive_k: bool = False,
+        zone_id: str | None = None,
+    ) -> list[Any]:
+        return self._results
+
+    def get_stats(self) -> dict[str, Any]:
+        return {"total_chunks": 100}
+
+    def get_health(self) -> dict[str, Any]:
+        return {"status": "healthy"}
+
+    async def notify_file_change(self, path: str, change_type: str = "update") -> None:
+        pass
 
 
 # =============================================================================
@@ -81,7 +73,7 @@ class SearchServiceAdapter:
         return await self._brick.search(query, limit=limit)
 
     async def get_stats(self) -> dict[str, Any]:
-        return await self._brick.get_stats()
+        return self._brick.get_stats()
 
 
 # =============================================================================
@@ -171,8 +163,8 @@ class TestProtocolPassthroughOverhead:
             )
 
     @pytest.mark.asyncio
-    async def test_verify_imports_sync_call(self) -> None:
-        """Sync verify_imports should work through protocol."""
+    async def test_get_health_sync_call(self) -> None:
+        """Sync get_health should work through protocol."""
         brick = FastMockSearchBrick()
-        result = brick.verify_imports()
+        result = brick.get_health()
         assert isinstance(result, dict)

--- a/tests/benchmarks/test_thread_pool_exhaustion.py
+++ b/tests/benchmarks/test_thread_pool_exhaustion.py
@@ -406,12 +406,18 @@ async def test_async_thread_exhaustion(
             if hasattr(nx._rebac_manager, "_l1_cache") and nx._rebac_manager._l1_cache:
                 nx._rebac_manager._l1_cache.clear()
 
-        async def sync_list_operation(request_id: int) -> RequestResult:
-            """Sync operation that will be run in thread pool."""
+        main_loop = asyncio.get_running_loop()
+
+        def sync_list_operation(request_id: int) -> RequestResult:
+            """Sync operation run in thread pool — simulates FastAPI sync endpoint."""
             thread_name = threading.current_thread().name
             start = time.time()
             try:
-                _result = await nx.sys_readdir("/", recursive=False, context=context)
+                future = asyncio.run_coroutine_threadsafe(
+                    nx.sys_readdir("/", recursive=False, context=context),
+                    main_loop,
+                )
+                _result = future.result(timeout=timeout)
                 end = time.time()
                 return RequestResult(
                     request_id=request_id,

--- a/tests/unit/core/test_pipe.py
+++ b/tests/unit/core/test_pipe.py
@@ -468,27 +468,24 @@ class TestPipeManager:
         assert await mgr.pipe_read("/nexus/pipes/mixed") == b"event-1"
         assert await mgr.pipe_read("/nexus/pipes/mixed") == b"event-2"
 
-    def test_close_all_clears_locks(self) -> None:
+    def test_close_all_clears_buffers(self) -> None:
         mgr, _ = self._make_manager()
         mgr.create("/nexus/pipes/a")
-        mgr._get_lock("/nexus/pipes/a")  # force lock creation
-        assert len(mgr._locks) == 1
+        assert len(mgr._buffers) == 1
         mgr.close_all()
-        assert len(mgr._locks) == 0
+        assert len(mgr._buffers) == 0
 
-    def test_close_clears_lock(self) -> None:
+    def test_close_removes_buffer(self) -> None:
         mgr, _ = self._make_manager()
         mgr.create("/nexus/pipes/a")
-        mgr._get_lock("/nexus/pipes/a")
         mgr.close("/nexus/pipes/a")
-        assert "/nexus/pipes/a" not in mgr._locks
+        assert "/nexus/pipes/a" not in mgr._buffers
 
-    def test_destroy_clears_lock(self) -> None:
+    def test_destroy_removes_buffer(self) -> None:
         mgr, _ = self._make_manager()
         mgr.create("/nexus/pipes/a")
-        mgr._get_lock("/nexus/pipes/a")
         mgr.destroy("/nexus/pipes/a")
-        assert "/nexus/pipes/a" not in mgr._locks
+        assert "/nexus/pipes/a" not in mgr._buffers
 
 
 # ======================================================================
@@ -1132,15 +1129,14 @@ class TestPipeManagerSignalClose:
         with pytest.raises(PipeClosedError):
             await mgr.pipe_read("/nexus/pipes/drain")
 
-    def test_signal_close_keeps_lock(self) -> None:
-        """signal_close() should NOT remove the lock (unlike close/destroy)."""
+    def test_signal_close_keeps_buffer(self) -> None:
+        """signal_close() should NOT remove the buffer (unlike close/destroy)."""
         mgr, _ = self._make_manager()
         mgr.create("/nexus/pipes/sc-lock", capacity=1024)
-        mgr._get_lock("/nexus/pipes/sc-lock")
-        assert "/nexus/pipes/sc-lock" in mgr._locks
+        assert "/nexus/pipes/sc-lock" in mgr._buffers
 
         mgr.signal_close("/nexus/pipes/sc-lock")
-        assert "/nexus/pipes/sc-lock" in mgr._locks  # Lock stays for drain
+        assert "/nexus/pipes/sc-lock" in mgr._buffers  # Buffer stays for drain
 
     def test_signal_close_keeps_buffer_in_registry(self) -> None:
         """signal_close() keeps the buffer in _buffers for drain access."""
@@ -1154,13 +1150,11 @@ class TestPipeManagerSignalClose:
         """close() after signal_close() should clean up everything."""
         mgr, _ = self._make_manager()
         mgr.create("/nexus/pipes/sc-then-close", capacity=1024)
-        mgr._get_lock("/nexus/pipes/sc-then-close")
 
         mgr.signal_close("/nexus/pipes/sc-then-close")
         mgr.close("/nexus/pipes/sc-then-close")
 
         assert "/nexus/pipes/sc-then-close" not in mgr._buffers
-        assert "/nexus/pipes/sc-then-close" not in mgr._locks
 
     def test_signal_close_nonexistent_raises(self) -> None:
         mgr, _ = self._make_manager()


### PR DESCRIPTION
## Summary

- Replace PipeManager's `dict[str, asyncio.Lock]` with Rust-backed VFSLockManager (~100-200ns per acquire) for per-pipe MPMC locking, providing hierarchical awareness, crash-safe release, and observability via `holders()`
- Dedicated VFSLockManager instance (not shared with NexusFS) to isolate pipe locks from filesystem locks that may block up to 5s on rename/move
- Async-safe acquire: fast non-blocking path for the common case, with dedicated 2-thread executor fallback on contention to avoid busy-spinning and shared executor starvation
- Fix benchmark tests: fail-closed SLA assertions with manual timing fallback when `benchmark.stats` is None (xdist), sync `FastMockSearchBrick` to current `SearchBrickProtocol`, restore `asyncio.to_thread` in thread exhaustion test

Closes #3198

## Test plan

- [x] All 48 pipe-related unit tests pass (test_workflow_dispatch, test_pipe_consumers, test_acp_service)
- [x] All 151 benchmark tests pass (0 failures, 2 skipped)
- [x] Pipe syscall overhead benchmark: `pipe_write_nowait` P50=167ns, `sys_write` P50=250ns, `sys_read` P50=334ns — no regression
- [x] Pre-commit hooks pass (ruff, mypy, format)
- [x] Codex review: both P2 findings addressed (busy-wait → dedicated executor, shared VFSLockManager → isolated instance)
- [x] Codex adversarial review: both findings addressed (executor starvation → dedicated pool, SLA assertions → fail-closed with manual timing)