### PR TITLE
feat(tui): status bar '? Help' hint + terminal size guard

### DIFF
--- a/packages/nexus-tui/src/app.tsx
+++ b/packages/nexus-tui/src/app.tsx
@@ -6,6 +6,7 @@
  */
 
 import React, { lazy, Suspense, useState, useCallback, useEffect } from "react";
+import { useTerminalDimensions } from "@opentui/react";
 import { useGlobalStore, type PanelId } from "./stores/global-store.js";
 import { useUiStore } from "./stores/ui-store.js";
 import { SideNav } from "./shared/components/side-nav.js";
@@ -107,7 +108,13 @@ function shutdown(): void {
   process.exit(0);
 }
 
+const MIN_COLS = 80;
+const MIN_ROWS = 24;
+
 export function App(): React.ReactNode {
+  const { width: termCols, height: termRows } = useTerminalDimensions();
+  const tooSmall = termCols < MIN_COLS || termRows < MIN_ROWS;
+
   const activePanel = useGlobalStore((s) => s.activePanel);
   const setActivePanel = useGlobalStore((s) => s.setActivePanel);
   const connectionStatus = useGlobalStore((s) => s.connectionStatus);
@@ -147,6 +154,7 @@ export function App(): React.ReactNode {
       ? {
           // Pre-connection screen handles its own keybindings
           "q": shutdown,
+          "?": () => setHelpOpen(true),
         }
       : identitySwitcherOpen || helpOpen || showWelcome
       ? {
@@ -180,11 +188,28 @@ export function App(): React.ReactNode {
         },
   );
 
+  // Terminal size guard: show friendly message when below 80×24
+  if (tooSmall) {
+    return (
+      <box height="100%" width="100%" justifyContent="center" alignItems="center" flexDirection="column">
+        <text><span bold>Terminal too small ({termCols}×{termRows})</span></text>
+        <text> </text>
+        <text>Nexus TUI requires at least {MIN_COLS}×{MIN_ROWS}</text>
+        <text><span dimColor>Current: {termCols}×{termRows}</span></text>
+      </box>
+    );
+  }
+
   // Pre-connection screen (Decision 3A): shown when server is unavailable
   if (showPreConnection) {
     return (
       <box height="100%" width="100%" flexDirection="column">
-        <PreConnectionScreen />
+        <box flexGrow={1}>
+          {helpOpen
+            ? <HelpOverlay visible={helpOpen} panel={activePanel} onDismiss={() => setHelpOpen(false)} />
+            : <PreConnectionScreen />
+          }
+        </box>
         <StatusBar />
       </box>
     );

--- a/packages/nexus-tui/src/shared/components/status-bar.tsx
+++ b/packages/nexus-tui/src/shared/components/status-bar.tsx
@@ -120,8 +120,9 @@ export function StatusBar(): React.ReactNode {
         {hasActiveFilter ? (
           <span foregroundColor="yellow">{" [filtered]"}</span>
         ) : ""}
-        <span foregroundColor={palette.faint}>{" │ Ctrl+D:setup  ?:help"}</span>
       </text>
+      <box flexGrow={1} />
+      <text dimColor>{"? Help"}</text>
     </box>
   );
 }


### PR DESCRIPTION
## Summary
Closes #3245

- **Status bar help hint**: Right-aligned `? Help` at the right edge of the status bar using a `flexGrow={1}` spacer, replacing the old inline `Ctrl+D:setup  ?:help` text
- **Terminal size guard**: Shows a friendly centered message when terminal is below 80×24, with no tab bar/status bar/panels — reactively recovers when resized back
- **Help on pre-connection screen**: `?` keybinding now works on the pre-connection screen, rendering the help overlay cleanly

## Test plan
- [ ] Start TUI (`bun run dev`) — verify `? Help` is right-aligned in status bar
- [ ] Press `?` on pre-connection screen — help overlay should render cleanly, replacing pre-connection content
- [ ] Press any key to dismiss help overlay — pre-connection screen returns
- [ ] Resize terminal below 80×24 — should see "Terminal too small" message
- [ ] Resize back above 80×24 — normal TUI should restore immediately