### PR TITLE
Use theme tokens in nexus TUI

### DIFF
--- a/packages/nexus-tui/src/panels/access/access-panel.tsx
+++ b/packages/nexus-tui/src/panels/access/access-panel.tsx
@@ -591,7 +591,7 @@ export default function AccessPanel(): React.ReactNode {
       {/* Help bar */}
       <box height={1} width="100%">
         {copied
-          ? <text foregroundColor="green">Copied!</text>
+          ? <text foregroundColor={statusColor.healthy}>Copied!</text>
           : <text>{HELP[activeTab]}</text>}
       </box>
     </box>

--- a/packages/nexus-tui/src/panels/agents/agents-panel.tsx
+++ b/packages/nexus-tui/src/panels/agents/agents-panel.tsx
@@ -374,20 +374,20 @@ export default function AgentsPanel(): React.ReactNode {
                   <box height="100%" width="100%" flexDirection="column" padding={1}>
                     <text bold>{`Agent: ${selectedAgent.agent_id}`}</text>
                     <text>{""}</text>
-                    <text><span foregroundColor="cyan">{"State:  "}</span><span>{"registered"}</span></text>
-                    <text><span foregroundColor="cyan">{"Name:   "}</span><span>{selectedAgent.name ?? selectedAgent.agent_id}</span></text>
-                    <text><span foregroundColor="cyan">{"Owner:  "}</span><span>{selectedAgent.owner_id}</span></text>
-                    <text><span foregroundColor="cyan">{"Zone:   "}</span><span>{selectedAgent.zone_id ?? "root"}</span></text>
+                    <text><span foregroundColor={statusColor.info}>{"State:  "}</span><span>{"registered"}</span></text>
+                    <text><span foregroundColor={statusColor.info}>{"Name:   "}</span><span>{selectedAgent.name ?? selectedAgent.agent_id}</span></text>
+                    <text><span foregroundColor={statusColor.info}>{"Owner:  "}</span><span>{selectedAgent.owner_id}</span></text>
+                    <text><span foregroundColor={statusColor.info}>{"Zone:   "}</span><span>{selectedAgent.zone_id ?? "root"}</span></text>
                     <text>{""}</text>
-                    <text bold foregroundColor="cyan">{"Permissions:"}</text>
+                    <text bold foregroundColor={statusColor.info}>{"Permissions:"}</text>
                     {perms.length === 0 ? (
                       <text dimColor>{"  No permissions assigned"}</text>
                     ) : (
                       perms.map((p, i) => (
                         <text key={`perm-${i}`}>
-                          <span foregroundColor="green">{`  ${p.relation}`}</span>
+                          <span foregroundColor={statusColor.healthy}>{`  ${p.relation}`}</span>
                           <span dimColor>{" on "}</span>
-                          <span foregroundColor="blue">{`${p.object_type}:${p.object_id}`}</span>
+                          <span foregroundColor={statusColor.reference}>{`${p.object_type}:${p.object_id}`}</span>
                         </text>
                       ))
                     )}
@@ -444,7 +444,7 @@ export default function AgentsPanel(): React.ReactNode {
       {/* Help bar */}
       <box height={1} width="100%">
         {copied
-          ? <text foregroundColor="green">Copied!</text>
+          ? <text foregroundColor={statusColor.healthy}>Copied!</text>
           : <text>
           {"j/k:navigate  Tab:switch tab  r:refresh  n:spawn agent  Enter:detail  d:revoke  Shift+W:warmup  Shift+E:evict  y:copy  q:quit"}
         </text>}

--- a/packages/nexus-tui/src/panels/agents/delegation-list.tsx
+++ b/packages/nexus-tui/src/panels/agents/delegation-list.tsx
@@ -51,15 +51,15 @@ function DelegationDetail({ delegation }: { delegation: DelegationItem }): React
       <text>{`  Created:  ${delegation.created_at}`}</text>
       <text>{`  Expires:  ${formatExpiry(delegation.lease_expires_at)}`}</text>
       <text>{""}</text>
-      <text bold foregroundColor="cyan">{"  Granted Permissions:"}</text>
+      <text bold foregroundColor={statusColor.info}>{"  Granted Permissions:"}</text>
       {perms.length === 0 ? (
         <text dimColor>{"    (none or loading...)"}</text>
       ) : (
         perms.map((p, i) => (
           <text key={`perm-${i}`}>
-            <span foregroundColor="green">{`    ${p.relation}`}</span>
+            <span foregroundColor={statusColor.healthy}>{`    ${p.relation}`}</span>
             <span dimColor>{" on "}</span>
-            <span foregroundColor="blue">{`${p.object_type}:${p.object_id}`}</span>
+            <span foregroundColor={statusColor.reference}>{`${p.object_type}:${p.object_id}`}</span>
           </text>
         ))
       )}

--- a/packages/nexus-tui/src/panels/events/events-panel.tsx
+++ b/packages/nexus-tui/src/panels/events/events-panel.tsx
@@ -35,6 +35,7 @@ import { SubTabBar } from "../../shared/components/sub-tab-bar.js";
 import { subTabCycleBindings } from "../../shared/components/sub-tab-bar-utils.js";
 import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
 import { EVENTS_TABS } from "../../shared/navigation.js";
+import { statusColor } from "../../shared/theme.js";
 
 type FilterMode = "none" | "type" | "search" | "mcl_urn" | "mcl_aspect" | "acquire_path" | "secrets_filter" | "replay_filter";
 
@@ -616,7 +617,7 @@ export default function EventsPanel(): React.ReactNode {
       {/* Help bar */}
       <box height={1} width="100%">
         {copied
-          ? <text foregroundColor="green">Copied!</text>
+          ? <text foregroundColor={statusColor.healthy}>Copied!</text>
           : <text>
           {filterMode !== "none"
             ? "Type value, Enter:apply, Escape:cancel, Backspace:delete"

--- a/packages/nexus-tui/src/panels/files/file-editor.tsx
+++ b/packages/nexus-tui/src/panels/files/file-editor.tsx
@@ -15,6 +15,10 @@ import { useApi } from "../../shared/hooks/use-api.js";
 import { useFilesStore } from "../../stores/files-store.js";
 import { useVersionsStore } from "../../stores/versions-store.js";
 import { Spinner } from "../../shared/components/spinner.js";
+import { palette } from "../../shared/theme.js";
+
+const EDITOR_BG = "#1a1a2e";
+const EDITOR_SELECTION = "#264f78";
 
 interface FileEditorProps {
   readonly path: string;
@@ -116,26 +120,26 @@ export function FileEditor({ path, onClose }: FileEditorProps): React.ReactNode 
       {/* Header */}
       <box height={1} width="100%">
         <text>
-          <span foregroundColor="#00d4ff" bold>{` ${fileName}`}</span>
-          <span foregroundColor="#666666">{` — ${path}`}</span>
-          {dirty ? <span foregroundColor="#ffaa00">{" [modified]"}</span> : ""}
-          {saving ? <span foregroundColor="#ffaa00">{" saving..."}</span> : ""}
-          {hasTxn ? <span foregroundColor="#4dff88">{` [txn:${activeTxn!.transaction_id.slice(0, 8)}]`}</span> : ""}
+          <span foregroundColor={palette.accent} bold>{` ${fileName}`}</span>
+          <span foregroundColor={palette.muted}>{` — ${path}`}</span>
+          {dirty ? <span foregroundColor={palette.warning}>{" [modified]"}</span> : ""}
+          {saving ? <span foregroundColor={palette.warning}>{" saving..."}</span> : ""}
+          {hasTxn ? <span foregroundColor={palette.success}>{` [txn:${activeTxn!.transaction_id.slice(0, 8)}]`}</span> : ""}
         </text>
       </box>
 
       {/* Editor */}
-      <box flexGrow={1} borderStyle="single" borderColor={dirty ? "#ffaa00" : "#444444"}>
+      <box flexGrow={1} borderStyle="single" borderColor={dirty ? palette.warning : palette.faint}>
         <textarea
           ref={textareaRef}
           initialValue={initialContent}
           placeholder="Start typing..."
           wrapMode="word"
-          focusedTextColor="#ffffff"
-          focusedBackgroundColor="#1a1a2e"
-          textColor="#cccccc"
-          cursorColor="#00d4ff"
-          selectionBg="#264f78"
+          focusedTextColor={palette.title}
+          focusedBackgroundColor={EDITOR_BG}
+          textColor={palette.bright}
+          cursorColor={palette.accent}
+          selectionBg={EDITOR_SELECTION}
           focused
           onContentChange={() => setDirty(true)}
           onSubmit={() => handleSave()}
@@ -145,13 +149,13 @@ export function FileEditor({ path, onClose }: FileEditorProps): React.ReactNode 
       {/* Footer */}
       <box height={1} width="100%">
         <text>
-          <span foregroundColor="#4dff88" bold>{"  Ctrl+S"}</span>
-          <span foregroundColor="#888888">{":save  "}</span>
-          <span foregroundColor="#ff4444" bold>{"Esc"}</span>
-          <span foregroundColor="#888888">{":cancel  "}</span>
-          <span foregroundColor="#00d4ff">{"Meta+Enter"}</span>
-          <span foregroundColor="#888888">{":save  "}</span>
-          {error ? <span foregroundColor="#ff4444">{`  Error: ${error}`}</span> : ""}
+          <span foregroundColor={palette.success} bold>{"  Ctrl+S"}</span>
+          <span foregroundColor={palette.muted}>{":save  "}</span>
+          <span foregroundColor={palette.error} bold>{"Esc"}</span>
+          <span foregroundColor={palette.muted}>{":cancel  "}</span>
+          <span foregroundColor={palette.accent}>{"Meta+Enter"}</span>
+          <span foregroundColor={palette.muted}>{":save  "}</span>
+          {error ? <span foregroundColor={palette.error}>{`  Error: ${error}`}</span> : ""}
         </text>
       </box>
     </box>

--- a/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
+++ b/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
@@ -52,7 +52,7 @@ import { subTabCycleBindings } from "../../shared/components/sub-tab-bar-utils.j
 import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
 import { useKnowledgeStore } from "../../stores/knowledge-store.js";
 import { useUiStore } from "../../stores/ui-store.js";
-import { focusColor } from "../../shared/theme.js";
+import { focusColor, statusColor } from "../../shared/theme.js";
 import crypto from "node:crypto";
 
 // =============================================================================
@@ -798,7 +798,7 @@ export default function FileExplorerPanel(): React.ReactNode {
       {/* Paste progress indicator */}
       {pasteProgress && (
         <box height={1} width="100%">
-          <text foregroundColor="cyan">
+          <text foregroundColor={statusColor.info}>
             {pasteProgress.completed + pasteProgress.failed >= pasteProgress.total
               ? `Paste complete: ${pasteProgress.completed}/${pasteProgress.total}${pasteProgress.failed > 0 ? ` (${pasteProgress.failed} failed)` : ""}`
               : `Pasting... ${pasteProgress.completed + pasteProgress.failed}/${pasteProgress.total}${pasteProgress.failed > 0 ? ` (${pasteProgress.failed} failed)` : ""}`}
@@ -809,7 +809,7 @@ export default function FileExplorerPanel(): React.ReactNode {
       {/* Clipboard indicator (only when not actively pasting) */}
       {clipboard && !pasteProgress && inputMode === "none" && (
         <box height={1} width="100%">
-          <text foregroundColor="yellow">
+          <text foregroundColor={statusColor.warning}>
             {`${clipboard.paths.length} file${clipboard.paths.length > 1 ? "s" : ""} ${clipboard.operation === "cut" ? "cut" : "copied"} — press p to paste`}
           </text>
         </box>
@@ -904,7 +904,7 @@ export default function FileExplorerPanel(): React.ReactNode {
       {/* Help bar */}
       <box height={1} width="100%">
         {copied
-          ? <text foregroundColor="green">Copied!</text>
+          ? <text foregroundColor={statusColor.healthy}>Copied!</text>
           : <text>
             {getHelpText(
               inputMode, activeTab, catalogAvailable,

--- a/packages/nexus-tui/src/panels/payments/payments-panel.tsx
+++ b/packages/nexus-tui/src/panels/payments/payments-panel.tsx
@@ -26,6 +26,7 @@ import { PolicyList } from "./policy-list.js";
 import { BudgetCard } from "./budget-card.js";
 import { ApprovalList } from "./approval-list.js";
 import { PAYMENTS_TABS } from "../../shared/navigation.js";
+import { statusColor } from "../../shared/theme.js";
 
 export default function PaymentsPanel(): React.ReactNode {
   const client = useApi();
@@ -500,7 +501,7 @@ export default function PaymentsPanel(): React.ReactNode {
         {/* Help bar */}
         <box height={1} width="100%">
           {copied
-            ? <text foregroundColor="green">Copied!</text>
+            ? <text foregroundColor={statusColor.healthy}>Copied!</text>
             : <text>
             {showTransfer
               ? "Tab:next field  Enter:submit  Escape:cancel"

--- a/packages/nexus-tui/src/panels/versions/versions-panel.tsx
+++ b/packages/nexus-tui/src/panels/versions/versions-panel.tsx
@@ -20,7 +20,7 @@ import { TransactionList } from "./transaction-list.js";
 import { EntryDetail } from "./entry-detail.js";
 import { ConflictsView } from "./conflicts-tab.js";
 import { useUiStore } from "../../stores/ui-store.js";
-import { focusColor } from "../../shared/theme.js";
+import { focusColor, statusColor } from "../../shared/theme.js";
 
 export default function VersionsPanel(): React.ReactNode {
   const client = useApi();
@@ -263,7 +263,7 @@ export default function VersionsPanel(): React.ReactNode {
         {/* Help bar */}
         <box height={1} width="100%">
           {copied
-            ? <text foregroundColor="green">Copied!</text>
+            ? <text foregroundColor={statusColor.healthy}>Copied!</text>
             : <text>
             {txnFilterMode
               ? "Type to filter, Enter:apply, Escape:clear"

--- a/packages/nexus-tui/src/shared/components/pre-connection-screen.tsx
+++ b/packages/nexus-tui/src/shared/components/pre-connection-screen.tsx
@@ -16,7 +16,7 @@ import { detectConnectionState } from "../hooks/use-connection-state.js";
 import { executeLocalCommand, useCommandRunnerStore } from "../../services/command-runner.js";
 import { CommandOutput } from "./command-output.js";
 import { Spinner } from "./spinner.js";
-import { statusColor } from "../theme.js";
+import { palette, statusColor } from "../theme.js";
 import { resolveConfig, FetchClient } from "@nexus/api-client";
 import { useFilesStore } from "../../stores/files-store.js";
 
@@ -225,25 +225,25 @@ export function PreConnectionScreen(): React.ReactNode {
         <box height={1} width="100%">
           {commandStatus === "success" ? (
             <text>
-              <span foregroundColor="#4dff88" bold>{"  ✓ Done"}</span>
-              <span foregroundColor="#666666">{"  │  "}</span>
-              <span foregroundColor="#00d4ff">{"Esc"}</span>
-              <span foregroundColor="#888888">{":back  "}</span>
-              <span foregroundColor="#00d4ff">{"R"}</span>
-              <span foregroundColor="#888888">{":retry"}</span>
+              <span foregroundColor={palette.success} bold>{"  ✓ Done"}</span>
+              <span foregroundColor={palette.muted}>{"  │  "}</span>
+              <span foregroundColor={palette.accent}>{"Esc"}</span>
+              <span foregroundColor={palette.muted}>{":back  "}</span>
+              <span foregroundColor={palette.accent}>{"R"}</span>
+              <span foregroundColor={palette.muted}>{":retry"}</span>
             </text>
           ) : commandStatus === "error" ? (
             <text>
-              <span foregroundColor="#ff4444" bold>{"  ✗ Failed"}</span>
-              <span foregroundColor="#666666">{"  │  "}</span>
-              <span foregroundColor="#00d4ff">{"Esc"}</span>
-              <span foregroundColor="#888888">{":back  "}</span>
-              <span foregroundColor="#00d4ff">{"R"}</span>
-              <span foregroundColor="#888888">{":retry"}</span>
+              <span foregroundColor={palette.error} bold>{"  ✗ Failed"}</span>
+              <span foregroundColor={palette.muted}>{"  │  "}</span>
+              <span foregroundColor={palette.accent}>{"Esc"}</span>
+              <span foregroundColor={palette.muted}>{":back  "}</span>
+              <span foregroundColor={palette.accent}>{"R"}</span>
+              <span foregroundColor={palette.muted}>{":retry"}</span>
             </text>
           ) : (
             <text>
-              <span foregroundColor="#ffaa00">{"  ◐ Running..."}</span>
+              <span foregroundColor={palette.warning}>{"  ◐ Running..."}</span>
             </text>
           )}
         </box>
@@ -259,20 +259,20 @@ export function PreConnectionScreen(): React.ReactNode {
         width={64}
         padding={1}
       >
-        {/* Logo with gradient: cyan → blue → magenta */}
-        <text bold foregroundColor="#00d4ff">
+        {/* Logo uses the shared accent token after theme unification. */}
+        <text bold foregroundColor={palette.accent}>
           {"    _   _ _____ __  __ _   _ ____"}
         </text>
-        <text bold foregroundColor="#00b8ff">
+        <text bold foregroundColor={palette.accent}>
           {"   | \\ | | ____|  \\/  | | | / ___|"}
         </text>
-        <text bold foregroundColor="#4d8eff">
+        <text bold foregroundColor={palette.accent}>
           {"   |  \\| |  _|  >\\/< | | | \\___ \\"}
         </text>
-        <text bold foregroundColor="#8066ff">
+        <text bold foregroundColor={palette.accent}>
           {"   | |\\  | |___/ /\\ \\| |_| |___) |"}
         </text>
-        <text bold foregroundColor="#b44dff">
+        <text bold foregroundColor={palette.accent}>
           {"   |_| \\_|_____/_/  \\_\\\\___/|____/"}
         </text>
         <text>{""}</text>
@@ -281,25 +281,25 @@ export function PreConnectionScreen(): React.ReactNode {
         {connState === "no-config" && (
           <>
             <text>
-              <span foregroundColor="#ffaa00" bold>{"  ⚠ "}</span>
-              <span foregroundColor="#ffaa00" bold>{"No API key configured"}</span>
+              <span foregroundColor={palette.warning} bold>{"  ⚠ "}</span>
+              <span foregroundColor={palette.warning} bold>{"No API key configured"}</span>
             </text>
             <text>{""}</text>
-            <text foregroundColor="#888888">{"  Set NEXUS_API_KEY or add api_key to ~/.nexus/config.yaml"}</text>
-            <text foregroundColor="#888888">{"  Or press [I] to initialize a new project."}</text>
+            <text foregroundColor={palette.muted}>{"  Set NEXUS_API_KEY or add api_key to ~/.nexus/config.yaml"}</text>
+            <text foregroundColor={palette.muted}>{"  Or press [I] to initialize a new project."}</text>
           </>
         )}
 
         {connState === "no-server" && (
           <>
             <text>
-              <span foregroundColor="#ff4444" bold>{"  ✗ "}</span>
-              <span foregroundColor="#ff4444" bold>{"Cannot connect to server"}</span>
+              <span foregroundColor={palette.error} bold>{"  ✗ "}</span>
+              <span foregroundColor={palette.error} bold>{"Cannot connect to server"}</span>
             </text>
             <text>{""}</text>
-            <text foregroundColor="#888888">{`  URL: ${config.baseUrl ?? "http://localhost:2026"}`}</text>
+            <text foregroundColor={palette.muted}>{`  URL: ${config.baseUrl ?? "http://localhost:2026"}`}</text>
             {connectionError && (
-              <text foregroundColor="#ff6666">{`  Error: ${connectionError}`}</text>
+              <text foregroundColor={palette.errorDim}>{`  Error: ${connectionError}`}</text>
             )}
           </>
         )}
@@ -307,12 +307,12 @@ export function PreConnectionScreen(): React.ReactNode {
         {connState === "auth-failed" && (
           <>
             <text>
-              <span foregroundColor="#ff4444" bold>{"  ✗ "}</span>
-              <span foregroundColor="#ff4444" bold>{"Authentication failed"}</span>
+              <span foregroundColor={palette.error} bold>{"  ✗ "}</span>
+              <span foregroundColor={palette.error} bold>{"Authentication failed"}</span>
             </text>
             <text>{""}</text>
-            <text foregroundColor="#888888">{`  URL: ${config.baseUrl ?? "http://localhost:2026"}`}</text>
-            <text foregroundColor="#ff6666">{"  Check your API key or credentials."}</text>
+            <text foregroundColor={palette.muted}>{`  URL: ${config.baseUrl ?? "http://localhost:2026"}`}</text>
+            <text foregroundColor={palette.errorDim}>{"  Check your API key or credentials."}</text>
           </>
         )}
 
@@ -323,7 +323,7 @@ export function PreConnectionScreen(): React.ReactNode {
         {apiKeyWarning && (
           <>
             <text>{""}</text>
-            <text foregroundColor="#ffaa00">{`  ⚠ ${apiKeyWarning}`}</text>
+            <text foregroundColor={palette.warning}>{`  ⚠ ${apiKeyWarning}`}</text>
           </>
         )}
 
@@ -332,11 +332,11 @@ export function PreConnectionScreen(): React.ReactNode {
         {/* URL editor */}
         {editingUrl && (
           <>
-            <text foregroundColor="#00d4ff">{"  Enter server URL:"}</text>
+            <text foregroundColor={palette.accent}>{"  Enter server URL:"}</text>
             <box height={1} width="100%">
-              <text foregroundColor="#ffffff">{`  > ${urlInput}\u2588`}</text>
+              <text foregroundColor={palette.title}>{`  > ${urlInput}\u2588`}</text>
             </box>
-            <text foregroundColor="#666666">{"  Enter to connect, Esc to cancel"}</text>
+            <text foregroundColor={palette.muted}>{"  Enter to connect, Esc to cancel"}</text>
             <text>{""}</text>
           </>
         )}
@@ -344,50 +344,50 @@ export function PreConnectionScreen(): React.ReactNode {
         {/* Actions */}
         {connState !== "connecting" && !editingUrl && (
           <>
-            <text foregroundColor="#888888" bold>{"  Setup"}</text>
+            <text foregroundColor={palette.muted} bold>{"  Setup"}</text>
             <text>
-              <span foregroundColor="#00d4ff" bold>{"  [I] "}</span>
-              <span foregroundColor="#cccccc">{"Init local"}</span>
-              <span foregroundColor="#666666">{" (nexus init)"}</span>
+              <span foregroundColor={palette.accent} bold>{"  [I] "}</span>
+              <span foregroundColor={palette.bright}>{"Init local"}</span>
+              <span foregroundColor={palette.muted}>{" (nexus init)"}</span>
             </text>
             <text>
-              <span foregroundColor="#00d4ff" bold>{"  [S] "}</span>
-              <span foregroundColor="#cccccc">{"Init shared Docker"}</span>
-              <span foregroundColor="#666666">{" (--preset shared)"}</span>
+              <span foregroundColor={palette.accent} bold>{"  [S] "}</span>
+              <span foregroundColor={palette.bright}>{"Init shared Docker"}</span>
+              <span foregroundColor={palette.muted}>{" (--preset shared)"}</span>
             </text>
             <text>
-              <span foregroundColor="#00d4ff" bold>{"  [D] "}</span>
-              <span foregroundColor="#cccccc">{"Init demo Docker"}</span>
-              <span foregroundColor="#666666">{" (--preset demo)"}</span>
+              <span foregroundColor={palette.accent} bold>{"  [D] "}</span>
+              <span foregroundColor={palette.bright}>{"Init demo Docker"}</span>
+              <span foregroundColor={palette.muted}>{" (--preset demo)"}</span>
             </text>
             <text>
-              <span foregroundColor="#4dff88" bold>{"  [U] "}</span>
-              <span foregroundColor="#cccccc">{"Start server"}</span>
-              <span foregroundColor="#666666">{" (nexus up)"}</span>
+              <span foregroundColor={palette.success} bold>{"  [U] "}</span>
+              <span foregroundColor={palette.bright}>{"Start server"}</span>
+              <span foregroundColor={palette.muted}>{" (nexus up)"}</span>
             </text>
             <text>
-              <span foregroundColor="#4dff88" bold>{"  [⇧U] "}</span>
-              <span foregroundColor="#cccccc">{"Build from source"}</span>
-              <span foregroundColor="#666666">{" (nexus up --build)"}</span>
+              <span foregroundColor={palette.success} bold>{"  [⇧U] "}</span>
+              <span foregroundColor={palette.bright}>{"Build from source"}</span>
+              <span foregroundColor={palette.muted}>{" (nexus up --build)"}</span>
             </text>
             <text>
-              <span foregroundColor="#ffaa00" bold>{"  [P] "}</span>
-              <span foregroundColor="#cccccc">{"Seed demo data"}</span>
-              <span foregroundColor="#666666">{" (nexus demo init)"}</span>
+              <span foregroundColor={palette.warning} bold>{"  [P] "}</span>
+              <span foregroundColor={palette.bright}>{"Seed demo data"}</span>
+              <span foregroundColor={palette.muted}>{" (nexus demo init)"}</span>
             </text>
             <text>{""}</text>
-            <text foregroundColor="#888888" bold>{"  Connection"}</text>
+            <text foregroundColor={palette.muted} bold>{"  Connection"}</text>
             <text>
-              <span foregroundColor="#b44dff" bold>{"  [C] "}</span>
-              <span foregroundColor="#cccccc">{"Connect to a different URL"}</span>
+              <span foregroundColor={palette.accent} bold>{"  [C] "}</span>
+              <span foregroundColor={palette.bright}>{"Connect to a different URL"}</span>
             </text>
             <text>
-              <span foregroundColor="#b44dff" bold>{"  [R] "}</span>
-              <span foregroundColor="#cccccc">{`Retry connection${retryCount > 0 ? ` (${retryCount})` : ""}`}</span>
+              <span foregroundColor={palette.accent} bold>{"  [R] "}</span>
+              <span foregroundColor={palette.bright}>{`Retry connection${retryCount > 0 ? ` (${retryCount})` : ""}`}</span>
             </text>
             <text>
-              <span foregroundColor={autoPoll ? "#4dff88" : "#888888"} bold>{"  [A] "}</span>
-              <span foregroundColor={autoPoll ? "#4dff88" : "#cccccc"}>{autoPoll ? "Auto-check: ON (every 5s)" : "Enable auto-check (every 5s)"}</span>
+              <span foregroundColor={autoPoll ? palette.success : palette.muted} bold>{"  [A] "}</span>
+              <span foregroundColor={autoPoll ? palette.success : palette.bright}>{autoPoll ? "Auto-check: ON (every 5s)" : "Enable auto-check (every 5s)"}</span>
             </text>
           </>
         )}

--- a/packages/nexus-tui/src/shared/components/status-bar.tsx
+++ b/packages/nexus-tui/src/shared/components/status-bar.tsx
@@ -118,7 +118,7 @@ export function StatusBar(): React.ReactNode {
           </>
         ) : ""}
         {hasActiveFilter ? (
-          <span foregroundColor="yellow">{" [filtered]"}</span>
+          <span foregroundColor={statusColor.warning}>{" [filtered]"}</span>
         ) : ""}
         <span foregroundColor={palette.faint}>{" │ Ctrl+D:setup  ?:help"}</span>
       </text>

--- a/packages/nexus-tui/src/shared/components/welcome-screen.tsx
+++ b/packages/nexus-tui/src/shared/components/welcome-screen.tsx
@@ -5,7 +5,7 @@
 import React, { useState } from "react";
 import { useKeyboard } from "../hooks/use-keyboard.js";
 import { useGlobalStore } from "../../stores/global-store.js";
-import { statusColor } from "../theme.js";
+import { palette, statusColor } from "../theme.js";
 import { Spinner } from "./spinner.js";
 
 interface WelcomeScreenProps {
@@ -48,19 +48,19 @@ export function WelcomeScreen({ onDismiss }: WelcomeScreenProps): React.ReactNod
         width={56}
         padding={1}
       >
-        <text bold foregroundColor="#00d4ff">
+        <text bold foregroundColor={palette.accent}>
           {"    _   _ _____ __  __ _   _ ____"}
         </text>
-        <text bold foregroundColor="#00b8ff">
+        <text bold foregroundColor={palette.accent}>
           {"   | \\ | | ____|  \\/  | | | / ___|"}
         </text>
-        <text bold foregroundColor="#4d8eff">
+        <text bold foregroundColor={palette.accent}>
           {"   |  \\| |  _|  >\\/< | | | \\___ \\"}
         </text>
-        <text bold foregroundColor="#8066ff">
+        <text bold foregroundColor={palette.accent}>
           {"   | |\\  | |___/ /\\ \\| |_| |___) |"}
         </text>
-        <text bold foregroundColor="#b44dff">
+        <text bold foregroundColor={palette.accent}>
           {"   |_| \\_|_____/_/  \\_\\\\___/|____/"}
         </text>
         <text>{""}</text>


### PR DESCRIPTION
## Summary
- replace remaining hardcoded TUI colors in the targeted panels with shared `palette` and `statusColor` tokens
- keep the file editor background and selection colors as the two allowed local hex constants
- update copy/help/status affordances to use the theme tokens consistently

## Verification
- `rg -n "#[0-9a-fA-F]{6}" packages/nexus-tui/src`
- `rg -n 'foregroundColor=\"(cyan|green|blue|yellow)\"' packages/nexus-tui/src`\n- `cd packages/nexus-tui && bun run tsc --noEmit 2>&1 | rg 'pre-connection-screen|file-editor|welcome-screen|agents-panel|delegation-list|file-explorer-panel|status-bar|access-panel|payments-panel|versions-panel|events-panel'`\n\nCloses #3246