### PR TITLE
feat(playground): add empty directory indicator

### DIFF
--- a/src/nexus/fs/_tui/file_browser.py
+++ b/src/nexus/fs/_tui/file_browser.py
@@ -56,6 +56,7 @@ class FileBrowser(Widget):
         text-align: center;
         padding: 4 2;
         color: $text-muted;
+        display: none;
     }
     FileBrowser .error-message {
         text-align: center;
@@ -102,6 +103,11 @@ class FileBrowser(Widget):
         table.cursor_type = "row"
         table.add_columns("Name", "Size", "Modified")
         yield table
+        yield Static(
+            "Empty folder\n\nPress [bold]b[/bold] to go back",
+            id="empty-state",
+            classes="empty-message",
+        )
         yield Static("", id="overflow", classes="overflow-indicator")
 
     async def load_directory(self, path: str) -> None:
@@ -134,6 +140,15 @@ class FileBrowser(Widget):
                 modified = _format_modified(entry.get("modified_at"))
                 table.add_row(name, size, modified)
 
+            # Toggle empty state vs table visibility
+            empty_state = self.query_one("#empty-state", Static)
+            if not self._entries:
+                table.display = False
+                empty_state.display = True
+            else:
+                table.display = True
+                empty_state.display = False
+
             # Update overflow indicator
             overflow = self.query_one("#overflow", Static)
             if self._total_count > MAX_DISPLAY_ENTRIES:
@@ -148,6 +163,8 @@ class FileBrowser(Widget):
             self._error = format_runtime_error(path, exc)
             self._entries = []
             self._total_count = 0
+            table.display = True
+            self.query_one("#empty-state", Static).display = False
             overflow = self.query_one("#overflow", Static)
             overflow.update(f"[red]Error: {self._error}[/red]")
 

--- a/tests/unit/fs/test_tui.py
+++ b/tests/unit/fs/test_tui.py
@@ -248,6 +248,22 @@ class TestFileBrowser:
         browser._total_count = 42
         assert browser.entry_count == 42
 
+    @pytest.mark.asyncio
+    async def test_empty_directory_shows_empty_state(self, tmp_path):
+        """Empty directory shows 'Empty folder' message instead of blank table."""
+        app = PlaygroundApp(uris=(f"local://{tmp_path}",))
+
+        async with app.run_test(size=(120, 40)) as pilot:
+            await pilot.pause(delay=0.5)
+            browser = app.query_one("#file-browser", FileBrowser)
+
+            from textual.widgets import Static
+
+            empty_state = browser.query_one("#empty-state", Static)
+            table = browser.query_one("#file-table", DataTable)
+            assert empty_state.display is True
+            assert table.display is False
+
 
 # ---------------------------------------------------------------------------
 # File preview tests


### PR DESCRIPTION
## Summary
- Show "Empty folder" with a "Press **b** to go back" hint when navigating to an empty directory in the file browser, instead of a blank DataTable
- Toggle visibility between the empty state message and the table so errors still render correctly

Closes #3507

## Test plan
- [x] New test `test_empty_directory_shows_empty_state` mounts an empty `tmp_path` and asserts the empty state is displayed while the table is hidden
- [x] All existing `TestFileBrowser` tests pass