### PR TITLE
fix(ci): harden Docker rust wheel build under buildx

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -97,7 +97,10 @@ RUN --mount=type=cache,target=/root/.cache/uv \
 COPY proto/ ./proto/
 COPY rust/ ./rust/
 
-ENV CARGO_TARGET_DIR=/build/target
+ENV CARGO_TARGET_DIR=/build/target \
+    CARGO_BUILD_JOBS=2 \
+    CARGO_NET_RETRY=10 \
+    CARGO_HTTP_TIMEOUT=120
 RUN --mount=type=cache,target=/root/.cargo/registry \
     --mount=type=cache,target=/root/.cargo/git \
     --mount=type=cache,id=cargo-target-${TARGETARCH},target=/build/target \
@@ -108,15 +111,27 @@ RUN --mount=type=cache,target=/root/.cargo/registry \
                SIMSIMD_TARGET_SVE_F16=0 \
                SIMSIMD_TARGET_SVE_I8=0; \
     fi && \
-    maturin build --release --out /build/dist -m rust/nexus_pyo3/Cargo.toml && \
-    maturin build --release --features full --out /build/dist -m rust/nexus_raft/Cargo.toml && \
-    pip install --no-cache-dir /build/dist/nexus_fast-*.whl /build/dist/nexus_raft-*.whl
+    maturin build --release --out /build/dist -m rust/nexus_pyo3/Cargo.toml
+RUN --mount=type=cache,target=/root/.cargo/registry \
+    --mount=type=cache,target=/root/.cargo/git \
+    --mount=type=cache,id=cargo-target-${TARGETARCH},target=/build/target \
+    if [ "${TARGETARCH}" = "arm64" ]; then \
+        export SIMSIMD_TARGET_SVE=0 \
+               SIMSIMD_TARGET_SVE2=0 \
+               SIMSIMD_TARGET_SVE_BF16=0 \
+               SIMSIMD_TARGET_SVE_F16=0 \
+               SIMSIMD_TARGET_SVE_I8=0; \
+    fi && \
+    maturin build --release --features full --out /build/dist -m rust/nexus_raft/Cargo.toml
+RUN pip install --no-cache-dir /build/dist/nexus_fast-*.whl /build/dist/nexus_raft-*.whl
 
 # ---------- Copy real application source and reinstall local package ----------
 COPY src/ ./src/
 COPY alembic/ ./alembic/
 COPY alembic/alembic.ini ./alembic.ini
 RUN rm -rf src/*.egg-info build/ && \
+    find /usr/local/lib/python3.*/site-packages/nexus/ -name "*.pyc" -delete 2>/dev/null; \
+    find /usr/local/lib/python3.*/site-packages/nexus/ -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null; \
     pip install --no-cache-dir --no-deps --force-reinstall .
 
 # On arm64, remove hnswlib LAST — after all pip installs are done.

--- a/src/nexus/bricks/rebac/deferred_permission_buffer.py
+++ b/src/nexus/bricks/rebac/deferred_permission_buffer.py
@@ -147,12 +147,9 @@ class DeferredPermissionBuffer(DeferredBuffer):
         hierarchy_batch: list[tuple[str, str]] = items[0]
         grants_batch: list[dict[str, Any]] = items[1]
 
-        retryable_errors: tuple[type[BaseException], ...]
-        if catch_unexpected:
-            retryable_errors = (Exception,)
-        else:
-            retryable_errors = (OperationalError, TimeoutError, RuntimeError)
-
+        retryable_errors: tuple[type[BaseException], ...] = (
+            (Exception,) if catch_unexpected else (OperationalError, TimeoutError)
+        )
         hierarchy_count = 0
         grants_count = 0
 

--- a/tests/unit/core/test_deferred_buffer_deadletter.py
+++ b/tests/unit/core/test_deferred_buffer_deadletter.py
@@ -125,15 +125,13 @@ class TestGrantsRetry:
         stats = buffer.get_stats()
         assert stats["pending_grants"] > 0
 
-    def test_grants_flush_retry_on_runtime_error(self, buffer, rebac_manager):
-        """On RuntimeError the grant items must be re-queued for retry."""
+    def test_grants_flush_runtime_error_propagates(self, buffer, rebac_manager):
+        """Unexpected RuntimeError should propagate on synchronous flush."""
         rebac_manager.rebac_write_batch.side_effect = RuntimeError("internal error")
 
         buffer.queue_owner_grant("alice", "/doc.txt", "z1")
-        buffer.flush()
-
-        stats = buffer.get_stats()
-        assert stats["pending_grants"] > 0
+        with pytest.raises(RuntimeError, match="internal error"):
+            buffer.flush()
 
     def test_grants_repeated_failures_dead_letter_after_max_retries(self, buffer, rebac_manager):
         """After max_retries failures, grants are dead-lettered, not re-queued."""
@@ -183,7 +181,7 @@ class TestTransientErrorRecovery:
     def test_permanent_error_not_caught(self, buffer, rebac_manager):
         """Errors NOT in the retry-safe tuple (e.g., ValueError) propagate.
 
-        The buffer only catches (OperationalError, TimeoutError, RuntimeError).
+        The buffer only catches (OperationalError, TimeoutError).
         Other exceptions propagate through _flush_sync.
         """
         rebac_manager.rebac_write_batch.side_effect = ValueError("bad data")

--- a/tests/unit/services/permissions/test_deferred_permission_buffer.py
+++ b/tests/unit/services/permissions/test_deferred_permission_buffer.py
@@ -426,6 +426,17 @@ class TestErrorHandling:
         assert stats["pending_grants"] == 2
         assert stats["total_grants_flushed"] == 0
 
+    def test_grant_flush_unexpected_runtime_error_propagates(self) -> None:
+        """Unexpected bugs should fail fast on the caller thread."""
+        rebac = MagicMock()
+        rebac.rebac_write_batch.side_effect = RuntimeError("unexpected bug")
+        buffer = DeferredPermissionBuffer(rebac_manager=rebac)
+
+        buffer.queue_owner_grant("user1", "/file1", "zone1")
+
+        with pytest.raises(RuntimeError, match="unexpected bug"):
+            buffer.flush()
+
     def test_flush_loop_catches_exceptions_and_continues(self) -> None:
         """Test that flush loop catches exceptions and continues running."""
         rebac = MagicMock()


### PR DESCRIPTION
## Summary
This PR contains two targeted hardening fixes:

1. Docker/buildx hardening for the multi-arch Rust wheel build used by `docker-publish.yml` and the release Docker flow.
2. Deferred permission buffer exception-scope tightening so synchronous flushes fail fast on unexpected bugs.

The original failing job was:
- https://github.com/nexi-lab/nexus/actions/runs/23781344746/job/69294600140

GitHub only exposed the top-level annotation publicly, but the failure was in the Dockerfile layer that does:
- `maturin build` for `nexus_pyo3`
- `maturin build` for `nexus_raft`
- `pip install` of both wheels

I could not reproduce a deterministic source-level break from commit `fe525a6`, which points to buildx/QEMU brittleness rather than a hard code regression.

## Changes
### Docker
- Split the combined Rust wheel build into separate `RUN` layers
- Limit Cargo parallelism with `CARGO_BUILD_JOBS=2`
- Add Cargo retry/timeout settings
- Keep the existing package reinstall cleanup in place

### Deferred permission buffer
- Stop treating `RuntimeError` as retryable in `_flush_sync()`
- Keep retry behavior limited to `OperationalError` and `TimeoutError`
- Preserve the broad catch in the background flush loop so the worker thread does not die
- Add tests to assert unexpected `RuntimeError` propagates on synchronous flush

## Why this helps
### Docker
The previous Dockerfile put both `maturin` builds plus the wheel install into one long buildx step. If that step flakes under multi-arch buildx, the whole layer is lost and the logs are less actionable. Splitting it gives smaller failure surfaces, better cache reuse, and less pressure under emulated builds.

### Deferred permission buffer
Foreground `flush()` and shutdown paths are correctness-critical and should not silently re-queue programmer/configuration bugs. Unexpected failures should surface immediately there, while the background worker should still log and continue.

## Verification
Ran successfully locally:
- `docker buildx build --platform linux/amd64 --progress=plain --target builder -f Dockerfile .`
- `docker buildx build --platform linux/arm64 --progress=plain --target builder -f Dockerfile .`
- `PYTHONPATH=src pytest -q tests/unit/core/test_deferred_buffer_deadletter.py`
- `PYTHONPATH=src pytest -q tests/unit/services/permissions/test_deferred_permission_buffer.py`
