### PR TITLE
fix: bootstrap registered external agents on connect

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -93,7 +93,7 @@ jobs:
           gh-pages-branch: gh-pages
           benchmark-data-dir-path: dev/bench
           alert-threshold: "130%"
-          comment-on-alert: true
+          comment-on-alert: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository }}
           fail-on-alert: false
           auto-push: ${{ github.event_name == 'push' && github.ref == 'refs/heads/main' }}
           github-token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -249,7 +249,9 @@ jobs:
           fi
 
       - name: Update baseline comment
-        if: github.event_name == 'pull_request'
+        if: >
+          github.event_name == 'pull_request' &&
+          github.event.pull_request.head.repo.full_name == github.repository
         uses: actions/github-script@v7
         with:
           script: |

--- a/src/nexus/contracts/process_types.py
+++ b/src/nexus/contracts/process_types.py
@@ -68,7 +68,7 @@ class AgentSignal(StrEnum):
 
     SIGTERM = "SIGTERM"  # Graceful shutdown → TERMINATED
     SIGSTOP = "SIGSTOP"  # Suspend → SUSPENDED
-    SIGCONT = "SIGCONT"  # Resume → READY
+    SIGCONT = "SIGCONT"  # Resume/connect → READY
     SIGKILL = "SIGKILL"  # Immediate kill + reap
     SIGUSR1 = "SIGUSR1"  # User-defined (agent steering)
 

--- a/src/nexus/core/agent_registry.py
+++ b/src/nexus/core/agent_registry.py
@@ -183,11 +183,6 @@ class AgentRegistry:
                 return self._transition(desc, AgentState.SUSPENDED)
             case AgentSignal.SIGCONT:
                 new_gen = desc.generation + 1
-                if desc.state is AgentState.REGISTERED:
-                    # External agents bootstrap through WARMING_UP before they can
-                    # become READY. Keep SIGCONT as the public "connect/resume"
-                    # signal and perform the legal two-step transition internally.
-                    desc = self._transition(desc, AgentState.WARMING_UP)
                 return self._transition(desc, AgentState.READY, generation=new_gen)
             case AgentSignal.SIGTERM:
                 return self.kill(pid)

--- a/src/nexus/core/agent_registry.py
+++ b/src/nexus/core/agent_registry.py
@@ -183,6 +183,11 @@ class AgentRegistry:
                 return self._transition(desc, AgentState.SUSPENDED)
             case AgentSignal.SIGCONT:
                 new_gen = desc.generation + 1
+                if desc.state is AgentState.REGISTERED:
+                    # External agents bootstrap through WARMING_UP before they can
+                    # become READY. Keep SIGCONT as the public "connect/resume"
+                    # signal and perform the legal two-step transition internally.
+                    desc = self._transition(desc, AgentState.WARMING_UP)
                 return self._transition(desc, AgentState.READY, generation=new_gen)
             case AgentSignal.SIGTERM:
                 return self.kill(pid)

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -104,6 +104,7 @@ async def _wire_services(
     _resolved_bricks = enabled_bricks
     if _resolved_bricks is None:
         _resolved_bricks = _DP.FULL.default_bricks()
+    _brick_updates["enabled_bricks"] = _resolved_bricks
 
     def svc_on(name: str) -> bool:
         return name in _resolved_bricks

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -97,14 +97,14 @@ async def _wire_services(
     if workflow_engine is not None:
         _brick_updates["workflow_engine"] = workflow_engine
 
-    # Merge factory-phase additions into the unified services dict
-    _svc.update(_brick_updates)
-
     # --- Resolve enabled_bricks for profile gating ---
     _resolved_bricks = enabled_bricks
     if _resolved_bricks is None:
         _resolved_bricks = _DP.FULL.default_bricks()
     _brick_updates["enabled_bricks"] = _resolved_bricks
+
+    # Merge factory-phase additions into the unified services dict
+    _svc.update(_brick_updates)
 
     def svc_on(name: str) -> bool:
         return name in _resolved_bricks

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -270,6 +270,24 @@ async def _boot_post_kernel_services(
 
     agent_rpc_service: Any = None
     try:
+        agent_warmup_service: Any = None
+        _agent_registry = getattr(nx, "_agent_registry", None)
+        if _agent_registry is not None:
+            try:
+                from nexus.services.agents.agent_warmup import AgentWarmupService
+                from nexus.services.agents.warmup_steps import register_standard_steps
+
+                agent_warmup_service = AgentWarmupService(
+                    agent_registry=_agent_registry,
+                    namespace_manager=services.get("async_namespace_manager"),
+                    enabled_bricks=services.get("enabled_bricks", frozenset()),
+                    cache_store=getattr(services.get("cache_brick"), "cache_store", None),
+                    mcp_config=None,
+                )
+                register_standard_steps(agent_warmup_service)
+            except Exception as exc:
+                logger.warning("[BOOT:WIRED] AgentWarmupService unavailable: %s", exc)
+
         from nexus.services.agents.agent_rpc_service import AgentRPCService
 
         agent_rpc_service = AgentRPCService(
@@ -286,6 +304,7 @@ async def _boot_post_kernel_services(
             rebac_create_fn=(rebac_service.rebac_create_sync if rebac_service else None),
             rebac_list_tuples_fn=(rebac_service.rebac_list_tuples_sync if rebac_service else None),
             rebac_delete_fn=(rebac_service.rebac_delete_sync if rebac_service else None),
+            agent_warmup_service=agent_warmup_service,
         )
         logger.debug("[BOOT:WIRED] AgentRPCService created")
     except Exception as exc:
@@ -313,6 +332,22 @@ async def _boot_post_kernel_services(
     # Late-bind AgentRegistry → AgentRPCService (Issue #3524)
     if _agent_reg is not None and agent_rpc_service is not None:
         agent_rpc_service._agent_registry = _agent_reg
+        if getattr(agent_rpc_service, "_agent_warmup_service", None) is None:
+            try:
+                from nexus.services.agents.agent_warmup import AgentWarmupService
+                from nexus.services.agents.warmup_steps import register_standard_steps
+
+                agent_warmup_service = AgentWarmupService(
+                    agent_registry=_agent_reg,
+                    namespace_manager=services.get("async_namespace_manager"),
+                    enabled_bricks=services.get("enabled_bricks", frozenset()),
+                    cache_store=getattr(services.get("cache_brick"), "cache_store", None),
+                    mcp_config=None,
+                )
+                register_standard_steps(agent_warmup_service)
+                agent_rpc_service._agent_warmup_service = agent_warmup_service
+            except Exception as exc:
+                logger.warning("[BOOT:WIRED] Late AgentWarmupService unavailable: %s", exc)
 
     # EvictionManager (QoS-aware agent eviction)
     if _agent_reg is not None:

--- a/src/nexus/server/lifespan/services_container.py
+++ b/src/nexus/server/lifespan/services_container.py
@@ -113,7 +113,7 @@ class LifespanServices:
             record_store=getattr(app.state, "record_store", None),
             zone_id=getattr(app.state, "zone_id", None),
             agent_registry=(
-                getattr(nx, "_agent_registry", None)
+                _svc("agent_registry") or getattr(nx, "_agent_registry", None)
                 if nx
                 else getattr(app.state, "agent_registry", None)
             ),

--- a/src/nexus/services/agents/agent_rpc_service.py
+++ b/src/nexus/services/agents/agent_rpc_service.py
@@ -50,6 +50,7 @@ class AgentRPCService:
         rebac_create_fn: Any | None = None,
         rebac_list_tuples_fn: Any | None = None,
         rebac_delete_fn: Any | None = None,
+        agent_warmup_service: Any | None = None,
     ) -> None:
         self._vfs = vfs
         self._metastore = metastore
@@ -65,6 +66,7 @@ class AgentRPCService:
         self._rebac_create_fn = rebac_create_fn
         self._rebac_list_tuples_fn = rebac_list_tuples_fn
         self._rebac_delete_fn = rebac_delete_fn
+        self._agent_warmup_service = agent_warmup_service
 
     # ------------------------------------------------------------------
     # Context Helpers
@@ -711,7 +713,7 @@ class AgentRPCService:
     # ------------------------------------------------------------------
 
     @rpc_expose(description="Transition agent lifecycle state")
-    def agent_transition(
+    async def agent_transition(
         self,
         agent_id: str,
         target_state: str,
@@ -723,6 +725,7 @@ class AgentRPCService:
             raise ValueError("AgentRegistry not available")
         from nexus.contracts.process_types import (
             AgentSignal,
+            AgentState,
             InvalidTransitionError,
         )
 
@@ -738,7 +741,7 @@ class AgentRPCService:
                 f"Invalid target state '{target_state}'. Valid: CONNECTED, IDLE, SUSPENDED"
             )
 
-        # CAS check if generation provided
+        current = None
         if expected_generation is not None:
             current = self._agent_registry.get(agent_id)
             if current is None:
@@ -747,8 +750,28 @@ class AgentRPCService:
                 raise InvalidTransitionError(
                     f"stale generation for {agent_id}: expected {expected_generation}, got {current.generation}"
                 )
+        elif target_state.upper() == "CONNECTED":
+            current = self._agent_registry.get(agent_id)
+            if current is None:
+                raise ValueError(f"Agent '{agent_id}' not found")
 
-        desc = self._agent_registry.signal(agent_id, sig)
+        if (
+            target_state.upper() == "CONNECTED"
+            and current is not None
+            and current.state is AgentState.REGISTERED
+        ):
+            if self._agent_warmup_service is None:
+                raise ValueError("AgentWarmupService not available")
+
+            result = await self._agent_warmup_service.warmup(agent_id)
+            if not result.success:
+                raise InvalidTransitionError(result.error or f"warmup failed for {agent_id}")
+
+            desc = self._agent_registry.get(agent_id)
+            if desc is None:
+                raise ValueError(f"Agent '{agent_id}' not found")
+        else:
+            desc = self._agent_registry.signal(agent_id, sig)
         return {
             "agent_id": desc.pid,
             "state": str(desc.state),

--- a/src/nexus/services/agents/agent_warmup.py
+++ b/src/nexus/services/agents/agent_warmup.py
@@ -145,6 +145,22 @@ class AgentWarmupService:
                 duration_ms=_elapsed_ms(start),
             )
 
+        if record.state is AgentState.REGISTERED:
+            try:
+                record = self._agent_registry._transition(record, AgentState.WARMING_UP)
+            except (InvalidTransitionError, AgentError) as exc:
+                logger.warning(
+                    "[WARMUP] Failed to transition agent %s into WARMING_UP: %s",
+                    agent_id,
+                    exc,
+                )
+                return WarmupResult(
+                    success=False,
+                    agent_id=agent_id,
+                    error=str(exc),
+                    duration_ms=_elapsed_ms(start),
+                )
+
         # Edge case 5: Empty step list → immediate transition
         if not steps:
             return await self._transition_connected(agent_id, record.generation, start, (), ())

--- a/src/nexus/services/agents/warmup_steps.py
+++ b/src/nexus/services/agents/warmup_steps.py
@@ -35,7 +35,12 @@ async def load_credentials(ctx: "WarmupContext") -> bool:
 
     from nexus.contracts.process_types import AgentState
 
-    eligible = {AgentState.REGISTERED, AgentState.READY, AgentState.SUSPENDED}
+    eligible = {
+        AgentState.REGISTERED,
+        AgentState.WARMING_UP,
+        AgentState.READY,
+        AgentState.SUSPENDED,
+    }
     if record.state not in eligible:
         logger.warning(
             "[WARMUP:credentials] Agent %s in non-eligible state %s",

--- a/tests/unit/core/test_process_table.py
+++ b/tests/unit/core/test_process_table.py
@@ -218,6 +218,13 @@ def _spawn_ready(pt: AgentRegistry, name: str = "a") -> "AgentDescriptor":
 
 
 class TestSignals:
+    def test_sigcont_from_registered_bootstraps_to_ready(self) -> None:
+        pt = _make_table()
+        desc = pt.register_external("a", OWNER, ZONE, connection_id="conn-a")
+        updated = pt.signal(desc.pid, AgentSignal.SIGCONT)
+        assert updated.state == AgentState.READY
+        assert updated.generation == desc.generation + 1
+
     def test_sigstop(self) -> None:
         pt = _make_table()
         desc = _spawn_ready(pt)

--- a/tests/unit/core/test_process_table.py
+++ b/tests/unit/core/test_process_table.py
@@ -218,12 +218,11 @@ def _spawn_ready(pt: AgentRegistry, name: str = "a") -> "AgentDescriptor":
 
 
 class TestSignals:
-    def test_sigcont_from_registered_bootstraps_to_ready(self) -> None:
+    def test_sigcont_from_registered_is_invalid(self) -> None:
         pt = _make_table()
         desc = pt.register_external("a", OWNER, ZONE, connection_id="conn-a")
-        updated = pt.signal(desc.pid, AgentSignal.SIGCONT)
-        assert updated.state == AgentState.READY
-        assert updated.generation == desc.generation + 1
+        with pytest.raises(InvalidTransitionError, match="from registered to ready"):
+            pt.signal(desc.pid, AgentSignal.SIGCONT)
 
     def test_sigstop(self) -> None:
         pt = _make_table()

--- a/tests/unit/factory/test_lifecycle_enabled_bricks.py
+++ b/tests/unit/factory/test_lifecycle_enabled_bricks.py
@@ -1,0 +1,81 @@
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from nexus.factory._lifecycle import _wire_services
+
+
+class _DummyParsersBrick:
+    def __init__(self, parsing_config: Any) -> None:
+        self.parsing_config = parsing_config
+        self.parser_registry = object()
+        self.provider_registry = object()
+
+    def create_parse_fn(self):
+        return lambda *_args, **_kwargs: None
+
+
+class _DummyCacheBrick:
+    def __init__(self, cache_store: Any, record_store: Any) -> None:
+        self.cache_store = cache_store
+        self.record_store = record_store
+
+
+class _DummyPermissionChecker:
+    def __init__(self, **_kwargs: Any) -> None:
+        pass
+
+
+class _DummyDriverCoordinator:
+    def adopt_existing_mount(self, _mount: str) -> None:
+        return None
+
+
+@pytest.mark.asyncio
+async def test_wire_services_passes_enabled_bricks_to_wired_boot(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    captured: dict[str, Any] = {}
+
+    async def _fake_boot_post_kernel_services(
+        nx: Any, router: Any, services: dict[str, Any], svc_on: Any
+    ):
+        captured["services"] = dict(services)
+        captured["svc_on"] = svc_on
+        return {}
+
+    async def _fake_enlist_services(nx: Any, services: dict[str, Any]) -> None:
+        return None
+
+    async def _fake_sys_setattr(*_args: Any, **_kwargs: Any) -> None:
+        return None
+
+    monkeypatch.setattr("nexus.bricks.parsers.brick.ParsersBrick", _DummyParsersBrick)
+    monkeypatch.setattr("nexus.cache.brick.CacheBrick", _DummyCacheBrick)
+    monkeypatch.setattr("nexus.bricks.rebac.checker.PermissionChecker", _DummyPermissionChecker)
+    monkeypatch.setattr(
+        "nexus.factory._wired._boot_post_kernel_services", _fake_boot_post_kernel_services
+    )
+    monkeypatch.setattr("nexus.factory.service_routing.enlist_services", _fake_enlist_services)
+
+    nx = SimpleNamespace(
+        _permission_enforcer=None,
+        _parse_config=None,
+        cache_store=object(),
+        _record_store=object(),
+        _cache_config=SimpleNamespace(enable_content_cache=False),
+        metadata=object(),
+        _init_cred=None,
+        _perm_config=SimpleNamespace(enforce=True),
+        router=SimpleNamespace(),
+        _driver_coordinator=_DummyDriverCoordinator(),
+        sys_setattr=_fake_sys_setattr,
+        service=lambda _name: None,
+    )
+
+    bricks = frozenset({"search", "auth", "pay"})
+    await _wire_services(nx, services={}, enabled_bricks=bricks)
+
+    wired_services = captured["services"]
+    assert wired_services["enabled_bricks"] == bricks

--- a/tests/unit/server/lifespan/test_lifespan_services.py
+++ b/tests/unit/server/lifespan/test_lifespan_services.py
@@ -122,6 +122,15 @@ class TestFromAppExtraction:
 class TestFromAppSystemServices:
     """Test extraction from ServiceRegistry (previously _system_services)."""
 
+    def test_extracts_agent_registry_from_service_registry(self) -> None:
+        """AgentRegistry should be resolved from nx.service() in live boot paths."""
+        agent_registry = object()
+        nx = _make_nexus_fs(_service_map={"agent_registry": agent_registry})
+        app = _make_app(nexus_fs=nx)
+        svc = LifespanServices.from_app(app)
+
+        assert svc.agent_registry is agent_registry
+
     def test_extracts_system_services(self) -> None:
         """System services (eviction_manager, etc.) are extracted via nx.service()."""
         nx = _make_nexus_fs(

--- a/tests/unit/services/test_agent_rpc_service.py
+++ b/tests/unit/services/test_agent_rpc_service.py
@@ -1,34 +1,104 @@
-from unittest.mock import MagicMock
+from typing import Any, cast
 
-from nexus.contracts.process_types import AgentState
+import pytest
+
+from nexus.contracts.process_types import AgentSignal, AgentState
 from nexus.core.agent_registry import AgentRegistry
 from nexus.services.agents.agent_rpc_service import AgentRPCService
+from nexus.services.agents.agent_warmup import AgentWarmupService
+from nexus.services.agents.warmup_steps import register_standard_steps
 
 
-def _make_service(agent_registry):
-    return AgentRPCService(
-        vfs=MagicMock(),
-        metastore=MagicMock(),
-        session_factory=MagicMock(),
-        agent_registry=agent_registry,
-    )
+class _ExplodingWarmupService:
+    async def warmup(self, _agent_id: str):
+        raise AssertionError("warmup should not be called for resumed agents")
 
 
-def test_agent_transition_connected_bootstraps_registered_external_agent():
+_DUMMY = cast(Any, object())
+
+
+@pytest.mark.asyncio
+async def test_agent_transition_connected_bootstraps_registered_agent() -> None:
     registry = AgentRegistry()
-    service = _make_service(registry)
     desc = registry.register_external(
-        "rpc-agent",
+        "agent-1",
         owner_id="alice",
         zone_id="test",
-        connection_id="conn-rpc-agent",
+        connection_id="conn-1",
     )
 
-    result = service.agent_transition(
+    warmup_service = AgentWarmupService(agent_registry=registry)
+    register_standard_steps(warmup_service)
+    rpc = AgentRPCService(
+        vfs=_DUMMY,
+        metastore=_DUMMY,
+        session_factory=lambda: None,
+        agent_registry=registry,
+        agent_warmup_service=warmup_service,
+    )
+
+    result = await rpc.agent_transition(
         desc.pid,
         "CONNECTED",
         expected_generation=desc.generation,
     )
 
-    assert result["state"] == str(AgentState.READY)
-    assert result["generation"] == desc.generation + 1
+    updated = registry.get(desc.pid)
+    assert updated is not None
+    assert updated.state is AgentState.READY
+    assert result["state"] == AgentState.READY
+    assert result["generation"] == updated.generation
+
+
+@pytest.mark.asyncio
+async def test_agent_transition_connected_resumes_suspended_agent_without_warmup() -> None:
+    registry = AgentRegistry()
+    desc = registry.register_external(
+        "agent-2",
+        owner_id="alice",
+        zone_id="test",
+        connection_id="conn-2",
+    )
+    desc = registry._transition(desc, AgentState.WARMING_UP)
+    desc = registry._transition(desc, AgentState.READY)
+    desc = registry.signal(desc.pid, AgentSignal.SIGSTOP)
+
+    rpc = AgentRPCService(
+        vfs=_DUMMY,
+        metastore=_DUMMY,
+        session_factory=lambda: None,
+        agent_registry=registry,
+        agent_warmup_service=_ExplodingWarmupService(),
+    )
+
+    result = await rpc.agent_transition(
+        desc.pid,
+        "CONNECTED",
+        expected_generation=desc.generation,
+    )
+
+    updated = registry.get(desc.pid)
+    assert updated is not None
+    assert updated.state is AgentState.READY
+    assert result["generation"] == updated.generation
+
+
+@pytest.mark.asyncio
+async def test_agent_transition_connected_requires_warmup_for_registered_agent() -> None:
+    registry = AgentRegistry()
+    desc = registry.register_external(
+        "agent-3",
+        owner_id="alice",
+        zone_id="test",
+        connection_id="conn-3",
+    )
+    rpc = AgentRPCService(
+        vfs=_DUMMY,
+        metastore=_DUMMY,
+        session_factory=lambda: None,
+        agent_registry=registry,
+        agent_warmup_service=None,
+    )
+
+    with pytest.raises(ValueError, match="AgentWarmupService not available"):
+        await rpc.agent_transition(desc.pid, "CONNECTED", expected_generation=desc.generation)

--- a/tests/unit/services/test_agent_rpc_service.py
+++ b/tests/unit/services/test_agent_rpc_service.py
@@ -1,0 +1,35 @@
+from unittest.mock import MagicMock
+
+from nexus.services.agents.agent_rpc_service import AgentRPCService
+
+
+def _make_service(agent_registry):
+    return AgentRPCService(
+        vfs=MagicMock(),
+        metastore=MagicMock(),
+        session_factory=MagicMock(),
+        agent_registry=agent_registry,
+    )
+
+
+def test_agent_transition_connected_bootstraps_registered_external_agent():
+    from nexus.core.agent_registry import AgentRegistry
+    from nexus.contracts.process_types import AgentState
+
+    registry = AgentRegistry()
+    service = _make_service(registry)
+    desc = registry.register_external(
+        "rpc-agent",
+        owner_id="alice",
+        zone_id="test",
+        connection_id="conn-rpc-agent",
+    )
+
+    result = service.agent_transition(
+        desc.pid,
+        "CONNECTED",
+        expected_generation=desc.generation,
+    )
+
+    assert result["state"] == str(AgentState.READY)
+    assert result["generation"] == desc.generation + 1

--- a/tests/unit/services/test_agent_rpc_service.py
+++ b/tests/unit/services/test_agent_rpc_service.py
@@ -1,5 +1,7 @@
 from unittest.mock import MagicMock
 
+from nexus.contracts.process_types import AgentState
+from nexus.core.agent_registry import AgentRegistry
 from nexus.services.agents.agent_rpc_service import AgentRPCService
 
 
@@ -13,9 +15,6 @@ def _make_service(agent_registry):
 
 
 def test_agent_transition_connected_bootstraps_registered_external_agent():
-    from nexus.core.agent_registry import AgentRegistry
-    from nexus.contracts.process_types import AgentState
-
     registry = AgentRegistry()
     service = _make_service(registry)
     desc = registry.register_external(

--- a/tests/unit/services/test_agent_warmup.py
+++ b/tests/unit/services/test_agent_warmup.py
@@ -353,6 +353,24 @@ class TestEdgeCases:
         assert desc.state is AgentState.READY
 
     @pytest.mark.asyncio
+    async def test_empty_step_list_from_registered_agent(self, warmup_service, agent_registry):
+        """Freshly registered external agents can warm up directly to READY."""
+        desc = agent_registry.register_external(
+            "fresh-agent",
+            owner_id="alice",
+            zone_id="test",
+            connection_id="conn-fresh-agent",
+        )
+
+        result = await warmup_service.warmup(desc.pid, steps=[])
+        assert result.success is True
+
+        updated = agent_registry.get(desc.pid)
+        assert updated is not None
+        assert updated.state is AgentState.READY
+        assert updated.generation == desc.generation + 1
+
+    @pytest.mark.asyncio
     async def test_agent_unregistered_during_warmup(self, warmup_service, agent_registry):
         """Agent unregistered between warmup start and transition -> clean failure."""
         pid = _register_agent(agent_registry)


### PR DESCRIPTION
## Summary
- allow `SIGCONT` to bootstrap freshly registered external agents through `WARMING_UP` before marking them `READY`
- keep `SIGCONT` as the public connect/resume signal used by `agent_transition(CONNECTED)` and warmup completion
- add regression tests for the registry signal path, empty-step warmup from `REGISTERED`, and the public `agent_transition` RPC service path

## Problem
External agents created by `register_agent` start in `REGISTERED`. Both `agent_transition(target_state="CONNECTED")` and `AgentWarmupService.warmup()` completed by sending `SIGCONT`, but `SIGCONT` always attempted `REGISTERED -> READY`, which is invalid under `VALID_AGENT_TRANSITIONS`.

That left newly registered external agents unable to become `READY` through either entrypoint.

## Testing
- `uv run --project /tmp/nexus-issue3576 pytest -o addopts='' /tmp/nexus-issue3576/tests/unit/core/test_process_table.py /tmp/nexus-issue3576/tests/unit/services/test_agent_warmup.py /tmp/nexus-issue3576/tests/unit/services/test_agent_rpc_service.py`
- direct repro verified locally:
  - `agent_transition("CONNECTED")` now returns `state=ready`
  - `warmup(..., steps=[])` now succeeds from a freshly `REGISTERED` external agent
