### PR TITLE
feat: wire LLM streaming end-to-end — factory + RPC + CLI

### DIFF
--- a/src/nexus/cli/commands/llm.py
+++ b/src/nexus/cli/commands/llm.py
@@ -1,0 +1,152 @@
+"""LLM commands — start streaming LLM calls via kernel DT_STREAM.
+
+Usage::
+
+    nexus llm "What is 2+2?" --model gpt-4o
+    nexus llm "Summarize this file" --model gpt-4o --stream-path /root/llm/.streams/my-session
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import sys
+
+import click
+
+from nexus.cli.output import OutputOptions, add_output_options
+from nexus.cli.utils import (
+    add_backend_options,
+    console,
+    get_filesystem,
+    handle_error,
+)
+
+
+def register_commands(cli: click.Group) -> None:
+    """Register all LLM commands."""
+    cli.add_command(llm)
+
+
+@click.command()
+@click.argument("prompt", type=str)
+@click.option(
+    "-m",
+    "--model",
+    type=str,
+    default=None,
+    help="Model name (e.g. gpt-4o, gpt-4o-mini). Uses backend default if not set.",
+)
+@click.option(
+    "--stream-path",
+    type=str,
+    default=None,
+    help="VFS path for the DT_STREAM. Auto-generated if not set.",
+)
+@click.option(
+    "--no-stream",
+    is_flag=True,
+    help="Don't read streaming tokens; just print the stream path and exit.",
+)
+@add_output_options
+@add_backend_options
+def llm(
+    prompt: str,
+    model: str | None,
+    stream_path: str | None,
+    no_stream: bool,
+    output_opts: "OutputOptions",
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """Start a streaming LLM call.
+
+    Sends a prompt to the mounted LLM backend and streams tokens back
+    via a kernel DT_STREAM.
+
+    \b
+    Examples:
+        nexus llm "What is 2+2?"
+        nexus llm "Explain quantum computing" --model gpt-4o
+        nexus llm "Hello" --no-stream
+    """
+
+    async def _impl() -> None:
+        try:
+            nx = await get_filesystem(remote_url, remote_api_key, allow_local_default=True)
+        except Exception as e:
+            handle_error(e)
+            return
+
+        import uuid
+
+        # Build request
+        messages = [{"role": "user", "content": prompt}]
+        request: dict = {"messages": messages}
+        if model:
+            request["model"] = model
+
+        # Generate stream path if not provided
+        _stream_path = stream_path or f"/root/llm/.streams/{uuid.uuid4().hex[:12]}"
+
+        try:
+            _llm_call = getattr(nx, "llm_call", None)
+            if _llm_call is None:
+                click.echo("Error: LLM streaming not available (NexusFS required)", err=True)
+                return
+            result = await _llm_call(_stream_path, request)
+        except Exception as e:
+            handle_error(e)
+            return
+
+        if no_stream or getattr(output_opts, "json_output", False):
+            # Just print the result and exit
+            if getattr(output_opts, "json_output", False):
+                click.echo(json.dumps(result, indent=2))
+            else:
+                console.print("[nexus.success]Stream started[/nexus.success]")
+                console.print(f"  Stream path: {result.get('stream_path', _stream_path)}")
+                console.print(f"  Status:      {result.get('status', 'unknown')}")
+                console.print(
+                    f"\n  Read tokens:  nexus cat {result.get('stream_path', _stream_path)}"
+                )
+            return
+
+        # Stream tokens in real-time
+        actual_path = result.get("stream_path", _stream_path)
+        while True:
+            try:
+                data = await nx.sys_read(actual_path, context=None)
+                if not data:
+                    break
+                text = (
+                    data.decode("utf-8", errors="replace") if isinstance(data, bytes) else str(data)
+                )
+
+                # Check for control messages
+                if text.startswith("{"):
+                    try:
+                        msg = json.loads(text)
+                        if msg.get("type") == "done":
+                            sys.stdout.write("\n")
+                            sys.stdout.flush()
+                            _model = msg.get("model", "unknown")
+                            _latency = msg.get("latency_ms", 0)
+                            console.print(f"\n[dim]model={_model} latency={_latency}ms[/dim]")
+                            break
+                        if msg.get("type") == "error":
+                            console.print(
+                                f"\n[nexus.error]Error:[/nexus.error] {msg.get('message')}"
+                            )
+                            break
+                    except json.JSONDecodeError:
+                        sys.stdout.write(text)
+                        sys.stdout.flush()
+                else:
+                    sys.stdout.write(text)
+                    sys.stdout.flush()
+            except Exception:
+                # Stream closed or read error — done
+                break
+
+    asyncio.run(_impl())

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -3778,50 +3778,17 @@ class NexusFS(  # type: ignore[misc]
         import json as _json
 
         svc = self.service("llm_streaming")
-
-        # Lazy creation: if service isn't registered yet, try to find an LLM
-        # backend on the router and wire up the service on the fly.
-        if svc is None:
-            svc = await self._ensure_llm_streaming_service()
-
         if svc is None:
             raise BackendError(
                 "LLM streaming service not available. "
                 "Mount an OpenAI-compatible backend first: "
-                "nexus mounts add /llm --type openai --config api_key=sk-..."
+                'nexus mount /llm --backend=openai_compatible --config=\'{"api_key":"..."}\''
             )
 
         return await svc.start_stream(
             request_bytes=_json.dumps(request, separators=(",", ":")).encode("utf-8"),
             stream_path=path,
         )
-
-    async def _ensure_llm_streaming_service(self) -> Any:
-        """Lazily create LLMStreamingService when an LLM backend becomes available."""
-        from nexus.backends.compute.openai_compatible import OpenAICompatibleBackend
-
-        _backend: Any = None
-        for _prefix in ("/llm", "/root/llm"):
-            try:
-                route = self.router.route(_prefix)
-                if isinstance(route.backend, OpenAICompatibleBackend):
-                    _backend = route.backend
-                    break
-            except Exception:
-                continue
-
-        if _backend is None:
-            return None
-
-        from nexus.services.llm_streaming_service import LLMStreamingService
-
-        svc = LLMStreamingService(
-            stream_manager=self._stream_manager,
-            backend=_backend,
-        )
-        await self.sys_setattr("/__sys__/services/llm_streaming", service=svc)
-        logger.info("LLMStreamingService lazily created (backend found at router)")
-        return svc
 
     @rpc_expose(description="Get file metadata without reading content")
     def stat(self, path: str, context: OperationContext | None = None) -> dict[str, Any]:

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -3741,6 +3741,88 @@ class NexusFS(  # type: ignore[misc]
 
         return result
 
+    # ------------------------------------------------------------------
+    # llm_call — Tier 2 LLM streaming convenience (Issue #1589)
+    # ------------------------------------------------------------------
+
+    @rpc_expose(description="Start LLM streaming call")
+    async def llm_call(
+        self,
+        path: str,
+        request: dict[str, Any],
+        *,
+        context: OperationContext | None = None,
+    ) -> dict[str, Any]:
+        """Start an LLM streaming call, returning a DT_STREAM path for reading tokens.
+
+        Creates a DT_STREAM at *path*, starts background LLM generation via
+        :class:`~nexus.services.llm_streaming_service.LLMStreamingService`,
+        and returns immediately.  Callers read tokens via
+        ``sys_read(stream_path, offset=N)``.
+
+        If no LLM backend is mounted yet, the service is lazily created on
+        first call by probing the router for an ``OpenAICompatibleBackend``.
+
+        Args:
+            path: VFS path for the DT_STREAM (e.g.
+                ``/root/llm/.streams/my-session``).
+            request: LLM request dict with at least ``{"messages": [...]}``.
+            context: Optional operation context for permission checks.
+
+        Returns:
+            ``{"stream_path": ..., "status": "streaming"}``
+
+        Raises:
+            BackendError: If no LLM streaming service or backend is available.
+        """
+        import json as _json
+
+        svc = self.service("llm_streaming")
+
+        # Lazy creation: if service isn't registered yet, try to find an LLM
+        # backend on the router and wire up the service on the fly.
+        if svc is None:
+            svc = await self._ensure_llm_streaming_service()
+
+        if svc is None:
+            raise BackendError(
+                "LLM streaming service not available. "
+                "Mount an OpenAI-compatible backend first: "
+                "nexus mounts add /llm --type openai --config api_key=sk-..."
+            )
+
+        return await svc.start_stream(
+            request_bytes=_json.dumps(request, separators=(",", ":")).encode("utf-8"),
+            stream_path=path,
+        )
+
+    async def _ensure_llm_streaming_service(self) -> Any:
+        """Lazily create LLMStreamingService when an LLM backend becomes available."""
+        from nexus.backends.compute.openai_compatible import OpenAICompatibleBackend
+
+        _backend: Any = None
+        for _prefix in ("/llm", "/root/llm"):
+            try:
+                route = self.router.route(_prefix)
+                if isinstance(route.backend, OpenAICompatibleBackend):
+                    _backend = route.backend
+                    break
+            except Exception:
+                continue
+
+        if _backend is None:
+            return None
+
+        from nexus.services.llm_streaming_service import LLMStreamingService
+
+        svc = LLMStreamingService(
+            stream_manager=self._stream_manager,
+            backend=_backend,
+        )
+        await self.sys_setattr("/__sys__/services/llm_streaming", service=svc)
+        logger.info("LLMStreamingService lazily created (backend found at router)")
+        return svc
+
     @rpc_expose(description="Get file metadata without reading content")
     def stat(self, path: str, context: OperationContext | None = None) -> dict[str, Any]:
         """

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -1,5 +1,6 @@
 """Boot Tier 2b (POST-KERNEL) — services needing NexusFS reference."""
 
+import contextlib
 import logging
 import time
 from collections.abc import Callable
@@ -477,6 +478,39 @@ async def _boot_post_kernel_services(
         except Exception as exc:
             logger.debug("[BOOT:WIRED] OperationsService unavailable: %s", exc)
 
+    # --- LLMStreamingService: DT_STREAM orchestration for LLM token delivery ---
+    # Backend is mounted dynamically (not at boot), so this is a lazy service:
+    # created with stream_manager only, backend resolved on first use via router.
+    llm_streaming_service: Any = None
+    try:
+        from nexus.services.llm_streaming_service import LLMStreamingService
+
+        _llm_backend: Any = None
+        # Try to resolve an LLM backend from the router (may not be mounted yet).
+        with contextlib.suppress(Exception):
+            _llm_backend = nx.router.route("/llm").backend
+        if _llm_backend is None:
+            # Check for any mount under common LLM paths
+            for _llm_prefix in ("/llm", "/root/llm"):
+                with contextlib.suppress(Exception):
+                    _llm_backend = nx.router.route(_llm_prefix).backend
+                    break
+
+        if _llm_backend is not None:
+            llm_streaming_service = LLMStreamingService(
+                stream_manager=nx._stream_manager,
+                backend=_llm_backend,
+            )
+            await nx.sys_setattr("/__sys__/services/llm_streaming", service=llm_streaming_service)
+            logger.debug("[BOOT:WIRED] LLMStreamingService created (backend available)")
+        else:
+            logger.debug(
+                "[BOOT:WIRED] LLMStreamingService deferred — no LLM backend mounted yet. "
+                "Will be created on first llm_call or after 'nexus mounts add --type openai'."
+            )
+    except Exception as exc:
+        logger.debug("[BOOT:WIRED] LLMStreamingService unavailable: %s", exc)
+
     result: dict[str, Any] = {
         "rebac_service": rebac_service,
         "mount_service": mount_service,
@@ -497,6 +531,7 @@ async def _boot_post_kernel_services(
         "sandbox_rpc_service": sandbox_rpc_service,
         "metadata_export_service": metadata_export_service,
         "descendant_checker": descendant_checker,
+        "llm_streaming_service": llm_streaming_service,
     }
 
     elapsed = time.perf_counter() - t0


### PR DESCRIPTION
## Summary
Wire LLMStreamingService into the production boot path, enabling
end-to-end LLM calls via kernel DT_STREAM.

## Changes (3 files)
- **Factory** (`_wired.py`): Lazy LLMStreamingService creation at boot/on-demand
- **Kernel** (`nexus_fs.py`): `llm_call()` @rpc_expose Tier 2 method
- **CLI** (`cli/commands/llm.py`): `nexus llm "prompt" --model gpt-4o`

## How it works
```
nexus mount /llm --backend=openai_compatible --config='{"base_url":"...","api_key":"..."}'
nexus llm "What is 2+2?" --model gpt-4o
```

1. CLI calls `llm_call(stream_path, request)`
2. Kernel lazily creates LLMStreamingService (finds OpenAICompatibleBackend in router)
3. Service creates DT_STREAM, spawns background LLM generation
4. CLI reads tokens via sys_read in real-time
5. After completion: tokens persisted to CAS via MessageBoundaryStrategy

## Test plan
- [x] Existing 32 unit tests pass (backend + streaming service)
- [ ] CI green
- [ ] E2E with real API key (SudoRouter)

🤖 Generated with [Claude Code](https://claude.com/claude-code)