### PR TITLE
release: bump version to v0.9.17

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.16"
+version = "0.9.17"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/nexus_pyo3/Cargo.toml
+++ b/rust/nexus_pyo3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus_pyo3"
-version = "0.9.16"
+version = "0.9.17"
 edition = "2021"
 
 [lib]

--- a/rust/nexus_pyo3/pyproject.toml
+++ b/rust/nexus_pyo3/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-fast"
-version = "0.9.16"
+version = "0.9.17"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
 requires-python = ">=3.12"
 classifiers = [


### PR DESCRIPTION
## Summary
- Bump version from 0.9.16 to 0.9.17

## Includes since v0.9.16
- Cluster profile with federation brick (#3490)
- 155 commits on develop since v0.9.16

## After merge
Tag `v0.9.17` on develop and create release to trigger conda packaging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)