### PR TITLE
refactor: remove resolve_get/put/list — metadata routing via PathRouter

### DIFF
--- a/src/nexus/contracts/vfs_hooks.py
+++ b/src/nexus/contracts/vfs_hooks.py
@@ -353,25 +353,6 @@ class VFSPathResolver(Protocol):
     def try_write(self, path: str, content: bytes) -> dict[str, Any] | None: ...
     def try_delete(self, path: str, *, context: Any = None) -> dict[str, Any] | None: ...
 
-    # Metadata routing (Linux inode_operations.setattr analogue).
-    # Default returns None = "not handled, pass to next resolver".
-    def try_get(self, path: str) -> Any | None:  # noqa: ARG002
-        """Route metadata read to correct store. Returns FileMetadata or None."""
-        return None
-
-    def try_put(self, path: str, metadata: Any) -> int | None:  # noqa: ARG002
-        """Route metadata write to correct store. Returns write token or None."""
-        return None
-
-    def try_list(
-        self,
-        prefix: str,  # noqa: ARG002
-        recursive: bool = True,  # noqa: ARG002
-        **kwargs: Any,  # noqa: ARG002
-    ) -> list[Any] | None:
-        """Route metadata list to correct store(s). Returns list or None."""
-        return None
-
 
 # ---------------------------------------------------------------------------
 # MOUNT/UNMOUNT hooks — driver lifecycle notifications (Issue #1811)

--- a/src/nexus/core/kernel_dispatch.py
+++ b/src/nexus/core/kernel_dispatch.py
@@ -336,45 +336,6 @@ class KernelDispatch:
                 return True, result
         return False, None
 
-    # ── Metadata routing (Linux inode_operations.setattr analogue) ───
-
-    def resolve_get(self, path: str) -> tuple[bool, Any]:
-        """PRE-DISPATCH: first-match resolver for metadata read.
-
-        Used by MetastoreABC.get() to route to the correct zone store
-        in federation mode. Non-federation = no resolvers = no-op.
-        """
-        for r in self._fallback_resolvers:
-            result = r.try_get(path)
-            if result is not None:
-                return True, result
-        return False, None
-
-    def resolve_put(self, path: str, metadata: Any) -> tuple[bool, Any]:
-        """PRE-DISPATCH: first-match resolver for metadata write.
-
-        Routes metadata.put() to the correct zone store. Returns
-        (True, write_token) when handled, (False, None) otherwise.
-        """
-        for r in self._fallback_resolvers:
-            result = r.try_put(path, metadata)
-            if result is not None:
-                return True, result
-        return False, None
-
-    def resolve_list(
-        self, prefix: str, recursive: bool = True, **kwargs: Any
-    ) -> tuple[bool, list[Any] | None]:
-        """PRE-DISPATCH: first-match resolver for metadata list.
-
-        Routes metadata.list() across zone boundaries (BFS mount traversal).
-        """
-        for r in self._fallback_resolvers:
-            result = r.try_list(prefix, recursive=recursive, **kwargs)
-            if result is not None:
-                return True, result
-        return False, None
-
     @property
     def resolver_count(self) -> int:
         return len(self._trie_resolvers) + len(self._fallback_resolvers)


### PR DESCRIPTION
## Summary
Remove `resolve_get`/`resolve_put`/`resolve_list` from KernelDispatch and
`try_get`/`try_put`/`try_list` from VFSPathResolver Protocol.

## Why
#3580 moved metadata routing to PathRouter's `route.metastore` — syscalls
get the zone-correct MetastoreABC directly from the route result. The
KernelDispatch metadata resolver chain added in #3560 is no longer needed.

Content routing (`try_read`/`try_write`/`try_delete`) remains — used by
FederationContentResolver for remote zone content fetch.

## Test plan
- [x] Pre-commit hooks pass
- [ ] CI green — no callers of removed methods exist

🤖 Generated with [Claude Code](https://claude.com/claude-code)