### PR TITLE
release: bump API client and TUI to 0.9.17

### DIFF
--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus/api-client",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "Shared HTTP client for Nexus APIs — retry, auth, error mapping, case transform",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus/tui",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "Terminal UI for Nexus — file explorer, API inspector, and monitoring dashboard",
   "type": "module",
   "bin": {


### PR DESCRIPTION
## Summary
Bump remaining package versions to 0.9.17:
- packages/nexus-api-client/package.json
- packages/nexus-tui/package.json

Release pipeline requires all versions match the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)