### PR TITLE
release: bump api-client and tui to 0.9.17

### DIFF
--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus/api-client",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "Shared HTTP client for Nexus APIs — retry, auth, error mapping, case transform",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus/tui",
-  "version": "0.9.16",
+  "version": "0.9.17",
   "description": "Terminal UI for Nexus — file explorer, API inspector, and monitoring dashboard",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Missed these two version files in the release PR. All 5 locations now at 0.9.17.