### PR TITLE
feat(tui): add accessibility announcements

### DIFF
--- a/packages/nexus-tui/src/app.tsx
+++ b/packages/nexus-tui/src/app.tsx
@@ -5,13 +5,16 @@
  * Shows PreConnectionScreen when the server is unavailable (Decision 3A).
  */
 
-import React, { lazy, Suspense, useState, useCallback, useEffect } from "react";
+import React, { lazy, Suspense, useState, useCallback, useEffect, useRef } from "react";
 import { useTerminalDimensions } from "@opentui/react";
 import { useGlobalStore, type PanelId } from "./stores/global-store.js";
 import { useUiStore } from "./stores/ui-store.js";
+import { useErrorStore } from "./stores/error-store.js";
+import { useAnnouncementStore } from "./stores/announcement-store.js";
 import { SideNav } from "./shared/components/side-nav.js";
 import { StatusBar } from "./shared/components/status-bar.js";
 import { ErrorBar } from "./shared/components/error-bar.js";
+import { AnnouncementBar } from "./shared/components/announcement-bar.js";
 import { ErrorBoundary } from "./shared/components/error-boundary.js";
 import { Spinner } from "./shared/components/spinner.js";
 import { useKeyboard } from "./shared/hooks/use-keyboard.js";
@@ -23,6 +26,12 @@ import { PreConnectionScreen } from "./shared/components/pre-connection-screen.j
 import { useFreshServer } from "./shared/hooks/use-fresh-server.js";
 import { detectConnectionState } from "./shared/hooks/use-connection-state.js";
 import { killAllProcesses } from "./services/command-runner.js";
+import { PANEL_DESCRIPTORS } from "./shared/navigation.js";
+import {
+  formatConnectionAnnouncement,
+  formatErrorAnnouncement,
+  formatPanelAnnouncement,
+} from "./shared/accessibility-announcements.js";
 
 // Lazy-loaded panels
 const FileExplorerPanel = lazy(() => import("./panels/files/file-explorer-panel.js"));
@@ -120,6 +129,8 @@ export function App(): React.ReactNode {
   const connectionStatus = useGlobalStore((s) => s.connectionStatus);
   const connectionError = useGlobalStore((s) => s.connectionError);
   const config = useGlobalStore((s) => s.config);
+  const latestError = useErrorStore((s) => (s.errors.length > 0 ? s.errors[s.errors.length - 1] : null));
+  const announce = useAnnouncementStore((s) => s.announce);
   const toggleZoom = useUiStore((s) => s.toggleZoom);
   const zoomedPanel = useUiStore((s) => s.zoomedPanel);
   const sideNavVisible = useUiStore((s) => s.sideNavVisible);
@@ -135,11 +146,38 @@ export function App(): React.ReactNode {
   // screen with a spinner to avoid flashing the main UI during connection attempts.
   const connState = detectConnectionState(connectionStatus, connectionError, config);
   const showPreConnection = connState !== "ready";
+  const previousPanelRef = useRef<PanelId | null>(null);
+  const previousConnectionRef = useRef(connectionStatus);
+  const lastErrorIdRef = useRef<string | null>(null);
+  const panelLabel = PANEL_DESCRIPTORS[activePanel]?.breadcrumbLabel ?? activePanel;
 
   const setOverlayActive = useUiStore((s) => s.setOverlayActive);
   useEffect(() => {
     setOverlayActive(identitySwitcherOpen || helpOpen || showWelcome);
   }, [identitySwitcherOpen, helpOpen, showWelcome, setOverlayActive]);
+
+  useEffect(() => {
+    if (previousPanelRef.current !== null && previousPanelRef.current !== activePanel) {
+      announce(formatPanelAnnouncement(panelLabel));
+    }
+    previousPanelRef.current = activePanel;
+  }, [activePanel, panelLabel, announce]);
+
+  useEffect(() => {
+    if (previousConnectionRef.current !== connectionStatus) {
+      announce(
+        formatConnectionAnnouncement(connectionStatus, connectionError),
+        connectionStatus === "error" ? "error" : connectionStatus === "connected" ? "success" : "info",
+      );
+    }
+    previousConnectionRef.current = connectionStatus;
+  }, [connectionStatus, connectionError, announce]);
+
+  useEffect(() => {
+    if (!latestError || lastErrorIdRef.current === latestError.id) return;
+    lastErrorIdRef.current = latestError.id;
+    announce(formatErrorAnnouncement(latestError.message), "error");
+  }, [latestError, announce]);
 
   const toggleIdentitySwitcher = useCallback(() => {
     setIdentitySwitcherOpen((prev) => !prev);
@@ -247,6 +285,7 @@ export function App(): React.ReactNode {
       <HelpOverlay visible={helpOpen} panel={activePanel} onDismiss={() => setHelpOpen(false)} />
 
       {/* Error bar + Status bar */}
+      <AnnouncementBar />
       <ErrorBar />
       <StatusBar />
     </box>

--- a/packages/nexus-tui/src/app.tsx
+++ b/packages/nexus-tui/src/app.tsx
@@ -176,8 +176,15 @@ export function App(): React.ReactNode {
   useEffect(() => {
     if (!latestError || lastErrorIdRef.current === latestError.id) return;
     lastErrorIdRef.current = latestError.id;
+    if (
+      latestError.source === "global"
+      && connectionStatus === "error"
+      && latestError.message === connectionError
+    ) {
+      return;
+    }
     announce(formatErrorAnnouncement(latestError.message), "error");
-  }, [latestError, announce]);
+  }, [latestError, connectionStatus, connectionError, announce]);
 
   const toggleIdentitySwitcher = useCallback(() => {
     setIdentitySwitcherOpen((prev) => !prev);

--- a/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
+++ b/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
@@ -17,7 +17,7 @@
  * @see Issue #3102 — TUI rendering & data-fetching performance
  */
 
-import React, { useState, useCallback, useEffect, useMemo } from "react";
+import React, { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import {
   useFilesStore,
   type FileItem,
@@ -52,7 +52,13 @@ import { subTabCycleBindings } from "../../shared/components/sub-tab-bar-utils.j
 import { useTabFallback } from "../../shared/hooks/use-tab-fallback.js";
 import { useKnowledgeStore } from "../../stores/knowledge-store.js";
 import { useUiStore } from "../../stores/ui-store.js";
+import { useAnnouncementStore } from "../../stores/announcement-store.js";
 import { focusColor, statusColor } from "../../shared/theme.js";
+import {
+  formatDirectoryAnnouncement,
+  formatSelectionAnnouncement,
+  formatSuccessAnnouncement,
+} from "../../shared/accessibility-announcements.js";
 import crypto from "node:crypto";
 
 // =============================================================================
@@ -551,6 +557,7 @@ export default function FileExplorerPanel(): React.ReactNode {
   const clearClipboard = useFilesStore((s) => s.clearClipboard);
   const pasteFiles = useFilesStore((s) => s.pasteFiles);
   const pasteProgress = useFilesStore((s) => s.pasteProgress);
+  const announce = useAnnouncementStore((s) => s.announce);
 
   // Share link store
   const shareLinks = useShareLinkStore((s) => s.links);
@@ -590,6 +597,10 @@ export default function FileExplorerPanel(): React.ReactNode {
 
   const selectedNode = visibleNodes[selectedIndex] ?? null;
   const isSentinel = selectedNode?.path.endsWith(LOAD_MORE_SENTINEL) ?? false;
+  const currentTreeNode = treeNodes.get(currentPath);
+  const lastDirectoryAnnouncementRef = useRef<string | null>(null);
+  const lastSelectionAnnouncementRef = useRef<string | null>(null);
+  const lastPasteAnnouncementRef = useRef<string | null>(null);
 
   // For metadata/actions, look up FileItem from parent's file cache first,
   // then fall back to constructing a minimal FileItem from the tree node.
@@ -620,6 +631,46 @@ export default function FileExplorerPanel(): React.ReactNode {
   const visibleNodeCount = visibleNodes.length;
   // Keep cachedFiles for backward compat with BindingContext (selection uses it)
   const cachedFiles = fileCacheRevision >= 0 ? (getCachedFiles(currentPath) ?? []) : [];
+
+  useEffect(() => {
+    lastSelectionAnnouncementRef.current = null;
+  }, [currentPath]);
+
+  useEffect(() => {
+    if (!currentTreeNode || currentTreeNode.loading) return;
+    const key = `${currentPath}:${cachedFiles.length}:${fileCacheRevision}`;
+    if (lastDirectoryAnnouncementRef.current === key) return;
+    lastDirectoryAnnouncementRef.current = key;
+    announce(formatDirectoryAnnouncement(currentPath, cachedFiles.length));
+  }, [currentTreeNode, currentPath, cachedFiles.length, fileCacheRevision, announce]);
+
+  useEffect(() => {
+    if (!selectedNode || isSentinel) return;
+    if (lastSelectionAnnouncementRef.current === null) {
+      lastSelectionAnnouncementRef.current = selectedNode.path;
+      return;
+    }
+    if (lastSelectionAnnouncementRef.current === selectedNode.path) return;
+    lastSelectionAnnouncementRef.current = selectedNode.path;
+    announce(formatSelectionAnnouncement(selectedNode.name, selectedNode.isDirectory));
+  }, [selectedNode, isSentinel, announce]);
+
+  useEffect(() => {
+    if (!pasteProgress) return;
+    const completed = pasteProgress.completed + pasteProgress.failed;
+    if (completed < pasteProgress.total) return;
+    const key = `${pasteProgress.total}:${pasteProgress.completed}:${pasteProgress.failed}`;
+    if (lastPasteAnnouncementRef.current === key) return;
+    lastPasteAnnouncementRef.current = key;
+    announce(
+      formatSuccessAnnouncement(
+        pasteProgress.failed > 0
+          ? `Paste complete: ${pasteProgress.completed} succeeded, ${pasteProgress.failed} failed`
+          : `Paste complete: ${pasteProgress.completed} items`,
+      ),
+      pasteProgress.failed > 0 ? "error" : "success",
+    );
+  }, [pasteProgress, announce]);
 
   // Aspect count badge
   const aspectsCache = useKnowledgeStore((s) => s.aspectsCache);

--- a/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
+++ b/packages/nexus-tui/src/panels/files/file-explorer-panel.tsx
@@ -637,6 +637,12 @@ export default function FileExplorerPanel(): React.ReactNode {
   }, [currentPath]);
 
   useEffect(() => {
+    if (pasteProgress === null) {
+      lastPasteAnnouncementRef.current = null;
+    }
+  }, [pasteProgress]);
+
+  useEffect(() => {
     if (!currentTreeNode || currentTreeNode.loading) return;
     const key = `${currentPath}:${cachedFiles.length}:${fileCacheRevision}`;
     if (lastDirectoryAnnouncementRef.current === key) return;
@@ -659,7 +665,7 @@ export default function FileExplorerPanel(): React.ReactNode {
     if (!pasteProgress) return;
     const completed = pasteProgress.completed + pasteProgress.failed;
     if (completed < pasteProgress.total) return;
-    const key = `${pasteProgress.total}:${pasteProgress.completed}:${pasteProgress.failed}`;
+    const key = `${pasteProgress.total}:${pasteProgress.completed}:${pasteProgress.failed}:${clipboard?.operation ?? "none"}`;
     if (lastPasteAnnouncementRef.current === key) return;
     lastPasteAnnouncementRef.current = key;
     announce(
@@ -670,7 +676,7 @@ export default function FileExplorerPanel(): React.ReactNode {
       ),
       pasteProgress.failed > 0 ? "error" : "success",
     );
-  }, [pasteProgress, announce]);
+  }, [pasteProgress, clipboard?.operation, announce]);
 
   // Aspect count badge
   const aspectsCache = useKnowledgeStore((s) => s.aspectsCache);

--- a/packages/nexus-tui/src/shared/accessibility-announcements.ts
+++ b/packages/nexus-tui/src/shared/accessibility-announcements.ts
@@ -1,0 +1,44 @@
+import type { ConnectionStatus } from "../stores/global-store.js";
+
+export type AnnouncementLevel = "info" | "success" | "error";
+
+export function normalizeAnnouncementMessage(message: string): string {
+  return message.replace(/\s+/g, " ").trim();
+}
+
+export function formatPanelAnnouncement(label: string): string {
+  return normalizeAnnouncementMessage(`Panel ${label}`);
+}
+
+export function formatConnectionAnnouncement(
+  status: ConnectionStatus,
+  error?: string | null,
+): string {
+  switch (status) {
+    case "connected":
+      return "Connected";
+    case "connecting":
+      return "Connecting";
+    case "disconnected":
+      return "Disconnected";
+    case "error":
+      return normalizeAnnouncementMessage(`Connection error${error ? `: ${error}` : ""}`);
+  }
+}
+
+export function formatDirectoryAnnouncement(path: string, count: number): string {
+  const noun = count === 1 ? "item" : "items";
+  return normalizeAnnouncementMessage(`${count} ${noun} in ${path}`);
+}
+
+export function formatSelectionAnnouncement(name: string, isDirectory: boolean): string {
+  return normalizeAnnouncementMessage(`Selected ${isDirectory ? "folder" : "file"} ${name}`);
+}
+
+export function formatErrorAnnouncement(message: string): string {
+  return normalizeAnnouncementMessage(`Error: ${message}`);
+}
+
+export function formatSuccessAnnouncement(message: string): string {
+  return normalizeAnnouncementMessage(message);
+}

--- a/packages/nexus-tui/src/shared/components/announcement-bar.tsx
+++ b/packages/nexus-tui/src/shared/components/announcement-bar.tsx
@@ -1,0 +1,30 @@
+import React, { useEffect } from "react";
+import { useAnnouncementStore } from "../../stores/announcement-store.js";
+import { palette, statusColor } from "../theme.js";
+
+const ANNOUNCEMENT_COLORS = {
+  info: palette.faint,
+  success: statusColor.healthy,
+  error: palette.error,
+} as const;
+
+export function AnnouncementBar(): React.ReactNode {
+  const message = useAnnouncementStore((s) => s.message);
+  const level = useAnnouncementStore((s) => s.level);
+  const sequence = useAnnouncementStore((s) => s.sequence);
+  const clear = useAnnouncementStore((s) => s.clear);
+
+  useEffect(() => {
+    if (!message) return;
+    const timer = setTimeout(() => clear(), 4000);
+    return () => clearTimeout(timer);
+  }, [message, sequence, clear]);
+
+  if (!message) return null;
+
+  return (
+    <box height={1} width="100%">
+      <text foregroundColor={ANNOUNCEMENT_COLORS[level]}>{message}</text>
+    </box>
+  );
+}

--- a/packages/nexus-tui/src/shared/components/announcement-bar.tsx
+++ b/packages/nexus-tui/src/shared/components/announcement-bar.tsx
@@ -20,11 +20,11 @@ export function AnnouncementBar(): React.ReactNode {
     return () => clearTimeout(timer);
   }, [message, sequence, clear]);
 
-  if (!message) return null;
-
   return (
     <box height={1} width="100%">
-      <text foregroundColor={ANNOUNCEMENT_COLORS[level]}>{message}</text>
+      {message
+        ? <text foregroundColor={ANNOUNCEMENT_COLORS[level]}>{message}</text>
+        : <text> </text>}
     </box>
   );
 }

--- a/packages/nexus-tui/src/shared/hooks/use-copy.ts
+++ b/packages/nexus-tui/src/shared/hooks/use-copy.ts
@@ -4,10 +4,13 @@
  */
 import { useState, useCallback, useRef, useEffect } from "react";
 import { copyToClipboard } from "../lib/clipboard.js";
+import { useAnnouncementStore } from "../../stores/announcement-store.js";
+import { formatSuccessAnnouncement } from "../accessibility-announcements.js";
 
 export function useCopy() {
   const [copied, setCopied] = useState(false);
   const timerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const announce = useAnnouncementStore((s) => s.announce);
 
   // Cleanup on unmount
   useEffect(() => {
@@ -18,10 +21,11 @@ export function useCopy() {
 
   const copy = useCallback((text: string) => {
     copyToClipboard(text);
+    announce(formatSuccessAnnouncement("Copied to clipboard"), "success");
     setCopied(true);
     if (timerRef.current) clearTimeout(timerRef.current);
     timerRef.current = setTimeout(() => setCopied(false), 1500);
-  }, []);
+  }, [announce]);
 
   return { copy, copied };
 }

--- a/packages/nexus-tui/src/stores/announcement-store.ts
+++ b/packages/nexus-tui/src/stores/announcement-store.ts
@@ -1,0 +1,46 @@
+import { create } from "zustand";
+import {
+  normalizeAnnouncementMessage,
+  type AnnouncementLevel,
+} from "../shared/accessibility-announcements.js";
+
+export interface AnnouncementState {
+  readonly message: string | null;
+  readonly level: AnnouncementLevel;
+  readonly sequence: number;
+  readonly announce: (message: string, level?: AnnouncementLevel) => void;
+  readonly clear: () => void;
+}
+
+function emitAnnouncementToStderr(message: string): void {
+  if (process.env.NEXUS_TUI_SCREEN_READER_STDERR !== "1") return;
+  try {
+    process.stderr.write(`${message}\n`);
+  } catch {
+    // Best-effort transport only.
+  }
+}
+
+export const useAnnouncementStore = create<AnnouncementState>((set) => ({
+  message: null,
+  level: "info",
+  sequence: 0,
+
+  announce: (message, level = "info") => {
+    const normalized = normalizeAnnouncementMessage(message);
+    if (!normalized) return;
+    emitAnnouncementToStderr(normalized);
+    set((state) => ({
+      message: normalized,
+      level,
+      sequence: state.sequence + 1,
+    }));
+  },
+
+  clear: () => {
+    set((state) => ({
+      ...state,
+      message: null,
+    }));
+  },
+}));

--- a/packages/nexus-tui/tests/shared/accessibility-announcements.test.ts
+++ b/packages/nexus-tui/tests/shared/accessibility-announcements.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from "bun:test";
+import {
+  formatConnectionAnnouncement,
+  formatDirectoryAnnouncement,
+  formatErrorAnnouncement,
+  formatPanelAnnouncement,
+  formatSelectionAnnouncement,
+  normalizeAnnouncementMessage,
+} from "../../src/shared/accessibility-announcements.js";
+
+describe("accessibility announcements", () => {
+  it("normalizes whitespace", () => {
+    expect(normalizeAnnouncementMessage("  one\n two\t three  ")).toBe("one two three");
+  });
+
+  it("formats panel announcements", () => {
+    expect(formatPanelAnnouncement("Files")).toBe("Panel Files");
+  });
+
+  it("formats connection status announcements", () => {
+    expect(formatConnectionAnnouncement("connected")).toBe("Connected");
+    expect(formatConnectionAnnouncement("error", "Server health check failed")).toBe(
+      "Connection error: Server health check failed",
+    );
+  });
+
+  it("formats directory load announcements", () => {
+    expect(formatDirectoryAnnouncement("/workspace", 1)).toBe("1 item in /workspace");
+    expect(formatDirectoryAnnouncement("/workspace", 12)).toBe("12 items in /workspace");
+  });
+
+  it("formats selection announcements", () => {
+    expect(formatSelectionAnnouncement("src", true)).toBe("Selected folder src");
+    expect(formatSelectionAnnouncement("README.md", false)).toBe("Selected file README.md");
+  });
+
+  it("formats error announcements", () => {
+    expect(formatErrorAnnouncement("No API key")).toBe("Error: No API key");
+  });
+});

--- a/packages/nexus-tui/tests/stores/announcement-store.test.ts
+++ b/packages/nexus-tui/tests/stores/announcement-store.test.ts
@@ -1,0 +1,49 @@
+import { afterEach, beforeEach, describe, expect, it, mock } from "bun:test";
+import { useAnnouncementStore } from "../../src/stores/announcement-store.js";
+
+describe("announcement-store", () => {
+  const originalEnv = process.env.NEXUS_TUI_SCREEN_READER_STDERR;
+  const originalWrite = process.stderr.write.bind(process.stderr);
+
+  beforeEach(() => {
+    useAnnouncementStore.setState({
+      message: null,
+      level: "info",
+      sequence: 0,
+    });
+    delete process.env.NEXUS_TUI_SCREEN_READER_STDERR;
+  });
+
+  afterEach(() => {
+    process.env.NEXUS_TUI_SCREEN_READER_STDERR = originalEnv;
+    process.stderr.write = originalWrite;
+  });
+
+  it("stores the latest announcement", () => {
+    useAnnouncementStore.getState().announce(" Connected  ");
+
+    const state = useAnnouncementStore.getState();
+    expect(state.message).toBe("Connected");
+    expect(state.level).toBe("info");
+    expect(state.sequence).toBe(1);
+  });
+
+  it("clears the current announcement", () => {
+    useAnnouncementStore.getState().announce("Copied to clipboard", "success");
+    useAnnouncementStore.getState().clear();
+
+    const state = useAnnouncementStore.getState();
+    expect(state.message).toBeNull();
+    expect(state.level).toBe("success");
+  });
+
+  it("mirrors announcements to stderr when enabled", () => {
+    const write = mock(() => true);
+    process.env.NEXUS_TUI_SCREEN_READER_STDERR = "1";
+    process.stderr.write = write as typeof process.stderr.write;
+
+    useAnnouncementStore.getState().announce("Panel Files");
+
+    expect(write).toHaveBeenCalledWith("Panel Files\n");
+  });
+});


### PR DESCRIPTION
## Summary
- add a centralized TUI announcement store and ephemeral announcement bar
- announce panel switches, connection/error changes, file list loads, file selection changes, clipboard copy, and paste completion
- add focused tests for announcement formatting and store behavior

## Testing
- bun test packages/nexus-tui/tests/shared/accessibility-announcements.test.ts packages/nexus-tui/tests/stores/announcement-store.test.ts

Closes #3249