### PR TITLE
release: nexus-ai-fs v0.9.18, nexus-fs v0.2.0, @nexus/tui v0.9.18

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,13 @@ Give every agent one place to read, write, search, remember, and collaborate —
 
 [![CI](https://github.com/nexi-lab/nexus/actions/workflows/test.yml/badge.svg)](https://github.com/nexi-lab/nexus/actions/workflows/test.yml)
 [![PyPI](https://img.shields.io/pypi/v/nexus-ai-fs?color=blue)](https://pypi.org/project/nexus-ai-fs/)
+[![nexus-fs](https://img.shields.io/pypi/v/nexus-fs?label=nexus-fs&color=blue)](https://pypi.org/project/nexus-fs/)
+[![@nexus/tui](https://img.shields.io/npm/v/@nexus/tui?label=@nexus/tui&color=blue)](https://www.npmjs.com/package/@nexus/tui)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-Apache_2.0-blue)](LICENSE)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/nexus)
 
-[Documentation](https://nexi-lab.github.io/nexus/) · [Quickstart](https://nexi-lab.github.io/nexus/getting-started/quickstart/) · [Examples](examples/) · [PyPI](https://pypi.org/project/nexus-ai-fs/) · [Roadmap](https://github.com/nexi-lab/nexus/issues)
+[Documentation](https://nexi-lab.github.io/nexus/) · [Quickstart](https://nexi-lab.github.io/nexus/getting-started/quickstart/) · [Examples](examples/) · [PyPI](https://pypi.org/project/nexus-ai-fs/) · [nexus-fs](https://pypi.org/project/nexus-fs/) · [TUI](https://www.npmjs.com/package/@nexus/tui) · [Roadmap](https://github.com/nexi-lab/nexus/issues)
 
 </div>
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,4 +36,6 @@ Read the design docs before changing the storage model, service boundaries, or d
 
 - GitHub: <https://github.com/nexi-lab/nexus>
 - PyPI: <https://pypi.org/project/nexus-ai-fs/>
+- nexus-fs (slim): <https://pypi.org/project/nexus-fs/>
+- @nexus/tui (Terminal UI): <https://www.npmjs.com/package/@nexus/tui>
 - Examples: <https://github.com/nexi-lab/nexus/tree/main/examples>

--- a/packages/nexus-fs/pyproject.toml
+++ b/packages/nexus-fs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nexus-fs"
-version = "0.1.0"
+version = "0.2.0"
 description = "Unified filesystem abstraction for cloud storage — mount S3, GCS, and local storage with two lines of Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus/tui",
-  "version": "0.9.17",
+  "version": "0.9.18",
   "description": "Terminal UI for Nexus — file explorer, API inspector, and monitoring dashboard",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.17"
+version = "0.9.18"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/nexus_pyo3/Cargo.toml
+++ b/rust/nexus_pyo3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus_pyo3"
-version = "0.9.17"
+version = "0.9.18"
 edition = "2021"
 
 [lib]

--- a/rust/nexus_pyo3/pyproject.toml
+++ b/rust/nexus_pyo3/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-fast"
-version = "0.9.17"
+version = "0.9.18"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
 requires-python = ">=3.12"
 classifiers = [

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -48,7 +48,7 @@ import logging
 import os as _os
 from typing import TYPE_CHECKING, Any, cast
 
-__version__ = "0.9.16"  # release version
+__version__ = "0.9.18"  # release version
 __author__ = "Nexi Lab Team"
 __license__ = "Apache-2.0"
 

--- a/src/nexus/fs/__init__.py
+++ b/src/nexus/fs/__init__.py
@@ -17,7 +17,7 @@ All imports are lazy to keep ``import nexus.fs`` under 200ms.
 
 from __future__ import annotations
 
-__version__ = "0.1.0"
+__version__ = "0.2.0"
 
 # =============================================================================
 # LAZY IMPORTS — everything is deferred for <200ms import time


### PR DESCRIPTION
## Summary
- Bump **nexus-ai-fs** to v0.9.18 (pyproject.toml + `src/nexus/__init__.py` which was stale at 0.9.16)
- Bump **nexus-fs** to v0.2.0 (pyproject.toml + `src/nexus/fs/__init__.py`)
- Bump **@nexus/tui** to v0.9.18 (package.json)
- Add PyPI badge for `nexus-fs` and npm badge for `@nexus/tui` to README front page
- Add `nexus-fs` and `@nexus/tui` links to docs index

## Note
`rust/nexus_pyo3` (pyproject.toml + Cargo.toml) and `packages/nexus-api-client/package.json` remain at 0.9.17 — bump separately if needed.

## Test plan
- [ ] Verify badges render correctly on GitHub README
- [ ] Verify PyPI publish for nexus-ai-fs 0.9.18 and nexus-fs 0.2.0
- [ ] Verify npm publish for @nexus/tui 0.9.18