### PR TITLE
fix: bump @nexus/api-client to 0.9.18

### DIFF
--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus/api-client",
-  "version": "0.9.17",
+  "version": "0.9.18",
   "description": "Shared HTTP client for Nexus APIs — retry, auth, error mapping, case transform",
   "type": "module",
   "main": "./dist/index.cjs",


### PR DESCRIPTION
## Summary
- Bump `@nexus/api-client` from 0.9.17 to 0.9.18 to match the release tag

Release CI requires all packages (nexus-ai-fs, nexus_pyo3, @nexus/api-client, @nexus/tui) to match the tag version. This was missed in #3599.

## Test plan
- [ ] CI passes
- [ ] Re-tag v0.9.18 after merge and verify release pipeline succeeds