### PR TITLE
fix: rename npm scope from @nexus to @nexus-ai-fs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -375,12 +375,12 @@ jobs:
           npm run build
           npm test
 
-      - name: Publish @nexus/api-client
+      - name: Publish @nexus-ai-fs/api-client
         if: ${{ env.NODE_AUTH_TOKEN != '' }}
         run: |
           VERSION="$(node -p "require('./packages/nexus-api-client/package.json').version")"
-          if npm view "@nexus/api-client@${VERSION}" version >/dev/null 2>&1; then
-            echo "@nexus/api-client@${VERSION} already published"
+          if npm view "@nexus-ai-fs/api-client@${VERSION}" version >/dev/null 2>&1; then
+            echo "@nexus-ai-fs/api-client@${VERSION} already published"
           else
             cd packages/nexus-api-client
             npm publish --access public
@@ -401,16 +401,16 @@ jobs:
           const fs = require("fs");
           const path = "packages/nexus-tui/package.json";
           const pkg = JSON.parse(fs.readFileSync(path, "utf8"));
-          pkg.dependencies["@nexus/api-client"] = `^${process.env.API_VERSION}`;
+          pkg.dependencies["@nexus-ai-fs/api-client"] = `^${process.env.API_VERSION}`;
           fs.writeFileSync(path, JSON.stringify(pkg, null, 2) + "\n");
           EOF
 
-      - name: Publish @nexus/tui
+      - name: Publish @nexus-ai-fs/tui
         if: ${{ env.NODE_AUTH_TOKEN != '' }}
         run: |
           VERSION="$(node -p "require('./packages/nexus-tui/package.json').version")"
-          if npm view "@nexus/tui@${VERSION}" version >/dev/null 2>&1; then
-            echo "@nexus/tui@${VERSION} already published"
+          if npm view "@nexus-ai-fs/tui@${VERSION}" version >/dev/null 2>&1; then
+            echo "@nexus-ai-fs/tui@${VERSION} already published"
           else
             cd packages/nexus-tui
             npm publish --access public

--- a/.github/workflows/ts-packages.yml
+++ b/.github/workflows/ts-packages.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   api-client:
-    name: "@nexus/api-client"
+    name: "@nexus-ai-fs/api-client"
     runs-on: ubuntu-latest
     defaults:
       run:
@@ -29,7 +29,7 @@ jobs:
       - run: npm run test:coverage
 
   nexus-pay-ts:
-    name: "@nexus/pay"
+    name: "@nexus-ai-fs/pay"
     runs-on: ubuntu-latest
     needs: api-client
     defaults:
@@ -49,7 +49,7 @@ jobs:
       - run: npm run test:coverage
 
   nexus-tui:
-    name: "@nexus/tui"
+    name: "@nexus-ai-fs/tui"
     runs-on: ubuntu-latest
     needs: api-client
     defaults:

--- a/README.md
+++ b/README.md
@@ -13,12 +13,12 @@ Give every agent one place to read, write, search, remember, and collaborate —
 [![CI](https://github.com/nexi-lab/nexus/actions/workflows/test.yml/badge.svg)](https://github.com/nexi-lab/nexus/actions/workflows/test.yml)
 [![PyPI](https://img.shields.io/pypi/v/nexus-ai-fs?color=blue)](https://pypi.org/project/nexus-ai-fs/)
 [![nexus-fs](https://img.shields.io/pypi/v/nexus-fs?label=nexus-fs&color=blue)](https://pypi.org/project/nexus-fs/)
-[![@nexus/tui](https://img.shields.io/npm/v/@nexus/tui?label=@nexus/tui&color=blue)](https://www.npmjs.com/package/@nexus/tui)
+[![@nexus-ai-fs/tui](https://img.shields.io/npm/v/@nexus-ai-fs/tui?label=@nexus-ai-fs/tui&color=blue)](https://www.npmjs.com/package/@nexus-ai-fs/tui)
 [![Python 3.12+](https://img.shields.io/badge/python-3.12+-3776AB?logo=python&logoColor=white)](https://www.python.org/downloads/)
 [![License](https://img.shields.io/badge/license-Apache_2.0-blue)](LICENSE)
 [![Discord](https://img.shields.io/badge/Discord-community-5865F2?logo=discord&logoColor=white)](https://discord.gg/nexus)
 
-[Documentation](https://nexi-lab.github.io/nexus/) · [Quickstart](https://nexi-lab.github.io/nexus/getting-started/quickstart/) · [Examples](examples/) · [PyPI](https://pypi.org/project/nexus-ai-fs/) · [nexus-fs](https://pypi.org/project/nexus-fs/) · [TUI](https://www.npmjs.com/package/@nexus/tui) · [Roadmap](https://github.com/nexi-lab/nexus/issues)
+[Documentation](https://nexi-lab.github.io/nexus/) · [Quickstart](https://nexi-lab.github.io/nexus/getting-started/quickstart/) · [Examples](examples/) · [PyPI](https://pypi.org/project/nexus-ai-fs/) · [nexus-fs](https://pypi.org/project/nexus-fs/) · [TUI](https://www.npmjs.com/package/@nexus-ai-fs/tui) · [Roadmap](https://github.com/nexi-lab/nexus/issues)
 
 </div>
 
@@ -101,8 +101,8 @@ nexus versions history /hello.txt
 The TUI is a separate TypeScript package built on OpenTUI:
 
 ```bash
-bunx @nexus/tui                                        # published package, connects to localhost:2026
-bunx @nexus/tui --url http://remote:2026 --api-key KEY # connect to remote instance
+bunx @nexus-ai-fs/tui                                        # published package, connects to localhost:2026
+bunx @nexus-ai-fs/tui --url http://remote:2026 --api-key KEY # connect to remote instance
 cd packages/nexus-api-client && npm install && npm run build && cd -  # build sibling dependency once in a fresh checkout
 cd packages/nexus-tui && bun install && bun run src/index.tsx          # local development from this repo
 ```

--- a/docs/index.md
+++ b/docs/index.md
@@ -37,5 +37,5 @@ Read the design docs before changing the storage model, service boundaries, or d
 - GitHub: <https://github.com/nexi-lab/nexus>
 - PyPI: <https://pypi.org/project/nexus-ai-fs/>
 - nexus-fs (slim): <https://pypi.org/project/nexus-fs/>
-- @nexus/tui (Terminal UI): <https://www.npmjs.com/package/@nexus/tui>
+- @nexus-ai-fs/tui (Terminal UI): <https://www.npmjs.com/package/@nexus-ai-fs/tui>
 - Examples: <https://github.com/nexi-lab/nexus/tree/main/examples>

--- a/packages/nexus-api-client/README.md
+++ b/packages/nexus-api-client/README.md
@@ -1,4 +1,4 @@
-# @nexus/api-client
+# @nexus-ai-fs/api-client
 
 Shared HTTP client for Nexus APIs.
 

--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nexus/api-client",
+  "name": "@nexus-ai-fs/api-client",
   "version": "0.9.18",
   "description": "Shared HTTP client for Nexus APIs — retry, auth, error mapping, case transform",
   "type": "module",

--- a/packages/nexus-api-client/src/index.ts
+++ b/packages/nexus-api-client/src/index.ts
@@ -1,9 +1,9 @@
 /**
- * @nexus/api-client — Shared HTTP client for Nexus APIs.
+ * @nexus-ai-fs/api-client — Shared HTTP client for Nexus APIs.
  *
  * @example
  * ```typescript
- * import { FetchClient, resolveConfig } from '@nexus/api-client';
+ * import { FetchClient, resolveConfig } from '@nexus-ai-fs/api-client';
  *
  * const config = resolveConfig({ apiKey: 'nx_live_myagent' });
  * const client = new FetchClient(config);

--- a/packages/nexus-pay-ts/README.md
+++ b/packages/nexus-pay-ts/README.md
@@ -1,4 +1,4 @@
-# @nexus/pay
+# @nexus-ai-fs/pay
 
 TypeScript SDK for Nexus Pay — agent payment API.
 
@@ -7,13 +7,13 @@ Zero dependencies. Works in Node.js 18+, browsers, Deno, Bun, and edge runtimes.
 ## Install
 
 ```bash
-npm install @nexus/pay
+npm install @nexus-ai-fs/pay
 ```
 
 ## Quick Start
 
 ```typescript
-import { NexusPay } from '@nexus/pay';
+import { NexusPay } from '@nexus-ai-fs/pay';
 
 const pay = new NexusPay({ apiKey: 'nx_live_myagent' });
 
@@ -64,7 +64,7 @@ All amounts are `string` type to prevent floating-point precision loss.
 ## Error Handling
 
 ```typescript
-import { NexusPay, InsufficientCreditsError, NexusPayError } from '@nexus/pay';
+import { NexusPay, InsufficientCreditsError, NexusPayError } from '@nexus-ai-fs/pay';
 
 try {
   await pay.transfer({ to: 'agent-bob', amount: '9999.00' });

--- a/packages/nexus-pay-ts/package.json
+++ b/packages/nexus-pay-ts/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nexus/pay",
+  "name": "@nexus-ai-fs/pay",
   "version": "0.1.0",
   "description": "TypeScript SDK for Nexus Pay — agent payment API",
   "type": "module",
@@ -35,7 +35,7 @@
     "node": ">=18"
   },
   "dependencies": {
-    "@nexus/api-client": "file:../nexus-api-client"
+    "@nexus-ai-fs/api-client": "file:../nexus-api-client"
   },
   "devDependencies": {
     "tsup": "^8.0.0",

--- a/packages/nexus-pay-ts/src/client.ts
+++ b/packages/nexus-pay-ts/src/client.ts
@@ -6,7 +6,7 @@
  *
  * @example
  * ```typescript
- * import { NexusPay } from '@nexus/pay';
+ * import { NexusPay } from '@nexus-ai-fs/pay';
  *
  * const pay = new NexusPay({ apiKey: 'sk-your-api-key' });
  * const balance = await pay.getBalance();

--- a/packages/nexus-pay-ts/src/errors.ts
+++ b/packages/nexus-pay-ts/src/errors.ts
@@ -1,11 +1,11 @@
 /**
  * Error classes for the Nexus Pay SDK.
  *
- * Extends the shared NexusApiError base from @nexus/api-client
+ * Extends the shared NexusApiError base from @nexus-ai-fs/api-client
  * with payment-specific error types.
  *
  * Hierarchy:
- *   NexusApiError (from @nexus/api-client)
+ *   NexusApiError (from @nexus-ai-fs/api-client)
  *   └── NexusPayError (base for pay-specific errors)
  *       ├── InsufficientCreditsError (402)
  *       ├── BudgetExceededError      (403)
@@ -13,10 +13,10 @@
  *       └── ReservationError         (409)
  *
  * Note: AuthenticationError (401) and RateLimitError (429) are
- * re-exported from @nexus/api-client — no pay-specific override needed.
+ * re-exported from @nexus-ai-fs/api-client — no pay-specific override needed.
  */
 
-import { NexusApiError } from "@nexus/api-client";
+import { NexusApiError } from "@nexus-ai-fs/api-client";
 
 export class NexusPayError extends NexusApiError {
   constructor(message: string, status: number, code: string) {
@@ -54,4 +54,4 @@ export class ReservationError extends NexusPayError {
 }
 
 // Re-export shared errors for backward compatibility
-export { AuthenticationError, RateLimitError } from "@nexus/api-client";
+export { AuthenticationError, RateLimitError } from "@nexus-ai-fs/api-client";

--- a/packages/nexus-pay-ts/src/fetch-client.ts
+++ b/packages/nexus-pay-ts/src/fetch-client.ts
@@ -1,13 +1,13 @@
 /**
  * Internal HTTP client for the Nexus Pay SDK.
  *
- * Thin wrapper around @nexus/api-client's FetchClient that overrides
+ * Thin wrapper around @nexus-ai-fs/api-client's FetchClient that overrides
  * error mapping to produce pay-specific error types (402, 403, 404, 409).
  *
  * Not exported from the public API — used only by the NexusPay client class.
  */
 
-import { FetchClient as BaseFetchClient, type NexusApiError } from "@nexus/api-client";
+import { FetchClient as BaseFetchClient, type NexusApiError } from "@nexus-ai-fs/api-client";
 import {
   BudgetExceededError,
   InsufficientCreditsError,

--- a/packages/nexus-pay-ts/src/index.ts
+++ b/packages/nexus-pay-ts/src/index.ts
@@ -1,9 +1,9 @@
 /**
- * @nexus/pay — TypeScript SDK for Nexus Pay agent payments.
+ * @nexus-ai-fs/pay — TypeScript SDK for Nexus Pay agent payments.
  *
  * @example
  * ```typescript
- * import { NexusPay } from '@nexus/pay';
+ * import { NexusPay } from '@nexus-ai-fs/pay';
  *
  * const pay = new NexusPay({ apiKey: 'nx_live_myagent' });
  * const balance = await pay.getBalance();
@@ -16,7 +16,7 @@
 // Client
 export { NexusPay } from "./client.js";
 
-// Errors (pay-specific + re-exported from @nexus/api-client)
+// Errors (pay-specific + re-exported from @nexus-ai-fs/api-client)
 export {
   NexusPayError,
   InsufficientCreditsError,
@@ -28,7 +28,7 @@ export {
 } from "./errors.js";
 
 // Shared base error (for instanceof checks)
-export { NexusApiError } from "@nexus/api-client";
+export { NexusApiError } from "@nexus-ai-fs/api-client";
 
 // Types
 export type {

--- a/packages/nexus-pay-ts/src/types.ts
+++ b/packages/nexus-pay-ts/src/types.ts
@@ -5,7 +5,7 @@
  * This matches the REST API wire format (JSON string amounts).
  */
 
-import type { NexusClientOptions, RequestOptions as BaseRequestOptions } from "@nexus/api-client";
+import type { NexusClientOptions, RequestOptions as BaseRequestOptions } from "@nexus-ai-fs/api-client";
 
 // =============================================================================
 // SDK Configuration (extends shared client options)
@@ -13,13 +13,13 @@ import type { NexusClientOptions, RequestOptions as BaseRequestOptions } from "@
 
 /**
  * Options for creating a NexusPay client.
- * Extends NexusClientOptions from @nexus/api-client.
+ * Extends NexusClientOptions from @nexus-ai-fs/api-client.
  */
 export type NexusPayOptions = NexusClientOptions;
 
 /**
  * Per-request options.
- * Re-exported from @nexus/api-client for backward compatibility.
+ * Re-exported from @nexus-ai-fs/api-client for backward compatibility.
  */
 export type RequestOptions = BaseRequestOptions;
 

--- a/packages/nexus-pay-ts/tests/errors.test.ts
+++ b/packages/nexus-pay-ts/tests/errors.test.ts
@@ -8,7 +8,7 @@ import {
   ReservationError,
   RateLimitError,
 } from "../src/errors.js";
-import { NexusApiError } from "@nexus/api-client";
+import { NexusApiError } from "@nexus-ai-fs/api-client";
 
 describe("NexusPayError", () => {
   it("has correct name, message, status, and code", () => {

--- a/packages/nexus-pay-ts/tests/fetch-client.test.ts
+++ b/packages/nexus-pay-ts/tests/fetch-client.test.ts
@@ -9,7 +9,7 @@ import {
   ReservationError,
   WalletNotFoundError,
 } from "../src/errors.js";
-import { NexusApiError } from "@nexus/api-client";
+import { NexusApiError } from "@nexus-ai-fs/api-client";
 
 function jsonResponse(body: unknown, status = 200, headers?: Record<string, string>): Response {
   return new Response(JSON.stringify(body), {

--- a/packages/nexus-tui/README.md
+++ b/packages/nexus-tui/README.md
@@ -1,4 +1,4 @@
-# @nexus/tui
+# @nexus-ai-fs/tui
 
 Terminal UI for Nexus.
 
@@ -7,8 +7,8 @@ Terminal UI for Nexus.
 Run the published package with Bun:
 
 ```bash
-bunx @nexus/tui
-bunx @nexus/tui --url http://remote:2026 --api-key KEY
+bunx @nexus-ai-fs/tui
+bunx @nexus-ai-fs/tui --url http://remote:2026 --api-key KEY
 ```
 
 The installed binary name is:

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "@nexus/tui",
+  "name": "@nexus-ai-fs/tui",
   "version": "0.9.18",
   "description": "Terminal UI for Nexus — file explorer, API inspector, and monitoring dashboard",
   "type": "module",
@@ -18,7 +18,7 @@
     "clean": "rm -rf dist"
   },
   "dependencies": {
-    "@nexus/api-client": "file:../nexus-api-client",
+    "@nexus-ai-fs/api-client": "file:../nexus-api-client",
     "@opentui/core": "latest",
     "@opentui/react": "latest",
     "anser": "^2.3.5",

--- a/packages/nexus-tui/src/index.tsx
+++ b/packages/nexus-tui/src/index.tsx
@@ -5,14 +5,14 @@
  * Parses CLI args, resolves config, and renders the TUI via OpenTUI.
  *
  * Usage:
- *   bunx @nexus/tui
- *   bunx @nexus/tui --url http://remote:2026 --api-key nx_live_myagent
- *   bunx @nexus/tui --agent-id bot-worker-1 --zone-id org_acme
+ *   bunx @nexus-ai-fs/tui
+ *   bunx @nexus-ai-fs/tui --url http://remote:2026 --api-key nx_live_myagent
+ *   bunx @nexus-ai-fs/tui --agent-id bot-worker-1 --zone-id org_acme
  */
 
 import { createCliRenderer } from "@opentui/core";
 import { createRoot } from "@opentui/react";
-import { resolveConfig } from "@nexus/api-client";
+import { resolveConfig } from "@nexus-ai-fs/api-client";
 import { useGlobalStore } from "./stores/global-store.js";
 import { App } from "./app.js";
 
@@ -56,7 +56,7 @@ Usage:
   nexus-tui [options]
 
 Published package:
-  bunx @nexus/tui [options]
+  bunx @nexus-ai-fs/tui [options]
 
 Options:
   --url, -u <url>        Nexus server URL (default: NEXUS_URL or http://localhost:2026)

--- a/packages/nexus-tui/src/panels/access/namespace-config-view.tsx
+++ b/packages/nexus-tui/src/panels/access/namespace-config-view.tsx
@@ -16,7 +16,7 @@ import { useAccessStore } from "../../stores/access-store.js";
 import { useKeyboard } from "../../shared/hooks/use-keyboard.js";
 import { useApi } from "../../shared/hooks/use-api.js";
 import { statusColor } from "../../shared/theme.js";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 
 type EditField = "scopePrefix" | "addGrant" | "removeGrant" | "readonlyPath";
 

--- a/packages/nexus-tui/src/panels/connectors/available-tab.tsx
+++ b/packages/nexus-tui/src/panels/connectors/available-tab.tsx
@@ -11,7 +11,7 @@
  */
 
 import React, { useState, useEffect, useRef, useCallback } from "react";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { useConnectorsStore } from "../../stores/connectors-store.js";
 import { useGlobalStore } from "../../stores/global-store.js";
 import { useKeyboard } from "../../shared/hooks/use-keyboard.js";

--- a/packages/nexus-tui/src/panels/connectors/mounted-tab.tsx
+++ b/packages/nexus-tui/src/panels/connectors/mounted-tab.tsx
@@ -5,7 +5,7 @@
  */
 
 import React, { useEffect, useCallback } from "react";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { useConnectorsStore } from "../../stores/connectors-store.js";
 import { useConfirmStore } from "../../shared/hooks/use-confirm.js";
 import { useKeyboard } from "../../shared/hooks/use-keyboard.js";

--- a/packages/nexus-tui/src/panels/connectors/skills-tab.tsx
+++ b/packages/nexus-tui/src/panels/connectors/skills-tab.tsx
@@ -6,7 +6,7 @@
  */
 
 import React, { useEffect, useCallback } from "react";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { useConnectorsStore } from "../../stores/connectors-store.js";
 import { useKeyboard } from "../../shared/hooks/use-keyboard.js";
 import { useCopy } from "../../shared/hooks/use-copy.js";

--- a/packages/nexus-tui/src/panels/connectors/write-tab.tsx
+++ b/packages/nexus-tui/src/panels/connectors/write-tab.tsx
@@ -13,7 +13,7 @@
  */
 
 import React, { useState, useEffect, useCallback } from "react";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { useConnectorsStore } from "../../stores/connectors-store.js";
 import { useConfirmStore } from "../../shared/hooks/use-confirm.js";
 import { useKeyboard } from "../../shared/hooks/use-keyboard.js";

--- a/packages/nexus-tui/src/shared/components/pre-connection-screen.tsx
+++ b/packages/nexus-tui/src/shared/components/pre-connection-screen.tsx
@@ -17,7 +17,7 @@ import { executeLocalCommand, useCommandRunnerStore } from "../../services/comma
 import { CommandOutput } from "./command-output.js";
 import { Spinner } from "./spinner.js";
 import { statusColor } from "../theme.js";
-import { resolveConfig, FetchClient } from "@nexus/api-client";
+import { resolveConfig, FetchClient } from "@nexus-ai-fs/api-client";
 import { useFilesStore } from "../../stores/files-store.js";
 import { textStyle } from "../text-style.js";
 

--- a/packages/nexus-tui/src/shared/hooks/use-api.ts
+++ b/packages/nexus-tui/src/shared/hooks/use-api.ts
@@ -3,7 +3,7 @@
  */
 
 import { useGlobalStore } from "../../stores/global-store.js";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 
 export function useApi(): FetchClient | null {
   return useGlobalStore((state) => state.client);

--- a/packages/nexus-tui/src/shared/hooks/use-connection-state.ts
+++ b/packages/nexus-tui/src/shared/hooks/use-connection-state.ts
@@ -5,7 +5,7 @@
  */
 
 import type { ConnectionStatus } from "../../stores/global-store.js";
-import type { NexusClientOptions } from "@nexus/api-client";
+import type { NexusClientOptions } from "@nexus-ai-fs/api-client";
 
 /**
  * Describes why the TUI cannot connect, guiding the PreConnectionScreen UI.

--- a/packages/nexus-tui/src/stores/access-store.ts
+++ b/packages/nexus-tui/src/stores/access-store.ts
@@ -5,7 +5,7 @@
  */
 
 import { create } from "zustand";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { createApiAction, categorizeError } from "./create-api-action.js";
 import { useErrorStore } from "./error-store.js";
 export type { DelegationItem } from "./delegation-store.js";

--- a/packages/nexus-tui/src/stores/agents-store.ts
+++ b/packages/nexus-tui/src/stores/agents-store.ts
@@ -3,7 +3,7 @@
  */
 
 import { create } from "zustand";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { createApiAction, categorizeError } from "./create-api-action.js";
 import { useErrorStore } from "./error-store.js";
 import { useUiStore } from "./ui-store.js";

--- a/packages/nexus-tui/src/stores/api-console-store.ts
+++ b/packages/nexus-tui/src/stores/api-console-store.ts
@@ -3,7 +3,7 @@
  */
 
 import { create } from "zustand";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { categorizeError } from "./create-api-action.js";
 import { useErrorStore } from "./error-store.js";
 import { useUiStore } from "./ui-store.js";

--- a/packages/nexus-tui/src/stores/connectors-store.ts
+++ b/packages/nexus-tui/src/stores/connectors-store.ts
@@ -6,7 +6,7 @@
 
 import { create } from "zustand";
 import { createApiAction } from "./create-api-action.js";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { useUiStore } from "./ui-store.js";
 
 // =============================================================================

--- a/packages/nexus-tui/src/stores/create-api-action.ts
+++ b/packages/nexus-tui/src/stores/create-api-action.ts
@@ -6,7 +6,7 @@
  * error store integration (Decision 8A).
  */
 
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { useErrorStore, type ErrorCategory } from "./error-store.js";
 import { useUiStore } from "./ui-store.js";
 import type { PanelId } from "./global-store.js";

--- a/packages/nexus-tui/src/stores/delegation-store.ts
+++ b/packages/nexus-tui/src/stores/delegation-store.ts
@@ -6,7 +6,7 @@
  */
 
 import { create } from "zustand";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { createApiAction, categorizeError } from "./create-api-action.js";
 import { useErrorStore } from "./error-store.js";
 

--- a/packages/nexus-tui/src/stores/events-store.ts
+++ b/packages/nexus-tui/src/stores/events-store.ts
@@ -3,8 +3,8 @@
  */
 
 import { create } from "zustand";
-import type { SseEvent } from "@nexus/api-client";
-import { SseClient } from "@nexus/api-client";
+import type { SseEvent } from "@nexus-ai-fs/api-client";
+import { SseClient } from "@nexus-ai-fs/api-client";
 import { CircularBuffer } from "../shared/lib/circular-buffer.js";
 
 const EVENTS_BUFFER_CAPACITY = 10_000;

--- a/packages/nexus-tui/src/stores/files-store.ts
+++ b/packages/nexus-tui/src/stores/files-store.ts
@@ -6,7 +6,7 @@
  */
 
 import { create } from "zustand";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { categorizeError } from "./create-api-action.js";
 import { useErrorStore } from "./error-store.js";
 import { useUiStore } from "./ui-store.js";

--- a/packages/nexus-tui/src/stores/global-store.ts
+++ b/packages/nexus-tui/src/stores/global-store.ts
@@ -3,8 +3,8 @@
  */
 
 import { create } from "zustand";
-import type { NexusClientOptions } from "@nexus/api-client";
-import { FetchClient, resolveConfig } from "@nexus/api-client";
+import type { NexusClientOptions } from "@nexus-ai-fs/api-client";
+import { FetchClient, resolveConfig } from "@nexus-ai-fs/api-client";
 import { categorizeError } from "./create-api-action.js";
 import { useErrorStore } from "./error-store.js";
 

--- a/packages/nexus-tui/src/stores/infra-store.ts
+++ b/packages/nexus-tui/src/stores/infra-store.ts
@@ -5,7 +5,7 @@
  */
 
 import { create } from "zustand";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { createApiAction, categorizeError } from "./create-api-action.js";
 import { useErrorStore } from "./error-store.js";
 import { useUiStore } from "./ui-store.js";

--- a/packages/nexus-tui/src/stores/knowledge-store.ts
+++ b/packages/nexus-tui/src/stores/knowledge-store.ts
@@ -4,7 +4,7 @@
  */
 
 import { create } from "zustand";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { createApiAction, categorizeError } from "./create-api-action.js";
 import { useErrorStore } from "./error-store.js";
 

--- a/packages/nexus-tui/src/stores/lineage-store.ts
+++ b/packages/nexus-tui/src/stores/lineage-store.ts
@@ -4,7 +4,7 @@
  */
 
 import { create } from "zustand";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { useErrorStore } from "./error-store.js";
 
 // =============================================================================

--- a/packages/nexus-tui/src/stores/mcp-store.ts
+++ b/packages/nexus-tui/src/stores/mcp-store.ts
@@ -5,7 +5,7 @@
  */
 
 import { create } from "zustand";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { createApiAction, categorizeError } from "./create-api-action.js";
 import { useErrorStore } from "./error-store.js";
 

--- a/packages/nexus-tui/src/stores/payments-store.ts
+++ b/packages/nexus-tui/src/stores/payments-store.ts
@@ -9,7 +9,7 @@
  */
 
 import { create } from "zustand";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { createApiAction, categorizeError } from "./create-api-action.js";
 import { useErrorStore } from "./error-store.js";
 import { useUiStore } from "./ui-store.js";

--- a/packages/nexus-tui/src/stores/search-store.ts
+++ b/packages/nexus-tui/src/stores/search-store.ts
@@ -6,7 +6,7 @@
  */
 
 import { create } from "zustand";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { createApiAction, categorizeError } from "./create-api-action.js";
 import { useErrorStore } from "./error-store.js";
 import { useUiStore } from "./ui-store.js";

--- a/packages/nexus-tui/src/stores/share-link-store.ts
+++ b/packages/nexus-tui/src/stores/share-link-store.ts
@@ -3,7 +3,7 @@
  */
 
 import { create } from "zustand";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { createApiAction, categorizeError } from "./create-api-action.js";
 import { useErrorStore } from "./error-store.js";
 

--- a/packages/nexus-tui/src/stores/stack-store.ts
+++ b/packages/nexus-tui/src/stores/stack-store.ts
@@ -7,7 +7,7 @@
  */
 
 import { create } from "zustand";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { useErrorStore } from "./error-store.js";
 import { categorizeError } from "./create-api-action.js";
 import { useUiStore } from "./ui-store.js";

--- a/packages/nexus-tui/src/stores/upload-store.ts
+++ b/packages/nexus-tui/src/stores/upload-store.ts
@@ -14,7 +14,7 @@
  */
 
 import { create } from "zustand";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { categorizeError } from "./create-api-action.js";
 import { useErrorStore } from "./error-store.js";
 

--- a/packages/nexus-tui/src/stores/versions-store.ts
+++ b/packages/nexus-tui/src/stores/versions-store.ts
@@ -6,7 +6,7 @@
  */
 
 import { create } from "zustand";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { createApiAction, categorizeError } from "./create-api-action.js";
 import { useErrorStore } from "./error-store.js";
 import { useUiStore } from "./ui-store.js";

--- a/packages/nexus-tui/src/stores/workflows-store.ts
+++ b/packages/nexus-tui/src/stores/workflows-store.ts
@@ -6,7 +6,7 @@
  */
 
 import { create } from "zustand";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { createApiAction, categorizeError } from "./create-api-action.js";
 import { useErrorStore } from "./error-store.js";
 import { useUiStore } from "./ui-store.js";

--- a/packages/nexus-tui/src/stores/workspace-store.ts
+++ b/packages/nexus-tui/src/stores/workspace-store.ts
@@ -7,7 +7,7 @@
  */
 
 import { create } from "zustand";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { createApiAction, categorizeError } from "./create-api-action.js";
 import { useErrorStore } from "./error-store.js";
 

--- a/packages/nexus-tui/src/stores/zones-store.ts
+++ b/packages/nexus-tui/src/stores/zones-store.ts
@@ -6,7 +6,7 @@
  */
 
 import { create } from "zustand";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { createApiAction, categorizeError } from "./create-api-action.js";
 import { useErrorStore } from "./error-store.js";
 import { useUiStore } from "./ui-store.js";

--- a/packages/nexus-tui/tests/shared/connection-state.test.ts
+++ b/packages/nexus-tui/tests/shared/connection-state.test.ts
@@ -6,7 +6,7 @@
 
 import { describe, it, expect } from "bun:test";
 import { detectConnectionState } from "../../src/shared/hooks/use-connection-state.js";
-import type { NexusClientOptions } from "@nexus/api-client";
+import type { NexusClientOptions } from "@nexus-ai-fs/api-client";
 
 const baseConfig: NexusClientOptions = {
   baseUrl: "http://localhost:2026",

--- a/packages/nexus-tui/tests/stores/access-store.test.ts
+++ b/packages/nexus-tui/tests/stores/access-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { useAccessStore } from "../../src/stores/access-store.js";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 
 function mockClient(responses: Record<string, unknown>): FetchClient {
   const handler = mock(async (path: string) => {

--- a/packages/nexus-tui/tests/stores/agents-store.test.ts
+++ b/packages/nexus-tui/tests/stores/agents-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { useAgentsStore } from "../../src/stores/agents-store.js";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 
 function mockClient(responses: Record<string, unknown>): FetchClient {
   return {

--- a/packages/nexus-tui/tests/stores/api-console-store.test.ts
+++ b/packages/nexus-tui/tests/stores/api-console-store.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach } from "bun:test";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 import { useApiConsoleStore, type EndpointInfo } from "../../src/stores/api-console-store.js";
 
 const SAMPLE_ENDPOINTS: readonly EndpointInfo[] = [

--- a/packages/nexus-tui/tests/stores/connection-lifecycle.test.ts
+++ b/packages/nexus-tui/tests/stores/connection-lifecycle.test.ts
@@ -8,7 +8,7 @@
 
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { useGlobalStore } from "../../src/stores/global-store.js";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 
 function createMockClient(overrides: {
   health?: () => Promise<unknown>;

--- a/packages/nexus-tui/tests/stores/connectors-store.test.ts
+++ b/packages/nexus-tui/tests/stores/connectors-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { useConnectorsStore } from "../../src/stores/connectors-store.js";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 
 // =============================================================================
 // Test utilities

--- a/packages/nexus-tui/tests/stores/create-api-action-v2.test.ts
+++ b/packages/nexus-tui/tests/stores/create-api-action-v2.test.ts
@@ -8,7 +8,7 @@
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { createApiAction } from "../../src/stores/create-api-action.js";
 import { useErrorStore } from "../../src/stores/error-store.js";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 
 // =============================================================================
 // Test helpers

--- a/packages/nexus-tui/tests/stores/create-api-action.test.ts
+++ b/packages/nexus-tui/tests/stores/create-api-action.test.ts
@@ -8,7 +8,7 @@
 import { describe, it, expect, mock, beforeEach } from "bun:test";
 import { createApiAction } from "../../src/stores/create-api-action.js";
 import { useUiStore } from "../../src/stores/ui-store.js";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 
 // =============================================================================
 // Test helpers

--- a/packages/nexus-tui/tests/stores/delegation-store.test.ts
+++ b/packages/nexus-tui/tests/stores/delegation-store.test.ts
@@ -13,7 +13,7 @@
 
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { useDelegationStore } from "../../src/stores/delegation-store.js";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 
 // =============================================================================
 // Helpers

--- a/packages/nexus-tui/tests/stores/files-store.test.ts
+++ b/packages/nexus-tui/tests/stores/files-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { useFilesStore, getEffectiveSelection, _fileCache } from "../../src/stores/files-store.js";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 
 function mockClient(responses: Record<string, unknown>): FetchClient {
   return {

--- a/packages/nexus-tui/tests/stores/global-store.test.ts
+++ b/packages/nexus-tui/tests/stores/global-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { useGlobalStore } from "../../src/stores/global-store.js";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 
 describe("GlobalStore", () => {
   beforeEach(() => {

--- a/packages/nexus-tui/tests/stores/infra-store.test.ts
+++ b/packages/nexus-tui/tests/stores/infra-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { useInfraStore } from "../../src/stores/infra-store.js";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 
 function mockClient(responses: Record<string, unknown>): FetchClient {
   return {

--- a/packages/nexus-tui/tests/stores/knowledge-store.test.ts
+++ b/packages/nexus-tui/tests/stores/knowledge-store.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { useKnowledgeStore } from "../../src/stores/knowledge-store.js";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 
 function mockClient(responses: Record<string, unknown>): FetchClient {
   return {

--- a/packages/nexus-tui/tests/stores/payments-store.test.ts
+++ b/packages/nexus-tui/tests/stores/payments-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { usePaymentsStore } from "../../src/stores/payments-store.js";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 
 function mockClient(responses: Record<string, unknown>): FetchClient {
   return {

--- a/packages/nexus-tui/tests/stores/search-store.test.ts
+++ b/packages/nexus-tui/tests/stores/search-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { useSearchStore } from "../../src/stores/search-store.js";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 
 function mockClient(responses: Record<string, unknown>): FetchClient {
   return {

--- a/packages/nexus-tui/tests/stores/stack-store.test.ts
+++ b/packages/nexus-tui/tests/stores/stack-store.test.ts
@@ -5,7 +5,7 @@
 
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { useStackStore } from "../../src/stores/stack-store.js";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 
 describe("StackStore", () => {
   beforeEach(() => {

--- a/packages/nexus-tui/tests/stores/versions-store.test.ts
+++ b/packages/nexus-tui/tests/stores/versions-store.test.ts
@@ -3,7 +3,7 @@ import {
   useVersionsStore,
   nextStatusFilter,
 } from "../../src/stores/versions-store.js";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 
 // =============================================================================
 // Helpers

--- a/packages/nexus-tui/tests/stores/workflows-store.test.ts
+++ b/packages/nexus-tui/tests/stores/workflows-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { useWorkflowsStore } from "../../src/stores/workflows-store.js";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 
 function mockClient(responses: Record<string, unknown>): FetchClient {
   return {

--- a/packages/nexus-tui/tests/stores/zones-store.test.ts
+++ b/packages/nexus-tui/tests/stores/zones-store.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, mock } from "bun:test";
 import { useZonesStore } from "../../src/stores/zones-store.js";
-import type { FetchClient } from "@nexus/api-client";
+import type { FetchClient } from "@nexus-ai-fs/api-client";
 
 function mockClient(responses: Record<string, unknown>): FetchClient {
   return {

--- a/src/nexus/cli/main.py
+++ b/src/nexus/cli/main.py
@@ -38,7 +38,7 @@ def _exec_tui(extra_args: list[str] | None = None) -> None:
     Order of preference:
       1. repo-local ``packages/nexus-tui/src/index.tsx`` via ``bun run``
       2. ``nexus-tui`` already on PATH
-      3. published ``@nexus/tui`` via ``bunx``
+      3. published ``@nexus-ai-fs/tui`` via ``bunx``
     """
     args = extra_args or []
 
@@ -75,13 +75,13 @@ def _exec_tui(extra_args: list[str] | None = None) -> None:
     # Fallback: use bunx (Bun's npx equivalent) against the scoped package.
     bunx = shutil.which("bunx")
     if bunx is not None:
-        os.execvp(bunx, ["bunx", "@nexus/tui", *args])
+        os.execvp(bunx, ["bunx", "@nexus-ai-fs/tui", *args])
         # execvp does not return
 
     # Neither found – give the user actionable guidance.
     click.secho("Error: could not find nexus-tui, bun, or bunx on PATH.", fg="red", err=True)
     click.echo(
-        "Install the TUI with:\n  bunx @nexus/tui   # or\n  bun install -g @nexus/tui\n",
+        "Install the TUI with:\n  bunx @nexus-ai-fs/tui   # or\n  bun install -g @nexus-ai-fs/tui\n",
         err=True,
     )
     sys.exit(1)

--- a/tests/evaluation/eval_workspace/docs/api-guide.md
+++ b/tests/evaluation/eval_workspace/docs/api-guide.md
@@ -217,7 +217,7 @@ Configure webhooks to receive real-time notifications for events.
 Official SDKs are available for:
 
 - **Python**: `pip install nexus-sdk`
-- **JavaScript**: `npm install @nexus/sdk`
+- **JavaScript**: `npm install @nexus-ai-fs/sdk`
 - **Go**: `go get github.com/nexus/go-sdk`
 
 ## Support


### PR DESCRIPTION
## Summary
- Rename `@nexus/api-client` → `@nexus-ai-fs/api-client`
- Rename `@nexus/tui` → `@nexus-ai-fs/tui`
- Rename `@nexus/pay` → `@nexus-ai-fs/pay`
- Update all imports, workflows, README, and docs (70 files)

The `@nexus` npm org is unavailable. Using `@nexus-ai-fs` to match the PyPI package name.

## Test plan
- [ ] CI passes (TS packages build + test)
- [ ] Re-tag v0.9.18 after merge and verify npm publish succeeds