### PR TITLE
feat: Rust default-on — remove all nexus_fast fallback patterns

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -34,6 +34,17 @@ jobs:
       - name: Create virtual environment
         run: uv venv --python 3.13
 
+      - name: Build Rust extensions
+        uses: ./.github/actions/build-rust-extensions
+        with:
+          profile: dev
+          rust-cache-shared-key: "rust-lint-py"
+          output-dir: dist
+          github-token: ${{ github.token }}
+
+      - name: Install Rust extensions
+        run: uv pip install dist/*.whl
+
       - name: Install dependencies
         run: |
           uv pip install -e ".[dev]"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -36,7 +36,7 @@ jobs:
 
   rpc-parity:
     name: RPC Parity Check
-    needs: detect-changes
+    needs: [detect-changes, build-rust]
     if: needs.detect-changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -56,6 +56,15 @@ jobs:
 
       - name: Create virtual environment
         run: uv venv --python 3.13
+
+      - name: Download Rust wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: rust-wheels-ubuntu-latest
+          path: dist
+
+      - name: Install Rust extensions
+        run: uv pip install dist/*.whl
 
       - name: Install dependencies
         run: uv pip install -e ".[dev,test]"
@@ -416,7 +425,7 @@ jobs:
   # ── nexus-fs standalone package validation ─────────────────────────────
   nexus-fs-smoke:
     name: nexus-fs Smoke Test
-    needs: detect-changes
+    needs: [detect-changes, build-rust]
     if: needs.detect-changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     steps:
@@ -460,11 +469,18 @@ jobs:
           pip install pydistcheck
           pydistcheck --max-allowed-size-compressed '5M' --ignore 'mixed-file-extensions' dist/*.whl
 
+      - name: Download Rust wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: rust-wheels-ubuntu-latest
+          path: rust-dist
+
       - name: Install in clean environment (with timing)
         env:
           VIRTUAL_ENV: /tmp/nexus-fs-test
         run: |
           uv venv --python 3.13 $VIRTUAL_ENV
+          uv pip install --python $VIRTUAL_ENV/bin/python rust-dist/*.whl
           start_time=$(date +%s%N)
           uv pip install --python $VIRTUAL_ENV/bin/python dist/*.whl
           end_time=$(date +%s%N)

--- a/src/nexus/backends/storage/cas_local.py
+++ b/src/nexus/backends/storage/cas_local.py
@@ -57,29 +57,22 @@ def _init_bloom_from_transport(
     capacity: int,
     fp_rate: float,
 ) -> Any:
-    """Initialize Bloom filter, populated from transport. Returns None if unavailable.
+    """Initialize Bloom filter, populated from transport.
 
     Uses transport.list_content_hashes() to seed the Bloom filter — works for
     both volume-packed storage and file-per-blob storage (Issue #3403).
     """
     # RUST_FALLBACK: BloomFilter
-    try:
-        from nexus_fast import BloomFilter
+    from nexus_fast import BloomFilter
 
-        bloom = BloomFilter(capacity, fp_rate)
-        if hasattr(transport, "list_content_hashes"):
-            hashes_ts = transport.list_content_hashes()
-            if hashes_ts:
-                keys = [h for h, _ts in hashes_ts]
-                bloom.add_bulk(keys)
-                logger.info("CAS Bloom filter populated with %d entries", len(keys))
-        return bloom
-    except ImportError:
-        logger.debug("nexus_fast not available, CAS Bloom filter disabled")
-        return None
-    except Exception as e:
-        logger.warning("Failed to initialize CAS Bloom filter: %s", e)
-        return None
+    bloom = BloomFilter(capacity, fp_rate)
+    if hasattr(transport, "list_content_hashes"):
+        hashes_ts = transport.list_content_hashes()
+        if hashes_ts:
+            keys = [h for h, _ts in hashes_ts]
+            bloom.add_bulk(keys)
+            logger.info("CAS Bloom filter populated with %d entries", len(keys))
+    return bloom
 
 
 @register_connector(

--- a/src/nexus/backends/transports/local_transport.py
+++ b/src/nexus/backends/transports/local_transport.py
@@ -376,34 +376,18 @@ class LocalTransport:
         return result
 
     def batch_fetch(self, keys: list[str]) -> dict[str, bytes | None]:
-        """Batch read multiple blobs, using Rust parallel mmap when available.
-
-        Falls back to sequential reads if nexus_fast is not available.
-        """
+        """Batch read multiple blobs, using Rust parallel mmap."""
         if not keys:
             return {}
 
         # RUST_FALLBACK: read_files_bulk
-        try:
-            from nexus_fast import read_files_bulk
+        from nexus_fast import read_files_bulk
 
-            paths = [str(self._resolve(k)) for k in keys]
-            disk_contents = read_files_bulk(paths)
-            result: dict[str, bytes | None] = {}
-            for key, path in zip(keys, paths, strict=True):
-                result[key] = disk_contents.get(path)
-            return result
-        except ImportError:
-            pass
-
-        # Sequential fallback
-        result = {}
-        for key in keys:
-            try:
-                data, _ = self.fetch(key)
-                result[key] = data
-            except Exception:
-                result[key] = None
+        paths = [str(self._resolve(k)) for k in keys]
+        disk_contents = read_files_bulk(paths)
+        result: dict[str, bytes | None] = {}
+        for key, path in zip(keys, paths, strict=True):
+            result[key] = disk_contents.get(path)
         return result
 
     # === Internal Helpers ===

--- a/src/nexus/backends/transports/volume_local_transport.py
+++ b/src/nexus/backends/transports/volume_local_transport.py
@@ -123,17 +123,10 @@ class VolumeLocalTransport:
         self._VolumeEngine: Any = None  # Class reference for lazy creation
 
         # RUST_FALLBACK: VolumeEngine
-        # Try to import Rust VolumeEngine
-        try:
-            from nexus_fast import VolumeEngine
+        from nexus_fast import VolumeEngine
 
-            self._VolumeEngine = VolumeEngine
-            self._volume_available = True
-        except ImportError:
-            logger.warning(
-                "nexus_fast.VolumeEngine not available, "
-                "falling back to file-per-blob LocalTransport"
-            )
+        self._VolumeEngine = VolumeEngine
+        self._volume_available = True
 
         # Permanent engine for non-TTL CAS blobs
         self._engine: Any = None

--- a/src/nexus/backends/wrappers/cache_mixin.py
+++ b/src/nexus/backends/wrappers/cache_mixin.py
@@ -82,24 +82,21 @@ class CacheConnectorMixin:
     _l1_default_ttl: int = 300
 
     @classmethod
-    def _get_l1_cache(cls) -> "L1MetadataCache | None":
+    def _get_l1_cache(cls) -> "L1MetadataCache":
         """Get or create the shared L1 metadata cache (Rust-based)."""
         if cls._l1_cache is None:
-            try:
-                from nexus_fast import L1MetadataCache
+            # RUST_FALLBACK: L1MetadataCache
+            from nexus_fast import L1MetadataCache
 
-                cls._l1_cache = L1MetadataCache(
-                    max_entries=cls._l1_max_entries,
-                    default_ttl=cls._l1_default_ttl,
-                )
-                logger.info(
-                    "[CACHE] L1 Rust cache initialized: max_entries=%d, default_ttl=%ds",
-                    cls._l1_max_entries,
-                    cls._l1_default_ttl,
-                )
-            except ImportError:
-                logger.debug("[CACHE] nexus_fast not available, L1 cache disabled")
-                return None
+            cls._l1_cache = L1MetadataCache(
+                max_entries=cls._l1_max_entries,
+                default_ttl=cls._l1_default_ttl,
+            )
+            logger.info(
+                "[CACHE] L1 Rust cache initialized: max_entries=%d, default_ttl=%ds",
+                cls._l1_max_entries,
+                cls._l1_default_ttl,
+            )
         return cls._l1_cache
 
     @classmethod

--- a/src/nexus/bricks/rebac/utils/fast.py
+++ b/src/nexus/bricks/rebac/utils/fast.py
@@ -15,6 +15,9 @@ The module automatically falls back to Python implementation if Rust is unavaila
 import logging
 from typing import TYPE_CHECKING, Any
 
+# RUST_FALLBACK: rebac — compute_permissions_bulk, etc. from nexus_fast
+import nexus_fast as _rust_module
+
 if TYPE_CHECKING:
     from nexus.bricks.rebac.domain import Entity
     from nexus.bricks.rebac.domain import NamespaceConfig as ReBACNamespaceConfig
@@ -24,21 +27,10 @@ NamespaceConfigDict = dict[str, Any]  # Contains 'relations' and 'permissions' k
 
 logger = logging.getLogger(__name__)
 
-# RUST_FALLBACK: rebac — compute_permissions_bulk, etc. from nexus_fast
-# Try to import Rust extension (nexus_fast PyO3 crate)
-_internal_module: Any = None
-_external_module: Any = None
-RUST_AVAILABLE = False
-
-try:
-    import nexus_fast as _rust_module
-
-    _internal_module = _rust_module
-    _external_module = _rust_module
-    RUST_AVAILABLE = True
-    logger.info("✓ Rust acceleration available (nexus_fast)")
-except ImportError:
-    logger.info("✗ Rust acceleration not available")
+_internal_module: Any = _rust_module
+_external_module: Any = _rust_module
+RUST_AVAILABLE = True
+logger.info("Rust acceleration available (nexus_fast)")
 
 
 def is_rust_available() -> bool:

--- a/src/nexus/bricks/search/primitives/glob_fast.py
+++ b/src/nexus/bricks/search/primitives/glob_fast.py
@@ -18,18 +18,11 @@ Functions:
 
 import fnmatch
 import re
-from collections.abc import Callable
 
 # RUST_FALLBACK: glob_match_bulk
-RUST_AVAILABLE = False
-_rust_glob_match_bulk: Callable[[list[str], list[str]], list[str]] | None = None
+from nexus_fast import glob_match_bulk as _rust_glob_match_bulk
 
-try:
-    from nexus_fast import glob_match_bulk as _rust_glob_match_bulk
-
-    RUST_AVAILABLE = True
-except ImportError:
-    pass
+RUST_AVAILABLE = True
 
 
 def glob_match_bulk(

--- a/src/nexus/bricks/search/primitives/grep_fast.py
+++ b/src/nexus/bricks/search/primitives/grep_fast.py
@@ -11,23 +11,14 @@ Falls back to None if Rust extension is not available.
 Issue #893: Added grep_files_mmap for memory-mapped I/O performance.
 """
 
-from collections.abc import Callable
 from typing import Any
 
 # RUST_FALLBACK: grep_bulk, grep_files_mmap
-RUST_AVAILABLE = False
-MMAP_AVAILABLE = False
-_rust_grep_bulk: Callable[..., list[dict[str, Any]]] | None = None
-_rust_grep_files_mmap: Callable[..., list[dict[str, Any]]] | None = None
+from nexus_fast import grep_bulk as _rust_grep_bulk
+from nexus_fast import grep_files_mmap as _rust_grep_files_mmap
 
-try:
-    from nexus_fast import grep_bulk as _rust_grep_bulk
-    from nexus_fast import grep_files_mmap as _rust_grep_files_mmap
-
-    RUST_AVAILABLE = True
-    MMAP_AVAILABLE = True
-except ImportError:
-    pass
+RUST_AVAILABLE = True
+MMAP_AVAILABLE = True
 
 
 def grep_bulk(

--- a/src/nexus/bricks/search/primitives/trigram_fast.py
+++ b/src/nexus/bricks/search/primitives/trigram_fast.py
@@ -12,46 +12,33 @@ Pattern follows grep_fast.py.
 
 import logging
 import os
-from collections.abc import Callable
 from typing import Any
+
+# RUST_FALLBACK: trigram_fast — build_trigram_index, trigram_grep, etc. have Rust equivalents in nexus_fast.
+from nexus_fast import (
+    build_trigram_index as _build_trigram_index,
+)
+from nexus_fast import (
+    build_trigram_index_from_entries as _build_trigram_index_from_entries,
+)
+from nexus_fast import (
+    invalidate_trigram_cache as _invalidate_trigram_cache,
+)
+from nexus_fast import (
+    trigram_grep as _trigram_grep,
+)
+from nexus_fast import (
+    trigram_index_stats as _trigram_index_stats,
+)
+from nexus_fast import (
+    trigram_search_candidates as _trigram_search_candidates,
+)
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 
 logger = logging.getLogger(__name__)
 
-# RUST_FALLBACK: trigram_fast — build_trigram_index, trigram_grep, etc. have Rust equivalents in nexus_fast.
-# Try to import Rust extension
-TRIGRAM_AVAILABLE = False
-_build_trigram_index: Callable[..., None] | None = None
-_build_trigram_index_from_entries: Callable[..., None] | None = None
-_trigram_grep: Callable[..., list[dict[str, Any]]] | None = None
-_trigram_search_candidates: Callable[..., list[str]] | None = None
-_trigram_index_stats: Callable[..., dict[str, Any]] | None = None
-_invalidate_trigram_cache: Callable[..., None] | None = None
-
-try:
-    from nexus_fast import (
-        build_trigram_index as _build_trigram_index,
-    )
-    from nexus_fast import (
-        build_trigram_index_from_entries as _build_trigram_index_from_entries,
-    )
-    from nexus_fast import (
-        invalidate_trigram_cache as _invalidate_trigram_cache,
-    )
-    from nexus_fast import (
-        trigram_grep as _trigram_grep,
-    )
-    from nexus_fast import (
-        trigram_index_stats as _trigram_index_stats,
-    )
-    from nexus_fast import (
-        trigram_search_candidates as _trigram_search_candidates,
-    )
-
-    TRIGRAM_AVAILABLE = True
-except ImportError:
-    pass
+TRIGRAM_AVAILABLE = True
 
 
 def is_available() -> bool:

--- a/src/nexus/core/hash_fast.py
+++ b/src/nexus/core/hash_fast.py
@@ -24,32 +24,20 @@ import hashlib
 import logging
 from typing import Any
 
+# RUST_FALLBACK: hash_content_py, hash_content_smart_py
+# Priority 1: Rust-accelerated BLAKE3
+from nexus_fast import hash_content_py, hash_content_smart_py
+
 logger = logging.getLogger(__name__)
 
 # --- Backend availability detection ---
 
-_RUST_AVAILABLE = False
 _PYTHON_BLAKE3_AVAILABLE = False
 _python_blake3: Any = None
-_rust_hash_content: Any = None
-_rust_hash_content_smart: Any = None
 
-# RUST_FALLBACK: hash_content_py, hash_content_smart_py
-# Priority 1: Rust-accelerated BLAKE3
-try:
-    from nexus_fast import hash_content_py, hash_content_smart_py
-
-    _rust_hash_content = hash_content_py
-    _rust_hash_content_smart = hash_content_smart_py
-    _RUST_AVAILABLE = True
-    logger.debug("Using Rust BLAKE3 acceleration")
-except (ImportError, AttributeError):
-    logger.info(
-        "Optional Rust BLAKE3 extension not available; using Python blake3. "
-        "Install with: pip install nexus-fast or, from a matching source "
-        "checkout in a Python 3.12+ environment, maturin develop "
-        "-m rust/nexus_pyo3/Cargo.toml"
-    )
+_rust_hash_content: Any = hash_content_py
+_rust_hash_content_smart: Any = hash_content_smart_py
+_RUST_AVAILABLE = True
 
 # Priority 2: Python blake3 package (Issue #582, #833)
 try:

--- a/src/nexus/core/kernel_dispatch.py
+++ b/src/nexus/core/kernel_dispatch.py
@@ -40,10 +40,12 @@ Issue #900, #889, #1665.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 from collections import defaultdict
 from typing import TYPE_CHECKING, Any
+
+# RUST_FALLBACK: PathTrie, HookRegistry, ObserverRegistry
+from nexus_fast import HookRegistry, ObserverRegistry, PathTrie
 
 from nexus.contracts.exceptions import AuditLogError
 from nexus.contracts.operation_result import OperationWarning
@@ -77,20 +79,11 @@ from nexus.contracts.vfs_hooks import (
 from nexus.core.file_events import FileEvent
 
 if TYPE_CHECKING:
-    from nexus_fast import HookRegistry, ObserverRegistry, PathTrie
-
     from nexus.contracts.vfs_hooks import VFSPathResolver
 
-# RUST_FALLBACK: PathTrie, HookRegistry, ObserverRegistry
-_PathTrie: type[PathTrie] | None = None
-_HookRegistry: type[HookRegistry] | None = None
-_ObserverRegistry: type[ObserverRegistry] | None = None
-with contextlib.suppress(ImportError):
-    from nexus_fast import HookRegistry, ObserverRegistry, PathTrie
-
-    _PathTrie = PathTrie
-    _HookRegistry = HookRegistry
-    _ObserverRegistry = ObserverRegistry
+_PathTrie = PathTrie
+_HookRegistry = HookRegistry
+_ObserverRegistry = ObserverRegistry
 
 logger = logging.getLogger(__name__)
 

--- a/src/nexus/core/mount_table.py
+++ b/src/nexus/core/mount_table.py
@@ -17,6 +17,17 @@ import posixpath
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+# RUST_FALLBACK: canonicalize_path, extract_zone_id, RustPathRouter
+from nexus_fast import (
+    RustPathRouter,
+)
+from nexus_fast import (
+    canonicalize_path as _rust_canonicalize_path,
+)
+from nexus_fast import (
+    extract_zone_id as _rust_extract_zone_id,
+)
+
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.core.path_utils import normalize_path
 
@@ -27,21 +38,9 @@ if TYPE_CHECKING:
 
 # ---------------------------------------------------------------------------
 # Zone-canonical path helpers (pure functions, ~0 cost)
-# RUST_FALLBACK: canonicalize_path, extract_zone_id
 # ---------------------------------------------------------------------------
 
-_RUST_ZONE_AVAILABLE = False
-try:
-    from nexus_fast import (
-        canonicalize_path as _rust_canonicalize_path,
-    )
-    from nexus_fast import (
-        extract_zone_id as _rust_extract_zone_id,
-    )
-
-    _RUST_ZONE_AVAILABLE = True
-except ImportError:
-    pass
+_RUST_ZONE_AVAILABLE = True
 
 
 def canonicalize_path(path: str, zone_id: str = ROOT_ZONE_ID) -> str:
@@ -116,13 +115,7 @@ class MountTable:
         self._entries: dict[str, MountEntry] = {}
         self._default_metastore: MetastoreABC = default_metastore
         # RUST_FALLBACK: RustPathRouter — LPM acceleration
-        self._rust: Any = None
-        try:
-            from nexus_fast import RustPathRouter
-
-            self._rust = RustPathRouter()
-        except ImportError:
-            pass
+        self._rust: Any = RustPathRouter()
 
     # -- Write operations (called by coordinator) ---------------------------
 

--- a/src/nexus/core/path_utils.py
+++ b/src/nexus/core/path_utils.py
@@ -14,28 +14,22 @@ All functions are pure and return immutable results (tuples).
 import functools
 import re
 
-from nexus.contracts.exceptions import InvalidPathError
-
 # ---------------------------------------------------------------------------
 # Rust acceleration (optional — falls back to Python below)
 # ---------------------------------------------------------------------------
+from nexus_fast import get_ancestors as _rust_get_ancestors
+from nexus_fast import get_parent as _rust_get_parent
+from nexus_fast import get_parent_chain as _rust_get_parent_chain
+from nexus_fast import normalize_path as _rust_normalize_path
+from nexus_fast import parent_path as _rust_parent_path
+from nexus_fast import path_matches_pattern as _rust_path_matches_pattern
+from nexus_fast import split_path as _rust_split_path
+from nexus_fast import unscope_internal_path as _rust_unscope_internal_path
+from nexus_fast import validate_path as _rust_validate_path
 
-_RUST_AVAILABLE = False
+from nexus.contracts.exceptions import InvalidPathError
 
-try:
-    from nexus_fast import get_ancestors as _rust_get_ancestors
-    from nexus_fast import get_parent as _rust_get_parent
-    from nexus_fast import get_parent_chain as _rust_get_parent_chain
-    from nexus_fast import normalize_path as _rust_normalize_path
-    from nexus_fast import parent_path as _rust_parent_path
-    from nexus_fast import path_matches_pattern as _rust_path_matches_pattern
-    from nexus_fast import split_path as _rust_split_path
-    from nexus_fast import unscope_internal_path as _rust_unscope_internal_path
-    from nexus_fast import validate_path as _rust_validate_path
-
-    _RUST_AVAILABLE = True
-except ImportError:
-    pass
+_RUST_AVAILABLE = True
 
 # Pre-compiled regex for normalizing consecutive slashes
 _MULTI_SLASH = re.compile(r"/+")

--- a/src/nexus/core/pipe.py
+++ b/src/nexus/core/pipe.py
@@ -28,83 +28,12 @@ from __future__ import annotations
 
 import asyncio
 import logging
-from collections import deque
 from typing import Protocol, runtime_checkable
 
 # RUST_FALLBACK: RingBufferCore
-_RingBufferCoreType: type | None = None
-try:
-    from nexus_fast import RingBufferCore
+from nexus_fast import RingBufferCore
 
-    _RingBufferCoreType = RingBufferCore
-except ImportError:  # pragma: no cover
-    pass
-
-if _RingBufferCoreType is None:  # pragma: no cover
-
-    class _RingBufferCoreFallback:
-        """Pure-Python fallback for source checkouts without ``nexus_fast``."""
-
-        def __init__(self, capacity: int) -> None:
-            self._capacity = capacity
-            self._queue: deque[bytes] = deque()
-            self._used = 0
-            self.closed = False
-
-        def push(self, data: bytes) -> int:
-            if self.closed:
-                raise RuntimeError("PipeClosed:write to closed pipe")
-            if len(data) > self._capacity:
-                raise ValueError("message larger than capacity")
-            if self._used + len(data) > self._capacity:
-                raise RuntimeError("PipeFull:buffer full")
-            payload = bytes(data)
-            self._queue.append(payload)
-            self._used += len(payload)
-            return len(payload)
-
-        def pop(self) -> bytes:
-            if self._queue:
-                payload = self._queue.popleft()
-                self._used -= len(payload)
-                return payload
-            if self.closed:
-                raise RuntimeError("PipeClosed:read from closed pipe")
-            raise RuntimeError("PipeEmpty:buffer empty")
-
-        def push_u64(self, val: int) -> None:
-            self.push(int(val).to_bytes(8, "little", signed=False))
-
-        def pop_u64(self) -> int:
-            payload = self.pop()
-            if len(payload) != 8:
-                raise RuntimeError("PipeEmpty:expected u64 frame")
-            return int.from_bytes(payload, "little", signed=False)
-
-        def is_full(self) -> bool:
-            return self._used >= self._capacity
-
-        def is_empty(self) -> bool:
-            return not self._queue
-
-        def peek(self) -> bytes | None:
-            return self._queue[0] if self._queue else None
-
-        def peek_all(self) -> list[bytes]:
-            return list(self._queue)
-
-        def close(self) -> None:
-            self.closed = True
-
-        def stats(self) -> dict[str, int | bool]:
-            return {
-                "capacity": self._capacity,
-                "used_bytes": self._used,
-                "message_count": len(self._queue),
-                "closed": self.closed,
-            }
-
-    _RingBufferCoreType = _RingBufferCoreFallback
+_RingBufferCoreType: type = RingBufferCore
 
 
 logger = logging.getLogger(__name__)
@@ -220,7 +149,6 @@ class RingBuffer:
         """
         if capacity <= 0:
             raise ValueError(f"capacity must be > 0, got {capacity}")
-        assert _RingBufferCoreType is not None
         self._core = _RingBufferCoreType(capacity)
         self._not_empty = asyncio.Event()
         self._not_full = asyncio.Event()

--- a/src/nexus/core/shm_pipe.py
+++ b/src/nexus/core/shm_pipe.py
@@ -32,9 +32,7 @@ if TYPE_CHECKING:
     from nexus_fast import SharedRingBufferCore
 
 # RUST_FALLBACK: SharedRingBufferCore
-_SharedRingBufferCore: type[SharedRingBufferCore] | None = None
-with contextlib.suppress(ImportError):
-    from nexus_fast import SharedRingBufferCore as _SharedRingBufferCore
+from nexus_fast import SharedRingBufferCore as _SharedRingBufferCore
 
 logger = logging.getLogger(__name__)
 
@@ -90,8 +88,6 @@ class SharedRingBuffer:
             - data_rd_fd: pass to child (child listens for data notifications)
             - space_rd_fd: keep in parent (parent listens for space notifications)
         """
-        if _SharedRingBufferCore is None:
-            raise ImportError("SharedRingBufferCore not available in nexus_fast")
         core, shm_path, data_rd_fd, space_rd_fd = _SharedRingBufferCore.create(capacity)
         # Parent keeps space_rd_fd (wakes when reader frees space)
         buf = cls(core, data_rd_fd=-1, space_rd_fd=space_rd_fd)
@@ -109,8 +105,6 @@ class SharedRingBuffer:
             notify_space_wr: Write-end of space pipe (child writes here after pop — passed to Rust core).
             data_rd_fd: Read-end of data pipe (child listens here for data notifications).
         """
-        if _SharedRingBufferCore is None:
-            raise ImportError("SharedRingBufferCore not available in nexus_fast")
         core = _SharedRingBufferCore.attach(shm_path, notify_data_wr, notify_space_wr)
         return cls(core, data_rd_fd=data_rd_fd, space_rd_fd=-1)
 

--- a/src/nexus/core/shm_stream.py
+++ b/src/nexus/core/shm_stream.py
@@ -25,9 +25,7 @@ if TYPE_CHECKING:
     from nexus_fast import SharedStreamBufferCore
 
 # RUST_FALLBACK: SharedStreamBufferCore
-_SharedStreamBufferCore: type[SharedStreamBufferCore] | None = None
-with contextlib.suppress(ImportError):
-    from nexus_fast import SharedStreamBufferCore as _SharedStreamBufferCore
+from nexus_fast import SharedStreamBufferCore as _SharedStreamBufferCore
 
 logger = logging.getLogger(__name__)
 
@@ -73,8 +71,6 @@ class SharedStreamBuffer:
             - shm_path: pass to reader for attach()
             - data_rd_fd: pass to reader (reader listens for data notifications)
         """
-        if _SharedStreamBufferCore is None:
-            raise ImportError("SharedStreamBufferCore not available in nexus_fast")
         core, shm_path, data_rd_fd = _SharedStreamBufferCore.create(capacity)
         buf = cls(core, data_rd_fd=-1)
         return buf, shm_path, data_rd_fd
@@ -88,8 +84,6 @@ class SharedStreamBuffer:
             notify_data_wr: Write-end of data pipe (passed to Rust core for notification).
             data_rd_fd: Read-end of data pipe (reader listens here).
         """
-        if _SharedStreamBufferCore is None:
-            raise ImportError("SharedStreamBufferCore not available in nexus_fast")
         core = _SharedStreamBufferCore.attach(shm_path, notify_data_wr)
         return cls(core, data_rd_fd=data_rd_fd)
 

--- a/src/nexus/core/stream.py
+++ b/src/nexus/core/stream.py
@@ -24,17 +24,14 @@ Data plane backed by Rust ``nexus_fast.StreamBufferCore``.
 from __future__ import annotations
 
 import asyncio
-import contextlib
 import logging
 from typing import TYPE_CHECKING, Protocol, runtime_checkable
 
 if TYPE_CHECKING:
-    from nexus_fast import StreamBufferCore
+    pass
 
 # RUST_FALLBACK: StreamBufferCore
-_StreamBufferCoreType: type[StreamBufferCore] | None = None
-with contextlib.suppress(ImportError):
-    from nexus_fast import StreamBufferCore as _StreamBufferCoreType
+from nexus_fast import StreamBufferCore as _StreamBufferCoreType
 
 logger = logging.getLogger(__name__)
 
@@ -120,11 +117,6 @@ class StreamBuffer:
     __slots__ = ("_core", "_not_empty", "_not_full")
 
     def __init__(self, capacity: int = 65_536) -> None:
-        if _StreamBufferCoreType is None:
-            raise ImportError(
-                "StreamBufferCore not available in nexus_fast — "
-                "rebuild the Rust extension with stream support"
-            )
         if capacity <= 0:
             raise ValueError(f"capacity must be > 0, got {capacity}")
         self._core = _StreamBufferCoreType(capacity)

--- a/src/nexus/fuse/filters.py
+++ b/src/nexus/fuse/filters.py
@@ -9,13 +9,9 @@ import fnmatch
 from typing import Any
 
 # RUST_FALLBACK: filter_paths
-# Try to import Rust acceleration
-try:
-    import nexus_fast
+import nexus_fast
 
-    RUST_AVAILABLE = True
-except ImportError:
-    RUST_AVAILABLE = False
+RUST_AVAILABLE = True
 
 # OS-generated metadata file patterns
 # These files are automatically created by operating systems and should be

--- a/src/nexus/remote/negative_cache.py
+++ b/src/nexus/remote/negative_cache.py
@@ -96,34 +96,24 @@ def create_negative_cache(
     capacity: int = 100_000,
     fp_rate: float = 0.01,
 ) -> NegativeCache:
-    """Create a NegativeCache, preferring Bloom filter if available.
-
-    Tries to create a BloomNegativeCache backed by nexus_fast.BloomFilter.
-    Falls back to NullNegativeCache if nexus_fast is not installed.
+    """Create a NegativeCache backed by nexus_fast.BloomFilter.
 
     Args:
         capacity: Maximum number of entries the Bloom filter can hold.
         fp_rate: Target false-positive rate (0.01 = 1%).
 
     Returns:
-        A NegativeCache instance (Bloom or Null).
+        A BloomNegativeCache instance.
     """
     # RUST_FALLBACK: BloomFilter
-    try:
-        from nexus_fast import BloomFilter
+    from nexus_fast import BloomFilter
 
-        bloom = BloomFilter(capacity, fp_rate)
-        cache = BloomNegativeCache(bloom)
-        logger.debug(
-            "Negative cache initialized: capacity=%d, fp_rate=%s, memory=%d bytes",
-            capacity,
-            fp_rate,
-            cache.memory_bytes,
-        )
-        return cache
-    except ImportError:
-        logger.debug("nexus_fast not available, negative cache disabled")
-        return NullNegativeCache()
-    except Exception as e:
-        logger.warning("Failed to initialize negative cache: %s", e)
-        return NullNegativeCache()
+    bloom = BloomFilter(capacity, fp_rate)
+    cache = BloomNegativeCache(bloom)
+    logger.debug(
+        "Negative cache initialized: capacity=%d, fp_rate=%s, memory=%d bytes",
+        capacity,
+        fp_rate,
+        cache.memory_bytes,
+    )
+    return cache

--- a/src/nexus/storage/file_cache.py
+++ b/src/nexus/storage/file_cache.py
@@ -104,21 +104,15 @@ class FileContentCache:
 
     def _init_bloom_filter(self) -> None:
         """Initialize Bloom filter for fast cache miss detection."""
-        try:
-            from nexus_fast import BloomFilter
+        # RUST_FALLBACK: BloomFilter
+        from nexus_fast import BloomFilter
 
-            self._bloom = BloomFilter(self._bloom_capacity, self._bloom_fp_rate)
-            self._populate_bloom_from_disk()
-            logger.debug(
-                f"Bloom filter initialized: capacity={self._bloom_capacity}, "
-                f"fp_rate={self._bloom_fp_rate}, memory={self._bloom.memory_bytes} bytes"
-            )
-        except ImportError:
-            logger.debug("nexus_fast not available, Bloom filter disabled")
-            self._bloom = None
-        except Exception as e:
-            logger.warning(f"Failed to initialize Bloom filter: {e}")
-            self._bloom = None
+        self._bloom = BloomFilter(self._bloom_capacity, self._bloom_fp_rate)
+        self._populate_bloom_from_disk()
+        logger.debug(
+            f"Bloom filter initialized: capacity={self._bloom_capacity}, "
+            f"fp_rate={self._bloom_fp_rate}, memory={self._bloom.memory_bytes} bytes"
+        )
 
     def _populate_bloom_from_disk(self) -> None:
         """Populate Bloom filter from existing cache entries on disk.
@@ -408,20 +402,12 @@ class FileContentCache:
 
         cache_path = self._get_cache_path(zone_id, virtual_path)
 
-        try:
-            from nexus_fast import read_file
+        # RUST_FALLBACK: read_file
+        from nexus_fast import read_file
 
+        try:
             result: bytes | None = read_file(str(cache_path))
             return result
-        except ImportError:
-            # Fallback to standard read if nexus_fast not available
-            if not cache_path.exists():
-                return None
-            try:
-                return cache_path.read_bytes()
-            except Exception as e:
-                logger.warning(f"Failed to read cache file {cache_path}: {e}")
-                return None
         except Exception as e:
             logger.warning(f"Failed to read cache file {cache_path}: {e}")
             return None
@@ -495,27 +481,19 @@ class FileContentCache:
             cache_to_virtual[cache_path] = vpath
             cache_paths.append(cache_path)
 
-        try:
-            from nexus_fast import read_files_bulk
+        # RUST_FALLBACK: read_files_bulk
+        from nexus_fast import read_files_bulk
 
-            # Parallel mmap read
-            cache_contents = read_files_bulk(cache_paths)
+        # Parallel mmap read
+        cache_contents = read_files_bulk(cache_paths)
 
-            # Map back to virtual paths
-            result: dict[str, bytes] = {}
-            for cache_path, content in cache_contents.items():
-                virtual_path = cache_to_virtual.get(cache_path)
-                if virtual_path:
-                    result[virtual_path] = content
-            return result
-        except ImportError:
-            # Fallback to sequential read if nexus_fast not available
-            fallback_result: dict[str, bytes] = {}
-            for path in paths_to_check:
-                cached = self.read(zone_id, path)
-                if cached is not None:
-                    fallback_result[path] = cached
-            return fallback_result
+        # Map back to virtual paths
+        result: dict[str, bytes] = {}
+        for cache_path, content in cache_contents.items():
+            virtual_path = cache_to_virtual.get(cache_path)
+            if virtual_path:
+                result[virtual_path] = content
+        return result
 
     def read_text_bulk(
         self,

--- a/src/nexus/storage/local_disk_cache.py
+++ b/src/nexus/storage/local_disk_cache.py
@@ -171,17 +171,14 @@ class LocalDiskCache:
 
     def _init_bloom_filter(self) -> None:
         """Initialize Bloom filter for fast cache miss detection."""
-        try:
-            from nexus_fast import BloomFilter
+        # RUST_FALLBACK: BloomFilter
+        from nexus_fast import BloomFilter
 
-            self._bloom = BloomFilter(self._bloom_capacity, self._bloom_fp_rate)
-            logger.debug(
-                f"Bloom filter initialized: capacity={self._bloom_capacity}, "
-                f"fp_rate={self._bloom_fp_rate}"
-            )
-        except ImportError:
-            logger.debug("nexus_fast not available, Bloom filter disabled")
-            self._bloom = None
+        self._bloom = BloomFilter(self._bloom_capacity, self._bloom_fp_rate)
+        logger.debug(
+            f"Bloom filter initialized: capacity={self._bloom_capacity}, "
+            f"fp_rate={self._bloom_fp_rate}"
+        )
 
     def _make_cache_key(self, content_hash: str, zone_id: str | None = None) -> str:
         """Create zone-isolated cache key.

--- a/stubs/nexus_fast/__init__.pyi
+++ b/stubs/nexus_fast/__init__.pyi
@@ -44,7 +44,7 @@ def hash_bytes(data: bytes) -> str: ...
 
 def grep_bulk(
     pattern: str,
-    file_contents: dict[str, str],
+    file_contents: dict[str, Any],
     ignore_case: bool = False,
     max_results: int = 1000,
 ) -> list[dict[str, Any]]: ...


### PR DESCRIPTION
## Summary
- Remove `try/except ImportError` fallback patterns across 20 files — `nexus_fast` (Rust) is now a hard dependency
- Add `build-rust-extensions` step to lint.yml so mypy can import `nexus_fast` during type checking
- Fix grep_bulk stub to accept `dict[str, Any]` (PyDict accepts both str and bytes values)
- Net -221 lines of fallback/degradation code

## Motivation
All CI workflows (Test, Benchmark, Docker) already build and install Rust extensions. Making Rust a hard dependency:
1. Eliminates dead code paths (Python fallbacks were never exercised in CI)
2. Catches Rust build failures at import time, not silently falling back
3. Simplifies every `nexus_fast` usage site (no `if RUST_AVAILABLE` checks)

## Files changed (21)
Core: path_utils, mount_table, kernel_dispatch, pipe, stream, shm_pipe, shm_stream, hash_fast
Search: glob_fast, grep_fast, trigram_fast
Backends: cas_local, local_transport, volume_local_transport, cache_mixin
Storage: file_cache, local_disk_cache, negative_cache
Other: rebac/utils/fast, fuse/filters
CI: lint.yml

## Test plan
- [ ] CI all green (Test + Benchmark + Lint)
- [ ] `grep -rn "except ImportError" src/ | grep nexus_fast` returns 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)