### PR TITLE
perf: parallelize GWS target probes in auth list/doctor

### DIFF
--- a/src/nexus/bricks/auth/unified_service.py
+++ b/src/nexus/bricks/auth/unified_service.py
@@ -752,6 +752,7 @@ class UnifiedAuthService:
         if shutil.which("gws") is None:
             return None
 
+        proc: asyncio.subprocess.Process | None = None
         try:
             proc = await asyncio.create_subprocess_exec(
                 "gws",
@@ -767,6 +768,9 @@ class UnifiedAuthService:
             )
             stdout_bytes, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
         except Exception:
+            if proc is not None and proc.returncode is None:
+                proc.kill()
+                await proc.wait()
             return None
 
         if proc.returncode != 0:
@@ -860,6 +864,7 @@ class UnifiedAuthService:
 
         async def _probe_single(target: str) -> tuple[str, dict[str, Any]]:
             args = _GWS_TARGET_PROBES[target]
+            proc: asyncio.subprocess.Process | None = None
             try:
                 env = {**os.environ}
                 if access_token:
@@ -872,6 +877,9 @@ class UnifiedAuthService:
                 )
                 stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=15)
             except Exception as exc:
+                if proc is not None and proc.returncode is None:
+                    proc.kill()
+                    await proc.wait()
                 return target, {
                     "target": target,
                     "success": False,

--- a/src/nexus/bricks/auth/unified_service.py
+++ b/src/nexus/bricks/auth/unified_service.py
@@ -767,7 +767,7 @@ class UnifiedAuthService:
                 stderr=asyncio.subprocess.PIPE,
             )
             stdout_bytes, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
-        except Exception:
+        except BaseException:
             if proc is not None and proc.returncode is None:
                 proc.kill()
                 await proc.wait()
@@ -876,15 +876,16 @@ class UnifiedAuthService:
                     env=env,
                 )
                 stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=15)
-            except Exception as exc:
+            except BaseException as exc:
                 if proc is not None and proc.returncode is None:
                     proc.kill()
                     await proc.wait()
+                error_msg = str(exc) or f"{target} probe timed out or was cancelled."
                 return target, {
                     "target": target,
                     "success": False,
                     "source": probe_source,
-                    "message": str(exc),
+                    "message": error_msg,
                     "reason": "probe_error",
                 }
 

--- a/src/nexus/bricks/auth/unified_service.py
+++ b/src/nexus/bricks/auth/unified_service.py
@@ -6,11 +6,11 @@ without forcing static secrets through OAuth-specific storage semantics.
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import os
 import shutil
-import subprocess
 from datetime import UTC, datetime
 from pathlib import Path
 from typing import TYPE_CHECKING, Any, cast
@@ -28,6 +28,7 @@ from nexus.fs._credentials import discover_credentials
 from nexus.security.secret_file import write_secret_file
 
 logger = logging.getLogger(__name__)
+_UNSET = object()
 
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext
@@ -410,13 +411,20 @@ class UnifiedAuthService:
 
         if self._oauth_service is not None:
             oauth_creds = await self._oauth_service.list_credentials(context=context)
+            cached_native: dict[str, str] | None | object = _UNSET
             for service, providers in _OAUTH_PROVIDER_ALIASES.items():
                 seen_services.add(service)
                 matching = [cred for cred in oauth_creds if cred.get("provider") in providers]
-                native = self._detect_oauth_native(service)
+                if service in _GOOGLE_OAUTH_SERVICES:
+                    if cached_native is _UNSET:
+                        cached_native = await self._detect_google_workspace_cli_native()
+                    native = cached_native if isinstance(cached_native, dict) else None
+                else:
+                    native = None
                 if native is not None and google_target_checks is None:
-                    google_target_checks = self._probe_google_workspace_targets(
+                    google_target_checks = await self._probe_google_workspace_targets(
                         _GWS_TARGETS,
+                        native=native,
                         user_email=native.get("email"),
                     )
                 if matching:
@@ -592,14 +600,15 @@ class UnifiedAuthService:
         if user_email is not None:
             matches = [cred for cred in matches if cred.get("user_email") == user_email]
         desired_targets = self._google_targets_for_service(service, target=target)
-        native = self._detect_oauth_native(service, user_email=user_email)
+        native = await self._detect_oauth_native(service, user_email=user_email)
         if not matches:
             if native is not None:
                 if desired_targets:
-                    return self._google_target_test_result(
+                    return await self._google_target_test_result(
                         service,
                         desired_targets,
                         source=native["source"],
+                        native=native,
                         user_email=user_email or native.get("email"),
                     )
                 return {
@@ -627,10 +636,11 @@ class UnifiedAuthService:
 
         if bool(candidate.get("is_expired")) and native is not None:
             if desired_targets:
-                result = self._google_target_test_result(
+                result = await self._google_target_test_result(
                     service,
                     desired_targets,
                     source=native["source"],
+                    native=native,
                     user_email=user_email or native.get("email"),
                 )
                 result["message"] = "Stored OAuth credential is expired; " + str(
@@ -724,7 +734,7 @@ class UnifiedAuthService:
         message = f"Native provider chain available via {details.get('source', 'native')}."
         return {**{k: str(v) for k, v in details.items()}, "message": message}
 
-    def _detect_oauth_native(
+    async def _detect_oauth_native(
         self,
         service: str,
         *,
@@ -732,9 +742,9 @@ class UnifiedAuthService:
     ) -> dict[str, str] | None:
         if service not in _GOOGLE_OAUTH_SERVICES:
             return None
-        return self._detect_google_workspace_cli_native(user_email=user_email)
+        return await self._detect_google_workspace_cli_native(user_email=user_email)
 
-    def _detect_google_workspace_cli_native(
+    async def _detect_google_workspace_cli_native(
         self,
         *,
         user_email: str | None = None,
@@ -743,29 +753,26 @@ class UnifiedAuthService:
             return None
 
         try:
-            result = subprocess.run(
-                [
-                    "gws",
-                    "gmail",
-                    "users",
-                    "getProfile",
-                    "--params",
-                    '{"userId":"me"}',
-                    "--format",
-                    "json",
-                ],
-                capture_output=True,
-                text=True,
-                timeout=10,
-                check=False,
+            proc = await asyncio.create_subprocess_exec(
+                "gws",
+                "gmail",
+                "users",
+                "getProfile",
+                "--params",
+                '{"userId":"me"}',
+                "--format",
+                "json",
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
             )
+            stdout_bytes, _ = await asyncio.wait_for(proc.communicate(), timeout=10)
         except Exception:
             return None
 
-        if result.returncode != 0:
+        if proc.returncode != 0:
             return None
 
-        stdout = result.stdout.strip()
+        stdout = stdout_bytes.decode().strip()
         if not stdout:
             return None
 
@@ -828,56 +835,56 @@ class UnifiedAuthService:
         except Exception:
             return None
 
-    def _probe_google_workspace_targets(
+    async def _probe_google_workspace_targets(
         self,
         targets: tuple[str, ...],
         *,
+        native: dict[str, str] | None = None,
         user_email: str | None = None,
         access_token: str | None = None,
         source: str | None = None,
     ) -> dict[str, dict[str, Any]]:
-        checks: dict[str, dict[str, Any]] = {}
-        native = self._detect_google_workspace_cli_native(user_email=user_email)
         probe_source = source or (native["source"] if native is not None else "oauth")
         probe_email = user_email or (native.get("email") if native is not None else None)
         if access_token is None and native is None:
-            for target in targets:
-                checks[target] = {
+            return {
+                target: {
                     "target": target,
                     "success": False,
                     "source": probe_source,
                     "message": "No Google auth is available for target verification.",
                     "reason": "missing_google_auth",
                 }
-            return checks
+                for target in targets
+            }
 
-        for target in targets:
+        async def _probe_single(target: str) -> tuple[str, dict[str, Any]]:
             args = _GWS_TARGET_PROBES[target]
             try:
-                env = None
+                env = {**os.environ}
                 if access_token:
-                    env = {"GWS_ACCESS_TOKEN": access_token}
-                result = subprocess.run(
-                    args,
-                    capture_output=True,
-                    text=True,
-                    timeout=15,
-                    check=False,
-                    env={**os.environ, **(env or {})},
+                    env["GWS_ACCESS_TOKEN"] = access_token
+                proc = await asyncio.create_subprocess_exec(
+                    *args,
+                    stdout=asyncio.subprocess.PIPE,
+                    stderr=asyncio.subprocess.PIPE,
+                    env=env,
                 )
+                stdout_bytes, stderr_bytes = await asyncio.wait_for(proc.communicate(), timeout=15)
             except Exception as exc:
-                checks[target] = {
+                return target, {
                     "target": target,
                     "success": False,
                     "source": probe_source,
                     "message": str(exc),
                     "reason": "probe_error",
                 }
-                continue
 
-            combined = f"{result.stdout}\n{result.stderr}".lower()
-            if result.returncode == 0:
-                checks[target] = {
+            stdout = stdout_bytes.decode()
+            stderr = stderr_bytes.decode()
+            combined = f"{stdout}\n{stderr}".lower()
+            if proc.returncode == 0:
+                return target, {
                     "target": target,
                     "success": True,
                     "source": probe_source,
@@ -887,7 +894,6 @@ class UnifiedAuthService:
                         else f"{target} target is ready via local gws CLI."
                     ),
                 }
-                continue
 
             if "insufficient authentication scopes" in combined:
                 message = (
@@ -902,18 +908,20 @@ class UnifiedAuthService:
                 )
                 reason = "expired"
             else:
-                summary = (result.stderr or result.stdout).strip() or f"{target} probe failed."
+                summary = (stderr or stdout).strip() or f"{target} probe failed."
                 message = summary.splitlines()[0]
                 reason = "probe_failed"
 
-            checks[target] = {
+            return target, {
                 "target": target,
                 "success": False,
                 "source": probe_source,
                 "message": message,
                 "reason": reason,
             }
-        return checks
+
+        results = await asyncio.gather(*[_probe_single(t) for t in targets])
+        return dict(results)
 
     async def _google_target_test_result_for_stored_oauth(
         self,
@@ -970,7 +978,7 @@ class UnifiedAuthService:
                 "stored_oauth_status": AuthStatus.AUTHED.value,
             }
 
-        return self._google_target_test_result(
+        return await self._google_target_test_result(
             service,
             targets,
             source="oauth",
@@ -1090,17 +1098,19 @@ class UnifiedAuthService:
             },
         }
 
-    def _google_target_test_result(
+    async def _google_target_test_result(
         self,
         service: str,
         targets: tuple[str, ...],
         *,
         source: str,
+        native: dict[str, str] | None = None,
         user_email: str | None = None,
         access_token: str | None = None,
     ) -> dict[str, Any]:
-        checks = self._probe_google_workspace_targets(
+        checks = await self._probe_google_workspace_targets(
             targets,
+            native=native,
             user_email=user_email,
             access_token=access_token,
             source=source,

--- a/tests/unit/auth/test_unified_service.py
+++ b/tests/unit/auth/test_unified_service.py
@@ -514,8 +514,16 @@ def test_probe_timeout_does_not_block_others(
     class _TimeoutProcess:
         """Simulates a process whose communicate() raises TimeoutError."""
 
+        returncode: int | None = None
+
         async def communicate(self) -> tuple[bytes, bytes]:
             raise TimeoutError("probe timed out")
+
+        def kill(self) -> None:
+            self.returncode = -9
+
+        async def wait(self) -> int:
+            return -9
 
     processes: dict[str, _FakeProcess] = {}
     for t in _TARGETS:

--- a/tests/unit/auth/test_unified_service.py
+++ b/tests/unit/auth/test_unified_service.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from pathlib import Path
 
 import pytest
@@ -7,6 +8,42 @@ import pytest
 from nexus.bricks.auth.oauth.types import OAuthCredential
 from nexus.bricks.auth.unified_service import FileSecretCredentialStore, UnifiedAuthService
 from nexus.contracts.unified_auth import AuthStatus, CredentialKind
+
+
+async def _fake_probe_all_ok(  # noqa: ANN001
+    targets, *, native=None, user_email=None, access_token=None, source=None
+):
+    return {
+        target: {
+            "target": target,
+            "success": True,
+            "source": source or "oauth",
+            "message": f"{target} target is ready via stored OAuth.",
+        }
+        for target in targets
+    }
+
+
+async def _fake_probe_native_ok(  # noqa: ANN001
+    targets, *, native=None, user_email=None, access_token=None, source=None
+):
+    return {
+        target: {
+            "target": target,
+            "success": True,
+            "source": source or "native:gws_cli",
+            "message": f"{target} target is ready via local gws CLI.",
+        }
+        for target in targets
+    }
+
+
+async def _fake_native_gws(*, user_email=None):  # noqa: ANN001, ARG001
+    return {
+        "source": "native:gws_cli",
+        "email": "alice@example.com",
+        "message": "Local gws CLI profile available for alice@example.com.",
+    }
 
 
 class _FakeOAuthService:
@@ -98,19 +135,7 @@ def test_list_summaries_includes_oauth_and_secret(
     monkeypatch.setattr(
         auth_service, "_get_stored_oauth_credential", _fake_get_stored_oauth_credential
     )
-    monkeypatch.setattr(
-        auth_service,
-        "_probe_google_workspace_targets",
-        lambda targets, user_email=None, access_token=None, source=None: {
-            target: {
-                "target": target,
-                "success": True,
-                "source": source or "oauth",
-                "message": f"{target} target is ready via stored OAuth.",
-            }
-            for target in targets
-        },
-    )
+    monkeypatch.setattr(auth_service, "_probe_google_workspace_targets", _fake_probe_all_ok)
 
     auth_service.connect_secret(
         "gcs",
@@ -176,15 +201,7 @@ def test_test_service_supports_gws_alias(
     monkeypatch.setattr(
         auth_service,
         "_probe_google_workspace_targets",
-        lambda targets, user_email=None, access_token=None, source=None: {
-            target: {
-                "target": target,
-                "success": True,
-                "source": source or "oauth",
-                "message": f"{target} target is ready via stored OAuth.",
-            }
-            for target in targets
-        },
+        _fake_probe_all_ok,
     )
 
     result = asyncio.run(auth_service.test_service("gws", user_email="alice@example.com"))
@@ -209,28 +226,8 @@ def test_list_summaries_prefers_native_gws_when_stored_oauth_expired(
         }
     ]
     service = UnifiedAuthService(oauth_service=oauth, secret_store=secret_store)
-    monkeypatch.setattr(
-        service,
-        "_detect_google_workspace_cli_native",
-        lambda user_email=None: {
-            "source": "native:gws_cli",
-            "email": "alice@example.com",
-            "message": "Local gws CLI profile available for alice@example.com.",
-        },
-    )
-    monkeypatch.setattr(
-        service,
-        "_probe_google_workspace_targets",
-        lambda targets, user_email=None, access_token=None, source=None: {
-            target: {
-                "target": target,
-                "success": True,
-                "source": source or "native:gws_cli",
-                "message": f"{target} target is ready via local gws CLI.",
-            }
-            for target in targets
-        },
-    )
+    monkeypatch.setattr(service, "_detect_google_workspace_cli_native", _fake_native_gws)
+    monkeypatch.setattr(service, "_probe_google_workspace_targets", _fake_probe_native_ok)
 
     summaries = asyncio.run(service.list_summaries())
     summary_by_service = {summary.service: summary for summary in summaries}
@@ -255,28 +252,8 @@ def test_test_service_prefers_native_gws_when_stored_oauth_expired(
         }
     ]
     service = UnifiedAuthService(oauth_service=oauth, secret_store=secret_store)
-    monkeypatch.setattr(
-        service,
-        "_detect_google_workspace_cli_native",
-        lambda user_email=None: {
-            "source": "native:gws_cli",
-            "email": "alice@example.com",
-            "message": "Local gws CLI profile available for alice@example.com.",
-        },
-    )
-    monkeypatch.setattr(
-        service,
-        "_probe_google_workspace_targets",
-        lambda targets, user_email=None, access_token=None, source=None: {
-            target: {
-                "target": target,
-                "success": True,
-                "source": source or "native:gws_cli",
-                "message": f"{target} target is ready via local gws CLI.",
-            }
-            for target in targets
-        },
-    )
+    monkeypatch.setattr(service, "_detect_google_workspace_cli_native", _fake_native_gws)
+    monkeypatch.setattr(service, "_probe_google_workspace_targets", _fake_probe_native_ok)
 
     result = asyncio.run(service.test_service("gws", user_email="alice@example.com"))
 
@@ -299,19 +276,12 @@ def test_test_service_gws_reports_target_failures(
         }
     ]
     service = UnifiedAuthService(oauth_service=oauth, secret_store=secret_store)
-    monkeypatch.setattr(
-        service,
-        "_detect_google_workspace_cli_native",
-        lambda user_email=None: {
-            "source": "native:gws_cli",
-            "email": "alice@example.com",
-            "message": "Local gws CLI profile available for alice@example.com.",
-        },
-    )
-    monkeypatch.setattr(
-        service,
-        "_probe_google_workspace_targets",
-        lambda targets, user_email=None, access_token=None, source=None: {
+    monkeypatch.setattr(service, "_detect_google_workspace_cli_native", _fake_native_gws)
+
+    async def _fake_probe_chat_fails(
+        targets, *, native=None, user_email=None, access_token=None, source=None
+    ):  # noqa: ANN001, ARG001
+        return {
             target: {
                 "target": target,
                 "success": target != "chat",
@@ -320,8 +290,9 @@ def test_test_service_gws_reports_target_failures(
                 "reason": None if target != "chat" else "missing_scopes",
             }
             for target in targets
-        },
-    )
+        }
+
+    monkeypatch.setattr(service, "_probe_google_workspace_targets", _fake_probe_chat_fails)
 
     result = asyncio.run(service.test_service("gws", user_email="alice@example.com"))
 
@@ -344,19 +315,12 @@ def test_list_summaries_marks_gws_error_when_some_targets_fail(
         }
     ]
     service = UnifiedAuthService(oauth_service=oauth, secret_store=secret_store)
-    monkeypatch.setattr(
-        service,
-        "_detect_google_workspace_cli_native",
-        lambda user_email=None: {
-            "source": "native:gws_cli",
-            "email": "alice@example.com",
-            "message": "Local gws CLI profile available for alice@example.com.",
-        },
-    )
-    monkeypatch.setattr(
-        service,
-        "_probe_google_workspace_targets",
-        lambda targets, user_email=None, access_token=None, source=None: {
+    monkeypatch.setattr(service, "_detect_google_workspace_cli_native", _fake_native_gws)
+
+    async def _fake_probe_chat_scopes(
+        targets, *, native=None, user_email=None, access_token=None, source=None
+    ):  # noqa: ANN001, ARG001
+        return {
             target: {
                 "target": target,
                 "success": target in {"drive", "docs", "sheets", "gmail", "calendar"},
@@ -367,8 +331,9 @@ def test_list_summaries_marks_gws_error_when_some_targets_fail(
                 "reason": None if target != "chat" else "missing_scopes",
             }
             for target in targets
-        },
-    )
+        }
+
+    monkeypatch.setattr(service, "_probe_google_workspace_targets", _fake_probe_chat_scopes)
 
     summaries = asyncio.run(service.list_summaries())
     summary_by_service = {summary.service: summary for summary in summaries}
@@ -428,3 +393,206 @@ def test_native_marker_requires_live_provider_chain_for_summary_and_resolution(
     assert summary_by_service["s3"].source == "missing"
     assert resolution.status == AuthStatus.NO_AUTH
     assert resolution.source == "missing"
+
+
+# ---------------------------------------------------------------------------
+# Direct tests for _probe_google_workspace_targets (async parallel probes)
+# ---------------------------------------------------------------------------
+
+
+class _FakeProcess:
+    """Simulates asyncio.subprocess.Process for testing."""
+
+    def __init__(self, returncode: int, stdout: str = "", stderr: str = "") -> None:
+        self.returncode = returncode
+        self._stdout = stdout.encode()
+        self._stderr = stderr.encode()
+
+    async def communicate(self) -> tuple[bytes, bytes]:
+        return self._stdout, self._stderr
+
+
+def _make_subprocess_mock(process_map: dict[str, _FakeProcess]):
+    """Return an async mock for asyncio.create_subprocess_exec.
+
+    ``process_map`` maps the first arg (program name + subcommand) to a _FakeProcess.
+    We identify each probe by matching the target-specific arguments from _GWS_TARGET_PROBES.
+    """
+    from nexus.bricks.auth.unified_service import _GWS_TARGET_PROBES
+
+    _probe_to_target = {tuple(args): target for target, args in _GWS_TARGET_PROBES.items()}
+
+    async def _mock_create(*args, **kwargs):  # noqa: ANN002, ANN003, ARG001
+        key = tuple(args)
+        target = _probe_to_target.get(key)
+        if target and target in process_map:
+            return process_map[target]
+        return _FakeProcess(returncode=1, stderr="unknown command")
+
+    return _mock_create
+
+
+@pytest.fixture
+def probe_service(tmp_path: Path) -> UnifiedAuthService:
+    store = FileSecretCredentialStore(tmp_path / "credentials.json")
+    return UnifiedAuthService(oauth_service=_FakeOAuthService(), secret_store=store)
+
+
+_NATIVE = {
+    "source": "native:gws_cli",
+    "email": "alice@example.com",
+    "message": "Local gws CLI profile available for alice@example.com.",
+}
+_TARGETS = ("drive", "docs", "sheets", "gmail", "calendar", "chat")
+
+
+def test_probe_all_targets_succeed(
+    probe_service: UnifiedAuthService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """All 6 probes succeed → every target marked success."""
+    import asyncio
+
+    processes = {t: _FakeProcess(returncode=0, stdout="{}") for t in _TARGETS}
+    monkeypatch.setattr(
+        "nexus.bricks.auth.unified_service.asyncio.create_subprocess_exec",
+        _make_subprocess_mock(processes),
+    )
+
+    checks = asyncio.run(
+        probe_service._probe_google_workspace_targets(
+            _TARGETS, native=_NATIVE, user_email="alice@example.com"
+        )
+    )
+
+    assert len(checks) == 6
+    for target in _TARGETS:
+        assert checks[target]["success"] is True
+        assert checks[target]["source"] == "native:gws_cli"
+
+
+def test_probe_failure_classification(
+    probe_service: UnifiedAuthService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Probes that fail are classified by error type: missing_scopes, expired, probe_failed."""
+    import asyncio
+
+    processes = {
+        "drive": _FakeProcess(returncode=0, stdout="{}"),
+        "docs": _FakeProcess(returncode=1, stderr="Insufficient Authentication Scopes for request"),
+        "sheets": _FakeProcess(returncode=1, stderr="auth_expired: token is no longer valid"),
+        "gmail": _FakeProcess(returncode=1, stderr="some other error occurred"),
+        "calendar": _FakeProcess(returncode=0, stdout="{}"),
+        "chat": _FakeProcess(returncode=0, stdout="{}"),
+    }
+    monkeypatch.setattr(
+        "nexus.bricks.auth.unified_service.asyncio.create_subprocess_exec",
+        _make_subprocess_mock(processes),
+    )
+
+    checks = asyncio.run(
+        probe_service._probe_google_workspace_targets(
+            _TARGETS, native=_NATIVE, user_email="alice@example.com"
+        )
+    )
+
+    assert checks["drive"]["success"] is True
+    assert checks["docs"]["success"] is False
+    assert checks["docs"]["reason"] == "missing_scopes"
+    assert checks["sheets"]["success"] is False
+    assert checks["sheets"]["reason"] == "expired"
+    assert checks["gmail"]["success"] is False
+    assert checks["gmail"]["reason"] == "probe_failed"
+    assert checks["calendar"]["success"] is True
+    assert checks["chat"]["success"] is True
+
+
+def test_probe_timeout_does_not_block_others(
+    probe_service: UnifiedAuthService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A single probe timing out doesn't prevent other probes from returning."""
+
+    class _TimeoutProcess:
+        """Simulates a process whose communicate() raises TimeoutError."""
+
+        async def communicate(self) -> tuple[bytes, bytes]:
+            raise TimeoutError("probe timed out")
+
+    processes: dict[str, _FakeProcess] = {}
+    for t in _TARGETS:
+        if t == "chat":
+            continue
+        processes[t] = _FakeProcess(returncode=0, stdout="{}")
+
+    from nexus.bricks.auth.unified_service import _GWS_TARGET_PROBES
+
+    _probe_to_target = {tuple(args): target for target, args in _GWS_TARGET_PROBES.items()}
+
+    async def _mock_create(*args, **kwargs):  # noqa: ANN002, ANN003, ARG001
+        target = _probe_to_target.get(tuple(args))
+        if target == "chat":
+            return _TimeoutProcess()
+        return processes.get(target, _FakeProcess(returncode=1, stderr="unknown"))
+
+    monkeypatch.setattr(
+        "nexus.bricks.auth.unified_service.asyncio.create_subprocess_exec",
+        _mock_create,
+    )
+
+    checks = asyncio.run(
+        probe_service._probe_google_workspace_targets(
+            _TARGETS, native=_NATIVE, user_email="alice@example.com"
+        )
+    )
+
+    assert len(checks) == 6
+    for t in ("drive", "docs", "sheets", "gmail", "calendar"):
+        assert checks[t]["success"] is True
+    assert checks["chat"]["success"] is False
+    assert checks["chat"]["reason"] == "probe_error"
+
+
+def test_probe_mixed_results(
+    probe_service: UnifiedAuthService, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Mix of success and failure returns correct per-target results with access_token path."""
+    import asyncio
+
+    processes = {
+        "drive": _FakeProcess(returncode=0, stdout="{}"),
+        "docs": _FakeProcess(returncode=0, stdout="{}"),
+        "sheets": _FakeProcess(returncode=1, stderr="permission denied"),
+        "gmail": _FakeProcess(returncode=0, stdout="{}"),
+        "calendar": _FakeProcess(returncode=1, stderr="Expired token"),
+        "chat": _FakeProcess(returncode=0, stdout="{}"),
+    }
+    monkeypatch.setattr(
+        "nexus.bricks.auth.unified_service.asyncio.create_subprocess_exec",
+        _make_subprocess_mock(processes),
+    )
+
+    checks = asyncio.run(
+        probe_service._probe_google_workspace_targets(
+            _TARGETS, access_token="ya29.test", user_email="alice@example.com"
+        )
+    )
+
+    assert checks["drive"]["success"] is True
+    assert "stored OAuth" in checks["drive"]["message"]
+    assert checks["sheets"]["success"] is False
+    assert checks["sheets"]["reason"] == "probe_failed"
+    assert checks["calendar"]["success"] is False
+    assert checks["calendar"]["reason"] == "expired"
+
+
+def test_probe_early_return_no_auth(probe_service: UnifiedAuthService) -> None:
+    """When no access_token and no native, all targets return missing_google_auth."""
+    import asyncio
+
+    checks = asyncio.run(
+        probe_service._probe_google_workspace_targets(_TARGETS, native=None, access_token=None)
+    )
+
+    assert len(checks) == 6
+    for target in _TARGETS:
+        assert checks[target]["success"] is False
+        assert checks[target]["reason"] == "missing_google_auth"

--- a/tests/unit/auth/test_unified_service.py
+++ b/tests/unit/auth/test_unified_service.py
@@ -517,7 +517,7 @@ def test_probe_timeout_does_not_block_others(
         returncode: int | None = None
 
         async def communicate(self) -> tuple[bytes, bytes]:
-            raise TimeoutError("probe timed out")
+            raise TimeoutError()  # real asyncio.wait_for raises empty TimeoutError
 
         def kill(self) -> None:
             self.returncode = -9
@@ -557,6 +557,7 @@ def test_probe_timeout_does_not_block_others(
         assert checks[t]["success"] is True
     assert checks["chat"]["success"] is False
     assert checks["chat"]["reason"] == "probe_error"
+    assert checks["chat"]["message"]  # must not be blank even with empty TimeoutError
 
 
 def test_probe_mixed_results(


### PR DESCRIPTION
## Summary

Closes #3604

- **Parallelizes 6 sequential GWS target probes** using `asyncio.create_subprocess_exec` + `asyncio.gather`, reducing `auth list` / `auth doctor` from ~7s to ~1-2s (bounded by the slowest single probe)
- **Converts `_detect_google_workspace_cli_native` to async** (`asyncio.create_subprocess_exec`), eliminating event loop blocking from the initial 10s-timeout subprocess call
- **Eliminates redundant native detection** (DRY fix): callers now pass the pre-computed `native` dict into the probe method instead of re-deriving it internally; caches the native result in the `list_summaries` loop so it's called once instead of 4x for Google services

## Test plan

- [x] All 12 existing auth unit tests pass (mocks updated for async signatures)
- [x] 5 new targeted tests for `_probe_google_workspace_targets`:
  - All 6 probes succeed → all targets marked success
  - Failure classification: missing_scopes, expired, probe_failed
  - Timeout isolation: one hanging probe doesn't block others
  - Mixed success/failure with access_token path
  - Early return when no native + no access_token
- [ ] Manual validation: `time nexus-fs auth list` with GWS credentials configured (expected ~1-2s vs previous ~7s)