### PR TITLE
feat(#1868): kernel boundary collapse — remove Python backend from Rust

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -560,6 +560,8 @@ jobs:
 
   migration-test:
     name: Migration Tests (SQLite)
+    needs: [detect-changes, build-rust]
+    if: needs.detect-changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
@@ -579,6 +581,15 @@ jobs:
       - name: Create virtual environment
         run: uv venv --python 3.13
 
+      - name: Download Rust wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: rust-wheels-ubuntu-latest
+          path: dist
+
+      - name: Install Rust extensions from wheels
+        run: uv pip install dist/*.whl
+
       - name: Install dependencies
         run: uv pip install -e ".[dev,test]"
 
@@ -588,6 +599,8 @@ jobs:
 
   migration-test-pg:
     name: Migration Tests (PostgreSQL)
+    needs: [detect-changes, build-rust]
+    if: needs.detect-changes.outputs.code_changed == 'true'
     runs-on: ubuntu-latest
     services:
       postgres:
@@ -622,6 +635,15 @@ jobs:
 
       - name: Create virtual environment
         run: uv venv --python 3.13
+
+      - name: Download Rust wheels
+        uses: actions/download-artifact@v4
+        with:
+          name: rust-wheels-ubuntu-latest
+          path: dist
+
+      - name: Install Rust extensions from wheels
+        run: uv pip install dist/*.whl
 
       - name: Install dependencies
         run: uv pip install -e ".[dev,test,postgres]"
@@ -706,3 +728,19 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - run: echo "No code changes — skipping E2E NATS tests"
+
+  migration-test-skip:
+    name: Migration Tests (SQLite)
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code_changed != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No code changes — skipping migration tests"
+
+  migration-test-pg-skip:
+    name: Migration Tests (PostgreSQL)
+    needs: detect-changes
+    if: needs.detect-changes.outputs.code_changed != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No code changes — skipping migration tests"

--- a/rust/nexus_pyo3/src/backend.rs
+++ b/rust/nexus_pyo3/src/backend.rs
@@ -1,0 +1,109 @@
+//! Kernel storage backend — pure Rust, no Python, no GIL.
+//!
+//! `StorageBackend` trait is the backend-level ABC for the Rust kernel.
+//! Each impl composes an addressing strategy with a transport:
+//!
+//!   `CasLocalBackend` = CAS addressing + LocalCASTransport
+//!
+//! Naming convention per `backend-architecture.md`: `<Addressing><Transport>Backend`.
+//!
+//! Future backends:
+//!   `CasGcsBackend` = CAS addressing + GCS transport
+//!   `PathLocalBackend` = Path addressing + Local transport
+
+use std::io;
+use std::path::Path;
+
+use crate::cas_engine::{CASEngine, CASError};
+use crate::cas_transport::LocalCASTransport;
+
+/// Error type for storage backend operations.
+#[derive(Debug)]
+#[allow(dead_code)]
+pub(crate) enum StorageError {
+    /// Content hash not found in storage.
+    NotFound(String),
+    /// Underlying I/O error.
+    IOError(io::Error),
+}
+
+impl From<CASError> for StorageError {
+    fn from(e: CASError) -> Self {
+        match e {
+            CASError::NotFound(s) => StorageError::NotFound(s),
+            CASError::IOError(e) => StorageError::IOError(e),
+        }
+    }
+}
+
+/// Kernel storage backend — pure Rust, no Python, no GIL.
+pub(crate) trait StorageBackend: Send + Sync {
+    fn read_content(&self, content_id: &str) -> Result<Vec<u8>, StorageError>;
+    fn write_content(&self, content: &[u8]) -> Result<String, StorageError>;
+}
+
+/// CAS + Local transport backend (Rust equivalent of Python CASLocalBackend).
+///
+/// Newtype around CASEngine to implement StorageBackend trait
+/// (avoids method name collision with CASEngine::read_content).
+pub(crate) struct CasLocalBackend(CASEngine);
+
+impl CasLocalBackend {
+    pub fn new(root: &Path, fsync: bool) -> io::Result<Self> {
+        let transport = LocalCASTransport::new(root, fsync)?;
+        Ok(Self(CASEngine::new(transport)))
+    }
+}
+
+impl StorageBackend for CasLocalBackend {
+    fn read_content(&self, content_id: &str) -> Result<Vec<u8>, StorageError> {
+        self.0.read_content(content_id).map_err(StorageError::from)
+    }
+
+    fn write_content(&self, content: &[u8]) -> Result<String, StorageError> {
+        self.0.write_content(content).map_err(StorageError::from)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn setup() -> (TempDir, CasLocalBackend) {
+        let tmp = TempDir::new().unwrap();
+        let backend = CasLocalBackend::new(tmp.path(), false).unwrap();
+        (tmp, backend)
+    }
+
+    #[test]
+    fn test_cas_local_backend_write_and_read() {
+        let (_tmp, backend) = setup();
+        let content = b"hello via StorageBackend";
+
+        let hash = backend.write_content(content).unwrap();
+        assert_eq!(hash.len(), 64);
+
+        let read_back = backend.read_content(&hash).unwrap();
+        assert_eq!(read_back, content);
+    }
+
+    #[test]
+    fn test_cas_local_backend_not_found() {
+        let (_tmp, backend) = setup();
+        let result = backend
+            .read_content("0000000000000000000000000000000000000000000000000000000000000000");
+        assert!(result.is_err());
+        assert!(matches!(result.unwrap_err(), StorageError::NotFound(_)));
+    }
+
+    #[test]
+    fn test_cas_local_backend_dedup() {
+        let (_tmp, backend) = setup();
+        let content = b"dedup via StorageBackend";
+
+        let hash1 = backend.write_content(content).unwrap();
+        let hash2 = backend.write_content(content).unwrap();
+        assert_eq!(hash1, hash2);
+    }
+}

--- a/rust/nexus_pyo3/src/backend.rs
+++ b/rust/nexus_pyo3/src/backend.rs
@@ -1,6 +1,6 @@
-//! Kernel storage backend — pure Rust, no Python, no GIL.
+//! ObjectStore pillar — Rust kernel `file_operations` contract.
 //!
-//! `StorageBackend` trait is the backend-level ABC for the Rust kernel.
+//! Rust equivalent of Python `ObjectStoreABC` (one of the Four Storage Pillars).
 //! Each impl composes an addressing strategy with a transport:
 //!
 //!   `CasLocalBackend` = CAS addressing + LocalCASTransport
@@ -17,14 +17,16 @@ use std::path::Path;
 use crate::cas_engine::{CASEngine, CASError};
 use crate::cas_transport::LocalCASTransport;
 
-/// Error type for storage backend operations.
+/// Error type for ObjectStore operations.
 #[derive(Debug)]
 #[allow(dead_code)]
 pub(crate) enum StorageError {
-    /// Content hash not found in storage.
+    /// Content not found.
     NotFound(String),
     /// Underlying I/O error.
     IOError(io::Error),
+    /// Operation not supported by this backend.
+    NotSupported(&'static str),
 }
 
 impl From<CASError> for StorageError {
@@ -36,16 +38,55 @@ impl From<CASError> for StorageError {
     }
 }
 
-/// Kernel storage backend — pure Rust, no Python, no GIL.
-pub(crate) trait StorageBackend: Send + Sync {
-    fn read_content(&self, content_id: &str) -> Result<Vec<u8>, StorageError>;
+/// ObjectStore pillar — kernel `file_operations` contract.
+///
+/// Rust equivalent of Python `ObjectStoreABC`.
+/// 6 abstract methods matching the Python ABC:
+///   - write_content, read_content, delete_content, get_content_size
+///   - mkdir, rmdir
+///
+/// Streaming (write_stream, stream_content, stream_range) and batch
+/// (batch_read/write/delete) have default impls in Python; they are
+/// not needed in the Rust kernel hot path and can be added later.
+#[allow(dead_code)]
+pub(crate) trait ObjectStore: Send + Sync {
+    /// Backend identifier (e.g. "local", "gcs", "s3").
+    fn name(&self) -> &str;
+
+    /// Write content and return `(content_id, size)`.
     fn write_content(&self, content: &[u8]) -> Result<String, StorageError>;
+
+    /// Read content by opaque identifier.
+    fn read_content(&self, content_id: &str) -> Result<Vec<u8>, StorageError>;
+
+    /// Delete content by identifier.
+    fn delete_content(&self, content_id: &str) -> Result<(), StorageError> {
+        let _ = content_id;
+        Err(StorageError::NotSupported("delete_content"))
+    }
+
+    /// Get content size in bytes.
+    fn get_content_size(&self, content_id: &str) -> Result<u64, StorageError> {
+        let _ = content_id;
+        Err(StorageError::NotSupported("get_content_size"))
+    }
+
+    /// Create a directory.
+    fn mkdir(&self, path: &str, parents: bool, exist_ok: bool) -> Result<(), StorageError> {
+        let _ = (path, parents, exist_ok);
+        Err(StorageError::NotSupported("mkdir"))
+    }
+
+    /// Remove a directory.
+    fn rmdir(&self, path: &str, recursive: bool) -> Result<(), StorageError> {
+        let _ = (path, recursive);
+        Err(StorageError::NotSupported("rmdir"))
+    }
 }
 
 /// CAS + Local transport backend (Rust equivalent of Python CASLocalBackend).
 ///
-/// Newtype around CASEngine to implement StorageBackend trait
-/// (avoids method name collision with CASEngine::read_content).
+/// Newtype around CASEngine to implement ObjectStore trait.
 pub(crate) struct CasLocalBackend(CASEngine);
 
 impl CasLocalBackend {
@@ -55,13 +96,27 @@ impl CasLocalBackend {
     }
 }
 
-impl StorageBackend for CasLocalBackend {
+impl ObjectStore for CasLocalBackend {
+    fn name(&self) -> &str {
+        "local"
+    }
+
     fn read_content(&self, content_id: &str) -> Result<Vec<u8>, StorageError> {
         self.0.read_content(content_id).map_err(StorageError::from)
     }
 
     fn write_content(&self, content: &[u8]) -> Result<String, StorageError> {
         self.0.write_content(content).map_err(StorageError::from)
+    }
+
+    fn delete_content(&self, content_id: &str) -> Result<(), StorageError> {
+        self.0
+            .delete_content(content_id)
+            .map_err(StorageError::from)
+    }
+
+    fn get_content_size(&self, content_id: &str) -> Result<u64, StorageError> {
+        self.0.content_size(content_id).map_err(StorageError::from)
     }
 }
 
@@ -79,7 +134,7 @@ mod tests {
     #[test]
     fn test_cas_local_backend_write_and_read() {
         let (_tmp, backend) = setup();
-        let content = b"hello via StorageBackend";
+        let content = b"hello via ObjectStore";
 
         let hash = backend.write_content(content).unwrap();
         assert_eq!(hash.len(), 64);
@@ -100,10 +155,49 @@ mod tests {
     #[test]
     fn test_cas_local_backend_dedup() {
         let (_tmp, backend) = setup();
-        let content = b"dedup via StorageBackend";
+        let content = b"dedup via ObjectStore";
 
         let hash1 = backend.write_content(content).unwrap();
         let hash2 = backend.write_content(content).unwrap();
         assert_eq!(hash1, hash2);
+    }
+
+    #[test]
+    fn test_cas_local_backend_name() {
+        let (_tmp, backend) = setup();
+        assert_eq!(backend.name(), "local");
+    }
+
+    #[test]
+    fn test_cas_local_backend_delete() {
+        let (_tmp, backend) = setup();
+        let hash = backend.write_content(b"to delete").unwrap();
+        assert!(backend.delete_content(&hash).is_ok());
+        assert!(matches!(
+            backend.read_content(&hash).unwrap_err(),
+            StorageError::NotFound(_)
+        ));
+    }
+
+    #[test]
+    fn test_cas_local_backend_get_content_size() {
+        let (_tmp, backend) = setup();
+        let content = b"size check";
+        let hash = backend.write_content(content).unwrap();
+        assert_eq!(
+            backend.get_content_size(&hash).unwrap(),
+            content.len() as u64
+        );
+    }
+
+    #[test]
+    fn test_default_mkdir_not_supported() {
+        // CasLocalBackend doesn't override mkdir/rmdir defaults
+        // (CAS backends have no directory concept)
+        let (_tmp, backend) = setup();
+        assert!(matches!(
+            backend.mkdir("/foo", false, false).unwrap_err(),
+            StorageError::NotSupported("mkdir")
+        ));
     }
 }

--- a/rust/nexus_pyo3/src/lib.rs
+++ b/rust/nexus_pyo3/src/lib.rs
@@ -4,6 +4,7 @@
 #[global_allocator]
 static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
+mod backend;
 mod bitmap;
 mod bloom;
 mod cache;
@@ -123,6 +124,9 @@ fn nexus_fast(m: &Bound<PyModule>) -> PyResult<()> {
     // Phase H: stat/rename plan types
     m.add_class::<syscall::StatPlan>()?;
     m.add_class::<syscall::RenamePlan>()?;
+    // Kernel boundary collapse: strong-typed syscall results
+    m.add_class::<syscall::SysReadResult>()?;
+    m.add_class::<syscall::SysWriteResult>()?;
     // Path utilities (Issue #1817 prerequisite)
     m.add_function(wrap_pyfunction!(path_utils::split_path, m)?)?;
     m.add_function(wrap_pyfunction!(path_utils::get_parent, m)?)?;

--- a/rust/nexus_pyo3/src/router.rs
+++ b/rust/nexus_pyo3/src/router.rs
@@ -14,7 +14,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::backend::{CasLocalBackend, StorageBackend};
+use crate::backend::{CasLocalBackend, ObjectStore};
 
 // ---------------------------------------------------------------------------
 // Internal types
@@ -26,7 +26,7 @@ struct MountEntry {
     admin_only: bool,
     io_profile: String,
     backend_name: String,
-    backend: Option<Box<dyn StorageBackend>>,
+    backend: Option<Box<dyn ObjectStore>>,
 }
 
 #[derive(Debug)]
@@ -188,7 +188,7 @@ impl RustPathRouter {
         fsync: bool,
     ) -> PyResult<()> {
         let canonical = canonicalize(mount_point, zone_id);
-        let backend: Option<Box<dyn StorageBackend>> = match local_root {
+        let backend: Option<Box<dyn ObjectStore>> = match local_root {
             Some(root) => {
                 let b = CasLocalBackend::new(Path::new(root), fsync)
                     .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;

--- a/rust/nexus_pyo3/src/router.rs
+++ b/rust/nexus_pyo3/src/router.rs
@@ -14,8 +14,7 @@ use std::collections::HashMap;
 use std::path::Path;
 use std::sync::Arc;
 
-use crate::cas_engine::CASEngine;
-use crate::cas_transport::LocalCASTransport;
+use crate::backend::{CasLocalBackend, StorageBackend};
 
 // ---------------------------------------------------------------------------
 // Internal types
@@ -27,8 +26,7 @@ struct MountEntry {
     admin_only: bool,
     io_profile: String,
     backend_name: String,
-    cas: Option<CASEngine>,
-    backend_obj: Option<Py<PyAny>>,
+    backend: Option<Box<dyn StorageBackend>>,
 }
 
 #[derive(Debug)]
@@ -131,66 +129,24 @@ impl RustPathRouterInner {
         )))
     }
 
-    /// Read content from the CAS engine attached to a mount (Phase E.1).
+    /// Read content from the storage backend attached to a mount.
     ///
     /// `mount_point` must be a zone-canonical key (from route result).
-    pub(crate) fn read_cas(&self, mount_point: &str, etag: &str) -> Option<Vec<u8>> {
+    /// Pure Rust — no GIL, no Python callbacks.
+    pub(crate) fn read_content(&self, mount_point: &str, etag: &str) -> Option<Vec<u8>> {
         let mounts = self.mounts.read();
         let entry = mounts.get(mount_point)?;
-        entry.cas.as_ref()?.read_content(etag).ok()
+        entry.backend.as_ref()?.read_content(etag).ok()
     }
 
-    /// Write content to the CAS engine attached to a mount (Phase E.1).
+    /// Write content to the storage backend attached to a mount.
     ///
     /// Returns BLAKE3 hex hash on success.
-    pub(crate) fn write_cas(&self, mount_point: &str, content: &[u8]) -> Option<String> {
+    /// Pure Rust — no GIL, no Python callbacks.
+    pub(crate) fn write_content(&self, mount_point: &str, content: &[u8]) -> Option<String> {
         let mounts = self.mounts.read();
         let entry = mounts.get(mount_point)?;
-        entry.cas.as_ref()?.write_content(content).ok()
-    }
-
-    /// Read content via the Python backend object (Phase F).
-    ///
-    /// GIL safety: clone `Py<PyAny>` under RwLock, release lock, then call Python.
-    /// Same pattern as dispatch.rs HookEntry.
-    ///
-    /// CAS backends: `read_content(etag)` — no context needed.
-    /// PAS backends: `read_content(etag, context=OperationContext(backend_path=...))`.
-    /// For simplicity, we always call `read_content(content_id)` without context —
-    /// PAS backends that need context will raise, and Python fallback handles it.
-    pub(crate) fn read_backend(
-        &self,
-        py: Python<'_>,
-        mount_point: &str,
-        etag: &str,
-    ) -> Option<Py<PyAny>> {
-        // 1. Hold RwLock → clone Py<PyAny> → release RwLock
-        let backend_ref = {
-            let mounts = self.mounts.read();
-            mounts.get(mount_point)?.backend_obj.as_ref()?.clone_ref(py)
-        };
-        // 2. RwLock released — safe to call Python
-        backend_ref.call_method1(py, "read_content", (etag,)).ok()
-    }
-
-    /// Write content via the Python backend object (Phase F).
-    ///
-    /// Returns the Python WriteResult object on success.
-    /// GIL safety: same clone-then-call pattern as read_backend.
-    pub(crate) fn write_backend(
-        &self,
-        py: Python<'_>,
-        mount_point: &str,
-        content: &[u8],
-    ) -> Option<Py<PyAny>> {
-        let backend_ref = {
-            let mounts = self.mounts.read();
-            mounts.get(mount_point)?.backend_obj.as_ref()?.clone_ref(py)
-        };
-        let py_bytes = pyo3::types::PyBytes::new(py, content);
-        backend_ref
-            .call_method1(py, "write_content", (py_bytes,))
-            .ok()
+        entry.backend.as_ref()?.write_content(content).ok()
     }
 }
 
@@ -214,9 +170,11 @@ impl RustPathRouter {
 
     /// Register a mount at a zone-canonical key.
     ///
-    /// When `local_root` is provided, a `CASEngine` is auto-created for the
-    /// mount point, enabling full Rust I/O via `SyscallEngine.execute_read/write`.
-    #[pyo3(signature = (mount_point, zone_id, readonly, admin_only, io_profile, backend_name="", local_root=None, fsync=false, backend=None))]
+    /// When `local_root` is provided, a `CasLocalBackend` is auto-created for
+    /// the mount point, enabling full Rust I/O via `SyscallEngine.sys_read/write`.
+    /// No Python backend — mounts without `local_root` return `None` from
+    /// `sys_read`/`sys_write`, and the Python full path handles them.
+    #[pyo3(signature = (mount_point, zone_id, readonly, admin_only, io_profile, backend_name="", local_root=None, fsync=false))]
     #[allow(clippy::too_many_arguments)]
     fn add_mount(
         &self,
@@ -228,14 +186,13 @@ impl RustPathRouter {
         backend_name: &str,
         local_root: Option<&str>,
         fsync: bool,
-        backend: Option<Py<PyAny>>,
     ) -> PyResult<()> {
         let canonical = canonicalize(mount_point, zone_id);
-        let cas = match local_root {
+        let backend: Option<Box<dyn StorageBackend>> = match local_root {
             Some(root) => {
-                let transport = LocalCASTransport::new(Path::new(root), fsync)
+                let b = CasLocalBackend::new(Path::new(root), fsync)
                     .map_err(|e| pyo3::exceptions::PyIOError::new_err(e.to_string()))?;
-                Some(CASEngine::new(transport))
+                Some(Box::new(b))
             }
             None => None,
         };
@@ -246,8 +203,7 @@ impl RustPathRouter {
                 admin_only,
                 io_profile: io_profile.to_string(),
                 backend_name: backend_name.to_string(),
-                cas,
-                backend_obj: backend,
+                backend,
             },
         );
         Ok(())
@@ -407,8 +363,7 @@ mod tests {
                     admin_only: false,
                     io_profile: "balanced".to_string(),
                     backend_name: String::new(),
-                    cas: None,
-                    backend_obj: None,
+                    backend: None,
                 },
             );
             m.insert(
@@ -418,8 +373,7 @@ mod tests {
                     admin_only: false,
                     io_profile: "fast".to_string(),
                     backend_name: String::new(),
-                    cas: None,
-                    backend_obj: None,
+                    backend: None,
                 },
             );
         }
@@ -442,8 +396,7 @@ mod tests {
                 admin_only: false,
                 io_profile: "balanced".to_string(),
                 backend_name: String::new(),
-                cas: None,
-                backend_obj: None,
+                backend: None,
             },
         );
 
@@ -464,8 +417,7 @@ mod tests {
                 admin_only: false,
                 io_profile: "balanced".to_string(),
                 backend_name: String::new(),
-                cas: None,
-                backend_obj: None,
+                backend: None,
             },
         );
 
@@ -485,8 +437,7 @@ mod tests {
                 admin_only: true,
                 io_profile: "balanced".to_string(),
                 backend_name: String::new(),
-                cas: None,
-                backend_obj: None,
+                backend: None,
             },
         );
 
@@ -513,8 +464,7 @@ mod tests {
                     admin_only: false,
                     io_profile: "balanced".to_string(),
                     backend_name: String::new(),
-                    cas: None,
-                    backend_obj: None,
+                    backend: None,
                 },
             );
             m.insert(
@@ -524,8 +474,7 @@ mod tests {
                     admin_only: false,
                     io_profile: "balanced".to_string(),
                     backend_name: String::new(),
-                    cas: None,
-                    backend_obj: None,
+                    backend: None,
                 },
             );
         }

--- a/rust/nexus_pyo3/src/syscall.rs
+++ b/rust/nexus_pyo3/src/syscall.rs
@@ -21,6 +21,26 @@ use pyo3::types::{PyBytes, PyDict};
 use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 
+// ── Strong-typed result types ──────────────────────────────────────────
+
+/// Result of sys_read(): concrete type instead of Option<bytes>.
+#[pyclass(get_all)]
+pub struct SysReadResult {
+    /// True if Rust backend served the read.
+    pub hit: bool,
+    /// Content bytes (only when hit=true).
+    pub data: Option<Py<PyBytes>>,
+}
+
+/// Result of sys_write(): concrete type instead of Option<str>.
+#[pyclass(get_all)]
+pub struct SysWriteResult {
+    /// True if Rust backend completed the write.
+    pub hit: bool,
+    /// BLAKE3 content hash (only when hit=true).
+    pub content_id: Option<String>,
+}
+
 // ── Action constants ────────────────────────────────────────────────────
 
 /// Normal read/write: dcache hit, routing resolved. Use plan fields directly.
@@ -237,27 +257,32 @@ impl SyscallEngine {
 
     /// Rust syscall: read file content.
     ///
-    /// Checks hook count → plans → acquires VFS read lock → CAS / backend I/O → releases lock.
-    /// Returns None if hooks are present, dcache miss, or I/O fails → Python fallback.
+    /// Checks hook count → plans → acquires VFS read lock → Rust backend I/O → releases lock.
+    /// Returns SysReadResult { hit: false } for Python fallback (hooks, dcache miss, no backend).
     fn sys_read<'py>(
         &self,
         py: Python<'py>,
         path: &str,
         zone_id: &str,
         is_admin: bool,
-    ) -> PyResult<Option<Bound<'py, PyBytes>>> {
+    ) -> SysReadResult {
+        let miss = || SysReadResult {
+            hit: false,
+            data: None,
+        };
+
         // 0. Hook check — if hooks registered, Python must run them
         if self.read_hook_count.load(Ordering::Relaxed) > 0 {
-            return Ok(None);
+            return miss();
         }
 
         let plan = self.plan_read(path, zone_id, is_admin);
         if plan.action != ACTION_DCACHE_HIT {
-            return Ok(None);
+            return miss();
         }
         let etag = match &plan.etag {
             Some(e) if !e.is_empty() => e.as_str(),
-            _ => return Ok(None),
+            _ => return miss(),
         };
 
         // 1. VFS read lock (non-blocking try-acquire)
@@ -267,25 +292,19 @@ impl SyscallEngine {
             .map(|lm| lm.try_acquire(path, LockMode::Read));
         if let Some(0) = lock_handle {
             // Lock contention — fall back to Python (which has blocking/timeout)
-            return Ok(None);
+            return miss();
         }
 
-        // 2. CAS fast path (pure Rust, ~2μs)
-        let result = if let Some(data) = self.router.read_cas(&plan.mount_point, etag) {
-            Ok(Some(PyBytes::new(py, &data)))
-        } else if let Some(py_result) = self.router.read_backend(py, &plan.mount_point, etag) {
-            // 3. Python backend callback (Phase F, ~12-15μs)
-            if let Ok(data) = py_result.extract::<Vec<u8>>(py) {
-                Ok(Some(PyBytes::new(py, &data)))
-            } else {
-                Ok(None)
-            }
-        } else {
-            // 4. Both failed → None → Python full path fallback
-            Ok(None)
+        // 2. Rust backend I/O (pure Rust, no GIL, ~2μs)
+        let result = match self.router.read_content(&plan.mount_point, etag) {
+            Some(data) => SysReadResult {
+                hit: true,
+                data: Some(PyBytes::new(py, &data).into()),
+            },
+            None => miss(),
         };
 
-        // 5. Release VFS lock
+        // 3. Release VFS lock
         if let Some(handle) = lock_handle {
             if handle > 0 {
                 if let Some(lm) = &self.vfs_lock {
@@ -301,19 +320,23 @@ impl SyscallEngine {
 
     /// Rust syscall: write file content.
     ///
-    /// Checks hook count → plans → acquires VFS write lock → CAS / backend I/O → releases lock.
-    /// Returns content_id on success, None for Python fallback.
+    /// Checks hook count → plans → acquires VFS write lock → Rust backend I/O → releases lock.
+    /// Returns SysWriteResult { hit: false } for Python fallback.
     fn sys_write(
         &self,
-        py: Python<'_>,
         path: &str,
         zone_id: &str,
         content: &[u8],
         is_admin: bool,
-    ) -> PyResult<Option<String>> {
+    ) -> PyResult<SysWriteResult> {
+        let miss = || SysWriteResult {
+            hit: false,
+            content_id: None,
+        };
+
         // 0. Hook check
         if self.write_hook_count.load(Ordering::Relaxed) > 0 {
-            return Ok(None);
+            return Ok(miss());
         }
 
         let plan = self.plan_write(path, zone_id, is_admin);
@@ -323,7 +346,7 @@ impl SyscallEngine {
             ));
         }
         if plan.action != ACTION_DCACHE_HIT {
-            return Ok(None);
+            return Ok(miss());
         }
 
         // 1. VFS write lock (non-blocking try-acquire)
@@ -332,29 +355,19 @@ impl SyscallEngine {
             .as_ref()
             .map(|lm| lm.try_acquire(path, LockMode::Write));
         if let Some(0) = lock_handle {
-            return Ok(None);
+            return Ok(miss());
         }
 
-        // 2. CAS fast path (pure Rust)
-        let result = if let Some(hash) = self.router.write_cas(&plan.mount_point, content) {
-            Ok(Some(hash))
-        } else if let Some(write_result) = self.router.write_backend(py, &plan.mount_point, content)
-        {
-            // 3. Python backend callback (Phase F)
-            if let Ok(content_id) = write_result.getattr(py, "content_id") {
-                if let Ok(s) = content_id.extract::<String>(py) {
-                    Ok(Some(s))
-                } else {
-                    Ok(None)
-                }
-            } else {
-                Ok(None)
-            }
-        } else {
-            Ok(None)
+        // 2. Rust backend I/O (pure Rust, no GIL)
+        let result = match self.router.write_content(&plan.mount_point, content) {
+            Some(hash) => SysWriteResult {
+                hit: true,
+                content_id: Some(hash),
+            },
+            None => miss(),
         };
 
-        // 4. Release VFS lock
+        // 3. Release VFS lock
         if let Some(handle) = lock_handle {
             if handle > 0 {
                 if let Some(lm) = &self.vfs_lock {
@@ -363,7 +376,7 @@ impl SyscallEngine {
             }
         }
 
-        result
+        Ok(result)
     }
 
     // ── sys_stat (Phase H) ──────────────────────────────────────────────

--- a/rust/nexus_pyo3/src/volume_engine.rs
+++ b/rust/nexus_pyo3/src/volume_engine.rs
@@ -2813,7 +2813,7 @@ mod tests {
         // Write enough data to trigger multiple volume seals
         for i in 0..10u8 {
             let hash = hash_hex(i);
-            engine.put(&hash, &vec![i; 100]).unwrap();
+            engine.put(&hash, &[i; 100]).unwrap();
         }
 
         // Should have sealed some volumes
@@ -2863,7 +2863,7 @@ mod tests {
 
         // Write 10 entries
         for i in 0..10u8 {
-            engine.put(&hash_hex(i), &vec![i; 50]).unwrap();
+            engine.put(&hash_hex(i), &[i; 50]).unwrap();
         }
         engine.do_seal_active().unwrap();
 

--- a/src/nexus/core/metastore.py
+++ b/src/nexus/core/metastore.py
@@ -81,7 +81,7 @@ class MetastoreABC(ABC):
         self._dcache: dict[str, FileMetadata] = {}
         self._dcache_hits: int = 0
         self._dcache_misses: int = 0
-        self._rust_dcache: Any = _RustDCache() if _RustDCache is not None else None
+        self._rust_dcache = _RustDCache()
 
     # ── Cached public API (signatures unchanged) ──────────────────────
 
@@ -126,8 +126,7 @@ class MetastoreABC(ABC):
     def delete(self, path: str, *, consistency: str = "sc") -> dict[str, Any] | None:
         """Delete file metadata (evicts dcache entry)."""
         self._dcache.pop(path, None)
-        if self._rust_dcache is not None:
-            self._rust_dcache.evict(path)
+        self._rust_dcache.evict(path)
         return self._delete_raw(path, consistency=consistency)
 
     def dcache_evict_prefix(self, prefix: str) -> int:
@@ -141,8 +140,7 @@ class MetastoreABC(ABC):
         keys = [k for k in self._dcache if k.startswith(prefix)]
         for k in keys:
             del self._dcache[k]
-        if self._rust_dcache is not None:
-            self._rust_dcache.evict_prefix(prefix)
+        self._rust_dcache.evict_prefix(prefix)
         return len(keys)
 
     def exists(self, path: str) -> bool:
@@ -208,8 +206,7 @@ class MetastoreABC(ABC):
         rust_dc = self._rust_dcache
         for p in paths:
             self._dcache.pop(p, None)
-            if rust_dc is not None:
-                rust_dc.evict(p)
+            rust_dc.evict(p)
         self._delete_batch_raw(paths)
 
     def put_batch(
@@ -265,7 +262,7 @@ class MetastoreABC(ABC):
             "hits": self._dcache_hits,
             "misses": self._dcache_misses,
             "size": len(self._dcache),
-            "rust": self._rust_dcache.stats() if self._rust_dcache is not None else {},
+            "rust": self._rust_dcache.stats(),
         }
 
     # ── Abstract raw methods (subclasses implement these) ─────────────

--- a/src/nexus/core/metastore.py
+++ b/src/nexus/core/metastore.py
@@ -30,24 +30,16 @@ from abc import ABC, abstractmethod
 from collections.abc import Iterator, Sequence
 from typing import Any
 
-from nexus.contracts.metadata import FileMetadata
+from nexus_fast import RustDCache as _RustDCache
 
-# RUST_FALLBACK: RustDCache — DashMap dentry cache (Issue #1838)
-_RustDCache: type | None
-try:
-    from nexus_fast import RustDCache as _RustDCache
-except ImportError:
-    _RustDCache = None
+from nexus.contracts.metadata import FileMetadata
 
 
 def _sync_to_rust(rust_dc: Any, meta: FileMetadata) -> None:
     """Push a FileMetadata into the Rust DashMap (hot-path projection).
 
-    No-op when RustDCache is unavailable (nexus_fast not installed).
     Phase H: added mime_type for sys_stat acceleration.
     """
-    if rust_dc is None:
-        return
     rust_dc.put(
         meta.path,
         meta.backend_name,

--- a/src/nexus/core/mount_table.py
+++ b/src/nexus/core/mount_table.py
@@ -160,7 +160,6 @@ class MountTable:
                 _backend_name,
                 _local_root,
                 True,  # fsync
-                backend,
             )
 
     def remove(self, mount_point: str, zone_id: str = ROOT_ZONE_ID) -> bool:

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -237,23 +237,15 @@ class NexusFS(  # type: ignore[misc]
         self._service_registry: ServiceRegistry = ServiceRegistry(dispatch=self._dispatch)
 
         # ── SyscallEngine (Issue #1817 — single-FFI sys_read/sys_write) ──
-        self._syscall_engine = None
-        try:
-            from nexus_fast import SyscallEngine as _SyscallEngine
+        from nexus_fast import SyscallEngine as _SyscallEngine
 
-            _rust_dcache = getattr(metadata_store, "_rust_dcache", None)
-            _rust_router = getattr(self._mount_table, "_rust", None)
-            _rust_trie = getattr(self._dispatch, "_trie", None)
-            _rust_vfs_lock = getattr(self._vfs_lock_manager, "_rust", None)
-            if _rust_dcache is not None and _rust_router is not None and _rust_trie is not None:
-                self._syscall_engine = _SyscallEngine(
-                    _rust_dcache, _rust_router, _rust_trie, _rust_vfs_lock
-                )
-                # Wire hook count sync (Phase G): dispatch pushes counts to Rust
-                self._dispatch._syscall_engine = self._syscall_engine
-                logger.info("SyscallEngine initialized (Rust fast path enabled)")
-        except (ImportError, TypeError):
-            pass  # nexus_fast not installed or mock objects in tests
+        self._syscall_engine = _SyscallEngine(
+            metadata_store._rust_dcache,
+            self._mount_table._rust,
+            self._dispatch._trie,
+            getattr(self._vfs_lock_manager, "_rust", None),
+        )
+        self._dispatch._syscall_engine = self._syscall_engine
 
         # ── Kernel-knows (sentinel None, injected by factory) ───────────
         # See KERNEL-ARCHITECTURE.md §1 DI patterns table.
@@ -643,7 +635,7 @@ class NexusFS(  # type: ignore[misc]
         """
         # ── Rust fast path (Phase H): dcache hit → dict from Rust ──────
         # Skipped when include_lock=True (needs Python _lock_manager).
-        if self._syscall_engine is not None and not include_lock:
+        if not include_lock:
             _is_admin = (
                 getattr(context, "is_admin", False)
                 if context is not None and not isinstance(context, dict)
@@ -1288,16 +1280,17 @@ class NexusFS(  # type: ignore[misc]
                 raise NexusFileNotFoundError(path, f"Stream closed: {path}") from None
 
         # ── Rust sys_read fast path (Issue #1817 Phase G) ─────────────────
-        # Hot path: hook check + dcache hit + VFS lock + CAS/backend I/O.
+        # Hot path: hook check + dcache hit + VFS lock + Rust backend I/O.
         # One FFI call replaces: validate + trie + route + dcache + lock + read.
-        # Falls back to Python path below on hook presence, dcache miss, or lock contention.
-        if self._syscall_engine is not None:
-            _is_admin = (
-                getattr(context, "is_admin", False)
-                if context is not None and not isinstance(context, dict)
-                else (context.get("is_admin", False) if isinstance(context, dict) else False)
-            )
-            _data = self._syscall_engine.sys_read(path, self._zone_id, _is_admin)
+        # Falls back to Python path below on hook presence, dcache miss, or no Rust backend.
+        _is_admin = (
+            getattr(context, "is_admin", False)
+            if context is not None and not isinstance(context, dict)
+            else (context.get("is_admin", False) if isinstance(context, dict) else False)
+        )
+        _result = self._syscall_engine.sys_read(path, self._zone_id, _is_admin)
+        if _result.hit:
+            _data = _result.data
             # CDC chunked manifests must be reassembled by Python — skip Rust fast path.
             if _data is not None and not _data[:30].startswith(b'{"type":"chunked_manifest'):
                 if offset or count is not None:

--- a/stubs/nexus_fast/__init__.pyi
+++ b/stubs/nexus_fast/__init__.pyi
@@ -349,7 +349,6 @@ class RustPathRouter:
         backend_name: str = "",
         local_root: str | None = None,
         fsync: bool = False,
-        backend: Any = None,
     ) -> None: ...
     def remove_mount(self, mount_point: str, zone_id: str) -> bool: ...
     def route(
@@ -429,6 +428,14 @@ class RenamePlan:
     entry_type: int
     error_msg: str | None
 
+class SysReadResult:
+    hit: bool
+    data: bytes | None
+
+class SysWriteResult:
+    hit: bool
+    content_id: str | None
+
 class SyscallEngine:
     def __init__(
         self,
@@ -444,8 +451,10 @@ class SyscallEngine:
     def plan_rename(
         self, old_path: str, new_path: str, zone_id: str, is_admin: bool
     ) -> RenamePlan: ...
-    def sys_read(self, path: str, zone_id: str, is_admin: bool) -> bytes | None: ...
-    def sys_write(self, path: str, zone_id: str, content: bytes, is_admin: bool) -> str | None: ...
+    def sys_read(self, path: str, zone_id: str, is_admin: bool) -> SysReadResult: ...
+    def sys_write(
+        self, path: str, zone_id: str, content: bytes, is_admin: bool
+    ) -> SysWriteResult: ...
     def sys_stat(self, path: str, zone_id: str, is_admin: bool) -> dict[str, Any] | None: ...
     def set_hook_count(self, op: str, count: int) -> None: ...
     def __repr__(self) -> str: ...

--- a/tests/e2e/self_contained/test_raft_metadata_store.py
+++ b/tests/e2e/self_contained/test_raft_metadata_store.py
@@ -12,6 +12,7 @@ from datetime import datetime
 from typing import Any
 
 import pytest
+from nexus_fast import RustDCache
 
 from nexus.contracts.metadata import FileMetadata
 from nexus.storage.raft_metadata_store import RaftMetadataStore
@@ -182,7 +183,7 @@ def _make_store(fake: FakeLocalRaft | None = None) -> RaftMetadataStore:
     store._dcache = {}
     store._dcache_hits = 0
     store._dcache_misses = 0
-    store._rust_dcache = None  # RustDCache fallback (Issue #1838)
+    store._rust_dcache = RustDCache()
     store._engine = fake
     store._client = None
     store._zone_id = None

--- a/tests/e2e/self_contained/test_raft_metadata_store.py
+++ b/tests/e2e/self_contained/test_raft_metadata_store.py
@@ -650,7 +650,7 @@ class TestMultiZoneIsolation:
         fake_a = FakeLocalRaft()
         store_a = object.__new__(RaftMetadataStore)
         store_a._dcache, store_a._dcache_hits, store_a._dcache_misses = {}, 0, 0
-        store_a._rust_dcache = None
+        store_a._rust_dcache = RustDCache()
         store_a._engine = fake_a
         store_a._client = None
         store_a._zone_id = "zone_a"
@@ -658,7 +658,7 @@ class TestMultiZoneIsolation:
         fake_b = FakeLocalRaft()
         store_b = object.__new__(RaftMetadataStore)
         store_b._dcache, store_b._dcache_hits, store_b._dcache_misses = {}, 0, 0
-        store_b._rust_dcache = None
+        store_b._rust_dcache = RustDCache()
         store_b._engine = fake_b
         store_b._client = None
         store_b._zone_id = "zone_b"
@@ -682,7 +682,7 @@ class TestMultiZoneIsolation:
         fake = FakeLocalRaft()
         store = object.__new__(RaftMetadataStore)
         store._dcache, store._dcache_hits, store._dcache_misses = {}, 0, 0
-        store._rust_dcache = None
+        store._rust_dcache = RustDCache()
         store._engine = fake
         store._client = None
         store._zone_id = "zone_a"

--- a/tests/unit/core/test_factory_boot.py
+++ b/tests/unit/core/test_factory_boot.py
@@ -397,7 +397,10 @@ class TestBrickServicesFieldCompleteness:
         record_store.database_url = "sqlite://"
         record_store.async_session_factory = MagicMock()
 
+        from nexus_fast import RustDCache
+
         metadata_store = MagicMock()
+        metadata_store._rust_dcache = RustDCache()
 
         backend = MagicMock()
         backend.root_path = "/tmp/test"
@@ -446,7 +449,10 @@ class TestBrickServicesFieldCompleteness:
         record_store.database_url = "sqlite://"
         record_store.async_session_factory = MagicMock()
 
+        from nexus_fast import RustDCache
+
         metadata_store = MagicMock()
+        metadata_store._rust_dcache = RustDCache()
 
         backend = MagicMock()
         backend.root_path = "/tmp/test"

--- a/tests/unit/core/test_syscall_backend_callback.py
+++ b/tests/unit/core/test_syscall_backend_callback.py
@@ -1,15 +1,12 @@
-"""Tests for SyscallEngine Python backend callback (Phase F — #1868).
+"""Tests for SyscallEngine backend I/O — Kernel Boundary Collapse (§7 PR 1).
 
-Verifies that when CAS is unavailable, Rust calls Python backend.read_content()
-and backend.write_content() via PyO3 callback, avoiding the full Python
-validate+route+dcache overhead.
-
-GIL safety: Rust clones Py<PyAny> under RwLock, releases lock, then calls Python.
-Same pattern as dispatch.rs HookEntry.
+After the boundary collapse, Python backends are removed from Rust.
+Mounts with local_root get a CasLocalBackend (pure Rust CAS + local transport).
+Mounts without local_root → sys_read/sys_write return hit=false → Python full path.
 """
 
-from dataclasses import dataclass
-from unittest.mock import MagicMock
+import tempfile
+from pathlib import Path
 
 import pytest
 from nexus_fast import (
@@ -17,19 +14,11 @@ from nexus_fast import (
     RustDCache,
     RustPathRouter,
     SyscallEngine,
+    hash_bytes,
 )
 
 # Entry type constants
 DT_REG = 0
-
-
-@dataclass(frozen=True, slots=True)
-class WriteResult:
-    """Minimal WriteResult for testing."""
-
-    content_id: str
-    version: str = ""
-    size: int = 0
 
 
 # ---------------------------------------------------------------------------
@@ -38,195 +27,98 @@ class WriteResult:
 
 
 @pytest.fixture
-def mock_backend():
-    """Mock ObjectStoreABC-like backend with read_content/write_content."""
-    backend = MagicMock()
-    backend.name = "mock-s3"
-    backend.has_root_path = False
-    backend.read_content.return_value = b"data from python backend"
-    backend.write_content.return_value = WriteResult(content_id="abc123hash", version="1", size=24)
-    return backend
-
-
-@pytest.fixture
-def engine_with_backend(mock_backend):
-    """SyscallEngine with a Python backend on the root mount (no CAS)."""
-    dcache = RustDCache()
-    router = RustPathRouter()
-    trie = PathTrie()
-    # Mount without local_root (no CAS) but WITH Python backend
-    router.add_mount("/", "root", False, False, "balanced", "mock-s3", None, False, mock_backend)
-    engine = SyscallEngine(dcache, router, trie)
-    return engine, dcache, mock_backend
+def engine_with_cas():
+    """SyscallEngine with a CAS-backed mount (local_root present)."""
+    with tempfile.TemporaryDirectory() as cas_dir:
+        dcache = RustDCache()
+        router = RustPathRouter()
+        trie = PathTrie()
+        router.add_mount("/", "root", False, False, "balanced", "local", cas_dir, False)
+        engine = SyscallEngine(dcache, router, trie)
+        yield engine, dcache, cas_dir
 
 
 # ---------------------------------------------------------------------------
-# execute_read backend callback
+# CAS backend works (read + write via Rust CasLocalBackend)
 # ---------------------------------------------------------------------------
 
 
-class TestExecuteReadBackendCallback:
-    def test_backend_read_called(self, engine_with_backend):
-        """CAS miss + backend present → backend.read_content() called."""
-        engine, dcache, backend = engine_with_backend
-        dcache.put("/workspace/test.txt", "mock-s3", "test.txt", 100, DT_REG, etag="hash123")
+class TestCASBackendWorks:
+    def test_cas_read(self, engine_with_cas):
+        """CAS backend serves read when content exists on disk."""
+        engine, dcache, cas_dir = engine_with_cas
+        content = b"cas content for read"
+        content_hash = hash_bytes(content)
 
-        result = engine.sys_read("/workspace/test.txt", "root", False)
-        assert result is not None
-        assert result == b"data from python backend"
-        backend.read_content.assert_called_once_with("hash123")
+        # Write CAS blob manually
+        cas_path = Path(cas_dir) / "cas" / content_hash[:2] / content_hash[2:4] / content_hash
+        cas_path.parent.mkdir(parents=True, exist_ok=True)
+        cas_path.write_bytes(content)
 
-    def test_backend_read_returns_bytes(self, engine_with_backend):
-        """Backend returns bytes, Rust wraps as PyBytes."""
-        engine, dcache, backend = engine_with_backend
-        backend.read_content.return_value = b"\x00\x01\x02binary"
-        dcache.put("/workspace/bin.dat", "mock-s3", "", 7, DT_REG, etag="binhash")
+        dcache.put(
+            "/workspace/f.txt", "local", content_hash, len(content), DT_REG, etag=content_hash
+        )
 
-        result = engine.sys_read("/workspace/bin.dat", "root", False)
-        assert result == b"\x00\x01\x02binary"
+        result = engine.sys_read("/workspace/f.txt", "root", False)
+        assert result.hit is True
+        assert result.data == content
 
-    def test_dcache_miss_returns_none(self, engine_with_backend):
-        """DCache miss → None (backend not called)."""
-        engine, _, backend = engine_with_backend
+    def test_cas_write(self, engine_with_cas):
+        """CAS backend completes write and returns BLAKE3 hash."""
+        engine, dcache, cas_dir = engine_with_cas
+        dcache.put("/workspace/f.txt", "local", "", 0, DT_REG, etag="old")
+
+        result = engine.sys_write("/workspace/f.txt", "root", b"new data", False)
+        assert result.hit is True
+        assert result.content_id is not None
+        assert len(result.content_id) == 64  # BLAKE3 hex
+
+    def test_cas_write_content_readable(self, engine_with_cas):
+        """Content written via sys_write is readable via sys_read."""
+        engine, dcache, _ = engine_with_cas
+        content = b"roundtrip content"
+        dcache.put("/workspace/rt.txt", "local", "", 0, DT_REG, etag="old")
+
+        write_result = engine.sys_write("/workspace/rt.txt", "root", content, False)
+        assert write_result.hit is True
+
+        # Update dcache with new etag
+        dcache.put(
+            "/workspace/rt.txt",
+            "local",
+            write_result.content_id,
+            len(content),
+            DT_REG,
+            etag=write_result.content_id,
+        )
+
+        read_result = engine.sys_read("/workspace/rt.txt", "root", False)
+        assert read_result.hit is True
+        assert read_result.data == content
+
+    def test_dcache_miss_returns_miss(self, engine_with_cas):
+        """DCache miss → hit=false (engine doesn't know the file)."""
+        engine, _, _ = engine_with_cas
         result = engine.sys_read("/workspace/missing.txt", "root", False)
-        assert result is None
-        backend.read_content.assert_not_called()
+        assert result.hit is False
+        assert result.data is None
 
-    def test_no_etag_returns_none(self, engine_with_backend):
-        """Entry without etag → None (backend not called)."""
-        engine, dcache, backend = engine_with_backend
-        dcache.put("/workspace/new.txt", "mock-s3", "", 0, DT_REG)
+    def test_no_etag_returns_miss(self, engine_with_cas):
+        """Entry without etag → hit=false (no content hash to read)."""
+        engine, dcache, _ = engine_with_cas
+        dcache.put("/workspace/new.txt", "local", "", 0, DT_REG)
         result = engine.sys_read("/workspace/new.txt", "root", False)
-        assert result is None
-        backend.read_content.assert_not_called()
+        assert result.hit is False
 
 
 # ---------------------------------------------------------------------------
-# execute_write backend callback
-# ---------------------------------------------------------------------------
-
-
-class TestExecuteWriteBackendCallback:
-    def test_backend_write_called(self, engine_with_backend):
-        """CAS miss + backend present → backend.write_content() called."""
-        engine, dcache, backend = engine_with_backend
-        dcache.put("/workspace/test.txt", "mock-s3", "test.txt", 100, DT_REG, etag="oldhash")
-
-        result = engine.sys_write("/workspace/test.txt", "root", b"new content", False)
-        assert result is not None
-        assert result == "abc123hash"
-        backend.write_content.assert_called_once_with(b"new content")
-
-    def test_backend_write_returns_content_id(self, engine_with_backend):
-        """Backend WriteResult.content_id is extracted correctly."""
-        engine, dcache, backend = engine_with_backend
-        backend.write_content.return_value = WriteResult(content_id="sha256hexhash")
-        dcache.put("/workspace/f.txt", "mock-s3", "", 0, DT_REG, etag="old")
-
-        result = engine.sys_write("/workspace/f.txt", "root", b"data", False)
-        assert result == "sha256hexhash"
-
-    def test_dcache_miss_returns_none(self, engine_with_backend):
-        """DCache miss → None (backend not called)."""
-        engine, _, backend = engine_with_backend
-        result = engine.sys_write("/workspace/missing.txt", "root", b"data", False)
-        assert result is None
-        backend.write_content.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# CAS preferred over backend
-# ---------------------------------------------------------------------------
-
-
-class TestCASPreferredOverBackend:
-    def test_cas_preferred_for_read(self, mock_backend):
-        """When CAS has the content, Python backend is NOT called."""
-        import tempfile
-        from pathlib import Path
-
-        from nexus_fast import hash_bytes
-
-        with tempfile.TemporaryDirectory() as cas_dir:
-            dcache = RustDCache()
-            router = RustPathRouter()
-            trie = PathTrie()
-            # Mount WITH CAS (local_root) AND Python backend
-            router.add_mount(
-                "/", "root", False, False, "balanced", "local", cas_dir, False, mock_backend
-            )
-            engine = SyscallEngine(dcache, router, trie)
-
-            content = b"cas content"
-            content_hash = hash_bytes(content)
-
-            # Write CAS blob manually
-            cas_path = Path(cas_dir) / "cas" / content_hash[:2] / content_hash[2:4] / content_hash
-            cas_path.parent.mkdir(parents=True, exist_ok=True)
-            cas_path.write_bytes(content)
-
-            dcache.put(
-                "/workspace/f.txt", "local", content_hash, len(content), DT_REG, etag=content_hash
-            )
-
-            result = engine.sys_read("/workspace/f.txt", "root", False)
-            assert result == content
-            # Backend should NOT be called — CAS served it
-            mock_backend.read_content.assert_not_called()
-
-    def test_cas_preferred_for_write(self, mock_backend):
-        """When CAS is available, Python backend write is NOT called."""
-        import tempfile
-
-        with tempfile.TemporaryDirectory() as cas_dir:
-            dcache = RustDCache()
-            router = RustPathRouter()
-            trie = PathTrie()
-            router.add_mount(
-                "/", "root", False, False, "balanced", "local", cas_dir, False, mock_backend
-            )
-            engine = SyscallEngine(dcache, router, trie)
-
-            dcache.put("/workspace/f.txt", "local", "", 0, DT_REG, etag="old")
-            result = engine.sys_write("/workspace/f.txt", "root", b"new data", False)
-            assert result is not None
-            assert len(result) == 64  # BLAKE3 hex
-            mock_backend.write_content.assert_not_called()
-
-
-# ---------------------------------------------------------------------------
-# Error handling
-# ---------------------------------------------------------------------------
-
-
-class TestBackendExceptionReturnsNone:
-    def test_read_exception_returns_none(self, engine_with_backend):
-        """Backend raises → Rust gets Err → returns None → Python full path fallback."""
-        engine, dcache, backend = engine_with_backend
-        backend.read_content.side_effect = RuntimeError("S3 timeout")
-        dcache.put("/workspace/test.txt", "mock-s3", "test.txt", 100, DT_REG, etag="hash123")
-
-        result = engine.sys_read("/workspace/test.txt", "root", False)
-        assert result is None  # Not an exception — just None for fallback
-
-    def test_write_exception_returns_none(self, engine_with_backend):
-        """Backend write raises → returns None → Python full path fallback."""
-        engine, dcache, backend = engine_with_backend
-        backend.write_content.side_effect = OSError("write failed")
-        dcache.put("/workspace/test.txt", "mock-s3", "test.txt", 100, DT_REG, etag="hash123")
-
-        result = engine.sys_write("/workspace/test.txt", "root", b"data", False)
-        assert result is None
-
-
-# ---------------------------------------------------------------------------
-# No backend registered
+# No backend registered → Python fallback
 # ---------------------------------------------------------------------------
 
 
 class TestNoBackendFallback:
-    def test_no_backend_read_returns_none(self):
-        """Mount without backend (backend=None) → CAS miss → None."""
+    def test_no_backend_read_returns_miss(self):
+        """Mount without local_root (no Rust backend) → hit=false."""
         dcache = RustDCache()
         router = RustPathRouter()
         trie = PathTrie()
@@ -235,10 +127,11 @@ class TestNoBackendFallback:
         dcache.put("/workspace/test.txt", "remote", "test.txt", 100, DT_REG, etag="hash")
 
         result = engine.sys_read("/workspace/test.txt", "root", False)
-        assert result is None
+        assert result.hit is False
+        assert result.data is None
 
-    def test_no_backend_write_returns_none(self):
-        """Mount without backend → CAS miss → None."""
+    def test_no_backend_write_returns_miss(self):
+        """Mount without local_root → write hit=false."""
         dcache = RustDCache()
         router = RustPathRouter()
         trie = PathTrie()
@@ -247,4 +140,5 @@ class TestNoBackendFallback:
         dcache.put("/workspace/test.txt", "remote", "test.txt", 100, DT_REG, etag="hash")
 
         result = engine.sys_write("/workspace/test.txt", "root", b"data", False)
-        assert result is None
+        assert result.hit is False
+        assert result.content_id is None

--- a/tests/unit/core/test_syscall_execute.py
+++ b/tests/unit/core/test_syscall_execute.py
@@ -185,39 +185,39 @@ class TestExecuteRead:
 
         # Execute read
         result = engine.sys_read("/workspace/test.txt", "root", False)
-        assert result is not None
-        assert result == content
+        assert result.hit is True
+        assert result.data == content
 
-    def test_dcache_miss_returns_none(self, engine_with_cas):
-        """DCache miss → None (Python fallback)."""
+    def test_dcache_miss_returns_miss(self, engine_with_cas):
+        """DCache miss → hit=false (Python fallback)."""
         engine, _, _ = engine_with_cas
         result = engine.sys_read("/workspace/missing.txt", "root", False)
-        assert result is None
+        assert result.hit is False
 
-    def test_no_cas_backend_returns_none(self, components):
-        """Mount without CAS (no local_root) → None (Python fallback)."""
+    def test_no_cas_backend_returns_miss(self, components):
+        """Mount without CAS (no local_root) → hit=false (Python fallback)."""
         dcache, router, trie = components
         dcache.put("/workspace/test.txt", "s3-backend", "test.txt", 100, DT_REG, etag="hash123")
         engine = SyscallEngine(dcache, router, trie)
         result = engine.sys_read("/workspace/test.txt", "root", False)
-        assert result is None
+        assert result.hit is False
 
-    def test_no_etag_returns_none(self, engine_with_cas):
-        """Entry without etag (e.g. new file) → None."""
+    def test_no_etag_returns_miss(self, engine_with_cas):
+        """Entry without etag (e.g. new file) → hit=false."""
         engine, dcache, _ = engine_with_cas
         dcache.put("/workspace/new.txt", "local", "", 0, DT_REG)
         result = engine.sys_read("/workspace/new.txt", "root", False)
-        assert result is None
+        assert result.hit is False
 
-    def test_pipe_entry_returns_none(self, engine_with_cas):
+    def test_pipe_entry_returns_miss(self, engine_with_cas):
         """DT_PIPE entries are handled by Python PipeManager."""
         engine, dcache, _ = engine_with_cas
         dcache.put("/pipes/fifo", "local", "", 0, DT_PIPE)
         result = engine.sys_read("/pipes/fifo", "root", False)
-        assert result is None
+        assert result.hit is False
 
-    def test_cas_read_failure_returns_none(self, engine_with_cas):
-        """CAS blob not on disk → None (Python fallback)."""
+    def test_cas_read_failure_returns_miss(self, engine_with_cas):
+        """CAS blob not on disk → hit=false (Python fallback)."""
         engine, dcache, _ = engine_with_cas
         dcache.put(
             "/workspace/test.txt",
@@ -228,7 +228,7 @@ class TestExecuteRead:
             etag="nonexistenthash0000000000000000000000000000000000000000000000",
         )
         result = engine.sys_read("/workspace/test.txt", "root", False)
-        assert result is None
+        assert result.hit is False
 
     def test_large_file(self, engine_with_cas):
         """Verify large file read works."""
@@ -244,8 +244,8 @@ class TestExecuteRead:
             "/workspace/big.bin", "local", content_hash, len(content), DT_REG, etag=content_hash
         )
         result = engine.sys_read("/workspace/big.bin", "root", False)
-        assert result is not None
-        assert len(result) == 512 * 1024
+        assert result.hit is True
+        assert len(result.data) == 512 * 1024
 
 
 # ── execute_write ─────────────────────────────────────────────────────
@@ -259,30 +259,31 @@ class TestExecuteWrite:
 
         content = b"new content from Rust execute_write"
         result = engine.sys_write("/workspace/test.txt", "root", content, False)
-        assert result is not None
-        assert len(result) == 64  # BLAKE3 hex
+        assert result.hit is True
+        assert len(result.content_id) == 64  # BLAKE3 hex
 
         # Verify content was actually written to CAS
-        cas_path = Path(cas_dir) / "cas" / result[:2] / result[2:4] / result
+        cid = result.content_id
+        cas_path = Path(cas_dir) / "cas" / cid[:2] / cid[2:4] / cid
         assert cas_path.exists()
         assert cas_path.read_bytes() == content
 
-    def test_dcache_miss_returns_none(self, engine_with_cas):
-        """DCache miss → None (Python handles new file)."""
+    def test_dcache_miss_returns_miss(self, engine_with_cas):
+        """DCache miss → hit=false (Python handles new file)."""
         engine, _, _ = engine_with_cas
         result = engine.sys_write("/workspace/new.txt", "root", b"data", False)
-        assert result is None
+        assert result.hit is False
 
-    def test_no_cas_backend_returns_none(self, components):
-        """Mount without CAS → None."""
+    def test_no_cas_backend_returns_miss(self, components):
+        """Mount without CAS → hit=false."""
         dcache, router, trie = components
         dcache.put("/workspace/test.txt", "s3-remote", "", 0, DT_REG, etag="hash")
         engine = SyscallEngine(dcache, router, trie)
         result = engine.sys_write("/workspace/test.txt", "root", b"data", False)
-        assert result is None
+        assert result.hit is False
 
-    def test_readonly_returns_none(self, cas_dir):
-        """Write to readonly mount → None (Python handles error)."""
+    def test_readonly_returns_miss(self, cas_dir):
+        """Write to readonly mount → hit=false (Python handles error)."""
         dcache = RustDCache()
         router = RustPathRouter()
         trie = PathTrie()
@@ -290,9 +291,9 @@ class TestExecuteWrite:
         router.add_mount("/readonly", "root", True, False, "balanced", "local", cas_dir, False)
         dcache.put("/readonly/file.txt", "local", "", 0, DT_REG, etag="hash")
         engine = SyscallEngine(dcache, router, trie)
-        # PR B returns cache miss on route failure → execute_write returns None
+        # PR B returns cache miss on route failure → returns hit=false
         result = engine.sys_write("/readonly/file.txt", "root", b"data", False)
-        assert result is None
+        assert result.hit is False
 
     def test_write_dedup(self, engine_with_cas):
         """Writing same content twice returns same hash (CAS dedup)."""
@@ -301,9 +302,9 @@ class TestExecuteWrite:
         dcache.put("/workspace/b.txt", "local", "", 0, DT_REG, etag="old2")
 
         content = b"deduplicated content"
-        hash1 = engine.sys_write("/workspace/a.txt", "root", content, False)
-        hash2 = engine.sys_write("/workspace/b.txt", "root", content, False)
-        assert hash1 == hash2
+        r1 = engine.sys_write("/workspace/a.txt", "root", content, False)
+        r2 = engine.sys_write("/workspace/b.txt", "root", content, False)
+        assert r1.content_id == r2.content_id
 
 
 # ── Arc sharing ───────────────────────────────────────────────────────
@@ -322,7 +323,7 @@ class TestArcSharing:
         cas_path.write_bytes(content)
 
         # Initially miss
-        assert engine.sys_read("/workspace/late.txt", "root", False) is None
+        assert engine.sys_read("/workspace/late.txt", "root", False).hit is False
 
         # Add to dcache (simulating metastore.put dual-write)
         dcache.put(
@@ -331,7 +332,8 @@ class TestArcSharing:
 
         # Now should hit
         result = engine.sys_read("/workspace/late.txt", "root", False)
-        assert result == content
+        assert result.hit is True
+        assert result.data == content
 
     def test_mount_updates_visible(self, cas_dir):
         """Mounts added after engine creation are visible."""
@@ -358,7 +360,8 @@ class TestArcSharing:
         assert plan.io_profile == "fast"  # Uses /workspace mount, not /
 
         result = engine.sys_read("/workspace/file.txt", "root", False)
-        assert result == content
+        assert result.hit is True
+        assert result.data == content
 
 
 # ── ReadPlan / WritePlan types ────────────────────────────────────────

--- a/tests/unit/core/test_syscall_phase_g.py
+++ b/tests/unit/core/test_syscall_phase_g.py
@@ -1,14 +1,13 @@
 """Tests for Phase G: Hook count + VFS lock integration in SyscallEngine.
 
 Verifies:
-- Hook count > 0 → sys_read/sys_write returns None (Python handles hooks)
+- Hook count > 0 → sys_read/sys_write returns hit=false (Python handles hooks)
 - VFS lock is acquired/released around I/O
-- VFS lock contention → returns None (Python handles with blocking/timeout)
+- VFS lock contention → returns hit=false (Python handles with blocking/timeout)
 """
 
 import tempfile
 from pathlib import Path
-from unittest.mock import MagicMock
 
 import pytest
 from nexus_fast import (
@@ -52,8 +51,8 @@ def engine_with_lock(cas_dir):
 
 
 class TestHookCountBypass:
-    def test_read_hooks_present_returns_none(self, engine_with_lock):
-        """When read hooks are registered, sys_read returns None."""
+    def test_read_hooks_present_returns_miss(self, engine_with_lock):
+        """When read hooks are registered, sys_read returns hit=false."""
         engine, dcache, cas_dir, _ = engine_with_lock
         content = b"hook test data"
         content_hash = hash_bytes(content)
@@ -64,31 +63,31 @@ class TestHookCountBypass:
             "/workspace/f.txt", "local", content_hash, len(content), DT_REG, etag=content_hash
         )
 
-        # Without hooks: should return data
-        assert engine.sys_read("/workspace/f.txt", "root", False) is not None
+        # Without hooks: should return hit=true
+        assert engine.sys_read("/workspace/f.txt", "root", False).hit is True
 
         # Set read hook count > 0
         engine.set_hook_count("read", 1)
-        # Now sys_read should return None (Python handles hooks)
-        assert engine.sys_read("/workspace/f.txt", "root", False) is None
+        # Now sys_read should return hit=false (Python handles hooks)
+        assert engine.sys_read("/workspace/f.txt", "root", False).hit is False
 
         # Reset hook count
         engine.set_hook_count("read", 0)
-        assert engine.sys_read("/workspace/f.txt", "root", False) is not None
+        assert engine.sys_read("/workspace/f.txt", "root", False).hit is True
 
-    def test_write_hooks_present_returns_none(self, engine_with_lock):
-        """When write hooks are registered, sys_write returns None."""
+    def test_write_hooks_present_returns_miss(self, engine_with_lock):
+        """When write hooks are registered, sys_write returns hit=false."""
         engine, dcache, _, _ = engine_with_lock
         dcache.put("/workspace/f.txt", "local", "", 0, DT_REG, etag="old")
 
-        # Without hooks: should return hash
+        # Without hooks: should return hit=true
         result = engine.sys_write("/workspace/f.txt", "root", b"data", False)
-        assert result is not None
+        assert result.hit is True
 
         # Set write hook count > 0
         engine.set_hook_count("write", 1)
         result = engine.sys_write("/workspace/f.txt", "root", b"data", False)
-        assert result is None
+        assert result.hit is False
 
     def test_set_hook_count_unknown_op_ignored(self, engine_with_lock):
         """Unknown operation names are silently ignored."""
@@ -115,12 +114,13 @@ class TestVFSLockIntegration:
         )
 
         result = engine.sys_read("/workspace/f.txt", "root", False)
-        assert result == content
+        assert result.hit is True
+        assert result.data == content
         # Lock should be released after read
         assert not lock.is_locked("/workspace/f.txt")
 
-    def test_write_lock_contention_returns_none(self, engine_with_lock):
-        """If a write lock is already held, sys_read returns None."""
+    def test_write_lock_contention_returns_miss(self, engine_with_lock):
+        """If a write lock is already held, sys_read returns hit=false."""
         engine, dcache, cas_dir, lock = engine_with_lock
         content = b"contention test"
         content_hash = hash_bytes(content)
@@ -135,19 +135,20 @@ class TestVFSLockIntegration:
         handle = lock.acquire("/workspace/f.txt", "write")
         assert handle > 0
 
-        # sys_read should return None (read blocked by write lock)
+        # sys_read should return hit=false (read blocked by write lock)
         result = engine.sys_read("/workspace/f.txt", "root", False)
-        assert result is None
+        assert result.hit is False
 
         # Release the external lock
         lock.release(handle)
 
         # Now sys_read should succeed
         result = engine.sys_read("/workspace/f.txt", "root", False)
-        assert result == content
+        assert result.hit is True
+        assert result.data == content
 
     def test_no_lock_manager_still_works(self):
-        """SyscallEngine without VFS lock manager still works (backward compat)."""
+        """SyscallEngine without VFS lock manager still works."""
         dcache = RustDCache()
         router = RustPathRouter()
         trie = PathTrie()
@@ -155,9 +156,9 @@ class TestVFSLockIntegration:
         engine = SyscallEngine(dcache, router, trie)  # No lock manager
         dcache.put("/workspace/f.txt", "remote", "", 0, DT_REG, etag="hash")
 
-        # Should not crash — just returns None (no CAS, no backend)
+        # Should not crash — returns hit=false (no Rust backend)
         result = engine.sys_read("/workspace/f.txt", "root", False)
-        assert result is None
+        assert result.hit is False
 
 
 # ---------------------------------------------------------------------------
@@ -165,24 +166,34 @@ class TestVFSLockIntegration:
 # ---------------------------------------------------------------------------
 
 
-class TestBackendCallbackWithLock:
-    def test_backend_read_with_lock(self):
-        """Backend callback works with VFS lock manager."""
-        backend = MagicMock()
-        backend.name = "mock-s3"
-        backend.has_root_path = False
-        backend.read_content.return_value = b"locked backend data"
+class TestCASBackendWithLock:
+    def test_cas_read_with_lock(self):
+        """CAS backend read works with VFS lock manager."""
+        import tempfile
+        from pathlib import Path
 
-        dcache = RustDCache()
-        router = RustPathRouter()
-        trie = PathTrie()
-        lock = VFSLockManager()
-        router.add_mount("/", "root", False, False, "balanced", "mock-s3", None, False, backend)
-        engine = SyscallEngine(dcache, router, trie, lock)
-        dcache.put("/workspace/f.txt", "mock-s3", "", 100, DT_REG, etag="hash123")
+        from nexus_fast import hash_bytes
 
-        result = engine.sys_read("/workspace/f.txt", "root", False)
-        assert result == b"locked backend data"
-        backend.read_content.assert_called_once()
-        # Lock released after read
-        assert not lock.is_locked("/workspace/f.txt")
+        with tempfile.TemporaryDirectory() as cas_dir:
+            dcache = RustDCache()
+            router = RustPathRouter()
+            trie = PathTrie()
+            lock = VFSLockManager()
+            router.add_mount("/", "root", False, False, "balanced", "local", cas_dir, False)
+            engine = SyscallEngine(dcache, router, trie, lock)
+
+            content = b"locked cas data"
+            content_hash = hash_bytes(content)
+            cas_path = Path(cas_dir) / "cas" / content_hash[:2] / content_hash[2:4] / content_hash
+            cas_path.parent.mkdir(parents=True, exist_ok=True)
+            cas_path.write_bytes(content)
+
+            dcache.put(
+                "/workspace/f.txt", "local", content_hash, len(content), DT_REG, etag=content_hash
+            )
+
+            result = engine.sys_read("/workspace/f.txt", "root", False)
+            assert result.hit is True
+            assert result.data == content
+            # Lock released after read
+            assert not lock.is_locked("/workspace/f.txt")


### PR DESCRIPTION
## Summary

- Remove all `Py<PyAny>` from Rust kernel — `MountEntry.backend_obj` replaced by `Option<Box<dyn StorageBackend>>`
- Introduce `StorageBackend` trait + `CasLocalBackend` (pure Rust CAS I/O, no GIL acquisition)
- Add `SysReadResult` / `SysWriteResult` strong-typed #[pyclass] return types (replaces bare `Option<bytes>` / `Option<str>`)
- Remove all Python fallback `try/except ImportError` patterns in `nexus_fs.py` and `metastore.py` — CI enforces `maturin develop`
- Delete `read_backend()` / `write_backend()` GIL callback methods from router
- Fix clippy warnings in `volume_engine.rs`, fix `test_factory_boot.py` mock setup

## Test plan

- [x] `cargo clippy --all-targets` — zero warnings
- [x] `maturin develop --release` — builds successfully
- [x] 63 syscall unit tests pass (`test_syscall_*.py`)
- [x] 2599 unit/core tests pass (0 new failures)
- [x] `grep -r "read_backend|write_backend|backend_obj" rust/` → zero hits
- [x] `grep "try:.*nexus_fast|except.*ImportError" src/nexus/core/{nexus_fs,metastore}.py` → zero hits

🤖 Generated with [Claude Code](https://claude.com/claude-code)