### PR TITLE
feat(nexus-fs): add CLI primitives and edit support for slim package

### DIFF
--- a/packages/nexus-fs/pyproject.toml
+++ b/packages/nexus-fs/pyproject.toml
@@ -52,10 +52,11 @@ gdrive = [
     "google-api-python-client>=2.0",
     "google-auth-oauthlib>=1.0",
 ]
+edit = ["rapidfuzz>=3.0"]
 fsspec = ["fsspec>=2024.0"]
 tui = ["textual>=1.0"]
 all = [
-    "nexus-fs[s3,gcs,gdrive,fsspec,tui]",
+    "nexus-fs[s3,gcs,gdrive,fsspec,tui,edit]",
 ]
 dev = [
     "nexus-fs[all]",
@@ -93,6 +94,8 @@ include = [
     "nexus/backends/**",
     "nexus/lib/**",
     "nexus/storage/**",
+    "nexus/utils/__init__.py",
+    "nexus/utils/edit_engine.py",
     "nexus/config.py",
 ]
 exclude = [

--- a/scripts/nexus-fs-demo/test_nexus_fs_0_s3_integration.sh
+++ b/scripts/nexus-fs-demo/test_nexus_fs_0_s3_integration.sh
@@ -20,6 +20,7 @@ step()   { echo -e "\n${CYAN}[$1]${NC} $2"; }
 ok()     { echo -e "  ${GREEN}OK${NC} $1"; }
 fail()   { echo -e "  ${RED}FAIL${NC} $1"; exit 1; }
 banner() { echo -e "\n${YELLOW}════════════════════════════════════════════════${NC}"; echo -e "${YELLOW}  $1${NC}"; echo -e "${YELLOW}════════════════════════════════════════════════${NC}"; }
+nfs() { "$PYTHON" -c "from nexus.fs._cli import main; main()" "$@"; }
 
 banner "Script 0: S3 Integration"
 echo "  S3 bucket: $S3_BUCKET"
@@ -27,7 +28,7 @@ echo "  S3 bucket: $S3_BUCKET"
 # ── Step 1: Verify S3 auth ───────────────────────────────────────────────────
 step "1/8" "Verifying S3 credentials..."
 echo "  > nexus-fs auth test s3"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['auth', 'test', 's3'])" 2>&1 || fail "S3 auth failed"
+nfs auth test s3 2>&1 || fail "S3 auth failed"
 ok "S3 credentials valid"
 
 # ── Step 2: Create local test data ───────────────────────────────────────────
@@ -48,20 +49,20 @@ ok "Local test files created"
 
 # ── Step 3: Mount local + S3 ─────────────────────────────────────────────────
 step "3/8" "Mounting local and S3 backends..."
-"$PYTHON" -c "from nexus.fs._cli import main; main(['unmount', 'local://$TESTROOT/s3test'])" 2>/dev/null || true
-"$PYTHON" -c "from nexus.fs._cli import main; main(['unmount', '$S3_URI'])" 2>/dev/null || true
+nfs unmount "local://$TESTROOT/s3test" 2>/dev/null || true
+nfs unmount "$S3_URI" 2>/dev/null || true
 
 echo "  > nexus-fs mount local://$TESTROOT/s3test"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['mount', 'local://$TESTROOT/s3test'])" 2>&1
+nfs mount "local://$TESTROOT/s3test" 2>&1
 echo ""
 echo "  > nexus-fs mount $S3_URI"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['mount', '$S3_URI'])" 2>&1
+nfs mount "$S3_URI" 2>&1
 ok "Both backends mounted"
 
 # ── Step 4: Test S3 mount connectivity ───────────────────────────────────────
 step "4/8" "Testing S3 mount connectivity..."
 echo "  > nexus-fs mount test $S3_URI"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['mount', 'test', '$S3_URI'])" 2>&1
+nfs mount test "$S3_URI" 2>&1
 ok "S3 connectivity confirmed"
 
 # ── Step 5: Seed local files into CAS and upload to S3 ──────────────────────
@@ -87,26 +88,17 @@ PYEOF
 
 echo ""
 echo "  > nexus-fs cp local -> S3 (upload.txt)"
-"$PYTHON" -c "
-from nexus.fs._cli import main
-main(['cp', '/local/nexus-fs-demo-s3test/upload.txt', '/s3/$S3_BUCKET/nexus-fs-test/upload.txt'])
-" 2>&1
+nfs cp "/local/nexus-fs-demo-s3test/upload.txt" "/s3/$S3_BUCKET/nexus-fs-test/upload.txt" 2>&1
 
 echo ""
 echo "  > nexus-fs cp local -> S3 (data.json)"
-"$PYTHON" -c "
-from nexus.fs._cli import main
-main(['cp', '/local/nexus-fs-demo-s3test/data.json', '/s3/$S3_BUCKET/nexus-fs-test/data.json'])
-" 2>&1
+nfs cp "/local/nexus-fs-demo-s3test/data.json" "/s3/$S3_BUCKET/nexus-fs-test/data.json" 2>&1
 ok "Files uploaded to S3"
 
 # ── Step 6: Copy back from S3 ───────────────────────────────────────────────
 step "6/8" "Copying S3 -> local (round-trip)..."
 echo "  > nexus-fs cp S3 -> local (upload.txt)"
-"$PYTHON" -c "
-from nexus.fs._cli import main
-main(['cp', '/s3/$S3_BUCKET/nexus-fs-test/upload.txt', '/local/nexus-fs-demo-s3test/downloaded.txt'])
-" 2>&1
+nfs cp "/s3/$S3_BUCKET/nexus-fs-test/upload.txt" "/local/nexus-fs-demo-s3test/downloaded.txt" 2>&1
 ok "Round-trip complete"
 
 # ── Step 7: Verify round-trip ────────────────────────────────────────────────
@@ -140,7 +132,7 @@ ok "Data integrity verified"
 # ── Step 8: Doctor with both mounts ──────────────────────────────────────────
 step "8/8" "Doctor with local + S3 mounts..."
 echo "  > nexus-fs doctor --mount local://$TESTROOT/s3test --mount $S3_URI"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['doctor', '--mount', 'local://$TESTROOT/s3test', '--mount', '$S3_URI'])" 2>&1
+nfs doctor --mount "local://$TESTROOT/s3test" --mount "$S3_URI" 2>&1
 ok "Doctor passed for both backends"
 
 # ── Cleanup ──────────────────────────────────────────────────────────────────

--- a/scripts/nexus-fs-demo/test_nexus_fs_1_setup_discovery.sh
+++ b/scripts/nexus-fs-demo/test_nexus_fs_1_setup_discovery.sh
@@ -13,7 +13,7 @@ set -euo pipefail
 
 PYTHON="${NEXUS_FS_PYTHON:-/Users/tafeng/nexus/.venv/bin/python}"
 TESTROOT="/tmp/nexus-fs-demo"
-nexus_fs() { "$PYTHON" -c "from nexus.fs._cli import main; main()" -- "$@"; }
+nfs() { "$PYTHON" -c "from nexus.fs._cli import main; main()" "$@"; }
 
 # ── Colors ───────────────────────────────────────────────────────────────────
 GREEN='\033[0;32m'; CYAN='\033[0;36m'; YELLOW='\033[1;33m'; NC='\033[0m'
@@ -26,22 +26,19 @@ banner "Script 1: Setup & Discovery"
 # ── Step 0a: --version ───────────────────────────────────────────────────────
 step "0a/11" "Testing --version..."
 echo "  > nexus-fs --version"
-"$PYTHON" -c "
-import importlib.metadata as _m
-print(f'nexus-fs, version {_m.version(\"nexus-ai-fs\")}')
-" 2>&1
+nfs --version 2>&1
 ok "--version"
 
 # ── Step 0b: --help ──────────────────────────────────────────────────────────
 step "0b/11" "Testing --help..."
 echo "  > nexus-fs --help"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['--help'])" 2>&1
+nfs --help 2>&1
 ok "--help"
 
 # ── Step 0c: playground --help (verify TUI does not launch) ──────────────────
 step "0c/11" "Testing playground --help (non-interactive)..."
 echo "  > nexus-fs playground --help"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['playground', '--help'])" 2>&1
+nfs playground --help 2>&1
 ok "playground --help"
 
 # ── Step 1: Clean slate ──────────────────────────────────────────────────────
@@ -49,7 +46,7 @@ step "1/11" "Cleaning previous test state..."
 rm -rf "$TESTROOT"
 # Remove any leftover mounts from previous runs
 for uri in "local://$TESTROOT/projects" "local://$TESTROOT/datasets" "local://$TESTROOT/custom"; do
-    "$PYTHON" -c "from nexus.fs._cli import main; main(['unmount', '$uri'])" 2>/dev/null || true
+    nfs unmount "$uri" 2>/dev/null || true
 done
 ok "Clean slate"
 
@@ -118,10 +115,10 @@ echo "  $(find "$TESTROOT/datasets" -type f | wc -l | tr -d ' ') files created"
 # ── Step 4: Mount backends ───────────────────────────────────────────────────
 step "4/11" "Mounting local backends..."
 echo "  > nexus-fs mount local://$TESTROOT/projects"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['mount', 'local://$TESTROOT/projects'])" 2>&1
+nfs mount "local://$TESTROOT/projects" 2>&1
 echo ""
 echo "  > nexus-fs mount local://$TESTROOT/datasets"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['mount', 'local://$TESTROOT/datasets'])" 2>&1
+nfs mount "local://$TESTROOT/datasets" 2>&1
 ok "Both backends mounted"
 
 # ── Step 5: Mount with --at (custom mount point) ─────────────────────────────
@@ -129,42 +126,42 @@ step "5/11" "Mounting with custom mount point (--at)..."
 mkdir -p "$TESTROOT/custom"
 echo "custom mount content" > "$TESTROOT/custom/readme.txt"
 echo "  > nexus-fs mount local://$TESTROOT/custom --at /my/custom/path"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['mount', 'local://$TESTROOT/custom', '--at', '/my/custom/path'])" 2>&1
+nfs mount "local://$TESTROOT/custom" --at /my/custom/path 2>&1
 ok "Custom mount point registered"
 
 # ── Step 6: List persisted mounts ────────────────────────────────────────────
 step "6/11" "Listing persisted mounts..."
 echo "  > nexus-fs mount list"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['mount', 'list'])" 2>&1
+nfs mount list 2>&1
 ok "Mount list retrieved (includes --at mount)"
 
 # ── Step 7: Run doctor diagnostics ───────────────────────────────────────────
 step "7/11" "Running doctor diagnostics..."
 echo "  > nexus-fs doctor --mount local://$TESTROOT/projects"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['doctor', '--mount', 'local://$TESTROOT/projects'])" 2>&1
+nfs doctor --mount "local://$TESTROOT/projects" 2>&1
 ok "Doctor completed"
 
 # ── Step 8: Doctor with multiple --mount flags ───────────────────────────────
 step "8/11" "Running doctor with multiple --mount flags..."
 echo "  > nexus-fs doctor --mount local://$TESTROOT/projects --mount local://$TESTROOT/datasets"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['doctor', '--mount', 'local://$TESTROOT/projects', '--mount', 'local://$TESTROOT/datasets'])" 2>&1
+nfs doctor --mount "local://$TESTROOT/projects" --mount "local://$TESTROOT/datasets" 2>&1
 ok "Doctor with multi-mount"
 
 # ── Step 9: Test mount connectivity ──────────────────────────────────────────
 step "9/11" "Testing mount connectivity..."
 echo "  > nexus-fs mount test local://$TESTROOT/datasets"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['mount', 'test', 'local://$TESTROOT/datasets'])" 2>&1
+nfs mount test "local://$TESTROOT/datasets" 2>&1
 ok "Mount test passed"
 
 # ── Step 10: Unmount custom mount (cleanup for later scripts) ────────────────
 step "10/11" "Unmounting custom mount point..."
 echo "  > nexus-fs unmount local://$TESTROOT/custom"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['unmount', 'local://$TESTROOT/custom'])" 2>&1
+nfs unmount "local://$TESTROOT/custom" 2>&1
 ok "Custom mount removed"
 
 # ── Step 11: Verify final mount list ─────────────────────────────────────────
 step "11/11" "Final mount list..."
-"$PYTHON" -c "from nexus.fs._cli import main; main(['mount', 'list'])" 2>&1
+nfs mount list 2>&1
 ok "Only projects + datasets remain"
 
 # ── Summary ──────────────────────────────────────────────────────────────────

--- a/scripts/nexus-fs-demo/test_nexus_fs_2_file_operations.sh
+++ b/scripts/nexus-fs-demo/test_nexus_fs_2_file_operations.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
 # =============================================================================
-# Script 2: File Operations (Write, Read, Copy, Verify)
+# Script 2: File Operations (Write, Read, Copy, Edit, Verify)
 # =============================================================================
-# Tests: Python API write/read, nexus-fs cp, cross-directory copy, --json,
-#        cp with trailing mount URIs (inline mounts)
+# Tests: nexus-fs write/cat/ls/stat/edit/rm/cp/mkdir CLI commands
 #
 # Prereq: Run script 1 first (creates /tmp/nexus-fs-demo and mounts)
 #
@@ -16,7 +15,7 @@ set -euo pipefail
 
 PYTHON="${NEXUS_FS_PYTHON:-/Users/tafeng/nexus/.venv/bin/python}"
 TESTROOT="/tmp/nexus-fs-demo"
-nexus_fs() { "$PYTHON" -c "from nexus.fs._cli import main; main()" -- "$@"; }
+nfs() { "$PYTHON" -c "from nexus.fs._cli import main; main()" "$@"; }
 
 GREEN='\033[0;32m'; CYAN='\033[0;36m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
 step()   { echo -e "\n${CYAN}[$1]${NC} $2"; }
@@ -32,212 +31,149 @@ if [ ! -d "$TESTROOT/projects" ] || [ ! -d "$TESTROOT/datasets" ]; then
 fi
 
 # ── Step 1: Create workspace backend ─────────────────────────────────────────
-step "1/10" "Creating workspace backend for copy targets..."
+step "1/13" "Creating workspace backend for copy targets..."
 mkdir -p "$TESTROOT/workspace"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['unmount', 'local://$TESTROOT/workspace'])" 2>/dev/null || true
-"$PYTHON" -c "from nexus.fs._cli import main; main(['mount', 'local://$TESTROOT/workspace'])" 2>&1
+nfs unmount "local://$TESTROOT/workspace" 2>/dev/null || true
+nfs mount "local://$TESTROOT/workspace" 2>&1
 ok "Workspace backend mounted"
 
-# ── Step 2: Seed files via NexusFS API ───────────────────────────────────────
-step "2/10" "Seeding files into CAS via NexusFS API..."
-"$PYTHON" << PYEOF
-import asyncio, contextlib
-from nexus.fs import mount
+# ── Step 2: Seed files via CLI ──────────────────────────────────────────────
+step "2/13" "Seeding files into CAS via nexus-fs write..."
+# Clean stale entries from previous runs
+for stale in \
+    /local/nexus-fs-demo-datasets/users_backup.csv \
+    /local/nexus-fs-demo-workspace/metrics.csv \
+    /local/nexus-fs-demo-workspace/main.py \
+    /local/nexus-fs-demo-workspace/config.json \
+    /local/nexus-fs-demo-workspace/inline_test.txt \
+    /local/nexus-fs-demo-workspace/main_edit.py; do
+    nfs rm "$stale" 2>/dev/null || true
+done
 
-async def seed():
-    fs = await mount(
-        'local://$TESTROOT/projects',
-        'local://$TESTROOT/datasets',
-        'local://$TESTROOT/workspace',
-    )
+# Seed project files
+nfs write /local/nexus-fs-demo-projects/README.md < "$TESTROOT/projects/README.md"
+nfs write /local/nexus-fs-demo-projects/src/main.py < "$TESTROOT/projects/src/main.py"
 
-    # Clean stale CAS entries from previous runs
-    for stale in [
-        '/local/nexus-fs-demo-datasets/users_backup.csv',
-        '/local/nexus-fs-demo-workspace/metrics.csv',
-        '/local/nexus-fs-demo-workspace/main.py',
-        '/local/nexus-fs-demo-workspace/config.json',
-        '/local/nexus-fs-demo-workspace/inline_test.txt',
-    ]:
-        with contextlib.suppress(Exception):
-            await fs.delete(stale)
+# Seed dataset files
+nfs write /local/nexus-fs-demo-datasets/users.csv < "$TESTROOT/datasets/users.csv"
+nfs write /local/nexus-fs-demo-datasets/config.json < "$TESTROOT/datasets/config.json"
+nfs write /local/nexus-fs-demo-datasets/metrics.csv < "$TESTROOT/datasets/metrics.csv"
 
-    # Seed project files into CAS
-    await fs.write('/local/nexus-fs-demo-projects/README.md', open('$TESTROOT/projects/README.md', 'rb').read())
-    await fs.write('/local/nexus-fs-demo-projects/src/main.py', open('$TESTROOT/projects/src/main.py', 'rb').read())
-
-    # Seed dataset files into CAS
-    await fs.write('/local/nexus-fs-demo-datasets/users.csv', open('$TESTROOT/datasets/users.csv', 'rb').read())
-    await fs.write('/local/nexus-fs-demo-datasets/config.json', open('$TESTROOT/datasets/config.json', 'rb').read())
-    await fs.write('/local/nexus-fs-demo-datasets/metrics.csv', open('$TESTROOT/datasets/metrics.csv', 'rb').read())
-
-    # List what we have
-    proj_files = await fs.ls('/local/nexus-fs-demo-projects/')
-    data_files = await fs.ls('/local/nexus-fs-demo-datasets/')
-    print(f"  Seeded {len(proj_files)} project files: {[f.split('/')[-1] for f in proj_files]}")
-    print(f"  Seeded {len(data_files)} dataset files: {[f.split('/')[-1] for f in data_files]}")
-
-    await fs.close()
-
-asyncio.run(seed())
-PYEOF
-ok "CAS seeded"
+# List what we have
+echo "  Projects:"
+nfs ls /local/nexus-fs-demo-projects/ 2>&1 | sed 's/^/    /'
+echo "  Datasets:"
+nfs ls /local/nexus-fs-demo-datasets/ 2>&1 | sed 's/^/    /'
+ok "CAS seeded via CLI"
 
 # ── Step 3: Copy file within same backend ────────────────────────────────────
-step "3/10" "Copying file within same backend (datasets -> datasets)..."
+step "3/13" "Copying file within same backend (datasets -> datasets)..."
 echo "  > nexus-fs cp /local/.../users.csv /local/.../users_backup.csv"
-"$PYTHON" -c "
-from nexus.fs._cli import main
-main(['cp', '/local/nexus-fs-demo-datasets/users.csv', '/local/nexus-fs-demo-datasets/users_backup.csv'])
-" 2>&1
+nfs cp /local/nexus-fs-demo-datasets/users.csv /local/nexus-fs-demo-datasets/users_backup.csv 2>&1
 ok "Same-backend copy"
 
 # ── Step 4: Copy across backends ─────────────────────────────────────────────
-step "4/10" "Copying across backends (datasets -> workspace)..."
+step "4/13" "Copying across backends (datasets -> workspace)..."
 echo "  > nexus-fs cp /local/.../metrics.csv /local/.../metrics.csv"
-"$PYTHON" -c "
-from nexus.fs._cli import main
-main(['cp', '/local/nexus-fs-demo-datasets/metrics.csv', '/local/nexus-fs-demo-workspace/metrics.csv'])
-" 2>&1
+nfs cp /local/nexus-fs-demo-datasets/metrics.csv /local/nexus-fs-demo-workspace/metrics.csv 2>&1
 ok "Cross-backend copy"
 
 # ── Step 5: Copy project file to workspace ───────────────────────────────────
-step "5/10" "Copying project source to workspace..."
+step "5/13" "Copying project source to workspace..."
 echo "  > nexus-fs cp /local/.../src/main.py /local/.../main.py"
-"$PYTHON" -c "
-from nexus.fs._cli import main
-main(['cp', '/local/nexus-fs-demo-projects/src/main.py', '/local/nexus-fs-demo-workspace/main.py'])
-" 2>&1
+nfs cp /local/nexus-fs-demo-projects/src/main.py /local/nexus-fs-demo-workspace/main.py 2>&1
 ok "Project -> workspace copy"
 
 # ── Step 6: Copy config to workspace ─────────────────────────────────────────
-step "6/10" "Copying config.json to workspace..."
+step "6/13" "Copying config.json to workspace..."
 echo "  > nexus-fs cp /local/.../config.json /local/.../config.json --json"
-"$PYTHON" -c "
-from nexus.fs._cli import main
-main(['cp', '/local/nexus-fs-demo-datasets/config.json', '/local/nexus-fs-demo-workspace/config.json', '--json'])
-" 2>&1
+nfs cp /local/nexus-fs-demo-datasets/config.json /local/nexus-fs-demo-workspace/config.json --json 2>&1
 ok "Config copied with --json output"
 
-# ── Step 7: Copy with trailing inline mount URIs (no persisted mounts) ───────
-step "7/10" "Copying with trailing inline mount URIs..."
+# ── Step 7: Surgical edit via CLI ────────────────────────────────────────────
+step "7/13" "Testing surgical edit (search/replace) on workspace file..."
+# Copy main.py to workspace for editing
+nfs cp /local/nexus-fs-demo-projects/src/main.py /local/nexus-fs-demo-workspace/main_edit.py 2>&1
+
+# Surgical edit: rename function without rewriting the whole file
+echo "  > nexus-fs edit ... -e 'def hello>>>def greet'"
+nfs edit /local/nexus-fs-demo-workspace/main_edit.py -e 'def hello>>>def greet' 2>&1
+
+# Preview mode: see diff without writing
+echo "  > nexus-fs edit ... -e 'def greet>>>def salute' --preview"
+nfs edit /local/nexus-fs-demo-workspace/main_edit.py -e 'def greet>>>def salute' --preview 2>&1
+
+# Verify original edit stuck and preview didn't modify
+CONTENT=$(nfs cat /local/nexus-fs-demo-workspace/main_edit.py 2>&1)
+echo "$CONTENT" | grep -q "def greet" || fail "Edit was not persisted"
+echo "$CONTENT" | grep -q "def salute" && fail "Preview should not have written"
+echo "  Verified: file contains 'def greet', not 'def salute'"
+ok "Surgical edit (search/replace)"
+
+# ── Step 8: Copy with trailing inline mount URIs (no persisted mounts) ───────
+step "8/13" "Copying with trailing inline mount URIs..."
 mkdir -p "$TESTROOT/scratch"
-"$PYTHON" << PYEOF
-import asyncio
-from nexus.fs import mount
-async def go():
-    fs = await mount('local://$TESTROOT/workspace', 'local://$TESTROOT/scratch')
-    # Seed a file in scratch via kernel for the next cp
-    await fs.write('/local/nexus-fs-demo-scratch/inline_test.txt', b'Copied via inline trailing URIs')
-    await fs.close()
-asyncio.run(go())
-PYEOF
+nfs mount "local://$TESTROOT/scratch" 2>/dev/null || true
+echo "Seeded via inline trailing URIs" | nfs write /local/nexus-fs-demo-scratch/inline_test.txt
 echo "  > nexus-fs cp ... inline_test.txt -> workspace (with trailing URIs)"
-"$PYTHON" -c "
-from nexus.fs._cli import main
-main(['cp', '/local/nexus-fs-demo-scratch/inline_test.txt', '/local/nexus-fs-demo-workspace/inline_test.txt',
-      'local://$TESTROOT/scratch', 'local://$TESTROOT/workspace'])
-" 2>&1
+nfs cp /local/nexus-fs-demo-scratch/inline_test.txt /local/nexus-fs-demo-workspace/inline_test.txt \
+    "local://$TESTROOT/scratch" "local://$TESTROOT/workspace" 2>&1
 ok "cp with trailing mount URIs"
 
-# ── Step 8: Verify all copies via API ────────────────────────────────────────
-step "8/10" "Verifying all copies..."
-"$PYTHON" << 'PYEOF'
-import asyncio
-from nexus.fs import mount
+# ── Step 9: Verify all copies via CLI ────────────────────────────────────────
+step "9/13" "Verifying all copies..."
+ALL_OK=true
+verify_file() {
+    local path="$1" expected="$2" label="$3"
+    CONTENT=$(nfs cat "$path" 2>&1) || { echo "  FAIL  $label (read error)"; ALL_OK=false; return; }
+    if echo "$CONTENT" | grep -q "$expected"; then
+        printf "  PASS  %-30s contains '%s'\n" "$label" "$expected"
+    else
+        printf "  FAIL  %-30s missing '%s'\n" "$label" "$expected"
+        ALL_OK=false
+    fi
+}
+verify_file /local/nexus-fs-demo-datasets/users_backup.csv "name,email,role" "users_backup.csv"
+verify_file /local/nexus-fs-demo-workspace/metrics.csv     "date,requests"   "metrics.csv"
+verify_file /local/nexus-fs-demo-workspace/main.py         "def hello"       "main.py"
+verify_file /local/nexus-fs-demo-workspace/config.json     "nexus-fs-demo"   "config.json"
+verify_file /local/nexus-fs-demo-workspace/inline_test.txt "inline trailing" "inline_test.txt"
 
-async def verify():
-    fs = await mount(
-        'local:///tmp/nexus-fs-demo/projects',
-        'local:///tmp/nexus-fs-demo/datasets',
-        'local:///tmp/nexus-fs-demo/workspace',
-        'local:///tmp/nexus-fs-demo/scratch',
-    )
-
-    checks = [
-        ("/local/nexus-fs-demo-datasets/users_backup.csv", "name,email,role"),
-        ("/local/nexus-fs-demo-workspace/metrics.csv", "date,requests"),
-        ("/local/nexus-fs-demo-workspace/main.py", "def hello"),
-        ("/local/nexus-fs-demo-workspace/config.json", "nexus-fs-demo"),
-        ("/local/nexus-fs-demo-workspace/inline_test.txt", "inline trailing URIs"),
-    ]
-
-    all_ok = True
-    for path, expected_substr in checks:
-        try:
-            content = await fs.read(path)
-            text = content.decode()
-            if expected_substr in text:
-                print(f"  PASS  {path.split('/')[-1]:30s} contains '{expected_substr}'")
-            else:
-                print(f"  FAIL  {path.split('/')[-1]:30s} missing '{expected_substr}'")
-                all_ok = False
-        except Exception as e:
-            print(f"  FAIL  {path.split('/')[-1]:30s} error: {e}")
-            all_ok = False
-
-    # Show workspace contents
-    ws_files = await fs.ls('/local/nexus-fs-demo-workspace/')
-    print(f"\n  Workspace files: {[f.split('/')[-1] for f in ws_files]}")
-
-    await fs.close()
-    return all_ok
-
-ok = asyncio.run(verify())
-if not ok:
-    raise SystemExit(1)
-PYEOF
+echo ""
+echo "  Workspace contents:"
+nfs ls /local/nexus-fs-demo-workspace/ 2>&1 | sed 's/^/    /'
+$ALL_OK || fail "Verification failed"
 ok "All copies verified"
 
-# ── Step 9: Sync CAS data to raw filesystem for playground visibility ────────
-step "9/12" "Syncing CAS data to filesystem (for playground)..."
-"$PYTHON" << 'PYEOF'
-import asyncio
-from pathlib import Path
-from nexus.fs import mount
-
-TESTROOT = Path("/tmp/nexus-fs-demo")
-
-async def sync_to_playground():
-    fs = await mount(
-        'local:///tmp/nexus-fs-demo/projects',
-        'local:///tmp/nexus-fs-demo/datasets',
-        'local:///tmp/nexus-fs-demo/workspace',
-    )
-
-    # Export CAS files to raw directories so playground can see them
-    exports = [
-        ("/local/nexus-fs-demo-datasets/users_backup.csv", TESTROOT / "datasets" / "users_backup.csv"),
-        ("/local/nexus-fs-demo-workspace/metrics.csv",     TESTROOT / "workspace" / "metrics.csv"),
-        ("/local/nexus-fs-demo-workspace/main.py",         TESTROOT / "workspace" / "main.py"),
-        ("/local/nexus-fs-demo-workspace/config.json",     TESTROOT / "workspace" / "config.json"),
-        ("/local/nexus-fs-demo-workspace/inline_test.txt", TESTROOT / "workspace" / "inline_test.txt"),
-    ]
-
-    for cas_path, raw_path in exports:
-        content = await fs.read(cas_path)
-        raw_path.parent.mkdir(parents=True, exist_ok=True)
-        raw_path.write_bytes(content)
-        print(f"  Synced {raw_path.name:30s} -> {raw_path.parent.name}/ ({len(content)} bytes)")
-
-    await fs.close()
-
-asyncio.run(sync_to_playground())
-PYEOF
+# ── Step 10: Sync CAS data to raw filesystem for playground visibility ───────
+step "10/13" "Syncing CAS data to filesystem (for playground)..."
+for pair in \
+    "/local/nexus-fs-demo-datasets/users_backup.csv:$TESTROOT/datasets/users_backup.csv" \
+    "/local/nexus-fs-demo-workspace/metrics.csv:$TESTROOT/workspace/metrics.csv" \
+    "/local/nexus-fs-demo-workspace/main.py:$TESTROOT/workspace/main.py" \
+    "/local/nexus-fs-demo-workspace/config.json:$TESTROOT/workspace/config.json" \
+    "/local/nexus-fs-demo-workspace/inline_test.txt:$TESTROOT/workspace/inline_test.txt"; do
+    CAS_PATH="${pair%%:*}"
+    RAW_PATH="${pair##*:}"
+    mkdir -p "$(dirname "$RAW_PATH")"
+    nfs cat "$CAS_PATH" > "$RAW_PATH" 2>/dev/null
+    SIZE=$(wc -c < "$RAW_PATH" | tr -d ' ')
+    printf "  Synced %-30s -> %s/ (%s bytes)\n" "$(basename "$RAW_PATH")" "$(basename "$(dirname "$RAW_PATH")")" "$SIZE"
+done
 ok "CAS -> filesystem sync for playground"
 
-# ── Step 10: Cleanup scratch ─────────────────────────────────────────────────
-step "10/12" "Cleaning up scratch backend..."
-"$PYTHON" -c "from nexus.fs._cli import main; main(['unmount', 'local://$TESTROOT/scratch'])" 2>/dev/null || true
+# ── Step 11: Cleanup scratch ─────────────────────────────────────────────────
+step "11/13" "Cleaning up scratch backend..."
+nfs unmount "local://$TESTROOT/scratch" 2>/dev/null || true
 rm -rf "$TESTROOT/scratch"
 ok "Scratch cleaned"
 
-# ── Step 11: Show mount list ─────────────────────────────────────────────────
-step "11/12" "Final mount state..."
-"$PYTHON" -c "from nexus.fs._cli import main; main(['mount', 'list'])" 2>&1
+# ── Step 12: Show mount list ─────────────────────────────────────────────────
+step "12/13" "Final mount state..."
+nfs mount list 2>&1
 
-# ── Step 12: Validate playground visibility ──────────────────────────────────
-step "12/12" "Validating playground visibility..."
+# ── Step 13: Validate playground visibility ──────────────────────────────────
+step "13/13" "Validating playground visibility..."
 "$PYTHON" << 'PYEOF'
 from pathlib import Path
 
@@ -260,18 +196,24 @@ for mount_name, expected_files in [
 
 if not all_ok:
     raise SystemExit(1)
-print(f"\n  All {sum(len(v) for v in [['README.md','src/main.py','src/utils.py','docs/setup.md'],['users.csv','config.json','metrics.csv','users_backup.csv'],['metrics.csv','main.py','config.json','inline_test.txt']])} files visible in playground")
+total = sum(len(v) for v in [
+    ["README.md", "src/main.py", "src/utils.py", "docs/setup.md"],
+    ["users.csv", "config.json", "metrics.csv", "users_backup.csv"],
+    ["metrics.csv", "main.py", "config.json", "inline_test.txt"],
+])
+print(f"\n  All {total} files visible in playground")
 PYEOF
 ok "Playground validation passed"
 
 banner "File Operations Complete!"
 echo ""
 echo "  Operations performed:"
-echo "    - Seeded 5 files via API"
+echo "    - Seeded 5 files via nexus-fs write"
 echo "    - Copied within same backend (users.csv backup)"
 echo "    - Copied across 3 backends (datasets/projects -> workspace)"
+echo "    - Surgical edit (search/replace) with preview mode"
 echo "    - Copied with trailing inline mount URIs"
-echo "    - Verified all copies match"
+echo "    - Verified all copies via nexus-fs cat"
 echo ""
 echo "  Open playground to see all 3 backends:"
 echo "    nexus-fs playground local://$TESTROOT/projects local://$TESTROOT/datasets local://$TESTROOT/workspace"

--- a/scripts/nexus-fs-demo/test_nexus_fs_3_auth_diagnostics.sh
+++ b/scripts/nexus-fs-demo/test_nexus_fs_3_auth_diagnostics.sh
@@ -14,6 +14,8 @@ set -euo pipefail
 PYTHON="${NEXUS_FS_PYTHON:-/Users/tafeng/nexus/.venv/bin/python}"
 TESTROOT="/tmp/nexus-fs-demo"
 
+nfs() { "$PYTHON" -c "from nexus.fs._cli import main; main()" "$@"; }
+
 GREEN='\033[0;32m'; CYAN='\033[0;36m'; YELLOW='\033[1;33m'; DIM='\033[2m'; NC='\033[0m'
 step()   { echo -e "\n${CYAN}[$1]${NC} $2"; }
 ok()     { echo -e "  ${GREEN}OK${NC} $1"; }
@@ -24,90 +26,90 @@ banner "Script 3: Auth & Diagnostics"
 # ── Step 1: Auth list ────────────────────────────────────────────────────────
 step "1/15" "Listing all configured auth services..."
 echo "  > nexus-fs auth list"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['auth', 'list'])" 2>&1
+nfs auth list 2>&1
 ok "Auth list retrieved"
 
 # ── Step 2: Auth list (JSON) ─────────────────────────────────────────────────
 step "2/15" "Auth list with JSON output..."
 echo "  > nexus-fs auth list --json"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['auth', 'list', '--json'])" 2>&1
+nfs auth list --json 2>&1
 ok "JSON auth list"
 
 # ── Step 3: Auth list with --fields filter ───────────────────────────────────
 step "3/15" "Auth list with --fields filter..."
 echo "  > nexus-fs auth list --json --fields service,status"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['auth', 'list', '--json', '--fields', 'service,status'])" 2>&1
+nfs auth list --json --fields service,status 2>&1
 ok "Filtered auth list (service + status only)"
 
 # ── Step 4: Test S3 auth ─────────────────────────────────────────────────────
 step "4/15" "Testing S3 credentials..."
 echo "  > nexus-fs auth test s3"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['auth', 'test', 's3'])" 2>&1
+nfs auth test s3 2>&1
 ok "S3 auth tested"
 
 # ── Step 5: Test GCS auth ────────────────────────────────────────────────────
 step "5/15" "Testing GCS credentials..."
 echo "  > nexus-fs auth test gcs"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['auth', 'test', 'gcs'])" 2>&1 || echo -e "  ${DIM}(GCS auth not configured -- expected in some environments)${NC}"
+nfs auth test gcs 2>&1 || echo -e "  ${DIM}(GCS auth not configured -- expected in some environments)${NC}"
 ok "GCS auth tested"
 
 # ── Step 6: Auth test with --user-email ──────────────────────────────────────
 step "6/15" "Testing auth with --user-email flag..."
 echo "  > nexus-fs auth test gcs --user-email test@example.com"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['auth', 'test', 'gcs', '--user-email', 'test@example.com'])" 2>&1 || echo -e "  ${DIM}(GCS may not need user-email -- flag accepted)${NC}"
+nfs auth test gcs --user-email test@example.com 2>&1 || echo -e "  ${DIM}(GCS may not need user-email -- flag accepted)${NC}"
 ok "auth test --user-email"
 
 # ── Step 7: Auth test with --target (GWS target readiness) ──────────────────
 step "7/15" "Testing GWS target readiness (--target drive)..."
 echo "  > nexus-fs auth test gws --target drive"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['auth', 'test', 'gws', '--target', 'drive'])" 2>&1 || echo -e "  ${DIM}(GWS target check completed with status above)${NC}"
+nfs auth test gws --target drive 2>&1 || echo -e "  ${DIM}(GWS target check completed with status above)${NC}"
 ok "auth test --target"
 
 # ── Step 8: Auth connect native (S3) ────────────────────────────────────────
 step "8/15" "Connecting S3 with native auth..."
 echo "  > nexus-fs auth connect s3 native"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['auth', 'connect', 's3', 'native'])" 2>&1
+nfs auth connect s3 native 2>&1
 ok "auth connect native"
 
 # ── Step 9: Auth connect secret with --set (S3) ─────────────────────────────
 step "9/15" "Connecting S3 with secret auth (--set key=value)..."
 echo "  > nexus-fs auth connect s3 secret --set access_key_id=... --set secret_access_key=..."
-"$PYTHON" -c "from nexus.fs._cli import main; main(['auth', 'connect', 's3', 'secret', '--set', 'access_key_id=AKIAIOSFODNN7EXAMPLE', '--set', 'secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY'])" 2>&1
+nfs auth connect s3 secret --set access_key_id=AKIAIOSFODNN7EXAMPLE --set secret_access_key=wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY 2>&1
 ok "auth connect secret --set"
 
 # ── Step 10: Verify secret was stored ────────────────────────────────────────
 step "10/15" "Verifying stored secret auth..."
 echo "  > nexus-fs auth test s3"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['auth', 'test', 's3'])" 2>&1
+nfs auth test s3 2>&1
 ok "Secret auth verified"
 
 # ── Step 11: Auth disconnect ─────────────────────────────────────────────────
 step "11/15" "Disconnecting S3 stored auth..."
 echo "  > nexus-fs auth disconnect s3"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['auth', 'disconnect', 's3'])" 2>&1
+nfs auth disconnect s3 2>&1
 ok "auth disconnect"
 
 # ── Step 11b: Restore S3 native auth ────────────────────────────────────────
 echo "  > Restoring S3 native auth..."
-"$PYTHON" -c "from nexus.fs._cli import main; main(['auth', 'connect', 's3', 'native'])" 2>&1
+nfs auth connect s3 native 2>&1
 ok "S3 native auth restored"
 
 # ── Step 12: Auth doctor ─────────────────────────────────────────────────────
 step "12/15" "Running auth doctor..."
 echo "  > nexus-fs auth doctor"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['auth', 'doctor'])" 2>&1 || true
+nfs auth doctor 2>&1 || true
 ok "Auth doctor completed"
 
 # ── Step 13: Full doctor + --quiet flag ──────────────────────────────────────
 step "13/15" "Running doctor with --quiet flag..."
 echo "  > nexus-fs doctor --quiet"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['doctor', '--quiet'])" 2>&1 || true
+nfs doctor --quiet 2>&1 || true
 ok "doctor --quiet"
 
 # ── Step 14: Doctor with --verbose flag ──────────────────────────────────────
 step "14/15" "Running doctor with --verbose flag..."
 echo "  > nexus-fs doctor -v"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['doctor', '-v'])" 2>&1
+nfs doctor -v 2>&1
 ok "doctor --verbose"
 
 # ── Step 15: Doctor with mount connectivity ──────────────────────────────────
@@ -115,7 +117,7 @@ step "15/15" "Running doctor with mount connectivity check..."
 mkdir -p "$TESTROOT/healthcheck"
 echo "healthcheck" > "$TESTROOT/healthcheck/probe.txt"
 echo "  > nexus-fs doctor --mount local://$TESTROOT/healthcheck"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['doctor', '--mount', 'local://$TESTROOT/healthcheck'])" 2>&1
+nfs doctor --mount "local://$TESTROOT/healthcheck" 2>&1
 rm -rf "$TESTROOT/healthcheck"
 ok "Doctor with mount check completed"
 

--- a/scripts/nexus-fs-demo/test_nexus_fs_3b_error_cases.sh
+++ b/scripts/nexus-fs-demo/test_nexus_fs_3b_error_cases.sh
@@ -14,6 +14,8 @@ PYTHON="${NEXUS_FS_PYTHON:-/Users/tafeng/nexus/.venv/bin/python}"
 TESTROOT="/tmp/nexus-fs-demo"
 ERRDIR="/tmp/nexus-fs-err-test"
 
+nfs() { "$PYTHON" -c "from nexus.fs._cli import main; main()" "$@"; }
+
 GREEN='\033[0;32m'; CYAN='\033[0;36m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
 step()    { echo -e "\n${CYAN}[$1]${NC} $2"; }
 ok()      { echo -e "  ${GREEN}PASS${NC} $1"; }
@@ -30,7 +32,7 @@ expect_error() {
     TOTAL=$((TOTAL+1))
 
     local output
-    output=$("$PYTHON" -c "from nexus.fs._cli import main; main($*)" 2>&1) || true
+    output=$(nfs "$@" 2>&1) || true
     local exit_code=${PIPESTATUS[0]:-0}
 
     if echo "$output" | grep -qi "$expect_substr"; then
@@ -45,24 +47,24 @@ banner "Script 3b: Error Cases"
 
 # ── mount errors ─────────────────────────────────────────────────────────────
 step "1/13" "mount: invalid URI scheme..."
-expect_error "mount foobar://x" "No module named" "['mount', 'foobar://nonsense']"
+expect_error "mount foobar://x" "No module named" mount foobar://nonsense
 
 step "2/13" "mount: --at with multiple URIs..."
 mkdir -p /tmp/nexus-fs-err-a /tmp/nexus-fs-err-b
-expect_error "mount --at + multi URI" "only valid with a single URI" "['mount', 'local:///tmp/nexus-fs-err-a', 'local:///tmp/nexus-fs-err-b', '--at', '/x']"
+expect_error "mount --at + multi URI" "only valid with a single URI" mount local:///tmp/nexus-fs-err-a local:///tmp/nexus-fs-err-b --at /x
 rm -rf /tmp/nexus-fs-err-a /tmp/nexus-fs-err-b
 
 step "3/13" "mount test: invalid scheme..."
-expect_error "mount test ftp://" "No module named" "['mount', 'test', 'ftp://invalid']"
+expect_error "mount test ftp://" "No module named" mount test ftp://invalid
 
 # ── unmount errors ───────────────────────────────────────────────────────────
 step "4/13" "unmount: non-existent mount..."
-expect_error "unmount missing" "mount not found" "['unmount', 'local:///no/such/mount']"
+expect_error "unmount missing" "mount not found" unmount local:///no/such/mount
 
 # ── cp errors ────────────────────────────────────────────────────────────────
 step "5/13" "cp: non-existent source file..."
 mkdir -p "$ERRDIR"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['mount', 'local://$ERRDIR'])" > /dev/null 2>&1
+nfs mount "local://$ERRDIR" > /dev/null 2>&1
 "$PYTHON" << PYEOF
 import asyncio
 from nexus.fs import mount
@@ -72,10 +74,10 @@ async def go():
     await fs.close()
 asyncio.run(go())
 PYEOF
-expect_error "cp missing source" "not found" "['cp', '/local/nexus-fs-err-test/no-such-file.txt', '/local/nexus-fs-err-test/dest.txt']"
+expect_error "cp missing source" "not found" cp /local/nexus-fs-err-test/no-such-file.txt /local/nexus-fs-err-test/dest.txt
 
 step "6/13" "cp: destination path outside any mount..."
-expect_error "cp unmounted dest" "No mount found" "['cp', '/local/nexus-fs-err-test/exists.txt', '/unmounted/path/dest.txt']"
+expect_error "cp unmounted dest" "No mount found" cp /local/nexus-fs-err-test/exists.txt /unmounted/path/dest.txt
 
 step "7/13" "cp: no mounts configured..."
 # Temporarily clear mounts
@@ -83,9 +85,9 @@ step "7/13" "cp: no mounts configured..."
 from nexus.fs._paths import save_persisted_mounts, load_persisted_mounts
 save_persisted_mounts([], merge=False)
 "
-expect_error "cp no mounts" "No mounts found" "['cp', '/x/y.txt', '/a/b.txt']"
+expect_error "cp no mounts" "No mounts found" cp /x/y.txt /a/b.txt
 # Restore
-"$PYTHON" -c "from nexus.fs._cli import main; main(['mount', 'local://$ERRDIR'])" > /dev/null 2>&1
+nfs mount "local://$ERRDIR" > /dev/null 2>&1
 
 step "8/13" "cp: destination already exists..."
 "$PYTHON" << PYEOF
@@ -98,18 +100,18 @@ async def go():
     await fs.close()
 asyncio.run(go())
 PYEOF
-expect_error "cp dest exists" "already exists" "['cp', '/local/nexus-fs-err-test/src.txt', '/local/nexus-fs-err-test/dst.txt']"
+expect_error "cp dest exists" "already exists" cp /local/nexus-fs-err-test/src.txt /local/nexus-fs-err-test/dst.txt
 
 # ── auth errors ──────────────────────────────────────────────────────────────
 step "9/13" "auth test: unknown service..."
-expect_error "auth test unknown" "Unknown auth service" "['auth', 'test', 'nonexistent-svc']"
+expect_error "auth test unknown" "Unknown auth service" auth test nonexistent-svc
 
 step "10/13" "auth disconnect: unconfigured service..."
-expect_error "auth disconnect slack" "No stored auth found" "['auth', 'disconnect', 'slack']"
+expect_error "auth disconnect slack" "No stored auth found" auth disconnect slack
 
 step "11/13" "auth doctor: partial failure (slack/x not configured)..."
 TOTAL=$((TOTAL+1))
-OUTPUT=$("$PYTHON" -c "from nexus.fs._cli import main; main(['auth', 'doctor'])" 2>&1) || true
+OUTPUT=$(nfs auth doctor 2>&1) || true
 if echo "$OUTPUT" | grep -q "need auth setup"; then
     ok "auth doctor reports missing services"
 else
@@ -119,7 +121,7 @@ fi
 # ── doctor edge cases ────────────────────────────────────────────────────────
 step "12/13" "doctor --mount: invalid scheme (warns, doesn't crash)..."
 TOTAL=$((TOTAL+1))
-OUTPUT=$("$PYTHON" -c "from nexus.fs._cli import main; main(['doctor', '--mount', 'ftp://invalid'])" 2>&1) || true
+OUTPUT=$(nfs doctor --mount ftp://invalid 2>&1) || true
 if echo "$OUTPUT" | grep -qi "unable to mount\|No module"; then
     ok "doctor --mount invalid scheme (warns gracefully)"
 else
@@ -128,13 +130,13 @@ fi
 
 # ── mount list edge case ─────────────────────────────────────────────────────
 step "13/13" "mount list: empty (no mounts)..."
-"$PYTHON" -c "from nexus.fs._cli import main; main(['unmount', 'local://$ERRDIR'])" > /dev/null 2>&1 || true
+nfs unmount "local://$ERRDIR" > /dev/null 2>&1 || true
 "$PYTHON" -c "
 from nexus.fs._paths import save_persisted_mounts
 save_persisted_mounts([], merge=False)
 "
 TOTAL=$((TOTAL+1))
-OUTPUT=$("$PYTHON" -c "from nexus.fs._cli import main; main(['mount', 'list'])" 2>&1) || true
+OUTPUT=$(nfs mount list 2>&1) || true
 if echo "$OUTPUT" | grep -qi "mounts.*\[\]"; then
     ok "mount list empty returns empty array"
 else
@@ -142,7 +144,7 @@ else
 fi
 
 # ── Cleanup ──────────────────────────────────────────────────────────────────
-"$PYTHON" -c "from nexus.fs._cli import main; main(['unmount', 'local://$ERRDIR'])" 2>/dev/null || true
+nfs unmount "local://$ERRDIR" 2>/dev/null || true
 rm -rf "$ERRDIR"
 
 # ── Summary ──────────────────────────────────────────────────────────────────

--- a/scripts/nexus-fs-demo/test_nexus_fs_4_multi_backend_workflow.sh
+++ b/scripts/nexus-fs-demo/test_nexus_fs_4_multi_backend_workflow.sh
@@ -18,6 +18,8 @@ set -euo pipefail
 PYTHON="${NEXUS_FS_PYTHON:-/Users/tafeng/nexus/.venv/bin/python}"
 TESTROOT="/tmp/nexus-fs-demo"
 
+nfs() { "$PYTHON" -c "from nexus.fs._cli import main; main()" "$@"; }
+
 GREEN='\033[0;32m'; CYAN='\033[0;36m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
 step()   { echo -e "\n${CYAN}[$1]${NC} $2"; }
 ok()     { echo -e "  ${GREEN}OK${NC} $1"; }
@@ -30,7 +32,7 @@ banner "Script 4: Multi-Backend Workspace"
 step "1/9" "Creating 4 backend directories..."
 for dir in inbox processed archive reports; do
     mkdir -p "$TESTROOT/$dir"
-    "$PYTHON" -c "from nexus.fs._cli import main; main(['unmount', 'local://$TESTROOT/$dir'])" 2>/dev/null || true
+    nfs unmount "local://$TESTROOT/$dir" 2>/dev/null || true
 done
 
 # Populate inbox with raw data files
@@ -64,7 +66,7 @@ ok "Created 4 backends, 3 inbox files"
 step "2/9" "Mounting all 4 backends..."
 for dir in inbox processed archive reports; do
     echo "  > nexus-fs mount local://$TESTROOT/$dir"
-    "$PYTHON" -c "from nexus.fs._cli import main; main(['mount', 'local://$TESTROOT/$dir'])" 2>&1
+    nfs mount "local://$TESTROOT/$dir" 2>&1
 done
 ok "4 backends mounted"
 
@@ -126,25 +128,16 @@ ok "Inbox files seeded into CAS"
 # ── Step 4: Process - copy from inbox to processed ───────────────────────────
 step "4/9" "Processing: inbox -> processed (via nexus-fs cp)..."
 echo "  > nexus-fs cp .../sales_2026_q1.csv -> processed"
-"$PYTHON" -c "
-from nexus.fs._cli import main
-main(['cp', '/local/nexus-fs-demo-inbox/sales_2026_q1.csv', '/local/nexus-fs-demo-processed/sales_2026_q1.csv'])
-" 2>&1
+nfs cp /local/nexus-fs-demo-inbox/sales_2026_q1.csv /local/nexus-fs-demo-processed/sales_2026_q1.csv 2>&1
 echo ""
 echo "  > nexus-fs cp .../events_march.json -> processed"
-"$PYTHON" -c "
-from nexus.fs._cli import main
-main(['cp', '/local/nexus-fs-demo-inbox/events_march.json', '/local/nexus-fs-demo-processed/events_march.json'])
-" 2>&1
+nfs cp /local/nexus-fs-demo-inbox/events_march.json /local/nexus-fs-demo-processed/events_march.json 2>&1
 ok "2 files processed"
 
 # ── Step 5: Archive - copy processed to archive ──────────────────────────────
 step "5/9" "Archiving: processed -> archive (via nexus-fs cp)..."
 echo "  > nexus-fs cp .../sales_2026_q1.csv -> archive"
-"$PYTHON" -c "
-from nexus.fs._cli import main
-main(['cp', '/local/nexus-fs-demo-processed/sales_2026_q1.csv', '/local/nexus-fs-demo-archive/sales_2026_q1.csv'])
-" 2>&1
+nfs cp /local/nexus-fs-demo-processed/sales_2026_q1.csv /local/nexus-fs-demo-archive/sales_2026_q1.csv 2>&1
 ok "Archived sales data"
 
 # ── Step 6: Generate reports via API (write, mkdir, stat) ────────────────────
@@ -256,10 +249,7 @@ ok "Pipeline verified"
 # ── Step 8: Copy large binary file ───────────────────────────────────────────
 step "8/9" "Copying binary file (model weights) to archive..."
 echo "  > nexus-fs cp .../model_weights.bin -> archive"
-"$PYTHON" -c "
-from nexus.fs._cli import main
-main(['cp', '/local/nexus-fs-demo-inbox/model_weights.bin', '/local/nexus-fs-demo-archive/model_weights.bin'])
-" 2>&1
+nfs cp /local/nexus-fs-demo-inbox/model_weights.bin /local/nexus-fs-demo-archive/model_weights.bin 2>&1
 ok "Binary file archived"
 
 # ── Step 9: Sync CAS data to filesystem for playground ───────────────────────
@@ -331,7 +321,7 @@ ok "Playground validation passed"
 
 # ── Step 11: Final mount list ────────────────────────────────────────────────
 step "11/11" "Final mount state..."
-"$PYTHON" -c "from nexus.fs._cli import main; main(['mount', 'list'])" 2>&1
+nfs mount list 2>&1
 
 banner "Multi-Backend Workflow Complete!"
 echo ""

--- a/scripts/nexus-fs-demo/test_nexus_fs_5_lifecycle_cleanup.sh
+++ b/scripts/nexus-fs-demo/test_nexus_fs_5_lifecycle_cleanup.sh
@@ -13,6 +13,8 @@ set -euo pipefail
 PYTHON="${NEXUS_FS_PYTHON:-/Users/tafeng/nexus/.venv/bin/python}"
 TESTROOT="/tmp/nexus-fs-demo"
 
+nfs() { "$PYTHON" -c "from nexus.fs._cli import main; main()" "$@"; }
+
 GREEN='\033[0;32m'; CYAN='\033[0;36m'; YELLOW='\033[1;33m'; RED='\033[0;31m'; NC='\033[0m'
 step()   { echo -e "\n${CYAN}[$1]${NC} $2"; }
 ok()     { echo -e "  ${GREEN}OK${NC} $1"; }
@@ -23,7 +25,7 @@ banner "Script 5: Mount Lifecycle & Cleanup"
 # ── Step 1: Show current mount state ─────────────────────────────────────────
 step "1/13" "Current mount state..."
 echo "  > nexus-fs mount list --json"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['mount', 'list', '--json'])" 2>&1
+nfs mount list --json 2>&1
 BEFORE=$("$PYTHON" -c "
 from nexus.fs._paths import load_persisted_mounts
 print(len(load_persisted_mounts()))
@@ -35,12 +37,12 @@ ok "State captured"
 # ── Step 2: Unmount one backend ──────────────────────────────────────────────
 step "2/13" "Unmounting inbox backend..."
 echo "  > nexus-fs unmount local://$TESTROOT/inbox"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['unmount', 'local://$TESTROOT/inbox'])" 2>&1
+nfs unmount "local://$TESTROOT/inbox" 2>&1
 ok "Inbox unmounted"
 
 # ── Step 3: Verify mount list updated ────────────────────────────────────────
 step "3/13" "Verifying mount list after unmount..."
-"$PYTHON" -c "from nexus.fs._cli import main; main(['mount', 'list'])" 2>&1
+nfs mount list 2>&1
 AFTER=$("$PYTHON" -c "
 from nexus.fs._paths import load_persisted_mounts
 print(len(load_persisted_mounts()))
@@ -52,52 +54,52 @@ ok "Mount list updated"
 # ── Step 4: Unmount another backend ──────────────────────────────────────────
 step "4/13" "Unmounting processed backend..."
 echo "  > nexus-fs unmount local://$TESTROOT/processed"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['unmount', 'local://$TESTROOT/processed'])" 2>&1
+nfs unmount "local://$TESTROOT/processed" 2>&1
 ok "Processed unmounted"
 
 # ── Step 5: Try unmounting non-existent mount ────────────────────────────────
 step "5/13" "Testing unmount of non-existent mount (expect error)..."
 echo "  > nexus-fs unmount local:///does/not/exist"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['unmount', 'local:///does/not/exist'])" 2>&1 || true
+nfs unmount local:///does/not/exist 2>&1 || true
 ok "Error handled gracefully"
 
 # ── Step 6: Re-mount inbox ───────────────────────────────────────────────────
 step "6/13" "Re-mounting inbox..."
 echo "  > nexus-fs mount local://$TESTROOT/inbox"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['mount', 'local://$TESTROOT/inbox'])" 2>&1
+nfs mount "local://$TESTROOT/inbox" 2>&1
 ok "Inbox re-mounted"
 
 # ── Step 7: Doctor after changes ─────────────────────────────────────────────
 step "7/13" "Running doctor after mount changes..."
 echo "  > nexus-fs doctor --mount local://$TESTROOT/inbox --json"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['doctor', '--mount', 'local://$TESTROOT/inbox', '--json'])" 2>&1
+nfs doctor --mount "local://$TESTROOT/inbox" --json 2>&1
 ok "Doctor passed"
 
 # ── Step 8: Output format comparison ─────────────────────────────────────────
 step "8/13" "Comparing output formats..."
 echo "  > nexus-fs mount list (default)"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['mount', 'list'])" 2>&1
+nfs mount list 2>&1
 echo ""
 echo "  > nexus-fs mount list --json"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['mount', 'list', '--json'])" 2>&1
+nfs mount list --json 2>&1
 ok "Output formats compared"
 
 # ── Step 9: --quiet flag ─────────────────────────────────────────────────────
 step "9/13" "Testing --quiet flag on mount list..."
 echo "  > nexus-fs mount list --quiet"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['mount', 'list', '--quiet'])" 2>&1
+nfs mount list --quiet 2>&1
 ok "mount list --quiet"
 
 # ── Step 10: --verbose flag ──────────────────────────────────────────────────
 step "10/13" "Testing --verbose flag on mount list..."
 echo "  > nexus-fs mount list -v"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['mount', 'list', '-v'])" 2>&1
+nfs mount list -v 2>&1
 ok "mount list --verbose"
 
 # ── Step 11: --fields flag on unmount ────────────────────────────────────────
 step "11/13" "Testing unmount with --json output..."
 echo "  > nexus-fs unmount local://$TESTROOT/inbox --json"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['unmount', 'local://$TESTROOT/inbox', '--json'])" 2>&1
+nfs unmount "local://$TESTROOT/inbox" --json 2>&1
 ok "unmount --json"
 
 # ── Step 12: Full cleanup of all mounts ──────────────────────────────────────
@@ -117,7 +119,7 @@ for entry in mounts:
 PYEOF
 echo ""
 echo "  > nexus-fs mount list"
-"$PYTHON" -c "from nexus.fs._cli import main; main(['mount', 'list'])" 2>&1
+nfs mount list 2>&1
 ok "All mounts removed"
 
 # ── Step 13: Cleanup test files ──────────────────────────────────────────────

--- a/src/nexus/fs/__init__.py
+++ b/src/nexus/fs/__init__.py
@@ -56,6 +56,7 @@ async def mount(
     *uris: str,
     at: str | None = None,
     mount_overrides: dict[str, str] | None = None,
+    skip_unavailable: bool = False,
 ) -> Any:
     """Mount one or more backends and return a SlimNexusFS facade.
 
@@ -65,6 +66,10 @@ async def mount(
         mount_overrides: Optional mapping of URI → custom mount point.
             Allows per-URI mount points when mounting multiple backends.
             Takes precedence over ``at``.
+        skip_unavailable: If True, backends that fail to connect (expired
+            credentials, missing bucket, network error) are skipped with a
+            warning instead of aborting the entire mount.  Useful for CLI
+            commands that should not fail because of an unrelated broken mount.
 
     Returns:
         SlimNexusFS facade with all backends mounted.
@@ -128,16 +133,31 @@ async def mount(
 
     # Create all backends with cleanup on partial failure
     backends: list[tuple[str, Any]] = []
+    skipped: list[tuple[str, str]] = []  # (uri, error_msg)
     try:
-        for spec, mp in resolved_mounts:
-            backend = create_backend(spec)
-            backends.append((mp, backend))
+        for (spec, mp), uri in zip(resolved_mounts, uris, strict=True):
+            try:
+                backend = create_backend(spec)
+                backends.append((mp, backend))
+            except Exception as exc:
+                if skip_unavailable:
+                    skipped.append((uri, str(exc)))
+                    logger.warning("Skipping unavailable backend %s: %s", uri, exc)
+                else:
+                    raise
     except Exception:
         # Clean up any already-created backends and the metastore
         for _, be in backends:
             _close_backend(be)
         metastore.close()
         raise
+
+    if not backends:
+        metastore.close()
+        skipped_summary = "; ".join(f"{u}: {e}" for u, e in skipped)
+        raise ValueError(
+            f"All mounts failed. Run 'nexus-fs doctor' to diagnose.\n{skipped_summary}"
+        )
 
     # Slim kernel boot — direct construction, no factory dependency.
     # Wrapped in try/except so backends and metastore are cleaned up if
@@ -167,12 +187,15 @@ async def mount(
 
         # Persist mount entries so playground/fsspec/cp can auto-discover them.
         # Merges with existing entries so repeated `mount` calls accumulate.
+        # Only persist URIs whose backends were successfully created.
+        skipped_uris = {u for u, _ in skipped}
         try:
             from nexus.fs._paths import save_persisted_mounts
 
             new_entries = [
                 {"uri": uri, "at": overrides.get(uri) or (at if i == 0 else None)}
                 for i, uri in enumerate(uris)
+                if uri not in skipped_uris
             ]
             save_persisted_mounts(new_entries)
         except OSError as exc:
@@ -198,6 +221,7 @@ def mount_sync(
     *uris: str,
     at: str | None = None,
     mount_overrides: dict[str, str] | None = None,
+    skip_unavailable: bool = False,
 ) -> Any:
     """Synchronous version of mount().
 
@@ -209,7 +233,14 @@ def mount_sync(
     """
     from nexus.fs._sync import SyncNexusFS, run_sync
 
-    async_fs = run_sync(mount(*uris, at=at, mount_overrides=mount_overrides))
+    async_fs = run_sync(
+        mount(
+            *uris,
+            at=at,
+            mount_overrides=mount_overrides,
+            skip_unavailable=skip_unavailable,
+        )
+    )
     return SyncNexusFS(async_fs)
 
 

--- a/src/nexus/fs/_cli.py
+++ b/src/nexus/fs/_cli.py
@@ -28,6 +28,7 @@ import asyncio
 import contextlib
 import sys
 from dataclasses import asdict
+from typing import Any
 
 import click
 
@@ -440,7 +441,7 @@ def cp(source: str, dest: str, mount_uris: tuple[str, ...], output_opts: OutputO
     )
 
 
-def _boot_fs():
+def _boot_fs() -> Any:
     """Boot a SlimNexusFS from persisted mounts only.
 
     Shared by ls, cat, write, edit, rm, mkdir, stat.
@@ -449,7 +450,7 @@ def _boot_fs():
     commands.  Users should run ``nexus-fs mount <uri>`` first.
     """
 
-    async def _run():
+    async def _run() -> Any:
         from nexus.fs import mount
         from nexus.fs._paths import build_mount_args, load_persisted_mounts
 
@@ -530,7 +531,7 @@ def cat(path: str) -> None:
 
     async def _run() -> bytes:
         fs = await _boot_fs()
-        content = await fs.read(path)
+        content: bytes = await fs.read(path)
         await fs.close()
         return content
 
@@ -779,9 +780,9 @@ def stat(path: str, output_opts: OutputOptions) -> None:
     """
     from nexus.fs._sync import run_sync
 
-    async def _run() -> dict:
+    async def _run() -> dict[str, Any]:
         fs = await _boot_fs()
-        info = await fs.stat(path)
+        info: dict[str, Any] | None = await fs.stat(path)
         await fs.close()
         if info is None:
             raise FileNotFoundError(f"Not found: {path}")

--- a/src/nexus/fs/_cli.py
+++ b/src/nexus/fs/_cli.py
@@ -613,6 +613,12 @@ def write(
     default=0.85,
     help="Fuzzy match threshold (0.0-1.0). Use 1.0 for exact only.",
 )
+@click.option(
+    "--if-match",
+    type=str,
+    default=None,
+    help="ETag for optimistic concurrency. Edit fails if file changed since this ETag.",
+)
 @click.argument("mount_uris", nargs=-1)
 @add_output_options
 def edit(
@@ -620,6 +626,7 @@ def edit(
     edits: tuple[str, ...],
     preview: bool,
     fuzzy: float,
+    if_match: str | None,
     mount_uris: tuple[str, ...],
     output_opts: OutputOptions,
 ) -> None:
@@ -632,6 +639,7 @@ def edit(
       nexus-fs edit /local/src/main.py -e 'def foo():>>>def bar():'
       nexus-fs edit /local/src/main.py -e 'old>>>new' --preview
       nexus-fs edit /local/src/main.py -e 'typo>>>fix' --fuzzy 0.8
+      nexus-fs edit /s3/bucket/f.py -e 'old>>>new' --if-match abc123
     """
     from nexus.fs._sync import run_sync
 
@@ -650,8 +658,12 @@ def edit(
             parsed_edits,
             preview=preview,
             fuzzy_threshold=fuzzy,
+            if_match=if_match,
         )
         await fs.close()
+        # Strip new_content from result to prevent leaking full file body
+        # into JSON output (auto-JSON in piped/CI contexts).
+        result.pop("new_content", None)
         return {"path": path, **result}
 
     try:

--- a/src/nexus/fs/_cli.py
+++ b/src/nexus/fs/_cli.py
@@ -408,7 +408,11 @@ def cp(source: str, dest: str, mount_uris: tuple[str, ...], output_opts: OutputO
                 "  nexus-fs cp /src /dst s3://bucket gcs://project/bucket"
             )
 
-        fs = await mount(*uris, mount_overrides=overrides or None)
+        fs = await mount(
+            *uris,
+            mount_overrides=overrides or None,
+            skip_unavailable=True,
+        )
 
         result = await fs.copy(source, dest)
         return {"source": source, "dest": dest, **result}
@@ -453,7 +457,11 @@ def _boot_fs():
         uris, overrides = build_mount_args(persisted)
         if not uris:
             raise click.UsageError("No mounts found. Run 'nexus-fs mount <uri>' first.")
-        return await mount(*uris, mount_overrides=overrides or None)
+        return await mount(
+            *uris,
+            mount_overrides=overrides or None,
+            skip_unavailable=True,
+        )
 
     return _run()
 
@@ -619,8 +627,8 @@ def write(
 @click.option(
     "--fuzzy",
     type=float,
-    default=0.85,
-    help="Fuzzy match threshold (0.0-1.0). Use 1.0 for exact only.",
+    default=1.0,
+    help="Fuzzy match threshold (0.0-1.0). Default 1.0 (exact only). Use 0.85 for typo tolerance.",
 )
 @add_output_options
 def edit(

--- a/src/nexus/fs/_cli.py
+++ b/src/nexus/fs/_cli.py
@@ -550,11 +550,18 @@ def cat(path: str, mount_uris: tuple[str, ...]) -> None:
     default=None,
     help="Content string to write. If omitted, reads from stdin.",
 )
+@click.option(
+    "--allow-empty",
+    is_flag=True,
+    default=False,
+    help="Allow writing empty content (e.g., truncating a file to zero bytes).",
+)
 @add_output_options
 def write(
     path: str,
     mount_uris: tuple[str, ...],
     data: str | None,
+    allow_empty: bool,
     output_opts: OutputOptions,
 ) -> None:
     """Write content to a file (creates or overwrites).
@@ -575,6 +582,14 @@ def write(
         content = sys.stdin.buffer.read()
     else:
         click.echo("Error: provide --data or pipe content via stdin.", err=True)
+        sys.exit(1)
+
+    if not content and not allow_empty:
+        click.echo(
+            "Error: refusing to write empty content (would truncate file). "
+            "Use --allow-empty to override.",
+            err=True,
+        )
         sys.exit(1)
 
     async def _run() -> dict:
@@ -613,12 +628,6 @@ def write(
     default=0.85,
     help="Fuzzy match threshold (0.0-1.0). Use 1.0 for exact only.",
 )
-@click.option(
-    "--if-match",
-    type=str,
-    default=None,
-    help="ETag for optimistic concurrency. Edit fails if file changed since this ETag.",
-)
 @click.argument("mount_uris", nargs=-1)
 @add_output_options
 def edit(
@@ -626,7 +635,6 @@ def edit(
     edits: tuple[str, ...],
     preview: bool,
     fuzzy: float,
-    if_match: str | None,
     mount_uris: tuple[str, ...],
     output_opts: OutputOptions,
 ) -> None:
@@ -639,7 +647,6 @@ def edit(
       nexus-fs edit /local/src/main.py -e 'def foo():>>>def bar():'
       nexus-fs edit /local/src/main.py -e 'old>>>new' --preview
       nexus-fs edit /local/src/main.py -e 'typo>>>fix' --fuzzy 0.8
-      nexus-fs edit /s3/bucket/f.py -e 'old>>>new' --if-match abc123
     """
     from nexus.fs._sync import run_sync
 
@@ -658,7 +665,6 @@ def edit(
             parsed_edits,
             preview=preview,
             fuzzy_threshold=fuzzy,
-            if_match=if_match,
         )
         await fs.close()
         # Strip new_content from result to prevent leaking full file body
@@ -672,6 +678,10 @@ def edit(
         click.echo(f"Error: {e}", err=True)
         sys.exit(1)
 
+    # Check success before rendering — ensures non-zero exit in ALL output
+    # modes (human, JSON, auto-JSON) so CI/agents don't treat failures as ok.
+    edit_failed = not result_data.get("success", True)
+
     def _human_display(d: dict) -> None:
         if d.get("success"):
             status = "preview" if preview else "applied"
@@ -682,9 +692,11 @@ def edit(
             click.echo("Edit failed:", err=True)
             for err in d.get("errors", []):
                 click.echo(f"  {err}", err=True)
-            sys.exit(1)
 
     render_output(data=result_data, output_opts=output_opts, human_formatter=_human_display)
+
+    if edit_failed:
+        sys.exit(1)
 
 
 @main.command()

--- a/src/nexus/fs/_cli.py
+++ b/src/nexus/fs/_cli.py
@@ -436,11 +436,13 @@ def cp(source: str, dest: str, mount_uris: tuple[str, ...], output_opts: OutputO
     )
 
 
-def _boot_fs(*extra_uris: str):
-    """Boot a SlimNexusFS from persisted mounts + optional extra URIs.
+def _boot_fs():
+    """Boot a SlimNexusFS from persisted mounts only.
 
     Shared by ls, cat, write, edit, rm, mkdir, stat.
-    Returns an async coroutine that yields the facade.
+    Uses only previously persisted mounts — does not accept ad-hoc URIs
+    to avoid mutating global mount state as a side effect of one-shot
+    commands.  Users should run ``nexus-fs mount <uri>`` first.
     """
 
     async def _run():
@@ -449,9 +451,6 @@ def _boot_fs(*extra_uris: str):
 
         persisted = load_persisted_mounts()
         uris, overrides = build_mount_args(persisted)
-        for uri in extra_uris:
-            if uri not in uris:
-                uris.append(uri)
         if not uris:
             raise click.UsageError("No mounts found. Run 'nexus-fs mount <uri>' first.")
         return await mount(*uris, mount_overrides=overrides or None)
@@ -466,13 +465,11 @@ def _boot_fs(*extra_uris: str):
 @click.argument("path", default="/")
 @click.option("-l", "--long", "detail", is_flag=True, help="Show detailed metadata.")
 @click.option("-r", "--recursive", is_flag=True, help="List recursively.")
-@click.argument("mount_uris", nargs=-1)
 @add_output_options
 def ls(
     path: str,
     detail: bool,
     recursive: bool,
-    mount_uris: tuple[str, ...],
     output_opts: OutputOptions,
 ) -> None:
     """List directory contents.
@@ -486,7 +483,7 @@ def ls(
     from nexus.fs._sync import run_sync
 
     async def _run() -> dict:
-        fs = await _boot_fs(*mount_uris)
+        fs = await _boot_fs()
         entries = await fs.ls(path, detail=detail, recursive=recursive)
         await fs.close()
         return {"path": path, "entries": entries}
@@ -513,8 +510,7 @@ def ls(
 
 @main.command()
 @click.argument("path", type=str)
-@click.argument("mount_uris", nargs=-1)
-def cat(path: str, mount_uris: tuple[str, ...]) -> None:
+def cat(path: str) -> None:
     """Read file contents to stdout.
 
     \b
@@ -525,7 +521,7 @@ def cat(path: str, mount_uris: tuple[str, ...]) -> None:
     from nexus.fs._sync import run_sync
 
     async def _run() -> bytes:
-        fs = await _boot_fs(*mount_uris)
+        fs = await _boot_fs()
         content = await fs.read(path)
         await fs.close()
         return content
@@ -542,7 +538,6 @@ def cat(path: str, mount_uris: tuple[str, ...]) -> None:
 
 @main.command()
 @click.argument("path", type=str)
-@click.argument("mount_uris", nargs=-1)
 @click.option(
     "--data",
     "-d",
@@ -559,7 +554,6 @@ def cat(path: str, mount_uris: tuple[str, ...]) -> None:
 @add_output_options
 def write(
     path: str,
-    mount_uris: tuple[str, ...],
     data: str | None,
     allow_empty: bool,
     output_opts: OutputOptions,
@@ -593,7 +587,7 @@ def write(
         sys.exit(1)
 
     async def _run() -> dict:
-        fs = await _boot_fs(*mount_uris)
+        fs = await _boot_fs()
         result = await fs.write(path, content)
         await fs.close()
         return {"path": path, **result}
@@ -628,14 +622,12 @@ def write(
     default=0.85,
     help="Fuzzy match threshold (0.0-1.0). Use 1.0 for exact only.",
 )
-@click.argument("mount_uris", nargs=-1)
 @add_output_options
 def edit(
     path: str,
     edits: tuple[str, ...],
     preview: bool,
     fuzzy: float,
-    mount_uris: tuple[str, ...],
     output_opts: OutputOptions,
 ) -> None:
     """Surgical search/replace edit on a file.
@@ -659,7 +651,7 @@ def edit(
         parsed_edits.append({"old_str": old, "new_str": new})
 
     async def _run() -> dict:
-        fs = await _boot_fs(*mount_uris)
+        fs = await _boot_fs()
         result = await fs.edit(
             path,
             parsed_edits,
@@ -701,9 +693,8 @@ def edit(
 
 @main.command()
 @click.argument("path", type=str)
-@click.argument("mount_uris", nargs=-1)
 @add_output_options
-def rm(path: str, mount_uris: tuple[str, ...], output_opts: OutputOptions) -> None:
+def rm(path: str, output_opts: OutputOptions) -> None:
     """Delete a file.
 
     \b
@@ -714,7 +705,7 @@ def rm(path: str, mount_uris: tuple[str, ...], output_opts: OutputOptions) -> No
     from nexus.fs._sync import run_sync
 
     async def _run() -> dict:
-        fs = await _boot_fs(*mount_uris)
+        fs = await _boot_fs()
         await fs.delete(path)
         await fs.close()
         return {"path": path, "deleted": True}
@@ -734,12 +725,10 @@ def rm(path: str, mount_uris: tuple[str, ...], output_opts: OutputOptions) -> No
 @main.command()
 @click.argument("path", type=str)
 @click.option("-p", "--parents", is_flag=True, default=True, help="Create parent dirs.")
-@click.argument("mount_uris", nargs=-1)
 @add_output_options
 def mkdir(
     path: str,
     parents: bool,
-    mount_uris: tuple[str, ...],
     output_opts: OutputOptions,
 ) -> None:
     """Create a directory.
@@ -752,7 +741,7 @@ def mkdir(
     from nexus.fs._sync import run_sync
 
     async def _run() -> dict:
-        fs = await _boot_fs(*mount_uris)
+        fs = await _boot_fs()
         await fs.mkdir(path, parents=parents)
         await fs.close()
         return {"path": path, "created": True}
@@ -771,9 +760,8 @@ def mkdir(
 
 @main.command()
 @click.argument("path", type=str)
-@click.argument("mount_uris", nargs=-1)
 @add_output_options
-def stat(path: str, mount_uris: tuple[str, ...], output_opts: OutputOptions) -> None:
+def stat(path: str, output_opts: OutputOptions) -> None:
     """Show file or directory metadata.
 
     \b
@@ -784,7 +772,7 @@ def stat(path: str, mount_uris: tuple[str, ...], output_opts: OutputOptions) -> 
     from nexus.fs._sync import run_sync
 
     async def _run() -> dict:
-        fs = await _boot_fs(*mount_uris)
+        fs = await _boot_fs()
         info = await fs.stat(path)
         await fs.close()
         if info is None:

--- a/src/nexus/fs/_cli.py
+++ b/src/nexus/fs/_cli.py
@@ -5,9 +5,16 @@ Provides the `nexus-fs` console command with subcommands:
 - nexus-fs mount list  — show persisted mounts
 - nexus-fs mount test  — test backend connectivity without persisting
 - nexus-fs unmount     — remove persisted mounts
+- nexus-fs ls          — list directory contents
+- nexus-fs cat         — read file contents to stdout
+- nexus-fs write       — write content to a file
+- nexus-fs edit        — surgical search/replace edit
+- nexus-fs rm          — delete a file
+- nexus-fs mkdir       — create a directory
+- nexus-fs stat        — show file/directory metadata
+- nexus-fs cp          — copy files between mounted backends
 - nexus-fs doctor      — diagnostic checks (environment, backends, mounts)
 - nexus-fs playground  — interactive TUI file browser
-- nexus-fs cp          — copy files between mounted backends
 - nexus-fs auth        — credential management
 
 This module is referenced by pyproject.toml [project.scripts].
@@ -427,6 +434,358 @@ def cp(source: str, dest: str, mount_uris: tuple[str, ...], output_opts: OutputO
         output_opts=output_opts,
         human_formatter=_human_display,
     )
+
+
+def _boot_fs(*extra_uris: str):
+    """Boot a SlimNexusFS from persisted mounts + optional extra URIs.
+
+    Shared by ls, cat, write, edit, rm, mkdir, stat.
+    Returns an async coroutine that yields the facade.
+    """
+
+    async def _run():
+        from nexus.fs import mount
+        from nexus.fs._paths import build_mount_args, load_persisted_mounts
+
+        persisted = load_persisted_mounts()
+        uris, overrides = build_mount_args(persisted)
+        for uri in extra_uris:
+            if uri not in uris:
+                uris.append(uri)
+        if not uris:
+            raise click.UsageError("No mounts found. Run 'nexus-fs mount <uri>' first.")
+        return await mount(*uris, mount_overrides=overrides or None)
+
+    return _run()
+
+
+# ── Basic filesystem primitives ──────────────────────────────────────────────
+
+
+@main.command()
+@click.argument("path", default="/")
+@click.option("-l", "--long", "detail", is_flag=True, help="Show detailed metadata.")
+@click.option("-r", "--recursive", is_flag=True, help="List recursively.")
+@click.argument("mount_uris", nargs=-1)
+@add_output_options
+def ls(
+    path: str,
+    detail: bool,
+    recursive: bool,
+    mount_uris: tuple[str, ...],
+    output_opts: OutputOptions,
+) -> None:
+    """List directory contents.
+
+    \b
+    Examples:
+      nexus-fs ls /s3/my-bucket/
+      nexus-fs ls /local/data/ -l
+      nexus-fs ls /s3/my-bucket/ -r
+    """
+    from nexus.fs._sync import run_sync
+
+    async def _run() -> dict:
+        fs = await _boot_fs(*mount_uris)
+        entries = await fs.ls(path, detail=detail, recursive=recursive)
+        await fs.close()
+        return {"path": path, "entries": entries}
+
+    try:
+        data = run_sync(_run())
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+    def _human_display(d: dict) -> None:
+        for entry in d["entries"]:
+            if isinstance(entry, dict):
+                size = entry.get("size", 0)
+                is_dir = entry.get("is_directory", False)
+                kind = "d" if is_dir else "-"
+                name = entry.get("path", entry.get("name", "?"))
+                click.echo(f"{kind} {size:>10}  {name}")
+            else:
+                click.echo(entry)
+
+    render_output(data=data, output_opts=output_opts, human_formatter=_human_display)
+
+
+@main.command()
+@click.argument("path", type=str)
+@click.argument("mount_uris", nargs=-1)
+def cat(path: str, mount_uris: tuple[str, ...]) -> None:
+    """Read file contents to stdout.
+
+    \b
+    Examples:
+      nexus-fs cat /s3/my-bucket/README.md
+      nexus-fs cat /local/data/config.json
+    """
+    from nexus.fs._sync import run_sync
+
+    async def _run() -> bytes:
+        fs = await _boot_fs(*mount_uris)
+        content = await fs.read(path)
+        await fs.close()
+        return content
+
+    try:
+        content = run_sync(_run())
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+    # Write raw bytes to stdout (handles binary gracefully)
+    sys.stdout.buffer.write(content)
+
+
+@main.command()
+@click.argument("path", type=str)
+@click.argument("mount_uris", nargs=-1)
+@click.option(
+    "--data",
+    "-d",
+    type=str,
+    default=None,
+    help="Content string to write. If omitted, reads from stdin.",
+)
+@add_output_options
+def write(
+    path: str,
+    mount_uris: tuple[str, ...],
+    data: str | None,
+    output_opts: OutputOptions,
+) -> None:
+    """Write content to a file (creates or overwrites).
+
+    Content can come from --data or stdin (piped).
+
+    \b
+    Examples:
+      nexus-fs write /local/data/hello.txt -d "Hello, world!"
+      echo "piped content" | nexus-fs write /s3/bucket/file.txt
+      nexus-fs write /local/data/config.json -d '{"key": "value"}'
+    """
+    from nexus.fs._sync import run_sync
+
+    if data is not None:
+        content = data.encode("utf-8")
+    elif not sys.stdin.isatty():
+        content = sys.stdin.buffer.read()
+    else:
+        click.echo("Error: provide --data or pipe content via stdin.", err=True)
+        sys.exit(1)
+
+    async def _run() -> dict:
+        fs = await _boot_fs(*mount_uris)
+        result = await fs.write(path, content)
+        await fs.close()
+        return {"path": path, **result}
+
+    try:
+        result_data = run_sync(_run())
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+    def _human_display(d: dict) -> None:
+        size = d.get("size", len(content))
+        click.echo(f"Wrote {size} bytes to {d['path']}")
+
+    render_output(data=result_data, output_opts=output_opts, human_formatter=_human_display)
+
+
+@main.command()
+@click.argument("path", type=str)
+@click.option(
+    "-e",
+    "--edit-spec",
+    "edits",
+    multiple=True,
+    required=True,
+    help="Edit spec as 'old_str>>>new_str'. Repeat for multiple edits.",
+)
+@click.option("--preview", is_flag=True, help="Show diff without writing.")
+@click.option(
+    "--fuzzy",
+    type=float,
+    default=0.85,
+    help="Fuzzy match threshold (0.0-1.0). Use 1.0 for exact only.",
+)
+@click.argument("mount_uris", nargs=-1)
+@add_output_options
+def edit(
+    path: str,
+    edits: tuple[str, ...],
+    preview: bool,
+    fuzzy: float,
+    mount_uris: tuple[str, ...],
+    output_opts: OutputOptions,
+) -> None:
+    """Surgical search/replace edit on a file.
+
+    Each -e flag takes 'old_str>>>new_str' (triple angle bracket separator).
+
+    \b
+    Examples:
+      nexus-fs edit /local/src/main.py -e 'def foo():>>>def bar():'
+      nexus-fs edit /local/src/main.py -e 'old>>>new' --preview
+      nexus-fs edit /local/src/main.py -e 'typo>>>fix' --fuzzy 0.8
+    """
+    from nexus.fs._sync import run_sync
+
+    parsed_edits = []
+    for spec in edits:
+        if ">>>" not in spec:
+            click.echo(f"Error: invalid edit spec (missing '>>>'): {spec}", err=True)
+            sys.exit(1)
+        old, new = spec.split(">>>", 1)
+        parsed_edits.append({"old_str": old, "new_str": new})
+
+    async def _run() -> dict:
+        fs = await _boot_fs(*mount_uris)
+        result = await fs.edit(
+            path,
+            parsed_edits,
+            preview=preview,
+            fuzzy_threshold=fuzzy,
+        )
+        await fs.close()
+        return {"path": path, **result}
+
+    try:
+        result_data = run_sync(_run())
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+    def _human_display(d: dict) -> None:
+        if d.get("success"):
+            status = "preview" if preview else "applied"
+            click.echo(f"Edit {status}: {d.get('applied_count', 0)} replacement(s)")
+            if d.get("diff"):
+                click.echo(d["diff"])
+        else:
+            click.echo("Edit failed:", err=True)
+            for err in d.get("errors", []):
+                click.echo(f"  {err}", err=True)
+            sys.exit(1)
+
+    render_output(data=result_data, output_opts=output_opts, human_formatter=_human_display)
+
+
+@main.command()
+@click.argument("path", type=str)
+@click.argument("mount_uris", nargs=-1)
+@add_output_options
+def rm(path: str, mount_uris: tuple[str, ...], output_opts: OutputOptions) -> None:
+    """Delete a file.
+
+    \b
+    Examples:
+      nexus-fs rm /s3/my-bucket/old-file.txt
+      nexus-fs rm /local/data/temp.csv
+    """
+    from nexus.fs._sync import run_sync
+
+    async def _run() -> dict:
+        fs = await _boot_fs(*mount_uris)
+        await fs.delete(path)
+        await fs.close()
+        return {"path": path, "deleted": True}
+
+    try:
+        data = run_sync(_run())
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+    def _human_display(d: dict) -> None:
+        click.echo(f"Deleted {d['path']}")
+
+    render_output(data=data, output_opts=output_opts, human_formatter=_human_display)
+
+
+@main.command()
+@click.argument("path", type=str)
+@click.option("-p", "--parents", is_flag=True, default=True, help="Create parent dirs.")
+@click.argument("mount_uris", nargs=-1)
+@add_output_options
+def mkdir(
+    path: str,
+    parents: bool,
+    mount_uris: tuple[str, ...],
+    output_opts: OutputOptions,
+) -> None:
+    """Create a directory.
+
+    \b
+    Examples:
+      nexus-fs mkdir /local/data/new-dir
+      nexus-fs mkdir /s3/bucket/path/to/dir
+    """
+    from nexus.fs._sync import run_sync
+
+    async def _run() -> dict:
+        fs = await _boot_fs(*mount_uris)
+        await fs.mkdir(path, parents=parents)
+        await fs.close()
+        return {"path": path, "created": True}
+
+    try:
+        data = run_sync(_run())
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+    def _human_display(d: dict) -> None:
+        click.echo(f"Created {d['path']}")
+
+    render_output(data=data, output_opts=output_opts, human_formatter=_human_display)
+
+
+@main.command()
+@click.argument("path", type=str)
+@click.argument("mount_uris", nargs=-1)
+@add_output_options
+def stat(path: str, mount_uris: tuple[str, ...], output_opts: OutputOptions) -> None:
+    """Show file or directory metadata.
+
+    \b
+    Examples:
+      nexus-fs stat /s3/my-bucket/file.txt
+      nexus-fs stat /local/data/ --json
+    """
+    from nexus.fs._sync import run_sync
+
+    async def _run() -> dict:
+        fs = await _boot_fs(*mount_uris)
+        info = await fs.stat(path)
+        await fs.close()
+        if info is None:
+            raise FileNotFoundError(f"Not found: {path}")
+        return info
+
+    try:
+        data = run_sync(_run())
+    except Exception as e:
+        click.echo(f"Error: {e}", err=True)
+        sys.exit(1)
+
+    def _human_display(d: dict) -> None:
+        click.echo(f"  Path:     {d.get('path')}")
+        click.echo(f"  Size:     {d.get('size', 0)}")
+        click.echo(f"  Type:     {'directory' if d.get('is_directory') else 'file'}")
+        click.echo(f"  MIME:     {d.get('mime_type', '?')}")
+        click.echo(f"  ETag:     {d.get('etag', '?')}")
+        click.echo(f"  Version:  {d.get('version', '?')}")
+        if d.get("created_at"):
+            click.echo(f"  Created:  {d['created_at']}")
+        if d.get("modified_at"):
+            click.echo(f"  Modified: {d['modified_at']}")
+
+    render_output(data=data, output_opts=output_opts, human_formatter=_human_display)
 
 
 main.add_command(auth_group)

--- a/src/nexus/fs/_facade.py
+++ b/src/nexus/fs/_facade.py
@@ -226,6 +226,42 @@ class SlimNexusFS:
         """
         return await self._kernel.sys_copy(src, dst, context=self._ctx)
 
+    async def edit(
+        self,
+        path: str,
+        edits: list[tuple[str, str]] | list[dict[str, Any]],
+        *,
+        if_match: str | None = None,
+        fuzzy_threshold: float = 0.85,
+        preview: bool = False,
+    ) -> dict[str, Any]:
+        """Apply surgical search/replace edits to a file.
+
+        Uses a layered matching strategy (exact -> whitespace-normalized -> fuzzy)
+        to find and replace text without rewriting the entire file.
+
+        Args:
+            path: Virtual file path.
+            edits: List of edit operations. Each can be:
+                - Tuple: (old_str, new_str)
+                - Dict: {"old_str": str, "new_str": str, "hint_line": int | None,
+                         "allow_multiple": bool}
+            if_match: Optional etag for optimistic concurrency control.
+            fuzzy_threshold: Similarity threshold (0.0-1.0) for fuzzy matching.
+            preview: If True, return preview without writing.
+
+        Returns:
+            Dict with success, diff, matches, applied_count, etag, version, errors.
+        """
+        return await self._kernel.edit(
+            path,
+            edits,
+            context=self._ctx,
+            if_match=if_match,
+            fuzzy_threshold=fuzzy_threshold,
+            preview=preview,
+        )
+
     # -- Metadata (optimized single-lookup) --
 
     async def stat(self, path: str) -> dict[str, Any] | None:

--- a/src/nexus/fs/_facade.py
+++ b/src/nexus/fs/_facade.py
@@ -252,6 +252,13 @@ class SlimNexusFS:
 
         Returns:
             Dict with success, diff, matches, applied_count, etag, version, errors.
+
+        Note:
+            The underlying kernel edit is NOT atomic — there is a TOCTOU window
+            between the read and the final write.  ``if_match`` catches stale
+            reads but cannot prevent a concurrent writer from updating the file
+            between the ETag check and the write.  For concurrent-writer safety,
+            use an external lock or wait for kernel-level OCC-aware writes.
         """
         return await self._kernel.edit(
             path,

--- a/src/nexus/fs/_oauth_support.py
+++ b/src/nexus/fs/_oauth_support.py
@@ -114,6 +114,104 @@ def get_token_manager(db_path: str | None = None) -> Any:
     return _get_token_manager_cls()(db_path=db_path, encryption_key=encryption_key)
 
 
+def get_google_auth_url(
+    *,
+    service_name: str = "gws",
+    client_id: str | None = None,
+    client_secret: str | None = None,
+    redirect_uri: str = "http://localhost",
+) -> str:
+    """Generate a Google OAuth authorization URL programmatically.
+
+    Returns the URL that the user (or agent) should visit to authorize.
+    No CLI interaction — suitable for embedding in web flows, agent
+    orchestration, or headless automation.
+
+    Args:
+        service_name: Google service scope set (gws, google-drive, gmail, google-calendar).
+        client_id: OAuth client ID. Falls back to NEXUS_OAUTH_GOOGLE_CLIENT_ID env var.
+        client_secret: OAuth client secret. Falls back to NEXUS_OAUTH_GOOGLE_CLIENT_SECRET env var.
+        redirect_uri: OAuth redirect URI. Defaults to http://localhost.
+
+    Returns:
+        The authorization URL string.
+
+    Raises:
+        ValueError: If client_id or client_secret is missing.
+    """
+    GoogleOAuthProvider = _il.import_module(
+        "nexus.bricks.auth.oauth.providers.google"
+    ).GoogleOAuthProvider
+
+    client_id = client_id or os.getenv("NEXUS_OAUTH_GOOGLE_CLIENT_ID")
+    client_secret = client_secret or os.getenv("NEXUS_OAUTH_GOOGLE_CLIENT_SECRET")
+    if not client_id:
+        raise ValueError("Google OAuth client ID not provided. Set NEXUS_OAUTH_GOOGLE_CLIENT_ID.")
+    if not client_secret:
+        raise ValueError(
+            "Google OAuth client secret not provided. Set NEXUS_OAUTH_GOOGLE_CLIENT_SECRET."
+        )
+
+    provider = GoogleOAuthProvider(
+        client_id=client_id,
+        client_secret=client_secret,
+        redirect_uri=redirect_uri,
+        scopes=_GOOGLE_SERVICE_SCOPES.get(service_name, _GOOGLE_SERVICE_SCOPES["gws"]),
+        provider_name=_GOOGLE_SERVICE_PROVIDER_NAMES.get(service_name, "google"),
+    )
+    return provider.get_authorization_url()
+
+
+def get_x_auth_url(
+    *,
+    client_id: str | None = None,
+    client_secret: str | None = None,
+    redirect_uri: str = "http://localhost",
+) -> tuple[str, dict[str, str]]:
+    """Generate an X (Twitter) OAuth authorization URL programmatically.
+
+    Returns the URL and PKCE data needed for the code exchange step.
+    No CLI interaction — suitable for embedding in web flows, agent
+    orchestration, or headless automation.
+
+    Args:
+        client_id: OAuth client ID. Falls back to NEXUS_OAUTH_X_CLIENT_ID env var.
+        client_secret: Optional OAuth client secret. Falls back to NEXUS_OAUTH_X_CLIENT_SECRET env var.
+        redirect_uri: OAuth redirect URI. Defaults to http://localhost.
+
+    Returns:
+        Tuple of (auth_url, pkce_data) where pkce_data contains 'code_verifier'.
+
+    Raises:
+        ValueError: If client_id is missing.
+    """
+    client_id = client_id or os.getenv("NEXUS_OAUTH_X_CLIENT_ID")
+    client_secret = client_secret or os.getenv("NEXUS_OAUTH_X_CLIENT_SECRET")
+    if not client_id:
+        raise ValueError("X OAuth client ID not provided. Set NEXUS_OAUTH_X_CLIENT_ID.")
+
+    provider = _get_x_oauth_provider_cls()(
+        client_id=client_id,
+        redirect_uri=redirect_uri,
+        scopes=[
+            "tweet.read",
+            "tweet.write",
+            "tweet.moderate.write",
+            "users.read",
+            "follows.read",
+            "offline.access",
+            "bookmark.read",
+            "bookmark.write",
+            "list.read",
+            "like.read",
+            "like.write",
+        ],
+        provider_name="x",
+        client_secret=client_secret,
+    )
+    return provider.get_authorization_url_with_pkce()
+
+
 def run_google_oauth_setup(
     *,
     user_email: str,
@@ -124,29 +222,17 @@ def run_google_oauth_setup(
     zone_id: str | None = None,
 ) -> None:
     """Run the Google OAuth browser/code flow for nexus-fs."""
-    GoogleOAuthProvider = _il.import_module(
-        "nexus.bricks.auth.oauth.providers.google"
-    ).GoogleOAuthProvider
-
-    client_id = client_id or os.getenv("NEXUS_OAUTH_GOOGLE_CLIENT_ID")
-    client_secret = client_secret or os.getenv("NEXUS_OAUTH_GOOGLE_CLIENT_SECRET")
-    if not client_id:
-        raise click.ClickException(
-            "Google OAuth client ID not provided. Set NEXUS_OAUTH_GOOGLE_CLIENT_ID first."
+    try:
+        auth_url = get_google_auth_url(
+            service_name=service_name,
+            client_id=client_id,
+            client_secret=client_secret,
         )
-    if not client_secret:
-        raise click.ClickException(
-            "Google OAuth client secret not provided. Set NEXUS_OAUTH_GOOGLE_CLIENT_SECRET first."
-        )
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
 
-    provider = GoogleOAuthProvider(
-        client_id=client_id,
-        client_secret=client_secret,
-        redirect_uri="http://localhost",
-        scopes=_GOOGLE_SERVICE_SCOPES.get(service_name, _GOOGLE_SERVICE_SCOPES["gws"]),
-        provider_name=_GOOGLE_SERVICE_PROVIDER_NAMES.get(service_name, "google"),
-    )
-    auth_url = provider.get_authorization_url()
+    # Resolve actual client_id for display (may have come from env var)
+    client_id = client_id or os.getenv("NEXUS_OAUTH_GOOGLE_CLIENT_ID", "")
 
     console.print("\n[bold green]Google OAuth Setup[/bold green]")
     console.print(f"\n[bold]User:[/bold] {user_email}")
@@ -160,6 +246,17 @@ def run_google_oauth_setup(
     auth_code = click.prompt("\nEnter authorization code")
 
     async def _exchange_and_store() -> str:
+        GoogleOAuthProvider = _il.import_module(
+            "nexus.bricks.auth.oauth.providers.google"
+        ).GoogleOAuthProvider
+        client_secret_resolved = client_secret or os.getenv("NEXUS_OAUTH_GOOGLE_CLIENT_SECRET", "")
+        provider = GoogleOAuthProvider(
+            client_id=client_id or "",
+            client_secret=client_secret_resolved,
+            redirect_uri="http://localhost",
+            scopes=_GOOGLE_SERVICE_SCOPES.get(service_name, _GOOGLE_SERVICE_SCOPES["gws"]),
+            provider_name=_GOOGLE_SERVICE_PROVIDER_NAMES.get(service_name, "google"),
+        )
         credential = await provider.exchange_code(auth_code)
         manager = get_token_manager(db_path)
         cred_id = await manager.store_credential(
@@ -190,32 +287,16 @@ def run_x_oauth_setup(
     zone_id: str | None = None,
 ) -> None:
     """Run the X OAuth browser/code flow for nexus-fs."""
-    client_id = client_id or os.getenv("NEXUS_OAUTH_X_CLIENT_ID")
-    client_secret = client_secret or os.getenv("NEXUS_OAUTH_X_CLIENT_SECRET")
-    if not client_id:
-        raise click.ClickException("X OAuth client ID not provided. Set NEXUS_OAUTH_X_CLIENT_ID.")
+    try:
+        auth_url, pkce_data = get_x_auth_url(
+            client_id=client_id,
+            client_secret=client_secret,
+        )
+    except ValueError as exc:
+        raise click.ClickException(str(exc)) from exc
 
-    provider = _get_x_oauth_provider_cls()(
-        client_id=client_id,
-        redirect_uri="http://localhost",
-        scopes=[
-            "tweet.read",
-            "tweet.write",
-            "tweet.moderate.write",
-            "users.read",
-            "follows.read",
-            "offline.access",
-            "bookmark.read",
-            "bookmark.write",
-            "list.read",
-            "like.read",
-            "like.write",
-        ],
-        provider_name="x",
-        client_secret=client_secret,
-    )
-    auth_url, pkce_data = provider.get_authorization_url_with_pkce()
     code_verifier = pkce_data["code_verifier"]
+    client_id = client_id or os.getenv("NEXUS_OAUTH_X_CLIENT_ID", "")
 
     console.print("\n[bold green]X OAuth Setup[/bold green]")
     console.print(f"\n[bold]User:[/bold] {user_email}")
@@ -228,6 +309,26 @@ def run_x_oauth_setup(
     auth_code = click.prompt("\nEnter authorization code")
 
     async def _exchange_and_store() -> str:
+        client_secret_resolved = client_secret or os.getenv("NEXUS_OAUTH_X_CLIENT_SECRET")
+        provider = _get_x_oauth_provider_cls()(
+            client_id=client_id or "",
+            redirect_uri="http://localhost",
+            scopes=[
+                "tweet.read",
+                "tweet.write",
+                "tweet.moderate.write",
+                "users.read",
+                "follows.read",
+                "offline.access",
+                "bookmark.read",
+                "bookmark.write",
+                "list.read",
+                "like.read",
+                "like.write",
+            ],
+            provider_name="x",
+            client_secret=client_secret_resolved,
+        )
         credential = await provider.exchange_code_pkce(auth_code, code_verifier)
         manager = get_token_manager(db_path)
         cred_id = await manager.store_credential(

--- a/src/nexus/fs/_oauth_support.py
+++ b/src/nexus/fs/_oauth_support.py
@@ -159,7 +159,8 @@ def get_google_auth_url(
         scopes=_GOOGLE_SERVICE_SCOPES.get(service_name, _GOOGLE_SERVICE_SCOPES["gws"]),
         provider_name=_GOOGLE_SERVICE_PROVIDER_NAMES.get(service_name, "google"),
     )
-    return provider.get_authorization_url()
+    result: str = provider.get_authorization_url()
+    return result
 
 
 def get_x_auth_url(
@@ -209,7 +210,8 @@ def get_x_auth_url(
         provider_name="x",
         client_secret=client_secret,
     )
-    return provider.get_authorization_url_with_pkce()
+    result: tuple[str, dict[str, str]] = provider.get_authorization_url_with_pkce()
+    return result
 
 
 def run_google_oauth_setup(

--- a/src/nexus/fs/_sync.py
+++ b/src/nexus/fs/_sync.py
@@ -144,6 +144,28 @@ class SyncNexusFS:
     def copy(self, src: str, dst: str) -> dict[str, Any]:
         return cast(dict[str, Any], self._runner(self._async.copy(src, dst)))
 
+    def edit(
+        self,
+        path: str,
+        edits: list[tuple[str, str]] | list[dict[str, Any]],
+        *,
+        if_match: str | None = None,
+        fuzzy_threshold: float = 0.85,
+        preview: bool = False,
+    ) -> dict[str, Any]:
+        return cast(
+            dict[str, Any],
+            self._runner(
+                self._async.edit(
+                    path,
+                    edits,
+                    if_match=if_match,
+                    fuzzy_threshold=fuzzy_threshold,
+                    preview=preview,
+                )
+            ),
+        )
+
     def read_range(self, path: str, start: int, end: int) -> bytes:
         return cast(bytes, self._runner(self._async.read_range(path, start, end)))
 

--- a/tests/unit/fs/test_integration.py
+++ b/tests/unit/fs/test_integration.py
@@ -245,6 +245,182 @@ class TestSingleBackendLifecycle:
 
 
 # ---------------------------------------------------------------------------
+# Edit operations
+# ---------------------------------------------------------------------------
+
+
+class TestEditOperations:
+    """Test the edit() method on SlimNexusFS facade."""
+
+    @pytest.mark.asyncio
+    async def test_edit_simple_replacement(self, slim_fs: SlimNexusFS):
+        """Simple search/replace edit."""
+        await slim_fs.write("/local/code.py", b"def foo():\n    return 1\n")
+
+        result = await slim_fs.edit("/local/code.py", [("def foo():", "def bar():")])
+
+        assert result["success"] is True
+        assert result["applied_count"] == 1
+        content = await slim_fs.read("/local/code.py")
+        assert b"def bar():" in content
+        assert b"def foo():" not in content
+
+    @pytest.mark.asyncio
+    async def test_edit_multiple_replacements(self, slim_fs: SlimNexusFS):
+        """Multiple edits applied in sequence."""
+        await slim_fs.write("/local/multi.py", b"x = 1\ny = 2\nz = 3\n")
+
+        result = await slim_fs.edit(
+            "/local/multi.py",
+            [("x = 1", "x = 10"), ("y = 2", "y = 20")],
+        )
+
+        assert result["success"] is True
+        assert result["applied_count"] == 2
+        content = await slim_fs.read("/local/multi.py")
+        assert content == b"x = 10\ny = 20\nz = 3\n"
+
+    @pytest.mark.asyncio
+    async def test_edit_returns_diff(self, slim_fs: SlimNexusFS):
+        """Edit result includes a unified diff."""
+        await slim_fs.write("/local/diff.txt", b"hello world\n")
+
+        result = await slim_fs.edit("/local/diff.txt", [("hello", "goodbye")])
+
+        assert result["success"] is True
+        assert "-hello world" in result["diff"]
+        assert "+goodbye world" in result["diff"]
+
+    @pytest.mark.asyncio
+    async def test_edit_preview_does_not_modify(self, slim_fs: SlimNexusFS):
+        """Preview mode returns diff but doesn't write."""
+        original = b"keep me unchanged\n"
+        await slim_fs.write("/local/preview.txt", original)
+
+        result = await slim_fs.edit(
+            "/local/preview.txt",
+            [("keep me unchanged", "I was changed")],
+            preview=True,
+        )
+
+        assert result["success"] is True
+        assert "+I was changed" in result["diff"]
+        # File should NOT have changed
+        content = await slim_fs.read("/local/preview.txt")
+        assert content == original
+
+    @pytest.mark.asyncio
+    async def test_edit_no_match_fails(self, slim_fs: SlimNexusFS):
+        """Edit fails when search string not found."""
+        await slim_fs.write("/local/nomatch.txt", b"actual content\n")
+
+        result = await slim_fs.edit(
+            "/local/nomatch.txt",
+            [("nonexistent text", "replacement")],
+            fuzzy_threshold=1.0,
+        )
+
+        assert result["success"] is False
+        assert len(result["errors"]) > 0
+
+    @pytest.mark.asyncio
+    async def test_edit_with_dict_format(self, slim_fs: SlimNexusFS):
+        """Edit accepts dict format with old_str/new_str keys."""
+        await slim_fs.write("/local/dict.txt", b"old value\n")
+
+        result = await slim_fs.edit(
+            "/local/dict.txt",
+            [{"old_str": "old value", "new_str": "new value"}],
+        )
+
+        assert result["success"] is True
+        content = await slim_fs.read("/local/dict.txt")
+        assert content == b"new value\n"
+
+    @pytest.mark.asyncio
+    async def test_edit_fuzzy_match(self, slim_fs: SlimNexusFS):
+        """Fuzzy matching handles minor differences."""
+        await slim_fs.write(
+            "/local/fuzzy.py",
+            b"def calculate_total(items):\n    return sum(items)\n",
+        )
+
+        result = await slim_fs.edit(
+            "/local/fuzzy.py",
+            [("def calcuate_total(items):", "def compute_sum(items):")],
+            fuzzy_threshold=0.8,
+        )
+
+        assert result["success"] is True
+        assert result["matches"][0]["match_type"] == "fuzzy"
+        content = await slim_fs.read("/local/fuzzy.py")
+        assert b"def compute_sum(items):" in content
+
+    @pytest.mark.asyncio
+    async def test_edit_etag_concurrency(self, slim_fs: SlimNexusFS):
+        """Optimistic concurrency: edit with correct etag succeeds."""
+        write_result = await slim_fs.write("/local/etag.txt", b"version 1\n")
+        etag = write_result["etag"]
+
+        result = await slim_fs.edit(
+            "/local/etag.txt",
+            [("version 1", "version 2")],
+            if_match=etag,
+        )
+
+        assert result["success"] is True
+        content = await slim_fs.read("/local/etag.txt")
+        assert content == b"version 2\n"
+
+    @pytest.mark.asyncio
+    async def test_edit_stale_etag_fails(self, slim_fs: SlimNexusFS):
+        """Optimistic concurrency: stale etag is rejected."""
+        write_result = await slim_fs.write("/local/stale.txt", b"version 1\n")
+        old_etag = write_result["etag"]
+
+        # Overwrite to change the etag
+        await slim_fs.write("/local/stale.txt", b"version 2\n")
+
+        from nexus.contracts.exceptions import ConflictError
+
+        with pytest.raises(ConflictError):
+            await slim_fs.edit(
+                "/local/stale.txt",
+                [("version 2", "version 3")],
+                if_match=old_etag,
+            )
+
+    @pytest.mark.asyncio
+    async def test_edit_delete_text(self, slim_fs: SlimNexusFS):
+        """Replace with empty string to delete text."""
+        await slim_fs.write("/local/del.txt", b"keep\nremove me\nkeep too\n")
+
+        result = await slim_fs.edit("/local/del.txt", [("remove me\n", "")])
+
+        assert result["success"] is True
+        content = await slim_fs.read("/local/del.txt")
+        assert content == b"keep\nkeep too\n"
+
+    @pytest.mark.asyncio
+    async def test_edit_multiline_block(self, slim_fs: SlimNexusFS):
+        """Edit a multiline block."""
+        await slim_fs.write(
+            "/local/block.py",
+            b"def old():\n    pass\n\ndef other():\n    pass\n",
+        )
+
+        result = await slim_fs.edit(
+            "/local/block.py",
+            [("def old():\n    pass", "def new():\n    return 42")],
+        )
+
+        assert result["success"] is True
+        content = await slim_fs.read("/local/block.py")
+        assert b"def new():\n    return 42" in content
+        assert b"def other():\n    pass" in content
+
+
+# ---------------------------------------------------------------------------
 # Multi-backend
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/fs/test_mount_cli.py
+++ b/tests/unit/fs/test_mount_cli.py
@@ -327,7 +327,9 @@ class TestMountPersistence:
             runner.invoke(main, ["cp", "/data/a.txt", "/data/b.txt"])
 
         mock_mount.assert_awaited_once_with(
-            "s3://my-bucket", mount_overrides={"s3://my-bucket": "/data"}
+            "s3://my-bucket",
+            mount_overrides={"s3://my-bucket": "/data"},
+            skip_unavailable=True,
         )
 
     def test_at_restored_by_cp_multiple_mounts(self, tmp_path, monkeypatch) -> None:
@@ -354,6 +356,7 @@ class TestMountPersistence:
             "s3://my-bucket",
             "local:///tmp/b",
             mount_overrides={"s3://my-bucket": "/data"},
+            skip_unavailable=True,
         )
 
     def test_backward_compat_legacy_format(self, tmp_path, monkeypatch) -> None:
@@ -369,4 +372,8 @@ class TestMountPersistence:
             runner = CliRunner(env=_env_no_auto_json())
             runner.invoke(main, ["cp", "/s3/old-bucket/a", "/s3/old-bucket/b"])
 
-        mock_mount.assert_awaited_once_with("s3://old-bucket", mount_overrides=None)
+        mock_mount.assert_awaited_once_with(
+            "s3://old-bucket",
+            mount_overrides=None,
+            skip_unavailable=True,
+        )

--- a/tests/unit/fs/test_s3_integration.py
+++ b/tests/unit/fs/test_s3_integration.py
@@ -174,3 +174,56 @@ class TestS3BackendLifecycle:
         await fs.write(f"{mp}/empty.txt", b"")
         result = await fs.read(f"{mp}/empty.txt")
         assert result == b""
+
+    @pytest.mark.asyncio
+    async def test_edit_simple(self, s3_fs):
+        fs, mp = s3_fs
+        await fs.write(f"{mp}/code.py", b"def foo():\n    return 1\n")
+        result = await fs.edit(f"{mp}/code.py", [("def foo():", "def bar():")])
+        assert result["success"] is True
+        assert result["applied_count"] == 1
+        content = await fs.read(f"{mp}/code.py")
+        assert b"def bar():" in content
+
+    @pytest.mark.asyncio
+    async def test_edit_preview(self, s3_fs):
+        fs, mp = s3_fs
+        original = b"keep this\n"
+        await fs.write(f"{mp}/preview.txt", original)
+        result = await fs.edit(f"{mp}/preview.txt", [("keep", "change")], preview=True)
+        assert result["success"] is True
+        content = await fs.read(f"{mp}/preview.txt")
+        assert content == original  # unchanged
+
+    @pytest.mark.asyncio
+    async def test_edit_multiple(self, s3_fs):
+        fs, mp = s3_fs
+        await fs.write(f"{mp}/multi.py", b"x = 1\ny = 2\n")
+        result = await fs.edit(f"{mp}/multi.py", [("x = 1", "x = 10"), ("y = 2", "y = 20")])
+        assert result["success"] is True
+        assert result["applied_count"] == 2
+        content = await fs.read(f"{mp}/multi.py")
+        assert content == b"x = 10\ny = 20\n"
+
+    @pytest.mark.asyncio
+    async def test_edit_fuzzy(self, s3_fs):
+        fs, mp = s3_fs
+        await fs.write(f"{mp}/fuzzy.py", b"def calculate_total(items):\n    pass\n")
+        result = await fs.edit(
+            f"{mp}/fuzzy.py",
+            [("def calcuate_total(items):", "def compute(items):")],
+            fuzzy_threshold=0.8,
+        )
+        assert result["success"] is True
+        assert result["matches"][0]["match_type"] == "fuzzy"
+
+    @pytest.mark.asyncio
+    async def test_edit_no_match(self, s3_fs):
+        fs, mp = s3_fs
+        await fs.write(f"{mp}/nomatch.txt", b"actual content\n")
+        result = await fs.edit(
+            f"{mp}/nomatch.txt",
+            [("nonexistent", "x")],
+            fuzzy_threshold=1.0,
+        )
+        assert result["success"] is False


### PR DESCRIPTION
## Summary
- Add 7 basic filesystem CLI commands to nexus-fs: `ls`, `cat`, `write`, `rm`, `mkdir`, `stat`, `edit`
- Expose `edit()` (surgical search/replace) on `SlimNexusFS` facade and `SyncNexusFS` wrapper
- Include `nexus/utils/edit_engine.py` in slim wheel (stdlib-only, no new deps)
- Add `rapidfuzz` as optional extra (`pip install nexus-fs[edit]`) for 84x faster fuzzy matching
- Rewrite all 7 demo scripts to use CLI commands instead of inline Python wrappers

## New CLI Commands
```
nexus-fs ls [-l] [-r] <path>          # list directory
nexus-fs cat <path>                    # read file to stdout
nexus-fs write <path> [-d data]        # write (from --data or stdin pipe)
nexus-fs edit <path> -e 'old>>>new'    # surgical search/replace
nexus-fs rm <path>                     # delete file
nexus-fs mkdir <path>                  # create directory
nexus-fs stat <path> [--json]          # file metadata
```

All commands support `--json`, `--quiet`, `-v` output options and auto-discover persisted mounts.

## Test plan
- [x] 12 CLI primitive tests (local backend) — all pass
- [x] 11 edit integration tests (local backend) — all pass
- [x] 5 S3 edit tests added to moto test suite
- [x] 13 tests against real S3 (nexus-888 bucket) — all pass, no performance issues
- [x] Edit performance: 0.94ms/op exact match, 1.56ms/op fuzzy on 1000-line file
- [x] All pre-commit hooks pass (ruff, mypy, etc.)
- [ ] Verify demo scripts 0-5 still run end-to-end