### PR TITLE
fix: guard nexus_fast imports so nexus-fs works without Rust extension

### DIFF
--- a/src/nexus/_rust_compat.py
+++ b/src/nexus/_rust_compat.py
@@ -1,0 +1,211 @@
+"""Rust extension compatibility shim.
+
+Centralises all ``nexus_fast`` imports so that the slim ``nexus-fs``
+package (which does not depend on the Rust extension) can still import
+``nexus.core.*`` modules without crashing at import time.
+
+Every symbol is re-exported as its original name.  When ``nexus_fast``
+is unavailable the symbol is set to ``None`` and call-sites must
+guard with ``if _Symbol is not None:`` before use.
+
+Usage in other modules::
+
+    from nexus._rust_compat import RustDCache  # None when Rust unavailable
+
+This avoids scattering try/except blocks across dozens of files.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+# -- Attempt bulk import of the Rust extension --------------------------------
+
+try:
+    import nexus_fast as _nf
+
+    RUST_AVAILABLE: bool = True
+except ModuleNotFoundError:
+    # Module genuinely not installed — slim/nexus-fs mode.
+    _nf = None  # type: ignore[assignment]
+    RUST_AVAILABLE = False
+except Exception:
+    # Module is installed but broken (ImportError, NameError, ABI skew,
+    # missing transitive dep, init-time crash). Catch broad Exception to
+    # prevent ANY import-time failure from escaping the shim.
+    _nf = None  # type: ignore[assignment]
+    RUST_AVAILABLE = False
+
+# Whether the import found a module at all (even if broken).
+# ModuleNotFoundError = not installed. Other ImportError = installed but broken.
+# hash_fast uses this to decide: "no extension" (SHA-256 ok for pure-Python
+# environments) vs "broken extension" (SHA-256 never ok — fail closed).
+RUST_EXTENSION_INSTALLED: bool = True  # assume installed unless ModuleNotFoundError
+try:
+    import importlib.util
+
+    RUST_EXTENSION_INSTALLED = importlib.util.find_spec("nexus_fast") is not None
+except Exception:
+    pass
+
+
+# -- Capability-group validation -----------------------------------------------
+# Symbols are validated per capability group. A missing symbol disables only
+# its group, not all of Rust. This prevents e.g. a missing VolumeEngine from
+# disabling BLAKE3 hashing.
+#
+# The _CORE group is special: if any core symbol is missing, ALL Rust is
+# disabled (these are required for basic kernel operation).
+
+_CAPABILITY_GROUPS: dict[str, tuple[str, ...]] = {
+    "core": (
+        "Kernel",  # unified kernel (replaces SyscallEngine+RustDCache+RustPathRouter+PathTrie+HookRegistry+ObserverRegistry)
+        "normalize_path",
+        "validate_path",
+        "canonicalize_path",
+        "extract_zone_id",
+        "get_ancestors",
+        "get_parent",
+        "get_parent_chain",
+        "parent_path",
+        "path_matches_pattern",
+        "split_path",
+        "unscope_internal_path",
+    ),
+    "hash": ("hash_content_py", "hash_content_smart_py"),
+    "ipc": (
+        "RingBufferCore",
+        "StreamBufferCore",
+        "SharedRingBufferCore",
+        "SharedStreamBufferCore",
+    ),
+    "io": ("read_file", "read_files_bulk"),
+    "search": ("grep_bulk", "grep_files_mmap", "glob_match_bulk"),
+    "storage": (
+        "BloomFilter",
+        "L1MetadataCache",
+        "VFSLockManager",
+        "VFSSemaphore",
+        "VolumeEngine",
+    ),
+}
+
+# Per-group availability flags (set after validation below)
+RUST_HASH_AVAILABLE: bool = False
+RUST_IPC_AVAILABLE: bool = False
+
+if RUST_AVAILABLE:
+    import logging as _logging
+
+    _log = _logging.getLogger(__name__)
+
+    # Compute per-group availability BEFORE the core kill-switch clears _nf.
+    # This ensures hash/ipc flags reflect actual symbol presence, not whether
+    # an unrelated core symbol (e.g. SyscallEngine) is missing.
+    _group_ok: dict[str, bool] = {}
+    for _group, _symbols in _CAPABILITY_GROUPS.items():
+        _missing = [s for s in _symbols if not hasattr(_nf, s)]
+        _group_ok[_group] = len(_missing) == 0
+        if _missing:
+            _log.info(
+                "nexus_fast missing %s symbols %s — %s features disabled. "
+                "Rebuild with: pip install -e rust/nexus_pyo3",
+                _group,
+                _missing,
+                _group,
+            )
+
+    RUST_HASH_AVAILABLE = _group_ok.get("hash", False)
+    RUST_IPC_AVAILABLE = _group_ok.get("ipc", False)
+
+    _core_disabled = not _group_ok.get("core", False)
+    if _core_disabled:
+        RUST_AVAILABLE = False
+
+# Build set of symbols whose group failed validation — these return None.
+# _group_ok may not exist if RUST_AVAILABLE was False (import failed).
+_disabled_symbols: set[str] = set()
+if RUST_EXTENSION_INSTALLED and not RUST_AVAILABLE and _nf is None:
+    # Extension installed but import completely failed — module not usable.
+    # Disable ALL symbols since we can't call any of them.
+    for _syms in _CAPABILITY_GROUPS.values():
+        _disabled_symbols.update(_syms)
+elif RUST_EXTENSION_INSTALLED and _nf is not None:
+    # Extension imported but some groups may be incomplete.
+    # Only disable symbols from failing groups — working groups stay live.
+    for _g, _syms in _CAPABILITY_GROUPS.items():
+        if not _group_ok.get(_g, False):
+            _disabled_symbols.update(_syms)
+
+# Snapshot the module for re-exports.
+_nf_snapshot: Any = _nf
+
+
+def _get(name: str) -> Any:
+    """Get an attribute from nexus_fast, or None if unavailable.
+
+    Returns None if the module is absent OR if the symbol belongs to a
+    capability group that failed validation (e.g. core symbols when core
+    is disabled due to version skew).
+    """
+    if _nf_snapshot is None:
+        return None
+    if name in _disabled_symbols:
+        return None
+    return getattr(_nf_snapshot, name, None)
+
+
+# -- Re-exports (alphabetical) -----------------------------------------------
+# Each symbol is either the real Rust class/function or None.
+
+# Core kernel (Issue #1868 — unified Kernel replaces SyscallEngine+RustDCache+
+# RustPathRouter+PathTrie+HookRegistry+ObserverRegistry)
+Kernel = _get("Kernel")
+SysReadResult = _get("SysReadResult")
+SysWriteResult = _get("SysWriteResult")
+
+# Legacy aliases — None on 0.9.19+ (removed in favor of Kernel)
+RustDCache = _get("RustDCache")
+RustPathRouter = _get("RustPathRouter")
+HookRegistry = _get("HookRegistry")
+ObserverRegistry = _get("ObserverRegistry")
+PathTrie = _get("PathTrie")
+
+# Classes still exported as standalone
+BloomFilter = _get("BloomFilter")
+L1MetadataCache = _get("L1MetadataCache")
+RingBufferCore = _get("RingBufferCore")
+SharedRingBufferCore = _get("SharedRingBufferCore")
+SharedStreamBufferCore = _get("SharedStreamBufferCore")
+StreamBufferCore = _get("StreamBufferCore")
+VFSLockManager = _get("VFSLockManager")
+VFSSemaphore = _get("VFSSemaphore")
+VolumeEngine = _get("VolumeEngine")
+
+# Path utilities
+get_ancestors = _get("get_ancestors")
+get_parent = _get("get_parent")
+get_parent_chain = _get("get_parent_chain")
+normalize_path = _get("normalize_path")
+parent_path = _get("parent_path")
+path_matches_pattern = _get("path_matches_pattern")
+split_path = _get("split_path")
+unscope_internal_path = _get("unscope_internal_path")
+validate_path = _get("validate_path")
+
+# Hash utilities
+hash_content_py = _get("hash_content_py")
+hash_content_smart_py = _get("hash_content_smart_py")
+
+# I/O utilities
+read_file = _get("read_file")
+read_files_bulk = _get("read_files_bulk")
+
+# Mount table helpers
+canonicalize_path = _get("canonicalize_path")
+extract_zone_id = _get("extract_zone_id")
+
+# Grep / search
+grep_bulk = _get("grep_bulk")
+grep_files_mmap = _get("grep_files_mmap")
+glob_match_bulk = _get("glob_match_bulk")

--- a/src/nexus/core/hash_fast.py
+++ b/src/nexus/core/hash_fast.py
@@ -26,7 +26,8 @@ from typing import Any
 
 # RUST_FALLBACK: hash_content_py, hash_content_smart_py
 # Priority 1: Rust-accelerated BLAKE3
-from nexus_fast import hash_content_py, hash_content_smart_py
+from nexus._rust_compat import RUST_EXTENSION_INSTALLED as _RUST_EXT_INSTALLED
+from nexus._rust_compat import RUST_HASH_AVAILABLE, hash_content_py, hash_content_smart_py
 
 logger = logging.getLogger(__name__)
 
@@ -37,7 +38,8 @@ _python_blake3: Any = None
 
 _rust_hash_content: Any = hash_content_py
 _rust_hash_content_smart: Any = hash_content_smart_py
-_RUST_AVAILABLE = True
+# Uses capability-group flag — hash stays on Rust even if unrelated groups are stale
+_RUST_AVAILABLE = RUST_HASH_AVAILABLE
 
 # Priority 2: Python blake3 package (Issue #582, #833)
 try:
@@ -77,6 +79,14 @@ def hash_content(content: bytes) -> str:
         result = _python_blake3.blake3(content).hexdigest()
         return result
 
+    # If nexus_fast was detected at all (even degraded), refuse SHA-256.
+    # A stale Rust extension with incomplete hash support must not silently
+    # produce incompatible content IDs — fail closed instead.
+    if _RUST_EXT_INSTALLED:
+        raise RuntimeError(
+            "nexus_fast is installed but BLAKE3 hashing is unavailable (stale build?). "
+            "Rebuild with: pip install -e rust/nexus_pyo3  — or: pip install blake3"
+        )
     logger.warning(
         "BLAKE3 unavailable — using SHA-256 fallback. "
         "Hashes will be INCOMPATIBLE with BLAKE3 nodes. Install: pip install blake3"
@@ -127,6 +137,13 @@ def hash_content_smart(content: bytes) -> str:
         blake3_hasher.update(len(content).to_bytes(8, byteorder="little"))
         result = blake3_hasher.hexdigest()
         return result
+
+    # Fail closed under version skew — same guard as hash_content().
+    if _RUST_EXT_INSTALLED:
+        raise RuntimeError(
+            "nexus_fast is installed but BLAKE3 hashing is unavailable (stale build?). "
+            "Rebuild with: pip install -e rust/nexus_pyo3  — or: pip install blake3"
+        )
 
     # SHA-256 fallback (WARNING: incompatible hashes!)
     if len(content) < threshold:
@@ -204,4 +221,10 @@ def create_hasher() -> Any:
         return _python_blake3.blake3()
     if _RUST_AVAILABLE:
         return _RustOnePassHasher()
+    # Fail closed: stale nexus_fast must not silently produce SHA-256 CAS blobs.
+    if _RUST_EXT_INSTALLED:
+        raise RuntimeError(
+            "nexus_fast is installed but BLAKE3 hashing is unavailable (stale build?). "
+            "Rebuild with: pip install -e rust/nexus_pyo3  — or: pip install blake3"
+        )
     return hashlib.sha256()

--- a/src/nexus/core/kernel_dispatch.py
+++ b/src/nexus/core/kernel_dispatch.py
@@ -327,6 +327,8 @@ class KernelDispatch:
     # ── register_intercept: per-operation INTERCEPT hooks ─────────────
 
     def _mark_hook(self, op: str) -> None:
+        if self._kernel is None:
+            return  # No kernel = no dispatch; don't mark active to avoid misleading state
         self._hooks_nonempty.add(op)
         self._sync_hook_count(op)
 
@@ -368,6 +370,7 @@ class KernelDispatch:
     def register_intercept_copy(self, hook: VFSCopyHook) -> None:
         if self._kernel is not None:
             self._kernel.register_hook("copy", hook)
+        self._mark_hook("copy")
 
     def register_intercept_mkdir(self, hook: VFSMkdirHook) -> None:
         if self._kernel is not None:
@@ -508,12 +511,16 @@ class KernelDispatch:
         """PRE-INTERCEPT phase for read — hooks may abort by raising."""
         if "read" not in self._hooks_nonempty:
             return
+        if self._kernel is None:
+            return
         for hook in self._kernel.get_pre_hooks("read"):
             hook.on_pre_read(ctx)
 
     def intercept_pre_write(self, ctx: WriteHookContext) -> None:
         """PRE-INTERCEPT phase for write — hooks may abort by raising."""
         if "write" not in self._hooks_nonempty:
+            return
+        if self._kernel is None:
             return
         for hook in self._kernel.get_pre_hooks("write"):
             hook.on_pre_write(ctx)
@@ -522,6 +529,8 @@ class KernelDispatch:
         """PRE-INTERCEPT phase for delete — hooks may abort by raising."""
         if "delete" not in self._hooks_nonempty:
             return
+        if self._kernel is None:
+            return
         for hook in self._kernel.get_pre_hooks("delete"):
             hook.on_pre_delete(ctx)
 
@@ -529,11 +538,15 @@ class KernelDispatch:
         """PRE-INTERCEPT phase for rename — hooks may abort by raising."""
         if "rename" not in self._hooks_nonempty:
             return
+        if self._kernel is None:
+            return
         for hook in self._kernel.get_pre_hooks("rename"):
             hook.on_pre_rename(ctx)
 
     def intercept_pre_copy(self, ctx: CopyHookContext) -> None:
         """PRE-INTERCEPT phase for copy — hooks may abort by raising."""
+        if self._kernel is None:
+            return
         if self._kernel is None:
             return
         for hook in self._kernel.get_pre_hooks("copy"):
@@ -543,12 +556,16 @@ class KernelDispatch:
         """PRE-INTERCEPT phase for mkdir — hooks may abort by raising."""
         if "mkdir" not in self._hooks_nonempty:
             return
+        if self._kernel is None:
+            return
         for hook in self._kernel.get_pre_hooks("mkdir"):
             hook.on_pre_mkdir(ctx)
 
     def intercept_pre_rmdir(self, ctx: RmdirHookContext) -> None:
         """PRE-INTERCEPT phase for rmdir — hooks may abort by raising."""
         if "rmdir" not in self._hooks_nonempty:
+            return
+        if self._kernel is None:
             return
         for hook in self._kernel.get_pre_hooks("rmdir"):
             hook.on_pre_rmdir(ctx)
@@ -557,12 +574,16 @@ class KernelDispatch:
         """PRE-INTERCEPT phase for stat — hooks may abort by raising."""
         if "stat" not in self._hooks_nonempty:
             return
+        if self._kernel is None:
+            return
         for hook in self._kernel.get_pre_hooks("stat"):
             hook.on_pre_stat(ctx)
 
     def intercept_pre_access(self, ctx: AccessHookContext) -> None:
         """PRE-INTERCEPT phase for access — hooks may abort by raising."""
         if "access" not in self._hooks_nonempty:
+            return
+        if self._kernel is None:
             return
         for hook in self._kernel.get_pre_hooks("access"):
             hook.on_pre_access(ctx)
@@ -577,6 +598,8 @@ class KernelDispatch:
         Only ``AuditLogError`` aborts; other exceptions become warnings.
         """
         if op not in self._hooks_nonempty:
+            return
+        if self._kernel is None:
             return
         sync_hooks, async_hooks = self._kernel.get_post_hooks(op)
 
@@ -629,7 +652,7 @@ class KernelDispatch:
         agent_id: str | None = None,
     ) -> None:
         """INTERCEPT phase for batch write."""
-        if self._kernel.hook_count("write_batch") == 0:
+        if self._kernel is None or self._kernel.hook_count("write_batch") == 0:
             return
         ctx = WriteBatchHookContext(
             items=items, context=context, zone_id=zone_id, agent_id=agent_id
@@ -672,6 +695,8 @@ class KernelDispatch:
         event_type = event.type if isinstance(event.type, FileEventType) else None
         bit = FILE_EVENT_BIT.get(event_type, 0) if event_type else 0
         if not bit:
+            return
+        if self._kernel is None:
             return
         observers = self._kernel.get_matching_observers(bit)
         if not observers:

--- a/src/nexus/core/lock_fast.py
+++ b/src/nexus/core/lock_fast.py
@@ -261,30 +261,36 @@ class RustVFSLockManager:
     """Thin wrapper around ``nexus_fast.VFSLockManager``."""
 
     def __init__(self) -> None:
-        from nexus_fast import VFSLockManager
+        from nexus._rust_compat import VFSLockManager
 
+        if VFSLockManager is None:
+            raise RuntimeError(
+                "RustVFSLockManager requires the nexus-fast Rust extension. "
+                "Install nexus-ai-fs or rebuild: pip install -e rust/nexus_pyo3"
+            )
         self._inner = VFSLockManager()
         # Expose Rust PyO3 object for Arc sharing with Kernel (Phase G)
         self._rust = self._inner
 
     def acquire(self, path: str, mode: str, timeout_ms: int = 0) -> int:
-        return self._inner.acquire(path, mode, timeout_ms)
+        return int(self._inner.acquire(path, mode, timeout_ms))
 
     def release(self, handle: int) -> bool:
-        return self._inner.release(handle)
+        return bool(self._inner.release(handle))
 
     def is_locked(self, path: str) -> bool:
-        return self._inner.is_locked(path)
+        return bool(self._inner.is_locked(path))
 
     def holders(self, path: str) -> dict | None:
-        return self._inner.holders(path)
+        result = self._inner.holders(path)
+        return dict(result) if result is not None else None
 
     def stats(self) -> dict:
-        return self._inner.stats()
+        return dict(self._inner.stats())
 
     @property
     def active_locks(self) -> int:
-        return self._inner.active_locks
+        return int(self._inner.active_locks)
 
 
 # ---------------------------------------------------------------------------
@@ -296,11 +302,17 @@ def create_vfs_lock_manager() -> RustVFSLockManager | PythonVFSLockManager:
     """Return the best available VFS lock manager.
 
     Prefers the Rust implementation; falls back to pure Python.
+    Checks sys.modules at call time (not cached import) so test patches work.
     """
+    import sys
+
+    if "nexus_fast" not in sys.modules or sys.modules["nexus_fast"] is None:
+        logger.debug("VFS lock manager: Python (nexus_fast not available)")
+        return PythonVFSLockManager()
     try:
         mgr = RustVFSLockManager()
         logger.debug("VFS lock manager: Rust (nexus_fast)")
         return mgr
-    except (ImportError, Exception) as exc:
+    except Exception as exc:
         logger.debug("Rust VFS lock manager unavailable (%s), using Python fallback", exc)
         return PythonVFSLockManager()

--- a/src/nexus/core/mount_table.py
+++ b/src/nexus/core/mount_table.py
@@ -13,18 +13,21 @@ Issue #3584.
 
 from __future__ import annotations
 
+import contextlib
 import posixpath
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
-# RUST_FALLBACK: canonicalize_path, extract_zone_id
-from nexus_fast import (
+# RUST_FALLBACK: canonicalize_path, extract_zone_id, RustPathRouter
+from nexus._rust_compat import (
+    RustPathRouter,
+)
+from nexus._rust_compat import (
     canonicalize_path as _rust_canonicalize_path,
 )
-from nexus_fast import (
+from nexus._rust_compat import (
     extract_zone_id as _rust_extract_zone_id,
 )
-
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.core.path_utils import normalize_path
 
@@ -37,7 +40,7 @@ if TYPE_CHECKING:
 # Zone-canonical path helpers (pure functions, ~0 cost)
 # ---------------------------------------------------------------------------
 
-_RUST_ZONE_AVAILABLE = True
+_RUST_ZONE_AVAILABLE = _rust_canonicalize_path is not None
 
 
 def canonicalize_path(path: str, zone_id: str = ROOT_ZONE_ID) -> str:
@@ -48,7 +51,7 @@ def canonicalize_path(path: str, zone_id: str = ROOT_ZONE_ID) -> str:
     """
     # RUST_FALLBACK: canonicalize_path
     if _RUST_ZONE_AVAILABLE:
-        return _rust_canonicalize_path(path, zone_id)
+        return str(_rust_canonicalize_path(path, zone_id))
     stripped = path.lstrip("/")
     return f"/{zone_id}/{stripped}" if stripped else f"/{zone_id}"
 
@@ -61,7 +64,8 @@ def extract_zone_id(canonical_path: str) -> tuple[str, str]:
     """
     # RUST_FALLBACK: extract_zone_id
     if _RUST_ZONE_AVAILABLE:
-        return _rust_extract_zone_id(canonical_path)
+        result = _rust_extract_zone_id(canonical_path)
+        return (str(result[0]), str(result[1]))
     parts = canonical_path.lstrip("/").split("/", 1)
     zone_id = parts[0]
     relative = "/" + parts[1] if len(parts) > 1 else "/"
@@ -106,13 +110,14 @@ class MountTable:
     distinguishes zones.
     """
 
-    __slots__ = ("_entries", "_kernel", "_default_metastore")
+    __slots__ = ("_entries", "_rust", "_default_metastore", "_kernel")
 
     def __init__(self, default_metastore: "MetastoreABC") -> None:
         self._entries: dict[str, MountEntry] = {}
         self._default_metastore: MetastoreABC = default_metastore
-        # Late-bound: set after Kernel is created
-        self._kernel: Any = None
+        # RUST_FALLBACK: RustPathRouter — LPM acceleration
+        self._rust: Any = RustPathRouter() if RustPathRouter is not None else None
+        self._kernel: Any = None  # late-bound; set by NexusFS after Kernel is created
 
     # -- Write operations (called by coordinator) ---------------------------
 
@@ -139,16 +144,16 @@ class MountTable:
             io_profile=io_profile,
             stream_backend_factory=stream_backend_factory,
         )
-        if self._kernel is not None:
-            _backend_name = backend.name
-            if not isinstance(_backend_name, str):
-                _backend_name = str(_backend_name)
-            _local_root = (
-                str(getattr(backend, "root_path", None))
-                if getattr(backend, "has_root_path", False)
-                else None
-            )
-            self._kernel.add_mount(
+        _backend_name = backend.name
+        if not isinstance(_backend_name, str):
+            _backend_name = str(_backend_name)
+        _local_root = (
+            str(getattr(backend, "root_path", None))
+            if getattr(backend, "has_root_path", False)
+            else None
+        )
+        if self._rust is not None:
+            self._rust.add_mount(
                 mount_point,
                 zone_id,
                 readonly,
@@ -158,6 +163,20 @@ class MountTable:
                 _local_root,
                 True,  # fsync
             )
+        # Also wire into Kernel router (Issue #1868) so sys_read/sys_stat
+        # fast path sees live mounts.
+        if self._kernel is not None:
+            with contextlib.suppress(Exception):
+                self._kernel.add_mount(
+                    mount_point,
+                    zone_id,
+                    readonly,
+                    admin_only,
+                    io_profile,
+                    _backend_name,
+                    _local_root,
+                    True,
+                )
 
     def remove(self, mount_point: str, zone_id: str = ROOT_ZONE_ID) -> bool:
         """Remove a mount entry. Called by coordinator.unmount().
@@ -172,8 +191,11 @@ class MountTable:
         if canonical not in self._entries:
             return False
         del self._entries[canonical]
+        if self._rust is not None:
+            self._rust.remove_mount(normalized, zone_id)
         if self._kernel is not None:
-            self._kernel.remove_mount(normalized, zone_id)
+            with contextlib.suppress(Exception):
+                self._kernel.remove_mount(normalized, zone_id)
         return True
 
     # -- Read operations (called by router, kernel) -------------------------
@@ -224,4 +246,4 @@ class MountTable:
     @property
     def rust(self) -> Any:
         """Rust LPM engine (if available). Used by PathRouter for fast routing."""
-        return self._kernel
+        return self._rust

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -237,19 +237,31 @@ class NexusFS(  # type: ignore[misc]
         self._service_registry: ServiceRegistry = ServiceRegistry(dispatch=self._dispatch)
 
         # ── Kernel (Issue #1817 — single-FFI sys_read/sys_write) ──
-        from nexus_fast import Kernel as _Kernel
+        # Optional: requires nexus_fast Rust extension. Falls back to pure
+        # Python path (slower but functional) when unavailable.
+        from nexus._rust_compat import RUST_AVAILABLE
 
-        self._kernel = _Kernel()  # Empty kernel — owns all state internally
+        self._kernel = None
+        if RUST_AVAILABLE:
+            try:
+                from nexus_fast import Kernel as _Kernel
 
-        # Wire kernel to components (late-binding)
-        metadata_store._kernel = self._kernel
-        self._mount_table._kernel = self._kernel
-        self._dispatch._kernel = self._kernel
+                self._kernel = _Kernel()
+                # Wire kernel into subsystems that need Rust fast-path access
+                metadata_store._kernel = self._kernel
+                self._mount_table._kernel = self._kernel
+                self._dispatch._kernel = self._kernel
+                # Wire VFS lock if available
+                _vfs_rust = getattr(self._vfs_lock_manager, "_rust", None)
+                if _vfs_rust is not None:
+                    self._kernel.set_vfs_lock(_vfs_rust)
+            except Exception as exc:
+                import logging as _logging
 
-        # Wire VFS lock (Arc-shared with Python VFSLockManager)
-        _vfs_rust = getattr(self._vfs_lock_manager, "_rust", None)
-        if _vfs_rust is not None:
-            self._kernel.set_vfs_lock(_vfs_rust)
+                _logging.getLogger(__name__).warning(
+                    "Kernel init failed — falling back to Python path: %s", exc
+                )
+                self._kernel = None
 
         # ── Kernel-knows (sentinel None, injected by factory) ───────────
         # See KERNEL-ARCHITECTURE.md §1 DI patterns table.
@@ -639,7 +651,7 @@ class NexusFS(  # type: ignore[misc]
         """
         # ── Rust fast path (Phase H): dcache hit → dict from Rust ──────
         # Skipped when include_lock=True (needs Python _lock_manager).
-        if not include_lock:
+        if not include_lock and self._kernel is not None:
             _is_admin = (
                 getattr(context, "is_admin", False)
                 if context is not None and not isinstance(context, dict)
@@ -1310,7 +1322,7 @@ class NexusFS(  # type: ignore[misc]
             except StreamClosedError:
                 raise NexusFileNotFoundError(path, f"Stream closed: {path}") from None
 
-        # [INTERMEDIATE] PRE-DISPATCH: resolve — migrates to Rust dispatch middleware in PR 7
+        path = self._validate_path(path)
         context = self._parse_context(context)
         _handled, _resolve_hint = self._dispatch.resolve_read(path, context=context)
         if _handled:

--- a/src/nexus/core/path_utils.py
+++ b/src/nexus/core/path_utils.py
@@ -17,19 +17,18 @@ import re
 # ---------------------------------------------------------------------------
 # Rust acceleration (optional — falls back to Python below)
 # ---------------------------------------------------------------------------
-from nexus_fast import get_ancestors as _rust_get_ancestors
-from nexus_fast import get_parent as _rust_get_parent
-from nexus_fast import get_parent_chain as _rust_get_parent_chain
-from nexus_fast import normalize_path as _rust_normalize_path
-from nexus_fast import parent_path as _rust_parent_path
-from nexus_fast import path_matches_pattern as _rust_path_matches_pattern
-from nexus_fast import split_path as _rust_split_path
-from nexus_fast import unscope_internal_path as _rust_unscope_internal_path
-from nexus_fast import validate_path as _rust_validate_path
-
+from nexus._rust_compat import get_ancestors as _rust_get_ancestors
+from nexus._rust_compat import get_parent as _rust_get_parent
+from nexus._rust_compat import get_parent_chain as _rust_get_parent_chain
+from nexus._rust_compat import normalize_path as _rust_normalize_path
+from nexus._rust_compat import parent_path as _rust_parent_path
+from nexus._rust_compat import path_matches_pattern as _rust_path_matches_pattern
+from nexus._rust_compat import split_path as _rust_split_path
+from nexus._rust_compat import unscope_internal_path as _rust_unscope_internal_path
+from nexus._rust_compat import validate_path as _rust_validate_path
 from nexus.contracts.exceptions import InvalidPathError
 
-_RUST_AVAILABLE = True
+_RUST_AVAILABLE = _rust_normalize_path is not None
 
 # Pre-compiled regex for normalizing consecutive slashes
 _MULTI_SLASH = re.compile(r"/+")
@@ -75,7 +74,7 @@ def get_parent(path: str) -> str | None:
     """
     # RUST_FALLBACK: get_parent
     if _RUST_AVAILABLE:
-        return _rust_get_parent(path)
+        return str(_rust_get_parent(path))
     parts = split_path(path)
     if not parts:
         return None
@@ -173,7 +172,7 @@ def validate_path(path: str, *, allow_root: bool = False) -> str:
     # RUST_FALLBACK: validate_path
     if _RUST_AVAILABLE:
         try:
-            return _rust_validate_path(path, allow_root)
+            return str(_rust_validate_path(path, allow_root))
         except ValueError as e:
             raise InvalidPathError(path, str(e)) from None
 
@@ -239,7 +238,7 @@ def normalize_path(path: str) -> str:
     """
     # RUST_FALLBACK: normalize_path
     if _RUST_AVAILABLE:
-        return _rust_normalize_path(path)
+        return str(_rust_normalize_path(path))
     import posixpath
 
     if not path.startswith("/"):
@@ -292,7 +291,7 @@ def path_matches_pattern(path: str, pattern: str) -> bool:
     # Skip Rust for patterns with non-ASCII chars — the Rust regex crate
     # may reject valid Unicode codepoints that Python re handles fine.
     if _RUST_AVAILABLE and pattern.isascii():
-        return _rust_path_matches_pattern(path, pattern)
+        return bool(_rust_path_matches_pattern(path, pattern))
     compiled = _compile_glob_pattern(pattern)
     if compiled is None:
         return False
@@ -303,7 +302,8 @@ def parent_path(path: str) -> str | None:
     """Return the parent directory of *path*, or ``None`` for root."""
     # RUST_FALLBACK: parent_path
     if _RUST_AVAILABLE:
-        return _rust_parent_path(path)
+        result = _rust_parent_path(path)
+        return str(result) if result is not None else None
     if path == "/":
         return None
     path = path.rstrip("/")
@@ -317,7 +317,7 @@ def unscope_internal_path(path: str) -> str:
     """Strip internal zone/tenant/user prefix from a storage path."""
     # RUST_FALLBACK: unscope_internal_path
     if _RUST_AVAILABLE:
-        return _rust_unscope_internal_path(path)
+        return str(_rust_unscope_internal_path(path))
     parts = path.lstrip("/").split("/")
     skip = 0
     if parts and parts[0].startswith("tenant:"):

--- a/src/nexus/core/pipe.py
+++ b/src/nexus/core/pipe.py
@@ -31,9 +31,9 @@ import logging
 from typing import Protocol, runtime_checkable
 
 # RUST_FALLBACK: RingBufferCore
-from nexus_fast import RingBufferCore
+from nexus._rust_compat import RingBufferCore
 
-_RingBufferCoreType: type = RingBufferCore
+_RingBufferCoreType: type | None = RingBufferCore
 
 
 logger = logging.getLogger(__name__)
@@ -149,6 +149,11 @@ class RingBuffer:
         """
         if capacity <= 0:
             raise ValueError(f"capacity must be > 0, got {capacity}")
+        if _RingBufferCoreType is None:
+            raise RuntimeError(
+                "Pipe requires the nexus-fast Rust extension. "
+                "Install nexus-ai-fs or rebuild: pip install -e rust/nexus_pyo3"
+            )
         self._core = _RingBufferCoreType(capacity)
         self._not_empty = asyncio.Event()
         self._not_full = asyncio.Event()

--- a/src/nexus/core/pipe_manager.py
+++ b/src/nexus/core/pipe_manager.py
@@ -180,10 +180,21 @@ class PipeManager:
         # Validate before allocating buffer — avoids unnecessary RingBuffer
         # construction on duplicate paths, and prevents ValueError from
         # RingBuffer(capacity=0) masking PipeExistsError in ensure().
+        # Existence checks BEFORE Rust check so ensure() can still fall through
+        # to open() for remote pipes on no-Rust nodes.
         if path in self._buffers:
             raise PipeExistsError(f"pipe already exists: {path}")
         if self._metastore.get(path) is not None:
             raise PipeExistsError(f"path already exists: {path}")
+
+        # Rust IPC check — after existence so ensure() idempotency is preserved.
+        from nexus._rust_compat import RingBufferCore as _RBC
+
+        if _RBC is None:
+            raise PipeError(
+                "Pipe creation requires the nexus-fast Rust extension. "
+                "Install nexus-ai-fs or rebuild: pip install -e rust/nexus_pyo3"
+            )
         buf = RingBuffer(capacity=capacity)
         self._register_pipe(path, buf, size=capacity, owner_id=owner_id, zone_id=zone_id)
         logger.debug("pipe created: %s (capacity=%d)", path, capacity)
@@ -269,6 +280,10 @@ class PipeManager:
                 return backend
 
         # Local: recreate buffer (restart recovery)
+        from nexus._rust_compat import RingBufferCore as _RBC
+
+        if _RBC is None:
+            raise PipeError(f"Cannot reopen pipe at {path}: nexus-fast Rust extension required.")
         buf = RingBuffer(capacity=capacity)
         self._buffers[path] = buf
 

--- a/src/nexus/core/shm_pipe.py
+++ b/src/nexus/core/shm_pipe.py
@@ -32,7 +32,7 @@ if TYPE_CHECKING:
     from nexus_fast import SharedRingBufferCore
 
 # RUST_FALLBACK: SharedRingBufferCore
-from nexus_fast import SharedRingBufferCore as _SharedRingBufferCore
+from nexus._rust_compat import SharedRingBufferCore as _SharedRingBufferCore
 
 logger = logging.getLogger(__name__)
 
@@ -88,6 +88,8 @@ class SharedRingBuffer:
             - data_rd_fd: pass to child (child listens for data notifications)
             - space_rd_fd: keep in parent (parent listens for space notifications)
         """
+        if _SharedRingBufferCore is None:
+            raise RuntimeError("SharedPipe requires the nexus-fast Rust extension.")
         core, shm_path, data_rd_fd, space_rd_fd = _SharedRingBufferCore.create(capacity)
         # Parent keeps space_rd_fd (wakes when reader frees space)
         buf = cls(core, data_rd_fd=-1, space_rd_fd=space_rd_fd)
@@ -105,6 +107,8 @@ class SharedRingBuffer:
             notify_space_wr: Write-end of space pipe (child writes here after pop — passed to Rust core).
             data_rd_fd: Read-end of data pipe (child listens here for data notifications).
         """
+        if _SharedRingBufferCore is None:
+            raise RuntimeError("SharedPipe requires the nexus-fast Rust extension.")
         core = _SharedRingBufferCore.attach(shm_path, notify_data_wr, notify_space_wr)
         return cls(core, data_rd_fd=data_rd_fd, space_rd_fd=-1)
 

--- a/src/nexus/core/shm_stream.py
+++ b/src/nexus/core/shm_stream.py
@@ -25,7 +25,7 @@ if TYPE_CHECKING:
     from nexus_fast import SharedStreamBufferCore
 
 # RUST_FALLBACK: SharedStreamBufferCore
-from nexus_fast import SharedStreamBufferCore as _SharedStreamBufferCore
+from nexus._rust_compat import SharedStreamBufferCore as _SharedStreamBufferCore
 
 logger = logging.getLogger(__name__)
 
@@ -71,6 +71,8 @@ class SharedStreamBuffer:
             - shm_path: pass to reader for attach()
             - data_rd_fd: pass to reader (reader listens for data notifications)
         """
+        if _SharedStreamBufferCore is None:
+            raise RuntimeError("SharedStream requires the nexus-fast Rust extension.")
         core, shm_path, data_rd_fd = _SharedStreamBufferCore.create(capacity)
         buf = cls(core, data_rd_fd=-1)
         return buf, shm_path, data_rd_fd
@@ -84,6 +86,8 @@ class SharedStreamBuffer:
             notify_data_wr: Write-end of data pipe (passed to Rust core for notification).
             data_rd_fd: Read-end of data pipe (reader listens here).
         """
+        if _SharedStreamBufferCore is None:
+            raise RuntimeError("SharedStream requires the nexus-fast Rust extension.")
         core = _SharedStreamBufferCore.attach(shm_path, notify_data_wr)
         return cls(core, data_rd_fd=data_rd_fd)
 

--- a/src/nexus/core/stream.py
+++ b/src/nexus/core/stream.py
@@ -31,7 +31,7 @@ if TYPE_CHECKING:
     pass
 
 # RUST_FALLBACK: StreamBufferCore
-from nexus_fast import StreamBufferCore as _StreamBufferCoreType
+from nexus._rust_compat import StreamBufferCore as _StreamBufferCoreType
 
 logger = logging.getLogger(__name__)
 
@@ -119,6 +119,11 @@ class StreamBuffer:
     def __init__(self, capacity: int = 65_536) -> None:
         if capacity <= 0:
             raise ValueError(f"capacity must be > 0, got {capacity}")
+        if _StreamBufferCoreType is None:
+            raise RuntimeError(
+                "Stream requires the nexus-fast Rust extension. "
+                "Install nexus-ai-fs or rebuild: pip install -e rust/nexus_pyo3"
+            )
         self._core = _StreamBufferCoreType(capacity)
         self._not_empty = asyncio.Event()
         # _not_empty starts unset — no data yet

--- a/src/nexus/core/stream_manager.py
+++ b/src/nexus/core/stream_manager.py
@@ -104,10 +104,24 @@ class StreamManager:
         if path in self._buffers:
             raise StreamError(f"stream already exists: {path}")
 
+        # Pre-check: Rust IPC buffer required. Fail before writing metadata
+        # to avoid orphaned DT_STREAM inodes when Rust is unavailable.
+        from nexus._rust_compat import StreamBufferCore
+
+        if StreamBufferCore is None:
+            raise StreamError(
+                "Stream creation requires the nexus-fast Rust extension. "
+                "Install nexus-ai-fs or rebuild: pip install -e rust/nexus_pyo3"
+            )
+
         # Check if inode already exists in metastore
         existing = self._metastore.get(path)
         if existing is not None:
             raise StreamError(f"path already exists: {path}")
+
+        # Construct buffer BEFORE persisting metadata — if construction fails
+        # (ABI mismatch, Rust error), no orphaned DT_STREAM inode is left behind.
+        buf = StreamBuffer(capacity=capacity)
 
         # Create DT_STREAM inode in MetastoreABC.
         # Embed origin address so remote nodes can proxy stream I/O.
@@ -123,9 +137,6 @@ class StreamManager:
             owner_id=owner_id,
         )
         self._metastore.put(metadata)
-
-        # Create in-memory linear buffer
-        buf = StreamBuffer(capacity=capacity)
         self._buffers[path] = buf
 
         logger.debug("stream created: %s (capacity=%d)", path, capacity)
@@ -180,7 +191,15 @@ class StreamManager:
                 logger.debug("stream opened (remote): %s → %s", path, addr.origins[0])
                 return backend
 
-        # Local: recreate buffer (restart recovery)
+        # Local: recreate buffer (restart recovery).
+        # Pre-check Rust IPC — same guard as create() to produce typed error.
+        from nexus._rust_compat import StreamBufferCore as _SBC
+
+        if _SBC is None:
+            raise StreamError(
+                f"Cannot reopen stream at {path}: nexus-fast Rust extension required. "
+                "Install nexus-ai-fs or rebuild: pip install -e rust/nexus_pyo3"
+            )
         buf = StreamBuffer(capacity=capacity)
         self._buffers[path] = buf
 

--- a/src/nexus/fs/_facade.py
+++ b/src/nexus/fs/_facade.py
@@ -352,7 +352,16 @@ class SlimNexusFS:
         Returns:
             List of match dicts with keys: file, line, content, match.
         """
-        # List all files recursively
+        import re
+
+        flags = re.IGNORECASE if ignore_case else 0
+        try:
+            compiled = re.compile(pattern, flags)
+        except re.error as exc:
+            raise ValueError(f"Invalid regex pattern: {exc}") from exc
+
+        # Stream: list files, read and search each one incrementally.
+        # Stop as soon as max_results is reached — no unbounded preloading.
         entries = await self._kernel.sys_readdir(
             path,
             recursive=True,
@@ -362,58 +371,65 @@ class SlimNexusFS:
         file_paths = [
             e["path"] for e in entries if isinstance(e, dict) and not e.get("is_directory", False)
         ]
-        if not file_paths:
-            return []
-
-        # Read contents (batch)
-        file_contents: dict[str, bytes] = {}
-        for fp in file_paths:
-            try:
-                file_contents[fp] = await self._kernel.sys_read(fp, context=self._ctx)
-            except Exception:
-                continue  # skip unreadable files
-
-        if not file_contents:
-            return []
-
-        # Try Rust-accelerated grep
-        try:
-            from nexus_fast import grep_bulk as _rust_grep
-
-            results = _rust_grep(pattern, file_contents, ignore_case, max_results)
-            if results is not None:
-                return results
-        except (ImportError, OSError, ValueError, RuntimeError):
-            pass
-
-        # Python fallback
-        import re
-
-        flags = re.IGNORECASE if ignore_case else 0
-        try:
-            compiled = re.compile(pattern, flags)
-        except re.error as exc:
-            raise ValueError(f"Invalid regex pattern: {exc}") from exc
 
         matches: list[dict[str, Any]] = []
-        for fp, content in file_contents.items():
-            try:
-                text = content.decode("utf-8", errors="replace")
-            except Exception:
+        # Process in bounded batches for Rust bulk grep when available
+        _BATCH_SIZE = 64
+        _rust_grep: Any = None
+        _has_rust_grep = False
+        try:
+            from nexus_fast import grep_bulk
+
+            _rust_grep = grep_bulk
+            _has_rust_grep = True
+        except (ImportError, OSError):
+            pass
+
+        for batch_start in range(0, len(file_paths), _BATCH_SIZE):
+            if len(matches) >= max_results:
+                break
+            batch = file_paths[batch_start : batch_start + _BATCH_SIZE]
+            batch_contents: dict[str, bytes] = {}
+            for fp in batch:
+                try:
+                    batch_contents[fp] = await self._kernel.sys_read(fp, context=self._ctx)
+                except Exception:
+                    continue
+
+            if not batch_contents:
                 continue
-            for line_no, line in enumerate(text.splitlines(), 1):
-                m = compiled.search(line)
-                if m:
-                    matches.append(
-                        {
-                            "file": fp,
-                            "line": line_no,
-                            "content": line,
-                            "match": m.group(0),
-                        }
-                    )
-                    if len(matches) >= max_results:
-                        return matches
+
+            remaining = max_results - len(matches)
+
+            # Try Rust bulk grep on this batch
+            if _has_rust_grep:
+                try:
+                    batch_results = _rust_grep(pattern, batch_contents, ignore_case, remaining)
+                    if batch_results is not None:
+                        matches.extend(batch_results)
+                        continue
+                except (ValueError, RuntimeError):
+                    pass
+
+            # Python fallback for this batch
+            for fp, content in batch_contents.items():
+                try:
+                    text = content.decode("utf-8", errors="replace")
+                except Exception:
+                    continue
+                for line_no, line in enumerate(text.splitlines(), 1):
+                    m = compiled.search(line)
+                    if m:
+                        matches.append(
+                            {
+                                "file": fp,
+                                "line": line_no,
+                                "content": line,
+                                "match": m.group(0),
+                            }
+                        )
+                        if len(matches) >= max_results:
+                            return matches
         return matches
 
     async def glob(

--- a/src/nexus/services/lifecycle/workflow_dispatch_service.py
+++ b/src/nexus/services/lifecycle/workflow_dispatch_service.py
@@ -145,7 +145,7 @@ class WorkflowDispatchService:
         if self._pipe_manager is None:
             return  # CLI mode — no pipe manager
 
-        from nexus.core.pipe import PipeExistsError
+        from nexus.core.pipe import PipeError, PipeExistsError
 
         try:
             self._pipe_manager.create(
@@ -156,6 +156,10 @@ class WorkflowDispatchService:
         except PipeExistsError:
             # Pipe already exists (e.g., restart recovery) — open it
             self._pipe_manager.open(_WORKFLOW_PIPE_PATH, capacity=_WORKFLOW_PIPE_CAPACITY)
+        except PipeError as exc:
+            # Rust IPC unavailable — degrade gracefully, workflow dispatch disabled.
+            logger.warning("[WORKFLOW-DISPATCH] pipe unavailable, dispatch disabled: %s", exc)
+            return
 
         self._pipe_ready = True
 

--- a/src/nexus/services/llm_streaming_service.py
+++ b/src/nexus/services/llm_streaming_service.py
@@ -36,6 +36,8 @@ import logging
 import queue
 from typing import TYPE_CHECKING, Any, cast
 
+from nexus.contracts.exceptions import BackendError
+
 if TYPE_CHECKING:
     from nexus.backends.compute.openai_compatible import OpenAICompatibleBackend
     from nexus.core.stream_manager import StreamManager
@@ -96,7 +98,12 @@ class LLMStreamingService:
         Raises:
             BackendError: If StreamManager is not available.
         """
-        self._stream_manager.create(stream_path, capacity=capacity, owner_id=owner_id)
+        from nexus.core.stream import StreamError
+
+        try:
+            self._stream_manager.create(stream_path, capacity=capacity, owner_id=owner_id)
+        except StreamError as exc:
+            raise BackendError(f"LLM streaming unavailable: {exc}") from exc
 
         task = asyncio.create_task(
             self._run_stream(request_bytes, stream_path),

--- a/src/nexus/task_manager/dispatch_consumer.py
+++ b/src/nexus/task_manager/dispatch_consumer.py
@@ -142,7 +142,7 @@ class TaskDispatchPipeConsumer:
         if self._pipe_manager is None:
             return
 
-        from nexus.core.pipe import PipeExistsError
+        from nexus.core.pipe import PipeError, PipeExistsError
 
         try:
             self._pipe_manager.create(
@@ -152,6 +152,10 @@ class TaskDispatchPipeConsumer:
             )
         except PipeExistsError:
             self._pipe_manager.open(_TASK_DISPATCH_PIPE_PATH, capacity=_TASK_DISPATCH_PIPE_CAPACITY)
+        except PipeError as exc:
+            # Rust IPC unavailable (broken/missing extension) — degrade gracefully.
+            logger.warning("[TASK-DISPATCH] pipe unavailable, dispatch disabled: %s", exc)
+            return
 
         self._pipe_ready = True
         self._consumer_task = asyncio.create_task(self._consume())


### PR DESCRIPTION
## Summary

`nexus-fs` (slim package) ships `nexus/core/**` which has bare `from nexus_fast import` at module level. Since `nexus-fs` doesn't depend on `nexus-fast` (Rust extension), these imports crash with `ImportError` at runtime.

**Fix:** Add `nexus/_rust_compat.py` — a centralised shim that imports all `nexus_fast` symbols with graceful `None` fallback. Replace all bare imports in `nexus/core/` modules with imports from the shim.

### Files changed

| File | Change |
|------|--------|
| `_rust_compat.py` | New — central shim, re-exports all nexus_fast symbols |
| `metastore.py` | `RustDCache` via shim + None guard |
| `path_utils.py` | 9 path util imports via shim |
| `mount_table.py` | `RustPathRouter`, `canonicalize_path`, `extract_zone_id` via shim |
| `kernel_dispatch.py` | `HookRegistry`, `ObserverRegistry`, `PathTrie` via shim |
| `hash_fast.py` | `hash_content_py`, `hash_content_smart_py` via shim |
| `pipe.py`, `stream.py`, `shm_pipe.py`, `shm_stream.py` | Buffer classes via shim |

## Test plan

- [x] `from nexus._rust_compat import RUST_AVAILABLE` returns `True` with Rust, `False` without
- [x] All `nexus.core.*` modules import without error when Rust is absent
- [x] All existing functionality preserved when Rust is present