### PR TITLE
release: nexus-ai-fs v0.9.20, nexus-fs v0.4.0, nexus-tui v0.9.20

### DIFF
--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/api-client",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "description": "Shared HTTP client for Nexus APIs — retry, auth, error mapping, case transform",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/nexus-fs/pyproject.toml
+++ b/packages/nexus-fs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nexus-fs"
-version = "0.3.0"
+version = "0.4.0"
 description = "Unified filesystem abstraction for cloud storage — mount S3, GCS, and local storage with two lines of Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/tui",
-  "version": "0.9.19",
+  "version": "0.9.20",
   "description": "Terminal UI for Nexus — file explorer, API inspector, and monitoring dashboard",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.19"
+version = "0.9.20"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/nexus_pyo3/Cargo.toml
+++ b/rust/nexus_pyo3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus_pyo3"
-version = "0.9.19"
+version = "0.9.20"
 edition = "2021"
 
 [lib]

--- a/rust/nexus_pyo3/pyproject.toml
+++ b/rust/nexus_pyo3/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-fast"
-version = "0.9.19"
+version = "0.9.20"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
 requires-python = ">=3.12"
 classifiers = [

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -48,7 +48,7 @@ import logging
 import os as _os
 from typing import TYPE_CHECKING, Any, cast
 
-__version__ = "0.9.19"  # release version
+__version__ = "0.9.20"  # release version
 __author__ = "Nexi Lab Team"
 __license__ = "Apache-2.0"
 


### PR DESCRIPTION
## Version bumps
- nexus-ai-fs: 0.9.19 → 0.9.20
- nexus-fs: 0.3.0 → 0.4.0
- @nexus-ai-fs/tui: 0.9.19 → 0.9.20
- @nexus-ai-fs/api-client: 0.9.19 → 0.9.20
- nexus_pyo3 (Rust): 0.9.19 → 0.9.20

## Changes since v0.9.19
- **#3619** feat(nexus-fs): grep and glob in slim package and CLI
- **#3620** fix: guard nexus_fast imports for nexus-fs slim package compatibility
- **#3621** refactor(#1868): SyscallEngine → Kernel arc consolidation
- **#3622** feat(#1868): full sys_read/sys_write — pure Rust kernel, remove Python fallback

nexus-fs bumps to 0.4.0 (minor) reflecting the full Rust kernel milestone.