### PR TITLE
feat: expose programmatic OAuth API on nexus.fs

### DIFF
--- a/packages/nexus-fs/pyproject.toml
+++ b/packages/nexus-fs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nexus-fs"
-version = "0.4.0"
+version = "0.4.1"
 description = "Unified filesystem abstraction for cloud storage — mount S3, GCS, and local storage with two lines of Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.20"
+version = "0.9.21"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/nexus_pyo3/Cargo.toml
+++ b/rust/nexus_pyo3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus_pyo3"
-version = "0.9.20"
+version = "0.9.21"
 edition = "2021"
 
 [lib]

--- a/rust/nexus_pyo3/pyproject.toml
+++ b/rust/nexus_pyo3/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-fast"
-version = "0.9.20"
+version = "0.9.21"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
 requires-python = ">=3.12"
 classifiers = [

--- a/src/nexus/fs/__init__.py
+++ b/src/nexus/fs/__init__.py
@@ -37,6 +37,8 @@ _LAZY_IMPORTS = {
     "NexusFileSystem": ("nexus.fs._fsspec", "NexusFileSystem"),
     "parse_uri": ("nexus.fs._uri", "parse_uri"),
     "MountSpec": ("nexus.fs._uri", "MountSpec"),
+    "generate_auth_url": ("nexus.fs._oauth_support", "generate_auth_url"),
+    "exchange_auth_code": ("nexus.fs._oauth_support", "exchange_auth_code"),
 }
 
 

--- a/src/nexus/fs/_oauth_support.py
+++ b/src/nexus/fs/_oauth_support.py
@@ -50,6 +50,20 @@ _GOOGLE_SERVICE_PROVIDER_NAMES: dict[str, str] = {
     "google-calendar": "google-calendar",
 }
 
+_X_SCOPES: list[str] = [
+    "tweet.read",
+    "tweet.write",
+    "tweet.moderate.write",
+    "users.read",
+    "follows.read",
+    "offline.access",
+    "bookmark.read",
+    "bookmark.write",
+    "list.read",
+    "like.read",
+    "like.write",
+]
+
 
 def _root_zone_id() -> str:
     try:
@@ -194,19 +208,7 @@ def get_x_auth_url(
     provider = _get_x_oauth_provider_cls()(
         client_id=client_id,
         redirect_uri=redirect_uri,
-        scopes=[
-            "tweet.read",
-            "tweet.write",
-            "tweet.moderate.write",
-            "users.read",
-            "follows.read",
-            "offline.access",
-            "bookmark.read",
-            "bookmark.write",
-            "list.read",
-            "like.read",
-            "like.write",
-        ],
+        scopes=_X_SCOPES,
         provider_name="x",
         client_secret=client_secret,
     )
@@ -315,19 +317,7 @@ def run_x_oauth_setup(
         provider = _get_x_oauth_provider_cls()(
             client_id=client_id or "",
             redirect_uri="http://localhost",
-            scopes=[
-                "tweet.read",
-                "tweet.write",
-                "tweet.moderate.write",
-                "users.read",
-                "follows.read",
-                "offline.access",
-                "bookmark.read",
-                "bookmark.write",
-                "list.read",
-                "like.read",
-                "like.write",
-            ],
+            scopes=_X_SCOPES,
             provider_name="x",
             client_secret=client_secret_resolved,
         )
@@ -350,3 +340,139 @@ def run_x_oauth_setup(
     except Exception as exc:
         console.print(f"\n[red]OAuth setup failed:[/red] {exc}")
         sys.exit(1)
+
+
+# =============================================================================
+# Programmatic OAuth API — for bridges, agents, and non-CLI callers
+# =============================================================================
+
+
+def generate_auth_url(
+    provider: str,
+    redirect_uri: str,
+) -> tuple[str, str | None]:
+    """Generate an OAuth authorization URL for the given provider.
+
+    No CLI interaction. Suitable for web flows, agent orchestration, or any
+    caller that owns the redirect URI (e.g. a localhost callback server).
+
+    Args:
+        provider: Provider name. One of: "google-drive", "gws", "gmail",
+            "google-calendar", "x".
+        redirect_uri: The redirect URI that OAuth will send the ``?code=``
+            parameter to after the user authorizes. Must match what you pass
+            to :func:`exchange_auth_code`.
+
+    Returns:
+        ``(auth_url, code_verifier)`` tuple.
+        - ``auth_url``: URL the user should visit to authorize.
+        - ``code_verifier``: PKCE verifier string for X OAuth; ``None`` for
+          Google providers. Pass this value to :func:`exchange_auth_code`.
+
+    Raises:
+        ValueError: If required credentials are missing or ``provider`` is
+            not recognized.
+
+    Examples:
+        # Google
+        url, _ = nexus.fs.generate_auth_url("google-drive", "http://localhost:4567/callback")
+
+        # X (Twitter) — store the verifier; you'll need it in exchange_auth_code
+        url, code_verifier = nexus.fs.generate_auth_url("x", "http://localhost:4567/callback")
+    """
+    if provider in _GOOGLE_SERVICE_SCOPES:
+        url = get_google_auth_url(service_name=provider, redirect_uri=redirect_uri)
+        return url, None
+    if provider == "x":
+        url, pkce_data = get_x_auth_url(redirect_uri=redirect_uri)
+        return url, pkce_data["code_verifier"]
+    supported = list(_GOOGLE_SERVICE_SCOPES) + ["x"]
+    raise ValueError(f"Unsupported provider {provider!r}. Supported: {supported}")
+
+
+async def exchange_auth_code(
+    provider: str,
+    user_email: str,
+    code: str,
+    redirect_uri: str,
+    code_verifier: str | None = None,
+    *,
+    db_path: str | None = None,
+    zone_id: str | None = None,
+) -> None:
+    """Exchange an OAuth authorization code for a token and persist it.
+
+    Call this after the user has authorized and your redirect URI received
+    ``?code=...``. The credential is stored in the nexus-fs token store and
+    will be used automatically by subsequent filesystem operations.
+
+    Args:
+        provider: Provider name. One of: "google-drive", "gws", "gmail",
+            "google-calendar", "x".
+        user_email: Email address to associate with this credential.
+        code: The authorization code from the ``?code=`` query parameter.
+        redirect_uri: Must be the same URI used in :func:`generate_auth_url`.
+        code_verifier: PKCE verifier returned by :func:`generate_auth_url`.
+            Required for X OAuth; ignored for Google providers.
+        db_path: Override the token database path. Uses the default nexus-fs
+            path if not provided.
+        zone_id: Zone to associate the credential with. Defaults to root.
+
+    Raises:
+        ValueError: If required credentials or arguments are missing.
+        OAuthError: If the code exchange with the provider fails.
+    """
+    if provider in _GOOGLE_SERVICE_SCOPES:
+        GoogleOAuthProvider = _il.import_module(
+            "nexus.bricks.auth.oauth.providers.google"
+        ).GoogleOAuthProvider
+        client_id = os.getenv("NEXUS_OAUTH_GOOGLE_CLIENT_ID", "")
+        client_secret = os.getenv("NEXUS_OAUTH_GOOGLE_CLIENT_SECRET", "")
+        if not client_id:
+            raise ValueError(
+                "Google OAuth client ID not provided. Set NEXUS_OAUTH_GOOGLE_CLIENT_ID."
+            )
+        if not client_secret:
+            raise ValueError(
+                "Google OAuth client secret not provided. Set NEXUS_OAUTH_GOOGLE_CLIENT_SECRET."
+            )
+        oauth_provider = GoogleOAuthProvider(
+            client_id=client_id,
+            client_secret=client_secret,
+            redirect_uri=redirect_uri,
+            scopes=_GOOGLE_SERVICE_SCOPES[provider],
+            provider_name=_GOOGLE_SERVICE_PROVIDER_NAMES[provider],
+        )
+        credential = await oauth_provider.exchange_code(code)
+        provider_name = _GOOGLE_SERVICE_PROVIDER_NAMES[provider]
+    elif provider == "x":
+        if not code_verifier:
+            raise ValueError("code_verifier is required for X OAuth (PKCE).")
+        client_id = os.getenv("NEXUS_OAUTH_X_CLIENT_ID", "")
+        client_secret = os.getenv("NEXUS_OAUTH_X_CLIENT_SECRET")
+        if not client_id:
+            raise ValueError("X OAuth client ID not provided. Set NEXUS_OAUTH_X_CLIENT_ID.")
+        oauth_provider = _get_x_oauth_provider_cls()(
+            client_id=client_id,
+            redirect_uri=redirect_uri,
+            scopes=_X_SCOPES,
+            provider_name="x",
+            client_secret=client_secret,
+        )
+        credential = await oauth_provider.exchange_code_pkce(code, code_verifier)
+        provider_name = "twitter"
+    else:
+        supported = list(_GOOGLE_SERVICE_SCOPES) + ["x"]
+        raise ValueError(f"Unsupported provider {provider!r}. Supported: {supported}")
+
+    manager = get_token_manager(db_path)
+    try:
+        await manager.store_credential(
+            provider=provider_name,
+            user_email=user_email,
+            credential=credential,
+            zone_id=zone_id or _root_zone_id(),
+            created_by=user_email,
+        )
+    finally:
+        manager.close()

--- a/src/nexus/fs/_oauth_support.py
+++ b/src/nexus/fs/_oauth_support.py
@@ -449,7 +449,7 @@ async def exchange_auth_code(
         if not code_verifier:
             raise ValueError("code_verifier is required for X OAuth (PKCE).")
         client_id = os.getenv("NEXUS_OAUTH_X_CLIENT_ID", "")
-        client_secret = os.getenv("NEXUS_OAUTH_X_CLIENT_SECRET")
+        x_client_secret: str | None = os.getenv("NEXUS_OAUTH_X_CLIENT_SECRET")
         if not client_id:
             raise ValueError("X OAuth client ID not provided. Set NEXUS_OAUTH_X_CLIENT_ID.")
         oauth_provider = _get_x_oauth_provider_cls()(
@@ -457,7 +457,7 @@ async def exchange_auth_code(
             redirect_uri=redirect_uri,
             scopes=_X_SCOPES,
             provider_name="x",
-            client_secret=client_secret,
+            client_secret=x_client_secret,
         )
         credential = await oauth_provider.exchange_code_pkce(code, code_verifier)
         provider_name = "twitter"


### PR DESCRIPTION
## Summary

- Add `nexus.fs.generate_auth_url(provider, redirect_uri)` → `(url, code_verifier | None)` — unified entry point for generating OAuth authorization URLs with a caller-supplied redirect URI
- Add `async nexus.fs.exchange_auth_code(provider, user_email, code, redirect_uri, code_verifier=None)` — exchanges the authorization code and persists the credential, replacing the buried `_exchange_and_store` logic in the CLI setup functions
- Extract `_X_SCOPES` constant to eliminate the duplicated scope list across three call sites

## Motivation

Bridges and agents need to drive the OAuth flow programmatically with their own `redirect_uri` (e.g. `http://localhost:PORT/callback`). Previously the only path was through the interactive CLI setup functions (`run_google_oauth_setup`, `run_x_oauth_setup`), which hardcode `http://localhost` and require stdin. The new API requires no nexus internals — just `import nexus.fs`.

## Usage

```python
# Step 1: generate URL (bridge spins up localhost server first)
url, code_verifier = nexus.fs.generate_auth_url("google-drive", "http://localhost:4567/callback")

# Step 2: user visits url, bridge catches ?code= on the callback
code = await your_server.wait_for_callback()

# Step 3: exchange and store
await nexus.fs.exchange_auth_code(
    "google-drive", "user@example.com", code, "http://localhost:4567/callback"
)
# X requires code_verifier:
await nexus.fs.exchange_auth_code(
    "x", "user@example.com", code, "http://localhost:4567/callback",
    code_verifier=code_verifier,
)
```

## Test plan

- [ ] `generate_auth_url("google-drive", ...)` returns a valid Google authorization URL and `None` verifier
- [ ] `generate_auth_url("x", ...)` returns a valid X authorization URL and a non-empty PKCE verifier
- [ ] `generate_auth_url("unsupported", ...)` raises `ValueError` with supported provider list
- [ ] `exchange_auth_code("x", ..., code_verifier=None)` raises `ValueError`
- [ ] `nexus.fs.generate_auth_url` and `nexus.fs.exchange_auth_code` are accessible without importing `nexus.fs._oauth_support`
- [ ] CLI `nexus-fs auth connect --oauth` still works (interactive copy-paste flow unchanged)