### PR TITLE
chore: bump nexus-api-client and nexus-tui to 0.9.21

### DIFF
--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/api-client",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "description": "Shared HTTP client for Nexus APIs — retry, auth, error mapping, case transform",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/tui",
-  "version": "0.9.20",
+  "version": "0.9.21",
   "description": "Terminal UI for Nexus — file explorer, API inspector, and monitoring dashboard",
   "type": "module",
   "bin": {


### PR DESCRIPTION
Fixes the release workflow version check — `nexus-api-client` and `nexus-tui` package.json were missed in the v0.9.21 bump.