### PR TITLE
fix(gdrive): AuthenticationError on missing token + dispatch None kernel guard (nexus-fs 0.4.3, nexus-ai-fs 0.9.22)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "nexus_kernel"
-version = "0.9.21"
+version = "0.9.22"
 dependencies = [
  "ahash",
  "blake3",

--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/api-client",
-  "version": "0.9.21",
+  "version": "0.9.22",
   "description": "Shared HTTP client for Nexus APIs — retry, auth, error mapping, case transform",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/nexus-fs/pyproject.toml
+++ b/packages/nexus-fs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nexus-fs"
-version = "0.4.2"
+version = "0.4.3"
 description = "Unified filesystem abstraction for cloud storage — mount S3, GCS, and local storage with two lines of Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/tui",
-  "version": "0.9.21",
+  "version": "0.9.22",
   "description": "Terminal UI for Nexus — file explorer, API inspector, and monitoring dashboard",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.21"
+version = "0.9.22"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/nexus_kernel/Cargo.toml
+++ b/rust/nexus_kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus_kernel"
-version = "0.9.21"
+version = "0.9.22"
 edition = "2021"
 
 [lib]

--- a/rust/nexus_kernel/pyproject.toml
+++ b/rust/nexus_kernel/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-kernel"
-version = "0.9.21"
+version = "0.9.22"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
 requires-python = ">=3.12"
 classifiers = [

--- a/src/nexus/backends/connectors/gdrive/transport.py
+++ b/src/nexus/backends/connectors/gdrive/transport.py
@@ -30,7 +30,7 @@ from collections.abc import Iterator
 from copy import copy
 from typing import TYPE_CHECKING, Any
 
-from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
+from nexus.contracts.exceptions import AuthenticationError, BackendError, NexusFileNotFoundError
 
 if TYPE_CHECKING:
     from googleapiclient.discovery import Resource
@@ -166,6 +166,8 @@ class DriveTransport:
                     zone_id=zone_id,
                 )
             )
+        except AuthenticationError:
+            raise
         except Exception as e:
             raise BackendError(
                 f"Failed to get valid OAuth token for user {user_email}: {e}",

--- a/src/nexus/core/nexus_fs_dispatch.py
+++ b/src/nexus/core/nexus_fs_dispatch.py
@@ -143,6 +143,8 @@ class DispatchMixin:
 
     def _resolve(self, path: str, method: str, **kwargs: Any) -> tuple[bool, Any]:
         """Generic PRE-DISPATCH: trie lookup → fallback scan."""
+        if self._kernel is None:
+            return False, None
         idx = self._kernel.trie_lookup(path)
         if idx is not None:
             resolver = self._trie_resolvers.get(idx)

--- a/src/nexus/fs/__init__.py
+++ b/src/nexus/fs/__init__.py
@@ -17,7 +17,7 @@ All imports are lazy to keep ``import nexus.fs`` under 200ms.
 
 from __future__ import annotations
 
-__version__ = "0.4.2"
+__version__ = "0.4.3"
 
 # =============================================================================
 # LAZY IMPORTS — everything is deferred for <200ms import time


### PR DESCRIPTION
## Problem

Two bugs that blocked the gdrive OAuth path in the slim nexus-fs package, both reproducible from the installed wheel:

### Bug 1 — \`AttributeError: 'NoneType' object has no attribute 'trie_lookup'\`

\`DispatchMixin._resolve()\` called \`self._kernel.trie_lookup()\` unconditionally. For slim-package users without \`nexus_kernel\` installed, \`_kernel\` is \`None\` and every \`read()\`/\`write()\`/\`delete()\` call crashed before reaching the backend — completely blocking the gdrive path.

Every other \`self._kernel.*\` call in the dispatch mixin has a \`if self._kernel is not None\` guard (lines 182, 188, 332…); \`_resolve()\` was the only exception.

### Bug 2 — \`BackendError\` instead of \`AuthenticationError\` on missing token

\`DriveTransport._get_drive_service()\` wrapped all exceptions from \`token_manager.get_valid_token()\` in a generic \`BackendError\`. This swallowed the \`AuthenticationError\` (with \`provider\`, \`auth_url\` fields) that the token manager raises for a missing or expired credential. Callers had no way to distinguish an auth failure from a network or Drive API error.

## Fix

**\`nexus/core/nexus_fs_dispatch.py\`** — early-return \`(False, None)\` in \`_resolve()\` when \`_kernel is None\`, consistent with the existing guards throughout the mixin.

**\`nexus/backends/connectors/gdrive/transport.py\`** — add \`except AuthenticationError: raise\` before the broad \`except Exception → BackendError\` so auth errors propagate with their type intact.

## Versions

| Package | Before | After | Changed |
|---|---|---|---|
| nexus-fs | 0.4.2 | 0.4.3 | ✅ bug fixes above |
| nexus-ai-fs | 0.9.21 | 0.9.22 | ✅ bug fixes above |
| nexus-kernel (Cargo + pyproject) | 0.9.21 | 0.9.22 | ✅ coordinated bump |
| nexus-api-client | 0.9.21 | 0.9.22 | ➡️ no code changes — required by \`verify-version\` |
| nexus-tui | 0.9.21 | 0.9.22 | ➡️ no code changes — required by \`verify-version\` |

nexus-api-client and nexus-tui have no code changes. Their versions are bumped because the \`verify-version\` job in \`release.yml\` requires all five package versions to match the tag — this is intentional coordinated versioning across the monorepo.

## Test plan

- [ ] \`nexus.fs.mount('gdrive://my-drive')\` followed by \`fs.read(...)\` with no stored token raises \`AuthenticationError\` (not \`AttributeError\` or \`BackendError\`) on slim wheel without \`nexus_kernel\`
- [ ] Same path with \`nexus_kernel\` installed raises \`AuthenticationError\`
- [ ] Full nexus-ai-fs gdrive path unaffected — \`AuthenticationError\` still propagates correctly
- [ ] All other backends (s3, gcs, local) unaffected by dispatch guard change