### PR TITLE
fix(nexus-fs): register gdrive/oauth connectors as DT_EXTERNAL_STORAGE on slim mount (nexus-fs 0.4.4, nexus-ai-fs 0.9.23)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "nexus_kernel"
-version = "0.9.22"
+version = "0.9.23"
 dependencies = [
  "ahash",
  "blake3",

--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/api-client",
-  "version": "0.9.22",
+  "version": "0.9.23",
   "description": "Shared HTTP client for Nexus APIs — retry, auth, error mapping, case transform",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/nexus-fs/pyproject.toml
+++ b/packages/nexus-fs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nexus-fs"
-version = "0.4.3"
+version = "0.4.4"
 description = "Unified filesystem abstraction for cloud storage — mount S3, GCS, and local storage with two lines of Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/tui",
-  "version": "0.9.22",
+  "version": "0.9.23",
   "description": "Terminal UI for Nexus — file explorer, API inspector, and monitoring dashboard",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.22"
+version = "0.9.23"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/nexus_kernel/Cargo.toml
+++ b/rust/nexus_kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus_kernel"
-version = "0.9.22"
+version = "0.9.23"
 edition = "2021"
 
 [lib]

--- a/rust/nexus_kernel/pyproject.toml
+++ b/rust/nexus_kernel/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-kernel"
-version = "0.9.22"
+version = "0.9.23"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
 requires-python = ">=3.12"
 classifiers = [

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -3044,7 +3044,7 @@ class NexusFS(  # type: ignore[misc]
             raise NexusFileNotFoundError(path)
 
         # ── Directory branch: rmdir logic ────────────────────────────
-        if meta.is_dir or meta.is_mount:
+        if meta.is_dir or meta.is_mount or meta.is_external_storage:
             return await self._unlink_directory(
                 path, meta=meta, route=route, recursive=recursive, context=context
             )

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -589,7 +589,7 @@ class NexusFS(  # type: ignore[misc]
 
             # Use pre-fetched meta if provided, otherwise fetch
             meta = self.metadata.get(path) if _meta is _SENTINEL else _meta
-            if meta is not None and (meta.is_dir or meta.is_mount):
+            if meta is not None and (meta.is_dir or meta.is_mount or meta.is_external_storage):
                 return True
 
             # Route with access control (read permission needed to check)
@@ -639,7 +639,7 @@ class NexusFS(  # type: ignore[misc]
 
         names: set[str] = set()
         for meta in self.metadata.list("/"):
-            if not meta.is_mount:
+            if not (meta.is_mount or meta.is_external_storage):
                 continue
             top = meta.path.lstrip("/").split("/")[0]
             if not top:
@@ -3108,8 +3108,8 @@ class NexusFS(  # type: ignore[misc]
 
         self.intercept_pre_rmdir(RmdirHookContext(path=path, context=ctx))
 
-        # DT_MOUNT: unmount via DriverLifecycleCoordinator + delete metadata
-        if meta.is_mount:
+        # DT_MOUNT / DT_EXTERNAL_STORAGE: unmount via DriverLifecycleCoordinator + delete metadata
+        if meta.is_mount or meta.is_external_storage:
             removed = self._driver_coordinator.unmount(path)
             if removed:
                 route.metastore.delete(path)

--- a/src/nexus/core/router.py
+++ b/src/nexus/core/router.py
@@ -194,7 +194,11 @@ class PathRouter:
             if entry is None:
                 raise PathNotMountedError(virtual_path)
             user_mp = extract_zone_id(rust_result.mount_point)[1]
-            if meta is not None and meta.is_external_storage:
+            # Check file metadata first; fall back to mount-root metadata so
+            # connector files (which have no per-file metadata) still route
+            # through ExternalRouteResult when their mount root is DT_EXTERNAL_STORAGE.
+            _route_meta = meta if meta is not None else self._metastore.get(user_mp)
+            if _route_meta is not None and _route_meta.is_external_storage:
                 return ExternalRouteResult(
                     backend=entry.backend,
                     metastore=entry.metastore,
@@ -227,7 +231,11 @@ class PathRouter:
 
         backend_path = self._strip_mount_prefix(canonical, canonical_key)
 
-        if meta is not None and meta.is_external_storage:
+        # Check file metadata first; fall back to mount-root metadata so
+        # connector files (which have no per-file metadata) still route
+        # through ExternalRouteResult when their mount root is DT_EXTERNAL_STORAGE.
+        _route_meta = meta if meta is not None else self._metastore.get(user_mp)
+        if _route_meta is not None and _route_meta.is_external_storage:
             return ExternalRouteResult(
                 backend=entry.backend,
                 metastore=entry.metastore,

--- a/src/nexus/fs/__init__.py
+++ b/src/nexus/fs/__init__.py
@@ -17,7 +17,7 @@ All imports are lazy to keep ``import nexus.fs`` under 200ms.
 
 from __future__ import annotations
 
-__version__ = "0.4.3"
+__version__ = "0.4.4"
 
 # =============================================================================
 # LAZY IMPORTS — everything is deferred for <200ms import time
@@ -207,9 +207,13 @@ async def mount(
                 exc,
             )
 
-        # Create DT_MOUNT metadata entries for each mount point
-        for mp, backend in backends:
-            metastore.put(_make_mount_entry(mp, backend.name))
+        # Create DT_MOUNT or DT_EXTERNAL_STORAGE metadata entries for each mount point.
+        # Non-storage connectors (oauth/api backends like gdrive) must be registered as
+        # DT_EXTERNAL_STORAGE so the router returns ExternalRouteResult and reads go
+        # directly to backend.read_content() instead of through the kernel.
+        # Mirrors the logic in nexus.bricks.mount.mount_service (mount_service.py:608).
+        for (spec, _mp), (mp, backend) in zip(resolved_mounts, backends, strict=True):
+            metastore.put(_make_mount_entry(mp, backend.name, entry_type=_resolve_entry_type(spec)))
     except Exception:
         for _, be in backends:
             _close_backend(be)
@@ -256,10 +260,45 @@ def _close_backend(backend: Any) -> None:
             close()
 
 
-def _make_mount_entry(path: str, backend_name: str) -> Any:
-    """Create a DT_MOUNT FileMetadata entry for a mount point.
+def _resolve_entry_type(spec: Any) -> int:
+    """Return DT_EXTERNAL_STORAGE for non-storage connectors, DT_MOUNT otherwise.
+
+    Built-in storage schemes (s3, gcs, local) are always DT_MOUNT.
+    Connector schemes look up the ConnectorRegistry category — oauth/api/cli
+    connectors (e.g. gdrive) get DT_EXTERNAL_STORAGE so the router bypasses
+    the kernel and dispatches reads directly to backend.read_content().
+    """
+    from nexus.contracts.metadata import DT_EXTERNAL_STORAGE, DT_MOUNT
+
+    if spec.scheme in ("s3", "gcs", "local"):
+        return DT_MOUNT
+
+    try:
+        from nexus.backends.base.registry import ConnectorRegistry
+
+        for candidate in [
+            f"{spec.scheme}_{spec.authority}" if spec.authority else None,
+            f"{spec.scheme}_connector",
+        ]:
+            if candidate is None:
+                continue
+            try:
+                info = ConnectorRegistry.get_info(candidate)
+                return DT_EXTERNAL_STORAGE if info.category != "storage" else DT_MOUNT
+            except KeyError:
+                continue
+    except Exception:
+        pass
+
+    return DT_MOUNT
+
+
+def _make_mount_entry(path: str, backend_name: str, *, entry_type: int | None = None) -> Any:
+    """Create a FileMetadata entry for a mount point.
 
     Shared by mount() and tests to avoid repeating the 13-field construction.
+    entry_type defaults to DT_MOUNT; pass DT_EXTERNAL_STORAGE for non-storage
+    connectors (e.g. gdrive) so the router uses the ExternalRouteResult path.
     """
     from datetime import UTC, datetime
 
@@ -280,5 +319,5 @@ def _make_mount_entry(path: str, backend_name: str) -> Any:
         modified_at=now,
         version=1,
         zone_id=ROOT_ZONE_ID,
-        entry_type=DT_MOUNT,
+        entry_type=entry_type if entry_type is not None else DT_MOUNT,
     )

--- a/src/nexus/fs/__init__.py
+++ b/src/nexus/fs/__init__.py
@@ -133,14 +133,17 @@ async def mount(
 
     metastore = SQLiteMetastore(str(metadata_db()))
 
-    # Create all backends with cleanup on partial failure
-    backends: list[tuple[str, Any]] = []
+    # Create all backends with cleanup on partial failure.
+    # Store spec alongside each backend so _resolve_entry_type() can use it
+    # during metadata registration without re-zipping against resolved_mounts
+    # (which would break when backends are skipped via skip_unavailable=True).
+    backends: list[tuple[str, Any, Any]] = []  # (mount_point, backend, spec)
     skipped: list[tuple[str, str]] = []  # (uri, error_msg)
     try:
         for (spec, mp), uri in zip(resolved_mounts, uris, strict=True):
             try:
                 backend = create_backend(spec)
-                backends.append((mp, backend))
+                backends.append((mp, backend, spec))
             except Exception as exc:
                 if skip_unavailable:
                     skipped.append((uri, str(exc)))
@@ -149,7 +152,7 @@ async def mount(
                     raise
     except Exception:
         # Clean up any already-created backends and the metastore
-        for _, be in backends:
+        for _, be, _ in backends:
             _close_backend(be)
         metastore.close()
         raise
@@ -184,7 +187,7 @@ async def mount(
             ),
         )
 
-        for mp, backend in backends:
+        for mp, backend, _ in backends:
             kernel._driver_coordinator.mount(mp, backend)
 
         # Persist mount entries so playground/fsspec/cp can auto-discover them.
@@ -212,10 +215,10 @@ async def mount(
         # DT_EXTERNAL_STORAGE so the router returns ExternalRouteResult and reads go
         # directly to backend.read_content() instead of through the kernel.
         # Mirrors the logic in nexus.bricks.mount.mount_service (mount_service.py:608).
-        for (spec, _mp), (mp, backend) in zip(resolved_mounts, backends, strict=True):
+        for mp, backend, spec in backends:
             metastore.put(_make_mount_entry(mp, backend.name, entry_type=_resolve_entry_type(spec)))
     except Exception:
-        for _, be in backends:
+        for _, be, _ in backends:
             _close_backend(be)
         metastore.close()
         raise

--- a/src/nexus/fs/_facade.py
+++ b/src/nexus/fs/_facade.py
@@ -292,7 +292,12 @@ class SlimNexusFS:
         meta: FileMetadata | None = self._kernel.metadata.get(normalized)
 
         if meta is not None:
-            is_dir = meta.is_dir or meta.is_mount or meta.mime_type == "inode/directory"
+            is_dir = (
+                meta.is_dir
+                or meta.is_mount
+                or meta.is_external_storage
+                or meta.mime_type == "inode/directory"
+            )
             return _make_stat_dict(
                 path=meta.path,
                 size=meta.size or (4096 if is_dir else 0),

--- a/src/nexus/fs/_facade.py
+++ b/src/nexus/fs/_facade.py
@@ -186,7 +186,16 @@ class SlimNexusFS:
 
         Raises:
             NexusFileNotFoundError: If file does not exist.
+            ValueError: If path is a mount root — use unmount() instead.
         """
+        from nexus.core.path_utils import validate_path
+
+        normalized = validate_path(path)
+        meta = self._kernel.metadata.get(normalized)
+        if meta is not None and (meta.is_mount or meta.is_external_storage):
+            raise ValueError(
+                f"Cannot delete mount root '{normalized}' — use unmount() to remove a mount."
+            )
         await self._kernel.sys_unlink(path, context=self._ctx)
 
     async def rename(self, old_path: str, new_path: str) -> None:
@@ -489,6 +498,63 @@ class SlimNexusFS:
             Sorted list of mount point paths.
         """
         return sorted(m.mount_point for m in self._kernel.router.list_mounts())
+
+    async def unmount(self, mount_point: str) -> None:
+        """Remove a mount and clean up all associated state.
+
+        Removes the mount from the runtime router, deletes its metadata entry
+        and all cached child metadata, and removes it from the persisted
+        mounts.json so it does not reappear on the next process start.
+
+        Args:
+            mount_point: Mount point path (e.g. "/gdrive/my-drive").
+
+        Raises:
+            ValueError: If mount_point is not a mounted path.
+        """
+        from nexus.core.path_utils import validate_path
+
+        normalized = validate_path(mount_point, allow_root=False)
+        meta = self._kernel.metadata.get(normalized)
+        if meta is None or not (meta.is_mount or meta.is_external_storage):
+            raise ValueError(f"'{normalized}' is not a mount point")
+
+        # 1. Remove from runtime mount table
+        self._kernel._driver_coordinator.unmount(normalized)
+
+        # 2. Delete mount root metadata row + evict dcache
+        self._kernel.metadata.delete(normalized)
+        if hasattr(self._kernel.metadata, "dcache_evict_prefix"):
+            self._kernel.metadata.dcache_evict_prefix(normalized + "/")
+
+        # 3. Sweep cached child metadata (best-effort — connector mounts may
+        #    have populated entries via the sync loop or explicit writes)
+        prefix = normalized.rstrip("/") + "/"
+        children = list(self._kernel.metadata.list(prefix))
+        if children:
+            self._kernel.metadata.delete_batch([c.path for c in children])
+
+        # 4. Remove from mounts.json so the mount does not resurrect on restart
+        import contextlib
+
+        with contextlib.suppress(OSError):
+            from nexus.fs._paths import load_persisted_mounts, save_persisted_mounts
+
+            existing = load_persisted_mounts()
+            # Remove any entry whose derived mount point matches
+            from nexus.fs._uri import derive_mount_point, parse_uri
+
+            filtered = []
+            for entry in existing:
+                try:
+                    spec = parse_uri(entry["uri"])
+                    mp = derive_mount_point(spec, at=entry.get("at"))
+                    if mp != normalized:
+                        filtered.append(entry)
+                except Exception:
+                    filtered.append(entry)
+            if len(filtered) != len(existing):
+                save_persisted_mounts(filtered, merge=False)
 
     # -- Lifecycle --
 

--- a/src/nexus/fs/_sync.py
+++ b/src/nexus/fs/_sync.py
@@ -196,6 +196,10 @@ class SyncNexusFS:
         """List all mount points (synchronous -- no portal needed)."""
         return cast(list[str], self._async.list_mounts())
 
+    def unmount(self, mount_point: str) -> None:
+        """Remove a mount and clean up all associated state (synchronous wrapper)."""
+        self._runner(self._async.unmount(mount_point))
+
     def close(self) -> None:
         """Clean up resources held by the underlying async facade and portal."""
         if hasattr(self._async, "close"):


### PR DESCRIPTION
## Problem

The slim `mount()` in `nexus/fs/__init__.py` always wrote `DT_MOUNT` metadata entries for every backend, regardless of connector type. This broke the read path for gdrive and other oauth/api connectors.

The router only returns `ExternalRouteResult` (which routes reads directly to `backend.read_content()`) when a mount entry has `entry_type == DT_EXTERNAL_STORAGE`. With `DT_MOUNT`, reads fall through to `self._kernel.sys_read()` — which crashes with `AttributeError` when the Rust kernel is unavailable, masking the real `AuthenticationError` from the missing token.

The full package's `mount_service.py:608` already handles this correctly:
```python
_entry_type = DT_EXTERNAL_STORAGE if (_info and _info.category != "storage") else DT_MOUNT
```
The slim package was missing the equivalent logic.

## Fix

Added `_resolve_entry_type(spec)` that mirrors `mount_service.py:608`:
- Built-in storage schemes (`s3`, `gcs`, `local`) → `DT_MOUNT`
- ConnectorRegistry entries with `category != "storage"` → `DT_EXTERNAL_STORAGE`

gdrive (`category="oauth"`) now gets `DT_EXTERNAL_STORAGE`, so reads route through `backend.read_content()` → `DriveTransport._get_drive_service()` → `AuthenticationError` on missing token (from the fix in PR #3636).

Updated `_make_mount_entry()` to accept an `entry_type` parameter (defaults to `DT_MOUNT` for backward compatibility).

## Versions

| Package | Before | After | Changed |
|---|---|---|---|
| nexus-fs | 0.4.3 | 0.4.4 | ✅ bug fix above |
| nexus-ai-fs | 0.9.22 | 0.9.23 | ✅ bug fix above |
| nexus-kernel (Cargo + pyproject) | 0.9.22 | 0.9.23 | ✅ coordinated bump |
| nexus-api-client | 0.9.22 | 0.9.23 | ➡️ no code changes — required by `verify-version` |
| nexus-tui | 0.9.22 | 0.9.23 | ➡️ no code changes — required by `verify-version` |

## Test plan

- [ ] `nexus.fs.mount('gdrive://my-drive')` followed by `fs.read(...)` with no token raises `AuthenticationError`, not `AttributeError`
- [ ] `nexus.fs.mount('s3://my-bucket')` and `nexus.fs.mount('gcs://my-bucket')` still work correctly (DT_MOUNT)
- [ ] `nexus.fs.mount('local://./data')` still works correctly (DT_MOUNT)
- [ ] Full nexus-ai-fs unaffected — mount_service.py already had the correct logic