### PR TITLE
fix(gdrive): enrich AuthenticationError with provider and user_email (nexus-fs 0.4.5, nexus-ai-fs 0.9.24)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "nexus_kernel"
-version = "0.9.23"
+version = "0.9.24"
 dependencies = [
  "ahash",
  "blake3",

--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/api-client",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "Shared HTTP client for Nexus APIs — retry, auth, error mapping, case transform",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/nexus-fs/pyproject.toml
+++ b/packages/nexus-fs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nexus-fs"
-version = "0.4.4"
+version = "0.4.5"
 description = "Unified filesystem abstraction for cloud storage — mount S3, GCS, and local storage with two lines of Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/tui",
-  "version": "0.9.23",
+  "version": "0.9.24",
   "description": "Terminal UI for Nexus — file explorer, API inspector, and monitoring dashboard",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.23"
+version = "0.9.24"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/nexus_kernel/Cargo.toml
+++ b/rust/nexus_kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus_kernel"
-version = "0.9.23"
+version = "0.9.24"
 edition = "2021"
 
 [lib]

--- a/rust/nexus_kernel/pyproject.toml
+++ b/rust/nexus_kernel/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-kernel"
-version = "0.9.23"
+version = "0.9.24"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
 requires-python = ">=3.12"
 classifiers = [

--- a/src/nexus/backends/connectors/gdrive/transport.py
+++ b/src/nexus/backends/connectors/gdrive/transport.py
@@ -166,8 +166,12 @@ class DriveTransport:
                     zone_id=zone_id,
                 )
             )
-        except AuthenticationError:
-            raise
+        except AuthenticationError as _auth_exc:
+            raise AuthenticationError(
+                str(_auth_exc),
+                provider=self._provider,
+                user_email=user_email,
+            ) from _auth_exc
         except Exception as e:
             raise BackendError(
                 f"Failed to get valid OAuth token for user {user_email}: {e}",

--- a/src/nexus/fs/__init__.py
+++ b/src/nexus/fs/__init__.py
@@ -17,7 +17,7 @@ All imports are lazy to keep ``import nexus.fs`` under 200ms.
 
 from __future__ import annotations
 
-__version__ = "0.4.4"
+__version__ = "0.4.5"
 
 # =============================================================================
 # LAZY IMPORTS — everything is deferred for <200ms import time


### PR DESCRIPTION
## Problem

`token_manager.get_valid_token()` raises `AuthenticationError` with only a string message — the `provider` and `user_email` fields on the exception object are `None`. The transport's `except AuthenticationError: raise` passed it through bare.

Any downstream handler checking `e.provider` (the slim package CLI in `_auth_cli.py`, Koi's bridge calling `generate_auth_url(e.provider, redirect_uri)`) always received `None` and could not act on the error without parsing the message string.

## Fix

Re-raise with fields populated from the transport's own context:

\`\`\`python
except AuthenticationError as _auth_exc:
    raise AuthenticationError(
        str(_auth_exc),
        provider=self._provider,
        user_email=user_email,
    ) from _auth_exc
\`\`\`

## Affected packages

`nexus/backends/connectors/gdrive/transport.py` is included in both the slim nexus-fs wheel (`nexus/backends/**`) and the full nexus-ai-fs package — both benefit.

## Versions

| Package | Before | After |
|---|---|---|
| nexus-fs | 0.4.4 | 0.4.5 |
| nexus-ai-fs | 0.9.23 | 0.9.24 |
| nexus-kernel (Cargo + pyproject) | 0.9.23 | 0.9.24 |
| nexus-api-client | 0.9.23 | 0.9.24 ➡️ coordinated |
| nexus-tui | 0.9.23 | 0.9.24 ➡️ coordinated |

## Test plan

- [ ] `fs.read("/gdrive/...")` with no stored token raises `AuthenticationError` where `e.provider == "google-drive"` and `e.user_email` is set
- [ ] `e.auth_url` is `None` (bridge calls `generate_auth_url` itself using `e.provider`)