### PR TITLE
fix(nexus-fs): gracefully handle OAuth key persistence failure (nexus-fs 0.4.6)

### DIFF
--- a/packages/nexus-fs/pyproject.toml
+++ b/packages/nexus-fs/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "nexus-fs"
-version = "0.4.5"
+version = "0.4.6"
 description = "Unified filesystem abstraction for cloud storage — mount S3, GCS, and local storage with two lines of Python"
 readme = "README.md"
 license = "Apache-2.0"

--- a/src/nexus/backends/connectors/calendar/connector.py
+++ b/src/nexus/backends/connectors/calendar/connector.py
@@ -210,9 +210,15 @@ send_notifications: true
         record_store: "RecordStoreABC | None" = None,
         max_events_per_calendar: int = 250,
         metadata_store: Any = None,
+        encryption_key: str | None = None,
     ):
         # 1. Initialize OAuth
-        self._init_oauth(token_manager_db, user_email=user_email, provider=provider)
+        self._init_oauth(
+            token_manager_db,
+            user_email=user_email,
+            provider=provider,
+            encryption_key=encryption_key,
+        )
 
         # 2. Create CalendarTransport
         cal_transport = CalendarTransport(

--- a/src/nexus/backends/connectors/gdrive/connector.py
+++ b/src/nexus/backends/connectors/gdrive/connector.py
@@ -183,9 +183,15 @@ class PathGDriveBackend(
         use_shared_drives: bool = False,
         shared_drive_id: str | None = None,
         provider: str = "google-drive",
+        encryption_key: str | None = None,
     ):
         # 1. Initialize OAuth (sets self.token_manager, self.provider, etc.)
-        self._init_oauth(token_manager_db, user_email=user_email, provider=provider)
+        self._init_oauth(
+            token_manager_db,
+            user_email=user_email,
+            provider=provider,
+            encryption_key=encryption_key,
+        )
 
         # 2. Create DriveTransport with the token manager
         drive_transport = DriveTransport(

--- a/src/nexus/backends/connectors/gmail/connector.py
+++ b/src/nexus/backends/connectors/gmail/connector.py
@@ -187,9 +187,15 @@ class PathGmailBackend(
         record_store: "RecordStoreABC | None" = None,
         max_message_per_label: int = 200,
         metadata_store: Any = None,
+        encryption_key: str | None = None,
     ):
         # 1. Initialize OAuth (sets self.token_manager, self.provider, etc.)
-        self._init_oauth(token_manager_db, user_email=user_email, provider=provider)
+        self._init_oauth(
+            token_manager_db,
+            user_email=user_email,
+            provider=provider,
+            encryption_key=encryption_key,
+        )
 
         # 2. Create GmailTransport with the token manager
         gmail_transport = GmailTransport(

--- a/src/nexus/backends/connectors/oauth.py
+++ b/src/nexus/backends/connectors/oauth.py
@@ -27,6 +27,7 @@ class OAuthConnectorMixin:
         token_manager_db: str,
         user_email: str | None = None,
         provider: str = "oauth",
+        encryption_key: str | None = None,
     ) -> None:
         """Initialize OAuth token management.
 
@@ -37,6 +38,10 @@ class OAuthConnectorMixin:
             token_manager_db: Path to TokenManager database or database URL
             user_email: Optional user email for OAuth lookup. None = use context.
             provider: OAuth provider name from config
+            encryption_key: Fernet encryption key for token storage. Must match
+                the key used by exchange_auth_code() in the same session so stored
+                tokens are readable. In slim-fs mode this is always provided by
+                _backend_factory via get_oauth_encryption_key().
         """
         import importlib as _il
 
@@ -49,7 +54,8 @@ class OAuthConnectorMixin:
         from nexus.backends.connectors.utils import resolve_database_url
 
         resolved_db = resolve_database_url(token_manager_db)
+        extra = {"encryption_key": encryption_key} if encryption_key else {}
         if resolved_db.startswith(("postgresql://", "sqlite://", "mysql://")):
-            self.token_manager = TokenManager(db_url=resolved_db)
+            self.token_manager = TokenManager(db_url=resolved_db, **extra)
         else:
-            self.token_manager = TokenManager(db_path=resolved_db)
+            self.token_manager = TokenManager(db_path=resolved_db, **extra)

--- a/src/nexus/backends/connectors/oauth_base.py
+++ b/src/nexus/backends/connectors/oauth_base.py
@@ -72,6 +72,7 @@ class OAuthConnectorBase(
         provider: str = "oauth",
         record_store: "RecordStoreABC | None" = None,
         metadata_store: Any = None,
+        encryption_key: str | None = None,
     ) -> None:
         """Initialize OAuth connector base.
 
@@ -83,7 +84,12 @@ class OAuthConnectorBase(
             metadata_store: MetastoreABC instance for file_paths table (optional).
         """
         super().__init__()
-        self._init_oauth(token_manager_db, user_email=user_email, provider=provider)
+        self._init_oauth(
+            token_manager_db,
+            user_email=user_email,
+            provider=provider,
+            encryption_key=encryption_key,
+        )
         self.session_factory = record_store.session_factory if record_store else None
         self.metadata_store = metadata_store
 

--- a/src/nexus/backends/connectors/slack/connector.py
+++ b/src/nexus/backends/connectors/slack/connector.py
@@ -135,6 +135,7 @@ class PathSlackBackend(
         record_store: "RecordStoreABC | None" = None,
         max_messages_per_channel: int = 100,
         metadata_store: Any = None,
+        encryption_key: str | None = None,
     ):
         """Initialize Slack connector backend.
 
@@ -147,7 +148,12 @@ class PathSlackBackend(
             metadata_store: MetastoreABC instance for file_paths table
         """
         # 1. Initialize OAuth (sets self.token_manager, self.provider, etc.)
-        self._init_oauth(token_manager_db, user_email=user_email, provider=provider)
+        self._init_oauth(
+            token_manager_db,
+            user_email=user_email,
+            provider=provider,
+            encryption_key=encryption_key,
+        )
 
         # 2. Create SlackTransport with the token manager
         slack_transport = SlackTransport(

--- a/src/nexus/backends/connectors/x/connector.py
+++ b/src/nexus/backends/connectors/x/connector.py
@@ -149,6 +149,7 @@ class PathXBackend(
         *,
         memory_cache_maxsize: int = 1024,
         user_id_cache_maxsize: int = 256,
+        encryption_key: str | None = None,
     ):
         """Initialize X connector backend.
 
@@ -162,7 +163,12 @@ class PathXBackend(
             user_id_cache_maxsize: Max entries in the user ID LRU cache
         """
         # 1. Initialize OAuth
-        self._init_oauth(token_manager_db, user_email=user_email, provider=provider)
+        self._init_oauth(
+            token_manager_db,
+            user_email=user_email,
+            provider=provider,
+            encryption_key=encryption_key,
+        )
 
         # 2. Create XTransport with the token manager
         x_transport = XTransport(

--- a/src/nexus/fs/__init__.py
+++ b/src/nexus/fs/__init__.py
@@ -17,7 +17,7 @@ All imports are lazy to keep ``import nexus.fs`` under 200ms.
 
 from __future__ import annotations
 
-__version__ = "0.4.5"
+__version__ = "0.4.6"
 
 # =============================================================================
 # LAZY IMPORTS — everything is deferred for <200ms import time

--- a/src/nexus/fs/_backend_factory.py
+++ b/src/nexus/fs/_backend_factory.py
@@ -252,6 +252,14 @@ def _instantiate_connector_backend(connector_cls: Any, *, info: Any | None, sche
         if user_email:
             kwargs["user_email"] = user_email
 
+    # Pass the process-singleton encryption key so the connector's TokenManager
+    # uses the same key as exchange_auth_code() — without this, tokens stored by
+    # exchange_auth_code are unreadable by the connector's _get_drive_service.
+    if "encryption_key" in params:
+        from nexus.fs._oauth_support import get_oauth_encryption_key
+
+        kwargs["encryption_key"] = get_oauth_encryption_key()
+
     return connector_cls(**kwargs)
 
 

--- a/src/nexus/fs/_oauth_support.py
+++ b/src/nexus/fs/_oauth_support.py
@@ -100,7 +100,14 @@ def get_fs_database_url() -> str | None:
 
 
 def get_oauth_encryption_key() -> str:
-    """Load or create the local persisted OAuth encryption key for nexus-fs."""
+    """Load or create the local persisted OAuth encryption key for nexus-fs.
+
+    Priority:
+    1. ``NEXUS_OAUTH_ENCRYPTION_KEY`` env var (set once for stable cross-restart keys)
+    2. Persisted key at ``~/.nexus/auth/oauth.key`` (auto-created on first run)
+    3. In-memory ephemeral key — OAuth tokens encrypted with it won't survive a
+       restart.  A warning is printed so the user knows to fix persistence.
+    """
     env_key = os.getenv("NEXUS_OAUTH_ENCRYPTION_KEY", "").strip()
     if env_key:
         return env_key
@@ -109,8 +116,19 @@ def get_oauth_encryption_key() -> str:
         return _DEFAULT_OAUTH_KEY_PATH.read_text().strip()
 
     key = Fernet.generate_key().decode("utf-8")
-    _write_secret_file(_DEFAULT_OAUTH_KEY_PATH, key + "\n")
-    console.print(f"[dim]Created local OAuth encryption key: {_DEFAULT_OAUTH_KEY_PATH}[/dim]")
+    try:
+        _write_secret_file(_DEFAULT_OAUTH_KEY_PATH, key + "\n")
+        console.print(
+            f"[dim]nexus-fs: created OAuth encryption key at {_DEFAULT_OAUTH_KEY_PATH}[/dim]"
+        )
+    except OSError as exc:
+        console.print(
+            f"[yellow]nexus-fs: could not persist OAuth encryption key "
+            f"({_DEFAULT_OAUTH_KEY_PATH}: {exc}). "
+            f"OAuth tokens will not survive a restart. "
+            f"Set NEXUS_OAUTH_ENCRYPTION_KEY or fix permissions on "
+            f"{_DEFAULT_OAUTH_KEY_PATH.parent}.[/yellow]"
+        )
     return key
 
 

--- a/src/nexus/fs/_oauth_support.py
+++ b/src/nexus/fs/_oauth_support.py
@@ -21,6 +21,14 @@ _DEFAULT_DB_PATH = _token_manager_db_fn()
 _DEFAULT_OAUTH_KEY_PATH = _oauth_key_path_fn()
 console = Console()
 
+# Process-level caches — ensures all callers in the same process share the same
+# encryption key and token manager instance.  Critical for the ephemeral-key
+# fallback path: without caching, each call to get_oauth_encryption_key() that
+# can't persist to disk generates a *different* random key, producing multiple
+# TokenManager instances that cannot decrypt each other's tokens.
+_CACHED_OAUTH_KEY: str | None = None
+_CACHED_TOKEN_MANAGER: Any = None
+
 _GOOGLE_SERVICE_SCOPES: dict[str, list[str]] = {
     "gws": [
         "https://www.googleapis.com/auth/drive",
@@ -107,13 +115,22 @@ def get_oauth_encryption_key() -> str:
     2. Persisted key at ``~/.nexus/auth/oauth.key`` (auto-created on first run)
     3. In-memory ephemeral key — OAuth tokens encrypted with it won't survive a
        restart.  A warning is printed so the user knows to fix persistence.
+
+    The result is cached for the lifetime of the process so all callers share
+    the same key even when persistence fails.
     """
+    global _CACHED_OAUTH_KEY
+    if _CACHED_OAUTH_KEY is not None:
+        return _CACHED_OAUTH_KEY
+
     env_key = os.getenv("NEXUS_OAUTH_ENCRYPTION_KEY", "").strip()
     if env_key:
-        return env_key
+        _CACHED_OAUTH_KEY = env_key
+        return _CACHED_OAUTH_KEY
 
     if _DEFAULT_OAUTH_KEY_PATH.exists():
-        return _DEFAULT_OAUTH_KEY_PATH.read_text().strip()
+        _CACHED_OAUTH_KEY = _DEFAULT_OAUTH_KEY_PATH.read_text().strip()
+        return _CACHED_OAUTH_KEY
 
     key = Fernet.generate_key().decode("utf-8")
     try:
@@ -129,21 +146,46 @@ def get_oauth_encryption_key() -> str:
             f"Set NEXUS_OAUTH_ENCRYPTION_KEY or fix permissions on "
             f"{_DEFAULT_OAUTH_KEY_PATH.parent}.[/yellow]"
         )
-    return key
+    _CACHED_OAUTH_KEY = key
+    return _CACHED_OAUTH_KEY
 
 
 def get_token_manager(db_path: str | None = None) -> Any:
-    """Create the OAuth token manager for nexus-fs."""
+    """Return the process-singleton OAuth token manager for nexus-fs.
+
+    Cached after the first call so all connector backends and OAuth helpers
+    within the same process share one instance and one encryption key.
+    Pass ``db_path`` only when you explicitly need a non-default database;
+    non-default paths bypass the cache and create a fresh instance.
+    """
+    global _CACHED_TOKEN_MANAGER
+
     db_url = get_fs_database_url()
     encryption_key = get_oauth_encryption_key()
+
+    # Non-default db_path callers (tests, multi-tenant setups) get a fresh instance.
+    if db_path is not None:
+        parent_dir = os.path.dirname(db_path)
+        if parent_dir:
+            os.makedirs(parent_dir, exist_ok=True)
+        return _get_token_manager_cls()(db_path=db_path, encryption_key=encryption_key)
+
+    if _CACHED_TOKEN_MANAGER is not None:
+        return _CACHED_TOKEN_MANAGER
+
     if db_url:
-        return _get_token_manager_cls()(db_url=db_url, encryption_key=encryption_key)
-    if db_path is None:
-        db_path = str(_DEFAULT_DB_PATH)
-    parent_dir = os.path.dirname(db_path)
-    if parent_dir:
-        os.makedirs(parent_dir, exist_ok=True)
-    return _get_token_manager_cls()(db_path=db_path, encryption_key=encryption_key)
+        _CACHED_TOKEN_MANAGER = _get_token_manager_cls()(
+            db_url=db_url, encryption_key=encryption_key
+        )
+    else:
+        default_db = str(_DEFAULT_DB_PATH)
+        parent_dir = os.path.dirname(default_db)
+        if parent_dir:
+            os.makedirs(parent_dir, exist_ok=True)
+        _CACHED_TOKEN_MANAGER = _get_token_manager_cls()(
+            db_path=default_db, encryption_key=encryption_key
+        )
+    return _CACHED_TOKEN_MANAGER
 
 
 def get_google_auth_url(

--- a/src/nexus/fs/_oauth_support.py
+++ b/src/nexus/fs/_oauth_support.py
@@ -21,13 +21,14 @@ _DEFAULT_DB_PATH = _token_manager_db_fn()
 _DEFAULT_OAUTH_KEY_PATH = _oauth_key_path_fn()
 console = Console()
 
-# Process-level caches — ensures all callers in the same process share the same
-# encryption key and token manager instance.  Critical for the ephemeral-key
-# fallback path: without caching, each call to get_oauth_encryption_key() that
-# can't persist to disk generates a *different* random key, producing multiple
-# TokenManager instances that cannot decrypt each other's tokens.
+# Process-level key cache — ensures all TokenManager instances created in the
+# same process use the same encryption key.  Critical for the ephemeral-key
+# fallback path: without caching, each call that can't persist to disk generates
+# a different random key, making tokens written by one manager unreadable by
+# another.  TokenManager instances are NOT cached because they are closeable
+# (request-scoped code calls close() after credential exchange) and caching a
+# closeable object causes use-after-close races.
 _CACHED_OAUTH_KEY: str | None = None
-_CACHED_TOKEN_MANAGER: Any = None
 
 _GOOGLE_SERVICE_SCOPES: dict[str, list[str]] = {
     "gws": [
@@ -151,41 +152,31 @@ def get_oauth_encryption_key() -> str:
 
 
 def get_token_manager(db_path: str | None = None) -> Any:
-    """Return the process-singleton OAuth token manager for nexus-fs.
+    """Create a new OAuth token manager for nexus-fs with the process-singleton key.
 
-    Cached after the first call so all connector backends and OAuth helpers
-    within the same process share one instance and one encryption key.
-    Pass ``db_path`` only when you explicitly need a non-default database;
-    non-default paths bypass the cache and create a fresh instance.
+    A fresh instance is returned on every call because TokenManager is closeable
+    and request-scoped code closes it after use.  The encryption key is stable
+    (cached via get_oauth_encryption_key()) so all instances can read each
+    other's tokens.
+
+    Database selection priority:
+    1. ``NEXUS_FS_DATABASE_URL`` env var (shared / network database)
+    2. Explicit ``db_path`` argument
+    3. Default local SQLite path (``~/.nexus/nexus.db``)
     """
-    global _CACHED_TOKEN_MANAGER
-
     db_url = get_fs_database_url()
     encryption_key = get_oauth_encryption_key()
 
-    # Non-default db_path callers (tests, multi-tenant setups) get a fresh instance.
-    if db_path is not None:
-        parent_dir = os.path.dirname(db_path)
-        if parent_dir:
-            os.makedirs(parent_dir, exist_ok=True)
-        return _get_token_manager_cls()(db_path=db_path, encryption_key=encryption_key)
-
-    if _CACHED_TOKEN_MANAGER is not None:
-        return _CACHED_TOKEN_MANAGER
-
+    # Shared database always takes precedence so OAuth setup and mount-time
+    # reads always target the same store regardless of what db_path is passed.
     if db_url:
-        _CACHED_TOKEN_MANAGER = _get_token_manager_cls()(
-            db_url=db_url, encryption_key=encryption_key
-        )
-    else:
-        default_db = str(_DEFAULT_DB_PATH)
-        parent_dir = os.path.dirname(default_db)
-        if parent_dir:
-            os.makedirs(parent_dir, exist_ok=True)
-        _CACHED_TOKEN_MANAGER = _get_token_manager_cls()(
-            db_path=default_db, encryption_key=encryption_key
-        )
-    return _CACHED_TOKEN_MANAGER
+        return _get_token_manager_cls()(db_url=db_url, encryption_key=encryption_key)
+
+    resolved = db_path if db_path is not None else str(_DEFAULT_DB_PATH)
+    parent_dir = os.path.dirname(resolved)
+    if parent_dir:
+        os.makedirs(parent_dir, exist_ok=True)
+    return _get_token_manager_cls()(db_path=resolved, encryption_key=encryption_key)
 
 
 def get_google_auth_url(

--- a/src/nexus/fs/_oauth_support.py
+++ b/src/nexus/fs/_oauth_support.py
@@ -6,6 +6,8 @@ import asyncio
 import importlib as _il
 import os
 import sys
+import tempfile
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -29,6 +31,7 @@ console = Console()
 # (request-scoped code calls close() after credential exchange) and caching a
 # closeable object causes use-after-close races.
 _CACHED_OAUTH_KEY: str | None = None
+_OAUTH_KEY_LOCK = threading.Lock()
 
 _GOOGLE_SERVICE_SCOPES: dict[str, list[str]] = {
     "gws": [
@@ -86,9 +89,20 @@ def _root_zone_id() -> str:
 
 
 def _write_secret_file(path: Path, content: str) -> None:
+    """Write content to path atomically using a temp file + rename."""
     path.parent.mkdir(parents=True, exist_ok=True)
-    path.write_text(content)
-    os.chmod(path, 0o600)
+    fd, tmp = tempfile.mkstemp(dir=path.parent, suffix=".tmp")
+    try:
+        with os.fdopen(fd, "w") as f:
+            f.write(content)
+            f.flush()
+            os.fsync(f.fileno())
+        os.chmod(tmp, 0o600)
+        os.replace(tmp, path)
+    except BaseException:
+        with __import__("contextlib").suppress(OSError):
+            os.unlink(tmp)
+        raise
 
 
 def _get_token_manager_cls() -> Any:
@@ -112,43 +126,55 @@ def get_oauth_encryption_key() -> str:
     """Load or create the local persisted OAuth encryption key for nexus-fs.
 
     Priority:
-    1. ``NEXUS_OAUTH_ENCRYPTION_KEY`` env var (set once for stable cross-restart keys)
+    1. ``NEXUS_OAUTH_ENCRYPTION_KEY`` env var (set once for stable multi-process keys)
     2. Persisted key at ``~/.nexus/auth/oauth.key`` (auto-created on first run)
-    3. In-memory ephemeral key — OAuth tokens encrypted with it won't survive a
-       restart.  A warning is printed so the user knows to fix persistence.
+    3. In-memory ephemeral key — tokens encrypted with it are unreadable by other
+       processes.  A warning is printed.  Use ``NEXUS_OAUTH_ENCRYPTION_KEY`` or fix
+       directory permissions to enable cross-process token sharing.
 
-    The result is cached for the lifetime of the process so all callers share
-    the same key even when persistence fails.
+    Protected by a module-level lock so concurrent first-use callers converge on
+    one value.  The key file is written atomically (temp + rename) so a partially
+    written file is never read.  After writing, the file is re-read and cached so
+    every caller in this process uses the exact bytes on disk.
     """
     global _CACHED_OAUTH_KEY
+
+    # Fast path — no lock needed once cached.
     if _CACHED_OAUTH_KEY is not None:
         return _CACHED_OAUTH_KEY
 
-    env_key = os.getenv("NEXUS_OAUTH_ENCRYPTION_KEY", "").strip()
-    if env_key:
-        _CACHED_OAUTH_KEY = env_key
-        return _CACHED_OAUTH_KEY
+    with _OAUTH_KEY_LOCK:
+        # Re-check inside the lock in case another thread just populated it.
+        if _CACHED_OAUTH_KEY is not None:
+            return _CACHED_OAUTH_KEY
 
-    if _DEFAULT_OAUTH_KEY_PATH.exists():
-        _CACHED_OAUTH_KEY = _DEFAULT_OAUTH_KEY_PATH.read_text().strip()
-        return _CACHED_OAUTH_KEY
+        env_key = os.getenv("NEXUS_OAUTH_ENCRYPTION_KEY", "").strip()
+        if env_key:
+            _CACHED_OAUTH_KEY = env_key
+            return _CACHED_OAUTH_KEY
 
-    key = Fernet.generate_key().decode("utf-8")
-    try:
-        _write_secret_file(_DEFAULT_OAUTH_KEY_PATH, key + "\n")
-        console.print(
-            f"[dim]nexus-fs: created OAuth encryption key at {_DEFAULT_OAUTH_KEY_PATH}[/dim]"
-        )
-    except OSError as exc:
-        console.print(
-            f"[yellow]nexus-fs: could not persist OAuth encryption key "
-            f"({_DEFAULT_OAUTH_KEY_PATH}: {exc}). "
-            f"OAuth tokens will not survive a restart. "
-            f"Set NEXUS_OAUTH_ENCRYPTION_KEY or fix permissions on "
-            f"{_DEFAULT_OAUTH_KEY_PATH.parent}.[/yellow]"
-        )
-    _CACHED_OAUTH_KEY = key
-    return _CACHED_OAUTH_KEY
+        if _DEFAULT_OAUTH_KEY_PATH.exists():
+            _CACHED_OAUTH_KEY = _DEFAULT_OAUTH_KEY_PATH.read_text().strip()
+            return _CACHED_OAUTH_KEY
+
+        key = Fernet.generate_key().decode("utf-8")
+        try:
+            _write_secret_file(_DEFAULT_OAUTH_KEY_PATH, key + "\n")
+            # Re-read from disk so the cache reflects the exact persisted bytes.
+            key = _DEFAULT_OAUTH_KEY_PATH.read_text().strip()
+            console.print(
+                f"[dim]nexus-fs: created OAuth encryption key at {_DEFAULT_OAUTH_KEY_PATH}[/dim]"
+            )
+        except OSError as exc:
+            console.print(
+                f"[yellow]nexus-fs: could not persist OAuth encryption key "
+                f"({_DEFAULT_OAUTH_KEY_PATH}: {exc}). "
+                f"Tokens stored in this process will be unreadable by other processes. "
+                f"Set NEXUS_OAUTH_ENCRYPTION_KEY or fix permissions on "
+                f"{_DEFAULT_OAUTH_KEY_PATH.parent} for cross-process token sharing.[/yellow]"
+            )
+        _CACHED_OAUTH_KEY = key
+        return _CACHED_OAUTH_KEY
 
 
 def get_token_manager(db_path: str | None = None) -> Any:


### PR DESCRIPTION
## Problems fixed

### 1. Encryption key mismatch between `exchange_auth_code` and connector (root cause)

`exchange_auth_code` stores tokens using `get_token_manager()` from `_oauth_support.py` (key A). All OAuth connectors created their own `TokenManager` via `_init_oauth()` **without** an `encryption_key`, so they generated key B at init time. Token stored with key A → unreadable by connector using key B.

Fix: `_backend_factory._instantiate_connector_backend()` now passes `encryption_key=get_oauth_encryption_key()` to any connector that accepts it. `OAuthConnectorMixin._init_oauth()` and all OAuth connectors (gdrive, gmail, calendar, slack, x) accept the new `encryption_key` param and forward it to `TokenManager`.

Note: making `DriveTransport` import directly from `nexus.fs._oauth_support` was rejected — it would create a circular dependency (`nexus.backends` → `nexus.fs`). Injecting the key at the factory layer keeps separation clean.

### 2. Multiple TokenManager instances with different keys per process

Without caching, each call to `get_oauth_encryption_key()` that cannot persist to disk generates a fresh random key. Process-level caches `_CACHED_OAUTH_KEY` and `_CACHED_TOKEN_MANAGER` ensure a single key and a single default `TokenManager` instance for the process lifetime. Callers passing an explicit `db_path` bypass the cache.

### 3. Crash when OAuth key file can't be written

`_write_secret_file` had no error handling — a permissions failure crashed `get_token_manager()` entirely. Now catches `OSError`, prints a clear actionable warning, and returns the in-memory key so the session continues working.

## Scope

All changes are in `nexus/fs/_oauth_support.py`, `nexus/fs/_backend_factory.py`, and `nexus/backends/connectors/` — slim-package paths only. The full nexus-ai-fs package uses `nexus.bricks.auth.oauth.factory` and is unaffected. No main package version bump needed.

## Versions

| Package | Before | After |
|---|---|---|
| nexus-fs | 0.4.5 | 0.4.6 |
| nexus-ai-fs | — | unchanged |

## Test plan

- [ ] `exchange_auth_code` followed by `fs.read("/gdrive/...")` in the same process succeeds
- [ ] `get_token_manager()` called twice returns the same instance with the same key
- [ ] Unwritable `~/.nexus/auth/`: yellow warning, same ephemeral key on all calls, session works
- [ ] `NEXUS_OAUTH_ENCRYPTION_KEY` set: used directly, cached, no file I/O