### PR TITLE
fix(rpc-proxy): block close() from being proxied as a remote RPC call (nexus-ai-fs 0.9.25)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "nexus_kernel"
-version = "0.9.24"
+version = "0.9.25"
 dependencies = [
  "ahash",
  "blake3",

--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/api-client",
-  "version": "0.9.24",
+  "version": "0.9.25",
   "description": "Shared HTTP client for Nexus APIs — retry, auth, error mapping, case transform",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/tui",
-  "version": "0.9.24",
+  "version": "0.9.25",
   "description": "Terminal UI for Nexus — file explorer, API inspector, and monitoring dashboard",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.24"
+version = "0.9.25"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/nexus_kernel/Cargo.toml
+++ b/rust/nexus_kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus_kernel"
-version = "0.9.24"
+version = "0.9.25"
 edition = "2021"
 
 [lib]

--- a/rust/nexus_kernel/pyproject.toml
+++ b/rust/nexus_kernel/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-kernel"
-version = "0.9.24"
+version = "0.9.25"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
 requires-python = ">=3.12"
 classifiers = [

--- a/src/nexus/remote/rpc_proxy.py
+++ b/src/nexus/remote/rpc_proxy.py
@@ -27,6 +27,7 @@ _INTERNAL_ATTRS = frozenset(
         "connect_timeout",
         "session",
         "max_retries",
+        "close",  # local lifecycle method — must not be proxied as an RPC call
     }
 )
 
@@ -49,6 +50,16 @@ class RPCProxyBase:
 
     # Cache for ABC method parameter names (class-level)
     _param_name_cache: dict[str, list[str]] = {}
+
+    def close(self) -> None:
+        """Local lifecycle method — close any underlying transport/session.
+
+        Subclasses should override to release resources.  The base
+        implementation is a no-op so that callers can safely call close()
+        without knowing whether the proxy has resources to release.
+        ``close`` must not be proxied as a remote RPC call (it is listed in
+        _INTERNAL_ATTRS for that reason).
+        """
 
     def _call_rpc(
         self,


### PR DESCRIPTION
## Problem

`__getattr__` in `RPCProxyBase` intercepted `proxy.close()` and dispatched it as `call_rpc('close', ...)`. The server has no `close` RPC method, so it returned:

```
RPCTransport RPC error: close — Invalid parameters: Unknown method: close
```

This caused docker publish integration tests (rebac demo) to fail with exit code 1.

## Fix

- Add `"close"` to `_INTERNAL_ATTRS` so `__getattr__` never intercepts it
- Add a no-op `close()` method to `RPCProxyBase` so callers can safely call `close()` — subclasses that hold real resources should override it

## Scope

`nexus/remote/rpc_proxy.py` is excluded from the nexus-fs slim wheel — nexus-ai-fs only. No nexus-fs version bump needed.

## Versions

| Package | Before | After |
|---|---|---|
| nexus-ai-fs | 0.9.24 | 0.9.25 |
| nexus-kernel | 0.9.24 | 0.9.25 |
| nexus-api-client | 0.9.24 | 0.9.25 ➡️ coordinated |
| nexus-tui | 0.9.24 | 0.9.25 ➡️ coordinated |
| nexus-fs | — | unchanged |

## Test plan

- [ ] Docker publish integration test passes (rebac demo no longer errors on close)
- [ ] `proxy.close()` on an `RPCProxyBase` instance is a no-op (no RPC call made)