### PR TITLE
fix(docker): default NEXUS_ADVERTISE_ADDR to 127.0.0.1 to fix single-node startup crash (nexus-ai-fs 0.9.26)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1276,7 +1276,7 @@ dependencies = [
 
 [[package]]
 name = "nexus_kernel"
-version = "0.9.25"
+version = "0.9.26"
 dependencies = [
  "ahash",
  "blake3",

--- a/nexus-stack.yml
+++ b/nexus-stack.yml
@@ -125,6 +125,10 @@ services:
       NEXUS_GRPC_PORT: "${NEXUS_GRPC_PORT:-2028}"
       NEXUS_GRPC_BIND_ALL: "true"  # Required: Docker port-forwarding needs 0.0.0.0
       NEXUS_GRPC_TLS: "${NEXUS_GRPC_TLS:-false}"  # Disable mTLS for standalone Docker (Issue #3192)
+      # 0.0.0.0 is a valid bind address but not a valid connect/advertise address.
+      # Without this, NEXUS_ADVERTISE_ADDR defaults to 0.0.0.0 which fails the
+      # insecure-channel loopback check when pipe_manager connects back to itself.
+      NEXUS_ADVERTISE_ADDR: "127.0.0.1:${NEXUS_GRPC_PORT:-2028}"
       # Runtime
       NEXUS_USE_UVLOOP: ${NEXUS_USE_UVLOOP:-true}
     volumes:

--- a/nexus-stack.yml
+++ b/nexus-stack.yml
@@ -126,9 +126,10 @@ services:
       NEXUS_GRPC_BIND_ALL: "true"  # Required: Docker port-forwarding needs 0.0.0.0
       NEXUS_GRPC_TLS: "${NEXUS_GRPC_TLS:-false}"  # Disable mTLS for standalone Docker (Issue #3192)
       # 0.0.0.0 is a valid bind address but not a valid connect/advertise address.
-      # Without this, NEXUS_ADVERTISE_ADDR defaults to 0.0.0.0 which fails the
-      # insecure-channel loopback check when pipe_manager connects back to itself.
-      NEXUS_ADVERTISE_ADDR: "127.0.0.1:${NEXUS_GRPC_PORT:-2028}"
+      # Without an explicit NEXUS_ADVERTISE_ADDR, the node would advertise 0.0.0.0
+      # which fails the insecure-channel loopback check in pipe_manager.
+      # Default to 127.0.0.1 for single-node; override for federation/cross-container.
+      NEXUS_ADVERTISE_ADDR: "${NEXUS_ADVERTISE_ADDR:-127.0.0.1:${NEXUS_GRPC_PORT:-2028}}"
       # Runtime
       NEXUS_USE_UVLOOP: ${NEXUS_USE_UVLOOP:-true}
     volumes:

--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/api-client",
-  "version": "0.9.25",
+  "version": "0.9.26",
   "description": "Shared HTTP client for Nexus APIs — retry, auth, error mapping, case transform",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/tui",
-  "version": "0.9.25",
+  "version": "0.9.26",
   "description": "Terminal UI for Nexus — file explorer, API inspector, and monitoring dashboard",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.25"
+version = "0.9.26"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/nexus_kernel/Cargo.toml
+++ b/rust/nexus_kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus_kernel"
-version = "0.9.25"
+version = "0.9.26"
 edition = "2021"
 
 [lib]

--- a/rust/nexus_kernel/pyproject.toml
+++ b/rust/nexus_kernel/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-kernel"
-version = "0.9.25"
+version = "0.9.26"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
 requires-python = ">=3.12"
 classifiers = [

--- a/src/nexus/cli/data/nexus-stack.yml
+++ b/src/nexus/cli/data/nexus-stack.yml
@@ -97,6 +97,10 @@ services:
       NEXUS_GRPC_PORT: "2028"  # Fixed inside container; host port varies via port mapping
       NEXUS_GRPC_TLS: ${NEXUS_GRPC_TLS:-false}
       NEXUS_GRPC_BIND_ALL: ${NEXUS_GRPC_BIND_ALL:-true}
+      # 0.0.0.0 is a valid bind address but not a valid connect/advertise address.
+      # Without this, NEXUS_ADVERTISE_ADDR defaults to 0.0.0.0 which fails the
+      # insecure-channel loopback check when pipe_manager connects back to itself.
+      NEXUS_ADVERTISE_ADDR: ${NEXUS_ADVERTISE_ADDR:-127.0.0.1:2028}
       # Zoekt (external container, not built-in sidecar)
       ZOEKT_ENABLED: ${ZOEKT_ENABLED:-false}
       ZOEKT_URL: ${ZOEKT_URL:-http://zoekt:6070}

--- a/src/nexus/cli/data/nexus-stack.yml
+++ b/src/nexus/cli/data/nexus-stack.yml
@@ -100,7 +100,9 @@ services:
       # 0.0.0.0 is a valid bind address but not a valid connect/advertise address.
       # Without this, NEXUS_ADVERTISE_ADDR defaults to 0.0.0.0 which fails the
       # insecure-channel loopback check when pipe_manager connects back to itself.
-      NEXUS_ADVERTISE_ADDR: "127.0.0.1:2028"  # loopback self-address; NEXUS_GRPC_PORT is fixed at 2028 inside container
+      # Default to 127.0.0.1 for single-node; override for federation/cross-container.
+      # NEXUS_GRPC_PORT is fixed at 2028 inside this container (host port varies via mapping).
+      NEXUS_ADVERTISE_ADDR: ${NEXUS_ADVERTISE_ADDR:-127.0.0.1:2028}
       # Zoekt (external container, not built-in sidecar)
       ZOEKT_ENABLED: ${ZOEKT_ENABLED:-false}
       ZOEKT_URL: ${ZOEKT_URL:-http://zoekt:6070}

--- a/src/nexus/cli/data/nexus-stack.yml
+++ b/src/nexus/cli/data/nexus-stack.yml
@@ -100,7 +100,7 @@ services:
       # 0.0.0.0 is a valid bind address but not a valid connect/advertise address.
       # Without this, NEXUS_ADVERTISE_ADDR defaults to 0.0.0.0 which fails the
       # insecure-channel loopback check when pipe_manager connects back to itself.
-      NEXUS_ADVERTISE_ADDR: ${NEXUS_ADVERTISE_ADDR:-127.0.0.1:2028}
+      NEXUS_ADVERTISE_ADDR: "127.0.0.1:2028"  # loopback self-address; NEXUS_GRPC_PORT is fixed at 2028 inside container
       # Zoekt (external container, not built-in sidecar)
       ZOEKT_ENABLED: ${ZOEKT_ENABLED:-false}
       ZOEKT_URL: ${ZOEKT_URL:-http://zoekt:6070}


### PR DESCRIPTION
## Problem

Container crashes on every startup with:
```
ValueError: Insecure gRPC channel refused for non-loopback address '0.0.0.0:2028'
```

Both stack configs set `NEXUS_GRPC_BIND_ALL: true` so gRPC binds to `0.0.0.0:2028`. When `NEXUS_ADVERTISE_ADDR` was unset or derived as `0.0.0.0`, the pipe_manager tried to connect back to the node at `0.0.0.0:2028`, which the insecure-channel loopback check rejects.

## Fix

Add `NEXUS_ADVERTISE_ADDR` as a **defaultable** env var (not a forced literal) in both stack templates:

- `nexus-stack.yml`: `${NEXUS_ADVERTISE_ADDR:-127.0.0.1:${NEXUS_GRPC_PORT:-2028}}`
- `src/nexus/cli/data/nexus-stack.yml`: `${NEXUS_ADVERTISE_ADDR:-127.0.0.1:2028}`

Single-node deployments get the loopback default that fixes the crash. Federation/cross-container deployments set `NEXUS_ADVERTISE_ADDR` explicitly (e.g. `nexus-1:2126`) and the default is never used.

## Scope

`src/nexus/cli/data/nexus-stack.yml` is embedded in the Python package, so a PyPI release is needed to ship this fix to users running `nexus up`.

## Versions

| Package | Before | After |
|---|---|---|
| nexus-ai-fs | 0.9.25 | 0.9.26 |
| nexus-kernel | 0.9.25 | 0.9.26 |
| nexus-api-client | 0.9.25 | 0.9.26 ➡️ coordinated |
| nexus-tui | 0.9.25 | 0.9.26 ➡️ coordinated |
| nexus-fs | — | unchanged |

## Test plan

- [ ] `nexus up` starts without the `ValueError: Insecure gRPC channel refused` crash
- [ ] `NEXUS_ADVERTISE_ADDR=nexus-1:2126` override is preserved (federation setups)
- [ ] 5 parallel `nexus up` instances each resolve different ports without conflict