### PR TITLE
fix(occ): add missing await on fs.write() in occ_write and delta handler

### DIFF
--- a/src/nexus/lib/occ.py
+++ b/src/nexus/lib/occ.py
@@ -85,5 +85,5 @@ async def occ_write(
                     current_etag=current_etag or "(no etag)",
                 )
 
-    result: dict[str, Any] = fs.write(path, buf, context=context)
+    result: dict[str, Any] = await fs.write(path, buf, context=context)
     return result

--- a/src/nexus/server/rpc/handlers/delta.py
+++ b/src/nexus/server/rpc/handlers/delta.py
@@ -159,11 +159,11 @@ async def handle_delta_write(nexus_fs: "NexusFS", params: Any, context: Any) -> 
     if if_match:
         from nexus.lib.occ import occ_write
 
-        write_result = occ_write(
+        write_result = await occ_write(
             nexus_fs, params.path, new_content, context=context, if_match=if_match
         )
     else:
-        write_result = nexus_fs.write(params.path, new_content, context=context)
+        write_result = await nexus_fs.write(params.path, new_content, context=context)
     new_hash = hash_content(new_content)
 
     result: dict[str, Any] = {


### PR DESCRIPTION
## Summary

- `occ_write()` in `src/nexus/lib/occ.py` called `fs.write()` without `await`, returning an unawaited coroutine instead of persisting the file. All writes using `if_none_match` or `if_match` were silently dropped while returning a success response (`{"bytes_written": N}`).
- `handle_delta_write` in `src/nexus/server/rpc/handlers/delta.py` had the same bug on both the `occ_write()` call and the bare `nexus_fs.write()` fallback — every `delta_write` RPC call was silently dropped regardless of OCC params.

## Root cause

Unawaited coroutines in async context. `isinstance(write_result, dict)` returns `False` for a coroutine, so callers skipped `result.update(write_result)` and returned a fake success with no actual I/O.

## Test plan

- [ ] `sys_write` with `if_none_match=True` on a new file — verify file persists after write
- [ ] `sys_write` with `if_match=<etag>` — verify file is updated
- [ ] `delta_write` with and without `if_match` — verify patch is applied and persists
- [ ] Existing OCC unit tests pass