### PR TITLE
refactor(#3646): EventBusObserver + WorkflowDispatchService → sync on_mutation

### DIFF
--- a/src/nexus/services/event_bus/observer.py
+++ b/src/nexus/services/event_bus/observer.py
@@ -8,13 +8,16 @@ with a direct ``event_bus`` reference at factory time — no late-binding needed
 Tests that need a different bus use ``await nx.swap_service("event_bus_observer",
 EventBusObserver(event_bus=shared_bus))`` to hot-swap the observer atomically.
 
-Issue #1812: async on_mutation — directly awaits bus.publish() instead of
-fire_and_forget, since KernelDispatch.notify() now dispatches observers as
-a single asyncio.Task via gather().
+Issue #3646: sync on_mutation — fire-and-forget ``bus.publish()`` via
+``create_task``. OBSERVE is fire-and-forget by contract; the async network
+I/O (Redis/NATS) runs as a background task, not on the OBSERVE critical path.
+This enables full Rust OBSERVE dispatch (all observers sync → no Python
+asyncio scheduling needed).
 """
 
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING
 
@@ -31,9 +34,9 @@ logger = logging.getLogger(__name__)
 class EventBusObserver:
     """Forward kernel FileEvents to the distributed EventBus (Redis/NATS).
 
-    ``on_mutation()`` is async — awaits ``bus.publish()`` directly.
-    KernelDispatch.notify() dispatches all observers concurrently via
-    ``gather()`` in a single ``create_task``.
+    ``on_mutation()`` is sync — fire-and-forget ``bus.publish()`` via
+    ``create_task``. OBSERVE contract is fire-and-forget; network I/O
+    runs as a background task outside the OBSERVE critical path.
 
     Constructed with a direct ``event_bus`` reference (Issue #1701).
     Use ``await nx.swap_service("event_bus_observer", EventBusObserver(...))``
@@ -41,7 +44,8 @@ class EventBusObserver:
     """
 
     event_mask: int = ALL_FILE_EVENTS
-    OBSERVE_INLINE: bool = False  # Issue #3391: network I/O → background task
+    # Sync on_mutation → safe to run inline on caller's path (Issue #3646).
+    # The actual network I/O is fire-and-forget via create_task.
 
     # ── Hook spec (duck-typed) (Issue #1616) ──────────────────────────
 
@@ -53,11 +57,20 @@ class EventBusObserver:
     def __init__(self, event_bus: "EventBusProtocol | None" = None) -> None:
         self._event_bus = event_bus
 
-    async def on_mutation(self, event: "FileEvent") -> None:
+    def on_mutation(self, event: "FileEvent") -> None:
         if self._event_bus is None:
             return
 
         bus = self._event_bus
+        try:
+            loop = asyncio.get_running_loop()
+            loop.create_task(self._publish(bus, event))
+        except RuntimeError:
+            pass  # no event loop (e.g. test teardown)
+
+    @staticmethod
+    async def _publish(bus: "EventBusProtocol", event: "FileEvent") -> None:
+        """Background task: publish event to EventBus (Redis/NATS)."""
         try:
             bus_started = getattr(bus, "_started", False)
             if not bus_started:

--- a/src/nexus/services/lifecycle/workflow_dispatch_service.py
+++ b/src/nexus/services/lifecycle/workflow_dispatch_service.py
@@ -12,7 +12,10 @@ DI dependencies (no god-object access):
     - subscription_manager: Optional webhook broadcast (injected late by server)
     - enable_workflows: Feature flag from DistributedConfig
 
-Issue #1812: async on_mutation + event_mask filtering.
+Issue #1812: event_mask filtering.
+Issue #3646: sync on_mutation — pipe_write_nowait is already sync; fallback
+and webhook broadcast fire-and-forget via create_task. Enables full Rust
+OBSERVE dispatch.
 """
 
 import asyncio
@@ -68,8 +71,12 @@ class WorkflowDispatchService:
     # VFSObserver — called by KernelDispatch OBSERVE phase
     # ------------------------------------------------------------------
 
-    async def on_mutation(self, event: FileEvent) -> None:
-        """Translate kernel FileEvent into workflow fire + webhook broadcast."""
+    def on_mutation(self, event: FileEvent) -> None:
+        """Translate kernel FileEvent into workflow fire + webhook broadcast.
+
+        Sync (Issue #3646) — pipe_write_nowait is ~0.5μs; fallback and
+        webhook broadcast fire-and-forget via create_task.
+        """
         from nexus.core.file_events import FileEventType
 
         trigger_type = (
@@ -99,14 +106,53 @@ class WorkflowDispatchService:
             ctx["created"] = event.is_new
 
         label = f"{trigger_type}:{event.path}"
-        await self.fire(trigger_type, ctx, label)
+        self._fire_sync(trigger_type, ctx, label)
 
     # ------------------------------------------------------------------
-    # fire() — async, called from on_mutation or directly
+    # _fire_sync() — sync fast path, called from on_mutation
+    # ------------------------------------------------------------------
+
+    def _fire_sync(self, trigger_type: str, event_context: dict[str, Any], label: str) -> None:
+        """Sync dispatch: pipe_write_nowait + fire-and-forget async work."""
+        if not (self._enable_workflows and self._workflow_engine):
+            return
+
+        from nexus.core.pipe import PipeClosedError, PipeFullError
+
+        if self._pipe_manager is not None and self._pipe_ready:
+            try:
+                data = json.dumps({"type": trigger_type, "ctx": event_context}).encode()
+                self._pipe_manager.pipe_write_nowait(_WORKFLOW_PIPE_PATH, data)
+            except (PipeClosedError, PipeFullError):
+                logger.warning("Workflow pipe full/closed, dropping event: %s", label)
+        else:
+            # Fallback: fire-and-forget async call (CLI mode or pre-startup)
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(self._workflow_engine.fire_event(trigger_type, event_context))
+            except RuntimeError:
+                pass  # no event loop
+
+        if self._subscription_manager:
+            event_type = label.split(":")[0] if ":" in label else label
+            try:
+                loop = asyncio.get_running_loop()
+                loop.create_task(
+                    self._subscription_manager.broadcast(
+                        event_type,
+                        event_context,
+                        event_context.get("zone_id", ROOT_ZONE_ID),
+                    )
+                )
+            except RuntimeError:
+                pass  # no event loop
+
+    # ------------------------------------------------------------------
+    # fire() — async, called directly by external callers (not from OBSERVE)
     # ------------------------------------------------------------------
 
     async def fire(self, trigger_type: str, event_context: dict[str, Any], label: str) -> None:
-        """Fire a workflow event and broadcast to webhook subscriptions.
+        """Async fire for direct callers (not from OBSERVE path).
 
         Uses PipeManager userspace API — never touches MemoryPipeBackend directly.
         """
@@ -122,7 +168,6 @@ class WorkflowDispatchService:
             except (PipeClosedError, PipeFullError):
                 logger.warning("Workflow pipe full/closed, dropping event: %s", label)
         else:
-            # Fallback: direct async call (CLI mode or pre-startup, no pipe yet)
             await self._workflow_engine.fire_event(trigger_type, event_context)
 
         if self._subscription_manager:

--- a/tests/unit/services/test_workflow_dispatch.py
+++ b/tests/unit/services/test_workflow_dispatch.py
@@ -156,7 +156,7 @@ class TestOnMutation:
             version=3,
             is_new=True,
         )
-        await svc.on_mutation(event)
+        svc.on_mutation(event)
 
         data = pm.pipe_peek("/nexus/pipes/workflow-events")
         assert data is not None
@@ -179,7 +179,7 @@ class TestOnMutation:
             zone_id="root",
             version=43,
         )
-        await svc.on_mutation(event)
+        svc.on_mutation(event)
 
         data = pm.pipe_peek("/nexus/pipes/workflow-events")
         msg = json.loads(data)
@@ -201,7 +201,7 @@ class TestOnMutation:
             version=44,
             new_path="/new/path.txt",
         )
-        await svc.on_mutation(event)
+        svc.on_mutation(event)
 
         data = pm.pipe_peek("/nexus/pipes/workflow-events")
         msg = json.loads(data)


### PR DESCRIPTION
## Summary
Last two async OBSERVE observers converted to sync, enabling full Rust OBSERVE dispatch:

- **EventBusObserver**: `async def on_mutation` → `def on_mutation` + `create_task(bus.publish)` fire-and-forget. Remove `OBSERVE_INLINE = False`.
- **WorkflowDispatchService**: `async def on_mutation` → `def on_mutation`. `pipe_write_nowait` already sync; fallback + webhook broadcast fire-and-forget via `create_task`. Keep `async fire()` for direct callers.

All OBSERVE observers are now sync → Rust `dispatch_observers()` can call them without Python asyncio scheduling.

Closes #3646

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, format)
- [x] Tests updated: `await svc.on_mutation(event)` → `svc.on_mutation(event)`
- [x] Dispatch already handles sync observers (line 318-320 in nexus_fs_dispatch.py)

🤖 Generated with [Claude Code](https://claude.com/claude-code)