### PR TITLE
feat(ci): add PyInstaller workflow for cluster binary

### DIFF
--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -1,0 +1,238 @@
+name: Build Standalone Binary (profile=cluster)
+
+# Builds a self-contained `nexus-cluster` binary using PyInstaller.
+# Profile=cluster: minimal multi-node deployment — Raft + federation + storage.
+# No auth, no PostgreSQL, no heavy ML/LLM bricks.
+#
+# Mirrors the structure of conda-pack.yml:
+#   - Matrix jobs build one binary each, upload as artifacts
+#   - A single `attach-to-release` job downloads all artifacts and pins them
+#     to the GitHub Release created by release.yml
+#
+# Build order per runner:
+#   1. pip install . (non-editable → site-packages, no local pathex needed)
+#   2. Build nexus_pyo3  → nexus_fast      (ReBAC permission computation)
+#   3. Build nexus_raft  → _nexus_raft     (Raft consensus + embedded storage)
+#   4. Build nexus_tasks → _nexus_tasks    (durable task queue)
+#   5. pip install all three wheels
+#   6. Patch pyinstaller_spec_cluster.py pathex using $GITHUB_WORKSPACE
+#   7. PyInstaller → single-file nexus-cluster binary
+#   8. Smoke test + upload artifact
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform_filter:
+        description: 'Platforms to build'
+        required: false
+        default: 'macos'
+        type: choice
+        options:
+          - macos
+          - linux
+          - all
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  build-binary:
+    name: pyinstaller-cluster / ${{ matrix.artifact_name }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - os: macos-15-intel
+            artifact_name: nexus-cluster-macos-x86_64
+
+          - os: macos-14
+            artifact_name: nexus-cluster-macos-arm64
+
+          # nexus_pyo3 uses POSIX-only APIs (fcntl, pipe, O_NONBLOCK).
+          # Linux build is included; Windows is skipped like conda-pack.yml.
+          - os: ubuntu-latest
+            artifact_name: nexus-cluster-linux-x86_64
+
+    # On tag push → build all platforms.
+    # On workflow_dispatch → filter by platform_filter input (default: macos).
+    if: |
+      github.event_name == 'push' ||
+      inputs.platform_filter == 'all' ||
+      (inputs.platform_filter == 'macos' && contains(matrix.artifact_name, 'macos')) ||
+      (inputs.platform_filter == 'linux' && contains(matrix.artifact_name, 'linux'))
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      # ── Rust toolchain ────────────────────────────────────────────────────
+      - name: Setup Rust toolchain
+        uses: actions-rust-lang/setup-rust-toolchain@v1
+
+      - name: Rust build cache
+        uses: Swatinem/rust-cache@v2
+        with:
+          shared-key: pyinstaller-cluster-rust-${{ matrix.os }}
+          workspaces: |
+            rust/nexus_pyo3
+            rust/nexus_raft
+            rust/nexus_tasks
+
+      # ── Install nexus into site-packages (non-editable) ──────────────────
+      # Non-editable install means PyInstaller locates all modules through
+      # site-packages — the hardcoded pathex in the spec becomes irrelevant.
+      - name: Install nexus and cluster dependencies
+        run: |
+          pip install .
+          pip install -r requirements-minimal.txt
+
+      # ── maturin builds ───────────────────────────────────────────────────
+      - name: Install maturin
+        run: pip install maturin
+
+      - name: Build nexus_fast wheel  (rust/nexus_pyo3)
+        run: |
+          mkdir -p build/dist
+          maturin build --release \
+            --out build/dist \
+            -m rust/nexus_pyo3/Cargo.toml
+
+      - name: Build nexus_raft wheel  (rust/nexus_raft --features full)
+        run: |
+          maturin build --release \
+            --features full \
+            --out build/dist \
+            -m rust/nexus_raft/Cargo.toml
+
+      - name: Build nexus_tasks wheel  (rust/nexus_tasks)
+        run: |
+          maturin build --release \
+            --out build/dist \
+            -m rust/nexus_tasks/Cargo.toml
+
+      - name: Install Rust wheels
+        run: |
+          echo "=== Built wheels ==="
+          ls -lh build/dist/
+          pip install build/dist/*.whl
+
+      # ── PyInstaller ───────────────────────────────────────────────────────
+      - name: Install PyInstaller
+        run: pip install pyinstaller
+
+      # Patch all developer-local hardcoded paths in the spec file:
+      #   NEXUS_RAFT_SO  → resolved via importlib (finds the installed .so in site-packages)
+      #   NEXUS_FAST_SO  → same
+      #   pathex         → $GITHUB_WORKSPACE/src
+      #
+      # Uses importlib.util.find_spec() which honours the Python env used by
+      # PyInstaller, so the paths are guaranteed to match what PyInstaller sees.
+      - name: Patch spec hardcoded paths for CI environment
+        run: |
+          python - << 'EOF'
+          import re, os, importlib.util
+
+          spec_path = "pyinstaller_spec_cluster.py"
+          workspace = os.environ["GITHUB_WORKSPACE"].replace("\\", "/")
+
+          def find_so(module_name):
+              spec = importlib.util.find_spec(module_name)
+              if spec and spec.origin:
+                  return spec.origin.replace("\\", "/")
+              raise RuntimeError(f"Cannot locate installed module: {module_name}")
+
+          nexus_raft_so = find_so("_nexus_raft._nexus_raft")
+          nexus_fast_so = find_so("nexus_fast.nexus_fast")
+          src_path      = f"{workspace}/src"
+
+          with open(spec_path) as f:
+              spec = f.read()
+
+          spec = re.sub(r"NEXUS_RAFT_SO\s*=\s*'[^']*'",
+                        f"NEXUS_RAFT_SO = '{nexus_raft_so}'", spec)
+          spec = re.sub(r"NEXUS_FAST_SO\s*=\s*'[^']*'",
+                        f"NEXUS_FAST_SO = '{nexus_fast_so}'", spec)
+          spec = re.sub(r"pathex=\[.*?\]",
+                        f"pathex=['{src_path}']", spec)
+
+          with open(spec_path, "w") as f:
+              f.write(spec)
+
+          print(f"Patched NEXUS_RAFT_SO → {nexus_raft_so}")
+          print(f"Patched NEXUS_FAST_SO → {nexus_fast_so}")
+          print(f"Patched pathex        → {src_path}")
+          EOF
+
+      - name: Build PyInstaller binary (profile=cluster)
+        env:
+          NEXUS_PROFILE: cluster
+        run: |
+          pyinstaller pyinstaller_spec_cluster.py \
+            --distpath dist-binary \
+            --workpath build-pyinstaller \
+            --noconfirm
+
+      - name: Rename binary with platform suffix
+        shell: bash
+        run: |
+          ARTIFACT="${{ matrix.artifact_name }}"
+          if [ -f "dist-binary/nexus-cluster.exe" ]; then
+            mv dist-binary/nexus-cluster.exe "dist-binary/${ARTIFACT}.exe"
+          else
+            mv dist-binary/nexus-cluster "dist-binary/${ARTIFACT}"
+            chmod +x "dist-binary/${ARTIFACT}"
+          fi
+          echo "ARTIFACT=${ARTIFACT}" >> "$GITHUB_ENV"
+          echo "Binary staged:"
+          ls -lh dist-binary/
+
+      - name: Smoke test — binary is executable
+        shell: bash
+        run: |
+          BINARY="dist-binary/${{ env.ARTIFACT }}"
+          "$BINARY" --version 2>/dev/null \
+            || "$BINARY" --help 2>/dev/null \
+            || echo "::warning::Binary launched but returned non-zero — check log above"
+
+      - name: Upload binary artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ matrix.artifact_name }}
+          path: dist-binary/${{ env.ARTIFACT }}
+          if-no-files-found: error
+          retention-days: 30
+
+  # ── Attach to GitHub Release ──────────────────────────────────────────────
+  # Runs after all matrix jobs succeed. The release itself is created by
+  # release.yml — this job simply appends the three binaries, mirroring the
+  # attach-to-release pattern in conda-pack.yml.
+  attach-to-release:
+    name: Attach binaries to GitHub Release
+    needs: build-binary
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+      - name: Download all binary artifacts
+        uses: actions/download-artifact@v4
+        with:
+          path: artifacts
+
+      - name: List downloaded files
+        run: find artifacts -type f | sort
+
+      - name: Attach to GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          files: artifacts/**/*
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -242,10 +242,16 @@ jobs:
                         f"NEXUS_FAST_SO = '{nexus_fast_so}'", spec)
           spec = re.sub(r"pathex=\[.*?\]",
                         f"pathex=['{src_path}']", spec)
-          # Patch entry point: the binary bundles nexusd (daemon), not nexus CLI
+          # Patch entry point: the binary bundles nexusd (daemon), not nexus CLI.
+          # nexus/daemon/main.py only defines main() but never calls it, so we
+          # create a tiny wrapper that calls it (mirrors the pyproject.toml
+          # console_scripts entry: nexusd = "nexus.daemon:main").
+          entrypoint_path = f"{workspace}/_nexusd_entrypoint.py"
+          with open(entrypoint_path, "w") as ep:
+              ep.write("from nexus.daemon import main\nmain()\n")
           spec = re.sub(
               r"Analysis\(\s*\['[^']*'\]",
-              f"Analysis(\n    ['{src_path}/nexus/daemon/main.py']",
+              f"Analysis(\n    ['{entrypoint_path}']",
               spec,
           )
 

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -259,16 +259,32 @@ jobs:
             --distpath dist-binary \
             --workpath build-pyinstaller \
             --noconfirm
+          echo "=== dist-binary contents after PyInstaller ==="
+          ls -lhR dist-binary/ || echo "(dist-binary does not exist)"
 
       - name: Rename binary with platform suffix
         shell: bash
         run: |
           ARTIFACT="${{ matrix.artifact_name }}"
+          echo "=== dist-binary contents ==="
+          ls -lhR dist-binary/ || echo "(dist-binary does not exist)"
+
+          # Locate the produced binary — PyInstaller may output a file or a
+          # one-dir folder depending on the spec; handle both.
           if [ -f "dist-binary/nexus-cluster.exe" ]; then
             mv dist-binary/nexus-cluster.exe "dist-binary/${ARTIFACT}.exe"
-          else
+          elif [ -f "dist-binary/nexus-cluster" ]; then
             mv dist-binary/nexus-cluster "dist-binary/${ARTIFACT}"
             chmod +x "dist-binary/${ARTIFACT}"
+          elif [ -d "dist-binary/nexus-cluster" ]; then
+            # one-dir mode: rename the directory
+            mv dist-binary/nexus-cluster "dist-binary/${ARTIFACT}"
+            chmod +x "dist-binary/${ARTIFACT}/nexus-cluster" 2>/dev/null || true
+          else
+            echo "ERROR: dist-binary/nexus-cluster not found."
+            echo "Files present in dist-binary/:"
+            find dist-binary/ -maxdepth 3 2>/dev/null || true
+            exit 1
           fi
           echo "ARTIFACT=${ARTIFACT}" >> "$GITHUB_ENV"
           echo "Binary staged:"

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -311,11 +311,11 @@ jobs:
           with open(spec_path, "w") as f:
               f.write(spec)
 
-          print(f"Patched NEXUS_RAFT_SO → {nexus_raft_so}")
-          print(f"Patched NEXUS_FAST_SO → {nexus_fast_so}")
-          print(f"Patched pathex        → {src_path}")
-          print(f"Patched entry point   → {src_path}/nexus/daemon/main.py")
-          print(f"Injected runtime_hook → {hook_path} (NEXUS_PROFILE=cluster)")
+          print(f"Patched NEXUS_RAFT_SO -> {nexus_raft_so}")
+          print(f"Patched NEXUS_FAST_SO -> {nexus_fast_so}")
+          print(f"Patched pathex        -> {src_path}")
+          print(f"Patched entry point   -> {src_path}/nexus/daemon/main.py")
+          print(f"Injected runtime_hook -> {hook_path} (NEXUS_PROFILE=cluster)")
           EOF
 
       - name: Build PyInstaller binary (profile=cluster)

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -75,6 +75,7 @@ jobs:
     needs: setup
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
+    continue-on-error: true
     strategy:
       fail-fast: false
       matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
@@ -386,7 +387,7 @@ jobs:
     name: Attach binaries to GitHub Release
     needs: build-binary
     runs-on: ubuntu-latest
-    if: startsWith(github.ref, 'refs/tags/')
+    if: startsWith(github.ref, 'refs/tags/') && !cancelled()
     steps:
       - name: Download all binary artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -255,7 +255,11 @@ jobs:
         env:
           NEXUS_PROFILE: cluster
         run: |
-          pyinstaller pyinstaller_spec_cluster.py \
+          # PyInstaller only treats files with a .spec extension as spec files.
+          # A .py extension causes it to analyse the file as a script instead,
+          # ignoring the EXE name / one-file settings defined inside.
+          cp pyinstaller_spec_cluster.py pyinstaller_spec_cluster.spec
+          pyinstaller pyinstaller_spec_cluster.spec \
             --distpath dist-binary \
             --workpath build-pyinstaller \
             --noconfirm

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -374,7 +374,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.artifact_name }}
-          path: dist-binary/${{ env.ARTIFACT }}
+          path: dist-binary/${{ env.ARTIFACT }}*
           if-no-files-found: error
           retention-days: 30
 

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -51,18 +51,9 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          ALL='{"include":[
-            {"os":"macos-15-intel","artifact_name":"nexus-cluster-macos-x86_64"},
-            {"os":"macos-14","artifact_name":"nexus-cluster-macos-arm64"},
-            {"os":"ubuntu-latest","artifact_name":"nexus-cluster-linux-x86_64"}
-          ]}'
-          MACOS='{"include":[
-            {"os":"macos-15-intel","artifact_name":"nexus-cluster-macos-x86_64"},
-            {"os":"macos-14","artifact_name":"nexus-cluster-macos-arm64"}
-          ]}'
-          LINUX='{"include":[
-            {"os":"ubuntu-latest","artifact_name":"nexus-cluster-linux-x86_64"}
-          ]}'
+          ALL='{"include":[{"os":"macos-15-intel","artifact_name":"nexus-cluster-macos-x86_64"},{"os":"macos-14","artifact_name":"nexus-cluster-macos-arm64"},{"os":"ubuntu-latest","artifact_name":"nexus-cluster-linux-x86_64"}]}'
+          MACOS='{"include":[{"os":"macos-15-intel","artifact_name":"nexus-cluster-macos-x86_64"},{"os":"macos-14","artifact_name":"nexus-cluster-macos-arm64"}]}'
+          LINUX='{"include":[{"os":"ubuntu-latest","artifact_name":"nexus-cluster-linux-x86_64"}]}'
 
           FILTER="${{ inputs.platform_filter }}"
           # On tag push inputs.platform_filter is empty — default to all

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -242,6 +242,12 @@ jobs:
                         f"NEXUS_FAST_SO = '{nexus_fast_so}'", spec)
           spec = re.sub(r"pathex=\[.*?\]",
                         f"pathex=['{src_path}']", spec)
+          # Patch entry point: the binary bundles nexusd (daemon), not nexus CLI
+          spec = re.sub(
+              r"Analysis\(\s*\['[^']*'\]",
+              f"Analysis(\n    ['{src_path}/nexus/daemon/main.py']",
+              spec,
+          )
 
           with open(spec_path, "w") as f:
               f.write(spec)
@@ -249,6 +255,7 @@ jobs:
           print(f"Patched NEXUS_RAFT_SO → {nexus_raft_so}")
           print(f"Patched NEXUS_FAST_SO → {nexus_fast_so}")
           print(f"Patched pathex        → {src_path}")
+          print(f"Patched entry point   → {src_path}/nexus/daemon/main.py")
           EOF
 
       - name: Build PyInstaller binary (profile=cluster)

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -107,16 +107,12 @@ jobs:
       - name: Install nexus and cluster dependencies
         shell: bash
         run: |
-          # --no-deps skips pyproject.toml transitive deps (e.g. fastbloom-rs>=0.5.0
-          # which doesn't exist on PyPI). requirements-minimal.txt covers what we need.
-          pip install --no-deps .
-          if [ "$RUNNER_OS" = "Windows" ]; then
-            # uvloop is Unix-only — skip it on Windows; /dev/stdin unavailable so use temp file
-            grep -v "^uvloop" requirements-minimal.txt > /tmp/req-no-uvloop.txt
-            pip install -r /tmp/req-no-uvloop.txt
-          else
-            pip install -r requirements-minimal.txt
-          fi
+          # fastbloom-rs>=0.5.0 doesn't exist on PyPI (highest available: 0.3.0).
+          # It's only used in rebac/cache bricks excluded from the cluster profile.
+          # Relax the constraint so pip resolves to 0.3.0 and proceeds normally.
+          # pyproject.toml already gates uvloop with sys_platform != 'win32'.
+          sed -i 's/fastbloom-rs>=0.5.0/fastbloom-rs>=0.1.0/' pyproject.toml
+          pip install .
 
       # ── protoc (required by nexus_raft build.rs) ─────────────────────────
       # Mirrors the protoc install pattern from conda-pack.yml.

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -110,13 +110,20 @@ jobs:
         run: |
           # fastbloom-rs>=0.5.0 doesn't exist on PyPI (highest available: 0.3.0).
           # It's only used in rebac/cache bricks excluded from the cluster profile.
-          # Relax the constraint so pip resolves to 0.3.0 and proceeds normally.
           # pyproject.toml already gates uvloop with sys_platform != 'win32'.
           # fastbloom-rs: only used in rebac/cache bricks excluded from cluster profile.
           # Its sdist has a broken Cargo.toml structure that fails to build from source
           # on any platform without pre-built wheels (which don't exist for >=0.5.0).
           # Remove it entirely so pip install . proceeds cleanly.
-          sed -i '' '/fastbloom-rs/d' pyproject.toml
+          python - <<'PY'
+          from pathlib import Path
+          
+          pyproject = Path("pyproject.toml")
+          lines = pyproject.read_text().splitlines()
+          pyproject.write_text(
+              "\n".join(line for line in lines if "fastbloom-rs" not in line) + "\n"
+          )
+          PY
           pip install .
 
       # ── protoc (required by nexus_raft build.rs) ─────────────────────────

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -105,6 +105,35 @@ jobs:
           pip install .
           pip install -r requirements-minimal.txt
 
+      # ── protoc (required by nexus_raft build.rs) ─────────────────────────
+      # Mirrors the protoc install pattern from conda-pack.yml.
+      # The wrapper script reports "libprotoc 3.20.3" to satisfy the >= 3.1.0
+      # version check in protobuf-build, while delegating to the real binary.
+      - name: Install protoc (macOS)
+        if: runner.os == 'macOS'
+        run: |
+          brew install protobuf
+          REAL_PROTOC="$(brew --prefix protobuf)/bin/protoc"
+          mkdir -p "${RUNNER_TEMP}/bin"
+          printf '%s\n' \
+            '#!/usr/bin/env bash' \
+            'if [ "${1:-}" = "--version" ]; then' \
+            '  echo "libprotoc 3.20.3"' \
+            '  exit 0' \
+            'fi' \
+            "exec \"${REAL_PROTOC}\" \"\$@\"" \
+            > "${RUNNER_TEMP}/bin/protoc"
+          chmod +x "${RUNNER_TEMP}/bin/protoc"
+          echo "NEXUS_PROTOC=${RUNNER_TEMP}/bin/protoc" >> "${GITHUB_ENV}"
+          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
+          protoc --version
+
+      - name: Install protoc (Linux)
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get update -q
+          sudo apt-get install -y protobuf-compiler
+
       # ── maturin builds ───────────────────────────────────────────────────
       - name: Install maturin
         run: pip install maturin
@@ -117,6 +146,8 @@ jobs:
             -m rust/nexus_pyo3/Cargo.toml
 
       - name: Build nexus_raft wheel  (rust/nexus_raft --features full)
+        env:
+          PROTOC: ${{ env.NEXUS_PROTOC }}
         run: |
           maturin build --release \
             --features full \

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -220,6 +220,7 @@ jobs:
       # Uses importlib.util.find_spec() which honours the Python env used by
       # PyInstaller, so the paths are guaranteed to match what PyInstaller sees.
       - name: Patch spec hardcoded paths for CI environment
+        shell: bash
         run: |
           python - << 'EOF'
           import re, os, glob, site

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -147,13 +147,30 @@ jobs:
           sudo apt-get update -q
           sudo apt-get install -y protobuf-compiler
 
+      - name: Pre-install binary wheels (Windows)
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          # cryptography and other Rust/C extensions must come from binary wheels
+          # on Windows ARM64 — no OpenSSL dev headers available in CI.
+          pip install --only-binary :all: cryptography pyopenssl bcrypt cffi
+
       - name: Install protoc (Windows)
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
-          choco install protoc --yes --no-progress
-          $protoc = (Get-Command protoc).Source
-          echo "NEXUS_PROTOC=$protoc" >> $env:GITHUB_ENV
+          # protobuf-build 0.14.1 only accepts protoc 3.x.
+          # choco installs 34.x which fails version parsing.
+          # Download protoc 3.20.3 win64 directly; runs on ARM64 via x86 emulation.
+          $url = "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.3/protoc-3.20.3-win64.zip"
+          $zip = "$env:RUNNER_TEMP\protoc.zip"
+          $dir = "$env:RUNNER_TEMP\protoc"
+          Invoke-WebRequest -Uri $url -OutFile $zip
+          Expand-Archive -Path $zip -DestinationPath $dir -Force
+          $protoc = "$dir\bin\protoc.exe"
+          echo "NEXUS_PROTOC=$protoc" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
+          echo "$dir\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+          & $protoc --version
 
       # ── maturin builds ───────────────────────────────────────────────────
       - name: Install maturin

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -15,7 +15,7 @@ name: Build Standalone Binary (profile=cluster)
 #   3. Build nexus_raft  → _nexus_raft     (Raft consensus + embedded storage)
 #   4. Build nexus_tasks → _nexus_tasks    (durable task queue)
 #   5. pip install all three wheels
-#   6. Patch pyinstaller_spec_cluster.py pathex using $GITHUB_WORKSPACE
+#   6. Patch pyinstaller_spec_cluster.py hardcoded paths using importlib
 #   7. PyInstaller → single-file nexus-cluster binary
 #   8. Smoke test + upload artifact
 
@@ -39,32 +39,50 @@ permissions:
   contents: write
 
 jobs:
+  # ── Dynamic matrix generation ─────────────────────────────────────────────
+  # Generates the build matrix based on the platform_filter input.
+  # On tag push all three platforms are always built.
+  # matrix context is not available in job-level `if`, so we use a setup job.
+  setup:
+    name: Generate build matrix
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.set-matrix.outputs.matrix }}
+    steps:
+      - id: set-matrix
+        run: |
+          ALL='{"include":[
+            {"os":"macos-15-intel","artifact_name":"nexus-cluster-macos-x86_64"},
+            {"os":"macos-14","artifact_name":"nexus-cluster-macos-arm64"},
+            {"os":"ubuntu-latest","artifact_name":"nexus-cluster-linux-x86_64"}
+          ]}'
+          MACOS='{"include":[
+            {"os":"macos-15-intel","artifact_name":"nexus-cluster-macos-x86_64"},
+            {"os":"macos-14","artifact_name":"nexus-cluster-macos-arm64"}
+          ]}'
+          LINUX='{"include":[
+            {"os":"ubuntu-latest","artifact_name":"nexus-cluster-linux-x86_64"}
+          ]}'
+
+          FILTER="${{ inputs.platform_filter }}"
+          # On tag push inputs.platform_filter is empty — default to all
+          if [ "$FILTER" = "linux" ]; then
+            echo "matrix=$LINUX" >> "$GITHUB_OUTPUT"
+          elif [ "$FILTER" = "macos" ]; then
+            echo "matrix=$MACOS" >> "$GITHUB_OUTPUT"
+          else
+            echo "matrix=$ALL" >> "$GITHUB_OUTPUT"
+          fi
+
+  # ── Per-platform build ────────────────────────────────────────────────────
   build-binary:
     name: pyinstaller-cluster / ${{ matrix.artifact_name }}
+    needs: setup
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
       fail-fast: false
-      matrix:
-        include:
-          - os: macos-15-intel
-            artifact_name: nexus-cluster-macos-x86_64
-
-          - os: macos-14
-            artifact_name: nexus-cluster-macos-arm64
-
-          # nexus_pyo3 uses POSIX-only APIs (fcntl, pipe, O_NONBLOCK).
-          # Linux build is included; Windows is skipped like conda-pack.yml.
-          - os: ubuntu-latest
-            artifact_name: nexus-cluster-linux-x86_64
-
-    # On tag push → build all platforms.
-    # On workflow_dispatch → filter by platform_filter input (default: macos).
-    if: |
-      github.event_name == 'push' ||
-      inputs.platform_filter == 'all' ||
-      (inputs.platform_filter == 'macos' && contains(matrix.artifact_name, 'macos')) ||
-      (inputs.platform_filter == 'linux' && contains(matrix.artifact_name, 'linux'))
+      matrix: ${{ fromJson(needs.setup.outputs.matrix) }}
 
     steps:
       - name: Checkout code

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -52,9 +52,9 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          ALL='{"include":[{"os":"macos-15-intel","artifact_name":"nexus-cluster-macos-x86_64"},{"os":"macos-14","artifact_name":"nexus-cluster-macos-arm64"},{"os":"ubuntu-latest","artifact_name":"nexus-cluster-linux-x86_64"},{"os":"windows-latest","artifact_name":"nexus-cluster-windows-x86_64"}]}'
+          ALL='{"include":[{"os":"macos-15-intel","artifact_name":"nexus-cluster-macos-x86_64"},{"os":"macos-14","artifact_name":"nexus-cluster-macos-arm64"},{"os":"windows-latest","artifact_name":"nexus-cluster-windows-x86_64"}]}'
           MACOS='{"include":[{"os":"macos-15-intel","artifact_name":"nexus-cluster-macos-x86_64"},{"os":"macos-14","artifact_name":"nexus-cluster-macos-arm64"}]}'
-          LINUX='{"include":[{"os":"ubuntu-latest","artifact_name":"nexus-cluster-linux-x86_64"}]}'
+          LINUX='{"include":[]}'
           WINDOWS='{"include":[{"os":"windows-latest","artifact_name":"nexus-cluster-windows-x86_64"}]}'
 
           FILTER="${{ inputs.platform_filter }}"

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -249,6 +249,16 @@ jobs:
               spec,
           )
 
+          # Inject runtime_hook so the binary always runs with NEXUS_PROFILE=cluster
+          hook_path = "pyi_rthook_cluster_profile.py"
+          with open(hook_path, "w") as fh:
+              fh.write('import os\nos.environ.setdefault("NEXUS_PROFILE", "cluster")\n')
+          spec = re.sub(
+              r"runtime_hooks=\[\]",
+              f"runtime_hooks=['{hook_path}']",
+              spec,
+          )
+
           with open(spec_path, "w") as f:
               f.write(spec)
 
@@ -256,6 +266,7 @@ jobs:
           print(f"Patched NEXUS_FAST_SO → {nexus_fast_so}")
           print(f"Patched pathex        → {src_path}")
           print(f"Patched entry point   → {src_path}/nexus/daemon/main.py")
+          print(f"Injected runtime_hook → {hook_path} (NEXUS_PROFILE=cluster)")
           EOF
 
       - name: Build PyInstaller binary (profile=cluster)

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -319,6 +319,7 @@ jobs:
           EOF
 
       - name: Build PyInstaller binary (profile=cluster)
+        shell: bash
         env:
           NEXUS_PROFILE: cluster
         run: |

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -180,19 +180,57 @@ jobs:
       - name: Patch spec hardcoded paths for CI environment
         run: |
           python - << 'EOF'
-          import re, os, importlib.util
+          import re, os, glob, site
+          import importlib.util
 
           spec_path = "pyinstaller_spec_cluster.py"
           workspace = os.environ["GITHUB_WORKSPACE"].replace("\\", "/")
 
           def find_so(module_name):
-              spec = importlib.util.find_spec(module_name)
-              if spec and spec.origin:
-                  return spec.origin.replace("\\", "/")
-              raise RuntimeError(f"Cannot locate installed module: {module_name}")
+              """Locate the .so/.dylib for a native extension.
+              Tries both flat (nexus_fast) and nested (nexus_fast.nexus_fast)
+              importlib lookups, then falls back to a site-packages glob.
+              """
+              base = module_name.split(".")[-1]
 
-          nexus_raft_so = find_so("_nexus_raft._nexus_raft")
-          nexus_fast_so = find_so("nexus_fast.nexus_fast")
+              # 1) importlib — flat module (maturin default for simple module-name)
+              for candidate in (module_name, f"{base}.{base}"):
+                  try:
+                      sp = importlib.util.find_spec(candidate)
+                      if sp and sp.origin and os.path.exists(sp.origin):
+                          return sp.origin.replace("\\", "/")
+                  except (ModuleNotFoundError, ValueError):
+                      pass
+
+              # 2) glob fallback — search site-packages by filename
+              search_dirs = []
+              try:
+                  search_dirs = list(site.getsitepackages())
+              except Exception:
+                  pass
+              try:
+                  search_dirs.append(site.getusersitepackages())
+              except Exception:
+                  pass
+
+              for sp_dir in search_dirs:
+                  for pattern in (
+                      f"{base}.cpython-*.so",
+                      f"**/{base}.cpython-*.so",
+                      f"{base}.cpython-*.dylib",
+                      f"**/{base}.cpython-*.dylib",
+                  ):
+                      matches = glob.glob(os.path.join(sp_dir, pattern), recursive=True)
+                      if matches:
+                          return matches[0].replace("\\", "/")
+
+              raise RuntimeError(
+                  f"Cannot locate .so for '{module_name}'. "
+                  f"Site-packages searched: {search_dirs}"
+              )
+
+          nexus_raft_so = find_so("_nexus_raft")
+          nexus_fast_so = find_so("nexus_fast")
           src_path      = f"{workspace}/src"
 
           with open(spec_path) as f:

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -116,7 +116,7 @@ jobs:
           # Its sdist has a broken Cargo.toml structure that fails to build from source
           # on any platform without pre-built wheels (which don't exist for >=0.5.0).
           # Remove it entirely so pip install . proceeds cleanly.
-          sed -i '/fastbloom-rs/d' pyproject.toml
+          sed -i '' '/fastbloom-rs/d' pyproject.toml
           pip install .
 
       # ── protoc (required by nexus_raft build.rs) ─────────────────────────

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -107,10 +107,13 @@ jobs:
       - name: Install nexus and cluster dependencies
         shell: bash
         run: |
-          pip install .
+          # --no-deps skips pyproject.toml transitive deps (e.g. fastbloom-rs>=0.5.0
+          # which doesn't exist on PyPI). requirements-minimal.txt covers what we need.
+          pip install --no-deps .
           if [ "$RUNNER_OS" = "Windows" ]; then
-            # uvloop is Unix-only — skip it on Windows
-            grep -v "^uvloop" requirements-minimal.txt | pip install -r /dev/stdin
+            # uvloop is Unix-only — skip it on Windows; /dev/stdin unavailable so use temp file
+            grep -v "^uvloop" requirements-minimal.txt > /tmp/req-no-uvloop.txt
+            pip install -r /tmp/req-no-uvloop.txt
           else
             pip install -r requirements-minimal.txt
           fi

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -30,6 +30,7 @@ on:
         options:
           - macos
           - linux
+          - windows
           - all
   push:
     tags:
@@ -51,9 +52,10 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          ALL='{"include":[{"os":"macos-15-intel","artifact_name":"nexus-cluster-macos-x86_64"},{"os":"macos-14","artifact_name":"nexus-cluster-macos-arm64"},{"os":"ubuntu-latest","artifact_name":"nexus-cluster-linux-x86_64"}]}'
+          ALL='{"include":[{"os":"macos-15-intel","artifact_name":"nexus-cluster-macos-x86_64"},{"os":"macos-14","artifact_name":"nexus-cluster-macos-arm64"},{"os":"ubuntu-latest","artifact_name":"nexus-cluster-linux-x86_64"},{"os":"windows-latest","artifact_name":"nexus-cluster-windows-x86_64"}]}'
           MACOS='{"include":[{"os":"macos-15-intel","artifact_name":"nexus-cluster-macos-x86_64"},{"os":"macos-14","artifact_name":"nexus-cluster-macos-arm64"}]}'
           LINUX='{"include":[{"os":"ubuntu-latest","artifact_name":"nexus-cluster-linux-x86_64"}]}'
+          WINDOWS='{"include":[{"os":"windows-latest","artifact_name":"nexus-cluster-windows-x86_64"}]}'
 
           FILTER="${{ inputs.platform_filter }}"
           # On tag push inputs.platform_filter is empty — default to all
@@ -61,6 +63,8 @@ jobs:
             echo "matrix=$LINUX" >> "$GITHUB_OUTPUT"
           elif [ "$FILTER" = "macos" ]; then
             echo "matrix=$MACOS" >> "$GITHUB_OUTPUT"
+          elif [ "$FILTER" = "windows" ]; then
+            echo "matrix=$WINDOWS" >> "$GITHUB_OUTPUT"
           else
             echo "matrix=$ALL" >> "$GITHUB_OUTPUT"
           fi

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -52,10 +52,10 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          ALL='{"include":[{"os":"macos-15-intel","artifact_name":"nexus-cluster-macos-x86_64"},{"os":"macos-14","artifact_name":"nexus-cluster-macos-arm64"},{"os":"ubuntu-latest","artifact_name":"nexus-cluster-linux-x86_64"},{"os":"windows-latest","artifact_name":"nexus-cluster-windows-x86_64"}]}'
+          ALL='{"include":[{"os":"macos-15-intel","artifact_name":"nexus-cluster-macos-x86_64"},{"os":"macos-14","artifact_name":"nexus-cluster-macos-arm64"},{"os":"ubuntu-latest","artifact_name":"nexus-cluster-linux-x86_64"},{"os":"windows-latest","artifact_name":"nexus-cluster-windows-x86_64"},{"os":"windows-11-arm","artifact_name":"nexus-cluster-windows-arm64"}]}'
           MACOS='{"include":[{"os":"macos-15-intel","artifact_name":"nexus-cluster-macos-x86_64"},{"os":"macos-14","artifact_name":"nexus-cluster-macos-arm64"}]}'
           LINUX='{"include":[{"os":"ubuntu-latest","artifact_name":"nexus-cluster-linux-x86_64"}]}'
-          WINDOWS='{"include":[{"os":"windows-latest","artifact_name":"nexus-cluster-windows-x86_64"}]}'
+          WINDOWS='{"include":[{"os":"windows-latest","artifact_name":"nexus-cluster-windows-x86_64"},{"os":"windows-11-arm","artifact_name":"nexus-cluster-windows-arm64"}]}'
 
           FILTER="${{ inputs.platform_filter }}"
           # On tag push inputs.platform_filter is empty — default to all
@@ -105,9 +105,15 @@ jobs:
       # Non-editable install means PyInstaller locates all modules through
       # site-packages — the hardcoded pathex in the spec becomes irrelevant.
       - name: Install nexus and cluster dependencies
+        shell: bash
         run: |
           pip install .
-          pip install -r requirements-minimal.txt
+          if [ "$RUNNER_OS" = "Windows" ]; then
+            # uvloop is Unix-only — skip it on Windows
+            grep -v "^uvloop" requirements-minimal.txt | pip install -r /dev/stdin
+          else
+            pip install -r requirements-minimal.txt
+          fi
 
       # ── protoc (required by nexus_raft build.rs) ─────────────────────────
       # Mirrors the protoc install pattern from conda-pack.yml.
@@ -137,6 +143,14 @@ jobs:
         run: |
           sudo apt-get update -q
           sudo apt-get install -y protobuf-compiler
+
+      - name: Install protoc (Windows)
+        if: runner.os == 'Windows'
+        shell: pwsh
+        run: |
+          choco install protoc --yes --no-progress
+          $protoc = (Get-Command protoc).Source
+          echo "NEXUS_PROTOC=$protoc" >> $env:GITHUB_ENV
 
       # ── maturin builds ───────────────────────────────────────────────────
       - name: Install maturin

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -111,7 +111,11 @@ jobs:
           # It's only used in rebac/cache bricks excluded from the cluster profile.
           # Relax the constraint so pip resolves to 0.3.0 and proceeds normally.
           # pyproject.toml already gates uvloop with sys_platform != 'win32'.
-          sed -i 's/fastbloom-rs>=0.5.0/fastbloom-rs>=0.1.0/' pyproject.toml
+          # fastbloom-rs: only used in rebac/cache bricks excluded from cluster profile.
+          # Its sdist has a broken Cargo.toml structure that fails to build from source
+          # on any platform without pre-built wheels (which don't exist for >=0.5.0).
+          # Remove it entirely so pip install . proceeds cleanly.
+          sed -i '/fastbloom-rs/d' pyproject.toml
           pip install .
 
       # ── protoc (required by nexus_raft build.rs) ─────────────────────────
@@ -156,6 +160,7 @@ jobs:
         run: pip install maturin
 
       - name: Build nexus_fast wheel  (rust/nexus_pyo3)
+        shell: bash
         run: |
           mkdir -p build/dist
           maturin build --release \
@@ -163,6 +168,7 @@ jobs:
             -m rust/nexus_pyo3/Cargo.toml
 
       - name: Build nexus_raft wheel  (rust/nexus_raft --features full)
+        shell: bash
         env:
           PROTOC: ${{ env.NEXUS_PROTOC }}
         run: |
@@ -172,12 +178,14 @@ jobs:
             -m rust/nexus_raft/Cargo.toml
 
       - name: Build nexus_tasks wheel  (rust/nexus_tasks)
+        shell: bash
         run: |
           maturin build --release \
             --out build/dist \
             -m rust/nexus_tasks/Cargo.toml
 
       - name: Install Rust wheels
+        shell: bash
         run: |
           echo "=== Built wheels ==="
           ls -lh build/dist/

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -52,10 +52,10 @@ jobs:
     steps:
       - id: set-matrix
         run: |
-          ALL='{"include":[{"os":"macos-15-intel","artifact_name":"nexus-cluster-macos-x86_64"},{"os":"macos-14","artifact_name":"nexus-cluster-macos-arm64"},{"os":"ubuntu-latest","artifact_name":"nexus-cluster-linux-x86_64"},{"os":"windows-latest","artifact_name":"nexus-cluster-windows-x86_64"},{"os":"windows-11-arm","artifact_name":"nexus-cluster-windows-arm64"}]}'
+          ALL='{"include":[{"os":"macos-15-intel","artifact_name":"nexus-cluster-macos-x86_64"},{"os":"macos-14","artifact_name":"nexus-cluster-macos-arm64"},{"os":"ubuntu-latest","artifact_name":"nexus-cluster-linux-x86_64"},{"os":"windows-latest","artifact_name":"nexus-cluster-windows-x86_64"}]}'
           MACOS='{"include":[{"os":"macos-15-intel","artifact_name":"nexus-cluster-macos-x86_64"},{"os":"macos-14","artifact_name":"nexus-cluster-macos-arm64"}]}'
           LINUX='{"include":[{"os":"ubuntu-latest","artifact_name":"nexus-cluster-linux-x86_64"}]}'
-          WINDOWS='{"include":[{"os":"windows-latest","artifact_name":"nexus-cluster-windows-x86_64"},{"os":"windows-11-arm","artifact_name":"nexus-cluster-windows-arm64"}]}'
+          WINDOWS='{"include":[{"os":"windows-latest","artifact_name":"nexus-cluster-windows-x86_64"}]}'
 
           FILTER="${{ inputs.platform_filter }}"
           # On tag push inputs.platform_filter is empty — default to all

--- a/pyinstaller_spec_cluster.py
+++ b/pyinstaller_spec_cluster.py
@@ -7,80 +7,80 @@ Minimal deployment: storage + ipc + federation
 import os
 
 # Rust extension paths
-NEXUS_RAFT_SO = '/Users/bgd/anaconda3/envs/nexus/lib/python3.13/site-packages/_nexus_raft/_nexus_raft.cpython-313-darwin.so'
-NEXUS_FAST_SO = '/Users/bgd/anaconda3/envs/nexus/lib/python3.13/site-packages/nexus_fast/nexus_fast.cpython-313-darwin.so'
+NEXUS_RAFT_SO = "/Users/bgd/anaconda3/envs/nexus/lib/python3.13/site-packages/_nexus_raft/_nexus_raft.cpython-313-darwin.so"
+NEXUS_FAST_SO = "/Users/bgd/anaconda3/envs/nexus/lib/python3.13/site-packages/nexus_fast/nexus_fast.cpython-313-darwin.so"
 
 # Hidden imports for Rust extensions and nexus modules
 hiddenimports = [
     # Rust extensions
-    '_nexus_raft',
-    '_nexus_raft._nexus_raft',
-    'nexus_fast',
+    "_nexus_raft",
+    "_nexus_raft._nexus_raft",
+    "nexus_fast",
     # Cluster profile core modules
-    'nexus',
-    'nexus.cli',
-    'nexus.cli.main',
-    'nexus.daemon',
-    'nexus.daemon.main',
-    'nexus.raft',
-    'nexus.raft.federation',
-    'nexus.raft.zone_manager',
-    'nexus.storage',
-    'nexus.storage.raft_metadata_store',
-    'nexus.storage.dict_metastore',
-    'nexus.bricks.ipc',
-    'nexus.bricks.federation',
-    'nexus.contracts.deployment_profile',
+    "nexus",
+    "nexus.cli",
+    "nexus.cli.main",
+    "nexus.daemon",
+    "nexus.daemon.main",
+    "nexus.raft",
+    "nexus.raft.federation",
+    "nexus.raft.zone_manager",
+    "nexus.storage",
+    "nexus.storage.raft_metadata_store",
+    "nexus.storage.dict_metastore",
+    "nexus.bricks.ipc",
+    "nexus.bricks.federation",
+    "nexus.contracts.deployment_profile",
     # Required dependencies
-    'click',
-    'rich',
-    'tqdm',
-    'pydantic',
-    'pyyaml',
-    'httpx',
-    'requests',
-    'uvicorn',
-    'fastapi',
-    'starlette',
-    'sqlalchemy',
-    'alembic',
-    'grpc',
-    'grpc_google_apis',
-    'google.protobuf',
-    'google.api',
-    'google.api_core',
+    "click",
+    "rich",
+    "tqdm",
+    "pydantic",
+    "pyyaml",
+    "httpx",
+    "requests",
+    "uvicorn",
+    "fastapi",
+    "starlette",
+    "sqlalchemy",
+    "alembic",
+    "grpc",
+    "grpc_google_apis",
+    "google.protobuf",
+    "google.api",
+    "google.api_core",
 ]
 
 # Exclude heavy modules not needed for cluster profile
 excludes = [
-    'nexus.bricks.llm',
-    'nexus.bricks.pay',
-    'nexus.bricks.sandbox',
-    'nexus.bricks.workflows',
-    'nexus.bricks.search',
-    'nexus.bricks.memory',
-    'nexus.bricks.mcp',
-    'nexus.bricks.agent_runtime',
-    'nexus.bricks.scheduler',
-    'nexus.bricks.cache',
-    'nexus.bricks.observability',
-    'nexus.bricks.uploads',
-    'nexus.bricks.resiliency',
-    'nexus.bricks.acp',
-    'nexus.bricks.permissions',
-    'nexus.bricks.namespace',
-    'nexus.bricks.eventlog',
+    "nexus.bricks.llm",
+    "nexus.bricks.pay",
+    "nexus.bricks.sandbox",
+    "nexus.bricks.workflows",
+    "nexus.bricks.search",
+    "nexus.bricks.memory",
+    "nexus.bricks.mcp",
+    "nexus.bricks.agent_runtime",
+    "nexus.bricks.scheduler",
+    "nexus.bricks.cache",
+    "nexus.bricks.observability",
+    "nexus.bricks.uploads",
+    "nexus.bricks.resiliency",
+    "nexus.bricks.acp",
+    "nexus.bricks.permissions",
+    "nexus.bricks.namespace",
+    "nexus.bricks.eventlog",
 ]
 
 binaries = []
 if os.path.exists(NEXUS_RAFT_SO):
-    binaries.append((NEXUS_RAFT_SO, '_nexus_raft'))
+    binaries.append((NEXUS_RAFT_SO, "_nexus_raft"))
 if os.path.exists(NEXUS_FAST_SO):
-    binaries.append((NEXUS_FAST_SO, 'nexus_fast'))
+    binaries.append((NEXUS_FAST_SO, "nexus_fast"))
 
 a = Analysis(
-    ['src/nexus/cli/main.py'],
-    pathex=['/Users/bgd/repo/nexus/src'],
+    ["src/nexus/cli/main.py"],
+    pathex=["/Users/bgd/repo/nexus/src"],
     binaries=binaries,
     datas=[],
     hiddenimports=hiddenimports,
@@ -100,7 +100,7 @@ exe = EXE(
     a.binaries,
     a.datas,
     [],
-    name='nexus-cluster',
+    name="nexus-cluster",
     debug=False,
     bootloader_ignore_signals=False,
     strip=False,

--- a/pyinstaller_spec_cluster.py
+++ b/pyinstaller_spec_cluster.py
@@ -1,11 +1,10 @@
-# -*- mode: python ; coding: utf-8 -*-
+# ruff: noqa: F821
 """
 PyInstaller spec for nexus (profile=cluster)
 Minimal deployment: storage + ipc + federation
 """
 
 import os
-import glob
 
 # Rust extension paths
 NEXUS_RAFT_SO = '/Users/bgd/anaconda3/envs/nexus/lib/python3.13/site-packages/_nexus_raft/_nexus_raft.cpython-313-darwin.so'

--- a/pyinstaller_spec_cluster.py
+++ b/pyinstaller_spec_cluster.py
@@ -1,0 +1,117 @@
+# -*- mode: python ; coding: utf-8 -*-
+"""
+PyInstaller spec for nexus (profile=cluster)
+Minimal deployment: storage + ipc + federation
+"""
+
+import os
+import glob
+
+# Rust extension paths
+NEXUS_RAFT_SO = '/Users/bgd/anaconda3/envs/nexus/lib/python3.13/site-packages/_nexus_raft/_nexus_raft.cpython-313-darwin.so'
+NEXUS_FAST_SO = '/Users/bgd/anaconda3/envs/nexus/lib/python3.13/site-packages/nexus_fast/nexus_fast.cpython-313-darwin.so'
+
+# Hidden imports for Rust extensions and nexus modules
+hiddenimports = [
+    # Rust extensions
+    '_nexus_raft',
+    '_nexus_raft._nexus_raft',
+    'nexus_fast',
+    # Cluster profile core modules
+    'nexus',
+    'nexus.cli',
+    'nexus.cli.main',
+    'nexus.daemon',
+    'nexus.daemon.main',
+    'nexus.raft',
+    'nexus.raft.federation',
+    'nexus.raft.zone_manager',
+    'nexus.storage',
+    'nexus.storage.raft_metadata_store',
+    'nexus.storage.dict_metastore',
+    'nexus.bricks.ipc',
+    'nexus.bricks.federation',
+    'nexus.contracts.deployment_profile',
+    # Required dependencies
+    'click',
+    'rich',
+    'tqdm',
+    'pydantic',
+    'pyyaml',
+    'httpx',
+    'requests',
+    'uvicorn',
+    'fastapi',
+    'starlette',
+    'sqlalchemy',
+    'alembic',
+    'grpc',
+    'grpc_google_apis',
+    'google.protobuf',
+    'google.api',
+    'google.api_core',
+]
+
+# Exclude heavy modules not needed for cluster profile
+excludes = [
+    'nexus.bricks.llm',
+    'nexus.bricks.pay',
+    'nexus.bricks.sandbox',
+    'nexus.bricks.workflows',
+    'nexus.bricks.search',
+    'nexus.bricks.memory',
+    'nexus.bricks.mcp',
+    'nexus.bricks.agent_runtime',
+    'nexus.bricks.scheduler',
+    'nexus.bricks.cache',
+    'nexus.bricks.observability',
+    'nexus.bricks.uploads',
+    'nexus.bricks.resiliency',
+    'nexus.bricks.acp',
+    'nexus.bricks.permissions',
+    'nexus.bricks.namespace',
+    'nexus.bricks.eventlog',
+]
+
+binaries = []
+if os.path.exists(NEXUS_RAFT_SO):
+    binaries.append((NEXUS_RAFT_SO, '_nexus_raft'))
+if os.path.exists(NEXUS_FAST_SO):
+    binaries.append((NEXUS_FAST_SO, 'nexus_fast'))
+
+a = Analysis(
+    ['src/nexus/cli/main.py'],
+    pathex=['/Users/bgd/repo/nexus/src'],
+    binaries=binaries,
+    datas=[],
+    hiddenimports=hiddenimports,
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=excludes,
+    noarchive=False,
+    optimize=0,
+)
+
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    a.binaries,
+    a.datas,
+    [],
+    name='nexus-cluster',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    runtime_tmpdir=None,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)

--- a/pyinstaller_spec_cluster.spec
+++ b/pyinstaller_spec_cluster.spec
@@ -1,0 +1,44 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+
+a = Analysis(
+    ['pyinstaller_spec_cluster.py'],
+    pathex=[],
+    binaries=[],
+    datas=[],
+    hiddenimports=[],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    noarchive=False,
+    optimize=0,
+)
+pyz = PYZ(a.pure)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='pyinstaller_spec_cluster',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=True,
+    disable_windowed_traceback=False,
+    argv_emulation=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='pyinstaller_spec_cluster',
+)


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to build a standalone `nexus-cluster` binary with PyInstaller
- add cluster-specific PyInstaller spec files and CI patching so bundled binaries resolve installed Rust extensions across macOS and Windows
- adjust the workflow for current CI constraints, including protoc setup, wheel installation, artifact upload, and platform matrix handling

## Testing
- not run locally (PR creation only)