### PR TITLE
cleanup: remove stale cache/sync references after kernel refactor

### DIFF
--- a/src/nexus/backends/base/path_addressing_engine.py
+++ b/src/nexus/backends/base/path_addressing_engine.py
@@ -250,16 +250,6 @@ class PathAddressingEngine(Backend):
                 backend=self.name,
             )
 
-        # Cache optimization: check cache first if available
-        if (
-            hasattr(self, "_get_size_from_cache")
-            and hasattr(context, "virtual_path")
-            and context.virtual_path
-        ):
-            cached_size = self._get_size_from_cache(context.virtual_path)
-            if cached_size is not None:
-                return int(cached_size)
-
         blob_path = self._get_key_path(context.backend_path)
         return self._transport.get_size(blob_path)
 

--- a/src/nexus/backends/connectors/slack/connector.py
+++ b/src/nexus/backends/connectors/slack/connector.py
@@ -319,7 +319,7 @@ class PathSlackBackend(
             if not backend_path.endswith(".yaml"):
                 return None
 
-            # Return timestamp-based version so sync_pipeline can detect staleness
+            # Return timestamp-based version for staleness detection
             return str(int(datetime.now(UTC).timestamp()))
         except Exception as e:
             logger.debug("Slack version check failed: %s", e)

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -763,11 +763,7 @@ class SearchService:
         list_context: Any,
         recursive: bool,
     ) -> builtins.list[str]:
-        """List directory entries via live API.
-
-        The old SYNC_ELIGIBLE / metastore-first path was removed — the sync
-        infrastructure that populated the metastore no longer exists.
-        """
+        """List directory entries via live API."""
         return self._list_dir_parallel(
             backend=route.backend,
             root_path=path,

--- a/src/nexus/contracts/backend_features.py
+++ b/src/nexus/contracts/backend_features.py
@@ -68,12 +68,6 @@ class BackendFeature(StrEnum):
     PATH_DELETE = "path_delete"
     """Backend supports path-based delete (not just hash-based)."""
 
-    CACHE_BULK_READ = "cache_bulk_read"
-    """Backend supports read_bulk_from_cache() for bulk cache reads."""
-
-    CACHE_SYNC = "cache_sync"
-    """Backend supports sync_to_cache() / sync_from_cache()."""
-
     MULTIPART_UPLOAD = "multipart_upload"
     """Backend supports multipart/chunked uploads."""
 

--- a/tests/unit/backends/test_capabilities.py
+++ b/tests/unit/backends/test_capabilities.py
@@ -45,8 +45,8 @@ class TestBackendFeatureEnum:
         assert len(values) == len(set(values))
 
     def test_expected_member_count(self) -> None:
-        """18 features after sync/cache cleanup removed SYNC_ELIGIBLE and CHANGE_NOTIFICATIONS."""
-        assert len(BackendFeature) == 18
+        """16 features after removing CACHE_BULK_READ and CACHE_SYNC."""
+        assert len(BackendFeature) == 16
 
     def test_str_enum_identity(self) -> None:
         """StrEnum values can be compared with plain strings."""


### PR DESCRIPTION
## Summary
Clean up 4 stale references left behind by the kernel Rust refactor:
- Delete dead `CACHE_BULK_READ` + `CACHE_SYNC` enum members (0 callers)
- Remove dead `_get_size_from_cache` hasattr check in PathAddressingEngine
- Clean stale `SYNC_ELIGIBLE` and `sync_pipeline` comments

## Test plan
- [x] Ruff + mypy clean
- [x] Pre-commit hooks pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)