### PR TITLE
chore(release): bump package versions to v0.9.27

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1572,7 +1572,7 @@ dependencies = [
 
 [[package]]
 name = "nexus_kernel"
-version = "0.9.26"
+version = "0.9.27"
 dependencies = [
  "ahash",
  "blake3",

--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/api-client",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "description": "Shared HTTP client for Nexus APIs — retry, auth, error mapping, case transform",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/tui",
-  "version": "0.9.26",
+  "version": "0.9.27",
   "description": "Terminal UI for Nexus \u2014 file explorer, API inspector, and monitoring dashboard",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.26"
+version = "0.9.27"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.12"

--- a/rust/nexus_kernel/Cargo.toml
+++ b/rust/nexus_kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nexus_kernel"
-version = "0.9.26"
+version = "0.9.27"
 edition = "2021"
 
 [lib]

--- a/rust/nexus_kernel/pyproject.toml
+++ b/rust/nexus_kernel/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-kernel"
-version = "0.9.26"
+version = "0.9.27"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
 requires-python = ">=3.12"
 classifiers = [

--- a/uv.lock
+++ b/uv.lock
@@ -3407,7 +3407,7 @@ wheels = [
 
 [[package]]
 name = "nexus-ai-fs"
-version = "0.9.26"
+version = "0.9.27"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary
- bump nexus-ai-fs package version to 0.9.27
- bump nexus-kernel Rust/Python package metadata to 0.9.27
- bump published TS package versions and sync lockfiles

## Testing
- not run (version metadata only)