### PR TITLE
chore(ipc): clean up PipeManager leftovers from PR #3671

### DIFF
--- a/docs/guides/user-guide.md
+++ b/docs/guides/user-guide.md
@@ -1136,7 +1136,8 @@ useful map.
 
 | Package group | What it gives you as a user |
 | --- | --- |
-| `nexus.core` | the kernel, VFS, syscalls, routing, locks |
+| `nexus.core` | the kernel facade, VFS, syscalls, routing, locks |
+| `nexus_kernel` (Rust) | Rust kernel binary — DT_PIPE / DT_STREAM registries, mount router, blocking IPC waits, and the syscall fast paths used by background consumers |
 | `nexus.contracts` | stable protocol and type boundaries |
 | `nexus.storage` | metadata, record store, history, audit, snapshots |
 | `nexus.backends` | local/cloud/object backends and connector adapters |
@@ -1160,7 +1161,6 @@ useful map.
 | `nexus.system_services.event_subsystem` | replay, subscriptions, exporters |
 | `nexus.system_services.sync` | sync and write-back plumbing |
 | `nexus.system_services.agent_runtime` | embedded agent process runtime |
-| `nexus.system_services.pipe_manager` | kernel pipe plumbing used by background consumers |
 
 ### Bricks for user features
 

--- a/src/nexus/cli/data/nexus-stack.yml
+++ b/src/nexus/cli/data/nexus-stack.yml
@@ -99,7 +99,7 @@ services:
       NEXUS_GRPC_BIND_ALL: ${NEXUS_GRPC_BIND_ALL:-true}
       # 0.0.0.0 is a valid bind address but not a valid connect/advertise address.
       # Without this, NEXUS_ADVERTISE_ADDR defaults to 0.0.0.0 which fails the
-      # insecure-channel loopback check when pipe_manager connects back to itself.
+      # gRPC insecure-channel loopback check when the kernel reconnects to itself.
       # Default to 127.0.0.1 for single-node; override for federation/cross-container.
       # NEXUS_GRPC_PORT is fixed at 2028 inside this container (host port varies via mapping).
       NEXUS_ADVERTISE_ADDR: ${NEXUS_ADVERTISE_ADDR:-127.0.0.1:2028}

--- a/src/nexus/core/pipe.py
+++ b/src/nexus/core/pipe.py
@@ -7,11 +7,13 @@ Implements the Kernel messaging tier from KERNEL-ARCHITECTURE.md §6:
     | **Kernel** | kfifo ring buffer| Nexus Native Pipe (DT_PIPE)        | ~0.5μs  |
 
 This file defines the PipeBackend protocol and exception classes for DT_PIPE.
-The actual data plane lives in the Rust kernel IPC registry (DashMap<String, RingBufferCore>).
-For VFS-visible named pipes (mkfifo/fs/pipe.c equivalent), see core/pipe_manager.py.
+The actual data plane lives in the Rust kernel IPC registry
+(DashMap<String, RingBufferCore>) inside ``nexus_kernel``. The mkfifo /
+``fs/pipe.c`` equivalent (named-pipe creation, lookup, destroy) is also
+owned by the Rust kernel — there is no Python ``PipeManager`` anymore.
 
-    pipe.py         = protocol + exceptions
-    core/pipe_manager.py = fs/pipe.c (VFS named pipe, kernel tier)
+    pipe.py = Python-side protocol + exceptions
+    rust/nexus_kernel/src/ipc/pipe.rs = Rust kernel pipe registry (data plane)
 
 Storage model (KERNEL-ARCHITECTURE.md line 228):
     - Pipe **inode** (FileMetadata, entry_type=DT_PIPE) → MetastoreABC

--- a/src/nexus/factory/zoekt_pipe_consumer.py
+++ b/src/nexus/factory/zoekt_pipe_consumer.py
@@ -5,7 +5,7 @@ chain with DT_PIPE kernel IPC via sys_write/sys_read, decoupling the
 ObjectStore write hot path from Zoekt's threading.Lock + timer debounce.
 
 Issue #810: Decouple Zoekt on_write_callback sync from ObjectStore write path.
-Issue #1772: Migrate from PipeManager to sys_write/sys_read.
+Issue #1772: Migrated to sys_write/sys_read backed by the Rust kernel pipe registry.
 
 Architecture:
     CASLocalBackend.write_content() (sync)
@@ -115,16 +115,9 @@ class ZoektPipeConsumer:
         if self._nx is None:
             return  # CLI mode
 
-        pipe_manager = getattr(self._nx, "_pipe_manager", None)
-        if pipe_manager is not None:
-            pipe_manager.ensure(
-                _ZOEKT_PIPE_PATH,
-                owner_id="kernel",
-            )
-        else:
-            # Test/degraded path: fall back to direct syscall-based pipe creation
-            # when NexusFS exposes DT_PIPE syscalls but no PipeManager object.
-            await self._nx.sys_setattr(_ZOEKT_PIPE_PATH)
+        # Create the pipe via the public syscall — the Rust kernel router
+        # picks up DT_PIPE entry_type from the metastore.
+        await self._nx.sys_setattr(_ZOEKT_PIPE_PATH)
 
         self._pipe_ready = True
         self._consumer_task = asyncio.create_task(self._consume())

--- a/src/nexus/server/lifespan/services.py
+++ b/src/nexus/server/lifespan/services.py
@@ -584,13 +584,15 @@ async def _startup_workflow_engine(app: "FastAPI", svc: "LifespanServices") -> N
 
 
 async def _startup_pipe_consumers(app: "FastAPI", svc: "LifespanServices") -> None:
-    """Inject PipeManager and start DT_PIPE consumers (Issue #809, #810).
+    """Start DT_PIPE consumers (Issue #809, #810).
 
     Two consumers are started here:
     1. PipedRecordStoreWriteObserver — async RecordStore sync via kernel IPC
     2. ZoektPipeConsumer — async Zoekt index notifications via kernel IPC
 
     All consumers use NexusFS sys_read/sys_write for pipe I/O (Rust kernel).
+    PipeManager itself was deleted in PR #3671 — the kernel pipe registry
+    is now managed entirely inside the Rust binary.
     """
     nx = svc.nexus_fs
 

--- a/src/nexus/storage/write_observer_hooks.py
+++ b/src/nexus/storage/write_observer_hooks.py
@@ -1,13 +1,14 @@
-"""Audit interceptor: serialize VFS mutations → DT_PIPE via sys_write.
+"""Audit interceptor: serialize VFS mutations → DT_PIPE via NexusFS Tier 2 API.
 
-Async VFS interceptor hook that serializes each mutation event to JSON
-and writes it into a DT_PIPE via ``nx.sys_write(pipe_path, data)``.
+Sync VFS interceptor hook that serializes each mutation event to JSON
+and writes it into the audit DT_PIPE via ``nx.pipe_write_nowait()``
+(Tier 2 sync passthrough to the Rust kernel ring buffer, ~0.5μs).
 The pipe is consumed by ``PipedRecordStoreWriteObserver`` which flushes
 events to RecordStore in batches.
 
-By using ``sys_write`` instead of ``PipeManager`` directly, the
-interceptor is decoupled from kernel internals and benefits from the
-IPC fast-path (~1μs).
+The interceptor uses the public NexusFS pipe API rather than reaching
+into kernel internals, decoupling it from the underlying transport
+while still benefiting from the IPC fast-path.
 
 Issue #900, #1772.
 """
@@ -155,7 +156,7 @@ class AuditWriteInterceptor:
 
     name = "audit_write_observer"
 
-    __slots__ = ("_nx", "_pipe_path", "_strict_mode", "_pipe_buffer")
+    __slots__ = ("_nx", "_pipe_path", "_strict_mode")
 
     # ── Hook spec (duck-typed) (Issue #1613) ──────────────────────────
 
@@ -175,11 +176,6 @@ class AuditWriteInterceptor:
         self._nx = nx
         self._pipe_path = pipe_path
         self._strict_mode = strict_mode
-        # Cache the pipe buffer reference for direct writes.
-        # Avoids going through the full VFS sys_write pipeline which would
-        # re-trigger post-write hooks (including this one), causing a 5s
-        # timeout per write via _post_dispatch's asyncio.wait_for.
-        self._pipe_buffer: Any = None
 
     # ── VFSWriteHook ──────────────────────────────────────────────────
 
@@ -278,32 +274,27 @@ class AuditWriteInterceptor:
     # ── Internal ──────────────────────────────────────────────────────
 
     def _emit(self, event: dict[str, Any], operation: str, op_path: str) -> None:
-        """Serialize event to JSON and write directly to the pipe buffer (~0.5μs).
+        """Serialize event to JSON and write directly to the Rust pipe buffer (~0.5μs).
 
-        Writes directly to PipeManager's in-memory ring buffer via
-        ``write_nowait()`` — synchronous, non-blocking Rust call.
+        Writes via ``NexusFS.pipe_write_nowait()`` — Tier 2 sync passthrough
+        to the Rust kernel ring buffer. Synchronous and non-blocking, so
+        this hook does not re-trigger post-write hooks (which would cause
+        a recursive sys_write loop and 5s timeout per write).
 
-        If the pipe buffer isn't ready (startup race), the event is dropped
-        with a warning. This eliminates the recursive sys_write fallback
-        that caused 5s timeouts in the previous async implementation.
+        If the pipe buffer is closed/missing (startup race or kernel
+        teardown), the event is dropped with a warning.
         """
         try:
             data = json.dumps(event).encode()
 
-            # Fast path: write directly to cached pipe buffer (~0.5μs)
-            buf = self._pipe_buffer
-            if buf is None:
-                pm = getattr(self._nx, "_pipe_manager", None)
-                if pm is not None:
-                    buf = pm._buffers.get(self._pipe_path)
-                    if buf is not None:
-                        self._pipe_buffer = buf
-
-            if buf is not None:
-                buf.write_nowait(data)
+            # Fast path: kernel ring buffer write (~0.5μs, no GIL re-entry).
+            try:
+                self._nx.pipe_write_nowait(self._pipe_path, data)
                 return
+            except Exception:
+                # Pipe not ready (startup race) or closed — fall through to drop.
+                pass
 
-            # Pipe not ready (startup race) — drop event with warning.
             logger.warning(
                 "Audit pipe not ready, dropping %s event for '%s'",
                 operation,

--- a/src/nexus/task_manager/dispatch_consumer.py
+++ b/src/nexus/task_manager/dispatch_consumer.py
@@ -94,12 +94,6 @@ class TaskDispatchPipeConsumer:
     # Deferred injection
     # ------------------------------------------------------------------
 
-    def set_pipe_manager(self, pipe_manager: Any) -> None:
-        """Legacy shim — accepts PipeManager or NexusFS. Use set_nx() instead."""
-        # Callers passing NexusFS directly
-        if hasattr(pipe_manager, "_kernel"):
-            self._nx = pipe_manager
-
     def set_nx(self, nx: "NexusFS") -> None:
         """Inject NexusFS for Rust-kernel pipe I/O."""
         self._nx = nx


### PR DESCRIPTION
## Summary

Follow-up cleanup for the IPC Rust-ification (PR #3671). PR #3671
deleted the Python ``PipeManager`` and migrated everything to the Rust
kernel ring-buffer registry, but a handful of adjacent files were
missed in the audit. This cleanup PR closes the remaining gaps.

## Production bug fix (audit logging silently broken)

``AuditWriteInterceptor._emit`` cached a pipe-buffer reference fetched
via ``getattr(self._nx, ""_pipe_manager"", None)`` — but ``_pipe_manager``
was deleted in PR #3671, so the lookup always returned None and every
audit event hit the ""Pipe not ready, dropping ..."" warning branch.
**Audit logging was effectively disabled.**

Fix: replace the cached buffer dance with a direct
``self._nx.pipe_write_nowait(self._pipe_path, data)`` call (Tier 2 sync
passthrough to the Rust kernel ring buffer, ~0.5μs). This is the
publicly supported NexusFS API added in PR #3671 and is exactly the
mechanism the rest of the IPC migration adopted.

Also drops the now-unused ``_pipe_buffer`` ``__slots__`` entry.

## Dead branch removals

- ``src/nexus/factory/zoekt_pipe_consumer.py``: drop the
  ``_pipe_manager`` getattr fallback — always None now, so the
  conditional always took the ``else`` branch. Collapse to it.
- ``src/nexus/task_manager/dispatch_consumer.py``: delete the
  ``set_pipe_manager()`` legacy shim. Zero callers remain.

## Stale comments / docs

- ``src/nexus/server/lifespan/services.py``: ``_startup_pipe_consumers``
  docstring claimed it injects PipeManager — it doesn't.
- ``src/nexus/core/pipe.py``: header docstring referenced
  ``core/pipe_manager.py`` (deleted). Point at the Rust source instead.
- ``docs/guides/user-guide.md``: replace the deleted
  ``nexus.system_services.pipe_manager`` row with a ``nexus_kernel``
  (Rust) row in the kernel section — the functionality moved to Rust,
  it didn't disappear.
- ``src/nexus/cli/data/nexus-stack.yml``: rewrite the
  ``NEXUS_ADVERTISE_ADDR`` comment that mentioned ``pipe_manager``.

## Test plan

- [x] 315 targeted unit tests pass locally (storage/test_piped_write_observer_flush, core/test_pipe_consumers, core/test_pipe_dispatch, core/test_write_observer_calls, factory/test_retroactive_hook_specs, services/test_dedup_work_queue, services/test_workflow_dispatch, services/test_acp_service, server/test_rpc_parity, server/lifespan/test_lifespan_services, fs/test_fsspec_upstream, bricks/ipc/*)
- [ ] CI green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)