### PR TITLE
ci(codegen): enforce kernel ABI codegen sync in CI + simplify pre-commit

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -38,9 +38,9 @@ jobs:
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             BASE=${{ github.event.pull_request.base.sha }}
             HEAD=${{ github.event.pull_request.head.sha }}
-            CHANGED=$(git diff --name-only "$BASE"..."$HEAD" | grep -E '\.(py|yaml)$' | grep -E '^(src/|tests/|\.pre-commit)' || true)
+            CHANGED=$(git diff --name-only "$BASE"..."$HEAD" | grep -E '\.(py|yaml|rs|pyi)$' | grep -E '^(src/|tests/|\.pre-commit|rust/|stubs/|scripts/codegen)' || true)
           else
-            CHANGED=$(git diff --name-only HEAD^...HEAD | grep -E '\.py$' | grep -E '^(src/|tests/)' || true)
+            CHANGED=$(git diff --name-only HEAD^...HEAD | grep -E '\.(py|rs|pyi)$' | grep -E '^(src/|tests/|rust/|stubs/|scripts/codegen)' || true)
           fi
           if [ -n "$CHANGED" ]; then
             echo "python_changed=true" >> $GITHUB_OUTPUT
@@ -187,6 +187,39 @@ jobs:
         if: failure()
         run: |
           echo "::error::Brick import boundary violations detected. See NEXUS-LEGO-ARCHITECTURE.md §1.2."
+
+  codegen-sync:
+    name: Codegen Sync Check
+    needs: detect-changes
+    if: needs.detect-changes.outputs.python_changed == 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.12'
+
+      - name: Install Rust toolchain (for rustfmt)
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: rustfmt
+
+      - name: Install ruff
+        run: pip install ruff
+
+      - name: Verify codegen outputs are up-to-date
+        run: python3 scripts/codegen_kernel_abi.py --check
+
+  # Skip-pass job for branch protection when no Python files changed
+  codegen-sync-skip:
+    name: Codegen Sync Check
+    needs: detect-changes
+    if: needs.detect-changes.outputs.python_changed != 'true'
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "No Python files changed — skipping codegen sync check"
 
   import-linter:
     name: Architecture Boundary Check (import-linter)

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -108,17 +108,13 @@ repos:
         pass_filenames: false
         files: ^rust/nexus_raft/.*\.rs$
 
-      # Codegen sync check — regenerate + ruff format + verify no diff
+      # Codegen sync check — verify all 4 generated files (Python + Rust) are up-to-date
       - id: codegen-check
         name: Codegen Sync Check
-        entry: >-
-          bash -c 'python3 scripts/codegen_kernel_abi.py
-          && python3 -m ruff format stubs/nexus_kernel/__init__.pyi src/nexus/core/kernel_protocols.py src/nexus/core/kernel_exports.py --quiet
-          && git diff --quiet stubs/nexus_kernel/__init__.pyi src/nexus/core/kernel_protocols.py src/nexus/core/kernel_exports.py
-          || (echo "ERROR: codegen output stale — run: python3 scripts/codegen_kernel_abi.py" && exit 1)'
+        entry: python3 scripts/codegen_kernel_abi.py --check
         language: system
         pass_filenames: false
-        files: ^(rust/nexus_kernel/src/.*\.rs|scripts/codegen_kernel_abi\.py)$
+        files: ^(rust/nexus_kernel/src/.*\.rs|scripts/codegen_kernel_abi\.py|stubs/nexus_kernel/|src/nexus/core/kernel_)$
 
       # Rust quality: no todo!()/unimplemented!() in committed code
       - id: rust-no-todo


### PR DESCRIPTION
## Summary

Two gaps in the kernel ABI codegen enforcement:

1. **Pre-commit hook didn't diff-check ``generated_pyo3.rs``** — the
   existing ``codegen-check`` hook ran ``git diff --quiet`` on the 3
   Python outputs (stubs, protocols, exports) only, so a hand-edited
   ``rust/nexus_kernel/src/generated_pyo3.rs`` (2215 lines, the PyO3
   boundary wrapper) could be committed undetected as long as the
   Python outputs happened to match.

2. **No CI step ran the codegen check at all.** If pre-commit was
   bypassed with ``--no-verify``, stale generated files could land on
   develop silently. The codegen script has a ``--check`` mode that
   was never wired into CI.

## Changes

### ``.pre-commit-config.yaml``
Replace the 4-step bash chain (regenerate + ruff format + ``git diff --quiet``
on 3 files) with a single ``python3 scripts/codegen_kernel_abi.py --check``
call. The ``--check`` mode already:
- Checks all 4 outputs including ``generated_pyo3.rs``
- Runs ``ruff format`` on Python outputs and ``rustfmt`` on Rust outputs internally
- Exits 1 with a ``STALE: <path>`` diagnostic on drift

Also widens the ``files:`` trigger to include the generated outputs themselves
(``stubs/``, ``kernel_exports.py``, ``kernel_protocols.py``) so edits to those
files also run the check.

### ``.github/workflows/code-quality.yml``
Add a new ``codegen-sync`` job (+ ``codegen-sync-skip`` for branch protection
when no relevant files changed) that runs ``codegen_kernel_abi.py --check``
in CI. Installs a stable Rust toolchain for ``rustfmt`` (needed because the
check formats Rust outputs before comparing).

### ``detect-changes``
Widen the filter to also trigger on ``.rs``, ``.pyi``, ``rust/``, ``stubs/``,
and ``scripts/codegen*`` changes so the codegen job runs on Rust-only PRs
(the previous filter only matched Python files under ``src/`` and ``tests/``).

## Test plan

- [x] ``python3 scripts/codegen_kernel_abi.py --check`` reports ``OK`` for all 4 outputs when in sync
- [x] Manually hand-edited ``generated_pyo3.rs`` → ``--check`` correctly reports ``STALE`` + exit 1
- [x] Pre-commit hook passes locally on the modified Rust kernel source files
- [ ] CI codegen-sync job green on PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)