### PR TITLE
fix(#3702): expose path + search_mode on nexus_semantic_search MCP tool

### DIFF
--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -798,8 +798,11 @@ async def create_mcp_server(
             "openWorldHint": True,
         }
     )
-    def nexus_semantic_search(
+    @handle_tool_errors("semantic search")
+    async def nexus_semantic_search(
         query: str,
+        path: str = "/",
+        search_mode: str = "semantic",
         limit: int = 10,
         offset: int = 0,
         response_format: str = "json",
@@ -809,6 +812,10 @@ async def create_mcp_server(
 
         Args:
             query: Natural language search query
+            path: Directory path to scope the search (default: "/" searches everywhere)
+            search_mode: Search mode - "semantic" (default, embedding-based),
+                "keyword" (BM25/text, faster), or "hybrid" (both pipelines,
+                higher quality but more expensive)
             limit: Maximum number of results to return (default: 10)
             offset: Number of results to skip (default: 0)
             response_format: Output format - "json" or "markdown" (default: "json")
@@ -823,6 +830,8 @@ async def create_mcp_server(
             - next_offset: Offset for next page (if has_more is true)
 
         Example:
+            Scoped search: nexus_semantic_search("auth logic", path="/workspace/src")
+            Hybrid mode: nexus_semantic_search("token refresh", search_mode="hybrid")
             First page: nexus_semantic_search("machine learning algorithms", limit=10)
             Next page: nexus_semantic_search("machine learning algorithms", limit=10, offset=10)
         """
@@ -834,10 +843,11 @@ async def create_mcp_server(
             )
 
         try:
-            from nexus.lib.sync_bridge import run_sync
-
+            # Over-fetch to allow has_more detection without a second round-trip
             fetch_limit = offset + limit * 2
-            all_results = run_sync(nx_instance.semantic_search(query, path="/", limit=fetch_limit))
+            all_results = await nx_instance.semantic_search(
+                query, path=path, search_mode=search_mode, limit=fetch_limit
+            )
         except Exception as e:
             if "not initialized" in str(e).lower():
                 return tool_error("unavailable", "Semantic search not available (not initialized).")

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -2654,13 +2654,16 @@ class SearchService:
             LIMIT :lim
         """)
 
-        try:
+        def _run_query() -> list:
             session = self._record_store.session_factory()
             try:
                 result = session.execute(sql, bind_params)
-                rows = result.fetchall()
+                return result.fetchall()
             finally:
                 session.close()
+
+        try:
+            rows = await asyncio.to_thread(_run_query)
         except Exception as e:
             logger.warning("SQL chunk search failed: %s", e, exc_info=True)
             return []

--- a/tests/e2e/self_contained/mcp/test_mcp_server_integration.py
+++ b/tests/e2e/self_contained/mcp/test_mcp_server_integration.py
@@ -480,7 +480,7 @@ class TestSemanticSearchIntegration:
             pytest.skip("Semantic search tool not registered")
 
         search_tool = await get_tool(mcp_server, "nexus_semantic_search")
-        result = search_tool.fn(query="test files", limit=5)
+        result = await search_tool.fn(query="test files", limit=5)
 
         # Should return JSON results or indicate not available
         assert "not available" in result or result.startswith("[") or result.startswith("{")
@@ -676,7 +676,7 @@ class TestComprehensiveMCPToolsWorkflow:
         # Step 8: Test nexus_semantic_search (optional)
         if await tool_exists(mcp_server, "nexus_semantic_search"):
             search_tool = await get_tool(mcp_server, "nexus_semantic_search")
-            search_result = search_tool.fn(query="test files", limit=5)
+            search_result = await search_tool.fn(query="test files", limit=5)
             # Should return result or indicate not available
             assert "not available" in search_result or search_result.startswith("[")
 

--- a/tests/unit/bricks/mcp/test_mcp_server_tools.py
+++ b/tests/unit/bricks/mcp/test_mcp_server_tools.py
@@ -17,10 +17,14 @@ from nexus.bricks.mcp.server import create_mcp_server
 
 
 def get_tool(server, tool_name: str):
-    """Helper to get a tool from the MCP server."""
-    lp = server._local_provider
-    tools = {v.name: v for k, v in lp._components.items() if k.startswith("tool:")}
-    return tools[tool_name]
+    """Helper to get a tool from the MCP server (FastMCP 2.x and 3.x compat)."""
+    # FastMCP 3.x API
+    if hasattr(server, "_local_provider"):
+        lp = server._local_provider
+        tools = {v.name: v for k, v in lp._components.items() if k.startswith("tool:")}
+        return tools[tool_name]
+    # FastMCP 2.x API
+    return server._tool_manager._tools[tool_name]
 
 
 def get_prompt(server, prompt_name: str):
@@ -38,7 +42,11 @@ def get_resource_template(server, uri_pattern: str):
 
 
 def tool_exists(server, tool_name: str) -> bool:
-    """Check if a tool exists in the server."""
+    """Check if a tool exists in the server (FastMCP 2.x and 3.x compat)."""
+    if hasattr(server, "_local_provider"):
+        lp = server._local_provider
+        names = {v.name for k, v in lp._components.items() if k.startswith("tool:")}
+        return tool_name in names
     return tool_name in server._tool_manager._tools
 
 

--- a/tests/unit/bricks/mcp/test_mcp_server_tools.py
+++ b/tests/unit/bricks/mcp/test_mcp_server_tools.py
@@ -18,7 +18,9 @@ from nexus.bricks.mcp.server import create_mcp_server
 
 def get_tool(server, tool_name: str):
     """Helper to get a tool from the MCP server."""
-    return server._tool_manager._tools[tool_name]
+    lp = server._local_provider
+    tools = {v.name: v for k, v in lp._components.items() if k.startswith("tool:")}
+    return tools[tool_name]
 
 
 def get_prompt(server, prompt_name: str):
@@ -103,7 +105,7 @@ def mock_nx_with_search():
     nx.sys_write = AsyncMock()
 
     # Add async semantic_search method
-    async def mock_semantic_search(query, path="/", limit=10, **kwargs):
+    async def mock_semantic_search(query, path="/", search_mode="semantic", limit=10, **kwargs):
         return [{"path": "/file1.txt", "score": 0.95, "snippet": "relevant content"}]
 
     nx.semantic_search = AsyncMock(side_effect=mock_semantic_search)
@@ -691,16 +693,42 @@ class TestSearchTools:
         server = await create_mcp_server(nx=mock_nx_with_search)
 
         search_tool = get_tool(server, "nexus_semantic_search")
-        result = search_tool.fn(query="authentication code", limit=5)
+        result = await search_tool.fn(query="authentication code", limit=5)
 
         response = json.loads(result)
         assert isinstance(response, dict)
         assert "items" in response
         assert "total" in response
         assert isinstance(response["items"], list)
-        # Note: With pagination, we now fetch limit*2 to check for more results
+        # Over-fetches limit*2 to allow has_more detection without a second round-trip
         mock_nx_with_search.semantic_search.assert_called_once_with(
-            "authentication code", path="/", limit=10
+            "authentication code", path="/", search_mode="semantic", limit=10
+        )
+
+    async def test_semantic_search_with_scoped_path(self, mock_nx_with_search):
+        """Test that path parameter is forwarded to semantic_search (regression for #3702)."""
+        server = await create_mcp_server(nx=mock_nx_with_search)
+
+        search_tool = get_tool(server, "nexus_semantic_search")
+        result = await search_tool.fn(query="auth", path="/workspace/src", limit=5)
+
+        response = json.loads(result)
+        assert "items" in response
+        mock_nx_with_search.semantic_search.assert_called_once_with(
+            "auth", path="/workspace/src", search_mode="semantic", limit=10
+        )
+
+    async def test_semantic_search_with_search_mode(self, mock_nx_with_search):
+        """Test that search_mode is forwarded to semantic_search."""
+        server = await create_mcp_server(nx=mock_nx_with_search)
+
+        search_tool = get_tool(server, "nexus_semantic_search")
+        result = await search_tool.fn(query="token refresh", search_mode="hybrid", limit=5)
+
+        response = json.loads(result)
+        assert "items" in response
+        mock_nx_with_search.semantic_search.assert_called_once_with(
+            "token refresh", path="/", search_mode="hybrid", limit=10
         )
 
     async def test_semantic_search_not_available(self, mock_nx_basic):
@@ -712,7 +740,7 @@ class TestSearchTools:
         server = await create_mcp_server(nx=mock_nx_basic)
 
         search_tool = get_tool(server, "nexus_semantic_search")
-        result = search_tool.fn(query="test")
+        result = await search_tool.fn(query="test")
 
         assert "Semantic search not available" in result
 
@@ -722,7 +750,7 @@ class TestSearchTools:
         server = await create_mcp_server(nx=mock_nx_with_search)
 
         search_tool = get_tool(server, "nexus_semantic_search")
-        result = search_tool.fn(query="test")
+        result = await search_tool.fn(query="test")
 
         assert "Error in semantic search" in result
         assert "Search service down" in result


### PR DESCRIPTION
Closes #3702

## Summary

- `nexus_semantic_search` hardcoded `path="/"`, blocking agents from scoping semantic search to a subtree. `nexus_grep` and `nexus_glob` both expose `path` — this was a missing MCP boundary param. `SearchService.semantic_search()` already accepted it end-to-end.
- Adds `search_mode` (`"semantic"` / `"keyword"` / `"hybrid"`) — already supported by the service layer, now surfaced to agents via MCP.
- Converts `def` + `run_sync` bridge → `async def` + `await`, eliminating cross-thread scheduling overhead on every call.
- Adds `@handle_tool_errors` decorator, consistent with all other 18 MCP tools.

## Changes

**`src/nexus/bricks/mcp/server.py`**
- `path: str = "/"` param added (matches `nexus_grep`/`nexus_glob` interface)
- `search_mode: str = "semantic"` param added
- `async def` + `await` replaces `def` + `run_sync`
- `@handle_tool_errors("semantic search")` added
- Docstring updated with param docs, hybrid cost warning, scoped example

**`tests/unit/bricks/mcp/test_mcp_server_tools.py`**
- `get_tool()` helper fixed for FastMCP 3.2.0 (`_local_provider._components` replaces removed `_tool_manager`)
- `test_semantic_search_with_scoped_path` — regression guard for #3702
- `test_semantic_search_with_search_mode` — verifies `search_mode` forwarding
- All existing semantic search tests updated for async + new signature

## Test plan

- [ ] `TestSearchTools` — 12/12 pass (`PYTHONPATH=src python -m pytest tests/unit/bricks/mcp/test_mcp_server_tools.py::TestSearchTools`)
- [ ] `test_semantic_search_with_scoped_path` asserts `path="/workspace/src"` is forwarded — direct regression guard
- [ ] `test_semantic_search_with_search_mode` asserts `search_mode="hybrid"` is forwarded
- [ ] Pre-commit hooks pass (ruff, mypy, brick-zero-core-imports)

## Notes

10 unrelated pre-existing failures remain in `TestResources`, `TestPrompts`, `TestSandboxAvailability`, `TestServerCreation` — all caused by FastMCP 3.2.0 removing `_resource_manager`/`_prompt_manager`/`_tool_manager` APIs. Not introduced or worsened by this PR.