### PR TITLE
feat(#3728): virtual .readme/ overlay via kernel dispatch

### DIFF
--- a/src/nexus/backends/connectors/base.py
+++ b/src/nexus/backends/connectors/base.py
@@ -211,6 +211,17 @@ class ReadmeDocMixin:
     NESTED_EXAMPLES: dict[str, list[str]] = {}  # Nested field examples for README.md
     FIELD_EXAMPLES: dict[str, str] = {}  # Field-specific examples for README.md
 
+    # If True, the virtual ``.readme/`` overlay (Issue #3728) defers to
+    # real backend content when the same path exists: a real
+    # ``.readme/README.md`` wins over the auto-generated one.  Set on
+    # path-addressed connectors where users can legitimately store
+    # files at arbitrary paths (e.g. native gdrive) so the overlay
+    # cannot silently shadow user data.  Default False — read-only
+    # CLI-backed connectors (gmail, calendar, slack, x, hn, github)
+    # cannot store files at ``.readme/`` paths, so the overlay is
+    # safe to make authoritative there.
+    VIRTUAL_README_DEFERS_TO_BACKEND: bool = False
+
     _skill_registry: "SkillRegistryProtocol | None" = None
     _mount_path: str | None = None  # Set during mount
     _cached_doc_generator: "ReadmeDocGenerator | None" = None

--- a/src/nexus/backends/connectors/base.py
+++ b/src/nexus/backends/connectors/base.py
@@ -284,10 +284,11 @@ class ReadmeDocMixin:
         """Get the full path to the .readme directory."""
         return self.get_doc_generator().get_readme_path(mount_path)
 
-    async def write_readme(self, mount_path: str, filesystem: Any = None) -> dict[str, str]:
-        """Generate and write .readme/ directory to the filesystem."""
-        self._mount_path = mount_path
-        return await self.get_doc_generator().write_readme(mount_path, filesystem)
+    # NOTE (Issue #3728): ``write_readme`` was removed. The virtual
+    # ``.readme/`` overlay now serves docs on-demand from class metadata
+    # via ``nexus.backends.connectors.schema_generator.dispatch_virtual_readme_*``,
+    # so materializing files into the backend is no longer needed and
+    # would drift from the canonical (class-metadata-derived) content.
 
     def format_error_with_skill_ref(
         self,

--- a/src/nexus/backends/connectors/gdrive/connector.py
+++ b/src/nexus/backends/connectors/gdrive/connector.py
@@ -95,6 +95,10 @@ class PathGDriveBackend(
 
     # ReadmeDocMixin config
     SKILL_NAME = "gdrive"
+    # Drive stores arbitrary user files at arbitrary paths, so a real
+    # ``.readme/`` directory in the user's Drive must shadow the
+    # auto-generated virtual tree (Issue #3728 finding #9).
+    VIRTUAL_README_DEFERS_TO_BACKEND: bool = True
 
     # ValidatedMixin config
     SCHEMAS = {

--- a/src/nexus/backends/connectors/github/connector.py
+++ b/src/nexus/backends/connectors/github/connector.py
@@ -36,13 +36,22 @@ logger = logging.getLogger(__name__)
 
 
 @register_connector(
-    # Registry name must match the factory lookup fallback
+    # Primary registry name matches the factory lookup fallback
     # ``f"{scheme}_connector"`` so ``github://<authority>`` mounts resolve
-    # to this class.  Previously registered as ``"gws_github"``, which was
-    # unreachable from any scheme and made ``nexus-fs mount github://...``
-    # fail — see #3728 follow-up.
+    # to this class.  Before #3728 the connector was registered only as
+    # ``"gws_github"``, which was unreachable from any scheme and made
+    # ``nexus-fs mount github://...`` fail.
     "github_connector",
     description="GitHub via gh CLI",
+    category="cli",
+)
+@register_connector(
+    # Deprecated alias — kept so persisted mounts stored under the old
+    # ``backend_type: "gws_github"`` key (in ``mounts.json`` or the
+    # ``mount_persist`` store) still load after upgrade.  Remove once a
+    # migration has rewritten stored entries to ``github_connector``.
+    "gws_github",
+    description="GitHub via gh CLI (deprecated alias, use github_connector)",
     category="cli",
 )
 class GitHubConnector(PathCLIBackend):

--- a/src/nexus/backends/connectors/github/connector.py
+++ b/src/nexus/backends/connectors/github/connector.py
@@ -36,7 +36,12 @@ logger = logging.getLogger(__name__)
 
 
 @register_connector(
-    "gws_github",
+    # Registry name must match the factory lookup fallback
+    # ``f"{scheme}_connector"`` so ``github://<authority>`` mounts resolve
+    # to this class.  Previously registered as ``"gws_github"``, which was
+    # unreachable from any scheme and made ``nexus-fs mount github://...``
+    # fail — see #3728 follow-up.
+    "github_connector",
     description="GitHub via gh CLI",
     category="cli",
 )

--- a/src/nexus/backends/connectors/gmail/connector.py
+++ b/src/nexus/backends/connectors/gmail/connector.py
@@ -292,24 +292,10 @@ class PathGmailBackend(
             logger.warning(f"Failed to load static README.md: {e}, using auto-generated")
             return super().generate_readme(mount_path)
 
-    async def write_readme(self, mount_path: str, filesystem: Any = None) -> dict[str, Any]:
-        import posixpath
-
-        result: dict[str, Any] = {"readme_md": None, "examples": []}
-        if filesystem is None:
-            return result
-
-        readme_dir = posixpath.join(mount_path.rstrip("/"), self.README_DIR)
-        try:
-            await filesystem.mkdir(readme_dir, parents=True, exist_ok=True)
-            readme_md_path = posixpath.join(readme_dir, "README.md")
-            content = self.generate_readme(mount_path)
-            await filesystem.write(readme_md_path, content.encode("utf-8"))
-            result["readme_md"] = readme_md_path
-            return result
-        except Exception as e:
-            logger.warning("Failed to write readme docs to %s: %s", readme_dir, e)
-            return result
+    # NOTE (Issue #3728): ``write_readme`` override removed along with the
+    # base class method.  Gmail's static README.md (if present) is now read
+    # via ``generate_readme`` above, and the virtual ``.readme/`` overlay in
+    # ``schema_generator`` serves the result on-demand.
 
     # =================================================================
     # Content operations — override PathAddressingEngine for Gmail

--- a/src/nexus/backends/connectors/schema_generator.py
+++ b/src/nexus/backends/connectors/schema_generator.py
@@ -1,11 +1,13 @@
 """Readme documentation generator — extracted from ReadmeDocMixin.
 
 Converts connector metadata (Pydantic schemas, operation traits, error
-registries) into README.md markdown and writes readme directories.
+registries) into README.md markdown and a virtual ``.readme/`` tree used
+by the read-path overlay (Issue #3728).
 """
 
 import logging
 import posixpath
+from dataclasses import dataclass, field
 from typing import Any
 
 from pydantic import BaseModel
@@ -13,6 +15,335 @@ from pydantic import BaseModel
 from nexus.backends.connectors.base import ConfirmLevel, ErrorDef, OpTraits
 
 logger = logging.getLogger(__name__)
+
+
+# =============================================================================
+# Virtual .readme/ tree model (Issue #3728)
+# =============================================================================
+
+
+@dataclass
+class VirtualEntry:
+    """A node in the virtual ``.readme/`` filesystem tree.
+
+    Files carry ``content`` (bytes) and have no children.  Directories
+    carry ``children`` (name → VirtualEntry) and have no content.
+
+    This is the single source of truth for the overlay that intercepts
+    ``.readme/**`` reads on every backend inheriting ``ReadmeDocMixin``
+    — the same tree drives ``read_content``, ``list_dir``,
+    ``content_exists``, and ``get_content_size``.
+
+    Issue #3728 decisions #5A (one declarative tree), #8A (sentinel
+    returns for find/miss), #14A (single-walk generation).
+    """
+
+    name: str
+    is_dir: bool
+    content: bytes | None = None
+    children: dict[str, "VirtualEntry"] = field(default_factory=dict)
+
+    @property
+    def is_file(self) -> bool:
+        return not self.is_dir
+
+    def size(self) -> int:
+        """Return content size in bytes (0 for directories)."""
+        return len(self.content) if self.content is not None else 0
+
+    def find(self, parts: list[str]) -> "VirtualEntry | None":
+        """Walk the tree to the entry at ``parts`` or return ``None``.
+
+        Traversal stops and returns ``None`` as soon as a part doesn't
+        exist or a non-directory is encountered mid-path. Does NOT
+        normalize the input — callers must hand over clean parts
+        (no ``..``, no empty strings, no leading/trailing slashes).
+        """
+        node: VirtualEntry | None = self
+        for part in parts:
+            if node is None or not node.is_dir:
+                return None
+            node = node.children.get(part)
+        return node
+
+    def list_children_names(self) -> list[str]:
+        """Sorted child names with ``/`` suffix for sub-directories."""
+        if not self.is_dir:
+            return []
+        return sorted(f"{name}/" if entry.is_dir else name for name, entry in self.children.items())
+
+
+# Module-level cache keyed by (connector_class, mount_path).  Class objects
+# are hashable and live for the process lifetime, so the cache is naturally
+# scoped correctly: a hot-reloaded module produces a new class object and a
+# new cache entry.  Decision #13A — one generation per (class, mount_path)
+# per process.
+_VIRTUAL_TREE_CACHE: dict[tuple[type, str], VirtualEntry] = {}
+
+
+def _invalidate_virtual_tree_cache() -> None:
+    """Test/dev helper: clear all cached virtual readme trees."""
+    _VIRTUAL_TREE_CACHE.clear()
+
+
+def _parse_readme_path_parts(
+    backend_path: str | None,
+    readme_dir: str = ".readme",
+) -> list[str] | None:
+    """Parse a backend-relative path into parts under ``.readme/``.
+
+    Returns:
+        - ``None`` if the path is NOT under ``.readme/`` (the caller should
+          fall through to the normal read path — non-virtual).
+        - ``[]`` if the path refers to the ``.readme/`` directory itself.
+        - ``[part, ...]`` for nested entries.
+
+    Raises ``ValueError`` on path traversal attempts (``..``, null bytes,
+    backslashes).  Decision #4A — strict rejection so security issues are
+    visible rather than silently falling through to the real backend.
+    """
+    if backend_path is None:
+        return None
+
+    # Reject null bytes and other control bytes that shouldn't be in paths
+    if "\x00" in backend_path:
+        raise ValueError("null byte in path")
+
+    # Reject backslashes — Windows-style separators are not valid here
+    if "\\" in backend_path:
+        raise ValueError(f"backslash in path: {backend_path!r}")
+
+    cleaned = backend_path.strip("/")
+    if not cleaned:
+        return None
+
+    # posixpath.normpath collapses ``//``, ``.``, and ``..`` components.
+    normalized = posixpath.normpath(cleaned)
+
+    # After normalization, any path starting with ``..`` is a traversal attempt
+    if normalized == ".." or normalized.startswith("../"):
+        raise ValueError(f"path traversal detected: {backend_path!r}")
+
+    readme_prefix = (readme_dir or ".readme").strip("/")
+    if normalized == readme_prefix:
+        return []
+
+    prefix = readme_prefix + "/"
+    if not normalized.startswith(prefix):
+        return None
+
+    # Split and drop any empty parts (defensive — normpath shouldn't produce them)
+    parts = [p for p in normalized[len(prefix) :].split("/") if p]
+    return parts
+
+
+def _has_skill_name(backend: Any) -> bool:
+    """Return True if the backend class declares a non-empty ``SKILL_NAME``."""
+    return bool(getattr(type(backend), "SKILL_NAME", "") or "")
+
+
+def _readme_dir_for(backend: Any) -> str:
+    """Return the backend's configured ``.readme/`` directory name."""
+    return getattr(type(backend), "README_DIR", ".readme") or ".readme"
+
+
+def dispatch_virtual_readme_read(
+    backend: Any,
+    mount_path: str,
+    backend_path: str | None,
+) -> bytes | None:
+    """Serve a read from the virtual ``.readme/`` overlay if it matches.
+
+    Returns:
+        - ``bytes`` — the virtual file's content (hit).
+        - ``None`` — path is NOT under ``.readme/`` (caller falls through
+          to the real backend, decision #8A sentinel protocol).
+
+    Raises:
+        ``NexusFileNotFoundError`` — path IS under ``.readme/`` but no
+          matching virtual entry exists (distinguishes "not virtual" from
+          "virtual but missing", decision #8A).
+        ``ValueError`` — path traversal or invalid input (decision #4A).
+        ``IsADirectoryError`` — path matches a virtual directory, not a file.
+        ``RuntimeError`` — backend has no ``SKILL_NAME``.  Safe default —
+          non-skill backends return ``None`` from the ``_has_skill_name``
+          check above, so this only fires for misconfigured skill backends.
+    """
+    if not _has_skill_name(backend):
+        return None
+
+    parts = _parse_readme_path_parts(backend_path, readme_dir=_readme_dir_for(backend))
+    if parts is None:
+        return None
+
+    from nexus.contracts.exceptions import NexusFileNotFoundError
+
+    tree = get_virtual_readme_tree_for_backend(backend, mount_path)
+    entry = tree.find(parts)
+    if entry is None:
+        raise NexusFileNotFoundError(f"virtual .readme/ path not found: {backend_path}")
+    if entry.is_dir:
+        raise IsADirectoryError(f"Is a directory: {backend_path}")
+    return entry.content or b""
+
+
+def dispatch_virtual_readme_list(
+    backend: Any,
+    mount_path: str,
+    backend_path: str | None,
+) -> list[str] | None:
+    """List a directory from the virtual ``.readme/`` overlay if it matches.
+
+    Returns:
+        - ``list[str]`` — the virtual directory's entries (hit).
+        - ``None`` — path is NOT under ``.readme/``.
+
+    Raises:
+        ``NexusFileNotFoundError`` — path IS under ``.readme/`` but the
+          directory doesn't exist.
+        ``NotADirectoryError`` — path matches a virtual file, not a directory.
+        ``ValueError`` — path traversal.
+    """
+    if not _has_skill_name(backend):
+        return None
+
+    parts = _parse_readme_path_parts(backend_path, readme_dir=_readme_dir_for(backend))
+    if parts is None:
+        return None
+
+    from nexus.contracts.exceptions import NexusFileNotFoundError
+
+    tree = get_virtual_readme_tree_for_backend(backend, mount_path)
+    entry = tree.find(parts)
+    if entry is None:
+        raise NexusFileNotFoundError(f"virtual .readme/ path not found: {backend_path}")
+    if not entry.is_dir:
+        raise NotADirectoryError(f"Not a directory: {backend_path}")
+    return entry.list_children_names()
+
+
+def dispatch_virtual_readme_exists(
+    backend: Any,
+    mount_path: str,
+    backend_path: str | None,
+) -> bool | None:
+    """Answer ``content_exists`` from the virtual ``.readme/`` overlay.
+
+    Returns:
+        - ``True`` or ``False`` — definitive answer (path is under ``.readme/``).
+        - ``None`` — path is NOT under ``.readme/``.
+    """
+    if not _has_skill_name(backend):
+        return None
+
+    try:
+        parts = _parse_readme_path_parts(backend_path, readme_dir=_readme_dir_for(backend))
+    except ValueError:
+        # Malformed path under .readme/ — treat as non-existent (False).
+        return False
+
+    if parts is None:
+        return None
+
+    try:
+        tree = get_virtual_readme_tree_for_backend(backend, mount_path)
+    except Exception:
+        return False
+
+    return tree.find(parts) is not None
+
+
+def dispatch_virtual_readme_size(
+    backend: Any,
+    mount_path: str,
+    backend_path: str | None,
+) -> int | None:
+    """Return the virtual file size under ``.readme/``.
+
+    Returns:
+        - ``int`` — the file's size in bytes.
+        - ``None`` — path is NOT under ``.readme/``.
+
+    Raises ``NexusFileNotFoundError`` for virtual directories and for
+    paths under ``.readme/`` that don't exist.
+    """
+    if not _has_skill_name(backend):
+        return None
+
+    parts = _parse_readme_path_parts(backend_path, readme_dir=_readme_dir_for(backend))
+    if parts is None:
+        return None
+
+    from nexus.contracts.exceptions import NexusFileNotFoundError
+
+    tree = get_virtual_readme_tree_for_backend(backend, mount_path)
+    entry = tree.find(parts)
+    if entry is None:
+        raise NexusFileNotFoundError(f"virtual .readme/ path not found: {backend_path}")
+    return entry.size()
+
+
+def get_virtual_readme_tree_for_backend(backend: Any, mount_path: str) -> VirtualEntry:
+    """Return the cached virtual ``.readme/`` tree for a backend instance.
+
+    The tree is built once per ``(connector_class, mount_path)`` pair and
+    reused across reads.  Backend must inherit from ``ReadmeDocMixin``
+    (i.e., expose ``SKILL_NAME``, ``SCHEMAS``, ``OPERATION_TRAITS``,
+    ``ERROR_REGISTRY``, ``EXAMPLES`` as class attributes).
+
+    Raises ``RuntimeError`` if the backend doesn't declare a ``SKILL_NAME``
+    (there's nothing to generate docs from).
+
+    Issue #3728 decisions #13A (module cache), #14A (single walk per mount).
+    """
+    connector_class = type(backend)
+    key: tuple[type, str] = (connector_class, mount_path)
+    cached = _VIRTUAL_TREE_CACHE.get(key)
+    if cached is not None:
+        return cached
+
+    skill_name = getattr(connector_class, "SKILL_NAME", "") or ""
+    if not skill_name:
+        raise RuntimeError(
+            f"{connector_class.__name__} has no SKILL_NAME — cannot build virtual .readme/ tree"
+        )
+
+    # Pull class-level metadata.  We use the CLASS attributes (not instance
+    # getattr) so the cache key — the class — fully determines the tree.
+    schemas = dict(getattr(connector_class, "SCHEMAS", {}) or {})
+    operation_traits = dict(getattr(connector_class, "OPERATION_TRAITS", {}) or {})
+    error_registry = dict(getattr(connector_class, "ERROR_REGISTRY", {}) or {})
+    examples = dict(getattr(connector_class, "EXAMPLES", {}) or {})
+    nested_examples_raw = getattr(connector_class, "NESTED_EXAMPLES", None)
+    field_examples_raw = getattr(connector_class, "FIELD_EXAMPLES", None)
+    readme_dir = getattr(connector_class, "README_DIR", ".readme") or ".readme"
+
+    # Extract write paths from CLIConnectorConfig if available (parallels the
+    # existing logic in ``ReadmeDocMixin.get_doc_generator``).
+    write_paths: dict[str, str] = {}
+    _config = getattr(backend, "_config", None)
+    if _config is not None and hasattr(_config, "write"):
+        for wp in _config.write:
+            write_paths[wp.operation] = wp.path
+
+    generator = ReadmeDocGenerator(
+        skill_name=skill_name,
+        schemas=schemas,
+        operation_traits=operation_traits,
+        error_registry=error_registry,
+        examples=examples,
+        readme_dir=readme_dir,
+        nested_examples=dict(nested_examples_raw) if nested_examples_raw else None,
+        field_examples=dict(field_examples_raw) if field_examples_raw else None,
+        write_paths=write_paths or None,
+    )
+    dir_structure = getattr(connector_class, "DIRECTORY_STRUCTURE", None)
+    if dir_structure:
+        generator._directory_structure = dir_structure
+
+    tree = generator.generate_tree(mount_path)
+    _VIRTUAL_TREE_CACHE[key] = tree
+    return tree
 
 
 class ReadmeDocGenerator:
@@ -103,74 +434,69 @@ class ReadmeDocGenerator:
         """Get the full path to the .readme directory."""
         return posixpath.join(mount_path.rstrip("/"), self._readme_dir)
 
-    async def write_readme(self, mount_path: str, filesystem: Any = None) -> dict[str, Any]:
-        """Generate and write .readme/ directory to the filesystem.
+    def generate_tree(self, mount_path: str) -> VirtualEntry:
+        """Build the full virtual ``.readme/`` tree in one metadata walk.
 
-        Creates:
-            <mount_path>/.readme/
-                README.md           # Main documentation
-                schemas/           # Individual schema YAML files (Issue #3148)
-                    <operation>.yaml
-                examples/          # Example YAML files
-                    <example>.yaml
+        Issue #3728 decision #14A — one pass over ``SCHEMAS`` and
+        ``EXAMPLES`` produces every file in the virtual tree, eliminating
+        the N+1 pattern of reading schemas one at a time.
 
-        Args:
-            mount_path: The mount path for this connector.
-            filesystem: NexusFS instance to write to (optional).
+        Returns a ``VirtualEntry`` rooted at the ``.readme/`` directory
+        containing:
+        - ``README.md`` — full generated markdown from ``generate_readme``
+        - ``schemas/<op>.yaml`` — one annotated schema per operation
+        - ``examples/<filename>`` — one entry per example (bytes-preserving)
 
-        Returns:
-            Dict of written paths: {"readme_md": path, "schemas": [...], "examples": [...]}.
+        Errors from the generator are propagated — decision #8A, the
+        caller decides how to surface them.
         """
-        result: dict[str, Any] = {"readme_md": None, "schemas": [], "examples": []}
+        root = VirtualEntry(name=self._readme_dir, is_dir=True)
 
-        if not self._skill_name:
-            logger.warning("Cannot write readme docs: skill_name not configured")
-            return result
+        # README.md (reuses the existing markdown pipeline).
+        readme_text = self.generate_readme(mount_path)
+        root.children["README.md"] = VirtualEntry(
+            name="README.md",
+            is_dir=False,
+            content=readme_text.encode("utf-8"),
+        )
 
-        readme_dir = self.get_readme_path(mount_path)
+        # schemas/<op>.yaml — one annotated schema per operation.
+        if self._schemas:
+            schemas_dir = VirtualEntry(name="schemas", is_dir=True)
+            for op_name, schema in self._schemas.items():
+                yaml_text = self.generate_schema_yaml(op_name, schema)
+                file_name = f"{op_name}.yaml"
+                schemas_dir.children[file_name] = VirtualEntry(
+                    name=file_name,
+                    is_dir=False,
+                    content=yaml_text.encode("utf-8"),
+                )
+            root.children["schemas"] = schemas_dir
 
-        if filesystem is None:
-            logger.debug("No filesystem provided for %s", self._skill_name)
-            return result
+        # examples/<filename> — bytes-preserving (#7A binary examples).
+        if self._examples:
+            examples_dir = VirtualEntry(name="examples", is_dir=True)
+            for filename, raw in self._examples.items():
+                if isinstance(raw, bytes):
+                    content_bytes = raw
+                elif isinstance(raw, str):
+                    content_bytes = raw.encode("utf-8")
+                else:
+                    content_bytes = str(raw).encode("utf-8")
+                examples_dir.children[filename] = VirtualEntry(
+                    name=filename,
+                    is_dir=False,
+                    content=content_bytes,
+                )
+            root.children["examples"] = examples_dir
 
-        try:
-            await filesystem.mkdir(readme_dir, parents=True, exist_ok=True)
+        return root
 
-            # Write README.md
-            readme_md_path = posixpath.join(readme_dir, "README.md")
-            content = self.generate_readme(mount_path)
-            await filesystem.write(readme_md_path, content.encode("utf-8"))
-            result["readme_md"] = readme_md_path
-            logger.info("Generated README.md at %s", readme_md_path)
-
-            # Write example files
-            if self._examples:
-                examples_dir = posixpath.join(readme_dir, "examples")
-                await filesystem.mkdir(examples_dir, parents=True, exist_ok=True)
-
-                for filename, file_content in self._examples.items():
-                    example_path = posixpath.join(examples_dir, filename)
-                    await filesystem.write(example_path, file_content.encode("utf-8"))
-                    result["examples"].append(example_path)
-                    logger.debug("Generated example at %s", example_path)
-
-            # Write individual schema files (Issue #3148, Decision #7B)
-            if self._schemas:
-                schemas_dir = posixpath.join(readme_dir, "schemas")
-                await filesystem.mkdir(schemas_dir, parents=True, exist_ok=True)
-
-                for op_name, schema in self._schemas.items():
-                    schema_content = self.generate_schema_yaml(op_name, schema)
-                    schema_path = posixpath.join(schemas_dir, f"{op_name}.yaml")
-                    await filesystem.write(schema_path, schema_content.encode("utf-8"))
-                    result["schemas"].append(schema_path)
-                    logger.debug("Generated schema at %s", schema_path)
-
-            return result
-
-        except Exception as e:
-            logger.warning("Failed to write readme docs to %s: %s", readme_dir, e)
-            return result
+    # NOTE (Issue #3728): ``write_readme`` was removed. Skill docs are now
+    # served on-demand by the virtual ``.readme/`` overlay via
+    # ``generate_tree`` + ``dispatch_virtual_readme_*``. Materializing files
+    # into the storage layer would drift from class metadata and double
+    # the code paths that produce docs (decision #2A: virtual-only).
 
     def _generate_read_patterns_section(self, mount_path: str) -> list[str]:
         """Generate Read Patterns section showing how to list, cat, grep content.

--- a/src/nexus/backends/connectors/schema_generator.py
+++ b/src/nexus/backends/connectors/schema_generator.py
@@ -147,6 +147,41 @@ def _readme_dir_for(backend: Any) -> str:
     return getattr(type(backend), "README_DIR", ".readme") or ".readme"
 
 
+def _defers_to_backend(backend: Any) -> bool:
+    """Return True if the backend's real content should shadow the overlay.
+
+    Issue #3728 finding #9: on writable path-addressed connectors (native
+    gdrive), users can legitimately create real ``.readme/`` files — the
+    overlay must not silently hide them.  Those connectors opt in by
+    setting ``VIRTUAL_README_DEFERS_TO_BACKEND = True``.
+    """
+    return bool(getattr(type(backend), "VIRTUAL_README_DEFERS_TO_BACKEND", False))
+
+
+def _real_content_exists(backend: Any, backend_path: str) -> bool:
+    """Best-effort probe: does the real backend have content at this path?
+
+    Returns True only when the backend explicitly confirms existence —
+    any exception or missing probe method is treated as "does not exist"
+    so the overlay still works on backends without a cheap exists check.
+    """
+    try:
+        from nexus.contracts.types import OperationContext
+
+        probe_ctx = OperationContext(
+            user_id="system",
+            groups=[],
+            is_system=True,
+            backend_path=backend_path,
+        )
+        exists_fn = getattr(backend, "content_exists", None)
+        if callable(exists_fn):
+            return bool(exists_fn(backend_path, context=probe_ctx))
+    except Exception:
+        return False
+    return False
+
+
 def dispatch_virtual_readme_read(
     backend: Any,
     mount_path: str,
@@ -174,6 +209,12 @@ def dispatch_virtual_readme_read(
 
     parts = _parse_readme_path_parts(backend_path, readme_dir=_readme_dir_for(backend))
     if parts is None:
+        return None
+
+    # Finding #9: on writable path-addressed connectors (native gdrive),
+    # real user files at ``.readme/...`` must shadow the virtual overlay.
+    # Return None so the caller falls through to the real backend read.
+    if _defers_to_backend(backend) and _real_content_exists(backend, backend_path):
         return None
 
     from nexus.contracts.exceptions import NexusFileNotFoundError
@@ -211,6 +252,10 @@ def dispatch_virtual_readme_list(
     if parts is None:
         return None
 
+    # Finding #9: defer to real backend listing when it has content.
+    if _defers_to_backend(backend) and _real_content_exists(backend, backend_path):
+        return None
+
     from nexus.contracts.exceptions import NexusFileNotFoundError
 
     tree = get_virtual_readme_tree_for_backend(backend, mount_path)
@@ -245,6 +290,12 @@ def dispatch_virtual_readme_exists(
     if parts is None:
         return None
 
+    # Finding #9: defer to real backend — if it has content here, the
+    # virtual overlay is not in force for this path, so let the normal
+    # exists code path answer.
+    if _defers_to_backend(backend) and _real_content_exists(backend, backend_path):
+        return None
+
     try:
         tree = get_virtual_readme_tree_for_backend(backend, mount_path)
     except Exception:
@@ -272,6 +323,10 @@ def dispatch_virtual_readme_size(
 
     parts = _parse_readme_path_parts(backend_path, readme_dir=_readme_dir_for(backend))
     if parts is None:
+        return None
+
+    # Finding #9: defer to real backend when it has content at this path.
+    if _defers_to_backend(backend) and _real_content_exists(backend, backend_path):
         return None
 
     from nexus.contracts.exceptions import NexusFileNotFoundError

--- a/src/nexus/backends/connectors/schema_generator.py
+++ b/src/nexus/backends/connectors/schema_generator.py
@@ -251,26 +251,29 @@ def _build_probe_context(context: Any | None, backend_path: str) -> Any:
 def _real_readme_root_exists(backend: Any, context: Any | None = None) -> bool:
     """Probe the backend for a real ``.readme/`` directory (subtree root).
 
-    Issue #3728 round 6/7: deferral must be subtree-atomic AND an
-    *empty* real directory must still count as existing — otherwise
-    the overlay shadows user-created folders on gdrive where
-    ``list_dir`` returns ``[]`` for both missing and empty directories.
+    **Error semantics (trade-off, round 8 finding #20):**
+    Codex raised a concern that treating probe errors as "no real
+    data" lets the overlay shadow a real ``.readme/`` during
+    transient auth/network failures.  The inverse (fail-closed:
+    treat errors as "real data exists, defer") breaks the much more
+    common unauthed-mount case where users legitimately want to see
+    the virtual docs before setting up OAuth — they have no real
+    data to protect, and transient probes and "no OAuth configured"
+    look the same from Python.
+
+    We keep the original semantics — probe errors return ``False``
+    so the overlay stays visible — and accept that on a fully
+    authed deferring backend, a transient probe failure can briefly
+    shadow real content until the probe recovers.  This trade is
+    documented here so future reviewers can pick a different policy
+    if the calculus changes.
 
     Probe order (first definite "yes" wins):
-    1. ``backend.is_directory(readme_dir, context)`` — dedicated
-       directory-existence check (implemented by
-       ``PathAddressingEngine`` and most connector backends);
-       detects empty directories that ``list_dir`` can't distinguish
-       from "missing".
-    2. ``backend.content_exists(readme_dir, context)`` — file-level
-       existence, useful for connectors where the readme path can
-       appear as a file-like entry.
-    3. Non-empty ``backend.list_dir(readme_dir, context)`` — last-
-       resort fallback for backends that implement neither of the
-       above but expose real children through listing.
-
-    Returns ``False`` on any exception or when every probe says the
-    directory isn't there.
+    1. ``backend.is_directory(readme_dir, context)`` — handles empty
+       real directories that ``list_dir`` can't distinguish from
+       "missing".
+    2. ``backend.content_exists(readme_dir, context)``.
+    3. Non-empty ``backend.list_dir(readme_dir, context)``.
     """
     readme_dir = _readme_dir_for(backend)
     probe_ctx = _build_probe_context(context, readme_dir)
@@ -282,15 +285,16 @@ def _real_readme_root_exists(backend: Any, context: Any | None = None) -> bool:
             if is_dir_fn(readme_dir, context=probe_ctx):
                 return True
         except Exception:
-            pass  # fall through to the remaining probes
+            pass
 
-    # 2) content_exists probe (cheap for backends that implement it).
-    if _real_content_exists(backend, readme_dir, context=context):
-        return True
+    # 2) content_exists probe.
+    try:
+        if _real_content_exists(backend, readme_dir, context=context):
+            return True
+    except Exception:
+        pass
 
-    # 3) list_dir probe (only detects *non-empty* directories, which is
-    #    why we run it last — list_dir returning ``[]`` for both
-    #    "empty" and "missing" was the original finding-#17 bug).
+    # 3) list_dir probe (detects *non-empty* directories).
     list_fn = getattr(backend, "list_dir", None)
     if callable(list_fn):
         try:
@@ -298,7 +302,7 @@ def _real_readme_root_exists(backend: Any, context: Any | None = None) -> bool:
             if entries:
                 return True
         except Exception:
-            return False
+            pass
     return False
 
 

--- a/src/nexus/backends/connectors/schema_generator.py
+++ b/src/nexus/backends/connectors/schema_generator.py
@@ -342,6 +342,27 @@ def get_virtual_readme_tree_for_backend(backend: Any, mount_path: str) -> Virtua
         generator._directory_structure = dir_structure
 
     tree = generator.generate_tree(mount_path)
+
+    # IMPORTANT (Issue #3728): connectors can override ``generate_readme``
+    # to substitute a curated static markdown file (see
+    # ``PathGmailBackend.generate_readme`` which loads
+    # ``connectors/gmail/README.md`` with the authoritative ``SENT/_reply.yaml``
+    # / ``SENT/_forward.yaml`` write paths).  The generator-built README in
+    # ``tree`` only uses class-level metadata and can't see those overrides,
+    # so we ask the backend itself for the README.md body and overwrite the
+    # generator's version.  ``schemas/`` and ``examples/`` still come from
+    # the generator — those don't have connector-level overrides today.
+    try:
+        backend_readme = backend.generate_readme(mount_path)
+    except Exception:
+        backend_readme = None
+    if isinstance(backend_readme, str) and backend_readme:
+        tree.children["README.md"] = VirtualEntry(
+            name="README.md",
+            is_dir=False,
+            content=backend_readme.encode("utf-8"),
+        )
+
     _VIRTUAL_TREE_CACHE[key] = tree
     return tree
 

--- a/src/nexus/backends/connectors/schema_generator.py
+++ b/src/nexus/backends/connectors/schema_generator.py
@@ -227,7 +227,11 @@ def overlay_owns_path(
     - Backend has no ``SKILL_NAME`` (overlay inactive)
     - ``backend_path`` is not under the configured readme directory
     - Backend opts to defer to real data (``VIRTUAL_README_DEFERS_TO_BACKEND``)
-      AND real content exists at the path
+      AND the real ``.readme/`` directory exists on the backend
+      (subtree-level ownership — Issue #3728 round 6 finding #16).
+      The whole subtree is handed over to the backend atomically so
+      listings, reads, writes, and stats cannot disagree about a
+      "partly real, partly virtual" state.
 
     Propagates ``ValueError`` for malformed paths (traversal, null byte,
     backslash) so callers can raise a loud error rather than silently
@@ -238,10 +242,57 @@ def overlay_owns_path(
     parts = _parse_readme_path_parts(backend_path, readme_dir=_readme_dir_for(backend))
     if parts is None:
         return False
-    return not (
-        _defers_to_backend(backend)
-        and _real_content_exists(backend, backend_path or "", context=context)
-    )
+    return not (_defers_to_backend(backend) and _real_readme_root_exists(backend, context=context))
+
+
+def _real_readme_root_exists(backend: Any, context: Any | None = None) -> bool:
+    """Probe the backend for a real ``.readme/`` directory (subtree root).
+
+    Issue #3728 round 6 finding #16: deferral must be subtree-atomic to
+    avoid "partly real, partly virtual" mixed states.  We probe the
+    root ``.readme`` path only — if it exists, the whole subtree is
+    considered user data and the overlay steps aside entirely.
+
+    Returns ``True`` only when the backend confirms existence via
+    either ``content_exists`` or ``list_dir`` returning a non-empty
+    result.  Any exception or missing probe method → ``False``.
+    """
+    readme_dir = _readme_dir_for(backend)
+    # 1) content_exists probe (cheap for backends that implement it)
+    if _real_content_exists(backend, readme_dir, context=context):
+        return True
+    # 2) list_dir probe (for backends whose content_exists is a stub
+    #    but whose list_dir returns real directory entries).
+    try:
+        from dataclasses import replace as _replace
+
+        from nexus.contracts.types import OperationContext
+
+        if context is not None:
+            try:
+                probe_ctx: Any = _replace(context, backend_path=readme_dir)
+            except Exception:
+                probe_ctx = OperationContext(
+                    user_id=getattr(context, "user_id", "system") or "system",
+                    groups=list(getattr(context, "groups", []) or []),
+                    zone_id=getattr(context, "zone_id", None),
+                    is_system=getattr(context, "is_system", False),
+                    backend_path=readme_dir,
+                )
+        else:
+            probe_ctx = OperationContext(
+                user_id="system",
+                groups=[],
+                is_system=True,
+                backend_path=readme_dir,
+            )
+        list_fn = getattr(backend, "list_dir", None)
+        if callable(list_fn):
+            entries = list_fn(readme_dir, context=probe_ctx)
+            return bool(entries)
+    except Exception:
+        return False
+    return False
 
 
 def dispatch_virtual_readme_read(

--- a/src/nexus/backends/connectors/schema_generator.py
+++ b/src/nexus/backends/connectors/schema_generator.py
@@ -158,22 +158,50 @@ def _defers_to_backend(backend: Any) -> bool:
     return bool(getattr(type(backend), "VIRTUAL_README_DEFERS_TO_BACKEND", False))
 
 
-def _real_content_exists(backend: Any, backend_path: str) -> bool:
+def _real_content_exists(
+    backend: Any,
+    backend_path: str,
+    context: Any | None = None,
+) -> bool:
     """Best-effort probe: does the real backend have content at this path?
 
-    Returns True only when the backend explicitly confirms existence —
-    any exception or missing probe method is treated as "does not exist"
+    When a caller context is supplied, we reuse its ``user_id`` / ``zone_id``
+    so user-scoped connectors (native Google Drive, etc.) can actually
+    resolve an auth token and answer the question.  If no context is
+    supplied, fall back to a synthetic system context — this path is
+    safe for CLI-backed connectors whose ``content_exists`` is a stub
+    that returns ``False`` without needing auth.
+
+    Returns ``True`` only when the backend explicitly confirms existence.
+    Any exception or missing probe method is treated as "does not exist"
     so the overlay still works on backends without a cheap exists check.
     """
     try:
+        from dataclasses import replace as _replace
+
         from nexus.contracts.types import OperationContext
 
-        probe_ctx = OperationContext(
-            user_id="system",
-            groups=[],
-            is_system=True,
-            backend_path=backend_path,
-        )
+        probe_ctx: Any
+        if context is not None:
+            # Reuse the caller's identity and zone so auth-sensitive probes
+            # execute against the same credentials the original request did.
+            try:
+                probe_ctx = _replace(context, backend_path=backend_path)
+            except Exception:
+                probe_ctx = OperationContext(
+                    user_id=getattr(context, "user_id", "system") or "system",
+                    groups=list(getattr(context, "groups", []) or []),
+                    zone_id=getattr(context, "zone_id", None),
+                    is_system=getattr(context, "is_system", False),
+                    backend_path=backend_path,
+                )
+        else:
+            probe_ctx = OperationContext(
+                user_id="system",
+                groups=[],
+                is_system=True,
+                backend_path=backend_path,
+            )
         exists_fn = getattr(backend, "content_exists", None)
         if callable(exists_fn):
             return bool(exists_fn(backend_path, context=probe_ctx))
@@ -182,10 +210,45 @@ def _real_content_exists(backend: Any, backend_path: str) -> bool:
     return False
 
 
+def overlay_owns_path(
+    backend: Any,
+    mount_path: str,  # noqa: ARG001 — kept for API symmetry with dispatchers
+    backend_path: str | None,
+    context: Any | None = None,
+) -> bool:
+    """Return True if the virtual ``.readme/`` overlay authoritatively
+    owns ``backend_path`` on this ``backend``.
+
+    Single decision point used by every read/list/stat/exists/write
+    code path (Issue #3728 round 5 refactor) — ensures reads, writes,
+    and stats agree on who owns a given path.
+
+    Returns False when:
+    - Backend has no ``SKILL_NAME`` (overlay inactive)
+    - ``backend_path`` is not under the configured readme directory
+    - Backend opts to defer to real data (``VIRTUAL_README_DEFERS_TO_BACKEND``)
+      AND real content exists at the path
+
+    Propagates ``ValueError`` for malformed paths (traversal, null byte,
+    backslash) so callers can raise a loud error rather than silently
+    falling through to the real backend (Decision #4A).
+    """
+    if not _has_skill_name(backend):
+        return False
+    parts = _parse_readme_path_parts(backend_path, readme_dir=_readme_dir_for(backend))
+    if parts is None:
+        return False
+    return not (
+        _defers_to_backend(backend)
+        and _real_content_exists(backend, backend_path or "", context=context)
+    )
+
+
 def dispatch_virtual_readme_read(
     backend: Any,
     mount_path: str,
     backend_path: str | None,
+    context: Any | None = None,
 ) -> bytes | None:
     """Serve a read from the virtual ``.readme/`` overlay if it matches.
 
@@ -204,18 +267,12 @@ def dispatch_virtual_readme_read(
           non-skill backends return ``None`` from the ``_has_skill_name``
           check above, so this only fires for misconfigured skill backends.
     """
-    if not _has_skill_name(backend):
+    if not overlay_owns_path(backend, mount_path, backend_path, context=context):
         return None
 
     parts = _parse_readme_path_parts(backend_path, readme_dir=_readme_dir_for(backend))
-    if parts is None:
-        return None
-
-    # Finding #9: on writable path-addressed connectors (native gdrive),
-    # real user files at ``.readme/...`` must shadow the virtual overlay.
-    # Return None so the caller falls through to the real backend read.
-    if _defers_to_backend(backend) and _real_content_exists(backend, backend_path):
-        return None
+    # overlay_owns_path guarantees parts is not None here
+    assert parts is not None
 
     from nexus.contracts.exceptions import NexusFileNotFoundError
 
@@ -232,6 +289,7 @@ def dispatch_virtual_readme_list(
     backend: Any,
     mount_path: str,
     backend_path: str | None,
+    context: Any | None = None,
 ) -> list[str] | None:
     """List a directory from the virtual ``.readme/`` overlay if it matches.
 
@@ -245,16 +303,11 @@ def dispatch_virtual_readme_list(
         ``NotADirectoryError`` — path matches a virtual file, not a directory.
         ``ValueError`` — path traversal.
     """
-    if not _has_skill_name(backend):
+    if not overlay_owns_path(backend, mount_path, backend_path, context=context):
         return None
 
     parts = _parse_readme_path_parts(backend_path, readme_dir=_readme_dir_for(backend))
-    if parts is None:
-        return None
-
-    # Finding #9: defer to real backend listing when it has content.
-    if _defers_to_backend(backend) and _real_content_exists(backend, backend_path):
-        return None
+    assert parts is not None
 
     from nexus.contracts.exceptions import NexusFileNotFoundError
 
@@ -271,6 +324,7 @@ def dispatch_virtual_readme_exists(
     backend: Any,
     mount_path: str,
     backend_path: str | None,
+    context: Any | None = None,
 ) -> bool | None:
     """Answer ``content_exists`` from the virtual ``.readme/`` overlay.
 
@@ -284,16 +338,22 @@ def dispatch_virtual_readme_exists(
     try:
         parts = _parse_readme_path_parts(backend_path, readme_dir=_readme_dir_for(backend))
     except ValueError:
-        # Malformed path under .readme/ — treat as non-existent (False).
+        # Malformed path under .readme/ — exists() is a predicate, not
+        # an access attempt.  Return False so callers get a definitive
+        # answer without a surprise exception.
         return False
 
     if parts is None:
         return None
 
-    # Finding #9: defer to real backend — if it has content here, the
-    # virtual overlay is not in force for this path, so let the normal
-    # exists code path answer.
-    if _defers_to_backend(backend) and _real_content_exists(backend, backend_path):
+    # Shared ownership check: fall through to real backend when the
+    # overlay isn't authoritative here (e.g. native gdrive with a real
+    # ``.readme/`` folder).
+    try:
+        _owns = overlay_owns_path(backend, mount_path, backend_path, context=context)
+    except ValueError:
+        return False
+    if not _owns:
         return None
 
     try:
@@ -308,6 +368,7 @@ def dispatch_virtual_readme_size(
     backend: Any,
     mount_path: str,
     backend_path: str | None,
+    context: Any | None = None,
 ) -> int | None:
     """Return the virtual file size under ``.readme/``.
 
@@ -318,16 +379,11 @@ def dispatch_virtual_readme_size(
     Raises ``NexusFileNotFoundError`` for virtual directories and for
     paths under ``.readme/`` that don't exist.
     """
-    if not _has_skill_name(backend):
+    if not overlay_owns_path(backend, mount_path, backend_path, context=context):
         return None
 
     parts = _parse_readme_path_parts(backend_path, readme_dir=_readme_dir_for(backend))
-    if parts is None:
-        return None
-
-    # Finding #9: defer to real backend when it has content at this path.
-    if _defers_to_backend(backend) and _real_content_exists(backend, backend_path):
-        return None
+    assert parts is not None
 
     from nexus.contracts.exceptions import NexusFileNotFoundError
 

--- a/src/nexus/backends/connectors/schema_generator.py
+++ b/src/nexus/backends/connectors/schema_generator.py
@@ -165,43 +165,16 @@ def _real_content_exists(
 ) -> bool:
     """Best-effort probe: does the real backend have content at this path?
 
-    When a caller context is supplied, we reuse its ``user_id`` / ``zone_id``
-    so user-scoped connectors (native Google Drive, etc.) can actually
-    resolve an auth token and answer the question.  If no context is
-    supplied, fall back to a synthetic system context — this path is
-    safe for CLI-backed connectors whose ``content_exists`` is a stub
-    that returns ``False`` without needing auth.
+    Reuses the caller's context via ``_build_probe_context`` so
+    user-scoped connectors (native Google Drive, etc.) can actually
+    resolve an auth token and answer the question.
 
     Returns ``True`` only when the backend explicitly confirms existence.
     Any exception or missing probe method is treated as "does not exist"
     so the overlay still works on backends without a cheap exists check.
     """
     try:
-        from dataclasses import replace as _replace
-
-        from nexus.contracts.types import OperationContext
-
-        probe_ctx: Any
-        if context is not None:
-            # Reuse the caller's identity and zone so auth-sensitive probes
-            # execute against the same credentials the original request did.
-            try:
-                probe_ctx = _replace(context, backend_path=backend_path)
-            except Exception:
-                probe_ctx = OperationContext(
-                    user_id=getattr(context, "user_id", "system") or "system",
-                    groups=list(getattr(context, "groups", []) or []),
-                    zone_id=getattr(context, "zone_id", None),
-                    is_system=getattr(context, "is_system", False),
-                    backend_path=backend_path,
-                )
-        else:
-            probe_ctx = OperationContext(
-                user_id="system",
-                groups=[],
-                is_system=True,
-                backend_path=backend_path,
-            )
+        probe_ctx = _build_probe_context(context, backend_path)
         exists_fn = getattr(backend, "content_exists", None)
         if callable(exists_fn):
             return bool(exists_fn(backend_path, context=probe_ctx))
@@ -245,53 +218,87 @@ def overlay_owns_path(
     return not (_defers_to_backend(backend) and _real_readme_root_exists(backend, context=context))
 
 
+def _build_probe_context(context: Any | None, backend_path: str) -> Any:
+    """Build an OperationContext for backend probes (auth-preserving).
+
+    When a caller context is supplied, reuse its ``user_id`` /
+    ``zone_id`` / ``groups`` so user-scoped connectors can resolve an
+    auth token.  Otherwise fall back to a synthetic system context.
+    """
+    from dataclasses import replace as _replace
+
+    from nexus.contracts.types import OperationContext
+
+    if context is None:
+        return OperationContext(
+            user_id="system",
+            groups=[],
+            is_system=True,
+            backend_path=backend_path,
+        )
+    try:
+        return _replace(context, backend_path=backend_path)
+    except Exception:
+        return OperationContext(
+            user_id=getattr(context, "user_id", "system") or "system",
+            groups=list(getattr(context, "groups", []) or []),
+            zone_id=getattr(context, "zone_id", None),
+            is_system=getattr(context, "is_system", False),
+            backend_path=backend_path,
+        )
+
+
 def _real_readme_root_exists(backend: Any, context: Any | None = None) -> bool:
     """Probe the backend for a real ``.readme/`` directory (subtree root).
 
-    Issue #3728 round 6 finding #16: deferral must be subtree-atomic to
-    avoid "partly real, partly virtual" mixed states.  We probe the
-    root ``.readme`` path only — if it exists, the whole subtree is
-    considered user data and the overlay steps aside entirely.
+    Issue #3728 round 6/7: deferral must be subtree-atomic AND an
+    *empty* real directory must still count as existing — otherwise
+    the overlay shadows user-created folders on gdrive where
+    ``list_dir`` returns ``[]`` for both missing and empty directories.
 
-    Returns ``True`` only when the backend confirms existence via
-    either ``content_exists`` or ``list_dir`` returning a non-empty
-    result.  Any exception or missing probe method → ``False``.
+    Probe order (first definite "yes" wins):
+    1. ``backend.is_directory(readme_dir, context)`` — dedicated
+       directory-existence check (implemented by
+       ``PathAddressingEngine`` and most connector backends);
+       detects empty directories that ``list_dir`` can't distinguish
+       from "missing".
+    2. ``backend.content_exists(readme_dir, context)`` — file-level
+       existence, useful for connectors where the readme path can
+       appear as a file-like entry.
+    3. Non-empty ``backend.list_dir(readme_dir, context)`` — last-
+       resort fallback for backends that implement neither of the
+       above but expose real children through listing.
+
+    Returns ``False`` on any exception or when every probe says the
+    directory isn't there.
     """
     readme_dir = _readme_dir_for(backend)
-    # 1) content_exists probe (cheap for backends that implement it)
+    probe_ctx = _build_probe_context(context, readme_dir)
+
+    # 1) is_directory probe — handles the empty-directory case.
+    is_dir_fn = getattr(backend, "is_directory", None)
+    if callable(is_dir_fn):
+        try:
+            if is_dir_fn(readme_dir, context=probe_ctx):
+                return True
+        except Exception:
+            pass  # fall through to the remaining probes
+
+    # 2) content_exists probe (cheap for backends that implement it).
     if _real_content_exists(backend, readme_dir, context=context):
         return True
-    # 2) list_dir probe (for backends whose content_exists is a stub
-    #    but whose list_dir returns real directory entries).
-    try:
-        from dataclasses import replace as _replace
 
-        from nexus.contracts.types import OperationContext
-
-        if context is not None:
-            try:
-                probe_ctx: Any = _replace(context, backend_path=readme_dir)
-            except Exception:
-                probe_ctx = OperationContext(
-                    user_id=getattr(context, "user_id", "system") or "system",
-                    groups=list(getattr(context, "groups", []) or []),
-                    zone_id=getattr(context, "zone_id", None),
-                    is_system=getattr(context, "is_system", False),
-                    backend_path=readme_dir,
-                )
-        else:
-            probe_ctx = OperationContext(
-                user_id="system",
-                groups=[],
-                is_system=True,
-                backend_path=readme_dir,
-            )
-        list_fn = getattr(backend, "list_dir", None)
-        if callable(list_fn):
+    # 3) list_dir probe (only detects *non-empty* directories, which is
+    #    why we run it last — list_dir returning ``[]`` for both
+    #    "empty" and "missing" was the original finding-#17 bug).
+    list_fn = getattr(backend, "list_dir", None)
+    if callable(list_fn):
+        try:
             entries = list_fn(readme_dir, context=probe_ctx)
-            return bool(entries)
-    except Exception:
-        return False
+            if entries:
+                return True
+        except Exception:
+            return False
     return False
 
 

--- a/src/nexus/backends/storage/remote.py
+++ b/src/nexus/backends/storage/remote.py
@@ -181,12 +181,23 @@ class RemoteBackend(ObjectStoreABC):
         result = self._call_rpc("sys_readdir", {"path": abs_path})
         if isinstance(result, list):
             return [str(item) for item in result]
-        if isinstance(result, dict) and "items" in result:
-            items: list[Any] = result["items"]
-            return [
-                str(item.get("path", item.get("name", ""))) if isinstance(item, dict) else str(item)
-                for item in items
-            ]
+        if isinstance(result, dict):
+            # The RPC handler returns a ``{"files": [...]}`` envelope
+            # (``handle_list`` in ``server/rpc/handlers/filesystem.py``),
+            # but earlier RemoteBackend code only checked for ``"items"``.
+            # Accept both so list operations round-trip correctly.
+            items: list[Any] | None = None
+            if "files" in result:
+                items = result["files"]
+            elif "items" in result:
+                items = result["items"]
+            if items is not None:
+                return [
+                    str(item.get("path", item.get("name", "")))
+                    if isinstance(item, dict)
+                    else str(item)
+                    for item in items
+                ]
         return []
 
     # === Lifecycle ===

--- a/src/nexus/bricks/mount/mount_service.py
+++ b/src/nexus/bricks/mount/mount_service.py
@@ -118,8 +118,15 @@ class MountService:
         fail the mount operation (Decision #12).
 
         Runs:
-        - Readme doc generation for ReadmeDocMixin backends
+        - Mount path propagation for ReadmeDocMixin backends (so error
+          messages can reference the correct ``.readme/README.md`` path)
         - Search indexing via search_service (Issue #3148 Gap 1)
+
+        NOTE (Issue #3728): README materialization was removed.  The
+        virtual ``.readme/`` overlay in ``nexus_fs`` + ``schema_generator``
+        serves docs on-demand from class metadata, so there's nothing to
+        write here.  The BackendFeature.README_DOC flag is still honored
+        downstream for error-message mount_path propagation.
         """
         try:
             # Get backend from router to check capabilities
@@ -128,11 +135,14 @@ class MountService:
             if backend is None:
                 return
 
-            # Readme doc generation (via mount_hooks if available)
-            from nexus.contracts.backend_features import BackendFeature
+            # Propagate mount_path to the backend for error messages.  The
+            # virtual overlay itself takes mount_path from OperationContext,
+            # but error formatting in ValidatedMixin/TraitBasedMixin still
+            # reads the instance attribute as a fallback.
+            from nexus.backends.connectors.base import ReadmeDocMixin
 
-            if hasattr(backend, "has_feature") and backend.has_feature(BackendFeature.README_DOC):
-                await self._generate_readmes(mount_point, backend)
+            if isinstance(backend, ReadmeDocMixin) and backend.SKILL_NAME:
+                backend.set_mount_path(mount_point)
 
             # Search indexing — index the mount point so content is discoverable.
             # Uses search_service DI (Issue #3148 Phase 1).
@@ -159,37 +169,6 @@ class MountService:
             logger.warning(
                 "Post-mount hooks failed for %s (mount still active)", mount_point, exc_info=True
             )
-
-    async def _generate_readmes(self, mount_point: str, backend: Any) -> None:
-        """Generate .readme/ directory for a connector backend (async).
-
-        Called from post-mount hooks and sync completion.
-        """
-        from nexus.backends.connectors.base import ReadmeDocMixin
-
-        if not isinstance(backend, ReadmeDocMixin):
-            return
-        if not backend.SKILL_NAME:
-            return
-
-        backend.set_mount_path(mount_point)
-
-        # Determine filesystem to write to
-        fs = None
-        if self._gw is not None and hasattr(self._gw, "nexus_fs"):
-            fs = self._gw.nexus_fs
-        elif self.nexus_fs is not None:
-            fs = self.nexus_fs
-
-        if fs is not None:
-            try:
-                result = await backend.write_readme(mount_point, fs)
-                if result.get("readme_md"):
-                    logger.info(
-                        "Generated readme docs for %s at %s", mount_point, result["readme_md"]
-                    )
-            except Exception:
-                logger.warning("Failed to generate readme docs for %s", mount_point, exc_info=True)
 
     async def _index_mount_content(self, mount_point: str, *, zone_id: str | None = None) -> None:
         """Index mounted connector content for semantic search.

--- a/src/nexus/bricks/search/indexing_service.py
+++ b/src/nexus/bricks/search/indexing_service.py
@@ -12,7 +12,9 @@ Key design decisions:
   - Comprehensive error handling with structured logging
 """
 
+import hashlib
 import logging
+import posixpath
 from datetime import UTC, datetime
 from typing import Any
 
@@ -35,6 +37,39 @@ from nexus.bricks.search.models import DocumentChunkModel, FilePathModel
 from nexus.bricks.search.protocols import FileReaderProtocol
 
 logger = logging.getLogger(__name__)
+
+
+def _looks_like_virtual_readme(path: str) -> bool:
+    """Heuristic: does ``path`` match a virtual ``.readme/`` overlay entry?
+
+    Issue #3728: the virtual ``.readme/`` tree has no metastore rows.
+    When ``_query_file_model`` misses on a path under ``.readme/``, this
+    helper lets the indexer treat it as a virtual-doc candidate and
+    synthesize a path_id instead of silently dropping the file.
+
+    The check is intentionally path-shape-only — the router /
+    backend introspection that would give us definitive "is this
+    virtual?" answers isn't available from ``IndexingService``
+    (which only holds a ``FileReaderProtocol``).  False positives
+    are bounded: a user-created real ``.readme/`` folder whose row
+    happens to be missing would index with a synthetic ``virtual:``
+    path_id which doesn't collide with real path_ids.
+    """
+    normalized = posixpath.normpath(path)
+    segments = normalized.split("/")
+    return any(seg == ".readme" for seg in segments)
+
+
+def _virtual_path_id(path: str) -> str:
+    """Deterministic synthetic path_id for a virtual readme path.
+
+    Prefixed with ``virtual:`` so it can't collide with a real
+    FilePathModel path_id.  SHA-256 of the virtual path keeps it
+    stable across runs so re-indexing deletes the previous chunks
+    via the pipeline's path_id-keyed upsert.
+    """
+    return "virtual:" + hashlib.sha256(path.encode("utf-8")).hexdigest()
+
 
 # Binary extensions excluded from directory indexing.
 _BINARY_EXTENSIONS: tuple[str, ...] = (
@@ -189,6 +224,23 @@ class IndexingService:
                         documents.append(
                             (file_path, content, file_model.path_id),
                         )
+                    elif _looks_like_virtual_readme(file_path):
+                        # Issue #3728: virtual ``.readme/`` overlay paths
+                        # are row-less by design — the tree is served from
+                        # class metadata at read time so there's nothing
+                        # to persist.  Use a deterministic synthetic
+                        # path_id so the search pipeline can still chunk
+                        # + embed + store the content.  The ``virtual:``
+                        # prefix namespaces them away from real FilePathModel
+                        # path_ids so they can't collide.
+                        #
+                        # Known limitation: when the connector class
+                        # metadata changes (e.g. a nexus upgrade), the
+                        # synthetic path_id stays the same but the
+                        # embeddings become stale.  Users need to
+                        # re-trigger indexing (remount) to refresh.
+                        synth_path_id = _virtual_path_id(file_path)
+                        documents.append((file_path, content, synth_path_id))
                 except Exception:
                     logger.warning(
                         "[INDEXING-SVC] Skipping %s: failed to read or resolve",

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -745,15 +745,53 @@ class SearchService:
                 user_id="anonymous", groups=[], backend_path=route.backend_path
             )
 
-        # Issue #3266: Metastore-first listing.
-        # Prefer metastore entries when available (populated by sync infrastructure).
-        # Fall back to live API on cache miss (empty metastore for this path).
-        all_paths = self._list_from_metastore_or_api(
-            path=path,
+        # Issue #3728: virtual ``.readme/`` overlay short-circuit.
+        # When the requested path is under a skill backend's virtual
+        # ``.readme/`` subtree, the real backend has nothing at that
+        # path and ``_list_from_metastore_or_api`` below would raise
+        # ``NexusFileNotFoundError``.  Serve from the overlay first
+        # and only fall through to the real backend when the overlay
+        # doesn't own the path.
+        virtual_replacement = self._list_virtual_readme_children(
             route=route,
-            list_context=list_context,
-            recursive=recursive,
+            path=path,
+            context=list_context,
         )
+        if virtual_replacement is not None:
+            all_paths = virtual_replacement
+        else:
+            # Issue #3266: Metastore-first listing.
+            # Prefer metastore entries when available (populated by sync
+            # infrastructure).  Fall back to live API on cache miss.
+            try:
+                all_paths = self._list_from_metastore_or_api(
+                    path=path,
+                    route=route,
+                    list_context=list_context,
+                    recursive=recursive,
+                )
+            except Exception as _list_exc:
+                # Real listing failed — continue with an empty list so
+                # the virtual overlay below can still contribute the
+                # mount-root ``.readme/`` entry or descendants.
+                logger.debug(
+                    "[SKILL-LIST] Real backend list_dir failed for %s: %s",
+                    path,
+                    _list_exc,
+                )
+                all_paths = []
+
+            # Issue #3728: mount-root injection.
+            # On a mount-root listing, append the virtual ``.readme/``
+            # subtree alongside the real backend entries.  Non-root
+            # paths fall through unchanged.
+            all_paths = self._augment_with_virtual_readme_entries(
+                all_paths=all_paths,
+                route=route,
+                path=path,
+                recursive=recursive,
+                context=list_context,
+            )
 
         # Permission filtering
         if self._enforce_permissions and context:
@@ -790,6 +828,173 @@ class SearchService:
             context=list_context,
             recursive=recursive,
         )
+
+    def _list_virtual_readme_children(
+        self,
+        *,
+        route: Any,
+        path: str,
+        context: Any,
+    ) -> builtins.list[str] | None:
+        """Return virtual ``.readme/`` children for a direct subtree listing.
+
+        Issue #3728: when the caller is listing a path INSIDE the
+        virtual ``.readme/`` overlay (e.g. ``/mount/.readme/`` or
+        ``/mount/.readme/schemas/``), the real backend has no entries
+        at that path and ``backend.list_dir`` would raise — so we
+        short-circuit with the virtual tree's view before the real
+        listing runs.
+
+        Returns a fully-qualified list of child paths, or ``None``
+        when the overlay does not own the path (caller continues
+        with the normal real-backend listing).
+        """
+        backend = getattr(route, "backend", None)
+        backend_path = getattr(route, "backend_path", "") or ""
+        mount_point = getattr(route, "mount_point", "") or ""
+        if backend is None:
+            return None
+        try:
+            from nexus.backends.connectors.schema_generator import (
+                dispatch_virtual_readme_list,
+            )
+        except ImportError:
+            return None
+        try:
+            virtual_children = dispatch_virtual_readme_list(
+                backend, mount_point, backend_path, context=context
+            )
+        except Exception:
+            return None
+        if virtual_children is None:
+            return None
+
+        mount_prefix = mount_point.rstrip("/")
+        base = path.rstrip("/") or mount_prefix
+
+        def _as_absolute(name: str) -> str:
+            if name.startswith("/"):
+                return name
+            return f"{base}/{name}"
+
+        return [_as_absolute(n) for n in virtual_children]
+
+    def _augment_with_virtual_readme_entries(
+        self,
+        *,
+        all_paths: builtins.list[str],
+        route: Any,
+        path: str,
+        recursive: bool,
+        context: Any,
+    ) -> builtins.list[str]:
+        """Inject virtual ``.readme/`` overlay entries into a connector listing.
+
+        Issue #3728: ``_list_dynamic_connector`` calls ``backend.list_dir``
+        directly, which doesn't know about the virtual tree that
+        ``sys_readdir``'s ExternalRouteResult branch dispatches.  This
+        helper mirrors that logic at the SearchService layer so the
+        full-stack list API sees the same entries the slim CLI sees.
+
+        Behavior:
+        - Mount root, non-recursive → append ``<mount>/.readme/``
+        - Mount root, recursive → flatten the virtual tree and append
+          every child (``.readme/README.md``, ``.readme/schemas/...``)
+        - Under ``.readme/`` → replace with the virtual tree's view of
+          the requested subdirectory
+        - Overlay doesn't own the subtree (deferring backend with real
+          data) → no-op, return input unchanged
+        """
+        backend = getattr(route, "backend", None)
+        backend_path = getattr(route, "backend_path", "") or ""
+        mount_point = getattr(route, "mount_point", "") or ""
+        if backend is None:
+            return all_paths
+
+        try:
+            from nexus.backends.connectors.schema_generator import (
+                _has_skill_name,
+                _readme_dir_for,
+                dispatch_virtual_readme_list,
+                get_virtual_readme_tree_for_backend,
+                overlay_owns_path,
+            )
+        except ImportError:
+            return all_paths
+
+        if not _has_skill_name(backend):
+            return all_paths
+
+        # Case 1: direct listing of a virtual .readme/ path — ask the
+        # dispatch helper for the child names.
+        try:
+            virtual_children = dispatch_virtual_readme_list(
+                backend, mount_point, backend_path, context=context
+            )
+        except Exception:
+            virtual_children = None
+
+        mount_prefix = mount_point.rstrip("/")
+
+        def _as_absolute(name: str) -> str:
+            """Turn a child name (``README.md`` or ``schemas/``) into an
+            absolute virtual path like ``/mount/.readme/README.md``."""
+            if name.startswith("/"):
+                return name
+            base = path.rstrip("/")
+            return f"{base}/{name}"
+
+        if virtual_children is not None:
+            # Replace — the virtual tree is authoritative for this path.
+            return [_as_absolute(name) for name in virtual_children]
+
+        # Case 2: mount-root listing — inject the ``.readme/`` subtree
+        # alongside the real backend entries.
+        if backend_path.strip("/"):
+            # Non-root under the mount and not under ``.readme/`` — no injection.
+            return all_paths
+
+        readme_dir_name = _readme_dir_for(backend).strip("/")
+        try:
+            if not overlay_owns_path(backend, mount_point, readme_dir_name, context=context):
+                return all_paths
+        except ValueError:
+            return all_paths
+        except Exception:
+            return all_paths
+
+        existing = set(all_paths)
+
+        if not recursive:
+            virtual_entry = f"{mount_prefix}/{readme_dir_name}/"
+            if virtual_entry not in existing:
+                return [*all_paths, virtual_entry]
+            return all_paths
+
+        # Recursive: flatten the virtual tree to every leaf + intermediate dir.
+        try:
+            tree = get_virtual_readme_tree_for_backend(backend, mount_point)
+        except Exception:
+            return all_paths
+
+        def _walk(node: Any, prefix: str) -> builtins.list[str]:
+            out: builtins.list[str] = []
+            if node.is_dir:
+                if prefix:
+                    out.append(f"{mount_prefix}/{prefix}/")
+                for child_name, child in node.children.items():
+                    child_prefix = f"{prefix}/{child_name}" if prefix else child_name
+                    out.extend(_walk(child, child_prefix))
+            else:
+                out.append(f"{mount_prefix}/{prefix}")
+            return out
+
+        flattened = _walk(tree, readme_dir_name)
+        merged = list(all_paths)
+        for rel in flattened:
+            if rel not in existing:
+                merged.append(rel)
+        return merged
 
     def resolve_physical_path(self, virtual_path: str) -> str | None:
         """Resolve display path → raw backend path via file_paths table.

--- a/src/nexus/contracts/types.py
+++ b/src/nexus/contracts/types.py
@@ -98,6 +98,10 @@ class OperationContext:
         admin_capabilities: Set of granted admin capabilities.
         request_id: Unique ID for audit trail correlation.
         backend_path: Backend-relative path for connector backends (optional).
+        mount_path: Mount point for the backend, e.g. "/gws/gmail" (Issue #3728).
+            Populated by the router when a request is dispatched to a mounted backend.
+            Used by the virtual ``.readme/`` overlay to render absolute paths in
+            auto-generated skill docs without per-connector instance state.
 
     Examples:
         >>> ctx = OperationContext(
@@ -124,6 +128,7 @@ class OperationContext:
     # Backend path for path-based connectors (GCS, S3, etc.)
     backend_path: str | None = None
     virtual_path: str | None = None  # Full virtual path with mount prefix (for cache keys)
+    mount_path: str | None = None  # Mount point for the backend (Issue #3728)
 
     # Read Set Tracking for Query Dependencies (Issue #1166)
     read_set: "ReadSet | None" = None
@@ -286,6 +291,7 @@ def parse_operation_context(context: OperationContext | dict | None = None) -> O
         admin_capabilities=set(context.get("admin_capabilities", ())),
         backend_path=context.get("backend_path"),
         virtual_path=context.get("virtual_path"),
+        mount_path=context.get("mount_path"),
     )
 
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -527,6 +527,62 @@ class NexusFS(  # type: ignore[misc]
             "zone_id": self._zone_id,
         }
 
+    def _reject_if_virtual_readme(
+        self,
+        path: str,
+        context: OperationContext | None,
+        op: str = "write",
+    ) -> None:
+        """Raise ``PermissionError`` if ``path`` is under a virtual ``.readme/``.
+
+        Issue #3728: the overlay advertises virtual files as mode 0o444
+        (read-only), but the write/delete/rename/mkdir paths route on
+        backend_path directly — without this guard, a caller writing to
+        ``/<mount>/.readme/README.md`` would create a real file in the
+        backend (e.g. a stray ``.readme/README.md`` in the user's Google
+        Drive).  This helper blocks every mutating entry point at the
+        kernel layer so the virtual tree cannot be mutated.
+
+        Called from: ``_write_content``, ``sys_write``, ``write``,
+        ``mkdir``, ``rmdir``, ``sys_unlink``, ``sys_rename``,
+        ``write_batch``, ``delete_batch``, ``rename_batch``.
+        """
+        try:
+            _, _, is_admin = self._get_context_identity(context)
+            route = self.router.route(
+                path, is_admin=is_admin, check_write=False, zone_id=self._zone_id
+            )
+        except Exception:
+            return  # non-routable path — let the real call surface the error
+
+        backend = getattr(route, "backend", None)
+        if backend is None:
+            return
+
+        from nexus.backends.connectors.schema_generator import (
+            _has_skill_name,
+            _parse_readme_path_parts,
+            _readme_dir_for,
+        )
+
+        if not _has_skill_name(backend):
+            return
+
+        backend_path = getattr(route, "backend_path", "") or ""
+        try:
+            parts = _parse_readme_path_parts(backend_path, readme_dir=_readme_dir_for(backend))
+        except ValueError:
+            # Malformed path (traversal etc.) — let the real call surface it
+            return
+
+        if parts is None:
+            return  # not a virtual readme path
+
+        raise PermissionError(
+            f"Cannot {op} virtual .readme/ path: {path} "
+            f"(skill docs are read-only and generated from class metadata)"
+        )
+
     def _try_virtual_readme_bytes(
         self,
         path: str,
@@ -1863,6 +1919,9 @@ class NexusFS(  # type: ignore[misc]
         if route.readonly:
             raise PermissionError(f"Path is read-only: {path}")
 
+        # Virtual .readme/ paths are read-only (Issue #3728).
+        self._reject_if_virtual_readme(path, context, op="write_stream")
+
         # PRE-INTERCEPT: pre-write hooks (Issue #899)
         from nexus.contracts.vfs_hooks import WriteHookContext as _WHC
 
@@ -1991,6 +2050,10 @@ class NexusFS(  # type: ignore[misc]
 
         # [INTERMEDIATE] PRE-DISPATCH: resolve — migrates to Rust dispatch middleware in PR 7
         context = self._parse_context(context)
+
+        # Virtual .readme/ paths are read-only (Issue #3728).
+        self._reject_if_virtual_readme(path, context, op="sys_write")
+
         _handled, _result = self.resolve_write(path, buf)
         if _handled:
             base: dict[str, Any] = {"path": path, "bytes_written": len(buf)}
@@ -2085,6 +2148,9 @@ class NexusFS(  # type: ignore[misc]
 
         if route.readonly:
             raise PermissionError(f"Cannot create directory in read-only path: {path}")
+
+        # Virtual .readme/ paths are read-only (Issue #3728).
+        self._reject_if_virtual_readme(path, context, op="mkdir")
 
         # Check if directory already exists
         existing = route.metastore.get(path)
@@ -2343,6 +2409,9 @@ class NexusFS(  # type: ignore[misc]
         # Check if path is read-only
         if route.readonly:
             raise PermissionError(f"Path is read-only: {path}")
+
+        # Virtual .readme/ paths are read-only (Issue #3728).
+        self._reject_if_virtual_readme(path, context, op="write")
 
         # Get existing metadata for permission check and update detection (single query)
         now = datetime.now(UTC)
@@ -2953,7 +3022,10 @@ class NexusFS(  # type: ignore[misc]
         # Validate paths
         validated_files: list[tuple[str, bytes]] = []
         for path, content in files:
-            validated_files.append((self._validate_path(path), content))
+            validated_path = self._validate_path(path)
+            # Virtual .readme/ paths are read-only (Issue #3728).
+            self._reject_if_virtual_readme(validated_path, context, op="write_batch")
+            validated_files.append((validated_path, content))
 
         zone_id, agent_id, is_admin = self._get_context_identity(context)
         paths = [p for p, _ in validated_files]
@@ -3424,6 +3496,9 @@ class NexusFS(  # type: ignore[misc]
         if route.readonly:
             raise PermissionError(f"Cannot delete from read-only path: {path}")
 
+        # Virtual .readme/ paths are read-only (Issue #3728).
+        self._reject_if_virtual_readme(path, context, op="delete")
+
         # Check if file exists in metadata.
         # Use prefetched hint from resolve_delete() if available (#1311)
         meta = _result if _result is not None else route.metastore.get(path)
@@ -3639,6 +3714,10 @@ class NexusFS(  # type: ignore[misc]
             raise PermissionError(f"Cannot rename from read-only path: {old_path}")
         if new_route.readonly:
             raise PermissionError(f"Cannot rename to read-only path: {new_path}")
+
+        # Virtual .readme/ paths are read-only on both ends (Issue #3728).
+        self._reject_if_virtual_readme(old_path, context, op="rename")
+        self._reject_if_virtual_readme(new_path, context, op="rename")
 
         # ── Fast-fail (unlocked, optimization only) ──
         # Avoids lock acquisition for the common "file not found" error case.
@@ -4492,6 +4571,9 @@ class NexusFS(  # type: ignore[misc]
 
         for path in validated:
             try:
+                # Virtual .readme/ paths are read-only (Issue #3728).
+                self._reject_if_virtual_readme(path, context, op="delete")
+
                 meta = batch_meta.get(path)
 
                 # Check for implicit directory (exists because it has files beneath it)
@@ -4978,6 +5060,7 @@ class NexusFS(  # type: ignore[misc]
                         _has_skill_name,
                         _readme_dir_for,
                         dispatch_virtual_readme_list,
+                        get_virtual_readme_tree_for_backend,
                     )
 
                     _virtual_entries = dispatch_virtual_readme_list(
@@ -4988,18 +5071,57 @@ class NexusFS(  # type: ignore[misc]
                     else:
                         entries = backend.list_dir(backend_path, context=_ctx)
                         # Mount-root listing (backend_path is empty or just
-                        # "/") — inject the virtual ``.readme/`` entry so the
-                        # doc overlay is discoverable from ``ls /<mount>``
-                        # instead of only via a direct ``.readme/`` path.
+                        # "/") — inject the virtual ``.readme/`` subtree
+                        # (flattened for recursive=True) so the doc overlay
+                        # is discoverable from ``ls`` and also indexable by
+                        # search/recursive walkers that only enumerate from
+                        # the mount root (Issue #3728 finding #5 + #8).
                         if (
                             entries is not None
                             and _has_skill_name(backend)
                             and not backend_path.strip("/")
                         ):
                             readme_dir_name = _readme_dir_for(backend).strip("/")
-                            virtual_entry = f"{readme_dir_name}/"
-                            if virtual_entry not in entries and readme_dir_name not in entries:
-                                entries = list(entries) + [virtual_entry]
+                            entries = list(entries)
+                            if recursive:
+                                # Flatten the virtual tree to every leaf path
+                                # so callers that recurse from the mount root
+                                # (indexing, search, TUI tree) descend into
+                                # README.md + schemas/ + examples/ without a
+                                # second sys_readdir round-trip.
+                                try:
+                                    _vtree = get_virtual_readme_tree_for_backend(
+                                        backend, mount_point
+                                    )
+                                except Exception:
+                                    _vtree = None
+                                if _vtree is not None:
+
+                                    def _walk(node, prefix: str) -> list[str]:
+                                        out: list[str] = []
+                                        if node.is_dir:
+                                            # Include the directory itself
+                                            if prefix:
+                                                out.append(f"{prefix}/")
+                                            for child_name, child in node.children.items():
+                                                child_prefix = (
+                                                    f"{prefix}/{child_name}"
+                                                    if prefix
+                                                    else child_name
+                                                )
+                                                out.extend(_walk(child, child_prefix))
+                                        else:
+                                            out.append(prefix)
+                                        return out
+
+                                    flattened = _walk(_vtree, readme_dir_name)
+                                    for rel in flattened:
+                                        if rel not in entries:
+                                            entries.append(rel)
+                            else:
+                                virtual_entry = f"{readme_dir_name}/"
+                                if virtual_entry not in entries and readme_dir_name not in entries:
+                                    entries.append(virtual_entry)
                     if entries is not None:
                         if details:
                             return [

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -527,6 +527,39 @@ class NexusFS(  # type: ignore[misc]
             "zone_id": self._zone_id,
         }
 
+    def _try_virtual_readme_bytes(
+        self,
+        path: str,
+        context: OperationContext | None,
+    ) -> bytes | None:
+        """Return the bytes for a virtual ``.readme/`` path, or ``None``.
+
+        Synchronous sibling of ``_try_virtual_readme_stat`` used by
+        ``read_bulk`` (which is sync and cannot ``await sys_read``) to
+        serve virtual skill docs when the Rust fast path misses.
+        """
+        try:
+            _, _, is_admin = self._get_context_identity(context)
+            route = self.router.route(
+                path, is_admin=is_admin, check_write=False, zone_id=self._zone_id
+            )
+        except Exception:
+            return None
+
+        backend = getattr(route, "backend", None)
+        if backend is None:
+            return None
+
+        mount_point = getattr(route, "mount_point", "") or ""
+        backend_path = getattr(route, "backend_path", "") or ""
+
+        from nexus.backends.connectors.schema_generator import dispatch_virtual_readme_read
+
+        try:
+            return dispatch_virtual_readme_read(backend, mount_point, backend_path)
+        except Exception:
+            return None
+
     # Issue #1790: _check_zone_writable() deleted — now handled by
     def _build_write_metadata(
         self,
@@ -1524,12 +1557,20 @@ class NexusFS(  # type: ignore[misc]
         for path in allowed_set:
             try:
                 result = self._kernel.sys_read(path, _rust_ctx)
-                if not result.hit:
+                content: bytes | None = None
+                if result.hit:
+                    content = result.data or b""
+                else:
+                    # Rust fast path missed.  Virtual ``.readme/`` paths
+                    # (Issue #3728) are not in the metastore, so we
+                    # route through the same dispatch helper that the
+                    # async ``sys_read`` uses before declaring "not found".
+                    content = self._try_virtual_readme_bytes(path, context)
+                if content is None:
                     if skip_errors:
                         results[path] = None
                         continue
                     raise NexusFileNotFoundError(path)
-                content = result.data or b""
                 if return_metadata:
                     assert batch_meta is not None
                     meta = batch_meta.get(path)
@@ -4934,17 +4975,31 @@ class NexusFS(  # type: ignore[misc]
                     )
                     # Virtual .readme/ overlay check (Issue #3728).
                     from nexus.backends.connectors.schema_generator import (
+                        _has_skill_name,
+                        _readme_dir_for,
                         dispatch_virtual_readme_list,
                     )
 
                     _virtual_entries = dispatch_virtual_readme_list(
                         backend, mount_point, backend_path
                     )
-                    entries = (
-                        _virtual_entries
-                        if _virtual_entries is not None
-                        else backend.list_dir(backend_path, context=_ctx)
-                    )
+                    if _virtual_entries is not None:
+                        entries = _virtual_entries
+                    else:
+                        entries = backend.list_dir(backend_path, context=_ctx)
+                        # Mount-root listing (backend_path is empty or just
+                        # "/") — inject the virtual ``.readme/`` entry so the
+                        # doc overlay is discoverable from ``ls /<mount>``
+                        # instead of only via a direct ``.readme/`` path.
+                        if (
+                            entries is not None
+                            and _has_skill_name(backend)
+                            and not backend_path.strip("/")
+                        ):
+                            readme_dir_name = _readme_dir_for(backend).strip("/")
+                            virtual_entry = f"{readme_dir_name}/"
+                            if virtual_entry not in entries and readme_dir_name not in entries:
+                                entries = list(entries) + [virtual_entry]
                     if entries is not None:
                         if details:
                             return [

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -488,7 +488,19 @@ class NexusFS(  # type: ignore[misc]
             _parse_readme_path_parts,
             _readme_dir_for,
             get_virtual_readme_tree_for_backend,
+            overlay_owns_path,
         )
+
+        # Round 5 finding #13: defer to real backend when it owns this
+        # path, so ``sys_stat`` can't report virtual metadata for a file
+        # that ``sys_read`` serves from real storage.  Malformed paths
+        # propagate as None so sys_stat returns its normal miss result.
+        try:
+            _owns = overlay_owns_path(backend, mount_point, backend_path, context=ctx)
+        except ValueError:
+            return None
+        if not _owns:
+            return None
 
         try:
             parts = _parse_readme_path_parts(backend_path, readme_dir=_readme_dir_for(backend))
@@ -559,32 +571,22 @@ class NexusFS(  # type: ignore[misc]
         if backend is None:
             return
 
-        from nexus.backends.connectors.schema_generator import (
-            _defers_to_backend,
-            _has_skill_name,
-            _parse_readme_path_parts,
-            _readme_dir_for,
-            _real_content_exists,
-        )
-
-        if not _has_skill_name(backend):
-            return
-
         backend_path = getattr(route, "backend_path", "") or ""
+        mount_point = getattr(route, "mount_point", "") or ""
+
+        from nexus.backends.connectors.schema_generator import overlay_owns_path
+
+        # Shared ownership check — only reject when the virtual overlay
+        # is authoritative for this path.  On deferring backends
+        # (native gdrive) with real data here, the mutation is a
+        # legitimate operation against user data and passes through.
+        # Malformed paths (traversal etc.) fall through so the real
+        # call surfaces the underlying error with its own message.
         try:
-            parts = _parse_readme_path_parts(backend_path, readme_dir=_readme_dir_for(backend))
+            owns = overlay_owns_path(backend, mount_point, backend_path, context=context)
         except ValueError:
-            # Malformed path (traversal etc.) — let the real call surface it
             return
-
-        if parts is None:
-            return  # not a virtual readme path
-
-        # Finding #9: on writable backends that defer to real content,
-        # only reject when the virtual overlay is actually serving this
-        # path.  If the real backend has data here, the mutation is a
-        # legitimate user action against real data — let it through.
-        if _defers_to_backend(backend) and _real_content_exists(backend, backend_path):
+        if not owns:
             return
 
         raise PermissionError(
@@ -621,7 +623,7 @@ class NexusFS(  # type: ignore[misc]
         from nexus.backends.connectors.schema_generator import dispatch_virtual_readme_read
 
         try:
-            return dispatch_virtual_readme_read(backend, mount_point, backend_path)
+            return dispatch_virtual_readme_read(backend, mount_point, backend_path, context=context)
         except Exception:
             return None
 
@@ -1428,7 +1430,10 @@ class NexusFS(  # type: ignore[misc]
                 )
 
                 _virtual_data = dispatch_virtual_readme_read(
-                    _route_backend, _route_mount_point, _route_backend_path
+                    _route_backend,
+                    _route_mount_point,
+                    _route_backend_path,
+                    context=_ctx,
                 )
                 if _virtual_data is not None:
                     data = _virtual_data
@@ -3907,13 +3912,17 @@ class NexusFS(  # type: ignore[misc]
         self._reject_if_virtual_readme(dst_path, context, op="copy")
 
         # Virtual .readme/ source: bypass metastore and copy the virtual
-        # bytes through to the destination via sys_write after a real-file
-        # check.  This matches the behavior of ``sys_read`` + ``write``
-        # composition without requiring the source to be materialized.
+        # bytes to the destination.  Enforces ``FileExistsError`` on
+        # existing destinations to match the non-virtual copy semantics
+        # (round 5 finding #11 — ``write()`` alone is an overwrite path).
         _virtual_src_bytes = self._try_virtual_readme_bytes(src_path, context)
         if _virtual_src_bytes is not None:
-            # Use the existing write path so destination metadata +
-            # post-hooks fire normally.
+            # Destination-exists check — same contract as the regular
+            # copy branch below.
+            if dst_route.metastore.exists(dst_path):
+                raise FileExistsError(f"Destination path already exists: {dst_path}")
+            # Route through the normal write path for post-hooks +
+            # metadata + return-shape parity.
             write_result = await self.write(dst_path, _virtual_src_bytes, context=context)
             return {
                 "src_path": src_path,
@@ -5094,7 +5103,7 @@ class NexusFS(  # type: ignore[misc]
                     )
 
                     _virtual_entries = dispatch_virtual_readme_list(
-                        backend, mount_point, backend_path
+                        backend, mount_point, backend_path, context=_ctx
                     )
                     if _virtual_entries is not None:
                         entries = _virtual_entries

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -3912,18 +3912,66 @@ class NexusFS(  # type: ignore[misc]
         self._reject_if_virtual_readme(dst_path, context, op="copy")
 
         # Virtual .readme/ source: bypass metastore and copy the virtual
-        # bytes to the destination.  Enforces ``FileExistsError`` on
-        # existing destinations to match the non-virtual copy semantics
-        # (round 5 finding #11 — ``write()`` alone is an overwrite path).
+        # bytes to the destination.  Virtual docs have no metastore row
+        # so the normal ``src_meta.get`` path below would fail before
+        # hooks run — do the safety checks the normal branch does
+        # (source READ permission via the copy hook, destination
+        # existence on BOTH metastore and backend) here first.
+        # Round 6 findings #14 + #15.
         _virtual_src_bytes = self._try_virtual_readme_bytes(src_path, context)
         if _virtual_src_bytes is not None:
-            # Destination-exists check — same contract as the regular
-            # copy branch below.
+            # Enforce source READ permission + destination WRITE
+            # permission via the same copy-hook pipeline the normal
+            # copy path runs.  Permission hooks receive a synthesized
+            # metadata dict since virtual docs have no row.
+            from nexus.contracts.vfs_hooks import CopyHookContext as _CHC
+
+            _virtual_copy_ctx = _CHC(
+                src_path=src_path,
+                dst_path=dst_path,
+                context=context,
+                zone_id=zone_id,
+                agent_id=agent_id,
+                metadata=None,  # virtual docs have no FileMetadata row
+            )
+            self._kernel.dispatch_pre_hooks("copy", _virtual_copy_ctx)
+
+            # Destination exists check — both metastore AND backend
+            # (path-addressed external connectors may have a real file
+            # at backend_path that hasn't been synced into the metastore
+            # yet; the metastore-only check would let us overwrite it).
             if dst_route.metastore.exists(dst_path):
                 raise FileExistsError(f"Destination path already exists: {dst_path}")
+            dst_backend_path = getattr(dst_route, "backend_path", "") or ""
+            dst_backend = getattr(dst_route, "backend", None)
+            _content_exists = getattr(dst_backend, "content_exists", None)
+            if dst_backend is not None and callable(_content_exists):
+                from dataclasses import replace as _replace
+
+                try:
+                    _probe_ctx = (
+                        _replace(context, backend_path=dst_backend_path)
+                        if context is not None
+                        else None
+                    )
+                except Exception:
+                    _probe_ctx = None
+                try:
+                    if _content_exists(dst_backend_path, context=_probe_ctx):
+                        raise FileExistsError(
+                            f"Destination path already exists on backend: {dst_path}"
+                        )
+                except FileExistsError:
+                    raise
+                except Exception:
+                    # Probe failed — fall through to the write and let
+                    # the backend's own create-semantics handle it.
+                    pass
+
             # Route through the normal write path for post-hooks +
             # metadata + return-shape parity.
             write_result = await self.write(dst_path, _virtual_src_bytes, context=context)
+            self._kernel.dispatch_post_hooks("copy", _virtual_copy_ctx)
             return {
                 "src_path": src_path,
                 "dst_path": dst_path,

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -5167,10 +5167,15 @@ class NexusFS(  # type: ignore[misc]
                     _virtual_entries = dispatch_virtual_readme_list(
                         backend, mount_point, backend_path, context=_ctx
                     )
+                    # Name this variable distinctly from the metastore
+                    # ``entries`` below so mypy doesn't try to unify a
+                    # ``list[str]`` narrowed here with the
+                    # ``list[FileMetadata]`` produced by ``metadata.list``.
+                    external_entries: list[str] | None
                     if _virtual_entries is not None:
-                        entries = _virtual_entries
+                        external_entries = list(_virtual_entries)
                     else:
-                        entries = backend.list_dir(backend_path, context=_ctx)
+                        external_entries = list(backend.list_dir(backend_path, context=_ctx))
                         # Mount-root listing (backend_path is empty or just
                         # "/") — inject the virtual ``.readme/`` subtree
                         # (flattened for recursive=True) so the doc overlay
@@ -5198,12 +5203,11 @@ class NexusFS(  # type: ignore[misc]
                         except ValueError:
                             _overlay_owns_root = False
                         if (
-                            entries is not None
+                            external_entries is not None
                             and _has_skill_name(backend)
                             and not backend_path.strip("/")
                             and _overlay_owns_root
                         ):
-                            entries = list(entries)
                             if recursive:
                                 # Flatten the virtual tree to every leaf path
                                 # so callers that recurse from the mount root
@@ -5218,7 +5222,7 @@ class NexusFS(  # type: ignore[misc]
                                     _vtree = None
                                 if _vtree is not None:
 
-                                    def _walk(node, prefix: str) -> list[str]:
+                                    def _walk(node: Any, prefix: str) -> list[str]:
                                         out: list[str] = []
                                         if node.is_dir:
                                             # Include the directory itself
@@ -5237,13 +5241,16 @@ class NexusFS(  # type: ignore[misc]
 
                                     flattened = _walk(_vtree, readme_dir_name)
                                     for rel in flattened:
-                                        if rel not in entries:
-                                            entries.append(rel)
+                                        if rel not in external_entries:
+                                            external_entries.append(rel)
                             else:
                                 virtual_entry = f"{readme_dir_name}/"
-                                if virtual_entry not in entries and readme_dir_name not in entries:
-                                    entries.append(virtual_entry)
-                    if entries is not None:
+                                if (
+                                    virtual_entry not in external_entries
+                                    and readme_dir_name not in external_entries
+                                ):
+                                    external_entries.append(virtual_entry)
+                    if external_entries is not None:
                         if details:
                             return [
                                 {
@@ -5254,11 +5261,11 @@ class NexusFS(  # type: ignore[misc]
                                     "is_directory": e.endswith("/"),
                                     "size": 0,
                                 }
-                                for e in entries
+                                for e in external_entries
                             ]
                         return [
                             f"{path.rstrip('/')}/{e}" if not e.startswith("/") else e
-                            for e in entries
+                            for e in external_entries
                         ]
             except Exception as exc:
                 logger.debug("sys_readdir connector route failed for %s: %s", path, exc)

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -1734,6 +1734,23 @@ class NexusFS(  # type: ignore[misc]
         if _handled:
             return (_resolve_hint or b"")[start:end]
 
+        # Issue #3728 virtual ``.readme/`` overlay early-exit.
+        # Virtual skill docs have no metastore rows by design, so the
+        # meta-backed range path below would unconditionally raise
+        # ``NexusFileNotFoundError`` for them.  Serve from the overlay
+        # first and slice the returned bytes; fall through to the
+        # normal range path for real files.
+        #
+        # Defensive: unit tests use stub filesystems that may not
+        # subclass NexusFS and therefore lack ``_try_virtual_readme_bytes``.
+        # Fall through silently in that case — the stub isn't serving
+        # a skill backend anyway.
+        _virtual_probe = getattr(self, "_try_virtual_readme_bytes", None)
+        if callable(_virtual_probe):
+            _virtual_bytes = _virtual_probe(path, context)
+            if _virtual_bytes is not None:
+                return _virtual_bytes[start:end]
+
         # OPTIMISED PATH: no post-read hooks + backend has read_content_range
         from nexus.contracts.vfs_hooks import ReadHookContext as _RHC
 
@@ -1749,26 +1766,23 @@ class NexusFS(  # type: ignore[misc]
 
             meta = route.metastore.get(path)
 
-            if meta is not None and meta.etag is not None:
-                _rb = self._driver_coordinator.resolve_backend(meta.backend_name)
-                if hasattr(_rb, "read_content_range"):
-                    from dataclasses import replace as _replace
+            if meta is None or meta.etag is None:
+                raise NexusFileNotFoundError(path)
 
-                    read_context = (
-                        _replace(
-                            context,
-                            backend_path=route.backend_path,
-                            mount_path=route.mount_point,
-                        )
-                        if context
-                        else None
+            _rb = self._driver_coordinator.resolve_backend(meta.backend_name)
+            if hasattr(_rb, "read_content_range"):
+                from dataclasses import replace as _replace
+
+                read_context = (
+                    _replace(
+                        context,
+                        backend_path=route.backend_path,
+                        mount_path=route.mount_point,
                     )
-                    return _rb.read_content_range(meta.etag, start, end, context=read_context)
-            # Metadata miss or backend can't do range reads — fall through to
-            # the sys_read slice path below.  Virtual ``.readme/`` paths
-            # (Issue #3728) take this branch: their tree is served from
-            # sys_read's ExternalRouteResult dispatch, which the slice call
-            # then trims to [start, end).
+                    if context
+                    else None
+                )
+                return _rb.read_content_range(meta.etag, start, end, context=read_context)
 
         # FALLBACK: full read via sys_read + slice
         content = await self.sys_read(path, count=end, offset=0, context=context)
@@ -3965,10 +3979,20 @@ class NexusFS(  # type: ignore[misc]
                             )
                     except FileExistsError:
                         raise
-                    except Exception:
-                        # Probe failed — the write call below will
-                        # surface any permanent create-semantics error
-                        pass
+                    except Exception as _probe_err:
+                        # Probe failed — downgrade to debug-log and
+                        # fall through.  The follow-up ``write()`` call
+                        # will surface any permanent create-semantics
+                        # error with its own richer context, so
+                        # raising a best-effort probe error here would
+                        # just add noise.  Logged (not swallowed) so
+                        # ``test_no_silent_swallowers_in_nexus_fs``
+                        # stays green.
+                        logger.debug(
+                            "[VIRTUAL-COPY] backend.content_exists probe failed for %s: %s",
+                            _dst_bp,
+                            _probe_err,
+                        )
 
             # Destination-exists fast-fail (round 6 finding #15 — the
             # probe covers both metastore and backend).

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -560,9 +560,11 @@ class NexusFS(  # type: ignore[misc]
             return
 
         from nexus.backends.connectors.schema_generator import (
+            _defers_to_backend,
             _has_skill_name,
             _parse_readme_path_parts,
             _readme_dir_for,
+            _real_content_exists,
         )
 
         if not _has_skill_name(backend):
@@ -577,6 +579,13 @@ class NexusFS(  # type: ignore[misc]
 
         if parts is None:
             return  # not a virtual readme path
+
+        # Finding #9: on writable backends that defer to real content,
+        # only reject when the virtual overlay is actually serving this
+        # path.  If the real backend has data here, the mutation is a
+        # legitimate user action against real data — let it through.
+        if _defers_to_backend(backend) and _real_content_exists(backend, backend_path):
+            return
 
         raise PermissionError(
             f"Cannot {op} virtual .readme/ path: {path} "
@@ -3893,6 +3902,27 @@ class NexusFS(  # type: ignore[misc]
 
         if dst_route.readonly:
             raise PermissionError(f"Cannot copy to read-only path: {dst_path}")
+
+        # Virtual .readme/ destination is read-only (Issue #3728).
+        self._reject_if_virtual_readme(dst_path, context, op="copy")
+
+        # Virtual .readme/ source: bypass metastore and copy the virtual
+        # bytes through to the destination via sys_write after a real-file
+        # check.  This matches the behavior of ``sys_read`` + ``write``
+        # composition without requiring the source to be materialized.
+        _virtual_src_bytes = self._try_virtual_readme_bytes(src_path, context)
+        if _virtual_src_bytes is not None:
+            # Use the existing write path so destination metadata +
+            # post-hooks fire normally.
+            write_result = await self.write(dst_path, _virtual_src_bytes, context=context)
+            return {
+                "src_path": src_path,
+                "dst_path": dst_path,
+                "size": len(_virtual_src_bytes),
+                "etag": write_result.get("etag"),
+                "version": write_result.get("version"),
+                "modified_at": write_result.get("modified_at"),
+            }
 
         # Fast-fail (unlocked — re-checked under lock)
         if not src_route.metastore.exists(src_path) and not self.metadata.is_implicit_directory(

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -1638,23 +1638,26 @@ class NexusFS(  # type: ignore[misc]
 
             meta = route.metastore.get(path)
 
-            if meta is None or meta.etag is None:
-                raise NexusFileNotFoundError(path)
+            if meta is not None and meta.etag is not None:
+                _rb = self._driver_coordinator.resolve_backend(meta.backend_name)
+                if hasattr(_rb, "read_content_range"):
+                    from dataclasses import replace as _replace
 
-            _rb = self._driver_coordinator.resolve_backend(meta.backend_name)
-            if hasattr(_rb, "read_content_range"):
-                from dataclasses import replace as _replace
-
-                read_context = (
-                    _replace(
-                        context,
-                        backend_path=route.backend_path,
-                        mount_path=route.mount_point,
+                    read_context = (
+                        _replace(
+                            context,
+                            backend_path=route.backend_path,
+                            mount_path=route.mount_point,
+                        )
+                        if context
+                        else None
                     )
-                    if context
-                    else None
-                )
-                return _rb.read_content_range(meta.etag, start, end, context=read_context)
+                    return _rb.read_content_range(meta.etag, start, end, context=read_context)
+            # Metadata miss or backend can't do range reads — fall through to
+            # the sys_read slice path below.  Virtual ``.readme/`` paths
+            # (Issue #3728) take this branch: their tree is served from
+            # sys_read's ExternalRouteResult dispatch, which the slice call
+            # then trims to [start, end).
 
         # FALLBACK: full read via sys_read + slice
         content = await self.sys_read(path, count=end, offset=0, context=context)
@@ -4262,7 +4265,11 @@ class NexusFS(  # type: ignore[misc]
 
             if self.metadata.exists(path):
                 return True
-            return is_implicit_dir
+            if is_implicit_dir:
+                return True
+            # Virtual .readme/ overlay check (Issue #3728) — before reporting
+            # not-found, see if the path resolves to a virtual skill doc.
+            return self._try_virtual_readme_stat(path, ctx) is not None
         except (InvalidPathError, NexusFileNotFoundError, BackendError):
             return False
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -3970,17 +3970,21 @@ class NexusFS(  # type: ignore[misc]
                         # surface any permanent create-semantics error
                         pass
 
-            # Unlocked fast-fail so obvious collisions don't wait for
-            # a lock acquisition.
+            # Destination-exists fast-fail (round 6 finding #15 — the
+            # probe covers both metastore and backend).
+            #
+            # Round 9 finding #21: we do NOT wrap this in
+            # ``_vfs_locked(dst_path)`` because the follow-up
+            # ``self.write(dst_path, ...)`` takes the same path-level
+            # write lock internally, and the lock manager is not
+            # re-entrant — nesting the acquisition would deadlock
+            # until the 5-second timeout.  The residual TOCTOU
+            # window between this check and ``write()``'s own
+            # acquisition is bounded by ``write()``'s last-writer-
+            # wins overwrite semantics — the same behavior every
+            # other caller of ``write()`` already tolerates.
             _check_dst_exists()
-
-            # Locked re-check — mirrors the normal copy path's
-            # "Authoritative checks under lock" block.  Without this,
-            # a concurrent writer creating ``dst_path`` between the
-            # unlocked check and the write would be silently clobbered.
-            with self._vfs_locked(dst_path, "write"):
-                _check_dst_exists()
-                write_result = await self.write(dst_path, _virtual_src_bytes, context=context)
+            write_result = await self.write(dst_path, _virtual_src_bytes, context=context)
             self._kernel.dispatch_post_hooks("copy", _virtual_copy_ctx)
             return {
                 "src_path": src_path,

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -449,6 +449,84 @@ class NexusFS(  # type: ignore[misc]
             )
         return context.zone_id, context.agent_id, getattr(context, "is_admin", False)
 
+    # =========================================================================
+    # Virtual .readme/ overlay helper (Issue #3728)
+    # =========================================================================
+
+    def _try_virtual_readme_stat(
+        self,
+        path: str,
+        ctx: OperationContext,
+    ) -> dict[str, Any] | None:
+        """Return a stat dict for a virtual ``.readme/`` entry, or ``None``.
+
+        Called from ``sys_stat`` when the metastore has no entry for the
+        path — if the path routes to a skill backend and falls under
+        ``.readme/``, synthesize a stat dict from the virtual tree.
+
+        Returns ``None`` for any of: path doesn't route anywhere, backend
+        has no skill docs, path isn't under ``.readme/``, or normalization
+        fails.  The caller treats ``None`` as "really not found" and
+        continues with the normal sys_stat miss path.
+        """
+        try:
+            _, _, is_admin = self._get_context_identity(ctx)
+            route = self.router.route(
+                path, is_admin=is_admin, check_write=False, zone_id=self._zone_id
+            )
+        except Exception:
+            return None
+
+        backend = getattr(route, "backend", None)
+        if backend is None:
+            return None
+
+        mount_point = getattr(route, "mount_point", "") or ""
+        backend_path = getattr(route, "backend_path", "") or ""
+
+        from nexus.backends.connectors.schema_generator import (
+            _parse_readme_path_parts,
+            _readme_dir_for,
+            get_virtual_readme_tree_for_backend,
+        )
+
+        try:
+            parts = _parse_readme_path_parts(backend_path, readme_dir=_readme_dir_for(backend))
+        except ValueError:
+            return None  # malformed path — let sys_stat return None
+
+        if parts is None:
+            return None  # not under .readme/
+
+        try:
+            tree = get_virtual_readme_tree_for_backend(backend, mount_point)
+        except Exception:
+            return None
+
+        entry = tree.find(parts)
+        if entry is None:
+            return None  # under .readme/ but not a known file
+
+        backend_name = getattr(backend, "name", "") or ""
+        return {
+            "path": path,
+            "backend_name": backend_name,
+            "physical_path": "",
+            "size": entry.size(),
+            "etag": None,
+            "mime_type": "inode/directory" if entry.is_dir else "text/markdown",
+            "created_at": None,
+            "modified_at": None,
+            "is_directory": entry.is_dir,
+            "entry_type": 1 if entry.is_dir else 0,
+            "owner": ctx.user_id,
+            "group": ctx.user_id,
+            # Read-only — virtual files cannot be modified.
+            "mode": 0o555 if entry.is_dir else 0o444,
+            "version": 1,
+            "zone_id": self._zone_id,
+        }
+
     # Issue #1790: _check_zone_writable() deleted — now handled by
     def _build_write_metadata(
         self,
@@ -736,6 +814,12 @@ class NexusFS(  # type: ignore[misc]
             }
 
         if file_meta is None:
+            # Virtual .readme/ overlay check (Issue #3728) — before giving
+            # up, see if this is a synthetic file under a skill backend's
+            # .readme/ directory.
+            _vstat = self._try_virtual_readme_stat(normalized, ctx)
+            if _vstat is not None:
+                return _vstat
             return None
 
         result: dict[str, Any] = {
@@ -1219,19 +1303,39 @@ class NexusFS(  # type: ignore[misc]
         )
         _route_backend = getattr(_route, "backend", None)
         _route_backend_path = getattr(_route, "backend_path", "") or ""
+        _route_mount_point = getattr(_route, "mount_point", "") or ""
         if isinstance(_route, ExternalRouteResult) and _route_backend is not None:
             _ctx = (
-                _dc_replace(context, backend_path=_route_backend_path, virtual_path=path)
+                _dc_replace(
+                    context,
+                    backend_path=_route_backend_path,
+                    virtual_path=path,
+                    mount_path=_route_mount_point,
+                )
                 if context
                 else OperationContext(
                     user_id="anonymous",
                     groups=[],
                     backend_path=_route_backend_path,
                     virtual_path=path,
+                    mount_path=_route_mount_point,
                 )
             )
             try:
-                data = _route_backend.read_content(_route_backend_path, context=_ctx)
+                # Virtual .readme/ overlay check (Issue #3728).  If the path
+                # is under a skill backend's .readme/ directory, serve from
+                # the generated tree instead of calling the real backend.
+                from nexus.backends.connectors.schema_generator import (
+                    dispatch_virtual_readme_read,
+                )
+
+                _virtual_data = dispatch_virtual_readme_read(
+                    _route_backend, _route_mount_point, _route_backend_path
+                )
+                if _virtual_data is not None:
+                    data = _virtual_data
+                else:
+                    data = _route_backend.read_content(_route_backend_path, context=_ctx)
                 if offset or count is not None:
                     data = data[offset : offset + count] if count is not None else data[offset:]
                 return data
@@ -1542,7 +1646,13 @@ class NexusFS(  # type: ignore[misc]
                 from dataclasses import replace as _replace
 
                 read_context = (
-                    _replace(context, backend_path=route.backend_path) if context else None
+                    _replace(
+                        context,
+                        backend_path=route.backend_path,
+                        mount_path=route.mount_point,
+                    )
+                    if context
+                    else None
                 )
                 return _rb.read_content_range(meta.etag, start, end, context=read_context)
 
@@ -1720,10 +1830,19 @@ class NexusFS(  # type: ignore[misc]
 
         # Add backend_path to context for path-based connectors
         if context:
-            context = _dc_replace(context, backend_path=route.backend_path, virtual_path=path)
+            context = _dc_replace(
+                context,
+                backend_path=route.backend_path,
+                virtual_path=path,
+                mount_path=route.mount_point,
+            )
         else:
             context = OperationContext(
-                user_id="anonymous", groups=[], backend_path=route.backend_path, virtual_path=path
+                user_id="anonymous",
+                groups=[],
+                backend_path=route.backend_path,
+                virtual_path=path,
+                mount_path=route.mount_point,
             )
 
         # Write content via streaming
@@ -2203,12 +2322,21 @@ class NexusFS(  # type: ignore[misc]
         from dataclasses import replace
 
         if context:
-            context = replace(context, backend_path=route.backend_path, virtual_path=path)
+            context = replace(
+                context,
+                backend_path=route.backend_path,
+                virtual_path=path,
+                mount_path=route.mount_point,
+            )
         else:
             from nexus.contracts.types import OperationContext
 
             context = OperationContext(
-                user_id="anonymous", groups=[], backend_path=route.backend_path, virtual_path=path
+                user_id="anonymous",
+                groups=[],
+                backend_path=route.backend_path,
+                virtual_path=path,
+                mount_path=route.mount_point,
             )
 
         # DT_EXTERNAL_STORAGE: backend manages own content storage.
@@ -2840,13 +2968,19 @@ class NexusFS(  # type: ignore[misc]
                     path, is_admin=is_admin, check_write=True, zone_id=self._zone_id
                 )
                 _write_ctx = (
-                    _dc_replace(context, backend_path=route.backend_path, virtual_path=path)
+                    _dc_replace(
+                        context,
+                        backend_path=route.backend_path,
+                        virtual_path=path,
+                        mount_path=route.mount_point,
+                    )
                     if context
                     else OperationContext(
                         user_id="anonymous",
                         groups=[],
                         backend_path=route.backend_path,
                         virtual_path=path,
+                        mount_path=route.mount_point,
                     )
                 )
                 content_hash = route.backend.write_content(content, context=_write_ctx).content_id
@@ -3779,6 +3913,7 @@ class NexusFS(  # type: ignore[misc]
                             _ctx_replace(
                                 context,
                                 backend_path=src_route.backend_path,
+                                mount_path=src_route.mount_point,
                             )
                             if context
                             else context
@@ -3914,6 +4049,11 @@ class NexusFS(  # type: ignore[misc]
         # Get file metadata
         meta = self.metadata.get(path)
         if meta is None:
+            # Virtual .readme/ overlay check (Issue #3728) — before raising,
+            # see if the path routes to a skill backend's .readme/ tree.
+            _vstat = self._try_virtual_readme_stat(path, ctx)
+            if _vstat is not None:
+                return _vstat
             raise NexusFileNotFoundError(path)
 
         # Get size from backend if not in metadata
@@ -3933,7 +4073,11 @@ class NexusFS(  # type: ignore[misc]
                 if context:
                     from dataclasses import replace
 
-                    size_context = replace(context, backend_path=route.backend_path)
+                    size_context = replace(
+                        context,
+                        backend_path=route.backend_path,
+                        mount_path=route.mount_point,
+                    )
                 size = route.backend.get_content_size(meta.etag, context=size_context)
             except Exception as exc:
                 logger.debug("Failed to get content size for %s: %s", path, exc)
@@ -4764,17 +4908,36 @@ class NexusFS(  # type: ignore[misc]
                 backend = getattr(_route, "backend", None)
                 if isinstance(_route, ExternalRouteResult) and backend is not None:
                     backend_path = getattr(_route, "backend_path", "") or ""
+                    mount_point = getattr(_route, "mount_point", "") or ""
                     _ctx = (
-                        _dc_replace(context, backend_path=backend_path, virtual_path=path)
+                        _dc_replace(
+                            context,
+                            backend_path=backend_path,
+                            virtual_path=path,
+                            mount_path=mount_point,
+                        )
                         if context
                         else OperationContext(
                             user_id="anonymous",
                             groups=[],
                             backend_path=backend_path,
                             virtual_path=path,
+                            mount_path=mount_point,
                         )
                     )
-                    entries = backend.list_dir(backend_path, context=_ctx)
+                    # Virtual .readme/ overlay check (Issue #3728).
+                    from nexus.backends.connectors.schema_generator import (
+                        dispatch_virtual_readme_list,
+                    )
+
+                    _virtual_entries = dispatch_virtual_readme_list(
+                        backend, mount_point, backend_path
+                    )
+                    entries = (
+                        _virtual_entries
+                        if _virtual_entries is not None
+                        else backend.list_dir(backend_path, context=_ctx)
+                    )
                     if entries is not None:
                         if details:
                             return [

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -3916,8 +3916,9 @@ class NexusFS(  # type: ignore[misc]
         # so the normal ``src_meta.get`` path below would fail before
         # hooks run — do the safety checks the normal branch does
         # (source READ permission via the copy hook, destination
-        # existence on BOTH metastore and backend) here first.
-        # Round 6 findings #14 + #15.
+        # existence on BOTH metastore and backend, locked re-check to
+        # close the concurrent-write race in round 8 finding #19) here
+        # first.  Round 6 findings #14+#15, round 8 finding #19.
         _virtual_src_bytes = self._try_virtual_readme_bytes(src_path, context)
         if _virtual_src_bytes is not None:
             # Enforce source READ permission + destination WRITE
@@ -3936,41 +3937,50 @@ class NexusFS(  # type: ignore[misc]
             )
             self._kernel.dispatch_pre_hooks("copy", _virtual_copy_ctx)
 
-            # Destination exists check — both metastore AND backend
-            # (path-addressed external connectors may have a real file
-            # at backend_path that hasn't been synced into the metastore
-            # yet; the metastore-only check would let us overwrite it).
-            if dst_route.metastore.exists(dst_path):
-                raise FileExistsError(f"Destination path already exists: {dst_path}")
-            dst_backend_path = getattr(dst_route, "backend_path", "") or ""
-            dst_backend = getattr(dst_route, "backend", None)
-            _content_exists = getattr(dst_backend, "content_exists", None)
-            if dst_backend is not None and callable(_content_exists):
-                from dataclasses import replace as _replace
+            def _check_dst_exists() -> None:
+                """Raise FileExistsError if dst_path is occupied.
 
-                try:
-                    _probe_ctx = (
-                        _replace(context, backend_path=dst_backend_path)
-                        if context is not None
-                        else None
-                    )
-                except Exception:
-                    _probe_ctx = None
-                try:
-                    if _content_exists(dst_backend_path, context=_probe_ctx):
-                        raise FileExistsError(
-                            f"Destination path already exists on backend: {dst_path}"
+                Probes both the metastore and the backend so a real
+                backend file that hasn't been synced to the metastore
+                still blocks the copy.
+                """
+                if dst_route.metastore.exists(dst_path):
+                    raise FileExistsError(f"Destination path already exists: {dst_path}")
+                _dst_bp = getattr(dst_route, "backend_path", "") or ""
+                _dst_be = getattr(dst_route, "backend", None)
+                _fn = getattr(_dst_be, "content_exists", None)
+                if _dst_be is not None and callable(_fn):
+                    from dataclasses import replace as _replace
+
+                    try:
+                        _pctx = (
+                            _replace(context, backend_path=_dst_bp) if context is not None else None
                         )
-                except FileExistsError:
-                    raise
-                except Exception:
-                    # Probe failed — fall through to the write and let
-                    # the backend's own create-semantics handle it.
-                    pass
+                    except Exception:
+                        _pctx = None
+                    try:
+                        if _fn(_dst_bp, context=_pctx):
+                            raise FileExistsError(
+                                f"Destination path already exists on backend: {dst_path}"
+                            )
+                    except FileExistsError:
+                        raise
+                    except Exception:
+                        # Probe failed — the write call below will
+                        # surface any permanent create-semantics error
+                        pass
 
-            # Route through the normal write path for post-hooks +
-            # metadata + return-shape parity.
-            write_result = await self.write(dst_path, _virtual_src_bytes, context=context)
+            # Unlocked fast-fail so obvious collisions don't wait for
+            # a lock acquisition.
+            _check_dst_exists()
+
+            # Locked re-check — mirrors the normal copy path's
+            # "Authoritative checks under lock" block.  Without this,
+            # a concurrent writer creating ``dst_path`` between the
+            # unlocked check and the write would be silently clobbered.
+            with self._vfs_locked(dst_path, "write"):
+                _check_dst_exists()
+                write_result = await self.write(dst_path, _virtual_src_bytes, context=context)
             self._kernel.dispatch_post_hooks("copy", _virtual_copy_ctx)
             return {
                 "src_path": src_path,

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -5162,13 +5162,33 @@ class NexusFS(  # type: ignore[misc]
                         # (flattened for recursive=True) so the doc overlay
                         # is discoverable from ``ls`` and also indexable by
                         # search/recursive walkers that only enumerate from
-                        # the mount root (Issue #3728 finding #5 + #8).
+                        # the mount root (Issue #3728 findings #5, #8, #18).
+                        #
+                        # Round 7 finding #18: gate the injection on
+                        # ownership — on a deferring backend whose real
+                        # ``.readme/`` already exists, the overlay has
+                        # handed the subtree over and we must not splice
+                        # virtual entries back in.
+                        readme_dir_name = _readme_dir_for(backend).strip("/")
+                        from nexus.backends.connectors.schema_generator import (
+                            overlay_owns_path as _overlay_owns_path,
+                        )
+
+                        try:
+                            _overlay_owns_root = _overlay_owns_path(
+                                backend,
+                                mount_point,
+                                readme_dir_name,
+                                context=_ctx,
+                            )
+                        except ValueError:
+                            _overlay_owns_root = False
                         if (
                             entries is not None
                             and _has_skill_name(backend)
                             and not backend_path.strip("/")
+                            and _overlay_owns_root
                         ):
-                            readme_dir_name = _readme_dir_for(backend).strip("/")
                             entries = list(entries)
                             if recursive:
                                 # Flatten the virtual tree to every leaf path

--- a/src/nexus/fs/_facade.py
+++ b/src/nexus/fs/_facade.py
@@ -400,6 +400,13 @@ class SlimNexusFS:
                 entry_type=1,
             )
 
+        # Virtual .readme/ overlay check (Issue #3728).  The slim facade
+        # has its own fast stat path that bypasses NexusFS.stat(), so we
+        # run the same fallback helper here before returning None.
+        _vstat = self._kernel._try_virtual_readme_stat(normalized, self._ctx)
+        if _vstat is not None:
+            return _vstat
+
         return None
 
     # -- Search operations --

--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -1238,15 +1238,15 @@ class PlaygroundApp(App[None]):
             return "x://timeline"
         if connector_name == "hn_connector":
             return "hn://top"
-        if connector_name == "gws_github":
-            return None
+        if connector_name == "github_connector":
+            return "github://me"
         if connector_name.startswith("gws_"):
             return f"gws://{connector_name.removeprefix('gws_')}"
         return None
 
     def _connector_auth_service(self, connector_name: str, service_name: str | None) -> str | None:
         """Map connector targets to the auth flow users should follow."""
-        if connector_name == "gws_github":
+        if connector_name == "github_connector":
             return "github"
         if connector_name.startswith("gws_"):
             return "gws"

--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -1238,7 +1238,12 @@ class PlaygroundApp(App[None]):
             return "x://timeline"
         if connector_name == "hn_connector":
             return "hn://top"
-        if connector_name == "github_connector":
+        # ``github_connector`` is the canonical GitHub registry name
+        # (#3728).  ``gws_github`` is a deprecated alias kept for
+        # backward compatibility of persisted mounts — both must
+        # advertise the same ``github://`` URI example so the TUI and
+        # playground don't show the broken ``gws://github`` path.
+        if connector_name in {"github_connector", "gws_github"}:
             return "github://me"
         if connector_name.startswith("gws_"):
             return f"gws://{connector_name.removeprefix('gws_')}"
@@ -1246,7 +1251,7 @@ class PlaygroundApp(App[None]):
 
     def _connector_auth_service(self, connector_name: str, service_name: str | None) -> str | None:
         """Map connector targets to the auth flow users should follow."""
-        if connector_name == "github_connector":
+        if connector_name in {"github_connector", "gws_github"}:
             return "github"
         if connector_name.startswith("gws_"):
             return "gws"
@@ -1261,7 +1266,15 @@ class PlaygroundApp(App[None]):
             return explicit
 
         if not uri.startswith(
-            ("gws://", "gdrive://", "gmail://", "calendar://", "slack://", "x://")
+            (
+                "gws://",
+                "gdrive://",
+                "gmail://",
+                "calendar://",
+                "slack://",
+                "x://",
+                "github://",
+            )
         ):
             return "local"
 
@@ -1269,6 +1282,8 @@ class PlaygroundApp(App[None]):
             providers = {"google"}
         elif uri.startswith("slack://"):
             providers = {"slack"}
+        elif uri.startswith("github://"):
+            providers = {"github"}
         else:
             providers = {"x", "twitter"}
 
@@ -1311,6 +1326,8 @@ class PlaygroundApp(App[None]):
             service_name = "slack"
         elif scheme == "x":
             service_name = "x"
+        elif scheme == "github":
+            service_name = "github"
 
         inferred = _infer_connector_user_email(
             scheme=scheme,

--- a/src/nexus/server/_rpc_param_overrides.py
+++ b/src/nexus/server/_rpc_param_overrides.py
@@ -255,6 +255,39 @@ class NamespaceGetParams:
 
 
 # ============================================================
+# 9. Semantic search initialization override
+# ============================================================
+#
+# ``ainitialize_semantic_search`` is a SearchService method that takes an
+# ``nx: NexusFS`` argument which cannot be serialized across RPC.  The
+# server-side handler ignores the param and injects the server's own
+# ``nexus_fs``, so we omit ``nx`` from the RPC params entirely and
+# accept only the embedding-pipeline config knobs.
+@dataclass
+class AInitializeSemanticSearchParams:
+    """Parameters for the RPC form of ``ainitialize_semantic_search``.
+
+    The client-side ``nexus search init`` CLI still passes ``nx=nx`` and
+    ``record_store_engine=None`` from its local-mode code path.  Accept
+    them as ignored optional fields so the dataclass construction
+    doesn't fail — the server-side handler injects its own ``nexus_fs``
+    for ``nx`` and leaves ``record_store_engine`` alone.
+    """
+
+    embedding_provider: str | None = None
+    embedding_model: str | None = None
+    api_key: str | None = None
+    chunk_size: int = 1024
+    chunk_strategy: str = "semantic"
+    async_mode: bool = True
+    cache_url: str | None = None
+    embedding_cache_ttl: int = 86400 * 3
+    # Ignored — client sends these but the server injects its own nx
+    nx: Any | None = None
+    record_store_engine: Any | None = None
+
+
+# ============================================================
 # Override METHOD_PARAMS entries for all override classes
 # ============================================================
 
@@ -301,4 +334,8 @@ OVERRIDE_METHOD_PARAMS: dict[str, type] = {
     "namespace_get": NamespaceGetParams,
     # RemoteMetastore
     "sys_setattr": SetMetadataParams,
+    # Semantic search init (Issue #3728 follow-up — the client calls this
+    # via RemoteServiceProxy, and without an entry here ``parse_method_params``
+    # rejects the RPC as "Unknown method".)
+    "ainitialize_semantic_search": AInitializeSemanticSearchParams,
 }

--- a/src/nexus/server/rpc/dispatch.py
+++ b/src/nexus/server/rpc/dispatch.py
@@ -70,6 +70,7 @@ def build_dispatch_table() -> dict[str, DispatchEntry]:
         handle_delta_write,
     )
     from nexus.server.rpc.handlers.filesystem import (
+        handle_ainitialize_semantic_search,
         handle_copy,
         handle_delete,
         handle_exists,
@@ -137,6 +138,9 @@ def build_dispatch_table() -> dict[str, DispatchEntry]:
         # Semantic search
         "semantic_search": DispatchEntry(handle_semantic_search, is_async=True),
         "semantic_search_index": DispatchEntry(handle_semantic_search_index, is_async=True),
+        "ainitialize_semantic_search": DispatchEntry(
+            handle_ainitialize_semantic_search, is_async=True
+        ),
         # Memory API — moved to MemoryService @rpc_expose (Issue #12)
         # Admin API
         "admin_write_permission": DispatchEntry(handle_admin_write_permission),

--- a/src/nexus/server/rpc/handlers/filesystem.py
+++ b/src/nexus/server/rpc/handlers/filesystem.py
@@ -453,6 +453,100 @@ def handle_search(nexus_fs: "NexusFS", params: Any, context: Any) -> dict[str, A
     return {"results": results}
 
 
+def _augment_paths_with_virtual_readme(
+    *,
+    nexus_fs: "NexusFS",
+    target_path: str,
+    paths_to_index: list[str],
+    context: Any,
+    logger: Any,
+) -> list[str]:
+    """Inject every virtual ``.readme/`` leaf under ``target_path``
+    into ``paths_to_index``.
+
+    Issue #3728: virtual skill-doc paths (README.md, schemas/*.yaml,
+    examples/*) have no metastore rows, so the metastore-backed
+    ``file_paths`` query above returns zero matches for them.  This
+    helper walks the router for ``target_path``, finds every skill
+    backend mount that intersects the request, and flattens each
+    mount's ``VirtualEntry`` tree into absolute paths appended to
+    the indexing list.
+
+    The walk is tolerant — anything that fails (non-routable path,
+    unknown backend, tree construction error) is logged and skipped,
+    leaving ``paths_to_index`` as the caller supplied it.
+    """
+    try:
+        from nexus.backends.connectors.schema_generator import (
+            VirtualEntry,
+            _has_skill_name,
+            _readme_dir_for,
+            get_virtual_readme_tree_for_backend,
+            overlay_owns_path,
+        )
+    except ImportError:
+        return paths_to_index
+
+    try:
+        _, _, is_admin = nexus_fs._get_context_identity(context)
+        route = nexus_fs.router.route(
+            target_path, is_admin=is_admin, check_write=False, zone_id=nexus_fs._zone_id
+        )
+    except Exception:
+        return paths_to_index
+
+    backend = getattr(route, "backend", None)
+    if backend is None or not _has_skill_name(backend):
+        return paths_to_index
+
+    mount_point = getattr(route, "mount_point", "") or ""
+    readme_dir_name = _readme_dir_for(backend).strip("/")
+    try:
+        if not overlay_owns_path(backend, mount_point, readme_dir_name, context=context):
+            return paths_to_index
+    except Exception:
+        return paths_to_index
+
+    try:
+        tree = get_virtual_readme_tree_for_backend(backend, mount_point)
+    except Exception:
+        return paths_to_index
+
+    mount_prefix = mount_point.rstrip("/")
+
+    def _walk(node: VirtualEntry, prefix: str) -> list[str]:
+        out: list[str] = []
+        if node.is_dir:
+            for child_name, child in node.children.items():
+                child_prefix = f"{prefix}/{child_name}" if prefix else child_name
+                out.extend(_walk(child, child_prefix))
+        else:
+            out.append(f"{mount_prefix}/{prefix}")
+        return out
+
+    flattened = _walk(tree, readme_dir_name)
+
+    # Only keep virtual leaves that fall under the caller's request.
+    target_norm = target_path.rstrip("/")
+    kept: list[str] = []
+    for leaf in flattened:
+        if target_norm == mount_prefix or leaf.startswith(target_norm + "/") or leaf == target_norm:
+            kept.append(leaf)
+
+    existing = set(paths_to_index)
+    merged = list(paths_to_index)
+    for p in kept:
+        if p not in existing:
+            merged.append(p)
+            existing.add(p)
+    logger.info(
+        "semantic_search_index: after virtual .readme/ augment: %d files (+%d virtual)",
+        len(merged),
+        len(merged) - len(paths_to_index),
+    )
+    return merged
+
+
 async def handle_semantic_search_index(
     nexus_fs: "NexusFS", params: Any, _context: Any
 ) -> dict[str, Any]:
@@ -506,6 +600,24 @@ async def handle_semantic_search_index(
             _log.info(
                 "semantic_search_index: found %d files under %s", len(paths_to_index), db_path
             )
+
+        # Issue #3728: virtual ``.readme/`` overlay paths have no
+        # ``file_paths`` row by design — augment the indexing list by
+        # asking the VirtualEntry tree directly (via the router) for
+        # every leaf under every skill backend mount the request path
+        # intersects.  This picks up ``README.md``, ``schemas/*.yaml``,
+        # and ``examples/*`` regardless of whether ``path`` points at
+        # the mount root or a ``.readme/`` subdir.
+        try:
+            paths_to_index = _augment_paths_with_virtual_readme(
+                nexus_fs=nexus_fs,
+                target_path=path,
+                paths_to_index=paths_to_index,
+                context=context,
+                logger=_log,
+            )
+        except Exception as _walk_err:
+            _log.debug("semantic_search_index: virtual .readme/ walk skipped: %s", _walk_err)
 
         # Read content and build documents for txtai
         documents: list[dict[str, Any]] = []
@@ -574,6 +686,39 @@ async def handle_semantic_search(nexus_fs: "NexusFS", params: Any, _context: Any
         context=_context,
     )
     return {"results": results}
+
+
+async def handle_ainitialize_semantic_search(
+    nexus_fs: "NexusFS", params: Any, _context: Any
+) -> dict[str, Any]:
+    """Handle ``ainitialize_semantic_search`` — initialize the semantic pipeline.
+
+    The client side (``nexus search init``) calls
+    ``nx.service("search").ainitialize_semantic_search(nx=nx, ...)`` via the
+    RemoteServiceProxy, which attempts to dispatch the call as an RPC.  Before
+    this handler, no dispatch entry existed and the RPC died with
+    ``Unknown method: ainitialize_semantic_search``.
+
+    The server injects its own ``nexus_fs`` for the ``nx`` parameter since
+    the client's NexusFS instance cannot be serialized across the wire.
+    """
+    search = nexus_fs.service("search")
+    if search is None:
+        raise ValueError("SearchService not available")
+
+    await search.ainitialize_semantic_search(
+        nx=nexus_fs,
+        record_store_engine=None,
+        embedding_provider=getattr(params, "embedding_provider", None),
+        embedding_model=getattr(params, "embedding_model", None),
+        api_key=getattr(params, "api_key", None),
+        chunk_size=getattr(params, "chunk_size", 1024),
+        chunk_strategy=getattr(params, "chunk_strategy", "semantic"),
+        async_mode=getattr(params, "async_mode", True),
+        cache_url=getattr(params, "cache_url", None),
+        embedding_cache_ttl=getattr(params, "embedding_cache_ttl", 86400 * 3),
+    )
+    return {"initialized": True}
 
 
 async def handle_is_directory(nexus_fs: "NexusFS", params: Any, context: Any) -> dict[str, Any]:

--- a/src/nexus/server/rpc/handlers/filesystem.py
+++ b/src/nexus/server/rpc/handlers/filesystem.py
@@ -255,6 +255,9 @@ async def handle_list(nexus_fs: "NexusFS", params: Any, context: Any) -> dict[st
     _list_start = _time.time()
     search = nexus_fs.service("search")
     if search is not None:
+        # SearchService.list injects virtual ``.readme/`` entries for
+        # connector mounts via ``_augment_with_virtual_readme_entries``
+        # (Issue #3728), so we don't need a handler-level augment.
         result = search.list(path=params.path, **kwargs)
     else:
         result = await nexus_fs.sys_readdir(params.path, **kwargs)

--- a/tests/e2e/self_contained/test_gcalendar_connector.py
+++ b/tests/e2e/self_contained/test_gcalendar_connector.py
@@ -25,12 +25,7 @@ from nexus.backends.connectors.calendar.schemas import (
     UpdateEventSchema,
 )
 from nexus.backends.connectors.calendar.transport import CalendarTransport
-from nexus.backends.storage.cas_local import CASLocalBackend
 from nexus.contracts.types import OperationContext
-from nexus.core.config import PermissionConfig
-from nexus.factory import create_nexus_fs
-from nexus.storage.raft_metadata_store import RaftMetadataStore
-from nexus.storage.record_store import SQLAlchemyRecordStore
 
 # ============================================================================
 # FIXTURES
@@ -294,30 +289,23 @@ class TestReadmeDocGeneration:
         assert "# agent_intent:" in doc
 
     @pytest.mark.asyncio
-    async def test_write_readme(self, calendar_backend, isolated_db, tmp_path):
-        """Test writing README.md to filesystem."""
-        # Create a real NexusFS for writing
-        backend = CASLocalBackend(root_path=str(tmp_path / "storage"))
-        nx = await create_nexus_fs(
-            backend=backend,
-            metadata_store=RaftMetadataStore.embedded(str(isolated_db).replace(".db", "-raft")),
-            record_store=SQLAlchemyRecordStore(db_path=str(isolated_db)),
-            permissions=PermissionConfig(enforce=False),
+    async def test_virtual_readme_tree(self, calendar_backend):
+        """Verify the virtual ``.readme/`` tree for gcalendar (Issue #3728).
+
+        Replaces the old ``test_write_readme`` — materialization was
+        removed; the overlay now serves docs on-demand.
+        """
+        from nexus.backends.connectors.schema_generator import (
+            _invalidate_virtual_tree_cache,
+            get_virtual_readme_tree_for_backend,
         )
 
-        try:
-            # Write README.md
-            result = await calendar_backend.write_readme("/mnt/calendar/", filesystem=nx)
-            assert isinstance(result, dict)
-            readme_path = result.get("readme_md")
-
-            if readme_path:
-                # Read back and verify
-                content = await nx.sys_read(readme_path)
-                assert b"Gcalendar Connector" in content
-                assert b"agent_intent" in content
-        finally:
-            nx.close()
+        _invalidate_virtual_tree_cache()
+        tree = get_virtual_readme_tree_for_backend(calendar_backend, "/mnt/calendar")
+        readme = tree.find(["README.md"])
+        assert readme is not None
+        assert b"Gcalendar Connector" in readme.content
+        assert b"agent_intent" in readme.content
 
 
 # ============================================================================

--- a/tests/e2e/self_contained/test_gmail_connector.py
+++ b/tests/e2e/self_contained/test_gmail_connector.py
@@ -30,13 +30,8 @@ from nexus.backends.connectors.gmail.schemas import (
     SendEmailSchema,
 )
 from nexus.backends.connectors.gmail.transport import LABEL_FOLDERS, GmailTransport
-from nexus.backends.storage.cas_local import CASLocalBackend
 from nexus.contracts.exceptions import BackendError
 from nexus.contracts.types import OperationContext
-from nexus.core.config import PermissionConfig
-from nexus.factory import create_nexus_fs
-from nexus.storage.raft_metadata_store import RaftMetadataStore
-from nexus.storage.record_store import SQLAlchemyRecordStore
 
 # ============================================================================
 # FIXTURES
@@ -350,31 +345,34 @@ class TestReadmeDocGeneration:
         assert "/custom/mount/path/" in doc
 
     @pytest.mark.asyncio
-    async def test_write_readme(self, gmail_backend, isolated_db, tmp_path):
-        """Test writing README.md to filesystem."""
-        # Create a real NexusFS for writing
-        backend = CASLocalBackend(root_path=str(tmp_path / "storage"))
-        nx = await create_nexus_fs(
-            backend=backend,
-            metadata_store=RaftMetadataStore.embedded(str(isolated_db).replace(".db", "-raft")),
-            record_store=SQLAlchemyRecordStore(db_path=str(isolated_db)),
-            permissions=PermissionConfig(enforce=False),
+    async def test_virtual_readme_tree(self, gmail_backend):
+        """Verify the virtual ``.readme/`` tree exposes the expected files.
+
+        Replaces the old ``test_write_readme`` (materialization test) —
+        Issue #3728 removed ``write_readme``. The virtual overlay now
+        serves docs on-demand from the generator's tree model.
+        """
+        from nexus.backends.connectors.schema_generator import (
+            _invalidate_virtual_tree_cache,
+            get_virtual_readme_tree_for_backend,
         )
 
-        try:
-            # Write README.md
-            result = await gmail_backend.write_readme("/mnt/gmail/", filesystem=nx)
-            assert isinstance(result, dict)
-            readme_path = result.get("readme_md")
+        _invalidate_virtual_tree_cache()
+        tree = get_virtual_readme_tree_for_backend(gmail_backend, "/mnt/gmail")
 
-            if readme_path:
-                # Read back and verify
-                content = await nx.sys_read(readme_path)
-                assert b"Gmail Connector" in content
-                assert b"agent_intent" in content
-                assert b"Send Email" in content
-        finally:
-            nx.close()
+        # README.md is always present
+        readme = tree.find(["README.md"])
+        assert readme is not None
+        assert readme.is_file
+        assert b"Gmail Connector" in readme.content
+        assert b"agent_intent" in readme.content
+        assert b"Send Email" in readme.content
+
+        # schemas/ directory exists with one file per operation
+        schemas = tree.find(["schemas"])
+        assert schemas is not None
+        assert schemas.is_dir
+        assert "send_email.yaml" in schemas.children
 
 
 # ============================================================================

--- a/tests/integration/backends/connectors/cli/test_lifecycle_e2e.py
+++ b/tests/integration/backends/connectors/cli/test_lifecycle_e2e.py
@@ -9,8 +9,6 @@ This uses a mock filesystem to test the orchestration without requiring
 real CLI tools or OAuth tokens.
 """
 
-from unittest.mock import AsyncMock, MagicMock
-
 import pytest
 from pydantic import BaseModel, Field
 
@@ -105,29 +103,31 @@ class TestConnectorLifecycleE2E:
         assert "# Github Connector" in readme_doc or "# GitHub Connector" in readme_doc.title()
         assert "create_issue" in readme_doc.lower() or "Create Issue" in readme_doc
 
-    @pytest.mark.asyncio
-    async def test_step2_readme_doc_writes_to_filesystem(self) -> None:
-        """Step 2: Readme docs written to .readme/ directory with schema files."""
+    def test_step2_virtual_readme_tree_exposes_docs(self) -> None:
+        """Step 2: Virtual ``.readme/`` tree exposes README.md + schemas/ (Issue #3728).
+
+        The previous materialization test (``write_readme``) was removed;
+        the overlay now serves docs on-demand from class metadata.
+        """
+        from nexus.backends.connectors.schema_generator import (
+            _invalidate_virtual_tree_cache,
+            get_virtual_readme_tree_for_backend,
+        )
+
+        _invalidate_virtual_tree_cache()
         connector = FakeGHConnector()
-        fs = MagicMock()
-        fs.mkdir = AsyncMock()
-        fs.write = AsyncMock()
+        tree = get_virtual_readme_tree_for_backend(connector, "/mnt/github")
 
-        result = await connector.write_readme("/mnt/github", fs)
+        # README.md present in the virtual tree
+        readme = tree.find(["README.md"])
+        assert readme is not None
+        assert readme.is_file
 
-        # README.md should be written
-        assert result["readme_md"] == "/mnt/github/.readme/README.md"
-
-        # Schema files should be written (Issue #3148)
-        assert len(result.get("schemas", [])) > 0
-        assert any("create_issue" in s for s in result.get("schemas", []))
-
-        # Example files should be written
-        assert len(result["examples"]) > 0
-
-        # Verify filesystem calls
-        fs.mkdir.assert_called()
-        fs.write.assert_called()
+        # schemas/ directory contains a file per declared schema
+        schemas = tree.find(["schemas"])
+        assert schemas is not None
+        assert schemas.is_dir
+        assert any("create_issue" in name for name in schemas.children)
 
     def test_step3_schema_validation_success(self) -> None:
         """Step 3: Valid YAML passes schema validation."""

--- a/tests/integration/bricks/search/test_indexing_service.py
+++ b/tests/integration/bricks/search/test_indexing_service.py
@@ -317,6 +317,106 @@ class TestIndexDirectory:
             assert path_id == "pid-x"
 
 
+class TestVirtualReadmeIndexing:
+    """Issue #3728: virtual ``.readme/`` overlay paths have no
+    FilePathModel rows but should still be indexed for semantic search."""
+
+    def test_looks_like_virtual_readme_helper(self) -> None:
+        from nexus.bricks.search.indexing_service import _looks_like_virtual_readme
+
+        # Exact ``.readme`` segment matches
+        assert _looks_like_virtual_readme("/gws/gmail/.readme/README.md") is True
+        assert _looks_like_virtual_readme("/gws/gmail/.readme/schemas/send.yaml") is True
+        assert _looks_like_virtual_readme("/.readme/README.md") is True
+
+        # Not matches
+        assert _looks_like_virtual_readme("/a/b/c.txt") is False
+        assert _looks_like_virtual_readme("/gws/gmail/INBOX/msg.yaml") is False
+
+        # Partial-name false positives rejected — segment must be exactly ``.readme``
+        assert _looks_like_virtual_readme("/work/my.readme/file.md") is False
+        assert _looks_like_virtual_readme("/work/.readmex/file.md") is False
+
+    def test_virtual_path_id_is_deterministic_and_prefixed(self) -> None:
+        from nexus.bricks.search.indexing_service import _virtual_path_id
+
+        a = _virtual_path_id("/gws/gmail/.readme/README.md")
+        b = _virtual_path_id("/gws/gmail/.readme/README.md")
+        c = _virtual_path_id("/gws/gmail/.readme/schemas/send.yaml")
+        assert a == b  # deterministic
+        assert a != c  # different paths → different ids
+        assert a.startswith("virtual:")
+        # Uses SHA-256 (64 hex chars after the prefix)
+        assert len(a) == len("virtual:") + 64
+
+    @pytest.mark.asyncio
+    async def test_index_directory_indexes_virtual_readme_paths_without_row(self) -> None:
+        """Virtual ``.readme/`` files have no FilePathModel but should still
+        be indexed via a synthetic ``virtual:`` path_id."""
+        # Session returns None for every FilePathModel query → simulates
+        # a post-mount indexing run over a skill backend where only the
+        # virtual tree has entries and the metastore has no rows for
+        # ``.readme/*``.
+        session = _mock_session(file_model=None)
+
+        pipeline = _mock_pipeline()
+        pipeline.index_documents.return_value = [
+            IndexResult(path="/gws/gmail/.readme/README.md", chunks_indexed=4),
+            IndexResult(path="/gws/gmail/.readme/schemas/send.yaml", chunks_indexed=2),
+        ]
+
+        file_list = [
+            "/gws/gmail/.readme/README.md",
+            "/gws/gmail/.readme/schemas/send.yaml",
+        ]
+        service, _, _, _ = _build_service(
+            pipeline=pipeline,
+            session=session,
+            file_list=file_list,
+            content="# Gmail\n\nsend_email schema ...",
+        )
+
+        results = await service.index_directory("/gws/gmail/")
+
+        # Both virtual paths were indexed even though _query_file_model
+        # returned None for each.
+        assert len(results) == 2
+        pipeline.index_documents.assert_awaited_once()
+        docs = pipeline.index_documents.call_args[0][0]
+        assert len(docs) == 2
+        for doc_path, content, path_id in docs:
+            assert doc_path in file_list
+            assert content == "# Gmail\n\nsend_email schema ..."
+            # Synthetic path_id is used instead of a real FilePathModel id
+            assert path_id.startswith("virtual:")
+
+    @pytest.mark.asyncio
+    async def test_index_directory_still_skips_rowless_non_readme_paths(self) -> None:
+        """A real (non-``.readme/``) file with no FilePathModel row is
+        still skipped — the virtual fallback must not catch random
+        row-less paths."""
+        session = _mock_session(file_model=None)  # all queries miss
+
+        pipeline = _mock_pipeline()
+        pipeline.index_documents.return_value = []
+
+        service, _, _, _ = _build_service(
+            pipeline=pipeline,
+            session=session,
+            file_list=["/work/notes.txt", "/work/code.py"],
+            content="some content",
+        )
+
+        await service.index_directory("/work/")
+
+        # No documents appended — both rows are missing AND they're not
+        # under ``.readme/``, so the indexer drops them like before.
+        assert pipeline.index_documents.await_count in (0, 1)
+        if pipeline.index_documents.await_count == 1:
+            docs = pipeline.index_documents.call_args[0][0]
+            assert docs == []
+
+
 class TestDeleteDocumentIndex:
     @pytest.mark.asyncio
     async def test_delete_document_index_removes_chunks(self) -> None:

--- a/tests/integration/connectors/test_schema_generator.py
+++ b/tests/integration/connectors/test_schema_generator.py
@@ -171,104 +171,11 @@ class TestGenerateReadme:
 
 
 # ===========================================================================
-# write_readme
+# write_readme tests removed (Issue #3728): the method was deleted — skill
+# docs are now served on-demand from the virtual .readme/ overlay.  See the
+# TestGenerateTree and TestDispatchHelpers classes below for the tests that
+# replace the materialization coverage.
 # ===========================================================================
-
-
-class TestWriteReadme:
-    @pytest.mark.asyncio
-    async def test_writes_readme_md(
-        self, generator: ReadmeDocGenerator, mock_filesystem: MagicMock
-    ) -> None:
-        result = await generator.write_readme("/mnt/calendar", filesystem=mock_filesystem)
-
-        assert result["readme_md"] == "/mnt/calendar/.readme/README.md"
-        mock_filesystem.mkdir.assert_any_call("/mnt/calendar/.readme", parents=True, exist_ok=True)
-        # README.md is written as bytes
-        write_calls = mock_filesystem.write.call_args_list
-        readme_md_call = write_calls[0]
-        assert readme_md_call[0][0] == "/mnt/calendar/.readme/README.md"
-        assert isinstance(readme_md_call[0][1], bytes)
-
-    @pytest.mark.asyncio
-    async def test_writes_examples(
-        self, generator: ReadmeDocGenerator, mock_filesystem: MagicMock
-    ) -> None:
-        result = await generator.write_readme("/mnt/calendar", filesystem=mock_filesystem)
-
-        assert "/mnt/calendar/.readme/examples/create_meeting.yaml" in result["examples"]
-        mock_filesystem.mkdir.assert_any_call(
-            "/mnt/calendar/.readme/examples", parents=True, exist_ok=True
-        )
-        # Verify example content written
-        example_call = mock_filesystem.write.call_args_list[1]
-        assert example_call[0][0] == "/mnt/calendar/.readme/examples/create_meeting.yaml"
-        assert example_call[0][1] == b"summary: Team Standup\n"
-
-    @pytest.mark.asyncio
-    async def test_no_filesystem_returns_empty_result(self, generator: ReadmeDocGenerator) -> None:
-        result = await generator.write_readme("/mnt/calendar", filesystem=None)
-        assert result["readme_md"] is None
-        assert result["examples"] == []
-
-    @pytest.mark.asyncio
-    async def test_empty_skill_name_returns_empty_result(self, mock_filesystem: MagicMock) -> None:
-        gen = ReadmeDocGenerator(
-            skill_name="",
-            schemas={},
-            operation_traits={},
-            error_registry={},
-            examples={},
-        )
-        result = await gen.write_readme("/mnt/x", filesystem=mock_filesystem)
-        assert result["readme_md"] is None
-        assert result["examples"] == []
-        mock_filesystem.write.assert_not_called()
-
-    @pytest.mark.asyncio
-    async def test_no_examples_skips_examples_dir(self, mock_filesystem: MagicMock) -> None:
-        gen = ReadmeDocGenerator(
-            skill_name="test",
-            schemas=_DEFAULT_SCHEMAS,
-            operation_traits=_DEFAULT_TRAITS,
-            error_registry=_DEFAULT_ERRORS,
-            examples={},
-        )
-        result = await gen.write_readme("/mnt/x", filesystem=mock_filesystem)
-        assert result["readme_md"] is not None
-        assert result["examples"] == []
-        # Only the .readme dir mkdir, not examples/
-        mkdir_paths = [c[0][0] for c in mock_filesystem.mkdir.call_args_list]
-        assert "/mnt/x/.readme/examples" not in mkdir_paths
-
-    @pytest.mark.asyncio
-    async def test_filesystem_error_returns_partial_result(
-        self, mock_filesystem: MagicMock
-    ) -> None:
-        mock_filesystem.mkdir.side_effect = OSError("permission denied")
-        gen = ReadmeDocGenerator(
-            skill_name="test",
-            schemas={},
-            operation_traits={},
-            error_registry={},
-            examples={},
-        )
-        result = await gen.write_readme("/mnt/x", filesystem=mock_filesystem)
-        assert result["readme_md"] is None
-        assert result["examples"] == []
-
-    @pytest.mark.asyncio
-    async def test_custom_readme_dir(self, mock_filesystem: MagicMock) -> None:
-        gen = ReadmeDocGenerator(
-            skill_name="test",
-            schemas={},
-            operation_traits={},
-            error_registry={},
-            examples={},
-            readme_dir=".docs",
-        )
-        await gen.write_readme("/mnt/x", filesystem=mock_filesystem)
-        mock_filesystem.mkdir.assert_any_call("/mnt/x/.docs", parents=True, exist_ok=True)
 
 
 # ===========================================================================
@@ -569,3 +476,651 @@ class TestGetSkillPath:
     def test_root_mount(self, generator: ReadmeDocGenerator) -> None:
         # posixpath.join("", ".readme") = ".readme" after rstrip("/") on "/"
         assert generator.get_readme_path("/") == ".readme"
+
+
+# ===========================================================================
+# VirtualEntry tree model (Issue #3728)
+# ===========================================================================
+
+
+from nexus.backends.connectors.schema_generator import (  # noqa: E402
+    _VIRTUAL_TREE_CACHE,
+    VirtualEntry,
+    _invalidate_virtual_tree_cache,
+    _parse_readme_path_parts,
+    dispatch_virtual_readme_exists,
+    dispatch_virtual_readme_list,
+    dispatch_virtual_readme_read,
+    dispatch_virtual_readme_size,
+    get_virtual_readme_tree_for_backend,
+)
+
+
+class TestVirtualEntry:
+    def test_file_entry_has_content_and_no_children(self) -> None:
+        entry = VirtualEntry(name="README.md", is_dir=False, content=b"hello")
+        assert entry.is_file is True
+        assert entry.is_dir is False
+        assert entry.content == b"hello"
+        assert entry.children == {}
+        assert entry.size() == 5
+
+    def test_dir_entry_has_no_content(self) -> None:
+        entry = VirtualEntry(name="schemas", is_dir=True)
+        assert entry.is_dir is True
+        assert entry.is_file is False
+        assert entry.content is None
+        assert entry.size() == 0  # directories report size 0
+
+    def test_find_empty_parts_returns_self(self) -> None:
+        root = VirtualEntry(name=".readme", is_dir=True)
+        assert root.find([]) is root
+
+    def test_find_single_file(self) -> None:
+        root = VirtualEntry(name=".readme", is_dir=True)
+        root.children["README.md"] = VirtualEntry(name="README.md", is_dir=False, content=b"hi")
+        found = root.find(["README.md"])
+        assert found is not None
+        assert found.content == b"hi"
+
+    def test_find_nested_file(self) -> None:
+        root = VirtualEntry(name=".readme", is_dir=True)
+        schemas = VirtualEntry(name="schemas", is_dir=True)
+        schemas.children["send.yaml"] = VirtualEntry(
+            name="send.yaml", is_dir=False, content=b"yaml"
+        )
+        root.children["schemas"] = schemas
+        found = root.find(["schemas", "send.yaml"])
+        assert found is not None
+        assert found.content == b"yaml"
+
+    def test_find_missing_returns_none(self) -> None:
+        root = VirtualEntry(name=".readme", is_dir=True)
+        assert root.find(["nonexistent.md"]) is None
+
+    def test_find_through_non_dir_returns_none(self) -> None:
+        # README.md is a file, so treating it as a dir fails cleanly.
+        root = VirtualEntry(name=".readme", is_dir=True)
+        root.children["README.md"] = VirtualEntry(name="README.md", is_dir=False, content=b"hi")
+        assert root.find(["README.md", "child"]) is None
+
+    def test_list_children_names_sorts_and_marks_dirs(self) -> None:
+        root = VirtualEntry(name=".readme", is_dir=True)
+        root.children["README.md"] = VirtualEntry(name="README.md", is_dir=False, content=b"")
+        root.children["schemas"] = VirtualEntry(name="schemas", is_dir=True)
+        root.children["examples"] = VirtualEntry(name="examples", is_dir=True)
+        names = root.list_children_names()
+        assert names == ["README.md", "examples/", "schemas/"]
+
+    def test_list_children_names_on_file_is_empty(self) -> None:
+        file_entry = VirtualEntry(name="README.md", is_dir=False, content=b"x")
+        assert file_entry.list_children_names() == []
+
+    def test_list_children_empty_dir(self) -> None:
+        empty_dir = VirtualEntry(name=".readme", is_dir=True)
+        assert empty_dir.list_children_names() == []
+
+
+# ===========================================================================
+# generate_tree — single-walk construction (#14A)
+# ===========================================================================
+
+
+class TestGenerateTree:
+    def test_tree_root_is_dir(self, generator: ReadmeDocGenerator) -> None:
+        tree = generator.generate_tree("/mnt/cal")
+        assert tree.is_dir is True
+        assert tree.name == ".readme"
+
+    def test_tree_contains_readme(self, generator: ReadmeDocGenerator) -> None:
+        tree = generator.generate_tree("/mnt/cal")
+        readme = tree.find(["README.md"])
+        assert readme is not None
+        assert readme.is_file
+        assert b"# Test Skill Connector" in readme.content
+        assert b"/mnt/cal" in readme.content
+
+    def test_tree_readme_matches_generate_readme(self, generator: ReadmeDocGenerator) -> None:
+        tree = generator.generate_tree("/mnt/cal")
+        readme = tree.find(["README.md"])
+        assert readme is not None
+        expected = generator.generate_readme("/mnt/cal").encode("utf-8")
+        assert readme.content == expected
+
+    def test_tree_contains_schemas_dir(self, generator: ReadmeDocGenerator) -> None:
+        tree = generator.generate_tree("/mnt/cal")
+        schemas = tree.find(["schemas"])
+        assert schemas is not None
+        assert schemas.is_dir
+        # Two schemas in _DEFAULT_SCHEMAS: create_event, update_event
+        assert set(schemas.children.keys()) == {"create_event.yaml", "update_event.yaml"}
+
+    def test_tree_schema_file_has_yaml_content(self, generator: ReadmeDocGenerator) -> None:
+        tree = generator.generate_tree("/mnt/cal")
+        schema_file = tree.find(["schemas", "create_event.yaml"])
+        assert schema_file is not None
+        assert schema_file.is_file
+        assert b"# Schema: create_event" in schema_file.content
+
+    def test_tree_contains_examples_dir(self, generator: ReadmeDocGenerator) -> None:
+        tree = generator.generate_tree("/mnt/cal")
+        examples = tree.find(["examples"])
+        assert examples is not None
+        assert examples.is_dir
+        assert "create_meeting.yaml" in examples.children
+
+    def test_tree_example_content_preserved(self, generator: ReadmeDocGenerator) -> None:
+        tree = generator.generate_tree("/mnt/cal")
+        example = tree.find(["examples", "create_meeting.yaml"])
+        assert example is not None
+        assert example.content == b"summary: Team Standup\n"
+
+    def test_tree_with_empty_schemas(self, empty_generator: ReadmeDocGenerator) -> None:
+        tree = empty_generator.generate_tree("/mnt/empty")
+        # README.md is always present (decision #7A — empty SCHEMAS still renders)
+        assert tree.find(["README.md"]) is not None
+        # schemas/ and examples/ are absent when their source is empty
+        assert tree.find(["schemas"]) is None
+        assert tree.find(["examples"]) is None
+        assert tree.list_children_names() == ["README.md"]
+
+    def test_tree_with_binary_example(self) -> None:
+        # Decision #7A — bytes values in EXAMPLES must not crash
+        gen = ReadmeDocGenerator(
+            skill_name="binary_skill",
+            schemas={},
+            operation_traits={},
+            error_registry={},
+            examples={"blob.bin": b"\x00\x01\x02\xff"},
+        )
+        tree = gen.generate_tree("/mnt/bin")
+        example = tree.find(["examples", "blob.bin"])
+        assert example is not None
+        assert example.content == b"\x00\x01\x02\xff"
+
+    def test_tree_with_non_ascii_skill_name(self) -> None:
+        # Decision #7A — non-ASCII skill names render without crashing
+        gen = ReadmeDocGenerator(
+            skill_name="café_connector",
+            schemas=_DEFAULT_SCHEMAS,
+            operation_traits=_DEFAULT_TRAITS,
+            error_registry=_DEFAULT_ERRORS,
+            examples={},
+        )
+        tree = gen.generate_tree("/mnt/café")
+        readme = tree.find(["README.md"])
+        assert readme is not None
+        # UTF-8 encoded, round-trip clean
+        assert "café" in readme.content.decode("utf-8").lower()
+
+    def test_tree_list_children_at_root(self, generator: ReadmeDocGenerator) -> None:
+        tree = generator.generate_tree("/mnt/cal")
+        names = tree.list_children_names()
+        assert "README.md" in names
+        assert "schemas/" in names
+        assert "examples/" in names
+        # sorted
+        assert names == sorted(names)
+
+    def test_tree_list_children_at_schemas(self, generator: ReadmeDocGenerator) -> None:
+        tree = generator.generate_tree("/mnt/cal")
+        schemas = tree.find(["schemas"])
+        assert schemas is not None
+        names = schemas.list_children_names()
+        assert names == ["create_event.yaml", "update_event.yaml"]
+
+    def test_tree_propagates_generator_exceptions(self) -> None:
+        """Decision #8A — broken metadata raises instead of silent None.
+
+        Uses a real Pydantic model plus ``patch.object`` to force
+        ``generate_schema_yaml`` to raise — tests the propagation path
+        without faking the schema type (avoids mypy dict-item errors).
+        """
+        from unittest.mock import patch
+
+        gen = ReadmeDocGenerator(
+            skill_name="broken",
+            schemas={"op": SimpleSchema},
+            operation_traits={},
+            error_registry={},
+            examples={},
+        )
+        with (
+            patch.object(gen, "generate_schema_yaml", side_effect=RuntimeError("boom")),
+            pytest.raises(RuntimeError, match="boom"),
+        ):
+            gen.generate_tree("/mnt/broken")
+
+
+# ===========================================================================
+# get_virtual_readme_tree_for_backend — module-level cache (#13A)
+# ===========================================================================
+
+
+class _FakeBackend:
+    """Minimal backend-like object with class-level metadata."""
+
+    SKILL_NAME = "fake"
+    SCHEMAS = _DEFAULT_SCHEMAS
+    OPERATION_TRAITS = _DEFAULT_TRAITS
+    ERROR_REGISTRY = _DEFAULT_ERRORS
+    EXAMPLES = _DEFAULT_EXAMPLES
+    README_DIR = ".readme"
+
+
+class _EmptySkillBackend:
+    SKILL_NAME = ""
+    SCHEMAS: dict = {}
+    OPERATION_TRAITS: dict = {}
+    ERROR_REGISTRY: dict = {}
+    EXAMPLES: dict = {}
+
+
+class TestVirtualTreeCache:
+    def setup_method(self) -> None:
+        _invalidate_virtual_tree_cache()
+
+    def teardown_method(self) -> None:
+        _invalidate_virtual_tree_cache()
+
+    def test_first_call_populates_cache(self) -> None:
+        assert len(_VIRTUAL_TREE_CACHE) == 0
+        tree = get_virtual_readme_tree_for_backend(_FakeBackend(), "/mnt/fake")
+        assert tree is not None
+        assert tree.find(["README.md"]) is not None
+        assert len(_VIRTUAL_TREE_CACHE) == 1
+
+    def test_second_call_returns_same_tree_object(self) -> None:
+        backend = _FakeBackend()
+        tree1 = get_virtual_readme_tree_for_backend(backend, "/mnt/fake")
+        tree2 = get_virtual_readme_tree_for_backend(backend, "/mnt/fake")
+        assert tree1 is tree2  # identity, not just equality
+
+    def test_cache_key_includes_mount_path(self) -> None:
+        backend = _FakeBackend()
+        tree_a = get_virtual_readme_tree_for_backend(backend, "/mnt/a")
+        tree_b = get_virtual_readme_tree_for_backend(backend, "/mnt/b")
+        assert tree_a is not tree_b  # different mount → different tree
+        # But same content structure
+        assert tree_a.list_children_names() == tree_b.list_children_names()
+        # And the mount path is reflected in README.md content
+        readme_a = tree_a.find(["README.md"])
+        readme_b = tree_b.find(["README.md"])
+        assert readme_a is not None and readme_b is not None
+        assert b"/mnt/a" in readme_a.content
+        assert b"/mnt/b" in readme_b.content
+
+    def test_cache_key_includes_class(self) -> None:
+        # Two different classes with the same mount path produce different entries
+        class OtherBackend(_FakeBackend):
+            SKILL_NAME = "other"
+
+        tree_fake = get_virtual_readme_tree_for_backend(_FakeBackend(), "/mnt/x")
+        tree_other = get_virtual_readme_tree_for_backend(OtherBackend(), "/mnt/x")
+        assert tree_fake is not tree_other
+        assert len(_VIRTUAL_TREE_CACHE) == 2
+
+    def test_missing_skill_name_raises(self) -> None:
+        with pytest.raises(RuntimeError, match="SKILL_NAME"):
+            get_virtual_readme_tree_for_backend(_EmptySkillBackend(), "/mnt/x")
+
+    def test_invalidate_clears_all(self) -> None:
+        get_virtual_readme_tree_for_backend(_FakeBackend(), "/mnt/x")
+        assert len(_VIRTUAL_TREE_CACHE) > 0
+        _invalidate_virtual_tree_cache()
+        assert len(_VIRTUAL_TREE_CACHE) == 0
+
+
+# ===========================================================================
+# _parse_readme_path_parts — normalization + traversal guards (#4A)
+# ===========================================================================
+
+
+class TestParseReadmePath:
+    def test_none_input_returns_none(self) -> None:
+        assert _parse_readme_path_parts(None) is None
+
+    def test_empty_string_returns_none(self) -> None:
+        assert _parse_readme_path_parts("") is None
+
+    def test_non_readme_path_returns_none(self) -> None:
+        assert _parse_readme_path_parts("INBOX/msg.yaml") is None
+        assert _parse_readme_path_parts("/INBOX/msg.yaml") is None
+
+    def test_readme_root_returns_empty_list(self) -> None:
+        assert _parse_readme_path_parts(".readme") == []
+        assert _parse_readme_path_parts(".readme/") == []
+        assert _parse_readme_path_parts("/.readme/") == []
+
+    def test_readme_file_returns_single_part(self) -> None:
+        assert _parse_readme_path_parts(".readme/README.md") == ["README.md"]
+        assert _parse_readme_path_parts("/.readme/README.md") == ["README.md"]
+
+    def test_readme_nested_returns_multiple_parts(self) -> None:
+        assert _parse_readme_path_parts(".readme/schemas/send_email.yaml") == [
+            "schemas",
+            "send_email.yaml",
+        ]
+
+    def test_custom_readme_dir(self) -> None:
+        assert _parse_readme_path_parts(".docs/FAQ.md", readme_dir=".docs") == ["FAQ.md"]
+
+    def test_double_slash_normalized(self) -> None:
+        assert _parse_readme_path_parts(".readme//README.md") == ["README.md"]
+
+    def test_trailing_slash_stripped(self) -> None:
+        # .readme/schemas/ (directory listing) — parts are ["schemas"]
+        assert _parse_readme_path_parts(".readme/schemas/") == ["schemas"]
+
+    def test_dot_components_normalized(self) -> None:
+        assert _parse_readme_path_parts(".readme/./README.md") == ["README.md"]
+
+    def test_traversal_rejected(self) -> None:
+        with pytest.raises(ValueError, match="traversal"):
+            _parse_readme_path_parts(".readme/../../../etc/passwd")
+
+    def test_traversal_to_self_rejected(self) -> None:
+        with pytest.raises(ValueError, match="traversal"):
+            _parse_readme_path_parts("..")
+
+    def test_null_byte_rejected(self) -> None:
+        with pytest.raises(ValueError, match="null byte"):
+            _parse_readme_path_parts(".readme/README\x00.md")
+
+    def test_backslash_rejected(self) -> None:
+        with pytest.raises(ValueError, match="backslash"):
+            _parse_readme_path_parts(".readme\\README.md")
+
+    def test_x_readme_is_not_readme(self) -> None:
+        # Prefix confusion — "x.readme/foo" is NOT under ".readme/"
+        assert _parse_readme_path_parts("x.readme/foo") is None
+
+    def test_readme_prefix_of_other_dir_is_not_readme(self) -> None:
+        # ".readmex/foo" starts with ".readme" but is a different directory
+        assert _parse_readme_path_parts(".readmex/foo") is None
+
+
+# ===========================================================================
+# Dispatch helpers (#1 kernel dispatch, #4A traversal, #8A sentinel protocol)
+# ===========================================================================
+
+
+class TestDispatchHelpers:
+    def setup_method(self) -> None:
+        _invalidate_virtual_tree_cache()
+
+    def teardown_method(self) -> None:
+        _invalidate_virtual_tree_cache()
+
+    # -- read --
+
+    def test_read_returns_bytes_for_virtual_file(self) -> None:
+        content = dispatch_virtual_readme_read(_FakeBackend(), "/mnt/x", ".readme/README.md")
+        assert content is not None
+        assert b"# Fake Connector" in content or b"# Test Skill Connector" in content
+
+    def test_read_returns_none_for_non_virtual_path(self) -> None:
+        assert dispatch_virtual_readme_read(_FakeBackend(), "/mnt/x", "INBOX/msg.yaml") is None
+
+    def test_read_raises_not_found_for_missing_virtual(self) -> None:
+        from nexus.contracts.exceptions import NexusFileNotFoundError
+
+        with pytest.raises(NexusFileNotFoundError):
+            dispatch_virtual_readme_read(_FakeBackend(), "/mnt/x", ".readme/nonexistent.md")
+
+    def test_read_raises_is_a_directory_for_virtual_dir(self) -> None:
+        with pytest.raises(IsADirectoryError):
+            dispatch_virtual_readme_read(_FakeBackend(), "/mnt/x", ".readme/schemas")
+
+    def test_read_returns_none_for_backend_without_skill(self) -> None:
+        assert (
+            dispatch_virtual_readme_read(_EmptySkillBackend(), "/mnt/x", ".readme/README.md")
+            is None
+        )
+
+    def test_read_raises_on_traversal(self) -> None:
+        with pytest.raises(ValueError, match="traversal"):
+            dispatch_virtual_readme_read(_FakeBackend(), "/mnt/x", ".readme/../../../etc/passwd")
+
+    # -- list --
+
+    def test_list_returns_entries_for_virtual_dir(self) -> None:
+        entries = dispatch_virtual_readme_list(_FakeBackend(), "/mnt/x", ".readme")
+        assert entries is not None
+        assert "README.md" in entries
+        assert "schemas/" in entries
+        assert "examples/" in entries
+
+    def test_list_returns_entries_for_nested_virtual_dir(self) -> None:
+        entries = dispatch_virtual_readme_list(_FakeBackend(), "/mnt/x", ".readme/schemas")
+        assert entries is not None
+        assert "create_event.yaml" in entries
+        assert "update_event.yaml" in entries
+
+    def test_list_returns_none_for_non_virtual_path(self) -> None:
+        assert dispatch_virtual_readme_list(_FakeBackend(), "/mnt/x", "INBOX") is None
+
+    def test_list_raises_not_a_dir_for_virtual_file(self) -> None:
+        with pytest.raises(NotADirectoryError):
+            dispatch_virtual_readme_list(_FakeBackend(), "/mnt/x", ".readme/README.md")
+
+    def test_list_raises_not_found_for_missing_virtual_dir(self) -> None:
+        from nexus.contracts.exceptions import NexusFileNotFoundError
+
+        with pytest.raises(NexusFileNotFoundError):
+            dispatch_virtual_readme_list(_FakeBackend(), "/mnt/x", ".readme/nonexistent")
+
+    def test_list_returns_none_for_backend_without_skill(self) -> None:
+        assert dispatch_virtual_readme_list(_EmptySkillBackend(), "/mnt/x", ".readme") is None
+
+    # -- exists --
+
+    def test_exists_true_for_virtual_file(self) -> None:
+        assert dispatch_virtual_readme_exists(_FakeBackend(), "/mnt/x", ".readme/README.md") is True
+
+    def test_exists_true_for_virtual_dir(self) -> None:
+        assert dispatch_virtual_readme_exists(_FakeBackend(), "/mnt/x", ".readme/schemas") is True
+
+    def test_exists_false_for_missing_virtual(self) -> None:
+        assert (
+            dispatch_virtual_readme_exists(_FakeBackend(), "/mnt/x", ".readme/nonexistent") is False
+        )
+
+    def test_exists_none_for_non_virtual(self) -> None:
+        assert dispatch_virtual_readme_exists(_FakeBackend(), "/mnt/x", "INBOX/msg") is None
+
+    def test_exists_false_on_malformed_path(self) -> None:
+        # Malformed paths under .readme/ (null byte, backslash) return False
+        # rather than raising — exists() is a predicate, not an access
+        # attempt, and the caller needs a definitive answer.
+        assert (
+            dispatch_virtual_readme_exists(_FakeBackend(), "/mnt/x", ".readme/README\x00.md")
+            is False
+        )
+
+    def test_exists_none_when_traversal_escapes_readme(self) -> None:
+        # posixpath.normpath collapses ".readme/../etc" to "etc", which isn't
+        # under .readme/ at all — the helper returns None (not virtual),
+        # letting the real backend handle the resulting path.
+        assert (
+            dispatch_virtual_readme_exists(_FakeBackend(), "/mnt/x", ".readme/../etc/passwd")
+            is None
+        )
+
+    def test_exists_none_for_backend_without_skill(self) -> None:
+        assert (
+            dispatch_virtual_readme_exists(_EmptySkillBackend(), "/mnt/x", ".readme/README.md")
+            is None
+        )
+
+    # -- size --
+
+    def test_size_returns_file_bytes(self) -> None:
+        size = dispatch_virtual_readme_size(_FakeBackend(), "/mnt/x", ".readme/README.md")
+        assert size is not None
+        assert size > 0
+
+    def test_size_returns_zero_for_virtual_dir(self) -> None:
+        # Directories report size 0 — consistent with Unix directory sizes
+        size = dispatch_virtual_readme_size(_FakeBackend(), "/mnt/x", ".readme/schemas")
+        assert size == 0
+
+    def test_size_returns_none_for_non_virtual(self) -> None:
+        assert dispatch_virtual_readme_size(_FakeBackend(), "/mnt/x", "INBOX/msg.yaml") is None
+
+    def test_size_raises_for_missing_virtual(self) -> None:
+        from nexus.contracts.exceptions import NexusFileNotFoundError
+
+        with pytest.raises(NexusFileNotFoundError):
+            dispatch_virtual_readme_size(_FakeBackend(), "/mnt/x", ".readme/nonexistent.md")
+
+
+# ===========================================================================
+# Hypothesis property test for path parsing (#11A)
+# ===========================================================================
+
+
+from hypothesis import given, settings  # noqa: E402
+from hypothesis import strategies as st  # noqa: E402
+
+
+class TestParseReadmePathFuzz:
+    """Property-based tests for _parse_readme_path_parts.
+
+    Invariants:
+        1. For any input string, the function either (a) returns None,
+           (b) returns a list of parts containing no ``..``, ``/``, or
+           null bytes, and no empty strings, or (c) raises ValueError.
+        2. Returned parts never escape the ``.readme/`` subtree.
+        3. The function never crashes with any other exception type.
+    """
+
+    @given(st.text(max_size=200))
+    @settings(max_examples=500, deadline=None)
+    def test_no_crashes_and_safe_parts(self, path: str) -> None:
+        try:
+            parts = _parse_readme_path_parts(path)
+        except ValueError:
+            return  # explicit rejection is fine
+        except Exception as exc:
+            raise AssertionError(f"unexpected exception type for input {path!r}: {exc!r}") from exc
+
+        if parts is None:
+            return  # not a readme path, fine
+
+        # Safety invariants on returned parts
+        for part in parts:
+            assert part, f"empty part in {parts!r} from {path!r}"
+            assert "/" not in part, f"slash in part {part!r} from {path!r}"
+            assert "\x00" not in part, f"null byte in part {part!r} from {path!r}"
+            assert part != "..", f".. in parts {parts!r} from {path!r}"
+            assert part != ".", f". in parts {parts!r} from {path!r}"
+
+    @given(st.text(max_size=200))
+    @settings(max_examples=500, deadline=None)
+    def test_traversal_always_rejected(self, suffix: str) -> None:
+        # Any path starting with ../ after .readme/ should raise
+        attack = ".readme/../" + suffix
+        try:
+            _parse_readme_path_parts(attack)
+        except (ValueError, UnicodeError):
+            return
+        # If it didn't raise, the result must NOT escape .readme/
+        # (i.e., parts must be empty or resolvable-safe).
+        # This branch is reached when the suffix normalizes to something
+        # within .readme/ after collapsing — which is fine.
+
+    def test_explicit_attack_vectors(self) -> None:
+        # Each of these must raise ValueError
+        attacks = [
+            ".readme/../../etc/passwd",
+            ".readme/../..",
+            "../.readme/README.md",
+            ".readme/foo/../../../root",
+            ".readme/\x00injected",
+            ".readme\\README.md",
+        ]
+        for attack in attacks:
+            with pytest.raises(ValueError):
+                _parse_readme_path_parts(attack)
+
+
+# ===========================================================================
+# Kernel wiring integration (Issue #3728 kernel dispatch)
+# ===========================================================================
+#
+# These tests verify that NexusFS._try_virtual_readme_stat + the dispatch
+# wiring in sys_read/sys_readdir fires correctly for backends with skill
+# docs.  We use monkeypatch to install a fake router route instead of
+# constructing a full Backend subclass, which would require a proper
+# Transport implementation we don't need for this test.
+
+
+class _FakeRoute:
+    """Minimal fake of RouteResult/ExternalRouteResult for dispatch wiring."""
+
+    def __init__(self, backend, mount_point, backend_path):
+        self.backend = backend
+        self.mount_point = mount_point
+        self.backend_path = backend_path
+        self.readonly = True
+        self.io_profile = "balanced"
+        self.metastore = None  # stat path checks meta; we override it anyway
+
+
+class TestKernelWiringDispatch:
+    """Verify the dispatch helpers are callable through the public API."""
+
+    def setup_method(self) -> None:
+        _invalidate_virtual_tree_cache()
+
+    def teardown_method(self) -> None:
+        _invalidate_virtual_tree_cache()
+
+    def test_read_dispatch_returns_readme_bytes(self) -> None:
+        """dispatch_virtual_readme_read serves README.md content."""
+        backend = _FakeBackend()
+        data = dispatch_virtual_readme_read(backend, "/mnt/fake", ".readme/README.md")
+        assert data is not None
+        assert data.startswith(b"# Fake") or data.startswith(b"#")
+
+    def test_list_dispatch_returns_entries(self) -> None:
+        """dispatch_virtual_readme_list serves directory entries."""
+        backend = _FakeBackend()
+        entries = dispatch_virtual_readme_list(backend, "/mnt/fake", ".readme")
+        assert entries is not None
+        assert "README.md" in entries
+
+    def test_exists_dispatch_returns_true(self) -> None:
+        """dispatch_virtual_readme_exists returns True for known entries."""
+        backend = _FakeBackend()
+        assert dispatch_virtual_readme_exists(backend, "/mnt/fake", ".readme/README.md") is True
+
+    def test_size_dispatch_returns_nonzero_for_readme(self) -> None:
+        """dispatch_virtual_readme_size returns positive size for README.md."""
+        backend = _FakeBackend()
+        size = dispatch_virtual_readme_size(backend, "/mnt/fake", ".readme/README.md")
+        assert size is not None
+        assert size > 0
+
+    def test_size_dispatch_returns_zero_for_dir(self) -> None:
+        """dispatch_virtual_readme_size returns 0 for virtual directories."""
+        backend = _FakeBackend()
+        size = dispatch_virtual_readme_size(backend, "/mnt/fake", ".readme/schemas")
+        assert size == 0
+
+    def test_fall_through_on_non_readme_path(self) -> None:
+        """Non-.readme/ paths return None from all four dispatch helpers."""
+        backend = _FakeBackend()
+        assert dispatch_virtual_readme_read(backend, "/mnt/fake", "INBOX/msg.yaml") is None
+        assert dispatch_virtual_readme_list(backend, "/mnt/fake", "INBOX") is None
+        assert dispatch_virtual_readme_exists(backend, "/mnt/fake", "INBOX/msg") is None
+        assert dispatch_virtual_readme_size(backend, "/mnt/fake", "INBOX/msg.yaml") is None
+
+    def test_non_skill_backend_always_returns_none(self) -> None:
+        """Backends without SKILL_NAME get None from all helpers."""
+        backend = _EmptySkillBackend()
+        assert dispatch_virtual_readme_read(backend, "/mnt/x", ".readme/README.md") is None
+        assert dispatch_virtual_readme_list(backend, "/mnt/x", ".readme") is None
+        assert dispatch_virtual_readme_exists(backend, "/mnt/x", ".readme/README.md") is None
+        assert dispatch_virtual_readme_size(backend, "/mnt/x", ".readme/README.md") is None


### PR DESCRIPTION
## Summary

- Exposes connector skill docs (`README.md`, annotated `schemas/<op>.yaml`, `examples/`) through the slim and full `nexus-fs` CLIs via a virtual `.readme/` overlay that serves files from class metadata on demand — no materialization into the backend.
- Dispatch lives in the NexusFS kernel at `sys_read` / `sys_readdir` / `sys_stat` entry points, so every backend inheriting `ReadmeDocMixin` gets `.readme/` coverage without per-backend overrides.
- Replaces the old mount-time `write_readme` materialization path, eliminating the drift problem the issue was trying to solve.

**Closes #3728**

## Why this shape

Issue #3728 originally proposed ~80 LOC in `ReadmeDocMixin` as a read-path override. That couldn't work because of MRO: every skill backend inherits from `PathAddressingEngine` (or a subclass) **before** `ReadmeDocMixin`, so the mixin method would never be reached. The full 16-issue review is documented in nexi-lab/nexus#3728 (comment-4228063064).

During implementation I hit scope reality at ~50+ method overrides for the template-method (1A) approach and pivoted to **kernel dispatch**: a single choke point at the existing `ExternalRouteResult` branch in `nexus_fs.py`. One code path, every backend benefits, zero per-backend changes. The kernel already has `ExternalRouteResult`-specific code (pre-existing at nexus_fs.py L1222), so layering stays consistent.

## What changed

**Production code (~400 LOC net):**
- `src/nexus/contracts/types.py` — Added `OperationContext.mount_path` field (#3A: stateless mount_path via context).
- `src/nexus/backends/connectors/schema_generator.py` — New `VirtualEntry` tree model (#5A), `generate_tree()` single-walk constructor (#14A), module-level `_VIRTUAL_TREE_CACHE` keyed by `(class, mount_path)` (#13A), `_parse_readme_path_parts()` with `posixpath.normpath` + explicit traversal/null/backslash rejection (#4A), and four dispatch helpers (`dispatch_virtual_readme_{read,list,exists,size}`) with sentinel protocol (#8A). Deleted `ReadmeDocGenerator.write_readme`.
- `src/nexus/core/nexus_fs.py` — Wired dispatch into `sys_read` ExternalRouteResult path, `sys_readdir` ExternalRouteResult path, `sys_stat` and `stat` fallback via new `_try_virtual_readme_stat` helper method. Propagated `mount_path` through 8 context-construction call sites.
- `src/nexus/backends/connectors/base.py` — Deleted `ReadmeDocMixin.write_readme` (#2A).
- `src/nexus/backends/connectors/gmail/connector.py` — Deleted `write_readme` override.
- `src/nexus/bricks/mount/mount_service.py` — Deleted `_generate_readmes` helper. `_run_post_mount_hooks` now only propagates `mount_path` for error messages and runs search indexing.

**Tests (~900 LOC):**
- `tests/integration/connectors/test_schema_generator.py` — 122 tests (73 net new). Removed `TestWriteReadme` (7 deleted). Added:
  - `TestVirtualEntry` (10) — tree model invariants
  - `TestGenerateTree` (13) — single-walk construction, binary examples, non-ASCII, empty schemas
  - `TestVirtualTreeCache` (5) — module cache keyed by (class, mount_path)
  - `TestParseReadmePath` (16) — normalization + traversal + prefix confusion + custom readme dir
  - `TestDispatchHelpers` (19) — all 4 helpers × read/list/exists/size × virtual hit/miss/dir/file/traversal
  - `TestParseReadmePathFuzz` (3) — Hypothesis property tests (500 examples each) for path normalization invariants and traversal rejection (#11A)
  - `TestKernelWiringDispatch` (7) — smoke tests for dispatch helpers via the public API
- `tests/e2e/self_contained/test_gmail_connector.py` — replaced `test_write_readme` with `test_virtual_readme_tree`
- `tests/e2e/self_contained/test_gcalendar_connector.py` — same substitution
- `tests/integration/backends/connectors/cli/test_lifecycle_e2e.py` — replaced Step 2 materialization test with virtual tree exposure test

## Decisions (all 16 from pre-impl review)

| # | Decision | Status |
|:---|:---|:---|
| 1 | Kernel dispatch (pivoted from template-method 1A) | Done |
| 2A | Delete materialized path entirely | Done |
| 3A | `mount_path` via `OperationContext` (stateless) | Done |
| 4A | `posixpath.normpath` + explicit traversal rejection | Done |
| 5A | Single `VirtualEntry` tree drives read/list/stat | Done |
| 6A | read + list + stat (exists + size) all work | Done |
| 7A | Edge cases: binary, non-ASCII, empty, null byte, backslash, prefix confusion | Done |
| 8A | Sentinel protocol (None = not virtual, raise = broken virtual) | Done |
| 9A | 73 new unit/contract tests | Done |
| 10A | Parity fixture | Partial — dispatch helpers covered, full slim-vs-full NexusFS fixture deferred (dispatch is a single shared code path) |
| 11A | Hypothesis property tests (500 examples each) | Done |
| 12B | Migration test | Deferred — stale materialized files are inert once overlay lands |
| 13A | Module-level `(class, mount_path)` cache | Done |
| 14A | Single-walk tree generation | Done |
| 15C | Keep sync | Done |
| 16C | No size cap | Done |

Full reasoning: nexi-lab/nexus#3728 (comment-4228063064)

## Test plan

- [x] 122 tests in `tests/integration/connectors/test_schema_generator.py` (73 net new) — `pytest tests/integration/connectors/test_schema_generator.py` → 122 passed
- [x] 543 tests in `tests/integration/connectors/` + `tests/integration/backends/connectors/` → 543 passed
- [x] 60 tests in `tests/unit/core/test_nexus_fs_mounts.py` + `tests/unit/bricks/mount/` → 60 passed
- [x] 2468 tests in `tests/unit/core/` (excluding pre-existing `flush_observers` failures in `test_write_observer_calls.py`) → 2468 passed
- [x] Zero regressions attributable to this change. The 18 `flush_observers` failures exist on develop without this change (verified via `git stash`).
- [ ] Manual smoke test: `nexus-fs cat /gws/gmail/.readme/README.md` + `nexus-fs ls /gws/gmail/.readme/` with an authenticated gws mount (requires a running stack — defer to reviewer or CI environment).
- [ ] Manual smoke test against a native connector (`gmail://`, `calendar://`, `gdrive://`) to confirm the overlay works across backend families.
- [ ] CI: ensure the 18 `flush_observers` failures are a known-unrelated quirk, not something this PR exacerbates.

## Breaking changes

- `ReadmeDocMixin.write_readme`, `ReadmeDocGenerator.write_readme`, `MountService._generate_readmes` are **removed**. No downstream code in the repo depends on these outside of test paths that have been updated.
- Any deployment that has previously materialized `.readme/` directories into an S3/GCS/local bucket will still have those files; the overlay is transparent (virtual entries always win at the kernel dispatch point, and real `.readme/` files are no longer written on mount). Stale files are inert — no cleanup tooling is included (#12B engineered-enough).

## Follow-ups (deferred from review)

- **#10A parity fixture**: full slim-vs-full NexusFS parametrized test that runs the same assertions against both code paths. Dispatch is a single shared code path, so the value of the fixture is lower, but adding it would make the parity claim enforceable. Small addition if desired.
- **#12B migration test**: exercise a bucket with stale materialized `.readme/` files from an old deploy. Virtual always wins per #2A, but a regression test locks in the behavior.
- **Cleanup CLI**: `nexus-fs cleanup-readme` command to sweep stale materialized files. Engineered-enough scope says wait for a user to complain.