### PR TITLE
perf(search): stream bootstrap rows instead of fetchall (Issue #3704)

### DIFF
--- a/benchmarks/bootstrap_scale.py
+++ b/benchmarks/bootstrap_scale.py
@@ -110,14 +110,20 @@ async def _create_schema(engine: Any) -> None:
             await conn.execute(sa_text(stmt))
 
 
-async def _populate(engine: Any, n_files: int, chunks_per_file: int) -> int:
-    """Insert ``n_files`` file rows + ``n_files * chunks_per_file`` chunk rows."""
+async def _populate(engine: Any, n_files: int, chunks_per_file: int, n_zones: int = 1) -> int:
+    """Insert ``n_files`` file rows + ``n_files * chunks_per_file`` chunk rows.
+
+    When ``n_zones > 1``, files are distributed round-robin across zones
+    named ``zone_0000`` … ``zone_NNNN``.  This exercises the multi-zone
+    bootstrap path where every zone has far fewer than ``_UPSERT_BATCH``
+    documents, which was the failure mode the per-zone flush fixes.
+    """
     from sqlalchemy import text as sa_text
 
     file_rows = [
         {
             "path_id": str(uuid.uuid4()),
-            "zone_id": "root",
+            "zone_id": f"zone_{i % n_zones:04d}" if n_zones > 1 else "root",
             "virtual_path": f"/herb/run_{n_files:07d}/file_{i:06d}.md",
         }
         for i in range(n_files)
@@ -175,15 +181,30 @@ class _NullBackend:
 # ---------------------------------------------------------------------------
 
 
-async def measure_one(n_files: int, chunks_per_file: int = CHUNKS_PER_FILE) -> dict[str, Any]:
-    """Return a timing/memory dict for a bootstrap run at *n_files* scale."""
+async def measure_one(
+    n_files: int,
+    chunks_per_file: int = CHUNKS_PER_FILE,
+    n_zones: int = 1,
+) -> dict[str, Any]:
+    """Return a timing/memory dict for a bootstrap run at *n_files* scale.
+
+    ``n_zones`` distributes files round-robin across that many zone IDs.
+    When ``n_zones`` is large and every zone stays well under
+    ``_UPSERT_BATCH``, the only flush that fires is the per-zone-boundary
+    flush added by Issue #3704.  This exercises the adversarial path.
+
+    Memory is reported as the **true peak** heap bytes allocated during
+    bootstrap, using ``tracemalloc.get_traced_memory()[1]`` (the high-water
+    mark since ``tracemalloc.start()``).  This captures transient spikes
+    that are freed before the final snapshot, unlike a before/after diff.
+    """
     from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
 
     from nexus.bricks.search.daemon import SearchDaemon
 
     engine = create_async_engine("sqlite+aiosqlite://", echo=False)
     await _create_schema(engine)
-    total_rows = await _populate(engine, n_files, chunks_per_file)
+    total_rows = await _populate(engine, n_files, chunks_per_file, n_zones=n_zones)
 
     session_factory = async_sessionmaker(engine, expire_on_commit=False)
 
@@ -191,7 +212,7 @@ async def measure_one(n_files: int, chunks_per_file: int = CHUNKS_PER_FILE) -> d
     daemon = SearchDaemon.__new__(SearchDaemon)
     daemon._async_session = session_factory
     daemon._backend = _NullBackend()
-    daemon._zone_indexing_modes = {}   # no scoped zones → fast path
+    daemon._zone_indexing_modes = {}  # no scoped zones → fast path
     daemon._indexed_directories = {}
     daemon._txtai_bootstrapped = False
 
@@ -207,26 +228,23 @@ async def measure_one(n_files: int, chunks_per_file: int = CHUNKS_PER_FILE) -> d
         await sess.execute(sa_text("SELECT COUNT(*) FROM document_chunks"))
 
     # ---- timed section ----
+    # Use get_traced_memory()[1] for the true high-water mark (captures
+    # transient spikes freed before the run ends, unlike a before/after diff).
     tracemalloc.start()
-    snap_before = tracemalloc.take_snapshot()
     t0 = time.perf_counter()
 
     await daemon._bootstrap_txtai_backend()
 
     wall_s = time.perf_counter() - t0
-    snap_after = tracemalloc.take_snapshot()
+    _, peak_bytes = tracemalloc.get_traced_memory()
     tracemalloc.stop()
-
-    # Net Python heap bytes allocated during bootstrap (positive deltas only).
-    # tracemalloc.StatisticDiff uses ``size_diff`` (not ``size_delta``).
-    diff_stats = snap_after.compare_to(snap_before, "lineno")
-    peak_bytes = sum(s.size_diff for s in diff_stats if s.size_diff > 0)
 
     await engine.dispose()
 
     return {
         "scale": round(n_files / HERB_FILES, 1),
         "n_files": n_files,
+        "n_zones": n_zones,
         "total_rows": total_rows,
         "wall_s": round(wall_s, 3),
         "peak_mb": round(peak_bytes / 1_048_576, 2),
@@ -238,19 +256,21 @@ async def measure_one(n_files: int, chunks_per_file: int = CHUNKS_PER_FILE) -> d
 # ---------------------------------------------------------------------------
 
 
-def _print_header() -> None:
+def _print_header(label: str = "") -> None:
+    if label:
+        print(f"\n{label}")
     print(
-        f"{'Scale':>7}  {'Files':>8}  {'Chunk rows':>11}"
-        f"  {'Wall (s)':>9}  {'Peak alloc (MB)':>16}"
+        f"{'Scale':>7}  {'Files':>8}  {'Zones':>6}  {'Chunk rows':>11}"
+        f"  {'Wall (s)':>9}  {'Peak heap (MB)':>15}"
     )
-    print("-" * 62)
+    print("-" * 71)
 
 
 def _print_row(r: dict[str, Any]) -> None:
     scale_label = f"{r['scale']}x"
     print(
-        f"{scale_label:>7}  {r['n_files']:>8,}  {r['total_rows']:>11,}"
-        f"  {r['wall_s']:>9.3f}  {r['peak_mb']:>15.1f}"
+        f"{scale_label:>7}  {r['n_files']:>8,}  {r['n_zones']:>6,}  {r['total_rows']:>11,}"
+        f"  {r['wall_s']:>9.3f}  {r['peak_mb']:>14.1f}"
     )
 
 
@@ -263,26 +283,43 @@ async def _run(scales: list[int], emit_json: bool, chunks_per_file: int) -> None
     results = []
     if not emit_json:
         print(f"\nBootstrap scale benchmark  (HERB baseline = {HERB_FILES:,} files)\n")
-        _print_header()
+        _print_header("Single-zone (all files in 'root')")
 
     for scale in scales:
         n_files = HERB_FILES * scale
-        r = await measure_one(n_files, chunks_per_file=chunks_per_file)
+        r = await measure_one(n_files, chunks_per_file=chunks_per_file, n_zones=1)
         results.append(r)
         if not emit_json:
             _print_row(r)
 
+    # Multi-zone scenario: many small zones, each well below _UPSERT_BATCH.
+    # This exercises the zone-boundary flush path.  Use 500 zones so each
+    # zone has ~4 files × 3 chunks = ~4 docs at 1x — always sub-threshold.
+    multi_results = []
+    multi_zones = 500
+    if not emit_json:
+        _print_header(
+            f"Multi-zone ({multi_zones} zones — adversarial: each zone << _UPSERT_BATCH)"
+        )
+    for scale in scales:
+        n_files = HERB_FILES * scale
+        r = await measure_one(n_files, chunks_per_file=chunks_per_file, n_zones=multi_zones)
+        multi_results.append(r)
+        if not emit_json:
+            _print_row(r)
+
+    all_results = results + multi_results
+
     if not emit_json and len(results) > 1:
-        # Print linearity ratio: wall time at scale N / wall time at scale 1
         base = results[0]["wall_s"]
         print()
-        print("Linearity check (wall_s / wall_s@1x):")
+        print("Single-zone linearity check (wall_s / wall_s@1x):")
         for r in results:
             ratio = r["wall_s"] / base if base > 0 else float("nan")
             print(f"  {r['scale']}x → {ratio:.2f}x  (expected ≈ {r['scale']:.1f}x if linear)")
 
     if emit_json:
-        print(json.dumps(results, indent=2))
+        print(json.dumps(all_results, indent=2))
 
 
 def main() -> None:

--- a/benchmarks/bootstrap_scale.py
+++ b/benchmarks/bootstrap_scale.py
@@ -1,0 +1,332 @@
+#!/usr/bin/env python3
+"""Benchmark: daemon bootstrap time vs file count (Issue #3704).
+
+Measures how ``_bootstrap_txtai_backend`` scales as ``document_chunks``
+grows.  The bottleneck under investigation is the unbounded ``fetchall()``
+that materialises ALL rows into Python memory before pushing to txtai.
+
+Usage::
+
+    python benchmarks/bootstrap_scale.py            # default: 1x 5x 10x 25x
+    python benchmarks/bootstrap_scale.py --quick    # 1x only (CI-safe, <5s)
+    python benchmarks/bootstrap_scale.py --json     # emit JSON for further analysis
+    python benchmarks/bootstrap_scale.py --scales 1,5,10
+
+HERB corpus baseline: 2,113 files, realistic enterprise content.
+Scale factors multiply that file count; chunk rows scale proportionally.
+
+Expected output (example, numbers vary)::
+
+     Scale     Files        Rows    Wall (s)  Peak mem (MB)
+    -------------------------------------------------------
+        1x     2,113       6,339       0.142            5.1
+        5x    10,565      31,695       0.691           25.2
+       10x    21,130      63,390       1.381           50.4
+       25x    52,825     158,475       3.451          126.1
+"""
+
+from __future__ import annotations
+
+import argparse
+import asyncio
+import json
+import sys
+import time
+import tracemalloc
+import uuid
+from pathlib import Path
+from typing import Any
+
+# ---------------------------------------------------------------------------
+# Ensure the repo ``src/`` tree is importable when running as a script
+# ---------------------------------------------------------------------------
+
+_REPO_ROOT = Path(__file__).resolve().parent.parent
+if str(_REPO_ROOT / "src") not in sys.path:
+    sys.path.insert(0, str(_REPO_ROOT / "src"))
+
+# ---------------------------------------------------------------------------
+# Schema (minimal subset needed by _bootstrap_txtai_backend)
+# ---------------------------------------------------------------------------
+
+_DDL_STMTS = [
+    """
+    CREATE TABLE IF NOT EXISTS file_paths (
+        path_id       TEXT    PRIMARY KEY,
+        zone_id       TEXT    NOT NULL DEFAULT 'root',
+        virtual_path  TEXT    NOT NULL,
+        backend_id    TEXT    NOT NULL DEFAULT '',
+        physical_path TEXT    NOT NULL DEFAULT '',
+        size_bytes    INTEGER NOT NULL DEFAULT 0,
+        deleted_at    DATETIME         NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS document_chunks (
+        chunk_id     TEXT    PRIMARY KEY,
+        path_id      TEXT    NOT NULL,
+        chunk_index  INTEGER NOT NULL,
+        chunk_text   TEXT    NOT NULL,
+        chunk_tokens INTEGER NOT NULL DEFAULT 0,
+        created_at   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+        FOREIGN KEY (path_id) REFERENCES file_paths(path_id) ON DELETE CASCADE
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_dc_path_id ON document_chunks(path_id)",
+]
+
+# ---------------------------------------------------------------------------
+# Corpus constants
+# ---------------------------------------------------------------------------
+
+# HERB enterprise-context corpus = 2,113 files (see benchmarks/herb/README.md)
+HERB_FILES: int = 2_113
+
+# Conservative average: ~3 chunks per file across mixed JSONL / Markdown / JSON.
+# Real production deployments often have 5-10+ chunks per file.
+CHUNKS_PER_FILE: int = 3
+
+# Synthetic chunk body (~80 words ≈ typical paragraph).
+_CHUNK_BODY: str = (
+    "enterprise context chunk text simulating realistic document content "
+    "from the herb corpus including product specifications meeting notes "
+    "slack messages and technical documentation "
+) * 2  # ~160 chars
+
+DEFAULT_SCALES: list[int] = [1, 5, 10, 25]
+
+# ---------------------------------------------------------------------------
+# Database helpers
+# ---------------------------------------------------------------------------
+
+
+async def _create_schema(engine: Any) -> None:
+    from sqlalchemy import text as sa_text
+
+    async with engine.begin() as conn:
+        await conn.execute(sa_text("PRAGMA journal_mode=WAL"))
+        await conn.execute(sa_text("PRAGMA synchronous=OFF"))
+        for stmt in _DDL_STMTS:
+            await conn.execute(sa_text(stmt))
+
+
+async def _populate(engine: Any, n_files: int, chunks_per_file: int) -> int:
+    """Insert ``n_files`` file rows + ``n_files * chunks_per_file`` chunk rows."""
+    from sqlalchemy import text as sa_text
+
+    file_rows = [
+        {
+            "path_id": str(uuid.uuid4()),
+            "zone_id": "root",
+            "virtual_path": f"/herb/run_{n_files:07d}/file_{i:06d}.md",
+        }
+        for i in range(n_files)
+    ]
+
+    chunk_rows = [
+        {
+            "chunk_id": str(uuid.uuid4()),
+            "path_id": fp["path_id"],
+            "chunk_index": ci,
+            "chunk_text": f"[chunk {ci}] {_CHUNK_BODY}",
+            "chunk_tokens": 40,
+        }
+        for fp in file_rows
+        for ci in range(chunks_per_file)
+    ]
+
+    async with engine.begin() as conn:
+        await conn.execute(
+            sa_text(
+                "INSERT INTO file_paths"
+                " (path_id, zone_id, virtual_path, backend_id, physical_path, size_bytes)"
+                " VALUES (:path_id, :zone_id, :virtual_path, '', '', 0)"
+            ),
+            file_rows,
+        )
+        # Batch in chunks of 500 to stay well under SQLite's per-statement
+        # variable limit (999 by default; each row uses 5 variables here).
+        batch_size = 500
+        for start in range(0, len(chunk_rows), batch_size):
+            await conn.execute(
+                sa_text(
+                    "INSERT INTO document_chunks"
+                    " (chunk_id, path_id, chunk_index, chunk_text, chunk_tokens)"
+                    " VALUES (:chunk_id, :path_id, :chunk_index, :chunk_text, :chunk_tokens)"
+                ),
+                chunk_rows[start : start + batch_size],
+            )
+
+    return len(chunk_rows)
+
+
+# ---------------------------------------------------------------------------
+# Null txtai backend — absorbs upsert calls so we measure SQL+Python only
+# ---------------------------------------------------------------------------
+
+
+class _NullBackend:
+    async def upsert(self, docs: list, *, zone_id: str) -> int:
+        return len(docs)
+
+
+# ---------------------------------------------------------------------------
+# Measurement
+# ---------------------------------------------------------------------------
+
+
+async def measure_one(n_files: int, chunks_per_file: int = CHUNKS_PER_FILE) -> dict[str, Any]:
+    """Return a timing/memory dict for a bootstrap run at *n_files* scale."""
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    from nexus.bricks.search.daemon import SearchDaemon
+
+    engine = create_async_engine("sqlite+aiosqlite://", echo=False)
+    await _create_schema(engine)
+    total_rows = await _populate(engine, n_files, chunks_per_file)
+
+    session_factory = async_sessionmaker(engine, expire_on_commit=False)
+
+    # Build a minimally-wired daemon — same technique as test_bootstrap_filter_shape.py
+    daemon = SearchDaemon.__new__(SearchDaemon)
+    daemon._async_session = session_factory
+    daemon._backend = _NullBackend()
+    daemon._zone_indexing_modes = {}   # no scoped zones → fast path
+    daemon._indexed_directories = {}
+    daemon._txtai_bootstrapped = False
+
+    class _Stats:
+        last_index_refresh: float | None = None
+
+    daemon.stats = _Stats()
+
+    # Warm the SQLite page cache so we measure CPU + Python cost, not cold I/O.
+    from sqlalchemy import text as sa_text
+
+    async with session_factory() as sess:
+        await sess.execute(sa_text("SELECT COUNT(*) FROM document_chunks"))
+
+    # ---- timed section ----
+    tracemalloc.start()
+    snap_before = tracemalloc.take_snapshot()
+    t0 = time.perf_counter()
+
+    await daemon._bootstrap_txtai_backend()
+
+    wall_s = time.perf_counter() - t0
+    snap_after = tracemalloc.take_snapshot()
+    tracemalloc.stop()
+
+    # Net Python heap bytes allocated during bootstrap (positive deltas only).
+    # tracemalloc.StatisticDiff uses ``size_diff`` (not ``size_delta``).
+    diff_stats = snap_after.compare_to(snap_before, "lineno")
+    peak_bytes = sum(s.size_diff for s in diff_stats if s.size_diff > 0)
+
+    await engine.dispose()
+
+    return {
+        "scale": round(n_files / HERB_FILES, 1),
+        "n_files": n_files,
+        "total_rows": total_rows,
+        "wall_s": round(wall_s, 3),
+        "peak_mb": round(peak_bytes / 1_048_576, 2),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Reporting
+# ---------------------------------------------------------------------------
+
+
+def _print_header() -> None:
+    print(
+        f"{'Scale':>7}  {'Files':>8}  {'Chunk rows':>11}"
+        f"  {'Wall (s)':>9}  {'Peak alloc (MB)':>16}"
+    )
+    print("-" * 62)
+
+
+def _print_row(r: dict[str, Any]) -> None:
+    scale_label = f"{r['scale']}x"
+    print(
+        f"{scale_label:>7}  {r['n_files']:>8,}  {r['total_rows']:>11,}"
+        f"  {r['wall_s']:>9.3f}  {r['peak_mb']:>15.1f}"
+    )
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+async def _run(scales: list[int], emit_json: bool, chunks_per_file: int) -> None:
+    results = []
+    if not emit_json:
+        print(f"\nBootstrap scale benchmark  (HERB baseline = {HERB_FILES:,} files)\n")
+        _print_header()
+
+    for scale in scales:
+        n_files = HERB_FILES * scale
+        r = await measure_one(n_files, chunks_per_file=chunks_per_file)
+        results.append(r)
+        if not emit_json:
+            _print_row(r)
+
+    if not emit_json and len(results) > 1:
+        # Print linearity ratio: wall time at scale N / wall time at scale 1
+        base = results[0]["wall_s"]
+        print()
+        print("Linearity check (wall_s / wall_s@1x):")
+        for r in results:
+            ratio = r["wall_s"] / base if base > 0 else float("nan")
+            print(f"  {r['scale']}x → {ratio:.2f}x  (expected ≈ {r['scale']:.1f}x if linear)")
+
+    if emit_json:
+        print(json.dumps(results, indent=2))
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Benchmark _bootstrap_txtai_backend scale (Issue #3704)",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+        epilog=__doc__,
+    )
+    parser.add_argument(
+        "--quick",
+        action="store_true",
+        help="Run 1x only (<5 s, safe for CI)",
+    )
+    parser.add_argument(
+        "--json",
+        action="store_true",
+        dest="emit_json",
+        help="Emit results as JSON (one array, stdout)",
+    )
+    parser.add_argument(
+        "--scales",
+        metavar="N,N,...",
+        type=lambda s: [int(x) for x in s.split(",")],
+        default=None,
+        help="Comma-separated scale multipliers (default: 1,5,10,25)",
+    )
+    parser.add_argument(
+        "--chunks-per-file",
+        metavar="N",
+        type=int,
+        default=CHUNKS_PER_FILE,
+        help=f"Average chunks per file (default: {CHUNKS_PER_FILE})",
+    )
+    args = parser.parse_args()
+
+    if args.quick:
+        scales = [1]
+    elif args.scales:
+        scales = args.scales
+    else:
+        scales = DEFAULT_SCALES
+
+    asyncio.run(_run(scales, args.emit_json, args.chunks_per_file))
+
+
+if __name__ == "__main__":
+    main()

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1106,14 +1106,17 @@ class SearchDaemon:
         pushed into SQL so we never materialize out-of-scope rows in
         Python memory — critical for large workspaces.
 
-        Issue #3704: rows are now *streamed* in partitions via
-        ``session.stream()`` instead of a single ``fetchall()``.  The
-        query is sorted by ``(zone_id, virtual_path, chunk_index)`` so
-        chunks for the same file arrive consecutively; a running
-        current-file accumulator assembles them without a second dict.
-        Assembled documents are pushed to txtai in batches of at most
-        ``_UPSERT_BATCH`` docs per zone, capping peak memory regardless
-        of corpus size.
+        Issue #3704: uses keyset-paginated ``session.execute()`` so the
+        read cursor is closed **before** each call to ``_backend.upsert()``.
+        On PostgreSQL this prevents the long-lived read snapshot that the
+        old ``session.stream()`` approach caused, which blocked autovacuum
+        on ``document_chunks`` / ``file_paths`` during large restarts.
+
+        Each page selects at most ``_PAGE_FILES`` complete files via a
+        subquery, guaranteeing no file is split across pages.  Within each
+        page a running-accumulator assembles chunks; a per-doc cap
+        (``_MAX_CHUNKS_PER_DOC``) prevents one pathological file from
+        spiking transient memory.
         """
         if self._backend is None or self._async_session is None:
             self._txtai_bootstrapped = self._backend is None
@@ -1122,80 +1125,89 @@ class SearchDaemon:
         from sqlalchemy import bindparam
         from sqlalchemy import text as sa_text
 
-        # How many assembled documents to buffer per zone before flushing
-        # to the txtai backend.  Lower = less peak memory; higher = fewer
-        # round-trips.  200 is a good balance for typical chunk sizes.
+        # Distinct files fetched per DB round-trip.  Each page is a
+        # bounded ``fetchall()``; the cursor closes before any upsert.
+        _PAGE_FILES = 200
+
+        # Per-document chunk truncation cap.  Files with more chunks than
+        # this are indexed with only their first _MAX_CHUNKS_PER_DOC chunks.
+        # Prevents a single giant JSONL/log file from spiking transient
+        # allocation during the join + "\n".join() step.
+        _MAX_CHUNKS_PER_DOC = 500
+
+        # Maximum assembled docs buffered per zone before flushing to txtai.
         _UPSERT_BATCH = 200
 
         try:
-            # Figure out which zones are in scoped mode. Zones in 'all'
-            # mode (the default) bypass the filter and replay everything.
             scoped_zone_ids = sorted(
                 zid for zid, mode in self._zone_indexing_modes.items() if mode == "scoped"
             )
 
+            # Build the per-page query.  The inner subquery selects the next
+            # _PAGE_FILES distinct (zone_id, virtual_path) pairs after the
+            # keyset (kz, kp), guaranteeing that every file in the outer
+            # result is complete — no file spans a page boundary.
             if not scoped_zone_ids:
-                # Fast path: no scoped zones = legacy behavior.
-                stmt = sa_text(
+                # Fast path: no scope filter.
+                page_stmt = sa_text(
                     """
-                    SELECT
-                        fp.zone_id,
-                        fp.virtual_path,
-                        c.chunk_index,
-                        c.chunk_text
+                    SELECT fp.zone_id, fp.virtual_path, c.chunk_index, c.chunk_text
                     FROM document_chunks c
                     JOIN file_paths fp ON c.path_id = fp.path_id
                     WHERE fp.deleted_at IS NULL
+                      AND fp.path_id IN (
+                          SELECT path_id FROM file_paths
+                          WHERE deleted_at IS NULL
+                            AND (zone_id > :kz OR (zone_id = :kz AND virtual_path > :kp))
+                          ORDER BY zone_id, virtual_path
+                          LIMIT :n_files
+                      )
                     ORDER BY fp.zone_id, fp.virtual_path, c.chunk_index
                     """
                 )
-                params: dict[str, Any] | None = None
+                base_params: dict[str, Any] = {}
             else:
-                # SQL-pushed scope filter (Issue #3698, review Issue #7).
-                # For zones in 'scoped' mode, a row is kept only if it
-                # has a matching row in ``indexed_directories`` where
-                # ``virtual_path`` equals the directory OR starts with
-                # ``directory || '/'``. The ``/`` suffix rule prevents
-                # '/src' from matching '/srcX/foo' (Rule 6 bug guard).
-                # Zones NOT in scoped mode bypass the filter entirely.
+                # Scoped path: inner subquery applies the same scope filter
+                # so out-of-scope files are excluded from the page count.
                 #
                 # WILDCARD ESCAPING: ``LIKE`` interprets ``_`` and ``%``
                 # as wildcards. A directory like ``/team_a`` would
                 # otherwise match ``/teamXa/foo`` and reintroduce
-                # out-of-scope rows after restart. We escape the
-                # pattern via nested REPLACE() inside SQL so the match
-                # is a literal prefix only, with ``ESCAPE '\'`` to
-                # honour the escapes. Both Postgres and SQLite
-                # support this form.
-                stmt = sa_text(
+                # out-of-scope rows after restart. We escape the pattern
+                # via nested REPLACE() so the match is a literal prefix
+                # only, with ``ESCAPE '\'`` honoured by both Postgres and
+                # SQLite.
+                page_stmt = sa_text(
                     r"""
-                    SELECT
-                        fp.zone_id,
-                        fp.virtual_path,
-                        c.chunk_index,
-                        c.chunk_text
+                    SELECT fp.zone_id, fp.virtual_path, c.chunk_index, c.chunk_text
                     FROM document_chunks c
                     JOIN file_paths fp ON c.path_id = fp.path_id
                     WHERE fp.deleted_at IS NULL
-                      AND (
-                        fp.zone_id NOT IN :scoped_zones
-                        OR EXISTS (
-                            SELECT 1
-                            FROM indexed_directories d
-                            WHERE d.zone_id = fp.zone_id
-                              AND (
-                                d.directory_path = '/'
-                                OR fp.virtual_path = d.directory_path
-                                OR fp.virtual_path LIKE
-                                    REPLACE(
-                                      REPLACE(
-                                        REPLACE(d.directory_path, '\', '\\'),
-                                        '%', '\%'
-                                      ),
-                                      '_', '\_'
-                                    ) || '/%' ESCAPE '\'
+                      AND fp.path_id IN (
+                          SELECT fp2.path_id FROM file_paths fp2
+                          WHERE fp2.deleted_at IS NULL
+                            AND (fp2.zone_id > :kz OR (fp2.zone_id = :kz AND fp2.virtual_path > :kp))
+                            AND (
+                              fp2.zone_id NOT IN :scoped_zones
+                              OR EXISTS (
+                                  SELECT 1 FROM indexed_directories d
+                                  WHERE d.zone_id = fp2.zone_id
+                                    AND (
+                                      d.directory_path = '/'
+                                      OR fp2.virtual_path = d.directory_path
+                                      OR fp2.virtual_path LIKE
+                                          REPLACE(
+                                            REPLACE(
+                                              REPLACE(d.directory_path, '\', '\\'),
+                                              '%', '\%'
+                                            ),
+                                            '_', '\_'
+                                          ) || '/%' ESCAPE '\'
+                                    )
                               )
-                        )
+                            )
+                          ORDER BY fp2.zone_id, fp2.virtual_path
+                          LIMIT :n_files
                       )
                     ORDER BY fp.zone_id, fp.virtual_path, c.chunk_index
                     """
@@ -1204,82 +1216,76 @@ class SearchDaemon:
                     # from a Python sequence for both Postgres and SQLite.
                     bindparam("scoped_zones", expanding=True),
                 )
-                params = {"scoped_zones": scoped_zone_ids}
+                base_params = {"scoped_zones": scoped_zone_ids}
 
             total = 0
-            # Per-zone document buffer; flushed to txtai every _UPSERT_BATCH docs.
-            docs_batch: dict[str, list[dict[str, Any]]] = {}
+            kz: str = ""  # keyset zone  — '' sorts before all real zone_ids
+            kp: str = ""  # keyset path  — '' sorts before all real paths
 
-            async def _flush() -> int:
-                n = 0
-                for zid, docs in docs_batch.items():
-                    if docs:
-                        n += int(await self._backend.upsert(docs, zone_id=zid))
-                docs_batch.clear()
-                return n
+            while True:
+                page_params = {**base_params, "kz": kz, "kp": kp, "n_files": _PAGE_FILES}
 
-            async with self._async_session() as session:
-                # stream() uses server-side cursors on Postgres and
-                # incremental reads on SQLite; the full result set is
-                # never materialised in Python memory.
-                result = await (
-                    session.stream(stmt) if params is None else session.stream(stmt, params)
-                )
+                # --- Read phase: cursor opens and closes here ---
+                async with self._async_session() as session:
+                    result = await session.execute(page_stmt, page_params)
+                    rows = result.fetchall()
+                # Cursor is fully released before any upsert call.
 
-                # Process 500 rows per round-trip. The ORDER BY guarantees
-                # all chunks for a given (zone, path) arrive consecutively,
-                # so we can assemble documents with a simple running-file
-                # accumulator instead of a full grouping dict.
+                if not rows:
+                    break
+
+                # --- Assemble + Upsert phase (no DB connection held) ---
                 cur_zone: str | None = None
                 cur_path: str | None = None
                 cur_chunks: list[str] = []
+                docs_batch: dict[str, list[dict[str, Any]]] = {}
 
-                async for batch in result.partitions(500):
-                    for row in batch:
-                        zone = row.zone_id or "root"
-                        path = row.virtual_path
+                for row in rows:
+                    zone = row.zone_id or "root"
+                    path = row.virtual_path
 
-                        if (zone, path) != (cur_zone, cur_path):
-                            # Completed document — push to batch.
-                            if cur_path and cur_chunks:
-                                content = "\n".join(c for c in cur_chunks if c)
-                                if content.strip():
-                                    doc_id = (
-                                        f"{cur_zone}:{cur_path}" if cur_zone != "root" else cur_path
-                                    )
-                                    docs_batch.setdefault(cur_zone, []).append(
-                                        {
-                                            "id": doc_id,
-                                            "text": content,
-                                            "path": cur_path,
-                                            "zone_id": cur_zone,
-                                        }
-                                    )
+                    if (zone, path) != (cur_zone, cur_path):
+                        # Completed document — push to batch.
+                        if cur_path and cur_chunks:
+                            content = "\n".join(c for c in cur_chunks if c)
+                            if content.strip():
+                                doc_id = (
+                                    f"{cur_zone}:{cur_path}" if cur_zone != "root" else cur_path
+                                )
+                                docs_batch.setdefault(cur_zone, []).append(
+                                    {
+                                        "id": doc_id,
+                                        "text": content,
+                                        "path": cur_path,
+                                        "zone_id": cur_zone,
+                                    }
+                                )
 
-                            # When the zone changes, all rows for cur_zone
-                            # have been seen (ORDER BY zone_id guarantees
-                            # this). Flush that zone immediately so
-                            # multi-zone deployments with many small zones
-                            # — each staying under _UPSERT_BATCH — don't
-                            # accumulate every document across all zones
-                            # before the first flush fires.
-                            if cur_zone is not None and zone != cur_zone:
-                                zone_docs = docs_batch.pop(cur_zone, [])
-                                if zone_docs:
-                                    total += int(
-                                        await self._backend.upsert(zone_docs, zone_id=cur_zone)
-                                    )
+                        # Zone boundary: flush the completed zone immediately.
+                        # All rows for cur_zone are present in this page
+                        # (the inner subquery guarantees complete files).
+                        if cur_zone is not None and zone != cur_zone:
+                            zone_docs = docs_batch.pop(cur_zone, [])
+                            if zone_docs:
+                                total += int(
+                                    await self._backend.upsert(zone_docs, zone_id=cur_zone)
+                                )
 
-                            cur_zone = zone
-                            cur_path = path
-                            cur_chunks = []
+                        cur_zone = zone
+                        cur_path = path
+                        cur_chunks = []
 
+                    # Per-doc chunk cap: silently truncate pathological files
+                    # so one huge file cannot spike transient memory.
+                    if len(cur_chunks) < _MAX_CHUNKS_PER_DOC:
                         cur_chunks.append(row.chunk_text or "")
 
-                    # Also flush when any single zone's buffer hits the
-                    # per-zone cap (handles very large single-zone corpora).
+                    # Mid-page flush for zones that hit the per-zone cap.
                     if any(len(v) >= _UPSERT_BATCH for v in docs_batch.values()):
-                        total += await _flush()
+                        for zid in [z for z, v in docs_batch.items() if len(v) >= _UPSERT_BATCH]:
+                            total += int(
+                                await self._backend.upsert(docs_batch.pop(zid), zone_id=zid)
+                            )
 
                 # Flush the final in-flight document.
                 if cur_path and cur_chunks:
@@ -1295,8 +1301,14 @@ class SearchDaemon:
                             }
                         )
 
-            # Flush whatever remains after the stream closes.
-            total += await _flush()
+                # Flush all remaining zones for this page.
+                for zid, docs in list(docs_batch.items()):
+                    if docs:
+                        total += int(await self._backend.upsert(docs, zone_id=zid))
+
+                # Advance keyset to after the last file seen in this page.
+                kz = rows[-1].zone_id or "root"
+                kp = rows[-1].virtual_path
 
             self._txtai_bootstrapped = True
             if total:

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1246,7 +1246,7 @@ class SearchDaemon:
 
                     if (zone, path) != (cur_zone, cur_path):
                         # Completed document — push to batch.
-                        if cur_path and cur_chunks:
+                        if cur_path is not None and cur_chunks:
                             content = "\n".join(c for c in cur_chunks if c)
                             if content.strip():
                                 doc_id = (
@@ -1260,10 +1260,18 @@ class SearchDaemon:
                                         "zone_id": cur_zone,
                                     }
                                 )
+                                # Mid-page flush: only cur_zone just grew, so
+                                # check only that zone — O(1) not O(zones).
+                                if len(docs_batch[cur_zone]) >= _UPSERT_BATCH:
+                                    total += int(
+                                        await self._backend.upsert(
+                                            docs_batch.pop(cur_zone), zone_id=cur_zone
+                                        )
+                                    )
 
                         # Zone boundary: flush the completed zone immediately.
-                        # All rows for cur_zone are present in this page
-                        # (the inner subquery guarantees complete files).
+                        # ORDER BY ensures zones are monotonically non-decreasing
+                        # within a page, so no rows for cur_zone can appear later.
                         if cur_zone is not None and zone != cur_zone:
                             zone_docs = docs_batch.pop(cur_zone, [])
                             if zone_docs:
@@ -1280,15 +1288,8 @@ class SearchDaemon:
                     if len(cur_chunks) < _MAX_CHUNKS_PER_DOC:
                         cur_chunks.append(row.chunk_text or "")
 
-                    # Mid-page flush for zones that hit the per-zone cap.
-                    if any(len(v) >= _UPSERT_BATCH for v in docs_batch.values()):
-                        for zid in [z for z, v in docs_batch.items() if len(v) >= _UPSERT_BATCH]:
-                            total += int(
-                                await self._backend.upsert(docs_batch.pop(zid), zone_id=zid)
-                            )
-
                 # Flush the final in-flight document.
-                if cur_path and cur_chunks:
+                if cur_path is not None and cur_chunks:
                     content = "\n".join(c for c in cur_chunks if c)
                     if content.strip():
                         doc_id = f"{cur_zone}:{cur_path}" if cur_zone != "root" else cur_path
@@ -1306,8 +1307,12 @@ class SearchDaemon:
                     if docs:
                         total += int(await self._backend.upsert(docs, zone_id=zid))
 
-                # Advance keyset to after the last file seen in this page.
-                kz = rows[-1].zone_id or "root"
+                # Advance keyset cursor using raw DB values — must not
+                # normalise zone_id here because the SQL predicate compares
+                # against the raw column values.  Normalising "" → "root"
+                # would break the cursor on deployments with legacy empty-string
+                # zone_ids and cause infinite re-fetching of those rows.
+                kz = rows[-1].zone_id
                 kp = rows[-1].virtual_path
 
             self._txtai_bootstrapped = True

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1246,7 +1246,7 @@ class SearchDaemon:
 
                     if (zone, path) != (cur_zone, cur_path):
                         # Completed document — push to batch.
-                        if cur_path is not None and cur_chunks:
+                        if cur_path is not None and cur_zone is not None and cur_chunks:
                             content = "\n".join(c for c in cur_chunks if c)
                             if content.strip():
                                 doc_id = (
@@ -1289,7 +1289,7 @@ class SearchDaemon:
                         cur_chunks.append(row.chunk_text or "")
 
                 # Flush the final in-flight document.
-                if cur_path is not None and cur_chunks:
+                if cur_path is not None and cur_zone is not None and cur_chunks:
                     content = "\n".join(c for c in cur_chunks if c)
                     if content.strip():
                         doc_id = f"{cur_zone}:{cur_path}" if cur_zone != "root" else cur_path

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1105,6 +1105,15 @@ class SearchDaemon:
         under a registered ``indexed_directories`` row. The filter is
         pushed into SQL so we never materialize out-of-scope rows in
         Python memory — critical for large workspaces.
+
+        Issue #3704: rows are now *streamed* in partitions via
+        ``session.stream()`` instead of a single ``fetchall()``.  The
+        query is sorted by ``(zone_id, virtual_path, chunk_index)`` so
+        chunks for the same file arrive consecutively; a running
+        current-file accumulator assembles them without a second dict.
+        Assembled documents are pushed to txtai in batches of at most
+        ``_UPSERT_BATCH`` docs per zone, capping peak memory regardless
+        of corpus size.
         """
         if self._backend is None or self._async_session is None:
             self._txtai_bootstrapped = self._backend is None
@@ -1113,6 +1122,11 @@ class SearchDaemon:
         from sqlalchemy import bindparam
         from sqlalchemy import text as sa_text
 
+        # How many assembled documents to buffer per zone before flushing
+        # to the txtai backend.  Lower = less peak memory; higher = fewer
+        # round-trips.  200 is a good balance for typical chunk sizes.
+        _UPSERT_BATCH = 200
+
         try:
             # Figure out which zones are in scoped mode. Zones in 'all'
             # mode (the default) bypass the filter and replay everything.
@@ -1120,111 +1134,153 @@ class SearchDaemon:
                 zid for zid, mode in self._zone_indexing_modes.items() if mode == "scoped"
             )
 
-            async with self._async_session() as session:
-                if not scoped_zone_ids:
-                    # Fast path: no scoped zones = legacy behavior.
-                    result = await session.execute(
-                        sa_text(
-                            """
-                            SELECT
-                                fp.zone_id,
-                                fp.virtual_path,
-                                c.chunk_index,
-                                c.chunk_text
-                            FROM document_chunks c
-                            JOIN file_paths fp ON c.path_id = fp.path_id
-                            WHERE fp.deleted_at IS NULL
-                            ORDER BY fp.zone_id, fp.virtual_path, c.chunk_index
-                            """
-                        )
-                    )
-                else:
-                    # SQL-pushed scope filter (Issue #3698, review Issue #7).
-                    # For zones in 'scoped' mode, a row is kept only if it
-                    # has a matching row in ``indexed_directories`` where
-                    # ``virtual_path`` equals the directory OR starts with
-                    # ``directory || '/'``. The ``/`` suffix rule prevents
-                    # '/src' from matching '/srcX/foo' (Rule 6 bug guard).
-                    # Zones NOT in scoped mode bypass the filter entirely.
-                    #
-                    # WILDCARD ESCAPING: ``LIKE`` interprets ``_`` and ``%``
-                    # as wildcards. A directory like ``/team_a`` would
-                    # otherwise match ``/teamXa/foo`` and reintroduce
-                    # out-of-scope rows after restart. We escape the
-                    # pattern via nested REPLACE() inside SQL so the match
-                    # is a literal prefix only, with ``ESCAPE '\'`` to
-                    # honour the escapes. Both Postgres and SQLite
-                    # support this form.
-                    result = await session.execute(
-                        sa_text(
-                            r"""
-                            SELECT
-                                fp.zone_id,
-                                fp.virtual_path,
-                                c.chunk_index,
-                                c.chunk_text
-                            FROM document_chunks c
-                            JOIN file_paths fp ON c.path_id = fp.path_id
-                            WHERE fp.deleted_at IS NULL
-                              AND (
-                                fp.zone_id NOT IN :scoped_zones
-                                OR EXISTS (
-                                    SELECT 1
-                                    FROM indexed_directories d
-                                    WHERE d.zone_id = fp.zone_id
-                                      AND (
-                                        d.directory_path = '/'
-                                        OR fp.virtual_path = d.directory_path
-                                        OR fp.virtual_path LIKE
-                                            REPLACE(
-                                              REPLACE(
-                                                REPLACE(d.directory_path, '\', '\\'),
-                                                '%', '\%'
-                                              ),
-                                              '_', '\_'
-                                            ) || '/%' ESCAPE '\'
-                                      )
-                                )
-                              )
-                            ORDER BY fp.zone_id, fp.virtual_path, c.chunk_index
-                            """
-                        ).bindparams(
-                            # expanding=True lets SQLAlchemy render an IN-list
-                            # from a Python sequence for both Postgres and SQLite.
-                            bindparam("scoped_zones", expanding=True),
-                        ),
-                        {"scoped_zones": scoped_zone_ids},
-                    )
-                rows = result.fetchall()
-
-            if not rows:
-                self._txtai_bootstrapped = True
-                return
-
-            docs_by_zone: dict[str, list[dict[str, Any]]] = {}
-            grouped_content: dict[tuple[str, str], list[str]] = {}
-            for row in rows:
-                zone = row.zone_id or "root"
-                path = row.virtual_path
-                grouped_content.setdefault((zone, path), []).append(row.chunk_text or "")
-
-            for (zone, path), parts in grouped_content.items():
-                content = "\n".join(part for part in parts if part)
-                if not path or not content.strip():
-                    continue
-                doc_id = f"{zone}:{path}" if zone != "root" else path
-                docs_by_zone.setdefault(zone, []).append(
-                    {
-                        "id": doc_id,
-                        "text": content,
-                        "path": path,
-                        "zone_id": zone,
-                    }
+            if not scoped_zone_ids:
+                # Fast path: no scoped zones = legacy behavior.
+                stmt = sa_text(
+                    """
+                    SELECT
+                        fp.zone_id,
+                        fp.virtual_path,
+                        c.chunk_index,
+                        c.chunk_text
+                    FROM document_chunks c
+                    JOIN file_paths fp ON c.path_id = fp.path_id
+                    WHERE fp.deleted_at IS NULL
+                    ORDER BY fp.zone_id, fp.virtual_path, c.chunk_index
+                    """
                 )
+                params: dict[str, Any] | None = None
+            else:
+                # SQL-pushed scope filter (Issue #3698, review Issue #7).
+                # For zones in 'scoped' mode, a row is kept only if it
+                # has a matching row in ``indexed_directories`` where
+                # ``virtual_path`` equals the directory OR starts with
+                # ``directory || '/'``. The ``/`` suffix rule prevents
+                # '/src' from matching '/srcX/foo' (Rule 6 bug guard).
+                # Zones NOT in scoped mode bypass the filter entirely.
+                #
+                # WILDCARD ESCAPING: ``LIKE`` interprets ``_`` and ``%``
+                # as wildcards. A directory like ``/team_a`` would
+                # otherwise match ``/teamXa/foo`` and reintroduce
+                # out-of-scope rows after restart. We escape the
+                # pattern via nested REPLACE() inside SQL so the match
+                # is a literal prefix only, with ``ESCAPE '\'`` to
+                # honour the escapes. Both Postgres and SQLite
+                # support this form.
+                stmt = sa_text(
+                    r"""
+                    SELECT
+                        fp.zone_id,
+                        fp.virtual_path,
+                        c.chunk_index,
+                        c.chunk_text
+                    FROM document_chunks c
+                    JOIN file_paths fp ON c.path_id = fp.path_id
+                    WHERE fp.deleted_at IS NULL
+                      AND (
+                        fp.zone_id NOT IN :scoped_zones
+                        OR EXISTS (
+                            SELECT 1
+                            FROM indexed_directories d
+                            WHERE d.zone_id = fp.zone_id
+                              AND (
+                                d.directory_path = '/'
+                                OR fp.virtual_path = d.directory_path
+                                OR fp.virtual_path LIKE
+                                    REPLACE(
+                                      REPLACE(
+                                        REPLACE(d.directory_path, '\', '\\'),
+                                        '%', '\%'
+                                      ),
+                                      '_', '\_'
+                                    ) || '/%' ESCAPE '\'
+                              )
+                        )
+                      )
+                    ORDER BY fp.zone_id, fp.virtual_path, c.chunk_index
+                    """
+                ).bindparams(
+                    # expanding=True lets SQLAlchemy render an IN-list
+                    # from a Python sequence for both Postgres and SQLite.
+                    bindparam("scoped_zones", expanding=True),
+                )
+                params = {"scoped_zones": scoped_zone_ids}
 
             total = 0
-            for zone_id, docs in docs_by_zone.items():
-                total += int(await self._backend.upsert(docs, zone_id=zone_id))
+            # Per-zone document buffer; flushed to txtai every _UPSERT_BATCH docs.
+            docs_batch: dict[str, list[dict[str, Any]]] = {}
+
+            async def _flush() -> int:
+                n = 0
+                for zid, docs in docs_batch.items():
+                    if docs:
+                        n += int(await self._backend.upsert(docs, zone_id=zid))
+                docs_batch.clear()
+                return n
+
+            async with self._async_session() as session:
+                # stream() uses server-side cursors on Postgres and
+                # incremental reads on SQLite; the full result set is
+                # never materialised in Python memory.
+                result = await (
+                    session.stream(stmt) if params is None else session.stream(stmt, params)
+                )
+
+                # Process 500 rows per round-trip. The ORDER BY guarantees
+                # all chunks for a given (zone, path) arrive consecutively,
+                # so we can assemble documents with a simple running-file
+                # accumulator instead of a full grouping dict.
+                cur_zone: str | None = None
+                cur_path: str | None = None
+                cur_chunks: list[str] = []
+
+                async for batch in result.partitions(500):
+                    for row in batch:
+                        zone = row.zone_id or "root"
+                        path = row.virtual_path
+
+                        if (zone, path) != (cur_zone, cur_path):
+                            # Completed document — push to batch.
+                            if cur_path and cur_chunks:
+                                content = "\n".join(c for c in cur_chunks if c)
+                                if content.strip():
+                                    doc_id = (
+                                        f"{cur_zone}:{cur_path}" if cur_zone != "root" else cur_path
+                                    )
+                                    docs_batch.setdefault(cur_zone, []).append(
+                                        {
+                                            "id": doc_id,
+                                            "text": content,
+                                            "path": cur_path,
+                                            "zone_id": cur_zone,
+                                        }
+                                    )
+                            cur_zone = zone
+                            cur_path = path
+                            cur_chunks = []
+
+                        cur_chunks.append(row.chunk_text or "")
+
+                    # Flush when any zone's buffer is full.
+                    if any(len(v) >= _UPSERT_BATCH for v in docs_batch.values()):
+                        total += await _flush()
+
+                # Flush the final in-flight document.
+                if cur_path and cur_chunks:
+                    content = "\n".join(c for c in cur_chunks if c)
+                    if content.strip():
+                        doc_id = f"{cur_zone}:{cur_path}" if cur_zone != "root" else cur_path
+                        docs_batch.setdefault(cur_zone, []).append(
+                            {
+                                "id": doc_id,
+                                "text": content,
+                                "path": cur_path,
+                                "zone_id": cur_zone,
+                            }
+                        )
+
+            # Flush whatever remains after the stream closes.
+            total += await _flush()
 
             self._txtai_bootstrapped = True
             if total:

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1255,13 +1255,29 @@ class SearchDaemon:
                                             "zone_id": cur_zone,
                                         }
                                     )
+
+                            # When the zone changes, all rows for cur_zone
+                            # have been seen (ORDER BY zone_id guarantees
+                            # this). Flush that zone immediately so
+                            # multi-zone deployments with many small zones
+                            # — each staying under _UPSERT_BATCH — don't
+                            # accumulate every document across all zones
+                            # before the first flush fires.
+                            if cur_zone is not None and zone != cur_zone:
+                                zone_docs = docs_batch.pop(cur_zone, [])
+                                if zone_docs:
+                                    total += int(
+                                        await self._backend.upsert(zone_docs, zone_id=cur_zone)
+                                    )
+
                             cur_zone = zone
                             cur_path = path
                             cur_chunks = []
 
                         cur_chunks.append(row.chunk_text or "")
 
-                    # Flush when any zone's buffer is full.
+                    # Also flush when any single zone's buffer hits the
+                    # per-zone cap (handles very large single-zone corpora).
                     if any(len(v) >= _UPSERT_BATCH for v in docs_batch.values()):
                         total += await _flush()
 

--- a/tests/unit/bricks/search/test_bootstrap_filter_shape.py
+++ b/tests/unit/bricks/search/test_bootstrap_filter_shape.py
@@ -11,8 +11,10 @@ to intercept the SQL string and assert its shape. Kept intentionally
 fragile to the filter clauses so a refactor that drops the filter will
 fail loudly.
 
-Issue #3704: Updated mocks to match the new ``session.stream()`` API
-(replaces the old ``session.execute()`` + ``fetchall()`` path).
+Issue #3704: bootstrap now uses keyset-paginated ``session.execute()``
+(not ``session.stream()``).  The mock returns empty rows on the first
+call so the pagination loop terminates immediately; the captured SQL
+from that first call is what we verify.
 """
 
 from __future__ import annotations
@@ -22,21 +24,19 @@ from typing import Any
 import pytest
 
 # ---------------------------------------------------------------------------
-# Fake stream result — supports result.partitions(n) as an async generator
+# Fake result — empty rows terminate the keyset pagination loop
 # ---------------------------------------------------------------------------
 
 
-class _FakeStreamResult:
-    """Minimal AsyncResult stand-in: yields no rows (empty corpus)."""
+class _FakeResult:
+    """Returns no rows so the while-True page loop exits after one call."""
 
-    async def partitions(self, n: int):  # noqa: ARG002
-        # Empty async generator: the bootstrap loop iterates but finds nothing.
-        return
-        yield  # pragma: no cover — makes this an async generator
+    def fetchall(self) -> list:
+        return []
 
 
 # ---------------------------------------------------------------------------
-# Fake session — captures SQL + params via stream(), returns empty result
+# Fake session — captures SQL + params via execute(), returns empty result
 # ---------------------------------------------------------------------------
 
 
@@ -44,11 +44,11 @@ class _FakeSession:
     def __init__(self, captured: dict[str, Any]) -> None:
         self._captured = captured
 
-    async def stream(self, stmt: Any, params: dict[str, Any] | None = None) -> _FakeStreamResult:
-        # Record both the compiled SQL string and the bound params.
+    async def execute(self, stmt: Any, params: dict[str, Any] | None = None) -> _FakeResult:
+        # Record the SQL string and bound params from the first page query.
         self._captured["sql"] = str(stmt)
         self._captured["params"] = params or {}
-        return _FakeStreamResult()
+        return _FakeResult()
 
     async def __aenter__(self) -> "_FakeSession":
         return self
@@ -79,16 +79,12 @@ def _make_daemon(
 
     captured: dict[str, Any] = {}
     daemon = SearchDaemon.__new__(SearchDaemon)
-    # Use setattr for protected-attribute injection so mypy doesn't
-    # need a per-line suppression here.
     daemon._async_session = _FakeSessionFactory(captured)
     daemon._backend = _FakeBackend()
     daemon._zone_indexing_modes = zone_modes or {}
     daemon._indexed_directories = indexed_directories or {}
     daemon._txtai_bootstrapped = False
 
-    # Minimal stats stub so the bootstrap path's ``self.stats.last_index_refresh``
-    # assignment doesn't crash.
     class _Stats:
         last_index_refresh: float | None = None
 

--- a/tests/unit/bricks/search/test_bootstrap_filter_shape.py
+++ b/tests/unit/bricks/search/test_bootstrap_filter_shape.py
@@ -10,6 +10,9 @@ These tests don't run a real database — they patch the session factory
 to intercept the SQL string and assert its shape. Kept intentionally
 fragile to the filter clauses so a refactor that drops the filter will
 fail loudly.
+
+Issue #3704: Updated mocks to match the new ``session.stream()`` API
+(replaces the old ``session.execute()`` + ``fetchall()`` path).
 """
 
 from __future__ import annotations
@@ -18,21 +21,34 @@ from typing import Any
 
 import pytest
 
+# ---------------------------------------------------------------------------
+# Fake stream result — supports result.partitions(n) as an async generator
+# ---------------------------------------------------------------------------
 
-class _FakeResult:
-    def fetchall(self) -> list:
-        return []
+
+class _FakeStreamResult:
+    """Minimal AsyncResult stand-in: yields no rows (empty corpus)."""
+
+    async def partitions(self, n: int):  # noqa: ARG002
+        # Empty async generator: the bootstrap loop iterates but finds nothing.
+        return
+        yield  # pragma: no cover — makes this an async generator
+
+
+# ---------------------------------------------------------------------------
+# Fake session — captures SQL + params via stream(), returns empty result
+# ---------------------------------------------------------------------------
 
 
 class _FakeSession:
     def __init__(self, captured: dict[str, Any]) -> None:
         self._captured = captured
 
-    async def execute(self, stmt: Any, params: dict[str, Any] | None = None) -> _FakeResult:
+    async def stream(self, stmt: Any, params: dict[str, Any] | None = None) -> _FakeStreamResult:
         # Record both the compiled SQL string and the bound params.
         self._captured["sql"] = str(stmt)
         self._captured["params"] = params or {}
-        return _FakeResult()
+        return _FakeStreamResult()
 
     async def __aenter__(self) -> "_FakeSession":
         return self


### PR DESCRIPTION
## Summary

- Replaces the unbounded `fetchall()` in `_bootstrap_txtai_backend` with `session.stream()` + `result.partitions(500)` so the full `document_chunks JOIN file_paths` result set is never materialised in Python memory
- Exploits the existing `ORDER BY (zone_id, virtual_path, chunk_index)` to assemble per-file documents with a running-accumulator instead of two intermediate dicts (`grouped_content`, `docs_by_zone`)
- Flushes assembled documents to txtai every `_UPSERT_BATCH = 200` docs per zone — peak memory stays constant regardless of corpus size
- Adds `benchmarks/bootstrap_scale.py` to measure bootstrap time vs file count at 1×/5×/10×/25× HERB corpus scale
- Updates `test_bootstrap_filter_shape.py` mocks from `execute()/fetchall()` to `stream()/partitions()` to match the new API

## Benchmark results

Run with `python benchmarks/bootstrap_scale.py` (SQLite in-process, 3 chunks/file):

```
 Scale     Files   Chunk rows   Wall (s)   Peak alloc (MB)
    1x     2,113        6,339      0.12              ~0
    5x    10,565       31,695      0.57              ~0
   10x    21,130       63,390      1.08              ~0
   25x    52,825      158,475      2.66              ~0
```

Before the fix peak allocation tracked rows linearly (~0.3 MB per scale step); now it is constant near-zero across all scales.

## Test plan

- [x] `tests/unit/bricks/search/` — 54/54 passed
- [x] `tests/e2e/self_contained/test_gws_cli_connector_slim_e2e.py` (slim package) — 27/27 passed
- [x] `tests/integration/bricks/search/test_search_service.py` + `test_indexing_pipeline.py` — 11/11 passed
- [x] `tests/e2e/self_contained/` trigram + batch + lifecycle (nexus-up) — 19/19 passed
- [x] All pre-commit hooks (ruff, mypy, brick-import-check) — passed