### PR TITLE
feat(#3723): credential pool with multi-account failover + failure-reason enum

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -602,6 +602,7 @@ disable_error_code = ["no-any-return"]
 module = [
     "nexus.server.auth.oidc",
     "nexus.bricks.auth.providers.oidc",
+    "nexus.bricks.auth.classifiers.google",
 ]
 # requests stubs
 disable_error_code = ["import-untyped"]

--- a/src/nexus/backends/compute/openai_compatible.py
+++ b/src/nexus/backends/compute/openai_compatible.py
@@ -389,24 +389,58 @@ class CASOpenAIBackend(CASAddressingEngine):
         messages = request["messages"]
         extra_params = {k: v for k, v in request.items() if k not in ("model", "messages")}
 
-        # Pool-based credential selection (Issue #3723).
-        # select_sync() is used here because generate_streaming() is a sync
-        # generator executed inside a thread-pool executor (_producer thread).
-        # When no pool is configured, fall back to the single pre-built client.
-        _pool_profile = None
+        # Pool-based credential selection with pre-first-token failover (Issue #3723).
+        # execute_sync() opens the stream inside a select+retry wrapper: if the
+        # initial API call fails with a retriable reason (RATE_LIMIT, OVERLOADED,
+        # TIMEOUT) before any bytes are emitted, the pool marks the profile on
+        # cooldown and retries with the next available credential automatically.
+        # Mid-stream failures (after the first byte) cannot be retried; they call
+        # mark_failure directly and re-raise. When no pool is configured, fall back
+        # to the single pre-built client (no change from pre-#3723 behaviour).
+        _pool_profile: "AuthProfile | None" = None
+
         if self._pool is not None:
             from nexus.bricks.auth.classifiers.openai import classify_openai_error
-            from nexus.bricks.auth.profile import ApiKeyCredential
+            from nexus.bricks.auth.profile import ApiKeyCredential, AuthProfile
 
-            _pool_profile = self._pool.select_sync()
-            key = (
-                _pool_profile.credential.key
-                if isinstance(_pool_profile.credential, ApiKeyCredential)
-                else self._api_key
-            )
-            client = _build_openai_client(self._base_url, key, self._timeout)
+            def _open_stream(profile: AuthProfile):
+                nonlocal _pool_profile
+                _pool_profile = profile  # capture so mid-stream failures can mark it
+                _key = (
+                    profile.credential.key
+                    if isinstance(profile.credential, ApiKeyCredential)
+                    else self._api_key
+                )
+                _client = _build_openai_client(self._base_url, _key, self._timeout)
+                return _client.chat.completions.create(
+                    model=model,
+                    messages=messages,
+                    stream=True,
+                    stream_options={"include_usage": True},
+                    **extra_params,
+                )
+
+            try:
+                stream = self._pool.execute_sync(_open_stream, classify_openai_error)
+            except Exception as e:
+                raise BackendError(
+                    f"LLM API call failed: {e}",
+                    backend="openai_compatible",
+                ) from e
         else:
-            client = self._client
+            try:
+                stream = self._client.chat.completions.create(
+                    model=model,
+                    messages=messages,
+                    stream=True,
+                    stream_options={"include_usage": True},
+                    **extra_params,
+                )
+            except Exception as e:
+                raise BackendError(
+                    f"LLM API call failed: {e}",
+                    backend="openai_compatible",
+                ) from e
 
         start_time = time.perf_counter()
         collected_model = model
@@ -417,25 +451,6 @@ class CASOpenAIBackend(CASAddressingEngine):
         # OpenAI streams tool_calls incrementally: each chunk carries an index
         # and a partial function name or arguments fragment that must be concatenated.
         tool_calls_accum: dict[int, dict[str, Any]] = {}
-
-        _stream_succeeded = False
-        try:
-            stream = client.chat.completions.create(
-                model=model,
-                messages=messages,
-                stream=True,
-                stream_options={"include_usage": True},
-                **extra_params,
-            )
-        except Exception as e:
-            if _pool_profile is not None and self._pool is not None:
-                from nexus.bricks.auth.classifiers.openai import classify_openai_error
-
-                self._pool.mark_failure(_pool_profile, classify_openai_error(e))
-            raise BackendError(
-                f"LLM API call failed: {e}",
-                backend="openai_compatible",
-            ) from e
 
         try:
             for chunk in stream:
@@ -494,7 +509,6 @@ class CASOpenAIBackend(CASAddressingEngine):
                 backend="openai_compatible",
             ) from e
 
-        _stream_succeeded = True
         elapsed_ms = (time.perf_counter() - start_time) * 1000
 
         # Build sorted tool_calls list from accumulated fragments
@@ -513,13 +527,6 @@ class CASOpenAIBackend(CASAddressingEngine):
                 "tool_calls": tool_calls,
             },
         )
-
-        # Mark pool success after generator is fully exhausted (after final yield).
-        # This runs when the caller's for-loop completes and the generator reaches
-        # its natural end. _stream_succeeded guards against marking success on a
-        # generator that was .close()d early.
-        if _stream_succeeded and _pool_profile is not None and self._pool is not None:
-            self._pool.mark_success(_pool_profile)
 
     # ------------------------------------------------------------------
     # CAS persistence — session envelope storage

--- a/src/nexus/backends/compute/openai_compatible.py
+++ b/src/nexus/backends/compute/openai_compatible.py
@@ -44,6 +44,7 @@ from nexus.contracts.exceptions import BackendError
 from nexus.core.object_store import WriteResult
 
 if TYPE_CHECKING:
+    from nexus.bricks.auth.credential_pool import CredentialPool
     from nexus.contracts.types import OperationContext
     from nexus.core.nexus_fs import NexusFS
 
@@ -136,12 +137,20 @@ class CASOpenAIBackend(CASAddressingEngine):
         api_key: str = "",
         default_model: str = "gpt-4o",
         timeout: float = 120.0,
+        pool: "CredentialPool | None" = None,
     ) -> None:
         self._base_url = base_url
         self._api_key = api_key
         self._default_model = default_model
+        self._timeout = timeout
 
-        # Build OpenAI client (lazy import)
+        # Optional credential pool for multi-key failover (Issue #3723).
+        # When set, generate_streaming() selects an API key from the pool each
+        # call and rotates on 429 / overload errors.
+        # When None (default), falls back to the single api_key (no change in behaviour).
+        self._pool: CredentialPool | None = pool
+
+        # Build OpenAI client (lazy import). Used when pool is None.
         self._client = _build_openai_client(base_url, api_key, timeout)
 
         # In-memory transport for CAS blobs
@@ -380,6 +389,25 @@ class CASOpenAIBackend(CASAddressingEngine):
         messages = request["messages"]
         extra_params = {k: v for k, v in request.items() if k not in ("model", "messages")}
 
+        # Pool-based credential selection (Issue #3723).
+        # select_sync() is used here because generate_streaming() is a sync
+        # generator executed inside a thread-pool executor (_producer thread).
+        # When no pool is configured, fall back to the single pre-built client.
+        _pool_profile = None
+        if self._pool is not None:
+            from nexus.bricks.auth.classifiers.openai import classify_openai_error
+            from nexus.bricks.auth.profile import ApiKeyCredential
+
+            _pool_profile = self._pool.select_sync()
+            key = (
+                _pool_profile.credential.key
+                if isinstance(_pool_profile.credential, ApiKeyCredential)
+                else self._api_key
+            )
+            client = _build_openai_client(self._base_url, key, self._timeout)
+        else:
+            client = self._client
+
         start_time = time.perf_counter()
         collected_model = model
         usage: dict[str, int] = {}
@@ -390,8 +418,9 @@ class CASOpenAIBackend(CASAddressingEngine):
         # and a partial function name or arguments fragment that must be concatenated.
         tool_calls_accum: dict[int, dict[str, Any]] = {}
 
+        _stream_succeeded = False
         try:
-            stream = self._client.chat.completions.create(
+            stream = client.chat.completions.create(
                 model=model,
                 messages=messages,
                 stream=True,
@@ -399,6 +428,10 @@ class CASOpenAIBackend(CASAddressingEngine):
                 **extra_params,
             )
         except Exception as e:
+            if _pool_profile is not None and self._pool is not None:
+                from nexus.bricks.auth.classifiers.openai import classify_openai_error
+
+                self._pool.mark_failure(_pool_profile, classify_openai_error(e))
             raise BackendError(
                 f"LLM API call failed: {e}",
                 backend="openai_compatible",
@@ -452,11 +485,16 @@ class CASOpenAIBackend(CASAddressingEngine):
                         "total_tokens": chunk.usage.total_tokens or 0,
                     }
         except Exception as e:
+            if _pool_profile is not None and self._pool is not None:
+                from nexus.bricks.auth.classifiers.openai import classify_openai_error
+
+                self._pool.mark_failure(_pool_profile, classify_openai_error(e))
             raise BackendError(
                 f"LLM streaming failed: {e}",
                 backend="openai_compatible",
             ) from e
 
+        _stream_succeeded = True
         elapsed_ms = (time.perf_counter() - start_time) * 1000
 
         # Build sorted tool_calls list from accumulated fragments
@@ -475,6 +513,13 @@ class CASOpenAIBackend(CASAddressingEngine):
                 "tool_calls": tool_calls,
             },
         )
+
+        # Mark pool success after generator is fully exhausted (after final yield).
+        # This runs when the caller's for-loop completes and the generator reaches
+        # its natural end. _stream_succeeded guards against marking success on a
+        # generator that was .close()d early.
+        if _stream_succeeded and _pool_profile is not None and self._pool is not None:
+            self._pool.mark_success(_pool_profile)
 
     # ------------------------------------------------------------------
     # CAS persistence — session envelope storage

--- a/src/nexus/backends/compute/openai_compatible.py
+++ b/src/nexus/backends/compute/openai_compatible.py
@@ -44,7 +44,6 @@ from nexus.contracts.exceptions import BackendError
 from nexus.core.object_store import WriteResult
 
 if TYPE_CHECKING:
-    from nexus.bricks.auth.credential_pool import CredentialPool
     from nexus.contracts.types import OperationContext
     from nexus.core.nexus_fs import NexusFS
 
@@ -137,7 +136,8 @@ class CASOpenAIBackend(CASAddressingEngine):
         api_key: str = "",
         default_model: str = "gpt-4o",
         timeout: float = 120.0,
-        pool: "CredentialPool | None" = None,
+        pool: Any = None,
+        pool_classifier: Any = None,
     ) -> None:
         self._base_url = base_url
         self._api_key = api_key
@@ -145,10 +145,12 @@ class CASOpenAIBackend(CASAddressingEngine):
         self._timeout = timeout
 
         # Optional credential pool for multi-key failover (Issue #3723).
-        # When set, generate_streaming() selects an API key from the pool each
-        # call and rotates on 429 / overload errors.
-        # When None (default), falls back to the single api_key (no change in behaviour).
-        self._pool: CredentialPool | None = pool
+        # pool: CredentialPool | None — injected as Any to avoid a bricks→backends
+        # import-layer violation (nexus.backends is below nexus.bricks in the tier stack).
+        # pool_classifier: CredentialErrorClassifier callable (e.g. classify_openai_error),
+        # also injected to keep nexus.bricks.auth imports out of this module.
+        self._pool: Any = pool
+        self._pool_classifier: Any = pool_classifier
 
         # Build OpenAI client (lazy import). Used when pool is None.
         self._client = _build_openai_client(base_url, api_key, timeout)
@@ -397,20 +399,17 @@ class CASOpenAIBackend(CASAddressingEngine):
         # Mid-stream failures (after the first byte) cannot be retried; they call
         # mark_failure directly and re-raise. When no pool is configured, fall back
         # to the single pre-built client (no change from pre-#3723 behaviour).
-        _pool_profile: "AuthProfile | None" = None
+        _pool_profile: Any = None
 
         if self._pool is not None:
-            from nexus.bricks.auth.classifiers.openai import classify_openai_error
-            from nexus.bricks.auth.profile import ApiKeyCredential, AuthProfile
 
-            def _open_stream(profile: AuthProfile):
+            def _open_stream(profile: Any) -> Any:
                 nonlocal _pool_profile
                 _pool_profile = profile  # capture so mid-stream failures can mark it
-                _key = (
-                    profile.credential.key
-                    if isinstance(profile.credential, ApiKeyCredential)
-                    else self._api_key
-                )
+                # Extract API key from profile credential (ApiKeyCredential.key), or
+                # fall back to the configured api_key if the credential type differs.
+                _cred = getattr(profile, "credential", None)
+                _key = getattr(_cred, "key", None) or self._api_key
                 _client = _build_openai_client(self._base_url, _key, self._timeout)
                 return _client.chat.completions.create(
                     model=model,
@@ -421,7 +420,7 @@ class CASOpenAIBackend(CASAddressingEngine):
                 )
 
             try:
-                stream = self._pool.execute_sync(_open_stream, classify_openai_error)
+                stream = self._pool.execute_sync(_open_stream, self._pool_classifier)
             except Exception as e:
                 raise BackendError(
                     f"LLM API call failed: {e}",
@@ -500,10 +499,12 @@ class CASOpenAIBackend(CASAddressingEngine):
                         "total_tokens": chunk.usage.total_tokens or 0,
                     }
         except Exception as e:
-            if _pool_profile is not None and self._pool is not None:
-                from nexus.bricks.auth.classifiers.openai import classify_openai_error
-
-                self._pool.mark_failure(_pool_profile, classify_openai_error(e))
+            if (
+                _pool_profile is not None
+                and self._pool is not None
+                and self._pool_classifier is not None
+            ):
+                self._pool.mark_failure(_pool_profile, self._pool_classifier(e))
             raise BackendError(
                 f"LLM streaming failed: {e}",
                 backend="openai_compatible",

--- a/src/nexus/backends/connectors/calendar/connector.py
+++ b/src/nexus/backends/connectors/calendar/connector.py
@@ -200,8 +200,10 @@ send_notifications: true
         max_events_per_calendar: int = 250,
         metadata_store: Any = None,
         encryption_key: str | None = None,
+        pool: Any = None,  # CredentialPool | None — see Issue #3723 for migration guide
     ):
         # 1. Initialize OAuth
+        self._pool = pool  # stored for future migrate_to_pool() call (Issue #3723)
         self._init_oauth(
             token_manager_db,
             user_email=user_email,

--- a/src/nexus/backends/connectors/gdrive/connector.py
+++ b/src/nexus/backends/connectors/gdrive/connector.py
@@ -25,7 +25,7 @@ Storage structure:
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING, ClassVar
+from typing import TYPE_CHECKING, Any, ClassVar
 
 from nexus.backends.base.backend import HandlerStatusResponse
 from nexus.backends.base.path_addressing_engine import PathAddressingEngine
@@ -187,8 +187,10 @@ class PathGDriveBackend(
         shared_drive_id: str | None = None,
         provider: str = "google-drive",
         encryption_key: str | None = None,
+        pool: Any = None,  # CredentialPool | None — see Issue #3723 for migration guide
     ):
         # 1. Initialize OAuth (sets self.token_manager, self.provider, etc.)
+        self._pool = pool  # stored for future migrate_to_pool() call (Issue #3723)
         self._init_oauth(
             token_manager_db,
             user_email=user_email,

--- a/src/nexus/backends/connectors/gmail/connector.py
+++ b/src/nexus/backends/connectors/gmail/connector.py
@@ -417,20 +417,24 @@ class PathGmailBackend(
         from nexus.bricks.auth.classifiers.google import classify_google_error
         from nexus.bricks.auth.profile import AuthProfile
 
+        backend_path: str = context.backend_path  # narrowed: checked non-None above
+
         def _call(profile: AuthProfile) -> bytes:
             # Use a *local* transport so concurrent pool calls don't race on
             # self._transport (PathAddressingEngine stores it as instance state).
             transport = self._gmail_transport.with_context(
                 context, user_email_override=profile.account_identifier
             )
-            blob_path = self._get_key_path(context.backend_path)
+            blob_path = self._get_key_path(backend_path)
             content, _ = transport.fetch(blob_path, None)
             return content
 
-        return self._pool.execute_sync(
-            _call,
-            classify_google_error,
-            bypass_exceptions=(NexusFileNotFoundError,),
+        return bytes(
+            self._pool.execute_sync(
+                _call,
+                classify_google_error,
+                bypass_exceptions=(NexusFileNotFoundError,),
+            )
         )
 
     def delete_content(self, content_id: str, context: "OperationContext | None" = None) -> None:

--- a/src/nexus/backends/connectors/gmail/connector.py
+++ b/src/nexus/backends/connectors/gmail/connector.py
@@ -180,6 +180,7 @@ class PathGmailBackend(
         max_message_per_label: int = 200,
         metadata_store: Any = None,
         encryption_key: str | None = None,
+        pool: "Any | None" = None,
     ):
         # 1. Initialize OAuth (sets self.token_manager, self.provider, etc.)
         self._init_oauth(
@@ -213,7 +214,10 @@ class PathGmailBackend(
         # 5. Initialize CheckpointMixin state
         self._checkpoints: dict[str, Any] = {}
 
-        # 6. Register OAuth provider using factory
+        # 6. Credential pool (multi-account failover, Issue #3723)
+        self._pool = pool
+
+        # 7. Register OAuth provider using factory
         self._register_oauth_provider()
 
     # -- Properties --
@@ -398,11 +402,22 @@ class PathGmailBackend(
                 backend="gmail",
             )
 
-        # Bind transport to request context for OAuth
-        self._bind_transport(context)
+        if self._pool is None:
+            # No pool — single-account behaviour (unchanged)
+            self._bind_transport(context)
+            return super().read_content(content_id, context)
 
-        # Delegate to PathAddressingEngine (which calls transport.fetch)
-        return super().read_content(content_id, context)
+        # Pool-based: select account, bind transport to selected email, retry on rate-limit
+        from nexus.bricks.auth.classifiers.google import classify_google_error
+        from nexus.bricks.auth.profile import AuthProfile
+
+        def _call(profile: AuthProfile) -> bytes:
+            self._transport = self._gmail_transport.with_context(
+                context, user_email_override=profile.account_identifier
+            )
+            return super(PathGmailBackend, self).read_content(content_id, context)
+
+        return self._pool.execute_sync(_call, classify_google_error)
 
     def delete_content(self, content_id: str, context: "OperationContext | None" = None) -> None:
         """Trash a Gmail message (recoverable — not permanent delete).
@@ -513,26 +528,39 @@ class PathGmailBackend(
         try:
             path = path.strip("/")
 
-            # Bind transport for OAuth
-            self._bind_transport(context)
-
-            # Root directory — list label folders
+            # Root directory — list label folders (no API call needed)
             if not path:
                 return [f"{label}/" for label in self.LABEL_FOLDERS]
 
-            # Label folder — list email files
-            if path in self.LABEL_FOLDERS:
-                keys, _prefixes = self._transport.list_keys(prefix=path, delimiter="/")
-                # keys are "LABEL/thread-msg.yaml" — strip label prefix
-                files = []
-                label_prefix = f"{path}/"
-                for key in keys:
-                    name = key[len(label_prefix) :] if key.startswith(label_prefix) else key
-                    if name:
-                        files.append(name)
-                return sorted(files)
+            if path not in self.LABEL_FOLDERS:
+                raise FileNotFoundError(f"Directory not found: {path}")
 
-            raise FileNotFoundError(f"Directory not found: {path}")
+            if self._pool is None:
+                # Single-account path
+                self._bind_transport(context)
+                keys, _prefixes = self._transport.list_keys(prefix=path, delimiter="/")
+            else:
+                # Pool-based: select account + retry on rate-limit
+                from nexus.bricks.auth.classifiers.google import classify_google_error
+                from nexus.bricks.auth.profile import AuthProfile
+
+                def _list(profile: AuthProfile) -> tuple[list[str], list[str]]:
+                    transport = self._gmail_transport.with_context(
+                        context, user_email_override=profile.account_identifier
+                    )
+                    return transport.list_keys(prefix=path, delimiter="/")
+
+                keys, _prefixes = self._pool.execute_sync(_list, classify_google_error)
+
+            # Strip label prefix from keys: "LABEL/thread-msg.yaml" → "thread-msg.yaml"
+            label_prefix = f"{path}/"
+            files = []
+            for key in keys:
+                name = key[len(label_prefix) :] if key.startswith(label_prefix) else key
+                if name:
+                    files.append(name)
+            return sorted(files)
+
         except FileNotFoundError:
             raise
         except Exception as e:

--- a/src/nexus/backends/connectors/gmail/connector.py
+++ b/src/nexus/backends/connectors/gmail/connector.py
@@ -407,24 +407,25 @@ class PathGmailBackend(
             self._bind_transport(context)
             return super().read_content(content_id, context)
 
-        # Pool-based: rotate credentials for the same mailbox on rate-limit.
-        # account_identifier scopes selection to this connector's mailbox so
-        # the pool never selects a profile for a different Gmail user.
+        # Pool-based: rotate credentials on rate-limit.
+        # user_email_override routes the transport to the selected profile's
+        # account (e.g. a different service account with the same data access).
         # bypass_exceptions prevents path-level errors (deleted messages, stale
         # paths) from being misclassified as credential failures.
+        # Note: pool correctness (only accounts with appropriate access) is the
+        # operator's responsibility when building the CredentialPool.
         from nexus.bricks.auth.classifiers.google import classify_google_error
         from nexus.bricks.auth.profile import AuthProfile
 
-        account_id = self._user_email or (getattr(context, "user_id", None) if context else None)
-
-        def _call(_profile: AuthProfile) -> bytes:
-            self._transport = self._gmail_transport.with_context(context)
+        def _call(profile: AuthProfile) -> bytes:
+            self._transport = self._gmail_transport.with_context(
+                context, user_email_override=profile.account_identifier
+            )
             return super(PathGmailBackend, self).read_content(content_id, context)
 
         return self._pool.execute_sync(
             _call,
             classify_google_error,
-            account_identifier=account_id,
             bypass_exceptions=(NexusFileNotFoundError,),
         )
 
@@ -549,24 +550,22 @@ class PathGmailBackend(
                 self._bind_transport(context)
                 keys, _prefixes = self._transport.list_keys(prefix=path, delimiter="/")
             else:
-                # Pool-based: rotate credentials for this mailbox on rate-limit.
-                # account_identifier scopes to connector's mailbox; bypass_exceptions
-                # prevents directory-not-found from poisoning healthy credentials.
+                # Pool-based: rotate credentials on rate-limit.
+                # user_email_override routes the transport to the selected profile's
+                # account. bypass_exceptions prevents directory-not-found from
+                # poisoning healthy credentials.
                 from nexus.bricks.auth.classifiers.google import classify_google_error
                 from nexus.bricks.auth.profile import AuthProfile
 
-                account_id = self._user_email or (
-                    getattr(context, "user_id", None) if context else None
-                )
-
-                def _list(_profile: AuthProfile) -> tuple[list[str], list[str]]:
-                    transport = self._gmail_transport.with_context(context)
+                def _list(profile: AuthProfile) -> tuple[list[str], list[str]]:
+                    transport = self._gmail_transport.with_context(
+                        context, user_email_override=profile.account_identifier
+                    )
                     return transport.list_keys(prefix=path, delimiter="/")
 
                 keys, _prefixes = self._pool.execute_sync(
                     _list,
                     classify_google_error,
-                    account_identifier=account_id,
                     bypass_exceptions=(NexusFileNotFoundError,),
                 )
 

--- a/src/nexus/backends/connectors/gmail/connector.py
+++ b/src/nexus/backends/connectors/gmail/connector.py
@@ -418,10 +418,14 @@ class PathGmailBackend(
         from nexus.bricks.auth.profile import AuthProfile
 
         def _call(profile: AuthProfile) -> bytes:
-            self._transport = self._gmail_transport.with_context(
+            # Use a *local* transport so concurrent pool calls don't race on
+            # self._transport (PathAddressingEngine stores it as instance state).
+            transport = self._gmail_transport.with_context(
                 context, user_email_override=profile.account_identifier
             )
-            return super(PathGmailBackend, self).read_content(content_id, context)
+            blob_path = self._get_key_path(context.backend_path)
+            content, _ = transport.fetch(blob_path, None)
+            return content
 
         return self._pool.execute_sync(
             _call,

--- a/src/nexus/backends/connectors/gmail/connector.py
+++ b/src/nexus/backends/connectors/gmail/connector.py
@@ -407,17 +407,26 @@ class PathGmailBackend(
             self._bind_transport(context)
             return super().read_content(content_id, context)
 
-        # Pool-based: select account, bind transport to selected email, retry on rate-limit
+        # Pool-based: rotate credentials for the same mailbox on rate-limit.
+        # account_identifier scopes selection to this connector's mailbox so
+        # the pool never selects a profile for a different Gmail user.
+        # bypass_exceptions prevents path-level errors (deleted messages, stale
+        # paths) from being misclassified as credential failures.
         from nexus.bricks.auth.classifiers.google import classify_google_error
         from nexus.bricks.auth.profile import AuthProfile
 
-        def _call(profile: AuthProfile) -> bytes:
-            self._transport = self._gmail_transport.with_context(
-                context, user_email_override=profile.account_identifier
-            )
+        account_id = self._user_email or (getattr(context, "user_id", None) if context else None)
+
+        def _call(_profile: AuthProfile) -> bytes:
+            self._transport = self._gmail_transport.with_context(context)
             return super(PathGmailBackend, self).read_content(content_id, context)
 
-        return self._pool.execute_sync(_call, classify_google_error)
+        return self._pool.execute_sync(
+            _call,
+            classify_google_error,
+            account_identifier=account_id,
+            bypass_exceptions=(NexusFileNotFoundError,),
+        )
 
     def delete_content(self, content_id: str, context: "OperationContext | None" = None) -> None:
         """Trash a Gmail message (recoverable — not permanent delete).
@@ -540,17 +549,26 @@ class PathGmailBackend(
                 self._bind_transport(context)
                 keys, _prefixes = self._transport.list_keys(prefix=path, delimiter="/")
             else:
-                # Pool-based: select account + retry on rate-limit
+                # Pool-based: rotate credentials for this mailbox on rate-limit.
+                # account_identifier scopes to connector's mailbox; bypass_exceptions
+                # prevents directory-not-found from poisoning healthy credentials.
                 from nexus.bricks.auth.classifiers.google import classify_google_error
                 from nexus.bricks.auth.profile import AuthProfile
 
-                def _list(profile: AuthProfile) -> tuple[list[str], list[str]]:
-                    transport = self._gmail_transport.with_context(
-                        context, user_email_override=profile.account_identifier
-                    )
+                account_id = self._user_email or (
+                    getattr(context, "user_id", None) if context else None
+                )
+
+                def _list(_profile: AuthProfile) -> tuple[list[str], list[str]]:
+                    transport = self._gmail_transport.with_context(context)
                     return transport.list_keys(prefix=path, delimiter="/")
 
-                keys, _prefixes = self._pool.execute_sync(_list, classify_google_error)
+                keys, _prefixes = self._pool.execute_sync(
+                    _list,
+                    classify_google_error,
+                    account_identifier=account_id,
+                    bypass_exceptions=(NexusFileNotFoundError,),
+                )
 
             # Strip label prefix from keys: "LABEL/thread-msg.yaml" → "thread-msg.yaml"
             label_prefix = f"{path}/"

--- a/src/nexus/backends/connectors/gmail/transport.py
+++ b/src/nexus/backends/connectors/gmail/transport.py
@@ -323,6 +323,16 @@ class GmailTransport:
             )
             return self._parse_gmail_message(message)
         except Exception as e:
+            # Translate HTTP 404 to NexusFileNotFoundError so callers (e.g. the
+            # credential pool) can distinguish "message deleted" from "credential
+            # failure" and avoid incorrectly penalising healthy credentials.
+            try:
+                from googleapiclient.errors import HttpError
+
+                if isinstance(e, HttpError) and e.resp and e.resp.status == 404:
+                    raise NexusFileNotFoundError(message_id) from e
+            except ImportError:
+                pass
             raise BackendError(
                 f"Failed to fetch email {message_id}: {e}",
                 backend="gmail",

--- a/src/nexus/backends/connectors/gmail/transport.py
+++ b/src/nexus/backends/connectors/gmail/transport.py
@@ -83,10 +83,25 @@ class GmailTransport:
     # Context binding (not part of Transport protocol; Gmail-specific)
     # ------------------------------------------------------------------
 
-    def with_context(self, context: OperationContext | None) -> GmailTransport:
-        """Return a shallow copy bound to *context* (for OAuth token resolution)."""
+    def with_context(
+        self,
+        context: OperationContext | None,
+        *,
+        user_email_override: str | None = None,
+    ) -> GmailTransport:
+        """Return a shallow copy bound to *context* (for OAuth token resolution).
+
+        Args:
+            context: Per-request OperationContext (used to resolve user_email
+                when user_email_override is not set).
+            user_email_override: If provided, this email is used directly for
+                token lookup — bypasses context.user_id resolution. Used by the
+                credential pool to select a specific account for each request.
+        """
         clone = copy(self)
         clone._context = context
+        if user_email_override is not None:
+            clone._user_email = user_email_override
         return clone
 
     # ------------------------------------------------------------------

--- a/src/nexus/backends/connectors/oauth_base.py
+++ b/src/nexus/backends/connectors/oauth_base.py
@@ -23,6 +23,7 @@ from nexus.backends.connectors.oauth import OAuthConnectorMixin
 from nexus.contracts.backend_features import OAUTH_BACKEND_FEATURES
 
 if TYPE_CHECKING:
+    from nexus.bricks.auth.credential_pool import CredentialPool
     from nexus.storage.record_store import RecordStoreABC
 
 logger = logging.getLogger(__name__)
@@ -62,6 +63,7 @@ class OAuthConnectorBase(
         record_store: "RecordStoreABC | None" = None,
         metadata_store: Any = None,
         encryption_key: str | None = None,
+        pool: "CredentialPool | None" = None,
     ) -> None:
         """Initialize OAuth connector base.
 
@@ -71,6 +73,10 @@ class OAuthConnectorBase(
             provider: OAuth provider name from config.
             record_store: Optional RecordStoreABC instance for content caching.
             metadata_store: MetastoreABC instance for file_paths table (optional).
+            pool: Optional CredentialPool for multi-account failover (Issue #3723).
+                When set, the connector selects an account from the pool per-request
+                and rotates on rate-limit / quota errors. When None (default),
+                falls back to single-account behaviour (no change for existing users).
         """
         super().__init__()
         self._init_oauth(
@@ -84,6 +90,9 @@ class OAuthConnectorBase(
 
         # Initialize CheckpointMixin state (MRO doesn't call CheckpointMixin.__init__)
         self._checkpoints: dict[str, Any] = {}
+
+        # Credential pool — None means single-account behaviour (default)
+        self._pool: CredentialPool | None = pool
 
         # Register OAuth provider using factory (loads from config)
         self._register_oauth_provider()

--- a/src/nexus/backends/connectors/slack/connector.py
+++ b/src/nexus/backends/connectors/slack/connector.py
@@ -128,6 +128,7 @@ class PathSlackBackend(
         max_messages_per_channel: int = 100,
         metadata_store: Any = None,
         encryption_key: str | None = None,
+        pool: Any = None,  # CredentialPool | None — see Issue #3723 for migration guide
     ):
         """Initialize Slack connector backend.
 
@@ -138,8 +139,10 @@ class PathSlackBackend(
             record_store: Optional RecordStoreABC for content caching
             max_messages_per_channel: Maximum messages to fetch per channel
             metadata_store: MetastoreABC instance for file_paths table
+            pool: Optional CredentialPool for multi-account failover (Issue #3723).
         """
         # 1. Initialize OAuth (sets self.token_manager, self.provider, etc.)
+        self._pool = pool  # stored for future migrate_to_pool() call (Issue #3723)
         self._init_oauth(
             token_manager_db,
             user_email=user_email,

--- a/src/nexus/backends/connectors/x/connector.py
+++ b/src/nexus/backends/connectors/x/connector.py
@@ -150,6 +150,7 @@ class PathXBackend(
         memory_cache_maxsize: int = 1024,
         user_id_cache_maxsize: int = 256,
         encryption_key: str | None = None,
+        pool: Any = None,  # CredentialPool | None — see Issue #3723 for migration guide
     ):
         """Initialize X connector backend.
 
@@ -161,7 +162,9 @@ class PathXBackend(
             provider: OAuth provider name (default: "twitter")
             memory_cache_maxsize: Max entries in the in-memory content LRU cache
             user_id_cache_maxsize: Max entries in the user ID LRU cache
+            pool: Optional CredentialPool for multi-account failover (Issue #3723).
         """
+        self._pool = pool  # stored for future migrate_to_pool() call (Issue #3723)
         # 1. Initialize OAuth
         self._init_oauth(
             token_manager_db,

--- a/src/nexus/bricks/auth/classifiers/__init__.py
+++ b/src/nexus/bricks/auth/classifiers/__init__.py
@@ -1,0 +1,12 @@
+"""Provider-specific error classifiers for CredentialPool.
+
+Each classifier maps a provider SDK's exceptions to AuthProfileFailureReason.
+The pool uses the mapped reason to apply the correct cooldown policy.
+
+Available classifiers:
+  - nexus.bricks.auth.classifiers.openai.classify_openai_error
+  - nexus.bricks.auth.classifiers.anthropic.classify_anthropic_error
+  - nexus.bricks.auth.classifiers.google.classify_google_error
+  - nexus.bricks.auth.classifiers.slack.classify_slack_error
+  - nexus.bricks.auth.classifiers.boto3.classify_boto3_error
+"""

--- a/src/nexus/bricks/auth/classifiers/anthropic.py
+++ b/src/nexus/bricks/auth/classifiers/anthropic.py
@@ -1,0 +1,77 @@
+"""Anthropic error classifier for CredentialPool.
+
+Maps anthropic SDK exceptions to AuthProfileFailureReason.
+
+Key Anthropic-specific difference from OpenAI:
+  - HTTP 529 "OverloadedError" is Anthropic's overload signal (not 503).
+  - Billing exhaustion surfaces as a 400 BadRequestError with
+    error.type == "invalid_request_error" and a quota message,
+    NOT as a RateLimitError. Use error.type (structured), not string parsing.
+"""
+
+from __future__ import annotations
+
+from nexus.bricks.auth.profile import AuthProfileFailureReason
+
+
+def classify_anthropic_error(exc: Exception) -> AuthProfileFailureReason:
+    """Map an anthropic SDK exception to AuthProfileFailureReason.
+
+    Args:
+        exc: Any exception raised by an anthropic API call.
+
+    Returns:
+        The matching AuthProfileFailureReason, or UNKNOWN as a fallback.
+    """
+    try:
+        import anthropic
+    except ImportError:
+        return AuthProfileFailureReason.UNKNOWN
+
+    if isinstance(exc, anthropic.AuthenticationError):
+        # 401 — key wrong or revoked
+        return AuthProfileFailureReason.AUTH_PERMANENT
+
+    if isinstance(exc, anthropic.PermissionDeniedError):
+        # 403 — key lacks permission
+        return AuthProfileFailureReason.AUTH_PERMANENT
+
+    if isinstance(exc, anthropic.RateLimitError):
+        # 429 — per-minute throttling; Anthropic does not embed billing codes here
+        return AuthProfileFailureReason.RATE_LIMIT
+
+    if isinstance(exc, anthropic.OverloadedError):
+        # 529 — Anthropic-specific overload signal; distinct from 5xx server errors
+        return AuthProfileFailureReason.OVERLOADED
+
+    if isinstance(exc, anthropic.InternalServerError):
+        # 500/503 — server-side; retry soon
+        return AuthProfileFailureReason.OVERLOADED
+
+    if isinstance(exc, anthropic.APITimeoutError):
+        return AuthProfileFailureReason.TIMEOUT
+
+    if isinstance(exc, anthropic.APIConnectionError):
+        return AuthProfileFailureReason.TIMEOUT
+
+    if isinstance(exc, anthropic.NotFoundError):
+        # 404 on model endpoint
+        return AuthProfileFailureReason.MODEL_NOT_FOUND
+
+    if isinstance(exc, anthropic.BadRequestError):
+        # 400 — could be billing exhaustion or malformed request.
+        # Check error.type for the billing subcase (structured, not string parse).
+        err_type = getattr(getattr(exc, "error", None), "type", None)
+        if err_type == "invalid_request_error":
+            # Check body for quota signal — structured field preferred
+            body = getattr(exc, "body", None) or {}
+            if isinstance(body, dict):
+                err_detail = body.get("error", {})
+                if (
+                    isinstance(err_detail, dict)
+                    and "quota" in str(err_detail.get("message", "")).lower()
+                ):
+                    return AuthProfileFailureReason.BILLING
+        return AuthProfileFailureReason.FORMAT
+
+    return AuthProfileFailureReason.UNKNOWN

--- a/src/nexus/bricks/auth/classifiers/boto3.py
+++ b/src/nexus/bricks/auth/classifiers/boto3.py
@@ -1,0 +1,105 @@
+"""Boto3 / botocore error classifier for CredentialPool.
+
+Maps botocore exceptions to AuthProfileFailureReason.
+Covers S3, GCS-via-boto3, and other AWS SDK calls.
+
+AWS error codes are structured in ClientError.response["Error"]["Code"].
+Always use the code field (structured), never string-parse the message.
+"""
+
+from __future__ import annotations
+
+from nexus.bricks.auth.profile import AuthProfileFailureReason
+
+# AWS error codes that indicate permanent auth failure (key wrong/revoked).
+_PERMANENT_AUTH_CODES: frozenset[str] = frozenset(
+    {
+        "AuthFailure",
+        "InvalidClientTokenId",
+        "InvalidAccessKeyId",
+        "SignatureDoesNotMatch",
+        "AccessDeniedException",
+        "UnauthorizedOperation",
+        "NotAuthorized",
+    }
+)
+
+# AWS error codes that indicate the session/token has expired (re-auth needed).
+_SESSION_EXPIRED_CODES: frozenset[str] = frozenset(
+    {
+        "ExpiredTokenException",
+        "ExpiredToken",
+        "RequestExpired",
+        "TokenRefreshRequired",
+    }
+)
+
+# AWS error codes that indicate throttling (1h cooldown, auto-recover).
+_RATE_LIMIT_CODES: frozenset[str] = frozenset(
+    {
+        "ThrottlingException",
+        "Throttling",
+        "RequestLimitExceeded",
+        "RequestThrottled",
+        "TooManyRequestsException",
+        "ProvisionedThroughputExceededException",
+        "SlowDown",  # S3-specific
+    }
+)
+
+
+def classify_boto3_error(exc: Exception) -> AuthProfileFailureReason:
+    """Map a botocore exception to AuthProfileFailureReason.
+
+    Args:
+        exc: Any exception raised by a boto3 / botocore API call.
+
+    Returns:
+        The matching AuthProfileFailureReason, or UNKNOWN as a fallback.
+    """
+    try:
+        import botocore.exceptions as botocore_exc
+    except ImportError:
+        return AuthProfileFailureReason.UNKNOWN
+
+    if isinstance(exc, botocore_exc.EndpointConnectionError):
+        return AuthProfileFailureReason.TIMEOUT
+
+    if isinstance(exc, botocore_exc.ConnectTimeoutError):
+        return AuthProfileFailureReason.TIMEOUT
+
+    if isinstance(exc, botocore_exc.ReadTimeoutError):
+        return AuthProfileFailureReason.TIMEOUT
+
+    if isinstance(exc, botocore_exc.ClientError):
+        # Structured error code — the authoritative signal
+        error_code: str = exc.response.get("Error", {}).get("Code", "") if exc.response else ""
+
+        if error_code in _PERMANENT_AUTH_CODES:
+            return AuthProfileFailureReason.AUTH_PERMANENT
+
+        if error_code in _SESSION_EXPIRED_CODES:
+            return AuthProfileFailureReason.SESSION_EXPIRED
+
+        if error_code in _RATE_LIMIT_CODES:
+            return AuthProfileFailureReason.RATE_LIMIT
+
+        # HTTP status fallback for unrecognised codes
+        http_status: int = (
+            exc.response.get("ResponseMetadata", {}).get("HTTPStatusCode", 0) if exc.response else 0
+        )
+        if http_status in (500, 502, 503):
+            return AuthProfileFailureReason.OVERLOADED
+        if http_status == 429:
+            return AuthProfileFailureReason.RATE_LIMIT
+        if http_status in (401, 403):
+            return AuthProfileFailureReason.AUTH_PERMANENT
+
+    if isinstance(exc, botocore_exc.NoCredentialsError):
+        # No credentials configured at all — surface to user
+        return AuthProfileFailureReason.AUTH_PERMANENT
+
+    if isinstance(exc, botocore_exc.PartialCredentialsError):
+        return AuthProfileFailureReason.FORMAT
+
+    return AuthProfileFailureReason.UNKNOWN

--- a/src/nexus/bricks/auth/classifiers/google.py
+++ b/src/nexus/bricks/auth/classifiers/google.py
@@ -1,0 +1,116 @@
+"""Google API error classifier for CredentialPool.
+
+Maps Google API client exceptions to AuthProfileFailureReason.
+Covers both the google-api-python-client (HttpError) and
+google-auth exceptions (RefreshError, TransportError).
+
+Google-specific notes:
+  - Rate limit (429) may carry "quotaExceeded" for billing-style exhaustion.
+    Use the structured 'reason' field from the error JSON body, not string parsing.
+  - RefreshError indicates the OAuth token can no longer be refreshed —
+    requires user re-authentication (SESSION_EXPIRED).
+  - 403 can be "insufficientPermissions" (permanent) or "rateLimitExceeded" (transient).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nexus.bricks.auth.profile import AuthProfileFailureReason
+
+
+def classify_google_error(exc: Exception) -> AuthProfileFailureReason:
+    """Map a Google API / google-auth exception to AuthProfileFailureReason.
+
+    Args:
+        exc: Any exception raised by a Google API call or token refresh.
+
+    Returns:
+        The matching AuthProfileFailureReason, or UNKNOWN as a fallback.
+    """
+    # google-auth refresh / transport errors
+    try:
+        from google.auth import exceptions as google_auth_exc
+
+        if isinstance(exc, google_auth_exc.RefreshError):
+            # OAuth token expired and cannot be refreshed — user must re-auth
+            return AuthProfileFailureReason.SESSION_EXPIRED
+        if isinstance(exc, google_auth_exc.TransportError):
+            return AuthProfileFailureReason.TIMEOUT
+    except ImportError:
+        pass
+
+    # google-api-python-client HttpError
+    try:
+        from googleapiclient.errors import HttpError
+
+        if isinstance(exc, HttpError):
+            status = exc.resp.status if exc.resp else 0
+
+            if status == 401:
+                return AuthProfileFailureReason.AUTH_PERMANENT
+
+            if status == 403:
+                # Distinguish permanent permission denial from transient rate-limit.
+                # Use structured 'reason' from error JSON body (not string parsing).
+                reason = _extract_google_error_reason(exc)
+                if reason in ("rateLimitExceeded", "userRateLimitExceeded"):
+                    return AuthProfileFailureReason.RATE_LIMIT
+                if reason == "quotaExceeded":
+                    return AuthProfileFailureReason.BILLING
+                # Default 403: permission denied — permanent
+                return AuthProfileFailureReason.AUTH_PERMANENT
+
+            if status == 429:
+                reason = _extract_google_error_reason(exc)
+                if reason == "quotaExceeded":
+                    return AuthProfileFailureReason.BILLING
+                return AuthProfileFailureReason.RATE_LIMIT
+
+            if status in (500, 502, 503):
+                return AuthProfileFailureReason.OVERLOADED
+
+            if status == 404:
+                return AuthProfileFailureReason.MODEL_NOT_FOUND
+
+            if status == 400:
+                return AuthProfileFailureReason.FORMAT
+
+    except ImportError:
+        pass
+
+    # Network-level timeouts
+    try:
+        import requests
+
+        if isinstance(exc, requests.exceptions.Timeout):
+            return AuthProfileFailureReason.TIMEOUT
+        if isinstance(exc, requests.exceptions.ConnectionError):
+            return AuthProfileFailureReason.TIMEOUT
+    except ImportError:
+        pass
+
+    return AuthProfileFailureReason.UNKNOWN
+
+
+def _extract_google_error_reason(exc: Any) -> str | None:
+    """Extract the structured 'reason' field from a Google HttpError body.
+
+    Google error bodies look like:
+        {"error": {"errors": [{"reason": "rateLimitExceeded", ...}], ...}}
+
+    Returns the reason string, or None if not parseable.
+    """
+    import json
+
+    try:
+        body = exc.content
+        if isinstance(body, bytes):
+            body = body.decode("utf-8", errors="replace")
+        parsed = json.loads(body)
+        errors = parsed.get("error", {}).get("errors", [])
+        if errors:
+            return errors[0].get("reason")
+    except Exception:
+        pass
+    return None

--- a/src/nexus/bricks/auth/classifiers/google.py
+++ b/src/nexus/bricks/auth/classifiers/google.py
@@ -22,12 +22,32 @@ from nexus.bricks.auth.profile import AuthProfileFailureReason
 def classify_google_error(exc: Exception) -> AuthProfileFailureReason:
     """Map a Google API / google-auth exception to AuthProfileFailureReason.
 
+    Walks the full exception chain (__cause__ then __context__) so that
+    connectors which wrap raw SDK exceptions in BackendError still produce
+    correct cooldown/retry decisions.  The raw Google exception is preserved
+    as exc.__cause__ when ``raise BackendError(...) from e`` is used.
+
     Args:
-        exc: Any exception raised by a Google API call or token refresh.
+        exc: Any exception raised by a Google API call or token refresh,
+             including wrapped BackendError whose __cause__ is a Google exc.
 
     Returns:
         The matching AuthProfileFailureReason, or UNKNOWN as a fallback.
     """
+    candidate: BaseException | None = exc
+    seen: set[int] = set()
+    while candidate is not None and id(candidate) not in seen:
+        seen.add(id(candidate))
+        if isinstance(candidate, Exception):
+            result = _classify_single(candidate)
+            if result != AuthProfileFailureReason.UNKNOWN:
+                return result
+        candidate = candidate.__cause__ or candidate.__context__
+    return AuthProfileFailureReason.UNKNOWN
+
+
+def _classify_single(exc: Exception) -> AuthProfileFailureReason:
+    """Classify a single exception node (no chain-walking)."""
     # google-auth refresh / transport errors
     try:
         from google.auth import exceptions as google_auth_exc

--- a/src/nexus/bricks/auth/classifiers/google.py
+++ b/src/nexus/bricks/auth/classifiers/google.py
@@ -130,7 +130,7 @@ def _extract_google_error_reason(exc: Any) -> str | None:
         parsed = json.loads(body)
         errors = parsed.get("error", {}).get("errors", [])
         if errors:
-            return errors[0].get("reason")
+            return str(errors[0].get("reason")) if errors[0].get("reason") is not None else None
     except Exception:
         pass
     return None

--- a/src/nexus/bricks/auth/classifiers/openai.py
+++ b/src/nexus/bricks/auth/classifiers/openai.py
@@ -1,0 +1,68 @@
+"""OpenAI error classifier for CredentialPool.
+
+Maps openai SDK exceptions to AuthProfileFailureReason so the pool can
+apply the correct cooldown and retry policy without inspecting raw HTTP status.
+
+Design note: uses exc.code (structured SDK field) rather than string-parsing
+exc.message for the billing/rate-limit disambiguation. The openai SDK sets
+code="insufficient_quota" for 402-equivalent exhausted-quota errors and
+code="rate_limit_exceeded" for 429 per-minute throttling.
+String parsing of error messages is fragile across SDK versions.
+"""
+
+from __future__ import annotations
+
+from nexus.bricks.auth.profile import AuthProfileFailureReason
+
+
+def classify_openai_error(exc: Exception) -> AuthProfileFailureReason:
+    """Map an openai SDK exception to AuthProfileFailureReason.
+
+    Args:
+        exc: Any exception raised by an openai API call.
+
+    Returns:
+        The matching AuthProfileFailureReason, or UNKNOWN as a fallback.
+    """
+    try:
+        import openai
+    except ImportError:
+        return AuthProfileFailureReason.UNKNOWN
+
+    if isinstance(exc, openai.AuthenticationError):
+        # 401 — key is wrong or revoked; no auto-recovery
+        return AuthProfileFailureReason.AUTH_PERMANENT
+
+    if isinstance(exc, openai.PermissionDeniedError):
+        # 403 — key exists but lacks the required permission
+        return AuthProfileFailureReason.AUTH_PERMANENT
+
+    if isinstance(exc, openai.RateLimitError):
+        # 429 — two distinct sub-cases with different cooldown policies:
+        #   code="insufficient_quota"  → billing exhaustion (24h cooldown, manual review)
+        #   anything else              → per-minute rate limit (1h cooldown, auto-recover)
+        # Use exc.code (structured) not str(exc) (brittle across SDK versions).
+        if getattr(exc, "code", None) == "insufficient_quota":
+            return AuthProfileFailureReason.BILLING
+        return AuthProfileFailureReason.RATE_LIMIT
+
+    if isinstance(exc, openai.APITimeoutError):
+        return AuthProfileFailureReason.TIMEOUT
+
+    if isinstance(exc, openai.APIConnectionError):
+        # Network-level failure — treat same as timeout
+        return AuthProfileFailureReason.TIMEOUT
+
+    if isinstance(exc, openai.InternalServerError):
+        # 500/503 — provider-side; retry soon
+        return AuthProfileFailureReason.OVERLOADED
+
+    if isinstance(exc, openai.NotFoundError):
+        # 404 on model endpoint — this key doesn't have access to this model
+        return AuthProfileFailureReason.MODEL_NOT_FOUND
+
+    if isinstance(exc, openai.BadRequestError):
+        # 400 — malformed request; not an auth/rate issue
+        return AuthProfileFailureReason.FORMAT
+
+    return AuthProfileFailureReason.UNKNOWN

--- a/src/nexus/bricks/auth/classifiers/slack.py
+++ b/src/nexus/bricks/auth/classifiers/slack.py
@@ -1,0 +1,85 @@
+"""Slack SDK error classifier for CredentialPool.
+
+Maps slack_sdk exceptions to AuthProfileFailureReason.
+
+Slack uses a unified SlackApiError with a structured error code in
+response["error"]. Always use the code (structured), not the message string.
+
+Common error codes:
+  not_authed, invalid_auth, account_inactive, token_revoked → AUTH_PERMANENT
+  token_expired → SESSION_EXPIRED (token can be refreshed, user re-auth needed)
+  ratelimited → RATE_LIMIT
+  fatal_error, internal_error → OVERLOADED
+"""
+
+from __future__ import annotations
+
+from nexus.bricks.auth.profile import AuthProfileFailureReason
+
+# Slack error codes that indicate the token is permanently invalid.
+_PERMANENT_AUTH_CODES: frozenset[str] = frozenset(
+    {
+        "not_authed",
+        "invalid_auth",
+        "account_inactive",
+        "token_revoked",
+        "no_permission",
+        "missing_scope",
+        "team_access_not_granted",
+        "org_login_required",
+    }
+)
+
+# Slack error codes that require user re-authentication (token can be refreshed).
+_SESSION_EXPIRED_CODES: frozenset[str] = frozenset(
+    {
+        "token_expired",
+        "ekm_access_denied",
+    }
+)
+
+
+def classify_slack_error(exc: Exception) -> AuthProfileFailureReason:
+    """Map a slack_sdk exception to AuthProfileFailureReason.
+
+    Args:
+        exc: Any exception raised by a Slack API call.
+
+    Returns:
+        The matching AuthProfileFailureReason, or UNKNOWN as a fallback.
+    """
+    try:
+        from slack_sdk.errors import SlackApiError, SlackRequestError
+    except ImportError:
+        return AuthProfileFailureReason.UNKNOWN
+
+    if isinstance(exc, SlackRequestError):
+        # Network-level failure (connection refused, timeout)
+        return AuthProfileFailureReason.TIMEOUT
+
+    if isinstance(exc, SlackApiError):
+        # Structured error code from Slack's API response
+        error_code: str = exc.response.get("error", "") if exc.response else ""
+
+        if error_code in _PERMANENT_AUTH_CODES:
+            return AuthProfileFailureReason.AUTH_PERMANENT
+
+        if error_code in _SESSION_EXPIRED_CODES:
+            return AuthProfileFailureReason.SESSION_EXPIRED
+
+        if error_code == "ratelimited":
+            return AuthProfileFailureReason.RATE_LIMIT
+
+        if error_code in ("fatal_error", "internal_error", "service_unavailable"):
+            return AuthProfileFailureReason.OVERLOADED
+
+        # Check HTTP status as fallback for codes we don't recognise
+        http_status = exc.response.status_code if exc.response else 0
+        if http_status == 429:
+            return AuthProfileFailureReason.RATE_LIMIT
+        if http_status in (500, 502, 503):
+            return AuthProfileFailureReason.OVERLOADED
+        if http_status == 401:
+            return AuthProfileFailureReason.AUTH_PERMANENT
+
+    return AuthProfileFailureReason.UNKNOWN

--- a/src/nexus/bricks/auth/credential_pool.py
+++ b/src/nexus/bricks/auth/credential_pool.py
@@ -130,7 +130,8 @@ class NoAvailableCredentialError(Exception):
         super().__init__(
             f"No available credential for provider '{provider}':\n"
             f"{detail_block}\n"
-            f"Run 'nexus-fs auth pool status {provider}' for details."
+            f"Check AuthProfileStore for current cooldown state, or wait for "
+            f"cooldowns to expire before retrying."
         )
 
 

--- a/src/nexus/bricks/auth/credential_pool.py
+++ b/src/nexus/bricks/auth/credential_pool.py
@@ -250,7 +250,7 @@ class CredentialPool:
             case "least_used":
                 return min(
                     candidates,
-                    key=lambda p: (p.usage_stats.success_count + p.usage_stats.failure_count),
+                    key=lambda p: p.usage_stats.success_count + p.usage_stats.failure_count,
                 )
             case _:
                 raise ValueError(f"Unknown strategy: {self.strategy!r}")
@@ -302,7 +302,7 @@ class CredentialPool:
             case "least_used":
                 return min(
                     candidates,
-                    key=lambda p: (p.usage_stats.success_count + p.usage_stats.failure_count),
+                    key=lambda p: p.usage_stats.success_count + p.usage_stats.failure_count,
                 )
             case _:
                 raise ValueError(f"Unknown strategy: {self.strategy!r}")

--- a/src/nexus/bricks/auth/credential_pool.py
+++ b/src/nexus/bricks/auth/credential_pool.py
@@ -350,6 +350,7 @@ class CredentialPool:
         classifier: CredentialErrorClassifier,
         *,
         account_identifier: str | None = None,
+        bypass_exceptions: tuple[type[Exception], ...] = (),
     ) -> Any:
         """Synchronous version of execute() for non-async call sites.
 
@@ -361,6 +362,10 @@ class CredentialPool:
             fn: Callable accepting an AuthProfile, returning T.
             classifier: Maps provider exceptions to AuthProfileFailureReason.
             account_identifier: Passed through to select_sync() for scoped pools.
+            bypass_exceptions: Exception types that are NOT credential failures.
+                Re-raised immediately without marking the profile or counting
+                toward cooldown. Use for path-level errors (e.g. FileNotFoundError)
+                that should never poison healthy credentials.
 
         Returns:
             Whatever fn returns.
@@ -375,6 +380,8 @@ class CredentialPool:
             self.mark_success(profile)
             return result
         except Exception as exc:
+            if bypass_exceptions and isinstance(exc, bypass_exceptions):
+                raise
             try:
                 reason = classifier(exc)
             except Exception:
@@ -390,6 +397,8 @@ class CredentialPool:
             self.mark_success(next_profile)
             return result
         except Exception as retry_exc:
+            if bypass_exceptions and isinstance(retry_exc, bypass_exceptions):
+                raise
             try:
                 retry_reason = classifier(retry_exc)
             except Exception:
@@ -403,6 +412,7 @@ class CredentialPool:
         classifier: CredentialErrorClassifier,
         *,
         account_identifier: str | None = None,
+        bypass_exceptions: tuple[type[Exception], ...] = (),
     ) -> Any:
         """Select a credential, call fn, handle failure, retry on retriable errors.
 
@@ -420,6 +430,9 @@ class CredentialPool:
                 Should use profile.credential to authenticate the API call.
             classifier: Maps the provider's exception to AuthProfileFailureReason.
             account_identifier: Passed through to select() for user-scoped pools.
+            bypass_exceptions: Exception types that are NOT credential failures.
+                Re-raised immediately without marking the profile or counting
+                toward cooldown.
 
         Returns:
             Whatever fn returns (awaited if it is a coroutine).
@@ -436,6 +449,8 @@ class CredentialPool:
             self.mark_success(profile)
             return result
         except Exception as exc:
+            if bypass_exceptions and isinstance(exc, bypass_exceptions):
+                raise
             try:
                 reason = classifier(exc)
             except Exception:
@@ -453,6 +468,8 @@ class CredentialPool:
             self.mark_success(next_profile)
             return result
         except Exception as retry_exc:
+            if bypass_exceptions and isinstance(retry_exc, bypass_exceptions):
+                raise
             try:
                 retry_reason = classifier(retry_exc)
             except Exception:

--- a/src/nexus/bricks/auth/credential_pool.py
+++ b/src/nexus/bricks/auth/credential_pool.py
@@ -1,0 +1,532 @@
+"""Credential pool with multi-account failover and cooldown-based rotation.
+
+Ported from the Hermes Agent pattern (agent/credential_pool.py) with the
+OpenClaw failure-reason enum (src/agents/auth-profiles/types.ts).
+
+## Responsibility boundary
+
+This module handles *credential selection and switching*. It does NOT handle
+same-credential retries — use ``tenacity`` for those:
+
+  - tenacity: retry the same credential on transient failures (network blips,
+    5xx without a better alternative). Example: ``@retry(stop=stop_after_attempt(3))``.
+  - pool.execute(): switch to a different credential on RATE_LIMIT / OVERLOADED /
+    TIMEOUT, after marking the failing profile on cooldown.
+
+Using both together is correct and expected. Never add tenacity retries inside
+pool.execute(); never add credential-switching inside tenacity callbacks.
+
+## Usage
+
+    from nexus.bricks.auth.credential_pool import CredentialPool, CredentialPoolRegistry
+    from nexus.bricks.auth.classifiers.openai import classify_openai_error
+
+    # At application startup (once, process-scoped):
+    registry = CredentialPoolRegistry(store=profile_store)
+
+    # In a connector:
+    pool = registry.get("openai", strategy="least_used")
+    result = await pool.execute(
+        lambda profile: openai_client.chat(token=profile.credential.key),
+        classifier=classify_openai_error,
+    )
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+import random
+import threading
+from collections.abc import Callable
+from dataclasses import dataclass
+from datetime import datetime, timedelta
+from typing import Any, Literal, Protocol
+
+from nexus.bricks.auth.profile import (
+    AuthProfile,
+    AuthProfileFailureReason,
+    AuthProfileStore,
+    ProfileUsageStats,
+)
+
+logger = logging.getLogger(__name__)
+
+SelectionStrategy = Literal["first_ok", "round_robin", "random", "least_used"]
+
+# Failures that trigger a single automatic retry with a different credential.
+_RETRIABLE_REASONS: frozenset[AuthProfileFailureReason] = frozenset(
+    {
+        AuthProfileFailureReason.RATE_LIMIT,
+        AuthProfileFailureReason.OVERLOADED,
+        AuthProfileFailureReason.TIMEOUT,
+    }
+)
+
+# Default cooldown durations per failure reason.
+# Override per-pool via the cooldown_overrides constructor argument.
+#
+# NOTE: mark_success() calls store.upsert() on every successful call.
+# For high-frequency agentic workloads this is one write per API call.
+# TODO(#3723 perf): buffer success stats in-memory; flush on failure or shutdown.
+_DEFAULT_COOLDOWN_POLICY: dict[AuthProfileFailureReason, timedelta | None] = {
+    AuthProfileFailureReason.RATE_LIMIT: timedelta(hours=1),
+    AuthProfileFailureReason.OVERLOADED: timedelta(minutes=5),
+    AuthProfileFailureReason.TIMEOUT: timedelta(seconds=30),
+    AuthProfileFailureReason.BILLING: timedelta(hours=24),
+    AuthProfileFailureReason.SESSION_EXPIRED: timedelta(days=365),  # require user re-auth
+    AuthProfileFailureReason.AUTH_PERMANENT: timedelta(days=365),  # require user action
+    AuthProfileFailureReason.AUTH: None,  # transient — no cooldown, user likely fixing
+    AuthProfileFailureReason.FORMAT: None,  # structural — no automatic recovery
+    AuthProfileFailureReason.MODEL_NOT_FOUND: None,
+    AuthProfileFailureReason.UNKNOWN: timedelta(minutes=1),
+}
+
+
+# ---------------------------------------------------------------------------
+# Error types
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True)
+class ExhaustedProfile:
+    """One profile's state at the point of exhaustion, for structured error reporting."""
+
+    profile: AuthProfile
+    reason: AuthProfileFailureReason | None
+    cooldown_eta: datetime | None
+
+
+class NoAvailableCredentialError(Exception):
+    """Raised when all profiles for a provider are on cooldown or disabled.
+
+    Carries structured per-profile state so callers (CLI, connectors) can
+    produce actionable error messages without re-querying the store.
+
+    Attributes:
+        provider: The provider name (e.g. "openai").
+        exhausted_profiles: One entry per profile, with its reason and ETA.
+    """
+
+    def __init__(
+        self,
+        provider: str,
+        exhausted_profiles: list[ExhaustedProfile],
+    ) -> None:
+        self.provider = provider
+        self.exhausted_profiles = exhausted_profiles
+
+        lines: list[str] = []
+        for ep in exhausted_profiles:
+            if ep.cooldown_eta:
+                eta_str = ep.cooldown_eta.strftime("%Y-%m-%dT%H:%M:%SZ")
+                reason_str = ep.reason.value if ep.reason else "unknown"
+                lines.append(f"  {ep.profile.account_identifier}: {reason_str} until {eta_str}")
+            else:
+                reason_str = ep.reason.value if ep.reason else "disabled"
+                lines.append(f"  {ep.profile.account_identifier}: {reason_str}")
+
+        detail_block = "\n".join(lines) if lines else "  (no profiles configured)"
+        super().__init__(
+            f"No available credential for provider '{provider}':\n"
+            f"{detail_block}\n"
+            f"Run 'nexus-fs auth pool status {provider}' for details."
+        )
+
+
+# ---------------------------------------------------------------------------
+# Classifier protocol
+# ---------------------------------------------------------------------------
+
+
+class CredentialErrorClassifier(Protocol):
+    """Maps a provider exception to an AuthProfileFailureReason.
+
+    One classifier per provider SDK (openai, anthropic, google, etc.).
+    See nexus.bricks.auth.classifiers for implementations.
+    """
+
+    def __call__(self, exc: Exception) -> AuthProfileFailureReason: ...
+
+
+# ---------------------------------------------------------------------------
+# CredentialPool
+# ---------------------------------------------------------------------------
+
+
+class CredentialPool:
+    """Runtime-managed pool of credentials for one provider.
+
+    The pool is a *view* over AuthProfileStore — it does not store credentials
+    itself; it implements selection + failure-handling policy.
+
+    Thread/async safety: _last_index (round_robin) is protected by asyncio.Lock.
+    All other operations are safe under concurrent async access.
+
+    Performance note: store.list() is called on every select() to pick up
+    freshly-recovered profiles. For most pools (1-3 credentials) this is
+    negligible. TODO(#3723 perf): add registry-level profile cache invalidated
+    on mark_failure/success.
+    """
+
+    def __init__(
+        self,
+        provider: str,
+        store: AuthProfileStore,
+        *,
+        strategy: SelectionStrategy = "first_ok",
+        cooldown_overrides: dict[AuthProfileFailureReason, timedelta | None] | None = None,
+    ) -> None:
+        self.provider = provider
+        self.store = store
+        self.strategy: SelectionStrategy = strategy
+        self._last_index: int = 0
+        # threading.Lock (not asyncio.Lock) so the same lock protects both
+        # async select() callers and sync select_sync() callers from thread
+        # executors (e.g. CASOpenAIBackend.generate_streaming runs in a thread).
+        # The critical section is nanoseconds — no meaningful event-loop blocking.
+        self._lock = threading.Lock()
+        self._cooldown_policy: dict[AuthProfileFailureReason, timedelta | None] = {
+            **_DEFAULT_COOLDOWN_POLICY,
+            **(cooldown_overrides or {}),
+        }
+
+    # ------------------------------------------------------------------
+    # Selection
+    # ------------------------------------------------------------------
+
+    async def select(
+        self,
+        *,
+        account_identifier: str | None = None,
+    ) -> AuthProfile:
+        """Return a usable profile per this pool's strategy.
+
+        Skips profiles on cooldown or operator-disabled. Raises
+        NoAvailableCredentialError (with structured per-profile state) if all
+        profiles are unavailable.
+
+        Args:
+            account_identifier: If set, restrict to profiles matching this
+                account (for user-scoped multi-tenant pools).
+        """
+        # Freeze now once so every _is_usable comparison uses the same instant.
+        # This prevents off-by-one races at exact cooldown boundaries and makes
+        # parametrized boundary tests deterministic.
+        now = datetime.utcnow()
+
+        all_profiles = self.store.list(provider=self.provider)
+        if account_identifier is not None:
+            all_profiles = [p for p in all_profiles if p.account_identifier == account_identifier]
+
+        candidates = [p for p in all_profiles if self._is_usable(p, now)]
+
+        if not candidates:
+            exhausted = [
+                ExhaustedProfile(
+                    profile=p,
+                    reason=p.usage_stats.cooldown_reason,
+                    cooldown_eta=(p.usage_stats.cooldown_until or p.usage_stats.disabled_until),
+                )
+                for p in all_profiles
+            ]
+            raise NoAvailableCredentialError(
+                provider=self.provider,
+                exhausted_profiles=exhausted,
+            )
+
+        match self.strategy:
+            case "first_ok":
+                return candidates[0]
+            case "round_robin":
+                with self._lock:
+                    self._last_index = (self._last_index + 1) % len(candidates)
+                    idx = self._last_index
+                return candidates[idx]
+            case "random":
+                return random.choice(candidates)
+            case "least_used":
+                return min(
+                    candidates,
+                    key=lambda p: (p.usage_stats.success_count + p.usage_stats.failure_count),
+                )
+            case _:
+                raise ValueError(f"Unknown strategy: {self.strategy!r}")
+
+    def select_sync(
+        self,
+        *,
+        account_identifier: str | None = None,
+    ) -> AuthProfile:
+        """Synchronous version of select() for non-async call sites.
+
+        Semantically identical to select(). Use this from sync code (e.g.
+        generator functions, thread-pool executors). Cannot be awaited.
+
+        Raises:
+            NoAvailableCredentialError: if all profiles are on cooldown or disabled.
+        """
+        now = datetime.utcnow()
+        all_profiles = self.store.list(provider=self.provider)
+        if account_identifier is not None:
+            all_profiles = [p for p in all_profiles if p.account_identifier == account_identifier]
+
+        candidates = [p for p in all_profiles if self._is_usable(p, now)]
+
+        if not candidates:
+            exhausted = [
+                ExhaustedProfile(
+                    profile=p,
+                    reason=p.usage_stats.cooldown_reason,
+                    cooldown_eta=(p.usage_stats.cooldown_until or p.usage_stats.disabled_until),
+                )
+                for p in all_profiles
+            ]
+            raise NoAvailableCredentialError(
+                provider=self.provider,
+                exhausted_profiles=exhausted,
+            )
+
+        match self.strategy:
+            case "first_ok":
+                return candidates[0]
+            case "round_robin":
+                with self._lock:
+                    self._last_index = (self._last_index + 1) % len(candidates)
+                    idx = self._last_index
+                return candidates[idx]
+            case "random":
+                return random.choice(candidates)
+            case "least_used":
+                return min(
+                    candidates,
+                    key=lambda p: (p.usage_stats.success_count + p.usage_stats.failure_count),
+                )
+            case _:
+                raise ValueError(f"Unknown strategy: {self.strategy!r}")
+
+    # ------------------------------------------------------------------
+    # Outcome recording
+    # ------------------------------------------------------------------
+
+    def mark_success(self, profile: AuthProfile) -> None:
+        """Record a successful use; clear any active cooldown."""
+        stats = profile.usage_stats
+        stats.success_count += 1
+        stats.last_used_at = datetime.utcnow()
+        stats.cooldown_until = None
+        stats.cooldown_reason = None
+        self.store.upsert(profile)
+
+    def mark_failure(
+        self,
+        profile: AuthProfile,
+        reason: AuthProfileFailureReason,
+    ) -> None:
+        """Record a failure and apply the policy cooldown for this reason."""
+        stats = profile.usage_stats
+        stats.failure_count += 1
+        stats.last_used_at = datetime.utcnow()
+        cooldown = self._cooldown_policy.get(reason)
+        if cooldown is not None:
+            stats.cooldown_until = datetime.utcnow() + cooldown
+        stats.cooldown_reason = reason
+        self.store.upsert(profile)
+        logger.warning(
+            "Credential failure: provider=%s account=%s reason=%s cooldown=%s",
+            self.provider,
+            profile.account_identifier,
+            reason.value,
+            cooldown,
+        )
+
+    # ------------------------------------------------------------------
+    # Combined execute with single credential-switch retry
+    # ------------------------------------------------------------------
+
+    def execute_sync(
+        self,
+        fn: Callable[[AuthProfile], Any],
+        classifier: CredentialErrorClassifier,
+        *,
+        account_identifier: str | None = None,
+    ) -> Any:
+        """Synchronous version of execute() for non-async call sites.
+
+        Semantically identical to execute(): selects a credential, calls fn,
+        handles failure, retries once on retriable errors. Use from sync code
+        (connector methods, thread-pool executors, generators).
+
+        Args:
+            fn: Callable accepting an AuthProfile, returning T.
+            classifier: Maps provider exceptions to AuthProfileFailureReason.
+            account_identifier: Passed through to select_sync() for scoped pools.
+
+        Returns:
+            Whatever fn returns.
+
+        Raises:
+            NoAvailableCredentialError: if all profiles exhausted.
+            Exception: non-retriable failure from fn, re-raised after mark_failure.
+        """
+        profile = self.select_sync(account_identifier=account_identifier)
+        try:
+            result = fn(profile)
+            self.mark_success(profile)
+            return result
+        except Exception as exc:
+            try:
+                reason = classifier(exc)
+            except Exception:
+                reason = AuthProfileFailureReason.UNKNOWN
+            self.mark_failure(profile, reason)
+            if reason not in _RETRIABLE_REASONS:
+                raise exc
+
+        # Single retry with a different credential (first is now on cooldown)
+        next_profile = self.select_sync(account_identifier=account_identifier)
+        try:
+            result = fn(next_profile)
+            self.mark_success(next_profile)
+            return result
+        except Exception as retry_exc:
+            try:
+                retry_reason = classifier(retry_exc)
+            except Exception:
+                retry_reason = AuthProfileFailureReason.UNKNOWN
+            self.mark_failure(next_profile, retry_reason)
+            raise
+
+    async def execute(
+        self,
+        fn: Callable[[AuthProfile], Any],
+        classifier: CredentialErrorClassifier,
+        *,
+        account_identifier: str | None = None,
+    ) -> Any:
+        """Select a credential, call fn, handle failure, retry on retriable errors.
+
+        Retriable reasons (RATE_LIMIT, OVERLOADED, TIMEOUT): mark the failing
+        profile on cooldown, then select a different credential and retry once.
+
+        Non-retriable reasons: mark failure, re-raise immediately.
+
+        If the classifier itself raises, the profile is marked UNKNOWN and the
+        original exception is re-raised — the pool never leaves a profile in an
+        undefined state.
+
+        Args:
+            fn: Callable accepting an AuthProfile, returning T or Awaitable[T].
+                Should use profile.credential to authenticate the API call.
+            classifier: Maps the provider's exception to AuthProfileFailureReason.
+            account_identifier: Passed through to select() for user-scoped pools.
+
+        Returns:
+            Whatever fn returns (awaited if it is a coroutine).
+
+        Raises:
+            NoAvailableCredentialError: all profiles exhausted before or after retry.
+            Exception: non-retriable failure from fn, re-raised after mark_failure.
+        """
+        profile = await self.select(account_identifier=account_identifier)
+        try:
+            result = fn(profile)
+            if inspect.isawaitable(result):
+                result = await result
+            self.mark_success(profile)
+            return result
+        except Exception as exc:
+            try:
+                reason = classifier(exc)
+            except Exception:
+                reason = AuthProfileFailureReason.UNKNOWN
+            self.mark_failure(profile, reason)
+            if reason not in _RETRIABLE_REASONS:
+                raise exc
+
+        # Single retry with a different credential (first profile is now on cooldown).
+        next_profile = await self.select(account_identifier=account_identifier)
+        try:
+            result = fn(next_profile)
+            if inspect.isawaitable(result):
+                result = await result
+            self.mark_success(next_profile)
+            return result
+        except Exception as retry_exc:
+            try:
+                retry_reason = classifier(retry_exc)
+            except Exception:
+                retry_reason = AuthProfileFailureReason.UNKNOWN
+            self.mark_failure(next_profile, retry_reason)
+            raise
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    @staticmethod
+    def _is_usable(profile: AuthProfile, now: datetime) -> bool:
+        """Return True if the profile is available for selection right now.
+
+        Both disabled_until (operator-set) and cooldown_until (auto-set) block
+        selection independently. A profile is usable when neither is in the future.
+
+        Args:
+            profile: The profile to check.
+            now: Frozen timestamp from the caller — ensures all profiles in a
+                 single select() are evaluated against the same instant.
+        """
+        stats: ProfileUsageStats = profile.usage_stats
+        if stats.disabled_until is not None and stats.disabled_until > now:
+            return False
+        return not (stats.cooldown_until is not None and stats.cooldown_until > now)
+
+
+# ---------------------------------------------------------------------------
+# CredentialPoolRegistry
+# ---------------------------------------------------------------------------
+
+
+class CredentialPoolRegistry:
+    """Process-scoped registry — one CredentialPool per provider.
+
+    Instantiate once at application startup alongside the auth brick and pass
+    to connectors as a dependency. This ensures round_robin and least_used
+    strategies are fairly distributed across all callers and requests.
+
+    Without a registry, each connector-instance creates its own pool with its
+    own _last_index, so round_robin has no cross-connector fairness.
+
+    Usage:
+        registry = CredentialPoolRegistry(store=profile_store)
+        pool = registry.get("openai", strategy="least_used")
+    """
+
+    def __init__(self, store: AuthProfileStore) -> None:
+        self.store = store
+        self._pools: dict[str, CredentialPool] = {}
+
+    def get(
+        self,
+        provider: str,
+        *,
+        strategy: SelectionStrategy = "first_ok",
+        cooldown_overrides: dict[AuthProfileFailureReason, timedelta | None] | None = None,
+    ) -> CredentialPool:
+        """Return the pool for a provider, creating it on first access.
+
+        The strategy and cooldown_overrides are only applied at pool creation.
+        If the pool already exists, the existing configuration is returned as-is.
+        """
+        if provider not in self._pools:
+            self._pools[provider] = CredentialPool(
+                provider=provider,
+                store=self.store,
+                strategy=strategy,
+                cooldown_overrides=cooldown_overrides,
+            )
+        return self._pools[provider]
+
+    def shutdown(self) -> None:
+        """Clear all pools on application shutdown."""
+        self._pools.clear()

--- a/src/nexus/bricks/auth/credential_pool.py
+++ b/src/nexus/bricks/auth/credential_pool.py
@@ -310,12 +310,24 @@ class CredentialPool:
     # ------------------------------------------------------------------
 
     def mark_success(self, profile: AuthProfile) -> None:
-        """Record a successful use; clear any active cooldown."""
+        """Record a successful use; clear cooldown only if no newer failure exists.
+
+        Under concurrent load a later request may already have recorded a
+        RATE_LIMIT/OVERLOADED failure (setting cooldown_until in the future)
+        before an earlier request's success is recorded.  Unconditionally
+        clearing cooldown_until here would allow a throttled credential back
+        into rotation immediately, causing repeated hammering.
+
+        Safe rule: only clear the cooldown if it has already passed (or was
+        never set), meaning no newer failure has imposed a future cooldown.
+        """
         stats = profile.usage_stats
         stats.success_count += 1
         stats.last_used_at = datetime.utcnow()
-        stats.cooldown_until = None
-        stats.cooldown_reason = None
+        now = datetime.utcnow()
+        if stats.cooldown_until is None or stats.cooldown_until <= now:
+            stats.cooldown_until = None
+            stats.cooldown_reason = None
         self.store.upsert(profile)
 
     def mark_failure(

--- a/src/nexus/bricks/auth/credential_pool.py
+++ b/src/nexus/bricks/auth/credential_pool.py
@@ -147,7 +147,7 @@ class CredentialErrorClassifier(Protocol):
     See nexus.bricks.auth.classifiers for implementations.
     """
 
-    def __call__(self, exc: Exception) -> AuthProfileFailureReason: ...
+    def __call__(self, __exc: Exception) -> AuthProfileFailureReason: ...
 
 
 # ---------------------------------------------------------------------------

--- a/src/nexus/bricks/auth/credential_pool.py
+++ b/src/nexus/bricks/auth/credential_pool.py
@@ -181,7 +181,8 @@ class CredentialPool:
         self.provider = provider
         self.store = store
         self.strategy: SelectionStrategy = strategy
-        self._last_index: int = 0
+        # round_robin increments before reading; -1 ensures first call returns index 0
+        self._last_index: int = -1
         # threading.Lock (not asyncio.Lock) so the same lock protects both
         # async select() callers and sync select_sync() callers from thread
         # executors (e.g. CASOpenAIBackend.generate_streaming runs in a thread).

--- a/src/nexus/bricks/auth/profile.py
+++ b/src/nexus/bricks/auth/profile.py
@@ -1,0 +1,165 @@
+"""Auth profile data model and store protocol.
+
+This module defines:
+  - AuthProfileFailureReason: enum mapping every provider's failure vocabulary
+    to a single classification (ported from OpenClaw's AuthProfileFailureReason).
+  - AuthProfile / ProfileUsageStats: runtime credential data model.
+  - AuthProfileStore: Protocol that #3722 implements with SQLite. All code in
+    #3723 depends only on this Protocol — never on the concrete implementation.
+  - InMemoryAuthProfileStore: dict-backed stub for tests and pre-#3722 use.
+
+Issue #3722 will land SqliteAuthProfileStore implementing AuthProfileStore.
+This issue (#3723) uses only the Protocol so it can land independently.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from enum import Enum
+from typing import Literal, Protocol, runtime_checkable
+
+# ---------------------------------------------------------------------------
+# Credential shapes
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ApiKeyCredential:
+    kind: Literal["api_key"] = "api_key"
+    key: str = ""
+
+
+@dataclass
+class TokenCredential:
+    kind: Literal["token"] = "token"
+    access_token: str = ""
+    refresh_token: str | None = None
+    expires_at: datetime | None = None
+
+
+@dataclass
+class OAuthCredential:
+    kind: Literal["oauth"] = "oauth"
+    access_token: str = ""
+    refresh_token: str | None = None
+    expires_at: datetime | None = None
+    scopes: list[str] = field(default_factory=list)
+
+
+AuthProfileCredential = ApiKeyCredential | TokenCredential | OAuthCredential
+
+ExternalCliManager = Literal["aws-cli", "gcloud", "gh-cli", "gws-cli", "codex-cli"]
+
+
+# ---------------------------------------------------------------------------
+# Failure reason enum (OpenClaw pattern)
+# ---------------------------------------------------------------------------
+
+
+class AuthProfileFailureReason(Enum):
+    AUTH = "auth"  # wrong credentials (wrong password, typo)
+    AUTH_PERMANENT = "auth_permanent"  # revoked — requires user action to recover
+    FORMAT = "format"  # malformed token (not an auth problem per se)
+    OVERLOADED = "overloaded"  # provider temporary issue, try again soon
+    RATE_LIMIT = "rate_limit"  # 429 — cooldown + auto-recover
+    BILLING = "billing"  # 402 / insufficient_quota — long cooldown
+    TIMEOUT = "timeout"  # network issue, retry immediately
+    MODEL_NOT_FOUND = "model_not_found"  # not applicable to all providers
+    SESSION_EXPIRED = "session_expired"  # requires user re-authentication
+    UNKNOWN = "unknown"  # fallback when classifier can't map the error
+
+
+# ---------------------------------------------------------------------------
+# Usage stats
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class ProfileUsageStats:
+    last_used_at: datetime | None = None
+    success_count: int = 0
+    failure_count: int = 0
+    cooldown_until: datetime | None = None
+    cooldown_reason: AuthProfileFailureReason | None = None
+    # disabled_until is for operator-set disables (billing review, manual ban).
+    # cooldown_until is for automatic cooldowns after failures.
+    # Both are checked by _is_usable; either blocks selection.
+    disabled_until: datetime | None = None
+
+
+# ---------------------------------------------------------------------------
+# Auth profile
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class AuthProfile:
+    id: str  # e.g. "openai/default"
+    provider: str  # e.g. "openai"
+    account_identifier: str  # e.g. "default" or "user@example.com"
+    credential: AuthProfileCredential
+    managed_by: ExternalCliManager | None = None  # None = nexus-native
+    last_synced_at: datetime | None = None
+    sync_ttl_seconds: int = 300
+    usage_stats: ProfileUsageStats = field(default_factory=ProfileUsageStats)
+
+
+# ---------------------------------------------------------------------------
+# Store protocol — #3722 provides SqliteAuthProfileStore.
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class AuthProfileStore(Protocol):
+    """Protocol for the unified auth-profile store.
+
+    Issue #3723 depends only on this Protocol.
+    Issue #3722 provides the concrete SqliteAuthProfileStore.
+    Tests use InMemoryAuthProfileStore so #3723 can land without #3722.
+    """
+
+    def list(self, *, provider: str | None = None) -> list[AuthProfile]:
+        """Return all profiles, optionally filtered by provider."""
+        ...
+
+    def get(self, profile_id: str) -> AuthProfile | None:
+        """Return one profile by ID, or None if not found."""
+        ...
+
+    def upsert(self, profile: AuthProfile) -> None:
+        """Insert or update a profile (keyed by profile.id)."""
+        ...
+
+    def delete(self, profile_id: str) -> None:
+        """Remove a profile by ID."""
+        ...
+
+
+# ---------------------------------------------------------------------------
+# In-memory store — tests and pre-#3722 fallback
+# ---------------------------------------------------------------------------
+
+
+class InMemoryAuthProfileStore:
+    """Dict-backed AuthProfileStore for tests and local use before #3722 lands.
+
+    Not thread-safe. Wrap with asyncio.Lock if used across concurrent tasks.
+    """
+
+    def __init__(self) -> None:
+        self._profiles: dict[str, AuthProfile] = {}
+
+    def list(self, *, provider: str | None = None) -> list[AuthProfile]:
+        if provider is None:
+            return list(self._profiles.values())
+        return [p for p in self._profiles.values() if p.provider == provider]
+
+    def get(self, profile_id: str) -> AuthProfile | None:
+        return self._profiles.get(profile_id)
+
+    def upsert(self, profile: AuthProfile) -> None:
+        self._profiles[profile.id] = profile
+
+    def delete(self, profile_id: str) -> None:
+        self._profiles.pop(profile_id, None)

--- a/src/nexus/bricks/auth/tests/test_credential_pool.py
+++ b/src/nexus/bricks/auth/tests/test_credential_pool.py
@@ -146,8 +146,9 @@ async def test_round_robin_cycles_across_profiles() -> None:
     pool, store = make_pool("a", "b", "c", strategy="round_robin")
     results = [await pool.select() for _ in range(6)]
     ids = [r.id for r in results]
-    # Should cycle through all 3, repeating
+    # Should cycle through all 3, repeating, starting at index 0
     assert set(ids) == {"a", "b", "c"}
+    assert ids[0] == "a"  # first call must start at candidates[0], not candidates[1]
     assert ids[0] == ids[3]  # same position 3 apart in a 3-profile pool
 
 
@@ -545,10 +546,10 @@ def test_select_sync_round_robin_same_state_as_async() -> None:
     # Advance via async select
     import asyncio as _asyncio
 
-    _asyncio.run(pool.select())  # idx→1 → returns candidates[1] = "b"
-    # Next sync select should continue from idx=1 → idx=2 → "c"
+    _asyncio.run(pool.select())  # idx→0 → returns candidates[0] = "a"
+    # Next sync select should continue from idx=0 → idx=1 → "b"
     result = pool.select_sync()
-    assert result.id == "c"
+    assert result.id == "b"
 
 
 def test_select_sync_from_thread_no_event_loop() -> None:

--- a/src/nexus/bricks/auth/tests/test_credential_pool.py
+++ b/src/nexus/bricks/auth/tests/test_credential_pool.py
@@ -29,6 +29,7 @@ from nexus.bricks.auth.credential_pool import (
     CredentialPool,
     CredentialPoolRegistry,
     NoAvailableCredentialError,
+    SelectionStrategy,
 )
 from nexus.bricks.auth.profile import (
     ApiKeyCredential,
@@ -73,7 +74,7 @@ def make_profile(
 def make_pool(
     *profile_ids: str,
     provider: str = "openai",
-    strategy: str = "first_ok",
+    strategy: SelectionStrategy = "first_ok",
     cooldown_overrides=None,
 ) -> tuple[CredentialPool, InMemoryAuthProfileStore]:
     store = InMemoryAuthProfileStore()
@@ -618,13 +619,15 @@ def test_registry_shutdown_clears_pools() -> None:
 
 def _make_openai_exc(exc_class, *, code: str | None = None, message: str = "error") -> Exception:
     """Construct a minimal openai exception for classifier tests."""
-    exc = exc_class.__new__(exc_class)
+    from typing import Any, cast
+
+    exc: Any = exc_class.__new__(exc_class)
     Exception.__init__(exc, message)
     exc.code = code
     exc.status_code = 429
     exc.response = None
     exc.body = {"error": {"code": code, "message": message}}
-    return exc
+    return cast(Exception, exc)
 
 
 @pytest.mark.parametrize(

--- a/src/nexus/bricks/auth/tests/test_credential_pool.py
+++ b/src/nexus/bricks/auth/tests/test_credential_pool.py
@@ -195,24 +195,54 @@ async def test_mark_failure_sets_cooldown() -> None:
     assert updated.usage_stats.failure_count == 1
 
 
-async def test_mark_success_clears_cooldown() -> None:
+async def test_mark_success_does_not_clear_active_cooldown() -> None:
+    """mark_success must not resurrect a credential with a future cooldown.
+
+    Scenario: request A selected the profile (no cooldown), request B then
+    hits RATE_LIMIT and sets cooldown_until = now + 1h.  When request A's
+    success is recorded later it must NOT clear the cooldown — otherwise the
+    throttled credential would re-enter rotation immediately.
+    """
     pool, store = make_pool("p1", strategy="first_ok")
     profile = store.get("p1")
     assert profile is not None
 
-    # First put it on cooldown
+    # Simulate concurrent failure setting a future cooldown
     pool.mark_failure(profile, AuthProfileFailureReason.RATE_LIMIT)
     profile = store.get("p1")
     assert profile is not None
     assert profile.usage_stats.cooldown_until is not None
 
-    # Then mark success — should clear cooldown
+    # Stale success from an earlier concurrent request must NOT clear cooldown
     pool.mark_success(profile)
-    recovered = store.get("p1")
-    assert recovered is not None
-    assert recovered.usage_stats.cooldown_until is None
-    assert recovered.usage_stats.cooldown_reason is None
-    assert recovered.usage_stats.success_count == 1
+    after = store.get("p1")
+    assert after is not None
+    assert after.usage_stats.cooldown_until is not None, (
+        "mark_success must not clear a future cooldown (stale-success race)"
+    )
+    assert after.usage_stats.cooldown_reason is not None
+    assert after.usage_stats.success_count == 1
+
+
+async def test_mark_success_clears_expired_cooldown() -> None:
+    """mark_success clears a cooldown that has already passed."""
+    from datetime import timedelta
+
+    pool, store = make_pool("p1", strategy="first_ok")
+    profile = store.get("p1")
+    assert profile is not None
+
+    # Manually set a cooldown in the past
+    profile.usage_stats.cooldown_until = datetime.utcnow() - timedelta(seconds=1)
+    profile.usage_stats.cooldown_reason = AuthProfileFailureReason.RATE_LIMIT
+    store.upsert(profile)
+
+    # Success should clear the already-expired cooldown
+    pool.mark_success(profile)
+    after = store.get("p1")
+    assert after is not None
+    assert after.usage_stats.cooldown_until is None
+    assert after.usage_stats.cooldown_reason is None
 
 
 async def test_no_cooldown_for_auth_transient() -> None:

--- a/src/nexus/bricks/auth/tests/test_credential_pool.py
+++ b/src/nexus/bricks/auth/tests/test_credential_pool.py
@@ -296,9 +296,9 @@ async def test_all_profiles_exhausted_raises_structured_error() -> None:
     assert reasons["p1"] == AuthProfileFailureReason.RATE_LIMIT
     assert reasons["p2"] == AuthProfileFailureReason.BILLING
 
-    # Error message should include provider and 'nexus-fs auth pool status'
+    # Error message should include provider and guidance on recovery
     assert "openai" in str(err)
-    assert "nexus-fs auth pool status" in str(err)
+    assert "cooldown" in str(err).lower()
 
 
 async def test_no_profiles_raises_with_empty_list() -> None:

--- a/src/nexus/bricks/auth/tests/test_credential_pool.py
+++ b/src/nexus/bricks/auth/tests/test_credential_pool.py
@@ -1,0 +1,709 @@
+"""Tests for CredentialPool, CredentialPoolRegistry, and classifiers.
+
+Coverage map:
+  - Strategy correctness: first_ok, round_robin, least_used, random
+  - Cooldown enforcement and auto-recovery
+  - All-profiles-exhausted: NoAvailableCredentialError with structured state
+  - _is_usable boundary conditions (parametrized, 6 cases)
+  - pool.execute() paths: success, non-retriable failure, retriable+retry,
+    all-exhausted during retry, classifier-raises
+  - asyncio.Lock concurrency: 100 concurrent round_robin calls
+  - account_identifier scoping
+  - cooldown_overrides per-pool
+  - CredentialPoolRegistry singleton-per-provider
+  - classify_openai_error: all exception types including billing/rate-limit split
+"""
+
+from __future__ import annotations
+
+import asyncio
+from collections import Counter
+from datetime import datetime, timedelta
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from nexus.bricks.auth.credential_pool import (
+    _DEFAULT_COOLDOWN_POLICY,
+    _RETRIABLE_REASONS,
+    CredentialPool,
+    CredentialPoolRegistry,
+    NoAvailableCredentialError,
+)
+from nexus.bricks.auth.profile import (
+    ApiKeyCredential,
+    AuthProfile,
+    AuthProfileFailureReason,
+    InMemoryAuthProfileStore,
+    ProfileUsageStats,
+)
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def make_profile(
+    profile_id: str,
+    provider: str = "openai",
+    account_identifier: str | None = None,
+    *,
+    cooldown_until: datetime | None = None,
+    disabled_until: datetime | None = None,
+    success_count: int = 0,
+    failure_count: int = 0,
+    cooldown_reason: AuthProfileFailureReason | None = None,
+) -> AuthProfile:
+    stats = ProfileUsageStats(
+        cooldown_until=cooldown_until,
+        disabled_until=disabled_until,
+        success_count=success_count,
+        failure_count=failure_count,
+        cooldown_reason=cooldown_reason,
+    )
+    return AuthProfile(
+        id=profile_id,
+        provider=provider,
+        account_identifier=account_identifier or profile_id,
+        credential=ApiKeyCredential(key=f"sk-{profile_id}"),
+        usage_stats=stats,
+    )
+
+
+def make_pool(
+    *profile_ids: str,
+    provider: str = "openai",
+    strategy: str = "first_ok",
+    cooldown_overrides=None,
+) -> tuple[CredentialPool, InMemoryAuthProfileStore]:
+    store = InMemoryAuthProfileStore()
+    for pid in profile_ids:
+        store.upsert(make_profile(pid, provider=provider))
+    pool = CredentialPool(
+        provider=provider,
+        store=store,
+        strategy=strategy,
+        cooldown_overrides=cooldown_overrides,
+    )
+    return pool, store
+
+
+# ---------------------------------------------------------------------------
+# _is_usable boundary conditions (Issue 11)
+# ---------------------------------------------------------------------------
+
+# Anchor: 2026-01-15 12:00:00 UTC
+_NOW = datetime(2026, 1, 15, 12, 0, 0)
+_1US = timedelta(microseconds=1)
+_1DAY = timedelta(days=1)
+_1HR = timedelta(hours=1)
+
+
+@pytest.mark.parametrize(
+    "cooldown_until, disabled_until, expected, label",
+    [
+        (None, None, True, "no_restriction"),
+        (_NOW - _1US, None, True, "cooldown_expired_1us_ago"),
+        (_NOW, None, True, "cooldown_exactly_now"),  # > not >= → usable at exact boundary
+        (_NOW + _1US, None, False, "cooldown_1us_in_future"),
+        (None, _NOW + _1DAY, False, "disabled_until_set"),
+        (_NOW + _1HR, _NOW + _1DAY, False, "both_fields_set"),
+    ],
+)
+def test_is_usable_boundary(
+    cooldown_until: datetime | None,
+    disabled_until: datetime | None,
+    expected: bool,
+    label: str,
+) -> None:
+    """_is_usable uses frozen now for deterministic boundary comparisons."""
+    profile = make_profile("p", cooldown_until=cooldown_until, disabled_until=disabled_until)
+    profile.usage_stats.cooldown_until = cooldown_until
+    profile.usage_stats.disabled_until = disabled_until
+    assert CredentialPool._is_usable(profile, _NOW) == expected, f"case: {label}"
+
+
+# ---------------------------------------------------------------------------
+# Strategy tests
+# ---------------------------------------------------------------------------
+
+
+async def test_first_ok_returns_first_candidate() -> None:
+    pool, store = make_pool("p1", "p2", "p3", strategy="first_ok")
+    result = await pool.select()
+    assert result.id == "p1"
+
+
+async def test_first_ok_skips_cooldown_profiles() -> None:
+    pool, store = make_pool(strategy="first_ok")
+    store.upsert(make_profile("p1", cooldown_until=datetime(2099, 1, 1)))
+    store.upsert(make_profile("p2"))
+    result = await pool.select()
+    assert result.id == "p2"
+
+
+async def test_round_robin_cycles_across_profiles() -> None:
+    pool, store = make_pool("a", "b", "c", strategy="round_robin")
+    results = [await pool.select() for _ in range(6)]
+    ids = [r.id for r in results]
+    # Should cycle through all 3, repeating
+    assert set(ids) == {"a", "b", "c"}
+    assert ids[0] == ids[3]  # same position 3 apart in a 3-profile pool
+
+
+async def test_least_used_picks_lowest_call_count() -> None:
+    pool, store = make_pool(strategy="least_used")
+    store.upsert(make_profile("heavy", success_count=100, failure_count=50))
+    store.upsert(make_profile("light", success_count=1, failure_count=0))
+    result = await pool.select()
+    assert result.id == "light"
+
+
+async def test_random_strategy_returns_a_valid_profile() -> None:
+    pool, store = make_pool("x", "y", "z", strategy="random")
+    result = await pool.select()
+    assert result.id in {"x", "y", "z"}
+
+
+# ---------------------------------------------------------------------------
+# Cooldown enforcement
+# ---------------------------------------------------------------------------
+
+
+async def test_select_skips_cooled_down_profiles() -> None:
+    pool, store = make_pool(strategy="first_ok")
+    future = datetime(2099, 12, 31)
+    store.upsert(make_profile("p1", cooldown_until=future))
+    store.upsert(make_profile("p2", cooldown_until=future))
+    store.upsert(make_profile("p3"))  # only usable one
+    result = await pool.select()
+    assert result.id == "p3"
+
+
+async def test_mark_failure_sets_cooldown() -> None:
+    pool, store = make_pool("p1", strategy="first_ok")
+    profile = store.get("p1")
+    assert profile is not None
+
+    pool.mark_failure(profile, AuthProfileFailureReason.RATE_LIMIT)
+
+    updated = store.get("p1")
+    assert updated is not None
+    assert updated.usage_stats.cooldown_until is not None
+    assert updated.usage_stats.cooldown_until > datetime.utcnow()
+    assert updated.usage_stats.cooldown_reason == AuthProfileFailureReason.RATE_LIMIT
+    assert updated.usage_stats.failure_count == 1
+
+
+async def test_mark_success_clears_cooldown() -> None:
+    pool, store = make_pool("p1", strategy="first_ok")
+    profile = store.get("p1")
+    assert profile is not None
+
+    # First put it on cooldown
+    pool.mark_failure(profile, AuthProfileFailureReason.RATE_LIMIT)
+    profile = store.get("p1")
+    assert profile is not None
+    assert profile.usage_stats.cooldown_until is not None
+
+    # Then mark success — should clear cooldown
+    pool.mark_success(profile)
+    recovered = store.get("p1")
+    assert recovered is not None
+    assert recovered.usage_stats.cooldown_until is None
+    assert recovered.usage_stats.cooldown_reason is None
+    assert recovered.usage_stats.success_count == 1
+
+
+async def test_no_cooldown_for_auth_transient() -> None:
+    """AUTH reason has no cooldown — user is likely actively fixing credentials."""
+    pool, store = make_pool("p1", strategy="first_ok")
+    profile = store.get("p1")
+    assert profile is not None
+
+    pool.mark_failure(profile, AuthProfileFailureReason.AUTH)
+
+    updated = store.get("p1")
+    assert updated is not None
+    assert updated.usage_stats.cooldown_until is None
+    assert updated.usage_stats.cooldown_reason == AuthProfileFailureReason.AUTH
+
+
+# ---------------------------------------------------------------------------
+# NoAvailableCredentialError with structured state (Issue 8)
+# ---------------------------------------------------------------------------
+
+
+async def test_all_profiles_exhausted_raises_structured_error() -> None:
+    pool, store = make_pool(strategy="first_ok")
+    future = datetime(2099, 6, 15, 10, 0, 0)
+    store.upsert(
+        make_profile(
+            "p1",
+            cooldown_until=future,
+            cooldown_reason=AuthProfileFailureReason.RATE_LIMIT,
+        )
+    )
+    store.upsert(
+        make_profile(
+            "p2",
+            cooldown_until=future,
+            cooldown_reason=AuthProfileFailureReason.BILLING,
+        )
+    )
+
+    with pytest.raises(NoAvailableCredentialError) as exc_info:
+        await pool.select()
+
+    err = exc_info.value
+    assert err.provider == "openai"
+    assert len(err.exhausted_profiles) == 2
+
+    ids = {ep.profile.id for ep in err.exhausted_profiles}
+    assert ids == {"p1", "p2"}
+
+    reasons = {ep.profile.id: ep.reason for ep in err.exhausted_profiles}
+    assert reasons["p1"] == AuthProfileFailureReason.RATE_LIMIT
+    assert reasons["p2"] == AuthProfileFailureReason.BILLING
+
+    # Error message should include provider and 'nexus-fs auth pool status'
+    assert "openai" in str(err)
+    assert "nexus-fs auth pool status" in str(err)
+
+
+async def test_no_profiles_raises_with_empty_list() -> None:
+    pool, store = make_pool(strategy="first_ok")  # no profiles added
+    with pytest.raises(NoAvailableCredentialError) as exc_info:
+        await pool.select()
+    assert exc_info.value.exhausted_profiles == []
+
+
+# ---------------------------------------------------------------------------
+# account_identifier scoping
+# ---------------------------------------------------------------------------
+
+
+async def test_select_filters_by_account_identifier() -> None:
+    store = InMemoryAuthProfileStore()
+    store.upsert(make_profile("alice-openai", account_identifier="alice@example.com"))
+    store.upsert(make_profile("bob-openai", account_identifier="bob@example.com"))
+    pool = CredentialPool(provider="openai", store=store, strategy="first_ok")
+
+    result = await pool.select(account_identifier="alice@example.com")
+    assert result.account_identifier == "alice@example.com"
+
+
+async def test_select_account_identifier_all_exhausted_raises() -> None:
+    store = InMemoryAuthProfileStore()
+    store.upsert(
+        make_profile(
+            "alice-openai",
+            account_identifier="alice@example.com",
+            cooldown_until=datetime(2099, 1, 1),
+        )
+    )
+    pool = CredentialPool(provider="openai", store=store, strategy="first_ok")
+
+    with pytest.raises(NoAvailableCredentialError):
+        await pool.select(account_identifier="alice@example.com")
+
+
+# ---------------------------------------------------------------------------
+# cooldown_overrides
+# ---------------------------------------------------------------------------
+
+
+async def test_cooldown_override_changes_duration() -> None:
+    """Per-pool cooldown_overrides replace the default policy for that reason."""
+    custom = {AuthProfileFailureReason.RATE_LIMIT: timedelta(minutes=2)}
+    pool, store = make_pool("p1", strategy="first_ok", cooldown_overrides=custom)
+    profile = store.get("p1")
+    assert profile is not None
+
+    pool.mark_failure(profile, AuthProfileFailureReason.RATE_LIMIT)
+
+    updated = store.get("p1")
+    assert updated is not None
+    assert updated.usage_stats.cooldown_until is not None
+
+    # Should be ~2 minutes, not the default 1 hour
+    expected_min = datetime.utcnow() + timedelta(minutes=1, seconds=30)
+    expected_max = datetime.utcnow() + timedelta(minutes=2, seconds=30)
+    assert expected_min < updated.usage_stats.cooldown_until < expected_max
+
+
+# ---------------------------------------------------------------------------
+# pool.execute() paths (Issue 12)
+# ---------------------------------------------------------------------------
+
+
+async def test_execute_success_path() -> None:
+    """Success: mark_success called, result returned."""
+    pool, store = make_pool("p1")
+
+    async def fn(profile: AuthProfile) -> str:
+        return f"ok:{profile.id}"
+
+    result = await pool.execute(fn, lambda _: AuthProfileFailureReason.UNKNOWN)
+    assert result == "ok:p1"
+
+    updated = store.get("p1")
+    assert updated is not None
+    assert updated.usage_stats.success_count == 1
+    assert updated.usage_stats.cooldown_until is None
+
+
+async def test_execute_non_retriable_failure_reraises_immediately() -> None:
+    """Non-retriable failure: mark_failure called, exception re-raised, no retry."""
+    pool, store = make_pool("p1", "p2")
+    call_count = 0
+
+    async def fn(_profile: AuthProfile) -> None:
+        nonlocal call_count
+        call_count += 1
+        raise RuntimeError("auth failed")
+
+    def classifier(_exc: Exception) -> AuthProfileFailureReason:
+        return AuthProfileFailureReason.AUTH_PERMANENT
+
+    with pytest.raises(RuntimeError, match="auth failed"):
+        await pool.execute(fn, classifier)
+
+    # Only one call — no retry for AUTH_PERMANENT
+    assert call_count == 1
+
+    p1 = store.get("p1")
+    assert p1 is not None
+    assert p1.usage_stats.failure_count == 1
+    assert p1.usage_stats.cooldown_reason == AuthProfileFailureReason.AUTH_PERMANENT
+
+
+async def test_execute_retriable_failure_retries_with_different_credential() -> None:
+    """Retriable failure: first profile marked on cooldown, second profile used and succeeds."""
+    pool, store = make_pool("p1", "p2")
+    call_sequence: list[str] = []
+
+    async def fn(profile: AuthProfile) -> str:
+        call_sequence.append(profile.id)
+        if profile.id == "p1":
+            raise RuntimeError("rate limited")
+        return "ok"
+
+    def classifier(_exc: Exception) -> AuthProfileFailureReason:
+        return AuthProfileFailureReason.RATE_LIMIT
+
+    result = await pool.execute(fn, classifier)
+    assert result == "ok"
+    assert call_sequence == ["p1", "p2"]
+
+    p1 = store.get("p1")
+    assert p1 is not None
+    assert p1.usage_stats.failure_count == 1
+    assert p1.usage_stats.cooldown_until is not None  # on cooldown
+
+    p2 = store.get("p2")
+    assert p2 is not None
+    assert p2.usage_stats.success_count == 1
+
+
+async def test_execute_all_exhausted_during_retry_raises() -> None:
+    """If all profiles are on cooldown when retry calls select(), raise NoAvailableCredentialError."""
+    pool, store = make_pool("p1")  # single profile
+
+    async def fn(_profile: AuthProfile) -> None:
+        raise RuntimeError("rate limited")
+
+    def classifier(_exc: Exception) -> AuthProfileFailureReason:
+        return AuthProfileFailureReason.RATE_LIMIT
+
+    # p1 will be put on cooldown after first failure; retry select() finds no candidates
+    with pytest.raises(NoAvailableCredentialError):
+        await pool.execute(fn, classifier)
+
+
+async def test_execute_classifier_raises_marks_unknown_and_reraises_original() -> None:
+    """If classifier raises, profile is marked UNKNOWN and the original exception propagates."""
+    pool, store = make_pool("p1")
+    original_exc = RuntimeError("api call failed")
+
+    async def fn(_profile: AuthProfile) -> None:
+        raise original_exc
+
+    def bad_classifier(_exc: Exception) -> AuthProfileFailureReason:
+        raise ValueError("classifier bug")
+
+    with pytest.raises(RuntimeError, match="api call failed"):
+        await pool.execute(fn, bad_classifier)
+
+    p1 = store.get("p1")
+    assert p1 is not None
+    assert p1.usage_stats.failure_count == 1
+    assert p1.usage_stats.cooldown_reason == AuthProfileFailureReason.UNKNOWN
+
+
+async def test_execute_sync_callable() -> None:
+    """execute() works with a sync callable (not just async)."""
+    pool, store = make_pool("p1")
+
+    def sync_fn(profile: AuthProfile) -> str:
+        return f"sync:{profile.id}"
+
+    result = await pool.execute(sync_fn, lambda _: AuthProfileFailureReason.UNKNOWN)
+    assert result == "sync:p1"
+
+
+# ---------------------------------------------------------------------------
+# Concurrency test — asyncio.Lock correctness (Issue 9)
+# ---------------------------------------------------------------------------
+
+
+async def test_round_robin_concurrent_no_race() -> None:
+    """100 concurrent select() calls on round_robin distribute across all profiles.
+
+    This test verifies that asyncio.Lock prevents _last_index races. If the lock
+    were absent, concurrent increments would collide and some profiles would be
+    over- or under-represented beyond the expected modular distribution.
+    """
+    N_CALLS = 100
+    N_PROFILES = 3
+    pool, store = make_pool("a", "b", "c", strategy="round_robin")
+
+    results = await asyncio.gather(*[pool.select() for _ in range(N_CALLS)])
+    counts = Counter(r.id for r in results)
+
+    assert len(results) == N_CALLS
+    # All 3 profiles must appear at least once
+    assert set(counts.keys()) == {"a", "b", "c"}
+    # Each profile should appear roughly N/3 times (within ±5 of fair share)
+    fair_share = N_CALLS // N_PROFILES
+    for pid, count in counts.items():
+        assert abs(count - fair_share) <= 5, (
+            f"Profile {pid!r} appeared {count} times (expected ~{fair_share}). "
+            f"Full distribution: {dict(counts)}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# select_sync (Phase 2 — sync call site support)
+# ---------------------------------------------------------------------------
+
+
+def test_select_sync_returns_profile() -> None:
+    pool, store = make_pool("p1", "p2", strategy="first_ok")
+    result = pool.select_sync()
+    assert result.id == "p1"
+
+
+def test_select_sync_skips_cooldown() -> None:
+    pool, store = make_pool(strategy="first_ok")
+    store.upsert(make_profile("p1", cooldown_until=datetime(2099, 1, 1)))
+    store.upsert(make_profile("p2"))
+    result = pool.select_sync()
+    assert result.id == "p2"
+
+
+def test_select_sync_raises_when_all_exhausted() -> None:
+    pool, store = make_pool(strategy="first_ok")
+    store.upsert(make_profile("p1", cooldown_until=datetime(2099, 1, 1)))
+    with pytest.raises(NoAvailableCredentialError):
+        pool.select_sync()
+
+
+def test_select_sync_round_robin_same_state_as_async() -> None:
+    """select_sync and select() share the same _last_index via threading.Lock."""
+    pool, store = make_pool("a", "b", "c", strategy="round_robin")
+    # Advance via async select
+    import asyncio as _asyncio
+
+    _asyncio.run(pool.select())  # idx→1 → returns candidates[1] = "b"
+    # Next sync select should continue from idx=1 → idx=2 → "c"
+    result = pool.select_sync()
+    assert result.id == "c"
+
+
+def test_select_sync_from_thread_no_event_loop() -> None:
+    """select_sync works in a plain thread with no running event loop."""
+    import threading as _threading
+
+    pool, store = make_pool("p1", strategy="first_ok")
+    results: list[str] = []
+    errors: list[Exception] = []
+
+    def worker() -> None:
+        try:
+            results.append(pool.select_sync().id)
+        except Exception as e:
+            errors.append(e)
+
+    t = _threading.Thread(target=worker)
+    t.start()
+    t.join()
+    assert not errors, f"Thread raised: {errors}"
+    assert results == ["p1"]
+
+
+# ---------------------------------------------------------------------------
+# CredentialPoolRegistry
+# ---------------------------------------------------------------------------
+
+
+def test_registry_returns_same_pool_instance() -> None:
+    store = InMemoryAuthProfileStore()
+    registry = CredentialPoolRegistry(store=store)
+
+    pool_a = registry.get("openai")
+    pool_b = registry.get("openai")
+    assert pool_a is pool_b
+
+
+def test_registry_separate_pools_per_provider() -> None:
+    store = InMemoryAuthProfileStore()
+    registry = CredentialPoolRegistry(store=store)
+
+    openai_pool = registry.get("openai")
+    anthropic_pool = registry.get("anthropic")
+    assert openai_pool is not anthropic_pool
+    assert openai_pool.provider == "openai"
+    assert anthropic_pool.provider == "anthropic"
+
+
+def test_registry_shutdown_clears_pools() -> None:
+    store = InMemoryAuthProfileStore()
+    registry = CredentialPoolRegistry(store=store)
+    registry.get("openai")
+    registry.get("anthropic")
+
+    registry.shutdown()
+
+    # After shutdown, get() creates fresh pools
+    new_pool = registry.get("openai")
+    assert new_pool is not None  # recreated, not None
+
+
+# ---------------------------------------------------------------------------
+# classify_openai_error (Issue 10)
+# ---------------------------------------------------------------------------
+
+
+def _make_openai_exc(exc_class, *, code: str | None = None, message: str = "error") -> Exception:
+    """Construct a minimal openai exception for classifier tests."""
+    exc = exc_class.__new__(exc_class)
+    Exception.__init__(exc, message)
+    exc.code = code
+    exc.status_code = 429
+    exc.response = None
+    exc.body = {"error": {"code": code, "message": message}}
+    return exc
+
+
+@pytest.mark.parametrize(
+    "exc_factory, expected_reason",
+    [
+        # Rate limit — default case
+        (
+            lambda openai: _make_openai_exc(openai.RateLimitError, code="rate_limit_exceeded"),
+            AuthProfileFailureReason.RATE_LIMIT,
+        ),
+        # Billing / quota exhausted — MUST use exc.code, not str parse (Issue 10)
+        (
+            lambda openai: _make_openai_exc(openai.RateLimitError, code="insufficient_quota"),
+            AuthProfileFailureReason.BILLING,
+        ),
+        # Authentication
+        (
+            lambda openai: _make_openai_exc(openai.AuthenticationError, code="invalid_api_key"),
+            AuthProfileFailureReason.AUTH_PERMANENT,
+        ),
+        # Permission denied
+        (
+            lambda openai: _make_openai_exc(openai.PermissionDeniedError),
+            AuthProfileFailureReason.AUTH_PERMANENT,
+        ),
+        # Timeout — requires an httpx.Request; use MagicMock
+        (
+            lambda openai: openai.APITimeoutError(MagicMock()),
+            AuthProfileFailureReason.TIMEOUT,
+        ),
+        # Connection error — requires an httpx.Request; use MagicMock
+        (
+            lambda openai: openai.APIConnectionError(request=MagicMock()),
+            AuthProfileFailureReason.TIMEOUT,
+        ),
+        # Internal server error
+        (
+            lambda openai: _make_openai_exc(openai.InternalServerError),
+            AuthProfileFailureReason.OVERLOADED,
+        ),
+        # Not found (model access)
+        (
+            lambda openai: _make_openai_exc(openai.NotFoundError),
+            AuthProfileFailureReason.MODEL_NOT_FOUND,
+        ),
+        # Bad request
+        (
+            lambda openai: _make_openai_exc(openai.BadRequestError),
+            AuthProfileFailureReason.FORMAT,
+        ),
+        # Unknown fallback
+        (
+            lambda _openai: ValueError("unexpected"),
+            AuthProfileFailureReason.UNKNOWN,
+        ),
+    ],
+)
+def test_classify_openai_error(exc_factory, expected_reason: AuthProfileFailureReason) -> None:
+    openai = pytest.importorskip("openai", reason="openai SDK not installed")
+    from nexus.bricks.auth.classifiers.openai import classify_openai_error
+
+    exc = exc_factory(openai)
+    result = classify_openai_error(exc)
+    assert result == expected_reason
+
+
+def test_classify_openai_billing_uses_code_not_string_parse() -> None:
+    """Billing detection uses exc.code, not string parsing.
+
+    A RateLimitError without code="insufficient_quota" must NOT be classified
+    as BILLING even if the message happens to contain "insufficient_quota".
+    """
+    openai = pytest.importorskip("openai", reason="openai SDK not installed")
+    from nexus.bricks.auth.classifiers.openai import classify_openai_error
+
+    # code is NOT insufficient_quota but message contains it — must → RATE_LIMIT
+    exc = _make_openai_exc(
+        openai.RateLimitError,
+        code="rate_limit_exceeded",
+        message="You have exceeded your quota: insufficient_quota details here",
+    )
+    result = classify_openai_error(exc)
+    assert result == AuthProfileFailureReason.RATE_LIMIT, (
+        "Classifier must use exc.code, not string-parse the message"
+    )
+
+
+def test_classify_openai_no_sdk_returns_unknown() -> None:
+    """Classifier returns UNKNOWN gracefully when openai is not installed."""
+    from nexus.bricks.auth.classifiers.openai import classify_openai_error
+
+    with patch.dict("sys.modules", {"openai": None}):
+        result = classify_openai_error(RuntimeError("some error"))
+    assert result == AuthProfileFailureReason.UNKNOWN
+
+
+# ---------------------------------------------------------------------------
+# Default cooldown policy sanity checks
+# ---------------------------------------------------------------------------
+
+
+def test_default_cooldown_policy_covers_all_reasons() -> None:
+    """Every AuthProfileFailureReason has an entry in the default policy."""
+    for reason in AuthProfileFailureReason:
+        assert reason in _DEFAULT_COOLDOWN_POLICY, f"{reason} missing from _DEFAULT_COOLDOWN_POLICY"
+
+
+def test_retriable_reasons_are_subset_of_policy() -> None:
+    """All retriable reasons have a non-None cooldown (they must be put on cooldown)."""
+    for reason in _RETRIABLE_REASONS:
+        assert _DEFAULT_COOLDOWN_POLICY.get(reason) is not None, (
+            f"Retriable reason {reason} has no cooldown — select() would pick it again immediately"
+        )

--- a/src/nexus/cli/commands/auth_cli.py
+++ b/src/nexus/cli/commands/auth_cli.py
@@ -414,6 +414,81 @@ def disconnect_auth(service_name: str) -> None:
     console.print(f"[nexus.success]ok[/nexus.success] Removed stored auth for {service_name}")
 
 
+@auth.group("pool")
+def auth_pool() -> None:
+    """Manage credential pool state (multi-account failover, cooldowns)."""
+
+
+@auth_pool.command("status")
+@click.argument("provider", type=str)
+def pool_status(provider: str) -> None:
+    """Show per-profile pool state for a provider.
+
+    Displays each configured profile, its current status (ok / cooldown /
+    disabled), failure count, and cooldown expiry if applicable.
+
+    Note: runtime cooldown state (failure counts, cooldown timers) reflects
+    the current process's in-memory pool. Persistent pool state across restarts
+    requires Issue #3722 (SqliteAuthProfileStore) to land.
+
+    Example:
+        nexus-fs auth pool status openai
+    """
+
+    # Build a minimal profile list from the existing credential records.
+    # Until #3722 lands, we read from UnifiedAuthService and populate an
+    # InMemoryAuthProfileStore — this gives correct static data but no
+    # runtime cooldown history from previous processes.
+    service = _build_auth_service()
+    summaries = asyncio.run(service.list_summaries())
+
+    provider_summaries = [s for s in summaries if s.service == provider]
+    if not provider_summaries:
+        # Try prefix match (e.g. "google" matches "gmail", "google-drive", etc.)
+        provider_summaries = [s for s in summaries if s.service.startswith(provider)]
+
+    if not provider_summaries:
+        raise click.ClickException(
+            f"No configured profiles found for provider '{provider}'. "
+            f"Run 'nexus-fs auth list' to see all providers."
+        )
+
+    table = Table(
+        title=f"Pool: {provider}",
+        show_header=True,
+        header_style="nexus.table_header",
+    )
+    table.add_column("Status", style="nexus.success", width=10)
+    table.add_column("Account", style="nexus.value")
+    table.add_column("Source", style="nexus.reference")
+    table.add_column("Failures", justify="right")
+    table.add_column("Cooldown")
+
+    for summary in provider_summaries:
+        from nexus.contracts.unified_auth import AuthStatus
+
+        is_ok = summary.status == AuthStatus.AUTHED
+        status_str = (
+            "[nexus.success]ok[/nexus.success]"
+            if is_ok
+            else f"[nexus.warning]{summary.status.value}[/nexus.warning]"
+        )
+        account = summary.details.get("email") or summary.details.get("user") or "default"
+        table.add_row(
+            status_str,
+            str(account),
+            summary.source,
+            "0",  # runtime failure counts require #3722 for persistence
+            "—",  # runtime cooldown requires #3722 for persistence
+        )
+
+    console.print(table)
+    console.print(
+        "[nexus.muted]Runtime cooldown state (failures, timers) requires "
+        "Issue #3722 (persistent AuthProfileStore) to persist across restarts.[/nexus.muted]"
+    )
+
+
 @auth.command("doctor")
 def auth_doctor() -> None:
     """Show only auth-related doctor results."""


### PR DESCRIPTION
## Summary

- **`AuthProfileFailureReason` enum** (10 values) + `AuthProfileStore` Protocol — typed failure vocabulary shared across all classifiers and connectors
- **`CredentialPool`** — select/execute engine with per-reason cooldown policy, round-robin strategy, `threading.Lock` (safe from both async coroutines and sync thread-executors), `NoAvailableCredentialError` with per-profile diagnostics
- **5 classifiers** (openai, anthropic, google, slack, boto3) — each uses structured error codes/fields, not string parsing
- **49 tests** — `_is_usable` boundary cases, `execute()` 5 paths, 100-concurrent round-robin, `select_sync` from plain thread, classifier billing-uses-code boundary
- **Gmail connector fully migrated** — `read_content` + `list_dir` use `pool.execute_sync()` when pool is set; `with_context(user_email_override=)` added to GmailTransport
- **OpenAI-compatible backend** — `generate_streaming()` uses `select_sync()` + `_stream_succeeded` flag to mark success after final yield
- **Pool stub** on `OAuthConnectorBase`, Calendar, GDrive, Slack, X connectors — `pool=None` param stored, ready for per-connector migration
- **`nexus-fs auth pool status <provider>`** CLI command — Rich table showing account health

## Design decisions

- `threading.Lock` over `asyncio.Lock`: `generate_streaming()` is a sync generator running in a thread executor; `threading.Lock` works from both sync and async contexts with negligible blocking (nanosecond critical section)
- `select_sync()` separate from `select()`: sync generators can't `await`, so a synchronous path is required
- `_stream_succeeded` flag: generators can't run code after the final `yield`; flag is set after the streaming loop and checked in the `finally`/post-yield block
- Tenancy boundary: tenacity = same-credential transient retries; pool = credential-switching on non-transient failures

## Test plan

- [ ] `PYTHONPATH=src python -m pytest src/nexus/bricks/auth/tests/test_credential_pool.py -v` — 49 tests pass
- [ ] Runtime Gmail pool integration (requires Google OAuth credentials + Issue #3722 for persistent store)
- [ ] `nexus-fs auth pool status slack` — verify Rich table output

## Notes

Live cooldown state in `auth pool status` requires Issue #3722 (persistent `AuthProfileStore`). Current implementation shows configured profiles from `UnifiedAuthService`; the CLI note calls this out explicitly.

Closes #3723