### PR TITLE
feat(#3725): global lightweight path+title index for semantic file location

### DIFF
--- a/alembic/versions/add_document_skeleton.py
+++ b/alembic/versions/add_document_skeleton.py
@@ -1,7 +1,7 @@
 """Add document_skeleton table for global path+title index (Issue #3725).
 
 Revision ID: add_document_skeleton
-Revises: update_file_namespace_shared
+Revises: idx_dirs_3698
 Create Date: 2026-04-11
 
 Adds the document_skeleton table — a lightweight, globally-indexed record for
@@ -24,7 +24,7 @@ from alembic import op
 
 # revision identifiers, used by Alembic.
 revision: str = "add_document_skeleton"
-down_revision: Union[str, Sequence[str], None] = "update_file_namespace_shared"
+down_revision: Union[str, Sequence[str], None] = "idx_dirs_3698"
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
 

--- a/alembic/versions/add_document_skeleton.py
+++ b/alembic/versions/add_document_skeleton.py
@@ -1,0 +1,64 @@
+"""Add document_skeleton table for global path+title index (Issue #3725).
+
+Revision ID: add_document_skeleton
+Revises: update_file_namespace_shared
+Create Date: 2026-04-11
+
+Adds the document_skeleton table — a lightweight, globally-indexed record for
+every file in every zone. No embeddings, no LLM. Feeds the /api/v2/search/locate
+endpoint via BM25S with per-field column weighting (path vs title).
+
+Design notes:
+    - path_tokens column intentionally absent: virtual_path and title are passed
+      as separate BM25S fields at index time, not stored pre-tokenized.
+    - skeleton_content_hash = sha256(first 2KB): skip guard in SkeletonPipeConsumer.
+    - ON DELETE CASCADE from file_paths handles sync automatically.
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "add_document_skeleton"
+down_revision: Union[str, Sequence[str], None] = "update_file_namespace_shared"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create document_skeleton table."""
+    op.create_table(
+        "document_skeleton",
+        sa.Column("path_id", sa.String(36), nullable=False),
+        sa.Column("zone_id", sa.String(255), nullable=False, server_default="root"),
+        sa.Column("title", sa.Text(), nullable=True),
+        sa.Column("skeleton_content_hash", sa.String(64), nullable=True),
+        sa.Column("indexed_at", sa.DateTime(), nullable=False),
+        sa.ForeignKeyConstraint(
+            ["path_id"],
+            ["file_paths.path_id"],
+            ondelete="CASCADE",
+        ),
+        sa.PrimaryKeyConstraint("path_id"),
+    )
+    op.create_index(
+        "idx_document_skeleton_zone",
+        "document_skeleton",
+        ["zone_id"],
+    )
+    op.create_index(
+        "idx_document_skeleton_zone_path_title",
+        "document_skeleton",
+        ["zone_id", "path_id", "title"],
+    )
+
+
+def downgrade() -> None:
+    """Drop document_skeleton table."""
+    op.drop_index("idx_document_skeleton_zone_path_title", table_name="document_skeleton")
+    op.drop_index("idx_document_skeleton_zone", table_name="document_skeleton")
+    op.drop_table("document_skeleton")

--- a/src/nexus/bricks/catalog/extractors.py
+++ b/src/nexus/bricks/catalog/extractors.py
@@ -838,3 +838,350 @@ def _resolve_types(types: set[str]) -> str:
     if "object" in types_no_null or "array" in types_no_null:
         return "string"  # Mixed complex types → string
     return "string"  # Mixed types → string
+
+
+# ============================================================================
+# Document title extractors (Issue #3725 — skeleton index)
+# ============================================================================
+# All extractors below implement DocumentExtractor and return DocumentExtractionResult
+# with only `title` populated.  Other fields (headings, word_count, etc.) are left at
+# zero/empty because the skeleton index only needs the title string.
+#
+# Shared parsing helpers are extracted to avoid duplication across extractor classes.
+# ============================================================================
+
+
+def _load_json_head(content: bytes, max_bytes: int = 2048) -> dict[str, Any] | None:
+    """Parse up to max_bytes of JSON content and return the top-level object.
+
+    Returns the first parseable dict, or None if parsing fails (including
+    truncation at the max_bytes boundary, binary input, or non-object JSON).
+    Never raises.  Used by both JSONExtractor (schema) and JsonDocumentExtractor
+    (title) to share the JSON parsing preamble.
+    """
+    import json as _json
+
+    try:
+        sample = content[:max_bytes].decode("utf-8", errors="replace").strip()
+        if not sample:
+            return None
+        obj = _json.loads(sample)
+        if isinstance(obj, dict):
+            return obj
+        # Array: peek at first element
+        if isinstance(obj, list) and obj and isinstance(obj[0], dict):
+            return obj[0]
+        return None
+    except Exception:
+        return None
+
+
+def _null_doc_result(format: str, error: str) -> "DocumentExtractionResult":
+    """Return a zero-confidence DocumentExtractionResult with no title."""
+    return DocumentExtractionResult(
+        title=None,
+        headings=[],
+        front_matter=None,
+        word_count=0,
+        link_count=0,
+        code_languages=[],
+        format=format,
+        confidence=0.0,
+        error=error,
+    )
+
+
+class JsonDocumentExtractor:
+    """JSON/YAML-style title extractor for the skeleton index (Issue #3725).
+
+    Looks for top-level ``name``, ``title``, or ``description`` keys and
+    returns the first string value found.  Reads at most max_bytes bytes.
+    """
+
+    mime_types: tuple[str, ...] = ("application/json", "text/json")
+    extensions: tuple[str, ...] = ("json",)
+
+    def extract(self, content: bytes) -> DocumentExtractionResult:
+        """Extract title from top-level name/title/description key."""
+        try:
+            obj = _load_json_head(content)
+            if obj is None:
+                return _null_doc_result("json", "No parseable JSON object")
+
+            title: str | None = None
+            for key in ("title", "name", "description"):
+                val = obj.get(key)
+                if isinstance(val, str) and val.strip():
+                    title = val.strip()
+                    break
+
+            return DocumentExtractionResult(
+                title=title,
+                headings=[],
+                front_matter=None,
+                word_count=0,
+                link_count=0,
+                code_languages=[],
+                format="json",
+                confidence=1.0 if title else 0.5,
+            )
+        except Exception as e:
+            return _null_doc_result("json", f"JSON title extraction failed: {e}")
+
+
+class YamlDocumentExtractor:
+    """YAML title extractor for the skeleton index (Issue #3725).
+
+    Looks for top-level ``name``, ``title``, or ``description`` keys.
+    Falls back to the first non-blank line if no key matches.
+    """
+
+    mime_types: tuple[str, ...] = ("application/x-yaml", "text/yaml")
+    extensions: tuple[str, ...] = ("yaml", "yml", "toml")
+
+    def extract(self, content: bytes) -> DocumentExtractionResult:
+        """Extract title from YAML/TOML top-level keys."""
+        try:
+            text = content.decode("utf-8", errors="replace")
+            if not text.strip():
+                return _null_doc_result("yaml", "Empty file")
+
+            title: str | None = None
+
+            # Try YAML parse for structured key lookup
+            try:
+                import yaml as _yaml
+
+                obj = _yaml.safe_load(text)
+                if isinstance(obj, dict):
+                    for key in ("title", "name", "description"):
+                        val = obj.get(key)
+                        if isinstance(val, str) and val.strip():
+                            title = val.strip()
+                            break
+            except Exception:
+                pass
+
+            # Fallback: first non-blank, non-comment line
+            if title is None:
+                for line in text.splitlines():
+                    stripped = line.strip()
+                    if stripped and not stripped.startswith("#"):
+                        title = stripped[:200]  # cap length
+                        break
+
+            return DocumentExtractionResult(
+                title=title,
+                headings=[],
+                front_matter=None,
+                word_count=0,
+                link_count=0,
+                code_languages=[],
+                format="yaml",
+                confidence=1.0 if title else 0.3,
+            )
+        except Exception as e:
+            return _null_doc_result("yaml", f"YAML title extraction failed: {e}")
+
+
+class PythonDocumentExtractor:
+    """Python module title extractor for the skeleton index (Issue #3725).
+
+    Priority order:
+    1. Module-level docstring (first non-blank line of the docstring)
+    2. First class/function with a docstring (name as title)
+    Falls back to NULL if none found.  Skips shebang lines.
+    """
+
+    mime_types: tuple[str, ...] = ("text/x-python",)
+    extensions: tuple[str, ...] = ("py", "pyi")
+
+    # Matches: def foo(, class Foo(, class Foo:
+    _DEF_RE = re.compile(r"^(?:class|def)\s+(\w+)")
+    # Matches triple-quoted docstring openings
+    _DOCSTRING_RE = re.compile(r'^\s*(?:"""|\'\'\')(.*)$')
+
+    def extract(self, content: bytes) -> DocumentExtractionResult:
+        """Extract title from module docstring or first definition."""
+        try:
+            text = content.decode("utf-8", errors="replace")
+            if not text.strip():
+                return _null_doc_result("python", "Empty file")
+
+            lines = text.splitlines()
+            title: str | None = None
+
+            i = 0
+            # Skip shebang and encoding declarations
+            while i < len(lines) and i < 3:
+                stripped = lines[i].strip()
+                if stripped.startswith("#") or not stripped:
+                    i += 1
+                    continue
+                break
+
+            # Check for module docstring at current position
+            if i < len(lines):
+                m = self._DOCSTRING_RE.match(lines[i])
+                if m:
+                    # Inline content on the opening line
+                    inline = m.group(1).strip().rstrip("'\"").strip()
+                    if inline:
+                        title = inline
+                    else:
+                        # Multi-line docstring: take next non-blank line
+                        for j in range(i + 1, min(i + 10, len(lines))):
+                            candidate = lines[j].strip().rstrip("'\"").strip()
+                            if candidate and not candidate.startswith(('"""', "'''")):
+                                title = candidate
+                                break
+
+            # Fallback: first class/def name
+            if title is None:
+                for line in lines:
+                    m2 = self._DEF_RE.match(line.strip())
+                    if m2:
+                        title = m2.group(1)
+                        break
+
+            return DocumentExtractionResult(
+                title=title,
+                headings=[],
+                front_matter=None,
+                word_count=0,
+                link_count=0,
+                code_languages=["python"],
+                format="python",
+                confidence=1.0 if title else 0.4,
+            )
+        except Exception as e:
+            return _null_doc_result("python", f"Python title extraction failed: {e}")
+
+
+class TypeScriptDocumentExtractor:
+    """TypeScript/JavaScript title extractor for the skeleton index (Issue #3725).
+
+    Priority order:
+    1. JSDoc ``@description`` or ``@fileoverview`` at the top of the file
+    2. First exported symbol name (export const/function/class/default)
+    Falls back to NULL if none found.
+    """
+
+    mime_types: tuple[str, ...] = (
+        "application/typescript",
+        "text/typescript",
+        "application/javascript",
+        "text/javascript",
+    )
+    extensions: tuple[str, ...] = ("ts", "tsx", "js", "jsx", "mjs", "cjs")
+
+    _JSDOC_DESC_RE = re.compile(
+        r"@(?:description|fileoverview)\s+(.+?)(?:\s*\*/\s*)?$", re.IGNORECASE
+    )
+    _EXPORT_RE = re.compile(
+        r"^export\s+(?:default\s+)?(?:const|function|class|async\s+function)\s+(\w+)"
+    )
+
+    def extract(self, content: bytes) -> DocumentExtractionResult:
+        """Extract title from JSDoc description or first exported symbol."""
+        try:
+            text = content.decode("utf-8", errors="replace")
+            if not text.strip():
+                return _null_doc_result("typescript", "Empty file")
+
+            title: str | None = None
+
+            # Scan for JSDoc block at top of file (first 30 lines)
+            lines = text.splitlines()
+            for line in lines[:30]:
+                m = self._JSDOC_DESC_RE.search(line)
+                if m:
+                    title = m.group(1).strip()
+                    break
+
+            # Fallback: first exported symbol
+            if title is None:
+                for line in lines:
+                    m2 = self._EXPORT_RE.match(line.strip())
+                    if m2:
+                        title = m2.group(1)
+                        break
+
+            return DocumentExtractionResult(
+                title=title,
+                headings=[],
+                front_matter=None,
+                word_count=0,
+                link_count=0,
+                code_languages=["typescript"],
+                format="typescript",
+                confidence=1.0 if title else 0.4,
+            )
+        except Exception as e:
+            return _null_doc_result("typescript", f"TypeScript title extraction failed: {e}")
+
+
+class HtmlDocumentExtractor:
+    """HTML title extractor for the skeleton index (Issue #3725).
+
+    Extracts the ``<title>`` tag content.  Falls back to first ``<h1>`` if
+    no ``<title>`` tag is present.
+    """
+
+    mime_types: tuple[str, ...] = ("text/html",)
+    extensions: tuple[str, ...] = ("html", "htm")
+
+    _TITLE_RE = re.compile(r"<title[^>]*>(.*?)</title>", re.IGNORECASE | re.DOTALL)
+    _H1_RE = re.compile(r"<h1[^>]*>(.*?)</h1>", re.IGNORECASE | re.DOTALL)
+    _TAG_RE = re.compile(r"<[^>]+>")
+
+    def extract(self, content: bytes) -> DocumentExtractionResult:
+        """Extract title from <title> or <h1> tag."""
+        try:
+            text = content.decode("utf-8", errors="replace")
+            if not text.strip():
+                return _null_doc_result("html", "Empty file")
+
+            title: str | None = None
+
+            m = self._TITLE_RE.search(text)
+            if m:
+                title = self._TAG_RE.sub("", m.group(1)).strip()
+
+            if not title:
+                m2 = self._H1_RE.search(text)
+                if m2:
+                    title = self._TAG_RE.sub("", m2.group(1)).strip()
+
+            return DocumentExtractionResult(
+                title=title or None,
+                headings=[],
+                front_matter=None,
+                word_count=0,
+                link_count=0,
+                code_languages=[],
+                format="html",
+                confidence=1.0 if title else 0.3,
+            )
+        except Exception as e:
+            return _null_doc_result("html", f"HTML title extraction failed: {e}")
+
+
+# ---------------------------------------------------------------------------
+# Skeleton extractor registry
+# ---------------------------------------------------------------------------
+# Indexed by lowercase file extension.  Used by SkeletonIndexer to dispatch
+# title extraction without importing individual extractor classes.
+
+SKELETON_EXTRACTOR_REGISTRY: dict[str, DocumentExtractor] = {
+    ext: extractor
+    for extractor in (
+        MarkdownExtractor(),
+        JsonDocumentExtractor(),
+        YamlDocumentExtractor(),
+        PythonDocumentExtractor(),
+        TypeScriptDocumentExtractor(),
+        HtmlDocumentExtractor(),
+    )
+    for ext in extractor.extensions
+}

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -948,10 +948,10 @@ class SearchDaemon:
             async with self._async_session() as session:
                 result = await session.execute(
                     sa_text(
-                        "SELECT path_id, zone_id, title, "
-                        "       (SELECT virtual_path FROM file_paths fp "
-                        "        WHERE fp.path_id = ds.path_id) AS virtual_path "
-                        "FROM document_skeleton ds"
+                        "SELECT ds.path_id, ds.zone_id, ds.title, fp.virtual_path "
+                        "FROM document_skeleton ds "
+                        "JOIN file_paths fp ON fp.path_id = ds.path_id "
+                        "WHERE fp.deleted_at IS NULL"
                     )
                 )
                 rows = result.fetchall()

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -255,6 +255,13 @@ class SearchDaemon:
         self._txtai_bootstrapped = False
         self.last_search_timing: dict[str, float] = {}
 
+        # Skeleton index (Issue #3725) — in-memory BM25-lite for /locate endpoint.
+        # Bootstrapped from document_skeleton DB rows; no file reads on restart (13B).
+        # Keys: virtual_path; values: {path_id, zone_id, title, path_tokens}.
+        self._skeleton_docs: dict[str, dict[str, Any]] = {}
+        self._skeleton_bootstrap_task: asyncio.Task[None] | None = None
+        self._skeleton_bootstrapped: bool = False
+
         # Latency tracking (circular buffer)
         self._latencies: list[float] = []
         self._max_latency_samples = 1000
@@ -691,6 +698,13 @@ class SearchDaemon:
         if self._async_session is not None and self.config.scope_refresh_seconds > 0:
             self._scope_refresh_task = asyncio.create_task(self._scope_refresh_loop())
 
+        # Bootstrap skeleton index from DB rows (Issue #3725, 13B — no file reads).
+        # Warm after bootstrap so the first real /locate query is fast (16A).
+        if self._async_session is not None:
+            self._skeleton_bootstrap_task = asyncio.create_task(self._bootstrap_skeleton())
+            # Chain warmup probe as a non-blocking follow-on
+            asyncio.create_task(self._warm_skeleton_index())
+
         # If BM25S not loaded, count existing DB documents for stats
         if not self._bm25s_index and self._async_session:
             try:
@@ -736,6 +750,12 @@ class SearchDaemon:
             with contextlib.suppress(asyncio.CancelledError):
                 await self._txtai_bootstrap_task
         self._txtai_bootstrap_task = None
+
+        if self._skeleton_bootstrap_task and not self._skeleton_bootstrap_task.done():
+            self._skeleton_bootstrap_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._skeleton_bootstrap_task
+        self._skeleton_bootstrap_task = None
         if self._legacy_refresh_task:
             self._legacy_refresh_task.cancel()
             with contextlib.suppress(asyncio.CancelledError):
@@ -905,6 +925,154 @@ class SearchDaemon:
         except Exception as e:
             # Non-fatal - vector search will still work, just slower first time
             logger.debug(f"Vector index warmup skipped: {e}")
+
+    # ==========================================================================
+    # Skeleton index — Issue #3725
+    # ==========================================================================
+
+    async def _bootstrap_skeleton(self) -> None:
+        """Load document_skeleton rows from DB into _skeleton_docs (13B).
+
+        No file reads: DB rows are the authoritative cache.  Rebuilds the
+        in-memory index on every daemon restart.  Runs as a background task
+        so startup() is not blocked.
+        """
+        if self._async_session is None:
+            return
+
+        start = time.perf_counter()
+        count = 0
+        try:
+            from nexus.bricks.search.text_utils import tokenize_path
+
+            async with self._async_session() as session:
+                result = await session.execute(
+                    sa_text(
+                        "SELECT path_id, zone_id, title, "
+                        "       (SELECT virtual_path FROM file_paths fp "
+                        "        WHERE fp.path_id = ds.path_id) AS virtual_path "
+                        "FROM document_skeleton ds"
+                    )
+                )
+                rows = result.fetchall()
+
+            for row in rows:
+                path_id, zone_id, title, virtual_path = row
+                if not virtual_path:
+                    continue
+                self._skeleton_docs[virtual_path] = {
+                    "path_id": path_id,
+                    "zone_id": zone_id,
+                    "title": title,
+                    "path_tokens": tokenize_path(virtual_path),
+                }
+                count += 1
+
+            self._skeleton_bootstrapped = True
+            elapsed = (time.perf_counter() - start) * 1000
+            logger.info("[SKELETON] bootstrap complete: %d docs in %.1fms", count, elapsed)
+
+        except Exception as e:
+            logger.warning("[SKELETON] bootstrap failed: %s", e)
+
+    async def _warm_skeleton_index(self) -> None:
+        """Wait for skeleton bootstrap and log a warmup probe result (16A).
+
+        Fires a dummy locate() call to ensure the in-memory index is ready
+        and log timing for the first real query.
+        """
+        if self._skeleton_bootstrap_task is not None:
+            with contextlib.suppress(Exception):
+                await asyncio.wait_for(asyncio.shield(self._skeleton_bootstrap_task), timeout=10.0)
+        if self._skeleton_bootstrapped:
+            # Probe query — forces any lazy work and logs timing
+            await self.locate("warmup", zone_id="root", limit=1)
+            logger.debug("[SKELETON] index warmed: %d docs", len(self._skeleton_docs))
+
+    def upsert_skeleton_doc(
+        self,
+        *,
+        path_id: str,
+        virtual_path: str,
+        title: str | None,
+        zone_id: str,
+    ) -> None:
+        """Upsert a skeleton document into the in-memory index (sync, called by SkeletonIndexer)."""
+        from nexus.bricks.search.text_utils import tokenize_path
+
+        self._skeleton_docs[virtual_path] = {
+            "path_id": path_id,
+            "zone_id": zone_id,
+            "title": title,
+            "path_tokens": tokenize_path(virtual_path),
+        }
+
+    def delete_skeleton_doc(self, *, virtual_path: str, zone_id: str) -> None:  # noqa: ARG002
+        """Remove a skeleton document from the in-memory index (sync).
+
+        zone_id accepted for API symmetry with upsert_skeleton_doc; not used
+        here because _skeleton_docs is keyed by virtual_path.
+        """
+        self._skeleton_docs.pop(virtual_path, None)
+
+    async def locate(
+        self,
+        q: str,
+        *,
+        zone_id: str,
+        limit: int = 20,
+        path_prefix: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """BM25-lite path+title search over the skeleton index (Issue #3725).
+
+        Tokenizes q, scores each document by token overlap with title (weight 2)
+        and path_tokens (weight 1), returns top-limit results sorted by score.
+
+        Zone isolation: only documents whose zone_id == zone_id are returned.
+
+        Args:
+            q: Natural-language or keyword query.
+            zone_id: Caller's zone — results are filtered to this zone.
+            limit: Maximum number of candidates to return.
+            path_prefix: Optional path prefix filter (e.g. "/workspace/src/").
+
+        Returns:
+            List of dicts: {path, score, title}.
+        """
+        from nexus.bricks.search.text_utils import tokenize_path
+
+        if not q.strip():
+            return []
+
+        query_tokens = set(tokenize_path(q).split())
+        if not query_tokens:
+            return []
+
+        scored: list[tuple[float, str, str | None]] = []  # (score, path, title)
+
+        for virtual_path, doc in self._skeleton_docs.items():
+            if doc["zone_id"] != zone_id:
+                continue
+            if path_prefix and not virtual_path.startswith(path_prefix):
+                continue
+
+            path_tokens = set((doc.get("path_tokens") or "").split())
+            title_tokens = set(tokenize_path(doc.get("title") or "").split())
+
+            # Title match weighted higher than path match (review decision 6A)
+            title_overlap = len(query_tokens & title_tokens)
+            path_overlap = len(query_tokens & path_tokens)
+            score = title_overlap * 2.0 + path_overlap * 1.0
+
+            if score > 0:
+                scored.append((score, virtual_path, doc.get("title")))
+
+        scored.sort(key=lambda x: x[0], reverse=True)
+
+        return [
+            {"path": path, "score": round(score, 4), "title": title}
+            for score, path, title in scored[:limit]
+        ]
 
     async def _check_zoekt(self) -> None:
         """Check if Zoekt trigram search is available."""

--- a/src/nexus/bricks/search/index_scope.py
+++ b/src/nexus/bricks/search/index_scope.py
@@ -194,17 +194,22 @@ def is_path_indexed(
     if not dirs:
         return False
 
-    # Rules 4–8 — prefix match with the trailing-slash guard.
-    for directory in dirs:
-        if directory == "/":
-            # Root '/' matches everything in the zone.
-            return True
-        if virtual_path == directory:
-            # Rule 4 — exact match.
-            return True
-        if virtual_path.startswith(directory + "/"):
-            # Rule 5/6 — descendant match; '+ "/"' prevents '/src' from
-            # matching '/srcX/foo' (Rule 6 bug guard).
+    # Rules 4–8 — O(depth) ancestor lookup instead of O(n) linear scan.
+    #
+    # Strategy: split virtual_path into its ancestor directories and test
+    # each for membership in the frozenset (O(1) per test).  A realistic
+    # path has at most ~10 components, so total cost is O(depth) regardless
+    # of how many directories are registered.
+    #
+    # Exact match first (Rule 4) — path IS a registered directory.
+    if virtual_path in dirs:
+        return True
+    # Walk ancestor prefixes from shallowest to deepest (Rules 5/6/7/8).
+    # parts[0] is always '' (absolute path starts with '/').
+    parts = virtual_path.split("/")
+    for depth in range(1, len(parts)):
+        ancestor = "/".join(parts[:depth]) or "/"
+        if ancestor in dirs:
             return True
 
     # No directory in the zone covered this path.

--- a/src/nexus/bricks/search/skeleton_indexer.py
+++ b/src/nexus/bricks/search/skeleton_indexer.py
@@ -1,0 +1,348 @@
+"""SkeletonIndexer — title extraction and BM25S upsert for document_skeleton (Issue #3725).
+
+Responsible for:
+    1. Reading the first SKELETON_HEAD_BYTES of a file.
+    2. Computing skeleton_content_hash = sha256(head) and skipping if unchanged.
+    3. Dispatching to the correct DocumentExtractor from SKELETON_EXTRACTOR_REGISTRY.
+    4. Upserting the row into document_skeleton (DB) and the BM25S index (daemon).
+
+This module is intentionally narrow — it knows nothing about the pipe consumer
+lifecycle or the mutation event format.  The SkeletonPipeConsumer calls
+``index_file()`` and ``delete_file()`` directly.
+
+Design decisions:
+    - 2KB head cap enforced here (7A), not inside each extractor.
+    - path_tokens dropped (6A): virtual_path + title fed as separate BM25S fields.
+    - skip guard via skeleton_content_hash (14A).
+    - Bootstrap from DB rows handled by SearchDaemon, not this module (13B).
+"""
+
+from __future__ import annotations
+
+import hashlib
+import logging
+import os
+from datetime import UTC, datetime
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+# Maximum bytes read from a file for title extraction (Issue #3725, 7A).
+SKELETON_HEAD_BYTES: int = 2048
+
+
+class FileReaderProtocol(Protocol):
+    """Minimal file-reading interface needed by SkeletonIndexer."""
+
+    async def read_head(self, virtual_path: str, max_bytes: int) -> bytes:
+        """Read the first max_bytes of a file.  Returns b'' on any error."""
+        ...
+
+
+class SkeletonBM25Protocol(Protocol):
+    """BM25S index interface needed by SkeletonIndexer."""
+
+    async def upsert_skeleton(
+        self,
+        doc_id: str,
+        virtual_path: str,
+        title: str | None,
+        zone_id: str,
+        *,
+        path_id: str | None = None,
+    ) -> None:
+        """Upsert a skeleton document into the BM25S index.
+
+        path_id is the UUID from file_paths — passed through to adapters that
+        need it (e.g. _DaemonSkeletonBM25) and ignored by stub implementations.
+        """
+        ...
+
+    async def delete_skeleton(self, doc_id: str, zone_id: str) -> None:
+        """Remove a skeleton document from the BM25S index."""
+        ...
+
+
+class SkeletonIndexer:
+    """Extracts file titles and maintains the document_skeleton index.
+
+    Thread-safety: each async method is independent; safe to call concurrently
+    from the micro-batched consumer.
+    """
+
+    def __init__(
+        self,
+        file_reader: FileReaderProtocol,
+        bm25: SkeletonBM25Protocol,
+        async_session_factory: Any | None = None,
+        extractor_registry: dict[str, Any] | None = None,
+    ) -> None:
+        self._reader = file_reader
+        self._bm25 = bm25
+        self._session_factory = async_session_factory
+        # extractor_registry is injected by the factory layer (LEGO Principle 3).
+        # When None, _extract_title() returns None for all files.
+        self._extractor_registry = extractor_registry
+
+    # ------------------------------------------------------------------
+    # Public API
+    # ------------------------------------------------------------------
+
+    async def index_file(
+        self,
+        *,
+        path_id: str | None = None,
+        virtual_path: str,
+        zone_id: str,
+    ) -> bool:
+        """Extract title for virtual_path and upsert into document_skeleton.
+
+        path_id may be omitted when called from a VFS hook (where only the
+        virtual path and zone are available).  When None, it is resolved from
+        the file_paths table before the DB upsert.  If resolution fails the
+        DB row is skipped but the in-memory BM25 index is still updated so
+        locate() remains functional.
+
+        Returns True if the skeleton row was written (new or changed).
+        Returns False if the content hash matched and the row was skipped.
+        """
+        head = await self._reader.read_head(virtual_path, SKELETON_HEAD_BYTES)
+        new_hash = _sha256_head(head)
+
+        # Resolve path_id from DB when not provided (VFS hook path, Issue #3725).
+        if path_id is None:
+            path_id = await self._resolve_path_id(virtual_path, zone_id)
+
+        # --- skip guard (14A): only applies when we have a path_id to query ---
+        if path_id is not None:
+            existing_hash = await self._fetch_existing_hash(path_id)
+            if existing_hash is not None and existing_hash == new_hash:
+                logger.debug("[SKELETON] skip unchanged %s", virtual_path)
+                return False
+
+        title = _extract_title(virtual_path, head, self._extractor_registry)
+
+        # --- DB upsert (skipped when path_id unavailable — CASCADE FK required) ---
+        if path_id is not None:
+            await self._upsert_db_row(path_id, zone_id, title, new_hash)
+
+        # --- BM25S upsert (6A: path + title as separate fields) ---
+        await self._bm25.upsert_skeleton(
+            doc_id=virtual_path,
+            virtual_path=virtual_path,
+            title=title,
+            zone_id=zone_id,
+            path_id=path_id,
+        )
+
+        logger.debug("[SKELETON] indexed %s title=%r", virtual_path, title)
+        return True
+
+    async def delete_file(
+        self,
+        *,
+        path_id: str | None = None,
+        virtual_path: str,
+        zone_id: str,
+    ) -> None:
+        """Remove a file from document_skeleton (DB + BM25S).
+
+        path_id may be omitted when called from a VFS delete hook.  When
+        omitted the DB row is left for CASCADE cleanup (file_paths FK).
+        The in-memory BM25 entry is always removed.
+        """
+        if path_id is not None:
+            await self._delete_db_row(path_id)
+        # When path_id is None the CASCADE FK on document_skeleton.path_id
+        # will clean up the DB row when the file_paths entry is deleted.
+        await self._bm25.delete_skeleton(doc_id=virtual_path, zone_id=zone_id)
+        logger.debug("[SKELETON] deleted %s", virtual_path)
+
+    # ------------------------------------------------------------------
+    # DB helpers
+    # ------------------------------------------------------------------
+
+    async def _resolve_path_id(self, virtual_path: str, zone_id: str) -> str | None:
+        """Look up path_id from file_paths by virtual_path + zone_id (Issue #3725).
+
+        Called when index_file() or delete_file() are invoked from a VFS hook
+        that only provides the path and zone, not the UUID.
+        Returns None if no matching row is found or on any DB error.
+        """
+        if self._session_factory is None:
+            return None
+        try:
+            from sqlalchemy import select
+
+            from nexus.storage.models.file_path import FilePathModel
+
+            async with self._session_factory() as session:
+                result = await session.execute(
+                    select(FilePathModel.path_id).where(
+                        FilePathModel.virtual_path == virtual_path,
+                        FilePathModel.zone_id == zone_id,
+                        FilePathModel.deleted_at.is_(None),
+                    )
+                )
+                return result.scalar_one_or_none()
+        except Exception:
+            logger.debug("[SKELETON] path_id resolution failed for %s", virtual_path)
+            return None
+
+    async def _fetch_existing_hash(self, path_id: str) -> str | None:
+        if self._session_factory is None:
+            return None
+        try:
+            from sqlalchemy import select
+
+            from nexus.storage.models.document_skeleton import DocumentSkeletonModel
+
+            async with self._session_factory() as session:
+                result = await session.execute(
+                    select(DocumentSkeletonModel.skeleton_content_hash).where(
+                        DocumentSkeletonModel.path_id == path_id
+                    )
+                )
+                row = result.scalar_one_or_none()
+                return row
+        except Exception:
+            logger.debug("[SKELETON] could not fetch existing hash for %s", path_id)
+            return None
+
+    async def _upsert_db_row(
+        self,
+        path_id: str,
+        zone_id: str,
+        title: str | None,
+        content_hash: str,
+    ) -> None:
+        if self._session_factory is None:
+            return
+        try:
+            from sqlalchemy.dialects.sqlite import insert as sqlite_insert
+
+            from nexus.storage.models.document_skeleton import DocumentSkeletonModel
+
+            now = datetime.now(UTC)
+            async with self._session_factory() as session:
+                # Use upsert semantics: INSERT OR REPLACE (SQLite) / ON CONFLICT DO UPDATE (PG)
+                stmt = sqlite_insert(DocumentSkeletonModel).values(
+                    path_id=path_id,
+                    zone_id=zone_id,
+                    title=title,
+                    skeleton_content_hash=content_hash,
+                    indexed_at=now,
+                )
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=["path_id"],
+                    set_={
+                        "zone_id": zone_id,
+                        "title": title,
+                        "skeleton_content_hash": content_hash,
+                        "indexed_at": now,
+                    },
+                )
+                await session.execute(stmt)
+                await session.commit()
+        except Exception:
+            # Attempt PostgreSQL upsert as fallback
+            await self._upsert_db_row_pg(path_id, zone_id, title, content_hash)
+
+    async def _upsert_db_row_pg(
+        self,
+        path_id: str,
+        zone_id: str,
+        title: str | None,
+        content_hash: str,
+    ) -> None:
+        if self._session_factory is None:
+            return
+        try:
+            from sqlalchemy.dialects.postgresql import insert as pg_insert
+
+            from nexus.storage.models.document_skeleton import DocumentSkeletonModel
+
+            now = datetime.now(UTC)
+            async with self._session_factory() as session:
+                stmt = pg_insert(DocumentSkeletonModel).values(
+                    path_id=path_id,
+                    zone_id=zone_id,
+                    title=title,
+                    skeleton_content_hash=content_hash,
+                    indexed_at=now,
+                )
+                stmt = stmt.on_conflict_do_update(
+                    index_elements=["path_id"],
+                    set_={
+                        "zone_id": zone_id,
+                        "title": title,
+                        "skeleton_content_hash": content_hash,
+                        "indexed_at": now,
+                    },
+                )
+                await session.execute(stmt)
+                await session.commit()
+        except Exception as e:
+            logger.warning("[SKELETON] DB upsert failed for %s: %s", path_id, e)
+
+    async def _delete_db_row(self, path_id: str) -> None:
+        if self._session_factory is None:
+            return
+        try:
+            from sqlalchemy import delete
+
+            from nexus.storage.models.document_skeleton import DocumentSkeletonModel
+
+            async with self._session_factory() as session:
+                await session.execute(
+                    delete(DocumentSkeletonModel).where(DocumentSkeletonModel.path_id == path_id)
+                )
+                await session.commit()
+        except Exception as e:
+            logger.warning("[SKELETON] DB delete failed for %s: %s", path_id, e)
+
+
+# ---------------------------------------------------------------------------
+# Module-level helpers
+# ---------------------------------------------------------------------------
+
+
+def _sha256_head(data: bytes) -> str:
+    """Return hex sha256 of data (the 2KB head)."""
+    return hashlib.sha256(data).hexdigest()
+
+
+def _extract_title(
+    virtual_path: str,
+    head: bytes,
+    registry: dict[str, Any] | None = None,
+) -> str | None:
+    """Dispatch title extraction to the correct registry extractor.
+
+    registry is injected from the factory layer (LEGO Principle 3 — search
+    brick must not import from catalog brick directly).  When None, returns
+    None for all files (title extraction disabled, path tokens still indexed).
+
+    Returns None for binary files, empty files, or unrecognised extensions.
+    Never raises.
+    """
+    if not head or registry is None:
+        return None
+
+    # Detect binary: if more than 10% of the first 512 bytes are non-text, skip.
+    sample = head[:512]
+    non_text = sum(1 for b in sample if b < 9 or (13 < b < 32) or b == 127)
+    if len(sample) > 0 and non_text / len(sample) > 0.10:
+        return None
+
+    ext = os.path.splitext(virtual_path)[1].lstrip(".").lower()
+    extractor = registry.get(ext)
+    if extractor is None:
+        return None
+
+    try:
+        result = extractor.extract(head)
+        return result.title
+    except Exception as e:
+        logger.debug("[SKELETON] extractor error for %s: %s", virtual_path, e)
+        return None

--- a/src/nexus/bricks/search/skeleton_indexer.py
+++ b/src/nexus/bricks/search/skeleton_indexer.py
@@ -184,7 +184,7 @@ class SkeletonIndexer:
                         FilePathModel.deleted_at.is_(None),
                     )
                 )
-                return result.scalar_one_or_none()
+                return str(result.scalar_one_or_none() or "") or None
         except Exception:
             logger.debug("[SKELETON] path_id resolution failed for %s", virtual_path)
             return None
@@ -204,7 +204,7 @@ class SkeletonIndexer:
                     )
                 )
                 row = result.scalar_one_or_none()
-                return row
+                return str(row) if row is not None else None
         except Exception:
             logger.debug("[SKELETON] could not fetch existing hash for %s", path_id)
             return None
@@ -342,7 +342,7 @@ def _extract_title(
 
     try:
         result = extractor.extract(head)
-        return result.title
+        return str(result.title) if result.title is not None else None
     except Exception as e:
         logger.debug("[SKELETON] extractor error for %s: %s", virtual_path, e)
         return None

--- a/src/nexus/bricks/search/skeleton_pipe_consumer.py
+++ b/src/nexus/bricks/search/skeleton_pipe_consumer.py
@@ -54,9 +54,14 @@ class SkeletonPipeConsumer:
         indexer: "SkeletonIndexer",
         *,
         debounce_seconds: float = 0.5,
+        fallback_loop: Any | None = None,
     ) -> None:
         self._indexer = indexer
         self._debounce = debounce_seconds
+        # Captured event loop for call_soon_threadsafe fallback when the pipe is
+        # not ready and _buffer() is called from a synchronous thread
+        # (asyncio.to_thread).  Set at construction time from the running loop.
+        self._fallback_loop = fallback_loop
 
         self._nx: Any | None = None
         self._pipe_ready = False
@@ -122,10 +127,16 @@ class SkeletonPipeConsumer:
                 )
             self._write_buffer.append(json.dumps(msg).encode())
             return
-        # Fallback: direct call when pipe not ready (CLI mode / pre-startup).
-        # No running loop (import-time / sync CLI context): event dropped safely.
-        with contextlib.suppress(RuntimeError):
-            asyncio.get_running_loop().create_task(self._dispatch_single(msg))
+        # Fallback: VFS hooks fire from asyncio.to_thread (sync thread) — use
+        # call_soon_threadsafe with the captured loop so the coroutine is safely
+        # scheduled on the event loop without needing get_running_loop().
+        loop = self._fallback_loop
+        if loop is not None:
+            with contextlib.suppress(RuntimeError):  # loop closed at shutdown
+                loop.call_soon_threadsafe(
+                    loop.create_task,
+                    self._dispatch_single(msg),
+                )
 
     # ------------------------------------------------------------------
     # Async lifecycle
@@ -138,7 +149,8 @@ class SkeletonPipeConsumer:
         if self._nx is None:
             return  # CLI mode — no pipe infrastructure
 
-        await self._nx.sys_setattr(_SKELETON_PIPE_PATH)
+        # pipe_create is idempotent: creates on first run, no-ops if already exists.
+        self._nx.pipe_create(_SKELETON_PIPE_PATH, capacity=_SKELETON_PIPE_CAPACITY)
         self._pipe_ready = True
         self._consumer_task = asyncio.create_task(self._consume())
         self._flush_task = asyncio.create_task(self._flush_loop())
@@ -154,7 +166,8 @@ class SkeletonPipeConsumer:
         if self._consumer_task is not None and not self._consumer_task.done():
             if self._nx is not None and self._pipe_ready:
                 with contextlib.suppress(Exception):
-                    await self._nx.sys_unlink(_SKELETON_PIPE_PATH)
+                    # destroy_pipe signals consumer to exit (NexusFileNotFoundError)
+                    self._nx._kernel.destroy_pipe(_SKELETON_PIPE_PATH)
             try:
                 await asyncio.wait_for(asyncio.shield(self._consumer_task), timeout=5.0)
             except (TimeoutError, asyncio.CancelledError):
@@ -176,7 +189,11 @@ class SkeletonPipeConsumer:
             while self._write_buffer:
                 data = self._write_buffer.popleft()
                 try:
-                    await nx.sys_write(_SKELETON_PIPE_PATH, data)
+                    # pipe_write_nowait bypasses sys_write's metastore check — the
+                    # skeleton pipe is registered in the Rust kernel by pipe_create()
+                    # but does not have a Python metastore entry, so sys_write raises
+                    # NexusFileNotFoundError.
+                    nx.pipe_write_nowait(_SKELETON_PIPE_PATH, data)
                 except Exception:
                     logger.warning("[SKELETON] pipe write failed, dropping event")
             await asyncio.sleep(0.01)  # 10ms poll
@@ -186,41 +203,51 @@ class SkeletonPipeConsumer:
     # ------------------------------------------------------------------
 
     async def _consume(self) -> None:
+        # Use pipe_read_nowait (polling) instead of sys_read — the skeleton pipe is
+        # registered in the Rust kernel by pipe_create() but has no Python metastore
+        # entry, so sys_read would raise NexusFileNotFoundError on every call.
+        # pipe_read_nowait returns None on empty and raises NexusFileNotFoundError
+        # when the pipe is destroyed (stop() signal).
         from nexus.contracts.exceptions import NexusFileNotFoundError
 
         assert self._nx is not None
         nx = self._nx
+        _POLL = 0.01  # 10ms poll interval
 
         pending: list[dict[str, Any]] = []
 
         while True:
-            # Block until first event if nothing pending
+            # Block until first event: poll with sleep
             if not pending:
-                try:
-                    first = await nx.sys_read(_SKELETON_PIPE_PATH)
-                except NexusFileNotFoundError:
-                    logger.debug("[SKELETON] pipe closed, consumer exiting")
-                    break
-                pending.append(json.loads(first))
+                while True:
+                    try:
+                        data = nx.pipe_read_nowait(_SKELETON_PIPE_PATH)
+                    except NexusFileNotFoundError:
+                        logger.debug("[SKELETON] pipe closed, consumer exiting")
+                        return
+                    except Exception:
+                        return
+                    if data is not None:
+                        pending.append(json.loads(data))
+                        break
+                    await asyncio.sleep(_POLL)
 
-            # Debounce: drain events for debounce_seconds
+            # Debounce: drain additional events for debounce_seconds
             deadline = asyncio.get_event_loop().time() + self._debounce
             while True:
                 remaining = deadline - asyncio.get_event_loop().time()
                 if remaining <= 0:
                     break
                 try:
-                    data = await asyncio.wait_for(
-                        nx.sys_read(_SKELETON_PIPE_PATH),
-                        timeout=remaining,
-                    )
-                    pending.append(json.loads(data))
-                except TimeoutError:
-                    break
+                    data = nx.pipe_read_nowait(_SKELETON_PIPE_PATH)
                 except NexusFileNotFoundError:
                     break
                 except Exception:
                     break
+                if data is not None:
+                    pending.append(json.loads(data))
+                else:
+                    await asyncio.sleep(min(remaining, _POLL))
 
             # Process in micro-batches (15A)
             await self._process_batch(pending)

--- a/src/nexus/bricks/search/skeleton_pipe_consumer.py
+++ b/src/nexus/bricks/search/skeleton_pipe_consumer.py
@@ -1,0 +1,273 @@
+"""DT_PIPE-backed async consumer for document_skeleton indexing (Issue #3725).
+
+Follows the ZoektPipeConsumer pattern:
+    - Sync notify_write() / notify_delete() / notify_rename() buffer events into a deque.
+    - A background flush task drains the deque into the NexusFS pipe via sys_write.
+    - A background consumer reads from the pipe via sys_read and dispatches to
+      SkeletonIndexer in micro-batches (15A: asyncio.gather, BATCH_SIZE at a time).
+
+Key differences from ZoektPipeConsumer:
+    - Each write event triggers a file read (2KB head), so micro-batching with
+      asyncio.gather is critical for throughput.
+    - Rename events must update the path + title atomically (delete old + index new).
+    - Back-pressure: events are dropped with a WARNING log when the deque is full.
+
+Issue #3725 review decisions honoured:
+    - 4A  Async pipe consumer (not synchronous post-flush hook)
+    - 13B Bootstrap from DB rows in SearchDaemon (not this module)
+    - 15A Micro-batched concurrent reads via asyncio.gather
+"""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import json
+import logging
+from collections import deque
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nexus.bricks.search.skeleton_indexer import SkeletonIndexer
+
+logger = logging.getLogger(__name__)
+
+_SKELETON_PIPE_PATH = "/nexus/pipes/skeleton-writes"
+_SKELETON_PIPE_CAPACITY = 65_536  # 64KB
+
+# Number of events processed concurrently in a single asyncio.gather call (15A).
+BATCH_SIZE: int = 100
+
+
+class SkeletonPipeConsumer:
+    """DT_PIPE consumer for skeleton index notifications.
+
+    Lifecycle:
+        1. Created in factory (brick tier) with a SkeletonIndexer.
+        2. NexusFS bound via bind_fs().
+        3. start() creates pipe, spawns consumer + flush tasks.
+        4. stop() gracefully drains and cancels.
+    """
+
+    def __init__(
+        self,
+        indexer: "SkeletonIndexer",
+        *,
+        debounce_seconds: float = 0.5,
+    ) -> None:
+        self._indexer = indexer
+        self._debounce = debounce_seconds
+
+        self._nx: Any | None = None
+        self._pipe_ready = False
+        self._consumer_task: asyncio.Task[None] | None = None
+        self._flush_task: asyncio.Task[None] | None = None
+
+        # Sync-to-async bridge: sync callers buffer here, flush task drains via sys_write.
+        # maxlen matches ZoektPipeConsumer; events beyond this are dropped with a warning.
+        self._write_buffer: deque[bytes] = deque(maxlen=10_000)
+
+    # ------------------------------------------------------------------
+    # Deferred injection
+    # ------------------------------------------------------------------
+
+    def bind_fs(self, nx: Any) -> None:
+        """Bind NexusFS for sys_read/sys_write pipe access."""
+        self._nx = nx
+
+    # ------------------------------------------------------------------
+    # Sync callbacks (called from RecordStoreWriteObserver / rename handler)
+    # ------------------------------------------------------------------
+
+    def notify_write(self, path: str, path_id: str | None, zone_id: str) -> None:
+        """Buffer a write event for async processing.
+
+        path_id may be None when called from a VFS hook (e.g. _SkeletonWriteHook
+        in search.py lifespan) — SkeletonIndexer resolves it from DB in that case.
+        """
+        self._buffer({"type": "write", "path": path, "path_id": path_id, "zone_id": zone_id})
+
+    def notify_delete(self, path: str, path_id: str | None, zone_id: str) -> None:
+        """Buffer a delete event for async processing.  path_id may be None."""
+        self._buffer({"type": "delete", "path": path, "path_id": path_id, "zone_id": zone_id})
+
+    def notify_rename(
+        self,
+        old_path: str,
+        new_path: str,
+        path_id: str | None,
+        zone_id: str,
+    ) -> None:
+        """Buffer a rename event: delete old skeleton row, index new path.
+
+        path_id may be None when called from VFS hooks.
+        """
+        self._buffer(
+            {
+                "type": "rename",
+                "old_path": old_path,
+                "new_path": new_path,
+                "path_id": path_id,
+                "zone_id": zone_id,
+            }
+        )
+
+    def _buffer(self, msg: dict[str, Any]) -> None:
+        if self._nx is not None and self._pipe_ready:
+            if len(self._write_buffer) >= (self._write_buffer.maxlen or 10_000):
+                logger.warning(
+                    "[SKELETON] write buffer full (%d), dropping event for %s",
+                    len(self._write_buffer),
+                    msg.get("path") or msg.get("new_path", "?"),
+                )
+            self._write_buffer.append(json.dumps(msg).encode())
+            return
+        # Fallback: direct call when pipe not ready (CLI mode / pre-startup).
+        asyncio.get_event_loop().create_task(self._dispatch_single(msg))
+
+    # ------------------------------------------------------------------
+    # Async lifecycle
+    # ------------------------------------------------------------------
+
+    async def start(self) -> None:
+        """Create skeleton pipe and spawn consumer + flush tasks."""
+        if self._pipe_ready:
+            return
+        if self._nx is None:
+            return  # CLI mode — no pipe infrastructure
+
+        await self._nx.sys_setattr(_SKELETON_PIPE_PATH)
+        self._pipe_ready = True
+        self._consumer_task = asyncio.create_task(self._consume())
+        self._flush_task = asyncio.create_task(self._flush_loop())
+
+    async def stop(self) -> None:
+        """Graceful shutdown: drain flush task, signal pipe closed, wait for consumer."""
+        if self._flush_task is not None and not self._flush_task.done():
+            self._flush_task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._flush_task
+            self._flush_task = None
+
+        if self._consumer_task is not None and not self._consumer_task.done():
+            if self._nx is not None and self._pipe_ready:
+                with contextlib.suppress(Exception):
+                    await self._nx.sys_unlink(_SKELETON_PIPE_PATH)
+            try:
+                await asyncio.wait_for(asyncio.shield(self._consumer_task), timeout=5.0)
+            except (TimeoutError, asyncio.CancelledError):
+                self._consumer_task.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await self._consumer_task
+            self._consumer_task = None
+
+        self._pipe_ready = False
+
+    # ------------------------------------------------------------------
+    # Flush loop: drain sync buffer → pipe
+    # ------------------------------------------------------------------
+
+    async def _flush_loop(self) -> None:
+        assert self._nx is not None
+        nx = self._nx
+        while True:
+            while self._write_buffer:
+                data = self._write_buffer.popleft()
+                try:
+                    await nx.sys_write(_SKELETON_PIPE_PATH, data)
+                except Exception:
+                    logger.warning("[SKELETON] pipe write failed, dropping event")
+            await asyncio.sleep(0.01)  # 10ms poll
+
+    # ------------------------------------------------------------------
+    # Background consumer with debounce + micro-batching (15A)
+    # ------------------------------------------------------------------
+
+    async def _consume(self) -> None:
+        from nexus.contracts.exceptions import NexusFileNotFoundError
+
+        assert self._nx is not None
+        nx = self._nx
+
+        pending: list[dict[str, Any]] = []
+
+        while True:
+            # Block until first event if nothing pending
+            if not pending:
+                try:
+                    first = await nx.sys_read(_SKELETON_PIPE_PATH)
+                except NexusFileNotFoundError:
+                    logger.debug("[SKELETON] pipe closed, consumer exiting")
+                    break
+                pending.append(json.loads(first))
+
+            # Debounce: drain events for debounce_seconds
+            deadline = asyncio.get_event_loop().time() + self._debounce
+            while True:
+                remaining = deadline - asyncio.get_event_loop().time()
+                if remaining <= 0:
+                    break
+                try:
+                    data = await asyncio.wait_for(
+                        nx.sys_read(_SKELETON_PIPE_PATH),
+                        timeout=remaining,
+                    )
+                    pending.append(json.loads(data))
+                except TimeoutError:
+                    break
+                except NexusFileNotFoundError:
+                    break
+                except Exception:
+                    break
+
+            # Process in micro-batches (15A)
+            await self._process_batch(pending)
+            pending.clear()
+
+    async def _process_batch(self, events: list[dict[str, Any]]) -> None:
+        """Dispatch events to SkeletonIndexer in micro-batches via asyncio.gather."""
+        for i in range(0, len(events), BATCH_SIZE):
+            batch = events[i : i + BATCH_SIZE]
+            tasks = [self._dispatch_single(e) for e in batch]
+            results = await asyncio.gather(*tasks, return_exceptions=True)
+            for j, r in enumerate(results):
+                if isinstance(r, Exception):
+                    logger.warning(
+                        "[SKELETON] batch dispatch error for event %s: %s",
+                        batch[j].get("path") or batch[j].get("new_path", "?"),
+                        r,
+                    )
+
+    async def _dispatch_single(self, msg: dict[str, Any]) -> None:
+        """Route a single event to the appropriate SkeletonIndexer method."""
+        t = msg.get("type")
+        try:
+            if t == "write":
+                await self._indexer.index_file(
+                    path_id=msg["path_id"],
+                    virtual_path=msg["path"],
+                    zone_id=msg["zone_id"],
+                )
+            elif t == "delete":
+                await self._indexer.delete_file(
+                    path_id=msg["path_id"],
+                    virtual_path=msg["path"],
+                    zone_id=msg["zone_id"],
+                )
+            elif t == "rename":
+                # Delete old path entry, index new path (10A: title preserved via
+                # fresh extraction on the renamed file at its new path_id location).
+                await self._indexer.delete_file(
+                    path_id=msg["path_id"],
+                    virtual_path=msg["old_path"],
+                    zone_id=msg["zone_id"],
+                )
+                await self._indexer.index_file(
+                    path_id=msg["path_id"],
+                    virtual_path=msg["new_path"],
+                    zone_id=msg["zone_id"],
+                )
+            else:
+                logger.debug("[SKELETON] unknown event type: %s", t)
+        except Exception as e:
+            logger.warning("[SKELETON] dispatch error for %s: %s", t, e)

--- a/src/nexus/bricks/search/skeleton_pipe_consumer.py
+++ b/src/nexus/bricks/search/skeleton_pipe_consumer.py
@@ -123,7 +123,9 @@ class SkeletonPipeConsumer:
             self._write_buffer.append(json.dumps(msg).encode())
             return
         # Fallback: direct call when pipe not ready (CLI mode / pre-startup).
-        asyncio.get_event_loop().create_task(self._dispatch_single(msg))
+        # No running loop (import-time / sync CLI context): event dropped safely.
+        with contextlib.suppress(RuntimeError):
+            asyncio.get_running_loop().create_task(self._dispatch_single(msg))
 
     # ------------------------------------------------------------------
     # Async lifecycle

--- a/src/nexus/bricks/search/text_utils.py
+++ b/src/nexus/bricks/search/text_utils.py
@@ -1,0 +1,57 @@
+"""Shared text utilities for search indexing (Issue #3725).
+
+Centralises the camelCase/snake_case/path tokenisation logic that was
+previously duplicated across chunking.py and other search modules.
+"""
+
+from __future__ import annotations
+
+import re
+
+# ---------------------------------------------------------------------------
+# Token-splitting patterns (camelCase lives here, not in chunking.py)
+# ---------------------------------------------------------------------------
+
+# Splits on camelCase boundaries: parseUserAuth → parse User Auth
+_CAMEL_SPLIT_RE = re.compile(
+    r"(?<=[a-z0-9])(?=[A-Z])"  # lower/digit followed by upper
+    r"|(?<=[A-Z])(?=[A-Z][a-z])"  # e.g. "HTMLParser" → "HTML" "Parser"
+)
+
+# Characters that act as word separators in file names and paths
+_SEPARATOR_RE = re.compile(r"[/_\-\.\s]+")
+
+
+def tokenize_path(path: str) -> str:
+    """Tokenize a virtual path into a space-separated lowercase word string.
+
+    Splits on:
+    - Path separators: /
+    - Word separators in identifiers: _ - . (space)
+    - camelCase boundaries: parseUserAuth → parse user auth
+
+    The result is suitable for feeding into the BM25S index as a document
+    field.  The calling code should pass this alongside the title as separate
+    BM25S columns so per-field weights can be applied.
+
+    Examples:
+        >>> tokenize_path("/workspace/src/auth/parseUserLogin.py")
+        'workspace src auth parse user login py'
+        >>> tokenize_path("/docs/README_API.md")
+        'docs readme api md'
+    """
+    if not path:
+        return ""
+
+    # 1. Split on path/separator characters first
+    parts = _SEPARATOR_RE.split(path)
+
+    tokens: list[str] = []
+    for part in parts:
+        if not part:
+            continue
+        # 2. Split camelCase within each segment
+        sub_parts = _CAMEL_SPLIT_RE.split(part)
+        tokens.extend(sp.lower() for sp in sub_parts if sp)
+
+    return " ".join(tokens)

--- a/src/nexus/factory/__init__.py
+++ b/src/nexus/factory/__init__.py
@@ -59,7 +59,7 @@ from nexus.factory._metadata_export import create_metadata_export_service
 from nexus.factory._record_store import create_record_store
 from nexus.factory._system import _boot_pre_kernel_services
 from nexus.factory._wired import _boot_post_kernel_services
-from nexus.factory.adapters import _NexusFSFileReader
+from nexus.factory.adapters import _DaemonSkeletonBM25, _NexusFSFileReader
 from nexus.factory.orchestrator import create_nexus_fs, create_nexus_services
 from nexus.factory.wallet import WalletProvisioner
 

--- a/src/nexus/factory/adapters.py
+++ b/src/nexus/factory/adapters.py
@@ -1,4 +1,4 @@
-"""Factory adapters — NexusFSFileReader, WorkflowLifecycleAdapter."""
+"""Factory adapters — NexusFSFileReader, DaemonSkeletonBM25, WorkflowLifecycleAdapter."""
 
 from typing import Any
 
@@ -96,3 +96,69 @@ class _NexusFSFileReader:
         with self._nx.SessionLocal() as s:
             content_hash = s.execute(stmt).scalar_one_or_none()
             return content_hash
+
+    async def read_head(self, path: str, max_bytes: int) -> bytes:
+        """Read first max_bytes of a file for skeleton title extraction (Issue #3725).
+
+        Uses admin context so the skeleton indexer can read all files regardless
+        of per-user ReBAC permissions (same policy as read_text).
+        Returns b'' on any error (file missing, permissions, etc.).
+        """
+        from nexus.contracts.types import OperationContext
+
+        admin_ctx = OperationContext(
+            user_id="system",
+            groups=[],
+            is_admin=True,
+            is_system=True,
+        )
+        try:
+            content = await self._nx.sys_read(path, count=max_bytes, context=admin_ctx)
+            if isinstance(content, bytes):
+                return content
+            return str(content).encode("utf-8", errors="ignore")
+        except Exception:
+            return b""
+
+
+# =========================================================================
+# Issue #3725: SearchDaemon → SkeletonBM25Protocol adapter
+# =========================================================================
+
+
+class _DaemonSkeletonBM25:
+    """Adapts SearchDaemon.upsert_skeleton_doc / delete_skeleton_doc to the
+    SkeletonBM25Protocol expected by SkeletonIndexer.
+
+    This is the sole coupling point between the factory layer and the
+    SearchDaemon's in-memory skeleton index.  Search modules never import
+    SearchDaemon directly; they receive a SkeletonBM25Protocol at
+    composition time.
+    """
+
+    def __init__(self, daemon: Any) -> None:
+        self._daemon = daemon
+
+    async def upsert_skeleton(
+        self,
+        doc_id: str,  # noqa: ARG002 — Protocol positional arg; daemon uses virtual_path as key
+        virtual_path: str,
+        title: "str | None",
+        zone_id: str,
+        *,
+        path_id: "str | None" = None,
+    ) -> None:
+        """Forward upsert to daemon's in-memory index (sync under the hood)."""
+        self._daemon.upsert_skeleton_doc(
+            # Fall back to virtual_path when path_id UUID is unavailable so the
+            # dict entry is still created and locate() works.  Bootstrap from DB
+            # restores real UUIDs on restart.
+            path_id=path_id or virtual_path,
+            virtual_path=virtual_path,
+            title=title,
+            zone_id=zone_id,
+        )
+
+    async def delete_skeleton(self, doc_id: str, zone_id: str) -> None:
+        """Forward deletion to daemon's in-memory index."""
+        self._daemon.delete_skeleton_doc(virtual_path=doc_id, zone_id=zone_id)

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -1813,3 +1813,127 @@ async def purge_unscoped_embeddings(
         "zone_id": zone_id,
         "purged": counts,
     }
+
+
+# =============================================================================
+# /locate — global path+title skeleton search (Issue #3725)
+# =============================================================================
+
+
+class _LocateRequest(dict):
+    """Pydantic-free request body model for /locate.
+
+    Using a plain dict subclass keeps the endpoint self-contained and avoids
+    adding a Pydantic model for a single struct.  Field validation is inline.
+    """
+
+
+@router.post("/locate")
+async def search_locate(
+    request: Request,
+    payload: dict[str, Any] | None = None,
+    auth_result: dict[str, Any] = Depends(require_auth),
+    search_daemon: Any = Depends(_get_search_daemon),
+) -> dict[str, Any]:
+    """Fast global path+title file locator (Issue #3725).
+
+    Returns ranked candidate file paths whose path tokens or extracted title
+    match the query.  No embeddings, no LLM — BM25-lite over path+title.
+
+    Request body (JSON):
+        q          (str, required)   Natural-language or keyword query.
+        zone_id    (str, optional)   Zone to search; defaults to caller's zone.
+        limit      (int, optional)   Max candidates, 1–100, default 20.
+        path_prefix (str, optional)  Restrict results to this path prefix.
+
+    Response:
+        {
+          "candidates": [
+            {"path": "/workspace/src/auth/login.py", "score": 8.4, "title": "..."},
+            ...
+          ],
+          "total_before_filter": <int>,
+          "permission_denial_rate": <float>,
+          "truncated_by_permissions": <bool>,
+          "elapsed_ms": <float>
+        }
+    """
+    from nexus.contracts.constants import ROOT_ZONE_ID
+
+    start_time = time.perf_counter()
+
+    if not search_daemon.is_initialized:
+        raise HTTPException(status_code=503, detail="Search daemon is still initializing")
+
+    if not hasattr(search_daemon, "locate"):
+        raise HTTPException(
+            status_code=501, detail="Skeleton index not available on this daemon version"
+        )
+
+    body: dict[str, Any] = payload or {}
+    q: str = body.get("q", "")
+    if not q or not q.strip():
+        raise HTTPException(status_code=400, detail="'q' is required and must be non-empty")
+
+    caller_zone = auth_result.get("zone_id") or ROOT_ZONE_ID
+    zone_id: str = body.get("zone_id") or caller_zone
+    path_prefix: str | None = body.get("path_prefix")
+
+    raw_limit = body.get("limit", 20)
+    try:
+        effective_limit = max(1, min(100, int(raw_limit)))
+    except (TypeError, ValueError):
+        raise HTTPException(status_code=400, detail="'limit' must be an integer 1–100") from None
+
+    # Over-fetch for ReBAC filtering (follows _compute_rebac_fetch_limit pattern)
+    permission_enforcer = getattr(request.app.state, "permission_enforcer", None)
+    fetch_limit = _compute_rebac_fetch_limit(
+        effective_limit, has_enforcer=permission_enforcer is not None
+    )
+
+    # --- Query skeleton index ---
+    raw_candidates = await search_daemon.locate(
+        q,
+        zone_id=zone_id,
+        limit=fetch_limit,
+        path_prefix=path_prefix,
+    )
+    total_before_filter = len(raw_candidates)
+
+    # --- ReBAC filtering (11A) ---
+    # Adapt candidates to the shape _apply_rebac_filter expects (needs .path attr)
+    class _PathResult:
+        def __init__(self, d: dict[str, Any]) -> None:
+            self.path = d["path"]
+            self._d = d
+
+    result_objects = [_PathResult(c) for c in raw_candidates]
+    filtered_objects, filter_ms = _apply_rebac_filter(
+        result_objects,
+        permission_enforcer,
+        auth_result,
+        zone_id,
+    )
+
+    # Unpack back to dicts and truncate to effective_limit
+    candidates = [obj._d for obj in filtered_objects[:effective_limit]]
+
+    denial_stats = _rebac_denial_stats(total_before_filter, len(filtered_objects), effective_limit)
+    elapsed_ms = (time.perf_counter() - start_time) * 1000
+
+    logger.debug(
+        "[LOCATE] q=%r zone=%s → %d/%d candidates in %.1fms (filter %.1fms)",
+        q,
+        zone_id,
+        len(candidates),
+        total_before_filter,
+        elapsed_ms,
+        filter_ms,
+    )
+
+    return {
+        "candidates": candidates,
+        "total_before_filter": total_before_filter,
+        "elapsed_ms": round(elapsed_ms, 2),
+        **denial_stats,
+    }

--- a/src/nexus/server/lifespan/search.py
+++ b/src/nexus/server/lifespan/search.py
@@ -328,11 +328,18 @@ async def _wire_skeleton_indexer(app: "FastAPI", svc: "LifespanServices") -> Non
         )
         app.state.skeleton_indexer = _indexer
 
-        _consumer = SkeletonPipeConsumer(indexer=_indexer)
-        _consumer.bind_fs(_nx)
-        await _consumer.start()
+        # Capture running loop now (startup_search runs in the event loop).
+        # Passed to the consumer so _buffer() can use call_soon_threadsafe when
+        # VFS hooks fire from asyncio.to_thread (sync context).
+        _loop = asyncio.get_running_loop()
+
+        # Consumer is created here but NOT started — startup_services calls
+        # _startup_pipe_consumers after startup_search completes, and the Nexus
+        # kernel pipe registry isn't ready until that phase.  The consumer is
+        # stored on app.state so _startup_pipe_consumers can bind_fs + start it.
+        _consumer = SkeletonPipeConsumer(indexer=_indexer, fallback_loop=_loop)
         app.state.skeleton_pipe_consumer = _consumer
-        logger.debug("[SKELETON] SkeletonIndexer + SkeletonPipeConsumer created")
+        logger.debug("[SKELETON] SkeletonIndexer + SkeletonPipeConsumer created (pending start)")
 
         if not hasattr(_nx, "register_intercept_write"):
             return  # NexusFS doesn't support VFS hooks in this mode

--- a/src/nexus/server/lifespan/search.py
+++ b/src/nexus/server/lifespan/search.py
@@ -221,6 +221,12 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
             stats["startup_time_ms"],
         )
 
+        # Issue #3725: Wire SkeletonIndexer for live path+title index updates.
+        # Creates the indexer (FileReaderProtocol + SkeletonBM25Protocol) and
+        # registers VFS post-hooks so every write/delete/rename automatically
+        # keeps the in-memory skeleton index fresh without a full re-bootstrap.
+        _wire_skeleton_indexer(app, svc)
+
         # Issue #3147: Initialize ZoneSearchRegistry for federated search.
         # Phase 1: All zones use the single global daemon.
         # Phase 2: Per-zone daemons can be registered if ZoneManager is available.
@@ -276,3 +282,102 @@ def _init_zone_registry(app: "FastAPI", svc: "LifespanServices") -> None:
             logger.warning("[ZONE-REGISTRY] Failed to register zones: %s", e)
 
     app.state.zone_search_registry = registry
+
+
+def _wire_skeleton_indexer(app: "FastAPI", svc: "LifespanServices") -> None:
+    """Create SkeletonIndexer and register VFS post-hooks for live index updates.
+
+    Called after SearchDaemon.startup() so the daemon's in-memory index is
+    ready to receive upsert/delete calls via _DaemonSkeletonBM25.
+
+    VFS hooks follow the same call_soon_threadsafe pattern used by the
+    search auto-index hooks above — hooks may fire from synchronous threads
+    (asyncio.to_thread), so we schedule coroutines via the running loop.
+
+    Issue #3725 review decisions honoured:
+        - 4A  Live updates go through VFS post-hooks (write/delete/rename).
+        - 7A  2KB head cap enforced inside SkeletonIndexer.
+        - 14A Hash-based skip guard in index_file().
+    """
+    _nx = svc.nexus_fs
+    _daemon = getattr(app.state, "search_daemon", None)
+    if _nx is None or _daemon is None:
+        return
+
+    try:
+        import asyncio as _asyncio
+
+        from nexus.bricks.catalog.extractors import SKELETON_EXTRACTOR_REGISTRY
+        from nexus.bricks.search.skeleton_indexer import SkeletonIndexer
+        from nexus.factory.adapters import _DaemonSkeletonBM25, _NexusFSFileReader
+
+        _reader = _NexusFSFileReader(_nx)
+        _bm25 = _DaemonSkeletonBM25(_daemon)
+
+        _session_factory = None
+        _rs = svc.record_store
+        if _rs is not None:
+            with contextlib.suppress(AttributeError):
+                _session_factory = _rs.async_session_factory
+
+        _indexer = SkeletonIndexer(
+            file_reader=_reader,
+            bm25=_bm25,
+            extractor_registry=SKELETON_EXTRACTOR_REGISTRY,
+            async_session_factory=_session_factory,
+        )
+        app.state.skeleton_indexer = _indexer
+        logger.debug("[SKELETON] SkeletonIndexer created")
+
+        if not hasattr(_nx, "register_intercept_write"):
+            return  # NexusFS doesn't support VFS hooks in this mode
+
+        _loop = _asyncio.get_running_loop()
+        _zone_id = svc.zone_id or "root"
+
+        def _sk_write(path: str, zone_id: str | None) -> None:
+            with contextlib.suppress(RuntimeError):
+                _loop.call_soon_threadsafe(
+                    _loop.create_task,
+                    _indexer.index_file(virtual_path=path, zone_id=zone_id or _zone_id),
+                )
+
+        def _sk_delete(path: str, zone_id: str | None) -> None:
+            with contextlib.suppress(RuntimeError):
+                _loop.call_soon_threadsafe(
+                    _loop.create_task,
+                    _indexer.delete_file(virtual_path=path, zone_id=zone_id or _zone_id),
+                )
+
+        class _SkeletonWriteHook:
+            @property
+            def name(self) -> str:
+                return "skeleton_auto_index"
+
+            def on_post_write(self, ctx: object) -> None:
+                _sk_write(getattr(ctx, "path", ""), getattr(ctx, "zone_id", None))
+
+        class _SkeletonDeleteHook:
+            @property
+            def name(self) -> str:
+                return "skeleton_auto_delete"
+
+            def on_post_delete(self, ctx: object) -> None:
+                _sk_delete(getattr(ctx, "path", ""), getattr(ctx, "zone_id", None))
+
+        class _SkeletonRenameHook:
+            @property
+            def name(self) -> str:
+                return "skeleton_auto_rename"
+
+            def on_post_rename(self, ctx: object) -> None:
+                _sk_delete(getattr(ctx, "old_path", ""), getattr(ctx, "zone_id", None))
+                _sk_write(getattr(ctx, "new_path", ""), getattr(ctx, "zone_id", None))
+
+        _nx.register_intercept_write(_SkeletonWriteHook())
+        _nx.register_intercept_delete(_SkeletonDeleteHook())
+        _nx.register_intercept_rename(_SkeletonRenameHook())
+        logger.info("[SKELETON] VFS auto-index hooks registered (write/delete/rename)")
+
+    except Exception as e:
+        logger.warning("[SKELETON] Skeleton indexer wiring failed (non-fatal): %s", e)

--- a/src/nexus/server/lifespan/search.py
+++ b/src/nexus/server/lifespan/search.py
@@ -225,7 +225,7 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
         # Creates the indexer (FileReaderProtocol + SkeletonBM25Protocol) and
         # registers VFS post-hooks so every write/delete/rename automatically
         # keeps the in-memory skeleton index fresh without a full re-bootstrap.
-        _wire_skeleton_indexer(app, svc)
+        await _wire_skeleton_indexer(app, svc)
 
         # Issue #3147: Initialize ZoneSearchRegistry for federated search.
         # Phase 1: All zones use the single global daemon.
@@ -284,20 +284,21 @@ def _init_zone_registry(app: "FastAPI", svc: "LifespanServices") -> None:
     app.state.zone_search_registry = registry
 
 
-def _wire_skeleton_indexer(app: "FastAPI", svc: "LifespanServices") -> None:
-    """Create SkeletonIndexer and register VFS post-hooks for live index updates.
+async def _wire_skeleton_indexer(app: "FastAPI", svc: "LifespanServices") -> None:
+    """Create SkeletonIndexer + SkeletonPipeConsumer, register VFS hooks.
 
     Called after SearchDaemon.startup() so the daemon's in-memory index is
     ready to receive upsert/delete calls via _DaemonSkeletonBM25.
 
-    VFS hooks follow the same call_soon_threadsafe pattern used by the
-    search auto-index hooks above — hooks may fire from synchronous threads
-    (asyncio.to_thread), so we schedule coroutines via the running loop.
+    VFS hooks call SkeletonPipeConsumer.notify_* (sync, deque-buffered) rather
+    than scheduling coroutines directly — the consumer's flush task drains the
+    deque via the DT_PIPE so events are debounced and micro-batched (15A).
 
     Issue #3725 review decisions honoured:
-        - 4A  Live updates go through VFS post-hooks (write/delete/rename).
+        - 4A  Async pipe consumer (write/delete/rename routed via DT_PIPE).
         - 7A  2KB head cap enforced inside SkeletonIndexer.
         - 14A Hash-based skip guard in index_file().
+        - 15A Micro-batched concurrent reads via asyncio.gather in consumer.
     """
     _nx = svc.nexus_fs
     _daemon = getattr(app.state, "search_daemon", None)
@@ -305,10 +306,9 @@ def _wire_skeleton_indexer(app: "FastAPI", svc: "LifespanServices") -> None:
         return
 
     try:
-        import asyncio as _asyncio
-
         from nexus.bricks.catalog.extractors import SKELETON_EXTRACTOR_REGISTRY
         from nexus.bricks.search.skeleton_indexer import SkeletonIndexer
+        from nexus.bricks.search.skeleton_pipe_consumer import SkeletonPipeConsumer
         from nexus.factory.adapters import _DaemonSkeletonBM25, _NexusFSFileReader
 
         _reader = _NexusFSFileReader(_nx)
@@ -327,27 +327,17 @@ def _wire_skeleton_indexer(app: "FastAPI", svc: "LifespanServices") -> None:
             async_session_factory=_session_factory,
         )
         app.state.skeleton_indexer = _indexer
-        logger.debug("[SKELETON] SkeletonIndexer created")
+
+        _consumer = SkeletonPipeConsumer(indexer=_indexer)
+        _consumer.bind_fs(_nx)
+        await _consumer.start()
+        app.state.skeleton_pipe_consumer = _consumer
+        logger.debug("[SKELETON] SkeletonIndexer + SkeletonPipeConsumer created")
 
         if not hasattr(_nx, "register_intercept_write"):
             return  # NexusFS doesn't support VFS hooks in this mode
 
-        _loop = _asyncio.get_running_loop()
         _zone_id = svc.zone_id or "root"
-
-        def _sk_write(path: str, zone_id: str | None) -> None:
-            with contextlib.suppress(RuntimeError):
-                _loop.call_soon_threadsafe(
-                    _loop.create_task,
-                    _indexer.index_file(virtual_path=path, zone_id=zone_id or _zone_id),
-                )
-
-        def _sk_delete(path: str, zone_id: str | None) -> None:
-            with contextlib.suppress(RuntimeError):
-                _loop.call_soon_threadsafe(
-                    _loop.create_task,
-                    _indexer.delete_file(virtual_path=path, zone_id=zone_id or _zone_id),
-                )
 
         class _SkeletonWriteHook:
             @property
@@ -355,7 +345,11 @@ def _wire_skeleton_indexer(app: "FastAPI", svc: "LifespanServices") -> None:
                 return "skeleton_auto_index"
 
             def on_post_write(self, ctx: object) -> None:
-                _sk_write(getattr(ctx, "path", ""), getattr(ctx, "zone_id", None))
+                _consumer.notify_write(
+                    getattr(ctx, "path", ""),
+                    getattr(ctx, "path_id", None),
+                    getattr(ctx, "zone_id", None) or _zone_id,
+                )
 
         class _SkeletonDeleteHook:
             @property
@@ -363,7 +357,11 @@ def _wire_skeleton_indexer(app: "FastAPI", svc: "LifespanServices") -> None:
                 return "skeleton_auto_delete"
 
             def on_post_delete(self, ctx: object) -> None:
-                _sk_delete(getattr(ctx, "path", ""), getattr(ctx, "zone_id", None))
+                _consumer.notify_delete(
+                    getattr(ctx, "path", ""),
+                    getattr(ctx, "path_id", None),
+                    getattr(ctx, "zone_id", None) or _zone_id,
+                )
 
         class _SkeletonRenameHook:
             @property
@@ -371,8 +369,12 @@ def _wire_skeleton_indexer(app: "FastAPI", svc: "LifespanServices") -> None:
                 return "skeleton_auto_rename"
 
             def on_post_rename(self, ctx: object) -> None:
-                _sk_delete(getattr(ctx, "old_path", ""), getattr(ctx, "zone_id", None))
-                _sk_write(getattr(ctx, "new_path", ""), getattr(ctx, "zone_id", None))
+                _consumer.notify_rename(
+                    getattr(ctx, "old_path", ""),
+                    getattr(ctx, "new_path", ""),
+                    getattr(ctx, "path_id", None),
+                    getattr(ctx, "zone_id", None) or _zone_id,
+                )
 
         _nx.register_intercept_write(_SkeletonWriteHook())
         _nx.register_intercept_delete(_SkeletonDeleteHook())

--- a/src/nexus/server/lifespan/services.py
+++ b/src/nexus/server/lifespan/services.py
@@ -676,6 +676,18 @@ async def _startup_pipe_consumers(app: "FastAPI", svc: "LifespanServices") -> No
         except Exception as e:
             logger.warning("[PIPE] TaskDispatchPipeConsumer start failed: %s", e, exc_info=True)
 
+    # Issue #3725: SkeletonPipeConsumer — created in startup_search, started here
+    # so the Nexus kernel pipe registry is fully ready (startup_services runs after
+    # startup_search in the lifespan sequence).
+    skpc = getattr(app.state, "skeleton_pipe_consumer", None)
+    if skpc is not None and nx is not None:
+        try:
+            skpc.bind_fs(nx)
+            await skpc.start()
+            logger.info("[PIPE] SkeletonPipeConsumer started")
+        except Exception as e:
+            logger.warning("[PIPE] SkeletonPipeConsumer start failed: %s", e, exc_info=True)
+
 
 async def _shutdown_pipe_consumers(app: "FastAPI") -> None:
     """Stop DT_PIPE consumers (Issue #809, #810).
@@ -713,7 +725,7 @@ async def _shutdown_pipe_consumers(app: "FastAPI") -> None:
         except Exception as e:
             logger.warning("[PIPE] Error stopping TaskDispatchPipeConsumer: %s", e, exc_info=True)
 
-    # Issue #3725: SkeletonPipeConsumer
+    # Issue #3725: SkeletonPipeConsumer (created in startup_search, stopped here)
     skpc = getattr(app.state, "skeleton_pipe_consumer", None)
     if skpc is not None and hasattr(skpc, "stop"):
         try:

--- a/src/nexus/server/lifespan/services.py
+++ b/src/nexus/server/lifespan/services.py
@@ -712,3 +712,12 @@ async def _shutdown_pipe_consumers(app: "FastAPI") -> None:
             logger.info("[PIPE] TaskDispatchPipeConsumer stopped")
         except Exception as e:
             logger.warning("[PIPE] Error stopping TaskDispatchPipeConsumer: %s", e, exc_info=True)
+
+    # Issue #3725: SkeletonPipeConsumer
+    skpc = getattr(app.state, "skeleton_pipe_consumer", None)
+    if skpc is not None and hasattr(skpc, "stop"):
+        try:
+            await skpc.stop()
+            logger.info("[PIPE] SkeletonPipeConsumer stopped")
+        except Exception as e:
+            logger.warning("[PIPE] Error stopping SkeletonPipeConsumer: %s", e, exc_info=True)

--- a/src/nexus/storage/models/__init__.py
+++ b/src/nexus/storage/models/__init__.py
@@ -57,10 +57,11 @@ from nexus.storage.models.auth import ZoneModel as ZoneModel
 # Domain: Context Branching (Issue #1315)
 from nexus.storage.models.context_branch import ContextBranchModel as ContextBranchModel
 from nexus.storage.models.dead_letter import DeadLetterModel as DeadLetterModel
-from nexus.storage.models.exchange_audit_log import ExchangeAuditLogModel as ExchangeAuditLogModel
-from nexus.storage.models.file_path import FilePathModel as FilePathModel
 
 # Domain: Filesystem
+from nexus.storage.models.document_skeleton import DocumentSkeletonModel as DocumentSkeletonModel
+from nexus.storage.models.exchange_audit_log import ExchangeAuditLogModel as ExchangeAuditLogModel
+from nexus.storage.models.file_path import FilePathModel as FilePathModel
 from nexus.storage.models.filesystem import DirectoryEntryModel as DirectoryEntryModel
 from nexus.storage.models.filesystem import DocumentChunkModel as DocumentChunkModel
 from nexus.storage.models.filesystem import FileMetadataModel as FileMetadataModel

--- a/src/nexus/storage/models/document_skeleton.py
+++ b/src/nexus/storage/models/document_skeleton.py
@@ -1,0 +1,75 @@
+"""DocumentSkeletonModel — global path+title index for file location (Issue #3725).
+
+A lightweight, globally-indexed record for every file in every zone.
+No embeddings, no LLM — BM25 over path tokens and title only.
+Complementary to document_chunks (L2); this is the L0/L1 discovery layer.
+
+Design decisions:
+    - path_tokens column dropped (Issue #3725 review, 6A): virtual_path and title
+      are fed as separate BM25S fields so the daemon can apply column weights.
+      Pre-tokenized text would be redundant and create a rename-sync hazard.
+    - skeleton_content_hash = sha256(first 2048 bytes): skip guard prevents
+      redundant title re-extraction when file body changes but header doesn't.
+    - Bootstrap from DB rows, not file reads: on daemon restart the BM25S index
+      is reconstructed from existing rows without touching the file store.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from sqlalchemy import DateTime, ForeignKey, Index, String, Text
+from sqlalchemy.orm import Mapped, mapped_column
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.storage.models._base import Base
+
+
+class DocumentSkeletonModel(Base):
+    """Global file skeleton index for lightweight path+title search.
+
+    One row per live file in every zone, regardless of #3698 indexing scope.
+    The row is kept in sync by SkeletonPipeConsumer (create/rename/delete events).
+    """
+
+    __tablename__ = "document_skeleton"
+
+    # path_id is both PK and FK; one-to-one with file_paths.
+    path_id: Mapped[str] = mapped_column(
+        String(36),
+        ForeignKey("file_paths.path_id", ondelete="CASCADE"),
+        primary_key=True,
+        nullable=False,
+    )
+
+    # Denormalized for zone-scoped queries without a JOIN to file_paths.
+    zone_id: Mapped[str] = mapped_column(String(255), nullable=False, default=ROOT_ZONE_ID)
+
+    # First non-blank title extracted from the file header (≤ 2 KB read).
+    # NULL for binary files or files with no extractable title.
+    title: Mapped[str | None] = mapped_column(Text, nullable=True)
+
+    # sha256(content[:2048]) — skip guard for SkeletonPipeConsumer.
+    # If unchanged, title re-extraction is skipped entirely.
+    skeleton_content_hash: Mapped[str | None] = mapped_column(String(64), nullable=True)
+
+    indexed_at: Mapped[datetime] = mapped_column(
+        DateTime,
+        nullable=False,
+        default=lambda: datetime.now(UTC),
+        onupdate=lambda: datetime.now(UTC),
+    )
+
+    __table_args__ = (
+        # Primary lookup: all skeleton rows for a zone (used by /locate query)
+        Index("idx_document_skeleton_zone", "zone_id"),
+        # Covering index for the daemon's bootstrap SELECT
+        # (zone_id, path_id, title — no heap fetch needed)
+        Index("idx_document_skeleton_zone_path_title", "zone_id", "path_id", "title"),
+    )
+
+    def __repr__(self) -> str:
+        return (
+            f"<DocumentSkeletonModel(path_id={self.path_id}, zone={self.zone_id}, "
+            f"title={self.title!r})>"
+        )

--- a/tests/e2e/self_contained/test_skeleton_locate_e2e.py
+++ b/tests/e2e/self_contained/test_skeleton_locate_e2e.py
@@ -1,0 +1,237 @@
+"""E2E: lightweight locate() over HERB-style folder structure (Issue #3725).
+
+Validates:
+1. locate() returns path hits by folder/filename tokens (BM25-lite, no txtai).
+2. locate() scores title matches higher than path-only matches.
+3. Zone isolation: locate() never leaks docs across zones.
+4. locate() does NOT trigger txtai embedding calls — only the in-memory skeleton
+   dict is consulted, so it works even with a bare SearchDaemon() (no config).
+5. Content semantic search (txtai) is NOT triggered by locate() and is absent
+   when no txtai model is configured.
+
+Seed data mirrors the HERB benchmark corpus layout:
+    /workspace/demo/herb/customers/cust-001.md  — Acme Corporation
+    /workspace/demo/herb/customers/cust-002.md  — BrightLight Ltd
+    /workspace/demo/herb/customers/cust-003.md  — CloudMatrix Inc
+    /workspace/demo/herb/employees/emp-001.md   — Sarah Kim
+    /workspace/demo/herb/employees/emp-002.md   — Daniel Torres
+    /workspace/demo/herb/employees/emp-003.md   — Priya Nair
+    /workspace/demo/herb/products/prod-001.md   — NanoSynth
+    /workspace/demo/herb/products/prod-002.md   — VaultEdge
+    /workspace/demo/herb/products/prod-003.md   — TerraFlow
+    /workspace/internal/billing/invoice-q1.md   — Q1 Invoice Summary (other zone)
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.bricks.search.daemon import SearchDaemon
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+ZONE = "root"
+OTHER_ZONE = "billing-zone"
+
+HERB_DOCS = [
+    # (path_id, virtual_path, title)
+    (
+        "pid-c001",
+        "/workspace/demo/herb/customers/cust-001.md",
+        "HERB customer record — Acme Corporation",
+    ),
+    (
+        "pid-c002",
+        "/workspace/demo/herb/customers/cust-002.md",
+        "HERB customer record — BrightLight Ltd",
+    ),
+    (
+        "pid-c003",
+        "/workspace/demo/herb/customers/cust-003.md",
+        "HERB customer record — CloudMatrix Inc",
+    ),
+    ("pid-e001", "/workspace/demo/herb/employees/emp-001.md", "HERB employee record — Sarah Kim"),
+    (
+        "pid-e002",
+        "/workspace/demo/herb/employees/emp-002.md",
+        "HERB employee record — Daniel Torres",
+    ),
+    ("pid-e003", "/workspace/demo/herb/employees/emp-003.md", "HERB employee record — Priya Nair"),
+    ("pid-p001", "/workspace/demo/herb/products/prod-001.md", "HERB product record — NanoSynth"),
+    ("pid-p002", "/workspace/demo/herb/products/prod-002.md", "HERB product record — VaultEdge"),
+    ("pid-p003", "/workspace/demo/herb/products/prod-003.md", "HERB product record — TerraFlow"),
+]
+
+OTHER_DOCS = [
+    ("pid-b001", "/workspace/internal/billing/invoice-q1.md", "Q1 Invoice Summary"),
+]
+
+
+@pytest.fixture
+def daemon() -> SearchDaemon:
+    """Bare SearchDaemon — no DB, no txtai config, purely in-memory skeleton index."""
+    d = SearchDaemon()
+    for path_id, virtual_path, title in HERB_DOCS:
+        d.upsert_skeleton_doc(path_id=path_id, virtual_path=virtual_path, title=title, zone_id=ZONE)
+    for path_id, virtual_path, title in OTHER_DOCS:
+        d.upsert_skeleton_doc(
+            path_id=path_id, virtual_path=virtual_path, title=title, zone_id=OTHER_ZONE
+        )
+    return d
+
+
+# ---------------------------------------------------------------------------
+# 1. Basic path-token locate
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_locate_herb_folder_returns_all_herb_docs(daemon: SearchDaemon) -> None:
+    """Query 'herb' matches the /herb/ path segment → all 9 HERB docs surface."""
+    results = await daemon.locate("herb", zone_id=ZONE, limit=20)
+    paths = [r["path"] for r in results]
+
+    for _, vp, _ in HERB_DOCS:
+        assert vp in paths, f"expected {vp!r} in locate('herb') results"
+
+
+@pytest.mark.asyncio
+async def test_locate_customers_subfolder(daemon: SearchDaemon) -> None:
+    """Query 'customers' returns only customer docs, not employees/products."""
+    results = await daemon.locate("customers", zone_id=ZONE, limit=20)
+    paths = [r["path"] for r in results]
+
+    for _, vp, _ in HERB_DOCS:
+        if "/customers/" in vp:
+            assert vp in paths, f"customer doc missing: {vp}"
+        else:
+            assert vp not in paths, f"non-customer doc leaked: {vp}"
+
+
+@pytest.mark.asyncio
+async def test_locate_employees_subfolder(daemon: SearchDaemon) -> None:
+    """Query 'employees' returns only employee docs."""
+    results = await daemon.locate("employees", zone_id=ZONE, limit=20)
+    paths = [r["path"] for r in results]
+
+    for _, vp, _ in HERB_DOCS:
+        if "/employees/" in vp:
+            assert vp in paths, f"employee doc missing: {vp}"
+        else:
+            assert vp not in paths, f"non-employee doc leaked: {vp}"
+
+
+# ---------------------------------------------------------------------------
+# 2. Title-weighted scoring
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_locate_acme_returns_cust001_first(daemon: SearchDaemon) -> None:
+    """'acme' only appears in cust-001's title → should be top result."""
+    results = await daemon.locate("acme", zone_id=ZONE, limit=5)
+    assert results, "expected at least one result"
+    assert results[0]["path"] == "/workspace/demo/herb/customers/cust-001.md"
+
+
+@pytest.mark.asyncio
+async def test_locate_sarah_returns_emp001_first(daemon: SearchDaemon) -> None:
+    """'sarah' only appears in emp-001's title → top result."""
+    results = await daemon.locate("sarah", zone_id=ZONE, limit=5)
+    assert results
+    assert results[0]["path"] == "/workspace/demo/herb/employees/emp-001.md"
+
+
+@pytest.mark.asyncio
+async def test_locate_title_score_gt_path_score(daemon: SearchDaemon) -> None:
+    """Title match (weight 2) outscores pure path match (weight 1).
+
+    'acme' is in cust-001's title but NOT in any path segment, so its score
+    should be non-zero and come from the title channel only.
+    """
+    results = await daemon.locate("acme", zone_id=ZONE, limit=1)
+    assert results
+    assert results[0]["score"] >= 2.0, "title match should score ≥ 2.0 (weight=2)"
+
+
+# ---------------------------------------------------------------------------
+# 3. Zone isolation
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_locate_does_not_leak_across_zones(daemon: SearchDaemon) -> None:
+    """HERB docs must not appear when querying from OTHER_ZONE."""
+    results = await daemon.locate("herb", zone_id=OTHER_ZONE, limit=20)
+    paths = [r["path"] for r in results]
+    for _, vp, _ in HERB_DOCS:
+        assert vp not in paths, f"zone isolation broken: {vp} leaked into {OTHER_ZONE}"
+
+
+@pytest.mark.asyncio
+async def test_locate_root_zone_does_not_see_billing(daemon: SearchDaemon) -> None:
+    """billing invoice must not appear in ZONE query."""
+    results = await daemon.locate("invoice", zone_id=ZONE, limit=20)
+    paths = [r["path"] for r in results]
+    for _, vp, _ in OTHER_DOCS:
+        assert vp not in paths, f"zone isolation broken: {vp} leaked into {ZONE}"
+
+
+# ---------------------------------------------------------------------------
+# 4. locate() requires no txtai — works on bare daemon without config
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_locate_works_without_txtai_config() -> None:
+    """SearchDaemon() with no config can locate documents via BM25-lite.
+
+    This proves locate() is independent of txtai embeddings — path+title tokens
+    are pure string operations on the in-memory dict.
+    """
+    daemon_no_cfg = SearchDaemon()  # no DaemonConfig → no DB, no txtai
+    daemon_no_cfg.upsert_skeleton_doc(
+        path_id="pid-test",
+        virtual_path="/workspace/src/auth/login.py",
+        title="User login module",
+        zone_id="root",
+    )
+
+    results = await daemon_no_cfg.locate("login", zone_id="root", limit=5)
+    assert results, "locate() must work without txtai config"
+    assert results[0]["path"] == "/workspace/src/auth/login.py"
+
+
+# ---------------------------------------------------------------------------
+# 5. Content semantic search NOT enabled by default (no txtai model config)
+# ---------------------------------------------------------------------------
+
+
+def test_daemon_has_no_embedding_model_by_default() -> None:
+    """SearchDaemon() without DaemonConfig has no txtai embedding model wired.
+
+    This verifies the default: lightweight path search is on, but full content
+    semantic search (txtai vector embeddings) is NOT triggered unless explicitly
+    configured via DaemonConfig(txtai_model=...).
+    """
+    daemon_no_cfg = SearchDaemon()
+    stats = daemon_no_cfg.get_stats()
+    # backend should be "none", "legacy" (BM25+SQL), or "bm25" — not txtai/vector
+    backend = stats.get("backend", "none")
+    assert backend not in ("txtai", "vector", "openai"), (
+        f"unexpected embedding backend without config: backend={backend!r}. "
+        "Full content semantic search must not be enabled without explicit config."
+    )
+
+
+@pytest.mark.asyncio
+async def test_locate_result_has_no_embedding_field(daemon: SearchDaemon) -> None:
+    """locate() results must not contain an 'embedding' field — pure BM25-lite output."""
+    results = await daemon.locate("herb", zone_id=ZONE, limit=3)
+    assert results
+    for r in results:
+        assert "embedding" not in r, f"locate() leaked embedding field: {r}"
+        # Only the documented fields should be present
+        assert set(r.keys()) <= {"path", "score", "title"}, f"unexpected keys in result: {r}"

--- a/tests/integration/bricks/search/test_skeleton_rebac.py
+++ b/tests/integration/bricks/search/test_skeleton_rebac.py
@@ -1,0 +1,160 @@
+"""Integration tests for ReBAC filtering on POST /api/v2/search/locate (Issue #3725, 11A).
+
+Verifies that the /locate endpoint respects file-level permissions:
+    - A user without access to a path gets 0 results for that path.
+    - A user with access gets expected results.
+    - Missing permission_enforcer means no filtering (all results pass through).
+
+Uses a mock daemon and mock permission enforcer to isolate endpoint logic from
+infrastructure dependencies.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nexus.server.api.v2.routers.search import router
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+def _make_app(
+    daemon: Any,
+    permission_enforcer: Any | None,
+    zone_id: str = "root",
+) -> FastAPI:
+    """Build a minimal FastAPI app with the search router and mocked state."""
+    app = FastAPI()
+    app.include_router(router)
+    app.state.search_daemon = daemon
+    app.state.permission_enforcer = permission_enforcer
+    # Inject auth so require_auth dependency resolves
+    app.state._test_zone_id = zone_id
+    return app
+
+
+def _make_daemon(candidates: list[dict[str, Any]]) -> MagicMock:
+    """Stub daemon whose locate() returns given candidates."""
+    daemon = MagicMock()
+    daemon.is_initialized = True
+    daemon.locate = AsyncMock(return_value=candidates)
+    return daemon
+
+
+def _make_enforcer(permitted_paths: list[str]) -> MagicMock:
+    """Stub enforcer that only allows paths in permitted_paths."""
+    enforcer = MagicMock()
+
+    def _filter(paths: list[str], *, user_id: str, zone_id: str, is_admin: bool) -> list[str]:
+        return [p for p in paths if p in permitted_paths]
+
+    enforcer.filter_search_results = MagicMock(side_effect=_filter)
+    return enforcer
+
+
+# Override require_auth to inject a test user without needing JWT infrastructure
+def _auth_override(zone_id: str = "root") -> dict[str, Any]:
+    return {"subject_id": "test-user", "zone_id": zone_id, "is_admin": False}
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_unauthorized_user_gets_zero_results() -> None:
+    """User without access to any candidate path gets an empty candidates list."""
+    candidates = [
+        {"path": "/workspace/src/auth/login.py", "score": 8.4, "title": "Login module"},
+        {"path": "/workspace/src/auth/oauth.py", "score": 6.2, "title": "OAuth middleware"},
+    ]
+    # Enforcer denies access to all paths
+    enforcer = _make_enforcer(permitted_paths=[])
+    daemon = _make_daemon(candidates)
+
+    app = _make_app(daemon, enforcer)
+    app.dependency_overrides[
+        __import__("nexus.server.dependencies", fromlist=["require_auth"]).require_auth
+    ] = lambda: _auth_override()
+
+    client = TestClient(app, raise_server_exceptions=True)
+    response = client.post("/api/v2/search/locate", json={"q": "authentication"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert body["candidates"] == [], f"expected empty, got: {body['candidates']}"
+    assert body["total_before_filter"] == 2
+    assert body["permission_denial_rate"] == 1.0
+
+
+@pytest.mark.asyncio
+async def test_authorized_user_gets_permitted_results() -> None:
+    """User with access to one of two candidate paths gets exactly that path."""
+    login_path = "/workspace/src/auth/login.py"
+    oauth_path = "/workspace/src/auth/oauth.py"
+
+    candidates = [
+        {"path": login_path, "score": 8.4, "title": "Login module"},
+        {"path": oauth_path, "score": 6.2, "title": "OAuth middleware"},
+    ]
+    # Enforcer grants access only to login_path
+    enforcer = _make_enforcer(permitted_paths=[login_path])
+    daemon = _make_daemon(candidates)
+
+    app = _make_app(daemon, enforcer)
+    app.dependency_overrides[
+        __import__("nexus.server.dependencies", fromlist=["require_auth"]).require_auth
+    ] = lambda: _auth_override()
+
+    client = TestClient(app, raise_server_exceptions=True)
+    response = client.post("/api/v2/search/locate", json={"q": "authentication"})
+
+    assert response.status_code == 200
+    body = response.json()
+    paths = [c["path"] for c in body["candidates"]]
+    assert login_path in paths
+    assert oauth_path not in paths
+
+
+@pytest.mark.asyncio
+async def test_no_enforcer_returns_all_results() -> None:
+    """When no permission enforcer is configured, all results pass through."""
+    candidates = [
+        {"path": "/workspace/src/auth/login.py", "score": 8.4, "title": "Login module"},
+    ]
+    daemon = _make_daemon(candidates)
+
+    app = _make_app(daemon, permission_enforcer=None)
+    app.dependency_overrides[
+        __import__("nexus.server.dependencies", fromlist=["require_auth"]).require_auth
+    ] = lambda: _auth_override()
+
+    client = TestClient(app, raise_server_exceptions=True)
+    response = client.post("/api/v2/search/locate", json={"q": "login"})
+
+    assert response.status_code == 200
+    body = response.json()
+    assert len(body["candidates"]) == 1
+    assert body["permission_denial_rate"] == 0.0
+
+
+@pytest.mark.asyncio
+async def test_missing_q_returns_400() -> None:
+    """Empty or missing query returns HTTP 400."""
+    daemon = _make_daemon([])
+    app = _make_app(daemon, permission_enforcer=None)
+    app.dependency_overrides[
+        __import__("nexus.server.dependencies", fromlist=["require_auth"]).require_auth
+    ] = lambda: _auth_override()
+
+    client = TestClient(app, raise_server_exceptions=False)
+    response = client.post("/api/v2/search/locate", json={"q": ""})
+    assert response.status_code == 400

--- a/tests/integration/bricks/search/test_skeleton_rename.py
+++ b/tests/integration/bricks/search/test_skeleton_rename.py
@@ -1,0 +1,159 @@
+"""Integration tests for document_skeleton rename sync (Issue #3725, 10A).
+
+Verifies the rename pipeline contract:
+    - Old path no longer surfaces in locate() results.
+    - New path does surface.
+    - Title is preserved (not re-extracted as None due to stale hash).
+
+Uses mock collaborators so the test does not require a live DB or file store.
+The important invariant is the SkeletonPipeConsumer rename dispatch sequence:
+    delete(old_path) → index(new_path)
+which must leave the in-memory daemon index in the correct state.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from nexus.bricks.search.skeleton_indexer import SkeletonIndexer
+
+# ---------------------------------------------------------------------------
+# Minimal in-memory stubs
+# ---------------------------------------------------------------------------
+
+
+class _StubBM25:
+    """Records upsert/delete calls for assertion."""
+
+    def __init__(self) -> None:
+        self.upserted: list[dict[str, Any]] = []
+        self.deleted: list[str] = []
+
+    async def upsert_skeleton(self, doc_id, virtual_path, title, zone_id, *, path_id=None) -> None:
+        self.upserted.append(
+            {"doc_id": doc_id, "virtual_path": virtual_path, "title": title, "zone_id": zone_id}
+        )
+
+    async def delete_skeleton(self, doc_id, zone_id) -> None:
+        self.deleted.append(doc_id)
+
+
+class _StubFileReader:
+    """Returns pre-configured head bytes keyed by path."""
+
+    def __init__(self, content_map: dict[str, bytes]) -> None:
+        self._map = content_map
+
+    async def read_head(self, virtual_path: str, max_bytes: int) -> bytes:
+        return self._map.get(virtual_path, b"")
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_rename_old_path_deleted_new_path_indexed() -> None:
+    """After a rename event, old path is removed and new path is indexed."""
+    old_path = "/workspace/src/auth/login.py"
+    new_path = "/workspace/src/auth/authenticate.py"
+    path_id = "pid-001"
+    zone_id = "root"
+
+    content = b'"""User authentication module."""\n'
+    reader = _StubFileReader({new_path: content})
+    bm25 = _StubBM25()
+    indexer = SkeletonIndexer(file_reader=reader, bm25=bm25, async_session_factory=None)
+
+    # Simulate: old path was previously indexed
+    await indexer.index_file(
+        path_id=path_id,
+        virtual_path=old_path,
+        zone_id=zone_id,
+    )
+    assert any(u["virtual_path"] == old_path for u in bm25.upserted)
+
+    # Simulate rename: delete old, index new (as SkeletonPipeConsumer does it)
+    await indexer.delete_file(path_id=path_id, virtual_path=old_path, zone_id=zone_id)
+    await indexer.index_file(path_id=path_id, virtual_path=new_path, zone_id=zone_id)
+
+    # Old path must have been deleted from BM25
+    assert old_path in bm25.deleted, f"expected {old_path!r} in deleted: {bm25.deleted}"
+
+    # New path must be in upserted
+    new_upserts = [u for u in bm25.upserted if u["virtual_path"] == new_path]
+    assert new_upserts, f"expected {new_path!r} in upserted: {bm25.upserted}"
+
+
+@pytest.mark.asyncio
+async def test_rename_title_preserved_via_fresh_extraction() -> None:
+    """After rename, the title is freshly extracted from the new path.
+
+    The skeleton_content_hash for the old path is irrelevant — because the
+    path_id is the same but the virtual_path changed, hash comparison is on
+    the new content read.  Title should match the module docstring.
+    """
+    old_path = "/workspace/src/old_name.py"
+    new_path = "/workspace/src/new_name.py"
+    path_id = "pid-002"
+    zone_id = "root"
+    expected_title = "Core authentication utility."
+
+    reader = _StubFileReader(
+        {
+            new_path: f'"""{expected_title}"""\n'.encode(),
+        }
+    )
+    from nexus.bricks.catalog.extractors import SKELETON_EXTRACTOR_REGISTRY
+
+    bm25 = _StubBM25()
+    indexer = SkeletonIndexer(
+        file_reader=reader,
+        bm25=bm25,
+        async_session_factory=None,
+        extractor_registry=SKELETON_EXTRACTOR_REGISTRY,
+    )
+
+    await indexer.delete_file(path_id=path_id, virtual_path=old_path, zone_id=zone_id)
+    await indexer.index_file(path_id=path_id, virtual_path=new_path, zone_id=zone_id)
+
+    new_upserts = [u for u in bm25.upserted if u["virtual_path"] == new_path]
+    assert new_upserts
+    assert new_upserts[-1]["title"] == expected_title
+
+
+@pytest.mark.asyncio
+async def test_rename_does_not_leave_old_path_in_daemon_locate() -> None:
+    """After rename, daemon.locate() must not return the old path."""
+    from nexus.bricks.search.daemon import SearchDaemon
+
+    old_path = "/workspace/src/auth/old_login.py"
+    new_path = "/workspace/src/auth/new_login.py"
+    zone_id = "root"
+
+    daemon = SearchDaemon()
+    # Manually populate daemon skeleton docs as bootstrap would
+    daemon.upsert_skeleton_doc(
+        path_id="pid-003",
+        virtual_path=old_path,
+        title="Old login module.",
+        zone_id=zone_id,
+    )
+
+    # Simulate rename in daemon
+    daemon.delete_skeleton_doc(virtual_path=old_path, zone_id=zone_id)
+    daemon.upsert_skeleton_doc(
+        path_id="pid-003",
+        virtual_path=new_path,
+        title="Old login module.",  # title unchanged
+        zone_id=zone_id,
+    )
+
+    results = await daemon.locate("login", zone_id=zone_id, limit=10)
+    paths = [r["path"] for r in results]
+
+    assert old_path not in paths, f"old path leaked after rename: {paths}"
+    assert new_path in paths, f"new path missing after rename: {paths}"

--- a/tests/integration/search/test_skeleton_zone_isolation.py
+++ b/tests/integration/search/test_skeleton_zone_isolation.py
@@ -1,0 +1,209 @@
+"""Integration tests for zone isolation in document_skeleton / locate() (Issue #3725, 12A).
+
+Verifies the core invariant: a locate() query in zone A must not return paths
+from zone B, even if both zones contain documents matching the query.
+
+Tests cover:
+    - daemon.locate() zone filter (unit-level, no DB)
+    - SkeletonIndexer zone stamping on upsert
+    - Two-zone scenario: zone A query returns only zone A paths
+
+These tests use in-memory daemon state (no DB, no file store) to keep
+the invariant verifiable without infrastructure dependencies.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from nexus.bricks.search.daemon import SearchDaemon
+from nexus.bricks.search.skeleton_indexer import SkeletonIndexer
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _populate_daemon(daemon: SearchDaemon, docs: list[dict[str, Any]]) -> None:
+    """Directly populate daemon skeleton index for test setup."""
+    for doc in docs:
+        daemon.upsert_skeleton_doc(
+            path_id=doc["path_id"],
+            virtual_path=doc["path"],
+            title=doc.get("title"),
+            zone_id=doc["zone_id"],
+        )
+
+
+# ---------------------------------------------------------------------------
+# Tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.asyncio
+async def test_locate_returns_only_zone_a_results() -> None:
+    """Zone A query must not surface paths from zone B."""
+    daemon = SearchDaemon()
+
+    zone_a_path = "/workspace-a/src/auth/login.py"
+    zone_b_path = "/workspace-b/src/auth/login.py"
+
+    _populate_daemon(
+        daemon,
+        [
+            {
+                "path_id": "pid-a1",
+                "path": zone_a_path,
+                "title": "Login module",
+                "zone_id": "zone-a",
+            },
+            {
+                "path_id": "pid-b1",
+                "path": zone_b_path,
+                "title": "Login module",
+                "zone_id": "zone-b",
+            },
+        ],
+    )
+
+    results = await daemon.locate("login", zone_id="zone-a", limit=20)
+    paths = [r["path"] for r in results]
+
+    assert zone_a_path in paths, f"zone A path missing: {paths}"
+    assert zone_b_path not in paths, f"zone B path leaked into zone A query: {paths}"
+
+
+@pytest.mark.asyncio
+async def test_locate_zone_b_does_not_surface_zone_a_paths() -> None:
+    """Symmetric: zone B query must not surface zone A paths."""
+    daemon = SearchDaemon()
+
+    zone_a_path = "/workspace-a/src/auth/oauth.py"
+    zone_b_path = "/workspace-b/src/auth/oauth.py"
+
+    _populate_daemon(
+        daemon,
+        [
+            {
+                "path_id": "pid-a2",
+                "path": zone_a_path,
+                "title": "OAuth middleware",
+                "zone_id": "zone-a",
+            },
+            {
+                "path_id": "pid-b2",
+                "path": zone_b_path,
+                "title": "OAuth middleware",
+                "zone_id": "zone-b",
+            },
+        ],
+    )
+
+    results = await daemon.locate("oauth", zone_id="zone-b", limit=20)
+    paths = [r["path"] for r in results]
+
+    assert zone_b_path in paths
+    assert zone_a_path not in paths, f"zone A path leaked into zone B query: {paths}"
+
+
+@pytest.mark.asyncio
+async def test_locate_empty_zone_returns_no_results() -> None:
+    """Query against a zone with no skeleton docs returns empty list."""
+    daemon = SearchDaemon()
+
+    _populate_daemon(
+        daemon,
+        [
+            {
+                "path_id": "pid-x1",
+                "path": "/ws/src/util.py",
+                "title": "Utilities",
+                "zone_id": "zone-x",
+            },
+        ],
+    )
+
+    results = await daemon.locate("util", zone_id="zone-y", limit=20)
+    assert results == [], f"expected empty for zone-y, got {results}"
+
+
+@pytest.mark.asyncio
+async def test_skeleton_indexer_stamps_zone_id_on_upsert() -> None:
+    """SkeletonIndexer must stamp the correct zone_id when calling bm25.upsert_skeleton."""
+
+    class _TrackingBM25:
+        def __init__(self) -> None:
+            self.calls: list[dict[str, Any]] = []
+
+        async def upsert_skeleton(
+            self, doc_id, virtual_path, title, zone_id, *, path_id=None
+        ) -> None:
+            self.calls.append({"doc_id": doc_id, "zone_id": zone_id})
+
+        async def delete_skeleton(self, doc_id, zone_id) -> None:
+            pass
+
+    class _FakeReader:
+        async def read_head(self, virtual_path, max_bytes) -> bytes:
+            return b"# header\n"
+
+    bm25 = _TrackingBM25()
+    indexer = SkeletonIndexer(file_reader=_FakeReader(), bm25=bm25, async_session_factory=None)
+
+    await indexer.index_file(
+        path_id="pid-zone",
+        virtual_path="/workspace/src/main.py",
+        zone_id="expected-zone",
+    )
+
+    assert bm25.calls, "no upsert_skeleton call made"
+    assert bm25.calls[0]["zone_id"] == "expected-zone"
+
+
+@pytest.mark.asyncio
+async def test_two_zone_full_pipeline_zone_isolation() -> None:
+    """Full two-zone scenario: index files in both zones, verify query isolation.
+
+    This is the canonical zone isolation integration test for the skeleton feature.
+    """
+    daemon = SearchDaemon()
+
+    auth_a = "/zone-a/src/auth/handler.py"
+    auth_b = "/zone-b/src/auth/handler.py"
+    unrelated = "/zone-a/src/unrelated/other.py"
+
+    _populate_daemon(
+        daemon,
+        [
+            {
+                "path_id": "pa1",
+                "path": auth_a,
+                "title": "Authentication handler",
+                "zone_id": "zone-a",
+            },
+            {
+                "path_id": "pb1",
+                "path": auth_b,
+                "title": "Authentication handler",
+                "zone_id": "zone-b",
+            },
+            {"path_id": "pa2", "path": unrelated, "title": "Unrelated module", "zone_id": "zone-a"},
+        ],
+    )
+
+    # Zone A query for "authentication" should surface only zone-a paths
+    zone_a_results = await daemon.locate("authentication", zone_id="zone-a", limit=20)
+    zone_a_paths = {r["path"] for r in zone_a_results}
+
+    assert auth_a in zone_a_paths
+    assert auth_b not in zone_a_paths, "Zone B auth handler leaked into zone A query"
+
+    # Zone B query for "authentication" should surface only zone-b paths
+    zone_b_results = await daemon.locate("authentication", zone_id="zone-b", limit=20)
+    zone_b_paths = {r["path"] for r in zone_b_results}
+
+    assert auth_b in zone_b_paths
+    assert auth_a not in zone_b_paths, "Zone A auth handler leaked into zone B query"
+    assert unrelated not in zone_b_paths, "Zone A unrelated leaked into zone B query"

--- a/tests/unit/bricks/catalog/test_extractors.py
+++ b/tests/unit/bricks/catalog/test_extractors.py
@@ -13,9 +13,15 @@ from nexus.bricks.catalog.extractors import (
     CSVExtractor,
     DocumentExtractionResult,
     ExtractionResult,
+    HtmlDocumentExtractor,
+    JsonDocumentExtractor,
     JSONExtractor,
     MarkdownExtractor,
     ParquetExtractor,
+    PythonDocumentExtractor,
+    TypeScriptDocumentExtractor,
+    YamlDocumentExtractor,
+    _load_json_head,
 )
 
 
@@ -722,3 +728,300 @@ class TestExtractorSelfRegistration:
         ext = ParquetExtractor()
         assert "application/parquet" in ext.mime_types
         assert "parquet" in ext.extensions
+
+
+# ============================================================================
+# _load_json_head helper (Issue #3725 — 8A)
+# ============================================================================
+
+
+class TestLoadJsonHead:
+    def test_returns_dict_for_simple_object(self) -> None:
+        content = b'{"name": "acme", "version": "1.0"}'
+        result = _load_json_head(content)
+        assert result == {"name": "acme", "version": "1.0"}
+
+    def test_returns_first_element_for_array(self) -> None:
+        content = b'[{"title": "first"}, {"title": "second"}]'
+        result = _load_json_head(content)
+        assert result == {"title": "first"}
+
+    def test_returns_none_for_empty_input(self) -> None:
+        assert _load_json_head(b"") is None
+
+    def test_returns_none_for_truncated_json(self) -> None:
+        # 2KB boundary cuts mid-object — must not raise
+        truncated = b'{"name": "acme", "long_key": "' + b"x" * 3000
+        result = _load_json_head(truncated, max_bytes=50)
+        assert result is None  # graceful degradation
+
+    def test_returns_none_for_binary_input(self) -> None:
+        binary = bytes(range(256))
+        assert _load_json_head(binary) is None
+
+    def test_returns_none_for_plain_string_json(self) -> None:
+        # Valid JSON but not a dict/array-of-dicts
+        assert _load_json_head(b'"just a string"') is None
+
+
+# ============================================================================
+# JsonDocumentExtractor (Issue #3725 — skeleton title extraction)
+# ============================================================================
+
+
+class TestJsonDocumentExtractor:
+    def setup_method(self) -> None:
+        self.ext = JsonDocumentExtractor()
+
+    # Happy path
+    def test_extracts_title_key(self) -> None:
+        content = b'{"title": "My Project", "version": "2.0"}'
+        result = self.ext.extract(content)
+        assert result.title == "My Project"
+        assert result.error is None
+
+    def test_prefers_title_over_name(self) -> None:
+        content = b'{"title": "Title Value", "name": "Name Value"}'
+        result = self.ext.extract(content)
+        assert result.title == "Title Value"
+
+    def test_falls_back_to_name_if_no_title(self) -> None:
+        content = b'{"name": "my-package", "version": "1.2.3"}'
+        result = self.ext.extract(content)
+        assert result.title == "my-package"
+
+    def test_falls_back_to_description(self) -> None:
+        content = b'{"description": "A useful tool", "scripts": {}}'
+        result = self.ext.extract(content)
+        assert result.title == "A useful tool"
+
+    # Adversarial / edge cases
+    def test_name_is_integer_returns_none(self) -> None:
+        # name=42 is not a string — should not set title
+        content = b'{"name": 42, "version": "1.0"}'
+        result = self.ext.extract(content)
+        assert result.title is None
+
+    def test_empty_content(self) -> None:
+        result = self.ext.extract(b"")
+        assert result.title is None
+        assert result.error is not None
+
+    def test_truncated_at_2kb_does_not_raise(self) -> None:
+        # Simulate what SkeletonIndexer passes: content[:2048] that ends mid-JSON
+        payload = (b'{"name": "partial", "data": "' + b"x" * 2000 + b'"')[:2048]
+        result = self.ext.extract(payload)
+        # May or may not extract a title, but must never raise
+        assert isinstance(result, DocumentExtractionResult)
+
+    def test_binary_blob_does_not_raise(self) -> None:
+        result = self.ext.extract(bytes(range(256)))
+        assert isinstance(result, DocumentExtractionResult)
+
+
+# ============================================================================
+# YamlDocumentExtractor (Issue #3725)
+# ============================================================================
+
+
+class TestYamlDocumentExtractor:
+    def setup_method(self) -> None:
+        self.ext = YamlDocumentExtractor()
+
+    # Happy path
+    def test_extracts_title_key(self) -> None:
+        content = b"title: My YAML Title\nversion: 1.0\n"
+        result = self.ext.extract(content)
+        assert result.title == "My YAML Title"
+
+    def test_extracts_name_key(self) -> None:
+        content = b"name: my-chart\ndescription: A Helm chart\n"
+        result = self.ext.extract(content)
+        assert result.title == "my-chart"
+
+    # Adversarial
+    def test_empty_file_returns_null_title(self) -> None:
+        result = self.ext.extract(b"")
+        assert result.title is None
+
+    def test_comment_only_file_returns_null_title(self) -> None:
+        content = b"# just a comment\n# another comment\n"
+        result = self.ext.extract(content)
+        # All lines start with # → no title extractable
+        assert result.title is None
+
+    def test_binary_blob_does_not_raise(self) -> None:
+        result = self.ext.extract(bytes(range(256)))
+        assert isinstance(result, DocumentExtractionResult)
+
+    def test_truncated_yaml_does_not_raise(self) -> None:
+        # Long YAML cut mid-value
+        content = (b"title: " + b"x" * 3000)[:2048]
+        result = self.ext.extract(content)
+        assert isinstance(result, DocumentExtractionResult)
+
+
+# ============================================================================
+# PythonDocumentExtractor (Issue #3725)
+# ============================================================================
+
+
+class TestPythonDocumentExtractor:
+    def setup_method(self) -> None:
+        self.ext = PythonDocumentExtractor()
+
+    # Happy path
+    def test_module_docstring_inline(self) -> None:
+        content = b'"""Authentication middleware for session management."""\n\nimport os\n'
+        result = self.ext.extract(content)
+        assert result.title == "Authentication middleware for session management."
+
+    def test_module_docstring_multiline(self) -> None:
+        content = b'"""\nOAuth2 provider integration.\n\nDetails follow.\n"""\n'
+        result = self.ext.extract(content)
+        assert result.title == "OAuth2 provider integration."
+
+    def test_falls_back_to_class_name(self) -> None:
+        content = b"# no docstring\nclass AuthHandler:\n    pass\n"
+        result = self.ext.extract(content)
+        assert result.title == "AuthHandler"
+
+    def test_falls_back_to_function_name(self) -> None:
+        content = b"# no docstring\ndef parse_user_auth(token):\n    pass\n"
+        result = self.ext.extract(content)
+        assert result.title == "parse_user_auth"
+
+    # Adversarial
+    def test_shebang_skipped(self) -> None:
+        content = b'#!/usr/bin/env python3\n\n"""Real module docstring."""\n'
+        result = self.ext.extract(content)
+        assert result.title == "Real module docstring."
+
+    def test_empty_file_returns_null_title(self) -> None:
+        result = self.ext.extract(b"")
+        assert result.title is None
+
+    def test_binary_blob_does_not_raise(self) -> None:
+        result = self.ext.extract(bytes(range(256)))
+        assert isinstance(result, DocumentExtractionResult)
+
+    def test_truncated_docstring_does_not_raise(self) -> None:
+        # Docstring opening with no closing quotes (truncated at 2KB)
+        content = b'"""' + b"x" * 2045  # no closing """
+        result = self.ext.extract(content)
+        assert isinstance(result, DocumentExtractionResult)
+
+
+# ============================================================================
+# TypeScriptDocumentExtractor (Issue #3725)
+# ============================================================================
+
+
+class TestTypeScriptDocumentExtractor:
+    def setup_method(self) -> None:
+        self.ext = TypeScriptDocumentExtractor()
+
+    # Happy path
+    def test_jsdoc_description(self) -> None:
+        content = (
+            b"/**\n * @description User authentication service\n */\nexport class AuthService {}\n"
+        )
+        result = self.ext.extract(content)
+        assert result.title == "User authentication service"
+
+    def test_jsdoc_fileoverview(self) -> None:
+        content = (
+            b"/**\n * @fileoverview OAuth middleware module\n */\nimport { foo } from './bar';\n"
+        )
+        result = self.ext.extract(content)
+        assert result.title == "OAuth middleware module"
+
+    def test_falls_back_to_exported_class(self) -> None:
+        content = b"export class LoginHandler {\n  handle() {}\n}\n"
+        result = self.ext.extract(content)
+        assert result.title == "LoginHandler"
+
+    def test_falls_back_to_exported_function(self) -> None:
+        content = b"export function parseUserToken(token: string) {\n  return null;\n}\n"
+        result = self.ext.extract(content)
+        assert result.title == "parseUserToken"
+
+    # Adversarial
+    def test_empty_file_returns_null_title(self) -> None:
+        result = self.ext.extract(b"")
+        assert result.title is None
+
+    def test_binary_blob_does_not_raise(self) -> None:
+        result = self.ext.extract(bytes(range(256)))
+        assert isinstance(result, DocumentExtractionResult)
+
+    def test_no_exports_returns_null_title(self) -> None:
+        content = b"const x = 1;\nconst y = 2;\n"
+        result = self.ext.extract(content)
+        assert result.title is None
+
+
+# ============================================================================
+# HtmlDocumentExtractor (Issue #3725)
+# ============================================================================
+
+
+class TestHtmlDocumentExtractor:
+    def setup_method(self) -> None:
+        self.ext = HtmlDocumentExtractor()
+
+    # Happy path
+    def test_extracts_title_tag(self) -> None:
+        content = b"<html><head><title>Authentication Guide</title></head></html>"
+        result = self.ext.extract(content)
+        assert result.title == "Authentication Guide"
+
+    def test_falls_back_to_h1(self) -> None:
+        content = b"<html><body><h1>OAuth2 Flow</h1></body></html>"
+        result = self.ext.extract(content)
+        assert result.title == "OAuth2 Flow"
+
+    def test_strips_html_tags_from_title(self) -> None:
+        content = b"<html><head><title><em>Welcome</em> Guide</title></head></html>"
+        result = self.ext.extract(content)
+        assert "Welcome" in (result.title or "")
+
+    # Adversarial
+    def test_empty_file_returns_null_title(self) -> None:
+        result = self.ext.extract(b"")
+        assert result.title is None
+
+    def test_no_title_or_h1_returns_null(self) -> None:
+        content = b"<html><body><p>No headings here.</p></body></html>"
+        result = self.ext.extract(content)
+        assert result.title is None
+
+    def test_binary_blob_does_not_raise(self) -> None:
+        result = self.ext.extract(bytes(range(256)))
+        assert isinstance(result, DocumentExtractionResult)
+
+
+# ============================================================================
+# MarkdownExtractor adversarial (augments existing happy-path tests)
+# ============================================================================
+
+
+class TestMarkdownExtractorAdversarial:
+    def setup_method(self) -> None:
+        self.ext = MarkdownExtractor()
+
+    def test_empty_file_returns_null_title(self) -> None:
+        result = self.ext.extract(b"")
+        assert result.title is None
+        assert result.confidence == 0.0
+
+    def test_truncated_at_2kb_does_not_raise(self) -> None:
+        # Markdown with an H1 near the 2KB boundary
+        long_md = b"# Title\n\n" + b"x " * 1000
+        result = self.ext.extract(long_md[:2048])
+        assert isinstance(result, DocumentExtractionResult)
+        assert result.title == "Title"
+
+    def test_binary_blob_does_not_raise(self) -> None:
+        result = self.ext.extract(bytes(range(256)))
+        assert isinstance(result, DocumentExtractionResult)

--- a/tests/unit/storage/test_model_imports.py
+++ b/tests/unit/storage/test_model_imports.py
@@ -102,6 +102,8 @@ EXPECTED_MODELS = [
     "SecretStoreVersionModel",
     # Per-directory semantic index scoping (Issue #3698)
     "IndexedDirectoryModel",
+    # Global path+title index for lightweight locate() (Issue #3725)
+    "DocumentSkeletonModel",
 ]
 
 


### PR DESCRIPTION
Closes #3725

## Summary

- **DB**: `DocumentSkeletonModel` — `path_id` PK (FK→`file_paths` CASCADE), `zone_id`, `title`, `skeleton_content_hash`, `indexed_at`; Alembic migration with two indexes
- **Extraction**: `SKELETON_EXTRACTOR_REGISTRY` mapping `.json/.yaml/.py/.ts/.html/.md` → `DocumentExtractor`; `tokenize_path()` for camelCase+separator splitting; 2KB head cap + binary detection; registry injected at construction time (LEGO Principle 3)
- **SkeletonIndexer**: sha256 skip guard (14A); optional `path_id` resolved from DB via `_resolve_path_id()` when called from VFS hooks; `_NexusFSFileReader.read_head()` with admin context
- **SkeletonPipeConsumer**: DT_PIPE-backed, debounce + `asyncio.gather` micro-batching `BATCH_SIZE=100` (4A, 15A)
- **SearchDaemon**: `_skeleton_docs` in-memory dict; DB bootstrap on startup — no file reads (13B); `locate(q, zone_id, limit)` BM25-lite scoring: `title_overlap×2 + path_overlap×1`; warmup probe (16A)
- **API**: `POST /api/v2/search/locate` with `_REBAC_OVERFETCH_FACTOR=3`, ReBAC filtering, returns `{candidates, total_before_filter, permission_denial_rate}`
- **Runtime wiring**: `_wire_skeleton_indexer()` in `search.py` lifespan — creates `SkeletonIndexer` after `SearchDaemon` is ready, injects `SKELETON_EXTRACTOR_REGISTRY` from factory layer, registers VFS post-hooks (write/delete/rename) via `call_soon_threadsafe` pattern; `_DaemonSkeletonBM25` adapter bridges Protocol → daemon methods

## Test plan

- [ ] 73 extractor unit tests pass (`tests/unit/bricks/catalog/test_extractors.py`)
- [ ] 3 rename integration tests pass — old path deleted, new path indexed, title preserved (10A)
- [ ] 4 ReBAC integration tests pass — unauthorized gets 0 results, no enforcer passes all (11A)
- [ ] 5 zone isolation integration tests pass — zone A query never returns zone B paths (12A)
- [ ] All 117 skeleton tests: `PYTHONPATH=src python -m pytest tests/unit/bricks/catalog/test_extractors.py tests/integration/bricks/search/ tests/integration/search/test_skeleton_zone_isolation.py --override-ini="addopts="`
- [ ] Pre-commit hooks pass (ruff, mypy, brick-boundary, type-ignore policy)