### PR TITLE
fix(nexus-fs): sync __version__ to 0.4.7

### DIFF
--- a/src/nexus/fs/__init__.py
+++ b/src/nexus/fs/__init__.py
@@ -17,7 +17,7 @@ All imports are lazy to keep ``import nexus.fs`` under 200ms.
 
 from __future__ import annotations
 
-__version__ = "0.4.6"
+__version__ = "0.4.7"
 
 # =============================================================================
 # LAZY IMPORTS — everything is deferred for <200ms import time


### PR DESCRIPTION
## Summary

- `src/nexus/fs/__init__.py`: hardcoded `__version__` was still `0.4.6`, causing smoke test to fail in the `nexus-fs-v0.4.7` release pipeline

## Root cause

`pyproject.toml` version was bumped but `__init__.py.__version__` was not. CI smoke test checks `nexus.fs.__version__` against the release tag.