### PR TITLE
feat(#3718): markdown structure index — partial reads by section/block

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -89,7 +89,6 @@ dependencies = [
     "tiktoken>=0.12", # Token counting for chunking
     "markdown-it-py>=3.0.0", # CommonMark-compliant markdown AST parser (Issue #3718)
     "mdit-py-plugins>=0.4.0", # markdown-it-py plugins: front_matter (Issue #3718)
-    "markdown-it-pyrs>=0.3.0", # Rust-backed parser — 10x faster (Issue #3718)
     "dotenv>=0.9.9",
     # MCP Server (v0.7.0)
     "fastmcp>=2.0.0", # Model Context Protocol server
@@ -142,6 +141,9 @@ performance = [
     # BLAKE3 hashing fallback when Rust extension unavailable (Issue #582)
     # Local embeddings without API (fast ONNX inference)
     "fastembed>=0.4.0",
+    # Rust-backed markdown parser — 10x faster structure indexing (Issue #3718)
+    # Optional: falls back to markdown-it-py (pure Python) when unavailable.
+    "markdown-it-pyrs>=0.3.0",
 ]
 
 pay = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -87,6 +87,9 @@ dependencies = [
     "google-auth-oauthlib>=1.2.0", # Google OAuth flow
     "slack-sdk>=3.39.0", # Slack API for Slack connector
     "tiktoken>=0.12", # Token counting for chunking
+    "markdown-it-py>=3.0.0", # CommonMark-compliant markdown AST parser (Issue #3718)
+    "mdit-py-plugins>=0.4.0", # markdown-it-py plugins: front_matter (Issue #3718)
+    "markdown-it-pyrs>=0.3.0", # Rust-backed parser — 10x faster (Issue #3718)
     "dotenv>=0.9.9",
     # MCP Server (v0.7.0)
     "fastmcp>=2.0.0", # Model Context Protocol server

--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -504,12 +504,13 @@ async def create_mcp_server(
                 return result
             # Any explicit section selector that returned None — don't leak full doc.
             if section == "frontmatter":
-                return tool_error(f"No frontmatter found in {path}")
+                return tool_error("not_found", f"No frontmatter found in {path}")
             if section == "*":
-                return tool_error(f"No markdown structure available for {path}")
+                return tool_error("not_found", f"No markdown structure available for {path}")
             return tool_error(
+                "not_found",
                 f"Section '{section}' not found in {path}. "
-                f"Use section='*' to list available sections."
+                f"Use section='*' to list available sections.",
             )
 
         return content_bytes.decode("utf-8", errors="replace")
@@ -543,14 +544,14 @@ async def create_mcp_server(
         try:
             raw = nx_instance.sys_read(path)
         except Exception as e:
-            return tool_error(f"Cannot access {path}: {e}")
+            return tool_error("access_denied", f"Cannot access {path}: {e}")
         content = raw if isinstance(raw, bytes) else str(raw).encode("utf-8")
         content_hash = _md_get_etag(nx_instance, path)
         listing = _md_get_structure_listing(
             nx_instance, path, content=content, content_hash=content_hash
         )
         if listing is None:
-            return tool_error(f"No markdown structure available for {path}")
+            return tool_error("not_found", f"No markdown structure available for {path}")
         return json.dumps(listing, indent=2)
 
     @mcp.tool(

--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -502,12 +502,15 @@ async def create_mcp_server(
             result = _md_section_read(nx_instance, path, content_bytes, section, block_type)
             if result is not None:
                 return result
-            # Section explicitly requested but not found — don't leak full doc.
-            if section not in ("*", "frontmatter"):
-                return tool_error(
-                    f"Section '{section}' not found in {path}. "
-                    f"Use section='*' to list available sections."
-                )
+            # Any explicit section selector that returned None — don't leak full doc.
+            if section == "frontmatter":
+                return tool_error(f"No frontmatter found in {path}")
+            if section == "*":
+                return tool_error(f"No markdown structure available for {path}")
+            return tool_error(
+                f"Section '{section}' not found in {path}. "
+                f"Use section='*' to list available sections."
+            )
 
         return content_bytes.decode("utf-8", errors="replace")
 

--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -402,6 +402,50 @@ async def create_mcp_server(
         return result
 
     # =========================================================================
+    # Markdown structure helpers (Issue #3718)
+    # =========================================================================
+
+    def _md_section_read(
+        nx_instance: NexusFS,
+        path: str,
+        content: bytes,
+        section: str,
+        block_type: str | None = None,
+    ) -> str | None:
+        """Attempt a partial markdown read using the structural index.
+
+        Returns section content as string, or None to fall back to full read.
+        Uses the service registry to access the md_structure hook (no
+        cross-brick imports).
+        """
+        hook = nx_instance.service("md_structure") if hasattr(nx_instance, "service") else None
+        if hook is None or not hasattr(hook, "read_section"):
+            return None
+
+        content_hash = ""
+        meta = getattr(nx_instance, "metadata", None)
+        if meta is not None:
+            try:
+                raw_meta = meta.get_file_metadata(path, "etag")
+                if raw_meta:
+                    content_hash = str(raw_meta)
+            except Exception:
+                pass
+
+        return hook.read_section(path, content, content_hash, section, block_type)
+
+    def _md_get_structure_listing(
+        nx_instance: NexusFS,
+        path: str,
+    ) -> list[dict[str, Any]] | None:
+        """Get the structure listing for a markdown file."""
+        hook = nx_instance.service("md_structure") if hasattr(nx_instance, "service") else None
+        if hook is None or not hasattr(hook, "get_structure_listing"):
+            return None
+
+        return hook.get_structure_listing(path)
+
+    # =========================================================================
     # FILE OPERATIONS TOOLS
     # =========================================================================
 
@@ -414,21 +458,79 @@ async def create_mcp_server(
         }
     )
     @handle_tool_errors("reading file")
-    async def nexus_read_file(path: str, ctx: Context | None = None) -> str:
+    async def nexus_read_file(
+        path: str,
+        section: str | None = None,
+        block_type: str | None = None,
+        ctx: Context | None = None,
+    ) -> str:
         """Read file content from Nexus filesystem.
+
+        For markdown files (.md), supports partial reads by section and block type
+        to reduce context window usage (Issue #3718).
 
         Args:
             path: File path to read (e.g., "/workspace/data.txt")
+            section: (Markdown only) Read a specific section by heading text.
+                Case-insensitive, supports substring matching.
+                Special values:
+                  - ``"*"`` — list document structure (headings, token estimates, block types) without content
+                  - ``"frontmatter"`` — read only the YAML frontmatter block
+                Example: section="Authentication" reads only that section.
+            block_type: (Markdown only) Filter by block type within a section.
+                Requires ``section`` to be set. Values: "code", "table".
+                Example: section="Auth", block_type="code" returns only code blocks.
             ctx: FastMCP Context (automatically injected, optional for backward compatibility)
 
         Returns:
-            File content as string
+            File content as string (full file, or section/block subset for markdown)
         """
         nx_instance = _get_nexus_instance(ctx)
         content = nx_instance.sys_read(path)
-        if isinstance(content, bytes):
-            return content.decode("utf-8", errors="replace")
-        return str(content)
+        content_bytes = content if isinstance(content, bytes) else str(content).encode("utf-8")
+
+        # Partial read for markdown files when section is requested.
+        if section and path.endswith(".md"):
+            result = _md_section_read(nx_instance, path, content_bytes, section, block_type)
+            if result is not None:
+                return result
+
+        return content_bytes.decode("utf-8", errors="replace")
+
+    @mcp.tool(
+        annotations={
+            "readOnlyHint": True,
+            "destructiveHint": False,
+            "idempotentHint": True,
+            "openWorldHint": True,
+        }
+    )
+    @handle_tool_errors("reading markdown structure")
+    async def nexus_md_structure(path: str, ctx: Context | None = None) -> str:
+        """List the structure of a markdown file without loading its content.
+
+        Returns headings, section token estimates, and block types — enabling
+        targeted reads via ``nexus_read_file(path, section=...)`` to minimize
+        context window usage.
+
+        Args:
+            path: Path to a markdown file (e.g., "/workspace/docs/arch.md")
+            ctx: FastMCP Context (automatically injected)
+
+        Returns:
+            JSON structure listing with sections, depths, token estimates,
+            and block types present in each section.
+        """
+        nx_instance = _get_nexus_instance(ctx)
+        # Permission gate: verify read access before exposing structure.
+        try:
+            nx_instance.sys_read(path)
+        except Exception as e:
+            return tool_error(f"Cannot access {path}: {e}")
+        listing = _md_get_structure_listing(nx_instance, path)
+        if listing is None:
+            return tool_error(f"No markdown structure available for {path}")
+        return json.dumps(listing, indent=2)
 
     @mcp.tool(
         annotations={

--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -502,6 +502,12 @@ async def create_mcp_server(
             result = _md_section_read(nx_instance, path, content_bytes, section, block_type)
             if result is not None:
                 return result
+            # Section explicitly requested but not found — don't leak full doc.
+            if section not in ("*", "frontmatter"):
+                return tool_error(
+                    f"Section '{section}' not found in {path}. "
+                    f"Use section='*' to list available sections."
+                )
 
         return content_bytes.decode("utf-8", errors="replace")
 

--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -405,6 +405,17 @@ async def create_mcp_server(
     # Markdown structure helpers (Issue #3718)
     # =========================================================================
 
+    def _md_get_etag(nx_instance: NexusFS, path: str) -> str:
+        """Get the authoritative file etag from the metastore primary row."""
+        meta = getattr(nx_instance, "metadata", None)
+        if meta is None:
+            return ""
+        try:
+            file_meta = meta.get(path)
+            return file_meta.etag if file_meta and file_meta.etag else ""
+        except Exception:
+            return ""
+
     def _md_section_read(
         nx_instance: NexusFS,
         path: str,
@@ -422,28 +433,25 @@ async def create_mcp_server(
         if hook is None or not hasattr(hook, "read_section"):
             return None
 
-        content_hash = ""
-        meta = getattr(nx_instance, "metadata", None)
-        if meta is not None:
-            try:
-                raw_meta = meta.get_file_metadata(path, "etag")
-                if raw_meta:
-                    content_hash = str(raw_meta)
-            except Exception:
-                pass
-
+        content_hash = _md_get_etag(nx_instance, path)
         return hook.read_section(path, content, content_hash, section, block_type)
 
     def _md_get_structure_listing(
         nx_instance: NexusFS,
         path: str,
+        content: bytes | None = None,
+        content_hash: str = "",
     ) -> list[dict[str, Any]] | None:
-        """Get the structure listing for a markdown file."""
+        """Get the structure listing for a markdown file.
+
+        Passes content + hash so the hook can lazily rebuild the index
+        for files that were never indexed (pre-existing or cache miss).
+        """
         hook = nx_instance.service("md_structure") if hasattr(nx_instance, "service") else None
         if hook is None or not hasattr(hook, "get_structure_listing"):
             return None
 
-        return hook.get_structure_listing(path)
+        return hook.get_structure_listing(path, content=content, content_hash=content_hash)
 
     # =========================================================================
     # FILE OPERATIONS TOOLS
@@ -522,12 +530,16 @@ async def create_mcp_server(
             and block types present in each section.
         """
         nx_instance = _get_nexus_instance(ctx)
-        # Permission gate: verify read access before exposing structure.
+        # Permission gate + content fetch for lazy index rebuild.
         try:
-            nx_instance.sys_read(path)
+            raw = nx_instance.sys_read(path)
         except Exception as e:
             return tool_error(f"Cannot access {path}: {e}")
-        listing = _md_get_structure_listing(nx_instance, path)
+        content = raw if isinstance(raw, bytes) else str(raw).encode("utf-8")
+        content_hash = _md_get_etag(nx_instance, path)
+        listing = _md_get_structure_listing(
+            nx_instance, path, content=content, content_hash=content_hash
+        )
         if listing is None:
             return tool_error(f"No markdown structure available for {path}")
         return json.dumps(listing, indent=2)

--- a/src/nexus/bricks/parsers/md_structure.py
+++ b/src/nexus/bricks/parsers/md_structure.py
@@ -1,0 +1,587 @@
+"""Canonical markdown structure parser — Issue #3718.
+
+Parses markdown into a hierarchical section index with nested blocks,
+byte offsets, line numbers, and token estimates.
+
+Uses ``markdown-it-pyrs`` (Rust, ~10x faster) when available, with
+automatic fallback to ``markdown-it-py`` (pure Python, CommonMark-
+compliant).
+
+This module is the **single source of truth** for markdown structure
+parsing.  ``extract_structure()`` and ``create_chunks()`` in
+``parsers/utils.py`` delegate to it.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+from typing import Any
+
+from markdown_it import MarkdownIt
+
+logger = logging.getLogger(__name__)
+
+# Schema version — bump when the stored JSON shape changes.
+SCHEMA_VERSION = 1
+
+# ---------------------------------------------------------------------------
+# Data model
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class BlockInfo:
+    """A notable block (code fence, table) inside a section."""
+
+    type: str  # "code", "table"
+    byte_start: int
+    byte_end: int
+    line_start: int  # 0-indexed
+    line_end: int  # 0-indexed, exclusive
+    language: str | None = None  # code blocks only
+    rows: int | None = None  # tables only
+
+
+@dataclass(slots=True)
+class SectionInfo:
+    """A heading-delimited section of a markdown document."""
+
+    heading: str
+    depth: int  # 1–6
+    byte_start: int
+    byte_end: int
+    line_start: int  # 0-indexed
+    line_end: int  # 0-indexed, exclusive
+    tokens_est: int = 0
+    blocks: list[BlockInfo] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class FrontmatterInfo:
+    """YAML frontmatter block."""
+
+    byte_start: int
+    byte_end: int
+    line_start: int
+    line_end: int
+    keys: list[str] = field(default_factory=list)
+
+
+@dataclass(slots=True)
+class MarkdownStructureIndex:
+    """Full structural index for a markdown document."""
+
+    version: int = SCHEMA_VERSION
+    content_hash: str = ""
+    tokens_est_method: str = "bytes/4"
+    frontmatter: FrontmatterInfo | None = None
+    sections: list[SectionInfo] = field(default_factory=list)
+
+    # ── Serialization ─────────────────────────────────────────────
+
+    def to_dict(self) -> dict[str, Any]:
+        d: dict[str, Any] = {
+            "version": self.version,
+            "content_hash": self.content_hash,
+            "tokens_est_method": self.tokens_est_method,
+            "sections": [_section_to_dict(s) for s in self.sections],
+        }
+        if self.frontmatter is not None:
+            d["frontmatter"] = _frontmatter_to_dict(self.frontmatter)
+        return d
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> MarkdownStructureIndex:
+        fm_data = data.get("frontmatter")
+        fm = _frontmatter_from_dict(fm_data) if fm_data else None
+        return cls(
+            version=data.get("version", SCHEMA_VERSION),
+            content_hash=data.get("content_hash", ""),
+            tokens_est_method=data.get("tokens_est_method", "bytes/4"),
+            frontmatter=fm,
+            sections=[_section_from_dict(s) for s in data.get("sections", [])],
+        )
+
+
+def _section_to_dict(s: SectionInfo) -> dict[str, Any]:
+    d: dict[str, Any] = {
+        "heading": s.heading,
+        "depth": s.depth,
+        "byte_start": s.byte_start,
+        "byte_end": s.byte_end,
+        "line_start": s.line_start,
+        "line_end": s.line_end,
+        "tokens_est": s.tokens_est,
+        "blocks": [_block_to_dict(b) for b in s.blocks],
+    }
+    return d
+
+
+def _block_to_dict(b: BlockInfo) -> dict[str, Any]:
+    d: dict[str, Any] = {
+        "type": b.type,
+        "byte_start": b.byte_start,
+        "byte_end": b.byte_end,
+        "line_start": b.line_start,
+        "line_end": b.line_end,
+    }
+    if b.language is not None:
+        d["language"] = b.language
+    if b.rows is not None:
+        d["rows"] = b.rows
+    return d
+
+
+def _frontmatter_to_dict(fm: FrontmatterInfo) -> dict[str, Any]:
+    return {
+        "byte_start": fm.byte_start,
+        "byte_end": fm.byte_end,
+        "line_start": fm.line_start,
+        "line_end": fm.line_end,
+        "keys": fm.keys,
+    }
+
+
+def _section_from_dict(data: dict[str, Any]) -> SectionInfo:
+    return SectionInfo(
+        heading=data["heading"],
+        depth=data["depth"],
+        byte_start=data["byte_start"],
+        byte_end=data["byte_end"],
+        line_start=data["line_start"],
+        line_end=data["line_end"],
+        tokens_est=data.get("tokens_est", 0),
+        blocks=[_block_from_dict(b) for b in data.get("blocks", [])],
+    )
+
+
+def _block_from_dict(data: dict[str, Any]) -> BlockInfo:
+    return BlockInfo(
+        type=data["type"],
+        byte_start=data["byte_start"],
+        byte_end=data["byte_end"],
+        line_start=data["line_start"],
+        line_end=data["line_end"],
+        language=data.get("language"),
+        rows=data.get("rows"),
+    )
+
+
+def _frontmatter_from_dict(data: dict[str, Any]) -> FrontmatterInfo:
+    return FrontmatterInfo(
+        byte_start=data["byte_start"],
+        byte_end=data["byte_end"],
+        line_start=data["line_start"],
+        line_end=data["line_end"],
+        keys=data.get("keys", []),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Parser — Rust fast path (markdown-it-pyrs) with Python fallback
+# ---------------------------------------------------------------------------
+
+_USE_RUST: bool | None = None
+_md_rust: Any = None
+_md_py: MarkdownIt | None = None
+
+
+def _init_rust_parser() -> bool:
+    """Try to initialise the Rust-backed parser.  Returns True on success."""
+    global _md_rust, _USE_RUST  # noqa: PLW0603
+    try:
+        from markdown_it_pyrs import MarkdownIt as MdRs
+
+        _md_rust = MdRs()
+        _md_rust.enable("table")
+        _md_rust.enable("front_matter")
+        _USE_RUST = True
+        logger.debug("markdown-it-pyrs (Rust) available — using fast path")
+        return True
+    except (ImportError, Exception):
+        _USE_RUST = False
+        logger.debug("markdown-it-pyrs not available — falling back to Python parser")
+        return False
+
+
+def _get_python_parser() -> MarkdownIt:
+    """Lazily initialise the Python ``MarkdownIt`` fallback."""
+    global _md_py  # noqa: PLW0603
+    if _md_py is None:
+        _md_py = MarkdownIt("commonmark").enable("table")
+        try:
+            from mdit_py_plugins.front_matter import front_matter_plugin
+
+            front_matter_plugin(_md_py)
+        except ImportError:
+            logger.debug("mdit_py_plugins not installed — frontmatter parsing disabled")
+    return _md_py
+
+
+def _build_line_byte_offsets(content: bytes) -> list[int]:
+    """Return a list where ``offsets[i]`` is the byte offset of line *i*.
+
+    An extra sentinel entry is appended equal to ``len(content)`` so that
+    the byte range for line *i* is ``[offsets[i], offsets[i + 1])``.
+    """
+    offsets: list[int] = [0]
+    pos = 0
+    while pos < len(content):
+        nl = content.find(b"\n", pos)
+        if nl == -1:
+            break
+        offsets.append(nl + 1)
+        pos = nl + 1
+    offsets.append(len(content))
+    return offsets
+
+
+def parse_markdown_structure(
+    content: bytes,
+    content_hash: str = "",
+) -> MarkdownStructureIndex:
+    """Parse markdown *content* (UTF-8 bytes) into a structural index.
+
+    Uses ``markdown-it-pyrs`` (Rust, ~10x faster) when available, with
+    automatic fallback to ``markdown-it-py`` (pure Python).
+
+    Args:
+        content: Raw UTF-8 bytes of the markdown file.
+        content_hash: Etag / content hash to embed in the index for
+            staleness detection on the read path.
+
+    Returns:
+        A ``MarkdownStructureIndex`` ready for JSON serialization and
+        storage in ``FileMetadataModel``.
+    """
+    global _USE_RUST  # noqa: PLW0603
+    if _USE_RUST is None:
+        _init_rust_parser()
+
+    if _USE_RUST:
+        return _parse_rust(content, content_hash)
+    return _parse_python(content, content_hash)
+
+
+# ---------------------------------------------------------------------------
+# Rust fast path — markdown-it-pyrs Node tree (byte offsets are native)
+# ---------------------------------------------------------------------------
+
+
+def _parse_rust(content: bytes, content_hash: str) -> MarkdownStructureIndex:
+    text = content.decode("utf-8", errors="replace")
+    tree = _md_rust.tree(text)
+    line_offsets = _build_line_byte_offsets(content)
+
+    headings: list[_RawHeading] = []
+    blocks: list[BlockInfo] = []
+    frontmatter: FrontmatterInfo | None = None
+
+    for node in tree.children:
+        srcmap = node.srcmap
+        if not srcmap:
+            continue
+
+        byte_start, byte_end = srcmap
+
+        if node.name == "front_matter":
+            fm_text = content[byte_start:byte_end].decode("utf-8", errors="replace")
+            keys = _extract_yaml_keys(fm_text)
+            frontmatter = FrontmatterInfo(
+                byte_start=byte_start,
+                byte_end=byte_end,
+                line_start=_byte_to_line(byte_start, line_offsets),
+                line_end=_byte_to_line(byte_end, line_offsets),
+                keys=keys,
+            )
+
+        elif node.name in ("heading", "lheading"):
+            raw = content[byte_start:byte_end].decode("utf-8", errors="replace")
+            heading_text = ""
+            depth = 1
+            if raw.startswith("#"):
+                depth = len(raw) - len(raw.lstrip("#"))
+                heading_text = raw.lstrip("#").strip().split("\n")[0]
+            elif node.name == "lheading":
+                lines = raw.strip().split("\n")
+                heading_text = lines[0].strip() if lines else ""
+                depth = 1 if len(lines) > 1 and lines[-1].startswith("=") else 2
+            else:
+                for child in node.children:
+                    if child.name == "text" and child.srcmap:
+                        cs, ce = child.srcmap
+                        heading_text = content[cs:ce].decode("utf-8", errors="replace").strip()
+                        break
+            headings.append(
+                _RawHeading(
+                    text=heading_text,
+                    depth=depth,
+                    line_start=_byte_to_line(byte_start, line_offsets),
+                )
+            )
+
+        elif node.name == "fence":
+            language = node.attrs.get("language") if node.attrs else None
+            if not language:
+                first_line = (
+                    content[byte_start:byte_end].decode("utf-8", errors="replace").split("\n")[0]
+                )
+                lang_part = first_line.lstrip("`").strip()
+                language = lang_part or None
+            blocks.append(
+                BlockInfo(
+                    type="code",
+                    byte_start=byte_start,
+                    byte_end=byte_end,
+                    line_start=_byte_to_line(byte_start, line_offsets),
+                    line_end=_byte_to_line(byte_end, line_offsets),
+                    language=language,
+                )
+            )
+
+        elif node.name == "table":
+            row_count = 0
+            for child in node.children:
+                if child.name == "tbody":
+                    row_count = sum(1 for gc in child.children if gc.name == "trow")
+            blocks.append(
+                BlockInfo(
+                    type="table",
+                    byte_start=byte_start,
+                    byte_end=byte_end,
+                    line_start=_byte_to_line(byte_start, line_offsets),
+                    line_end=_byte_to_line(byte_end, line_offsets),
+                    rows=row_count,
+                )
+            )
+
+    return _build_index(headings, blocks, frontmatter, line_offsets, content_hash)
+
+
+def _byte_to_line(byte_offset: int, line_offsets: list[int]) -> int:
+    """Convert a byte offset to a 0-indexed line number (binary search)."""
+    lo, hi = 0, len(line_offsets) - 1
+    while lo < hi:
+        mid = (lo + hi + 1) // 2
+        if line_offsets[mid] <= byte_offset:
+            lo = mid
+        else:
+            hi = mid - 1
+    return lo
+
+
+# ---------------------------------------------------------------------------
+# Python fallback — markdown-it-py token stream (line numbers → byte offsets)
+# ---------------------------------------------------------------------------
+
+
+def _parse_python(content: bytes, content_hash: str) -> MarkdownStructureIndex:
+    text = content.decode("utf-8", errors="replace")
+    md = _get_python_parser()
+    tokens = md.parse(text)
+    line_offsets = _build_line_byte_offsets(content)
+
+    headings: list[_RawHeading] = []
+    blocks: list[BlockInfo] = []
+    frontmatter: FrontmatterInfo | None = None
+
+    i = 0
+    while i < len(tokens):
+        tok = tokens[i]
+
+        if tok.type == "front_matter" and tok.map is not None:
+            fm_line_start, fm_line_end = tok.map
+            fm_byte_start = line_offsets[fm_line_start]
+            fm_byte_end = line_offsets[min(fm_line_end, len(line_offsets) - 1)]
+            keys = _extract_yaml_keys(tok.content)
+            frontmatter = FrontmatterInfo(
+                byte_start=fm_byte_start,
+                byte_end=fm_byte_end,
+                line_start=fm_line_start,
+                line_end=fm_line_end,
+                keys=keys,
+            )
+
+        elif tok.type == "heading_open" and tok.map is not None:
+            depth = int(tok.tag[1])
+            heading_text = ""
+            if i + 1 < len(tokens) and tokens[i + 1].type == "inline":
+                heading_text = tokens[i + 1].content
+            headings.append(
+                _RawHeading(
+                    text=heading_text,
+                    depth=depth,
+                    line_start=tok.map[0],
+                )
+            )
+
+        elif tok.type == "fence" and tok.map is not None:
+            bl_start, bl_end = tok.map
+            blocks.append(
+                BlockInfo(
+                    type="code",
+                    byte_start=line_offsets[bl_start],
+                    byte_end=line_offsets[min(bl_end, len(line_offsets) - 1)],
+                    line_start=bl_start,
+                    line_end=bl_end,
+                    language=tok.info.strip() or None,
+                )
+            )
+
+        elif tok.type == "table_open" and tok.map is not None:
+            tbl_start, tbl_end = tok.map
+            row_count = 0
+            j = i + 1
+            in_tbody = False
+            while j < len(tokens) and tokens[j].type != "table_close":
+                if tokens[j].type == "tbody_open":
+                    in_tbody = True
+                elif tokens[j].type == "tbody_close":
+                    in_tbody = False
+                elif tokens[j].type == "tr_open" and in_tbody:
+                    row_count += 1
+                j += 1
+            blocks.append(
+                BlockInfo(
+                    type="table",
+                    byte_start=line_offsets[tbl_start],
+                    byte_end=line_offsets[min(tbl_end, len(line_offsets) - 1)],
+                    line_start=tbl_start,
+                    line_end=tbl_end,
+                    rows=row_count,
+                )
+            )
+
+        i += 1
+
+    return _build_index(headings, blocks, frontmatter, line_offsets, content_hash)
+
+
+# ---------------------------------------------------------------------------
+# Shared section builder
+# ---------------------------------------------------------------------------
+
+
+def _build_index(
+    headings: list[_RawHeading],
+    blocks: list[BlockInfo],
+    frontmatter: FrontmatterInfo | None,
+    line_offsets: list[int],
+    content_hash: str,
+) -> MarkdownStructureIndex:
+    """Build hierarchical sections from raw headings and blocks."""
+    total_lines = len(line_offsets) - 1
+    sections: list[SectionInfo] = []
+
+    for idx, h in enumerate(headings):
+        section_line_start = h.line_start
+        section_line_end = total_lines
+        for nxt in headings[idx + 1 :]:
+            if nxt.depth <= h.depth:
+                section_line_end = nxt.line_start
+                break
+
+        sec_byte_start = line_offsets[section_line_start]
+        sec_byte_end = line_offsets[min(section_line_end, len(line_offsets) - 1)]
+        sec_tokens_est = (sec_byte_end - sec_byte_start) // 4
+
+        sec_blocks = [
+            b
+            for b in blocks
+            if b.line_start >= section_line_start and b.line_end <= section_line_end
+        ]
+
+        sections.append(
+            SectionInfo(
+                heading=h.text,
+                depth=h.depth,
+                byte_start=sec_byte_start,
+                byte_end=sec_byte_end,
+                line_start=section_line_start,
+                line_end=section_line_end,
+                tokens_est=sec_tokens_est,
+                blocks=sec_blocks,
+            )
+        )
+
+    return MarkdownStructureIndex(
+        version=SCHEMA_VERSION,
+        content_hash=content_hash,
+        frontmatter=frontmatter,
+        sections=sections,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Section lookup helpers (used by read path)
+# ---------------------------------------------------------------------------
+
+
+def find_section(
+    index: MarkdownStructureIndex,
+    section_name: str,
+) -> SectionInfo | None:
+    """Find a section by heading text (case-insensitive substring match).
+
+    Exact match is tried first; falls back to substring.
+    """
+    lower = section_name.lower()
+    # Exact match first
+    for s in index.sections:
+        if s.heading.lower() == lower:
+            return s
+    # Substring fallback
+    for s in index.sections:
+        if lower in s.heading.lower():
+            return s
+    return None
+
+
+def filter_blocks(
+    section: SectionInfo,
+    block_type: str,
+) -> list[BlockInfo]:
+    """Return blocks within *section* matching *block_type*."""
+    return [b for b in section.blocks if b.type == block_type]
+
+
+def slice_content(
+    content: bytes,
+    byte_start: int,
+    byte_end: int,
+) -> str:
+    """Decode a byte range to a UTF-8 string."""
+    return content[byte_start:byte_end].decode("utf-8", errors="replace")
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+@dataclass(slots=True)
+class _RawHeading:
+    """Intermediate heading data before section boundaries are computed."""
+
+    text: str
+    depth: int
+    line_start: int
+
+
+def _extract_yaml_keys(frontmatter_content: str) -> list[str]:
+    """Extract top-level YAML keys from frontmatter content.
+
+    Uses a simple line-based approach rather than a full YAML parser to
+    avoid adding a dependency and to handle malformed YAML gracefully.
+    """
+    keys: list[str] = []
+    for line in frontmatter_content.split("\n"):
+        stripped = line.strip()
+        if not stripped or stripped.startswith("#"):
+            continue
+        if ":" in stripped and not stripped.startswith(" ") and not stripped.startswith("\t"):
+            key = stripped.split(":", 1)[0].strip()
+            if key and key != "---":
+                keys.append(key)
+    return keys

--- a/src/nexus/bricks/parsers/md_structure.py
+++ b/src/nexus/bricks/parsers/md_structure.py
@@ -278,10 +278,14 @@ def _parse_rust(content: bytes, content_hash: str) -> MarkdownStructureIndex:
     blocks: list[BlockInfo] = []
     frontmatter: FrontmatterInfo | None = None
 
-    for node in tree.children:
+    def _walk(node: Any) -> None:
+        """Recursively walk the AST to find blocks nested inside containers."""
+        nonlocal frontmatter
         srcmap = node.srcmap
         if not srcmap:
-            continue
+            for child in node.children:
+                _walk(child)
+            return
 
         byte_start, byte_end = srcmap
 
@@ -356,6 +360,13 @@ def _parse_rust(content: bytes, content_hash: str) -> MarkdownStructureIndex:
                 )
             )
 
+        # Recurse into container blocks (blockquotes, list items, etc.)
+        # to find nested fences/tables.
+        if node.name not in ("fence", "front_matter", "heading", "lheading", "table"):
+            for child in node.children:
+                _walk(child)
+
+    _walk(tree)
     return _build_index(headings, blocks, frontmatter, line_offsets, content_hash)
 
 

--- a/src/nexus/bricks/parsers/md_structure_hook.py
+++ b/src/nexus/bricks/parsers/md_structure_hook.py
@@ -100,6 +100,12 @@ class MarkdownStructureWriteHook:
         if self._metadata is None:
             return None
 
+        # If the caller can't provide a hash (e.g. connector paths with no
+        # authoritative etag), skip the cache entirely and parse from content.
+        # This prevents stale cached indices from serving wrong byte ranges.
+        if not current_hash and current_content is not None:
+            return self._reindex(path, current_content, "")
+
         raw = self._metadata.get_file_metadata(path, MD_STRUCTURE_KEY)
         if raw is not None:
             try:
@@ -218,19 +224,16 @@ class MarkdownStructureWriteHook:
 
     def _reindex(
         self,
-        path: str,
+        _path: str,
         content: bytes,
         content_hash: str,
     ) -> MarkdownStructureIndex:
-        """Re-parse and store updated index."""
-        index = parse_markdown_structure(content, content_hash=content_hash)
-        if self._metadata is not None:
-            try:
-                self._metadata.set_file_metadata(
-                    path,
-                    MD_STRUCTURE_KEY,
-                    json.dumps(index.to_dict()),
-                )
-            except Exception:
-                logger.debug("Failed to store re-indexed md_structure for %s", path, exc_info=True)
-        return index
+        """Re-parse on demand (in-memory only — never persisted from read path).
+
+        Only the write hook (``on_post_write``) persists the index, because it
+        has an atomically-consistent content/hash pair.  Read-side rebuilds
+        cannot guarantee the caller-supplied hash matches the content bytes
+        (a write between the read and the hash fetch would create a mismatch),
+        so we return an ephemeral index without writing to the metastore.
+        """
+        return parse_markdown_structure(content, content_hash=content_hash)

--- a/src/nexus/bricks/parsers/md_structure_hook.py
+++ b/src/nexus/bricks/parsers/md_structure_hook.py
@@ -64,6 +64,10 @@ class MarkdownStructureWriteHook:
             return
         if not ctx.path.endswith(".md"):
             return
+        # Skip streamed/empty writes — they pass content=b'' with no hash.
+        # Persisting an empty index would poison the cache.
+        if not ctx.content:
+            return
 
         try:
             content_hash = ctx.content_hash or ""
@@ -112,13 +116,12 @@ class MarkdownStructureWriteHook:
                 data = json.loads(raw) if isinstance(raw, str) else raw
                 index = MarkdownStructureIndex.from_dict(data)
 
-                # Lazy hash validation
-                if current_hash and index.content_hash and index.content_hash != current_hash:
+                # Lazy hash validation.
+                # Treat empty content_hash in stored index as stale (streamed writes).
+                if current_hash and (not index.content_hash or index.content_hash != current_hash):
                     logger.debug("Stale md_structure for %s — re-parsing", path)
                     if current_content is not None:
                         return self._reindex(path, current_content, current_hash)
-                    # No content provided — return stale index (caller
-                    # doesn't have content, so we can't re-parse).
                     return index
                 return index
             except (json.JSONDecodeError, KeyError, TypeError):

--- a/src/nexus/bricks/parsers/md_structure_hook.py
+++ b/src/nexus/bricks/parsers/md_structure_hook.py
@@ -1,0 +1,236 @@
+"""MarkdownStructureWriteHook — synchronous post-write indexing for .md files.
+
+Issue #3718: On every ``.md`` write, parse the markdown structure and store
+the index as ``md_structure`` metadata.  The index enables partial reads
+by section/block without loading the full file.
+
+Architecture decisions:
+    - **Synchronous** (not background) because markdown-it-py parses 50 KB
+      in < 1 ms — no reason to complicate with threading.
+    - **Lazy hash validation** on the read path: if the stored
+      ``content_hash`` doesn't match the file's current etag, re-parse
+      inline and update the index (self-healing).
+    - Follows the ``AutoParseWriteHook`` pattern for DI and registration.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from nexus.bricks.parsers.md_structure import (
+    MarkdownStructureIndex,
+    filter_blocks,
+    find_section,
+    parse_markdown_structure,
+    slice_content,
+)
+from nexus.contracts.vfs_hooks import WriteHookContext
+
+if TYPE_CHECKING:
+    from nexus.contracts.protocols.service_hooks import HookSpec
+
+logger = logging.getLogger(__name__)
+
+# Metadata key used to store the structural index.
+MD_STRUCTURE_KEY = "md_structure"
+
+
+class MarkdownStructureWriteHook:
+    """Post-write hook that builds a structural index for markdown files.
+
+    Dependencies injected at construction:
+        metadata: MetastoreABC — for storing/retrieving the index.
+    """
+
+    def __init__(self, metadata: Any = None) -> None:
+        self._metadata = metadata
+
+    # ── Hook spec (duck-typed, matches AutoParseWriteHook pattern) ──
+
+    def hook_spec(self) -> "HookSpec":
+        from nexus.contracts.protocols.service_hooks import HookSpec
+
+        return HookSpec(write_hooks=(self,))
+
+    @property
+    def name(self) -> str:
+        return "md_structure"
+
+    def on_post_write(self, ctx: WriteHookContext) -> None:
+        """Parse markdown structure and store index after .md writes."""
+        if self._metadata is None:
+            return
+        if not ctx.path.endswith(".md"):
+            return
+
+        try:
+            content_hash = ctx.content_hash or ""
+            index = parse_markdown_structure(ctx.content, content_hash=content_hash)
+            self._metadata.set_file_metadata(
+                ctx.path,
+                MD_STRUCTURE_KEY,
+                json.dumps(index.to_dict()),
+            )
+        except Exception:
+            logger.debug("md_structure indexing failed for %s", ctx.path, exc_info=True)
+
+    # ── Read-path helpers ────────────────────────────────────────
+
+    def get_index(
+        self,
+        path: str,
+        current_content: bytes | None = None,
+        current_hash: str | None = None,
+    ) -> MarkdownStructureIndex | None:
+        """Retrieve the structural index for *path*, re-parsing if stale.
+
+        Args:
+            path: Virtual file path.
+            current_content: If provided, used for stale-index re-parse
+                instead of requiring a separate read.
+            current_hash: Current etag of the file — compared against the
+                stored ``content_hash`` to detect staleness.
+
+        Returns:
+            The index, or ``None`` if no index exists and no content was
+            provided for on-demand parsing.
+        """
+        if self._metadata is None:
+            return None
+
+        raw = self._metadata.get_file_metadata(path, MD_STRUCTURE_KEY)
+        if raw is not None:
+            try:
+                data = json.loads(raw) if isinstance(raw, str) else raw
+                index = MarkdownStructureIndex.from_dict(data)
+
+                # Lazy hash validation
+                if current_hash and index.content_hash and index.content_hash != current_hash:
+                    logger.debug("Stale md_structure for %s — re-parsing", path)
+                    if current_content is not None:
+                        return self._reindex(path, current_content, current_hash)
+                    # No content provided — return stale index (caller
+                    # doesn't have content, so we can't re-parse).
+                    return index
+                return index
+            except (json.JSONDecodeError, KeyError, TypeError):
+                logger.debug("Corrupt md_structure for %s — discarding", path, exc_info=True)
+
+        # No stored index — parse on demand if content available.
+        if current_content is not None:
+            return self._reindex(path, current_content, current_hash or "")
+        return None
+
+    def read_section(
+        self,
+        path: str,
+        content: bytes,
+        content_hash: str,
+        section: str,
+        block_type: str | None = None,
+    ) -> str | None:
+        """Read a specific section (optionally filtered by block type).
+
+        Special section values:
+            ``"*"`` — return the structure listing as JSON (no content).
+            ``"frontmatter"`` — return the raw frontmatter block.
+
+        Returns the section content as a string, or ``None`` if the
+        section wasn't found (caller should fall back to full content).
+        """
+        index = self.get_index(path, current_content=content, current_hash=content_hash)
+        if index is None:
+            return None
+
+        # Special: structure listing
+        if section == "*":
+            listing = self.get_structure_listing(path, content=content, content_hash=content_hash)
+            return json.dumps(listing, indent=2) if listing is not None else None
+
+        # Special: frontmatter
+        if section.lower() == "frontmatter":
+            if index.frontmatter is None:
+                return None
+            return slice_content(
+                content,
+                index.frontmatter.byte_start,
+                index.frontmatter.byte_end,
+            )
+
+        sec = find_section(index, section)
+        if sec is None:
+            return None
+
+        if block_type:
+            blocks = filter_blocks(sec, block_type)
+            if not blocks:
+                return None
+            # Concatenate all matching blocks within the section.
+            parts = [slice_content(content, b.byte_start, b.byte_end) for b in blocks]
+            return "\n\n".join(parts)
+
+        return slice_content(content, sec.byte_start, sec.byte_end)
+
+    def get_structure_listing(
+        self,
+        path: str,
+        content: bytes | None = None,
+        content_hash: str | None = None,
+    ) -> list[dict[str, Any]] | None:
+        """Return a lightweight structure listing (no content).
+
+        Used by the ``nexus_md_structure`` MCP tool and REST endpoint.
+        """
+        index = self.get_index(path, current_content=content, current_hash=content_hash)
+        if index is None:
+            return None
+
+        listing: list[dict[str, Any]] = []
+
+        if index.frontmatter:
+            listing.append(
+                {
+                    "type": "frontmatter",
+                    "keys": index.frontmatter.keys,
+                    "line_start": index.frontmatter.line_start,
+                    "line_end": index.frontmatter.line_end,
+                }
+            )
+
+        for sec in index.sections:
+            block_types = list({b.type for b in sec.blocks})
+            entry: dict[str, Any] = {
+                "type": "section",
+                "heading": sec.heading,
+                "depth": sec.depth,
+                "tokens_est": sec.tokens_est,
+                "line_start": sec.line_start,
+                "line_end": sec.line_end,
+                "blocks": block_types,
+            }
+            listing.append(entry)
+
+        return listing
+
+    # ── Internal ─────────────────────────────────────────────────
+
+    def _reindex(
+        self,
+        path: str,
+        content: bytes,
+        content_hash: str,
+    ) -> MarkdownStructureIndex:
+        """Re-parse and store updated index."""
+        index = parse_markdown_structure(content, content_hash=content_hash)
+        if self._metadata is not None:
+            try:
+                self._metadata.set_file_metadata(
+                    path,
+                    MD_STRUCTURE_KEY,
+                    json.dumps(index.to_dict()),
+                )
+            except Exception:
+                logger.debug("Failed to store re-indexed md_structure for %s", path, exc_info=True)
+        return index

--- a/src/nexus/bricks/parsers/utils.py
+++ b/src/nexus/bricks/parsers/utils.py
@@ -2,10 +2,15 @@
 
 Deduplicated from MarkItDownParser, MarkItDownProvider, and LlamaParseProvider
 (Issue #5A).
+
+Issue #3718: Both functions now delegate to the canonical
+``md_structure.parse_markdown_structure()`` parser, preserving their
+original return shapes for backward compatibility.
 """
 
 from typing import Any
 
+from nexus.bricks.parsers.md_structure import parse_markdown_structure, slice_content
 from nexus.bricks.parsers.types import TextChunk
 
 
@@ -18,26 +23,22 @@ def extract_structure(text: str) -> dict[str, Any]:
     Returns:
         Dictionary with ``headings``, ``has_headings``, and ``line_count``.
     """
-    lines = text.split("\n")
-    headings: list[dict[str, Any]] = []
-
-    for line in lines:
-        if line.startswith("#"):
-            level = len(line) - len(line.lstrip("#"))
-            heading_text = line.lstrip("#").strip()
-            # Skip empty headings (e.g. a line that is just "###")
-            if heading_text:
-                headings.append({"level": level, "text": heading_text})
-
+    content = text.encode("utf-8")
+    index = parse_markdown_structure(content)
+    headings = [{"level": s.depth, "text": s.heading} for s in index.sections]
     return {
         "headings": headings,
         "has_headings": len(headings) > 0,
-        "line_count": len(lines),
+        "line_count": text.count("\n") + 1,
     }
 
 
 def create_chunks(text: str) -> list[TextChunk]:
     """Create semantic chunks from markdown text by splitting on headers.
+
+    Each heading starts a new **flat** (non-overlapping) chunk that extends
+    to the next heading at any depth.  This preserves the original pre-#3718
+    behaviour where chunks are contiguous and non-hierarchical.
 
     Args:
         text: Markdown text content
@@ -46,38 +47,42 @@ def create_chunks(text: str) -> list[TextChunk]:
         List of TextChunk objects.  Falls back to a single chunk when the
         text contains no headers.
     """
+    content = text.encode("utf-8")
+    index = parse_markdown_structure(content)
+
+    if not index.sections:
+        return [TextChunk(text=text, start_index=0, end_index=len(text))]
+
+    # Sort all sections by byte_start to get document order.
+    ordered = sorted(index.sections, key=lambda s: s.byte_start)
+
+    # Deduplicate positions (hierarchical sections can share a start).
+    seen_starts: set[int] = set()
+    unique: list[tuple[int, int]] = []  # (byte_start, depth)
+    for sec in ordered:
+        if sec.byte_start not in seen_starts:
+            seen_starts.add(sec.byte_start)
+            unique.append((sec.byte_start, sec.depth))
+
     chunks: list[TextChunk] = []
-    lines = text.split("\n")
 
-    current_chunk: list[str] = []
-    current_start = 0
+    # Pre-heading content (before the first heading).
+    first_byte = unique[0][0]
+    if first_byte > 0:
+        pre_text = slice_content(content, 0, first_byte).strip()
+        if pre_text:
+            chunks.append(TextChunk(text=pre_text, start_index=0, end_index=first_byte))
 
-    for line in lines:
-        # Start a new chunk on headers
-        if line.startswith("#") and current_chunk:
-            chunk_text = "\n".join(current_chunk).strip()
-            if chunk_text:
-                chunks.append(
-                    TextChunk(
-                        text=chunk_text,
-                        start_index=current_start,
-                        end_index=current_start + len(chunk_text),
-                    )
-                )
-            current_chunk = [line]
-            current_start += len(chunk_text) + 1
-        else:
-            current_chunk.append(line)
-
-    # Add final chunk
-    if current_chunk:
-        chunk_text = "\n".join(current_chunk).strip()
+    # Flat chunks: each heading → next heading (any depth) or EOF.
+    for i, (byte_start, _depth) in enumerate(unique):
+        byte_end = unique[i + 1][0] if i + 1 < len(unique) else len(content)
+        chunk_text = slice_content(content, byte_start, byte_end).strip()
         if chunk_text:
             chunks.append(
                 TextChunk(
                     text=chunk_text,
-                    start_index=current_start,
-                    end_index=current_start + len(chunk_text),
+                    start_index=byte_start,
+                    end_index=byte_end,
                 )
             )
 

--- a/src/nexus/cli/commands/file_ops.py
+++ b/src/nexus/cli/commands/file_ops.py
@@ -97,6 +97,18 @@ def init(path: str) -> None:
     type=str,
     help="Read file content at a historical operation point (time-travel debugging)",
 )
+@click.option(
+    "--section",
+    type=str,
+    default=None,
+    help="(Markdown) Read a specific section by heading text (case-insensitive)",
+)
+@click.option(
+    "--block-type",
+    type=click.Choice(["code", "table"]),
+    default=None,
+    help="(Markdown) Filter by block type within --section",
+)
 @add_output_options
 @add_backend_options
 @add_context_options
@@ -104,6 +116,8 @@ def cat(
     path: str,
     metadata: bool,
     at_operation: str | None,
+    section: str | None,
+    block_type: str | None,
     output_opts: OutputOptions,
     remote_url: str | None,
     remote_api_key: str | None,
@@ -117,7 +131,13 @@ def cat(
         nexus cat /workspace/data.txt --metadata
         nexus cat /workspace/data.txt --json
         nexus cat /workspace/data.txt --at-operation op_abc123
+        nexus cat /workspace/docs/arch.md --section Authentication
+        nexus cat /workspace/docs/arch.md --section Auth --block-type code
+        nexus cat /workspace/docs/arch.md#authentication
     """
+    # Support fragment syntax: /path/file.md#section → path=/path/file.md, section=section
+    if "#" in path and section is None:
+        path, section = path.rsplit("#", 1)
 
     async def _impl() -> None:
         timing = CommandTiming()
@@ -175,6 +195,15 @@ def cat(
 
                         content = nx.sys_read(path, context=cast(Any, operation_context))
                         meta_data = None
+
+                # --- Markdown partial read (Issue #3718) ---
+                if section and path.endswith(".md"):
+                    content_bytes = (
+                        content if isinstance(content, bytes) else content.encode("utf-8")
+                    )
+                    partial = _cat_md_section(nx, path, content_bytes, section, block_type)
+                    if partial is not None:
+                        content = partial.encode("utf-8")
 
             # JSON mode: return structured data
             if output_opts.json_output:
@@ -283,6 +312,32 @@ def _cat_time_travel(
         console.print("[bold]Content:[/bold]")
 
     _print_content(path, content)
+
+
+def _cat_md_section(
+    nx: Any,
+    path: str,
+    content: bytes,
+    section: str,
+    block_type: str | None,
+) -> str | None:
+    """Attempt a partial markdown read using the structural index (Issue #3718)."""
+    try:
+        hook = nx.service("md_structure") if hasattr(nx, "service") else None
+        if hook is None or not hasattr(hook, "read_section"):
+            return None
+        content_hash = ""
+        meta = getattr(nx, "metadata", None)
+        if meta is not None:
+            try:
+                raw_meta = meta.get_file_metadata(path, "etag")
+                if raw_meta:
+                    content_hash = str(raw_meta)
+            except Exception:
+                pass
+        return hook.read_section(path, content, content_hash, section, block_type)
+    except Exception:
+        return None
 
 
 def _print_content(path: str, content: bytes) -> None:

--- a/src/nexus/cli/commands/file_ops.py
+++ b/src/nexus/cli/commands/file_ops.py
@@ -330,9 +330,9 @@ def _cat_md_section(
         meta = getattr(nx, "metadata", None)
         if meta is not None:
             try:
-                raw_meta = meta.get_file_metadata(path, "etag")
-                if raw_meta:
-                    content_hash = str(raw_meta)
+                file_meta = meta.get(path)
+                if file_meta and file_meta.etag:
+                    content_hash = file_meta.etag
             except Exception:
                 pass
         return hook.read_section(path, content, content_hash, section, block_type)

--- a/src/nexus/cli/commands/file_ops.py
+++ b/src/nexus/cli/commands/file_ops.py
@@ -182,7 +182,7 @@ def cat(
                             except Exception:
                                 file_size = 0
 
-                        if file_size > STREAM_THRESHOLD:
+                        if file_size > STREAM_THRESHOLD and not section:
                             console.print(
                                 f"[nexus.muted]Streaming large file ({file_size:,} bytes)...[/nexus.muted]"
                             )

--- a/src/nexus/cli/commands/file_ops.py
+++ b/src/nexus/cli/commands/file_ops.py
@@ -335,7 +335,8 @@ def _cat_md_section(
                     content_hash = file_meta.etag
             except Exception:
                 pass
-        return hook.read_section(path, content, content_hash, section, block_type)
+        result: str | None = hook.read_section(path, content, content_hash, section, block_type)
+        return result
     except Exception:
         return None
 

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -477,6 +477,12 @@ async def _register_vfs_hooks(
         )
         await _enlist("auto_parse", _auto_parse_hook)
 
+    # MarkdownStructureWriteHook (post-write: sync structural index — Issue #3718)
+    from nexus.bricks.parsers.md_structure_hook import MarkdownStructureWriteHook
+
+    _md_struct_hook = MarkdownStructureWriteHook(metadata=nx.metadata)
+    await _enlist("md_structure", _md_struct_hook)
+
     # TigerCacheRenameHook (post-rename: bitmap updates)
     _rebac_mgr = _ss.get("rebac_manager")
     tiger_cache = getattr(_rebac_mgr, "_tiger_cache", None) if _rebac_mgr else None

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -843,6 +843,12 @@ def create_async_files_router(
                         content=ReadResponse(content=partial).model_dump_json(),
                         media_type="application/json",
                     )
+                # Section explicitly requested but not found — don't leak full doc.
+                if section not in ("*", "frontmatter"):
+                    raise HTTPException(
+                        status_code=404,
+                        detail=f"Section '{section}' not found in {path}",
+                    )
 
             if include_metadata and isinstance(result, dict):
                 file_content: str = result["content"]

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -897,11 +897,20 @@ def create_async_files_router(
         """
         try:
             fs = await _get_fs()
-            # Permission gate: verify read access before exposing structure.
+            # Permission gate + content fetch for lazy index rebuild.
             accessible = await fs.access(path, context=context)
             if not accessible:
                 raise NexusFileNotFoundError(path)
-            listing = _md_get_listing(fs, path)
+            raw = await fs.read(path, context=context)
+            content = (
+                raw
+                if isinstance(raw, bytes)
+                else (raw["content"] if isinstance(raw, dict) else str(raw).encode("utf-8"))
+            )
+            if isinstance(content, str):
+                content = content.encode("utf-8")
+            content_hash = _md_get_etag(fs, path)
+            listing = _md_get_listing(fs, path, content=content, content_hash=content_hash)
             if listing is None:
                 raise HTTPException(
                     status_code=404,
@@ -923,6 +932,17 @@ def create_async_files_router(
 
     # --- Markdown helpers (Issue #3718) ---
 
+    def _md_get_etag(fs: Any, path: str) -> str:
+        """Get the authoritative file etag from the metastore primary row."""
+        meta = getattr(fs, "metadata", None)
+        if meta is None:
+            return ""
+        try:
+            file_meta = meta.get(path)
+            return file_meta.etag if file_meta and file_meta.etag else ""
+        except Exception:
+            return ""
+
     def _md_partial_read(
         fs: Any,
         path: str,
@@ -935,27 +955,24 @@ def create_async_files_router(
             hook = fs.service("md_structure") if hasattr(fs, "service") else None
             if hook is None or not hasattr(hook, "read_section"):
                 return None
-            content_hash = ""
-            meta = getattr(fs, "metadata", None)
-            if meta is not None:
-                try:
-                    raw_meta = meta.get_file_metadata(path, "etag")
-                    if raw_meta:
-                        content_hash = str(raw_meta)
-                except Exception:
-                    pass
+            content_hash = _md_get_etag(fs, path)
             return hook.read_section(path, content, content_hash, section_name, block_type)
         except Exception:
             logger.debug("md partial read failed for %s", path, exc_info=True)
             return None
 
-    def _md_get_listing(fs: Any, path: str) -> list[dict[str, Any]] | None:
+    def _md_get_listing(
+        fs: Any,
+        path: str,
+        content: bytes | None = None,
+        content_hash: str = "",
+    ) -> list[dict[str, Any]] | None:
         """Get the structure listing for a markdown file."""
         try:
             hook = fs.service("md_structure") if hasattr(fs, "service") else None
             if hook is None or not hasattr(hook, "get_structure_listing"):
                 return None
-            return hook.get_structure_listing(path)
+            return hook.get_structure_listing(path, content=content, content_hash=content_hash)
         except Exception:
             logger.debug("md structure listing failed for %s", path, exc_info=True)
             return None

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -844,11 +844,11 @@ def create_async_files_router(
                         media_type="application/json",
                     )
                 # Section explicitly requested but not found — don't leak full doc.
-                if section not in ("*", "frontmatter"):
-                    raise HTTPException(
-                        status_code=404,
-                        detail=f"Section '{section}' not found in {path}",
-                    )
+                # Any explicit section selector that returned None — don't leak full doc.
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"Section '{section}' not found in {path}",
+                )
 
             if include_metadata and isinstance(result, dict):
                 file_content: str = result["content"]

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -799,7 +799,14 @@ def create_async_files_router(
                         )
 
             if connector_content is not None:
-                # Connector fast path — return content directly
+                # Connector fast path — apply section filtering before returning.
+                if section and path.endswith(".md"):
+                    partial = _md_partial_read(fs, path, connector_content, section, block_type)
+                    if partial is not None:
+                        return Response(
+                            content=ReadResponse(content=partial).model_dump_json(),
+                            media_type="application/json",
+                        )
                 text = connector_content.decode("utf-8", errors="replace")
                 if include_metadata:
                     resp = ReadResponse(

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -969,7 +969,10 @@ def create_async_files_router(
             if hook is None or not hasattr(hook, "read_section"):
                 return None
             content_hash = _md_get_etag(fs, path)
-            return hook.read_section(path, content, content_hash, section_name, block_type)
+            result: str | None = hook.read_section(
+                path, content, content_hash, section_name, block_type
+            )
+            return result
         except Exception:
             logger.debug("md partial read failed for %s", path, exc_info=True)
             return None
@@ -985,7 +988,10 @@ def create_async_files_router(
             hook = fs.service("md_structure") if hasattr(fs, "service") else None
             if hook is None or not hasattr(hook, "get_structure_listing"):
                 return None
-            return hook.get_structure_listing(path, content=content, content_hash=content_hash)
+            listing: list[dict[str, Any]] | None = hook.get_structure_listing(
+                path, content=content, content_hash=content_hash
+            )
+            return listing
         except Exception:
             logger.debug("md structure listing failed for %s", path, exc_info=True)
             return None

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -27,6 +27,7 @@ All operations pass user context for permission enforcement.
 
 import asyncio
 import base64
+import json
 import logging
 from collections.abc import AsyncIterator, Iterator
 from typing import Any, cast
@@ -667,6 +668,14 @@ def create_async_files_router(
             None,
             description="Transaction ID — required when version is set to validate the hash belongs to this path",
         ),
+        section: str | None = Query(
+            None,
+            description="(Markdown only) Read a specific section by heading text (case-insensitive)",
+        ),
+        block_type: str | None = Query(
+            None,
+            description="(Markdown only) Filter by block type within section: 'code' or 'table'",
+        ),
         context: Any = Depends(get_context),
     ) -> Response:
         """
@@ -810,6 +819,24 @@ def create_async_files_router(
             # Standard VFS read
             result = fs.read(path, return_metadata=include_metadata, context=context)
 
+            # --- Markdown partial read (Issue #3718) ---
+            if section and path.endswith(".md"):
+                raw_content: bytes
+                if include_metadata and isinstance(result, dict):
+                    _rc = result["content"]
+                    raw_content = _rc if isinstance(_rc, bytes) else _rc.encode("utf-8")
+                elif isinstance(result, bytes):
+                    raw_content = result
+                else:
+                    raw_content = str(result).encode("utf-8")
+
+                partial = _md_partial_read(fs, path, raw_content, section, block_type)
+                if partial is not None:
+                    return Response(
+                        content=ReadResponse(content=partial).model_dump_json(),
+                        media_type="application/json",
+                    )
+
             if include_metadata and isinstance(result, dict):
                 file_content: str = result["content"]
                 if isinstance(file_content, bytes):
@@ -853,6 +880,85 @@ def create_async_files_router(
         except Exception as e:
             logger.exception(f"Read error: {e}")
             raise HTTPException(status_code=500, detail=str(e)) from e
+
+    # =============================================================================
+    # Markdown Structure Endpoint (Issue #3718)
+    # =============================================================================
+
+    @router.get("/md-structure")
+    async def md_structure(
+        path: str = Query(..., description="Path to a markdown file"),
+        context: Any = Depends(get_context),
+    ) -> Response:
+        """Return the structural index of a markdown file (headings, blocks, token estimates).
+
+        No file content is returned — only metadata for targeted reads via
+        ``GET /read?section=...&block_type=...``.
+        """
+        try:
+            fs = await _get_fs()
+            # Permission gate: verify read access before exposing structure.
+            accessible = await fs.access(path, context=context)
+            if not accessible:
+                raise NexusFileNotFoundError(path)
+            listing = _md_get_listing(fs, path)
+            if listing is None:
+                raise HTTPException(
+                    status_code=404,
+                    detail=f"No markdown structure available for {path}",
+                )
+            return Response(
+                content=json.dumps(listing),
+                media_type="application/json",
+            )
+        except HTTPException:
+            raise
+        except NexusPermissionError as e:
+            raise HTTPException(status_code=403, detail=str(e)) from e
+        except NexusFileNotFoundError as e:
+            raise HTTPException(status_code=404, detail=str(e)) from e
+        except Exception as e:
+            logger.exception(f"md-structure error: {e}")
+            raise HTTPException(status_code=500, detail=str(e)) from e
+
+    # --- Markdown helpers (Issue #3718) ---
+
+    def _md_partial_read(
+        fs: Any,
+        path: str,
+        content: bytes,
+        section_name: str,
+        block_type: str | None,
+    ) -> str | None:
+        """Attempt a partial markdown read. Returns content string or None."""
+        try:
+            hook = fs.service("md_structure") if hasattr(fs, "service") else None
+            if hook is None or not hasattr(hook, "read_section"):
+                return None
+            content_hash = ""
+            meta = getattr(fs, "metadata", None)
+            if meta is not None:
+                try:
+                    raw_meta = meta.get_file_metadata(path, "etag")
+                    if raw_meta:
+                        content_hash = str(raw_meta)
+                except Exception:
+                    pass
+            return hook.read_section(path, content, content_hash, section_name, block_type)
+        except Exception:
+            logger.debug("md partial read failed for %s", path, exc_info=True)
+            return None
+
+    def _md_get_listing(fs: Any, path: str) -> list[dict[str, Any]] | None:
+        """Get the structure listing for a markdown file."""
+        try:
+            hook = fs.service("md_structure") if hasattr(fs, "service") else None
+            if hook is None or not hasattr(hook, "get_structure_listing"):
+                return None
+            return hook.get_structure_listing(path)
+        except Exception:
+            logger.debug("md structure listing failed for %s", path, exc_info=True)
+            return None
 
     # =============================================================================
     # Delete Endpoint

--- a/tests/e2e/self_contained/mcp/test_md_structure_e2e.py
+++ b/tests/e2e/self_contained/mcp/test_md_structure_e2e.py
@@ -1,0 +1,455 @@
+"""E2E tests for markdown structure index — Issue #3718.
+
+Tests the full write→index→read pipeline through MCP tools against a
+real NexusFS instance with CASLocalBackend.  Exercises:
+    - nexus_write_file → automatic index creation
+    - nexus_read_file(section=..., block_type=...)
+    - nexus_read_file(section="*") → structure listing
+    - nexus_read_file(section="frontmatter")
+    - nexus_md_structure tool
+    - Edge cases: non-md, missing section, stale index, CJK, empty doc
+"""
+
+import json
+
+import pytest
+
+from nexus.backends.storage.cas_local import CASLocalBackend
+from nexus.bricks.mcp.server import create_mcp_server
+from nexus.core.config import PermissionConfig
+from nexus.factory import create_nexus_fs
+from nexus.storage.raft_metadata_store import RaftMetadataStore
+from nexus.storage.record_store import SQLAlchemyRecordStore
+
+# ============================================================================
+# HELPERS
+# ============================================================================
+
+
+async def get_tool(server, tool_name: str):
+    return await server.get_tool(tool_name)
+
+
+# ============================================================================
+# FIXTURES
+# ============================================================================
+
+SAMPLE_MD = """\
+---
+title: Architecture
+tags: [auth, api]
+---
+
+# Overview
+
+System architecture document.
+
+## Authentication
+
+Auth uses JWT tokens.
+
+```python
+def verify_token(token: str) -> bool:
+    return jwt.decode(token)
+```
+
+### OAuth Flow
+
+The OAuth flow is standard.
+
+```yaml
+oauth:
+  provider: google
+  scopes: [openid, email]
+```
+
+## API Design
+
+Endpoints:
+
+| Method | Path       |
+|--------|------------|
+| GET    | /api/users |
+| POST   | /api/users |
+| DELETE | /api/users |
+
+## Conclusion
+
+Final thoughts.
+"""
+
+CJK_MD = """\
+# 日本語ドキュメント
+
+概要テキスト。
+
+## 認証セクション
+
+```python
+def 認証(トークン):
+    return True
+```
+
+## APIセクション
+
+テーブル:
+
+| メソッド | パス |
+|----------|------|
+| GET      | /api |
+"""
+
+
+@pytest.fixture
+async def nexus_fs(isolated_db, tmp_path):
+    backend = CASLocalBackend(root_path=str(tmp_path / "storage"))
+    nx = await create_nexus_fs(
+        backend=backend,
+        metadata_store=RaftMetadataStore.embedded(str(isolated_db).replace(".db", "-raft")),
+        record_store=SQLAlchemyRecordStore(db_path=str(isolated_db)),
+        permissions=PermissionConfig(enforce=False),
+    )
+    yield nx
+    nx.close()
+
+
+@pytest.fixture
+async def mcp_server(nexus_fs):
+    return await create_mcp_server(nx=nexus_fs)
+
+
+@pytest.fixture
+async def md_file(nexus_fs):
+    """Write the sample markdown file and return its path."""
+    path = "/docs/arch.md"
+    await nexus_fs.write(path, SAMPLE_MD.encode("utf-8"))
+    return path
+
+
+@pytest.fixture
+async def cjk_file(nexus_fs):
+    """Write the CJK markdown file."""
+    path = "/docs/cjk.md"
+    await nexus_fs.write(path, CJK_MD.encode("utf-8"))
+    return path
+
+
+# ============================================================================
+# CORE E2E: WRITE → INDEX → READ
+# ============================================================================
+
+
+class TestMdStructureE2E:
+    """Core write→read round trip through MCP tools."""
+
+    @pytest.mark.asyncio
+    async def test_write_creates_index(self, mcp_server, nexus_fs, md_file):
+        """Writing a .md file should automatically create a structural index."""
+        # The write hook should have fired during fixture setup.
+        # Verify by reading the structure.
+        tool = await get_tool(mcp_server, "nexus_md_structure")
+        result = await tool.fn(path=md_file)
+        listing = json.loads(result)
+
+        assert isinstance(listing, list)
+        assert len(listing) >= 1
+
+        # Should have frontmatter
+        fm_entries = [e for e in listing if e.get("type") == "frontmatter"]
+        assert len(fm_entries) == 1
+        assert "title" in fm_entries[0]["keys"]
+        assert "tags" in fm_entries[0]["keys"]
+
+        # Should have sections
+        sec_entries = [e for e in listing if e.get("type") == "section"]
+        headings = [e["heading"] for e in sec_entries]
+        assert "Overview" in headings
+        assert "Authentication" in headings
+        assert "OAuth Flow" in headings
+        assert "API Design" in headings
+        assert "Conclusion" in headings
+
+    @pytest.mark.asyncio
+    async def test_read_full_file_unchanged(self, mcp_server, md_file):
+        """Reading without section param returns full content (backward compat)."""
+        read_tool = await get_tool(mcp_server, "nexus_read_file")
+        result = await read_tool.fn(path=md_file)
+        assert "# Overview" in result
+        assert "## Authentication" in result
+        assert "## API Design" in result
+        assert "## Conclusion" in result
+
+    @pytest.mark.asyncio
+    async def test_read_section(self, mcp_server, md_file):
+        """section='Authentication' returns only that section."""
+        read_tool = await get_tool(mcp_server, "nexus_read_file")
+        result = await read_tool.fn(path=md_file, section="Authentication")
+
+        assert "## Authentication" in result
+        assert "verify_token" in result
+        assert "OAuth Flow" in result  # H3 is nested inside H2
+        assert "## API Design" not in result  # sibling H2 excluded
+        assert "## Conclusion" not in result
+
+    @pytest.mark.asyncio
+    async def test_read_section_case_insensitive(self, mcp_server, md_file):
+        """Section lookup is case-insensitive."""
+        read_tool = await get_tool(mcp_server, "nexus_read_file")
+        result = await read_tool.fn(path=md_file, section="authentication")
+        assert "## Authentication" in result
+        assert "verify_token" in result
+
+    @pytest.mark.asyncio
+    async def test_read_section_substring(self, mcp_server, md_file):
+        """Section lookup supports substring matching."""
+        read_tool = await get_tool(mcp_server, "nexus_read_file")
+        result = await read_tool.fn(path=md_file, section="Auth")
+        assert "## Authentication" in result
+
+    @pytest.mark.asyncio
+    async def test_read_section_with_code_block_type(self, mcp_server, md_file):
+        """block_type='code' filters to only code blocks within section."""
+        read_tool = await get_tool(mcp_server, "nexus_read_file")
+        result = await read_tool.fn(path=md_file, section="Authentication", block_type="code")
+
+        assert result is not None
+        assert "verify_token" in result
+        # Should contain the code block content
+        assert "```" in result
+        # Should NOT contain section heading or prose
+        assert "Auth uses JWT" not in result
+
+    @pytest.mark.asyncio
+    async def test_read_section_with_table_block_type(self, mcp_server, md_file):
+        """block_type='table' filters to only tables within section."""
+        read_tool = await get_tool(mcp_server, "nexus_read_file")
+        result = await read_tool.fn(path=md_file, section="API Design", block_type="table")
+
+        assert result is not None
+        assert "/api/users" in result
+        assert "GET" in result
+        # Should NOT contain non-table content
+        assert "Endpoints:" not in result
+
+    @pytest.mark.asyncio
+    async def test_read_section_star(self, mcp_server, md_file):
+        """section='*' returns structure listing as JSON."""
+        read_tool = await get_tool(mcp_server, "nexus_read_file")
+        result = await read_tool.fn(path=md_file, section="*")
+
+        listing = json.loads(result)
+        assert isinstance(listing, list)
+
+        sec_entries = [e for e in listing if e.get("type") == "section"]
+        for entry in sec_entries:
+            assert "heading" in entry
+            assert "depth" in entry
+            assert "tokens_est" in entry
+            assert isinstance(entry["tokens_est"], int)
+            assert entry["tokens_est"] > 0
+
+    @pytest.mark.asyncio
+    async def test_read_section_frontmatter(self, mcp_server, md_file):
+        """section='frontmatter' returns only the YAML frontmatter."""
+        read_tool = await get_tool(mcp_server, "nexus_read_file")
+        result = await read_tool.fn(path=md_file, section="frontmatter")
+
+        assert result is not None
+        assert "title" in result
+        assert "Architecture" in result
+        assert "tags" in result
+        # Should NOT contain any markdown content
+        assert "# Overview" not in result
+
+    @pytest.mark.asyncio
+    async def test_nexus_md_structure_tool(self, mcp_server, md_file):
+        """Dedicated structure tool returns listing without content."""
+        tool = await get_tool(mcp_server, "nexus_md_structure")
+        result = await tool.fn(path=md_file)
+
+        listing = json.loads(result)
+        sec_entries = [e for e in listing if e.get("type") == "section"]
+
+        # Check structure has expected fields
+        auth = next((e for e in sec_entries if e["heading"] == "Authentication"), None)
+        assert auth is not None
+        assert auth["depth"] == 2
+        assert auth["tokens_est"] > 0
+        assert "code" in auth["blocks"]  # has code blocks
+
+        api = next((e for e in sec_entries if e["heading"] == "API Design"), None)
+        assert api is not None
+        assert "table" in api["blocks"]  # has tables
+
+
+# ============================================================================
+# EDGE CASES
+# ============================================================================
+
+
+class TestMdStructureEdgeCases:
+    """Edge cases exercised end-to-end."""
+
+    @pytest.mark.asyncio
+    async def test_non_md_file_ignores_section(self, mcp_server, nexus_fs):
+        """section param on non-.md files returns full content."""
+        await nexus_fs.write("/data.txt", b"# Not markdown\nJust text.")
+        read_tool = await get_tool(mcp_server, "nexus_read_file")
+        result = await read_tool.fn(path="/data.txt", section="Not markdown")
+        # Should return full content since it's not .md
+        assert "# Not markdown" in result
+        assert "Just text." in result
+
+    @pytest.mark.asyncio
+    async def test_missing_section_returns_full(self, mcp_server, md_file):
+        """Requesting a non-existent section falls back to full content."""
+        read_tool = await get_tool(mcp_server, "nexus_read_file")
+        result = await read_tool.fn(path=md_file, section="NonexistentSection")
+        # Should fall back to full content
+        assert "# Overview" in result
+
+    @pytest.mark.asyncio
+    async def test_empty_md_file(self, mcp_server, nexus_fs):
+        """Empty .md file should not crash."""
+        await nexus_fs.write("/empty.md", b"")
+        read_tool = await get_tool(mcp_server, "nexus_read_file")
+        result = await read_tool.fn(path="/empty.md", section="*")
+        # Should return empty listing
+        listing = json.loads(result)
+        sec_entries = [e for e in listing if e.get("type") == "section"]
+        assert len(sec_entries) == 0
+
+    @pytest.mark.asyncio
+    async def test_md_no_headings(self, mcp_server, nexus_fs):
+        """Markdown with no headings should handle section param gracefully."""
+        await nexus_fs.write("/plain.md", b"Just plain text.\nNo headings here.\n")
+        read_tool = await get_tool(mcp_server, "nexus_read_file")
+        result = await read_tool.fn(path="/plain.md", section="anything")
+        # Should fall back to full content
+        assert "Just plain text" in result
+
+    @pytest.mark.asyncio
+    async def test_md_frontmatter_only(self, mcp_server, nexus_fs):
+        """File with only frontmatter, no content."""
+        await nexus_fs.write("/fm_only.md", b"---\ntitle: Test\n---\n")
+        tool = await get_tool(mcp_server, "nexus_md_structure")
+        result = await tool.fn(path="/fm_only.md")
+        listing = json.loads(result)
+        fm = [e for e in listing if e.get("type") == "frontmatter"]
+        assert len(fm) == 1
+        assert "title" in fm[0]["keys"]
+
+    @pytest.mark.asyncio
+    async def test_cjk_section_read(self, mcp_server, cjk_file):
+        """CJK headings can be read by section with correct byte offsets."""
+        read_tool = await get_tool(mcp_server, "nexus_read_file")
+        result = await read_tool.fn(path=cjk_file, section="認証セクション")
+
+        assert "認証セクション" in result
+        assert "認証(トークン)" in result
+        # Should NOT bleed into the API section
+        assert "APIセクション" not in result
+
+    @pytest.mark.asyncio
+    async def test_cjk_code_block_filter(self, mcp_server, cjk_file):
+        """Code block filtering works with CJK content."""
+        read_tool = await get_tool(mcp_server, "nexus_read_file")
+        result = await read_tool.fn(path=cjk_file, section="認証", block_type="code")
+        assert result is not None
+        assert "認証(トークン)" in result
+
+    @pytest.mark.asyncio
+    async def test_cjk_table_filter(self, mcp_server, cjk_file):
+        """Table filtering works with CJK content."""
+        read_tool = await get_tool(mcp_server, "nexus_read_file")
+        result = await read_tool.fn(path=cjk_file, section="API", block_type="table")
+        assert result is not None
+        assert "メソッド" in result
+        assert "/api" in result
+
+    @pytest.mark.asyncio
+    async def test_stale_index_self_heals(self, mcp_server, nexus_fs, md_file):
+        """After overwriting a file, the index self-heals on read."""
+        new_content = """\
+# New Title
+
+Completely different content.
+
+## New Section
+
+Brand new section.
+"""
+        await nexus_fs.write(md_file, new_content.encode("utf-8"))
+
+        # Read structure — should reflect the NEW content
+        tool = await get_tool(mcp_server, "nexus_md_structure")
+        result = await tool.fn(path=md_file)
+        listing = json.loads(result)
+        sec_entries = [e for e in listing if e.get("type") == "section"]
+        headings = [e["heading"] for e in sec_entries]
+
+        # Old headings should be gone
+        assert "Overview" not in headings
+        assert "Authentication" not in headings
+        # New headings should be present
+        assert "New Title" in headings
+        assert "New Section" in headings
+
+    @pytest.mark.asyncio
+    async def test_write_via_mcp_tool_indexes(self, mcp_server):
+        """Writing via nexus_write_file MCP tool should trigger indexing."""
+        write_tool = await get_tool(mcp_server, "nexus_write_file")
+        await write_tool.fn(
+            path="/mcp_written.md",
+            content="# Written via MCP\n\n## SubSection\n\nContent here.\n",
+        )
+
+        struct_tool = await get_tool(mcp_server, "nexus_md_structure")
+        result = await struct_tool.fn(path="/mcp_written.md")
+        listing = json.loads(result)
+        sec_entries = [e for e in listing if e.get("type") == "section"]
+        headings = [e["heading"] for e in sec_entries]
+        assert "Written via MCP" in headings
+        assert "SubSection" in headings
+
+    @pytest.mark.asyncio
+    async def test_heading_inside_code_fence_not_indexed(self, mcp_server, nexus_fs):
+        """Headings inside code fences must not appear in the index."""
+        doc = """\
+## Real Heading
+
+```markdown
+# Fake Heading Inside Code
+## Also Fake
+```
+
+## Another Real Heading
+"""
+        await nexus_fs.write("/fenced.md", doc.encode("utf-8"))
+        tool = await get_tool(mcp_server, "nexus_md_structure")
+        result = await tool.fn(path="/fenced.md")
+        listing = json.loads(result)
+        sec_entries = [e for e in listing if e.get("type") == "section"]
+        headings = [e["heading"] for e in sec_entries]
+
+        assert "Real Heading" in headings
+        assert "Another Real Heading" in headings
+        assert "Fake Heading Inside Code" not in headings
+        assert "Also Fake" not in headings
+
+    @pytest.mark.asyncio
+    async def test_structure_tool_on_nonexistent_file(self, mcp_server):
+        """nexus_md_structure on non-existent file returns an error."""
+        tool = await get_tool(mcp_server, "nexus_md_structure")
+        result = await tool.fn(path="/does/not/exist.md")
+        # Should return an error string, not crash
+        assert "Error" in result or "No markdown structure" in result
+
+    @pytest.mark.asyncio
+    async def test_block_type_without_section_ignored(self, mcp_server, md_file):
+        """block_type without section should return full content."""
+        read_tool = await get_tool(mcp_server, "nexus_read_file")
+        result = await read_tool.fn(path=md_file, block_type="code")
+        # Without section, block_type is ignored — full content returned
+        assert "# Overview" in result
+        assert "## Authentication" in result

--- a/tests/e2e/self_contained/mcp/test_md_structure_e2e.py
+++ b/tests/e2e/self_contained/mcp/test_md_structure_e2e.py
@@ -301,12 +301,13 @@ class TestMdStructureEdgeCases:
         assert "Just text." in result
 
     @pytest.mark.asyncio
-    async def test_missing_section_returns_full(self, mcp_server, md_file):
-        """Requesting a non-existent section falls back to full content."""
+    async def test_missing_section_returns_error(self, mcp_server, md_file):
+        """Requesting a non-existent section returns error, not full content."""
         read_tool = await get_tool(mcp_server, "nexus_read_file")
         result = await read_tool.fn(path=md_file, section="NonexistentSection")
-        # Should fall back to full content
-        assert "# Overview" in result
+        # Should NOT leak full content — should return error
+        assert "Error" in result or "not found" in result
+        assert "# Overview" not in result
 
     @pytest.mark.asyncio
     async def test_empty_md_file(self, mcp_server, nexus_fs):
@@ -321,12 +322,12 @@ class TestMdStructureEdgeCases:
 
     @pytest.mark.asyncio
     async def test_md_no_headings(self, mcp_server, nexus_fs):
-        """Markdown with no headings should handle section param gracefully."""
+        """Markdown with no headings should return error for section requests."""
         await nexus_fs.write("/plain.md", b"Just plain text.\nNo headings here.\n")
         read_tool = await get_tool(mcp_server, "nexus_read_file")
         result = await read_tool.fn(path="/plain.md", section="anything")
-        # Should fall back to full content
-        assert "Just plain text" in result
+        # Should NOT leak full content — section not found
+        assert "Error" in result or "not found" in result
 
     @pytest.mark.asyncio
     async def test_md_frontmatter_only(self, mcp_server, nexus_fs):

--- a/tests/e2e/self_contained/mcp/test_md_structure_e2e.py
+++ b/tests/e2e/self_contained/mcp/test_md_structure_e2e.py
@@ -122,7 +122,7 @@ async def mcp_server(nexus_fs):
 async def md_file(nexus_fs):
     """Write the sample markdown file and return its path."""
     path = "/docs/arch.md"
-    await nexus_fs.write(path, SAMPLE_MD.encode("utf-8"))
+    nexus_fs.write(path, SAMPLE_MD.encode("utf-8"))
     return path
 
 
@@ -130,7 +130,7 @@ async def md_file(nexus_fs):
 async def cjk_file(nexus_fs):
     """Write the CJK markdown file."""
     path = "/docs/cjk.md"
-    await nexus_fs.write(path, CJK_MD.encode("utf-8"))
+    nexus_fs.write(path, CJK_MD.encode("utf-8"))
     return path
 
 
@@ -293,7 +293,7 @@ class TestMdStructureEdgeCases:
     @pytest.mark.asyncio
     async def test_non_md_file_ignores_section(self, mcp_server, nexus_fs):
         """section param on non-.md files returns full content."""
-        await nexus_fs.write("/data.txt", b"# Not markdown\nJust text.")
+        nexus_fs.write("/data.txt", b"# Not markdown\nJust text.")
         read_tool = await get_tool(mcp_server, "nexus_read_file")
         result = await read_tool.fn(path="/data.txt", section="Not markdown")
         # Should return full content since it's not .md
@@ -312,7 +312,7 @@ class TestMdStructureEdgeCases:
     @pytest.mark.asyncio
     async def test_empty_md_file(self, mcp_server, nexus_fs):
         """Empty .md file should not crash."""
-        await nexus_fs.write("/empty.md", b"")
+        nexus_fs.write("/empty.md", b"")
         read_tool = await get_tool(mcp_server, "nexus_read_file")
         result = await read_tool.fn(path="/empty.md", section="*")
         # Should return empty listing
@@ -323,7 +323,7 @@ class TestMdStructureEdgeCases:
     @pytest.mark.asyncio
     async def test_md_no_headings(self, mcp_server, nexus_fs):
         """Markdown with no headings should return error for section requests."""
-        await nexus_fs.write("/plain.md", b"Just plain text.\nNo headings here.\n")
+        nexus_fs.write("/plain.md", b"Just plain text.\nNo headings here.\n")
         read_tool = await get_tool(mcp_server, "nexus_read_file")
         result = await read_tool.fn(path="/plain.md", section="anything")
         # Should NOT leak full content — section not found
@@ -332,7 +332,7 @@ class TestMdStructureEdgeCases:
     @pytest.mark.asyncio
     async def test_md_frontmatter_only(self, mcp_server, nexus_fs):
         """File with only frontmatter, no content."""
-        await nexus_fs.write("/fm_only.md", b"---\ntitle: Test\n---\n")
+        nexus_fs.write("/fm_only.md", b"---\ntitle: Test\n---\n")
         tool = await get_tool(mcp_server, "nexus_md_structure")
         result = await tool.fn(path="/fm_only.md")
         listing = json.loads(result)
@@ -380,7 +380,7 @@ Completely different content.
 
 Brand new section.
 """
-        await nexus_fs.write(md_file, new_content.encode("utf-8"))
+        nexus_fs.write(md_file, new_content.encode("utf-8"))
 
         # Read structure — should reflect the NEW content
         tool = await get_tool(mcp_server, "nexus_md_structure")
@@ -426,7 +426,7 @@ Brand new section.
 
 ## Another Real Heading
 """
-        await nexus_fs.write("/fenced.md", doc.encode("utf-8"))
+        nexus_fs.write("/fenced.md", doc.encode("utf-8"))
         tool = await get_tool(mcp_server, "nexus_md_structure")
         result = await tool.fn(path="/fenced.md")
         listing = json.loads(result)

--- a/tests/unit/bricks/parsers/test_md_structure.py
+++ b/tests/unit/bricks/parsers/test_md_structure.py
@@ -237,6 +237,20 @@ More content.
         assert len(idx.sections) == 1
         assert idx.sections[0].heading == "Section"
 
+    def test_code_block_inside_blockquote(self) -> None:
+        """Code blocks nested inside blockquotes must be indexed."""
+        doc = b"## Section\n\n> Some quote:\n>\n> ```python\n> nested_code()\n> ```\n"
+        idx = parse_markdown_structure(doc)
+        code_blocks = filter_blocks(idx.sections[0], "code")
+        assert len(code_blocks) >= 1, "Code block inside blockquote was not indexed"
+
+    def test_code_block_inside_list_item(self) -> None:
+        """Code blocks nested inside list items must be indexed."""
+        doc = b"## Section\n\n- Item one\n\n  ```python\n  list_code()\n  ```\n\n- Item two\n"
+        idx = parse_markdown_structure(doc)
+        code_blocks = filter_blocks(idx.sections[0], "code")
+        assert len(code_blocks) >= 1, "Code block inside list item was not indexed"
+
     def test_section_boundary_respects_depth(self) -> None:
         """H2 section ends at next H2, not at nested H3."""
         doc = b"## A\nContent A.\n### A.1\nNested.\n## B\nContent B.\n"

--- a/tests/unit/bricks/parsers/test_md_structure.py
+++ b/tests/unit/bricks/parsers/test_md_structure.py
@@ -1,0 +1,433 @@
+"""Tests for markdown structure parser — Issue #3718.
+
+Covers:
+    - Parser correctness (parametrized, ~20 cases)
+    - Section lookup and block filtering
+    - Serialization round-trip
+    - Edge cases and failure modes
+"""
+
+from __future__ import annotations
+
+import json
+
+import pytest
+
+from nexus.bricks.parsers.md_structure import (
+    SCHEMA_VERSION,
+    MarkdownStructureIndex,
+    filter_blocks,
+    find_section,
+    parse_markdown_structure,
+    slice_content,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures: reusable markdown documents
+# ---------------------------------------------------------------------------
+
+SIMPLE_DOC = b"""\
+# Title
+
+Intro paragraph.
+
+## Section A
+
+Content of section A.
+
+## Section B
+
+Content of section B.
+"""
+
+FULL_DOC = b"""\
+---
+title: Architecture
+tags: [auth, api]
+---
+
+# Overview
+
+System architecture document.
+
+## Authentication
+
+Auth uses JWT tokens.
+
+```python
+def verify_token(token: str) -> bool:
+    return jwt.decode(token)
+```
+
+### OAuth Flow
+
+The OAuth flow is standard.
+
+## API Design
+
+| Method | Path       |
+|--------|------------|
+| GET    | /api/users |
+| POST   | /api/users |
+
+## Conclusion
+
+Final thoughts.
+"""
+
+CJK_DOC = """\
+# 日本語タイトル
+
+導入テキスト。
+
+## セクションA
+
+コンテンツA。
+
+## セクションB
+
+コンテンツB。
+""".encode()
+
+
+# ---------------------------------------------------------------------------
+# Parser correctness — parametrized
+# ---------------------------------------------------------------------------
+
+
+class TestParserCorrectness:
+    """Parametrized tests for parser edge cases."""
+
+    def test_simple_headings(self) -> None:
+        idx = parse_markdown_structure(SIMPLE_DOC)
+        assert len(idx.sections) == 3
+        assert idx.sections[0].heading == "Title"
+        assert idx.sections[0].depth == 1
+        assert idx.sections[1].heading == "Section A"
+        assert idx.sections[1].depth == 2
+        assert idx.sections[2].heading == "Section B"
+
+    def test_frontmatter_parsed(self) -> None:
+        idx = parse_markdown_structure(FULL_DOC)
+        assert idx.frontmatter is not None
+        assert "title" in idx.frontmatter.keys
+        assert "tags" in idx.frontmatter.keys
+
+    def test_code_block_inside_section(self) -> None:
+        idx = parse_markdown_structure(FULL_DOC)
+        auth = find_section(idx, "Authentication")
+        assert auth is not None
+        code_blocks = filter_blocks(auth, "code")
+        assert len(code_blocks) == 1
+        assert code_blocks[0].language == "python"
+
+    def test_table_inside_section(self) -> None:
+        idx = parse_markdown_structure(FULL_DOC)
+        api = find_section(idx, "API Design")
+        assert api is not None
+        tables = filter_blocks(api, "table")
+        assert len(tables) == 1
+        assert tables[0].rows == 2
+
+    def test_heading_inside_code_fence_ignored(self) -> None:
+        """Headings inside code fences must NOT be indexed."""
+        doc = b"""\
+## Real Heading
+
+```markdown
+# This Is Not A Heading
+## Neither Is This
+```
+
+## Another Real Heading
+"""
+        idx = parse_markdown_structure(doc)
+        headings = [s.heading for s in idx.sections]
+        assert "This Is Not A Heading" not in headings
+        assert "Neither Is This" not in headings
+        assert "Real Heading" in headings
+        assert "Another Real Heading" in headings
+        assert len(idx.sections) == 2
+
+    def test_setext_headings(self) -> None:
+        """Setext-style headings (=== / ---) must be indexed."""
+        doc = b"""\
+Setext H1
+=========
+
+Some content.
+
+Setext H2
+---------
+
+More content.
+"""
+        idx = parse_markdown_structure(doc)
+        assert len(idx.sections) == 2
+        assert idx.sections[0].heading == "Setext H1"
+        assert idx.sections[0].depth == 1
+        assert idx.sections[1].heading == "Setext H2"
+        assert idx.sections[1].depth == 2
+
+    def test_utf8_byte_offsets(self) -> None:
+        """Byte offsets must be correct for multi-byte characters."""
+        idx = parse_markdown_structure(CJK_DOC)
+        assert len(idx.sections) == 3
+        for sec in idx.sections:
+            content = slice_content(CJK_DOC, sec.byte_start, sec.byte_end)
+            assert sec.heading in content
+
+    def test_empty_document(self) -> None:
+        idx = parse_markdown_structure(b"")
+        assert len(idx.sections) == 0
+        assert idx.frontmatter is None
+
+    def test_no_headings(self) -> None:
+        idx = parse_markdown_structure(b"Just plain text.\nNo headings.\n")
+        assert len(idx.sections) == 0
+
+    def test_frontmatter_only(self) -> None:
+        doc = b"---\ntitle: Test\n---\n"
+        idx = parse_markdown_structure(doc)
+        assert idx.frontmatter is not None
+        assert idx.frontmatter.keys == ["title"]
+        assert len(idx.sections) == 0
+
+    def test_empty_section_between_headings(self) -> None:
+        """Adjacent headings with no content between them."""
+        doc = b"## A\n## B\n## C\n"
+        idx = parse_markdown_structure(doc)
+        assert len(idx.sections) == 3
+        # All sections should have valid byte ranges (non-negative size)
+        for sec in idx.sections:
+            assert sec.byte_end >= sec.byte_start
+
+    def test_deeply_nested_headings(self) -> None:
+        doc = b"# H1\n## H2\n### H3\n#### H4\n##### H5\n###### H6\n"
+        idx = parse_markdown_structure(doc)
+        assert len(idx.sections) == 6
+        for i, sec in enumerate(idx.sections):
+            assert sec.depth == i + 1
+
+    def test_code_fence_with_no_language(self) -> None:
+        doc = b"## Section\n\n```\nplain code\n```\n"
+        idx = parse_markdown_structure(doc)
+        blocks = filter_blocks(idx.sections[0], "code")
+        assert len(blocks) == 1
+        assert blocks[0].language is None
+
+    def test_code_fence_with_language(self) -> None:
+        doc = b"## Section\n\n```rust\nfn main() {}\n```\n"
+        idx = parse_markdown_structure(doc)
+        blocks = filter_blocks(idx.sections[0], "code")
+        assert blocks[0].language == "rust"
+
+    def test_multiple_code_blocks_in_section(self) -> None:
+        doc = b"## Section\n\n```python\na = 1\n```\n\nText.\n\n```js\nlet b = 2;\n```\n"
+        idx = parse_markdown_structure(doc)
+        blocks = filter_blocks(idx.sections[0], "code")
+        assert len(blocks) == 2
+        assert blocks[0].language == "python"
+        assert blocks[1].language == "js"
+
+    def test_nested_code_fences(self) -> None:
+        """Nested fences (``````` inside ```) must be handled correctly."""
+        doc = b"## Section\n\n````\n```\nnot a heading: # H1\n```\n````\n"
+        idx = parse_markdown_structure(doc)
+        assert len(idx.sections) == 1
+        assert idx.sections[0].heading == "Section"
+
+    def test_section_boundary_respects_depth(self) -> None:
+        """H2 section ends at next H2, not at nested H3."""
+        doc = b"## A\nContent A.\n### A.1\nNested.\n## B\nContent B.\n"
+        idx = parse_markdown_structure(doc)
+        sec_a = find_section(idx, "A")
+        assert sec_a is not None
+        content = slice_content(doc, sec_a.byte_start, sec_a.byte_end)
+        assert "Content A" in content
+        assert "Nested" in content  # H3 is inside H2 "A"
+        assert "Content B" not in content  # H2 "B" is a sibling
+
+    def test_content_hash_stored(self) -> None:
+        idx = parse_markdown_structure(SIMPLE_DOC, content_hash="abc123")
+        assert idx.content_hash == "abc123"
+
+    def test_tokens_est(self) -> None:
+        idx = parse_markdown_structure(FULL_DOC)
+        for sec in idx.sections:
+            expected = (sec.byte_end - sec.byte_start) // 4
+            assert sec.tokens_est == expected
+
+    def test_schema_version(self) -> None:
+        idx = parse_markdown_structure(SIMPLE_DOC)
+        assert idx.version == SCHEMA_VERSION
+
+
+# ---------------------------------------------------------------------------
+# Section lookup
+# ---------------------------------------------------------------------------
+
+
+class TestSectionLookup:
+    def test_exact_match(self) -> None:
+        idx = parse_markdown_structure(FULL_DOC)
+        sec = find_section(idx, "Authentication")
+        assert sec is not None
+        assert sec.heading == "Authentication"
+
+    def test_case_insensitive(self) -> None:
+        idx = parse_markdown_structure(FULL_DOC)
+        sec = find_section(idx, "authentication")
+        assert sec is not None
+        assert sec.heading == "Authentication"
+
+    def test_substring_match(self) -> None:
+        idx = parse_markdown_structure(FULL_DOC)
+        sec = find_section(idx, "Auth")
+        assert sec is not None
+        assert sec.heading == "Authentication"
+
+    def test_exact_match_preferred_over_substring(self) -> None:
+        doc = b"## Auth\nShort.\n## Authentication\nFull.\n"
+        idx = parse_markdown_structure(doc)
+        sec = find_section(idx, "Auth")
+        assert sec is not None
+        assert sec.heading == "Auth"
+
+    def test_not_found(self) -> None:
+        idx = parse_markdown_structure(SIMPLE_DOC)
+        assert find_section(idx, "Nonexistent") is None
+
+    def test_cjk_lookup(self) -> None:
+        idx = parse_markdown_structure(CJK_DOC)
+        sec = find_section(idx, "セクションA")
+        assert sec is not None
+        assert sec.heading == "セクションA"
+
+
+# ---------------------------------------------------------------------------
+# Serialization round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestSerialization:
+    def test_roundtrip(self) -> None:
+        idx = parse_markdown_structure(FULL_DOC, content_hash="hash123")
+        d = idx.to_dict()
+        json_str = json.dumps(d)
+        idx2 = MarkdownStructureIndex.from_dict(json.loads(json_str))
+
+        assert idx2.version == idx.version
+        assert idx2.content_hash == idx.content_hash
+        assert idx2.tokens_est_method == idx.tokens_est_method
+        assert len(idx2.sections) == len(idx.sections)
+        for s1, s2 in zip(idx.sections, idx2.sections):
+            assert s1.heading == s2.heading
+            assert s1.depth == s2.depth
+            assert s1.byte_start == s2.byte_start
+            assert s1.byte_end == s2.byte_end
+            assert len(s1.blocks) == len(s2.blocks)
+
+    def test_frontmatter_roundtrip(self) -> None:
+        idx = parse_markdown_structure(FULL_DOC)
+        d = idx.to_dict()
+        idx2 = MarkdownStructureIndex.from_dict(d)
+        assert idx2.frontmatter is not None
+        assert idx2.frontmatter.keys == idx.frontmatter.keys
+
+    def test_empty_doc_roundtrip(self) -> None:
+        idx = parse_markdown_structure(b"")
+        d = idx.to_dict()
+        idx2 = MarkdownStructureIndex.from_dict(d)
+        assert len(idx2.sections) == 0
+        assert idx2.frontmatter is None
+
+
+# ---------------------------------------------------------------------------
+# Byte-range slicing round-trip
+# ---------------------------------------------------------------------------
+
+
+class TestByteRangeRoundTrip:
+    """Verify that byte offsets produce correct content when sliced."""
+
+    @pytest.mark.parametrize(
+        "doc",
+        [SIMPLE_DOC, FULL_DOC, CJK_DOC],
+        ids=["simple", "full", "cjk"],
+    )
+    def test_all_sections_slice_correctly(self, doc: bytes) -> None:
+        idx = parse_markdown_structure(doc)
+        for sec in idx.sections:
+            content = slice_content(doc, sec.byte_start, sec.byte_end)
+            # Section content should contain its heading
+            assert sec.heading in content, (
+                f"Section '{sec.heading}' heading not found in sliced content"
+            )
+
+    def test_code_block_slice(self) -> None:
+        idx = parse_markdown_structure(FULL_DOC)
+        auth = find_section(idx, "Authentication")
+        assert auth is not None
+        for block in auth.blocks:
+            if block.type == "code":
+                content = slice_content(FULL_DOC, block.byte_start, block.byte_end)
+                assert "verify_token" in content
+
+    def test_table_slice(self) -> None:
+        idx = parse_markdown_structure(FULL_DOC)
+        api = find_section(idx, "API Design")
+        assert api is not None
+        for block in api.blocks:
+            if block.type == "table":
+                content = slice_content(FULL_DOC, block.byte_start, block.byte_end)
+                assert "/api/users" in content
+
+
+# ---------------------------------------------------------------------------
+# Failure modes
+# ---------------------------------------------------------------------------
+
+
+class TestFailureModes:
+    def test_binary_content_no_crash(self) -> None:
+        """Binary content with .md extension should not crash."""
+        binary = bytes(range(256)) * 10
+        idx = parse_markdown_structure(binary)
+        # May produce garbage sections, but must not raise
+        assert isinstance(idx, MarkdownStructureIndex)
+
+    def test_malformed_frontmatter(self) -> None:
+        """Malformed YAML in frontmatter should not crash."""
+        doc = b"---\n: invalid yaml [[\n---\n# Heading\nContent.\n"
+        idx = parse_markdown_structure(doc)
+        # Parser should handle gracefully
+        assert isinstance(idx, MarkdownStructureIndex)
+        # Heading should still be indexed
+        assert len(idx.sections) >= 1
+
+    def test_very_large_heading_count(self) -> None:
+        """Many headings should not cause performance issues."""
+        lines = [f"## Heading {i}\n\nContent {i}.\n" for i in range(200)]
+        doc = "\n".join(lines).encode("utf-8")
+        idx = parse_markdown_structure(doc)
+        assert len(idx.sections) == 200
+
+    def test_from_dict_missing_fields(self) -> None:
+        """Deserialization should handle missing optional fields."""
+        data = {
+            "sections": [
+                {
+                    "heading": "H",
+                    "depth": 1,
+                    "byte_start": 0,
+                    "byte_end": 10,
+                    "line_start": 0,
+                    "line_end": 1,
+                }
+            ]
+        }
+        idx = MarkdownStructureIndex.from_dict(data)
+        assert len(idx.sections) == 1
+        assert idx.sections[0].tokens_est == 0
+        assert idx.frontmatter is None

--- a/tests/unit/bricks/parsers/test_md_structure_hook.py
+++ b/tests/unit/bricks/parsers/test_md_structure_hook.py
@@ -1,0 +1,304 @@
+"""Integration tests for MarkdownStructureWriteHook — Issue #3718.
+
+Tests the full write-hook → metastore → read round trip using a
+real DictMetastore (in-memory, no DB).
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+
+import pytest
+
+from nexus.bricks.parsers.md_structure_hook import (
+    MD_STRUCTURE_KEY,
+    MarkdownStructureWriteHook,
+)
+from nexus.contracts.vfs_hooks import WriteHookContext
+
+# ---------------------------------------------------------------------------
+# Lightweight in-memory metastore stub
+# ---------------------------------------------------------------------------
+
+
+class _StubMetastore:
+    """Minimal metastore stub for testing (mirrors DictMetastore API)."""
+
+    def __init__(self) -> None:
+        self._data: dict[str, dict[str, Any]] = {}
+
+    def set_file_metadata(self, path: str, key: str, value: Any) -> None:
+        if path not in self._data:
+            self._data[path] = {}
+        self._data[path][key] = value
+
+    def get_file_metadata(self, path: str, key: str) -> Any:
+        return self._data.get(path, {}).get(key)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SAMPLE_MD = b"""\
+---
+title: Architecture
+---
+
+# Overview
+
+System overview text.
+
+## Authentication
+
+```python
+def verify(token):
+    return True
+```
+
+## API
+
+| Method | Path  |
+|--------|-------|
+| GET    | /api  |
+"""
+
+
+@pytest.fixture
+def meta() -> _StubMetastore:
+    return _StubMetastore()
+
+
+@pytest.fixture
+def hook(meta: _StubMetastore) -> MarkdownStructureWriteHook:
+    return MarkdownStructureWriteHook(metadata=meta)
+
+
+def _make_write_ctx(path: str, content: bytes, content_hash: str = "hash1") -> WriteHookContext:
+    return WriteHookContext(
+        path=path,
+        content=content,
+        context=None,
+        content_hash=content_hash,
+    )
+
+
+# ---------------------------------------------------------------------------
+# Write hook tests
+# ---------------------------------------------------------------------------
+
+
+class TestWriteHook:
+    def test_indexes_md_file(self, hook: MarkdownStructureWriteHook, meta: _StubMetastore) -> None:
+        ctx = _make_write_ctx("/docs/arch.md", SAMPLE_MD)
+        hook.on_post_write(ctx)
+
+        raw = meta.get_file_metadata("/docs/arch.md", MD_STRUCTURE_KEY)
+        assert raw is not None
+        data = json.loads(raw)
+        assert data["version"] == 1
+        assert len(data["sections"]) >= 3
+        assert data["content_hash"] == "hash1"
+
+    def test_skips_non_md_files(
+        self, hook: MarkdownStructureWriteHook, meta: _StubMetastore
+    ) -> None:
+        ctx = _make_write_ctx("/data/file.txt", b"# Heading\nContent")
+        hook.on_post_write(ctx)
+        assert meta.get_file_metadata("/data/file.txt", MD_STRUCTURE_KEY) is None
+
+    def test_updates_on_rewrite(
+        self, hook: MarkdownStructureWriteHook, meta: _StubMetastore
+    ) -> None:
+        ctx1 = _make_write_ctx("/doc.md", b"# V1\nFirst version.\n", content_hash="v1")
+        hook.on_post_write(ctx1)
+
+        ctx2 = _make_write_ctx("/doc.md", b"# V2\nSecond version.\n## New\n", content_hash="v2")
+        hook.on_post_write(ctx2)
+
+        data = json.loads(meta.get_file_metadata("/doc.md", MD_STRUCTURE_KEY))
+        assert data["content_hash"] == "v2"
+        headings = [s["heading"] for s in data["sections"]]
+        assert "V2" in headings
+        assert "New" in headings
+
+    def test_handles_empty_content(
+        self, hook: MarkdownStructureWriteHook, meta: _StubMetastore
+    ) -> None:
+        ctx = _make_write_ctx("/empty.md", b"")
+        hook.on_post_write(ctx)
+        raw = meta.get_file_metadata("/empty.md", MD_STRUCTURE_KEY)
+        assert raw is not None
+        data = json.loads(raw)
+        assert len(data["sections"]) == 0
+
+    def test_no_metadata_no_crash(self) -> None:
+        """Hook with no metastore should silently skip."""
+        hook = MarkdownStructureWriteHook(metadata=None)
+        ctx = _make_write_ctx("/doc.md", SAMPLE_MD)
+        hook.on_post_write(ctx)  # should not raise
+
+    def test_hook_spec(self, hook: MarkdownStructureWriteHook) -> None:
+        spec = hook.hook_spec()
+        assert len(spec.write_hooks) == 1
+        assert spec.write_hooks[0] is hook
+
+    def test_hook_name(self, hook: MarkdownStructureWriteHook) -> None:
+        assert hook.name == "md_structure"
+
+
+# ---------------------------------------------------------------------------
+# Read path tests
+# ---------------------------------------------------------------------------
+
+
+class TestReadPath:
+    def test_get_index_after_write(self, hook: MarkdownStructureWriteHook) -> None:
+        ctx = _make_write_ctx("/doc.md", SAMPLE_MD, content_hash="h1")
+        hook.on_post_write(ctx)
+
+        index = hook.get_index("/doc.md", current_hash="h1")
+        assert index is not None
+        assert len(index.sections) >= 3
+
+    def test_stale_index_triggers_reparse(self, hook: MarkdownStructureWriteHook) -> None:
+        """If content_hash doesn't match, re-parse with provided content."""
+        ctx = _make_write_ctx("/doc.md", b"# Old\nOld content.\n", content_hash="old_hash")
+        hook.on_post_write(ctx)
+
+        new_content = b"# New\nNew content.\n## Added\n"
+        index = hook.get_index("/doc.md", current_content=new_content, current_hash="new_hash")
+        assert index is not None
+        assert index.content_hash == "new_hash"
+        headings = [s.heading for s in index.sections]
+        assert "New" in headings
+        assert "Added" in headings
+
+    def test_stale_index_without_content_returns_stale(
+        self, hook: MarkdownStructureWriteHook
+    ) -> None:
+        """If hash mismatches but no content provided, return stale index."""
+        ctx = _make_write_ctx("/doc.md", b"# Old\n", content_hash="old")
+        hook.on_post_write(ctx)
+
+        index = hook.get_index("/doc.md", current_hash="new")
+        assert index is not None  # Returns stale index rather than None
+        assert index.content_hash == "old"
+
+    def test_no_index_with_content_parses_on_demand(self, hook: MarkdownStructureWriteHook) -> None:
+        """No stored index but content provided → parse on demand."""
+        content = b"# OnDemand\nParsed on the fly.\n"
+        index = hook.get_index("/new.md", current_content=content, current_hash="fresh")
+        assert index is not None
+        assert index.sections[0].heading == "OnDemand"
+
+    def test_no_index_no_content_returns_none(self, hook: MarkdownStructureWriteHook) -> None:
+        assert hook.get_index("/nonexistent.md") is None
+
+    def test_corrupt_index_discarded(
+        self, hook: MarkdownStructureWriteHook, meta: _StubMetastore
+    ) -> None:
+        """Corrupt JSON in metadata should not crash."""
+        meta.set_file_metadata("/doc.md", MD_STRUCTURE_KEY, "not valid json{{{")
+        index = hook.get_index("/doc.md")
+        assert index is None
+
+
+# ---------------------------------------------------------------------------
+# Section read tests
+# ---------------------------------------------------------------------------
+
+
+class TestSectionRead:
+    def _setup(self, hook: MarkdownStructureWriteHook) -> None:
+        ctx = _make_write_ctx("/doc.md", SAMPLE_MD, content_hash="h1")
+        hook.on_post_write(ctx)
+
+    def test_read_section(self, hook: MarkdownStructureWriteHook) -> None:
+        self._setup(hook)
+        result = hook.read_section("/doc.md", SAMPLE_MD, "h1", "Authentication")
+        assert result is not None
+        assert "verify" in result
+        assert "## API" not in result
+
+    def test_read_section_with_block_type(self, hook: MarkdownStructureWriteHook) -> None:
+        self._setup(hook)
+        result = hook.read_section("/doc.md", SAMPLE_MD, "h1", "Authentication", block_type="code")
+        assert result is not None
+        assert "verify" in result
+        # Should only contain the code block, not the heading text
+        assert "## Authentication" not in result
+
+    def test_read_section_not_found(self, hook: MarkdownStructureWriteHook) -> None:
+        self._setup(hook)
+        result = hook.read_section("/doc.md", SAMPLE_MD, "h1", "Nonexistent")
+        assert result is None
+
+    def test_read_section_block_type_not_found(self, hook: MarkdownStructureWriteHook) -> None:
+        self._setup(hook)
+        # API section has a table but no code blocks
+        result = hook.read_section("/doc.md", SAMPLE_MD, "h1", "API", block_type="code")
+        assert result is None
+
+    def test_read_section_star_returns_listing(self, hook: MarkdownStructureWriteHook) -> None:
+        """section='*' returns structure listing as JSON."""
+        self._setup(hook)
+        result = hook.read_section("/doc.md", SAMPLE_MD, "h1", "*")
+        assert result is not None
+        listing = json.loads(result)
+        assert isinstance(listing, list)
+        # Should have frontmatter + sections
+        types = {e["type"] for e in listing}
+        assert "frontmatter" in types
+        assert "section" in types
+
+    def test_read_section_frontmatter(self, hook: MarkdownStructureWriteHook) -> None:
+        """section='frontmatter' returns the frontmatter block."""
+        self._setup(hook)
+        result = hook.read_section("/doc.md", SAMPLE_MD, "h1", "frontmatter")
+        assert result is not None
+        assert "title" in result
+        assert "Architecture" in result
+
+    def test_read_section_frontmatter_missing(self, hook: MarkdownStructureWriteHook) -> None:
+        """section='frontmatter' on a doc without frontmatter returns None."""
+        no_fm = b"# Heading\nContent.\n"
+        ctx = _make_write_ctx("/nofm.md", no_fm, content_hash="h2")
+        hook.on_post_write(ctx)
+        result = hook.read_section("/nofm.md", no_fm, "h2", "frontmatter")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# Structure listing tests
+# ---------------------------------------------------------------------------
+
+
+class TestStructureListing:
+    def test_listing_format(self, hook: MarkdownStructureWriteHook) -> None:
+        ctx = _make_write_ctx("/doc.md", SAMPLE_MD, content_hash="h1")
+        hook.on_post_write(ctx)
+
+        listing = hook.get_structure_listing("/doc.md")
+        assert listing is not None
+        assert len(listing) >= 1
+
+        # Should have frontmatter entry
+        fm_entries = [e for e in listing if e["type"] == "frontmatter"]
+        assert len(fm_entries) == 1
+        assert "title" in fm_entries[0]["keys"]
+
+        # Should have section entries
+        sec_entries = [e for e in listing if e["type"] == "section"]
+        assert len(sec_entries) >= 3
+
+        # Each section entry has required fields
+        for entry in sec_entries:
+            assert "heading" in entry
+            assert "depth" in entry
+            assert "tokens_est" in entry
+            assert "blocks" in entry
+
+    def test_listing_no_index(self, hook: MarkdownStructureWriteHook) -> None:
+        assert hook.get_structure_listing("/nonexistent.md") is None

--- a/tests/unit/bricks/parsers/test_md_structure_hook.py
+++ b/tests/unit/bricks/parsers/test_md_structure_hook.py
@@ -128,10 +128,9 @@ class TestWriteHook:
     ) -> None:
         ctx = _make_write_ctx("/empty.md", b"")
         hook.on_post_write(ctx)
+        # Empty content is skipped to prevent poisoning the cache
         raw = meta.get_file_metadata("/empty.md", MD_STRUCTURE_KEY)
-        assert raw is not None
-        data = json.loads(raw)
-        assert len(data["sections"]) == 0
+        assert raw is None
 
     def test_no_metadata_no_crash(self) -> None:
         """Hook with no metastore should silently skip."""


### PR DESCRIPTION
## Summary

- Parse markdown structure on `.md` write using `markdown-it-pyrs` (Rust, ~5-7x faster) with automatic `markdown-it-py` (Python) fallback
- Store hierarchical section index as sidecar metadata (`md_structure` key) for O(1) partial reads by section and block type
- Add structure-listing endpoints and partial-read params across MCP, REST, and CLI surfaces
- Fix ReBAC permission enforcement on all new structure-listing endpoints
- No cross-brick imports — all surface code accesses the hook via service registry

### Surfaces

| Surface | Feature | Example |
|---------|---------|---------|
| MCP | `nexus_md_structure` tool | Structure listing (zero content tokens) |
| MCP | `nexus_read_file(section=, block_type=)` | `section="Auth"`, `block_type="code"` |
| MCP | `section="*"` / `section="frontmatter"` | Structure listing / frontmatter only |
| REST | `GET /md-structure?path=...` | Structure listing endpoint |
| REST | `GET /read?section=Auth&block_type=code` | Partial read query params |
| CLI | `nexus cat --section Auth --block-type code` | Section + block filter flags |
| CLI | `nexus cat path.md#section` | Fragment syntax |

### Performance (realistic docs, Rust parser)

| Size | Sections | Parse time |
|------|----------|-----------|
| 5KB | 10 | 0.3ms |
| 50KB | 93 | 3.0ms |
| 200KB | 364 | 16.7ms |

### Architecture decisions

- **Rust fast path**: `markdown-it-pyrs` (10x raw parser speedup, ~5-7x end-to-end) with Python fallback
- **Synchronous write hook**: Sub-ms for typical files, no threading complexity needed
- **Lazy hash validation**: Read path compares stored `content_hash` vs current etag; re-parses inline on mismatch (self-healing)
- **ReBAC enforced**: Both structure endpoints gate on `sys_read()`/`fs.access()` before exposing metadata
- **Service registry**: MCP/REST/CLI access the hook via `nx.service("md_structure")` — zero cross-brick imports

Closes #3718

## Test plan

- [x] 37 unit tests — parser correctness (code fences, setext, CJK byte offsets, frontmatter, edge cases)
- [x] 22 unit tests — hook integration (write→store→read round trip, stale detection, section read, structure listing)
- [x] 23 E2E tests — MCP tools against real NexusFS + CASLocalBackend (write→index→read, edge cases, CJK, stale index)
- [x] 9 existing parser tests — no regressions in `extract_structure()` / `create_chunks()` wrappers
- [x] 12 live stack tests — `nexus up --build`, REST curl, CLI `--section`/`--block-type`/fragment syntax against running server
- [x] All pre-commit hooks pass (ruff, mypy, brick-import-check)