### PR TITLE
fix(ci): gate E2E tests on gRPC readiness

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -135,13 +135,13 @@ jobs:
               docker logs nexus-e2e 2>&1 | tail -200 || true
               exit 1
             fi
-            if curl -sf http://localhost:2026/health > /dev/null 2>&1; then
+            if curl -sf http://localhost:2026/healthz/ready > /dev/null 2>&1; then
               echo "Nexus is ready (${i}s)"
               break
             fi
             sleep 1
           done
-          if ! curl -sf http://localhost:2026/health > /dev/null 2>&1; then
+          if ! curl -sf http://localhost:2026/healthz/ready > /dev/null 2>&1; then
             echo "::error::nexus-e2e never became healthy within 90 seconds"
             docker inspect nexus-e2e --format 'exit_code={{.State.ExitCode}} status={{.State.Status}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}} started_at={{.State.StartedAt}} finished_at={{.State.FinishedAt}} error={{json .State.Error}}' || true
             echo "Crash signatures from container logs:"

--- a/src/nexus/grpc/server.py
+++ b/src/nexus/grpc/server.py
@@ -51,15 +51,26 @@ def _resolve_tls_config(app: "FastAPI") -> "ZoneTlsConfig | None":
     return None
 
 
+def _mark_grpc_done(app: "FastAPI") -> None:
+    """Mark the GRPC startup phase complete on the startup tracker."""
+    from nexus.server.health.startup_tracker import StartupPhase
+
+    tracker = getattr(app.state, "startup_tracker", None)
+    if tracker is not None:
+        tracker.complete(StartupPhase.GRPC)
+
+
 async def startup_grpc(app: "FastAPI", _svc: "LifespanServices") -> list[asyncio.Task]:
     """Start the gRPC server if configured."""
     port = int(os.environ.get("NEXUS_GRPC_PORT", "2028"))
     if not port:
+        _mark_grpc_done(app)  # intentionally disabled
         return []
 
     nexus_fs = getattr(app.state, "nexus_fs", None)
     if nexus_fs is None:
         logger.warning("gRPC disabled: no nexus_fs on app.state")
+        _mark_grpc_done(app)  # not applicable for this deployment
         return []
 
     exposed_methods = getattr(app.state, "exposed_methods", {})
@@ -129,6 +140,7 @@ async def startup_grpc(app: "FastAPI", _svc: "LifespanServices") -> list[asyncio
     await server.start()
 
     app.state.grpc_server = server
+    _mark_grpc_done(app)  # gRPC listener is up
 
     # Enlist gRPC server (Q1 — infrastructure, manual start/stop)
     coord = getattr(_svc, "service_coordinator", None)

--- a/src/nexus/server/health/startup_tracker.py
+++ b/src/nexus/server/health/startup_tracker.py
@@ -40,6 +40,7 @@ _REQUIRED_FOR_READY: frozenset[StartupPhase] = frozenset(
         StartupPhase.FEATURES,
         StartupPhase.PERMISSIONS,
         StartupPhase.SERVICES,
+        StartupPhase.GRPC,
     }
 )
 

--- a/src/nexus/server/lifespan/__init__.py
+++ b/src/nexus/server/lifespan/__init__.py
@@ -200,7 +200,8 @@ async def lifespan(app: "FastAPI") -> AsyncIterator[None]:
     _done(StartupPhase.IPC)
 
     bg_tasks.extend(await startup_grpc(app, svc))
-    _done(StartupPhase.GRPC)
+    # StartupPhase.GRPC is marked by startup_grpc() itself — only after
+    # the listener is confirmed up (or gRPC is intentionally disabled).
 
     # Wire QueryObserverComponent into registry after services start (Issue #2072)
     _wire_query_observer(app, svc)


### PR DESCRIPTION
## Summary

- **Root cause**: CI health-check loop polled `/health` (always-200 liveness probe) instead of `/healthz/ready` (readiness probe). gRPC is the last lifespan phase, so there was a race window where HTTP was up but port 2029 was not yet bound — causing `UNAVAILABLE: failed to connect to all addresses` at the `edit` RPC call.
- Add `StartupPhase.GRPC` to `_REQUIRED_FOR_READY` so `/healthz/ready` blocks until gRPC is listening
- Switch CI wait-loop from `/health` to `/healthz/ready`

Fixes the failure in https://github.com/nexi-lab/nexus/actions/runs/24318791535/job/71006019379

## Test plan

- [x] Unit tests pass (`test_startup_tracker.py` — 7/7)
- [ ] CI E2E edge smoke tests pass on this branch