### PR TITLE
fix(ci): disable gRPC TLS in E2E smoke tests

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -118,6 +118,7 @@ jobs:
             -e NEXUS_HOST=0.0.0.0 \
             -e NEXUS_PORT=2026 \
             -e NEXUS_GRPC_PORT=2029 \
+            -e NEXUS_GRPC_TLS=false \
             -e NEXUS_PROFILE=full \
             -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libgomp.so.1 \
             -v /tmp/nexus-data:/app/data \


### PR DESCRIPTION
## Summary

- The gRPC server auto-detects TLS certs in `/app/data/tls/` (generated during bootstrap) and binds with mTLS. The E2E test client uses an insecure channel, causing SSL handshake failures: `WRONG_VERSION_NUMBER`
- Set `NEXUS_GRPC_TLS=false` in the CI container so the gRPC server binds insecure, matching the test client

Fixes https://github.com/nexi-lab/nexus/actions/runs/24349458982/job/71117776765

Follow-up to #3750 which fixed the readiness race but didn't address the TLS mismatch.

## Test plan

- [ ] CI E2E edge smoke tests pass (gRPC edit call succeeds)