### PR TITLE
fix(grpc): make NEXUS_GRPC_TLS an override, preserve data-dir fallback

### DIFF
--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -284,16 +284,17 @@ async def connect(
         # Single shared RPCTransport (gRPC channel) for all remote proxies.
         from nexus.remote.rpc_transport import RPCTransport
 
-        # TLS: only use TLS when explicitly requested via:
-        #   1. NEXUS_DATA_DIR env var (2-phase bootstrap)
-        #   2. nexus.yaml tls: true (written by `nexus up` when server uses mTLS)
-        # Do NOT auto-discover from data_dir/tls/ alone — the server may
-        # generate certs but run gRPC insecure (new default on develop).
+        # TLS: NEXUS_GRPC_TLS env var overrides all other TLS signals.
+        #   true  → force TLS
+        #   false → force insecure
+        #   unset → fall back to nexus.yaml tls / NEXUS_DATA_DIR auto-detect
         _tls_config = None
-        _tls_enabled = False
+        _grpc_tls_env = os.getenv("NEXUS_GRPC_TLS", "").lower()
+        _tls_enabled = _grpc_tls_env in ("true", "1", "yes")
+        _tls_disabled = _grpc_tls_env in ("false", "0", "no")
         _data_dir = os.getenv("NEXUS_DATA_DIR")
-        if _data_dir:
-            _tls_enabled = True  # Explicit env var = TLS intended
+        if _data_dir and not _tls_disabled:
+            _tls_enabled = True  # Auto-detect from NEXUS_DATA_DIR (backward compat)
         if not _data_dir:
             _project_yaml = Path("nexus.yaml")
             if _project_yaml.exists():
@@ -303,7 +304,9 @@ async def connect(
                     with open(_project_yaml) as _f:
                         _project_cfg = _yaml.safe_load(_f) or {}
                     _data_dir = _project_cfg.get("data_dir")
-                    _tls_enabled = bool(_project_cfg.get("tls"))
+                    # nexus.yaml tls: only used when env var is unset
+                    if not _grpc_tls_env:
+                        _tls_enabled = bool(_project_cfg.get("tls"))
                 except Exception:
                     pass
         if not _data_dir:
@@ -313,6 +316,14 @@ async def connect(
             from nexus.security.tls.config import ZoneTlsConfig
 
             _tls_config = ZoneTlsConfig.from_data_dir(_data_dir)
+
+        # Fail closed: NEXUS_GRPC_TLS=true but no certs resolved
+        _tls_explicit = _grpc_tls_env in ("true", "1", "yes")
+        if _tls_explicit and _tls_config is None:
+            raise RuntimeError(
+                "NEXUS_GRPC_TLS=true but no TLS certificates found. "
+                "Provide certs in {data_dir}/tls/ or set data_dir in nexus.yaml."
+            )
 
         transport = RPCTransport(
             server_address=grpc_address,

--- a/src/nexus/cli/commands/admin.py
+++ b/src/nexus/cli/commands/admin.py
@@ -95,14 +95,25 @@ def get_admin_rpc(url: str | None, api_key: str | None) -> AdminRPC:
     grpc_address = f"{parsed.hostname}:{grpc_port}"
 
     tls_config = None
-    if tls.get("cert") or os.environ.get("NEXUS_TLS_CERT"):
+    _grpc_tls_env = os.environ.get("NEXUS_GRPC_TLS", "").lower()
+    _grpc_tls_off = _grpc_tls_env in ("false", "0", "no")
+    _grpc_tls_on = _grpc_tls_env in ("true", "1", "yes")
+
+    # NEXUS_GRPC_TLS takes precedence over stale env vars / state
+    if _grpc_tls_off:
+        pass  # force insecure — ignore NEXUS_TLS_* and state.json certs
+    elif tls.get("cert") or os.environ.get("NEXUS_TLS_CERT"):
         tls_config = ZoneTlsConfig.from_env()
     elif data_dir:
-        # Auto-detect TLS from data dir (Docker containers where NEXUS_DATA_DIR
-        # is set but no nexus.yaml/.state.json exists — e.g. inside the server
-        # container itself where TLS certs live in {data_dir}/tls/).
         with contextlib.suppress(Exception):
             tls_config = ZoneTlsConfig.from_data_dir(data_dir)
+
+    # Fail closed: explicit true but no certs resolved
+    if _grpc_tls_on and tls_config is None:
+        raise click.ClickException(
+            "NEXUS_GRPC_TLS=true but no TLS certificates found. "
+            "Provide certs in {data_dir}/tls/ or configure TLS in state.json."
+        )
     transport = RPCTransport(server_address=grpc_address, auth_token=api_key, tls_config=tls_config)
     return transport.call_rpc
 

--- a/src/nexus/grpc/server.py
+++ b/src/nexus/grpc/server.py
@@ -25,28 +25,45 @@ def _resolve_tls_config(app: "FastAPI") -> "ZoneTlsConfig | None":
     """Resolve TLS config from ZoneManager or auto-detection.
 
     Priority:
-    0. NEXUS_GRPC_TLS=false → disable TLS (for standalone Docker / dev)
-    1. ZoneManager.tls_config (provisioned by 2-phase TLS bootstrap)
-    2. Auto-detect from {NEXUS_DATA_DIR}/tls/
-    3. None → insecure (no certs available)
+    1. NEXUS_GRPC_TLS=false → disable TLS unconditionally
+    2. ZoneManager.tls_config (Raft / federation)
+    3. Auto-detect from {NEXUS_DATA_DIR}/tls/
+    4. NEXUS_GRPC_TLS=true but no certs → raise (fail closed)
+    5. None → insecure (no certs, no explicit request)
+
+    NEXUS_GRPC_TLS=false is an unconditional override (step 1).
+    NEXUS_GRPC_TLS=true ensures TLS is required — if no certs are
+    found after steps 2-3, startup fails rather than falling back
+    to insecure.  When unset, existing behavior is preserved.
     """
-    # 0. Explicit disable via env var (standalone / dev mode)
-    if os.environ.get("NEXUS_GRPC_TLS", "").lower() in ("false", "0", "no"):
+    grpc_tls = os.environ.get("NEXUS_GRPC_TLS", "").lower()
+
+    # 1. Explicit disable — takes precedence over everything
+    if grpc_tls in ("false", "0", "no"):
         return None
 
     from nexus.security.tls.config import ZoneTlsConfig
 
-    # 1. ZoneManager (if running federation / Raft)
+    # 2. ZoneManager (federation / Raft)
     zone_mgr = getattr(app.state, "zone_manager", None)
     if zone_mgr is not None:
         tls_cfg: ZoneTlsConfig | None = getattr(zone_mgr, "tls_config", None)
         if tls_cfg is not None:
             return tls_cfg
 
-    # 2. Auto-detect from NEXUS_DATA_DIR
+    # 3. Load from NEXUS_DATA_DIR/tls/
     data_dir = os.environ.get("NEXUS_DATA_DIR")
     if data_dir:
-        return ZoneTlsConfig.from_data_dir(data_dir)
+        cfg = ZoneTlsConfig.from_data_dir(data_dir)
+        if cfg is not None:
+            return cfg
+
+    # 4. Explicit enable requested but no certs found — fail closed
+    if grpc_tls in ("true", "1", "yes"):
+        raise RuntimeError(
+            "NEXUS_GRPC_TLS=true but no TLS certificates found. "
+            "Provide certs in {NEXUS_DATA_DIR}/tls/ or configure ZoneManager."
+        )
 
     return None
 


### PR DESCRIPTION
## Summary

Fixes CI E2E gRPC failures (`WRONG_VERSION_NUMBER`) while preserving backward compat.

**Problem**: `NEXUS_DATA_DIR=/app/data` is baked into every Dockerfile. Server auto-generates TLS certs during startup, then both server and client auto-detect them → mTLS enabled even though the E2E test expects insecure gRPC.

**Fix**: `NEXUS_GRPC_TLS` is now a two-way **override** with env precedence:
| `NEXUS_GRPC_TLS` | Behavior |
|---|---|
| `true` | Force TLS (env wins over `nexus.yaml`) |
| `false` | Force insecure (suppresses data-dir auto-detect) |
| unset | Existing behavior — auto-detect from data dir / `nexus.yaml` |

Applied consistently across all three code paths:
- **Server** (`grpc/server.py`): override → ZoneManager → data-dir fallback → insecure
- **Client** (`__init__.py`): override → `NEXUS_DATA_DIR` → `nexus.yaml` → insecure
- **CLI** (`admin.py`): explicit certs → override → data-dir fallback → insecure

Also fixes env precedence bug where `nexus.yaml tls:` could silently overwrite `NEXUS_GRPC_TLS`.

CI sets `NEXUS_GRPC_TLS=false` in the Docker container to suppress auto-detect.

Follow-up to #3750 and #3751.

## Test plan

- [x] Unit tests pass (87/87 — health, gRPC, stack)
- [x] Env precedence verified: all 5 combinations correct
- [ ] CI E2E edge smoke tests pass