### PR TITLE
feat(#3719): section-aware markdown chunking with heading context prepend

### DIFF
--- a/src/nexus/bricks/search/chunking.py
+++ b/src/nexus/bricks/search/chunking.py
@@ -220,13 +220,17 @@ def _parse_headings_fence_aware(content: str) -> list[_HeadingInfo]:
 
     # Detect YAML frontmatter range to exclude from setext detection.
     # Frontmatter `---` / `key: value` / `---` looks like setext H2.
+    # Require at least one YAML key: value line to avoid thematic breaks.
     fm_end = 0
     stripped = content.lstrip()
     leading_ws = len(content) - len(stripped)
     if stripped.startswith("---"):
         close = stripped.find("\n---", 3)
         if close != -1:
-            fm_end = leading_ws + close + 4
+            fm_body = stripped[4:close]
+            has_yaml = any(":" in line for line in fm_body.split("\n") if line.strip())
+            if has_yaml:
+                fm_end = leading_ws + close + 4
             if fm_end < len(content) and content[fm_end] == "\n":
                 fm_end += 1
 
@@ -953,28 +957,34 @@ class DocumentChunker:
         # ── Build raw segments from heading positions ────────────────
         segments: list[_MdSegment] = []
 
-        # Detect YAML frontmatter (--- ... ---)
+        # Detect YAML frontmatter (--- ... ---).
+        # Validates that the block contains YAML-like content (at least
+        # one "key:" line) to avoid false positives on thematic breaks.
         fm_end_offset = 0
         stripped = content.lstrip()
         leading_ws = len(content) - len(stripped)
         if stripped.startswith("---"):
             close = stripped.find("\n---", 3)
             if close != -1:
-                fm_end_offset = leading_ws + close + 4  # past closing ---
-                # Skip trailing newline after closing ---
-                if fm_end_offset < len(content) and content[fm_end_offset] == "\n":
-                    fm_end_offset += 1
-                fm_text = content[:fm_end_offset].strip()
-                if fm_text:
-                    segments.append(
-                        _MdSegment(
-                            text=fm_text,
-                            char_start=0,
-                            char_end=fm_end_offset,
-                            heading_prefix=f"[{file_name} > frontmatter]",
-                            tokens=self._count_tokens(fm_text),
+                fm_body = stripped[4:close]  # content between --- markers
+                # Require at least one YAML key: value line
+                has_yaml = any(":" in line for line in fm_body.split("\n") if line.strip())
+                if has_yaml:
+                    fm_end_offset = leading_ws + close + 4  # past closing ---
+                    # Skip trailing newline after closing ---
+                    if fm_end_offset < len(content) and content[fm_end_offset] == "\n":
+                        fm_end_offset += 1
+                    fm_text = content[:fm_end_offset].strip()
+                    if fm_text:
+                        segments.append(
+                            _MdSegment(
+                                text=fm_text,
+                                char_start=0,
+                                char_end=fm_end_offset,
+                                heading_prefix=f"[{file_name} > frontmatter]",
+                                tokens=self._count_tokens(fm_text),
+                            )
                         )
-                    )
 
         # Preamble (content between frontmatter end and first heading)
         first_heading_offset = headings[0].char_offset

--- a/src/nexus/bricks/search/chunking.py
+++ b/src/nexus/bricks/search/chunking.py
@@ -182,21 +182,19 @@ def _parse_headings_fence_aware(content: str) -> list[_HeadingInfo]:
     """
     # Build set of fenced ranges
     fenced: list[tuple[int, int]] = []
-    fence_stack: list[tuple[str, int]] = []  # (fence_char, start_offset)
+    fence_stack: list[tuple[str, int]] = []  # (opener_marker, start_offset)
     for m in _FENCE_RE.finditer(content):
         marker = m.group(1)
         fence_char = marker[0]  # ` or ~
         fence_len = len(marker)
-        if (
-            fence_stack
-            and fence_stack[-1][0] == fence_char
-            and fence_len >= len(fence_stack[-1][0])
-        ):
-            # Close the fence
-            start = fence_stack.pop()[1]
-            fenced.append((start, m.end()))
-        else:
-            fence_stack.append((marker, m.start()))
+        if fence_stack:
+            opener_marker = fence_stack[-1][0]
+            # Close: same fence char and at least as many chars as opener
+            if opener_marker[0] == fence_char and fence_len >= len(opener_marker):
+                start = fence_stack.pop()[1]
+                fenced.append((start, m.end()))
+                continue
+        fence_stack.append((marker, m.start()))
     # Unclosed fences: treat everything from opener to EOF as fenced
     for _marker, start in fence_stack:
         fenced.append((start, len(content)))
@@ -214,9 +212,24 @@ def _parse_headings_fence_aware(content: str) -> list[_HeadingInfo]:
         text = m.group(2).strip()
         headings.append(_HeadingInfo(heading=text, depth=depth, char_offset=m.start()))
 
+    # Detect YAML frontmatter range to exclude from setext detection.
+    # Frontmatter `---` / `key: value` / `---` looks like setext H2.
+    fm_end = 0
+    stripped = content.lstrip()
+    leading_ws = len(content) - len(stripped)
+    if stripped.startswith("---"):
+        close = stripped.find("\n---", 3)
+        if close != -1:
+            fm_end = leading_ws + close + 4
+            if fm_end < len(content) and content[fm_end] == "\n":
+                fm_end += 1
+
     # Setext headings (underline with === or ---)
     for m in _SETEXT_RE.finditer(content):
         if _is_fenced(m.start()):
+            continue
+        # Skip matches inside frontmatter
+        if m.start() < fm_end:
             continue
         text = m.group(1).strip()
         # Skip if the text line looks like a YAML frontmatter delimiter

--- a/src/nexus/bricks/search/chunking.py
+++ b/src/nexus/bricks/search/chunking.py
@@ -153,6 +153,8 @@ def _compute_line_numbers_fast(
 
 # Minimum tokens for a standalone chunk; smaller sections merge with siblings.
 _MIN_CHUNK_TOKENS = 80
+# Maximum characters for a heading prefix to prevent oversized embedding inputs.
+_MAX_HEADING_PREFIX_CHARS = 200
 
 # Regex for ATX headings (# through ######), allowing up to 3 leading spaces (CommonMark)
 _HEADING_RE = re.compile(r"^ {0,3}(#{1,6})\s+(.*?)$", re.MULTILINE)
@@ -180,24 +182,28 @@ def _parse_headings_fence_aware(content: str) -> list[_HeadingInfo]:
     Returns:
         List of headings in document order.
     """
-    # Build set of fenced ranges
+    # Build set of fenced ranges using a flat state machine.
+    # CommonMark: a code fence is closed only by a fence line with the
+    # same character and >= the opener length.  Shorter fence-like lines
+    # inside an open fence are just literal content (no nesting).
     fenced: list[tuple[int, int]] = []
-    fence_stack: list[tuple[str, int]] = []  # (opener_marker, start_offset)
+    active_fence: tuple[str, int, int] | None = None  # (char, length, start_offset)
     for m in _FENCE_RE.finditer(content):
         marker = m.group(1)
-        fence_char = marker[0]  # ` or ~
+        fence_char = marker[0]
         fence_len = len(marker)
-        if fence_stack:
-            opener_marker = fence_stack[-1][0]
-            # Close: same fence char and at least as many chars as opener
-            if opener_marker[0] == fence_char and fence_len >= len(opener_marker):
-                start = fence_stack.pop()[1]
-                fenced.append((start, m.end()))
-                continue
-        fence_stack.append((marker, m.start()))
-    # Unclosed fences: treat everything from opener to EOF as fenced
-    for _marker, start in fence_stack:
-        fenced.append((start, len(content)))
+        if active_fence is not None:
+            # Inside a fence — only close if same char and >= length
+            if fence_char == active_fence[0] and fence_len >= active_fence[1]:
+                fenced.append((active_fence[2], m.end()))
+                active_fence = None
+            # Otherwise: literal content inside the fence, ignore
+        else:
+            # Not inside a fence — this is an opener
+            active_fence = (fence_char, fence_len, m.start())
+    # Unclosed fence: treat opener to EOF as fenced
+    if active_fence is not None:
+        fenced.append((active_fence[2], len(content)))
 
     def _is_fenced(offset: int) -> bool:
         return any(s <= offset < e for s, e in fenced)
@@ -304,10 +310,15 @@ def build_heading_hierarchy(
     parents.reverse()
     parts = parents + [target.heading]
     path = " > ".join(parts)
+    result = f"[{file_name} > {path}]" if file_name else f"[{path}]"
 
-    if file_name:
-        return f"[{file_name} > {path}]"
-    return f"[{path}]"
+    # Truncate to prevent oversized embedding inputs.  Keep the
+    # file name and the deepest heading levels (most specific context).
+    if len(result) > _MAX_HEADING_PREFIX_CHARS:
+        tail = " > ".join(parts[-2:]) if len(parts) >= 2 else parts[-1]
+        result = f"[{file_name} > ... > {tail}]" if file_name else f"[... > {tail}]"
+
+    return result
 
 
 def _merge_small_segments(
@@ -1082,19 +1093,22 @@ class DocumentChunker:
         Fenced blocks up to 1.5× budget are emitted whole; larger blocks
         are sub-split as a last resort.
         """
-        # Find fenced ranges within this text
+        # Find fenced ranges within this text (flat state machine,
+        # same logic as _parse_headings_fence_aware).
         fenced_ranges: list[tuple[int, int]] = []
-        opener: tuple[str, int] | None = None
+        active: tuple[str, int, int] | None = None  # (char, length, start)
         for m in _FENCE_RE.finditer(text):
             marker = m.group(1)
-            if opener is None:
-                opener = (marker, m.start())
-            elif marker[0] == opener[0] and len(marker) >= len(opener[0]):
-                fenced_ranges.append((opener[1], m.end()))
-                opener = None
-        # Unclosed fence: extend to end of text
-        if opener is not None:
-            fenced_ranges.append((opener[1], len(text)))
+            fence_char = marker[0]
+            fence_len = len(marker)
+            if active is not None:
+                if fence_char == active[0] and fence_len >= active[1]:
+                    fenced_ranges.append((active[2], m.end()))
+                    active = None
+            else:
+                active = (fence_char, fence_len, m.start())
+        if active is not None:
+            fenced_ranges.append((active[2], len(text)))
 
         if not fenced_ranges:
             # No fences — safe to use generic splitter

--- a/src/nexus/bricks/search/chunking.py
+++ b/src/nexus/bricks/search/chunking.py
@@ -45,6 +45,7 @@ class ChunkStrategy(StrEnum):
     FIXED = "fixed"  # Fixed-size chunks
     SEMANTIC = "semantic"  # Semantic chunks (paragraphs/sections)
     OVERLAPPING = "overlapping"  # Overlapping fixed-size chunks
+    MARKDOWN_AWARE = "markdown_aware"  # Structure-aware markdown chunks (Issue #3719)
 
 
 @dataclass
@@ -58,6 +59,7 @@ class DocumentChunk:
     end_offset: int  # End character offset
     line_start: int | None = None  # Line number where chunk starts (1-indexed)
     line_end: int | None = None  # Line number where chunk ends (1-indexed)
+    heading_prefix: str | None = None  # Heading hierarchy for embedding (Issue #3719)
 
 
 def _offset_to_line(content: str, offset: int) -> int:
@@ -143,6 +145,225 @@ def _compute_line_numbers_fast(
     line_start = _offset_to_line_fast(start_offset, line_offsets)
     line_end = _offset_to_line_fast(end_offset, line_offsets)
     return line_start, line_end
+
+
+# ---------------------------------------------------------------------------
+# Markdown-aware chunking helpers (Issue #3719)
+# ---------------------------------------------------------------------------
+
+# Minimum tokens for a standalone chunk; smaller sections merge with siblings.
+_MIN_CHUNK_TOKENS = 80
+
+# Regex for ATX headings (# through ######)
+_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)$", re.MULTILINE)
+# Regex for code fence openers/closers (``` or ~~~, 3+ chars)
+_FENCE_RE = re.compile(r"^(`{3,}|~{3,})", re.MULTILINE)
+
+
+@dataclass(slots=True)
+class _HeadingInfo:
+    """A heading found in markdown content (search-brick local)."""
+
+    heading: str
+    depth: int
+    char_offset: int  # character offset of the heading line
+
+
+def _parse_headings_fence_aware(content: str) -> list[_HeadingInfo]:
+    """Find ATX headings while ignoring those inside code fences.
+
+    Builds a set of fenced character ranges, then filters headings
+    that fall within them. Handles nested/mismatched fences gracefully.
+
+    Returns:
+        List of headings in document order.
+    """
+    # Build set of fenced ranges
+    fenced: list[tuple[int, int]] = []
+    fence_stack: list[tuple[str, int]] = []  # (fence_char, start_offset)
+    for m in _FENCE_RE.finditer(content):
+        marker = m.group(1)
+        fence_char = marker[0]  # ` or ~
+        fence_len = len(marker)
+        if (
+            fence_stack
+            and fence_stack[-1][0] == fence_char
+            and fence_len >= len(fence_stack[-1][0])
+        ):
+            # Close the fence
+            start = fence_stack.pop()[1]
+            fenced.append((start, m.end()))
+        else:
+            fence_stack.append((marker, m.start()))
+    # Unclosed fences: treat everything from opener to EOF as fenced
+    for _marker, start in fence_stack:
+        fenced.append((start, len(content)))
+
+    def _is_fenced(offset: int) -> bool:
+        return any(s <= offset < e for s, e in fenced)
+
+    headings: list[_HeadingInfo] = []
+    for m in _HEADING_RE.finditer(content):
+        if _is_fenced(m.start()):
+            continue
+        depth = len(m.group(1))
+        text = m.group(2).strip()
+        headings.append(_HeadingInfo(heading=text, depth=depth, char_offset=m.start()))
+
+    return headings
+
+
+@dataclass
+class _MdSegment:
+    """Internal segment for markdown-aware chunking."""
+
+    text: str
+    char_start: int
+    char_end: int
+    heading_prefix: str
+    tokens: int
+
+
+def _safe_line_char_offset(line_offsets: list[int], line_num: int, content_len: int) -> int:
+    """Get the character offset for a 0-indexed line number, clamped safely."""
+    if line_num >= len(line_offsets):
+        return content_len
+    return line_offsets[line_num]
+
+
+def _extract_file_name(file_path: str) -> str:
+    """Extract just the filename from a path."""
+    if "/" in file_path:
+        return file_path.rsplit("/", 1)[-1]
+    return file_path
+
+
+def build_heading_hierarchy(
+    sections: list[Any],
+    section_index: int,
+    file_name: str = "",
+) -> str:
+    """Build heading hierarchy prefix for embedding context.
+
+    Walks backward through sections to find parent headings,
+    building a path like ``[file.md > Auth > JWT Tokens]``.
+
+    Args:
+        sections: List of SectionInfo objects (from md_structure).
+        section_index: Index of the current section.
+        file_name: Filename to include at the start of the path.
+
+    Returns:
+        Bracket-notation heading path string.
+    """
+    if section_index < 0 or section_index >= len(sections):
+        return f"[{file_name}]" if file_name else ""
+
+    target = sections[section_index]
+    parents: list[str] = []
+    current_depth = target.depth
+
+    for i in range(section_index - 1, -1, -1):
+        if sections[i].depth < current_depth:
+            parents.append(sections[i].heading)
+            current_depth = sections[i].depth
+            if current_depth <= 1:
+                break
+
+    parents.reverse()
+    parts = parents + [target.heading]
+    path = " > ".join(parts)
+
+    if file_name:
+        return f"[{file_name} > {path}]"
+    return f"[{path}]"
+
+
+def _merge_small_segments(
+    segments: list[_MdSegment],
+    min_tokens: int = _MIN_CHUNK_TOKENS,
+    max_tokens: int = 1024,
+) -> list[_MdSegment]:
+    """Merge consecutive tiny segments using single-pass greedy algorithm.
+
+    Segments with fewer than *min_tokens* are accumulated and merged with
+    the next segment(s) until the accumulator exceeds *min_tokens* or
+    adding more would exceed *max_tokens*.
+
+    Args:
+        segments: Ordered list of segments.
+        min_tokens: Minimum token threshold for a standalone segment.
+        max_tokens: Maximum token budget for a merged segment.
+
+    Returns:
+        New list of segments with tiny segments merged.
+    """
+    if not segments:
+        return []
+
+    merged: list[_MdSegment] = []
+    acc_texts: list[str] = []
+    acc_start: int = 0
+    acc_end: int = 0
+    acc_prefix: str = ""
+    acc_tokens: int = 0
+
+    def _emit_accumulator() -> None:
+        if acc_texts:
+            merged.append(
+                _MdSegment(
+                    text="\n\n".join(acc_texts),
+                    char_start=acc_start,
+                    char_end=acc_end,
+                    heading_prefix=acc_prefix,
+                    tokens=acc_tokens,
+                )
+            )
+
+    for seg in segments:
+        if not acc_texts:
+            # Start new accumulator
+            acc_texts = [seg.text]
+            acc_start = seg.char_start
+            acc_end = seg.char_end
+            acc_prefix = seg.heading_prefix
+            acc_tokens = seg.tokens
+
+            # If segment is big enough on its own, emit immediately
+            if seg.tokens >= min_tokens:
+                _emit_accumulator()
+                acc_texts = []
+                acc_tokens = 0
+        else:
+            # Try to add to accumulator
+            combined = acc_tokens + seg.tokens
+            if combined <= max_tokens:
+                acc_texts.append(seg.text)
+                acc_end = seg.char_end
+                acc_tokens = combined
+
+                # If big enough now, emit
+                if acc_tokens >= min_tokens:
+                    _emit_accumulator()
+                    acc_texts = []
+                    acc_tokens = 0
+            else:
+                # Would exceed budget — emit accumulator, start fresh
+                _emit_accumulator()
+                acc_texts = [seg.text]
+                acc_start = seg.char_start
+                acc_end = seg.char_end
+                acc_prefix = seg.heading_prefix
+                acc_tokens = seg.tokens
+
+                if seg.tokens >= min_tokens:
+                    _emit_accumulator()
+                    acc_texts = []
+                    acc_tokens = 0
+
+    # Emit any remaining
+    _emit_accumulator()
+    return merged
 
 
 class DocumentChunker:
@@ -267,6 +488,8 @@ class DocumentChunker:
             chunks = self._chunk_semantic(content, file_path)
         elif self.strategy == ChunkStrategy.OVERLAPPING:
             chunks = self._chunk_overlapping(content)
+        elif self.strategy == ChunkStrategy.MARKDOWN_AWARE:
+            chunks = self._chunk_markdown_aware(content, file_path)
         else:
             raise ValueError(f"Unknown chunking strategy: {self.strategy}")
 
@@ -652,6 +875,153 @@ class DocumentChunker:
             # Move forward by step_size
             i += step_size
             current_offset += len(" ".join(words[i - step_size : i])) + 1
+
+        return chunks
+
+    def _chunk_markdown_aware(self, content: str, file_path: str) -> list[DocumentChunk]:
+        """Chunk markdown using structural index with heading context prepend.
+
+        Issue #3719: Uses the md_structure parser for heading boundaries,
+        keeps code blocks and tables atomic, merges tiny sections, and
+        attaches heading hierarchy prefix for embedding enrichment.
+
+        Falls back to ``_chunk_semantic()`` for non-markdown files and to
+        ``_chunk_fixed()`` when the parser produces no sections.
+
+        Args:
+            content: Document content (string).
+            file_path: Path to the file.
+
+        Returns:
+            List of chunks with ``heading_prefix`` set.
+        """
+        # Non-markdown files: delegate to semantic strategy
+        if not file_path.endswith((".md", ".markdown")):
+            return self._chunk_semantic(content, file_path)
+
+        # Parse headings with code-fence awareness (no cross-brick import)
+        headings = _parse_headings_fence_aware(content)
+
+        # Fallback if no headings found
+        if not headings:
+            return self._chunk_fixed(content)
+
+        file_name = _extract_file_name(file_path)
+
+        # ── Build raw segments from heading positions ────────────────
+        segments: list[_MdSegment] = []
+
+        # Detect YAML frontmatter (--- ... ---)
+        fm_end_offset = 0
+        stripped = content.lstrip()
+        leading_ws = len(content) - len(stripped)
+        if stripped.startswith("---"):
+            close = stripped.find("\n---", 3)
+            if close != -1:
+                fm_end_offset = leading_ws + close + 4  # past closing ---
+                # Skip trailing newline after closing ---
+                if fm_end_offset < len(content) and content[fm_end_offset] == "\n":
+                    fm_end_offset += 1
+                fm_text = content[:fm_end_offset].strip()
+                if fm_text:
+                    segments.append(
+                        _MdSegment(
+                            text=fm_text,
+                            char_start=0,
+                            char_end=fm_end_offset,
+                            heading_prefix=f"[{file_name} > frontmatter]",
+                            tokens=self._count_tokens(fm_text),
+                        )
+                    )
+
+        # Preamble (content between frontmatter end and first heading)
+        first_heading_offset = headings[0].char_offset
+        preamble_text = content[fm_end_offset:first_heading_offset].strip()
+        if preamble_text:
+            segments.append(
+                _MdSegment(
+                    text=preamble_text,
+                    char_start=fm_end_offset,
+                    char_end=first_heading_offset,
+                    heading_prefix=f"[{file_name}]",
+                    tokens=self._count_tokens(preamble_text),
+                )
+            )
+
+        # Each heading → a segment (heading to next heading = non-overlapping)
+        for i, h in enumerate(headings):
+            sec_start = h.char_offset
+            sec_end = headings[i + 1].char_offset if i + 1 < len(headings) else len(content)
+            sec_text = content[sec_start:sec_end]
+            if not sec_text.strip():
+                continue
+
+            heading_prefix = build_heading_hierarchy(headings, i, file_name)
+            segments.append(
+                _MdSegment(
+                    text=sec_text,
+                    char_start=sec_start,
+                    char_end=sec_end,
+                    heading_prefix=heading_prefix,
+                    tokens=self._count_tokens(sec_text),
+                )
+            )
+
+        if not segments:
+            return self._chunk_fixed(content)
+
+        # ── Merge tiny segments (single-pass greedy, O(n)) ──────────
+        merged = _merge_small_segments(
+            segments,
+            min_tokens=_MIN_CHUNK_TOKENS,
+            max_tokens=self.chunk_size,
+        )
+
+        # ── Build final chunks, splitting oversized segments ────────
+        chunks: list[DocumentChunk] = []
+        for seg in merged:
+            prefix_tokens = (
+                self._count_tokens(seg.heading_prefix + " ") if seg.heading_prefix else 0
+            )
+            effective_budget = max(self.chunk_size - prefix_tokens, self.chunk_size // 2)
+
+            if seg.tokens <= effective_budget:
+                chunks.append(
+                    DocumentChunk(
+                        text=seg.text,
+                        chunk_index=len(chunks),
+                        tokens=seg.tokens,
+                        start_offset=seg.char_start,
+                        end_offset=seg.char_end,
+                        heading_prefix=seg.heading_prefix,
+                    )
+                )
+            else:
+                # Oversized section: sub-split with reduced budget
+                sub_chunker = DocumentChunker(
+                    chunk_size=effective_budget,
+                    overlap_size=self.overlap_size,
+                    strategy=ChunkStrategy.FIXED,
+                    encoding_name=self.encoding_name,
+                )
+                sub_chunker.encoding = self.encoding  # reuse cached encoding
+                sub_chunks = sub_chunker._chunk_fixed(seg.text)
+                for sc in sub_chunks:
+                    sc.start_offset += seg.char_start
+                    sc.end_offset += seg.char_start
+                    sc.heading_prefix = seg.heading_prefix
+                    chunks.append(sc)
+
+        # Renumber chunk indices
+        for i, chunk in enumerate(chunks):
+            chunk.chunk_index = i
+
+        logger.info(
+            "[MARKDOWN-AWARE] path=%s headings=%d chunks=%d",
+            file_path,
+            len(headings),
+            len(chunks),
+        )
 
         return chunks
 

--- a/src/nexus/bricks/search/chunking.py
+++ b/src/nexus/bricks/search/chunking.py
@@ -154,10 +154,12 @@ def _compute_line_numbers_fast(
 # Minimum tokens for a standalone chunk; smaller sections merge with siblings.
 _MIN_CHUNK_TOKENS = 80
 
-# Regex for ATX headings (# through ######)
-_HEADING_RE = re.compile(r"^(#{1,6})\s+(.*?)$", re.MULTILINE)
-# Regex for code fence openers/closers (``` or ~~~, 3+ chars)
-_FENCE_RE = re.compile(r"^(`{3,}|~{3,})", re.MULTILINE)
+# Regex for ATX headings (# through ######), allowing up to 3 leading spaces (CommonMark)
+_HEADING_RE = re.compile(r"^ {0,3}(#{1,6})\s+(.*?)$", re.MULTILINE)
+# Regex for setext headings: text line followed by === or --- underline
+_SETEXT_RE = re.compile(r"^([^\n]+)\n {0,3}(=+|-+)\s*$", re.MULTILINE)
+# Regex for code fence openers/closers (``` or ~~~, 3+ chars, up to 3 leading spaces)
+_FENCE_RE = re.compile(r"^ {0,3}(`{3,}|~{3,})", re.MULTILINE)
 
 
 @dataclass(slots=True)
@@ -203,12 +205,28 @@ def _parse_headings_fence_aware(content: str) -> list[_HeadingInfo]:
         return any(s <= offset < e for s, e in fenced)
 
     headings: list[_HeadingInfo] = []
+
+    # ATX headings (# through ######)
     for m in _HEADING_RE.finditer(content):
         if _is_fenced(m.start()):
             continue
         depth = len(m.group(1))
         text = m.group(2).strip()
         headings.append(_HeadingInfo(heading=text, depth=depth, char_offset=m.start()))
+
+    # Setext headings (underline with === or ---)
+    for m in _SETEXT_RE.finditer(content):
+        if _is_fenced(m.start()):
+            continue
+        text = m.group(1).strip()
+        # Skip if the text line looks like a YAML frontmatter delimiter
+        if text == "---" or not text:
+            continue
+        depth = 1 if m.group(2)[0] == "=" else 2
+        headings.append(_HeadingInfo(heading=text, depth=depth, char_offset=m.start()))
+
+    # Sort by position (ATX and setext may interleave)
+    headings.sort(key=lambda h: h.char_offset)
 
     return headings
 
@@ -970,9 +988,24 @@ class DocumentChunker:
         if not segments:
             return self._chunk_fixed(content)
 
-        # ── Merge tiny segments (single-pass greedy, O(n)) ──────────
-        merged = _merge_small_segments(
-            segments,
+        # ── Separate frontmatter/preamble from heading segments ─────
+        # Frontmatter and preamble are emitted as standalone chunks —
+        # they must not be merged with heading segments, otherwise the
+        # merged chunk inherits the wrong heading_prefix.
+        standalone: list[_MdSegment] = []
+        heading_segments: list[_MdSegment] = []
+        for seg in segments:
+            if (
+                seg.heading_prefix.endswith("frontmatter]")
+                or seg.heading_prefix == f"[{file_name}]"
+            ):
+                standalone.append(seg)
+            else:
+                heading_segments.append(seg)
+
+        # ── Merge tiny heading segments (single-pass greedy, O(n)) ──
+        merged = standalone + _merge_small_segments(
+            heading_segments,
             min_tokens=_MIN_CHUNK_TOKENS,
             max_tokens=self.chunk_size,
         )
@@ -997,18 +1030,16 @@ class DocumentChunker:
                     )
                 )
             else:
-                # Oversized section: sub-split with reduced budget
-                sub_chunker = DocumentChunker(
-                    chunk_size=effective_budget,
-                    overlap_size=self.overlap_size,
-                    strategy=ChunkStrategy.FIXED,
-                    encoding_name=self.encoding_name,
+                # Oversized section: split around code fences to keep
+                # fenced blocks intact.  Splits text into alternating
+                # prose / fenced-block fragments, then sub-splits only
+                # the prose parts with the generic fixed splitter.
+                sub_chunks = self._split_preserving_fences(
+                    seg.text,
+                    seg.char_start,
+                    effective_budget,
                 )
-                sub_chunker.encoding = self.encoding  # reuse cached encoding
-                sub_chunks = sub_chunker._chunk_fixed(seg.text)
                 for sc in sub_chunks:
-                    sc.start_offset += seg.char_start
-                    sc.end_offset += seg.char_start
                     sc.heading_prefix = seg.heading_prefix
                     chunks.append(sc)
 
@@ -1024,6 +1055,96 @@ class DocumentChunker:
         )
 
         return chunks
+
+    def _split_preserving_fences(
+        self,
+        text: str,
+        base_offset: int,
+        budget: int,
+    ) -> list[DocumentChunk]:
+        """Split oversized section while keeping fenced code blocks intact.
+
+        Splits *text* into alternating prose / fenced-block fragments.
+        Prose fragments are sub-split with the fixed splitter at *budget*.
+        Fenced blocks up to 1.5× budget are emitted whole; larger blocks
+        are sub-split as a last resort.
+        """
+        # Find fenced ranges within this text
+        fenced_ranges: list[tuple[int, int]] = []
+        opener: tuple[str, int] | None = None
+        for m in _FENCE_RE.finditer(text):
+            marker = m.group(1)
+            if opener is None:
+                opener = (marker, m.start())
+            elif marker[0] == opener[0] and len(marker) >= len(opener[0]):
+                fenced_ranges.append((opener[1], m.end()))
+                opener = None
+        # Unclosed fence: extend to end of text
+        if opener is not None:
+            fenced_ranges.append((opener[1], len(text)))
+
+        if not fenced_ranges:
+            # No fences — safe to use generic splitter
+            return self._sub_split_prose(text, base_offset, budget)
+
+        # Build alternating fragments: prose, fence, prose, fence, ...
+        chunks: list[DocumentChunk] = []
+        pos = 0
+        allowance = int(budget * 1.5)
+
+        for fence_start, fence_end in fenced_ranges:
+            # Prose before this fence
+            if pos < fence_start:
+                prose = text[pos:fence_start]
+                if prose.strip():
+                    chunks.extend(self._sub_split_prose(prose, base_offset + pos, budget))
+
+            # The fenced block itself
+            block_text = text[fence_start:fence_end]
+            block_tokens = self._count_tokens(block_text)
+            if block_tokens <= allowance:
+                # Keep intact
+                chunks.append(
+                    DocumentChunk(
+                        text=block_text,
+                        chunk_index=0,
+                        tokens=block_tokens,
+                        start_offset=base_offset + fence_start,
+                        end_offset=base_offset + fence_end,
+                    )
+                )
+            else:
+                # Truly enormous block — last resort split
+                chunks.extend(self._sub_split_prose(block_text, base_offset + fence_start, budget))
+            pos = fence_end
+
+        # Trailing prose after last fence
+        if pos < len(text):
+            trailing = text[pos:]
+            if trailing.strip():
+                chunks.extend(self._sub_split_prose(trailing, base_offset + pos, budget))
+
+        return chunks
+
+    def _sub_split_prose(
+        self,
+        text: str,
+        base_offset: int,
+        budget: int,
+    ) -> list[DocumentChunk]:
+        """Sub-split a prose fragment using a fixed-budget chunker."""
+        sub_chunker = DocumentChunker(
+            chunk_size=budget,
+            overlap_size=self.overlap_size,
+            strategy=ChunkStrategy.FIXED,
+            encoding_name=self.encoding_name,
+        )
+        sub_chunker.encoding = self.encoding
+        sub_chunks = sub_chunker._chunk_fixed(text)
+        for sc in sub_chunks:
+            sc.start_offset += base_offset
+            sc.end_offset += base_offset
+        return sub_chunks
 
 
 @dataclass

--- a/src/nexus/bricks/search/indexing.py
+++ b/src/nexus/bricks/search/indexing.py
@@ -301,6 +301,16 @@ class IndexingPipeline:
             chunks = await asyncio.to_thread(self._chunker.chunk, content, path)
             chunk_texts = [c.text for c in chunks]
 
+        # Issue #3719: When chunks carry heading_prefix (markdown-aware strategy),
+        # prepend it to chunk_texts for embedding enrichment while keeping
+        # chunk.text raw for storage.  Skipped when contextual chunking is
+        # active because LLM-generated context is strictly richer.
+        if contextual_result is None:
+            chunk_texts = [
+                f"{c.heading_prefix} {t}" if getattr(c, "heading_prefix", None) else t
+                for c, t in zip(chunks, chunk_texts, strict=True)
+            ]
+
         return _ChunkedDoc(
             path=path,
             path_id=path_id,

--- a/src/nexus/factory/_semantic_search.py
+++ b/src/nexus/factory/_semantic_search.py
@@ -60,7 +60,7 @@ async def create_semantic_search_components(
         embedding_model: Model name for embeddings.
         api_key: API key for embedding provider.
         chunk_size: Chunk size in tokens.
-        chunk_strategy: "fixed", "semantic", or "overlapping".
+        chunk_strategy: "fixed", "semantic", "overlapping", or "markdown_aware".
         cache_url: Redis/Dragonfly URL for embedding cache.
         embedding_cache_ttl: Cache TTL in seconds (default: 3 days).
         nx: NexusFS instance (NexusFS-path only).
@@ -86,6 +86,7 @@ async def create_semantic_search_components(
         "fixed": ChunkStrategy.FIXED,
         "semantic": ChunkStrategy.SEMANTIC,
         "overlapping": ChunkStrategy.OVERLAPPING,
+        "markdown_aware": ChunkStrategy.MARKDOWN_AWARE,
     }
     chunk_strat = strategy_map.get(chunk_strategy, ChunkStrategy.SEMANTIC)
 

--- a/tests/integration/bricks/search/test_indexing_pipeline.py
+++ b/tests/integration/bricks/search/test_indexing_pipeline.py
@@ -354,3 +354,83 @@ class TestCrossDocBatching:
         results = await pipeline.index_documents(docs)
 
         assert all(r.chunks_indexed == 2 for r in results)
+
+
+# ---------------------------------------------------------------------------
+# Tests: Heading prefix in embedding contract (Issue #3719)
+# ---------------------------------------------------------------------------
+
+
+class TestMarkdownAwareHeadingPrefix:
+    """Verify chunk_texts carries heading prefix while stored text stays raw."""
+
+    @pytest.mark.asyncio
+    async def test_heading_prefix_in_embedded_text_not_in_stored(self) -> None:
+        """chunk_texts should have heading prefix; chunks.text should not."""
+        from nexus.bricks.search.chunking import ChunkStrategy
+
+        chunker = DocumentChunker(chunk_size=1024, strategy=ChunkStrategy.MARKDOWN_AWARE)
+        provider = _mock_embedding_provider()
+        session_factory = _mock_session_factory()
+
+        pipeline = IndexingPipeline(
+            chunker=chunker,
+            embedding_provider=provider,
+            async_session_factory=session_factory,
+        )
+
+        md_content = "# Auth\n\nJWT tokens expire after 1 hour.\n\n## OAuth\n\nOAuth2 flow.\n"
+
+        result = await pipeline.index_document("docs/auth.md", md_content, "pid-1")
+        assert result.chunks_indexed >= 1
+
+        # Verify embed_texts_batched was called with heading-prefixed texts
+        embed_call = provider.embed_texts_batched.call_args
+        embedded_texts = embed_call[0][0]
+        assert any("[" in t and "Auth" in t for t in embedded_texts), (
+            f"Expected heading prefix in embedded texts, got: {embedded_texts}"
+        )
+
+        # Verify stored chunk_text (via session.execute) does NOT have prefix
+        session = session_factory._session
+        insert_calls = session.execute.call_args_list
+        # The last batch of insert calls contains the chunk data
+        for call in insert_calls:
+            if call.args and hasattr(call.args[0], "text") and "INSERT" in str(call.args[0]):
+                # Check the params — chunk_text should not contain bracket prefix
+                params_list = call.args[1] if len(call.args) > 1 else []
+                if isinstance(params_list, list):
+                    for params in params_list:
+                        if isinstance(params, dict) and "chunk_text" in params:
+                            assert not params["chunk_text"].startswith("["), (
+                                f"Stored chunk_text should not have heading prefix: "
+                                f"{params['chunk_text'][:80]}"
+                            )
+
+    @pytest.mark.asyncio
+    async def test_non_markdown_no_prefix(self) -> None:
+        """Non-markdown files should not get heading prefix even with MARKDOWN_AWARE."""
+        from nexus.bricks.search.chunking import ChunkStrategy
+
+        chunker = DocumentChunker(chunk_size=1024, strategy=ChunkStrategy.MARKDOWN_AWARE)
+        provider = _mock_embedding_provider()
+        session_factory = _mock_session_factory()
+
+        pipeline = IndexingPipeline(
+            chunker=chunker,
+            embedding_provider=provider,
+            async_session_factory=session_factory,
+        )
+
+        result = await pipeline.index_document(
+            "src/main.py",
+            "def main():\n    pass\n",
+            "pid-2",
+        )
+        assert result.chunks_indexed >= 1
+
+        # Embedded texts should not have bracket prefixes
+        embed_call = provider.embed_texts_batched.call_args
+        embedded_texts = embed_call[0][0]
+        for t in embedded_texts:
+            assert not t.startswith("["), f"Python file should not have heading prefix: {t[:80]}"

--- a/tests/unit/bricks/search/test_chunking.py
+++ b/tests/unit/bricks/search/test_chunking.py
@@ -1,0 +1,531 @@
+"""Unit tests for DocumentChunker — Issue #3719.
+
+Covers:
+    - Regression tests for existing strategies (FIXED, SEMANTIC, OVERLAPPING)
+    - Comprehensive MARKDOWN_AWARE tests (10 cases)
+    - build_heading_hierarchy() and _merge_small_segments() helpers
+    - Property-based regression for SEMANTIC on .md files
+"""
+
+from __future__ import annotations
+
+from nexus.bricks.search.chunking import (
+    ChunkStrategy,
+    DocumentChunker,
+    _MdSegment,
+    _merge_small_segments,
+    build_heading_hierarchy,
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+SIMPLE_MD = """\
+# Title
+
+Intro paragraph with enough content to be meaningful for the search
+indexing pipeline. This paragraph discusses the overall architecture
+of the system and how various components interact with each other
+to provide a seamless experience for end users. The system consists
+of multiple microservices communicating via gRPC and REST APIs with
+a central message broker handling asynchronous event processing
+between components that need eventual consistency guarantees.
+
+## Section A
+
+Content of section A with some details about the topic. This section
+covers authentication mechanisms including JWT tokens, OAuth2 flows,
+and session management. The authentication layer sits between the
+API gateway and the core business logic, intercepting every request
+to validate credentials before forwarding to downstream services.
+Token rotation is handled automatically by the refresh middleware
+which monitors expiration timestamps and proactively refreshes tokens
+before they expire to prevent disruption to long-running operations.
+
+## Section B
+
+Content of section B with different details about the database layer.
+The persistence layer uses PostgreSQL for structured data and Redis
+for caching hot paths. Connection pooling is managed centrally with
+configurable min/max sizes to handle traffic spikes gracefully without
+exhausting database resources under load. Migrations are managed via
+Alembic with automatic rollback support and a pre-deployment validation
+step that checks schema compatibility with the running application
+version to prevent breaking changes from reaching production.
+"""
+
+DEEP_NESTING_MD = """\
+# Top Level
+
+Overview text that provides a comprehensive introduction to the system
+architecture and its main components. This document is organized into
+categories and subcategories for easier navigation and reference by
+the engineering team working on the platform. The architecture follows
+a modular design pattern where each component can be independently
+deployed and scaled. Service discovery is handled by a central registry
+that maintains health check information for all running instances.
+
+## Category
+
+Category description covering the major functional areas of the system.
+Each category contains multiple subcategories with detailed implementation
+notes and design decisions that inform the development process and help
+new team members ramp up on the codebase quickly and effectively. This
+section describes the authentication subsystem which handles user identity
+verification, session management, and token lifecycle across distributed
+services using a centralized identity provider.
+
+### Subcategory
+
+Subcategory details about a specific aspect of the category. This section
+covers the implementation patterns used throughout the module, including
+error handling strategies, retry policies, and circuit breaker configurations
+that ensure the system remains resilient under adverse conditions. The
+retry policy uses exponential backoff with jitter starting at 100ms and
+capping at 30 seconds. Circuit breakers trip after five consecutive failures
+and enter a half-open state after a configurable cooldown period.
+
+#### Detail
+
+Deep detail text about a very specific implementation concern. The token
+validation pipeline processes each incoming request through a series of
+middleware checks before allowing access to protected resources. Each
+check is designed to fail fast and provide meaningful error messages
+back to the client. The validation chain includes signature verification,
+expiration checking, scope validation, and rate limit enforcement. All
+validation results are cached in Redis for five minutes to reduce the
+load on the identity provider during traffic spikes.
+"""
+
+FRONTMATTER_MD = """\
+---
+title: Architecture
+tags: [auth, api]
+---
+
+Preamble text before any heading.
+
+# Overview
+
+System architecture document.
+
+## Authentication
+
+Auth uses JWT tokens.
+"""
+
+PREAMBLE_ONLY_MD = """\
+This document has content before any heading.
+
+It has multiple paragraphs of preamble text.
+
+# First Section
+
+Section content here.
+"""
+
+CODE_FENCE_WITH_HEADING_MD = """\
+# Real Heading
+
+Some prose content.
+
+```python
+# This is NOT a heading — it's a comment inside a code block
+def verify_token(token: str) -> bool:
+    return jwt.decode(token)
+```
+
+## Another Real Heading
+
+More content.
+"""
+
+NO_HEADINGS_MD = """\
+This document has no headings at all.
+
+It's just paragraphs of plain text.
+
+With some content that should still be chunked.
+"""
+
+TINY_SECTIONS_MD = """\
+# Doc
+
+Main document heading with sufficient introductory content so that
+this section stands on its own as a meaningful chunk. The document
+covers several small sub-topics organized into sections below, some
+of which are intentionally tiny to test the merging behavior.
+
+## A
+
+Hi.
+
+## B
+
+Yo.
+
+## C
+
+This section has enough content to be meaningful on its own and
+should not be merged with its neighbors because it exceeds the
+minimum token threshold for standalone chunks in the system. It
+discusses configuration management patterns and best practices
+for deploying the application in containerized environments with
+proper secrets handling and environment variable management across
+multiple deployment stages from development to production.
+"""
+
+# A large section that will exceed default chunk_size
+LARGE_SECTION_MD = "# Big Section\n\n" + "\n\n".join(
+    f"Paragraph {i} with some filler content to make it reasonably sized." for i in range(200)
+)
+
+
+# ---------------------------------------------------------------------------
+# Helper: make SectionInfo-like objects for build_heading_hierarchy tests
+# ---------------------------------------------------------------------------
+
+
+class _FakeSection:
+    """Minimal stand-in for SectionInfo used by build_heading_hierarchy."""
+
+    def __init__(self, heading: str, depth: int) -> None:
+        self.heading = heading
+        self.depth = depth
+
+
+# ---------------------------------------------------------------------------
+# Tests: build_heading_hierarchy
+# ---------------------------------------------------------------------------
+
+
+class TestBuildHeadingHierarchy:
+    def test_single_section(self) -> None:
+        sections = [_FakeSection("Title", 1)]
+        assert build_heading_hierarchy(sections, 0, "doc.md") == "[doc.md > Title]"
+
+    def test_nested_hierarchy(self) -> None:
+        sections = [
+            _FakeSection("Doc", 1),
+            _FakeSection("Auth", 2),
+            _FakeSection("JWT", 3),
+        ]
+        assert build_heading_hierarchy(sections, 2, "f.md") == "[f.md > Doc > Auth > JWT]"
+
+    def test_sibling_sections(self) -> None:
+        sections = [
+            _FakeSection("Doc", 1),
+            _FakeSection("Auth", 2),
+            _FakeSection("Database", 2),
+        ]
+        assert build_heading_hierarchy(sections, 2, "f.md") == "[f.md > Doc > Database]"
+
+    def test_deep_nesting(self) -> None:
+        sections = [
+            _FakeSection("L1", 1),
+            _FakeSection("L2", 2),
+            _FakeSection("L3", 3),
+            _FakeSection("L4", 4),
+            _FakeSection("L5", 5),
+        ]
+        result = build_heading_hierarchy(sections, 4, "d.md")
+        assert result == "[d.md > L1 > L2 > L3 > L4 > L5]"
+
+    def test_no_file_name(self) -> None:
+        sections = [_FakeSection("Title", 1)]
+        assert build_heading_hierarchy(sections, 0) == "[Title]"
+
+    def test_out_of_bounds(self) -> None:
+        sections = [_FakeSection("Title", 1)]
+        assert build_heading_hierarchy(sections, 5, "f.md") == "[f.md]"
+
+    def test_depth_skip(self) -> None:
+        """H1 → H3 (skipping H2) should still build correct path."""
+        sections = [
+            _FakeSection("Top", 1),
+            _FakeSection("Deep", 3),
+        ]
+        assert build_heading_hierarchy(sections, 1, "f.md") == "[f.md > Top > Deep]"
+
+
+# ---------------------------------------------------------------------------
+# Tests: _merge_small_segments
+# ---------------------------------------------------------------------------
+
+
+class TestMergeSmallSegments:
+    def test_no_merge_needed(self) -> None:
+        segs = [_MdSegment("text", 0, 100, "[p]", 200)]
+        result = _merge_small_segments(segs, min_tokens=80, max_tokens=1024)
+        assert len(result) == 1
+        assert result[0].tokens == 200
+
+    def test_merge_consecutive_tiny(self) -> None:
+        segs = [
+            _MdSegment("a", 0, 10, "[p1]", 20),
+            _MdSegment("b", 10, 20, "[p2]", 30),
+        ]
+        result = _merge_small_segments(segs, min_tokens=80, max_tokens=1024)
+        assert len(result) == 1
+        assert result[0].tokens == 50
+        assert result[0].heading_prefix == "[p1]"  # first segment's prefix
+
+    def test_respects_max_tokens(self) -> None:
+        segs = [
+            _MdSegment("a", 0, 10, "[p]", 60),
+            _MdSegment("b", 10, 20, "[p]", 60),
+        ]
+        result = _merge_small_segments(segs, min_tokens=80, max_tokens=100)
+        # Can't merge (60+60=120 > 100), so each stays separate
+        assert len(result) == 2
+
+    def test_big_segment_emitted_directly(self) -> None:
+        segs = [
+            _MdSegment("small", 0, 5, "[p1]", 10),
+            _MdSegment("big", 5, 100, "[p2]", 500),
+            _MdSegment("small2", 100, 110, "[p3]", 10),
+        ]
+        result = _merge_small_segments(segs, min_tokens=80, max_tokens=1024)
+        # "small" (10 tokens) is accumulated. "big" (500 tokens) is added to
+        # accumulator (combined 510 <= 1024). 510 >= 80 so emit merged.
+        # "small2" (10 tokens) accumulated and emitted at end.
+        assert len(result) == 2
+        assert result[0].tokens == 510  # small + big merged
+        assert result[0].heading_prefix == "[p1]"  # first segment's prefix
+        assert result[1].tokens == 10  # small2 alone
+
+    def test_empty_input(self) -> None:
+        assert _merge_small_segments([], min_tokens=80) == []
+
+
+# ---------------------------------------------------------------------------
+# Tests: FIXED strategy regression
+# ---------------------------------------------------------------------------
+
+
+class TestFixedStrategy:
+    def test_small_document_single_chunk(self) -> None:
+        chunker = DocumentChunker(chunk_size=1024, strategy=ChunkStrategy.FIXED)
+        chunks = chunker.chunk("Hello world.", compute_lines=False)
+        assert len(chunks) == 1
+        assert chunks[0].text == "Hello world."
+
+    def test_large_document_splits(self) -> None:
+        content = " ".join(f"word{i}" for i in range(2000))
+        chunker = DocumentChunker(chunk_size=256, strategy=ChunkStrategy.FIXED)
+        chunks = chunker.chunk(content, compute_lines=False)
+        assert len(chunks) > 1
+        for chunk in chunks:
+            assert chunk.text  # non-empty
+
+    def test_offsets_are_monotonic(self) -> None:
+        content = "First paragraph.\n\nSecond paragraph.\n\nThird paragraph."
+        chunker = DocumentChunker(chunk_size=8, strategy=ChunkStrategy.FIXED)
+        chunks = chunker.chunk(content, compute_lines=False)
+        for i in range(1, len(chunks)):
+            assert chunks[i].start_offset >= chunks[i - 1].start_offset
+
+
+# ---------------------------------------------------------------------------
+# Tests: SEMANTIC strategy regression (property-based)
+# ---------------------------------------------------------------------------
+
+
+class TestSemanticStrategyRegression:
+    def test_markdown_produces_chunks(self) -> None:
+        chunker = DocumentChunker(chunk_size=1024, strategy=ChunkStrategy.SEMANTIC)
+        chunks = chunker.chunk(SIMPLE_MD, file_path="test.md", compute_lines=True)
+        assert len(chunks) >= 1
+        for chunk in chunks:
+            assert chunk.text.strip()
+
+    def test_offsets_monotonic(self) -> None:
+        chunker = DocumentChunker(chunk_size=1024, strategy=ChunkStrategy.SEMANTIC)
+        chunks = chunker.chunk(SIMPLE_MD, file_path="test.md", compute_lines=False)
+        for i in range(1, len(chunks)):
+            assert chunks[i].start_offset >= chunks[i - 1].start_offset
+
+    def test_line_numbers_present(self) -> None:
+        chunker = DocumentChunker(chunk_size=1024, strategy=ChunkStrategy.SEMANTIC)
+        chunks = chunker.chunk(SIMPLE_MD, file_path="test.md", compute_lines=True)
+        for chunk in chunks:
+            assert chunk.line_start is not None
+            assert chunk.line_end is not None
+            assert chunk.line_start >= 1
+
+    def test_code_file_dispatches_to_paragraphs(self) -> None:
+        content = "def foo():\n    pass\n\ndef bar():\n    pass"
+        chunker = DocumentChunker(chunk_size=1024, strategy=ChunkStrategy.SEMANTIC)
+        chunks = chunker.chunk(content, file_path="test.py", compute_lines=False)
+        assert len(chunks) >= 1
+
+    def test_no_heading_prefix_on_semantic(self) -> None:
+        """SEMANTIC strategy should NOT produce heading_prefix."""
+        chunker = DocumentChunker(chunk_size=1024, strategy=ChunkStrategy.SEMANTIC)
+        chunks = chunker.chunk(SIMPLE_MD, file_path="test.md", compute_lines=False)
+        for chunk in chunks:
+            assert chunk.heading_prefix is None
+
+
+# ---------------------------------------------------------------------------
+# Tests: OVERLAPPING strategy regression
+# ---------------------------------------------------------------------------
+
+
+class TestOverlappingStrategyRegression:
+    def test_produces_overlapping_chunks(self) -> None:
+        content = " ".join(f"word{i}" for i in range(500))
+        chunker = DocumentChunker(
+            chunk_size=100,
+            overlap_size=20,
+            strategy=ChunkStrategy.OVERLAPPING,
+        )
+        chunks = chunker.chunk(content, compute_lines=False)
+        assert len(chunks) > 1
+
+
+# ---------------------------------------------------------------------------
+# Tests: MARKDOWN_AWARE strategy (10 cases)
+# ---------------------------------------------------------------------------
+
+
+class TestMarkdownAwareStrategy:
+    """Comprehensive tests for the MARKDOWN_AWARE chunking strategy."""
+
+    def _make_chunker(self, chunk_size: int = 1024) -> DocumentChunker:
+        return DocumentChunker(chunk_size=chunk_size, strategy=ChunkStrategy.MARKDOWN_AWARE)
+
+    # 1. Happy path: multi-section doc with headings
+    def test_happy_path_multi_section(self) -> None:
+        chunker = self._make_chunker()
+        chunks = chunker.chunk(SIMPLE_MD, file_path="test.md")
+        assert len(chunks) >= 2
+        # All chunks should have heading_prefix set
+        for chunk in chunks:
+            assert chunk.heading_prefix is not None
+            assert chunk.heading_prefix.startswith("[")
+            assert chunk.heading_prefix.endswith("]")
+
+    # 2. Heading hierarchy prefix format
+    def test_heading_hierarchy_prefix(self) -> None:
+        chunker = self._make_chunker()
+        chunks = chunker.chunk(DEEP_NESTING_MD, file_path="deep.md")
+        prefixes = [c.heading_prefix for c in chunks]
+        # Should see nested paths
+        assert any(">" in p for p in prefixes if p)
+        # The deepest section should have full hierarchy
+        deep_chunks = [c for c in chunks if c.heading_prefix and "Detail" in c.heading_prefix]
+        assert len(deep_chunks) >= 1
+        assert "Subcategory" in deep_chunks[0].heading_prefix
+        assert "Category" in deep_chunks[0].heading_prefix
+
+    # 3. Pre-heading content (preamble)
+    def test_preamble_content_captured(self) -> None:
+        chunker = self._make_chunker()
+        chunks = chunker.chunk(PREAMBLE_ONLY_MD, file_path="pre.md")
+        # First chunk should contain the preamble text
+        preamble_chunks = [c for c in chunks if "before any heading" in c.text]
+        assert len(preamble_chunks) >= 1
+        assert preamble_chunks[0].heading_prefix == "[pre.md]"
+
+    # 4. Frontmatter chunk
+    def test_frontmatter_as_chunk(self) -> None:
+        chunker = self._make_chunker()
+        chunks = chunker.chunk(FRONTMATTER_MD, file_path="arch.md")
+        fm_chunks = [c for c in chunks if "frontmatter" in (c.heading_prefix or "")]
+        assert len(fm_chunks) == 1
+        assert "title" in fm_chunks[0].text.lower() or "---" in fm_chunks[0].text
+
+    # 5. Oversized section triggers sub-splitting
+    def test_oversized_section_splits(self) -> None:
+        chunker = self._make_chunker(chunk_size=256)
+        chunks = chunker.chunk(LARGE_SECTION_MD, file_path="big.md")
+        # Should produce multiple chunks from the single large section
+        assert len(chunks) > 1
+        # All chunks should share the same heading prefix
+        prefixes = {c.heading_prefix for c in chunks}
+        assert len(prefixes) == 1
+        assert "Big Section" in prefixes.pop()
+
+    # 6. Atomic block within budget stays intact
+    def test_small_code_block_stays_intact(self) -> None:
+        md = "# Code\n\n```python\ndef foo():\n    return 42\n```\n"
+        chunker = self._make_chunker(chunk_size=1024)
+        chunks = chunker.chunk(md, file_path="code.md")
+        # The code block should be within one chunk
+        code_chunks = [c for c in chunks if "def foo" in c.text]
+        assert len(code_chunks) == 1
+
+    # 7. Tiny sections merge
+    def test_tiny_sections_merge(self) -> None:
+        chunker = self._make_chunker(chunk_size=1024)
+        chunks = chunker.chunk(TINY_SECTIONS_MD, file_path="tiny.md")
+        # Sections A ("Hi.") and B ("Yo.") are tiny and should be merged
+        # Section C is large enough to stand alone
+        # So we expect fewer chunks than sections
+        section_count = TINY_SECTIONS_MD.count("\n## ")
+        assert len(chunks) < section_count + 1  # +1 for the H1
+
+    # 8. No headings → fallback to _chunk_fixed
+    def test_no_headings_fallback(self) -> None:
+        chunker = self._make_chunker()
+        chunks = chunker.chunk(NO_HEADINGS_MD, file_path="plain.md")
+        assert len(chunks) >= 1
+        # Fallback produces chunks without heading_prefix
+        for chunk in chunks:
+            assert chunk.heading_prefix is None
+
+    # 9. Heading inside code fence not treated as section boundary
+    def test_heading_in_code_fence_ignored(self) -> None:
+        chunker = self._make_chunker()
+        chunks = chunker.chunk(CODE_FENCE_WITH_HEADING_MD, file_path="fence.md")
+        # The comment "# This is NOT a heading" should be inside a chunk,
+        # not creating its own section
+        headings_in_prefixes = [
+            c.heading_prefix
+            for c in chunks
+            if c.heading_prefix and "NOT a heading" in c.heading_prefix
+        ]
+        assert len(headings_in_prefixes) == 0
+
+    # 10. Non-markdown file delegates to semantic strategy
+    def test_non_markdown_delegates(self) -> None:
+        chunker = self._make_chunker()
+        content = "def foo():\n    pass\n\ndef bar():\n    pass"
+        chunks = chunker.chunk(content, file_path="test.py")
+        assert len(chunks) >= 1
+        # No heading prefix on non-markdown
+        for chunk in chunks:
+            assert chunk.heading_prefix is None
+
+    # ── Additional properties ──
+
+    def test_chunk_offsets_monotonic(self) -> None:
+        chunker = self._make_chunker()
+        chunks = chunker.chunk(SIMPLE_MD, file_path="test.md")
+        for i in range(1, len(chunks)):
+            assert chunks[i].start_offset >= chunks[i - 1].start_offset
+
+    def test_line_numbers_computed(self) -> None:
+        chunker = self._make_chunker()
+        chunks = chunker.chunk(SIMPLE_MD, file_path="test.md", compute_lines=True)
+        for chunk in chunks:
+            assert chunk.line_start is not None
+            assert chunk.line_end is not None
+
+    def test_chunk_indices_sequential(self) -> None:
+        chunker = self._make_chunker()
+        chunks = chunker.chunk(SIMPLE_MD, file_path="test.md")
+        for i, chunk in enumerate(chunks):
+            assert chunk.chunk_index == i
+
+    def test_frontmatter_plus_preamble(self) -> None:
+        """Document with frontmatter AND preamble before first heading."""
+        chunker = self._make_chunker()
+        chunks = chunker.chunk(FRONTMATTER_MD, file_path="doc.md")
+        # Should have: frontmatter chunk, preamble chunk, section chunks
+        fm_chunks = [c for c in chunks if "frontmatter" in (c.heading_prefix or "")]
+        preamble_chunks = [c for c in chunks if "Preamble text" in c.text]
+        assert len(fm_chunks) == 1
+        assert len(preamble_chunks) >= 1

--- a/tests/unit/bricks/search/test_chunking.py
+++ b/tests/unit/bricks/search/test_chunking.py
@@ -594,3 +594,35 @@ class TestMarkdownAwareStrategy:
         assert any("Indented Heading" in p for p in prefixes), (
             f"Indented ATX heading not detected: {prefixes}"
         )
+
+    # ── Adversarial review regressions (Codex round 2) ──
+
+    def test_heading_after_code_fence_detected(self) -> None:
+        """Headings after fenced code blocks must still be detected."""
+        from nexus.bricks.search.chunking import _parse_headings_fence_aware
+
+        md = (
+            "# First\n\nSome prose.\n\n```python\ndef foo():\n    pass\n```\n\n"
+            "## Second\n\nMore prose after the code block.\n"
+        )
+        # Verify at the parser level that both headings survive
+        headings = _parse_headings_fence_aware(md)
+        heading_names = [h.heading for h in headings]
+        assert "First" in heading_names, f"H1 missing: {heading_names}"
+        assert "Second" in heading_names, f"H2 after fence missing: {heading_names}"
+
+        # Also verify chunker produces chunks containing "## Second" text
+        chunker = self._make_chunker()
+        chunks = chunker.chunk(md, file_path="fenced.md")
+        all_text = " ".join(c.text for c in chunks)
+        assert "## Second" in all_text, "Second heading lost during chunking"
+
+    def test_frontmatter_not_parsed_as_setext_heading(self) -> None:
+        """YAML frontmatter keys must not become setext headings."""
+        md = "---\ntitle: Architecture\ntags: [auth, api]\n---\n\n# Overview\n\nContent.\n"
+        chunker = self._make_chunker()
+        chunks = chunker.chunk(md, file_path="arch.md")
+        prefixes = [c.heading_prefix or "" for c in chunks]
+        # No prefix should contain YAML keys like "tags"
+        for p in prefixes:
+            assert "tags" not in p, f"YAML key parsed as setext heading: {p}"

--- a/tests/unit/bricks/search/test_chunking.py
+++ b/tests/unit/bricks/search/test_chunking.py
@@ -626,3 +626,31 @@ class TestMarkdownAwareStrategy:
         # No prefix should contain YAML keys like "tags"
         for p in prefixes:
             assert "tags" not in p, f"YAML key parsed as setext heading: {p}"
+
+    # ── Adversarial review regressions (Codex round 3) ──
+
+    def test_nested_backtick_fences_do_not_suppress_headings(self) -> None:
+        """4-backtick fence containing literal 3-backtick lines."""
+        from nexus.bricks.search.chunking import _parse_headings_fence_aware
+
+        md = (
+            "## Before\n\nProse.\n\n"
+            "````\n```\ninner literal content\n```\n````\n\n"
+            "## After\n\nMore prose.\n"
+        )
+        headings = _parse_headings_fence_aware(md)
+        names = [h.heading for h in headings]
+        assert "Before" in names
+        assert "After" in names, f"Heading after nested fence lost: {names}"
+
+    def test_heading_prefix_truncated_for_long_paths(self) -> None:
+        """Very long heading hierarchy is truncated to stay under limit."""
+        long_heading = "A" * 100
+        sections = [
+            _FakeSection(long_heading, 1),
+            _FakeSection(long_heading, 2),
+            _FakeSection(long_heading, 3),
+        ]
+        result = build_heading_hierarchy(sections, 2, "file.md")
+        assert len(result) <= 250  # reasonable cap
+        assert "..." in result, f"Expected truncation ellipsis: {result}"

--- a/tests/unit/bricks/search/test_chunking.py
+++ b/tests/unit/bricks/search/test_chunking.py
@@ -529,3 +529,68 @@ class TestMarkdownAwareStrategy:
         preamble_chunks = [c for c in chunks if "Preamble text" in c.text]
         assert len(fm_chunks) == 1
         assert len(preamble_chunks) >= 1
+
+    # ── Adversarial review regressions (Codex round 1) ──
+
+    def test_frontmatter_does_not_absorb_heading_sections(self) -> None:
+        """Short doc: frontmatter must not merge with heading sections."""
+        md = "---\ntitle: Test\n---\n\n# Overview\n\nShort overview text.\n"
+        chunker = self._make_chunker()
+        chunks = chunker.chunk(md, file_path="short.md")
+        # The heading section must NOT have a frontmatter prefix
+        heading_chunks = [
+            c for c in chunks if "# Overview" in c.text or "overview" in c.text.lower()
+        ]
+        for c in heading_chunks:
+            assert "frontmatter" not in (c.heading_prefix or ""), (
+                f"Heading section wrongly embedded as frontmatter: {c.heading_prefix}"
+            )
+
+    def test_oversized_section_preserves_code_fence(self) -> None:
+        """Code block within 1.5x budget must not be split mid-fence."""
+        # Build a code block of ~100 tokens (within 1.5x of chunk_size=128 = 192)
+        code = "\n".join(f"    line_{i} = {i}" for i in range(20))
+        md = (
+            "# Code\n\nSome introductory prose about the code example.\n\n"
+            f"```python\n{code}\n```\n\nTrailing prose after the block.\n"
+        )
+        chunker = self._make_chunker(chunk_size=128)
+        chunks = chunker.chunk(md, file_path="code.md")
+        # The code block should be kept intact in a single chunk
+        fence_chunks = [c for c in chunks if "```python" in c.text]
+        assert len(fence_chunks) >= 1
+        for c in fence_chunks:
+            assert "```" in c.text[c.text.index("```python") + 10 :], (
+                "Code fence was split across chunks — opening ``` without closing ```"
+            )
+
+    def test_setext_headings_detected(self) -> None:
+        """Setext headings (=== / ---) must be recognized as section boundaries."""
+        md = (
+            "Title\n=====\n\nIntro content with enough words to exceed the "
+            "minimum token threshold for a standalone chunk in tests.\n\n"
+            "Subtitle\n--------\n\nMore content with enough text to also "
+            "exceed the minimum threshold for standalone chunks.\n"
+        )
+        chunker = self._make_chunker()
+        chunks = chunker.chunk(md, file_path="setext.md")
+        # Verify setext headings were detected (reflected in heading_prefix)
+        prefixes = [c.heading_prefix or "" for c in chunks]
+        assert any("Title" in p for p in prefixes), f"Setext H1 (===) not detected: {prefixes}"
+        # At least one chunk should exist with correct prefix
+        assert len(chunks) >= 1
+
+    def test_indented_atx_heading_detected(self) -> None:
+        """ATX headings with up to 3 spaces of indentation are valid CommonMark."""
+        md = (
+            "   # Indented Heading\n\nContent under the indented heading "
+            "with enough words to be meaningful for search indexing.\n\n"
+            "## Normal Heading\n\nMore content under a normally formatted "
+            "heading that also has enough text for search.\n"
+        )
+        chunker = self._make_chunker()
+        chunks = chunker.chunk(md, file_path="indent.md")
+        prefixes = [c.heading_prefix or "" for c in chunks]
+        assert any("Indented Heading" in p for p in prefixes), (
+            f"Indented ATX heading not detected: {prefixes}"
+        )

--- a/tests/unit/bricks/search/test_chunking.py
+++ b/tests/unit/bricks/search/test_chunking.py
@@ -654,3 +654,16 @@ class TestMarkdownAwareStrategy:
         result = build_heading_hierarchy(sections, 2, "file.md")
         assert len(result) <= 250  # reasonable cap
         assert "..." in result, f"Expected truncation ellipsis: {result}"
+
+    # ── Adversarial review regressions (Codex round 4) ──
+
+    def test_thematic_break_not_frontmatter(self) -> None:
+        """Document starting with --- thematic break must not be treated as frontmatter."""
+        md = "---\n\n# Title\n\nContent after thematic break.\n"
+        chunker = self._make_chunker()
+        chunks = chunker.chunk(md, file_path="hr.md")
+        # No chunk should have a frontmatter prefix
+        for c in chunks:
+            assert "frontmatter" not in (c.heading_prefix or ""), (
+                f"Thematic break wrongly treated as frontmatter: {c.heading_prefix}"
+            )


### PR DESCRIPTION
## Summary

Closes #3719

- Adds `MARKDOWN_AWARE` chunking strategy (`NEXUS_CHUNK_STRATEGY=markdown_aware`) that splits markdown at heading boundaries using a code-fence-aware parser, replacing blind 1024-token splits
- Prepends heading hierarchy prefix (e.g. `[file.md > Auth > JWT Tokens]`) to chunk text before embedding — zero LLM cost, stored text stays raw
- Handles 4 edge cases: preamble content before first heading, YAML frontmatter, oversized sections (sub-split with reduced budget to account for prefix overhead), and tiny section merging (80-token minimum, single-pass greedy O(n))
- Composes cleanly with existing chunking layers: entropy filtering works on top, contextual chunking skips heading prepend (it's a superset)

### Architecture decisions (from interactive review)

| Decision | Choice |
|---|---|
| Component boundary | New `ChunkStrategy.MARKDOWN_AWARE` on `DocumentChunker` (not a separate class) |
| Heading parser | Local `_parse_headings_fence_aware()` in search brick (respects LEGO brick boundaries) |
| Text separation | `chunk_texts` gets prefix for embedding, `chunk.text` stays raw for storage (follows `ContextualChunker` pattern) |
| Composition | Base strategy — entropy/contextual layer on top |

### Files changed

| File | Change |
|---|---|
| `src/nexus/bricks/search/chunking.py` | `MARKDOWN_AWARE` strategy, `_parse_headings_fence_aware()`, `build_heading_hierarchy()`, `_merge_small_segments()`, `_chunk_markdown_aware()` |
| `src/nexus/bricks/search/indexing.py` | Heading prefix → `chunk_texts` enrichment in `_chunk_document()` |
| `src/nexus/factory/_semantic_search.py` | `"markdown_aware"` in strategy map |
| `tests/unit/bricks/search/test_chunking.py` | **New**: 35 unit tests (existing strategy regressions + 14 MARKDOWN_AWARE cases + helper tests) |
| `tests/integration/bricks/search/test_indexing_pipeline.py` | 2 new tests for prefix-in-embedding contract |

### Evidence (from issue)

| Source | Finding |
|---|---|
| [Anthropic Contextual Retrieval](https://www.anthropic.com/research/contextual-retrieval) | Context prepend reduces retrieval failures 49-67% |
| [NAACL 2025 — Vectara](https://aclanthology.org/2025.findings-naacl.114/) | Chunking strategy has as much influence as embedding model choice |

## Test plan

- [x] 35 unit tests pass (`test_chunking.py`)
- [x] 12 integration tests pass (`test_indexing_pipeline.py`, including 2 new)
- [x] 40 md_structure parser tests pass (no regressions)
- [x] 89 total search unit tests pass
- [x] mypy clean
- [x] All pre-commit hooks pass (ruff, brick import boundary, etc.)
- [ ] Manual test: set `NEXUS_CHUNK_STRATEGY=markdown_aware` and verify search quality on markdown-heavy workspace
- [ ] Verify chunk count logging in daemon output (`[MARKDOWN-AWARE] path=... headings=... chunks=...`)