### PR TITLE
fix(ci): seed demo workspace + harden TLS env contract

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -171,6 +171,16 @@ jobs:
           echo "NEXUS_API_KEY=${ADMIN_KEY}" >> "$GITHUB_ENV"
           echo "Admin key obtained: ${ADMIN_KEY:0:10}..."
 
+      - name: Seed demo workspace
+        run: |
+          docker exec \
+            -e NEXUS_URL=http://localhost:2026 \
+            -e NEXUS_API_KEY="${NEXUS_API_KEY}" \
+            -e NEXUS_PROFILE=remote \
+            -e NEXUS_GRPC_PORT=2029 \
+            -e NEXUS_GRPC_TLS=false \
+            nexus-e2e nexus demo init --skip-semantic
+
       - name: Copy test scripts into container
         run: |
           docker cp permissions_demo_enhanced.sh nexus-e2e:/tmp/

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -315,7 +315,7 @@ async def connect(
         if _data_dir and _tls_enabled:
             from nexus.security.tls.config import ZoneTlsConfig
 
-            _tls_config = ZoneTlsConfig.from_data_dir(_data_dir)
+            _tls_config = ZoneTlsConfig.from_data_dir_any(_data_dir)
 
         # Fail closed: NEXUS_GRPC_TLS=true but no certs resolved.
         # As a last resort, check NEXUS_TLS_* env vars — but only when

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -315,7 +315,14 @@ async def connect(
         if _data_dir and _tls_enabled:
             from nexus.security.tls.config import ZoneTlsConfig
 
-            _tls_config = ZoneTlsConfig.from_data_dir_any(_data_dir)
+            # Explicit true: check both Raft + OpenSSL layouts
+            # Auto-detect (unset): Raft-only (backward compat)
+            _tls_explicit = _grpc_tls_env in ("true", "1", "yes")
+            _tls_config = (
+                ZoneTlsConfig.from_data_dir_any(_data_dir)
+                if _tls_explicit
+                else ZoneTlsConfig.from_data_dir(_data_dir)
+            )
 
         # Fail closed: NEXUS_GRPC_TLS=true but no certs resolved.
         # As a last resort, check NEXUS_TLS_* env vars — but only when

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -317,12 +317,23 @@ async def connect(
 
             _tls_config = ZoneTlsConfig.from_data_dir(_data_dir)
 
-        # Fail closed: NEXUS_GRPC_TLS=true but no certs resolved
+        # Fail closed: NEXUS_GRPC_TLS=true but no certs resolved.
+        # As a last resort, check NEXUS_TLS_* env vars — but only when
+        # TLS was explicitly requested, to avoid stale env vars from a
+        # previous session flipping a plaintext stack onto mTLS.
         _tls_explicit = _grpc_tls_env in ("true", "1", "yes")
+        if _tls_explicit and _tls_config is None and os.getenv("NEXUS_TLS_CERT"):
+            import contextlib
+
+            from nexus.security.tls.config import ZoneTlsConfig
+
+            with contextlib.suppress(Exception):
+                _tls_config = ZoneTlsConfig.from_env()
         if _tls_explicit and _tls_config is None:
             raise RuntimeError(
                 "NEXUS_GRPC_TLS=true but no TLS certificates found. "
-                "Provide certs in {data_dir}/tls/ or set data_dir in nexus.yaml."
+                "Provide certs via NEXUS_TLS_CERT/KEY/CA, "
+                "in {data_dir}/tls/, or set data_dir in nexus.yaml."
             )
 
         transport = RPCTransport(

--- a/src/nexus/cli/commands/admin.py
+++ b/src/nexus/cli/commands/admin.py
@@ -99,9 +99,11 @@ def get_admin_rpc(url: str | None, api_key: str | None) -> AdminRPC:
     _grpc_tls_off = _grpc_tls_env in ("false", "0", "no")
     _grpc_tls_on = _grpc_tls_env in ("true", "1", "yes")
 
-    # NEXUS_GRPC_TLS takes precedence over stale env vars / state
+    # NEXUS_GRPC_TLS=false is an unconditional disable — matches server
+    # semantics. Operator explicitly wants insecure, even if stale certs
+    # exist in state.json or env.
     if _grpc_tls_off:
-        pass  # force insecure — ignore NEXUS_TLS_* and state.json certs
+        pass
     elif tls.get("cert") or os.environ.get("NEXUS_TLS_CERT"):
         tls_config = ZoneTlsConfig.from_env()
     elif data_dir:
@@ -112,7 +114,8 @@ def get_admin_rpc(url: str | None, api_key: str | None) -> AdminRPC:
     if _grpc_tls_on and tls_config is None:
         raise click.ClickException(
             "NEXUS_GRPC_TLS=true but no TLS certificates found. "
-            "Provide certs in {data_dir}/tls/ or configure TLS in state.json."
+            "Provide certs via NEXUS_TLS_CERT/KEY/CA, "
+            "in {data_dir}/tls/, or configure TLS in state.json."
         )
     transport = RPCTransport(server_address=grpc_address, auth_token=api_key, tls_config=tls_config)
     return transport.call_rpc

--- a/src/nexus/cli/commands/admin.py
+++ b/src/nexus/cli/commands/admin.py
@@ -108,7 +108,7 @@ def get_admin_rpc(url: str | None, api_key: str | None) -> AdminRPC:
         tls_config = ZoneTlsConfig.from_env()
     elif data_dir:
         with contextlib.suppress(Exception):
-            tls_config = ZoneTlsConfig.from_data_dir(data_dir)
+            tls_config = ZoneTlsConfig.from_data_dir_any(data_dir)
 
     # Fail closed: explicit true but no certs resolved
     if _grpc_tls_on and tls_config is None:

--- a/src/nexus/cli/state.py
+++ b/src/nexus/cli/state.py
@@ -167,16 +167,21 @@ def resolve_connection_env(
     if api_key:
         env_vars["NEXUS_API_KEY"] = api_key
 
-    # TLS paths for gRPC — prefer state.json (runtime-discovered), fall back to config
+    # TLS paths for gRPC — prefer state.json (runtime-discovered), fall back to config.
+    # Also emit NEXUS_GRPC_TLS=true so SDK connect() and admin CLI know
+    # TLS is intentional (not stale env from a previous session).
     tls = state.get("tls", {})
     if tls.get("cert"):
         env_vars["NEXUS_TLS_CERT"] = tls["cert"]
         env_vars["NEXUS_TLS_KEY"] = tls.get("key", "")
         env_vars["NEXUS_TLS_CA"] = tls.get("ca", "")
+        env_vars["NEXUS_GRPC_TLS"] = "true"
     elif config.get("tls_cert"):
         env_vars["NEXUS_TLS_CERT"] = config["tls_cert"]
         env_vars["NEXUS_TLS_KEY"] = config.get("tls_key", "")
         env_vars["NEXUS_TLS_CA"] = config.get("tls_ca", "")
+        # Don't emit NEXUS_GRPC_TLS=true from declarative config —
+        # cert files may not exist yet (e.g. openssl unavailable at init).
 
     # DATABASE_URL if postgres is in the service list
     services = config.get("services", [])

--- a/src/nexus/cli/state.py
+++ b/src/nexus/cli/state.py
@@ -177,14 +177,23 @@ def resolve_connection_env(
         env_vars["NEXUS_TLS_CA"] = tls.get("ca", "")
         env_vars["NEXUS_GRPC_TLS"] = "true"
     elif config.get("tls_cert"):
-        env_vars["NEXUS_TLS_CERT"] = config["tls_cert"]
-        env_vars["NEXUS_TLS_KEY"] = config.get("tls_key", "")
-        env_vars["NEXUS_TLS_CA"] = config.get("tls_ca", "")
-        # Emit NEXUS_GRPC_TLS=true only if cert files actually exist on disk
         import pathlib
 
-        if pathlib.Path(config["tls_cert"]).exists():
+        _cert = pathlib.Path(config["tls_cert"])
+        _key = pathlib.Path(config.get("tls_key", ""))
+        _ca = pathlib.Path(config.get("tls_ca", ""))
+        # All-or-nothing: only export TLS when all 3 files exist
+        if _cert.exists() and _key.exists() and _ca.exists():
+            env_vars["NEXUS_TLS_CERT"] = config["tls_cert"]
+            env_vars["NEXUS_TLS_KEY"] = config.get("tls_key", "")
+            env_vars["NEXUS_TLS_CA"] = config.get("tls_ca", "")
             env_vars["NEXUS_GRPC_TLS"] = "true"
+        else:
+            # Config declares TLS but files missing — treat as non-TLS
+            env_vars["NEXUS_GRPC_TLS"] = "false"
+            env_vars["NEXUS_TLS_CERT"] = ""
+            env_vars["NEXUS_TLS_KEY"] = ""
+            env_vars["NEXUS_TLS_CA"] = ""
     else:
         # Non-TLS stack: clear any stale TLS override from a previous session
         env_vars["NEXUS_GRPC_TLS"] = "false"

--- a/src/nexus/cli/state.py
+++ b/src/nexus/cli/state.py
@@ -180,8 +180,11 @@ def resolve_connection_env(
         env_vars["NEXUS_TLS_CERT"] = config["tls_cert"]
         env_vars["NEXUS_TLS_KEY"] = config.get("tls_key", "")
         env_vars["NEXUS_TLS_CA"] = config.get("tls_ca", "")
-        # Don't emit NEXUS_GRPC_TLS=true from declarative config —
-        # cert files may not exist yet (e.g. openssl unavailable at init).
+        # Emit NEXUS_GRPC_TLS=true only if cert files actually exist on disk
+        import pathlib
+
+        if pathlib.Path(config["tls_cert"]).exists():
+            env_vars["NEXUS_GRPC_TLS"] = "true"
     else:
         # Non-TLS stack: clear any stale TLS override from a previous session
         env_vars["NEXUS_GRPC_TLS"] = "false"

--- a/src/nexus/cli/state.py
+++ b/src/nexus/cli/state.py
@@ -168,8 +168,8 @@ def resolve_connection_env(
         env_vars["NEXUS_API_KEY"] = api_key
 
     # TLS paths for gRPC — prefer state.json (runtime-discovered), fall back to config.
-    # Also emit NEXUS_GRPC_TLS=true so SDK connect() and admin CLI know
-    # TLS is intentional (not stale env from a previous session).
+    # Always emit NEXUS_GRPC_TLS so `eval $(nexus env)` clears stale overrides
+    # when switching between TLS and plaintext stacks.
     tls = state.get("tls", {})
     if tls.get("cert"):
         env_vars["NEXUS_TLS_CERT"] = tls["cert"]
@@ -182,6 +182,12 @@ def resolve_connection_env(
         env_vars["NEXUS_TLS_CA"] = config.get("tls_ca", "")
         # Don't emit NEXUS_GRPC_TLS=true from declarative config —
         # cert files may not exist yet (e.g. openssl unavailable at init).
+    else:
+        # Non-TLS stack: clear any stale TLS override from a previous session
+        env_vars["NEXUS_GRPC_TLS"] = "false"
+        env_vars["NEXUS_TLS_CERT"] = ""
+        env_vars["NEXUS_TLS_KEY"] = ""
+        env_vars["NEXUS_TLS_CA"] = ""
 
     # DATABASE_URL if postgres is in the service list
     services = config.get("services", [])

--- a/src/nexus/cli/state.py
+++ b/src/nexus/cli/state.py
@@ -177,23 +177,18 @@ def resolve_connection_env(
         env_vars["NEXUS_TLS_CA"] = tls.get("ca", "")
         env_vars["NEXUS_GRPC_TLS"] = "true"
     elif config.get("tls_cert"):
+        # Always export paths (subprocesses may need them)
+        env_vars["NEXUS_TLS_CERT"] = config["tls_cert"]
+        env_vars["NEXUS_TLS_KEY"] = config.get("tls_key", "")
+        env_vars["NEXUS_TLS_CA"] = config.get("tls_ca", "")
+        # Only signal TLS active when all 3 files actually exist
         import pathlib
 
         _cert = pathlib.Path(config["tls_cert"])
         _key = pathlib.Path(config.get("tls_key", ""))
         _ca = pathlib.Path(config.get("tls_ca", ""))
-        # All-or-nothing: only export TLS when all 3 files exist
         if _cert.exists() and _key.exists() and _ca.exists():
-            env_vars["NEXUS_TLS_CERT"] = config["tls_cert"]
-            env_vars["NEXUS_TLS_KEY"] = config.get("tls_key", "")
-            env_vars["NEXUS_TLS_CA"] = config.get("tls_ca", "")
             env_vars["NEXUS_GRPC_TLS"] = "true"
-        else:
-            # Config declares TLS but files missing — treat as non-TLS
-            env_vars["NEXUS_GRPC_TLS"] = "false"
-            env_vars["NEXUS_TLS_CERT"] = ""
-            env_vars["NEXUS_TLS_KEY"] = ""
-            env_vars["NEXUS_TLS_CA"] = ""
     else:
         # Non-TLS stack: clear any stale TLS override from a previous session
         env_vars["NEXUS_GRPC_TLS"] = "false"

--- a/src/nexus/grpc/server.py
+++ b/src/nexus/grpc/server.py
@@ -52,21 +52,29 @@ def _resolve_tls_config(app: "FastAPI") -> "ZoneTlsConfig | None":
         if tls_cfg is not None:
             return tls_cfg
 
-    # 3. Load from NEXUS_DATA_DIR/tls/ (Raft or OpenSSL layout)
+    # 3. Load from NEXUS_DATA_DIR/tls/
+    #    - Explicit true: check both Raft + OpenSSL layouts
+    #    - Unset (auto-detect): Raft-only (backward compat)
+    _explicit_on = grpc_tls in ("true", "1", "yes")
     data_dir = os.environ.get("NEXUS_DATA_DIR")
     if data_dir:
-        cfg = ZoneTlsConfig.from_data_dir_any(data_dir)
+        cfg = (
+            ZoneTlsConfig.from_data_dir_any(data_dir)
+            if _explicit_on
+            else ZoneTlsConfig.from_data_dir(data_dir)
+        )
         if cfg is not None:
             return cfg
 
-    # 4. NEXUS_TLS_CERT/KEY/CA env vars (OpenSSL-style, set by `nexus up`)
-    if os.environ.get("NEXUS_TLS_CERT"):
+    # 4. NEXUS_TLS_CERT/KEY/CA env vars — only when explicitly requested
+    #    (avoids stale env vars flipping a plaintext server to mTLS)
+    if _explicit_on and os.environ.get("NEXUS_TLS_CERT"):
         cfg = ZoneTlsConfig.from_env()
         if cfg is not None:
             return cfg
 
     # 5. Explicit enable requested but no certs found — fail closed
-    if grpc_tls in ("true", "1", "yes"):
+    if _explicit_on:
         raise RuntimeError(
             "NEXUS_GRPC_TLS=true but no TLS certificates found. "
             "Provide certs via NEXUS_TLS_CERT/KEY/CA, "

--- a/src/nexus/grpc/server.py
+++ b/src/nexus/grpc/server.py
@@ -52,10 +52,10 @@ def _resolve_tls_config(app: "FastAPI") -> "ZoneTlsConfig | None":
         if tls_cfg is not None:
             return tls_cfg
 
-    # 3. Load from NEXUS_DATA_DIR/tls/ (Raft-style ca.pem/node.pem layout)
+    # 3. Load from NEXUS_DATA_DIR/tls/ (Raft or OpenSSL layout)
     data_dir = os.environ.get("NEXUS_DATA_DIR")
     if data_dir:
-        cfg = ZoneTlsConfig.from_data_dir(data_dir)
+        cfg = ZoneTlsConfig.from_data_dir_any(data_dir)
         if cfg is not None:
             return cfg
 

--- a/src/nexus/grpc/server.py
+++ b/src/nexus/grpc/server.py
@@ -27,9 +27,10 @@ def _resolve_tls_config(app: "FastAPI") -> "ZoneTlsConfig | None":
     Priority:
     1. NEXUS_GRPC_TLS=false → disable TLS unconditionally
     2. ZoneManager.tls_config (Raft / federation)
-    3. Auto-detect from {NEXUS_DATA_DIR}/tls/
-    4. NEXUS_GRPC_TLS=true but no certs → raise (fail closed)
-    5. None → insecure (no certs, no explicit request)
+    3. Auto-detect from {NEXUS_DATA_DIR}/tls/ (Raft-style PEM layout)
+    4. NEXUS_TLS_CERT/KEY/CA env vars (OpenSSL-style, set by nexus up)
+    5. NEXUS_GRPC_TLS=true but no certs → raise (fail closed)
+    6. None → insecure (no certs, no explicit request)
 
     NEXUS_GRPC_TLS=false is an unconditional override (step 1).
     NEXUS_GRPC_TLS=true ensures TLS is required — if no certs are
@@ -51,18 +52,25 @@ def _resolve_tls_config(app: "FastAPI") -> "ZoneTlsConfig | None":
         if tls_cfg is not None:
             return tls_cfg
 
-    # 3. Load from NEXUS_DATA_DIR/tls/
+    # 3. Load from NEXUS_DATA_DIR/tls/ (Raft-style ca.pem/node.pem layout)
     data_dir = os.environ.get("NEXUS_DATA_DIR")
     if data_dir:
         cfg = ZoneTlsConfig.from_data_dir(data_dir)
         if cfg is not None:
             return cfg
 
-    # 4. Explicit enable requested but no certs found — fail closed
+    # 4. NEXUS_TLS_CERT/KEY/CA env vars (OpenSSL-style, set by `nexus up`)
+    if os.environ.get("NEXUS_TLS_CERT"):
+        cfg = ZoneTlsConfig.from_env()
+        if cfg is not None:
+            return cfg
+
+    # 5. Explicit enable requested but no certs found — fail closed
     if grpc_tls in ("true", "1", "yes"):
         raise RuntimeError(
             "NEXUS_GRPC_TLS=true but no TLS certificates found. "
-            "Provide certs in {NEXUS_DATA_DIR}/tls/ or configure ZoneManager."
+            "Provide certs via NEXUS_TLS_CERT/KEY/CA, "
+            "in {NEXUS_DATA_DIR}/tls/, or configure ZoneManager."
         )
 
     return None

--- a/src/nexus/security/tls/config.py
+++ b/src/nexus/security/tls/config.py
@@ -23,20 +23,36 @@ class ZoneTlsConfig:
     def from_data_dir(cls, data_dir: str | Path) -> ZoneTlsConfig | None:
         """Auto-detect TLS config from ``{data_dir}/tls/``.
 
-        Returns ``None`` if the expected certificate files do not exist.
+        Checks two layouts:
+        1. Raft-style: ``ca.pem``, ``node.pem``, ``node-key.pem``
+        2. OpenSSL-style (``nexus init --tls``): ``ca.crt``, ``server.crt``, ``server.key``
+
+        Returns ``None`` if no recognized certificate layout exists.
         """
         tls_dir = Path(data_dir) / "tls"
+        # 1. Raft-style layout
         ca = tls_dir / "ca.pem"
         cert = tls_dir / "node.pem"
         key = tls_dir / "node-key.pem"
-        if not (ca.exists() and cert.exists() and key.exists()):
-            return None
-        return cls(
-            ca_cert_path=ca,
-            node_cert_path=cert,
-            node_key_path=key,
-            known_zones_path=tls_dir / "known_zones",
-        )
+        if ca.exists() and cert.exists() and key.exists():
+            return cls(
+                ca_cert_path=ca,
+                node_cert_path=cert,
+                node_key_path=key,
+                known_zones_path=tls_dir / "known_zones",
+            )
+        # 2. OpenSSL-style layout (nexus init --tls)
+        ca_ssl = tls_dir / "ca.crt"
+        cert_ssl = tls_dir / "server.crt"
+        key_ssl = tls_dir / "server.key"
+        if ca_ssl.exists() and cert_ssl.exists() and key_ssl.exists():
+            return cls(
+                ca_cert_path=ca_ssl,
+                node_cert_path=cert_ssl,
+                node_key_path=key_ssl,
+                known_zones_path=tls_dir / "known_zones",
+            )
+        return None
 
     @classmethod
     def from_env(cls) -> ZoneTlsConfig | None:

--- a/src/nexus/security/tls/config.py
+++ b/src/nexus/security/tls/config.py
@@ -21,38 +21,51 @@ class ZoneTlsConfig:
 
     @classmethod
     def from_data_dir(cls, data_dir: str | Path) -> ZoneTlsConfig | None:
-        """Auto-detect TLS config from ``{data_dir}/tls/``.
+        """Auto-detect TLS config from ``{data_dir}/tls/`` (Raft layout).
 
-        Checks two layouts:
-        1. Raft-style: ``ca.pem``, ``node.pem``, ``node-key.pem``
-        2. OpenSSL-style (``nexus init --tls``): ``ca.crt``, ``server.crt``, ``server.key``
+        Recognizes the Raft/federation layout only: ``ca.pem``,
+        ``node.pem``, ``node-key.pem``.  Used by ZoneManager to decide
+        whether to auto-generate federation certs — must NOT match the
+        OpenSSL layout to avoid suppressing Raft bootstrap.
 
-        Returns ``None`` if no recognized certificate layout exists.
+        Returns ``None`` if the expected certificate files do not exist.
         """
         tls_dir = Path(data_dir) / "tls"
-        # 1. Raft-style layout
         ca = tls_dir / "ca.pem"
         cert = tls_dir / "node.pem"
         key = tls_dir / "node-key.pem"
-        if ca.exists() and cert.exists() and key.exists():
-            return cls(
-                ca_cert_path=ca,
-                node_cert_path=cert,
-                node_key_path=key,
-                known_zones_path=tls_dir / "known_zones",
-            )
-        # 2. OpenSSL-style layout (nexus init --tls)
-        ca_ssl = tls_dir / "ca.crt"
-        cert_ssl = tls_dir / "server.crt"
-        key_ssl = tls_dir / "server.key"
-        if ca_ssl.exists() and cert_ssl.exists() and key_ssl.exists():
-            return cls(
-                ca_cert_path=ca_ssl,
-                node_cert_path=cert_ssl,
-                node_key_path=key_ssl,
-                known_zones_path=tls_dir / "known_zones",
-            )
-        return None
+        if not (ca.exists() and cert.exists() and key.exists()):
+            return None
+        return cls(
+            ca_cert_path=ca,
+            node_cert_path=cert,
+            node_key_path=key,
+            known_zones_path=tls_dir / "known_zones",
+        )
+
+    @classmethod
+    def from_data_dir_any(cls, data_dir: str | Path) -> ZoneTlsConfig | None:
+        """Auto-detect TLS config from ``{data_dir}/tls/`` (any layout).
+
+        Checks Raft-style first, then OpenSSL-style (``ca.crt``,
+        ``server.crt``, ``server.key`` from ``nexus init --tls``).
+        Used by the gRPC server/client — NOT by ZoneManager.
+        """
+        cfg = cls.from_data_dir(data_dir)
+        if cfg is not None:
+            return cfg
+        tls_dir = Path(data_dir) / "tls"
+        ca = tls_dir / "ca.crt"
+        cert = tls_dir / "server.crt"
+        key = tls_dir / "server.key"
+        if not (ca.exists() and cert.exists() and key.exists()):
+            return None
+        return cls(
+            ca_cert_path=ca,
+            node_cert_path=cert,
+            node_key_path=key,
+            known_zones_path=tls_dir / "known_zones",
+        )
 
     @classmethod
     def from_env(cls) -> ZoneTlsConfig | None:


### PR DESCRIPTION
## Summary

- Add `nexus demo init --skip-semantic` step in CI before E2E tests — seeds `/workspace/demo/` files (README.md, plan.md, HERB corpus) that the build-perf test expects
- Review-loop TLS hardening (rounds 3-4 of adversarial review):
  - `resolve_connection_env()` emits `NEXUS_GRPC_TLS=true` alongside `NEXUS_TLS_*` from runtime state
  - SDK `connect()` only consults `NEXUS_TLS_*` under explicit `NEXUS_GRPC_TLS=true` (avoids stale env)
  - Admin CLI: `false` is unconditional disable matching server semantics

Follow-up to #3752.

## Test plan

- [x] Ruff + mypy pass
- [x] Unit tests pass (27/27)
- [ ] CI E2E edge smoke tests pass (demo files seeded + gRPC insecure)