### PR TITLE
feat(#3720): grep block_type filter for markdown files

### DIFF
--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -967,6 +967,7 @@ async def create_mcp_server(
         before_context: int = 0,
         after_context: int = 0,
         invert_match: bool = False,
+        block_type: str | None = None,
         ctx: Context | None = None,
     ) -> str:
         """Search file contents using regex pattern with pagination.
@@ -989,6 +990,12 @@ async def create_mcp_server(
                 (#3701 follow-up). Equivalent to ``grep -A N``.
             invert_match: Return non-matching lines instead of matches
                 (#3701 follow-up). Equivalent to ``grep -v`` / ``--invert-match``.
+            block_type: Restrict matches to a specific markdown block type
+                (#3720). Only matches inside blocks of this type are
+                returned. Valid values: ``"code"``, ``"table"``,
+                ``"frontmatter"``, ``"paragraph"``, ``"blockquote"``,
+                ``"list"``, ``"heading"``. Non-markdown files pass
+                through unfiltered. Omit for default full-file search.
 
         Returns:
             Formatted string with paginated search results containing:
@@ -1038,6 +1045,8 @@ async def create_mcp_server(
             grep_kwargs["after_context"] = after_context
         if invert_match:
             grep_kwargs["invert_match"] = True
+        if block_type is not None:
+            grep_kwargs["block_type"] = block_type
 
         all_results = await _search.grep(pattern, path, **grep_kwargs)
         raw_count = len(all_results)

--- a/src/nexus/bricks/parsers/md_structure.py
+++ b/src/nexus/bricks/parsers/md_structure.py
@@ -23,7 +23,8 @@ from markdown_it import MarkdownIt
 logger = logging.getLogger(__name__)
 
 # Schema version — bump when the stored JSON shape changes.
-SCHEMA_VERSION = 1
+# v2: added paragraph, blockquote, list, heading block types (#3720).
+SCHEMA_VERSION = 2
 
 # ---------------------------------------------------------------------------
 # Data model
@@ -289,6 +290,10 @@ def _parse_rust(content: bytes, content_hash: str) -> MarkdownStructureIndex:
 
         byte_start, byte_end = srcmap
 
+        # Helper: exclusive line_end for Rust srcmap byte ranges.
+        def _excl_line_end() -> int:
+            return _byte_end_to_line_exclusive(byte_end, byte_start, line_offsets)
+
         if node.name == "front_matter":
             fm_text = content[byte_start:byte_end].decode("utf-8", errors="replace")
             keys = _extract_yaml_keys(fm_text)
@@ -296,7 +301,7 @@ def _parse_rust(content: bytes, content_hash: str) -> MarkdownStructureIndex:
                 byte_start=byte_start,
                 byte_end=byte_end,
                 line_start=_byte_to_line(byte_start, line_offsets),
-                line_end=_byte_to_line(byte_end, line_offsets),
+                line_end=_excl_line_end(),
                 keys=keys,
             )
 
@@ -317,11 +322,22 @@ def _parse_rust(content: bytes, content_hash: str) -> MarkdownStructureIndex:
                         cs, ce = child.srcmap
                         heading_text = content[cs:ce].decode("utf-8", errors="replace").strip()
                         break
+            h_line_start = _byte_to_line(byte_start, line_offsets)
             headings.append(
                 _RawHeading(
                     text=heading_text,
                     depth=depth,
-                    line_start=_byte_to_line(byte_start, line_offsets),
+                    line_start=h_line_start,
+                )
+            )
+            # Issue #3720: also record as a searchable block.
+            blocks.append(
+                BlockInfo(
+                    type="heading",
+                    byte_start=byte_start,
+                    byte_end=byte_end,
+                    line_start=h_line_start,
+                    line_end=_excl_line_end(),
                 )
             )
 
@@ -339,7 +355,7 @@ def _parse_rust(content: bytes, content_hash: str) -> MarkdownStructureIndex:
                     byte_start=byte_start,
                     byte_end=byte_end,
                     line_start=_byte_to_line(byte_start, line_offsets),
-                    line_end=_byte_to_line(byte_end, line_offsets),
+                    line_end=_excl_line_end(),
                     language=language,
                 )
             )
@@ -355,14 +371,48 @@ def _parse_rust(content: bytes, content_hash: str) -> MarkdownStructureIndex:
                     byte_start=byte_start,
                     byte_end=byte_end,
                     line_start=_byte_to_line(byte_start, line_offsets),
-                    line_end=_byte_to_line(byte_end, line_offsets),
+                    line_end=_excl_line_end(),
                     rows=row_count,
                 )
             )
 
+        # Issue #3720: track paragraph, blockquote, list blocks.
+        elif node.name == "paragraph":
+            blocks.append(
+                BlockInfo(
+                    type="paragraph",
+                    byte_start=byte_start,
+                    byte_end=byte_end,
+                    line_start=_byte_to_line(byte_start, line_offsets),
+                    line_end=_excl_line_end(),
+                )
+            )
+
+        elif node.name == "blockquote":
+            blocks.append(
+                BlockInfo(
+                    type="blockquote",
+                    byte_start=byte_start,
+                    byte_end=byte_end,
+                    line_start=_byte_to_line(byte_start, line_offsets),
+                    line_end=_excl_line_end(),
+                )
+            )
+
+        elif node.name in ("bullet_list", "ordered_list"):
+            blocks.append(
+                BlockInfo(
+                    type="list",
+                    byte_start=byte_start,
+                    byte_end=byte_end,
+                    line_start=_byte_to_line(byte_start, line_offsets),
+                    line_end=_excl_line_end(),
+                )
+            )
+
         # Recurse into container blocks (blockquotes, list items, etc.)
-        # to find nested fences/tables.
-        if node.name not in ("fence", "front_matter", "heading", "lheading", "table"):
+        # to find nested fences/tables and other tracked blocks.
+        if node.name not in ("fence", "front_matter", "heading", "lheading", "table", "paragraph"):
             for child in node.children:
                 _walk(child)
 
@@ -380,6 +430,23 @@ def _byte_to_line(byte_offset: int, line_offsets: list[int]) -> int:
         else:
             hi = mid - 1
     return lo
+
+
+def _byte_end_to_line_exclusive(byte_end: int, byte_start: int, line_offsets: list[int]) -> int:
+    """Convert an *exclusive* byte-end offset to an exclusive 0-indexed line.
+
+    Rust's ``srcmap`` gives ``(byte_start, byte_end)`` where ``byte_end``
+    is exclusive (one past the last byte).  ``_byte_to_line(byte_end)``
+    returns the line *containing* ``byte_end``, which equals
+    ``line_start`` for single-line blocks — producing an empty
+    ``[start, start)`` range.
+
+    Fix: convert the last *inclusive* byte (``byte_end - 1``) to a line,
+    then add 1 to make the result exclusive.
+    """
+    if byte_end <= byte_start:
+        return _byte_to_line(byte_start, line_offsets) + 1
+    return _byte_to_line(byte_end - 1, line_offsets) + 1
 
 
 # ---------------------------------------------------------------------------
@@ -419,11 +486,22 @@ def _parse_python(content: bytes, content_hash: str) -> MarkdownStructureIndex:
             heading_text = ""
             if i + 1 < len(tokens) and tokens[i + 1].type == "inline":
                 heading_text = tokens[i + 1].content
+            h_start, h_end = tok.map
             headings.append(
                 _RawHeading(
                     text=heading_text,
                     depth=depth,
-                    line_start=tok.map[0],
+                    line_start=h_start,
+                )
+            )
+            # Issue #3720: also record as a searchable block.
+            blocks.append(
+                BlockInfo(
+                    type="heading",
+                    byte_start=line_offsets[h_start],
+                    byte_end=line_offsets[min(h_end, len(line_offsets) - 1)],
+                    line_start=h_start,
+                    line_end=h_end,
                 )
             )
 
@@ -464,6 +542,43 @@ def _parse_python(content: bytes, content_hash: str) -> MarkdownStructureIndex:
                 )
             )
 
+        # Issue #3720: paragraph, blockquote, list blocks.
+        elif tok.type == "paragraph_open" and tok.map is not None:
+            p_start, p_end = tok.map
+            blocks.append(
+                BlockInfo(
+                    type="paragraph",
+                    byte_start=line_offsets[p_start],
+                    byte_end=line_offsets[min(p_end, len(line_offsets) - 1)],
+                    line_start=p_start,
+                    line_end=p_end,
+                )
+            )
+
+        elif tok.type == "blockquote_open" and tok.map is not None:
+            bq_start, bq_end = tok.map
+            blocks.append(
+                BlockInfo(
+                    type="blockquote",
+                    byte_start=line_offsets[bq_start],
+                    byte_end=line_offsets[min(bq_end, len(line_offsets) - 1)],
+                    line_start=bq_start,
+                    line_end=bq_end,
+                )
+            )
+
+        elif tok.type in ("bullet_list_open", "ordered_list_open") and tok.map is not None:
+            li_start, li_end = tok.map
+            blocks.append(
+                BlockInfo(
+                    type="list",
+                    byte_start=line_offsets[li_start],
+                    byte_end=line_offsets[min(li_end, len(line_offsets) - 1)],
+                    line_start=li_start,
+                    line_end=li_end,
+                )
+            )
+
         i += 1
 
     return _build_index(headings, blocks, frontmatter, line_offsets, content_hash)
@@ -484,6 +599,32 @@ def _build_index(
     """Build hierarchical sections from raw headings and blocks."""
     total_lines = len(line_offsets) - 1
     sections: list[SectionInfo] = []
+
+    # Issue #3720 (Codex R1): synthesize a root section for content
+    # before the first heading (or the entire file if headingless) so
+    # blocks in that region are searchable via block_type filtering.
+    first_heading_line = headings[0].line_start if headings else total_lines
+    fm_end = frontmatter.line_end if frontmatter else 0
+    preamble_start = fm_end  # skip frontmatter lines
+    if first_heading_line > preamble_start:
+        pre_blocks = [
+            b for b in blocks if b.line_start >= preamble_start and b.line_end <= first_heading_line
+        ]
+        if pre_blocks:
+            pre_byte_start = line_offsets[preamble_start]
+            pre_byte_end = line_offsets[min(first_heading_line, len(line_offsets) - 1)]
+            sections.append(
+                SectionInfo(
+                    heading="",
+                    depth=0,
+                    byte_start=pre_byte_start,
+                    byte_end=pre_byte_end,
+                    line_start=preamble_start,
+                    line_end=first_heading_line,
+                    tokens_est=(pre_byte_end - pre_byte_start) // 4,
+                    blocks=pre_blocks,
+                )
+            )
 
     for idx, h in enumerate(headings):
         section_line_start = h.line_start

--- a/src/nexus/bricks/parsers/md_structure_hook.py
+++ b/src/nexus/bricks/parsers/md_structure_hook.py
@@ -35,6 +35,8 @@ logger = logging.getLogger(__name__)
 
 # Metadata key used to store the structural index.
 MD_STRUCTURE_KEY = "md_structure"
+# Issue #3720 (Codex R5): shared markdown extension set.
+_MARKDOWN_EXTENSIONS: tuple[str, ...] = (".md", ".markdown", ".mdown", ".mkd")
 
 
 class MarkdownStructureWriteHook:
@@ -62,7 +64,7 @@ class MarkdownStructureWriteHook:
         """Parse markdown structure and store index after .md writes."""
         if self._metadata is None:
             return
-        if not ctx.path.endswith(".md"):
+        if not ctx.path.lower().endswith(_MARKDOWN_EXTENSIONS):
             return
         # Skip streamed/empty writes — they pass content=b'' with no hash.
         # Persisting an empty index would poison the cache.
@@ -209,6 +211,11 @@ class MarkdownStructureWriteHook:
             )
 
         for sec in index.sections:
+            # Issue #3720 (Codex R2): skip synthetic root sections
+            # (depth=0, empty heading) from structure listings so the
+            # grep-only preamble fix doesn't pollute outline APIs.
+            if sec.depth == 0 and sec.heading == "":
+                continue
             block_types = list({b.type for b in sec.blocks})
             entry: dict[str, Any] = {
                 "type": "section",

--- a/src/nexus/bricks/parsers/utils.py
+++ b/src/nexus/bricks/parsers/utils.py
@@ -25,7 +25,13 @@ def extract_structure(text: str) -> dict[str, Any]:
     """
     content = text.encode("utf-8")
     index = parse_markdown_structure(content)
-    headings = [{"level": s.depth, "text": s.heading} for s in index.sections]
+    # Issue #3720 (Codex R3): skip synthetic root sections (depth=0,
+    # empty heading) so the preamble fix doesn't leak into structure APIs.
+    headings = [
+        {"level": s.depth, "text": s.heading}
+        for s in index.sections
+        if not (s.depth == 0 and s.heading == "")
+    ]
     return {
         "headings": headings,
         "has_headings": len(headings) > 0,
@@ -50,11 +56,15 @@ def create_chunks(text: str) -> list[TextChunk]:
     content = text.encode("utf-8")
     index = parse_markdown_structure(content)
 
-    if not index.sections:
+    # Issue #3720 (Codex R6): filter out synthetic root sections
+    # (depth=0, empty heading) so chunking logic sees only real headings.
+    real_sections = [s for s in index.sections if not (s.depth == 0 and s.heading == "")]
+
+    if not real_sections:
         return [TextChunk(text=text, start_index=0, end_index=len(text))]
 
     # Sort all sections by byte_start to get document order.
-    ordered = sorted(index.sections, key=lambda s: s.byte_start)
+    ordered = sorted(real_sections, key=lambda s: s.byte_start)
 
     # Deduplicate positions (hierarchical sections can share a start).
     seen_starts: set[int] = set()

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -64,6 +64,25 @@ FILES_FILTER_TRIGRAM_THRESHOLD = 200
 # the ReBAC over-fetch factor — adjust if benchmarks show a better value.
 _REBAC_OVERFETCH_FACTOR_FOR_FILES = 3
 
+# Issue #3720: block_type filter for markdown grep.  When set, grep
+# over-fetches internally (most matches may be in prose) then post-filters
+# to lines inside the requested block type's line ranges.
+VALID_BLOCK_TYPES: frozenset[str] = frozenset(
+    {
+        "code",
+        "table",
+        "frontmatter",
+        "paragraph",
+        "blockquote",
+        "list",
+        "heading",
+    }
+)
+# Issue #3720 (Codex R4): markdown file extensions for block_type filtering.
+_MARKDOWN_EXTENSIONS: tuple[str, ...] = (".md", ".markdown", ".mdown", ".mkd")
+_BLOCK_TYPE_OVERFETCH_FACTOR = 5
+_BLOCK_TYPE_OVERFETCH_CAP = 2000
+
 # Zone-aware path prefixes for cross-zone filtering (Issue #899)
 ZONE_AWARE_PREFIXES: tuple[str, ...] = ("/zones/", "/shared/", "/archives/")
 
@@ -1978,6 +1997,7 @@ class SearchService:
         after_context: int = 0,
         invert_match: bool = False,
         files: builtins.list[str] | None = None,
+        block_type: str | None = None,
     ) -> builtins.list[dict[str, Any]]:
         r"""Search file contents using regex patterns.
 
@@ -2002,15 +2022,38 @@ class SearchService:
                 ``files ∩ glob(file_pattern)`` when both are present.
                 See ``_validate_and_normalize_files`` for the full
                 edge-case spec.
+            block_type: #3720: optional markdown block type filter.
+                When set, only return matches from lines inside blocks
+                of the given type.  Valid values: ``"code"``,
+                ``"table"``, ``"frontmatter"``.  Non-markdown files
+                (or markdown files without ``md_structure`` metadata)
+                pass through unfiltered.
         """
         if path and path != "/":
             path = self._validate_path(path)
+
+        # Issue #3720: validate block_type early.
+        if block_type is not None and block_type not in VALID_BLOCK_TYPES:
+            raise ValueError(
+                f"Invalid block_type {block_type!r}. "
+                f"Valid values: {', '.join(sorted(VALID_BLOCK_TYPES))}"
+            )
 
         flags = re.IGNORECASE if ignore_case else 0
         try:
             regex = re.compile(pattern, flags)
         except re.error as e:
             raise ValueError(f"Invalid regex pattern: {e}") from e
+
+        # Issue #3720: over-fetch when block_type filtering will discard
+        # some matches.  The original max_results is restored after
+        # post-filtering so callers see the expected result count.
+        original_max_results = max_results
+        if block_type is not None:
+            max_results = min(
+                max_results * _BLOCK_TYPE_OVERFETCH_FACTOR,
+                max(max_results, _BLOCK_TYPE_OVERFETCH_CAP),
+            )
 
         # Phase 1: Get files to search.
         #
@@ -2070,7 +2113,13 @@ class SearchService:
         # threshold lives in ``FILES_FILTER_TRIGRAM_THRESHOLD`` and is
         # benchmark-backed.
         zone_id, _, _ = self._get_routing_params(context)
-        if needs_python_path:
+        if block_type is not None:
+            # Issue #3720 (Codex R2+R5): block_type MUST use SEQUENTIAL
+            # to ensure ALL files (cached + uncached) are searched.
+            # CACHED_TEXT skips files_needing_raw; TRIGRAM/ZOEKT return
+            # a fixed page that may miss qualifying block matches.
+            strategy = SearchStrategy.SEQUENTIAL
+        elif needs_python_path:
             # Force a Python-loop strategy so context/invert flags take
             # effect. CACHED_TEXT is preferred when the metastore has
             # text cached for most candidates; otherwise SEQUENTIAL
@@ -2134,6 +2183,12 @@ class SearchService:
                     trigram_results = [
                         r for r in trigram_results if r.get("file") in _files_filter_set
                     ][:max_results]
+                # Issue #3720: apply block_type post-filter before returning.
+                if block_type is not None:
+                    trigram_results = self._filter_results_by_block_type(
+                        trigram_results, block_type
+                    )
+                    return trigram_results[:original_max_results]
                 return trigram_results
             strategy = SearchStrategy.RUST_BULK  # Fallback
 
@@ -2148,6 +2203,10 @@ class SearchService:
                 context=context,
             )
             if zoekt_results is not None:
+                # Issue #3720: apply block_type post-filter before returning.
+                if block_type is not None:
+                    zoekt_results = self._filter_results_by_block_type(zoekt_results, block_type)
+                    return zoekt_results[:original_max_results]
                 return zoekt_results
             strategy = SearchStrategy.RUST_BULK
 
@@ -2168,43 +2227,50 @@ class SearchService:
                         max_results=max_results - len(results),
                     )
                 )
-            if strategy == SearchStrategy.CACHED_TEXT and len(results) >= max_results:
+            if (
+                strategy == SearchStrategy.CACHED_TEXT
+                and block_type is None
+                and len(results) >= max_results
+            ):
                 return results[:max_results]
 
-        if len(results) >= max_results:
+        if block_type is None and len(results) >= max_results:
             return results[:max_results]
 
         # Process remaining files needing raw content
-        if not files_needing_raw:
-            return results
+        if files_needing_raw:
+            remaining_results = max_results - len(results)
 
-        remaining_results = max_results - len(results)
+            if strategy == SearchStrategy.PARALLEL_POOL:
+                results.extend(
+                    await self._grep_parallel(
+                        regex=regex,
+                        files=files_needing_raw,
+                        max_results=remaining_results,
+                        context=context,
+                    )
+                )
+            elif strategy in (SearchStrategy.RUST_BULK, SearchStrategy.SEQUENTIAL):
+                results.extend(
+                    await self._grep_raw_content(
+                        regex=regex,
+                        pattern=pattern,
+                        files_needing_raw=files_needing_raw,
+                        strategy=strategy,
+                        ignore_case=ignore_case,
+                        remaining_results=remaining_results,
+                        context=context,
+                        before_context=before_context,
+                        after_context=after_context,
+                        invert_match=invert_match,
+                        force_python_path=needs_python_path,
+                    )
+                )
 
-        if strategy == SearchStrategy.PARALLEL_POOL:
-            results.extend(
-                await self._grep_parallel(
-                    regex=regex,
-                    files=files_needing_raw,
-                    max_results=remaining_results,
-                    context=context,
-                )
-            )
-        elif strategy in (SearchStrategy.RUST_BULK, SearchStrategy.SEQUENTIAL):
-            results.extend(
-                await self._grep_raw_content(
-                    regex=regex,
-                    pattern=pattern,
-                    files_needing_raw=files_needing_raw,
-                    strategy=strategy,
-                    ignore_case=ignore_case,
-                    remaining_results=remaining_results,
-                    context=context,
-                    before_context=before_context,
-                    after_context=after_context,
-                    invert_match=invert_match,
-                    force_python_path=needs_python_path,
-                )
-            )
+        # Issue #3720: post-filter by block_type when requested.
+        if block_type is not None:
+            results = self._filter_results_by_block_type(results, block_type)
+            max_results = original_max_results
 
         return results[:max_results]
 
@@ -2294,6 +2360,107 @@ class SearchService:
                 results.append(entry)
 
         return results
+
+    def _filter_results_by_block_type(
+        self,
+        results: builtins.list[dict[str, Any]],
+        block_type: str,
+    ) -> builtins.list[dict[str, Any]]:
+        """Post-filter grep results to lines inside *block_type* regions.
+
+        Issue #3720.  For each ``.md`` file in *results*, fetches the
+        ``md_structure`` index from the metastore and keeps only matches
+        whose 0-indexed line falls within a block of the requested type.
+        Non-markdown files (or markdown files without stored metadata)
+        pass through unfiltered.
+
+        Works directly with the raw JSON dict to avoid cross-brick
+        imports (``nexus.bricks.parsers`` is a separate brick).
+        """
+        import json as _json
+
+        MD_STRUCTURE_KEY = "md_structure"  # noqa: N806
+        _V2_BLOCK_TYPES = frozenset({"paragraph", "blockquote", "list", "heading"})
+
+        # Group results by file so we fetch metadata once per file.
+        by_file: dict[str, builtins.list[dict[str, Any]]] = {}
+        for r in results:
+            by_file.setdefault(r.get("file", ""), []).append(r)
+
+        filtered: builtins.list[dict[str, Any]] = []
+        start = time.monotonic()
+
+        for file_path, file_results in by_file.items():
+            if not file_path.lower().endswith(_MARKDOWN_EXTENSIONS):
+                # Non-markdown — include all results (decision #4A).
+                filtered.extend(file_results)
+                continue
+
+            # Fetch md_structure metadata for this file.
+            raw = self.metadata.get_file_metadata(file_path, MD_STRUCTURE_KEY)
+            if raw is None:
+                # Issue #3720 (Codex R6): recognized markdown without
+                # metadata → fail closed.
+                logger.debug(
+                    "No md_structure for %s — excluding results (fail closed)",
+                    file_path,
+                )
+                continue
+
+            try:
+                data: dict[str, Any] = raw if isinstance(raw, dict) else _json.loads(raw)
+            except Exception:
+                # Issue #3720 (Codex R7): fail closed on corrupt metadata.
+                logger.debug("Corrupt md_structure for %s — excluding results", file_path)
+                continue
+
+            # Issue #3720 (Codex R1+R2): v1 indices don't contain the
+            # new block types. Fail closed.
+            version = data.get("version", 1)
+            if version < 2 and block_type in _V2_BLOCK_TYPES:
+                logger.warning(
+                    "md_structure v%d for %s lacks %s blocks — "
+                    "excluding results until file is reindexed "
+                    "(rewrite the file or run a reindex to upgrade)",
+                    version,
+                    file_path,
+                    block_type,
+                )
+                continue
+
+            # Build a flat list of (line_start, line_end) for the requested
+            # block type. Normalize frontmatter into the same shape.
+            block_ranges: builtins.list[tuple[int, int]] = []
+            if block_type == "frontmatter":
+                fm = data.get("frontmatter")
+                if fm is not None:
+                    block_ranges.append((fm["line_start"], fm["line_end"]))
+            else:
+                for section in data.get("sections", []):
+                    for blk in section.get("blocks", []):
+                        if blk.get("type") == block_type:
+                            block_ranges.append((blk["line_start"], blk["line_end"]))
+
+            # Filter: keep results whose 0-indexed line falls in a range.
+            for r in file_results:
+                line_0 = r.get("line", 0) - 1  # grep results are 1-indexed
+                for rng_start, rng_end in block_ranges:
+                    if rng_start <= line_0 < rng_end:
+                        filtered.append(r)
+                        break
+
+        elapsed_ms = (time.monotonic() - start) * 1000
+        if elapsed_ms > 5:
+            logger.debug(
+                "[GREP] Issue #3720: block_type=%s filter took %.1f ms (%d→%d results, %d files)",
+                block_type,
+                elapsed_ms,
+                len(results),
+                len(filtered),
+                len(by_file),
+            )
+
+        return filtered
 
     async def _grep_raw_content(
         self,

--- a/src/nexus/cli/commands/search.py
+++ b/src/nexus/cli/commands/search.py
@@ -309,6 +309,17 @@ def glob(
         "``nexus grep 'auth' -l | nexus grep 'JWT' --files-from=-``."
     ),
 )
+@click.option(
+    "--block-type",
+    type=click.Choice(
+        ["code", "table", "frontmatter", "paragraph", "blockquote", "list", "heading"]
+    ),
+    default=None,
+    help=(
+        "Restrict matches to a markdown block type (#3720). "
+        "Non-markdown files pass through unfiltered."
+    ),
+)
 @add_output_options
 @add_backend_options
 def grep(
@@ -327,6 +338,7 @@ def grep(
     search_mode: str,
     files: tuple[str, ...],
     files_from: str | None,
+    block_type: str | None,
     output_opts: OutputOptions,
     remote_url: str | None,
     remote_api_key: str | None,
@@ -383,6 +395,8 @@ def grep(
                         grep_kwargs["invert_match"] = True
                     if files_list is not None:
                         grep_kwargs["files"] = files_list
+                    if block_type is not None:
+                        grep_kwargs["block_type"] = block_type
 
                     result = nx.service("search").grep(pattern, **grep_kwargs)
 

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -690,6 +690,7 @@ async def _do_grep_operation(
     after_context: int,
     invert_match: bool,
     files: list[str] | None,
+    block_type: str | None = None,
 ) -> dict[str, Any]:
     """Execute a grep request and assemble the paginated response.
 
@@ -729,17 +730,21 @@ async def _do_grep_operation(
     )
 
     try:
-        raw_results = await search_service.grep(
-            pattern=pattern,
-            path=path,
-            ignore_case=ignore_case,
-            max_results=fetch_limit,
-            context=op_context,
-            before_context=before_context,
-            after_context=after_context,
-            invert_match=invert_match,
-            files=files,
-        )
+        grep_kwargs: dict[str, Any] = {
+            "pattern": pattern,
+            "path": path,
+            "ignore_case": ignore_case,
+            "max_results": fetch_limit,
+            "context": op_context,
+            "before_context": before_context,
+            "after_context": after_context,
+            "invert_match": invert_match,
+            "files": files,
+        }
+        # Issue #3720: only forward block_type when set (backward compat).
+        if block_type is not None:
+            grep_kwargs["block_type"] = block_type
+        raw_results = await search_service.grep(**grep_kwargs)
     except (ValueError, InvalidPathError) as exc:
         # Client errors from SearchService:
         #  * ValueError — invalid regex, size cap exceeded, cross-zone entry
@@ -998,6 +1003,15 @@ async def search_grep(
             "set of file paths instead of walking the tree (#3701)."
         ),
     ),
+    block_type: str | None = Query(
+        None,
+        description=(
+            "Restrict matches to a specific markdown block type (#3720). "
+            "Valid values: code, table, frontmatter, paragraph, "
+            "blockquote, list, heading. Non-markdown files pass through "
+            "unfiltered."
+        ),
+    ),
     auth_result: dict[str, Any] = Depends(require_auth),
 ) -> dict[str, Any]:
     """Search file contents via regex (#3701 Issue 1A).
@@ -1029,6 +1043,7 @@ async def search_grep(
         after_context=after_context,
         invert_match=invert_match,
         files=files,
+        block_type=block_type,
     )
 
 
@@ -1096,6 +1111,11 @@ async def search_grep_post(
 
     files = _body_get_files(body)
 
+    # Issue #3720: block_type (optional string, no type coercion needed).
+    block_type = body.get("block_type")
+    if block_type is not None and not isinstance(block_type, str):
+        raise HTTPException(status_code=400, detail="Field 'block_type' must be a string")
+
     return await _do_grep_operation(
         request,
         auth_result,
@@ -1108,6 +1128,7 @@ async def search_grep_post(
         after_context=after_context,
         invert_match=invert_match,
         files=files,
+        block_type=block_type,
     )
 
 

--- a/tests/integration/server/api/v2/routers/test_search_http_grep_glob.py
+++ b/tests/integration/server/api/v2/routers/test_search_http_grep_glob.py
@@ -235,6 +235,71 @@ class TestGrepHappyPath:
         assert data["next_offset"] is None
 
 
+class TestGrepBlockType:
+    """#3720: block_type filtering via HTTP grep endpoints."""
+
+    def test_get_block_type_forwarded(self) -> None:
+        """GET ?block_type=code forwards to SearchService."""
+        svc = _make_search_service(grep_return=[])
+        client = TestClient(_build_app(search_service=svc))
+        client.get("/api/v2/search/grep?pattern=SELECT&block_type=code")
+        kwargs = svc.grep.await_args.kwargs
+        assert kwargs["block_type"] == "code"
+
+    def test_post_block_type_forwarded(self) -> None:
+        """POST block_type in JSON body forwards to SearchService."""
+        svc = _make_search_service(grep_return=[])
+        client = TestClient(_build_app(search_service=svc))
+        client.post(
+            "/api/v2/search/grep",
+            json={"pattern": "SELECT", "block_type": "table"},
+        )
+        kwargs = svc.grep.await_args.kwargs
+        assert kwargs["block_type"] == "table"
+
+    def test_block_type_none_omitted(self) -> None:
+        """Default (no block_type) must NOT forward block_type to SearchService."""
+        svc = _make_search_service(grep_return=[])
+        client = TestClient(_build_app(search_service=svc))
+        client.get("/api/v2/search/grep?pattern=x")
+        kwargs = svc.grep.await_args.kwargs
+        assert "block_type" not in kwargs
+
+    def test_invalid_block_type_returns_400(self) -> None:
+        """SearchService raises ValueError for invalid block_type → 400."""
+        svc = _make_search_service(grep_raises=ValueError("Invalid block_type 'heading'"))
+        client = TestClient(_build_app(search_service=svc))
+        resp = client.get("/api/v2/search/grep?pattern=x&block_type=heading")
+        assert resp.status_code == 400
+        assert "block_type" in resp.json()["detail"]
+
+    def test_post_block_type_non_string_returns_400(self) -> None:
+        """POST block_type must be a string or null."""
+        svc = _make_search_service(grep_return=[])
+        client = TestClient(_build_app(search_service=svc))
+        resp = client.post(
+            "/api/v2/search/grep",
+            json={"pattern": "x", "block_type": 123},
+        )
+        assert resp.status_code == 400
+        assert "block_type" in resp.json()["detail"]
+
+    def test_block_type_pagination_total_reflects_filtered_count(self) -> None:
+        """When block_type filtering reduces results, 'total' reflects
+        the post-filter count, not the pre-filter count."""
+        # SearchService returns 5 results (already block-filtered internally).
+        results = [
+            {"file": f"/doc{i}.md", "line": i + 1, "content": "code", "match": "code"}
+            for i in range(5)
+        ]
+        svc = _make_search_service(grep_return=results)
+        client = TestClient(_build_app(search_service=svc))
+        resp = client.get("/api/v2/search/grep?pattern=code&block_type=code&limit=10")
+        data = resp.json()
+        assert data["total"] == 5
+        assert data["count"] == 5
+
+
 class TestGlobHappyPath:
     def test_basic_match_returns_paths(self) -> None:
         svc = _make_search_service(glob_return=["/a.py", "/b.py", "/c.py"])

--- a/tests/integration/services/test_search_service.py
+++ b/tests/integration/services/test_search_service.py
@@ -1374,3 +1374,390 @@ class TestGlobFilesParam:
             )
         # Only .py files survive the glob pattern.
         assert set(result) == {"/a.py", "/c.py"}
+
+
+# =============================================================================
+# Issue #3720: block_type filter for markdown grep
+# =============================================================================
+
+# Sample markdown with known block structure for testing.
+_MD_WITH_BLOCKS = """\
+---
+title: test
+---
+
+# Introduction
+
+This is prose text with SELECT query mentions.
+
+```sql
+SELECT * FROM users WHERE active = true;
+```
+
+More prose text here.
+
+| col1 | col2 |
+|------|------|
+| a    | b    |
+
+## Notes
+
+Final paragraph.
+"""
+
+
+def _make_md_structure_json():
+    """Build a realistic md_structure JSON matching _MD_WITH_BLOCKS."""
+    import json
+
+    return json.dumps(
+        {
+            "version": 2,
+            "content_hash": "abc123",
+            "tokens_est_method": "bytes/4",
+            "frontmatter": {
+                "byte_start": 0,
+                "byte_end": 20,
+                "line_start": 0,
+                "line_end": 3,
+                "keys": ["title"],
+            },
+            "sections": [
+                {
+                    "heading": "Introduction",
+                    "depth": 1,
+                    "byte_start": 21,
+                    "byte_end": 200,
+                    "line_start": 4,
+                    "line_end": 20,
+                    "tokens_est": 45,
+                    "blocks": [
+                        {
+                            "type": "heading",
+                            "byte_start": 21,
+                            "byte_end": 40,
+                            "line_start": 4,
+                            "line_end": 5,
+                        },
+                        {
+                            "type": "paragraph",
+                            "byte_start": 41,
+                            "byte_end": 79,
+                            "line_start": 6,
+                            "line_end": 7,
+                        },
+                        {
+                            "type": "code",
+                            "byte_start": 80,
+                            "byte_end": 140,
+                            "line_start": 8,
+                            "line_end": 11,
+                            "language": "sql",
+                        },
+                        {
+                            "type": "paragraph",
+                            "byte_start": 141,
+                            "byte_end": 159,
+                            "line_start": 12,
+                            "line_end": 13,
+                        },
+                        {
+                            "type": "table",
+                            "byte_start": 160,
+                            "byte_end": 200,
+                            "line_start": 14,
+                            "line_end": 17,
+                            "rows": 1,
+                        },
+                    ],
+                },
+                {
+                    "heading": "Notes",
+                    "depth": 2,
+                    "byte_start": 200,
+                    "byte_end": 250,
+                    "line_start": 20,
+                    "line_end": 23,
+                    "tokens_est": 12,
+                    "blocks": [
+                        {
+                            "type": "heading",
+                            "byte_start": 200,
+                            "byte_end": 210,
+                            "line_start": 20,
+                            "line_end": 21,
+                        },
+                        {
+                            "type": "paragraph",
+                            "byte_start": 211,
+                            "byte_end": 250,
+                            "line_start": 22,
+                            "line_end": 23,
+                        },
+                    ],
+                },
+            ],
+        }
+    )
+
+
+class TestGrepBlockType:
+    """Issue #3720: block_type filtering for markdown grep."""
+
+    @pytest.fixture
+    def service_with_md(self, mock_metadata_store, mock_gateway):
+        """SearchService with md_structure metadata pre-loaded."""
+
+        # Configure metastore to return md_structure for .md files.
+        def _get_file_metadata(path, key):
+            if path.endswith(".md") and key == "md_structure":
+                return _make_md_structure_json()
+            return None
+
+        mock_metadata_store.get_file_metadata.side_effect = _get_file_metadata
+        mock_metadata_store.get_searchable_text_bulk.return_value = {}
+
+        return SearchService(
+            metadata_store=mock_metadata_store,
+            gateway=mock_gateway,
+            enforce_permissions=False,
+        )
+
+    def _make_results(self, file_path: str, lines: list[int]) -> list[dict]:
+        """Build fake grep results at the given 1-indexed line numbers."""
+        return [
+            {"file": file_path, "line": ln, "content": f"line {ln}", "match": f"line {ln}"}
+            for ln in lines
+        ]
+
+    async def test_block_type_code_returns_only_code_block_matches(self, service_with_md, context):
+        """block_type='code' keeps only matches inside code fence lines."""
+        # Lines 9, 10 are inside the code block (line_start=8, line_end=11, 0-indexed).
+        # Line 7 is prose. Results are 1-indexed.
+        all_results = self._make_results("/doc.md", [8, 9, 10, 11])
+        with patch.object(service_with_md, "metadata") as mock_meta:
+            mock_meta.get_file_metadata.side_effect = lambda p, k: (
+                _make_md_structure_json() if p.endswith(".md") and k == "md_structure" else None
+            )
+            filtered = service_with_md._filter_results_by_block_type(all_results, "code")
+        # 0-indexed: lines 8,9,10 are inside [8,11). Line 11 (0-indexed=10) is inside.
+        # 1-indexed lines 9,10,11 map to 0-indexed 8,9,10 → inside [8,11).
+        # 1-indexed line 8 maps to 0-indexed 7 → NOT inside [8,11).
+        assert len(filtered) == 3
+        assert all(r["line"] in (9, 10, 11) for r in filtered)
+
+    async def test_block_type_table_returns_only_table_matches(self, service_with_md, context):
+        """block_type='table' keeps only matches inside table lines."""
+        all_results = self._make_results("/doc.md", [6, 15, 16, 22])
+        with patch.object(service_with_md, "metadata") as mock_meta:
+            mock_meta.get_file_metadata.side_effect = lambda p, k: (
+                _make_md_structure_json() if p.endswith(".md") and k == "md_structure" else None
+            )
+            filtered = service_with_md._filter_results_by_block_type(all_results, "table")
+        # 1-indexed 15,16 → 0-indexed 14,15 → inside [14,17).
+        assert len(filtered) == 2
+        assert {r["line"] for r in filtered} == {15, 16}
+
+    async def test_block_type_frontmatter_returns_only_frontmatter_matches(
+        self, service_with_md, context
+    ):
+        """block_type='frontmatter' keeps only matches in YAML frontmatter."""
+        all_results = self._make_results("/doc.md", [1, 2, 3, 7])
+        with patch.object(service_with_md, "metadata") as mock_meta:
+            mock_meta.get_file_metadata.side_effect = lambda p, k: (
+                _make_md_structure_json() if p.endswith(".md") and k == "md_structure" else None
+            )
+            filtered = service_with_md._filter_results_by_block_type(all_results, "frontmatter")
+        # 1-indexed 1,2,3 → 0-indexed 0,1,2 → inside [0,3). Line 7 → 6 → outside.
+        assert len(filtered) == 3
+        assert {r["line"] for r in filtered} == {1, 2, 3}
+
+    async def test_block_type_none_returns_all_matches(self, service_with_md, context):
+        """No block_type → all results pass through (default behavior)."""
+        # block_type=None should not invoke filtering at all.
+        with patch.object(service_with_md, "list", return_value=[]):
+            results = await service_with_md.grep(pattern="x", context=context)
+        # Empty because list returns nothing; the point is it doesn't crash.
+        assert results == []
+
+    async def test_block_type_on_non_md_file_returns_all_matches(self, service_with_md, context):
+        """Non-markdown files pass through unfiltered (decision #4A)."""
+        all_results = self._make_results("/src/main.py", [1, 5, 10])
+        with patch.object(service_with_md, "metadata") as mock_meta:
+            mock_meta.get_file_metadata.return_value = None
+            filtered = service_with_md._filter_results_by_block_type(all_results, "code")
+        assert len(filtered) == 3  # all pass through
+
+    async def test_block_type_with_no_md_structure_metadata(self, service_with_md, context):
+        """Markdown file without md_structure metadata → fail closed
+        (Codex R6: don't leak unfiltered results through)."""
+        all_results = self._make_results("/orphan.md", [1, 5])
+        with patch.object(service_with_md, "metadata") as mock_meta:
+            mock_meta.get_file_metadata.return_value = None  # no metadata
+            filtered = service_with_md._filter_results_by_block_type(all_results, "code")
+        assert len(filtered) == 0  # fail closed
+
+    async def test_block_type_with_no_matching_blocks_returns_empty(self, service_with_md, context):
+        """block_type='table' on a file with only code blocks → empty."""
+        # All results are on lines that are NOT inside a table.
+        all_results = self._make_results("/doc.md", [9, 10])  # inside code block
+        with patch.object(service_with_md, "metadata") as mock_meta:
+            mock_meta.get_file_metadata.side_effect = lambda p, k: (
+                _make_md_structure_json() if p.endswith(".md") and k == "md_structure" else None
+            )
+            filtered = service_with_md._filter_results_by_block_type(all_results, "table")
+        assert filtered == []
+
+    async def test_block_type_paragraph_returns_only_prose(self, service_with_md, context):
+        """block_type='paragraph' keeps only matches inside paragraphs."""
+        # Paragraph at lines 6-7 (0-indexed) → 1-indexed 7.
+        # Paragraph at lines 12-13 → 1-indexed 13.
+        all_results = self._make_results("/doc.md", [7, 10, 13])
+        with patch.object(service_with_md, "metadata") as mock_meta:
+            mock_meta.get_file_metadata.side_effect = lambda p, k: (
+                _make_md_structure_json() if p.endswith(".md") and k == "md_structure" else None
+            )
+            filtered = service_with_md._filter_results_by_block_type(all_results, "paragraph")
+        # Line 7 (0-idx 6) → inside [6,7). Line 13 (0-idx 12) → inside [12,13).
+        # Line 10 (0-idx 9) → inside code block, NOT paragraph.
+        assert len(filtered) == 2
+        assert {r["line"] for r in filtered} == {7, 13}
+
+    async def test_block_type_heading_returns_only_headings(self, service_with_md, context):
+        """block_type='heading' keeps only matches inside heading lines."""
+        # Heading at lines 4-5 and 20-21 (0-indexed).
+        all_results = self._make_results("/doc.md", [5, 7, 21])
+        with patch.object(service_with_md, "metadata") as mock_meta:
+            mock_meta.get_file_metadata.side_effect = lambda p, k: (
+                _make_md_structure_json() if p.endswith(".md") and k == "md_structure" else None
+            )
+            filtered = service_with_md._filter_results_by_block_type(all_results, "heading")
+        # Line 5 (0-idx 4) → inside [4,5). Line 21 (0-idx 20) → inside [20,21).
+        # Line 7 (0-idx 6) → paragraph, not heading.
+        assert len(filtered) == 2
+        assert {r["line"] for r in filtered} == {5, 21}
+
+    async def test_block_type_invalid_value_raises_value_error(self, service_with_md, context):
+        """Invalid block_type raises ValueError with supported values."""
+        with pytest.raises(ValueError, match="Invalid block_type"):
+            await service_with_md.grep(pattern="x", block_type="definition", context=context)
+
+    # ── Edge cases (decision #12A) ──
+
+    async def test_match_on_code_fence_boundary_line(self, service_with_md, context):
+        """Match on the opening ``` line of a code fence is inside the block."""
+        # Code block is line_start=8, line_end=11 (0-indexed).
+        # 1-indexed line 9 → 0-indexed 8 → first line of block.
+        all_results = self._make_results("/doc.md", [9])
+        with patch.object(service_with_md, "metadata") as mock_meta:
+            mock_meta.get_file_metadata.side_effect = lambda p, k: (
+                _make_md_structure_json() if p.endswith(".md") and k == "md_structure" else None
+            )
+            filtered = service_with_md._filter_results_by_block_type(all_results, "code")
+        assert len(filtered) == 1
+
+    async def test_mixed_md_and_non_md_results(self, service_with_md, context):
+        """Mixed results from .md (filtered) and .py (unfiltered) files."""
+        results = [
+            {"file": "/doc.md", "line": 7, "content": "prose", "match": "prose"},
+            {"file": "/doc.md", "line": 10, "content": "code", "match": "code"},
+            {"file": "/main.py", "line": 1, "content": "import", "match": "import"},
+        ]
+        with patch.object(service_with_md, "metadata") as mock_meta:
+            mock_meta.get_file_metadata.side_effect = lambda p, k: (
+                _make_md_structure_json() if p.endswith(".md") and k == "md_structure" else None
+            )
+            filtered = service_with_md._filter_results_by_block_type(results, "code")
+        # /doc.md line 10 (0-indexed 9) is inside code [8,11). Line 7 (0-indexed 6) is not.
+        # /main.py passes through unfiltered.
+        assert len(filtered) == 2
+        files = [r["file"] for r in filtered]
+        assert "/main.py" in files
+        assert any(r["file"] == "/doc.md" and r["line"] == 10 for r in filtered)
+
+    async def test_block_type_with_stale_metadata(self, service_with_md, context):
+        """Corrupt/malformed md_structure metadata → fail closed
+        (Codex R7: don't leak unfiltered results)."""
+        all_results = self._make_results("/bad.md", [1, 5])
+        with patch.object(service_with_md, "metadata") as mock_meta:
+            mock_meta.get_file_metadata.return_value = "not valid json {"
+            filtered = service_with_md._filter_results_by_block_type(all_results, "code")
+        # Corrupt metadata → fail closed, no results.
+        assert len(filtered) == 0
+
+    async def test_block_type_with_context_lines(self, service_with_md, context):
+        """Context lines that extend outside the block are still included
+        with the match — we filter by match line, not context lines."""
+        results = [
+            {
+                "file": "/doc.md",
+                "line": 10,  # 0-indexed 9 → inside code [8,11)
+                "content": "SELECT",
+                "match": "SELECT",
+                "before_context": [
+                    {"line": 8, "content": "prose before fence"},
+                ],
+                "after_context": [
+                    {"line": 12, "content": "prose after fence"},
+                ],
+            },
+        ]
+        with patch.object(service_with_md, "metadata") as mock_meta:
+            mock_meta.get_file_metadata.side_effect = lambda p, k: (
+                _make_md_structure_json() if p.endswith(".md") and k == "md_structure" else None
+            )
+            filtered = service_with_md._filter_results_by_block_type(results, "code")
+        # Match line is inside code block → kept. Context lines are preserved as-is.
+        assert len(filtered) == 1
+        assert filtered[0]["before_context"][0]["content"] == "prose before fence"
+        assert filtered[0]["after_context"][0]["content"] == "prose after fence"
+
+
+class TestGrepBlockTypeOverfetch:
+    """Issue #3720: over-fetch multiplier and cap tests."""
+
+    async def test_overfetch_multiplier_applied(self, service, context):
+        """When block_type is set, grep over-fetches internally."""
+
+        # Use max_results=50. Expected internal max_results = min(50*5, max(50, 2000)) = 250.
+        with patch.object(service, "list", return_value=[]):
+            await service.grep(pattern="x", block_type="code", max_results=50, context=context)
+        # No files → short circuit → no results, but we can check the method ran.
+        # The over-fetch is applied before Phase 1, so just verify no crash.
+
+    async def test_overfetch_cap_respected(self, service, context):
+        """Over-fetch is capped at _BLOCK_TYPE_OVERFETCH_CAP."""
+
+        # max_results=10000 → 10000*5 = 50000 > cap → capped at max(10000, 2000) = 10000.
+        with patch.object(service, "list", return_value=[]):
+            # Should not crash — cap prevents runaway allocation.
+            await service.grep(pattern="x", block_type="code", max_results=10000, context=context)
+
+    async def test_block_type_results_capped_to_original_max_results(self, service, context):
+        """After post-filtering, results are capped to the ORIGINAL
+        max_results, not the inflated over-fetch value."""
+        with (
+            patch.object(service, "list", return_value=["/a.py"]),
+            patch.object(service, "metadata") as mock_meta,
+        ):
+            mock_meta.get_searchable_text_bulk.return_value = {
+                "/a.py": "\n".join(f"x line {i}" for i in range(20))
+            }
+            mock_meta.get_file_metadata.return_value = None
+            results = await service.grep(
+                pattern="x",
+                block_type="code",
+                max_results=5,
+                context=context,
+            )
+        # Non-md file → all pass through, but capped to original max_results=5.
+        assert len(results) <= 5
+
+    async def test_block_type_validation_lists_valid_types(self, service, context):
+        """Validation error message includes all valid block type names."""
+        with pytest.raises(ValueError, match="code") as exc_info:
+            await service.grep(pattern="x", block_type="definition", context=context)
+        msg = str(exc_info.value)
+        assert "table" in msg
+        assert "frontmatter" in msg
+        assert "paragraph" in msg

--- a/tests/unit/bricks/mcp/test_mcp_server_tools.py
+++ b/tests/unit/bricks/mcp/test_mcp_server_tools.py
@@ -883,6 +883,29 @@ class TestSearchTools:
         assert "after_context" not in kwargs
         assert "invert_match" not in kwargs
 
+    async def test_grep_block_type_forwarded(self, mock_nx_basic):
+        """#3720: block_type flows through MCP to SearchService."""
+        mock_nx_basic._mock_search.grep.return_value = []
+        server = await create_mcp_server(nx=mock_nx_basic)
+
+        grep_tool = get_tool(server, "nexus_grep")
+        await grep_tool.fn(pattern="SELECT", block_type="code")
+
+        kwargs = mock_nx_basic._mock_search.grep.call_args.kwargs
+        assert kwargs["block_type"] == "code"
+
+    async def test_grep_block_type_none_omitted_from_kwargs(self, mock_nx_basic):
+        """#3720: default block_type=None must NOT appear in kwargs
+        forwarded to SearchService — backward compat with older servers."""
+        mock_nx_basic._mock_search.grep.return_value = []
+        server = await create_mcp_server(nx=mock_nx_basic)
+
+        grep_tool = get_tool(server, "nexus_grep")
+        await grep_tool.fn(pattern="SELECT")
+
+        kwargs = mock_nx_basic._mock_search.grep.call_args.kwargs
+        assert "block_type" not in kwargs
+
     async def test_grep_error(self, mock_nx_basic):
         """Test grep error handling."""
         mock_nx_basic._mock_search.grep.side_effect = ValueError("Invalid regex")

--- a/tests/unit/bricks/parsers/test_md_structure.py
+++ b/tests/unit/bricks/parsers/test_md_structure.py
@@ -184,7 +184,11 @@ More content.
 
     def test_no_headings(self) -> None:
         idx = parse_markdown_structure(b"Just plain text.\nNo headings.\n")
-        assert len(idx.sections) == 0
+        # Issue #3720 (Codex R1): headingless files with blocks now get
+        # a synthetic root section (depth=0) so block_type filtering works.
+        assert len(idx.sections) == 1
+        assert idx.sections[0].depth == 0
+        assert idx.sections[0].heading == ""
 
     def test_frontmatter_only(self) -> None:
         doc = b"---\ntitle: Test\n---\n"
@@ -445,3 +449,103 @@ class TestFailureModes:
         assert len(idx.sections) == 1
         assert idx.sections[0].tokens_est == 0
         assert idx.frontmatter is None
+
+
+# ---------------------------------------------------------------------------
+# Issue #3720: new block types (paragraph, blockquote, list, heading)
+# ---------------------------------------------------------------------------
+
+_BLOCK_TYPES_DOC = b"""\
+# Title
+
+A paragraph of text.
+
+> A blockquote
+> spanning two lines.
+
+- bullet one
+- bullet two
+
+1. ordered one
+2. ordered two
+
+```python
+code here
+```
+
+| col1 | col2 |
+|------|------|
+| a    | b    |
+"""
+
+
+class TestNewBlockTypes:
+    """Issue #3720: paragraph, blockquote, list, heading block extraction."""
+
+    @pytest.fixture
+    def index(self) -> MarkdownStructureIndex:
+        return parse_markdown_structure(_BLOCK_TYPES_DOC, "test")
+
+    def test_heading_block_tracked(self, index: MarkdownStructureIndex) -> None:
+        """Heading lines are recorded as BlockInfo(type='heading')."""
+        sec = index.sections[0]
+        headings = filter_blocks(sec, "heading")
+        assert len(headings) >= 1
+        assert headings[0].type == "heading"
+
+    def test_paragraph_block_tracked(self, index: MarkdownStructureIndex) -> None:
+        """Paragraphs are recorded as BlockInfo(type='paragraph')."""
+        sec = index.sections[0]
+        paragraphs = filter_blocks(sec, "paragraph")
+        assert len(paragraphs) >= 1
+        # Verify the first paragraph contains "A paragraph of text"
+        for p in paragraphs:
+            text = slice_content(_BLOCK_TYPES_DOC, p.byte_start, p.byte_end)
+            if "paragraph of text" in text:
+                break
+        else:
+            pytest.fail("Expected paragraph containing 'paragraph of text'")
+
+    def test_blockquote_block_tracked(self, index: MarkdownStructureIndex) -> None:
+        """Blockquotes are recorded as BlockInfo(type='blockquote')."""
+        sec = index.sections[0]
+        quotes = filter_blocks(sec, "blockquote")
+        assert len(quotes) >= 1
+        text = slice_content(_BLOCK_TYPES_DOC, quotes[0].byte_start, quotes[0].byte_end)
+        assert "blockquote" in text
+
+    def test_list_block_tracked_bullet(self, index: MarkdownStructureIndex) -> None:
+        """Bullet lists are recorded as BlockInfo(type='list')."""
+        sec = index.sections[0]
+        lists = filter_blocks(sec, "list")
+        assert len(lists) >= 1
+        # At least one list contains bullet items
+        found_bullet = False
+        for lst in lists:
+            text = slice_content(_BLOCK_TYPES_DOC, lst.byte_start, lst.byte_end)
+            if "bullet" in text:
+                found_bullet = True
+                break
+        assert found_bullet, "Expected a list block containing 'bullet'"
+
+    def test_list_block_tracked_ordered(self, index: MarkdownStructureIndex) -> None:
+        """Ordered lists are also recorded as BlockInfo(type='list')."""
+        sec = index.sections[0]
+        lists = filter_blocks(sec, "list")
+        found_ordered = False
+        for lst in lists:
+            text = slice_content(_BLOCK_TYPES_DOC, lst.byte_start, lst.byte_end)
+            if "ordered" in text:
+                found_ordered = True
+                break
+        assert found_ordered, "Expected a list block containing 'ordered'"
+
+    def test_code_and_table_still_tracked(self, index: MarkdownStructureIndex) -> None:
+        """Existing code and table blocks still work."""
+        sec = index.sections[0]
+        assert len(filter_blocks(sec, "code")) >= 1
+        assert len(filter_blocks(sec, "table")) >= 1
+
+    def test_schema_version_is_2(self, index: MarkdownStructureIndex) -> None:
+        """Schema version bumped to 2 for new block types."""
+        assert index.version == 2

--- a/tests/unit/bricks/parsers/test_md_structure_hook.py
+++ b/tests/unit/bricks/parsers/test_md_structure_hook.py
@@ -97,7 +97,7 @@ class TestWriteHook:
         raw = meta.get_file_metadata("/docs/arch.md", MD_STRUCTURE_KEY)
         assert raw is not None
         data = json.loads(raw)
-        assert data["version"] == 1
+        assert data["version"] == 2
         assert len(data["sections"]) >= 3
         assert data["content_hash"] == "hash1"
 


### PR DESCRIPTION
## Summary

- Adds optional `block_type` parameter to grep (MCP, REST, CLI) to restrict matches to specific markdown block types: `code`, `table`, `frontmatter`, `paragraph`, `blockquote`, `list`, `heading`
- Extends the markdown structure parser to track paragraph, blockquote, list, and heading blocks (schema v2)
- Fixes pre-existing `line_end` off-by-one in the Rust parser path (`_byte_end_to_line_exclusive`)

## How it works

```python
nexus_grep("SELECT.*FROM", path="/docs", block_type="code")
# → only matches inside code fences, no prose false positives

nexus_grep("TODO", path="/docs", block_type="paragraph")
# → only matches in prose paragraphs
```

- Post-filter in `SearchService.grep()` using `md_structure` metadata line ranges
- Forces SEQUENTIAL strategy (no trigram/zoekt bypass) for correctness
- Over-fetch with 5x multiplier capped at 2000 for sparse block matches
- Fail-closed for missing/corrupt/v1 metadata on recognized markdown files
- Supports `.md`, `.markdown`, `.mdown`, `.mkd` (case-insensitive)

## Hardening

7 rounds of Codex adversarial review with 12 findings fixed:
- R1: trigram/zoekt early-return bypass, headingless file support, v1 schema guard
- R2: scan path enforcement, fail-closed semantics, structure listing isolation
- R3: `extract_structure()` synthetic section leak
- R4: markdown extension coverage (`.markdown`/`.mdown`/`.mkd`)
- R5: CACHED_TEXT uncached-file gap, write hook extension alignment
- R6: missing metadata fail-closed, `create_chunks()` fix, blank `block_type=""` rejection
- R7: corrupt metadata fail-closed

## Test plan

- [x] 104 unit/integration tests pass (33 new + 71 existing)
- [x] E2E tested via `nexus up --build` — all 7 block types verified via REST API
- [x] Performance: <1ms overhead for block_type filtering
- [x] Pre-commit hooks pass (ruff, mypy, brick import boundary)
- [x] Zero regressions on existing test suites