### PR TITLE
fix(ci): drop --skip-semantic from demo init

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -182,7 +182,7 @@ jobs:
             -e NEXUS_PROFILE=remote \
             -e NEXUS_GRPC_PORT=2029 \
             -e NEXUS_GRPC_TLS=false \
-            nexus-e2e nexus demo init --skip-semantic
+            nexus-e2e nexus demo init
 
       - name: Copy test scripts into container
         run: |


### PR DESCRIPTION
## Summary

E2E test sections 6 (HERB search), 9 (auto-index), and 10 (delete index) require semantic search indexing. `--skip-semantic` was skipping the corpus seeding they depend on → 0/8 hit rate.

Remove `--skip-semantic` so `nexus demo init` runs full initialization.

Follow-up to #3759.

## Test plan

- [ ] CI E2E edge smoke tests: sections 6, 9, 10 pass