### PR TITLE
fix(ci): add --skip-semantic to demo init in E2E workflow

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -182,7 +182,7 @@ jobs:
             -e NEXUS_PROFILE=remote \
             -e NEXUS_GRPC_PORT=2029 \
             -e NEXUS_GRPC_TLS=false \
-            nexus-e2e nexus demo init
+            nexus-e2e nexus demo init --skip-semantic
 
       - name: Copy test scripts into container
         run: |


### PR DESCRIPTION
## Summary

The edge Docker image has no embedding models, so `nexus demo init` semantic seeding always fails and adds error noise. The E2E test already skips search sections gracefully when indexing is unavailable (#3761).

One-line change: `nexus demo init` → `nexus demo init --skip-semantic`

## Test plan

- [ ] CI E2E edge smoke tests pass (19/19, search sections skipped)