### PR TITLE
fix(docker): GLIBC_TUNABLES on all platforms for faiss TLS

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -120,7 +120,6 @@ jobs:
             -e NEXUS_GRPC_PORT=2029 \
             -e NEXUS_GRPC_TLS=false \
             -e NEXUS_PROFILE=full \
-            -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libgomp.so.1 \
             -v /tmp/nexus-data:/app/data \
             ghcr.io/nexi-lab/nexus:edge
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -479,7 +479,7 @@ jobs:
         if: matrix.variant == 'cpu'
         run: |
           docker run --rm --entrypoint "" \
-            -e LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libgomp.so.1 \
+            -e GLIBC_TUNABLES=glibc.rtld.optional_static_tls=16384 \
             ghcr.io/nexi-lab/nexus:smoke-test \
             python3 -c "
           import nexus_kernel

--- a/Dockerfile
+++ b/Dockerfile
@@ -164,9 +164,12 @@ RUN set -eux; \
     && rm -rf /var/lib/apt/lists/*
 
 # PyTorch/txtai on slim Linux containers can fail with:
-# "libc10.so: cannot allocate memory in static TLS block".
-# Preload libgomp plus torch's libc10 via stable symlinks so
-# ``from txtai import Embeddings`` works reliably at runtime.
+# "cannot allocate memory in static TLS block" for libgomp or libc10.
+# Two-layer fix:
+#   1. LD_PRELOAD: load the system libgomp + torch libc10 early so they
+#      get TLS slots before the pool fills up.
+#   2. GLIBC_TUNABLES: expand the static-TLS reservation so that
+#      *additional* copies (e.g. faiss-cpu's bundled libgomp) still fit.
 RUN set -eux; \
     if [ "${TARGETARCH}" = "arm64" ]; then \
         ln -sf /usr/lib/aarch64-linux-gnu/libgomp.so.1 /usr/lib/libgomp.so.1; \
@@ -175,6 +178,7 @@ RUN set -eux; \
     fi && \
     ln -sf /usr/local/lib/python3.13/site-packages/torch/lib/libc10.so /usr/lib/libc10.so
 ENV LD_PRELOAD="/usr/lib/libgomp.so.1 /usr/lib/libc10.so"
+ENV GLIBC_TUNABLES="glibc.rtld.optional_static_tls=16384"
 
 # ---------- CLI connectors: gws + gh (Issue #3148) ----------
 # gws: Google Workspace CLI for Gmail/Calendar/Drive/Sheets/Docs/Chat connectors
@@ -264,9 +268,9 @@ RUN mkdir -p /app/data && chown -R nexus:nexus /app
 USER nexus
 
 # ---------- Environment variables ----------
-# ARM64-specific mitigations (FAISS_OPT_LEVEL, OMP_NUM_THREADS, GLIBC_TUNABLES)
-# are applied conditionally at runtime in docker-entrypoint.sh to avoid
-# regressing x86_64 throughput (Issue #3125).
+# ARM64-specific mitigations (FAISS_OPT_LEVEL, OMP_NUM_THREADS) are applied
+# conditionally at runtime in docker-entrypoint.sh to avoid regressing x86_64
+# throughput (Issue #3125).  GLIBC_TUNABLES is set unconditionally above.
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
     NEXUS_HOST=0.0.0.0 \

--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -7,31 +7,39 @@ set -e
 set -o pipefail
 
 # ---------------------------------------------------------------------------
+# Static-TLS reservation (all platforms)
+#
+# faiss-cpu bundles its own libgomp (faiss_cpu.libs/libgomp-*.so) which is a
+# different .so from the system libgomp preloaded via LD_PRELOAD.  On x86_64
+# CPU-only containers the Dockerfile's LD_PRELOAD ensures the *system* libgomp
+# gets TLS early, but when faiss later dlopen()s its *bundled* copy the default
+# static-TLS pool is already full → "cannot allocate memory in static TLS block".
+#
+# GLIBC_TUNABLES expands the reservation so both copies fit.  It is harmless on
+# all platforms and also covers libc10 (PyTorch), ggml, numpy, etc.
+# ---------------------------------------------------------------------------
+export GLIBC_TUNABLES="${GLIBC_TUNABLES:-glibc.rtld.optional_static_tls=16384}"
+
+# ---------------------------------------------------------------------------
 # ARM64 mitigations (Issue #3125)
-# Applied only on aarch64 to avoid regressing x86_64 throughput.
 #   FAISS_OPT_LEVEL=generic  — prevent faiss SVE auto-detection crash in
 #                               Docker where CPU feature flags may be masked.
 #   OMP_NUM_THREADS=1        — avoid OpenMP runtime conflict between faiss-cpu
 #                               and PyTorch on ARM (libiomp5 vs libomp).
-#   GLIBC_TUNABLES           — work around PyTorch libc10.so TLS allocation
-#                               failure on aarch64 (pytorch/pytorch#76689).
 # Users can still override by setting the variable before starting the container.
 # ---------------------------------------------------------------------------
 if [ "$(uname -m)" = "aarch64" ]; then
     export FAISS_OPT_LEVEL="${FAISS_OPT_LEVEL:-generic}"
     export OMP_NUM_THREADS="${OMP_NUM_THREADS:-1}"
-    export GLIBC_TUNABLES="${GLIBC_TUNABLES:-glibc.rtld.optional_static_tls=16384}"
 fi
 
 # ---------------------------------------------------------------------------
-# TLS block exhaustion fix (ggml, numpy, etc.)
-# CPU: LD_PRELOAD loads libgomp before TLS slots fill up.
-# CUDA: LD_PRELOAD conflicts with NVIDIA's libgomp (SIGILL); use
-#       GLIBC_TUNABLES to expand the static TLS reservation instead.
+# LD_PRELOAD fallback (CPU-only)
+# Preloading the system libgomp helps libraries other than faiss that link
+# against the system copy.  On CUDA, LD_PRELOAD conflicts with NVIDIA's
+# libgomp (SIGILL), so we skip it — GLIBC_TUNABLES above is sufficient.
 # ---------------------------------------------------------------------------
-if [ -d /usr/local/cuda ]; then
-    export GLIBC_TUNABLES="${GLIBC_TUNABLES:-glibc.rtld.optional_static_tls=16384}"
-elif [ -z "${LD_PRELOAD:-}" ]; then
+if [ ! -d /usr/local/cuda ] && [ -z "${LD_PRELOAD:-}" ]; then
     _gomp=$(find /usr/lib -name 'libgomp.so.1' -print -quit 2>/dev/null || true)
     [ -n "$_gomp" ] && export LD_PRELOAD="$_gomp"
     unset _gomp


### PR DESCRIPTION
## Summary
- faiss-cpu bundles its own `libgomp-*.so` separate from the system one preloaded via `LD_PRELOAD`. On x86_64 CPU-only (CI), the static TLS pool is exhausted by the time faiss dlopen()s its bundled copy, causing `ImportError: cannot allocate memory in static TLS block` on every `semantic_search` call.
- Sets `GLIBC_TUNABLES=glibc.rtld.optional_static_tls=16384` unconditionally (Dockerfile ENV + entrypoint). Was previously ARM64/CUDA only.
- Removes redundant `-e LD_PRELOAD` override from CI workflow — Dockerfile + entrypoint already handle it.

Fixes 3 E2E failures: `HERB hit rate 0/8`, `auto-index after edit`, `file indexed before delete`.

## Test plan
- [ ] Docker Publish workflow E2E edge smoke tests pass (all 22 tests)
- [ ] Release workflow smoke test (critical imports) passes
- [ ] ARM64 still gets FAISS_OPT_LEVEL + OMP_NUM_THREADS mitigations