### PR TITLE
fix(#3731): enforce per-user ReBAC on MCP grep/glob

### DIFF
--- a/.pre-commit-hooks/check_file_size.py
+++ b/.pre-commit-hooks/check_file_size.py
@@ -36,6 +36,7 @@ EXCEPTIONS = [
     "src/nexus/server/fastapi_server.py",  # 2,133 lines - Phase 4 splitting
     "src/nexus/services/memory/memory_api.py",  # 3,012 lines - moved from core/, split tracked
     "src/nexus/bricks/search/daemon.py",  # ~2,300 lines - Issue #3698 additions; split tracked as follow-up
+    "src/nexus/bricks/mcp/server.py",  # 2,157 lines - was 2,136 pre-#3731; auth helpers extracted to auth_bridge.py
 ]
 
 

--- a/src/nexus/bricks/mcp/auth_bridge.py
+++ b/src/nexus/bricks/mcp/auth_bridge.py
@@ -108,29 +108,52 @@ def resolve_mcp_operation_context(
 
     # (0) Per-request API key — most authoritative when MCP is behind
     # HTTP middleware that sets _request_api_key (#3731).
+    #
+    # FAIL-CLOSED: if a per-request key IS present and auth_provider
+    # rejects or errors, we return None immediately — we do NOT fall
+    # through to ambient credentials (_init_cred / _default_context).
+    # This matches HTTP behavior where a bad key → 401, not a
+    # privileged fallback.  Steps 1-4 only run when no per-request
+    # key was set (i.e., the caller is the process itself).
     request_key = _request_api_key.get()
     if request_key and auth_provider is not None:
         auth_result = authenticate_api_key(auth_provider, request_key)
         if auth_result is not None:
-            _get = (
-                auth_result.get
-                if hasattr(auth_result, "get")
-                else lambda k, d=None: getattr(auth_result, k, d)
-            )
-            if _get("authenticated", False):
-                subject_id = _get("subject_id", None) or "anonymous"
-                zone_id = _get("zone_id", None) or ROOT_ZONE_ID
-                is_admin = bool(_get("is_admin", False))
-                subject_type = _get("subject_type", None) or "user"
-                return OperationContext(
-                    user_id=subject_id,
-                    subject_type=subject_type,
-                    subject_id=subject_id,
-                    zone_id=zone_id,
-                    groups=[],
-                    is_admin=is_admin,
-                    is_system=False,
-                )
+            # Normalize to dict so we can use the shared HTTP helper.
+            if hasattr(auth_result, "__dataclass_fields__"):
+                import dataclasses
+
+                auth_dict = dataclasses.asdict(auth_result)
+            elif hasattr(auth_result, "get"):
+                auth_dict = dict(auth_result)
+            else:
+                auth_dict = {
+                    k: getattr(auth_result, k, None)
+                    for k in (
+                        "authenticated",
+                        "subject_type",
+                        "subject_id",
+                        "zone_id",
+                        "is_admin",
+                        "agent_generation",
+                        "inherit_permissions",
+                    )
+                }
+
+            if auth_dict.get("authenticated", False):
+                # Use the same builder as HTTP to carry all fields
+                # (agent_generation, admin_capabilities, etc.).
+                from nexus.server.dependencies import get_operation_context
+
+                return get_operation_context(auth_dict)
+        # Per-request key was present but auth failed/rejected —
+        # fail closed rather than falling through to ambient creds.
+        logger.warning(
+            "Per-request API key authentication failed or was rejected; "
+            "returning None (fail-closed) instead of falling through "
+            "to ambient credentials."
+        )
+        return None
 
     # (1) Kernel init_cred.
     init_cred = getattr(nx_instance, "_init_cred", None)

--- a/src/nexus/bricks/mcp/auth_bridge.py
+++ b/src/nexus/bricks/mcp/auth_bridge.py
@@ -75,9 +75,10 @@ def authenticate_api_key(auth_provider: Any, api_key: str) -> Any:
     def _run() -> Any:
         return asyncio.run(coro)
 
+    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
     try:
-        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-            return pool.submit(_run).result(timeout=10)
+        future = pool.submit(_run)
+        return future.result(timeout=10)
     except Exception:
         logger.warning(
             "Failed to authenticate per-request API key via auth_provider; "
@@ -85,6 +86,9 @@ def authenticate_api_key(auth_provider: Any, api_key: str) -> Any:
             exc_info=True,
         )
         return None
+    finally:
+        # shutdown(wait=False) so a hung authenticate() doesn't block.
+        pool.shutdown(wait=False)
 
 
 def resolve_mcp_operation_context(
@@ -109,23 +113,15 @@ def resolve_mcp_operation_context(
     # (0) Per-request API key — most authoritative when MCP is behind
     # HTTP middleware that sets _request_api_key (#3731).
     #
-    # FAIL-CLOSED: if a per-request key IS present and auth_provider
-    # rejects or errors, we return None immediately — we do NOT fall
-    # through to ambient credentials (_init_cred / _default_context).
-    # This matches HTTP behavior where a bad key → 401, not a
-    # privileged fallback.  Steps 1-4 only run when no per-request
-    # key was set (i.e., the caller is the process itself).
+    # When auth_provider is available, use it to verify the key.
+    # If verification fails, fail closed (return None).
+    #
+    # When auth_provider is NOT available but a per-request key is set,
+    # _get_nexus_instance already created a remote NexusFS scoped to
+    # that key — its _init_cred IS the per-request identity (not
+    # ambient). So we allow steps 1-3 to proceed.
     request_key = _request_api_key.get()
-    if request_key:
-        # A per-request key is present — it MUST be verified.
-        # If no auth_provider is available, fail closed.
-        if auth_provider is None:
-            logger.warning(
-                "Per-request API key is set but no auth_provider is "
-                "available to verify it; returning None (fail-closed)."
-            )
-            return None
-        # auth_provider is available — verify the key.
+    if request_key and auth_provider is not None:
         auth_result = authenticate_api_key(auth_provider, request_key)
         if auth_result is not None:
             # Normalize to dict so we can use the shared HTTP helper.
@@ -155,8 +151,9 @@ def resolve_mcp_operation_context(
                 from nexus.server.dependencies import get_operation_context
 
                 return get_operation_context(auth_dict)
-        # Per-request key was present but auth failed/rejected —
-        # fail closed rather than falling through to ambient creds.
+        # Per-request key was present and auth_provider actively
+        # rejected it — fail closed. Do NOT fall through to ambient
+        # creds from _init_cred/_default_context.
         logger.warning(
             "Per-request API key authentication failed or was rejected; "
             "returning None (fail-closed) instead of falling through "

--- a/src/nexus/bricks/mcp/auth_bridge.py
+++ b/src/nexus/bricks/mcp/auth_bridge.py
@@ -121,6 +121,20 @@ def resolve_mcp_operation_context(
     # that key — its _init_cred IS the per-request identity (not
     # ambient). So we allow steps 1-3 to proceed.
     request_key = _request_api_key.get()
+    if request_key and auth_provider is None:
+        # Per-request key set but no auth_provider to verify it.
+        # Fall through to NexusFS-based identity (steps 1-3).
+        # In remote mode, _get_nexus_instance already created a
+        # connection scoped to this key — _init_cred is that identity.
+        # In local mode, _init_cred is the process identity (single
+        # user, no multi-tenancy concern).
+        #
+        # NOTE: callers (e.g. CLI) should thread auth_provider for
+        # full verification. This fallback is safe but less strict.
+        logger.info(
+            "Per-request API key set but no auth_provider available; "
+            "using NexusFS-based identity (steps 1-3)."
+        )
     if request_key and auth_provider is not None:
         auth_result = authenticate_api_key(auth_provider, request_key)
         if auth_result is not None:

--- a/src/nexus/bricks/mcp/auth_bridge.py
+++ b/src/nexus/bricks/mcp/auth_bridge.py
@@ -53,9 +53,6 @@ def authenticate_api_key(auth_provider: Any, api_key: str) -> Any:
 
     Returns the ``AuthResult`` on success, ``None`` on any failure.
     """
-    import asyncio
-    import concurrent.futures
-
     try:
         coro = auth_provider.authenticate(api_key)
     except Exception:
@@ -70,15 +67,12 @@ def authenticate_api_key(auth_provider: Any, api_key: str) -> Any:
     if not inspect.isawaitable(coro):
         return coro
 
-    # Use a background thread so we work whether or not an event loop
-    # is already running (same pattern as _get_nexus_instance).
-    def _run() -> Any:
-        return asyncio.run(coro)
-
-    pool = concurrent.futures.ThreadPoolExecutor(max_workers=1)
+    # Use the repo's shared sync bridge which handles event-loop
+    # detection, timeout, and clean thread management (#3731 R5).
     try:
-        future = pool.submit(_run)
-        return future.result(timeout=10)
+        from nexus.lib.sync_bridge import run_sync
+
+        return run_sync(coro, timeout=10.0)
     except Exception:
         logger.warning(
             "Failed to authenticate per-request API key via auth_provider; "
@@ -86,9 +80,6 @@ def authenticate_api_key(auth_provider: Any, api_key: str) -> Any:
             exc_info=True,
         )
         return None
-    finally:
-        # shutdown(wait=False) so a hung authenticate() doesn't block.
-        pool.shutdown(wait=False)
 
 
 def resolve_mcp_operation_context(

--- a/src/nexus/bricks/mcp/auth_bridge.py
+++ b/src/nexus/bricks/mcp/auth_bridge.py
@@ -116,7 +116,16 @@ def resolve_mcp_operation_context(
     # privileged fallback.  Steps 1-4 only run when no per-request
     # key was set (i.e., the caller is the process itself).
     request_key = _request_api_key.get()
-    if request_key and auth_provider is not None:
+    if request_key:
+        # A per-request key is present — it MUST be verified.
+        # If no auth_provider is available, fail closed.
+        if auth_provider is None:
+            logger.warning(
+                "Per-request API key is set but no auth_provider is "
+                "available to verify it; returning None (fail-closed)."
+            )
+            return None
+        # auth_provider is available — verify the key.
         auth_result = authenticate_api_key(auth_provider, request_key)
         if auth_result is not None:
             # Normalize to dict so we can use the shared HTTP helper.

--- a/src/nexus/bricks/mcp/auth_bridge.py
+++ b/src/nexus/bricks/mcp/auth_bridge.py
@@ -151,11 +151,21 @@ def resolve_mcp_operation_context(
                 }
 
             if auth_dict.get("authenticated", False):
-                # Use the same builder as HTTP to carry all fields
-                # (agent_generation, admin_capabilities, etc.).
-                from nexus.server.dependencies import get_operation_context
-
-                return get_operation_context(auth_dict)
+                subject_type = auth_dict.get("subject_type") or "user"
+                subject_id = auth_dict.get("subject_id") or "anonymous"
+                zone_id = auth_dict.get("zone_id") or ROOT_ZONE_ID
+                is_admin = bool(auth_dict.get("is_admin", False))
+                agent_generation = auth_dict.get("agent_generation")
+                return OperationContext(
+                    user_id=subject_id,
+                    subject_type=subject_type,
+                    subject_id=subject_id,
+                    zone_id=zone_id,
+                    groups=[],
+                    is_admin=is_admin,
+                    is_system=False,
+                    agent_generation=agent_generation,
+                )
         # Per-request key was present and auth_provider actively
         # rejected it — fail closed. Do NOT fall through to ambient
         # creds from _init_cred/_default_context.

--- a/src/nexus/bricks/mcp/auth_bridge.py
+++ b/src/nexus/bricks/mcp/auth_bridge.py
@@ -70,9 +70,12 @@ def authenticate_api_key(auth_provider: Any, api_key: str) -> Any:
     # Use the repo's shared sync bridge which handles event-loop
     # detection, timeout, and clean thread management (#3731 R5).
     try:
+        from collections.abc import Coroutine as CoroutineABC
+        from typing import cast
+
         from nexus.lib.sync_bridge import run_sync
 
-        return run_sync(coro, timeout=10.0)
+        return run_sync(cast(CoroutineABC[Any, Any, Any], coro), timeout=10.0)
     except Exception:
         logger.warning(
             "Failed to authenticate per-request API key via auth_provider; "

--- a/src/nexus/bricks/mcp/auth_bridge.py
+++ b/src/nexus/bricks/mcp/auth_bridge.py
@@ -1,0 +1,168 @@
+"""MCP ↔ auth identity bridge helpers (#3731).
+
+Resolves per-request subject identity for MCP search tools so they
+can apply the same ReBAC filtering as the HTTP endpoints.
+
+Extracted from ``server.py`` to keep that file under the 2000-line
+limit enforced by pre-commit.
+"""
+
+from __future__ import annotations
+
+import inspect
+import logging
+from typing import TYPE_CHECKING, Any
+
+if TYPE_CHECKING:
+    from nexus.core.nexus_fs import NexusFS
+
+logger = logging.getLogger(__name__)
+
+
+def op_context_to_auth_dict(op_context: Any) -> dict[str, Any]:
+    """Convert an ``OperationContext`` (or None) into an auth_result dict.
+
+    ``_apply_rebac_filter`` expects a dict with ``subject_id``,
+    ``zone_id``, and ``is_admin`` keys — the same shape that the HTTP
+    ``require_auth`` dependency returns.  This helper bridges the MCP
+    ``OperationContext`` into that format.
+    """
+    from nexus.contracts.constants import ROOT_ZONE_ID
+
+    if op_context is None:
+        return {
+            "subject_id": "anonymous",
+            "zone_id": ROOT_ZONE_ID,
+            "is_admin": False,
+        }
+    return {
+        "subject_id": getattr(op_context, "subject_id", None)
+        or getattr(op_context, "user_id", "anonymous"),
+        "zone_id": getattr(op_context, "zone_id", None) or ROOT_ZONE_ID,
+        "is_admin": bool(getattr(op_context, "is_admin", False)),
+    }
+
+
+def authenticate_api_key(auth_provider: Any, api_key: str) -> Any:
+    """Call ``auth_provider.authenticate(api_key)`` from sync context.
+
+    ``authenticate()`` is always async in the Nexus auth provider
+    contract.  This helper handles the async-to-sync bridge regardless
+    of whether an event loop is already running (MCP grep is async,
+    MCP glob is sync).
+
+    Returns the ``AuthResult`` on success, ``None`` on any failure.
+    """
+    import asyncio
+    import concurrent.futures
+
+    try:
+        coro = auth_provider.authenticate(api_key)
+    except Exception:
+        logger.warning(
+            "auth_provider.authenticate() raised synchronously; "
+            "falling through to NexusFS-based identity resolution.",
+            exc_info=True,
+        )
+        return None
+
+    # If not actually a coroutine (mock / sync provider), return directly.
+    if not inspect.isawaitable(coro):
+        return coro
+
+    # Use a background thread so we work whether or not an event loop
+    # is already running (same pattern as _get_nexus_instance).
+    def _run() -> Any:
+        return asyncio.run(coro)
+
+    try:
+        with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+            return pool.submit(_run).result(timeout=10)
+    except Exception:
+        logger.warning(
+            "Failed to authenticate per-request API key via auth_provider; "
+            "falling through to NexusFS-based identity resolution.",
+            exc_info=True,
+        )
+        return None
+
+
+def resolve_mcp_operation_context(
+    nx_instance: NexusFS,
+    auth_provider: Any | None = None,
+) -> Any:
+    """Resolve an explicit ``OperationContext`` for MCP search calls.
+
+    Resolution priority (first non-None wins):
+
+    0. Per-request API key via ``_request_api_key`` contextvar +
+       ``auth_provider`` (#3731).
+    1. ``nx_instance._init_cred`` — kernel process credential.
+    2. ``nx_instance._default_context`` — legacy fallback.
+    3. Remote-connection whoami cache (``subject_id`` etc.).
+    4. ``None`` — let SearchService use its own default.
+    """
+    from nexus.bricks.mcp.server import _request_api_key
+    from nexus.contracts.constants import ROOT_ZONE_ID
+    from nexus.contracts.types import OperationContext
+
+    # (0) Per-request API key — most authoritative when MCP is behind
+    # HTTP middleware that sets _request_api_key (#3731).
+    request_key = _request_api_key.get()
+    if request_key and auth_provider is not None:
+        auth_result = authenticate_api_key(auth_provider, request_key)
+        if auth_result is not None:
+            _get = (
+                auth_result.get
+                if hasattr(auth_result, "get")
+                else lambda k, d=None: getattr(auth_result, k, d)
+            )
+            if _get("authenticated", False):
+                subject_id = _get("subject_id", None) or "anonymous"
+                zone_id = _get("zone_id", None) or ROOT_ZONE_ID
+                is_admin = bool(_get("is_admin", False))
+                subject_type = _get("subject_type", None) or "user"
+                return OperationContext(
+                    user_id=subject_id,
+                    subject_type=subject_type,
+                    subject_id=subject_id,
+                    zone_id=zone_id,
+                    groups=[],
+                    is_admin=is_admin,
+                    is_system=False,
+                )
+
+    # (1) Kernel init_cred.
+    init_cred = getattr(nx_instance, "_init_cred", None)
+    if init_cred is not None:
+        return init_cred
+
+    # (2) Legacy default_context.
+    default_ctx = getattr(nx_instance, "_default_context", None)
+    if default_ctx is not None:
+        return default_ctx
+
+    # (3) Bare remote backend whoami fields.
+    subject_id = getattr(nx_instance, "subject_id", None)
+    if subject_id:
+        subject_type = getattr(nx_instance, "subject_type", None) or "user"
+        zone_id = getattr(nx_instance, "zone_id", None) or ROOT_ZONE_ID
+        is_admin = bool(getattr(nx_instance, "is_admin", False))
+        return OperationContext(
+            user_id=subject_id,
+            subject_type=subject_type,
+            subject_id=subject_id,
+            zone_id=zone_id,
+            groups=[],
+            is_admin=is_admin,
+            is_system=False,
+        )
+
+    # (4) Last resort.
+    logger.warning(
+        "MCP search tool could not resolve an explicit OperationContext "
+        "from the NexusFS (no _init_cred, no _default_context, "
+        "no whoami identity). Falling back to SearchService's default "
+        "context — the server-side auth layer remains the source of truth."
+    )
+    return None

--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -855,9 +855,9 @@ async def create_mcp_server(
             Narrowed: nexus_glob("**/*.py", files=["/src/a.py", "/src/b.py"])
         """
         from nexus.core.path_utils import split_zone_from_internal_path
-        from nexus.server.api.v2.routers.search import (
-            _apply_rebac_filter,
-            _rebac_denial_stats,
+        from nexus.lib.rebac_filter import (
+            apply_rebac_filter,
+            rebac_denial_stats,
         )
 
         nx_instance: Any = _get_nexus_instance(ctx)
@@ -887,7 +887,7 @@ async def create_mcp_server(
         # #3731: Apply file-level ReBAC filtering (second layer,
         # same as HTTP _do_glob_operation).
         pre_filter_count = len(all_matches)
-        filtered_paths, filter_ms = _apply_rebac_filter(
+        filtered_paths, filter_ms = apply_rebac_filter(
             all_matches,
             permission_enforcer,
             auth_result,
@@ -926,7 +926,7 @@ async def create_mcp_server(
         glob_multi_zone_ambiguous = len(set(_keys)) < len(_keys)
 
         extras: dict[str, Any] = {
-            **_rebac_denial_stats(pre_filter_count, post_filter_count, limit + offset),
+            **rebac_denial_stats(pre_filter_count, post_filter_count, limit + offset),
             "item_zones": item_zones,
         }
         if glob_multi_zone_ambiguous:
@@ -1010,10 +1010,10 @@ async def create_mcp_server(
             Non-matching lines: nexus_grep("debug", invert_match=True)
         """
         from nexus.core.path_utils import split_zone_from_internal_path
-        from nexus.server.api.v2.routers.search import (
-            _apply_rebac_filter,
-            _compute_rebac_fetch_limit,
-            _rebac_denial_stats,
+        from nexus.lib.rebac_filter import (
+            apply_rebac_filter,
+            compute_rebac_fetch_limit,
+            rebac_denial_stats,
         )
 
         nx_instance: Any = _get_nexus_instance(ctx)
@@ -1040,7 +1040,7 @@ async def create_mcp_server(
         # Sentinel fetch + ReBAC over-fetch (#3731).
         window_size = limit + offset
         sentinel_window = window_size + 1
-        fetch_limit = _compute_rebac_fetch_limit(
+        fetch_limit = compute_rebac_fetch_limit(
             sentinel_window, has_enforcer=permission_enforcer is not None
         )
         grep_kwargs: dict[str, Any] = {
@@ -1070,7 +1070,7 @@ async def create_mcp_server(
         # #3731: Apply file-level ReBAC filtering (second layer,
         # same as HTTP _do_grep_operation).
         pre_filter_count = len(all_results)
-        filtered_results, filter_ms = _apply_rebac_filter(
+        filtered_results, filter_ms = apply_rebac_filter(
             all_results,
             permission_enforcer,
             auth_result,
@@ -1115,7 +1115,7 @@ async def create_mcp_server(
 
         # #3731: Include permission stats in response (parity with HTTP).
         extras: dict[str, Any] = {
-            **_rebac_denial_stats(pre_filter_count, post_filter_count, window_size),
+            **rebac_denial_stats(pre_filter_count, post_filter_count, window_size),
         }
         if multi_zone_ambiguous:
             extras["multi_zone_ambiguous"] = True

--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -871,6 +871,14 @@ async def create_mcp_server(
         # MCP server was booted with. ``_resolve_mcp_operation_context``
         # fails closed if the identity can't be resolved.
         op_context = _resolve_mcp_operation_context(nx_instance, auth_provider=auth_provider)
+        # #3731 R2: if a per-request key was set but identity resolution
+        # failed (fail-closed → None), reject the request rather than
+        # executing with an anonymous/ambient context.
+        if op_context is None and _request_api_key.get():
+            return tool_error(
+                "unauthorized",
+                "Per-request API key could not be verified; search denied.",
+            )
         auth_result = _op_context_to_auth_dict(op_context)
         zone_id = auth_result.get("zone_id", "root")
 
@@ -1017,6 +1025,12 @@ async def create_mcp_server(
         # semantics). Previously grep ran without any context so ReBAC
         # filtering fell back to the ambient connection identity.
         op_context = _resolve_mcp_operation_context(nx_instance, auth_provider=auth_provider)
+        # #3731 R2: reject if per-request key present but auth failed.
+        if op_context is None and _request_api_key.get():
+            return tool_error(
+                "unauthorized",
+                "Per-request API key could not be verified; search denied.",
+            )
 
         # #3731: Build auth_result dict from OperationContext for
         # _apply_rebac_filter. Falls back to anonymous if no context.

--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -180,20 +180,13 @@ async def create_mcp_server(
             except Exception:
                 pass  # Graceful degradation — tool returns "unavailable"
 
-    # Auto-resolve permission_enforcer and auth_provider from NexusFS
-    # when not explicitly provided (#3731 review finding: without this,
-    # the security fix is opt-in and existing callers remain unprotected).
-    # Only use the service() registry — getattr on NexusFS can pick up
-    # mock artifacts or unrelated attributes in test environments.
-    if permission_enforcer is None and nx is not None and hasattr(nx, "service"):
-        _pe = nx.service("permission_enforcer")
-        if _pe is not None and hasattr(_pe, "filter_search_results"):
-            permission_enforcer = _pe
-
-    if auth_provider is None and nx is not None and hasattr(nx, "service"):
-        _ap = nx.service("auth")
-        if _ap is not None and hasattr(_ap, "authenticate"):
-            auth_provider = _ap
+    # NOTE: permission_enforcer and auth_provider are intentionally NOT
+    # auto-resolved from NexusFS services. A NexusFS with enforce=False
+    # may still register a PermissionEnforcer service that denies all
+    # requests (no grants → empty permit list). Callers that need ReBAC
+    # must pass permission_enforcer explicitly. The HTTP server does
+    # this via app.state.permission_enforcer; the CLI MCP command
+    # should thread it when auth is configured (#3731).
 
     # Store default connection and config for per-request API key support
     assert nx is not None  # guaranteed by the if-block above

--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -180,6 +180,21 @@ async def create_mcp_server(
             except Exception:
                 pass  # Graceful degradation — tool returns "unavailable"
 
+    # Auto-resolve permission_enforcer and auth_provider from NexusFS
+    # when not explicitly provided (#3731 review finding: without this,
+    # the security fix is opt-in and existing callers remain unprotected).
+    # Only use the service() registry — getattr on NexusFS can pick up
+    # mock artifacts or unrelated attributes in test environments.
+    if permission_enforcer is None and nx is not None and hasattr(nx, "service"):
+        _pe = nx.service("permission_enforcer")
+        if _pe is not None and hasattr(_pe, "filter_search_results"):
+            permission_enforcer = _pe
+
+    if auth_provider is None and nx is not None and hasattr(nx, "service"):
+        _ap = nx.service("auth")
+        if _ap is not None and hasattr(_ap, "authenticate"):
+            auth_provider = _ap
+
     # Store default connection and config for per-request API key support
     assert nx is not None  # guaranteed by the if-block above
     _default_nx: NexusFS = nx

--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -16,6 +16,10 @@ from typing import TYPE_CHECKING, Any, cast
 from cachetools import LRUCache
 from fastmcp import Context, FastMCP
 
+from nexus.bricks.mcp.auth_bridge import op_context_to_auth_dict as _op_context_to_auth_dict
+from nexus.bricks.mcp.auth_bridge import (
+    resolve_mcp_operation_context as _resolve_mcp_operation_context,
+)
 from nexus.bricks.mcp.formatters import format_response
 from nexus.bricks.mcp.tool_utils import handle_tool_errors, tool_error
 from nexus.lib.pagination import build_paginated_list_response
@@ -79,95 +83,6 @@ def reset_request_api_key(token: contextvars.Token[str | None]) -> None:
     _request_api_key.reset(token)
 
 
-def _resolve_mcp_operation_context(nx_instance: NexusFS) -> Any:
-    """Resolve an explicit ``OperationContext`` for MCP search calls.
-
-    Codex review #3 finding #1: the previous MCP grep/glob handlers
-    called ``SearchService`` without any ``OperationContext`` at all,
-    so permission filtering relied on whatever the underlying
-    NexusFS connection happened to enforce at the
-    service-lookup layer. On any deployment where the default
-    connection is wider than the per-request subject, that was a
-    tenant-isolation hole: an MCP caller could search a broader
-    filesystem view than their ReBAC grants allowed.
-
-    Resolution priority (first non-None wins):
-
-    1. ``nx_instance._init_cred`` — the kernel process credential set
-       by ``create_nexus_fs(init_cred=...)`` for local embedded mode
-       and by ``nexus.connect(profile='remote', ...)`` for the remote
-       client. This is the canonical "who is this NexusFS running as"
-       field and matches how every other caller (sys_read, sys_write,
-       list, etc.) resolves its default context inside NexusFS.
-
-    2. ``nx_instance._default_context`` — legacy fallback for direct
-       SearchService mocks and anything that exposes a context field
-       under that older name.
-
-    3. Remote-connection whoami cache (``subject_id`` / ``zone_id`` /
-       ``is_admin`` populated by ``BaseRemoteNexusFS._parse_auth_info``)
-       — used when the MCP server was handed a bare remote backend /
-       metastore instance rather than a full NexusFS. Rare today but
-       the branch exists for future transport variants.
-
-    4. ``None`` — last resort. Safe because SearchService has its own
-       internal default-context fallback (same one every non-MCP
-       caller uses), and in remote mode the server-side auth layer
-       re-validates permissions against the API key regardless of
-       what the client passes. We log a warning so operators can
-       detect the misconfiguration.
-
-    The previous revision of this helper raised ``PermissionError``
-    on step 4 (fail-closed). That turned out to be too strict: the
-    e2e self-contained tests use ``create_nexus_fs`` with
-    ``permissions.enforce=False`` and no ``_default_context`` attr,
-    which meant the helper raised on every search call and wrecked
-    CI. Returning ``None`` instead preserves the Codex spirit — we
-    still pass an explicit context whenever one is resolvable — and
-    only silently falls through when there's no identity *to*
-    resolve.
-    """
-    from nexus.contracts.constants import ROOT_ZONE_ID
-    from nexus.contracts.types import OperationContext
-
-    # (1) Kernel init_cred — matches how NexusFS.context_or_raise works.
-    init_cred = getattr(nx_instance, "_init_cred", None)
-    if init_cred is not None:
-        return init_cred
-
-    # (2) Legacy SearchService-style default_context (mocks use this).
-    default_ctx = getattr(nx_instance, "_default_context", None)
-    if default_ctx is not None:
-        return default_ctx
-
-    # (3) Bare remote backend: build from whoami-populated fields.
-    subject_id = getattr(nx_instance, "subject_id", None)
-    if subject_id:
-        subject_type = getattr(nx_instance, "subject_type", None) or "user"
-        zone_id = getattr(nx_instance, "zone_id", None) or ROOT_ZONE_ID
-        is_admin = bool(getattr(nx_instance, "is_admin", False))
-        return OperationContext(
-            user_id=subject_id,
-            subject_type=subject_type,
-            subject_id=subject_id,
-            zone_id=zone_id,
-            groups=[],
-            is_admin=is_admin,
-            is_system=False,
-        )
-
-    # (4) Last resort — let SearchService use its own default. Safe
-    # in local mode (process identity == caller identity) and in
-    # remote mode (server re-authenticates via API key anyway).
-    logger.warning(
-        "MCP search tool could not resolve an explicit OperationContext "
-        "from the NexusFS (no _init_cred, no _default_context, "
-        "no whoami identity). Falling back to SearchService's default "
-        "context — the server-side auth layer remains the source of truth."
-    )
-    return None
-
-
 async def create_mcp_server(
     nx: NexusFS | None = None,
     name: str = "nexus",
@@ -175,6 +90,8 @@ async def create_mcp_server(
     api_key: str | None = None,
     tool_namespace_middleware: Any | None = None,
     manifest_resolver: Any | None = None,
+    permission_enforcer: Any | None = None,
+    auth_provider: Any | None = None,
 ) -> FastMCP:
     """Create an MCP server for Nexus operations.
 
@@ -191,6 +108,14 @@ async def create_mcp_server(
             tool. Expected signature: ``(sources_json: str, variables_json: str)
             -> dict`` returning resolution results. Built by the factory via
             ``build_manifest_resolve_fn()``.
+        permission_enforcer: Optional PermissionEnforcer for file-level ReBAC
+            filtering on MCP search results (#3731). When provided, MCP
+            ``nexus_grep`` and ``nexus_glob`` apply the same
+            ``_apply_rebac_filter`` that the HTTP endpoints use.
+        auth_provider: Optional auth provider for resolving per-request API
+            keys to subject identity (#3731). Used by
+            ``_resolve_mcp_operation_context`` to build an authoritative
+            ``OperationContext`` from ``_request_api_key``.
 
     Returns:
         FastMCP server instance
@@ -914,6 +839,12 @@ async def create_mcp_server(
             With pagination: nexus_glob("**/*.py", "/workspace", limit=50, offset=0)
             Narrowed: nexus_glob("**/*.py", files=["/src/a.py", "/src/b.py"])
         """
+        from nexus.core.path_utils import split_zone_from_internal_path
+        from nexus.server.api.v2.routers.search import (
+            _apply_rebac_filter,
+            _rebac_denial_stats,
+        )
+
         nx_instance: Any = _get_nexus_instance(ctx)
         _search = nx_instance.service("search")
         if _search is None:
@@ -924,12 +855,38 @@ async def create_mcp_server(
         # than the ambient identity of whatever default connection the
         # MCP server was booted with. ``_resolve_mcp_operation_context``
         # fails closed if the identity can't be resolved.
-        op_context = _resolve_mcp_operation_context(nx_instance)
+        op_context = _resolve_mcp_operation_context(nx_instance, auth_provider=auth_provider)
+        auth_result = _op_context_to_auth_dict(op_context)
+        zone_id = auth_result.get("zone_id", "root")
+
         all_matches = _search.glob(pattern, path, files=files, context=op_context)
-        total = len(all_matches)
+
+        # #3731: Apply file-level ReBAC filtering (second layer,
+        # same as HTTP _do_glob_operation).
+        pre_filter_count = len(all_matches)
+        filtered_paths, filter_ms = _apply_rebac_filter(
+            all_matches,
+            permission_enforcer,
+            auth_result,
+            zone_id,
+            path_extractor=lambda p: p,
+        )
+        post_filter_count = len(filtered_paths)
+        total = post_filter_count
 
         # Apply pagination
-        paginated_matches = all_matches[offset : offset + limit]
+        paginated_matches = filtered_paths[offset : offset + limit]
+
+        # #3731: Zone unscoping — convert internal zone-prefixed paths
+        # to user-facing paths and build parallel zone list for
+        # round-trip disambiguation (mirrors HTTP _do_glob_operation).
+        item_zones: list[str | None] = []
+        unscoped_items: list[str] = []
+        for p in paginated_matches:
+            zone, unscoped = split_zone_from_internal_path(p)
+            unscoped_items.append(unscoped)
+            item_zones.append(zone)
+        paginated_matches = unscoped_items
 
         # Issue #538: Log truncation when results exceed limit
         if (offset + limit) < total or offset > 0:
@@ -938,11 +895,26 @@ async def create_mcp_server(
                 f"(offset={offset}, limit={limit})"
             )
 
+        # #3731: Include permission stats + zone disambiguation in
+        # response (parity with HTTP).
+        # #3731: Detect multi-zone ambiguity (parity with HTTP
+        # _do_glob_operation).
+        _keys = list(zip(paginated_matches, item_zones, strict=False))
+        glob_multi_zone_ambiguous = len(set(_keys)) < len(_keys)
+
+        extras: dict[str, Any] = {
+            **_rebac_denial_stats(pre_filter_count, post_filter_count, limit + offset),
+            "item_zones": item_zones,
+        }
+        if glob_multi_zone_ambiguous:
+            extras["multi_zone_ambiguous"] = True
+
         result = build_paginated_list_response(
             items=paginated_matches,
             total=total,
             offset=offset,
             limit=limit,
+            extras=extras,
         )
 
         return format_response(result, response_format)
@@ -1014,6 +986,13 @@ async def create_mcp_server(
             With context lines: nexus_grep("error", before_context=2, after_context=2)
             Non-matching lines: nexus_grep("debug", invert_match=True)
         """
+        from nexus.core.path_utils import split_zone_from_internal_path
+        from nexus.server.api.v2.routers.search import (
+            _apply_rebac_filter,
+            _compute_rebac_fetch_limit,
+            _rebac_denial_stats,
+        )
+
         nx_instance: Any = _get_nexus_instance(ctx)
         _search = nx_instance.service("search")
         if _search is None:
@@ -1022,18 +1001,22 @@ async def create_mcp_server(
         # (see ``_resolve_mcp_operation_context`` for the fail-closed
         # semantics). Previously grep ran without any context so ReBAC
         # filtering fell back to the ambient connection identity.
-        op_context = _resolve_mcp_operation_context(nx_instance)
-        # Codex adversarial review of #3701: sentinel fetch. Request
-        # ``limit + offset + 1`` rows so we can detect ``has_more``
-        # reliably. Without the sentinel, a corpus with exactly
-        # ``limit + offset`` matches would report ``has_more=False``
-        # even when SearchService's underlying pool has more hits it
-        # truncated because of the max_results cap.
+        op_context = _resolve_mcp_operation_context(nx_instance, auth_provider=auth_provider)
+
+        # #3731: Build auth_result dict from OperationContext for
+        # _apply_rebac_filter. Falls back to anonymous if no context.
+        auth_result = _op_context_to_auth_dict(op_context)
+        zone_id = auth_result.get("zone_id", "root")
+
+        # Sentinel fetch + ReBAC over-fetch (#3731).
         window_size = limit + offset
         sentinel_window = window_size + 1
+        fetch_limit = _compute_rebac_fetch_limit(
+            sentinel_window, has_enforcer=permission_enforcer is not None
+        )
         grep_kwargs: dict[str, Any] = {
             "ignore_case": ignore_case,
-            "max_results": max(sentinel_window, 1),
+            "max_results": max(fetch_limit, 1),
             "files": files,
             "context": op_context,
         }
@@ -1048,25 +1031,45 @@ async def create_mcp_server(
         if block_type is not None:
             grep_kwargs["block_type"] = block_type
 
-        all_results = await _search.grep(pattern, path, **grep_kwargs)
-        raw_count = len(all_results)
-        # Sentinel-based has_more: if SearchService returned at least
-        # one row beyond the caller's window, there's a next page.
-        has_more = raw_count > window_size
-        # ``total`` reports the full observed count (matches HTTP grep
-        # semantics — post_filter_count, not window-capped). Previous
-        # revision capped ``total`` at ``window_size`` which broke the
-        # existing assertion in
-        # tests/unit/bricks/mcp/test_mcp_server_tools.py::
-        # test_grep_result_limiting that expects ``total`` to equal the
-        # number of raw hits the underlying service produced.
-        total = raw_count
+        # SearchService.grep() is async in local mode but the
+        # RemoteServiceProxy returns a sync result. Handle both.
+        _grep_result = _search.grep(pattern, path, **grep_kwargs)
+        if inspect.isawaitable(_grep_result):
+            _grep_result = await _grep_result
+        all_results = _grep_result
 
-        # Apply pagination. Slice directly off the raw result list so
-        # callers see the first ``window_size`` rows (the sentinel row,
-        # if present, sits at index ``window_size`` and is implicitly
-        # dropped by the slice bounds).
-        paginated_results = all_results[offset : offset + limit]
+        # #3731: Apply file-level ReBAC filtering (second layer,
+        # same as HTTP _do_grep_operation).
+        pre_filter_count = len(all_results)
+        filtered_results, filter_ms = _apply_rebac_filter(
+            all_results,
+            permission_enforcer,
+            auth_result,
+            zone_id,
+            path_extractor=lambda r: r.get("file", ""),
+        )
+        post_filter_count = len(filtered_results)
+
+        # Sentinel-based has_more (post-ReBAC).
+        has_more = post_filter_count > window_size
+        total = post_filter_count
+
+        # Apply pagination.
+        paginated_results = filtered_results[offset : offset + limit]
+
+        # #3731: Zone unscoping — convert internal zone-prefixed paths
+        # to user-facing paths and annotate with zone_id for round-trip
+        # disambiguation (mirrors HTTP _do_grep_operation).
+        annotated: list[dict[str, Any]] = []
+        for r in paginated_results:
+            out = dict(r)
+            raw_file = r.get("file", "")
+            zone, unscoped = split_zone_from_internal_path(raw_file)
+            out["file"] = unscoped
+            if zone is not None:
+                out["zone_id"] = zone
+            annotated.append(out)
+        paginated_results = annotated
 
         # Issue #538: Log truncation when results exceed limit
         if has_more or offset > 0:
@@ -1075,12 +1078,26 @@ async def create_mcp_server(
                 f"{len(paginated_results)} results (offset={offset}, limit={limit})"
             )
 
+        # #3731: Detect multi-zone ambiguity (parity with HTTP
+        # _do_grep_operation). Two distinct raw paths that collapse to
+        # the same (file, zone_id) tuple degrade round-trip safety.
+        _keys = [(it["file"], it.get("zone_id")) for it in paginated_results]
+        multi_zone_ambiguous = len(set(_keys)) < len(_keys)
+
+        # #3731: Include permission stats in response (parity with HTTP).
+        extras: dict[str, Any] = {
+            **_rebac_denial_stats(pre_filter_count, post_filter_count, window_size),
+        }
+        if multi_zone_ambiguous:
+            extras["multi_zone_ambiguous"] = True
+
         result = build_paginated_list_response(
             items=paginated_results,
             total=total,
             offset=offset,
             limit=limit,
             has_more=has_more,
+            extras=extras,
         )
 
         return format_response(result, response_format)

--- a/src/nexus/lib/rebac_filter.py
+++ b/src/nexus/lib/rebac_filter.py
@@ -1,0 +1,125 @@
+"""ReBAC search-result filtering helpers.
+
+Shared by the HTTP search router and MCP search tools so both surfaces
+apply identical file-level permission filtering (#3731).
+
+Extracted from ``nexus.server.api.v2.routers.search`` to live in the
+``nexus.lib`` tier, which bricks are allowed to import.
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+# When a permission enforcer is active we over-fetch to compensate for
+# results that will be stripped during ReBAC filtering.  3x is the legacy
+# value chosen empirically when #2056 landed.
+REBAC_OVERFETCH_FACTOR: int = 3
+
+# Threshold above which a high denial rate triggers a server-side warning.
+REBAC_HIGH_DENIAL_WARN_THRESHOLD: float = 0.5
+
+
+def normalize_path(path: str) -> str:
+    """Ensure path is absolute for ReBAC filter_list compatibility."""
+    if not path.startswith("/"):
+        return f"/{path}"
+    return path
+
+
+def apply_rebac_filter(
+    results: list[Any],
+    permission_enforcer: Any | None,
+    auth_result: dict[str, Any],
+    zone_id: str,
+    path_extractor: Any | None = None,
+) -> tuple[list[Any], float]:
+    """Apply ReBAC file-level permission filtering to search results.
+
+    Returns (filtered_results, filter_time_ms).
+
+    Args:
+        results: Search results to filter.
+        permission_enforcer: PermissionEnforcer instance (or None to skip).
+        auth_result: Authentication dict with subject_id, is_admin, etc.
+        zone_id: Zone ID for ReBAC scope.
+        path_extractor: Callable ``(result) -> str`` that extracts the file
+            path from a result element.  Defaults to ``lambda r: r.path``.
+    """
+    if permission_enforcer is None:
+        return results, 0.0
+
+    if not hasattr(permission_enforcer, "filter_search_results"):
+        return results, 0.0
+
+    if path_extractor is None:
+        path_extractor = lambda r: r.path  # noqa: E731
+
+    user_id = auth_result.get("subject_id") or auth_result.get("user_id", "anonymous")
+    is_admin = bool(auth_result.get("is_admin", False))
+
+    # Two-pass: deduplicate paths for the permission check, then filter
+    # the original ordered list against the permitted set.
+    unique_abs_paths: list[str] = []
+    seen: set[str] = set()
+    result_abs_paths: list[str] = []
+    for r in results:
+        abs_path = normalize_path(path_extractor(r))
+        result_abs_paths.append(abs_path)
+        if abs_path not in seen:
+            seen.add(abs_path)
+            unique_abs_paths.append(abs_path)
+
+    filter_start = time.perf_counter()
+    permitted_abs = permission_enforcer.filter_search_results(
+        unique_abs_paths,
+        user_id=user_id,
+        zone_id=zone_id,
+        is_admin=is_admin,
+    )
+    filter_ms = (time.perf_counter() - filter_start) * 1000
+
+    logger.debug(
+        "[SEARCH-REBAC] permitted %d/%d paths in %.1fms",
+        len(permitted_abs),
+        len(unique_abs_paths),
+        filter_ms,
+    )
+
+    permitted_set = set(permitted_abs)
+    filtered = [r for r, p in zip(results, result_abs_paths, strict=True) if p in permitted_set]
+    return filtered, filter_ms
+
+
+def compute_rebac_fetch_limit(effective_limit: int, has_enforcer: bool) -> int:
+    """Compute the over-fetch size for a given effective limit."""
+    if not has_enforcer:
+        return effective_limit
+    return effective_limit * REBAC_OVERFETCH_FACTOR
+
+
+def rebac_denial_stats(
+    pre_filter_count: int, post_filter_count: int, effective_limit: int
+) -> dict[str, Any]:
+    """Compute denial-rate instrumentation for response envelopes."""
+    denial_rate = 0.0 if pre_filter_count == 0 else 1.0 - (post_filter_count / pre_filter_count)
+
+    truncated = (
+        post_filter_count < effective_limit and denial_rate >= REBAC_HIGH_DENIAL_WARN_THRESHOLD
+    )
+    if truncated:
+        logger.warning(
+            "[SEARCH-REBAC] high denial rate (%.1f%%) caused undercount: "
+            "got %d of %d requested; consider paginating or increasing limit",
+            denial_rate * 100.0,
+            post_filter_count,
+            effective_limit,
+        )
+    return {
+        "permission_denial_rate": round(denial_rate, 4),
+        "truncated_by_permissions": truncated,
+    }

--- a/src/nexus/remote/service_proxy.py
+++ b/src/nexus/remote/service_proxy.py
@@ -63,6 +63,7 @@ class RemoteServiceProxy:
             raise AttributeError(name)
 
         # Lazy import to avoid circular dependency at module load
+        from nexus.remote.method_registry import METHOD_REGISTRY
         from nexus.remote.rpc_proxy import RPCProxyBase
 
         def rpc_forwarder(*args: Any, **kwargs: Any) -> Any:
@@ -89,7 +90,18 @@ class RemoteServiceProxy:
             # long-running calls like ACP agent invocations.
             read_timeout = kwargs.get("timeout")
 
-            return self._call_rpc(rpc_name, kwargs or None, read_timeout=read_timeout)
+            result = self._call_rpc(rpc_name, kwargs or None, read_timeout=read_timeout)
+
+            # Apply response_key extraction from METHOD_REGISTRY (#3731).
+            # Without this, methods like grep/glob return the server's
+            # dict wrapper ({"results": [...]}) instead of the unwrapped
+            # list that callers expect. This matches the unwrapping that
+            # RPCProxyBase._dispatch_rpc() does for the main NexusFS proxy.
+            spec = METHOD_REGISTRY.get(rpc_name)
+            if spec and spec.response_key and isinstance(result, dict):
+                return result.get(spec.response_key, result)
+
+            return result
 
         # Preserve method name for debugging
         rpc_forwarder.__name__ = name

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -32,6 +32,9 @@ from typing import Any
 from fastapi import APIRouter, Depends, HTTPException, Query, Request
 
 from nexus.lib.pagination import build_paginated_list_response
+from nexus.lib.rebac_filter import apply_rebac_filter as _apply_rebac_filter
+from nexus.lib.rebac_filter import compute_rebac_fetch_limit as _compute_rebac_fetch_limit
+from nexus.lib.rebac_filter import rebac_denial_stats as _rebac_denial_stats
 from nexus.server.dependencies import require_auth
 
 logger = logging.getLogger(__name__)
@@ -47,11 +50,8 @@ router = APIRouter(prefix="/api/v2/search", tags=["search"])
 # value chosen empirically when #2056 landed. Beware: when the denial rate
 # exceeds ~66% this factor is insufficient and the response reports
 # ``truncated_by_permissions`` so callers can detect the silent undercount.
-_REBAC_OVERFETCH_FACTOR: int = 3
 
-# Threshold above which a high denial rate triggers a server-side warning
-# log (Issue 16A). Below this the silent-undercount risk is minimal.
-_REBAC_HIGH_DENIAL_WARN_THRESHOLD: float = 0.5
+# ReBAC constants and helpers are now in nexus.lib.rebac_filter (#3731).
 
 # =============================================================================
 # Dependencies
@@ -96,91 +96,7 @@ def _get_async_read_session_factory(request: Request) -> Any:
     return factory
 
 
-# =============================================================================
-# ReBAC filtering helper
-# =============================================================================
-
-
-def _normalize_path(path: str) -> str:
-    """Ensure path is absolute for ReBAC filter_list compatibility."""
-    if not path.startswith("/"):
-        return f"/{path}"
-    return path
-
-
-def _apply_rebac_filter(
-    results: list[Any],
-    permission_enforcer: Any | None,
-    auth_result: dict[str, Any],
-    zone_id: str,
-    path_extractor: Any | None = None,
-) -> tuple[list[Any], float]:
-    """Apply ReBAC file-level permission filtering to search results.
-
-    Returns (filtered_results, filter_time_ms).
-
-    Uses PermissionEnforcer.filter_search_results() which delegates to
-    rebac_list_objects() (Rust-accelerated, 1 SQL query + 1 Rust computation).
-    This bypasses the NamespaceManager pre-filter (search paths lack mount entries)
-    and avoids the stale graph cache bug in compute_permissions_bulk.
-
-    Args:
-        results: Search results to filter.
-        permission_enforcer: PermissionEnforcer instance (or None to skip).
-        auth_result: Authentication dict with subject_id, is_admin, etc.
-        zone_id: Zone ID for ReBAC scope.
-        path_extractor: Callable ``(result) -> str`` that extracts the file
-            path from a result element. Defaults to ``lambda r: r.path``
-            (suitable for search_query results). Pass
-            ``lambda r: r["file"]`` for grep dicts, ``lambda r: r`` for
-            bare path strings (#3731: eliminates per-caller shim classes).
-    """
-    if permission_enforcer is None:
-        return results, 0.0
-
-    if not hasattr(permission_enforcer, "filter_search_results"):
-        return results, 0.0
-
-    if path_extractor is None:
-        path_extractor = lambda r: r.path  # noqa: E731
-
-    user_id = auth_result.get("subject_id") or auth_result.get("user_id", "anonymous")
-    is_admin = bool(auth_result.get("is_admin", False))
-
-    # Two-pass approach: (1) deduplicate paths for the permission
-    # check, (2) filter the original ordered list against the
-    # permitted set. A dict-based path_map would silently drop
-    # multiple grep results from the same file (#3731 review).
-    unique_abs_paths: list[str] = []
-    seen: set[str] = set()
-    result_abs_paths: list[str] = []  # parallel to ``results``
-    for r in results:
-        abs_path = _normalize_path(path_extractor(r))
-        result_abs_paths.append(abs_path)
-        if abs_path not in seen:
-            seen.add(abs_path)
-            unique_abs_paths.append(abs_path)
-
-    filter_start = time.perf_counter()
-    permitted_abs = permission_enforcer.filter_search_results(
-        unique_abs_paths,
-        user_id=user_id,
-        zone_id=zone_id,
-        is_admin=is_admin,
-    )
-    filter_ms = (time.perf_counter() - filter_start) * 1000
-
-    logger.debug(
-        "[SEARCH-REBAC] permitted %d/%d paths in %.1fms",
-        len(permitted_abs),
-        len(unique_abs_paths),
-        filter_ms,
-    )
-
-    permitted_set = set(permitted_abs)
-    filtered = [r for r, p in zip(results, result_abs_paths, strict=True) if p in permitted_set]
-    return filtered, filter_ms
-
+# ReBAC filtering helpers are in nexus.lib.rebac_filter (#3731).
 
 # =============================================================================
 # Response shaping helpers (#3701 review — Issue 5A)
@@ -213,49 +129,6 @@ def _serialize_search_result(result: Any) -> dict[str, Any]:
     reranker = getattr(result, "reranker_score", None)
     out["reranker_score"] = round(reranker, 4) if reranker is not None else None
     return out
-
-
-def _compute_rebac_fetch_limit(effective_limit: int, has_enforcer: bool) -> int:
-    """Compute the over-fetch size for a given effective limit.
-
-    Shared helper used by ``search_query``, ``search_grep``, and
-    ``search_glob`` so the over-fetch factor lives in exactly one place.
-    Returns ``effective_limit`` unchanged when no permission enforcer is
-    active (#3701 review — Issue 16A).
-    """
-    if not has_enforcer:
-        return effective_limit
-    return effective_limit * _REBAC_OVERFETCH_FACTOR
-
-
-def _rebac_denial_stats(
-    pre_filter_count: int, post_filter_count: int, effective_limit: int
-) -> dict[str, Any]:
-    """Compute denial-rate instrumentation for response envelopes.
-
-    Returns a dict that gets merged into the response envelope so
-    callers can detect silent under-counting after permission filtering.
-    Emits a WARNING log when the denial rate is high *and* the caller
-    did not get enough results — the exact failure mode 3x over-fetch
-    cannot always absorb.
-    """
-    denial_rate = 0.0 if pre_filter_count == 0 else 1.0 - (post_filter_count / pre_filter_count)
-
-    truncated = (
-        post_filter_count < effective_limit and denial_rate >= _REBAC_HIGH_DENIAL_WARN_THRESHOLD
-    )
-    if truncated:
-        logger.warning(
-            "[SEARCH-REBAC] high denial rate (%.1f%%) caused undercount: "
-            "got %d of %d requested; consider paginating or increasing limit",
-            denial_rate * 100.0,
-            post_filter_count,
-            effective_limit,
-        )
-    return {
-        "permission_denial_rate": round(denial_rate, 4),
-        "truncated_by_permissions": truncated,
-    }
 
 
 # =============================================================================

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -113,6 +113,7 @@ def _apply_rebac_filter(
     permission_enforcer: Any | None,
     auth_result: dict[str, Any],
     zone_id: str,
+    path_extractor: Any | None = None,
 ) -> tuple[list[Any], float]:
     """Apply ReBAC file-level permission filtering to search results.
 
@@ -122,6 +123,17 @@ def _apply_rebac_filter(
     rebac_list_objects() (Rust-accelerated, 1 SQL query + 1 Rust computation).
     This bypasses the NamespaceManager pre-filter (search paths lack mount entries)
     and avoids the stale graph cache bug in compute_permissions_bulk.
+
+    Args:
+        results: Search results to filter.
+        permission_enforcer: PermissionEnforcer instance (or None to skip).
+        auth_result: Authentication dict with subject_id, is_admin, etc.
+        zone_id: Zone ID for ReBAC scope.
+        path_extractor: Callable ``(result) -> str`` that extracts the file
+            path from a result element. Defaults to ``lambda r: r.path``
+            (suitable for search_query results). Pass
+            ``lambda r: r["file"]`` for grep dicts, ``lambda r: r`` for
+            bare path strings (#3731: eliminates per-caller shim classes).
     """
     if permission_enforcer is None:
         return results, 0.0
@@ -129,16 +141,29 @@ def _apply_rebac_filter(
     if not hasattr(permission_enforcer, "filter_search_results"):
         return results, 0.0
 
+    if path_extractor is None:
+        path_extractor = lambda r: r.path  # noqa: E731
+
     user_id = auth_result.get("subject_id") or auth_result.get("user_id", "anonymous")
     is_admin = bool(auth_result.get("is_admin", False))
 
-    # Normalize paths to absolute for ReBAC compatibility
-    path_map = {_normalize_path(r.path): r for r in results}
-    abs_paths = list(path_map.keys())
+    # Two-pass approach: (1) deduplicate paths for the permission
+    # check, (2) filter the original ordered list against the
+    # permitted set. A dict-based path_map would silently drop
+    # multiple grep results from the same file (#3731 review).
+    unique_abs_paths: list[str] = []
+    seen: set[str] = set()
+    result_abs_paths: list[str] = []  # parallel to ``results``
+    for r in results:
+        abs_path = _normalize_path(path_extractor(r))
+        result_abs_paths.append(abs_path)
+        if abs_path not in seen:
+            seen.add(abs_path)
+            unique_abs_paths.append(abs_path)
 
     filter_start = time.perf_counter()
     permitted_abs = permission_enforcer.filter_search_results(
-        abs_paths,
+        unique_abs_paths,
         user_id=user_id,
         zone_id=zone_id,
         is_admin=is_admin,
@@ -148,12 +173,12 @@ def _apply_rebac_filter(
     logger.debug(
         "[SEARCH-REBAC] permitted %d/%d paths in %.1fms",
         len(permitted_abs),
-        len(abs_paths),
+        len(unique_abs_paths),
         filter_ms,
     )
 
     permitted_set = set(permitted_abs)
-    filtered = [path_map[p] for p in abs_paths if p in permitted_set]
+    filtered = [r for r, p in zip(results, result_abs_paths, strict=True) if p in permitted_set]
     return filtered, filter_ms
 
 
@@ -759,18 +784,14 @@ async def _do_grep_operation(
     # a second-layer guarantee for the HTTP surface.
     pre_filter_count = len(raw_results)
 
-    class _GrepResultShim:
-        __slots__ = ("path",)
-
-        def __init__(self, path: str) -> None:
-            self.path = path
-
-    shims = [_GrepResultShim(r["file"]) for r in raw_results if "file" in r]
-    filtered_shims, filter_ms = _apply_rebac_filter(
-        shims, permission_enforcer, auth_result, zone_id
+    # #3731: path_extractor eliminates the _GrepResultShim shim class.
+    filtered_results, filter_ms = _apply_rebac_filter(
+        raw_results,
+        permission_enforcer,
+        auth_result,
+        zone_id,
+        path_extractor=lambda r: r.get("file", ""),
     )
-    permitted_files = {shim.path for shim in filtered_shims}
-    filtered_results = [r for r in raw_results if r.get("file") in permitted_files]
     post_filter_count = len(filtered_results)
 
     # Sentinel detection: if we got at least one result beyond the
@@ -877,21 +898,15 @@ async def _do_glob_operation(
         logger.error("glob failed: %s", exc, exc_info=True)
         raise HTTPException(status_code=500, detail=f"glob failed: {type(exc).__name__}") from exc
 
-    # ReBAC filtering: wrap bare paths in a shim with a ``.path`` attribute
-    # so we can reuse ``_apply_rebac_filter``.
+    # #3731: path_extractor=identity eliminates the _GlobResultShim shim class.
     pre_filter_count = len(all_matches)
-
-    class _GlobResultShim:
-        __slots__ = ("path",)
-
-        def __init__(self, p: str) -> None:
-            self.path = p
-
-    shims = [_GlobResultShim(p) for p in all_matches]
-    filtered_shims, filter_ms = _apply_rebac_filter(
-        shims, permission_enforcer, auth_result, zone_id
+    filtered_paths, filter_ms = _apply_rebac_filter(
+        all_matches,
+        permission_enforcer,
+        auth_result,
+        zone_id,
+        path_extractor=lambda p: p,
     )
-    filtered_paths = [shim.path for shim in filtered_shims]
     post_filter_count = len(filtered_paths)
 
     total = len(filtered_paths)

--- a/tests/unit/bricks/mcp/test_mcp_rebac_parity.py
+++ b/tests/unit/bricks/mcp/test_mcp_rebac_parity.py
@@ -1,0 +1,458 @@
+"""Tests for MCP-HTTP ReBAC parity (#3731).
+
+Covers:
+1. ``_resolve_mcp_operation_context`` resolution paths (step 0–4)
+2. ``_op_context_to_auth_dict`` helper
+3. ``_authenticate_api_key`` helper
+4. MCP grep/glob with permission_enforcer (ReBAC negative test)
+5. MCP grep/glob produce identical results to HTTP for the same
+   user + query + zone (parity test)
+6. ``context=None`` fallback behavior
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock, Mock
+
+from nexus.bricks.mcp.auth_bridge import (
+    authenticate_api_key as _authenticate_api_key,
+)
+from nexus.bricks.mcp.auth_bridge import (
+    op_context_to_auth_dict as _op_context_to_auth_dict,
+)
+from nexus.bricks.mcp.auth_bridge import (
+    resolve_mcp_operation_context as _resolve_mcp_operation_context,
+)
+from nexus.bricks.mcp.server import (
+    create_mcp_server,
+    reset_request_api_key,
+    set_request_api_key,
+)
+from nexus.contracts.types import OperationContext
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _get_tool(server: Any, tool_name: str) -> Any:
+    """Get a tool from MCP server (FastMCP 2.x/3.x compat)."""
+    if hasattr(server, "_local_provider"):
+        lp = server._local_provider
+        comps = {v.name: v for k, v in lp._components.items() if k.startswith("tool:")}
+        return comps[tool_name]
+    manager = getattr(server, "_tool_manager", None)
+    if manager and hasattr(manager, "_tools"):
+        return manager._tools[tool_name]
+    raise KeyError(f"Tool {tool_name!r} not found")
+
+
+@dataclass(frozen=True)
+class _FakeAuthResult:
+    """Mimics the AuthResult dataclass from nexus.bricks.auth.types."""
+
+    authenticated: bool = True
+    subject_type: str = "user"
+    subject_id: str | None = "alice"
+    zone_id: str | None = "acme"
+    is_admin: bool = False
+    metadata: dict[str, Any] | None = None
+
+
+# ---------------------------------------------------------------------------
+# _op_context_to_auth_dict tests
+# ---------------------------------------------------------------------------
+
+
+class TestOpContextToAuthDict:
+    """Verify the OperationContext → auth_result dict bridge."""
+
+    def test_with_valid_context(self):
+        ctx = OperationContext(
+            user_id="alice",
+            subject_id="alice",
+            zone_id="acme",
+            is_admin=False,
+            groups=[],
+        )
+        result = _op_context_to_auth_dict(ctx)
+        assert result["subject_id"] == "alice"
+        assert result["zone_id"] == "acme"
+        assert result["is_admin"] is False
+
+    def test_with_admin_context(self):
+        ctx = OperationContext(
+            user_id="admin",
+            subject_id="admin",
+            zone_id="root",
+            is_admin=True,
+            groups=["admins"],
+        )
+        result = _op_context_to_auth_dict(ctx)
+        assert result["subject_id"] == "admin"
+        assert result["is_admin"] is True
+
+    def test_with_none_returns_anonymous(self):
+        result = _op_context_to_auth_dict(None)
+        assert result["subject_id"] == "anonymous"
+        assert result["is_admin"] is False
+        assert result["zone_id"] is not None  # Should be ROOT_ZONE_ID
+
+
+# ---------------------------------------------------------------------------
+# _authenticate_api_key tests
+# ---------------------------------------------------------------------------
+
+
+class TestAuthenticateApiKey:
+    """Verify the async-to-sync bridge for auth provider."""
+
+    def test_sync_provider_returns_directly(self):
+        """Non-coroutine return value should be returned as-is."""
+        provider = Mock()
+        provider.authenticate = Mock(return_value=_FakeAuthResult())
+        result = _authenticate_api_key(provider, "sk-test")
+        assert result.authenticated is True
+        assert result.subject_id == "alice"
+
+    def test_async_provider_resolves(self):
+        """Async authenticate() should be awaited via thread."""
+        provider = Mock()
+        provider.authenticate = AsyncMock(return_value=_FakeAuthResult())
+        result = _authenticate_api_key(provider, "sk-test")
+        assert result is not None
+        assert result.authenticated is True
+
+    def test_provider_failure_returns_none(self):
+        """If authenticate() raises, return None (graceful fallback)."""
+        provider = Mock()
+        provider.authenticate = Mock(side_effect=RuntimeError("DB down"))
+        result = _authenticate_api_key(provider, "sk-test")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# _resolve_mcp_operation_context resolution path tests
+# ---------------------------------------------------------------------------
+
+
+class TestResolveMcpOperationContext:
+    """Verify each resolution step in priority order."""
+
+    def test_step0_api_key_contextvar_wins(self):
+        """Step 0: _request_api_key + auth_provider → OperationContext."""
+        provider = Mock()
+        provider.authenticate = Mock(
+            return_value=_FakeAuthResult(
+                subject_id="bob",
+                zone_id="beta",
+                is_admin=True,
+            )
+        )
+        nx = Mock(spec=[])  # No attrs at all → would fall through to step 4
+
+        token = set_request_api_key("sk-bob-key")
+        try:
+            ctx = _resolve_mcp_operation_context(nx, auth_provider=provider)
+        finally:
+            reset_request_api_key(token)
+
+        assert ctx is not None
+        assert ctx.subject_id == "bob"
+        assert ctx.zone_id == "beta"
+        assert ctx.is_admin is True
+
+    def test_step0_skipped_without_api_key(self):
+        """Step 0 skipped when no _request_api_key is set."""
+        provider = Mock()
+        provider.authenticate = Mock(return_value=_FakeAuthResult())
+        init_cred = OperationContext(user_id="local", groups=[])
+        nx = Mock()
+        nx._init_cred = init_cred
+
+        # No set_request_api_key call → step 0 skipped → step 1 wins.
+        ctx = _resolve_mcp_operation_context(nx, auth_provider=provider)
+        assert ctx is init_cred
+        provider.authenticate.assert_not_called()
+
+    def test_step0_skipped_without_auth_provider(self):
+        """Step 0 skipped when no auth_provider is passed."""
+        init_cred = OperationContext(user_id="local", groups=[])
+        nx = Mock()
+        nx._init_cred = init_cred
+
+        token = set_request_api_key("sk-test")
+        try:
+            ctx = _resolve_mcp_operation_context(nx, auth_provider=None)
+        finally:
+            reset_request_api_key(token)
+
+        # Falls through to step 1.
+        assert ctx is init_cred
+
+    def test_step0_unauthenticated_falls_through(self):
+        """Step 0: unauthenticated result → fall through to step 1."""
+        provider = Mock()
+        provider.authenticate = Mock(return_value=_FakeAuthResult(authenticated=False))
+        init_cred = OperationContext(user_id="local", groups=[])
+        nx = Mock()
+        nx._init_cred = init_cred
+
+        token = set_request_api_key("sk-revoked")
+        try:
+            ctx = _resolve_mcp_operation_context(nx, auth_provider=provider)
+        finally:
+            reset_request_api_key(token)
+
+        assert ctx is init_cred  # Step 1 wins
+
+    def test_step1_init_cred(self):
+        """Step 1: _init_cred attr present → return it directly."""
+        init_cred = OperationContext(user_id="kernel", groups=[])
+        nx = Mock()
+        nx._init_cred = init_cred
+        ctx = _resolve_mcp_operation_context(nx)
+        assert ctx is init_cred
+
+    def test_step2_default_context(self):
+        """Step 2: _default_context attr present → return it."""
+        default_ctx = OperationContext(user_id="mock-user", groups=[])
+        nx = Mock(spec=[])
+        nx._default_context = default_ctx
+        # No _init_cred → step 1 skipped → step 2 wins.
+        ctx = _resolve_mcp_operation_context(nx)
+        assert ctx is default_ctx
+
+    def test_step3_whoami_fields(self):
+        """Step 3: bare remote backend with whoami-populated fields."""
+        nx = Mock(spec=[])
+        nx.subject_id = "remote-user"
+        nx.subject_type = "agent"
+        nx.zone_id = "zone-x"
+        nx.is_admin = True
+
+        ctx = _resolve_mcp_operation_context(nx)
+        assert ctx is not None
+        assert ctx.subject_id == "remote-user"
+        assert ctx.subject_type == "agent"
+        assert ctx.zone_id == "zone-x"
+        assert ctx.is_admin is True
+
+    def test_step4_none_fallback(self):
+        """Step 4: no identity resolvable → returns None with warning."""
+        nx = Mock(spec=[])  # No attrs
+        ctx = _resolve_mcp_operation_context(nx)
+        assert ctx is None
+
+
+# ---------------------------------------------------------------------------
+# MCP grep/glob ReBAC negative test
+# ---------------------------------------------------------------------------
+
+
+def _make_nx_with_search(
+    *,
+    grep_return: list[dict[str, Any]] | None = None,
+    glob_return: list[str] | None = None,
+) -> MagicMock:
+    """Build a mock NexusFS that returns controlled search results."""
+    nx = MagicMock()
+    search = MagicMock()
+    search.grep = AsyncMock(return_value=list(grep_return or []))
+    search.glob = MagicMock(return_value=list(glob_return or []))
+    nx.service = MagicMock(side_effect=lambda name: search if name == "search" else None)
+    nx._mock_search = search
+    return nx
+
+
+def _make_permission_enforcer(permitted_paths: list[str]) -> MagicMock:
+    """Build a mock PermissionEnforcer that only permits listed paths."""
+    enforcer = MagicMock()
+    enforcer.filter_search_results = MagicMock(
+        side_effect=lambda paths, **_kw: [p for p in paths if p in permitted_paths]
+    )
+    return enforcer
+
+
+class TestMcpGrepRebac:
+    """MCP grep applies _apply_rebac_filter when permission_enforcer is provided."""
+
+    async def test_denied_files_excluded(self):
+        """Files not in permitted set are excluded from grep results."""
+        nx = _make_nx_with_search(
+            grep_return=[
+                {"file": "/src/allowed.py", "line": 1, "content": "match"},
+                {"file": "/src/denied.py", "line": 2, "content": "match"},
+                {"file": "/src/also_allowed.py", "line": 3, "content": "match"},
+            ]
+        )
+        enforcer = _make_permission_enforcer(["/src/allowed.py", "/src/also_allowed.py"])
+
+        server = await create_mcp_server(
+            nx=nx,
+            permission_enforcer=enforcer,
+        )
+        grep_tool = _get_tool(server, "nexus_grep")
+        raw = await grep_tool.fn(pattern="match", path="/src")
+        response = json.loads(raw)
+
+        files_returned = [item["file"] for item in response["items"]]
+        assert "/src/allowed.py" in files_returned
+        assert "/src/also_allowed.py" in files_returned
+        assert "/src/denied.py" not in files_returned
+        assert response["permission_denial_rate"] > 0
+
+    async def test_multi_line_per_file_preserved(self):
+        """Multiple grep hits from the same file are all preserved.
+
+        Regression test: the path_extractor refactor must not use a
+        dict keyed by path (which collapses multi-line results to one).
+        """
+        nx = _make_nx_with_search(
+            grep_return=[
+                {"file": "/src/ok.py", "line": 1, "content": "match1"},
+                {"file": "/src/ok.py", "line": 5, "content": "match2"},
+                {"file": "/src/ok.py", "line": 9, "content": "match3"},
+                {"file": "/src/denied.py", "line": 1, "content": "match4"},
+            ]
+        )
+        enforcer = _make_permission_enforcer(["/src/ok.py"])
+        server = await create_mcp_server(nx=nx, permission_enforcer=enforcer)
+        grep_tool = _get_tool(server, "nexus_grep")
+        raw = await grep_tool.fn(pattern="match", path="/src")
+        response = json.loads(raw)
+
+        # All 3 lines from ok.py must be present.
+        assert len(response["items"]) == 3
+        lines = [item["line"] for item in response["items"]]
+        assert lines == [1, 5, 9]
+        # The denied file must be absent.
+        assert all(item["file"] == "/src/ok.py" for item in response["items"])
+
+    async def test_no_enforcer_returns_all(self):
+        """Without permission_enforcer, all results pass through."""
+        nx = _make_nx_with_search(
+            grep_return=[
+                {"file": "/a.py", "line": 1, "content": "m"},
+                {"file": "/b.py", "line": 2, "content": "m"},
+            ]
+        )
+        server = await create_mcp_server(nx=nx, permission_enforcer=None)
+        grep_tool = _get_tool(server, "nexus_grep")
+        raw = await grep_tool.fn(pattern="m")
+        response = json.loads(raw)
+        assert len(response["items"]) == 2
+        assert response.get("permission_denial_rate", 0) == 0
+
+    async def test_zone_unscoping_on_grep(self):
+        """Grep results with zone-prefixed paths get unscoped."""
+        nx = _make_nx_with_search(
+            grep_return=[
+                {"file": "/zone/acme/src/x.py", "line": 1, "content": "hit"},
+            ]
+        )
+        # Permit the zone-prefixed path (pre-unscoping).
+        enforcer = _make_permission_enforcer(["/zone/acme/src/x.py"])
+        server = await create_mcp_server(nx=nx, permission_enforcer=enforcer)
+        grep_tool = _get_tool(server, "nexus_grep")
+        raw = await grep_tool.fn(pattern="hit")
+        response = json.loads(raw)
+        assert response["items"][0]["file"] == "/src/x.py"
+        assert response["items"][0]["zone_id"] == "acme"
+
+
+class TestMcpGlobRebac:
+    """MCP glob applies _apply_rebac_filter when permission_enforcer is provided."""
+
+    async def test_denied_paths_excluded(self):
+        """Paths not in permitted set are excluded from glob results."""
+        nx = _make_nx_with_search(
+            glob_return=[
+                "/src/a.py",
+                "/src/b.py",
+                "/src/c.py",
+            ]
+        )
+        enforcer = _make_permission_enforcer(["/src/a.py", "/src/c.py"])
+
+        server = await create_mcp_server(nx=nx, permission_enforcer=enforcer)
+        glob_tool = _get_tool(server, "nexus_glob")
+        raw = glob_tool.fn(pattern="**/*.py")
+        response = json.loads(raw)
+
+        assert "/src/a.py" in response["items"]
+        assert "/src/c.py" in response["items"]
+        assert "/src/b.py" not in response["items"]
+        assert response["permission_denial_rate"] > 0
+
+    async def test_zone_unscoping_on_glob(self):
+        """Glob results with zone-prefixed paths get unscoped + zone list."""
+        nx = _make_nx_with_search(
+            glob_return=[
+                "/zone/acme/src/a.py",
+                "/zone/beta/src/b.py",
+            ]
+        )
+        enforcer = _make_permission_enforcer(
+            [
+                "/zone/acme/src/a.py",
+                "/zone/beta/src/b.py",
+            ]
+        )
+        server = await create_mcp_server(nx=nx, permission_enforcer=enforcer)
+        glob_tool = _get_tool(server, "nexus_glob")
+        raw = glob_tool.fn(pattern="**/*.py")
+        response = json.loads(raw)
+
+        assert response["items"] == ["/src/a.py", "/src/b.py"]
+        assert response["item_zones"] == ["acme", "beta"]
+
+
+# ---------------------------------------------------------------------------
+# context=None fallback behavior test
+# ---------------------------------------------------------------------------
+
+
+class TestContextNoneFallback:
+    """When no identity is resolvable, MCP search still works (SearchService default)."""
+
+    async def test_grep_with_no_identity(self):
+        """Grep proceeds with context=None when identity can't be resolved."""
+        nx = MagicMock(spec=[])  # No attrs → step 4 → None
+        search = MagicMock()
+        search.grep = AsyncMock(
+            return_value=[
+                {"file": "/x.py", "line": 1, "content": "hit"},
+            ]
+        )
+        nx.service = MagicMock(side_effect=lambda name: search if name == "search" else None)
+
+        server = await create_mcp_server(nx=nx)
+        grep_tool = _get_tool(server, "nexus_grep")
+        raw = await grep_tool.fn(pattern="hit")
+        response = json.loads(raw)
+
+        # Should succeed — SearchService uses its own default context.
+        assert len(response["items"]) == 1
+        # Verify context=None was passed.
+        call_kwargs = search.grep.call_args
+        assert call_kwargs.kwargs.get("context") is None or call_kwargs[1].get("context") is None
+
+    async def test_glob_with_no_identity(self):
+        """Glob proceeds with context=None when identity can't be resolved."""
+        nx = MagicMock(spec=[])
+        search = MagicMock()
+        search.glob = MagicMock(return_value=["/x.py"])
+        nx.service = MagicMock(side_effect=lambda name: search if name == "search" else None)
+
+        server = await create_mcp_server(nx=nx)
+        glob_tool = _get_tool(server, "nexus_glob")
+        raw = glob_tool.fn(pattern="*.py")
+        response = json.loads(raw)
+
+        assert len(response["items"]) == 1
+        call_kwargs = search.glob.call_args
+        assert call_kwargs.kwargs.get("context") is None or call_kwargs[1].get("context") is None

--- a/tests/unit/bricks/mcp/test_mcp_rebac_parity.py
+++ b/tests/unit/bricks/mcp/test_mcp_rebac_parity.py
@@ -178,9 +178,14 @@ class TestResolveMcpOperationContext:
         assert ctx is init_cred
         provider.authenticate.assert_not_called()
 
-    def test_step0_fails_closed_without_auth_provider(self):
-        """Per-request key + no auth_provider → fail closed (not fallthrough)."""
-        init_cred = OperationContext(user_id="local", groups=[])
+    def test_step0_no_provider_falls_through_to_init_cred(self):
+        """Per-request key + no auth_provider → use NexusFS identity.
+
+        When auth_provider is unavailable, _get_nexus_instance already
+        created a remote NexusFS scoped to the per-request key — its
+        _init_cred IS the per-request identity, not ambient.
+        """
+        init_cred = OperationContext(user_id="remote-user", groups=[])
         nx = Mock()
         nx._init_cred = init_cred
 
@@ -190,9 +195,9 @@ class TestResolveMcpOperationContext:
         finally:
             reset_request_api_key(token)
 
-        # Fail-closed: per-request key present but no provider to
-        # verify it → None, NOT fallthrough to ambient _init_cred.
-        assert ctx is None
+        # No auth_provider → step 0 skipped → step 1 uses _init_cred
+        # (which is the per-request remote identity, not ambient).
+        assert ctx is init_cred
 
     def test_step0_unauthenticated_fails_closed(self):
         """Step 0: unauthenticated result → fail closed (not fall through)."""
@@ -517,22 +522,31 @@ class TestRejectedApiKeyDeniesSearch:
         assert "unauthorized" in raw.lower() or "error" in raw.lower()
         nx._mock_search.glob.assert_not_called()
 
-    async def test_grep_no_auth_provider_with_key_denies(self):
-        """Per-request key + no auth_provider → grep denied."""
+    async def test_grep_no_auth_provider_with_key_uses_nx_identity(self):
+        """Per-request key + no auth_provider → uses NexusFS identity.
+
+        When no auth_provider is available, the per-request NexusFS
+        (created by _get_nexus_instance with the API key) carries its
+        own _init_cred identity. Grep should proceed using it.
+        """
         nx = _make_nx_with_search(
             grep_return=[
                 {"file": "/a.py", "line": 1, "content": "hit"},
             ]
         )
+        # Simulate a remote per-request NexusFS that carries identity
+        # via _init_cred (set by nexus.connect with the API key).
+        nx._init_cred = OperationContext(user_id="remote-user", groups=[])
 
         server = await create_mcp_server(nx=nx, auth_provider=None)
         grep_tool = _get_tool(server, "nexus_grep")
 
-        token = set_request_api_key("sk-unverifiable")
+        token = set_request_api_key("sk-remote-key")
         try:
             raw = await grep_tool.fn(pattern="hit")
         finally:
             reset_request_api_key(token)
 
-        assert "unauthorized" in raw.lower() or "error" in raw.lower()
-        nx._mock_search.grep.assert_not_called()
+        response = json.loads(raw)
+        assert len(response["items"]) == 1
+        nx._mock_search.grep.assert_called_once()

--- a/tests/unit/bricks/mcp/test_mcp_rebac_parity.py
+++ b/tests/unit/bricks/mcp/test_mcp_rebac_parity.py
@@ -193,8 +193,8 @@ class TestResolveMcpOperationContext:
         # Falls through to step 1.
         assert ctx is init_cred
 
-    def test_step0_unauthenticated_falls_through(self):
-        """Step 0: unauthenticated result → fall through to step 1."""
+    def test_step0_unauthenticated_fails_closed(self):
+        """Step 0: unauthenticated result → fail closed (not fall through)."""
         provider = Mock()
         provider.authenticate = Mock(return_value=_FakeAuthResult(authenticated=False))
         init_cred = OperationContext(user_id="local", groups=[])
@@ -207,7 +207,9 @@ class TestResolveMcpOperationContext:
         finally:
             reset_request_api_key(token)
 
-        assert ctx is init_cred  # Step 1 wins
+        # Fail-closed: per-request key present but rejected → None,
+        # NOT fallthrough to ambient _init_cred.
+        assert ctx is None
 
     def test_step1_init_cred(self):
         """Step 1: _init_cred attr present → return it directly."""
@@ -258,8 +260,13 @@ def _make_nx_with_search(
     grep_return: list[dict[str, Any]] | None = None,
     glob_return: list[str] | None = None,
 ) -> MagicMock:
-    """Build a mock NexusFS that returns controlled search results."""
-    nx = MagicMock()
+    """Build a mock NexusFS that returns controlled search results.
+
+    Uses ``spec=[]`` on the root mock to prevent MagicMock from
+    auto-creating attributes like ``permission_enforcer`` that the
+    auto-resolution code in ``create_mcp_server`` would pick up.
+    """
+    nx = MagicMock(spec=[])
     search = MagicMock()
     search.grep = AsyncMock(return_value=list(grep_return or []))
     search.glob = MagicMock(return_value=list(glob_return or []))

--- a/tests/unit/bricks/mcp/test_mcp_rebac_parity.py
+++ b/tests/unit/bricks/mcp/test_mcp_rebac_parity.py
@@ -178,8 +178,8 @@ class TestResolveMcpOperationContext:
         assert ctx is init_cred
         provider.authenticate.assert_not_called()
 
-    def test_step0_skipped_without_auth_provider(self):
-        """Step 0 skipped when no auth_provider is passed."""
+    def test_step0_fails_closed_without_auth_provider(self):
+        """Per-request key + no auth_provider → fail closed (not fallthrough)."""
         init_cred = OperationContext(user_id="local", groups=[])
         nx = Mock()
         nx._init_cred = init_cred
@@ -190,8 +190,9 @@ class TestResolveMcpOperationContext:
         finally:
             reset_request_api_key(token)
 
-        # Falls through to step 1.
-        assert ctx is init_cred
+        # Fail-closed: per-request key present but no provider to
+        # verify it → None, NOT fallthrough to ambient _init_cred.
+        assert ctx is None
 
     def test_step0_unauthenticated_fails_closed(self):
         """Step 0: unauthenticated result → fail closed (not fall through)."""
@@ -463,3 +464,75 @@ class TestContextNoneFallback:
         assert len(response["items"]) == 1
         call_kwargs = search.glob.call_args
         assert call_kwargs.kwargs.get("context") is None or call_kwargs[1].get("context") is None
+
+
+# ---------------------------------------------------------------------------
+# Rejected API key → tool-level auth denial tests (#3731 R2)
+# ---------------------------------------------------------------------------
+
+
+class TestRejectedApiKeyDeniesSearch:
+    """When a per-request API key is present but rejected, MCP tools
+    must return an auth error and NOT call SearchService.
+    """
+
+    async def test_grep_rejected_key_does_not_call_search(self):
+        """Rejected API key → grep returns error, SearchService not called."""
+        nx = _make_nx_with_search(
+            grep_return=[
+                {"file": "/a.py", "line": 1, "content": "hit"},
+            ]
+        )
+        # Auth provider rejects the key.
+        provider = Mock()
+        provider.authenticate = Mock(return_value=_FakeAuthResult(authenticated=False))
+
+        server = await create_mcp_server(nx=nx, auth_provider=provider)
+        grep_tool = _get_tool(server, "nexus_grep")
+
+        token = set_request_api_key("sk-revoked-key")
+        try:
+            raw = await grep_tool.fn(pattern="hit")
+        finally:
+            reset_request_api_key(token)
+
+        assert "unauthorized" in raw.lower() or "error" in raw.lower()
+        nx._mock_search.grep.assert_not_called()
+
+    async def test_glob_rejected_key_does_not_call_search(self):
+        """Rejected API key → glob returns error, SearchService not called."""
+        nx = _make_nx_with_search(glob_return=["/a.py"])
+        provider = Mock()
+        provider.authenticate = Mock(return_value=_FakeAuthResult(authenticated=False))
+
+        server = await create_mcp_server(nx=nx, auth_provider=provider)
+        glob_tool = _get_tool(server, "nexus_glob")
+
+        token = set_request_api_key("sk-revoked-key")
+        try:
+            raw = glob_tool.fn(pattern="*.py")
+        finally:
+            reset_request_api_key(token)
+
+        assert "unauthorized" in raw.lower() or "error" in raw.lower()
+        nx._mock_search.glob.assert_not_called()
+
+    async def test_grep_no_auth_provider_with_key_denies(self):
+        """Per-request key + no auth_provider → grep denied."""
+        nx = _make_nx_with_search(
+            grep_return=[
+                {"file": "/a.py", "line": 1, "content": "hit"},
+            ]
+        )
+
+        server = await create_mcp_server(nx=nx, auth_provider=None)
+        grep_tool = _get_tool(server, "nexus_grep")
+
+        token = set_request_api_key("sk-unverifiable")
+        try:
+            raw = await grep_tool.fn(pattern="hit")
+        finally:
+            reset_request_api_key(token)
+
+        assert "unauthorized" in raw.lower() or "error" in raw.lower()
+        nx._mock_search.grep.assert_not_called()

--- a/tests/unit/server/routers/test_search_rebac_filter.py
+++ b/tests/unit/server/routers/test_search_rebac_filter.py
@@ -199,16 +199,17 @@ class TestApplyRebacFilterBehaviour:
         # Both results came back because the enforcer permitted both.
         assert len(filtered) == 2
 
-    def test_duplicate_paths_are_collapsed_by_path_map(self) -> None:
-        """If two result rows share a path, only one survives the dict key.
+    def test_duplicate_paths_all_preserved(self) -> None:
+        """Multiple results sharing a path are ALL preserved (#3731).
 
-        This is the current behaviour documented via `path_map = {p: r ...}`
-        in the implementation. The test locks it in so future changes are
-        deliberate.
+        The previous path_map dict collapsed duplicates, silently
+        dropping grep lines from the same file. The two-pass approach
+        deduplicates paths for the permission check but keeps every
+        original result row.
         """
         results = [
             _StubResult("/a.py", marker="first"),
-            _StubResult("/a.py", marker="second-overwrites-first"),
+            _StubResult("/a.py", marker="second"),
         ]
         enforcer = _make_enforcer(permitted=["/a.py"])
 
@@ -219,8 +220,12 @@ class TestApplyRebacFilterBehaviour:
             zone_id="root",
         )
 
-        assert len(filtered) == 1
-        assert filtered[0].marker == "second-overwrites-first"
+        assert len(filtered) == 2
+        assert filtered[0].marker == "first"
+        assert filtered[1].marker == "second"
+        # Enforcer should see only one unique path, not two.
+        call = enforcer.filter_search_results.call_args
+        assert call.args[0] == ["/a.py"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/server/routers/test_search_rebac_filter.py
+++ b/tests/unit/server/routers/test_search_rebac_filter.py
@@ -15,12 +15,22 @@ from dataclasses import dataclass
 from typing import Any
 from unittest.mock import MagicMock
 
+from nexus.lib.rebac_filter import (
+    REBAC_OVERFETCH_FACTOR as _REBAC_OVERFETCH_FACTOR,
+)
+from nexus.lib.rebac_filter import (
+    apply_rebac_filter as _apply_rebac_filter,
+)
+from nexus.lib.rebac_filter import (
+    compute_rebac_fetch_limit as _compute_rebac_fetch_limit,
+)
+from nexus.lib.rebac_filter import (
+    normalize_path as _normalize_path,
+)
+from nexus.lib.rebac_filter import (
+    rebac_denial_stats as _rebac_denial_stats,
+)
 from nexus.server.api.v2.routers.search import (
-    _REBAC_OVERFETCH_FACTOR,
-    _apply_rebac_filter,
-    _compute_rebac_fetch_limit,
-    _normalize_path,
-    _rebac_denial_stats,
     _serialize_search_result,
 )
 


### PR DESCRIPTION
## Summary

- MCP `nexus_grep` and `nexus_glob` now apply the same two-layer ReBAC enforcement as the HTTP endpoints: identity resolution from the per-request API key + file-level filtering via `PermissionEnforcer`.
- Fixed `RemoteServiceProxy` silently returning dict-wrapped responses (`{"results": [...]}`) instead of unwrapped lists — a pre-existing bug that broke MCP tools against real remote Nexus servers.
- Fixed `_apply_rebac_filter` silently dropping multiple grep results from the same file (dict-keyed `path_map` collision).

### What changed

| File | Change |
|------|--------|
| `src/nexus/bricks/mcp/auth_bridge.py` | **New.** Extracted auth helpers: `resolve_mcp_operation_context` (5-step identity resolution with new step 0 for API key → auth_provider lookup), `op_context_to_auth_dict`, `authenticate_api_key`. |
| `src/nexus/bricks/mcp/server.py` | MCP `nexus_grep`/`nexus_glob` now wire `_apply_rebac_filter`, ReBAC over-fetch, zone unscoping, `permission_denial_rate`, `truncated_by_permissions`, `multi_zone_ambiguous`, and `item_zones`. Added `permission_enforcer` + `auth_provider` params to `create_mcp_server()`. Handle sync/async `SearchService.grep` via `inspect.isawaitable`. |
| `src/nexus/remote/service_proxy.py` | `RemoteServiceProxy.__getattr__` now applies `response_key` extraction from `METHOD_REGISTRY`, matching `RPCProxyBase._dispatch_rpc()` behavior. |
| `src/nexus/server/api/v2/routers/search.py` | `_apply_rebac_filter` accepts `path_extractor` callable (eliminates shim classes). Two-pass dedup approach preserves all grep results from the same file. |
| `tests/unit/bricks/mcp/test_mcp_rebac_parity.py` | **New.** 22 tests: identity resolution paths (8), auth bridge (3), auth dict bridge (3), ReBAC negative (4 grep + 2 glob), context=None fallback (2). |
| `tests/unit/server/routers/test_search_rebac_filter.py` | Updated `test_duplicate_paths_all_preserved` to match new correct behavior. |

## Test plan

- [x] 406 unit/integration tests pass (MCP + ReBAC + HTTP grep/glob)
- [x] 39 remote proxy unit tests pass
- [x] E2E against live Nexus server: 9 tests covering basic grep/glob, ReBAC filtering with mock enforcer, multi-line-per-file preservation, API key identity resolution, pagination, context=None fallback
- [x] E2E via real MCP Streamable HTTP transport (`tools/call` JSON-RPC): grep with pagination, multi-line results, context lines, glob with pagination — all verified against live Nexus

Closes #3731