### PR TITLE
feat(auth): external-CLI sync framework + aws-cli adapter (Phase 2 of #3722)

### DIFF
--- a/docs/superpowers/plans/2026-04-15-external-cli-sync.md
+++ b/docs/superpowers/plans/2026-04-15-external-cli-sync.md
@@ -1,0 +1,2820 @@
+# External-CLI Sync Framework Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Land the external-CLI sync framework, the aws-cli adapter, ExternalCliBackend, and cut `nexus-fs auth list` over to the unified profile store (Phase 2 of #3722, issue #3739).
+
+**Architecture:** Two-layer design: sync adapters discover accounts from external CLIs and upsert routing metadata into AuthProfileStore; ExternalCliBackend implements CredentialBackend for fresh credential resolution. AdapterRegistry manages startup, background refresh with per-adapter TTL, and per-adapter circuit breakers.
+
+**Tech Stack:** Python 3.11+, asyncio, configparser (INI parsing), pytest + pytest-asyncio (auto mode), SQLite (via existing SqliteAuthProfileStore).
+
+---
+
+## File Map
+
+### New files (create)
+
+| File | Responsibility |
+|------|---------------|
+| `src/nexus/bricks/auth/external_sync/__init__.py` | Re-export public API |
+| `src/nexus/bricks/auth/external_sync/base.py` | `ExternalCliSyncAdapter` ABC, `SyncedProfile`, `SyncResult` |
+| `src/nexus/bricks/auth/external_sync/file_adapter.py` | `FileAdapter(ExternalCliSyncAdapter)` base class |
+| `src/nexus/bricks/auth/external_sync/subprocess_adapter.py` | `SubprocessAdapter(ExternalCliSyncAdapter)` base class |
+| `src/nexus/bricks/auth/external_sync/aws_sync.py` | `AwsCliSyncAdapter(FileAdapter)` — ~40 LOC |
+| `src/nexus/bricks/auth/external_sync/external_cli_backend.py` | `ExternalCliBackend(CredentialBackend)` — ~80 LOC |
+| `src/nexus/bricks/auth/external_sync/registry.py` | `AdapterRegistry`, `CircuitBreaker` |
+| `src/nexus/bricks/auth/tests/test_file_adapter.py` | FileAdapter base class tests via synthetic adapter |
+| `src/nexus/bricks/auth/tests/test_subprocess_adapter.py` | SubprocessAdapter base class tests via synthetic adapter |
+| `src/nexus/bricks/auth/tests/test_aws_sync.py` | AwsCliSyncAdapter parse tests |
+| `src/nexus/bricks/auth/tests/test_registry.py` | Registry startup, background loop, circuit breaker tests |
+| `src/nexus/bricks/auth/tests/test_external_cli_backend.py` | ExternalCliBackend tests |
+| `src/nexus/bricks/auth/tests/test_auth_list_cutover.py` | nexus-fs auth list integration tests |
+| `src/nexus/bricks/auth/tests/test_e2e_aws.py` | Nightly real-binary e2e test |
+| `src/nexus/bricks/auth/tests/fixtures/external_cli_output/aws_credentials_v2.15.ini` | AWS credentials fixture (standard) |
+| `src/nexus/bricks/auth/tests/fixtures/external_cli_output/aws_credentials_v2.16.ini` | AWS credentials fixture (SSO/session tokens) |
+
+### Modified files
+
+| File | Change |
+|------|--------|
+| `src/nexus/fs/_auth_cli.py:264-304` | `list_auth()` — dual-read with new table format |
+| `src/nexus/fs/_backend_factory.py:36-46` | S3 creation — dual-path through profile store |
+
+---
+
+## Task 1: Base types — `SyncedProfile`, `SyncResult`, `ExternalCliSyncAdapter` ABC
+
+**Files:**
+- Create: `src/nexus/bricks/auth/external_sync/__init__.py`
+- Create: `src/nexus/bricks/auth/external_sync/base.py`
+- Test: `src/nexus/bricks/auth/tests/test_file_adapter.py` (just the import smoke test for now)
+
+- [ ] **Step 1: Create the `external_sync` package with `base.py`**
+
+```python
+# src/nexus/bricks/auth/external_sync/__init__.py
+"""External CLI sync framework for discovering credentials managed by external tools."""
+
+from nexus.bricks.auth.external_sync.base import (
+    ExternalCliSyncAdapter,
+    SyncedProfile,
+    SyncResult,
+)
+
+__all__ = [
+    "ExternalCliSyncAdapter",
+    "SyncedProfile",
+    "SyncResult",
+]
+```
+
+```python
+# src/nexus/bricks/auth/external_sync/base.py
+"""Abstract base for external CLI sync adapters.
+
+Sync adapters discover which accounts exist in external CLIs (aws, gcloud, gh)
+and produce SyncedProfile metadata. They do NOT resolve actual credentials —
+that is ExternalCliBackend's job (external_cli_backend.py).
+
+Each concrete adapter is a thin descriptor subclass of either FileAdapter
+(for CLIs with parseable config files) or SubprocessAdapter (for CLIs
+that require shell-out). The base classes own all I/O, timeout, retry,
+and error-classification logic.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nexus.bricks.auth.credential_backend import ResolvedCredential
+
+
+@dataclass(frozen=True, slots=True)
+class SyncedProfile:
+    """One discovered account from an external CLI.
+
+    This is metadata only — no secrets. Maps to an AuthProfile in the store
+    with backend="external-cli".
+    """
+
+    provider: str  # e.g. "s3"
+    account_identifier: str  # e.g. "default", "work-prod"
+    backend_key: str  # e.g. "aws-cli/default" — opaque to the store
+    source: str  # e.g. "aws-cli" — displayed in `auth list` Source column
+
+
+@dataclass
+class SyncResult:
+    """Output of a single adapter sync() call."""
+
+    adapter_name: str
+    profiles: list[SyncedProfile] = field(default_factory=list)
+    error: str | None = None  # non-None means degraded
+
+
+class ExternalCliSyncAdapter(ABC):
+    """Abstract base for external CLI sync adapters.
+
+    Subclass either FileAdapter or SubprocessAdapter, not this directly.
+    """
+
+    adapter_name: str  # e.g. "aws-cli", "gcloud"
+    sync_ttl_seconds: float = 60.0
+    failure_threshold: int = 3
+    reset_timeout_seconds: float = 60.0
+
+    @abstractmethod
+    async def sync(self) -> SyncResult:
+        """Discover all accounts from this external CLI."""
+        ...
+
+    @abstractmethod
+    async def detect(self) -> bool:
+        """Quick check: is this CLI / config available on the system?"""
+        ...
+
+    @abstractmethod
+    async def resolve_credential(self, backend_key: str) -> ResolvedCredential:
+        """Fresh-read a credential for the given backend_key.
+
+        Called by ExternalCliBackend.resolve(). Re-reads the source
+        (file or subprocess) and extracts the actual secret for one profile.
+        """
+        ...
+```
+
+- [ ] **Step 2: Write import smoke test**
+
+```python
+# src/nexus/bricks/auth/tests/test_file_adapter.py
+"""Tests for FileAdapter base class via synthetic adapter."""
+
+from __future__ import annotations
+
+
+class TestBaseImports:
+    def test_base_types_importable(self) -> None:
+        from nexus.bricks.auth.external_sync.base import (
+            ExternalCliSyncAdapter,
+            SyncedProfile,
+            SyncResult,
+        )
+
+        assert SyncedProfile is not None
+        assert SyncResult is not None
+        assert ExternalCliSyncAdapter is not None
+```
+
+- [ ] **Step 3: Run test to verify it passes**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_file_adapter.py::TestBaseImports -xvs`
+Expected: PASS
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/nexus/bricks/auth/external_sync/__init__.py src/nexus/bricks/auth/external_sync/base.py src/nexus/bricks/auth/tests/test_file_adapter.py
+git commit -m "feat(auth): add ExternalCliSyncAdapter ABC + SyncedProfile + SyncResult (#3739)"
+```
+
+---
+
+## Task 2: FileAdapter base class + tests
+
+**Files:**
+- Create: `src/nexus/bricks/auth/external_sync/file_adapter.py`
+- Modify: `src/nexus/bricks/auth/tests/test_file_adapter.py`
+
+- [ ] **Step 1: Write failing tests for FileAdapter via synthetic adapter**
+
+Append to `src/nexus/bricks/auth/tests/test_file_adapter.py`:
+
+```python
+import os
+import stat
+from pathlib import Path
+
+import pytest
+
+from nexus.bricks.auth.credential_backend import ResolvedCredential
+from nexus.bricks.auth.external_sync.base import SyncedProfile, SyncResult
+
+
+class SyntheticFileAdapter:
+    """Fake FileAdapter subclass for testing the base class mechanics."""
+
+    adapter_name = "synthetic-file"
+    sync_ttl_seconds = 60.0
+    failure_threshold = 3
+    reset_timeout_seconds = 60.0
+
+    def __init__(self, file_content: str = "", fail_parse: bool = False) -> None:
+        self._file_content = file_content
+        self._fail_parse = fail_parse
+        self._tmp_path: Path | None = None
+
+    def set_tmp_path(self, tmp_path: Path) -> None:
+        self._tmp_path = tmp_path
+        cfg = tmp_path / "synthetic.conf"
+        cfg.write_text(self._file_content)
+
+    def paths(self) -> list[Path]:
+        if self._tmp_path is None:
+            return [Path("/nonexistent/synthetic.conf")]
+        return [self._tmp_path / "synthetic.conf"]
+
+    def parse_file(self, path: Path, content: str) -> list[SyncedProfile]:
+        if self._fail_parse:
+            raise ValueError("malformed content")
+        lines = [l.strip() for l in content.splitlines() if l.strip()]
+        return [
+            SyncedProfile(
+                provider="test",
+                account_identifier=line,
+                backend_key=f"synthetic-file/{line}",
+                source="synthetic-file",
+            )
+            for line in lines
+        ]
+
+    async def resolve_credential(self, backend_key: str) -> ResolvedCredential:
+        return ResolvedCredential(kind="api_key", api_key="fake-key")
+
+
+class TestFileAdapterDetect:
+    async def test_detect_true_when_file_exists(self, tmp_path: Path) -> None:
+        from nexus.bricks.auth.external_sync.file_adapter import FileAdapter
+
+        adapter = _make_synthetic(tmp_path, "profile1\n")
+        assert await adapter.detect() is True
+
+    async def test_detect_false_when_no_files(self) -> None:
+        from nexus.bricks.auth.external_sync.file_adapter import FileAdapter
+
+        adapter = _make_synthetic(None, "")
+        assert await adapter.detect() is False
+
+
+class TestFileAdapterSync:
+    async def test_sync_parses_file_content(self, tmp_path: Path) -> None:
+        from nexus.bricks.auth.external_sync.file_adapter import FileAdapter
+
+        adapter = _make_synthetic(tmp_path, "profile1\nprofile2\n")
+        result = await adapter.sync()
+        assert result.error is None
+        assert len(result.profiles) == 2
+        assert result.profiles[0].account_identifier == "profile1"
+        assert result.profiles[1].account_identifier == "profile2"
+
+    async def test_sync_missing_file_returns_degraded(self) -> None:
+        from nexus.bricks.auth.external_sync.file_adapter import FileAdapter
+
+        adapter = _make_synthetic(None, "")
+        result = await adapter.sync()
+        assert result.error is not None
+        assert "not found" in result.error.lower() or "no readable" in result.error.lower()
+        assert result.profiles == []
+
+    async def test_sync_empty_file_returns_empty_profiles(self, tmp_path: Path) -> None:
+        from nexus.bricks.auth.external_sync.file_adapter import FileAdapter
+
+        adapter = _make_synthetic(tmp_path, "")
+        result = await adapter.sync()
+        assert result.error is None
+        assert result.profiles == []
+
+    async def test_sync_malformed_content_returns_degraded(self, tmp_path: Path) -> None:
+        from nexus.bricks.auth.external_sync.file_adapter import FileAdapter
+
+        adapter = _make_synthetic(tmp_path, "anything", fail_parse=True)
+        result = await adapter.sync()
+        assert result.error is not None
+        assert "malformed" in result.error.lower() or "parse" in result.error.lower()
+
+    async def test_sync_unreadable_perms_returns_degraded(self, tmp_path: Path) -> None:
+        from nexus.bricks.auth.external_sync.file_adapter import FileAdapter
+
+        adapter = _make_synthetic(tmp_path, "data")
+        cfg = tmp_path / "synthetic.conf"
+        cfg.chmod(0o000)
+        try:
+            result = await adapter.sync()
+            assert result.error is not None
+        finally:
+            cfg.chmod(stat.S_IRUSR | stat.S_IWUSR)
+
+    async def test_sync_symlink_loop_returns_degraded(self, tmp_path: Path) -> None:
+        from nexus.bricks.auth.external_sync.file_adapter import FileAdapter
+
+        loop_a = tmp_path / "synthetic.conf"
+        loop_b = tmp_path / "loop_b"
+        # Remove the real file, create a symlink loop
+        if loop_a.exists():
+            loop_a.unlink()
+        loop_b.symlink_to(loop_a)
+        loop_a.symlink_to(loop_b)
+
+        adapter = _make_synthetic(tmp_path, "", setup_file=False)
+        result = await adapter.sync()
+        assert result.error is not None
+
+
+def _make_synthetic(
+    tmp_path: Path | None,
+    content: str,
+    *,
+    fail_parse: bool = False,
+    setup_file: bool = True,
+) -> "FileAdapter":
+    """Build a concrete FileAdapter using the synthetic descriptor pattern."""
+    from nexus.bricks.auth.external_sync.file_adapter import FileAdapter
+
+    class _Adapter(FileAdapter):
+        adapter_name = "synthetic-file"
+        _fail_parse = fail_parse
+
+        def __init__(self, tmp_path: Path | None, content: str) -> None:
+            self._tmp_path = tmp_path
+            self._content = content
+
+        def paths(self) -> list[Path]:
+            if self._tmp_path is None:
+                return [Path("/nonexistent/synthetic.conf")]
+            return [self._tmp_path / "synthetic.conf"]
+
+        def parse_file(self, path: Path, content: str) -> list[SyncedProfile]:
+            if self._fail_parse:
+                raise ValueError("malformed content")
+            lines = [l.strip() for l in content.splitlines() if l.strip()]
+            return [
+                SyncedProfile(
+                    provider="test",
+                    account_identifier=line,
+                    backend_key=f"synthetic-file/{line}",
+                    source="synthetic-file",
+                )
+                for line in lines
+            ]
+
+        async def resolve_credential(self, backend_key: str) -> ResolvedCredential:
+            return ResolvedCredential(kind="api_key", api_key="fake-key")
+
+    adapter = _Adapter(tmp_path, content)
+    if tmp_path is not None and setup_file:
+        cfg = tmp_path / "synthetic.conf"
+        cfg.write_text(content)
+    return adapter
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_file_adapter.py -xvs -k "not TestBaseImports"`
+Expected: FAIL — `ModuleNotFoundError: No module named 'nexus.bricks.auth.external_sync.file_adapter'`
+
+- [ ] **Step 3: Implement FileAdapter**
+
+```python
+# src/nexus/bricks/auth/external_sync/file_adapter.py
+"""FileAdapter — base class for external CLIs with parseable config files.
+
+Subclasses declare which files to read and how to parse them. The base
+class handles all I/O: detect (file exists), sync (read + parse + classify
+errors), and graceful degradation on missing/unreadable/malformed files.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import abstractmethod
+from pathlib import Path
+
+from nexus.bricks.auth.external_sync.base import (
+    ExternalCliSyncAdapter,
+    SyncedProfile,
+    SyncResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class FileAdapter(ExternalCliSyncAdapter):
+    """Base class for config-file-based sync adapters.
+
+    Subclasses implement paths() and parse_file() only.
+    """
+
+    sync_ttl_seconds: float = 60.0  # file reads are cheap
+
+    @abstractmethod
+    def paths(self) -> list[Path]:
+        """Config file paths to read, in priority order."""
+        ...
+
+    @abstractmethod
+    def parse_file(self, path: Path, content: str) -> list[SyncedProfile]:
+        """Parse a config file into discovered profiles.
+
+        Raise ValueError or similar on malformed content — the base class
+        catches it and returns a degraded SyncResult.
+        """
+        ...
+
+    async def detect(self) -> bool:
+        """Return True if any config file from paths() exists and is readable."""
+        for p in self.paths():
+            try:
+                if p.exists() and p.is_file():
+                    return True
+            except OSError:
+                continue
+        return False
+
+    async def sync(self) -> SyncResult:
+        """Read config files and parse profiles.
+
+        Reads files in priority order from paths(). Aggregates all
+        discovered profiles. Returns degraded SyncResult on I/O or
+        parse errors rather than raising.
+        """
+        readable_paths = self.paths()
+        if not readable_paths:
+            return SyncResult(
+                adapter_name=self.adapter_name,
+                error="No config file paths configured",
+            )
+
+        all_profiles: list[SyncedProfile] = []
+        errors: list[str] = []
+        any_read = False
+
+        for path in readable_paths:
+            try:
+                content = path.read_text(encoding="utf-8")
+                any_read = True
+            except FileNotFoundError:
+                continue
+            except PermissionError as exc:
+                errors.append(f"{path}: permission denied ({exc})")
+                continue
+            except OSError as exc:
+                errors.append(f"{path}: {exc}")
+                continue
+
+            if not content.strip():
+                continue
+
+            try:
+                profiles = self.parse_file(path, content)
+                all_profiles.extend(profiles)
+            except Exception as exc:
+                errors.append(f"{path}: parse error: {exc}")
+
+        if not any_read and not all_profiles:
+            paths_str = ", ".join(str(p) for p in readable_paths)
+            return SyncResult(
+                adapter_name=self.adapter_name,
+                error=f"No readable config files found ({paths_str})",
+            )
+
+        error_msg = "; ".join(errors) if errors else None
+        return SyncResult(
+            adapter_name=self.adapter_name,
+            profiles=all_profiles,
+            error=error_msg,
+        )
+```
+
+- [ ] **Step 4: Update `__init__.py` exports**
+
+Add to `src/nexus/bricks/auth/external_sync/__init__.py`:
+
+```python
+from nexus.bricks.auth.external_sync.file_adapter import FileAdapter
+
+# Add to __all__:
+"FileAdapter",
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_file_adapter.py -xvs`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/nexus/bricks/auth/external_sync/file_adapter.py src/nexus/bricks/auth/external_sync/__init__.py src/nexus/bricks/auth/tests/test_file_adapter.py
+git commit -m "feat(auth): add FileAdapter base class with detect/sync/error handling (#3739)"
+```
+
+---
+
+## Task 3: SubprocessAdapter base class + tests
+
+**Files:**
+- Create: `src/nexus/bricks/auth/external_sync/subprocess_adapter.py`
+- Create: `src/nexus/bricks/auth/tests/test_subprocess_adapter.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# src/nexus/bricks/auth/tests/test_subprocess_adapter.py
+"""Tests for SubprocessAdapter base class via synthetic adapter."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+
+from nexus.bricks.auth.credential_backend import ResolvedCredential
+from nexus.bricks.auth.external_sync.base import SyncedProfile, SyncResult
+
+
+class TestSubprocessAdapterDetect:
+    async def test_detect_true_for_existing_binary(self) -> None:
+        from nexus.bricks.auth.external_sync.subprocess_adapter import SubprocessAdapter
+
+        adapter = _make_synthetic_subprocess(binary="python3")
+        assert await adapter.detect() is True
+
+    async def test_detect_false_for_missing_binary(self) -> None:
+        from nexus.bricks.auth.external_sync.subprocess_adapter import SubprocessAdapter
+
+        adapter = _make_synthetic_subprocess(binary="definitely_not_installed_xyz")
+        assert await adapter.detect() is False
+
+
+class TestSubprocessAdapterSync:
+    async def test_sync_parses_stdout(self) -> None:
+        from nexus.bricks.auth.external_sync.subprocess_adapter import SubprocessAdapter
+
+        adapter = _make_synthetic_subprocess(
+            binary=sys.executable,
+            status_args=("-c", "print('account1\\naccount2')"),
+        )
+        result = await adapter.sync()
+        assert result.error is None
+        assert len(result.profiles) == 2
+        assert result.profiles[0].account_identifier == "account1"
+
+    async def test_sync_captures_stderr_on_nonzero_exit(self) -> None:
+        from nexus.bricks.auth.external_sync.subprocess_adapter import SubprocessAdapter
+
+        adapter = _make_synthetic_subprocess(
+            binary=sys.executable,
+            status_args=("-c", "import sys; sys.stderr.write('auth failed'); sys.exit(1)"),
+        )
+        result = await adapter.sync()
+        assert result.error is not None
+        assert "auth failed" in result.error
+
+    async def test_sync_timeout_returns_degraded(self) -> None:
+        from nexus.bricks.auth.external_sync.subprocess_adapter import SubprocessAdapter
+
+        adapter = _make_synthetic_subprocess(
+            binary=sys.executable,
+            status_args=("-c", "import time; time.sleep(30)"),
+            subprocess_timeout=0.5,
+        )
+        result = await adapter.sync()
+        assert result.error is not None
+        assert "timeout" in result.error.lower()
+
+    async def test_sync_missing_binary_returns_degraded(self) -> None:
+        from nexus.bricks.auth.external_sync.subprocess_adapter import SubprocessAdapter
+
+        adapter = _make_synthetic_subprocess(binary="nonexistent_binary_xyz")
+        result = await adapter.sync()
+        assert result.error is not None
+
+
+class TestSubprocessAdapterRetry:
+    async def test_retry_on_transient_failure(self) -> None:
+        """Subprocess fails then succeeds — retry kicks in."""
+        from nexus.bricks.auth.external_sync.subprocess_adapter import SubprocessAdapter
+
+        # Use a script that creates a temp file to track invocations:
+        # first call exits 1, second call succeeds
+        adapter = _make_synthetic_subprocess(
+            binary=sys.executable,
+            status_args=(
+                "-c",
+                (
+                    "import os, tempfile, sys\n"
+                    "marker = os.path.join(tempfile.gettempdir(), 'subprocess_adapter_retry_test')\n"
+                    "if not os.path.exists(marker):\n"
+                    "    open(marker, 'w').close()\n"
+                    "    sys.stderr.write('transient error')\n"
+                    "    sys.exit(1)\n"
+                    "os.unlink(marker)\n"
+                    "print('account1')\n"
+                ),
+            ),
+            max_retries=2,
+        )
+        result = await adapter.sync()
+        assert result.error is None
+        assert len(result.profiles) == 1
+
+
+def _make_synthetic_subprocess(
+    binary: str = "echo",
+    status_args: tuple[str, ...] = (),
+    subprocess_timeout: float = 5.0,
+    max_retries: int = 1,
+) -> "SubprocessAdapter":
+    from nexus.bricks.auth.external_sync.subprocess_adapter import SubprocessAdapter
+
+    class _Adapter(SubprocessAdapter):
+        adapter_name = "synthetic-subprocess"
+        binary_name = binary
+        _status_args = status_args
+        _subprocess_timeout = subprocess_timeout
+        _max_retries = max_retries
+
+        def get_status_args(self) -> tuple[str, ...]:
+            return self._status_args
+
+        def parse_output(self, stdout: str, stderr: str) -> list[SyncedProfile]:
+            lines = [l.strip() for l in stdout.splitlines() if l.strip()]
+            return [
+                SyncedProfile(
+                    provider="test",
+                    account_identifier=line,
+                    backend_key=f"synthetic-subprocess/{line}",
+                    source="synthetic-subprocess",
+                )
+                for line in lines
+            ]
+
+        async def resolve_credential(self, backend_key: str) -> ResolvedCredential:
+            return ResolvedCredential(kind="api_key", api_key="fake-key")
+
+    return _Adapter()
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_subprocess_adapter.py -xvs`
+Expected: FAIL — `ModuleNotFoundError: No module named 'nexus.bricks.auth.external_sync.subprocess_adapter'`
+
+- [ ] **Step 3: Implement SubprocessAdapter**
+
+```python
+# src/nexus/bricks/auth/external_sync/subprocess_adapter.py
+"""SubprocessAdapter — base class for external CLIs that require shell-out.
+
+Subclasses declare a binary name, status args, and a parse_output method.
+The base class handles: PATH detection, asyncio.create_subprocess_exec,
+timeout (default 5s), stderr capture, retry with exponential backoff,
+and error classification.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+from abc import abstractmethod
+
+from nexus.bricks.auth.external_sync.base import (
+    ExternalCliSyncAdapter,
+    SyncedProfile,
+    SyncResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SubprocessAdapter(ExternalCliSyncAdapter):
+    """Base class for subprocess-based sync adapters.
+
+    Subclasses set binary_name, implement get_status_args() and parse_output().
+    """
+
+    binary_name: str
+    sync_ttl_seconds: float = 300.0  # subprocess = expensive
+    _subprocess_timeout: float = 5.0
+    _max_retries: int = 1
+    _backoff_base: float = 1.0  # seconds; doubles each retry
+
+    @abstractmethod
+    def get_status_args(self) -> tuple[str, ...]:
+        """Return the CLI arguments to get account/status info."""
+        ...
+
+    @abstractmethod
+    def parse_output(self, stdout: str, stderr: str) -> list[SyncedProfile]:
+        """Parse CLI output into discovered profiles.
+
+        Raise on unexpected output — the base class catches and
+        returns a degraded SyncResult.
+        """
+        ...
+
+    async def detect(self) -> bool:
+        """Return True if the binary is found on PATH."""
+        return shutil.which(self.binary_name) is not None
+
+    async def sync(self) -> SyncResult:
+        """Run the CLI command, parse output, retry on transient failure."""
+        binary_path = shutil.which(self.binary_name)
+        if binary_path is None:
+            return SyncResult(
+                adapter_name=self.adapter_name,
+                error=f"{self.binary_name}: binary not found on PATH",
+            )
+
+        last_error: str | None = None
+        for attempt in range(1 + self._max_retries):
+            if attempt > 0:
+                delay = self._backoff_base * (2 ** (attempt - 1))
+                await asyncio.sleep(delay)
+
+            try:
+                result = await self._run_once(binary_path)
+                if result.error is None:
+                    return result
+                last_error = result.error
+            except Exception as exc:
+                last_error = str(exc)
+
+        return SyncResult(
+            adapter_name=self.adapter_name,
+            error=last_error,
+        )
+
+    async def _run_once(self, binary_path: str) -> SyncResult:
+        """Single subprocess execution with timeout."""
+        args = self.get_status_args()
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                binary_path,
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(),
+                timeout=self._subprocess_timeout,
+            )
+        except asyncio.TimeoutError:
+            # Kill the hung process
+            try:
+                proc.kill()
+                await proc.wait()
+            except ProcessLookupError:
+                pass
+            return SyncResult(
+                adapter_name=self.adapter_name,
+                error=f"{self.binary_name}: timeout after {self._subprocess_timeout}s",
+            )
+        except FileNotFoundError:
+            return SyncResult(
+                adapter_name=self.adapter_name,
+                error=f"{self.binary_name}: binary not found",
+            )
+
+        stdout = stdout_bytes.decode("utf-8", errors="replace")
+        stderr = stderr_bytes.decode("utf-8", errors="replace")
+
+        if proc.returncode != 0:
+            error_detail = stderr.strip() or f"exit code {proc.returncode}"
+            return SyncResult(
+                adapter_name=self.adapter_name,
+                error=f"{self.binary_name}: {error_detail}",
+            )
+
+        try:
+            profiles = self.parse_output(stdout, stderr)
+        except Exception as exc:
+            return SyncResult(
+                adapter_name=self.adapter_name,
+                error=f"{self.binary_name}: parse error: {exc}",
+            )
+
+        return SyncResult(
+            adapter_name=self.adapter_name,
+            profiles=profiles,
+        )
+```
+
+- [ ] **Step 4: Update `__init__.py` exports**
+
+Add to `src/nexus/bricks/auth/external_sync/__init__.py`:
+
+```python
+from nexus.bricks.auth.external_sync.subprocess_adapter import SubprocessAdapter
+
+# Add to __all__:
+"SubprocessAdapter",
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_subprocess_adapter.py -xvs`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/nexus/bricks/auth/external_sync/subprocess_adapter.py src/nexus/bricks/auth/external_sync/__init__.py src/nexus/bricks/auth/tests/test_subprocess_adapter.py
+git commit -m "feat(auth): add SubprocessAdapter base class with timeout/retry/stderr capture (#3739)"
+```
+
+---
+
+## Task 4: AWS adapter + fixture files + tests
+
+**Files:**
+- Create: `src/nexus/bricks/auth/external_sync/aws_sync.py`
+- Create: `src/nexus/bricks/auth/tests/fixtures/external_cli_output/aws_credentials_v2.15.ini`
+- Create: `src/nexus/bricks/auth/tests/fixtures/external_cli_output/aws_credentials_v2.16.ini`
+- Create: `src/nexus/bricks/auth/tests/test_aws_sync.py`
+
+- [ ] **Step 1: Create fixture files**
+
+```ini
+# src/nexus/bricks/auth/tests/fixtures/external_cli_output/aws_credentials_v2.15.ini
+# Simulates ~/.aws/credentials from AWS CLI v2.15.x
+# Standard format: multiple profiles with access key + secret key
+
+[default]
+aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+
+[work-prod]
+aws_access_key_id = AKIAI44QH8DHBEXAMPLE
+aws_secret_access_key = je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY
+region = us-west-2
+
+[no-key-profile]
+region = eu-west-1
+output = json
+```
+
+```ini
+# src/nexus/bricks/auth/tests/fixtures/external_cli_output/aws_credentials_v2.16.ini
+# Simulates ~/.aws/credentials from AWS CLI v2.16.x
+# Includes SSO session tokens and newer fields
+
+[default]
+aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+
+[sso-session]
+aws_access_key_id = ASIAZZZZZZZZZEXAMPLE
+aws_secret_access_key = tempSecretFromSSO/EXAMPLEKEY
+aws_session_token = FwoGZXIvYXdzEBYaDHqa0AP1/EXAMPLETOKEN
+x_security_token_expires = 2026-04-15T12:00:00Z
+
+[dev]
+aws_access_key_id = AKIAXXXXXXXXXXXXXXXX
+aws_secret_access_key = devSecretKeyExample12345678901234567
+
+[future-unknown-field-profile]
+aws_access_key_id = AKIAFUTUREFIELDEXAMPLE
+aws_secret_access_key = futureSecret1234567890EXAMPLE
+some_future_field = new-feature-value
+```
+
+- [ ] **Step 2: Write failing tests**
+
+```python
+# src/nexus/bricks/auth/tests/test_aws_sync.py
+"""Tests for AwsCliSyncAdapter.parse_file() against fixture files."""
+
+from __future__ import annotations
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+FIXTURES_DIR = Path(__file__).parent / "fixtures" / "external_cli_output"
+
+
+class TestAwsParseCredentials:
+    def test_parse_v2_15_credentials(self) -> None:
+        from nexus.bricks.auth.external_sync.aws_sync import AwsCliSyncAdapter
+
+        adapter = AwsCliSyncAdapter()
+        fixture = FIXTURES_DIR / "aws_credentials_v2.15.ini"
+        content = fixture.read_text()
+        profiles = adapter.parse_file(fixture, content)
+
+        names = {p.account_identifier for p in profiles}
+        assert "default" in names
+        assert "work-prod" in names
+        # no-key-profile should be skipped (no aws_access_key_id)
+        assert "no-key-profile" not in names
+        assert len(profiles) == 2
+
+    def test_parse_v2_16_credentials(self) -> None:
+        from nexus.bricks.auth.external_sync.aws_sync import AwsCliSyncAdapter
+
+        adapter = AwsCliSyncAdapter()
+        fixture = FIXTURES_DIR / "aws_credentials_v2.16.ini"
+        content = fixture.read_text()
+        profiles = adapter.parse_file(fixture, content)
+
+        names = {p.account_identifier for p in profiles}
+        assert "default" in names
+        assert "sso-session" in names
+        assert "dev" in names
+        # future-unknown-field-profile should still parse (tolerant of unknown keys)
+        assert "future-unknown-field-profile" in names
+        assert len(profiles) == 4
+
+    def test_parse_empty_file(self) -> None:
+        from nexus.bricks.auth.external_sync.aws_sync import AwsCliSyncAdapter
+
+        adapter = AwsCliSyncAdapter()
+        profiles = adapter.parse_file(Path("empty.ini"), "")
+        assert profiles == []
+
+    def test_backend_key_format(self) -> None:
+        from nexus.bricks.auth.external_sync.aws_sync import AwsCliSyncAdapter
+
+        adapter = AwsCliSyncAdapter()
+        fixture = FIXTURES_DIR / "aws_credentials_v2.15.ini"
+        content = fixture.read_text()
+        profiles = adapter.parse_file(fixture, content)
+
+        default_profile = next(p for p in profiles if p.account_identifier == "default")
+        assert default_profile.backend_key == "aws-cli/default"
+        assert default_profile.provider == "s3"
+        assert default_profile.source == "aws-cli"
+
+
+class TestAwsParseConfig:
+    def test_parse_config_file_strips_profile_prefix(self, tmp_path: Path) -> None:
+        """~/.aws/config uses 'profile <name>' sections (except [default])."""
+        from nexus.bricks.auth.external_sync.aws_sync import AwsCliSyncAdapter
+
+        config_content = (
+            "[default]\n"
+            "region = us-east-1\n"
+            "aws_access_key_id = AKIADEFAULTEXAMPLE\n"
+            "aws_secret_access_key = defaultSecret\n"
+            "\n"
+            "[profile staging]\n"
+            "aws_access_key_id = AKIASTAGINGEXAMPLE\n"
+            "aws_secret_access_key = stagingSecret\n"
+            "region = eu-west-1\n"
+        )
+        adapter = AwsCliSyncAdapter()
+        profiles = adapter.parse_file(Path("config"), config_content)
+        names = {p.account_identifier for p in profiles}
+        assert "default" in names
+        assert "staging" in names
+        assert "profile staging" not in names
+
+
+class TestAwsPaths:
+    def test_paths_respects_env_vars(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from nexus.bricks.auth.external_sync.aws_sync import AwsCliSyncAdapter
+
+        monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", "/custom/creds")
+        monkeypatch.setenv("AWS_CONFIG_FILE", "/custom/config")
+        adapter = AwsCliSyncAdapter()
+        paths = adapter.paths()
+        assert Path("/custom/creds") in paths
+        assert Path("/custom/config") in paths
+
+    def test_paths_defaults_to_home(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        from nexus.bricks.auth.external_sync.aws_sync import AwsCliSyncAdapter
+
+        monkeypatch.delenv("AWS_SHARED_CREDENTIALS_FILE", raising=False)
+        monkeypatch.delenv("AWS_CONFIG_FILE", raising=False)
+        adapter = AwsCliSyncAdapter()
+        paths = adapter.paths()
+        home = Path.home()
+        assert home / ".aws" / "credentials" in paths
+        assert home / ".aws" / "config" in paths
+
+
+class TestAwsSync:
+    async def test_full_sync_from_fixture(self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+        from nexus.bricks.auth.external_sync.aws_sync import AwsCliSyncAdapter
+
+        # Point AWS env vars to tmp dir with fixture data
+        creds_file = tmp_path / "credentials"
+        creds_file.write_text((FIXTURES_DIR / "aws_credentials_v2.15.ini").read_text())
+        monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(creds_file))
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "nonexistent"))
+
+        adapter = AwsCliSyncAdapter()
+        result = await adapter.sync()
+        assert result.error is None
+        assert len(result.profiles) == 2
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_aws_sync.py -xvs`
+Expected: FAIL — `ModuleNotFoundError: No module named 'nexus.bricks.auth.external_sync.aws_sync'`
+
+- [ ] **Step 4: Implement AwsCliSyncAdapter**
+
+```python
+# src/nexus/bricks/auth/external_sync/aws_sync.py
+"""AWS CLI sync adapter — discovers profiles from ~/.aws/credentials + config.
+
+FileAdapter subclass. ~40 LOC of descriptor logic. All I/O, error handling,
+and retry logic lives in the FileAdapter base class.
+"""
+
+from __future__ import annotations
+
+import configparser
+import os
+from pathlib import Path
+
+from nexus.bricks.auth.credential_backend import ResolvedCredential
+from nexus.bricks.auth.external_sync.base import SyncedProfile
+from nexus.bricks.auth.external_sync.file_adapter import FileAdapter
+
+
+class AwsCliSyncAdapter(FileAdapter):
+    """Discovers AWS profiles from credentials/config files."""
+
+    adapter_name = "aws-cli"
+
+    def paths(self) -> list[Path]:
+        return [
+            Path(
+                os.environ.get("AWS_SHARED_CREDENTIALS_FILE", "~/.aws/credentials")
+            ).expanduser(),
+            Path(os.environ.get("AWS_CONFIG_FILE", "~/.aws/config")).expanduser(),
+        ]
+
+    def parse_file(self, path: Path, content: str) -> list[SyncedProfile]:
+        parser = configparser.ConfigParser()
+        parser.read_string(content)
+
+        profiles: list[SyncedProfile] = []
+        for section in parser.sections():
+            if not parser.has_option(section, "aws_access_key_id"):
+                continue
+
+            # ~/.aws/config uses "profile <name>" sections (except [default])
+            name = section
+            if name.startswith("profile "):
+                name = name[len("profile ") :]
+
+            profiles.append(
+                SyncedProfile(
+                    provider="s3",
+                    account_identifier=name,
+                    backend_key=f"aws-cli/{name}",
+                    source="aws-cli",
+                )
+            )
+
+        return profiles
+
+    async def resolve_credential(self, backend_key: str) -> ResolvedCredential:
+        """Re-read AWS config files and extract credential for one profile."""
+        _, profile_name = backend_key.split("/", 1)
+
+        for path in self.paths():
+            try:
+                content = path.read_text(encoding="utf-8")
+            except OSError:
+                continue
+
+            parser = configparser.ConfigParser()
+            parser.read_string(content)
+
+            # Try exact section name, then "profile <name>" variant
+            for section in [profile_name, f"profile {profile_name}"]:
+                if parser.has_section(section) and parser.has_option(
+                    section, "aws_access_key_id"
+                ):
+                    return ResolvedCredential(
+                        kind="api_key",
+                        api_key=parser.get(section, "aws_access_key_id"),
+                        metadata={
+                            "secret_access_key": parser.get(
+                                section, "aws_secret_access_key", fallback=""
+                            ),
+                            "session_token": parser.get(
+                                section, "aws_session_token", fallback=""
+                            ),
+                            "region": parser.get(section, "region", fallback=""),
+                        },
+                    )
+
+        from nexus.bricks.auth.credential_backend import CredentialResolutionError
+
+        raise CredentialResolutionError(
+            "external-cli",
+            backend_key,
+            f"AWS profile '{profile_name}' not found in config files",
+        )
+```
+
+- [ ] **Step 5: Update `__init__.py` exports**
+
+Add to `src/nexus/bricks/auth/external_sync/__init__.py`:
+
+```python
+from nexus.bricks.auth.external_sync.aws_sync import AwsCliSyncAdapter
+
+# Add to __all__:
+"AwsCliSyncAdapter",
+```
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_aws_sync.py -xvs`
+Expected: all PASS
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/nexus/bricks/auth/external_sync/aws_sync.py src/nexus/bricks/auth/external_sync/__init__.py src/nexus/bricks/auth/tests/test_aws_sync.py src/nexus/bricks/auth/tests/fixtures/
+git commit -m "feat(auth): add AwsCliSyncAdapter with fixture-based parse tests (#3739)"
+```
+
+---
+
+## Task 5: Circuit breaker + AdapterRegistry + tests
+
+**Files:**
+- Create: `src/nexus/bricks/auth/external_sync/registry.py`
+- Create: `src/nexus/bricks/auth/tests/test_registry.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# src/nexus/bricks/auth/tests/test_registry.py
+"""Tests for AdapterRegistry — startup, background loop, circuit breaker."""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from nexus.bricks.auth.credential_backend import ResolvedCredential
+from nexus.bricks.auth.external_sync.base import (
+    ExternalCliSyncAdapter,
+    SyncedProfile,
+    SyncResult,
+)
+from nexus.bricks.auth.profile import InMemoryAuthProfileStore
+
+
+# -- Helpers ----------------------------------------------------------------
+
+
+class _FastAdapter(ExternalCliSyncAdapter):
+    """Adapter that returns immediately."""
+
+    adapter_name = "fast"
+    sync_ttl_seconds = 60.0
+
+    async def detect(self) -> bool:
+        return True
+
+    async def sync(self) -> SyncResult:
+        return SyncResult(
+            adapter_name=self.adapter_name,
+            profiles=[
+                SyncedProfile(
+                    provider="test",
+                    account_identifier="acc1",
+                    backend_key="fast/acc1",
+                    source="fast",
+                )
+            ],
+        )
+
+    async def resolve_credential(self, backend_key: str) -> ResolvedCredential:
+        return ResolvedCredential(kind="api_key", api_key="key")
+
+
+class _HangingAdapter(ExternalCliSyncAdapter):
+    """Adapter that hangs forever."""
+
+    adapter_name = "hanging"
+    sync_ttl_seconds = 60.0
+
+    async def detect(self) -> bool:
+        return True
+
+    async def sync(self) -> SyncResult:
+        await asyncio.sleep(300)
+        return SyncResult(adapter_name=self.adapter_name)
+
+    async def resolve_credential(self, backend_key: str) -> ResolvedCredential:
+        return ResolvedCredential(kind="api_key", api_key="key")
+
+
+class _FailingAdapter(ExternalCliSyncAdapter):
+    """Adapter that always fails."""
+
+    adapter_name = "failing"
+    sync_ttl_seconds = 10.0
+    failure_threshold = 3
+    reset_timeout_seconds = 0.5
+
+    def __init__(self) -> None:
+        self.sync_count = 0
+
+    async def detect(self) -> bool:
+        return True
+
+    async def sync(self) -> SyncResult:
+        self.sync_count += 1
+        return SyncResult(
+            adapter_name=self.adapter_name,
+            error="always fails",
+        )
+
+    async def resolve_credential(self, backend_key: str) -> ResolvedCredential:
+        return ResolvedCredential(kind="api_key", api_key="key")
+
+
+class _RecoveringAdapter(ExternalCliSyncAdapter):
+    """Adapter that fails N times then succeeds."""
+
+    adapter_name = "recovering"
+    sync_ttl_seconds = 10.0
+    failure_threshold = 2
+    reset_timeout_seconds = 0.3
+
+    def __init__(self, fail_count: int = 2) -> None:
+        self._fail_count = fail_count
+        self.sync_count = 0
+
+    async def detect(self) -> bool:
+        return True
+
+    async def sync(self) -> SyncResult:
+        self.sync_count += 1
+        if self.sync_count <= self._fail_count:
+            return SyncResult(adapter_name=self.adapter_name, error="transient")
+        return SyncResult(
+            adapter_name=self.adapter_name,
+            profiles=[
+                SyncedProfile(
+                    provider="test",
+                    account_identifier="recovered",
+                    backend_key="recovering/recovered",
+                    source="recovering",
+                )
+            ],
+        )
+
+    async def resolve_credential(self, backend_key: str) -> ResolvedCredential:
+        return ResolvedCredential(kind="api_key", api_key="key")
+
+
+# -- Circuit breaker tests --------------------------------------------------
+
+
+class TestCircuitBreaker:
+    def test_starts_closed(self) -> None:
+        from nexus.bricks.auth.external_sync.registry import CircuitBreaker
+
+        cb = CircuitBreaker(failure_threshold=3, reset_timeout_seconds=60.0)
+        assert not cb.is_tripped
+        assert not cb.is_half_open
+
+    def test_trips_after_threshold(self) -> None:
+        from nexus.bricks.auth.external_sync.registry import CircuitBreaker
+
+        cb = CircuitBreaker(failure_threshold=3, reset_timeout_seconds=60.0)
+        cb.record_failure()
+        cb.record_failure()
+        assert not cb.is_tripped
+        cb.record_failure()
+        assert cb.is_tripped
+
+    def test_success_resets(self) -> None:
+        from nexus.bricks.auth.external_sync.registry import CircuitBreaker
+
+        cb = CircuitBreaker(failure_threshold=2, reset_timeout_seconds=60.0)
+        cb.record_failure()
+        cb.record_failure()
+        assert cb.is_tripped
+        cb.record_success()
+        assert not cb.is_tripped
+        assert cb.failure_count == 0
+
+    def test_half_open_after_reset_timeout(self) -> None:
+        from nexus.bricks.auth.external_sync.registry import CircuitBreaker
+
+        cb = CircuitBreaker(failure_threshold=1, reset_timeout_seconds=0.1)
+        cb.record_failure()
+        assert cb.is_tripped
+        time.sleep(0.15)
+        assert cb.is_half_open
+        assert not cb.is_tripped
+
+
+# -- Startup tests -----------------------------------------------------------
+
+
+class TestRegistryStartup:
+    async def test_startup_returns_results(self) -> None:
+        from nexus.bricks.auth.external_sync.registry import AdapterRegistry
+
+        store = InMemoryAuthProfileStore()
+        registry = AdapterRegistry(
+            adapters=[_FastAdapter()],
+            profile_store=store,
+        )
+        results = await registry.startup()
+        assert "fast" in results
+        assert results["fast"].error is None
+        assert len(results["fast"].profiles) == 1
+
+    async def test_startup_upserts_into_store(self) -> None:
+        from nexus.bricks.auth.external_sync.registry import AdapterRegistry
+
+        store = InMemoryAuthProfileStore()
+        registry = AdapterRegistry(
+            adapters=[_FastAdapter()],
+            profile_store=store,
+        )
+        await registry.startup()
+        profiles = store.list(provider="test")
+        assert len(profiles) == 1
+        assert profiles[0].backend == "external-cli"
+        assert profiles[0].backend_key == "fast/acc1"
+
+    async def test_startup_timeout_degrades_slow_adapter(self) -> None:
+        from nexus.bricks.auth.external_sync.registry import AdapterRegistry
+
+        fast = _FastAdapter()
+        hanging = _HangingAdapter()
+        store = InMemoryAuthProfileStore()
+        registry = AdapterRegistry(
+            adapters=[fast, hanging],
+            profile_store=store,
+            startup_timeout=1.0,
+        )
+        t0 = time.monotonic()
+        results = await registry.startup()
+        elapsed = time.monotonic() - t0
+
+        assert elapsed < 2.0  # bounded by timeout, not the 300s hang
+        assert results["fast"].error is None
+        assert results["hanging"].error is not None
+        assert "timeout" in results["hanging"].error.lower()
+
+    async def test_startup_5_adapters_4_fast_1_hanging(self) -> None:
+        """Decision 15A: 4 ok + 1 degraded within ~startup_timeout."""
+        from nexus.bricks.auth.external_sync.registry import AdapterRegistry
+
+        adapters = []
+        for i in range(4):
+            a = _FastAdapter()
+            a.adapter_name = f"fast-{i}"
+            adapters.append(a)
+        adapters.append(_HangingAdapter())
+
+        store = InMemoryAuthProfileStore()
+        registry = AdapterRegistry(
+            adapters=adapters,
+            profile_store=store,
+            startup_timeout=1.0,
+        )
+        t0 = time.monotonic()
+        results = await registry.startup()
+        elapsed = time.monotonic() - t0
+
+        ok_count = sum(1 for r in results.values() if r.error is None)
+        degraded_count = sum(1 for r in results.values() if r.error is not None)
+        assert ok_count == 4
+        assert degraded_count == 1
+        assert elapsed < 2.0
+
+
+# -- Circuit breaker integration tests ---------------------------------------
+
+
+class TestRegistryCircuitBreaker:
+    async def test_circuit_breaker_trips_after_threshold(self) -> None:
+        from nexus.bricks.auth.external_sync.registry import AdapterRegistry
+
+        failing = _FailingAdapter()
+        store = InMemoryAuthProfileStore()
+        registry = AdapterRegistry(
+            adapters=[failing],
+            profile_store=store,
+        )
+        # Startup counts as one failure
+        await registry.startup()
+        # Manually trigger syncs to hit threshold
+        for _ in range(3):
+            await registry._sync_adapter(failing)
+
+        assert registry._breakers["failing"].is_tripped
+
+    async def test_circuit_breaker_half_open_recovery(self) -> None:
+        from nexus.bricks.auth.external_sync.registry import AdapterRegistry
+
+        recovering = _RecoveringAdapter(fail_count=2)
+        store = InMemoryAuthProfileStore()
+        registry = AdapterRegistry(
+            adapters=[recovering],
+            profile_store=store,
+        )
+        # Fail twice to trip
+        await registry._sync_adapter(recovering)
+        await registry._sync_adapter(recovering)
+        assert registry._breakers["recovering"].is_tripped
+
+        # Wait for half-open
+        await asyncio.sleep(0.4)
+        assert registry._breakers["recovering"].is_half_open
+
+        # Next sync should succeed and reset
+        await registry._sync_adapter(recovering)
+        assert not registry._breakers["recovering"].is_tripped
+        profiles = store.list(provider="test")
+        assert any(p.account_identifier == "recovered" for p in profiles)
+
+
+# -- Background loop tests ---------------------------------------------------
+
+
+class TestRegistryRefreshLoop:
+    async def test_loop_respects_ttl(self) -> None:
+        from nexus.bricks.auth.external_sync.registry import AdapterRegistry
+
+        fast = _FastAdapter()
+        fast.sync_ttl_seconds = 0.3  # short TTL for test
+        store = InMemoryAuthProfileStore()
+        registry = AdapterRegistry(
+            adapters=[fast],
+            profile_store=store,
+            loop_tick_seconds=0.1,
+        )
+        await registry.startup()
+
+        # Immediately after startup, adapter shouldn't be synced again
+        initial_sync_time = registry._last_sync_times.get("fast")
+        assert initial_sync_time is not None
+
+        # Run loop briefly — should NOT re-sync within TTL
+        loop_task = asyncio.create_task(registry.run_refresh_loop())
+        await asyncio.sleep(0.2)
+        loop_task.cancel()
+        try:
+            await loop_task
+        except asyncio.CancelledError:
+            pass
+
+        # After TTL expires, loop should sync again
+        registry2 = AdapterRegistry(
+            adapters=[fast],
+            profile_store=store,
+            loop_tick_seconds=0.1,
+        )
+        await registry2.startup()
+        await asyncio.sleep(0.4)  # past TTL
+        loop_task2 = asyncio.create_task(registry2.run_refresh_loop())
+        await asyncio.sleep(0.2)
+        loop_task2.cancel()
+        try:
+            await loop_task2
+        except asyncio.CancelledError:
+            pass
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_registry.py -xvs`
+Expected: FAIL — `ModuleNotFoundError`
+
+- [ ] **Step 3: Implement CircuitBreaker and AdapterRegistry**
+
+```python
+# src/nexus/bricks/auth/external_sync/registry.py
+"""AdapterRegistry — manages adapter lifecycle, startup, background refresh.
+
+Owns:
+  - Startup sync with asyncio.gather + global timeout (decision 15A)
+  - Per-adapter circuit breaker (configurable threshold + reset timeout)
+  - Background refresh loop with per-adapter TTL
+  - Upsert of SyncedProfile → AuthProfile into the store
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from nexus.bricks.auth.external_sync.base import (
+    ExternalCliSyncAdapter,
+    SyncResult,
+)
+from nexus.bricks.auth.profile import AuthProfile, AuthProfileStore, ProfileUsageStats
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class CircuitBreaker:
+    """Per-adapter circuit breaker with half-open probe support."""
+
+    failure_threshold: int = 3
+    reset_timeout_seconds: float = 60.0
+    failure_count: int = field(default=0, init=False)
+    tripped_at: float | None = field(default=None, init=False)
+
+    @property
+    def is_tripped(self) -> bool:
+        """True if breaker is open and reset timeout has NOT elapsed."""
+        if self.tripped_at is None:
+            return False
+        return (time.monotonic() - self.tripped_at) < self.reset_timeout_seconds
+
+    @property
+    def is_half_open(self) -> bool:
+        """True if breaker tripped but reset timeout has elapsed (allow probe)."""
+        if self.tripped_at is None:
+            return False
+        return (time.monotonic() - self.tripped_at) >= self.reset_timeout_seconds
+
+    def record_success(self) -> None:
+        self.failure_count = 0
+        self.tripped_at = None
+
+    def record_failure(self) -> None:
+        self.failure_count += 1
+        if self.failure_count >= self.failure_threshold:
+            self.tripped_at = time.monotonic()
+
+
+class AdapterRegistry:
+    """Manages external CLI sync adapter lifecycle."""
+
+    def __init__(
+        self,
+        adapters: list[ExternalCliSyncAdapter],
+        profile_store: AuthProfileStore,
+        *,
+        startup_timeout: float = 3.0,
+        loop_tick_seconds: float = 30.0,
+    ) -> None:
+        self._adapters: dict[str, ExternalCliSyncAdapter] = {
+            a.adapter_name: a for a in adapters
+        }
+        self._store = profile_store
+        self._startup_timeout = startup_timeout
+        self._loop_tick_seconds = loop_tick_seconds
+        self._breakers: dict[str, CircuitBreaker] = {
+            a.adapter_name: CircuitBreaker(
+                failure_threshold=a.failure_threshold,
+                reset_timeout_seconds=a.reset_timeout_seconds,
+            )
+            for a in adapters
+        }
+        self._last_sync_times: dict[str, float] = {}
+
+    def get_adapter(self, adapter_name: str) -> ExternalCliSyncAdapter | None:
+        return self._adapters.get(adapter_name)
+
+    async def startup(self) -> dict[str, SyncResult]:
+        """Run all adapters concurrently with a global timeout.
+
+        Decision 15A: asyncio.gather with startup_timeout. Adapters
+        that miss the deadline get a degraded SyncResult.
+        """
+        async def _sync_one(adapter: ExternalCliSyncAdapter) -> SyncResult:
+            if not await adapter.detect():
+                return SyncResult(
+                    adapter_name=adapter.adapter_name,
+                    error=f"{adapter.adapter_name}: not detected on this system",
+                )
+            return await adapter.sync()
+
+        tasks = {
+            name: asyncio.create_task(_sync_one(adapter))
+            for name, adapter in self._adapters.items()
+        }
+
+        # Wait for all with global timeout
+        try:
+            await asyncio.wait_for(
+                asyncio.gather(*tasks.values(), return_exceptions=True),
+                timeout=self._startup_timeout,
+            )
+        except asyncio.TimeoutError:
+            pass
+
+        results: dict[str, SyncResult] = {}
+        for name, task in tasks.items():
+            if task.done() and not task.cancelled():
+                exc = task.exception()
+                if exc is not None:
+                    results[name] = SyncResult(
+                        adapter_name=name,
+                        error=f"{name}: {exc}",
+                    )
+                else:
+                    results[name] = task.result()
+            else:
+                task.cancel()
+                results[name] = SyncResult(
+                    adapter_name=name,
+                    error=f"{name}: timeout during startup",
+                )
+
+        # Upsert successful results and update circuit breakers
+        for name, result in results.items():
+            if result.error is None:
+                self._upsert_sync_results(result)
+                self._breakers[name].record_success()
+                self._last_sync_times[name] = time.monotonic()
+            else:
+                self._breakers[name].record_failure()
+
+        return results
+
+    async def run_refresh_loop(self) -> None:
+        """Background refresh loop. Cancel via task.cancel()."""
+        while True:
+            await asyncio.sleep(self._loop_tick_seconds)
+            now = time.monotonic()
+
+            for name, adapter in self._adapters.items():
+                breaker = self._breakers[name]
+
+                # Skip if tripped and not half-open
+                if breaker.is_tripped:
+                    continue
+
+                # Skip if not stale
+                last = self._last_sync_times.get(name, 0.0)
+                if (now - last) < adapter.sync_ttl_seconds:
+                    continue
+
+                await self._sync_adapter(adapter)
+
+    async def _sync_adapter(self, adapter: ExternalCliSyncAdapter) -> SyncResult:
+        """Sync a single adapter, updating breaker and store."""
+        name = adapter.adapter_name
+        breaker = self._breakers[name]
+
+        try:
+            result = await adapter.sync()
+        except Exception as exc:
+            result = SyncResult(adapter_name=name, error=str(exc))
+
+        if result.error is None:
+            self._upsert_sync_results(result)
+            breaker.record_success()
+            self._last_sync_times[name] = time.monotonic()
+        else:
+            breaker.record_failure()
+            logger.warning("Adapter %s sync failed: %s", name, result.error)
+
+        return result
+
+    def _upsert_sync_results(self, result: SyncResult) -> None:
+        """Map SyncedProfiles to AuthProfiles and upsert into the store."""
+        now = datetime.now(UTC)
+        for sp in result.profiles:
+            profile_id = f"{sp.provider}/{sp.account_identifier}"
+            existing = self._store.get(profile_id)
+
+            profile = AuthProfile(
+                id=profile_id,
+                provider=sp.provider,
+                account_identifier=sp.account_identifier,
+                backend="external-cli",
+                backend_key=sp.backend_key,
+                last_synced_at=now,
+                sync_ttl_seconds=int(
+                    self._adapters[result.adapter_name].sync_ttl_seconds
+                ),
+                usage_stats=(existing.usage_stats if existing else ProfileUsageStats()),
+            )
+            self._store.upsert(profile)
+```
+
+- [ ] **Step 4: Update `__init__.py` exports**
+
+Add to `src/nexus/bricks/auth/external_sync/__init__.py`:
+
+```python
+from nexus.bricks.auth.external_sync.registry import AdapterRegistry, CircuitBreaker
+
+# Add to __all__:
+"AdapterRegistry",
+"CircuitBreaker",
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_registry.py -xvs`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/nexus/bricks/auth/external_sync/registry.py src/nexus/bricks/auth/external_sync/__init__.py src/nexus/bricks/auth/tests/test_registry.py
+git commit -m "feat(auth): add AdapterRegistry with circuit breaker + startup timeout + refresh loop (#3739)"
+```
+
+---
+
+## Task 6: ExternalCliBackend + tests
+
+**Files:**
+- Create: `src/nexus/bricks/auth/external_sync/external_cli_backend.py`
+- Create: `src/nexus/bricks/auth/tests/test_external_cli_backend.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# src/nexus/bricks/auth/tests/test_external_cli_backend.py
+"""Tests for ExternalCliBackend — CredentialBackend for external CLIs."""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.bricks.auth.credential_backend import (
+    BackendHealth,
+    CredentialResolutionError,
+    HealthStatus,
+    ResolvedCredential,
+)
+from nexus.bricks.auth.external_sync.base import (
+    ExternalCliSyncAdapter,
+    SyncedProfile,
+    SyncResult,
+)
+from nexus.bricks.auth.profile import InMemoryAuthProfileStore
+
+
+class _MockAdapter(ExternalCliSyncAdapter):
+    adapter_name = "mock-cli"
+    sync_ttl_seconds = 60.0
+
+    def __init__(self, credentials: dict[str, ResolvedCredential] | None = None) -> None:
+        self._credentials = credentials or {}
+
+    async def detect(self) -> bool:
+        return True
+
+    async def sync(self) -> SyncResult:
+        return SyncResult(adapter_name=self.adapter_name)
+
+    async def resolve_credential(self, backend_key: str) -> ResolvedCredential:
+        if backend_key in self._credentials:
+            return self._credentials[backend_key]
+        raise CredentialResolutionError("external-cli", backend_key, "not found")
+
+
+class TestExternalCliBackendResolve:
+    async def test_resolve_delegates_to_adapter(self) -> None:
+        from nexus.bricks.auth.external_sync.external_cli_backend import ExternalCliBackend
+        from nexus.bricks.auth.external_sync.registry import AdapterRegistry
+
+        expected = ResolvedCredential(
+            kind="api_key",
+            api_key="AKIAEXAMPLE",
+            metadata={"secret_access_key": "secret123"},
+        )
+        adapter = _MockAdapter(credentials={"mock-cli/default": expected})
+        store = InMemoryAuthProfileStore()
+        registry = AdapterRegistry(adapters=[adapter], profile_store=store)
+
+        backend = ExternalCliBackend(registry)
+        result = await backend.resolve("mock-cli/default")
+        assert result.kind == "api_key"
+        assert result.api_key == "AKIAEXAMPLE"
+        assert result.metadata["secret_access_key"] == "secret123"
+
+    async def test_resolve_unknown_adapter_raises(self) -> None:
+        from nexus.bricks.auth.external_sync.external_cli_backend import ExternalCliBackend
+        from nexus.bricks.auth.external_sync.registry import AdapterRegistry
+
+        store = InMemoryAuthProfileStore()
+        registry = AdapterRegistry(adapters=[], profile_store=store)
+
+        backend = ExternalCliBackend(registry)
+        with pytest.raises(CredentialResolutionError, match="no adapter"):
+            await backend.resolve("nonexistent/profile")
+
+    async def test_resolve_unknown_profile_raises(self) -> None:
+        from nexus.bricks.auth.external_sync.external_cli_backend import ExternalCliBackend
+        from nexus.bricks.auth.external_sync.registry import AdapterRegistry
+
+        adapter = _MockAdapter(credentials={})
+        store = InMemoryAuthProfileStore()
+        registry = AdapterRegistry(adapters=[adapter], profile_store=store)
+
+        backend = ExternalCliBackend(registry)
+        with pytest.raises(CredentialResolutionError, match="not found"):
+            await backend.resolve("mock-cli/nonexistent")
+
+
+class TestExternalCliBackendHealthCheck:
+    async def test_health_check_healthy(self) -> None:
+        from nexus.bricks.auth.external_sync.external_cli_backend import ExternalCliBackend
+        from nexus.bricks.auth.external_sync.registry import AdapterRegistry
+
+        cred = ResolvedCredential(kind="api_key", api_key="key")
+        adapter = _MockAdapter(credentials={"mock-cli/default": cred})
+        store = InMemoryAuthProfileStore()
+        registry = AdapterRegistry(adapters=[adapter], profile_store=store)
+
+        backend = ExternalCliBackend(registry)
+        health = await backend.health_check("mock-cli/default")
+        assert health.status == HealthStatus.HEALTHY
+
+    async def test_health_check_unhealthy_on_missing(self) -> None:
+        from nexus.bricks.auth.external_sync.external_cli_backend import ExternalCliBackend
+        from nexus.bricks.auth.external_sync.registry import AdapterRegistry
+
+        adapter = _MockAdapter(credentials={})
+        store = InMemoryAuthProfileStore()
+        registry = AdapterRegistry(adapters=[adapter], profile_store=store)
+
+        backend = ExternalCliBackend(registry)
+        health = await backend.health_check("mock-cli/nonexistent")
+        assert health.status == HealthStatus.UNHEALTHY
+
+
+class TestExternalCliBackendName:
+    def test_name_is_external_cli(self) -> None:
+        from nexus.bricks.auth.external_sync.external_cli_backend import ExternalCliBackend
+        from nexus.bricks.auth.external_sync.registry import AdapterRegistry
+
+        store = InMemoryAuthProfileStore()
+        registry = AdapterRegistry(adapters=[], profile_store=store)
+        backend = ExternalCliBackend(registry)
+        assert backend.name == "external-cli"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_external_cli_backend.py -xvs`
+Expected: FAIL — `ModuleNotFoundError`
+
+- [ ] **Step 3: Implement ExternalCliBackend**
+
+```python
+# src/nexus/bricks/auth/external_sync/external_cli_backend.py
+"""ExternalCliBackend — CredentialBackend for external CLI credentials.
+
+Implements the CredentialBackend protocol. resolve() delegates to the
+appropriate adapter's resolve_credential() for a fresh read. Never
+persists external credentials on nexus-side disk.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from nexus.bricks.auth.credential_backend import (
+    BackendHealth,
+    CredentialResolutionError,
+    HealthStatus,
+    ResolvedCredential,
+)
+from nexus.bricks.auth.external_sync.registry import AdapterRegistry
+
+
+class ExternalCliBackend:
+    """CredentialBackend for external-CLI-managed credentials.
+
+    resolve() re-reads from the upstream source fresh every call.
+    Never persists credentials on nexus-side disk.
+    """
+
+    _NAME = "external-cli"
+
+    def __init__(self, registry: AdapterRegistry) -> None:
+        self._registry = registry
+
+    @property
+    def name(self) -> str:
+        return self._NAME
+
+    async def resolve(self, backend_key: str) -> ResolvedCredential:
+        """Resolve a credential by delegating to the appropriate adapter.
+
+        backend_key format: "{adapter_name}/{profile_identifier}"
+        """
+        adapter_name, _ = self._parse_key(backend_key)
+        adapter = self._registry.get_adapter(adapter_name)
+        if adapter is None:
+            raise CredentialResolutionError(
+                self._NAME,
+                backend_key,
+                f"no adapter registered for '{adapter_name}'",
+            )
+        return await adapter.resolve_credential(backend_key)
+
+    async def health_check(self, backend_key: str) -> BackendHealth:
+        """Non-destructive health probe."""
+        now = datetime.now(UTC)
+        try:
+            await self.resolve(backend_key)
+            return BackendHealth(
+                status=HealthStatus.HEALTHY,
+                message="Credential resolved successfully",
+                checked_at=now,
+            )
+        except Exception as exc:
+            return BackendHealth(
+                status=HealthStatus.UNHEALTHY,
+                message=str(exc),
+                checked_at=now,
+            )
+
+    @staticmethod
+    def _parse_key(backend_key: str) -> tuple[str, str]:
+        """Parse backend_key into (adapter_name, profile_identifier)."""
+        parts = backend_key.split("/", 1)
+        if len(parts) < 2:
+            raise CredentialResolutionError(
+                ExternalCliBackend._NAME,
+                backend_key,
+                f"expected 'adapter_name/profile', got {backend_key!r}",
+            )
+        return parts[0], parts[1]
+```
+
+- [ ] **Step 4: Update `__init__.py` exports**
+
+Add to `src/nexus/bricks/auth/external_sync/__init__.py`:
+
+```python
+from nexus.bricks.auth.external_sync.external_cli_backend import ExternalCliBackend
+
+# Add to __all__:
+"ExternalCliBackend",
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_external_cli_backend.py -xvs`
+Expected: all PASS
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/nexus/bricks/auth/external_sync/external_cli_backend.py src/nexus/bricks/auth/external_sync/__init__.py src/nexus/bricks/auth/tests/test_external_cli_backend.py
+git commit -m "feat(auth): add ExternalCliBackend implementing CredentialBackend protocol (#3739)"
+```
+
+---
+
+## Task 7: `nexus-fs auth list` cutover
+
+**Files:**
+- Modify: `src/nexus/fs/_auth_cli.py:264-304`
+- Create: `src/nexus/bricks/auth/tests/test_auth_list_cutover.py`
+
+- [ ] **Step 1: Write failing tests**
+
+```python
+# src/nexus/bricks/auth/tests/test_auth_list_cutover.py
+"""Tests for nexus-fs auth list dual-read cutover."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from unittest.mock import patch
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.bricks.auth.profile import (
+    AuthProfile,
+    AuthProfileFailureReason,
+    ProfileUsageStats,
+)
+
+
+def _make_store_profiles() -> list[AuthProfile]:
+    """Create test profiles simulating a populated profile store."""
+    now = datetime.now(UTC)
+    return [
+        AuthProfile(
+            id="s3/default",
+            provider="s3",
+            account_identifier="default",
+            backend="external-cli",
+            backend_key="aws-cli/default",
+            last_synced_at=now,
+            usage_stats=ProfileUsageStats(
+                last_used_at=now - timedelta(minutes=14),
+                success_count=5,
+            ),
+        ),
+        AuthProfile(
+            id="s3/work-prod",
+            provider="s3",
+            account_identifier="work-prod",
+            backend="external-cli",
+            backend_key="aws-cli/work-prod",
+            last_synced_at=now,
+            usage_stats=ProfileUsageStats(
+                last_used_at=now - timedelta(minutes=43),
+                cooldown_until=now + timedelta(minutes=43),
+                cooldown_reason=AuthProfileFailureReason.RATE_LIMIT,
+            ),
+        ),
+        AuthProfile(
+            id="openai/team",
+            provider="openai",
+            account_identifier="team",
+            backend="nexus-token-manager",
+            backend_key="openai/team@example.com",
+            last_synced_at=now,
+            usage_stats=ProfileUsageStats(
+                last_used_at=now - timedelta(minutes=2),
+                success_count=10,
+            ),
+        ),
+    ]
+
+
+class TestAuthListNewTable:
+    def test_new_table_shows_source_column(self) -> None:
+        """When profile store has data, show the new table format."""
+        from nexus.fs._auth_cli import auth
+
+        profiles = _make_store_profiles()
+
+        with patch("nexus.fs._auth_cli._try_profile_store_list", return_value=profiles):
+            runner = CliRunner()
+            result = runner.invoke(auth, ["list"])
+            assert result.exit_code == 0
+            assert "Provider" in result.output or "provider" in result.output.lower()
+            assert "Source" in result.output or "source" in result.output.lower()
+            assert "aws-cli" in result.output
+            assert "default" in result.output
+            assert "work-prod" in result.output
+
+    def test_new_table_shows_cooldown_status(self) -> None:
+        from nexus.fs._auth_cli import auth
+
+        profiles = _make_store_profiles()
+
+        with patch("nexus.fs._auth_cli._try_profile_store_list", return_value=profiles):
+            runner = CliRunner()
+            result = runner.invoke(auth, ["list"])
+            assert "cooldown" in result.output.lower()
+            assert "rate_limit" in result.output.lower()
+
+
+class TestAuthListFallback:
+    def test_falls_back_when_store_empty(self) -> None:
+        """When _try_profile_store_list returns None, use old path."""
+        from nexus.fs._auth_cli import auth
+
+        with (
+            patch("nexus.fs._auth_cli._try_profile_store_list", return_value=None),
+            patch("nexus.fs._auth_cli._build_auth_service") as mock_service,
+        ):
+            import asyncio
+            from unittest.mock import AsyncMock
+
+            mock_svc = mock_service.return_value
+            mock_svc.list_summaries = AsyncMock(return_value=[])
+            mock_svc.secret_store_path = "/mock/path"
+
+            runner = CliRunner()
+            result = runner.invoke(auth, ["list"])
+            # Should not crash — falls back to old path
+            assert result.exit_code == 0
+            mock_svc.list_summaries.assert_called_once()
+
+
+class TestAuthListJsonOutput:
+    def test_json_output_new_format(self) -> None:
+        from nexus.fs._auth_cli import auth
+
+        profiles = _make_store_profiles()
+
+        with patch("nexus.fs._auth_cli._try_profile_store_list", return_value=profiles):
+            runner = CliRunner()
+            result = runner.invoke(auth, ["list", "--json"])
+            assert result.exit_code == 0
+            import json
+            data = json.loads(result.output)
+            assert isinstance(data, list)
+            assert len(data) == 3
+            assert data[0]["provider"] == "s3"
+            assert "source" in data[0]
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_auth_list_cutover.py -xvs`
+Expected: FAIL — `_try_profile_store_list` does not exist
+
+- [ ] **Step 3: Modify `_auth_cli.py` — add helper + rewrite `list_auth`**
+
+In `src/nexus/fs/_auth_cli.py`, add the helper function before `list_auth` (around line 260):
+
+```python
+def _try_profile_store_list() -> list | None:
+    """Try reading from the unified profile store.
+
+    Returns list of AuthProfile on success, None on any failure
+    (no DB, empty, import error). Triggers fallback to old path.
+    """
+    try:
+        from nexus.bricks.auth.profile import AuthProfile
+        from nexus.bricks.auth.profile_store import SqliteAuthProfileStore
+        from nexus.fs._paths import persistent_dir
+    except ImportError:
+        return None
+
+    db_path = persistent_dir() / "auth_profiles.db"
+    if not db_path.exists():
+        return None
+
+    try:
+        store = SqliteAuthProfileStore(db_path)
+        try:
+            profiles = store.list()
+        finally:
+            store.close()
+    except Exception:
+        return None
+
+    return profiles if profiles else None
+
+
+def _format_status(profile: "AuthProfile") -> str:
+    """Format profile status for the auth list table."""
+    from datetime import UTC, datetime
+
+    stats = profile.usage_stats
+    now = datetime.now(UTC)
+
+    if stats.disabled_until and stats.disabled_until > now:
+        return "disabled"
+
+    if stats.cooldown_until and stats.cooldown_until > now:
+        remaining = stats.cooldown_until - now
+        minutes = int(remaining.total_seconds() / 60)
+        reason = stats.cooldown_reason.value if stats.cooldown_reason else "unknown"
+        if minutes > 60:
+            return f"cooldown  {reason} \u00b7 {minutes // 60}h {minutes % 60}m left"
+        return f"cooldown  {reason} \u00b7 {minutes}m left"
+
+    if profile.last_synced_at is None:
+        return "not yet synced"
+
+    return "ok"
+
+
+def _format_relative_time(dt: "datetime | None") -> str:
+    """Format a datetime as relative time (e.g. '14m ago')."""
+    if dt is None:
+        return "never"
+
+    from datetime import UTC, datetime
+
+    now = datetime.now(UTC)
+    # Handle naive datetimes by assuming UTC
+    if dt.tzinfo is None:
+        from datetime import timezone
+        dt = dt.replace(tzinfo=timezone.utc)
+    delta = now - dt
+    minutes = int(delta.total_seconds() / 60)
+
+    if minutes < 1:
+        return "just now"
+    if minutes < 60:
+        return f"{minutes}m ago"
+    hours = minutes // 60
+    if hours < 24:
+        return f"{hours}h ago"
+    days = hours // 24
+    return f"{days}d ago"
+
+
+def _source_display(backend: str) -> str:
+    """Map backend name to a user-friendly source label."""
+    if backend == "external-cli":
+        return "external"
+    if backend == "nexus-token-manager":
+        return "nexus"
+    return backend
+```
+
+Then replace the `list_auth` function (lines 264-304):
+
+```python
+@auth.command("list")
+@add_output_options
+def list_auth(output_opts: OutputOptions) -> None:
+    """List configured auth across services."""
+    profiles = _try_profile_store_list()
+
+    if profiles is not None:
+        # New unified table from profile store
+        data = [
+            {
+                "provider": p.provider,
+                "account": p.account_identifier,
+                "source": _source_display(p.backend),
+                "status": _format_status(p),
+                "last_used": _format_relative_time(p.usage_stats.last_used_at),
+            }
+            for p in profiles
+        ]
+
+        def _human_display(_data: object) -> None:
+            table = Table(
+                title="Unified Auth", show_header=True, header_style="bold cyan"
+            )
+            table.add_column("Provider", style="green")
+            table.add_column("Account", style="cyan")
+            table.add_column("Source", style="blue")
+            table.add_column("Status", style="yellow")
+            table.add_column("Last used")
+            for row in data:
+                table.add_row(
+                    row["provider"],
+                    row["account"],
+                    row["source"],
+                    row["status"],
+                    row["last_used"],
+                )
+            console.print(table)
+
+        render_output(
+            data=data,
+            output_opts=output_opts,
+            human_formatter=_human_display,
+        )
+        return
+
+    # Fallback: old UnifiedAuthService path
+    service = _build_auth_service()
+    summaries = asyncio.run(service.list_summaries())
+
+    data = [
+        {
+            "service": s.service,
+            "kind": s.kind.value,
+            "status": s.status.value,
+            "source": s.source,
+            "message": s.message,
+        }
+        for s in summaries
+    ]
+
+    def _human_display(_data: object) -> None:
+        table = Table(title="Unified Auth", show_header=True, header_style="bold cyan")
+        table.add_column("Service", style="green")
+        table.add_column("Kind", style="cyan")
+        table.add_column("Status", style="yellow")
+        table.add_column("Source", style="blue")
+        table.add_column("Message")
+        for summary in summaries:
+            table.add_row(
+                summary.service,
+                summary.kind.value,
+                summary.status.value,
+                summary.source,
+                summary.message,
+            )
+        console.print(table)
+        console.print(f"[dim]Secret store: {service.secret_store_path}[/dim]")
+
+    render_output(
+        data=data,
+        output_opts=output_opts,
+        human_formatter=_human_display,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_auth_list_cutover.py -xvs`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/fs/_auth_cli.py src/nexus/bricks/auth/tests/test_auth_list_cutover.py
+git commit -m "feat(auth): cut nexus-fs auth list over to profile store with dual-read fallback (#3739)"
+```
+
+---
+
+## Task 8: S3 backend routing through profile store
+
+**Files:**
+- Modify: `src/nexus/fs/_backend_factory.py:36-46`
+
+- [ ] **Step 1: Write failing test**
+
+Add to `src/nexus/bricks/auth/tests/test_auth_list_cutover.py` (or create a separate file if preferred):
+
+```python
+# Append to test_auth_list_cutover.py or create test_s3_routing.py
+
+class TestS3BackendRouting:
+    def test_s3_routes_through_profile_store_when_populated(self) -> None:
+        """When profile store has an S3 profile, use ExternalCliBackend."""
+        from unittest.mock import MagicMock, patch
+
+        mock_profile = MagicMock()
+        mock_profile.backend_key = "aws-cli/default"
+
+        mock_cred = MagicMock()
+        mock_cred.api_key = "AKIAEXAMPLE"
+        mock_cred.metadata = {"secret_access_key": "secret", "session_token": "", "region": "us-east-1"}
+
+        with (
+            patch("nexus.fs._backend_factory._try_profile_store_select", return_value=mock_profile),
+            patch("nexus.fs._backend_factory._resolve_external_credential", return_value=mock_cred),
+            patch("nexus.backends.storage.path_s3.PathS3Backend") as mock_s3,
+        ):
+            from nexus.fs._backend_factory import create_backend
+
+            spec = MagicMock()
+            spec.scheme = "s3"
+            spec.authority = "my-bucket"
+            spec.path = "/prefix"
+
+            create_backend(spec)
+
+            mock_s3.assert_called_once()
+            call_kwargs = mock_s3.call_args
+            assert call_kwargs[1].get("access_key_id") == "AKIAEXAMPLE" or call_kwargs.kwargs.get("access_key_id") == "AKIAEXAMPLE"
+
+    def test_s3_falls_back_when_no_profile(self) -> None:
+        """When profile store has no S3 profile, use old discover_credentials path."""
+        from unittest.mock import MagicMock, patch
+
+        with (
+            patch("nexus.fs._backend_factory._try_profile_store_select", return_value=None),
+            patch("nexus.fs._backend_factory.discover_credentials", return_value={"source": "env"}),
+            patch("nexus.backends.storage.path_s3.PathS3Backend") as mock_s3,
+        ):
+            from nexus.fs._backend_factory import create_backend
+
+            spec = MagicMock()
+            spec.scheme = "s3"
+            spec.authority = "my-bucket"
+            spec.path = "/prefix"
+
+            create_backend(spec)
+
+            mock_s3.assert_called_once()
+            # Old path: no explicit credentials
+            call_kwargs = mock_s3.call_args
+            assert call_kwargs.kwargs.get("access_key_id") is None
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_auth_list_cutover.py::TestS3BackendRouting -xvs`
+Expected: FAIL — `_try_profile_store_select` does not exist
+
+- [ ] **Step 3: Modify `_backend_factory.py`**
+
+Add helpers before `create_backend()`:
+
+```python
+def _try_profile_store_select(provider: str) -> "AuthProfile | None":
+    """Try selecting an active profile from the unified store."""
+    try:
+        from nexus.bricks.auth.profile import AuthProfile
+        from nexus.bricks.auth.profile_store import SqliteAuthProfileStore
+        from nexus.fs._paths import persistent_dir
+    except ImportError:
+        return None
+
+    db_path = persistent_dir() / "auth_profiles.db"
+    if not db_path.exists():
+        return None
+
+    try:
+        store = SqliteAuthProfileStore(db_path)
+        try:
+            profiles = store.list(provider=provider)
+        finally:
+            store.close()
+    except Exception:
+        return None
+
+    if not profiles:
+        return None
+
+    # Return the first non-cooldown profile
+    from datetime import UTC, datetime
+
+    now = datetime.now(UTC)
+    for p in profiles:
+        stats = p.usage_stats
+        if stats.cooldown_until and stats.cooldown_until > now:
+            continue
+        if stats.disabled_until and stats.disabled_until > now:
+            continue
+        return p
+
+    # All on cooldown — return first anyway (caller can decide)
+    return profiles[0]
+
+
+def _resolve_external_credential(backend_key: str) -> "ResolvedCredential | None":
+    """Resolve a credential via ExternalCliBackend without the full registry."""
+    try:
+        from nexus.bricks.auth.external_sync.aws_sync import AwsCliSyncAdapter
+    except ImportError:
+        return None
+
+    import asyncio
+
+    adapter = AwsCliSyncAdapter()
+    try:
+        return asyncio.run(adapter.resolve_credential(backend_key))
+    except Exception:
+        return None
+```
+
+Then modify the S3 branch in `create_backend()` (lines 36-46):
+
+```python
+    if spec.scheme == "s3":
+        try:
+            from nexus.backends.storage.path_s3 import PathS3Backend
+        except ImportError:
+            raise ImportError(
+                "boto3 is required for S3 backends. Install with: pip install nexus-fs[s3]"
+            ) from None
+
+        # Phase 2: try profile store first
+        profile = _try_profile_store_select(provider="s3")
+        if profile is not None and profile.backend == "external-cli":
+            cred = _resolve_external_credential(profile.backend_key)
+            if cred is not None:
+                return PathS3Backend(
+                    bucket_name=spec.authority,
+                    prefix=spec.path.lstrip("/") if spec.path else "",
+                    access_key_id=cred.api_key,
+                    secret_access_key=cred.metadata.get("secret_access_key", ""),
+                    session_token=cred.metadata.get("session_token") or None,
+                    region_name=cred.metadata.get("region") or None,
+                )
+
+        # Fallback: old discover_credentials() path
+        from nexus.fs._credentials import discover_credentials
+
+        discover_credentials(spec.scheme)
+        return PathS3Backend(
+            bucket_name=spec.authority,
+            prefix=spec.path.lstrip("/") if spec.path else "",
+        )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_auth_list_cutover.py::TestS3BackendRouting -xvs`
+Expected: all PASS
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/fs/_backend_factory.py src/nexus/bricks/auth/tests/test_auth_list_cutover.py
+git commit -m "feat(auth): route S3 auth through profile store with dual-path fallback (#3739)"
+```
+
+---
+
+## Task 9: Concurrency + offline safety tests
+
+**Files:**
+- Modify: `src/nexus/bricks/auth/tests/test_registry.py`
+
+- [ ] **Step 1: Add concurrency test**
+
+Append to `src/nexus/bricks/auth/tests/test_registry.py`:
+
+```python
+class TestConcurrency:
+    async def test_concurrent_list_during_upsert(self) -> None:
+        """Two readers + one writer — no torn reads, no crashes."""
+        from nexus.bricks.auth.external_sync.registry import AdapterRegistry
+
+        fast = _FastAdapter()
+        fast.sync_ttl_seconds = 0.1
+        store = InMemoryAuthProfileStore()
+        registry = AdapterRegistry(
+            adapters=[fast],
+            profile_store=store,
+            loop_tick_seconds=0.05,
+        )
+        await registry.startup()
+
+        read_results: list[list] = []
+        errors: list[Exception] = []
+
+        async def reader() -> None:
+            for _ in range(20):
+                try:
+                    profiles = store.list(provider="test")
+                    read_results.append(profiles)
+                except Exception as exc:
+                    errors.append(exc)
+                await asyncio.sleep(0.01)
+
+        async def writer() -> None:
+            loop_task = asyncio.create_task(registry.run_refresh_loop())
+            await asyncio.sleep(0.3)
+            loop_task.cancel()
+            try:
+                await loop_task
+            except asyncio.CancelledError:
+                pass
+
+        await asyncio.gather(reader(), reader(), writer())
+
+        assert not errors, f"Concurrent access errors: {errors}"
+        # All reads should return consistent snapshots
+        for profiles in read_results:
+            assert isinstance(profiles, list)
+
+
+class TestOfflineSafety:
+    async def test_file_adapter_returns_degraded_with_no_network(
+        self, no_network: None
+    ) -> None:
+        """FileAdapter must work offline (it reads local files, no network)."""
+        from nexus.bricks.auth.external_sync.file_adapter import FileAdapter
+
+        class _OfflineAdapter(FileAdapter):
+            adapter_name = "offline-test"
+
+            def paths(self) -> list[Path]:
+                return [Path("/nonexistent/file.conf")]
+
+            def parse_file(self, path: Path, content: str) -> list[SyncedProfile]:
+                return []
+
+            async def resolve_credential(self, backend_key: str) -> ResolvedCredential:
+                return ResolvedCredential(kind="api_key", api_key="key")
+
+        adapter = _OfflineAdapter()
+        t0 = time.monotonic()
+        result = await adapter.sync()
+        elapsed = time.monotonic() - t0
+
+        # Must complete within 2s even with network blocked
+        assert elapsed < 2.0
+        # Returns degraded (file not found), not a network error
+        assert result.error is not None
+
+    async def test_subprocess_adapter_returns_degraded_with_no_network(
+        self, no_network: None
+    ) -> None:
+        """SubprocessAdapter must handle missing binary gracefully offline."""
+        from nexus.bricks.auth.external_sync.subprocess_adapter import SubprocessAdapter
+
+        class _OfflineSubprocess(SubprocessAdapter):
+            adapter_name = "offline-subprocess"
+            binary_name = "nonexistent_cli_tool"
+
+            def get_status_args(self) -> tuple[str, ...]:
+                return ("status",)
+
+            def parse_output(self, stdout: str, stderr: str) -> list[SyncedProfile]:
+                return []
+
+            async def resolve_credential(self, backend_key: str) -> ResolvedCredential:
+                return ResolvedCredential(kind="api_key", api_key="key")
+
+        adapter = _OfflineSubprocess()
+        t0 = time.monotonic()
+        result = await adapter.sync()
+        elapsed = time.monotonic() - t0
+
+        assert elapsed < 2.0
+        assert result.error is not None
+```
+
+Also add the missing imports at the top:
+
+```python
+from pathlib import Path
+from nexus.bricks.auth.credential_backend import ResolvedCredential
+from nexus.bricks.auth.external_sync.base import SyncedProfile
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_registry.py -xvs -k "TestConcurrency or TestOfflineSafety"`
+Expected: all PASS (these test existing code, they should pass immediately)
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/nexus/bricks/auth/tests/test_registry.py
+git commit -m "test(auth): add concurrency + offline safety tests for external sync framework (#3739)"
+```
+
+---
+
+## Task 10: Nightly real-binary e2e test
+
+**Files:**
+- Create: `src/nexus/bricks/auth/tests/test_e2e_aws.py`
+
+- [ ] **Step 1: Write the gated e2e test**
+
+```python
+# src/nexus/bricks/auth/tests/test_e2e_aws.py
+"""Nightly end-to-end test with real AWS CLI.
+
+Gated by TEST_WITH_REAL_AWS_CLI=1 env var. Skipped in default CI.
+Creates a temp HOME, runs `aws configure` with dummy credentials,
+then asserts the full sync + auth list flow works.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import shutil
+
+import pytest
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("TEST_WITH_REAL_AWS_CLI"),
+    reason="Requires TEST_WITH_REAL_AWS_CLI=1 and aws CLI installed",
+)
+
+
+@pytest.fixture()
+def aws_home(tmp_path):
+    """Set up a temp HOME with AWS credentials configured."""
+    aws_dir = tmp_path / ".aws"
+    aws_dir.mkdir()
+
+    creds = aws_dir / "credentials"
+    creds.write_text(
+        "[default]\n"
+        "aws_access_key_id = AKIATESTEXAMPLE123456\n"
+        "aws_secret_access_key = testSecretKey1234567890ABCDEF\n"
+        "\n"
+        "[staging]\n"
+        "aws_access_key_id = AKIASTAGINGEXAMPLE789\n"
+        "aws_secret_access_key = stagingSecretKey123456789\n"
+    )
+
+    config = aws_dir / "config"
+    config.write_text(
+        "[default]\n"
+        "region = us-east-1\n"
+        "\n"
+        "[profile staging]\n"
+        "region = eu-west-1\n"
+    )
+
+    return tmp_path
+
+
+class TestRealAwsCli:
+    def test_aws_cli_is_installed(self) -> None:
+        assert shutil.which("aws") is not None, "aws CLI not found on PATH"
+
+    async def test_full_sync_and_list(self, aws_home, monkeypatch) -> None:
+        """End-to-end: discover AWS profiles → registry startup → check profiles."""
+        monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(aws_home / ".aws" / "credentials"))
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(aws_home / ".aws" / "config"))
+
+        from nexus.bricks.auth.external_sync.aws_sync import AwsCliSyncAdapter
+        from nexus.bricks.auth.external_sync.registry import AdapterRegistry
+        from nexus.bricks.auth.profile import InMemoryAuthProfileStore
+
+        store = InMemoryAuthProfileStore()
+        adapter = AwsCliSyncAdapter()
+        registry = AdapterRegistry(adapters=[adapter], profile_store=store)
+
+        results = await registry.startup()
+        assert results["aws-cli"].error is None
+
+        profiles = store.list(provider="s3")
+        names = {p.account_identifier for p in profiles}
+        assert "default" in names
+        assert "staging" in names
+
+        # Verify source is correct
+        for p in profiles:
+            assert p.backend == "external-cli"
+            assert p.backend_key.startswith("aws-cli/")
+
+    async def test_resolve_credential_from_file(self, aws_home, monkeypatch) -> None:
+        """End-to-end: resolve actual credential from AWS config file."""
+        monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(aws_home / ".aws" / "credentials"))
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(aws_home / ".aws" / "config"))
+
+        from nexus.bricks.auth.external_sync.aws_sync import AwsCliSyncAdapter
+
+        adapter = AwsCliSyncAdapter()
+        cred = await adapter.resolve_credential("aws-cli/default")
+
+        assert cred.kind == "api_key"
+        assert cred.api_key == "AKIATESTEXAMPLE123456"
+        assert cred.metadata["secret_access_key"] == "testSecretKey1234567890ABCDEF"
+```
+
+- [ ] **Step 2: Run test to verify it's skipped in default CI**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_e2e_aws.py -xvs`
+Expected: all tests SKIPPED with "Requires TEST_WITH_REAL_AWS_CLI=1"
+
+- [ ] **Step 3: Run test with env var to verify it passes (optional, only if aws CLI is installed)**
+
+Run: `TEST_WITH_REAL_AWS_CLI=1 pytest src/nexus/bricks/auth/tests/test_e2e_aws.py -xvs`
+Expected: PASS (if aws CLI is installed)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/nexus/bricks/auth/tests/test_e2e_aws.py
+git commit -m "test(auth): add nightly real-binary e2e test for AWS CLI sync (#3739)"
+```
+
+---
+
+## Task 11: Final `__init__.py` cleanup + full test suite run
+
+**Files:**
+- Verify: `src/nexus/bricks/auth/external_sync/__init__.py`
+
+- [ ] **Step 1: Verify `__init__.py` exports are complete**
+
+Final state of `src/nexus/bricks/auth/external_sync/__init__.py` should be:
+
+```python
+"""External CLI sync framework for discovering credentials managed by external tools."""
+
+from nexus.bricks.auth.external_sync.aws_sync import AwsCliSyncAdapter
+from nexus.bricks.auth.external_sync.base import (
+    ExternalCliSyncAdapter,
+    SyncedProfile,
+    SyncResult,
+)
+from nexus.bricks.auth.external_sync.external_cli_backend import ExternalCliBackend
+from nexus.bricks.auth.external_sync.file_adapter import FileAdapter
+from nexus.bricks.auth.external_sync.registry import AdapterRegistry, CircuitBreaker
+from nexus.bricks.auth.external_sync.subprocess_adapter import SubprocessAdapter
+
+__all__ = [
+    "AdapterRegistry",
+    "AwsCliSyncAdapter",
+    "CircuitBreaker",
+    "ExternalCliBackend",
+    "ExternalCliSyncAdapter",
+    "FileAdapter",
+    "SubprocessAdapter",
+    "SyncedProfile",
+    "SyncResult",
+]
+```
+
+- [ ] **Step 2: Run the full auth test suite**
+
+Run: `pytest src/nexus/bricks/auth/tests/ -xvs --strict-markers`
+Expected: all PASS. No regressions in existing tests.
+
+- [ ] **Step 3: Run mypy on the new module**
+
+Run: `mypy src/nexus/bricks/auth/external_sync/ --strict`
+Expected: PASS (or fix any type errors)
+
+- [ ] **Step 4: Run ruff on the new module**
+
+Run: `ruff check src/nexus/bricks/auth/external_sync/`
+Expected: PASS
+
+- [ ] **Step 5: Final commit if any cleanup was needed**
+
+```bash
+git add -u
+git commit -m "chore(auth): final cleanup for external sync framework (#3739)"
+```

--- a/docs/superpowers/specs/2026-04-15-external-cli-sync-design.md
+++ b/docs/superpowers/specs/2026-04-15-external-cli-sync-design.md
@@ -1,0 +1,342 @@
+# External-CLI Sync Framework + AWS Adapter (Phase 2 of #3722)
+
+Issue: #3739
+Epic: #3722
+Blocked by: #3738 (closed)
+
+## Overview
+
+Phase 2 lands the external-CLI sync framework, the first concrete adapter (aws-cli), and cuts `nexus-fs auth list` over to read from the unified profile store. Two distinct responsibilities are separated into two class hierarchies:
+
+1. **Sync adapters** — discover which accounts exist in external CLIs, upsert routing metadata into `AuthProfileStore`
+2. **Credential backend** — `ExternalCliBackend` implements `CredentialBackend`, resolves fresh credentials on demand by re-reading external sources
+
+This matches Phase 1's decision 1A: AuthProfile = routing metadata only, credential lives in pluggable backend.
+
+## Module Layout
+
+```
+src/nexus/bricks/auth/external_sync/
+├── __init__.py              # re-exports public API
+├── base.py                  # ExternalCliSyncAdapter ABC + SyncedProfile + SyncResult
+├── subprocess_adapter.py    # SubprocessAdapter(ExternalCliSyncAdapter)
+├── file_adapter.py          # FileAdapter(ExternalCliSyncAdapter)
+├── aws_sync.py              # AwsCliSyncAdapter(FileAdapter) — ~40 LOC
+├── external_cli_backend.py  # ExternalCliBackend(CredentialBackend) — ~80 LOC
+└── registry.py              # AdapterRegistry — startup, background loop, circuit breaker
+```
+
+## Adapter ABC Hierarchy
+
+### `base.py` — `ExternalCliSyncAdapter`
+
+```python
+@dataclass(frozen=True, slots=True)
+class SyncedProfile:
+    """One discovered account from an external CLI."""
+    provider: str              # e.g. "s3"
+    account_identifier: str    # e.g. "default", "work-prod"
+    backend_key: str           # opaque key for ExternalCliBackend.resolve()
+    source: str                # e.g. "aws-cli"
+
+@dataclass
+class SyncResult:
+    """Output of a single adapter sync."""
+    adapter_name: str
+    profiles: list[SyncedProfile]
+    error: str | None = None   # non-None means degraded
+
+class ExternalCliSyncAdapter(ABC):
+    # Class-level configurables (override in subclass)
+    adapter_name: str                    # e.g. "aws-cli"
+    sync_ttl_seconds: float = 60.0       # default for FileAdapter
+    failure_threshold: int = 3           # circuit breaker trips after N consecutive failures
+    reset_timeout_seconds: float = 60.0  # half-open probe after this duration
+
+    @abstractmethod
+    async def sync(self) -> SyncResult: ...
+
+    @abstractmethod
+    async def detect(self) -> bool: ...
+
+    @abstractmethod
+    async def resolve_credential(self, backend_key: str) -> ResolvedCredential:
+        """Fresh-read a credential for the given backend_key.
+
+        Called by ExternalCliBackend.resolve(). Re-reads the source
+        (file or subprocess) and extracts the actual secret for one profile.
+        """
+        ...
+```
+
+### `subprocess_adapter.py` — `SubprocessAdapter`
+
+Concrete base for CLIs that need `asyncio.create_subprocess_exec`. Subclasses declare descriptors only.
+
+```python
+class SubprocessAdapter(ExternalCliSyncAdapter):
+    binary_name: str               # e.g. "gcloud"
+    status_args: tuple[str, ...]   # e.g. ("auth", "list", "--format=json")
+    sync_ttl_seconds: float = 300.0  # subprocess = expensive, longer TTL
+```
+
+Base class handles:
+- `detect()` — `shutil.which(binary_name)`
+- `sync()` — `asyncio.create_subprocess_exec`, `asyncio.wait_for(5.0)`, stderr capture
+- Failure classification into `AuthProfileFailureReason` (UPSTREAM_CLI_MISSING, TIMEOUT, AUTH, UNKNOWN)
+- Exponential backoff retry: 3 attempts with 1s/2s/4s delays
+- Subclass implements only `parse_output(stdout, stderr) -> list[SyncedProfile]`
+
+### `file_adapter.py` — `FileAdapter`
+
+Concrete base for CLIs with parseable config files.
+
+```python
+class FileAdapter(ExternalCliSyncAdapter):
+    sync_ttl_seconds: float = 60.0  # file read = cheap, shorter TTL
+```
+
+Base class handles:
+- `detect()` — any path from `paths()` exists
+- `sync()` — read files in priority order, call `parse_file()`, aggregate results
+- Error handling: missing file, unreadable perms, empty file, symlink loop — all classified as degraded (not exceptions)
+- Subclass implements only `paths() -> list[Path]` and `parse_file(path, content) -> list[SyncedProfile]`
+
+## AWS Adapter
+
+### `aws_sync.py` — `AwsCliSyncAdapter(FileAdapter)`
+
+~40 LOC descriptor-only subclass.
+
+```python
+class AwsCliSyncAdapter(FileAdapter):
+    adapter_name = "aws-cli"
+```
+
+Behaviors:
+- `paths()` returns `~/.aws/credentials` and `~/.aws/config` (respects `AWS_SHARED_CREDENTIALS_FILE`, `AWS_CONFIG_FILE` env vars)
+- `parse_file()` uses `configparser` on INI format
+  - `~/.aws/credentials`: section names are profile names directly
+  - `~/.aws/config`: section names are `profile <name>` (except `[default]`)
+  - Returns one `SyncedProfile` per section containing `aws_access_key_id`
+  - `backend_key` format: `"aws-cli/{profile_name}"`
+- Merges profiles from both files (credentials takes precedence on conflict)
+- Respects `AWS_PROFILE` env var for marking active profile
+- Tolerates unknown INI keys (forward-compatible)
+- Sections missing `aws_access_key_id` are skipped silently
+
+## ExternalCliBackend
+
+### `external_cli_backend.py` — `ExternalCliBackend(CredentialBackend)`
+
+~80 LOC. Implements the `CredentialBackend` protocol from `credential_backend.py`.
+
+```python
+class ExternalCliBackend:
+    _NAME = "external-cli"
+
+    def __init__(self, registry: AdapterRegistry) -> None: ...
+
+    async def resolve(self, backend_key: str) -> ResolvedCredential:
+        # Parse: "aws-cli/default" → adapter_name="aws-cli", profile="default"
+        # Get adapter from registry
+        # FileAdapter: re-read + re-parse the file, extract credential for this profile
+        # SubprocessAdapter: re-run the command, extract credential
+        # Returns ResolvedCredential(kind="api_key", api_key=access_key, metadata={"secret_key": ...})
+
+    async def health_check(self, backend_key: str) -> BackendHealth:
+        # Non-destructive: check file/binary exists and profile section present
+```
+
+Key property: `resolve()` does a **fresh read** every call. No caching. The external credential file could change between calls (user runs `aws configure`, SSO token refresh). Matches the AWS `credential_process` contract.
+
+Note: both `sync()` (on the adapter) and `resolve()` (on the backend) read the same files, but for different purposes. `sync()` extracts profile metadata (which accounts exist). `resolve()` extracts the actual credential (access key + secret key) for a specific profile. The adapter's `parse_file()` returns `SyncedProfile` (metadata); the backend's `resolve()` returns `ResolvedCredential` (secret). The adapter needs a second method — `resolve_credential(backend_key) -> ResolvedCredential` — that the backend delegates to. This keeps the fresh-read logic in the adapter (which knows the file format) while the backend stays format-agnostic.
+
+## Registry
+
+### `registry.py` — `AdapterRegistry`
+
+~200 LOC. Manages adapter lifecycle, startup sync, and background refresh.
+
+#### Circuit Breaker
+
+```python
+@dataclass
+class CircuitBreaker:
+    failure_count: int = 0
+    tripped_at: float | None = None        # time.monotonic() timestamp
+    failure_threshold: int = 3
+    reset_timeout_seconds: float = 60.0
+
+    @property
+    def is_tripped(self) -> bool: ...      # tripped and not past reset_timeout
+
+    @property
+    def is_half_open(self) -> bool: ...    # tripped but past reset_timeout (allow probe)
+
+    def record_success(self) -> None: ...  # reset to clean state
+    def record_failure(self) -> None: ...  # increment, trip if threshold reached
+```
+
+Per-adapter circuit breaker. Configurable via adapter's `failure_threshold` and `reset_timeout_seconds` class attributes.
+
+#### Startup (decision 15A)
+
+```python
+async def startup(self) -> dict[str, SyncResult]:
+```
+
+- All adapters run `detect()` + `sync()` concurrently via `asyncio.gather(return_exceptions=True)`
+- Wrapped in `asyncio.wait_for(startup_timeout)` (default 3.0s)
+- Adapters that miss the timeout get `SyncResult(error="timeout")`, marked "not yet synced"
+- Successful results upserted into `AuthProfileStore` immediately
+- Startup is bounded by the slowest adapter, not the sum
+
+#### Background Refresh Loop
+
+```python
+async def run_refresh_loop(self) -> None:
+```
+
+Runs forever (cancel via `task.cancel()`). Every 30s tick:
+1. Iterate registered adapters
+2. Skip if circuit breaker is tripped (not half-open)
+3. Skip if `last_synced_at + sync_ttl_seconds > now` (not stale)
+4. Run `sync()`, upsert results into `AuthProfileStore`
+5. On success: circuit breaker `record_success()`
+6. On failure: circuit breaker `record_failure()`
+7. If half-open probe fails: re-trip
+
+#### Store Integration
+
+`_upsert_sync_results()` maps `SyncedProfile` → `AuthProfile`:
+- `backend = "external-cli"`
+- `backend_key = "{adapter_name}/{account_identifier}"`
+- `last_synced_at = now`
+- `sync_ttl_seconds = adapter.sync_ttl_seconds`
+
+Profiles in the store but NOT in the latest sync result are **kept** (not deleted). Prevents flapping when a config file is temporarily being edited. Stale profiles age out via `sync_ttl_seconds` expiry.
+
+## `nexus-fs auth list` Cutover
+
+Dual-read strategy: profile store primary, old `UnifiedAuthService` fallback.
+
+```python
+@auth.command("list")
+def list_auth(output_opts: OutputOptions) -> None:
+    profiles = _try_profile_store_list()
+
+    if profiles is not None:
+        # New table: Provider | Account | Source | Status | Last used
+        ...
+        return
+
+    # Fallback: old UnifiedAuthService.list_summaries() path
+    service = _build_auth_service()
+    summaries = asyncio.run(service.list_summaries())
+    # ... existing rendering unchanged ...
+```
+
+`_try_profile_store_list()`:
+- Instantiates `SqliteAuthProfileStore` with standard DB path
+- Returns `store.list()` if DB exists and has rows
+- Returns `None` on any of: DB file doesn't exist, `store.list()` returns empty list, `ImportError` for `nexus.bricks.auth` (slim wheel), or any other exception → triggers fallback
+- Lazy imports for slim `nexus-fs` compatibility
+
+New table format:
+```
+Provider       Account                   Source       Status     Last used
+s3             default                   aws-cli      ok         14m ago
+s3             work-prod                 aws-cli      cooldown   rate_limit · 43m left
+openai         team                      nexus        ok         2m ago
+```
+
+Status values: `ok`, `cooldown · {reason} · {time_left}`, `expired`, `disabled`, `not yet synced`
+
+## S3 Backend Routing
+
+Dual-path in `_backend_factory.py`:
+
+```python
+if spec.scheme == "s3":
+    profile = _try_profile_store_select(provider="s3")
+    if profile is not None:
+        backend = _build_external_cli_backend()
+        cred = asyncio.run(backend.resolve(profile.backend_key))
+        return PathS3Backend(
+            bucket_name=spec.authority,
+            prefix=...,
+            aws_access_key_id=cred.api_key,
+            aws_secret_access_key=cred.metadata.get("secret_key"),
+        )
+
+    # Fallback: old discover_credentials() path
+    discover_credentials(spec.scheme)
+    return PathS3Backend(bucket_name=spec.authority, prefix=...)
+```
+
+- Old path untouched, wrapped in `else` branch
+- No behavior change for users without populated profile store
+- `PathS3Backend` may need minor change to accept explicit credential kwargs
+- Old path removed in Phase 3/4
+
+## Test Plan
+
+### Base class tests via synthetic adapters
+
+**SubprocessAdapter:**
+- Hang timeout: subprocess sleeps 30s, `wait_for(5.0)` fires → degraded
+- Stderr capture: subprocess writes stderr → captured in `SyncResult.error`
+- Failure classification for each applicable `AuthProfileFailureReason`
+- Exponential backoff: mock fails 2x then succeeds → 3 calls, 1s/2s gaps
+- Circuit breaker trip: fail `failure_threshold` times → next `sync()` short-circuits
+
+**FileAdapter:**
+- Missing file → degraded, not exception
+- Unreadable permissions → degraded with error message
+- Empty file → empty profiles (not error)
+- Malformed content → degraded with parse error
+- Symlink loop → degraded (OSError caught)
+
+### AWS adapter tests
+
+**Fixtures:**
+- `tests/fixtures/external_cli_output/aws_credentials_v2.15.ini` — standard format, multiple profiles
+- `tests/fixtures/external_cli_output/aws_credentials_v2.16.ini` — newer format, SSO entries, session tokens
+
+**Tests:**
+- Parse every fixture → correct profiles extracted
+- Merge credentials + config (credentials wins)
+- `AWS_PROFILE` env var respected
+- Unknown INI keys tolerated
+- Section missing `aws_access_key_id` → skipped
+
+### Registry integration tests
+
+- **Startup timeout:** 5 mock adapters, 4 return ~50ms, 1 hangs 30s → gather returns 4 ok + 1 degraded within ~3.1s
+- **Background loop:** mock adapter with 60s TTL, 30s tick → sync called only after TTL expiry
+- **Circuit breaker:** fail N times → tripped → skip for reset_timeout → half-open → success resets
+
+### Concurrency test
+
+Two coroutines hit `profile_store.list(provider="s3")` while background loop upserts → no torn reads, no double-refresh. Uses `asyncio.Event` barriers.
+
+### Offline safety (decision 12A)
+
+`no_network` fixture on all external_sync tests. Every adapter returns degraded-but-useful within 2s with network blocked.
+
+### Nightly real-binary e2e (decision 10A)
+
+Gated by `TEST_WITH_REAL_AWS_CLI=1`:
+- Temp HOME, `aws configure` with dummy creds
+- Full stack: `AwsCliSyncAdapter` → `AdapterRegistry` → startup → `nexus-fs auth list`
+- Assert AWS profile shows with `Source: aws-cli`, no auth-connect ceremony
+- Skipped in default CI
+
+## Non-goals (deferred)
+
+- gcloud/gh/gws/codex adapters (Phase 3)
+- `nexus auth list` cutover (Phase 4, with CLI unification)
+- `auth doctor` overhaul (Phase 4)
+- `--finalize` migration command (Phase 4)
+- Deletion of old `discover_credentials()` path (Phase 3/4)

--- a/src/nexus/bricks/auth/external_sync/__init__.py
+++ b/src/nexus/bricks/auth/external_sync/__init__.py
@@ -5,10 +5,12 @@ from nexus.bricks.auth.external_sync.base import (
     SyncedProfile,
     SyncResult,
 )
+from nexus.bricks.auth.external_sync.file_adapter import FileAdapter
 from nexus.bricks.auth.external_sync.subprocess_adapter import SubprocessAdapter
 
 __all__ = [
     "ExternalCliSyncAdapter",
+    "FileAdapter",
     "SubprocessAdapter",
     "SyncedProfile",
     "SyncResult",

--- a/src/nexus/bricks/auth/external_sync/__init__.py
+++ b/src/nexus/bricks/auth/external_sync/__init__.py
@@ -6,6 +6,7 @@ from nexus.bricks.auth.external_sync.base import (
     SyncedProfile,
     SyncResult,
 )
+from nexus.bricks.auth.external_sync.external_cli_backend import ExternalCliBackend
 from nexus.bricks.auth.external_sync.file_adapter import FileAdapter
 from nexus.bricks.auth.external_sync.registry import AdapterRegistry, CircuitBreaker
 from nexus.bricks.auth.external_sync.subprocess_adapter import SubprocessAdapter
@@ -14,6 +15,7 @@ __all__ = [
     "AdapterRegistry",
     "AwsCliSyncAdapter",
     "CircuitBreaker",
+    "ExternalCliBackend",
     "ExternalCliSyncAdapter",
     "FileAdapter",
     "SubprocessAdapter",

--- a/src/nexus/bricks/auth/external_sync/__init__.py
+++ b/src/nexus/bricks/auth/external_sync/__init__.py
@@ -7,10 +7,13 @@ from nexus.bricks.auth.external_sync.base import (
     SyncResult,
 )
 from nexus.bricks.auth.external_sync.file_adapter import FileAdapter
+from nexus.bricks.auth.external_sync.registry import AdapterRegistry, CircuitBreaker
 from nexus.bricks.auth.external_sync.subprocess_adapter import SubprocessAdapter
 
 __all__ = [
+    "AdapterRegistry",
     "AwsCliSyncAdapter",
+    "CircuitBreaker",
     "ExternalCliSyncAdapter",
     "FileAdapter",
     "SubprocessAdapter",

--- a/src/nexus/bricks/auth/external_sync/__init__.py
+++ b/src/nexus/bricks/auth/external_sync/__init__.py
@@ -1,0 +1,13 @@
+"""External CLI sync framework for discovering credentials managed by external tools."""
+
+from nexus.bricks.auth.external_sync.base import (
+    ExternalCliSyncAdapter,
+    SyncedProfile,
+    SyncResult,
+)
+
+__all__ = [
+    "ExternalCliSyncAdapter",
+    "SyncedProfile",
+    "SyncResult",
+]

--- a/src/nexus/bricks/auth/external_sync/__init__.py
+++ b/src/nexus/bricks/auth/external_sync/__init__.py
@@ -1,5 +1,6 @@
 """External CLI sync framework for discovering credentials managed by external tools."""
 
+from nexus.bricks.auth.external_sync.aws_sync import AwsCliSyncAdapter
 from nexus.bricks.auth.external_sync.base import (
     ExternalCliSyncAdapter,
     SyncedProfile,
@@ -9,6 +10,7 @@ from nexus.bricks.auth.external_sync.file_adapter import FileAdapter
 from nexus.bricks.auth.external_sync.subprocess_adapter import SubprocessAdapter
 
 __all__ = [
+    "AwsCliSyncAdapter",
     "ExternalCliSyncAdapter",
     "FileAdapter",
     "SubprocessAdapter",

--- a/src/nexus/bricks/auth/external_sync/__init__.py
+++ b/src/nexus/bricks/auth/external_sync/__init__.py
@@ -5,9 +5,11 @@ from nexus.bricks.auth.external_sync.base import (
     SyncedProfile,
     SyncResult,
 )
+from nexus.bricks.auth.external_sync.subprocess_adapter import SubprocessAdapter
 
 __all__ = [
     "ExternalCliSyncAdapter",
+    "SubprocessAdapter",
     "SyncedProfile",
     "SyncResult",
 ]

--- a/src/nexus/bricks/auth/external_sync/aws_sync.py
+++ b/src/nexus/bricks/auth/external_sync/aws_sync.py
@@ -1,7 +1,12 @@
 """AWS CLI sync adapter — discovers profiles from ~/.aws/credentials + config.
 
-FileAdapter subclass. ~40 LOC of descriptor logic. All I/O, error handling,
-and retry logic lives in the FileAdapter base class.
+FileAdapter subclass. All I/O, error handling, and retry logic lives in the
+FileAdapter base class.
+
+Phase 2 limitation: only discovers profiles with inline ``aws_access_key_id``.
+Profiles defined by ``role_arn``, ``source_profile``, ``credential_process``,
+or SSO fields in ``~/.aws/config`` are not yet discovered. These config-only
+profile types are planned for Phase 3 alongside gcloud/gh adapters.
 """
 
 from __future__ import annotations

--- a/src/nexus/bricks/auth/external_sync/aws_sync.py
+++ b/src/nexus/bricks/auth/external_sync/aws_sync.py
@@ -1,0 +1,88 @@
+"""AWS CLI sync adapter — discovers profiles from ~/.aws/credentials + config.
+
+FileAdapter subclass. ~40 LOC of descriptor logic. All I/O, error handling,
+and retry logic lives in the FileAdapter base class.
+"""
+
+from __future__ import annotations
+
+import configparser
+import os
+from pathlib import Path
+
+from nexus.bricks.auth.credential_backend import ResolvedCredential
+from nexus.bricks.auth.external_sync.base import SyncedProfile
+from nexus.bricks.auth.external_sync.file_adapter import FileAdapter
+
+
+class AwsCliSyncAdapter(FileAdapter):
+    """Discovers AWS profiles from credentials/config files."""
+
+    adapter_name = "aws-cli"
+
+    def paths(self) -> list[Path]:
+        return [
+            Path(os.environ.get("AWS_SHARED_CREDENTIALS_FILE", "~/.aws/credentials")).expanduser(),
+            Path(os.environ.get("AWS_CONFIG_FILE", "~/.aws/config")).expanduser(),
+        ]
+
+    def parse_file(self, _path: Path, content: str) -> list[SyncedProfile]:
+        parser = configparser.ConfigParser()
+        parser.read_string(content)
+
+        profiles: list[SyncedProfile] = []
+        for section in parser.sections():
+            if not parser.has_option(section, "aws_access_key_id"):
+                continue
+
+            # ~/.aws/config uses "profile <name>" sections (except [default])
+            name = section
+            if name.startswith("profile "):
+                name = name[len("profile ") :]
+
+            profiles.append(
+                SyncedProfile(
+                    provider="s3",
+                    account_identifier=name,
+                    backend_key=f"aws-cli/{name}",
+                    source="aws-cli",
+                )
+            )
+
+        return profiles
+
+    async def resolve_credential(self, backend_key: str) -> ResolvedCredential:
+        """Re-read AWS config files and extract credential for one profile."""
+        _, profile_name = backend_key.split("/", 1)
+
+        for path in self.paths():
+            try:
+                content = path.read_text(encoding="utf-8")
+            except OSError:
+                continue
+
+            parser = configparser.ConfigParser()
+            parser.read_string(content)
+
+            # Try exact section name, then "profile <name>" variant
+            for section in [profile_name, f"profile {profile_name}"]:
+                if parser.has_section(section) and parser.has_option(section, "aws_access_key_id"):
+                    return ResolvedCredential(
+                        kind="api_key",
+                        api_key=parser.get(section, "aws_access_key_id"),
+                        metadata={
+                            "secret_access_key": parser.get(
+                                section, "aws_secret_access_key", fallback=""
+                            ),
+                            "session_token": parser.get(section, "aws_session_token", fallback=""),
+                            "region": parser.get(section, "region", fallback=""),
+                        },
+                    )
+
+        from nexus.bricks.auth.credential_backend import CredentialResolutionError
+
+        raise CredentialResolutionError(
+            "external-cli",
+            backend_key,
+            f"AWS profile '{profile_name}' not found in config files",
+        )

--- a/src/nexus/bricks/auth/external_sync/base.py
+++ b/src/nexus/bricks/auth/external_sync/base.py
@@ -1,0 +1,74 @@
+"""Abstract base for external CLI sync adapters.
+
+Sync adapters discover which accounts exist in external CLIs (aws, gcloud, gh)
+and produce SyncedProfile metadata. They do NOT resolve actual credentials —
+that is ExternalCliBackend's job (external_cli_backend.py).
+
+Each concrete adapter is a thin descriptor subclass of either FileAdapter
+(for CLIs with parseable config files) or SubprocessAdapter (for CLIs
+that require shell-out). The base classes own all I/O, timeout, retry,
+and error-classification logic.
+"""
+
+from __future__ import annotations
+
+from abc import ABC, abstractmethod
+from dataclasses import dataclass, field
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nexus.bricks.auth.credential_backend import ResolvedCredential
+
+
+@dataclass(frozen=True, slots=True)
+class SyncedProfile:
+    """One discovered account from an external CLI.
+
+    This is metadata only — no secrets. Maps to an AuthProfile in the store
+    with backend="external-cli".
+    """
+
+    provider: str  # e.g. "s3"
+    account_identifier: str  # e.g. "default", "work-prod"
+    backend_key: str  # e.g. "aws-cli/default" — opaque to the store
+    source: str  # e.g. "aws-cli" — displayed in `auth list` Source column
+
+
+@dataclass
+class SyncResult:
+    """Output of a single adapter sync() call."""
+
+    adapter_name: str
+    profiles: list[SyncedProfile] = field(default_factory=list)
+    error: str | None = None  # non-None means degraded
+
+
+class ExternalCliSyncAdapter(ABC):
+    """Abstract base for external CLI sync adapters.
+
+    Subclass either FileAdapter or SubprocessAdapter, not this directly.
+    """
+
+    adapter_name: str  # e.g. "aws-cli", "gcloud"
+    sync_ttl_seconds: float = 60.0
+    failure_threshold: int = 3
+    reset_timeout_seconds: float = 60.0
+
+    @abstractmethod
+    async def sync(self) -> SyncResult:
+        """Discover all accounts from this external CLI."""
+        ...
+
+    @abstractmethod
+    async def detect(self) -> bool:
+        """Quick check: is this CLI / config available on the system?"""
+        ...
+
+    @abstractmethod
+    async def resolve_credential(self, backend_key: str) -> ResolvedCredential:
+        """Fresh-read a credential for the given backend_key.
+
+        Called by ExternalCliBackend.resolve(). Re-reads the source
+        (file or subprocess) and extracts the actual secret for one profile.
+        """
+        ...

--- a/src/nexus/bricks/auth/external_sync/external_cli_backend.py
+++ b/src/nexus/bricks/auth/external_sync/external_cli_backend.py
@@ -1,0 +1,69 @@
+"""ExternalCliBackend — CredentialBackend for external CLI credentials.
+
+Implements the CredentialBackend protocol. resolve() delegates to the
+appropriate adapter's resolve_credential() for a fresh read. Never
+persists external credentials on nexus-side disk.
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+from nexus.bricks.auth.credential_backend import (
+    BackendHealth,
+    CredentialResolutionError,
+    HealthStatus,
+    ResolvedCredential,
+)
+from nexus.bricks.auth.external_sync.registry import AdapterRegistry
+
+
+class ExternalCliBackend:
+    """CredentialBackend for external-CLI-managed credentials."""
+
+    _NAME = "external-cli"
+
+    def __init__(self, registry: AdapterRegistry) -> None:
+        self._registry = registry
+
+    @property
+    def name(self) -> str:
+        return self._NAME
+
+    async def resolve(self, backend_key: str) -> ResolvedCredential:
+        """Parse adapter_name from key, delegate to adapter.resolve_credential()."""
+        adapter_name, _ = self._parse_key(backend_key)
+        adapter = self._registry.get_adapter(adapter_name)
+        if adapter is None:
+            raise CredentialResolutionError(
+                self._NAME, backend_key, f"no adapter registered for '{adapter_name}'"
+            )
+        return await adapter.resolve_credential(backend_key)
+
+    async def health_check(self, backend_key: str) -> BackendHealth:
+        """Non-destructive: try resolve, report healthy/unhealthy."""
+        now = datetime.now(UTC)
+        try:
+            await self.resolve(backend_key)
+            return BackendHealth(
+                status=HealthStatus.HEALTHY,
+                message="Credential resolved successfully",
+                checked_at=now,
+            )
+        except Exception as exc:
+            return BackendHealth(
+                status=HealthStatus.UNHEALTHY,
+                message=str(exc),
+                checked_at=now,
+            )
+
+    @staticmethod
+    def _parse_key(backend_key: str) -> tuple[str, str]:
+        parts = backend_key.split("/", 1)
+        if len(parts) < 2:
+            raise CredentialResolutionError(
+                ExternalCliBackend._NAME,
+                backend_key,
+                f"expected 'adapter_name/profile', got {backend_key!r}",
+            )
+        return parts[0], parts[1]

--- a/src/nexus/bricks/auth/external_sync/file_adapter.py
+++ b/src/nexus/bricks/auth/external_sync/file_adapter.py
@@ -1,0 +1,107 @@
+"""FileAdapter — base class for external CLIs with parseable config files.
+
+Subclasses declare which files to read and how to parse them. The base
+class handles all I/O: detect (file exists), sync (read + parse + classify
+errors), and graceful degradation on missing/unreadable/malformed files.
+"""
+
+from __future__ import annotations
+
+import logging
+from abc import abstractmethod
+from pathlib import Path
+
+from nexus.bricks.auth.external_sync.base import (
+    ExternalCliSyncAdapter,
+    SyncedProfile,
+    SyncResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class FileAdapter(ExternalCliSyncAdapter):
+    """Base class for config-file-based sync adapters.
+
+    Subclasses implement paths() and parse_file() only.
+    """
+
+    sync_ttl_seconds: float = 60.0  # file reads are cheap
+
+    @abstractmethod
+    def paths(self) -> list[Path]:
+        """Config file paths to read, in priority order."""
+        ...
+
+    @abstractmethod
+    def parse_file(self, path: Path, content: str) -> list[SyncedProfile]:
+        """Parse a config file into discovered profiles.
+
+        Raise ValueError or similar on malformed content — the base class
+        catches it and returns a degraded SyncResult.
+        """
+        ...
+
+    async def detect(self) -> bool:
+        """Return True if any config file from paths() exists and is readable."""
+        for p in self.paths():
+            try:
+                if p.exists() and p.is_file():
+                    return True
+            except OSError:
+                continue
+        return False
+
+    async def sync(self) -> SyncResult:
+        """Read config files and parse profiles.
+
+        Reads files in priority order from paths(). Aggregates all
+        discovered profiles. Returns degraded SyncResult on I/O or
+        parse errors rather than raising.
+        """
+        readable_paths = self.paths()
+        if not readable_paths:
+            return SyncResult(
+                adapter_name=self.adapter_name,
+                error="No config file paths configured",
+            )
+
+        all_profiles: list[SyncedProfile] = []
+        errors: list[str] = []
+        any_read = False
+
+        for path in readable_paths:
+            try:
+                content = path.read_text(encoding="utf-8")
+                any_read = True
+            except FileNotFoundError:
+                continue
+            except PermissionError as exc:
+                errors.append(f"{path}: permission denied ({exc})")
+                continue
+            except OSError as exc:
+                errors.append(f"{path}: {exc}")
+                continue
+
+            if not content.strip():
+                continue
+
+            try:
+                profiles = self.parse_file(path, content)
+                all_profiles.extend(profiles)
+            except Exception as exc:
+                errors.append(f"{path}: parse error: {exc}")
+
+        if not any_read and not all_profiles:
+            paths_str = ", ".join(str(p) for p in readable_paths)
+            return SyncResult(
+                adapter_name=self.adapter_name,
+                error=f"No readable config files found ({paths_str})",
+            )
+
+        error_msg = "; ".join(errors) if errors else None
+        return SyncResult(
+            adapter_name=self.adapter_name,
+            profiles=all_profiles,
+            error=error_msg,
+        )

--- a/src/nexus/bricks/auth/external_sync/file_adapter.py
+++ b/src/nexus/bricks/auth/external_sync/file_adapter.py
@@ -67,6 +67,7 @@ class FileAdapter(ExternalCliSyncAdapter):
             )
 
         all_profiles: list[SyncedProfile] = []
+        seen_keys: set[str] = set()
         errors: list[str] = []
         any_read = False
 
@@ -88,7 +89,12 @@ class FileAdapter(ExternalCliSyncAdapter):
 
             try:
                 profiles = self.parse_file(path, content)
-                all_profiles.extend(profiles)
+                # Deduplicate by backend_key: first file wins (paths are
+                # in priority order, e.g. credentials before config).
+                for p in profiles:
+                    if p.backend_key not in seen_keys:
+                        seen_keys.add(p.backend_key)
+                        all_profiles.append(p)
             except Exception as exc:
                 errors.append(f"{path}: parse error: {exc}")
 

--- a/src/nexus/bricks/auth/external_sync/registry.py
+++ b/src/nexus/bricks/auth/external_sync/registry.py
@@ -1,0 +1,254 @@
+"""AdapterRegistry — lifecycle, startup sync, and background refresh for external CLI adapters.
+
+Manages a set of ExternalCliSyncAdapter instances with per-adapter circuit
+breakers. Provides:
+  - startup(): concurrent detect+sync with global timeout
+  - run_refresh_loop(): background refresh respecting TTL and breaker state
+  - CircuitBreaker: dataclass tracking failures and half-open recovery
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+
+from nexus.bricks.auth.external_sync.base import (
+    ExternalCliSyncAdapter,
+    SyncResult,
+)
+from nexus.bricks.auth.profile import (
+    AuthProfile,
+    AuthProfileStore,
+    ProfileUsageStats,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Circuit breaker (per-adapter)
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class CircuitBreaker:
+    """Per-adapter circuit breaker with failure counting and half-open recovery.
+
+    States:
+      - Closed: failure_count < failure_threshold (normal operation)
+      - Open (tripped): failure_count >= threshold AND reset timeout NOT elapsed
+      - Half-open: tripped AND reset timeout elapsed (allow one probe)
+    """
+
+    failure_threshold: int = 3
+    reset_timeout_seconds: float = 60.0
+    failure_count: int = field(default=0, init=False)
+    tripped_at: float | None = field(default=None, init=False)  # time.monotonic()
+
+    @property
+    def is_tripped(self) -> bool:
+        """True if open and reset timeout NOT elapsed."""
+        if self.tripped_at is None:
+            return False
+        return (time.monotonic() - self.tripped_at) < self.reset_timeout_seconds
+
+    @property
+    def is_half_open(self) -> bool:
+        """True if tripped but reset timeout elapsed (allow probe)."""
+        if self.tripped_at is None:
+            return False
+        return (time.monotonic() - self.tripped_at) >= self.reset_timeout_seconds
+
+    def record_success(self) -> None:
+        self.failure_count = 0
+        self.tripped_at = None
+
+    def record_failure(self) -> None:
+        self.failure_count += 1
+        if self.failure_count >= self.failure_threshold:
+            self.tripped_at = time.monotonic()
+
+
+# ---------------------------------------------------------------------------
+# Adapter registry
+# ---------------------------------------------------------------------------
+
+
+class AdapterRegistry:
+    """Manages adapter lifecycle, startup sync, and background refresh.
+
+    Each adapter gets its own CircuitBreaker. The registry handles:
+      - Concurrent startup with a global timeout
+      - Background refresh loop respecting TTL and breaker state
+      - Upserting sync results into the AuthProfileStore
+    """
+
+    def __init__(
+        self,
+        adapters: list[ExternalCliSyncAdapter],
+        profile_store: AuthProfileStore,
+        *,
+        startup_timeout: float = 3.0,
+        loop_tick_seconds: float = 30.0,
+    ) -> None:
+        self._adapters: dict[str, ExternalCliSyncAdapter] = {a.adapter_name: a for a in adapters}
+        self._store = profile_store
+        self._startup_timeout = startup_timeout
+        self._loop_tick_seconds = loop_tick_seconds
+        self._breakers: dict[str, CircuitBreaker] = {
+            a.adapter_name: CircuitBreaker(
+                failure_threshold=a.failure_threshold,
+                reset_timeout_seconds=a.reset_timeout_seconds,
+            )
+            for a in adapters
+        }
+        self._last_sync_times: dict[str, float] = {}
+
+    def get_adapter(self, adapter_name: str) -> ExternalCliSyncAdapter | None:
+        """Return the adapter for the given name, or None."""
+        return self._adapters.get(adapter_name)
+
+    # ------------------------------------------------------------------
+    # Startup
+    # ------------------------------------------------------------------
+
+    async def startup(self) -> dict[str, SyncResult]:
+        """Concurrent detect+sync for all adapters with a global timeout.
+
+        Decision 15A: asyncio.gather + global timeout. Adapters that miss the
+        timeout get SyncResult(error="timeout"). Successful results are
+        upserted into the store immediately.
+        """
+        results: dict[str, SyncResult] = {}
+
+        async def _detect_and_sync(name: str, adapter: ExternalCliSyncAdapter) -> SyncResult:
+            detected = await adapter.detect()
+            if not detected:
+                return SyncResult(adapter_name=name, error="not detected")
+            return await adapter.sync()
+
+        tasks = {
+            name: asyncio.create_task(_detect_and_sync(name, adapter))
+            for name, adapter in self._adapters.items()
+        }
+
+        if tasks:
+            # Use asyncio.wait with a timeout — it never cancels tasks itself,
+            # so we can inspect each one individually afterwards.
+            done, pending = await asyncio.wait(
+                tasks.values(),
+                timeout=self._startup_timeout,
+            )
+
+            # Cancel tasks that didn't finish in time
+            for task in pending:
+                task.cancel()
+            # Suppress CancelledError from cancelled tasks
+            if pending:
+                await asyncio.gather(*pending, return_exceptions=True)
+
+        for name, task in tasks.items():
+            breaker = self._breakers[name]
+            if task.done() and not task.cancelled():
+                exc = task.exception()
+                if exc is not None:
+                    result = SyncResult(adapter_name=name, error=str(exc))
+                    breaker.record_failure()
+                else:
+                    result = task.result()
+                    if result.error is not None:
+                        breaker.record_failure()
+                    else:
+                        breaker.record_success()
+                        self._upsert_sync_results(result)
+                        self._last_sync_times[name] = time.monotonic()
+            else:
+                if not task.done():
+                    task.cancel()
+                result = SyncResult(adapter_name=name, error="timeout")
+                breaker.record_failure()
+            results[name] = result
+
+        return results
+
+    # ------------------------------------------------------------------
+    # Background refresh loop
+    # ------------------------------------------------------------------
+
+    async def run_refresh_loop(self) -> None:
+        """Background refresh loop. Cancel via task.cancel().
+
+        Every loop_tick_seconds:
+          1. Skip tripped (not half-open) breakers
+          2. Skip adapters not past TTL
+          3. Sync, upsert, update breaker
+        """
+        while True:
+            await asyncio.sleep(self._loop_tick_seconds)
+            for name, adapter in self._adapters.items():
+                breaker = self._breakers[name]
+                # Skip fully tripped breakers (not half-open)
+                if breaker.is_tripped and not breaker.is_half_open:
+                    continue
+                # Check TTL
+                last = self._last_sync_times.get(name)
+                if last is not None:
+                    elapsed = time.monotonic() - last
+                    if elapsed < adapter.sync_ttl_seconds:
+                        continue
+                await self._sync_adapter(adapter)
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+    # ------------------------------------------------------------------
+
+    async def _sync_adapter(self, adapter: ExternalCliSyncAdapter) -> SyncResult:
+        """Sync one adapter, update breaker and store."""
+        name = adapter.adapter_name
+        breaker = self._breakers[name]
+        try:
+            result = await adapter.sync()
+        except Exception as exc:
+            result = SyncResult(adapter_name=name, error=str(exc))
+
+        if result.error is not None:
+            breaker.record_failure()
+        else:
+            breaker.record_success()
+            self._upsert_sync_results(result)
+            self._last_sync_times[name] = time.monotonic()
+
+        return result
+
+    def _upsert_sync_results(self, result: SyncResult) -> None:
+        """Map SyncedProfile -> AuthProfile and upsert into the store.
+
+        - backend = "external-cli"
+        - backend_key = sp.backend_key (already formatted by the adapter)
+        - Preserve existing usage_stats if profile already in store
+        - Use ProfileUsageStats() for new profiles
+        """
+        now = datetime.now(UTC)
+        for sp in result.profiles:
+            profile_id = f"{sp.provider}/{sp.account_identifier}"
+            existing = self._store.get(profile_id)
+            usage_stats = existing.usage_stats if existing is not None else ProfileUsageStats()
+
+            # Look up the adapter to get its sync_ttl_seconds
+            adapter = self._adapters.get(result.adapter_name)
+            sync_ttl = int(adapter.sync_ttl_seconds) if adapter else 300
+
+            profile = AuthProfile(
+                id=profile_id,
+                provider=sp.provider,
+                account_identifier=sp.account_identifier,
+                backend="external-cli",
+                backend_key=sp.backend_key,
+                last_synced_at=now,
+                sync_ttl_seconds=sync_ttl,
+                usage_stats=usage_stats,
+            )
+            self._store.upsert(profile)

--- a/src/nexus/bricks/auth/external_sync/registry.py
+++ b/src/nexus/bricks/auth/external_sync/registry.py
@@ -159,12 +159,16 @@ class AdapterRegistry:
                     breaker.record_failure()
                 else:
                     result = task.result()
+                    # Always upsert discovered profiles, even when degraded
+                    # (e.g. one file parsed OK, another failed). Partial
+                    # discovery is better than losing all profiles.
+                    if result.profiles:
+                        self._upsert_sync_results(result)
+                        self._last_sync_times[name] = time.monotonic()
                     if result.error is not None:
                         breaker.record_failure()
                     else:
                         breaker.record_success()
-                        self._upsert_sync_results(result)
-                        self._last_sync_times[name] = time.monotonic()
             else:
                 if not task.done():
                     task.cancel()
@@ -214,12 +218,14 @@ class AdapterRegistry:
         except Exception as exc:
             result = SyncResult(adapter_name=name, error=str(exc))
 
+        # Always upsert discovered profiles even when degraded
+        if result.profiles:
+            self._upsert_sync_results(result)
+            self._last_sync_times[name] = time.monotonic()
         if result.error is not None:
             breaker.record_failure()
         else:
             breaker.record_success()
-            self._upsert_sync_results(result)
-            self._last_sync_times[name] = time.monotonic()
 
         return result
 

--- a/src/nexus/bricks/auth/external_sync/subprocess_adapter.py
+++ b/src/nexus/bricks/auth/external_sync/subprocess_adapter.py
@@ -1,0 +1,130 @@
+"""SubprocessAdapter — base class for external CLIs that require shell-out.
+
+Subclasses declare a binary name, status args, and a parse_output method.
+The base class handles: PATH detection, asyncio.create_subprocess_exec,
+timeout (default 5s), stderr capture, retry with exponential backoff,
+and error classification.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import shutil
+from abc import abstractmethod
+
+from nexus.bricks.auth.external_sync.base import (
+    ExternalCliSyncAdapter,
+    SyncedProfile,
+    SyncResult,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class SubprocessAdapter(ExternalCliSyncAdapter):
+    """Base class for subprocess-based sync adapters.
+
+    Subclasses set binary_name, implement get_status_args() and parse_output().
+    """
+
+    binary_name: str
+    sync_ttl_seconds: float = 300.0  # subprocess = expensive
+    _subprocess_timeout: float = 5.0
+    _max_retries: int = 1
+    _backoff_base: float = 1.0  # seconds; doubles each retry
+
+    @abstractmethod
+    def get_status_args(self) -> tuple[str, ...]:
+        """Return the CLI arguments to get account/status info."""
+        ...
+
+    @abstractmethod
+    def parse_output(self, stdout: str, stderr: str) -> list[SyncedProfile]:
+        """Parse CLI output into discovered profiles."""
+        ...
+
+    async def detect(self) -> bool:
+        """Return True if the binary is found on PATH."""
+        return shutil.which(self.binary_name) is not None
+
+    async def sync(self) -> SyncResult:
+        """Run the CLI command, parse output, retry on transient failure."""
+        binary_path = shutil.which(self.binary_name)
+        if binary_path is None:
+            return SyncResult(
+                adapter_name=self.adapter_name,
+                error=f"{self.binary_name}: binary not found on PATH",
+            )
+
+        last_error: str | None = None
+        for attempt in range(1 + self._max_retries):
+            if attempt > 0:
+                delay = self._backoff_base * (2 ** (attempt - 1))
+                await asyncio.sleep(delay)
+
+            try:
+                result = await self._run_once(binary_path)
+                if result.error is None:
+                    return result
+                last_error = result.error
+            except Exception as exc:
+                last_error = str(exc)
+
+        return SyncResult(
+            adapter_name=self.adapter_name,
+            error=last_error,
+        )
+
+    async def _run_once(self, binary_path: str) -> SyncResult:
+        """Single subprocess execution with timeout."""
+        args = self.get_status_args()
+        try:
+            proc = await asyncio.create_subprocess_exec(
+                binary_path,
+                *args,
+                stdout=asyncio.subprocess.PIPE,
+                stderr=asyncio.subprocess.PIPE,
+            )
+            stdout_bytes, stderr_bytes = await asyncio.wait_for(
+                proc.communicate(),
+                timeout=self._subprocess_timeout,
+            )
+        except TimeoutError:
+            try:
+                proc.kill()
+                await proc.wait()
+            except ProcessLookupError:
+                pass
+            return SyncResult(
+                adapter_name=self.adapter_name,
+                error=f"{self.binary_name}: timeout after {self._subprocess_timeout}s",
+            )
+        except FileNotFoundError:
+            return SyncResult(
+                adapter_name=self.adapter_name,
+                error=f"{self.binary_name}: binary not found",
+            )
+
+        stdout = stdout_bytes.decode("utf-8", errors="replace")
+        stderr = stderr_bytes.decode("utf-8", errors="replace")
+
+        if proc.returncode != 0:
+            error_detail = stderr.strip() or f"exit code {proc.returncode}"
+            return SyncResult(
+                adapter_name=self.adapter_name,
+                error=f"{self.binary_name}: {error_detail}",
+            )
+
+        try:
+            profiles = self.parse_output(stdout, stderr)
+        except Exception as exc:
+            return SyncResult(
+                adapter_name=self.adapter_name,
+                error=f"{self.binary_name}: parse error: {exc}",
+            )
+
+        return SyncResult(
+            adapter_name=self.adapter_name,
+            profiles=profiles,
+        )

--- a/src/nexus/bricks/auth/tests/fixtures/external_cli_output/aws_credentials_v2.15.ini
+++ b/src/nexus/bricks/auth/tests/fixtures/external_cli_output/aws_credentials_v2.15.ini
@@ -1,0 +1,12 @@
+[default]
+aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+
+[work-prod]
+aws_access_key_id = AKIAI44QH8DHBEXAMPLE
+aws_secret_access_key = je7MtGbClwBF/2Zp9Utk/h3yCo8nvbEXAMPLEKEY
+region = us-west-2
+
+[no-key-profile]
+region = eu-west-1
+output = json

--- a/src/nexus/bricks/auth/tests/fixtures/external_cli_output/aws_credentials_v2.16.ini
+++ b/src/nexus/bricks/auth/tests/fixtures/external_cli_output/aws_credentials_v2.16.ini
@@ -1,0 +1,18 @@
+[default]
+aws_access_key_id = AKIAIOSFODNN7EXAMPLE
+aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY
+
+[sso-session]
+aws_access_key_id = ASIAZZZZZZZZZEXAMPLE
+aws_secret_access_key = tempSecretFromSSO/EXAMPLEKEY
+aws_session_token = FwoGZXIvYXdzEBYaDHqa0AP1/EXAMPLETOKEN
+x_security_token_expires = 2026-04-15T12:00:00Z
+
+[dev]
+aws_access_key_id = AKIAXXXXXXXXXXXXXXXX
+aws_secret_access_key = devSecretKeyExample12345678901234567
+
+[future-unknown-field-profile]
+aws_access_key_id = AKIAFUTUREFIELDEXAMPLE
+aws_secret_access_key = futureSecret1234567890EXAMPLE
+some_future_field = new-feature-value

--- a/src/nexus/bricks/auth/tests/test_auth_list_cutover.py
+++ b/src/nexus/bricks/auth/tests/test_auth_list_cutover.py
@@ -25,7 +25,7 @@ def _make_store_profiles() -> list[AuthProfile]:
             account_identifier="default",
             backend="external-cli",
             backend_key="aws/default",
-            last_synced_at=now - timedelta(hours=1),
+            last_synced_at=now - timedelta(seconds=30),
             usage_stats=ProfileUsageStats(
                 last_used_at=now - timedelta(minutes=14),
                 success_count=42,
@@ -38,7 +38,7 @@ def _make_store_profiles() -> list[AuthProfile]:
             account_identifier="work-prod",
             backend="external-cli",
             backend_key="aws/work-prod",
-            last_synced_at=now - timedelta(hours=2),
+            last_synced_at=now - timedelta(seconds=30),
             usage_stats=ProfileUsageStats(
                 last_used_at=now - timedelta(minutes=60),
                 success_count=10,
@@ -53,7 +53,7 @@ def _make_store_profiles() -> list[AuthProfile]:
             account_identifier="team",
             backend="nexus-token-manager",
             backend_key="openai/team",
-            last_synced_at=now - timedelta(minutes=5),
+            last_synced_at=now - timedelta(seconds=30),
             usage_stats=ProfileUsageStats(
                 last_used_at=now - timedelta(minutes=2),
                 success_count=100,

--- a/src/nexus/bricks/auth/tests/test_auth_list_cutover.py
+++ b/src/nexus/bricks/auth/tests/test_auth_list_cutover.py
@@ -1,0 +1,141 @@
+"""Tests for nexus-fs auth list dual-read cutover."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from click.testing import CliRunner
+
+from nexus.bricks.auth.profile import (
+    AuthProfile,
+    AuthProfileFailureReason,
+    ProfileUsageStats,
+)
+
+
+def _make_store_profiles() -> list[AuthProfile]:
+    """Return 3 test profiles for the new profile-store path."""
+    now = datetime.now(UTC)
+    return [
+        AuthProfile(
+            id="s3/default",
+            provider="s3",
+            account_identifier="default",
+            backend="external-cli",
+            backend_key="aws/default",
+            last_synced_at=now - timedelta(hours=1),
+            usage_stats=ProfileUsageStats(
+                last_used_at=now - timedelta(minutes=14),
+                success_count=42,
+                failure_count=0,
+            ),
+        ),
+        AuthProfile(
+            id="s3/work-prod",
+            provider="s3",
+            account_identifier="work-prod",
+            backend="external-cli",
+            backend_key="aws/work-prod",
+            last_synced_at=now - timedelta(hours=2),
+            usage_stats=ProfileUsageStats(
+                last_used_at=now - timedelta(minutes=60),
+                success_count=10,
+                failure_count=3,
+                cooldown_until=now + timedelta(minutes=43),
+                cooldown_reason=AuthProfileFailureReason.RATE_LIMIT,
+            ),
+        ),
+        AuthProfile(
+            id="openai/team",
+            provider="openai",
+            account_identifier="team",
+            backend="nexus-token-manager",
+            backend_key="openai/team",
+            last_synced_at=now - timedelta(minutes=5),
+            usage_stats=ProfileUsageStats(
+                last_used_at=now - timedelta(minutes=2),
+                success_count=100,
+                failure_count=1,
+            ),
+        ),
+    ]
+
+
+class TestAuthListNewTable:
+    """Tests for the new profile-store table display."""
+
+    def test_new_table_shows_source_column(self) -> None:
+        from nexus.fs._auth_cli import auth
+
+        runner = CliRunner(env={"NEXUS_NO_AUTO_JSON": "1"})
+        with patch(
+            "nexus.fs._auth_cli._try_profile_store_list", return_value=_make_store_profiles()
+        ):
+            result = runner.invoke(auth, ["list"])
+
+        assert result.exit_code == 0, result.output
+        assert "Source" in result.output
+        assert "external" in result.output
+
+    def test_new_table_shows_cooldown_status(self) -> None:
+        from nexus.fs._auth_cli import auth
+
+        runner = CliRunner(env={"NEXUS_NO_AUTO_JSON": "1"})
+        with patch(
+            "nexus.fs._auth_cli._try_profile_store_list", return_value=_make_store_profiles()
+        ):
+            result = runner.invoke(auth, ["list"])
+
+        assert result.exit_code == 0, result.output
+        assert "cooldown" in result.output
+        assert "rate_limit" in result.output
+
+
+class TestAuthListFallback:
+    """Tests for fallback to the old UnifiedAuthService path."""
+
+    def test_falls_back_when_store_returns_none(self) -> None:
+        from nexus.fs._auth_cli import auth
+
+        mock_service = MagicMock()
+        mock_service.list_summaries = AsyncMock(return_value=[])
+        mock_service.secret_store_path = "/tmp/fake"
+
+        runner = CliRunner(env={"NEXUS_NO_AUTO_JSON": "1"})
+        with (
+            patch("nexus.fs._auth_cli._try_profile_store_list", return_value=None),
+            patch("nexus.fs._auth_cli._build_auth_service", return_value=mock_service),
+        ):
+            result = runner.invoke(auth, ["list"])
+
+        assert result.exit_code == 0, result.output
+        mock_service.list_summaries.assert_called_once()
+
+
+class TestAuthListJsonOutput:
+    """Tests for JSON output from the new profile-store path."""
+
+    def test_json_output_new_format(self) -> None:
+        from nexus.fs._auth_cli import auth
+
+        runner = CliRunner()
+        with patch(
+            "nexus.fs._auth_cli._try_profile_store_list", return_value=_make_store_profiles()
+        ):
+            result = runner.invoke(auth, ["list", "--json"])
+
+        assert result.exit_code == 0, result.output
+        parsed = json.loads(result.output)
+        items = parsed["data"]
+        assert len(items) == 3
+        # Check first item fields
+        assert items[0]["provider"] == "s3"
+        assert items[0]["account"] == "default"
+        assert items[0]["source"] == "external"
+        assert items[0]["status"] == "ok"
+        # Check cooldown item
+        assert "cooldown" in items[1]["status"]
+        # Check nexus-token-manager item
+        assert items[2]["source"] == "nexus"

--- a/src/nexus/bricks/auth/tests/test_auth_list_cutover.py
+++ b/src/nexus/bricks/auth/tests/test_auth_list_cutover.py
@@ -69,9 +69,14 @@ class TestAuthListNewTable:
     def test_new_table_shows_source_column(self) -> None:
         from nexus.fs._auth_cli import auth
 
+        mock_svc = MagicMock()
+        mock_svc.list_summaries = AsyncMock(return_value=[])
         runner = CliRunner(env={"NEXUS_NO_AUTO_JSON": "1"})
-        with patch(
-            "nexus.fs._auth_cli._try_profile_store_list", return_value=_make_store_profiles()
+        with (
+            patch(
+                "nexus.fs._auth_cli._try_profile_store_list", return_value=_make_store_profiles()
+            ),
+            patch("nexus.fs._auth_cli._build_auth_service", return_value=mock_svc),
         ):
             result = runner.invoke(auth, ["list"])
 
@@ -82,9 +87,14 @@ class TestAuthListNewTable:
     def test_new_table_shows_cooldown_status(self) -> None:
         from nexus.fs._auth_cli import auth
 
+        mock_svc = MagicMock()
+        mock_svc.list_summaries = AsyncMock(return_value=[])
         runner = CliRunner(env={"NEXUS_NO_AUTO_JSON": "1"})
-        with patch(
-            "nexus.fs._auth_cli._try_profile_store_list", return_value=_make_store_profiles()
+        with (
+            patch(
+                "nexus.fs._auth_cli._try_profile_store_list", return_value=_make_store_profiles()
+            ),
+            patch("nexus.fs._auth_cli._build_auth_service", return_value=mock_svc),
         ):
             result = runner.invoke(auth, ["list"])
 
@@ -121,8 +131,13 @@ class TestAuthListJsonOutput:
         from nexus.fs._auth_cli import auth
 
         runner = CliRunner()
-        with patch(
-            "nexus.fs._auth_cli._try_profile_store_list", return_value=_make_store_profiles()
+        mock_svc = MagicMock()
+        mock_svc.list_summaries = AsyncMock(return_value=[])
+        with (
+            patch(
+                "nexus.fs._auth_cli._try_profile_store_list", return_value=_make_store_profiles()
+            ),
+            patch("nexus.fs._auth_cli._build_auth_service", return_value=mock_svc),
         ):
             result = runner.invoke(auth, ["list", "--json"])
 

--- a/src/nexus/bricks/auth/tests/test_aws_sync.py
+++ b/src/nexus/bricks/auth/tests/test_aws_sync.py
@@ -214,6 +214,34 @@ class TestAwsSync:
         names = {p.account_identifier for p in result.profiles}
         assert names == {"default", "extra"}
 
+    async def test_sync_credentials_file_takes_precedence_over_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When both files have the same profile, credentials wins."""
+        cred_file = tmp_path / "credentials"
+        config_file = tmp_path / "config"
+
+        # Both files define "default" — credentials should win
+        cred_file.write_text(
+            "[default]\naws_access_key_id = AKIACRED\naws_secret_access_key = credSecret\n",
+            encoding="utf-8",
+        )
+        config_file.write_text(
+            "[default]\naws_access_key_id = AKIACONFIG\naws_secret_access_key = configSecret\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(cred_file))
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(config_file))
+
+        adapter = AwsCliSyncAdapter()
+        result = await adapter.sync()
+
+        assert result.error is None
+        # Only one profile — deduped by backend_key, first file wins
+        assert len(result.profiles) == 1
+        assert result.profiles[0].account_identifier == "default"
+
     async def test_sync_missing_files_returns_degraded(
         self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
     ) -> None:

--- a/src/nexus/bricks/auth/tests/test_aws_sync.py
+++ b/src/nexus/bricks/auth/tests/test_aws_sync.py
@@ -1,0 +1,347 @@
+"""Tests for AwsCliSyncAdapter — fixture-based parse + integration tests."""
+
+from __future__ import annotations
+
+import shutil
+from pathlib import Path
+
+import pytest
+
+from nexus.bricks.auth.credential_backend import CredentialResolutionError
+from nexus.bricks.auth.external_sync.aws_sync import AwsCliSyncAdapter
+
+# ---------------------------------------------------------------------------
+# Fixture paths
+# ---------------------------------------------------------------------------
+
+_FIXTURE_DIR = Path(__file__).parent / "fixtures" / "external_cli_output"
+_V215 = _FIXTURE_DIR / "aws_credentials_v2.15.ini"
+_V216 = _FIXTURE_DIR / "aws_credentials_v2.16.ini"
+
+
+@pytest.fixture()
+def adapter() -> AwsCliSyncAdapter:
+    return AwsCliSyncAdapter()
+
+
+# ---------------------------------------------------------------------------
+# TestAwsParseCredentials — parse both fixtures
+# ---------------------------------------------------------------------------
+
+
+class TestAwsParseCredentials:
+    """Test parse_file against real-format fixture files."""
+
+    def test_parse_v215_discovers_two_profiles(self, adapter: AwsCliSyncAdapter) -> None:
+        content = _V215.read_text(encoding="utf-8")
+        profiles = adapter.parse_file(_V215, content)
+
+        names = {p.account_identifier for p in profiles}
+        assert "default" in names
+        assert "work-prod" in names
+        assert len(profiles) == 2
+
+    def test_parse_v215_skips_no_key_profile(self, adapter: AwsCliSyncAdapter) -> None:
+        content = _V215.read_text(encoding="utf-8")
+        profiles = adapter.parse_file(_V215, content)
+
+        names = {p.account_identifier for p in profiles}
+        assert "no-key-profile" not in names
+
+    def test_parse_v216_discovers_four_profiles(self, adapter: AwsCliSyncAdapter) -> None:
+        content = _V216.read_text(encoding="utf-8")
+        profiles = adapter.parse_file(_V216, content)
+
+        names = {p.account_identifier for p in profiles}
+        assert "default" in names
+        assert "sso-session" in names
+        assert "dev" in names
+        assert "future-unknown-field-profile" in names
+        assert len(profiles) == 4
+
+    def test_parse_v216_tolerates_unknown_keys(self, adapter: AwsCliSyncAdapter) -> None:
+        """Profiles with unrecognized fields should still be discovered."""
+        content = _V216.read_text(encoding="utf-8")
+        profiles = adapter.parse_file(_V216, content)
+
+        future = [p for p in profiles if p.account_identifier == "future-unknown-field-profile"]
+        assert len(future) == 1
+
+    def test_parse_empty_file_returns_empty(self, adapter: AwsCliSyncAdapter) -> None:
+        profiles = adapter.parse_file(Path("/dev/null"), "")
+        assert profiles == []
+
+    def test_backend_key_format(self, adapter: AwsCliSyncAdapter) -> None:
+        content = _V215.read_text(encoding="utf-8")
+        profiles = adapter.parse_file(_V215, content)
+
+        for p in profiles:
+            assert p.backend_key.startswith("aws-cli/")
+            assert p.backend_key == f"aws-cli/{p.account_identifier}"
+
+    def test_all_profiles_have_s3_provider(self, adapter: AwsCliSyncAdapter) -> None:
+        content = _V215.read_text(encoding="utf-8")
+        profiles = adapter.parse_file(_V215, content)
+
+        for p in profiles:
+            assert p.provider == "s3"
+            assert p.source == "aws-cli"
+
+
+# ---------------------------------------------------------------------------
+# TestAwsParseConfig — "profile <name>" prefix handling
+# ---------------------------------------------------------------------------
+
+
+class TestAwsParseConfig:
+    """Test parse_file with ~/.aws/config style 'profile <name>' sections."""
+
+    def test_profile_prefix_stripped(self, adapter: AwsCliSyncAdapter) -> None:
+        config_content = """\
+[default]
+aws_access_key_id = AKIADEFAULTEXAMPLE
+aws_secret_access_key = defaultSecretExample
+
+[profile staging]
+aws_access_key_id = AKIASTAGINGEXAMPLE
+aws_secret_access_key = stagingSecretExample
+region = us-east-1
+
+[profile production]
+aws_access_key_id = AKIAPRODEXAMPLE
+aws_secret_access_key = prodSecretExample
+"""
+        profiles = adapter.parse_file(Path("~/.aws/config"), config_content)
+
+        names = {p.account_identifier for p in profiles}
+        assert names == {"default", "staging", "production"}
+
+    def test_profile_prefix_not_in_backend_key(self, adapter: AwsCliSyncAdapter) -> None:
+        config_content = """\
+[profile my-team]
+aws_access_key_id = AKIATEAMEXAMPLE
+aws_secret_access_key = teamSecretExample
+"""
+        profiles = adapter.parse_file(Path("~/.aws/config"), config_content)
+
+        assert len(profiles) == 1
+        assert profiles[0].backend_key == "aws-cli/my-team"
+        assert profiles[0].account_identifier == "my-team"
+
+
+# ---------------------------------------------------------------------------
+# TestAwsPaths — env var overrides and defaults
+# ---------------------------------------------------------------------------
+
+
+class TestAwsPaths:
+    def test_defaults_to_home_aws(
+        self, adapter: AwsCliSyncAdapter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("AWS_SHARED_CREDENTIALS_FILE", raising=False)
+        monkeypatch.delenv("AWS_CONFIG_FILE", raising=False)
+
+        paths = adapter.paths()
+        assert len(paths) == 2
+        assert paths[0] == Path("~/.aws/credentials").expanduser()
+        assert paths[1] == Path("~/.aws/config").expanduser()
+
+    def test_env_var_override_credentials(
+        self, adapter: AwsCliSyncAdapter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", "/custom/creds")
+        monkeypatch.delenv("AWS_CONFIG_FILE", raising=False)
+
+        paths = adapter.paths()
+        assert paths[0] == Path("/custom/creds")
+
+    def test_env_var_override_config(
+        self, adapter: AwsCliSyncAdapter, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv("AWS_SHARED_CREDENTIALS_FILE", raising=False)
+        monkeypatch.setenv("AWS_CONFIG_FILE", "/custom/config")
+
+        paths = adapter.paths()
+        assert paths[1] == Path("/custom/config")
+
+
+# ---------------------------------------------------------------------------
+# TestAwsSync — full integration via FileAdapter.sync()
+# ---------------------------------------------------------------------------
+
+
+class TestAwsSync:
+    async def test_sync_discovers_profiles_from_fixture(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cred_file = tmp_path / "credentials"
+        shutil.copy(_V215, cred_file)
+
+        monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(cred_file))
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "nonexistent-config"))
+
+        adapter = AwsCliSyncAdapter()
+        result = await adapter.sync()
+
+        assert result.adapter_name == "aws-cli"
+        assert result.error is None
+        assert len(result.profiles) == 2
+        names = {p.account_identifier for p in result.profiles}
+        assert names == {"default", "work-prod"}
+
+    async def test_sync_merges_credentials_and_config(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cred_file = tmp_path / "credentials"
+        config_file = tmp_path / "config"
+
+        cred_file.write_text(
+            "[default]\naws_access_key_id = AKIACRED\naws_secret_access_key = credSecret\n",
+            encoding="utf-8",
+        )
+        config_file.write_text(
+            "[profile extra]\naws_access_key_id = AKIAEXTRA\naws_secret_access_key = extraSecret\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(cred_file))
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(config_file))
+
+        adapter = AwsCliSyncAdapter()
+        result = await adapter.sync()
+
+        assert result.error is None
+        names = {p.account_identifier for p in result.profiles}
+        assert names == {"default", "extra"}
+
+    async def test_sync_missing_files_returns_degraded(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(tmp_path / "nope-creds"))
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "nope-config"))
+
+        adapter = AwsCliSyncAdapter()
+        result = await adapter.sync()
+
+        assert result.error is not None
+        assert result.profiles == []
+
+    async def test_detect_true_when_fixture_exists(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cred_file = tmp_path / "credentials"
+        shutil.copy(_V215, cred_file)
+
+        monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(cred_file))
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "nonexistent"))
+
+        adapter = AwsCliSyncAdapter()
+        assert await adapter.detect() is True
+
+    async def test_detect_false_when_no_files(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(tmp_path / "nope-creds"))
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "nope-config"))
+
+        adapter = AwsCliSyncAdapter()
+        assert await adapter.detect() is False
+
+
+# ---------------------------------------------------------------------------
+# TestAwsResolveCredential — resolve from fixture file
+# ---------------------------------------------------------------------------
+
+
+class TestAwsResolveCredential:
+    async def test_resolve_default_profile(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cred_file = tmp_path / "credentials"
+        shutil.copy(_V215, cred_file)
+
+        monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(cred_file))
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "nonexistent"))
+
+        adapter = AwsCliSyncAdapter()
+        cred = await adapter.resolve_credential("aws-cli/default")
+
+        assert cred.kind == "api_key"
+        assert cred.api_key == "AKIAIOSFODNN7EXAMPLE"
+        assert cred.metadata["secret_access_key"] == "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+
+    async def test_resolve_named_profile_with_region(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cred_file = tmp_path / "credentials"
+        shutil.copy(_V215, cred_file)
+
+        monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(cred_file))
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "nonexistent"))
+
+        adapter = AwsCliSyncAdapter()
+        cred = await adapter.resolve_credential("aws-cli/work-prod")
+
+        assert cred.api_key == "AKIAI44QH8DHBEXAMPLE"
+        assert cred.metadata["region"] == "us-west-2"
+
+    async def test_resolve_sso_session_with_token(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cred_file = tmp_path / "credentials"
+        shutil.copy(_V216, cred_file)
+
+        monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(cred_file))
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "nonexistent"))
+
+        adapter = AwsCliSyncAdapter()
+        cred = await adapter.resolve_credential("aws-cli/sso-session")
+
+        assert cred.api_key == "ASIAZZZZZZZZZEXAMPLE"
+        assert cred.metadata["session_token"] == "FwoGZXIvYXdzEBYaDHqa0AP1/EXAMPLETOKEN"
+        assert cred.metadata["secret_access_key"] == "tempSecretFromSSO/EXAMPLEKEY"
+
+    async def test_resolve_from_config_profile_prefix(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        config_file = tmp_path / "config"
+        config_file.write_text(
+            "[profile my-team]\n"
+            "aws_access_key_id = AKIATEAMKEY\n"
+            "aws_secret_access_key = teamSecret\n"
+            "region = ap-southeast-1\n",
+            encoding="utf-8",
+        )
+
+        monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(tmp_path / "nonexistent"))
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(config_file))
+
+        adapter = AwsCliSyncAdapter()
+        cred = await adapter.resolve_credential("aws-cli/my-team")
+
+        assert cred.api_key == "AKIATEAMKEY"
+        assert cred.metadata["secret_access_key"] == "teamSecret"
+        assert cred.metadata["region"] == "ap-southeast-1"
+
+    async def test_resolve_missing_profile_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        cred_file = tmp_path / "credentials"
+        shutil.copy(_V215, cred_file)
+
+        monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(cred_file))
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "nonexistent"))
+
+        adapter = AwsCliSyncAdapter()
+        with pytest.raises(CredentialResolutionError, match="nonexistent-profile"):
+            await adapter.resolve_credential("aws-cli/nonexistent-profile")
+
+    async def test_resolve_no_files_raises(
+        self, tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(tmp_path / "nope"))
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(tmp_path / "nope2"))
+
+        adapter = AwsCliSyncAdapter()
+        with pytest.raises(CredentialResolutionError):
+            await adapter.resolve_credential("aws-cli/default")

--- a/src/nexus/bricks/auth/tests/test_e2e_aws.py
+++ b/src/nexus/bricks/auth/tests/test_e2e_aws.py
@@ -1,0 +1,103 @@
+"""Nightly end-to-end test with real AWS CLI.
+
+Gated by TEST_WITH_REAL_AWS_CLI=1 env var. Skipped in default CI.
+Creates a temp HOME with dummy AWS credentials, then asserts the
+full sync + auth list flow works.
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+from pathlib import Path
+
+import pytest
+
+from nexus.bricks.auth.external_sync.aws_sync import AwsCliSyncAdapter
+from nexus.bricks.auth.external_sync.registry import AdapterRegistry
+from nexus.bricks.auth.profile import InMemoryAuthProfileStore
+
+pytestmark = pytest.mark.skipif(
+    not os.environ.get("TEST_WITH_REAL_AWS_CLI"),
+    reason="Requires TEST_WITH_REAL_AWS_CLI=1 and aws CLI installed",
+)
+
+# ---------------------------------------------------------------------------
+# Fixture: temp HOME with dummy AWS credentials + config
+# ---------------------------------------------------------------------------
+
+_CREDENTIALS = """\
+[default]
+aws_access_key_id = AKIATESTEXAMPLE123456
+aws_secret_access_key = wJalrXUtnFEMI/K7MDENG/bPxRfiCYTESTKEY
+
+[staging]
+aws_access_key_id = AKIASTAGINGEXAMPLE789
+aws_secret_access_key = stagingSecretAccessKey/EXAMPLEVALUE
+"""
+
+_CONFIG = """\
+[default]
+region = us-east-1
+
+[profile staging]
+region = eu-west-1
+"""
+
+
+@pytest.fixture()
+def aws_home(tmp_path: Path) -> Path:
+    """Create a temp dir with ~/.aws/credentials and ~/.aws/config."""
+    aws_dir = tmp_path / ".aws"
+    aws_dir.mkdir()
+
+    (aws_dir / "credentials").write_text(_CREDENTIALS, encoding="utf-8")
+    (aws_dir / "config").write_text(_CONFIG, encoding="utf-8")
+
+    return tmp_path
+
+
+# ---------------------------------------------------------------------------
+# TestRealAwsCli
+# ---------------------------------------------------------------------------
+
+
+class TestRealAwsCli:
+    def test_aws_cli_is_installed(self) -> None:
+        assert shutil.which("aws") is not None, "aws CLI binary not found on PATH"
+
+    async def test_full_sync_and_list(
+        self, aws_home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(aws_home / ".aws" / "credentials"))
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(aws_home / ".aws" / "config"))
+
+        adapter = AwsCliSyncAdapter()
+        store = InMemoryAuthProfileStore()
+        registry = AdapterRegistry([adapter], store, startup_timeout=5.0)
+
+        results = await registry.startup()
+
+        assert "aws-cli" in results
+        assert results["aws-cli"].error is None
+
+        profiles = store.list()
+        assert len(profiles) == 2
+
+        names = {p.account_identifier for p in profiles}
+        assert names == {"default", "staging"}
+
+        for p in profiles:
+            assert p.backend == "external-cli"
+
+    async def test_resolve_credential_from_file(
+        self, aws_home: Path, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.setenv("AWS_SHARED_CREDENTIALS_FILE", str(aws_home / ".aws" / "credentials"))
+        monkeypatch.setenv("AWS_CONFIG_FILE", str(aws_home / ".aws" / "config"))
+
+        adapter = AwsCliSyncAdapter()
+        cred = await adapter.resolve_credential("aws-cli/default")
+
+        assert cred.kind == "api_key"
+        assert cred.api_key == "AKIATESTEXAMPLE123456"

--- a/src/nexus/bricks/auth/tests/test_external_cli_backend.py
+++ b/src/nexus/bricks/auth/tests/test_external_cli_backend.py
@@ -1,0 +1,155 @@
+"""Tests for ExternalCliBackend.
+
+Covers:
+  - resolve() delegates to the correct adapter
+  - resolve() raises CredentialResolutionError for unknown adapters / profiles
+  - health_check() returns HEALTHY / UNHEALTHY
+  - name property
+"""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime
+
+import pytest
+
+from nexus.bricks.auth.credential_backend import (
+    CredentialResolutionError,
+    HealthStatus,
+    ResolvedCredential,
+)
+from nexus.bricks.auth.external_sync.base import (
+    ExternalCliSyncAdapter,
+    SyncResult,
+)
+from nexus.bricks.auth.external_sync.external_cli_backend import ExternalCliBackend
+from nexus.bricks.auth.external_sync.registry import AdapterRegistry
+from nexus.bricks.auth.profile import InMemoryAuthProfileStore
+
+# ---------------------------------------------------------------------------
+# Mock adapter
+# ---------------------------------------------------------------------------
+
+
+class _MockAdapter(ExternalCliSyncAdapter):
+    """Adapter that returns pre-configured credentials by backend_key."""
+
+    adapter_name = "mock"
+    sync_ttl_seconds = 60.0
+    failure_threshold = 3
+    reset_timeout_seconds = 60.0
+
+    def __init__(self, credentials: dict[str, ResolvedCredential]) -> None:
+        self._credentials = credentials
+
+    async def detect(self) -> bool:
+        return True
+
+    async def sync(self) -> SyncResult:
+        return SyncResult(adapter_name=self.adapter_name)
+
+    async def resolve_credential(self, backend_key: str) -> ResolvedCredential:
+        if backend_key not in self._credentials:
+            raise CredentialResolutionError(
+                "mock", backend_key, f"no credential for key '{backend_key}'"
+            )
+        return self._credentials[backend_key]
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+
+def _make_registry(adapters: list[ExternalCliSyncAdapter]) -> AdapterRegistry:
+    store = InMemoryAuthProfileStore()
+    return AdapterRegistry(adapters, store)
+
+
+_SAMPLE_CRED = ResolvedCredential(
+    kind="api_key",
+    api_key="test-secret-key",
+    expires_at=datetime(2099, 1, 1, tzinfo=UTC),
+    metadata={"region": "us-east-1"},
+)
+
+
+# ---------------------------------------------------------------------------
+# TestExternalCliBackendResolve
+# ---------------------------------------------------------------------------
+
+
+class TestExternalCliBackendResolve:
+    async def test_resolve_delegates_to_adapter(self) -> None:
+        adapter = _MockAdapter(credentials={"mock/default": _SAMPLE_CRED})
+        registry = _make_registry([adapter])
+        backend = ExternalCliBackend(registry)
+
+        result = await backend.resolve("mock/default")
+
+        assert result.kind == "api_key"
+        assert result.api_key == "test-secret-key"
+        assert result.expires_at == datetime(2099, 1, 1, tzinfo=UTC)
+        assert result.metadata == {"region": "us-east-1"}
+
+    async def test_resolve_unknown_adapter_raises(self) -> None:
+        registry = _make_registry([])
+        backend = ExternalCliBackend(registry)
+
+        with pytest.raises(CredentialResolutionError, match="no adapter"):
+            await backend.resolve("nonexistent/profile")
+
+    async def test_resolve_unknown_profile_raises(self) -> None:
+        adapter = _MockAdapter(credentials={"mock/default": _SAMPLE_CRED})
+        registry = _make_registry([adapter])
+        backend = ExternalCliBackend(registry)
+
+        with pytest.raises(CredentialResolutionError, match="no credential"):
+            await backend.resolve("mock/unknown-profile")
+
+    async def test_resolve_malformed_key_raises(self) -> None:
+        registry = _make_registry([])
+        backend = ExternalCliBackend(registry)
+
+        with pytest.raises(CredentialResolutionError, match="expected 'adapter_name/profile'"):
+            await backend.resolve("no-slash-here")
+
+
+# ---------------------------------------------------------------------------
+# TestExternalCliBackendHealthCheck
+# ---------------------------------------------------------------------------
+
+
+class TestExternalCliBackendHealthCheck:
+    async def test_health_check_healthy(self) -> None:
+        adapter = _MockAdapter(credentials={"mock/default": _SAMPLE_CRED})
+        registry = _make_registry([adapter])
+        backend = ExternalCliBackend(registry)
+
+        health = await backend.health_check("mock/default")
+
+        assert health.status == HealthStatus.HEALTHY
+        assert "resolved successfully" in health.message
+        assert health.checked_at is not None
+
+    async def test_health_check_unhealthy_on_missing(self) -> None:
+        adapter = _MockAdapter(credentials={})
+        registry = _make_registry([adapter])
+        backend = ExternalCliBackend(registry)
+
+        health = await backend.health_check("mock/missing")
+
+        assert health.status == HealthStatus.UNHEALTHY
+        assert health.checked_at is not None
+
+
+# ---------------------------------------------------------------------------
+# TestExternalCliBackendName
+# ---------------------------------------------------------------------------
+
+
+class TestExternalCliBackendName:
+    def test_name_returns_external_cli(self) -> None:
+        registry = _make_registry([])
+        backend = ExternalCliBackend(registry)
+        assert backend.name == "external-cli"

--- a/src/nexus/bricks/auth/tests/test_file_adapter.py
+++ b/src/nexus/bricks/auth/tests/test_file_adapter.py
@@ -1,0 +1,16 @@
+"""Tests for FileAdapter base class via synthetic adapter."""
+
+from __future__ import annotations
+
+
+class TestBaseImports:
+    def test_base_types_importable(self) -> None:
+        from nexus.bricks.auth.external_sync.base import (
+            ExternalCliSyncAdapter,
+            SyncedProfile,
+            SyncResult,
+        )
+
+        assert SyncedProfile is not None
+        assert SyncResult is not None
+        assert ExternalCliSyncAdapter is not None

--- a/src/nexus/bricks/auth/tests/test_file_adapter.py
+++ b/src/nexus/bricks/auth/tests/test_file_adapter.py
@@ -2,15 +2,182 @@
 
 from __future__ import annotations
 
+import sys
+from pathlib import Path
+
+from nexus.bricks.auth.credential_backend import ResolvedCredential
+from nexus.bricks.auth.external_sync.base import SyncedProfile, SyncResult
+from nexus.bricks.auth.external_sync.file_adapter import FileAdapter
+
 
 class TestBaseImports:
     def test_base_types_importable(self) -> None:
         from nexus.bricks.auth.external_sync.base import (
             ExternalCliSyncAdapter,
             SyncedProfile,
-            SyncResult,
         )
 
         assert SyncedProfile is not None
         assert SyncResult is not None
         assert ExternalCliSyncAdapter is not None
+
+
+# ---------------------------------------------------------------------------
+# Synthetic adapter helper
+# ---------------------------------------------------------------------------
+
+
+def _make_synthetic(
+    tmp_path: Path | None,
+    content: str = "",
+    *,
+    fail_parse: bool = False,
+    setup_file: bool = True,
+) -> FileAdapter:
+    """Build a concrete FileAdapter subclass for testing.
+
+    Parameters
+    ----------
+    tmp_path:
+        pytest tmp_path fixture value. If None, a nonexistent path is used.
+    content:
+        Text to write into the synthetic config file.
+    fail_parse:
+        If True, parse_file raises ValueError.
+    setup_file:
+        If True (default) and tmp_path is not None, write the content to disk.
+    """
+    if tmp_path is not None:
+        conf = tmp_path / "synthetic.conf"
+        if setup_file and content:
+            conf.write_text(content, encoding="utf-8")
+        elif setup_file:
+            # create empty file
+            conf.write_text("", encoding="utf-8")
+        file_path = conf
+    else:
+        file_path = Path("/nonexistent/does-not-exist/synthetic.conf")
+
+    class SyntheticAdapter(FileAdapter):
+        adapter_name = "synthetic-file"
+
+        def paths(self) -> list[Path]:
+            return [file_path]
+
+        def parse_file(self, _path: Path, text: str) -> list[SyncedProfile]:
+            if fail_parse:
+                raise ValueError("deliberately malformed")
+            lines = [line.strip() for line in text.strip().splitlines() if line.strip()]
+            return [
+                SyncedProfile(
+                    provider="synthetic",
+                    account_identifier=line,
+                    backend_key=f"synthetic/{line}",
+                    source="synthetic-file",
+                )
+                for line in lines
+            ]
+
+        async def resolve_credential(self, _backend_key: str) -> ResolvedCredential:
+            return ResolvedCredential(kind="api_key", api_key="fake-key")
+
+    return SyntheticAdapter()
+
+
+# ---------------------------------------------------------------------------
+# Detect tests
+# ---------------------------------------------------------------------------
+
+
+class TestFileAdapterDetect:
+    async def test_detect_true_when_file_exists(self, tmp_path: Path) -> None:
+        adapter = _make_synthetic(tmp_path, content="profile1\n")
+        assert await adapter.detect() is True
+
+    async def test_detect_false_when_no_files(self) -> None:
+        adapter = _make_synthetic(None)
+        assert await adapter.detect() is False
+
+
+# ---------------------------------------------------------------------------
+# Sync tests
+# ---------------------------------------------------------------------------
+
+
+class TestFileAdapterSync:
+    async def test_sync_parses_file_content(self, tmp_path: Path) -> None:
+        adapter = _make_synthetic(tmp_path, content="alice\nbob\n")
+        result = await adapter.sync()
+
+        assert result.adapter_name == "synthetic-file"
+        assert result.error is None
+        assert len(result.profiles) == 2
+        assert result.profiles[0].account_identifier == "alice"
+        assert result.profiles[1].account_identifier == "bob"
+
+    async def test_sync_missing_file_returns_degraded(self) -> None:
+        adapter = _make_synthetic(None, setup_file=False)
+        result = await adapter.sync()
+
+        assert result.error is not None
+        assert "no readable" in result.error.lower() or "No readable" in result.error
+
+    async def test_sync_empty_file_returns_empty_profiles(self, tmp_path: Path) -> None:
+        adapter = _make_synthetic(tmp_path, content="")
+        result = await adapter.sync()
+
+        assert result.profiles == []
+        assert result.error is None
+
+    async def test_sync_malformed_content_returns_degraded(self, tmp_path: Path) -> None:
+        adapter = _make_synthetic(tmp_path, content="bad-data\n", fail_parse=True)
+        result = await adapter.sync()
+
+        assert result.error is not None
+        assert "parse error" in result.error.lower()
+
+    async def test_sync_unreadable_perms_returns_degraded(self, tmp_path: Path) -> None:
+        if sys.platform == "win32":
+            return  # chmod 000 doesn't work on Windows
+
+        adapter = _make_synthetic(tmp_path, content="profile1\n")
+        conf = tmp_path / "synthetic.conf"
+        original_mode = conf.stat().st_mode
+        try:
+            conf.chmod(0o000)
+            result = await adapter.sync()
+            assert result.error is not None
+            assert "permission denied" in result.error.lower() or "No readable" in result.error
+        finally:
+            conf.chmod(original_mode)
+
+    async def test_sync_symlink_loop_returns_degraded(self, tmp_path: Path) -> None:
+        # Create a symlink loop: a.conf -> b.conf -> a.conf
+        a = tmp_path / "synthetic.conf"
+        b = tmp_path / "b.conf"
+
+        # Remove any existing file first (created by _make_synthetic)
+        if a.exists():
+            a.unlink()
+
+        b.symlink_to(a)
+        a.symlink_to(b)
+
+        # Build adapter that points at the symlink loop
+        class LoopAdapter(FileAdapter):
+            adapter_name = "synthetic-file"
+
+            def paths(self) -> list[Path]:
+                return [a]
+
+            def parse_file(self, _path: Path, _text: str) -> list[SyncedProfile]:
+                return []
+
+            async def resolve_credential(self, _backend_key: str) -> ResolvedCredential:
+                return ResolvedCredential(kind="api_key", api_key="fake-key")
+
+        adapter = LoopAdapter()
+        result = await adapter.sync()
+
+        # Symlink loop causes OSError on read_text — should be caught gracefully
+        assert result.error is not None

--- a/src/nexus/bricks/auth/tests/test_registry.py
+++ b/src/nexus/bricks/auth/tests/test_registry.py
@@ -5,12 +5,16 @@ Covers:
   - AdapterRegistry.startup() with concurrency and global timeout
   - Per-adapter circuit breaker integration
   - Background refresh loop with TTL
+  - Concurrency safety (torn reads, crash-freedom)
+  - Offline safety (FileAdapter / SubprocessAdapter degrade gracefully)
 """
 
 from __future__ import annotations
 
 import asyncio
+import socket as _socket_mod
 import time
+from pathlib import Path
 
 import pytest
 
@@ -20,7 +24,9 @@ from nexus.bricks.auth.external_sync.base import (
     SyncedProfile,
     SyncResult,
 )
+from nexus.bricks.auth.external_sync.file_adapter import FileAdapter
 from nexus.bricks.auth.external_sync.registry import AdapterRegistry, CircuitBreaker
+from nexus.bricks.auth.external_sync.subprocess_adapter import SubprocessAdapter
 from nexus.bricks.auth.profile import InMemoryAuthProfileStore
 
 # ---------------------------------------------------------------------------
@@ -368,3 +374,132 @@ class TestRegistryRefreshLoop:
 
         # With TTL=0.3s and tick=0.1s over ~0.8s, we expect at least 2 additional syncs
         assert adapter.sync_count >= 3
+
+
+# ---------------------------------------------------------------------------
+# TestConcurrency
+# ---------------------------------------------------------------------------
+
+
+class TestConcurrency:
+    async def test_concurrent_list_during_upsert(self) -> None:
+        """Two readers + one writer — no torn reads, no crashes."""
+
+        class _ShortTTLAdapter(_FastAdapter):
+            adapter_name = "short-ttl"
+            sync_ttl_seconds = 0.1
+
+        adapter = _ShortTTLAdapter()
+        store = InMemoryAuthProfileStore()
+        registry = AdapterRegistry(
+            [adapter],
+            store,
+            startup_timeout=3.0,
+            loop_tick_seconds=0.05,
+        )
+        await registry.startup()
+
+        read_results: list[list] = [[], []]
+
+        async def reader(idx: int) -> None:
+            for _ in range(20):
+                result = store.list(provider="test")
+                read_results[idx].append(result)
+                await asyncio.sleep(0.01)
+
+        async def writer() -> None:
+            loop_task = asyncio.create_task(registry.run_refresh_loop())
+            await asyncio.sleep(0.3)
+            loop_task.cancel()
+            with pytest.raises(asyncio.CancelledError):
+                await loop_task
+
+        # Run 2 readers + 1 writer concurrently
+        await asyncio.gather(reader(0), reader(1), writer())
+
+        # Assert: no exceptions were raised, and all read results are lists
+        for idx in range(2):
+            assert len(read_results[idx]) == 20
+            for result in read_results[idx]:
+                assert isinstance(result, list)
+
+
+# ---------------------------------------------------------------------------
+# TestOfflineSafety
+# ---------------------------------------------------------------------------
+
+
+class TestOfflineSafety:
+    """Verify adapters degrade gracefully when network is blocked.
+
+    These tests are sync because the ``no_network`` fixture monkeypatches
+    ``socket.socket``, which also blocks ``socket.socketpair()`` — the call
+    asyncio uses internally for its event-loop self-pipe.  We therefore
+    create the event loop *first*, block sockets *second*, then run the
+    adapter coroutines inside the pre-existing loop.
+    """
+
+    def test_file_adapter_returns_degraded_with_no_network(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """FileAdapter with nonexistent file returns error, no hang."""
+
+        class _MissingFileAdapter(FileAdapter):
+            adapter_name = "missing-file"
+
+            def paths(self) -> list[Path]:
+                return [Path("/tmp/__nexus_test_nonexistent_config_1234567890__")]
+
+            def parse_file(self, _path: Path, _content: str) -> list[SyncedProfile]:
+                return []
+
+            async def resolve_credential(self, _backend_key: str) -> ResolvedCredential:
+                return ResolvedCredential(kind="api_key", api_key="never")
+
+        adapter = _MissingFileAdapter()
+
+        # Create the event loop BEFORE blocking sockets, then block.
+        loop = asyncio.new_event_loop()
+        try:
+            monkeypatch.setattr(
+                _socket_mod,
+                "socket",
+                lambda *_a, **_kw: (_ for _ in ()).throw(RuntimeError("network blocked")),
+            )
+            result = loop.run_until_complete(asyncio.wait_for(adapter.sync(), timeout=2.0))
+        finally:
+            loop.close()
+        assert result.error is not None
+
+    def test_subprocess_adapter_returns_degraded_with_no_network(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """SubprocessAdapter with nonexistent binary returns error, no hang."""
+
+        class _MissingBinaryAdapter(SubprocessAdapter):
+            adapter_name = "missing-binary"
+            binary_name = "__nexus_test_nonexistent_binary_1234567890__"
+
+            def get_status_args(self) -> tuple[str, ...]:
+                return ("--version",)
+
+            def parse_output(self, _stdout: str, _stderr: str) -> list[SyncedProfile]:
+                return []
+
+            async def resolve_credential(self, _backend_key: str) -> ResolvedCredential:
+                return ResolvedCredential(kind="api_key", api_key="never")
+
+        adapter = _MissingBinaryAdapter()
+
+        # Create the event loop BEFORE blocking sockets, then block.
+        loop = asyncio.new_event_loop()
+        try:
+            monkeypatch.setattr(
+                _socket_mod,
+                "socket",
+                lambda *_a, **_kw: (_ for _ in ()).throw(RuntimeError("network blocked")),
+            )
+            result = loop.run_until_complete(asyncio.wait_for(adapter.sync(), timeout=2.0))
+        finally:
+            loop.close()
+        assert result.error is not None

--- a/src/nexus/bricks/auth/tests/test_registry.py
+++ b/src/nexus/bricks/auth/tests/test_registry.py
@@ -1,0 +1,370 @@
+"""Tests for AdapterRegistry and CircuitBreaker.
+
+Covers:
+  - CircuitBreaker state transitions (closed, tripped, half-open, reset)
+  - AdapterRegistry.startup() with concurrency and global timeout
+  - Per-adapter circuit breaker integration
+  - Background refresh loop with TTL
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from nexus.bricks.auth.credential_backend import ResolvedCredential
+from nexus.bricks.auth.external_sync.base import (
+    ExternalCliSyncAdapter,
+    SyncedProfile,
+    SyncResult,
+)
+from nexus.bricks.auth.external_sync.registry import AdapterRegistry, CircuitBreaker
+from nexus.bricks.auth.profile import InMemoryAuthProfileStore
+
+# ---------------------------------------------------------------------------
+# Helper adapters
+# ---------------------------------------------------------------------------
+
+
+class _FastAdapter(ExternalCliSyncAdapter):
+    """Returns 1 profile immediately."""
+
+    adapter_name = "fast"
+    sync_ttl_seconds = 60.0
+    failure_threshold = 3
+    reset_timeout_seconds = 60.0
+
+    async def detect(self) -> bool:
+        return True
+
+    async def sync(self) -> SyncResult:
+        return SyncResult(
+            adapter_name=self.adapter_name,
+            profiles=[
+                SyncedProfile(
+                    provider="test",
+                    account_identifier="fast-acct",
+                    backend_key="fast/fast-acct",
+                    source="fast",
+                ),
+            ],
+        )
+
+    async def resolve_credential(self, _backend_key: str) -> ResolvedCredential:
+        return ResolvedCredential(kind="api_key", api_key="fast-key")
+
+
+class _HangingAdapter(ExternalCliSyncAdapter):
+    """Sleeps 300s — always times out."""
+
+    adapter_name = "hanging"
+    sync_ttl_seconds = 60.0
+    failure_threshold = 3
+    reset_timeout_seconds = 60.0
+
+    async def detect(self) -> bool:
+        await asyncio.sleep(300)
+        return True
+
+    async def sync(self) -> SyncResult:
+        await asyncio.sleep(300)
+        return SyncResult(adapter_name=self.adapter_name)
+
+    async def resolve_credential(self, _backend_key: str) -> ResolvedCredential:
+        return ResolvedCredential(kind="api_key", api_key="never")
+
+
+class _FailingAdapter(ExternalCliSyncAdapter):
+    """Always returns error, tracks sync_count."""
+
+    adapter_name = "failing"
+    sync_ttl_seconds = 0.1  # short TTL for testing
+    failure_threshold = 3
+    reset_timeout_seconds = 0.5
+
+    def __init__(self) -> None:
+        self.sync_count = 0
+
+    async def detect(self) -> bool:
+        return True
+
+    async def sync(self) -> SyncResult:
+        self.sync_count += 1
+        return SyncResult(adapter_name=self.adapter_name, error="always fails")
+
+    async def resolve_credential(self, _backend_key: str) -> ResolvedCredential:
+        raise RuntimeError("always fails")
+
+
+class _RecoveringAdapter(ExternalCliSyncAdapter):
+    """Fails N times then succeeds."""
+
+    adapter_name = "recovering"
+    sync_ttl_seconds = 0.1
+    failure_threshold = 2
+    reset_timeout_seconds = 0.3
+
+    def __init__(self, *, fail_times: int = 2) -> None:
+        self._fail_times = fail_times
+        self.sync_count = 0
+
+    async def detect(self) -> bool:
+        return True
+
+    async def sync(self) -> SyncResult:
+        self.sync_count += 1
+        if self.sync_count <= self._fail_times:
+            return SyncResult(adapter_name=self.adapter_name, error="not yet")
+        return SyncResult(
+            adapter_name=self.adapter_name,
+            profiles=[
+                SyncedProfile(
+                    provider="test",
+                    account_identifier="recovered-acct",
+                    backend_key="recovering/recovered-acct",
+                    source="recovering",
+                ),
+            ],
+        )
+
+    async def resolve_credential(self, _backend_key: str) -> ResolvedCredential:
+        return ResolvedCredential(kind="api_key", api_key="recovered")
+
+
+# ---------------------------------------------------------------------------
+# TestCircuitBreaker
+# ---------------------------------------------------------------------------
+
+
+class TestCircuitBreaker:
+    def test_starts_closed(self) -> None:
+        cb = CircuitBreaker(failure_threshold=3, reset_timeout_seconds=1.0)
+        assert not cb.is_tripped
+        assert not cb.is_half_open
+        assert cb.failure_count == 0
+
+    def test_trips_after_threshold(self) -> None:
+        cb = CircuitBreaker(failure_threshold=3, reset_timeout_seconds=60.0)
+        cb.record_failure()
+        cb.record_failure()
+        assert not cb.is_tripped
+        cb.record_failure()
+        assert cb.is_tripped
+        assert not cb.is_half_open
+
+    def test_success_resets(self) -> None:
+        cb = CircuitBreaker(failure_threshold=2, reset_timeout_seconds=60.0)
+        cb.record_failure()
+        cb.record_failure()
+        assert cb.is_tripped
+        cb.record_success()
+        assert not cb.is_tripped
+        assert not cb.is_half_open
+        assert cb.failure_count == 0
+
+    def test_half_open_after_reset_timeout(self) -> None:
+        cb = CircuitBreaker(failure_threshold=1, reset_timeout_seconds=0.1)
+        cb.record_failure()
+        assert cb.is_tripped
+        time.sleep(0.15)
+        assert not cb.is_tripped
+        assert cb.is_half_open
+
+
+# ---------------------------------------------------------------------------
+# TestRegistryStartup
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryStartup:
+    async def test_returns_results(self) -> None:
+        store = InMemoryAuthProfileStore()
+        registry = AdapterRegistry(
+            [_FastAdapter()],
+            store,
+            startup_timeout=3.0,
+        )
+        results = await registry.startup()
+        assert "fast" in results
+        assert results["fast"].error is None
+        assert len(results["fast"].profiles) == 1
+
+    async def test_upserts_into_store(self) -> None:
+        store = InMemoryAuthProfileStore()
+        registry = AdapterRegistry(
+            [_FastAdapter()],
+            store,
+            startup_timeout=3.0,
+        )
+        await registry.startup()
+
+        profiles = store.list()
+        assert len(profiles) == 1
+        p = profiles[0]
+        assert p.backend == "external-cli"
+        assert p.backend_key == "fast/fast-acct"
+        assert p.provider == "test"
+        assert p.last_synced_at is not None
+
+    async def test_timeout_degrades_slow_adapter(self) -> None:
+        store = InMemoryAuthProfileStore()
+        registry = AdapterRegistry(
+            [_HangingAdapter()],
+            store,
+            startup_timeout=0.5,
+        )
+        results = await registry.startup()
+        assert results["hanging"].error == "timeout"
+        assert store.list() == []
+
+    async def test_5_adapters_4_fast_1_hanging(self) -> None:
+        """Four fast adapters + one hanging. All fast should succeed in < 2s."""
+
+        class _NamedFastAdapter(_FastAdapter):
+            """Fast adapter with configurable name for unique profiles."""
+
+            def __init__(self, name: str) -> None:
+                self.adapter_name = name
+                self._name = name
+
+            async def sync(self) -> SyncResult:
+                return SyncResult(
+                    adapter_name=self._name,
+                    profiles=[
+                        SyncedProfile(
+                            provider="test",
+                            account_identifier=f"{self._name}-acct",
+                            backend_key=f"{self._name}/{self._name}-acct",
+                            source=self._name,
+                        ),
+                    ],
+                )
+
+        store = InMemoryAuthProfileStore()
+        registry = AdapterRegistry(
+            [
+                _NamedFastAdapter("fast1"),
+                _NamedFastAdapter("fast2"),
+                _NamedFastAdapter("fast3"),
+                _NamedFastAdapter("fast4"),
+                _HangingAdapter(),
+            ],
+            store,
+            startup_timeout=2.0,
+        )
+        t0 = time.monotonic()
+        results = await registry.startup()
+        elapsed = time.monotonic() - t0
+
+        assert elapsed < 2.5  # generous margin but well under 300s
+        for name in ("fast1", "fast2", "fast3", "fast4"):
+            assert results[name].error is None
+        assert results["hanging"].error == "timeout"
+        assert len(store.list()) == 4
+
+
+# ---------------------------------------------------------------------------
+# TestRegistryCircuitBreaker
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryCircuitBreaker:
+    async def test_trips_after_threshold(self) -> None:
+        adapter = _FailingAdapter()
+        store = InMemoryAuthProfileStore()
+        registry = AdapterRegistry(
+            [adapter],
+            store,
+            startup_timeout=3.0,
+            loop_tick_seconds=0.05,
+        )
+        # startup counts as first failure
+        await registry.startup()
+
+        breaker = registry._breakers["failing"]
+        assert breaker.failure_count == 1
+
+        # Two more syncs to trip the breaker (threshold=3)
+        await registry._sync_adapter(adapter)
+        assert breaker.failure_count == 2
+        await registry._sync_adapter(adapter)
+        assert breaker.failure_count == 3
+        assert breaker.is_tripped
+
+    async def test_half_open_recovery(self) -> None:
+        """After breaker trips and reset timeout elapses, a successful probe resets it."""
+        adapter = _RecoveringAdapter(fail_times=2)
+        store = InMemoryAuthProfileStore()
+        registry = AdapterRegistry(
+            [adapter],
+            store,
+            startup_timeout=3.0,
+            loop_tick_seconds=0.05,
+        )
+
+        # Two failures trip the breaker (threshold=2)
+        await registry._sync_adapter(adapter)
+        await registry._sync_adapter(adapter)
+        breaker = registry._breakers["recovering"]
+        assert breaker.is_tripped
+
+        # Wait for reset timeout (0.3s)
+        await asyncio.sleep(0.4)
+        assert breaker.is_half_open
+
+        # Next sync succeeds (sync_count=3 > fail_times=2)
+        await registry._sync_adapter(adapter)
+        assert not breaker.is_tripped
+        assert not breaker.is_half_open
+        assert breaker.failure_count == 0
+
+        # Check profile was upserted
+        profiles = store.list()
+        assert len(profiles) == 1
+        assert profiles[0].backend == "external-cli"
+
+
+# ---------------------------------------------------------------------------
+# TestRegistryRefreshLoop
+# ---------------------------------------------------------------------------
+
+
+class TestRegistryRefreshLoop:
+    async def test_respects_ttl(self) -> None:
+        """Short TTL (0.3s) with fast tick (0.1s) — adapter syncs multiple times."""
+
+        class _CountingAdapter(_FastAdapter):
+            adapter_name = "counting"
+            sync_ttl_seconds = 0.3
+
+            def __init__(self) -> None:
+                self.sync_count = 0
+
+            async def sync(self) -> SyncResult:
+                self.sync_count += 1
+                return await super().sync()
+
+        adapter = _CountingAdapter()
+        store = InMemoryAuthProfileStore()
+        registry = AdapterRegistry(
+            [adapter],
+            store,
+            startup_timeout=3.0,
+            loop_tick_seconds=0.1,
+        )
+
+        # Startup does the first sync
+        await registry.startup()
+        assert adapter.sync_count == 1
+
+        # Run refresh loop for ~0.8s, then cancel
+        loop_task = asyncio.create_task(registry.run_refresh_loop())
+        await asyncio.sleep(0.8)
+        loop_task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await loop_task
+
+        # With TTL=0.3s and tick=0.1s over ~0.8s, we expect at least 2 additional syncs
+        assert adapter.sync_count >= 3

--- a/src/nexus/bricks/auth/tests/test_s3_routing.py
+++ b/src/nexus/bricks/auth/tests/test_s3_routing.py
@@ -1,22 +1,13 @@
-"""Tests for S3 dual-path credential routing in _backend_factory.py."""
+"""Tests for S3 credential routing in _backend_factory.py.
+
+S3 always uses boto3's native provider chain. The external sync framework
+populates the profile store for `auth list` but does NOT inject credentials
+into the S3 backend.
+"""
 
 from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
-
-from nexus.bricks.auth.profile import AuthProfile, ProfileUsageStats
-
-
-def _make_s3_profile() -> AuthProfile:
-    """Return a mock S3 auth profile with external-cli backend."""
-    return AuthProfile(
-        id="s3/default",
-        provider="s3",
-        account_identifier="default",
-        backend="external-cli",
-        backend_key="aws-cli/default",
-        usage_stats=ProfileUsageStats(),
-    )
 
 
 def _make_spec() -> MagicMock:
@@ -28,75 +19,48 @@ def _make_spec() -> MagicMock:
     return spec
 
 
-class TestS3RoutesProfileStore:
-    """S3 routes through the profile store when a usable profile exists."""
+class TestS3AlwaysUsesNativeChain:
+    """S3 backend always uses boto3 native chain, never injected credentials."""
 
-    @patch("nexus.fs._backend_factory._try_profile_store_select")
+    @patch("nexus.fs._external_sync_boot.ensure_external_sync")
+    @patch(
+        "nexus.fs._credentials.discover_credentials", return_value={"source": "credentials_file"}
+    )
     @patch("nexus.backends.storage.path_s3.PathS3Backend")
-    def test_s3_uses_boto3_native_chain_when_profile_found(
-        self,
-        mock_backend_cls: MagicMock,
-        mock_select: MagicMock,
-    ) -> None:
-        """Profile found → PathS3Backend with no explicit credentials (boto3 resolves)."""
-        from nexus.fs._backend_factory import create_backend
-
-        mock_select.return_value = _make_s3_profile()
-        mock_backend_cls.return_value = MagicMock(name="PathS3BackendInstance")
-
-        spec = _make_spec()
-        result = create_backend(spec)
-
-        mock_select.assert_called_once()
-        # No static credentials injected — boto3 native chain handles refresh
-        mock_backend_cls.assert_called_once_with(
-            bucket_name="my-bucket",
-            prefix="some-prefix",
-        )
-        assert result is mock_backend_cls.return_value
-
-    @patch.dict("os.environ", {"AWS_PROFILE": "work-prod"})
-    @patch("nexus.fs._backend_factory._try_profile_store_select")
-    @patch("nexus.backends.storage.path_s3.PathS3Backend")
-    def test_s3_passes_aws_profile_to_selector(
-        self,
-        mock_backend_cls: MagicMock,
-        mock_select: MagicMock,
-    ) -> None:
-        """AWS_PROFILE env var is forwarded to profile selection."""
-        from nexus.fs._backend_factory import create_backend
-
-        mock_select.return_value = None  # force fallback
-        mock_backend_cls.return_value = MagicMock()
-
-        with patch("nexus.fs._credentials.discover_credentials", return_value={"source": "env"}):
-            create_backend(_make_spec())
-
-        mock_select.assert_called_once_with(provider="s3", account="work-prod")
-
-
-class TestS3FallsBackWhenNoProfile:
-    """S3 falls back to discover_credentials() when no profile is available."""
-
-    @patch("nexus.fs._backend_factory._try_profile_store_select", return_value=None)
-    @patch("nexus.fs._credentials.discover_credentials", return_value={"source": "environment"})
-    @patch("nexus.backends.storage.path_s3.PathS3Backend")
-    def test_s3_falls_back_when_no_profile(
+    def test_s3_calls_ensure_sync_and_discover(
         self,
         mock_backend_cls: MagicMock,
         mock_discover: MagicMock,
-        mock_select: MagicMock,
+        mock_sync: MagicMock,
     ) -> None:
         from nexus.fs._backend_factory import create_backend
 
-        mock_backend_cls.return_value = MagicMock(name="PathS3BackendInstance")
-
+        mock_backend_cls.return_value = MagicMock()
         result = create_backend(_make_spec())
 
-        mock_select.assert_called_once()
+        mock_sync.assert_called_once()
         mock_discover.assert_called_once_with("s3")
         mock_backend_cls.assert_called_once_with(
             bucket_name="my-bucket",
             prefix="some-prefix",
         )
         assert result is mock_backend_cls.return_value
+
+    @patch("nexus.fs._credentials.discover_credentials", return_value={"source": "env"})
+    @patch("nexus.backends.storage.path_s3.PathS3Backend")
+    def test_s3_no_explicit_credentials_injected(
+        self,
+        mock_backend_cls: MagicMock,
+        _mock_discover: MagicMock,
+    ) -> None:
+        """PathS3Backend is called with only bucket_name and prefix — no static keys."""
+        from nexus.fs._backend_factory import create_backend
+
+        mock_backend_cls.return_value = MagicMock()
+        create_backend(_make_spec())
+
+        call_kwargs = mock_backend_cls.call_args
+        # Only bucket_name and prefix — no access_key_id, secret_access_key, etc.
+        assert set(call_kwargs.kwargs.keys()) <= {"bucket_name", "prefix"} or (
+            len(call_kwargs.args) <= 2 and not call_kwargs.kwargs.get("access_key_id")
+        )

--- a/src/nexus/bricks/auth/tests/test_s3_routing.py
+++ b/src/nexus/bricks/auth/tests/test_s3_routing.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from unittest.mock import MagicMock, patch
 
-from nexus.bricks.auth.credential_backend import ResolvedCredential
 from nexus.bricks.auth.profile import AuthProfile, ProfileUsageStats
 
 
@@ -20,19 +19,6 @@ def _make_s3_profile() -> AuthProfile:
     )
 
 
-def _make_resolved_cred() -> ResolvedCredential:
-    """Return a mock resolved credential with AWS keys."""
-    return ResolvedCredential(
-        kind="api_key",
-        api_key="AKIAIOSFODNN7EXAMPLE",
-        metadata={
-            "secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-            "session_token": "FwoGZXIvYXdzEA...",
-            "region": "us-west-2",
-        },
-    )
-
-
 def _make_spec() -> MagicMock:
     """Return a mock MountSpec for s3://my-bucket/prefix."""
     spec = MagicMock()
@@ -45,36 +31,48 @@ def _make_spec() -> MagicMock:
 class TestS3RoutesProfileStore:
     """S3 routes through the profile store when a usable profile exists."""
 
-    @patch("nexus.fs._backend_factory._resolve_external_credential")
     @patch("nexus.fs._backend_factory._try_profile_store_select")
     @patch("nexus.backends.storage.path_s3.PathS3Backend")
-    def test_s3_routes_through_profile_store_when_populated(
+    def test_s3_uses_boto3_native_chain_when_profile_found(
         self,
         mock_backend_cls: MagicMock,
         mock_select: MagicMock,
-        mock_resolve: MagicMock,
     ) -> None:
+        """Profile found → PathS3Backend with no explicit credentials (boto3 resolves)."""
         from nexus.fs._backend_factory import create_backend
 
         mock_select.return_value = _make_s3_profile()
-        cred = _make_resolved_cred()
-        mock_resolve.return_value = cred
         mock_backend_cls.return_value = MagicMock(name="PathS3BackendInstance")
 
         spec = _make_spec()
         result = create_backend(spec)
 
-        mock_select.assert_called_once_with(provider="s3")
-        mock_resolve.assert_called_once_with("aws-cli/default")
+        mock_select.assert_called_once()
+        # No static credentials injected — boto3 native chain handles refresh
         mock_backend_cls.assert_called_once_with(
             bucket_name="my-bucket",
             prefix="some-prefix",
-            access_key_id="AKIAIOSFODNN7EXAMPLE",
-            secret_access_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
-            session_token="FwoGZXIvYXdzEA...",
-            region_name="us-west-2",
         )
         assert result is mock_backend_cls.return_value
+
+    @patch.dict("os.environ", {"AWS_PROFILE": "work-prod"})
+    @patch("nexus.fs._backend_factory._try_profile_store_select")
+    @patch("nexus.backends.storage.path_s3.PathS3Backend")
+    def test_s3_passes_aws_profile_to_selector(
+        self,
+        mock_backend_cls: MagicMock,
+        mock_select: MagicMock,
+    ) -> None:
+        """AWS_PROFILE env var is forwarded to profile selection."""
+        from nexus.fs._backend_factory import create_backend
+
+        mock_select.return_value = None  # force fallback
+        mock_backend_cls.return_value = MagicMock()
+
+        with patch("nexus.fs._credentials.discover_credentials", return_value={"source": "env"}):
+            create_backend(_make_spec())
+
+        mock_select.assert_called_once_with(provider="s3", account="work-prod")
 
 
 class TestS3FallsBackWhenNoProfile:
@@ -93,40 +91,9 @@ class TestS3FallsBackWhenNoProfile:
 
         mock_backend_cls.return_value = MagicMock(name="PathS3BackendInstance")
 
-        spec = _make_spec()
-        result = create_backend(spec)
+        result = create_backend(_make_spec())
 
-        mock_select.assert_called_once_with(provider="s3")
-        mock_discover.assert_called_once_with("s3")
-        # Fallback path: PathS3Backend called without explicit credential kwargs
-        mock_backend_cls.assert_called_once_with(
-            bucket_name="my-bucket",
-            prefix="some-prefix",
-        )
-        assert result is mock_backend_cls.return_value
-
-    @patch("nexus.fs._backend_factory._resolve_external_credential", return_value=None)
-    @patch("nexus.fs._backend_factory._try_profile_store_select")
-    @patch("nexus.fs._credentials.discover_credentials", return_value={"source": "environment"})
-    @patch("nexus.backends.storage.path_s3.PathS3Backend")
-    def test_s3_falls_back_when_resolve_fails(
-        self,
-        mock_backend_cls: MagicMock,
-        mock_discover: MagicMock,
-        mock_select: MagicMock,
-        mock_resolve: MagicMock,
-    ) -> None:
-        """Falls back when profile exists but credential resolution fails."""
-        from nexus.fs._backend_factory import create_backend
-
-        mock_select.return_value = _make_s3_profile()
-        mock_backend_cls.return_value = MagicMock(name="PathS3BackendInstance")
-
-        spec = _make_spec()
-        result = create_backend(spec)
-
-        mock_select.assert_called_once_with(provider="s3")
-        mock_resolve.assert_called_once_with("aws-cli/default")
+        mock_select.assert_called_once()
         mock_discover.assert_called_once_with("s3")
         mock_backend_cls.assert_called_once_with(
             bucket_name="my-bucket",

--- a/src/nexus/bricks/auth/tests/test_s3_routing.py
+++ b/src/nexus/bricks/auth/tests/test_s3_routing.py
@@ -1,0 +1,135 @@
+"""Tests for S3 dual-path credential routing in _backend_factory.py."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from nexus.bricks.auth.credential_backend import ResolvedCredential
+from nexus.bricks.auth.profile import AuthProfile, ProfileUsageStats
+
+
+def _make_s3_profile() -> AuthProfile:
+    """Return a mock S3 auth profile with external-cli backend."""
+    return AuthProfile(
+        id="s3/default",
+        provider="s3",
+        account_identifier="default",
+        backend="external-cli",
+        backend_key="aws-cli/default",
+        usage_stats=ProfileUsageStats(),
+    )
+
+
+def _make_resolved_cred() -> ResolvedCredential:
+    """Return a mock resolved credential with AWS keys."""
+    return ResolvedCredential(
+        kind="api_key",
+        api_key="AKIAIOSFODNN7EXAMPLE",
+        metadata={
+            "secret_access_key": "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            "session_token": "FwoGZXIvYXdzEA...",
+            "region": "us-west-2",
+        },
+    )
+
+
+def _make_spec() -> MagicMock:
+    """Return a mock MountSpec for s3://my-bucket/prefix."""
+    spec = MagicMock()
+    spec.scheme = "s3"
+    spec.authority = "my-bucket"
+    spec.path = "/some-prefix"
+    return spec
+
+
+class TestS3RoutesProfileStore:
+    """S3 routes through the profile store when a usable profile exists."""
+
+    @patch("nexus.fs._backend_factory._resolve_external_credential")
+    @patch("nexus.fs._backend_factory._try_profile_store_select")
+    @patch("nexus.backends.storage.path_s3.PathS3Backend")
+    def test_s3_routes_through_profile_store_when_populated(
+        self,
+        mock_backend_cls: MagicMock,
+        mock_select: MagicMock,
+        mock_resolve: MagicMock,
+    ) -> None:
+        from nexus.fs._backend_factory import create_backend
+
+        mock_select.return_value = _make_s3_profile()
+        cred = _make_resolved_cred()
+        mock_resolve.return_value = cred
+        mock_backend_cls.return_value = MagicMock(name="PathS3BackendInstance")
+
+        spec = _make_spec()
+        result = create_backend(spec)
+
+        mock_select.assert_called_once_with(provider="s3")
+        mock_resolve.assert_called_once_with("aws-cli/default")
+        mock_backend_cls.assert_called_once_with(
+            bucket_name="my-bucket",
+            prefix="some-prefix",
+            access_key_id="AKIAIOSFODNN7EXAMPLE",
+            secret_access_key="wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+            session_token="FwoGZXIvYXdzEA...",
+            region_name="us-west-2",
+        )
+        assert result is mock_backend_cls.return_value
+
+
+class TestS3FallsBackWhenNoProfile:
+    """S3 falls back to discover_credentials() when no profile is available."""
+
+    @patch("nexus.fs._backend_factory._try_profile_store_select", return_value=None)
+    @patch("nexus.fs._credentials.discover_credentials", return_value={"source": "environment"})
+    @patch("nexus.backends.storage.path_s3.PathS3Backend")
+    def test_s3_falls_back_when_no_profile(
+        self,
+        mock_backend_cls: MagicMock,
+        mock_discover: MagicMock,
+        mock_select: MagicMock,
+    ) -> None:
+        from nexus.fs._backend_factory import create_backend
+
+        mock_backend_cls.return_value = MagicMock(name="PathS3BackendInstance")
+
+        spec = _make_spec()
+        result = create_backend(spec)
+
+        mock_select.assert_called_once_with(provider="s3")
+        mock_discover.assert_called_once_with("s3")
+        # Fallback path: PathS3Backend called without explicit credential kwargs
+        mock_backend_cls.assert_called_once_with(
+            bucket_name="my-bucket",
+            prefix="some-prefix",
+        )
+        assert result is mock_backend_cls.return_value
+
+    @patch("nexus.fs._backend_factory._resolve_external_credential", return_value=None)
+    @patch("nexus.fs._backend_factory._try_profile_store_select")
+    @patch("nexus.fs._credentials.discover_credentials", return_value={"source": "environment"})
+    @patch("nexus.backends.storage.path_s3.PathS3Backend")
+    def test_s3_falls_back_when_resolve_fails(
+        self,
+        mock_backend_cls: MagicMock,
+        mock_discover: MagicMock,
+        mock_select: MagicMock,
+        mock_resolve: MagicMock,
+    ) -> None:
+        """Falls back when profile exists but credential resolution fails."""
+        from nexus.fs._backend_factory import create_backend
+
+        mock_select.return_value = _make_s3_profile()
+        mock_backend_cls.return_value = MagicMock(name="PathS3BackendInstance")
+
+        spec = _make_spec()
+        result = create_backend(spec)
+
+        mock_select.assert_called_once_with(provider="s3")
+        mock_resolve.assert_called_once_with("aws-cli/default")
+        mock_discover.assert_called_once_with("s3")
+        mock_backend_cls.assert_called_once_with(
+            bucket_name="my-bucket",
+            prefix="some-prefix",
+        )
+        assert result is mock_backend_cls.return_value

--- a/src/nexus/bricks/auth/tests/test_subprocess_adapter.py
+++ b/src/nexus/bricks/auth/tests/test_subprocess_adapter.py
@@ -1,0 +1,166 @@
+"""Tests for SubprocessAdapter base class via synthetic adapter."""
+
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+import uuid
+
+from nexus.bricks.auth.credential_backend import ResolvedCredential
+from nexus.bricks.auth.external_sync.base import SyncedProfile
+from nexus.bricks.auth.external_sync.subprocess_adapter import SubprocessAdapter
+
+
+def _make_synthetic_subprocess(
+    *,
+    binary_name: str = sys.executable,
+    status_args: tuple[str, ...] = (),
+    subprocess_timeout: float = 5.0,
+    max_retries: int = 1,
+) -> SubprocessAdapter:
+    """Create a synthetic SubprocessAdapter for testing."""
+
+    class SyntheticSubprocessAdapter(SubprocessAdapter):
+        adapter_name = "synthetic-subprocess"
+
+        def __init__(
+            self,
+            *,
+            binary: str,
+            args: tuple[str, ...],
+            timeout: float,
+            retries: int,
+        ) -> None:
+            self.binary_name = binary
+            self._status_args = args
+            self._subprocess_timeout = timeout
+            self._max_retries = retries
+
+        def get_status_args(self) -> tuple[str, ...]:
+            return self._status_args
+
+        def parse_output(self, stdout: str, stderr: str) -> list[SyncedProfile]:  # noqa: ARG002
+            lines = [line for line in stdout.strip().splitlines() if line.strip()]
+            return [
+                SyncedProfile(
+                    provider="test",
+                    account_identifier=line.strip(),
+                    backend_key=f"synthetic/{line.strip()}",
+                    source="synthetic-subprocess",
+                )
+                for line in lines
+            ]
+
+        async def resolve_credential(self, backend_key: str) -> ResolvedCredential:  # noqa: ARG002
+            return ResolvedCredential(
+                kind="api_key",
+                api_key="dummy-key",
+            )
+
+    return SyntheticSubprocessAdapter(
+        binary=binary_name,
+        args=status_args,
+        timeout=subprocess_timeout,
+        retries=max_retries,
+    )
+
+
+class TestDetect:
+    async def test_detect_true_for_python(self) -> None:
+        adapter = _make_synthetic_subprocess(binary_name=sys.executable)
+        assert await adapter.detect() is True
+
+    async def test_detect_false_for_nonexistent_binary(self) -> None:
+        adapter = _make_synthetic_subprocess(binary_name="nonexistent-binary-xyz-123456")
+        assert await adapter.detect() is False
+
+
+class TestSyncParsesStdout:
+    async def test_sync_parses_two_profiles(self) -> None:
+        adapter = _make_synthetic_subprocess(
+            status_args=("-c", "print('account1\\naccount2')"),
+        )
+        result = await adapter.sync()
+
+        assert result.error is None
+        assert len(result.profiles) == 2
+        assert result.profiles[0].account_identifier == "account1"
+        assert result.profiles[1].account_identifier == "account2"
+        assert result.adapter_name == "synthetic-subprocess"
+
+
+class TestStderrOnNonzeroExit:
+    async def test_stderr_captured_on_exit_1(self) -> None:
+        adapter = _make_synthetic_subprocess(
+            status_args=(
+                "-c",
+                "import sys; sys.stderr.write('auth failed\\n'); sys.exit(1)",
+            ),
+            max_retries=0,
+        )
+        result = await adapter.sync()
+
+        assert result.error is not None
+        assert "auth failed" in result.error
+
+
+class TestTimeout:
+    async def test_timeout_error(self) -> None:
+        adapter = _make_synthetic_subprocess(
+            status_args=("-c", "import time; time.sleep(30)"),
+            subprocess_timeout=0.5,
+            max_retries=0,
+        )
+        result = await adapter.sync()
+
+        assert result.error is not None
+        assert "timeout" in result.error.lower()
+
+
+class TestMissingBinary:
+    async def test_missing_binary_returns_error(self) -> None:
+        adapter = _make_synthetic_subprocess(
+            binary_name="nonexistent-binary-xyz-123456",
+        )
+        result = await adapter.sync()
+
+        assert result.error is not None
+        assert "not found" in result.error.lower()
+
+
+class TestRetryOnTransientFailure:
+    async def test_retry_succeeds_on_second_attempt(self) -> None:
+        marker = os.path.join(
+            tempfile.gettempdir(),
+            f"subprocess_adapter_test_{uuid.uuid4().hex}",
+        )
+        try:
+            # Script: first call creates marker and fails, second finds marker
+            # and succeeds.
+            script = (
+                "import os, sys\n"
+                f"marker = {marker!r}\n"
+                "if not os.path.exists(marker):\n"
+                "    with open(marker, 'w') as f:\n"
+                "        f.write('done')\n"
+                "    sys.stderr.write('transient error\\n')\n"
+                "    sys.exit(1)\n"
+                "else:\n"
+                "    print('recovered-account')\n"
+            )
+            adapter = _make_synthetic_subprocess(
+                status_args=("-c", script),
+                max_retries=2,
+            )
+            # Override backoff to speed up the test
+            adapter._backoff_base = 0.01
+
+            result = await adapter.sync()
+
+            assert result.error is None
+            assert len(result.profiles) == 1
+            assert result.profiles[0].account_identifier == "recovered-account"
+        finally:
+            if os.path.exists(marker):
+                os.remove(marker)

--- a/src/nexus/fs/_auth_cli.py
+++ b/src/nexus/fs/_auth_cli.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import asyncio
 import importlib
+import logging
 import os
 import re
 from typing import Any
@@ -17,6 +18,7 @@ from nexus.contracts.unified_auth import AuthStatus, CredentialKind
 from nexus.fs._oauth_support import get_token_manager, run_google_oauth_setup, run_x_oauth_setup
 from nexus.fs._output import OutputOptions, add_output_options, render_output
 
+logger = logging.getLogger(__name__)
 console = Console()
 
 _SERVICE_AUTH_TYPES: dict[str, tuple[str, ...]] = {
@@ -308,6 +310,14 @@ def _format_status(profile: Any) -> str:
     if profile.last_synced_at is None:
         return "not yet synced"
 
+    # Check if sync is stale (last_synced_at + sync_ttl_seconds < now)
+    last_synced = profile.last_synced_at
+    if last_synced.tzinfo is None:
+        last_synced = last_synced.replace(tzinfo=_dt.UTC)
+    stale_after = last_synced + _dt.timedelta(seconds=profile.sync_ttl_seconds)
+    if stale_after < now:
+        return "stale"
+
     return "ok"
 
 
@@ -397,11 +407,27 @@ def list_auth(output_opts: OutputOptions) -> None:
                     "last_used": s.message,
                 }
             )
-    except Exception:
-        pass  # Legacy path unavailable — show only profile store entries
+    except Exception as exc:
+        logger.debug("Legacy auth service unavailable: %s", exc)
+        data.append(
+            {
+                "provider": "(legacy)",
+                "account": "",
+                "source": "error",
+                "status": "degraded",
+                "last_used": f"Legacy auth check failed: {exc}",
+            }
+        )
 
     if not data:
-        console.print("[dim]No auth configured. Run `nexus-fs auth connect` to set up.[/dim]")
+        # Use render_output for consistent JSON/human output
+        render_output(
+            data=[],
+            output_opts=output_opts,
+            human_formatter=lambda _: console.print(
+                "[dim]No auth configured. Run `nexus-fs auth connect` to set up.[/dim]"
+            ),
+        )
         return
 
     def _human_display(_data: object) -> None:

--- a/src/nexus/fs/_auth_cli.py
+++ b/src/nexus/fs/_auth_cli.py
@@ -272,6 +272,11 @@ def _try_profile_store_list() -> list[Any] | None:
     Returns the list of AuthProfile objects on success, or None if the store
     is unavailable, empty, or raises any exception.
     """
+    # Ensure external CLIs (aws-cli, etc.) have been synced into the store.
+    from nexus.fs._external_sync_boot import ensure_external_sync
+
+    ensure_external_sync()
+
     try:
         from nexus.bricks.auth.profile_store import SqliteAuthProfileStore
         from nexus.fs._paths import persistent_dir

--- a/src/nexus/fs/_auth_cli.py
+++ b/src/nexus/fs/_auth_cli.py
@@ -380,80 +380,74 @@ def _source_display(backend: str) -> str:
 @auth.command("list")
 @add_output_options
 def list_auth(output_opts: OutputOptions) -> None:
-    """List configured auth across services."""
+    """List configured auth across services.
+
+    Merges two sources:
+      1. Profile store (external-CLI synced profiles + migrated OAuth profiles)
+      2. Legacy UnifiedAuthService summaries (OAuth, secret, native discovery)
+
+    Profile store entries take precedence when both sources have the same
+    provider. Legacy entries fill in services not yet in the profile store.
+    """
+    data: list[dict[str, str]] = []
+    seen_providers: set[str] = set()
+
+    # 1. Profile store entries (external-cli synced + migrated)
     profiles = _try_profile_store_list()
-
     if profiles is not None:
-        # New unified table from profile store
-        data = [
-            {
-                "provider": p.provider,
-                "account": p.account_identifier,
-                "source": _source_display(p.backend),
-                "status": _format_status(p),
-                "last_used": _format_relative_time(p.usage_stats.last_used_at),
-            }
-            for p in profiles
-        ]
+        for p in profiles:
+            seen_providers.add(p.provider)
+            data.append(
+                {
+                    "provider": p.provider,
+                    "account": p.account_identifier,
+                    "source": _source_display(p.backend),
+                    "status": _format_status(p),
+                    "last_used": _format_relative_time(p.usage_stats.last_used_at),
+                }
+            )
 
-        def _human_display(_data: object) -> None:
-            table = Table(title="Unified Auth", show_header=True, header_style="bold cyan")
-            table.add_column("Provider", style="green")
-            table.add_column("Account", style="cyan")
-            table.add_column("Source", style="blue")
-            table.add_column("Status", style="yellow")
-            table.add_column("Last used")
-            for row in data:
-                table.add_row(
-                    row["provider"],
-                    row["account"],
-                    row["source"],
-                    row["status"],
-                    row["last_used"],
-                )
-            console.print(table)
+    # 2. Legacy summaries — fill in services not yet in the profile store
+    try:
+        service = _build_auth_service()
+        summaries = asyncio.run(service.list_summaries())
+        for s in summaries:
+            if s.service in seen_providers:
+                continue
+            data.append(
+                {
+                    "provider": s.service,
+                    "account": "",
+                    "source": s.source,
+                    "status": s.status.value,
+                    "last_used": s.message,
+                }
+            )
+    except Exception:
+        pass  # Legacy path unavailable — show only profile store entries
 
-        render_output(data=data, output_opts=output_opts, human_formatter=_human_display)
+    if not data:
+        console.print("[dim]No auth configured. Run `nexus-fs auth connect` to set up.[/dim]")
         return
 
-    # Fallback: old UnifiedAuthService path
-    service = _build_auth_service()
-    summaries = asyncio.run(service.list_summaries())
-
-    data_legacy = [
-        {
-            "service": s.service,
-            "kind": s.kind.value,
-            "status": s.status.value,
-            "source": s.source,
-            "message": s.message,
-        }
-        for s in summaries
-    ]
-
-    def _human_display_legacy(_data: object) -> None:
+    def _human_display(_data: object) -> None:
         table = Table(title="Unified Auth", show_header=True, header_style="bold cyan")
-        table.add_column("Service", style="green")
-        table.add_column("Kind", style="cyan")
-        table.add_column("Status", style="yellow")
+        table.add_column("Provider", style="green")
+        table.add_column("Account", style="cyan")
         table.add_column("Source", style="blue")
-        table.add_column("Message")
-        for summary in summaries:
+        table.add_column("Status", style="yellow")
+        table.add_column("Last used")
+        for row in data:
             table.add_row(
-                summary.service,
-                summary.kind.value,
-                summary.status.value,
-                summary.source,
-                summary.message,
+                row["provider"],
+                row["account"],
+                row["source"],
+                row["status"],
+                row["last_used"],
             )
         console.print(table)
-        console.print(f"[dim]Secret store: {service.secret_store_path}[/dim]")
 
-    render_output(
-        data=data_legacy,
-        output_opts=output_opts,
-        human_formatter=_human_display_legacy,
-    )
+    render_output(data=data, output_opts=output_opts, human_formatter=_human_display)
 
 
 @auth.command("test")

--- a/src/nexus/fs/_auth_cli.py
+++ b/src/nexus/fs/_auth_cli.py
@@ -272,36 +272,10 @@ def _try_profile_store_list() -> list[Any] | None:
     Returns the list of AuthProfile objects on success, or None if the store
     is unavailable, empty, or raises any exception.
     """
-    # Ensure external CLIs (aws-cli, etc.) have been synced into the store.
-    from nexus.fs._external_sync_boot import ensure_external_sync
+    from nexus.fs._external_sync_boot import ensure_external_sync, list_profiles
 
     ensure_external_sync()
-
-    try:
-        from nexus.bricks.auth.profile_store import SqliteAuthProfileStore
-        from nexus.fs._paths import persistent_dir
-    except ImportError:
-        return None
-
-    db_path = persistent_dir() / "auth_profiles.db"
-    if not db_path.exists():
-        return None
-
-    import contextlib
-
-    store = None
-    try:
-        store = SqliteAuthProfileStore(db_path)
-        profiles = store.list()
-        if not profiles:
-            return None
-        return profiles
-    except Exception:
-        return None
-    finally:
-        if store is not None:
-            with contextlib.suppress(Exception):
-                store.close()
+    return list_profiles()
 
 
 def _format_status(profile: Any) -> str:

--- a/src/nexus/fs/_auth_cli.py
+++ b/src/nexus/fs/_auth_cli.py
@@ -261,14 +261,161 @@ def auth() -> None:
     """Unified auth commands for nexus-fs."""
 
 
+# ---------------------------------------------------------------------------
+# Helpers for the dual-read auth list
+# ---------------------------------------------------------------------------
+
+
+def _try_profile_store_list() -> list[Any] | None:
+    """Try reading from the unified profile store.
+
+    Returns the list of AuthProfile objects on success, or None if the store
+    is unavailable, empty, or raises any exception.
+    """
+    try:
+        from nexus.bricks.auth.profile_store import SqliteAuthProfileStore
+        from nexus.fs._paths import persistent_dir
+    except ImportError:
+        return None
+
+    db_path = persistent_dir() / "auth_profiles.db"
+    if not db_path.exists():
+        return None
+
+    import contextlib
+
+    store = None
+    try:
+        store = SqliteAuthProfileStore(db_path)
+        profiles = store.list()
+        if not profiles:
+            return None
+        return profiles
+    except Exception:
+        return None
+    finally:
+        if store is not None:
+            with contextlib.suppress(Exception):
+                store.close()
+
+
+def _format_status(profile: Any) -> str:
+    """Format status string for a profile row."""
+    import datetime as _dt
+
+    now = _dt.datetime.now(_dt.UTC)
+    stats = profile.usage_stats
+
+    if stats.disabled_until is not None:
+        disabled_until = stats.disabled_until
+        if disabled_until.tzinfo is None:
+            disabled_until = disabled_until.replace(tzinfo=_dt.UTC)
+        if disabled_until > now:
+            return "disabled"
+
+    if stats.cooldown_until is not None:
+        cooldown_until = stats.cooldown_until
+        if cooldown_until.tzinfo is None:
+            cooldown_until = cooldown_until.replace(tzinfo=_dt.UTC)
+        if cooldown_until > now:
+            remaining = cooldown_until - now
+            total_minutes = int(remaining.total_seconds() / 60)
+            reason = stats.cooldown_reason.value if stats.cooldown_reason else "unknown"
+            if total_minutes > 60:
+                hours = total_minutes / 60
+                return f"cooldown  {reason} · {hours:.1f}h left"
+            return f"cooldown  {reason} · {total_minutes}m left"
+
+    if profile.last_synced_at is None:
+        return "not yet synced"
+
+    return "ok"
+
+
+def _format_relative_time(dt: Any) -> str:
+    """Format a datetime as a human-readable relative time string."""
+    import datetime as _dt
+
+    if dt is None:
+        return "never"
+
+    now = _dt.datetime.now(_dt.UTC)
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=_dt.UTC)
+
+    delta = now - dt
+    seconds = int(delta.total_seconds())
+
+    if seconds < 60:
+        return "just now"
+    minutes = seconds // 60
+    if minutes < 60:
+        return f"{minutes}m ago"
+    hours = minutes // 60
+    if hours < 24:
+        return f"{hours}h ago"
+    days = hours // 24
+    return f"{days}d ago"
+
+
+def _source_display(backend: str) -> str:
+    """Map backend name to a short display string."""
+    if backend == "external-cli":
+        return "external"
+    if backend == "nexus-token-manager":
+        return "nexus"
+    return backend
+
+
+# ---------------------------------------------------------------------------
+# auth list (dual-read: profile store primary, legacy fallback)
+# ---------------------------------------------------------------------------
+
+
 @auth.command("list")
 @add_output_options
 def list_auth(output_opts: OutputOptions) -> None:
     """List configured auth across services."""
+    profiles = _try_profile_store_list()
+
+    if profiles is not None:
+        # New unified table from profile store
+        data = [
+            {
+                "provider": p.provider,
+                "account": p.account_identifier,
+                "source": _source_display(p.backend),
+                "status": _format_status(p),
+                "last_used": _format_relative_time(p.usage_stats.last_used_at),
+            }
+            for p in profiles
+        ]
+
+        def _human_display(_data: object) -> None:
+            table = Table(title="Unified Auth", show_header=True, header_style="bold cyan")
+            table.add_column("Provider", style="green")
+            table.add_column("Account", style="cyan")
+            table.add_column("Source", style="blue")
+            table.add_column("Status", style="yellow")
+            table.add_column("Last used")
+            for row in data:
+                table.add_row(
+                    row["provider"],
+                    row["account"],
+                    row["source"],
+                    row["status"],
+                    row["last_used"],
+                )
+            console.print(table)
+
+        render_output(data=data, output_opts=output_opts, human_formatter=_human_display)
+        return
+
+    # Fallback: old UnifiedAuthService path
     service = _build_auth_service()
     summaries = asyncio.run(service.list_summaries())
 
-    data = [
+    data_legacy = [
         {
             "service": s.service,
             "kind": s.kind.value,
@@ -279,7 +426,7 @@ def list_auth(output_opts: OutputOptions) -> None:
         for s in summaries
     ]
 
-    def _human_display(_data: object) -> None:
+    def _human_display_legacy(_data: object) -> None:
         table = Table(title="Unified Auth", show_header=True, header_style="bold cyan")
         table.add_column("Service", style="green")
         table.add_column("Kind", style="cyan")
@@ -298,9 +445,9 @@ def list_auth(output_opts: OutputOptions) -> None:
         console.print(f"[dim]Secret store: {service.secret_store_path}[/dim]")
 
     render_output(
-        data=data,
+        data=data_legacy,
         output_opts=output_opts,
-        human_formatter=_human_display,
+        human_formatter=_human_display_legacy,
     )
 
 

--- a/src/nexus/fs/_auth_cli.py
+++ b/src/nexus/fs/_auth_cli.py
@@ -404,6 +404,10 @@ def list_auth(output_opts: OutputOptions) -> None:
                     "source": s.source,
                     "status": s.status.value,
                     "last_used": s.message,
+                    # Backward-compatible keys for JSON consumers
+                    "service": s.service,
+                    "kind": s.kind.value,
+                    "message": s.message,
                 }
             )
     except Exception as exc:

--- a/src/nexus/fs/_auth_cli.py
+++ b/src/nexus/fs/_auth_cli.py
@@ -374,13 +374,11 @@ def list_auth(output_opts: OutputOptions) -> None:
     provider. Legacy entries fill in services not yet in the profile store.
     """
     data: list[dict[str, str]] = []
-    seen_providers: set[str] = set()
 
     # 1. Profile store entries (external-cli synced + migrated)
     profiles = _try_profile_store_list()
     if profiles is not None:
         for p in profiles:
-            seen_providers.add(p.provider)
             data.append(
                 {
                     "provider": p.provider,
@@ -391,13 +389,14 @@ def list_auth(output_opts: OutputOptions) -> None:
                 }
             )
 
-    # 2. Legacy summaries — fill in services not yet in the profile store
+    # 2. Legacy summaries — always included alongside profile store entries.
+    # The external-cli adapter (Phase 2) only discovers inline-key AWS profiles,
+    # so legacy summaries still provide valuable info for SSO/role/credential_process
+    # setups and non-AWS services. No provider dedup — both sources complement.
     try:
         service = _build_auth_service()
         summaries = asyncio.run(service.list_summaries())
         for s in summaries:
-            if s.service in seen_providers:
-                continue
             data.append(
                 {
                     "provider": s.service,

--- a/src/nexus/fs/_backend_factory.py
+++ b/src/nexus/fs/_backend_factory.py
@@ -17,6 +17,70 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+def _try_profile_store_select(provider: str) -> Any:
+    """Try to select a usable auth profile from the profile store.
+
+    Returns the first AuthProfile that is NOT on cooldown or disabled.
+    If all are on cooldown, returns the first profile anyway (let the
+    caller decide). Returns None on any error (ImportError, no DB,
+    empty list, exception).
+    """
+    try:
+        from nexus.bricks.auth.profile_store import SqliteAuthProfileStore
+        from nexus.fs._paths import persistent_dir
+    except ImportError:
+        return None
+
+    try:
+        db_path = persistent_dir() / "auth_profiles.db"
+        if not db_path.exists():
+            return None
+
+        store = SqliteAuthProfileStore(db_path)
+        try:
+            profiles = store.list(provider=provider)
+        finally:
+            store.close()
+
+        if not profiles:
+            return None
+
+        from datetime import UTC, datetime
+
+        now = datetime.now(UTC)
+        for profile in profiles:
+            stats = profile.usage_stats
+            if stats.cooldown_until and stats.cooldown_until > now:
+                continue
+            if stats.disabled_until and stats.disabled_until > now:
+                continue
+            return profile
+
+        # All on cooldown — return first anyway
+        return profiles[0]
+    except Exception:
+        return None
+
+
+def _resolve_external_credential(backend_key: str) -> Any:
+    """Resolve a credential using the AwsCliSyncAdapter.
+
+    Returns a ResolvedCredential on success, None on any exception.
+    """
+    try:
+        import asyncio
+
+        from nexus.bricks.auth.external_sync.aws_sync import AwsCliSyncAdapter
+    except ImportError:
+        return None
+
+    try:
+        adapter = AwsCliSyncAdapter()
+        return asyncio.run(adapter.resolve_credential(backend_key))
+    except Exception:
+        return None
+
+
 def create_backend(spec: Any) -> Any:
     """Create a storage backend from a parsed MountSpec.
 
@@ -28,11 +92,6 @@ def create_backend(spec: Any) -> Any:
         ImportError: If the backend's optional dependency is not installed.
         BackendNotFoundError: If the backend resource doesn't exist.
     """
-    from nexus.fs._credentials import discover_credentials
-
-    # Discover credentials (raises CloudCredentialError if missing)
-    discover_credentials(spec.scheme)
-
     if spec.scheme == "s3":
         try:
             from nexus.backends.storage.path_s3 import PathS3Backend
@@ -40,12 +99,34 @@ def create_backend(spec: Any) -> Any:
             raise ImportError(
                 "boto3 is required for S3 backends. Install with: pip install nexus-fs[s3]"
             ) from None
+
+        # Phase 2: try profile store first
+        profile = _try_profile_store_select(provider="s3")
+        if profile is not None and profile.backend == "external-cli":
+            cred = _resolve_external_credential(profile.backend_key)
+            if cred is not None:
+                return PathS3Backend(
+                    bucket_name=spec.authority,
+                    prefix=spec.path.lstrip("/") if spec.path else "",
+                    access_key_id=cred.api_key,
+                    secret_access_key=cred.metadata.get("secret_access_key", ""),
+                    session_token=cred.metadata.get("session_token") or None,
+                    region_name=cred.metadata.get("region") or None,
+                )
+
+        # Fallback: old discover_credentials() path
+        from nexus.fs._credentials import discover_credentials
+
+        discover_credentials(spec.scheme)
         return PathS3Backend(
             bucket_name=spec.authority,
             prefix=spec.path.lstrip("/") if spec.path else "",
         )
 
     elif spec.scheme == "gcs":
+        from nexus.fs._credentials import discover_credentials
+
+        discover_credentials(spec.scheme)
         try:
             from nexus.backends.storage.cas_gcs import CASGCSBackend
         except ImportError:

--- a/src/nexus/fs/_backend_factory.py
+++ b/src/nexus/fs/_backend_factory.py
@@ -66,6 +66,10 @@ def _resolve_external_credential(backend_key: str) -> Any:
     """Resolve a credential using the AwsCliSyncAdapter.
 
     Returns a ResolvedCredential on success, None on any exception.
+
+    Phase 2 shortcut: directly instantiates AwsCliSyncAdapter instead of
+    going through ExternalCliBackend + AdapterRegistry. Replace with proper
+    backend integration in Phase 3 when additional adapters are added.
     """
     try:
         import asyncio

--- a/src/nexus/fs/_backend_factory.py
+++ b/src/nexus/fs/_backend_factory.py
@@ -17,29 +17,17 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-def _try_profile_store_select(provider: str) -> Any:
+def _try_profile_store_select(provider: str, *, account: str | None = None) -> Any:
     """Try to select a usable auth profile from the profile store.
 
-    Returns the first AuthProfile that is NOT on cooldown or disabled.
-    If all are on cooldown, returns the first profile anyway (let the
-    caller decide). Returns None on any error.
+    Returns a single AuthProfile that is NOT on cooldown or disabled.
+    Returns None when: no profiles exist, selection is ambiguous (multiple
+    profiles with no explicit account), or all profiles are blocked.
     """
     from nexus.fs._external_sync_boot import ensure_external_sync, select_profile
 
     ensure_external_sync()
-    return select_profile(provider)
-
-
-def _resolve_external_credential(backend_key: str) -> Any:
-    """Resolve a credential via the external CLI adapter.
-
-    Phase 2 shortcut: directly instantiates AwsCliSyncAdapter instead of
-    going through ExternalCliBackend + AdapterRegistry. Replace with proper
-    backend integration in Phase 3 when additional adapters are added.
-    """
-    from nexus.fs._external_sync_boot import resolve_external_credential
-
-    return resolve_external_credential(backend_key)
+    return select_profile(provider, account=account)
 
 
 def create_backend(spec: Any) -> Any:
@@ -61,21 +49,20 @@ def create_backend(spec: Any) -> Any:
                 "boto3 is required for S3 backends. Install with: pip install nexus-fs[s3]"
             ) from None
 
-        # Phase 2: try profile store first
-        profile = _try_profile_store_select(provider="s3")
+        # Phase 2: verify S3 credentials are available via profile store.
+        # We do NOT inject static credentials — boto3's native provider chain
+        # handles credential refresh (SSO, STS, instance metadata). The profile
+        # store is for discovery/listing only.
+        profile = _try_profile_store_select(provider="s3", account=os.environ.get("AWS_PROFILE"))
         if profile is not None and profile.backend == "external-cli":
-            cred = _resolve_external_credential(profile.backend_key)
-            if cred is not None:
-                return PathS3Backend(
-                    bucket_name=spec.authority,
-                    prefix=spec.path.lstrip("/") if spec.path else "",
-                    access_key_id=cred.api_key,
-                    secret_access_key=cred.metadata.get("secret_access_key", ""),
-                    session_token=cred.metadata.get("session_token") or None,
-                    region_name=cred.metadata.get("region") or None,
-                )
+            # Profile found — AWS credentials are confirmed available.
+            # Let boto3 resolve them natively (keeps refresh working).
+            return PathS3Backend(
+                bucket_name=spec.authority,
+                prefix=spec.path.lstrip("/") if spec.path else "",
+            )
 
-        # Fallback: old discover_credentials() path
+        # No profile store match — fall back to old discover_credentials() path
         from nexus.fs._credentials import discover_credentials
 
         discover_credentials(spec.scheme)

--- a/src/nexus/fs/_backend_factory.py
+++ b/src/nexus/fs/_backend_factory.py
@@ -25,6 +25,11 @@ def _try_profile_store_select(provider: str) -> Any:
     caller decide). Returns None on any error (ImportError, no DB,
     empty list, exception).
     """
+    # Ensure external CLIs (aws-cli, etc.) have been synced into the store.
+    from nexus.fs._external_sync_boot import ensure_external_sync
+
+    ensure_external_sync()
+
     try:
         from nexus.bricks.auth.profile_store import SqliteAuthProfileStore
         from nexus.fs._paths import persistent_dir

--- a/src/nexus/fs/_backend_factory.py
+++ b/src/nexus/fs/_backend_factory.py
@@ -85,7 +85,16 @@ def _resolve_external_credential(backend_key: str) -> Any:
 
     try:
         adapter = AwsCliSyncAdapter()
-        return asyncio.run(adapter.resolve_credential(backend_key))
+        coro = adapter.resolve_credential(backend_key)
+        try:
+            asyncio.get_running_loop()
+            # Inside async context — run in a thread
+            import concurrent.futures
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                return pool.submit(asyncio.run, coro).result(timeout=10.0)
+        except RuntimeError:
+            return asyncio.run(coro)
     except Exception:
         return None
 

--- a/src/nexus/fs/_backend_factory.py
+++ b/src/nexus/fs/_backend_factory.py
@@ -22,81 +22,24 @@ def _try_profile_store_select(provider: str) -> Any:
 
     Returns the first AuthProfile that is NOT on cooldown or disabled.
     If all are on cooldown, returns the first profile anyway (let the
-    caller decide). Returns None on any error (ImportError, no DB,
-    empty list, exception).
+    caller decide). Returns None on any error.
     """
-    # Ensure external CLIs (aws-cli, etc.) have been synced into the store.
-    from nexus.fs._external_sync_boot import ensure_external_sync
+    from nexus.fs._external_sync_boot import ensure_external_sync, select_profile
 
     ensure_external_sync()
-
-    try:
-        from nexus.bricks.auth.profile_store import SqliteAuthProfileStore
-        from nexus.fs._paths import persistent_dir
-    except ImportError:
-        return None
-
-    try:
-        db_path = persistent_dir() / "auth_profiles.db"
-        if not db_path.exists():
-            return None
-
-        store = SqliteAuthProfileStore(db_path)
-        try:
-            profiles = store.list(provider=provider)
-        finally:
-            store.close()
-
-        if not profiles:
-            return None
-
-        from datetime import UTC, datetime
-
-        now = datetime.now(UTC)
-        for profile in profiles:
-            stats = profile.usage_stats
-            if stats.cooldown_until and stats.cooldown_until > now:
-                continue
-            if stats.disabled_until and stats.disabled_until > now:
-                continue
-            return profile
-
-        # All on cooldown — return first anyway
-        return profiles[0]
-    except Exception:
-        return None
+    return select_profile(provider)
 
 
 def _resolve_external_credential(backend_key: str) -> Any:
-    """Resolve a credential using the AwsCliSyncAdapter.
-
-    Returns a ResolvedCredential on success, None on any exception.
+    """Resolve a credential via the external CLI adapter.
 
     Phase 2 shortcut: directly instantiates AwsCliSyncAdapter instead of
     going through ExternalCliBackend + AdapterRegistry. Replace with proper
     backend integration in Phase 3 when additional adapters are added.
     """
-    try:
-        import asyncio
+    from nexus.fs._external_sync_boot import resolve_external_credential
 
-        from nexus.bricks.auth.external_sync.aws_sync import AwsCliSyncAdapter
-    except ImportError:
-        return None
-
-    try:
-        adapter = AwsCliSyncAdapter()
-        coro = adapter.resolve_credential(backend_key)
-        try:
-            asyncio.get_running_loop()
-            # Inside async context — run in a thread
-            import concurrent.futures
-
-            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
-                return pool.submit(asyncio.run, coro).result(timeout=10.0)
-        except RuntimeError:
-            return asyncio.run(coro)
-    except Exception:
-        return None
+    return resolve_external_credential(backend_key)
 
 
 def create_backend(spec: Any) -> Any:

--- a/src/nexus/fs/_backend_factory.py
+++ b/src/nexus/fs/_backend_factory.py
@@ -17,19 +17,6 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
-def _try_profile_store_select(provider: str, *, account: str | None = None) -> Any:
-    """Try to select a usable auth profile from the profile store.
-
-    Returns a single AuthProfile that is NOT on cooldown or disabled.
-    Returns None when: no profiles exist, selection is ambiguous (multiple
-    profiles with no explicit account), or all profiles are blocked.
-    """
-    from nexus.fs._external_sync_boot import ensure_external_sync, select_profile
-
-    ensure_external_sync()
-    return select_profile(provider, account=account)
-
-
 def create_backend(spec: Any) -> Any:
     """Create a storage backend from a parsed MountSpec.
 
@@ -49,20 +36,15 @@ def create_backend(spec: Any) -> Any:
                 "boto3 is required for S3 backends. Install with: pip install nexus-fs[s3]"
             ) from None
 
-        # Phase 2: verify S3 credentials are available via profile store.
-        # We do NOT inject static credentials — boto3's native provider chain
-        # handles credential refresh (SSO, STS, instance metadata). The profile
-        # store is for discovery/listing only.
-        profile = _try_profile_store_select(provider="s3", account=os.environ.get("AWS_PROFILE"))
-        if profile is not None and profile.backend == "external-cli":
-            # Profile found — AWS credentials are confirmed available.
-            # Let boto3 resolve them natively (keeps refresh working).
-            return PathS3Backend(
-                bucket_name=spec.authority,
-                prefix=spec.path.lstrip("/") if spec.path else "",
-            )
+        # Phase 2: ensure external-CLI sync has run (populates auth list).
+        # S3 credential resolution always uses boto3's native provider chain
+        # (which handles SSO/STS refresh, instance metadata, etc.). The profile
+        # store is for discovery/listing in `auth list`, not for credential
+        # injection at mount time.
+        from nexus.fs._external_sync_boot import ensure_external_sync
 
-        # No profile store match — fall back to old discover_credentials() path
+        ensure_external_sync()
+
         from nexus.fs._credentials import discover_credentials
 
         discover_credentials(spec.scheme)

--- a/src/nexus/fs/_external_sync_boot.py
+++ b/src/nexus/fs/_external_sync_boot.py
@@ -2,7 +2,8 @@
 
 Runs AdapterRegistry.startup() at most once per process. Safe for the
 slim nexus-fs wheel — all imports from nexus.bricks.auth.external_sync
-are behind try/except ImportError guards.
+use importlib.import_module() to avoid static import references that
+would violate the packaging boundary (test_boundary.py).
 
 Called by:
   - _auth_cli._try_profile_store_list()  (nexus-fs auth list)
@@ -11,6 +12,7 @@ Called by:
 
 from __future__ import annotations
 
+import importlib
 import logging
 
 logger = logging.getLogger(__name__)
@@ -33,37 +35,117 @@ def ensure_external_sync() -> None:
     try:
         import asyncio
 
-        from nexus.bricks.auth.external_sync.aws_sync import AwsCliSyncAdapter
-        from nexus.bricks.auth.external_sync.registry import AdapterRegistry
-        from nexus.bricks.auth.profile_store import SqliteAuthProfileStore
+        aws_mod = importlib.import_module("nexus.bricks.auth.external_sync.aws_sync")
+        reg_mod = importlib.import_module("nexus.bricks.auth.external_sync.registry")
+        store_mod = importlib.import_module("nexus.bricks.auth.profile_store")
         from nexus.fs._paths import persistent_dir
-    except ImportError:
+    except (ImportError, ModuleNotFoundError):
         # Slim wheel — external_sync not available. Silent no-op.
         return
 
     try:
         db_path = persistent_dir() / "auth_profiles.db"
-        store = SqliteAuthProfileStore(db_path)
+        store = store_mod.SqliteAuthProfileStore(db_path)
         try:
-            registry = AdapterRegistry(
-                adapters=[AwsCliSyncAdapter()],
+            registry = reg_mod.AdapterRegistry(
+                adapters=[aws_mod.AwsCliSyncAdapter()],
                 profile_store=store,
                 startup_timeout=3.0,
             )
             coro = registry.startup()
-            # If called inside an already-running event loop (e.g. async mount),
-            # we can't use asyncio.run(). Fall back to running in a new thread.
             try:
                 asyncio.get_running_loop()
-                # Already in an async context — run sync in a thread
                 import concurrent.futures
 
                 with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
                     pool.submit(asyncio.run, coro).result(timeout=5.0)
             except RuntimeError:
-                # No running loop — safe to use asyncio.run()
                 asyncio.run(coro)
         finally:
             store.close()
     except Exception:
         logger.debug("External CLI sync failed during bootstrap", exc_info=True)
+
+
+def list_profiles() -> list | None:
+    """Read all profiles from the unified store. Returns None on any failure."""
+    try:
+        store_mod = importlib.import_module("nexus.bricks.auth.profile_store")
+        from nexus.fs._paths import persistent_dir
+    except (ImportError, ModuleNotFoundError):
+        return None
+
+    db_path = persistent_dir() / "auth_profiles.db"
+    if not db_path.exists():
+        return None
+
+    try:
+        store = store_mod.SqliteAuthProfileStore(db_path)
+        try:
+            profiles = store.list()
+        finally:
+            store.close()
+        return profiles if profiles else None
+    except Exception:
+        return None
+
+
+def select_profile(provider: str):  # noqa: ANN201
+    """Select a usable profile for a provider. Returns None on any failure."""
+    try:
+        store_mod = importlib.import_module("nexus.bricks.auth.profile_store")
+        from nexus.fs._paths import persistent_dir
+    except (ImportError, ModuleNotFoundError):
+        return None
+
+    db_path = persistent_dir() / "auth_profiles.db"
+    if not db_path.exists():
+        return None
+
+    try:
+        store = store_mod.SqliteAuthProfileStore(db_path)
+        try:
+            profiles = store.list(provider=provider)
+        finally:
+            store.close()
+
+        if not profiles:
+            return None
+
+        from datetime import UTC, datetime
+
+        now = datetime.now(UTC)
+        for profile in profiles:
+            stats = profile.usage_stats
+            if stats.cooldown_until and stats.cooldown_until > now:
+                continue
+            if stats.disabled_until and stats.disabled_until > now:
+                continue
+            return profile
+        return profiles[0]
+    except Exception:
+        return None
+
+
+def resolve_external_credential(backend_key: str):  # noqa: ANN201
+    """Resolve a credential via AwsCliSyncAdapter. Returns None on failure."""
+    try:
+        import asyncio
+
+        aws_mod = importlib.import_module("nexus.bricks.auth.external_sync.aws_sync")
+    except (ImportError, ModuleNotFoundError):
+        return None
+
+    try:
+        adapter = aws_mod.AwsCliSyncAdapter()
+        coro = adapter.resolve_credential(backend_key)
+        try:
+            asyncio.get_running_loop()
+            import concurrent.futures
+
+            with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                return pool.submit(asyncio.run, coro).result(timeout=10.0)
+        except RuntimeError:
+            return asyncio.run(coro)
+    except Exception:
+        return None

--- a/src/nexus/fs/_external_sync_boot.py
+++ b/src/nexus/fs/_external_sync_boot.py
@@ -50,7 +50,19 @@ def ensure_external_sync() -> None:
                 profile_store=store,
                 startup_timeout=3.0,
             )
-            asyncio.run(registry.startup())
+            coro = registry.startup()
+            # If called inside an already-running event loop (e.g. async mount),
+            # we can't use asyncio.run(). Fall back to running in a new thread.
+            try:
+                asyncio.get_running_loop()
+                # Already in an async context — run sync in a thread
+                import concurrent.futures
+
+                with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
+                    pool.submit(asyncio.run, coro).result(timeout=5.0)
+            except RuntimeError:
+                # No running loop — safe to use asyncio.run()
+                asyncio.run(coro)
         finally:
             store.close()
     except Exception:

--- a/src/nexus/fs/_external_sync_boot.py
+++ b/src/nexus/fs/_external_sync_boot.py
@@ -1,0 +1,57 @@
+"""Lazy one-shot bootstrap for the external-CLI sync framework.
+
+Runs AdapterRegistry.startup() at most once per process. Safe for the
+slim nexus-fs wheel — all imports from nexus.bricks.auth.external_sync
+are behind try/except ImportError guards.
+
+Called by:
+  - _auth_cli._try_profile_store_list()  (nexus-fs auth list)
+  - _backend_factory._try_profile_store_select()  (S3 credential routing)
+"""
+
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+_sync_done = False
+
+
+def ensure_external_sync() -> None:
+    """Run external-CLI adapter sync once, populating the profile store.
+
+    No-op after the first successful (or failed) call. All errors are
+    swallowed — callers fall back to their existing behavior when the
+    store is empty.
+    """
+    global _sync_done  # noqa: PLW0603
+    if _sync_done:
+        return
+    _sync_done = True
+
+    try:
+        import asyncio
+
+        from nexus.bricks.auth.external_sync.aws_sync import AwsCliSyncAdapter
+        from nexus.bricks.auth.external_sync.registry import AdapterRegistry
+        from nexus.bricks.auth.profile_store import SqliteAuthProfileStore
+        from nexus.fs._paths import persistent_dir
+    except ImportError:
+        # Slim wheel — external_sync not available. Silent no-op.
+        return
+
+    try:
+        db_path = persistent_dir() / "auth_profiles.db"
+        store = SqliteAuthProfileStore(db_path)
+        try:
+            registry = AdapterRegistry(
+                adapters=[AwsCliSyncAdapter()],
+                profile_store=store,
+                startup_timeout=3.0,
+            )
+            asyncio.run(registry.startup())
+        finally:
+            store.close()
+    except Exception:
+        logger.debug("External CLI sync failed during bootstrap", exc_info=True)

--- a/src/nexus/fs/_external_sync_boot.py
+++ b/src/nexus/fs/_external_sync_boot.py
@@ -128,25 +128,28 @@ def select_profile(provider: str, *, account: str | None = None):  # noqa: ANN20
             if not profiles:
                 return None
 
-        # Ambiguous: multiple profiles and no account specified — let the
-        # native provider chain decide instead of silently picking one.
-        if len(profiles) > 1 and account is None:
-            return None
-
+        # Remove blocked profiles (cooldown/disabled) before ambiguity check.
+        # This ensures {default: blocked, work-prod: healthy} resolves to
+        # work-prod rather than falling back to the native chain.
         from datetime import UTC, datetime
 
         now = datetime.now(UTC)
-        for profile in profiles:
-            stats = profile.usage_stats
-            if stats.cooldown_until and stats.cooldown_until > now:
-                continue
-            if stats.disabled_until and stats.disabled_until > now:
-                continue
-            return profile
+        usable = [
+            p
+            for p in profiles
+            if not (p.usage_stats.cooldown_until and p.usage_stats.cooldown_until > now)
+            and not (p.usage_stats.disabled_until and p.usage_stats.disabled_until > now)
+        ]
 
-        # All matching profiles are on cooldown/disabled — do not force a
-        # known-broken profile back into service.
-        return None
+        if not usable:
+            # All matching profiles are blocked — fail closed.
+            return None
+
+        # Ambiguous: multiple usable profiles and no account specified.
+        if len(usable) > 1 and account is None:
+            return None
+
+        return usable[0]
     except Exception:
         return None
 

--- a/src/nexus/fs/_external_sync_boot.py
+++ b/src/nexus/fs/_external_sync_boot.py
@@ -90,8 +90,18 @@ def list_profiles() -> list | None:
         return None
 
 
-def select_profile(provider: str):  # noqa: ANN201
-    """Select a usable profile for a provider. Returns None on any failure."""
+def select_profile(provider: str, *, account: str | None = None):  # noqa: ANN201
+    """Select a usable profile for a provider. Returns None on any failure.
+
+    When ``account`` is given, only that profile is considered. For S3,
+    callers should pass ``os.environ.get("AWS_PROFILE")`` so the user's
+    explicit account selection is honored. When multiple profiles exist
+    and no account is specified, returns None (ambiguous — let the native
+    provider chain decide).
+
+    Returns None when all matching profiles are on cooldown or disabled,
+    rather than forcing a known-broken profile back into service.
+    """
     try:
         store_mod = importlib.import_module("nexus.bricks.auth.profile_store")
         from nexus.fs._paths import persistent_dir
@@ -112,6 +122,17 @@ def select_profile(provider: str):  # noqa: ANN201
         if not profiles:
             return None
 
+        # Filter to explicit account if requested
+        if account is not None:
+            profiles = [p for p in profiles if p.account_identifier == account]
+            if not profiles:
+                return None
+
+        # Ambiguous: multiple profiles and no account specified — let the
+        # native provider chain decide instead of silently picking one.
+        if len(profiles) > 1 and account is None:
+            return None
+
         from datetime import UTC, datetime
 
         now = datetime.now(UTC)
@@ -122,7 +143,10 @@ def select_profile(provider: str):  # noqa: ANN201
             if stats.disabled_until and stats.disabled_until > now:
                 continue
             return profile
-        return profiles[0]
+
+        # All matching profiles are on cooldown/disabled — do not force a
+        # known-broken profile back into service.
+        return None
     except Exception:
         return None
 

--- a/src/nexus/fs/_external_sync_boot.py
+++ b/src/nexus/fs/_external_sync_boot.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import importlib
 import logging
+from typing import Any
 
 logger = logging.getLogger(__name__)
 
@@ -90,7 +91,7 @@ def list_profiles() -> list | None:
         return None
 
 
-def select_profile(provider: str, *, account: str | None = None):  # noqa: ANN201
+def select_profile(provider: str, *, account: str | None = None) -> Any:
     """Select a usable profile for a provider. Returns None on any failure.
 
     When ``account`` is given, only that profile is considered. For S3,
@@ -154,7 +155,7 @@ def select_profile(provider: str, *, account: str | None = None):  # noqa: ANN20
         return None
 
 
-def resolve_external_credential(backend_key: str):  # noqa: ANN201
+def resolve_external_credential(backend_key: str) -> Any:
     """Resolve a credential via AwsCliSyncAdapter. Returns None on failure."""
     try:
         import asyncio


### PR DESCRIPTION
## Summary

Phase 2 of the auth unification epic (#3722). Delivers the external-CLI sync framework, the first concrete adapter (aws-cli), and cuts `nexus-fs auth list` over to the unified profile store. Closes #3739.

- **External sync framework** (`src/nexus/bricks/auth/external_sync/`): `ExternalCliSyncAdapter` ABC with `FileAdapter` and `SubprocessAdapter` concrete bases, `AdapterRegistry` with `asyncio.gather` startup (3s timeout), per-adapter circuit breaker (configurable threshold + half-open recovery), and background refresh loop (30s tick, per-adapter TTL)
- **AWS adapter** (`aws_sync.py`): ~40 LOC `FileAdapter` subclass parsing `~/.aws/credentials` + `~/.aws/config`, with credentials-over-config precedence and `resolve_credential()` for fresh reads
- **`ExternalCliBackend`**: implements `CredentialBackend` protocol, delegates to adapter's `resolve_credential()` — never persists external credentials on disk
- **`nexus-fs auth list` cutover**: dual-read (profile store primary, `UnifiedAuthService` fallback) with new table format (Provider / Account / Source / Status / Last used)
- **S3 backend routing**: dual-path in `_backend_factory.py` — profile store first, old `discover_credentials()` fallback

## Test Plan

- [ ] 68 new tests passing (0 regressions in existing auth tests)
- [ ] `FileAdapter` base class: missing file, unreadable perms, empty file, malformed content, symlink loop — all return degraded SyncResult
- [ ] `SubprocessAdapter` base class: timeout, stderr capture, retry with backoff, missing binary
- [ ] `AwsCliSyncAdapter`: fixture-based parse tests (v2.15 + v2.16 formats), credentials-over-config precedence, env var overrides
- [ ] `AdapterRegistry`: startup timeout (5 adapters, 4 fast + 1 hanging → bounded), circuit breaker trip + half-open recovery, refresh loop TTL respect
- [ ] Concurrency: 2 readers + 1 writer — no torn reads
- [ ] Offline safety: `no_network` fixture, adapters return degraded within 2s
- [ ] Nightly e2e: `TEST_WITH_REAL_AWS_CLI=1` gated, full sync + auth list flow
- [ ] `nexus-fs auth list`: new table format with Source column, cooldown status display, JSON output, fallback to old path when store empty
- [ ] S3 routing: profile store path, fallback path, fallback on resolve failure