### PR TITLE
fix(ci): use pgvector image for E2E postgres service

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -84,7 +84,7 @@ jobs:
     timeout-minutes: 15
     services:
       postgres:
-        image: postgres:16
+        image: pgvector/pgvector:pg16
         env:
           POSTGRES_USER: postgres
           POSTGRES_PASSWORD: nexus


### PR DESCRIPTION
## Summary
- The prior TLS fix (nexi-lab/nexus#3767) resolved the faiss `ImportError`, but unmasked a second issue: the E2E service container uses plain `postgres:16` which lacks the pgvector extension.
- txtai needs `CREATE EXTENSION vector` to create its `vectors` table. Without it: `extension "vector" is not available` → `relation "vectors" does not exist` → all semantic search fails.
- Switch to `pgvector/pgvector:pg16` (same PG version, adds pgvector).

## Test plan
- [ ] Docker Publish E2E: all 22 tests pass (HERB hit rate, auto-index, file-indexed-before-delete)