### PR TITLE
fix(docker): add ATEN_CPU_CAPABILITY=default for PyTorch SIGILL

### DIFF
--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -38,14 +38,20 @@ export GLIBC_TUNABLES="${GLIBC_TUNABLES:-glibc.rtld.optional_static_tls=16384}"
 #   OMP_NUM_THREADS=1              — single-threaded OpenMP (avoids
 #                                    libgomp/libiomp5 runtime conflict)
 #   MKL_ENABLE_INSTRUCTIONS=SSE4_2 — clamp Intel MKL to SSE4.2 (no AVX*)
+#   ATEN_CPU_CAPABILITY=default    — disable PyTorch ATen SIMD kernels
+#                                    (covers the path MKL_ENABLE_INSTRUCTIONS
+#                                    misses — e.g. sentence-transformers
+#                                    forward passes via torch native ops)
 #
 # Users running on known-good modern CPUs can override at `docker run` time:
 #   docker run -e FAISS_OPT_LEVEL=avx2 -e OMP_NUM_THREADS=4 \
-#              -e MKL_ENABLE_INSTRUCTIONS=AVX512 ...
+#              -e MKL_ENABLE_INSTRUCTIONS=AVX512 \
+#              -e ATEN_CPU_CAPABILITY=avx512 ...
 # ---------------------------------------------------------------------------
 export FAISS_OPT_LEVEL="${FAISS_OPT_LEVEL:-generic}"
 export OMP_NUM_THREADS="${OMP_NUM_THREADS:-1}"
 export MKL_ENABLE_INSTRUCTIONS="${MKL_ENABLE_INSTRUCTIONS:-SSE4_2}"
+export ATEN_CPU_CAPABILITY="${ATEN_CPU_CAPABILITY:-default}"
 
 # ---------------------------------------------------------------------------
 # LD_PRELOAD fallback (CPU-only)


### PR DESCRIPTION
## Summary

Follow-up to nexi-lab/nexus#3771. The prior fix (moving `FAISS_OPT_LEVEL=generic`, `OMP_NUM_THREADS=1`, `MKL_ENABLE_INSTRUCTIONS=SSE4_2` into the entrypoint as portable defaults) did resolve the faiss part — CI logs confirmed the shift from `Loading faiss with AVX2 support.` to `Loading faiss.`. But the container still SIGILL'd right after faiss loaded.

## What was still failing

PyTorch's ATen kernels have their own SIMD dispatch path that `MKL_ENABLE_INSTRUCTIONS` does **not** control. Once `txtai` ran an actual embedding forward pass (sentence-transformers → torch native ops), ATen emitted AVX2/AVX-512 instructions that GitHub Actions runners don't always support → `Illegal instruction (core dumped)`.

## Fix

Add `ATEN_CPU_CAPABILITY=default` to the entrypoint env defaults. This is PyTorch's documented runtime knob for exactly this failure mode (pytorch #37577, #155552). Same pattern as the other three: applied as a default, overridable via `docker run -e ATEN_CPU_CAPABILITY=avx512 ...` for users on known-good hardware.

## Test plan

- [ ] Docker Publish E2E reaches "Successfully loaded faiss." with no downstream SIGILL
- [ ] All 22 E2E tests pass