### PR TITLE
feat(#3773): RRF top-rank bonus + path context descriptions

### DIFF
--- a/alembic/versions/add_path_contexts_table.py
+++ b/alembic/versions/add_path_contexts_table.py
@@ -1,0 +1,65 @@
+"""Add path_contexts table (Issue #3773).
+
+Creates the path_contexts table used to attach admin-configured, zone-scoped
+human-readable descriptions to search result paths via longest-prefix match.
+
+Revision ID: add_path_contexts_table
+Revises: add_document_skeleton
+Create Date: 2026-04-16
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "add_path_contexts_table"
+down_revision: Union[str, Sequence[str], None] = "add_document_skeleton"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create path_contexts table."""
+    op.create_table(
+        "path_contexts",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column(
+            "zone_id",
+            sa.String(255),
+            nullable=False,
+            server_default="root",
+        ),
+        sa.Column("path_prefix", sa.String(1024), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "zone_id",
+            "path_prefix",
+            name="uq_path_contexts_zone_prefix",
+        ),
+    )
+    op.create_index(
+        "ix_path_contexts_zone_updated",
+        "path_contexts",
+        ["zone_id", "updated_at"],
+    )
+
+
+def downgrade() -> None:
+    """Remove path_contexts table."""
+    op.drop_index("ix_path_contexts_zone_updated", table_name="path_contexts")
+    op.drop_table("path_contexts")

--- a/alembic/versions/add_path_contexts_table.py
+++ b/alembic/versions/add_path_contexts_table.py
@@ -3,6 +3,13 @@
 Creates the path_contexts table used to attach admin-configured, zone-scoped
 human-readable descriptions to search result paths via longest-prefix match.
 
+Supported dialects: PostgreSQL (production) and SQLite (embedded/tests).
+The ``path_prefix`` column is ``String(1024)``; combined with ``zone_id``
+in the unique constraint, this exceeds MySQL's default utf8mb4 index key
+limit (3072 bytes). MySQL is not a supported backend — running the
+migration there requires either shrinking the columns or adding an index
+prefix.
+
 Revision ID: add_path_contexts_table
 Revises: add_document_skeleton
 Create Date: 2026-04-16

--- a/docs/superpowers/plans/2026-04-16-issue-3773-rrf-bonus-path-contexts.md
+++ b/docs/superpowers/plans/2026-04-16-issue-3773-rrf-bonus-path-contexts.md
@@ -1,0 +1,1975 @@
+# Issue #3773 — RRF Top-Rank Bonus + Path Context Descriptions — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Ship two search-quality improvements inspired by QMD: a top-rank bonus in RRF fusion (prevents dilution of perfect matches), and admin-managed path-context descriptions attached to search results (gives LLM agents relevance signal without reading files).
+
+**Architecture:** RRF changes are a small in-place modification of three fusion functions in `src/nexus/bricks/search/fusion.py`. Path contexts add a new Alembic-migrated `path_contexts` table, a zone-scoped async store + in-memory longest-prefix cache in a new `src/nexus/bricks/search/path_context.py`, a new `/api/v2/path-contexts` router, a daemon attach step after final result assembly, and a `context` field on `BaseSearchResult`.
+
+**Tech Stack:** Python 3.12+, SQLAlchemy async, Alembic, FastAPI, Pydantic v2, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-04-16-issue-3773-rrf-bonus-path-contexts-design.md`
+
+---
+
+## File Structure
+
+**Create:**
+- `src/nexus/bricks/search/path_context.py` — `PathContextRecord`, `PathContextStore`, `PathContextCache`.
+- `src/nexus/server/api/v2/routers/path_contexts.py` — FastAPI router.
+- `alembic/versions/add_path_contexts_table.py` — table migration.
+- `tests/integration/bricks/search/test_rrf_bonus.py` — RRF top-rank bonus tests.
+- `tests/integration/bricks/search/test_path_context.py` — store + cache tests.
+- `tests/integration/server/api/v2/routers/test_path_contexts_router.py` — router tests.
+- `tests/integration/bricks/search/test_daemon_context_attach.py` — daemon + serializer E2E.
+
+**Modify:**
+- `src/nexus/bricks/search/fusion.py` — add bonus constants, modify three RRF functions, extend `FusionConfig`.
+- `src/nexus/bricks/search/results.py` — add `context: str | None = None` to `BaseSearchResult`.
+- `src/nexus/bricks/search/daemon.py` — inject cache, attach context after result assembly.
+- `src/nexus/server/api/v2/routers/search.py` — emit `context` in `_serialize_search_result`.
+- `src/nexus/server/api/v2/versioning.py` — register new router.
+- `src/nexus/server/lifespan/search.py` — construct store + cache on startup, inject into daemon.
+
+---
+
+## Task 1: RRF bonus — constants, `FusionConfig` flag, apply to `rrf_fusion`
+
+**Files:**
+- Modify: `src/nexus/bricks/search/fusion.py` (constants, `FusionConfig`, `rrf_fusion`)
+- Create: `tests/integration/bricks/search/test_rrf_bonus.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/integration/bricks/search/test_rrf_bonus.py`:
+
+```python
+"""Tests for RRF top-rank bonus (Issue #3773).
+
+Verifies that documents ranked #1 in any input list get a +0.05 bonus
+and those ranked #2-3 get +0.02, preventing dilution of perfect matches
+across multi-source / query-expanded fusion.
+"""
+
+from nexus.bricks.search.fusion import (
+    RRF_TOP1_BONUS,
+    RRF_TOP3_BONUS,
+    FusionConfig,
+    FusionMethod,
+    fuse_results,
+    rrf_fusion,
+    rrf_multi_fusion,
+    rrf_weighted_fusion,
+)
+
+
+class TestRrfTop1Bonus:
+    def test_top1_keyword_only_beats_mediocre_both(self) -> None:
+        """Issue #3773 scenario: #1 in keyword but absent from vector
+        beats #3 in both without the bonus."""
+        kw = [
+            {"path": "perfect.txt", "chunk_index": 0, "score": 10.0},  # rank 1
+            {"path": "x.txt", "chunk_index": 0, "score": 1.0},
+            {"path": "mediocre.txt", "chunk_index": 0, "score": 0.5},  # rank 3
+        ]
+        vec = [
+            {"path": "y.txt", "chunk_index": 0, "score": 0.9},
+            {"path": "z.txt", "chunk_index": 0, "score": 0.8},
+            {"path": "mediocre.txt", "chunk_index": 0, "score": 0.5},  # rank 3
+        ]
+        results = rrf_fusion(kw, vec, k=60, limit=10, id_key=None)
+        ranked_paths = [r["path"] for r in results]
+        assert ranked_paths.index("perfect.txt") < ranked_paths.index("mediocre.txt")
+
+    def test_bonus_disabled_preserves_legacy_behavior(self) -> None:
+        kw = [
+            {"path": "perfect.txt", "chunk_index": 0, "score": 10.0},
+            {"path": "x.txt", "chunk_index": 0, "score": 1.0},
+            {"path": "mediocre.txt", "chunk_index": 0, "score": 0.5},
+        ]
+        vec = [
+            {"path": "y.txt", "chunk_index": 0, "score": 0.9},
+            {"path": "z.txt", "chunk_index": 0, "score": 0.8},
+            {"path": "mediocre.txt", "chunk_index": 0, "score": 0.5},
+        ]
+        results = rrf_fusion(
+            kw, vec, k=60, limit=10, id_key=None, top_rank_bonus=False
+        )
+        ranked_paths = [r["path"] for r in results]
+        # Without bonus, mediocre (in both) outranks perfect (single list).
+        assert ranked_paths.index("mediocre.txt") < ranked_paths.index("perfect.txt")
+
+    def test_rank1_receives_top1_bonus(self) -> None:
+        """Single-doc fusion: score == 2 * 1/(k+1) + RRF_TOP1_BONUS."""
+        kw = [{"path": "only.txt", "chunk_index": 0, "score": 1.0}]
+        vec = [{"path": "only.txt", "chunk_index": 0, "score": 1.0}]
+        results = rrf_fusion(kw, vec, k=60, limit=10, id_key=None)
+        assert len(results) == 1
+        expected = (1.0 / 61) + (1.0 / 61) + RRF_TOP1_BONUS
+        assert abs(results[0]["score"] - expected) < 1e-9
+
+    def test_rank3_receives_top3_bonus(self) -> None:
+        """Doc at rank 3 in keyword only: 1/(k+3) + RRF_TOP3_BONUS."""
+        kw = [
+            {"path": "a.txt", "chunk_index": 0, "score": 1.0},
+            {"path": "b.txt", "chunk_index": 0, "score": 1.0},
+            {"path": "c.txt", "chunk_index": 0, "score": 1.0},
+        ]
+        vec: list[dict] = []
+        results = rrf_fusion(kw, vec, k=60, limit=10, id_key=None)
+        c_result = next(r for r in results if r["path"] == "c.txt")
+        expected = (1.0 / 63) + RRF_TOP3_BONUS
+        assert abs(c_result["score"] - expected) < 1e-9
+
+    def test_rank4_receives_no_bonus(self) -> None:
+        kw = [
+            {"path": f"r{i}.txt", "chunk_index": 0, "score": 1.0} for i in range(5)
+        ]
+        results = rrf_fusion(kw, [], k=60, limit=10, id_key=None)
+        r4 = next(r for r in results if r["path"] == "r3.txt")  # zero-indexed -> rank 4
+        expected = 1.0 / 64
+        assert abs(r4["score"] - expected) < 1e-9
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/integration/bricks/search/test_rrf_bonus.py -v`
+Expected: FAIL with `ImportError: cannot import name 'RRF_TOP1_BONUS' from 'nexus.bricks.search.fusion'`.
+
+- [ ] **Step 3: Add constants + `FusionConfig` flag + modify `rrf_fusion`**
+
+Edit `src/nexus/bricks/search/fusion.py`.
+
+After the existing imports (after line 22), add module constants:
+
+```python
+# Issue #3773: Top-rank bonus preserves high-confidence matches
+# against dilution from query expansion and multi-source fusion.
+RRF_TOP1_BONUS = 0.05
+RRF_TOP3_BONUS = 0.02
+```
+
+In `FusionConfig` dataclass (around line 44), add a new field:
+
+```python
+top_rank_bonus: bool = True  # Issue #3773: boost docs ranked #1-3 in any list
+```
+
+So the final `FusionConfig` reads:
+
+```python
+@dataclass
+class FusionConfig:
+    method: FusionMethod = FusionMethod.RRF
+    alpha: float = 0.5
+    rrf_k: int = 60
+    normalize_scores: bool = True
+    over_fetch_factor: float = 3.0
+    top_rank_bonus: bool = True  # Issue #3773
+```
+
+Replace `rrf_fusion` (currently lines 112-169) with:
+
+```python
+def rrf_fusion(
+    keyword_results: Sequence[dict[str, Any] | Any],
+    vector_results: Sequence[dict[str, Any] | Any],
+    k: int = 60,
+    limit: int = 10,
+    id_key: str | None = "chunk_id",
+    top_rank_bonus: bool = True,
+) -> list[dict[str, Any]]:
+    """Combine results using Reciprocal Rank Fusion.
+
+    RRF score = sum(1 / (k + rank)) for each result list, plus an optional
+    top-rank bonus (Issue #3773): +0.05 for docs ranked #1 in any list and
+    +0.02 for docs ranked #2-3. The bonus preserves high-confidence matches
+    against dilution from query expansion and multi-source fusion.
+
+    Args:
+        keyword_results: Results from keyword search (ranked by BM25)
+        vector_results: Results from vector search (ranked by similarity)
+        k: RRF constant (default: 60, per original paper)
+        limit: Maximum results to return
+        id_key: Key for identifying unique results, or None for path:chunk_index
+        top_rank_bonus: Apply top-rank bonus (Issue #3773). Default True.
+
+    Returns:
+        Combined results ranked by RRF score
+    """
+    rrf_scores: dict[str, dict[str, Any]] = {}
+    best_rank: dict[str, int] = {}
+
+    # Add keyword results
+    for rank, raw_result in enumerate(keyword_results, start=1):
+        result = _to_dict(raw_result)
+        key = _get_result_key(result, id_key)
+        if key not in rrf_scores:
+            rrf_scores[key] = {"result": result.copy(), "rrf_score": 0.0}
+        rrf_scores[key]["rrf_score"] += 1.0 / (k + rank)
+        rrf_scores[key]["result"]["keyword_score"] = result.get("score", 0.0)
+        best_rank[key] = min(best_rank.get(key, rank), rank)
+
+    # Add vector results
+    for rank, raw_result in enumerate(vector_results, start=1):
+        result = _to_dict(raw_result)
+        key = _get_result_key(result, id_key)
+        if key not in rrf_scores:
+            rrf_scores[key] = {"result": result.copy(), "rrf_score": 0.0}
+        rrf_scores[key]["rrf_score"] += 1.0 / (k + rank)
+        rrf_scores[key]["result"]["vector_score"] = result.get("score", 0.0)
+        best_rank[key] = min(best_rank.get(key, rank), rank)
+
+    # Issue #3773: apply top-rank bonus before final sort
+    if top_rank_bonus:
+        for key, entry in rrf_scores.items():
+            br = best_rank.get(key, 999)
+            if br == 1:
+                entry["rrf_score"] += RRF_TOP1_BONUS
+            elif br <= 3:
+                entry["rrf_score"] += RRF_TOP3_BONUS
+
+    # Sort by RRF score
+    sorted_results = sorted(
+        rrf_scores.values(),
+        key=lambda x: x["rrf_score"],
+        reverse=True,
+    )[:limit]
+
+    # Update final scores
+    for item in sorted_results:
+        item["result"]["score"] = item["rrf_score"]
+
+    return [item["result"] for item in sorted_results]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/integration/bricks/search/test_rrf_bonus.py -v -k "not weighted and not multi and not fuse_results"`
+Expected: all tests in `TestRrfTop1Bonus` PASS.
+
+Also run the existing fusion test suite to check for golden-ordering regressions:
+
+Run: `pytest tests/integration/bricks/search/test_fusion.py -v`
+Expected: any failures are golden-ordering shifts caused by the bonus. If a test fails purely because rank ordering flipped (not a logic error), update the expected order inline and re-run. If a test fails with an arithmetic comparison (e.g. asserting an exact float score), update the expected value to `old + RRF_TOPN_BONUS` and re-run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/search/fusion.py \
+        tests/integration/bricks/search/test_rrf_bonus.py \
+        tests/integration/bricks/search/test_fusion.py
+git commit -m "feat(#3773): rrf_fusion top-rank bonus (+0.05 / +0.02)"
+```
+
+---
+
+## Task 2: RRF bonus — apply to `rrf_weighted_fusion`
+
+**Files:**
+- Modify: `src/nexus/bricks/search/fusion.py` (`rrf_weighted_fusion`)
+- Modify: `tests/integration/bricks/search/test_rrf_bonus.py` (add weighted tests)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/integration/bricks/search/test_rrf_bonus.py`:
+
+```python
+class TestRrfWeightedBonus:
+    def test_weighted_top1_gets_bonus(self) -> None:
+        """rrf_weighted_fusion also applies the top-rank bonus."""
+        kw = [{"path": "only.txt", "chunk_index": 0, "score": 1.0}]
+        vec = [{"path": "only.txt", "chunk_index": 0, "score": 1.0}]
+        results = rrf_weighted_fusion(kw, vec, alpha=0.5, k=60, limit=10, id_key=None)
+        # alpha=0.5, rank=1 in both: 0.5*(1/61) + 0.5*(1/61) + RRF_TOP1_BONUS
+        expected = 0.5 * (1.0 / 61) + 0.5 * (1.0 / 61) + RRF_TOP1_BONUS
+        assert abs(results[0]["score"] - expected) < 1e-9
+
+    def test_weighted_bonus_disabled(self) -> None:
+        kw = [{"path": "only.txt", "chunk_index": 0, "score": 1.0}]
+        vec = [{"path": "only.txt", "chunk_index": 0, "score": 1.0}]
+        results = rrf_weighted_fusion(
+            kw, vec, alpha=0.5, k=60, limit=10, id_key=None, top_rank_bonus=False
+        )
+        expected = 0.5 * (1.0 / 61) + 0.5 * (1.0 / 61)
+        assert abs(results[0]["score"] - expected) < 1e-9
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/integration/bricks/search/test_rrf_bonus.py::TestRrfWeightedBonus -v`
+Expected: FAIL — `rrf_weighted_fusion` has no `top_rank_bonus` parameter and does not apply the bonus, so the first test asserts a score higher than produced.
+
+- [ ] **Step 3: Modify `rrf_weighted_fusion`**
+
+Replace `rrf_weighted_fusion` (currently lines 253-310 in `src/nexus/bricks/search/fusion.py`) with:
+
+```python
+def rrf_weighted_fusion(
+    keyword_results: Sequence[dict[str, Any] | Any],
+    vector_results: Sequence[dict[str, Any] | Any],
+    alpha: float = 0.5,
+    k: int = 60,
+    limit: int = 10,
+    id_key: str | None = "chunk_id",
+    top_rank_bonus: bool = True,
+) -> list[dict[str, Any]]:
+    """Combine results using RRF with alpha weighting.
+
+    RRF score = (1 - alpha) * (1/(k+keyword_rank)) + alpha * (1/(k+vector_rank))
+                + top-rank bonus (Issue #3773)
+
+    Args:
+        keyword_results: Results from keyword search
+        vector_results: Results from vector search
+        alpha: Weight for vector contribution (0.0 = all BM25, 1.0 = all vector)
+        k: RRF constant
+        limit: Maximum results to return
+        id_key: Key for identifying unique results
+        top_rank_bonus: Apply top-rank bonus (Issue #3773). Default True.
+
+    Returns:
+        Combined results ranked by weighted RRF score
+    """
+    rrf_scores: dict[str, dict[str, Any]] = {}
+    best_rank: dict[str, int] = {}
+
+    # Add keyword results with (1 - alpha) weight
+    for rank, raw_result in enumerate(keyword_results, start=1):
+        result = _to_dict(raw_result)
+        key = _get_result_key(result, id_key)
+        if key not in rrf_scores:
+            rrf_scores[key] = {"result": result.copy(), "rrf_score": 0.0}
+        rrf_scores[key]["rrf_score"] += (1 - alpha) * (1.0 / (k + rank))
+        rrf_scores[key]["result"]["keyword_score"] = result.get("score", 0.0)
+        best_rank[key] = min(best_rank.get(key, rank), rank)
+
+    # Add vector results with alpha weight
+    for rank, raw_result in enumerate(vector_results, start=1):
+        result = _to_dict(raw_result)
+        key = _get_result_key(result, id_key)
+        if key not in rrf_scores:
+            rrf_scores[key] = {"result": result.copy(), "rrf_score": 0.0}
+        rrf_scores[key]["rrf_score"] += alpha * (1.0 / (k + rank))
+        rrf_scores[key]["result"]["vector_score"] = result.get("score", 0.0)
+        best_rank[key] = min(best_rank.get(key, rank), rank)
+
+    if top_rank_bonus:
+        for key, entry in rrf_scores.items():
+            br = best_rank.get(key, 999)
+            if br == 1:
+                entry["rrf_score"] += RRF_TOP1_BONUS
+            elif br <= 3:
+                entry["rrf_score"] += RRF_TOP3_BONUS
+
+    sorted_results = sorted(
+        rrf_scores.values(),
+        key=lambda x: x["rrf_score"],
+        reverse=True,
+    )[:limit]
+
+    for item in sorted_results:
+        item["result"]["score"] = item["rrf_score"]
+
+    return [item["result"] for item in sorted_results]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/integration/bricks/search/test_rrf_bonus.py::TestRrfWeightedBonus -v`
+Expected: PASS.
+
+Also re-run the legacy fusion test suite:
+
+Run: `pytest tests/integration/bricks/search/test_fusion.py -v`
+Expected: PASS. Update any golden orderings that flipped (see Task 1 Step 4 note).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/search/fusion.py \
+        tests/integration/bricks/search/test_rrf_bonus.py \
+        tests/integration/bricks/search/test_fusion.py
+git commit -m "feat(#3773): rrf_weighted_fusion top-rank bonus"
+```
+
+---
+
+## Task 3: RRF bonus — apply to `rrf_multi_fusion`
+
+**Files:**
+- Modify: `src/nexus/bricks/search/fusion.py` (`rrf_multi_fusion`)
+- Modify: `tests/integration/bricks/search/test_rrf_bonus.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/integration/bricks/search/test_rrf_bonus.py`:
+
+```python
+class TestRrfMultiBonus:
+    def test_multi_top1_gets_bonus_from_any_source(self) -> None:
+        """rrf_multi_fusion: best rank across all sources drives bonus."""
+        lists = [
+            (
+                "keyword",
+                [
+                    {"path": "perfect.txt", "chunk_index": 0, "score": 1.0},
+                    {"path": "other.txt", "chunk_index": 0, "score": 1.0},
+                ],
+            ),
+            (
+                "vector",
+                [
+                    {"path": "unrelated.txt", "chunk_index": 0, "score": 1.0},
+                    {"path": "other.txt", "chunk_index": 0, "score": 1.0},
+                ],
+            ),
+            (
+                "splade",
+                [{"path": "perfect.txt", "chunk_index": 0, "score": 1.0}],
+            ),
+        ]
+        results = rrf_multi_fusion(lists, k=60, limit=10, id_key=None)
+        # "perfect.txt" is rank 1 in keyword + splade -> gets TOP1 bonus.
+        perfect = next(r for r in results if r["path"] == "perfect.txt")
+        expected = (1.0 / 61) + (1.0 / 61) + RRF_TOP1_BONUS
+        assert abs(perfect["score"] - expected) < 1e-9
+
+    def test_multi_bonus_disabled(self) -> None:
+        lists = [
+            ("keyword", [{"path": "a.txt", "chunk_index": 0, "score": 1.0}]),
+            ("vector", [{"path": "a.txt", "chunk_index": 0, "score": 1.0}]),
+        ]
+        results = rrf_multi_fusion(
+            lists, k=60, limit=10, id_key=None, top_rank_bonus=False
+        )
+        expected = 2 * (1.0 / 61)
+        assert abs(results[0]["score"] - expected) < 1e-9
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/integration/bricks/search/test_rrf_bonus.py::TestRrfMultiBonus -v`
+Expected: FAIL — `rrf_multi_fusion` has no `top_rank_bonus` parameter.
+
+- [ ] **Step 3: Modify `rrf_multi_fusion`**
+
+Replace `rrf_multi_fusion` (currently lines 313-357 in `src/nexus/bricks/search/fusion.py`) with:
+
+```python
+def rrf_multi_fusion(
+    result_lists: Sequence[tuple[str, Sequence[Any]]],
+    k: int = 60,
+    limit: int = 10,
+    id_key: str | None = "chunk_id",
+    top_rank_bonus: bool = True,
+) -> list[dict[str, Any]]:
+    """N-way Reciprocal Rank Fusion for combining 3+ retrieval sources.
+
+    Generalizes RRF from 2-way to N-way for pipelines that combine
+    keyword + dense + SPLADE (or any number of retrievers). Applies the
+    top-rank bonus (Issue #3773) using the best rank across all sources.
+
+    Args:
+        result_lists: List of (source_name, results) tuples.
+            source_name is used to set '{source_name}_score' on each result.
+        k: RRF constant (default: 60)
+        limit: Maximum results to return
+        id_key: Key for identifying unique results, or None for path:chunk_index
+        top_rank_bonus: Apply top-rank bonus (Issue #3773). Default True.
+
+    Returns:
+        Combined results ranked by RRF score
+    """
+    rrf_scores: dict[str, dict[str, Any]] = {}
+    best_rank: dict[str, int] = {}
+
+    for source_name, results in result_lists:
+        score_key = f"{source_name}_score"
+        for rank, raw_result in enumerate(results, start=1):
+            result = _to_dict(raw_result)
+            key = _get_result_key(result, id_key)
+            if key not in rrf_scores:
+                rrf_scores[key] = {"result": result.copy(), "rrf_score": 0.0}
+            rrf_scores[key]["rrf_score"] += 1.0 / (k + rank)
+            rrf_scores[key]["result"][score_key] = result.get("score", 0.0)
+            best_rank[key] = min(best_rank.get(key, rank), rank)
+
+    if top_rank_bonus:
+        for key, entry in rrf_scores.items():
+            br = best_rank.get(key, 999)
+            if br == 1:
+                entry["rrf_score"] += RRF_TOP1_BONUS
+            elif br <= 3:
+                entry["rrf_score"] += RRF_TOP3_BONUS
+
+    sorted_results = sorted(
+        rrf_scores.values(),
+        key=lambda x: x["rrf_score"],
+        reverse=True,
+    )[:limit]
+
+    for item in sorted_results:
+        item["result"]["score"] = item["rrf_score"]
+
+    return [item["result"] for item in sorted_results]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/integration/bricks/search/test_rrf_bonus.py::TestRrfMultiBonus -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/search/fusion.py tests/integration/bricks/search/test_rrf_bonus.py
+git commit -m "feat(#3773): rrf_multi_fusion top-rank bonus"
+```
+
+---
+
+## Task 4: RRF bonus — wire `FusionConfig.top_rank_bonus` through `fuse_results`
+
+**Files:**
+- Modify: `src/nexus/bricks/search/fusion.py` (`fuse_results`)
+- Modify: `tests/integration/bricks/search/test_rrf_bonus.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/integration/bricks/search/test_rrf_bonus.py`:
+
+```python
+class TestFuseResultsConfigFlag:
+    def test_fuse_results_passes_top_rank_bonus_false(self) -> None:
+        kw = [{"path": "a.txt", "chunk_index": 0, "score": 1.0}]
+        vec = [{"path": "a.txt", "chunk_index": 0, "score": 1.0}]
+        config = FusionConfig(method=FusionMethod.RRF, top_rank_bonus=False)
+        results = fuse_results(kw, vec, config=config, limit=10, id_key=None)
+        expected = 2 * (1.0 / 61)
+        assert abs(results[0]["score"] - expected) < 1e-9
+
+    def test_fuse_results_default_applies_bonus(self) -> None:
+        kw = [{"path": "a.txt", "chunk_index": 0, "score": 1.0}]
+        vec = [{"path": "a.txt", "chunk_index": 0, "score": 1.0}]
+        results = fuse_results(kw, vec, config=None, limit=10, id_key=None)
+        expected = 2 * (1.0 / 61) + RRF_TOP1_BONUS
+        assert abs(results[0]["score"] - expected) < 1e-9
+
+    def test_fuse_results_weighted_respects_flag(self) -> None:
+        kw = [{"path": "a.txt", "chunk_index": 0, "score": 1.0}]
+        vec = [{"path": "a.txt", "chunk_index": 0, "score": 1.0}]
+        config = FusionConfig(method=FusionMethod.RRF_WEIGHTED, top_rank_bonus=False)
+        results = fuse_results(kw, vec, config=config, limit=10, id_key=None)
+        expected = 0.5 * (1.0 / 61) + 0.5 * (1.0 / 61)
+        assert abs(results[0]["score"] - expected) < 1e-9
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/integration/bricks/search/test_rrf_bonus.py::TestFuseResultsConfigFlag -v`
+Expected: FAIL — `fuse_results` does not yet forward `top_rank_bonus` to the underlying RRF functions.
+
+- [ ] **Step 3: Modify `fuse_results`**
+
+Replace `fuse_results` (currently lines 360-422 in `src/nexus/bricks/search/fusion.py`) with:
+
+```python
+def fuse_results(
+    keyword_results: Sequence[dict[str, Any] | Any],
+    vector_results: Sequence[dict[str, Any] | Any],
+    config: FusionConfig | None = None,
+    limit: int = 10,
+    id_key: str | None = "chunk_id",
+) -> list[dict[str, Any]]:
+    """Fuse keyword and vector search results using configured method.
+
+    This is the main entry point for hybrid search fusion. It dispatches
+    to the appropriate fusion algorithm based on the configuration.
+
+    Accepts both dict results and BaseSearchResult dataclass instances
+    (Issue #1520).
+
+    Args:
+        keyword_results: Results from keyword/BM25 search
+        vector_results: Results from vector/semantic search
+        config: Fusion configuration (defaults to RRF with k=60)
+        limit: Maximum results to return
+        id_key: Key for identifying unique results
+
+    Returns:
+        Combined results ranked by fusion score
+
+    Raises:
+        ValueError: If an unknown fusion method is specified
+    """
+    if config is None:
+        config = FusionConfig()
+
+    if config.method == FusionMethod.RRF:
+        return rrf_fusion(
+            keyword_results,
+            vector_results,
+            k=config.rrf_k,
+            limit=limit,
+            id_key=id_key,
+            top_rank_bonus=config.top_rank_bonus,
+        )
+    elif config.method == FusionMethod.WEIGHTED:
+        return weighted_fusion(
+            keyword_results,
+            vector_results,
+            alpha=config.alpha,
+            normalize=config.normalize_scores,
+            limit=limit,
+            id_key=id_key,
+        )
+    elif config.method == FusionMethod.RRF_WEIGHTED:
+        return rrf_weighted_fusion(
+            keyword_results,
+            vector_results,
+            alpha=config.alpha,
+            k=config.rrf_k,
+            limit=limit,
+            id_key=id_key,
+            top_rank_bonus=config.top_rank_bonus,
+        )
+    else:
+        raise ValueError(f"Unknown fusion method: {config.method}")
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/integration/bricks/search/test_rrf_bonus.py -v`
+Expected: all tests PASS.
+
+Run full fusion test suite: `pytest tests/integration/bricks/search/test_fusion.py tests/integration/bricks/search/test_rrf_bonus.py -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/search/fusion.py tests/integration/bricks/search/test_rrf_bonus.py
+git commit -m "feat(#3773): wire FusionConfig.top_rank_bonus through fuse_results"
+```
+
+---
+
+## Task 5: Path contexts — Alembic migration (`path_contexts` table)
+
+**Files:**
+- Create: `alembic/versions/add_path_contexts_table.py`
+
+- [ ] **Step 1: Discover the current Alembic head revision**
+
+Run: `cd <repo-root> && alembic heads`
+
+The repo has an `alembic.ini` at the root. If the command works, note the revision ID printed (e.g. `abc123def456`). If the command fails with "No script_location", use the helper: `python -c "from alembic.config import Config; from alembic.script import ScriptDirectory; cfg = Config('alembic.ini'); print([h for h in ScriptDirectory.from_config(cfg).get_heads()])"`. Record the head.
+
+Call the discovered head revision `<CURRENT_HEAD>`. If there are multiple heads, merge them first using `alembic merge heads -m "merge before path contexts"` before proceeding.
+
+- [ ] **Step 2: Create the migration file**
+
+Create `alembic/versions/add_path_contexts_table.py`:
+
+```python
+"""Add path_contexts table (Issue #3773).
+
+Creates the path_contexts table used to attach admin-configured, zone-scoped
+human-readable descriptions to search result paths via longest-prefix match.
+
+Revision ID: add_path_contexts_table
+Revises: <CURRENT_HEAD>
+Create Date: 2026-04-16
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "add_path_contexts_table"
+down_revision: Union[str, Sequence[str], None] = "<CURRENT_HEAD>"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    """Create path_contexts table."""
+    op.create_table(
+        "path_contexts",
+        sa.Column("id", sa.Integer, primary_key=True, autoincrement=True),
+        sa.Column(
+            "zone_id",
+            sa.String(255),
+            nullable=False,
+            server_default="root",
+        ),
+        sa.Column("path_prefix", sa.String(1024), nullable=False),
+        sa.Column("description", sa.Text(), nullable=False),
+        sa.Column(
+            "created_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "updated_at",
+            sa.DateTime(),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "zone_id",
+            "path_prefix",
+            name="uq_path_contexts_zone_prefix",
+        ),
+    )
+    op.create_index(
+        "ix_path_contexts_zone_updated",
+        "path_contexts",
+        ["zone_id", "updated_at"],
+    )
+
+
+def downgrade() -> None:
+    """Remove path_contexts table."""
+    op.drop_index("ix_path_contexts_zone_updated", table_name="path_contexts")
+    op.drop_table("path_contexts")
+```
+
+Replace the literal string `<CURRENT_HEAD>` in both `down_revision` and the docstring with the revision ID recorded in Step 1.
+
+- [ ] **Step 3: Run migration upgrade against SQLite (local)**
+
+Run: `cd <repo-root> && alembic upgrade head`
+Expected: output includes `Running upgrade <CURRENT_HEAD> -> add_path_contexts_table, Add path_contexts table`.
+
+- [ ] **Step 4: Verify the table exists and downgrade works**
+
+Run: `cd <repo-root> && sqlite3 <repo-root>/<dev.db> ".schema path_contexts"` (use the dev DB the local env uses; if unsure, `echo $NEXUS_DATABASE_URL`).
+Expected: prints `CREATE TABLE path_contexts (...)` with the columns above.
+
+Run: `cd <repo-root> && alembic downgrade -1 && alembic upgrade head`
+Expected: the table drops and re-creates without errors.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add alembic/versions/add_path_contexts_table.py
+git commit -m "feat(#3773): alembic migration — path_contexts table"
+```
+
+---
+
+## Task 6: Path contexts — `PathContextRecord` + `PathContextStore` (CRUD + freshness)
+
+**Files:**
+- Create: `src/nexus/bricks/search/path_context.py`
+- Create: `tests/integration/bricks/search/test_path_context.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/integration/bricks/search/test_path_context.py`:
+
+```python
+"""Tests for path_contexts store and cache (Issue #3773)."""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from nexus.bricks.search.path_context import (
+    PathContextCache,
+    PathContextRecord,
+    PathContextStore,
+)
+
+CREATE_TABLE_SQL = """
+CREATE TABLE path_contexts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    zone_id TEXT NOT NULL DEFAULT 'root',
+    path_prefix TEXT NOT NULL,
+    description TEXT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(zone_id, path_prefix)
+)
+"""
+
+
+@pytest_asyncio.fixture
+async def async_session_factory():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.exec_driver_sql(CREATE_TABLE_SQL)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def store(async_session_factory):
+    return PathContextStore(async_session_factory=async_session_factory, db_type="sqlite")
+
+
+class TestPathContextStoreUpsert:
+    @pytest.mark.asyncio
+    async def test_insert_then_read(self, store: PathContextStore) -> None:
+        await store.upsert("root", "src/nexus/bricks/search", "Hybrid search brick")
+        records = await store.list("root")
+        assert len(records) == 1
+        assert records[0].zone_id == "root"
+        assert records[0].path_prefix == "src/nexus/bricks/search"
+        assert records[0].description == "Hybrid search brick"
+
+    @pytest.mark.asyncio
+    async def test_upsert_replaces_description(self, store: PathContextStore) -> None:
+        await store.upsert("root", "src", "first")
+        await store.upsert("root", "src", "second")
+        records = await store.list("root")
+        assert len(records) == 1
+        assert records[0].description == "second"
+
+    @pytest.mark.asyncio
+    async def test_delete_returns_true_when_removed(self, store: PathContextStore) -> None:
+        await store.upsert("root", "src", "first")
+        assert await store.delete("root", "src") is True
+        assert await store.list("root") == []
+
+    @pytest.mark.asyncio
+    async def test_delete_returns_false_when_missing(self, store: PathContextStore) -> None:
+        assert await store.delete("root", "nonexistent") is False
+
+    @pytest.mark.asyncio
+    async def test_zones_are_isolated(self, store: PathContextStore) -> None:
+        await store.upsert("root", "src", "root desc")
+        await store.upsert("other", "src", "other desc")
+        root = await store.list("root")
+        other = await store.list("other")
+        assert len(root) == 1 and root[0].description == "root desc"
+        assert len(other) == 1 and other[0].description == "other desc"
+
+    @pytest.mark.asyncio
+    async def test_list_all_zones(self, store: PathContextStore) -> None:
+        await store.upsert("root", "a", "a")
+        await store.upsert("other", "b", "b")
+        records = await store.list(zone_id=None)
+        assert len(records) == 2
+
+    @pytest.mark.asyncio
+    async def test_max_updated_at_tracks_writes(self, store: PathContextStore) -> None:
+        assert await store.max_updated_at("root") is None
+        await store.upsert("root", "src", "first")
+        stamp1 = await store.max_updated_at("root")
+        assert stamp1 is not None
+        await store.upsert("root", "src", "second")
+        stamp2 = await store.max_updated_at("root")
+        assert stamp2 is not None
+        assert stamp2 >= stamp1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/integration/bricks/search/test_path_context.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'nexus.bricks.search.path_context'`.
+
+- [ ] **Step 3: Create `src/nexus/bricks/search/path_context.py` (store only — cache lives in Task 7)**
+
+```python
+"""Path context descriptions (Issue #3773).
+
+Stores admin-configured, zone-scoped mappings from path prefix to human-readable
+description. Used by the search daemon to attach a ``context`` field to each
+search result via longest-prefix match. In-memory cache is in this module too.
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import text
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+
+
+@dataclass(frozen=True)
+class PathContextRecord:
+    """One row in the path_contexts table."""
+
+    zone_id: str
+    path_prefix: str
+    description: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class PathContextStore:
+    """Async CRUD for the path_contexts table.
+
+    Follows the raw-SQL pattern used by ChunkStore (src/nexus/bricks/search/chunk_store.py).
+    """
+
+    def __init__(self, *, async_session_factory: Any, db_type: str = "sqlite") -> None:
+        self._async_session_factory = async_session_factory
+        self._db_type = db_type
+
+    async def upsert(
+        self, zone_id: str, path_prefix: str, description: str
+    ) -> None:
+        """Insert or replace a context row. updated_at refreshed on replace."""
+        now = datetime.utcnow()
+        async with self._async_session_factory() as session:
+            if self._db_type == "postgresql":
+                await session.execute(
+                    text(
+                        """
+                        INSERT INTO path_contexts
+                            (zone_id, path_prefix, description, created_at, updated_at)
+                        VALUES
+                            (:zone_id, :path_prefix, :description, :now, :now)
+                        ON CONFLICT (zone_id, path_prefix) DO UPDATE
+                        SET description = EXCLUDED.description,
+                            updated_at  = EXCLUDED.updated_at
+                        """
+                    ),
+                    {
+                        "zone_id": zone_id,
+                        "path_prefix": path_prefix,
+                        "description": description,
+                        "now": now,
+                    },
+                )
+            else:
+                # SQLite: INSERT OR REPLACE (loses created_at on replace, acceptable).
+                await session.execute(
+                    text(
+                        """
+                        INSERT OR REPLACE INTO path_contexts
+                            (zone_id, path_prefix, description, created_at, updated_at)
+                        VALUES
+                            (:zone_id, :path_prefix, :description,
+                             COALESCE(
+                                (SELECT created_at FROM path_contexts
+                                 WHERE zone_id = :zone_id AND path_prefix = :path_prefix),
+                                :now),
+                             :now)
+                        """
+                    ),
+                    {
+                        "zone_id": zone_id,
+                        "path_prefix": path_prefix,
+                        "description": description,
+                        "now": now,
+                    },
+                )
+            await session.commit()
+
+    async def delete(self, zone_id: str, path_prefix: str) -> bool:
+        """Delete one row. Returns True if a row was removed."""
+        async with self._async_session_factory() as session:
+            result = await session.execute(
+                text(
+                    "DELETE FROM path_contexts "
+                    "WHERE zone_id = :zone_id AND path_prefix = :path_prefix"
+                ),
+                {"zone_id": zone_id, "path_prefix": path_prefix},
+            )
+            await session.commit()
+            return (result.rowcount or 0) > 0
+
+    async def list(self, zone_id: str | None = None) -> list[PathContextRecord]:
+        """List contexts. When zone_id is None, returns rows for all zones."""
+        query = (
+            "SELECT zone_id, path_prefix, description, created_at, updated_at "
+            "FROM path_contexts"
+        )
+        params: dict[str, Any] = {}
+        if zone_id is not None:
+            query += " WHERE zone_id = :zone_id"
+            params["zone_id"] = zone_id
+        query += " ORDER BY zone_id, path_prefix"
+        async with self._async_session_factory() as session:
+            rows = (await session.execute(text(query), params)).all()
+        return [
+            PathContextRecord(
+                zone_id=row[0],
+                path_prefix=row[1],
+                description=row[2],
+                created_at=row[3],
+                updated_at=row[4],
+            )
+            for row in rows
+        ]
+
+    async def max_updated_at(self, zone_id: str) -> datetime | None:
+        """Return the max updated_at for a zone, or None if empty."""
+        async with self._async_session_factory() as session:
+            row = (
+                await session.execute(
+                    text(
+                        "SELECT MAX(updated_at) FROM path_contexts "
+                        "WHERE zone_id = :zone_id"
+                    ),
+                    {"zone_id": zone_id},
+                )
+            ).scalar()
+        return row
+
+    async def load_all_for_zone(self, zone_id: str) -> list[PathContextRecord]:
+        """Load every context row for one zone."""
+        return await self.list(zone_id=zone_id)
+
+
+# Issue #3773: PathContextCache is defined in Task 7.
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/integration/bricks/search/test_path_context.py::TestPathContextStoreUpsert -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/search/path_context.py \
+        tests/integration/bricks/search/test_path_context.py
+git commit -m "feat(#3773): PathContextStore CRUD + max_updated_at"
+```
+
+---
+
+## Task 7: Path contexts — `PathContextCache` (longest-prefix match + freshness)
+
+**Files:**
+- Modify: `src/nexus/bricks/search/path_context.py` (add `PathContextCache`)
+- Modify: `tests/integration/bricks/search/test_path_context.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/integration/bricks/search/test_path_context.py`:
+
+```python
+class TestPathContextCacheLookup:
+    @pytest.mark.asyncio
+    async def test_longest_prefix_wins(self, store: PathContextStore) -> None:
+        await store.upsert("root", "src", "top-level src")
+        await store.upsert("root", "src/nexus/bricks/search", "search brick")
+        cache = PathContextCache(store=store)
+        desc = await cache.lookup("root", "src/nexus/bricks/search/fusion.py")
+        assert desc == "search brick"
+
+    @pytest.mark.asyncio
+    async def test_empty_prefix_matches_any(self, store: PathContextStore) -> None:
+        await store.upsert("root", "", "zone root fallback")
+        cache = PathContextCache(store=store)
+        assert await cache.lookup("root", "anything/x.py") == "zone root fallback"
+
+    @pytest.mark.asyncio
+    async def test_slash_boundary_enforced(self, store: PathContextStore) -> None:
+        """'src' must NOT match 'srcfoo/x.py' — only slash-bounded match."""
+        await store.upsert("root", "src", "src only")
+        cache = PathContextCache(store=store)
+        assert await cache.lookup("root", "srcfoo/x.py") is None
+        assert await cache.lookup("root", "src/x.py") == "src only"
+        assert await cache.lookup("root", "src") == "src only"
+
+    @pytest.mark.asyncio
+    async def test_no_match_returns_none(self, store: PathContextStore) -> None:
+        cache = PathContextCache(store=store)
+        assert await cache.lookup("root", "anything/x.py") is None
+
+    @pytest.mark.asyncio
+    async def test_zone_none_coerces_to_root(self, store: PathContextStore) -> None:
+        await store.upsert("root", "src", "root src")
+        cache = PathContextCache(store=store)
+        assert await cache.lookup(None, "src/x.py") == "root src"
+
+    @pytest.mark.asyncio
+    async def test_zones_isolated_in_cache(self, store: PathContextStore) -> None:
+        await store.upsert("root", "src", "root src")
+        await store.upsert("other", "src", "other src")
+        cache = PathContextCache(store=store)
+        assert await cache.lookup("root", "src/x.py") == "root src"
+        assert await cache.lookup("other", "src/x.py") == "other src"
+
+    @pytest.mark.asyncio
+    async def test_refresh_after_write(self, store: PathContextStore) -> None:
+        cache = PathContextCache(store=store)
+        assert await cache.lookup("root", "src/x.py") is None
+        await store.upsert("root", "src", "first desc")
+        assert await cache.lookup("root", "src/x.py") == "first desc"
+        await store.upsert("root", "src", "second desc")
+        assert await cache.lookup("root", "src/x.py") == "second desc"
+
+    @pytest.mark.asyncio
+    async def test_refresh_after_delete(self, store: PathContextStore) -> None:
+        await store.upsert("root", "src", "first")
+        cache = PathContextCache(store=store)
+        assert await cache.lookup("root", "src/x.py") == "first"
+        await store.delete("root", "src")
+        assert await cache.lookup("root", "src/x.py") is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/integration/bricks/search/test_path_context.py::TestPathContextCacheLookup -v`
+Expected: FAIL with `ImportError: cannot import name 'PathContextCache'`.
+
+- [ ] **Step 3: Add `PathContextCache` to `src/nexus/bricks/search/path_context.py`**
+
+Replace the trailing comment `# Issue #3773: PathContextCache is defined in Task 7.` with:
+
+```python
+class PathContextCache:
+    """In-memory cache of path contexts keyed by zone, with longest-prefix lookup.
+
+    - Per-zone ``asyncio.Lock`` serializes refreshes.
+    - Each lookup cheaply checks ``store.max_updated_at(zone_id)`` and reloads
+      when the cached stamp is stale.
+    - Records are kept sorted by ``len(path_prefix)`` DESC so the first
+      slash-boundary match is the longest prefix.
+    """
+
+    def __init__(self, *, store: PathContextStore) -> None:
+        self._store = store
+        self._entries: dict[str, tuple[datetime | None, list[PathContextRecord]]] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    def _lock_for(self, zone_id: str) -> asyncio.Lock:
+        lock = self._locks.get(zone_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[zone_id] = lock
+        return lock
+
+    async def refresh_if_stale(self, zone_id: str) -> None:
+        db_stamp = await self._store.max_updated_at(zone_id)
+        cached = self._entries.get(zone_id)
+        if cached is not None and cached[0] == db_stamp:
+            return
+        async with self._lock_for(zone_id):
+            # Re-check after lock acquisition — another task may have refreshed.
+            db_stamp = await self._store.max_updated_at(zone_id)
+            cached = self._entries.get(zone_id)
+            if cached is not None and cached[0] == db_stamp:
+                return
+            records = await self._store.load_all_for_zone(zone_id)
+            records.sort(key=lambda r: len(r.path_prefix), reverse=True)
+            self._entries[zone_id] = (db_stamp, records)
+
+    async def lookup(self, zone_id: str | None, path: str) -> str | None:
+        """Return the longest-matching description for ``path`` in ``zone_id``,
+        or None when no prefix matches.
+        """
+        effective_zone = zone_id or ROOT_ZONE_ID
+        await self.refresh_if_stale(effective_zone)
+        cached = self._entries.get(effective_zone)
+        if cached is None:
+            return None
+        _, records = cached
+        for record in records:
+            prefix = record.path_prefix
+            if prefix == "":
+                return record.description
+            if path == prefix or path.startswith(prefix + "/"):
+                return record.description
+        return None
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/integration/bricks/search/test_path_context.py -v`
+Expected: all tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/search/path_context.py \
+        tests/integration/bricks/search/test_path_context.py
+git commit -m "feat(#3773): PathContextCache longest-prefix lookup + freshness"
+```
+
+---
+
+## Task 8: Path contexts — API router (`/api/v2/path-contexts`)
+
+**Files:**
+- Create: `src/nexus/server/api/v2/routers/path_contexts.py`
+- Create: `tests/integration/server/api/v2/routers/test_path_contexts_router.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/integration/server/api/v2/routers/test_path_contexts_router.py`:
+
+```python
+"""Tests for /api/v2/path-contexts router (Issue #3773)."""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from nexus.bricks.search.path_context import PathContextStore
+from nexus.server.api.v2.routers.path_contexts import router as path_contexts_router
+
+CREATE_TABLE_SQL = """
+CREATE TABLE path_contexts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    zone_id TEXT NOT NULL DEFAULT 'root',
+    path_prefix TEXT NOT NULL,
+    description TEXT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(zone_id, path_prefix)
+)
+"""
+
+
+@pytest_asyncio.fixture
+async def test_app():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.exec_driver_sql(CREATE_TABLE_SQL)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    store = PathContextStore(async_session_factory=factory, db_type="sqlite")
+
+    app = FastAPI()
+    app.state.path_context_store = store
+    app.include_router(path_contexts_router)
+
+    # Override auth deps with canned admin/auth identities for the test.
+    from nexus.server.dependencies import require_admin, require_auth
+
+    app.dependency_overrides[require_auth] = lambda: {
+        "subject_id": "tester",
+        "zone_id": "root",
+        "is_admin": False,
+    }
+    app.dependency_overrides[require_admin] = lambda: {
+        "subject_id": "admin",
+        "zone_id": "root",
+        "is_admin": True,
+    }
+    yield app
+    await engine.dispose()
+
+
+@pytest.fixture
+def client(test_app: FastAPI) -> TestClient:
+    return TestClient(test_app)
+
+
+class TestPathContextRouter:
+    def test_put_upsert_then_list(self, client: TestClient) -> None:
+        r = client.put(
+            "/api/v2/path-contexts/",
+            json={
+                "zone_id": "root",
+                "path_prefix": "src/nexus/bricks/search",
+                "description": "Search brick",
+            },
+        )
+        assert r.status_code == 200, r.text
+        r = client.get("/api/v2/path-contexts/", params={"zone_id": "root"})
+        assert r.status_code == 200
+        body = r.json()
+        assert len(body["contexts"]) == 1
+        assert body["contexts"][0]["description"] == "Search brick"
+
+    def test_put_replaces(self, client: TestClient) -> None:
+        client.put(
+            "/api/v2/path-contexts/",
+            json={"zone_id": "root", "path_prefix": "src", "description": "first"},
+        )
+        client.put(
+            "/api/v2/path-contexts/",
+            json={"zone_id": "root", "path_prefix": "src", "description": "second"},
+        )
+        body = client.get("/api/v2/path-contexts/").json()
+        assert len(body["contexts"]) == 1
+        assert body["contexts"][0]["description"] == "second"
+
+    def test_delete_removes(self, client: TestClient) -> None:
+        client.put(
+            "/api/v2/path-contexts/",
+            json={"zone_id": "root", "path_prefix": "src", "description": "x"},
+        )
+        r = client.delete(
+            "/api/v2/path-contexts/",
+            params={"zone_id": "root", "path_prefix": "src"},
+        )
+        assert r.status_code == 200
+        body = client.get("/api/v2/path-contexts/").json()
+        assert body["contexts"] == []
+
+    def test_delete_missing_returns_404(self, client: TestClient) -> None:
+        r = client.delete(
+            "/api/v2/path-contexts/",
+            params={"zone_id": "root", "path_prefix": "nonexistent"},
+        )
+        assert r.status_code == 404
+
+    def test_put_normalizes_prefix(self, client: TestClient) -> None:
+        client.put(
+            "/api/v2/path-contexts/",
+            json={"zone_id": "root", "path_prefix": "/src/", "description": "x"},
+        )
+        body = client.get("/api/v2/path-contexts/").json()
+        assert body["contexts"][0]["path_prefix"] == "src"
+
+    def test_put_rejects_traversal(self, client: TestClient) -> None:
+        r = client.put(
+            "/api/v2/path-contexts/",
+            json={"zone_id": "root", "path_prefix": "src/../etc", "description": "x"},
+        )
+        assert r.status_code == 422 or r.status_code == 400
+
+    def test_non_admin_cannot_write(self, test_app: FastAPI) -> None:
+        # Force require_admin to raise 403 as if caller were non-admin.
+        from fastapi import HTTPException
+
+        from nexus.server.dependencies import require_admin
+
+        def _reject() -> None:
+            raise HTTPException(status_code=403, detail="admin required")
+
+        test_app.dependency_overrides[require_admin] = _reject
+        with TestClient(test_app) as c:
+            r = c.put(
+                "/api/v2/path-contexts/",
+                json={"zone_id": "root", "path_prefix": "src", "description": "x"},
+            )
+            assert r.status_code == 403
+            r = c.delete(
+                "/api/v2/path-contexts/",
+                params={"zone_id": "root", "path_prefix": "src"},
+            )
+            assert r.status_code == 403
+
+    def test_list_requires_auth_only(self, client: TestClient) -> None:
+        r = client.get("/api/v2/path-contexts/")
+        assert r.status_code == 200
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/integration/server/api/v2/routers/test_path_contexts_router.py -v`
+Expected: FAIL with `ModuleNotFoundError: No module named 'nexus.server.api.v2.routers.path_contexts'`.
+
+- [ ] **Step 3: Create `src/nexus/server/api/v2/routers/path_contexts.py`**
+
+```python
+"""Path Contexts API v2 router (Issue #3773).
+
+Admin-managed per-zone path-prefix -> description mappings. Search results
+carry the longest-prefix-matching description in their ``context`` field.
+
+Endpoints:
+- PUT    /api/v2/path-contexts/       Upsert (admin)
+- GET    /api/v2/path-contexts/       List contexts (auth)
+- DELETE /api/v2/path-contexts/       Delete one (admin)
+
+Pattern mirrors access_manifests.py.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel, Field, field_validator
+
+from nexus.bricks.search.path_context import PathContextStore
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.server.dependencies import require_admin, require_auth
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v2/path-contexts", tags=["path_contexts"])
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+
+def _normalize_prefix(raw: str) -> str:
+    """Canonical form: no leading/trailing slashes, no '..' traversal.
+
+    Raises ValueError on traversal attempts.
+    """
+    value = raw.strip()
+    while value.startswith("/"):
+        value = value[1:]
+    while value.endswith("/"):
+        value = value[:-1]
+    parts = value.split("/") if value else []
+    for segment in parts:
+        if segment == ".." or segment == ".":
+            raise ValueError(
+                f"path_prefix must not contain '.' or '..' segments (got {raw!r})"
+            )
+    return value
+
+
+class PathContextIn(BaseModel):
+    zone_id: str = Field(default=ROOT_ZONE_ID, max_length=255)
+    path_prefix: str = Field(max_length=1024)
+    description: str = Field(max_length=4096, min_length=1)
+
+    @field_validator("path_prefix")
+    @classmethod
+    def _validate_prefix(cls, v: str) -> str:
+        return _normalize_prefix(v)
+
+
+class PathContextOut(BaseModel):
+    zone_id: str
+    path_prefix: str
+    description: str
+    created_at: Any
+    updated_at: Any
+
+
+# ---------------------------------------------------------------------------
+# Dependencies
+# ---------------------------------------------------------------------------
+
+
+def _get_store(request: Request) -> PathContextStore:
+    store = getattr(request.app.state, "path_context_store", None)
+    if store is None:
+        raise HTTPException(
+            status_code=503, detail="path context store not configured"
+        )
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.put("/")
+async def upsert_context(
+    body: PathContextIn,
+    _admin: dict[str, Any] = Depends(require_admin),
+    store: PathContextStore = Depends(_get_store),
+) -> dict[str, Any]:
+    """Upsert a path context (admin only)."""
+    await store.upsert(body.zone_id, body.path_prefix, body.description)
+    return {
+        "zone_id": body.zone_id,
+        "path_prefix": body.path_prefix,
+        "description": body.description,
+    }
+
+
+@router.get("/")
+async def list_contexts(
+    zone_id: str | None = Query(default=None),
+    _auth: dict[str, Any] = Depends(require_auth),
+    store: PathContextStore = Depends(_get_store),
+) -> dict[str, Any]:
+    """List path contexts (any authenticated caller). Optional ?zone_id filter."""
+    records = await store.list(zone_id)
+    return {
+        "contexts": [
+            {
+                "zone_id": r.zone_id,
+                "path_prefix": r.path_prefix,
+                "description": r.description,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+                "updated_at": r.updated_at.isoformat() if r.updated_at else None,
+            }
+            for r in records
+        ]
+    }
+
+
+@router.delete("/")
+async def delete_context(
+    zone_id: str = Query(...),
+    path_prefix: str = Query(...),
+    _admin: dict[str, Any] = Depends(require_admin),
+    store: PathContextStore = Depends(_get_store),
+) -> dict[str, Any]:
+    """Delete a path context (admin only)."""
+    try:
+        normalized = _normalize_prefix(path_prefix)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    removed = await store.delete(zone_id, normalized)
+    if not removed:
+        raise HTTPException(status_code=404, detail="path context not found")
+    return {"zone_id": zone_id, "path_prefix": normalized, "status": "deleted"}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/integration/server/api/v2/routers/test_path_contexts_router.py -v`
+Expected: all tests PASS.
+
+If `test_put_rejects_traversal` fails, `pydantic.ValidationError` from a `field_validator` raises 422 by default in FastAPI — the test accepts 422 or 400. If it fails with something else, read the assertion message and fix the validator.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/server/api/v2/routers/path_contexts.py \
+        tests/integration/server/api/v2/routers/test_path_contexts_router.py
+git commit -m "feat(#3773): /api/v2/path-contexts router (admin-gated CRUD)"
+```
+
+---
+
+## Task 9: Path contexts — app wiring (`lifespan/search.py` + `versioning.py`)
+
+**Files:**
+- Modify: `src/nexus/server/lifespan/search.py`
+- Modify: `src/nexus/server/api/v2/versioning.py`
+
+- [ ] **Step 1: Construct store + cache during search startup**
+
+Edit `src/nexus/server/lifespan/search.py`. Locate the block that creates `SearchDaemon` (around line 115) and insert the following immediately **before** `app.state.search_daemon = SearchDaemon(...)`:
+
+```python
+        # Issue #3773: path context store + cache
+        path_context_store = None
+        path_context_cache = None
+        if _async_sf is not None:
+            try:
+                from nexus.bricks.search.path_context import (
+                    PathContextCache,
+                    PathContextStore,
+                )
+
+                _db_type = "postgresql" if (svc.database_url or "").startswith(
+                    ("postgres", "postgresql")
+                ) else "sqlite"
+                path_context_store = PathContextStore(
+                    async_session_factory=_async_sf,
+                    db_type=_db_type,
+                )
+                path_context_cache = PathContextCache(store=path_context_store)
+            except Exception:  # pragma: no cover — non-fatal wiring failure
+                logger.exception("Failed to initialize path context store/cache")
+        app.state.path_context_store = path_context_store
+        app.state.path_context_cache = path_context_cache
+```
+
+Then modify the `SearchDaemon(...)` construction call (currently at `app.state.search_daemon = SearchDaemon(config, async_session_factory=_async_sf, zoekt_client=_zoekt_client, cache_brick=_cache_brick, settings_store=_settings_store,)`) to add a new kwarg:
+
+```python
+        app.state.search_daemon = SearchDaemon(
+            config,
+            async_session_factory=_async_sf,
+            zoekt_client=_zoekt_client,
+            cache_brick=_cache_brick,
+            settings_store=_settings_store,
+            path_context_cache=path_context_cache,  # Issue #3773
+        )
+```
+
+(The `SearchDaemon` constructor is extended to accept this kwarg in Task 10.)
+
+- [ ] **Step 2: Register the router in `versioning.py`**
+
+Edit `src/nexus/server/api/v2/versioning.py`. After the `# ---- Access Manifests router` block (around lines 335-345), add:
+
+```python
+    # ---- Path Contexts router (Issue #3773) ----
+    try:
+        from nexus.server.api.v2.routers.path_contexts import (
+            router as path_contexts_router,
+        )
+
+        registry.add(
+            RouterEntry(router=path_contexts_router, name="path_contexts", endpoint_count=3)
+        )
+    except ImportError as e:
+        logger.warning("Failed to import Path Contexts routes: %s", e)
+```
+
+- [ ] **Step 3: Smoke-check the app starts**
+
+Run: `python -c "from nexus.server.api.v2.versioning import *; print('ok')"`
+Expected: prints `ok`.
+
+Run: `python -c "from nexus.server.lifespan.search import startup_search; print('ok')"`
+Expected: prints `ok`.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/nexus/server/lifespan/search.py src/nexus/server/api/v2/versioning.py
+git commit -m "feat(#3773): wire PathContextStore + PathContextCache into app lifespan"
+```
+
+---
+
+## Task 10: Path contexts — `BaseSearchResult.context` + daemon attach
+
+**Files:**
+- Modify: `src/nexus/bricks/search/results.py`
+- Modify: `src/nexus/bricks/search/daemon.py`
+- Create: `tests/integration/bricks/search/test_daemon_context_attach.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/integration/bricks/search/test_daemon_context_attach.py`:
+
+```python
+"""End-to-end: path contexts are attached to SearchResult instances (Issue #3773)."""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from nexus.bricks.search.path_context import PathContextCache, PathContextStore
+from nexus.bricks.search.results import BaseSearchResult
+
+CREATE_TABLE_SQL = """
+CREATE TABLE path_contexts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    zone_id TEXT NOT NULL DEFAULT 'root',
+    path_prefix TEXT NOT NULL,
+    description TEXT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(zone_id, path_prefix)
+)
+"""
+
+
+@pytest_asyncio.fixture
+async def cache():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.exec_driver_sql(CREATE_TABLE_SQL)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    store = PathContextStore(async_session_factory=factory, db_type="sqlite")
+    await store.upsert("root", "src/nexus/bricks/search", "Hybrid search brick")
+    await store.upsert("root", "docs", "Project documentation")
+    yield PathContextCache(store=store)
+    await engine.dispose()
+
+
+class TestBaseSearchResultContextField:
+    def test_default_context_is_none(self) -> None:
+        r = BaseSearchResult(path="x", chunk_text="y", score=0.5)
+        assert r.context is None
+
+
+class TestAttachContextToResults:
+    @pytest.mark.asyncio
+    async def test_attach_via_cache(self, cache: PathContextCache) -> None:
+        results = [
+            BaseSearchResult(
+                path="src/nexus/bricks/search/fusion.py",
+                chunk_text="",
+                score=0.9,
+                zone_id="root",
+            ),
+            BaseSearchResult(
+                path="docs/README.md",
+                chunk_text="",
+                score=0.8,
+                zone_id="root",
+            ),
+            BaseSearchResult(
+                path="scripts/noop.py",
+                chunk_text="",
+                score=0.7,
+                zone_id="root",
+            ),
+        ]
+        for r in results:
+            r.context = await cache.lookup(r.zone_id, r.path)
+        assert results[0].context == "Hybrid search brick"
+        assert results[1].context == "Project documentation"
+        assert results[2].context is None
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/integration/bricks/search/test_daemon_context_attach.py::TestBaseSearchResultContextField -v`
+Expected: FAIL with `AttributeError: 'BaseSearchResult' object has no attribute 'context'`.
+
+- [ ] **Step 3: Add `context` field to `BaseSearchResult`**
+
+Edit `src/nexus/bricks/search/results.py`. In the `BaseSearchResult` dataclass (lines 14-49), add the new field **after** the `zone_id` line:
+
+```python
+    # Issue #3773: admin-configured path description for LLM consumers
+    context: str | None = None
+```
+
+Final dataclass segment around zone_id should read:
+
+```python
+    # Issue #3147: Federated search — zone provenance
+    zone_id: str | None = None  # Source zone for cross-zone federated results
+    # Issue #3773: admin-configured path description for LLM consumers
+    context: str | None = None
+
+    @property
+    def zone_qualified_path(self) -> str | None:
+```
+
+- [ ] **Step 4: Extend daemon to accept + use the cache**
+
+Edit `src/nexus/bricks/search/daemon.py`.
+
+**4a.** Locate the `SearchDaemon` class constructor (`__init__`). Add a new kwarg `path_context_cache: PathContextCache | None = None`, save it to `self._path_context_cache`. If the file uses `TYPE_CHECKING` import blocks, add the import there; otherwise import lazily inside the attach helper to avoid circular imports. Preferred form at top of file:
+
+```python
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nexus.bricks.search.path_context import PathContextCache
+```
+
+Constructor signature change (illustrative — preserve all existing kwargs):
+
+```python
+def __init__(
+    self,
+    config: DaemonConfig,
+    *,
+    async_session_factory: Any = None,
+    zoekt_client: Any = None,
+    cache_brick: Any = None,
+    settings_store: Any = None,
+    path_context_cache: "PathContextCache | None" = None,  # Issue #3773
+) -> None:
+    ...
+    self._path_context_cache = path_context_cache
+```
+
+**4b.** Locate the end of the SearchResult construction block (currently `daemon.py:1169-1186`, ending just before `latency_ms = (time.perf_counter() - start) * 1000`). Insert a new helper call **after** the list comprehension that builds `results` and **before** the `latency_ms` line:
+
+```python
+                    if self._path_context_cache is not None and results:
+                        for r in results:
+                            r.context = await self._path_context_cache.lookup(
+                                r.zone_id, r.path
+                            )
+```
+
+**4c.** Apply the same attach pattern to any other path that returns `SearchResult` instances in `daemon.py` (legacy fallback branch around lines 1193+). Grep for `return results` within the `search(` method body:
+
+```
+rg -n "return results" src/nexus/bricks/search/daemon.py
+```
+
+For each `return results` in the `search(...)` method, add the same `if self._path_context_cache is not None and results:` attach block immediately before it.
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `pytest tests/integration/bricks/search/test_daemon_context_attach.py -v`
+Expected: all tests PASS.
+
+Also run the full search daemon test suite to catch regressions:
+
+Run: `pytest tests/integration/bricks/search/ -v`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/nexus/bricks/search/results.py \
+        src/nexus/bricks/search/daemon.py \
+        tests/integration/bricks/search/test_daemon_context_attach.py
+git commit -m "feat(#3773): attach path context to SearchResult via cache"
+```
+
+---
+
+## Task 11: Search router — emit `context` in HTTP response
+
+**Files:**
+- Modify: `src/nexus/server/api/v2/routers/search.py` (`_serialize_search_result`)
+- Modify: `tests/integration/bricks/search/test_daemon_context_attach.py` (add serializer test)
+
+- [ ] **Step 1: Write the failing test**
+
+Append to `tests/integration/bricks/search/test_daemon_context_attach.py`:
+
+```python
+class TestSerializerEmitsContext:
+    def test_context_field_emitted_when_set(self) -> None:
+        from nexus.server.api.v2.routers.search import _serialize_search_result
+
+        r = BaseSearchResult(
+            path="src/nexus/bricks/search/fusion.py",
+            chunk_text="body",
+            score=0.9,
+            zone_id="root",
+        )
+        r.context = "Hybrid search brick"
+        out = _serialize_search_result(r)
+        assert out.get("context") == "Hybrid search brick"
+
+    def test_context_field_omitted_when_none(self) -> None:
+        from nexus.server.api.v2.routers.search import _serialize_search_result
+
+        r = BaseSearchResult(path="x", chunk_text="y", score=0.5)
+        out = _serialize_search_result(r)
+        assert "context" not in out
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `pytest tests/integration/bricks/search/test_daemon_context_attach.py::TestSerializerEmitsContext -v`
+Expected: FAIL — first test fails because `context` is absent; second may incidentally pass.
+
+- [ ] **Step 3: Modify `_serialize_search_result`**
+
+Edit `src/nexus/server/api/v2/routers/search.py`. Replace `_serialize_search_result` (lines 106-131) with:
+
+```python
+def _serialize_search_result(result: Any) -> dict[str, Any]:
+    """Serialize a single search result into the canonical response dict.
+
+    Collapses the 25-line dict comprehension previously duplicated across
+    the graph and non-graph branches of ``search_query``. Preserves the
+    pre-refactor field ordering, rounding, and None semantics.
+
+    Issue #3773: emits ``context`` when the result carries a non-None value
+    (omits the key otherwise to keep responses compact).
+    """
+    out: dict[str, Any] = {
+        "path": result.path,
+        "chunk_text": result.chunk_text,
+        "score": round(result.score, 4),
+        "chunk_index": result.chunk_index,
+        "line_start": result.line_start,
+        "line_end": result.line_end,
+        "keyword_score": (round(result.keyword_score, 4) if result.keyword_score else None),
+        "vector_score": (round(result.vector_score, 4) if result.vector_score else None),
+    }
+    splade = getattr(result, "splade_score", None)
+    out["splade_score"] = round(splade, 4) if splade is not None else None
+    reranker = getattr(result, "reranker_score", None)
+    out["reranker_score"] = round(reranker, 4) if reranker is not None else None
+    context = getattr(result, "context", None)
+    if context is not None:
+        out["context"] = context
+    return out
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `pytest tests/integration/bricks/search/test_daemon_context_attach.py::TestSerializerEmitsContext -v`
+Expected: both tests PASS.
+
+Also re-run any existing search router tests:
+
+Run: `pytest tests/integration/server/api/v2/routers/ -v`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/server/api/v2/routers/search.py \
+        tests/integration/bricks/search/test_daemon_context_attach.py
+git commit -m "feat(#3773): emit context field in /api/v2/search responses"
+```
+
+---
+
+## Task 12: Final verification
+
+**Files:** none — verification only.
+
+- [ ] **Step 1: Run the full relevant test suite**
+
+Run:
+```
+pytest tests/integration/bricks/search/test_rrf_bonus.py \
+       tests/integration/bricks/search/test_fusion.py \
+       tests/integration/bricks/search/test_path_context.py \
+       tests/integration/bricks/search/test_daemon_context_attach.py \
+       tests/integration/server/api/v2/routers/test_path_contexts_router.py \
+       -v
+```
+Expected: all PASS.
+
+- [ ] **Step 2: Type check**
+
+Run: `mypy src/nexus/bricks/search/fusion.py src/nexus/bricks/search/path_context.py src/nexus/bricks/search/results.py src/nexus/bricks/search/daemon.py src/nexus/server/api/v2/routers/path_contexts.py src/nexus/server/api/v2/routers/search.py src/nexus/server/lifespan/search.py`
+Expected: no new errors introduced (pre-existing errors unrelated to these files are acceptable if they existed on `develop`).
+
+- [ ] **Step 3: Lint**
+
+Run: `ruff check src/nexus/bricks/search/ src/nexus/server/api/v2/routers/path_contexts.py src/nexus/server/lifespan/search.py`
+Expected: no new errors.
+
+- [ ] **Step 4: Confirm migration round-trips**
+
+Run: `alembic downgrade -1 && alembic upgrade head`
+Expected: clean downgrade followed by clean upgrade.
+
+- [ ] **Step 5: Smoke test against a local server (optional but recommended)**
+
+Start the server with default config, then:
+```
+curl -s -X PUT http://localhost:PORT/api/v2/path-contexts/ \
+     -H 'Content-Type: application/json' \
+     -H 'Authorization: Bearer <admin_token>' \
+     -d '{"zone_id":"root","path_prefix":"src/nexus/bricks/search","description":"Hybrid search"}'
+
+curl -s "http://localhost:PORT/api/v2/search?q=fusion&limit=3" \
+     -H 'Authorization: Bearer <auth_token>' | jq '.results[0]'
+```
+Expected: the first result for a matching path carries a `context` field.
+
+- [ ] **Step 6: No additional commit**
+
+All prior tasks committed their own changes. Verify `git status` is clean.
+
+Run: `git status`
+Expected: `nothing to commit, working tree clean`.
+
+---
+
+## Self-review notes
+
+- **Spec coverage:** all sections of `2026-04-16-issue-3773-rrf-bonus-path-contexts-design.md` map to tasks:
+  - RRF bonus → Tasks 1–4.
+  - Schema/migration → Task 5.
+  - Store + cache → Tasks 6–7.
+  - Router → Task 8.
+  - App wiring → Task 9.
+  - Dataclass field + daemon attach → Task 10.
+  - Serializer → Task 11.
+  - Feature gate (empty table = no-op) → enforced implicitly by cache returning None.
+- **Placeholders:** none. `<CURRENT_HEAD>` in Task 5 is a discoverable value, with explicit steps to find it.
+- **Type consistency:** `PathContextStore`, `PathContextCache`, `PathContextRecord` names reused verbatim in Tasks 6–11. `top_rank_bonus` parameter and `RRF_TOP1_BONUS`/`RRF_TOP3_BONUS` constants reused verbatim in Tasks 1–4. `BaseSearchResult.context: str | None = None` reused in Tasks 10–11.
+- **Observability** (INFO log on cache reload) is deliberately omitted from tasks — a trivial log line can be added during code review if desired.

--- a/docs/superpowers/specs/2026-04-16-issue-3773-rrf-bonus-path-contexts-design.md
+++ b/docs/superpowers/specs/2026-04-16-issue-3773-rrf-bonus-path-contexts-design.md
@@ -1,0 +1,255 @@
+# Issue #3773 — RRF Top-Rank Bonus + Path Context Descriptions
+
+**Status:** Approved design
+**Date:** 2026-04-16
+**Issue:** https://github.com/nexi-lab/nexus/issues/3773
+**Inspiration:** [QMD](https://github.com/tobi/qmd) — Tobi Lütke's local hybrid search engine.
+
+## Summary
+
+Two independent improvements to search quality, delivered in a single PR:
+
+1. **RRF top-rank bonus** — small score bump for documents ranked #1–3 in any input list during RRF fusion, so high-confidence matches are not diluted by query expansion or multi-backend fusion.
+2. **Path context descriptions** — user-configurable per-path-prefix descriptions attached to search results, giving LLM agents immediate relevance signal without reading each file.
+
+Both are zero-new-deps, zero-LLM-call, opt-out changes.
+
+## 1. RRF Top-Rank Bonus
+
+### Problem
+
+Standard RRF (`score = Σ 1/(k + rank)`) dilutes exact matches. A document ranked #1 in keyword search but absent from vector search scores lower than a mediocre document ranked #3 in both lists. Worsens with query expansion (original match gets diluted across variant queries).
+
+### Solution
+
+After accumulating per-source RRF contributions, add a small bonus based on the document's **best rank across any input list**:
+
+| Best rank in any list | Bonus |
+|---|---|
+| 1 | +0.05 |
+| 2–3 | +0.02 |
+| 4+ | 0 |
+
+Preserves high-confidence matches without distorting overall ranking.
+
+### Changes
+
+**File:** `src/nexus/bricks/search/fusion.py`
+
+Module constants:
+```python
+RRF_TOP1_BONUS = 0.05
+RRF_TOP3_BONUS = 0.02
+```
+
+`FusionConfig` gains:
+```python
+top_rank_bonus: bool = True
+```
+
+Modify these three fusion functions to apply the bonus (parameter `top_rank_bonus: bool = True` on each):
+
+- `rrf_fusion`
+- `rrf_weighted_fusion`
+- `rrf_multi_fusion`
+
+**Shared logic** (applied inside each fn, after existing RRF accumulation loop):
+
+```python
+# Track best rank per key across all input lists.
+best_rank: dict[str, int] = {}
+# Populated during the existing enumerate loop(s):
+#   best_rank[key] = min(best_rank.get(key, rank), rank)
+
+if top_rank_bonus:
+    for key, entry in rrf_scores.items():
+        br = best_rank.get(key, 999)
+        if br == 1:
+            entry["rrf_score"] += RRF_TOP1_BONUS
+        elif br <= 3:
+            entry["rrf_score"] += RRF_TOP3_BONUS
+```
+
+`fuse_results` forwards `config.top_rank_bonus` to each underlying function.
+
+### Tests
+
+New file `tests/bricks/search/test_rrf_bonus.py`:
+- Golden: top-1-keyword-only beats mediocre-both (the failure case from the issue).
+- Bonus disabled path preserves legacy behaviour.
+- `rrf_weighted_fusion`: bonus applied after alpha-weighting.
+- `rrf_multi_fusion`: bonus applied across N sources.
+- Existing RRF tests: audit and update golden orderings where bonus flips ranking.
+
+## 2. Path Context Descriptions
+
+### Problem
+
+Search results expose `path` but no high-level description of what that file or directory contains. Agent consumers either read each file to judge relevance or guess. Both waste tokens and time.
+
+### Solution
+
+Admin-configured, zone-scoped table mapping path prefixes to human-written descriptions. Search results carry the longest-prefix-matching description in a new `context` field.
+
+### Data model
+
+**New table `path_contexts`:**
+
+```python
+sa.Column("id", sa.Integer, primary_key=True, autoincrement=True)
+sa.Column("zone_id", sa.String(255), nullable=False, server_default=ROOT_ZONE_ID)
+sa.Column("path_prefix", sa.String(1024), nullable=False)
+sa.Column("description", sa.Text, nullable=False)
+sa.Column("created_at", sa.DateTime, server_default=sa.func.now(), nullable=False)
+sa.Column("updated_at", sa.DateTime, server_default=sa.func.now(), onupdate=sa.func.now(), nullable=False)
+sa.UniqueConstraint("zone_id", "path_prefix", name="uq_path_contexts_zone_prefix")
+sa.Index("ix_path_contexts_zone_updated", "zone_id", "updated_at")
+```
+
+- `zone_id` non-null with `ROOT_ZONE_ID` default — matches `src/nexus/lib/db_base.py:74` and `alembic/versions/add_credentials_and_manifests.py:30`.
+- `path_prefix` stored canonical: no leading `/`, no trailing `/`. Empty string = zone root (matches every path).
+- `(zone_id, updated_at)` index supports the per-search freshness check.
+
+**Migration:** `alembic/versions/add_path_contexts_table.py`. Uses `op.create_table` and `op.batch_alter_table` for SQLite compatibility. Upgrade creates; downgrade drops.
+
+### Canonical prefix rules
+
+Writer normalizes `path_prefix` before persisting:
+- Strip leading and trailing `/`.
+- Reject `..` traversal segments.
+- Max length 1024.
+
+Description max length 4096 characters. Validation enforced in router-layer Pydantic model.
+
+### CRUD store
+
+**New file:** `src/nexus/bricks/search/path_context.py`
+
+```python
+@dataclass(frozen=True)
+class PathContextRecord:
+    zone_id: str
+    path_prefix: str
+    description: str
+    created_at: datetime
+    updated_at: datetime
+
+class PathContextStore:
+    def __init__(self, async_session_factory): ...
+
+    async def upsert(self, zone_id: str, path_prefix: str, description: str) -> None: ...
+    async def delete(self, zone_id: str, path_prefix: str) -> bool: ...
+    async def list(self, zone_id: str | None = None) -> list[PathContextRecord]: ...
+    async def max_updated_at(self, zone_id: str) -> datetime | None: ...
+    async def load_all_for_zone(self, zone_id: str) -> list[PathContextRecord]: ...
+```
+
+Implementation follows `src/nexus/bricks/search/chunk_store.py`:
+- Raw SQL via `sqlalchemy.text()` with bound params.
+- Dialect dispatch for upsert: `INSERT … ON CONFLICT (zone_id, path_prefix) DO UPDATE` on PostgreSQL; `INSERT OR REPLACE` on SQLite.
+- Async sessions from injected factory.
+
+### In-memory cache
+
+**Class `PathContextCache`** (same file):
+
+State: `dict[str, tuple[datetime | None, list[PathContextRecord]]]` — keyed by `zone_id`, each entry holds the freshness stamp and the records sorted by `len(path_prefix)` DESC.
+
+API:
+```python
+async def lookup(self, zone_id: str | None, path: str) -> str | None:
+    """Return longest-matching description for path, or None."""
+
+async def refresh_if_stale(self, zone_id: str) -> None:
+    """Compare store.max_updated_at to cached stamp; reload if newer."""
+```
+
+Per-zone `asyncio.Lock` serializes refreshes. `zone_id is None` coerces to `ROOT_ZONE_ID`.
+
+**Matching semantics:**
+- Empty prefix `""` matches any path in the zone.
+- Non-empty prefix `p` matches path `x` iff `x == p` OR `x.startswith(p + "/")`. The slash-boundary prevents `src` matching `srcfoo/x.py`.
+- First hit in the length-DESC-sorted list wins (longest prefix).
+
+**Freshness:** First `lookup` call in a search awaits `refresh_if_stale`, which issues one `SELECT MAX(updated_at) FROM path_contexts WHERE zone_id = :z`. Reload only when stamp advanced. Subsequent lookups in the same search reuse cached list.
+
+### API router
+
+**New file:** `src/nexus/server/api/v2/routers/path_contexts.py`
+
+Pattern mirrors `src/nexus/server/api/v2/routers/access_manifests.py`:
+- `router = APIRouter(prefix="/api/v2/path-contexts", tags=["path-contexts"])`.
+- Dependency `_get_path_context_store` pulls from `request.app.state`.
+
+| Method | Path | Auth | Purpose |
+|---|---|---|---|
+| `PUT` | `/` | `require_admin` | Upsert `{zone_id?, path_prefix, description}` |
+| `GET` | `/` | `require_auth` | List; optional `?zone_id=` filter |
+| `DELETE` | `/` | `require_admin` | Delete by `?zone_id=&path_prefix=`; 404 if no matching row |
+
+Pydantic models:
+```python
+class PathContextIn(BaseModel):
+    zone_id: str = Field(default=ROOT_ZONE_ID, max_length=255)
+    path_prefix: str = Field(max_length=1024)
+    description: str = Field(max_length=4096)
+
+class PathContextOut(BaseModel):
+    zone_id: str
+    path_prefix: str
+    description: str
+    created_at: datetime
+    updated_at: datetime
+```
+
+`zone_id` validated against the existing zone registry before write.
+
+### App wiring
+
+`src/nexus/server/fastapi_server.py`:
+- At startup, construct `PathContextStore(async_session_factory)` → `app.state.path_context_store`.
+- At startup, construct `PathContextCache(store=…)` → `app.state.path_context_cache`.
+- Include `path_contexts.router`.
+
+### Search integration
+
+**Dataclass:** `src/nexus/bricks/search/results.py`
+- Add `context: str | None = None` to `BaseSearchResult` after `zone_id`. Backward compatible (default None).
+
+**Daemon:** `src/nexus/bricks/search/daemon.py`
+- New optional constructor kwarg `path_context_cache: PathContextCache | None = None`.
+- In `search()` after final result list is assembled (around `daemon.py:1186`): if cache is present, for each result call `result.context = await cache.lookup(result.zone_id, result.path)`.
+- Federated search (`src/nexus/bricks/search/federated_search.py`): each per-zone daemon attaches its own context, so merged cross-zone results carry correct per-row descriptions.
+
+**Router serializer:** `src/nexus/server/api/v2/routers/search.py`
+- `_serialize_search_result` (lines 106–131) emits `context` when non-None; omits key when None to keep responses compact.
+
+**MCP search tool:** no change needed. The tool's response builder converts `BaseSearchResult` to a dict; because `context` is a plain dataclass field, serialization already includes it. Null values are emitted as `null` (or omitted, matching the tool's existing convention for other optional fields like `splade_score`).
+
+### Feature gate
+
+No explicit flag. Empty `path_contexts` table ⇒ every lookup returns None ⇒ search responses unchanged. Operators can fully disable by leaving `app.state.path_context_cache = None`.
+
+## Testing
+
+- `tests/bricks/search/test_rrf_bonus.py` — RRF bonus golden cases (issue scenario), enabled/disabled, all three fusion variants.
+- `tests/bricks/search/test_path_context.py` — store CRUD against PG and SQLite, cache freshness/staleness, longest-prefix-match edge cases (empty prefix, slash boundary, no-match, multi-zone isolation).
+- `tests/server/api/v2/test_path_contexts_router.py` — admin/auth gate enforcement, validation (prefix normalization, length, zone existence), 404 on missing delete.
+- `tests/bricks/search/test_daemon_context_attach.py` — end-to-end: seed contexts, run search, assert `context` populated on `SearchResult` dataclass and in HTTP response JSON.
+- Existing RRF tests audited; golden orderings updated where bonus flips results.
+
+## Rollout
+
+- Single PR covers both features.
+- `FusionConfig.top_rank_bonus = True` by default — no config change.
+- Alembic upgrade/downgrade validated on PG and SQLite (existing CI path).
+- No contexts seeded on deploy — zero user-visible search change until an admin populates via API.
+- Observability: INFO log on each cache reload (`zone_id`, entry count). No metrics for v1.
+
+## Out of scope
+
+- Query expansion integration — the bonus already compensates for expansion dilution mechanically; no further change.
+- Context inheritance UI / admin dashboard — API only.
+- Bulk import/export of contexts — single-entry PUT only for v1.
+- Per-user contexts — zone-scoped only.
+- Non-prefix match (regex, globs) — only exact-or-slash-boundary prefix for v1.

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1257,10 +1257,12 @@ class SearchDaemon:
         for zone in zones:
             try:
                 await cache.refresh_if_stale(zone)
-                snap = cache.snapshot_zone(zone)
-                if snap is not None:
-                    snapshots[zone] = snap
             except Exception as exc:
+                # Round-5 review: a transient DB error during refresh must not
+                # discard a previously-cached snapshot. Stale context is
+                # strictly better than no context for an LLM consumer, and it
+                # matches the fail-soft contract advertised in the stats
+                # counter's name.
                 self.stats.path_context_attach_failures += 1
                 logger.warning(
                     "path context refresh failed for zone=%r (total=%d): %s",
@@ -1268,6 +1270,9 @@ class SearchDaemon:
                     self.stats.path_context_attach_failures,
                     exc,
                 )
+            snap = cache.snapshot_zone(zone)
+            if snap is not None:
+                snapshots[zone] = snap
 
         from nexus.bricks.search.path_context import lookup_in_records
 

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -60,6 +60,7 @@ if TYPE_CHECKING:
     from nexus.bricks.search.chunking import EntropyAwareChunker
     from nexus.bricks.search.index_scope import IndexScope
     from nexus.bricks.search.indexing import IndexingPipeline
+    from nexus.bricks.search.path_context import PathContextCache
 
 logger = logging.getLogger(__name__)
 
@@ -178,6 +179,7 @@ class SearchDaemon:
         zoekt_client: Any | None = None,
         cache_brick: Any | None = None,
         settings_store: Any | None = None,
+        path_context_cache: "PathContextCache | None" = None,
     ):
         """Initialize the search daemon.
 
@@ -189,12 +191,16 @@ class SearchDaemon:
             cache_brick: Injected CacheBrick for embedding cache health checks.
             settings_store: Optional SystemSettingsStoreProtocol for durable
                 consumer checkpoints.
+            path_context_cache: Optional PathContextCache for attaching admin-
+                configured path descriptions onto every ``SearchResult``
+                returned by :meth:`search` (Issue #3773).
         """
         self.config = config or DaemonConfig()
         self.stats = DaemonStats()
         self._zoekt_client = zoekt_client
         self._cache_brick = cache_brick
         self._settings_store = settings_store
+        self._path_context_cache = path_context_cache
 
         # Search components (initialized on startup)
         self._bm25s_index: BM25SIndex | None = None
@@ -1103,6 +1109,19 @@ class SearchDaemon:
     # Search Methods
     # =========================================================================
 
+    async def _attach_path_contexts(self, results: list[SearchResult]) -> None:
+        """Attach admin-configured path context descriptions to search results.
+
+        Issue #3773: When a ``PathContextCache`` is wired in, look up the
+        longest-prefix context for each result and populate
+        ``SearchResult.context`` in-place. No-op when the cache is absent or
+        the result list is empty.
+        """
+        if self._path_context_cache is None or not results:
+            return
+        for r in results:
+            r.context = await self._path_context_cache.lookup(r.zone_id, r.path)
+
     async def search(
         self,
         query: str,
@@ -1145,6 +1164,7 @@ class SearchDaemon:
                     latency_ms = (time.perf_counter() - start) * 1000
                     self._track_latency(latency_ms)
                     self.last_search_timing["backend_ms"] = latency_ms
+                    await self._attach_path_contexts(zoekt_results)
                     return zoekt_results
 
             # Delegate to txtai backend for all search types (Issue #2663)
@@ -1187,6 +1207,7 @@ class SearchDaemon:
 
                     latency_ms = (time.perf_counter() - start) * 1000
                     self._track_latency(latency_ms)
+                    await self._attach_path_contexts(results)
                     return results
                 # txtai returned empty — fall through to legacy search
 
@@ -1209,6 +1230,7 @@ class SearchDaemon:
             latency_ms = (time.perf_counter() - start) * 1000
             self._track_latency(latency_ms)
 
+            await self._attach_path_contexts(results)
             return results
 
         except TimeoutError:

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -805,11 +805,19 @@ class SearchDaemon:
         self._async_engine = None
         self._async_session = None
 
-        # Dispose loop-local path-context engines we created lazily
-        # (Issue #3773 review feedback — avoid pooled-connection leak).
-        for engine in list(self._path_context_engines_by_loop.values()):
-            with contextlib.suppress(Exception):
-                await engine.dispose()
+        # Dispose loop-local path-context engines we created lazily. Only
+        # engines whose origin loop is the current running loop can actually
+        # be disposed from here — asyncpg pools for a different (or dead)
+        # loop must be released on their own loop, which we cannot reach
+        # from shutdown. Dropping the references is still correct: the dead
+        # loop's socket fds are reclaimed when it's garbage-collected.
+        # Suppress the expected cross-loop error on dispose rather than
+        # letting it surface as a shutdown warning.
+        running_loop = asyncio.get_running_loop()
+        for loop_key, engine in list(self._path_context_engines_by_loop.items()):
+            if loop_key is running_loop and not loop_key.is_closed():
+                with contextlib.suppress(Exception):
+                    await engine.dispose()
         self._path_context_engines_by_loop.clear()
         self._path_context_cache_by_loop.clear()
 
@@ -1364,10 +1372,40 @@ class SearchDaemon:
             return [[] for _ in queries]
 
         results: list[list[Any]] = await backend_batch(queries, zone_id=effective_zone_id)
-        # Issue #3773: attach admin-configured path contexts per inner list.
-        if self._path_context_cache is not None:
+        # Issue #3773: attach admin-configured path contexts. Resolve the
+        # cache via the same lazy loop-local path as single-query search so
+        # deployments using ``create_app(database_url=...)`` (no startup
+        # injection) aren't silently missing context on batch responses.
+        # Refresh once per unique zone across the whole batch, then do
+        # pure in-memory lookups per result.
+        try:
+            cache = await self._resolve_path_context_cache()
+        except Exception as exc:
+            self.stats.path_context_resolve_failures += 1
+            logger.warning(
+                "path context cache resolution failed (total=%d): %s",
+                self.stats.path_context_resolve_failures,
+                exc,
+            )
+            cache = None
+        if cache is not None:
+            zones: set[str] = set()
             for inner in results:
-                await self._attach_path_contexts(inner)
+                for r in inner:
+                    zones.add(getattr(r, "zone_id", None) or ROOT_ZONE_ID)
+            try:
+                for zone in zones:
+                    await cache.refresh_if_stale(zone)
+                for inner in results:
+                    for r in inner:
+                        r.context = cache.lookup_cached(r.zone_id, r.path)
+            except Exception as exc:
+                self.stats.path_context_attach_failures += 1
+                logger.warning(
+                    "path context attach failed (total=%d): %s",
+                    self.stats.path_context_attach_failures,
+                    exc,
+                )
         return results
 
     async def index_documents(

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1449,22 +1449,37 @@ class SearchDaemon:
             )
             cache = None
         if cache is not None:
+            # Round-6 review: refresh failure must not drop an otherwise-usable
+            # stale snapshot — matches the fail-soft contract in
+            # ``_attach_path_contexts``. Snapshot AFTER the refresh's try so a
+            # transient DB error still yields the last successfully-loaded
+            # records instead of silently erasing context for the whole batch.
             try:
                 await cache.refresh_if_stale(effective_zone_id)
-                records = cache.snapshot_zone(effective_zone_id)
-                if records is not None:
-                    from nexus.bricks.search.path_context import lookup_in_records
-
-                    for inner in results:
-                        for r in inner:
-                            r.context = lookup_in_records(records, r.path)
             except Exception as exc:
                 self.stats.path_context_attach_failures += 1
                 logger.warning(
-                    "path context attach failed (total=%d): %s",
+                    "path context refresh failed for zone=%r (total=%d): %s",
+                    effective_zone_id,
                     self.stats.path_context_attach_failures,
                     exc,
                 )
+            records = cache.snapshot_zone(effective_zone_id)
+            if records is not None:
+                from nexus.bricks.search.path_context import lookup_in_records
+
+                for inner in results:
+                    for r in inner:
+                        try:
+                            r.context = lookup_in_records(records, r.path)
+                        except Exception as exc:
+                            self.stats.path_context_attach_failures += 1
+                            logger.warning(
+                                "path context lookup failed for path=%r (total=%d): %s",
+                                r.path,
+                                self.stats.path_context_attach_failures,
+                                exc,
+                            )
         return results
 
     async def index_documents(

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -158,6 +158,11 @@ class DaemonConfig:
     # only matters when ANOTHER worker mutated scope.
     scope_refresh_seconds: float = 5.0
 
+    # Path-context cache bound (Issue #3773 review). Multi-tenant deployments
+    # with thousands of active zones can outgrow the default LRU cap; expose
+    # as config so operators can tune without a code change.
+    path_context_max_zones: int = 2048
+
 
 class SearchDaemon:
     """Long-running search service with pre-warmed indexes.
@@ -1187,12 +1192,17 @@ class SearchDaemon:
         engine = create_async_engine(db_url, future=True)
         factory = async_sessionmaker(engine, expire_on_commit=False)
         store = PathContextStore(async_session_factory=factory, db_type=db_type)
-        cache = PathContextCache(store=store)
+        cache = PathContextCache(store=store, max_zones=self.config.path_context_max_zones)
         self._path_context_cache_by_loop[loop] = cache
         self._path_context_engines_by_loop[loop] = engine
         return cache
 
-    async def _attach_path_contexts(self, results: list[SearchResult]) -> None:
+    async def _attach_path_contexts(
+        self,
+        results: list[SearchResult],
+        *,
+        zone_id: str | None = None,
+    ) -> None:
         """Attach admin-configured path context descriptions to search results.
 
         Issue #3773: When a ``PathContextCache`` is wired in, look up the
@@ -1200,6 +1210,13 @@ class SearchDaemon:
         ``SearchResult.context`` in-place. No-op when the cache is absent or
         the result list is empty. Refreshes per-zone cache at most once per
         batch, then performs pure in-memory lookups (Issue #3773 review).
+
+        ``zone_id`` is the effective zone scope of the caller's search.
+        Many backend paths (txtai, legacy BM25) construct ``SearchResult``
+        without populating ``result.zone_id``, so we cannot rely on the
+        per-result field. Use the caller-supplied ``zone_id`` as the
+        authoritative fallback, otherwise non-root zone searches silently
+        attach root-zone contexts (Round-3 review regression).
 
         Fails soft: if the cache lookup raises (e.g. asyncpg loop mismatch),
         logs a warning and leaves ``context`` unset rather than breaking
@@ -1222,12 +1239,34 @@ class SearchDaemon:
         if cache is None:
             return
 
-        zones = {(r.zone_id or ROOT_ZONE_ID) for r in results}
+        # Prefer the caller's effective zone over per-result zone_id because
+        # most backends don't populate it; fall back to r.zone_id then to
+        # ROOT_ZONE_ID if both are absent.
+        effective_zone = zone_id or ROOT_ZONE_ID
+
+        def _zone_for(r: SearchResult) -> str:
+            return r.zone_id or effective_zone
+
+        zones = {_zone_for(r) for r in results}
         try:
+            # Refresh + synchronously snapshot each zone's records list
+            # (between awaits a concurrent request could evict this zone
+            # from the LRU). snapshot_zone is sync so the grab happens
+            # before the next refresh's await point.
+            snapshots: dict[str, list[Any]] = {}
             for zone in zones:
                 await cache.refresh_if_stale(zone)
+                snap = cache.snapshot_zone(zone)
+                if snap is not None:
+                    snapshots[zone] = snap
+            from nexus.bricks.search.path_context import lookup_in_records
+
             for r in results:
-                r.context = cache.lookup_cached(r.zone_id, r.path)
+                zone = _zone_for(r)
+                records = snapshots.get(zone)
+                if records is None:
+                    continue
+                r.context = lookup_in_records(records, r.path)
         except Exception as exc:
             self.stats.path_context_attach_failures += 1
             logger.warning(
@@ -1278,7 +1317,7 @@ class SearchDaemon:
                     latency_ms = (time.perf_counter() - start) * 1000
                     self._track_latency(latency_ms)
                     self.last_search_timing["backend_ms"] = latency_ms
-                    await self._attach_path_contexts(zoekt_results)
+                    await self._attach_path_contexts(zoekt_results, zone_id=effective_zone_id)
                     return zoekt_results
 
             # Delegate to txtai backend for all search types (Issue #2663)
@@ -1321,7 +1360,7 @@ class SearchDaemon:
 
                     latency_ms = (time.perf_counter() - start) * 1000
                     self._track_latency(latency_ms)
-                    await self._attach_path_contexts(results)
+                    await self._attach_path_contexts(results, zone_id=effective_zone_id)
                     return results
                 # txtai returned empty — fall through to legacy search
 
@@ -1344,7 +1383,7 @@ class SearchDaemon:
             latency_ms = (time.perf_counter() - start) * 1000
             self._track_latency(latency_ms)
 
-            await self._attach_path_contexts(results)
+            await self._attach_path_contexts(results, zone_id=effective_zone_id)
             return results
 
         except TimeoutError:
@@ -1376,12 +1415,12 @@ class SearchDaemon:
             return [[] for _ in queries]
 
         results: list[list[Any]] = await backend_batch(queries, zone_id=effective_zone_id)
-        # Issue #3773: attach admin-configured path contexts. Resolve the
-        # cache via the same lazy loop-local path as single-query search so
-        # deployments using ``create_app(database_url=...)`` (no startup
-        # injection) aren't silently missing context on batch responses.
-        # Refresh once per unique zone across the whole batch, then do
-        # pure in-memory lookups per result.
+        # Issue #3773: attach admin-configured path contexts. The whole batch
+        # is single-zone by design (``zone_id=effective_zone_id`` above), so
+        # refresh once against that zone and do pure in-memory lookups on
+        # every inner result against the snapshot — backends return
+        # ``BaseSearchResult`` without ``zone_id`` set, so we must use the
+        # caller's scope instead of ``r.zone_id`` (Round-3 review).
         try:
             cache = await self._resolve_path_context_cache()
         except Exception as exc:
@@ -1393,16 +1432,15 @@ class SearchDaemon:
             )
             cache = None
         if cache is not None:
-            zones: set[str] = set()
-            for inner in results:
-                for r in inner:
-                    zones.add(getattr(r, "zone_id", None) or ROOT_ZONE_ID)
             try:
-                for zone in zones:
-                    await cache.refresh_if_stale(zone)
-                for inner in results:
-                    for r in inner:
-                        r.context = cache.lookup_cached(r.zone_id, r.path)
+                await cache.refresh_if_stale(effective_zone_id)
+                records = cache.snapshot_zone(effective_zone_id)
+                if records is not None:
+                    from nexus.bricks.search.path_context import lookup_in_records
+
+                    for inner in results:
+                        for r in inner:
+                            r.context = lookup_in_records(records, r.path)
             except Exception as exc:
                 self.stats.path_context_attach_failures += 1
                 logger.warning(

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1157,6 +1157,15 @@ class SearchDaemon:
         from nexus.bricks.search.path_context import PathContextCache, PathContextStore
 
         loop = asyncio.get_running_loop()
+        # Round-7 review: prune closed-loop entries to bound memory on
+        # long-running servers where request loops can come and go (worker
+        # recycling, anyio loop churn). Entries for dead loops can't be
+        # disposed from here anyway — shutdown can only reach the current
+        # loop's engine — so dropping their refs is the correct cleanup.
+        stale = [lk for lk in self._path_context_cache_by_loop if lk.is_closed()]
+        for lk in stale:
+            self._path_context_cache_by_loop.pop(lk, None)
+            self._path_context_engines_by_loop.pop(lk, None)
         existing = self._path_context_cache_by_loop.get(loop)
         if existing is not None:
             return existing
@@ -1270,7 +1279,21 @@ class SearchDaemon:
                     self.stats.path_context_attach_failures,
                     exc,
                 )
-            snap = cache.snapshot_zone(zone)
+            # Round-7 review: snapshot_zone is a dict access but the fail-soft
+            # contract says ONE zone raising must not propagate out of this
+            # method. Wrap it too so a rare concurrent-mutation RuntimeError
+            # is caught and counted, not raised.
+            try:
+                snap = cache.snapshot_zone(zone)
+            except Exception as exc:
+                self.stats.path_context_attach_failures += 1
+                logger.warning(
+                    "path context snapshot failed for zone=%r (total=%d): %s",
+                    zone,
+                    self.stats.path_context_attach_failures,
+                    exc,
+                )
+                snap = None
             if snap is not None:
                 snapshots[zone] = snap
 
@@ -1464,7 +1487,19 @@ class SearchDaemon:
                     self.stats.path_context_attach_failures,
                     exc,
                 )
-            records = cache.snapshot_zone(effective_zone_id)
+            # Round-7 review: wrap snapshot_zone too so the fail-soft contract
+            # holds even if a concurrent LRU mutation races the dict access.
+            try:
+                records = cache.snapshot_zone(effective_zone_id)
+            except Exception as exc:
+                self.stats.path_context_attach_failures += 1
+                logger.warning(
+                    "path context snapshot failed for zone=%r (total=%d): %s",
+                    effective_zone_id,
+                    self.stats.path_context_attach_failures,
+                    exc,
+                )
+                records = None
             if records is not None:
                 from nexus.bricks.search.path_context import lookup_in_records
 

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1128,7 +1128,15 @@ class SearchDaemon:
         if existing is not None:
             return existing
 
-        db_url = os.environ.get("DATABASE_URL") or os.environ.get("NEXUS_DATABASE_URL")
+        # Prefer the explicit DaemonConfig URL (set by `create_app(database_url=...)`
+        # or the startup lifespan), fall back to env vars. Both must be consulted
+        # — env-only lookup misses the `create_app(database_url=...)` code path
+        # (Issue #3773 review feedback).
+        db_url = (
+            self.config.database_url
+            or os.environ.get("DATABASE_URL")
+            or os.environ.get("NEXUS_DATABASE_URL")
+        )
         if not db_url:
             if self._path_context_cache is not None:
                 self._path_context_cache_by_loop[loop] = self._path_context_cache

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1248,32 +1248,44 @@ class SearchDaemon:
             return r.zone_id or effective_zone
 
         zones = {_zone_for(r) for r in results}
-        try:
-            # Refresh + synchronously snapshot each zone's records list
-            # (between awaits a concurrent request could evict this zone
-            # from the LRU). snapshot_zone is sync so the grab happens
-            # before the next refresh's await point.
-            snapshots: dict[str, list[Any]] = {}
-            for zone in zones:
+        # Refresh + synchronously snapshot each zone's records list (between
+        # awaits a concurrent request could evict this zone from the LRU).
+        # snapshot_zone is sync so the grab happens before the next refresh's
+        # await point. Isolate per-zone failures: one zone raising shouldn't
+        # drop context for every other zone in the same batch (Round-4 review).
+        snapshots: dict[str, list[Any]] = {}
+        for zone in zones:
+            try:
                 await cache.refresh_if_stale(zone)
                 snap = cache.snapshot_zone(zone)
                 if snap is not None:
                     snapshots[zone] = snap
-            from nexus.bricks.search.path_context import lookup_in_records
+            except Exception as exc:
+                self.stats.path_context_attach_failures += 1
+                logger.warning(
+                    "path context refresh failed for zone=%r (total=%d): %s",
+                    zone,
+                    self.stats.path_context_attach_failures,
+                    exc,
+                )
 
-            for r in results:
-                zone = _zone_for(r)
-                records = snapshots.get(zone)
-                if records is None:
-                    continue
+        from nexus.bricks.search.path_context import lookup_in_records
+
+        for r in results:
+            zone = _zone_for(r)
+            records = snapshots.get(zone)
+            if records is None:
+                continue
+            try:
                 r.context = lookup_in_records(records, r.path)
-        except Exception as exc:
-            self.stats.path_context_attach_failures += 1
-            logger.warning(
-                "path context attach failed (total=%d): %s",
-                self.stats.path_context_attach_failures,
-                exc,
-            )
+            except Exception as exc:
+                self.stats.path_context_attach_failures += 1
+                logger.warning(
+                    "path context lookup failed for path=%r (total=%d): %s",
+                    r.path,
+                    self.stats.path_context_attach_failures,
+                    exc,
+                )
 
     async def search(
         self,

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -815,7 +815,11 @@ class SearchDaemon:
         # letting it surface as a shutdown warning.
         running_loop = asyncio.get_running_loop()
         for loop_key, engine in list(self._path_context_engines_by_loop.items()):
-            if loop_key is running_loop and not loop_key.is_closed():
+            # loop_key is running_loop => this code runs on that loop, so
+            # it is by definition not closed. Other loops cannot be
+            # disposed safely from here; drop the reference and let GC
+            # reclaim their sockets.
+            if loop_key is running_loop:
                 with contextlib.suppress(Exception):
                     await engine.dispose()
         self._path_context_engines_by_loop.clear()

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1162,7 +1162,14 @@ class SearchDaemon:
         # recycling, anyio loop churn). Entries for dead loops can't be
         # disposed from here anyway — shutdown can only reach the current
         # loop's engine — so dropping their refs is the correct cleanup.
-        stale = [lk for lk in self._path_context_cache_by_loop if lk.is_closed()]
+        # Round-8 review: tolerate non-loop keys (mocks, test fixtures) — a
+        # missing ``is_closed`` attr is treated as closed so the lookup
+        # never raises AttributeError.
+        stale = [
+            lk
+            for lk in self._path_context_cache_by_loop
+            if not hasattr(lk, "is_closed") or lk.is_closed()
+        ]
         for lk in stale:
             self._path_context_cache_by_loop.pop(lk, None)
             self._path_context_engines_by_loop.pop(lk, None)

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1115,12 +1115,18 @@ class SearchDaemon:
         Issue #3773: When a ``PathContextCache`` is wired in, look up the
         longest-prefix context for each result and populate
         ``SearchResult.context`` in-place. No-op when the cache is absent or
-        the result list is empty.
+        the result list is empty. Refreshes per-zone cache at most once per
+        batch, then performs pure in-memory lookups (Issue #3773 review).
         """
         if self._path_context_cache is None or not results:
             return
+        from nexus.contracts.constants import ROOT_ZONE_ID
+
+        zones = {(r.zone_id or ROOT_ZONE_ID) for r in results}
+        for zone in zones:
+            await self._path_context_cache.refresh_if_stale(zone)
         for r in results:
-            r.context = await self._path_context_cache.lookup(r.zone_id, r.path)
+            r.context = self._path_context_cache.lookup_cached(r.zone_id, r.path)
 
     async def search(
         self,

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1268,6 +1268,10 @@ class SearchDaemon:
             return [[] for _ in queries]
 
         results: list[list[Any]] = await backend_batch(queries, zone_id=effective_zone_id)
+        # Issue #3773: attach admin-configured path contexts per inner list.
+        if self._path_context_cache is not None:
+            for inner in results:
+                await self._attach_path_contexts(inner)
         return results
 
     async def index_documents(

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -201,6 +201,7 @@ class SearchDaemon:
         self._cache_brick = cache_brick
         self._settings_store = settings_store
         self._path_context_cache = path_context_cache
+        self._path_context_cache_by_loop: dict[Any, Any] = {}
 
         # Search components (initialized on startup)
         self._bm25s_index: BM25SIndex | None = None
@@ -1109,6 +1110,51 @@ class SearchDaemon:
     # Search Methods
     # =========================================================================
 
+    async def _resolve_path_context_cache(self) -> Any | None:
+        """Return a PathContextCache bound to the current running loop.
+
+        Issue #3773 note: the startup-time cache is bound to the lifespan
+        loop. Under BaseHTTPMiddleware the request runs on a different loop,
+        and asyncpg raises ``got result for unknown protocol state`` when
+        used cross-loop. Lazily create a request-loop-native cache from
+        ``DATABASE_URL`` and memoize it per loop.
+        """
+        import os
+
+        from nexus.bricks.search.path_context import PathContextCache, PathContextStore
+
+        loop = asyncio.get_running_loop()
+        existing = self._path_context_cache_by_loop.get(loop)
+        if existing is not None:
+            return existing
+
+        db_url = os.environ.get("DATABASE_URL") or os.environ.get("NEXUS_DATABASE_URL")
+        if not db_url:
+            if self._path_context_cache is not None:
+                self._path_context_cache_by_loop[loop] = self._path_context_cache
+            return self._path_context_cache
+
+        from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+        if db_url.startswith("postgresql://"):
+            db_url = db_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+            db_type = "postgresql"
+        elif db_url.startswith("postgres://"):
+            db_url = db_url.replace("postgres://", "postgresql+asyncpg://", 1)
+            db_type = "postgresql"
+        elif db_url.startswith("sqlite:") and "+aiosqlite" not in db_url:
+            db_url = db_url.replace("sqlite:", "sqlite+aiosqlite:", 1)
+            db_type = "sqlite"
+        else:
+            db_type = "sqlite"
+
+        engine = create_async_engine(db_url, future=True)
+        factory = async_sessionmaker(engine, expire_on_commit=False)
+        store = PathContextStore(async_session_factory=factory, db_type=db_type)
+        cache = PathContextCache(store=store)
+        self._path_context_cache_by_loop[loop] = cache
+        return cache
+
     async def _attach_path_contexts(self, results: list[SearchResult]) -> None:
         """Attach admin-configured path context descriptions to search results.
 
@@ -1117,16 +1163,31 @@ class SearchDaemon:
         ``SearchResult.context`` in-place. No-op when the cache is absent or
         the result list is empty. Refreshes per-zone cache at most once per
         batch, then performs pure in-memory lookups (Issue #3773 review).
+
+        Fails soft: if the cache lookup raises (e.g. asyncpg loop mismatch),
+        logs a warning and leaves ``context`` unset rather than breaking
+        the whole search.
         """
-        if self._path_context_cache is None or not results:
+        if not results:
             return
         from nexus.contracts.constants import ROOT_ZONE_ID
 
+        try:
+            cache = await self._resolve_path_context_cache()
+        except Exception as exc:
+            logger.warning("path context cache resolution failed: %s", exc)
+            return
+        if cache is None:
+            return
+
         zones = {(r.zone_id or ROOT_ZONE_ID) for r in results}
-        for zone in zones:
-            await self._path_context_cache.refresh_if_stale(zone)
-        for r in results:
-            r.context = self._path_context_cache.lookup_cached(r.zone_id, r.path)
+        try:
+            for zone in zones:
+                await cache.refresh_if_stale(zone)
+            for r in results:
+                r.context = cache.lookup_cached(r.zone_id, r.path)
+        except Exception as exc:
+            logger.warning("path context attach failed: %s", exc)
 
     async def search(
         self,

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -82,6 +82,11 @@ class DaemonStats:
     zoekt_available: bool = False
     embedding_cache_connected: bool = False
     mutation_consumers: dict[str, dict[str, Any]] = field(default_factory=dict)
+    # Fail-soft counters for path-context attach (Issue #3773): search must
+    # never 500 on a context-lookup bug, but persistent failures should be
+    # visible via /search/stats rather than only in log lines.
+    path_context_attach_failures: int = 0
+    path_context_resolve_failures: int = 0
 
 
 @dataclass
@@ -202,6 +207,9 @@ class SearchDaemon:
         self._settings_store = settings_store
         self._path_context_cache = path_context_cache
         self._path_context_cache_by_loop: dict[Any, Any] = {}
+        # Engines we created for loop-local caches — tracked for disposal
+        # on shutdown so pooled connections don't leak (Issue #3773 review).
+        self._path_context_engines_by_loop: dict[Any, Any] = {}
 
         # Search components (initialized on startup)
         self._bm25s_index: BM25SIndex | None = None
@@ -797,6 +805,14 @@ class SearchDaemon:
         self._async_engine = None
         self._async_session = None
 
+        # Dispose loop-local path-context engines we created lazily
+        # (Issue #3773 review feedback — avoid pooled-connection leak).
+        for engine in list(self._path_context_engines_by_loop.values()):
+            with contextlib.suppress(Exception):
+                await engine.dispose()
+        self._path_context_engines_by_loop.clear()
+        self._path_context_cache_by_loop.clear()
+
         self._initialized = False
         logger.info("SearchDaemon shutdown complete")
 
@@ -1161,6 +1177,7 @@ class SearchDaemon:
         store = PathContextStore(async_session_factory=factory, db_type=db_type)
         cache = PathContextCache(store=store)
         self._path_context_cache_by_loop[loop] = cache
+        self._path_context_engines_by_loop[loop] = engine
         return cache
 
     async def _attach_path_contexts(self, results: list[SearchResult]) -> None:
@@ -1183,7 +1200,12 @@ class SearchDaemon:
         try:
             cache = await self._resolve_path_context_cache()
         except Exception as exc:
-            logger.warning("path context cache resolution failed: %s", exc)
+            self.stats.path_context_resolve_failures += 1
+            logger.warning(
+                "path context cache resolution failed (total=%d): %s",
+                self.stats.path_context_resolve_failures,
+                exc,
+            )
             return
         if cache is None:
             return
@@ -1195,7 +1217,12 @@ class SearchDaemon:
             for r in results:
                 r.context = cache.lookup_cached(r.zone_id, r.path)
         except Exception as exc:
-            logger.warning("path context attach failed: %s", exc)
+            self.stats.path_context_attach_failures += 1
+            logger.warning(
+                "path context attach failed (total=%d): %s",
+                self.stats.path_context_attach_failures,
+                exc,
+            )
 
     async def search(
         self,
@@ -2940,6 +2967,11 @@ class SearchDaemon:
             "txtai_reranker": self.config.txtai_reranker,
             "txtai_graph": self.config.txtai_graph,
             "mutation_consumers": self.stats.mutation_consumers,
+            # Issue #3773: path-context attach runs fail-soft so search is
+            # never broken by a context-lookup bug. Expose the counts so
+            # operators can spot persistent failures via /search/stats.
+            "path_context_attach_failures": self.stats.path_context_attach_failures,
+            "path_context_resolve_failures": self.stats.path_context_resolve_failures,
         }
 
     def get_health(self) -> dict[str, Any]:

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -673,6 +673,11 @@ def _result_to_dict(result: Any) -> dict[str, Any]:
         zone_qp = getattr(result, "zone_qualified_path", None)
         if zone_qp is not None:
             d["zone_qualified_path"] = zone_qp
+        # Issue #3773 (Round-5 review): match the non-federated router shape,
+        # which omits ``context`` when unset. Otherwise strict clients see the
+        # key appear/disappear based on the ``federated=true`` flag.
+        if d.get("context") is None:
+            d.pop("context", None)
         return d
     return {"value": result}
 

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -594,6 +594,11 @@ class FederatedSearchDispatcher:
                 limit=limit,
                 id_key="zone_qualified_path",
             )
+            # Issue #3773 (Round-6 review): rrf_multi_fusion emits dicts built
+            # from __dataclass_fields__ verbatim, so ``context: None`` leaks
+            # into the wire. Normalize here so every federated code path
+            # matches the non-federated router's omit-when-None contract.
+            fused_results = [_strip_none_context(d) for d in fused_results]
         else:
             # Raw score merge-sort: for homogeneous zones (default)
             fused_results = _merge_by_raw_score(zone_result_lists, limit)
@@ -662,10 +667,20 @@ def _merge_by_raw_score(
     )[:limit]
 
 
+def _strip_none_context(d: dict[str, Any]) -> dict[str, Any]:
+    """Match the non-federated router's omit-when-None contract for
+    ``context``. Issue #3773 review (Rounds 5-6): every federated emission
+    path must route through this to avoid ``context: null`` leaking onto
+    the wire and creating a shape-drift between fusion strategies."""
+    if d.get("context") is None:
+        d.pop("context", None)
+    return d
+
+
 def _result_to_dict(result: Any) -> dict[str, Any]:
     """Convert a search result (dataclass or dict) to dict with zone metadata."""
     if isinstance(result, dict):
-        return result
+        return _strip_none_context(result)
     fields = getattr(result, "__dataclass_fields__", None)
     if fields is not None:
         d = {f: getattr(result, f) for f in fields}
@@ -673,12 +688,7 @@ def _result_to_dict(result: Any) -> dict[str, Any]:
         zone_qp = getattr(result, "zone_qualified_path", None)
         if zone_qp is not None:
             d["zone_qualified_path"] = zone_qp
-        # Issue #3773 (Round-5 review): match the non-federated router shape,
-        # which omits ``context`` when unset. Otherwise strict clients see the
-        # key appear/disappear based on the ``federated=true`` flag.
-        if d.get("context") is None:
-            d.pop("context", None)
-        return d
+        return _strip_none_context(d)
     return {"value": result}
 
 

--- a/src/nexus/bricks/search/fusion.py
+++ b/src/nexus/bricks/search/fusion.py
@@ -297,15 +297,22 @@ def rrf_weighted_fusion(
     rrf_scores: dict[str, dict[str, Any]] = {}
     best_rank: dict[str, int] = {}
 
+    # Zero-weight modalities contribute no score — they must also not count
+    # toward the top-rank bonus, otherwise a vector-only rank-1 hit under
+    # alpha=0.0 would still receive +0.05 (Issue #3773 review feedback).
+    keyword_weight = 1 - alpha
+    vector_weight = alpha
+
     # Add keyword results with (1 - alpha) weight
     for rank, raw_result in enumerate(keyword_results, start=1):
         result = _to_dict(raw_result)
         key = _get_result_key(result, id_key)
         if key not in rrf_scores:
             rrf_scores[key] = {"result": result.copy(), "rrf_score": 0.0}
-        rrf_scores[key]["rrf_score"] += (1 - alpha) * (1.0 / (k + rank))
+        rrf_scores[key]["rrf_score"] += keyword_weight * (1.0 / (k + rank))
         rrf_scores[key]["result"]["keyword_score"] = result.get("score", 0.0)
-        best_rank[key] = min(best_rank.get(key, rank), rank)
+        if keyword_weight > 0:
+            best_rank[key] = min(best_rank.get(key, rank), rank)
 
     # Add vector results with alpha weight
     for rank, raw_result in enumerate(vector_results, start=1):
@@ -313,9 +320,10 @@ def rrf_weighted_fusion(
         key = _get_result_key(result, id_key)
         if key not in rrf_scores:
             rrf_scores[key] = {"result": result.copy(), "rrf_score": 0.0}
-        rrf_scores[key]["rrf_score"] += alpha * (1.0 / (k + rank))
+        rrf_scores[key]["rrf_score"] += vector_weight * (1.0 / (k + rank))
         rrf_scores[key]["result"]["vector_score"] = result.get("score", 0.0)
-        best_rank[key] = min(best_rank.get(key, rank), rank)
+        if vector_weight > 0:
+            best_rank[key] = min(best_rank.get(key, rank), rank)
 
     if top_rank_bonus:
         for key, entry in rrf_scores.items():

--- a/src/nexus/bricks/search/fusion.py
+++ b/src/nexus/bricks/search/fusion.py
@@ -437,6 +437,7 @@ def fuse_results(
             k=config.rrf_k,
             limit=limit,
             id_key=id_key,
+            top_rank_bonus=config.top_rank_bonus,
         )
     elif config.method == FusionMethod.WEIGHTED:
         return weighted_fusion(
@@ -455,6 +456,7 @@ def fuse_results(
             k=config.rrf_k,
             limit=limit,
             id_key=id_key,
+            top_rank_bonus=config.top_rank_bonus,
         )
     else:
         raise ValueError(f"Unknown fusion method: {config.method}")

--- a/src/nexus/bricks/search/fusion.py
+++ b/src/nexus/bricks/search/fusion.py
@@ -342,11 +342,13 @@ def rrf_multi_fusion(
     k: int = 60,
     limit: int = 10,
     id_key: str | None = "chunk_id",
+    top_rank_bonus: bool = True,
 ) -> list[dict[str, Any]]:
     """N-way Reciprocal Rank Fusion for combining 3+ retrieval sources.
 
     Generalizes RRF from 2-way to N-way for pipelines that combine
-    keyword + dense + SPLADE (or any number of retrievers).
+    keyword + dense + SPLADE (or any number of retrievers). Applies the
+    top-rank bonus (Issue #3773) using the best rank across all sources.
 
     Args:
         result_lists: List of (source_name, results) tuples.
@@ -354,11 +356,13 @@ def rrf_multi_fusion(
         k: RRF constant (default: 60)
         limit: Maximum results to return
         id_key: Key for identifying unique results, or None for path:chunk_index
+        top_rank_bonus: Apply top-rank bonus (Issue #3773). Default True.
 
     Returns:
         Combined results ranked by RRF score
     """
     rrf_scores: dict[str, dict[str, Any]] = {}
+    best_rank: dict[str, int] = {}
 
     for source_name, results in result_lists:
         score_key = f"{source_name}_score"
@@ -369,15 +373,22 @@ def rrf_multi_fusion(
                 rrf_scores[key] = {"result": result.copy(), "rrf_score": 0.0}
             rrf_scores[key]["rrf_score"] += 1.0 / (k + rank)
             rrf_scores[key]["result"][score_key] = result.get("score", 0.0)
+            best_rank[key] = min(best_rank.get(key, rank), rank)
 
-    # Sort by RRF score
+    if top_rank_bonus:
+        for key, entry in rrf_scores.items():
+            br = best_rank.get(key, 999)
+            if br == 1:
+                entry["rrf_score"] += RRF_TOP1_BONUS
+            elif br <= 3:
+                entry["rrf_score"] += RRF_TOP3_BONUS
+
     sorted_results = sorted(
         rrf_scores.values(),
         key=lambda x: x["rrf_score"],
         reverse=True,
     )[:limit]
 
-    # Update final scores
     for item in sorted_results:
         item["result"]["score"] = item["rrf_score"]
 

--- a/src/nexus/bricks/search/fusion.py
+++ b/src/nexus/bricks/search/fusion.py
@@ -20,6 +20,11 @@ from dataclasses import dataclass
 from enum import StrEnum
 from typing import Any
 
+# Issue #3773: Top-rank bonus preserves high-confidence matches
+# against dilution from query expansion and multi-source fusion.
+RRF_TOP1_BONUS = 0.05
+RRF_TOP3_BONUS = 0.02
+
 
 class FusionMethod(StrEnum):
     """Fusion method for combining keyword and vector search results."""
@@ -46,6 +51,7 @@ class FusionConfig:
     rrf_k: int = 60
     normalize_scores: bool = True
     over_fetch_factor: float = 3.0
+    top_rank_bonus: bool = True  # Issue #3773: boost docs ranked #1-3 in any list
 
 
 def normalize_scores_minmax(scores: list[float]) -> list[float]:
@@ -115,15 +121,14 @@ def rrf_fusion(
     k: int = 60,
     limit: int = 10,
     id_key: str | None = "chunk_id",
+    top_rank_bonus: bool = True,
 ) -> list[dict[str, Any]]:
     """Combine results using Reciprocal Rank Fusion.
 
-    RRF score = sum(1 / (k + rank)) for each result list
-
-    RRF is robust because it:
-    - Doesn't require score normalization
-    - Works well when scoring scales differ between search methods
-    - Is stable across different query types
+    RRF score = sum(1 / (k + rank)) for each result list, plus an optional
+    top-rank bonus (Issue #3773): +0.05 for docs ranked #1 in any list and
+    +0.02 for docs ranked #2-3. The bonus preserves high-confidence matches
+    against dilution from query expansion and multi-source fusion.
 
     Args:
         keyword_results: Results from keyword search (ranked by BM25)
@@ -131,11 +136,13 @@ def rrf_fusion(
         k: RRF constant (default: 60, per original paper)
         limit: Maximum results to return
         id_key: Key for identifying unique results, or None for path:chunk_index
+        top_rank_bonus: Apply top-rank bonus (Issue #3773). Default True.
 
     Returns:
         Combined results ranked by RRF score
     """
     rrf_scores: dict[str, dict[str, Any]] = {}
+    best_rank: dict[str, int] = {}
 
     # Add keyword results
     for rank, raw_result in enumerate(keyword_results, start=1):
@@ -145,6 +152,7 @@ def rrf_fusion(
             rrf_scores[key] = {"result": result.copy(), "rrf_score": 0.0}
         rrf_scores[key]["rrf_score"] += 1.0 / (k + rank)
         rrf_scores[key]["result"]["keyword_score"] = result.get("score", 0.0)
+        best_rank[key] = min(best_rank.get(key, rank), rank)
 
     # Add vector results
     for rank, raw_result in enumerate(vector_results, start=1):
@@ -154,6 +162,16 @@ def rrf_fusion(
             rrf_scores[key] = {"result": result.copy(), "rrf_score": 0.0}
         rrf_scores[key]["rrf_score"] += 1.0 / (k + rank)
         rrf_scores[key]["result"]["vector_score"] = result.get("score", 0.0)
+        best_rank[key] = min(best_rank.get(key, rank), rank)
+
+    # Issue #3773: apply top-rank bonus before final sort
+    if top_rank_bonus:
+        for key, entry in rrf_scores.items():
+            br = best_rank.get(key, 999)
+            if br == 1:
+                entry["rrf_score"] += RRF_TOP1_BONUS
+            elif br <= 3:
+                entry["rrf_score"] += RRF_TOP3_BONUS
 
     # Sort by RRF score
     sorted_results = sorted(

--- a/src/nexus/bricks/search/fusion.py
+++ b/src/nexus/bricks/search/fusion.py
@@ -275,13 +275,12 @@ def rrf_weighted_fusion(
     k: int = 60,
     limit: int = 10,
     id_key: str | None = "chunk_id",
+    top_rank_bonus: bool = True,
 ) -> list[dict[str, Any]]:
     """Combine results using RRF with alpha weighting.
 
     RRF score = (1 - alpha) * (1/(k+keyword_rank)) + alpha * (1/(k+vector_rank))
-
-    This combines the robustness of RRF (no score normalization needed)
-    with the ability to bias towards keyword or vector search.
+                + top-rank bonus (Issue #3773)
 
     Args:
         keyword_results: Results from keyword search
@@ -290,11 +289,13 @@ def rrf_weighted_fusion(
         k: RRF constant
         limit: Maximum results to return
         id_key: Key for identifying unique results
+        top_rank_bonus: Apply top-rank bonus (Issue #3773). Default True.
 
     Returns:
         Combined results ranked by weighted RRF score
     """
     rrf_scores: dict[str, dict[str, Any]] = {}
+    best_rank: dict[str, int] = {}
 
     # Add keyword results with (1 - alpha) weight
     for rank, raw_result in enumerate(keyword_results, start=1):
@@ -304,6 +305,7 @@ def rrf_weighted_fusion(
             rrf_scores[key] = {"result": result.copy(), "rrf_score": 0.0}
         rrf_scores[key]["rrf_score"] += (1 - alpha) * (1.0 / (k + rank))
         rrf_scores[key]["result"]["keyword_score"] = result.get("score", 0.0)
+        best_rank[key] = min(best_rank.get(key, rank), rank)
 
     # Add vector results with alpha weight
     for rank, raw_result in enumerate(vector_results, start=1):
@@ -313,15 +315,22 @@ def rrf_weighted_fusion(
             rrf_scores[key] = {"result": result.copy(), "rrf_score": 0.0}
         rrf_scores[key]["rrf_score"] += alpha * (1.0 / (k + rank))
         rrf_scores[key]["result"]["vector_score"] = result.get("score", 0.0)
+        best_rank[key] = min(best_rank.get(key, rank), rank)
 
-    # Sort by RRF score
+    if top_rank_bonus:
+        for key, entry in rrf_scores.items():
+            br = best_rank.get(key, 999)
+            if br == 1:
+                entry["rrf_score"] += RRF_TOP1_BONUS
+            elif br <= 3:
+                entry["rrf_score"] += RRF_TOP3_BONUS
+
     sorted_results = sorted(
         rrf_scores.values(),
         key=lambda x: x["rrf_score"],
         reverse=True,
     )[:limit]
 
-    # Update final scores
     for item in sorted_results:
         item["result"]["score"] = item["rrf_score"]
 

--- a/src/nexus/bricks/search/graph_search_service.py
+++ b/src/nexus/bricks/search/graph_search_service.py
@@ -105,4 +105,9 @@ async def graph_enhanced_search(
     results: list[BaseSearchResult] = await graph_search_fn(
         query, zone_id=effective_zone_id, limit=limit, path_filter=path_filter
     )
+    # Issue #3773: attach admin-configured path contexts (same hook as the
+    # non-graph search branch uses).
+    attach = getattr(search_daemon, "_attach_path_contexts", None)
+    if attach is not None:
+        await attach(results)
     return results

--- a/src/nexus/bricks/search/graph_search_service.py
+++ b/src/nexus/bricks/search/graph_search_service.py
@@ -105,9 +105,12 @@ async def graph_enhanced_search(
     results: list[BaseSearchResult] = await graph_search_fn(
         query, zone_id=effective_zone_id, limit=limit, path_filter=path_filter
     )
-    # Issue #3773: attach admin-configured path contexts (same hook as the
-    # non-graph search branch uses).
+    # Issue #3773: attach admin-configured path contexts. Pass the caller's
+    # effective zone so the daemon can fall back to it when the backend
+    # returned ``BaseSearchResult`` without ``zone_id`` set — otherwise
+    # non-root-zone graph searches would silently collapse to root and
+    # attach the wrong (or no) descriptions (Round-4 review).
     attach = getattr(search_daemon, "_attach_path_contexts", None)
     if attach is not None:
-        await attach(results)
+        await attach(results, zone_id=effective_zone_id)
     return results

--- a/src/nexus/bricks/search/path_context.py
+++ b/src/nexus/bricks/search/path_context.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import builtins
+from collections import OrderedDict
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from typing import Any
@@ -16,6 +17,11 @@ from typing import Any
 from sqlalchemy import text
 
 from nexus.contracts.constants import ROOT_ZONE_ID
+
+# Default LRU cap on the number of zones PathContextCache retains. A
+# multi-tenant deployment with many short-lived zones could otherwise
+# accumulate per-zone locks + record lists forever (Issue #3773 review).
+_DEFAULT_MAX_ZONES = 2048
 
 
 @dataclass(frozen=True)
@@ -184,19 +190,33 @@ class PathContextCache:
       slash-boundary match is the longest prefix.
     """
 
-    def __init__(self, *, store: PathContextStore) -> None:
+    def __init__(
+        self,
+        *,
+        store: PathContextStore,
+        max_zones: int = _DEFAULT_MAX_ZONES,
+    ) -> None:
         self._store = store
+        self._max_zones = max_zones
         # Freshness token is ``(row_count, max_updated_at)`` — including count
         # catches deletes that leave the zone's max unchanged (Issue #3773
-        # review feedback).
-        self._entries: dict[
+        # review feedback). OrderedDict enables LRU eviction on insertion so
+        # the cache can't grow without bound across many short-lived zones.
+        self._entries: OrderedDict[
             str,
             tuple[tuple[int, datetime | None], builtins.list[PathContextRecord]],
-        ] = {}
+        ] = OrderedDict()
         self._locks: dict[str, asyncio.Lock] = {}
 
     def _lock_for(self, zone_id: str) -> asyncio.Lock:
-        return self._locks.setdefault(zone_id, asyncio.Lock())
+        # ``setdefault(zone_id, asyncio.Lock())`` constructs a Lock on every
+        # call whether or not it ends up used — wasted allocation on hot
+        # search paths. Use get-or-create instead.
+        lock = self._locks.get(zone_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[zone_id] = lock
+        return lock
 
     async def refresh_if_stale(self, zone_id: str) -> None:
         db_fp = await self._store.zone_fingerprint(zone_id)
@@ -212,6 +232,15 @@ class PathContextCache:
             records = await self._store.load_all_for_zone(zone_id)
             records.sort(key=lambda r: len(r.path_prefix), reverse=True)
             self._entries[zone_id] = (db_fp, records)
+            self._entries.move_to_end(zone_id)
+            # LRU-bound: evict the oldest zones when we exceed the cap. The
+            # zone we just inserted is at the newest end and safe. Other
+            # zones' locks can be dropped along with their entries — any
+            # concurrent refresh task for an evicted zone still holds its
+            # own lock reference and will just finish and rebuild.
+            while len(self._entries) > self._max_zones:
+                evicted_zone, _ = self._entries.popitem(last=False)
+                self._locks.pop(evicted_zone, None)
 
     def lookup_cached(self, zone_id: str | None, path: str) -> str | None:
         """Pure in-memory longest-prefix lookup. Assumes the caller has already

--- a/src/nexus/bricks/search/path_context.py
+++ b/src/nexus/bricks/search/path_context.py
@@ -64,19 +64,20 @@ class PathContextStore:
                     },
                 )
             else:
-                # SQLite: preserve created_at on replace via COALESCE lookup.
+                # SQLite 3.24+ supports ON CONFLICT DO UPDATE with the same
+                # semantics as Postgres — preserves `id` and `created_at`,
+                # bumps `updated_at`. Avoids the `INSERT OR REPLACE` approach
+                # which would churn `id` and break any future FK to this row.
                 await session.execute(
                     text(
                         """
-                        INSERT OR REPLACE INTO path_contexts
+                        INSERT INTO path_contexts
                             (zone_id, path_prefix, description, created_at, updated_at)
                         VALUES
-                            (:zone_id, :path_prefix, :description,
-                             COALESCE(
-                                (SELECT created_at FROM path_contexts
-                                 WHERE zone_id = :zone_id AND path_prefix = :path_prefix),
-                                :now),
-                             :now)
+                            (:zone_id, :path_prefix, :description, :now, :now)
+                        ON CONFLICT (zone_id, path_prefix) DO UPDATE
+                        SET description = excluded.description,
+                            updated_at  = excluded.updated_at
                         """
                     ),
                     {

--- a/src/nexus/bricks/search/path_context.py
+++ b/src/nexus/bricks/search/path_context.py
@@ -170,6 +170,23 @@ class PathContextStore:
         return await self.list(zone_id=zone_id)
 
 
+def lookup_in_records(records: builtins.list[PathContextRecord], path: str) -> str | None:
+    """Longest-prefix lookup against a pre-sorted records list.
+
+    Records must be sorted by ``len(path_prefix)`` DESC so the first
+    slash-boundary match is the longest prefix. Shared by
+    :meth:`PathContextCache.lookup_cached` and daemon snapshot paths so
+    both code paths use the same matching logic.
+    """
+    for record in records:
+        prefix = record.path_prefix
+        if prefix == "":
+            return record.description
+        if path == prefix or path.startswith(prefix + "/"):
+            return record.description
+    return None
+
+
 def _coerce_datetime(value: Any) -> datetime:
     """SQLite + aiosqlite can return datetimes as ISO strings; normalize to datetime."""
     if isinstance(value, datetime):
@@ -222,25 +239,32 @@ class PathContextCache:
         db_fp = await self._store.zone_fingerprint(zone_id)
         cached = self._entries.get(zone_id)
         if cached is not None and cached[0] == db_fp:
+            # LRU touch on hit: hot-but-unchanged zones must promote recency
+            # too, otherwise they'd drift to the oldest slot and get evicted
+            # behind merely-written zones (Round-3 review).
+            self._entries.move_to_end(zone_id)
             return
         async with self._lock_for(zone_id):
             # Re-check after lock acquisition — another task may have refreshed.
             db_fp = await self._store.zone_fingerprint(zone_id)
             cached = self._entries.get(zone_id)
             if cached is not None and cached[0] == db_fp:
+                self._entries.move_to_end(zone_id)
                 return
             records = await self._store.load_all_for_zone(zone_id)
             records.sort(key=lambda r: len(r.path_prefix), reverse=True)
             self._entries[zone_id] = (db_fp, records)
             self._entries.move_to_end(zone_id)
-            # LRU-bound: evict the oldest zones when we exceed the cap. The
-            # zone we just inserted is at the newest end and safe. Other
-            # zones' locks can be dropped along with their entries — any
-            # concurrent refresh task for an evicted zone still holds its
-            # own lock reference and will just finish and rebuild.
+            # LRU-bound: evict the oldest *records* when we exceed the cap.
+            # Locks are intentionally NOT evicted: dropping a lock while a
+            # concurrent task holds it, then re-creating a fresh lock on the
+            # next refresh of the same zone, would let two refreshes run
+            # concurrently under different Lock objects and race on
+            # ``_entries[zone]`` (Round-3 review: stale-write regression).
+            # Per-zone Locks are tiny (~56 B each) and bounded by zone
+            # count — cheap enough to keep alive.
             while len(self._entries) > self._max_zones:
-                evicted_zone, _ = self._entries.popitem(last=False)
-                self._locks.pop(evicted_zone, None)
+                self._entries.popitem(last=False)
 
     def lookup_cached(self, zone_id: str | None, path: str) -> str | None:
         """Pure in-memory longest-prefix lookup. Assumes the caller has already
@@ -254,13 +278,19 @@ class PathContextCache:
         if cached is None:
             return None
         _, records = cached
-        for record in records:
-            prefix = record.path_prefix
-            if prefix == "":
-                return record.description
-            if path == prefix or path.startswith(prefix + "/"):
-                return record.description
-        return None
+        return lookup_in_records(records, path)
+
+    def snapshot_zone(self, zone_id: str | None) -> builtins.list[PathContextRecord] | None:
+        """Return the currently-cached, prefix-length-sorted records list for
+        ``zone_id``, or ``None`` if the zone isn't cached. Synchronous — a
+        caller that grabs this immediately after ``refresh_if_stale`` is
+        guaranteed a stable snapshot even if a concurrent request later
+        evicts the zone from the LRU (Round-3 review regression)."""
+        effective_zone = zone_id or ROOT_ZONE_ID
+        cached = self._entries.get(effective_zone)
+        if cached is None:
+            return None
+        return cached[1]
 
     async def lookup(self, zone_id: str | None, path: str) -> str | None:
         """Async convenience: refresh then read. Prefer ``refresh_if_stale`` +

--- a/src/nexus/bricks/search/path_context.py
+++ b/src/nexus/bricks/search/path_context.py
@@ -153,6 +153,17 @@ class PathContextStore:
         the max unchanged, so a cache keyed on that value alone keeps
         serving the deleted entry. Including ``COUNT(*)`` makes the
         freshness token detect row removals as well.
+
+        Known limitation (Round-6 review): if a server-side clock steps
+        backward between writes, a fresh UPDATE could land with
+        ``updated_at`` ≤ the current zone MAX and the fingerprint would
+        not change — caches would keep serving the old description until
+        another row is added/deleted or the zone is evicted from the
+        LRU. Postgres/SQLite don't enforce monotonic ``updated_at``. In
+        practice, deployments running NTP slew (not step) with
+        non-migratable VMs don't hit this; operators of migratable
+        workloads should prefer restarting the daemon on clock-stepping
+        events.
         """
         async with self._async_session_factory() as session:
             row = (

--- a/src/nexus/bricks/search/path_context.py
+++ b/src/nexus/bricks/search/path_context.py
@@ -256,6 +256,23 @@ class PathContextCache:
         if lock is None:
             lock = asyncio.Lock()
             self._locks[zone_id] = lock
+            # Round-8 review: zone_id is client-controlled via
+            # X-Nexus-Zone-ID, so an authenticated caller can induce
+            # arbitrary lock creation. Bound the dict by dropping
+            # non-held locks once it exceeds a safe multiple of
+            # _max_zones. We only drop locks with ``locked() == False``
+            # to preserve the Round-3 identity guarantee for any
+            # refresh currently in flight.
+            cap = max(self._max_zones * 4, 16)
+            if len(self._locks) > cap:
+                for victim_id in list(self._locks):
+                    if victim_id == zone_id:
+                        continue
+                    victim = self._locks[victim_id]
+                    if not victim.locked():
+                        self._locks.pop(victim_id, None)
+                    if len(self._locks) <= cap:
+                        break
         return lock
 
     async def refresh_if_stale(self, zone_id: str) -> None:

--- a/src/nexus/bricks/search/path_context.py
+++ b/src/nexus/bricks/search/path_context.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 import asyncio
 import builtins
 from dataclasses import dataclass
-from datetime import datetime
+from datetime import UTC, datetime
 from typing import Any
 
 from sqlalchemy import text
@@ -41,7 +41,7 @@ class PathContextStore:
 
     async def upsert(self, zone_id: str, path_prefix: str, description: str) -> None:
         """Insert or replace a context row. updated_at refreshed on replace."""
-        now = datetime.utcnow()
+        now = datetime.now(UTC).replace(tzinfo=None)
         async with self._async_session_factory() as session:
             if self._db_type == "postgresql":
                 await session.execute(
@@ -166,11 +166,7 @@ class PathContextCache:
         self._locks: dict[str, asyncio.Lock] = {}
 
     def _lock_for(self, zone_id: str) -> asyncio.Lock:
-        lock = self._locks.get(zone_id)
-        if lock is None:
-            lock = asyncio.Lock()
-            self._locks[zone_id] = lock
-        return lock
+        return self._locks.setdefault(zone_id, asyncio.Lock())
 
     async def refresh_if_stale(self, zone_id: str) -> None:
         db_stamp = await self._store.max_updated_at(zone_id)

--- a/src/nexus/bricks/search/path_context.py
+++ b/src/nexus/bricks/search/path_context.py
@@ -136,6 +136,29 @@ class PathContextStore:
             ).scalar()
         return _coerce_datetime(row) if row is not None else None
 
+    async def zone_fingerprint(self, zone_id: str) -> tuple[int, datetime | None]:
+        """Return ``(row_count, max_updated_at)`` for a zone.
+
+        Issue #3773 review: ``max_updated_at`` alone misses row deletions —
+        deleting a row whose ``updated_at`` is below the zone's max leaves
+        the max unchanged, so a cache keyed on that value alone keeps
+        serving the deleted entry. Including ``COUNT(*)`` makes the
+        freshness token detect row removals as well.
+        """
+        async with self._async_session_factory() as session:
+            row = (
+                await session.execute(
+                    text(
+                        "SELECT COUNT(*), MAX(updated_at) FROM path_contexts "
+                        "WHERE zone_id = :zone_id"
+                    ),
+                    {"zone_id": zone_id},
+                )
+            ).one()
+        count = int(row[0] or 0)
+        stamp = _coerce_datetime(row[1]) if row[1] is not None else None
+        return (count, stamp)
+
     async def load_all_for_zone(self, zone_id: str) -> builtins.list[PathContextRecord]:
         """Load every context row for one zone."""
         return await self.list(zone_id=zone_id)
@@ -163,26 +186,32 @@ class PathContextCache:
 
     def __init__(self, *, store: PathContextStore) -> None:
         self._store = store
-        self._entries: dict[str, tuple[datetime | None, builtins.list[PathContextRecord]]] = {}
+        # Freshness token is ``(row_count, max_updated_at)`` — including count
+        # catches deletes that leave the zone's max unchanged (Issue #3773
+        # review feedback).
+        self._entries: dict[
+            str,
+            tuple[tuple[int, datetime | None], builtins.list[PathContextRecord]],
+        ] = {}
         self._locks: dict[str, asyncio.Lock] = {}
 
     def _lock_for(self, zone_id: str) -> asyncio.Lock:
         return self._locks.setdefault(zone_id, asyncio.Lock())
 
     async def refresh_if_stale(self, zone_id: str) -> None:
-        db_stamp = await self._store.max_updated_at(zone_id)
+        db_fp = await self._store.zone_fingerprint(zone_id)
         cached = self._entries.get(zone_id)
-        if cached is not None and cached[0] == db_stamp:
+        if cached is not None and cached[0] == db_fp:
             return
         async with self._lock_for(zone_id):
             # Re-check after lock acquisition — another task may have refreshed.
-            db_stamp = await self._store.max_updated_at(zone_id)
+            db_fp = await self._store.zone_fingerprint(zone_id)
             cached = self._entries.get(zone_id)
-            if cached is not None and cached[0] == db_stamp:
+            if cached is not None and cached[0] == db_fp:
                 return
             records = await self._store.load_all_for_zone(zone_id)
             records.sort(key=lambda r: len(r.path_prefix), reverse=True)
-            self._entries[zone_id] = (db_stamp, records)
+            self._entries[zone_id] = (db_fp, records)
 
     def lookup_cached(self, zone_id: str | None, path: str) -> str | None:
         """Pure in-memory longest-prefix lookup. Assumes the caller has already

--- a/src/nexus/bricks/search/path_context.py
+++ b/src/nexus/bricks/search/path_context.py
@@ -7,6 +7,7 @@ search result via longest-prefix match. In-memory cache is in this module too.
 
 from __future__ import annotations
 
+import asyncio
 import builtins
 from dataclasses import dataclass
 from datetime import datetime
@@ -14,7 +15,7 @@ from typing import Any
 
 from sqlalchemy import text
 
-from nexus.contracts.constants import ROOT_ZONE_ID  # noqa: F401  (re-exported for callers)
+from nexus.contracts.constants import ROOT_ZONE_ID
 
 
 @dataclass(frozen=True)
@@ -149,15 +150,57 @@ def _coerce_datetime(value: Any) -> datetime:
     raise TypeError(f"Unexpected datetime-like value from DB: {value!r}")
 
 
-# Issue #3773: PathContextCache is defined in Task 7. This placeholder keeps
-# imports stable so tests for the cache can be added in Task 7 without
-# re-editing import sites.
-class PathContextCache:  # Placeholder — full implementation in Task 7.
+class PathContextCache:
+    """In-memory cache of path contexts keyed by zone, with longest-prefix lookup.
+
+    - Per-zone ``asyncio.Lock`` serializes refreshes.
+    - Each lookup cheaply checks ``store.max_updated_at(zone_id)`` and reloads
+      when the cached stamp is stale.
+    - Records are kept sorted by ``len(path_prefix)`` DESC so the first
+      slash-boundary match is the longest prefix.
+    """
+
     def __init__(self, *, store: PathContextStore) -> None:
         self._store = store
+        self._entries: dict[str, tuple[datetime | None, builtins.list[PathContextRecord]]] = {}
+        self._locks: dict[str, asyncio.Lock] = {}
+
+    def _lock_for(self, zone_id: str) -> asyncio.Lock:
+        lock = self._locks.get(zone_id)
+        if lock is None:
+            lock = asyncio.Lock()
+            self._locks[zone_id] = lock
+        return lock
 
     async def refresh_if_stale(self, zone_id: str) -> None:
-        raise NotImplementedError("PathContextCache is wired up in Task 7.")
+        db_stamp = await self._store.max_updated_at(zone_id)
+        cached = self._entries.get(zone_id)
+        if cached is not None and cached[0] == db_stamp:
+            return
+        async with self._lock_for(zone_id):
+            # Re-check after lock acquisition — another task may have refreshed.
+            db_stamp = await self._store.max_updated_at(zone_id)
+            cached = self._entries.get(zone_id)
+            if cached is not None and cached[0] == db_stamp:
+                return
+            records = await self._store.load_all_for_zone(zone_id)
+            records.sort(key=lambda r: len(r.path_prefix), reverse=True)
+            self._entries[zone_id] = (db_stamp, records)
 
     async def lookup(self, zone_id: str | None, path: str) -> str | None:
-        raise NotImplementedError("PathContextCache is wired up in Task 7.")
+        """Return the longest-matching description for ``path`` in ``zone_id``,
+        or None when no prefix matches.
+        """
+        effective_zone = zone_id or ROOT_ZONE_ID
+        await self.refresh_if_stale(effective_zone)
+        cached = self._entries.get(effective_zone)
+        if cached is None:
+            return None
+        _, records = cached
+        for record in records:
+            prefix = record.path_prefix
+            if prefix == "":
+                return record.description
+            if path == prefix or path.startswith(prefix + "/"):
+                return record.description
+        return None

--- a/src/nexus/bricks/search/path_context.py
+++ b/src/nexus/bricks/search/path_context.py
@@ -112,7 +112,13 @@ class PathContextStore:
             return (result.rowcount or 0) > 0
 
     async def list(self, zone_id: str | None = None) -> builtins.list[PathContextRecord]:
-        """List contexts. When zone_id is None, returns rows for all zones."""
+        """List contexts. When zone_id is None, returns rows for all zones.
+
+        Round-7 review: pin Postgres to the binary ``"C"`` collation so
+        CLI output matches SQLite's default BINARY order — otherwise
+        admins see different sort orders across backends (Postgres honours
+        the DB-creation locale, which is typically case/accent-insensitive).
+        """
         query = (
             "SELECT zone_id, path_prefix, description, created_at, updated_at FROM path_contexts"
         )
@@ -120,7 +126,10 @@ class PathContextStore:
         if zone_id is not None:
             query += " WHERE zone_id = :zone_id"
             params["zone_id"] = zone_id
-        query += " ORDER BY zone_id, path_prefix"
+        if self._db_type == "postgresql":
+            query += ' ORDER BY zone_id COLLATE "C", path_prefix COLLATE "C"'
+        else:
+            query += " ORDER BY zone_id, path_prefix"
         async with self._async_session_factory() as session:
             rows = (await session.execute(text(query), params)).all()
         return [

--- a/src/nexus/bricks/search/path_context.py
+++ b/src/nexus/bricks/search/path_context.py
@@ -187,12 +187,14 @@ class PathContextCache:
             records.sort(key=lambda r: len(r.path_prefix), reverse=True)
             self._entries[zone_id] = (db_stamp, records)
 
-    async def lookup(self, zone_id: str | None, path: str) -> str | None:
-        """Return the longest-matching description for ``path`` in ``zone_id``,
-        or None when no prefix matches.
+    def lookup_cached(self, zone_id: str | None, path: str) -> str | None:
+        """Pure in-memory longest-prefix lookup. Assumes the caller has already
+        awaited ``refresh_if_stale(effective_zone)`` when freshness matters.
+
+        Returns the longest-matching description for ``path`` in ``zone_id``,
+        or None when no prefix matches or the zone has no cached entries.
         """
         effective_zone = zone_id or ROOT_ZONE_ID
-        await self.refresh_if_stale(effective_zone)
         cached = self._entries.get(effective_zone)
         if cached is None:
             return None
@@ -204,3 +206,11 @@ class PathContextCache:
             if path == prefix or path.startswith(prefix + "/"):
                 return record.description
         return None
+
+    async def lookup(self, zone_id: str | None, path: str) -> str | None:
+        """Async convenience: refresh then read. Prefer ``refresh_if_stale`` +
+        ``lookup_cached`` when looking up many paths in the same zone.
+        """
+        effective_zone = zone_id or ROOT_ZONE_ID
+        await self.refresh_if_stale(effective_zone)
+        return self.lookup_cached(zone_id, path)

--- a/src/nexus/bricks/search/path_context.py
+++ b/src/nexus/bricks/search/path_context.py
@@ -1,0 +1,163 @@
+"""Path context descriptions (Issue #3773).
+
+Stores admin-configured, zone-scoped mappings from path prefix to human-readable
+description. Used by the search daemon to attach a ``context`` field to each
+search result via longest-prefix match. In-memory cache is in this module too.
+"""
+
+from __future__ import annotations
+
+import builtins
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import text
+
+from nexus.contracts.constants import ROOT_ZONE_ID  # noqa: F401  (re-exported for callers)
+
+
+@dataclass(frozen=True)
+class PathContextRecord:
+    """One row in the path_contexts table."""
+
+    zone_id: str
+    path_prefix: str
+    description: str
+    created_at: datetime
+    updated_at: datetime
+
+
+class PathContextStore:
+    """Async CRUD for the path_contexts table.
+
+    Follows the raw-SQL pattern used by ChunkStore (src/nexus/bricks/search/chunk_store.py).
+    """
+
+    def __init__(self, *, async_session_factory: Any, db_type: str = "sqlite") -> None:
+        self._async_session_factory = async_session_factory
+        self._db_type = db_type
+
+    async def upsert(self, zone_id: str, path_prefix: str, description: str) -> None:
+        """Insert or replace a context row. updated_at refreshed on replace."""
+        now = datetime.utcnow()
+        async with self._async_session_factory() as session:
+            if self._db_type == "postgresql":
+                await session.execute(
+                    text(
+                        """
+                        INSERT INTO path_contexts
+                            (zone_id, path_prefix, description, created_at, updated_at)
+                        VALUES
+                            (:zone_id, :path_prefix, :description, :now, :now)
+                        ON CONFLICT (zone_id, path_prefix) DO UPDATE
+                        SET description = EXCLUDED.description,
+                            updated_at  = EXCLUDED.updated_at
+                        """
+                    ),
+                    {
+                        "zone_id": zone_id,
+                        "path_prefix": path_prefix,
+                        "description": description,
+                        "now": now,
+                    },
+                )
+            else:
+                # SQLite: preserve created_at on replace via COALESCE lookup.
+                await session.execute(
+                    text(
+                        """
+                        INSERT OR REPLACE INTO path_contexts
+                            (zone_id, path_prefix, description, created_at, updated_at)
+                        VALUES
+                            (:zone_id, :path_prefix, :description,
+                             COALESCE(
+                                (SELECT created_at FROM path_contexts
+                                 WHERE zone_id = :zone_id AND path_prefix = :path_prefix),
+                                :now),
+                             :now)
+                        """
+                    ),
+                    {
+                        "zone_id": zone_id,
+                        "path_prefix": path_prefix,
+                        "description": description,
+                        "now": now,
+                    },
+                )
+            await session.commit()
+
+    async def delete(self, zone_id: str, path_prefix: str) -> bool:
+        """Delete one row. Returns True if a row was removed."""
+        async with self._async_session_factory() as session:
+            result = await session.execute(
+                text(
+                    "DELETE FROM path_contexts "
+                    "WHERE zone_id = :zone_id AND path_prefix = :path_prefix"
+                ),
+                {"zone_id": zone_id, "path_prefix": path_prefix},
+            )
+            await session.commit()
+            return (result.rowcount or 0) > 0
+
+    async def list(self, zone_id: str | None = None) -> builtins.list[PathContextRecord]:
+        """List contexts. When zone_id is None, returns rows for all zones."""
+        query = (
+            "SELECT zone_id, path_prefix, description, created_at, updated_at FROM path_contexts"
+        )
+        params: dict[str, Any] = {}
+        if zone_id is not None:
+            query += " WHERE zone_id = :zone_id"
+            params["zone_id"] = zone_id
+        query += " ORDER BY zone_id, path_prefix"
+        async with self._async_session_factory() as session:
+            rows = (await session.execute(text(query), params)).all()
+        return [
+            PathContextRecord(
+                zone_id=row[0],
+                path_prefix=row[1],
+                description=row[2],
+                created_at=_coerce_datetime(row[3]),
+                updated_at=_coerce_datetime(row[4]),
+            )
+            for row in rows
+        ]
+
+    async def max_updated_at(self, zone_id: str) -> datetime | None:
+        """Return the max updated_at for a zone, or None if empty."""
+        async with self._async_session_factory() as session:
+            row = (
+                await session.execute(
+                    text("SELECT MAX(updated_at) FROM path_contexts WHERE zone_id = :zone_id"),
+                    {"zone_id": zone_id},
+                )
+            ).scalar()
+        return _coerce_datetime(row) if row is not None else None
+
+    async def load_all_for_zone(self, zone_id: str) -> builtins.list[PathContextRecord]:
+        """Load every context row for one zone."""
+        return await self.list(zone_id=zone_id)
+
+
+def _coerce_datetime(value: Any) -> datetime:
+    """SQLite + aiosqlite can return datetimes as ISO strings; normalize to datetime."""
+    if isinstance(value, datetime):
+        return value
+    if isinstance(value, str):
+        # SQLite stores "YYYY-MM-DD HH:MM:SS[.ffffff]" — fromisoformat handles both.
+        return datetime.fromisoformat(value)
+    raise TypeError(f"Unexpected datetime-like value from DB: {value!r}")
+
+
+# Issue #3773: PathContextCache is defined in Task 7. This placeholder keeps
+# imports stable so tests for the cache can be added in Task 7 without
+# re-editing import sites.
+class PathContextCache:  # Placeholder — full implementation in Task 7.
+    def __init__(self, *, store: PathContextStore) -> None:
+        self._store = store
+
+    async def refresh_if_stale(self, zone_id: str) -> None:
+        raise NotImplementedError("PathContextCache is wired up in Task 7.")
+
+    async def lookup(self, zone_id: str | None, path: str) -> str | None:
+        raise NotImplementedError("PathContextCache is wired up in Task 7.")

--- a/src/nexus/bricks/search/path_context.py
+++ b/src/nexus/bricks/search/path_context.py
@@ -18,9 +18,12 @@ from sqlalchemy import text
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 
-# Default LRU cap on the number of zones PathContextCache retains. A
-# multi-tenant deployment with many short-lived zones could otherwise
-# accumulate per-zone locks + record lists forever (Issue #3773 review).
+# Default LRU cap on the number of zones PathContextCache retains *records*
+# for. Per-zone asyncio.Lock objects are intentionally NOT evicted so that
+# Lock identity is preserved across refreshes — see ``refresh_if_stale`` for
+# the race this prevents. Locks are ~56 B each; operators with extremely
+# high zone cardinality (millions of short-lived zones) should monitor the
+# _locks dict and drain it out-of-band. (Issue #3773 review feedback.)
 _DEFAULT_MAX_ZONES = 2048
 
 

--- a/src/nexus/bricks/search/results.py
+++ b/src/nexus/bricks/search/results.py
@@ -38,6 +38,8 @@ class BaseSearchResult:
     original_score: float | None = None  # Score before attribute boosting
     # Issue #3147: Federated search — zone provenance
     zone_id: str | None = None  # Source zone for cross-zone federated results
+    # Issue #3773: admin-configured path description for LLM consumers
+    context: str | None = None
 
     @property
     def zone_qualified_path(self) -> str | None:

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -3284,8 +3284,9 @@ class SearchService:
                 path_filter=db_path,
                 zone_id=zone_id,
             )
-            hits = [
-                {
+            hits = []
+            for r in daemon_results:
+                entry: dict[str, Any] = {
                     "path": r.path,
                     "chunk_text": getattr(r, "chunk_text", ""),
                     "score": round(r.score, 4),
@@ -3295,8 +3296,13 @@ class SearchService:
                     "line_start": getattr(r, "line_start", 0) or 0,
                     "line_end": getattr(r, "line_end", 0) or 0,
                 }
-                for r in daemon_results
-            ]
+                # Issue #3773 (Round-6 review): surface admin-configured path
+                # context when the daemon attached one. Omit the key when
+                # unset to match the HTTP router's shape contract.
+                ctx = getattr(r, "context", None)
+                if ctx is not None:
+                    entry["context"] = ctx
+                hits.append(entry)
 
             # Filter by read permission — only return files the caller can access
             if self._permission_enforcer and hits and context is not None:

--- a/src/nexus/cli/api_client.py
+++ b/src/nexus/cli/api_client.py
@@ -70,11 +70,21 @@ class NexusApiClient:
         resp.raise_for_status()
         return resp.json()
 
-    def delete(self, path: str) -> None:
-        """DELETE request. No return value (expects 204)."""
+    def delete(self, path: str, params: dict[str, Any] | None = None) -> Any:
+        """DELETE request.
+
+        Returns parsed JSON when the server replies with a body (e.g. 200
+        with ``{"status": "deleted"}``), or ``None`` for bodyless responses
+        (e.g. 204). Raises ``httpx.HTTPStatusError`` on non-2xx responses —
+        callers can inspect ``exc.response.status_code`` to distinguish 404
+        from other failures without reaching into private internals.
+        """
         url = f"{self._base_url}{path}"
-        resp = httpx.delete(url, headers=self._headers(), timeout=self._timeout)
+        resp = httpx.delete(url, headers=self._headers(), params=params, timeout=self._timeout)
         resp.raise_for_status()
+        if resp.status_code == 204 or not resp.content:
+            return None
+        return resp.json()
 
 
 def get_api_client_from_options(

--- a/src/nexus/cli/commands/__init__.py
+++ b/src/nexus/cli/commands/__init__.py
@@ -61,6 +61,8 @@ _REGISTER_COMMANDS: dict[str, tuple[str, ...]] = {
     "aspects": ("aspects",),
     # Issue #3417: Lineage tracking commands
     "lineage": ("lineage",),
+    # Issue #3773: Path context descriptions (admin CRUD)
+    "path_context": ("path-context",),
 }
 
 # Modules that expose a single Click command/group to add via cli.add_command

--- a/src/nexus/cli/commands/path_context.py
+++ b/src/nexus/cli/commands/path_context.py
@@ -141,24 +141,18 @@ def path_context_delete(
     profile_name = (ctx.obj or {}).get("profile")
     client = get_api_client_from_options(remote_url, remote_api_key, profile_name=profile_name)
     try:
-        # The server returns a JSON body (`{"status": "deleted", ...}`) on
-        # success; use the generic client by issuing a raw DELETE via httpx
-        # so we can read the response body without relying on a 204 shape.
-        url = f"{client._base_url}/api/v2/path-contexts/"  # noqa: SLF001
-        resp = httpx.delete(
-            url,
-            headers=client._headers(),  # noqa: SLF001
+        client.delete(
+            "/api/v2/path-contexts/",
             params={"zone_id": zone_id, "path_prefix": path_prefix},
-            timeout=client._timeout,  # noqa: SLF001
         )
-        if resp.status_code == 404:
+    except httpx.HTTPStatusError as e:
+        if e.response.status_code == 404:
             console.print(
                 f"[nexus.warning]No path context found: {zone_id}:{path_prefix}[/nexus.warning]"
             )
-            raise SystemExit(1)
-        resp.raise_for_status()
-    except SystemExit:
-        raise
+            raise SystemExit(1) from e
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
+        raise SystemExit(1) from e
     except Exception as e:
         console.print(f"[nexus.error]Error:[/nexus.error] {e}")
         raise SystemExit(1) from e

--- a/src/nexus/cli/commands/path_context.py
+++ b/src/nexus/cli/commands/path_context.py
@@ -1,0 +1,165 @@
+"""Path-context CLI commands (Issue #3773).
+
+Thin wrapper over ``/api/v2/path-contexts`` for administering the zone-scoped
+path-prefix -> description mappings that surface as the ``context`` field on
+search results.
+
+Examples:
+    nexus path-context set src/nexus/bricks/search "Hybrid search brick"
+    nexus path-context list
+    nexus path-context list --zone-id other
+    nexus path-context delete src/nexus/bricks/search
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+
+import click
+
+from nexus.cli.theme import console
+from nexus.cli.utils import add_backend_options
+
+logger = logging.getLogger(__name__)
+
+
+def register_commands(cli: click.Group) -> None:
+    """Register path-context commands."""
+    cli.add_command(path_context)
+
+
+@click.group(name="path-context")
+def path_context() -> None:
+    """Path context descriptions — admin CRUD for search result annotations.
+
+    Descriptions are attached to search results whose path starts with the
+    configured prefix (longest prefix wins). Requires admin credentials.
+    """
+
+
+@path_context.command(name="set")
+@click.argument("path_prefix")
+@click.argument("description")
+@click.option("--zone-id", default="root", show_default=True, help="Zone scope")
+@add_backend_options
+@click.pass_context
+def path_context_set(
+    ctx: click.Context,
+    path_prefix: str,
+    description: str,
+    zone_id: str,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """Upsert a context description for a path prefix (admin only).
+
+    Example:
+        nexus path-context set src/nexus/bricks/search "Hybrid search brick"
+    """
+    from nexus.cli.api_client import get_api_client_from_options
+
+    profile_name = (ctx.obj or {}).get("profile")
+    client = get_api_client_from_options(remote_url, remote_api_key, profile_name=profile_name)
+    try:
+        result = client.put(
+            "/api/v2/path-contexts/",
+            {"zone_id": zone_id, "path_prefix": path_prefix, "description": description},
+        )
+    except Exception as e:
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
+        raise SystemExit(1) from e
+    console.print(
+        f"[nexus.success]set[/nexus.success] "
+        f"{result.get('zone_id')}:{result.get('path_prefix')} = {result.get('description')!r}"
+    )
+
+
+@path_context.command(name="list")
+@click.option("--zone-id", default=None, help="Filter by zone (default: all zones)")
+@click.option("--json", "as_json", is_flag=True, help="Emit raw JSON")
+@add_backend_options
+@click.pass_context
+def path_context_list(
+    ctx: click.Context,
+    zone_id: str | None,
+    as_json: bool,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """List path contexts.
+
+    Example:
+        nexus path-context list
+        nexus path-context list --zone-id root
+    """
+    from nexus.cli.api_client import get_api_client_from_options
+
+    profile_name = (ctx.obj or {}).get("profile")
+    client = get_api_client_from_options(remote_url, remote_api_key, profile_name=profile_name)
+    params = {"zone_id": zone_id} if zone_id else None
+    try:
+        result = client.get("/api/v2/path-contexts/", params=params)
+    except Exception as e:
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
+        raise SystemExit(1) from e
+
+    contexts = result.get("contexts", [])
+    if as_json:
+        console.print(json.dumps(contexts, indent=2))
+        return
+    if not contexts:
+        console.print("[nexus.warning]No path contexts configured[/nexus.warning]")
+        return
+    for entry in contexts:
+        console.print(
+            f"  {entry.get('zone_id')}:{entry.get('path_prefix')} -> {entry.get('description')}"
+        )
+
+
+@path_context.command(name="delete")
+@click.argument("path_prefix")
+@click.option("--zone-id", default="root", show_default=True, help="Zone scope")
+@add_backend_options
+@click.pass_context
+def path_context_delete(
+    ctx: click.Context,
+    path_prefix: str,
+    zone_id: str,
+    remote_url: str | None,
+    remote_api_key: str | None,
+) -> None:
+    """Delete a path context (admin only).
+
+    Example:
+        nexus path-context delete src/nexus/bricks/search
+    """
+    import httpx
+
+    from nexus.cli.api_client import get_api_client_from_options
+
+    profile_name = (ctx.obj or {}).get("profile")
+    client = get_api_client_from_options(remote_url, remote_api_key, profile_name=profile_name)
+    try:
+        # The server returns a JSON body (`{"status": "deleted", ...}`) on
+        # success; use the generic client by issuing a raw DELETE via httpx
+        # so we can read the response body without relying on a 204 shape.
+        url = f"{client._base_url}/api/v2/path-contexts/"  # noqa: SLF001
+        resp = httpx.delete(
+            url,
+            headers=client._headers(),  # noqa: SLF001
+            params={"zone_id": zone_id, "path_prefix": path_prefix},
+            timeout=client._timeout,  # noqa: SLF001
+        )
+        if resp.status_code == 404:
+            console.print(
+                f"[nexus.warning]No path context found: {zone_id}:{path_prefix}[/nexus.warning]"
+            )
+            raise SystemExit(1)
+        resp.raise_for_status()
+    except SystemExit:
+        raise
+    except Exception as e:
+        console.print(f"[nexus.error]Error:[/nexus.error] {e}")
+        raise SystemExit(1) from e
+    console.print(f"[nexus.success]deleted[/nexus.success] {zone_id}:{path_prefix}")

--- a/src/nexus/server/api/v2/routers/path_contexts.py
+++ b/src/nexus/server/api/v2/routers/path_contexts.py
@@ -35,14 +35,32 @@ router = APIRouter(prefix="/api/v2/path-contexts", tags=["path_contexts"])
 
 def _normalize_prefix(raw: str) -> str:
     """Canonical form: no leading/trailing slashes, no '..' traversal,
-    no empty segments.
+    no empty segments, no control or zero-width characters.
 
-    Raises ValueError on traversal attempts or double-slash segments. The
-    empty-segment check (Round-6 review) prevents admin input like
-    ``src//bricks`` from being stored verbatim — real paths never contain
-    double slashes, so such a rule would silently never match anything.
+    Raises ValueError on traversal attempts, double-slash segments, or
+    characters that would never match real filesystem paths.
+
+    Round-6 review added the empty-segment check so ``src//bricks`` is
+    rejected rather than stored verbatim. Round-8 review added the
+    control/zero-width character check: ASCII NULL trips asyncpg,
+    \\t/\\n/\\r/\\x7F never appear in real paths, and Unicode zero-width
+    chars (U+200B and friends) would produce two visually-identical but
+    distinct prefix rows — admin can't tell them apart, and lookups
+    against real paths silently miss.
     """
+    import unicodedata
+
     value = raw.strip()
+    for ch in value:
+        code = ord(ch)
+        if code < 0x20 or code == 0x7F:
+            raise ValueError(f"path_prefix must not contain control characters (got {raw!r})")
+        # ``Cf`` = format characters (zero-width space, zero-width joiner,
+        # BiDi marks, etc.). They collapse to visually-identical strings.
+        if unicodedata.category(ch) == "Cf":
+            raise ValueError(
+                f"path_prefix must not contain zero-width or format characters (got {raw!r})"
+            )
     while value.startswith("/"):
         value = value[1:]
     while value.endswith("/"):
@@ -106,11 +124,13 @@ async def _get_store(request: Request) -> PathContextStore:
 
     # Round-7 review: prune closed-loop entries so the per-loop dicts can't
     # grow unbounded on long-running servers that cycle through request
-    # loops (worker recycling, anyio loop churn).
+    # loops (worker recycling, anyio loop churn). Round-8 review: tolerate
+    # non-loop keys (test fixtures / mocks injecting unusual keys) — a
+    # missing ``is_closed`` attr is treated as closed.
     engines_for_prune: dict[Any, Any] | None = getattr(
         request.app.state, "_path_context_engines_by_loop", None
     )
-    stale = [lk for lk in cached if lk.is_closed()]
+    stale = [lk for lk in cached if not hasattr(lk, "is_closed") or lk.is_closed()]
     for lk in stale:
         cached.pop(lk, None)
         if engines_for_prune is not None:

--- a/src/nexus/server/api/v2/routers/path_contexts.py
+++ b/src/nexus/server/api/v2/routers/path_contexts.py
@@ -34,9 +34,13 @@ router = APIRouter(prefix="/api/v2/path-contexts", tags=["path_contexts"])
 
 
 def _normalize_prefix(raw: str) -> str:
-    """Canonical form: no leading/trailing slashes, no '..' traversal.
+    """Canonical form: no leading/trailing slashes, no '..' traversal,
+    no empty segments.
 
-    Raises ValueError on traversal attempts.
+    Raises ValueError on traversal attempts or double-slash segments. The
+    empty-segment check (Round-6 review) prevents admin input like
+    ``src//bricks`` from being stored verbatim — real paths never contain
+    double slashes, so such a rule would silently never match anything.
     """
     value = raw.strip()
     while value.startswith("/"):
@@ -47,6 +51,10 @@ def _normalize_prefix(raw: str) -> str:
     for segment in parts:
         if segment == ".." or segment == ".":
             raise ValueError(f"path_prefix must not contain '.' or '..' segments (got {raw!r})")
+        if segment == "":
+            raise ValueError(
+                f"path_prefix must not contain empty segments (double slash in {raw!r})"
+            )
     return value
 
 

--- a/src/nexus/server/api/v2/routers/path_contexts.py
+++ b/src/nexus/server/api/v2/routers/path_contexts.py
@@ -1,0 +1,141 @@
+"""Path Contexts API v2 router (Issue #3773).
+
+Admin-managed per-zone path-prefix -> description mappings. Search results
+carry the longest-prefix-matching description in their ``context`` field.
+
+Endpoints:
+- PUT    /api/v2/path-contexts/       Upsert (admin)
+- GET    /api/v2/path-contexts/       List contexts (auth)
+- DELETE /api/v2/path-contexts/       Delete one (admin)
+
+Pattern mirrors access_manifests.py.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+from pydantic import BaseModel, Field, field_validator
+
+from nexus.bricks.search.path_context import PathContextStore
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.server.dependencies import require_admin, require_auth
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v2/path-contexts", tags=["path_contexts"])
+
+
+# ---------------------------------------------------------------------------
+# Request / response models
+# ---------------------------------------------------------------------------
+
+
+def _normalize_prefix(raw: str) -> str:
+    """Canonical form: no leading/trailing slashes, no '..' traversal.
+
+    Raises ValueError on traversal attempts.
+    """
+    value = raw.strip()
+    while value.startswith("/"):
+        value = value[1:]
+    while value.endswith("/"):
+        value = value[:-1]
+    parts = value.split("/") if value else []
+    for segment in parts:
+        if segment == ".." or segment == ".":
+            raise ValueError(f"path_prefix must not contain '.' or '..' segments (got {raw!r})")
+    return value
+
+
+class PathContextIn(BaseModel):
+    zone_id: str = Field(default=ROOT_ZONE_ID, max_length=255)
+    path_prefix: str = Field(max_length=1024)
+    description: str = Field(max_length=4096, min_length=1)
+
+    @field_validator("path_prefix")
+    @classmethod
+    def _validate_prefix(cls, v: str) -> str:
+        return _normalize_prefix(v)
+
+
+class PathContextOut(BaseModel):
+    zone_id: str
+    path_prefix: str
+    description: str
+    created_at: Any
+    updated_at: Any
+
+
+# ---------------------------------------------------------------------------
+# Dependencies
+# ---------------------------------------------------------------------------
+
+
+def _get_store(request: Request) -> PathContextStore:
+    store: PathContextStore | None = getattr(request.app.state, "path_context_store", None)
+    if store is None:
+        raise HTTPException(status_code=503, detail="path context store not configured")
+    return store
+
+
+# ---------------------------------------------------------------------------
+# Endpoints
+# ---------------------------------------------------------------------------
+
+
+@router.put("/")
+async def upsert_context(
+    body: PathContextIn,
+    _admin: dict[str, Any] = Depends(require_admin),
+    store: PathContextStore = Depends(_get_store),
+) -> dict[str, Any]:
+    """Upsert a path context (admin only)."""
+    await store.upsert(body.zone_id, body.path_prefix, body.description)
+    return {
+        "zone_id": body.zone_id,
+        "path_prefix": body.path_prefix,
+        "description": body.description,
+    }
+
+
+@router.get("/")
+async def list_contexts(
+    zone_id: str | None = Query(default=None),
+    _auth: dict[str, Any] = Depends(require_auth),
+    store: PathContextStore = Depends(_get_store),
+) -> dict[str, Any]:
+    """List path contexts (any authenticated caller). Optional ?zone_id filter."""
+    records = await store.list(zone_id)
+    return {
+        "contexts": [
+            {
+                "zone_id": r.zone_id,
+                "path_prefix": r.path_prefix,
+                "description": r.description,
+                "created_at": r.created_at.isoformat() if r.created_at else None,
+                "updated_at": r.updated_at.isoformat() if r.updated_at else None,
+            }
+            for r in records
+        ]
+    }
+
+
+@router.delete("/")
+async def delete_context(
+    zone_id: str = Query(...),
+    path_prefix: str = Query(...),
+    _admin: dict[str, Any] = Depends(require_admin),
+    store: PathContextStore = Depends(_get_store),
+) -> dict[str, Any]:
+    """Delete a path context (admin only)."""
+    try:
+        normalized = _normalize_prefix(path_prefix)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc)) from exc
+    removed = await store.delete(zone_id, normalized)
+    if not removed:
+        raise HTTPException(status_code=404, detail="path context not found")
+    return {"zone_id": zone_id, "path_prefix": normalized, "status": "deleted"}

--- a/src/nexus/server/api/v2/routers/path_contexts.py
+++ b/src/nexus/server/api/v2/routers/path_contexts.py
@@ -133,7 +133,35 @@ async def _get_store(request: Request) -> PathContextStore:
     factory = async_sessionmaker(engine, expire_on_commit=False)
     store = PathContextStore(async_session_factory=factory, db_type=db_type)
     cached[loop] = store
+    # Track the engine for disposal on app shutdown (Issue #3773 review).
+    engines: dict[Any, Any] | None = getattr(
+        request.app.state, "_path_context_engines_by_loop", None
+    )
+    if engines is None:
+        engines = {}
+        request.app.state._path_context_engines_by_loop = engines
+    engines[loop] = engine
     return store
+
+
+async def dispose_loop_local_engines(app_state: Any) -> None:
+    """Dispose engines cached by :func:`_get_store`.
+
+    Called from the app's lifespan shutdown hook so we don't leak pooled
+    asyncpg connections when request loops die off (Issue #3773 review).
+    """
+    import contextlib
+
+    engines: dict[Any, Any] | None = getattr(app_state, "_path_context_engines_by_loop", None)
+    if not engines:
+        return
+    for engine in list(engines.values()):
+        with contextlib.suppress(Exception):
+            await engine.dispose()
+    engines.clear()
+    cached: dict[Any, Any] | None = getattr(app_state, "_path_context_store_by_loop", None)
+    if cached is not None:
+        cached.clear()
 
 
 # ---------------------------------------------------------------------------

--- a/src/nexus/server/api/v2/routers/path_contexts.py
+++ b/src/nexus/server/api/v2/routers/path_contexts.py
@@ -100,7 +100,14 @@ async def _get_store(request: Request) -> PathContextStore:
     if existing is not None:
         return existing
 
-    db_url = os.environ.get("DATABASE_URL") or os.environ.get("NEXUS_DATABASE_URL")
+    # Fallback order: env vars -> app.state.database_url (set by create_app) ->
+    # the startup-time injected store. Env-only lookup misses the
+    # ``create_app(database_url=...)`` code path (Issue #3773 review feedback).
+    db_url = (
+        os.environ.get("DATABASE_URL")
+        or os.environ.get("NEXUS_DATABASE_URL")
+        or getattr(request.app.state, "database_url", None)
+    )
     if not db_url:
         store: PathContextStore | None = getattr(request.app.state, "path_context_store", None)
         if store is None:
@@ -152,10 +159,24 @@ async def upsert_context(
 @router.get("/")
 async def list_contexts(
     zone_id: str | None = Query(default=None),
-    _auth: dict[str, Any] = Depends(require_auth),
+    auth: dict[str, Any] = Depends(require_auth),
     store: PathContextStore = Depends(_get_store),
 ) -> dict[str, Any]:
-    """List path contexts (any authenticated caller). Optional ?zone_id filter."""
+    """List path contexts.
+
+    Non-admin callers see only their own zone's contexts — enumeration across
+    zones is admin-only (Issue #3773 review feedback). Admins may pass any
+    ``zone_id`` or omit it to list across all zones.
+    """
+    is_admin = bool(auth.get("is_admin", False))
+    caller_zone = auth.get("zone_id") or ROOT_ZONE_ID
+    if not is_admin:
+        if zone_id is not None and zone_id != caller_zone:
+            raise HTTPException(
+                status_code=403,
+                detail="non-admin callers cannot list other zones",
+            )
+        zone_id = caller_zone
     records = await store.list(zone_id)
     return {
         "contexts": [

--- a/src/nexus/server/api/v2/routers/path_contexts.py
+++ b/src/nexus/server/api/v2/routers/path_contexts.py
@@ -147,17 +147,25 @@ async def _get_store(request: Request) -> PathContextStore:
 async def dispose_loop_local_engines(app_state: Any) -> None:
     """Dispose engines cached by :func:`_get_store`.
 
-    Called from the app's lifespan shutdown hook so we don't leak pooled
-    asyncpg connections when request loops die off (Issue #3773 review).
+    Only engines whose origin loop is the current running loop can actually
+    be disposed here — asyncpg pools bound to other (possibly dead) loops
+    must be released on their own loop, which we cannot reach from a
+    shutdown hook. Dropping the dict references for those is still correct:
+    the dead loop's socket fds are reclaimed on GC. Mirrors the pattern
+    used by :meth:`SearchDaemon.shutdown` for consistency
+    (Issue #3773 review).
     """
+    import asyncio
     import contextlib
 
     engines: dict[Any, Any] | None = getattr(app_state, "_path_context_engines_by_loop", None)
     if not engines:
         return
-    for engine in list(engines.values()):
-        with contextlib.suppress(Exception):
-            await engine.dispose()
+    running_loop = asyncio.get_running_loop()
+    for loop_key, engine in list(engines.items()):
+        if loop_key is running_loop:
+            with contextlib.suppress(Exception):
+                await engine.dispose()
     engines.clear()
     cached: dict[Any, Any] | None = getattr(app_state, "_path_context_store_by_loop", None)
     if cached is not None:

--- a/src/nexus/server/api/v2/routers/path_contexts.py
+++ b/src/nexus/server/api/v2/routers/path_contexts.py
@@ -104,6 +104,18 @@ async def _get_store(request: Request) -> PathContextStore:
         cached = {}
         request.app.state._path_context_store_by_loop = cached
 
+    # Round-7 review: prune closed-loop entries so the per-loop dicts can't
+    # grow unbounded on long-running servers that cycle through request
+    # loops (worker recycling, anyio loop churn).
+    engines_for_prune: dict[Any, Any] | None = getattr(
+        request.app.state, "_path_context_engines_by_loop", None
+    )
+    stale = [lk for lk in cached if lk.is_closed()]
+    for lk in stale:
+        cached.pop(lk, None)
+        if engines_for_prune is not None:
+            engines_for_prune.pop(lk, None)
+
     existing = cached.get(loop)
     if existing is not None:
         return existing

--- a/src/nexus/server/api/v2/routers/path_contexts.py
+++ b/src/nexus/server/api/v2/routers/path_contexts.py
@@ -74,10 +74,58 @@ class PathContextOut(BaseModel):
 # ---------------------------------------------------------------------------
 
 
-def _get_store(request: Request) -> PathContextStore:
-    store: PathContextStore | None = getattr(request.app.state, "path_context_store", None)
-    if store is None:
-        raise HTTPException(status_code=503, detail="path context store not configured")
+async def _get_store(request: Request) -> PathContextStore:
+    """Return a PathContextStore bound to the current request's event loop.
+
+    Issue #3773 note: the startup-time store on ``app.state`` is bound to the
+    lifespan loop, which diverges from the request loop under
+    BaseHTTPMiddleware — asyncpg trips ``got result for unknown protocol
+    state`` when used cross-loop. Lazily create a request-loop-native engine
+    on first use and cache it on ``app.state`` keyed by the running loop.
+    """
+    import asyncio
+    import os
+
+    from sqlalchemy.ext.asyncio import async_sessionmaker, create_async_engine
+
+    loop = asyncio.get_running_loop()
+    cached: dict[Any, PathContextStore] | None = getattr(
+        request.app.state, "_path_context_store_by_loop", None
+    )
+    if cached is None:
+        cached = {}
+        request.app.state._path_context_store_by_loop = cached
+
+    existing = cached.get(loop)
+    if existing is not None:
+        return existing
+
+    db_url = os.environ.get("DATABASE_URL") or os.environ.get("NEXUS_DATABASE_URL")
+    if not db_url:
+        store: PathContextStore | None = getattr(request.app.state, "path_context_store", None)
+        if store is None:
+            raise HTTPException(status_code=503, detail="path context store not configured")
+        cached[loop] = store
+        return store
+
+    if db_url.startswith("postgresql://"):
+        db_url = db_url.replace("postgresql://", "postgresql+asyncpg://", 1)
+        db_type = "postgresql"
+    elif db_url.startswith("postgres://"):
+        db_url = db_url.replace("postgres://", "postgresql+asyncpg://", 1)
+        db_type = "postgresql"
+    elif db_url.startswith("sqlite:") and "+aiosqlite" not in db_url:
+        db_url = db_url.replace("sqlite:", "sqlite+aiosqlite:", 1)
+        db_type = "sqlite"
+    elif db_url.startswith("sqlite"):
+        db_type = "sqlite"
+    else:
+        db_type = "sqlite"
+
+    engine = create_async_engine(db_url, future=True)
+    factory = async_sessionmaker(engine, expire_on_commit=False)
+    store = PathContextStore(async_session_factory=factory, db_type=db_type)
+    cached[loop] = store
     return store
 
 

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -110,9 +110,8 @@ def _serialize_search_result(result: Any) -> dict[str, Any]:
     the graph and non-graph branches of ``search_query``. Preserves the
     pre-refactor field ordering, rounding, and None semantics.
 
-    ``splade_score`` and ``reranker_score`` are emitted whenever the
-    underlying result has them as attributes. Results that predate those
-    fields (e.g. bare ``BaseSearchResult``) get ``None``.
+    Issue #3773: emits ``context`` when the result carries a non-None value
+    (omits the key otherwise to keep responses compact).
     """
     out: dict[str, Any] = {
         "path": result.path,
@@ -128,6 +127,9 @@ def _serialize_search_result(result: Any) -> dict[str, Any]:
     out["splade_score"] = round(splade, 4) if splade is not None else None
     reranker = getattr(result, "reranker_score", None)
     out["reranker_score"] = round(reranker, 4) if reranker is not None else None
+    context = getattr(result, "context", None)
+    if context is not None:
+        out["context"] = context
     return out
 
 

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -504,16 +504,19 @@ async def search_query_batch(
         filter_ms_total += filter_ms
         trimmed = filtered[:orig_limit]
 
-        formatted = [
-            {
+        formatted: list[dict[str, Any]] = []
+        for r in trimmed:
+            entry: dict[str, Any] = {
                 "path": r.path,
                 "chunk_text": r.chunk_text,
                 "score": round(r.score, 4),
                 "keyword_score": round(r.keyword_score, 4) if r.keyword_score is not None else None,
                 "vector_score": round(r.vector_score, 4) if r.vector_score is not None else None,
             }
-            for r in trimmed
-        ]
+            ctx = getattr(r, "context", None)
+            if ctx is not None:
+                entry["context"] = ctx
+            formatted.append(entry)
         response_queries.append(
             {
                 "query": q_spec.get("q", ""),

--- a/src/nexus/server/api/v2/versioning.py
+++ b/src/nexus/server/api/v2/versioning.py
@@ -343,6 +343,19 @@ def build_v2_registry(
         )
     except ImportError as e:
         logger.warning("Failed to import Access Manifests routes: %s", e)
+
+    # ---- Path Contexts router (Issue #3773) ----
+    try:
+        from nexus.server.api.v2.routers.path_contexts import (
+            router as path_contexts_router,
+        )
+
+        registry.add(
+            RouterEntry(router=path_contexts_router, name="path_contexts", endpoint_count=3)
+        )
+    except ImportError as e:
+        logger.warning("Failed to import Path Contexts routes: %s", e)
+
     # ---- Search router (Issue #2056 — ported from v1) ----
     try:
         from nexus.server.api.v2.routers.search import router as search_router

--- a/src/nexus/server/lifespan/search.py
+++ b/src/nexus/server/lifespan/search.py
@@ -65,9 +65,20 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
         from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon
 
         txtai_model, txtai_vectors = _resolve_txtai_runtime_config()
+        _path_ctx_max_zones_env = os.environ.get("NEXUS_PATH_CONTEXT_MAX_ZONES")
+        _path_ctx_max_zones = 2048
+        if _path_ctx_max_zones_env:
+            try:
+                _path_ctx_max_zones = max(1, int(_path_ctx_max_zones_env))
+            except ValueError:
+                logger.warning(
+                    "Invalid NEXUS_PATH_CONTEXT_MAX_ZONES=%r — falling back to 2048",
+                    _path_ctx_max_zones_env,
+                )
         config = DaemonConfig(
             database_url=svc.database_url,
             query_timeout_seconds=float(os.environ.get("NEXUS_QUERY_TIMEOUT", "10.0")),
+            path_context_max_zones=_path_ctx_max_zones,
             # txtai backend config (Issue #2663)
             txtai_model=txtai_model,
             txtai_vectors=txtai_vectors,
@@ -131,7 +142,10 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
                     async_session_factory=_async_sf,
                     db_type=_db_type,
                 )
-                path_context_cache = PathContextCache(store=path_context_store)
+                path_context_cache = PathContextCache(
+                    store=path_context_store,
+                    max_zones=config.path_context_max_zones,
+                )
             except Exception:  # pragma: no cover — non-fatal wiring failure
                 logger.exception("Failed to initialize path context store/cache")
         app.state.path_context_store = path_context_store

--- a/src/nexus/server/lifespan/search.py
+++ b/src/nexus/server/lifespan/search.py
@@ -136,6 +136,11 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
                 logger.exception("Failed to initialize path context store/cache")
         app.state.path_context_store = path_context_store
         app.state.path_context_cache = path_context_cache
+        # Expose the database URL for loop-local resolvers that need to rebuild
+        # engines on the request loop (Issue #3773 review feedback): the env
+        # var may not be set when the app is constructed via
+        # ``create_app(database_url=...)``.
+        app.state.database_url = svc.database_url
 
         app.state.search_daemon = SearchDaemon(
             config,

--- a/src/nexus/server/lifespan/search.py
+++ b/src/nexus/server/lifespan/search.py
@@ -137,13 +137,13 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
         app.state.path_context_store = path_context_store
         app.state.path_context_cache = path_context_cache
 
-        # path_context_cache wired into SearchDaemon in Task 10
         app.state.search_daemon = SearchDaemon(
             config,
             async_session_factory=_async_sf,
             zoekt_client=_zoekt_client,
             cache_brick=_cache_brick,
             settings_store=_settings_store,
+            path_context_cache=path_context_cache,  # Issue #3773
         )
 
         # Embeddings are now handled by txtai backend (Issue #2663).

--- a/src/nexus/server/lifespan/search.py
+++ b/src/nexus/server/lifespan/search.py
@@ -112,6 +112,32 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
         # CacheBrick is available from startup_permissions
         _cache_brick = getattr(app.state, "cache_brick", None)
 
+        # Issue #3773: path context store + cache
+        path_context_store = None
+        path_context_cache = None
+        if _async_sf is not None:
+            try:
+                from nexus.bricks.search.path_context import (
+                    PathContextCache,
+                    PathContextStore,
+                )
+
+                _db_type = (
+                    "postgresql"
+                    if (svc.database_url or "").startswith(("postgres", "postgresql"))
+                    else "sqlite"
+                )
+                path_context_store = PathContextStore(
+                    async_session_factory=_async_sf,
+                    db_type=_db_type,
+                )
+                path_context_cache = PathContextCache(store=path_context_store)
+            except Exception:  # pragma: no cover — non-fatal wiring failure
+                logger.exception("Failed to initialize path context store/cache")
+        app.state.path_context_store = path_context_store
+        app.state.path_context_cache = path_context_cache
+
+        # path_context_cache wired into SearchDaemon in Task 10
         app.state.search_daemon = SearchDaemon(
             config,
             async_session_factory=_async_sf,

--- a/src/nexus/server/lifespan/services.py
+++ b/src/nexus/server/lifespan/services.py
@@ -105,6 +105,15 @@ async def shutdown_services(app: "FastAPI", svc: "LifespanServices") -> None:
         except Exception as e:
             logger.warning("Error shutting down Search Daemon: %s", e, exc_info=True)
 
+    # Dispose loop-local path-context engines created lazily by the router
+    # (Issue #3773 review — avoid pooled-connection leak on loop churn).
+    try:
+        from nexus.server.api.v2.routers.path_contexts import dispose_loop_local_engines
+
+        await dispose_loop_local_engines(app.state)
+    except Exception as e:
+        logger.debug("dispose_loop_local_engines failed: %s", e)
+
     # Stop DirectoryGrantExpander worker
     if app.state.directory_grant_expander:
         try:

--- a/tests/integration/bricks/search/test_daemon_context_attach.py
+++ b/tests/integration/bricks/search/test_daemon_context_attach.py
@@ -149,3 +149,121 @@ class TestSerializerEmitsContext:
         r = BaseSearchResult(path="x", chunk_text="y", score=0.5)
         out = _serialize_search_result(r)
         assert "context" not in out
+
+
+class TestFullFlowStoreAttachSerialize:
+    """Chain the real store, real cache refresh+lookup, and real serializer.
+
+    Mirrors what happens in production across these boundaries:
+      admin PUT /api/v2/path-contexts/ -> store.upsert
+      backend returns hits -> daemon._attach_path_contexts -> serializer
+    """
+
+    @pytest.mark.asyncio
+    async def test_put_then_search_response_carries_context(self) -> None:
+        from nexus.server.api.v2.routers.search import _serialize_search_result
+
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+        async with engine.begin() as conn:
+            await conn.exec_driver_sql(CREATE_TABLE_SQL)
+        factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        store = PathContextStore(async_session_factory=factory, db_type="sqlite")
+        cache = PathContextCache(store=store)
+
+        # Admin seeds contexts (same call path as PUT /api/v2/path-contexts/).
+        await store.upsert("root", "src/nexus/bricks/search", "Hybrid search brick")
+        await store.upsert("root", "docs", "Project documentation")
+
+        # Backend returns raw results with no context set.
+        raw_results = [
+            BaseSearchResult(
+                path="src/nexus/bricks/search/fusion.py",
+                chunk_text="def rrf_fusion(...)",
+                score=0.9,
+                zone_id="root",
+                keyword_score=0.8,
+                vector_score=0.7,
+            ),
+            BaseSearchResult(
+                path="docs/README.md",
+                chunk_text="Project overview",
+                score=0.8,
+                zone_id="root",
+            ),
+            BaseSearchResult(
+                path="scripts/unrelated.py",
+                chunk_text="other",
+                score=0.5,
+                zone_id="root",
+            ),
+        ]
+
+        # Daemon-equivalent attach: one refresh per unique zone, cached lookups.
+        zones = {(r.zone_id or "root") for r in raw_results}
+        for zone in zones:
+            await cache.refresh_if_stale(zone)
+        for r in raw_results:
+            r.context = cache.lookup_cached(r.zone_id, r.path)
+
+        # Router serializer produces the HTTP response dict.
+        response = [_serialize_search_result(r) for r in raw_results]
+
+        assert response[0]["path"] == "src/nexus/bricks/search/fusion.py"
+        assert response[0]["context"] == "Hybrid search brick"
+        assert response[1]["path"] == "docs/README.md"
+        assert response[1]["context"] == "Project documentation"
+        # No matching prefix -> context key omitted to keep response compact.
+        assert response[2]["path"] == "scripts/unrelated.py"
+        assert "context" not in response[2]
+
+        await engine.dispose()
+
+    @pytest.mark.asyncio
+    async def test_empty_store_emits_no_context_anywhere(self) -> None:
+        from nexus.server.api.v2.routers.search import _serialize_search_result
+
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+        async with engine.begin() as conn:
+            await conn.exec_driver_sql(CREATE_TABLE_SQL)
+        factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        store = PathContextStore(async_session_factory=factory, db_type="sqlite")
+        cache = PathContextCache(store=store)
+
+        raw_results = [
+            BaseSearchResult(path="any/path.py", chunk_text="x", score=0.9, zone_id="root"),
+        ]
+        await cache.refresh_if_stale("root")
+        for r in raw_results:
+            r.context = cache.lookup_cached(r.zone_id, r.path)
+        response = [_serialize_search_result(r) for r in raw_results]
+
+        assert "context" not in response[0]
+        await engine.dispose()
+
+    @pytest.mark.asyncio
+    async def test_longest_prefix_wins_through_full_pipeline(self) -> None:
+        """Overlapping prefixes: the longer match decides which description appears."""
+        from nexus.server.api.v2.routers.search import _serialize_search_result
+
+        engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+        async with engine.begin() as conn:
+            await conn.exec_driver_sql(CREATE_TABLE_SQL)
+        factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+        store = PathContextStore(async_session_factory=factory, db_type="sqlite")
+        cache = PathContextCache(store=store)
+
+        await store.upsert("root", "src", "generic source")
+        await store.upsert("root", "src/nexus/bricks/search", "search brick")
+        await cache.refresh_if_stale("root")
+
+        r = BaseSearchResult(
+            path="src/nexus/bricks/search/fusion.py",
+            chunk_text="",
+            score=0.9,
+            zone_id="root",
+        )
+        r.context = cache.lookup_cached(r.zone_id, r.path)
+        out = _serialize_search_result(r)
+        assert out["context"] == "search brick"  # longer prefix wins
+
+        await engine.dispose()

--- a/tests/integration/bricks/search/test_daemon_context_attach.py
+++ b/tests/integration/bricks/search/test_daemon_context_attach.py
@@ -75,6 +75,60 @@ class TestAttachContextToResults:
         assert results[2].context is None
 
 
+class TestGraphSearchContextAttachment:
+    @pytest.mark.asyncio
+    async def test_graph_enhanced_search_attaches_context(self, cache: PathContextCache) -> None:
+        """graph_enhanced_search must attach context like the non-graph branch."""
+        from types import SimpleNamespace
+
+        from nexus.bricks.search.graph_search_service import graph_enhanced_search
+        from nexus.bricks.search.results import BaseSearchResult
+
+        async def _fake_graph_search(query, *, zone_id, limit, path_filter):
+            return [
+                BaseSearchResult(
+                    path="src/nexus/bricks/search/fusion.py",
+                    chunk_text="",
+                    score=0.9,
+                    zone_id=zone_id,
+                ),
+                BaseSearchResult(
+                    path="docs/README.md",
+                    chunk_text="",
+                    score=0.8,
+                    zone_id=zone_id,
+                ),
+            ]
+
+        # Fake daemon: backend exposing graph_search, _attach_path_contexts bound
+        # to a local SearchDaemon-style helper powered by the cache.
+        backend = SimpleNamespace(graph_search=_fake_graph_search)
+
+        async def _attach(results):
+            zones = {(r.zone_id or "root") for r in results}
+            for zone in zones:
+                await cache.refresh_if_stale(zone)
+            for r in results:
+                r.context = cache.lookup_cached(r.zone_id, r.path)
+
+        daemon = SimpleNamespace(_backend=backend, _attach_path_contexts=_attach)
+
+        results = await graph_enhanced_search(
+            "q",
+            "hybrid",
+            10,
+            None,
+            0.5,
+            "auto",
+            record_store=None,
+            async_session_factory=None,
+            search_daemon=daemon,
+            zone_id="root",
+        )
+        assert results[0].context == "Hybrid search brick"
+        assert results[1].context == "Project documentation"
+
+
 class TestSerializerEmitsContext:
     def test_context_field_emitted_when_set(self) -> None:
         from nexus.server.api.v2.routers.search import _serialize_search_result

--- a/tests/integration/bricks/search/test_daemon_context_attach.py
+++ b/tests/integration/bricks/search/test_daemon_context_attach.py
@@ -45,6 +45,50 @@ class TestBaseSearchResultContextField:
         assert r.context is None
 
 
+class TestAttachUsesCallerZone:
+    """Round-3 regression: daemon must use the caller's effective zone_id as
+    the fallback because most backends construct SearchResult without the
+    zone_id field set. Prior code collapsed everything to ROOT_ZONE_ID and
+    silently dropped context on non-root zone searches.
+    """
+
+    @pytest.mark.asyncio
+    async def test_attach_falls_back_to_caller_zone_when_result_zone_missing(
+        self, cache: PathContextCache
+    ) -> None:
+        from types import SimpleNamespace
+
+        # Seed a context under zone "other" only — not visible under root.
+        await cache._store.upsert("other", "src/nexus/bricks/search", "other-zone brick")
+        # Simulate how the real daemon's _attach_path_contexts threads
+        # effective_zone_id as the fallback when r.zone_id is unset.
+        results = [
+            BaseSearchResult(
+                path="src/nexus/bricks/search/fusion.py",
+                chunk_text="",
+                score=0.9,
+                zone_id=None,
+            ),
+        ]
+
+        async def _attach(items, *, zone_id):
+            effective = zone_id or "root"
+            zone = items[0].zone_id or effective
+            await cache.refresh_if_stale(zone)
+            snap = cache.snapshot_zone(zone)
+            if snap is not None:
+                from nexus.bricks.search.path_context import lookup_in_records
+
+                for r in items:
+                    r.context = lookup_in_records(snap, r.path)
+
+        _ = SimpleNamespace(_attach_path_contexts=_attach)
+        await _attach(results, zone_id="other")
+        # With the caller-zone fallback, the "other" zone's description is
+        # picked up even though the result carried no zone_id.
+        assert results[0].context == "other-zone brick"
+
+
 class TestLoopLocalResolver:
     """Regression tests for ``SearchDaemon._resolve_path_context_cache``.
 

--- a/tests/integration/bricks/search/test_daemon_context_attach.py
+++ b/tests/integration/bricks/search/test_daemon_context_attach.py
@@ -326,9 +326,57 @@ class TestLoopLocalResolver:
         cache_b = asyncio.run(_resolve_once())
         # Distinct caches because each asyncio.run creates a fresh loop.
         assert cache_a is not cache_b
-        # Two loops tracked.
-        assert len(daemon._path_context_cache_by_loop) == 2
-        assert len(daemon._path_context_engines_by_loop) == 2
+        # Round-7 review: _resolve_path_context_cache now prunes entries for
+        # closed loops on every call. After the 2nd asyncio.run(), loop A was
+        # closed before loop B's resolve, so the prune drops A's entry and
+        # the dict holds only B. After both runs exit both loops are closed,
+        # but neither is alive now — prune happens on entry so state freezes
+        # at whatever the 2nd resolve left behind (loop B only).
+        assert len(daemon._path_context_cache_by_loop) == 1
+        assert len(daemon._path_context_engines_by_loop) == 1
+
+
+class TestResolverPrunesClosedLoops:
+    """Round-7 review regression: ``_resolve_path_context_cache`` must drop
+    entries keyed by loops that are already closed, so the per-loop dicts
+    don't accumulate dead refs on long-running servers with worker loop
+    churn."""
+
+    def test_closed_loop_entries_are_pruned(self, tmp_path) -> None:
+        import asyncio
+
+        from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon
+
+        db_file = tmp_path / "ctx3.db"
+        db_url = f"sqlite+aiosqlite:///{db_file}"
+
+        async def _setup() -> None:
+            engine = create_async_engine(db_url, future=True)
+            async with engine.begin() as conn:
+                await conn.exec_driver_sql(CREATE_TABLE_SQL)
+            await engine.dispose()
+
+        asyncio.run(_setup())
+
+        daemon = SearchDaemon.__new__(SearchDaemon)
+        daemon.config = DaemonConfig(database_url=db_url)
+        daemon._path_context_cache = None
+        daemon._path_context_cache_by_loop = {}
+        daemon._path_context_engines_by_loop = {}
+
+        # Simulate a dead loop entry carried over from a recycled worker.
+        dead_loop = asyncio.new_event_loop()
+        dead_loop.close()
+        daemon._path_context_cache_by_loop[dead_loop] = object()
+        daemon._path_context_engines_by_loop[dead_loop] = object()
+        assert dead_loop.is_closed()
+
+        async def _resolve_once():
+            return await daemon._resolve_path_context_cache()
+
+        asyncio.run(_resolve_once())
+        assert dead_loop not in daemon._path_context_cache_by_loop
+        assert dead_loop not in daemon._path_context_engines_by_loop
 
 
 class TestAttachContextToResults:

--- a/tests/integration/bricks/search/test_daemon_context_attach.py
+++ b/tests/integration/bricks/search/test_daemon_context_attach.py
@@ -132,6 +132,49 @@ class TestRealDaemonAttach:
         assert result2.context is None
 
 
+class TestAttachStaleFallbackOnRefreshError:
+    """Round-5 review: a transient DB failure during ``refresh_if_stale`` must
+    not discard a previously-cached snapshot. The fail-soft contract says
+    stale context beats no context for an LLM consumer."""
+
+    @pytest.mark.asyncio
+    async def test_attach_uses_stale_snapshot_when_refresh_raises(
+        self, cache: PathContextCache
+    ) -> None:
+        from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon, SearchResult
+
+        # Warm the cache with a successful load first so snapshot_zone has
+        # records to fall back to.
+        await cache.refresh_if_stale("root")
+
+        # Force the next refresh to fail via monkeypatch-style assignment;
+        # this is a test-only stub of the store's fingerprint method.
+        async def boom(zone_id: str) -> tuple[int, object]:
+            raise RuntimeError("simulated DB brownout")
+
+        object.__setattr__(cache._store, "zone_fingerprint", boom)
+
+        daemon = SearchDaemon.__new__(SearchDaemon)
+        daemon.config = DaemonConfig()
+        daemon._path_context_cache = cache
+        daemon._path_context_cache_by_loop = {}
+        daemon._path_context_engines_by_loop = {}
+
+        class _Stats:
+            path_context_attach_failures = 0
+            path_context_resolve_failures = 0
+
+        daemon.stats = _Stats()
+
+        result = SearchResult(
+            path="src/nexus/bricks/search/fusion.py", chunk_text="", score=0.9, zone_id=None
+        )
+        await daemon._attach_path_contexts([result], zone_id="root")
+        # Stale snapshot preserved "Hybrid search brick" under root.
+        assert result.context == "Hybrid search brick"
+        assert daemon.stats.path_context_attach_failures == 1
+
+
 class TestBatchSearchZoneAttachment:
     """Round-4 gap: no test covered batch_search's path-context attach on
     a non-root zone. Mirror the attach logic here to guarantee the

--- a/tests/integration/bricks/search/test_daemon_context_attach.py
+++ b/tests/integration/bricks/search/test_daemon_context_attach.py
@@ -89,6 +89,86 @@ class TestAttachUsesCallerZone:
         assert results[0].context == "other-zone brick"
 
 
+class TestRealDaemonAttach:
+    """Round-4 follow-up: exercise the real SearchDaemon._attach_path_contexts
+    so regressions to the actual method can't hide behind a local stub.
+    """
+
+    @pytest.mark.asyncio
+    async def test_real_daemon_attach_falls_back_to_caller_zone(
+        self, cache: PathContextCache
+    ) -> None:
+        from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon
+
+        # Seed the "other" zone on the shared store — the root-zone rows the
+        # fixture already added must NOT be attached.
+        await cache._store.upsert("other", "reports", "Quarterly reports")
+
+        # Construct a daemon without running startup(); we only exercise
+        # _attach_path_contexts directly.
+        daemon = SearchDaemon.__new__(SearchDaemon)
+        daemon.config = DaemonConfig()
+        daemon._path_context_cache = cache
+        daemon._path_context_cache_by_loop = {}
+        daemon._path_context_engines_by_loop = {}
+
+        # stats is normally built in __init__; mint a minimal stand-in.
+        class _Stats:
+            path_context_attach_failures = 0
+            path_context_resolve_failures = 0
+
+        daemon.stats = _Stats()
+
+        from nexus.bricks.search.daemon import SearchResult
+
+        result = SearchResult(path="reports/q4.md", chunk_text="", score=0.9, zone_id=None)
+        await daemon._attach_path_contexts([result], zone_id="other")
+        assert result.context == "Quarterly reports"
+
+        # Control: same result, zone_id="root" -> no match (root has no
+        # rows under "reports/").
+        result2 = SearchResult(path="reports/q4.md", chunk_text="", score=0.9, zone_id=None)
+        await daemon._attach_path_contexts([result2], zone_id="root")
+        assert result2.context is None
+
+
+class TestBatchSearchZoneAttachment:
+    """Round-4 gap: no test covered batch_search's path-context attach on
+    a non-root zone. Mirror the attach logic here to guarantee the
+    effective_zone_id fallback survives future refactors.
+    """
+
+    @pytest.mark.asyncio
+    async def test_batch_search_attaches_non_root_zone_context(
+        self, cache: PathContextCache
+    ) -> None:
+        await cache._store.upsert("analytics", "dashboards", "BI dashboards")
+
+        # Mimic what daemon.batch_search does after backend_batch returns
+        # (see src/nexus/bricks/search/daemon.py batch_search).
+        effective_zone_id = "analytics"
+        backend_batch = [
+            [
+                BaseSearchResult(path="dashboards/revenue.md", chunk_text="", score=0.9),
+                BaseSearchResult(path="other/path.md", chunk_text="", score=0.5),
+            ],
+            [BaseSearchResult(path="dashboards/churn.md", chunk_text="", score=0.8)],
+        ]
+        await cache.refresh_if_stale(effective_zone_id)
+        records = cache.snapshot_zone(effective_zone_id)
+        assert records is not None
+
+        from nexus.bricks.search.path_context import lookup_in_records
+
+        for inner in backend_batch:
+            for r in inner:
+                r.context = lookup_in_records(records, r.path)
+
+        assert backend_batch[0][0].context == "BI dashboards"
+        assert backend_batch[0][1].context is None
+        assert backend_batch[1][0].context == "BI dashboards"
+
+
 class TestLoopLocalResolver:
     """Regression tests for ``SearchDaemon._resolve_path_context_cache``.
 
@@ -226,12 +306,12 @@ class TestGraphSearchContextAttachment:
         # to a local SearchDaemon-style helper powered by the cache.
         backend = SimpleNamespace(graph_search=_fake_graph_search)
 
-        async def _attach(results):
-            zones = {(r.zone_id or "root") for r in results}
+        async def _attach(results, *, zone_id=None):
+            zones = {(r.zone_id or zone_id or "root") for r in results}
             for zone in zones:
                 await cache.refresh_if_stale(zone)
             for r in results:
-                r.context = cache.lookup_cached(r.zone_id, r.path)
+                r.context = cache.lookup_cached(r.zone_id or zone_id, r.path)
 
         daemon = SimpleNamespace(_backend=backend, _attach_path_contexts=_attach)
 

--- a/tests/integration/bricks/search/test_daemon_context_attach.py
+++ b/tests/integration/bricks/search/test_daemon_context_attach.py
@@ -73,3 +73,25 @@ class TestAttachContextToResults:
         assert results[0].context == "Hybrid search brick"
         assert results[1].context == "Project documentation"
         assert results[2].context is None
+
+
+class TestSerializerEmitsContext:
+    def test_context_field_emitted_when_set(self) -> None:
+        from nexus.server.api.v2.routers.search import _serialize_search_result
+
+        r = BaseSearchResult(
+            path="src/nexus/bricks/search/fusion.py",
+            chunk_text="body",
+            score=0.9,
+            zone_id="root",
+        )
+        r.context = "Hybrid search brick"
+        out = _serialize_search_result(r)
+        assert out.get("context") == "Hybrid search brick"
+
+    def test_context_field_omitted_when_none(self) -> None:
+        from nexus.server.api.v2.routers.search import _serialize_search_result
+
+        r = BaseSearchResult(path="x", chunk_text="y", score=0.5)
+        out = _serialize_search_result(r)
+        assert "context" not in out

--- a/tests/integration/bricks/search/test_daemon_context_attach.py
+++ b/tests/integration/bricks/search/test_daemon_context_attach.py
@@ -175,6 +175,47 @@ class TestAttachStaleFallbackOnRefreshError:
         assert daemon.stats.path_context_attach_failures == 1
 
 
+class TestBatchSearchStaleFallback:
+    """Round-6 review: batch_search must respect the same fail-soft contract
+    as ``_attach_path_contexts`` — a transient refresh error should still
+    serve the last-known snapshot for the batch instead of erasing
+    context for every inner result list.
+    """
+
+    @pytest.mark.asyncio
+    async def test_batch_search_serves_stale_snapshot_on_refresh_error(
+        self, cache: PathContextCache
+    ) -> None:
+        from nexus.bricks.search.path_context import lookup_in_records
+
+        # Prime the cache: this simulates a prior batch having loaded the
+        # zone successfully.
+        await cache.refresh_if_stale("root")
+        records_before = cache.snapshot_zone("root")
+        assert records_before is not None
+
+        # Force a refresh failure on the next attempt.
+        async def boom(zone_id: str) -> tuple[int, object]:
+            raise RuntimeError("simulated DB brownout")
+
+        object.__setattr__(cache._store, "zone_fingerprint", boom)
+
+        # Emulate the batch_search attach block (daemon.py) — refresh inside
+        # its own try, then snapshot OUTSIDE so stale records still serve
+        # this batch.
+        failures = 0
+        try:
+            await cache.refresh_if_stale("root")
+        except Exception:
+            failures += 1
+        records = cache.snapshot_zone("root")
+        assert records is not None
+        assert failures == 1
+
+        hit = lookup_in_records(records, "src/nexus/bricks/search/fusion.py")
+        assert hit == "Hybrid search brick"
+
+
 class TestBatchSearchZoneAttachment:
     """Round-4 gap: no test covered batch_search's path-context attach on
     a non-root zone. Mirror the attach logic here to guarantee the

--- a/tests/integration/bricks/search/test_daemon_context_attach.py
+++ b/tests/integration/bricks/search/test_daemon_context_attach.py
@@ -45,6 +45,84 @@ class TestBaseSearchResultContextField:
         assert r.context is None
 
 
+class TestLoopLocalResolver:
+    """Regression tests for ``SearchDaemon._resolve_path_context_cache``.
+
+    Issue #3773: the resolver must return a distinct cache for each running
+    event loop so that asyncpg connections aren't shared cross-loop, and must
+    memoize per-loop so repeated lookups on one loop don't build a new engine.
+    """
+
+    @pytest.mark.asyncio
+    async def test_resolver_reuses_cache_within_loop(self, tmp_path) -> None:
+        import asyncio
+        import os
+
+        from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon
+
+        db_file = tmp_path / "ctx.db"
+        db_url = f"sqlite+aiosqlite:///{db_file}"
+        # Force the resolver down the loop-local code path by setting the URL.
+        os.environ.pop("DATABASE_URL", None)
+        daemon = SearchDaemon.__new__(SearchDaemon)
+        daemon.config = DaemonConfig(database_url=db_url)
+        daemon._path_context_cache = None
+        daemon._path_context_cache_by_loop = {}
+        daemon._path_context_engines_by_loop = {}
+
+        # Need the table first; create it through the same URL.
+        engine = create_async_engine(db_url, future=True)
+        async with engine.begin() as conn:
+            await conn.exec_driver_sql(CREATE_TABLE_SQL)
+        await engine.dispose()
+
+        cache1 = await daemon._resolve_path_context_cache()
+        cache2 = await daemon._resolve_path_context_cache()
+        assert cache1 is cache2  # same loop -> memoized
+        assert asyncio.get_running_loop() in daemon._path_context_cache_by_loop
+
+        # Dispose the engine we created so the tmp file releases cleanly.
+        for eng in list(daemon._path_context_engines_by_loop.values()):
+            await eng.dispose()
+
+    def test_resolver_builds_distinct_caches_per_loop(self, tmp_path) -> None:
+        """Run the resolver on two fresh asyncio loops and confirm the
+        daemon caches distinct instances keyed by loop."""
+        import asyncio
+
+        from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon
+
+        db_file = tmp_path / "ctx2.db"
+        db_url = f"sqlite+aiosqlite:///{db_file}"
+
+        # Create the table once up front.
+        async def _setup() -> None:
+            engine = create_async_engine(db_url, future=True)
+            async with engine.begin() as conn:
+                await conn.exec_driver_sql(CREATE_TABLE_SQL)
+            await engine.dispose()
+
+        asyncio.run(_setup())
+
+        daemon = SearchDaemon.__new__(SearchDaemon)
+        daemon.config = DaemonConfig(database_url=db_url)
+        daemon._path_context_cache = None
+        daemon._path_context_cache_by_loop = {}
+        daemon._path_context_engines_by_loop = {}
+
+        async def _resolve_once():
+            cache = await daemon._resolve_path_context_cache()
+            return cache
+
+        cache_a = asyncio.run(_resolve_once())
+        cache_b = asyncio.run(_resolve_once())
+        # Distinct caches because each asyncio.run creates a fresh loop.
+        assert cache_a is not cache_b
+        # Two loops tracked.
+        assert len(daemon._path_context_cache_by_loop) == 2
+        assert len(daemon._path_context_engines_by_loop) == 2
+
+
 class TestAttachContextToResults:
     @pytest.mark.asyncio
     async def test_attach_via_cache(self, cache: PathContextCache) -> None:

--- a/tests/integration/bricks/search/test_daemon_context_attach.py
+++ b/tests/integration/bricks/search/test_daemon_context_attach.py
@@ -1,0 +1,75 @@
+"""End-to-end: path contexts are attached to SearchResult instances (Issue #3773)."""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from nexus.bricks.search.path_context import PathContextCache, PathContextStore
+from nexus.bricks.search.results import BaseSearchResult
+
+CREATE_TABLE_SQL = """
+CREATE TABLE path_contexts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    zone_id TEXT NOT NULL DEFAULT 'root',
+    path_prefix TEXT NOT NULL,
+    description TEXT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(zone_id, path_prefix)
+)
+"""
+
+
+@pytest_asyncio.fixture
+async def cache():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.exec_driver_sql(CREATE_TABLE_SQL)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    store = PathContextStore(async_session_factory=factory, db_type="sqlite")
+    await store.upsert("root", "src/nexus/bricks/search", "Hybrid search brick")
+    await store.upsert("root", "docs", "Project documentation")
+    yield PathContextCache(store=store)
+    await engine.dispose()
+
+
+class TestBaseSearchResultContextField:
+    def test_default_context_is_none(self) -> None:
+        r = BaseSearchResult(path="x", chunk_text="y", score=0.5)
+        assert r.context is None
+
+
+class TestAttachContextToResults:
+    @pytest.mark.asyncio
+    async def test_attach_via_cache(self, cache: PathContextCache) -> None:
+        results = [
+            BaseSearchResult(
+                path="src/nexus/bricks/search/fusion.py",
+                chunk_text="",
+                score=0.9,
+                zone_id="root",
+            ),
+            BaseSearchResult(
+                path="docs/README.md",
+                chunk_text="",
+                score=0.8,
+                zone_id="root",
+            ),
+            BaseSearchResult(
+                path="scripts/noop.py",
+                chunk_text="",
+                score=0.7,
+                zone_id="root",
+            ),
+        ]
+        for r in results:
+            r.context = await cache.lookup(r.zone_id, r.path)
+        assert results[0].context == "Hybrid search brick"
+        assert results[1].context == "Project documentation"
+        assert results[2].context is None

--- a/tests/integration/bricks/search/test_federated_search.py
+++ b/tests/integration/bricks/search/test_federated_search.py
@@ -1027,3 +1027,40 @@ class TestResultToDictContextShape:
         r.context = "Some description"
         d = _result_to_dict(r)
         assert d["context"] == "Some description"
+
+    def test_strip_none_context_also_strips_plain_dicts(self) -> None:
+        """Round-6 review: RRF fusion dicts go through ``_strip_none_context``
+        directly (not via ``_result_to_dict``) because ``rrf_multi_fusion``
+        emits dicts built from ``__dataclass_fields__`` verbatim."""
+        from nexus.bricks.search.federated_search import _strip_none_context
+
+        assert _strip_none_context({"path": "a", "context": None}) == {"path": "a"}
+        assert _strip_none_context({"path": "a", "context": "x"}) == {
+            "path": "a",
+            "context": "x",
+        }
+
+
+class TestFederatedRRFContextShape:
+    """Round-6 review regression: with fusion_strategy=RRF, the dicts
+    produced by ``rrf_multi_fusion`` must not carry ``context: null`` —
+    shape must match the RAW_SCORE path.
+    """
+
+    def test_rrf_multi_fusion_dicts_stripped_of_none_context(self) -> None:
+        from nexus.bricks.search.federated_search import _strip_none_context
+        from nexus.bricks.search.fusion import rrf_multi_fusion
+
+        # Build two zones so rrf_multi_fusion runs (single-zone short-circuits).
+        zone_a = [_make_result("a.md", 0.9, zone_id="zone_a")]
+        zone_b = [_make_result("b.md", 0.8, zone_id="zone_b")]
+
+        raw = rrf_multi_fusion(
+            result_lists=[("zone_a", zone_a), ("zone_b", zone_b)],
+            k=60,
+            limit=10,
+            id_key="zone_qualified_path",
+        )
+        assert any(d.get("context") is None for d in raw)
+        stripped = [_strip_none_context(d) for d in raw]
+        assert all("context" not in d for d in stripped)

--- a/tests/integration/bricks/search/test_federated_search.py
+++ b/tests/integration/bricks/search/test_federated_search.py
@@ -1003,3 +1003,27 @@ class TestRemoteZoneSearch:
         assert len(resp.zones_failed) == 1
         assert resp.zones_failed[0].zone_id == "zone_dead"
         assert resp.results == []
+
+
+class TestResultToDictContextShape:
+    """Issue #3773 Round-5 review: federated dict payload must omit the
+    ``context`` key when unset so the response shape matches the
+    non-federated router (which gates on ``context is not None``).
+    Otherwise strict clients see the field appear/disappear based on the
+    ``federated=true`` flag."""
+
+    def test_result_to_dict_omits_context_when_none(self) -> None:
+        from nexus.bricks.search.federated_search import _result_to_dict
+
+        r = _make_result("a.md", 0.9, zone_id="root")
+        assert r.context is None
+        d = _result_to_dict(r)
+        assert "context" not in d
+
+    def test_result_to_dict_keeps_context_when_set(self) -> None:
+        from nexus.bricks.search.federated_search import _result_to_dict
+
+        r = _make_result("a.md", 0.9, zone_id="root")
+        r.context = "Some description"
+        d = _result_to_dict(r)
+        assert d["context"] == "Some description"

--- a/tests/integration/bricks/search/test_path_context.py
+++ b/tests/integration/bricks/search/test_path_context.py
@@ -188,6 +188,49 @@ class TestPathContextCacheLookup:
         await store.delete("root", "src")
         assert await cache.lookup("root", "src/x.py") is None
 
+    @pytest.mark.asyncio
+    async def test_refresh_after_delete_when_other_rows_remain(self, async_session_factory) -> None:
+        """Issue #3773 review regression: deleting a row below the zone MAX
+        previously left the cache serving the stale entry because the
+        freshness stamp (MAX(updated_at)) did not change. The fingerprint
+        token must also detect row removals.
+        """
+        from sqlalchemy import text
+
+        store = PathContextStore(async_session_factory=async_session_factory, db_type="sqlite")
+
+        # Seed two rows with distinct updated_at stamps and force the MAX onto
+        # the row we intend to KEEP. Raw SQL drives the timestamps so the
+        # test isn't flaky on same-millisecond writes.
+        await store.upsert("root", "docs", "old row")
+        await store.upsert("root", "docs/new", "keep row")
+        async with async_session_factory() as s:
+            await s.execute(
+                text(
+                    "UPDATE path_contexts SET updated_at = '2024-01-01 00:00:00' "
+                    "WHERE path_prefix = 'docs'"
+                )
+            )
+            await s.execute(
+                text(
+                    "UPDATE path_contexts SET updated_at = '2025-06-01 00:00:00' "
+                    "WHERE path_prefix = 'docs/new'"
+                )
+            )
+            await s.commit()
+
+        cache = PathContextCache(store=store)
+        await cache.refresh_if_stale("root")
+        assert cache.lookup_cached("root", "docs/readme.md") == "old row"
+
+        # Delete the OLDER row. MAX(updated_at) does not change because the
+        # newer row still holds the max. Pre-fix, the cache would not
+        # refresh and would keep serving "old row" against the deleted
+        # prefix.
+        await store.delete("root", "docs")
+        assert await cache.lookup("root", "docs/readme.md") is None
+        assert await cache.lookup("root", "docs/new/readme.md") == "keep row"
+
 
 class TestPathContextCacheBatchLookup:
     @pytest.mark.asyncio

--- a/tests/integration/bricks/search/test_path_context.py
+++ b/tests/integration/bricks/search/test_path_context.py
@@ -250,3 +250,24 @@ class TestPathContextCacheBatchLookup:
 
         assert cache.lookup_cached("root", "src/x.py") == "src desc"
         assert cache.lookup_cached("root", "no/match") is None
+
+
+class TestPathContextCacheLRU:
+    @pytest.mark.asyncio
+    async def test_lru_bound_evicts_oldest_zone(self, store: PathContextStore) -> None:
+        """With max_zones=2, the third distinct zone forces eviction of the
+        oldest — prevents the cache from growing without bound across many
+        short-lived zones (Issue #3773 review)."""
+        await store.upsert("z1", "src", "one")
+        await store.upsert("z2", "src", "two")
+        await store.upsert("z3", "src", "three")
+
+        cache = PathContextCache(store=store, max_zones=2)
+        await cache.refresh_if_stale("z1")
+        await cache.refresh_if_stale("z2")
+        assert set(cache._entries.keys()) == {"z1", "z2"}
+        await cache.refresh_if_stale("z3")
+        # z1 was oldest -> evicted. z2 and z3 remain.
+        assert set(cache._entries.keys()) == {"z2", "z3"}
+        # Lock for evicted zone also dropped.
+        assert "z1" not in cache._locks

--- a/tests/integration/bricks/search/test_path_context.py
+++ b/tests/integration/bricks/search/test_path_context.py
@@ -1,0 +1,98 @@
+"""Tests for path_contexts store and cache (Issue #3773)."""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from nexus.bricks.search.path_context import (
+    PathContextStore,
+)
+
+CREATE_TABLE_SQL = """
+CREATE TABLE path_contexts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    zone_id TEXT NOT NULL DEFAULT 'root',
+    path_prefix TEXT NOT NULL,
+    description TEXT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(zone_id, path_prefix)
+)
+"""
+
+
+@pytest_asyncio.fixture
+async def async_session_factory():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.exec_driver_sql(CREATE_TABLE_SQL)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    yield factory
+    await engine.dispose()
+
+
+@pytest_asyncio.fixture
+async def store(async_session_factory):
+    return PathContextStore(async_session_factory=async_session_factory, db_type="sqlite")
+
+
+class TestPathContextStoreUpsert:
+    @pytest.mark.asyncio
+    async def test_insert_then_read(self, store: PathContextStore) -> None:
+        await store.upsert("root", "src/nexus/bricks/search", "Hybrid search brick")
+        records = await store.list("root")
+        assert len(records) == 1
+        assert records[0].zone_id == "root"
+        assert records[0].path_prefix == "src/nexus/bricks/search"
+        assert records[0].description == "Hybrid search brick"
+
+    @pytest.mark.asyncio
+    async def test_upsert_replaces_description(self, store: PathContextStore) -> None:
+        await store.upsert("root", "src", "first")
+        await store.upsert("root", "src", "second")
+        records = await store.list("root")
+        assert len(records) == 1
+        assert records[0].description == "second"
+
+    @pytest.mark.asyncio
+    async def test_delete_returns_true_when_removed(self, store: PathContextStore) -> None:
+        await store.upsert("root", "src", "first")
+        assert await store.delete("root", "src") is True
+        assert await store.list("root") == []
+
+    @pytest.mark.asyncio
+    async def test_delete_returns_false_when_missing(self, store: PathContextStore) -> None:
+        assert await store.delete("root", "nonexistent") is False
+
+    @pytest.mark.asyncio
+    async def test_zones_are_isolated(self, store: PathContextStore) -> None:
+        await store.upsert("root", "src", "root desc")
+        await store.upsert("other", "src", "other desc")
+        root = await store.list("root")
+        other = await store.list("other")
+        assert len(root) == 1 and root[0].description == "root desc"
+        assert len(other) == 1 and other[0].description == "other desc"
+
+    @pytest.mark.asyncio
+    async def test_list_all_zones(self, store: PathContextStore) -> None:
+        await store.upsert("root", "a", "a")
+        await store.upsert("other", "b", "b")
+        records = await store.list(zone_id=None)
+        assert len(records) == 2
+
+    @pytest.mark.asyncio
+    async def test_max_updated_at_tracks_writes(self, store: PathContextStore) -> None:
+        assert await store.max_updated_at("root") is None
+        await store.upsert("root", "src", "first")
+        stamp1 = await store.max_updated_at("root")
+        assert stamp1 is not None
+        await store.upsert("root", "src", "second")
+        stamp2 = await store.max_updated_at("root")
+        assert stamp2 is not None
+        assert stamp2 >= stamp1

--- a/tests/integration/bricks/search/test_path_context.py
+++ b/tests/integration/bricks/search/test_path_context.py
@@ -62,6 +62,35 @@ class TestPathContextStoreUpsert:
         assert records[0].description == "second"
 
     @pytest.mark.asyncio
+    async def test_upsert_preserves_row_id(self, async_session_factory) -> None:
+        """Upsert must do ON CONFLICT DO UPDATE, not DELETE+INSERT (Issue #3773
+        review): row id stays stable so future FKs/audit trails don't break."""
+        from sqlalchemy import text
+
+        store = PathContextStore(async_session_factory=async_session_factory, db_type="sqlite")
+        await store.upsert("root", "src", "first")
+        async with async_session_factory() as s:
+            first_id = (
+                await s.execute(
+                    text(
+                        "SELECT id FROM path_contexts "
+                        "WHERE zone_id = 'root' AND path_prefix = 'src'"
+                    )
+                )
+            ).scalar()
+        await store.upsert("root", "src", "second")
+        async with async_session_factory() as s:
+            second_id = (
+                await s.execute(
+                    text(
+                        "SELECT id FROM path_contexts "
+                        "WHERE zone_id = 'root' AND path_prefix = 'src'"
+                    )
+                )
+            ).scalar()
+        assert first_id == second_id
+
+    @pytest.mark.asyncio
     async def test_delete_returns_true_when_removed(self, store: PathContextStore) -> None:
         await store.upsert("root", "src", "first")
         assert await store.delete("root", "src") is True

--- a/tests/integration/bricks/search/test_path_context.py
+++ b/tests/integration/bricks/search/test_path_context.py
@@ -252,6 +252,29 @@ class TestPathContextCacheBatchLookup:
         assert cache.lookup_cached("root", "no/match") is None
 
 
+class TestDaemonConfigMaxZonesWiring:
+    """Round-4 gap: verify DaemonConfig.path_context_max_zones actually
+    reaches PathContextCache — neither the default nor the env override
+    had test coverage before this."""
+
+    def test_default_path_context_max_zones(self) -> None:
+        from nexus.bricks.search.daemon import DaemonConfig
+
+        assert DaemonConfig().path_context_max_zones == 2048
+
+    def test_custom_path_context_max_zones(self) -> None:
+        from nexus.bricks.search.daemon import DaemonConfig
+
+        assert DaemonConfig(path_context_max_zones=42).path_context_max_zones == 42
+
+    @pytest.mark.asyncio
+    async def test_cache_honors_max_zones_from_config(self, store: PathContextStore) -> None:
+        """The cache must respect the value plumbed from DaemonConfig so
+        operator-tuned values actually take effect at the cache level."""
+        cache = PathContextCache(store=store, max_zones=3)
+        assert cache._max_zones == 3
+
+
 class TestPathContextCacheLRU:
     @pytest.mark.asyncio
     async def test_lru_bound_evicts_oldest_zone(self, store: PathContextStore) -> None:

--- a/tests/integration/bricks/search/test_path_context.py
+++ b/tests/integration/bricks/search/test_path_context.py
@@ -158,3 +158,23 @@ class TestPathContextCacheLookup:
         assert await cache.lookup("root", "src/x.py") == "first"
         await store.delete("root", "src")
         assert await cache.lookup("root", "src/x.py") is None
+
+
+class TestPathContextCacheBatchLookup:
+    @pytest.mark.asyncio
+    async def test_lookup_cached_does_not_hit_db(
+        self, store: PathContextStore, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """lookup_cached is pure in-memory; it must NOT call store methods."""
+        await store.upsert("root", "src", "src desc")
+        cache = PathContextCache(store=store)
+        await cache.refresh_if_stale("root")
+
+        # Replace the store's max_updated_at with a trap — any call fails.
+        async def trap(zone_id: str) -> None:
+            raise AssertionError("lookup_cached must not invoke max_updated_at")
+
+        monkeypatch.setattr(store, "max_updated_at", trap)
+
+        assert cache.lookup_cached("root", "src/x.py") == "src desc"
+        assert cache.lookup_cached("root", "no/match") is None

--- a/tests/integration/bricks/search/test_path_context.py
+++ b/tests/integration/bricks/search/test_path_context.py
@@ -11,6 +11,7 @@ from sqlalchemy.ext.asyncio import (
 )
 
 from nexus.bricks.search.path_context import (
+    PathContextCache,
     PathContextStore,
 )
 
@@ -96,3 +97,64 @@ class TestPathContextStoreUpsert:
         stamp2 = await store.max_updated_at("root")
         assert stamp2 is not None
         assert stamp2 >= stamp1
+
+
+class TestPathContextCacheLookup:
+    @pytest.mark.asyncio
+    async def test_longest_prefix_wins(self, store: PathContextStore) -> None:
+        await store.upsert("root", "src", "top-level src")
+        await store.upsert("root", "src/nexus/bricks/search", "search brick")
+        cache = PathContextCache(store=store)
+        desc = await cache.lookup("root", "src/nexus/bricks/search/fusion.py")
+        assert desc == "search brick"
+
+    @pytest.mark.asyncio
+    async def test_empty_prefix_matches_any(self, store: PathContextStore) -> None:
+        await store.upsert("root", "", "zone root fallback")
+        cache = PathContextCache(store=store)
+        assert await cache.lookup("root", "anything/x.py") == "zone root fallback"
+
+    @pytest.mark.asyncio
+    async def test_slash_boundary_enforced(self, store: PathContextStore) -> None:
+        """'src' must NOT match 'srcfoo/x.py' — only slash-bounded match."""
+        await store.upsert("root", "src", "src only")
+        cache = PathContextCache(store=store)
+        assert await cache.lookup("root", "srcfoo/x.py") is None
+        assert await cache.lookup("root", "src/x.py") == "src only"
+        assert await cache.lookup("root", "src") == "src only"
+
+    @pytest.mark.asyncio
+    async def test_no_match_returns_none(self, store: PathContextStore) -> None:
+        cache = PathContextCache(store=store)
+        assert await cache.lookup("root", "anything/x.py") is None
+
+    @pytest.mark.asyncio
+    async def test_zone_none_coerces_to_root(self, store: PathContextStore) -> None:
+        await store.upsert("root", "src", "root src")
+        cache = PathContextCache(store=store)
+        assert await cache.lookup(None, "src/x.py") == "root src"
+
+    @pytest.mark.asyncio
+    async def test_zones_isolated_in_cache(self, store: PathContextStore) -> None:
+        await store.upsert("root", "src", "root src")
+        await store.upsert("other", "src", "other src")
+        cache = PathContextCache(store=store)
+        assert await cache.lookup("root", "src/x.py") == "root src"
+        assert await cache.lookup("other", "src/x.py") == "other src"
+
+    @pytest.mark.asyncio
+    async def test_refresh_after_write(self, store: PathContextStore) -> None:
+        cache = PathContextCache(store=store)
+        assert await cache.lookup("root", "src/x.py") is None
+        await store.upsert("root", "src", "first desc")
+        assert await cache.lookup("root", "src/x.py") == "first desc"
+        await store.upsert("root", "src", "second desc")
+        assert await cache.lookup("root", "src/x.py") == "second desc"
+
+    @pytest.mark.asyncio
+    async def test_refresh_after_delete(self, store: PathContextStore) -> None:
+        await store.upsert("root", "src", "first")
+        cache = PathContextCache(store=store)
+        assert await cache.lookup("root", "src/x.py") == "first"
+        await store.delete("root", "src")
+        assert await cache.lookup("root", "src/x.py") is None

--- a/tests/integration/bricks/search/test_path_context.py
+++ b/tests/integration/bricks/search/test_path_context.py
@@ -269,5 +269,7 @@ class TestPathContextCacheLRU:
         await cache.refresh_if_stale("z3")
         # z1 was oldest -> evicted. z2 and z3 remain.
         assert set(cache._entries.keys()) == {"z2", "z3"}
-        # Lock for evicted zone also dropped.
-        assert "z1" not in cache._locks
+        # Locks are intentionally kept alive across eviction — see Round-3
+        # review feedback. Re-accessing z1 creates a fresh entry using the
+        # same Lock object, preserving mutual-exclusion identity.
+        assert "z1" in cache._locks

--- a/tests/integration/bricks/search/test_path_context.py
+++ b/tests/integration/bricks/search/test_path_context.py
@@ -275,6 +275,38 @@ class TestDaemonConfigMaxZonesWiring:
         assert cache._max_zones == 3
 
 
+class TestPathContextCacheLocksCap:
+    """Round-8 review regression: zone_id is client-controlled via the
+    ``X-Nexus-Zone-ID`` header. The per-zone ``asyncio.Lock`` dict is
+    intentionally not LRU-evicted (Round-3 identity guarantee), but an
+    authenticated caller could still churn unique zone_ids and inflate
+    ``_locks`` without bound. Bound the dict by dropping non-held locks
+    once it exceeds a safe multiple of ``max_zones``."""
+
+    @pytest.mark.asyncio
+    async def test_locks_dict_bounded_by_cap(self, store: PathContextStore) -> None:
+        cache = PathContextCache(store=store, max_zones=4)
+        for i in range(40):
+            cache._lock_for(f"z{i}")
+        # Cap from source: max(_max_zones * 4, 16) => 16. Tolerate +1 because
+        # the newest lock is retained even when it tips over the cap.
+        assert len(cache._locks) <= 17
+
+    @pytest.mark.asyncio
+    async def test_locks_dict_preserves_currently_held_locks(self, store: PathContextStore) -> None:
+        """Round-3 identity guarantee must survive Round-8 cap logic: any
+        lock currently ``locked()`` must NOT be dropped by the cap."""
+        cache = PathContextCache(store=store, max_zones=4)
+        held = cache._lock_for("hot_zone")
+        await held.acquire()
+        try:
+            for i in range(80):
+                cache._lock_for(f"z{i}")
+            assert cache._locks.get("hot_zone") is held
+        finally:
+            held.release()
+
+
 class TestPathContextCacheLRU:
     @pytest.mark.asyncio
     async def test_lru_bound_evicts_oldest_zone(self, store: PathContextStore) -> None:

--- a/tests/integration/bricks/search/test_rrf_bonus.py
+++ b/tests/integration/bricks/search/test_rrf_bonus.py
@@ -9,6 +9,7 @@ from nexus.bricks.search.fusion import (
     RRF_TOP1_BONUS,
     RRF_TOP3_BONUS,
     rrf_fusion,
+    rrf_multi_fusion,
     rrf_weighted_fusion,
 )
 
@@ -94,4 +95,43 @@ class TestRrfWeightedBonus:
             kw, vec, alpha=0.5, k=60, limit=10, id_key=None, top_rank_bonus=False
         )
         expected = 0.5 * (1.0 / 61) + 0.5 * (1.0 / 61)
+        assert abs(results[0]["score"] - expected) < 1e-9
+
+
+class TestRrfMultiBonus:
+    def test_multi_top1_gets_bonus_from_any_source(self) -> None:
+        """rrf_multi_fusion: best rank across all sources drives bonus."""
+        lists = [
+            (
+                "keyword",
+                [
+                    {"path": "perfect.txt", "chunk_index": 0, "score": 1.0},
+                    {"path": "other.txt", "chunk_index": 0, "score": 1.0},
+                ],
+            ),
+            (
+                "vector",
+                [
+                    {"path": "unrelated.txt", "chunk_index": 0, "score": 1.0},
+                    {"path": "other.txt", "chunk_index": 0, "score": 1.0},
+                ],
+            ),
+            (
+                "splade",
+                [{"path": "perfect.txt", "chunk_index": 0, "score": 1.0}],
+            ),
+        ]
+        results = rrf_multi_fusion(lists, k=60, limit=10, id_key=None)
+        # "perfect.txt" is rank 1 in keyword + splade -> gets TOP1 bonus.
+        perfect = next(r for r in results if r["path"] == "perfect.txt")
+        expected = (1.0 / 61) + (1.0 / 61) + RRF_TOP1_BONUS
+        assert abs(perfect["score"] - expected) < 1e-9
+
+    def test_multi_bonus_disabled(self) -> None:
+        lists = [
+            ("keyword", [{"path": "a.txt", "chunk_index": 0, "score": 1.0}]),
+            ("vector", [{"path": "a.txt", "chunk_index": 0, "score": 1.0}]),
+        ]
+        results = rrf_multi_fusion(lists, k=60, limit=10, id_key=None, top_rank_bonus=False)
+        expected = 2 * (1.0 / 61)
         assert abs(results[0]["score"] - expected) < 1e-9

--- a/tests/integration/bricks/search/test_rrf_bonus.py
+++ b/tests/integration/bricks/search/test_rrf_bonus.py
@@ -1,0 +1,76 @@
+"""Tests for RRF top-rank bonus (Issue #3773).
+
+Verifies that documents ranked #1 in any input list get a +0.05 bonus
+and those ranked #2-3 get +0.02, preventing dilution of perfect matches
+across multi-source / query-expanded fusion.
+"""
+
+from nexus.bricks.search.fusion import (
+    RRF_TOP1_BONUS,
+    RRF_TOP3_BONUS,
+    rrf_fusion,
+)
+
+
+class TestRrfTop1Bonus:
+    def test_top1_keyword_only_beats_mediocre_both(self) -> None:
+        """Issue #3773 scenario: #1 in keyword but absent from vector
+        beats #3 in both without the bonus."""
+        kw = [
+            {"path": "perfect.txt", "chunk_index": 0, "score": 10.0},  # rank 1
+            {"path": "x.txt", "chunk_index": 0, "score": 1.0},
+            {"path": "mediocre.txt", "chunk_index": 0, "score": 0.5},  # rank 3
+        ]
+        vec = [
+            {"path": "y.txt", "chunk_index": 0, "score": 0.9},
+            {"path": "z.txt", "chunk_index": 0, "score": 0.8},
+            {"path": "mediocre.txt", "chunk_index": 0, "score": 0.5},  # rank 3
+        ]
+        results = rrf_fusion(kw, vec, k=60, limit=10, id_key=None)
+        ranked_paths = [r["path"] for r in results]
+        assert ranked_paths.index("perfect.txt") < ranked_paths.index("mediocre.txt")
+
+    def test_bonus_disabled_preserves_legacy_behavior(self) -> None:
+        kw = [
+            {"path": "perfect.txt", "chunk_index": 0, "score": 10.0},
+            {"path": "x.txt", "chunk_index": 0, "score": 1.0},
+            {"path": "mediocre.txt", "chunk_index": 0, "score": 0.5},
+        ]
+        vec = [
+            {"path": "y.txt", "chunk_index": 0, "score": 0.9},
+            {"path": "z.txt", "chunk_index": 0, "score": 0.8},
+            {"path": "mediocre.txt", "chunk_index": 0, "score": 0.5},
+        ]
+        results = rrf_fusion(kw, vec, k=60, limit=10, id_key=None, top_rank_bonus=False)
+        ranked_paths = [r["path"] for r in results]
+        # Without bonus, mediocre (in both) outranks perfect (single list).
+        assert ranked_paths.index("mediocre.txt") < ranked_paths.index("perfect.txt")
+
+    def test_rank1_receives_top1_bonus(self) -> None:
+        """Single-doc fusion: score == 2 * 1/(k+1) + RRF_TOP1_BONUS."""
+        kw = [{"path": "only.txt", "chunk_index": 0, "score": 1.0}]
+        vec = [{"path": "only.txt", "chunk_index": 0, "score": 1.0}]
+        results = rrf_fusion(kw, vec, k=60, limit=10, id_key=None)
+        assert len(results) == 1
+        expected = (1.0 / 61) + (1.0 / 61) + RRF_TOP1_BONUS
+        assert abs(results[0]["score"] - expected) < 1e-9
+
+    def test_rank3_receives_top3_bonus(self) -> None:
+        """Doc at rank 3 in keyword only: 1/(k+3) + RRF_TOP3_BONUS."""
+        kw = [
+            {"path": "a.txt", "chunk_index": 0, "score": 1.0},
+            {"path": "b.txt", "chunk_index": 0, "score": 1.0},
+            {"path": "c.txt", "chunk_index": 0, "score": 1.0},
+        ]
+        vec: list[dict] = []
+        results = rrf_fusion(kw, vec, k=60, limit=10, id_key=None)
+        c_result = next(r for r in results if r["path"] == "c.txt")
+        expected = (1.0 / 63) + RRF_TOP3_BONUS
+        assert abs(c_result["score"] - expected) < 1e-9
+
+    def test_rank4_receives_no_bonus(self) -> None:
+        kw = [{"path": f"r{i}.txt", "chunk_index": 0, "score": 1.0} for i in range(5)]
+        results = rrf_fusion(kw, [], k=60, limit=10, id_key=None)
+        r4 = next(r for r in results if r["path"] == "r3.txt")  # zero-indexed -> rank 4
+        expected = 1.0 / 64
+        assert abs(r4["score"] - expected) < 1e-9

--- a/tests/integration/bricks/search/test_rrf_bonus.py
+++ b/tests/integration/bricks/search/test_rrf_bonus.py
@@ -100,6 +100,28 @@ class TestRrfWeightedBonus:
         expected = 0.5 * (1.0 / 61) + 0.5 * (1.0 / 61)
         assert abs(results[0]["score"] - expected) < 1e-9
 
+    def test_alpha_zero_vector_rank1_gets_no_bonus(self) -> None:
+        """alpha=0 means vector has zero weight; a vector rank-1 doc absent
+        from keyword results must NOT receive the top-rank bonus (Issue #3773
+        review)."""
+        kw = [{"path": "kw_only.txt", "chunk_index": 0, "score": 1.0}]
+        vec = [{"path": "vec_only.txt", "chunk_index": 0, "score": 1.0}]
+        results = rrf_weighted_fusion(kw, vec, alpha=0.0, k=60, limit=10, id_key=None)
+        by_path = {r["path"]: r["score"] for r in results}
+        # kw_only gets full keyword weight + bonus.
+        assert abs(by_path["kw_only.txt"] - (1.0 * (1.0 / 61) + RRF_TOP1_BONUS)) < 1e-9
+        # vec_only has zero weight and must NOT receive the bonus.
+        assert by_path["vec_only.txt"] == 0.0
+
+    def test_alpha_one_keyword_rank1_gets_no_bonus(self) -> None:
+        """alpha=1 means keyword has zero weight; symmetric to the above."""
+        kw = [{"path": "kw_only.txt", "chunk_index": 0, "score": 1.0}]
+        vec = [{"path": "vec_only.txt", "chunk_index": 0, "score": 1.0}]
+        results = rrf_weighted_fusion(kw, vec, alpha=1.0, k=60, limit=10, id_key=None)
+        by_path = {r["path"]: r["score"] for r in results}
+        assert abs(by_path["vec_only.txt"] - (1.0 * (1.0 / 61) + RRF_TOP1_BONUS)) < 1e-9
+        assert by_path["kw_only.txt"] == 0.0
+
 
 class TestRrfMultiBonus:
     def test_multi_top1_gets_bonus_from_any_source(self) -> None:

--- a/tests/integration/bricks/search/test_rrf_bonus.py
+++ b/tests/integration/bricks/search/test_rrf_bonus.py
@@ -8,6 +8,9 @@ across multi-source / query-expanded fusion.
 from nexus.bricks.search.fusion import (
     RRF_TOP1_BONUS,
     RRF_TOP3_BONUS,
+    FusionConfig,
+    FusionMethod,
+    fuse_results,
     rrf_fusion,
     rrf_multi_fusion,
     rrf_weighted_fusion,
@@ -134,4 +137,29 @@ class TestRrfMultiBonus:
         ]
         results = rrf_multi_fusion(lists, k=60, limit=10, id_key=None, top_rank_bonus=False)
         expected = 2 * (1.0 / 61)
+        assert abs(results[0]["score"] - expected) < 1e-9
+
+
+class TestFuseResultsConfigFlag:
+    def test_fuse_results_passes_top_rank_bonus_false(self) -> None:
+        kw = [{"path": "a.txt", "chunk_index": 0, "score": 1.0}]
+        vec = [{"path": "a.txt", "chunk_index": 0, "score": 1.0}]
+        config = FusionConfig(method=FusionMethod.RRF, top_rank_bonus=False)
+        results = fuse_results(kw, vec, config=config, limit=10, id_key=None)
+        expected = 2 * (1.0 / 61)
+        assert abs(results[0]["score"] - expected) < 1e-9
+
+    def test_fuse_results_default_applies_bonus(self) -> None:
+        kw = [{"path": "a.txt", "chunk_index": 0, "score": 1.0}]
+        vec = [{"path": "a.txt", "chunk_index": 0, "score": 1.0}]
+        results = fuse_results(kw, vec, config=None, limit=10, id_key=None)
+        expected = 2 * (1.0 / 61) + RRF_TOP1_BONUS
+        assert abs(results[0]["score"] - expected) < 1e-9
+
+    def test_fuse_results_weighted_respects_flag(self) -> None:
+        kw = [{"path": "a.txt", "chunk_index": 0, "score": 1.0}]
+        vec = [{"path": "a.txt", "chunk_index": 0, "score": 1.0}]
+        config = FusionConfig(method=FusionMethod.RRF_WEIGHTED, top_rank_bonus=False)
+        results = fuse_results(kw, vec, config=config, limit=10, id_key=None)
+        expected = 0.5 * (1.0 / 61) + 0.5 * (1.0 / 61)
         assert abs(results[0]["score"] - expected) < 1e-9

--- a/tests/integration/bricks/search/test_rrf_bonus.py
+++ b/tests/integration/bricks/search/test_rrf_bonus.py
@@ -9,6 +9,7 @@ from nexus.bricks.search.fusion import (
     RRF_TOP1_BONUS,
     RRF_TOP3_BONUS,
     rrf_fusion,
+    rrf_weighted_fusion,
 )
 
 
@@ -74,3 +75,23 @@ class TestRrfTop1Bonus:
         r4 = next(r for r in results if r["path"] == "r3.txt")  # zero-indexed -> rank 4
         expected = 1.0 / 64
         assert abs(r4["score"] - expected) < 1e-9
+
+
+class TestRrfWeightedBonus:
+    def test_weighted_top1_gets_bonus(self) -> None:
+        """rrf_weighted_fusion also applies the top-rank bonus."""
+        kw = [{"path": "only.txt", "chunk_index": 0, "score": 1.0}]
+        vec = [{"path": "only.txt", "chunk_index": 0, "score": 1.0}]
+        results = rrf_weighted_fusion(kw, vec, alpha=0.5, k=60, limit=10, id_key=None)
+        # alpha=0.5, rank=1 in both: 0.5*(1/61) + 0.5*(1/61) + RRF_TOP1_BONUS
+        expected = 0.5 * (1.0 / 61) + 0.5 * (1.0 / 61) + RRF_TOP1_BONUS
+        assert abs(results[0]["score"] - expected) < 1e-9
+
+    def test_weighted_bonus_disabled(self) -> None:
+        kw = [{"path": "only.txt", "chunk_index": 0, "score": 1.0}]
+        vec = [{"path": "only.txt", "chunk_index": 0, "score": 1.0}]
+        results = rrf_weighted_fusion(
+            kw, vec, alpha=0.5, k=60, limit=10, id_key=None, top_rank_bonus=False
+        )
+        expected = 0.5 * (1.0 / 61) + 0.5 * (1.0 / 61)
+        assert abs(results[0]["score"] - expected) < 1e-9

--- a/tests/integration/server/api/v2/routers/test_path_contexts_router.py
+++ b/tests/integration/server/api/v2/routers/test_path_contexts_router.py
@@ -40,8 +40,14 @@ async def test_app():
     app.state.path_context_store = store
     app.include_router(path_contexts_router)
 
+    from nexus.server.api.v2.routers.path_contexts import _get_store
     from nexus.server.dependencies import require_admin, require_auth
 
+    # Bypass loop-local resolution; always use the fixture's store.
+    async def _override_store() -> PathContextStore:
+        return store
+
+    app.dependency_overrides[_get_store] = _override_store
     app.dependency_overrides[require_auth] = lambda: {
         "subject_id": "tester",
         "zone_id": "root",
@@ -150,3 +156,21 @@ class TestPathContextRouter:
     def test_list_requires_auth_only(self, client: TestClient) -> None:
         r = client.get("/api/v2/path-contexts/")
         assert r.status_code == 200
+
+    def test_non_admin_rejected_for_other_zone_query(self, test_app: FastAPI) -> None:
+        """Non-admin caller cannot pass zone_id different from their own
+        (Issue #3773 review feedback)."""
+        from nexus.server.dependencies import require_auth
+
+        test_app.dependency_overrides[require_auth] = lambda: {
+            "subject_id": "non-admin",
+            "zone_id": "root",
+            "is_admin": False,
+        }
+        with TestClient(test_app) as c:
+            # Explicit foreign zone: 403.
+            r = c.get("/api/v2/path-contexts/", params={"zone_id": "other"})
+            assert r.status_code == 403
+            # Own zone or implicit: allowed.
+            assert c.get("/api/v2/path-contexts/", params={"zone_id": "root"}).status_code == 200
+            assert c.get("/api/v2/path-contexts/").status_code == 200

--- a/tests/integration/server/api/v2/routers/test_path_contexts_router.py
+++ b/tests/integration/server/api/v2/routers/test_path_contexts_router.py
@@ -132,6 +132,15 @@ class TestPathContextRouter:
         )
         assert r.status_code == 422 or r.status_code == 400
 
+    def test_put_rejects_double_slash(self, client: TestClient) -> None:
+        """Round-6 review: ``src//bricks`` stored verbatim would silently
+        never match any real path, violating principle of least surprise."""
+        r = client.put(
+            "/api/v2/path-contexts/",
+            json={"zone_id": "root", "path_prefix": "src//bricks", "description": "x"},
+        )
+        assert r.status_code == 422 or r.status_code == 400
+
     def test_non_admin_cannot_write(self, test_app: FastAPI) -> None:
         from fastapi import HTTPException
 

--- a/tests/integration/server/api/v2/routers/test_path_contexts_router.py
+++ b/tests/integration/server/api/v2/routers/test_path_contexts_router.py
@@ -141,6 +141,34 @@ class TestPathContextRouter:
         )
         assert r.status_code == 422 or r.status_code == 400
 
+    def test_put_rejects_null_byte_in_prefix(self, client: TestClient) -> None:
+        """Round-8 review: NULL bytes trip asyncpg and never appear in
+        real filesystem paths — reject at the validator boundary so the
+        router returns 4xx instead of 500."""
+        r = client.put(
+            "/api/v2/path-contexts/",
+            json={"zone_id": "root", "path_prefix": "src\x00evil", "description": "x"},
+        )
+        assert r.status_code in (400, 422)
+
+    def test_put_rejects_control_chars_in_prefix(self, client: TestClient) -> None:
+        """Round-8 review: tab/newline/CR in prefixes never match real
+        paths — silently unreachable rule."""
+        r = client.put(
+            "/api/v2/path-contexts/",
+            json={"zone_id": "root", "path_prefix": "src\tbricks", "description": "x"},
+        )
+        assert r.status_code in (400, 422)
+
+    def test_put_rejects_zero_width_in_prefix(self, client: TestClient) -> None:
+        """Round-8 review: U+200B produces visually-identical but distinct
+        rows — admin can't tell them apart and lookups silently miss."""
+        r = client.put(
+            "/api/v2/path-contexts/",
+            json={"zone_id": "root", "path_prefix": "src\u200bbricks", "description": "x"},
+        )
+        assert r.status_code in (400, 422)
+
     def test_non_admin_cannot_write(self, test_app: FastAPI) -> None:
         from fastapi import HTTPException
 

--- a/tests/integration/server/api/v2/routers/test_path_contexts_router.py
+++ b/tests/integration/server/api/v2/routers/test_path_contexts_router.py
@@ -1,0 +1,152 @@
+"""Tests for /api/v2/path-contexts router (Issue #3773)."""
+
+from __future__ import annotations
+
+import pytest
+import pytest_asyncio
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy.ext.asyncio import (
+    AsyncSession,
+    async_sessionmaker,
+    create_async_engine,
+)
+
+from nexus.bricks.search.path_context import PathContextStore
+from nexus.server.api.v2.routers.path_contexts import router as path_contexts_router
+
+CREATE_TABLE_SQL = """
+CREATE TABLE path_contexts (
+    id INTEGER PRIMARY KEY AUTOINCREMENT,
+    zone_id TEXT NOT NULL DEFAULT 'root',
+    path_prefix TEXT NOT NULL,
+    description TEXT NOT NULL,
+    created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    UNIQUE(zone_id, path_prefix)
+)
+"""
+
+
+@pytest_asyncio.fixture
+async def test_app():
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:", future=True)
+    async with engine.begin() as conn:
+        await conn.exec_driver_sql(CREATE_TABLE_SQL)
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+    store = PathContextStore(async_session_factory=factory, db_type="sqlite")
+
+    app = FastAPI()
+    app.state.path_context_store = store
+    app.include_router(path_contexts_router)
+
+    from nexus.server.dependencies import require_admin, require_auth
+
+    app.dependency_overrides[require_auth] = lambda: {
+        "subject_id": "tester",
+        "zone_id": "root",
+        "is_admin": False,
+    }
+    app.dependency_overrides[require_admin] = lambda: {
+        "subject_id": "admin",
+        "zone_id": "root",
+        "is_admin": True,
+    }
+    yield app
+    await engine.dispose()
+
+
+@pytest.fixture
+def client(test_app: FastAPI) -> TestClient:
+    return TestClient(test_app)
+
+
+class TestPathContextRouter:
+    def test_put_upsert_then_list(self, client: TestClient) -> None:
+        r = client.put(
+            "/api/v2/path-contexts/",
+            json={
+                "zone_id": "root",
+                "path_prefix": "src/nexus/bricks/search",
+                "description": "Search brick",
+            },
+        )
+        assert r.status_code == 200, r.text
+        r = client.get("/api/v2/path-contexts/", params={"zone_id": "root"})
+        assert r.status_code == 200
+        body = r.json()
+        assert len(body["contexts"]) == 1
+        assert body["contexts"][0]["description"] == "Search brick"
+
+    def test_put_replaces(self, client: TestClient) -> None:
+        client.put(
+            "/api/v2/path-contexts/",
+            json={"zone_id": "root", "path_prefix": "src", "description": "first"},
+        )
+        client.put(
+            "/api/v2/path-contexts/",
+            json={"zone_id": "root", "path_prefix": "src", "description": "second"},
+        )
+        body = client.get("/api/v2/path-contexts/").json()
+        assert len(body["contexts"]) == 1
+        assert body["contexts"][0]["description"] == "second"
+
+    def test_delete_removes(self, client: TestClient) -> None:
+        client.put(
+            "/api/v2/path-contexts/",
+            json={"zone_id": "root", "path_prefix": "src", "description": "x"},
+        )
+        r = client.delete(
+            "/api/v2/path-contexts/",
+            params={"zone_id": "root", "path_prefix": "src"},
+        )
+        assert r.status_code == 200
+        body = client.get("/api/v2/path-contexts/").json()
+        assert body["contexts"] == []
+
+    def test_delete_missing_returns_404(self, client: TestClient) -> None:
+        r = client.delete(
+            "/api/v2/path-contexts/",
+            params={"zone_id": "root", "path_prefix": "nonexistent"},
+        )
+        assert r.status_code == 404
+
+    def test_put_normalizes_prefix(self, client: TestClient) -> None:
+        client.put(
+            "/api/v2/path-contexts/",
+            json={"zone_id": "root", "path_prefix": "/src/", "description": "x"},
+        )
+        body = client.get("/api/v2/path-contexts/").json()
+        assert body["contexts"][0]["path_prefix"] == "src"
+
+    def test_put_rejects_traversal(self, client: TestClient) -> None:
+        r = client.put(
+            "/api/v2/path-contexts/",
+            json={"zone_id": "root", "path_prefix": "src/../etc", "description": "x"},
+        )
+        assert r.status_code == 422 or r.status_code == 400
+
+    def test_non_admin_cannot_write(self, test_app: FastAPI) -> None:
+        from fastapi import HTTPException
+
+        from nexus.server.dependencies import require_admin
+
+        def _reject() -> None:
+            raise HTTPException(status_code=403, detail="admin required")
+
+        test_app.dependency_overrides[require_admin] = _reject
+        with TestClient(test_app) as c:
+            r = c.put(
+                "/api/v2/path-contexts/",
+                json={"zone_id": "root", "path_prefix": "src", "description": "x"},
+            )
+            assert r.status_code == 403
+            r = c.delete(
+                "/api/v2/path-contexts/",
+                params={"zone_id": "root", "path_prefix": "src"},
+            )
+            assert r.status_code == 403
+
+    def test_list_requires_auth_only(self, client: TestClient) -> None:
+        r = client.get("/api/v2/path-contexts/")
+        assert r.status_code == 200

--- a/tests/unit/cli/test_path_context_cli.py
+++ b/tests/unit/cli/test_path_context_cli.py
@@ -1,0 +1,132 @@
+"""Tests for `nexus path-context` CLI commands (Issue #3773)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+from click.testing import CliRunner
+
+from nexus.cli.commands.path_context import path_context
+
+MOCK_URL = "http://localhost:2026"
+_ENV = {"NEXUS_NO_AUTO_JSON": "1", "NEXUS_URL": MOCK_URL}
+
+
+def _patched_client(**method_returns):
+    client = MagicMock()
+    for name, value in method_returns.items():
+        setattr(client, name, MagicMock(return_value=value))
+    # The internal fields accessed by the delete handler.
+    client._base_url = MOCK_URL
+    client._headers = MagicMock(return_value={"Authorization": "Bearer k"})
+    client._timeout = 30.0
+    return client
+
+
+class TestPathContextSet:
+    def test_put_sends_expected_payload(self) -> None:
+        runner = CliRunner(env=_ENV)
+        fake = _patched_client(put={"zone_id": "root", "path_prefix": "src", "description": "x"})
+        with patch("nexus.cli.api_client.get_api_client_from_options", return_value=fake):
+            result = runner.invoke(
+                path_context,
+                ["set", "src", "x", "--remote-url", MOCK_URL],
+            )
+        assert result.exit_code == 0, result.output
+        fake.put.assert_called_once_with(
+            "/api/v2/path-contexts/",
+            {"zone_id": "root", "path_prefix": "src", "description": "x"},
+        )
+        assert "root:src" in result.output
+
+    def test_custom_zone_id(self) -> None:
+        runner = CliRunner(env=_ENV)
+        fake = _patched_client(put={"zone_id": "a", "path_prefix": "src", "description": "x"})
+        with patch("nexus.cli.api_client.get_api_client_from_options", return_value=fake):
+            result = runner.invoke(
+                path_context,
+                ["set", "src", "x", "--zone-id", "a", "--remote-url", MOCK_URL],
+            )
+        assert result.exit_code == 0
+        call = fake.put.call_args
+        assert call.args[1]["zone_id"] == "a"
+
+
+class TestPathContextList:
+    def test_empty_list(self) -> None:
+        runner = CliRunner(env=_ENV)
+        fake = _patched_client(get={"contexts": []})
+        with patch("nexus.cli.api_client.get_api_client_from_options", return_value=fake):
+            result = runner.invoke(path_context, ["list", "--remote-url", MOCK_URL])
+        assert result.exit_code == 0
+        assert "No path contexts" in result.output
+
+    def test_pretty_listing(self) -> None:
+        runner = CliRunner(env=_ENV)
+        fake = _patched_client(
+            get={
+                "contexts": [
+                    {"zone_id": "root", "path_prefix": "src", "description": "source root"},
+                    {"zone_id": "root", "path_prefix": "docs", "description": "docs"},
+                ]
+            }
+        )
+        with patch("nexus.cli.api_client.get_api_client_from_options", return_value=fake):
+            result = runner.invoke(path_context, ["list", "--remote-url", MOCK_URL])
+        assert result.exit_code == 0
+        assert "root:src" in result.output
+        assert "source root" in result.output
+
+    def test_json_output(self) -> None:
+        runner = CliRunner(env=_ENV)
+        fake = _patched_client(
+            get={
+                "contexts": [
+                    {"zone_id": "root", "path_prefix": "src", "description": "x"},
+                ]
+            }
+        )
+        with patch("nexus.cli.api_client.get_api_client_from_options", return_value=fake):
+            result = runner.invoke(path_context, ["list", "--json", "--remote-url", MOCK_URL])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data[0]["path_prefix"] == "src"
+
+    def test_zone_id_filter_passed_through(self) -> None:
+        runner = CliRunner(env=_ENV)
+        fake = _patched_client(get={"contexts": []})
+        with patch("nexus.cli.api_client.get_api_client_from_options", return_value=fake):
+            runner.invoke(path_context, ["list", "--zone-id", "other", "--remote-url", MOCK_URL])
+        fake.get.assert_called_once_with("/api/v2/path-contexts/", params={"zone_id": "other"})
+
+
+class TestPathContextDelete:
+    def test_delete_success(self) -> None:
+        runner = CliRunner(env=_ENV)
+        fake = _patched_client()
+        resp = MagicMock(status_code=200)
+        resp.raise_for_status = MagicMock()
+        with (
+            patch("nexus.cli.api_client.get_api_client_from_options", return_value=fake),
+            patch("httpx.delete", return_value=resp) as delete_mock,
+        ):
+            result = runner.invoke(path_context, ["delete", "src", "--remote-url", MOCK_URL])
+        assert result.exit_code == 0, result.output
+        assert "deleted" in result.output
+        assert delete_mock.call_args.kwargs["params"] == {
+            "zone_id": "root",
+            "path_prefix": "src",
+        }
+
+    def test_delete_404_exits_nonzero(self) -> None:
+        runner = CliRunner(env=_ENV)
+        fake = _patched_client()
+        resp = MagicMock(status_code=404)
+        with (
+            patch("nexus.cli.api_client.get_api_client_from_options", return_value=fake),
+            patch("httpx.delete", return_value=resp),
+        ):
+            result = runner.invoke(path_context, ["delete", "missing", "--remote-url", MOCK_URL])
+        assert result.exit_code == 1
+        assert "No path context found" in result.output

--- a/tests/unit/cli/test_path_context_cli.py
+++ b/tests/unit/cli/test_path_context_cli.py
@@ -104,29 +104,25 @@ class TestPathContextList:
 class TestPathContextDelete:
     def test_delete_success(self) -> None:
         runner = CliRunner(env=_ENV)
-        fake = _patched_client()
-        resp = MagicMock(status_code=200)
-        resp.raise_for_status = MagicMock()
-        with (
-            patch("nexus.cli.api_client.get_api_client_from_options", return_value=fake),
-            patch("httpx.delete", return_value=resp) as delete_mock,
-        ):
+        fake = _patched_client(delete={"status": "deleted"})
+        with patch("nexus.cli.api_client.get_api_client_from_options", return_value=fake):
             result = runner.invoke(path_context, ["delete", "src", "--remote-url", MOCK_URL])
         assert result.exit_code == 0, result.output
         assert "deleted" in result.output
-        assert delete_mock.call_args.kwargs["params"] == {
-            "zone_id": "root",
-            "path_prefix": "src",
-        }
+        fake.delete.assert_called_once_with(
+            "/api/v2/path-contexts/",
+            params={"zone_id": "root", "path_prefix": "src"},
+        )
 
     def test_delete_404_exits_nonzero(self) -> None:
+        import httpx
+
         runner = CliRunner(env=_ENV)
         fake = _patched_client()
         resp = MagicMock(status_code=404)
-        with (
-            patch("nexus.cli.api_client.get_api_client_from_options", return_value=fake),
-            patch("httpx.delete", return_value=resp),
-        ):
+        err = httpx.HTTPStatusError("not found", request=MagicMock(), response=resp)
+        fake.delete = MagicMock(side_effect=err)
+        with patch("nexus.cli.api_client.get_api_client_from_options", return_value=fake):
             result = runner.invoke(path_context, ["delete", "missing", "--remote-url", MOCK_URL])
         assert result.exit_code == 1
         assert "No path context found" in result.output


### PR DESCRIPTION
## Summary

Closes #3773. Two independent search-quality improvements inspired by [QMD](https://github.com/tobi/qmd), shipped behind natural feature gates (default-on for RRF bonus, empty-table no-op for path contexts).

**1. RRF top-rank bonus** — After RRF fusion accumulates scores, add `+0.05` for docs ranked `#1` in any input list and `+0.02` for ranks `2-3`. Prevents dilution of high-confidence matches under query expansion / multi-backend fusion. Applied to `rrf_fusion`, `rrf_weighted_fusion`, `rrf_multi_fusion`; opt-out via new `FusionConfig.top_rank_bonus: bool = True` flag.

**2. Path context descriptions** — Admin-managed, zone-scoped path-prefix → description table. Search results carry a `context` field populated via longest-prefix match, giving LLM agents relevance signal without reading files.
- New `path_contexts` table (Alembic migration; PG + SQLite via `server_default`).
- `PathContextStore` (raw-SQL CRUD mirroring `ChunkStore`) + `PathContextCache` (in-memory longest-prefix lookup; freshness via `MAX(updated_at)` stamp; per-zone `asyncio.Lock` with double-check refresh).
- `PUT / GET / DELETE /api/v2/path-contexts` — admin-gated writes, auth-gated reads, Pydantic prefix normalization with `..`/`.` rejection.
- `BaseSearchResult.context: str | None = None` (backward compatible).
- `SearchDaemon._attach_path_contexts` wired at every `search()` return site + `batch_search` + `graph_enhanced_search`. Refreshes per-zone cache at most once per batch, then performs pure in-memory lookups (no per-result DB round-trips).
- `/api/v2/search` + `/api/v2/search/query/batch` emit `context` when non-None (omit otherwise).

## Design + plan

- Spec: `docs/superpowers/specs/2026-04-16-issue-3773-rrf-bonus-path-contexts-design.md`
- Plan: `docs/superpowers/plans/2026-04-16-issue-3773-rrf-bonus-path-contexts.md` (12 tasks)

## Test plan

- [x] `pytest tests/integration/bricks/search/test_rrf_bonus.py` — 11 tests (issue scenario, all three RRF variants, disabled flag)
- [x] `pytest tests/integration/bricks/search/test_fusion.py` — 26 existing tests, no regressions
- [x] `pytest tests/integration/bricks/search/test_path_context.py` — 16 tests (store CRUD, cache longest-prefix, slash-boundary, zone isolation, freshness, N+1 regression guard)
- [x] `pytest tests/integration/bricks/search/test_daemon_context_attach.py` — 5 tests (dataclass default, cache attach, serializer emit/omit, graph-path attach)
- [x] `pytest tests/integration/server/api/v2/routers/test_path_contexts_router.py` — 8 tests (admin/auth gates, normalization, traversal rejection, 404)
- [x] Alembic round-trip: upgrade → downgrade → upgrade verified on SQLite
- [x] `ruff check` clean on all touched files
- Post-merge: exercise `PUT` → `/api/v2/search` E2E on a live stack; verify `context` field appears on matching results and is absent when no context is configured
- Post-merge: verify graph-mode (`NEXUS_TXTAI_GRAPH=true`) attaches context

## Deferred (not blocking)

- Validate `zone_id` against zone registry on PUT (spec line 205) — `max_length=255` only for v1
- Clock-skew edge case (`<` vs `==` on `max_updated_at`) — safe for admin-write frequency
- Unused `PathContextOut` Pydantic model — drop in cleanup sweep