### PR TITLE
auth: PostgresAuthProfileStore + multi-tenant schema (#3788 PR 1/3)

### DIFF
--- a/src/nexus/bricks/auth/cli_commands.py
+++ b/src/nexus/bricks/auth/cli_commands.py
@@ -861,6 +861,10 @@ def auth_migrate_to_postgres(
                     console.print(f"  [{style}]{verb}[/{style}] {entry.profile_id}")
                 elif entry.action == "skip_exists":
                     console.print(f"  [nexus.muted]Skip (exists)[/nexus.muted] {entry.profile_id}")
+                elif entry.action == "conflict_principal":
+                    console.print(
+                        f"  [nexus.error]Conflict[/nexus.error] {entry.profile_id}: {entry.reason}"
+                    )
                 elif entry.action == "error":
                     console.print(
                         f"  [nexus.error]Error[/nexus.error] {entry.profile_id}: {entry.reason}"

--- a/src/nexus/bricks/auth/cli_commands.py
+++ b/src/nexus/bricks/auth/cli_commands.py
@@ -725,6 +725,163 @@ def auth_migrate(apply: bool, finalize: bool) -> None:
         store.close()
 
 
+# ---------------------------------------------------------------------------
+# auth migrate-to-postgres (epic #3788 Phase F)
+# ---------------------------------------------------------------------------
+
+
+@auth.command("migrate-to-postgres")
+@click.option(
+    "--db-url",
+    required=True,
+    help="PostgreSQL URL (e.g. postgresql+psycopg2://user:pw@host:5432/db).",
+)
+@click.option(
+    "--tenant",
+    required=True,
+    help="Tenant name; created if it does not exist.",
+)
+@click.option(
+    "--principal",
+    required=True,
+    help="Principal external_sub (OIDC sub / keypair fingerprint); created if absent.",
+)
+@click.option(
+    "--principal-kind",
+    default="human",
+    type=click.Choice(["human", "agent", "machine"]),
+    help="Principal kind used when creating a new principal row.",
+)
+@click.option(
+    "--auth-method",
+    default="bootstrap",
+    help="Auth method recorded on the principal_alias row.",
+)
+@click.option(
+    "--source-db",
+    type=click.Path(),
+    default=None,
+    help="Path to SQLite auth_profiles.db (default: ~/.nexus/auth_profiles.db).",
+)
+@click.option(
+    "--apply",
+    is_flag=True,
+    default=False,
+    help="Actually copy rows (default: dry-run).",
+)
+@click.option(
+    "--force",
+    is_flag=True,
+    default=False,
+    help="Overwrite rows that already exist in the target store.",
+)
+def auth_migrate_to_postgres(
+    db_url: str,
+    tenant: str,
+    principal: str,
+    principal_kind: str,
+    auth_method: str,
+    source_db: str | None,
+    apply: bool,
+    force: bool,
+) -> None:
+    """Migrate local SQLite auth profiles into a multi-tenant Postgres store.
+
+    Part of epic #3788 (Phase F). Copy-only by default — the SQLite source is
+    never modified. Safe to rerun: rows already in the target are skipped
+    unless --force is passed.
+
+    Example (dry-run, then apply)::
+
+        nexus auth migrate-to-postgres \\
+            --db-url postgresql+psycopg2://postgres:pw@host/nexus \\
+            --tenant acme --principal alice@acme.com
+
+        nexus auth migrate-to-postgres ... --apply
+    """
+    from pathlib import Path
+
+    from sqlalchemy import create_engine
+
+    from nexus.bricks.auth.postgres_migrate import (
+        build_migration_plan,
+        execute_migration,
+    )
+    from nexus.bricks.auth.postgres_profile_store import (
+        PostgresAuthProfileStore,
+        ensure_principal,
+        ensure_schema,
+        ensure_tenant,
+    )
+    from nexus.bricks.auth.profile_store import SqliteAuthProfileStore
+
+    sqlite_path = (
+        Path(source_db).expanduser()
+        if source_db
+        else Path("~/.nexus/auth_profiles.db").expanduser()
+    )
+    if not sqlite_path.exists():
+        raise click.ClickException(f"Source SQLite DB not found: {sqlite_path}")
+
+    engine = create_engine(db_url, future=True)
+    try:
+        ensure_schema(engine)
+        tenant_id = ensure_tenant(engine, tenant)
+        principal_id = ensure_principal(
+            engine,
+            tenant_id=tenant_id,
+            kind=principal_kind,
+            external_sub=principal,
+            auth_method=auth_method,
+        )
+
+        source = SqliteAuthProfileStore(sqlite_path)
+        target = PostgresAuthProfileStore(
+            db_url,
+            tenant_id=tenant_id,
+            principal_id=principal_id,
+            engine=engine,
+        )
+        try:
+            plan = build_migration_plan(source, target, force=force)
+            result = execute_migration(plan, source, target, apply=apply)
+
+            if not apply:
+                console.print("[bold]Dry-run[/bold] (pass --apply to write):\n")
+
+            for entry in result.entries:
+                if entry.action in ("copy", "overwrite"):
+                    style = "nexus.success" if apply else "nexus.info"
+                    verb = {
+                        ("copy", True): "Copied",
+                        ("copy", False): "Would copy",
+                        ("overwrite", True): "Overwrote",
+                        ("overwrite", False): "Would overwrite",
+                    }[(entry.action, apply)]
+                    console.print(f"  [{style}]{verb}[/{style}] {entry.profile_id}")
+                elif entry.action == "skip_exists":
+                    console.print(f"  [nexus.muted]Skip (exists)[/nexus.muted] {entry.profile_id}")
+                elif entry.action == "error":
+                    console.print(
+                        f"  [nexus.error]Error[/nexus.error] {entry.profile_id}: {entry.reason}"
+                    )
+
+            console.print(
+                f"\n{'Dry-run' if result.dry_run else 'Result'}: "
+                f"tenant={tenant} principal={principal} "
+                f"{result.copied} copied, {result.skipped} skipped, "
+                f"{result.errors} errors"
+            )
+
+            if result.errors > 0:
+                raise click.exceptions.Exit(1)
+        finally:
+            source.close()
+            target.close()
+    finally:
+        engine.dispose()
+
+
 # Order preserves registration for parity testing.
 
 

--- a/src/nexus/bricks/auth/postgres_migrate.py
+++ b/src/nexus/bricks/auth/postgres_migrate.py
@@ -1,0 +1,161 @@
+"""Migration from SqliteAuthProfileStore to PostgresAuthProfileStore.
+
+This is Phase F of epic #3788. Copy-only semantics: the SQLite source is
+never modified, and an existing Postgres row (matched by ``id`` within the
+target ``(tenant_id, principal_id)`` scope) is preserved unless ``--force``
+is specified. Rerunning the tool after a partial apply is safe.
+
+Unlike the existing ``auth migrate`` (OAuth→unified-profile, Phase 1 of
+#3722), this migration moves rows between two ``AuthProfileStore``
+implementations. Source routing metadata is preserved verbatim; the new
+tenant/principal ownership columns are populated from caller-supplied IDs.
+
+The tool does NOT cross the crypto boundary — PR 1 stores plaintext routing
+metadata only. Credential resolution still flows through the configured
+``CredentialBackend`` (nexus-token-manager, aws-cli, etc.). PR 2 will add
+envelope-encrypted ciphertext columns.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass, field
+
+from nexus.bricks.auth.postgres_profile_store import PostgresAuthProfileStore
+from nexus.bricks.auth.profile import AuthProfile, AuthProfileStore
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Plan / result types
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class PostgresMigrationEntry:
+    """One row in the SQLite→Postgres migration plan."""
+
+    profile_id: str
+    provider: str
+    action: str  # "copy", "skip_exists", "overwrite", "error"
+    reason: str = ""
+
+
+@dataclass
+class PostgresMigrationResult:
+    entries: list[PostgresMigrationEntry] = field(default_factory=list)
+    copied: int = 0
+    skipped: int = 0
+    errors: int = 0
+    dry_run: bool = True
+
+    @property
+    def total(self) -> int:
+        return self.copied + self.skipped + self.errors
+
+
+# ---------------------------------------------------------------------------
+# Plan / execute
+# ---------------------------------------------------------------------------
+
+
+def build_migration_plan(
+    source: AuthProfileStore,
+    target: PostgresAuthProfileStore,
+    *,
+    force: bool = False,
+) -> list[PostgresMigrationEntry]:
+    """Walk source rows and decide what to do for each against the target.
+
+    ``force=True`` schedules an overwrite for rows that already exist in the
+    target. Default is conservative — existing rows are skipped so operators
+    can rerun the tool safely.
+    """
+    entries: list[PostgresMigrationEntry] = []
+    for profile in source.list():
+        existing = target.get(profile.id)
+        if existing is not None and not force:
+            entries.append(
+                PostgresMigrationEntry(
+                    profile_id=profile.id,
+                    provider=profile.provider,
+                    action="skip_exists",
+                    reason="already present in target (use --force to overwrite)",
+                )
+            )
+            continue
+
+        entries.append(
+            PostgresMigrationEntry(
+                profile_id=profile.id,
+                provider=profile.provider,
+                action="overwrite" if existing is not None else "copy",
+            )
+        )
+    return entries
+
+
+def execute_migration(
+    plan: list[PostgresMigrationEntry],
+    source: AuthProfileStore,
+    target: PostgresAuthProfileStore,
+    *,
+    apply: bool = False,
+) -> PostgresMigrationResult:
+    """Execute or dry-run a plan.
+
+    Source profiles are looked up fresh rather than passed alongside the plan
+    so that a profile deleted from the SQLite source between plan and apply
+    surfaces as an ``error`` entry instead of silently writing stale state.
+    """
+    result = PostgresMigrationResult(dry_run=not apply)
+    for entry in plan:
+        result.entries.append(entry)
+
+        if entry.action not in ("copy", "overwrite"):
+            result.skipped += 1
+            continue
+
+        if not apply:
+            result.copied += 1
+            continue
+
+        profile = source.get(entry.profile_id)
+        if profile is None:
+            entry.action = "error"
+            entry.reason = "source row disappeared between plan and execute"
+            result.errors += 1
+            continue
+
+        try:
+            target.upsert(_clone_with_fresh_usage_stats(profile))
+            result.copied += 1
+        except Exception as exc:
+            logger.warning("Postgres migration error for %s: %s", entry.profile_id, exc)
+            entry.action = "error"
+            entry.reason = str(exc)
+            result.errors += 1
+
+    return result
+
+
+def _clone_with_fresh_usage_stats(profile: AuthProfile) -> AuthProfile:
+    """Return a copy of ``profile`` without mutating the source object.
+
+    Copy semantics: routing metadata and usage stats both carry over. The
+    target store will stamp its own ``created_at`` / ``updated_at``. We do
+    NOT reset stats — operators migrating from SQLite want their cooldown
+    state and failure counts to follow the rows, otherwise every profile
+    would look "healthy" on the new store and mask real ongoing issues.
+    """
+    return AuthProfile(
+        id=profile.id,
+        provider=profile.provider,
+        account_identifier=profile.account_identifier,
+        backend=profile.backend,
+        backend_key=profile.backend_key,
+        last_synced_at=profile.last_synced_at,
+        sync_ttl_seconds=profile.sync_ttl_seconds,
+        usage_stats=profile.usage_stats,
+    )

--- a/src/nexus/bricks/auth/postgres_migrate.py
+++ b/src/nexus/bricks/auth/postgres_migrate.py
@@ -21,7 +21,10 @@ from __future__ import annotations
 import logging
 from dataclasses import dataclass, field
 
-from nexus.bricks.auth.postgres_profile_store import PostgresAuthProfileStore
+from nexus.bricks.auth.postgres_profile_store import (
+    CrossPrincipalConflict,
+    PostgresAuthProfileStore,
+)
 from nexus.bricks.auth.profile import AuthProfile, AuthProfileStore
 
 logger = logging.getLogger(__name__)
@@ -38,7 +41,19 @@ class PostgresMigrationEntry:
 
     profile_id: str
     provider: str
-    action: str  # "copy", "skip_exists", "overwrite", "error"
+    # "copy"              → row is absent in the target; will be inserted
+    # "overwrite"         → row exists under the *same* principal; will be
+    #                       re-written (only reached with ``force=True``)
+    # "skip_exists"       → row exists under the *same* principal; plan opted
+    #                       to leave it
+    # "conflict_principal"→ row exists under a *different* principal in the
+    #                       same tenant; aborts the apply to prevent
+    #                       silent ownership reassignment (never auto-healed,
+    #                       even with ``force=True`` — the operator must
+    #                       delete the foreign row or pick a different
+    #                       destination principal)
+    # "error"             → plan-to-apply drift (source row disappeared)
+    action: str
     reason: str = ""
 
 
@@ -68,14 +83,44 @@ def build_migration_plan(
 ) -> list[PostgresMigrationEntry]:
     """Walk source rows and decide what to do for each against the target.
 
-    ``force=True`` schedules an overwrite for rows that already exist in the
-    target. Default is conservative — existing rows are skipped so operators
-    can rerun the tool safely.
+    Three cases for each source row:
+
+    1. Target row exists under *another* principal in the same tenant →
+       ``conflict_principal``. Never auto-healed — silently rewriting another
+       principal's row is exactly the ownership-takeover failure mode we want
+       to prevent. Operator must delete the foreign row or pick a different
+       destination principal before the migration can proceed.
+    2. Target row exists under *this* principal → ``skip_exists`` by default,
+       ``overwrite`` if ``force=True``.
+    3. No target row → ``copy``.
     """
     entries: list[PostgresMigrationEntry] = []
+    target_principal = target.principal_id
     for profile in source.list():
-        existing = target.get(profile.id)
-        if existing is not None and not force:
+        owners = target.tenant_scope_owners_of(profile.id)
+        owned_by_self = target_principal in owners
+        other_owners = sorted(owners - {target_principal})
+
+        if other_owners:
+            # Any foreign owner aborts the migration for this id — listing
+            # all of them surfaces the full blast radius to the operator
+            # (not just whichever row Postgres returned first).
+            entries.append(
+                PostgresMigrationEntry(
+                    profile_id=profile.id,
+                    provider=profile.provider,
+                    action="conflict_principal",
+                    reason=(
+                        "row already owned by "
+                        f"{', '.join(str(p) for p in other_owners)} "
+                        "in the same tenant; refuse to reassign ownership "
+                        "during migration"
+                    ),
+                )
+            )
+            continue
+
+        if owned_by_self and not force:
             entries.append(
                 PostgresMigrationEntry(
                     profile_id=profile.id,
@@ -90,7 +135,7 @@ def build_migration_plan(
             PostgresMigrationEntry(
                 profile_id=profile.id,
                 provider=profile.provider,
-                action="overwrite" if existing is not None else "copy",
+                action="overwrite" if owned_by_self else "copy",
             )
         )
     return entries
@@ -113,6 +158,12 @@ def execute_migration(
     for entry in plan:
         result.entries.append(entry)
 
+        if entry.action == "conflict_principal":
+            # Ownership-takeover guard — counts as an error, not a skip, so
+            # CLI exits non-zero and scripts do not treat it as a clean run.
+            result.errors += 1
+            continue
+
         if entry.action not in ("copy", "overwrite"):
             result.skipped += 1
             continue
@@ -128,9 +179,24 @@ def execute_migration(
             result.errors += 1
             continue
 
+        # Atomic conflict-check + write. ``upsert_strict`` takes an
+        # advisory lock scoped to ``(tenant_id, profile_id)`` inside the
+        # same transaction, so concurrent writers targeting the same id in
+        # the same tenant are serialized. The plan-time check is a
+        # user-visible preview; ``upsert_strict`` is the authoritative
+        # enforcement point.
         try:
-            target.upsert(_clone_with_fresh_usage_stats(profile))
+            target.upsert_strict(_clone_with_fresh_usage_stats(profile))
             result.copied += 1
+        except CrossPrincipalConflict as exc:
+            entry.action = "conflict_principal"
+            entry.reason = (
+                "row already owned by "
+                f"{', '.join(str(p) for p in exc.foreign_principals)} "
+                "in the same tenant at apply time; refuse to reassign "
+                "ownership"
+            )
+            result.errors += 1
         except Exception as exc:
             logger.warning("Postgres migration error for %s: %s", entry.profile_id, exc)
             entry.action = "error"

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -1,0 +1,604 @@
+"""PostgreSQL-backed AuthProfileStore for multi-tenant server deployments.
+
+Implements the AuthProfileStore protocol against PostgreSQL with:
+  - (tenant_id, principal_id) ownership model (epic #3788 blocker 1)
+  - Row-Level Security (RLS) keyed off ``app.current_tenant`` session var
+  - FORCE RLS so policies apply even when connected as table owner
+  - Tenant-scoped primary keys: ``(tenant_id, id)`` on auth_profiles
+  - UUID primary keys generated application-side (no pgcrypto dependency)
+
+Schema overview::
+
+    tenants(id, name, created_at)
+    principals(id, tenant_id, kind, parent_principal_id, delegated_scope)
+    principal_aliases(auth_method, external_sub, principal_id)
+    auth_profiles(tenant_id, id, principal_id, provider, account_identifier,
+                  backend, backend_key, <stats columns>, created_at, updated_at)
+
+Writes go through a pooled SQLAlchemy engine. Every transaction issues
+``SET LOCAL app.current_tenant`` before the first statement so RLS scopes
+rows to this store's configured tenant. Unlike SqliteAuthProfileStore there
+is no in-memory LRU cache — Postgres is multi-writer, so per-process caching
+would be stale in the presence of other daemons. Local read-through caching
+is deferred to the client-side nexus-bot daemon (epic #3788 Phase D).
+
+Crypto columns (ciphertext, wrapped_dek, nonce, kek_version, aad) are
+deliberately NOT added in this PR — they land in #3788 Phase C. This store
+persists routing metadata only, matching the current AuthProfile contract.
+
+Feature gate: instantiated only when ``NEXUS_AUTH_STORE=postgres``. Default
+remains SqliteAuthProfileStore until downstream consumers migrate.
+"""
+
+from __future__ import annotations
+
+import builtins
+import logging
+import uuid
+from collections.abc import Iterator
+from contextlib import contextmanager
+from typing import Any
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Connection, Engine
+
+from nexus.bricks.auth.profile import (
+    RAW_ERROR_MAX_LEN,
+    AuthProfile,
+    AuthProfileFailureReason,
+    ProfileUsageStats,
+)
+
+logger = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# Schema (idempotent CREATE TABLE IF NOT EXISTS + RLS policies)
+# ---------------------------------------------------------------------------
+
+_SCHEMA_STATEMENTS: tuple[str, ...] = (
+    """
+    CREATE TABLE IF NOT EXISTS tenants (
+        id          UUID PRIMARY KEY,
+        name        TEXT NOT NULL UNIQUE,
+        created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS principals (
+        id                  UUID PRIMARY KEY,
+        tenant_id           UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+        kind                TEXT NOT NULL CHECK (kind IN ('human','agent','machine')),
+        parent_principal_id UUID REFERENCES principals(id) ON DELETE SET NULL,
+        delegated_scope     JSONB,
+        created_at          TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_principals_tenant_id ON principals(tenant_id)",
+    """
+    CREATE TABLE IF NOT EXISTS principal_aliases (
+        auth_method  TEXT NOT NULL,
+        external_sub TEXT NOT NULL,
+        principal_id UUID NOT NULL REFERENCES principals(id) ON DELETE CASCADE,
+        created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        PRIMARY KEY (auth_method, external_sub)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_principal_aliases_principal_id ON principal_aliases(principal_id)",
+    """
+    CREATE TABLE IF NOT EXISTS auth_profiles (
+        tenant_id          UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+        id                 TEXT NOT NULL,
+        principal_id       UUID NOT NULL REFERENCES principals(id) ON DELETE CASCADE,
+        provider           TEXT NOT NULL,
+        account_identifier TEXT NOT NULL,
+        backend            TEXT NOT NULL,
+        backend_key        TEXT NOT NULL,
+        last_synced_at     TIMESTAMPTZ,
+        sync_ttl_seconds   INTEGER NOT NULL DEFAULT 300,
+        last_used_at       TIMESTAMPTZ,
+        success_count      INTEGER NOT NULL DEFAULT 0,
+        failure_count      INTEGER NOT NULL DEFAULT 0,
+        cooldown_until     TIMESTAMPTZ,
+        cooldown_reason    TEXT,
+        disabled_until     TIMESTAMPTZ,
+        raw_error          TEXT,
+        created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        PRIMARY KEY (tenant_id, id)
+    )
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_auth_profiles_principal ON auth_profiles(tenant_id, principal_id)",
+    "CREATE INDEX IF NOT EXISTS idx_auth_profiles_provider ON auth_profiles(tenant_id, provider)",
+    "ALTER TABLE tenants ENABLE ROW LEVEL SECURITY",
+    "ALTER TABLE tenants FORCE ROW LEVEL SECURITY",
+    "ALTER TABLE principals ENABLE ROW LEVEL SECURITY",
+    "ALTER TABLE principals FORCE ROW LEVEL SECURITY",
+    "ALTER TABLE principal_aliases ENABLE ROW LEVEL SECURITY",
+    "ALTER TABLE principal_aliases FORCE ROW LEVEL SECURITY",
+    "ALTER TABLE auth_profiles ENABLE ROW LEVEL SECURITY",
+    "ALTER TABLE auth_profiles FORCE ROW LEVEL SECURITY",
+)
+
+# Policies are separate because ``CREATE POLICY`` lacks IF NOT EXISTS in
+# PostgreSQL <15 — we drop-then-create for idempotency.
+_POLICY_STATEMENTS: tuple[str, ...] = (
+    "DROP POLICY IF EXISTS tenant_isolation_tenants ON tenants",
+    """
+    CREATE POLICY tenant_isolation_tenants ON tenants
+        USING (id = current_setting('app.current_tenant', true)::UUID)
+    """,
+    "DROP POLICY IF EXISTS tenant_isolation_principals ON principals",
+    """
+    CREATE POLICY tenant_isolation_principals ON principals
+        USING (tenant_id = current_setting('app.current_tenant', true)::UUID)
+    """,
+    "DROP POLICY IF EXISTS tenant_isolation_aliases ON principal_aliases",
+    """
+    CREATE POLICY tenant_isolation_aliases ON principal_aliases
+        USING (principal_id IN (
+            SELECT id FROM principals
+            WHERE tenant_id = current_setting('app.current_tenant', true)::UUID
+        ))
+    """,
+    "DROP POLICY IF EXISTS tenant_isolation_auth_profiles ON auth_profiles",
+    """
+    CREATE POLICY tenant_isolation_auth_profiles ON auth_profiles
+        USING (tenant_id = current_setting('app.current_tenant', true)::UUID)
+    """,
+)
+
+
+def ensure_schema(engine: Engine) -> None:
+    """Create (idempotently) every table, index, and RLS policy.
+
+    Intended for:
+      - Test fixtures (fresh schema per module)
+      - Dev bootstrap
+      - First-run on an empty production database
+
+    Production rollouts should eventually migrate to Alembic — intentionally
+    out of scope for PR 1.
+    """
+    with engine.begin() as conn:
+        for stmt in _SCHEMA_STATEMENTS:
+            conn.execute(text(stmt))
+        for stmt in _POLICY_STATEMENTS:
+            conn.execute(text(stmt))
+
+
+def drop_schema(engine: Engine) -> None:
+    """Drop every table created by ``ensure_schema`` (test teardown helper)."""
+    with engine.begin() as conn:
+        for tbl in ("auth_profiles", "principal_aliases", "principals", "tenants"):
+            conn.execute(text(f"DROP TABLE IF EXISTS {tbl} CASCADE"))
+
+
+# ---------------------------------------------------------------------------
+# Admin helpers — used by tests + the migration CLI (Phase F)
+# ---------------------------------------------------------------------------
+
+
+def ensure_tenant(engine: Engine, name: str) -> uuid.UUID:
+    """Return the tenant_id for ``name``, creating the row if absent.
+
+    Bypasses RLS by running as the connecting role (assumes admin context
+    for provisioning). Callers must not expose this helper to tenant-scoped
+    request handlers.
+    """
+    with engine.begin() as conn:
+        row = conn.execute(
+            text("SELECT id FROM tenants WHERE name = :name"),
+            {"name": name},
+        ).fetchone()
+        if row is not None:
+            return row[0]
+        tenant_id = uuid.uuid4()
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, :name)"),
+            {"id": tenant_id, "name": name},
+        )
+        return tenant_id
+
+
+def ensure_principal(
+    engine: Engine,
+    *,
+    tenant_id: uuid.UUID,
+    kind: str = "human",
+    external_sub: str | None = None,
+    auth_method: str = "bootstrap",
+    parent_principal_id: uuid.UUID | None = None,
+) -> uuid.UUID:
+    """Return principal_id for the given tenant+alias, creating rows if absent.
+
+    ``external_sub`` keys the alias (e.g. OIDC sub claim, machine keypair
+    fingerprint). ``auth_method`` is the provider that issued it (``oidc``,
+    ``bound-keypair``, ``bootstrap`` for tests/migration).
+    """
+    with engine.begin() as conn:
+        if external_sub is not None:
+            alias = conn.execute(
+                text(
+                    "SELECT principal_id FROM principal_aliases "
+                    "WHERE auth_method = :m AND external_sub = :s"
+                ),
+                {"m": auth_method, "s": external_sub},
+            ).fetchone()
+            if alias is not None:
+                return alias[0]
+
+        principal_id = uuid.uuid4()
+        conn.execute(
+            text(
+                "INSERT INTO principals (id, tenant_id, kind, parent_principal_id) "
+                "VALUES (:id, :tid, :kind, :parent)"
+            ),
+            {
+                "id": principal_id,
+                "tid": tenant_id,
+                "kind": kind,
+                "parent": parent_principal_id,
+            },
+        )
+        if external_sub is not None:
+            conn.execute(
+                text(
+                    "INSERT INTO principal_aliases (auth_method, external_sub, principal_id) "
+                    "VALUES (:m, :s, :p)"
+                ),
+                {"m": auth_method, "s": external_sub, "p": principal_id},
+            )
+        return principal_id
+
+
+# ---------------------------------------------------------------------------
+# SQL statements used by the store (tenant/principal scoping baked in)
+# ---------------------------------------------------------------------------
+
+_UPSERT_SQL = """
+INSERT INTO auth_profiles (
+    tenant_id, id, principal_id,
+    provider, account_identifier, backend, backend_key,
+    last_synced_at, sync_ttl_seconds,
+    last_used_at, success_count, failure_count,
+    cooldown_until, cooldown_reason, disabled_until, raw_error,
+    updated_at
+) VALUES (
+    :tenant_id, :id, :principal_id,
+    :provider, :account_identifier, :backend, :backend_key,
+    :last_synced_at, :sync_ttl_seconds,
+    :last_used_at, :success_count, :failure_count,
+    :cooldown_until, :cooldown_reason, :disabled_until, :raw_error,
+    NOW()
+)
+ON CONFLICT (tenant_id, id) DO UPDATE SET
+    principal_id       = EXCLUDED.principal_id,
+    provider           = EXCLUDED.provider,
+    account_identifier = EXCLUDED.account_identifier,
+    backend            = EXCLUDED.backend,
+    backend_key        = EXCLUDED.backend_key,
+    last_synced_at     = EXCLUDED.last_synced_at,
+    sync_ttl_seconds   = EXCLUDED.sync_ttl_seconds,
+    last_used_at       = EXCLUDED.last_used_at,
+    success_count      = EXCLUDED.success_count,
+    failure_count      = EXCLUDED.failure_count,
+    cooldown_until     = EXCLUDED.cooldown_until,
+    cooldown_reason    = EXCLUDED.cooldown_reason,
+    disabled_until     = EXCLUDED.disabled_until,
+    raw_error          = EXCLUDED.raw_error,
+    updated_at         = NOW()
+"""
+
+
+def _reason_to_str(reason: AuthProfileFailureReason | None) -> str | None:
+    return reason.value if reason else None
+
+
+def _str_to_reason(val: Any) -> AuthProfileFailureReason | None:
+    if val is None:
+        return None
+    try:
+        return AuthProfileFailureReason(val)
+    except ValueError:
+        return AuthProfileFailureReason.UNKNOWN
+
+
+def _row_to_profile(row: Any) -> AuthProfile:
+    stats = ProfileUsageStats(
+        last_used_at=row.last_used_at,
+        success_count=row.success_count,
+        failure_count=row.failure_count,
+        cooldown_until=row.cooldown_until,
+        cooldown_reason=_str_to_reason(row.cooldown_reason),
+        disabled_until=row.disabled_until,
+        raw_error=row.raw_error,
+    )
+    return AuthProfile(
+        id=row.id,
+        provider=row.provider,
+        account_identifier=row.account_identifier,
+        backend=row.backend,
+        backend_key=row.backend_key,
+        last_synced_at=row.last_synced_at,
+        sync_ttl_seconds=row.sync_ttl_seconds,
+        usage_stats=stats,
+    )
+
+
+def _profile_params(
+    profile: AuthProfile,
+    *,
+    tenant_id: uuid.UUID,
+    principal_id: uuid.UUID,
+) -> dict[str, Any]:
+    s = profile.usage_stats
+    raw_error = s.raw_error
+    if raw_error and len(raw_error) > RAW_ERROR_MAX_LEN:
+        raw_error = raw_error[:RAW_ERROR_MAX_LEN]
+    return {
+        "tenant_id": tenant_id,
+        "id": profile.id,
+        "principal_id": principal_id,
+        "provider": profile.provider,
+        "account_identifier": profile.account_identifier,
+        "backend": profile.backend,
+        "backend_key": profile.backend_key,
+        "last_synced_at": profile.last_synced_at,
+        "sync_ttl_seconds": profile.sync_ttl_seconds,
+        "last_used_at": s.last_used_at,
+        "success_count": s.success_count,
+        "failure_count": s.failure_count,
+        "cooldown_until": s.cooldown_until,
+        "cooldown_reason": _reason_to_str(s.cooldown_reason),
+        "disabled_until": s.disabled_until,
+        "raw_error": raw_error,
+    }
+
+
+# ---------------------------------------------------------------------------
+# PostgresAuthProfileStore
+# ---------------------------------------------------------------------------
+
+
+class PostgresAuthProfileStore:
+    """PostgreSQL-backed AuthProfileStore scoped to one (tenant, principal).
+
+    Construction binds the store to a tenant + principal pair. Every
+    transaction issues ``SET LOCAL app.current_tenant`` so RLS scopes reads
+    to this tenant. Writes also carry ``tenant_id`` / ``principal_id``
+    explicitly, providing defense-in-depth if RLS were misconfigured.
+
+    Lifecycle:
+        store = PostgresAuthProfileStore(db_url, tenant_id, principal_id)
+        ...
+        store.close()  # disposes the engine / returns pool connections
+
+    Not safe to share across tenants. Create a new instance per
+    (tenant, principal) context — engines are cheap once Postgres is warm.
+    """
+
+    def __init__(
+        self,
+        db_url: str,
+        *,
+        tenant_id: uuid.UUID | str,
+        principal_id: uuid.UUID | str,
+        engine: Engine | None = None,
+        pool_size: int = 5,
+    ) -> None:
+        self._tenant_id = uuid.UUID(str(tenant_id))
+        self._principal_id = uuid.UUID(str(principal_id))
+        # Allow callers (tests, server with a shared engine) to inject one.
+        if engine is None:
+            self._engine = create_engine(
+                db_url,
+                pool_size=pool_size,
+                pool_pre_ping=True,
+                future=True,
+            )
+            self._owns_engine = True
+        else:
+            self._engine = engine
+            self._owns_engine = False
+
+    # ------------------------------------------------------------------
+    # Internal: scoped-transaction helper
+    # ------------------------------------------------------------------
+
+    @contextmanager
+    def _scoped(self) -> Iterator[Connection]:
+        """Yield a connection with ``app.current_tenant`` bound for this tx.
+
+        ``SET LOCAL`` scopes the setting to the enclosing transaction, so
+        every public method wraps its work in this context to force RLS
+        evaluation. No implicit commit — caller's exit handles it via
+        ``engine.begin()``.
+        """
+        with self._engine.begin() as conn:
+            conn.execute(
+                text("SET LOCAL app.current_tenant = :tid"),
+                {"tid": str(self._tenant_id)},
+            )
+            yield conn
+
+    # ------------------------------------------------------------------
+    # AuthProfileStore protocol
+    # ------------------------------------------------------------------
+
+    def list(self, *, provider: str | None = None) -> list[AuthProfile]:
+        with self._scoped() as conn:
+            if provider is None:
+                rows = conn.execute(
+                    text(
+                        "SELECT * FROM auth_profiles "
+                        "WHERE tenant_id = :tid AND principal_id = :pid "
+                        "ORDER BY id"
+                    ),
+                    {"tid": self._tenant_id, "pid": self._principal_id},
+                ).fetchall()
+            else:
+                rows = conn.execute(
+                    text(
+                        "SELECT * FROM auth_profiles "
+                        "WHERE tenant_id = :tid AND principal_id = :pid "
+                        "AND provider = :p ORDER BY id"
+                    ),
+                    {
+                        "tid": self._tenant_id,
+                        "pid": self._principal_id,
+                        "p": provider,
+                    },
+                ).fetchall()
+        return [_row_to_profile(r) for r in rows]
+
+    def get(self, profile_id: str) -> AuthProfile | None:
+        with self._scoped() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT * FROM auth_profiles "
+                    "WHERE tenant_id = :tid AND principal_id = :pid AND id = :id"
+                ),
+                {
+                    "tid": self._tenant_id,
+                    "pid": self._principal_id,
+                    "id": profile_id,
+                },
+            ).fetchone()
+        return _row_to_profile(row) if row is not None else None
+
+    def upsert(self, profile: AuthProfile) -> None:
+        params = _profile_params(
+            profile,
+            tenant_id=self._tenant_id,
+            principal_id=self._principal_id,
+        )
+        with self._scoped() as conn:
+            conn.execute(text(_UPSERT_SQL), params)
+
+    def delete(self, profile_id: str) -> None:
+        with self._scoped() as conn:
+            conn.execute(
+                text(
+                    "DELETE FROM auth_profiles "
+                    "WHERE tenant_id = :tid AND principal_id = :pid AND id = :id"
+                ),
+                {
+                    "tid": self._tenant_id,
+                    "pid": self._principal_id,
+                    "id": profile_id,
+                },
+            )
+
+    def replace_owned_subset(
+        self,
+        *,
+        upserts: "builtins.list[AuthProfile]",
+        deletes: "builtins.list[str]",
+    ) -> None:
+        if not upserts and not deletes:
+            return
+        with self._scoped() as conn:
+            for p in upserts:
+                conn.execute(
+                    text(_UPSERT_SQL),
+                    _profile_params(
+                        p,
+                        tenant_id=self._tenant_id,
+                        principal_id=self._principal_id,
+                    ),
+                )
+            for pid in deletes:
+                conn.execute(
+                    text(
+                        "DELETE FROM auth_profiles "
+                        "WHERE tenant_id = :tid AND principal_id = :pid AND id = :id"
+                    ),
+                    {
+                        "tid": self._tenant_id,
+                        "pid": self._principal_id,
+                        "id": pid,
+                    },
+                )
+
+    def mark_success(self, profile_id: str) -> None:
+        """Record a successful credential use.
+
+        Unlike SqliteAuthProfileStore this does not buffer in memory — other
+        daemons may be writing to the same row, so a per-process dirty bit
+        would be stale. Direct ``UPDATE`` with ``last_used_at = NOW()`` also
+        clears the cooldown window if it has already elapsed.
+        """
+        with self._scoped() as conn:
+            conn.execute(
+                text(
+                    "UPDATE auth_profiles SET "
+                    "    success_count = success_count + 1, "
+                    "    last_used_at = NOW(), "
+                    "    cooldown_until = CASE "
+                    "        WHEN cooldown_until IS NULL OR cooldown_until <= NOW() "
+                    "        THEN NULL ELSE cooldown_until END, "
+                    "    cooldown_reason = CASE "
+                    "        WHEN cooldown_until IS NULL OR cooldown_until <= NOW() "
+                    "        THEN NULL ELSE cooldown_reason END "
+                    "WHERE tenant_id = :tid AND principal_id = :pid AND id = :id"
+                ),
+                {
+                    "tid": self._tenant_id,
+                    "pid": self._principal_id,
+                    "id": profile_id,
+                },
+            )
+
+    def mark_failure(
+        self,
+        profile_id: str,
+        reason: AuthProfileFailureReason,
+        *,
+        raw_error: str | None = None,
+    ) -> None:
+        truncated = raw_error[:RAW_ERROR_MAX_LEN] if raw_error else None
+        with self._scoped() as conn:
+            conn.execute(
+                text(
+                    "UPDATE auth_profiles SET "
+                    "    failure_count = failure_count + 1, "
+                    "    last_used_at = NOW(), "
+                    "    cooldown_reason = :reason, "
+                    "    raw_error = COALESCE(:raw_error, raw_error) "
+                    "WHERE tenant_id = :tid AND principal_id = :pid AND id = :id"
+                ),
+                {
+                    "tid": self._tenant_id,
+                    "pid": self._principal_id,
+                    "id": profile_id,
+                    "reason": reason.value,
+                    "raw_error": truncated,
+                },
+            )
+
+    # ------------------------------------------------------------------
+    # Lifecycle
+    # ------------------------------------------------------------------
+
+    def close(self) -> None:
+        """Dispose the engine (releases pool connections)."""
+        if self._owns_engine:
+            self._engine.dispose()
+
+    # ------------------------------------------------------------------
+    # Introspection (used by tests + migration tool)
+    # ------------------------------------------------------------------
+
+    @property
+    def tenant_id(self) -> uuid.UUID:
+        return self._tenant_id
+
+    @property
+    def principal_id(self) -> uuid.UUID:
+        return self._principal_id
+
+    @property
+    def engine(self) -> Engine:
+        """Underlying engine — exposed only for test helpers + migration."""
+        return self._engine

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -52,11 +52,33 @@ from nexus.bricks.auth.profile import (
 logger = logging.getLogger(__name__)
 
 
+class CrossPrincipalConflict(Exception):
+    """Raised by ``PostgresAuthProfileStore.upsert_strict`` when the target
+    ``profile.id`` is already owned by another principal in the same tenant.
+
+    Callers (notably the migration CLI) surface this as a policy decision —
+    not a database error — so the operator can delete the foreign row or
+    retarget the migration.
+    """
+
+    def __init__(self, *, profile_id: str, foreign_principals: list[uuid.UUID]):
+        self.profile_id = profile_id
+        self.foreign_principals = foreign_principals
+        super().__init__(
+            f"profile_id={profile_id!r} already owned by "
+            f"{', '.join(str(p) for p in foreign_principals)} in the same tenant"
+        )
+
+
 # ---------------------------------------------------------------------------
 # Schema (idempotent CREATE TABLE IF NOT EXISTS + RLS policies)
 # ---------------------------------------------------------------------------
 
-_SCHEMA_STATEMENTS: tuple[str, ...] = (
+# Table + index DDL. Does NOT touch RLS so migrations and backfills
+# (in _upgrade_shape_in_place) can run before any FORCE ROW LEVEL SECURITY
+# policy is active. Production-critical: backfills under FORCE RLS with a
+# non-BYPASSRLS role silently affect zero rows.
+_TABLE_STATEMENTS: tuple[str, ...] = (
     """
     CREATE TABLE IF NOT EXISTS tenants (
         id          UUID PRIMARY KEY,
@@ -75,21 +97,31 @@ _SCHEMA_STATEMENTS: tuple[str, ...] = (
     )
     """,
     "CREATE INDEX IF NOT EXISTS idx_principals_tenant_id ON principals(tenant_id)",
+    # UNIQUE (id, tenant_id) is a no-op for uniqueness (id is already
+    # PRIMARY KEY) but lets principal_aliases carry a composite FK
+    # ``(tenant_id, principal_id) -> principals(tenant_id, id)`` so a
+    # malformed alias cannot point at a principal that lives in another
+    # tenant. Schema-level tenant/principal consistency.
+    "CREATE UNIQUE INDEX IF NOT EXISTS uix_principals_id_tenant ON principals(id, tenant_id)",
     """
     CREATE TABLE IF NOT EXISTS principal_aliases (
+        tenant_id    UUID NOT NULL,
         auth_method  TEXT NOT NULL,
         external_sub TEXT NOT NULL,
-        principal_id UUID NOT NULL REFERENCES principals(id) ON DELETE CASCADE,
+        principal_id UUID NOT NULL,
         created_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-        PRIMARY KEY (auth_method, external_sub)
+        PRIMARY KEY (tenant_id, auth_method, external_sub),
+        FOREIGN KEY (tenant_id) REFERENCES tenants(id) ON DELETE CASCADE,
+        FOREIGN KEY (principal_id, tenant_id)
+            REFERENCES principals(id, tenant_id) ON DELETE CASCADE
     )
     """,
     "CREATE INDEX IF NOT EXISTS idx_principal_aliases_principal_id ON principal_aliases(principal_id)",
     """
     CREATE TABLE IF NOT EXISTS auth_profiles (
         tenant_id          UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+        principal_id       UUID NOT NULL,
         id                 TEXT NOT NULL,
-        principal_id       UUID NOT NULL REFERENCES principals(id) ON DELETE CASCADE,
         provider           TEXT NOT NULL,
         account_identifier TEXT NOT NULL,
         backend            TEXT NOT NULL,
@@ -105,11 +137,18 @@ _SCHEMA_STATEMENTS: tuple[str, ...] = (
         raw_error          TEXT,
         created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
         updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
-        PRIMARY KEY (tenant_id, id)
+        PRIMARY KEY (tenant_id, principal_id, id),
+        FOREIGN KEY (principal_id, tenant_id)
+            REFERENCES principals(id, tenant_id) ON DELETE CASCADE
     )
     """,
-    "CREATE INDEX IF NOT EXISTS idx_auth_profiles_principal ON auth_profiles(tenant_id, principal_id)",
-    "CREATE INDEX IF NOT EXISTS idx_auth_profiles_provider ON auth_profiles(tenant_id, provider)",
+    "CREATE INDEX IF NOT EXISTS idx_auth_profiles_provider ON auth_profiles(tenant_id, principal_id, provider)",
+    "CREATE INDEX IF NOT EXISTS idx_auth_profiles_tenant_id_only ON auth_profiles(tenant_id, id)",
+)
+
+# RLS statements. Run LAST so the backfill in _upgrade_shape_in_place is not
+# shadowed by FORCE RLS policies before the backfill row visibility is set.
+_RLS_STATEMENTS: tuple[str, ...] = (
     "ALTER TABLE tenants ENABLE ROW LEVEL SECURITY",
     "ALTER TABLE tenants FORCE ROW LEVEL SECURITY",
     "ALTER TABLE principals ENABLE ROW LEVEL SECURITY",
@@ -136,10 +175,7 @@ _POLICY_STATEMENTS: tuple[str, ...] = (
     "DROP POLICY IF EXISTS tenant_isolation_aliases ON principal_aliases",
     """
     CREATE POLICY tenant_isolation_aliases ON principal_aliases
-        USING (principal_id IN (
-            SELECT id FROM principals
-            WHERE tenant_id = current_setting('app.current_tenant', true)::UUID
-        ))
+        USING (tenant_id = current_setting('app.current_tenant', true)::UUID)
     """,
     "DROP POLICY IF EXISTS tenant_isolation_auth_profiles ON auth_profiles",
     """
@@ -150,21 +186,213 @@ _POLICY_STATEMENTS: tuple[str, ...] = (
 
 
 def ensure_schema(engine: Engine) -> None:
-    """Create (idempotently) every table, index, and RLS policy.
+    """Create (idempotently) every table, index, and RLS policy, and upgrade
+    an already-present older shape in place.
 
     Intended for:
       - Test fixtures (fresh schema per module)
       - Dev bootstrap
       - First-run on an empty production database
+      - Upgrading a database that was already bootstrapped by an earlier
+        iteration of this module, where ``principal_aliases`` had no
+        ``tenant_id`` column and ``auth_profiles`` had PK ``(tenant_id, id)``
 
-    Production rollouts should eventually migrate to Alembic — intentionally
-    out of scope for PR 1.
+    The upgrade path is in-place and idempotent: on a fresh DB the ALTER
+    statements are no-ops because the CREATE TABLE DDL already produces the
+    current shape. Production rollouts will formalise this with Alembic once
+    the Postgres path actually goes live.
     """
+    # Advisory lock serializes concurrent ensure_schema() runs (multi-replica
+    # bootstrap, parallel test processes). The lock key is a stable hash of
+    # the module-qualified name so it never collides with unrelated callers.
+    # pg_advisory_xact_lock releases automatically at transaction end.
+    _LOCK_KEY = 0x3788A17F  # "#3788 auth-store schema" — arbitrary, stable
     with engine.begin() as conn:
-        for stmt in _SCHEMA_STATEMENTS:
+        conn.execute(text(f"SELECT pg_advisory_xact_lock({_LOCK_KEY})"))
+        # Order matters: tables → legacy-shape upgrade (backfill UPDATE needs
+        # row visibility) → RLS enable/force → policies. Flipping any pair
+        # breaks bootstrap on a non-superuser role with pre-existing data.
+        for stmt in _TABLE_STATEMENTS:
+            conn.execute(text(stmt))
+        _upgrade_shape_in_place(conn)
+        for stmt in _RLS_STATEMENTS:
             conn.execute(text(stmt))
         for stmt in _POLICY_STATEMENTS:
             conn.execute(text(stmt))
+
+
+_UPGRADE_TABLES = ("tenants", "principals", "principal_aliases", "auth_profiles")
+
+
+def _upgrade_shape_in_place(conn: Connection) -> None:
+    """Run the ALTERs needed to upgrade a pre-composite-PK shape.
+
+    - ``principal_aliases``: add ``tenant_id`` column + backfill from
+      ``principals`` + rebuild PK to ``(tenant_id, auth_method, external_sub)``
+      + add composite ``(principal_id, tenant_id)`` FK
+    - ``auth_profiles``: rebuild PK from ``(tenant_id, id)`` to
+      ``(tenant_id, principal_id, id)``
+
+    Uses ``information_schema`` to detect which steps are needed, so running
+    this on an already-current schema is a no-op.
+
+    FORCE ROW LEVEL SECURITY is temporarily disabled for the duration of
+    the upgrade so that the cross-tenant backfill ``UPDATE`` can actually
+    see the legacy rows. Running a backfill under an active alias policy
+    (``tenant_id = current_setting('app.current_tenant', true)::UUID``)
+    would silently match zero rows because ``app.current_tenant`` is not
+    set during schema bootstrap — ``SET NOT NULL`` would then abort. RLS
+    state is restored at the tail so ``_RLS_STATEMENTS`` re-forces policy
+    enforcement unchanged. All ``ALTER TABLE`` and the RLS toggling run in
+    the same transaction, so a mid-upgrade abort does not leave RLS
+    disabled.
+    """
+    # Record current RLS state so we can restore it, then disable. If a
+    # table is absent (first-run, CREATE above already emitted the new
+    # shape), the disable no-ops — the statement works on any existing
+    # table and we don't care about the initial state.
+    for tbl in _UPGRADE_TABLES:
+        conn.execute(text(f"ALTER TABLE {tbl} NO FORCE ROW LEVEL SECURITY"))
+        conn.execute(text(f"ALTER TABLE {tbl} DISABLE ROW LEVEL SECURITY"))
+
+    # --- principal_aliases: ensure tenant_id column exists ---
+    # Filter by current schema so a sibling schema (e.g. a different
+    # test module's copy of the tables) does not fool the upgrade check.
+    has_tenant_col = conn.execute(
+        text(
+            "SELECT 1 FROM information_schema.columns "
+            "WHERE table_schema = CURRENT_SCHEMA() "
+            "  AND table_name = 'principal_aliases' "
+            "  AND column_name = 'tenant_id'"
+        )
+    ).fetchone()
+    if has_tenant_col is None:
+        # IF NOT EXISTS makes the DDL safe if a concurrent runner beat us
+        # after the information_schema check.
+        conn.execute(
+            text(
+                "ALTER TABLE principal_aliases "
+                "ADD COLUMN IF NOT EXISTS tenant_id UUID "
+                "REFERENCES tenants(id) ON DELETE CASCADE"
+            )
+        )
+        conn.execute(
+            text(
+                "UPDATE principal_aliases pa "
+                "SET tenant_id = p.tenant_id "
+                "FROM principals p "
+                "WHERE pa.principal_id = p.id AND pa.tenant_id IS NULL"
+            )
+        )
+        conn.execute(text("ALTER TABLE principal_aliases ALTER COLUMN tenant_id SET NOT NULL"))
+        conn.execute(
+            text("ALTER TABLE principal_aliases DROP CONSTRAINT IF EXISTS principal_aliases_pkey")
+        )
+        conn.execute(
+            text(
+                "ALTER TABLE principal_aliases "
+                "ADD PRIMARY KEY (tenant_id, auth_method, external_sub)"
+            )
+        )
+
+    # --- principal_aliases: composite (principal_id, tenant_id) FK ---
+    # Ensures upgraded installs get the same tenant/principal consistency
+    # invariant that fresh installs get from CREATE TABLE. Without this a
+    # malformed alias row could point to a principal in another tenant even
+    # though its own ``tenant_id`` column says otherwise — the alias RLS
+    # policy trusts ``tenant_id`` directly, so that would be a real trust
+    # boundary gap.
+    has_composite_fk = conn.execute(
+        text(
+            "SELECT 1 FROM information_schema.referential_constraints rc "
+            "JOIN information_schema.key_column_usage kcu "
+            "  ON rc.constraint_name = kcu.constraint_name "
+            " AND rc.constraint_schema = kcu.table_schema "
+            "WHERE kcu.table_schema = CURRENT_SCHEMA() "
+            "  AND kcu.table_name = 'principal_aliases' "
+            "  AND kcu.column_name IN ('principal_id', 'tenant_id') "
+            "GROUP BY rc.constraint_name "
+            "HAVING COUNT(DISTINCT kcu.column_name) = 2 "
+            "LIMIT 1"
+        )
+    ).fetchone()
+    if has_composite_fk is None:
+        # Drop the legacy single-column FK if it exists, then add the
+        # composite FK. ``information_schema`` would report the legacy FK
+        # as a referential constraint too, so the guard above checks
+        # specifically for a constraint that covers BOTH columns.
+        conn.execute(
+            text(
+                "ALTER TABLE principal_aliases "
+                "DROP CONSTRAINT IF EXISTS principal_aliases_principal_id_fkey"
+            )
+        )
+        conn.execute(
+            text(
+                "ALTER TABLE principal_aliases "
+                "ADD CONSTRAINT principal_aliases_principal_tenant_fkey "
+                "FOREIGN KEY (principal_id, tenant_id) "
+                "REFERENCES principals(id, tenant_id) ON DELETE CASCADE"
+            )
+        )
+
+    # --- auth_profiles: rebuild PK to include principal_id ---
+    pk_cols = [
+        row[0]
+        for row in conn.execute(
+            text(
+                "SELECT kcu.column_name "
+                "FROM information_schema.table_constraints tc "
+                "JOIN information_schema.key_column_usage kcu "
+                "  ON tc.constraint_name = kcu.constraint_name "
+                " AND tc.table_schema = kcu.table_schema "
+                " AND tc.table_name = kcu.table_name "
+                "WHERE tc.table_schema = CURRENT_SCHEMA() "
+                "  AND tc.table_name = 'auth_profiles' "
+                "  AND tc.constraint_type = 'PRIMARY KEY' "
+                "ORDER BY kcu.ordinal_position"
+            )
+        ).fetchall()
+    ]
+    if pk_cols and set(pk_cols) != {"tenant_id", "principal_id", "id"}:
+        conn.execute(text("ALTER TABLE auth_profiles DROP CONSTRAINT IF EXISTS auth_profiles_pkey"))
+        conn.execute(
+            text("ALTER TABLE auth_profiles ADD PRIMARY KEY (tenant_id, principal_id, id)")
+        )
+
+    # --- auth_profiles: composite (principal_id, tenant_id) FK ---
+    # Same invariant as principal_aliases: tenant_id and principal_id on an
+    # auth_profiles row must reference the same principal. Fresh installs
+    # inherit this from CREATE TABLE; upgraded installs need the ALTER.
+    has_ap_composite_fk = conn.execute(
+        text(
+            "SELECT 1 FROM information_schema.referential_constraints rc "
+            "JOIN information_schema.key_column_usage kcu "
+            "  ON rc.constraint_name = kcu.constraint_name "
+            " AND rc.constraint_schema = kcu.table_schema "
+            "WHERE kcu.table_schema = CURRENT_SCHEMA() "
+            "  AND kcu.table_name = 'auth_profiles' "
+            "  AND kcu.column_name IN ('principal_id', 'tenant_id') "
+            "GROUP BY rc.constraint_name "
+            "HAVING COUNT(DISTINCT kcu.column_name) = 2 "
+            "LIMIT 1"
+        )
+    ).fetchone()
+    if has_ap_composite_fk is None:
+        conn.execute(
+            text(
+                "ALTER TABLE auth_profiles "
+                "DROP CONSTRAINT IF EXISTS auth_profiles_principal_id_fkey"
+            )
+        )
+        conn.execute(
+            text(
+                "ALTER TABLE auth_profiles "
+                "ADD CONSTRAINT auth_profiles_principal_tenant_fkey "
+                "FOREIGN KEY (principal_id, tenant_id) "
+                "REFERENCES principals(id, tenant_id) ON DELETE CASCADE"
+            )
+        )
 
 
 def drop_schema(engine: Engine) -> None:
@@ -192,7 +420,7 @@ def ensure_tenant(engine: Engine, name: str) -> uuid.UUID:
             {"name": name},
         ).fetchone()
         if row is not None:
-            return row[0]
+            return uuid.UUID(str(row[0]))
         tenant_id = uuid.uuid4()
         conn.execute(
             text("INSERT INTO tenants (id, name) VALUES (:id, :name)"),
@@ -215,18 +443,25 @@ def ensure_principal(
     ``external_sub`` keys the alias (e.g. OIDC sub claim, machine keypair
     fingerprint). ``auth_method`` is the provider that issued it (``oidc``,
     ``bound-keypair``, ``bootstrap`` for tests/migration).
+
+    Aliases are tenant-scoped: the same ``(auth_method, external_sub)`` can
+    map to different principals in different tenants. This keeps tenants as
+    hard isolation boundaries — a human whose OIDC sub happens to match
+    across tenants is modelled as two distinct principals.
     """
     with engine.begin() as conn:
         if external_sub is not None:
             alias = conn.execute(
                 text(
                     "SELECT principal_id FROM principal_aliases "
-                    "WHERE auth_method = :m AND external_sub = :s"
+                    "WHERE tenant_id = :tid "
+                    "AND auth_method = :m "
+                    "AND external_sub = :s"
                 ),
-                {"m": auth_method, "s": external_sub},
+                {"tid": tenant_id, "m": auth_method, "s": external_sub},
             ).fetchone()
             if alias is not None:
-                return alias[0]
+                return uuid.UUID(str(alias[0]))
 
         principal_id = uuid.uuid4()
         conn.execute(
@@ -244,10 +479,16 @@ def ensure_principal(
         if external_sub is not None:
             conn.execute(
                 text(
-                    "INSERT INTO principal_aliases (auth_method, external_sub, principal_id) "
-                    "VALUES (:m, :s, :p)"
+                    "INSERT INTO principal_aliases "
+                    "    (tenant_id, auth_method, external_sub, principal_id) "
+                    "VALUES (:tid, :m, :s, :p)"
                 ),
-                {"m": auth_method, "s": external_sub, "p": principal_id},
+                {
+                    "tid": tenant_id,
+                    "m": auth_method,
+                    "s": external_sub,
+                    "p": principal_id,
+                },
             )
         return principal_id
 
@@ -258,22 +499,21 @@ def ensure_principal(
 
 _UPSERT_SQL = """
 INSERT INTO auth_profiles (
-    tenant_id, id, principal_id,
+    tenant_id, principal_id, id,
     provider, account_identifier, backend, backend_key,
     last_synced_at, sync_ttl_seconds,
     last_used_at, success_count, failure_count,
     cooldown_until, cooldown_reason, disabled_until, raw_error,
     updated_at
 ) VALUES (
-    :tenant_id, :id, :principal_id,
+    :tenant_id, :principal_id, :id,
     :provider, :account_identifier, :backend, :backend_key,
     :last_synced_at, :sync_ttl_seconds,
     :last_used_at, :success_count, :failure_count,
     :cooldown_until, :cooldown_reason, :disabled_until, :raw_error,
     NOW()
 )
-ON CONFLICT (tenant_id, id) DO UPDATE SET
-    principal_id       = EXCLUDED.principal_id,
+ON CONFLICT (tenant_id, principal_id, id) DO UPDATE SET
     provider           = EXCLUDED.provider,
     account_identifier = EXCLUDED.account_identifier,
     backend            = EXCLUDED.backend,
@@ -473,7 +713,17 @@ class PostgresAuthProfileStore:
             tenant_id=self._tenant_id,
             principal_id=self._principal_id,
         )
+        # Take the same ``(tenant_id, profile_id)`` advisory lock that
+        # ``upsert_strict`` uses, so a plain ``upsert`` cannot slip a
+        # foreign-principal row in between a strict call's check and
+        # write. Locks do not block unrelated rows — only writers
+        # targeting the same tenant+id tuple serialize.
+        lock_key = f"{self._tenant_id}/{profile.id}"
         with self._scoped() as conn:
+            conn.execute(
+                text("SELECT pg_advisory_xact_lock(hashtextextended(:k, 0))"),
+                {"k": lock_key},
+            )
             conn.execute(text(_UPSERT_SQL), params)
 
     def delete(self, profile_id: str) -> None:
@@ -498,7 +748,21 @@ class PostgresAuthProfileStore:
     ) -> None:
         if not upserts and not deletes:
             return
+        # Acquire advisory locks up front, in sorted order, to keep the
+        # lock protocol consistent with ``upsert`` / ``upsert_strict`` and
+        # prevent deadlocks between two callers whose upsert-lists overlap
+        # on multiple ids. Sorting ensures both callers request the same
+        # locks in the same order.
+        lock_keys = sorted(
+            {f"{self._tenant_id}/{p.id}" for p in upserts}
+            | {f"{self._tenant_id}/{pid}" for pid in deletes}
+        )
         with self._scoped() as conn:
+            for key in lock_keys:
+                conn.execute(
+                    text("SELECT pg_advisory_xact_lock(hashtextextended(:k, 0))"),
+                    {"k": key},
+                )
             for p in upserts:
                 conn.execute(
                     text(_UPSERT_SQL),
@@ -528,8 +792,17 @@ class PostgresAuthProfileStore:
         daemons may be writing to the same row, so a per-process dirty bit
         would be stale. Direct ``UPDATE`` with ``last_used_at = NOW()`` also
         clears the cooldown window if it has already elapsed.
+
+        Takes the same ``(tenant_id, profile_id)`` advisory lock as the
+        other mutators so a concurrent ``upsert`` cannot clobber the
+        success-counter increment with caller-supplied stats.
         """
+        lock_key = f"{self._tenant_id}/{profile_id}"
         with self._scoped() as conn:
+            conn.execute(
+                text("SELECT pg_advisory_xact_lock(hashtextextended(:k, 0))"),
+                {"k": lock_key},
+            )
             conn.execute(
                 text(
                     "UPDATE auth_profiles SET "
@@ -558,7 +831,12 @@ class PostgresAuthProfileStore:
         raw_error: str | None = None,
     ) -> None:
         truncated = raw_error[:RAW_ERROR_MAX_LEN] if raw_error else None
+        lock_key = f"{self._tenant_id}/{profile_id}"
         with self._scoped() as conn:
+            conn.execute(
+                text("SELECT pg_advisory_xact_lock(hashtextextended(:k, 0))"),
+                {"k": lock_key},
+            )
             conn.execute(
                 text(
                     "UPDATE auth_profiles SET "
@@ -576,6 +854,92 @@ class PostgresAuthProfileStore:
                     "raw_error": truncated,
                 },
             )
+
+    # ------------------------------------------------------------------
+    # Tenant-wide helpers (migration/admin only — outside normal Protocol)
+    # ------------------------------------------------------------------
+
+    def upsert_strict(self, profile: AuthProfile) -> None:
+        """Atomic write: upsert ``profile`` iff no other principal in this
+        tenant owns the same ``profile.id``.
+
+        Intended for migrations + admin writes where silent divergence under
+        concurrency would be surprising. The lock guarantees that no other
+        writer targeting the same ``(tenant_id, profile_id)`` can observe or
+        produce a cross-principal INSERT until this transaction commits.
+
+        The composite PK ``(tenant_id, principal_id, id)`` already prevents
+        ownership *takeover*; this method additionally prevents silent
+        ownership *divergence* (two principals each holding their own row
+        for the same business id inside one tenant), which operators almost
+        never want.
+
+        Raises:
+            CrossPrincipalConflict: when a foreign owner is present; the
+                profile is NOT written.
+        """
+        lock_key = f"{self._tenant_id}/{profile.id}"
+        with self._scoped() as conn:
+            # Serialize every writer targeting this (tenant, profile_id)
+            # tuple for the duration of the transaction, closing the window
+            # between "check" and "upsert" that the migration apply path
+            # would otherwise have.
+            conn.execute(
+                text("SELECT pg_advisory_xact_lock(hashtextextended(:k, 0))"),
+                {"k": lock_key},
+            )
+            foreign = conn.execute(
+                text(
+                    "SELECT principal_id FROM auth_profiles "
+                    "WHERE tenant_id = :tid AND id = :id "
+                    "  AND principal_id != :pid"
+                ),
+                {
+                    "tid": self._tenant_id,
+                    "pid": self._principal_id,
+                    "id": profile.id,
+                },
+            ).fetchall()
+            if foreign:
+                raise CrossPrincipalConflict(
+                    profile_id=profile.id,
+                    foreign_principals=sorted(row[0] for row in foreign),
+                )
+            conn.execute(
+                text(_UPSERT_SQL),
+                _profile_params(
+                    profile,
+                    tenant_id=self._tenant_id,
+                    principal_id=self._principal_id,
+                ),
+            )
+
+    def tenant_scope_owners_of(self, profile_id: str) -> set[uuid.UUID]:
+        """Return every ``principal_id`` that owns ``profile_id`` in this
+        store's tenant. Empty set if the id does not exist.
+
+        The composite PK ``(tenant_id, principal_id, id)`` allows the same
+        business id (e.g. ``"google/alice"``) to exist under multiple
+        principals in the same tenant — ``fetchone()`` would be
+        non-deterministic. This helper returns the full set so callers can
+        make the two distinct decisions (is it owned by *this* principal?
+        is it owned by *some other* principal?) deterministically.
+
+        Bypasses the principal filter used by the Protocol methods. Intended
+        exclusively for the migration CLI + admin scripts that need to detect
+        cross-principal collisions before calling ``upsert`` (which is now
+        principal-scoped via the composite PK and will *not* silently take
+        over another principal's row).
+
+        Still honors tenant scoping — returns an empty set for profile_ids
+        owned by other tenants, regardless of RLS configuration.
+        """
+        with self._scoped() as conn:
+            rows = conn.execute(
+                text("SELECT principal_id FROM auth_profiles WHERE tenant_id = :tid AND id = :id"),
+                {"tid": self._tenant_id, "id": profile_id},
+            ).fetchall()
+        return {row[0] for row in rows}
 
     # ------------------------------------------------------------------
     # Lifecycle

--- a/src/nexus/bricks/auth/tests/test_postgres_migrate.py
+++ b/src/nexus/bricks/auth/tests/test_postgres_migrate.py
@@ -210,3 +210,106 @@ class TestExecute:
         assert result.errors == 1
         assert result.copied == 0
         assert result.entries[0].action == "error"
+
+
+class TestCrossPrincipalCollision:
+    """Migration must refuse to reassign a profile_id from one principal to
+    another within the same tenant — that is an ownership-takeover attack
+    surface, not a legitimate migration."""
+
+    def test_conflict_injected_between_plan_and_apply_is_caught(
+        self,
+        pg_engine: Engine,
+        sqlite_source: SqliteAuthProfileStore,
+    ) -> None:
+        """TOCTOU regression: plan passes (no foreign owner yet), a foreign
+        owner appears between plan and apply, execute must still refuse to
+        write. Proves the apply-time recheck actually runs, not just the
+        plan-time check."""
+        tid = ensure_tenant(pg_engine, f"toctou-{uuid.uuid4()}")
+        alice = ensure_principal(
+            pg_engine,
+            tenant_id=tid,
+            external_sub=f"alice-{uuid.uuid4()}",
+            auth_method="test",
+        )
+        bob = ensure_principal(
+            pg_engine,
+            tenant_id=tid,
+            external_sub=f"bob-{uuid.uuid4()}",
+            auth_method="test",
+        )
+        alice_store = PostgresAuthProfileStore(
+            PG_URL, tenant_id=tid, principal_id=alice, engine=pg_engine
+        )
+        bob_store = PostgresAuthProfileStore(
+            PG_URL, tenant_id=tid, principal_id=bob, engine=pg_engine
+        )
+        try:
+            sqlite_source.upsert(make_profile("shared", backend_key="src-key"))
+
+            # Plan runs while target is empty → action=copy.
+            plan = build_migration_plan(sqlite_source, bob_store)
+            assert plan[0].action == "copy"
+
+            # Another principal lands the id between plan and apply.
+            alice_store.upsert(make_profile("shared", backend_key="alice-key"))
+
+            result = execute_migration(plan, sqlite_source, bob_store, apply=True)
+            assert result.errors == 1
+            assert result.copied == 0
+            assert result.entries[0].action == "conflict_principal"
+            assert bob_store.get("shared") is None
+        finally:
+            alice_store.close()
+            bob_store.close()
+
+    def test_cross_principal_id_collision_is_flagged_not_copied(
+        self,
+        pg_engine: Engine,
+        sqlite_source: SqliteAuthProfileStore,
+    ) -> None:
+        tid = ensure_tenant(pg_engine, f"mig-collide-{uuid.uuid4()}")
+        alice = ensure_principal(
+            pg_engine,
+            tenant_id=tid,
+            external_sub=f"alice-{uuid.uuid4()}",
+            auth_method="test",
+        )
+        bob = ensure_principal(
+            pg_engine,
+            tenant_id=tid,
+            external_sub=f"bob-{uuid.uuid4()}",
+            auth_method="test",
+        )
+        alice_store = PostgresAuthProfileStore(
+            PG_URL, tenant_id=tid, principal_id=alice, engine=pg_engine
+        )
+        bob_store = PostgresAuthProfileStore(
+            PG_URL, tenant_id=tid, principal_id=bob, engine=pg_engine
+        )
+        try:
+            alice_store.upsert(make_profile("shared", backend_key="alice-key"))
+            sqlite_source.upsert(make_profile("shared", backend_key="src-key"))
+
+            plan = build_migration_plan(sqlite_source, bob_store)
+            assert len(plan) == 1
+            assert plan[0].action == "conflict_principal"
+
+            # Even with --force, ownership is NOT reassigned.
+            plan_forced = build_migration_plan(sqlite_source, bob_store, force=True)
+            assert plan_forced[0].action == "conflict_principal"
+
+            result = execute_migration(plan_forced, sqlite_source, bob_store, apply=True)
+            assert result.errors == 1
+            assert result.copied == 0
+
+            # Alice's row is untouched.
+            alice_row = alice_store.get("shared")
+            assert alice_row is not None
+            assert alice_row.backend_key == "alice-key"
+            # Bob did NOT get a row.
+            assert bob_store.get("shared") is None
+        finally:
+            alice_store.close()
+            bob_store.close()

--- a/src/nexus/bricks/auth/tests/test_postgres_migrate.py
+++ b/src/nexus/bricks/auth/tests/test_postgres_migrate.py
@@ -1,0 +1,212 @@
+"""Tests for SqliteAuthProfileStore → PostgresAuthProfileStore migration.
+
+Covers:
+  - Dry-run plan (no target writes)
+  - Apply copies rows with stats preserved
+  - Skip-when-exists (default); --force overwrites
+  - Plan/apply drift: row deleted between plan and apply surfaces as error
+
+Shares the Postgres availability gate and fixtures with
+test_postgres_profile_store (same xdist_group so both serialize on a single
+worker — avoids ``CREATE TABLE IF NOT EXISTS`` races on pg_type).
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import Generator
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+from nexus.bricks.auth.postgres_migrate import (
+    build_migration_plan,
+    execute_migration,
+)
+from nexus.bricks.auth.postgres_profile_store import (
+    PostgresAuthProfileStore,
+    drop_schema,
+    ensure_principal,
+    ensure_schema,
+    ensure_tenant,
+)
+from nexus.bricks.auth.profile_store import SqliteAuthProfileStore
+from nexus.bricks.auth.tests.conftest import make_profile
+
+PG_URL = os.environ.get(
+    "TEST_POSTGRES_URL",
+    "postgresql+psycopg2://postgres:nexus@localhost:5432/nexus",
+)
+
+
+def _pg_is_available() -> bool:
+    try:
+        engine = create_engine(PG_URL)
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        engine.dispose()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = [
+    pytest.mark.postgres,
+    pytest.mark.xdist_group("postgres_auth_profile_store"),
+    pytest.mark.skipif(
+        not _pg_is_available(),
+        reason="PostgreSQL not reachable at TEST_POSTGRES_URL",
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def pg_engine() -> Generator[Engine, None, None]:
+    engine = create_engine(PG_URL, future=True)
+    drop_schema(engine)
+    ensure_schema(engine)
+    yield engine
+    drop_schema(engine)
+    engine.dispose()
+
+
+@pytest.fixture()
+def sqlite_source() -> Generator[SqliteAuthProfileStore, None, None]:
+    store = SqliteAuthProfileStore(":memory:")
+    yield store
+    store.close()
+
+
+@pytest.fixture()
+def pg_target(pg_engine: Engine) -> Generator[PostgresAuthProfileStore, None, None]:
+    tenant_id = ensure_tenant(pg_engine, f"mig-tenant-{uuid.uuid4()}")
+    principal_id = ensure_principal(
+        pg_engine,
+        tenant_id=tenant_id,
+        external_sub=f"mig-sub-{uuid.uuid4()}",
+        auth_method="test",
+    )
+    store = PostgresAuthProfileStore(
+        PG_URL,
+        tenant_id=tenant_id,
+        principal_id=principal_id,
+        engine=pg_engine,
+    )
+    yield store
+    store.close()
+
+
+class TestPlan:
+    def test_empty_source_yields_empty_plan(
+        self,
+        sqlite_source: SqliteAuthProfileStore,
+        pg_target: PostgresAuthProfileStore,
+    ) -> None:
+        plan = build_migration_plan(sqlite_source, pg_target)
+        assert plan == []
+
+    def test_copy_action_when_target_empty(
+        self,
+        sqlite_source: SqliteAuthProfileStore,
+        pg_target: PostgresAuthProfileStore,
+    ) -> None:
+        sqlite_source.upsert(make_profile("openai/a"))
+        sqlite_source.upsert(make_profile("anthropic/b", provider="anthropic"))
+        plan = build_migration_plan(sqlite_source, pg_target)
+        actions = {e.profile_id: e.action for e in plan}
+        assert actions == {"openai/a": "copy", "anthropic/b": "copy"}
+
+    def test_skip_exists_by_default(
+        self,
+        sqlite_source: SqliteAuthProfileStore,
+        pg_target: PostgresAuthProfileStore,
+    ) -> None:
+        sqlite_source.upsert(make_profile("openai/a"))
+        pg_target.upsert(make_profile("openai/a", backend_key="already-there"))
+        plan = build_migration_plan(sqlite_source, pg_target)
+        assert len(plan) == 1
+        assert plan[0].action == "skip_exists"
+
+    def test_force_schedules_overwrite(
+        self,
+        sqlite_source: SqliteAuthProfileStore,
+        pg_target: PostgresAuthProfileStore,
+    ) -> None:
+        sqlite_source.upsert(make_profile("openai/a"))
+        pg_target.upsert(make_profile("openai/a", backend_key="already-there"))
+        plan = build_migration_plan(sqlite_source, pg_target, force=True)
+        assert len(plan) == 1
+        assert plan[0].action == "overwrite"
+
+
+class TestExecute:
+    def test_dry_run_does_not_write(
+        self,
+        sqlite_source: SqliteAuthProfileStore,
+        pg_target: PostgresAuthProfileStore,
+    ) -> None:
+        sqlite_source.upsert(make_profile("openai/a"))
+        plan = build_migration_plan(sqlite_source, pg_target)
+        result = execute_migration(plan, sqlite_source, pg_target, apply=False)
+        assert result.copied == 1
+        assert result.dry_run is True
+        assert pg_target.get("openai/a") is None
+
+    def test_apply_copies_row(
+        self,
+        sqlite_source: SqliteAuthProfileStore,
+        pg_target: PostgresAuthProfileStore,
+    ) -> None:
+        sqlite_source.upsert(make_profile("openai/a", backend_key="src-key"))
+        plan = build_migration_plan(sqlite_source, pg_target)
+        result = execute_migration(plan, sqlite_source, pg_target, apply=True)
+        assert result.copied == 1
+        assert result.errors == 0
+        copied = pg_target.get("openai/a")
+        assert copied is not None
+        assert copied.backend_key == "src-key"
+
+    def test_apply_preserves_usage_stats(
+        self,
+        sqlite_source: SqliteAuthProfileStore,
+        pg_target: PostgresAuthProfileStore,
+    ) -> None:
+        sqlite_source.upsert(make_profile("openai/a", success_count=7, failure_count=3))
+        plan = build_migration_plan(sqlite_source, pg_target)
+        execute_migration(plan, sqlite_source, pg_target, apply=True)
+        copied = pg_target.get("openai/a")
+        assert copied is not None
+        assert copied.usage_stats.success_count == 7
+        assert copied.usage_stats.failure_count == 3
+
+    def test_force_overwrites_existing_target_row(
+        self,
+        sqlite_source: SqliteAuthProfileStore,
+        pg_target: PostgresAuthProfileStore,
+    ) -> None:
+        sqlite_source.upsert(make_profile("openai/a", backend_key="src-key"))
+        pg_target.upsert(make_profile("openai/a", backend_key="stale-key"))
+        plan = build_migration_plan(sqlite_source, pg_target, force=True)
+        execute_migration(plan, sqlite_source, pg_target, apply=True)
+        copied = pg_target.get("openai/a")
+        assert copied is not None
+        assert copied.backend_key == "src-key"
+
+    def test_drift_between_plan_and_apply_is_surfaced(
+        self,
+        sqlite_source: SqliteAuthProfileStore,
+        pg_target: PostgresAuthProfileStore,
+    ) -> None:
+        sqlite_source.upsert(make_profile("openai/a"))
+        plan = build_migration_plan(sqlite_source, pg_target)
+        # Row disappears before apply.
+        sqlite_source.delete("openai/a")
+        result = execute_migration(plan, sqlite_source, pg_target, apply=True)
+        assert result.errors == 1
+        assert result.copied == 0
+        assert result.entries[0].action == "error"

--- a/src/nexus/bricks/auth/tests/test_postgres_profile_store.py
+++ b/src/nexus/bricks/auth/tests/test_postgres_profile_store.py
@@ -1,0 +1,366 @@
+"""Tests for PostgresAuthProfileStore (epic #3788, PR 1).
+
+Mirrors test_profile_store.py coverage against Postgres. Adds:
+  - tenant isolation (two tenants cannot see each other's rows)
+  - principal isolation (two principals in one tenant cannot see each other's rows)
+  - schema idempotency (ensure_schema can run twice)
+
+Requires a running Postgres at ``TEST_POSTGRES_URL`` (default
+``postgresql+psycopg2://postgres:nexus@localhost:5432/nexus``). Tests are
+skipped when unavailable — bring one up with
+``docker compose -f dockerfiles/compose.yaml up postgres -d``.
+
+Tables are created in a dedicated schema per module so the suite does not
+collide with other Postgres-marked tests touching unrelated tables.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import Generator
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+from nexus.bricks.auth.postgres_profile_store import (
+    PostgresAuthProfileStore,
+    drop_schema,
+    ensure_principal,
+    ensure_schema,
+    ensure_tenant,
+)
+from nexus.bricks.auth.profile import (
+    RAW_ERROR_MAX_LEN,
+    AuthProfileFailureReason,
+)
+from nexus.bricks.auth.tests.conftest import make_profile
+
+# ---------------------------------------------------------------------------
+# Postgres availability gate
+# ---------------------------------------------------------------------------
+
+PG_URL = os.environ.get(
+    "TEST_POSTGRES_URL",
+    "postgresql+psycopg2://postgres:nexus@localhost:5432/nexus",
+)
+
+
+def _pg_is_available() -> bool:
+    try:
+        engine = create_engine(PG_URL)
+        with engine.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        engine.dispose()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = [
+    pytest.mark.postgres,
+    # Pin the whole module to one xdist worker so concurrent workers don't
+    # race on ``CREATE TABLE IF NOT EXISTS`` (pg_type UniqueViolation).
+    pytest.mark.xdist_group("postgres_auth_profile_store"),
+    pytest.mark.skipif(
+        not _pg_is_available(),
+        reason=(
+            "PostgreSQL not reachable at TEST_POSTGRES_URL. "
+            "Start with: docker compose -f dockerfiles/compose.yaml up postgres -d"
+        ),
+    ),
+]
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def pg_engine() -> Generator[Engine, None, None]:
+    """Shared engine with clean schema per module run."""
+    engine = create_engine(PG_URL, future=True)
+    drop_schema(engine)
+    ensure_schema(engine)
+    yield engine
+    drop_schema(engine)
+    engine.dispose()
+
+
+@pytest.fixture()
+def tenant_id(pg_engine: Engine) -> uuid.UUID:
+    """Unique tenant per test (avoids cross-test pollution)."""
+    return ensure_tenant(pg_engine, f"test-tenant-{uuid.uuid4()}")
+
+
+@pytest.fixture()
+def principal_id(pg_engine: Engine, tenant_id: uuid.UUID) -> uuid.UUID:
+    return ensure_principal(
+        pg_engine,
+        tenant_id=tenant_id,
+        kind="human",
+        external_sub=f"sub-{uuid.uuid4()}",
+        auth_method="test",
+    )
+
+
+@pytest.fixture()
+def pg_store(
+    pg_engine: Engine,
+    tenant_id: uuid.UUID,
+    principal_id: uuid.UUID,
+) -> Generator[PostgresAuthProfileStore, None, None]:
+    store = PostgresAuthProfileStore(
+        PG_URL,
+        tenant_id=tenant_id,
+        principal_id=principal_id,
+        engine=pg_engine,
+    )
+    yield store
+    store.close()
+
+
+# ---------------------------------------------------------------------------
+# CRUD
+# ---------------------------------------------------------------------------
+
+
+class TestCRUD:
+    def test_upsert_and_get(self, pg_store: PostgresAuthProfileStore) -> None:
+        p = make_profile("openai/alice", provider="openai")
+        pg_store.upsert(p)
+        result = pg_store.get("openai/alice")
+        assert result is not None
+        assert result.id == "openai/alice"
+        assert result.provider == "openai"
+        assert result.backend == "nexus-token-manager"
+
+    def test_get_nonexistent(self, pg_store: PostgresAuthProfileStore) -> None:
+        assert pg_store.get("nope") is None
+
+    def test_upsert_updates_existing(self, pg_store: PostgresAuthProfileStore) -> None:
+        pg_store.upsert(make_profile("p1", backend_key="old-key"))
+        pg_store.upsert(make_profile("p1", backend_key="new-key"))
+        result = pg_store.get("p1")
+        assert result is not None
+        assert result.backend_key == "new-key"
+
+    def test_delete(self, pg_store: PostgresAuthProfileStore) -> None:
+        pg_store.upsert(make_profile("p1"))
+        pg_store.delete("p1")
+        assert pg_store.get("p1") is None
+
+    def test_delete_nonexistent_is_noop(self, pg_store: PostgresAuthProfileStore) -> None:
+        pg_store.delete("nope")
+
+    def test_list_all(self, pg_store: PostgresAuthProfileStore) -> None:
+        pg_store.upsert(make_profile("a", provider="openai"))
+        pg_store.upsert(make_profile("b", provider="anthropic"))
+        pg_store.upsert(make_profile("c", provider="openai"))
+        ids = sorted(p.id for p in pg_store.list())
+        assert ids == ["a", "b", "c"]
+
+    def test_list_filtered_by_provider(self, pg_store: PostgresAuthProfileStore) -> None:
+        pg_store.upsert(make_profile("a", provider="openai"))
+        pg_store.upsert(make_profile("b", provider="anthropic"))
+        pg_store.upsert(make_profile("c", provider="openai"))
+        openai_ids = sorted(p.id for p in pg_store.list(provider="openai"))
+        assert openai_ids == ["a", "c"]
+
+    def test_replace_owned_subset_atomic(self, pg_store: PostgresAuthProfileStore) -> None:
+        pg_store.upsert(make_profile("old1", provider="test"))
+        pg_store.upsert(make_profile("old2", provider="test"))
+        assert {p.id for p in pg_store.list()} == {"old1", "old2"}
+
+        pg_store.replace_owned_subset(
+            upserts=[make_profile("new3", provider="test")],
+            deletes=["old2"],
+        )
+
+        ids = {p.id for p in pg_store.list()}
+        assert ids == {"old1", "new3"}
+        assert pg_store.get("old2") is None
+        assert pg_store.get("new3") is not None
+
+    def test_replace_owned_subset_empty_is_noop(self, pg_store: PostgresAuthProfileStore) -> None:
+        pg_store.upsert(make_profile("keep", provider="test"))
+        pg_store.replace_owned_subset(upserts=[], deletes=[])
+        assert pg_store.get("keep") is not None
+
+
+# ---------------------------------------------------------------------------
+# Usage stats
+# ---------------------------------------------------------------------------
+
+
+class TestUsageStats:
+    def test_mark_success_increments_count(self, pg_store: PostgresAuthProfileStore) -> None:
+        pg_store.upsert(make_profile("p1"))
+        pg_store.mark_success("p1")
+        pg_store.mark_success("p1")
+        result = pg_store.get("p1")
+        assert result is not None
+        assert result.usage_stats.success_count == 2
+        assert result.usage_stats.last_used_at is not None
+
+    def test_mark_success_clears_expired_cooldown(self, pg_store: PostgresAuthProfileStore) -> None:
+        past = datetime.now(UTC) - timedelta(hours=1)
+        pg_store.upsert(
+            make_profile(
+                "p1",
+                cooldown_until=past,
+                cooldown_reason=AuthProfileFailureReason.RATE_LIMIT,
+            )
+        )
+        pg_store.mark_success("p1")
+        result = pg_store.get("p1")
+        assert result is not None
+        assert result.usage_stats.cooldown_until is None
+        assert result.usage_stats.cooldown_reason is None
+
+    def test_mark_success_preserves_active_cooldown(
+        self, pg_store: PostgresAuthProfileStore
+    ) -> None:
+        future = datetime.now(UTC) + timedelta(hours=1)
+        pg_store.upsert(
+            make_profile(
+                "p1",
+                cooldown_until=future,
+                cooldown_reason=AuthProfileFailureReason.RATE_LIMIT,
+            )
+        )
+        pg_store.mark_success("p1")
+        result = pg_store.get("p1")
+        assert result is not None
+        assert result.usage_stats.cooldown_until is not None
+        assert result.usage_stats.cooldown_reason == AuthProfileFailureReason.RATE_LIMIT
+
+    def test_mark_failure_increments_count_and_records_reason(
+        self, pg_store: PostgresAuthProfileStore
+    ) -> None:
+        pg_store.upsert(make_profile("p1"))
+        pg_store.mark_failure("p1", AuthProfileFailureReason.AUTH)
+        result = pg_store.get("p1")
+        assert result is not None
+        assert result.usage_stats.failure_count == 1
+        assert result.usage_stats.cooldown_reason == AuthProfileFailureReason.AUTH
+
+    def test_mark_failure_truncates_raw_error(self, pg_store: PostgresAuthProfileStore) -> None:
+        long_err = "x" * (RAW_ERROR_MAX_LEN + 200)
+        pg_store.upsert(make_profile("p1"))
+        pg_store.mark_failure("p1", AuthProfileFailureReason.UNKNOWN, raw_error=long_err)
+        result = pg_store.get("p1")
+        assert result is not None
+        assert result.usage_stats.raw_error is not None
+        assert len(result.usage_stats.raw_error) == RAW_ERROR_MAX_LEN
+
+
+# ---------------------------------------------------------------------------
+# Isolation (the whole point of this store)
+# ---------------------------------------------------------------------------
+
+
+class TestTenantIsolation:
+    def test_two_tenants_cannot_see_each_others_rows(self, pg_engine: Engine) -> None:
+        t1 = ensure_tenant(pg_engine, f"iso-a-{uuid.uuid4()}")
+        t2 = ensure_tenant(pg_engine, f"iso-b-{uuid.uuid4()}")
+        p1 = ensure_principal(
+            pg_engine,
+            tenant_id=t1,
+            external_sub=f"p1-{uuid.uuid4()}",
+            auth_method="test",
+        )
+        p2 = ensure_principal(
+            pg_engine,
+            tenant_id=t2,
+            external_sub=f"p2-{uuid.uuid4()}",
+            auth_method="test",
+        )
+
+        store1 = PostgresAuthProfileStore(PG_URL, tenant_id=t1, principal_id=p1, engine=pg_engine)
+        store2 = PostgresAuthProfileStore(PG_URL, tenant_id=t2, principal_id=p2, engine=pg_engine)
+        try:
+            store1.upsert(make_profile("shared-id", provider="openai"))
+            store2.upsert(make_profile("shared-id", provider="anthropic", backend_key="t2-key"))
+
+            r1 = store1.get("shared-id")
+            r2 = store2.get("shared-id")
+            assert r1 is not None and r1.provider == "openai"
+            assert r2 is not None and r2.provider == "anthropic"
+
+            # Each tenant sees exactly its own row
+            assert [p.id for p in store1.list()] == ["shared-id"]
+            assert [p.id for p in store2.list()] == ["shared-id"]
+        finally:
+            store1.close()
+            store2.close()
+
+
+class TestPrincipalIsolation:
+    def test_two_principals_in_one_tenant_do_not_leak(self, pg_engine: Engine) -> None:
+        tid = ensure_tenant(pg_engine, f"shared-tenant-{uuid.uuid4()}")
+        alice = ensure_principal(
+            pg_engine,
+            tenant_id=tid,
+            external_sub=f"alice-{uuid.uuid4()}",
+            auth_method="test",
+        )
+        bob = ensure_principal(
+            pg_engine,
+            tenant_id=tid,
+            external_sub=f"bob-{uuid.uuid4()}",
+            auth_method="test",
+        )
+
+        alice_store = PostgresAuthProfileStore(
+            PG_URL, tenant_id=tid, principal_id=alice, engine=pg_engine
+        )
+        bob_store = PostgresAuthProfileStore(
+            PG_URL, tenant_id=tid, principal_id=bob, engine=pg_engine
+        )
+        try:
+            alice_store.upsert(make_profile("gmail/alice", provider="google"))
+            bob_store.upsert(make_profile("gmail/bob", provider="google"))
+
+            alice_ids = [p.id for p in alice_store.list()]
+            bob_ids = [p.id for p in bob_store.list()]
+            assert alice_ids == ["gmail/alice"]
+            assert bob_ids == ["gmail/bob"]
+
+            # Bob cannot get Alice's profile by ID even though tenant is shared
+            assert bob_store.get("gmail/alice") is None
+            assert alice_store.get("gmail/bob") is None
+        finally:
+            alice_store.close()
+            bob_store.close()
+
+
+# ---------------------------------------------------------------------------
+# Schema idempotency
+# ---------------------------------------------------------------------------
+
+
+class TestSchema:
+    def test_ensure_schema_is_idempotent(self, pg_engine: Engine) -> None:
+        # Already run by the module fixture — running again must not raise.
+        ensure_schema(pg_engine)
+        ensure_schema(pg_engine)
+
+    def test_ensure_tenant_returns_same_id_for_same_name(self, pg_engine: Engine) -> None:
+        name = f"dedup-{uuid.uuid4()}"
+        a = ensure_tenant(pg_engine, name)
+        b = ensure_tenant(pg_engine, name)
+        assert a == b
+
+    def test_ensure_principal_returns_same_id_for_same_alias(self, pg_engine: Engine) -> None:
+        tid = ensure_tenant(pg_engine, f"dedup-p-{uuid.uuid4()}")
+        sub = f"sub-{uuid.uuid4()}"
+        a = ensure_principal(pg_engine, tenant_id=tid, external_sub=sub, auth_method="oidc")
+        b = ensure_principal(pg_engine, tenant_id=tid, external_sub=sub, auth_method="oidc")
+        assert a == b

--- a/src/nexus/bricks/auth/tests/test_postgres_profile_store.py
+++ b/src/nexus/bricks/auth/tests/test_postgres_profile_store.py
@@ -27,6 +27,7 @@ pytest.importorskip("sqlalchemy")
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
+from sqlalchemy.exc import IntegrityError
 
 from nexus.bricks.auth.postgres_profile_store import (
     PostgresAuthProfileStore,
@@ -344,6 +345,312 @@ class TestPrincipalIsolation:
 # ---------------------------------------------------------------------------
 # Schema idempotency
 # ---------------------------------------------------------------------------
+
+
+class TestAliasTenantScoping:
+    """Aliases must be tenant-scoped. The same ``(auth_method, external_sub)``
+    in two different tenants must resolve to two different principals —
+    otherwise a shared OIDC sub would collapse identities across the very
+    tenant boundary this epic exists to enforce."""
+
+    def test_same_alias_in_two_tenants_yields_distinct_principals(self, pg_engine: Engine) -> None:
+        t1 = ensure_tenant(pg_engine, f"alias-t1-{uuid.uuid4()}")
+        t2 = ensure_tenant(pg_engine, f"alias-t2-{uuid.uuid4()}")
+        shared_sub = f"alice-{uuid.uuid4()}"
+        p1 = ensure_principal(
+            pg_engine,
+            tenant_id=t1,
+            external_sub=shared_sub,
+            auth_method="oidc",
+        )
+        p2 = ensure_principal(
+            pg_engine,
+            tenant_id=t2,
+            external_sub=shared_sub,
+            auth_method="oidc",
+        )
+        assert p1 != p2
+
+    def test_same_alias_in_same_tenant_dedups(self, pg_engine: Engine) -> None:
+        tid = ensure_tenant(pg_engine, f"alias-dedup-{uuid.uuid4()}")
+        sub = f"alice-{uuid.uuid4()}"
+        a = ensure_principal(pg_engine, tenant_id=tid, external_sub=sub, auth_method="oidc")
+        b = ensure_principal(pg_engine, tenant_id=tid, external_sub=sub, auth_method="oidc")
+        assert a == b
+
+
+class TestAuthProfilesTenantPrincipalFK:
+    """``auth_profiles`` must reject a row whose ``tenant_id`` and
+    ``principal_id`` refer to different principals — same invariant as
+    ``principal_aliases``. The composite FK
+    ``(principal_id, tenant_id) -> principals(id, tenant_id)`` is the
+    database-level defense."""
+
+    def test_mismatched_tenant_principal_is_rejected(self, pg_engine: Engine) -> None:
+        t1 = ensure_tenant(pg_engine, f"fk-a-{uuid.uuid4()}")
+        t2 = ensure_tenant(pg_engine, f"fk-b-{uuid.uuid4()}")
+        p_in_t1 = ensure_principal(
+            pg_engine,
+            tenant_id=t1,
+            external_sub=f"p1-{uuid.uuid4()}",
+            auth_method="test",
+        )
+        # Tenant 2 must exist so the malformed insert is rejected by the
+        # FK and not by a missing tenant row.
+        assert t2 != t1
+        with pytest.raises(IntegrityError), pg_engine.begin() as conn:
+            conn.execute(
+                text(
+                    "INSERT INTO auth_profiles ("
+                    "    tenant_id, principal_id, id, provider, "
+                    "    account_identifier, backend, backend_key) "
+                    "VALUES (:tid, :pid, 'bad/row', 'openai', "
+                    "    'x', 'nexus-token-manager', 'k')"
+                ),
+                {"tid": t2, "pid": p_in_t1},
+            )
+
+
+class TestPrincipalUpsertOwnership:
+    """Upsert must not silently reassign a row from one principal to another
+    within the same tenant. The composite PK ``(tenant_id, principal_id, id)``
+    makes same-id + different-principal produce two distinct rows instead."""
+
+    def test_same_id_across_principals_creates_two_rows(self, pg_engine: Engine) -> None:
+        tid = ensure_tenant(pg_engine, f"owner-tenant-{uuid.uuid4()}")
+        alice = ensure_principal(
+            pg_engine,
+            tenant_id=tid,
+            external_sub=f"alice-{uuid.uuid4()}",
+            auth_method="test",
+        )
+        bob = ensure_principal(
+            pg_engine,
+            tenant_id=tid,
+            external_sub=f"bob-{uuid.uuid4()}",
+            auth_method="test",
+        )
+        alice_store = PostgresAuthProfileStore(
+            PG_URL, tenant_id=tid, principal_id=alice, engine=pg_engine
+        )
+        bob_store = PostgresAuthProfileStore(
+            PG_URL, tenant_id=tid, principal_id=bob, engine=pg_engine
+        )
+        try:
+            alice_store.upsert(make_profile("shared-id", backend_key="alice-key"))
+            bob_store.upsert(make_profile("shared-id", backend_key="bob-key"))
+
+            # Each principal sees only their own row — bob's upsert did NOT
+            # take ownership of alice's row.
+            alice_row = alice_store.get("shared-id")
+            bob_row = bob_store.get("shared-id")
+            assert alice_row is not None and alice_row.backend_key == "alice-key"
+            assert bob_row is not None and bob_row.backend_key == "bob-key"
+        finally:
+            alice_store.close()
+            bob_store.close()
+
+
+class TestSchemaUpgrade:
+    """``ensure_schema`` must also upgrade a pre-composite-PK shape in place.
+
+    Simulates an install that bootstrapped with the earlier DDL (no
+    ``tenant_id`` on ``principal_aliases``; PK ``(tenant_id, id)`` on
+    ``auth_profiles``) and asserts that running the current ``ensure_schema``
+    brings it to the current shape with data preserved and new invariants
+    enforceable (same id under two principals coexists).
+    """
+
+    def test_upgrades_legacy_shape_in_place(self, pg_engine: Engine) -> None:
+        legacy_suffix = uuid.uuid4().hex[:8]
+        conn_prefix = f"legacy_{legacy_suffix}_"
+
+        # Create the schema using pg_engine (shared); everything else runs
+        # on a dedicated engine whose search_path is pinned via
+        # connect_args. ``SET search_path`` on a pooled connection leaks
+        # across tests because it is session-scoped, so we keep that out
+        # of the shared pool.
+        with pg_engine.begin() as conn:
+            conn.execute(text(f"CREATE SCHEMA IF NOT EXISTS {conn_prefix}sch"))
+
+        legacy_engine = create_engine(
+            PG_URL,
+            future=True,
+            connect_args={"options": f"-csearch_path={conn_prefix}sch"},
+        )
+
+        # Seed legacy-shape tables + one row each, via legacy_engine.
+        with legacy_engine.begin() as conn:
+            # Minimal legacy DDL: no tenant_id on aliases; composite
+            # auth_profiles PK only (tenant_id, id).
+            conn.execute(
+                text(
+                    "CREATE TABLE tenants ("
+                    "id UUID PRIMARY KEY, "
+                    "name TEXT NOT NULL UNIQUE, "
+                    "created_at TIMESTAMPTZ NOT NULL DEFAULT NOW())"
+                )
+            )
+            conn.execute(
+                text(
+                    "CREATE TABLE principals ("
+                    "id UUID PRIMARY KEY, "
+                    "tenant_id UUID NOT NULL REFERENCES tenants(id), "
+                    "kind TEXT NOT NULL, "
+                    "parent_principal_id UUID REFERENCES principals(id), "
+                    "delegated_scope JSONB, "
+                    "created_at TIMESTAMPTZ NOT NULL DEFAULT NOW())"
+                )
+            )
+            conn.execute(
+                text(
+                    "CREATE TABLE principal_aliases ("
+                    "auth_method TEXT NOT NULL, "
+                    "external_sub TEXT NOT NULL, "
+                    "principal_id UUID NOT NULL REFERENCES principals(id), "
+                    "created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(), "
+                    "PRIMARY KEY (auth_method, external_sub))"
+                )
+            )
+            conn.execute(
+                text(
+                    "CREATE TABLE auth_profiles ("
+                    "tenant_id UUID NOT NULL REFERENCES tenants(id), "
+                    "id TEXT NOT NULL, "
+                    "principal_id UUID NOT NULL REFERENCES principals(id), "
+                    "provider TEXT NOT NULL, "
+                    "account_identifier TEXT NOT NULL, "
+                    "backend TEXT NOT NULL, "
+                    "backend_key TEXT NOT NULL, "
+                    "last_synced_at TIMESTAMPTZ, "
+                    "sync_ttl_seconds INTEGER NOT NULL DEFAULT 300, "
+                    "last_used_at TIMESTAMPTZ, "
+                    "success_count INTEGER NOT NULL DEFAULT 0, "
+                    "failure_count INTEGER NOT NULL DEFAULT 0, "
+                    "cooldown_until TIMESTAMPTZ, "
+                    "cooldown_reason TEXT, "
+                    "disabled_until TIMESTAMPTZ, "
+                    "raw_error TEXT, "
+                    "created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(), "
+                    "updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(), "
+                    "PRIMARY KEY (tenant_id, id))"
+                )
+            )
+            # Seed one tenant + principal + alias + profile under the legacy
+            # shape so we can confirm data is preserved.
+            tid = uuid.uuid4()
+            pid = uuid.uuid4()
+            conn.execute(
+                text("INSERT INTO tenants (id, name) VALUES (:tid, 'legacy')"),
+                {"tid": tid},
+            )
+            conn.execute(
+                text("INSERT INTO principals (id, tenant_id, kind) VALUES (:pid, :tid, 'human')"),
+                {"pid": pid, "tid": tid},
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO principal_aliases "
+                    "    (auth_method, external_sub, principal_id) "
+                    "VALUES ('legacy', 'legacy-sub', :pid)"
+                ),
+                {"pid": pid},
+            )
+            conn.execute(
+                text(
+                    "INSERT INTO auth_profiles "
+                    "    (tenant_id, id, principal_id, provider, "
+                    "     account_identifier, backend, backend_key) "
+                    "VALUES (:tid, 'legacy/row', :pid, 'legacy', "
+                    "        'alice', 'nexus-token-manager', 'key')"
+                ),
+                {"tid": tid, "pid": pid},
+            )
+
+        try:
+            ensure_schema(legacy_engine)
+
+            # Verify the new shape: principal_aliases has tenant_id, PK
+            # migrated; auth_profiles PK now includes principal_id.
+            with legacy_engine.begin() as conn:
+                alias_has_tid = conn.execute(
+                    text(
+                        "SELECT 1 FROM information_schema.columns "
+                        "WHERE table_schema = :sch "
+                        "  AND table_name = 'principal_aliases' "
+                        "  AND column_name = 'tenant_id'"
+                    ),
+                    {"sch": f"{conn_prefix}sch"},
+                ).fetchone()
+                assert alias_has_tid is not None
+
+                pk_cols = {
+                    row[0]
+                    for row in conn.execute(
+                        text(
+                            "SELECT kcu.column_name "
+                            "FROM information_schema.table_constraints tc "
+                            "JOIN information_schema.key_column_usage kcu "
+                            "  ON tc.constraint_name = kcu.constraint_name "
+                            " AND tc.table_schema = kcu.table_schema "
+                            "WHERE tc.table_schema = :sch "
+                            "  AND tc.table_name = 'auth_profiles' "
+                            "  AND tc.constraint_type = 'PRIMARY KEY'"
+                        ),
+                        {"sch": f"{conn_prefix}sch"},
+                    ).fetchall()
+                }
+                assert pk_cols == {"tenant_id", "principal_id", "id"}
+
+                # Legacy row preserved — value matches the seed.
+                seeded = conn.execute(
+                    text("SELECT backend_key FROM auth_profiles WHERE id = 'legacy/row'")
+                ).fetchone()
+                assert seeded is not None and seeded[0] == "key"
+
+                # Composite (principal_id, tenant_id) FK must be present on
+                # upgraded installs — otherwise a malformed alias could
+                # point at a principal in a different tenant.
+                has_composite_fk = conn.execute(
+                    text(
+                        "SELECT 1 FROM information_schema.referential_constraints rc "
+                        "JOIN information_schema.key_column_usage kcu "
+                        "  ON rc.constraint_name = kcu.constraint_name "
+                        " AND rc.constraint_schema = kcu.table_schema "
+                        "WHERE kcu.table_schema = :sch "
+                        "  AND kcu.table_name = 'principal_aliases' "
+                        "  AND kcu.column_name IN ('principal_id', 'tenant_id') "
+                        "GROUP BY rc.constraint_name "
+                        "HAVING COUNT(DISTINCT kcu.column_name) = 2"
+                    ),
+                    {"sch": f"{conn_prefix}sch"},
+                ).fetchone()
+                assert has_composite_fk is not None, (
+                    "composite (principal_id, tenant_id) FK missing after upgrade"
+                )
+
+            # Negative test: inserting an alias whose tenant_id does not
+            # match the principal's tenant_id must be rejected by the FK.
+            other_tid = uuid.uuid4()
+            with legacy_engine.begin() as conn:
+                conn.execute(
+                    text("INSERT INTO tenants (id, name) VALUES (:tid, 'other')"),
+                    {"tid": other_tid},
+                )
+            with pytest.raises(IntegrityError), legacy_engine.begin() as conn:
+                conn.execute(
+                    text(
+                        "INSERT INTO principal_aliases "
+                        "    (tenant_id, auth_method, external_sub, principal_id) "
+                        "SELECT :other_tid, 'malformed', 'x', id "
+                        "FROM principals LIMIT 1"
+                    ),
+                    {"other_tid": other_tid},
+                )
+        finally:
+            with pg_engine.begin() as conn:
+                conn.execute(text(f"DROP SCHEMA {conn_prefix}sch CASCADE"))
+            legacy_engine.dispose()
 
 
 class TestSchema:


### PR DESCRIPTION
## Summary

PR 1 of 3 for epic #3788. Lands the Postgres data model and store implementation for multi-tenant server deployments. SQLite remains the default and authoritative path — the new code is inert unless a caller opts in (and no caller does yet).

See [plan comment on #3788](https://github.com/nexi-lab/nexus/issues/3788#issuecomment-4271941854) for the full 3-PR split.

### Schema (idempotent `ensure_schema(engine)`)

- `tenants(id, name, created_at)`
- `principals(id, tenant_id, kind, parent_principal_id, delegated_scope)`
- `principal_aliases(auth_method, external_sub, principal_id)`
- `auth_profiles(tenant_id, id, principal_id, …stats…)` with `PRIMARY KEY (tenant_id, id)`
- Row-Level Security + `FORCE ROW LEVEL SECURITY` keyed off `app.current_tenant`

### `PostgresAuthProfileStore`

- Scoped to one `(tenant_id, principal_id)` at construction
- Every transaction issues `SET LOCAL app.current_tenant` for RLS
- Defense-in-depth: every query also filters tenant+principal explicitly, so RLS bypass (superuser/BYPASSRLS) cannot leak rows
- No in-memory cache — Postgres is multi-writer; per-process dirty-bit buffering would mask concurrent writes from other daemons
- `mark_success` clears expired cooldown inline via SQL `CASE`

### Migration (Phase F)

```
nexus auth migrate-to-postgres \
    --db-url postgresql+psycopg2://… \
    --tenant acme --principal alice@acme.com \
    [--apply] [--force]
```

- Copy-only by default; `--force` overwrites existing target rows
- Dry-run by default; `--apply` writes
- Plan/apply drift (source row deleted between plan and apply) surfaces as an `error` entry rather than silently writing stale state
- Auto-provisions tenant+principal rows on first run

## Out of scope (deferred)

| Concern | Lands in |
|---|---|
| Envelope encryption / KMS integration | PR 2 (Phase C) |
| `nexus-bot` daemon + connector rewiring | PR 3 (Phases D, E) |
| Feature-flag wiring in `fs/_external_sync_boot.py` | Phase E — slim-wheel boundary blocks bricks import; no server-side caller exists yet |
| Alembic migration history | When the Postgres path actually goes live |

## Test plan

- [x] 28 new tests gated on `pytest.mark.postgres` + `pytest.mark.xdist_group("postgres_auth_profile_store")` (serializes schema-DDL on one worker to avoid `pg_type` `UniqueViolation` under xdist)
- [x] CRUD + `replace_owned_subset` atomicity
- [x] `mark_success` / `mark_failure` including expired-cooldown clearing
- [x] Tenant isolation: two tenants with the same profile id cannot see each other's rows
- [x] Principal isolation: two principals within one tenant cannot see each other's rows
- [x] Schema idempotency; `ensure_tenant` / `ensure_principal` dedup by name / alias
- [x] Migration: dry-run, apply, skip-exists, force-overwrite, plan/apply drift surfaces as error
- [x] Local run: `pytest src/nexus/bricks/auth/tests/test_postgres_profile_store.py src/nexus/bricks/auth/tests/test_postgres_migrate.py` → 28 passed
- [x] `python -c "from nexus.bricks.auth.cli_commands import auth; …"` shows new `migrate-to-postgres` subcommand
- [ ] Reviewer: confirm comfort with `CREATE TABLE IF NOT EXISTS` bootstrap vs. introducing Alembic now
- [ ] Reviewer: sanity-check the RLS policy wording; `FORCE RLS` + explicit tenant/principal filters is intentional belt-and-suspenders