### PR TITLE
fix(factory): restore IPC wiring on edge — /api/v2/ipc/* returns 503

### DIFF
--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -242,16 +242,25 @@ async def _initialize_services(
     """
     # --- IPC adapter bind + mount (extracted from _boot_wired_services) ---
     from nexus.factory._wired import _initialize_wired_ipc
+    from nexus.factory.service_routing import enlist_services
 
     # Build services dict from ServiceRegistry for IPC initialization
     _ipc_services: dict[str, Any] = {}
     _ipc_svc_fn = getattr(nx, "service", None)
     if _ipc_svc_fn is not None:
-        for _ipc_name in ("ipc_provisioner",):
+        for _ipc_name in ("ipc_zone_id", "ipc_provisioner"):
             _ipc_val = _ipc_svc_fn(_ipc_name)
             if _ipc_val is not None:
+                # Unwrap ServiceRef proxy to the raw instance — downstream
+                # consumers (AgentProvisioner, PyO3 Rust bindings) need the
+                # underlying type (str for zone_id, object for provisioner),
+                # not the transparent proxy.
+                _ipc_val = getattr(_ipc_val, "_service_instance", _ipc_val)
                 _ipc_services[_ipc_name] = _ipc_val
     _initialize_wired_ipc(nx, _ipc_services)
+    # _initialize_wired_ipc may have created ipc_provisioner — enlist newly
+    # produced services so /api/v2/ipc/* and lifespan IPC startup can resolve them.
+    await enlist_services(nx, _ipc_services)
 
     # --- Register VFS hooks (INTERCEPT + OBSERVE — Issue #900) ---
     # Issue #1610/#1612/#1613/#1616: All hooks declare hook_spec() (duck-typed).

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -535,6 +535,16 @@ def _initialize_wired_ipc(nx: Any, services: dict[str, Any]) -> None:
     """
     _ipc_zone_id = services.get("ipc_zone_id")
     if _ipc_zone_id is None:
+        # Brick-disabled profiles never register ipc_zone_id — silent skip is correct.
+        # But if the brick IS registered yet missing from `services`, the caller
+        # forgot to thread it through — that's a wiring bug, warn loudly.
+        _svc_fn = getattr(nx, "service", None)
+        if _svc_fn is not None and _svc_fn("ipc_zone_id") is not None:
+            logger.warning(
+                "[BOOT:WIRED] IPC init skipped: ipc_zone_id registered but not "
+                "threaded into services dict — /api/v2/ipc/* will return 503. "
+                "Check caller in _lifecycle.py."
+            )
         return
 
     try:


### PR DESCRIPTION
## Summary

- IPC REST API (`/api/v2/ipc/*`) returns **503 "IPC storage is not available"** on every request against the `:edge` image (and any build off develop since 2026-04-06), because regression in `0f4bb8525` broke the IPC init wiring
- Also breaks every agent registration: `ipc_provisioned: false` because a `ServiceRef` proxy leaks into the PyO3 binding as `zone_id`
- Fix restores three wiring gaps in `src/nexus/factory/_lifecycle.py` + `_wired.py`

## Three bugs stacked

1. `_lifecycle.py` loop only pulled `ipc_provisioner` from the registry, but `_initialize_wired_ipc` reads `services.get("ipc_zone_id")` and silent-returns if missing → `/agents` never mounted, no `AgentProvisioner` ever created
2. After creating `AgentProvisioner`, `_initialize_wired_ipc` stored it only in a local dict — never re-registered with the ServiceRegistry, so `lifespan/ipc.py` got `None` for `ipc_provisioner` and bailed before setting `app.state.ipc_nexus_fs`
3. `nx.service("ipc_zone_id")` returns a transparent `ServiceRef` proxy, not the raw `str`. Passing the proxy to `AgentProvisioner(zone_id=...)` fails inside the Rust binding with `'ServiceRef' object cannot be cast as 'str'` — every `provision()` call failed per-agent

Also upgrades the silent early-return in `_initialize_wired_ipc` to `logger.warning` when `ipc_zone_id` IS registered but missing from the threaded dict — so the next wiring regression surfaces in logs instead of masquerading as a 503.

## Test plan

- [x] Reproduced 503 against `ghcr.io/nexi-lab/nexus:edge` + `NEXUS_PROFILE=full` + real Postgres (matches CI e2e smoke preset)
- [x] Validated end-to-end on `nexus up --build` (shared preset):
  - register alpha + beta with `ipc:true` → `ipc_provisioned: true`, inbox paths assigned
  - `POST /api/v2/ipc/send` alpha→beta → **200** with `message_id`
  - `GET /api/v2/ipc/inbox/{beta}` → **200**, 1 message, correct filename
  - `GET /api/v2/ipc/inbox/{beta}/count` → **200**, count=1
- [x] Boot log now emits full `[IPC] ...` lifecycle: `EventPublisher wired via CacheStore pub/sub`, `TTLSweeper started`, `IPC brick ready`
- [x] `pytest tests/unit/{factory,server,bricks/ipc,core/test_service_registry.py}` → 1248 passed, 3 skipped, 0 failures

## Scope

- Breaks every build off develop since 2026-04-06 (commit `0f4bb8525`). Affects `:edge` and any image derived from it
- `:latest` (last `v*` semver release) is older than the regression, so production releases are not affected
- Present on all presets where the `ipc` brick is enabled (default in FULL)
- Existing CI `e2e-edge` smoke in `.github/workflows/docker-publish.yml` didn't catch this — it never touches `/api/v2/ipc/*`. Follow-up: add an inbox readback probe to that smoke

## Performance

No hot-path changes. All edits are in the one-time startup path (`_initialize_services`). `/api/v2/ipc/*` handlers unchanged — they just see a populated `app.state.ipc_nexus_fs` now.