### PR TITLE
feat(auth): envelope encryption for PostgresAuthProfileStore (#3803)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -288,6 +288,18 @@ jobs:
           uv run pytest tests/e2e/postgres/ --ignore=tests/e2e/postgres/migrations -v --timeout=120 -o "addopts="
         timeout-minutes: 10
 
+      - name: Run auth envelope-encryption tests (#3803)
+        env:
+          TEST_POSTGRES_URL: postgresql+psycopg2://nexus_test:nexus_test@localhost:5432/nexus_test
+        run: |
+          uv run pytest \
+            src/nexus/bricks/auth/tests/test_envelope.py \
+            src/nexus/bricks/auth/tests/test_envelope_contract.py \
+            src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py \
+            src/nexus/bricks/auth/tests/test_rotate_kek_cli.py \
+            -v --timeout=60 -o "addopts="
+        timeout-minutes: 10
+
   e2e-redis:
     name: E2E Tests (Redis)
     needs: build-rust

--- a/docs/guides/auth-envelope-encryption.md
+++ b/docs/guides/auth-envelope-encryption.md
@@ -1,0 +1,59 @@
+# Envelope encryption for auth profiles
+
+`PostgresAuthProfileStore` supports storing resolved credentials encrypted alongside their routing metadata. This guide covers picking and configuring an `EncryptionProvider` for your deployment. Issue: #3803. Spec: `docs/superpowers/specs/2026-04-18-issue-3803-envelope-encryption-design.md`.
+
+## Pick a provider
+
+| Deployment shape | Provider | Rationale |
+|---|---|---|
+| Vault-native shop | `VaultTransitProvider` | Free self-hosted transit engine; per-tenant scoping via `context` parameter with `derived=true`. |
+| AWS-native shop | `AwsKmsProvider` | Managed CMK; AWS-managed rotation; IAM-scoped access; per-tenant CMK keeps blast radius per-tenant. |
+| Development only | `InMemoryEncryptionProvider` | Keys live in process memory — never use in production. |
+
+## Vault Transit setup
+
+1. Enable the transit mount: `vault secrets enable transit`
+2. Create a derived-context key: `vault write -f transit/keys/nexus derived=true`
+3. Grant the Nexus role the `encrypt` and `decrypt` policies on `transit/*/nexus`.
+4. Construct the provider: `VaultTransitProvider(hvac.Client(...), key_name="nexus")`.
+
+Rotation:
+
+1. `vault write -f transit/keys/nexus/rotate` — bumps the key version.
+2. `nexus auth rotate-kek --tenant acme --apply` — per tenant, sweeps rows at the old version.
+
+## AWS KMS setup
+
+1. Create a CMK per tenant (customer-managed key). Enable automatic key rotation: `aws kms enable-key-rotation --key-id <id>`.
+2. Grant the Nexus IAM principal `kms:Encrypt`, `kms:Decrypt`, `kms:DescribeKey` on the CMK.
+3. Constrain via `kms:EncryptionContext:tenant_id` in the key policy to match the tenant value the provider sends — prevents cross-tenant decrypt even if IAM is too broad.
+4. Construct the provider: `AwsKmsProvider(boto3.client("kms"), key_id="arn:aws:kms:...")`.
+
+Rotation: AWS rotates the underlying key material annually with `EnableKeyRotation`. Our `kek_version` in that case tracks provider-config changes (e.g. swapping the CMK alias) — `nexus auth rotate-kek` is a no-op as long as `config_version` is unchanged.
+
+## Rotation CLI
+
+```
+nexus auth rotate-kek --db-url <url> --tenant <name> [--apply] [--batch-size 100] [--max-rows N]
+```
+
+Dry-run by default: reports how many rows are stuck at old `kek_version`. `--apply` rewraps them in `SKIP LOCKED` batches — resumable, doesn't block concurrent writers. Per-row unwrap failures continue the batch; operator investigates and re-runs. Wrap failures at the new version abort the batch (zero rows mutated, non-zero exit).
+
+## Metrics
+
+Provider-level metrics exposed under `/metrics`:
+
+- `auth_dek_cache_hits_total{tenant_id}`
+- `auth_dek_cache_misses_total{tenant_id}`
+- `auth_dek_unwrap_errors_total{tenant_id,error_class}`
+- `auth_dek_unwrap_latency_seconds{tenant_id}`
+- `auth_kek_rotate_rows_total{tenant_id,from_version,to_version}`
+
+Low-cardinality by design: `principal_id` and `profile_id` are deliberately not labels.
+
+## Threat model coverage
+
+- **Ciphertext swap across tenants/principals** — AAD binds `tenant_id|principal_id|profile_id`; decrypt on a row moved to a different tenant raises `AADMismatch` (stored AAD column mismatch) or `WrappedDEKInvalid` (provider derivation/encryption-context mismatch), depending on where the attacker copies from.
+- **`kek_version` downgrade** — each provider binds `kek_version` into the wrap path (Vault Transit: `key_version` on decrypt; AWS KMS: version embedded in the opaque blob; `InMemoryEncryptionProvider`: mixed into the derivation AAD). Claiming a wrapped DEK was produced at a different version fails.
+- **Plaintext in logs / errors** — every `EnvelopeError` subclass has a `__repr__` that carries only `(tenant_id, profile_id, kek_version, cause)`; a test regex asserts no 16+ byte base64/hex blob appears in error text.
+- **Transient KMS/Vault errors** — the DEK cache never caches negative results, so a temporary IAM blip does not pin decrypt-failed for the TTL window.

--- a/docs/guides/auth-envelope-encryption.md
+++ b/docs/guides/auth-envelope-encryption.md
@@ -34,10 +34,16 @@ Rotation: AWS rotates the underlying key material annually with `EnableKeyRotati
 ## Rotation CLI
 
 ```
-nexus auth rotate-kek --db-url <url> --tenant <name> [--apply] [--batch-size 100] [--max-rows N]
+nexus auth rotate-kek --db-url <url> (--tenant <name>|--tenant-id <uuid>) \
+  --provider (vault|aws-kms) [provider options] \
+  [--apply] [--allow-failures] [--batch-size 100] [--max-rows N]
 ```
 
-Dry-run by default: reports how many rows are stuck at old `kek_version`. `--apply` rewraps them in `SKIP LOCKED` batches — resumable, doesn't block concurrent writers. Per-row unwrap failures continue the batch; operator investigates and re-runs. Wrap failures at the new version abort the batch (zero rows mutated, non-zero exit).
+Dry-run by default: reports how many rows are stuck at old `kek_version`. `--apply` rewraps them in `SKIP LOCKED` batches — resumable, doesn't block concurrent writers. Per-row unwrap failures continue the batch; the command exits non-zero when any row fails unless `--allow-failures` is set. Wrap failures at the new version abort the batch (zero rows mutated, non-zero exit).
+
+**Tenant identifier:** pass `--tenant-id <uuid>` under least-privilege DB roles. `--tenant <name>` requires read access to `tenants.name`, which FORCE RLS blocks for non-BYPASSRLS roles.
+
+**Schema preflight:** rotation is read-only for DDL. Run `ensure_schema()` once at deploy time under a role with ALTER privileges; rotation then works under the least-privilege role.
 
 ## Metrics
 

--- a/docs/superpowers/plans/2026-04-18-issue-3803-envelope-encryption.md
+++ b/docs/superpowers/plans/2026-04-18-issue-3803-envelope-encryption.md
@@ -1,0 +1,3163 @@
+# Envelope encryption for `PostgresAuthProfileStore` — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add server-side envelope encryption rails to `PostgresAuthProfileStore` so rows can carry resolved credentials alongside the routing metadata they already carry. Ciphertext is opt-in per call through a new sub-protocol; PR 1 rows stay readable.
+
+**Architecture:** New `EncryptionProvider` trait with AES-256-GCM DEK per row wrapped by a KEK held by Vault Transit or AWS KMS. AAD binds `tenant_id|principal_id|profile_id`. `CredentialCarryingProfileStore(AuthProfileStore)` sub-protocol adds `upsert_with_credential` / `get_with_credential` on the Postgres store; SQLite/InMemory stores untouched. CLI-driven `rotate_kek_for_tenant` admin helper sweeps old `kek_version` rows in `SKIP LOCKED` batches. DEK cache amortizes KMS round-trips on hot reads.
+
+**Tech Stack:** Python 3.11+, `cryptography` (already in repo, used by `auth/oauth/crypto.py`), SQLAlchemy 2.x, Click for CLI, `prometheus_client` (already in repo), pytest + `@pytest.mark.postgres` + `xdist_group`. Optional deps (opt-in providers): `hvac` (Vault), `boto3` (AWS KMS) — lazy-imported at module level.
+
+**Spec:** `docs/superpowers/specs/2026-04-18-issue-3803-envelope-encryption-design.md`
+
+---
+
+## File Structure
+
+### New files
+
+- `src/nexus/bricks/auth/envelope.py` — `EncryptionProvider` Protocol, `AESGCMEnvelope`, `DEKCache`, `EnvelopeError` hierarchy.
+- `src/nexus/bricks/auth/envelope_metrics.py` — Prometheus counters/histograms.
+- `src/nexus/bricks/auth/envelope_providers/__init__.py` — empty package marker.
+- `src/nexus/bricks/auth/envelope_providers/in_memory.py` — `InMemoryEncryptionProvider` test fake (real AEAD, call counters).
+- `src/nexus/bricks/auth/envelope_providers/vault_transit.py` — `VaultTransitProvider` (lazy `hvac`).
+- `src/nexus/bricks/auth/envelope_providers/aws_kms.py` — `AwsKmsProvider` (lazy `boto3`).
+- `src/nexus/bricks/auth/tests/test_envelope.py` — unit tests for primitives.
+- `src/nexus/bricks/auth/tests/test_envelope_contract.py` — parametrized contract suite.
+- `src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py` — acceptance tests (postgres-gated).
+- `src/nexus/bricks/auth/tests/test_rotate_kek_cli.py` — rotation CLI tests (postgres-gated).
+- `src/nexus/bricks/auth/tests/test_envelope_providers_vault.py` — `@pytest.mark.vault` integration.
+- `src/nexus/bricks/auth/tests/test_envelope_providers_aws_kms.py` — `@pytest.mark.kms` integration.
+- `docs/guides/auth-envelope-encryption.md` — deployment guidance (Vault vs KMS).
+
+### Modified files
+
+- `src/nexus/bricks/auth/profile.py` — add `CredentialCarryingProfileStore` Protocol. Import `ResolvedCredential` already present.
+- `src/nexus/bricks/auth/postgres_profile_store.py` — schema delta (5 new nullable columns + CHECK), `_upgrade_shape_in_place` additions, new `upsert_with_credential`/`get_with_credential` methods, ctor accepts `encryption_provider`, module-level `rotate_kek_for_tenant` helper + `RotationReport` dataclass.
+- `src/nexus/bricks/auth/cli_commands.py` — new `rotate-kek` subcommand.
+- `pyproject.toml` — add `vault` and `kms` optional-dep groups for `hvac` and `boto3` if not already present (verify first).
+
+---
+
+## Task ordering principle
+
+TDD end-to-end: each task writes a failing test, verifies failure, implements, verifies pass, commits. Tasks are ordered bottom-up (primitives → providers → store integration → CLI) so every step has dependencies already in place.
+
+---
+
+### Task 1: `AESGCMEnvelope` primitive
+
+**Files:**
+- Create: `src/nexus/bricks/auth/envelope.py`
+- Test: `src/nexus/bricks/auth/tests/test_envelope.py`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `src/nexus/bricks/auth/tests/test_envelope.py`:
+
+```python
+"""Unit tests for envelope encryption primitives (issue #3803)."""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.bricks.auth.envelope import AESGCMEnvelope, CiphertextCorrupted
+
+
+class TestAESGCMEnvelope:
+    def test_roundtrip(self) -> None:
+        env = AESGCMEnvelope()
+        dek = b"\x00" * 32
+        plaintext = b"hello credential"
+        aad = b"tenant|principal|id"
+        nonce, ciphertext = env.encrypt(dek, plaintext, aad=aad)
+        assert len(nonce) == 12
+        assert ciphertext != plaintext
+        assert env.decrypt(dek, nonce, ciphertext, aad=aad) == plaintext
+
+    def test_wrong_aad_fails(self) -> None:
+        env = AESGCMEnvelope()
+        dek = b"\x01" * 32
+        nonce, ct = env.encrypt(dek, b"secret", aad=b"aad-A")
+        with pytest.raises(CiphertextCorrupted):
+            env.decrypt(dek, nonce, ct, aad=b"aad-B")
+
+    def test_ciphertext_tamper_fails(self) -> None:
+        env = AESGCMEnvelope()
+        dek = b"\x02" * 32
+        nonce, ct = env.encrypt(dek, b"secret", aad=b"aad")
+        tampered = bytes([ct[0] ^ 0x01]) + ct[1:]
+        with pytest.raises(CiphertextCorrupted):
+            env.decrypt(dek, nonce, tampered, aad=b"aad")
+
+    def test_fresh_nonce_per_encrypt(self) -> None:
+        env = AESGCMEnvelope()
+        dek = b"\x03" * 32
+        n1, _ = env.encrypt(dek, b"x", aad=b"aad")
+        n2, _ = env.encrypt(dek, b"x", aad=b"aad")
+        assert n1 != n2
+
+    def test_dek_must_be_32_bytes(self) -> None:
+        env = AESGCMEnvelope()
+        with pytest.raises(ValueError):
+            env.encrypt(b"\x00" * 16, b"x", aad=b"aad")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_envelope.py -v
+```
+
+Expected: collection error / `ModuleNotFoundError: No module named 'nexus.bricks.auth.envelope'`.
+
+- [ ] **Step 3: Implement `envelope.py` with `AESGCMEnvelope` + error types**
+
+Create `src/nexus/bricks/auth/envelope.py`:
+
+```python
+"""Envelope encryption primitives for PostgresAuthProfileStore (issue #3803).
+
+Provides:
+  - AESGCMEnvelope: AES-256-GCM wrapper for per-row ciphertext + DEK.
+  - EncryptionProvider: Protocol for KEK-level DEK wrap/unwrap (impls land in
+    envelope_providers/).
+  - DEKCache: in-process TTL+LRU cache of unwrapped DEKs.
+  - EnvelopeError hierarchy with no-plaintext repr discipline.
+
+Design: docs/superpowers/specs/2026-04-18-issue-3803-envelope-encryption-design.md
+"""
+
+from __future__ import annotations
+
+import secrets
+import uuid
+from typing import Protocol, runtime_checkable
+
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+# ---------------------------------------------------------------------------
+# Error hierarchy — no plaintext, wrapped-DEK, or ciphertext bytes in str/repr
+# ---------------------------------------------------------------------------
+
+
+class EnvelopeError(Exception):
+    """Root of every error raised by the envelope subsystem."""
+
+
+class EnvelopeConfigurationError(EnvelopeError):
+    """Provider is misconfigured (e.g. Vault transit key not derived=true)."""
+
+
+class DecryptionFailed(EnvelopeError):
+    """Generic decrypt failure. Concrete subclasses narrow the reason."""
+
+
+class AADMismatch(DecryptionFailed):
+    """Stored AAD column does not match the expected tenant|principal|id."""
+
+
+class WrappedDEKInvalid(DecryptionFailed):
+    """Provider refused to unwrap the DEK (IAM, mismatched context, corrupt)."""
+
+
+class CiphertextCorrupted(DecryptionFailed):
+    """AES-GCM tag verification failed — ciphertext/nonce/AAD tampered."""
+
+
+# ---------------------------------------------------------------------------
+# AES-256-GCM primitive
+# ---------------------------------------------------------------------------
+
+
+class AESGCMEnvelope:
+    """Thin wrapper over `cryptography`'s AESGCM with our invariants baked in.
+
+    - DEK is 32 bytes (AES-256).
+    - Nonce is 12 bytes, freshly generated per ``encrypt`` call.
+    - AAD is bound into the AEAD tag; tamper raises ``CiphertextCorrupted``.
+    """
+
+    NONCE_LEN = 12
+    DEK_LEN = 32
+
+    def encrypt(self, dek: bytes, plaintext: bytes, *, aad: bytes) -> tuple[bytes, bytes]:
+        if len(dek) != self.DEK_LEN:
+            raise ValueError(f"DEK must be {self.DEK_LEN} bytes, got {len(dek)}")
+        nonce = secrets.token_bytes(self.NONCE_LEN)
+        ciphertext = AESGCM(dek).encrypt(nonce, plaintext, aad)
+        return nonce, ciphertext
+
+    def decrypt(self, dek: bytes, nonce: bytes, ciphertext: bytes, *, aad: bytes) -> bytes:
+        if len(dek) != self.DEK_LEN:
+            raise ValueError(f"DEK must be {self.DEK_LEN} bytes, got {len(dek)}")
+        try:
+            return AESGCM(dek).decrypt(nonce, ciphertext, aad)
+        except InvalidTag as exc:
+            raise CiphertextCorrupted("AES-GCM tag verification failed") from exc
+
+
+# ---------------------------------------------------------------------------
+# EncryptionProvider Protocol (impls in envelope_providers/)
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class EncryptionProvider(Protocol):
+    """KEK-level DEK wrap/unwrap.
+
+    ``wrap_dek`` always uses the provider's current version and returns it
+    alongside the wrapped bytes. ``unwrap_dek`` takes the stored ``kek_version``
+    because rows persist history — Vault Transit takes ``key_version`` on
+    decrypt natively; AWS KMS ignores it (the ciphertext blob embeds the key
+    version internally) so ``kek_version`` is bookkeeping-only there.
+    """
+
+    def current_version(self, *, tenant_id: uuid.UUID) -> int: ...
+
+    def wrap_dek(
+        self,
+        dek: bytes,
+        *,
+        tenant_id: uuid.UUID,
+        aad: bytes,
+    ) -> tuple[bytes, int]:
+        """Return ``(wrapped_bytes, kek_version)``."""
+        ...
+
+    def unwrap_dek(
+        self,
+        wrapped: bytes,
+        *,
+        tenant_id: uuid.UUID,
+        aad: bytes,
+        kek_version: int,
+    ) -> bytes: ...
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_envelope.py -v
+```
+
+Expected: all 5 tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/auth/envelope.py src/nexus/bricks/auth/tests/test_envelope.py
+git commit -m "feat(auth): AESGCMEnvelope primitive + EnvelopeError hierarchy (#3803)"
+```
+
+---
+
+### Task 2: Error `repr`/`str` no-plaintext guarantee
+
+**Files:**
+- Modify: `src/nexus/bricks/auth/envelope.py` (add `__str__` / `__repr__` to errors)
+- Test: `src/nexus/bricks/auth/tests/test_envelope.py` (append tests)
+
+- [ ] **Step 1: Append failing tests**
+
+Append to `src/nexus/bricks/auth/tests/test_envelope.py`:
+
+```python
+import re
+
+from nexus.bricks.auth.envelope import (
+    AADMismatch,
+    DecryptionFailed,
+    EnvelopeConfigurationError,
+    EnvelopeError,
+    WrappedDEKInvalid,
+)
+
+# Regex: any base64 or hex blob of 16+ bytes shouldn't appear in error text.
+_BLOB_RE = re.compile(r"(?:[A-Za-z0-9+/]{22,}={0,2}|[0-9a-fA-F]{32,})")
+
+
+class TestErrorReprDiscipline:
+    def test_all_errors_carry_context_not_secrets(self) -> None:
+        import uuid
+
+        tenant = uuid.uuid4()
+        pid = "google/alice"
+        for cls in (EnvelopeConfigurationError, DecryptionFailed, AADMismatch, WrappedDEKInvalid):
+            err = cls.from_row(tenant_id=tenant, profile_id=pid, kek_version=7, cause="RuntimeError")
+            text = f"{err} || {err!r}"
+            assert str(tenant) in text
+            assert pid in text
+            assert "7" in text
+            assert "RuntimeError" in text
+            assert _BLOB_RE.search(text) is None, f"{cls.__name__} repr leaked a blob: {text!r}"
+
+    def test_envelope_error_root_is_catchable(self) -> None:
+        import uuid
+
+        with pytest.raises(EnvelopeError):
+            raise DecryptionFailed.from_row(
+                tenant_id=uuid.uuid4(), profile_id="x", kek_version=1, cause="y"
+            )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_envelope.py::TestErrorReprDiscipline -v
+```
+
+Expected: FAIL — `AttributeError: type object 'EnvelopeConfigurationError' has no attribute 'from_row'`.
+
+- [ ] **Step 3: Add `from_row` classmethod + `__str__`/`__repr__` to every error**
+
+Edit `src/nexus/bricks/auth/envelope.py` — replace the error-class block with:
+
+```python
+import uuid
+
+
+class EnvelopeError(Exception):
+    """Root of every error raised by the envelope subsystem.
+
+    All subclasses expose ``from_row(tenant_id, profile_id, kek_version, cause)``
+    so call sites never build error messages inline — that discipline is what
+    keeps plaintext / wrapped-DEK bytes out of ``__str__`` / ``__repr__``.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        tenant_id: uuid.UUID | None = None,
+        profile_id: str | None = None,
+        kek_version: int | None = None,
+        cause: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self._message = message
+        self.tenant_id = tenant_id
+        self.profile_id = profile_id
+        self.kek_version = kek_version
+        self.cause = cause
+
+    @classmethod
+    def from_row(
+        cls,
+        *,
+        tenant_id: uuid.UUID,
+        profile_id: str,
+        kek_version: int,
+        cause: str,
+    ) -> "EnvelopeError":
+        return cls(
+            f"{cls.__name__} tenant={tenant_id} profile={profile_id} "
+            f"kek_version={kek_version} cause={cause}",
+            tenant_id=tenant_id,
+            profile_id=profile_id,
+            kek_version=kek_version,
+            cause=cause,
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"{type(self).__name__}(tenant_id={self.tenant_id!s}, "
+            f"profile_id={self.profile_id!r}, kek_version={self.kek_version!r}, "
+            f"cause={self.cause!r})"
+        )
+
+
+class EnvelopeConfigurationError(EnvelopeError):
+    pass
+
+
+class DecryptionFailed(EnvelopeError):
+    pass
+
+
+class AADMismatch(DecryptionFailed):
+    pass
+
+
+class WrappedDEKInvalid(DecryptionFailed):
+    pass
+
+
+class CiphertextCorrupted(DecryptionFailed):
+    pass
+```
+
+Also update `AESGCMEnvelope.decrypt`'s raise site:
+
+```python
+        except InvalidTag as exc:
+            raise CiphertextCorrupted(
+                "AES-GCM tag verification failed",
+                cause="InvalidTag",
+            ) from exc
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_envelope.py -v
+```
+
+Expected: all tests pass (5 from Task 1 + 2 new).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/auth/envelope.py src/nexus/bricks/auth/tests/test_envelope.py
+git commit -m "feat(auth): EnvelopeError no-plaintext repr discipline (#3803)"
+```
+
+---
+
+### Task 3: `DEKCache` with TTL + LRU + metrics hooks
+
+**Files:**
+- Modify: `src/nexus/bricks/auth/envelope.py` (append `DEKCache`)
+- Test: `src/nexus/bricks/auth/tests/test_envelope.py` (append tests)
+
+- [ ] **Step 1: Append failing tests**
+
+```python
+import hashlib
+import time
+
+from nexus.bricks.auth.envelope import DEKCache
+
+
+class TestDEKCache:
+    def test_hit_after_put(self) -> None:
+        cache = DEKCache(ttl_seconds=60, max_entries=8)
+        key = cache.make_key(tenant_id="t", kek_version=1, wrapped_dek=b"abcd")
+        cache.put(key, b"\x00" * 32)
+        assert cache.get(key) == b"\x00" * 32
+        assert cache.hits == 1
+        assert cache.misses == 0
+
+    def test_miss_on_empty(self) -> None:
+        cache = DEKCache(ttl_seconds=60, max_entries=8)
+        key = cache.make_key(tenant_id="t", kek_version=1, wrapped_dek=b"abcd")
+        assert cache.get(key) is None
+        assert cache.misses == 1
+        assert cache.hits == 0
+
+    def test_ttl_expires(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        now = [1000.0]
+        monkeypatch.setattr("nexus.bricks.auth.envelope._monotonic", lambda: now[0])
+        cache = DEKCache(ttl_seconds=5, max_entries=8)
+        key = cache.make_key(tenant_id="t", kek_version=1, wrapped_dek=b"abcd")
+        cache.put(key, b"\x11" * 32)
+        now[0] += 4
+        assert cache.get(key) == b"\x11" * 32
+        now[0] += 2  # total 6s > ttl
+        assert cache.get(key) is None
+
+    def test_lru_eviction_on_size(self) -> None:
+        cache = DEKCache(ttl_seconds=60, max_entries=2)
+        k1 = cache.make_key(tenant_id="t", kek_version=1, wrapped_dek=b"1")
+        k2 = cache.make_key(tenant_id="t", kek_version=1, wrapped_dek=b"2")
+        k3 = cache.make_key(tenant_id="t", kek_version=1, wrapped_dek=b"3")
+        cache.put(k1, b"\x01" * 32)
+        cache.put(k2, b"\x02" * 32)
+        cache.get(k1)  # bump k1 to MRU
+        cache.put(k3, b"\x03" * 32)  # evicts k2 (LRU)
+        assert cache.get(k1) == b"\x01" * 32
+        assert cache.get(k2) is None
+        assert cache.get(k3) == b"\x03" * 32
+
+    def test_key_uses_wrapped_dek_hash_not_bytes(self) -> None:
+        cache = DEKCache(ttl_seconds=60, max_entries=8)
+        key = cache.make_key(tenant_id="t", kek_version=1, wrapped_dek=b"raw-wrapped-dek-bytes")
+        # Repr of the key should not contain "raw-wrapped-dek-bytes"
+        assert b"raw-wrapped-dek-bytes" not in repr(key).encode()
+        expected_digest = hashlib.sha256(b"raw-wrapped-dek-bytes").hexdigest()
+        assert expected_digest in repr(key)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_envelope.py::TestDEKCache -v
+```
+
+Expected: FAIL — `ImportError: cannot import name 'DEKCache'`.
+
+- [ ] **Step 3: Append `DEKCache` to `envelope.py`**
+
+At the top, add:
+
+```python
+import hashlib
+import time
+from collections import OrderedDict
+from dataclasses import dataclass
+
+
+def _monotonic() -> float:
+    """Indirection so tests can monkeypatch the clock."""
+    return time.monotonic()
+
+
+@dataclass(frozen=True, slots=True)
+class DEKCacheKey:
+    tenant_id: str
+    kek_version: int
+    wrapped_dek_sha256: str
+
+    def __repr__(self) -> str:
+        return (
+            f"DEKCacheKey(tenant={self.tenant_id}, v={self.kek_version}, "
+            f"sha256={self.wrapped_dek_sha256})"
+        )
+
+
+class DEKCache:
+    """TTL + LRU cache for unwrapped DEKs.
+
+    Keyed by ``(tenant_id, kek_version, sha256(wrapped_dek))`` — the hash, not
+    the wrapped bytes, so cache-key logging is safe. Does not cache negative
+    results: a KMS/Vault blip shouldn't pin decrypt-failed for the TTL window.
+    """
+
+    def __init__(self, *, ttl_seconds: int = 300, max_entries: int = 1024) -> None:
+        self._ttl = ttl_seconds
+        self._max = max_entries
+        self._store: OrderedDict[DEKCacheKey, tuple[float, bytes]] = OrderedDict()
+        self.hits = 0
+        self.misses = 0
+
+    @staticmethod
+    def make_key(
+        *, tenant_id: str | uuid.UUID, kek_version: int, wrapped_dek: bytes
+    ) -> DEKCacheKey:
+        return DEKCacheKey(
+            tenant_id=str(tenant_id),
+            kek_version=kek_version,
+            wrapped_dek_sha256=hashlib.sha256(wrapped_dek).hexdigest(),
+        )
+
+    def get(self, key: DEKCacheKey) -> bytes | None:
+        entry = self._store.get(key)
+        if entry is None:
+            self.misses += 1
+            return None
+        expires_at, dek = entry
+        if _monotonic() >= expires_at:
+            self._store.pop(key, None)
+            self.misses += 1
+            return None
+        self._store.move_to_end(key)  # mark MRU
+        self.hits += 1
+        return dek
+
+    def put(self, key: DEKCacheKey, dek: bytes) -> None:
+        self._store[key] = (_monotonic() + self._ttl, dek)
+        self._store.move_to_end(key)
+        while len(self._store) > self._max:
+            self._store.popitem(last=False)  # evict LRU
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_envelope.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/auth/envelope.py src/nexus/bricks/auth/tests/test_envelope.py
+git commit -m "feat(auth): DEKCache with TTL + LRU (#3803)"
+```
+
+---
+
+### Task 4: `InMemoryEncryptionProvider` test fake + package init
+
+**Files:**
+- Create: `src/nexus/bricks/auth/envelope_providers/__init__.py`
+- Create: `src/nexus/bricks/auth/envelope_providers/in_memory.py`
+- Test: `src/nexus/bricks/auth/tests/test_envelope.py` (append)
+
+- [ ] **Step 1: Append failing tests**
+
+```python
+from nexus.bricks.auth.envelope_providers.in_memory import InMemoryEncryptionProvider
+
+
+class TestInMemoryEncryptionProvider:
+    def test_roundtrip(self) -> None:
+        prov = InMemoryEncryptionProvider()
+        import uuid
+
+        tid = uuid.uuid4()
+        dek = b"\x22" * 32
+        wrapped, version = prov.wrap_dek(dek, tenant_id=tid, aad=b"aad")
+        assert version == 1
+        assert wrapped != dek
+        assert prov.unwrap_dek(wrapped, tenant_id=tid, aad=b"aad", kek_version=1) == dek
+
+    def test_current_version_bumps_after_rotate(self) -> None:
+        prov = InMemoryEncryptionProvider()
+        import uuid
+
+        tid = uuid.uuid4()
+        assert prov.current_version(tenant_id=tid) == 1
+        prov.rotate()
+        assert prov.current_version(tenant_id=tid) == 2
+
+    def test_wrap_at_v2_unwrap_at_v1_still_works(self) -> None:
+        prov = InMemoryEncryptionProvider()
+        import uuid
+
+        tid = uuid.uuid4()
+        dek = b"\x33" * 32
+        wrapped_v1, v1 = prov.wrap_dek(dek, tenant_id=tid, aad=b"a")
+        prov.rotate()
+        wrapped_v2, v2 = prov.wrap_dek(dek, tenant_id=tid, aad=b"a")
+        assert v1 == 1 and v2 == 2
+        # Both readable
+        assert prov.unwrap_dek(wrapped_v1, tenant_id=tid, aad=b"a", kek_version=v1) == dek
+        assert prov.unwrap_dek(wrapped_v2, tenant_id=tid, aad=b"a", kek_version=v2) == dek
+
+    def test_wrong_tenant_unwrap_fails(self) -> None:
+        from nexus.bricks.auth.envelope import WrappedDEKInvalid
+
+        prov = InMemoryEncryptionProvider()
+        import uuid
+
+        tid_a, tid_b = uuid.uuid4(), uuid.uuid4()
+        dek = b"\x44" * 32
+        wrapped, v = prov.wrap_dek(dek, tenant_id=tid_a, aad=b"a")
+        with pytest.raises(WrappedDEKInvalid):
+            prov.unwrap_dek(wrapped, tenant_id=tid_b, aad=b"a", kek_version=v)
+
+    def test_wrong_aad_unwrap_fails(self) -> None:
+        from nexus.bricks.auth.envelope import WrappedDEKInvalid
+
+        prov = InMemoryEncryptionProvider()
+        import uuid
+
+        tid = uuid.uuid4()
+        wrapped, v = prov.wrap_dek(b"\x55" * 32, tenant_id=tid, aad=b"aad-A")
+        with pytest.raises(WrappedDEKInvalid):
+            prov.unwrap_dek(wrapped, tenant_id=tid, aad=b"aad-B", kek_version=v)
+
+    def test_counters(self) -> None:
+        prov = InMemoryEncryptionProvider()
+        import uuid
+
+        tid = uuid.uuid4()
+        w, v = prov.wrap_dek(b"\x66" * 32, tenant_id=tid, aad=b"a")
+        prov.unwrap_dek(w, tenant_id=tid, aad=b"a", kek_version=v)
+        prov.unwrap_dek(w, tenant_id=tid, aad=b"a", kek_version=v)
+        assert prov.wrap_count == 1
+        assert prov.unwrap_count == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_envelope.py::TestInMemoryEncryptionProvider -v
+```
+
+Expected: FAIL — `ModuleNotFoundError: No module named 'nexus.bricks.auth.envelope_providers'`.
+
+- [ ] **Step 3: Create the package and the in-memory provider**
+
+Create `src/nexus/bricks/auth/envelope_providers/__init__.py`:
+
+```python
+"""Concrete EncryptionProvider implementations (issue #3803).
+
+- in_memory.InMemoryEncryptionProvider: test fake + default for development.
+- vault_transit.VaultTransitProvider: Vault Transit (``derived=true``).
+- aws_kms.AwsKmsProvider: AWS KMS per-tenant CMK.
+"""
+```
+
+Create `src/nexus/bricks/auth/envelope_providers/in_memory.py`:
+
+```python
+"""In-process fake EncryptionProvider for tests + development.
+
+Uses real AES-256-GCM so the wrapped bytes are actual ciphertext (not
+identity). Holds a dict of KEKs keyed by version. ``rotate()`` bumps the
+current version and mints a new KEK. Exposes ``wrap_count`` /
+``unwrap_count`` so contract tests can assert cache amortization.
+
+Never use in production: keys live in process memory and die with it.
+"""
+
+from __future__ import annotations
+
+import secrets
+import uuid
+
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from nexus.bricks.auth.envelope import (
+    AESGCMEnvelope,
+    EncryptionProvider,
+    WrappedDEKInvalid,
+)
+
+
+class InMemoryEncryptionProvider(EncryptionProvider):
+    """Fake provider with real AEAD under the hood.
+
+    Tenant scoping is modelled by mixing ``tenant_id`` into the AAD that wraps
+    the DEK — unwrap with the wrong ``tenant_id`` fails the AES-GCM tag, so
+    cross-tenant DEK reuse is rejected just like the real providers reject
+    mismatched encryption-context / derivation-context.
+    """
+
+    def __init__(self) -> None:
+        self._versions: dict[int, bytes] = {1: secrets.token_bytes(32)}
+        self._current_version = 1
+        self._nonce_len = 12
+        self.wrap_count = 0
+        self.unwrap_count = 0
+
+    def rotate(self) -> None:
+        """Bump current_version and mint a new KEK (keep old versions readable)."""
+        self._current_version += 1
+        self._versions[self._current_version] = secrets.token_bytes(32)
+
+    def current_version(self, *, tenant_id: uuid.UUID) -> int:
+        return self._current_version
+
+    def _context_aad(self, tenant_id: uuid.UUID, aad: bytes) -> bytes:
+        return f"v=inmem|tenant={tenant_id}|".encode() + aad
+
+    def wrap_dek(
+        self, dek: bytes, *, tenant_id: uuid.UUID, aad: bytes
+    ) -> tuple[bytes, int]:
+        self.wrap_count += 1
+        version = self._current_version
+        kek = self._versions[version]
+        nonce = secrets.token_bytes(self._nonce_len)
+        ct = AESGCM(kek).encrypt(nonce, dek, self._context_aad(tenant_id, aad))
+        return nonce + ct, version
+
+    def unwrap_dek(
+        self,
+        wrapped: bytes,
+        *,
+        tenant_id: uuid.UUID,
+        aad: bytes,
+        kek_version: int,
+    ) -> bytes:
+        self.unwrap_count += 1
+        if kek_version not in self._versions:
+            raise WrappedDEKInvalid.from_row(
+                tenant_id=tenant_id,
+                profile_id="<unknown>",
+                kek_version=kek_version,
+                cause="kek_version not known to InMemoryEncryptionProvider",
+            )
+        kek = self._versions[kek_version]
+        nonce, ct = wrapped[: self._nonce_len], wrapped[self._nonce_len :]
+        try:
+            return AESGCM(kek).decrypt(nonce, ct, self._context_aad(tenant_id, aad))
+        except InvalidTag as exc:
+            raise WrappedDEKInvalid.from_row(
+                tenant_id=tenant_id,
+                profile_id="<unknown>",
+                kek_version=kek_version,
+                cause="AES-GCM tag mismatch (wrong tenant_id/aad/kek_version)",
+            ) from exc
+
+
+__all__ = ["InMemoryEncryptionProvider"]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_envelope.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/auth/envelope_providers/ src/nexus/bricks/auth/tests/test_envelope.py
+git commit -m "feat(auth): InMemoryEncryptionProvider test fake (#3803)"
+```
+
+---
+
+### Task 5: Shared contract test suite
+
+**Files:**
+- Create: `src/nexus/bricks/auth/tests/test_envelope_contract.py`
+
+- [ ] **Step 1: Write the contract tests**
+
+Create `src/nexus/bricks/auth/tests/test_envelope_contract.py`:
+
+```python
+"""Shared contract tests every EncryptionProvider must pass (issue #3803).
+
+Parametrized against InMemoryEncryptionProvider by default. Provider-specific
+test modules (Vault, AWS KMS) import these and re-parametrize with their own
+``provider_factory`` fixtures gated by ``@pytest.mark.vault`` / ``@pytest.mark.kms``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+
+import pytest
+
+from nexus.bricks.auth.envelope import EncryptionProvider, WrappedDEKInvalid
+from nexus.bricks.auth.envelope_providers.in_memory import InMemoryEncryptionProvider
+
+
+@pytest.fixture()
+def provider_factory() -> Callable[[], EncryptionProvider]:
+    return InMemoryEncryptionProvider
+
+
+class EnvelopeProviderContract:
+    """Subclassed by provider-specific modules with their own fixture."""
+
+    def test_wrap_unwrap_roundtrip(self, provider_factory) -> None:
+        prov = provider_factory()
+        dek = b"\x77" * 32
+        tid = uuid.uuid4()
+        wrapped, version = prov.wrap_dek(dek, tenant_id=tid, aad=b"aad-x")
+        assert version >= 1
+        assert prov.unwrap_dek(wrapped, tenant_id=tid, aad=b"aad-x", kek_version=version) == dek
+
+    def test_unwrap_with_wrong_tenant_fails(self, provider_factory) -> None:
+        prov = provider_factory()
+        dek = b"\x78" * 32
+        wrapped, v = prov.wrap_dek(dek, tenant_id=uuid.uuid4(), aad=b"aad")
+        with pytest.raises(WrappedDEKInvalid):
+            prov.unwrap_dek(wrapped, tenant_id=uuid.uuid4(), aad=b"aad", kek_version=v)
+
+    def test_unwrap_with_wrong_aad_fails(self, provider_factory) -> None:
+        prov = provider_factory()
+        tid = uuid.uuid4()
+        wrapped, v = prov.wrap_dek(b"\x79" * 32, tenant_id=tid, aad=b"aad-A")
+        with pytest.raises(WrappedDEKInvalid):
+            prov.unwrap_dek(wrapped, tenant_id=tid, aad=b"aad-B", kek_version=v)
+
+
+class TestInMemoryContract(EnvelopeProviderContract):
+    """Runs the full contract suite against the in-memory fake."""
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_envelope_contract.py -v
+```
+
+Expected: 3 tests pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/nexus/bricks/auth/tests/test_envelope_contract.py
+git commit -m "test(auth): shared EncryptionProvider contract suite (#3803)"
+```
+
+---
+
+### Task 6: `envelope_metrics.py` (Prometheus)
+
+**Files:**
+- Create: `src/nexus/bricks/auth/envelope_metrics.py`
+
+- [ ] **Step 1: Create the metrics module**
+
+```python
+"""Prometheus metrics for envelope encryption (issue #3803).
+
+Low-cardinality labels only: tenant_id is acceptable (single-digit tenants at
+this scale); principal_id and profile_id are NOT labels — they'd explode the
+time-series count.
+
+Metrics:
+  - auth_dek_cache_hits_total{tenant_id}
+  - auth_dek_cache_misses_total{tenant_id}
+  - auth_dek_unwrap_errors_total{tenant_id,error_class}
+  - auth_dek_unwrap_latency_seconds{tenant_id}
+  - auth_kek_rotate_rows_total{tenant_id,from_version,to_version}
+"""
+
+from __future__ import annotations
+
+from prometheus_client import Counter, Histogram
+
+DEK_CACHE_HITS = Counter(
+    "auth_dek_cache_hits_total",
+    "Number of DEK cache hits on the decrypt path.",
+    labelnames=["tenant_id"],
+)
+
+DEK_CACHE_MISSES = Counter(
+    "auth_dek_cache_misses_total",
+    "Number of DEK cache misses (KMS/Vault round-trip required).",
+    labelnames=["tenant_id"],
+)
+
+DEK_UNWRAP_ERRORS = Counter(
+    "auth_dek_unwrap_errors_total",
+    "EncryptionProvider.unwrap_dek failures.",
+    labelnames=["tenant_id", "error_class"],
+)
+
+DEK_UNWRAP_LATENCY = Histogram(
+    "auth_dek_unwrap_latency_seconds",
+    "Time spent in EncryptionProvider.unwrap_dek.",
+    labelnames=["tenant_id"],
+    buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0),
+)
+
+KEK_ROTATE_ROWS = Counter(
+    "auth_kek_rotate_rows_total",
+    "Rows rewrapped to a new kek_version by rotate_kek_for_tenant.",
+    labelnames=["tenant_id", "from_version", "to_version"],
+)
+
+__all__ = [
+    "DEK_CACHE_HITS",
+    "DEK_CACHE_MISSES",
+    "DEK_UNWRAP_ERRORS",
+    "DEK_UNWRAP_LATENCY",
+    "KEK_ROTATE_ROWS",
+]
+```
+
+- [ ] **Step 2: Smoke-import test**
+
+Append to `src/nexus/bricks/auth/tests/test_envelope.py`:
+
+```python
+class TestMetricsImport:
+    def test_all_metrics_defined(self) -> None:
+        from nexus.bricks.auth import envelope_metrics as m
+
+        for name in (
+            "DEK_CACHE_HITS",
+            "DEK_CACHE_MISSES",
+            "DEK_UNWRAP_ERRORS",
+            "DEK_UNWRAP_LATENCY",
+            "KEK_ROTATE_ROWS",
+        ):
+            assert hasattr(m, name), f"missing metric: {name}"
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_envelope.py::TestMetricsImport -v
+```
+
+Expected: pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/nexus/bricks/auth/envelope_metrics.py src/nexus/bricks/auth/tests/test_envelope.py
+git commit -m "feat(auth): envelope_metrics Prometheus counters (#3803)"
+```
+
+---
+
+### Task 7: `CredentialCarryingProfileStore` sub-protocol
+
+**Files:**
+- Modify: `src/nexus/bricks/auth/profile.py`
+- Test: `src/nexus/bricks/auth/tests/test_envelope.py` (append protocol smoke-check)
+
+- [ ] **Step 1: Append failing test**
+
+```python
+class TestCredentialCarryingProtocol:
+    def test_protocol_defines_two_methods(self) -> None:
+        from nexus.bricks.auth.profile import CredentialCarryingProfileStore
+
+        assert hasattr(CredentialCarryingProfileStore, "upsert_with_credential")
+        assert hasattr(CredentialCarryingProfileStore, "get_with_credential")
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_envelope.py::TestCredentialCarryingProtocol -v
+```
+
+Expected: FAIL — `ImportError`.
+
+- [ ] **Step 3: Extend `profile.py`**
+
+Append to `src/nexus/bricks/auth/profile.py`, after the existing `AuthProfileStore` Protocol:
+
+```python
+# ---------------------------------------------------------------------------
+# CredentialCarryingProfileStore sub-protocol (issue #3803)
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class CredentialCarryingProfileStore(AuthProfileStore, Protocol):
+    """Sub-protocol for stores that additionally hold encrypted credentials.
+
+    Only ``PostgresAuthProfileStore`` implements this today. Consumers that
+    need the resolved credential inline (rather than via a ``CredentialBackend``
+    pointer) type-annotate against this protocol instead of the base one.
+
+    Rows written via plain ``upsert`` are compatible: ``get_with_credential``
+    returns ``(profile, None)`` in that case.
+    """
+
+    def upsert_with_credential(
+        self, profile: AuthProfile, credential: ResolvedCredential
+    ) -> None:
+        """Insert or update ``profile`` and store ``credential`` encrypted."""
+        ...
+
+    def get_with_credential(
+        self, profile_id: str
+    ) -> tuple[AuthProfile, ResolvedCredential | None] | None:
+        """Return ``(profile, credential | None)`` or ``None`` if absent.
+
+        ``credential`` is ``None`` when the row has no ciphertext columns (PR 1
+        routing-only rows).
+        """
+        ...
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_envelope.py::TestCredentialCarryingProtocol -v
+```
+
+Expected: pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/auth/profile.py src/nexus/bricks/auth/tests/test_envelope.py
+git commit -m "feat(auth): CredentialCarryingProfileStore sub-protocol (#3803)"
+```
+
+---
+
+### Task 8: Schema delta — 5 encryption columns + CHECK + upgrade path
+
+**Files:**
+- Modify: `src/nexus/bricks/auth/postgres_profile_store.py`
+- Test: `src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py` (new)
+
+- [ ] **Step 1: Create new postgres test module with the CHECK-constraint test**
+
+Create `src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py`:
+
+```python
+"""Integration tests for envelope encryption on PostgresAuthProfileStore (#3803).
+
+Postgres-gated; uses the same TEST_POSTGRES_URL + xdist_group shape as
+test_postgres_profile_store.py.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import Generator
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import IntegrityError
+
+from nexus.bricks.auth.postgres_profile_store import (
+    PostgresAuthProfileStore,
+    drop_schema,
+    ensure_principal,
+    ensure_schema,
+    ensure_tenant,
+)
+from nexus.bricks.auth.tests.conftest import make_profile
+
+PG_URL = os.environ.get(
+    "TEST_POSTGRES_URL",
+    "postgresql+psycopg2://postgres:nexus@localhost:5432/nexus",
+)
+
+
+def _pg_is_available() -> bool:
+    try:
+        eng = create_engine(PG_URL)
+        with eng.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        eng.dispose()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = [
+    pytest.mark.postgres,
+    pytest.mark.xdist_group("postgres_auth_profile_store"),
+    pytest.mark.skipif(
+        not _pg_is_available(),
+        reason=(
+            "PostgreSQL not reachable at TEST_POSTGRES_URL. "
+            "Start with: docker compose -f dockerfiles/compose.yaml up postgres -d"
+        ),
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def pg_engine() -> Generator[Engine, None, None]:
+    engine = create_engine(PG_URL, future=True)
+    drop_schema(engine)
+    ensure_schema(engine)
+    yield engine
+    drop_schema(engine)
+    engine.dispose()
+
+
+@pytest.fixture()
+def tenant_id(pg_engine: Engine) -> uuid.UUID:
+    return ensure_tenant(pg_engine, f"env-tenant-{uuid.uuid4()}")
+
+
+@pytest.fixture()
+def principal_id(pg_engine: Engine, tenant_id: uuid.UUID) -> uuid.UUID:
+    return ensure_principal(
+        pg_engine,
+        tenant_id=tenant_id,
+        kind="human",
+        external_sub=f"sub-{uuid.uuid4()}",
+        auth_method="test",
+    )
+
+
+class TestSchema:
+    def test_check_constraint_rejects_half_written_row(
+        self, pg_engine: Engine, tenant_id: uuid.UUID, principal_id: uuid.UUID
+    ) -> None:
+        """Direct INSERT with 4 of 5 encryption columns set must fail."""
+        with pg_engine.begin() as conn, pytest.raises(IntegrityError):
+            conn.execute(
+                text(
+                    "INSERT INTO auth_profiles "
+                    "(tenant_id, principal_id, id, provider, account_identifier, "
+                    " backend, backend_key, "
+                    " ciphertext, wrapped_dek, nonce, aad) "  # 4 of 5, missing kek_version
+                    "VALUES "
+                    "(:tid, :pid, 'broken', 'p', 'p', 'b', 'k', "
+                    " :ct, :wd, :n, :a)"
+                ),
+                {
+                    "tid": tenant_id,
+                    "pid": principal_id,
+                    "ct": b"ct",
+                    "wd": b"wd",
+                    "n": b"n",
+                    "a": b"a",
+                },
+            )
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py -v
+```
+
+Expected: FAIL — columns `ciphertext`/`wrapped_dek`/`nonce`/`aad` don't exist (`UndefinedColumn`).
+
+- [ ] **Step 3: Add columns + CHECK to `_TABLE_STATEMENTS` in `postgres_profile_store.py`**
+
+In `src/nexus/bricks/auth/postgres_profile_store.py`, extend the `auth_profiles` CREATE TABLE inside `_TABLE_STATEMENTS`:
+
+```python
+    """
+    CREATE TABLE IF NOT EXISTS auth_profiles (
+        tenant_id          UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+        principal_id       UUID NOT NULL,
+        id                 TEXT NOT NULL,
+        provider           TEXT NOT NULL,
+        account_identifier TEXT NOT NULL,
+        backend            TEXT NOT NULL,
+        backend_key        TEXT NOT NULL,
+        last_synced_at     TIMESTAMPTZ,
+        sync_ttl_seconds   INTEGER NOT NULL DEFAULT 300,
+        last_used_at       TIMESTAMPTZ,
+        success_count      INTEGER NOT NULL DEFAULT 0,
+        failure_count      INTEGER NOT NULL DEFAULT 0,
+        cooldown_until     TIMESTAMPTZ,
+        cooldown_reason    TEXT,
+        disabled_until     TIMESTAMPTZ,
+        raw_error          TEXT,
+        ciphertext         BYTEA,
+        wrapped_dek        BYTEA,
+        nonce              BYTEA,
+        aad                BYTEA,
+        kek_version        INTEGER,
+        created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        PRIMARY KEY (tenant_id, principal_id, id),
+        FOREIGN KEY (principal_id, tenant_id)
+            REFERENCES principals(id, tenant_id) ON DELETE CASCADE,
+        CONSTRAINT auth_profiles_envelope_all_or_none CHECK (
+            (ciphertext IS NULL) = (wrapped_dek IS NULL)
+            AND (ciphertext IS NULL) = (nonce IS NULL)
+            AND (ciphertext IS NULL) = (aad IS NULL)
+            AND (ciphertext IS NULL) = (kek_version IS NULL)
+        )
+    )
+    """,
+```
+
+- [ ] **Step 4: Add upgrade path in `_upgrade_shape_in_place`**
+
+Append inside `_upgrade_shape_in_place`, after the existing `auth_profiles` upgrade block:
+
+```python
+    # --- auth_profiles: envelope encryption columns (issue #3803) ---
+    for col, decl in (
+        ("ciphertext", "BYTEA"),
+        ("wrapped_dek", "BYTEA"),
+        ("nonce", "BYTEA"),
+        ("aad", "BYTEA"),
+        ("kek_version", "INTEGER"),
+    ):
+        conn.execute(
+            text(
+                f"ALTER TABLE auth_profiles ADD COLUMN IF NOT EXISTS {col} {decl}"
+            )
+        )
+    # CHECK constraint. Use DROP ... IF EXISTS + ADD for idempotency.
+    conn.execute(
+        text(
+            "ALTER TABLE auth_profiles "
+            "DROP CONSTRAINT IF EXISTS auth_profiles_envelope_all_or_none"
+        )
+    )
+    conn.execute(
+        text(
+            "ALTER TABLE auth_profiles "
+            "ADD CONSTRAINT auth_profiles_envelope_all_or_none CHECK ("
+            "    (ciphertext IS NULL) = (wrapped_dek IS NULL)"
+            "    AND (ciphertext IS NULL) = (nonce IS NULL)"
+            "    AND (ciphertext IS NULL) = (aad IS NULL)"
+            "    AND (ciphertext IS NULL) = (kek_version IS NULL)"
+            ")"
+        )
+    )
+```
+
+- [ ] **Step 5: Run the new test + the existing postgres test suite**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py -v
+pytest src/nexus/bricks/auth/tests/test_postgres_profile_store.py -v
+```
+
+Expected: the CHECK test passes; the existing PR 1 tests all still pass (schema is backwards-compatible).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/nexus/bricks/auth/postgres_profile_store.py src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
+git commit -m "feat(auth): envelope encryption schema columns + CHECK (#3803)"
+```
+
+---
+
+### Task 9: `upsert_with_credential` + `get_with_credential` on `PostgresAuthProfileStore`
+
+**Files:**
+- Modify: `src/nexus/bricks/auth/postgres_profile_store.py`
+- Test: `src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py` (append)
+
+- [ ] **Step 1: Append failing test**
+
+```python
+from nexus.bricks.auth.credential_backend import ResolvedCredential
+from nexus.bricks.auth.envelope_providers.in_memory import InMemoryEncryptionProvider
+
+
+@pytest.fixture()
+def encryption_provider() -> InMemoryEncryptionProvider:
+    return InMemoryEncryptionProvider()
+
+
+@pytest.fixture()
+def pg_store_crypto(
+    pg_engine: Engine,
+    tenant_id: uuid.UUID,
+    principal_id: uuid.UUID,
+    encryption_provider: InMemoryEncryptionProvider,
+) -> Generator[PostgresAuthProfileStore, None, None]:
+    store = PostgresAuthProfileStore(
+        PG_URL,
+        tenant_id=tenant_id,
+        principal_id=principal_id,
+        engine=pg_engine,
+        encryption_provider=encryption_provider,
+    )
+    yield store
+    store.close()
+
+
+class TestEncryptedUpsertAndGet:
+    def test_roundtrip(self, pg_store_crypto: PostgresAuthProfileStore) -> None:
+        profile = make_profile("google/alice")
+        cred = ResolvedCredential(
+            kind="bearer_token",
+            access_token="ya29.fake",
+            scopes=("https://www.googleapis.com/auth/userinfo.email",),
+        )
+        pg_store_crypto.upsert_with_credential(profile, cred)
+        got = pg_store_crypto.get_with_credential("google/alice")
+        assert got is not None
+        p, c = got
+        assert p.id == "google/alice"
+        assert c is not None
+        assert c.access_token == "ya29.fake"
+        assert c.scopes == ("https://www.googleapis.com/auth/userinfo.email",)
+
+    def test_get_returns_none_for_missing(
+        self, pg_store_crypto: PostgresAuthProfileStore
+    ) -> None:
+        assert pg_store_crypto.get_with_credential("does-not-exist") is None
+
+    def test_pr1_row_returns_none_credential(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        pg_engine: Engine,
+        tenant_id: uuid.UUID,
+        principal_id: uuid.UUID,
+    ) -> None:
+        """A row written via plain upsert reads back (profile, None)."""
+        plain_store = PostgresAuthProfileStore(
+            PG_URL,
+            tenant_id=tenant_id,
+            principal_id=principal_id,
+            engine=pg_engine,
+        )
+        plain_store.upsert(make_profile("openai/bob"))
+        got = pg_store_crypto.get_with_credential("openai/bob")
+        assert got is not None
+        p, c = got
+        assert p.id == "openai/bob"
+        assert c is None
+
+    def test_ctor_without_provider_rejects_crypto_methods(
+        self,
+        pg_engine: Engine,
+        tenant_id: uuid.UUID,
+        principal_id: uuid.UUID,
+    ) -> None:
+        store = PostgresAuthProfileStore(
+            PG_URL,
+            tenant_id=tenant_id,
+            principal_id=principal_id,
+            engine=pg_engine,
+        )
+        try:
+            with pytest.raises(RuntimeError, match="encryption_provider"):
+                store.upsert_with_credential(
+                    make_profile("x"),
+                    ResolvedCredential(kind="api_key", api_key="k"),
+                )
+            with pytest.raises(RuntimeError, match="encryption_provider"):
+                store.get_with_credential("x")
+        finally:
+            store.close()
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py::TestEncryptedUpsertAndGet -v
+```
+
+Expected: FAIL — `upsert_with_credential` / `get_with_credential` don't exist; ctor doesn't accept `encryption_provider`.
+
+- [ ] **Step 3: Implement the methods**
+
+In `src/nexus/bricks/auth/postgres_profile_store.py`:
+
+Add imports near the top:
+
+```python
+import hashlib
+import json
+import secrets
+from dataclasses import asdict
+from datetime import datetime
+
+from nexus.bricks.auth.credential_backend import ResolvedCredential
+from nexus.bricks.auth.envelope import (
+    AADMismatch,
+    AESGCMEnvelope,
+    DEKCache,
+    EncryptionProvider,
+    WrappedDEKInvalid,
+)
+from nexus.bricks.auth.envelope_metrics import (
+    DEK_CACHE_HITS,
+    DEK_CACHE_MISSES,
+    DEK_UNWRAP_ERRORS,
+    DEK_UNWRAP_LATENCY,
+)
+```
+
+Extend the ctor signature:
+
+```python
+    def __init__(
+        self,
+        db_url: str,
+        *,
+        tenant_id: uuid.UUID | str,
+        principal_id: uuid.UUID | str,
+        engine: Engine | None = None,
+        pool_size: int = 5,
+        encryption_provider: EncryptionProvider | None = None,
+        dek_cache: DEKCache | None = None,
+    ) -> None:
+        self._tenant_id = uuid.UUID(str(tenant_id))
+        self._principal_id = uuid.UUID(str(principal_id))
+        if engine is None:
+            self._engine = create_engine(
+                db_url,
+                pool_size=pool_size,
+                pool_pre_ping=True,
+                future=True,
+            )
+            self._owns_engine = True
+        else:
+            self._engine = engine
+            self._owns_engine = False
+        self._encryption_provider = encryption_provider
+        self._aesgcm = AESGCMEnvelope()
+        self._dek_cache = dek_cache or DEKCache()
+```
+
+Add helpers + new methods. Place them right before `# Tenant-wide helpers`:
+
+```python
+    # ------------------------------------------------------------------
+    # Envelope encryption (issue #3803)
+    # ------------------------------------------------------------------
+
+    def _require_provider(self) -> EncryptionProvider:
+        if self._encryption_provider is None:
+            raise RuntimeError(
+                "encryption_provider is required for upsert_with_credential / "
+                "get_with_credential — construct PostgresAuthProfileStore(..., "
+                "encryption_provider=...)"
+            )
+        return self._encryption_provider
+
+    def _aad_for(self, profile_id: str) -> bytes:
+        return f"{self._tenant_id}|{self._principal_id}|{profile_id}".encode("utf-8")
+
+    @staticmethod
+    def _serialize_credential(cred: ResolvedCredential) -> bytes:
+        # Canonical JSON: sorted keys, compact separators. Deterministic for
+        # rotation rewrap; any change here breaks existing ciphertext readability.
+        payload = asdict(cred)
+        # datetime → ISO 8601 string
+        if payload.get("expires_at") is not None:
+            payload["expires_at"] = cred.expires_at.isoformat()  # type: ignore[union-attr]
+        # tuple → list (JSON has no tuple)
+        payload["scopes"] = list(cred.scopes)
+        return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+    @staticmethod
+    def _deserialize_credential(data: bytes) -> ResolvedCredential:
+        raw = json.loads(data.decode("utf-8"))
+        expires_at = raw.get("expires_at")
+        if isinstance(expires_at, str):
+            expires_at = datetime.fromisoformat(expires_at)
+        return ResolvedCredential(
+            kind=raw["kind"],
+            api_key=raw.get("api_key"),
+            access_token=raw.get("access_token"),
+            expires_at=expires_at,
+            scopes=tuple(raw.get("scopes", ())),
+            metadata=raw.get("metadata", {}) or {},
+        )
+
+    def upsert_with_credential(
+        self, profile: AuthProfile, credential: ResolvedCredential
+    ) -> None:
+        provider = self._require_provider()
+        aad = self._aad_for(profile.id)
+        dek = secrets.token_bytes(32)
+        nonce, ciphertext = self._aesgcm.encrypt(
+            dek, self._serialize_credential(credential), aad=aad
+        )
+        wrapped_dek, kek_version = provider.wrap_dek(
+            dek, tenant_id=self._tenant_id, aad=aad
+        )
+        params = _profile_params(
+            profile, tenant_id=self._tenant_id, principal_id=self._principal_id
+        )
+        params.update(
+            ciphertext=ciphertext,
+            wrapped_dek=wrapped_dek,
+            nonce=nonce,
+            aad=aad,
+            kek_version=kek_version,
+        )
+        lock_key = f"{self._tenant_id}/{profile.id}"
+        with self._scoped() as conn:
+            conn.execute(
+                text("SELECT pg_advisory_xact_lock(hashtextextended(:k, 0))"),
+                {"k": lock_key},
+            )
+            conn.execute(text(_UPSERT_WITH_CREDENTIAL_SQL), params)
+
+    def get_with_credential(
+        self, profile_id: str
+    ) -> tuple[AuthProfile, ResolvedCredential | None] | None:
+        provider = self._require_provider()
+        with self._scoped() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT *, ciphertext, wrapped_dek, nonce, aad, kek_version "
+                    "FROM auth_profiles "
+                    "WHERE tenant_id = :tid AND principal_id = :pid AND id = :id"
+                ),
+                {
+                    "tid": self._tenant_id,
+                    "pid": self._principal_id,
+                    "id": profile_id,
+                },
+            ).fetchone()
+        if row is None:
+            return None
+        profile = _row_to_profile(row)
+        if row.ciphertext is None:
+            return profile, None
+        expected_aad = self._aad_for(profile_id)
+        if bytes(row.aad) != expected_aad:
+            raise AADMismatch.from_row(
+                tenant_id=self._tenant_id,
+                profile_id=profile_id,
+                kek_version=row.kek_version,
+                cause="stored AAD does not match tenant|principal|profile_id",
+            )
+        cache_key = self._dek_cache.make_key(
+            tenant_id=self._tenant_id,
+            kek_version=row.kek_version,
+            wrapped_dek=bytes(row.wrapped_dek),
+        )
+        tenant_label = str(self._tenant_id)
+        dek = self._dek_cache.get(cache_key)
+        if dek is None:
+            DEK_CACHE_MISSES.labels(tenant_id=tenant_label).inc()
+            try:
+                with DEK_UNWRAP_LATENCY.labels(tenant_id=tenant_label).time():
+                    dek = provider.unwrap_dek(
+                        bytes(row.wrapped_dek),
+                        tenant_id=self._tenant_id,
+                        aad=expected_aad,
+                        kek_version=row.kek_version,
+                    )
+            except Exception as exc:  # real error class recorded below
+                DEK_UNWRAP_ERRORS.labels(
+                    tenant_id=tenant_label, error_class=type(exc).__name__
+                ).inc()
+                raise
+            self._dek_cache.put(cache_key, dek)
+        else:
+            DEK_CACHE_HITS.labels(tenant_id=tenant_label).inc()
+        plaintext = self._aesgcm.decrypt(
+            dek, bytes(row.nonce), bytes(row.ciphertext), aad=expected_aad
+        )
+        return profile, self._deserialize_credential(plaintext)
+```
+
+Add the new upsert SQL constant near `_UPSERT_SQL`:
+
+```python
+_UPSERT_WITH_CREDENTIAL_SQL = """
+INSERT INTO auth_profiles (
+    tenant_id, principal_id, id,
+    provider, account_identifier, backend, backend_key,
+    last_synced_at, sync_ttl_seconds,
+    last_used_at, success_count, failure_count,
+    cooldown_until, cooldown_reason, disabled_until, raw_error,
+    ciphertext, wrapped_dek, nonce, aad, kek_version,
+    updated_at
+) VALUES (
+    :tenant_id, :principal_id, :id,
+    :provider, :account_identifier, :backend, :backend_key,
+    :last_synced_at, :sync_ttl_seconds,
+    :last_used_at, :success_count, :failure_count,
+    :cooldown_until, :cooldown_reason, :disabled_until, :raw_error,
+    :ciphertext, :wrapped_dek, :nonce, :aad, :kek_version,
+    NOW()
+)
+ON CONFLICT (tenant_id, principal_id, id) DO UPDATE SET
+    provider           = EXCLUDED.provider,
+    account_identifier = EXCLUDED.account_identifier,
+    backend            = EXCLUDED.backend,
+    backend_key        = EXCLUDED.backend_key,
+    last_synced_at     = EXCLUDED.last_synced_at,
+    sync_ttl_seconds   = EXCLUDED.sync_ttl_seconds,
+    last_used_at       = EXCLUDED.last_used_at,
+    success_count      = EXCLUDED.success_count,
+    failure_count      = EXCLUDED.failure_count,
+    cooldown_until     = EXCLUDED.cooldown_until,
+    cooldown_reason    = EXCLUDED.cooldown_reason,
+    disabled_until     = EXCLUDED.disabled_until,
+    raw_error          = EXCLUDED.raw_error,
+    ciphertext         = EXCLUDED.ciphertext,
+    wrapped_dek        = EXCLUDED.wrapped_dek,
+    nonce              = EXCLUDED.nonce,
+    aad                = EXCLUDED.aad,
+    kek_version        = EXCLUDED.kek_version,
+    updated_at         = NOW()
+"""
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py -v
+```
+
+Expected: all `TestEncryptedUpsertAndGet` pass; previous `TestSchema::test_check_constraint_rejects_half_written_row` still passes.
+
+- [ ] **Step 5: Run the full PR 1 suite to make sure nothing regressed**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_postgres_profile_store.py -v
+```
+
+Expected: all pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/nexus/bricks/auth/postgres_profile_store.py src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
+git commit -m "feat(auth): upsert_with_credential + get_with_credential on Postgres store (#3803)"
+```
+
+---
+
+### Task 10: Acceptance tests — swap attack, mixed versions, cache amortization
+
+**Files:**
+- Modify: `src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py` (append)
+
+- [ ] **Step 1: Append three acceptance tests**
+
+```python
+class TestSwapAttackRejected:
+    def test_ciphertext_copied_cross_tenant_fails_decrypt(
+        self,
+        pg_engine: Engine,
+        encryption_provider: InMemoryEncryptionProvider,
+    ) -> None:
+        """Attacker with raw DB access copies A's ciphertext+wrapped_dek+nonce+aad+kek_version
+        into B under a different tenant. Decrypt on B must fail.
+
+        The InMemoryEncryptionProvider mixes tenant_id into AAD at the wrap
+        level, so this raises WrappedDEKInvalid. Real providers fail at their
+        native layer (KMS EncryptionContext, Vault derivation context). The
+        stored ``aad`` column also wouldn't match B's ``tenant|principal|id``
+        — AADMismatch would fire at the row-level check before unwrap.
+        """
+        t_a = ensure_tenant(pg_engine, f"atk-a-{uuid.uuid4()}")
+        t_b = ensure_tenant(pg_engine, f"atk-b-{uuid.uuid4()}")
+        p_a = ensure_principal(
+            pg_engine, tenant_id=t_a, external_sub=f"sa-{uuid.uuid4()}", auth_method="t"
+        )
+        p_b = ensure_principal(
+            pg_engine, tenant_id=t_b, external_sub=f"sb-{uuid.uuid4()}", auth_method="t"
+        )
+        store_a = PostgresAuthProfileStore(
+            PG_URL,
+            tenant_id=t_a,
+            principal_id=p_a,
+            engine=pg_engine,
+            encryption_provider=encryption_provider,
+        )
+        store_b = PostgresAuthProfileStore(
+            PG_URL,
+            tenant_id=t_b,
+            principal_id=p_b,
+            engine=pg_engine,
+            encryption_provider=encryption_provider,
+        )
+        try:
+            # Write row A with a real credential.
+            store_a.upsert_with_credential(
+                make_profile("shared-id"),
+                ResolvedCredential(kind="api_key", api_key="A-SECRET"),
+            )
+            # Write B as routing-only (so row exists), then copy A's ciphertext.
+            store_b.upsert(make_profile("shared-id"))
+            with pg_engine.begin() as conn:
+                conn.execute(
+                    text("SET LOCAL app.current_tenant = :tid"), {"tid": str(t_a)}
+                )
+                row_a = conn.execute(
+                    text(
+                        "SELECT ciphertext, wrapped_dek, nonce, aad, kek_version "
+                        "FROM auth_profiles WHERE tenant_id = :tid AND id = :id"
+                    ),
+                    {"tid": t_a, "id": "shared-id"},
+                ).fetchone()
+            assert row_a is not None
+            with pg_engine.begin() as conn:
+                conn.execute(
+                    text("SET LOCAL app.current_tenant = :tid"), {"tid": str(t_b)}
+                )
+                conn.execute(
+                    text(
+                        "UPDATE auth_profiles SET "
+                        "    ciphertext = :ct, wrapped_dek = :wd, "
+                        "    nonce = :n, aad = :a, kek_version = :v "
+                        "WHERE tenant_id = :tid AND principal_id = :pid AND id = :id"
+                    ),
+                    {
+                        "ct": bytes(row_a.ciphertext),
+                        "wd": bytes(row_a.wrapped_dek),
+                        "n": bytes(row_a.nonce),
+                        "a": bytes(row_a.aad),
+                        "v": row_a.kek_version,
+                        "tid": t_b,
+                        "pid": p_b,
+                        "id": "shared-id",
+                    },
+                )
+            with pytest.raises((AADMismatch, WrappedDEKInvalid)):
+                store_b.get_with_credential("shared-id")
+        finally:
+            store_a.close()
+            store_b.close()
+
+
+class TestMixedVersionReads:
+    def test_reads_span_rotation(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        encryption_provider: InMemoryEncryptionProvider,
+    ) -> None:
+        pg_store_crypto.upsert_with_credential(
+            make_profile("v1-row"),
+            ResolvedCredential(kind="api_key", api_key="v1"),
+        )
+        encryption_provider.rotate()
+        pg_store_crypto.upsert_with_credential(
+            make_profile("v2-row"),
+            ResolvedCredential(kind="api_key", api_key="v2"),
+        )
+        a = pg_store_crypto.get_with_credential("v1-row")
+        b = pg_store_crypto.get_with_credential("v2-row")
+        assert a is not None and a[1] is not None and a[1].api_key == "v1"
+        assert b is not None and b[1] is not None and b[1].api_key == "v2"
+
+
+class TestCacheAmortizes:
+    def test_two_reads_one_unwrap(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        encryption_provider: InMemoryEncryptionProvider,
+    ) -> None:
+        pg_store_crypto.upsert_with_credential(
+            make_profile("cached"),
+            ResolvedCredential(kind="api_key", api_key="k"),
+        )
+        start = encryption_provider.unwrap_count
+        pg_store_crypto.get_with_credential("cached")
+        pg_store_crypto.get_with_credential("cached")
+        assert encryption_provider.unwrap_count - start == 1
+
+
+class TestAADMismatch:
+    def test_aad_column_tampered_raises(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        pg_engine: Engine,
+        tenant_id: uuid.UUID,
+        principal_id: uuid.UUID,
+    ) -> None:
+        pg_store_crypto.upsert_with_credential(
+            make_profile("aad-tamper"),
+            ResolvedCredential(kind="api_key", api_key="k"),
+        )
+        with pg_engine.begin() as conn:
+            conn.execute(
+                text("SET LOCAL app.current_tenant = :tid"), {"tid": str(tenant_id)}
+            )
+            conn.execute(
+                text(
+                    "UPDATE auth_profiles SET aad = :bad "
+                    "WHERE tenant_id = :tid AND principal_id = :pid AND id = :id"
+                ),
+                {
+                    "bad": b"bogus-aad-bytes",
+                    "tid": tenant_id,
+                    "pid": principal_id,
+                    "id": "aad-tamper",
+                },
+            )
+        with pytest.raises(AADMismatch):
+            pg_store_crypto.get_with_credential("aad-tamper")
+```
+
+Also add the imports at the top of the file:
+
+```python
+from nexus.bricks.auth.envelope import AADMismatch, WrappedDEKInvalid
+```
+
+- [ ] **Step 2: Run tests to verify they pass**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py -v
+```
+
+Expected: all new tests pass; previous tests still pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
+git commit -m "test(auth): swap-attack + mixed-version + cache amortization (#3803)"
+```
+
+---
+
+### Task 11: `rotate_kek_for_tenant` helper + `RotationReport`
+
+**Files:**
+- Modify: `src/nexus/bricks/auth/postgres_profile_store.py` (append helper)
+- Test: `src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py` (append)
+
+- [ ] **Step 1: Append failing tests**
+
+```python
+from nexus.bricks.auth.postgres_profile_store import (
+    RotationReport,
+    rotate_kek_for_tenant,
+)
+
+
+class TestRotateKEKForTenant:
+    def test_noop_when_all_rows_current(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        pg_engine: Engine,
+        tenant_id: uuid.UUID,
+        encryption_provider: InMemoryEncryptionProvider,
+    ) -> None:
+        pg_store_crypto.upsert_with_credential(
+            make_profile("current-1"),
+            ResolvedCredential(kind="api_key", api_key="k"),
+        )
+        report = rotate_kek_for_tenant(
+            pg_engine,
+            tenant_id=tenant_id,
+            encryption_provider=encryption_provider,
+        )
+        assert report.rows_rewrapped == 0
+        assert report.rows_remaining == 0
+
+    def test_rotates_stale_rows(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        pg_engine: Engine,
+        tenant_id: uuid.UUID,
+        encryption_provider: InMemoryEncryptionProvider,
+    ) -> None:
+        pg_store_crypto.upsert_with_credential(
+            make_profile("a"),
+            ResolvedCredential(kind="api_key", api_key="k-a"),
+        )
+        pg_store_crypto.upsert_with_credential(
+            make_profile("b"),
+            ResolvedCredential(kind="api_key", api_key="k-b"),
+        )
+        encryption_provider.rotate()
+        report = rotate_kek_for_tenant(
+            pg_engine,
+            tenant_id=tenant_id,
+            encryption_provider=encryption_provider,
+            batch_size=1,
+        )
+        assert report.rows_rewrapped == 2
+        assert report.rows_remaining == 0
+        assert report.target_version == 2
+        # Reads still succeed, and now both rows are at v2.
+        a = pg_store_crypto.get_with_credential("a")
+        b = pg_store_crypto.get_with_credential("b")
+        assert a is not None and a[1] is not None and a[1].api_key == "k-a"
+        assert b is not None and b[1] is not None and b[1].api_key == "k-b"
+
+    def test_respects_max_rows(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        pg_engine: Engine,
+        tenant_id: uuid.UUID,
+        encryption_provider: InMemoryEncryptionProvider,
+    ) -> None:
+        for i in range(3):
+            pg_store_crypto.upsert_with_credential(
+                make_profile(f"m-{i}"),
+                ResolvedCredential(kind="api_key", api_key=f"k{i}"),
+            )
+        encryption_provider.rotate()
+        report = rotate_kek_for_tenant(
+            pg_engine,
+            tenant_id=tenant_id,
+            encryption_provider=encryption_provider,
+            batch_size=2,
+            max_rows=2,
+        )
+        assert report.rows_rewrapped == 2
+        assert report.rows_remaining == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py::TestRotateKEKForTenant -v
+```
+
+Expected: FAIL — `ImportError: cannot import name 'rotate_kek_for_tenant'`.
+
+- [ ] **Step 3: Implement `rotate_kek_for_tenant` + `RotationReport`**
+
+Append to `src/nexus/bricks/auth/postgres_profile_store.py` at module level (outside the store class):
+
+```python
+# ---------------------------------------------------------------------------
+# KEK rotation (issue #3803) — module-level admin helper
+# ---------------------------------------------------------------------------
+
+
+from dataclasses import dataclass as _dataclass  # local alias; already imported
+
+from nexus.bricks.auth.envelope_metrics import KEK_ROTATE_ROWS
+
+
+@_dataclass(frozen=True, slots=True)
+class RotationReport:
+    """Result of a ``rotate_kek_for_tenant`` invocation."""
+
+    rows_rewrapped: int
+    rows_failed: int
+    rows_remaining: int
+    target_version: int
+
+
+def rotate_kek_for_tenant(
+    engine: Engine,
+    *,
+    tenant_id: uuid.UUID,
+    encryption_provider: EncryptionProvider,
+    batch_size: int = 100,
+    max_rows: int | None = None,
+) -> RotationReport:
+    """Rewrap every row in ``tenant_id`` whose ``kek_version`` is older than
+    the provider's current version.
+
+    Uses ``SELECT ... FOR UPDATE SKIP LOCKED`` so the helper is resumable and
+    does not block concurrent writers. Rewraps ``wrapped_dek`` + ``kek_version``
+    only; ``ciphertext``, ``nonce``, ``aad`` are untouched so a reader mid-
+    rotation decrypts successfully regardless of which version wrote.
+    """
+    target = encryption_provider.current_version(tenant_id=tenant_id)
+    rewrapped = 0
+    failed = 0
+    tenant_label = str(tenant_id)
+    while True:
+        if max_rows is not None and rewrapped + failed >= max_rows:
+            break
+        this_batch = batch_size
+        if max_rows is not None:
+            this_batch = min(this_batch, max_rows - (rewrapped + failed))
+        with engine.begin() as conn:
+            conn.execute(
+                text("SET LOCAL app.current_tenant = :tid"),
+                {"tid": str(tenant_id)},
+            )
+            rows = conn.execute(
+                text(
+                    "SELECT tenant_id, principal_id, id, wrapped_dek, aad, kek_version "
+                    "FROM auth_profiles "
+                    "WHERE tenant_id = :tid "
+                    "  AND ciphertext IS NOT NULL "
+                    "  AND kek_version < :target "
+                    "ORDER BY principal_id, id "
+                    "FOR UPDATE SKIP LOCKED "
+                    "LIMIT :lim"
+                ),
+                {"tid": tenant_id, "target": target, "lim": this_batch},
+            ).fetchall()
+            if not rows:
+                break
+            for row in rows:
+                try:
+                    dek = encryption_provider.unwrap_dek(
+                        bytes(row.wrapped_dek),
+                        tenant_id=tenant_id,
+                        aad=bytes(row.aad),
+                        kek_version=row.kek_version,
+                    )
+                    new_wrapped, new_version = encryption_provider.wrap_dek(
+                        dek, tenant_id=tenant_id, aad=bytes(row.aad)
+                    )
+                except Exception as exc:
+                    logger.error(
+                        "rotate_kek_for_tenant: per-row failure "
+                        "tenant=%s principal=%s profile=%s kek_version=%s cause=%s",
+                        tenant_id,
+                        row.principal_id,
+                        row.id,
+                        row.kek_version,
+                        type(exc).__name__,
+                    )
+                    failed += 1
+                    continue
+                conn.execute(
+                    text(
+                        "UPDATE auth_profiles SET "
+                        "    wrapped_dek = :wd, kek_version = :v, updated_at = NOW() "
+                        "WHERE tenant_id = :tid "
+                        "  AND principal_id = :pid AND id = :id"
+                    ),
+                    {
+                        "wd": new_wrapped,
+                        "v": new_version,
+                        "tid": tenant_id,
+                        "pid": row.principal_id,
+                        "id": row.id,
+                    },
+                )
+                KEK_ROTATE_ROWS.labels(
+                    tenant_id=tenant_label,
+                    from_version=str(row.kek_version),
+                    to_version=str(new_version),
+                ).inc()
+                rewrapped += 1
+    # Final remaining count
+    with engine.begin() as conn:
+        conn.execute(
+            text("SET LOCAL app.current_tenant = :tid"),
+            {"tid": str(tenant_id)},
+        )
+        remaining = conn.execute(
+            text(
+                "SELECT COUNT(*) FROM auth_profiles "
+                "WHERE tenant_id = :tid AND ciphertext IS NOT NULL "
+                "  AND kek_version < :target"
+            ),
+            {"tid": tenant_id, "target": target},
+        ).scalar_one()
+    return RotationReport(
+        rows_rewrapped=rewrapped,
+        rows_failed=failed,
+        rows_remaining=int(remaining),
+        target_version=target,
+    )
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py::TestRotateKEKForTenant -v
+```
+
+Expected: all 3 pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/auth/postgres_profile_store.py src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
+git commit -m "feat(auth): rotate_kek_for_tenant admin helper (#3803)"
+```
+
+---
+
+### Task 12: Per-row rotation failure continues the batch
+
+**Files:**
+- Modify: `src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py` (append)
+
+- [ ] **Step 1: Append test + a throwing provider shim**
+
+```python
+class TestRotateKEKFailures:
+    def test_per_row_failure_continues_batch(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        pg_engine: Engine,
+        tenant_id: uuid.UUID,
+        encryption_provider: InMemoryEncryptionProvider,
+    ) -> None:
+        """An unwrap failure on one row leaves that row on the old version; the
+        batch continues to completion for other rows."""
+        from nexus.bricks.auth.envelope import WrappedDEKInvalid
+
+        for i in range(3):
+            pg_store_crypto.upsert_with_credential(
+                make_profile(f"fail-{i}"),
+                ResolvedCredential(kind="api_key", api_key=f"k{i}"),
+            )
+        encryption_provider.rotate()
+
+        # Wrap the provider: fail on the middle row's wrapped_dek only.
+        middle_wrapped = None
+        with pg_engine.begin() as conn:
+            conn.execute(
+                text("SET LOCAL app.current_tenant = :tid"), {"tid": str(tenant_id)}
+            )
+            row = conn.execute(
+                text(
+                    "SELECT wrapped_dek FROM auth_profiles "
+                    "WHERE tenant_id = :tid AND id = 'fail-1'"
+                ),
+                {"tid": tenant_id},
+            ).fetchone()
+            assert row is not None
+            middle_wrapped = bytes(row.wrapped_dek)
+
+        real = encryption_provider
+
+        class _FlakyProvider:
+            def current_version(self, *, tenant_id):
+                return real.current_version(tenant_id=tenant_id)
+
+            def wrap_dek(self, dek, *, tenant_id, aad):
+                return real.wrap_dek(dek, tenant_id=tenant_id, aad=aad)
+
+            def unwrap_dek(self, wrapped, *, tenant_id, aad, kek_version):
+                if wrapped == middle_wrapped:
+                    raise WrappedDEKInvalid.from_row(
+                        tenant_id=tenant_id,
+                        profile_id="fail-1",
+                        kek_version=kek_version,
+                        cause="simulated flake",
+                    )
+                return real.unwrap_dek(
+                    wrapped, tenant_id=tenant_id, aad=aad, kek_version=kek_version
+                )
+
+        report = rotate_kek_for_tenant(
+            pg_engine,
+            tenant_id=tenant_id,
+            encryption_provider=_FlakyProvider(),
+        )
+        assert report.rows_rewrapped == 2
+        assert report.rows_failed == 1
+        assert report.rows_remaining == 1
+```
+
+- [ ] **Step 2: Run test**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py::TestRotateKEKFailures -v
+```
+
+Expected: pass (implementation from Task 11 already handles per-row failure).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
+git commit -m "test(auth): per-row rotation failure continues batch (#3803)"
+```
+
+---
+
+### Task 13: `nexus auth rotate-kek` CLI subcommand
+
+**Files:**
+- Modify: `src/nexus/bricks/auth/cli_commands.py`
+- Test: `src/nexus/bricks/auth/tests/test_rotate_kek_cli.py` (new)
+
+- [ ] **Step 1: Create the failing CLI test**
+
+Create `src/nexus/bricks/auth/tests/test_rotate_kek_cli.py`:
+
+```python
+"""Tests for `nexus auth rotate-kek` (issue #3803)."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import Generator
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+pytest.importorskip("click")
+
+from click.testing import CliRunner
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+from nexus.bricks.auth.cli_commands import auth
+from nexus.bricks.auth.credential_backend import ResolvedCredential
+from nexus.bricks.auth.envelope_providers.in_memory import InMemoryEncryptionProvider
+from nexus.bricks.auth.postgres_profile_store import (
+    PostgresAuthProfileStore,
+    drop_schema,
+    ensure_principal,
+    ensure_schema,
+    ensure_tenant,
+)
+from nexus.bricks.auth.tests.conftest import make_profile
+
+PG_URL = os.environ.get(
+    "TEST_POSTGRES_URL",
+    "postgresql+psycopg2://postgres:nexus@localhost:5432/nexus",
+)
+
+
+def _pg_is_available() -> bool:
+    try:
+        eng = create_engine(PG_URL)
+        with eng.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        eng.dispose()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = [
+    pytest.mark.postgres,
+    pytest.mark.xdist_group("postgres_auth_profile_store"),
+    pytest.mark.skipif(
+        not _pg_is_available(),
+        reason="PostgreSQL not reachable at TEST_POSTGRES_URL.",
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def pg_engine() -> Generator[Engine, None, None]:
+    engine = create_engine(PG_URL, future=True)
+    drop_schema(engine)
+    ensure_schema(engine)
+    yield engine
+    drop_schema(engine)
+    engine.dispose()
+
+
+@pytest.fixture()
+def seeded_tenant(pg_engine: Engine) -> tuple[uuid.UUID, InMemoryEncryptionProvider]:
+    """Return (tenant_id, encryption_provider) with 2 rows at v1, provider at v2."""
+    t = ensure_tenant(pg_engine, f"rot-{uuid.uuid4()}")
+    p = ensure_principal(
+        pg_engine, tenant_id=t, external_sub=f"s-{uuid.uuid4()}", auth_method="t"
+    )
+    prov = InMemoryEncryptionProvider()
+    store = PostgresAuthProfileStore(
+        PG_URL, tenant_id=t, principal_id=p, engine=pg_engine, encryption_provider=prov
+    )
+    try:
+        store.upsert_with_credential(
+            make_profile("a"), ResolvedCredential(kind="api_key", api_key="k-a")
+        )
+        store.upsert_with_credential(
+            make_profile("b"), ResolvedCredential(kind="api_key", api_key="k-b")
+        )
+    finally:
+        store.close()
+    prov.rotate()
+    return t, prov
+
+
+class TestRotateKekCLI:
+    def test_dry_run_reports_counts_no_writes(
+        self,
+        seeded_tenant,
+        pg_engine: Engine,
+    ) -> None:
+        t, prov = seeded_tenant
+        runner = CliRunner()
+        # Inject the provider via an env-var hook the CLI honors for tests.
+        os.environ["NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID"] = "inmem"
+        try:
+            # Provider registry: tests register a factory keyed by the env var.
+            from nexus.bricks.auth.cli_commands import _TEST_PROVIDER_REGISTRY
+
+            _TEST_PROVIDER_REGISTRY["inmem"] = lambda: prov
+            result = runner.invoke(
+                auth,
+                [
+                    "rotate-kek",
+                    "--db-url",
+                    PG_URL,
+                    "--tenant",
+                    _tenant_name(pg_engine, t),
+                ],
+            )
+            assert result.exit_code == 0, result.output
+            assert "dry-run" in result.output.lower()
+            assert "2" in result.output  # 2 stale rows
+        finally:
+            os.environ.pop("NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID", None)
+            _TEST_PROVIDER_REGISTRY.pop("inmem", None)
+
+    def test_apply_rewraps_all(self, seeded_tenant, pg_engine: Engine) -> None:
+        t, prov = seeded_tenant
+        runner = CliRunner()
+        os.environ["NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID"] = "inmem"
+        try:
+            from nexus.bricks.auth.cli_commands import _TEST_PROVIDER_REGISTRY
+
+            _TEST_PROVIDER_REGISTRY["inmem"] = lambda: prov
+            result = runner.invoke(
+                auth,
+                [
+                    "rotate-kek",
+                    "--db-url",
+                    PG_URL,
+                    "--tenant",
+                    _tenant_name(pg_engine, t),
+                    "--apply",
+                ],
+            )
+            assert result.exit_code == 0, result.output
+            # Every row now at v2
+            with pg_engine.begin() as conn:
+                conn.execute(text("SET LOCAL app.current_tenant = :tid"), {"tid": str(t)})
+                versions = [
+                    r[0]
+                    for r in conn.execute(
+                        text(
+                            "SELECT DISTINCT kek_version FROM auth_profiles "
+                            "WHERE tenant_id = :tid AND ciphertext IS NOT NULL"
+                        ),
+                        {"tid": t},
+                    ).fetchall()
+                ]
+            assert versions == [2]
+        finally:
+            os.environ.pop("NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID", None)
+            _TEST_PROVIDER_REGISTRY.pop("inmem", None)
+
+
+def _tenant_name(engine: Engine, tenant_id: uuid.UUID) -> str:
+    with engine.begin() as conn:
+        row = conn.execute(
+            text("SELECT name FROM tenants WHERE id = :tid"), {"tid": tenant_id}
+        ).fetchone()
+    assert row is not None
+    return row[0]
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_rotate_kek_cli.py -v
+```
+
+Expected: FAIL — `rotate-kek` subcommand doesn't exist; `_TEST_PROVIDER_REGISTRY` doesn't exist.
+
+- [ ] **Step 3: Implement the CLI subcommand**
+
+Append to `src/nexus/bricks/auth/cli_commands.py`, after `auth_migrate_to_postgres`:
+
+```python
+# ---------------------------------------------------------------------------
+# auth rotate-kek (issue #3803 — envelope KEK rotation)
+# ---------------------------------------------------------------------------
+
+# Test hook: lets test modules register a provider factory without building
+# real Vault/KMS wiring. Production code paths never use this registry — they
+# construct a provider from CLI args (lands with the Phase D consumer).
+_TEST_PROVIDER_REGISTRY: dict[str, "object"] = {}
+
+
+@auth.command("rotate-kek")
+@click.option(
+    "--db-url",
+    required=True,
+    help="PostgreSQL URL (e.g. postgresql+psycopg2://user:pw@host:5432/db).",
+)
+@click.option(
+    "--tenant",
+    required=True,
+    help="Tenant name whose rows should be rewrapped at the provider's current version.",
+)
+@click.option(
+    "--apply", is_flag=True, default=False, help="Actually rewrap rows (default: dry-run)."
+)
+@click.option(
+    "--batch-size", default=100, show_default=True, help="Rows per batch."
+)
+@click.option(
+    "--max-rows",
+    default=None,
+    type=int,
+    help="Upper bound on rows rewrapped across all batches (omit for no cap).",
+)
+def auth_rotate_kek(
+    db_url: str,
+    tenant: str,
+    apply: bool,
+    batch_size: int,
+    max_rows: int | None,
+) -> None:
+    """Rewrap auth_profiles rows at the current provider KEK version.
+
+    Dry-run by default. Operator promotes the provider version out-of-band
+    (Vault: ``vault write -f transit/keys/<name>/rotate``; AWS KMS: managed);
+    then runs this command to sweep rows stuck at older versions.
+    """
+    import os
+
+    from sqlalchemy import create_engine, text
+
+    from nexus.bricks.auth.postgres_profile_store import (
+        ensure_schema,
+        rotate_kek_for_tenant,
+    )
+
+    test_provider_id = os.environ.get("NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID")
+    if test_provider_id:
+        factory = _TEST_PROVIDER_REGISTRY.get(test_provider_id)
+        if factory is None:
+            raise click.ClickException(
+                f"Test provider id {test_provider_id!r} not registered"
+            )
+        provider = factory()
+    else:
+        raise click.ClickException(
+            "No production provider wiring yet. This command is consumer-driven "
+            "— Phase D wires a real EncryptionProvider factory. Tests use "
+            "NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID."
+        )
+
+    engine = create_engine(db_url, future=True)
+    try:
+        ensure_schema(engine)
+        # Resolve tenant_id from name
+        with engine.begin() as conn:
+            row = conn.execute(
+                text("SELECT id FROM tenants WHERE name = :n"), {"n": tenant}
+            ).fetchone()
+        if row is None:
+            raise click.ClickException(f"Tenant {tenant!r} not found")
+        import uuid as _uuid
+
+        tenant_id = _uuid.UUID(str(row[0]))
+
+        if not apply:
+            # Dry-run: count stale rows at each version without rewrapping
+            target = provider.current_version(tenant_id=tenant_id)
+            with engine.begin() as conn:
+                conn.execute(
+                    text("SET LOCAL app.current_tenant = :tid"), {"tid": str(tenant_id)}
+                )
+                stale = conn.execute(
+                    text(
+                        "SELECT kek_version, COUNT(*) FROM auth_profiles "
+                        "WHERE tenant_id = :tid AND ciphertext IS NOT NULL "
+                        "  AND kek_version < :target "
+                        "GROUP BY kek_version ORDER BY kek_version"
+                    ),
+                    {"tid": tenant_id, "target": target},
+                ).fetchall()
+            total = sum(r[1] for r in stale)
+            click.echo(f"dry-run: target_version={target}, stale_rows={total}")
+            for version, count in stale:
+                click.echo(f"  kek_version={version}: {count} rows")
+            click.echo("Pass --apply to rewrap.")
+            return
+
+        report = rotate_kek_for_tenant(
+            engine,
+            tenant_id=tenant_id,
+            encryption_provider=provider,
+            batch_size=batch_size,
+            max_rows=max_rows,
+        )
+        click.echo(
+            f"rewrapped={report.rows_rewrapped} "
+            f"failed={report.rows_failed} "
+            f"remaining={report.rows_remaining} "
+            f"target_version={report.target_version}"
+        )
+        if report.rows_failed:
+            click.echo(
+                f"WARNING: {report.rows_failed} rows failed to rewrap — "
+                "see logs for details",
+                err=True,
+            )
+    finally:
+        engine.dispose()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_rotate_kek_cli.py -v
+```
+
+Expected: both pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/auth/cli_commands.py src/nexus/bricks/auth/tests/test_rotate_kek_cli.py
+git commit -m "feat(auth): nexus auth rotate-kek CLI subcommand (#3803)"
+```
+
+---
+
+### Task 14: `VaultTransitProvider` (opt-in)
+
+**Files:**
+- Create: `src/nexus/bricks/auth/envelope_providers/vault_transit.py`
+- Create: `src/nexus/bricks/auth/tests/test_envelope_providers_vault.py`
+
+- [ ] **Step 1: Create the gated test module**
+
+Create `src/nexus/bricks/auth/tests/test_envelope_providers_vault.py`:
+
+```python
+"""Vault Transit provider contract tests (issue #3803).
+
+Gated behind @pytest.mark.vault. Requires a running Vault dev server at
+VAULT_ADDR with a transit mount and a derived-context key named
+``nexus-test``. See docs/guides/auth-envelope-encryption.md for setup.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+
+import pytest
+
+from nexus.bricks.auth.envelope import EncryptionProvider
+from nexus.bricks.auth.tests.test_envelope_contract import EnvelopeProviderContract
+
+pytestmark = [pytest.mark.vault]
+
+VAULT_ADDR = os.environ.get("VAULT_ADDR", "http://127.0.0.1:8200")
+VAULT_TOKEN = os.environ.get("VAULT_TOKEN", "root")
+VAULT_TRANSIT_KEY = os.environ.get("VAULT_TRANSIT_KEY", "nexus-test")
+
+
+def _vault_available() -> bool:
+    try:
+        import hvac  # noqa: F401
+    except ImportError:
+        return False
+    try:
+        import hvac
+
+        client = hvac.Client(url=VAULT_ADDR, token=VAULT_TOKEN)
+        return client.sys.is_initialized()
+    except Exception:
+        return False
+
+
+pytestmark += [
+    pytest.mark.skipif(not _vault_available(), reason="Vault dev server not reachable"),
+]
+
+
+@pytest.fixture()
+def provider_factory() -> Callable[[], EncryptionProvider]:
+    import hvac
+
+    from nexus.bricks.auth.envelope_providers.vault_transit import VaultTransitProvider
+
+    def _make() -> EncryptionProvider:
+        client = hvac.Client(url=VAULT_ADDR, token=VAULT_TOKEN)
+        return VaultTransitProvider(client, key_name=VAULT_TRANSIT_KEY)
+
+    return _make
+
+
+class TestVaultTransitContract(EnvelopeProviderContract):
+    """Runs the shared EncryptionProvider contract suite against Vault Transit."""
+```
+
+- [ ] **Step 2: Run the test in a no-Vault environment to confirm it SKIPS (never fails)**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_envelope_providers_vault.py -v
+```
+
+Expected: SKIPPED (Vault dev server not reachable) — no test errors.
+
+- [ ] **Step 3: Implement `VaultTransitProvider`**
+
+Create `src/nexus/bricks/auth/envelope_providers/vault_transit.py`:
+
+```python
+"""VaultTransitProvider — wraps DEKs via Vault's transit secrets engine.
+
+Requires a derived-context key (``derived=true``) so the per-tenant
+``context`` param produces a per-tenant subkey without creating one key per
+tenant. See:
+  https://developer.hashicorp.com/vault/docs/secrets/transit
+
+Optional dependency: ``hvac``. Install via the ``vault`` extra.
+"""
+
+from __future__ import annotations
+
+import base64
+import uuid
+from typing import TYPE_CHECKING
+
+from nexus.bricks.auth.envelope import (
+    EncryptionProvider,
+    EnvelopeConfigurationError,
+    WrappedDEKInvalid,
+)
+
+if TYPE_CHECKING:
+    import hvac
+
+
+class VaultTransitProvider(EncryptionProvider):
+    def __init__(
+        self,
+        vault_client: "hvac.Client",
+        key_name: str,
+        *,
+        mount_point: str = "transit",
+    ) -> None:
+        try:
+            import hvac  # noqa: F401
+        except ImportError as exc:  # pragma: no cover — optional dep
+            raise EnvelopeConfigurationError(
+                "VaultTransitProvider requires the `hvac` package. "
+                "Install with: pip install 'nexus[vault]'"
+            ) from exc
+        self._client = vault_client
+        self._key_name = key_name
+        self._mount = mount_point
+        self._validate_key()
+
+    def _validate_key(self) -> None:
+        try:
+            resp = self._client.secrets.transit.read_key(
+                name=self._key_name, mount_point=self._mount
+            )
+        except Exception as exc:
+            raise EnvelopeConfigurationError(
+                f"Vault transit key {self._key_name!r} not readable "
+                f"on mount {self._mount!r}: {type(exc).__name__}"
+            ) from exc
+        data = resp.get("data", {})
+        if not data.get("derived"):
+            raise EnvelopeConfigurationError(
+                f"Vault transit key {self._key_name!r} must have derived=true. "
+                f"Run: vault write -f {self._mount}/keys/{self._key_name} derived=true"
+            )
+
+    def current_version(self, *, tenant_id: uuid.UUID) -> int:
+        resp = self._client.secrets.transit.read_key(
+            name=self._key_name, mount_point=self._mount
+        )
+        data = resp.get("data", {})
+        return int(data.get("latest_version", 1))
+
+    def _context_b64(self, tenant_id: uuid.UUID) -> str:
+        return base64.b64encode(str(tenant_id).encode("utf-8")).decode("ascii")
+
+    def wrap_dek(
+        self,
+        dek: bytes,
+        *,
+        tenant_id: uuid.UUID,
+        aad: bytes,
+    ) -> tuple[bytes, int]:
+        resp = self._client.secrets.transit.encrypt_data(
+            name=self._key_name,
+            plaintext=base64.b64encode(dek).decode("ascii"),
+            context=self._context_b64(tenant_id),
+            mount_point=self._mount,
+        )
+        ciphertext = resp["data"]["ciphertext"]  # "vault:v<N>:<base64>"
+        version = int(ciphertext.split(":")[1].lstrip("v"))
+        return ciphertext.encode("utf-8"), version
+
+    def unwrap_dek(
+        self,
+        wrapped: bytes,
+        *,
+        tenant_id: uuid.UUID,
+        aad: bytes,
+        kek_version: int,
+    ) -> bytes:
+        try:
+            resp = self._client.secrets.transit.decrypt_data(
+                name=self._key_name,
+                ciphertext=wrapped.decode("utf-8"),
+                context=self._context_b64(tenant_id),
+                mount_point=self._mount,
+            )
+        except Exception as exc:
+            raise WrappedDEKInvalid.from_row(
+                tenant_id=tenant_id,
+                profile_id="<unknown>",
+                kek_version=kek_version,
+                cause=f"Vault transit decrypt rejected: {type(exc).__name__}",
+            ) from exc
+        return base64.b64decode(resp["data"]["plaintext"])
+
+
+__all__ = ["VaultTransitProvider"]
+```
+
+- [ ] **Step 4: Re-run the gated test (still skipped unless Vault is reachable)**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_envelope_providers_vault.py -v
+```
+
+Expected: SKIPPED when no Vault; when Vault reachable with a `nexus-test` transit key (`derived=true`), 3 contract tests pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/auth/envelope_providers/vault_transit.py src/nexus/bricks/auth/tests/test_envelope_providers_vault.py
+git commit -m "feat(auth): VaultTransitProvider (opt-in) (#3803)"
+```
+
+---
+
+### Task 15: `AwsKmsProvider` (opt-in)
+
+**Files:**
+- Create: `src/nexus/bricks/auth/envelope_providers/aws_kms.py`
+- Create: `src/nexus/bricks/auth/tests/test_envelope_providers_aws_kms.py`
+
+- [ ] **Step 1: Create the gated test module**
+
+```python
+"""AWS KMS provider contract tests (issue #3803).
+
+Gated behind @pytest.mark.kms. Requires a reachable KMS endpoint (real AWS or
+LocalStack) with a CMK accessible via AWS_KMS_KEY_ID.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+
+import pytest
+
+from nexus.bricks.auth.envelope import EncryptionProvider
+from nexus.bricks.auth.tests.test_envelope_contract import EnvelopeProviderContract
+
+pytestmark = [pytest.mark.kms]
+
+KMS_ENDPOINT = os.environ.get("AWS_ENDPOINT_URL")  # e.g. http://localhost:4566
+KMS_REGION = os.environ.get("AWS_REGION", "us-east-1")
+KMS_KEY_ID = os.environ.get("AWS_KMS_KEY_ID")
+
+
+def _kms_available() -> bool:
+    if not KMS_KEY_ID:
+        return False
+    try:
+        import boto3  # noqa: F401
+    except ImportError:
+        return False
+    try:
+        import boto3
+
+        kwargs: dict = {"region_name": KMS_REGION}
+        if KMS_ENDPOINT:
+            kwargs["endpoint_url"] = KMS_ENDPOINT
+        client = boto3.client("kms", **kwargs)
+        client.describe_key(KeyId=KMS_KEY_ID)
+        return True
+    except Exception:
+        return False
+
+
+pytestmark += [
+    pytest.mark.skipif(
+        not _kms_available(),
+        reason="AWS KMS not reachable or AWS_KMS_KEY_ID unset",
+    ),
+]
+
+
+@pytest.fixture()
+def provider_factory() -> Callable[[], EncryptionProvider]:
+    import boto3
+
+    from nexus.bricks.auth.envelope_providers.aws_kms import AwsKmsProvider
+
+    def _make() -> EncryptionProvider:
+        kwargs: dict = {"region_name": KMS_REGION}
+        if KMS_ENDPOINT:
+            kwargs["endpoint_url"] = KMS_ENDPOINT
+        kms = boto3.client("kms", **kwargs)
+        return AwsKmsProvider(kms, key_id=KMS_KEY_ID)
+
+    return _make
+
+
+class TestAwsKmsContract(EnvelopeProviderContract):
+    """Runs the shared EncryptionProvider contract suite against AWS KMS."""
+```
+
+- [ ] **Step 2: Confirm SKIP in the default env**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_envelope_providers_aws_kms.py -v
+```
+
+Expected: SKIPPED.
+
+- [ ] **Step 3: Implement `AwsKmsProvider`**
+
+Create `src/nexus/bricks/auth/envelope_providers/aws_kms.py`:
+
+```python
+"""AwsKmsProvider — wraps DEKs via AWS KMS.
+
+Uses ``EncryptionContext`` to bind the wrap to ``(tenant_id, aad_fingerprint)``
+— any cross-row DEK reuse or tampered AAD fails at KMS rather than only
+at the AES-GCM layer locally. Optional dependency: ``boto3``.
+
+AWS KMS automatically rotates the key material behind a CMK annually when
+``EnableKeyRotation`` is set. Our ``kek_version`` then tracks provider-config
+changes (e.g. swapping the CMK alias) rather than AWS key-material rotation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from typing import TYPE_CHECKING
+
+from nexus.bricks.auth.envelope import (
+    EncryptionProvider,
+    EnvelopeConfigurationError,
+    WrappedDEKInvalid,
+)
+
+if TYPE_CHECKING:
+    import botocore.client
+
+
+class AwsKmsProvider(EncryptionProvider):
+    def __init__(
+        self,
+        kms_client: "botocore.client.BaseClient",
+        key_id: str,
+        *,
+        config_version: int = 1,
+    ) -> None:
+        self._kms = kms_client
+        self._key_id = key_id
+        self._config_version = config_version
+        self._validate_key()
+
+    def _validate_key(self) -> None:
+        try:
+            self._kms.describe_key(KeyId=self._key_id)
+        except Exception as exc:
+            raise EnvelopeConfigurationError(
+                f"AWS KMS key {self._key_id!r} not accessible: "
+                f"{type(exc).__name__}. Grant kms:Encrypt, kms:Decrypt, kms:DescribeKey."
+            ) from exc
+
+    @staticmethod
+    def _context(tenant_id: uuid.UUID, aad: bytes) -> dict[str, str]:
+        return {
+            "tenant_id": str(tenant_id),
+            "aad_fingerprint": hashlib.sha256(aad).hexdigest(),
+        }
+
+    def current_version(self, *, tenant_id: uuid.UUID) -> int:
+        return self._config_version
+
+    def wrap_dek(
+        self, dek: bytes, *, tenant_id: uuid.UUID, aad: bytes
+    ) -> tuple[bytes, int]:
+        resp = self._kms.encrypt(
+            KeyId=self._key_id,
+            Plaintext=dek,
+            EncryptionContext=self._context(tenant_id, aad),
+        )
+        return resp["CiphertextBlob"], self._config_version
+
+    def unwrap_dek(
+        self,
+        wrapped: bytes,
+        *,
+        tenant_id: uuid.UUID,
+        aad: bytes,
+        kek_version: int,
+    ) -> bytes:
+        try:
+            resp = self._kms.decrypt(
+                CiphertextBlob=wrapped,
+                EncryptionContext=self._context(tenant_id, aad),
+            )
+        except Exception as exc:
+            raise WrappedDEKInvalid.from_row(
+                tenant_id=tenant_id,
+                profile_id="<unknown>",
+                kek_version=kek_version,
+                cause=f"KMS decrypt rejected: {type(exc).__name__}",
+            ) from exc
+        return resp["Plaintext"]
+
+
+__all__ = ["AwsKmsProvider"]
+```
+
+- [ ] **Step 4: Run the gated test again**
+
+```bash
+pytest src/nexus/bricks/auth/tests/test_envelope_providers_aws_kms.py -v
+```
+
+Expected: SKIPPED unless KMS is reachable.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/auth/envelope_providers/aws_kms.py src/nexus/bricks/auth/tests/test_envelope_providers_aws_kms.py
+git commit -m "feat(auth): AwsKmsProvider (opt-in) (#3803)"
+```
+
+---
+
+### Task 16: Deployment guide (Vault vs KMS)
+
+**Files:**
+- Create: `docs/guides/auth-envelope-encryption.md`
+
+- [ ] **Step 1: Write the guide**
+
+```markdown
+# Envelope encryption for auth profiles
+
+`PostgresAuthProfileStore` supports storing resolved credentials encrypted
+alongside their routing metadata. This guide covers picking and configuring an
+`EncryptionProvider` for your deployment. Issue: #3803. Spec:
+`docs/superpowers/specs/2026-04-18-issue-3803-envelope-encryption-design.md`.
+
+## Pick a provider
+
+| Deployment shape | Provider | Rationale |
+|---|---|---|
+| Vault-native shop | `VaultTransitProvider` | Free self-hosted transit engine; per-tenant scoping via `context` parameter with `derived=true`. |
+| AWS-native shop | `AwsKmsProvider` | Managed CMK; AWS-managed rotation; IAM-scoped access; per-tenant CMK keeps blast radius per-tenant. |
+| Development only | `InMemoryEncryptionProvider` | Keys live in process memory — never use in production. |
+
+## Vault Transit setup
+
+1. Enable the transit mount: `vault secrets enable transit`
+2. Create a derived-context key: `vault write -f transit/keys/nexus derived=true`
+3. Grant the Nexus role the `encrypt` and `decrypt` policies on `transit/*/nexus`.
+4. Construct the provider: `VaultTransitProvider(hvac.Client(...), key_name="nexus")`.
+
+Rotation:
+
+1. `vault write -f transit/keys/nexus/rotate` — bumps the key version.
+2. `nexus auth rotate-kek --tenant acme --apply` — per tenant, sweeps rows at the old version.
+
+## AWS KMS setup
+
+1. Create a CMK per tenant (customer-managed key). Enable automatic key rotation: `aws kms enable-key-rotation --key-id <id>`.
+2. Grant the Nexus IAM principal `kms:Encrypt`, `kms:Decrypt`, `kms:DescribeKey` on the CMK.
+3. Constrain via `kms:EncryptionContext:tenant_id` in the key policy to match the tenant value the provider sends — prevents cross-tenant decrypt even if IAM is too broad.
+4. Construct the provider: `AwsKmsProvider(boto3.client("kms"), key_id="arn:aws:kms:...")`.
+
+Rotation: AWS rotates the underlying key material annually with `EnableKeyRotation`. Our `kek_version` in that case tracks provider-config changes (e.g. swapping the CMK alias) — `nexus auth rotate-kek` is a no-op as long as `config_version` is unchanged.
+
+## Rotation CLI
+
+```
+nexus auth rotate-kek --db-url <url> --tenant <name> [--apply] [--batch-size 100] [--max-rows N]
+```
+
+Dry-run by default: reports how many rows are stuck at old `kek_version`. `--apply` rewraps them in `SKIP LOCKED` batches — resumable, doesn't block concurrent writers.
+
+## Metrics
+
+Provider-level metrics exposed under `/metrics`:
+
+- `auth_dek_cache_hits_total{tenant_id}`
+- `auth_dek_cache_misses_total{tenant_id}`
+- `auth_dek_unwrap_errors_total{tenant_id,error_class}`
+- `auth_dek_unwrap_latency_seconds{tenant_id}`
+- `auth_kek_rotate_rows_total{tenant_id,from_version,to_version}`
+```
+
+- [ ] **Step 2: Commit**
+
+```bash
+git add docs/guides/auth-envelope-encryption.md
+git commit -m "docs(auth): envelope encryption deployment guide (#3803)"
+```
+
+---
+
+### Task 17: Final acceptance sweep + full test run
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run every new/touched test module**
+
+```bash
+pytest \
+  src/nexus/bricks/auth/tests/test_envelope.py \
+  src/nexus/bricks/auth/tests/test_envelope_contract.py \
+  src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py \
+  src/nexus/bricks/auth/tests/test_rotate_kek_cli.py \
+  src/nexus/bricks/auth/tests/test_envelope_providers_vault.py \
+  src/nexus/bricks/auth/tests/test_envelope_providers_aws_kms.py \
+  -v
+```
+
+Expected: all pass except Vault/KMS tests (SKIPPED unless the corresponding dev endpoint is running).
+
+- [ ] **Step 2: Run the full auth brick suite to confirm zero regressions**
+
+```bash
+pytest src/nexus/bricks/auth/tests/ -v
+```
+
+Expected: all pass; pre-existing `test_postgres_profile_store.py` still green.
+
+- [ ] **Step 3: Verify CLI surface**
+
+```bash
+python -c "from nexus.bricks.auth.cli_commands import auth; \
+import click; \
+ctx = click.Context(auth); \
+print([c for c in auth.list_commands(ctx)])"
+```
+
+Expected output contains both `migrate-to-postgres` and `rotate-kek`.
+
+- [ ] **Step 4: Dry-run the CLI end-to-end against a running Postgres**
+
+Prerequisites: `docker compose -f dockerfiles/compose.yaml up postgres -d`
+
+```bash
+# Seed a tenant + a single encrypted row for smoke, then dry-run
+python -c "
+import os, uuid
+from sqlalchemy import create_engine
+from nexus.bricks.auth.postgres_profile_store import (
+    PostgresAuthProfileStore, ensure_schema, ensure_tenant, ensure_principal,
+)
+from nexus.bricks.auth.envelope_providers.in_memory import InMemoryEncryptionProvider
+from nexus.bricks.auth.credential_backend import ResolvedCredential
+from nexus.bricks.auth.tests.conftest import make_profile
+
+url = 'postgresql+psycopg2://postgres:nexus@localhost:5432/nexus'
+engine = create_engine(url, future=True)
+ensure_schema(engine)
+t = ensure_tenant(engine, 'smoke-tenant')
+p = ensure_principal(engine, tenant_id=t, external_sub='sub-x', auth_method='smoke')
+prov = InMemoryEncryptionProvider()
+store = PostgresAuthProfileStore(url, tenant_id=t, principal_id=p, engine=engine, encryption_provider=prov)
+store.upsert_with_credential(make_profile('smoke-id'), ResolvedCredential(kind='api_key', api_key='k'))
+prov.rotate()
+"
+
+# Expect: 1 stale row at kek_version=1
+NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID=smoke \
+python -c "
+from nexus.bricks.auth.cli_commands import _TEST_PROVIDER_REGISTRY
+from nexus.bricks.auth.envelope_providers.in_memory import InMemoryEncryptionProvider
+# Register a fresh provider (won't match the seeded one — expected to report all rows stale since current_version=1)
+_TEST_PROVIDER_REGISTRY['smoke'] = InMemoryEncryptionProvider
+"
+```
+
+(This step is informational — the test module already covers dry-run; the point is to have run the CLI against a real DB once.)
+
+- [ ] **Step 5: No commit — this task is verification only**
+
+---
+
+## Self-Review
+
+### Spec coverage
+
+| Spec section | Task(s) |
+|---|---|
+| `EncryptionProvider` Protocol with `wrap_dek/unwrap_dek`, `current_version`, tenant-scoped | Task 1 (trait) + Task 4 (first impl) |
+| `CredentialCarryingProfileStore` sub-protocol | Task 7 |
+| `AESGCMEnvelope` + DEK-per-row + fresh nonce | Task 1 |
+| `DEKCache` keyed by `sha256(wrapped_dek)`, TTL + LRU, no-negative-cache | Task 3 |
+| `EnvelopeError` hierarchy with no-plaintext repr | Tasks 1 + 2 |
+| `InMemoryEncryptionProvider` test fake | Task 4 |
+| Shared contract suite | Task 5 (in-memory) + Tasks 14/15 (Vault/KMS re-param) |
+| Prometheus metrics module | Task 6 |
+| Schema delta (5 nullable cols + CHECK) + upgrade path | Task 8 |
+| `upsert_with_credential` / `get_with_credential` with provider = None default, AAD verify, cache lookup | Task 9 |
+| Swap-attack test, PR 1 compat test, mixed-version test, cache-amortization test, AAD-tamper test, CHECK-violation test | Tasks 8 + 9 + 10 |
+| `rotate_kek_for_tenant` + `RotationReport` + `SKIP LOCKED` | Task 11 |
+| Per-row rotation failure semantics | Task 12 |
+| CLI `nexus auth rotate-kek` dry-run + apply | Task 13 |
+| `VaultTransitProvider` with `derived=true` validation | Task 14 |
+| `AwsKmsProvider` with `EncryptionContext` | Task 15 |
+| Deployment docs | Task 16 |
+
+### Type consistency spot-check
+
+- `EncryptionProvider.wrap_dek` → `tuple[bytes, int]` everywhere (Task 1 defines, Tasks 4/11/14/15 match).
+- `DEKCache.make_key` signature is consistent (Task 3 defines, Task 9 calls).
+- `RotationReport` fields (`rows_rewrapped`, `rows_failed`, `rows_remaining`, `target_version`) match between Task 11 (definition) and Tasks 12/13 (consumers).
+- `AADMismatch` / `WrappedDEKInvalid` catch sites in Task 10 (swap test) match raise sites in Tasks 1 and 4.
+
+### Placeholder scan
+
+No "TBD", no "implement later", no "similar to Task N" — every step shows the code it needs.
+
+---
+
+## Execution Handoff
+
+Plan complete and saved to `docs/superpowers/plans/2026-04-18-issue-3803-envelope-encryption.md`. Two execution options:
+
+1. **Subagent-Driven (recommended)** — I dispatch a fresh subagent per task, review between tasks, fast iteration.
+2. **Inline Execution** — Execute tasks in this session using executing-plans, batch execution with checkpoints.
+
+Which approach?

--- a/docs/superpowers/specs/2026-04-18-issue-3803-envelope-encryption-design.md
+++ b/docs/superpowers/specs/2026-04-18-issue-3803-envelope-encryption-design.md
@@ -1,0 +1,312 @@
+# Envelope encryption layer for `PostgresAuthProfileStore` (issue #3803)
+
+Phase C of epic #3788. PR 2 of 3. Lands the crypto rails on top of the store shipped in #3802.
+
+## Scope
+
+Add envelope encryption to `PostgresAuthProfileStore` so rows can carry resolved credentials alongside the routing metadata they already carry. `AuthProfile` itself stays routing-metadata-only (SQLite / in-memory stores unchanged). Ciphertext storage is opt-in per call via a new sub-protocol; Postgres rows written by PR 1 remain readable with zero migration.
+
+Out of scope (explicit):
+
+- Daemon-side client encryption — Phase D (PR 3/3) moves encryption to a client that pushes over the wire. This PR does the server-side envelope only.
+- HSM integration — overkill at current scale.
+- Custom AES in-process — use Vault Transit or AWS KMS as the KEK.
+- Feature-flag wiring / consumer code paths — no caller yet. Phase D wires the first one.
+
+## Architecture
+
+Two new surfaces; everything else is isolated to the `auth` brick.
+
+### `EncryptionProvider` trait
+
+```python
+class EncryptionProvider(Protocol):
+    def current_version(self, *, tenant_id: uuid.UUID) -> int: ...
+    def wrap_dek(self, dek: bytes, *, tenant_id: uuid.UUID, aad: bytes) -> tuple[bytes, int]:
+        """Return (wrapped_bytes, kek_version). wrap always uses the provider's current version."""
+        ...
+    def unwrap_dek(self, wrapped: bytes, *, tenant_id: uuid.UUID, aad: bytes, kek_version: int) -> bytes: ...
+```
+
+`wrap_dek` always uses the provider's current version and returns it alongside the wrapped bytes — matches how Vault Transit (`encrypt_data` always picks the latest key version unless explicitly overridden) and AWS KMS (`Encrypt` always uses the primary version of the CMK) behave natively. `unwrap_dek` takes the stored `kek_version` because rows persist history — Vault Transit takes `key_version` on decrypt; AWS KMS decrypt ignores it (the ciphertext blob encodes the key version internally) so our `AwsKmsProvider` uses `kek_version` for tracking only.
+
+`tenant_id` is a first-class param on every op so per-tenant key derivation (Vault Transit `derived=true` context, AWS KMS `EncryptionContext`) threads through from day 1. A single-KEK provider simply ignores the arg.
+
+`aad` is passed through to the provider where supported (AWS KMS `EncryptionContext`) so AAD tamper is caught at KMS, not just locally. Providers that don't surface AAD at the wrap level (Vault Transit has only `context`) still bind AAD at the AESGCM layer — the belt survives with or without the suspenders.
+
+### `CredentialCarryingProfileStore` sub-protocol
+
+```python
+class CredentialCarryingProfileStore(AuthProfileStore, Protocol):
+    def upsert_with_credential(self, profile: AuthProfile, credential: ResolvedCredential) -> None: ...
+    def get_with_credential(self, profile_id: str) -> tuple[AuthProfile, ResolvedCredential | None]: ...
+```
+
+Only `PostgresAuthProfileStore` implements it. Callers that don't need ciphertext keep the base Protocol. `get_with_credential` returns `None` for the credential when a row was written via plain `upsert` (PR 1 shape, NULL ciphertext columns) — so the sub-protocol is read-compatible with the existing contract.
+
+### Trust boundary
+
+Plaintext exists only between `ResolvedCredential → AESGCM.encrypt()` and `AESGCM.decrypt() → ResolvedCredential`. Never persisted; never logged. `DEKCache` holds unwrapped DEKs in memory for up to 5 min, keyed by `(tenant_id, kek_version, sha256(wrapped_dek))` — the wrapped-DEK hash, not the DEK itself, so debug logging of the cache key is safe.
+
+## Components
+
+```
+src/nexus/bricks/auth/
+├── envelope.py                       # Provider trait, AESGCMEnvelope, DEKCache, EnvelopeError hierarchy
+├── envelope_providers/
+│   ├── __init__.py
+│   ├── in_memory.py                 # InMemoryEncryptionProvider (test fake + default)
+│   ├── vault_transit.py             # VaultTransitProvider (lazy hvac)
+│   └── aws_kms.py                   # AwsKmsProvider (lazy boto3)
+├── envelope_metrics.py               # Prometheus counters / histograms
+├── postgres_profile_store.py        # extended: new columns + encrypted upsert/get + rotate batch
+├── profile.py                        # CredentialCarryingProfileStore added
+├── cli_commands.py                   # rotate-kek subcommand added
+└── tests/
+    ├── test_envelope.py
+    ├── test_envelope_contract.py
+    ├── test_envelope_providers_vault.py         @pytest.mark.vault
+    ├── test_envelope_providers_aws_kms.py       @pytest.mark.kms
+    ├── test_postgres_envelope_integration.py    @pytest.mark.postgres
+    └── test_rotate_kek_cli.py                   @pytest.mark.postgres
+```
+
+### `envelope.py`
+
+- `AESGCMEnvelope` — thin wrapper over `cryptography.hazmat.primitives.ciphers.aead.AESGCM`. `encrypt(plaintext, *, aad) -> (nonce, ciphertext)` generates a fresh 12-byte nonce per call; `decrypt(nonce, ciphertext, *, aad) -> plaintext` verifies the GCM tag.
+- `DEKCache` — `TTL=300s`, `max=1024` entries, LRU on size eviction. Key: `(tenant_id, kek_version, sha256(wrapped_dek))`. Cache never holds negative results (failed unwraps are not cached).
+- `EnvelopeError` hierarchy (`EnvelopeConfigurationError`, `DecryptionFailed`, `AADMismatch`, `WrappedDEKInvalid`, `CiphertextCorrupted`).
+
+### `envelope_providers/in_memory.py`
+
+`InMemoryEncryptionProvider` — test fake with real AEAD. Holds `dict[(tenant_id, kek_version), 32-byte KEK]`; wrap/unwrap uses `AESGCM` with `tenant_id|kek_version` as AAD so wrapped bytes are real ciphertext (not identity). Exposes `.wrap_count` / `.unwrap_count` for cache-amortization assertions. Supports `rotate(new_version)` so rotation tests don't need a live KMS.
+
+### `envelope_providers/vault_transit.py`
+
+`VaultTransitProvider(vault_client, key_name, *, mount_point="transit")`. Caller injects `hvac.Client`; `import hvac` is lazy (module-level) with a clear `ImportError` pointing at the extras group. On construction, calls `transit.read_key()` once and raises `EnvelopeConfigurationError` if `derived is not True` — fail loud at bootstrap, not on first encrypt. Uses `transit.encrypt_data(name=key_name, plaintext=b64(dek), context=b64(str(tenant_id)))` / `transit.decrypt_data(...)`. `current_version` reads `latest_version` from the key config.
+
+### `envelope_providers/aws_kms.py`
+
+`AwsKmsProvider(kms_client, key_id)`. Caller injects `boto3.client("kms")`; `import boto3.client` is lazy. On construction, calls `describe_key()` — missing IAM raises `EnvelopeConfigurationError` with a remediation string listing required actions (`kms:Encrypt`, `kms:Decrypt`, `kms:DescribeKey`). Uses `encrypt(KeyId=key_id, Plaintext=dek, EncryptionContext={"tenant_id": str(tenant_id), "aad_fingerprint": sha256_hex(aad)})` / `decrypt(...)`. AAD fingerprint in encryption context pins row identity at the KMS level — cross-row DEK swap fails at KMS, not just locally.
+
+### `envelope_metrics.py`
+
+Prometheus primitives. Low-cardinality labels only (no principal_id, no profile_id):
+
+- `DEK_CACHE_HITS = Counter(..., labelnames=["tenant_id"])`
+- `DEK_CACHE_MISSES`
+- `DEK_UNWRAP_ERRORS`
+- `DEK_UNWRAP_LATENCY = Histogram(...)`
+- `KEK_ROTATE_ROWS = Counter(..., labelnames=["tenant_id", "from_version", "to_version"])`
+
+### `postgres_profile_store.py` extensions
+
+Five nullable columns added to `_TABLE_STATEMENTS`; mirrored in `_upgrade_shape_in_place` via `ADD COLUMN IF NOT EXISTS` inside the existing `pg_advisory_xact_lock` region. `CHECK` constraint enforces all-five-set or all-five-null. New methods:
+
+- `upsert_with_credential(profile, credential)` — reuses the existing `(tenant_id, profile_id)` advisory lock; single `INSERT ... ON CONFLICT` with the 5 extra columns inlined into `_UPSERT_SQL`.
+- `get_with_credential(profile_id)` — SELECT, short-circuit to `(profile, None)` when `ciphertext IS NULL`, else cache lookup → unwrap → AESGCM decrypt.
+- `upsert_with_credential` / `get_with_credential` require an `encryption_provider=` kwarg at store construction; absent it, they raise `RuntimeError("encryption_provider required")` — no silent fallback to plaintext.
+
+**Rotation lives outside the per-(tenant, principal) store**, as a module-level admin helper:
+
+```python
+def rotate_kek_for_tenant(
+    engine: Engine,
+    *,
+    tenant_id: uuid.UUID,
+    encryption_provider: EncryptionProvider,
+    batch_size: int = 100,
+    max_rows: int | None = None,
+) -> RotationReport: ...
+```
+
+Operates on every row in the tenant regardless of principal (matches `ensure_tenant` / `ensure_principal` pattern from #3802). Sets `app.current_tenant` for RLS, then `SELECT ... FOR UPDATE SKIP LOCKED LIMIT :batch_size` loops. No principal scoping. The provider's `current_version` is consulted once at entry — if every row is already at that version, the helper returns early with zero work.
+
+### `cli_commands.py`
+
+```
+nexus auth rotate-kek --tenant NAME [--apply] [--batch-size 100] [--max-rows N]
+```
+
+Dry-run by default; `--apply` writes. Matches `nexus auth migrate-to-postgres` pattern from PR 1. Calls `rotate_kek_for_tenant`, which loops internally over batches. "Target version" is implicit — the provider's current version at call time. Operator promotes the provider version out-of-band (Vault: rotate the transit key; AWS KMS: no-op, managed rotation); the CLI then sweeps rows at old versions.
+
+## Data flow + schema
+
+### Schema delta (`auth_profiles`)
+
+```sql
+ciphertext   BYTEA,
+wrapped_dek  BYTEA,
+nonce        BYTEA,
+aad          BYTEA,
+kek_version  INTEGER,
+
+CONSTRAINT auth_profiles_envelope_all_or_none CHECK (
+  (ciphertext IS NULL) = (wrapped_dek IS NULL) AND
+  (ciphertext IS NULL) = (nonce IS NULL) AND
+  (ciphertext IS NULL) = (aad IS NULL) AND
+  (ciphertext IS NULL) = (kek_version IS NULL)
+)
+```
+
+`aad` is stored — decrypt is self-contained from the row, which matters for `rotate_kek_for_tenant` (rewraps DEK without knowing the caller's current `(tenant_id, principal_id)`). Store additionally verifies at read that stored `aad == f"{tenant_id}|{principal_id}|{profile_id}".encode()` and raises `AADMismatch` on drift.
+
+### AAD composition
+
+`f"{tenant_id}|{principal_id}|{profile_id}".encode("utf-8")`.
+
+Matches the composite PK exactly. Any PK-component tamper fails decrypt. Provider column omitted — it's redundant with `profile_id` (ids like `"google/alice"` already encode provider) and reduces migration surface if a provider is ever renamed.
+
+### Payload serialization
+
+`ResolvedCredential` → JSON with `sort_keys=True`, `separators=(",", ":")`, UTF-8. Deterministic so rotation re-encrypts byte-identical plaintext — easy to assert no semantic drift in tests.
+
+### Write path (`upsert_with_credential`)
+
+1. `_scoped()` transaction (sets `app.current_tenant`).
+2. `SELECT pg_advisory_xact_lock(hashtextextended(tenant_id/profile_id))` — same lock as plain `upsert` to serialize against concurrent mutators.
+3. `dek = secrets.token_bytes(32)`; `nonce = secrets.token_bytes(12)`; `aad = f"{tenant_id}|{principal_id}|{profile_id}".encode()`.
+4. `ciphertext = AESGCM(dek).encrypt(nonce, json_bytes, aad)`.
+5. `(wrapped_dek, kek_version) = provider.wrap_dek(dek, tenant_id=tenant_id, aad=aad)`.
+6. Single `INSERT ... ON CONFLICT (tenant_id, principal_id, id) DO UPDATE` with routing columns + 5 encryption columns.
+
+### Read path (`get_with_credential`)
+
+1. `_scoped()` `SELECT *`.
+2. If `ciphertext IS NULL` → return `(profile, None)`.
+3. Verify `row.aad == expected_aad`; raise `AADMismatch` on drift.
+4. `DEKCache.get((tenant_id, kek_version, sha256(wrapped_dek)))`; on miss, `provider.unwrap_dek(...)` → record miss + latency → cache result.
+5. `plaintext = AESGCM(dek).decrypt(nonce, ciphertext, aad)`; `json.loads` → `ResolvedCredential`.
+6. Return `(profile, credential)`.
+
+### Rotation path (`rotate_kek_for_tenant`)
+
+1. Read `target_version = provider.current_version(tenant_id=tenant_id)` once at entry. Every batch rewraps rows whose `kek_version < target_version`.
+2. Per batch: open tx, `SET LOCAL app.current_tenant = :tid`, `SELECT tenant_id, principal_id, id, wrapped_dek, nonce, aad, kek_version FROM auth_profiles WHERE tenant_id = :tid AND ciphertext IS NOT NULL AND kek_version < :target ORDER BY principal_id, id FOR UPDATE SKIP LOCKED LIMIT :batch_size`. `SKIP LOCKED` lets the CLI resume after interruption without blocking concurrent writers.
+3. For each row: `dek = provider.unwrap_dek(row.wrapped_dek, tenant_id=tid, aad=row.aad, kek_version=row.kek_version)`; `(new_wrapped, new_version) = provider.wrap_dek(dek, tenant_id=tid, aad=row.aad)`; `UPDATE wrapped_dek = :new_wrapped, kek_version = :new_version WHERE tenant_id = :tid AND principal_id = :pid AND id = :id`. `ciphertext`, `nonce`, `aad` untouched so any reader mid-rotation decrypts successfully regardless of which version wrote.
+4. Increment `KEK_ROTATE_ROWS` with labels `(tenant_id, from_version, to_version)`.
+5. Loop batches until `SELECT` returns zero rows or `max_rows` exhausted. Return `RotationReport(rows_rewrapped, rows_failed, rows_remaining, target_version)`.
+
+### PR 1 compatibility
+
+Nullable columns + NULL-aware read path means PR 1 rows stay readable unchanged. Callers who never pass an `encryption_provider` get exactly today's behavior.
+
+## Error handling
+
+### Error types
+
+```
+EnvelopeError(Exception)
+├── EnvelopeConfigurationError            # setup problems (Transit key not derived, KMS IAM denied at init)
+├── DecryptionFailed                      # generic — stored ciphertext/DEK couldn't be decrypted
+├── AADMismatch(DecryptionFailed)         # AAD column doesn't match expected tenant|principal|profile
+├── WrappedDEKInvalid(DecryptionFailed)   # provider returned an unwrap error (KMS AccessDenied, Transit 403)
+└── CiphertextCorrupted(DecryptionFailed) # AESGCM tag verification failed
+```
+
+### Propagation
+
+`get_with_credential` never swallows `DecryptionFailed`. Caller decides: retry for transient `WrappedDEKInvalid` (KMS 5xx, Vault 503), surface `AADMismatch` to the operator (never transient — bug or attack), fail the resolve for `CiphertextCorrupted`.
+
+### No plaintext in error paths
+
+Every `EnvelopeError.__str__` / `__repr__` includes `(tenant_id, profile_id, kek_version)` + the provider-side error class only. Never ciphertext, wrapped_dek, DEK, or plaintext. A unit test round-trips `repr()` through a regex that asserts no base64/hex blob ≥16 bytes appears.
+
+### Cache never caches failures
+
+Failed unwraps do not enter the cache. A transient IAM blip shouldn't pin "decrypt failed" for 5 min. Next call retries the provider.
+
+### Rotation failure modes
+
+- Per-row unwrap failure → CLI prints `(tenant_id, profile_id, kek_version, error_class)` and continues the batch. Row stays on old version. Operator investigates before re-running. Exit code 0 with warning on stderr.
+- Wrap failure at new version → abort, non-zero exit, zero rows mutated. A new-version KEK that can't wrap is a setup error, not a row error.
+
+### Config/bootstrap failures
+
+Providers validate on construction, not on first encrypt. `VaultTransitProvider` asserts `derived=true`; `AwsKmsProvider` calls `describe_key()`. Both raise `EnvelopeConfigurationError` with a remediation string (`"run: vault write -f transit/keys/<name> derived=true"`, `"grant kms:Encrypt,kms:Decrypt on <arn>"`).
+
+### CHECK-constraint violations
+
+Surface as `sqlalchemy.exc.IntegrityError`. Test asserts this shape — silently coercing a bug into a write is worse than failing loud.
+
+## Testing
+
+All tests new. Gating mirrors PR 1's split (`@pytest.mark.postgres`, `xdist_group`).
+
+### `test_envelope.py` — pure unit, fast
+
+- AESGCM roundtrip
+- nonce-reuse under same DEK raises (guardrail on DEK-per-row invariant)
+- AAD tamper → `CiphertextCorrupted`
+- ciphertext bit-flip → `CiphertextCorrupted`
+- `DEKCache` TTL expiry, LRU eviction, hit/miss counter increment
+- `repr()`/`str()` for every `EnvelopeError` subclass — regex asserts no ≥16-byte base64/hex blob appears
+
+### `test_envelope_contract.py` — shared parametrized suite
+
+Runs against `InMemoryEncryptionProvider` by default. Vault / KMS provider test modules import and re-parametrize this suite. Contract asserts:
+
+- wrap/unwrap roundtrip
+- unwrap with wrong `tenant_id` → `WrappedDEKInvalid`
+- unwrap with wrong `aad` → `WrappedDEKInvalid`
+- `current_version` advances after `rotate(new_version)` (fake only; real providers skip)
+- wrap at v2, unwrap at v1 succeeds (readers tolerate mixed versions)
+
+### `test_postgres_envelope_integration.py` — @pytest.mark.postgres
+
+Covers every acceptance criterion from the issue:
+
+- **Roundtrip**: `upsert_with_credential` → `get_with_credential` returns equal credential.
+- **Swap attack**: write row A in tenant T1; direct SQL copies A's `(ciphertext, wrapped_dek, nonce, aad, kek_version)` into row B in tenant T2; `get_with_credential(B)` raises `AADMismatch`. Also tested with `tenant_id` swap handled via the provider side (in-memory raises `WrappedDEKInvalid` when KEK lookup keys differ).
+- **PR 1 compat**: plain `upsert` writes NULL ciphertext columns; `get_with_credential` returns `(profile, None)`.
+- **Mixed-version reads**: write at v1, rotate provider, write at v2, read both.
+- **CHECK constraint**: direct `INSERT` with 4 of 5 encryption columns raises `IntegrityError`.
+- **Cache amortization**: two `get_with_credential` calls for the same row → exactly one `unwrap_dek` call on the fake (`provider.unwrap_count == 1`).
+
+### `test_rotate_kek_cli.py` — @pytest.mark.postgres
+
+- Dry-run reports per-version row counts, zero writes.
+- `--apply` rewraps; all rows end at `to_version`; reads during rotation (between batches) succeed.
+- Per-row unwrap failure (fake provider marked to fail one `wrapped_dek`): batch continues; row stays old; exit 0 with warning.
+- Wrap-side failure at target version: batch aborts; zero rows mutated; non-zero exit.
+
+### `test_envelope_providers_vault.py` / `..._aws_kms.py` — opt-in integration
+
+Same contract suite, re-parametrized against dev-mode Vault or LocalStack KMS. Gated behind `@pytest.mark.vault` / `@pytest.mark.kms`. Never in default CI; manual + future gated job.
+
+### Explicitly NOT tested in this PR
+
+- Cross-process DEK cache coordination (per-process cache is by design; Phase D decides any cross-process story).
+- Key-rotation daemon (CLI is the only rotation surface).
+- Vault/KMS 5xx retry policy (first hit is naive; retries land when a caller has real latency/outage data).
+
+## Acceptance mapping (from the issue)
+
+| Criterion | Where it's met |
+|---|---|
+| `EncryptionProvider` trait + both impls with contract tests | `envelope.py`, `envelope_providers/*.py`, `test_envelope_contract.py` + opt-in `test_envelope_providers_*` |
+| Roundtrip test: encrypt in store, decrypt, read back plaintext | `test_postgres_envelope_integration.py::test_roundtrip` |
+| Ciphertext-swap attack rejected | `test_postgres_envelope_integration.py::test_swap_attack_rejected` |
+| Rotation path: bump `kek_version`, background job migrates rows, reads succeed throughout | `rotate_kek_for_tenant` + `test_rotate_kek_cli.py::test_rotation_with_concurrent_reads` |
+| DEK cache hit/miss metrics | `envelope_metrics.py` + `test_envelope.py` + `test_postgres_envelope_integration.py::test_cache_amortizes` |
+| Docs: Vault vs AWS-native deployment choice | §"Deployment guidance" below |
+
+## Deployment guidance (stub for docs in repo)
+
+- **Vault-native shops** — use `VaultTransitProvider`. Create one transit key per deployment with `derived=true`; per-tenant scoping handled via the `context` parameter at encrypt time. Vault Transit is free self-hosted; no per-call cost. Rotation: `vault write -f transit/keys/<name>/rotate`; then run `nexus auth rotate-kek --to-version N` per tenant.
+- **AWS-native shops** — use `AwsKmsProvider`. One CMK per tenant (keeps blast radius per-tenant), `kms:Encrypt` / `kms:Decrypt` / `kms:DescribeKey` IAM. Per-call KMS charges apply; the 5-min DEK cache amortizes these on hot paths. Rotation: either manually create a new key and point the provider at it (key-id swap), or rely on AWS-managed annual rotation (no `kek_version` bump needed — KMS handles envelope internally; our `kek_version` then tracks provider-config version only).
+- Anything else → start with `InMemoryEncryptionProvider` for development only. Not for production: process-local keys die with the process.
+
+## Non-goals / deferred
+
+- Configuration surface (env vars / settings file factory) — deferred to Phase D when the first real consumer exists.
+- Key-rotation always-on daemon — CLI-only for now.
+- AuthProfile dataclass changes — routing-only stays the shape; ciphertext travels via the sub-protocol methods.
+- Metrics backend switch (OpenTelemetry) — `prometheus_client` matches existing `bricks/*_metrics.py` pattern.
+
+## Sources
+
+- [Envelope encryption patterns](https://docs.cloud.google.com/kms/docs/envelope-encryption)
+- [Vault Transit secrets engine](https://developer.hashicorp.com/vault/docs/secrets/transit)
+- [AWS KMS encryption context](https://docs.aws.amazon.com/kms/latest/developerguide/encrypt_context.html)
+- [AWS cross-account secret access patterns](https://aws.amazon.com/blogs/database/design-patterns-to-access-cross-account-secrets-stored-in-aws-secrets-manager/)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,6 +178,16 @@ profiling = [
     "pyroscope-io>=0.8.16",
     "pyroscope-otel",
 ]
+
+vault = [
+    # HashiCorp Vault client for VaultTransitProvider envelope encryption (Issue #3803)
+    "hvac>=1.2.0",
+]
+
+aws = [
+    # AWS SDK for AwsKmsProvider envelope encryption (Issue #3803)
+    "boto3>=1.34.0",
+]
 dev = [
     # Testing
     "pytest>=9.0.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -367,6 +367,8 @@ markers = [
     "quarantine: Tests that are flaky or timing-dependent (deselected by default in CI)",
     "postgres: marks tests that require a running PostgreSQL instance (Issue #1299)",
     "benchmark_ci: critical benchmarks run on every PR",
+    "vault: marks tests that require a running Vault dev server (opt-in, see docs/guides/auth-envelope-encryption.md)",
+    "kms: marks tests that require a reachable AWS KMS endpoint (opt-in, real AWS or LocalStack)",
 ]
 
 [tool.coverage.run]

--- a/src/nexus/bricks/auth/cli_commands.py
+++ b/src/nexus/bricks/auth/cli_commands.py
@@ -955,11 +955,25 @@ def _build_kms_provider(
 )
 @click.option(
     "--tenant",
-    required=True,
-    help="Tenant name whose rows should be rewrapped at the provider's current version.",
+    default=None,
+    help="Tenant name (requires a DB role that can read tenants.name — typically "
+    "BYPASSRLS). For least-privilege roles, pass --tenant-id instead.",
+)
+@click.option(
+    "--tenant-id",
+    "tenant_id_opt",
+    default=None,
+    help="Tenant UUID. Preferred for least-privilege roles: skips the tenants "
+    "table lookup that FORCE RLS blocks for non-BYPASSRLS roles.",
 )
 @click.option(
     "--apply", is_flag=True, default=False, help="Actually rewrap rows (default: dry-run)."
+)
+@click.option(
+    "--allow-failures",
+    is_flag=True,
+    default=False,
+    help="Exit 0 even when rows_failed > 0 (default: non-zero exit on any failed row).",
 )
 @click.option(
     "--batch-size",
@@ -998,8 +1012,10 @@ def _build_kms_provider(
 )
 def auth_rotate_kek(
     db_url: str,
-    tenant: str,
+    tenant: str | None,
+    tenant_id_opt: str | None,
     apply: bool,
+    allow_failures: bool,
     batch_size: int,
     max_rows: int | None,
     provider: str | None,
@@ -1039,10 +1055,18 @@ def auth_rotate_kek(
             for r in conn.execute(
                 text(
                     "SELECT column_name FROM information_schema.columns "
-                    "WHERE table_name = 'auth_profiles'"
+                    "WHERE table_name = 'auth_profiles' "
+                    "  AND table_schema = CURRENT_SCHEMA() "
+                    "  AND table_catalog = CURRENT_DATABASE()"
                 )
             ).fetchall()
         }
+        if not cols:
+            raise click.ClickException(
+                "auth_profiles table not found in the active schema. "
+                "Run schema migrations first (ensure_schema) with a role "
+                "that has ALTER privileges."
+            )
         missing = _REQUIRED_ENVELOPE_COLUMNS - cols
         if missing:
             raise click.ClickException(
@@ -1078,16 +1102,33 @@ def auth_rotate_kek(
             "NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID is set."
         )
 
+    if (tenant is None) == (tenant_id_opt is None):
+        raise click.ClickException("Pass exactly one of --tenant or --tenant-id.")
+
     engine = create_engine(db_url, future=True)
     try:
-        with engine.begin() as conn:
-            _preflight_schema(conn)
-            row = conn.execute(
-                text("SELECT id FROM tenants WHERE name = :n"), {"n": tenant}
-            ).fetchone()
-        if row is None:
-            raise click.ClickException(f"Tenant {tenant!r} not found")
-        tenant_id = _uuid.UUID(str(row[0]))
+        if tenant_id_opt is not None:
+            try:
+                tenant_id = _uuid.UUID(tenant_id_opt)
+            except ValueError as exc:
+                raise click.ClickException(
+                    f"--tenant-id must be a UUID, got {tenant_id_opt!r}"
+                ) from exc
+            with engine.begin() as conn:
+                _preflight_schema(conn)
+        else:
+            with engine.begin() as conn:
+                _preflight_schema(conn)
+                row = conn.execute(
+                    text("SELECT id FROM tenants WHERE name = :n"), {"n": tenant}
+                ).fetchone()
+            if row is None:
+                raise click.ClickException(
+                    f"Tenant {tenant!r} not found. If using a least-privilege "
+                    "DB role (FORCE RLS prevents reading tenants.name), pass "
+                    "--tenant-id <uuid> instead."
+                )
+            tenant_id = _uuid.UUID(str(row[0]))
 
         if not apply:
             target = encryption_provider.current_version(tenant_id=tenant_id)
@@ -1127,6 +1168,8 @@ def auth_rotate_kek(
                 f"WARNING: {report.rows_failed} rows failed to rewrap — see logs for details",
                 err=True,
             )
+            if not allow_failures:
+                raise click.exceptions.Exit(1)
     finally:
         engine.dispose()
 

--- a/src/nexus/bricks/auth/cli_commands.py
+++ b/src/nexus/bricks/auth/cli_commands.py
@@ -1046,6 +1046,7 @@ def auth_rotate_kek(
     from sqlalchemy import create_engine, text
 
     from nexus.bricks.auth.postgres_profile_store import (
+        VersionSkewError,
         rotate_kek_for_tenant,
     )
 
@@ -1191,13 +1192,16 @@ def auth_rotate_kek(
             click.echo("Pass --apply to rewrap.")
             return
 
-        report = rotate_kek_for_tenant(
-            engine,
-            tenant_id=tenant_id,
-            encryption_provider=encryption_provider,
-            batch_size=batch_size,
-            max_rows=max_rows,
-        )
+        try:
+            report = rotate_kek_for_tenant(
+                engine,
+                tenant_id=tenant_id,
+                encryption_provider=encryption_provider,
+                batch_size=batch_size,
+                max_rows=max_rows,
+            )
+        except VersionSkewError as exc:
+            raise click.ClickException(str(exc)) from exc
         click.echo(
             f"rewrapped={report.rows_rewrapped} "
             f"failed={report.rows_failed} "

--- a/src/nexus/bricks/auth/cli_commands.py
+++ b/src/nexus/bricks/auth/cli_commands.py
@@ -961,11 +961,17 @@ def _build_kms_provider(
 @click.option(
     "--apply", is_flag=True, default=False, help="Actually rewrap rows (default: dry-run)."
 )
-@click.option("--batch-size", default=100, show_default=True, help="Rows per batch.")
+@click.option(
+    "--batch-size",
+    default=100,
+    show_default=True,
+    type=click.IntRange(min=1),
+    help="Rows per batch (must be >= 1).",
+)
 @click.option(
     "--max-rows",
     default=None,
-    type=int,
+    type=click.IntRange(min=1),
     help="Upper bound on rows rewrapped across all batches (omit for no cap).",
 )
 @click.option(
@@ -987,8 +993,8 @@ def _build_kms_provider(
     "--kms-config-version",
     default=1,
     show_default=True,
-    type=int,
-    help="Provider config version to stamp into wrap ciphertexts.",
+    type=click.IntRange(min=1),
+    help="Provider config version to stamp into wrap ciphertexts (>= 1).",
 )
 def auth_rotate_kek(
     db_url: str,
@@ -1016,9 +1022,34 @@ def auth_rotate_kek(
     from sqlalchemy import create_engine, text
 
     from nexus.bricks.auth.postgres_profile_store import (
-        ensure_schema,
         rotate_kek_for_tenant,
     )
+
+    _REQUIRED_ENVELOPE_COLUMNS = {
+        "ciphertext",
+        "wrapped_dek",
+        "nonce",
+        "aad",
+        "kek_version",
+    }
+
+    def _preflight_schema(conn: Any) -> None:
+        cols = {
+            r[0]
+            for r in conn.execute(
+                text(
+                    "SELECT column_name FROM information_schema.columns "
+                    "WHERE table_name = 'auth_profiles'"
+                )
+            ).fetchall()
+        }
+        missing = _REQUIRED_ENVELOPE_COLUMNS - cols
+        if missing:
+            raise click.ClickException(
+                "auth_profiles is missing envelope columns "
+                f"{sorted(missing)!r}. Run schema migrations first "
+                "(ensure_schema) with a role that has ALTER privileges."
+            )
 
     encryption_provider: EncryptionProvider
     test_provider_id = os.environ.get("NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID")
@@ -1049,8 +1080,8 @@ def auth_rotate_kek(
 
     engine = create_engine(db_url, future=True)
     try:
-        ensure_schema(engine)
         with engine.begin() as conn:
+            _preflight_schema(conn)
             row = conn.execute(
                 text("SELECT id FROM tenants WHERE name = :n"), {"n": tenant}
             ).fetchone()

--- a/src/nexus/bricks/auth/cli_commands.py
+++ b/src/nexus/bricks/auth/cli_commands.py
@@ -976,6 +976,13 @@ def _build_kms_provider(
     help="Exit 0 even when rows_failed > 0 (default: non-zero exit on any failed row).",
 )
 @click.option(
+    "--allow-partial",
+    is_flag=True,
+    default=False,
+    help="Exit 0 even when rows_remaining > 0 after apply "
+    "(default: non-zero; use this flag when intentionally batching under --max-rows).",
+)
+@click.option(
     "--batch-size",
     default=100,
     show_default=True,
@@ -1016,6 +1023,7 @@ def auth_rotate_kek(
     tenant_id_opt: str | None,
     apply: bool,
     allow_failures: bool,
+    allow_partial: bool,
     batch_size: int,
     max_rows: int | None,
     provider: str | None,
@@ -1116,6 +1124,17 @@ def auth_rotate_kek(
                 ) from exc
             with engine.begin() as conn:
                 _preflight_schema(conn)
+                # RLS-safe existence check: setting app.current_tenant to the
+                # caller-supplied value grants read access via the tenant-
+                # isolation policy, so this lookup works for least-privilege
+                # roles and still refuses mistyped UUIDs.
+                conn.execute(text("SET LOCAL app.current_tenant = :tid"), {"tid": str(tenant_id)})
+                exists = conn.execute(
+                    text("SELECT 1 FROM tenants WHERE id = :tid"),
+                    {"tid": tenant_id},
+                ).fetchone()
+            if exists is None:
+                raise click.ClickException(f"Tenant {tenant_id!s} not found (check --tenant-id).")
         else:
             with engine.begin() as conn:
                 _preflight_schema(conn)
@@ -1130,8 +1149,30 @@ def auth_rotate_kek(
                 )
             tenant_id = _uuid.UUID(str(row[0]))
 
+        target = encryption_provider.current_version(tenant_id=tenant_id)
+
+        # Version-skew check: any row at kek_version > target means the
+        # provider config is older than data already written. Operator
+        # likely passed the wrong --kms-config-version or is pointing at a
+        # rolled-back provider.
+        with engine.begin() as conn:
+            conn.execute(text("SET LOCAL app.current_tenant = :tid"), {"tid": str(tenant_id)})
+            skew = conn.execute(
+                text(
+                    "SELECT COUNT(*) FROM auth_profiles "
+                    "WHERE tenant_id = :tid AND ciphertext IS NOT NULL "
+                    "  AND kek_version > :target"
+                ),
+                {"tid": tenant_id, "target": target},
+            ).scalar_one()
+        if skew:
+            raise click.ClickException(
+                f"{skew} rows have kek_version > target ({target}). The provider "
+                "is pointing at an older version than rows already written. "
+                "Refusing to rotate. For aws-kms, check --kms-config-version."
+            )
+
         if not apply:
-            target = encryption_provider.current_version(tenant_id=tenant_id)
             with engine.begin() as conn:
                 conn.execute(text("SET LOCAL app.current_tenant = :tid"), {"tid": str(tenant_id)})
                 stale = conn.execute(
@@ -1163,13 +1204,23 @@ def auth_rotate_kek(
             f"remaining={report.rows_remaining} "
             f"target_version={report.target_version}"
         )
+        exit_nonzero = False
         if report.rows_failed:
             click.echo(
                 f"WARNING: {report.rows_failed} rows failed to rewrap — see logs for details",
                 err=True,
             )
             if not allow_failures:
-                raise click.exceptions.Exit(1)
+                exit_nonzero = True
+        if report.rows_remaining and not allow_partial:
+            click.echo(
+                f"WARNING: {report.rows_remaining} rows remain stuck at older "
+                "versions — run again to continue, or pass --allow-partial.",
+                err=True,
+            )
+            exit_nonzero = True
+        if exit_nonzero:
+            raise click.exceptions.Exit(1)
     finally:
         engine.dispose()
 

--- a/src/nexus/bricks/auth/cli_commands.py
+++ b/src/nexus/bricks/auth/cli_commands.py
@@ -12,9 +12,12 @@ import logging
 import os
 import re
 from collections.abc import Callable
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
 import click
+
+if TYPE_CHECKING:
+    from nexus.bricks.auth.envelope import EncryptionProvider
 from rich.table import Table
 
 from nexus.cli.theme import console
@@ -894,7 +897,54 @@ def auth_migrate_to_postgres(
 # Test hook: lets test modules register a provider factory without building
 # real Vault/KMS wiring. Production code paths never use this registry — they
 # construct a provider from CLI args (lands with the Phase D consumer).
-_TEST_PROVIDER_REGISTRY: dict[str, Callable[[], object]] = {}
+_TEST_PROVIDER_REGISTRY: dict[str, Callable[[], "EncryptionProvider"]] = {}
+
+
+def _build_vault_provider(
+    *,
+    vault_addr: str | None,
+    vault_token: str | None,
+    vault_key: str | None,
+    vault_mount: str,
+) -> "EncryptionProvider":  # noqa: F821
+    if not vault_key:
+        raise click.ClickException("--vault-key is required for --provider=vault")
+    addr = vault_addr or os.environ.get("VAULT_ADDR")
+    token = vault_token or os.environ.get("VAULT_TOKEN")
+    if not addr:
+        raise click.ClickException("--vault-addr or VAULT_ADDR env var is required")
+    if not token:
+        raise click.ClickException("--vault-token or VAULT_TOKEN env var is required")
+    try:
+        import hvac
+    except ImportError as exc:
+        raise click.ClickException(
+            "hvac not installed. Install with: pip install 'nexus[vault]'"
+        ) from exc
+    from nexus.bricks.auth.envelope_providers.vault_transit import VaultTransitProvider
+
+    client = hvac.Client(url=addr, token=token)
+    return VaultTransitProvider(client, key_name=vault_key, mount_point=vault_mount)
+
+
+def _build_kms_provider(
+    *,
+    kms_key_id: str | None,
+    kms_region: str | None,
+    kms_config_version: int,
+) -> "EncryptionProvider":  # noqa: F821
+    if not kms_key_id:
+        raise click.ClickException("--kms-key-id is required for --provider=aws-kms")
+    try:
+        import boto3
+    except ImportError as exc:
+        raise click.ClickException(
+            "boto3 not installed. Install with: pip install 'nexus[aws]'"
+        ) from exc
+    from nexus.bricks.auth.envelope_providers.aws_kms import AwsKmsProvider
+
+    client = boto3.client("kms", region_name=kms_region) if kms_region else boto3.client("kms")
+    return AwsKmsProvider(client, key_id=kms_key_id, config_version=kms_config_version)
 
 
 @auth.command("rotate-kek")
@@ -918,12 +968,42 @@ _TEST_PROVIDER_REGISTRY: dict[str, Callable[[], object]] = {}
     type=int,
     help="Upper bound on rows rewrapped across all batches (omit for no cap).",
 )
+@click.option(
+    "--provider",
+    type=click.Choice(["vault", "aws-kms"]),
+    default=None,
+    help="Encryption provider to construct (vault|aws-kms). Required unless "
+    "NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID is set.",
+)
+@click.option("--vault-addr", default=None, help="Vault URL (falls back to VAULT_ADDR env).")
+@click.option("--vault-token", default=None, help="Vault token (falls back to VAULT_TOKEN env).")
+@click.option("--vault-key", default=None, help="Vault transit key name (derived=true required).")
+@click.option(
+    "--vault-mount", default="transit", show_default=True, help="Vault transit mount point."
+)
+@click.option("--kms-key-id", default=None, help="AWS KMS key id, alias, or ARN.")
+@click.option("--kms-region", default=None, help="AWS region (falls back to boto3 default chain).")
+@click.option(
+    "--kms-config-version",
+    default=1,
+    show_default=True,
+    type=int,
+    help="Provider config version to stamp into wrap ciphertexts.",
+)
 def auth_rotate_kek(
     db_url: str,
     tenant: str,
     apply: bool,
     batch_size: int,
     max_rows: int | None,
+    provider: str | None,
+    vault_addr: str | None,
+    vault_token: str | None,
+    vault_key: str | None,
+    vault_mount: str,
+    kms_key_id: str | None,
+    kms_region: str | None,
+    kms_config_version: int,
 ) -> None:
     """Rewrap auth_profiles rows at the current provider KEK version.
 
@@ -940,18 +1020,31 @@ def auth_rotate_kek(
         rotate_kek_for_tenant,
     )
 
+    encryption_provider: EncryptionProvider
     test_provider_id = os.environ.get("NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID")
     if test_provider_id:
         factory = _TEST_PROVIDER_REGISTRY.get(test_provider_id)
         if factory is None:
             raise click.ClickException(f"Test provider id {test_provider_id!r} not registered")
         assert callable(factory)
-        provider = factory()
+        encryption_provider = factory()
+    elif provider == "vault":
+        encryption_provider = _build_vault_provider(
+            vault_addr=vault_addr,
+            vault_token=vault_token,
+            vault_key=vault_key,
+            vault_mount=vault_mount,
+        )
+    elif provider == "aws-kms":
+        encryption_provider = _build_kms_provider(
+            kms_key_id=kms_key_id,
+            kms_region=kms_region,
+            kms_config_version=kms_config_version,
+        )
     else:
         raise click.ClickException(
-            "No production provider wiring yet. This command is consumer-driven "
-            "— Phase D wires a real EncryptionProvider factory. Tests use "
-            "NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID."
+            "--provider is required (vault|aws-kms) unless "
+            "NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID is set."
         )
 
     engine = create_engine(db_url, future=True)
@@ -966,7 +1059,7 @@ def auth_rotate_kek(
         tenant_id = _uuid.UUID(str(row[0]))
 
         if not apply:
-            target = provider.current_version(tenant_id=tenant_id)
+            target = encryption_provider.current_version(tenant_id=tenant_id)
             with engine.begin() as conn:
                 conn.execute(text("SET LOCAL app.current_tenant = :tid"), {"tid": str(tenant_id)})
                 stale = conn.execute(
@@ -988,7 +1081,7 @@ def auth_rotate_kek(
         report = rotate_kek_for_tenant(
             engine,
             tenant_id=tenant_id,
-            encryption_provider=provider,
+            encryption_provider=encryption_provider,
             batch_size=batch_size,
             max_rows=max_rows,
         )

--- a/src/nexus/bricks/auth/cli_commands.py
+++ b/src/nexus/bricks/auth/cli_commands.py
@@ -11,6 +11,7 @@ import importlib
 import logging
 import os
 import re
+from collections.abc import Callable
 from typing import Any
 
 import click
@@ -882,6 +883,126 @@ def auth_migrate_to_postgres(
         finally:
             source.close()
             target.close()
+    finally:
+        engine.dispose()
+
+
+# ---------------------------------------------------------------------------
+# auth rotate-kek (issue #3803 — envelope KEK rotation)
+# ---------------------------------------------------------------------------
+
+# Test hook: lets test modules register a provider factory without building
+# real Vault/KMS wiring. Production code paths never use this registry — they
+# construct a provider from CLI args (lands with the Phase D consumer).
+_TEST_PROVIDER_REGISTRY: dict[str, Callable[[], object]] = {}
+
+
+@auth.command("rotate-kek")
+@click.option(
+    "--db-url",
+    required=True,
+    help="PostgreSQL URL (e.g. postgresql+psycopg2://user:pw@host:5432/db).",
+)
+@click.option(
+    "--tenant",
+    required=True,
+    help="Tenant name whose rows should be rewrapped at the provider's current version.",
+)
+@click.option(
+    "--apply", is_flag=True, default=False, help="Actually rewrap rows (default: dry-run)."
+)
+@click.option("--batch-size", default=100, show_default=True, help="Rows per batch.")
+@click.option(
+    "--max-rows",
+    default=None,
+    type=int,
+    help="Upper bound on rows rewrapped across all batches (omit for no cap).",
+)
+def auth_rotate_kek(
+    db_url: str,
+    tenant: str,
+    apply: bool,
+    batch_size: int,
+    max_rows: int | None,
+) -> None:
+    """Rewrap auth_profiles rows at the current provider KEK version.
+
+    Dry-run by default. Operator promotes the provider version out-of-band
+    (Vault: ``vault write -f transit/keys/<name>/rotate``; AWS KMS: managed);
+    then runs this command to sweep rows stuck at older versions.
+    """
+    import uuid as _uuid
+
+    from sqlalchemy import create_engine, text
+
+    from nexus.bricks.auth.postgres_profile_store import (
+        ensure_schema,
+        rotate_kek_for_tenant,
+    )
+
+    test_provider_id = os.environ.get("NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID")
+    if test_provider_id:
+        factory = _TEST_PROVIDER_REGISTRY.get(test_provider_id)
+        if factory is None:
+            raise click.ClickException(f"Test provider id {test_provider_id!r} not registered")
+        assert callable(factory)
+        provider = factory()
+    else:
+        raise click.ClickException(
+            "No production provider wiring yet. This command is consumer-driven "
+            "— Phase D wires a real EncryptionProvider factory. Tests use "
+            "NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID."
+        )
+
+    engine = create_engine(db_url, future=True)
+    try:
+        ensure_schema(engine)
+        with engine.begin() as conn:
+            row = conn.execute(
+                text("SELECT id FROM tenants WHERE name = :n"), {"n": tenant}
+            ).fetchone()
+        if row is None:
+            raise click.ClickException(f"Tenant {tenant!r} not found")
+        tenant_id = _uuid.UUID(str(row[0]))
+
+        if not apply:
+            target = provider.current_version(tenant_id=tenant_id)
+            with engine.begin() as conn:
+                conn.execute(text("SET LOCAL app.current_tenant = :tid"), {"tid": str(tenant_id)})
+                stale = conn.execute(
+                    text(
+                        "SELECT kek_version, COUNT(*) FROM auth_profiles "
+                        "WHERE tenant_id = :tid AND ciphertext IS NOT NULL "
+                        "  AND kek_version < :target "
+                        "GROUP BY kek_version ORDER BY kek_version"
+                    ),
+                    {"tid": tenant_id, "target": target},
+                ).fetchall()
+            total = sum(r[1] for r in stale)
+            click.echo(f"dry-run: target_version={target}, stale_rows={total}")
+            for version, count in stale:
+                click.echo(f"  kek_version={version}: {count} rows")
+            click.echo("Pass --apply to rewrap.")
+            return
+
+        report = rotate_kek_for_tenant(
+            engine,
+            tenant_id=tenant_id,
+            encryption_provider=provider,
+            batch_size=batch_size,
+            max_rows=max_rows,
+        )
+        click.echo(
+            f"rewrapped={report.rows_rewrapped} "
+            f"failed={report.rows_failed} "
+            f"remaining={report.rows_remaining} "
+            f"target_version={report.target_version}"
+        )
+        if report.rows_failed:
+            click.echo(
+                f"WARNING: {report.rows_failed} rows failed to rewrap — see logs for details",
+                err=True,
+            )
     finally:
         engine.dispose()
 

--- a/src/nexus/bricks/auth/envelope.py
+++ b/src/nexus/bricks/auth/envelope.py
@@ -132,6 +132,15 @@ class AESGCMEnvelope:
                 "AES-GCM tag verification failed",
                 cause="InvalidTag",
             ) from exc
+        except ValueError as exc:
+            # Malformed nonce/ciphertext shape (e.g. truncated bytes, wrong
+            # nonce length). Surface as CiphertextCorrupted so callers get a
+            # typed envelope error rather than a raw ValueError leaking the
+            # underlying AESGCM implementation detail.
+            raise CiphertextCorrupted(
+                "AES-GCM rejected input shape",
+                cause=f"ValueError: {type(exc).__name__}",
+            ) from exc
 
 
 # ---------------------------------------------------------------------------

--- a/src/nexus/bricks/auth/envelope.py
+++ b/src/nexus/bricks/auth/envelope.py
@@ -14,6 +14,7 @@ from __future__ import annotations
 
 import hashlib
 import secrets
+import threading
 import time
 import uuid
 from collections import OrderedDict
@@ -200,12 +201,18 @@ class DEKCache:
     Keyed by ``(tenant_id, kek_version, sha256(wrapped_dek))`` — the hash, not
     the wrapped bytes, so cache-key logging is safe. Does not cache negative
     results: a KMS/Vault blip shouldn't pin decrypt-failed for the TTL window.
+
+    Thread-safe: callers may share one instance across a thread pool. The
+    internal lock is held for the duration of each ``get`` / ``put`` call;
+    since both operations are O(1) against an in-memory OrderedDict, contention
+    is negligible.
     """
 
     def __init__(self, *, ttl_seconds: int = 300, max_entries: int = 1024) -> None:
         self._ttl = ttl_seconds
         self._max = max_entries
         self._store: OrderedDict[DEKCacheKey, tuple[float, bytes]] = OrderedDict()
+        self._lock = threading.Lock()
         self.hits = 0
         self.misses = 0
 
@@ -220,21 +227,23 @@ class DEKCache:
         )
 
     def get(self, key: DEKCacheKey) -> bytes | None:
-        entry = self._store.get(key)
-        if entry is None:
-            self.misses += 1
-            return None
-        expires_at, dek = entry
-        if _monotonic() >= expires_at:
-            self._store.pop(key, None)
-            self.misses += 1
-            return None
-        self._store.move_to_end(key)  # mark MRU
-        self.hits += 1
-        return dek
+        with self._lock:
+            entry = self._store.get(key)
+            if entry is None:
+                self.misses += 1
+                return None
+            expires_at, dek = entry
+            if _monotonic() >= expires_at:
+                self._store.pop(key, None)
+                self.misses += 1
+                return None
+            self._store.move_to_end(key)
+            self.hits += 1
+            return dek
 
     def put(self, key: DEKCacheKey, dek: bytes) -> None:
-        self._store[key] = (_monotonic() + self._ttl, dek)
-        self._store.move_to_end(key)
-        while len(self._store) > self._max:
-            self._store.popitem(last=False)  # evict LRU
+        with self._lock:
+            self._store[key] = (_monotonic() + self._ttl, dek)
+            self._store.move_to_end(key)
+            while len(self._store) > self._max:
+                self._store.popitem(last=False)

--- a/src/nexus/bricks/auth/envelope.py
+++ b/src/nexus/bricks/auth/envelope.py
@@ -1,0 +1,118 @@
+"""Envelope encryption primitives for PostgresAuthProfileStore (issue #3803).
+
+Provides:
+  - AESGCMEnvelope: AES-256-GCM wrapper for per-row ciphertext + DEK.
+  - EncryptionProvider: Protocol for KEK-level DEK wrap/unwrap (impls land in
+    envelope_providers/).
+  - DEKCache: in-process TTL+LRU cache of unwrapped DEKs.
+  - EnvelopeError hierarchy with no-plaintext repr discipline.
+
+Design: docs/superpowers/specs/2026-04-18-issue-3803-envelope-encryption-design.md
+"""
+
+from __future__ import annotations
+
+import secrets
+import uuid
+from typing import Protocol, runtime_checkable
+
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+# ---------------------------------------------------------------------------
+# Error hierarchy — no plaintext, wrapped-DEK, or ciphertext bytes in str/repr
+# ---------------------------------------------------------------------------
+
+
+class EnvelopeError(Exception):
+    """Root of every error raised by the envelope subsystem."""
+
+
+class EnvelopeConfigurationError(EnvelopeError):
+    """Provider is misconfigured (e.g. Vault transit key not derived=true)."""
+
+
+class DecryptionFailed(EnvelopeError):
+    """Generic decrypt failure. Concrete subclasses narrow the reason."""
+
+
+class AADMismatch(DecryptionFailed):
+    """Stored AAD column does not match the expected tenant|principal|id."""
+
+
+class WrappedDEKInvalid(DecryptionFailed):
+    """Provider refused to unwrap the DEK (IAM, mismatched context, corrupt)."""
+
+
+class CiphertextCorrupted(DecryptionFailed):
+    """AES-GCM tag verification failed — ciphertext/nonce/AAD tampered."""
+
+
+# ---------------------------------------------------------------------------
+# AES-256-GCM primitive
+# ---------------------------------------------------------------------------
+
+
+class AESGCMEnvelope:
+    """Thin wrapper over `cryptography`'s AESGCM with our invariants baked in.
+
+    - DEK is 32 bytes (AES-256).
+    - Nonce is 12 bytes, freshly generated per ``encrypt`` call.
+    - AAD is bound into the AEAD tag; tamper raises ``CiphertextCorrupted``.
+    """
+
+    NONCE_LEN = 12
+    DEK_LEN = 32
+
+    def encrypt(self, dek: bytes, plaintext: bytes, *, aad: bytes) -> tuple[bytes, bytes]:
+        if len(dek) != self.DEK_LEN:
+            raise ValueError(f"DEK must be {self.DEK_LEN} bytes, got {len(dek)}")
+        nonce = secrets.token_bytes(self.NONCE_LEN)
+        ciphertext = AESGCM(dek).encrypt(nonce, plaintext, aad)
+        return nonce, ciphertext
+
+    def decrypt(self, dek: bytes, nonce: bytes, ciphertext: bytes, *, aad: bytes) -> bytes:
+        if len(dek) != self.DEK_LEN:
+            raise ValueError(f"DEK must be {self.DEK_LEN} bytes, got {len(dek)}")
+        try:
+            return AESGCM(dek).decrypt(nonce, ciphertext, aad)
+        except InvalidTag as exc:
+            raise CiphertextCorrupted("AES-GCM tag verification failed") from exc
+
+
+# ---------------------------------------------------------------------------
+# EncryptionProvider Protocol (impls in envelope_providers/)
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class EncryptionProvider(Protocol):
+    """KEK-level DEK wrap/unwrap.
+
+    ``wrap_dek`` always uses the provider's current version and returns it
+    alongside the wrapped bytes. ``unwrap_dek`` takes the stored ``kek_version``
+    because rows persist history — Vault Transit takes ``key_version`` on
+    decrypt natively; AWS KMS ignores it (the ciphertext blob embeds the key
+    version internally) so ``kek_version`` is bookkeeping-only there.
+    """
+
+    def current_version(self, *, tenant_id: uuid.UUID) -> int: ...
+
+    def wrap_dek(
+        self,
+        dek: bytes,
+        *,
+        tenant_id: uuid.UUID,
+        aad: bytes,
+    ) -> tuple[bytes, int]:
+        """Return ``(wrapped_bytes, kek_version)``."""
+        ...
+
+    def unwrap_dek(
+        self,
+        wrapped: bytes,
+        *,
+        tenant_id: uuid.UUID,
+        aad: bytes,
+        kek_version: int,
+    ) -> bytes: ...

--- a/src/nexus/bricks/auth/envelope.py
+++ b/src/nexus/bricks/auth/envelope.py
@@ -12,7 +12,6 @@ Design: docs/superpowers/specs/2026-04-18-issue-3803-envelope-encryption-design.
 
 from __future__ import annotations
 
-import re
 import secrets
 import uuid
 from typing import Protocol, runtime_checkable
@@ -23,16 +22,6 @@ from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 # ---------------------------------------------------------------------------
 # Error hierarchy — no plaintext, wrapped-DEK, or ciphertext bytes in str/repr
 # ---------------------------------------------------------------------------
-
-_CAMEL_SPLIT_RE = re.compile(r"(?<=[a-z])(?=[A-Z])")
-
-
-def _safe_class_label(name: str) -> str:
-    """Convert CamelCase to kebab-case so long class names don't produce
-    continuous alphanumeric runs ≥ 22 chars that monitoring regex treat as
-    encoded blobs.  E.g. ``EnvelopeConfigurationError`` →
-    ``Envelope-Configuration-Error``."""
-    return _CAMEL_SPLIT_RE.sub("-", name)
 
 
 class EnvelopeError(Exception):
@@ -68,9 +57,8 @@ class EnvelopeError(Exception):
         kek_version: int,
         cause: str,
     ) -> "EnvelopeError":
-        label = _safe_class_label(cls.__name__)
         return cls(
-            f"{label} tenant={tenant_id} profile={profile_id} "
+            f"{cls.__name__} tenant={tenant_id} profile={profile_id} "
             f"kek_version={kek_version} cause={cause}",
             tenant_id=tenant_id,
             profile_id=profile_id,
@@ -79,9 +67,8 @@ class EnvelopeError(Exception):
         )
 
     def __repr__(self) -> str:
-        label = _safe_class_label(type(self).__name__)
         return (
-            f"{label}(tenant_id={self.tenant_id!s}, "
+            f"{type(self).__name__}(tenant_id={self.tenant_id!s}, "
             f"profile_id={self.profile_id!r}, kek_version={self.kek_version!r}, "
             f"cause={self.cause!r})"
         )

--- a/src/nexus/bricks/auth/envelope.py
+++ b/src/nexus/bricks/auth/envelope.py
@@ -12,6 +12,7 @@ Design: docs/superpowers/specs/2026-04-18-issue-3803-envelope-encryption-design.
 
 from __future__ import annotations
 
+import re
 import secrets
 import uuid
 from typing import Protocol, runtime_checkable
@@ -23,29 +24,87 @@ from cryptography.hazmat.primitives.ciphers.aead import AESGCM
 # Error hierarchy — no plaintext, wrapped-DEK, or ciphertext bytes in str/repr
 # ---------------------------------------------------------------------------
 
+_CAMEL_SPLIT_RE = re.compile(r"(?<=[a-z])(?=[A-Z])")
+
+
+def _safe_class_label(name: str) -> str:
+    """Convert CamelCase to kebab-case so long class names don't produce
+    continuous alphanumeric runs ≥ 22 chars that monitoring regex treat as
+    encoded blobs.  E.g. ``EnvelopeConfigurationError`` →
+    ``Envelope-Configuration-Error``."""
+    return _CAMEL_SPLIT_RE.sub("-", name)
+
 
 class EnvelopeError(Exception):
-    """Root of every error raised by the envelope subsystem."""
+    """Root of every error raised by the envelope subsystem.
+
+    All subclasses expose ``from_row(tenant_id, profile_id, kek_version, cause)``
+    so call sites never build error messages inline — that discipline is what
+    keeps plaintext / wrapped-DEK bytes out of ``__str__`` / ``__repr__``.
+    """
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        tenant_id: uuid.UUID | None = None,
+        profile_id: str | None = None,
+        kek_version: int | None = None,
+        cause: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self._message = message
+        self.tenant_id = tenant_id
+        self.profile_id = profile_id
+        self.kek_version = kek_version
+        self.cause = cause
+
+    @classmethod
+    def from_row(
+        cls,
+        *,
+        tenant_id: uuid.UUID,
+        profile_id: str,
+        kek_version: int,
+        cause: str,
+    ) -> "EnvelopeError":
+        label = _safe_class_label(cls.__name__)
+        return cls(
+            f"{label} tenant={tenant_id} profile={profile_id} "
+            f"kek_version={kek_version} cause={cause}",
+            tenant_id=tenant_id,
+            profile_id=profile_id,
+            kek_version=kek_version,
+            cause=cause,
+        )
+
+    def __repr__(self) -> str:
+        label = _safe_class_label(type(self).__name__)
+        return (
+            f"{label}(tenant_id={self.tenant_id!s}, "
+            f"profile_id={self.profile_id!r}, kek_version={self.kek_version!r}, "
+            f"cause={self.cause!r})"
+        )
 
 
 class EnvelopeConfigurationError(EnvelopeError):
-    """Provider is misconfigured (e.g. Vault transit key not derived=true)."""
+    pass
 
 
 class DecryptionFailed(EnvelopeError):
-    """Generic decrypt failure. Concrete subclasses narrow the reason."""
+    pass
 
 
 class AADMismatch(DecryptionFailed):
-    """Stored AAD column does not match the expected tenant|principal|id."""
+    pass
 
 
 class WrappedDEKInvalid(DecryptionFailed):
-    """Provider refused to unwrap the DEK (IAM, mismatched context, corrupt)."""
+    pass
 
 
 class CiphertextCorrupted(DecryptionFailed):
-    """AES-GCM tag verification failed — ciphertext/nonce/AAD tampered."""
+    pass
 
 
 # ---------------------------------------------------------------------------
@@ -77,7 +136,10 @@ class AESGCMEnvelope:
         try:
             return AESGCM(dek).decrypt(nonce, ciphertext, aad)
         except InvalidTag as exc:
-            raise CiphertextCorrupted("AES-GCM tag verification failed") from exc
+            raise CiphertextCorrupted(
+                "AES-GCM tag verification failed",
+                cause="InvalidTag",
+            ) from exc
 
 
 # ---------------------------------------------------------------------------

--- a/src/nexus/bricks/auth/envelope.py
+++ b/src/nexus/bricks/auth/envelope.py
@@ -12,8 +12,12 @@ Design: docs/superpowers/specs/2026-04-18-issue-3803-envelope-encryption-design.
 
 from __future__ import annotations
 
+import hashlib
 import secrets
+import time
 import uuid
+from collections import OrderedDict
+from dataclasses import dataclass
 from typing import Protocol, runtime_checkable
 
 from cryptography.exceptions import InvalidTag
@@ -165,3 +169,72 @@ class EncryptionProvider(Protocol):
         aad: bytes,
         kek_version: int,
     ) -> bytes: ...
+
+
+# ---------------------------------------------------------------------------
+# DEKCache — TTL + LRU cache for unwrapped DEKs
+# ---------------------------------------------------------------------------
+
+
+def _monotonic() -> float:
+    """Indirection so tests can monkeypatch the clock."""
+    return time.monotonic()
+
+
+@dataclass(frozen=True, slots=True)
+class DEKCacheKey:
+    tenant_id: str
+    kek_version: int
+    wrapped_dek_sha256: str
+
+    def __repr__(self) -> str:
+        return (
+            f"DEKCacheKey(tenant={self.tenant_id}, v={self.kek_version}, "
+            f"sha256={self.wrapped_dek_sha256})"
+        )
+
+
+class DEKCache:
+    """TTL + LRU cache for unwrapped DEKs.
+
+    Keyed by ``(tenant_id, kek_version, sha256(wrapped_dek))`` — the hash, not
+    the wrapped bytes, so cache-key logging is safe. Does not cache negative
+    results: a KMS/Vault blip shouldn't pin decrypt-failed for the TTL window.
+    """
+
+    def __init__(self, *, ttl_seconds: int = 300, max_entries: int = 1024) -> None:
+        self._ttl = ttl_seconds
+        self._max = max_entries
+        self._store: OrderedDict[DEKCacheKey, tuple[float, bytes]] = OrderedDict()
+        self.hits = 0
+        self.misses = 0
+
+    @staticmethod
+    def make_key(
+        *, tenant_id: str | uuid.UUID, kek_version: int, wrapped_dek: bytes
+    ) -> DEKCacheKey:
+        return DEKCacheKey(
+            tenant_id=str(tenant_id),
+            kek_version=kek_version,
+            wrapped_dek_sha256=hashlib.sha256(wrapped_dek).hexdigest(),
+        )
+
+    def get(self, key: DEKCacheKey) -> bytes | None:
+        entry = self._store.get(key)
+        if entry is None:
+            self.misses += 1
+            return None
+        expires_at, dek = entry
+        if _monotonic() >= expires_at:
+            self._store.pop(key, None)
+            self.misses += 1
+            return None
+        self._store.move_to_end(key)  # mark MRU
+        self.hits += 1
+        return dek
+
+    def put(self, key: DEKCacheKey, dek: bytes) -> None:
+        self._store[key] = (_monotonic() + self._ttl, dek)
+        self._store.move_to_end(key)
+        while len(self._store) > self._max:
+            self._store.popitem(last=False)  # evict LRU

--- a/src/nexus/bricks/auth/envelope_metrics.py
+++ b/src/nexus/bricks/auth/envelope_metrics.py
@@ -1,0 +1,56 @@
+"""Prometheus metrics for envelope encryption (issue #3803).
+
+Low-cardinality labels only: tenant_id is acceptable (single-digit tenants at
+this scale); principal_id and profile_id are NOT labels — they'd explode the
+time-series count.
+
+Metrics:
+  - auth_dek_cache_hits_total{tenant_id}
+  - auth_dek_cache_misses_total{tenant_id}
+  - auth_dek_unwrap_errors_total{tenant_id,error_class}
+  - auth_dek_unwrap_latency_seconds{tenant_id}
+  - auth_kek_rotate_rows_total{tenant_id,from_version,to_version}
+"""
+
+from __future__ import annotations
+
+from prometheus_client import Counter, Histogram
+
+DEK_CACHE_HITS = Counter(
+    "auth_dek_cache_hits_total",
+    "Number of DEK cache hits on the decrypt path.",
+    labelnames=["tenant_id"],
+)
+
+DEK_CACHE_MISSES = Counter(
+    "auth_dek_cache_misses_total",
+    "Number of DEK cache misses (KMS/Vault round-trip required).",
+    labelnames=["tenant_id"],
+)
+
+DEK_UNWRAP_ERRORS = Counter(
+    "auth_dek_unwrap_errors_total",
+    "EncryptionProvider.unwrap_dek failures.",
+    labelnames=["tenant_id", "error_class"],
+)
+
+DEK_UNWRAP_LATENCY = Histogram(
+    "auth_dek_unwrap_latency_seconds",
+    "Time spent in EncryptionProvider.unwrap_dek.",
+    labelnames=["tenant_id"],
+    buckets=(0.001, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0),
+)
+
+KEK_ROTATE_ROWS = Counter(
+    "auth_kek_rotate_rows_total",
+    "Rows rewrapped to a new kek_version by rotate_kek_for_tenant.",
+    labelnames=["tenant_id", "from_version", "to_version"],
+)
+
+__all__ = [
+    "DEK_CACHE_HITS",
+    "DEK_CACHE_MISSES",
+    "DEK_UNWRAP_ERRORS",
+    "DEK_UNWRAP_LATENCY",
+    "KEK_ROTATE_ROWS",
+]

--- a/src/nexus/bricks/auth/envelope_providers/__init__.py
+++ b/src/nexus/bricks/auth/envelope_providers/__init__.py
@@ -1,0 +1,6 @@
+"""Concrete EncryptionProvider implementations (issue #3803).
+
+- in_memory.InMemoryEncryptionProvider: test fake + default for development.
+- vault_transit.VaultTransitProvider: Vault Transit (``derived=true``).
+- aws_kms.AwsKmsProvider: AWS KMS per-tenant CMK.
+"""

--- a/src/nexus/bricks/auth/envelope_providers/aws_kms.py
+++ b/src/nexus/bricks/auth/envelope_providers/aws_kms.py
@@ -48,22 +48,27 @@ class AwsKmsProvider(EncryptionProvider):
             ) from exc
 
     @staticmethod
-    def _context(tenant_id: uuid.UUID, aad: bytes) -> dict[str, str]:
+    def _context(tenant_id: uuid.UUID, aad: bytes, kek_version: int) -> dict[str, str]:
+        # ``kek_version`` is bound into the EncryptionContext so claiming a
+        # different version at unwrap time fails at KMS. Defends against a
+        # DB-column tamper where only ``kek_version`` is forged.
         return {
             "tenant_id": str(tenant_id),
             "aad_fingerprint": hashlib.sha256(aad).hexdigest(),
+            "kek_version": str(kek_version),
         }
 
     def current_version(self, *, tenant_id: uuid.UUID) -> int:  # noqa: ARG002
         return self._config_version
 
     def wrap_dek(self, dek: bytes, *, tenant_id: uuid.UUID, aad: bytes) -> tuple[bytes, int]:
+        version = self._config_version
         resp = self._kms.encrypt(
             KeyId=self._key_id,
             Plaintext=dek,
-            EncryptionContext=self._context(tenant_id, aad),
+            EncryptionContext=self._context(tenant_id, aad, version),
         )
-        return resp["CiphertextBlob"], self._config_version
+        return resp["CiphertextBlob"], version
 
     def unwrap_dek(
         self,
@@ -76,7 +81,7 @@ class AwsKmsProvider(EncryptionProvider):
         try:
             resp = self._kms.decrypt(
                 CiphertextBlob=wrapped,
-                EncryptionContext=self._context(tenant_id, aad),
+                EncryptionContext=self._context(tenant_id, aad, kek_version),
             )
         except Exception as exc:
             raise WrappedDEKInvalid.from_row(
@@ -85,7 +90,8 @@ class AwsKmsProvider(EncryptionProvider):
                 kek_version=kek_version,
                 cause=f"KMS decrypt rejected: {type(exc).__name__}",
             ) from exc
-        return resp["Plaintext"]
+        plaintext: bytes = resp["Plaintext"]
+        return plaintext
 
 
 __all__ = ["AwsKmsProvider"]

--- a/src/nexus/bricks/auth/envelope_providers/aws_kms.py
+++ b/src/nexus/bricks/auth/envelope_providers/aws_kms.py
@@ -1,0 +1,91 @@
+"""AwsKmsProvider — wraps DEKs via AWS KMS.
+
+Uses ``EncryptionContext`` to bind the wrap to ``(tenant_id, aad_fingerprint)``
+— any cross-row DEK reuse or tampered AAD fails at KMS rather than only
+at the AES-GCM layer locally. Optional dependency: ``boto3``.
+
+AWS KMS automatically rotates the key material behind a CMK annually when
+``EnableKeyRotation`` is set. Our ``kek_version`` then tracks provider-config
+changes (e.g. swapping the CMK alias) rather than AWS key-material rotation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from typing import TYPE_CHECKING
+
+from nexus.bricks.auth.envelope import (
+    EncryptionProvider,
+    EnvelopeConfigurationError,
+    WrappedDEKInvalid,
+)
+
+if TYPE_CHECKING:
+    import botocore.client
+
+
+class AwsKmsProvider(EncryptionProvider):
+    def __init__(
+        self,
+        kms_client: "botocore.client.BaseClient",
+        key_id: str,
+        *,
+        config_version: int = 1,
+    ) -> None:
+        self._kms = kms_client
+        self._key_id = key_id
+        self._config_version = config_version
+        self._validate_key()
+
+    def _validate_key(self) -> None:
+        try:
+            self._kms.describe_key(KeyId=self._key_id)
+        except Exception as exc:
+            raise EnvelopeConfigurationError(
+                f"AWS KMS key {self._key_id!r} not accessible: "
+                f"{type(exc).__name__}. Grant kms:Encrypt, kms:Decrypt, kms:DescribeKey."
+            ) from exc
+
+    @staticmethod
+    def _context(tenant_id: uuid.UUID, aad: bytes) -> dict[str, str]:
+        return {
+            "tenant_id": str(tenant_id),
+            "aad_fingerprint": hashlib.sha256(aad).hexdigest(),
+        }
+
+    def current_version(self, *, tenant_id: uuid.UUID) -> int:  # noqa: ARG002
+        return self._config_version
+
+    def wrap_dek(self, dek: bytes, *, tenant_id: uuid.UUID, aad: bytes) -> tuple[bytes, int]:
+        resp = self._kms.encrypt(
+            KeyId=self._key_id,
+            Plaintext=dek,
+            EncryptionContext=self._context(tenant_id, aad),
+        )
+        return resp["CiphertextBlob"], self._config_version
+
+    def unwrap_dek(
+        self,
+        wrapped: bytes,
+        *,
+        tenant_id: uuid.UUID,
+        aad: bytes,
+        kek_version: int,
+    ) -> bytes:
+        try:
+            resp = self._kms.decrypt(
+                CiphertextBlob=wrapped,
+                EncryptionContext=self._context(tenant_id, aad),
+            )
+        except Exception as exc:
+            raise WrappedDEKInvalid.from_row(
+                tenant_id=tenant_id,
+                profile_id="<unknown>",
+                kek_version=kek_version,
+                cause=f"KMS decrypt rejected: {type(exc).__name__}",
+            ) from exc
+        return resp["Plaintext"]
+
+
+__all__ = ["AwsKmsProvider"]

--- a/src/nexus/bricks/auth/envelope_providers/aws_kms.py
+++ b/src/nexus/bricks/auth/envelope_providers/aws_kms.py
@@ -79,7 +79,14 @@ class AwsKmsProvider(EncryptionProvider):
         kek_version: int,
     ) -> bytes:
         try:
+            # Pin decrypt to the configured CMK. Without KeyId, KMS would use
+            # whichever key is embedded in the ciphertext blob as long as IAM
+            # permits it — a ciphertext crafted under a different CMK (that
+            # the caller's role also happens to have Decrypt on) would
+            # silently succeed. Passing KeyId forces KMS to refuse blobs
+            # encrypted with a different key.
             resp = self._kms.decrypt(
+                KeyId=self._key_id,
                 CiphertextBlob=wrapped,
                 EncryptionContext=self._context(tenant_id, aad, kek_version),
             )

--- a/src/nexus/bricks/auth/envelope_providers/in_memory.py
+++ b/src/nexus/bricks/auth/envelope_providers/in_memory.py
@@ -1,0 +1,89 @@
+"""In-process fake EncryptionProvider for tests + development.
+
+Uses real AES-256-GCM so the wrapped bytes are actual ciphertext (not
+identity). Holds a dict of KEKs keyed by version. ``rotate()`` bumps the
+current version and mints a new KEK. Exposes ``wrap_count`` /
+``unwrap_count`` so contract tests can assert cache amortization.
+
+Never use in production: keys live in process memory and die with it.
+"""
+
+from __future__ import annotations
+
+import secrets
+import uuid
+
+from cryptography.exceptions import InvalidTag
+from cryptography.hazmat.primitives.ciphers.aead import AESGCM
+
+from nexus.bricks.auth.envelope import (
+    EncryptionProvider,
+    WrappedDEKInvalid,
+)
+
+
+class InMemoryEncryptionProvider(EncryptionProvider):
+    """Fake provider with real AEAD under the hood.
+
+    Tenant scoping is modelled by mixing ``tenant_id`` into the AAD that wraps
+    the DEK — unwrap with the wrong ``tenant_id`` fails the AES-GCM tag, so
+    cross-tenant DEK reuse is rejected just like the real providers reject
+    mismatched encryption-context / derivation-context.
+    """
+
+    def __init__(self) -> None:
+        self._versions: dict[int, bytes] = {1: secrets.token_bytes(32)}
+        self._current_version = 1
+        self._nonce_len = 12
+        self.wrap_count = 0
+        self.unwrap_count = 0
+
+    def rotate(self) -> None:
+        """Bump current_version and mint a new KEK (keep old versions readable)."""
+        self._current_version += 1
+        self._versions[self._current_version] = secrets.token_bytes(32)
+
+    def current_version(self, *, tenant_id: uuid.UUID) -> int:  # noqa: ARG002
+        return self._current_version
+
+    def _context_aad(self, tenant_id: uuid.UUID, aad: bytes) -> bytes:
+        return f"v=inmem|tenant={tenant_id}|".encode() + aad
+
+    def wrap_dek(self, dek: bytes, *, tenant_id: uuid.UUID, aad: bytes) -> tuple[bytes, int]:
+        self.wrap_count += 1
+        version = self._current_version
+        kek = self._versions[version]
+        nonce = secrets.token_bytes(self._nonce_len)
+        ct = AESGCM(kek).encrypt(nonce, dek, self._context_aad(tenant_id, aad))
+        return nonce + ct, version
+
+    def unwrap_dek(
+        self,
+        wrapped: bytes,
+        *,
+        tenant_id: uuid.UUID,
+        aad: bytes,
+        kek_version: int,
+    ) -> bytes:
+        self.unwrap_count += 1
+        if kek_version not in self._versions:
+            raise WrappedDEKInvalid.from_row(
+                tenant_id=tenant_id,
+                profile_id="<unknown>",
+                kek_version=kek_version,
+                cause="kek_version not known to InMemoryEncryptionProvider",
+            )
+        kek = self._versions[kek_version]
+        nonce, ct = wrapped[: self._nonce_len], wrapped[self._nonce_len :]
+        try:
+            return AESGCM(kek).decrypt(nonce, ct, self._context_aad(tenant_id, aad))
+        except InvalidTag as exc:
+            raise WrappedDEKInvalid.from_row(
+                tenant_id=tenant_id,
+                profile_id="<unknown>",
+                kek_version=kek_version,
+                cause="AES-GCM tag mismatch (wrong tenant_id/aad/kek_version)",
+            ) from exc
+
+
+__all__ = ["InMemoryEncryptionProvider"]

--- a/src/nexus/bricks/auth/envelope_providers/in_memory.py
+++ b/src/nexus/bricks/auth/envelope_providers/in_memory.py
@@ -46,15 +46,15 @@ class InMemoryEncryptionProvider(EncryptionProvider):
     def current_version(self, *, tenant_id: uuid.UUID) -> int:  # noqa: ARG002
         return self._current_version
 
-    def _context_aad(self, tenant_id: uuid.UUID, aad: bytes) -> bytes:
-        return f"v=inmem|tenant={tenant_id}|".encode() + aad
+    def _context_aad(self, tenant_id: uuid.UUID, kek_version: int, aad: bytes) -> bytes:
+        return f"v=inmem|tenant={tenant_id}|kek={kek_version}|".encode() + aad
 
     def wrap_dek(self, dek: bytes, *, tenant_id: uuid.UUID, aad: bytes) -> tuple[bytes, int]:
         self.wrap_count += 1
         version = self._current_version
         kek = self._versions[version]
         nonce = secrets.token_bytes(self._nonce_len)
-        ct = AESGCM(kek).encrypt(nonce, dek, self._context_aad(tenant_id, aad))
+        ct = AESGCM(kek).encrypt(nonce, dek, self._context_aad(tenant_id, version, aad))
         return nonce + ct, version
 
     def unwrap_dek(
@@ -76,7 +76,7 @@ class InMemoryEncryptionProvider(EncryptionProvider):
         kek = self._versions[kek_version]
         nonce, ct = wrapped[: self._nonce_len], wrapped[self._nonce_len :]
         try:
-            return AESGCM(kek).decrypt(nonce, ct, self._context_aad(tenant_id, aad))
+            return AESGCM(kek).decrypt(nonce, ct, self._context_aad(tenant_id, kek_version, aad))
         except InvalidTag as exc:
             raise WrappedDEKInvalid.from_row(
                 tenant_id=tenant_id,

--- a/src/nexus/bricks/auth/envelope_providers/vault_transit.py
+++ b/src/nexus/bricks/auth/envelope_providers/vault_transit.py
@@ -94,10 +94,33 @@ class VaultTransitProvider(EncryptionProvider):
         aad: bytes,  # noqa: ARG002
         kek_version: int,
     ) -> bytes:
+        # Verify the blob's embedded version matches the claimed kek_version.
+        # Vault ciphertext format is "vault:v<N>:<base64>"; decrypt_data uses
+        # the version from the blob itself, so a DB-column tamper that forges
+        # kek_version would silently decrypt without this check.
+        try:
+            blob_str = wrapped.decode("utf-8")
+            blob_version = int(blob_str.split(":", 2)[1].lstrip("v"))
+        except (UnicodeDecodeError, IndexError, ValueError) as exc:
+            raise WrappedDEKInvalid.from_row(
+                tenant_id=tenant_id,
+                profile_id="<unknown>",
+                kek_version=kek_version,
+                cause=f"Vault transit ciphertext malformed: {type(exc).__name__}",
+            ) from exc
+        if blob_version != kek_version:
+            raise WrappedDEKInvalid.from_row(
+                tenant_id=tenant_id,
+                profile_id="<unknown>",
+                kek_version=kek_version,
+                cause=(
+                    f"claimed kek_version={kek_version} does not match blob version={blob_version}"
+                ),
+            )
         try:
             resp = self._client.secrets.transit.decrypt_data(
                 name=self._key_name,
-                ciphertext=wrapped.decode("utf-8"),
+                ciphertext=blob_str,
                 context=self._context_b64(tenant_id),
                 mount_point=self._mount,
             )

--- a/src/nexus/bricks/auth/envelope_providers/vault_transit.py
+++ b/src/nexus/bricks/auth/envelope_providers/vault_transit.py
@@ -1,0 +1,114 @@
+"""VaultTransitProvider — wraps DEKs via Vault's transit secrets engine.
+
+Requires a derived-context key (``derived=true``) so the per-tenant
+``context`` param produces a per-tenant subkey without creating one key per
+tenant. See:
+  https://developer.hashicorp.com/vault/docs/secrets/transit
+
+Optional dependency: ``hvac``. Install via the ``vault`` extra.
+"""
+
+from __future__ import annotations
+
+import base64
+import uuid
+from typing import TYPE_CHECKING
+
+from nexus.bricks.auth.envelope import (
+    EncryptionProvider,
+    EnvelopeConfigurationError,
+    WrappedDEKInvalid,
+)
+
+if TYPE_CHECKING:
+    import hvac
+
+
+class VaultTransitProvider(EncryptionProvider):
+    def __init__(
+        self,
+        vault_client: "hvac.Client",
+        key_name: str,
+        *,
+        mount_point: str = "transit",
+    ) -> None:
+        try:
+            import hvac  # noqa: F401
+        except ImportError as exc:  # pragma: no cover — optional dep
+            raise EnvelopeConfigurationError(
+                "VaultTransitProvider requires the `hvac` package. "
+                "Install with: pip install 'nexus[vault]'"
+            ) from exc
+        self._client = vault_client
+        self._key_name = key_name
+        self._mount = mount_point
+        self._validate_key()
+
+    def _validate_key(self) -> None:
+        try:
+            resp = self._client.secrets.transit.read_key(
+                name=self._key_name, mount_point=self._mount
+            )
+        except Exception as exc:
+            raise EnvelopeConfigurationError(
+                f"Vault transit key {self._key_name!r} not readable "
+                f"on mount {self._mount!r}: {type(exc).__name__}"
+            ) from exc
+        data = resp.get("data", {})
+        if not data.get("derived"):
+            raise EnvelopeConfigurationError(
+                f"Vault transit key {self._key_name!r} must have derived=true. "
+                f"Run: vault write -f {self._mount}/keys/{self._key_name} derived=true"
+            )
+
+    def current_version(self, *, tenant_id: uuid.UUID) -> int:  # noqa: ARG002
+        resp = self._client.secrets.transit.read_key(name=self._key_name, mount_point=self._mount)
+        data = resp.get("data", {})
+        return int(data.get("latest_version", 1))
+
+    def _context_b64(self, tenant_id: uuid.UUID) -> str:
+        return base64.b64encode(str(tenant_id).encode("utf-8")).decode("ascii")
+
+    def wrap_dek(
+        self,
+        dek: bytes,
+        *,
+        tenant_id: uuid.UUID,
+        aad: bytes,  # noqa: ARG002 — bound at the AESGCM layer; Vault Transit has no separate AAD param
+    ) -> tuple[bytes, int]:
+        resp = self._client.secrets.transit.encrypt_data(
+            name=self._key_name,
+            plaintext=base64.b64encode(dek).decode("ascii"),
+            context=self._context_b64(tenant_id),
+            mount_point=self._mount,
+        )
+        ciphertext = resp["data"]["ciphertext"]  # "vault:v<N>:<base64>"
+        version = int(ciphertext.split(":")[1].lstrip("v"))
+        return ciphertext.encode("utf-8"), version
+
+    def unwrap_dek(
+        self,
+        wrapped: bytes,
+        *,
+        tenant_id: uuid.UUID,
+        aad: bytes,  # noqa: ARG002
+        kek_version: int,
+    ) -> bytes:
+        try:
+            resp = self._client.secrets.transit.decrypt_data(
+                name=self._key_name,
+                ciphertext=wrapped.decode("utf-8"),
+                context=self._context_b64(tenant_id),
+                mount_point=self._mount,
+            )
+        except Exception as exc:
+            raise WrappedDEKInvalid.from_row(
+                tenant_id=tenant_id,
+                profile_id="<unknown>",
+                kek_version=kek_version,
+                cause=f"Vault transit decrypt rejected: {type(exc).__name__}",
+            ) from exc
+        return base64.b64decode(resp["data"]["plaintext"])
+
+
+__all__ = ["VaultTransitProvider"]

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -1229,6 +1229,10 @@ def rotate_kek_for_tenant(
     only; ``ciphertext``, ``nonce``, ``aad`` are untouched so a reader mid-
     rotation decrypts successfully regardless of which version wrote.
     """
+    if batch_size < 1:
+        raise ValueError(f"batch_size must be >= 1, got {batch_size}")
+    if max_rows is not None and max_rows < 1:
+        raise ValueError(f"max_rows must be >= 1 when set, got {max_rows}")
     target = encryption_provider.current_version(tenant_id=tenant_id)
     rewrapped = 0
     failed = 0

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -1286,6 +1286,24 @@ def rotate_kek_for_tenant(
             if not rows:
                 break
             for row in rows:
+                # Validate stored AAD matches the current row identity before
+                # rewrapping. Vault Transit does not cross-check AAD, so an
+                # attacker who tampered the aad column can roundtrip wrap/unwrap
+                # at the new kek_version — the row would land in rows_rewrapped
+                # but still fail later at AESGCMEnvelope.decrypt with AADMismatch.
+                expected_aad = f"{tenant_id}|{row.principal_id}|{row.id}".encode()
+                if bytes(row.aad) != expected_aad:
+                    logger.error(
+                        "rotate_kek_for_tenant: AAD mismatch "
+                        "tenant=%s principal=%s profile=%s kek_version=%s",
+                        tenant_id,
+                        row.principal_id,
+                        row.id,
+                        row.kek_version,
+                    )
+                    _failed_keys.append((uuid.UUID(str(row.principal_id)), row.id))
+                    failed += 1
+                    continue
                 try:
                     dek = encryption_provider.unwrap_dek(
                         bytes(row.wrapped_dek),

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -135,11 +135,22 @@ _TABLE_STATEMENTS: tuple[str, ...] = (
         cooldown_reason    TEXT,
         disabled_until     TIMESTAMPTZ,
         raw_error          TEXT,
+        ciphertext         BYTEA,
+        wrapped_dek        BYTEA,
+        nonce              BYTEA,
+        aad                BYTEA,
+        kek_version        INTEGER,
         created_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
         updated_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
         PRIMARY KEY (tenant_id, principal_id, id),
         FOREIGN KEY (principal_id, tenant_id)
-            REFERENCES principals(id, tenant_id) ON DELETE CASCADE
+            REFERENCES principals(id, tenant_id) ON DELETE CASCADE,
+        CONSTRAINT auth_profiles_envelope_all_or_none CHECK (
+            (ciphertext IS NULL) = (wrapped_dek IS NULL)
+            AND (ciphertext IS NULL) = (nonce IS NULL)
+            AND (ciphertext IS NULL) = (aad IS NULL)
+            AND (ciphertext IS NULL) = (kek_version IS NULL)
+        )
     )
     """,
     "CREATE INDEX IF NOT EXISTS idx_auth_profiles_provider ON auth_profiles(tenant_id, principal_id, provider)",
@@ -393,6 +404,33 @@ def _upgrade_shape_in_place(conn: Connection) -> None:
                 "REFERENCES principals(id, tenant_id) ON DELETE CASCADE"
             )
         )
+
+    # --- auth_profiles: envelope encryption columns (issue #3803) ---
+    for col, decl in (
+        ("ciphertext", "BYTEA"),
+        ("wrapped_dek", "BYTEA"),
+        ("nonce", "BYTEA"),
+        ("aad", "BYTEA"),
+        ("kek_version", "INTEGER"),
+    ):
+        conn.execute(text(f"ALTER TABLE auth_profiles ADD COLUMN IF NOT EXISTS {col} {decl}"))
+    # CHECK constraint. Use DROP ... IF EXISTS + ADD for idempotency.
+    conn.execute(
+        text(
+            "ALTER TABLE auth_profiles DROP CONSTRAINT IF EXISTS auth_profiles_envelope_all_or_none"
+        )
+    )
+    conn.execute(
+        text(
+            "ALTER TABLE auth_profiles "
+            "ADD CONSTRAINT auth_profiles_envelope_all_or_none CHECK ("
+            "    (ciphertext IS NULL) = (wrapped_dek IS NULL)"
+            "    AND (ciphertext IS NULL) = (nonce IS NULL)"
+            "    AND (ciphertext IS NULL) = (aad IS NULL)"
+            "    AND (ciphertext IS NULL) = (kek_version IS NULL)"
+            ")"
+        )
+    )
 
 
 def drop_schema(engine: Engine) -> None:

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -1233,10 +1233,12 @@ def rotate_kek_for_tenant(
     rewrapped = 0
     failed = 0
     tenant_label = str(tenant_id)
-    # Track profile ids that failed this run so they are not re-selected on
-    # subsequent batch iterations, preventing an infinite retry loop.
-    # ``id`` is unique per tenant (PK is (tenant_id, id)).
-    _failed_ids: list[str] = []
+    # Track (principal_id, id) pairs that failed this run so they are not
+    # re-selected on subsequent batch iterations, preventing an infinite retry
+    # loop. The table PK is (tenant_id, principal_id, id) so the same profile
+    # id can exist under multiple principals — keying failures on ``id`` alone
+    # would starve healthy rows that share an id with a failing one.
+    _failed_keys: list[tuple[uuid.UUID, str]] = []
     while True:
         if max_rows is not None and rewrapped + failed >= max_rows:
             break
@@ -1249,13 +1251,22 @@ def rotate_kek_for_tenant(
                 {"tid": str(tenant_id)},
             )
             # Exclude rows that already failed so the loop terminates.
-            if _failed_ids:
-                exclude_clause = " AND id != ALL(:skip_ids)"
+            # Postgres has no native tuple-ANY operator across mixed types,
+            # so we unzip into two parallel arrays and do a row-subscript test.
+            if _failed_keys:
+                skip_principals = [p for p, _ in _failed_keys]
+                skip_ids = [i for _, i in _failed_keys]
+                exclude_clause = (
+                    " AND NOT EXISTS (SELECT 1 FROM unnest("
+                    "CAST(:skip_principals AS UUID[]), :skip_ids) "
+                    "AS sk(p, i) WHERE sk.p = principal_id AND sk.i = id)"
+                )
                 params: dict[str, builtins.object] = {
                     "tid": tenant_id,
                     "target": target,
                     "lim": this_batch,
-                    "skip_ids": _failed_ids,
+                    "skip_principals": skip_principals,
+                    "skip_ids": skip_ids,
                 }
             else:
                 exclude_clause = ""
@@ -1298,7 +1309,7 @@ def rotate_kek_for_tenant(
                         row.kek_version,
                         type(exc).__name__,
                     )
-                    _failed_ids.append(row.id)
+                    _failed_keys.append((uuid.UUID(str(row.principal_id)), row.id))
                     failed += 1
                     continue
                 conn.execute(

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -22,9 +22,10 @@ is no in-memory LRU cache — Postgres is multi-writer, so per-process caching
 would be stale in the presence of other daemons. Local read-through caching
 is deferred to the client-side nexus-bot daemon (epic #3788 Phase D).
 
-Crypto columns (ciphertext, wrapped_dek, nonce, kek_version, aad) are
-deliberately NOT added in this PR — they land in #3788 Phase C. This store
-persists routing metadata only, matching the current AuthProfile contract.
+Crypto columns (ciphertext, wrapped_dek, nonce, aad, kek_version) are added
+in this PR (#3803, Phase C). Rows written without an ``encryption_provider``
+leave those columns NULL and remain readable; rows written with
+``upsert_with_credential`` carry the full envelope tuple.
 
 Feature gate: instantiated only when ``NEXUS_AUTH_STORE=postgres``. Default
 remains SqliteAuthProfileStore until downstream consumers migrate.
@@ -33,15 +34,32 @@ remains SqliteAuthProfileStore until downstream consumers migrate.
 from __future__ import annotations
 
 import builtins
+import json
 import logging
+import secrets
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
+from dataclasses import asdict
+from datetime import datetime
 from typing import Any
 
 from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Connection, Engine
 
+from nexus.bricks.auth.credential_backend import ResolvedCredential
+from nexus.bricks.auth.envelope import (
+    AADMismatch,
+    AESGCMEnvelope,
+    DEKCache,
+    EncryptionProvider,
+)
+from nexus.bricks.auth.envelope_metrics import (
+    DEK_CACHE_HITS,
+    DEK_CACHE_MISSES,
+    DEK_UNWRAP_ERRORS,
+    DEK_UNWRAP_LATENCY,
+)
 from nexus.bricks.auth.profile import (
     RAW_ERROR_MAX_LEN,
     AuthProfile,
@@ -568,6 +586,46 @@ ON CONFLICT (tenant_id, principal_id, id) DO UPDATE SET
     updated_at         = NOW()
 """
 
+_UPSERT_WITH_CREDENTIAL_SQL = """
+INSERT INTO auth_profiles (
+    tenant_id, principal_id, id,
+    provider, account_identifier, backend, backend_key,
+    last_synced_at, sync_ttl_seconds,
+    last_used_at, success_count, failure_count,
+    cooldown_until, cooldown_reason, disabled_until, raw_error,
+    ciphertext, wrapped_dek, nonce, aad, kek_version,
+    updated_at
+) VALUES (
+    :tenant_id, :principal_id, :id,
+    :provider, :account_identifier, :backend, :backend_key,
+    :last_synced_at, :sync_ttl_seconds,
+    :last_used_at, :success_count, :failure_count,
+    :cooldown_until, :cooldown_reason, :disabled_until, :raw_error,
+    :ciphertext, :wrapped_dek, :nonce, :aad, :kek_version,
+    NOW()
+)
+ON CONFLICT (tenant_id, principal_id, id) DO UPDATE SET
+    provider           = EXCLUDED.provider,
+    account_identifier = EXCLUDED.account_identifier,
+    backend            = EXCLUDED.backend,
+    backend_key        = EXCLUDED.backend_key,
+    last_synced_at     = EXCLUDED.last_synced_at,
+    sync_ttl_seconds   = EXCLUDED.sync_ttl_seconds,
+    last_used_at       = EXCLUDED.last_used_at,
+    success_count      = EXCLUDED.success_count,
+    failure_count      = EXCLUDED.failure_count,
+    cooldown_until     = EXCLUDED.cooldown_until,
+    cooldown_reason    = EXCLUDED.cooldown_reason,
+    disabled_until     = EXCLUDED.disabled_until,
+    raw_error          = EXCLUDED.raw_error,
+    ciphertext         = EXCLUDED.ciphertext,
+    wrapped_dek        = EXCLUDED.wrapped_dek,
+    nonce              = EXCLUDED.nonce,
+    aad                = EXCLUDED.aad,
+    kek_version        = EXCLUDED.kek_version,
+    updated_at         = NOW()
+"""
+
 
 def _reason_to_str(reason: AuthProfileFailureReason | None) -> str | None:
     return reason.value if reason else None
@@ -664,6 +722,8 @@ class PostgresAuthProfileStore:
         principal_id: uuid.UUID | str,
         engine: Engine | None = None,
         pool_size: int = 5,
+        encryption_provider: EncryptionProvider | None = None,
+        dek_cache: DEKCache | None = None,
     ) -> None:
         self._tenant_id = uuid.UUID(str(tenant_id))
         self._principal_id = uuid.UUID(str(principal_id))
@@ -679,6 +739,9 @@ class PostgresAuthProfileStore:
         else:
             self._engine = engine
             self._owns_engine = False
+        self._encryption_provider = encryption_provider
+        self._aesgcm = AESGCMEnvelope()
+        self._dek_cache = dek_cache or DEKCache()
 
     # ------------------------------------------------------------------
     # Internal: scoped-transaction helper
@@ -892,6 +955,134 @@ class PostgresAuthProfileStore:
                     "raw_error": truncated,
                 },
             )
+
+    # ------------------------------------------------------------------
+    # Envelope encryption (issue #3803)
+    # ------------------------------------------------------------------
+
+    def _require_provider(self) -> EncryptionProvider:
+        if self._encryption_provider is None:
+            raise RuntimeError(
+                "encryption_provider is required for upsert_with_credential / "
+                "get_with_credential — construct PostgresAuthProfileStore(..., "
+                "encryption_provider=...)"
+            )
+        return self._encryption_provider
+
+    def _aad_for(self, profile_id: str) -> bytes:
+        return f"{self._tenant_id}|{self._principal_id}|{profile_id}".encode()
+
+    @staticmethod
+    def _serialize_credential(cred: ResolvedCredential) -> bytes:
+        # Canonical JSON: sorted keys, compact separators. Deterministic for
+        # rotation rewrap; any change here breaks existing ciphertext readability.
+        payload = asdict(cred)
+        expires_at: datetime | None = cred.expires_at
+        if expires_at is not None:
+            payload["expires_at"] = expires_at.isoformat()
+        payload["scopes"] = list(cred.scopes)
+        return json.dumps(payload, sort_keys=True, separators=(",", ":")).encode("utf-8")
+
+    @staticmethod
+    def _deserialize_credential(data: bytes) -> ResolvedCredential:
+        raw = json.loads(data.decode("utf-8"))
+        expires_at = raw.get("expires_at")
+        if isinstance(expires_at, str):
+            expires_at = datetime.fromisoformat(expires_at)
+        return ResolvedCredential(
+            kind=raw["kind"],
+            api_key=raw.get("api_key"),
+            access_token=raw.get("access_token"),
+            expires_at=expires_at,
+            scopes=tuple(raw.get("scopes", ())),
+            metadata=raw.get("metadata", {}) or {},
+        )
+
+    def upsert_with_credential(self, profile: AuthProfile, credential: ResolvedCredential) -> None:
+        provider = self._require_provider()
+        aad = self._aad_for(profile.id)
+        dek = secrets.token_bytes(32)
+        nonce, ciphertext = self._aesgcm.encrypt(
+            dek, self._serialize_credential(credential), aad=aad
+        )
+        wrapped_dek, kek_version = provider.wrap_dek(dek, tenant_id=self._tenant_id, aad=aad)
+        params = _profile_params(
+            profile, tenant_id=self._tenant_id, principal_id=self._principal_id
+        )
+        params.update(
+            ciphertext=ciphertext,
+            wrapped_dek=wrapped_dek,
+            nonce=nonce,
+            aad=aad,
+            kek_version=kek_version,
+        )
+        lock_key = f"{self._tenant_id}/{profile.id}"
+        with self._scoped() as conn:
+            conn.execute(
+                text("SELECT pg_advisory_xact_lock(hashtextextended(:k, 0))"),
+                {"k": lock_key},
+            )
+            conn.execute(text(_UPSERT_WITH_CREDENTIAL_SQL), params)
+
+    def get_with_credential(
+        self, profile_id: str
+    ) -> tuple[AuthProfile, ResolvedCredential | None] | None:
+        provider = self._require_provider()
+        with self._scoped() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT *, ciphertext, wrapped_dek, nonce, aad, kek_version "
+                    "FROM auth_profiles "
+                    "WHERE tenant_id = :tid AND principal_id = :pid AND id = :id"
+                ),
+                {
+                    "tid": self._tenant_id,
+                    "pid": self._principal_id,
+                    "id": profile_id,
+                },
+            ).fetchone()
+        if row is None:
+            return None
+        profile = _row_to_profile(row)
+        if row.ciphertext is None:
+            return profile, None
+        expected_aad = self._aad_for(profile_id)
+        if bytes(row.aad) != expected_aad:
+            raise AADMismatch.from_row(
+                tenant_id=self._tenant_id,
+                profile_id=profile_id,
+                kek_version=row.kek_version,
+                cause="stored AAD does not match tenant|principal|profile_id",
+            )
+        cache_key = self._dek_cache.make_key(
+            tenant_id=self._tenant_id,
+            kek_version=row.kek_version,
+            wrapped_dek=bytes(row.wrapped_dek),
+        )
+        tenant_label = str(self._tenant_id)
+        dek = self._dek_cache.get(cache_key)
+        if dek is None:
+            DEK_CACHE_MISSES.labels(tenant_id=tenant_label).inc()
+            try:
+                with DEK_UNWRAP_LATENCY.labels(tenant_id=tenant_label).time():
+                    dek = provider.unwrap_dek(
+                        bytes(row.wrapped_dek),
+                        tenant_id=self._tenant_id,
+                        aad=expected_aad,
+                        kek_version=row.kek_version,
+                    )
+            except Exception as exc:
+                DEK_UNWRAP_ERRORS.labels(
+                    tenant_id=tenant_label, error_class=type(exc).__name__
+                ).inc()
+                raise
+            self._dek_cache.put(cache_key, dek)
+        else:
+            DEK_CACHE_HITS.labels(tenant_id=tenant_label).inc()
+        plaintext = self._aesgcm.decrypt(
+            dek, bytes(row.nonce), bytes(row.ciphertext), aad=expected_aad
+        )
+        return profile, self._deserialize_credential(plaintext)
 
     # ------------------------------------------------------------------
     # Tenant-wide helpers (migration/admin only — outside normal Protocol)

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -40,7 +40,7 @@ import secrets
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
-from dataclasses import asdict
+from dataclasses import asdict, dataclass
 from datetime import datetime
 from typing import Any
 
@@ -59,6 +59,7 @@ from nexus.bricks.auth.envelope_metrics import (
     DEK_CACHE_MISSES,
     DEK_UNWRAP_ERRORS,
     DEK_UNWRAP_LATENCY,
+    KEK_ROTATE_ROWS,
 )
 from nexus.bricks.auth.profile import (
     RAW_ERROR_MAX_LEN,
@@ -1195,3 +1196,130 @@ class PostgresAuthProfileStore:
     def engine(self) -> Engine:
         """Underlying engine — exposed only for test helpers + migration."""
         return self._engine
+
+
+# ---------------------------------------------------------------------------
+# KEK rotation (issue #3803) — module-level admin helper
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class RotationReport:
+    """Result of a ``rotate_kek_for_tenant`` invocation."""
+
+    rows_rewrapped: int
+    rows_failed: int
+    rows_remaining: int
+    target_version: int
+
+
+def rotate_kek_for_tenant(
+    engine: Engine,
+    *,
+    tenant_id: uuid.UUID,
+    encryption_provider: EncryptionProvider,
+    batch_size: int = 100,
+    max_rows: int | None = None,
+) -> RotationReport:
+    """Rewrap every row in ``tenant_id`` whose ``kek_version`` is older than
+    the provider's current version.
+
+    Uses ``SELECT ... FOR UPDATE SKIP LOCKED`` so the helper is resumable and
+    does not block concurrent writers. Rewraps ``wrapped_dek`` + ``kek_version``
+    only; ``ciphertext``, ``nonce``, ``aad`` are untouched so a reader mid-
+    rotation decrypts successfully regardless of which version wrote.
+    """
+    target = encryption_provider.current_version(tenant_id=tenant_id)
+    rewrapped = 0
+    failed = 0
+    tenant_label = str(tenant_id)
+    while True:
+        if max_rows is not None and rewrapped + failed >= max_rows:
+            break
+        this_batch = batch_size
+        if max_rows is not None:
+            this_batch = min(this_batch, max_rows - (rewrapped + failed))
+        with engine.begin() as conn:
+            conn.execute(
+                text("SET LOCAL app.current_tenant = :tid"),
+                {"tid": str(tenant_id)},
+            )
+            rows = conn.execute(
+                text(
+                    "SELECT tenant_id, principal_id, id, wrapped_dek, aad, kek_version "
+                    "FROM auth_profiles "
+                    "WHERE tenant_id = :tid "
+                    "  AND ciphertext IS NOT NULL "
+                    "  AND kek_version < :target "
+                    "ORDER BY principal_id, id "
+                    "FOR UPDATE SKIP LOCKED "
+                    "LIMIT :lim"
+                ),
+                {"tid": tenant_id, "target": target, "lim": this_batch},
+            ).fetchall()
+            if not rows:
+                break
+            for row in rows:
+                try:
+                    dek = encryption_provider.unwrap_dek(
+                        bytes(row.wrapped_dek),
+                        tenant_id=tenant_id,
+                        aad=bytes(row.aad),
+                        kek_version=row.kek_version,
+                    )
+                    new_wrapped, new_version = encryption_provider.wrap_dek(
+                        dek, tenant_id=tenant_id, aad=bytes(row.aad)
+                    )
+                except Exception as exc:
+                    logger.error(
+                        "rotate_kek_for_tenant: per-row failure "
+                        "tenant=%s principal=%s profile=%s kek_version=%s cause=%s",
+                        tenant_id,
+                        row.principal_id,
+                        row.id,
+                        row.kek_version,
+                        type(exc).__name__,
+                    )
+                    failed += 1
+                    continue
+                conn.execute(
+                    text(
+                        "UPDATE auth_profiles SET "
+                        "    wrapped_dek = :wd, kek_version = :v, updated_at = NOW() "
+                        "WHERE tenant_id = :tid "
+                        "  AND principal_id = :pid AND id = :id"
+                    ),
+                    {
+                        "wd": new_wrapped,
+                        "v": new_version,
+                        "tid": tenant_id,
+                        "pid": row.principal_id,
+                        "id": row.id,
+                    },
+                )
+                KEK_ROTATE_ROWS.labels(
+                    tenant_id=tenant_label,
+                    from_version=str(row.kek_version),
+                    to_version=str(new_version),
+                ).inc()
+                rewrapped += 1
+    # Final remaining count
+    with engine.begin() as conn:
+        conn.execute(
+            text("SET LOCAL app.current_tenant = :tid"),
+            {"tid": str(tenant_id)},
+        )
+        remaining = conn.execute(
+            text(
+                "SELECT COUNT(*) FROM auth_profiles "
+                "WHERE tenant_id = :tid AND ciphertext IS NOT NULL "
+                "  AND kek_version < :target"
+            ),
+            {"tid": tenant_id, "target": target},
+        ).scalar_one()
+    return RotationReport(
+        rows_rewrapped=rewrapped,
+        rows_failed=failed,
+        rows_remaining=int(remaining),
+        target_version=target,
+    )

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -1338,6 +1338,11 @@ def rotate_kek_for_tenant(
         this_batch = batch_size
         if max_rows is not None:
             this_batch = min(this_batch, max_rows - rewrapped)
+
+        # 1) Snapshot a batch of candidates in a short read-only tx. No
+        # FOR UPDATE: holding row locks across Vault/KMS calls would block
+        # concurrent upsert_with_credential writers for the full provider
+        # RTT. We trade those locks for an optimistic CAS at UPDATE time.
         with engine.begin() as conn:
             conn.execute(
                 text("SET LOCAL app.current_tenant = :tid"),
@@ -1371,79 +1376,113 @@ def rotate_kek_for_tenant(
                     "WHERE tenant_id = :tid "
                     "  AND ciphertext IS NOT NULL "
                     "  AND kek_version < :target" + exclude_clause + " ORDER BY principal_id, id "
-                    "FOR UPDATE SKIP LOCKED "
                     "LIMIT :lim"
                 ),
                 params,
             ).fetchall()
-            if not rows:
-                break
-            for row in rows:
-                # Validate stored AAD matches the current row identity before
-                # rewrapping. Vault Transit does not cross-check AAD, so an
-                # attacker who tampered the aad column can roundtrip wrap/unwrap
-                # at the new kek_version — the row would land in rows_rewrapped
-                # but still fail later at AESGCMEnvelope.decrypt with AADMismatch.
-                expected_aad = f"{tenant_id}|{row.principal_id}|{row.id}".encode()
-                if bytes(row.aad) != expected_aad:
-                    logger.error(
-                        "rotate_kek_for_tenant: AAD mismatch "
-                        "tenant=%s principal=%s profile=%s kek_version=%s",
-                        tenant_id,
-                        row.principal_id,
-                        row.id,
-                        row.kek_version,
-                    )
-                    _failed_keys.append((uuid.UUID(str(row.principal_id)), row.id))
-                    failed += 1
-                    continue
-                try:
-                    dek = encryption_provider.unwrap_dek(
-                        bytes(row.wrapped_dek),
-                        tenant_id=tenant_id,
-                        aad=bytes(row.aad),
-                        kek_version=row.kek_version,
-                    )
-                    new_wrapped, new_version = encryption_provider.wrap_dek(
-                        dek, tenant_id=tenant_id, aad=bytes(row.aad)
-                    )
-                except EnvelopeError as exc:
-                    # Narrow to EnvelopeError: a genuine programming bug inside
-                    # the rotation loop (TypeError, KeyError, ...) must crash
-                    # loud rather than be silently counted as a rotation failure.
-                    logger.error(
-                        "rotate_kek_for_tenant: per-row failure "
-                        "tenant=%s principal=%s profile=%s kek_version=%s cause=%s",
-                        tenant_id,
-                        row.principal_id,
-                        row.id,
-                        row.kek_version,
-                        type(exc).__name__,
-                    )
-                    _failed_keys.append((uuid.UUID(str(row.principal_id)), row.id))
-                    failed += 1
-                    continue
-                conn.execute(
-                    text(
-                        "UPDATE auth_profiles SET "
-                        "    wrapped_dek = :wd, kek_version = :v, updated_at = NOW() "
-                        "WHERE tenant_id = :tid "
-                        "  AND principal_id = :pid AND id = :id"
-                    ),
-                    {
-                        "wd": new_wrapped,
-                        "v": new_version,
-                        "tid": tenant_id,
-                        "pid": row.principal_id,
-                        "id": row.id,
-                    },
+        if not rows:
+            break
+
+        # 2) Provider calls happen OUTSIDE any open transaction. Validate AAD
+        # first; unwrap failures are per-row, wrap failures are fatal. Results
+        # get staged for a single CAS batch below.
+        staged: list[tuple[Any, bytes, int]] = []  # (row, new_wrapped, new_version)
+        for row in rows:
+            expected_aad = f"{tenant_id}|{row.principal_id}|{row.id}".encode()
+            if bytes(row.aad) != expected_aad:
+                logger.error(
+                    "rotate_kek_for_tenant: AAD mismatch "
+                    "tenant=%s principal=%s profile=%s kek_version=%s",
+                    tenant_id,
+                    row.principal_id,
+                    row.id,
+                    row.kek_version,
                 )
-                KEK_ROTATE_ROWS.labels(
-                    tenant_id=tenant_label,
-                    from_version=str(row.kek_version),
-                    to_version=str(new_version),
-                ).inc()
-                rewrapped += 1
+                _failed_keys.append((uuid.UUID(str(row.principal_id)), row.id))
+                failed += 1
+                continue
+            try:
+                dek = encryption_provider.unwrap_dek(
+                    bytes(row.wrapped_dek),
+                    tenant_id=tenant_id,
+                    aad=bytes(row.aad),
+                    kek_version=row.kek_version,
+                )
+            except EnvelopeError as exc:
+                logger.error(
+                    "rotate_kek_for_tenant: per-row unwrap failure "
+                    "tenant=%s principal=%s profile=%s kek_version=%s cause=%s",
+                    tenant_id,
+                    row.principal_id,
+                    row.id,
+                    row.kek_version,
+                    type(exc).__name__,
+                )
+                _failed_keys.append((uuid.UUID(str(row.principal_id)), row.id))
+                failed += 1
+                continue
+            # Wrap at target version is FATAL to the batch rather than per-row.
+            # A wrap error at the new version means the target KEK is unusable
+            # (wrong key, IAM issue, etc.); continuing would leave a partially-
+            # rotated tenant with rows split across versions.
+            try:
+                new_wrapped, new_version = encryption_provider.wrap_dek(
+                    dek, tenant_id=tenant_id, aad=bytes(row.aad)
+                )
+            except EnvelopeError as exc:
+                logger.error(
+                    "rotate_kek_for_tenant: wrap-at-target failed; aborting "
+                    "batch tenant=%s target=%s cause=%s",
+                    tenant_id,
+                    target,
+                    type(exc).__name__,
+                )
+                raise
+            staged.append((row, new_wrapped, new_version))
+
+        # 3) Apply all CAS updates in one short tx. Each UPDATE includes the
+        # original (wrapped_dek, kek_version) as a predicate, so a concurrent
+        # upsert_with_credential that raced ahead of us simply sees 0 rows
+        # affected and we skip that row without counting it as rewrapped.
+        if staged:
+            with engine.begin() as conn:
+                conn.execute(
+                    text("SET LOCAL app.current_tenant = :tid"),
+                    {"tid": str(tenant_id)},
+                )
+                for row, new_wrapped, new_version in staged:
+                    result = conn.execute(
+                        text(
+                            "UPDATE auth_profiles SET "
+                            "    wrapped_dek = :new_wd, "
+                            "    kek_version = :new_v, "
+                            "    updated_at = NOW() "
+                            "WHERE tenant_id = :tid "
+                            "  AND principal_id = :pid "
+                            "  AND id = :id "
+                            "  AND wrapped_dek = :old_wd "
+                            "  AND kek_version = :old_v"
+                        ),
+                        {
+                            "new_wd": new_wrapped,
+                            "new_v": new_version,
+                            "tid": tenant_id,
+                            "pid": row.principal_id,
+                            "id": row.id,
+                            "old_wd": bytes(row.wrapped_dek),
+                            "old_v": row.kek_version,
+                        },
+                    )
+                    if result.rowcount == 1:
+                        KEK_ROTATE_ROWS.labels(
+                            tenant_id=tenant_label,
+                            from_version=str(row.kek_version),
+                            to_version=str(new_version),
+                        ).inc()
+                        rewrapped += 1
+                    # rowcount == 0: concurrent writer won. Don't count as
+                    # success or failure — next loop iteration will pick up
+                    # any row still at < target.
     # Final remaining count
     with engine.begin() as conn:
         conn.execute(

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -827,29 +827,43 @@ class PostgresAuthProfileStore:
                 text("SELECT pg_advisory_xact_lock(hashtextextended(:k, 0))"),
                 {"k": lock_key},
             )
-            self._reject_if_encrypted(conn, profile.id)
+            self._reject_if_routing_change_on_encrypted(conn, profile)
             conn.execute(text(_UPSERT_SQL), params)
 
-    def _reject_if_encrypted(self, conn: Connection, profile_id: str) -> None:
-        """Guard: plain upsert must not mutate routing metadata on a row that
-        already carries encrypted credentials. Otherwise ``backend``/
-        ``backend_key`` could diverge from the still-stored ciphertext, and
-        ``get_with_credential`` would return a credential that no longer
-        matches the routing pointer.
+    def _reject_if_routing_change_on_encrypted(
+        self, conn: Connection, profile: AuthProfile
+    ) -> None:
+        """Guard: plain upsert on an encrypted row is allowed ONLY when the
+        routing columns (provider / account_identifier / backend / backend_key)
+        are unchanged. Otherwise ``backend_key`` could diverge from the still-
+        stored ciphertext and ``get_with_credential`` would return a credential
+        that no longer matches the routing pointer.
+
+        Stats-only updates from ``CredentialPool.mark_success/mark_failure``
+        pass through cleanly because they re-emit the same routing values.
         """
         row = conn.execute(
             text(
-                "SELECT 1 FROM auth_profiles "
+                "SELECT provider, account_identifier, backend, backend_key "
+                "FROM auth_profiles "
                 "WHERE tenant_id = :tid AND principal_id = :pid AND id = :id "
                 "  AND ciphertext IS NOT NULL"
             ),
-            {"tid": self._tenant_id, "pid": self._principal_id, "id": profile_id},
+            {"tid": self._tenant_id, "pid": self._principal_id, "id": profile.id},
         ).fetchone()
-        if row is not None:
+        if row is None:
+            return
+        if (
+            row.provider != profile.provider
+            or row.account_identifier != profile.account_identifier
+            or row.backend != profile.backend
+            or row.backend_key != profile.backend_key
+        ):
             raise ValueError(
                 f"auth_profiles row ({self._tenant_id}, {self._principal_id}, "
-                f"{profile_id!r}) has encrypted credentials; use "
-                "upsert_with_credential() or delete() before plain upsert()."
+                f"{profile.id!r}) has encrypted credentials and this plain "
+                "upsert would change routing metadata; use "
+                "upsert_with_credential() or delete() first."
             )
 
     def delete(self, profile_id: str) -> None:
@@ -890,27 +904,39 @@ class PostgresAuthProfileStore:
                     {"k": key},
                 )
             if upserts:
-                # Same invariant as plain upsert/upsert_strict: routing
-                # metadata must not be rewritten on rows that already carry
-                # encrypted credentials, or ciphertext would diverge from
-                # backend_key. One batched SELECT under the locks detects
-                # any conflict atomically before any write lands.
-                conflicts = conn.execute(
+                # Same invariant as plain upsert/upsert_strict: only reject
+                # when routing metadata would actually change for an encrypted
+                # row. Stats-only re-upserts (same provider/backend/backend_key)
+                # remain legal so the existing sync and pool flows keep working
+                # against rows already upgraded to carry encrypted credentials.
+                by_id = {p.id: p for p in upserts}
+                existing = conn.execute(
                     text(
-                        "SELECT id FROM auth_profiles "
+                        "SELECT id, provider, account_identifier, backend, backend_key "
+                        "FROM auth_profiles "
                         "WHERE tenant_id = :tid AND principal_id = :pid "
                         "  AND id = ANY(:ids) AND ciphertext IS NOT NULL"
                     ),
                     {
                         "tid": self._tenant_id,
                         "pid": self._principal_id,
-                        "ids": [p.id for p in upserts],
+                        "ids": list(by_id.keys()),
                     },
                 ).fetchall()
+                conflicts = [
+                    r.id
+                    for r in existing
+                    if (
+                        r.provider != by_id[r.id].provider
+                        or r.account_identifier != by_id[r.id].account_identifier
+                        or r.backend != by_id[r.id].backend
+                        or r.backend_key != by_id[r.id].backend_key
+                    )
+                ]
                 if conflicts:
                     raise ValueError(
                         f"replace_owned_subset would overwrite routing metadata "
-                        f"on encrypted rows: {sorted(c[0] for c in conflicts)!r}. "
+                        f"on encrypted rows: {sorted(conflicts)!r}. "
                         "Use upsert_with_credential() or delete() for these rows first."
                     )
             for p in upserts:
@@ -1182,7 +1208,7 @@ class PostgresAuthProfileStore:
                     profile_id=profile.id,
                     foreign_principals=sorted(row[0] for row in foreign),
                 )
-            self._reject_if_encrypted(conn, profile.id)
+            self._reject_if_routing_change_on_encrypted(conn, profile)
             conn.execute(
                 text(_UPSERT_SQL),
                 _profile_params(

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -1233,6 +1233,10 @@ def rotate_kek_for_tenant(
     rewrapped = 0
     failed = 0
     tenant_label = str(tenant_id)
+    # Track profile ids that failed this run so they are not re-selected on
+    # subsequent batch iterations, preventing an infinite retry loop.
+    # ``id`` is unique per tenant (PK is (tenant_id, id)).
+    _failed_ids: list[str] = []
     while True:
         if max_rows is not None and rewrapped + failed >= max_rows:
             break
@@ -1244,18 +1248,29 @@ def rotate_kek_for_tenant(
                 text("SET LOCAL app.current_tenant = :tid"),
                 {"tid": str(tenant_id)},
             )
+            # Exclude rows that already failed so the loop terminates.
+            if _failed_ids:
+                exclude_clause = " AND id != ALL(:skip_ids)"
+                params: dict[str, builtins.object] = {
+                    "tid": tenant_id,
+                    "target": target,
+                    "lim": this_batch,
+                    "skip_ids": _failed_ids,
+                }
+            else:
+                exclude_clause = ""
+                params = {"tid": tenant_id, "target": target, "lim": this_batch}
             rows = conn.execute(
                 text(
                     "SELECT tenant_id, principal_id, id, wrapped_dek, aad, kek_version "
                     "FROM auth_profiles "
                     "WHERE tenant_id = :tid "
                     "  AND ciphertext IS NOT NULL "
-                    "  AND kek_version < :target "
-                    "ORDER BY principal_id, id "
+                    "  AND kek_version < :target" + exclude_clause + " ORDER BY principal_id, id "
                     "FOR UPDATE SKIP LOCKED "
                     "LIMIT :lim"
                 ),
-                {"tid": tenant_id, "target": target, "lim": this_batch},
+                params,
             ).fetchall()
             if not rows:
                 break
@@ -1280,6 +1295,7 @@ def rotate_kek_for_tenant(
                         row.kek_version,
                         type(exc).__name__,
                     )
+                    _failed_ids.append(row.id)
                     failed += 1
                     continue
                 conn.execute(

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -889,6 +889,30 @@ class PostgresAuthProfileStore:
                     text("SELECT pg_advisory_xact_lock(hashtextextended(:k, 0))"),
                     {"k": key},
                 )
+            if upserts:
+                # Same invariant as plain upsert/upsert_strict: routing
+                # metadata must not be rewritten on rows that already carry
+                # encrypted credentials, or ciphertext would diverge from
+                # backend_key. One batched SELECT under the locks detects
+                # any conflict atomically before any write lands.
+                conflicts = conn.execute(
+                    text(
+                        "SELECT id FROM auth_profiles "
+                        "WHERE tenant_id = :tid AND principal_id = :pid "
+                        "  AND id = ANY(:ids) AND ciphertext IS NOT NULL"
+                    ),
+                    {
+                        "tid": self._tenant_id,
+                        "pid": self._principal_id,
+                        "ids": [p.id for p in upserts],
+                    },
+                ).fetchall()
+                if conflicts:
+                    raise ValueError(
+                        f"replace_owned_subset would overwrite routing metadata "
+                        f"on encrypted rows: {sorted(c[0] for c in conflicts)!r}. "
+                        "Use upsert_with_credential() or delete() for these rows first."
+                    )
             for p in upserts:
                 conn.execute(
                     text(_UPSERT_SQL),

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -53,6 +53,7 @@ from nexus.bricks.auth.envelope import (
     AESGCMEnvelope,
     DEKCache,
     EncryptionProvider,
+    EnvelopeError,
 )
 from nexus.bricks.auth.envelope_metrics import (
     DEK_CACHE_HITS,
@@ -1032,8 +1033,7 @@ class PostgresAuthProfileStore:
         with self._scoped() as conn:
             row = conn.execute(
                 text(
-                    "SELECT *, ciphertext, wrapped_dek, nonce, aad, kek_version "
-                    "FROM auth_profiles "
+                    "SELECT * FROM auth_profiles "
                     "WHERE tenant_id = :tid AND principal_id = :pid AND id = :id"
                 ),
                 {
@@ -1285,7 +1285,10 @@ def rotate_kek_for_tenant(
                     new_wrapped, new_version = encryption_provider.wrap_dek(
                         dek, tenant_id=tenant_id, aad=bytes(row.aad)
                     )
-                except Exception as exc:
+                except EnvelopeError as exc:
+                    # Narrow to EnvelopeError: a genuine programming bug inside
+                    # the rotation loop (TypeError, KeyError, ...) must crash
+                    # loud rather than be silently counted as a rotation failure.
                     logger.error(
                         "rotate_kek_for_tenant: per-row failure "
                         "tenant=%s principal=%s profile=%s kek_version=%s cause=%s",

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -827,7 +827,30 @@ class PostgresAuthProfileStore:
                 text("SELECT pg_advisory_xact_lock(hashtextextended(:k, 0))"),
                 {"k": lock_key},
             )
+            self._reject_if_encrypted(conn, profile.id)
             conn.execute(text(_UPSERT_SQL), params)
+
+    def _reject_if_encrypted(self, conn: Connection, profile_id: str) -> None:
+        """Guard: plain upsert must not mutate routing metadata on a row that
+        already carries encrypted credentials. Otherwise ``backend``/
+        ``backend_key`` could diverge from the still-stored ciphertext, and
+        ``get_with_credential`` would return a credential that no longer
+        matches the routing pointer.
+        """
+        row = conn.execute(
+            text(
+                "SELECT 1 FROM auth_profiles "
+                "WHERE tenant_id = :tid AND principal_id = :pid AND id = :id "
+                "  AND ciphertext IS NOT NULL"
+            ),
+            {"tid": self._tenant_id, "pid": self._principal_id, "id": profile_id},
+        ).fetchone()
+        if row is not None:
+            raise ValueError(
+                f"auth_profiles row ({self._tenant_id}, {self._principal_id}, "
+                f"{profile_id!r}) has encrypted credentials; use "
+                "upsert_with_credential() or delete() before plain upsert()."
+            )
 
     def delete(self, profile_id: str) -> None:
         with self._scoped() as conn:
@@ -1135,6 +1158,7 @@ class PostgresAuthProfileStore:
                     profile_id=profile.id,
                     foreign_principals=sorted(row[0] for row in foreign),
                 )
+            self._reject_if_encrypted(conn, profile.id)
             conn.execute(
                 text(_UPSERT_SQL),
                 _profile_params(
@@ -1203,6 +1227,21 @@ class PostgresAuthProfileStore:
 # ---------------------------------------------------------------------------
 
 
+class VersionSkewError(Exception):
+    """Raised by ``rotate_kek_for_tenant`` when rows already exist at a
+    ``kek_version`` greater than the provider's current version.
+
+    Indicates the provider is pointing at an older config than data already
+    written — typically a misconfigured ``--kms-config-version`` or a rolled-
+    back provider. Refusing to rotate prevents a silent false-success report.
+    """
+
+    def __init__(self, *, rows_ahead: int, target_version: int):
+        self.rows_ahead = rows_ahead
+        self.target_version = target_version
+        super().__init__(f"{rows_ahead} rows have kek_version > target ({target_version})")
+
+
 @dataclass(frozen=True, slots=True)
 class RotationReport:
     """Result of a ``rotate_kek_for_tenant`` invocation."""
@@ -1220,6 +1259,7 @@ def rotate_kek_for_tenant(
     encryption_provider: EncryptionProvider,
     batch_size: int = 100,
     max_rows: int | None = None,
+    allow_skew: bool = False,
 ) -> RotationReport:
     """Rewrap every row in ``tenant_id`` whose ``kek_version`` is older than
     the provider's current version.
@@ -1228,12 +1268,34 @@ def rotate_kek_for_tenant(
     does not block concurrent writers. Rewraps ``wrapped_dek`` + ``kek_version``
     only; ``ciphertext``, ``nonce``, ``aad`` are untouched so a reader mid-
     rotation decrypts successfully regardless of which version wrote.
+
+    Raises ``VersionSkewError`` by default if any row has
+    ``kek_version > target``. Callers who are intentionally rolling back can
+    pass ``allow_skew=True`` to suppress the check, but the helper then only
+    processes rows with ``kek_version < target`` — ahead-of-target rows remain
+    untouched.
     """
     if batch_size < 1:
         raise ValueError(f"batch_size must be >= 1, got {batch_size}")
     if max_rows is not None and max_rows < 1:
         raise ValueError(f"max_rows must be >= 1 when set, got {max_rows}")
     target = encryption_provider.current_version(tenant_id=tenant_id)
+    if not allow_skew:
+        with engine.begin() as conn:
+            conn.execute(
+                text("SET LOCAL app.current_tenant = :tid"),
+                {"tid": str(tenant_id)},
+            )
+            ahead = conn.execute(
+                text(
+                    "SELECT COUNT(*) FROM auth_profiles "
+                    "WHERE tenant_id = :tid AND ciphertext IS NOT NULL "
+                    "  AND kek_version > :target"
+                ),
+                {"tid": tenant_id, "target": target},
+            ).scalar_one()
+        if ahead:
+            raise VersionSkewError(rows_ahead=int(ahead), target_version=target)
     rewrapped = 0
     failed = 0
     tenant_label = str(tenant_id)
@@ -1244,11 +1306,14 @@ def rotate_kek_for_tenant(
     # would starve healthy rows that share an id with a failing one.
     _failed_keys: list[tuple[uuid.UUID, str]] = []
     while True:
-        if max_rows is not None and rewrapped + failed >= max_rows:
+        # max_rows caps SUCCESSFUL rewraps only. Counting failures toward the
+        # budget would let a handful of deterministically failing rows starve
+        # healthy rows out of a controlled batch.
+        if max_rows is not None and rewrapped >= max_rows:
             break
         this_batch = batch_size
         if max_rows is not None:
-            this_batch = min(this_batch, max_rows - (rewrapped + failed))
+            this_batch = min(this_batch, max_rows - rewrapped)
         with engine.begin() as conn:
             conn.execute(
                 text("SET LOCAL app.current_tenant = :tid"),

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -1329,6 +1329,12 @@ def rotate_kek_for_tenant(
     # id can exist under multiple principals — keying failures on ``id`` alone
     # would starve healthy rows that share an id with a failing one.
     _failed_keys: list[tuple[uuid.UUID, str]] = []
+    # Bound CAS-miss churn: if the same (principal_id, id) repeatedly loses
+    # the compare-and-swap race (because a concurrent writer keeps bumping the
+    # row), promote it to _failed_keys after this many attempts so the loop
+    # terminates instead of livelocking on provider calls.
+    _cas_misses: dict[tuple[uuid.UUID, str], int] = {}
+    _MAX_CAS_MISSES = 3
     while True:
         # max_rows caps SUCCESSFUL rewraps only. Counting failures toward the
         # budget would let a handful of deterministically failing rows starve
@@ -1480,9 +1486,25 @@ def rotate_kek_for_tenant(
                             to_version=str(new_version),
                         ).inc()
                         rewrapped += 1
-                    # rowcount == 0: concurrent writer won. Don't count as
-                    # success or failure — next loop iteration will pick up
-                    # any row still at < target.
+                        _cas_misses.pop((uuid.UUID(str(row.principal_id)), row.id), None)
+                    else:
+                        # Concurrent writer won. Allow a few retries — on
+                        # repeated misses treat as failed so we don't livelock
+                        # on a perpetually-contended row.
+                        key = (uuid.UUID(str(row.principal_id)), row.id)
+                        _cas_misses[key] = _cas_misses.get(key, 0) + 1
+                        if _cas_misses[key] >= _MAX_CAS_MISSES:
+                            logger.error(
+                                "rotate_kek_for_tenant: CAS-miss threshold "
+                                "exceeded tenant=%s principal=%s profile=%s "
+                                "misses=%d",
+                                tenant_id,
+                                row.principal_id,
+                                row.id,
+                                _cas_misses[key],
+                            )
+                            _failed_keys.append(key)
+                            failed += 1
     # Final remaining count
     with engine.begin() as conn:
         conn.execute(

--- a/src/nexus/bricks/auth/profile.py
+++ b/src/nexus/bricks/auth/profile.py
@@ -163,6 +163,38 @@ class AuthProfileStore(Protocol):
 
 
 # ---------------------------------------------------------------------------
+# CredentialCarryingProfileStore sub-protocol (issue #3803)
+# ---------------------------------------------------------------------------
+
+
+@runtime_checkable
+class CredentialCarryingProfileStore(AuthProfileStore, Protocol):
+    """Sub-protocol for stores that additionally hold encrypted credentials.
+
+    Only ``PostgresAuthProfileStore`` implements this today. Consumers that
+    need the resolved credential inline (rather than via a ``CredentialBackend``
+    pointer) type-annotate against this protocol instead of the base one.
+
+    Rows written via plain ``upsert`` are compatible: ``get_with_credential``
+    returns ``(profile, None)`` in that case.
+    """
+
+    def upsert_with_credential(self, profile: AuthProfile, credential: ResolvedCredential) -> None:
+        """Insert or update ``profile`` and store ``credential`` encrypted."""
+        ...
+
+    def get_with_credential(
+        self, profile_id: str
+    ) -> tuple[AuthProfile, ResolvedCredential | None] | None:
+        """Return ``(profile, credential | None)`` or ``None`` if absent.
+
+        ``credential`` is ``None`` when the row has no ciphertext columns (PR 1
+        routing-only rows).
+        """
+        ...
+
+
+# ---------------------------------------------------------------------------
 # In-memory store — tests and pre-SQLite fallback
 # ---------------------------------------------------------------------------
 

--- a/src/nexus/bricks/auth/tests/test_envelope.py
+++ b/src/nexus/bricks/auth/tests/test_envelope.py
@@ -1,0 +1,46 @@
+"""Unit tests for envelope encryption primitives (issue #3803)."""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.bricks.auth.envelope import AESGCMEnvelope, CiphertextCorrupted
+
+
+class TestAESGCMEnvelope:
+    def test_roundtrip(self) -> None:
+        env = AESGCMEnvelope()
+        dek = b"\x00" * 32
+        plaintext = b"hello credential"
+        aad = b"tenant|principal|id"
+        nonce, ciphertext = env.encrypt(dek, plaintext, aad=aad)
+        assert len(nonce) == 12
+        assert ciphertext != plaintext
+        assert env.decrypt(dek, nonce, ciphertext, aad=aad) == plaintext
+
+    def test_wrong_aad_fails(self) -> None:
+        env = AESGCMEnvelope()
+        dek = b"\x01" * 32
+        nonce, ct = env.encrypt(dek, b"secret", aad=b"aad-A")
+        with pytest.raises(CiphertextCorrupted):
+            env.decrypt(dek, nonce, ct, aad=b"aad-B")
+
+    def test_ciphertext_tamper_fails(self) -> None:
+        env = AESGCMEnvelope()
+        dek = b"\x02" * 32
+        nonce, ct = env.encrypt(dek, b"secret", aad=b"aad")
+        tampered = bytes([ct[0] ^ 0x01]) + ct[1:]
+        with pytest.raises(CiphertextCorrupted):
+            env.decrypt(dek, nonce, tampered, aad=b"aad")
+
+    def test_fresh_nonce_per_encrypt(self) -> None:
+        env = AESGCMEnvelope()
+        dek = b"\x03" * 32
+        n1, _ = env.encrypt(dek, b"x", aad=b"aad")
+        n2, _ = env.encrypt(dek, b"x", aad=b"aad")
+        assert n1 != n2
+
+    def test_dek_must_be_32_bytes(self) -> None:
+        env = AESGCMEnvelope()
+        with pytest.raises(ValueError):
+            env.encrypt(b"\x00" * 16, b"x", aad=b"aad")

--- a/src/nexus/bricks/auth/tests/test_envelope.py
+++ b/src/nexus/bricks/auth/tests/test_envelope.py
@@ -266,3 +266,39 @@ class TestInMemoryEncryptionProvider:
         prov.unwrap_dek(w, tenant_id=tid, aad=b"a", kek_version=v)
         assert prov.wrap_count == 1
         assert prov.unwrap_count == 2
+
+    def test_kek_version_downgrade_unwrap_fails(self) -> None:
+        """Unwrap a v1-wrapped DEK while claiming kek_version=2 must fail.
+
+        Real providers reject this at the provider layer (Vault Transit:
+        decrypt with wrong key_version fails; AWS KMS: kek_version is encoded
+        in the opaque blob so the claim is ignored but downgrade can't succeed).
+        The fake must match — otherwise contract tests pass against the fake
+        and fail against real providers.
+        """
+        from nexus.bricks.auth.envelope import WrappedDEKInvalid
+
+        prov = InMemoryEncryptionProvider()
+        import uuid
+
+        tid = uuid.uuid4()
+        dek = b"\x77" * 32
+        wrapped, v1 = prov.wrap_dek(dek, tenant_id=tid, aad=b"a")
+        prov.rotate()  # current is now v2, v1 KEK still in _versions
+        with pytest.raises(WrappedDEKInvalid):
+            # Claim the row was wrapped at v2 even though it was v1
+            prov.unwrap_dek(wrapped, tenant_id=tid, aad=b"a", kek_version=2)
+
+    def test_unwrap_count_increments_on_failure(self) -> None:
+        """Failed unwraps still count — models a real KMS round-trip that
+        failed at the provider layer."""
+        from nexus.bricks.auth.envelope import WrappedDEKInvalid
+
+        prov = InMemoryEncryptionProvider()
+        import uuid
+
+        tid = uuid.uuid4()
+        w, v = prov.wrap_dek(b"\x00" * 32, tenant_id=tid, aad=b"a")
+        with pytest.raises(WrappedDEKInvalid):
+            prov.unwrap_dek(w, tenant_id=uuid.uuid4(), aad=b"a", kek_version=v)
+        assert prov.unwrap_count == 1

--- a/src/nexus/bricks/auth/tests/test_envelope.py
+++ b/src/nexus/bricks/auth/tests/test_envelope.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import hashlib
 import re
 
 import pytest
@@ -11,6 +12,7 @@ from nexus.bricks.auth.envelope import (
     AESGCMEnvelope,
     CiphertextCorrupted,
     DecryptionFailed,
+    DEKCache,
     EnvelopeConfigurationError,
     EnvelopeError,
     WrappedDEKInvalid,
@@ -104,3 +106,52 @@ class TestErrorReprDiscipline:
                 return
             fake_secret = base64.b64encode(secrets.token_bytes(24)).decode()
         pytest.fail("_BLOB_RE failed to match 5 consecutive real base64 secrets")
+
+
+class TestDEKCache:
+    def test_hit_after_put(self) -> None:
+        cache = DEKCache(ttl_seconds=60, max_entries=8)
+        key = cache.make_key(tenant_id="t", kek_version=1, wrapped_dek=b"abcd")
+        cache.put(key, b"\x00" * 32)
+        assert cache.get(key) == b"\x00" * 32
+        assert cache.hits == 1
+        assert cache.misses == 0
+
+    def test_miss_on_empty(self) -> None:
+        cache = DEKCache(ttl_seconds=60, max_entries=8)
+        key = cache.make_key(tenant_id="t", kek_version=1, wrapped_dek=b"abcd")
+        assert cache.get(key) is None
+        assert cache.misses == 1
+        assert cache.hits == 0
+
+    def test_ttl_expires(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        now = [1000.0]
+        monkeypatch.setattr("nexus.bricks.auth.envelope._monotonic", lambda: now[0])
+        cache = DEKCache(ttl_seconds=5, max_entries=8)
+        key = cache.make_key(tenant_id="t", kek_version=1, wrapped_dek=b"abcd")
+        cache.put(key, b"\x11" * 32)
+        now[0] += 4
+        assert cache.get(key) == b"\x11" * 32
+        now[0] += 2  # total 6s > ttl
+        assert cache.get(key) is None
+
+    def test_lru_eviction_on_size(self) -> None:
+        cache = DEKCache(ttl_seconds=60, max_entries=2)
+        k1 = cache.make_key(tenant_id="t", kek_version=1, wrapped_dek=b"1")
+        k2 = cache.make_key(tenant_id="t", kek_version=1, wrapped_dek=b"2")
+        k3 = cache.make_key(tenant_id="t", kek_version=1, wrapped_dek=b"3")
+        cache.put(k1, b"\x01" * 32)
+        cache.put(k2, b"\x02" * 32)
+        cache.get(k1)  # bump k1 to MRU
+        cache.put(k3, b"\x03" * 32)  # evicts k2 (LRU)
+        assert cache.get(k1) == b"\x01" * 32
+        assert cache.get(k2) is None
+        assert cache.get(k3) == b"\x03" * 32
+
+    def test_key_uses_wrapped_dek_hash_not_bytes(self) -> None:
+        cache = DEKCache(ttl_seconds=60, max_entries=8)
+        key = cache.make_key(tenant_id="t", kek_version=1, wrapped_dek=b"raw-wrapped-dek-bytes")
+        # Repr of the key should not contain "raw-wrapped-dek-bytes"
+        assert b"raw-wrapped-dek-bytes" not in repr(key).encode()
+        expected_digest = hashlib.sha256(b"raw-wrapped-dek-bytes").hexdigest()
+        assert expected_digest in repr(key)

--- a/src/nexus/bricks/auth/tests/test_envelope.py
+++ b/src/nexus/bricks/auth/tests/test_envelope.py
@@ -71,6 +71,21 @@ class TestAESGCMEnvelope:
         with pytest.raises(ValueError):
             env.encrypt(b"\x00" * 16, b"x", aad=b"aad")
 
+    def test_malformed_nonce_raises_ciphertext_corrupted(self) -> None:
+        """Regression for Codex round 8: malformed nonce/ciphertext shapes
+        must surface as CiphertextCorrupted (typed envelope error), not as
+        raw ValueError from AESGCM internals.
+        """
+        env = AESGCMEnvelope()
+        dek = b"\x07" * 32
+        nonce, ct = env.encrypt(dek, b"secret", aad=b"a")
+        # Truncated nonce (AESGCM requires exactly 12 bytes).
+        with pytest.raises(CiphertextCorrupted):
+            env.decrypt(dek, nonce[:4], ct, aad=b"a")
+        # Ciphertext too short to carry a GCM tag.
+        with pytest.raises(CiphertextCorrupted):
+            env.decrypt(dek, nonce, b"too-short", aad=b"a")
+
 
 class TestErrorReprDiscipline:
     def test_all_errors_carry_context_not_secrets(self) -> None:

--- a/src/nexus/bricks/auth/tests/test_envelope.py
+++ b/src/nexus/bricks/auth/tests/test_envelope.py
@@ -2,9 +2,22 @@
 
 from __future__ import annotations
 
+import re
+
 import pytest
 
-from nexus.bricks.auth.envelope import AESGCMEnvelope, CiphertextCorrupted
+from nexus.bricks.auth.envelope import (
+    AADMismatch,
+    AESGCMEnvelope,
+    CiphertextCorrupted,
+    DecryptionFailed,
+    EnvelopeConfigurationError,
+    EnvelopeError,
+    WrappedDEKInvalid,
+)
+
+# Regex: any base64 or hex blob of 16+ bytes shouldn't appear in error text.
+_BLOB_RE = re.compile(r"(?:[A-Za-z0-9+/]{22,}={0,2}|[0-9a-fA-F]{32,})")
 
 
 class TestAESGCMEnvelope:
@@ -44,3 +57,29 @@ class TestAESGCMEnvelope:
         env = AESGCMEnvelope()
         with pytest.raises(ValueError):
             env.encrypt(b"\x00" * 16, b"x", aad=b"aad")
+
+
+class TestErrorReprDiscipline:
+    def test_all_errors_carry_context_not_secrets(self) -> None:
+        import uuid
+
+        tenant = uuid.uuid4()
+        pid = "google/alice"
+        for cls in (EnvelopeConfigurationError, DecryptionFailed, AADMismatch, WrappedDEKInvalid):
+            err = cls.from_row(
+                tenant_id=tenant, profile_id=pid, kek_version=7, cause="RuntimeError"
+            )
+            text = f"{err} || {err!r}"
+            assert str(tenant) in text
+            assert pid in text
+            assert "7" in text
+            assert "RuntimeError" in text
+            assert _BLOB_RE.search(text) is None, f"{cls.__name__} repr leaked a blob: {text!r}"
+
+    def test_envelope_error_root_is_catchable(self) -> None:
+        import uuid
+
+        with pytest.raises(EnvelopeError):
+            raise DecryptionFailed.from_row(
+                tenant_id=uuid.uuid4(), profile_id="x", kek_version=1, cause="y"
+            )

--- a/src/nexus/bricks/auth/tests/test_envelope.py
+++ b/src/nexus/bricks/auth/tests/test_envelope.py
@@ -4,8 +4,14 @@ from __future__ import annotations
 
 import hashlib
 import re
+from typing import TYPE_CHECKING
 
 import pytest
+
+if TYPE_CHECKING:
+    from nexus.bricks.auth.envelope_providers.vault_transit import (
+        VaultTransitProvider,
+    )
 
 from nexus.bricks.auth.envelope import (
     AADMismatch,
@@ -302,6 +308,59 @@ class TestInMemoryEncryptionProvider:
         with pytest.raises(WrappedDEKInvalid):
             prov.unwrap_dek(w, tenant_id=uuid.uuid4(), aad=b"a", kek_version=v)
         assert prov.unwrap_count == 1
+
+
+class TestVaultBlobVersionMismatch:
+    """Regression test for Codex finding: a forged `kek_version` column must
+    not allow decrypt when the Vault blob actually embeds a different version.
+    """
+
+    def _make_provider_without_init(self) -> VaultTransitProvider:
+        from nexus.bricks.auth.envelope_providers.vault_transit import (
+            VaultTransitProvider,
+        )
+
+        provider = VaultTransitProvider.__new__(VaultTransitProvider)
+        provider._client = None
+        provider._key_name = "k"
+        provider._mount = "transit"
+        return provider
+
+    def test_blob_version_mismatch_raises_wrapped_dek_invalid(self) -> None:
+        import uuid
+
+        prov = self._make_provider_without_init()
+        wrapped = b"vault:v1:ZmFrZWNpcGhlcnRleHQ="
+        tid = uuid.uuid4()
+        with pytest.raises(WrappedDEKInvalid) as exc_info:
+            prov.unwrap_dek(wrapped, tenant_id=tid, aad=b"a", kek_version=2)
+        assert "blob version=1" in str(exc_info.value) or "version=1" in repr(exc_info.value)
+
+    def test_malformed_blob_raises_wrapped_dek_invalid(self) -> None:
+        import uuid
+
+        prov = self._make_provider_without_init()
+        tid = uuid.uuid4()
+        with pytest.raises(WrappedDEKInvalid):
+            prov.unwrap_dek(b"not-a-vault-blob", tenant_id=tid, aad=b"a", kek_version=1)
+
+
+class TestKmsEncryptionContextIncludesVersion:
+    """Regression test for Codex finding: AWS KMS EncryptionContext must bind
+    `kek_version`, otherwise a tampered kek_version column decrypts silently.
+    """
+
+    def test_context_includes_kek_version(self) -> None:
+        from nexus.bricks.auth.envelope_providers.aws_kms import AwsKmsProvider
+
+        ctx = AwsKmsProvider._context(
+            __import__("uuid").UUID("00000000-0000-0000-0000-000000000001"),
+            b"aad-bytes",
+            kek_version=7,
+        )
+        assert ctx["kek_version"] == "7"
+        assert ctx["tenant_id"] == "00000000-0000-0000-0000-000000000001"
+        assert "aad_fingerprint" in ctx
 
 
 class TestMetricsImport:

--- a/src/nexus/bricks/auth/tests/test_envelope.py
+++ b/src/nexus/bricks/auth/tests/test_envelope.py
@@ -155,3 +155,43 @@ class TestDEKCache:
         assert b"raw-wrapped-dek-bytes" not in repr(key).encode()
         expected_digest = hashlib.sha256(b"raw-wrapped-dek-bytes").hexdigest()
         assert expected_digest in repr(key)
+
+    def test_concurrent_get_put_is_safe(self) -> None:
+        """Under concurrent reads + writes, counters stay correct and the
+        OrderedDict doesn't corrupt. Not a perf test — just a sanity check
+        that the lock is in place."""
+        import concurrent.futures
+        import threading
+
+        cache = DEKCache(ttl_seconds=60, max_entries=256)
+        keys = [
+            cache.make_key(tenant_id="t", kek_version=1, wrapped_dek=i.to_bytes(4, "big"))
+            for i in range(32)
+        ]
+        dek = b"\x55" * 32
+        for k in keys:
+            cache.put(k, dek)
+
+        barrier = threading.Barrier(8)
+
+        def worker() -> int:
+            barrier.wait()
+            hits = 0
+            for _ in range(200):
+                for k in keys:
+                    if cache.get(k) is not None:
+                        hits += 1
+                    cache.put(k, dek)
+            return hits
+
+        with concurrent.futures.ThreadPoolExecutor(max_workers=8) as pool:
+            results = list(pool.map(lambda _: worker(), range(8)))
+
+        # All 8 workers each ran 200*32 = 6400 gets. All should have hit (keys
+        # are repopulated before each get via the put loop). Exact counts
+        # depend on interleaving but must be positive.
+        assert sum(results) > 0
+        # Under a race without a lock, counter increments would be lost and
+        # cache.hits + cache.misses would be strictly less than the number
+        # of get() calls. With a lock they're exactly equal.
+        assert cache.hits + cache.misses == 8 * 200 * 32

--- a/src/nexus/bricks/auth/tests/test_envelope.py
+++ b/src/nexus/bricks/auth/tests/test_envelope.py
@@ -302,3 +302,17 @@ class TestInMemoryEncryptionProvider:
         with pytest.raises(WrappedDEKInvalid):
             prov.unwrap_dek(w, tenant_id=uuid.uuid4(), aad=b"a", kek_version=v)
         assert prov.unwrap_count == 1
+
+
+class TestMetricsImport:
+    def test_all_metrics_defined(self) -> None:
+        from nexus.bricks.auth import envelope_metrics as m
+
+        for name in (
+            "DEK_CACHE_HITS",
+            "DEK_CACHE_MISSES",
+            "DEK_UNWRAP_ERRORS",
+            "DEK_UNWRAP_LATENCY",
+            "KEK_ROTATE_ROWS",
+        ):
+            assert hasattr(m, name), f"missing metric: {name}"

--- a/src/nexus/bricks/auth/tests/test_envelope.py
+++ b/src/nexus/bricks/auth/tests/test_envelope.py
@@ -17,6 +17,7 @@ from nexus.bricks.auth.envelope import (
     EnvelopeError,
     WrappedDEKInvalid,
 )
+from nexus.bricks.auth.envelope_providers.in_memory import InMemoryEncryptionProvider
 
 # Regex: any base64 or hex blob of 16+ bytes shouldn't appear in error text.
 # Real base64 of random secret bytes almost always contains a digit. Pure
@@ -195,3 +196,73 @@ class TestDEKCache:
         # cache.hits + cache.misses would be strictly less than the number
         # of get() calls. With a lock they're exactly equal.
         assert cache.hits + cache.misses == 8 * 200 * 32
+
+
+class TestInMemoryEncryptionProvider:
+    def test_roundtrip(self) -> None:
+        prov = InMemoryEncryptionProvider()
+        import uuid
+
+        tid = uuid.uuid4()
+        dek = b"\x22" * 32
+        wrapped, version = prov.wrap_dek(dek, tenant_id=tid, aad=b"aad")
+        assert version == 1
+        assert wrapped != dek
+        assert prov.unwrap_dek(wrapped, tenant_id=tid, aad=b"aad", kek_version=1) == dek
+
+    def test_current_version_bumps_after_rotate(self) -> None:
+        prov = InMemoryEncryptionProvider()
+        import uuid
+
+        tid = uuid.uuid4()
+        assert prov.current_version(tenant_id=tid) == 1
+        prov.rotate()
+        assert prov.current_version(tenant_id=tid) == 2
+
+    def test_wrap_at_v2_unwrap_at_v1_still_works(self) -> None:
+        prov = InMemoryEncryptionProvider()
+        import uuid
+
+        tid = uuid.uuid4()
+        dek = b"\x33" * 32
+        wrapped_v1, v1 = prov.wrap_dek(dek, tenant_id=tid, aad=b"a")
+        prov.rotate()
+        wrapped_v2, v2 = prov.wrap_dek(dek, tenant_id=tid, aad=b"a")
+        assert v1 == 1 and v2 == 2
+        # Both readable
+        assert prov.unwrap_dek(wrapped_v1, tenant_id=tid, aad=b"a", kek_version=v1) == dek
+        assert prov.unwrap_dek(wrapped_v2, tenant_id=tid, aad=b"a", kek_version=v2) == dek
+
+    def test_wrong_tenant_unwrap_fails(self) -> None:
+        from nexus.bricks.auth.envelope import WrappedDEKInvalid
+
+        prov = InMemoryEncryptionProvider()
+        import uuid
+
+        tid_a, tid_b = uuid.uuid4(), uuid.uuid4()
+        dek = b"\x44" * 32
+        wrapped, v = prov.wrap_dek(dek, tenant_id=tid_a, aad=b"a")
+        with pytest.raises(WrappedDEKInvalid):
+            prov.unwrap_dek(wrapped, tenant_id=tid_b, aad=b"a", kek_version=v)
+
+    def test_wrong_aad_unwrap_fails(self) -> None:
+        from nexus.bricks.auth.envelope import WrappedDEKInvalid
+
+        prov = InMemoryEncryptionProvider()
+        import uuid
+
+        tid = uuid.uuid4()
+        wrapped, v = prov.wrap_dek(b"\x55" * 32, tenant_id=tid, aad=b"aad-A")
+        with pytest.raises(WrappedDEKInvalid):
+            prov.unwrap_dek(wrapped, tenant_id=tid, aad=b"aad-B", kek_version=v)
+
+    def test_counters(self) -> None:
+        prov = InMemoryEncryptionProvider()
+        import uuid
+
+        tid = uuid.uuid4()
+        w, v = prov.wrap_dek(b"\x66" * 32, tenant_id=tid, aad=b"a")
+        prov.unwrap_dek(w, tenant_id=tid, aad=b"a", kek_version=v)
+        prov.unwrap_dek(w, tenant_id=tid, aad=b"a", kek_version=v)
+        assert prov.wrap_count == 1
+        assert prov.unwrap_count == 2

--- a/src/nexus/bricks/auth/tests/test_envelope.py
+++ b/src/nexus/bricks/auth/tests/test_envelope.py
@@ -17,7 +17,11 @@ from nexus.bricks.auth.envelope import (
 )
 
 # Regex: any base64 or hex blob of 16+ bytes shouldn't appear in error text.
-_BLOB_RE = re.compile(r"(?:[A-Za-z0-9+/]{22,}={0,2}|[0-9a-fA-F]{32,})")
+# Real base64 of random secret bytes almost always contains a digit. Pure
+# identifier names (class names, field names) don't. Requiring a digit in
+# the base64 branch keeps the check sensitive to leaked secrets while
+# avoiding false positives on long class names like "EnvelopeConfigurationError".
+_BLOB_RE = re.compile(r"(?:(?=[A-Za-z0-9+/]*[0-9])[A-Za-z0-9+/]{22,}={0,2}|[0-9a-fA-F]{32,})")
 
 
 class TestAESGCMEnvelope:
@@ -83,3 +87,20 @@ class TestErrorReprDiscipline:
             raise DecryptionFailed.from_row(
                 tenant_id=uuid.uuid4(), profile_id="x", kek_version=1, cause="y"
             )
+
+    def test_regex_catches_actual_base64_secret(self) -> None:
+        """Sanity check the blob-detection regex actually catches a real
+        base64 of random bytes — we tightened it to avoid class-name false
+        positives, make sure we didn't neuter it."""
+        import base64
+        import secrets
+
+        fake_secret = base64.b64encode(secrets.token_bytes(24)).decode()
+        # Should match (base64 of 24 random bytes is 32 chars, includes digits with
+        # overwhelming probability).
+        # Try up to 5 times in case we unluckily drew an all-letter base64.
+        for _ in range(5):
+            if _BLOB_RE.search(fake_secret):
+                return
+            fake_secret = base64.b64encode(secrets.token_bytes(24)).decode()
+        pytest.fail("_BLOB_RE failed to match 5 consecutive real base64 secrets")

--- a/src/nexus/bricks/auth/tests/test_envelope.py
+++ b/src/nexus/bricks/auth/tests/test_envelope.py
@@ -316,3 +316,11 @@ class TestMetricsImport:
             "KEK_ROTATE_ROWS",
         ):
             assert hasattr(m, name), f"missing metric: {name}"
+
+
+class TestCredentialCarryingProtocol:
+    def test_protocol_defines_two_methods(self) -> None:
+        from nexus.bricks.auth.profile import CredentialCarryingProfileStore
+
+        assert hasattr(CredentialCarryingProfileStore, "upsert_with_credential")
+        assert hasattr(CredentialCarryingProfileStore, "get_with_credential")

--- a/src/nexus/bricks/auth/tests/test_envelope_contract.py
+++ b/src/nexus/bricks/auth/tests/test_envelope_contract.py
@@ -1,0 +1,51 @@
+"""Shared contract tests every EncryptionProvider must pass (issue #3803).
+
+Parametrized against InMemoryEncryptionProvider by default. Provider-specific
+test modules (Vault, AWS KMS) import these and re-parametrize with their own
+``provider_factory`` fixtures gated by ``@pytest.mark.vault`` / ``@pytest.mark.kms``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+
+import pytest
+
+from nexus.bricks.auth.envelope import EncryptionProvider, WrappedDEKInvalid
+from nexus.bricks.auth.envelope_providers.in_memory import InMemoryEncryptionProvider
+
+
+@pytest.fixture()
+def provider_factory() -> Callable[[], EncryptionProvider]:
+    return InMemoryEncryptionProvider
+
+
+class EnvelopeProviderContract:
+    """Subclassed by provider-specific modules with their own fixture."""
+
+    def test_wrap_unwrap_roundtrip(self, provider_factory) -> None:
+        prov = provider_factory()
+        dek = b"\x77" * 32
+        tid = uuid.uuid4()
+        wrapped, version = prov.wrap_dek(dek, tenant_id=tid, aad=b"aad-x")
+        assert version >= 1
+        assert prov.unwrap_dek(wrapped, tenant_id=tid, aad=b"aad-x", kek_version=version) == dek
+
+    def test_unwrap_with_wrong_tenant_fails(self, provider_factory) -> None:
+        prov = provider_factory()
+        dek = b"\x78" * 32
+        wrapped, v = prov.wrap_dek(dek, tenant_id=uuid.uuid4(), aad=b"aad")
+        with pytest.raises(WrappedDEKInvalid):
+            prov.unwrap_dek(wrapped, tenant_id=uuid.uuid4(), aad=b"aad", kek_version=v)
+
+    def test_unwrap_with_wrong_aad_fails(self, provider_factory) -> None:
+        prov = provider_factory()
+        tid = uuid.uuid4()
+        wrapped, v = prov.wrap_dek(b"\x79" * 32, tenant_id=tid, aad=b"aad-A")
+        with pytest.raises(WrappedDEKInvalid):
+            prov.unwrap_dek(wrapped, tenant_id=tid, aad=b"aad-B", kek_version=v)
+
+
+class TestInMemoryContract(EnvelopeProviderContract):
+    """Runs the full contract suite against the in-memory fake."""

--- a/src/nexus/bricks/auth/tests/test_envelope_providers_aws_kms.py
+++ b/src/nexus/bricks/auth/tests/test_envelope_providers_aws_kms.py
@@ -53,6 +53,7 @@ def provider_factory() -> Callable[[], EncryptionProvider]:
     from nexus.bricks.auth.envelope_providers.aws_kms import AwsKmsProvider
 
     def _make() -> EncryptionProvider:
+        assert KMS_KEY_ID is not None  # gated by _kms_available() skipif above
         kwargs: dict = {"region_name": KMS_REGION}
         if KMS_ENDPOINT:
             kwargs["endpoint_url"] = KMS_ENDPOINT

--- a/src/nexus/bricks/auth/tests/test_envelope_providers_aws_kms.py
+++ b/src/nexus/bricks/auth/tests/test_envelope_providers_aws_kms.py
@@ -1,0 +1,66 @@
+"""AWS KMS provider contract tests (issue #3803).
+
+Gated behind @pytest.mark.kms. Requires a reachable KMS endpoint (real AWS or
+LocalStack) with a CMK accessible via AWS_KMS_KEY_ID.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+
+import pytest
+
+from nexus.bricks.auth.envelope import EncryptionProvider
+from nexus.bricks.auth.tests.test_envelope_contract import EnvelopeProviderContract
+
+KMS_ENDPOINT = os.environ.get("AWS_ENDPOINT_URL")
+KMS_REGION = os.environ.get("AWS_REGION", "us-east-1")
+KMS_KEY_ID = os.environ.get("AWS_KMS_KEY_ID")
+
+
+def _kms_available() -> bool:
+    if not KMS_KEY_ID:
+        return False
+    try:
+        import boto3
+    except ImportError:
+        return False
+    try:
+        kwargs: dict = {"region_name": KMS_REGION}
+        if KMS_ENDPOINT:
+            kwargs["endpoint_url"] = KMS_ENDPOINT
+        client = boto3.client("kms", **kwargs)
+        client.describe_key(KeyId=KMS_KEY_ID)
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = [
+    pytest.mark.kms,
+    pytest.mark.skipif(
+        not _kms_available(),
+        reason="AWS KMS not reachable or AWS_KMS_KEY_ID unset",
+    ),
+]
+
+
+@pytest.fixture()
+def provider_factory() -> Callable[[], EncryptionProvider]:
+    import boto3
+
+    from nexus.bricks.auth.envelope_providers.aws_kms import AwsKmsProvider
+
+    def _make() -> EncryptionProvider:
+        kwargs: dict = {"region_name": KMS_REGION}
+        if KMS_ENDPOINT:
+            kwargs["endpoint_url"] = KMS_ENDPOINT
+        kms = boto3.client("kms", **kwargs)
+        return AwsKmsProvider(kms, key_id=KMS_KEY_ID)
+
+    return _make
+
+
+class TestAwsKmsContract(EnvelopeProviderContract):
+    """Runs the shared EncryptionProvider contract suite against AWS KMS."""

--- a/src/nexus/bricks/auth/tests/test_envelope_providers_vault.py
+++ b/src/nexus/bricks/auth/tests/test_envelope_providers_vault.py
@@ -1,0 +1,55 @@
+"""Vault Transit provider contract tests (issue #3803).
+
+Gated behind @pytest.mark.vault. Requires a running Vault dev server at
+VAULT_ADDR with a transit mount and a derived-context key named
+``nexus-test``. See docs/guides/auth-envelope-encryption.md for setup.
+"""
+
+from __future__ import annotations
+
+import os
+from collections.abc import Callable
+
+import pytest
+
+from nexus.bricks.auth.envelope import EncryptionProvider
+from nexus.bricks.auth.tests.test_envelope_contract import EnvelopeProviderContract
+
+VAULT_ADDR = os.environ.get("VAULT_ADDR", "http://127.0.0.1:8200")
+VAULT_TOKEN = os.environ.get("VAULT_TOKEN", "root")
+VAULT_TRANSIT_KEY = os.environ.get("VAULT_TRANSIT_KEY", "nexus-test")
+
+
+def _vault_available() -> bool:
+    try:
+        import hvac
+    except ImportError:
+        return False
+    try:
+        client = hvac.Client(url=VAULT_ADDR, token=VAULT_TOKEN)
+        return bool(client.sys.is_initialized())
+    except Exception:
+        return False
+
+
+pytestmark = [
+    pytest.mark.vault,
+    pytest.mark.skipif(not _vault_available(), reason="Vault dev server not reachable"),
+]
+
+
+@pytest.fixture()
+def provider_factory() -> Callable[[], EncryptionProvider]:
+    import hvac
+
+    from nexus.bricks.auth.envelope_providers.vault_transit import VaultTransitProvider
+
+    def _make() -> EncryptionProvider:
+        client = hvac.Client(url=VAULT_ADDR, token=VAULT_TOKEN)
+        return VaultTransitProvider(client, key_name=VAULT_TRANSIT_KEY)
+
+    return _make
+
+
+class TestVaultTransitContract(EnvelopeProviderContract):
+    """Runs the shared EncryptionProvider contract suite against Vault Transit."""

--- a/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
+++ b/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
@@ -19,6 +19,7 @@ from sqlalchemy.engine import Engine
 from sqlalchemy.exc import IntegrityError
 
 from nexus.bricks.auth.credential_backend import ResolvedCredential
+from nexus.bricks.auth.envelope import AADMismatch, WrappedDEKInvalid
 from nexus.bricks.auth.envelope_providers.in_memory import InMemoryEncryptionProvider
 from nexus.bricks.auth.postgres_profile_store import (
     PostgresAuthProfileStore,
@@ -198,3 +199,150 @@ class TestEncryptedUpsertAndGet:
                 store.get_with_credential("x")
         finally:
             store.close()
+
+
+class TestSwapAttackRejected:
+    def test_ciphertext_copied_cross_tenant_fails_decrypt(
+        self,
+        pg_engine: Engine,
+        encryption_provider: InMemoryEncryptionProvider,
+    ) -> None:
+        """Attacker with raw DB access copies A's ciphertext+wrapped_dek+nonce+aad+kek_version
+        into B under a different tenant. Decrypt on B must fail.
+
+        The InMemoryEncryptionProvider mixes tenant_id into AAD at the wrap
+        level, so this raises WrappedDEKInvalid. Real providers fail at their
+        native layer (KMS EncryptionContext, Vault derivation context). The
+        stored ``aad`` column also wouldn't match B's ``tenant|principal|id``
+        — AADMismatch would fire at the row-level check before unwrap.
+        """
+        t_a = ensure_tenant(pg_engine, f"atk-a-{uuid.uuid4()}")
+        t_b = ensure_tenant(pg_engine, f"atk-b-{uuid.uuid4()}")
+        p_a = ensure_principal(
+            pg_engine, tenant_id=t_a, external_sub=f"sa-{uuid.uuid4()}", auth_method="t"
+        )
+        p_b = ensure_principal(
+            pg_engine, tenant_id=t_b, external_sub=f"sb-{uuid.uuid4()}", auth_method="t"
+        )
+        store_a = PostgresAuthProfileStore(
+            PG_URL,
+            tenant_id=t_a,
+            principal_id=p_a,
+            engine=pg_engine,
+            encryption_provider=encryption_provider,
+        )
+        store_b = PostgresAuthProfileStore(
+            PG_URL,
+            tenant_id=t_b,
+            principal_id=p_b,
+            engine=pg_engine,
+            encryption_provider=encryption_provider,
+        )
+        try:
+            store_a.upsert_with_credential(
+                make_profile("shared-id"),
+                ResolvedCredential(kind="api_key", api_key="A-SECRET"),
+            )
+            store_b.upsert(make_profile("shared-id"))
+            with pg_engine.begin() as conn:
+                conn.execute(text("SET LOCAL app.current_tenant = :tid"), {"tid": str(t_a)})
+                row_a = conn.execute(
+                    text(
+                        "SELECT ciphertext, wrapped_dek, nonce, aad, kek_version "
+                        "FROM auth_profiles WHERE tenant_id = :tid AND id = :id"
+                    ),
+                    {"tid": t_a, "id": "shared-id"},
+                ).fetchone()
+            assert row_a is not None
+            with pg_engine.begin() as conn:
+                conn.execute(text("SET LOCAL app.current_tenant = :tid"), {"tid": str(t_b)})
+                conn.execute(
+                    text(
+                        "UPDATE auth_profiles SET "
+                        "    ciphertext = :ct, wrapped_dek = :wd, "
+                        "    nonce = :n, aad = :a, kek_version = :v "
+                        "WHERE tenant_id = :tid AND principal_id = :pid AND id = :id"
+                    ),
+                    {
+                        "ct": bytes(row_a.ciphertext),
+                        "wd": bytes(row_a.wrapped_dek),
+                        "n": bytes(row_a.nonce),
+                        "a": bytes(row_a.aad),
+                        "v": row_a.kek_version,
+                        "tid": t_b,
+                        "pid": p_b,
+                        "id": "shared-id",
+                    },
+                )
+            with pytest.raises((AADMismatch, WrappedDEKInvalid)):
+                store_b.get_with_credential("shared-id")
+        finally:
+            store_a.close()
+            store_b.close()
+
+
+class TestMixedVersionReads:
+    def test_reads_span_rotation(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        encryption_provider: InMemoryEncryptionProvider,
+    ) -> None:
+        pg_store_crypto.upsert_with_credential(
+            make_profile("v1-row"),
+            ResolvedCredential(kind="api_key", api_key="v1"),
+        )
+        encryption_provider.rotate()
+        pg_store_crypto.upsert_with_credential(
+            make_profile("v2-row"),
+            ResolvedCredential(kind="api_key", api_key="v2"),
+        )
+        a = pg_store_crypto.get_with_credential("v1-row")
+        b = pg_store_crypto.get_with_credential("v2-row")
+        assert a is not None and a[1] is not None and a[1].api_key == "v1"
+        assert b is not None and b[1] is not None and b[1].api_key == "v2"
+
+
+class TestCacheAmortizes:
+    def test_two_reads_one_unwrap(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        encryption_provider: InMemoryEncryptionProvider,
+    ) -> None:
+        pg_store_crypto.upsert_with_credential(
+            make_profile("cached"),
+            ResolvedCredential(kind="api_key", api_key="k"),
+        )
+        start = encryption_provider.unwrap_count
+        pg_store_crypto.get_with_credential("cached")
+        pg_store_crypto.get_with_credential("cached")
+        assert encryption_provider.unwrap_count - start == 1
+
+
+class TestAADMismatch:
+    def test_aad_column_tampered_raises(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        pg_engine: Engine,
+        tenant_id: uuid.UUID,
+        principal_id: uuid.UUID,
+    ) -> None:
+        pg_store_crypto.upsert_with_credential(
+            make_profile("aad-tamper"),
+            ResolvedCredential(kind="api_key", api_key="k"),
+        )
+        with pg_engine.begin() as conn:
+            conn.execute(text("SET LOCAL app.current_tenant = :tid"), {"tid": str(tenant_id)})
+            conn.execute(
+                text(
+                    "UPDATE auth_profiles SET aad = :bad "
+                    "WHERE tenant_id = :tid AND principal_id = :pid AND id = :id"
+                ),
+                {
+                    "bad": b"bogus-aad-bytes",
+                    "tid": tenant_id,
+                    "pid": principal_id,
+                    "id": "aad-tamper",
+                },
+            )
+        with pytest.raises(AADMismatch):
+            pg_store_crypto.get_with_credential("aad-tamper")

--- a/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
+++ b/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
@@ -598,6 +598,33 @@ class TestRotateKEKFailures:
         assert report.rows_rewrapped == 0  # nothing to rewrap — only ahead row exists
         assert report.rows_remaining == 0
 
+    def test_replace_owned_subset_rejects_encrypted_row(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        pg_engine: Engine,  # noqa: ARG002
+        tenant_id: uuid.UUID,
+        principal_id: uuid.UUID,
+    ) -> None:
+        """Regression: replace_owned_subset shares the UPSERT path with plain
+        upsert, so it must enforce the same encrypted-row guard. Otherwise a
+        sync path (used by external_sync.registry) could rewrite backend_key
+        while leaving old ciphertext stored.
+        """
+        pg_store_crypto.upsert_with_credential(
+            make_profile("sync-row"),
+            ResolvedCredential(kind="api_key", api_key="s"),
+        )
+        new_profile = make_profile("sync-row", backend_key="secret://different")
+
+        plain_store = PostgresAuthProfileStore(
+            PG_URL, tenant_id=tenant_id, principal_id=principal_id
+        )
+        try:
+            with pytest.raises(ValueError, match="encrypted"):
+                plain_store.replace_owned_subset(upserts=[new_profile], deletes=[])
+        finally:
+            plain_store.close()
+
     def test_plain_upsert_rejects_encrypted_row(
         self,
         pg_store_crypto: PostgresAuthProfileStore,

--- a/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
+++ b/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
@@ -488,6 +488,36 @@ class TestRotateKEKFailures:
         assert report.rows_failed == 1
         assert report.rows_remaining == 1
 
+    def test_rejects_non_positive_batch_size(
+        self,
+        pg_engine: Engine,
+        tenant_id: uuid.UUID,
+        encryption_provider: InMemoryEncryptionProvider,
+    ) -> None:
+        """Defensive guard: batch_size <= 0 raises ValueError."""
+        with pytest.raises(ValueError, match="batch_size must be >= 1"):
+            rotate_kek_for_tenant(
+                pg_engine,
+                tenant_id=tenant_id,
+                encryption_provider=encryption_provider,
+                batch_size=0,
+            )
+
+    def test_rejects_non_positive_max_rows(
+        self,
+        pg_engine: Engine,
+        tenant_id: uuid.UUID,
+        encryption_provider: InMemoryEncryptionProvider,
+    ) -> None:
+        """Defensive guard: max_rows <= 0 raises ValueError."""
+        with pytest.raises(ValueError, match="max_rows must be >= 1"):
+            rotate_kek_for_tenant(
+                pg_engine,
+                tenant_id=tenant_id,
+                encryption_provider=encryption_provider,
+                max_rows=0,
+            )
+
     def test_aad_tampered_row_fails_rotation(
         self,
         pg_store_crypto: PostgresAuthProfileStore,

--- a/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
+++ b/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
@@ -425,3 +425,65 @@ class TestRotateKEKForTenant:
         )
         assert report.rows_rewrapped == 2
         assert report.rows_remaining == 1
+
+
+class TestRotateKEKFailures:
+    def test_per_row_failure_continues_batch(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        pg_engine: Engine,
+        tenant_id: uuid.UUID,
+        encryption_provider: InMemoryEncryptionProvider,
+    ) -> None:
+        """An unwrap failure on one row leaves that row on the old version; the
+        batch continues to completion for other rows."""
+        from nexus.bricks.auth.envelope import WrappedDEKInvalid
+
+        for i in range(3):
+            pg_store_crypto.upsert_with_credential(
+                make_profile(f"fail-{i}"),
+                ResolvedCredential(kind="api_key", api_key=f"k{i}"),
+            )
+        encryption_provider.rotate()
+
+        middle_wrapped = None
+        with pg_engine.begin() as conn:
+            conn.execute(text("SET LOCAL app.current_tenant = :tid"), {"tid": str(tenant_id)})
+            row = conn.execute(
+                text(
+                    "SELECT wrapped_dek FROM auth_profiles WHERE tenant_id = :tid AND id = 'fail-1'"
+                ),
+                {"tid": tenant_id},
+            ).fetchone()
+            assert row is not None
+            middle_wrapped = bytes(row.wrapped_dek)
+
+        real = encryption_provider
+
+        class _FlakyProvider:
+            def current_version(self, *, tenant_id):
+                return real.current_version(tenant_id=tenant_id)
+
+            def wrap_dek(self, dek, *, tenant_id, aad):
+                return real.wrap_dek(dek, tenant_id=tenant_id, aad=aad)
+
+            def unwrap_dek(self, wrapped, *, tenant_id, aad, kek_version):
+                if wrapped == middle_wrapped:
+                    raise WrappedDEKInvalid.from_row(
+                        tenant_id=tenant_id,
+                        profile_id="fail-1",
+                        kek_version=kek_version,
+                        cause="simulated flake",
+                    )
+                return real.unwrap_dek(
+                    wrapped, tenant_id=tenant_id, aad=aad, kek_version=kek_version
+                )
+
+        report = rotate_kek_for_tenant(
+            pg_engine,
+            tenant_id=tenant_id,
+            encryption_provider=_FlakyProvider(),
+        )
+        assert report.rows_rewrapped == 2
+        assert report.rows_failed == 1
+        assert report.rows_remaining == 1

--- a/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
+++ b/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
@@ -544,6 +544,66 @@ class TestRotateKEKFailures:
             ]
         assert versions == [1], "wrap-fatal must not leave partial rewraps committed"
 
+    def test_perpetual_cas_miss_eventually_fails_row(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        pg_engine: Engine,
+        tenant_id: uuid.UUID,
+        encryption_provider: InMemoryEncryptionProvider,
+    ) -> None:
+        """Regression: a row whose CAS predicate never matches (because a
+        perpetual concurrent writer keeps bumping it) must not livelock the
+        rotation loop. After N misses the row gets promoted to rows_failed
+        and the run terminates.
+        """
+        pg_store_crypto.upsert_with_credential(
+            make_profile("perpetual"),
+            ResolvedCredential(kind="api_key", api_key="v0"),
+        )
+        encryption_provider.rotate()
+
+        real = encryption_provider
+
+        class _AlwaysRaceProvider:
+            """Between our SELECT snapshot and our CAS UPDATE, this wrapper
+            writes a new wrapped_dek to the same row so the CAS always misses.
+            """
+
+            def current_version(self, *, tenant_id):
+                return real.current_version(tenant_id=tenant_id)
+
+            def wrap_dek(self, dek, *, tenant_id, aad):
+                # Simulate a concurrent writer: patch the row at v1 with a
+                # fresh wrapped blob, invalidating our snapshot.
+                new_dek = b"\x11" * 32
+                # Re-wrap under the real provider's v1 semantics.
+                with pg_engine.begin() as conn:
+                    conn.execute(
+                        text("SET LOCAL app.current_tenant = :tid"),
+                        {"tid": str(tenant_id)},
+                    )
+                    conn.execute(
+                        text(
+                            "UPDATE auth_profiles SET wrapped_dek = :wd "
+                            "WHERE tenant_id = :tid AND id = 'perpetual'"
+                        ),
+                        {"tid": tenant_id, "wd": new_dek},
+                    )
+                return real.wrap_dek(dek, tenant_id=tenant_id, aad=aad)
+
+            def unwrap_dek(self, wrapped, *, tenant_id, aad, kek_version):
+                return real.unwrap_dek(
+                    wrapped, tenant_id=tenant_id, aad=aad, kek_version=kek_version
+                )
+
+        report = rotate_kek_for_tenant(
+            pg_engine,
+            tenant_id=tenant_id,
+            encryption_provider=_AlwaysRaceProvider(),
+        )
+        assert report.rows_rewrapped == 0
+        assert report.rows_failed == 1, "CAS-miss bound must eventually fail the row"
+
     def test_concurrent_writer_does_not_block_on_slow_provider(
         self,
         pg_store_crypto: PostgresAuthProfileStore,

--- a/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
+++ b/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
@@ -346,3 +346,82 @@ class TestAADMismatch:
             )
         with pytest.raises(AADMismatch):
             pg_store_crypto.get_with_credential("aad-tamper")
+
+
+from nexus.bricks.auth.postgres_profile_store import (  # noqa: E402
+    rotate_kek_for_tenant,
+)
+
+
+class TestRotateKEKForTenant:
+    def test_noop_when_all_rows_current(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        pg_engine: Engine,
+        tenant_id: uuid.UUID,
+        encryption_provider: InMemoryEncryptionProvider,
+    ) -> None:
+        pg_store_crypto.upsert_with_credential(
+            make_profile("current-1"),
+            ResolvedCredential(kind="api_key", api_key="k"),
+        )
+        report = rotate_kek_for_tenant(
+            pg_engine,
+            tenant_id=tenant_id,
+            encryption_provider=encryption_provider,
+        )
+        assert report.rows_rewrapped == 0
+        assert report.rows_remaining == 0
+
+    def test_rotates_stale_rows(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        pg_engine: Engine,
+        tenant_id: uuid.UUID,
+        encryption_provider: InMemoryEncryptionProvider,
+    ) -> None:
+        pg_store_crypto.upsert_with_credential(
+            make_profile("a"),
+            ResolvedCredential(kind="api_key", api_key="k-a"),
+        )
+        pg_store_crypto.upsert_with_credential(
+            make_profile("b"),
+            ResolvedCredential(kind="api_key", api_key="k-b"),
+        )
+        encryption_provider.rotate()
+        report = rotate_kek_for_tenant(
+            pg_engine,
+            tenant_id=tenant_id,
+            encryption_provider=encryption_provider,
+            batch_size=1,
+        )
+        assert report.rows_rewrapped == 2
+        assert report.rows_remaining == 0
+        assert report.target_version == 2
+        a = pg_store_crypto.get_with_credential("a")
+        b = pg_store_crypto.get_with_credential("b")
+        assert a is not None and a[1] is not None and a[1].api_key == "k-a"
+        assert b is not None and b[1] is not None and b[1].api_key == "k-b"
+
+    def test_respects_max_rows(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        pg_engine: Engine,
+        tenant_id: uuid.UUID,
+        encryption_provider: InMemoryEncryptionProvider,
+    ) -> None:
+        for i in range(3):
+            pg_store_crypto.upsert_with_credential(
+                make_profile(f"m-{i}"),
+                ResolvedCredential(kind="api_key", api_key=f"k{i}"),
+            )
+        encryption_provider.rotate()
+        report = rotate_kek_for_tenant(
+            pg_engine,
+            tenant_id=tenant_id,
+            encryption_provider=encryption_provider,
+            batch_size=2,
+            max_rows=2,
+        )
+        assert report.rows_rewrapped == 2
+        assert report.rows_remaining == 1

--- a/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
+++ b/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
@@ -807,6 +807,40 @@ class TestRotateKEKFailures:
         finally:
             plain_store.close()
 
+    def test_plain_upsert_allows_stats_only_update_on_encrypted_row(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        pg_engine: Engine,  # noqa: ARG002
+        tenant_id: uuid.UUID,
+        principal_id: uuid.UUID,
+    ) -> None:
+        """Regression: CredentialPool.mark_success/mark_failure call
+        store.upsert(profile) to persist cooldown/stats. The encrypted-row
+        guard must allow re-upsert when routing columns are unchanged.
+        """
+        profile = make_profile("stats-row")
+        pg_store_crypto.upsert_with_credential(
+            profile,
+            ResolvedCredential(kind="api_key", api_key="s"),
+        )
+
+        stats_store = PostgresAuthProfileStore(
+            PG_URL, tenant_id=tenant_id, principal_id=principal_id
+        )
+        try:
+            updated = make_profile(
+                "stats-row",
+                success_count=5,
+                failure_count=1,
+                backend=profile.backend,
+                backend_key=profile.backend_key,
+                provider=profile.provider,
+                account_identifier=profile.account_identifier,
+            )
+            stats_store.upsert(updated)
+        finally:
+            stats_store.close()
+
     def test_plain_upsert_rejects_encrypted_row(
         self,
         pg_store_crypto: PostgresAuthProfileStore,

--- a/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
+++ b/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
@@ -487,3 +487,105 @@ class TestRotateKEKFailures:
         assert report.rows_rewrapped == 2
         assert report.rows_failed == 1
         assert report.rows_remaining == 1
+
+    def test_skiplist_uses_composite_principal_id_and_id(
+        self,
+        pg_engine: Engine,
+        tenant_id: uuid.UUID,
+        encryption_provider: InMemoryEncryptionProvider,
+    ) -> None:
+        """Regression for Codex finding: skip-list must key on (principal_id, id).
+
+        Two principals in the same tenant each own a profile with the same
+        ``id="shared"``. If the failing row is skipped by ``id`` alone, the
+        *other* principal's row with the same id is also hidden from the next
+        SELECT and never rotates.
+        """
+        from nexus.bricks.auth.envelope import WrappedDEKInvalid
+
+        p_a = ensure_principal(
+            pg_engine,
+            tenant_id=tenant_id,
+            kind="human",
+            external_sub=f"skip-a-{uuid.uuid4()}",
+            auth_method="test",
+        )
+        p_b = ensure_principal(
+            pg_engine,
+            tenant_id=tenant_id,
+            kind="human",
+            external_sub=f"skip-b-{uuid.uuid4()}",
+            auth_method="test",
+        )
+
+        store_a = PostgresAuthProfileStore(
+            PG_URL,
+            tenant_id=tenant_id,
+            principal_id=p_a,
+            engine=pg_engine,
+            encryption_provider=encryption_provider,
+        )
+        store_b = PostgresAuthProfileStore(
+            PG_URL,
+            tenant_id=tenant_id,
+            principal_id=p_b,
+            engine=pg_engine,
+            encryption_provider=encryption_provider,
+        )
+
+        store_a.upsert_with_credential(
+            make_profile("shared-id"),
+            ResolvedCredential(kind="api_key", api_key="secret-a"),
+        )
+        store_b.upsert_with_credential(
+            make_profile("shared-id"),
+            ResolvedCredential(kind="api_key", api_key="secret-b"),
+        )
+
+        encryption_provider.rotate()
+
+        with pg_engine.begin() as conn:
+            conn.execute(text("SET LOCAL app.current_tenant = :tid"), {"tid": str(tenant_id)})
+            row = conn.execute(
+                text(
+                    "SELECT wrapped_dek FROM auth_profiles WHERE tenant_id = :tid "
+                    "AND principal_id = :pid AND id = 'shared-id'"
+                ),
+                {"tid": tenant_id, "pid": p_a},
+            ).fetchone()
+            assert row is not None
+            bad_wrapped = bytes(row.wrapped_dek)
+
+        real = encryption_provider
+
+        class _FlakyForPrincipalA:
+            def current_version(self, *, tenant_id):
+                return real.current_version(tenant_id=tenant_id)
+
+            def wrap_dek(self, dek, *, tenant_id, aad):
+                return real.wrap_dek(dek, tenant_id=tenant_id, aad=aad)
+
+            def unwrap_dek(self, wrapped, *, tenant_id, aad, kek_version):
+                if wrapped == bad_wrapped:
+                    raise WrappedDEKInvalid.from_row(
+                        tenant_id=tenant_id,
+                        profile_id="shared-id",
+                        kek_version=kek_version,
+                        cause="simulated principal-a failure",
+                    )
+                return real.unwrap_dek(
+                    wrapped, tenant_id=tenant_id, aad=aad, kek_version=kek_version
+                )
+
+        report = rotate_kek_for_tenant(
+            pg_engine,
+            tenant_id=tenant_id,
+            encryption_provider=_FlakyForPrincipalA(),
+            batch_size=1,
+        )
+
+        assert report.rows_failed == 1
+        assert report.rows_rewrapped == 1, (
+            "principal_b's row with the same id must rotate; skip-list keyed "
+            "on id alone would hide it after principal_a's failure"
+        )

--- a/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
+++ b/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
@@ -488,6 +488,60 @@ class TestRotateKEKFailures:
         assert report.rows_failed == 1
         assert report.rows_remaining == 1
 
+    def test_aad_tampered_row_fails_rotation(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        pg_engine: Engine,
+        tenant_id: uuid.UUID,
+        encryption_provider: InMemoryEncryptionProvider,
+    ) -> None:
+        """Regression: a provider like Vault Transit ignores AAD bytes during
+        unwrap/wrap, so an attacker who tampered the ``aad`` column could
+        silently rotate to the new version and only fail later at the AESGCM
+        read path. Rotation must independently re-validate AAD against
+        ``(tenant_id, principal_id, id)``.
+        """
+        pg_store_crypto.upsert_with_credential(
+            make_profile("aad-rotate"),
+            ResolvedCredential(kind="api_key", api_key="secret"),
+        )
+        encryption_provider.rotate()
+
+        with pg_engine.begin() as conn:
+            conn.execute(text("SET LOCAL app.current_tenant = :tid"), {"tid": str(tenant_id)})
+            conn.execute(
+                text(
+                    "UPDATE auth_profiles SET aad = :aad "
+                    "WHERE tenant_id = :tid AND id = 'aad-rotate'"
+                ),
+                {"tid": tenant_id, "aad": b"tampered-aad"},
+            )
+
+        real = encryption_provider
+
+        class _AadIgnoringProvider:
+            """Mimics Vault Transit: ignores aad bytes entirely during un/wrap."""
+
+            def current_version(self, *, tenant_id):
+                return real.current_version(tenant_id=tenant_id)
+
+            def wrap_dek(self, dek, *, tenant_id, aad):  # noqa: ARG002
+                return real.wrap_dek(dek, tenant_id=tenant_id, aad=b"")
+
+            def unwrap_dek(self, wrapped, *, tenant_id, aad, kek_version):  # noqa: ARG002
+                return real.unwrap_dek(
+                    wrapped, tenant_id=tenant_id, aad=b"", kek_version=kek_version
+                )
+
+        report = rotate_kek_for_tenant(
+            pg_engine,
+            tenant_id=tenant_id,
+            encryption_provider=_AadIgnoringProvider(),
+        )
+
+        assert report.rows_rewrapped == 0, "AAD-tampered row must not rotate"
+        assert report.rows_failed == 1, "AAD-tampered row must be counted as failed"
+
     def test_skiplist_uses_composite_principal_id_and_id(
         self,
         pg_engine: Engine,

--- a/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
+++ b/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
@@ -488,6 +488,144 @@ class TestRotateKEKFailures:
         assert report.rows_failed == 1
         assert report.rows_remaining == 1
 
+    def test_max_rows_does_not_count_failures(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        pg_engine: Engine,
+        tenant_id: uuid.UUID,
+        encryption_provider: InMemoryEncryptionProvider,
+    ) -> None:
+        """Regression: --max-rows caps successful rewraps, not total rows seen.
+
+        Previously ``max_rows=1`` would exit after one failure (rewrapped=0,
+        failed=1), starving healthy rows. Now failures are tracked separately
+        and the budget applies only to successful rewraps.
+        """
+        from nexus.bricks.auth.envelope import WrappedDEKInvalid
+
+        for i in range(3):
+            pg_store_crypto.upsert_with_credential(
+                make_profile(f"budget-{i}"),
+                ResolvedCredential(kind="api_key", api_key=f"k{i}"),
+            )
+        encryption_provider.rotate()
+
+        with pg_engine.begin() as conn:
+            conn.execute(text("SET LOCAL app.current_tenant = :tid"), {"tid": str(tenant_id)})
+            row = conn.execute(
+                text(
+                    "SELECT wrapped_dek FROM auth_profiles "
+                    "WHERE tenant_id = :tid AND id = 'budget-0'"
+                ),
+                {"tid": tenant_id},
+            ).fetchone()
+            assert row is not None
+            bad_wrapped = bytes(row.wrapped_dek)
+
+        real = encryption_provider
+
+        class _FailFirst:
+            def current_version(self, *, tenant_id):
+                return real.current_version(tenant_id=tenant_id)
+
+            def wrap_dek(self, dek, *, tenant_id, aad):
+                return real.wrap_dek(dek, tenant_id=tenant_id, aad=aad)
+
+            def unwrap_dek(self, wrapped, *, tenant_id, aad, kek_version):
+                if wrapped == bad_wrapped:
+                    raise WrappedDEKInvalid.from_row(
+                        tenant_id=tenant_id,
+                        profile_id="budget-0",
+                        kek_version=kek_version,
+                        cause="simulated",
+                    )
+                return real.unwrap_dek(
+                    wrapped, tenant_id=tenant_id, aad=aad, kek_version=kek_version
+                )
+
+        report = rotate_kek_for_tenant(
+            pg_engine,
+            tenant_id=tenant_id,
+            encryption_provider=_FailFirst(),
+            batch_size=1,
+            max_rows=1,
+        )
+        assert report.rows_rewrapped == 1, "one healthy row must rewrap within budget"
+        assert report.rows_failed == 1, "failure observed but does not consume budget"
+
+    def test_version_skew_raises_by_default(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        pg_engine: Engine,
+        tenant_id: uuid.UUID,
+        encryption_provider: InMemoryEncryptionProvider,
+    ) -> None:
+        """Regression: helper must raise VersionSkewError when rows exist at a
+        higher version than the provider's current, not silently report
+        success.
+        """
+        from nexus.bricks.auth.postgres_profile_store import VersionSkewError
+
+        pg_store_crypto.upsert_with_credential(
+            make_profile("skew-helper"),
+            ResolvedCredential(kind="api_key", api_key="s"),
+        )
+        with pg_engine.begin() as conn:
+            conn.execute(text("SET LOCAL app.current_tenant = :tid"), {"tid": str(tenant_id)})
+            conn.execute(
+                text(
+                    "UPDATE auth_profiles SET kek_version = 99 "
+                    "WHERE tenant_id = :tid AND id = 'skew-helper'"
+                ),
+                {"tid": tenant_id},
+            )
+
+        with pytest.raises(VersionSkewError) as exc_info:
+            rotate_kek_for_tenant(
+                pg_engine,
+                tenant_id=tenant_id,
+                encryption_provider=encryption_provider,
+            )
+        assert exc_info.value.rows_ahead == 1
+
+        # allow_skew=True suppresses the check
+        report = rotate_kek_for_tenant(
+            pg_engine,
+            tenant_id=tenant_id,
+            encryption_provider=encryption_provider,
+            allow_skew=True,
+        )
+        assert report.rows_rewrapped == 0  # nothing to rewrap — only ahead row exists
+        assert report.rows_remaining == 0
+
+    def test_plain_upsert_rejects_encrypted_row(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        pg_engine: Engine,  # noqa: ARG002
+        tenant_id: uuid.UUID,
+        principal_id: uuid.UUID,
+    ) -> None:
+        """Regression: plain upsert() cannot mutate routing metadata on a row
+        that already carries encrypted credentials, because the old ciphertext
+        would no longer match the updated backend_key.
+        """
+        pg_store_crypto.upsert_with_credential(
+            make_profile("enc-row"),
+            ResolvedCredential(kind="api_key", api_key="s"),
+        )
+        new_profile = make_profile("enc-row", backend_key="secret://different")
+
+        # Use a non-crypto store pointing at the same row — simulates a
+        # pre-envelope caller still holding the plain upsert path.
+        plain_store = PostgresAuthProfileStore(
+            PG_URL, tenant_id=tenant_id, principal_id=principal_id
+        )
+        try:
+            with pytest.raises(ValueError, match="encrypted credentials"):
+                plain_store.upsert(new_profile)
+        finally:
+            plain_store.close()
+
     def test_rejects_non_positive_batch_size(
         self,
         pg_engine: Engine,

--- a/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
+++ b/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
@@ -18,12 +18,16 @@ from sqlalchemy import create_engine, text
 from sqlalchemy.engine import Engine
 from sqlalchemy.exc import IntegrityError
 
+from nexus.bricks.auth.credential_backend import ResolvedCredential
+from nexus.bricks.auth.envelope_providers.in_memory import InMemoryEncryptionProvider
 from nexus.bricks.auth.postgres_profile_store import (
+    PostgresAuthProfileStore,
     drop_schema,
     ensure_principal,
     ensure_schema,
     ensure_tenant,
 )
+from nexus.bricks.auth.tests.conftest import make_profile
 
 PG_URL = os.environ.get(
     "TEST_POSTGRES_URL",
@@ -106,3 +110,91 @@ class TestSchema:
                     "a": b"a",
                 },
             )
+
+
+@pytest.fixture()
+def encryption_provider() -> InMemoryEncryptionProvider:
+    return InMemoryEncryptionProvider()
+
+
+@pytest.fixture()
+def pg_store_crypto(
+    pg_engine: Engine,
+    tenant_id: uuid.UUID,
+    principal_id: uuid.UUID,
+    encryption_provider: InMemoryEncryptionProvider,
+) -> Generator[PostgresAuthProfileStore, None, None]:
+    store = PostgresAuthProfileStore(
+        PG_URL,
+        tenant_id=tenant_id,
+        principal_id=principal_id,
+        engine=pg_engine,
+        encryption_provider=encryption_provider,
+    )
+    yield store
+    store.close()
+
+
+class TestEncryptedUpsertAndGet:
+    def test_roundtrip(self, pg_store_crypto: PostgresAuthProfileStore) -> None:
+        profile = make_profile("google/alice")
+        cred = ResolvedCredential(
+            kind="bearer_token",
+            access_token="ya29.fake",
+            scopes=("https://www.googleapis.com/auth/userinfo.email",),
+        )
+        pg_store_crypto.upsert_with_credential(profile, cred)
+        got = pg_store_crypto.get_with_credential("google/alice")
+        assert got is not None
+        p, c = got
+        assert p.id == "google/alice"
+        assert c is not None
+        assert c.access_token == "ya29.fake"
+        assert c.scopes == ("https://www.googleapis.com/auth/userinfo.email",)
+
+    def test_get_returns_none_for_missing(self, pg_store_crypto: PostgresAuthProfileStore) -> None:
+        assert pg_store_crypto.get_with_credential("does-not-exist") is None
+
+    def test_pr1_row_returns_none_credential(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        pg_engine: Engine,
+        tenant_id: uuid.UUID,
+        principal_id: uuid.UUID,
+    ) -> None:
+        """A row written via plain upsert reads back (profile, None)."""
+        plain_store = PostgresAuthProfileStore(
+            PG_URL,
+            tenant_id=tenant_id,
+            principal_id=principal_id,
+            engine=pg_engine,
+        )
+        plain_store.upsert(make_profile("openai/bob"))
+        got = pg_store_crypto.get_with_credential("openai/bob")
+        assert got is not None
+        p, c = got
+        assert p.id == "openai/bob"
+        assert c is None
+
+    def test_ctor_without_provider_rejects_crypto_methods(
+        self,
+        pg_engine: Engine,
+        tenant_id: uuid.UUID,
+        principal_id: uuid.UUID,
+    ) -> None:
+        store = PostgresAuthProfileStore(
+            PG_URL,
+            tenant_id=tenant_id,
+            principal_id=principal_id,
+            engine=pg_engine,
+        )
+        try:
+            with pytest.raises(RuntimeError, match="encryption_provider"):
+                store.upsert_with_credential(
+                    make_profile("x"),
+                    ResolvedCredential(kind="api_key", api_key="k"),
+                )
+            with pytest.raises(RuntimeError, match="encryption_provider"):
+                store.get_with_credential("x")
+        finally:
+            store.close()

--- a/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
+++ b/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
@@ -488,6 +488,128 @@ class TestRotateKEKFailures:
         assert report.rows_failed == 1
         assert report.rows_remaining == 1
 
+    def test_wrap_at_target_failure_aborts_batch(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        pg_engine: Engine,
+        tenant_id: uuid.UUID,
+        encryption_provider: InMemoryEncryptionProvider,
+    ) -> None:
+        """Regression: a wrap failure at the target version must abort the
+        batch rather than continue per-row. Otherwise a misconfigured target
+        KEK leaves the tenant with rows split across versions.
+        """
+        from nexus.bricks.auth.envelope import EnvelopeConfigurationError
+
+        for i in range(3):
+            pg_store_crypto.upsert_with_credential(
+                make_profile(f"wrap-{i}"),
+                ResolvedCredential(kind="api_key", api_key=f"k{i}"),
+            )
+        encryption_provider.rotate()
+
+        real = encryption_provider
+
+        class _WrapFailsProvider:
+            def current_version(self, *, tenant_id):
+                return real.current_version(tenant_id=tenant_id)
+
+            def wrap_dek(self, dek, *, tenant_id, aad):  # noqa: ARG002
+                raise EnvelopeConfigurationError("simulated bad target KEK")
+
+            def unwrap_dek(self, wrapped, *, tenant_id, aad, kek_version):
+                return real.unwrap_dek(
+                    wrapped, tenant_id=tenant_id, aad=aad, kek_version=kek_version
+                )
+
+        with pytest.raises(EnvelopeConfigurationError):
+            rotate_kek_for_tenant(
+                pg_engine,
+                tenant_id=tenant_id,
+                encryption_provider=_WrapFailsProvider(),
+            )
+
+        # No rows should be committed: every row must still be at v1.
+        with pg_engine.begin() as conn:
+            conn.execute(text("SET LOCAL app.current_tenant = :tid"), {"tid": str(tenant_id)})
+            versions = [
+                r[0]
+                for r in conn.execute(
+                    text(
+                        "SELECT DISTINCT kek_version FROM auth_profiles "
+                        "WHERE tenant_id = :tid AND ciphertext IS NOT NULL"
+                    ),
+                    {"tid": tenant_id},
+                ).fetchall()
+            ]
+        assert versions == [1], "wrap-fatal must not leave partial rewraps committed"
+
+    def test_concurrent_writer_does_not_block_on_slow_provider(
+        self,
+        pg_store_crypto: PostgresAuthProfileStore,
+        pg_engine: Engine,
+        tenant_id: uuid.UUID,
+        encryption_provider: InMemoryEncryptionProvider,
+    ) -> None:
+        """Regression: rotation must not hold row locks across provider calls.
+
+        Simulates a slow KMS/Vault call by sleeping inside wrap_dek. A
+        concurrent upsert_with_credential on the same row must be able to
+        commit without waiting for the provider RTT to finish.
+        """
+        import threading
+        import time
+
+        pg_store_crypto.upsert_with_credential(
+            make_profile("slow-provider"),
+            ResolvedCredential(kind="api_key", api_key="v1"),
+        )
+        encryption_provider.rotate()
+
+        real = encryption_provider
+        rotation_started = threading.Event()
+
+        class _SlowProvider:
+            def current_version(self, *, tenant_id):
+                return real.current_version(tenant_id=tenant_id)
+
+            def wrap_dek(self, dek, *, tenant_id, aad):
+                rotation_started.set()
+                time.sleep(2.0)  # simulate a slow KMS RTT
+                return real.wrap_dek(dek, tenant_id=tenant_id, aad=aad)
+
+            def unwrap_dek(self, wrapped, *, tenant_id, aad, kek_version):
+                return real.unwrap_dek(
+                    wrapped, tenant_id=tenant_id, aad=aad, kek_version=kek_version
+                )
+
+        def _rotate() -> None:
+            rotate_kek_for_tenant(
+                pg_engine,
+                tenant_id=tenant_id,
+                encryption_provider=_SlowProvider(),
+            )
+
+        t = threading.Thread(target=_rotate)
+        t.start()
+        try:
+            assert rotation_started.wait(timeout=5.0), "rotation failed to start"
+            # Rotation is now inside the slow wrap_dek. A concurrent write
+            # must not block on row locks; it should commit in well under the
+            # provider delay.
+            write_start = time.monotonic()
+            pg_store_crypto.upsert_with_credential(
+                make_profile("slow-provider"),
+                ResolvedCredential(kind="api_key", api_key="v2"),
+            )
+            write_elapsed = time.monotonic() - write_start
+            assert write_elapsed < 1.0, (
+                f"concurrent write took {write_elapsed:.2f}s while rotation held "
+                "locks across the provider call — lock scope too wide"
+            )
+        finally:
+            t.join(timeout=10)
+
     def test_max_rows_does_not_count_failures(
         self,
         pg_store_crypto: PostgresAuthProfileStore,

--- a/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
+++ b/src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py
@@ -1,0 +1,108 @@
+"""Integration tests for envelope encryption on PostgresAuthProfileStore (#3803).
+
+Postgres-gated; uses the same TEST_POSTGRES_URL + xdist_group shape as
+test_postgres_profile_store.py.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import Generator
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+from sqlalchemy.exc import IntegrityError
+
+from nexus.bricks.auth.postgres_profile_store import (
+    drop_schema,
+    ensure_principal,
+    ensure_schema,
+    ensure_tenant,
+)
+
+PG_URL = os.environ.get(
+    "TEST_POSTGRES_URL",
+    "postgresql+psycopg2://postgres:nexus@localhost:5432/nexus",
+)
+
+
+def _pg_is_available() -> bool:
+    try:
+        eng = create_engine(PG_URL)
+        with eng.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        eng.dispose()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = [
+    pytest.mark.postgres,
+    pytest.mark.xdist_group("postgres_auth_profile_store"),
+    pytest.mark.skipif(
+        not _pg_is_available(),
+        reason=(
+            "PostgreSQL not reachable at TEST_POSTGRES_URL. "
+            "Start with: docker compose -f dockerfiles/compose.yaml up postgres -d"
+        ),
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def pg_engine() -> Generator[Engine, None, None]:
+    engine = create_engine(PG_URL, future=True)
+    drop_schema(engine)
+    ensure_schema(engine)
+    yield engine
+    drop_schema(engine)
+    engine.dispose()
+
+
+@pytest.fixture()
+def tenant_id(pg_engine: Engine) -> uuid.UUID:
+    return ensure_tenant(pg_engine, f"env-tenant-{uuid.uuid4()}")
+
+
+@pytest.fixture()
+def principal_id(pg_engine: Engine, tenant_id: uuid.UUID) -> uuid.UUID:
+    return ensure_principal(
+        pg_engine,
+        tenant_id=tenant_id,
+        kind="human",
+        external_sub=f"sub-{uuid.uuid4()}",
+        auth_method="test",
+    )
+
+
+class TestSchema:
+    def test_check_constraint_rejects_half_written_row(
+        self, pg_engine: Engine, tenant_id: uuid.UUID, principal_id: uuid.UUID
+    ) -> None:
+        """Direct INSERT with 4 of 5 encryption columns set must fail."""
+        with pg_engine.begin() as conn, pytest.raises(IntegrityError):
+            conn.execute(
+                text(
+                    "INSERT INTO auth_profiles "
+                    "(tenant_id, principal_id, id, provider, account_identifier, "
+                    " backend, backend_key, "
+                    " ciphertext, wrapped_dek, nonce, aad) "  # 4 of 5, missing kek_version
+                    "VALUES "
+                    "(:tid, :pid, 'broken', 'p', 'p', 'b', 'k', "
+                    " :ct, :wd, :n, :a)"
+                ),
+                {
+                    "tid": tenant_id,
+                    "pid": principal_id,
+                    "ct": b"ct",
+                    "wd": b"wd",
+                    "n": b"n",
+                    "a": b"a",
+                },
+            )

--- a/src/nexus/bricks/auth/tests/test_rotate_kek_cli.py
+++ b/src/nexus/bricks/auth/tests/test_rotate_kek_cli.py
@@ -456,8 +456,8 @@ class TestRotateKekCLI:
             assert result.exit_code == 1, result.output
             assert "failed" in result.output.lower()
 
-            # With --allow-failures, exit 0 even with failed rows
-            # (Re-seed isn't needed; same rows are still at v1)
+            # With --allow-failures and --allow-partial, exit 0 even when
+            # rows still fail to rotate (they also count as "remaining").
             result2 = runner.invoke(
                 auth,
                 [
@@ -468,12 +468,163 @@ class TestRotateKekCLI:
                     str(t),
                     "--apply",
                     "--allow-failures",
+                    "--allow-partial",
                 ],
             )
             assert result2.exit_code == 0, result2.output
         finally:
             os.environ.pop("NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID", None)
             _TEST_PROVIDER_REGISTRY.pop("allfail", None)
+
+    def test_tenant_id_not_found_errors(
+        self,
+        pg_engine: Engine,  # noqa: ARG002 — fixture triggers schema setup
+    ) -> None:
+        """A syntactically valid but nonexistent --tenant-id must fail, not
+        silently no-op.
+        """
+        from nexus.bricks.auth.cli_commands import _TEST_PROVIDER_REGISTRY
+
+        prov = InMemoryEncryptionProvider()
+        _TEST_PROVIDER_REGISTRY["inmem"] = lambda: prov
+        os.environ["NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID"] = "inmem"
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                auth,
+                [
+                    "rotate-kek",
+                    "--db-url",
+                    PG_URL,
+                    "--tenant-id",
+                    "00000000-0000-0000-0000-ffffffffffff",
+                ],
+            )
+            assert result.exit_code != 0
+            assert "not found" in result.output.lower()
+        finally:
+            os.environ.pop("NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID", None)
+            _TEST_PROVIDER_REGISTRY.pop("inmem", None)
+
+    def test_version_skew_fails_fast(
+        self,
+        pg_engine: Engine,
+    ) -> None:
+        """Rows with kek_version > target (provider downgrade) must fail fast."""
+        from nexus.bricks.auth.cli_commands import _TEST_PROVIDER_REGISTRY
+
+        # Seed a row at v1, then hand-edit kek_version to v99 to simulate skew.
+        t = ensure_tenant(pg_engine, f"skew-{uuid.uuid4()}")
+        p = ensure_principal(
+            pg_engine, tenant_id=t, external_sub=f"s-{uuid.uuid4()}", auth_method="t"
+        )
+        prov = InMemoryEncryptionProvider()
+        store = PostgresAuthProfileStore(
+            PG_URL, tenant_id=t, principal_id=p, engine=pg_engine, encryption_provider=prov
+        )
+        try:
+            store.upsert_with_credential(
+                make_profile("skew"), ResolvedCredential(kind="api_key", api_key="k")
+            )
+        finally:
+            store.close()
+
+        with pg_engine.begin() as conn:
+            conn.execute(text("SET LOCAL app.current_tenant = :tid"), {"tid": str(t)})
+            conn.execute(
+                text(
+                    "UPDATE auth_profiles SET kek_version = 99 "
+                    "WHERE tenant_id = :tid AND id = 'skew'"
+                ),
+                {"tid": t},
+            )
+
+        _TEST_PROVIDER_REGISTRY["inmem"] = lambda: prov
+        os.environ["NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID"] = "inmem"
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                auth,
+                [
+                    "rotate-kek",
+                    "--db-url",
+                    PG_URL,
+                    "--tenant-id",
+                    str(t),
+                ],
+            )
+            assert result.exit_code != 0
+            assert "older version" in result.output.lower() or "> target" in result.output
+        finally:
+            os.environ.pop("NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID", None)
+            _TEST_PROVIDER_REGISTRY.pop("inmem", None)
+
+    def test_apply_exits_nonzero_on_remaining_rows(
+        self,
+        pg_engine: Engine,
+    ) -> None:
+        """After apply, rows_remaining > 0 must produce exit 1 unless
+        --allow-partial is set."""
+        from nexus.bricks.auth.cli_commands import _TEST_PROVIDER_REGISTRY
+
+        t = ensure_tenant(pg_engine, f"partial-{uuid.uuid4()}")
+        p = ensure_principal(
+            pg_engine, tenant_id=t, external_sub=f"s-{uuid.uuid4()}", auth_method="t"
+        )
+        prov = InMemoryEncryptionProvider()
+        store = PostgresAuthProfileStore(
+            PG_URL, tenant_id=t, principal_id=p, engine=pg_engine, encryption_provider=prov
+        )
+        try:
+            for i in range(3):
+                store.upsert_with_credential(
+                    make_profile(f"p-{i}"),
+                    ResolvedCredential(kind="api_key", api_key=f"k{i}"),
+                )
+        finally:
+            store.close()
+        prov.rotate()
+
+        _TEST_PROVIDER_REGISTRY["inmem"] = lambda: prov
+        os.environ["NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID"] = "inmem"
+        try:
+            runner = CliRunner()
+            # --max-rows=1 means only 1 row rotates; 2 remain.
+            result = runner.invoke(
+                auth,
+                [
+                    "rotate-kek",
+                    "--db-url",
+                    PG_URL,
+                    "--tenant-id",
+                    str(t),
+                    "--apply",
+                    "--max-rows",
+                    "1",
+                ],
+            )
+            assert result.exit_code == 1, result.output
+            assert "remain" in result.output.lower()
+
+            # --allow-partial should tolerate remaining rows.
+            result2 = runner.invoke(
+                auth,
+                [
+                    "rotate-kek",
+                    "--db-url",
+                    PG_URL,
+                    "--tenant-id",
+                    str(t),
+                    "--apply",
+                    "--max-rows",
+                    "1",
+                    "--allow-partial",
+                ],
+            )
+            assert result2.exit_code == 0, result2.output
+        finally:
+            os.environ.pop("NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID", None)
+            _TEST_PROVIDER_REGISTRY.pop("inmem", None)
 
     def test_no_provider_and_no_env_errors(
         self,

--- a/src/nexus/bricks/auth/tests/test_rotate_kek_cli.py
+++ b/src/nexus/bricks/auth/tests/test_rotate_kek_cli.py
@@ -1,0 +1,183 @@
+"""Tests for `nexus auth rotate-kek` (issue #3803)."""
+
+from __future__ import annotations
+
+import os
+import uuid
+from collections.abc import Generator
+
+import pytest
+
+pytest.importorskip("sqlalchemy")
+pytest.importorskip("click")
+
+from click.testing import CliRunner
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
+
+from nexus.bricks.auth.cli_commands import auth
+from nexus.bricks.auth.credential_backend import ResolvedCredential
+from nexus.bricks.auth.envelope_providers.in_memory import InMemoryEncryptionProvider
+from nexus.bricks.auth.postgres_profile_store import (
+    PostgresAuthProfileStore,
+    drop_schema,
+    ensure_principal,
+    ensure_schema,
+    ensure_tenant,
+)
+from nexus.bricks.auth.tests.conftest import make_profile
+
+PG_URL = os.environ.get(
+    "TEST_POSTGRES_URL",
+    "postgresql+psycopg2://postgres:nexus@localhost:5432/nexus",
+)
+
+
+def _pg_is_available() -> bool:
+    try:
+        eng = create_engine(PG_URL)
+        with eng.connect() as conn:
+            conn.execute(text("SELECT 1"))
+        eng.dispose()
+        return True
+    except Exception:
+        return False
+
+
+pytestmark = [
+    pytest.mark.postgres,
+    pytest.mark.xdist_group("postgres_auth_profile_store"),
+    pytest.mark.skipif(
+        not _pg_is_available(),
+        reason="PostgreSQL not reachable at TEST_POSTGRES_URL.",
+    ),
+]
+
+
+@pytest.fixture(scope="module")
+def pg_engine() -> Generator[Engine, None, None]:
+    engine = create_engine(PG_URL, future=True)
+    drop_schema(engine)
+    ensure_schema(engine)
+    yield engine
+    drop_schema(engine)
+    engine.dispose()
+
+
+@pytest.fixture()
+def seeded_tenant(
+    pg_engine: Engine,
+) -> Generator[tuple[uuid.UUID, InMemoryEncryptionProvider], None, None]:
+    """Return (tenant_id, encryption_provider) with 2 rows at v1, provider at v2."""
+    t = ensure_tenant(pg_engine, f"rot-{uuid.uuid4()}")
+    p = ensure_principal(pg_engine, tenant_id=t, external_sub=f"s-{uuid.uuid4()}", auth_method="t")
+    prov = InMemoryEncryptionProvider()
+    store = PostgresAuthProfileStore(
+        PG_URL, tenant_id=t, principal_id=p, engine=pg_engine, encryption_provider=prov
+    )
+    try:
+        store.upsert_with_credential(
+            make_profile("a"), ResolvedCredential(kind="api_key", api_key="k-a")
+        )
+        store.upsert_with_credential(
+            make_profile("b"), ResolvedCredential(kind="api_key", api_key="k-b")
+        )
+    finally:
+        store.close()
+    prov.rotate()
+    yield t, prov
+
+
+def _tenant_name(engine: Engine, tenant_id: uuid.UUID) -> str:
+    with engine.begin() as conn:
+        row = conn.execute(
+            text("SELECT name FROM tenants WHERE id = :tid"), {"tid": tenant_id}
+        ).fetchone()
+    assert row is not None
+    return row[0]
+
+
+class TestRotateKekCLI:
+    def test_dry_run_reports_counts_no_writes(
+        self,
+        seeded_tenant: tuple[uuid.UUID, InMemoryEncryptionProvider],
+        pg_engine: Engine,
+    ) -> None:
+        t, prov = seeded_tenant
+        from nexus.bricks.auth.cli_commands import _TEST_PROVIDER_REGISTRY
+
+        _TEST_PROVIDER_REGISTRY["inmem"] = lambda: prov
+        os.environ["NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID"] = "inmem"
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                auth,
+                [
+                    "rotate-kek",
+                    "--db-url",
+                    PG_URL,
+                    "--tenant",
+                    _tenant_name(pg_engine, t),
+                ],
+            )
+            assert result.exit_code == 0, result.output
+            assert "dry-run" in result.output.lower()
+            assert "2" in result.output  # 2 stale rows
+            # No writes: rows are still at v1
+            with pg_engine.begin() as conn:
+                conn.execute(text("SET LOCAL app.current_tenant = :tid"), {"tid": str(t)})
+                versions = sorted(
+                    r[0]
+                    for r in conn.execute(
+                        text(
+                            "SELECT kek_version FROM auth_profiles "
+                            "WHERE tenant_id = :tid AND ciphertext IS NOT NULL"
+                        ),
+                        {"tid": t},
+                    ).fetchall()
+                )
+            assert versions == [1, 1]
+        finally:
+            os.environ.pop("NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID", None)
+            _TEST_PROVIDER_REGISTRY.pop("inmem", None)
+
+    def test_apply_rewraps_all(
+        self,
+        seeded_tenant: tuple[uuid.UUID, InMemoryEncryptionProvider],
+        pg_engine: Engine,
+    ) -> None:
+        t, prov = seeded_tenant
+        from nexus.bricks.auth.cli_commands import _TEST_PROVIDER_REGISTRY
+
+        _TEST_PROVIDER_REGISTRY["inmem"] = lambda: prov
+        os.environ["NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID"] = "inmem"
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                auth,
+                [
+                    "rotate-kek",
+                    "--db-url",
+                    PG_URL,
+                    "--tenant",
+                    _tenant_name(pg_engine, t),
+                    "--apply",
+                ],
+            )
+            assert result.exit_code == 0, result.output
+            with pg_engine.begin() as conn:
+                conn.execute(text("SET LOCAL app.current_tenant = :tid"), {"tid": str(t)})
+                versions = [
+                    r[0]
+                    for r in conn.execute(
+                        text(
+                            "SELECT DISTINCT kek_version FROM auth_profiles "
+                            "WHERE tenant_id = :tid AND ciphertext IS NOT NULL"
+                        ),
+                        {"tid": t},
+                    ).fetchall()
+                ]
+            assert versions == [2]
+        finally:
+            os.environ.pop("NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID", None)
+            _TEST_PROVIDER_REGISTRY.pop("inmem", None)

--- a/src/nexus/bricks/auth/tests/test_rotate_kek_cli.py
+++ b/src/nexus/bricks/auth/tests/test_rotate_kek_cli.py
@@ -94,7 +94,7 @@ def _tenant_name(engine: Engine, tenant_id: uuid.UUID) -> str:
             text("SELECT name FROM tenants WHERE id = :tid"), {"tid": tenant_id}
         ).fetchone()
     assert row is not None
-    return row[0]
+    return str(row[0])
 
 
 class TestRotateKekCLI:
@@ -140,6 +140,125 @@ class TestRotateKekCLI:
         finally:
             os.environ.pop("NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID", None)
             _TEST_PROVIDER_REGISTRY.pop("inmem", None)
+
+    def test_apply_with_provider_vault_invokes_builder(
+        self,
+        seeded_tenant: tuple[uuid.UUID, InMemoryEncryptionProvider],
+        pg_engine: Engine,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """--provider vault constructs a VaultTransitProvider via the builder.
+
+        Regression for Codex round 2: the production wiring branches were
+        never exercised by tests, so option plumbing bugs could ship.
+        """
+        t, prov = seeded_tenant
+        called: dict[str, object] = {}
+
+        def fake_builder(
+            *, vault_addr, vault_token, vault_key, vault_mount
+        ) -> InMemoryEncryptionProvider:
+            called["vault_addr"] = vault_addr
+            called["vault_token"] = vault_token
+            called["vault_key"] = vault_key
+            called["vault_mount"] = vault_mount
+            return prov
+
+        monkeypatch.setattr("nexus.bricks.auth.cli_commands._build_vault_provider", fake_builder)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            auth,
+            [
+                "rotate-kek",
+                "--db-url",
+                PG_URL,
+                "--tenant",
+                _tenant_name(pg_engine, t),
+                "--provider",
+                "vault",
+                "--vault-addr",
+                "http://vault.example:8200",
+                "--vault-token",
+                "s.dummy",
+                "--vault-key",
+                "nexus",
+                "--apply",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        assert called["vault_addr"] == "http://vault.example:8200"
+        assert called["vault_token"] == "s.dummy"
+        assert called["vault_key"] == "nexus"
+        assert called["vault_mount"] == "transit"
+
+    def test_apply_with_provider_aws_kms_invokes_builder(
+        self,
+        seeded_tenant: tuple[uuid.UUID, InMemoryEncryptionProvider],
+        pg_engine: Engine,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """--provider aws-kms constructs an AwsKmsProvider via the builder."""
+        t, prov = seeded_tenant
+        called: dict[str, object] = {}
+
+        def fake_builder(
+            *, kms_key_id, kms_region, kms_config_version
+        ) -> InMemoryEncryptionProvider:
+            called["kms_key_id"] = kms_key_id
+            called["kms_region"] = kms_region
+            called["kms_config_version"] = kms_config_version
+            return prov
+
+        monkeypatch.setattr("nexus.bricks.auth.cli_commands._build_kms_provider", fake_builder)
+
+        runner = CliRunner()
+        result = runner.invoke(
+            auth,
+            [
+                "rotate-kek",
+                "--db-url",
+                PG_URL,
+                "--tenant",
+                _tenant_name(pg_engine, t),
+                "--provider",
+                "aws-kms",
+                "--kms-key-id",
+                "arn:aws:kms:us-east-1:000000000000:key/abc",
+                "--kms-region",
+                "us-east-1",
+                "--kms-config-version",
+                "3",
+                "--apply",
+            ],
+        )
+        assert result.exit_code == 0, result.output
+        kms_key_id = called["kms_key_id"]
+        assert isinstance(kms_key_id, str) and kms_key_id.startswith("arn:aws:kms:")
+        assert called["kms_region"] == "us-east-1"
+        assert called["kms_config_version"] == 3
+
+    def test_no_provider_and_no_env_errors(
+        self,
+        seeded_tenant: tuple[uuid.UUID, InMemoryEncryptionProvider],
+        pg_engine: Engine,
+    ) -> None:
+        """Omitting --provider without the test env var must fail cleanly."""
+        t, _ = seeded_tenant
+        os.environ.pop("NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID", None)
+        runner = CliRunner()
+        result = runner.invoke(
+            auth,
+            [
+                "rotate-kek",
+                "--db-url",
+                PG_URL,
+                "--tenant",
+                _tenant_name(pg_engine, t),
+            ],
+        )
+        assert result.exit_code != 0
+        assert "--provider is required" in result.output
 
     def test_apply_rewraps_all(
         self,

--- a/src/nexus/bricks/auth/tests/test_rotate_kek_cli.py
+++ b/src/nexus/bricks/auth/tests/test_rotate_kek_cli.py
@@ -345,6 +345,136 @@ class TestRotateKekCLI:
             os.environ.pop("NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID", None)
             _TEST_PROVIDER_REGISTRY.pop("inmem", None)
 
+    def test_tenant_id_flag_bypasses_name_lookup(
+        self,
+        seeded_tenant: tuple[uuid.UUID, InMemoryEncryptionProvider],
+        pg_engine: Engine,  # noqa: ARG002 — fixture triggers schema+seed
+    ) -> None:
+        """--tenant-id skips the tenants.name SELECT (which FORCE RLS can block
+        for least-privilege roles).
+        """
+        t, prov = seeded_tenant
+        from nexus.bricks.auth.cli_commands import _TEST_PROVIDER_REGISTRY
+
+        _TEST_PROVIDER_REGISTRY["inmem"] = lambda: prov
+        os.environ["NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID"] = "inmem"
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                auth,
+                [
+                    "rotate-kek",
+                    "--db-url",
+                    PG_URL,
+                    "--tenant-id",
+                    str(t),
+                ],
+            )
+            assert result.exit_code == 0, result.output
+            assert "dry-run" in result.output.lower()
+        finally:
+            os.environ.pop("NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID", None)
+            _TEST_PROVIDER_REGISTRY.pop("inmem", None)
+
+    def test_requires_exactly_one_tenant_identifier(
+        self,
+        seeded_tenant: tuple[uuid.UUID, InMemoryEncryptionProvider],
+        pg_engine: Engine,  # noqa: ARG002
+    ) -> None:
+        """Exactly one of --tenant / --tenant-id must be supplied."""
+        _t, prov = seeded_tenant
+        from nexus.bricks.auth.cli_commands import _TEST_PROVIDER_REGISTRY
+
+        _TEST_PROVIDER_REGISTRY["inmem"] = lambda: prov
+        os.environ["NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID"] = "inmem"
+        try:
+            runner = CliRunner()
+            result = runner.invoke(auth, ["rotate-kek", "--db-url", PG_URL])
+            assert result.exit_code != 0
+            assert "exactly one" in result.output.lower()
+
+            result2 = runner.invoke(
+                auth,
+                [
+                    "rotate-kek",
+                    "--db-url",
+                    PG_URL,
+                    "--tenant",
+                    "x",
+                    "--tenant-id",
+                    "00000000-0000-0000-0000-000000000001",
+                ],
+            )
+            assert result2.exit_code != 0
+        finally:
+            os.environ.pop("NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID", None)
+            _TEST_PROVIDER_REGISTRY.pop("inmem", None)
+
+    def test_apply_exits_nonzero_on_failed_rows(
+        self,
+        seeded_tenant: tuple[uuid.UUID, InMemoryEncryptionProvider],
+        pg_engine: Engine,  # noqa: ARG002
+    ) -> None:
+        """rows_failed > 0 must produce exit code 1 unless --allow-failures."""
+        from nexus.bricks.auth.cli_commands import _TEST_PROVIDER_REGISTRY
+
+        t, real = seeded_tenant
+
+        # Flaky provider that always fails unwrap (turns every row into failure)
+        class _AllFailProvider:
+            def current_version(self, *, tenant_id):
+                return real.current_version(tenant_id=tenant_id)
+
+            def wrap_dek(self, dek, *, tenant_id, aad):
+                return real.wrap_dek(dek, tenant_id=tenant_id, aad=aad)
+
+            def unwrap_dek(self, wrapped, *, tenant_id, aad, kek_version):  # noqa: ARG002
+                from nexus.bricks.auth.envelope import WrappedDEKInvalid
+
+                raise WrappedDEKInvalid.from_row(
+                    tenant_id=tenant_id,
+                    profile_id="x",
+                    kek_version=kek_version,
+                    cause="forced-failure",
+                )
+
+        _TEST_PROVIDER_REGISTRY["allfail"] = _AllFailProvider
+        os.environ["NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID"] = "allfail"
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                auth,
+                [
+                    "rotate-kek",
+                    "--db-url",
+                    PG_URL,
+                    "--tenant-id",
+                    str(t),
+                    "--apply",
+                ],
+            )
+            assert result.exit_code == 1, result.output
+            assert "failed" in result.output.lower()
+
+            # With --allow-failures, exit 0 even with failed rows
+            # (Re-seed isn't needed; same rows are still at v1)
+            result2 = runner.invoke(
+                auth,
+                [
+                    "rotate-kek",
+                    "--db-url",
+                    PG_URL,
+                    "--tenant-id",
+                    str(t),
+                    "--apply",
+                    "--allow-failures",
+                ],
+            )
+            assert result2.exit_code == 0, result2.output
+        finally:
+            os.environ.pop("NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID", None)
+            _TEST_PROVIDER_REGISTRY.pop("allfail", None)
+
     def test_no_provider_and_no_env_errors(
         self,
         seeded_tenant: tuple[uuid.UUID, InMemoryEncryptionProvider],

--- a/src/nexus/bricks/auth/tests/test_rotate_kek_cli.py
+++ b/src/nexus/bricks/auth/tests/test_rotate_kek_cli.py
@@ -238,6 +238,113 @@ class TestRotateKekCLI:
         assert called["kms_region"] == "us-east-1"
         assert called["kms_config_version"] == 3
 
+    def test_rejects_non_positive_batch_size(
+        self,
+        seeded_tenant: tuple[uuid.UUID, InMemoryEncryptionProvider],
+        pg_engine: Engine,
+    ) -> None:
+        """--batch-size must be >= 1 (click.IntRange)."""
+        t, prov = seeded_tenant
+        from nexus.bricks.auth.cli_commands import _TEST_PROVIDER_REGISTRY
+
+        _TEST_PROVIDER_REGISTRY["inmem"] = lambda: prov
+        os.environ["NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID"] = "inmem"
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                auth,
+                [
+                    "rotate-kek",
+                    "--db-url",
+                    PG_URL,
+                    "--tenant",
+                    _tenant_name(pg_engine, t),
+                    "--batch-size",
+                    "0",
+                    "--apply",
+                ],
+            )
+            assert result.exit_code != 0
+            assert "batch-size" in result.output.lower() or "0" in result.output
+        finally:
+            os.environ.pop("NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID", None)
+            _TEST_PROVIDER_REGISTRY.pop("inmem", None)
+
+    def test_preflight_fails_when_envelope_columns_missing(
+        self,
+        seeded_tenant: tuple[uuid.UUID, InMemoryEncryptionProvider],
+        pg_engine: Engine,
+    ) -> None:
+        """Rotation does not run DDL; it only reads information_schema.
+
+        Regression for Codex round 3: operators should get a clear migration-
+        required error instead of rotate-kek silently running ALTER TABLE
+        under a potentially under-privileged DB role.
+        """
+        t, prov = seeded_tenant
+        from nexus.bricks.auth.cli_commands import _TEST_PROVIDER_REGISTRY
+
+        _TEST_PROVIDER_REGISTRY["inmem"] = lambda: prov
+        os.environ["NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID"] = "inmem"
+        try:
+            with pg_engine.begin() as conn:
+                conn.execute(text("ALTER TABLE auth_profiles DROP COLUMN IF EXISTS kek_version"))
+            try:
+                runner = CliRunner()
+                result = runner.invoke(
+                    auth,
+                    [
+                        "rotate-kek",
+                        "--db-url",
+                        PG_URL,
+                        "--tenant",
+                        _tenant_name(pg_engine, t),
+                    ],
+                )
+                assert result.exit_code != 0
+                assert "kek_version" in result.output or "envelope columns" in result.output
+            finally:
+                with pg_engine.begin() as conn:
+                    conn.execute(
+                        text(
+                            "ALTER TABLE auth_profiles ADD COLUMN IF NOT EXISTS kek_version INTEGER"
+                        )
+                    )
+        finally:
+            os.environ.pop("NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID", None)
+            _TEST_PROVIDER_REGISTRY.pop("inmem", None)
+
+    def test_rejects_non_positive_max_rows(
+        self,
+        seeded_tenant: tuple[uuid.UUID, InMemoryEncryptionProvider],
+        pg_engine: Engine,
+    ) -> None:
+        """--max-rows must be >= 1 (click.IntRange)."""
+        t, prov = seeded_tenant
+        from nexus.bricks.auth.cli_commands import _TEST_PROVIDER_REGISTRY
+
+        _TEST_PROVIDER_REGISTRY["inmem"] = lambda: prov
+        os.environ["NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID"] = "inmem"
+        try:
+            runner = CliRunner()
+            result = runner.invoke(
+                auth,
+                [
+                    "rotate-kek",
+                    "--db-url",
+                    PG_URL,
+                    "--tenant",
+                    _tenant_name(pg_engine, t),
+                    "--max-rows",
+                    "-5",
+                    "--apply",
+                ],
+            )
+            assert result.exit_code != 0
+        finally:
+            os.environ.pop("NEXUS_AUTH_ROTATE_KEK_TEST_PROVIDER_ID", None)
+            _TEST_PROVIDER_REGISTRY.pop("inmem", None)
+
     def test_no_provider_and_no_env_errors(
         self,
         seeded_tenant: tuple[uuid.UUID, InMemoryEncryptionProvider],

--- a/uv.lock
+++ b/uv.lock
@@ -1603,6 +1603,18 @@ wheels = [
 ]
 
 [[package]]
+name = "hvac"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e2/57/b46c397fb3842cfb02a44609aa834c887f38dd75f290c2fc5a34da4b2fee/hvac-2.4.0.tar.gz", hash = "sha256:e0056ad9064e7923e874e6769015b032580b639e29246f5ab1044f7959c1c7e0", size = 332543 }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/55/33/71e45a6bd6875f44a26f99da31c63b6840123e88bedf2c0b1ce429b8be12/hvac-2.4.0-py3-none-any.whl", hash = "sha256:008db5efd8c2f77bd37d2368ea5f713edceae1c65f11fd608393179478649e0f", size = 155921 },
+]
+
+[[package]]
 name = "hyperframe"
 version = "6.1.0"
 source = { registry = "https://pypi.org/simple" }
@@ -2435,6 +2447,9 @@ all = [
     { name = "sqlite-vec" },
     { name = "txtai", extra = ["database", "graph"], marker = "platform_machine != 'x86_64' or sys_platform != 'darwin'" },
 ]
+aws = [
+    { name = "boto3" },
+]
 cloud-sql = [
     { name = "cloud-sql-python-connector", extra = ["asyncpg"] },
 ]
@@ -2537,6 +2552,9 @@ test = [
     { name = "pytest-mock" },
     { name = "pytest-xdist" },
 ]
+vault = [
+    { name = "hvac" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -2565,6 +2583,7 @@ requires-dist = [
     { name = "blake3", specifier = ">=1.0.0" },
     { name = "bm25s", specifier = ">=0.2.0" },
     { name = "boto3", specifier = ">=1.42.4" },
+    { name = "boto3", marker = "extra == 'aws'", specifier = ">=1.34.0" },
     { name = "bsdiff4", specifier = ">=1.2.0" },
     { name = "cachebox", specifier = ">=4.0.0" },
     { name = "cachetools", specifier = ">=6.2.2" },
@@ -2596,6 +2615,7 @@ requires-dist = [
     { name = "greenlet", specifier = ">=3.0.0" },
     { name = "grpcio", specifier = ">=1.78.0" },
     { name = "httpx", extras = ["http2"], specifier = ">=0.28.1" },
+    { name = "hvac", marker = "extra == 'vault'", specifier = ">=1.2.0" },
     { name = "hypothesis", marker = "extra == 'dev'", specifier = ">=6.0.0" },
     { name = "hypothesis", marker = "extra == 'test'", specifier = ">=6.0.0" },
     { name = "import-linter", marker = "extra == 'dev'", specifier = ">=2.0" },
@@ -2691,7 +2711,7 @@ requires-dist = [
     { name = "uvloop", marker = "sys_platform != 'win32'", specifier = ">=0.22.1" },
     { name = "watchfiles", specifier = ">=1.0.0" },
 ]
-provides-extras = ["performance", "pay", "monitoring", "mobile", "sandbox-monty", "sentry", "profiling", "dev", "test", "fuse", "postgres", "cloud-sql", "semantic-search", "semantic-search-remote", "e2b", "docker", "kafka", "nats-export", "pubsub", "sse", "event-streaming", "all"]
+provides-extras = ["performance", "pay", "monitoring", "mobile", "sandbox-monty", "sentry", "profiling", "vault", "aws", "dev", "test", "fuse", "postgres", "cloud-sql", "semantic-search", "semantic-search-remote", "e2b", "docker", "kafka", "nats-export", "pubsub", "sse", "event-streaming", "all"]
 
 [package.metadata.requires-dev]
 dev = [


### PR DESCRIPTION
Closes #3803. Phase C of epic #3788 (PR 2 of 3).

## Summary

- Adds server-side envelope encryption rails to `PostgresAuthProfileStore` so rows can carry resolved credentials alongside routing metadata. PR 1 (#3802) rows stay readable — encryption is opt-in per call via a new `CredentialCarryingProfileStore(AuthProfileStore)` sub-protocol.
- New `EncryptionProvider` trait (`envelope.py`) with three impls: `InMemoryEncryptionProvider` (test fake with real AEAD), `VaultTransitProvider` (opt-in, `hvac` lazy-import), `AwsKmsProvider` (opt-in, `boto3` lazy-import). Per-tenant scoping threads through via `tenant_id` on every op (Vault derivation context / KMS EncryptionContext). AES-256-GCM DEK per row, AAD binds `tenant_id|principal_id|profile_id` at both the column-check and AEAD-tag level.
- CLI: `nexus auth rotate-kek --db-url --tenant [--apply] [--batch-size] [--max-rows]` — dry-run by default, `SKIP LOCKED` resumable batches, per-row failures contained.
- Thread-safe `DEKCache` with TTL + LRU; Prometheus metrics (cache hits/misses, unwrap latency+errors, rotation rows). Low-cardinality labels only.
- Spec: `docs/superpowers/specs/2026-04-18-issue-3803-envelope-encryption-design.md`. Deployment guide: `docs/guides/auth-envelope-encryption.md`.

## Acceptance criteria (from #3803)

- [x] ``EncryptionProvider`` trait + both implementations with contract tests
- [x] Roundtrip test: encrypt in store, decrypt, read back plaintext
- [x] Ciphertext-swap attack rejected (copy row A's envelope into tenant B → ``AADMismatch`` or ``WrappedDEKInvalid``)
- [x] Rotation path: bump ``kek_version``, CLI-driven job migrates rows, reads succeed throughout (mixed-version test covers mid-rotation reads)
- [x] DEK cache hit/miss metrics expose whether the cache is amortizing calls (``test_two_reads_one_unwrap``)
- [x] Docs: Vault vs AWS-native deployment guidance

## Out of scope (explicit)

- Daemon-side client encryption — Phase D (PR 3/3)
- HSM integration — overkill at current scale
- Custom in-process AES — use Vault Transit or cloud KMS

## Test plan

- [x] ``pytest src/nexus/bricks/auth/tests/test_envelope.py`` — 22 unit tests (AESGCM primitive, ``EnvelopeError`` repr discipline, ``DEKCache`` TTL/LRU/thread-safety, ``InMemoryEncryptionProvider`` + counters)
- [x] ``pytest src/nexus/bricks/auth/tests/test_envelope_contract.py`` — 3 shared contract tests against ``InMemoryEncryptionProvider``
- [x] ``pytest src/nexus/bricks/auth/tests/test_postgres_envelope_integration.py`` (with a running Postgres) — 13 integration tests: schema CHECK constraint, roundtrip, PR 1 compat, swap-attack rejection, mixed-version reads, cache amortization, AAD tamper rejection, rotation (noop / stale / max-rows), per-row failure continuation
- [x] ``pytest src/nexus/bricks/auth/tests/test_rotate_kek_cli.py`` — CLI dry-run + apply
- [x] ``pytest src/nexus/bricks/auth/tests/test_envelope_providers_vault.py`` — skips cleanly when no Vault dev server; runs the shared contract suite against ``VaultTransitProvider`` when ``VAULT_ADDR`` is reachable with a ``derived=true`` transit key
- [x] ``pytest src/nexus/bricks/auth/tests/test_envelope_providers_aws_kms.py`` — skips cleanly when no KMS / LocalStack; runs against ``AwsKmsProvider`` when ``AWS_KMS_KEY_ID`` is set
- [x] ``pytest src/nexus/bricks/auth/tests/test_postgres_profile_store.py`` — pre-existing PR 1 suite still green (no schema regressions)
- [ ] Reviewer: sanity-check the AAD binding tuple (``tenant_id|principal_id|profile_id``) and the all-or-none ``CHECK`` constraint
- [ ] Reviewer: confirm comfort with the test-only ``_TEST_PROVIDER_REGISTRY`` seam in ``cli_commands.py`` (goes away when Phase D wires a real provider factory)