### PR TITLE
fix(kernel): harden correctness and concurrency fast paths

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1292,6 +1292,7 @@ dependencies = [
  "criterion",
  "dashmap",
  "encoding_rs",
+ "futures-util",
  "globset",
  "hmac",
  "libc",

--- a/rust/kernel/Cargo.toml
+++ b/rust/kernel/Cargo.toml
@@ -36,17 +36,18 @@ crc32fast = { workspace = true }
 transport = { workspace = true }
 tonic = { workspace = true }
 prost = { workspace = true }
-tokio = { version = "1", features = ["rt", "net", "sync"] }
+tokio = { version = "1", features = ["rt", "rt-multi-thread", "net", "sync"] }
 reqwest = { version = "0.12", features = ["json", "stream", "rustls-tls"], default-features = false, optional = true }
 hmac = { version = "0.12", optional = true }
 sha2 = { version = "0.10", optional = true }
+futures-util = { version = "0.3", default-features = false, optional = true }
 chrono = { version = "0.4", default-features = false, features = ["std", "clock"] }
 mimalloc = { workspace = true, optional = true }
 
 [features]
 default = ["mimalloc", "connectors", "py-hook-adapters"]
 mimalloc = ["dep:mimalloc"]
-connectors = ["dep:reqwest", "dep:hmac", "dep:sha2"]
+connectors = ["dep:reqwest", "dep:hmac", "dep:sha2", "dep:futures-util"]
 # §11 Phase 14: Python hook/resolver adapters. Enabled by default (POST hooks
 # still use PyInterceptHookAdapter). Disable to compile out all Python-to-Rust
 # adapter bridging — requires ALL hooks to be NativeInterceptHook impls.

--- a/rust/kernel/src/agent_registry.rs
+++ b/rust/kernel/src/agent_registry.rs
@@ -193,28 +193,22 @@ impl AgentRegistry {
 
 /// PathResolver for /{zone}/proc/{pid}/status — reads from kernel AgentRegistry.
 ///
-/// Registered in Kernel's Trie at boot time.
-/// try_read returns JSON-serialized agent status.
+/// Registered in Kernel's Trie at boot time. `try_read` returns JSON-serialized
+/// agent status. Ownership is shared via `Arc`, so the resolver remains
+/// valid for as long as any caller holds it, independent of the Kernel's
+/// lifetime or field layout (§ review fix #4).
 pub(crate) struct AgentStatusResolver {
-    registry: *const AgentRegistry,
+    registry: std::sync::Arc<AgentRegistry>,
 }
 
-// Safety: AgentRegistry is behind DashMap (Send+Sync). The pointer is stable
-// because AgentRegistry lives inside Kernel which is heap-pinned by PyKernel.
-unsafe impl Send for AgentStatusResolver {}
-unsafe impl Sync for AgentStatusResolver {}
-
 impl AgentStatusResolver {
-    /// Create resolver pointing to kernel's agent registry.
-    ///
-    /// # Safety
-    /// The registry pointer must remain valid for the lifetime of this resolver.
-    pub(crate) unsafe fn new(registry: *const AgentRegistry) -> Self {
+    /// Create resolver sharing ownership of an agent registry.
+    pub(crate) fn new(registry: std::sync::Arc<AgentRegistry>) -> Self {
         Self { registry }
     }
 
     fn registry(&self) -> &AgentRegistry {
-        unsafe { &*self.registry }
+        &self.registry
     }
 }
 
@@ -227,19 +221,24 @@ impl PathResolver for AgentStatusResolver {
         }
         let pid = segments[2];
         let desc = self.registry().get(pid)?;
-        // Serialize to JSON
-        let json = format!(
-            r#"{{"pid":"{}","name":"{}","kind":"{}","state":"{}","owner_id":"{}","zone_id":"{}","created_at_ms":{},"exit_code":{}}}"#,
-            desc.pid,
-            desc.name,
-            desc.kind.as_str(),
-            desc.state.as_str(),
-            desc.owner_id,
-            desc.zone_id,
-            desc.created_at_ms,
-            desc.exit_code.map_or("null".to_string(), |c| c.to_string()),
-        );
-        Some(json.into_bytes())
+
+        // Use serde_json so any special character in a user-controlled field
+        // (pid, name, owner_id, zone_id) is escaped correctly instead of
+        // producing syntactically invalid JSON (§ review fix #6).
+        let value = serde_json::json!({
+            "pid": desc.pid,
+            "name": desc.name,
+            "kind": desc.kind.as_str(),
+            "state": desc.state.as_str(),
+            "owner_id": desc.owner_id,
+            "zone_id": desc.zone_id,
+            "created_at_ms": desc.created_at_ms,
+            "exit_code": desc.exit_code,
+        });
+        Some(
+            serde_json::to_vec(&value)
+                .unwrap_or_else(|_| b"{\"error\":\"serialization failed\"}".to_vec()),
+        )
     }
 
     fn try_write(&self, _path: &str, _content: &[u8]) -> Option<()> {
@@ -399,9 +398,9 @@ mod tests {
 
     #[test]
     fn test_agent_status_resolver() {
-        let reg = AgentRegistry::new();
+        let reg = std::sync::Arc::new(AgentRegistry::new());
         reg.register(make_desc("abc123", "test-agent"));
-        let resolver = unsafe { AgentStatusResolver::new(&reg as *const AgentRegistry) };
+        let resolver = AgentStatusResolver::new(std::sync::Arc::clone(&reg));
         let data = resolver.try_read("/zone1/proc/abc123/status").unwrap();
         let json = String::from_utf8(data).unwrap();
         assert!(json.contains("\"pid\":\"abc123\""));

--- a/rust/kernel/src/bitmap.rs
+++ b/rust/kernel/src/bitmap.rs
@@ -5,27 +5,38 @@ use pyo3::types::PyDict;
 use rayon::prelude::*;
 use roaring::RoaringBitmap;
 
+/// Copy the Python-owned bytes into an owned `Vec<u8>` so the subsequent
+/// deserialization + filter can run without holding the GIL
+/// (§ review fix #16). Also centralizes the error message.
+#[inline]
+fn deserialize_bitmap(bitmap_bytes: Vec<u8>) -> Result<RoaringBitmap, pyo3::PyErr> {
+    RoaringBitmap::deserialize_from(bitmap_bytes.as_slice()).map_err(|e| {
+        pyo3::exceptions::PyValueError::new_err(format!(
+            "Failed to deserialize Tiger Cache bitmap: {e}"
+        ))
+    })
+}
+
 /// Filter path IDs using a pre-materialized Tiger Cache bitmap.
 #[pyfunction]
 pub fn filter_paths_with_tiger_cache(
     py: Python<'_>,
     path_int_ids: Vec<u32>,
-    bitmap_bytes: &[u8],
+    bitmap_bytes: Vec<u8>,
 ) -> PyResult<Vec<u32>> {
-    let bitmap = RoaringBitmap::deserialize_from(bitmap_bytes).map_err(|e| {
-        pyo3::exceptions::PyValueError::new_err(format!(
-            "Failed to deserialize Tiger Cache bitmap: {}",
-            e
-        ))
-    })?;
-
-    let accessible = py.detach(|| {
-        path_int_ids
-            .into_iter()
-            .filter(|&id| bitmap.contains(id))
-            .collect::<Vec<u32>>()
+    let (err, accessible) = py.detach(|| match deserialize_bitmap(bitmap_bytes) {
+        Ok(bitmap) => (
+            None,
+            path_int_ids
+                .into_iter()
+                .filter(|&id| bitmap.contains(id))
+                .collect::<Vec<u32>>(),
+        ),
+        Err(e) => (Some(e), Vec::new()),
     });
-
+    if let Some(e) = err {
+        return Err(e);
+    }
     Ok(accessible)
 }
 
@@ -34,31 +45,30 @@ pub fn filter_paths_with_tiger_cache(
 pub fn filter_paths_with_tiger_cache_parallel(
     py: Python<'_>,
     path_int_ids: Vec<u32>,
-    bitmap_bytes: &[u8],
+    bitmap_bytes: Vec<u8>,
 ) -> PyResult<Vec<u32>> {
-    let bitmap = RoaringBitmap::deserialize_from(bitmap_bytes).map_err(|e| {
-        pyo3::exceptions::PyValueError::new_err(format!(
-            "Failed to deserialize Tiger Cache bitmap: {}",
-            e
-        ))
-    })?;
-
     const PARALLEL_THRESHOLD: usize = 1000;
 
-    let accessible = py.detach(|| {
-        if path_int_ids.len() > PARALLEL_THRESHOLD {
-            path_int_ids
-                .into_par_iter()
-                .filter(|&id| bitmap.contains(id))
-                .collect::<Vec<u32>>()
-        } else {
-            path_int_ids
-                .into_iter()
-                .filter(|&id| bitmap.contains(id))
-                .collect::<Vec<u32>>()
+    let (err, accessible) = py.detach(|| match deserialize_bitmap(bitmap_bytes) {
+        Ok(bitmap) => {
+            let out = if path_int_ids.len() > PARALLEL_THRESHOLD {
+                path_int_ids
+                    .into_par_iter()
+                    .filter(|&id| bitmap.contains(id))
+                    .collect::<Vec<u32>>()
+            } else {
+                path_int_ids
+                    .into_iter()
+                    .filter(|&id| bitmap.contains(id))
+                    .collect::<Vec<u32>>()
+            };
+            (None, out)
         }
+        Err(e) => (Some(e), Vec::new()),
     });
-
+    if let Some(e) = err {
+        return Err(e);
+    }
     Ok(accessible)
 }
 
@@ -67,21 +77,19 @@ pub fn filter_paths_with_tiger_cache_parallel(
 pub fn intersect_paths_with_tiger_cache(
     py: Python<'_>,
     path_int_ids: Vec<u32>,
-    bitmap_bytes: &[u8],
+    bitmap_bytes: Vec<u8>,
 ) -> PyResult<Vec<u32>> {
-    let bitmap = RoaringBitmap::deserialize_from(bitmap_bytes).map_err(|e| {
-        pyo3::exceptions::PyValueError::new_err(format!(
-            "Failed to deserialize Tiger Cache bitmap: {}",
-            e
-        ))
-    })?;
-
-    let result = py.detach(|| {
-        let input_bitmap: RoaringBitmap = path_int_ids.into_iter().collect();
-        let intersection = input_bitmap & bitmap;
-        intersection.iter().collect::<Vec<u32>>()
+    let (err, result) = py.detach(|| match deserialize_bitmap(bitmap_bytes) {
+        Ok(bitmap) => {
+            let input_bitmap: RoaringBitmap = path_int_ids.into_iter().collect();
+            let intersection = input_bitmap & bitmap;
+            (None, intersection.iter().collect::<Vec<u32>>())
+        }
+        Err(e) => (Some(e), Vec::new()),
     });
-
+    if let Some(e) = err {
+        return Err(e);
+    }
     Ok(result)
 }
 
@@ -90,32 +98,30 @@ pub fn intersect_paths_with_tiger_cache(
 pub fn any_path_accessible_tiger_cache(
     py: Python<'_>,
     path_int_ids: Vec<u32>,
-    bitmap_bytes: &[u8],
+    bitmap_bytes: Vec<u8>,
 ) -> PyResult<bool> {
-    let bitmap = RoaringBitmap::deserialize_from(bitmap_bytes).map_err(|e| {
-        pyo3::exceptions::PyValueError::new_err(format!(
-            "Failed to deserialize Tiger Cache bitmap: {}",
-            e
-        ))
-    })?;
-
-    let result = py.detach(|| path_int_ids.iter().any(|&id| bitmap.contains(id)));
-
+    let (err, result) = py.detach(|| match deserialize_bitmap(bitmap_bytes) {
+        Ok(bitmap) => (None, path_int_ids.iter().any(|&id| bitmap.contains(id))),
+        Err(e) => (Some(e), false),
+    });
+    if let Some(e) = err {
+        return Err(e);
+    }
     Ok(result)
 }
 
 /// Get statistics about a Tiger Cache bitmap.
 #[pyfunction]
-pub fn tiger_cache_bitmap_stats(py: Python<'_>, bitmap_bytes: &[u8]) -> PyResult<Py<PyAny>> {
+pub fn tiger_cache_bitmap_stats(py: Python<'_>, bitmap_bytes: Vec<u8>) -> PyResult<Py<PyAny>> {
     let serialized_len = bitmap_bytes.len();
-    let bitmap = RoaringBitmap::deserialize_from(bitmap_bytes).map_err(|e| {
-        pyo3::exceptions::PyValueError::new_err(format!(
-            "Failed to deserialize Tiger Cache bitmap: {}",
-            e
-        ))
-    })?;
-
-    let (cardinality, is_empty) = py.detach(|| (bitmap.len(), bitmap.is_empty()));
+    let (err, card_empty) = py.detach(|| match deserialize_bitmap(bitmap_bytes) {
+        Ok(bitmap) => (None, (bitmap.len(), bitmap.is_empty())),
+        Err(e) => (Some(e), (0, true)),
+    });
+    if let Some(e) = err {
+        return Err(e);
+    }
+    let (cardinality, is_empty) = card_empty;
 
     let dict = PyDict::new(py);
     dict.set_item("cardinality", cardinality)?;

--- a/rust/kernel/src/bloom.rs
+++ b/rust/kernel/src/bloom.rs
@@ -5,9 +5,13 @@ use pyo3::prelude::*;
 use std::sync::RwLock;
 
 /// Bloom filter for fast cache miss detection.
+///
+/// §review fix #17: store the filter over `str` (`Bloom<str>`) so `set`/
+/// `check` accept a borrowed `&str` directly; previously we allocated a
+/// `String` per call to match the `Bloom<String>` generic.
 #[pyclass]
 pub struct BloomFilter {
-    bloom: RwLock<Bloom<String>>,
+    bloom: RwLock<Bloom<str>>,
     capacity: usize,
     fp_rate: f64,
 }
@@ -33,25 +37,33 @@ impl BloomFilter {
     }
 
     fn add(&self, key: &str) -> PyResult<()> {
-        self.bloom.write().map_err(lock_err)?.set(&key.to_string());
+        self.bloom.write().map_err(lock_err)?.set(key);
         Ok(())
     }
 
-    fn add_bulk(&self, keys: Vec<String>) -> PyResult<()> {
-        let mut bloom = self.bloom.write().map_err(lock_err)?;
-        for key in keys {
-            bloom.set(&key);
-        }
-        Ok(())
+    fn add_bulk(&self, py: Python<'_>, keys: Vec<String>) -> PyResult<()> {
+        // Take the lock *inside* `py.detach` — std's RwLockWriteGuard is not
+        // Send, so the closure must acquire and release within the same
+        // thread. Holding the GIL across bloom hashing of a large batch is
+        // what we want to avoid here.
+        py.detach(|| -> PyResult<()> {
+            let mut bloom = self.bloom.write().map_err(lock_err)?;
+            for key in &keys {
+                bloom.set(key.as_str());
+            }
+            Ok(())
+        })
     }
 
     fn might_exist(&self, key: &str) -> PyResult<bool> {
-        Ok(self.bloom.read().map_err(lock_err)?.check(&key.to_string()))
+        Ok(self.bloom.read().map_err(lock_err)?.check(key))
     }
 
-    fn check_bulk(&self, keys: Vec<String>) -> PyResult<Vec<bool>> {
-        let bloom = self.bloom.read().map_err(lock_err)?;
-        Ok(keys.iter().map(|k| bloom.check(k)).collect())
+    fn check_bulk(&self, py: Python<'_>, keys: Vec<String>) -> PyResult<Vec<bool>> {
+        py.detach(|| -> PyResult<Vec<bool>> {
+            let bloom = self.bloom.read().map_err(lock_err)?;
+            Ok(keys.iter().map(|k| bloom.check(k.as_str())).collect())
+        })
     }
 
     fn clear(&self) -> PyResult<()> {

--- a/rust/kernel/src/cas_chunking.rs
+++ b/rust/kernel/src/cas_chunking.rs
@@ -73,8 +73,12 @@ impl ChunkAssembler for ChunkedManifestAssembler {
 }
 
 /// Reassemble CDC chunks from manifest chunk array.
+///
+/// Validates that chunks cover `[0, total)` exactly — no gaps, no overlaps,
+/// no negative offsets (§ review fix #7). A malformed manifest that once
+/// produced silently corrupt content now surfaces as `CASError::IOError`.
 fn reassemble_chunks(chunks: &[Value], transport: &LocalCASTransport) -> Result<Vec<u8>, CASError> {
-    let mut parts: Vec<(i64, Vec<u8>)> = Vec::with_capacity(chunks.len());
+    let mut parts: Vec<(u64, Vec<u8>)> = Vec::with_capacity(chunks.len());
     for chunk in chunks {
         let hash = chunk
             .get("chunk_hash")
@@ -86,15 +90,48 @@ fn reassemble_chunks(chunks: &[Value], transport: &LocalCASTransport) -> Result<
                 ))
             })?;
         let offset = chunk.get("offset").and_then(|o| o.as_i64()).unwrap_or(0);
+        if offset < 0 {
+            return Err(CASError::IOError(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!("negative chunk offset {offset} for {hash}"),
+            )));
+        }
         let data = transport.read_blob(hash).map_err(|e| match e.kind() {
             std::io::ErrorKind::NotFound => CASError::NotFound(hash.to_string()),
             _ => CASError::IOError(e),
         })?;
-        parts.push((offset, data));
+        parts.push((offset as u64, data));
     }
 
     parts.sort_by_key(|(offset, _)| *offset);
-    let total: usize = parts.iter().map(|(_, d)| d.len()).sum();
+
+    // Reject gaps / overlaps. We require chunks to start at 0 and each
+    // subsequent chunk to begin exactly where the previous chunk ended.
+    let mut expected: u64 = 0;
+    for (offset, data) in &parts {
+        if *offset != expected {
+            return Err(CASError::IOError(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                format!(
+                    "chunked manifest has {} at offset {offset} (expected {expected})",
+                    if *offset > expected { "gap" } else { "overlap" },
+                ),
+            )));
+        }
+        expected = offset.checked_add(data.len() as u64).ok_or_else(|| {
+            CASError::IOError(std::io::Error::new(
+                std::io::ErrorKind::InvalidData,
+                "chunked manifest total size overflows u64",
+            ))
+        })?;
+    }
+
+    let total: usize = expected.try_into().map_err(|_| {
+        CASError::IOError(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "chunked manifest total size exceeds addressable memory",
+        ))
+    })?;
     let mut result = Vec::with_capacity(total);
     for (_, data) in parts {
         result.extend_from_slice(&data);

--- a/rust/kernel/src/cas_transport.rs
+++ b/rust/kernel/src/cas_transport.rs
@@ -17,6 +17,7 @@
 
 use std::io::{self, Write};
 use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Mutex;
 
 use ahash::AHashSet;
@@ -50,6 +51,10 @@ pub(crate) struct LocalCASTransport {
     /// it is never deleted during normal operation. Matches Python
     /// `LocalTransport._known_parents`.
     known_parents: Mutex<AHashSet<String>>,
+    /// Monotonic counter used to produce unique temp-file suffixes for
+    /// rename-based atomic writes. Process-unique is sufficient because the
+    /// final CAS path is keyed by content hash.
+    tmp_counter: AtomicU64,
 }
 
 #[allow(dead_code)]
@@ -63,7 +68,73 @@ impl LocalCASTransport {
             root: root_path.to_path_buf(),
             fsync_on_write,
             known_parents: Mutex::new(AHashSet::new()),
+            tmp_counter: AtomicU64::new(0),
         })
+    }
+
+    /// Atomic write: `tmp` in the same directory, optional fsync, rename to
+    /// `dst`, and fsync the parent directory when durability is requested.
+    ///
+    /// This prevents (a) torn reads of concurrently-written blobs and
+    /// (b) on-crash observation of zero-length blobs (open+O_TRUNC race).
+    fn write_atomic(&self, dst: &Path, content: &[u8]) -> io::Result<()> {
+        let parent = dst.parent().ok_or_else(|| {
+            io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "CAS path has no parent directory",
+            )
+        })?;
+        let dst_name = dst.file_name().and_then(|s| s.to_str()).unwrap_or("cas");
+        let pid = std::process::id();
+
+        // Try O_CREAT|O_EXCL with a fresh counter value, retrying on the
+        // unlikely AlreadyExists (different writer picked the same suffix).
+        let (tmp, mut file) = {
+            let mut attempt = 0u32;
+            loop {
+                let suffix = self.tmp_counter.fetch_add(1, Ordering::Relaxed);
+                let candidate = parent.join(format!(".{dst_name}.tmp-{pid}-{suffix}"));
+                match std::fs::OpenOptions::new()
+                    .write(true)
+                    .create_new(true)
+                    .open(&candidate)
+                {
+                    Ok(f) => break (candidate, f),
+                    Err(e) if e.kind() == io::ErrorKind::AlreadyExists && attempt < 8 => {
+                        attempt += 1;
+                        continue;
+                    }
+                    Err(e) => return Err(e),
+                }
+            }
+        };
+
+        // Write + optional fsync before rename.
+        file.write_all(content)?;
+        if self.fsync_on_write {
+            file.sync_all()?;
+        }
+        drop(file); // close before rename (required on Windows)
+
+        // Atomic rename to the destination path.
+        //
+        // On POSIX this is replace-in-place. On Windows, rename may fail when
+        // `dst` already exists, which can happen under concurrent same-hash
+        // CAS writers. Callers handle that race by treating "dst now exists"
+        // as successful dedup.
+        if let Err(e) = std::fs::rename(&tmp, dst) {
+            let _ = std::fs::remove_file(&tmp);
+            return Err(e);
+        }
+
+        // Sync the directory so the rename is durable on crash.
+        if self.fsync_on_write {
+            if let Ok(dir) = std::fs::File::open(parent) {
+                let _ = dir.sync_all();
+            }
+        }
+
+        Ok(())
     }
 
     /// Resolve a CAS blob key to an absolute filesystem path.
@@ -127,22 +198,23 @@ impl LocalCASTransport {
 
         self.ensure_parent(&path)?;
 
-        // Write content using O_CREAT | O_WRONLY | O_TRUNC semantics.
-        // OpenOptions::create(true).truncate(true) matches Python's
-        // os.open(path, O_CREAT | O_WRONLY | O_TRUNC, 0o644).
-        let mut file = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(&path)?;
-
-        file.write_all(content)?;
-
-        if self.fsync_on_write {
-            file.sync_all()?;
+        // Write via temp file + rename so concurrent writers (or a crash in
+        // the middle of a write) cannot be observed as zero-length/corrupt
+        // by a racing reader. POSIX `rename` is atomic even when the target
+        // already exists, so two writers of the same content simply swap the
+        // same bytes in place — readers always see a complete blob.
+        match self.write_atomic(&path, content) {
+            Ok(()) => Ok(hash),
+            Err(e) => {
+                // Windows race: another writer may have won the final rename
+                // and created the same CAS blob between our exists() and rename().
+                if path.is_file() {
+                    Ok(hash)
+                } else {
+                    Err(e)
+                }
+            }
         }
-
-        Ok(hash)
     }
 
     /// Write a pre-hashed blob (caller already knows the content hash).
@@ -161,19 +233,18 @@ impl LocalCASTransport {
 
         self.ensure_parent(&path)?;
 
-        let mut file = std::fs::OpenOptions::new()
-            .write(true)
-            .create(true)
-            .truncate(true)
-            .open(&path)?;
-
-        file.write_all(content)?;
-
-        if self.fsync_on_write {
-            file.sync_all()?;
+        // Atomic write (see `write_blob` for rationale).
+        match self.write_atomic(&path, content) {
+            Ok(()) => Ok(true),
+            Err(e) => {
+                // Same concurrent-writer race handling as `write_blob`.
+                if path.is_file() {
+                    Ok(false)
+                } else {
+                    Err(e)
+                }
+            }
         }
-
-        Ok(true)
     }
 
     /// Check if a CAS blob exists on disk.
@@ -433,6 +504,49 @@ mod tests {
         // Verify 2-level directory structure: root/cas/XX/YY/hash
         assert!(path_str.contains(&format!("cas/{}/{}/{}", &hash[..2], &hash[2..4], &hash)));
         assert!(path.is_file());
+    }
+
+    #[test]
+    fn test_concurrent_writes_never_truncated_readable() {
+        // Regression for review fix #2: the old code used
+        // OpenOptions::create(true).truncate(true), so concurrent writers of
+        // the same hash would both truncate and re-write. Any reader racing
+        // in between could observe a zero-length file (wrong content hash).
+        // The new tmp+rename path must keep readers consistent at all times.
+        use std::sync::Arc;
+        use std::thread;
+
+        let tmp = TempDir::new().unwrap();
+        let transport = Arc::new(LocalCASTransport::new(tmp.path(), false).unwrap());
+        let content = vec![0x7A; 128 * 1024];
+        let hash = library::hash::hash_content(&content);
+
+        let writers: Vec<_> = (0..8)
+            .map(|_| {
+                let t = Arc::clone(&transport);
+                let c = content.clone();
+                thread::spawn(move || t.write_blob(&c).unwrap())
+            })
+            .collect();
+        let reader = {
+            let t = Arc::clone(&transport);
+            let hash_reader = hash.clone();
+            thread::spawn(move || {
+                for _ in 0..200 {
+                    if let Ok(bytes) = t.read_blob(&hash_reader) {
+                        // Partial reads (wrong length) would indicate the
+                        // destination was observed mid-write.
+                        assert_eq!(bytes.len(), 128 * 1024);
+                    }
+                }
+            })
+        };
+        for h in writers {
+            assert_eq!(h.join().unwrap(), hash);
+        }
+        reader.join().unwrap();
+        let final_bytes = transport.read_blob(&hash).unwrap();
+        assert_eq!(final_bytes, content);
     }
 
     #[test]

--- a/rust/kernel/src/dispatch.rs
+++ b/rust/kernel/src/dispatch.rs
@@ -143,51 +143,58 @@ pub(crate) struct FileEvent {
 #[allow(dead_code)]
 impl FileEvent {
     /// Serialize to compact JSON for DT_STREAM / audit trail.
+    ///
+    /// Uses `serde_json` so arbitrary control characters in path/new_path
+    /// (e.g. `\n`, `\0`) produce valid JSON (§ review fix #6). Unset
+    /// `Option` fields are omitted to match the previous wire shape; scalar
+    /// fields continue to use the compact ordering the Python parsers expect.
     pub(crate) fn to_json(&self) -> String {
-        let mut s = String::with_capacity(256);
-        s.push('{');
-        s.push_str(&format!(
-            "\"type\":\"{}\",\"path\":\"{}\"",
-            self.event_type.as_str(),
-            self.path.replace('\\', "\\\\").replace('"', "\\\"")
-        ));
-        s.push_str(&format!(",\"event_id\":\"{}\"", self.event_id));
-        s.push_str(&format!(",\"timestamp\":\"{}\"", self.timestamp));
+        let mut map = serde_json::Map::with_capacity(12);
+        map.insert(
+            "type".to_string(),
+            serde_json::Value::String(self.event_type.as_str().to_string()),
+        );
+        map.insert(
+            "path".to_string(),
+            serde_json::Value::String(self.path.clone()),
+        );
+        map.insert(
+            "event_id".to_string(),
+            serde_json::Value::String(self.event_id.clone()),
+        );
+        map.insert(
+            "timestamp".to_string(),
+            serde_json::Value::String(self.timestamp.clone()),
+        );
         if let Some(ref v) = self.zone_id {
-            s.push_str(&format!(",\"zone_id\":\"{v}\""));
+            map.insert("zone_id".to_string(), serde_json::Value::String(v.clone()));
         }
         if let Some(ref v) = self.agent_id {
-            s.push_str(&format!(",\"agent_id\":\"{v}\""));
+            map.insert("agent_id".to_string(), serde_json::Value::String(v.clone()));
         }
         if let Some(ref v) = self.user_id {
-            s.push_str(&format!(",\"user_id\":\"{v}\""));
+            map.insert("user_id".to_string(), serde_json::Value::String(v.clone()));
         }
         if let Some(ref v) = self.etag {
-            s.push_str(&format!(",\"etag\":\"{v}\""));
+            map.insert("etag".to_string(), serde_json::Value::String(v.clone()));
         }
         if let Some(v) = self.size {
-            s.push_str(&format!(",\"size\":{v}"));
+            map.insert("size".to_string(), serde_json::Value::from(v));
         }
         if let Some(v) = self.version {
-            s.push_str(&format!(",\"version\":{v}"));
+            map.insert("version".to_string(), serde_json::Value::from(v));
         }
         if self.is_new {
-            s.push_str(",\"is_new\":true");
+            map.insert("is_new".to_string(), serde_json::Value::Bool(true));
         }
         if let Some(ref v) = self.old_path {
-            s.push_str(&format!(
-                ",\"old_path\":\"{}\"",
-                v.replace('\\', "\\\\").replace('"', "\\\"")
-            ));
+            map.insert("old_path".to_string(), serde_json::Value::String(v.clone()));
         }
         if let Some(ref v) = self.new_path {
-            s.push_str(&format!(
-                ",\"new_path\":\"{}\"",
-                v.replace('\\', "\\\\").replace('"', "\\\"")
-            ));
+            map.insert("new_path".to_string(), serde_json::Value::String(v.clone()));
         }
-        s.push('}');
-        s
+        serde_json::to_string(&serde_json::Value::Object(map))
+            .unwrap_or_else(|_| String::from("{\"error\":\"serialization failed\"}"))
     }
 
     /// Minimal-constructor convenience for sys_* call sites that only

--- a/rust/kernel/src/generated_pyo3.rs
+++ b/rust/kernel/src/generated_pyo3.rs
@@ -23,8 +23,11 @@ use crate::backend::{
     CasLocalBackend, LocalConnectorBackend, ObjectStore, PathLocalBackend, StorageError,
     WriteResult,
 };
+#[cfg(feature = "py-hook-adapters")]
 use crate::dispatch::PathResolver;
-use crate::hook_registry::{HookRegistry, InterceptHook};
+use crate::hook_registry::HookRegistry;
+#[cfg(feature = "py-hook-adapters")]
+use crate::hook_registry::InterceptHook;
 use crate::kernel::{Kernel, KernelError, OperationContext};
 use crate::lock::VFSLockManager;
 use crate::metastore::{FileMetadata, MetastoreError};
@@ -491,9 +494,12 @@ pub(crate) struct PyInterceptHookAdapter {
     hook_name: String,
 }
 
+#[cfg(feature = "py-hook-adapters")]
 unsafe impl Send for PyInterceptHookAdapter {}
+#[cfg(feature = "py-hook-adapters")]
 unsafe impl Sync for PyInterceptHookAdapter {}
 
+#[cfg(feature = "py-hook-adapters")]
 impl PyInterceptHookAdapter {
     pub(crate) fn new(py: Python<'_>, hook: Py<PyAny>) -> Self {
         let name = hook
@@ -508,6 +514,7 @@ impl PyInterceptHookAdapter {
     }
 }
 
+#[cfg(feature = "py-hook-adapters")]
 impl InterceptHook for PyInterceptHookAdapter {
     fn name(&self) -> &str {
         &self.hook_name
@@ -712,9 +719,12 @@ pub(crate) struct PyPathResolverAdapter {
     inner: Py<PyAny>,
 }
 
+#[cfg(feature = "py-hook-adapters")]
 unsafe impl Send for PyPathResolverAdapter {}
+#[cfg(feature = "py-hook-adapters")]
 unsafe impl Sync for PyPathResolverAdapter {}
 
+#[cfg(feature = "py-hook-adapters")]
 impl PathResolver for PyPathResolverAdapter {
     fn try_read(&self, path: &str) -> Option<Vec<u8>> {
         Python::attach(|py| {
@@ -1160,6 +1170,25 @@ impl PyKernel {
         metastore_path: Option<&str>,
         is_external: bool,
     ) -> PyResult<()> {
+        #[cfg(not(feature = "connectors"))]
+        let _ = (
+            openai_base_url,
+            openai_api_key,
+            openai_model,
+            s3_bucket,
+            s3_prefix,
+            aws_region,
+            aws_access_key,
+            aws_secret_key,
+            s3_endpoint,
+            gcs_bucket,
+            gcs_prefix,
+            access_token,
+            root_folder_id,
+            bot_token,
+            default_channel,
+        );
+
         // Backend resolution: grpc_addr -> GrpcObjectStoreAdapter (zero GIL)
         //                     local_root -> CasLocalBackend/PathLocalBackend/LocalConnectorBackend
         //                     openai_* -> OpenAIBackend (§10 D3)
@@ -1498,11 +1527,22 @@ impl PyKernel {
             Err(_) => false,
         };
 
-        let adapter = PyInterceptHookAdapter::new(py, hook.clone_ref(py));
-        self.hooks
-            .lock()
-            .register(op, Box::new(adapter), hook, has_pre, is_async_post, name);
-        Ok(())
+        #[cfg(feature = "py-hook-adapters")]
+        {
+            let adapter = PyInterceptHookAdapter::new(py, hook.clone_ref(py));
+            self.hooks
+                .lock()
+                .register(op, Box::new(adapter), hook, has_pre, is_async_post, name);
+            Ok(())
+        }
+
+        #[cfg(not(feature = "py-hook-adapters"))]
+        {
+            let _ = (hook, has_pre, is_async_post, name);
+            Err(pyo3::exceptions::PyRuntimeError::new_err(
+                "register_hook requires feature 'py-hook-adapters'",
+            ))
+        }
     }
 
     fn unregister_hook(&self, py: Python<'_>, op: &str, hook: &Bound<'_, PyAny>) -> bool {

--- a/rust/kernel/src/grpc_backend.rs
+++ b/rust/kernel/src/grpc_backend.rs
@@ -10,9 +10,16 @@
 //! Issue #1868: Phase 11 — Direction 3 gRPC adapter.
 
 use std::io;
+use std::time::Duration;
+
+use parking_lot::Mutex;
 
 use crate::backend::{ObjectStore, StorageError, WriteResult};
 use crate::kernel::OperationContext;
+
+/// Per-request deadline. Applied on every tonic request so a stuck sidecar
+/// cannot hang the kernel indefinitely (§ review fix #9).
+const REQUEST_TIMEOUT: Duration = Duration::from_secs(120);
 
 /// Generated protobuf + gRPC client stubs.
 pub(crate) mod proto {
@@ -23,8 +30,10 @@ use proto::object_store_service_client::ObjectStoreServiceClient;
 
 /// gRPC-based ObjectStore — Rust kernel makes gRPC calls, zero GIL.
 ///
-/// Holds a blocking gRPC channel to a Python sidecar server.
-/// Each method creates a one-shot tokio runtime for the async gRPC call.
+/// Holds a lazily-connected gRPC channel to a Python sidecar server.
+/// Each method reuses the same channel — tonic multiplexes requests over
+/// HTTP/2 streams, so cloning is cheap. Previous behaviour created a new
+/// channel per call, paying a full HTTP/2 handshake each time.
 #[allow(dead_code)]
 pub(crate) struct GrpcObjectStoreAdapter {
     /// gRPC endpoint (e.g. "http://127.0.0.1:50051")
@@ -33,10 +42,15 @@ pub(crate) struct GrpcObjectStoreAdapter {
     name: String,
     /// Shared tokio runtime for blocking gRPC calls
     runtime: tokio::runtime::Runtime,
+    /// Lazily-established channel. Wrapped in `Mutex<Option<_>>` so we can
+    /// drop and reconnect if a call fails with a transport error (e.g.
+    /// sidecar restart) without taking the slow path on every request.
+    channel: Mutex<Option<tonic::transport::Channel>>,
 }
 
 impl GrpcObjectStoreAdapter {
-    /// Create a new gRPC adapter connecting to the given endpoint.
+    /// Create a new gRPC adapter for the given endpoint. The underlying
+    /// channel is connected lazily on first use.
     pub fn new(endpoint: &str, name: &str) -> Result<Self, io::Error> {
         let runtime = tokio::runtime::Builder::new_current_thread()
             .enable_all()
@@ -46,16 +60,56 @@ impl GrpcObjectStoreAdapter {
             endpoint: endpoint.to_string(),
             name: name.to_string(),
             runtime,
+            channel: Mutex::new(None),
         })
     }
 
-    /// Get a connected gRPC client (blocking).
-    fn client(&self) -> Result<ObjectStoreServiceClient<tonic::transport::Channel>, StorageError> {
-        self.runtime.block_on(async {
-            ObjectStoreServiceClient::connect(self.endpoint.clone())
+    /// Return a cloned, connected gRPC channel. Connects once and reuses
+    /// for subsequent calls.
+    fn channel(&self) -> Result<tonic::transport::Channel, StorageError> {
+        if let Some(ch) = self.channel.lock().as_ref() {
+            return Ok(ch.clone());
+        }
+        // Slow path — connect and cache. We must not hold the mutex across
+        // the await, so build outside the lock and install under it.
+        let endpoint = self.endpoint.clone();
+        let ch = self.runtime.block_on(async move {
+            let ep = tonic::transport::Endpoint::from_shared(endpoint)
+                .map_err(|e| {
+                    StorageError::IOError(io::Error::other(format!("gRPC endpoint: {e}")))
+                })?
+                .timeout(REQUEST_TIMEOUT)
+                .connect_timeout(Duration::from_secs(10))
+                .tcp_keepalive(Some(Duration::from_secs(30)));
+            ep.connect()
                 .await
                 .map_err(|e| StorageError::IOError(io::Error::other(format!("gRPC connect: {e}"))))
-        })
+        })?;
+        *self.channel.lock() = Some(ch.clone());
+        Ok(ch)
+    }
+
+    /// Get a connected gRPC client (blocking). Reuses the cached channel.
+    fn client(&self) -> Result<ObjectStoreServiceClient<tonic::transport::Channel>, StorageError> {
+        Ok(ObjectStoreServiceClient::new(self.channel()?))
+    }
+
+    /// Build a tonic request with the standard per-request timeout.
+    fn request<T>(&self, msg: T) -> tonic::Request<T> {
+        let mut req = tonic::Request::new(msg);
+        req.set_timeout(REQUEST_TIMEOUT);
+        req
+    }
+
+    /// Classify transport-level errors so we can drop the cached channel and
+    /// reconnect on next call (e.g. after the sidecar restarts).
+    fn reset_channel_on_transport_error(&self, status: &tonic::Status) {
+        match status.code() {
+            tonic::Code::Unavailable | tonic::Code::Unknown | tonic::Code::Internal => {
+                *self.channel.lock() = None;
+            }
+            _ => {}
+        }
     }
 }
 
@@ -71,7 +125,7 @@ impl ObjectStore for GrpcObjectStoreAdapter {
         ctx: &OperationContext,
     ) -> Result<Vec<u8>, StorageError> {
         let mut client = self.client()?;
-        let request = tonic::Request::new(proto::ReadContentRequest {
+        let request = self.request(proto::ReadContentRequest {
             content_id: content_id.to_string(),
             backend_path: backend_path.to_string(),
             user_id: ctx.user_id.clone(),
@@ -82,6 +136,7 @@ impl ObjectStore for GrpcObjectStoreAdapter {
             .runtime
             .block_on(client.read_content(request))
             .map_err(|e| {
+                self.reset_channel_on_transport_error(&e);
                 if e.code() == tonic::Code::NotFound {
                     StorageError::NotFound(backend_path.to_string())
                 } else {
@@ -98,7 +153,7 @@ impl ObjectStore for GrpcObjectStoreAdapter {
         ctx: &OperationContext,
     ) -> Result<WriteResult, StorageError> {
         let mut client = self.client()?;
-        let request = tonic::Request::new(proto::WriteContentRequest {
+        let request = self.request(proto::WriteContentRequest {
             content: content.to_vec(),
             content_id: content_id.to_string(),
             user_id: ctx.user_id.clone(),
@@ -108,7 +163,10 @@ impl ObjectStore for GrpcObjectStoreAdapter {
         let response = self
             .runtime
             .block_on(client.write_content(request))
-            .map_err(|e| StorageError::IOError(io::Error::other(format!("gRPC write: {e}"))))?;
+            .map_err(|e| {
+                self.reset_channel_on_transport_error(&e);
+                StorageError::IOError(io::Error::other(format!("gRPC write: {e}")))
+            })?;
         let resp = response.into_inner();
         Ok(WriteResult {
             content_id: resp.content_id,
@@ -119,49 +177,55 @@ impl ObjectStore for GrpcObjectStoreAdapter {
 
     fn delete_file(&self, path: &str) -> Result<(), StorageError> {
         let mut client = self.client()?;
-        let request = tonic::Request::new(proto::DeleteFileRequest {
+        let request = self.request(proto::DeleteFileRequest {
             path: path.to_string(),
         });
         self.runtime
             .block_on(client.delete_file(request))
-            .map_err(|e| StorageError::IOError(io::Error::other(format!("gRPC delete: {e}"))))?;
+            .map_err(|e| {
+                self.reset_channel_on_transport_error(&e);
+                StorageError::IOError(io::Error::other(format!("gRPC delete: {e}")))
+            })?;
         Ok(())
     }
 
     fn mkdir(&self, path: &str, parents: bool, exist_ok: bool) -> Result<(), StorageError> {
         let mut client = self.client()?;
-        let request = tonic::Request::new(proto::MkdirRequest {
+        let request = self.request(proto::MkdirRequest {
             path: path.to_string(),
             parents,
             exist_ok,
         });
-        self.runtime
-            .block_on(client.mkdir(request))
-            .map_err(|e| StorageError::IOError(io::Error::other(format!("gRPC mkdir: {e}"))))?;
+        self.runtime.block_on(client.mkdir(request)).map_err(|e| {
+            self.reset_channel_on_transport_error(&e);
+            StorageError::IOError(io::Error::other(format!("gRPC mkdir: {e}")))
+        })?;
         Ok(())
     }
 
     fn rmdir(&self, path: &str, recursive: bool) -> Result<(), StorageError> {
         let mut client = self.client()?;
-        let request = tonic::Request::new(proto::RmdirRequest {
+        let request = self.request(proto::RmdirRequest {
             path: path.to_string(),
             recursive,
         });
-        self.runtime
-            .block_on(client.rmdir(request))
-            .map_err(|e| StorageError::IOError(io::Error::other(format!("gRPC rmdir: {e}"))))?;
+        self.runtime.block_on(client.rmdir(request)).map_err(|e| {
+            self.reset_channel_on_transport_error(&e);
+            StorageError::IOError(io::Error::other(format!("gRPC rmdir: {e}")))
+        })?;
         Ok(())
     }
 
     fn rename(&self, old_path: &str, new_path: &str) -> Result<(), StorageError> {
         let mut client = self.client()?;
-        let request = tonic::Request::new(proto::RenameRequest {
+        let request = self.request(proto::RenameRequest {
             old_path: old_path.to_string(),
             new_path: new_path.to_string(),
         });
-        self.runtime
-            .block_on(client.rename(request))
-            .map_err(|e| StorageError::IOError(io::Error::other(format!("gRPC rename: {e}"))))?;
+        self.runtime.block_on(client.rename(request)).map_err(|e| {
+            self.reset_channel_on_transport_error(&e);
+            StorageError::IOError(io::Error::other(format!("gRPC rename: {e}")))
+        })?;
         Ok(())
     }
 }

--- a/rust/kernel/src/hash.rs
+++ b/rust/kernel/src/hash.rs
@@ -4,17 +4,32 @@ use library::hash::{hash_content, hash_content_smart};
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
 
+/// Below this size, GIL-release overhead outweighs the hashing cost —
+/// stay on the caller thread. Tuned loosely: BLAKE3 is ~1 GB/s on modern
+/// x86, so 16 KiB hashes in under 20 µs while `py.detach` adds ~1 µs.
+const DETACH_THRESHOLD: usize = 16 * 1024;
+
 /// Compute BLAKE3 hash of content (full hash). Returns 64-char hex string.
 #[pyfunction]
-pub fn hash_content_py(_py: Python<'_>, content: &[u8]) -> String {
-    hash_content(content)
+pub fn hash_content_py(py: Python<'_>, content: &[u8]) -> String {
+    if content.len() < DETACH_THRESHOLD {
+        hash_content(content)
+    } else {
+        // §review fix #18: release the GIL for multi-MB payloads instead
+        // of stalling every other Python thread during the hash.
+        py.detach(|| hash_content(content))
+    }
 }
 
 /// Compute BLAKE3 hash with strategic sampling for large files.
 /// For files < 256KB: full hash. For >= 256KB: samples first+middle+last 64KB.
 #[pyfunction]
-pub fn hash_content_smart_py(_py: Python<'_>, content: &[u8]) -> String {
-    hash_content_smart(content)
+pub fn hash_content_smart_py(py: Python<'_>, content: &[u8]) -> String {
+    if content.len() < DETACH_THRESHOLD {
+        hash_content_smart(content)
+    } else {
+        py.detach(|| hash_content_smart(content))
+    }
 }
 
 /// Compute BLAKE3 hash from a Python bytes object, releasing the GIL.

--- a/rust/kernel/src/hook_registry.rs
+++ b/rust/kernel/src/hook_registry.rs
@@ -82,6 +82,7 @@ impl HookRegistry {
     }
 
     /// Register a hook for the given operation.
+    #[cfg(feature = "py-hook-adapters")]
     pub(crate) fn register(
         &mut self,
         op: &str,

--- a/rust/kernel/src/io.rs
+++ b/rust/kernel/src/io.rs
@@ -7,35 +7,52 @@ use rayon::prelude::*;
 use std::fs::File;
 
 /// Read a file using memory-mapped I/O for zero-copy performance.
+///
+/// § review fix #28: open + mmap run off the GIL. The final `PyBytes::new`
+/// copy necessarily holds the GIL, but at that point all syscall work is
+/// done.
 #[pyfunction]
 pub fn read_file(py: Python<'_>, path: &str) -> PyResult<Option<Py<PyBytes>>> {
-    let file = match File::open(path) {
-        Ok(f) => f,
-        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
-        Err(e) => {
-            return Err(pyo3::exceptions::PyIOError::new_err(format!(
-                "Failed to open file '{}': {}",
-                path, e
-            )))
-        }
-    };
-
-    let metadata = file.metadata().map_err(|e| {
-        pyo3::exceptions::PyIOError::new_err(format!("Failed to get file metadata: {}", e))
-    })?;
-
-    if metadata.len() == 0 {
-        return Ok(Some(PyBytes::new(py, &[]).into()));
+    enum Outcome {
+        NotFound,
+        Empty,
+        Mapped(Mmap),
     }
+    let path_str = path.to_string();
+    let outcome: Result<Outcome, pyo3::PyErr> = py.detach(|| {
+        let file = match File::open(&path_str) {
+            Ok(f) => f,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Outcome::NotFound),
+            Err(e) => {
+                return Err(pyo3::exceptions::PyIOError::new_err(format!(
+                    "Failed to open file '{}': {}",
+                    path_str, e
+                )))
+            }
+        };
+        let metadata = file.metadata().map_err(|e| {
+            pyo3::exceptions::PyIOError::new_err(format!("Failed to get file metadata: {}", e))
+        })?;
+        if metadata.len() == 0 {
+            return Ok(Outcome::Empty);
+        }
+        // SAFETY: The file is opened read-only and we don't modify it.
+        let mmap = unsafe {
+            Mmap::map(&file).map_err(|e| {
+                pyo3::exceptions::PyIOError::new_err(format!(
+                    "Failed to mmap file '{}': {}",
+                    path_str, e
+                ))
+            })?
+        };
+        Ok(Outcome::Mapped(mmap))
+    });
 
-    // SAFETY: The file is opened read-only and we don't modify it.
-    let mmap = unsafe {
-        Mmap::map(&file).map_err(|e| {
-            pyo3::exceptions::PyIOError::new_err(format!("Failed to mmap file '{}': {}", path, e))
-        })?
-    };
-
-    Ok(Some(PyBytes::new(py, &mmap).into()))
+    match outcome? {
+        Outcome::NotFound => Ok(None),
+        Outcome::Empty => Ok(Some(PyBytes::new(py, &[]).into())),
+        Outcome::Mapped(mmap) => Ok(Some(PyBytes::new(py, &mmap).into())),
+    }
 }
 
 /// Read multiple files using memory-mapped I/O in parallel.

--- a/rust/kernel/src/kernel.rs
+++ b/rust/kernel/src/kernel.rs
@@ -443,8 +443,10 @@ pub struct Kernel {
     zone_revisions: DashMap<String, Arc<ZoneRevisionEntry>>,
     // FileWatcher — inotify equivalent. Arc-shared with observer registry.
     file_watches: Arc<FileWatcher>,
-    // Agent registry — DashMap backing store (§10 B1)
-    pub(crate) agent_registry: crate::agent_registry::AgentRegistry,
+    // Agent registry — DashMap backing store (§10 B1).
+    // Held in an Arc so components like `AgentStatusResolver` can share
+    // ownership without relying on raw pointers / field address stability.
+    pub(crate) agent_registry: Arc<crate::agent_registry::AgentRegistry>,
     // Per-mount metastores — federation zones have independent redb instances.
     // Keyed by zone-canonical mount point (e.g. "/zone-beta/shared").
     // Syscalls check here first, then fall back to self.metastore (global).
@@ -483,7 +485,7 @@ impl Kernel {
             observers: Mutex::new(KernelObserverRegistry::new()),
             zone_revisions: DashMap::new(),
             file_watches: Arc::new(FileWatcher::new()),
-            agent_registry: crate::agent_registry::AgentRegistry::new(),
+            agent_registry: Arc::new(crate::agent_registry::AgentRegistry::new()),
             mount_metastores: DashMap::new(),
             pipe_manager: crate::pipe_manager::PipeManager::new(),
             stream_manager: Arc::new(crate::stream_manager::StreamManager::new()),

--- a/rust/kernel/src/lock.rs
+++ b/rust/kernel/src/lock.rs
@@ -185,18 +185,11 @@ impl VFSLockManagerInner {
         // Blocking wait with Condvar — woken on every release().
         let deadline = start + Duration::from_millis(timeout_ms);
 
+        // Try-before-wait: if the lock became free between the fast-path
+        // attempt and entering this loop, succeed without burning a
+        // scheduler round trip (§ review fix #11).
         loop {
-            self.contention_count.fetch_add(1, Ordering::Relaxed);
-
             let mut state = self.state.lock();
-            let remaining = deadline.saturating_duration_since(Instant::now());
-            if remaining.is_zero() {
-                self.timeout_count.fetch_add(1, Ordering::Relaxed);
-                return 0;
-            }
-
-            let wait_result = self.notify.wait_for(&mut state, remaining);
-
             if let Some(handle) =
                 Self::try_acquire_locked(&mut state, &self.next_handle, &norm_path, mode)
             {
@@ -206,7 +199,26 @@ impl VFSLockManagerInner {
                 return handle;
             }
 
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                self.timeout_count.fetch_add(1, Ordering::Relaxed);
+                return 0;
+            }
+
+            // Count one contended wait (not one per loop iteration).
+            self.contention_count.fetch_add(1, Ordering::Relaxed);
+            let wait_result = self.notify.wait_for(&mut state, remaining);
             if wait_result.timed_out() {
+                // Give the lock a final try — a release may have raced in
+                // while we were marked as timed out.
+                if let Some(handle) =
+                    Self::try_acquire_locked(&mut state, &self.next_handle, &norm_path, mode)
+                {
+                    let elapsed = start.elapsed().as_nanos() as u64;
+                    self.total_acquire_ns.fetch_add(elapsed, Ordering::Relaxed);
+                    self.acquire_count.fetch_add(1, Ordering::Relaxed);
+                    return handle;
+                }
                 self.timeout_count.fetch_add(1, Ordering::Relaxed);
                 return 0;
             }
@@ -215,7 +227,7 @@ impl VFSLockManagerInner {
 
     /// Release a previously acquired lock by handle (for Rust-internal callers).
     pub(crate) fn do_release(&self, handle: u64) -> bool {
-        let released = {
+        let wake_all = {
             let mut state = self.state.lock();
 
             let info = match state.handles.remove(&handle) {
@@ -240,15 +252,19 @@ impl VFSLockManagerInner {
                 }
             }
 
-            true
+            // Releasing a writer can unblock multiple readers, so broadcast.
+            // Releasing a reader usually frees at most one writer contender.
+            matches!(info.mode, LockMode::Write)
         };
 
-        if released {
+        if wake_all {
             self.notify.notify_all();
-            self.release_count.fetch_add(1, Ordering::Relaxed);
+        } else {
+            self.notify.notify_one();
         }
+        self.release_count.fetch_add(1, Ordering::Relaxed);
 
-        released
+        true
     }
 
     /// Check whether `path` in `mode` conflicts with any *ancestor* locks.
@@ -288,7 +304,16 @@ impl VFSLockManagerInner {
         upper.pop();
         upper.push('0');
 
-        for (_key, entry) in locks.range(prefix..upper) {
+        // `path == "/"` produces `prefix = "/"`, which makes the range
+        // `["/", "0")` include the root lock entry itself. Exclude it so
+        // the descendant check is strictly about descendants, not the path
+        // under consideration (§ review fix #12). For non-root paths the
+        // path itself is not a member of the prefix-sentinel range, so
+        // this exclusion is a no-op there.
+        for (key, entry) in locks.range(prefix..upper) {
+            if key == path {
+                continue;
+            }
             match mode {
                 LockMode::Read => {
                     if entry.writer.is_some() {

--- a/rust/kernel/src/openai_inference.rs
+++ b/rust/kernel/src/openai_inference.rs
@@ -8,6 +8,42 @@
 
 use pyo3::prelude::*;
 use pyo3::types::PyBytes;
+use std::sync::OnceLock;
+use std::time::Duration;
+
+/// Default per-request timeout for OpenAI-compatible endpoints. Chosen to
+/// be longer than most hosted models' p99 latency but short enough that a
+/// stuck endpoint cannot deadlock a Python caller forever (§ review fix #8).
+const DEFAULT_HTTP_TIMEOUT: Duration = Duration::from_secs(120);
+
+/// Lazily-initialized multi-thread tokio runtime. Reused across every call
+/// instead of building a fresh single-threaded runtime per request (which
+/// previously cost ~milliseconds and defeated the GIL-free goal).
+fn runtime() -> &'static tokio::runtime::Runtime {
+    static RT: OnceLock<tokio::runtime::Runtime> = OnceLock::new();
+    RT.get_or_init(|| {
+        tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(2)
+            .enable_all()
+            .thread_name("nexus-openai")
+            .build()
+            .expect("failed to build tokio runtime for openai_inference")
+    })
+}
+
+/// Shared `reqwest::Client` — reuses TLS sessions and HTTP/2 connections
+/// across calls. Constructing a client per call was prohibitively expensive.
+fn http_client() -> &'static reqwest::Client {
+    static CLIENT: OnceLock<reqwest::Client> = OnceLock::new();
+    CLIENT.get_or_init(|| {
+        reqwest::Client::builder()
+            .pool_idle_timeout(Duration::from_secs(90))
+            .tcp_keepalive(Duration::from_secs(30))
+            .timeout(DEFAULT_HTTP_TIMEOUT)
+            .build()
+            .expect("failed to build reqwest client for openai_inference")
+    })
+}
 
 /// Synchronous OpenAI chat completion — releases GIL during HTTP.
 ///
@@ -30,12 +66,7 @@ pub fn openai_chat_completion<'py>(
     let model = model.to_string();
 
     let result = py.detach(move || -> Result<Vec<u8>, String> {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(|e| format!("tokio: {e}"))?;
-
-        rt.block_on(async {
+        runtime().block_on(async {
             let messages: serde_json::Value =
                 serde_json::from_slice(&msgs).map_err(|e| format!("JSON parse: {e}"))?;
 
@@ -51,8 +82,7 @@ pub fn openai_chat_completion<'py>(
                 body["max_tokens"] = serde_json::json!(mt);
             }
 
-            let client = reqwest::Client::new();
-            let resp = client
+            let resp = http_client()
                 .post(&url)
                 .header("Authorization", format!("Bearer {api_key}"))
                 .header("Content-Type", "application/json")
@@ -101,12 +131,9 @@ pub fn openai_chat_completion_stream(
     let model = model.to_string();
 
     let result = py.detach(move || -> Result<String, String> {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .map_err(|e| format!("tokio: {e}"))?;
+        runtime().block_on(async {
+            use futures_util::StreamExt;
 
-        rt.block_on(async {
             let messages: serde_json::Value =
                 serde_json::from_slice(&msgs).map_err(|e| format!("JSON parse: {e}"))?;
 
@@ -122,8 +149,7 @@ pub fn openai_chat_completion_stream(
                 body["max_tokens"] = serde_json::json!(mt);
             }
 
-            let client = reqwest::Client::new();
-            let resp = client
+            let resp = http_client()
                 .post(&url)
                 .header("Authorization", format!("Bearer {api_key}"))
                 .header("Content-Type", "application/json")
@@ -138,16 +164,37 @@ pub fn openai_chat_completion_stream(
                 return Err(format!("OpenAI API {status}: {text}"));
             }
 
-            let body_text = resp.text().await.map_err(|e| format!("read: {e}"))?;
+            // True streaming: parse SSE chunks as they arrive instead of
+            // buffering the whole response (§ review fix #8).
             let mut collected = String::new();
-
-            for line in body_text.lines() {
-                if let Some(data) = line.strip_prefix("data: ") {
-                    if data == "[DONE]" {
-                        break;
+            let mut pending: Vec<u8> = Vec::new();
+            let mut stream = resp.bytes_stream();
+            'outer: while let Some(chunk) = stream.next().await {
+                let bytes = chunk.map_err(|e| format!("stream: {e}"))?;
+                pending.extend_from_slice(&bytes);
+                // Process complete lines; keep any trailing partial.
+                while let Some(nl) = pending.iter().position(|&b| b == b'\n') {
+                    let mut line_bytes: Vec<u8> = pending.drain(..=nl).collect();
+                    // Drop trailing '\n' (and optional '\r') from this line.
+                    if line_bytes.last() == Some(&b'\n') {
+                        line_bytes.pop();
                     }
-                    if let Ok(chunk) = serde_json::from_str::<serde_json::Value>(data) {
-                        if let Some(content) = chunk
+                    if line_bytes.last() == Some(&b'\r') {
+                        line_bytes.pop();
+                    }
+                    let line = match std::str::from_utf8(&line_bytes) {
+                        Ok(s) => s,
+                        Err(_) => continue,
+                    };
+                    let data = match line.strip_prefix("data: ") {
+                        Some(d) => d,
+                        None => continue,
+                    };
+                    if data == "[DONE]" {
+                        break 'outer;
+                    }
+                    if let Ok(chunk_json) = serde_json::from_str::<serde_json::Value>(data) {
+                        if let Some(content) = chunk_json
                             .get("choices")
                             .and_then(|c| c.get(0))
                             .and_then(|c| c.get("delta"))

--- a/rust/kernel/src/path_utils.rs
+++ b/rust/kernel/src/path_utils.rs
@@ -160,8 +160,11 @@ pub fn validate_path(path: &str, allow_root: bool) -> PyResult<String> {
         }
     }
 
-    // Parent directory traversal
-    if result.contains("..") {
+    // Parent directory traversal. Check segment-by-segment instead of a
+    // substring match — `..b.txt` or `/a/..b` are legitimate file names
+    // and must not be rejected (§ review fix #22). Only whole-component
+    // `.` / `..` segments are traversal.
+    if result.split('/').any(|seg| seg == ".." || seg == ".") {
         return Err(PyValueError::new_err("Path contains '..' segments"));
     }
 

--- a/rust/kernel/src/pipe.rs
+++ b/rust/kernel/src/pipe.rs
@@ -131,8 +131,24 @@ impl MemoryPipeBackend {
 
         let frame_len = HEADER_SIZE + payload_len;
         let tail = self.tail.load(Ordering::Relaxed);
+        let head = self.head.load(Ordering::Acquire);
         let tail_idx = tail % self.ring_cap;
         let contiguous = self.ring_cap - tail_idx;
+
+        // Physical ring-space check: payloads alone cannot be trusted because
+        // `user_capacity` ignores 4-byte frame headers and potential wrap
+        // sentinels. For tiny payloads (< HEADER_SIZE) the header overhead
+        // alone exceeds the slack between `user_capacity` and `ring_cap`.
+        // Enforce the invariant `(tail - head) + <bytes we are about to
+        // write> <= ring_cap`, where we must include a potential sentinel.
+        let need = if frame_len > contiguous {
+            contiguous + frame_len
+        } else {
+            frame_len
+        };
+        if tail.saturating_sub(head) + need > self.ring_cap {
+            return Err(PipeError::Full(used, self.user_capacity));
+        }
 
         let ring = unsafe { &mut *self.ring.get() };
 
@@ -582,6 +598,57 @@ mod tests {
         for i in 0u64..20 {
             push_u64(&core, i);
             assert_eq!(pop_u64(&core), i);
+        }
+    }
+
+    // -- Ring-physical-space regression (§ review fix #1) --
+
+    #[test]
+    fn test_many_tiny_pushes_cannot_overwrite_unread() {
+        // user_capacity=32, ring_cap=64. Each 1-byte payload consumes a
+        // 5-byte frame in the ring. Without the physical-space guard, 13+
+        // consecutive pushes would wrap past head=0 and corrupt data.
+        let core = make(32);
+        let mut accepted = 0usize;
+        for _ in 0..64 {
+            match core.push(&[0xAAu8]) {
+                Ok(_) => accepted += 1,
+                Err(PipeError::Full(_, _)) => break,
+                Err(e) => panic!("unexpected push error: {e:?}"),
+            }
+        }
+        // Floor: floor(ring_cap / frame_len) = 64 / 5 = 12. Must reject the 13th.
+        assert!(
+            accepted <= 12,
+            "ring overflow accepted {accepted} pushes of frame_len=5 into ring_cap=64"
+        );
+        // Every accepted payload must still be readable in order.
+        for _ in 0..accepted {
+            assert_eq!(pop(&core), vec![0xAAu8]);
+        }
+    }
+
+    #[test]
+    fn test_tiny_push_fails_before_overwriting_with_sentinel() {
+        let core = make(16);
+        // Fill to near capacity then force sentinel + wrap, verifying the
+        // sentinel-requiring push is rejected when the ring cannot absorb
+        // the waste + new frame without overtaking head.
+        for _ in 0..5 {
+            let _ = core.push(b"x");
+        }
+        // Pop just enough to leave head < tail but keep ring nearly full.
+        let _ = core.pop();
+        // Do not panic; whatever the implementation decides must preserve
+        // the invariant tail - head <= ring_cap after the next push.
+        for _ in 0..100 {
+            let _ = core.push(b"y");
+        }
+        // Invariant check: size() <= user_capacity and remaining pops match.
+        let used = core.msg_count();
+        for _ in 0..used {
+            let v = pop(&core);
+            assert_eq!(v.len(), 1);
         }
     }
 

--- a/rust/kernel/src/rebac.rs
+++ b/rust/kernel/src/rebac.rs
@@ -127,7 +127,13 @@ fn compute_permission_interned_shared(
             let result = check_relation_with_usersets_interned_shared(
                 subject, permission, object, graph, namespaces, memo_cache, visited, depth,
             );
-            memo_cache.insert(memo_key, result);
+            // Cross-request shared memoization must not persist `false`:
+            // a cycle-specific visited set can produce a local false that is
+            // not globally valid for another traversal. Positive results are
+            // monotonic and safe to share across workers.
+            if result {
+                memo_cache.insert(memo_key, true);
+            }
             return result;
         }
     };
@@ -221,7 +227,10 @@ fn compute_permission_interned_shared(
         )
     };
 
-    memo_cache.insert(memo_key, result);
+    // See note above: cache only positive results in the shared map.
+    if result {
+        memo_cache.insert(memo_key, true);
+    }
     result
 }
 
@@ -255,6 +264,40 @@ fn parse_tuples_from_py(tuples: &Bound<PyList>) -> PyResult<Vec<ReBACTuple>> {
         .collect()
 }
 
+/// Convert one (obj_type, config_dict) pair into a `NamespaceConfig`,
+/// using the thread-local LRU to skip re-parsing identical JSON blobs.
+///
+/// Extracted from the two callers below so they don't diverge
+/// (§ review fix #26).
+fn namespace_config_from_py_entry(
+    py: Python<'_>,
+    obj_type: &str,
+    config_dict: &Bound<'_, PyDict>,
+) -> PyResult<NamespaceConfig> {
+    let json_module = py.import("json")?;
+    let config_json_py = json_module.call_method1("dumps", (config_dict,))?;
+    let config_json: String = config_json_py.extract()?;
+
+    let mut hasher = DefaultHasher::new();
+    obj_type.hash(&mut hasher);
+    config_json.hash(&mut hasher);
+    let cache_key = hasher.finish();
+
+    NAMESPACE_CONFIG_CACHE.with(|cache| {
+        let mut cache_ref = cache.borrow_mut();
+        if let Some((cached_type, cached_config)) = cache_ref.get(&cache_key) {
+            if cached_type == obj_type {
+                return Ok::<NamespaceConfig, pyo3::PyErr>(cached_config.clone());
+            }
+        }
+        let parsed: NamespaceConfig = serde_json::from_str(&config_json).map_err(|e| {
+            pyo3::exceptions::PyValueError::new_err(format!("JSON parse error: {}", e))
+        })?;
+        cache_ref.put(cache_key, (obj_type.to_string(), parsed.clone()));
+        Ok(parsed)
+    })
+}
+
 fn parse_namespace_configs_from_py(
     py: Python<'_>,
     namespace_configs: &Bound<PyDict>,
@@ -263,28 +306,7 @@ fn parse_namespace_configs_from_py(
     for (key, value) in namespace_configs.iter() {
         let obj_type: String = key.extract()?;
         let config_dict: Bound<'_, PyDict> = value.extract()?;
-        let json_module = py.import("json")?;
-        let config_json_py = json_module.call_method1("dumps", (config_dict,))?;
-        let config_json: String = config_json_py.extract()?;
-
-        let mut hasher = DefaultHasher::new();
-        obj_type.hash(&mut hasher);
-        config_json.hash(&mut hasher);
-        let cache_key = hasher.finish();
-
-        let config: NamespaceConfig = NAMESPACE_CONFIG_CACHE.with(|cache| {
-            let mut cache_ref = cache.borrow_mut();
-            if let Some((cached_type, cached_config)) = cache_ref.get(&cache_key) {
-                if cached_type == &obj_type {
-                    return Ok::<NamespaceConfig, pyo3::PyErr>(cached_config.clone());
-                }
-            }
-            let parsed: NamespaceConfig = serde_json::from_str(&config_json).map_err(|e| {
-                pyo3::exceptions::PyValueError::new_err(format!("JSON parse error: {}", e))
-            })?;
-            cache_ref.put(cache_key, (obj_type.clone(), parsed.clone()));
-            Ok(parsed)
-        })?;
+        let config = namespace_config_from_py_entry(py, &obj_type, &config_dict)?;
         namespaces.insert(obj_type, config);
     }
     Ok(namespaces)
@@ -315,25 +337,45 @@ pub fn check_permission_bitmap(user_bitmap_bytes: &[u8], resource_bitmap_bytes: 
 }
 
 /// Batch permission check: intersect user bitmap with each resource bitmap.
-/// Returns Vec<bool> — one result per resource.
+/// Returns `Vec<bool>` — one result per resource.
+///
+/// § review fix #25: releases the GIL and parallelizes the
+/// deserialize+intersect work above a threshold. For small batches the
+/// sequential path avoids rayon's scheduling overhead.
 #[pyfunction]
 pub fn check_permission_bitmap_batch(
-    user_bitmap_bytes: &[u8],
+    py: Python<'_>,
+    user_bitmap_bytes: Vec<u8>,
     resource_bitmaps: Vec<Vec<u8>>,
 ) -> Vec<bool> {
     use roaring::RoaringBitmap;
-    let user = match RoaringBitmap::deserialize_from(user_bitmap_bytes) {
-        Ok(bm) => bm,
-        Err(_) => return vec![false; resource_bitmaps.len()],
-    };
-    resource_bitmaps
-        .iter()
-        .map(|rb| {
-            RoaringBitmap::deserialize_from(rb.as_slice())
-                .map(|res| !(&user & &res).is_empty())
-                .unwrap_or(false)
-        })
-        .collect()
+    const PARALLEL_THRESHOLD: usize = 16;
+
+    py.detach(move || {
+        let user = match RoaringBitmap::deserialize_from(user_bitmap_bytes.as_slice()) {
+            Ok(bm) => bm,
+            Err(_) => return vec![false; resource_bitmaps.len()],
+        };
+        if resource_bitmaps.len() >= PARALLEL_THRESHOLD {
+            resource_bitmaps
+                .par_iter()
+                .map(|rb| {
+                    RoaringBitmap::deserialize_from(rb.as_slice())
+                        .map(|res| !(&user & &res).is_empty())
+                        .unwrap_or(false)
+                })
+                .collect()
+        } else {
+            resource_bitmaps
+                .iter()
+                .map(|rb| {
+                    RoaringBitmap::deserialize_from(rb.as_slice())
+                        .map(|res| !(&user & &res).is_empty())
+                        .unwrap_or(false)
+                })
+                .collect()
+        }
+    })
 }
 
 // ============================================================================
@@ -425,33 +467,13 @@ pub fn compute_permissions_bulk<'py>(
         InternedGraph::from_tuples(&interned_tuples, &mut interner)
     };
 
+    // § review fix #26: share the parsing + cache path with
+    // `parse_namespace_configs_from_py` via `namespace_config_from_py_entry`.
     let mut interned_namespaces: AHashMap<Sym, InternedNamespaceConfig> = AHashMap::new();
     for (key, value) in namespace_configs.iter() {
         let obj_type: String = key.extract()?;
         let config_dict: Bound<'_, PyDict> = value.extract()?;
-        let json_module = py.import("json")?;
-        let config_json_py = json_module.call_method1("dumps", (config_dict,))?;
-        let config_json: String = config_json_py.extract()?;
-
-        let mut hasher = DefaultHasher::new();
-        obj_type.hash(&mut hasher);
-        config_json.hash(&mut hasher);
-        let cache_key = hasher.finish();
-
-        let config: NamespaceConfig = NAMESPACE_CONFIG_CACHE.with(|cache| {
-            let mut cache_ref = cache.borrow_mut();
-            if let Some((cached_type, cached_config)) = cache_ref.get(&cache_key) {
-                if cached_type == &obj_type {
-                    return Ok::<NamespaceConfig, pyo3::PyErr>(cached_config.clone());
-                }
-            }
-            let parsed: NamespaceConfig = serde_json::from_str(&config_json).map_err(|e| {
-                pyo3::exceptions::PyValueError::new_err(format!("JSON parse error: {}", e))
-            })?;
-            cache_ref.put(cache_key, (obj_type.clone(), parsed.clone()));
-            Ok(parsed)
-        })?;
-
+        let config = namespace_config_from_py_entry(py, &obj_type, &config_dict)?;
         let interned_config = InternedNamespaceConfig::from_config(&config, &mut interner);
         interned_namespaces.insert(interner.get_or_intern(&obj_type), interned_config);
     }

--- a/rust/kernel/src/replication.rs
+++ b/rust/kernel/src/replication.rs
@@ -9,8 +9,10 @@
 #![allow(dead_code)]
 
 use crate::kernel::OperationContext;
+use parking_lot::Mutex;
 use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
 use std::sync::Arc;
+use std::thread::JoinHandle;
 
 /// Replication scanner — scans metastore for entries needing replication.
 pub(crate) struct ReplicationScanner {
@@ -24,6 +26,9 @@ pub(crate) struct ReplicationScanner {
     target_mount: String,
     /// Running flag — set to false to stop the background loop.
     running: Arc<AtomicBool>,
+    /// Handle to the background worker, so `stop()` can join and callers
+    /// can verify the thread has actually exited (§ review fix #27).
+    worker: Mutex<Option<JoinHandle<()>>>,
     /// Counters for monitoring.
     pub scanned_count: Arc<AtomicU64>,
     pub replicated_count: Arc<AtomicU64>,
@@ -44,11 +49,56 @@ impl ReplicationScanner {
             source_mount: source_mount.to_string(),
             target_mount: target_mount.to_string(),
             running: Arc::new(AtomicBool::new(false)),
+            worker: Mutex::new(None),
             scanned_count: Arc::new(AtomicU64::new(0)),
             replicated_count: Arc::new(AtomicU64::new(0)),
             error_count: Arc::new(AtomicU64::new(0)),
             last_scan_ms: Arc::new(AtomicU64::new(0)),
         }
+    }
+
+    /// Normalize mount path into zone-canonical form.
+    ///
+    /// Examples for `zone_id = "z1"`:
+    /// - `"/z1/source"` -> `"/z1/source"` (already canonical)
+    /// - `"/source"`    -> `"/z1/source"`
+    /// - `"source"`     -> `"/z1/source"`
+    fn canonical_mount_for_zone(&self, mount: &str) -> String {
+        let normalized = if mount.starts_with('/') {
+            mount.to_string()
+        } else {
+            format!("/{mount}")
+        };
+        let zone_root = format!("/{}", self.zone_id);
+        let zone_prefix = format!("{zone_root}/");
+        if normalized == zone_root || normalized.starts_with(&zone_prefix) {
+            normalized
+        } else if normalized == "/" {
+            zone_root
+        } else {
+            format!("{zone_root}/{}", normalized.trim_start_matches('/'))
+        }
+    }
+
+    /// Map a source path under `source_mount` to the corresponding target path
+    /// under `target_mount`.
+    ///
+    /// Returns `None` when `source_path` is outside the source mount subtree.
+    fn map_source_to_target_path(
+        source_path: &str,
+        source_mount: &str,
+        target_mount: &str,
+    ) -> Option<String> {
+        if source_path == source_mount {
+            return Some(target_mount.to_string());
+        }
+        let source_prefix = format!("{}/", source_mount.trim_end_matches('/'));
+        if !source_path.starts_with(&source_prefix) {
+            return None;
+        }
+        let suffix = &source_path[source_prefix.len()..];
+        let target_base = target_mount.trim_end_matches('/');
+        Some(format!("{target_base}/{suffix}"))
     }
 
     /// Run one scan-and-replicate pass using the kernel.
@@ -69,6 +119,8 @@ impl ReplicationScanner {
         };
 
         let ctx = OperationContext::new(&self.zone_id, &self.zone_id, true, None, true);
+        let source_mount = self.canonical_mount_for_zone(&self.source_mount);
+        let target_mount = self.canonical_mount_for_zone(&self.target_mount);
         let mut scanned = 0;
         let mut replicated = 0;
         let mut errors = 0;
@@ -80,8 +132,16 @@ impl ReplicationScanner {
                 _ => continue, // No content to replicate
             };
 
-            // Check if content exists in target mount
-            let target_read = kernel.route(&entry.path, &self.zone_id, true, false);
+            // Only replicate entries under the configured source mount, and
+            // map them into the target mount subtree.
+            let target_path =
+                match Self::map_source_to_target_path(&entry.path, &source_mount, &target_mount) {
+                    Some(p) => p,
+                    None => continue,
+                };
+
+            // Check target path is routable/writable.
+            let target_read = kernel.route(&target_path, &self.zone_id, true, true);
             if target_read.is_err() {
                 continue; // Not routable to target
             }
@@ -96,8 +156,8 @@ impl ReplicationScanner {
                 _ => continue,
             };
 
-            // Write to target (the router will pick the target mount based on routing)
-            match kernel.sys_write(&entry.path, &ctx, &content) {
+            // Write to the mapped target path.
+            match kernel.sys_write(&target_path, &ctx, &content) {
                 Ok(r) if r.hit => {
                     replicated += 1;
                 }
@@ -138,7 +198,7 @@ impl ReplicationScanner {
         }
         let scanner = Arc::clone(self);
         let interval = std::time::Duration::from_millis(self.interval_ms);
-        std::thread::Builder::new()
+        let handle = std::thread::Builder::new()
             .name("replication-scanner".to_string())
             .spawn(move || {
                 while scanner.running.load(Ordering::Relaxed) {
@@ -150,6 +210,7 @@ impl ReplicationScanner {
                 }
             })
             .expect("failed to spawn replication-scanner thread");
+        *self.worker.lock() = Some(handle);
     }
 
     /// Check if the scanner is running.
@@ -157,9 +218,24 @@ impl ReplicationScanner {
         self.running.load(Ordering::Relaxed)
     }
 
-    /// Signal the scanner to stop.
+    /// Signal the scanner to stop. Returns without waiting; prefer
+    /// `stop_and_join` when deterministic shutdown matters.
     pub(crate) fn stop(&self) {
         self.running.store(false, Ordering::Relaxed);
+    }
+
+    /// Signal stop and block until the worker has actually exited
+    /// (§ review fix #27). Safe to call multiple times; a no-op if the
+    /// worker has already been joined.
+    #[allow(dead_code)]
+    pub(crate) fn stop_and_join(&self) {
+        self.running.store(false, Ordering::Relaxed);
+        let handle = self.worker.lock().take();
+        if let Some(handle) = handle {
+            // Swallow panics here — the scanner is background; we should
+            // not propagate a worker panic to the caller of shutdown.
+            let _ = handle.join();
+        }
     }
 
     /// Get stats: (scanned, replicated, errors, last_scan_ms).

--- a/rust/kernel/src/semaphore.rs
+++ b/rust/kernel/src/semaphore.rs
@@ -102,7 +102,10 @@ impl VFSSemaphore {
         ttl_ms: u64,
     ) -> Result<Option<String>, String> {
         let now_ns = monotonic_ns();
-        let expires_at_ns = now_ns + ttl_ms * 1_000_000;
+        // Saturating arithmetic so callers passing very large TTLs (or
+        // `u64::MAX` for "effectively forever") do not wrap past 0 and
+        // make the holder appear already expired (§ review fix #21).
+        let expires_at_ns = ttl_ms.saturating_mul(1_000_000).saturating_add(now_ns);
 
         let entry = state.semaphores.get_mut(name);
 
@@ -217,11 +220,23 @@ impl VFSSemaphore {
                 return Ok(None);
             }
 
-            // Blocking wait with Condvar
+            // Blocking wait with Condvar. Try-before-wait: a release may
+            // have raced in between the fast-path attempt above and us
+            // acquiring the mutex; detect that before sleeping (§ review
+            // fix #11).
             let deadline = Instant::now() + Duration::from_millis(timeout_ms);
 
             loop {
                 let mut state = self.state.lock();
+                match Self::try_acquire_locked(&mut state, &name, max_holders, ttl_ms) {
+                    Ok(Some(holder_id)) => {
+                        self.acquire_count.fetch_add(1, Ordering::Relaxed);
+                        return Ok(Some(holder_id));
+                    }
+                    Ok(None) => {}
+                    Err(msg) => return Err(msg),
+                }
+
                 let remaining = deadline.saturating_duration_since(Instant::now());
                 if remaining.is_zero() {
                     self.timeout_count.fetch_add(1, Ordering::Relaxed);
@@ -229,17 +244,16 @@ impl VFSSemaphore {
                 }
 
                 let wait_result = self.notify.wait_for(&mut state, remaining);
-
-                match Self::try_acquire_locked(&mut state, &name, max_holders, ttl_ms) {
-                    Ok(Some(holder_id)) => {
-                        self.acquire_count.fetch_add(1, Ordering::Relaxed);
-                        return Ok(Some(holder_id));
-                    }
-                    Ok(None) => {} // still full
-                    Err(msg) => return Err(msg),
-                }
-
                 if wait_result.timed_out() {
+                    // Final try after timeout (a release may race in).
+                    match Self::try_acquire_locked(&mut state, &name, max_holders, ttl_ms) {
+                        Ok(Some(holder_id)) => {
+                            self.acquire_count.fetch_add(1, Ordering::Relaxed);
+                            return Ok(Some(holder_id));
+                        }
+                        Ok(None) => {}
+                        Err(msg) => return Err(msg),
+                    }
                     self.timeout_count.fetch_add(1, Ordering::Relaxed);
                     return Ok(None);
                 }
@@ -274,7 +288,9 @@ impl VFSSemaphore {
         };
 
         if released {
-            self.notify.notify_all();
+            // One release frees one slot, so wake a single waiter to avoid a
+            // thundering-herd of futile wakeups under contention.
+            self.notify.notify_one();
             self.release_count.fetch_add(1, Ordering::Relaxed);
         }
 
@@ -294,7 +310,8 @@ impl VFSSemaphore {
 
         match entry.holders.get_mut(holder_id) {
             Some(holder) => {
-                holder.expires_at_ns = now_ns + ttl_ms * 1_000_000;
+                // Saturating arithmetic (§ review fix #21).
+                holder.expires_at_ns = ttl_ms.saturating_mul(1_000_000).saturating_add(now_ns);
                 true
             }
             None => false,

--- a/rust/kernel/src/shm_pipe.rs
+++ b/rust/kernel/src/shm_pipe.rs
@@ -243,8 +243,22 @@ impl SharedMemoryPipeBackend {
 
         let frame_len = HEADER_SIZE + payload_len;
         let tail_val = self.tail().load(Ordering::Relaxed);
+        let head_val = self.head().load(Ordering::Acquire);
         let tail_idx = tail_val % self.ring_cap;
         let contiguous = self.ring_cap - tail_idx;
+
+        // Physical ring-space check (includes header + potential sentinel).
+        // `used_bytes` is payload-only, which can under-count true ring fill
+        // for tiny payloads where header overhead (HEADER_SIZE=4) plus wrap
+        // padding is larger than the slack `ring_cap - user_capacity`.
+        let need = if frame_len > contiguous {
+            contiguous + frame_len
+        } else {
+            frame_len
+        };
+        if tail_val.saturating_sub(head_val) + need > self.ring_cap {
+            return Err(PipeError::Full(used, self.user_capacity));
+        }
 
         let ring = self.ring_slice();
 
@@ -436,12 +450,22 @@ impl SharedMemoryPipeBackend {
             libc::fcntl(space_fds[1], libc::F_SETFL, libc::O_NONBLOCK);
         }
 
+        // The creator is the writer only: it writes into `notify_data_wr`
+        // to wake the reader and listens on `space_rd_fd` for reader-side
+        // space notifications. It does NOT need `space_fds[1]` at all —
+        // retaining that fd kept the space-pipe alive even after the
+        // reader died, so `read(space_rd_fd)` would never see EOF and
+        // graceful shutdown was impossible (§ review fix #13). Close it.
+        unsafe {
+            libc::close(space_fds[1]);
+        }
+
         let core = SharedMemoryPipeBackend {
             mmap,
             ring_cap,
             user_capacity: capacity,
-            notify_data_wr: data_fds[1], // creator is the writer, writes data notification
-            notify_space_wr: space_fds[1], // attacher (reader) will write space notification
+            notify_data_wr: data_fds[1], // creator is the writer
+            notify_space_wr: -1,         // creator does not send space notifications
             is_creator: true,
             shm_path: shm_path.clone(),
         };
@@ -800,6 +824,27 @@ mod tests {
         assert!(std::path::Path::new(&path).exists());
         creator.cleanup().unwrap();
         assert!(!std::path::Path::new(&path).exists());
+    }
+
+    #[test]
+    fn test_many_tiny_pushes_cannot_overwrite_unread() {
+        // Regression for review fix #1: tiny payloads + frame headers must
+        // respect ring_cap, not only user_capacity.
+        let (creator, attacher) = create_pair(32);
+        let mut accepted = 0usize;
+        for _ in 0..64 {
+            match creator.push_inner(&[0xBBu8]) {
+                Ok(_) => accepted += 1,
+                Err(PipeError::Full(_, _)) => break,
+                Err(e) => panic!("unexpected push error: {e:?}"),
+            }
+        }
+        // floor(ring_cap / frame_len) = 64 / 5 = 12
+        assert!(accepted <= 12, "overflow: accepted {accepted} pushes");
+        for _ in 0..accepted {
+            assert_eq!(pop(&attacher), vec![0xBBu8]);
+        }
+        creator.cleanup().unwrap();
     }
 
     #[test]

--- a/rust/kernel/src/trigram.rs
+++ b/rust/kernel/src/trigram.rs
@@ -15,16 +15,17 @@ use library::trigram::format::{
 use library::trigram::posting::{intersect, union, PostingList};
 use library::trigram::query::{build_trigram_query, TrigramQuery};
 use library::trigram::write_index;
+use lru::LruCache;
 use memmap2::Mmap;
-use parking_lot::RwLock;
+use parking_lot::Mutex;
 use pyo3::prelude::*;
 use pyo3::types::PyDict;
 use rayon::prelude::*;
 use roaring::RoaringBitmap;
 use simdutf8::basic::from_utf8 as simd_from_utf8;
-use std::collections::HashMap;
 use std::fs::File;
 use std::io::Write;
+use std::num::NonZeroUsize;
 use std::path::{Path, PathBuf};
 use std::sync::Arc;
 
@@ -385,26 +386,42 @@ fn verify_file(
 // ---------------------------------------------------------------------------
 
 /// Global index cache: zone_path → reader.
-static INDEX_CACHE: std::sync::LazyLock<RwLock<HashMap<PathBuf, Arc<TrigramIndexReader>>>> =
-    std::sync::LazyLock::new(|| RwLock::new(HashMap::new()));
+///
+/// Bounded LRU (§ review fix #14). Previous `HashMap` grew forever — each
+/// entry pins a mmap + file handle, so long-lived processes touching many
+/// zones would eventually exhaust fds. Capacity picked to fit typical
+/// workloads (a few dozen active zones) while still being easy to tune.
+const TRIGRAM_CACHE_CAPACITY: usize = 64;
+
+static INDEX_CACHE: std::sync::LazyLock<Mutex<LruCache<PathBuf, Arc<TrigramIndexReader>>>> =
+    std::sync::LazyLock::new(|| {
+        Mutex::new(LruCache::new(
+            NonZeroUsize::new(TRIGRAM_CACHE_CAPACITY).unwrap(),
+        ))
+    });
 
 /// Get or open a cached index reader.
 fn get_cached_reader(path: &Path) -> Result<Arc<TrigramIndexReader>, TrigramError> {
-    // Fast path: read lock.
+    // Cheap lookup (LruCache::get is &mut, so a single Mutex is simpler
+    // than RwLock + two-phase lookup, and the critical section is tiny).
     {
-        let cache = INDEX_CACHE.read();
+        let mut cache = INDEX_CACHE.lock();
         if let Some(reader) = cache.get(path) {
             return Ok(Arc::clone(reader));
         }
     }
 
-    // Slow path: write lock, re-check to avoid TOCTOU race.
-    let mut cache = INDEX_CACHE.write();
-    if let Some(reader) = cache.get(path) {
-        return Ok(Arc::clone(reader));
-    }
+    // Slow path: open outside the lock (mmap + CRC verification can be
+    // expensive; holding the lock across it would serialize first-time
+    // access to distinct indices).
     let reader = Arc::new(TrigramIndexReader::open(path)?);
-    cache.insert(path.to_path_buf(), Arc::clone(&reader));
+
+    // Re-check under the lock to avoid a duplicate open racing in.
+    let mut cache = INDEX_CACHE.lock();
+    if let Some(existing) = cache.get(path) {
+        return Ok(Arc::clone(existing));
+    }
+    cache.put(path.to_path_buf(), Arc::clone(&reader));
     Ok(reader)
 }
 
@@ -415,32 +432,43 @@ fn get_cached_reader(path: &Path) -> Result<Arc<TrigramIndexReader>, TrigramErro
 /// Build a trigram index from a list of file paths and write to output_path.
 #[pyfunction]
 #[pyo3(signature = (file_paths, output_path))]
-pub fn build_trigram_index(file_paths: Vec<String>, output_path: &str) -> PyResult<()> {
-    let mut builder = TrigramIndexBuilder::new();
+pub fn build_trigram_index(
+    py: Python<'_>,
+    file_paths: Vec<String>,
+    output_path: &str,
+) -> PyResult<()> {
+    let output = output_path.to_string();
 
-    for path in &file_paths {
-        let content = match std::fs::read(path) {
-            Ok(c) => c,
-            Err(_) => continue, // Skip unreadable files.
-        };
-        builder.add_file(path, &content);
-    }
+    // File I/O and index construction can take seconds on large corpora;
+    // hold the GIL only for the final cache-invalidation step (§ review
+    // fix #15).
+    let build_result: Result<Vec<u8>, String> = py.detach(|| {
+        let mut builder = TrigramIndexBuilder::new();
+        for path in &file_paths {
+            let content = match std::fs::read(path) {
+                Ok(c) => c,
+                Err(_) => continue, // Skip unreadable files.
+            };
+            builder.add_file(path, &content);
+        }
+        write_index(&builder).map_err(|e| format!("Failed to build index: {e}"))
+    });
 
-    let bytes = write_index(&builder).map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to build index: {}", e))
-    })?;
+    let bytes = build_result.map_err(pyo3::exceptions::PyRuntimeError::new_err)?;
 
-    let mut file = File::create(output_path).map_err(|e| {
-        pyo3::exceptions::PyIOError::new_err(format!("Failed to create index file: {}", e))
-    })?;
-    file.write_all(&bytes).map_err(|e| {
-        pyo3::exceptions::PyIOError::new_err(format!("Failed to write index: {}", e))
-    })?;
+    py.detach(|| -> Result<(), String> {
+        let mut file =
+            File::create(&output).map_err(|e| format!("Failed to create index file: {e}"))?;
+        file.write_all(&bytes)
+            .map_err(|e| format!("Failed to write index: {e}"))?;
+        Ok(())
+    })
+    .map_err(pyo3::exceptions::PyIOError::new_err)?;
 
     // Invalidate cache for this path.
     let path = PathBuf::from(output_path);
-    let mut cache = INDEX_CACHE.write();
-    cache.remove(&path);
+    let mut cache = INDEX_CACHE.lock();
+    let _ = cache.pop(&path);
 
     Ok(())
 }
@@ -452,30 +480,36 @@ pub fn build_trigram_index(file_paths: Vec<String>, output_path: &str) -> PyResu
 #[pyfunction]
 #[pyo3(signature = (entries, output_path))]
 pub fn build_trigram_index_from_entries(
+    py: Python<'_>,
     entries: Vec<(String, Vec<u8>)>,
     output_path: &str,
 ) -> PyResult<()> {
-    let mut builder = TrigramIndexBuilder::new();
+    let output = output_path.to_string();
 
-    for (path, content) in &entries {
-        builder.add_file(path, content);
-    }
+    // Index construction + disk write are done off the GIL (§ review fix #15).
+    let bytes: Vec<u8> = py
+        .detach(|| -> Result<Vec<u8>, String> {
+            let mut builder = TrigramIndexBuilder::new();
+            for (path, content) in &entries {
+                builder.add_file(path, content);
+            }
+            write_index(&builder).map_err(|e| format!("Failed to build index: {e}"))
+        })
+        .map_err(pyo3::exceptions::PyRuntimeError::new_err)?;
 
-    let bytes = write_index(&builder).map_err(|e| {
-        pyo3::exceptions::PyRuntimeError::new_err(format!("Failed to build index: {}", e))
-    })?;
-
-    let mut file = File::create(output_path).map_err(|e| {
-        pyo3::exceptions::PyIOError::new_err(format!("Failed to create index file: {}", e))
-    })?;
-    file.write_all(&bytes).map_err(|e| {
-        pyo3::exceptions::PyIOError::new_err(format!("Failed to write index: {}", e))
-    })?;
+    py.detach(|| -> Result<(), String> {
+        let mut file =
+            File::create(&output).map_err(|e| format!("Failed to create index file: {e}"))?;
+        file.write_all(&bytes)
+            .map_err(|e| format!("Failed to write index: {e}"))?;
+        Ok(())
+    })
+    .map_err(pyo3::exceptions::PyIOError::new_err)?;
 
     // Invalidate cache for this path.
     let path = PathBuf::from(output_path);
-    let mut cache = INDEX_CACHE.write();
-    cache.remove(&path);
+    let mut cache = INDEX_CACHE.lock();
+    let _ = cache.pop(&path);
 
     Ok(())
 }
@@ -569,7 +603,7 @@ pub fn trigram_index_stats<'py>(
 #[pyo3(signature = (index_path,))]
 pub fn invalidate_trigram_cache(index_path: &str) -> PyResult<()> {
     let path = PathBuf::from(index_path);
-    let mut cache = INDEX_CACHE.write();
-    cache.remove(&path);
+    let mut cache = INDEX_CACHE.lock();
+    let _ = cache.pop(&path);
     Ok(())
 }

--- a/rust/kernel/src/volume_engine.rs
+++ b/rust/kernel/src/volume_engine.rs
@@ -1861,13 +1861,20 @@ impl VolumeEngine {
         let vol_id = vol.volume_id;
         let (sealed_path, _entries) = vol.seal(&self.volumes_dir).map_err(io_err)?;
 
-        // Cache FD for pread access (Issue #3404)
-        if let Err(e) = self.mem_index.write().open_volume(vol_id, &sealed_path) {
-            eprintln!(
-                "Warning: failed to cache volume FD for {}: {}",
-                sealed_path.display(),
-                e
-            );
+        // Cache FD for pread access (Issue #3404).
+        //
+        // `seal_volume` can be reached while `put_impl` is holding a mem_index
+        // write lock during dedup+append. Re-acquiring that same non-reentrant
+        // lock here deadlocks on volume rollover paths. Best-effort cache the
+        // FD only when we can grab the lock immediately.
+        if let Some(mut idx) = self.mem_index.try_write() {
+            if let Err(e) = idx.open_volume(vol_id, &sealed_path) {
+                eprintln!(
+                    "Warning: failed to cache volume FD for {}: {}",
+                    sealed_path.display(),
+                    e
+                );
+            }
         }
 
         // Register sealed volume path (replaces the .tmp entry)

--- a/rust/kernel/src/volume_engine.rs
+++ b/rust/kernel/src/volume_engine.rs
@@ -1649,17 +1649,37 @@ impl VolumeEngine {
     fn put_impl(&self, hash_hex: &str, data: &[u8], expiry: f64) -> PyResult<bool> {
         let hash = hex_to_hash(hash_hex)?;
 
-        // Dedup check: O(1) via in-memory index (Issue #3404)
-        // Use lookup_raw to bypass expiry check — we want to dedup even against expired entries
-        // that haven't been swept yet (content is still physically present).
-        if self.mem_index.read().lookup_raw(&hash).is_some() {
+        // Dedup check must be atomic with the subsequent append + index
+        // insert — otherwise two concurrent `put`s with the same hash can
+        // both pass the read check and both append, wasting space and
+        // breaking the CAS dedup guarantee (§ review fix #20).
+        //
+        // We hold the mem_index write lock across the entire append so
+        // exactly one writer wins and the loser is a cheap early-return.
+        let mut idx = self.mem_index.write();
+        // Use lookup_raw to bypass expiry — the blob is still physically
+        // present even if its TTL has elapsed.
+        if idx.lookup_raw(&hash).is_some() {
             return Ok(false);
         }
 
-        // Append to active volume
+        // Append to active volume (may seal + open a new volume).
         let (volume_id, offset) = self.append_to_active(&hash, data)?;
 
-        // Buffer index entry (not committed to redb yet)
+        // Update in-memory index while still holding the write lock so
+        // racing `exists`/`get` callers see a consistent view.
+        idx.insert(
+            hash,
+            MemIndexEntry {
+                volume_id,
+                offset,
+                size: data.len() as u32,
+                expiry,
+            },
+        );
+        drop(idx);
+
+        // Buffer index entry (not committed to redb yet).
         let entry = IndexEntry {
             volume_id,
             offset,
@@ -1673,17 +1693,6 @@ impl VolumeEngine {
             pending.push((hash, entry));
             pending.len() >= self.index_batch_size
         };
-
-        // Update in-memory index for O(1) reads (Issue #3404)
-        self.mem_index.write().insert(
-            hash,
-            MemIndexEntry {
-                volume_id,
-                offset,
-                size: data.len() as u32,
-                expiry,
-            },
-        );
 
         // Track per-volume max expiry for volume-level TTL (Issue #3405)
         if expiry > 0.0 {

--- a/scripts/codegen_kernel_abi.py
+++ b/scripts/codegen_kernel_abi.py
@@ -1765,12 +1765,15 @@ def _dispatch_adapter_bodies(traits: list[TraitDef]) -> list[str]:
             lines.append(f"    {cached_name}: String,")
         lines.append("}")
         lines.append("")
+        lines.append('#[cfg(feature = "py-hook-adapters")]')
         lines.append(f"unsafe impl Send for {adapter_name} {{}}")
+        lines.append('#[cfg(feature = "py-hook-adapters")]')
         lines.append(f"unsafe impl Sync for {adapter_name} {{}}")
 
         # Constructor (only for those with cached_name)
         if cached_name:
             lines.append("")
+            lines.append('#[cfg(feature = "py-hook-adapters")]')
             lines.append(f"impl {adapter_name} {{")
             lines.append("    pub(crate) fn new(py: Python<'_>, hook: Py<PyAny>) -> Self {")
             lines.append("        let name = hook")
@@ -1787,6 +1790,7 @@ def _dispatch_adapter_bodies(traits: list[TraitDef]) -> list[str]:
 
         # Trait impl
         lines.append("")
+        lines.append('#[cfg(feature = "py-hook-adapters")]')
         lines.append(f"impl {trait_name} for {adapter_name} {{")
         for method in trait.methods:
             method_lines = _gen_dispatch_method(trait_name, method)
@@ -1842,8 +1846,11 @@ def generate_pyo3_rs(traits: list[TraitDef]) -> str:
             "    CasLocalBackend, LocalConnectorBackend, ObjectStore, PathLocalBackend, StorageError,",
             "    WriteResult,",
             "};",
+            '#[cfg(feature = "py-hook-adapters")]',
             "use crate::dispatch::PathResolver;",
-            "use crate::hook_registry::{HookRegistry, InterceptHook};",
+            "use crate::hook_registry::HookRegistry;",
+            '#[cfg(feature = "py-hook-adapters")]',
+            "use crate::hook_registry::InterceptHook;",
             "use crate::kernel::{Kernel, KernelError, OperationContext};",
             "use crate::lock::VFSLockManager;",
             "use crate::metastore::{FileMetadata, MetastoreError};",
@@ -2583,6 +2590,25 @@ def generate_pyo3_rs(traits: list[TraitDef]) -> str:
             "        metastore_path: Option<&str>,",
             "        is_external: bool,",
             "    ) -> PyResult<()> {",
+            '        #[cfg(not(feature = "connectors"))]',
+            "        let _ = (",
+            "            openai_base_url,",
+            "            openai_api_key,",
+            "            openai_model,",
+            "            s3_bucket,",
+            "            s3_prefix,",
+            "            aws_region,",
+            "            aws_access_key,",
+            "            aws_secret_key,",
+            "            s3_endpoint,",
+            "            gcs_bucket,",
+            "            gcs_prefix,",
+            "            access_token,",
+            "            root_folder_id,",
+            "            bot_token,",
+            "            default_channel,",
+            "        );",
+            "",
             "        // Backend resolution: grpc_addr -> GrpcObjectStoreAdapter (zero GIL)",
             "        //                     local_root -> CasLocalBackend/PathLocalBackend/LocalConnectorBackend",
             "        //                     openai_* -> OpenAIBackend (§10 D3)",
@@ -2872,11 +2898,22 @@ def generate_pyo3_rs(traits: list[TraitDef]) -> str:
             "            Err(_) => false,",
             "        };",
             "",
-            "        let adapter = PyInterceptHookAdapter::new(py, hook.clone_ref(py));",
-            "        self.hooks",
-            "            .lock()",
-            "            .register(op, Box::new(adapter), hook, has_pre, is_async_post, name);",
-            "        Ok(())",
+            '        #[cfg(feature = "py-hook-adapters")]',
+            "        {",
+            "            let adapter = PyInterceptHookAdapter::new(py, hook.clone_ref(py));",
+            "            self.hooks",
+            "                .lock()",
+            "                .register(op, Box::new(adapter), hook, has_pre, is_async_post, name);",
+            "            Ok(())",
+            "        }",
+            "",
+            '        #[cfg(not(feature = "py-hook-adapters"))]',
+            "        {",
+            "            let _ = (hook, has_pre, is_async_post, name);",
+            "            Err(pyo3::exceptions::PyRuntimeError::new_err(",
+            "                \"register_hook requires feature 'py-hook-adapters'\",",
+            "            ))",
+            "        }",
             "    }",
             "",
             "    fn unregister_hook(&self, py: Python<'_>, op: &str, hook: &Bound<'_, PyAny>) -> bool {",

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -3840,6 +3840,25 @@ class NexusFS(  # type: ignore[misc]
         _rust_ctx = self._build_rust_ctx(context, is_admin)
         _rename_result = self._kernel.sys_rename(old_path, new_path, _rust_ctx)
 
+        # Rust fast path completed the full rename (metastore + backend + dcache).
+        # Do not run Python fallback rename again; that can turn a successful
+        # rename into a false 404 because the source path is already gone.
+        if _rename_result.hit:
+            if _rename_result.post_hook_needed:
+                from nexus.contracts.vfs_hooks import RenameHookContext
+
+                _rename_ctx = RenameHookContext(
+                    old_path=old_path,
+                    new_path=new_path,
+                    context=context,
+                    zone_id=zone_id,
+                    agent_id=agent_id,
+                    is_directory=bool(_rename_result.is_directory),
+                    metadata=meta,
+                )
+                self._kernel.dispatch_post_hooks("rename", _rename_ctx)
+            return {}
+
         # Python always does full metastore rename under VFS lock
         # (Rust kernel has the capability for FUSE/gRPC bypass, but Python
         # wrapper continues to use route.metastore for authoritative metadata)

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -3840,10 +3840,17 @@ class NexusFS(  # type: ignore[misc]
         _rust_ctx = self._build_rust_ctx(context, is_admin)
         _rename_result = self._kernel.sys_rename(old_path, new_path, _rust_ctx)
 
-        # Rust fast path completed the full rename (metastore + backend + dcache).
-        # Do not run Python fallback rename again; that can turn a successful
-        # rename into a false 404 because the source path is already gone.
-        if _rename_result.hit:
+        # Rust may report hit=true even when the authoritative Python metastore
+        # (e.g. dual-write/raft-backed configurations) still requires the
+        # Python rename path to update its own rows. Only short-circuit when the
+        # metastore already reflects old->new; otherwise run Python fallback.
+        _old_still_visible = old_route.metastore.exists(
+            old_path
+        ) or self.metadata.is_implicit_directory(old_path)
+        _new_now_visible = new_route.metastore.exists(
+            new_path
+        ) or self.metadata.is_implicit_directory(new_path)
+        if _rename_result.hit and not _old_still_visible and _new_now_visible:
             if _rename_result.post_hook_needed:
                 from nexus.contracts.vfs_hooks import RenameHookContext
 

--- a/src/nexus/server/api/v2/routers/locks.py
+++ b/src/nexus/server/api/v2/routers/locks.py
@@ -9,6 +9,7 @@ Issue #3250: TUI Locks tab.
 import logging
 import time
 import uuid
+from dataclasses import asdict, is_dataclass
 from typing import Any
 
 from fastapi import APIRouter, HTTPException, Request
@@ -40,6 +41,85 @@ def _get_lock_manager(request: Request) -> Any:
     return None
 
 
+def _normalize_mode(mode: str) -> str:
+    """Map API lock modes to AdvisoryLockManager modes."""
+    mode_norm = (mode or "mutex").strip().lower()
+    if mode_norm in {"shared", "read", "reader"}:
+        return "shared"
+    return "exclusive"
+
+
+def _holder_to_dict(holder: Any) -> dict[str, Any]:
+    """Normalize holder info from dict/dataclass/object to dict."""
+    if holder is None:
+        return {}
+    if isinstance(holder, dict):
+        return holder
+    if is_dataclass(holder) and not isinstance(holder, type):
+        return asdict(holder)
+    return {
+        "lock_id": getattr(holder, "lock_id", None),
+        "holder_info": getattr(holder, "holder_info", ""),
+        "acquired_at": getattr(holder, "acquired_at", 0),
+        "expires_at": getattr(holder, "expires_at", 0),
+    }
+
+
+def _lock_to_response(lock: Any) -> dict[str, Any]:
+    """Normalize lock info from manager/list call into API response shape."""
+    if lock is None:
+        return {}
+    if isinstance(lock, dict):
+        holders = lock.get("holders", [])
+        first_holder = _holder_to_dict(holders[0]) if holders else {}
+        return {
+            "lock_id": lock.get("lock_id") or first_holder.get("lock_id") or str(uuid.uuid4()),
+            "resource": lock.get("resource", lock.get("path", "")),
+            "mode": lock.get("mode", "mutex"),
+            "max_holders": lock.get("max_holders", 1),
+            "holder_info": lock.get("holder_info", first_holder.get("holder_info", "")),
+            "acquired_at": lock.get("acquired_at", first_holder.get("acquired_at", 0)),
+            "expires_at": lock.get("expires_at", first_holder.get("expires_at", 0)),
+            "fence_token": lock.get("fence_token", 0),
+        }
+
+    # Dataclass/object shape (e.g. LockInfo + HolderInfo).
+    holders = list(getattr(lock, "holders", []) or [])
+    first_holder = _holder_to_dict(holders[0]) if holders else {}
+    return {
+        "lock_id": first_holder.get("lock_id") or str(uuid.uuid4()),
+        "resource": getattr(lock, "resource", getattr(lock, "path", "")),
+        "mode": getattr(lock, "mode", "mutex"),
+        "max_holders": getattr(lock, "max_holders", 1),
+        "holder_info": first_holder.get("holder_info", ""),
+        "acquired_at": first_holder.get("acquired_at", 0),
+        "expires_at": first_holder.get("expires_at", 0),
+        "fence_token": getattr(lock, "fence_token", 0),
+    }
+
+
+def _mgr_release(mgr: Any, lock_id: str, resource: str) -> bool:
+    """Call manager.release with cross-version signature compatibility."""
+    try:
+        return bool(mgr.release(lock_id, resource))
+    except TypeError:
+        try:
+            return bool(mgr.release(resource, lock_id=lock_id))
+        except TypeError:
+            return bool(mgr.release(resource, lock_id))
+
+
+def _mgr_extend(mgr: Any, lock_id: str, resource: str, ttl: int) -> Any:
+    """Call manager.extend with cross-version signature compatibility."""
+    try:
+        return mgr.extend(lock_id, resource, ttl=float(ttl))
+    except TypeError:
+        try:
+            return mgr.extend(resource, lock_id=lock_id, ttl=ttl)
+        except TypeError:
+            return mgr.extend(resource, lock_id, ttl)
+
+
 @router.get("")
 async def list_locks(request: Request) -> dict[str, Any]:
     """List all active locks."""
@@ -47,20 +127,11 @@ async def list_locks(request: Request) -> dict[str, Any]:
     mgr = _get_lock_manager(request)
     if mgr and hasattr(mgr, "list_locks"):
         try:
-            kernel_locks = mgr.list_locks()
-            locks = [
-                {
-                    "lock_id": lock.get("lock_id", str(uuid.uuid4())),
-                    "resource": lock.get("resource", lock.get("path", "")),
-                    "mode": lock.get("mode", "mutex"),
-                    "max_holders": lock.get("max_holders", 1),
-                    "holder_info": lock.get("holder_info", lock.get("holder", "")),
-                    "acquired_at": lock.get("acquired_at", 0),
-                    "expires_at": lock.get("expires_at", 0),
-                    "fence_token": lock.get("fence_token", 0),
-                }
-                for lock in kernel_locks
-            ]
+            try:
+                kernel_locks = mgr.list_locks(pattern="", limit=1000)
+            except TypeError:
+                kernel_locks = mgr.list_locks()
+            locks = [_lock_to_response(lock) for lock in (kernel_locks or [])]
             return {"locks": locks, "count": len(locks)}
         except Exception as e:
             logger.debug("Kernel lock list failed: %s", e)
@@ -86,8 +157,26 @@ async def acquire_lock(
     mgr = _get_lock_manager(request)
     if mgr and hasattr(mgr, "acquire"):
         try:
-            result = mgr.acquire(resource, mode=body.mode, ttl=body.ttl_seconds)
-            return {"status": "acquired", "lock_id": str(result), "resource": resource}
+            mode = _normalize_mode(body.mode)
+            lock_id = mgr.acquire(resource, mode=mode, ttl=float(body.ttl_seconds))
+            if lock_id is None:
+                raise HTTPException(status_code=409, detail=f"Resource already locked: {resource}")
+
+            # Keep mirror state for compatibility/fallback paths.
+            now = time.time()
+            _locks[resource] = {
+                "lock_id": str(lock_id),
+                "resource": resource,
+                "mode": "mutex" if mode == "exclusive" else "shared",
+                "max_holders": 1,
+                "holder_info": "kernel",
+                "acquired_at": now,
+                "expires_at": now + body.ttl_seconds,
+                "fence_token": 0,
+            }
+            return {"status": "acquired", "lock_id": str(lock_id), "resource": resource}
+        except HTTPException:
+            raise
         except Exception as e:
             logger.debug("Kernel lock acquire failed: %s", e)
 
@@ -121,9 +210,13 @@ async def release_lock(
     mgr = _get_lock_manager(request)
     if mgr and hasattr(mgr, "release"):
         try:
-            mgr.release(resource, lock_id=lock_id)
+            released = _mgr_release(mgr, lock_id, resource)
+            if not released:
+                raise HTTPException(status_code=404, detail=f"Lock not found: {resource}")
             _locks.pop(resource, None)
             return
+        except HTTPException:
+            raise
         except Exception as e:
             logger.debug("Kernel lock release failed: %s", e)
 
@@ -144,8 +237,16 @@ async def extend_lock(
     mgr = _get_lock_manager(request)
     if mgr and hasattr(mgr, "extend"):
         try:
-            mgr.extend(resource, lock_id=body.lock_id, ttl=body.ttl)
+            result = _mgr_extend(mgr, body.lock_id, resource, body.ttl)
+            success = bool(getattr(result, "success", result))
+            if not success:
+                raise HTTPException(status_code=404, detail=f"Lock not found: {resource}")
+
+            if resource in _locks:
+                _locks[resource]["expires_at"] = time.time() + body.ttl
             return {"status": "extended", "resource": resource}
+        except HTTPException:
+            raise
         except Exception as e:
             logger.debug("Kernel lock extend failed: %s", e)
 


### PR DESCRIPTION
## Summary
- Fix correctness bugs found in `rust/kernel` review, including CAS chunk reassembly validation, lock-free ring overwrite guards, path traversal segment handling, and Windows-safe CAS dedup races.
- Improve hot-path performance by releasing the GIL in heavy PyO3 paths, reusing OpenAI/gRPC runtime clients, and reducing lock/semaphore thundering-herd wakeups.
- Align feature-gating and codegen for `generated_pyo3`/hook adapters so `--no-default-features` builds stay healthy, then regenerate synced bindings.

## Test plan
- [x] `cargo check -p kernel --tests`
- [x] `cargo check -p kernel --tests --no-default-features`
- [x] `cargo clippy -p kernel`
- [ ] `cargo test -p kernel` (environment-dependent PyO3 linking on this host)

