### PR TITLE
refactor: rename PersistentService -> BackgroundService + add PasswordVaultService

### DIFF
--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -81,13 +81,13 @@ See `factory/orchestrator.py` for implementation.
 #### Service Lifecycle Protocols
 
 One-dimension model: the only user-facing lifecycle dimension is
-**daemon vs on-demand** (`PersistentService` protocol). Hook management
+**background vs on-demand** (`BackgroundService` protocol). Hook management
 uses duck-typed `hook_spec()` — the kernel auto-captures hooks via
 `hasattr(instance, 'hook_spec')` at `enlist()` time.
 
 | Mechanism | Methods | Kernel auto-manages |
 |-----------|---------|---------------------|
-| `PersistentService` protocol | `start()`, `stop()` | `start()` on bootstrap (dependency order); `stop()` on shutdown (reverse order) |
+| `BackgroundService` protocol | `start()`, `stop()` | `start()` on bootstrap (dependency order); `stop()` on shutdown (reverse order) |
 | Duck-typed `hook_spec()` | `hook_spec()` → `HookSpec` | Hook registration into KernelDispatch at `enlist()` time; unregister at shutdown |
 
 One-click contract: implement protocol / `hook_spec()` →
@@ -395,7 +395,7 @@ with them indirectly through syscalls. See §2.2 for per-syscall usage.
 | **Dispatch (Rust Kernel + DispatchMixin)** | `core.nexus_fs_dispatch` + `rust/kernel/src/dispatch.rs` | `security_hook_heads` + `fsnotify` | Three-phase VFS dispatch (§2.4) + driver lifecycle hooks (MOUNT/UNMOUNT). Rust Kernel owns PathTrie + HookRegistry + ObserverRegistry (pure Rust, zero Py\<PyAny\>). DispatchMixin provides Python-side registration API. Empty = zero overhead |
 | **PipeManager + StreamManager** | `rust/kernel/src/pipe_manager.rs` + `rust/kernel/src/stream_manager.rs` | `pipe(2)` + append-only log | VFS named IPC. DT_PIPE: destructive FIFO (MemoryPipeBackend / SharedMemoryPipeBackend). DT_STREAM: non-destructive offset reads. Details in §4.2 |
 | **FileWatcher + FileEvent** | `core.file_watcher` + `core.file_events` | `inotify(7)` + `fsnotify_event` | File change notification + immutable mutation records. Local OBSERVE waiters + optional RemoteWatchProtocol. Details in §4.3 |
-| **ServiceRegistry** | `core.service_registry` | `init/main.c` + `module.c` | Kernel-owned symbol table + lifecycle orchestration (enlist/swap/shutdown). PersistentService + duck-typed hook_spec() |
+| **ServiceRegistry** | `core.service_registry` | `init/main.c` + `module.c` | Kernel-owned symbol table + lifecycle orchestration (enlist/swap/shutdown). BackgroundService + duck-typed hook_spec() |
 | **DriverLifecycleCoordinator** | `rust/kernel/src/dlc.rs` + `core.driver_lifecycle_coordinator` | `register_filesystem` + `kern_mount` | Rust DLC: routing table + metastore + dcache + lock manager upgrade + **federation dcache-coherence callback** (installs a per-mount invalidator on the zone's state machine so committed metadata mutations evict stale dcache entries on every voter). Python DLC: backend refs (`_PyMountInfo`) + event dispatch |
 
 ### 4.1 Unified LockManager — I/O Lock + Advisory Lock

--- a/src/nexus/bricks/rebac/cache/tiger/expander.py
+++ b/src/nexus/bricks/rebac/cache/tiger/expander.py
@@ -379,16 +379,16 @@ class DirectoryGrantExpander:
         return total_expanded
 
     async def start(self) -> None:
-        """PersistentService: start the worker loop as a background task."""
+        """BackgroundService: start the worker loop as a background task."""
         if self._running:
             return  # idempotent
         self._worker_task: asyncio.Task | None = asyncio.create_task(
             self.run_worker(), name="directory-grant-expander"
         )
-        logger.info("[LEOPARD-WORKER] Started via PersistentService.start()")
+        logger.info("[LEOPARD-WORKER] Started via BackgroundService.start()")
 
     async def stop(self) -> None:
-        """PersistentService: stop the worker gracefully."""
+        """BackgroundService: stop the worker gracefully."""
         self._running = False
         if self._stop_event:
             self._stop_event.set()
@@ -400,7 +400,7 @@ class DirectoryGrantExpander:
     async def run_worker(self) -> None:
         """Run the expansion worker continuously.
 
-        Prefer ``start()`` / ``stop()`` for PersistentService lifecycle.
+        Prefer ``start()`` / ``stop()`` for BackgroundService lifecycle.
         """
         self._running = True
         self._stop_event = asyncio.Event()

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -834,7 +834,7 @@ class SearchDaemon:
         self._initialized = False
         logger.info("SearchDaemon shutdown complete")
 
-    # PersistentService protocol aliases
+    # BackgroundService protocol aliases
     start = startup
     stop = shutdown
 

--- a/src/nexus/cache/brick.py
+++ b/src/nexus/cache/brick.py
@@ -50,7 +50,7 @@ class CacheBrick:
     """Tier 2 Cache Brick — owns all cache domain services.
 
     Provides protocol-typed accessors for domain caches with
-    start/stop lifecycle (enlisted as PersistentService via ServiceRegistry).
+    start/stop lifecycle (enlisted as BackgroundService via ServiceRegistry).
 
     Example::
 

--- a/src/nexus/contracts/protocols/__init__.py
+++ b/src/nexus/contracts/protocols/__init__.py
@@ -38,7 +38,7 @@ from nexus.contracts.protocols.rebac import ReBACBrickProtocol
 from nexus.contracts.protocols.sandbox import SandboxProtocol
 from nexus.contracts.protocols.scheduler import AgentRequest, SchedulerProtocol
 from nexus.contracts.protocols.search import SearchBrickProtocol, SearchProtocol
-from nexus.contracts.protocols.service_lifecycle import PersistentService
+from nexus.contracts.protocols.service_lifecycle import BackgroundService
 from nexus.contracts.protocols.share_link import ShareLinkProtocol
 from nexus.contracts.protocols.time_travel import TimeTravelProtocol
 from nexus.contracts.protocols.token_encryptor import TokenEncryptor
@@ -49,6 +49,7 @@ from nexus.contracts.protocols.workspace_manager import WorkspaceManagerProtocol
 __all__ = [
     "APIKeyCreatorProtocol",
     "AgentRequest",
+    "BackgroundService",
     "ChunkedUploadProtocol",
     "EntityRegistryProtocol",
     "FileReaderProtocol",
@@ -62,7 +63,6 @@ __all__ = [
     "OperationLogProtocol",
     "ParseProtocol",
     "PaymentProtocol",
-    "PersistentService",
     "PermissionEnforcerProtocol",
     "PermissionProtocol",
     "ReBACBrickProtocol",

--- a/src/nexus/contracts/protocols/service_lifecycle.py
+++ b/src/nexus/contracts/protocols/service_lifecycle.py
@@ -42,27 +42,27 @@ from __future__ import annotations
 from typing import Protocol, runtime_checkable
 
 # ---------------------------------------------------------------------------
-# PersistentService — requires long-running process
+# BackgroundService — requires long-running process
 # ---------------------------------------------------------------------------
 
 
 @runtime_checkable
-class PersistentService(Protocol):
+class BackgroundService(Protocol):
     """Service that requires a long-running process (background workers).
 
-    PersistentServices have background tasks that run continuously
+    BackgroundServices have background tasks that run continuously
     (e.g., event delivery polling, deferred permission flushing).
     They need an ``asyncio`` event loop and cannot operate in
     on-demand mode (Lambda, Cloud Run single-request).
 
     The kernel and CLI use this protocol to determine distro type::
 
-        persistent = [
+        background = [
             name for name, svc in registry.all()
-            if isinstance(svc, PersistentService)
+            if isinstance(svc, BackgroundService)
         ]
-        if persistent:
-            log.info("Persistent distro: %s", persistent)
+        if background:
+            log.info("Background distro: %s", background)
         else:
             log.info("On-demand compatible distro")
 
@@ -82,7 +82,7 @@ class PersistentService(Protocol):
 
     Design note:
         Separate from ``BrickLifecycleProtocol`` which adds ``health_check()``
-        and integrates with the BLM FSM.  ``PersistentService`` is lighter —
+        and integrates with the BLM FSM.  ``BackgroundService`` is lighter —
         just the start/stop contract for distro classification.
     """
 

--- a/src/nexus/contracts/protocols/service_lifecycle.py
+++ b/src/nexus/contracts/protocols/service_lifecycle.py
@@ -1,40 +1,73 @@
-"""Service lifecycle contract — PersistentService protocol (Issue #1577).
+"""Service lifecycle contract — ``BackgroundService`` protocol (Issue #1577).
 
-One-dimension model: the only user-facing lifecycle dimension is
-**daemon vs on-demand** (PersistentService).  Hook management uses
-duck-typed ``hook_spec()`` — the kernel auto-captures hooks via
-``hasattr(instance, 'hook_spec')`` at enlist() time.
+``BackgroundService`` is the **opt-in** protocol for services that run
+background work (event loops, queue pollers, replication scanners,
+deferred flushers).  It is not a default — implement it **only** when
+the service actually spawns long-running tasks that outlive a single
+request.
 
-Usage::
+**Most services don't implement this — they're plain classes.**  Plain
+classes are on-demand compatible (AWS Lambda, Cloud Run single-request)
+by default, no declaration needed.  A service becomes a
+``BackgroundService`` by adding ``start()`` and ``stop()`` methods; the
+``ServiceRegistry`` detects this structurally at ``enlist()`` time
+(``@runtime_checkable``).
 
-    from nexus.contracts.protocols.service_lifecycle import PersistentService
+Two parallel shapes — pick whichever the service actually needs:
 
-    if isinstance(svc, PersistentService):
-        await svc.start()              # begin background work
-        await svc.stop()               # graceful shutdown
+On-demand (default) — no lifecycle declaration::
 
-    # Hook management — duck-typed, no protocol needed:
-    if hasattr(svc, 'hook_spec'):
-        spec = svc.hook_spec()         # declare VFS hooks
+    class SecretsService:
+        def __init__(self, store: KVStore) -> None:
+            self._store = store
+
+        def get(self, key: str) -> str | None:
+            return self._store.get(key)
+
+        # No start() / stop() — plain class, registered on-demand.
+
+Background (opt-in) — implements start/stop::
+
+    class EventDeliveryWorker:
+        async def start(self) -> None:
+            self._task = asyncio.create_task(self._poll_loop())
+
+        async def stop(self) -> None:
+            self._running = False
+            await self._task
+
+Distribution classification:
+    Services that do **not** implement ``BackgroundService`` → on-demand
+    distro (Lambda / Cloud Run compatible). A distro with zero
+    ``BackgroundService`` implementations can run without a long-lived
+    process; any non-empty set requires a server/worker host.
+
+Hook management is a separate, duck-typed concern: any service
+(background or on-demand) may expose a ``hook_spec()`` method; the
+kernel auto-captures it via ``hasattr(instance, 'hook_spec')`` at
+``enlist()`` time.  ``hook_spec()`` is not part of this protocol.
 
 Design decisions:
-    - Protocol (structural) over ABC (nominal) — services satisfy the contract
-      by implementing the methods, no explicit inheritance required.
-    - @runtime_checkable — coordinator and CLI can use isinstance() checks.
-    - hook_spec() is duck-typed convention, not a protocol requirement.
-      The kernel auto-captures via hasattr() at enlist() time.
+    - Protocol (structural) over ABC (nominal) — services satisfy the
+      contract by implementing the methods; no explicit inheritance.
+    - ``@runtime_checkable`` — registry and CLI use ``isinstance()``.
+    - ``hook_spec()`` is a duck-typed convention, not a protocol
+      requirement. Captured via ``hasattr()`` at enlist() time.
     - HotSwappable protocol deleted (YAGNI) — all 22 implementations had
       trivial drain()/activate().  Swap uses unified refcount drain path.
-    - ServiceQuadrant enum deleted — the "HotSwappable" axis was a kernel
-      implementation detail, not a user-facing constraint.
+    - ServiceQuadrant enum deleted — the "HotSwappable" axis was a
+      kernel implementation detail, not a user-facing constraint.
 
 Linux analogy:
-    PersistentService ~ kthread (kernel thread that runs in background)
+    ``BackgroundService`` ~ kthread (kernel thread that runs in the
+    background).  On-demand services ~ regular functions invoked per
+    request.
 
 References:
     - docs/architecture/KERNEL-ARCHITECTURE.md
     - Issue #1452: Service lifecycle / hot-swap
     - Issue #1577: HotSwappable + PersistentService protocols
+    - Issue #1580: Auto-lifecycle for background services
 """
 
 from __future__ import annotations
@@ -42,48 +75,20 @@ from __future__ import annotations
 from typing import Protocol, runtime_checkable
 
 # ---------------------------------------------------------------------------
-# BackgroundService — requires long-running process
+# BackgroundService — opt-in: implement only for services with background work
 # ---------------------------------------------------------------------------
 
 
 @runtime_checkable
 class BackgroundService(Protocol):
-    """Service that requires a long-running process (background workers).
-
-    BackgroundServices have background tasks that run continuously
-    (e.g., event delivery polling, deferred permission flushing).
-    They need an ``asyncio`` event loop and cannot operate in
-    on-demand mode (Lambda, Cloud Run single-request).
-
-    The kernel and CLI use this protocol to determine distro type::
-
-        background = [
-            name for name, svc in registry.all()
-            if isinstance(svc, BackgroundService)
-        ]
-        if background:
-            log.info("Background distro: %s", background)
-        else:
-            log.info("On-demand compatible distro")
+    """Opt-in protocol for services with long-running background work.
 
     Implementors provide:
         start()  — begin background work (spawn tasks, open connections)
         stop()   — graceful shutdown (drain queues, close connections)
 
-    Example::
-
-        class EventDeliveryWorker:
-            async def start(self) -> None:
-                self._task = asyncio.create_task(self._poll_loop())
-
-            async def stop(self) -> None:
-                self._running = False
-                await self._task
-
-    Design note:
-        Separate from ``BrickLifecycleProtocol`` which adds ``health_check()``
-        and integrates with the BLM FSM.  ``BackgroundService`` is lighter —
-        just the start/stop contract for distro classification.
+    Most services should NOT implement this protocol (see module
+    docstring for the on-demand default).
     """
 
     async def start(self) -> None:

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -275,11 +275,11 @@ class NexusFS(  # type: ignore[misc]
         self._initialized = True
 
     def bootstrap(self) -> None:
-        """Phase 3: Start persistent services.  Server/Worker only.
+        """Phase 3: Start background services.  Server/Worker only.
 
-        Auto-starts all PersistentService instances (ZoneLifecycleService,
+        Auto-starts all BackgroundService instances (ZoneLifecycleService,
         EventDeliveryWorker, DeferredPermissionBuffer, etc.) via
-        ServiceRegistry.start_persistent_services().
+        ServiceRegistry.start_background_services().
 
         Idempotent — guarded by ``_bootstrapped`` flag.
         """
@@ -287,10 +287,10 @@ class NexusFS(  # type: ignore[misc]
             return
         if not self._initialized:
             self.initialize()
-        # Auto-lifecycle: start PersistentService instances (Issue #1580)
+        # Auto-lifecycle: start BackgroundService instances (Issue #1580)
         coord = self.service_coordinator
         if coord is not None:
-            coord.start_persistent_services()
+            coord.start_background_services()
             coord.mark_bootstrapped()  # future enlist() calls auto-start
         self._bootstrapped = True
 
@@ -4796,7 +4796,7 @@ class NexusFS(  # type: ignore[misc]
     # Pipe/stream methods in nexus_fs_ipc.py (IPCMixin)
 
     def aclose(self) -> None:
-        """Shutdown: stop PersistentService + unregister hooks, then close.
+        """Shutdown: stop BackgroundService + unregister hooks, then close.
 
         Calls coordinator lifecycle methods first, then
         delegates to close() for sync resource cleanup.
@@ -4806,7 +4806,7 @@ class NexusFS(  # type: ignore[misc]
 
         coord = self.service_coordinator
         if coord is not None:
-            coord.stop_persistent_services()
+            coord.stop_background_services()
             coord._unregister_all_hooks()
         self.close()
 

--- a/src/nexus/core/service_registry.py
+++ b/src/nexus/core/service_registry.py
@@ -10,7 +10,7 @@ lifecycle in one module.
 It auto-detects lifecycle requirements:
 
     On-demand service       — register only, duck-type hook_spec() for hooks
-    PersistentService       — register + start (deferred pre-bootstrap)
+    BackgroundService       — register + start (deferred pre-bootstrap)
 
 Hook management is automatic: if an instance has a ``hook_spec()`` method
 (duck-typed), the kernel captures and registers hooks at enlist() time.
@@ -36,7 +36,7 @@ from types import MappingProxyType
 from typing import Any
 
 from nexus.contracts.protocols.service_hooks import HookSpec
-from nexus.contracts.protocols.service_lifecycle import PersistentService
+from nexus.contracts.protocols.service_lifecycle import BackgroundService
 from nexus.lib.registry import BaseRegistry
 
 logger = logging.getLogger(__name__)
@@ -332,8 +332,8 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
     def mark_bootstrapped(self) -> None:
         """Mark that bootstrap() has completed.
 
-        After this, enlist() auto-starts Q3 PersistentService instances
-        immediately instead of deferring to start_persistent_services().
+        After this, enlist() auto-starts Q3 BackgroundService instances
+        immediately instead of deferring to start_background_services().
         """
         self._bootstrapped = True
 
@@ -377,11 +377,11 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
         Auto-detects lifecycle requirements:
 
         - **On-demand**: register only.
-        - **PersistentService**: register + ``start()`` (post-bootstrap).
+        - **BackgroundService**: register + ``start()`` (post-bootstrap).
         - **Duck-typed hook_spec()**: auto-capture and register hooks.
 
-        Post-bootstrap, PersistentService instances are auto-started immediately.
-        Pre-bootstrap, start() is deferred to start_persistent_services().
+        Post-bootstrap, BackgroundService instances are auto-started immediately.
+        Pre-bootstrap, start() is deferred to start_background_services().
 
         Args:
             depends_on: Accepted for call-site compatibility; currently unused
@@ -390,14 +390,14 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
         del depends_on  # accepted but unused (BLM removed)
         self._register_service(name, instance, exports=exports, allow_overwrite=allow_overwrite)
 
-        # Auto-start persistent background work (only post-bootstrap)
-        if isinstance(instance, PersistentService) and self._bootstrapped:
+        # Auto-start background work (only post-bootstrap)
+        if isinstance(instance, BackgroundService) and self._bootstrapped:
             from nexus.lib.sync_bridge import run_sync
 
             coro = instance.start()
             if asyncio.iscoroutine(coro):
                 run_sync(coro, timeout=30.0)
-            logger.info("[COORDINATOR] enlist %r — started (PersistentService)", name)
+            logger.info("[COORDINATOR] enlist %r — started (BackgroundService)", name)
 
         # Auto-capture hooks via duck-typed hook_spec()
         if _declares_hook_spec(instance):
@@ -406,7 +406,7 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
                 self._register_hooks(name)
             logger.info("[COORDINATOR] enlist %r — hooks registered", name)
 
-        if not isinstance(instance, PersistentService) and not _declares_hook_spec(instance):
+        if not isinstance(instance, BackgroundService) and not _declares_hook_spec(instance):
             logger.info("[COORDINATOR] enlist %r — registered (on-demand)", name)
 
     # -- mount — register VFS hooks ----------------------------------------
@@ -485,10 +485,10 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
 
         logger.info("[COORDINATOR] swap %r — complete", name)
 
-    # -- Auto-lifecycle — PersistentService management ----------------------
+    # -- Auto-lifecycle — BackgroundService management ----------------------
 
-    def start_persistent_services(self, *, timeout: float = 30.0) -> list[str]:
-        """Auto-start all PersistentService instances in dependency order."""
+    def start_background_services(self, *, timeout: float = 30.0) -> list[str]:
+        """Auto-start all BackgroundService instances in dependency order."""
         from nexus.lib.sync_bridge import run_sync
 
         started: list[str] = []
@@ -496,24 +496,24 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
             info = self.service_info(name)
             if info is None:
                 continue
-            if not isinstance(info.instance, PersistentService):
+            if not isinstance(info.instance, BackgroundService):
                 continue
             try:
                 coro = info.instance.start()
                 if asyncio.iscoroutine(coro):
                     run_sync(coro, timeout=timeout)
                 started.append(name)
-                logger.info("[COORDINATOR] auto-started persistent service %r", name)
+                logger.info("[COORDINATOR] auto-started background service %r", name)
             except TimeoutError:
                 logger.error("[COORDINATOR] timeout starting %r after %.1fs", name, timeout)
             except Exception as exc:
                 logger.error("[COORDINATOR] failed to start %r: %s", name, exc)
         if started:
-            logger.info("[COORDINATOR] started %d persistent services: %s", len(started), started)
+            logger.info("[COORDINATOR] started %d background services: %s", len(started), started)
         return started
 
-    def stop_persistent_services(self, *, timeout: float = 10.0) -> list[str]:
-        """Auto-stop all PersistentService instances in reverse dependency order."""
+    def stop_background_services(self, *, timeout: float = 10.0) -> list[str]:
+        """Auto-stop all BackgroundService instances in reverse dependency order."""
         from nexus.lib.sync_bridge import run_sync
 
         stopped: list[str] = []
@@ -521,20 +521,20 @@ class ServiceRegistry(BaseRegistry["ServiceInfo"]):
             info = self.service_info(name)
             if info is None:
                 continue
-            if not isinstance(info.instance, PersistentService):
+            if not isinstance(info.instance, BackgroundService):
                 continue
             try:
                 coro = info.instance.stop()
                 if asyncio.iscoroutine(coro):
                     run_sync(coro, timeout=timeout)
                 stopped.append(name)
-                logger.info("[COORDINATOR] auto-stopped persistent service %r", name)
+                logger.info("[COORDINATOR] auto-stopped background service %r", name)
             except TimeoutError:
                 logger.error("[COORDINATOR] timeout stopping %r after %.1fs", name, timeout)
             except Exception as exc:
                 logger.error("[COORDINATOR] failed to stop %r: %s", name, exc)
         if stopped:
-            logger.info("[COORDINATOR] stopped %d persistent services: %s", len(stopped), stopped)
+            logger.info("[COORDINATOR] stopped %d background services: %s", len(stopped), stopped)
         return stopped
 
     def close_all_services(self) -> None:

--- a/src/nexus/factory/_background.py
+++ b/src/nexus/factory/_background.py
@@ -30,7 +30,7 @@ def _start_background_services(system: dict[str, Any]) -> None:
 
     # Event Delivery Worker (system tier)
     # Issue #3193: start() is now async — auto-started by
-    # ServiceRegistry.start_persistent_services() (Q3).
+    # ServiceRegistry.start_background_services() (Q3).
 
     # Zone Lifecycle — load Terminating zones from DB (Issue #2061)
     zl = system.get("zone_lifecycle")

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -184,7 +184,7 @@ async def _wire_services(
         nx._close_callbacks.append(_close_write_observer_cancel)
 
     # Issue #3193: Cancel the delivery worker asyncio.Task on sync close.
-    # The coordinator's stop_persistent_services() is async and only runs
+    # The coordinator's stop_background_services() is async and only runs
     # during lifespan shutdown. For sync close (tests, CLI), we cancel
     # the task directly so it doesn't block event loop cleanup.
     _dw = _svc.get("delivery_worker")
@@ -268,8 +268,8 @@ async def _initialize_services(
     )
 
     # Background services (DeferredPermissionBuffer, EventDeliveryWorker,
-    # ZoneLifecycleService) implement PersistentService and are auto-started
-    # by the coordinator's start_persistent_services() at bootstrap.
+    # ZoneLifecycleService) implement BackgroundService and are auto-started
+    # by the coordinator's start_background_services() at bootstrap.
     # No manual _bootstrap_callbacks needed.
 
 

--- a/src/nexus/lib/deferred_buffer.py
+++ b/src/nexus/lib/deferred_buffer.py
@@ -60,7 +60,7 @@ class DeferredBuffer(ABC, Generic[T]):
         self._flush_count = 0
         self._total_flushed = 0
 
-    # ── Lifecycle (PersistentService protocol) ──
+    # ── Lifecycle (BackgroundService protocol) ──
 
     async def start(self) -> None:
         """Start the background flush worker thread."""

--- a/src/nexus/server/api/v2/routers/password_vault.py
+++ b/src/nexus/server/api/v2/routers/password_vault.py
@@ -8,10 +8,21 @@
     GET    /api/v2/password_vault                             — List entries (full)
     GET    /api/v2/password_vault/{title}/versions            — List version history
 
+Titles use the ``{title:path}`` convertor so URL-encoded slashes in a
+title (e.g., a URL used *as* a title) round-trip correctly. Starlette
+decodes ``%2F`` to ``/`` before routing, so only the ``path`` convertor
+can match a title that contains ``/``. The 1024-char cap on the decoded
+title guards against pathological URLs / accidental DoS.
+
+Route declaration order matters: suffixed routes (``/versions``,
+``/restore``) must come before the bare ``/{title:path}`` wildcards, or
+the wildcard will swallow the suffix and the targeted handler will
+never be reached.
+
 Performance: all endpoints use plain ``def`` (not ``async def``) so
-FastAPI auto-dispatches to a threadpool — matches secrets router and
-keeps the asyncio event loop unblocked during synchronous SQLAlchemy
-I/O in the underlying SecretsService.
+FastAPI auto-dispatches to a threadpool — matches the secrets router
+and keeps the asyncio event loop unblocked during synchronous
+SQLAlchemy I/O in the underlying SecretsService.
 """
 
 from __future__ import annotations
@@ -33,6 +44,17 @@ logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v2/password_vault", tags=["password_vault"])
 
+_MAX_TITLE_LEN = 1024
+
+
+def _validate_title(title: str) -> None:
+    """Reject pathologically long titles before hitting the service layer."""
+    if len(title) > _MAX_TITLE_LEN:
+        raise HTTPException(
+            status_code=400,
+            detail=f"title too long ({len(title)} > {_MAX_TITLE_LEN} chars)",
+        )
+
 
 # --------------------------------------------------------------------------
 # Dependency — injected by fastapi_server.py
@@ -45,11 +67,101 @@ def get_password_vault_service() -> PasswordVaultService:
 
 
 # --------------------------------------------------------------------------
-# Write
+# List (no path param — safe to declare first)
 # --------------------------------------------------------------------------
 
 
-@router.put("/{title}")
+@router.get("")
+def list_entries(
+    auth_result: dict[str, Any] = Depends(require_auth),
+    service: PasswordVaultService = Depends(get_password_vault_service),
+) -> dict[str, Any]:
+    """List every (live) vault entry with full decrypted payloads."""
+    actor_id = auth_result.get("subject_id") or "anonymous"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
+    subject_id = auth_result.get("subject_id") or "anonymous"
+    subject_type = auth_result.get("subject_type") or "user"
+
+    try:
+        entries = service.list_entries(
+            actor_id=actor_id,
+            zone_id=zone_id,
+            subject_id=subject_id,
+            subject_type=subject_type,
+        )
+        return {"entries": [e.model_dump() for e in entries], "count": len(entries)}
+    except Exception as e:
+        logger.error("Failed to list vault entries: %s", e)
+        raise HTTPException(status_code=500, detail=f"Failed to list vault entries: {e}") from e
+
+
+# --------------------------------------------------------------------------
+# Suffixed routes — MUST come before bare /{title:path} wildcards
+# --------------------------------------------------------------------------
+
+
+@router.get("/{title:path}/versions")
+def list_versions(
+    title: str,
+    auth_result: dict[str, Any] = Depends(require_auth),
+    service: PasswordVaultService = Depends(get_password_vault_service),
+) -> dict[str, Any]:
+    """List version history for a vault entry (for rotation audits)."""
+    _validate_title(title)
+    subject_id = auth_result.get("subject_id") or "anonymous"
+    subject_type = auth_result.get("subject_type") or "user"
+
+    try:
+        versions = service.list_versions(
+            title,
+            subject_id=subject_id,
+            subject_type=subject_type,
+        )
+        return {"title": title, "versions": versions, "count": len(versions)}
+    except Exception as e:
+        logger.error("Failed to list vault entry versions: %s", e)
+        raise HTTPException(
+            status_code=500, detail=f"Failed to list vault entry versions: {e}"
+        ) from e
+
+
+@router.post("/{title:path}/restore")
+def restore_entry(
+    title: str,
+    auth_result: dict[str, Any] = Depends(require_auth),
+    service: PasswordVaultService = Depends(get_password_vault_service),
+) -> dict[str, Any]:
+    """Restore a soft-deleted vault entry."""
+    _validate_title(title)
+    actor_id = auth_result.get("subject_id") or "anonymous"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
+    subject_id = auth_result.get("subject_id") or "anonymous"
+    subject_type = auth_result.get("subject_type") or "user"
+
+    try:
+        ok = service.restore_entry(
+            title,
+            actor_id=actor_id,
+            zone_id=zone_id,
+            subject_id=subject_id,
+            subject_type=subject_type,
+        )
+        if not ok:
+            raise HTTPException(status_code=404, detail="Vault entry not found")
+        return {"title": title, "restored": True}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Failed to restore vault entry: %s", e)
+        raise HTTPException(status_code=500, detail=f"Failed to restore vault entry: {e}") from e
+
+
+# --------------------------------------------------------------------------
+# Bare /{title:path} — wildcards, declared last so suffixed routes win
+# --------------------------------------------------------------------------
+
+
+@router.put("/{title:path}")
 def put_entry(
     title: str,
     entry: VaultEntry,
@@ -60,6 +172,7 @@ def put_entry(
 
     ``body.title`` must match the URL path segment.
     """
+    _validate_title(title)
     if entry.title != title:
         raise HTTPException(
             status_code=400,
@@ -84,12 +197,7 @@ def put_entry(
         raise HTTPException(status_code=500, detail=f"Failed to put vault entry: {e}") from e
 
 
-# --------------------------------------------------------------------------
-# Read
-# --------------------------------------------------------------------------
-
-
-@router.get("/{title}")
+@router.get("/{title:path}")
 def get_entry(
     title: str,
     version: int | None = None,
@@ -97,6 +205,7 @@ def get_entry(
     service: PasswordVaultService = Depends(get_password_vault_service),
 ) -> VaultEntry:
     """Get a vault entry (latest unless ``?version=N`` is specified)."""
+    _validate_title(title)
     actor_id = auth_result.get("subject_id") or "anonymous"
     zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     subject_id = auth_result.get("subject_id") or "anonymous"
@@ -124,66 +233,14 @@ def get_entry(
         raise HTTPException(status_code=500, detail=f"Failed to get vault entry: {e}") from e
 
 
-@router.get("")
-def list_entries(
-    auth_result: dict[str, Any] = Depends(require_auth),
-    service: PasswordVaultService = Depends(get_password_vault_service),
-) -> dict[str, Any]:
-    """List every (live) vault entry with full decrypted payloads."""
-    actor_id = auth_result.get("subject_id") or "anonymous"
-    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
-    subject_id = auth_result.get("subject_id") or "anonymous"
-    subject_type = auth_result.get("subject_type") or "user"
-
-    try:
-        entries = service.list_entries(
-            actor_id=actor_id,
-            zone_id=zone_id,
-            subject_id=subject_id,
-            subject_type=subject_type,
-        )
-        return {"entries": [e.model_dump() for e in entries], "count": len(entries)}
-    except Exception as e:
-        logger.error("Failed to list vault entries: %s", e)
-        raise HTTPException(status_code=500, detail=f"Failed to list vault entries: {e}") from e
-
-
-@router.get("/{title}/versions")
-def list_versions(
-    title: str,
-    auth_result: dict[str, Any] = Depends(require_auth),
-    service: PasswordVaultService = Depends(get_password_vault_service),
-) -> dict[str, Any]:
-    """List version history for a vault entry (for rotation audits)."""
-    subject_id = auth_result.get("subject_id") or "anonymous"
-    subject_type = auth_result.get("subject_type") or "user"
-
-    try:
-        versions = service.list_versions(
-            title,
-            subject_id=subject_id,
-            subject_type=subject_type,
-        )
-        return {"title": title, "versions": versions, "count": len(versions)}
-    except Exception as e:
-        logger.error("Failed to list vault entry versions: %s", e)
-        raise HTTPException(
-            status_code=500, detail=f"Failed to list vault entry versions: {e}"
-        ) from e
-
-
-# --------------------------------------------------------------------------
-# Delete / Restore (soft)
-# --------------------------------------------------------------------------
-
-
-@router.delete("/{title}")
+@router.delete("/{title:path}")
 def delete_entry(
     title: str,
     auth_result: dict[str, Any] = Depends(require_auth),
     service: PasswordVaultService = Depends(get_password_vault_service),
 ) -> dict[str, Any]:
     """Soft-delete a vault entry."""
+    _validate_title(title)
     actor_id = auth_result.get("subject_id") or "anonymous"
     zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     subject_id = auth_result.get("subject_id") or "anonymous"
@@ -205,33 +262,3 @@ def delete_entry(
     except Exception as e:
         logger.error("Failed to delete vault entry: %s", e)
         raise HTTPException(status_code=500, detail=f"Failed to delete vault entry: {e}") from e
-
-
-@router.post("/{title}/restore")
-def restore_entry(
-    title: str,
-    auth_result: dict[str, Any] = Depends(require_auth),
-    service: PasswordVaultService = Depends(get_password_vault_service),
-) -> dict[str, Any]:
-    """Restore a soft-deleted vault entry."""
-    actor_id = auth_result.get("subject_id") or "anonymous"
-    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
-    subject_id = auth_result.get("subject_id") or "anonymous"
-    subject_type = auth_result.get("subject_type") or "user"
-
-    try:
-        ok = service.restore_entry(
-            title,
-            actor_id=actor_id,
-            zone_id=zone_id,
-            subject_id=subject_id,
-            subject_type=subject_type,
-        )
-        if not ok:
-            raise HTTPException(status_code=404, detail="Vault entry not found")
-        return {"title": title, "restored": True}
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error("Failed to restore vault entry: %s", e)
-        raise HTTPException(status_code=500, detail=f"Failed to restore vault entry: {e}") from e

--- a/src/nexus/server/api/v2/routers/password_vault.py
+++ b/src/nexus/server/api/v2/routers/password_vault.py
@@ -1,0 +1,237 @@
+"""Password vault REST API — domain-typed wrapper over SecretsService.
+
+    PUT    /api/v2/password_vault/{title}                     — Create/update entry
+    GET    /api/v2/password_vault/{title}                     — Get entry (latest)
+    GET    /api/v2/password_vault/{title}?version=N           — Get specific version
+    DELETE /api/v2/password_vault/{title}                     — Soft delete
+    POST   /api/v2/password_vault/{title}/restore             — Restore soft-deleted
+    GET    /api/v2/password_vault                             — List entries (full)
+    GET    /api/v2/password_vault/{title}/versions            — List version history
+
+Performance: all endpoints use plain ``def`` (not ``async def``) so
+FastAPI auto-dispatches to a threadpool — matches secrets router and
+keeps the asyncio event loop unblocked during synchronous SQLAlchemy
+I/O in the underlying SecretsService.
+"""
+
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.server.dependencies import require_auth
+from nexus.services.password_vault.schema import VaultEntry
+from nexus.services.password_vault.service import (
+    PasswordVaultService,
+    VaultEntryNotFoundError,
+)
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/v2/password_vault", tags=["password_vault"])
+
+
+# --------------------------------------------------------------------------
+# Dependency — injected by fastapi_server.py
+# --------------------------------------------------------------------------
+
+
+def get_password_vault_service() -> PasswordVaultService:
+    """Placeholder dependency — overridden by fastapi_server.py."""
+    raise HTTPException(status_code=500, detail="Password vault service not configured")
+
+
+# --------------------------------------------------------------------------
+# Write
+# --------------------------------------------------------------------------
+
+
+@router.put("/{title}")
+def put_entry(
+    title: str,
+    entry: VaultEntry,
+    auth_result: dict[str, Any] = Depends(require_auth),
+    service: PasswordVaultService = Depends(get_password_vault_service),
+) -> dict[str, Any]:
+    """Create or update a vault entry (new version per write).
+
+    ``body.title`` must match the URL path segment.
+    """
+    if entry.title != title:
+        raise HTTPException(
+            status_code=400,
+            detail=f"Body title {entry.title!r} does not match URL title {title!r}",
+        )
+
+    actor_id = auth_result.get("subject_id") or "anonymous"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
+    subject_id = auth_result.get("subject_id") or "anonymous"
+    subject_type = auth_result.get("subject_type") or "user"
+
+    try:
+        return service.put_entry(
+            entry,
+            actor_id=actor_id,
+            zone_id=zone_id,
+            subject_id=subject_id,
+            subject_type=subject_type,
+        )
+    except Exception as e:
+        logger.error("Failed to put vault entry: %s", e)
+        raise HTTPException(status_code=500, detail=f"Failed to put vault entry: {e}") from e
+
+
+# --------------------------------------------------------------------------
+# Read
+# --------------------------------------------------------------------------
+
+
+@router.get("/{title}")
+def get_entry(
+    title: str,
+    version: int | None = None,
+    auth_result: dict[str, Any] = Depends(require_auth),
+    service: PasswordVaultService = Depends(get_password_vault_service),
+) -> VaultEntry:
+    """Get a vault entry (latest unless ``?version=N`` is specified)."""
+    actor_id = auth_result.get("subject_id") or "anonymous"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
+    subject_id = auth_result.get("subject_id") or "anonymous"
+    subject_type = auth_result.get("subject_type") or "user"
+
+    try:
+        from nexus.bricks.secrets.service import SecretDisabledError
+
+        return service.get_entry(
+            title,
+            version=version,
+            actor_id=actor_id,
+            zone_id=zone_id,
+            subject_id=subject_id,
+            subject_type=subject_type,
+        )
+    except VaultEntryNotFoundError as e:
+        raise HTTPException(status_code=404, detail="Vault entry not found") from e
+    except SecretDisabledError as e:
+        raise HTTPException(status_code=403, detail=str(e)) from e
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Failed to get vault entry: %s", e)
+        raise HTTPException(status_code=500, detail=f"Failed to get vault entry: {e}") from e
+
+
+@router.get("")
+def list_entries(
+    auth_result: dict[str, Any] = Depends(require_auth),
+    service: PasswordVaultService = Depends(get_password_vault_service),
+) -> dict[str, Any]:
+    """List every (live) vault entry with full decrypted payloads."""
+    actor_id = auth_result.get("subject_id") or "anonymous"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
+    subject_id = auth_result.get("subject_id") or "anonymous"
+    subject_type = auth_result.get("subject_type") or "user"
+
+    try:
+        entries = service.list_entries(
+            actor_id=actor_id,
+            zone_id=zone_id,
+            subject_id=subject_id,
+            subject_type=subject_type,
+        )
+        return {"entries": [e.model_dump() for e in entries], "count": len(entries)}
+    except Exception as e:
+        logger.error("Failed to list vault entries: %s", e)
+        raise HTTPException(status_code=500, detail=f"Failed to list vault entries: {e}") from e
+
+
+@router.get("/{title}/versions")
+def list_versions(
+    title: str,
+    auth_result: dict[str, Any] = Depends(require_auth),
+    service: PasswordVaultService = Depends(get_password_vault_service),
+) -> dict[str, Any]:
+    """List version history for a vault entry (for rotation audits)."""
+    subject_id = auth_result.get("subject_id") or "anonymous"
+    subject_type = auth_result.get("subject_type") or "user"
+
+    try:
+        versions = service.list_versions(
+            title,
+            subject_id=subject_id,
+            subject_type=subject_type,
+        )
+        return {"title": title, "versions": versions, "count": len(versions)}
+    except Exception as e:
+        logger.error("Failed to list vault entry versions: %s", e)
+        raise HTTPException(
+            status_code=500, detail=f"Failed to list vault entry versions: {e}"
+        ) from e
+
+
+# --------------------------------------------------------------------------
+# Delete / Restore (soft)
+# --------------------------------------------------------------------------
+
+
+@router.delete("/{title}")
+def delete_entry(
+    title: str,
+    auth_result: dict[str, Any] = Depends(require_auth),
+    service: PasswordVaultService = Depends(get_password_vault_service),
+) -> dict[str, Any]:
+    """Soft-delete a vault entry."""
+    actor_id = auth_result.get("subject_id") or "anonymous"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
+    subject_id = auth_result.get("subject_id") or "anonymous"
+    subject_type = auth_result.get("subject_type") or "user"
+
+    try:
+        ok = service.delete_entry(
+            title,
+            actor_id=actor_id,
+            zone_id=zone_id,
+            subject_id=subject_id,
+            subject_type=subject_type,
+        )
+        if not ok:
+            raise HTTPException(status_code=404, detail="Vault entry not found")
+        return {"title": title, "deleted": True}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Failed to delete vault entry: %s", e)
+        raise HTTPException(status_code=500, detail=f"Failed to delete vault entry: {e}") from e
+
+
+@router.post("/{title}/restore")
+def restore_entry(
+    title: str,
+    auth_result: dict[str, Any] = Depends(require_auth),
+    service: PasswordVaultService = Depends(get_password_vault_service),
+) -> dict[str, Any]:
+    """Restore a soft-deleted vault entry."""
+    actor_id = auth_result.get("subject_id") or "anonymous"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
+    subject_id = auth_result.get("subject_id") or "anonymous"
+    subject_type = auth_result.get("subject_type") or "user"
+
+    try:
+        ok = service.restore_entry(
+            title,
+            actor_id=actor_id,
+            zone_id=zone_id,
+            subject_id=subject_id,
+            subject_type=subject_type,
+        )
+        if not ok:
+            raise HTTPException(status_code=404, detail="Vault entry not found")
+        return {"title": title, "restored": True}
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Failed to restore vault entry: %s", e)
+        raise HTTPException(status_code=500, detail=f"Failed to restore vault entry: {e}") from e

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -968,6 +968,34 @@ def _register_routes(app: FastAPI) -> None:
         app.dependency_overrides[_secrets_service_dep] = _get_secrets_service_override
         app.include_router(secrets_router)
         logger.info("Secrets store routes registered")
+
+        # Password vault endpoints (domain wrapper over SecretsService).
+        # Nested inside the secrets try so the _get_secrets_service_override
+        # closure is guaranteed to exist when we build the vault singleton.
+        try:
+            from nexus.server.api.v2.routers.password_vault import (
+                get_password_vault_service as _pv_service_dep,
+            )
+            from nexus.server.api.v2.routers.password_vault import (
+                router as password_vault_router,
+            )
+            from nexus.services.password_vault.service import PasswordVaultService
+
+            _password_vault_instance: PasswordVaultService | None = None
+
+            def _get_password_vault_override() -> PasswordVaultService:
+                nonlocal _password_vault_instance
+                if _password_vault_instance is None:
+                    _password_vault_instance = PasswordVaultService(
+                        secrets_service=_get_secrets_service_override(),
+                    )
+                return _password_vault_instance
+
+            app.dependency_overrides[_pv_service_dep] = _get_password_vault_override
+            app.include_router(password_vault_router)
+            logger.info("Password vault routes registered")
+        except ImportError as e:
+            logger.warning(f"Failed to import password vault router: {e}")
     except ImportError as e:
         logger.warning(f"Failed to import secrets router: {e}")
 

--- a/src/nexus/server/lifespan/__init__.py
+++ b/src/nexus/server/lifespan/__init__.py
@@ -231,13 +231,13 @@ async def lifespan(app: "FastAPI") -> AsyncIterator[None]:
         await _durable.stop()
         logger.debug("Durable invalidation stream stopped")
 
-    # Close NexusFS kernel (async shutdown for PersistentService + hooks)
+    # Close NexusFS kernel (async shutdown for BackgroundService + hooks)
     if app.state.nexus_fs:
         if hasattr(app.state.nexus_fs, "aclose"):
             app.state.nexus_fs.aclose()
         elif hasattr(app.state.nexus_fs, "close"):
             app.state.nexus_fs.close()
 
-    # CacheBrick stop is now handled by coordinator via aclose() (enlisted as PersistentService)
+    # CacheBrick stop is now handled by coordinator via aclose() (enlisted as BackgroundService)
 
     await shutdown_observability(app, svc)

--- a/src/nexus/server/lifespan/permissions.py
+++ b/src/nexus/server/lifespan/permissions.py
@@ -395,7 +395,7 @@ async def _startup_tiger_cache(app: "FastAPI", svc: "LifespanServices") -> list[
                     )
                     app.state.directory_grant_expander = expander
 
-                    # Q3 PersistentService — coordinator auto-calls start()
+                    # Q3 BackgroundService — coordinator auto-calls start()
                     coord = svc.service_coordinator
                     if coord is not None:
                         coord.enlist("directory_grant_expander", expander)

--- a/src/nexus/server/lifespan/services.py
+++ b/src/nexus/server/lifespan/services.py
@@ -611,7 +611,7 @@ async def _startup_pipe_consumers(app: "FastAPI", svc: "LifespanServices") -> No
         logger.info("[OBSERVE] RecordStoreWriteObserver registered (OBSERVE-phase)")
 
     # Issue #3193: EventDeliveryWorker is started by ServiceRegistry
-    # (PersistentService auto-start). We only expose it + event_signal on
+    # (BackgroundService auto-start). We only expose it + event_signal on
     # app.state so the API layer (EventReplayService) can access the signal.
     if svc.delivery_worker is not None:
         app.state.delivery_worker = svc.delivery_worker
@@ -682,7 +682,7 @@ async def _shutdown_pipe_consumers(app: "FastAPI") -> None:
     """Stop DT_PIPE consumers (Issue #809, #810).
 
     Note: EventDeliveryWorker (Issue #3193) is stopped by
-    ServiceRegistry.stop_persistent_services() — no
+    ServiceRegistry.stop_background_services() — no
     explicit stop here to avoid double-stop.
     """
     # Issue #809: RecordStoreWriteObserver (OBSERVE-phase)

--- a/src/nexus/server/subscriptions/manager.py
+++ b/src/nexus/server/subscriptions/manager.py
@@ -673,5 +673,6 @@ class SubscriptionManager:
         # Currently no persistent connections to close
         # Future: close any persistent HTTP clients or background tasks
 
-    # PersistentService-compatible alias (Q1 for now — no background loop)
+    # NOT a BackgroundService today (no start() / no background loop).
+    # Alias kept so a future opt-in only needs to add start().
     stop = close

--- a/src/nexus/services/event_log/delivery.py
+++ b/src/nexus/services/event_log/delivery.py
@@ -103,7 +103,7 @@ class EventDeliveryWorker:
     # ---- Lifecycle -----------------------------------------------------------
 
     async def start(self) -> None:
-        """Start background consumer task (PersistentService protocol)."""
+        """Start background consumer task (BackgroundService protocol)."""
         if self._consumer_task is not None and not self._consumer_task.done():
             logger.warning("EventDeliveryWorker already running")
             return
@@ -118,7 +118,7 @@ class EventDeliveryWorker:
         )
 
     async def stop(self, timeout: float = 5.0) -> None:  # noqa: ARG002
-        """Graceful shutdown: cancel task and await completion (PersistentService protocol)."""
+        """Graceful shutdown: cancel task and await completion (BackgroundService protocol)."""
         self._stopped = True
         if self._consumer_task is not None:
             self._consumer_task.cancel()

--- a/src/nexus/services/event_log/exporter_registry.py
+++ b/src/nexus/services/event_log/exporter_registry.py
@@ -156,7 +156,8 @@ class ExporterRegistry:
         self._exporters.clear()
         self._breakers.clear()
 
-    # PersistentService protocol alias
+    # NOT a BackgroundService today (no start()). Alias kept as a
+    # convenience — close_all() is the real shutdown hook.
     stop = close_all
 
     async def health_check(self) -> dict[str, bool]:

--- a/src/nexus/services/lifecycle/zone_lifecycle.py
+++ b/src/nexus/services/lifecycle/zone_lifecycle.py
@@ -75,13 +75,13 @@ class ZoneLifecycleService:
         )
 
     # ------------------------------------------------------------------
-    # PersistentService lifecycle (auto-managed by ServiceRegistry)
+    # BackgroundService lifecycle (auto-managed by ServiceRegistry)
     # ------------------------------------------------------------------
 
     async def start(self) -> None:
         """Load terminating zones from DB at bootstrap.
 
-        Called by ServiceRegistry.start_persistent_services(). Replaces
+        Called by ServiceRegistry.start_background_services(). Replaces
         the old _bootstrap_callbacks pattern.
         """
         try:
@@ -89,7 +89,7 @@ class ZoneLifecycleService:
                 with self._session_factory() as session:
                     self.load_terminating_zones(session)
                 logger.debug(
-                    "[ZoneLifecycle] Loaded terminating zones at PersistentService.start()"
+                    "[ZoneLifecycle] Loaded terminating zones at BackgroundService.start()"
                 )
         except Exception as exc:
             logger.warning("[ZoneLifecycle] Failed to load terminating zones: %s", exc)

--- a/src/nexus/services/password_vault/__init__.py
+++ b/src/nexus/services/password_vault/__init__.py
@@ -1,0 +1,18 @@
+"""Password vault service — domain wrapper over SecretsService.
+
+On-demand service (not a BackgroundService). Storage, encryption, audit,
+versioning and soft-delete are delegated to SecretsService — this module
+only provides a domain-typed API (VaultEntry in, VaultEntry out).
+"""
+
+from nexus.services.password_vault.schema import VaultEntry
+from nexus.services.password_vault.service import (
+    PasswordVaultService,
+    VaultEntryNotFoundError,
+)
+
+__all__ = [
+    "PasswordVaultService",
+    "VaultEntry",
+    "VaultEntryNotFoundError",
+]

--- a/src/nexus/services/password_vault/schema.py
+++ b/src/nexus/services/password_vault/schema.py
@@ -10,18 +10,23 @@ from __future__ import annotations
 
 from typing import Any
 
-from pydantic import Field
-
-from nexus.server.api.v2.models.base import ApiModel
+from pydantic import BaseModel, ConfigDict, Field
 
 
-class VaultEntry(ApiModel):
+class VaultEntry(BaseModel):
     """A single credential in the password vault.
 
     Only ``title`` is required. All other fields are optional so entries
     can be as small as ``{title, password}`` or carry a full profile
     (TOTP seed, tags, arbitrary extras such as bank PINs).
+
+    Mirrors the Tolerant Reader pattern from ``server.api.v2.models.base``:
+    unknown fields in requests are silently dropped for forward compat.
+    The config is inlined rather than inherited from ``ApiModel`` to
+    keep ``services/`` free of ``server/`` imports (kernel layering).
     """
+
+    model_config = ConfigDict(extra="ignore")
 
     title: str = Field(..., min_length=1, description="Stable identifier; used as the storage key.")
     username: str | None = None

--- a/src/nexus/services/password_vault/schema.py
+++ b/src/nexus/services/password_vault/schema.py
@@ -1,0 +1,36 @@
+"""VaultEntry schema — the domain type stored by PasswordVaultService.
+
+A ``VaultEntry`` represents a single logical credential. It is persisted
+as a JSON string inside SecretsService (which stays opaque, dealing in
+encrypted bytes). ``title`` is the stable identifier and maps directly
+to the SecretsService key.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from pydantic import Field
+
+from nexus.server.api.v2.models.base import ApiModel
+
+
+class VaultEntry(ApiModel):
+    """A single credential in the password vault.
+
+    Only ``title`` is required. All other fields are optional so entries
+    can be as small as ``{title, password}`` or carry a full profile
+    (TOTP seed, tags, arbitrary extras such as bank PINs).
+    """
+
+    title: str = Field(..., min_length=1, description="Stable identifier; used as the storage key.")
+    username: str | None = None
+    password: str | None = None
+    url: str | None = None
+    notes: str | None = None
+    tags: str | None = Field(default=None, description="Comma-separated tag list.")
+    totp_secret: str | None = None
+    extra: dict[str, Any] | None = Field(
+        default=None,
+        description="Arbitrary JSON for extra fields (e.g., bank PINs, recovery codes).",
+    )

--- a/src/nexus/services/password_vault/service.py
+++ b/src/nexus/services/password_vault/service.py
@@ -10,13 +10,19 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.services.password_vault.schema import VaultEntry
 
-if TYPE_CHECKING:
-    from nexus.bricks.secrets.service import SecretsService
+# ``secrets_service`` is typed as ``Any`` below rather than the concrete
+# ``nexus.bricks.secrets.service.SecretsService`` because the import-linter
+# four-tier architecture contract forbids ``services`` → ``bricks`` imports
+# (including TYPE_CHECKING-only). The wrapper is pure delegation; duck
+# typing is sufficient. Expected shape: ``.put_secret``, ``.get_secret``,
+# ``.list_secrets``, ``.delete_secret``, ``.restore_secret``,
+# ``.list_versions``, ``.batch_get`` — all kwargs as used by the ``/api/v2/secrets``
+# router.
 
 logger = logging.getLogger(__name__)
 
@@ -36,7 +42,7 @@ class PasswordVaultService:
 
     NAMESPACE = "passwords"
 
-    def __init__(self, secrets_service: SecretsService) -> None:
+    def __init__(self, secrets_service: Any) -> None:
         self._secrets = secrets_service
 
     # ------------------------------------------------------------------

--- a/src/nexus/services/password_vault/service.py
+++ b/src/nexus/services/password_vault/service.py
@@ -10,7 +10,7 @@ from __future__ import annotations
 
 import json
 import logging
-from typing import Any
+from typing import Any, cast
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.services.password_vault.schema import VaultEntry
@@ -152,11 +152,14 @@ class PasswordVaultService:
         subject_type: str | None = None,
     ) -> list[dict[str, Any]]:
         """Return version history (for rotation audits, M3)."""
-        return self._secrets.list_versions(
-            namespace=self.NAMESPACE,
-            key=title,
-            subject_id=subject_id,
-            subject_type=subject_type,
+        return cast(
+            "list[dict[str, Any]]",
+            self._secrets.list_versions(
+                namespace=self.NAMESPACE,
+                key=title,
+                subject_id=subject_id,
+                subject_type=subject_type,
+            ),
         )
 
     # ------------------------------------------------------------------

--- a/src/nexus/services/password_vault/service.py
+++ b/src/nexus/services/password_vault/service.py
@@ -1,0 +1,198 @@
+"""PasswordVaultService — domain wrapper over SecretsService.
+
+On-demand service (not a BackgroundService) — no ``start`` / ``stop``
+lifecycle. All storage, encryption, audit, versioning and soft-delete
+is delegated to SecretsService; this module only serializes
+``VaultEntry`` ↔ JSON and translates errors into domain exceptions.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from typing import TYPE_CHECKING, Any
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.services.password_vault.schema import VaultEntry
+
+if TYPE_CHECKING:
+    from nexus.bricks.secrets.service import SecretsService
+
+logger = logging.getLogger(__name__)
+
+
+class VaultEntryNotFoundError(LookupError):
+    """Raised when a vault entry does not exist (or is soft-deleted)."""
+
+
+class PasswordVaultService:
+    """Domain-typed wrapper over SecretsService for vault entries.
+
+    Every entry lives under a single SecretsService namespace
+    (``"passwords"``) and uses the entry's ``title`` as the key.
+    Values are JSON-serialised ``VaultEntry`` dicts; SecretsService
+    itself sees only opaque strings.
+    """
+
+    NAMESPACE = "passwords"
+
+    def __init__(self, secrets_service: SecretsService) -> None:
+        self._secrets = secrets_service
+
+    # ------------------------------------------------------------------
+    # Writes
+    # ------------------------------------------------------------------
+
+    def put_entry(
+        self,
+        entry: VaultEntry,
+        *,
+        actor_id: str = "system",
+        zone_id: str = ROOT_ZONE_ID,
+        subject_id: str | None = None,
+        subject_type: str | None = None,
+    ) -> dict[str, Any]:
+        """Create or update a vault entry. Creates a new version per write."""
+        value = json.dumps(entry.model_dump(), sort_keys=True)
+        result = self._secrets.put_secret(
+            namespace=self.NAMESPACE,
+            key=entry.title,
+            value=value,
+            actor_id=actor_id,
+            zone_id=zone_id,
+            subject_id=subject_id,
+            subject_type=subject_type,
+        )
+        return {
+            "id": result.get("id"),
+            "title": entry.title,
+            "version": result.get("version"),
+            "created_at": result.get("created_at"),
+        }
+
+    # ------------------------------------------------------------------
+    # Reads
+    # ------------------------------------------------------------------
+
+    def get_entry(
+        self,
+        title: str,
+        *,
+        version: int | None = None,
+        actor_id: str = "system",
+        zone_id: str = ROOT_ZONE_ID,
+        subject_id: str | None = None,
+        subject_type: str | None = None,
+    ) -> VaultEntry:
+        """Fetch and decrypt a vault entry (latest version unless specified)."""
+        result = self._secrets.get_secret(
+            namespace=self.NAMESPACE,
+            key=title,
+            actor_id=actor_id,
+            version=version,
+            zone_id=zone_id,
+            subject_id=subject_id,
+            subject_type=subject_type,
+        )
+        if result is None:
+            raise VaultEntryNotFoundError(title)
+        return VaultEntry.model_validate(json.loads(result["value"]))
+
+    def list_entries(
+        self,
+        *,
+        actor_id: str = "system",
+        zone_id: str = ROOT_ZONE_ID,
+        subject_id: str | None = None,
+        subject_type: str | None = None,
+    ) -> list[VaultEntry]:
+        """Return every (live) vault entry with its latest-version payload."""
+        metadata = self._secrets.list_secrets(
+            namespace=self.NAMESPACE,
+            include_deleted=False,
+            subject_id=subject_id,
+            subject_type=subject_type,
+        )
+        if not metadata:
+            return []
+
+        queries = [{"namespace": self.NAMESPACE, "key": m["key"]} for m in metadata]
+        decrypted = self._secrets.batch_get(
+            queries=queries,
+            actor_id=actor_id,
+            zone_id=zone_id,
+            subject_id=subject_id,
+            subject_type=subject_type,
+        )
+
+        entries: list[VaultEntry] = []
+        for m in metadata:
+            composite_key = f"{self.NAMESPACE}:{m['key']}"
+            raw = decrypted.get(composite_key)
+            if raw is None:
+                # SecretsService already logged (disabled / fetch error); skip.
+                continue
+            try:
+                entries.append(VaultEntry.model_validate(json.loads(raw)))
+            except (json.JSONDecodeError, ValueError) as exc:
+                logger.warning("Skipping malformed vault entry %r: %s", m["key"], exc)
+        return entries
+
+    def list_versions(
+        self,
+        title: str,
+        *,
+        subject_id: str | None = None,
+        subject_type: str | None = None,
+    ) -> list[dict[str, Any]]:
+        """Return version history (for rotation audits, M3)."""
+        return self._secrets.list_versions(
+            namespace=self.NAMESPACE,
+            key=title,
+            subject_id=subject_id,
+            subject_type=subject_type,
+        )
+
+    # ------------------------------------------------------------------
+    # Delete / restore (soft)
+    # ------------------------------------------------------------------
+
+    def delete_entry(
+        self,
+        title: str,
+        *,
+        actor_id: str = "system",
+        zone_id: str = ROOT_ZONE_ID,
+        subject_id: str | None = None,
+        subject_type: str | None = None,
+    ) -> bool:
+        return bool(
+            self._secrets.delete_secret(
+                namespace=self.NAMESPACE,
+                key=title,
+                actor_id=actor_id,
+                zone_id=zone_id,
+                subject_id=subject_id,
+                subject_type=subject_type,
+            )
+        )
+
+    def restore_entry(
+        self,
+        title: str,
+        *,
+        actor_id: str = "system",
+        zone_id: str = ROOT_ZONE_ID,
+        subject_id: str | None = None,
+        subject_type: str | None = None,
+    ) -> bool:
+        return bool(
+            self._secrets.restore_secret(
+                namespace=self.NAMESPACE,
+                key=title,
+                actor_id=actor_id,
+                zone_id=zone_id,
+                subject_id=subject_id,
+                subject_type=subject_type,
+            )
+        )

--- a/src/nexus/services/scheduler/service.py
+++ b/src/nexus/services/scheduler/service.py
@@ -137,18 +137,18 @@ class SchedulerService:
         logger.info("SchedulerService initialized (pool connected, fair-share synced)")
 
     async def start(self) -> None:
-        """PersistentService: no-op — lifecycle managed by initialize(pool)/shutdown().
+        """BackgroundService: no-op — lifecycle managed by initialize(pool)/shutdown().
 
         The scheduler has two-phase init: factory creates with db_pool=None,
         lifespan calls initialize(pool) after bootstrap.  start() exists
-        solely for PersistentService protocol conformance and is called
+        solely for BackgroundService protocol conformance and is called
         during bootstrap before initialize() — this ordering is expected.
         """
         if not self._initialized:
             logger.debug("SchedulerService.start() awaiting initialize(pool) — two-phase init")
 
     async def stop(self) -> None:
-        """PersistentService: close the asyncpg pool and mark as uninitialized."""
+        """BackgroundService: close the asyncpg pool and mark as uninitialized."""
         if self._pool is not None:
             await self._pool.close()
             self._pool = None

--- a/src/nexus/tasks/runner.py
+++ b/src/nexus/tasks/runner.py
@@ -35,7 +35,7 @@ Executor = Callable[[bytes, ProgressReporter], Coroutine[Any, Any, bytes | None]
 class AsyncTaskRunner:
     """Async worker pool that claims and executes tasks from TaskEngine.
 
-    Implements PersistentService protocol (start/stop) for coordinator
+    Implements BackgroundService protocol (start/stop) for coordinator
     auto-lifecycle management.
 
     Usage:
@@ -166,15 +166,15 @@ class AsyncTaskRunner:
             await asyncio.sleep(self.requeue_interval)
 
     async def start(self) -> None:
-        """PersistentService: spawn the worker pool as a background task."""
+        """BackgroundService: spawn the worker pool as a background task."""
         if self._run_task is not None and not self._run_task.done():
             return  # idempotent
         self._shutdown = False
         self._run_task = asyncio.create_task(self.run(), name="async-task-runner")
-        logger.info("AsyncTaskRunner started via PersistentService.start()")
+        logger.info("AsyncTaskRunner started via BackgroundService.start()")
 
     async def stop(self) -> None:
-        """PersistentService: signal graceful shutdown and await completion."""
+        """BackgroundService: signal graceful shutdown and await completion."""
         logger.info("AsyncTaskRunner stop requested")
         self._shutdown = True
         if self._run_task is not None and not self._run_task.done():

--- a/tests/integration/test_password_vault_api.py
+++ b/tests/integration/test_password_vault_api.py
@@ -7,6 +7,8 @@ full HTTP + DI + SecretsService + PasswordVaultService stack end-to-end.
 
 from __future__ import annotations
 
+from urllib.parse import quote
+
 import pytest
 from fastapi.testclient import TestClient
 
@@ -50,6 +52,11 @@ def client() -> TestClient:
     return setup_server()
 
 
+def _encode(title: str) -> str:
+    """URL-encode a title so embedded ``/`` / ``:`` survive routing."""
+    return quote(title, safe="")
+
+
 @pytest.fixture(autouse=True)
 def _clean_between_tests(client: TestClient):
     """Delete any leftover vault entries between tests (InMemoryRecordStore is session-shared)."""
@@ -57,7 +64,7 @@ def _clean_between_tests(client: TestClient):
     resp = client.get("/api/v2/password_vault")
     if resp.status_code == 200:
         for entry in resp.json().get("entries", []):
-            client.delete(f"/api/v2/password_vault/{entry['title']}")
+            client.delete(f"/api/v2/password_vault/{_encode(entry['title'])}")
 
 
 def _sample_body(title: str = "github", **overrides):
@@ -216,3 +223,48 @@ def test_minimal_entry_just_title(client: TestClient) -> None:
     assert got["title"] == "wifi-home"
     assert got["password"] is None
     assert got["extra"] is None
+
+
+# ---------------------------------------------------------------------------
+# URL-encoding / path regression (real Quip data has URLs as titles)
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    "title",
+    [
+        "https://100moffett.activebuilding.com/portal/wall",
+        "a/b/c/d",  # multi-segment
+        "weird:chars?and=stuff",  # colons + query-looking chars
+    ],
+)
+def test_url_as_title_round_trips(client: TestClient, title: str) -> None:
+    encoded = _encode(title)
+    body = _sample_body(title=title, password="secret-for-" + title)
+
+    assert client.put(f"/api/v2/password_vault/{encoded}", json=body).status_code == 200
+
+    got = client.get(f"/api/v2/password_vault/{encoded}").json()
+    assert got["title"] == title
+    assert got["password"] == "secret-for-" + title
+
+    listed = client.get("/api/v2/password_vault").json()
+    assert any(e["title"] == title for e in listed["entries"])
+
+    versions = client.get(f"/api/v2/password_vault/{encoded}/versions").json()
+    assert versions["title"] == title and versions["count"] == 1
+
+    assert client.delete(f"/api/v2/password_vault/{encoded}").status_code == 200
+    assert client.get(f"/api/v2/password_vault/{encoded}").status_code == 404
+    assert client.post(f"/api/v2/password_vault/{encoded}/restore").status_code == 200
+    assert client.get(f"/api/v2/password_vault/{encoded}").status_code == 200
+
+
+def test_title_length_cap_rejects_at_1025_chars(client: TestClient) -> None:
+    long_title = "a" * 1025
+    resp = client.put(
+        f"/api/v2/password_vault/{_encode(long_title)}",
+        json={"title": long_title},
+    )
+    assert resp.status_code == 400
+    assert "too long" in resp.json()["detail"].lower()

--- a/tests/integration/test_password_vault_api.py
+++ b/tests/integration/test_password_vault_api.py
@@ -1,0 +1,218 @@
+"""Integration tests for /api/v2/password_vault/* endpoints.
+
+Uses the same session-scoped TestClient pattern as test_secrets_api_automated.py:
+spin up a real FastAPI app with an in-memory record store, then exercise the
+full HTTP + DI + SecretsService + PasswordVaultService stack end-to-end.
+"""
+
+from __future__ import annotations
+
+import pytest
+from fastapi.testclient import TestClient
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.server.fastapi_server import create_app
+from tests.conftest import make_test_nexus
+from tests.helpers.in_memory_record_store import InMemoryRecordStore
+
+# Session-scoped shared server (matches test_secrets_api_automated.py)
+_server_app = None
+_server_client = None
+
+
+def setup_server() -> TestClient:
+    """Build a server once per session."""
+    global _server_app, _server_client
+
+    if _server_app is None:
+        import asyncio
+        import tempfile
+
+        tmp_path = tempfile.mkdtemp(prefix="nexus_pv_test_")
+        in_memory_rs = InMemoryRecordStore()
+
+        loop = asyncio.new_event_loop()
+        nexus_fs = loop.run_until_complete(make_test_nexus(tmp_path, record_store=in_memory_rs))
+        loop.close()
+
+        api_key = "test-api-key"
+        _server_app = create_app(nexus_fs, api_key=api_key)
+        _server_client = TestClient(_server_app, raise_server_exceptions=True)
+        _server_client.headers["Authorization"] = f"Bearer {api_key}"
+        _server_client.headers["X-Actor-ID"] = "test-actor"
+        _server_client.headers["X-Zone-ID"] = ROOT_ZONE_ID
+
+    return _server_client
+
+
+@pytest.fixture(scope="session")
+def client() -> TestClient:
+    return setup_server()
+
+
+@pytest.fixture(autouse=True)
+def _clean_between_tests(client: TestClient):
+    """Delete any leftover vault entries between tests (InMemoryRecordStore is session-shared)."""
+    yield
+    resp = client.get("/api/v2/password_vault")
+    if resp.status_code == 200:
+        for entry in resp.json().get("entries", []):
+            client.delete(f"/api/v2/password_vault/{entry['title']}")
+
+
+def _sample_body(title: str = "github", **overrides):
+    body = {
+        "title": title,
+        "username": "alice",
+        "password": "hunter2",
+        "url": "https://github.com",
+        "notes": "primary work account",
+        "tags": "dev,work",
+        "totp_secret": "JBSWY3DPEHPK3PXP",
+        "extra": {"recovery_codes": ["a1", "b2"]},
+    }
+    body.update(overrides)
+    return body
+
+
+# ---------------------------------------------------------------------------
+# Auth
+# ---------------------------------------------------------------------------
+
+
+def test_endpoints_reject_unauthenticated_requests(client: TestClient) -> None:
+    app = client.app
+    unauth = TestClient(app)
+
+    for verb, path in [
+        ("get", "/api/v2/password_vault"),
+        ("get", "/api/v2/password_vault/github"),
+        ("put", "/api/v2/password_vault/github"),
+        ("delete", "/api/v2/password_vault/github"),
+        ("post", "/api/v2/password_vault/github/restore"),
+        ("get", "/api/v2/password_vault/github/versions"),
+    ]:
+        method = getattr(unauth, verb)
+        kwargs = {"json": _sample_body()} if verb == "put" else {}
+        resp = method(path, **kwargs)
+        assert resp.status_code == 401, f"{verb.upper()} {path} -> {resp.status_code}"
+
+
+# ---------------------------------------------------------------------------
+# Lifecycle
+# ---------------------------------------------------------------------------
+
+
+def test_put_then_get_round_trips(client: TestClient) -> None:
+    resp = client.put("/api/v2/password_vault/github", json=_sample_body())
+    assert resp.status_code == 200, resp.text
+    result = resp.json()
+    assert result["title"] == "github"
+    assert result["version"] == 1
+
+    resp = client.get("/api/v2/password_vault/github")
+    assert resp.status_code == 200
+    entry = resp.json()
+    assert entry["title"] == "github"
+    assert entry["username"] == "alice"
+    assert entry["password"] == "hunter2"
+    assert entry["extra"] == {"recovery_codes": ["a1", "b2"]}
+
+
+def test_put_bumps_version_and_get_version_query_works(client: TestClient) -> None:
+    client.put("/api/v2/password_vault/github", json=_sample_body(password="v1"))
+    client.put("/api/v2/password_vault/github", json=_sample_body(password="v2"))
+
+    latest = client.get("/api/v2/password_vault/github").json()
+    assert latest["password"] == "v2"
+
+    v1 = client.get("/api/v2/password_vault/github?version=1").json()
+    assert v1["password"] == "v1"
+
+
+def test_put_rejects_mismatched_title(client: TestClient) -> None:
+    resp = client.put(
+        "/api/v2/password_vault/github",
+        json=_sample_body(title="aws"),
+    )
+    assert resp.status_code == 400
+    assert "does not match" in resp.json()["detail"]
+
+
+def test_get_missing_returns_404(client: TestClient) -> None:
+    resp = client.get("/api/v2/password_vault/does-not-exist")
+    assert resp.status_code == 404
+
+
+def test_list_entries_returns_full_payloads(client: TestClient) -> None:
+    client.put("/api/v2/password_vault/github", json=_sample_body(title="github"))
+    client.put(
+        "/api/v2/password_vault/aws",
+        json=_sample_body(title="aws", username="root", password="p@ss"),
+    )
+
+    resp = client.get("/api/v2/password_vault")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["count"] == 2
+    titles = sorted(e["title"] for e in data["entries"])
+    assert titles == ["aws", "github"]
+    # full payload, not just metadata
+    aws = next(e for e in data["entries"] if e["title"] == "aws")
+    assert aws["password"] == "p@ss"
+
+
+def test_delete_then_restore(client: TestClient) -> None:
+    client.put("/api/v2/password_vault/github", json=_sample_body())
+
+    resp = client.delete("/api/v2/password_vault/github")
+    assert resp.status_code == 200
+    assert resp.json() == {"title": "github", "deleted": True}
+
+    # Gone from list + GET
+    listed = client.get("/api/v2/password_vault").json()
+    assert all(e["title"] != "github" for e in listed["entries"])
+    assert client.get("/api/v2/password_vault/github").status_code == 404
+
+    # Restore
+    resp = client.post("/api/v2/password_vault/github/restore")
+    assert resp.status_code == 200
+    assert resp.json() == {"title": "github", "restored": True}
+    assert client.get("/api/v2/password_vault/github").status_code == 200
+
+
+def test_delete_nonexistent_returns_404(client: TestClient) -> None:
+    resp = client.delete("/api/v2/password_vault/missing")
+    assert resp.status_code == 404
+
+
+def test_restore_nonexistent_returns_404(client: TestClient) -> None:
+    resp = client.post("/api/v2/password_vault/missing/restore")
+    assert resp.status_code == 404
+
+
+def test_list_versions(client: TestClient) -> None:
+    client.put("/api/v2/password_vault/github", json=_sample_body(password="v1"))
+    client.put("/api/v2/password_vault/github", json=_sample_body(password="v2"))
+    client.put("/api/v2/password_vault/github", json=_sample_body(password="v3"))
+
+    resp = client.get("/api/v2/password_vault/github/versions")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["title"] == "github"
+    assert data["count"] == 3
+    # list_versions returns DESC by version
+    assert [v["version"] for v in data["versions"]] == [3, 2, 1]
+
+
+def test_minimal_entry_just_title(client: TestClient) -> None:
+    resp = client.put(
+        "/api/v2/password_vault/wifi-home",
+        json={"title": "wifi-home"},
+    )
+    assert resp.status_code == 200
+
+    got = client.get("/api/v2/password_vault/wifi-home").json()
+    assert got["title"] == "wifi-home"
+    assert got["password"] is None
+    assert got["extra"] is None

--- a/tests/unit/contracts/test_service_lifecycle_protocols.py
+++ b/tests/unit/contracts/test_service_lifecycle_protocols.py
@@ -1,4 +1,4 @@
-"""Unit tests for PersistentService protocol (Issue #1577).
+"""Unit tests for BackgroundService protocol (Issue #1577).
 
 Verifies structural subtyping (Protocol) works correctly for service
 lifecycle classification without requiring explicit inheritance.
@@ -8,15 +8,15 @@ from __future__ import annotations
 
 import pytest
 
-from nexus.contracts.protocols.service_lifecycle import PersistentService
+from nexus.contracts.protocols.service_lifecycle import BackgroundService
 
 # ---------------------------------------------------------------------------
 # Test stubs — satisfy protocols structurally (no inheritance)
 # ---------------------------------------------------------------------------
 
 
-class _FullPersistent:
-    """Structurally satisfies PersistentService — start + stop."""
+class _FullBackground:
+    """Structurally satisfies BackgroundService — start + stop."""
 
     async def start(self) -> None:
         pass
@@ -26,37 +26,37 @@ class _FullPersistent:
 
 
 class _PlainService:
-    """No lifecycle methods — not PersistentService."""
+    """No lifecycle methods — not BackgroundService."""
 
     def do_work(self) -> str:
         return "done"
 
 
-class _PartialPersistent:
-    """Has start but missing stop — NOT PersistentService."""
+class _PartialBackground:
+    """Has start but missing stop — NOT BackgroundService."""
 
     async def start(self) -> None:
         pass
 
 
 # ---------------------------------------------------------------------------
-# PersistentService Protocol
+# BackgroundService Protocol
 # ---------------------------------------------------------------------------
 
 
-class TestPersistentServiceProtocol:
+class TestBackgroundServiceProtocol:
     def test_full_implementation_detected(self) -> None:
-        assert isinstance(_FullPersistent(), PersistentService)
+        assert isinstance(_FullBackground(), BackgroundService)
 
     def test_plain_service_not_detected(self) -> None:
-        assert not isinstance(_PlainService(), PersistentService)
+        assert not isinstance(_PlainService(), BackgroundService)
 
     def test_partial_not_detected(self) -> None:
-        """Missing stop() → not PersistentService."""
-        assert not isinstance(_PartialPersistent(), PersistentService)
+        """Missing stop() → not BackgroundService."""
+        assert not isinstance(_PartialBackground(), BackgroundService)
 
     @pytest.mark.asyncio()
     async def test_start_and_stop_are_async(self) -> None:
-        svc = _FullPersistent()
+        svc = _FullBackground()
         await svc.start()
         await svc.stop()

--- a/tests/unit/server/test_rpc_parity.py
+++ b/tests/unit/server/test_rpc_parity.py
@@ -106,7 +106,7 @@ def test_all_public_methods_are_exposed_or_excluded():
     # ADD NEW METHODS HERE if they should remain local-only
     INTERNAL_ONLY_METHODS = {
         # Lifecycle/infrastructure methods
-        "aclose",  # Async shutdown — stop PersistentService + unregister hooks (Issue #1580)
+        "aclose",  # Async shutdown — stop BackgroundService + unregister hooks (Issue #1580)
         "close",  # Connection management - handled differently for remote
         "link",  # Boot phase 1 - pure memory wiring, not an RPC operation
         "initialize",  # Boot phase 2 - one-time side effects, not an RPC operation

--- a/tests/unit/services/test_password_vault_service.py
+++ b/tests/unit/services/test_password_vault_service.py
@@ -1,0 +1,244 @@
+"""Unit tests for PasswordVaultService.
+
+The service is a thin JSON-serialisation wrapper over SecretsService —
+these tests mock SecretsService and verify:
+    * VaultEntry ↔ JSON round-trips via put/get
+    * list_entries uses list_secrets + batch_get and hydrates entries
+    * delete / restore / list_versions delegate with the right namespace
+    * Missing entries raise VaultEntryNotFoundError on get_entry
+    * Malformed persisted JSON is skipped (not fatal) in list_entries
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.services.password_vault.schema import VaultEntry
+from nexus.services.password_vault.service import (
+    PasswordVaultService,
+    VaultEntryNotFoundError,
+)
+
+
+@pytest.fixture()
+def secrets() -> MagicMock:
+    return MagicMock()
+
+
+@pytest.fixture()
+def vault(secrets: MagicMock) -> PasswordVaultService:
+    return PasswordVaultService(secrets_service=secrets)
+
+
+def _sample_entry(**overrides: Any) -> VaultEntry:
+    base = {
+        "title": "github",
+        "username": "alice",
+        "password": "hunter2",
+        "url": "https://github.com",
+        "notes": "primary work account",
+        "tags": "dev,work",
+        "totp_secret": "JBSWY3DPEHPK3PXP",
+        "extra": {"recovery_codes": ["a1", "b2"]},
+    }
+    base.update(overrides)
+    return VaultEntry.model_validate(base)
+
+
+# ---------------------------------------------------------------------------
+# put_entry
+# ---------------------------------------------------------------------------
+
+
+class TestPutEntry:
+    def test_serialises_entry_to_json_under_passwords_namespace(
+        self, vault: PasswordVaultService, secrets: MagicMock
+    ) -> None:
+        entry = _sample_entry()
+        secrets.put_secret.return_value = {
+            "id": 42,
+            "version": 1,
+            "created_at": "2026-04-20T10:00:00",
+        }
+
+        result = vault.put_entry(entry, actor_id="alice", subject_id="alice", subject_type="user")
+
+        secrets.put_secret.assert_called_once()
+        kwargs = secrets.put_secret.call_args.kwargs
+        assert kwargs["namespace"] == "passwords"
+        assert kwargs["key"] == "github"
+        assert kwargs["actor_id"] == "alice"
+        assert kwargs["subject_id"] == "alice"
+        assert kwargs["subject_type"] == "user"
+
+        # Value is JSON and round-trips to the same entry
+        payload = json.loads(kwargs["value"])
+        assert VaultEntry.model_validate(payload) == entry
+
+        assert result == {
+            "id": 42,
+            "title": "github",
+            "version": 1,
+            "created_at": "2026-04-20T10:00:00",
+        }
+
+    def test_accepts_minimal_entry(self, vault: PasswordVaultService, secrets: MagicMock) -> None:
+        entry = VaultEntry(title="wifi-home")
+        secrets.put_secret.return_value = {"id": 1, "version": 1, "created_at": None}
+
+        vault.put_entry(entry)
+
+        kwargs = secrets.put_secret.call_args.kwargs
+        payload = json.loads(kwargs["value"])
+        assert payload["title"] == "wifi-home"
+        assert payload["password"] is None
+
+
+# ---------------------------------------------------------------------------
+# get_entry
+# ---------------------------------------------------------------------------
+
+
+class TestGetEntry:
+    def test_decodes_json_to_vault_entry(
+        self, vault: PasswordVaultService, secrets: MagicMock
+    ) -> None:
+        entry = _sample_entry()
+        secrets.get_secret.return_value = {
+            "value": json.dumps(entry.model_dump()),
+            "version": 3,
+        }
+
+        got = vault.get_entry("github", version=3, actor_id="alice")
+
+        assert got == entry
+        kwargs = secrets.get_secret.call_args.kwargs
+        assert kwargs["namespace"] == "passwords"
+        assert kwargs["key"] == "github"
+        assert kwargs["version"] == 3
+
+    def test_missing_raises_not_found(
+        self, vault: PasswordVaultService, secrets: MagicMock
+    ) -> None:
+        secrets.get_secret.return_value = None
+
+        with pytest.raises(VaultEntryNotFoundError):
+            vault.get_entry("nonexistent")
+
+    def test_passes_version_kwarg_through(
+        self, vault: PasswordVaultService, secrets: MagicMock
+    ) -> None:
+        secrets.get_secret.return_value = {
+            "value": json.dumps({"title": "x"}),
+            "version": 7,
+        }
+
+        vault.get_entry("x", version=7)
+
+        assert secrets.get_secret.call_args.kwargs["version"] == 7
+
+
+# ---------------------------------------------------------------------------
+# list_entries
+# ---------------------------------------------------------------------------
+
+
+class TestListEntries:
+    def test_empty_when_no_metadata(self, vault: PasswordVaultService, secrets: MagicMock) -> None:
+        secrets.list_secrets.return_value = []
+
+        assert vault.list_entries() == []
+        secrets.batch_get.assert_not_called()
+
+    def test_hydrates_all_entries_via_batch_get(
+        self, vault: PasswordVaultService, secrets: MagicMock
+    ) -> None:
+        e1 = _sample_entry(title="github")
+        e2 = _sample_entry(title="aws", username="root", password="p@ss")
+        secrets.list_secrets.return_value = [
+            {"key": "github", "namespace": "passwords"},
+            {"key": "aws", "namespace": "passwords"},
+        ]
+        secrets.batch_get.return_value = {
+            "passwords:github": json.dumps(e1.model_dump()),
+            "passwords:aws": json.dumps(e2.model_dump()),
+        }
+
+        entries = vault.list_entries(actor_id="alice")
+
+        assert entries == [e1, e2]
+        queries = secrets.batch_get.call_args.kwargs["queries"]
+        assert queries == [
+            {"namespace": "passwords", "key": "github"},
+            {"namespace": "passwords", "key": "aws"},
+        ]
+
+    def test_skips_keys_missing_from_batch_get(
+        self, vault: PasswordVaultService, secrets: MagicMock
+    ) -> None:
+        e1 = _sample_entry(title="github")
+        secrets.list_secrets.return_value = [
+            {"key": "github", "namespace": "passwords"},
+            {"key": "disabled", "namespace": "passwords"},
+        ]
+        # Only github comes back from batch_get (disabled secret)
+        secrets.batch_get.return_value = {
+            "passwords:github": json.dumps(e1.model_dump()),
+        }
+
+        assert vault.list_entries() == [e1]
+
+    def test_skips_malformed_json(self, vault: PasswordVaultService, secrets: MagicMock) -> None:
+        e1 = _sample_entry(title="good")
+        secrets.list_secrets.return_value = [
+            {"key": "good", "namespace": "passwords"},
+            {"key": "broken", "namespace": "passwords"},
+        ]
+        secrets.batch_get.return_value = {
+            "passwords:good": json.dumps(e1.model_dump()),
+            "passwords:broken": "not-json-at-all",
+        }
+
+        assert vault.list_entries() == [e1]
+
+
+# ---------------------------------------------------------------------------
+# delete_entry / restore_entry / list_versions
+# ---------------------------------------------------------------------------
+
+
+class TestLifecycle:
+    def test_delete_entry_delegates(self, vault: PasswordVaultService, secrets: MagicMock) -> None:
+        secrets.delete_secret.return_value = True
+
+        assert vault.delete_entry("github", actor_id="alice") is True
+        kwargs = secrets.delete_secret.call_args.kwargs
+        assert kwargs["namespace"] == "passwords"
+        assert kwargs["key"] == "github"
+        assert kwargs["actor_id"] == "alice"
+
+    def test_restore_entry_delegates(self, vault: PasswordVaultService, secrets: MagicMock) -> None:
+        secrets.restore_secret.return_value = True
+
+        assert vault.restore_entry("github") is True
+        assert secrets.restore_secret.call_args.kwargs["key"] == "github"
+
+    def test_list_versions_delegates(self, vault: PasswordVaultService, secrets: MagicMock) -> None:
+        secrets.list_versions.return_value = [
+            {"version": 3, "created_at": "2026-04-20T10:00:00"},
+            {"version": 2, "created_at": "2026-04-19T10:00:00"},
+            {"version": 1, "created_at": "2026-04-18T10:00:00"},
+        ]
+
+        versions = vault.list_versions("github", subject_id="alice", subject_type="user")
+
+        assert len(versions) == 3
+        assert versions[0]["version"] == 3
+        kwargs = secrets.list_versions.call_args.kwargs
+        assert kwargs["namespace"] == "passwords"
+        assert kwargs["key"] == "github"
+        assert kwargs["subject_id"] == "alice"

--- a/tests/unit/services/test_service_lifecycle_coordinator.py
+++ b/tests/unit/services/test_service_lifecycle_coordinator.py
@@ -3,7 +3,7 @@
 These tests exercise the lifecycle methods (enlist, swap_service, start/stop)
 that were merged from ServiceLifecycleCoordinator into ServiceRegistry in Issue #1814.
 
-One-dimension model: PersistentService protocol + duck-typed hook_spec().
+One-dimension model: BackgroundService protocol + duck-typed hook_spec().
 """
 
 from __future__ import annotations
@@ -15,7 +15,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from nexus.contracts.protocols.service_hooks import HookSpec
-from nexus.contracts.protocols.service_lifecycle import PersistentService
+from nexus.contracts.protocols.service_lifecycle import BackgroundService
 from nexus.core.nexus_fs_dispatch import DispatchMixin
 from nexus.core.service_registry import ServiceRegistry
 
@@ -93,8 +93,8 @@ class _FakeHookServiceV2(_FakeHookService):
         return [f"v2:{pattern}"]
 
 
-class _PersistentFakeService:
-    """PersistentService stub — satisfies the Protocol structurally."""
+class _BackgroundFakeService:
+    """BackgroundService stub — satisfies the Protocol structurally."""
 
     def __init__(self) -> None:
         self.started = False
@@ -110,7 +110,7 @@ class _PersistentFakeService:
         return "working"
 
 
-class _FakePersistentHookService:
+class _FakeBackgroundHookService:
     """Fake service with both start/stop and hook_spec()."""
 
     def __init__(self, hook_spec_value: HookSpec | None = None) -> None:
@@ -523,14 +523,14 @@ class TestSwapWithFullHookSpec:
 
 
 class TestProtocolConformance:
-    """Verify structural subtyping works for PersistentService."""
+    """Verify structural subtyping works for BackgroundService."""
 
     @pytest.mark.parametrize(
         "service_class,protocol,expected",
         [
-            (_PersistentFakeService, PersistentService, True),
-            (_FakeService, PersistentService, False),
-            (_FakeHookService, PersistentService, False),
+            (_BackgroundFakeService, BackgroundService, True),
+            (_FakeService, BackgroundService, False),
+            (_FakeHookService, BackgroundService, False),
         ],
     )
     def test_protocol_conformance(
@@ -542,29 +542,29 @@ class TestProtocolConformance:
 
 
 # ---------------------------------------------------------------------------
-# Auto-lifecycle — PersistentService management (Issue #1580)
+# Auto-lifecycle — BackgroundService management (Issue #1580)
 # ---------------------------------------------------------------------------
 
 
-class TestAutoLifecyclePersistentService:
-    """Auto start/stop for PersistentService (Q3 + Q4)."""
+class TestAutoLifecycleBackgroundService:
+    """Auto start/stop for BackgroundService (Q3 + Q4)."""
 
-    def test_start_calls_start_on_persistent(self, coordinator: ServiceRegistry) -> None:
-        svc = _PersistentFakeService()
+    def test_start_calls_start_on_background(self, coordinator: ServiceRegistry) -> None:
+        svc = _BackgroundFakeService()
         coordinator._register_service("worker", svc)
-        started = coordinator.start_persistent_services()
+        started = coordinator.start_background_services()
         assert started == ["worker"]
         assert svc.started is True
 
-    def test_start_skips_non_persistent(self, coordinator: ServiceRegistry) -> None:
+    def test_start_skips_non_background(self, coordinator: ServiceRegistry) -> None:
         coordinator._register_service("search", _FakeService())
-        started = coordinator.start_persistent_services()
+        started = coordinator.start_background_services()
         assert started == []
 
-    def test_stop_calls_stop_on_persistent(self, coordinator: ServiceRegistry) -> None:
-        svc = _PersistentFakeService()
+    def test_stop_calls_stop_on_background(self, coordinator: ServiceRegistry) -> None:
+        svc = _BackgroundFakeService()
         coordinator._register_service("worker", svc)
-        stopped = coordinator.stop_persistent_services()
+        stopped = coordinator.stop_background_services()
         assert stopped == ["worker"]
         assert svc.stopped is True
 
@@ -578,10 +578,10 @@ class TestAutoLifecyclePersistentService:
             async def stop(self) -> None:
                 pass
 
-        ok_svc = _PersistentFakeService()
+        ok_svc = _BackgroundFakeService()
         coordinator._register_service("fail", _FailStart())
         coordinator._register_service("ok", ok_svc)
-        started = coordinator.start_persistent_services()
+        started = coordinator.start_background_services()
         assert "ok" in started
         assert "fail" not in started
         assert ok_svc.started is True
@@ -596,10 +596,10 @@ class TestAutoLifecyclePersistentService:
             async def stop(self) -> None:
                 raise RuntimeError("boom")
 
-        ok_svc = _PersistentFakeService()
+        ok_svc = _BackgroundFakeService()
         coordinator._register_service("fail", _FailStop())
         coordinator._register_service("ok", ok_svc)
-        stopped = coordinator.stop_persistent_services()
+        stopped = coordinator.stop_background_services()
         assert "ok" in stopped
         assert "fail" not in stopped
         assert ok_svc.stopped is True
@@ -614,21 +614,21 @@ class TestAutoLifecyclePersistentService:
             async def stop(self) -> None:
                 pass
 
-        ok_svc = _PersistentFakeService()
+        ok_svc = _BackgroundFakeService()
         coordinator._register_service("slow", _SlowStart())
         coordinator._register_service("ok", ok_svc)
-        started = coordinator.start_persistent_services(timeout=0.01)
+        started = coordinator.start_background_services(timeout=0.01)
         assert "ok" in started
         assert "slow" not in started
 
     def test_start_stop_idempotent(self, coordinator: ServiceRegistry) -> None:
-        svc = _PersistentFakeService()
+        svc = _BackgroundFakeService()
         coordinator._register_service("worker", svc)
-        coordinator.start_persistent_services()
-        coordinator.start_persistent_services()
+        coordinator.start_background_services()
+        coordinator.start_background_services()
         assert svc.started is True
-        coordinator.stop_persistent_services()
-        coordinator.stop_persistent_services()
+        coordinator.stop_background_services()
+        coordinator.stop_background_services()
         assert svc.stopped is True
 
 
@@ -675,12 +675,12 @@ class TestEnlist:
         assert info is not None
         assert info.instance is svc
 
-    def test_enlist_persistent_pre_bootstrap(
+    def test_enlist_background_pre_bootstrap(
         self,
         coordinator: ServiceRegistry,
     ) -> None:
-        """PersistentService pre-bootstrap: enlist registers but defers start()."""
-        svc = _PersistentFakeService()
+        """BackgroundService pre-bootstrap: enlist registers but defers start()."""
+        svc = _BackgroundFakeService()
         assert svc.started is False
 
         coordinator.enlist("svc", svc)
@@ -689,13 +689,13 @@ class TestEnlist:
         info = coordinator.service_info("svc")
         assert info is not None
 
-    def test_enlist_persistent_post_bootstrap(
+    def test_enlist_background_post_bootstrap(
         self,
         coordinator: ServiceRegistry,
     ) -> None:
-        """PersistentService post-bootstrap: enlist registers + calls start() immediately."""
+        """BackgroundService post-bootstrap: enlist registers + calls start() immediately."""
         coordinator.mark_bootstrapped()
-        svc = _PersistentFakeService()
+        svc = _BackgroundFakeService()
         assert svc.started is False
 
         coordinator.enlist("svc", svc)
@@ -720,14 +720,14 @@ class TestEnlist:
         assert coordinator._get_hook_spec("svc") is not None
         assert dispatch.read_hook_count == 1
 
-    def test_enlist_persistent_with_hooks_pre_bootstrap(
+    def test_enlist_background_with_hooks_pre_bootstrap(
         self,
         coordinator: ServiceRegistry,
         dispatch: _TestDispatch,
     ) -> None:
-        """PersistentService + hook_spec pre-bootstrap: hooks registered, start deferred."""
+        """BackgroundService + hook_spec pre-bootstrap: hooks registered, start deferred."""
         hook = MagicMock()
-        svc = _FakePersistentHookService(hook_spec_value=HookSpec(read_hooks=(hook,)))
+        svc = _FakeBackgroundHookService(hook_spec_value=HookSpec(read_hooks=(hook,)))
         assert svc.started is False
 
         coordinator.enlist("svc", svc)
@@ -736,15 +736,15 @@ class TestEnlist:
         assert coordinator._get_hook_spec("svc") is not None
         assert dispatch.read_hook_count == 1
 
-    def test_enlist_persistent_with_hooks_post_bootstrap(
+    def test_enlist_background_with_hooks_post_bootstrap(
         self,
         coordinator: ServiceRegistry,
         dispatch: _TestDispatch,
     ) -> None:
-        """PersistentService + hook_spec post-bootstrap: hooks registered + started."""
+        """BackgroundService + hook_spec post-bootstrap: hooks registered + started."""
         coordinator.mark_bootstrapped()
         hook = MagicMock()
-        svc = _FakePersistentHookService(hook_spec_value=HookSpec(read_hooks=(hook,)))
+        svc = _FakeBackgroundHookService(hook_spec_value=HookSpec(read_hooks=(hook,)))
 
         coordinator.enlist("svc", svc)
 
@@ -760,7 +760,7 @@ class TestEnlist:
         dep = _FakeService()
         coordinator.enlist("dep", dep)
 
-        svc = _PersistentFakeService()
+        svc = _BackgroundFakeService()
         coordinator.enlist("child", svc, depends_on=("dep",))
 
         info = coordinator.service_info("child")
@@ -774,9 +774,9 @@ class TestSwapUnifiedPath:
         "service_class,replacement_class",
         [
             (_FakeService, _FakeServiceV2),
-            (_PersistentFakeService, _PersistentFakeService),
+            (_BackgroundFakeService, _BackgroundFakeService),
             (_FakeHookService, _FakeHookServiceV2),
-            (_FakePersistentHookService, _FakePersistentHookService),
+            (_FakeBackgroundHookService, _FakeBackgroundHookService),
         ],
     )
     def test_swap_all_service_types(


### PR DESCRIPTION
## Summary

Two independent changes bundled (PR can't merge until #3765 anyway):

### 1. Rename `PersistentService` → `BackgroundService` (commits 1-2)

External reviewers kept misreading the old name as mandatory. Root cause was naming, not just docstring wording.

- Class: `PersistentService` → `BackgroundService` (`contracts/protocols/service_lifecycle.py`, `__init__.py`)
- Method rename on `ServiceRegistry`: `start_persistent_services` → `start_background_services`, `stop_persistent_services` → `stop_background_services`
- All 6 `isinstance()` sites updated + cascaded across ~25 files
- Module docstring rewritten to lead with opt-in framing and side-by-side examples
- `docs/architecture/KERNEL-ARCHITECTURE.md` terminology updated

### 2. `PasswordVaultService` (commits 3-4)

Thin domain wrapper over `SecretsService` — all storage/encryption/audit/versioning/soft-delete delegated, only adds a `VaultEntry`-typed API. Reinforces the new `BackgroundService` opt-in story (this is explicitly an on-demand service, no `start`/`stop`).

- `src/nexus/services/password_vault/` — service + schema + unit tests
- `src/nexus/server/api/v2/routers/password_vault.py` — REST endpoints
- `src/nexus/server/fastapi_server.py` — DI wiring nested inside existing secrets block (shares SecretsService singleton)
- `tests/integration/test_password_vault_api.py` — session-scoped TestClient + InMemoryRecordStore

## Out of scope (follow-up)

`src/nexus/daemon/main.py:120-142 _print_lifecycle_summary` references removed `classify_all()` API, swallowed by silent try/except. File a separate issue.

## Test plan

- [ ] CI: targeted pytest (rename protocol tests + password vault unit + integration)
- [ ] CI: ruff / mypy on `src/` and `tests/`
- [ ] CI: grep residual — `PersistentService|persistent_services` should return only the Issue #1577 historical-reference line
- [ ] Rebase onto develop once #3765 lands; resolve conflicts