### PR TITLE
fix(fs): slim cross-session reads for local:// mounts (#3821)

### DIFF
--- a/src/nexus/fs/_facade.py
+++ b/src/nexus/fs/_facade.py
@@ -99,7 +99,49 @@ class SlimNexusFS:
         Raises:
             NexusFileNotFoundError: If file does not exist.
         """
-        return self._kernel.sys_read(path, context=self._ctx)
+        from nexus.contracts.exceptions import NexusFileNotFoundError
+
+        try:
+            return self._kernel.sys_read(path, context=self._ctx)
+        except NexusFileNotFoundError:
+            # Issue #3821: the slim package wires a SQLiteMetastore that the
+            # Rust kernel cannot see (its metastore hook expects a redb path).
+            # Same-session reads succeed via dcache, but a fresh process has
+            # an empty dcache → Rust raises FileNotFound even though the row
+            # exists in SQLite.  Fall back to the Python metastore + backend.
+            data = self._slim_metastore_read(path)
+            if data is None:
+                raise
+            return data
+
+    def _slim_metastore_read(self, path: str) -> bytes | None:
+        """Read via Python metastore + backend.read_content (slim fallback).
+
+        Returns ``None`` when the metadata or backend cannot be resolved so
+        the caller re-raises the original ``NexusFileNotFoundError``.
+        """
+        from nexus.core.path_utils import validate_path
+
+        try:
+            normalized = validate_path(path)
+        except Exception:
+            return None
+        meta = self._kernel.metadata.get(normalized)
+        if meta is None or not meta.etag:
+            return None
+        # backend_name on metadata may be ``name`` or ``name:mount@origin``;
+        # only the bare name is needed to find the live backend instance.
+        bare = meta.backend_name.split(":", 1)[0].split("@", 1)[0]
+        for entry in self._kernel.router._mount_table._entries.values():
+            backend = getattr(entry, "backend", None)
+            if backend is None or getattr(backend, "name", None) != bare:
+                continue
+            read_content = getattr(backend, "read_content", None)
+            if read_content is None:
+                return None
+            data = read_content(meta.etag, context=self._ctx)
+            return bytes(data) if isinstance(data, (bytes, bytearray)) else None
+        return None
 
     def read_range(self, path: str, start: int, end: int) -> bytes:
         """Read a specific byte range from a file.

--- a/tests/unit/fs/test_slim_cross_session_read.py
+++ b/tests/unit/fs/test_slim_cross_session_read.py
@@ -1,0 +1,78 @@
+"""Regression test for Issue #3821.
+
+Writes through one SlimNexusFS instance, then reads from a fresh one built
+against the same on-disk SQLite metastore + CAS backend.  Previously the
+read raised ``NexusFileNotFoundError`` because the Rust kernel's dcache was
+empty and its metastore hook expects a redb path — the SQLite metastore was
+invisible to it.  The facade's Python fallback keeps slim-package reads
+working across process boundaries.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from nexus.backends.storage.cas_local import CASLocalBackend
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.exceptions import NexusFileNotFoundError
+from nexus.contracts.types import OperationContext
+from nexus.core.config import PermissionConfig
+from nexus.core.mount_table import MountTable
+from nexus.core.nexus_fs import NexusFS
+from nexus.core.router import PathRouter
+from nexus.fs import _make_mount_entry
+from nexus.fs._facade import SlimNexusFS
+from nexus.fs._sqlite_meta import SQLiteMetastore
+
+
+def _build_slim(db_path: Path, data_dir: Path) -> SlimNexusFS:
+    metastore = SQLiteMetastore(str(db_path))
+    backend = CASLocalBackend(root_path=data_dir)
+    mount_table = MountTable(metastore)
+    router = PathRouter(mount_table)
+    kernel = NexusFS(
+        metadata_store=metastore,
+        permissions=PermissionConfig(enforce=False),
+        router=router,
+    )
+    kernel._init_cred = OperationContext(
+        user_id="slim-xsession", groups=[], zone_id=ROOT_ZONE_ID, is_admin=True
+    )
+    kernel._driver_coordinator.mount("/files", backend)
+    metastore.put(_make_mount_entry("/files", backend.name))
+    return SlimNexusFS(kernel)
+
+
+def test_slim_read_survives_fresh_process(tmp_path: Path) -> None:
+    db_path = tmp_path / "meta.db"
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    writer = _build_slim(db_path, data_dir)
+    writer.write("/files/hello.txt", b"hi")
+    assert writer.read("/files/hello.txt") == b"hi"  # same-session baseline
+    writer.close()  # close SQLite + kernel, like a process exit
+
+    reader = _build_slim(db_path, data_dir)
+    try:
+        # Previously raised NexusFileNotFoundError — the Rust kernel has
+        # cold dcache and no wired metastore in slim mode, so the Python
+        # fallback is what makes this succeed.
+        assert reader.read("/files/hello.txt") == b"hi"
+    finally:
+        reader.close()
+
+
+def test_slim_read_missing_path_still_raises(tmp_path: Path) -> None:
+    db_path = tmp_path / "meta.db"
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+
+    slim = _build_slim(db_path, data_dir)
+    try:
+        with pytest.raises(NexusFileNotFoundError):
+            slim.read("/files/does-not-exist.txt")
+    finally:
+        slim.close()


### PR DESCRIPTION
## Summary
- Fixes #3821 — `nexus.fs.mount("local://...")` + `fs.write()` in one process produced a `NexusFileNotFoundError` when a fresh process re-mounted the same URI and called `fs.read()`, even though the CAS blob and `metadata.db` row were both intact on disk.
- Root cause: the slim package wires a `SQLiteMetastore`, but the Rust kernel's metastore hook only accepts a redb path, so the Rust side has no metastore. Same-session reads succeeded because the dcache had the entry from the write. A fresh process starts with a cold dcache → Rust's `sys_read` raises `FileNotFound` even though the row is sitting in SQLite.
- Fix: add a Python-side fallback in `SlimNexusFS.read()` — on `NexusFileNotFoundError`, look up the metadata via the Python `SQLiteMetastore`, locate the live backend by bare name, and call `backend.read_content(content_id)`. Genuinely missing rows still raise.
- Scope is intentionally the public `read()` path, which is what users hit via the reproducer. `read_range`, `read_batch`, `copy`, `stat`, `exists`, `ls` already survive cross-session because they consult the Python metastore directly. `edit()` (which internally calls read) is a related but secondary break — tracked separately.

## Test plan
- [x] New regression test `tests/unit/fs/test_slim_cross_session_read.py::test_slim_read_survives_fresh_process` simulates a process boundary (writer `.close()`, fresh `SlimNexusFS` against the same SQLite + CAS dir) and asserts the read succeeds.
- [x] `test_slim_read_missing_path_still_raises` confirms genuinely absent paths still raise `NexusFileNotFoundError`.
- [x] Manual reproducer from #3821 passes end-to-end (write in one process → read in another).
- [x] `pytest tests/unit/fs/{test_slim_cross_session_read,test_slim_batch,test_ephemeral_mount,test_integration}.py` — 54 passed.