### PR TITLE
fix(gdrive): raise AuthenticationError with auth_url on missing token (#3822)

### DIFF
--- a/src/nexus/backends/connectors/gdrive/connector.py
+++ b/src/nexus/backends/connectors/gdrive/connector.py
@@ -48,7 +48,7 @@ from nexus.backends.connectors.gws.schemas import (
 )
 from nexus.backends.connectors.oauth import OAuthConnectorMixin
 from nexus.contracts.backend_features import OAUTH_BACKEND_FEATURES, BackendFeature
-from nexus.contracts.exceptions import BackendError
+from nexus.contracts.exceptions import AuthenticationError, BackendError
 from nexus.core.hash_fast import hash_content
 from nexus.core.object_store import WriteResult
 
@@ -504,6 +504,12 @@ class PathGDriveBackend(
             return sorted(entries)
 
         except FileNotFoundError:
+            raise
+        except AuthenticationError:
+            # Issue #3822: propagate auth-required signal unchanged so
+            # callers can read ``.provider`` / ``.user_email`` / ``.auth_url``
+            # and drive the OAuth flow.  Wrapping into BackendError here is
+            # what made ``fs.ls`` silently return [].
             raise
         except Exception as e:
             if "not found" in str(e).lower():

--- a/src/nexus/backends/connectors/gdrive/transport.py
+++ b/src/nexus/backends/connectors/gdrive/transport.py
@@ -139,16 +139,23 @@ class DriveTransport:
                 backend="gdrive",
             ) from None
 
-        # Resolve user email
+        # Resolve user email — absence is an auth-required signal, not a
+        # backend error.  Callers (fs.ls, fs.read, …) need to surface the
+        # authorize URL so UIs can drive the OAuth flow (#3822).
         if self._user_email:
-            user_email = self._user_email
+            user_email: str | None = self._user_email
         elif self._context and self._context.user_id:
             user_email = self._context.user_id
         else:
-            raise BackendError(
-                "Google Drive transport requires either configured user_email "
-                "or authenticated user in OperationContext",
-                backend="gdrive",
+            user_email = None
+
+        if user_email is None:
+            raise AuthenticationError(
+                f"Google Drive requires authorization (provider={self._provider}). "
+                "Configure user_email on the mount or authenticate a user.",
+                provider=self._provider,
+                user_email=None,
+                auth_url=self._build_auth_url(user_email=None),
             )
 
         from nexus.lib.sync_bridge import run_sync
@@ -171,8 +178,12 @@ class DriveTransport:
                 str(_auth_exc),
                 provider=self._provider,
                 user_email=user_email,
+                auth_url=self._build_auth_url(user_email=user_email),
             ) from _auth_exc
         except Exception as e:
+            # Non-auth failure (network error, misconfigured token manager, …)
+            # stays a BackendError so callers don't get false auth-required
+            # signals for transient problems.
             raise BackendError(
                 f"Failed to get valid OAuth token for user {user_email}: {e}",
                 backend="gdrive",
@@ -182,6 +193,50 @@ class DriveTransport:
 
         creds = Credentials(token=access_token)
         return build("drive", "v3", credentials=creds)
+
+    def _build_auth_url(self, *, user_email: str | None) -> str | None:
+        """Build a best-effort OAuth authorization URL for the bound provider.
+
+        Returns ``None`` when the environment is missing OAuth client
+        credentials — the caller still raises ``AuthenticationError`` so the
+        auth-required signal isn't lost, it just ships without a URL.
+        The redirect URI is derived from
+        ``NEXUS_OAUTH_REDIRECT_URI`` (set by the frontend / CLI callback
+        listener) and falls back to ``http://localhost`` so the URL is
+        well-formed even in headless test runs.
+        """
+        import os
+
+        try:
+            from nexus.fs._oauth_support import get_google_auth_url
+        except Exception:
+            return None
+
+        provider = self._provider or "google-drive"
+        redirect_uri = (
+            os.getenv("NEXUS_OAUTH_REDIRECT_URI")
+            or os.getenv("NEXUS_FS_OAUTH_REDIRECT_URI")
+            or "http://localhost"
+        )
+        # ``get_google_auth_url`` only knows a fixed set of service names
+        # (gws / google-drive / gmail / google-calendar).  Unknown provider
+        # labels fall back to gws-scope so the user gets *some* URL.
+        service = (
+            provider
+            if provider in {"google-drive", "gws", "gmail", "google-calendar"}
+            else "google-drive"
+        )
+        try:
+            return get_google_auth_url(
+                service_name=service,
+                redirect_uri=redirect_uri,
+            )
+        except Exception:
+            # Missing NEXUS_OAUTH_GOOGLE_CLIENT_ID/SECRET, or any other
+            # config miss.  The AuthenticationError still conveys the
+            # auth-required signal; the URL is optional context.
+            del user_email
+            return None
 
     # ------------------------------------------------------------------
     # Internal helpers — folder resolution

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -14,6 +14,7 @@ from typing import Any, NamedTuple
 from nexus.contracts.cache_store import CacheStoreABC, NullCacheStore
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.exceptions import (
+    AuthenticationError,
     BackendError,
     ConflictError,
     InvalidPathError,
@@ -5342,6 +5343,11 @@ class NexusFS(  # type: ignore[misc]
                             f"{path.rstrip('/')}/{e}" if not e.startswith("/") else e
                             for e in external_entries
                         ]
+            except AuthenticationError:
+                # Issue #3822: auth-required must surface so UIs can drive the
+                # OAuth flow.  Silently falling through to the metastore path
+                # returns [] (empty drive) and masks the missing token.
+                raise
             except Exception as exc:
                 logger.debug("sys_readdir connector route failed for %s: %s", path, exc)
 

--- a/tests/integration/backends/connectors/gdrive/test_gdrive_auth_required.py
+++ b/tests/integration/backends/connectors/gdrive/test_gdrive_auth_required.py
@@ -1,0 +1,130 @@
+"""Regression tests for Issue #3822.
+
+The gdrive connector must raise :class:`AuthenticationError` (with
+``provider`` / ``user_email`` / ``auth_url`` populated when possible)
+whenever a Drive operation is attempted without a valid OAuth token.
+Silently returning ``[]`` from ``fs.ls`` masked missing tokens and left
+no signal for callers to drive the OAuth flow.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.contracts.exceptions import AuthenticationError
+
+
+def _build_transport(monkeypatch: pytest.MonkeyPatch) -> Any:
+    """Import the transport lazily to skip when google-api-python-client is absent."""
+    pytest.importorskip("googleapiclient.discovery")
+    from nexus.backends.connectors.gdrive.transport import DriveTransport
+
+    monkeypatch.setenv("NEXUS_OAUTH_GOOGLE_CLIENT_ID", "fake-id.apps.googleusercontent.com")
+    monkeypatch.setenv("NEXUS_OAUTH_GOOGLE_CLIENT_SECRET", "fake-secret")
+    monkeypatch.setenv("NEXUS_OAUTH_REDIRECT_URI", "http://localhost:4567/callback")
+
+    token_manager = MagicMock()
+    return DriveTransport(token_manager=token_manager, provider="google-drive")
+
+
+def test_get_drive_service_raises_authentication_error_when_no_user(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """No user_email + no context -> AuthenticationError with auth_url, not BackendError."""
+    transport = _build_transport(monkeypatch)
+
+    with pytest.raises(AuthenticationError) as exc_info:
+        transport._get_drive_service()
+
+    err = exc_info.value
+    assert err.provider == "google-drive"
+    assert err.user_email is None
+    assert err.auth_url is not None
+    assert err.auth_url.startswith("https://accounts.google.com/o/oauth2/")
+    assert "client_id=fake-id.apps.googleusercontent.com" in err.auth_url
+    assert "redirect_uri=http%3A%2F%2Flocalhost%3A4567%2Fcallback" in err.auth_url
+
+
+def test_get_drive_service_raises_authentication_error_when_token_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """user_email present but token_manager has no valid token -> AuthenticationError."""
+    transport = _build_transport(monkeypatch)
+    transport._user_email = "user@example.com"
+
+    # token_manager.get_valid_token raises AuthenticationError (missing credential)
+    async def _raise(*_a: object, **_kw: object) -> None:
+        raise AuthenticationError("No credential for google-drive:user@example.com")
+
+    transport._token_manager.get_valid_token = _raise
+
+    with pytest.raises(AuthenticationError) as exc_info:
+        transport._get_drive_service()
+
+    err = exc_info.value
+    assert err.provider == "google-drive"
+    assert err.user_email == "user@example.com"
+    assert err.auth_url is not None
+    assert "accounts.google.com" in err.auth_url
+
+
+def test_auth_url_is_none_when_client_credentials_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Missing NEXUS_OAUTH_GOOGLE_CLIENT_ID -> AuthenticationError still raised, auth_url=None."""
+    pytest.importorskip("googleapiclient.discovery")
+    from nexus.backends.connectors.gdrive.transport import DriveTransport
+
+    monkeypatch.delenv("NEXUS_OAUTH_GOOGLE_CLIENT_ID", raising=False)
+    monkeypatch.delenv("NEXUS_OAUTH_GOOGLE_CLIENT_SECRET", raising=False)
+
+    transport = DriveTransport(token_manager=MagicMock(), provider="google-drive")
+
+    with pytest.raises(AuthenticationError) as exc_info:
+        transport._get_drive_service()
+
+    err = exc_info.value
+    assert err.provider == "google-drive"
+    assert err.auth_url is None
+
+
+def test_connector_list_dir_propagates_authentication_error(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """PathGDriveBackend.list_dir must not wrap AuthenticationError as BackendError.
+
+    Previously the bare ``except Exception`` in ``list_dir`` caught the
+    auth-required signal from the transport and re-raised it as
+    :class:`BackendError`, which upstream ``sys_readdir`` then swallowed
+    into an empty list.  The explicit ``except AuthenticationError``
+    clause added for #3822 lets the signal bubble up with its
+    ``provider`` / ``user_email`` / ``auth_url`` intact.
+    """
+    pytest.importorskip("googleapiclient.discovery")
+    from nexus.backends.connectors.gdrive.connector import PathGDriveBackend
+
+    monkeypatch.setenv("NEXUS_OAUTH_GOOGLE_CLIENT_ID", "fake.apps.googleusercontent.com")
+    monkeypatch.setenv("NEXUS_OAUTH_GOOGLE_CLIENT_SECRET", "fake")
+
+    connector = PathGDriveBackend(
+        token_manager_db=":memory:",
+        user_email="user@example.com",
+        provider="google-drive",
+    )
+
+    # Swap the token manager so get_valid_token raises — simulates a mount
+    # whose user has not yet completed the OAuth flow.
+    async def _raise(*_a: object, **_kw: object) -> None:
+        raise AuthenticationError("No credential for google-drive:user@example.com")
+
+    connector.token_manager.get_valid_token = _raise
+    connector._drive_transport._token_manager = connector.token_manager
+
+    with pytest.raises(AuthenticationError) as exc_info:
+        connector.list_dir("/")
+
+    assert exc_info.value.provider == "google-drive"
+    assert exc_info.value.user_email == "user@example.com"


### PR DESCRIPTION
## Summary

Fixes #3822. `fs.ls("/gdrive/…")` returned `[]` when the user hadn't completed OAuth — indistinguishable from \"drive is truly empty\", so UIs/agents/CLIs couldn't drive the OAuth flow.

Three scoped changes:

- **`src/nexus/backends/connectors/gdrive/transport.py::_get_drive_service`** — unresolved `user_email` now raises `AuthenticationError` (was `BackendError`); `get_valid_token` failures propagate `AuthenticationError` with `provider` / `user_email` / `auth_url` populated. Auth URL built via `nexus.fs._oauth_support.get_google_auth_url` (universal OAuth — scopes, PKCE stance, state) using `NEXUS_OAUTH_REDIRECT_URI` with `http://localhost` fallback. `auth_url` is `None` when OAuth client credentials aren't configured (signal still fires; URL is optional context).
- **`src/nexus/backends/connectors/gdrive/connector.py::list_dir`** — explicit `except AuthenticationError: raise` before the catch-all `Exception` wrapper that was masking the signal as `BackendError`.
- **`src/nexus/core/nexus_fs.py::sys_readdir`** (external-route path) — explicit `except AuthenticationError: raise` before the debug-log catch-all that was swallowing the signal into the empty metastore fallback.

## Test plan

- [x] Unit: `tests/integration/backends/connectors/gdrive/test_gdrive_auth_required.py` — 4 tests covering unresolved user, failed `get_valid_token`, missing client creds, and `list_dir` propagation.
- [x] E2E slim: built `packages/nexus-fs` wheel, installed into a clean Python 3.14 venv, ran issue reproducer → `AuthenticationError` with populated `provider=\"google-drive\"`, `user_email=\"local\"`, full `auth_url` (was: silent `[]`).
- [x] E2E full: `nexus up --build` started the full stack, ran issue reproducer through the live server → same `AuthenticationError` payload.
- [x] Unaffected paths: `pytest tests/integration/backends/connectors/gdrive/ tests/unit/fs/test_slim_cross_session_read.py tests/unit/fs/test_slim_batch.py` → 32 passed.

## Ship plan

Intended for the v0.9.32 release alongside #3823 (slim cross-session reads). Both PRs land on develop, then re-tag v0.9.32 on the new develop tip.