### PR TITLE
fix(raft): harden forwarding and witness transport safety

### DIFF
--- a/proto/nexus/raft/transport.proto
+++ b/proto/nexus/raft/transport.proto
@@ -110,6 +110,9 @@ message ProposeResponse {
   optional string leader_address = 3;
   optional RaftResponse result = 4;
   uint64 applied_index = 5;
+  // Internal forwarding: bincode-serialized CommandResult from leader.
+  // Preserves full result variants for follower->leader forwarding.
+  bytes raw_result = 6;
 }
 
 // QueryRequest reads from the local state machine.
@@ -142,6 +145,10 @@ message GetClusterInfoResponse {
   ClusterConfig config = 4;
   bool is_leader = 5;
   optional string leader_address = 6;
+  // True when this node returns ProposeResponse.raw_result for successful writes.
+  bool supports_raw_result = 7;
+  // Versioned contract for forwarded raw_result encoding.
+  string protocol_version = 8;
 }
 
 // JoinZoneRequest is sent by a new node to an existing zone member.

--- a/rust/raft/src/bin/witness.rs
+++ b/rust/raft/src/bin/witness.rs
@@ -66,20 +66,26 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         .map(|s| s.trim().to_string())
         .filter(|s| !s.is_empty())
         .collect();
+    let max_auto_join_zones: usize = env::var("NEXUS_WITNESS_MAX_AUTO_ZONES")
+        .ok()
+        .and_then(|v| v.trim().parse::<usize>().ok())
+        .filter(|v| *v > 0)
+        .unwrap_or(128);
 
     tracing::info!(
-        "Starting Nexus Witness Node\n  Hostname: {}\n  Node ID: {}\n  Bind: {}\n  Data: {}\n  Federation zones: {:?}",
+        "Starting Nexus Witness Node\n  Hostname: {}\n  Node ID: {}\n  Bind: {}\n  Data: {}\n  Federation zones: {:?}\n  Max auto-join zones: {}",
         hostname,
         node_id,
         bind_addr,
         data_path.display(),
         federation_zones,
+        max_auto_join_zones,
     );
 
     #[cfg(all(feature = "grpc", has_protos))]
     {
         use _nexus_raft::transport::{
-            NodeAddress, RaftWitnessServer, ServerConfig, WitnessZoneRegistry,
+            parse_join_token, NodeAddress, RaftWitnessServer, ServerConfig, WitnessZoneRegistry,
         };
 
         let tls_dir = data_path.join("tls");
@@ -120,6 +126,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Create registry + zones
         let mut registry = WitnessZoneRegistry::new(data_path.clone(), node_id, tls_config.clone());
         registry.set_peers(peers.clone());
+        registry.set_max_auto_join_zones(max_auto_join_zones);
         let registry = Arc::new(registry);
         let runtime_handle = tokio::runtime::Handle::current();
 
@@ -149,15 +156,13 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         // Token is file-only (no env var) — consistent with file-based design.
         if needs_bootstrap && !peers.is_empty() {
             let token_path = tls_dir.join("join-token");
-            let password = if token_path.exists() {
+            let join_token = if token_path.exists() {
                 let token = std::fs::read_to_string(&token_path).unwrap_or_default();
-                let token = token.trim();
-                if let Some(body) = token.strip_prefix("K10") {
-                    body.split("::server:").next().unwrap_or("").to_string()
-                } else {
-                    tracing::warn!("Join token file has invalid format (expected K10...)");
-                    String::new()
+                let token = token.trim().to_string();
+                if token.is_empty() {
+                    tracing::warn!("Join token file is empty: {}", token_path.display());
                 }
+                token
             } else {
                 tracing::warn!(
                     "No join token at {} — cannot provision TLS certs",
@@ -166,17 +171,36 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 String::new()
             };
 
-            if !password.is_empty() {
-                let tls_dir_bg = tls_dir.clone();
-                let peers_bg = peers.clone();
-                let my_addr = peers
-                    .iter()
-                    .find(|p| p.id == node_id)
-                    .map(|p| p.endpoint.clone())
-                    .unwrap_or_else(|| format!("http://{}", bind_addr));
-                tokio::spawn(async move {
-                    tls_bootstrap_loop(node_id, &my_addr, &peers_bg, &tls_dir_bg, &password).await;
-                });
+            if !join_token.is_empty() {
+                let parsed = match parse_join_token(&join_token) {
+                    Ok(parsed) => Some(parsed),
+                    Err(e) => {
+                        tracing::warn!("Join token file has invalid format: {}", e);
+                        None
+                    }
+                };
+                if let Some(parsed) = parsed {
+                    let password = parsed.password;
+                    let expected_ca_fingerprint = parsed.ca_fingerprint;
+                    let tls_dir_bg = tls_dir.clone();
+                    let peers_bg = peers.clone();
+                    let my_addr = peers
+                        .iter()
+                        .find(|p| p.id == node_id)
+                        .map(|p| p.endpoint.clone())
+                        .unwrap_or_else(|| format!("http://{}", bind_addr));
+                    tokio::spawn(async move {
+                        tls_bootstrap_loop(
+                            node_id,
+                            &my_addr,
+                            &peers_bg,
+                            &tls_dir_bg,
+                            &password,
+                            &expected_ca_fingerprint,
+                        )
+                        .await;
+                    });
+                }
             }
         }
 
@@ -240,6 +264,7 @@ async fn tls_bootstrap_loop(
     peers: &[_nexus_raft::transport::NodeAddress],
     tls_dir: &std::path::Path,
     password: &str,
+    expected_ca_fingerprint: &str,
 ) {
     use _nexus_raft::transport::call_join_cluster;
 
@@ -272,6 +297,29 @@ async fn tls_bootstrap_loop(
             .await
             {
                 Ok(result) => {
+                    let ca_fingerprint =
+                        match _nexus_raft::transport::ca_fingerprint_from_pem(&result.ca_pem) {
+                            Ok(fingerprint) => fingerprint,
+                            Err(e) => {
+                                tracing::warn!(
+                                "TLS bootstrap: failed to compute CA fingerprint from peer {}: {}",
+                                peer.id,
+                                e
+                            );
+                                continue;
+                            }
+                        };
+
+                    if ca_fingerprint != expected_ca_fingerprint {
+                        tracing::error!(
+                            "TLS bootstrap: CA fingerprint mismatch from peer {} (expected '{}', got '{}')",
+                            peer.id,
+                            expected_ca_fingerprint,
+                            ca_fingerprint
+                        );
+                        continue;
+                    }
+
                     // Save certs to disk
                     std::fs::create_dir_all(tls_dir).expect("create tls dir");
                     std::fs::write(tls_dir.join("ca.pem"), &result.ca_pem).expect("write CA");

--- a/rust/raft/src/pyo3_bindings.rs
+++ b/rust/raft/src/pyo3_bindings.rs
@@ -1376,30 +1376,10 @@ fn join_cluster(
     let node_id = crate::transport::hostname_to_node_id(hostname);
 
     // Parse join token: K10<password>::server:<ca_fingerprint>
-    let token_prefix = "K10";
-    let separator = "::server:";
-    if !join_token.starts_with(token_prefix) {
-        return Err(PyRuntimeError::new_err(
-            "Invalid join token: must start with 'K10'",
-        ));
-    }
-    let body = &join_token[token_prefix.len()..];
-    let sep_pos = body.find(separator).ok_or_else(|| {
-        PyRuntimeError::new_err("Invalid join token: missing '::server:' separator")
-    })?;
-    let password = &body[..sep_pos];
-    let expected_fingerprint = &body[sep_pos + separator.len()..];
-
-    if password.is_empty() {
-        return Err(PyRuntimeError::new_err(
-            "Invalid join token: empty password",
-        ));
-    }
-    if !expected_fingerprint.starts_with("SHA256:") {
-        return Err(PyRuntimeError::new_err(
-            "Invalid join token: fingerprint must start with 'SHA256:'",
-        ));
-    }
+    let parsed_token =
+        crate::transport::parse_join_token(join_token).map_err(PyRuntimeError::new_err)?;
+    let password = parsed_token.password;
+    let expected_fingerprint = parsed_token.ca_fingerprint;
 
     // Build endpoint URL
     let endpoint = if peer_address.starts_with("http") {
@@ -1417,12 +1397,12 @@ fn join_cluster(
     let result = runtime
         .block_on(call_join_cluster(
             &endpoint, node_id, "", // node_address — not needed for pre-provision
-            "root", password, 30, // timeout_secs
+            "root", &password, 30, // timeout_secs
         ))
         .map_err(|e| PyRuntimeError::new_err(format!("JoinCluster RPC failed: {}", e)))?;
 
     // Verify CA fingerprint matches the join token
-    let ca_fingerprint = crate::transport::certgen::ca_fingerprint_from_pem(&result.ca_pem)
+    let ca_fingerprint = crate::transport::ca_fingerprint_from_pem(&result.ca_pem)
         .map_err(|e| PyRuntimeError::new_err(format!("Failed to compute CA fingerprint: {}", e)))?;
     if ca_fingerprint != expected_fingerprint {
         return Err(PyRuntimeError::new_err(format!(

--- a/rust/raft/src/raft/error.rs
+++ b/rust/raft/src/raft/error.rs
@@ -55,6 +55,15 @@ pub enum RaftError {
     /// Transport error (gRPC forwarding failed).
     #[error("transport error: {0}")]
     Transport(String),
+
+    /// Command was committed but caller did not receive a decodable result.
+    #[error("command committed at index {applied_index} but result is undecodable: {details}")]
+    CommittedUnknown {
+        /// Applied log index reported by the leader.
+        applied_index: u64,
+        /// Human-readable reconciliation guidance.
+        details: String,
+    },
 }
 
 impl From<crate::storage::StorageError> for RaftError {

--- a/rust/raft/src/raft/node.rs
+++ b/rust/raft/src/raft/node.rs
@@ -265,6 +265,9 @@ struct ForwardContext {
     /// `Arc<tokio::sync::Mutex<..>>` so `ForwardContext` stays Clone + Send.
     cached_api_client:
         std::sync::Arc<tokio::sync::Mutex<Option<(String, crate::transport::RaftApiClient)>>>,
+    /// Cached leader capability: whether endpoint supports raw_result forwarding.
+    leader_raw_result_support:
+        std::sync::Arc<tokio::sync::Mutex<Option<(String, bool, std::time::Instant)>>>,
 }
 
 pub struct ZoneConsensus<S: StateMachine + 'static> {
@@ -413,22 +416,20 @@ impl<S: StateMachine + 'static> ZoneConsensus<S> {
             // Build the expected voter set from config.
             let mut voters = vec![config.id];
             voters.extend(config.peers.iter());
+            let persisted = &initial_state.conf_state;
+            let local_in_conf_state = persisted.voters.contains(&config.id)
+                || persisted.learners.contains(&config.id)
+                || persisted.voters_outgoing.contains(&config.id)
+                || persisted.learners_next.contains(&config.id);
+            if !persisted.voters.is_empty() && !local_in_conf_state {
+                return Err(RaftError::InvalidState(format!(
+                    "Persisted ConfState (voters={:?}, learners={:?}) does not include local node {}",
+                    persisted.voters, persisted.learners, config.id
+                )));
+            }
 
             let needs_bootstrap = if initial_state.conf_state.voters.is_empty() {
                 // Fresh cluster — no ConfState in storage yet.
-                true
-            } else if config.peers.is_empty() && initial_state.conf_state.voters != vec![config.id]
-            {
-                // Single-node restart with STALE ConfState from a previous
-                // multi-node cluster (e.g. Docker container restarted with
-                // different node ID but persistent storage). Force-reset to
-                // just [self.id] so raft-rs doesn't send messages to phantom
-                // peers that no longer exist.
-                tracing::warn!(
-                    "Stale ConfState detected (voters={:?}, expected={:?}) — resetting for single-node",
-                    initial_state.conf_state.voters,
-                    voters,
-                );
                 true
             } else {
                 false
@@ -518,6 +519,7 @@ impl<S: StateMachine + 'static> ZoneConsensus<S> {
             peers,
             zone_id,
             cached_api_client: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
+            leader_raw_result_support: std::sync::Arc::new(tokio::sync::Mutex::new(None)),
         });
     }
 
@@ -683,6 +685,7 @@ impl<S: StateMachine + 'static> ZoneConsensus<S> {
                 command,
                 &ctx.zone_id,
                 &ctx.cached_api_client,
+                &ctx.leader_raw_result_support,
             )
             .await
             {
@@ -1607,6 +1610,83 @@ mod tests {
             vec![1, 2, 3],
             "Multi-node ConfState must include self and all peers"
         );
+    }
+
+    #[test]
+    fn test_restart_with_empty_runtime_peers_preserves_persisted_conf_state() {
+        let dir = TempDir::new().unwrap();
+
+        // First boot as multi-node to persist a non-singleton ConfState.
+        {
+            let storage = RaftStorage::open(dir.path()).unwrap();
+            let store = RedbStore::open(dir.path().join("sm")).unwrap();
+            let state_machine = FullStateMachine::new(&store).unwrap();
+
+            let config = RaftConfig {
+                id: 1,
+                peers: vec![2],
+                ..Default::default()
+            };
+
+            let (_handle, _driver) =
+                ZoneConsensus::new(config, storage, state_machine, None).unwrap();
+        }
+
+        // Restart with empty runtime peers should reopen and preserve
+        // persisted multi-node membership (used during cold recovery).
+        {
+            let storage = RaftStorage::open(dir.path()).unwrap();
+            let store = RedbStore::open(dir.path().join("sm")).unwrap();
+            let state_machine = FullStateMachine::new(&store).unwrap();
+            let config = RaftConfig {
+                id: 1,
+                peers: vec![],
+                ..Default::default()
+            };
+
+            let (_handle, _driver) =
+                ZoneConsensus::new(config, storage, state_machine, None).unwrap();
+        }
+
+        let storage = RaftStorage::open(dir.path()).unwrap();
+        let state = Storage::initial_state(&storage).unwrap();
+        let mut voters = state.conf_state.voters.clone();
+        voters.sort();
+        assert_eq!(voters, vec![1, 2]);
+    }
+
+    #[test]
+    fn test_restart_rejects_persisted_conf_state_without_local_node() {
+        use raft::eraftpb::ConfState;
+
+        let dir = TempDir::new().unwrap();
+
+        {
+            let storage = RaftStorage::open(dir.path()).unwrap();
+            storage
+                .set_conf_state(&ConfState {
+                    voters: vec![2],
+                    ..Default::default()
+                })
+                .unwrap();
+        }
+
+        let storage = RaftStorage::open(dir.path()).unwrap();
+        let store = RedbStore::open(dir.path().join("sm")).unwrap();
+        let state_machine = FullStateMachine::new(&store).unwrap();
+        let config = RaftConfig {
+            id: 1,
+            peers: vec![],
+            ..Default::default()
+        };
+
+        let err = match ZoneConsensus::new(config, storage, state_machine, None) {
+            Ok(_) => {
+                panic!("Expected InvalidState when local node is absent from persisted voters")
+            }
+            Err(err) => err,
+        };
+        assert!(matches!(err, RaftError::InvalidState(_)));
     }
 
     #[tokio::test]

--- a/rust/raft/src/raft/zone_registry.rs
+++ b/rust/raft/src/raft/zone_registry.rs
@@ -23,7 +23,8 @@ use crate::transport::{
     TransportLoop,
 };
 use dashmap::DashMap;
-use std::collections::HashMap;
+use raft::Storage as RaftStorageTrait;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use tokio::sync::watch;
@@ -93,6 +94,8 @@ pub struct ZoneRaftRegistry {
     /// ("Database already open") without a global mutex that would serialize
     /// creation of *different* zones.
     creating: DashMap<String, ()>,
+    /// Cached persisted membership from on-disk ConfState (zone_id -> node IDs).
+    persisted_members: DashMap<String, HashSet<u64>>,
 }
 
 impl ZoneRaftRegistry {
@@ -109,6 +112,7 @@ impl ZoneRaftRegistry {
             node_id,
             tls: Arc::new(RwLock::new(None)),
             creating: DashMap::new(),
+            persisted_members: DashMap::new(),
         }
     }
 
@@ -121,6 +125,7 @@ impl ZoneRaftRegistry {
             node_id,
             tls: Arc::new(RwLock::new(tls)),
             creating: DashMap::new(),
+            persisted_members: DashMap::new(),
         }
     }
 
@@ -251,6 +256,22 @@ impl ZoneRaftRegistry {
         let raft_storage = RaftStorage::open(zone_path.join("raft")).map_err(|e| {
             TransportError::Connection(format!("Failed to open raft storage: {}", e))
         })?;
+        let mut persisted_members = HashSet::new();
+        if let Ok(initial_state) = RaftStorageTrait::initial_state(&raft_storage) {
+            let conf_state = initial_state.conf_state;
+            persisted_members.extend(conf_state.voters);
+            persisted_members.extend(conf_state.learners);
+            persisted_members.extend(conf_state.voters_outgoing);
+            persisted_members.extend(conf_state.learners_next);
+        }
+        if persisted_members.is_empty() {
+            persisted_members.insert(config.id);
+            persisted_members.extend(config.peers.iter().copied());
+        }
+        if !persisted_members.is_empty() {
+            self.persisted_members
+                .insert(zone_id.to_string(), persisted_members);
+        }
         let state_machine = FullStateMachine::new(&store).map_err(|e| {
             TransportError::Connection(format!("Failed to create state machine: {}", e))
         })?;
@@ -351,6 +372,71 @@ impl ZoneRaftRegistry {
             .map(|e| e.peers.read().unwrap().clone())
     }
 
+    fn load_persisted_members(&self, zone_id: &str) -> Option<HashSet<u64>> {
+        let zone_raft_path = self.base_path.join(zone_id).join("raft");
+        let storage = RaftStorage::open(&zone_raft_path).ok()?;
+        let initial_state = RaftStorageTrait::initial_state(&storage).ok()?;
+        let conf_state = initial_state.conf_state;
+
+        let mut members = HashSet::new();
+        members.extend(conf_state.voters);
+        members.extend(conf_state.learners);
+        members.extend(conf_state.voters_outgoing);
+        members.extend(conf_state.learners_next);
+
+        if members.is_empty() {
+            None
+        } else {
+            Some(members)
+        }
+    }
+
+    /// Check persisted on-disk ConfState membership, using an in-memory cache.
+    pub fn is_persisted_member(&self, zone_id: &str, node_id: u64) -> bool {
+        if let Some(entry) = self.zones.get(zone_id) {
+            let peers = entry.peers.read().unwrap();
+            if !peers.is_empty() {
+                let mut members: HashSet<u64> = peers.keys().copied().collect();
+                members.insert(self.node_id);
+                let is_member = members.contains(&node_id);
+                self.persisted_members.insert(zone_id.to_string(), members);
+                return is_member;
+            }
+        }
+
+        if let Some(cached) = self.persisted_members.get(zone_id) {
+            return cached.contains(&node_id);
+        }
+
+        let members = match self.load_persisted_members(zone_id) {
+            Some(members) => members,
+            None => return false,
+        };
+        let is_member = members.contains(&node_id);
+        self.persisted_members.insert(zone_id.to_string(), members);
+        is_member
+    }
+
+    /// Refresh persisted membership from disk when possible, then evaluate membership.
+    pub fn is_persisted_member_fresh(&self, zone_id: &str, node_id: u64) -> bool {
+        if let Some(members) = self.load_persisted_members(zone_id) {
+            let is_member = members.contains(&node_id);
+            self.persisted_members.insert(zone_id.to_string(), members);
+            return is_member;
+        }
+
+        // Fall back to cached membership when refresh is temporarily unavailable.
+        if let Some(cached) = self.persisted_members.get(zone_id) {
+            tracing::warn!(
+                zone = zone_id,
+                "Using cached membership because persisted refresh was unavailable"
+            );
+            return cached.contains(&node_id);
+        }
+
+        false
+    }
+
     /// Get cluster peer addresses from any existing zone (all zones share the same peers).
     /// Used by auto-join for new zones that don't have their own peer map yet.
     pub fn get_all_peers(&self) -> Vec<NodeAddress> {
@@ -370,6 +456,7 @@ impl ZoneRaftRegistry {
     pub fn add_peer(&self, zone_id: &str, node_id: u64, address: NodeAddress) -> bool {
         if let Some(entry) = self.zones.get(zone_id) {
             entry.peers.write().unwrap().insert(node_id, address);
+            self.persisted_members.remove(zone_id);
             true
         } else {
             false
@@ -388,6 +475,7 @@ impl ZoneRaftRegistry {
             Some((_, entry)) => {
                 // Signal shutdown to transport loop
                 let _ = entry.shutdown_tx.send(true);
+                self.persisted_members.remove(zone_id);
                 tracing::info!("Zone '{}' removed", zone_id);
                 Ok(())
             }

--- a/rust/raft/src/transport/certgen.rs
+++ b/rust/raft/src/transport/certgen.rs
@@ -12,6 +12,51 @@ use rcgen::{
 };
 use std::net::{Ipv4Addr, Ipv6Addr};
 
+/// Parsed K3s-style join token material used during TLS bootstrap.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ParsedJoinToken {
+    /// Shared secret used as JoinCluster password.
+    pub password: String,
+    /// Expected CA fingerprint in `SHA256:<base64-no-padding>` format.
+    pub ca_fingerprint: String,
+}
+
+/// Parse a K3s-style join token (`K10<password>::server:<ca_fingerprint>`).
+pub fn parse_join_token(join_token: &str) -> Result<ParsedJoinToken, String> {
+    const TOKEN_PREFIX: &str = "K10";
+    const SEPARATOR: &str = "::server:";
+
+    let token = join_token.trim();
+    if !token.starts_with(TOKEN_PREFIX) {
+        return Err("Invalid join token: must start with 'K10'".to_string());
+    }
+
+    let body = &token[TOKEN_PREFIX.len()..];
+    let sep_pos = body
+        .find(SEPARATOR)
+        .ok_or_else(|| "Invalid join token: missing '::server:' separator".to_string())?;
+
+    let password = body[..sep_pos].to_string();
+    let ca_fingerprint = body[sep_pos + SEPARATOR.len()..].to_string();
+
+    if password.is_empty() {
+        return Err("Invalid join token: empty password".to_string());
+    }
+
+    if !ca_fingerprint.starts_with("SHA256:") {
+        return Err("Invalid join token: fingerprint must start with 'SHA256:'".to_string());
+    }
+
+    if ca_fingerprint.len() == "SHA256:".len() {
+        return Err("Invalid join token: empty fingerprint body".to_string());
+    }
+
+    Ok(ParsedJoinToken {
+        password,
+        ca_fingerprint,
+    })
+}
+
 /// Generate a node certificate signed by the cluster CA.
 ///
 /// Returns `(node_cert_pem, node_key_pem)` as PEM-encoded bytes.
@@ -188,5 +233,21 @@ mod tests {
         let (ca_cert_pem, _) = generate_test_ca();
         let result = generate_node_cert(1, "root", ca_cert_pem.as_bytes(), b"not-a-key", &[], None);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_parse_join_token_ok() {
+        let parsed = parse_join_token("K10secret::server:SHA256:abc123").unwrap();
+        assert_eq!(parsed.password, "secret");
+        assert_eq!(parsed.ca_fingerprint, "SHA256:abc123");
+    }
+
+    #[test]
+    fn test_parse_join_token_rejects_invalid_format() {
+        assert!(parse_join_token("not-a-token").is_err());
+        assert!(parse_join_token("K10secret").is_err());
+        assert!(parse_join_token("K10::server:SHA256:x").is_err());
+        assert!(parse_join_token("K10secret::server:not-sha").is_err());
+        assert!(parse_join_token("K10secret::server:SHA256:").is_err());
     }
 }

--- a/rust/raft/src/transport/client.rs
+++ b/rust/raft/src/transport/client.rs
@@ -533,6 +533,8 @@ impl RaftApiClient {
             term: resp.term,
             is_leader: resp.is_leader,
             leader_address: resp.leader_address,
+            supports_raw_result: resp.supports_raw_result,
+            protocol_version: resp.protocol_version,
         })
     }
 }
@@ -576,6 +578,10 @@ pub struct ClusterInfoResult {
     pub is_leader: bool,
     /// Leader address (if known).
     pub leader_address: Option<String>,
+    /// Whether leader supports raw_result in ProposeResponse.
+    pub supports_raw_result: bool,
+    /// Forwarded result protocol version.
+    pub protocol_version: String,
 }
 
 // =============================================================================

--- a/rust/raft/src/transport/mod.rs
+++ b/rust/raft/src/transport/mod.rs
@@ -49,6 +49,8 @@ mod server;
 mod transport_loop;
 
 #[cfg(all(feature = "grpc", has_protos))]
+pub use certgen::{ca_fingerprint_from_pem, parse_join_token, ParsedJoinToken};
+#[cfg(all(feature = "grpc", has_protos))]
 pub use client::{
     call_join_cluster, ClientConfig, ClusterInfoResult, JoinClusterResult, ProposeResult,
     QueryResult, RaftApiClient, RaftClient, RaftClientPool,
@@ -57,6 +59,321 @@ pub use client::{
 pub use server::{RaftGrpcServer, RaftWitnessServer, ServerConfig, WitnessZoneRegistry};
 #[cfg(all(feature = "grpc", has_protos))]
 pub use transport_loop::TransportLoop;
+
+#[cfg(all(feature = "grpc", has_protos))]
+fn command_name(command: &crate::raft::Command) -> &'static str {
+    use crate::raft::Command;
+    match command {
+        Command::SetMetadata { .. } => "SetMetadata",
+        Command::DeleteMetadata { .. } => "DeleteMetadata",
+        Command::AcquireLock { .. } => "AcquireLock",
+        Command::ReleaseLock { .. } => "ReleaseLock",
+        Command::ExtendLock { .. } => "ExtendLock",
+        Command::CasSetMetadata { .. } => "CasSetMetadata",
+        Command::AdjustCounter { .. } => "AdjustCounter",
+        Command::Noop => "Noop",
+    }
+}
+
+#[cfg(all(feature = "grpc", has_protos))]
+fn result_name(result: &crate::raft::CommandResult) -> &'static str {
+    use crate::raft::CommandResult;
+    match result {
+        CommandResult::Success => "Success",
+        CommandResult::Value(_) => "Value",
+        CommandResult::LockResult(_) => "LockResult",
+        CommandResult::CasResult { .. } => "CasResult",
+        CommandResult::Error(_) => "Error",
+    }
+}
+
+#[cfg(all(feature = "grpc", has_protos))]
+const MAX_FORWARDED_RAW_RESULT_BYTES: u64 = 4 * 1024 * 1024;
+#[cfg(all(feature = "grpc", has_protos))]
+const RAW_RESULT_NEGATIVE_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(30);
+#[cfg(all(feature = "grpc", has_protos))]
+const RAW_RESULT_POSITIVE_CACHE_TTL: std::time::Duration = std::time::Duration::from_secs(30);
+#[cfg(all(feature = "grpc", has_protos))]
+const FORWARDED_RESULT_PROTOCOL_VERSION: &str = "nexus-raft-forward-v1";
+
+#[cfg(all(feature = "grpc", has_protos))]
+fn requires_lossless_forward_result(command: &crate::raft::Command) -> bool {
+    matches!(
+        command,
+        crate::raft::Command::AcquireLock { .. }
+            | crate::raft::Command::CasSetMetadata { .. }
+            | crate::raft::Command::AdjustCounter { .. }
+    )
+}
+
+#[cfg(all(feature = "grpc", has_protos))]
+fn validate_forwarded_result(
+    command: &crate::raft::Command,
+    result: &crate::raft::CommandResult,
+) -> crate::raft::Result<()> {
+    use crate::raft::{Command, CommandResult, RaftError};
+
+    let expected = match command {
+        Command::SetMetadata { .. }
+        | Command::DeleteMetadata { .. }
+        | Command::ReleaseLock { .. }
+        | Command::ExtendLock { .. }
+        | Command::Noop => matches!(result, CommandResult::Success | CommandResult::Error(_)),
+        Command::AcquireLock { .. } => {
+            matches!(
+                result,
+                CommandResult::LockResult(_) | CommandResult::Error(_)
+            )
+        }
+        Command::CasSetMetadata { .. } => {
+            matches!(
+                result,
+                CommandResult::CasResult { .. } | CommandResult::Error(_)
+            )
+        }
+        Command::AdjustCounter { .. } => {
+            matches!(result, CommandResult::Value(_) | CommandResult::Error(_))
+        }
+    };
+
+    if expected {
+        return Ok(());
+    }
+
+    Err(RaftError::Serialization(format!(
+        "Forwarded {} returned incompatible result variant {}",
+        command_name(command),
+        result_name(result),
+    )))
+}
+
+#[cfg(all(feature = "grpc", has_protos))]
+fn lock_state_from_proto(lock: proto::nexus::raft::LockResult) -> crate::raft::LockState {
+    let proto::nexus::raft::LockResult {
+        acquired,
+        current_holder,
+        expires_at_ms,
+    } = lock;
+    let expires_at_secs = (expires_at_ms.max(0) as u64) / 1000;
+
+    let holders: Vec<crate::raft::HolderInfo> = current_holder
+        .into_iter()
+        .map(|holder_info| crate::raft::HolderInfo {
+            lock_id: String::new(),
+            holder_info,
+            acquired_at: 0,
+            expires_at: expires_at_secs,
+        })
+        .collect();
+
+    crate::raft::LockState {
+        acquired,
+        current_holders: holders.len() as u32,
+        max_holders: 1,
+        holders,
+    }
+}
+
+#[cfg(all(feature = "grpc", has_protos))]
+fn decode_legacy_forwarded_result(
+    command: &crate::raft::Command,
+    response: proto::nexus::raft::RaftResponse,
+) -> crate::raft::Result<crate::raft::CommandResult> {
+    use crate::raft::{Command, CommandResult, RaftError};
+    use proto::nexus::raft::raft_response::Result as ProtoResponseResultVariant;
+
+    if !response.success {
+        if let Some(err) = response.error {
+            if matches!(command, Command::CasSetMetadata { .. }) {
+                return Err(RaftError::Serialization(format!(
+                    "Forwarded {} response omitted CAS version details: {}",
+                    command_name(command),
+                    err
+                )));
+            }
+            return Ok(CommandResult::Error(err));
+        }
+        return Err(RaftError::Serialization(format!(
+            "Forwarded {} failed without details",
+            command_name(command)
+        )));
+    }
+
+    match response.result {
+        Some(ProtoResponseResultVariant::LockResult(lock)) => {
+            Ok(CommandResult::LockResult(lock_state_from_proto(lock)))
+        }
+        Some(ProtoResponseResultVariant::MetadataResult(_)) => {
+            if matches!(command, Command::AdjustCounter { .. }) {
+                Err(RaftError::Serialization(
+                    "Forwarded AdjustCounter response omitted counter bytes".to_string(),
+                ))
+            } else {
+                Ok(CommandResult::Success)
+            }
+        }
+        None => Ok(CommandResult::Success),
+    }
+}
+
+#[cfg(all(feature = "grpc", has_protos))]
+fn decode_forwarded_propose_response(
+    command: &crate::raft::Command,
+    response: proto::nexus::raft::ProposeResponse,
+) -> crate::raft::Result<crate::raft::CommandResult> {
+    use crate::raft::{CommandResult, RaftError};
+
+    let proto::nexus::raft::ProposeResponse {
+        success,
+        error,
+        leader_address,
+        result,
+        raw_result,
+        applied_index,
+        ..
+    } = response;
+    let mut legacy_result = result;
+
+    if !success {
+        if let Some(err) = error {
+            if err.contains("Not the leader") || err.contains("not leader") {
+                return Err(RaftError::NotLeader { leader_hint: None });
+            }
+            return Err(RaftError::Raft(err));
+        }
+        if leader_address.is_some() {
+            return Err(RaftError::NotLeader { leader_hint: None });
+        }
+        return Err(RaftError::Raft(format!(
+            "Forwarded {} failed without details",
+            command_name(command)
+        )));
+    }
+
+    let result = if !raw_result.is_empty() {
+        if raw_result.len() as u64 > MAX_FORWARDED_RAW_RESULT_BYTES {
+            if requires_lossless_forward_result(command) {
+                return Err(RaftError::Raft(format!(
+                    "Forwarded {} appears committed at index {} but returned an oversized result ({} bytes > {} bytes); \
+                     fetch authoritative state from leader before retrying",
+                    command_name(command),
+                    applied_index,
+                    raw_result.len(),
+                    MAX_FORWARDED_RAW_RESULT_BYTES
+                )));
+            }
+            if let Some(proto_result) = legacy_result.take() {
+                tracing::warn!(
+                    command = command_name(command),
+                    size = raw_result.len(),
+                    limit = MAX_FORWARDED_RAW_RESULT_BYTES,
+                    "raw_result exceeds size limit; falling back to legacy result"
+                );
+                decode_legacy_forwarded_result(command, proto_result)?
+            } else {
+                return Err(RaftError::Serialization(format!(
+                    "Forwarded {} raw_result too large ({} bytes > {} bytes)",
+                    command_name(command),
+                    raw_result.len(),
+                    MAX_FORWARDED_RAW_RESULT_BYTES
+                )));
+            }
+        } else {
+            match bincode::deserialize::<CommandResult>(&raw_result) {
+                Ok(decoded) => decoded,
+                Err(e) => {
+                    if requires_lossless_forward_result(command) {
+                        return Err(RaftError::Raft(format!(
+                            "Forwarded {} appears committed at index {} but result decoding failed ({}); \
+                             fetch authoritative state from leader before retrying",
+                            command_name(command),
+                            applied_index,
+                            e
+                        )));
+                    }
+                    if let Some(proto_result) = legacy_result.take() {
+                        tracing::warn!(
+                            command = command_name(command),
+                            "Failed to decode raw_result ({}), falling back to legacy result",
+                            e
+                        );
+                        decode_legacy_forwarded_result(command, proto_result)?
+                    } else {
+                        return Err(RaftError::Serialization(format!(
+                            "Failed to deserialize forwarded {} result: {}",
+                            command_name(command),
+                            e
+                        )));
+                    }
+                }
+            }
+        }
+    } else if let Some(proto_result) = legacy_result.take() {
+        decode_legacy_forwarded_result(command, proto_result)?
+    } else {
+        CommandResult::Success
+    };
+
+    validate_forwarded_result(command, &result)?;
+    Ok(result)
+}
+
+#[cfg(all(feature = "grpc", has_protos))]
+async fn probe_leader_raw_result_support(
+    api_client: &mut RaftApiClient,
+    leader_addr: &NodeAddress,
+    zone_id: &str,
+    raw_result_support: &tokio::sync::Mutex<Option<(String, bool, std::time::Instant)>>,
+) -> crate::raft::Result<bool> {
+    use crate::raft::RaftError;
+    use std::time::Instant;
+
+    let cached = {
+        let guard = raw_result_support.lock().await;
+        guard.as_ref().and_then(|(endpoint, supports, checked_at)| {
+            if endpoint != &leader_addr.endpoint {
+                return None;
+            }
+            if *supports {
+                if checked_at.elapsed() < RAW_RESULT_POSITIVE_CACHE_TTL {
+                    return Some(true);
+                }
+                return None;
+            }
+            if checked_at.elapsed() < RAW_RESULT_NEGATIVE_CACHE_TTL {
+                return Some(false);
+            }
+            None
+        })
+    };
+    if let Some(supports) = cached {
+        return Ok(supports);
+    }
+
+    let request = tonic::Request::new(proto::nexus::raft::GetClusterInfoRequest {
+        zone_id: zone_id.to_string(),
+    });
+    let response = api_client
+        .inner_mut()
+        .get_cluster_info(request)
+        .await
+        .map_err(|e| RaftError::Transport(e.to_string()))?
+        .into_inner();
+
+    let supports = response.supports_raw_result
+        && response.protocol_version == FORWARDED_RESULT_PROTOCOL_VERSION;
+    if response.supports_raw_result && !supports {
+        tracing::warn!(
+            leader = %leader_addr.endpoint,
+            reported_version = %response.protocol_version,
+            expected_version = FORWARDED_RESULT_PROTOCOL_VERSION,
+            "Leader reported incompatible forwarded-result protocol version",
+        );
+    }
+    let mut guard = raw_result_support.lock().await;
+    *guard = Some((leader_addr.endpoint.clone(), supports, Instant::now()));
+    Ok(supports)
+}
 
 /// Forward a Raft proposal to a leader node via gRPC Propose RPC.
 ///
@@ -75,8 +392,10 @@ pub(crate) async fn forward_propose(
     command: crate::raft::Command,
     zone_id: &str,
     cached_client: &tokio::sync::Mutex<Option<(String, RaftApiClient)>>,
+    raw_result_support: &tokio::sync::Mutex<Option<(String, bool, std::time::Instant)>>,
 ) -> crate::raft::Result<crate::raft::CommandResult> {
-    use crate::raft::{CommandResult, RaftError};
+    use crate::raft::RaftError;
+    use std::time::Instant;
 
     let raw_bytes =
         bincode::serialize(&command).map_err(|e| RaftError::Serialization(e.to_string()))?;
@@ -99,6 +418,29 @@ pub(crate) async fn forward_propose(
         }
     };
 
+    if requires_lossless_forward_result(&command) {
+        let supports = probe_leader_raw_result_support(
+            &mut api_client,
+            leader_addr,
+            zone_id,
+            raw_result_support,
+        )
+        .await?;
+        if !supports {
+            // Keep the warmed client cached even when capability is missing.
+            let mut guard = cached_client.lock().await;
+            *guard = Some((leader_addr.endpoint.clone(), api_client));
+            tracing::warn!(
+                leader = %leader_addr.endpoint,
+                command = command_name(&command),
+                "Leader lacks lossless forwarding capability; redirecting caller to leader",
+            );
+            return Err(RaftError::NotLeader {
+                leader_hint: Some(leader_addr.id),
+            });
+        }
+    }
+
     let request = tonic::Request::new(proto::nexus::raft::ProposeRequest {
         command: None,
         request_id: String::new(),
@@ -119,18 +461,35 @@ pub(crate) async fn forward_propose(
             let mut guard = cached_client.lock().await;
             *guard = Some((leader_addr.endpoint.clone(), api_client));
 
-            let resp = response.into_inner();
-            if resp.success {
-                Ok(CommandResult::Success)
-            } else if let Some(ref err) = resp.error {
-                if err.contains("Not the leader") || err.contains("not leader") {
-                    Err(RaftError::NotLeader { leader_hint: None })
-                } else {
-                    Err(RaftError::Raft(err.clone()))
+            let response = response.into_inner();
+            if response.success {
+                if !response.raw_result.is_empty() {
+                    let mut capability = raw_result_support.lock().await;
+                    *capability = Some((leader_addr.endpoint.clone(), true, Instant::now()));
+                } else if requires_lossless_forward_result(&command) {
+                    let mut capability = raw_result_support.lock().await;
+                    *capability = None;
+                    return Err(RaftError::CommittedUnknown {
+                        applied_index: response.applied_index,
+                        details: format!(
+                            "Command {} committed on leader {}, but forwarded response was not lossless. Reconcile state from leader before retrying.",
+                            command_name(&command),
+                            leader_addr.endpoint
+                        ),
+                    });
                 }
             } else {
-                Ok(CommandResult::Success)
+                let mut capability = raw_result_support.lock().await;
+                if capability
+                    .as_ref()
+                    .map(|(endpoint, _, _)| endpoint == &leader_addr.endpoint)
+                    .unwrap_or(false)
+                {
+                    *capability = None;
+                }
             }
+
+            decode_forwarded_propose_response(&command, response)
         }
         Err(e) => {
             // Transport error — evict cached client (already taken above).
@@ -190,3 +549,133 @@ pub mod proto {
 }
 
 // Tests for PeerAddress, NodeAddress, hostname_to_node_id now live in transport.
+
+#[cfg(all(test, feature = "grpc", has_protos))]
+mod tests {
+    use super::*;
+    use crate::raft::{Command, CommandResult};
+    use proto::nexus::raft::raft_response::Result as ProtoResponseResultVariant;
+
+    #[test]
+    fn test_requires_lossless_forward_result_classification() {
+        assert!(requires_lossless_forward_result(&Command::AcquireLock {
+            path: "/locks/test".to_string(),
+            lock_id: "lock-1".to_string(),
+            max_holders: 1,
+            ttl_secs: 30,
+            holder_info: "holder-a".to_string(),
+            now_secs: 1,
+        }));
+        assert!(requires_lossless_forward_result(&Command::CasSetMetadata {
+            key: "/meta".to_string(),
+            value: vec![1],
+            expected_version: 0,
+        }));
+        assert!(requires_lossless_forward_result(&Command::AdjustCounter {
+            key: "__counter__".to_string(),
+            delta: 1,
+        }));
+        assert!(!requires_lossless_forward_result(&Command::ReleaseLock {
+            path: "/locks/test".to_string(),
+            lock_id: "lock-1".to_string(),
+        }));
+    }
+
+    #[test]
+    fn test_decode_forwarded_propose_falls_back_to_legacy_on_raw_decode_error() {
+        let command = Command::ReleaseLock {
+            path: "/locks/test".to_string(),
+            lock_id: "lock-1".to_string(),
+        };
+        let response = proto::nexus::raft::ProposeResponse {
+            success: true,
+            error: None,
+            leader_address: None,
+            result: Some(proto::nexus::raft::RaftResponse {
+                success: true,
+                error: None,
+                result: Some(ProtoResponseResultVariant::MetadataResult(
+                    proto::nexus::raft::MetadataResult { metadata: None },
+                )),
+            }),
+            applied_index: 0,
+            raw_result: vec![0x00, 0xff, 0x01], // invalid bincode payload
+        };
+
+        let decoded = decode_forwarded_propose_response(&command, response).unwrap();
+        assert!(matches!(decoded, CommandResult::Success));
+    }
+
+    #[test]
+    fn test_decode_forwarded_propose_prefers_raw_result_when_valid() {
+        let command = Command::AdjustCounter {
+            key: "__counter__".to_string(),
+            delta: 1,
+        };
+        let expected = CommandResult::Value(42_i64.to_be_bytes().to_vec());
+        let raw_result = bincode::serialize(&expected).unwrap();
+        let response = proto::nexus::raft::ProposeResponse {
+            success: true,
+            error: None,
+            leader_address: None,
+            result: None,
+            applied_index: 0,
+            raw_result,
+        };
+
+        let decoded = decode_forwarded_propose_response(&command, response).unwrap();
+        assert!(matches!(decoded, CommandResult::Value(v) if v == 42_i64.to_be_bytes().to_vec()));
+    }
+
+    #[test]
+    fn test_decode_forwarded_propose_rejects_oversized_raw_result_without_legacy() {
+        let command = Command::ReleaseLock {
+            path: "/locks/test".to_string(),
+            lock_id: "lock-1".to_string(),
+        };
+        let response = proto::nexus::raft::ProposeResponse {
+            success: true,
+            error: None,
+            leader_address: None,
+            result: None,
+            applied_index: 0,
+            raw_result: vec![0u8; (MAX_FORWARDED_RAW_RESULT_BYTES as usize) + 1],
+        };
+
+        let err = decode_forwarded_propose_response(&command, response).unwrap_err();
+        assert!(matches!(err, crate::raft::RaftError::Serialization(_)));
+    }
+
+    #[test]
+    fn test_decode_forwarded_propose_rejects_lossy_fallback_for_lock_results() {
+        let command = Command::AcquireLock {
+            path: "/locks/test".to_string(),
+            lock_id: "lock-1".to_string(),
+            max_holders: 2,
+            ttl_secs: 30,
+            holder_info: "holder-a".to_string(),
+            now_secs: 1,
+        };
+        let response = proto::nexus::raft::ProposeResponse {
+            success: true,
+            error: None,
+            leader_address: None,
+            result: Some(proto::nexus::raft::RaftResponse {
+                success: true,
+                error: None,
+                result: Some(ProtoResponseResultVariant::LockResult(
+                    proto::nexus::raft::LockResult {
+                        acquired: true,
+                        current_holder: Some("holder-a".to_string()),
+                        expires_at_ms: 1_000,
+                    },
+                )),
+            }),
+            applied_index: 0,
+            raw_result: vec![0u8; (MAX_FORWARDED_RAW_RESULT_BYTES as usize) + 1],
+        };
+
+        let err = decode_forwarded_propose_response(&command, response).unwrap_err();
+        assert!(matches!(err, crate::raft::RaftError::Raft(_)));
+    }
+}

--- a/rust/raft/src/transport/server.rs
+++ b/rust/raft/src/transport/server.rs
@@ -31,9 +31,17 @@ use protobuf::Message as ProtobufV2Message;
 use std::collections::HashMap;
 use std::net::SocketAddr;
 use std::path::PathBuf;
-use std::sync::{Arc, RwLock};
+use std::sync::{Arc, Mutex, RwLock};
 use tokio::task::JoinHandle;
 use tonic::{Request, Response, Status};
+
+/// Versioned contract for forwarded raw-result encoding.
+const FORWARDED_RESULT_PROTOCOL_VERSION: &str = "nexus-raft-forward-v1";
+
+/// Default safety cap for witness dynamic auto-join zone creation.
+const DEFAULT_WITNESS_MAX_AUTO_JOIN_ZONES: usize = 128;
+/// Marker file created for zones admitted via dynamic witness auto-join.
+const WITNESS_AUTO_JOIN_MARKER_FILE: &str = ".witness_auto_join";
 
 /// Configuration for Raft transport server.
 #[derive(Debug, Clone)]
@@ -346,8 +354,6 @@ async fn parse_and_step_message<S: crate::raft::StateMachine + Send + Sync + 'st
     }))
 }
 
-/// Check that a sender node is a known member of a zone.
-///
 /// Extract hostnames from a node_address for cert SAN inclusion.
 ///
 /// Parses addresses like "http://nexus-1:2126" or "0.0.0.0:2126" and returns
@@ -371,10 +377,10 @@ fn extract_hostnames(node_address: &str) -> Vec<String> {
     vec![host.to_string()]
 }
 
-/// Soft check: if the peer list is unavailable (e.g. during bootstrap), the
-/// request is allowed.  This prevents rogue nodes from injecting Raft messages
-/// for zones they don't belong to (CockroachDB/etcd pattern: zone auth at app
-/// layer, node identity at TLS layer).
+/// Check that a sender node is a known member of a zone.
+///
+/// This check is fail-closed: if peer membership is unavailable or empty,
+/// remote senders are rejected.
 #[allow(clippy::result_large_err)]
 fn check_zone_membership(
     registry: &ZoneRaftRegistry,
@@ -382,14 +388,43 @@ fn check_zone_membership(
     sender_node_id: u64,
 ) -> std::result::Result<(), Status> {
     if let Some(peers) = registry.get_peers(zone_id) {
-        if !peers.is_empty() && !peers.contains_key(&sender_node_id) {
+        if !peers.is_empty() {
+            if peers.contains_key(&sender_node_id) {
+                return Ok(());
+            }
+
+            if sender_in_persisted_conf_state(registry, zone_id, sender_node_id) {
+                tracing::warn!(
+                    zone = zone_id,
+                    sender = sender_node_id,
+                    "Accepted sender from persisted ConfState despite runtime peer map mismatch"
+                );
+                return Ok(());
+            }
+
             return Err(Status::permission_denied(format!(
                 "node {} is not a member of zone '{}'",
                 sender_node_id, zone_id,
             )));
         }
     }
-    Ok(())
+
+    if sender_in_persisted_conf_state(registry, zone_id, sender_node_id) {
+        return Ok(());
+    }
+
+    Err(Status::permission_denied(format!(
+        "zone '{}' membership unavailable; rejecting sender {}",
+        zone_id, sender_node_id
+    )))
+}
+
+fn sender_in_persisted_conf_state(
+    registry: &ZoneRaftRegistry,
+    zone_id: &str,
+    sender_node_id: u64,
+) -> bool {
+    registry.is_persisted_member_fresh(zone_id, sender_node_id)
 }
 
 // =============================================================================
@@ -566,6 +601,7 @@ impl ZoneApiService for ZoneApiServiceImpl {
                         leader_address: None,
                         result: None,
                         applied_index: 0,
+                        raw_result: Vec::new(),
                     }));
                 }
             }
@@ -579,6 +615,7 @@ impl ZoneApiService for ZoneApiServiceImpl {
                         leader_address: None,
                         result: None,
                         applied_index: 0,
+                        raw_result: Vec::new(),
                     }));
                 }
             };
@@ -592,6 +629,7 @@ impl ZoneApiService for ZoneApiServiceImpl {
                         leader_address: None,
                         result: None,
                         applied_index: 0,
+                        raw_result: Vec::new(),
                     }));
                 }
             }
@@ -619,12 +657,16 @@ impl ZoneApiService for ZoneApiServiceImpl {
         match result {
             Ok(result) => {
                 let proto_result = command_result_to_proto(&result);
+                let raw_result = bincode::serialize(&result).map_err(|e| {
+                    Status::internal(format!("Failed to serialize command result: {}", e))
+                })?;
                 Ok(Response::new(ProposeResponse {
                     success: true,
                     error: None,
                     leader_address: None,
                     result: Some(proto_result),
                     applied_index: 0,
+                    raw_result,
                 }))
             }
             Err(RaftError::NotLeader { leader_hint }) => {
@@ -637,6 +679,7 @@ impl ZoneApiService for ZoneApiServiceImpl {
                     leader_address: addr,
                     result: None,
                     applied_index: 0,
+                    raw_result: Vec::new(),
                 }))
             }
             Err(e) => Ok(Response::new(ProposeResponse {
@@ -645,6 +688,7 @@ impl ZoneApiService for ZoneApiServiceImpl {
                 leader_address: None,
                 result: None,
                 applied_index: 0,
+                raw_result: Vec::new(),
             })),
         }
     }
@@ -848,6 +892,8 @@ impl ZoneApiService for ZoneApiServiceImpl {
             }),
             is_leader,
             leader_address: leader_addr,
+            supports_raw_result: true,
+            protocol_version: FORWARDED_RESULT_PROTOCOL_VERSION.to_string(),
         }))
     }
 
@@ -1089,6 +1135,7 @@ impl ZoneApiService for ZoneApiServiceImpl {
 /// A single witness zone entry.
 struct WitnessZoneEntry {
     node: ZoneConsensus<WitnessStateMachine>,
+    peers: super::SharedPeerMap,
     shutdown_tx: tokio::sync::watch::Sender<bool>,
     _transport_handle: JoinHandle<()>,
 }
@@ -1100,11 +1147,16 @@ struct WitnessZoneEntry {
 /// state machine entries or serves reads.
 pub struct WitnessZoneRegistry {
     zones: DashMap<String, WitnessZoneEntry>,
+    auto_joined_zones: DashMap<String, ()>,
     base_path: PathBuf,
     node_id: u64,
     tls: Arc<RwLock<Option<super::TlsConfig>>>,
     /// Cluster peer addresses — used by auto_join_zone() for transport routing.
     peers: Vec<NodeAddress>,
+    /// Safety cap to prevent unbounded dynamic zone creation.
+    max_auto_join_zones: usize,
+    /// Serializes auto-join admission so zone cap checks are race-free.
+    auto_join_lock: Mutex<()>,
 }
 
 impl WitnessZoneRegistry {
@@ -1112,16 +1164,57 @@ impl WitnessZoneRegistry {
     pub fn new(base_path: PathBuf, node_id: u64, tls: Option<super::TlsConfig>) -> Self {
         Self {
             zones: DashMap::new(),
+            auto_joined_zones: DashMap::new(),
             base_path,
             node_id,
             tls: Arc::new(RwLock::new(tls)),
             peers: Vec::new(),
+            max_auto_join_zones: DEFAULT_WITNESS_MAX_AUTO_JOIN_ZONES,
+            auto_join_lock: Mutex::new(()),
         }
     }
 
     /// Set the cluster peer addresses (called after parsing NEXUS_PEERS).
     pub fn set_peers(&mut self, peers: Vec<NodeAddress>) {
         self.peers = peers;
+    }
+
+    /// Set safety cap for dynamic auto-join zone creation.
+    pub fn set_max_auto_join_zones(&mut self, max_auto_join_zones: usize) {
+        self.max_auto_join_zones = max_auto_join_zones.max(1);
+    }
+
+    fn count_persisted_auto_joined_zones(&self) -> usize {
+        std::fs::read_dir(&self.base_path)
+            .ok()
+            .into_iter()
+            .flat_map(|entries| entries.flatten())
+            .filter_map(|entry| {
+                let file_type = entry.file_type().ok()?;
+                if !file_type.is_dir() {
+                    return None;
+                }
+                Some(entry.path().join(WITNESS_AUTO_JOIN_MARKER_FILE).exists())
+            })
+            .filter(|is_auto_joined| *is_auto_joined)
+            .count()
+    }
+
+    /// Whether witness transport has TLS authentication enabled.
+    pub fn is_tls_enabled(&self) -> bool {
+        self.tls.read().unwrap().is_some()
+    }
+
+    /// Check whether a Raft sender ID is a configured cluster peer.
+    pub fn is_known_peer(&self, peer_id: u64) -> bool {
+        if self.peers.iter().any(|peer| peer.id == peer_id) {
+            return true;
+        }
+
+        self.zones.iter().any(|entry| {
+            let peers = entry.peers.read().unwrap();
+            peers.contains_key(&peer_id)
+        })
     }
 
     /// Create a witness Raft group for a zone (static bootstrap).
@@ -1166,8 +1259,42 @@ impl WitnessZoneRegistry {
     ) -> Result<ZoneConsensus<WitnessStateMachine>> {
         use crate::raft::RaftConfig;
 
+        let _guard = self.auto_join_lock.lock().unwrap();
+
         if let Some(existing) = self.zones.get(zone_id) {
             return Ok(existing.node.clone());
+        }
+
+        let zone_path = self.base_path.join(zone_id);
+        let has_persisted_state = zone_path.join("raft").exists();
+        let marker_path = zone_path.join(WITNESS_AUTO_JOIN_MARKER_FILE);
+        let is_known_dynamic_zone =
+            marker_path.exists() || self.auto_joined_zones.contains_key(zone_id);
+        if !has_persisted_state
+            && !is_known_dynamic_zone
+            && self.count_persisted_auto_joined_zones() >= self.max_auto_join_zones
+        {
+            return Err(TransportError::Connection(format!(
+                "Auto-join zone limit reached (limit={})",
+                self.max_auto_join_zones
+            )));
+        }
+
+        let mut created_marker = false;
+        if !marker_path.exists() {
+            std::fs::create_dir_all(&zone_path).map_err(|e| {
+                TransportError::Connection(format!(
+                    "Failed to create witness auto-join marker directory: {}",
+                    e
+                ))
+            })?;
+            std::fs::write(&marker_path, b"auto-joined").map_err(|e| {
+                TransportError::Connection(format!(
+                    "Failed to persist witness auto-join marker: {}",
+                    e
+                ))
+            })?;
+            created_marker = true;
         }
 
         // skip_bootstrap=true: empty ConfState, leader sends snapshot
@@ -1181,7 +1308,19 @@ impl WitnessZoneRegistry {
         };
 
         let peers: Vec<NodeAddress> = self.peers.clone();
-        self.setup_witness_zone(zone_id, config, peers, runtime_handle)
+        let handle = match self.setup_witness_zone(zone_id, config, peers, runtime_handle) {
+            Ok(handle) => handle,
+            Err(err) => {
+                if created_marker {
+                    let _ = std::fs::remove_file(&marker_path);
+                }
+                return Err(err);
+            }
+        };
+        if marker_path.exists() {
+            self.auto_joined_zones.insert(zone_id.to_string(), ());
+        }
+        Ok(handle)
     }
 
     /// Internal: open storage, create ZoneConsensus + driver, spawn transport loop, register zone.
@@ -1226,7 +1365,7 @@ impl WitnessZoneRegistry {
         };
         let transport_loop = TransportLoop::new(
             driver,
-            shared_peers,
+            shared_peers.clone(),
             RaftClientPool::with_config(client_config),
         )
         .with_zone_id(zone_id.to_string());
@@ -1244,6 +1383,7 @@ impl WitnessZoneRegistry {
             zone_id.to_string(),
             WitnessZoneEntry {
                 node: handle.clone(),
+                peers: shared_peers.clone(),
                 shutdown_tx,
                 _transport_handle: transport_handle,
             },
@@ -1268,6 +1408,7 @@ impl WitnessZoneRegistry {
             let _ = entry.shutdown_tx.send(true);
         }
         self.zones.clear();
+        self.auto_joined_zones.clear();
         tracing::info!("All witness zones shut down");
     }
 }
@@ -1353,11 +1494,27 @@ impl ZoneTransportService for WitnessServiceImpl {
         request: Request<StepMessageRequest>,
     ) -> std::result::Result<Response<StepMessageResponse>, Status> {
         let req = request.into_inner();
+        let parsed = raft::eraftpb::Message::parse_from_bytes(&req.message).map_err(|e| {
+            Status::invalid_argument(format!("Failed to deserialize witness raft message: {}", e))
+        })?;
+
+        if !self.registry.is_known_peer(parsed.from) {
+            return Err(Status::permission_denied(format!(
+                "Rejecting witness message for zone '{}' from unknown peer {}",
+                req.zone_id, parsed.from
+            )));
+        }
 
         // Route by zone_id — auto-join if zone not found (dynamic federation)
         let node = match self.registry.get_node(&req.zone_id) {
             Some(n) => n,
             None => {
+                if !self.registry.is_tls_enabled() {
+                    return Err(Status::permission_denied(
+                        "Witness auto-join requires mTLS-authenticated transport",
+                    ));
+                }
+
                 // Auto-join: create witness zone with skip_bootstrap=true.
                 // Leader will send snapshot with correct ConfState.
                 let handle = tokio::runtime::Handle::current();
@@ -1401,6 +1558,52 @@ mod tests {
         assert_eq!(config.max_message_size, 64 * 1024 * 1024);
     }
 
+    #[test]
+    fn test_check_zone_membership_fails_closed_when_zone_membership_unavailable() {
+        use tempfile::TempDir;
+        use tonic::Code;
+
+        let tmp_dir = TempDir::new().unwrap();
+        let registry = ZoneRaftRegistry::new(tmp_dir.path().to_path_buf(), 1);
+
+        let err = check_zone_membership(&registry, "root", 2).unwrap_err();
+        assert_eq!(err.code(), Code::PermissionDenied);
+    }
+
+    #[test]
+    fn test_check_zone_membership_rejects_local_sender_without_peer_map() {
+        use tempfile::TempDir;
+        use tonic::Code;
+
+        let tmp_dir = TempDir::new().unwrap();
+        let registry = ZoneRaftRegistry::new(tmp_dir.path().to_path_buf(), 1);
+
+        let err = check_zone_membership(&registry, "root", 1).unwrap_err();
+        assert_eq!(err.code(), Code::PermissionDenied);
+    }
+
+    #[test]
+    fn test_check_zone_membership_uses_persisted_conf_state_fallback() {
+        use raft::eraftpb::ConfState;
+        use tempfile::TempDir;
+
+        let tmp_dir = TempDir::new().unwrap();
+        let registry = ZoneRaftRegistry::new(tmp_dir.path().to_path_buf(), 1);
+
+        let zone_raft_path = tmp_dir.path().join("root").join("raft");
+        std::fs::create_dir_all(&zone_raft_path).unwrap();
+        let storage = crate::raft::RaftStorage::open(&zone_raft_path).unwrap();
+        storage
+            .set_conf_state(&ConfState {
+                voters: vec![1, 2],
+                ..Default::default()
+            })
+            .unwrap();
+        drop(storage);
+
+        assert!(check_zone_membership(&registry, "root", 2).is_ok());
+    }
+
     #[tokio::test]
     async fn test_zone_registry_server() {
         use tempfile::TempDir;
@@ -1418,6 +1621,71 @@ mod tests {
             server.bind_address(),
             "127.0.0.1:0".parse::<SocketAddr>().unwrap()
         );
+    }
+
+    #[tokio::test]
+    async fn test_witness_auto_join_zone_cap_enforced_under_concurrency() {
+        use tempfile::TempDir;
+
+        let tmp_dir = TempDir::new().unwrap();
+        let mut registry = WitnessZoneRegistry::new(tmp_dir.path().to_path_buf(), 1, None);
+        registry.set_max_auto_join_zones(1);
+        let registry = Arc::new(registry);
+        let handle1 = tokio::runtime::Handle::current();
+        let handle2 = tokio::runtime::Handle::current();
+
+        let (r1, r2) = tokio::join!(
+            async { registry.auto_join_zone("zone-a", &handle1).is_ok() },
+            async { registry.auto_join_zone("zone-b", &handle2).is_ok() }
+        );
+
+        assert_eq!(u8::from(r1) + u8::from(r2), 1);
+    }
+
+    #[tokio::test]
+    async fn test_witness_auto_join_cap_excludes_preconfigured_zones() {
+        use tempfile::TempDir;
+
+        let tmp_dir = TempDir::new().unwrap();
+        let mut registry = WitnessZoneRegistry::new(tmp_dir.path().to_path_buf(), 1, None);
+        registry.set_max_auto_join_zones(1);
+        let handle = tokio::runtime::Handle::current();
+
+        // Preconfigured zones should not consume dynamic auto-join budget.
+        assert!(registry.create_zone("root", vec![], &handle).is_ok());
+        assert!(registry.create_zone("federation", vec![], &handle).is_ok());
+
+        assert!(registry.auto_join_zone("zone-a", &handle).is_ok());
+        assert!(registry.auto_join_zone("zone-b", &handle).is_err());
+    }
+
+    #[tokio::test]
+    async fn test_witness_auto_join_reopens_persisted_zone_without_marker() {
+        use tempfile::TempDir;
+
+        let tmp_dir = TempDir::new().unwrap();
+        let handle = tokio::runtime::Handle::current();
+
+        {
+            let mut registry = WitnessZoneRegistry::new(tmp_dir.path().to_path_buf(), 1, None);
+            registry.set_max_auto_join_zones(1);
+            assert!(registry.auto_join_zone("zone-a", &handle).is_ok());
+            assert!(registry.auto_join_zone("legacy-zone", &handle).is_ok());
+        }
+
+        let legacy_marker = tmp_dir
+            .path()
+            .join("legacy-zone")
+            .join(WITNESS_AUTO_JOIN_MARKER_FILE);
+        std::fs::remove_file(&legacy_marker).unwrap();
+
+        let mut registry = WitnessZoneRegistry::new(tmp_dir.path().to_path_buf(), 1, None);
+        registry.set_max_auto_join_zones(1);
+
+        // Existing persisted zones must reopen even if marker migration is pending.
+        assert!(registry.auto_join_zone("legacy-zone", &handle).is_ok());
+        // Brand-new zones still respect the dynamic cap.
+        assert!(registry.auto_join_zone("zone-b", &handle).is_err());
     }
 
     // ---------------------------------------------------------------

--- a/rust/raft/src/transport/transport_loop.rs
+++ b/rust/raft/src/transport/transport_loop.rs
@@ -30,10 +30,10 @@ use super::proto::nexus::raft::EcReplicationEntry;
 use super::{NodeAddress, SharedPeerMap};
 use crate::raft::{StateMachine, ZoneConsensusDriver};
 use protobuf::Message as ProtobufV2Message;
-use std::collections::HashMap;
-use std::sync::Arc;
+use std::collections::{HashMap, VecDeque};
+use std::sync::{Arc, RwLock};
 use std::time::{Duration, Instant};
-use tokio::sync::watch;
+use tokio::sync::{watch, Semaphore};
 use tokio::task::JoinSet;
 
 use std::time::Duration as StdDuration;
@@ -46,6 +46,24 @@ const EC_BACKOFF_CAP: Duration = Duration::from_secs(60);
 /// Timeout for individual Raft consensus message sends.
 /// Kept short because Raft heartbeats/votes must be fast.
 const RAFT_SEND_TIMEOUT: StdDuration = StdDuration::from_secs(5);
+
+/// Upper bound for concurrent in-flight Raft send tasks per peer.
+///
+/// Per-peer isolation prevents one unhealthy destination from starving all
+/// other peers in the transport loop.
+const MAX_INFLIGHT_RAFT_SENDS_PER_PEER: usize = 64;
+/// Buffered unsent Raft messages retained per peer while permits are saturated.
+const MAX_PENDING_RAFT_MESSAGES_PER_PEER: usize = 1024;
+/// Hard cap for non-evictable control traffic per peer.
+const MAX_PENDING_CRITICAL_RAFT_MESSAGES_PER_PEER: usize = 4096;
+/// Per-peer byte budget for pending Raft messages.
+const MAX_PENDING_RAFT_BYTES_PER_PEER: usize = 64 * 1024 * 1024;
+/// Global byte budget for pending Raft messages across peers.
+const MAX_PENDING_RAFT_BYTES_GLOBAL: usize = 256 * 1024 * 1024;
+/// Per-peer byte budget for pending snapshot messages.
+const MAX_PENDING_SNAPSHOT_BYTES_PER_PEER: usize = 256 * 1024 * 1024;
+/// Global byte budget for pending snapshot messages.
+const MAX_PENDING_SNAPSHOT_BYTES_GLOBAL: usize = 512 * 1024 * 1024;
 
 /// Maximum entries to send per peer per EC replication cycle.
 /// Caps memory and prevents the tonic request timeout from being exceeded
@@ -106,6 +124,14 @@ pub struct TransportLoop<S: StateMachine + 'static> {
     node_id: u64,
     /// Per-peer EC replication tracking (peer_id → state).
     ec_peer_state: HashMap<u64, PeerReplicationState>,
+    /// Per-peer limiter for detached send tasks.
+    peer_send_permits: Arc<RwLock<HashMap<u64, Arc<Semaphore>>>>,
+    /// Per-peer pending Raft messages awaiting available send permits.
+    pending_peer_messages: HashMap<u64, VecDeque<raft::eraftpb::Message>>,
+    /// Per-peer pending byte accounting.
+    pending_peer_bytes: HashMap<u64, usize>,
+    /// Global pending byte accounting.
+    pending_total_bytes: usize,
 }
 
 impl<S: StateMachine + Send + Sync + 'static> TransportLoop<S> {
@@ -128,6 +154,10 @@ impl<S: StateMachine + Send + Sync + 'static> TransportLoop<S> {
             zone_id: String::new(),
             node_id,
             ec_peer_state: HashMap::new(),
+            peer_send_permits: Arc::new(RwLock::new(HashMap::new())),
+            pending_peer_messages: HashMap::new(),
+            pending_peer_bytes: HashMap::new(),
+            pending_total_bytes: 0,
         }
     }
 
@@ -176,9 +206,7 @@ impl<S: StateMachine + Send + Sync + 'static> TransportLoop<S> {
             // 2. Advance raft state + apply entries + get outgoing messages
             match self.driver.advance().await {
                 Ok(messages) => {
-                    if !messages.is_empty() {
-                        self.send_messages_fire_and_forget(messages);
-                    }
+                    self.send_messages_with_backpressure(messages);
                 }
                 Err(e) => {
                     tracing::error!("advance() error: {}", e);
@@ -203,60 +231,303 @@ impl<S: StateMachine + Send + Sync + 'static> TransportLoop<S> {
             .collect()
     }
 
+    fn peer_send_semaphore_from_map(
+        peer_send_permits: &Arc<RwLock<HashMap<u64, Arc<Semaphore>>>>,
+        peer_id: u64,
+    ) -> Arc<Semaphore> {
+        if let Some(existing) = peer_send_permits.read().unwrap().get(&peer_id) {
+            return existing.clone();
+        }
+
+        let mut permits = peer_send_permits.write().unwrap();
+        permits
+            .entry(peer_id)
+            .or_insert_with(|| Arc::new(Semaphore::new(MAX_INFLIGHT_RAFT_SENDS_PER_PEER)))
+            .clone()
+    }
+
     /// Send Raft messages to peers concurrently using JoinSet.
     ///
     /// Each peer send gets its own task with an independent timeout.
     /// Slow peers don't block fast peers. If a send fails or times out,
     /// the error is logged and the client is evicted from the pool.
-    /// Send Raft messages to peers — fire and forget.
+    /// Send Raft messages to peers with bounded per-peer concurrency.
     ///
-    /// Each message is spawned as an independent task with its own timeout.
-    /// The transport loop does NOT await results — this ensures tick() is
-    /// never blocked by slow/unreachable peers.  Raft handles retransmission
-    /// via its own heartbeat/election timeout mechanism.
+    /// Messages for saturated peers are queued (bounded) and retried on later
+    /// ticks, so one slow peer does not block dispatch to other peers.
     ///
     /// Failed sends log a warning and evict the client from the pool
     /// (reconnected on next attempt).
-    fn send_messages_fire_and_forget(&self, messages: Vec<raft::eraftpb::Message>) {
+    fn send_messages_with_backpressure(&mut self, messages: Vec<raft::eraftpb::Message>) {
         let peers_snapshot = self.snapshot_peers();
+        let peer_send_permits = self.peer_send_permits.clone();
 
-        for msg in messages {
-            let target_id = msg.to;
-            let addr = match peers_snapshot.get(&target_id) {
-                Some(a) => a.clone(),
-                None => {
-                    tracing::warn!("No address for peer {} — dropping message", target_id);
-                    continue;
+        let removed_peers: Vec<u64> = self
+            .pending_peer_messages
+            .keys()
+            .copied()
+            .filter(|peer_id| !peers_snapshot.contains_key(peer_id))
+            .collect();
+        for peer_id in removed_peers {
+            if let Some(queue) = self.pending_peer_messages.remove(&peer_id) {
+                if !queue.is_empty() {
+                    tracing::warn!(
+                        peer = peer_id,
+                        dropped = queue.len(),
+                        "Dropping pending Raft messages for removed peer",
+                    );
                 }
+                let dropped_bytes = self.pending_peer_bytes.remove(&peer_id).unwrap_or_else(|| {
+                    queue
+                        .iter()
+                        .map(Self::raft_message_size_bytes)
+                        .sum::<usize>()
+                });
+                self.pending_total_bytes = self.pending_total_bytes.saturating_sub(dropped_bytes);
+            } else {
+                self.pending_peer_bytes.remove(&peer_id);
+            }
+        }
+        {
+            let mut permits = peer_send_permits.write().unwrap();
+            permits.retain(|peer_id, _| peers_snapshot.contains_key(peer_id));
+        }
+
+        'enqueue: for msg in messages {
+            let target_id = msg.to;
+            if !peers_snapshot.contains_key(&target_id) {
+                tracing::warn!("No address for peer {} — dropping message", target_id);
+                continue;
+            }
+
+            let msg_bytes = Self::raft_message_size_bytes(&msg);
+            let is_snapshot = Self::is_snapshot_raft_message(&msg);
+            let per_peer_budget = if is_snapshot {
+                MAX_PENDING_SNAPSHOT_BYTES_PER_PEER
+            } else {
+                MAX_PENDING_RAFT_BYTES_PER_PEER
+            };
+            let global_budget = if is_snapshot {
+                MAX_PENDING_SNAPSHOT_BYTES_GLOBAL
+            } else {
+                MAX_PENDING_RAFT_BYTES_GLOBAL
+            };
+            if msg_bytes > per_peer_budget || msg_bytes > global_budget {
+                tracing::warn!(
+                    peer = target_id,
+                    msg_type = ?msg.get_msg_type(),
+                    msg_bytes,
+                    per_peer_budget,
+                    global_budget,
+                    "Dropping oversized Raft message that exceeds configured budget",
+                );
+                continue;
+            }
+
+            let queue = self.pending_peer_messages.entry(target_id).or_default();
+            let peer_bytes = self.pending_peer_bytes.entry(target_id).or_default();
+            if is_snapshot {
+                while let Some(pos) = queue.iter().position(Self::is_snapshot_raft_message) {
+                    if let Some(evicted) = queue.remove(pos) {
+                        let evicted_bytes = Self::raft_message_size_bytes(&evicted);
+                        *peer_bytes = peer_bytes.saturating_sub(evicted_bytes);
+                        self.pending_total_bytes =
+                            self.pending_total_bytes.saturating_sub(evicted_bytes);
+                        tracing::warn!(
+                            peer = target_id,
+                            evicted_bytes,
+                            "Replacing older queued snapshot for peer",
+                        );
+                    }
+                }
+            }
+
+            if queue.len() >= MAX_PENDING_RAFT_MESSAGES_PER_PEER {
+                // Preserve safety-critical traffic by evicting only low-priority
+                // messages when possible.
+                if let Some(pos) = queue.iter().position(Self::is_evictable_raft_message) {
+                    if let Some(evicted) = queue.remove(pos) {
+                        let evicted_bytes = Self::raft_message_size_bytes(&evicted);
+                        *peer_bytes = peer_bytes.saturating_sub(evicted_bytes);
+                        self.pending_total_bytes =
+                            self.pending_total_bytes.saturating_sub(evicted_bytes);
+                    }
+                    tracing::warn!(
+                        peer = target_id,
+                        limit = MAX_PENDING_RAFT_MESSAGES_PER_PEER,
+                        "Pending queue full; evicting low-priority Raft message",
+                    );
+                } else if Self::is_evictable_raft_message(&msg) {
+                    tracing::warn!(
+                        peer = target_id,
+                        limit = MAX_PENDING_RAFT_MESSAGES_PER_PEER,
+                        "Pending queue full; dropping low-priority Raft message",
+                    );
+                    continue;
+                } else if queue.len() >= MAX_PENDING_CRITICAL_RAFT_MESSAGES_PER_PEER {
+                    tracing::warn!(
+                        peer = target_id,
+                        limit = MAX_PENDING_CRITICAL_RAFT_MESSAGES_PER_PEER,
+                        msg_type = ?msg.get_msg_type(),
+                        "Critical Raft queue hard limit reached; dropping message",
+                    );
+                    continue;
+                } else {
+                    tracing::warn!(
+                        peer = target_id,
+                        limit = MAX_PENDING_RAFT_MESSAGES_PER_PEER,
+                        msg_type = ?msg.get_msg_type(),
+                        "Pending queue full; reserving overflow capacity for control traffic",
+                    );
+                }
+            }
+
+            while *peer_bytes + msg_bytes > per_peer_budget
+                || self.pending_total_bytes + msg_bytes > global_budget
+            {
+                if let Some(pos) = queue.iter().position(Self::is_evictable_raft_message) {
+                    if let Some(evicted) = queue.remove(pos) {
+                        let evicted_bytes = Self::raft_message_size_bytes(&evicted);
+                        *peer_bytes = peer_bytes.saturating_sub(evicted_bytes);
+                        self.pending_total_bytes =
+                            self.pending_total_bytes.saturating_sub(evicted_bytes);
+                        tracing::warn!(
+                            peer = target_id,
+                            evicted_bytes,
+                            peer_bytes = *peer_bytes,
+                            total_bytes = self.pending_total_bytes,
+                            "Evicted low-priority Raft message to satisfy byte budget",
+                        );
+                    } else {
+                        break;
+                    }
+                } else if Self::is_evictable_raft_message(&msg) {
+                    tracing::warn!(
+                        peer = target_id,
+                        msg_type = ?msg.get_msg_type(),
+                        msg_bytes,
+                        peer_bytes = *peer_bytes,
+                        total_bytes = self.pending_total_bytes,
+                        "Dropping low-priority Raft message due byte budget saturation",
+                    );
+                    continue 'enqueue;
+                } else {
+                    tracing::warn!(
+                        peer = target_id,
+                        msg_type = ?msg.get_msg_type(),
+                        msg_bytes,
+                        peer_bytes = *peer_bytes,
+                        total_bytes = self.pending_total_bytes,
+                        per_peer_budget,
+                        global_budget,
+                        "Dropping control Raft message due hard byte budget saturation",
+                    );
+                    continue 'enqueue;
+                }
+            }
+
+            queue.push_back(msg);
+            *peer_bytes = peer_bytes.saturating_add(msg_bytes);
+            self.pending_total_bytes = self.pending_total_bytes.saturating_add(msg_bytes);
+        }
+
+        for (peer_id, queue) in self.pending_peer_messages.iter_mut() {
+            if queue.is_empty() {
+                continue;
+            }
+            let addr = match peers_snapshot.get(peer_id) {
+                Some(addr) => addr.clone(),
+                None => continue,
             };
 
             let client_pool = self.client_pool.clone();
             let zone_id = self.zone_id.clone();
+            let permits = Self::peer_send_semaphore_from_map(&peer_send_permits, *peer_id);
 
-            tokio::spawn(async move {
-                let result = tokio::time::timeout(
-                    RAFT_SEND_TIMEOUT,
-                    send_raft_message(&client_pool, target_id, &addr, msg, zone_id),
-                )
-                .await;
-
-                match result {
-                    Ok(Ok(())) => {}
-                    Ok(Err(e)) => {
-                        tracing::warn!(peer = target_id, "Raft message send failed: {}", e);
-                        client_pool.remove(target_id).await;
-                    }
-                    Err(_elapsed) => {
-                        tracing::warn!(
-                            peer = target_id,
-                            "Raft message send timeout after {:?}",
-                            RAFT_SEND_TIMEOUT,
-                        );
-                        client_pool.remove(target_id).await;
-                    }
+            while let Some(msg) = queue.pop_front() {
+                let msg_bytes = Self::raft_message_size_bytes(&msg);
+                if let Some(peer_bytes) = self.pending_peer_bytes.get_mut(peer_id) {
+                    *peer_bytes = peer_bytes.saturating_sub(msg_bytes);
                 }
-            });
+                self.pending_total_bytes = self.pending_total_bytes.saturating_sub(msg_bytes);
+
+                let permit = match permits.clone().try_acquire_owned() {
+                    Ok(permit) => permit,
+                    Err(_) => {
+                        queue.push_front(msg);
+                        if let Some(peer_bytes) = self.pending_peer_bytes.get_mut(peer_id) {
+                            *peer_bytes = peer_bytes.saturating_add(msg_bytes);
+                        }
+                        self.pending_total_bytes =
+                            self.pending_total_bytes.saturating_add(msg_bytes);
+                        break;
+                    }
+                };
+                let target_id = *peer_id;
+                let send_client_pool = client_pool.clone();
+                let send_addr = addr.clone();
+                let send_zone_id = zone_id.clone();
+
+                tokio::spawn(async move {
+                    let _permit = permit;
+                    let result = tokio::time::timeout(
+                        RAFT_SEND_TIMEOUT,
+                        send_raft_message(
+                            &send_client_pool,
+                            target_id,
+                            &send_addr,
+                            msg,
+                            send_zone_id,
+                        ),
+                    )
+                    .await;
+
+                    match result {
+                        Ok(Ok(())) => {}
+                        Ok(Err(e)) => {
+                            tracing::warn!(peer = target_id, "Raft message send failed: {}", e);
+                            send_client_pool.remove(target_id).await;
+                        }
+                        Err(_elapsed) => {
+                            tracing::warn!(
+                                peer = target_id,
+                                "Raft message send timeout after {:?}",
+                                RAFT_SEND_TIMEOUT,
+                            );
+                            send_client_pool.remove(target_id).await;
+                        }
+                    }
+                });
+            }
         }
+        let stale_byte_entries: Vec<u64> = self
+            .pending_peer_bytes
+            .keys()
+            .copied()
+            .filter(|peer_id| !self.pending_peer_messages.contains_key(peer_id))
+            .collect();
+        for peer_id in stale_byte_entries {
+            if let Some(bytes) = self.pending_peer_bytes.remove(&peer_id) {
+                self.pending_total_bytes = self.pending_total_bytes.saturating_sub(bytes);
+            }
+        }
+    }
+
+    fn is_evictable_raft_message(msg: &raft::eraftpb::Message) -> bool {
+        use raft::eraftpb::MessageType;
+        matches!(
+            msg.get_msg_type(),
+            MessageType::MsgHeartbeat | MessageType::MsgHeartbeatResponse
+        )
+    }
+
+    fn is_snapshot_raft_message(msg: &raft::eraftpb::Message) -> bool {
+        use raft::eraftpb::MessageType;
+        matches!(msg.get_msg_type(), MessageType::MsgSnapshot)
+    }
+
+    fn raft_message_size_bytes(msg: &raft::eraftpb::Message) -> usize {
+        std::cmp::max(msg.compute_size() as usize, 1)
     }
 
     // =========================================================================


### PR DESCRIPTION
## Summary
- harden follower-to-leader forwarding semantics with explicit raw-result capability/version negotiation and committed-unknown error signaling for ambiguous responses
- tighten witness and zone membership boundaries (token parsing/fingerprint pinning, auto-join controls, persisted-membership checks) while preserving restart and mixed-topology recovery behavior
- add bounded per-peer transport backpressure with queue/byte accounting and prioritized eviction to reduce liveness regressions under slow or degraded peers

## Test plan
- [x] `cargo fmt --manifest-path rust/raft/Cargo.toml`
- [x] `cargo check --manifest-path rust/raft/Cargo.toml --no-default-features --features grpc`
- [x] repository pre-commit hooks during commit (including `Rust Format Check (raft)` and `Rust Clippy (raft)`)

Made with [Cursor](https://cursor.com)