### PR TITLE
fix(api-client/fs): harden reconnect and cache correctness

### DIFF
--- a/packages/nexus-api-client/src/fetch-client.ts
+++ b/packages/nexus-api-client/src/fetch-client.ts
@@ -130,7 +130,7 @@ export class FetchClient {
         signal: controller.signal,
       });
     } catch (error) {
-      if (error instanceof DOMException && error.name === "AbortError") {
+      if (isAbortError(error)) {
         if (userSignal?.aborted) {
           throw new AbortError("Request aborted");
         }
@@ -263,7 +263,7 @@ export class FetchClient {
         signal: controller.signal,
       });
     } catch (error) {
-      if (error instanceof DOMException && error.name === "AbortError") {
+      if (isAbortError(error)) {
         if (userSignal?.aborted) {
           throw new AbortError("Request aborted");
         }
@@ -379,8 +379,11 @@ export class FetchClient {
       return await this.get<AspectEnvelope>(
         `/api/v2/aspects/${encodeURIComponent(urn)}/${encodeURIComponent(name)}`,
       );
-    } catch {
-      return null;
+    } catch (error) {
+      if (error instanceof NotFoundError) {
+        return null;
+      }
+      throw error;
     }
   }
 
@@ -424,6 +427,18 @@ export class FetchClient {
     const qs = params.toString();
     return this.get<ReplayResponse>(`/api/v2/ops/replay${qs ? `?${qs}` : ""}`);
   }
+}
+
+function isAbortError(error: unknown): boolean {
+  if (typeof DOMException !== "undefined" && error instanceof DOMException) {
+    return error.name === "AbortError";
+  }
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    (error as { name?: unknown }).name === "AbortError"
+  );
 }
 
 function sleep(ms: number): Promise<void> {

--- a/packages/nexus-api-client/src/sse-client.ts
+++ b/packages/nexus-api-client/src/sse-client.ts
@@ -19,6 +19,9 @@ export class RingBuffer<T> {
   private _totalPushed = 0;
 
   constructor(readonly capacity: number) {
+    if (!Number.isInteger(capacity) || capacity < 1) {
+      throw new RangeError("RingBuffer capacity must be a positive integer");
+    }
     this.buffer = new Array<T | undefined>(capacity);
   }
 
@@ -57,8 +60,13 @@ export class RingBuffer<T> {
   lastN(n: number): readonly T[] {
     if (n <= 0 || this.count === 0) return [];
     const take = Math.min(n, this.count);
-    const all = this.toArray();
-    return all.slice(all.length - take);
+    const result = new Array<T>(take);
+    const start = (this.head - take + this.capacity) % this.capacity;
+    for (let i = 0; i < take; i++) {
+      const index = (start + i) % this.capacity;
+      result[i] = this.buffer[index] as T;
+    }
+    return result;
   }
 
   clear(): void {
@@ -169,6 +177,13 @@ export class SseClient {
     while (this.abortController && !this.abortController.signal.aborted) {
       try {
         await this.streamEvents(path);
+        if (this.abortController?.signal.aborted) return;
+
+        // A clean stream close still means we should reconnect. Apply the
+        // same backoff policy to avoid hot-loop reconnect storms.
+        this.reconnectAttempt++;
+        this.reconnectHandler?.(this.reconnectAttempt);
+        await sleep(this.computeReconnectDelay());
       } catch (error) {
         if (this.abortController?.signal.aborted) return;
 
@@ -245,7 +260,8 @@ export class SseClient {
     remaining: string;
   } {
     const parsed: SseEvent[] = [];
-    const blocks = text.split("\n\n");
+    const normalizedText = text.replace(/\r\n/g, "\n");
+    const blocks = normalizedText.split("\n\n");
 
     // Last block may be incomplete — keep it as remaining
     const remaining = blocks.pop() ?? "";

--- a/packages/nexus-api-client/tests/fetch-client.test.ts
+++ b/packages/nexus-api-client/tests/fetch-client.test.ts
@@ -443,6 +443,35 @@ describe("FetchClient", () => {
     });
   });
 
+  describe("getAspect", () => {
+    it("returns null on 404 only", async () => {
+      const fetchFn = mockFetch([{ status: 404, body: { detail: "Not found" } }]);
+      client = new FetchClient({ apiKey: "k", baseUrl: "http://localhost", fetch: fetchFn, maxRetries: 0 });
+
+      await expect(client.getAspect("urn:li:dataset:test", "schema")).resolves.toBeNull();
+    });
+
+    it("rethrows non-404 errors", async () => {
+      const fetchFn = mockFetch([{ status: 401, body: { detail: "Unauthorized" } }]);
+      client = new FetchClient({ apiKey: "k", baseUrl: "http://localhost", fetch: fetchFn, maxRetries: 0 });
+
+      await expect(client.getAspect("urn:li:dataset:test", "schema")).rejects.toThrow(AuthenticationError);
+    });
+  });
+
+  describe("abort compatibility", () => {
+    it("maps non-DOM abort errors to TimeoutError", async () => {
+      const fetchFn = vi.fn(async () => {
+        const error = new Error("aborted");
+        Object.assign(error, { name: "AbortError" });
+        throw error;
+      }) as unknown as typeof globalThis.fetch;
+      client = new FetchClient({ apiKey: "k", baseUrl: "http://localhost", fetch: fetchFn, maxRetries: 0, timeout: 100 });
+
+      await expect(client.get("/test")).rejects.toThrow(TimeoutError);
+    });
+  });
+
   describe("base URL handling", () => {
     it("strips trailing slashes", async () => {
       const fetchFn = mockFetch([{ status: 200, body: {} }]);

--- a/packages/nexus-api-client/tests/sse-client.test.ts
+++ b/packages/nexus-api-client/tests/sse-client.test.ts
@@ -52,6 +52,12 @@ describe("RingBuffer", () => {
     expect(buf.toArray()).toEqual(["b"]);
   });
 
+  it("rejects invalid capacities", () => {
+    expect(() => new RingBuffer<number>(0)).toThrow(RangeError);
+    expect(() => new RingBuffer<number>(-1)).toThrow(RangeError);
+    expect(() => new RingBuffer<number>(1.5)).toThrow(RangeError);
+  });
+
   it("tracks totalPushed monotonically", () => {
     const buf = new RingBuffer<number>(2);
     expect(buf.totalPushed).toBe(0);
@@ -266,6 +272,28 @@ describe("SseClient", () => {
     expect(events[0]!.data).toBe("line1\nline2");
   });
 
+  it("parses CRLF-terminated SSE events", async () => {
+    const clientRef: { current: SseClient | null } = { current: null };
+    const fetchFn = mockSseFetch(
+      ["id: 7\r\nevent: update\r\ndata: hello\r\n\r\n"],
+      clientRef,
+    );
+
+    const client = new SseClient({
+      baseUrl: "http://localhost:2026",
+      apiKey: "test-key",
+      fetch: fetchFn,
+      flushIntervalMs: 10_000,
+    });
+    clientRef.current = client;
+
+    await client.connect("/events");
+
+    const events = client.getBufferedEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ id: "7", event: "update", data: "hello", retry: undefined });
+  });
+
   it("skips empty SSE blocks", async () => {
     const clientRef: { current: SseClient | null } = { current: null };
     const fetchFn = mockSseFetch(
@@ -390,6 +418,40 @@ describe("SseClient", () => {
 
     const connectPromise = client.connect("/events");
     // Wait enough for first failure + first reconnect attempt
+    await new Promise((r) => setTimeout(r, 700));
+    client.disconnect();
+    await connectPromise;
+
+    expect(reconnectHandler).toHaveBeenCalledWith(1);
+  });
+
+  it("fires reconnect handler when stream closes cleanly", async () => {
+    let callCount = 0;
+    const fetchFn = vi.fn(async (_url: string, init?: RequestInit) => {
+      callCount++;
+      if (init?.signal?.aborted) {
+        throw new DOMException("Aborted", "AbortError");
+      }
+      // Return an empty stream that closes immediately.
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.close();
+          },
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    const reconnectHandler = vi.fn();
+    const client = new SseClient({
+      baseUrl: "http://localhost:2026",
+      apiKey: "test-key",
+      fetch: fetchFn,
+    });
+    client.onReconnect(reconnectHandler);
+
+    const connectPromise = client.connect("/events");
     await new Promise((r) => setTimeout(r, 700));
     client.disconnect();
     await connectPromise;

--- a/src/nexus/fs/_backend_factory.py
+++ b/src/nexus/fs/_backend_factory.py
@@ -17,6 +17,21 @@ from typing import Any
 logger = logging.getLogger(__name__)
 
 
+def _local_root_from_spec(spec: Any) -> str:
+    """Reconstruct a local backend root path from a parsed MountSpec.
+
+    ``parse_uri()`` stores ``local:///tmp/data`` as authority="tmp", path="data".
+    This helper restores the missing separator and keeps absolute-path semantics.
+    """
+    path_segments = [spec.authority]
+    if spec.path:
+        path_segments.append(str(spec.path).lstrip("/"))
+    joined = "/".join(segment.rstrip("/") for segment in path_segments if segment)
+    if str(spec.uri).startswith("local:///") and not joined.startswith("/"):
+        joined = "/" + joined
+    return joined or "."
+
+
 def create_backend(spec: Any) -> Any:
     """Create a storage backend from a parsed MountSpec.
 
@@ -73,7 +88,7 @@ def create_backend(spec: Any) -> Any:
 
         from nexus.backends.storage.cas_local import CASLocalBackend
 
-        root = _Path(spec.authority + (spec.path or "")).expanduser().resolve()
+        root = _Path(_local_root_from_spec(spec)).expanduser().resolve()
         root.mkdir(parents=True, exist_ok=True)
         return CASLocalBackend(root_path=root)
 

--- a/src/nexus/fs/_fsspec.py
+++ b/src/nexus/fs/_fsspec.py
@@ -279,6 +279,8 @@ class NexusFileSystem(AbstractFileSystem):
         """Write data to a file."""
         path = self._strip_protocol(path)
         self._nexus.write(path, value)
+        # Mutations invalidate directory listings and metadata cache.
+        self.dircache.clear()
 
     # -- Delete ----------------------------------------------------------------
 
@@ -297,6 +299,8 @@ class NexusFileSystem(AbstractFileSystem):
             self._nexus.rmdir(path, recursive=recursive)
         else:
             self._nexus.delete(path)
+        # Mutations invalidate directory listings and metadata cache.
+        self.dircache.clear()
 
     # -- Copy ------------------------------------------------------------------
 
@@ -305,6 +309,8 @@ class NexusFileSystem(AbstractFileSystem):
         path1 = self._strip_protocol(path1)
         path2 = self._strip_protocol(path2)
         self._nexus.copy(path1, path2)
+        # Mutations invalidate directory listings and metadata cache.
+        self.dircache.clear()
 
     # -- Directories -----------------------------------------------------------
 

--- a/tests/unit/fs/test_fsspec.py
+++ b/tests/unit/fs/test_fsspec.py
@@ -10,7 +10,7 @@ Organized into:
 from __future__ import annotations
 
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -74,7 +74,8 @@ def nexus_fsspec(mock_nexus_fs):
     """NexusFileSystem instance with mocked backend."""
     fs = NexusFileSystem(nexus_fs=mock_nexus_fs)
     yield fs
-    fs._runner.close()
+    if hasattr(fs, "_runner"):
+        fs._runner.close()
 
 
 # ===========================================================================
@@ -244,6 +245,12 @@ class TestPipeFile:
         nexus_fsspec._pipe_file("/output.txt", b"new content")
         mock_nexus_fs.write.assert_awaited_once()
 
+    def test_pipe_file_clears_dircache(self, nexus_fsspec, mock_nexus_fs):
+        mock_nexus_fs.write = MagicMock()
+        nexus_fsspec.dircache["/dir"] = [{"name": "/dir/old.txt", "size": 1, "type": "file"}]
+        nexus_fsspec._pipe_file("/dir/new.txt", b"new content")
+        assert nexus_fsspec.dircache == {}
+
 
 # ===========================================================================
 # _rm()
@@ -268,6 +275,13 @@ class TestRm:
         nexus_fsspec._rm("/dir", recursive=False)
         mock_nexus_fs.rmdir.assert_awaited_once_with("/dir", recursive=False)
 
+    def test_rm_clears_dircache(self, nexus_fsspec, mock_nexus_fs):
+        mock_nexus_fs.stat = MagicMock(return_value={"is_directory": False})
+        mock_nexus_fs.delete = MagicMock()
+        nexus_fsspec.dircache["/dir"] = [{"name": "/dir/file.txt", "size": 1, "type": "file"}]
+        nexus_fsspec._rm("/dir/file.txt")
+        assert nexus_fsspec.dircache == {}
+
 
 # ===========================================================================
 # _cp_file()
@@ -278,6 +292,12 @@ class TestCpFile:
     def test_cp_file(self, nexus_fsspec, mock_nexus_fs):
         nexus_fsspec._cp_file("/src.txt", "/dst.txt")
         mock_nexus_fs.copy.assert_awaited_once()
+
+    def test_cp_file_clears_dircache(self, nexus_fsspec, mock_nexus_fs):
+        mock_nexus_fs.copy = MagicMock()
+        nexus_fsspec.dircache["/dir"] = [{"name": "/dir/src.txt", "size": 1, "type": "file"}]
+        nexus_fsspec._cp_file("/dir/src.txt", "/dir/dst.txt")
+        assert nexus_fsspec.dircache == {}
 
 
 class TestCpFileComprehensive:
@@ -767,7 +787,8 @@ class TestFsspecIntegration:
         facade = SlimNexusFS(kernel)
         fs = NexusFileSystem(nexus_fs=facade)
         yield fs
-        fs._runner.close()
+        if hasattr(fs, "_runner"):
+            fs._runner.close()
 
     def test_write_and_cat(self, fsspec_real):
         """Write via _pipe_file, read via _cat_file — full round-trip."""

--- a/tests/unit/fs/test_release_integrity.py
+++ b/tests/unit/fs/test_release_integrity.py
@@ -383,6 +383,17 @@ class TestBackendFactoryErrorPaths:
             with pytest.raises(ImportError, match="boto3"):
                 create_backend(spec)
 
+    def test_local_uri_preserves_path_separators(self, tmp_path: Path) -> None:
+        """local:// URIs should map to the exact requested local root path."""
+        from nexus.fs._backend_factory import create_backend
+        from nexus.fs._uri import parse_uri
+
+        target = tmp_path / "nested" / "data"
+        spec = parse_uri(f"local://{target}")
+        backend = create_backend(spec)
+
+        assert getattr(backend, "root_path", None) == target.resolve()
+
 
 class TestUriEdgeCases:
     """Additional URI edge cases for derive_bucket()."""


### PR DESCRIPTION
## Summary
- tighten `@nexus-ai-fs/api-client` correctness by only treating 404 as `getAspect()` null, while rethrowing other failures and handling non-DOM `AbortError` shapes consistently
- improve SSE client behavior with CRLF-tolerant parsing, validated ring buffer capacity, optimized `lastN()` retrieval, and backoff/reconnect callbacks even on clean stream closes
- fix `nexus-fs` local mount root reconstruction for `local://` URIs and invalidate `fsspec` `dircache` after write/remove/copy mutations to prevent stale listings
- add regression coverage for all of the above, including targeted `test_fsspec` cache invalidation cases and local backend path reconstruction

## Test plan
- [x] `cd packages/nexus-api-client && npx tsc --noEmit && npm test`
- [x] `python -m ruff check src/nexus/fs/_backend_factory.py src/nexus/fs/_fsspec.py tests/unit/fs/test_release_integrity.py tests/unit/fs/test_fsspec.py`
- [x] `PYTHONPATH=src python -m pytest -n 0 tests/unit/fs/test_release_integrity.py::TestBackendFactoryErrorPaths tests/unit/fs/test_uri.py tests/unit/fs/test_fsspec.py::TestPipeFile::test_pipe_file_clears_dircache tests/unit/fs/test_fsspec.py::TestRm::test_rm_clears_dircache tests/unit/fs/test_fsspec.py::TestCpFile::test_cp_file_clears_dircache -vv`

Made with [Cursor](https://cursor.com)