### PR TITLE
fix(pay,tui): harden validation and worker crash recovery

### DIFF
--- a/packages/nexus-api-client/package-lock.json
+++ b/packages/nexus-api-client/package-lock.json
@@ -1,12 +1,12 @@
 {
-  "name": "@nexus/api-client",
-  "version": "0.1.0",
+  "name": "@nexus-ai-fs/api-client",
+  "version": "0.9.31",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@nexus/api-client",
-      "version": "0.1.0",
+      "name": "@nexus-ai-fs/api-client",
+      "version": "0.9.31",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.4.0",

--- a/packages/nexus-pay-ts/package-lock.json
+++ b/packages/nexus-pay-ts/package-lock.json
@@ -1,15 +1,15 @@
 {
-  "name": "@nexus/pay",
+  "name": "@nexus-ai-fs/pay",
   "version": "0.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@nexus/pay",
+      "name": "@nexus-ai-fs/pay",
       "version": "0.1.0",
       "license": "MIT",
       "dependencies": {
-        "@nexus/api-client": "file:../nexus-api-client"
+        "@nexus-ai-fs/api-client": "file:../nexus-api-client"
       },
       "devDependencies": {
         "@vitest/coverage-v8": "^2.0.0",
@@ -22,7 +22,8 @@
       }
     },
     "../nexus-api-client": {
-      "version": "0.1.0",
+      "name": "@nexus-ai-fs/api-client",
+      "version": "0.9.31",
       "license": "MIT",
       "devDependencies": {
         "@types/node": "^25.4.0",
@@ -577,7 +578,7 @@
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
     },
-    "node_modules/@nexus/api-client": {
+    "node_modules/@nexus-ai-fs/api-client": {
       "resolved": "../nexus-api-client",
       "link": true
     },

--- a/packages/nexus-pay-ts/src/client.ts
+++ b/packages/nexus-pay-ts/src/client.ts
@@ -112,6 +112,11 @@ export class NexusPay {
       );
     }
 
+    for (const transfer of transfers) {
+      validateRecipient(transfer.to);
+      validateAmount(transfer.amount);
+    }
+
     const body = {
       transfers: transfers.map((t) => ({
         to: t.to,
@@ -151,6 +156,8 @@ export class NexusPay {
     params?: CommitParams,
     options?: RequestOptions,
   ): Promise<void> {
+    validateReservationId(reservationId);
+
     const body = {
       actual_amount: params?.actualAmount,
     };
@@ -163,6 +170,8 @@ export class NexusPay {
   }
 
   async release(reservationId: string, options?: RequestOptions): Promise<void> {
+    validateReservationId(reservationId);
+
     await this.client.postNoContent(
       `/api/v2/pay/reserve/${encodeURIComponent(reservationId)}/release`,
       undefined,
@@ -232,6 +241,12 @@ function validateAmountNonEmpty(amount: string): void {
 function validateRecipient(to: string): void {
   if (!to) {
     throw new NexusPayError("Recipient 'to' must not be empty", 0, "validation_error");
+  }
+}
+
+function validateReservationId(reservationId: string): void {
+  if (!reservationId) {
+    throw new NexusPayError("Reservation ID must not be empty", 0, "validation_error");
   }
 }
 

--- a/packages/nexus-pay-ts/src/fetch-client.ts
+++ b/packages/nexus-pay-ts/src/fetch-client.ts
@@ -42,9 +42,12 @@ export class FetchClient extends BaseFetchClient {
    * 409 → ReservationError (overrides generic ConflictError)
    */
   protected override async buildError(response: Response): Promise<NexusApiError> {
+    // Read from a clone so super.buildError() can still parse the original body
+    // for non-pay statuses (401, 429, 5xx, etc.).
+    const responseForPayMapping = response.clone();
     let message: string;
     try {
-      const body = (await response.json()) as { detail?: string };
+      const body = (await responseForPayMapping.json()) as { detail?: string };
       message = body.detail ?? `HTTP ${response.status}`;
     } catch {
       message = `HTTP ${response.status}`;

--- a/packages/nexus-pay-ts/tests/client.test.ts
+++ b/packages/nexus-pay-ts/tests/client.test.ts
@@ -307,6 +307,24 @@ describe("NexusPay methods", () => {
       }));
       await expect(pay.transferBatch(bigBatch)).rejects.toThrow(NexusPayError);
     });
+
+    it("validates every transfer recipient", async () => {
+      await expect(
+        pay.transferBatch([
+          { to: "alice", amount: "1.00" },
+          { to: "", amount: "2.00" },
+        ]),
+      ).rejects.toThrow(NexusPayError);
+    });
+
+    it("validates every transfer amount", async () => {
+      await expect(
+        pay.transferBatch([
+          { to: "alice", amount: "1.00" },
+          { to: "bob", amount: "0" },
+        ]),
+      ).rejects.toThrow(NexusPayError);
+    });
   });
 
   // =========================================================================
@@ -390,6 +408,11 @@ describe("NexusPay methods", () => {
       );
       await expect(pay.commit("res_001")).rejects.toThrow(ReservationError);
     });
+
+    it("validates reservationId is not empty", async () => {
+      await expect(pay.commit("")).rejects.toThrow(NexusPayError);
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
   });
 
   // =========================================================================
@@ -411,6 +434,11 @@ describe("NexusPay methods", () => {
         jsonResponse({ detail: "Already released" }, 409),
       );
       await expect(pay.release("res_001")).rejects.toThrow(ReservationError);
+    });
+
+    it("validates reservationId is not empty", async () => {
+      await expect(pay.release("")).rejects.toThrow(NexusPayError);
+      expect(mockFetch).not.toHaveBeenCalled();
     });
   });
 

--- a/packages/nexus-pay-ts/tests/fetch-client.test.ts
+++ b/packages/nexus-pay-ts/tests/fetch-client.test.ts
@@ -141,6 +141,19 @@ describe("FetchClient", () => {
       await expect(client.get("/test")).rejects.toThrow(AuthenticationError);
     });
 
+    it("401 preserves detail message from JSON response", async () => {
+      mockFetch.mockResolvedValueOnce(
+        jsonResponse({ detail: "Token expired for this session" }, 401),
+      );
+      try {
+        await client.get("/test");
+        expect.fail("should have thrown");
+      } catch (e) {
+        expect(e).toBeInstanceOf(AuthenticationError);
+        expect((e as AuthenticationError).message).toBe("Token expired for this session");
+      }
+    });
+
     it("402 → InsufficientCreditsError", async () => {
       mockFetch.mockResolvedValueOnce(
         jsonResponse({ detail: "Not enough", error_code: "insufficient_credits" }, 402),

--- a/packages/nexus-tui/src/worker/worker-manager.ts
+++ b/packages/nexus-tui/src/worker/worker-manager.ts
@@ -20,6 +20,8 @@ import type { ToWorkerMessage } from "./protocol.js";
 const MAX_RESTARTS = 5;
 /** Backoff delays indexed by restart attempt (capped at last value). */
 const RESTART_BACKOFF_MS = [0, 500, 1_000, 2_000, 5_000] as const;
+/** Healthy-window duration before restart counter resets. */
+const RESTART_RESET_WINDOW_MS = 30_000;
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
@@ -46,6 +48,29 @@ export function createWorkerManager(initialConfig: NexusClientOptions): WorkerMa
   let currentWorker: Worker | null = null;
   let restartCount = 0;
   let terminated = false;
+  let restartScheduled = false;
+  let restartTimer: ReturnType<typeof setTimeout> | null = null;
+  let restartResetTimer: ReturnType<typeof setTimeout> | null = null;
+
+  function clearRestartResetTimer(): void {
+    if (restartResetTimer !== null) {
+      clearTimeout(restartResetTimer);
+      restartResetTimer = null;
+    }
+  }
+
+  function scheduleRestartReset(readyPromise: Promise<void>): void {
+    void readyPromise.then(() => {
+      if (terminated) return;
+      clearRestartResetTimer();
+      restartResetTimer = setTimeout(() => {
+        restartCount = 0;
+        restartResetTimer = null;
+      }, RESTART_RESET_WINDOW_MS);
+    }).catch(() => {
+      // Worker failed before ready; no reset scheduling needed.
+    });
+  }
 
   // ─── Spawn helpers ──────────────────────────────────────────────────────────
 
@@ -72,13 +97,13 @@ export function createWorkerManager(initialConfig: NexusClientOptions): WorkerMa
     worker.onerror = (event) => {
       if (terminated) return;
       console.error("[nexus-tui worker] Uncaught error:", event.message ?? event);
-      handleCrash();
+      handleCrash(worker);
     };
 
     // Bun workers emit 'close' event (not 'exit') on termination
     worker.addEventListener("close", () => {
       if (terminated) return;
-      handleCrash();
+      handleCrash(worker);
     });
 
     worker.postMessage({ type: "init", config: currentConfig } satisfies ToWorkerMessage);
@@ -88,8 +113,11 @@ export function createWorkerManager(initialConfig: NexusClientOptions): WorkerMa
 
   // ─── Crash recovery ─────────────────────────────────────────────────────────
 
-  function handleCrash(): void {
+  function handleCrash(sourceWorker: Worker): void {
     if (terminated) return;
+    if (sourceWorker !== currentWorker) return;
+    if (restartScheduled) return;
+    clearRestartResetTimer();
 
     // Reject all pending requests on the crashed client
     client._rejectAll(new Error("Worker crashed — request failed"));
@@ -110,17 +138,23 @@ export function createWorkerManager(initialConfig: NexusClientOptions): WorkerMa
       (delay > 0 ? ` after ${delay}ms` : ""),
     );
 
-    // Use queueMicrotask so restarts fire within the current microtask queue
-    // drain — this makes the restart immediately observable to callers without
-    // needing a real timer tick. The `delay` is retained above for logging;
-    // a proper time-based exponential-backoff strategy can be wired in later
-    // without changing the observable restart semantics used by tests.
-    queueMicrotask(() => {
+    restartScheduled = true;
+
+    const restart = () => {
+      restartScheduled = false;
+      restartTimer = null;
       if (terminated) return;
       const { worker: newWorker, readyPromise: newReady } = spawn();
       currentWorker = newWorker;
       client._rewire(newWorker, newReady);
-    });
+      scheduleRestartReset(newReady);
+    };
+
+    if (delay <= 0) {
+      queueMicrotask(restart);
+    } else {
+      restartTimer = setTimeout(restart, delay);
+    }
   }
 
   // ─── Bootstrap ──────────────────────────────────────────────────────────────
@@ -128,11 +162,7 @@ export function createWorkerManager(initialConfig: NexusClientOptions): WorkerMa
   const { worker: initialWorker, readyPromise: initialReady } = spawn();
   currentWorker = initialWorker;
   const client = new WorkerFetchClient(initialWorker, initialReady);
-
-  // Reset the restart counter after the worker stays healthy for 30s
-  void initialReady.then(() => {
-    restartCount = 0;
-  });
+  scheduleRestartReset(initialReady);
 
   // ─── Public API ─────────────────────────────────────────────────────────────
 
@@ -146,6 +176,12 @@ export function createWorkerManager(initialConfig: NexusClientOptions): WorkerMa
 
     terminate(): void {
       terminated = true;
+      if (restartTimer !== null) {
+        clearTimeout(restartTimer);
+        restartTimer = null;
+      }
+      clearRestartResetTimer();
+      restartScheduled = false;
       currentWorker?.terminate();
       currentWorker = null;
     },

--- a/packages/nexus-tui/tests/stores/worker-manager.test.ts
+++ b/packages/nexus-tui/tests/stores/worker-manager.test.ts
@@ -14,7 +14,7 @@
  * @see §2 Worker thread isolation — Issue #3632
  */
 
-import { describe, it, expect, beforeEach, afterEach, mock } from "bun:test";
+import { describe, it, expect, beforeEach, afterEach, vi } from "bun:test";
 import type { ToWorkerMessage, FromWorkerMessage } from "../../src/worker/protocol.js";
 
 // ─── MockWorker ───────────────────────────────────────────────────────────────
@@ -207,6 +207,25 @@ describe("WorkerManager", () => {
     manager.terminate();
   });
 
+  it("does not restart twice for duplicate crash signals from one worker", async () => {
+    const manager = createWorkerManager(baseConfig);
+    await tickN(3);
+
+    // Same crash can emit both onerror and close in real runtimes.
+    workers[0].simulateCrash();
+    workers[0].simulateClose();
+    await tickN(5);
+
+    expect(workers).toHaveLength(2);
+
+    // A late close event from the retired worker should be ignored.
+    workers[0].simulateClose();
+    await tickN(5);
+    expect(workers).toHaveLength(2);
+
+    manager.terminate();
+  });
+
   it("replacement worker receives correct config via init", async () => {
     const manager = createWorkerManager(baseConfig);
     await tickN(3);
@@ -227,22 +246,66 @@ describe("WorkerManager", () => {
   // ─── Restart limit ───────────────────────────────────────────────────────
 
   it("stops restarting after MAX_RESTARTS crashes", async () => {
-    const manager = createWorkerManager(baseConfig);
-    await tickN(3);
+    vi.useFakeTimers();
+    try {
+      const manager = createWorkerManager(baseConfig);
+      await tickN(3);
 
-    const MAX_RESTARTS = 5;
-    for (let i = 0; i < MAX_RESTARTS; i++) {
+      const MAX_RESTARTS = 5;
+      for (let i = 0; i < MAX_RESTARTS; i++) {
+        workers[workers.length - 1].simulateCrash();
+        vi.advanceTimersByTime(5_000);
+        await tickN(5);
+      }
+
+      const countBefore = workers.length;
+      // One more crash — should NOT spawn another worker
+      workers[workers.length - 1].simulateCrash();
+      vi.advanceTimersByTime(5_000);
+      await tickN(5);
+      expect(workers.length).toBe(countBefore);
+
+      manager.terminate();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("resets restart counter after worker is healthy for 30s", async () => {
+    vi.useFakeTimers();
+    try {
+      const manager = createWorkerManager(baseConfig);
+      await tickN(3);
+
+      // Burn one restart so the counter is non-zero.
       workers[workers.length - 1].simulateCrash();
       await tickN(5);
+      expect(workers).toHaveLength(2);
+
+      // Keep the replacement worker healthy long enough to reset restartCount.
+      vi.advanceTimersByTime(30_000);
+      await tickN(3);
+
+      // After reset, we should still be allowed 5 more restart attempts.
+      const baseCount = workers.length;
+      for (let i = 0; i < 5; i++) {
+        workers[workers.length - 1].simulateCrash();
+        vi.advanceTimersByTime(5_000);
+        await tickN(5);
+      }
+      expect(workers.length).toBe(baseCount + 5);
+
+      // The next crash should hit MAX_RESTARTS and stop spawning.
+      const countBeforeFinalCrash = workers.length;
+      workers[workers.length - 1].simulateCrash();
+      vi.advanceTimersByTime(5_000);
+      await tickN(5);
+      expect(workers.length).toBe(countBeforeFinalCrash);
+
+      manager.terminate();
+    } finally {
+      vi.useRealTimers();
     }
-
-    const countBefore = workers.length;
-    // One more crash — should NOT spawn another worker
-    workers[workers.length - 1].simulateCrash();
-    await tickN(5);
-    expect(workers.length).toBe(countBefore);
-
-    manager.terminate();
   });
 
   // ─── terminate ───────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary
- preserve server-side `detail` messages for non-pay error statuses in `@nexus-ai-fs/pay` by cloning the response before fallthrough error mapping
- enforce missing pay SDK input validation (`transferBatch` item validation and non-empty reservation IDs), with regression tests
- make TUI worker crash handling more robust by preventing duplicate/stale restarts, applying real backoff delays, and resetting restart budget after a healthy window

## Test plan
- [x] `cd packages/nexus-pay-ts && npm test`
- [x] `cd packages/nexus-pay-ts && npm run lint`
- [x] `cd packages/nexus-tui && bun test tests/stores/worker-manager.test.ts`
- [x] `cd packages/nexus-tui && bun test`

Made with [Cursor](https://cursor.com)