### PR TITLE
fix(api-client/fs): harden reconnect and cache correctness

### DIFF
--- a/packages/nexus-api-client/src/fetch-client.ts
+++ b/packages/nexus-api-client/src/fetch-client.ts
@@ -130,7 +130,7 @@ export class FetchClient {
         signal: controller.signal,
       });
     } catch (error) {
-      if (error instanceof DOMException && error.name === "AbortError") {
+      if (isAbortError(error)) {
         if (userSignal?.aborted) {
           throw new AbortError("Request aborted");
         }
@@ -263,7 +263,7 @@ export class FetchClient {
         signal: controller.signal,
       });
     } catch (error) {
-      if (error instanceof DOMException && error.name === "AbortError") {
+      if (isAbortError(error)) {
         if (userSignal?.aborted) {
           throw new AbortError("Request aborted");
         }
@@ -379,8 +379,11 @@ export class FetchClient {
       return await this.get<AspectEnvelope>(
         `/api/v2/aspects/${encodeURIComponent(urn)}/${encodeURIComponent(name)}`,
       );
-    } catch {
-      return null;
+    } catch (error) {
+      if (error instanceof NotFoundError) {
+        return null;
+      }
+      throw error;
     }
   }
 
@@ -424,6 +427,18 @@ export class FetchClient {
     const qs = params.toString();
     return this.get<ReplayResponse>(`/api/v2/ops/replay${qs ? `?${qs}` : ""}`);
   }
+}
+
+function isAbortError(error: unknown): boolean {
+  if (typeof DOMException !== "undefined" && error instanceof DOMException) {
+    return error.name === "AbortError";
+  }
+  return (
+    typeof error === "object" &&
+    error !== null &&
+    "name" in error &&
+    (error as { name?: unknown }).name === "AbortError"
+  );
 }
 
 function sleep(ms: number): Promise<void> {

--- a/packages/nexus-api-client/src/sse-client.ts
+++ b/packages/nexus-api-client/src/sse-client.ts
@@ -19,6 +19,9 @@ export class RingBuffer<T> {
   private _totalPushed = 0;
 
   constructor(readonly capacity: number) {
+    if (!Number.isInteger(capacity) || capacity < 1) {
+      throw new RangeError("RingBuffer capacity must be a positive integer");
+    }
     this.buffer = new Array<T | undefined>(capacity);
   }
 
@@ -57,8 +60,13 @@ export class RingBuffer<T> {
   lastN(n: number): readonly T[] {
     if (n <= 0 || this.count === 0) return [];
     const take = Math.min(n, this.count);
-    const all = this.toArray();
-    return all.slice(all.length - take);
+    const result = new Array<T>(take);
+    const start = (this.head - take + this.capacity) % this.capacity;
+    for (let i = 0; i < take; i++) {
+      const index = (start + i) % this.capacity;
+      result[i] = this.buffer[index] as T;
+    }
+    return result;
   }
 
   clear(): void {
@@ -169,6 +177,13 @@ export class SseClient {
     while (this.abortController && !this.abortController.signal.aborted) {
       try {
         await this.streamEvents(path);
+        if (this.abortController?.signal.aborted) return;
+
+        // A clean stream close still means we should reconnect. Apply the
+        // same backoff policy to avoid hot-loop reconnect storms.
+        this.reconnectAttempt++;
+        this.reconnectHandler?.(this.reconnectAttempt);
+        await sleep(this.computeReconnectDelay());
       } catch (error) {
         if (this.abortController?.signal.aborted) return;
 
@@ -245,7 +260,8 @@ export class SseClient {
     remaining: string;
   } {
     const parsed: SseEvent[] = [];
-    const blocks = text.split("\n\n");
+    const normalizedText = text.replace(/\r\n/g, "\n");
+    const blocks = normalizedText.split("\n\n");
 
     // Last block may be incomplete — keep it as remaining
     const remaining = blocks.pop() ?? "";

--- a/packages/nexus-api-client/src/sse-client.ts
+++ b/packages/nexus-api-client/src/sse-client.ts
@@ -110,6 +110,7 @@ export class SseClient {
   private reconnectAttempt = 0;
   private lastEventId: string | undefined;
   private connected = false;
+  private connectSessionId = 0;
 
   private eventHandler: SseEventHandler | null = null;
   private errorHandler: SseErrorHandler | null = null;
@@ -145,13 +146,16 @@ export class SseClient {
   async connect(path: string): Promise<void> {
     this.disconnect();
 
-    this.abortController = new AbortController();
+    const controller = new AbortController();
+    this.abortController = controller;
+    const sessionId = ++this.connectSessionId;
     this.startFlushTimer();
 
-    await this.connectWithRetry(path);
+    await this.connectWithRetry(path, controller, sessionId);
   }
 
   disconnect(): void {
+    this.connectSessionId++;
     this.abortController?.abort();
     this.abortController = null;
     this.stopFlushTimer();
@@ -173,32 +177,41 @@ export class SseClient {
   // Internal
   // ===========================================================================
 
-  private async connectWithRetry(path: string): Promise<void> {
-    while (this.abortController && !this.abortController.signal.aborted) {
+  private async connectWithRetry(
+    path: string,
+    controller: AbortController,
+    sessionId: number,
+  ): Promise<void> {
+    while (!controller.signal.aborted && this.connectSessionId === sessionId) {
       try {
-        await this.streamEvents(path);
-        if (this.abortController?.signal.aborted) return;
+        await this.streamEvents(path, controller, sessionId);
+        if (controller.signal.aborted || this.connectSessionId !== sessionId) return;
 
         // A clean stream close still means we should reconnect. Apply the
         // same backoff policy to avoid hot-loop reconnect storms.
         this.reconnectAttempt++;
         this.reconnectHandler?.(this.reconnectAttempt);
-        await sleep(this.computeReconnectDelay());
+        const slept = await sleepWithAbort(this.computeReconnectDelay(), controller.signal);
+        if (!slept || this.connectSessionId !== sessionId) return;
       } catch (error) {
-        if (this.abortController?.signal.aborted) return;
+        if (controller.signal.aborted || this.connectSessionId !== sessionId) return;
 
         this.connected = false;
         this.reconnectAttempt++;
         this.errorHandler?.(error instanceof Error ? error : new Error(String(error)));
         this.reconnectHandler?.(this.reconnectAttempt);
 
-        const delay = this.computeReconnectDelay();
-        await sleep(delay);
+        const slept = await sleepWithAbort(this.computeReconnectDelay(), controller.signal);
+        if (!slept || this.connectSessionId !== sessionId) return;
       }
     }
   }
 
-  private async streamEvents(path: string): Promise<void> {
+  private async streamEvents(
+    path: string,
+    controller: AbortController,
+    sessionId: number,
+  ): Promise<void> {
     const url = `${this.baseUrl}${path}`;
     const headers: Record<string, string> = {
       Authorization: `Bearer ${this.apiKey}`,
@@ -215,7 +228,7 @@ export class SseClient {
 
     const response = await this.fetchFn(url, {
       headers,
-      signal: this.abortController?.signal,
+      signal: controller.signal,
     });
 
     if (!response.ok) {
@@ -235,7 +248,12 @@ export class SseClient {
 
     try {
       while (true) {
+        if (controller.signal.aborted || this.connectSessionId !== sessionId) return;
         const { done, value } = await reader.read();
+        if (controller.signal.aborted || this.connectSessionId !== sessionId) {
+          void reader.cancel().catch(() => {});
+          return;
+        }
         if (done) break;
 
         partial += decoder.decode(value, { stream: true });
@@ -251,7 +269,9 @@ export class SseClient {
       }
     } finally {
       reader.releaseLock();
-      this.connected = false;
+      if (this.connectSessionId === sessionId) {
+        this.connected = false;
+      }
     }
   }
 
@@ -327,6 +347,24 @@ export class SseClient {
   }
 }
 
-function sleep(ms: number): Promise<void> {
-  return new Promise((resolve) => setTimeout(resolve, ms));
+function sleepWithAbort(ms: number, signal: AbortSignal): Promise<boolean> {
+  return new Promise((resolve) => {
+    if (signal.aborted) {
+      resolve(false);
+      return;
+    }
+
+    const timeoutId = setTimeout(() => {
+      signal.removeEventListener("abort", onAbort);
+      resolve(true);
+    }, ms);
+
+    const onAbort = (): void => {
+      clearTimeout(timeoutId);
+      signal.removeEventListener("abort", onAbort);
+      resolve(false);
+    };
+
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
 }

--- a/packages/nexus-api-client/tests/fetch-client.test.ts
+++ b/packages/nexus-api-client/tests/fetch-client.test.ts
@@ -443,6 +443,35 @@ describe("FetchClient", () => {
     });
   });
 
+  describe("getAspect", () => {
+    it("returns null on 404 only", async () => {
+      const fetchFn = mockFetch([{ status: 404, body: { detail: "Not found" } }]);
+      client = new FetchClient({ apiKey: "k", baseUrl: "http://localhost", fetch: fetchFn, maxRetries: 0 });
+
+      await expect(client.getAspect("urn:li:dataset:test", "schema")).resolves.toBeNull();
+    });
+
+    it("rethrows non-404 errors", async () => {
+      const fetchFn = mockFetch([{ status: 401, body: { detail: "Unauthorized" } }]);
+      client = new FetchClient({ apiKey: "k", baseUrl: "http://localhost", fetch: fetchFn, maxRetries: 0 });
+
+      await expect(client.getAspect("urn:li:dataset:test", "schema")).rejects.toThrow(AuthenticationError);
+    });
+  });
+
+  describe("abort compatibility", () => {
+    it("maps non-DOM abort errors to TimeoutError", async () => {
+      const fetchFn = vi.fn(async () => {
+        const error = new Error("aborted");
+        Object.assign(error, { name: "AbortError" });
+        throw error;
+      }) as unknown as typeof globalThis.fetch;
+      client = new FetchClient({ apiKey: "k", baseUrl: "http://localhost", fetch: fetchFn, maxRetries: 0, timeout: 100 });
+
+      await expect(client.get("/test")).rejects.toThrow(TimeoutError);
+    });
+  });
+
   describe("base URL handling", () => {
     it("strips trailing slashes", async () => {
       const fetchFn = mockFetch([{ status: 200, body: {} }]);

--- a/packages/nexus-api-client/tests/sse-client.test.ts
+++ b/packages/nexus-api-client/tests/sse-client.test.ts
@@ -52,6 +52,12 @@ describe("RingBuffer", () => {
     expect(buf.toArray()).toEqual(["b"]);
   });
 
+  it("rejects invalid capacities", () => {
+    expect(() => new RingBuffer<number>(0)).toThrow(RangeError);
+    expect(() => new RingBuffer<number>(-1)).toThrow(RangeError);
+    expect(() => new RingBuffer<number>(1.5)).toThrow(RangeError);
+  });
+
   it("tracks totalPushed monotonically", () => {
     const buf = new RingBuffer<number>(2);
     expect(buf.totalPushed).toBe(0);
@@ -266,6 +272,28 @@ describe("SseClient", () => {
     expect(events[0]!.data).toBe("line1\nline2");
   });
 
+  it("parses CRLF-terminated SSE events", async () => {
+    const clientRef: { current: SseClient | null } = { current: null };
+    const fetchFn = mockSseFetch(
+      ["id: 7\r\nevent: update\r\ndata: hello\r\n\r\n"],
+      clientRef,
+    );
+
+    const client = new SseClient({
+      baseUrl: "http://localhost:2026",
+      apiKey: "test-key",
+      fetch: fetchFn,
+      flushIntervalMs: 10_000,
+    });
+    clientRef.current = client;
+
+    await client.connect("/events");
+
+    const events = client.getBufferedEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({ id: "7", event: "update", data: "hello", retry: undefined });
+  });
+
   it("skips empty SSE blocks", async () => {
     const clientRef: { current: SseClient | null } = { current: null };
     const fetchFn = mockSseFetch(
@@ -390,6 +418,40 @@ describe("SseClient", () => {
 
     const connectPromise = client.connect("/events");
     // Wait enough for first failure + first reconnect attempt
+    await new Promise((r) => setTimeout(r, 700));
+    client.disconnect();
+    await connectPromise;
+
+    expect(reconnectHandler).toHaveBeenCalledWith(1);
+  });
+
+  it("fires reconnect handler when stream closes cleanly", async () => {
+    let callCount = 0;
+    const fetchFn = vi.fn(async (_url: string, init?: RequestInit) => {
+      callCount++;
+      if (init?.signal?.aborted) {
+        throw new DOMException("Aborted", "AbortError");
+      }
+      // Return an empty stream that closes immediately.
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.close();
+          },
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    const reconnectHandler = vi.fn();
+    const client = new SseClient({
+      baseUrl: "http://localhost:2026",
+      apiKey: "test-key",
+      fetch: fetchFn,
+    });
+    client.onReconnect(reconnectHandler);
+
+    const connectPromise = client.connect("/events");
     await new Promise((r) => setTimeout(r, 700));
     client.disconnect();
     await connectPromise;

--- a/packages/nexus-api-client/tests/sse-client.test.ts
+++ b/packages/nexus-api-client/tests/sse-client.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 import { RingBuffer, SseClient } from "../src/sse-client.js";
+import type { SseEvent } from "../src/types.js";
 
 describe("RingBuffer", () => {
   it("stores items up to capacity", () => {
@@ -457,6 +458,93 @@ describe("SseClient", () => {
     await connectPromise;
 
     expect(reconnectHandler).toHaveBeenCalledWith(1);
+  });
+
+  it("does not let an old connect loop restart after a new connect call", async () => {
+    const fetchFn = vi.fn(async (url: string, init?: RequestInit) => {
+      if (init?.signal?.aborted) {
+        throw new DOMException("Aborted", "AbortError");
+      }
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.close();
+          },
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    const client = new SseClient({
+      baseUrl: "http://localhost:2026",
+      apiKey: "test-key",
+      fetch: fetchFn,
+    });
+
+    const firstConnect = client.connect("/events-a");
+    await new Promise((r) => setTimeout(r, 100));
+    const secondConnect = client.connect("/events-b");
+    await new Promise((r) => setTimeout(r, 900));
+    client.disconnect();
+
+    await Promise.all([firstConnect, secondConnect]);
+
+    const eventARequests = fetchFn.mock.calls.filter(([requestUrl]) =>
+      String(requestUrl).endsWith("/events-a"),
+    ).length;
+    expect(eventARequests).toBe(1);
+  });
+
+  it("does not ingest stale events from an invalidated session", async () => {
+    const emitted: SseEvent[] = [];
+    const encoder = new TextEncoder();
+    const fetchFn = vi.fn(async (url: string, init?: RequestInit) => {
+      if (init?.signal?.aborted) {
+        throw new DOMException("Aborted", "AbortError");
+      }
+
+      if (url.endsWith("/events-a")) {
+        return new Response(
+          new ReadableStream<Uint8Array>({
+            start(controller) {
+              setTimeout(() => {
+                controller.enqueue(encoder.encode("event: msg\ndata: from-old\n\n"));
+                controller.close();
+              }, 150);
+            },
+          }),
+          { status: 200 },
+        );
+      }
+
+      return new Response(
+        new ReadableStream<Uint8Array>({
+          start(controller) {
+            controller.close();
+          },
+        }),
+        { status: 200 },
+      );
+    }) as unknown as typeof globalThis.fetch;
+
+    const client = new SseClient({
+      baseUrl: "http://localhost:2026",
+      apiKey: "test-key",
+      fetch: fetchFn,
+      flushIntervalMs: 10,
+    });
+    client.onEvent((batch) => emitted.push(...batch));
+
+    const firstConnect = client.connect("/events-a");
+    await new Promise((r) => setTimeout(r, 50));
+    const secondConnect = client.connect("/events-b");
+    await new Promise((r) => setTimeout(r, 450));
+    client.disconnect();
+
+    await Promise.all([firstConnect, secondConnect]);
+
+    expect(emitted.some((event) => event.data === "from-old")).toBe(false);
+    expect(client.getBufferedEvents().some((event) => event.data === "from-old")).toBe(false);
   });
 
   it("strips trailing slashes from baseUrl", async () => {

--- a/src/nexus/fs/_backend_factory.py
+++ b/src/nexus/fs/_backend_factory.py
@@ -10,11 +10,38 @@ import importlib
 import inspect
 import logging
 import os
+import re
 import shutil
 import subprocess
 from typing import Any
 
 logger = logging.getLogger(__name__)
+
+_WINDOWS_DRIVE_PATH = re.compile(r"^[A-Za-z]:(?:/.*)?$")
+
+
+def _local_root_from_spec(spec: Any) -> str:
+    """Reconstruct a local backend root path from a parsed MountSpec.
+
+    ``parse_uri()`` stores ``local:///tmp/data`` as authority="tmp", path="data".
+    This helper restores the missing separator and keeps absolute-path semantics.
+    """
+    path_segments = [spec.authority]
+    if spec.path:
+        path_segments.append(str(spec.path).lstrip("/"))
+    joined = "/".join(segment.rstrip("/") for segment in path_segments if segment)
+    uri_lower = str(spec.uri).lower()
+    if (
+        uri_lower.startswith("local:///") or uri_lower.startswith("cas-local:///")
+    ) and not joined.startswith("/"):
+        if _WINDOWS_DRIVE_PATH.match(joined):
+            if joined.endswith(":"):
+                joined = f"{joined}/"
+            if os.name != "nt":
+                joined = f"/{joined}"
+        else:
+            joined = "/" + joined
+    return joined or "."
 
 
 def create_backend(spec: Any) -> Any:
@@ -79,19 +106,11 @@ def create_backend(spec: Any) -> Any:
         # URI reconstruction: ``parse_uri`` splits ``local:///abs/path``
         # into ``authority="abs"`` + ``path="path"`` because urllib's
         # netloc empty-case handler takes the first path segment as a
-        # stand-in authority.  Concatenating those back drops the
-        # leading ``/``, giving a cwd-relative path (e.g.
-        # ``$(pwd)/abspath``) instead of the intended absolute one.
-        # Rebuild from the original URI — everything after the scheme
-        # prefix is the filesystem path as the user typed it.
+        # stand-in authority.  ``_local_root_from_spec`` restores the
+        # intended absolute/path semantics (including drive-root forms).
         from pathlib import Path as _Path
 
-        prefix = f"{spec.scheme}://"
-        raw_path = spec.uri[len(prefix) :] if spec.uri.startswith(prefix) else ""
-        if not raw_path:
-            # Fallback for callers that constructed a MountSpec directly.
-            raw_path = spec.authority + (spec.path or "")
-        root = _Path(raw_path).expanduser().resolve()
+        root = _Path(_local_root_from_spec(spec)).expanduser().resolve()
         root.mkdir(parents=True, exist_ok=True)
         if spec.scheme == "cas-local":
             from nexus.backends.storage.cas_local import CASLocalBackend

--- a/src/nexus/fs/_fsspec.py
+++ b/src/nexus/fs/_fsspec.py
@@ -278,9 +278,11 @@ class NexusFileSystem(AbstractFileSystem):
     ) -> None:
         """Write data to a file."""
         path = self._strip_protocol(path)
-        self._nexus.write(path, value)
-        # Mutations invalidate directory listings and metadata cache.
-        self.dircache.clear()
+        try:
+            self._nexus.write(path, value)
+        finally:
+            # Mutations invalidate directory listings and metadata cache.
+            self.dircache.clear()
 
     # -- Delete ----------------------------------------------------------------
 
@@ -293,14 +295,16 @@ class NexusFileSystem(AbstractFileSystem):
                 recursively.
         """
         path = self._strip_protocol(path)
-        # Check if it's a directory — if so, use rmdir
-        stat = self._nexus.stat(path)
-        if stat and stat.get("is_directory"):
-            self._nexus.rmdir(path, recursive=recursive)
-        else:
-            self._nexus.delete(path)
-        # Mutations invalidate directory listings and metadata cache.
-        self.dircache.clear()
+        try:
+            # Check if it's a directory — if so, use rmdir
+            stat = self._nexus.stat(path)
+            if stat and stat.get("is_directory"):
+                self._nexus.rmdir(path, recursive=recursive)
+            else:
+                self._nexus.delete(path)
+        finally:
+            # Mutations invalidate directory listings and metadata cache.
+            self.dircache.clear()
 
     # -- Copy ------------------------------------------------------------------
 
@@ -308,9 +312,11 @@ class NexusFileSystem(AbstractFileSystem):
         """Copy a single file."""
         path1 = self._strip_protocol(path1)
         path2 = self._strip_protocol(path2)
-        self._nexus.copy(path1, path2)
-        # Mutations invalidate directory listings and metadata cache.
-        self.dircache.clear()
+        try:
+            self._nexus.copy(path1, path2)
+        finally:
+            # Mutations invalidate directory listings and metadata cache.
+            self.dircache.clear()
 
     # -- Directories -----------------------------------------------------------
 
@@ -529,7 +535,13 @@ class NexusWriteFile:
         if not self._closed:
             self._closed = True
             self._buffer.seek(0)
-            self._nexus.write(self.path, self._buffer.read())
+            try:
+                self._nexus.write(self.path, self._buffer.read())
+            finally:
+                # Keep listings consistent after buffered writes, including
+                # the case where backend write outcome is uncertain.
+                if self.fs is not None and hasattr(self.fs, "dircache"):
+                    self.fs.dircache.clear()
 
     @property
     def closed(self) -> bool:

--- a/src/nexus/fs/_fsspec.py
+++ b/src/nexus/fs/_fsspec.py
@@ -279,6 +279,8 @@ class NexusFileSystem(AbstractFileSystem):
         """Write data to a file."""
         path = self._strip_protocol(path)
         self._nexus.write(path, value)
+        # Mutations invalidate directory listings and metadata cache.
+        self.dircache.clear()
 
     # -- Delete ----------------------------------------------------------------
 
@@ -297,6 +299,8 @@ class NexusFileSystem(AbstractFileSystem):
             self._nexus.rmdir(path, recursive=recursive)
         else:
             self._nexus.delete(path)
+        # Mutations invalidate directory listings and metadata cache.
+        self.dircache.clear()
 
     # -- Copy ------------------------------------------------------------------
 
@@ -305,6 +309,8 @@ class NexusFileSystem(AbstractFileSystem):
         path1 = self._strip_protocol(path1)
         path2 = self._strip_protocol(path2)
         self._nexus.copy(path1, path2)
+        # Mutations invalidate directory listings and metadata cache.
+        self.dircache.clear()
 
     # -- Directories -----------------------------------------------------------
 

--- a/tests/unit/fs/test_fsspec.py
+++ b/tests/unit/fs/test_fsspec.py
@@ -10,7 +10,7 @@ Organized into:
 from __future__ import annotations
 
 import json
-from unittest.mock import AsyncMock, patch
+from unittest.mock import AsyncMock, MagicMock, patch
 
 import pytest
 
@@ -75,7 +75,8 @@ def nexus_fsspec(mock_nexus_fs):
     """NexusFileSystem instance with mocked backend."""
     fs = NexusFileSystem(nexus_fs=mock_nexus_fs)
     yield fs
-    fs._runner.close()
+    if hasattr(fs, "_runner"):
+        fs._runner.close()
 
 
 # ===========================================================================
@@ -245,6 +246,19 @@ class TestPipeFile:
         nexus_fsspec._pipe_file("/output.txt", b"new content")
         mock_nexus_fs.write.assert_awaited_once()
 
+    def test_pipe_file_clears_dircache(self, nexus_fsspec, mock_nexus_fs):
+        mock_nexus_fs.write = MagicMock()
+        nexus_fsspec.dircache["/dir"] = [{"name": "/dir/old.txt", "size": 1, "type": "file"}]
+        nexus_fsspec._pipe_file("/dir/new.txt", b"new content")
+        assert nexus_fsspec.dircache == {}
+
+    def test_pipe_file_clears_dircache_on_error(self, nexus_fsspec, mock_nexus_fs):
+        mock_nexus_fs.write = MagicMock(side_effect=RuntimeError("write failed"))
+        nexus_fsspec.dircache["/dir"] = [{"name": "/dir/old.txt", "size": 1, "type": "file"}]
+        with pytest.raises(RuntimeError, match="write failed"):
+            nexus_fsspec._pipe_file("/dir/new.txt", b"new content")
+        assert nexus_fsspec.dircache == {}
+
 
 # ===========================================================================
 # _rm()
@@ -269,6 +283,21 @@ class TestRm:
         nexus_fsspec._rm("/dir", recursive=False)
         mock_nexus_fs.rmdir.assert_awaited_once_with("/dir", recursive=False)
 
+    def test_rm_clears_dircache(self, nexus_fsspec, mock_nexus_fs):
+        mock_nexus_fs.stat = MagicMock(return_value={"is_directory": False})
+        mock_nexus_fs.delete = MagicMock()
+        nexus_fsspec.dircache["/dir"] = [{"name": "/dir/file.txt", "size": 1, "type": "file"}]
+        nexus_fsspec._rm("/dir/file.txt")
+        assert nexus_fsspec.dircache == {}
+
+    def test_rm_clears_dircache_on_error(self, nexus_fsspec, mock_nexus_fs):
+        mock_nexus_fs.stat = MagicMock(return_value={"is_directory": False})
+        mock_nexus_fs.delete = MagicMock(side_effect=RuntimeError("delete failed"))
+        nexus_fsspec.dircache["/dir"] = [{"name": "/dir/file.txt", "size": 1, "type": "file"}]
+        with pytest.raises(RuntimeError, match="delete failed"):
+            nexus_fsspec._rm("/dir/file.txt")
+        assert nexus_fsspec.dircache == {}
+
 
 # ===========================================================================
 # _cp_file()
@@ -279,6 +308,19 @@ class TestCpFile:
     def test_cp_file(self, nexus_fsspec, mock_nexus_fs):
         nexus_fsspec._cp_file("/src.txt", "/dst.txt")
         mock_nexus_fs.copy.assert_awaited_once()
+
+    def test_cp_file_clears_dircache(self, nexus_fsspec, mock_nexus_fs):
+        mock_nexus_fs.copy = MagicMock()
+        nexus_fsspec.dircache["/dir"] = [{"name": "/dir/src.txt", "size": 1, "type": "file"}]
+        nexus_fsspec._cp_file("/dir/src.txt", "/dir/dst.txt")
+        assert nexus_fsspec.dircache == {}
+
+    def test_cp_file_clears_dircache_on_error(self, nexus_fsspec, mock_nexus_fs):
+        mock_nexus_fs.copy = MagicMock(side_effect=RuntimeError("copy failed"))
+        nexus_fsspec.dircache["/dir"] = [{"name": "/dir/src.txt", "size": 1, "type": "file"}]
+        with pytest.raises(RuntimeError, match="copy failed"):
+            nexus_fsspec._cp_file("/dir/src.txt", "/dir/dst.txt")
+        assert nexus_fsspec.dircache == {}
 
 
 class TestCpFileComprehensive:
@@ -470,6 +512,13 @@ class TestOpenWrite:
         mock_nexus_fs.write.assert_awaited_once()
         args = mock_nexus_fs.write.await_args
         assert args[0][1] == b"hello world"
+
+    def test_open_write_clears_dircache(self, nexus_fsspec, mock_nexus_fs):
+        mock_nexus_fs.write = MagicMock()
+        nexus_fsspec.dircache["/output"] = [{"name": "/output/old.txt", "size": 1, "type": "file"}]
+        with nexus_fsspec._open("/output/new.txt", mode="wb") as f:
+            f.write(b"fresh")
+        assert nexus_fsspec.dircache == {}
 
     def test_open_write_context_manager(self, nexus_fsspec, mock_nexus_fs):
         with nexus_fsspec._open("/output.txt", mode="wb") as f:
@@ -762,7 +811,8 @@ class TestFsspecIntegration:
         facade = SlimNexusFS(kernel)
         fs = NexusFileSystem(nexus_fs=facade)
         yield fs
-        fs._runner.close()
+        if hasattr(fs, "_runner"):
+            fs._runner.close()
 
     def test_write_and_cat(self, fsspec_real):
         """Write via _pipe_file, read via _cat_file — full round-trip."""

--- a/tests/unit/fs/test_release_integrity.py
+++ b/tests/unit/fs/test_release_integrity.py
@@ -380,6 +380,17 @@ class TestBackendFactoryErrorPaths:
             with pytest.raises(ImportError, match="boto3"):
                 create_backend(spec)
 
+    def test_local_uri_preserves_path_separators(self, tmp_path: Path) -> None:
+        """local:// URIs should map to the exact requested local root path."""
+        from nexus.fs._backend_factory import create_backend
+        from nexus.fs._uri import parse_uri
+
+        target = tmp_path / "nested" / "data"
+        spec = parse_uri(f"local://{target}")
+        backend = create_backend(spec)
+
+        assert getattr(backend, "root_path", None) == target.resolve()
+
 
 class TestLocalSchemePassthrough:
     """Guardrails for the ``local://`` passthrough-by-default behaviour.

--- a/tests/unit/fs/test_release_integrity.py
+++ b/tests/unit/fs/test_release_integrity.py
@@ -10,6 +10,7 @@ Covers:
 from __future__ import annotations
 
 import inspect
+import os
 import sqlite3
 import threading
 from datetime import UTC, datetime
@@ -390,6 +391,32 @@ class TestBackendFactoryErrorPaths:
         backend = create_backend(spec)
 
         assert getattr(backend, "root_path", None) == target.resolve()
+
+    def test_local_windows_drive_uri_preserves_drive_prefix(self) -> None:
+        """local:///C:/... should keep drive-root semantics (no extra leading slash)."""
+        from nexus.fs._backend_factory import _local_root_from_spec
+        from nexus.fs._uri import parse_uri
+
+        spec = parse_uri("local:///C:/Users/alice/data")
+        expected = "C:/Users/alice/data" if os.name == "nt" else "/C:/Users/alice/data"
+        assert _local_root_from_spec(spec) == expected
+
+    def test_local_windows_root_drive_uri_is_absolute(self) -> None:
+        """local:///C:/ should stay drive-rooted on Windows and absolute on POSIX."""
+        from nexus.fs._backend_factory import _local_root_from_spec
+        from nexus.fs._uri import parse_uri
+
+        spec = parse_uri("local:///C:/")
+        expected = "C:/" if os.name == "nt" else "/C:/"
+        assert _local_root_from_spec(spec) == expected
+
+    def test_local_uppercase_scheme_uri_is_still_absolute(self) -> None:
+        """LOCAL:///tmp/data should preserve absolute semantics like local:///tmp/data."""
+        from nexus.fs._backend_factory import _local_root_from_spec
+        from nexus.fs._uri import parse_uri
+
+        spec = parse_uri("LOCAL:///tmp/data")
+        assert _local_root_from_spec(spec) == "/tmp/data"
 
 
 class TestLocalSchemePassthrough:


### PR DESCRIPTION
## Summary
- harden `@nexus-ai-fs/api-client` by tightening `getAspect()` error semantics, improving abort detection portability, and fixing SSE session/reconnect race behavior (including stale-session guards)
- improve SSE robustness/perf with CRLF-tolerant parsing, ring buffer validation/`lastN()` optimization, and reconnect backoff behavior on clean stream closes
- fix `nexus-fs` local path reconstruction edge cases (mixed-case `local:///` and drive-root forms), and make fsspec mutation cache invalidation failure-safe with targeted regression coverage
- supersedes #3832, which targeted `release/v0.9.32`

## Test plan
- [x] `cd packages/nexus-api-client && npx tsc --noEmit && npm test`
- [x] `python -m ruff check src/nexus/fs/_backend_factory.py src/nexus/fs/_fsspec.py tests/unit/fs/test_release_integrity.py tests/unit/fs/test_fsspec.py`
- [x] `PYTHONPATH=src python -m pytest -n 0 tests/unit/fs/test_release_integrity.py::TestBackendFactoryErrorPaths tests/unit/fs/test_uri.py tests/unit/fs/test_fsspec.py::TestOpenWrite::test_open_write_clears_dircache tests/unit/fs/test_fsspec.py::TestPipeFile::test_pipe_file_clears_dircache_on_error tests/unit/fs/test_fsspec.py::TestRm::test_rm_clears_dircache_on_error tests/unit/fs/test_fsspec.py::TestCpFile::test_cp_file_clears_dircache_on_error -vv`

Made with [Cursor](https://cursor.com)