### PR TITLE
refactor(#1824): move user_scoped/has_token_manager to OAuthCapableProtocol

### DIFF
--- a/src/nexus/backends/base/backend.py
+++ b/src/nexus/backends/base/backend.py
@@ -127,24 +127,6 @@ class Backend(ObjectStoreABC):
     # must implement it.  No redeclaration needed here.
     # ------------------------------------------------------------------
 
-    # === Backend-level capability flags (not on ObjectStoreABC) ===
-
-    @property
-    def user_scoped(self) -> bool:
-        """Whether this backend requires per-user credentials (OAuth-based).
-
-        TODO(#1824): Move to Connector Protocol after external connector redesign.
-        """
-        return False
-
-    @property
-    def has_token_manager(self) -> bool:
-        """Whether this backend manages OAuth tokens.
-
-        TODO(#1824): Move to Connector Protocol after external connector redesign.
-        """
-        return False
-
     # === Service-level properties (not on ObjectStoreABC) ===
 
     @property
@@ -266,7 +248,7 @@ class Backend(ObjectStoreABC):
         return HandlerStatusResponse(
             success=success,
             latency_ms=latency_ms,
-            details={"backend": self.name, "user_scoped": self.user_scoped},
+            details={"backend": self.name, "user_scoped": getattr(self, "user_scoped", False)},
         )
 
     # === Content Operations (CAS) ===

--- a/src/nexus/backends/base/registry.py
+++ b/src/nexus/backends/base/registry.py
@@ -94,10 +94,8 @@ _CONNECTOR_PROTOCOL_MEMBERS: frozenset[str] = frozenset(
         # ConnectorProtocol (connection lifecycle — connect/disconnect deleted #1811)
         "check_connection",
         # ConnectorProtocol (capability flags)
-        "user_scoped",
         "is_connected",
         "has_root_path",
-        "has_token_manager",
         # CapabilityAwareProtocol (Issue #2069)
         "backend_features",
         "has_feature",

--- a/src/nexus/backends/connectors/hn/connector.py
+++ b/src/nexus/backends/connectors/hn/connector.py
@@ -67,8 +67,6 @@ class PathHNBackend(
     # Skill documentation settings
     SKILL_NAME = "hn"
 
-    user_scoped = False  # Public API, no per-user auth
-
     CONNECTION_ARGS: dict[str, ConnectionArg] = {
         "cache_ttl": ConnectionArg(
             type=ArgType.INTEGER,

--- a/src/nexus/backends/storage/delegating.py
+++ b/src/nexus/backends/storage/delegating.py
@@ -76,7 +76,7 @@ class DelegatingBackend(Backend):
 
     @property
     def user_scoped(self) -> bool:
-        return self._inner.user_scoped
+        return getattr(self._inner, "user_scoped", False)
 
     @property
     def is_connected(self) -> bool:
@@ -92,7 +92,7 @@ class DelegatingBackend(Backend):
 
     @property
     def has_token_manager(self) -> bool:
-        return self._inner.has_token_manager
+        return getattr(self._inner, "has_token_manager", False)
 
     @property
     def has_data_dir(self) -> bool:

--- a/src/nexus/backends/storage/remote.py
+++ b/src/nexus/backends/storage/remote.py
@@ -66,16 +66,6 @@ class RemoteBackend(ObjectStoreABC):
         """Remote server always has a configured root path."""
         return True
 
-    @property
-    def user_scoped(self) -> bool:
-        """REMOTE profile is not a per-user OAuth connector backend."""
-        return False
-
-    @property
-    def has_token_manager(self) -> bool:
-        """REMOTE profile delegates auth to the server transport."""
-        return False
-
     # === RPC Transport ===
 
     def _call_rpc(

--- a/src/nexus/bricks/sandbox/isolation/backend.py
+++ b/src/nexus/bricks/sandbox/isolation/backend.py
@@ -59,7 +59,10 @@ class IsolatedBackend(Backend):
 
     @property
     def user_scoped(self) -> bool:
-        return bool(self._cached_prop("user_scoped"))
+        try:
+            return bool(self._cached_prop("user_scoped"))
+        except IsolationError:
+            return False
 
     @property
     def is_connected(self) -> bool:
@@ -75,7 +78,10 @@ class IsolatedBackend(Backend):
 
     @property
     def has_token_manager(self) -> bool:
-        return bool(self._cached_prop("has_token_manager"))
+        try:
+            return bool(self._cached_prop("has_token_manager"))
+        except IsolationError:
+            return False
 
     @property
     def has_data_dir(self) -> bool:

--- a/src/nexus/core/protocols/connector.py
+++ b/src/nexus/core/protocols/connector.py
@@ -164,16 +164,10 @@ class ConnectorProtocol(
     # --- Capability flags ---
 
     @property
-    def user_scoped(self) -> bool: ...
-
-    @property
     def is_connected(self) -> bool: ...
 
     @property
     def has_root_path(self) -> bool: ...
-
-    @property
-    def has_token_manager(self) -> bool: ...
 
 @runtime_checkable
 class OAuthCapableProtocol(Protocol):
@@ -182,12 +176,22 @@ class OAuthCapableProtocol(Protocol):
     Implemented by connectors that use OAuth credentials (Gmail, GDrive,
     Slack, X, Google Calendar). Used to detect OAuth backends dynamically
     instead of hardcoding backend type lists.
+
+    ``user_scoped`` and ``has_token_manager`` moved here from
+    ConnectorProtocol (Issue #1824) — non-OAuth connectors no longer
+    need to declare these.
     """
 
     token_manager: Any
     token_manager_db: str
     user_email: str | None
     provider: str
+
+    @property
+    def user_scoped(self) -> bool: ...
+
+    @property
+    def has_token_manager(self) -> bool: ...
 
 @runtime_checkable
 class StreamingProtocol(Protocol):

--- a/src/nexus/server/api/core/health.py
+++ b/src/nexus/server/api/core/health.py
@@ -175,7 +175,7 @@ async def health_check_detailed(request: Request) -> dict[str, Any]:
                     "backend": backend.name,
                     "healthy": status.success,
                     "latency_ms": status.latency_ms,
-                    "user_scoped": backend.user_scoped,
+                    "user_scoped": getattr(backend, "user_scoped", False),
                     "thread_safe": backend.thread_safe,
                 }
                 if status.error_message:

--- a/tests/benchmarks/bench_isolation.py
+++ b/tests/benchmarks/bench_isolation.py
@@ -30,10 +30,6 @@ class BenchMockBackend:
         return "bench_mock"
 
     @property
-    def user_scoped(self) -> bool:
-        return False
-
-    @property
     def thread_safe(self) -> bool:
         return True
 

--- a/tests/helpers/failing_backend.py
+++ b/tests/helpers/failing_backend.py
@@ -196,7 +196,7 @@ class FailingBackend(Backend):
 
     @property
     def user_scoped(self) -> bool:
-        return self._inner.user_scoped
+        return getattr(self._inner, "user_scoped", False)
 
     @property
     def is_connected(self) -> bool:
@@ -216,7 +216,7 @@ class FailingBackend(Backend):
 
     @property
     def has_token_manager(self) -> bool:
-        return self._inner.has_token_manager
+        return getattr(self._inner, "has_token_manager", False)
 
     @property
     def has_data_dir(self) -> bool:

--- a/tests/unit/backends/test_backend_contract.py
+++ b/tests/unit/backends/test_backend_contract.py
@@ -201,10 +201,8 @@ class TestBackendContract:
     # -- Capability Flags --
 
     def test_capability_flags_are_booleans(self, backend: Backend) -> None:
-        assert isinstance(backend.user_scoped, bool)
         assert isinstance(backend.is_connected, bool)
         assert isinstance(backend.has_root_path, bool)
-        assert isinstance(backend.has_token_manager, bool)
 
     def test_name_returns_string(self, backend: Backend) -> None:
         assert isinstance(backend.name, str)

--- a/tests/unit/backends/test_capabilities.py
+++ b/tests/unit/backends/test_capabilities.py
@@ -190,19 +190,11 @@ class TestRegistryCapabilities:
                 return "fake"
 
             @property
-            def user_scoped(self) -> bool:
-                return False
-
-            @property
             def is_connected(self) -> bool:
                 return False
 
             @property
             def has_root_path(self) -> bool:
-                return False
-
-            @property
-            def has_token_manager(self) -> bool:
                 return False
 
             def connect(self) -> None:

--- a/tests/unit/backends/test_connector_protocol_compliance.py
+++ b/tests/unit/backends/test_connector_protocol_compliance.py
@@ -130,10 +130,8 @@ class TestConnectorProtocolMethods:
 
     _LIFECYCLE_METHODS = ["check_connection"]
     _CAPABILITY_PROPERTIES = [
-        "user_scoped",
         "is_connected",
         "has_root_path",
-        "has_token_manager",
     ]
 
     @pytest.mark.parametrize("method_name", _LIFECYCLE_METHODS)

--- a/tests/unit/backends/test_delegating_backend.py
+++ b/tests/unit/backends/test_delegating_backend.py
@@ -27,12 +27,10 @@ def mock_inner() -> MagicMock:
     mock.name = "test-backend"
     mock.describe.return_value = "test-backend"
     # Set all capability flags to True (opposite of Backend defaults)
-    type(mock).user_scoped = PropertyMock(return_value=True)
     type(mock).is_connected = PropertyMock(return_value=True)
     type(mock).thread_safe = PropertyMock(return_value=True)
     type(mock).supports_rename = PropertyMock(return_value=True)
     type(mock).has_root_path = PropertyMock(return_value=True)
-    type(mock).has_token_manager = PropertyMock(return_value=True)
     type(mock).has_data_dir = PropertyMock(return_value=True)
     type(mock).supports_parallel_mmap_read = PropertyMock(return_value=True)
     return mock
@@ -55,12 +53,10 @@ class TestPropertyDelegation:
     @pytest.mark.parametrize(
         "prop",
         [
-            "user_scoped",
             "is_connected",
             "thread_safe",
             "supports_rename",
             "has_root_path",
-            "has_token_manager",
             "has_data_dir",
             "supports_parallel_mmap_read",
         ],

--- a/tests/unit/backends/test_protocol_conformance.py
+++ b/tests/unit/backends/test_protocol_conformance.py
@@ -256,6 +256,14 @@ class TestOAuthCapableProtocol:
                 self.user_email = "test@example.com"
                 self.provider = "google"
 
+            @property
+            def user_scoped(self) -> bool:
+                return True
+
+            @property
+            def has_token_manager(self) -> bool:
+                return True
+
         backend = FakeOAuthBackend()
         assert isinstance(backend, OAuthCapableProtocol)
 

--- a/tests/unit/backends/test_remote_backend.py
+++ b/tests/unit/backends/test_remote_backend.py
@@ -46,11 +46,6 @@ class TestRemoteBackendProperties:
     def test_transport_stored(self, backend: RemoteBackend, mock_transport) -> None:
         assert backend._transport is mock_transport
 
-    def test_user_scoped_is_false(self, backend: RemoteBackend) -> None:
-        assert backend.user_scoped is False
-
-    def test_has_token_manager_is_false(self, backend: RemoteBackend) -> None:
-        assert backend.has_token_manager is False
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/backends/test_remote_backend.py
+++ b/tests/unit/backends/test_remote_backend.py
@@ -47,7 +47,6 @@ class TestRemoteBackendProperties:
         assert backend._transport is mock_transport
 
 
-
 # ---------------------------------------------------------------------------
 # RPC Dispatch Tests
 # ---------------------------------------------------------------------------

--- a/tests/unit/backends/test_streaming.py
+++ b/tests/unit/backends/test_streaming.py
@@ -34,10 +34,6 @@ class TestBackendWriteStreamDefault:
             def name(self) -> str:
                 return "test"
 
-            @property
-            def user_scoped(self) -> bool:
-                return False
-
             def write_content(
                 self, content: bytes, content_id: str = "", *, offset: int = 0, context=None
             ) -> ObjectStoreWriteResult:

--- a/tests/unit/backends/wrapper_test_helpers.py
+++ b/tests/unit/backends/wrapper_test_helpers.py
@@ -26,12 +26,10 @@ def make_leaf(name: str = "local") -> MagicMock:
     mock = MagicMock(spec=Backend)
     mock.name = name
     mock.describe.return_value = name
-    type(mock).user_scoped = PropertyMock(return_value=False)
     type(mock).is_connected = PropertyMock(return_value=True)
     type(mock).thread_safe = PropertyMock(return_value=True)
     type(mock).supports_rename = PropertyMock(return_value=False)
     type(mock).has_root_path = PropertyMock(return_value=True)
-    type(mock).has_token_manager = PropertyMock(return_value=False)
     type(mock).has_data_dir = PropertyMock(return_value=False)
     type(mock).supports_parallel_mmap_read = PropertyMock(return_value=False)
     return mock

--- a/tests/unit/core/test_nexus_fs_stream_range.py
+++ b/tests/unit/core/test_nexus_fs_stream_range.py
@@ -83,10 +83,6 @@ def stub_fs():
     backend.stream_range.return_value = iter([b"Hello", b", Wor", b"ld!"])
     # Prevent MagicMock hasattr from matching read_content_range
     del backend.read_content_range
-    # Stub needs explicit False for dynamic connector check
-    backend.user_scoped = False
-    backend.has_token_manager = False
-
     meta_entry = MagicMock()
     meta_entry.etag = "sha256:abc123"
     meta_entry.size = 34


### PR DESCRIPTION
## Summary
- Remove `user_scoped` and `has_token_manager` from `ConnectorProtocol` and `Backend` base class — non-OAuth connectors no longer need to declare these
- Add both properties to existing `OAuthCapableProtocol` where they semantically belong
- Safe `getattr` fallback in all consumers (wrappers, health check, check_connection)

## Changes (18 files, -57 lines net)

| Layer | File | Change |
|-------|------|--------|
| Protocol | `core/protocols/connector.py` | Remove from ConnectorProtocol, add to OAuthCapableProtocol |
| Base class | `backends/base/backend.py` | Delete the two TODO(#1824) properties |
| Registry | `backends/base/registry.py` | Remove from CONNECTOR_PROTOCOL_ATTRS |
| Non-OAuth | `backends/storage/remote.py` | Delete False declarations |
| Non-OAuth | `backends/connectors/hn/connector.py` | Delete `user_scoped = False` |
| Wrapper | `backends/storage/delegating.py` | Safe getattr delegation |
| Wrapper | `bricks/sandbox/isolation/backend.py` | Safe try/except delegation |
| Health | `server/api/core/health.py` | getattr fallback |
| Tests | 10 test files | Remove stale mocks/assertions |

## Test plan
- [ ] CI full test suite (mypy, ruff, pytest)
- [ ] OAuth connectors (Gmail, GDrive, Slack, X, Calendar) unaffected — they define the properties on OAuthBaseConnector

Closes #1824.

🤖 Generated with [Claude Code](https://claude.com/claude-code)