### PR TITLE
fix(e2e): back-to-back cluster stability (subset zone check + partition heal timeout)

### DIFF
--- a/tests/e2e/docker/test_federation_e2e.py
+++ b/tests/e2e/docker/test_federation_e2e.py
@@ -1110,13 +1110,13 @@ class TestAdminIntrospection:
     """Federation topology inspection and cluster-info queries."""
 
     def test_list_zones(self, cluster, api_key):
-        """federation_list_zones returns all 5 zones."""
+        """federation_list_zones includes all 5 canonical zones (others may exist from prior runs)."""
         grpc1 = cluster["grpc1"]
         r = _grpc_call(grpc1, "federation_list_zones", {}, api_key=api_key)
         assert "error" not in r, f"federation_list_zones failed: {r}"
-        zone_ids = sorted(z["zone_id"] for z in r["result"]["zones"])
-        expected = sorted(["root", "corp", "corp-eng", "corp-sales", "family"])
-        assert zone_ids == expected, f"Expected {expected}, got {zone_ids}"
+        zone_ids = {z["zone_id"] for z in r["result"]["zones"]}
+        expected = {"root", "corp", "corp-eng", "corp-sales", "family"}
+        assert expected.issubset(zone_ids), f"Expected {sorted(expected)} ⊆ {sorted(zone_ids)}"
 
     def test_cluster_info_per_zone(self, cluster, api_key):
         """federation_cluster_info returns valid info for each zone."""
@@ -2075,7 +2075,7 @@ class TestPartialReplicationFailure:
                 path,
                 api_key,
                 msg=f"Post-partition catch-up missing: {path}",
-                timeout=30,
+                timeout=60,
             )
 
 


### PR DESCRIPTION
## Summary
- \`test_list_zones\`: relax strict equality to subset check — other tests (TestConcurrentZoneCreation, TestFederationShareJoin, TestZoneSnapshotExportImport, TestNewTeamOnboarding, TestWitnessAutoJoin) create zones that persist across back-to-back runs on the same cluster; the canonical 5 zones are a subset, not the full set.
- \`test_partition_then_heal\`: extend \`_wait_replicated\` timeout 30s → 60s. After node-2 reconnects from a network partition, it must replay raft entries accumulated during the partition window; under back-to-back cluster load, 30 s proved insufficient.

Found while running the post-PR-#3765 develop-tip verification (3× back-to-back docker federation E2E).

## Test plan
- [x] cargo test -p kernel --lib — 460 / 0
- [x] cargo test --manifest-path rust/raft/Cargo.toml --features full --lib — 129 / 0
- [x] Docker federation E2E × 3 back-to-back on fresh cluster — 50 / 0 / 0 × 3
- [x] Ruff + pre-commit hooks clean
