### PR TITLE
chore(release): bump version to 0.9.33

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "kernel"
-version = "0.9.31"
+version = "0.9.33"
 dependencies = [
  "ahash",
  "blake3",

--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/api-client",
-  "version": "0.9.31",
+  "version": "0.9.33",
   "description": "Shared HTTP client for Nexus APIs — retry, auth, error mapping, case transform",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/tui",
-  "version": "0.9.31",
+  "version": "0.9.33",
   "description": "Terminal UI for Nexus \u2014 file explorer, API inspector, and monitoring dashboard",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.31"
+version = "0.9.33"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/rust/kernel/Cargo.toml
+++ b/rust/kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel"
-version = "0.9.31"
+version = "0.9.33"
 edition = "2021"
 
 [lib]

--- a/rust/kernel/pyproject.toml
+++ b/rust/kernel/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-kernel"
-version = "0.9.31"
+version = "0.9.33"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
 requires-python = ">=3.14"
 classifiers = [

--- a/uv.lock
+++ b/uv.lock
@@ -2362,7 +2362,7 @@ wheels = [
 
 [[package]]
 name = "nexus-ai-fs"
-version = "0.9.31"
+version = "0.9.33"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary

- Bump 0.9.31 → 0.9.33 across the 5 version SSOTs enforced by `.github/workflows/release.yml` verify-version job
- Regenerate `Cargo.lock` + update `nexus-ai-fs` entry in `uv.lock` (2-line minimal — no transitive upgrades)
- Skip 0.9.32: that tag pointed at `85edec29b` but never shipped a files-bump commit, so file state stayed at 0.9.31

Downstream unblocks:
- `sudowork` bumps `src/shared/runtime-versions.json` `nexus` 0.9.29 → 0.9.33 after tag + COS artifact land
- password-agent deploys against the tag (first tag that carries PasswordVaultService)

Contents captured by this tag:
- #3765 — BackgroundService rename
- #3819 — PasswordVaultService (REST router, DI wiring, integration tests)

## Test plan

- [ ] CI green (verify-version + build wheel + build rust wheel matrix)
- [ ] After merge: tag v0.9.33 on merge commit, push tag
- [ ] Confirm release.yml fires: GitHub Release + PyPI + Docker
- [ ] Confirm pyinstaller-cluster.yml fires: three COS artifacts HEAD 200
  - `nexus-cluster-macos-arm64.tar.gz`
  - `nexus-cluster-macos-x86_64.tar.gz`
  - `nexus-cluster-windows-x86_64.zip`
- [ ] `gh api repos/nexi-lab/nexus/contents/src/nexus/services/password_vault?ref=v0.9.33` returns non-404