### PR TITLE
feat(rust): vendor protoc — kill system-protoc SSOT duplication (unblocks nexus-kernel PyPI publish)

### DIFF
--- a/.github/actions/build-rust-extensions/action.yml
+++ b/.github/actions/build-rust-extensions/action.yml
@@ -39,23 +39,6 @@ runs:
           rust/raft
           rust/tasks
 
-    - name: Install protoc
-      run: |
-        # raft-proto's protobuf-build requires protoc >= 3.1.0 (semver 3.x).
-        # Modern protoc (28.x+) uses a different version scheme that fails the check.
-        # Python 3.14 is set up by the actions/setup-python step in calling workflows;
-        # this action's setup is version-agnostic.
-        if [ "$RUNNER_OS" = "Linux" ]; then
-          sudo apt-get update && sudo apt-get install -y protobuf-compiler
-        elif [ "$RUNNER_OS" = "macOS" ]; then
-          PROTOC_VERSION="3.20.3"
-          PROTOC_ARCH="osx-x86_64"
-          curl -fsSL "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-${PROTOC_ARCH}.zip" -o /tmp/protoc.zip
-          sudo unzip -o /tmp/protoc.zip -d /usr/local bin/protoc
-          protoc --version
-        fi
-      shell: bash
-
     - name: Install maturin
       run: pip install maturin
       shell: bash

--- a/.github/workflows/conda-pack.yml
+++ b/.github/workflows/conda-pack.yml
@@ -91,41 +91,6 @@ jobs:
             rust/kernel
             rust/raft
 
-      - name: Install protoc (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          $protocDir = Join-Path $env:RUNNER_TEMP "protoc-3.20.3-win64"
-          $zipPath = Join-Path $env:RUNNER_TEMP "protoc-3.20.3-win64.zip"
-          Invoke-WebRequest "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.3/protoc-3.20.3-win64.zip" -OutFile $zipPath
-          Expand-Archive -Path $zipPath -DestinationPath $protocDir -Force
-          $protocExe = Join-Path $protocDir "bin/protoc.exe"
-          $protocBin = Split-Path $protocExe
-          echo "NEXUS_PROTOC=$protocExe" >> $env:GITHUB_ENV
-          echo $protocBin >> $env:GITHUB_PATH
-          $env:PATH = "$protocBin;$env:PATH"
-          & $protocExe --version
-
-      - name: Install protoc (macOS)
-        if: runner.os == 'macOS'
-        shell: bash -el {0}
-        run: |
-          brew install protobuf
-          REAL_PROTOC="$(brew --prefix protobuf)/bin/protoc"
-          mkdir -p "${RUNNER_TEMP}/bin"
-          printf '%s\n' \
-            '#!/usr/bin/env bash' \
-            'if [ "${1:-}" = "--version" ]; then' \
-            '  echo "libprotoc 3.20.3"' \
-            '  exit 0' \
-            'fi' \
-            "exec \"${REAL_PROTOC}\" \"\$@\"" \
-            > "${RUNNER_TEMP}/bin/protoc"
-          chmod +x "${RUNNER_TEMP}/bin/protoc"
-          echo "NEXUS_PROTOC=${RUNNER_TEMP}/bin/protoc" >> "${GITHUB_ENV}"
-          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
-          protoc --version
-
       # ── maturin builds ───────────────────────────────────────────────────
       # Install maturin inside the nexus env so it automatically uses the
       # correct Python interpreter when building the extension modules.
@@ -146,8 +111,6 @@ jobs:
 
       - name: Build raft wheel  (rust/raft --features full)
         shell: bash -el {0}
-        env:
-          PROTOC: ${{ env.NEXUS_PROTOC }}
         run: |
           mkdir -p build/dist
           conda run -n nexus maturin build --release \

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -102,9 +102,6 @@ jobs:
             rust/kernel
             rust/raft
 
-      - name: Install protobuf compiler
-        run: sudo apt-get install -y protobuf-compiler
-
       - name: Check Rust formatting
         run: |
           for crate in tasks library kernel raft; do

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -152,35 +152,6 @@ jobs:
           PY
           pip install .
 
-      # ── protoc (required by nexus_raft build.rs) ─────────────────────────
-      # Mirrors the protoc install pattern from conda-pack.yml.
-      # The wrapper script reports "libprotoc 3.20.3" to satisfy the >= 3.1.0
-      # version check in protobuf-build, while delegating to the real binary.
-      - name: Install protoc (macOS)
-        if: runner.os == 'macOS'
-        run: |
-          brew install protobuf
-          REAL_PROTOC="$(brew --prefix protobuf)/bin/protoc"
-          mkdir -p "${RUNNER_TEMP}/bin"
-          printf '%s\n' \
-            '#!/usr/bin/env bash' \
-            'if [ "${1:-}" = "--version" ]; then' \
-            '  echo "libprotoc 3.20.3"' \
-            '  exit 0' \
-            'fi' \
-            "exec \"${REAL_PROTOC}\" \"\$@\"" \
-            > "${RUNNER_TEMP}/bin/protoc"
-          chmod +x "${RUNNER_TEMP}/bin/protoc"
-          echo "NEXUS_PROTOC=${RUNNER_TEMP}/bin/protoc" >> "${GITHUB_ENV}"
-          echo "${RUNNER_TEMP}/bin" >> "${GITHUB_PATH}"
-          protoc --version
-
-      - name: Install protoc (Linux)
-        if: runner.os == 'Linux'
-        run: |
-          sudo apt-get update -q
-          sudo apt-get install -y protobuf-compiler
-
       - name: Pre-install binary wheels (Windows)
         if: runner.os == 'Windows'
         shell: bash
@@ -188,23 +159,6 @@ jobs:
           # cryptography and other Rust/C extensions must come from binary wheels
           # on Windows ARM64 — no OpenSSL dev headers available in CI.
           pip install --only-binary :all: cryptography pyopenssl bcrypt cffi
-
-      - name: Install protoc (Windows)
-        if: runner.os == 'Windows'
-        shell: pwsh
-        run: |
-          # protobuf-build 0.14.1 only accepts protoc 3.x.
-          # choco installs 34.x which fails version parsing.
-          # Download protoc 3.20.3 win64 directly; runs on ARM64 via x86 emulation.
-          $url = "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.3/protoc-3.20.3-win64.zip"
-          $zip = "$env:RUNNER_TEMP\protoc.zip"
-          $dir = "$env:RUNNER_TEMP\protoc"
-          Invoke-WebRequest -Uri $url -OutFile $zip
-          Expand-Archive -Path $zip -DestinationPath $dir -Force
-          $protoc = "$dir\bin\protoc.exe"
-          echo "NEXUS_PROTOC=$protoc" | Out-File -Append -FilePath $env:GITHUB_ENV -Encoding utf8
-          echo "$dir\bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-          & $protoc --version
 
       # ── maturin builds ───────────────────────────────────────────────────
       - name: Install maturin
@@ -220,8 +174,6 @@ jobs:
 
       - name: Build raft wheel  (rust/raft --features full)
         shell: bash
-        env:
-          PROTOC: ${{ env.NEXUS_PROTOC }}
         run: |
           maturin build --release \
             --features full \

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1343,6 +1343,7 @@ dependencies = [
  "mimalloc",
  "parking_lot",
  "prost",
+ "protoc-bin-vendored",
  "pyo3",
  "raft 0.1.0",
  "rayon",
@@ -1925,6 +1926,70 @@ dependencies = [
 ]
 
 [[package]]
+name = "protoc-bin-vendored"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+dependencies = [
+ "protoc-bin-vendored-linux-aarch_64",
+ "protoc-bin-vendored-linux-ppcle_64",
+ "protoc-bin-vendored-linux-s390_64",
+ "protoc-bin-vendored-linux-x86_32",
+ "protoc-bin-vendored-linux-x86_64",
+ "protoc-bin-vendored-macos-aarch_64",
+ "protoc-bin-vendored-macos-x86_64",
+ "protoc-bin-vendored-win32",
+]
+
+[[package]]
+name = "protoc-bin-vendored-linux-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-ppcle_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
+
+[[package]]
+name = "protoc-bin-vendored-linux-s390_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+
+[[package]]
+name = "protoc-bin-vendored-linux-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+
+[[package]]
+name = "protoc-bin-vendored-macos-aarch_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+
+[[package]]
+name = "protoc-bin-vendored-macos-x86_64"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+
+[[package]]
+name = "protoc-bin-vendored-win32"
+version = "3.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
+
+[[package]]
 name = "pyo3"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2093,6 +2158,7 @@ dependencies = [
  "pem",
  "prost",
  "protobuf",
+ "protoc-bin-vendored",
  "pyo3",
  "raft 0.7.0",
  "rcgen",

--- a/Dockerfile
+++ b/Dockerfile
@@ -33,7 +33,6 @@ RUN set -eux; \
         curl \
         build-essential \
         ca-certificates \
-        protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
 # ---------- Rust Toolchain ----------

--- a/dockerfiles/Dockerfile.minimal
+++ b/dockerfiles/Dockerfile.minimal
@@ -18,7 +18,6 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         curl \
         build-essential \
         ca-certificates \
-        protobuf-compiler \
     && rm -rf /var/lib/apt/lists/*
 
 # ---------- Rust toolchain (for _nexus_raft) ----------

--- a/dockerfiles/Dockerfile.raft-server
+++ b/dockerfiles/Dockerfile.raft-server
@@ -13,11 +13,6 @@
 
 FROM rust:1-slim-bookworm AS builder
 
-# Install protobuf compiler (required by tonic-build)
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends protobuf-compiler && \
-    rm -rf /var/lib/apt/lists/*
-
 WORKDIR /build
 
 # Copy proto files (build.rs expects ../../proto relative to rust/raft/)

--- a/dockerfiles/Dockerfile.raft-witness
+++ b/dockerfiles/Dockerfile.raft-witness
@@ -14,11 +14,6 @@
 
 FROM rust:1-slim-bookworm AS builder
 
-# Install protobuf compiler (required by tonic-build)
-RUN apt-get update && \
-    apt-get install -y --no-install-recommends protobuf-compiler && \
-    rm -rf /var/lib/apt/lists/*
-
 WORKDIR /build
 
 # Copy workspace root manifests — nexus_raft uses `workspace = true` deps

--- a/rust/kernel/Cargo.toml
+++ b/rust/kernel/Cargo.toml
@@ -63,6 +63,10 @@ py-hook-adapters = []
 
 [build-dependencies]
 tonic-build = "0.13"
+# Vendored protoc binary so kernel build works on any host without a
+# system-wide protobuf-compiler install. Tier-1 platforms (linux/macos/windows
+# × x86_64/aarch64) all covered by the pre-compiled binary the crate ships.
+protoc-bin-vendored = "3"
 
 [dev-dependencies]
 criterion = "0.5"

--- a/rust/kernel/build.rs
+++ b/rust/kernel/build.rs
@@ -1,4 +1,11 @@
 fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // Point tonic_build (→ prost-build) at the vendored protoc binary so the
+    // crate builds without a system-wide protobuf-compiler. Respect an
+    // externally-set PROTOC if the caller already chose one.
+    if std::env::var_os("PROTOC").is_none() {
+        std::env::set_var("PROTOC", protoc_bin_vendored::protoc_bin_path()?);
+    }
+
     // Compile vfs.proto → client for inter-node ReadBlob (federation remote fetch).
     tonic_build::configure()
         .build_server(false)

--- a/rust/raft/Cargo.toml
+++ b/rust/raft/Cargo.toml
@@ -95,6 +95,10 @@ mimalloc = { workspace = true, optional = true }
 
 [build-dependencies]
 tonic-build = { version = "0.13", optional = true }
+# Vendored protoc binary so raft build works on any host without a
+# system-wide protobuf-compiler install. Only used when grpc feature
+# triggers proto codegen (see build.rs).
+protoc-bin-vendored = "3"
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/rust/raft/build.rs
+++ b/rust/raft/build.rs
@@ -12,6 +12,13 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Only compile protos when grpc feature is enabled
     #[cfg(feature = "grpc")]
     {
+        // Point tonic_build (→ prost-build) at the vendored protoc binary so
+        // the crate builds without a system-wide protobuf-compiler. Respect
+        // an externally-set PROTOC if the caller already chose one.
+        if std::env::var_os("PROTOC").is_none() {
+            std::env::set_var("PROTOC", protoc_bin_vendored::protoc_bin_path()?);
+        }
+
         // Proto files are in project root's proto/ directory (SSOT)
         let proto_root = "../../proto";
         let core_proto = format!("{}/nexus/core/metadata.proto", proto_root);


### PR DESCRIPTION
## Summary

Kernel and raft \`build.rs\` both invoke \`tonic_build\` → \`prost-build\`, which needs a system \`protoc\` binary. Without vendoring, every build site has to install protoc separately — **8 places already do**, and \`release.yml\`'s \`build-rust-wheel\` + \`build-rust-sdist\` jobs silently missed it, which is why **\`nexus-kernel\` has never been published to PyPI** (every wheel build failed with \`Could not find \`protoc\`\`).

Fix at the root: use \`protoc-bin-vendored\` to provide the compiler as a build-dep, point \`PROTOC\` at the vendored binary in \`build.rs\`. Tier-1 platforms (linux/macos/windows × x86_64/aarch64) all covered by pre-compiled binaries the crate ships. Respect an externally-set \`PROTOC\` so callers can still override.

## Consequences

- \`release.yml\` wheel build / sdist build now work without further edits — **after this merges + a tag push, \`nexus-kernel\` can publish to PyPI** (pending \`NEXUS_FAST_PYPI_API_TOKEN\` secret, which is an admin action outside this PR).
- 4 CI workflows and 4 Dockerfiles shrink — no more per-platform protoc-install incantations.
- Local developers \`cargo build\` / \`maturin develop\` open-box.
- No more "forgot to install protoc in the new workflow" class of bug.

## Files

| Type | Files |
|---|---|
| Vendor protoc into crates | \`rust/kernel/Cargo.toml\`, \`rust/kernel/build.rs\`, \`rust/raft/Cargo.toml\`, \`rust/raft/build.rs\` |
| Delete system-protoc install (CI) | \`.github/actions/build-rust-extensions/action.yml\`, \`.github/workflows/lint.yml\`, \`.github/workflows/conda-pack.yml\`, \`.github/workflows/pyinstaller-cluster.yml\` |
| Delete \`protobuf-compiler\` apt install (Docker) | \`Dockerfile\`, \`dockerfiles/Dockerfile.minimal\`, \`dockerfiles/Dockerfile.raft-witness\`, \`dockerfiles/Dockerfile.raft-server\` |

Net: **+88 / -117**.

## Test plan

- [x] \`unset PROTOC && cargo test -p kernel --lib\` → 460 / 0
- [x] \`unset PROTOC && cargo test --manifest-path rust/raft/Cargo.toml --features full --lib\` → 129 / 0
- [x] cargo fmt + clippy clean (pre-commit gates passed)
- [ ] CI — this PR validates it end-to-end: if lint.yml, test.yml, release-triggered jobs all pass without the deleted protoc-install steps, the vendored path works everywhere

## Out of scope (follow-ups)

- \`NEXUS_FAST_PYPI_API_TOKEN\` secret config — repo admin action, Settings → Secrets
- Conda Pack macOS \`PYO3_USE_ABI3_FORWARD_COMPATIBILITY\` issue — orthogonal, separate PR
- \`nexus-ai-fs\` adds \`nexus-kernel\` to \`dependencies\` — gated on first successful kernel PyPI publish, otherwise \`pip install nexus-ai-fs\` would break

Root-cause background: release.yml's wheel builds on all platforms failed with \`Could not find \`protoc\`\` since at least v0.9.29 (4 consecutive tag pushes). Every other build site worked around it by installing protoc per-workflow; release.yml was the one that got skipped. Fixing one more workflow would have been the quick patch — this vendors at the crate level so *all* builds trust the crate, not the ambient toolchain.
