### PR TITLE
feat(password_vault): access_context audit observability + server-side TOTP (spec v3)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,6 +78,7 @@ dependencies = [
     "bcrypt>=4.0.0", # Password hashing for local auth
     "cryptography>=41.0.0", # OAuth token encryption (Fernet) + Ed25519 identity signing
     "PyJWT>=2.8.0", # JWT-VC issuance/verification for agent identity (Issue #1355)
+    "pyotp>=2.9.0", # RFC 6238 TOTP for server-side password-vault totp codes
     "itsdangerous>=2.2.0", # Signed, TTL-bounded OAuth state tokens (URLSafeTimedSerializer)
     # Cloud Storage Backends
     "boto3>=1.42.4", # AWS SDK for Python (S3 connector)

--- a/src/nexus/bricks/secrets/service.py
+++ b/src/nexus/bricks/secrets/service.py
@@ -453,6 +453,7 @@ class SecretsService:
         subject_id: str | None = None,
         subject_type: str | None = None,
         audit_context: AccessAuditContext | None = None,
+        audit_event_type: str = "key_accessed",
     ) -> dict[str, Any] | None:
         """Get a secret value (decrypted) with version info.
 
@@ -466,6 +467,10 @@ class SecretsService:
             subject_type: The subject type
             audit_context: Optional caller context (access_context, client_id,
                 agent_session) merged into the audit log ``details`` JSON.
+            audit_event_type: Audit event type recorded for this read.
+                Defaults to ``key_accessed``; domain wrappers that repurpose
+                a read (e.g. TOTP generation) pass their own event type so
+                audit queries can count purposes separately.
 
         Returns:
             Dict with 'value' and 'version' keys, or None if not found
@@ -520,7 +525,7 @@ class SecretsService:
             if audit_context is not None:
                 details.update(audit_context.to_audit_details())
             self._audit_logger.log_event(
-                event_type="key_accessed",
+                event_type=audit_event_type,
                 actor_id=actor_id,
                 credential_id=secret_id,
                 zone_id=zone_id,

--- a/src/nexus/bricks/secrets/service.py
+++ b/src/nexus/bricks/secrets/service.py
@@ -19,6 +19,7 @@ from sqlalchemy import select
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.protocols.token_encryptor import TokenEncryptor
+from nexus.contracts.secrets_access import AccessAuditContext
 from nexus.storage.models.secret_store import SecretStoreModel, SecretStoreVersionModel
 from nexus.storage.secrets_audit_logger import SecretsAuditLogger
 
@@ -451,6 +452,7 @@ class SecretsService:
         zone_id: str = ROOT_ZONE_ID,
         subject_id: str | None = None,
         subject_type: str | None = None,
+        audit_context: AccessAuditContext | None = None,
     ) -> dict[str, Any] | None:
         """Get a secret value (decrypted) with version info.
 
@@ -462,6 +464,8 @@ class SecretsService:
             zone_id: The zone ID
             subject_id: The subject ID who owns this secret
             subject_type: The subject type
+            audit_context: Optional caller context (access_context, client_id,
+                agent_session) merged into the audit log ``details`` JSON.
 
         Returns:
             Dict with 'value' and 'version' keys, or None if not found
@@ -508,12 +512,19 @@ class SecretsService:
 
         # Audit log
         try:
+            details: dict[str, Any] = {
+                "namespace": namespace,
+                "key": key,
+                "version": actual_version,
+            }
+            if audit_context is not None:
+                details.update(audit_context.to_audit_details())
             self._audit_logger.log_event(
                 event_type="key_accessed",
                 actor_id=actor_id,
                 credential_id=secret_id,
                 zone_id=zone_id,
-                details={"namespace": namespace, "key": key, "version": actual_version},
+                details=details,
             )
         except Exception as e:
             logger.warning("Failed to write audit log: %s", e)
@@ -726,6 +737,7 @@ class SecretsService:
         zone_id: str = ROOT_ZONE_ID,
         subject_id: str | None = None,
         subject_type: str | None = None,
+        audit_context: AccessAuditContext | None = None,
     ) -> dict[str, str]:
         """Batch read secrets.
 
@@ -735,6 +747,8 @@ class SecretsService:
             zone_id: The zone ID
             subject_id: The subject ID who owns these secrets
             subject_type: The subject type
+            audit_context: Forwarded to each ``get_secret`` call so every
+                per-entry audit event carries the same caller tag.
 
         Returns:
             Dict mapping "namespace:key" to decrypted value
@@ -753,6 +767,7 @@ class SecretsService:
                     zone_id=zone_id,
                     subject_id=subject_id,
                     subject_type=subject_type,
+                    audit_context=audit_context,
                 )
                 if result is not None:
                     results[f"{namespace}:{key}"] = result["value"]

--- a/src/nexus/contracts/secrets_access.py
+++ b/src/nexus/contracts/secrets_access.py
@@ -1,0 +1,58 @@
+"""Access-context typing for secrets / password-vault read endpoints.
+
+A caller tags every credential read with an ``access_context`` so the
+audit log can later distinguish an admin CLI lookup from an agent
+auto-login from a human-approved reveal. The value is observability only
+— it is not enforced for access control.
+
+Lives in ``nexus.contracts`` (not ``services/password_vault``) so both
+the ``secrets`` brick and the ``password_vault`` service wrapper can
+import it without creating a bricks→services dependency.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any, Literal, get_args
+
+AccessContext = Literal[
+    "admin_cli",
+    "auto_login",
+    "auto_rotate",
+    "reveal_approved",
+    "agent_direct",
+]
+
+DEFAULT_ACCESS_CONTEXT: AccessContext = "admin_cli"
+
+ACCESS_CONTEXT_VALUES: frozenset[str] = frozenset(get_args(AccessContext))
+
+
+@dataclass(frozen=True, slots=True)
+class AccessAuditContext:
+    """Audit-only context carried with every credential-read call.
+
+    Fields are informational — no server-side enforcement. They land in
+    the ``details`` JSON of the ``secrets_audit_log`` row so downstream
+    queries can slice reads by caller identity / agent session.
+
+    Attributes:
+        access_context: Who/why is reading. Defaults to ``admin_cli``.
+        client_id: Free-form client identifier (e.g. ``"sudowork"``).
+        agent_session: Free-form agent session identifier. Pairs with
+            ``client_id`` to let operators reconstruct "what did this
+            agent session read?"
+    """
+
+    access_context: AccessContext = DEFAULT_ACCESS_CONTEXT
+    client_id: str | None = None
+    agent_session: str | None = None
+
+    def to_audit_details(self) -> dict[str, Any]:
+        """Return non-None fields for merging into audit ``details``."""
+        d: dict[str, Any] = {"access_context": self.access_context}
+        if self.client_id is not None:
+            d["client_id"] = self.client_id
+        if self.agent_session is not None:
+            d["agent_session"] = self.agent_session
+        return d

--- a/src/nexus/server/api/v2/routers/password_vault.py
+++ b/src/nexus/server/api/v2/routers/password_vault.py
@@ -28,11 +28,17 @@ SQLAlchemy I/O in the underlying SecretsService.
 from __future__ import annotations
 
 import logging
-from typing import Any
+from typing import Any, cast
 
-from fastapi import APIRouter, Depends, HTTPException
+from fastapi import APIRouter, Depends, HTTPException, Query
 
 from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.secrets_access import (
+    ACCESS_CONTEXT_VALUES,
+    DEFAULT_ACCESS_CONTEXT,
+    AccessAuditContext,
+    AccessContext,
+)
 from nexus.server.dependencies import require_auth
 from nexus.services.password_vault.schema import VaultEntry
 from nexus.services.password_vault.service import (
@@ -56,6 +62,38 @@ def _validate_title(title: str) -> None:
         )
 
 
+def _build_audit_context(
+    access_context: str | None,
+    client_id: str | None,
+    agent_session: str | None,
+) -> AccessAuditContext:
+    """Validate query params and build an ``AccessAuditContext``.
+
+    Unknown ``access_context`` values → 400, keeping the typed-enum
+    invariant clients (and future enforcement) can rely on. Missing
+    value defaults to ``admin_cli``.
+    """
+    value: AccessContext
+    if access_context is None:
+        value = DEFAULT_ACCESS_CONTEXT
+    elif access_context in ACCESS_CONTEXT_VALUES:
+        # Runtime-validated against the Literal's canonical values.
+        value = cast(AccessContext, access_context)
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail=(
+                f"Unknown access_context {access_context!r}. "
+                f"Allowed: {sorted(ACCESS_CONTEXT_VALUES)}"
+            ),
+        )
+    return AccessAuditContext(
+        access_context=value,
+        client_id=client_id,
+        agent_session=agent_session,
+    )
+
+
 # --------------------------------------------------------------------------
 # Dependency — injected by fastapi_server.py
 # --------------------------------------------------------------------------
@@ -73,6 +111,9 @@ def get_password_vault_service() -> PasswordVaultService:
 
 @router.get("")
 def list_entries(
+    access_context: str | None = Query(default=None),
+    client_id: str | None = Query(default=None),
+    agent_session: str | None = Query(default=None),
     auth_result: dict[str, Any] = Depends(require_auth),
     service: PasswordVaultService = Depends(get_password_vault_service),
 ) -> dict[str, Any]:
@@ -81,6 +122,7 @@ def list_entries(
     zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     subject_id = auth_result.get("subject_id") or "anonymous"
     subject_type = auth_result.get("subject_type") or "user"
+    audit_context = _build_audit_context(access_context, client_id, agent_session)
 
     try:
         entries = service.list_entries(
@@ -88,6 +130,7 @@ def list_entries(
             zone_id=zone_id,
             subject_id=subject_id,
             subject_type=subject_type,
+            audit_context=audit_context,
         )
         return {"entries": [e.model_dump() for e in entries], "count": len(entries)}
     except Exception as e:
@@ -201,6 +244,9 @@ def put_entry(
 def get_entry(
     title: str,
     version: int | None = None,
+    access_context: str | None = Query(default=None),
+    client_id: str | None = Query(default=None),
+    agent_session: str | None = Query(default=None),
     auth_result: dict[str, Any] = Depends(require_auth),
     service: PasswordVaultService = Depends(get_password_vault_service),
 ) -> VaultEntry:
@@ -210,6 +256,7 @@ def get_entry(
     zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     subject_id = auth_result.get("subject_id") or "anonymous"
     subject_type = auth_result.get("subject_type") or "user"
+    audit_context = _build_audit_context(access_context, client_id, agent_session)
 
     try:
         from nexus.bricks.secrets.service import SecretDisabledError
@@ -221,6 +268,7 @@ def get_entry(
             zone_id=zone_id,
             subject_id=subject_id,
             subject_type=subject_type,
+            audit_context=audit_context,
         )
     except VaultEntryNotFoundError as e:
         raise HTTPException(status_code=404, detail="Vault entry not found") from e

--- a/src/nexus/server/api/v2/routers/password_vault.py
+++ b/src/nexus/server/api/v2/routers/password_vault.py
@@ -31,6 +31,7 @@ import logging
 from typing import Any, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel, ConfigDict
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.secrets_access import (
@@ -43,8 +44,25 @@ from nexus.server.dependencies import require_auth
 from nexus.services.password_vault.schema import VaultEntry
 from nexus.services.password_vault.service import (
     PasswordVaultService,
+    TotpNotConfiguredError,
     VaultEntryNotFoundError,
 )
+
+
+class TotpRequest(BaseModel):
+    """Request body for ``POST /{title}/totp``.
+
+    All fields optional — carries the same caller-tag tuple as Ask 1 GET
+    endpoints so a TOTP generation shows up in the audit log with the
+    same client_id / agent_session as the parent auto-login session.
+    """
+
+    model_config = ConfigDict(extra="ignore")
+
+    access_context: str | None = None
+    client_id: str | None = None
+    agent_session: str | None = None
+
 
 logger = logging.getLogger(__name__)
 
@@ -197,6 +215,57 @@ def restore_entry(
     except Exception as e:
         logger.error("Failed to restore vault entry: %s", e)
         raise HTTPException(status_code=500, detail=f"Failed to restore vault entry: {e}") from e
+
+
+@router.post("/{title:path}/totp")
+def generate_totp_code(
+    title: str,
+    body: TotpRequest | None = None,
+    auth_result: dict[str, Any] = Depends(require_auth),
+    service: PasswordVaultService = Depends(get_password_vault_service),
+) -> dict[str, Any]:
+    """Compute a TOTP code server-side from the entry's stored ``totp_secret``.
+
+    The secret never leaves nexus; only the 6-digit code + window metadata
+    are returned. Emits a distinct ``totp_generated`` audit event.
+
+    Response: ``{"code", "expires_in_seconds", "period_seconds"}``.
+
+    Status codes:
+        200 — Code generated.
+        400 — Unknown ``access_context`` value in body.
+        404 — Entry does not exist, or subject has no access to it.
+        422 — Entry exists but has no ``totp_secret`` configured.
+    """
+    _validate_title(title)
+    actor_id = auth_result.get("subject_id") or "anonymous"
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
+    subject_id = auth_result.get("subject_id") or "anonymous"
+    subject_type = auth_result.get("subject_type") or "user"
+
+    body = body or TotpRequest()
+    audit_context = _build_audit_context(body.access_context, body.client_id, body.agent_session)
+
+    try:
+        result = service.generate_totp(
+            title,
+            actor_id=actor_id,
+            zone_id=zone_id,
+            subject_id=subject_id,
+            subject_type=subject_type,
+            audit_context=audit_context,
+        )
+    except TotpNotConfiguredError as e:
+        raise HTTPException(status_code=422, detail="totp_not_configured") from e
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error("Failed to generate TOTP: %s", e)
+        raise HTTPException(status_code=500, detail=f"Failed to generate TOTP: {e}") from e
+
+    if result is None:
+        raise HTTPException(status_code=404, detail="Vault entry not found")
+    return result
 
 
 # --------------------------------------------------------------------------

--- a/src/nexus/services/password_vault/service.py
+++ b/src/nexus/services/password_vault/service.py
@@ -13,6 +13,7 @@ import logging
 from typing import Any, cast
 
 from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.secrets_access import AccessAuditContext
 from nexus.services.password_vault.schema import VaultEntry
 
 # ``secrets_service`` is typed as ``Any`` below rather than the concrete
@@ -89,6 +90,7 @@ class PasswordVaultService:
         zone_id: str = ROOT_ZONE_ID,
         subject_id: str | None = None,
         subject_type: str | None = None,
+        audit_context: AccessAuditContext | None = None,
     ) -> VaultEntry:
         """Fetch and decrypt a vault entry (latest version unless specified)."""
         result = self._secrets.get_secret(
@@ -99,6 +101,7 @@ class PasswordVaultService:
             zone_id=zone_id,
             subject_id=subject_id,
             subject_type=subject_type,
+            audit_context=audit_context,
         )
         if result is None:
             raise VaultEntryNotFoundError(title)
@@ -111,6 +114,7 @@ class PasswordVaultService:
         zone_id: str = ROOT_ZONE_ID,
         subject_id: str | None = None,
         subject_type: str | None = None,
+        audit_context: AccessAuditContext | None = None,
     ) -> list[VaultEntry]:
         """Return every (live) vault entry with its latest-version payload."""
         metadata = self._secrets.list_secrets(
@@ -129,6 +133,7 @@ class PasswordVaultService:
             zone_id=zone_id,
             subject_id=subject_id,
             subject_type=subject_type,
+            audit_context=audit_context,
         )
 
         entries: list[VaultEntry] = []

--- a/src/nexus/services/password_vault/service.py
+++ b/src/nexus/services/password_vault/service.py
@@ -10,11 +10,17 @@ from __future__ import annotations
 
 import json
 import logging
+import time
 from typing import Any, cast
+
+import pyotp
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.secrets_access import AccessAuditContext
 from nexus.services.password_vault.schema import VaultEntry
+
+TOTP_PERIOD_SECONDS = 30
+TOTP_AUDIT_EVENT_TYPE = "totp_generated"
 
 # ``secrets_service`` is typed as ``Any`` below rather than the concrete
 # ``nexus.bricks.secrets.service.SecretsService`` because the import-linter
@@ -32,6 +38,10 @@ class VaultEntryNotFoundError(LookupError):
     """Raised when a vault entry does not exist (or is soft-deleted)."""
 
 
+class TotpNotConfiguredError(ValueError):
+    """Raised when a vault entry exists but has no ``totp_secret`` to seed TOTP."""
+
+
 class PasswordVaultService:
     """Domain-typed wrapper over SecretsService for vault entries.
 
@@ -45,6 +55,10 @@ class PasswordVaultService:
 
     def __init__(self, secrets_service: Any) -> None:
         self._secrets = secrets_service
+        # TOTP oracle cache keyed by ``(subject_id, title, window_index)``.
+        # Within one 30s window we return the same code per (subject, entry);
+        # callers that hammer the endpoint see one computation, not many.
+        self._totp_cache: dict[tuple[str, str, int], str] = {}
 
     # ------------------------------------------------------------------
     # Writes
@@ -210,3 +224,82 @@ class PasswordVaultService:
                 subject_type=subject_type,
             )
         )
+
+    # ------------------------------------------------------------------
+    # TOTP (RFC 6238)
+    # ------------------------------------------------------------------
+
+    def generate_totp(
+        self,
+        title: str,
+        *,
+        now: float | None = None,
+        actor_id: str = "system",
+        zone_id: str = ROOT_ZONE_ID,
+        subject_id: str | None = None,
+        subject_type: str | None = None,
+        audit_context: AccessAuditContext | None = None,
+    ) -> dict[str, Any] | None:
+        """Compute a current TOTP code from the entry's stored ``totp_secret``.
+
+        The secret never leaves this process — only the 6-digit code and
+        window metadata are returned. A single audit event typed
+        ``totp_generated`` is recorded (distinct from ``key_accessed`` so
+        audit queries can count TOTP requests separately).
+
+        Args:
+            title: Vault entry title.
+            now: Override current time (seconds since epoch). Tests only.
+            actor_id, zone_id, subject_id, subject_type: auth context.
+            audit_context: Caller tag merged into audit details.
+
+        Returns:
+            ``{"code", "expires_in_seconds", "period_seconds"}`` on success,
+            or ``None`` if the entry does not exist / is not visible to the
+            subject. (Callers map ``None`` to HTTP 404.)
+
+        Raises:
+            TotpNotConfiguredError: Entry exists but has no ``totp_secret``.
+                Callers map this to HTTP 422 (spec v3: distinguish
+                "not found / unauthorized" from "no TOTP on this entry").
+        """
+        result = self._secrets.get_secret(
+            namespace=self.NAMESPACE,
+            key=title,
+            actor_id=actor_id,
+            zone_id=zone_id,
+            subject_id=subject_id,
+            subject_type=subject_type,
+            audit_context=audit_context,
+            audit_event_type=TOTP_AUDIT_EVENT_TYPE,
+        )
+        if result is None:
+            return None
+
+        entry = VaultEntry.model_validate(json.loads(result["value"]))
+        if not entry.totp_secret:
+            raise TotpNotConfiguredError(title)
+
+        now_seconds = int(now if now is not None else time.time())
+        window_index = now_seconds // TOTP_PERIOD_SECONDS
+        cache_key = (subject_id or "anonymous", title, window_index)
+
+        code = self._totp_cache.get(cache_key)
+        if code is None:
+            code = pyotp.TOTP(entry.totp_secret).at(now_seconds)
+            self._totp_cache[cache_key] = code
+            # Drop entries from past windows so the dict doesn't grow
+            # unbounded under long-running servers.
+            self._prune_totp_cache(current_window=window_index)
+
+        return {
+            "code": code,
+            "expires_in_seconds": TOTP_PERIOD_SECONDS - (now_seconds % TOTP_PERIOD_SECONDS),
+            "period_seconds": TOTP_PERIOD_SECONDS,
+        }
+
+    def _prune_totp_cache(self, *, current_window: int) -> None:
+        """Drop cache entries from windows older than ``current_window``."""
+        stale = [k for k in self._totp_cache if k[2] < current_window]
+        for k in stale:
+            self._totp_cache.pop(k, None)

--- a/src/nexus/storage/models/secrets_audit_log.py
+++ b/src/nexus/storage/models/secrets_audit_log.py
@@ -28,6 +28,7 @@ class SecretsAuditEventType(StrEnum):
     FAMILY_INVALIDATED = "family_invalidated"
     KEY_ACCESSED = "key_accessed"
     KEY_ROTATED = "key_rotated"
+    TOTP_GENERATED = "totp_generated"
 
 
 class SecretsAuditLogModel(Base):

--- a/tests/integration/test_password_vault_api.py
+++ b/tests/integration/test_password_vault_api.py
@@ -330,3 +330,97 @@ def test_get_entry_with_version_query_and_access_context(client: TestClient) -> 
 
     assert resp.status_code == 200
     assert resp.json()["password"] == "v1"
+
+
+# ---------------------------------------------------------------------------
+# POST /{title}/totp — server-side TOTP (Ask 2 of spec v3)
+# ---------------------------------------------------------------------------
+
+
+def test_generate_totp_returns_code_and_window_metadata(client: TestClient) -> None:
+    client.put("/api/v2/password_vault/github", json=_sample_body())  # has totp_secret
+
+    resp = client.post("/api/v2/password_vault/github/totp", json={})
+
+    assert resp.status_code == 200, resp.text
+    body = resp.json()
+    assert set(body.keys()) == {"code", "expires_in_seconds", "period_seconds"}
+    assert body["period_seconds"] == 30
+    assert isinstance(body["code"], str) and len(body["code"]) == 6
+    assert 0 < body["expires_in_seconds"] <= 30
+
+
+def test_generate_totp_accepts_access_context_in_body(client: TestClient) -> None:
+    client.put("/api/v2/password_vault/github", json=_sample_body())
+
+    resp = client.post(
+        "/api/v2/password_vault/github/totp",
+        json={"access_context": "auto_login", "client_id": "sudowork", "agent_session": "s-1"},
+    )
+
+    assert resp.status_code == 200
+
+
+def test_generate_totp_rejects_unknown_access_context(client: TestClient) -> None:
+    client.put("/api/v2/password_vault/github", json=_sample_body())
+
+    resp = client.post(
+        "/api/v2/password_vault/github/totp",
+        json={"access_context": "not_a_real_value"},
+    )
+
+    assert resp.status_code == 400
+
+
+def test_generate_totp_accepts_empty_body(client: TestClient) -> None:
+    """No body at all should still work — defaults to admin_cli context."""
+    client.put("/api/v2/password_vault/github", json=_sample_body())
+
+    resp = client.post("/api/v2/password_vault/github/totp")
+
+    assert resp.status_code == 200
+
+
+def test_generate_totp_missing_entry_returns_404(client: TestClient) -> None:
+    resp = client.post("/api/v2/password_vault/does-not-exist/totp", json={})
+
+    assert resp.status_code == 404
+
+
+def test_generate_totp_entry_without_totp_secret_returns_422(client: TestClient) -> None:
+    client.put(
+        "/api/v2/password_vault/no-totp",
+        json={"title": "no-totp", "password": "x"},  # no totp_secret
+    )
+
+    resp = client.post("/api/v2/password_vault/no-totp/totp", json={})
+
+    assert resp.status_code == 422
+    assert "totp_not_configured" in resp.json()["detail"]
+
+
+def test_generate_totp_same_window_returns_same_code(client: TestClient) -> None:
+    """Oracle rate-limit: two calls in the same 30s window → same code."""
+    client.put("/api/v2/password_vault/github", json=_sample_body())
+
+    r1 = client.post("/api/v2/password_vault/github/totp", json={})
+    r2 = client.post("/api/v2/password_vault/github/totp", json={})
+
+    assert r1.status_code == 200 and r2.status_code == 200
+    # Real-clock race: if these calls straddle a 30s boundary, codes can
+    # legitimately differ. Accept either equal codes OR clearly-different
+    # expires_in_seconds (indicating window rollover).
+    if r1.json()["code"] != r2.json()["code"]:
+        assert r1.json()["expires_in_seconds"] != r2.json()["expires_in_seconds"]
+    else:
+        # Same window: expires_in should be monotonic (later call = lower-or-equal)
+        assert r2.json()["expires_in_seconds"] <= r1.json()["expires_in_seconds"]
+
+
+def test_generate_totp_requires_auth(client: TestClient) -> None:
+    app = client.app
+    unauth = TestClient(app)
+
+    resp = unauth.post("/api/v2/password_vault/github/totp", json={})
+
+    assert resp.status_code == 401

--- a/tests/integration/test_password_vault_api.py
+++ b/tests/integration/test_password_vault_api.py
@@ -268,3 +268,65 @@ def test_title_length_cap_rejects_at_1025_chars(client: TestClient) -> None:
     )
     assert resp.status_code == 400
     assert "too long" in resp.json()["detail"].lower()
+
+
+# ---------------------------------------------------------------------------
+# access_context query params (audit observability, Ask 1 of spec v3)
+# ---------------------------------------------------------------------------
+
+
+def test_get_entry_accepts_access_context_query_params(client: TestClient) -> None:
+    client.put("/api/v2/password_vault/github", json=_sample_body())
+
+    for ctx in ("admin_cli", "auto_login", "auto_rotate", "reveal_approved", "agent_direct"):
+        resp = client.get(
+            f"/api/v2/password_vault/github"
+            f"?access_context={ctx}&client_id=sudowork&agent_session=s-1"
+        )
+        assert resp.status_code == 200, f"{ctx}: {resp.status_code} {resp.text}"
+        assert resp.json()["title"] == "github"
+
+
+def test_get_entry_without_access_context_still_works(client: TestClient) -> None:
+    """Backwards compat: omitting access_context must behave exactly as before."""
+    client.put("/api/v2/password_vault/github", json=_sample_body())
+
+    resp = client.get("/api/v2/password_vault/github")
+
+    assert resp.status_code == 200
+    assert resp.json()["title"] == "github"
+
+
+def test_get_entry_rejects_unknown_access_context(client: TestClient) -> None:
+    client.put("/api/v2/password_vault/github", json=_sample_body())
+
+    resp = client.get("/api/v2/password_vault/github?access_context=bogus_value")
+
+    assert resp.status_code == 400
+    assert "bogus_value" in resp.json()["detail"]
+
+
+def test_list_entries_accepts_access_context_query_params(client: TestClient) -> None:
+    client.put("/api/v2/password_vault/github", json=_sample_body())
+
+    resp = client.get("/api/v2/password_vault?access_context=auto_login&client_id=sudowork")
+
+    assert resp.status_code == 200
+    assert resp.json()["count"] == 1
+
+
+def test_list_entries_rejects_unknown_access_context(client: TestClient) -> None:
+    resp = client.get("/api/v2/password_vault?access_context=not_a_real_value")
+
+    assert resp.status_code == 400
+
+
+def test_get_entry_with_version_query_and_access_context(client: TestClient) -> None:
+    """Query params compose: ?version=N coexists with access_context."""
+    client.put("/api/v2/password_vault/github", json=_sample_body(password="v1"))
+    client.put("/api/v2/password_vault/github", json=_sample_body(password="v2"))
+
+    resp = client.get("/api/v2/password_vault/github?version=1&access_context=admin_cli")
+
+    assert resp.status_code == 200
+    assert resp.json()["password"] == "v1"

--- a/tests/unit/services/test_password_vault_service.py
+++ b/tests/unit/services/test_password_vault_service.py
@@ -20,7 +20,9 @@ import pytest
 from nexus.contracts.secrets_access import AccessAuditContext
 from nexus.services.password_vault.schema import VaultEntry
 from nexus.services.password_vault.service import (
+    TOTP_PERIOD_SECONDS,
     PasswordVaultService,
+    TotpNotConfiguredError,
     VaultEntryNotFoundError,
 )
 
@@ -321,3 +323,158 @@ class TestAccessAuditContext:
             "client_id": "sudowork-ui",
             "agent_session": "abc-123",
         }
+
+
+# ---------------------------------------------------------------------------
+# generate_totp (Ask 2)
+# ---------------------------------------------------------------------------
+
+
+# RFC 6238 test vector: at t = 59 (window 1), secret "JBSWY3DPEHPK3PXP" has
+# a stable 6-digit TOTP. We pick a time that makes the cache math easy.
+_TOTP_SECRET = "JBSWY3DPEHPK3PXP"
+
+
+class TestGenerateTotp:
+    def test_returns_code_and_window_metadata(
+        self, vault: PasswordVaultService, secrets: MagicMock
+    ) -> None:
+        entry = _sample_entry(totp_secret=_TOTP_SECRET)
+        secrets.get_secret.return_value = {
+            "value": json.dumps(entry.model_dump()),
+            "version": 1,
+        }
+
+        # t = 90s → window 3, 0s into window → expires_in = 30
+        result = vault.generate_totp("github", now=90.0)
+
+        assert result is not None
+        assert set(result.keys()) == {"code", "expires_in_seconds", "period_seconds"}
+        assert result["period_seconds"] == 30
+        assert result["expires_in_seconds"] == 30
+        assert isinstance(result["code"], str) and len(result["code"]) == 6
+
+    def test_forwards_totp_audit_event_type(
+        self, vault: PasswordVaultService, secrets: MagicMock
+    ) -> None:
+        entry = _sample_entry(totp_secret=_TOTP_SECRET)
+        secrets.get_secret.return_value = {
+            "value": json.dumps(entry.model_dump()),
+            "version": 1,
+        }
+
+        vault.generate_totp("github", now=0.0)
+
+        # TOTP must NOT share audit channel with entry reads.
+        assert secrets.get_secret.call_args.kwargs["audit_event_type"] == "totp_generated"
+
+    def test_forwards_audit_context(self, vault: PasswordVaultService, secrets: MagicMock) -> None:
+        entry = _sample_entry(totp_secret=_TOTP_SECRET)
+        secrets.get_secret.return_value = {
+            "value": json.dumps(entry.model_dump()),
+            "version": 1,
+        }
+        ctx = AccessAuditContext(access_context="auto_login", client_id="sudowork")
+
+        vault.generate_totp("github", now=0.0, audit_context=ctx)
+
+        assert secrets.get_secret.call_args.kwargs["audit_context"] is ctx
+
+    def test_missing_entry_returns_none(
+        self, vault: PasswordVaultService, secrets: MagicMock
+    ) -> None:
+        secrets.get_secret.return_value = None
+
+        assert vault.generate_totp("nonexistent") is None
+
+    def test_entry_without_totp_secret_raises(
+        self, vault: PasswordVaultService, secrets: MagicMock
+    ) -> None:
+        entry = _sample_entry(totp_secret=None)
+        secrets.get_secret.return_value = {
+            "value": json.dumps(entry.model_dump()),
+            "version": 1,
+        }
+
+        with pytest.raises(TotpNotConfiguredError):
+            vault.generate_totp("github")
+
+    def test_empty_totp_secret_raises(
+        self, vault: PasswordVaultService, secrets: MagicMock
+    ) -> None:
+        entry = _sample_entry(totp_secret="")
+        secrets.get_secret.return_value = {
+            "value": json.dumps(entry.model_dump()),
+            "version": 1,
+        }
+
+        with pytest.raises(TotpNotConfiguredError):
+            vault.generate_totp("github")
+
+    def test_cache_returns_same_code_within_window(
+        self, vault: PasswordVaultService, secrets: MagicMock
+    ) -> None:
+        entry = _sample_entry(totp_secret=_TOTP_SECRET)
+        secrets.get_secret.return_value = {
+            "value": json.dumps(entry.model_dump()),
+            "version": 1,
+        }
+
+        # Two calls in the same 30s window — same subject, same title
+        r1 = vault.generate_totp("github", now=90.0, subject_id="alice")
+        r2 = vault.generate_totp("github", now=115.0, subject_id="alice")  # still window 3
+
+        assert r1 is not None and r2 is not None
+        assert r1["code"] == r2["code"]
+        # expires_in_seconds should tick down across the window
+        assert r1["expires_in_seconds"] == TOTP_PERIOD_SECONDS
+        assert r2["expires_in_seconds"] == 5
+
+    def test_cache_recomputes_across_windows(
+        self, vault: PasswordVaultService, secrets: MagicMock
+    ) -> None:
+        entry = _sample_entry(totp_secret=_TOTP_SECRET)
+        secrets.get_secret.return_value = {
+            "value": json.dumps(entry.model_dump()),
+            "version": 1,
+        }
+
+        r1 = vault.generate_totp("github", now=0.0, subject_id="alice")  # window 0
+        r2 = vault.generate_totp("github", now=30.0, subject_id="alice")  # window 1
+
+        assert r1 is not None and r2 is not None
+        # Different windows → almost always different codes. (Collision
+        # across adjacent windows is ~1 in 1e6; fine for deterministic vector.)
+        assert r1["code"] != r2["code"]
+
+    def test_cache_is_per_subject(self, vault: PasswordVaultService, secrets: MagicMock) -> None:
+        entry = _sample_entry(totp_secret=_TOTP_SECRET)
+        secrets.get_secret.return_value = {
+            "value": json.dumps(entry.model_dump()),
+            "version": 1,
+        }
+
+        vault.generate_totp("github", now=0.0, subject_id="alice")
+        vault.generate_totp("github", now=0.0, subject_id="bob")
+
+        # Both subjects share the same TOTP value (same secret + window), but
+        # cache entries are keyed separately so get_secret is called once per
+        # (subject, window) combination.
+        assert secrets.get_secret.call_count == 2
+
+    def test_prune_drops_stale_windows(
+        self, vault: PasswordVaultService, secrets: MagicMock
+    ) -> None:
+        entry = _sample_entry(totp_secret=_TOTP_SECRET)
+        secrets.get_secret.return_value = {
+            "value": json.dumps(entry.model_dump()),
+            "version": 1,
+        }
+
+        vault.generate_totp("github", now=0.0, subject_id="alice")  # window 0
+        assert len(vault._totp_cache) == 1
+
+        vault.generate_totp("github", now=90.0, subject_id="alice")  # window 3
+        # Stale window-0 entry should be pruned when window-3 is inserted.
+        assert len(vault._totp_cache) == 1
+        assert all(k[2] == 3 for k in vault._totp_cache)

--- a/tests/unit/services/test_password_vault_service.py
+++ b/tests/unit/services/test_password_vault_service.py
@@ -17,6 +17,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
+from nexus.contracts.secrets_access import AccessAuditContext
 from nexus.services.password_vault.schema import VaultEntry
 from nexus.services.password_vault.service import (
     PasswordVaultService,
@@ -242,3 +243,81 @@ class TestLifecycle:
         assert kwargs["namespace"] == "passwords"
         assert kwargs["key"] == "github"
         assert kwargs["subject_id"] == "alice"
+
+
+# ---------------------------------------------------------------------------
+# AccessAuditContext propagation
+# ---------------------------------------------------------------------------
+
+
+class TestAuditContextPropagation:
+    def test_get_entry_forwards_audit_context(
+        self, vault: PasswordVaultService, secrets: MagicMock
+    ) -> None:
+        secrets.get_secret.return_value = {
+            "value": json.dumps({"title": "github"}),
+            "version": 1,
+        }
+        ctx = AccessAuditContext(
+            access_context="auto_login", client_id="sudowork", agent_session="s-42"
+        )
+
+        vault.get_entry("github", audit_context=ctx)
+
+        assert secrets.get_secret.call_args.kwargs["audit_context"] is ctx
+
+    def test_get_entry_without_audit_context_passes_none(
+        self, vault: PasswordVaultService, secrets: MagicMock
+    ) -> None:
+        secrets.get_secret.return_value = {
+            "value": json.dumps({"title": "x"}),
+            "version": 1,
+        }
+
+        vault.get_entry("x")
+
+        assert secrets.get_secret.call_args.kwargs["audit_context"] is None
+
+    def test_list_entries_forwards_audit_context_to_batch_get(
+        self, vault: PasswordVaultService, secrets: MagicMock
+    ) -> None:
+        secrets.list_secrets.return_value = [{"key": "github", "namespace": "passwords"}]
+        secrets.batch_get.return_value = {
+            "passwords:github": json.dumps({"title": "github"}),
+        }
+        ctx = AccessAuditContext(access_context="reveal_approved")
+
+        vault.list_entries(audit_context=ctx)
+
+        assert secrets.batch_get.call_args.kwargs["audit_context"] is ctx
+
+
+# ---------------------------------------------------------------------------
+# AccessAuditContext value object
+# ---------------------------------------------------------------------------
+
+
+class TestAccessAuditContext:
+    def test_default_access_context_is_admin_cli(self) -> None:
+        ctx = AccessAuditContext()
+
+        assert ctx.access_context == "admin_cli"
+        assert ctx.to_audit_details() == {"access_context": "admin_cli"}
+
+    def test_to_audit_details_omits_none_fields(self) -> None:
+        ctx = AccessAuditContext(access_context="auto_login")
+
+        assert ctx.to_audit_details() == {"access_context": "auto_login"}
+
+    def test_to_audit_details_includes_all_when_set(self) -> None:
+        ctx = AccessAuditContext(
+            access_context="reveal_approved",
+            client_id="sudowork-ui",
+            agent_session="abc-123",
+        )
+
+        assert ctx.to_audit_details() == {
+            "access_context": "reveal_approved",
+            "client_id": "sudowork-ui",
+            "agent_session": "abc-123",
+        }


### PR DESCRIPTION
## Summary

Implements both Asks from `spec-nexus-reveal-context v3` (password-agent → nexus cross-repo spec, reviewed 2026-04-22). Two commits, one PR, no migrations.

- **Ask 1** — `access_context` / `client_id` / `agent_session` query params on credential-read endpoints land in the `secrets_audit_log` details JSON so operators can distinguish admin-CLI reads from agent auto-login / auto-rotate / reveal-approved flows. Typed `Literal` enum in `nexus.contracts.secrets_access`; unknown values rejected with 400. Omitting defaults to `admin_cli` → pre-existing clients unchanged.
- **Ask 2** — `POST /api/v2/password_vault/{title}/totp` computes the RFC 6238 code server-side so `totp_secret` never leaves nexus. Per-`(subject, title, window_index)` 30s oracle cache, stale-window pruning on insert. Distinct `totp_generated` audit event, separate from `key_accessed`. 404 for missing/unauthorized, 422 for `totp_not_configured` (per spec disambiguation).

Architecture note: `PasswordVaultService` is a `services/` wrapper over the `secrets` brick (`NAMESPACE = "passwords"`). Both Asks land in `nexus.contracts.secrets_access` so they're importable from bricks and services without tier violation. Future per-namespace ACL work on `SecretsService` (related to #3829) will cover password_vault automatically — no parallel ACL track needed.

## Changes

- `src/nexus/contracts/secrets_access.py` *(new)* — `AccessContext` Literal + `AccessAuditContext` frozen dataclass
- `src/nexus/bricks/secrets/service.py` — `get_secret` / `batch_get` accept `audit_context`; `get_secret` also gains `audit_event_type` so callers can repurpose the audit channel
- `src/nexus/services/password_vault/service.py` — threads `audit_context` on reads; adds `generate_totp()` + `TotpNotConfiguredError` + oracle cache
- `src/nexus/server/api/v2/routers/password_vault.py` — `GET /{title}` + `GET /` accept query params; new `POST /{title}/totp` with `TotpRequest` body
- `src/nexus/storage/models/secrets_audit_log.py` — `SecretsAuditEventType.TOTP_GENERATED` (enum addition only; 15 chars fits existing `String(30)` column)
- `pyproject.toml` — `pyotp>=2.9.0` (stdlib has no RFC 6238; pyotp is 50KB pure-Python, already in password-agent's dep tree)
- Tests: 11 new unit (`test_password_vault_service.py`) + 12 new integration (`test_password_vault_api.py`)

## Spec / cross-repo context

- Spec v3: `elfenlieds7/password-agent/docs/spec-nexus-reveal-context.md` (commit `ea39b80`), reviewed & green-lit 2026-04-22.
- Downstream consumers: password-agent Tier-1 auto-login, sudowork's `pwd_login` Phase-1.

## Test plan

- [ ] CI: existing `test_password_vault_service.py` + `test_password_vault_api.py` suites stay green.
- [ ] CI: new `TestGenerateTotp` / `TestAuditContextPropagation` / `TestAccessAuditContext` unit classes pass.
- [ ] CI: new integration tests (`test_generate_totp_*`, `test_get_entry_accepts_access_context_*`, etc.) pass.
- [ ] Manual: `pre-commit run --all-files` ran clean locally (ruff, ruff-format, mypy, check-type-ignore, brick-layering).
- [ ] Manual: password-agent / sudowork can point at dev nexusd and exercise the new endpoint end-to-end (follow-up, not blocking this PR).

## Not in scope (flagged)

- `list_versions` endpoint doesn't accept `access_context` — the underlying `SecretsService.list_versions` doesn't audit today. Adding a `versions_listed` event is scope-creep vs this spec and should land as a separate PR if desired.
- Per-subject ACL on `SecretsService` (the real security fix for the loopback-trust model described in spec v3's threat-model section) is tracked separately (see #3829). This PR is observability only.