### PR TITLE
refactor(#1817): eliminate Python glue — dead code, redundant IPC dispatch, VFS bypass

### DIFF
--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -195,6 +195,9 @@ Lock operations are consolidated into two syscalls (POSIX `fcntl(F_SETLK)` patte
 
 - **Mutating syscalls** (write, unlink, rename, rmdir): full pipeline — VFSRouter →
   VFSLock → KernelDispatch (3-phase) → Metastore → FileEvent
+- **DT_PIPE / DT_STREAM I/O**: Rust dcache detects entry_type early in sys_read/sys_write
+  and dispatches to PipeManager/StreamManager inline — no VFS lock, no metastore update,
+  no observer dispatch (matching Linux `write(2)` on a pipe not triggering inotify)
 - **Read**: same pipeline minus FileEvent (reads are not mutations)
 - **Read-only metadata** (stat, access, readdir, is_directory): direct Metastore
   lookup only — no routing, locking, or dispatch

--- a/src/nexus/bricks/search/skeleton_pipe_consumer.py
+++ b/src/nexus/bricks/search/skeleton_pipe_consumer.py
@@ -189,11 +189,9 @@ class SkeletonPipeConsumer:
             while self._write_buffer:
                 data = self._write_buffer.popleft()
                 try:
-                    # pipe_write_nowait bypasses sys_write's metastore check — the
-                    # skeleton pipe is registered in the Rust kernel by pipe_create()
-                    # but does not have a Python metastore entry, so sys_write raises
-                    # NexusFileNotFoundError.
-                    nx.pipe_write_nowait(_SKELETON_PIPE_PATH, data)
+                    # sys_write routes to Rust dcache for DT_PIPE — no Python
+                    # metastore entry needed (Rust handles inline).
+                    nx.sys_write(_SKELETON_PIPE_PATH, data)
                 except Exception:
                     logger.warning("[SKELETON] pipe write failed, dropping event")
             await asyncio.sleep(0.01)  # 10ms poll
@@ -203,10 +201,11 @@ class SkeletonPipeConsumer:
     # ------------------------------------------------------------------
 
     async def _consume(self) -> None:
-        # Use pipe_read_nowait (polling) instead of sys_read — the skeleton pipe is
-        # registered in the Rust kernel by pipe_create() but has no Python metastore
-        # entry, so sys_read would raise NexusFileNotFoundError on every call.
-        # pipe_read_nowait returns None on empty and raises NexusFileNotFoundError
+        # Use pipe_read_nowait (polling) instead of sys_read — sys_read blocks
+        # for up to 5s when the pipe is empty, which would block the asyncio
+        # event loop. pipe_read_nowait returns None immediately on empty,
+        # allowing cooperative polling with asyncio.sleep.
+        # pipe_read_nowait raises NexusFileNotFoundError
         # when the pipe is destroyed (stop() signal).
         from nexus.contracts.exceptions import NexusFileNotFoundError
 

--- a/src/nexus/bricks/task_manager/dispatch_consumer.py
+++ b/src/nexus/bricks/task_manager/dispatch_consumer.py
@@ -8,7 +8,7 @@ Flow::
 
     TaskWriteHook.on_post_write() [sync, kernel dispatch]
       → TaskDispatchPipeConsumer.on_task_signal(signal_type, payload)
-        → JSON → pipe_write_nowait("/nexus/pipes/task-dispatch")
+        → JSON → sys_write("/nexus/pipes/task-dispatch")
 
     Background _consume() [asyncio.Task]
       → pipe_read() → JSON → _dispatch()

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -644,25 +644,6 @@ class NexusFS(  # type: ignore[misc]
 
     # ── IPC primitives (inlined from IPCMixin) ─────────────────────────
 
-    def _pipe_read(self, path: str, *, count: int | None = None, offset: int = 0) -> bytes:
-        """Read from DT_PIPE — nowait hot path + Rust blocking slow path (GIL-free)."""
-        # Hot path: try nowait first (zero GIL)
-        _data = self._kernel.pipe_read_nowait(path)
-        if _data is not None:
-            if offset or count is not None:
-                _data = _data[offset : offset + count] if count is not None else _data[offset:]
-            return bytes(_data)
-
-        # Slow path: block in Rust (GIL released by PyO3), 5s timeout
-        _data = self._kernel.pipe_read_blocking(path, 5000)
-        if offset or count is not None:
-            _data = _data[offset : offset + count] if count is not None else _data[offset:]
-        return bytes(_data)
-
-    def _pipe_write(self, path: str, data: bytes) -> int:
-        """Write to DT_PIPE — non-blocking via Rust kernel (condvar wakes readers)."""
-        return self._kernel.pipe_write_nowait(path, data)
-
     def _pipe_destroy(self, path: str) -> dict[str, Any]:
         """Destroy DT_PIPE — close Rust buffer."""
 
@@ -686,13 +667,6 @@ class NexusFS(  # type: ignore[misc]
         Sync passthrough to ``Kernel.pipe_read_nowait``.
         """
         return self._kernel.pipe_read_nowait(path)
-
-    def pipe_write_nowait(self, path: str, data: bytes) -> int:
-        """Non-blocking pipe write. Returns bytes written.
-
-        Sync passthrough to ``Kernel.pipe_write_nowait``.
-        """
-        return self._kernel.pipe_write_nowait(path, data)
 
     def pipe_create(self, path: str, capacity: int = 65_536) -> None:
         """Create a DT_PIPE in the kernel registry.

--- a/src/nexus/core/nexus_fs_content.py
+++ b/src/nexus/core/nexus_fs_content.py
@@ -37,6 +37,13 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+def _apply_slice(data: bytes, offset: int = 0, count: int | None = None) -> bytes:
+    """Apply POSIX pread-style offset/count slicing."""
+    if offset or count is not None:
+        return data[offset : offset + count] if count is not None else data[offset:]
+    return data
+
+
 class ContentMixin:
     """Content I/O: sys_read, sys_write, and Tier 2 convenience methods."""
 
@@ -74,9 +81,9 @@ class ContentMixin:
     ) -> bytes:
         """Read file content as bytes (POSIX pread(2)).
 
-        Thin async wrapper around Rust Kernel.sys_read (pure Rust, zero GIL).
-        DT_PIPE/DT_STREAM, resolve, and hooks are [TRANSITIONAL] — migrates
-        to Rust dispatch middleware in PR 7.
+        Rust Kernel.sys_read handles DT_REG (CAS read), DT_PIPE (ring buffer
+        pop), DT_STREAM (cursor read), and external connector dispatch.
+        Python handles resolve (intercept), POST-hooks, and offset/count slicing.
         """
         # DT_PIPE/DT_STREAM: Rust IPC registry handles all backends
         # (memory, SHM, remote) via PipeManager/StreamManager.
@@ -85,12 +92,7 @@ class ContentMixin:
         context = self._parse_context(context)
         _handled, _resolve_hint = self.resolve_read(path, context=context)
         if _handled:
-            content = _resolve_hint or b""
-            if offset or count is not None:
-                content = (
-                    content[offset : offset + count] if count is not None else content[offset:]
-                )
-            return content
+            return _apply_slice(_resolve_hint or b"", offset, count)
 
         _is_admin = (
             getattr(context, "is_admin", False)
@@ -150,9 +152,7 @@ class ContentMixin:
                         data = _virtual_data
                     else:
                         data = _route_backend.read_content(_route_backend_path, context=_ctx)
-                    if offset or count is not None:
-                        data = data[offset : offset + count] if count is not None else data[offset:]
-                    return data
+                    return _apply_slice(data, offset, count)
                 except Exception:
                     if isinstance(_route, ExternalRouteResult):
                         raise
@@ -160,20 +160,13 @@ class ContentMixin:
         # DT_PIPE: result.data is the popped frame when available; None = empty.
         if result.entry_type == 3:  # DT_PIPE
             if result.data is not None:
-                data = result.data
-                if offset or count is not None:
-                    data = data[offset : offset + count] if count is not None else data[offset:]
-                return data
+                return _apply_slice(result.data, offset, count)
             # Empty pipe — try nowait (hot path), then block in Rust (GIL-free)
             _data = self._kernel.pipe_read_nowait(path)
             if _data is not None:
-                if offset or count is not None:
-                    _data = _data[offset : offset + count] if count is not None else _data[offset:]
-                return bytes(_data)
+                return _apply_slice(bytes(_data), offset, count)
             _data = self._kernel.pipe_read_blocking(path, 5000)
-            if offset or count is not None:
-                _data = _data[offset : offset + count] if count is not None else _data[offset:]
-            return bytes(_data)
+            return _apply_slice(bytes(_data), offset, count)
 
         # DT_STREAM: blocking reads with offset tracking
         if result.entry_type == 4:  # DT_STREAM
@@ -185,10 +178,7 @@ class ContentMixin:
             return bytes(_data)
 
         # DT_REG: Rust guarantees data is set on success.
-        data = result.data or b""
-
-        if offset or count is not None:
-            data = data[offset : offset + count] if count is not None else data[offset:]
+        data = _apply_slice(result.data or b"", offset, count)
 
         # POST-INTERCEPT: hooks dispatched via Rust dispatch_post_hooks
         if result.post_hook_needed:
@@ -777,9 +767,9 @@ class ContentMixin:
     ) -> dict[str, Any]:
         """Write content to a file (POSIX write(2)).
 
-        Thin async wrapper around Rust Kernel.sys_write (CAS I/O is pure Rust,
-        zero GIL). Metastore.put stays in Python [TRANSITIONAL] — migrates to
-        Rust metastore in PR 7.
+        Rust Kernel.sys_write handles DT_PIPE/DT_STREAM (ring buffer push),
+        DT_REG (CAS write + metastore.put + dcache update + observer dispatch).
+        Python handles resolve (intercept), POST-hook dispatch, and event emission.
         """
         # Normalize input
         if isinstance(buf, str):
@@ -787,7 +777,6 @@ class ContentMixin:
         if count is not None:
             buf = buf[:count]
 
-        # [TRANSITIONAL] PRE-DISPATCH: resolve — migrates to Rust dispatch middleware in PR 7
         context = self._parse_context(context)
 
         # Virtual .readme/ paths are read-only (Issue #3728).
@@ -800,21 +789,10 @@ class ContentMixin:
                 base.update(_result)
             return base
 
-        # IPC write: Rust kernel handles DT_PIPE/DT_STREAM inline.
-        # Rust condvar wakes blocked readers automatically after write.
+        # Snapshot old metadata BEFORE Rust write (for POST-hook event payload).
         _meta = self.metadata.get(path)
-        if _meta is not None and _meta.is_pipe:
-            n = self._kernel.pipe_write_nowait(path, buf)
-            return {"path": path, "bytes_written": n}
-        if _meta is not None and _meta.is_stream:
-            _off = self._kernel.stream_write_nowait(path, buf)
-            return {"path": path, "bytes_written": len(buf), "offset": _off}
-        if _meta is None:
-            raise NexusFileNotFoundError(
-                path, "sys_write requires existing file — use write() for create-on-write"
-            )
 
-        # ── KERNEL (pure Rust CAS write, zero GIL) ──
+        # ── KERNEL (pure Rust — DT_PIPE/DT_STREAM via dcache, DT_REG via CAS, zero GIL) ──
         _is_admin = (
             getattr(context, "is_admin", False)
             if context is not None and not isinstance(context, dict)
@@ -822,6 +800,10 @@ class ContentMixin:
         )
         _rust_ctx = self._build_rust_ctx(context, _is_admin)
         result = self._kernel.sys_write(path, _rust_ctx, buf, offset)
+
+        # DT_PIPE / DT_STREAM: Rust handled inline (no content_id, no post-hooks)
+        if result.hit and not result.content_id:
+            return {"path": path, "bytes_written": len(buf)}
 
         if result.hit:
             # Rust wrote to backend (CAS or PAS) + built metadata + updated dcache

--- a/src/nexus/core/nexus_fs_metadata.py
+++ b/src/nexus/core/nexus_fs_metadata.py
@@ -492,21 +492,9 @@ class MetadataMixin:
                     self._ensure_parent_directories(path, ctx)
                 return
 
-        # PRE-INTERCEPT hooks via Rust kernel
+        # Rust kernel: backend.mkdir + ensure_parent_directories + DT_DIR metadata + dcache
         _rust_ctx = self._build_rust_ctx(ctx, ctx.is_admin)
         _mkdir_result = self._kernel.sys_mkdir(path, _rust_ctx, parents, exist_ok)
-
-        # Python always does metastore + backend (authoritative metadata with timestamps/backend_key)
-        route.backend.mkdir(route.backend_path, parents=parents, exist_ok=True, context=ctx)
-
-        if parents:
-            self._ensure_parent_directories(path, ctx)
-
-        self._kernel.sys_setattr(
-            path,
-            DT_DIR,
-            zone_id=ctx.zone_id or ROOT_ZONE_ID,
-        )
 
         # OBSERVE: Rust kernel fires DirCreate when hit=true (§11 Phase 5).
         # Only Python fires for the fallback path.

--- a/src/nexus/services/lifecycle/workflow_dispatch_service.py
+++ b/src/nexus/services/lifecycle/workflow_dispatch_service.py
@@ -70,7 +70,7 @@ class WorkflowDispatchService:
     # ------------------------------------------------------------------
 
     def _fire_sync(self, trigger_type: str, event_context: dict[str, Any], label: str) -> None:
-        """Sync dispatch: pipe_write_nowait + fire-and-forget async work."""
+        """Sync dispatch: sys_write to DT_PIPE + fire-and-forget async work."""
         if not (self._enable_workflows and self._workflow_engine):
             return
 
@@ -79,7 +79,7 @@ class WorkflowDispatchService:
         if self._nx is not None and self._pipe_ready:
             try:
                 data = json.dumps({"type": trigger_type, "ctx": event_context}).encode()
-                self._nx.pipe_write_nowait(_WORKFLOW_PIPE_PATH, data)
+                self._nx.sys_write(_WORKFLOW_PIPE_PATH, data)
             except (PipeClosedError, PipeFullError):
                 logger.warning("Workflow pipe full/closed, dropping event: %s", label)
         else:
@@ -111,7 +111,7 @@ class WorkflowDispatchService:
     async def fire(self, trigger_type: str, event_context: dict[str, Any], label: str) -> None:
         """Async fire for direct callers (not from OBSERVE path).
 
-        Uses Rust kernel pipe_write_nowait — never touches Python backends directly.
+        Uses sys_write to DT_PIPE — routes through Rust kernel ring buffer.
         """
         if not (self._enable_workflows and self._workflow_engine):
             return
@@ -119,7 +119,7 @@ class WorkflowDispatchService:
         if self._nx is not None and self._pipe_ready:
             try:
                 data = json.dumps({"type": trigger_type, "ctx": event_context}).encode()
-                self._nx.pipe_write_nowait(_WORKFLOW_PIPE_PATH, data)
+                self._nx.sys_write(_WORKFLOW_PIPE_PATH, data)
             except Exception:
                 logger.warning("Workflow pipe full/closed, dropping event: %s", label)
         else:

--- a/src/nexus/storage/write_observer_hooks.py
+++ b/src/nexus/storage/write_observer_hooks.py
@@ -1,8 +1,8 @@
-"""Audit interceptor: serialize VFS mutations → DT_PIPE via NexusFS Tier 2 API.
+"""Audit interceptor: serialize VFS mutations → DT_PIPE via sys_write.
 
 Sync VFS interceptor hook that serializes each mutation event to JSON
-and writes it into the audit DT_PIPE via ``nx.pipe_write_nowait()``
-(Tier 2 sync passthrough to the Rust kernel ring buffer, ~0.5μs).
+and writes it into the audit DT_PIPE via ``nx.sys_write()``
+(Rust kernel routes DT_PIPE writes through dcache ring buffer, ~0.5μs).
 The pipe is consumed by ``RecordStoreWriteObserver`` which flushes
 events to RecordStore in batches.
 
@@ -276,10 +276,9 @@ class AuditWriteInterceptor:
     def _emit(self, event: dict[str, Any], operation: str, op_path: str) -> None:
         """Serialize event to JSON and write directly to the Rust pipe buffer (~0.5μs).
 
-        Writes via ``NexusFS.pipe_write_nowait()`` — Tier 2 sync passthrough
-        to the Rust kernel ring buffer. Synchronous and non-blocking, so
-        this hook does not re-trigger post-write hooks (which would cause
-        a recursive sys_write loop and 5s timeout per write).
+        Uses ``sys_write`` which routes to the Rust kernel ring buffer for
+        DT_PIPE entries. Rust skips observer dispatch for DT_PIPE, so this
+        hook does not re-trigger post-write hooks (no recursion).
 
         If the pipe buffer is closed/missing (startup race or kernel
         teardown), the event is dropped with a warning.
@@ -287,9 +286,9 @@ class AuditWriteInterceptor:
         try:
             data = json.dumps(event).encode()
 
-            # Fast path: kernel ring buffer write (~0.5μs, no GIL re-entry).
+            # Fast path: kernel ring buffer write via VFS (~0.5μs, no GIL re-entry).
             try:
-                self._nx.pipe_write_nowait(self._pipe_path, data)
+                self._nx.sys_write(self._pipe_path, data)
                 return
             except Exception:
                 # Pipe not ready (startup race) or closed — fall through to drop.

--- a/src/nexus/task_manager/dispatch_consumer.py
+++ b/src/nexus/task_manager/dispatch_consumer.py
@@ -8,7 +8,7 @@ Flow::
 
     TaskWriteHook.on_post_write() [sync, kernel dispatch]
       → TaskDispatchPipeConsumer.on_task_signal(signal_type, payload)
-        → JSON → pipe_write_nowait("/nexus/pipes/task-dispatch")
+        → JSON → sys_write("/nexus/pipes/task-dispatch")
 
     Background _consume() [asyncio.Task]
       → pipe_read() → JSON → _dispatch()
@@ -118,13 +118,13 @@ class TaskDispatchPipeConsumer:
     # ------------------------------------------------------------------
 
     def on_task_signal(self, signal_type: str, payload: dict[str, Any]) -> None:
-        """Serialize signal and write to pipe (non-blocking)."""
+        """Serialize signal and write to pipe via sys_write (non-blocking for DT_PIPE)."""
         if self._nx is None or not self._pipe_ready:
             return
 
         try:
             data = json.dumps({"type": signal_type, "payload": payload}).encode()
-            self._nx.pipe_write_nowait(_TASK_DISPATCH_PIPE_PATH, data)
+            self._nx.sys_write(_TASK_DISPATCH_PIPE_PATH, data)
         except Exception:
             logger.warning("[TASK-DISPATCH] pipe full/closed, dropping signal: %s", signal_type)
 

--- a/tests/unit/server/test_rpc_parity.py
+++ b/tests/unit/server/test_rpc_parity.py
@@ -256,7 +256,6 @@ def test_all_public_methods_are_exposed_or_excluded():
         "pipe_close",  # Tier 2 → kernel.close_pipe (local-only)
         "pipe_destroy",  # Tier 2 → kernel.destroy_pipe (local-only)
         "pipe_read_nowait",  # Tier 2 → kernel.pipe_read_nowait (local-only)
-        "pipe_write_nowait",  # Tier 2 → kernel.pipe_write_nowait (local-only)
         "has_pipe",  # Tier 2 → kernel.has_pipe (local-only)
         "stream_create",  # Tier 2 → kernel.create_stream (local-only)
         "stream_close",  # Tier 2 → kernel.close_stream (local-only)

--- a/tests/unit/services/test_workflow_dispatch.py
+++ b/tests/unit/services/test_workflow_dispatch.py
@@ -24,15 +24,15 @@ _WORKFLOW_PIPE_PATH = "/nexus/pipes/workflow-events"
 
 
 def _make_mock_nx() -> MagicMock:
-    """Create a mock NexusFS exposing the public Tier 2 pipe API.
+    """Create a mock NexusFS exposing VFS pipe API.
 
-    Production code calls ``self._nx.pipe_write_nowait`` /
-    ``self._nx.pipe_close`` (sync passthroughs to the Rust kernel) and
-    ``self._nx.sys_setattr`` / ``self._nx.sys_read`` (sync).
+    Production code calls ``self._nx.sys_write`` (DT_PIPE routes through
+    Rust dcache) / ``self._nx.pipe_close`` and ``self._nx.sys_setattr`` /
+    ``self._nx.sys_read`` (sync).
     """
     nx = MagicMock()
     # Sync passthrough methods
-    nx.pipe_write_nowait = MagicMock()
+    nx.sys_write = MagicMock(return_value={"path": _WORKFLOW_PIPE_PATH, "bytes_written": 0})
     nx.pipe_close = MagicMock()
     # Sync syscalls — NexusFS methods are sync def
     nx.sys_setattr = MagicMock(return_value={"path": _WORKFLOW_PIPE_PATH, "created": True})
@@ -63,15 +63,15 @@ def _make_service(
 class TestFire:
     @pytest.mark.asyncio
     async def test_writes_to_pipe(self) -> None:
-        """Event should be serialized and written to kernel pipe via pipe_write_nowait."""
+        """Event should be serialized and written to kernel pipe via sys_write."""
         svc, nx = _make_service()
         await svc.start()
 
         await svc.fire("file_write", {"path": "/foo.txt"}, "file_write:/foo.txt")
 
-        # Verify kernel.pipe_write_nowait was called with serialized data
-        nx.pipe_write_nowait.assert_called_once()
-        call_args = nx.pipe_write_nowait.call_args
+        # Verify sys_write was called with serialized data
+        nx.sys_write.assert_called_once()
+        call_args = nx.sys_write.call_args
         assert call_args[0][0] == _WORKFLOW_PIPE_PATH
         msg = json.loads(call_args[0][1])
         assert msg["type"] == "file_write"
@@ -85,8 +85,8 @@ class TestFire:
         svc, nx = _make_service()
         await svc.start()
 
-        # Make pipe_write_nowait raise to simulate full pipe
-        nx.pipe_write_nowait.side_effect = RuntimeError("PipeFull: buffer full")
+        # Make sys_write raise to simulate full pipe
+        nx.sys_write.side_effect = RuntimeError("PipeFull: buffer full")
 
         # Should not raise
         await svc.fire("file_write", {"path": "/big.txt"}, "file_write:/big.txt")
@@ -119,8 +119,8 @@ class TestFire:
         await svc.start()
 
         await svc.fire("file_write", {"path": "/z"}, "file_write:/z")
-        # Kernel pipe_write_nowait should NOT be called
-        nx.pipe_write_nowait.assert_not_called()
+        # sys_write should NOT be called
+        nx.sys_write.assert_not_called()
 
         await svc.stop()
 


### PR DESCRIPTION
## Summary

Eliminate residual Python glue code that duplicates what Rust kernel already does:

- **Phase 1 — sys_mkdir**: Delete 11 lines of dead code (Python `backend.mkdir()` + `_ensure_parent_directories()` + `sys_setattr(DT_DIR)` that Rust already executes)
- **Phase 2 — sys_write**: Delete redundant IPC pre-check (Python `metadata.get()` for DT_PIPE/DT_STREAM detection — Rust dcache handles inline)
- **Phase 3 — sys_read**: Extract `_apply_slice()` helper, consolidating 6 identical `data[offset:offset+count]` patterns
- **Phase 4**: Confirmed Rust already skips observer dispatch for DT_PIPE (early return before `dispatch_mutation`) — no Rust changes needed
- **Phase 5**: Migrated 5 service callers from `pipe_write_nowait` bypass to `sys_write` VFS routing (write_observer_hooks, workflow_dispatch_service, dispatch_consumer, skeleton_pipe_consumer). Deleted `pipe_write_nowait` + dead `_pipe_read`/`_pipe_write` from NexusFS
- **Phase 6**: Removed `[TRANSITIONAL]` comments, updated docstrings and KERNEL-ARCHITECTURE.md

Net: **-56 lines** (66 insertions, 122 deletions). No Rust changes. No new Python→Rust→Python crossings.

## Test plan

- [x] `python3 scripts/codegen_kernel_abi.py --check` — all OK
- [x] Pre-commit hooks pass (ruff lint/format, brick zero-core-imports)
- [x] `test_workflow_dispatch.py` — 6 tests pass (mock updated from `pipe_write_nowait` → `sys_write`)
- [x] `test_rpc_parity.py` — passes with `pipe_write_nowait` removed from INTERNAL_ONLY_METHODS
- [x] grep confirms zero `pipe_write_nowait` callers in services (only DedupWorkQueue kernel-direct remains)
- [ ] CI: full pytest + cargo clippy (pre-existing clippy warnings in shm_stream.rs unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)