### PR TITLE
fix(daemon,secrets): wire --database-url + SQL SSOT for OAuth key (R20.18.5 data-loss fix)

### DIFF
--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -528,10 +528,12 @@ async def connect(
     enable_tiger_cache = enable_tiger_cache_env in ("true", "1", "yes")
 
     # RecordStore (Four Pillars) — created from NEXUS_RECORD_STORE_PATH or
-    # NEXUS_DATABASE_URL.  Passing None gives a bare kernel (storage-only)
-    # where all service-layer features (audit log, versioning, ReBAC, Memory
-    # API, etc.) are skipped.  The factory handles record_store=None gracefully.
-    _database_url = os.environ.get("NEXUS_DATABASE_URL")
+    # NEXUS_DATABASE_URL (both flow into ``cfg`` via env overrides, or via
+    # explicit config keys from callers like nexusd --database-url).
+    # Passing None gives a bare kernel (storage-only) where all service-layer
+    # features (audit log, versioning, ReBAC, Memory API, etc.) are skipped.
+    # The factory handles record_store=None gracefully.
+    _database_url = cfg.database_url
     if record_store_path:
         from nexus.storage.record_store import SQLAlchemyRecordStore
 

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -169,6 +169,14 @@ class NexusConfig(BaseModel):
         default=None,
         description="Path for the SQLAlchemy record store (SQLite). None = no record store (bare kernel).",
     )
+    database_url: str | None = Field(
+        default=None,
+        description=(
+            "Full database URL for the SQLAlchemy record store "
+            "(e.g. 'postgresql://user:pass@host/db' or 'sqlite:///path/to/db.sqlite'). "
+            "Ignored when record_store_path is set."
+        ),
+    )
 
     # In-memory metadata caching settings
     cache_path_size: int = Field(default=512, description="Max entries for path metadata cache")
@@ -559,6 +567,7 @@ def _build_env_overrides() -> dict[str, Any]:
         "NEXUS_DB_PATH": "db_path",
         "NEXUS_METASTORE_PATH": "metastore_path",
         "NEXUS_RECORD_STORE_PATH": "record_store_path",
+        "NEXUS_DATABASE_URL": "database_url",
         "NEXUS_CACHE_PATH_SIZE": "cache_path_size",
         "NEXUS_CACHE_LIST_SIZE": "cache_list_size",
         "NEXUS_CACHE_KV_SIZE": "cache_kv_size",

--- a/src/nexus/daemon/main.py
+++ b/src/nexus/daemon/main.py
@@ -317,6 +317,14 @@ def main(
             if data_dir:
                 connect_config["data_dir"] = data_dir
 
+            # Forward --database-url to NexusFS so SecretsService /
+            # PasswordVaultService / ReBAC etc. get a wired record_store.
+            # Previously the flag was only consumed by DatabaseAPIKeyAuth
+            # below, which surprised callers who expected the obvious
+            # "wire the DB" semantics.
+            if database_url:
+                connect_config["database_url"] = database_url
+
             # Respect NEXUS_ENFORCE_PERMISSIONS env var
             import os as _os
 

--- a/src/nexus/lib/oauth/crypto.py
+++ b/src/nexus/lib/oauth/crypto.py
@@ -6,7 +6,10 @@ Key resolution order (first match wins):
     1. Explicit ``encryption_key`` parameter
     2. Database-backed ``settings_store``
     3. ``NEXUS_OAUTH_ENCRYPTION_KEY`` environment variable
-    4. Random ephemeral key (development only — warns loudly)
+    4. Random ephemeral key — **only** when ``NEXUS_ALLOW_EPHEMERAL_OAUTH_KEY=1``;
+       otherwise raises. This prevents silent data loss on the next restart
+       (the ephemeral key never persists, so previously-encrypted secrets
+       become undecryptable).
 """
 
 import asyncio
@@ -23,6 +26,19 @@ logger = logging.getLogger(__name__)
 
 OAUTH_ENCRYPTION_KEY_NAME = "oauth_encryption_key"
 OAUTH_ENCRYPTION_KEY_ENV = "NEXUS_OAUTH_ENCRYPTION_KEY"
+ALLOW_EPHEMERAL_KEY_ENV = "NEXUS_ALLOW_EPHEMERAL_OAUTH_KEY"
+
+
+class EphemeralOAuthKeyRefused(RuntimeError):
+    """Raised when no persistent OAuth encryption key is available and the
+    caller has not opted into ephemeral keys via ``NEXUS_ALLOW_EPHEMERAL_OAUTH_KEY=1``.
+
+    Historically this path silently generated a throwaway key, which meant
+    any secret written in the previous process run was permanently
+    undecryptable after restart.  The correct response is to raise so the
+    operator can wire a ``settings_store`` or set ``NEXUS_OAUTH_ENCRYPTION_KEY``
+    before any data is written.
+    """
 
 
 class OAuthCrypto:
@@ -65,11 +81,28 @@ class OAuthCrypto:
             self._init_fernet(env_key)
             return
 
-        # 4. Random ephemeral key (development fallback)
+        # 4. Random ephemeral key — refuse by default; opt-in via env.
+        #
+        # Silent fallback here was the root cause of the post-R20.18.5
+        # data-loss: any previously-encrypted secret became undecryptable
+        # on next boot because the key was never persisted. The only
+        # sanctioned use of ephemeral keys is dev/test scenarios where
+        # the caller has explicitly accepted that tradeoff.
+        if os.environ.get(ALLOW_EPHEMERAL_KEY_ENV) != "1":
+            raise EphemeralOAuthKeyRefused(
+                "No persistent OAuth encryption key available and "
+                f"{ALLOW_EPHEMERAL_KEY_ENV}=1 was not set. Wire a "
+                "settings_store (e.g. SQLAlchemySystemSettingsStore on the "
+                f"record_store) or set {OAUTH_ENCRYPTION_KEY_ENV} to a 32-byte "
+                "urlsafe-base64 Fernet key before starting. Generating an "
+                "ephemeral key silently would orphan any secret written in "
+                "previous process runs."
+            )
         logger.warning(
-            "Generating random OAuth encryption key. This key will NOT persist "
-            "across restarts! Set %s or pass encryption_key for production use.",
-            OAUTH_ENCRYPTION_KEY_ENV,
+            "Generating ephemeral OAuth encryption key (%s=1). "
+            "This key will NOT persist across restarts — any secret stored "
+            "in this process will be UNREADABLE after the next boot.",
+            ALLOW_EPHEMERAL_KEY_ENV,
         )
         key_bytes: bytes = Fernet.generate_key()
         self._init_fernet(key_bytes.decode("utf-8"))

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -934,11 +934,18 @@ def _register_routes(app: FastAPI) -> None:
                 # settings and was the root cause of the silent OAuth-key
                 # data-loss on upgrade (the redb filename changed between
                 # versions with no migration path).
+                from nexus.storage.auth_stores.legacy_oauth_key_migration import (
+                    migrate_legacy_oauth_key,
+                )
                 from nexus.storage.auth_stores.sqlalchemy_system_settings_store import (
                     SQLAlchemySystemSettingsStore,
                 )
 
                 _settings_store = SQLAlchemySystemSettingsStore(_sa_rs.session_factory)
+                # One-shot upgrade path: copy OAuth key from a legacy
+                # ~/.nexus/metastore[.redb] file into SQL if present. Idempotent;
+                # no-ops once SQL already has the key.
+                migrate_legacy_oauth_key(_settings_store)
                 _oauth_crypto = OAuthCrypto(settings_store=_settings_store)
                 _audit_logger = SecretsAuditLogger(record_store=_sa_rs)
                 _secrets_service_instance = SecretsService(

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -926,36 +926,19 @@ def _register_routes(app: FastAPI) -> None:
                 if _sa_rs is None:
                     raise HTTPException(status_code=500, detail="Secrets service not configured")
 
-                # Build a settings_store so the encryption key is
-                # persisted across restarts. R20.18.5: route through
-                # RustMetastoreProxy directly — the old
-                # `RaftMetadataStore.embedded` helper was just a shim
-                # that returned the same proxy.
-                _settings_store = None
-                try:
-                    from pathlib import Path
+                # Persist OAuth encryption key in the record_store (SQL) —
+                # the services-tier SSOT for application-level settings.
+                # Pre-R20.18.5 this went through a second Kernel() instance
+                # + RustMetastoreProxy pointing at ~/.nexus/metastore.redb,
+                # which mixed filesystem-metastore tier with app-level
+                # settings and was the root cause of the silent OAuth-key
+                # data-loss on upgrade (the redb filename changed between
+                # versions with no migration path).
+                from nexus.storage.auth_stores.sqlalchemy_system_settings_store import (
+                    SQLAlchemySystemSettingsStore,
+                )
 
-                    from nexus.core.metastore import RustMetastoreProxy
-                    from nexus.storage.auth_stores.metastore_settings_store import (
-                        MetastoreSettingsStore,
-                    )
-
-                    try:
-                        from nexus_kernel import Kernel as _Kernel
-                    except ImportError as _imp_err:
-                        raise RuntimeError(
-                            "nexus_kernel not available for OAuth settings store"
-                        ) from _imp_err
-
-                    _metadata_path = str(Path.home() / ".nexus" / "metastore")
-                    _py_metastore = RustMetastoreProxy(_Kernel(), _metadata_path + ".redb")
-                    _settings_store = MetastoreSettingsStore(_py_metastore)
-                except Exception:
-                    logger.warning(
-                        "MetastoreSettingsStore unavailable; using ephemeral OAuth key",
-                        exc_info=True,
-                    )
-
+                _settings_store = SQLAlchemySystemSettingsStore(_sa_rs.session_factory)
                 _oauth_crypto = OAuthCrypto(settings_store=_settings_store)
                 _audit_logger = SecretsAuditLogger(record_store=_sa_rs)
                 _secrets_service_instance = SecretsService(

--- a/src/nexus/storage/auth_stores/__init__.py
+++ b/src/nexus/storage/auth_stores/__init__.py
@@ -8,6 +8,9 @@ from nexus.storage.auth_stores.metastore_settings_store import MetastoreSettings
 from nexus.storage.auth_stores.sqlalchemy_api_key_store import SQLAlchemyAPIKeyStore
 from nexus.storage.auth_stores.sqlalchemy_oauth_account import SQLAlchemyOAuthAccountStore
 from nexus.storage.auth_stores.sqlalchemy_oauth_credential import SQLAlchemyOAuthCredentialStore
+from nexus.storage.auth_stores.sqlalchemy_system_settings_store import (
+    SQLAlchemySystemSettingsStore,
+)
 from nexus.storage.auth_stores.sqlalchemy_user_store import SQLAlchemyUserStore
 from nexus.storage.auth_stores.sqlalchemy_zone_store import SQLAlchemyZoneStore
 
@@ -16,6 +19,7 @@ __all__ = [
     "SQLAlchemyAPIKeyStore",
     "SQLAlchemyOAuthAccountStore",
     "SQLAlchemyOAuthCredentialStore",
+    "SQLAlchemySystemSettingsStore",
     "SQLAlchemyUserStore",
     "SQLAlchemyZoneStore",
 ]

--- a/src/nexus/storage/auth_stores/legacy_oauth_key_migration.py
+++ b/src/nexus/storage/auth_stores/legacy_oauth_key_migration.py
@@ -1,0 +1,139 @@
+"""One-shot migration of the OAuth encryption key from legacy metastore
+(redb) files into the record_store (SQL).
+
+Context
+-------
+Prior to R20.18.5, OAuth encryption keys were persisted via
+``MetastoreSettingsStore`` backed by a Python ``RaftMetadataStore`` at
+``~/.nexus/metastore`` (no extension). R20.18.5 swapped the wrapper to
+``RustMetastoreProxy`` and appended a ``.redb`` extension to the path.
+Neither change migrated existing key data, so any install that had
+already written an OAuth key silently lost it on upgrade: next boot
+generated an ephemeral key, and every secret encrypted under the old
+key became undecryptable.
+
+We now persist the key in the record_store (SQL) via
+``SQLAlchemySystemSettingsStore`` — the correct services-tier SSOT —
+which makes filesystem-metastore paths irrelevant going forward. This
+module bridges the upgrade: on first boot after this change, if the
+record_store has no OAuth key yet, peek at the legacy redb files and
+copy the key over if found.
+
+Idempotent: if the record_store already has a key (either migrated
+earlier or written in a later boot), the legacy paths are never opened.
+"""
+
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+
+from nexus.contracts.auth_store_protocols import SystemSettingsStoreProtocol
+from nexus.lib.oauth.crypto import OAUTH_ENCRYPTION_KEY_NAME
+
+logger = logging.getLogger(__name__)
+
+
+# Paths to probe, in order. Both point at the same default location under
+# ``$HOME``; the difference is the extension (pre vs. post R20.18.5).
+def _legacy_redb_candidates() -> list[Path]:
+    base = Path.home() / ".nexus"
+    return [
+        base / "metastore.redb",  # post-R20.18.5 naming
+        base / "metastore",  # pre-R20.18.5 naming (Python RaftMetadataStore.embedded)
+    ]
+
+
+def migrate_legacy_oauth_key(sql_settings_store: SystemSettingsStoreProtocol) -> bool:
+    """Copy the OAuth key from a legacy redb file into the SQL settings store.
+
+    Returns:
+        True if a migration actually happened this call; False if the SQL
+        store already had a key, no legacy file existed, or no legacy file
+        contained the key.
+
+    Raises:
+        Exception: if a legacy file holds a key but writing it into the SQL
+            settings store fails. This is a data-integrity failure the
+            operator needs to see; silently continuing would let the next
+            request generate a fresh ephemeral key and orphan all data
+            encrypted under the legacy key.
+    """
+    # Idempotency guard — once the SQL store has the key, the redb files
+    # stop being load-bearing and we don't touch them again.
+    if sql_settings_store.get_setting(OAUTH_ENCRYPTION_KEY_NAME) is not None:
+        return False
+
+    for path in _legacy_redb_candidates():
+        if not path.exists():
+            continue
+        key = _read_oauth_key_from_redb(path)
+        if key is None:
+            continue
+        sql_settings_store.set_setting(
+            OAUTH_ENCRYPTION_KEY_NAME,
+            key,
+            description=(
+                f"Migrated from legacy filesystem-metastore key store at {path} "
+                "(pre-R20.18.5 / R20.18.5-era layout)."
+            ),
+        )
+        logger.info(
+            "Migrated legacy OAuth encryption key: %s -> record_store.system_settings",
+            path,
+        )
+        return True
+
+    return False
+
+
+def _read_oauth_key_from_redb(path: Path) -> str | None:
+    """Open a legacy redb file one-shot, read the OAuth key, close.
+
+    Returns ``None`` when the file can't be opened, when the Rust kernel
+    isn't importable in this process, or when the key isn't present. A
+    log line at WARNING level is emitted for unexpected failures so an
+    operator looking into a data-loss incident has something to grep.
+    """
+    # nexus.core.metastore + nexus_kernel are kernel-tier imports — allowed
+    # from nexus.storage (this module) by the five-tier architecture; they
+    # would be disallowed from nexus.lib. See import-linter config.
+    try:
+        from nexus.core.metastore import RustMetastoreProxy
+        from nexus.storage.auth_stores.metastore_settings_store import (
+            MetastoreSettingsStore,
+        )
+    except ImportError as exc:
+        logger.warning(
+            "Legacy OAuth key migration skipped (%s): %s",
+            path,
+            exc,
+        )
+        return None
+
+    try:
+        from nexus_kernel import Kernel
+    except ImportError as exc:
+        logger.warning(
+            "Legacy OAuth key migration skipped — nexus_kernel unavailable (%s): %s",
+            path,
+            exc,
+        )
+        return None
+
+    try:
+        proxy = RustMetastoreProxy(Kernel(), str(path))
+        store = MetastoreSettingsStore(proxy)
+        dto = store.get_setting(OAUTH_ENCRYPTION_KEY_NAME)
+        if dto is None:
+            return None
+        return dto.value
+    except Exception as exc:
+        # Narrow log — don't fail boot on a best-effort probe — but loud
+        # enough to surface in an incident grep.
+        logger.warning(
+            "Legacy OAuth key migration could not read %s: %s",
+            path,
+            exc,
+        )
+        return None

--- a/src/nexus/storage/auth_stores/sqlalchemy_system_settings_store.py
+++ b/src/nexus/storage/auth_stores/sqlalchemy_system_settings_store.py
@@ -1,0 +1,72 @@
+"""SQLAlchemy implementation of ``SystemSettingsStoreProtocol``.
+
+Stores application-level key/value settings in the ``system_settings``
+RecordStore table (one of the Four Storage Pillars — *services-only*).
+This is the canonical home for all application settings including the
+OAuth encryption key; earlier implementations that persisted settings
+into the filesystem metastore (``cfg:`` prefix on ``FileMetadata``)
+violated the LEGO tier boundary between filesystem-level and
+application-level SSOTs.
+
+Pairs with ``RecordStoreABC`` — takes a session factory, not a
+Metastore — so the OAuth key lives alongside other app-level secrets
+(``secret_store``, ``secrets_audit_log``, ``oauth_credentials``).
+"""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable
+
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from nexus.contracts.auth_store_types import SystemSettingDTO
+from nexus.storage.models import SystemSettingsModel
+
+logger = logging.getLogger(__name__)
+
+
+def _to_dto(row: SystemSettingsModel) -> SystemSettingDTO:
+    return SystemSettingDTO(
+        key=row.key,
+        value=row.value,
+        description=row.description,
+    )
+
+
+class SQLAlchemySystemSettingsStore:
+    """``SystemSettingsStoreProtocol`` backed by the ``system_settings`` table.
+
+    Upserts via read-then-insert/update within a single transaction — the
+    primary key is ``key``, so SQLite / PostgreSQL both converge on the
+    same row under concurrent writers. Callers get last-writer-wins; no
+    optimistic-concurrency token because settings are infrequently
+    updated (OAuth key once per install).
+    """
+
+    def __init__(self, session_factory: Callable[[], Session]) -> None:
+        self._session_factory = session_factory
+
+    def get_setting(self, key: str) -> SystemSettingDTO | None:
+        with self._session_factory() as session:
+            row = session.execute(
+                select(SystemSettingsModel).where(SystemSettingsModel.key == key)
+            ).scalar_one_or_none()
+            if row is None:
+                return None
+            return _to_dto(row)
+
+    def set_setting(self, key: str, value: str, *, description: str | None = None) -> None:
+        with self._session_factory() as session:
+            row = session.execute(
+                select(SystemSettingsModel).where(SystemSettingsModel.key == key)
+            ).scalar_one_or_none()
+            if row is None:
+                session.add(SystemSettingsModel(key=key, value=value, description=description))
+            else:
+                row.value = value
+                if description is not None:
+                    row.description = description
+            # ``TimestampMixin`` handles created_at default + updated_at onupdate.
+            session.commit()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,17 @@ if os.environ.get("NEXUS_RUST_EDITABLE") == "1":
 os.environ.setdefault("NEXUS_ENABLE_WRITE_BUFFER", "false")
 
 # ---------------------------------------------------------------------------
+# OAuthCrypto: allow ephemeral keys in the test suite.
+# Tests do not persist secrets across process restarts, so the production
+# fail-loud default (which prevents silent data loss on the next boot) is
+# overly strict for test fixtures that call ``OAuthCrypto()`` with no
+# wired settings_store or explicit key. Tests that specifically exercise
+# the fail-loud contract use ``monkeypatch.delenv`` to remove this flag.
+# See ``tests/unit/lib/oauth/test_crypto_fail_loud.py``.
+# ---------------------------------------------------------------------------
+os.environ.setdefault("NEXUS_ALLOW_EPHEMERAL_OAUTH_KEY", "1")
+
+# ---------------------------------------------------------------------------
 # Hypothesis profiles (Issue #1303)
 # ---------------------------------------------------------------------------
 

--- a/tests/e2e/self_contained/test_oauth_api_key_simple.py
+++ b/tests/e2e/self_contained/test_oauth_api_key_simple.py
@@ -34,9 +34,10 @@ def db_session(db_engine):
 
 @pytest.fixture
 def oauth_crypto():
-    """Create OAuthCrypto instance for testing."""
-    # Use random key for testing (simpler than database persistence)
-    return OAuthCrypto()
+    """Create OAuthCrypto instance for testing with an ephemeral key."""
+    # Explicit key — post-fail-loud OAuthCrypto() no-args raises unless
+    # NEXUS_ALLOW_EPHEMERAL_OAUTH_KEY=1 or a settings_store is wired.
+    return OAuthCrypto(encryption_key=OAuthCrypto.generate_key())
 
 
 @pytest.fixture

--- a/tests/e2e/self_contained/test_user_auth.py
+++ b/tests/e2e/self_contained/test_user_auth.py
@@ -65,7 +65,7 @@ def auth_provider(test_db):
 @pytest.fixture
 def oauth_provider(test_db):
     """Create OAuthUserAuth provider for testing."""
-    oauth_crypto = OAuthCrypto()
+    oauth_crypto = OAuthCrypto(encryption_key=OAuthCrypto.generate_key())
     google_provider = GoogleOAuthProvider(
         client_id="test-client-id.apps.googleusercontent.com",
         client_secret="test-client-secret",

--- a/tests/e2e/server/test_oauth_provision_integration.py
+++ b/tests/e2e/server/test_oauth_provision_integration.py
@@ -57,8 +57,8 @@ def admin_context():
 
 @pytest.fixture
 def oauth_crypto():
-    """Create OAuthCrypto instance for testing."""
-    return OAuthCrypto()
+    """Create OAuthCrypto instance for testing with an ephemeral key."""
+    return OAuthCrypto(encryption_key=OAuthCrypto.generate_key())
 
 
 class TestOAuthProvisionIntegration:

--- a/tests/unit/lib/oauth/test_crypto_fail_loud.py
+++ b/tests/unit/lib/oauth/test_crypto_fail_loud.py
@@ -1,0 +1,137 @@
+"""Tests for OAuthCrypto's fail-loud policy on missing key persistence.
+
+Historical behavior: with no explicit key, no wired settings_store, and
+no ``NEXUS_OAUTH_ENCRYPTION_KEY`` env, ``OAuthCrypto()`` silently
+generated an ephemeral Fernet key. Any OAuth token encrypted under
+that key became undecryptable after the next restart — the root
+cause of the post-R20.18.5 password_vault data-loss incident.
+
+New behavior (this test file):
+
+* Default: raise ``EphemeralOAuthKeyRefused``.
+* Opt-in via ``NEXUS_ALLOW_EPHEMERAL_OAUTH_KEY=1``: allow ephemeral
+  but log a loud warning. The opt-in exists for dev/test only.
+* Explicit ``encryption_key=...`` still works unchanged.
+* A valid ``settings_store`` path still works unchanged (load existing
+  or create-and-store a new key).
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.contracts.auth_store_types import SystemSettingDTO
+from nexus.lib.oauth.crypto import (
+    ALLOW_EPHEMERAL_KEY_ENV,
+    OAUTH_ENCRYPTION_KEY_ENV,
+    EphemeralOAuthKeyRefused,
+    OAuthCrypto,
+)
+
+
+class _InMemorySettingsStore:
+    """Minimal SystemSettingsStoreProtocol for unit tests."""
+
+    def __init__(self) -> None:
+        self._data: dict[str, tuple[str, str | None]] = {}
+
+    def get_setting(self, key: str) -> SystemSettingDTO | None:
+        if key not in self._data:
+            return None
+        value, description = self._data[key]
+        return SystemSettingDTO(key=key, value=value, description=description)
+
+    def set_setting(self, key: str, value: str, *, description: str | None = None) -> None:
+        self._data[key] = (value, description)
+
+
+class TestFailLoudDefault:
+    def test_no_inputs_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(OAUTH_ENCRYPTION_KEY_ENV, raising=False)
+        monkeypatch.delenv(ALLOW_EPHEMERAL_KEY_ENV, raising=False)
+
+        with pytest.raises(EphemeralOAuthKeyRefused):
+            OAuthCrypto()
+
+    def test_error_message_lists_all_resolution_paths(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        monkeypatch.delenv(OAUTH_ENCRYPTION_KEY_ENV, raising=False)
+        monkeypatch.delenv(ALLOW_EPHEMERAL_KEY_ENV, raising=False)
+
+        with pytest.raises(EphemeralOAuthKeyRefused) as exc_info:
+            OAuthCrypto()
+
+        message = str(exc_info.value)
+        assert "settings_store" in message
+        assert OAUTH_ENCRYPTION_KEY_ENV in message
+        assert ALLOW_EPHEMERAL_KEY_ENV in message
+
+
+class TestOptInEphemeral:
+    def test_env_opt_in_allows_ephemeral(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(OAUTH_ENCRYPTION_KEY_ENV, raising=False)
+        monkeypatch.setenv(ALLOW_EPHEMERAL_KEY_ENV, "1")
+
+        crypto = OAuthCrypto()
+
+        # Smoke: can round-trip a token with the generated key.
+        encrypted = crypto.encrypt_token("hello")
+        assert crypto.decrypt_token(encrypted) == "hello"
+
+    def test_env_set_to_non_1_still_fails(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Only the literal ``1`` opts in — prevents typo / truthy surprises."""
+        monkeypatch.delenv(OAUTH_ENCRYPTION_KEY_ENV, raising=False)
+        monkeypatch.setenv(ALLOW_EPHEMERAL_KEY_ENV, "true")
+
+        with pytest.raises(EphemeralOAuthKeyRefused):
+            OAuthCrypto()
+
+
+class TestPersistentPathsStillWork:
+    def test_explicit_key_bypasses_fail_loud(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(OAUTH_ENCRYPTION_KEY_ENV, raising=False)
+        monkeypatch.delenv(ALLOW_EPHEMERAL_KEY_ENV, raising=False)
+
+        key = OAuthCrypto.generate_key()
+        crypto = OAuthCrypto(encryption_key=key)
+        encrypted = crypto.encrypt_token("hello")
+        assert crypto.decrypt_token(encrypted) == "hello"
+
+    def test_env_key_bypasses_fail_loud(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv(OAUTH_ENCRYPTION_KEY_ENV, OAuthCrypto.generate_key())
+        monkeypatch.delenv(ALLOW_EPHEMERAL_KEY_ENV, raising=False)
+
+        crypto = OAuthCrypto()
+        encrypted = crypto.encrypt_token("hello")
+        assert crypto.decrypt_token(encrypted) == "hello"
+
+    def test_settings_store_creates_key_on_first_use(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv(OAUTH_ENCRYPTION_KEY_ENV, raising=False)
+        monkeypatch.delenv(ALLOW_EPHEMERAL_KEY_ENV, raising=False)
+
+        store = _InMemorySettingsStore()
+        crypto1 = OAuthCrypto(settings_store=store)
+
+        # Second instance sees persisted key → can decrypt first's ciphertext.
+        ciphertext = crypto1.encrypt_token("hello")
+        crypto2 = OAuthCrypto(settings_store=store)
+        assert crypto2.decrypt_token(ciphertext) == "hello"
+
+    def test_settings_store_key_survives_env_and_ephemeral_flags(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        """When a wired settings_store provides a key, env and ephemeral
+        paths are irrelevant — the persistent key wins."""
+        monkeypatch.setenv(OAUTH_ENCRYPTION_KEY_ENV, OAuthCrypto.generate_key())
+        monkeypatch.setenv(ALLOW_EPHEMERAL_KEY_ENV, "1")
+
+        store = _InMemorySettingsStore()
+        crypto1 = OAuthCrypto(settings_store=store)
+        ciphertext = crypto1.encrypt_token("hello")
+
+        # Second instance without the env keys still decrypts via the store.
+        monkeypatch.delenv(OAUTH_ENCRYPTION_KEY_ENV, raising=False)
+        monkeypatch.delenv(ALLOW_EPHEMERAL_KEY_ENV, raising=False)
+        crypto2 = OAuthCrypto(settings_store=store)
+        assert crypto2.decrypt_token(ciphertext) == "hello"

--- a/tests/unit/storage/test_auth_stores.py
+++ b/tests/unit/storage/test_auth_stores.py
@@ -19,6 +19,7 @@ from nexus.storage.auth_stores import (
     SQLAlchemyAPIKeyStore,
     SQLAlchemyOAuthAccountStore,
     SQLAlchemyOAuthCredentialStore,
+    SQLAlchemySystemSettingsStore,
     SQLAlchemyUserStore,
     SQLAlchemyZoneStore,
 )
@@ -346,3 +347,59 @@ class TestSettingsStore:
         dto = store.get_setting("key1")
         assert dto is not None
         assert dto.description == "new"
+
+
+# ===========================================================================
+# SQLAlchemySystemSettingsStore — SQL-backed, records-tier implementation
+# ===========================================================================
+
+
+class TestSQLAlchemySystemSettingsStore:
+    """Behavioral parity with ``TestSettingsStore`` above, but against the
+    record_store SQL backend rather than the tier-violating metastore shim."""
+
+    @pytest.fixture()
+    def store(self, session_factory):
+        return SQLAlchemySystemSettingsStore(session_factory)
+
+    def test_set_and_get_setting(self, store):
+        store.set_setting("key1", "value1", description="desc")
+        dto = store.get_setting("key1")
+        assert isinstance(dto, SystemSettingDTO)
+        assert dto.key == "key1"
+        assert dto.value == "value1"
+        assert dto.description == "desc"
+
+    def test_get_setting_not_found(self, store):
+        assert store.get_setting("nonexistent") is None
+
+    def test_set_setting_upsert(self, store):
+        store.set_setting("key1", "v1")
+        store.set_setting("key1", "v2")
+        dto = store.get_setting("key1")
+        assert dto is not None
+        assert dto.value == "v2"
+
+    def test_set_setting_update_description(self, store):
+        store.set_setting("key1", "v1", description="old")
+        store.set_setting("key1", "v1", description="new")
+        dto = store.get_setting("key1")
+        assert dto is not None
+        assert dto.description == "new"
+
+    def test_description_not_overwritten_when_omitted(self, store):
+        """Passing description=None on update must not nullify the existing one."""
+        store.set_setting("key1", "v1", description="keep me")
+        store.set_setting("key1", "v2")  # no description kwarg — None default
+        dto = store.get_setting("key1")
+        assert dto is not None
+        assert dto.value == "v2"
+        assert dto.description == "keep me"
+
+    def test_multiple_keys_independent(self, store):
+        store.set_setting("a", "1")
+        store.set_setting("b", "2")
+        a = store.get_setting("a")
+        b = store.get_setting("b")
+        assert a is not None and a.value == "1"
+        assert b is not None and b.value == "2"

--- a/tests/unit/storage/test_legacy_oauth_key_migration.py
+++ b/tests/unit/storage/test_legacy_oauth_key_migration.py
@@ -1,0 +1,172 @@
+"""Tests for the legacy-redb → SQL OAuth key migration shim.
+
+The migration is a one-shot upgrade path that copies an existing
+OAuth encryption key from the pre-R20.18.5 filesystem-metastore
+location (``~/.nexus/metastore[.redb]``) into the record_store (SQL)
+so the post-R20.18.5 boot path, which reads only from SQL, can find
+it. These tests stub out the redb reader so they don't need a real
+nexus_kernel; the migration function is a pure orchestration layer
+above ``_read_oauth_key_from_redb``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from nexus.contracts.auth_store_types import SystemSettingDTO
+from nexus.lib.oauth.crypto import OAUTH_ENCRYPTION_KEY_NAME
+from nexus.storage.auth_stores import legacy_oauth_key_migration
+from nexus.storage.auth_stores.legacy_oauth_key_migration import migrate_legacy_oauth_key
+
+
+class _FakeSettingsStore:
+    def __init__(self, initial: dict[str, str] | None = None) -> None:
+        self._data: dict[str, tuple[str, str | None]] = {
+            k: (v, None) for k, v in (initial or {}).items()
+        }
+
+    def get_setting(self, key: str) -> SystemSettingDTO | None:
+        if key not in self._data:
+            return None
+        value, description = self._data[key]
+        return SystemSettingDTO(key=key, value=value, description=description)
+
+    def set_setting(self, key: str, value: str, *, description: str | None = None) -> None:
+        self._data[key] = (value, description)
+
+
+def _patch_candidates(monkeypatch: pytest.MonkeyPatch, paths: list[Path]) -> None:
+    monkeypatch.setattr(legacy_oauth_key_migration, "_legacy_redb_candidates", lambda: paths)
+
+
+def _patch_reader(monkeypatch: pytest.MonkeyPatch, result_by_path: dict[Path, Any]) -> None:
+    def _fake_read(path: Path) -> str | None:
+        return result_by_path.get(path)
+
+    monkeypatch.setattr(legacy_oauth_key_migration, "_read_oauth_key_from_redb", _fake_read)
+
+
+class TestIdempotency:
+    def test_skips_when_sql_already_has_key(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        store = _FakeSettingsStore(initial={OAUTH_ENCRYPTION_KEY_NAME: "existing-key"})
+
+        # Rig the reader to return a different key — we must NOT see it.
+        candidate = tmp_path / "metastore.redb"
+        candidate.touch()
+        _patch_candidates(monkeypatch, [candidate])
+        _patch_reader(monkeypatch, {candidate: "legacy-key-would-overwrite"})
+
+        migrated = migrate_legacy_oauth_key(store)
+
+        assert migrated is False
+        dto = store.get_setting(OAUTH_ENCRYPTION_KEY_NAME)
+        assert dto is not None and dto.value == "existing-key"
+
+    def test_running_twice_is_noop(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        store = _FakeSettingsStore()
+        candidate = tmp_path / "metastore.redb"
+        candidate.touch()
+        _patch_candidates(monkeypatch, [candidate])
+        _patch_reader(monkeypatch, {candidate: "legacy-key"})
+
+        assert migrate_legacy_oauth_key(store) is True
+        # Second call sees the key already in SQL → skips.
+        assert migrate_legacy_oauth_key(store) is False
+
+
+class TestMigrationHappyPath:
+    def test_migrates_redb_candidate(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        store = _FakeSettingsStore()
+        candidate = tmp_path / "metastore.redb"
+        candidate.touch()
+        _patch_candidates(monkeypatch, [candidate])
+        _patch_reader(monkeypatch, {candidate: "secret-legacy-key"})
+
+        migrated = migrate_legacy_oauth_key(store)
+
+        assert migrated is True
+        dto = store.get_setting(OAUTH_ENCRYPTION_KEY_NAME)
+        assert dto is not None
+        assert dto.value == "secret-legacy-key"
+        assert dto.description is not None and "Migrated" in dto.description
+
+    def test_prefers_redb_over_noext_when_both_present(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        store = _FakeSettingsStore()
+        redb = tmp_path / "metastore.redb"
+        noext = tmp_path / "metastore"
+        redb.touch()
+        noext.touch()
+        _patch_candidates(monkeypatch, [redb, noext])
+        _patch_reader(
+            monkeypatch,
+            {redb: "redb-era-key", noext: "pre-redb-era-key"},
+        )
+
+        migrate_legacy_oauth_key(store)
+
+        dto = store.get_setting(OAUTH_ENCRYPTION_KEY_NAME)
+        assert dto is not None and dto.value == "redb-era-key"
+
+    def test_falls_through_to_noext_when_redb_missing(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        store = _FakeSettingsStore()
+        redb = tmp_path / "metastore.redb"  # does NOT exist
+        noext = tmp_path / "metastore"
+        noext.touch()
+        _patch_candidates(monkeypatch, [redb, noext])
+        _patch_reader(monkeypatch, {noext: "pre-redb-era-key"})
+
+        migrate_legacy_oauth_key(store)
+
+        dto = store.get_setting(OAUTH_ENCRYPTION_KEY_NAME)
+        assert dto is not None and dto.value == "pre-redb-era-key"
+
+    def test_falls_through_to_noext_when_redb_has_no_key(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        store = _FakeSettingsStore()
+        redb = tmp_path / "metastore.redb"
+        noext = tmp_path / "metastore"
+        redb.touch()
+        noext.touch()
+        _patch_candidates(monkeypatch, [redb, noext])
+        _patch_reader(monkeypatch, {redb: None, noext: "legacy-key"})
+
+        migrate_legacy_oauth_key(store)
+
+        dto = store.get_setting(OAUTH_ENCRYPTION_KEY_NAME)
+        assert dto is not None and dto.value == "legacy-key"
+
+
+class TestFreshInstall:
+    def test_no_legacy_files_is_noop(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        store = _FakeSettingsStore()
+        _patch_candidates(monkeypatch, [tmp_path / "metastore.redb", tmp_path / "metastore"])
+        _patch_reader(monkeypatch, {})  # reader never called (file doesn't exist)
+
+        migrated = migrate_legacy_oauth_key(store)
+
+        assert migrated is False
+        assert store.get_setting(OAUTH_ENCRYPTION_KEY_NAME) is None
+
+    def test_legacy_files_with_no_key_is_noop(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        store = _FakeSettingsStore()
+        redb = tmp_path / "metastore.redb"
+        redb.touch()
+        _patch_candidates(monkeypatch, [redb])
+        _patch_reader(monkeypatch, {redb: None})  # file exists but no key inside
+
+        migrated = migrate_legacy_oauth_key(store)
+
+        assert migrated is False
+        assert store.get_setting(OAUTH_ENCRYPTION_KEY_NAME) is None

--- a/tests/unit/test_config_database_url.py
+++ b/tests/unit/test_config_database_url.py
@@ -1,0 +1,50 @@
+"""Tests for the ``database_url`` config field / NEXUS_DATABASE_URL env mapping.
+
+Covers the UX fix where ``nexusd --database-url`` previously did not wire the
+SQLAlchemy record store onto ``NexusFS`` (the flag was consumed only by
+DatabaseAPIKeyAuth). Now the flag/env/config-key all route into
+``cfg.database_url`` and are honored by ``nexus.connect()``.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.config import NexusConfig, _load_from_dict, _load_from_environment
+
+
+class TestDatabaseUrlField:
+    def test_default_is_none(self) -> None:
+        cfg = NexusConfig()
+        assert cfg.database_url is None
+
+    def test_accepts_postgres_url(self) -> None:
+        cfg = NexusConfig(database_url="postgresql://u:p@h/db")
+        assert cfg.database_url == "postgresql://u:p@h/db"
+
+    def test_accepts_sqlite_url(self) -> None:
+        cfg = NexusConfig(database_url="sqlite:///tmp/x.db")
+        assert cfg.database_url == "sqlite:///tmp/x.db"
+
+
+class TestDatabaseUrlFromDict:
+    def test_explicit_config_key_flows_through(self) -> None:
+        cfg = _load_from_dict({"database_url": "sqlite:///tmp/from-dict.db"})
+        assert cfg.database_url == "sqlite:///tmp/from-dict.db"
+
+    def test_absent_key_stays_none(self) -> None:
+        cfg = _load_from_dict({"profile": "cluster"})
+        assert cfg.database_url is None
+
+
+class TestDatabaseUrlFromEnv:
+    def test_nexus_database_url_env_maps_to_field(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NEXUS_DATABASE_URL", "postgresql://e:e@h/e")
+        cfg = _load_from_environment()
+        assert cfg.database_url == "postgresql://e:e@h/e"
+
+    def test_dict_key_overrides_env(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Explicit config-dict wins over NEXUS_DATABASE_URL env."""
+        monkeypatch.setenv("NEXUS_DATABASE_URL", "postgresql://env:env@h/db")
+        cfg = _load_from_dict({"database_url": "sqlite:///tmp/dict.db"})
+        assert cfg.database_url == "sqlite:///tmp/dict.db"


### PR DESCRIPTION
## Summary

Bundles a CLI-flag forward fix with the architectural fix for the OAuth encryption-key data-loss introduced by R20.18.5. Five commits, each reviewable independently, no squash.

### What broke

1. **`nexusd --database-url <url>`** was a UX trap: the flag was consumed only by the `DatabaseAPIKeyAuth` path and never forwarded to `nexus.connect()`, so `SecretsService` / `PasswordVaultService` / `ReBAC` / audit log all ran with `record_store=None` even though the user had explicitly told the daemon where the DB was.
2. **Post-R20.18.5 silent OAuth-key data-loss**: the key was persisted via a second `Kernel()` instance pointing at `~/.nexus/metastore[.redb]` (filesystem-metastore tier). When R20.18.5 renamed `metastore` → `metastore.redb` without a migration, the first post-upgrade boot found an empty redb, silently generated a fresh ephemeral Fernet key, and all prior encrypted secrets became unreadable.

Root cause of #2 is the tier violation — app-level settings were living in the filesystem metastore. `src/nexus/core/metastore.py:6` already documented the rule:
> RecordStoreABC (services-only — storage/record_store.py)

The fix moves OAuth key storage back where it belongs and installs a fail-loud guard so future boot-time fallbacks can't silently orphan data.

## Commits (read in order)

| SHA | Scope |
|---|---|
| `5ced6edcd` | `fix(daemon): forward --database-url to nexus.connect` |
| `dc530e68f` | `feat(storage): SQLAlchemySystemSettingsStore — record-store backed app settings` |
| `8d29ba5ef` | `refactor(server): move OAuth key persistence to record_store, delete second-Kernel dance` |
| `7a283dc57` | `feat(oauth): fail-loud on missing key persistence; NEXUS_ALLOW_EPHEMERAL_OAUTH_KEY opt-in` |
| `a523ac80a` | `feat(migration): auto-migrate legacy OAuth key from redb metastore → SQL on first boot` |

## Architecture notes

- **SSOT correct**: OAuth key now lives in the `system_settings` record-store table alongside other app-level persistent state (`secret_store`, `secrets_audit_log`, `oauth_credentials`). Stops piggybacking on the kernel's filesystem metastore.
- **DRY**: New `SQLAlchemySystemSettingsStore` implements `SystemSettingsStoreProtocol` cleanly; any future app-level setting (feature flags, webhook secrets, service configs) uses the same store.
- **Tier correctness**: No more second `Kernel()` instance, no more `FEDERATION_CLAIMED` atomic workaround for settings-store racing, no more `Path.home() / ".nexus" / "metastore"` hardcoded in `fastapi_server.py`.
- **Fail-loud**: `OAuthCrypto` raises `EphemeralOAuthKeyRefused` by default when no persistent key source is wired. The silent ephemeral path now requires `NEXUS_ALLOW_EPHEMERAL_OAUTH_KEY=1` (literal "1", not truthy) for explicit dev scenarios.
- **Migration path**: `migrate_legacy_oauth_key()` runs once at boot, idempotently. Probes `~/.nexus/metastore.redb` (post-R20.18.5) then `~/.nexus/metastore` (pre-R20.18.5). If either holds the key, copies it into SQL. Fresh installs and already-migrated installs no-op.

## Future work (tracked separately, not this PR)

- Rust-side `RecordStore` implementation — `rust/services/` crate is currently empty; we'd need sqlx + Cloud SQL IAM proxy + Alembic-equivalent migrations to cut over. Scope is R-series refactoring wave (~10-18K LOC), not a bug fix. Decision memo pending.
- Delete `MetastoreSettingsStore` shim — can happen once all remaining callers (if any) move to `SQLAlchemySystemSettingsStore`. Kept for this PR to keep the diff narrow and reviewable.
- `--database-url` + `--record-store-path` CLI-flag parity — `NEXUS_RECORD_STORE_PATH` exists as env-only today.

## Test plan

- [ ] CI: all green on the full Python/Rust/integration suites.
- [ ] New unit suites pass (`test_config_database_url.py`, `test_auth_stores.py::TestSQLAlchemySystemSettingsStore`, `test_crypto_fail_loud.py`, `test_legacy_key_migration.py`).
- [ ] Manual: Ethan's dev recipe now works — `nexusd --profile cluster --auth-type none --database-url sqlite:///tmp/.../nexus.db --data-dir /tmp/...` → `curl /api/v2/password_vault` returns 200.
- [ ] Manual: operator with a pre-existing `~/.nexus/metastore.redb` containing an OAuth key sees it migrated to `system_settings` on first boot after this PR (no manual `NEXUS_OAUTH_ENCRYPTION_KEY` required).

## Backward compatibility

- `NEXUS_DATABASE_URL` env still wires record_store (now via the typed `cfg.database_url` field rather than a direct `os.environ` read — no visible behavior change).
- `NEXUS_OAUTH_ENCRYPTION_KEY` env still overrides (unchanged precedence: explicit key > settings_store > env > ephemeral).
- **Breaking**: `OAuthCrypto()` with no settings_store, no env key, and no `NEXUS_ALLOW_EPHEMERAL_OAUTH_KEY=1` now raises instead of silently generating an ephemeral key. Any caller that relied on the silent fallback was previously accepting silent data loss across restarts; three test fixtures updated to pass an explicit `encryption_key=OAuthCrypto.generate_key()`.

## Spec ref

Surfaced during a cross-AI debugging thread where password-agent observed `500 "Secrets service not configured"` on a dev nexusd pointed at an existing record store. Initial fix (commit 1) addressed the CLI flag; investigation then surfaced the OAuth-key data-loss as a separate architectural issue behind the same wall. One PR because the commits all flow through the same boot path and the migration shim (commit 5) depends on the SQL store (commit 2) being wired first.