### PR TITLE
refactor(#1817): eliminate pipe_read_nowait + pipe_destroy bypass

### DIFF
--- a/src/nexus/bricks/search/skeleton_pipe_consumer.py
+++ b/src/nexus/bricks/search/skeleton_pipe_consumer.py
@@ -201,12 +201,8 @@ class SkeletonPipeConsumer:
     # ------------------------------------------------------------------
 
     async def _consume(self) -> None:
-        # Use pipe_read_nowait (polling) instead of sys_read — sys_read blocks
-        # for up to 5s when the pipe is empty, which would block the asyncio
-        # event loop. pipe_read_nowait returns None immediately on empty,
-        # allowing cooperative polling with asyncio.sleep.
-        # pipe_read_nowait raises NexusFileNotFoundError
-        # when the pipe is destroyed (stop() signal).
+        # sys_read returns b"" for empty DT_PIPE (POSIX non-blocking semantics).
+        # NexusFileNotFoundError signals pipe destroyed (stop() signal).
         from nexus.contracts.exceptions import NexusFileNotFoundError
 
         assert self._nx is not None
@@ -220,13 +216,13 @@ class SkeletonPipeConsumer:
             if not pending:
                 while True:
                     try:
-                        data = nx.pipe_read_nowait(_SKELETON_PIPE_PATH)
+                        data = nx.sys_read(_SKELETON_PIPE_PATH)
                     except NexusFileNotFoundError:
                         logger.debug("[SKELETON] pipe closed, consumer exiting")
                         return
                     except Exception:
                         return
-                    if data is not None:
+                    if data:
                         pending.append(json.loads(data))
                         break
                     await asyncio.sleep(_POLL)
@@ -238,12 +234,12 @@ class SkeletonPipeConsumer:
                 if remaining <= 0:
                     break
                 try:
-                    data = nx.pipe_read_nowait(_SKELETON_PIPE_PATH)
+                    data = nx.sys_read(_SKELETON_PIPE_PATH)
                 except NexusFileNotFoundError:
                     break
                 except Exception:
                     break
-                if data is not None:
+                if data:
                     pending.append(json.loads(data))
                 else:
                     await asyncio.sleep(min(remaining, _POLL))

--- a/src/nexus/bricks/task_manager/dispatch_consumer.py
+++ b/src/nexus/bricks/task_manager/dispatch_consumer.py
@@ -188,6 +188,10 @@ class TaskDispatchPipeConsumer:
                 logger.debug("[TASK-DISPATCH] pipe closed, consumer exiting")
                 break
 
+            if not data:
+                await asyncio.sleep(0.01)
+                continue
+
             try:
                 msg = json.loads(data)
                 await self._dispatch(msg)

--- a/src/nexus/contracts/types.py
+++ b/src/nexus/contracts/types.py
@@ -49,11 +49,6 @@ class VFSOperations(Protocol):
 
     def sys_unlink(self, path: str, **kw: Any) -> None: ...
 
-    # Tier 2 sync convenience methods (kernel passthroughs).  These exist
-    # so callers don't need to reach into ``self._kernel`` for non-blocking
-    # pipe ops or sync teardown contexts.
-    def pipe_destroy(self, path: str) -> None: ...
-
 
 class Permission(IntFlag):
     """Permission flags for file operations.

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -661,13 +661,6 @@ class NexusFS(  # type: ignore[misc]
     # and sync teardown contexts (AcpService) where async wrapping would
     # add event-loop ping-pong without buying anything.
 
-    def pipe_read_nowait(self, path: str) -> bytes | None:
-        """Non-blocking pipe read. Returns ``None`` if pipe is empty.
-
-        Sync passthrough to ``Kernel.pipe_read_nowait``.
-        """
-        return self._kernel.pipe_read_nowait(path)
-
     def pipe_create(self, path: str, capacity: int = 65_536) -> None:
         """Create a DT_PIPE in the kernel registry.
 
@@ -684,15 +677,6 @@ class NexusFS(  # type: ignore[misc]
         if self._kernel is None:
             return False
         return self._kernel.has_pipe(path)
-
-    def pipe_destroy(self, path: str) -> None:
-        """Destroy a DT_PIPE — close Rust kernel buffer + custom backend cleanup.
-
-        Sync alternative to ``await sys_unlink(path)`` for sync teardown
-        contexts that don't need full metastore/dcache cleanup. Internally
-        delegates to the existing ``_pipe_destroy()`` helper.
-        """
-        self._pipe_destroy(path)
 
     # ------------------------------------------------------------------
     # Tier 2 public sync stream methods (kernel passthroughs)

--- a/src/nexus/core/nexus_fs_content.py
+++ b/src/nexus/core/nexus_fs_content.py
@@ -157,16 +157,12 @@ class ContentMixin:
                     if isinstance(_route, ExternalRouteResult):
                         raise
 
-        # DT_PIPE: result.data is the popped frame when available; None = empty.
+        # DT_PIPE: Rust pops one frame from ring buffer (non-blocking).
+        # Empty pipe returns b"" (POSIX non-blocking read(2) semantics).
         if result.entry_type == 3:  # DT_PIPE
             if result.data is not None:
                 return _apply_slice(result.data, offset, count)
-            # Empty pipe — try nowait (hot path), then block in Rust (GIL-free)
-            _data = self._kernel.pipe_read_nowait(path)
-            if _data is not None:
-                return _apply_slice(bytes(_data), offset, count)
-            _data = self._kernel.pipe_read_blocking(path, 5000)
-            return _apply_slice(bytes(_data), offset, count)
+            return b""
 
         # DT_STREAM: blocking reads with offset tracking
         if result.entry_type == 4:  # DT_STREAM

--- a/src/nexus/services/acp/service.py
+++ b/src/nexus/services/acp/service.py
@@ -389,7 +389,7 @@ class AcpService:
         if self._nexus_fs is not None:
             for fd_path in (active.fd0_path, active.fd1_path, active.fd2_path):
                 with contextlib.suppress(Exception):
-                    self._nexus_fs.pipe_destroy(fd_path)
+                    self._nexus_fs.sys_unlink(fd_path)
 
     def kill_agent(self, pid: str) -> AgentDescriptor:
         """Kill a running agent connection and mark TERMINATED in AgentRegistry."""

--- a/src/nexus/services/lifecycle/workflow_dispatch_service.py
+++ b/src/nexus/services/lifecycle/workflow_dispatch_service.py
@@ -202,6 +202,11 @@ class WorkflowDispatchService:
             except NexusFileNotFoundError:
                 logger.debug("Workflow pipe closed, consumer exiting")
                 break
+
+            if not data:
+                await asyncio.sleep(0.01)
+                continue
+
             try:
                 msg = json.loads(data)
                 await engine.fire_event(msg["type"], msg["ctx"])

--- a/src/nexus/task_manager/dispatch_consumer.py
+++ b/src/nexus/task_manager/dispatch_consumer.py
@@ -190,6 +190,10 @@ class TaskDispatchPipeConsumer:
                 logger.debug("[TASK-DISPATCH] pipe closed, consumer exiting")
                 break
 
+            if not data:
+                await asyncio.sleep(0.01)
+                continue
+
             try:
                 msg = json.loads(data)
                 await self._dispatch(msg)

--- a/tests/unit/server/test_rpc_parity.py
+++ b/tests/unit/server/test_rpc_parity.py
@@ -254,8 +254,6 @@ def test_all_public_methods_are_exposed_or_excluded():
         # LLM token pump) where async wrapping adds event-loop ping-pong.
         "pipe_create",  # Tier 2 → kernel.create_pipe (local-only)
         "pipe_close",  # Tier 2 → kernel.close_pipe (local-only)
-        "pipe_destroy",  # Tier 2 → kernel.destroy_pipe (local-only)
-        "pipe_read_nowait",  # Tier 2 → kernel.pipe_read_nowait (local-only)
         "has_pipe",  # Tier 2 → kernel.has_pipe (local-only)
         "stream_create",  # Tier 2 → kernel.create_stream (local-only)
         "stream_close",  # Tier 2 → kernel.close_stream (local-only)

--- a/tests/unit/services/test_acp_service.py
+++ b/tests/unit/services/test_acp_service.py
@@ -114,15 +114,14 @@ class TestAcpServiceKillAgent:
     """Test kill_agent teardown."""
 
     def test_kill_agent_destroys_pipes(self):
-        """kill_agent should destroy all 3 fd pipes via NexusFS.pipe_destroy()."""
+        """kill_agent should destroy all 3 fd pipes via NexusFS.sys_unlink()."""
         pt = MockAgentRegistry()
         svc = AcpService(agent_registry=pt)
 
-        # NexusFS is the primary owner of the pipe destroy path post IPC
-        # Rust-ification — teardown calls nx.pipe_destroy(path).
+        # Teardown calls nx.sys_unlink(path) for each fd pipe.
         destroyed: list[str] = []
         mock_nx = MagicMock()
-        mock_nx.pipe_destroy = MagicMock(side_effect=lambda path: destroyed.append(path))
+        mock_nx.sys_unlink = MagicMock(side_effect=lambda path, **kw: destroyed.append(path))
         svc.bind_fs(mock_nx)
 
         # Set up an active agent
@@ -149,7 +148,7 @@ class TestAcpServiceKillAgent:
         # Verify subprocess killed
         mock_proc.kill.assert_called_once()
 
-        # Verify DT_PIPEs destroyed via nx.pipe_destroy (all 3 fds)
+        # Verify DT_PIPEs destroyed via nx.sys_unlink (all 3 fds)
         assert "/root/proc/pid-1/fd/0" in destroyed
         assert "/root/proc/pid-1/fd/1" in destroyed
         assert "/root/proc/pid-1/fd/2" in destroyed
@@ -162,10 +161,10 @@ class TestAcpServiceCloseAll:
         pt = MockAgentRegistry()
         svc = AcpService(agent_registry=pt)
 
-        # Teardown goes through nx.pipe_destroy post IPC Rust-ification.
+        # Teardown goes through nx.sys_unlink post IPC Rust-ification.
         destroyed: list[str] = []
         mock_nx = MagicMock()
-        mock_nx.pipe_destroy = MagicMock(side_effect=lambda path: destroyed.append(path))
+        mock_nx.sys_unlink = MagicMock(side_effect=lambda path, **kw: destroyed.append(path))
         svc.bind_fs(mock_nx)
 
         for i in range(3):


### PR DESCRIPTION
## Summary

Follow-up to PR #3848 — complete elimination of all remaining pipe bypass APIs:

- **sys_read DT_PIPE non-blocking**: Remove `pipe_read_blocking(5s)` fallback, return `b""` for empty pipe (POSIX non-blocking `read(2)` semantics). Update 4 pipe consumers to poll with `asyncio.sleep(0.01)` on empty.
- **pipe_read_nowait eliminated**: Migrate skeleton_pipe_consumer from `pipe_read_nowait` to `sys_read`. Delete `pipe_read_nowait` from NexusFS public API.
- **pipe_destroy → sys_unlink**: Migrate ACP `_teardown_agent` from `pipe_destroy` to `sys_unlink`. Delete `pipe_destroy` from NexusFS and `VFSOperations` contract.

After this PR, all pipe I/O goes through `sys_read`/`sys_write`/`sys_unlink`. Only internal `_pipe_destroy` remains (sys_unlink fast-path for non-routable pipe paths).

Net: -18 lines (23 ins, 41 del).

## Test plan

- [x] `codegen_kernel_abi.py --check` — all OK
- [x] Pre-commit hooks pass (ruff, brick imports)
- [x] `test_rpc_parity.py` — passes with `pipe_read_nowait` + `pipe_destroy` removed from INTERNAL_ONLY_METHODS
- [x] `test_workflow_dispatch.py` — 16 tests pass
- [x] grep confirms zero `pipe_read_nowait`/`pipe_write_nowait`/`pipe_destroy` public API callers

🤖 Generated with [Claude Code](https://claude.com/claude-code)