### PR TITLE
fix(chat): use anthropic_* params for Anthropic backend mount

### DIFF
--- a/src/nexus/cli/commands/chat.py
+++ b/src/nexus/cli/commands/chat.py
@@ -248,9 +248,9 @@ async def _run_chat(
                 entry_type=DT_MOUNT,
                 backend_type="anthropic",
                 backend_name="anthropic_native",
-                openai_base_url=base_url,
-                openai_api_key=api_key,
-                openai_model=model,
+                anthropic_base_url=base_url,
+                anthropic_api_key=api_key,
+                anthropic_model=model,
             )
         else:
             # OpenAI-compatible driver


### PR DESCRIPTION
## Summary

- Fix `chat.py` Anthropic backend mount using wrong parameter names (`openai_*` → `anthropic_*`)
- `sys_setattr` with `backend_type="anthropic"` reads `anthropic_base_url`/`anthropic_api_key`/`anthropic_model` (nexus_fs_metadata.py:321-323), but chat.py was passing `openai_*` params → Anthropic client gets empty API key → 401

## Test plan

- [ ] `ANTHROPIC_API_KEY=sk-ant-... nexus chat -p "hello"` no longer returns 401
- [ ] `SUDOROUTER_BASE_URL=... nexus chat --acp` session/prompt works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)