### PR TITLE
fix(connectors): harden x cache scoping and gdrive listing

### DIFF
--- a/src/nexus/backends/connectors/gdrive/connector.py
+++ b/src/nexus/backends/connectors/gdrive/connector.py
@@ -25,6 +25,7 @@ Storage structure:
 from __future__ import annotations
 
 import logging
+import time
 from typing import TYPE_CHECKING, Any, ClassVar
 
 from nexus.backends.base.backend import HandlerStatusResponse
@@ -474,12 +475,73 @@ class PathGDriveBackend(
         try:
             path = path.strip("/")
             self._bind_transport(context)
+            bound = self._drive_transport.with_context(context)
+            service = bound._get_drive_service()
+            folder_id, path_prefix = bound._resolve_list_prefix(service, path)
+            if folder_id is None:
+                return []
 
-            blob_keys, common_prefixes = self._transport.list_keys(prefix=path, delimiter="/")
+            blob_keys: list[str] = []
+            common_prefixes: list[str] = []
+            next_page_token: str | None = None
+            seen_page_tokens: set[str] = set()
+            pages_fetched = 0
+            started_at = time.monotonic()
+
+            while True:
+                page_blobs, page_prefixes, next_page_token = bound._list_page_under_folder(
+                    service,
+                    folder_id,
+                    path_prefix,
+                    page_token=next_page_token,
+                    page_size=1000,
+                )
+                blob_keys.extend(page_blobs)
+                common_prefixes.extend(page_prefixes)
+                pages_fetched += 1
+
+                if not next_page_token:
+                    break
+                if next_page_token in seen_page_tokens:
+                    raise BackendError(
+                        f"Drive listing incomplete for '{path}': "
+                        f"repeated next_page_token={next_page_token}",
+                        backend="gdrive",
+                        path=path,
+                    )
+                seen_page_tokens.add(next_page_token)
+
+                limit_reason: str | None = None
+                if (
+                    bound._LIST_KEYS_MAX_ELAPSED_SECONDS is not None
+                    and (time.monotonic() - started_at) >= bound._LIST_KEYS_MAX_ELAPSED_SECONDS
+                ):
+                    limit_reason = (
+                        f"max_elapsed_seconds={bound._LIST_KEYS_MAX_ELAPSED_SECONDS} reached"
+                    )
+                elif (
+                    bound._LIST_KEYS_MAX_PAGES is not None
+                    and pages_fetched >= bound._LIST_KEYS_MAX_PAGES
+                ):
+                    limit_reason = f"max_pages={bound._LIST_KEYS_MAX_PAGES} reached"
+                elif (
+                    bound._LIST_KEYS_MAX_ITEMS is not None
+                    and (len(blob_keys) + len(common_prefixes)) >= bound._LIST_KEYS_MAX_ITEMS
+                ):
+                    limit_reason = f"max_items={bound._LIST_KEYS_MAX_ITEMS} reached"
+
+                if limit_reason:
+                    message = (
+                        f"Drive listing incomplete for '{path}': {limit_reason}. "
+                        f"next_page_token={next_page_token}"
+                    )
+                    if bound._LIST_KEYS_FAIL_ON_TRUNCATION:
+                        raise BackendError(message, backend="gdrive", path=path)
+                    logger.warning(message)
+                    break
 
             # Build entry list: folder names with trailing /, file names without
             entries: list[str] = []
-            path_prefix = f"{path}/" if path else ""
 
             for prefix_path in common_prefixes:
                 name = (

--- a/src/nexus/backends/connectors/gdrive/transport.py
+++ b/src/nexus/backends/connectors/gdrive/transport.py
@@ -26,6 +26,7 @@ from __future__ import annotations
 import io
 import logging
 import mimetypes
+import time
 from collections.abc import Iterator
 from copy import copy
 from typing import TYPE_CHECKING, Any
@@ -91,6 +92,10 @@ class DriveTransport:
     """
 
     transport_name: str = "gdrive"
+    _LIST_KEYS_MAX_PAGES: int | None = 200
+    _LIST_KEYS_MAX_ITEMS: int | None = 50000
+    _LIST_KEYS_MAX_ELAPSED_SECONDS: float = 120.0
+    _LIST_KEYS_FAIL_ON_TRUNCATION: bool = True
 
     def __init__(
         self,
@@ -186,48 +191,102 @@ class DriveTransport:
         query: str,
         fields: str = "files(id, name)",
         page_size: int = 1000,
+        *,
+        all_pages: bool = False,
+        max_pages: int | None = None,
+        max_items: int | None = None,
+        max_elapsed_seconds: float | None = None,
+        fail_on_truncation: bool = False,
     ) -> list[dict[str, Any]]:
-        """Execute files.list with shared drive support."""
-        if self._use_shared_drives and self._shared_drive_id:
-            results = (
-                service.files()
-                .list(
-                    q=query,
-                    spaces="drive",
-                    fields=fields,
-                    corpora="drive",
-                    driveId=self._shared_drive_id,
-                    includeItemsFromAllDrives=True,
-                    supportsAllDrives=True,
-                    pageSize=page_size,
+        """Execute files.list with shared-drive support and optional pagination."""
+        list_fields = fields
+        if all_pages and "nextPageToken" not in list_fields:
+            list_fields = f"nextPageToken, {list_fields}"
+
+        collected: list[dict[str, Any]] = []
+        page_token: str | None = None
+        seen_page_tokens: set[str] = set()
+        pages_fetched = 0
+        truncation_reason: str | None = None
+        started_at = time.monotonic()
+
+        while True:
+            if (
+                max_elapsed_seconds is not None
+                and (time.monotonic() - started_at) >= max_elapsed_seconds
+            ):
+                truncation_reason = f"max_elapsed_seconds={max_elapsed_seconds} reached"
+                break
+
+            page_size_for_call = page_size
+            if max_items is not None:
+                remaining = max_items - len(collected)
+                if remaining <= 0:
+                    truncation_reason = f"max_items={max_items} reached"
+                    break
+                page_size_for_call = min(page_size, remaining)
+
+            kwargs: dict[str, Any] = {
+                "q": query,
+                "spaces": "drive",
+                "fields": list_fields,
+                "pageSize": page_size_for_call,
+            }
+            if page_token:
+                kwargs["pageToken"] = page_token
+
+            if self._use_shared_drives and self._shared_drive_id:
+                kwargs.update(
+                    {
+                        "corpora": "drive",
+                        "driveId": self._shared_drive_id,
+                        "includeItemsFromAllDrives": True,
+                        "supportsAllDrives": True,
+                    }
                 )
-                .execute()
-            )
-        elif self._use_shared_drives:
-            results = (
-                service.files()
-                .list(
-                    q=query,
-                    spaces="drive",
-                    fields=fields,
-                    includeItemsFromAllDrives=True,
-                    supportsAllDrives=True,
-                    pageSize=page_size,
+            elif self._use_shared_drives:
+                kwargs.update(
+                    {
+                        "includeItemsFromAllDrives": True,
+                        "supportsAllDrives": True,
+                    }
                 )
-                .execute()
-            )
-        else:
-            results = (
-                service.files()
-                .list(
-                    q=query,
-                    spaces="drive",
-                    fields=fields,
-                    pageSize=page_size,
-                )
-                .execute()
-            )
-        return list(results.get("files", []))
+
+            results = service.files().list(**kwargs).execute()
+            pages_fetched += 1
+            page_files = list(results.get("files", []))
+            collected.extend(page_files)
+
+            if not all_pages:
+                break
+
+            next_page_token = results.get("nextPageToken")
+            if not next_page_token:
+                break
+            if max_pages is not None and pages_fetched >= max_pages:
+                truncation_reason = f"max_pages={max_pages} reached"
+                break
+            if max_items is not None and len(collected) >= max_items:
+                truncation_reason = f"max_items={max_items} reached"
+                break
+            if next_page_token in seen_page_tokens:
+                truncation_reason = "repeated nextPageToken detected"
+                break
+            seen_page_tokens.add(next_page_token)
+            page_token = next_page_token
+
+        if truncation_reason:
+            message = f"Drive listing incomplete for query={query}: {truncation_reason}"
+            if fail_on_truncation:
+                raise BackendError(message, backend="gdrive")
+            logger.warning(message)
+
+        return collected
+
+    @staticmethod
+    def _escape_query_literal(value: str) -> str:
+        """Escape string literal for Google Drive query expressions."""
+        return value.replace("\\", "\\\\").replace("'", "\\'")
 
     def _get_or_create_root_folder(self, service: Resource) -> str:
         """Get or create root folder in Drive.
@@ -246,8 +305,9 @@ class DriveTransport:
             return self._folder_cache[cache_key]
 
         try:
+            escaped_root_folder = self._escape_query_literal(self._root_folder)
             query = (
-                f"name='{self._root_folder}' "
+                f"name='{escaped_root_folder}' "
                 f"and mimeType='application/vnd.google-apps.folder' "
                 f"and trashed=false"
             )
@@ -302,8 +362,10 @@ class DriveTransport:
             return self._folder_cache[cache_key]
 
         try:
+            escaped_name = self._escape_query_literal(name)
+            escaped_parent_id = self._escape_query_literal(parent_id)
             query = (
-                f"name='{name}' and '{parent_id}' in parents "
+                f"name='{escaped_name}' and '{escaped_parent_id}' in parents "
                 f"and mimeType='application/vnd.google-apps.folder' "
                 f"and trashed=false"
             )
@@ -345,8 +407,10 @@ class DriveTransport:
         Returns:
             Folder ID if found, None otherwise.
         """
+        escaped_name = self._escape_query_literal(name)
+        escaped_parent_id = self._escape_query_literal(parent_id)
         query = (
-            f"name='{name}' and '{parent_id}' in parents "
+            f"name='{escaped_name}' and '{escaped_parent_id}' in parents "
             f"and mimeType='application/vnd.google-apps.folder' and trashed=false"
         )
         files = self._list_files(service, query)
@@ -403,7 +467,9 @@ class DriveTransport:
         fields: str = "files(id, name)",
     ) -> list[dict[str, Any]]:
         """Find files by name in a parent folder."""
-        query = f"name='{filename}' and '{parent_id}' in parents and trashed=false"
+        escaped_filename = self._escape_query_literal(filename)
+        escaped_parent_id = self._escape_query_literal(parent_id)
+        query = f"name='{escaped_filename}' and '{escaped_parent_id}' in parents and trashed=false"
         return self._list_files(service, query, fields=fields)
 
     # ------------------------------------------------------------------
@@ -573,6 +639,98 @@ class DriveTransport:
         except Exception as e:
             raise NexusFileNotFoundError(key) from e
 
+    def _resolve_list_prefix(
+        self,
+        service: Resource,
+        prefix: str,
+    ) -> tuple[str | None, str]:
+        """Resolve list prefix to (folder_id, path_prefix)."""
+        if not prefix:
+            return self._get_or_create_root_folder(service), ""
+
+        root_id = self._get_or_create_root_folder(service)
+        parts = prefix.split("/")
+        current_id = root_id
+        for part in parts:
+            if not part:
+                continue
+            found = self._find_folder(service, part, current_id)
+            if found is None:
+                return None, ""
+            current_id = found
+        return current_id, prefix + "/"
+
+    def _list_page_under_folder(
+        self,
+        service: Resource,
+        folder_id: str,
+        path_prefix: str,
+        *,
+        page_size: int = 1000,
+        page_token: str | None = None,
+    ) -> tuple[list[str], list[str], str | None]:
+        """List a single Drive page under a folder and return nextPageToken."""
+        escaped_folder_id = self._escape_query_literal(folder_id)
+        query = f"'{escaped_folder_id}' in parents and trashed=false"
+        kwargs: dict[str, Any] = {
+            "q": query,
+            "spaces": "drive",
+            "fields": "nextPageToken, files(id, name, mimeType)",
+            "pageSize": page_size,
+        }
+        if page_token:
+            kwargs["pageToken"] = page_token
+        if self._use_shared_drives and self._shared_drive_id:
+            kwargs.update(
+                {
+                    "corpora": "drive",
+                    "driveId": self._shared_drive_id,
+                    "includeItemsFromAllDrives": True,
+                    "supportsAllDrives": True,
+                }
+            )
+        elif self._use_shared_drives:
+            kwargs.update(
+                {
+                    "includeItemsFromAllDrives": True,
+                    "supportsAllDrives": True,
+                }
+            )
+
+        result = service.files().list(**kwargs).execute()
+        blob_keys: list[str] = []
+        common_prefixes: list[str] = []
+        for file_entry in result.get("files", []):
+            name = file_entry["name"]
+            file_mime = file_entry.get("mimeType", "")
+            if file_mime == "application/vnd.google-apps.folder":
+                common_prefixes.append(f"{path_prefix}{name}/")
+            else:
+                blob_keys.append(f"{path_prefix}{name}")
+        return blob_keys, common_prefixes, result.get("nextPageToken")
+
+    def list_keys_page(
+        self,
+        prefix: str,
+        *,
+        page_token: str | None = None,
+        page_size: int = 1000,
+    ) -> tuple[list[str], list[str], str | None]:
+        """List a single page of keys and return continuation token."""
+        service = self._get_drive_service()
+        prefix = prefix.strip("/")
+        folder_id, path_prefix = self._resolve_list_prefix(service, prefix)
+        if folder_id is None:
+            return [], [], None
+        blob_keys, common_prefixes, next_page_token = self._list_page_under_folder(
+            service,
+            folder_id,
+            path_prefix,
+            page_size=page_size,
+            page_token=page_token,
+        )
+        return sorted(set(blob_keys)), sorted(set(common_prefixes)), next_page_token
+
     def list_keys(self, prefix: str, delimiter: str = "/") -> tuple[list[str], list[str]]:
         """List files and folders under *prefix*.
 
@@ -585,43 +743,65 @@ class DriveTransport:
         """
         service = self._get_drive_service()
         prefix = prefix.strip("/")
-
-        # Resolve prefix to folder ID
-        if not prefix:
-            folder_id = self._get_or_create_root_folder(service)
-            path_prefix = ""
-        else:
-            root_id = self._get_or_create_root_folder(service)
-            parts = prefix.split("/")
-            current_id = root_id
-            for part in parts:
-                if not part:
-                    continue
-                found = self._find_folder(service, part, current_id)
-                if found is None:
-                    # Folder doesn't exist — return empty
-                    return [], []
-                current_id = found
-            folder_id = current_id
-            path_prefix = prefix + "/"
-
-        # Query all files/folders in this directory
-        query = f"'{folder_id}' in parents and trashed=false"
-        files = self._list_files(service, query, fields="files(id, name, mimeType)", page_size=1000)
-
         blob_keys: list[str] = []
         common_prefixes: list[str] = []
+        folder_id, path_prefix = self._resolve_list_prefix(service, prefix)
+        if folder_id is None:
+            return [], []
 
-        for file_entry in files:
-            name = file_entry["name"]
-            file_mime = file_entry.get("mimeType", "")
+        next_page_token: str | None = None
+        pages_fetched = 0
+        started_at = time.monotonic()
+        truncation_reason: str | None = None
+        seen_page_tokens: set[str] = set()
 
-            if file_mime == "application/vnd.google-apps.folder":
-                common_prefixes.append(f"{path_prefix}{name}/")
-            else:
-                blob_keys.append(f"{path_prefix}{name}")
+        while True:
+            page_blobs, page_prefixes, next_page_token = self._list_page_under_folder(
+                service,
+                folder_id,
+                path_prefix,
+                page_size=1000,
+                page_token=next_page_token,
+            )
+            blob_keys.extend(page_blobs)
+            common_prefixes.extend(page_prefixes)
+            pages_fetched += 1
 
-        return sorted(blob_keys), sorted(common_prefixes)
+            if not next_page_token:
+                break
+            if next_page_token in seen_page_tokens:
+                truncation_reason = "repeated nextPageToken detected"
+                break
+            seen_page_tokens.add(next_page_token)
+            if (
+                self._LIST_KEYS_MAX_ELAPSED_SECONDS is not None
+                and (time.monotonic() - started_at) >= self._LIST_KEYS_MAX_ELAPSED_SECONDS
+            ):
+                truncation_reason = (
+                    f"max_elapsed_seconds={self._LIST_KEYS_MAX_ELAPSED_SECONDS} reached"
+                )
+                break
+            if self._LIST_KEYS_MAX_PAGES is not None and pages_fetched >= self._LIST_KEYS_MAX_PAGES:
+                truncation_reason = f"max_pages={self._LIST_KEYS_MAX_PAGES} reached"
+                break
+            if (
+                self._LIST_KEYS_MAX_ITEMS is not None
+                and (len(blob_keys) + len(common_prefixes)) >= self._LIST_KEYS_MAX_ITEMS
+            ):
+                truncation_reason = f"max_items={self._LIST_KEYS_MAX_ITEMS} reached"
+                break
+
+        if truncation_reason and next_page_token:
+            message = (
+                f"Drive listing incomplete for prefix='{prefix}': {truncation_reason}. "
+                f"next_page_token={next_page_token}. "
+                "Use list_keys_page(prefix=..., page_token=...) to continue."
+            )
+            if self._LIST_KEYS_FAIL_ON_TRUNCATION:
+                raise BackendError(message, backend="gdrive")
+            logger.warning(message)
+
+        return sorted(set(blob_keys)), sorted(set(common_prefixes))
 
     def copy_key(self, src_key: str, dst_key: str) -> None:
         """Copy a file within Drive (server-side copy)."""

--- a/src/nexus/backends/connectors/x/connector.py
+++ b/src/nexus/backends/connectors/x/connector.py
@@ -413,8 +413,19 @@ class PathXBackend(
         if pattern.startswith("/x/search/"):
             cache_path = Path(self._cache_dir)
             matches = []
-            for file in cache_path.glob("x:*:search:*.json"):
-                virtual_path = f"/x/search/{file.stem.split(':')[-1]}.json"
+            bound_transport = self._x_transport.with_context(context)
+            scope_token = bound_transport._scope_cache_token(
+                bound_transport._cache_scope_identity()
+            )
+            for file in cache_path.glob(f"x:{scope_token}:search:*.json"):
+                stem = file.stem
+                try:
+                    _, endpoint, query_hash = stem.rsplit(":", 2)
+                except ValueError:
+                    continue
+                if endpoint != "search":
+                    continue
+                virtual_path = f"/x/search/{query_hash}.json"
                 matches.append(virtual_path)
             filtered = glob_fast.glob_filter(matches, include_patterns=[pattern])
             return sorted(set(filtered))
@@ -448,33 +459,36 @@ class PathXBackend(
 
         # Search cached files
         if path.startswith("x/timeline") or path.startswith("x/bookmarks"):
-            return self._grep_cached(regex, path, max_results)
+            return self._grep_cached(regex, path, max_results, context=context)
 
         # Search user's tweets via API
         if path.startswith("x/posts"):
             return self._grep_user_tweets(regex, max_results, context)
 
         # Fallback: search cached files
-        return self._grep_cached(regex, path, max_results)
+        return self._grep_cached(regex, path, max_results, context=context)
 
     def _grep_cached(
         self,
         regex: re.Pattern[str],
         path: str,
         max_results: int,
+        context: Any = None,
     ) -> list[dict[str, Any]]:
         """Search cached JSON files."""
         import json
 
         results: list[dict[str, Any]] = []
         cache_path = Path(self._cache_dir)
+        bound_transport = self._x_transport.with_context(context)
+        scope_token = bound_transport._scope_cache_token(bound_transport._cache_scope_identity())
 
         pattern_map = {
-            "x/timeline": "x:*:timeline:*.json",
-            "x/bookmarks": "x:*:bookmarks:*.json",
-            "x/mentions": "x:*:mentions:*.json",
+            "x/timeline": f"x:{scope_token}:timeline:*.json",
+            "x/bookmarks": f"x:{scope_token}:bookmarks:*.json",
+            "x/mentions": f"x:{scope_token}:mentions:*.json",
         }
-        glob_pattern = pattern_map.get(path, "*.json")
+        glob_pattern = pattern_map.get(path, f"x:{scope_token}:*.json")
 
         for file in cache_path.glob(glob_pattern):
             if len(results) >= max_results:
@@ -516,7 +530,7 @@ class PathXBackend(
             transport = self._x_transport.with_context(context)
             client = await transport._get_api_client_async()
             try:
-                user_id = await transport._get_user_id()
+                user_id = await transport._get_user_id(client=client)
                 response = await client.get_user_tweets(user_id, max_results=100)
                 for tweet in response.get("data", []):
                     if len(results) >= max_results:

--- a/src/nexus/backends/connectors/x/transport.py
+++ b/src/nexus/backends/connectors/x/transport.py
@@ -87,6 +87,17 @@ class XTransport:
     """
 
     transport_name: str = "x"
+    _CACHE_SCOPE_REVALIDATE_SECONDS: float = 60.0
+    _READ_CACHE_ENDPOINTS: tuple[str, ...] = (
+        "timeline",
+        "mentions",
+        "user_tweets",
+        "user_tweets_by_username",
+        "single_tweet",
+        "bookmarks",
+        "search",
+        "user_profile",
+    )
 
     def __init__(
         self,
@@ -109,13 +120,19 @@ class XTransport:
         # Create cache directory
         os.makedirs(self._cache_dir, exist_ok=True)
 
-        # In-memory cache: (cache_key, user_id) -> (content, timestamp)
+        # In-memory cache: (cache_key, cache_scope) -> (content, timestamp)
         self._memory_cache: LRUCache[tuple[str, str], tuple[bytes, float]] = LRUCache(
             maxsize=memory_cache_maxsize
         )
 
-        # User ID cache: user_email -> x_user_id
-        self._user_id_cache: LRUCache[str, str] = LRUCache(maxsize=user_id_cache_maxsize)
+        # User ID cache: (provider, zone_id, user_email, token_fingerprint) -> x_user_id
+        # Include token fingerprint so account relink/rotation doesn't reuse a stale ID.
+        self._user_id_cache: LRUCache[tuple[str, str, str, str], str] = LRUCache(
+            maxsize=user_id_cache_maxsize
+        )
+        # Tracks last seen token fingerprint per cache scope.
+        self._scope_token_fingerprint: dict[str, str] = {}
+        self._scope_fingerprint_checked_at: dict[str, float] = {}
 
     # ------------------------------------------------------------------
     # Context binding (per-request OAuth token resolution)
@@ -265,7 +282,11 @@ class XTransport:
                 backend="x",
             ) from e
 
-        return XAPIClient(access_token=access_token)
+        token_fingerprint = hashlib.sha256(access_token.encode("utf-8")).hexdigest()[:16]
+        client = XAPIClient(access_token=access_token)
+        # Attach a stable token identifier for cache keying without exposing token contents.
+        client._token_fingerprint = token_fingerprint
+        return client
 
     def _get_api_client(self) -> Any:
         """Get authenticated X API client (sync wrapper)."""
@@ -273,38 +294,56 @@ class XTransport:
 
         return run_sync(self._get_api_client_async())
 
-    async def _get_user_id(self) -> str:
-        """Get X user ID for authenticated user.
+    def _user_cache_key(
+        self,
+        resolved_email: str,
+        zone_id: str,
+        token_fingerprint: str,
+    ) -> tuple[str, str, str, str]:
+        """Build cache key for user-id lookups scoped to credential context."""
+        return (self._provider, zone_id, resolved_email, token_fingerprint)
 
-        Key the user-id cache on the resolved ``(zone_id, oauth_email)``
-        principal (not the raw nexus subject ID) so two zones sharing a
-        subject cannot pin each other's X user id.
-        """
+    def _cache_scope_identity(self) -> str:
+        """Build scoped identity used for read-cache segregation."""
+        resolved_email, zone_id = self._resolve_principal()
+        return self._cache_principal(resolved_email, zone_id)
+
+    @staticmethod
+    def _scope_cache_token(scope_identity: str) -> str:
+        """Normalize cache scope to a filename-safe token."""
+        return hashlib.sha256(scope_identity.encode("utf-8")).hexdigest()[:20]
+
+    async def _get_user_id(self, client: Any | None = None) -> str:
+        """Get X user ID for authenticated user."""
         resolved_email, zone_id = await self._resolve_principal_async()
-        cache_key = self._cache_principal(resolved_email, zone_id)
 
-        if cache_key in self._user_id_cache:
-            return self._user_id_cache[cache_key]
-
-        client = await self._get_api_client_async()
+        owns_client = client is None
+        active_client = client or await self._get_api_client_async()
         try:
-            user_data = await client.get_me()
+            token_fingerprint = getattr(active_client, "_token_fingerprint", "unknown-token")
+            cache_key = self._user_cache_key(resolved_email, zone_id, token_fingerprint)
+            if cache_key in self._user_id_cache:
+                return self._user_id_cache[cache_key]
+
+            user_data = await active_client.get_me()
             user_id: str = user_data["data"]["id"]
             self._user_id_cache[cache_key] = user_id
             return user_id
         finally:
-            await client.close()
+            if owns_client:
+                await active_client.close()
 
     def _generate_cache_key(
         self,
         endpoint: str,
         params: dict[str, Any],
-        user_id: str,
+        cache_scope: str,
     ) -> str:
         """Generate deterministic cache key for API request."""
         param_str = json.dumps(params, sort_keys=True)
         param_hash = hashlib.md5(param_str.encode()).hexdigest()[:8]
-        return f"x:{user_id}:{endpoint}:{param_hash}"
+        scope_token = self._scope_cache_token(cache_scope)
+        return f"x:{scope_token}:{endpoint}:{param_hash}"
 
     def _get_cached(
         self,
@@ -351,13 +390,13 @@ class XTransport:
 
     def _invalidate_caches(
         self,
-        user_id: str,
+        cache_scope: str,
         endpoint_types: list[str],
     ) -> None:
         """Invalidate caches for specific endpoint types."""
         keys_to_delete = []
         for cache_key, cached_user_id in self._memory_cache:
-            if cached_user_id == user_id:
+            if cached_user_id == cache_scope:
                 for endpoint_type in endpoint_types:
                     if f":{endpoint_type}:" in cache_key:
                         keys_to_delete.append((cache_key, cached_user_id))
@@ -368,12 +407,17 @@ class XTransport:
             logger.debug("[X-CACHE] Invalidated: %s", key[0])
 
         cache_dir = Path(self._cache_dir)
-        for cache_file in cache_dir.glob(f"x:{user_id}:*.json"):
-            for endpoint_type in endpoint_types:
-                if f":{endpoint_type}:" in cache_file.name:
-                    cache_file.unlink()
-                    logger.debug("[X-CACHE] Deleted: %s", cache_file.name)
-                    break
+        patterns = [
+            f"x:{self._scope_cache_token(cache_scope)}:*.json",
+            f"x:{cache_scope}:*.json",  # Legacy pre-tokenized cache key fallback
+        ]
+        for pattern in patterns:
+            for cache_file in cache_dir.glob(pattern):
+                for endpoint_type in endpoint_types:
+                    if f":{endpoint_type}:" in cache_file.name:
+                        cache_file.unlink()
+                        logger.debug("[X-CACHE] Deleted: %s", cache_file.name)
+                        break
 
     def _resolve_path(self, backend_path: str) -> tuple[str, dict[str, Any]]:
         """Resolve virtual path to X API endpoint.
@@ -566,19 +610,12 @@ class XTransport:
     def fetch(self, key: str, version_id: str | None = None) -> tuple[bytes, str | None]:
         """Fetch X content as JSON bytes by transport key."""
         endpoint_type, params = self._resolve_path(key)
-
-        # Resolve the OAuth principal BEFORE touching the cache — keying on
-        # the raw ``context.user_id`` (e.g. ``"admin"``) would let two zones
-        # or two accounts sharing a nexus subject serve each other's cached
-        # responses.  ``_cache_principal`` composes zone + email so each
-        # tenant's cache is physically distinct.
-        resolved_email, zone_id = self._resolve_principal()
-        principal = self._cache_principal(resolved_email, zone_id)
-
-        # Check cache
-        cache_key = self._generate_cache_key(endpoint_type, params, principal)
         ttl = self._cache_ttl.get(endpoint_type, 300)
-        cached = self._get_cached(cache_key, principal, ttl)
+        cache_scope = self._cache_scope_identity()
+        cache_key = self._generate_cache_key(endpoint_type, params, cache_scope)
+
+        # Keep cache fast-path independent from OAuth/token-manager health.
+        cached = self._get_cached(cache_key, cache_scope, ttl)
         if cached:
             return cached, None
 
@@ -586,11 +623,11 @@ class XTransport:
         async def _read() -> bytes:
             client = await self._get_api_client_async()
             try:
-                user_id = await self._get_user_id()
+                user_id = await self._get_user_id(client=client)
                 data = await self._fetch_from_api(client, endpoint_type, params, user_id)
                 transformed = self._transform_response(endpoint_type, data)
                 content = json.dumps(transformed, indent=2).encode("utf-8")
-                self._set_cached(cache_key, principal, content)
+                self._set_cached(cache_key, cache_scope, content)
                 return content
             finally:
                 await client.close()
@@ -709,8 +746,16 @@ class XTransport:
         if prefix == "search":
             cache_path = Path(self._cache_dir)
             entries = []
-            for file in cache_path.glob("x:*:search:*.json"):
-                entries.append(f"search/{file.name.replace('x:', '').split(':')[2]}.json")
+            scope_token = self._scope_cache_token(self._cache_scope_identity())
+            for file in cache_path.glob(f"x:{scope_token}:search:*.json"):
+                stem = file.stem
+                try:
+                    _, endpoint, query_hash = stem.rsplit(":", 2)
+                except ValueError:
+                    # Legacy/unexpected cache key format — ignore noisy entries.
+                    continue
+                if endpoint == "search":
+                    entries.append(f"search/{query_hash}.json")
             return sorted(set(entries)), []
 
         if prefix == "users":

--- a/src/nexus/backends/connectors/x/transport.py
+++ b/src/nexus/backends/connectors/x/transport.py
@@ -33,7 +33,7 @@ from collections.abc import Iterator
 from copy import copy
 from datetime import datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from cachetools import LRUCache
 
@@ -285,7 +285,7 @@ class XTransport:
         token_fingerprint = hashlib.sha256(access_token.encode("utf-8")).hexdigest()[:16]
         client = XAPIClient(access_token=access_token)
         # Attach a stable token identifier for cache keying without exposing token contents.
-        client._token_fingerprint = token_fingerprint
+        cast(Any, client)._token_fingerprint = token_fingerprint
         return client
 
     def _get_api_client(self) -> Any:


### PR DESCRIPTION
## Summary
- Harden X connector cache scoping and rotation behavior to reduce stale cross-scope data exposure risks across `fetch`, `glob`, and `grep` paths.
- Improve Google Drive connector listing robustness with safer pagination handling, repeated-token detection, and large-directory safeguards.
- Add connector-level pagination utilities to make large directory enumeration behavior more predictable under load and API edge conditions.

## Test plan
- [x] `ruff check src/nexus/backends/connectors/x/transport.py src/nexus/backends/connectors/x/connector.py src/nexus/backends/connectors/gdrive/transport.py src/nexus/backends/connectors/gdrive/connector.py`
- [x] `python -m py_compile src/nexus/backends/connectors/x/transport.py src/nexus/backends/connectors/x/connector.py src/nexus/backends/connectors/gdrive/transport.py src/nexus/backends/connectors/gdrive/connector.py`
- [x] Pre-commit hooks pass on commit
- [ ] Run connector integration tests in CI

Made with [Cursor](https://cursor.com)