### PR TITLE
release: v0.9.35 — fix macos-14 protoc + stale _nexus_raft smoke test

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -121,6 +121,10 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Install protoc (macOS)
+        if: runner.os == 'macOS'
+        run: brew install protobuf
+
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
@@ -486,7 +490,7 @@ jobs:
             ghcr.io/nexi-lab/nexus:smoke-test \
             python3 -c "
           import nexus_kernel
-          from _nexus_raft import Metastore
+          from nexus_kernel import Metastore
           import txtai
           import pgvector
           import docker

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "kernel"
-version = "0.9.34"
+version = "0.9.35"
 dependencies = [
  "ahash",
  "blake3",

--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/api-client",
-  "version": "0.9.34",
+  "version": "0.9.35",
   "description": "Shared HTTP client for Nexus APIs — retry, auth, error mapping, case transform",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/tui",
-  "version": "0.9.34",
+  "version": "0.9.35",
   "description": "Terminal UI for Nexus \u2014 file explorer, API inspector, and monitoring dashboard",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.34"
+version = "0.9.35"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/rust/kernel/Cargo.toml
+++ b/rust/kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel"
-version = "0.9.34"
+version = "0.9.35"
 edition = "2021"
 
 [lib]

--- a/rust/kernel/pyproject.toml
+++ b/rust/kernel/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-kernel"
-version = "0.9.34"
+version = "0.9.35"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
 requires-python = ">=3.14"
 classifiers = [


### PR DESCRIPTION
## Summary

- v0.9.34 release workflow ([run 24816674711](https://github.com/nexi-lab/nexus/actions/runs/24816674711)) failed on two jobs — **Build nexus-kernel wheel (macos-14, py3.14)** and **Build & push Docker (cpu)**. This PR bumps to 0.9.35 and fixes both.
- **macos-14 wheel**: `raft-proto v0.7.0` build script requires `protoc` in `PATH`; macos-14 runner image doesn't ship one. `rust/kernel/build.rs`'s vendored-protoc setup only covers its own prost/tonic codegen — it can't reach raft-proto's separate build process. Added a `brew install protobuf` step gated on `runner.os == 'macOS'`.
- **Docker cpu smoke test**: `_nexus_raft` Python module was removed in the F2/C8 refactor (`nexus_raft` crate is now rlib-only; `Metastore`/`ZoneManager`/`ZoneHandle` are registered into the `nexus_kernel` cdylib — see `rust/kernel/src/lib.rs:212`). The smoke test still imported `_nexus_raft`. Changed to `from nexus_kernel import Metastore`.
- Version bumps to 0.9.35: `pyproject.toml`, `rust/kernel/pyproject.toml`, `rust/kernel/Cargo.toml`, `Cargo.lock`, `packages/nexus-api-client/package.json`, `packages/nexus-tui/package.json`.

## Out of scope (not blocking this release)

Other stale `_nexus_raft` references exist but are in workflows that didn't run for this release and can be cleaned up in a follow-up:
- `.github/workflows/conda-pack.yml:132`
- `.github/workflows/pyinstaller-cluster.yml:262`
- `rust/raft/pyproject.toml` (dead maturin config — crate is rlib-only)

## Test plan

- [ ] Merge, then tag `v0.9.35` on develop tip.
- [ ] Release workflow passes on all four wheel matrix entries (ubuntu, windows, macos-14, macos-15-intel).
- [ ] Docker cpu smoke test imports `nexus_kernel.Metastore` successfully.
- [ ] Publish-pypi and Create-GitHub-Release jobs run (not skipped).