### PR TITLE
release: v0.9.36 — pin protoc 3.20.3 for raft-proto build on macOS

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,8 +122,26 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install protoc (macOS)
+        # raft-proto's build script uses `protobuf-build v0.14.1`, which
+        # rejects protoc's new calendar-versioned releases (e.g. "libprotoc
+        # 34.1") with "No suitable `protoc` (>= 3.1.0) found in PATH". Pin
+        # to the last classic 3.x release — brew's `protobuf` formula ships
+        # 34.x and is unusable here.
         if: runner.os == 'macOS'
-        run: brew install protobuf
+        run: |
+          set -euo pipefail
+          PROTOC_VERSION=3.20.3
+          case "$(uname -m)" in
+            arm64) ARCH=aarch_64 ;;
+            x86_64) ARCH=x86_64 ;;
+            *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;;
+          esac
+          mkdir -p "$HOME/protoc"
+          curl -fsSL -o /tmp/protoc.zip \
+            "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-osx-${ARCH}.zip"
+          unzip -o /tmp/protoc.zip -d "$HOME/protoc"
+          echo "$HOME/protoc/bin" >> "$GITHUB_PATH"
+          "$HOME/protoc/bin/protoc" --version
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "kernel"
-version = "0.9.35"
+version = "0.9.36"
 dependencies = [
  "ahash",
  "blake3",

--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/api-client",
-  "version": "0.9.35",
+  "version": "0.9.36",
   "description": "Shared HTTP client for Nexus APIs — retry, auth, error mapping, case transform",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/tui",
-  "version": "0.9.35",
+  "version": "0.9.36",
   "description": "Terminal UI for Nexus \u2014 file explorer, API inspector, and monitoring dashboard",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.35"
+version = "0.9.36"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/rust/kernel/Cargo.toml
+++ b/rust/kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel"
-version = "0.9.35"
+version = "0.9.36"
 edition = "2021"
 
 [lib]

--- a/rust/kernel/pyproject.toml
+++ b/rust/kernel/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-kernel"
-version = "0.9.35"
+version = "0.9.36"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
 requires-python = ">=3.14"
 classifiers = [


### PR DESCRIPTION
## Summary

- v0.9.35's `brew install protobuf` step pulled protoc **34.1.x** (new calendar versioning). `protobuf-build v0.14.1` — the build-time helper used by `raft-proto v0.7.0` — rejects anything outside the classic 3.x scheme, so the macos-14 wheel still failed ([run 24818089067](https://github.com/nexi-lab/nexus/actions/runs/24818089067)):
  ```
  The system `protoc` version mismatch, require >= 3.1.0, got 34.1.x
  No suitable `protoc` (>= 3.1.0) found in PATH
  ```
- Fix: download the last classic 3.x release (**3.20.3**) directly from the protocolbuffers GitHub release, arch-matched via `uname -m`, and prepend to `PATH` via `$GITHUB_PATH`. No external action, no Homebrew drift.
- Version bumps to 0.9.36 in the six usual files.

## Scope note

The other failed runs on v0.9.35 tag — **Conda Pack** and **Build Standalone Binary** — are unrelated pre-existing breakages and are NOT fixed in this PR:

- Both workflows still reference the deleted `_nexus_raft` Python module (`conda-pack.yml:132`, `pyinstaller-cluster.yml:262`, `pyinstaller_spec_cluster.py`, `rust/raft/pyproject.toml`).
- Conda-pack additionally fails much earlier: the `pdf-inspector` transitive dep bundles `pyo3-ffi 0.22.6`, which caps Python at 3.13; conda envs run 3.14, so `pip install .` breaks before reaching any raft code.

These block binary-artifact publishing but not the PyPI / npm / GitHub-Release path in `release.yml`. Tracking for a follow-up PR.

## Test plan

- [ ] Merge, tag `v0.9.36`, push tag.
- [ ] Release workflow: all four wheel matrix entries green (ubuntu, windows, macos-14, macos-15-intel).
- [ ] Docker cpu smoke test passes (validated in v0.9.35 path — smoke-test import fix already landed).
- [ ] `Publish nexus-kernel to PyPI` and `Publish nexus-ai-fs to PyPI` run (not skipped).
- [ ] `Create GitHub Release` runs.