### PR TITLE
release: v0.9.37 — unblock conda-pack on Python 3.14

### DIFF
--- a/.github/workflows/conda-pack.yml
+++ b/.github/workflows/conda-pack.yml
@@ -7,11 +7,13 @@ name: Conda Pack
 # so there is no conflict between this workflow and release.yml.
 #
 # Build order per runner:
-#   1. Create nexus conda env (Python 3.14) + pip install .
-#   2. Compile kernel  (rust/kernel) via maturin
-#   3. Compile raft  (rust/raft --features full) via maturin
-#   4. pip install both .whl files into the nexus env
-#   5. conda-pack the nexus env → <artifact_name>-<version>.tar.gz
+#   1. Create nexus conda env (Python 3.14)
+#   2. Rust toolchain + (macOS) pinned protoc 3.20.3
+#   3. pip install . (pdf-inspector builds from sdist against pyo3-ffi)
+#   4. Compile kernel (rust/kernel) via maturin — pulls in raft rlib;
+#      Metastore / ZoneManager are re-exported from nexus_kernel
+#   5. pip install kernel wheel into the nexus env (skipped on Windows)
+#   6. conda-pack the nexus env → <artifact_name>-<version>.tar.gz
 
 on:
   workflow_dispatch:
@@ -21,6 +23,12 @@ on:
 
 permissions:
   contents: write
+
+# pdf-inspector ships PyO3 0.22.6 in its sdist; that release caps at
+# Python 3.13 and only accepts 3.14 when we opt into abi3 forward-
+# compatibility. pyproject.toml's core deps document the requirement.
+env:
+  PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
 
 jobs:
   conda-pack:
@@ -67,14 +75,10 @@ jobs:
         run: |
           conda create -n nexus python=3.14 -y
 
-      - name: Install project into nexus environment
-        shell: bash -el {0}
-        run: |
-          conda run -n nexus pip install .
-
       # ── Rust toolchain ────────────────────────────────────────────────────
-      # Reads the required toolchain version from rust-toolchain.toml
-      # automatically. No need to specify the version explicitly.
+      # Must come BEFORE `pip install .` because pdf-inspector's sdist has
+      # no cp314 wheel and builds from source against pyo3-ffi. Reads the
+      # required toolchain version from rust-toolchain.toml automatically.
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
@@ -89,7 +93,34 @@ jobs:
           shared-key: conda-pack-rust-${{ matrix.os }}
           workspaces: |
             rust/kernel
-            rust/raft
+
+      # ── protoc for raft-proto transitive build script ────────────────────
+      # rust/kernel pulls in raft → raft-proto, whose build script uses
+      # protobuf-build 0.14.1 and only accepts classic 3.x protoc. brew's
+      # current `protobuf` formula ships 34.x which is rejected, so pin
+      # the last classic release and prepend it to PATH.
+      - name: Install protoc (macOS)
+        if: runner.os == 'macOS'
+        shell: bash -el {0}
+        run: |
+          set -euo pipefail
+          PROTOC_VERSION=3.20.3
+          case "$(uname -m)" in
+            arm64) ARCH=aarch_64 ;;
+            x86_64) ARCH=x86_64 ;;
+            *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;;
+          esac
+          mkdir -p "$HOME/protoc"
+          curl -fsSL -o /tmp/protoc.zip \
+            "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-osx-${ARCH}.zip"
+          unzip -o /tmp/protoc.zip -d "$HOME/protoc"
+          echo "$HOME/protoc/bin" >> "$GITHUB_PATH"
+          "$HOME/protoc/bin/protoc" --version
+
+      - name: Install project into nexus environment
+        shell: bash -el {0}
+        run: |
+          conda run -n nexus pip install .
 
       # ── maturin builds ───────────────────────────────────────────────────
       # Install maturin inside the nexus env so it automatically uses the
@@ -100,6 +131,9 @@ jobs:
           conda run -n nexus pip install maturin
 
       # Skipped on Windows: shm_pipe.rs / shm_stream.rs use POSIX-only APIs.
+      # The nexus_raft crate is now rlib-only and is linked into the kernel
+      # cdylib, so there is no separate raft wheel to build here anymore —
+      # Metastore / ZoneManager are exposed from nexus_kernel directly.
       - name: Build kernel wheel  (rust/kernel)
         if: matrix.os != 'windows-latest'
         shell: bash -el {0}
@@ -109,27 +143,20 @@ jobs:
             --out build/dist \
             -m rust/kernel/Cargo.toml
 
-      - name: Build raft wheel  (rust/raft --features full)
-        shell: bash -el {0}
-        run: |
-          mkdir -p build/dist
-          conda run -n nexus maturin build --release \
-            --features full \
-            --out build/dist \
-            -m rust/raft/Cargo.toml
-
       # ── Install wheels into the nexus env ────────────────────────────────
       - name: Install Rust wheels into nexus environment
+        if: matrix.os != 'windows-latest'
         shell: bash -el {0}
         run: |
           echo "=== Built wheels ==="
           ls -lh build/dist/
           conda run -n nexus pip install build/dist/*.whl
 
-      - name: Verify full raft extension in nexus environment
+      - name: Verify kernel extension in nexus environment
+        if: matrix.os != 'windows-latest'
         shell: bash -el {0}
         run: |
-          conda run -n nexus python -c "from _nexus_raft import Metastore, ZoneManager; print('raft full OK')"
+          conda run -n nexus python -c "from nexus_kernel import Metastore, ZoneManager; print('nexus_kernel OK')"
 
       # ── conda-pack ───────────────────────────────────────────────────────
       - name: Install conda-pack into base environment

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "kernel"
-version = "0.9.36"
+version = "0.9.37"
 dependencies = [
  "ahash",
  "blake3",

--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/api-client",
-  "version": "0.9.36",
+  "version": "0.9.37",
   "description": "Shared HTTP client for Nexus APIs — retry, auth, error mapping, case transform",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/tui",
-  "version": "0.9.36",
+  "version": "0.9.37",
   "description": "Terminal UI for Nexus \u2014 file explorer, API inspector, and monitoring dashboard",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.36"
+version = "0.9.37"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/rust/kernel/Cargo.toml
+++ b/rust/kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel"
-version = "0.9.36"
+version = "0.9.37"
 edition = "2021"
 
 [lib]

--- a/rust/kernel/pyproject.toml
+++ b/rust/kernel/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-kernel"
-version = "0.9.36"
+version = "0.9.37"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
 requires-python = ">=3.14"
 classifiers = [


### PR DESCRIPTION
## Summary

Conda-pack has been failing across all three matrix entries on the v0.9.35 and v0.9.36 tags for reasons unrelated to the earlier release fixes. This PR brings it current and bumps to 0.9.37.

### Fixes

- **pdf-inspector sdist build** failed with `the configured Python interpreter version (3.14) is newer than PyO3's maximum supported version (3.13)`. The core-deps comment in `pyproject.toml` already spells out the fix — the sdist builds from source and needs Rust + `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1`. conda-pack.yml neither installed Rust before `pip install .` nor set the env var. Reordered Rust toolchain setup ahead of `pip install .` and added a workflow-level `env.PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"`.
- **raft-proto transitive build** rejects brew's protoc 34.x (same issue fixed in release.yml for v0.9.36). Pinned protoc 3.20.3 via direct GitHub release download on macOS.
- **Obsolete raft wheel build**: `rust/raft` is rlib-only now; its PyO3 classes are registered into the `nexus_kernel` cdylib (`rust/kernel/src/lib.rs:212`). Dropped the `maturin build -m rust/raft/Cargo.toml` step and retargeted the verify step to `from nexus_kernel import Metastore, ZoneManager`.
- **Windows gating**: the wheel-install and verify steps are now gated on `matrix.os != 'windows-latest'` alongside the kernel-wheel build — nothing is produced on Windows for pip to install or verify.

### Version bumps to 0.9.37
- `pyproject.toml`, `rust/kernel/pyproject.toml`, `rust/kernel/Cargo.toml`, `Cargo.lock`
- `packages/nexus-api-client/package.json`, `packages/nexus-tui/package.json`

## Not in this PR

`pyinstaller-cluster.yml` still references the deleted `_nexus_raft` module and still runs `maturin build -m rust/raft/Cargo.toml`; `rust/raft/pyproject.toml` is likewise stale. Those need their own follow-up once the required binary-artifact matrix is decided — they don't block PyPI / npm / conda-pack artifacts.

## Test plan

- [ ] Merge, tag `v0.9.37`, push tag.
- [ ] Release workflow: all four wheel matrix entries green, publish + create release steps run.
- [ ] Conda Pack: all three runners green, tarballs attached to the GitHub Release.