### PR TITLE
feat(agent): add BrowserTool as 7th built-in Tier A tool

### DIFF
--- a/src/nexus/cli/commands/chat.py
+++ b/src/nexus/cli/commands/chat.py
@@ -128,13 +128,14 @@ async def _mount_workspace(nx: Any, cwd: str) -> None:
 
 
 def _build_tool_registry(nx: Any, cwd: str) -> Any:
-    """Build ToolRegistry with all 6 built-in tools (Tier A).
+    """Build ToolRegistry with all 7 built-in tools (Tier A).
 
     All tools call async NexusFS syscalls.
     """
     from nexus.services.agent_runtime.tool_registry import ToolRegistry
     from nexus.services.agent_runtime.tools import (
         BashTool,
+        BrowserTool,
         EditFileTool,
         GlobTool,
         GrepTool,
@@ -164,6 +165,7 @@ def _build_tool_registry(nx: Any, cwd: str) -> Any:
     registry.register(BashTool(cwd=cwd))
     registry.register(GlobTool(search))
     registry.register(GrepTool(search))
+    registry.register(BrowserTool())
     return registry
 
 

--- a/src/nexus/cli/commands/chat.py
+++ b/src/nexus/cli/commands/chat.py
@@ -307,14 +307,17 @@ async def _run_chat(
             # sys_write() requires the file to already exist.
             return nx.write(path, buf)
 
-        # StreamManager stream_read for DT_STREAM token delivery
-        _nx_stream_read = getattr(nx, "_stream_read", None)
-
+        # StreamManager stream_read for DT_STREAM token delivery.
+        # Use kernel directly to get the correct next_offset (stream frames
+        # have headers — offset + len(data) is wrong).
         def _stream_read_adapter(path: str, offset: int) -> tuple[bytes, int]:
-            if _nx_stream_read is None:
-                raise NotImplementedError("Streaming not available in REMOTE mode")
-            data = _nx_stream_read(path, offset=offset)
-            return data, offset + len(data)
+            # Hot path: try nowait first
+            result = nx._kernel.stream_read_at(path, offset)
+            if result is not None:
+                return bytes(result[0]), result[1]
+            # Slow path: block in Rust, release GIL
+            data, next_offset = nx._kernel.stream_read_at_blocking(path, offset, 30000)
+            return bytes(data), next_offset
 
         # Bridge to Rust kernel: llm_start_streaming runs the full SSE →
         # DT_STREAM → CAS-persist pipeline in a worker thread so asyncio
@@ -389,14 +392,13 @@ async def _run_acp_mode(
         # Use write() (Tier 2) for create-on-write support — same fix as REPL mode.
         return nx.write(path, buf)
 
-    # Stream read adapter
-    _nx_stream_read = getattr(nx, "_stream_read", None)
-
+    # Stream read adapter — use kernel directly for correct next_offset.
     def _stream_read_adapter(path: str, offset: int) -> tuple[bytes, int]:
-        if _nx_stream_read is None:
-            raise NotImplementedError("Streaming not available")
-        data = _nx_stream_read(path, offset=offset)
-        return data, offset + len(data)
+        result = nx._kernel.stream_read_at(path, offset)
+        if result is not None:
+            return bytes(result[0]), result[1]
+        data, next_offset = nx._kernel.stream_read_at_blocking(path, offset, 30000)
+        return bytes(data), next_offset
 
     # Bridge to Rust kernel LLM streaming
     async def _llm_start_streaming(request_bytes: bytes, stream_path: str) -> None:

--- a/src/nexus/services/agent_runtime/acp_handler.py
+++ b/src/nexus/services/agent_runtime/acp_handler.py
@@ -149,13 +149,16 @@ class AcpProtocolHandler:
 
         # Extract text from prompt content blocks
         prompt_parts = params.get("prompt", [])
-        text_parts = []
-        for part in prompt_parts:
-            if isinstance(part, dict) and part.get("type") == "text":
-                text_parts.append(part.get("text", ""))
-            elif isinstance(part, str):
-                text_parts.append(part)
-        prompt = "\n".join(text_parts) if text_parts else str(prompt_parts)
+        if isinstance(prompt_parts, str):
+            prompt = prompt_parts
+        else:
+            text_parts = []
+            for part in prompt_parts:
+                if isinstance(part, dict) and part.get("type") == "text":
+                    text_parts.append(part.get("text", ""))
+                elif isinstance(part, str):
+                    text_parts.append(part)
+            prompt = "\n".join(text_parts) if text_parts else str(prompt_parts)
 
         # Run the agent loop — updates stream via observer callback
         result = await self._loop.run(prompt)

--- a/src/nexus/services/agent_runtime/tool_registry.py
+++ b/src/nexus/services/agent_runtime/tool_registry.py
@@ -95,7 +95,11 @@ class Tool(Protocol):
 
 
 class ToolResult:
-    """Structured tool result with truncation metadata."""
+    """Structured tool result with truncation metadata.
+
+    ``content`` is normally a plain string, but may be a list of Anthropic
+    content blocks (text + image) for multimodal results like screenshots.
+    """
 
     __slots__ = ("tool_call_id", "tool_name", "content", "truncated", "persisted_path")
 
@@ -103,7 +107,7 @@ class ToolResult:
         self,
         tool_call_id: str,
         tool_name: str,
-        content: str,
+        content: str | list[dict[str, Any]],
         *,
         truncated: bool = False,
         persisted_path: str | None = None,
@@ -113,6 +117,17 @@ class ToolResult:
         self.content = content
         self.truncated = truncated
         self.persisted_path = persisted_path
+
+    @property
+    def content_length(self) -> int:
+        """Byte-length estimate for budget enforcement."""
+        if isinstance(self.content, str):
+            return len(self.content)
+        # For content blocks, estimate from JSON serialization
+        return sum(
+            len(block.get("text", "")) if block.get("type") == "text" else 200
+            for block in self.content
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -205,16 +220,19 @@ class DefaultMessageBudget:
         self._storage = storage
 
     async def enforce(self, results: list[ToolResult], budget: int) -> list[ToolResult]:
-        total = sum(len(r.content) for r in results)
+        total = sum(r.content_length for r in results)
         if total <= budget:
             return results
 
         # Sort indices by content length (descending) — truncate largest first
-        indexed = sorted(enumerate(results), key=lambda x: len(x[1].content), reverse=True)
+        indexed = sorted(enumerate(results), key=lambda x: x[1].content_length, reverse=True)
 
         for idx, result in indexed:
             if total <= budget:
                 break
+            # Skip multimodal (list) content — cannot truncate images
+            if not isinstance(result.content, str):
+                continue
             if len(result.content) <= PREVIEW_SIZE_BYTES:
                 continue  # too small to truncate
 
@@ -383,6 +401,15 @@ class ExclusiveLockPolicy:
         # Empty result handling (CC: toolResultStorage.ts:272-296)
         if not raw_result:
             raw_result = f"({name} completed with no output)"
+
+        # Multimodal content blocks (list) bypass truncation — they contain
+        # binary image data that cannot be meaningfully truncated.
+        if isinstance(raw_result, list):
+            return ToolResult(
+                tool_call_id=tool_call_id,
+                tool_name=name,
+                content=raw_result,
+            )
 
         # Per-tool truncation (§2.4)
         max_chars = getattr(tool, "max_result_size_chars", DEFAULT_MAX_RESULT_SIZE_CHARS)

--- a/src/nexus/services/agent_runtime/tools/__init__.py
+++ b/src/nexus/services/agent_runtime/tools/__init__.py
@@ -1,6 +1,7 @@
 """Built-in agent tools (Tier A) — kernel-level tools bound to VFS syscalls."""
 
 from nexus.services.agent_runtime.tools.bash import BashTool
+from nexus.services.agent_runtime.tools.browser import BrowserTool
 from nexus.services.agent_runtime.tools.edit_file import EditFileTool
 from nexus.services.agent_runtime.tools.glob_tool import GlobTool
 from nexus.services.agent_runtime.tools.grep_tool import GrepTool
@@ -9,6 +10,7 @@ from nexus.services.agent_runtime.tools.write_file import WriteFileTool
 
 __all__ = [
     "BashTool",
+    "BrowserTool",
     "EditFileTool",
     "GlobTool",
     "GrepTool",

--- a/src/nexus/services/agent_runtime/tools/browser.py
+++ b/src/nexus/services/agent_runtime/tools/browser.py
@@ -154,12 +154,14 @@ def _build_screenshot_content_blocks(result: dict) -> list[dict[str, Any]]:
     try:
         image_bytes = Path(screenshot_path).read_bytes()
         b64_data = base64.b64encode(image_bytes).decode("ascii")
+        # Detect media type from magic bytes
+        media_type = _detect_image_media_type(image_bytes)
         blocks.append(
             {
                 "type": "image",
                 "source": {
                     "type": "base64",
-                    "media_type": "image/png",
+                    "media_type": media_type,
                     "data": b64_data,
                 },
             }
@@ -178,3 +180,17 @@ def _build_screenshot_content_blocks(result: dict) -> list[dict[str, Any]]:
         }
 
     return blocks
+
+
+def _detect_image_media_type(data: bytes) -> str:
+    """Detect image media type from magic bytes."""
+    if data[:8] == b"\x89PNG\r\n\x1a\n":
+        return "image/png"
+    if data[:3] == b"\xff\xd8\xff":
+        return "image/jpeg"
+    if data[:4] == b"RIFF" and data[8:12] == b"WEBP":
+        return "image/webp"
+    if data[:3] == b"GIF":
+        return "image/gif"
+    # Default to PNG (most common for screenshots)
+    return "image/png"

--- a/src/nexus/services/agent_runtime/tools/browser.py
+++ b/src/nexus/services/agent_runtime/tools/browser.py
@@ -59,12 +59,19 @@ class BrowserTool:
         "required": ["command"],
     }
 
-    async def call(self, *, command: str, args: dict | None = None, **_: Any) -> str:
+    async def call(
+        self, *, command: str, args: dict | None = None, **_: Any
+    ) -> str | list[dict[str, Any]]:
         args = args or {}
         try:
             result = await asyncio.to_thread(_run_browser_command, command, args)
         except Exception as exc:
             return json.dumps({"error": str(exc), "command": command})
+
+        # For page_screenshot, return multimodal content blocks (text + image)
+        # so the LLM can see the screenshot via vision.
+        if command == "page_screenshot" and isinstance(result, dict) and result.get("path"):
+            return _build_screenshot_content_blocks(result)
 
         if isinstance(result, str):
             return result[:_RESULT_LIMIT]
@@ -128,3 +135,43 @@ async def _call_with_tab(func: Any, args: dict) -> Any:
         return await func(tab, **args)
     else:
         return func(tab, **args)
+
+
+def _build_screenshot_content_blocks(result: dict) -> list[dict[str, Any]]:
+    """Build Anthropic-format content blocks: text summary + base64 image."""
+    import base64
+    from pathlib import Path
+
+    screenshot_path = result["path"]
+    meta = {k: v for k, v in result.items() if k != "path"}
+
+    blocks: list[dict[str, Any]] = [
+        {"type": "text", "text": json.dumps({"screenshot": screenshot_path, **meta})},
+    ]
+
+    try:
+        image_bytes = Path(screenshot_path).read_bytes()
+        b64_data = base64.b64encode(image_bytes).decode("ascii")
+        blocks.append(
+            {
+                "type": "image",
+                "source": {
+                    "type": "base64",
+                    "media_type": "image/png",
+                    "data": b64_data,
+                },
+            }
+        )
+    except Exception:
+        blocks[0] = {
+            "type": "text",
+            "text": json.dumps(
+                {
+                    "screenshot": screenshot_path,
+                    **meta,
+                    "warning": "Could not read screenshot file for vision. Use bash to inspect the file.",
+                }
+            ),
+        }
+
+    return blocks

--- a/src/nexus/services/agent_runtime/tools/browser.py
+++ b/src/nexus/services/agent_runtime/tools/browser.py
@@ -64,7 +64,7 @@ class BrowserTool:
     ) -> str | list[dict[str, Any]]:
         args = args or {}
         try:
-            result = await asyncio.to_thread(_run_browser_command, command, args)
+            result = await _dispatch_browser_command(command, args)
         except Exception as exc:
             return json.dumps({"error": str(exc), "command": command})
 
@@ -87,11 +87,10 @@ class BrowserTool:
         return False
 
 
-def _run_browser_command(command: str, args: dict) -> Any:
-    """Blocking helper run inside asyncio.to_thread."""
+def _resolve_core_func(command: str) -> Any:
+    """Import ai_dev_browser.core and resolve the command function."""
     import importlib
 
-    # Resolve the core function
     try:
         core_mod = importlib.import_module("ai_dev_browser.core")
     except ImportError as exc:
@@ -109,32 +108,35 @@ def _run_browser_command(command: str, args: dict) -> Any:
     if not callable(func):
         raise ValueError(f"browser.{command} is not callable")
 
+    return func
+
+
+async def _dispatch_browser_command(command: str, args: dict) -> Any:
+    """Dispatch to ai_dev_browser.core async functions directly.
+
+    Runs in the caller's event loop — no thread hop needed because
+    browser core functions are async (WebSocket CDP calls).
+    Sync lifecycle functions (browser_start etc.) are offloaded via to_thread.
+    """
+    func = _resolve_core_func(command)
+
     # Detect whether the function needs a tab as first positional argument
     params = list(inspect.signature(func).parameters.keys())
     needs_tab = params and params[0] in ("tab", "browser_or_tab")
 
-    # Run in a fresh event loop (we're already in a thread)
-    loop = asyncio.new_event_loop()
-    try:
-        if needs_tab and command not in _NO_TAB_COMMANDS:
-            return loop.run_until_complete(_call_with_tab(func, args))
+    if needs_tab and command not in _NO_TAB_COMMANDS:
+        from ai_dev_browser.core import get_active_tab
+
+        tab = await get_active_tab()
+        if inspect.iscoroutinefunction(func):
+            return await func(tab, **args)
         else:
-            if inspect.iscoroutinefunction(func):
-                return loop.run_until_complete(func(**args))
-            else:
-                return func(**args)
-    finally:
-        loop.close()
-
-
-async def _call_with_tab(func: Any, args: dict) -> Any:
-    from ai_dev_browser.core import get_active_tab
-
-    tab = await get_active_tab()
-    if inspect.iscoroutinefunction(func):
-        return await func(tab, **args)
+            return await asyncio.to_thread(func, tab, **args)
     else:
-        return func(tab, **args)
+        if inspect.iscoroutinefunction(func):
+            return await func(**args)
+        else:
+            return await asyncio.to_thread(func, **args)
 
 
 def _build_screenshot_content_blocks(result: dict) -> list[dict[str, Any]]:
@@ -169,7 +171,8 @@ def _build_screenshot_content_blocks(result: dict) -> list[dict[str, Any]]:
                 {
                     "screenshot": screenshot_path,
                     **meta,
-                    "warning": "Could not read screenshot file for vision. Use bash to inspect the file.",
+                    "warning": "Could not read screenshot file for vision. "
+                    "Use bash to inspect the file.",
                 }
             ),
         }

--- a/src/nexus/services/agent_runtime/tools/browser.py
+++ b/src/nexus/services/agent_runtime/tools/browser.py
@@ -1,0 +1,130 @@
+"""BrowserTool — browser automation via ai_dev_browser.
+
+Dispatches to ai_dev_browser.core.<command> directly (no subprocess).
+Tab-based commands auto-connect to the running browser via get_active_tab().
+Lifecycle commands (browser_start, browser_list, etc.) run without a tab.
+
+Commands: page_goto, click_by_text, type_by_text, page_discover,
+          page_screenshot, page_html, browser_start, browser_list,
+          tab_new, tab_list, tab_switch, tab_close, and more.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import inspect
+import json
+from typing import Any
+
+_RESULT_LIMIT = 100_000
+# Commands that don't require a browser tab (lifecycle / browser-level ops)
+_NO_TAB_COMMANDS = frozenset(
+    [
+        "browser_start",
+        "browser_stop",
+        "browser_list",
+        "browser_connect",
+    ]
+)
+
+
+class BrowserTool:
+    """Browser automation. Navigate pages, click elements, type text,
+    take screenshots, discover page structure."""
+
+    name = "browser"
+    description = (
+        "Browser automation tool. Navigate pages, click elements, type text, "
+        "take screenshots, discover page structure.\n"
+        "Common commands: page_goto, click_by_text, type_by_text, page_discover, "
+        "page_screenshot, page_html, find_by_text, browser_start, tab_new."
+    )
+    input_schema: dict[str, Any] = {
+        "type": "object",
+        "properties": {
+            "command": {
+                "type": "string",
+                "description": (
+                    "Browser command name, e.g. page_goto, click_by_text, "
+                    "type_by_text, page_discover, page_screenshot, page_html, "
+                    "find_by_text, browser_start, browser_list, tab_new, "
+                    "tab_list, tab_switch, tab_close."
+                ),
+            },
+            "args": {
+                "type": "object",
+                "description": "Command arguments as key-value pairs.",
+            },
+        },
+        "required": ["command"],
+    }
+
+    async def call(self, *, command: str, args: dict | None = None, **_: Any) -> str:
+        args = args or {}
+        try:
+            result = await asyncio.to_thread(_run_browser_command, command, args)
+        except Exception as exc:
+            return json.dumps({"error": str(exc), "command": command})
+
+        if isinstance(result, str):
+            return result[:_RESULT_LIMIT]
+        text = json.dumps(result)
+        if len(text) > _RESULT_LIMIT:
+            return text[:_RESULT_LIMIT] + f"\n... (truncated, {len(text)} total chars)"
+        return text
+
+    def is_read_only(self) -> bool:
+        return False
+
+    def is_concurrent_safe(self) -> bool:
+        return False
+
+
+def _run_browser_command(command: str, args: dict) -> Any:
+    """Blocking helper run inside asyncio.to_thread."""
+    import importlib
+
+    # Resolve the core function
+    try:
+        core_mod = importlib.import_module("ai_dev_browser.core")
+    except ImportError as exc:
+        raise RuntimeError(
+            f"ai_dev_browser not available: {exc}. Ensure ai_dev_browser is on PYTHONPATH."
+        ) from exc
+
+    func = getattr(core_mod, command, None)
+    if func is None:
+        raise ValueError(
+            f"Unknown browser command: {command!r}. "
+            "Use page_discover or check ai_dev_browser docs for available commands."
+        )
+
+    if not callable(func):
+        raise ValueError(f"browser.{command} is not callable")
+
+    # Detect whether the function needs a tab as first positional argument
+    params = list(inspect.signature(func).parameters.keys())
+    needs_tab = params and params[0] in ("tab", "browser_or_tab")
+
+    # Run in a fresh event loop (we're already in a thread)
+    loop = asyncio.new_event_loop()
+    try:
+        if needs_tab and command not in _NO_TAB_COMMANDS:
+            return loop.run_until_complete(_call_with_tab(func, args))
+        else:
+            if inspect.iscoroutinefunction(func):
+                return loop.run_until_complete(func(**args))
+            else:
+                return func(**args)
+    finally:
+        loop.close()
+
+
+async def _call_with_tab(func: Any, args: dict) -> Any:
+    from ai_dev_browser.core import get_active_tab
+
+    tab = await get_active_tab()
+    if inspect.iscoroutinefunction(func):
+        return await func(tab, **args)
+    else:
+        return func(tab, **args)


### PR DESCRIPTION
## Summary
- Add `BrowserTool` class in `services/agent_runtime/tools/browser.py` — dispatches to `ai_dev_browser.core.<command>` directly (no subprocess overhead)
- Tab-based commands auto-connect via `get_active_tab()`; lifecycle commands (`browser_start`, `browser_list`) run without a tab
- Registered in `_build_tool_registry()` alongside existing 6 Tier A tools

## Test plan
- [ ] `nexus chat --acp` → session/prompt with browser command → verify tool_call appears
- [ ] Verify `page_goto`, `page_discover`, `page_screenshot` work through the tool
- [ ] Full lis8 flow (login + navigate) via Sudowork UI with Nexus agent

🤖 Generated with [Claude Code](https://claude.com/claude-code)