### PR TITLE
fix(kernel): enter tokio runtime for RpcTransport channel construction

### DIFF
--- a/rust/kernel/src/rpc_transport.rs
+++ b/rust/kernel/src/rpc_transport.rs
@@ -44,7 +44,16 @@ impl RpcTransport {
         tls: Option<&TlsConfig>,
         timeout: Duration,
     ) -> Result<Self, String> {
-        let channel = Self::build_channel(address, tls, timeout)?;
+        // tonic's `Endpoint::connect_lazy` builds a hyper-util legacy Client
+        // that spawns its connection-pool driver via `TokioExecutor::execute`.
+        // That spawn requires `Handle::current()`, so when we build the
+        // channel directly from Python's sys_setattr thread it panics with
+        // "there is no reactor running". Enter the transport's own runtime
+        // for the duration of channel construction.
+        let channel = {
+            let _guard = runtime.enter();
+            Self::build_channel(address, tls, timeout)?
+        };
 
         Ok(Self {
             runtime,


### PR DESCRIPTION
## Summary

[Docker Publish run 24845213978 / job 72748519948](https://github.com/nexi-lab/nexus/actions/runs/24845213978/job/72748519948) failed the E2E edge smoke test on develop with:

\`\`\`
thread '<unnamed>' (158) panicked at hyper-util-0.1.20/src/rt/tokio.rs:115:9:
there is no reactor running, must be called from the context of a Tokio 1.x runtime
...
pyo3_runtime.PanicException: there is no reactor running, must be
called from the context of a Tokio 1.x runtime
\`\`\`

The panic fires on the very first \`nexus.connect()\` in the REMOTE profile (\`nexus demo init\`), through this path introduced by PR #3855:

1. Python: \`nfs.sys_setattr(\"/\", backend_type=\"remote\", server_address=..., ...)\`
2. Rust \`generated_pyo3.rs\` \"remote\" branch calls \`RpcTransport::new(runtime, addr, ...)\`
3. \`RpcTransport::new\` calls \`build_channel()\` which calls \`tonic::transport::Endpoint::connect_lazy()\`
4. \`connect_lazy\` builds a \`hyper_util::client::legacy::Client\` whose pool driver is spawned via \`TokioExecutor::execute\` (→ \`tokio::spawn\` → \`Handle::current()\`)
5. The call came from Python's sys_setattr thread — no current runtime → panic

All RPC methods on the transport already wrap with \`self.runtime.block_on(async { ... })\`, which enters the runtime for the duration of the future. Only construction was unscoped.

## Fix

Enter \`RpcTransport::runtime\` for the scope of \`build_channel()\` in \`RpcTransport::new\`:

\`\`\`rust
let channel = {
    let _guard = runtime.enter();
    Self::build_channel(address, tls, timeout)?
};
\`\`\`

One file, 10 lines added (most of them an explanatory comment).

## Test plan

- [ ] \`cargo check -p kernel\` (done locally, passes).
- [ ] Re-run Docker Publish E2E on the merge commit — \`nexus demo init\` should complete without \`PanicException\`.
- [ ] Full E2E smoke block (CLI, config, version, stress) runs to completion.

## Out of scope

No version bump. \`release/v0.9.37\` (PR #3863) will carry the next release cut; this fix lands on develop and gets picked up by whatever the next tag is.