### PR TITLE
release: v0.9.38 — pin protoc to 3.20.2 (has arm64 macOS asset)

### DIFF
--- a/.github/workflows/conda-pack.yml
+++ b/.github/workflows/conda-pack.yml
@@ -98,13 +98,16 @@ jobs:
       # rust/kernel pulls in raft → raft-proto, whose build script uses
       # protobuf-build 0.14.1 and only accepts classic 3.x protoc. brew's
       # current `protobuf` formula ships 34.x which is rejected, so pin
-      # the last classic release and prepend it to PATH.
+      # a late 3.x release and prepend it to PATH. 3.20.2 (not 3.20.3)
+      # is the last 3.x release whose GitHub assets include an arm64
+      # macOS zip — 3.20.3 shipped x86_64 only, so `osx-aarch_64.zip`
+      # 404s on macos-14.
       - name: Install protoc (macOS)
         if: runner.os == 'macOS'
         shell: bash -el {0}
         run: |
           set -euo pipefail
-          PROTOC_VERSION=3.20.3
+          PROTOC_VERSION=3.20.2
           case "$(uname -m)" in
             arm64) ARCH=aarch_64 ;;
             x86_64) ARCH=x86_64 ;;

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -125,12 +125,15 @@ jobs:
         # raft-proto's build script uses `protobuf-build v0.14.1`, which
         # rejects protoc's new calendar-versioned releases (e.g. "libprotoc
         # 34.1") with "No suitable `protoc` (>= 3.1.0) found in PATH". Pin
-        # to the last classic 3.x release — brew's `protobuf` formula ships
-        # 34.x and is unusable here.
+        # to a late 3.x release — brew's `protobuf` formula ships 34.x
+        # and is unusable here. We pick 3.20.2 rather than 3.20.3 because
+        # the 3.20.3 GitHub release only published `osx-x86_64.zip`; the
+        # arm64 artifact was dropped, so `osx-aarch_64.zip` 404s on
+        # macos-14 (Apple Silicon) runners.
         if: runner.os == 'macOS'
         run: |
           set -euo pipefail
-          PROTOC_VERSION=3.20.3
+          PROTOC_VERSION=3.20.2
           case "$(uname -m)" in
             arm64) ARCH=aarch_64 ;;
             x86_64) ARCH=x86_64 ;;

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "kernel"
-version = "0.9.37"
+version = "0.9.38"
 dependencies = [
  "ahash",
  "blake3",

--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/api-client",
-  "version": "0.9.37",
+  "version": "0.9.38",
   "description": "Shared HTTP client for Nexus APIs — retry, auth, error mapping, case transform",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/tui",
-  "version": "0.9.37",
+  "version": "0.9.38",
   "description": "Terminal UI for Nexus \u2014 file explorer, API inspector, and monitoring dashboard",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.37"
+version = "0.9.38"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/rust/kernel/Cargo.toml
+++ b/rust/kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel"
-version = "0.9.37"
+version = "0.9.38"
 edition = "2021"
 
 [lib]

--- a/rust/kernel/pyproject.toml
+++ b/rust/kernel/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-kernel"
-version = "0.9.37"
+version = "0.9.38"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
 requires-python = ">=3.14"
 classifiers = [


### PR DESCRIPTION
## Summary

v0.9.37 release workflow failed on **macos-14 (Apple Silicon)** ([run 24858517640 / job 72777772030](https://github.com/nexi-lab/nexus/actions/runs/24858517640/job/72777772030)) with:

\`\`\`
curl: (56) The requested URL returned error: 404
\`\`\`

The 404'd URL:
\`\`\`
https://github.com/protocolbuffers/protobuf/releases/download/v3.20.3/protoc-3.20.3-osx-aarch_64.zip
\`\`\`

Upstream \`protoc 3.20.3\` GitHub release only published \`osx-x86_64.zip\` — the arm64 asset is missing. Verified via \`gh api\`:

- **3.20.1** → has \`osx-aarch_64.zip\` + \`osx-x86_64.zip\`
- **3.20.2** → has \`osx-aarch_64.zip\` + \`osx-x86_64.zip\`
- **3.20.3** → has \`osx-x86_64.zip\` **only** (upstream packaging glitch)

The x86_64 job (macos-15-intel) would pass with 3.20.3, but arm64 is broken on this pin.

## Fix

Bump \`PROTOC_VERSION\` from \`3.20.3\` → \`3.20.2\` in both \`release.yml\` and \`conda-pack.yml\`. 3.20.2 is the last 3.x release with complete macOS arch coverage; protobuf-build 0.14.1's version gate still accepts it.

## Version bumps to 0.9.38
- \`pyproject.toml\`, \`rust/kernel/pyproject.toml\`, \`rust/kernel/Cargo.toml\`, \`Cargo.lock\`
- \`packages/nexus-api-client/package.json\`, \`packages/nexus-tui/package.json\`

## Test plan

- [ ] Merge, tag \`v0.9.38\`, push tag.
- [ ] Release workflow: all four wheel matrix entries green (ubuntu, windows, macos-14, macos-15-intel).
- [ ] Conda Pack: all three runners green.