### PR TITLE
release: v0.9.39 — skip local-load Docker build for CUDA (disk-full fix)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -464,6 +464,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      # Reclaim ~30 GB from the hosted runner before the build. CUDA
+      # variant pulls torch-cuda (~2 GB), txtai + sentence-transformers,
+      # and builds a multi-arch image (amd64 + arm64 via QEMU) — that
+      # combined layer store repeatedly blew past ubuntu-latest's
+      # ~14 GB post-checkout budget and got the runner killed. Removes
+      # tooling (Android SDK, .NET, Haskell, CodeQL, etc.) we don't
+      # use in this job.
+      - name: Free disk space (CUDA variant)
+        if: matrix.variant == 'cuda'
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: false
+          swap-storage: true
+
       - name: Set up QEMU (multi-arch)
         uses: docker/setup-qemu-action@v3
 
@@ -490,7 +509,16 @@ jobs:
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
           echo "tags=ghcr.io/nexi-lab/nexus:${VERSION}${SUFFIX},ghcr.io/nexi-lab/nexus:stable${SUFFIX},ghcr.io/nexi-lab/nexus:latest${SUFFIX}" >> "$GITHUB_OUTPUT"
 
+      # Local-load build is ONLY needed to run the CPU-gated smoke tests
+      # below. The CUDA variant skips all of those tests (PyTorch CUDA
+      # wheels ship AVX-512 binaries that SIGILL on hosted runners), so
+      # materializing a ~8-10 GB CUDA image into the local Docker store
+      # is wasted work AND blows past the standard ubuntu-latest runner's
+      # ~14 GB disk budget (it competes with the later multi-arch layer
+      # store in "Build and push to GHCR"). Scope this step to CPU only;
+      # CUDA goes straight to the registry-cached multi-arch push.
       - name: Build image (local load for smoke tests)
+        if: matrix.variant == 'cpu'
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "kernel"
-version = "0.9.38"
+version = "0.9.39"
 dependencies = [
  "ahash",
  "blake3",

--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/api-client",
-  "version": "0.9.38",
+  "version": "0.9.39",
   "description": "Shared HTTP client for Nexus APIs — retry, auth, error mapping, case transform",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/tui",
-  "version": "0.9.38",
+  "version": "0.9.39",
   "description": "Terminal UI for Nexus \u2014 file explorer, API inspector, and monitoring dashboard",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.38"
+version = "0.9.39"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/rust/kernel/Cargo.toml
+++ b/rust/kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel"
-version = "0.9.38"
+version = "0.9.39"
 edition = "2021"
 
 [lib]

--- a/rust/kernel/pyproject.toml
+++ b/rust/kernel/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-kernel"
-version = "0.9.38"
+version = "0.9.39"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
 requires-python = ">=3.14"
 classifiers = [


### PR DESCRIPTION
## Root cause

\`release.yml\`'s \`build-docker\` CUDA matrix entry has been failing on **every release since v0.9.29** (10+ tags). No \`*-cuda\` image has ever been published to GHCR — verified from the package versions list. Example failure: [run 24860859284 / job 72785714771](https://github.com/nexi-lab/nexus/actions/runs/24860859284/job/72785714771).

### Which step actually dies

Comparing CPU vs CUDA job step conclusions on v0.9.38:

| Step | CPU | CUDA |
|------|-----|------|
| 7. Build image (local load for smoke tests) | ✅ | `null` (killed mid-run at ~7m) |
| 8–10. CPU-gated smoke tests | ✅ | `null` (gated off anyway) |
| 11. Build and push to GHCR | cancelled (fail-fast cascade from CUDA) | `null` |

Step 7 is the proximate killer for CUDA. Step 11 for CUDA has never even been reached on the runner, so we don't actually know whether the multi-arch push itself also fails — but given it builds amd64 + arm64 (arm64 via QEMU emulation, memory-heavy) on top of the same image, it's the next likely disk-exhaustion point.

### Why step 7 kills CUDA

1. **Step 7 is wasted work for CUDA.** It builds the full image into the runner's local Docker daemon purely to feed the CPU-only smoke tests (steps 8–10, gated on \`matrix.variant == 'cpu'\` because CUDA wheels SIGILL on hosted runners).
2. For CUDA, that local image is ~8–10 GB (torch-cuda ~2 GB + ML stack).
3. Combined with step 11's upcoming multi-arch layer store, this overruns ubuntu-latest's ~14 GB post-checkout disk budget. Classic runner-terminated-externally signature: all conclusions after step 6 are \`null\`, job log API returns 404, job vanishes at 7m38s with no tail.

## Fix

Two changes:

1. **Skip the local-load build for CUDA.** It only existed to feed CPU-gated smoke tests — dead work for the CUDA variant.
2. **\`jlumbroso/free-disk-space@main\` at job start (CUDA only).** Reclaims ~30 GB by removing Android SDK, .NET, Haskell, large-packages, swap. Belt-and-suspenders so step 11's multi-arch push has headroom. Scoped to \`matrix.variant == 'cuda'\` so CPU continues unchanged (it's been working).

\`docker-publish.yml\` already pushes a CPU multi-arch image independently on the same tag, so this PR only fixes the \`release.yml\` path — which is where the CUDA publish + GitHub Release gate live.

## Can I guarantee it works?

No. Step 11 for CUDA has never run on an un-cramped runner, so there's a residual risk of a second disk-exhaustion point we can't see until we test. But: this fix is a strict improvement (eliminates a provably-wasted ~10 GB allocation and adds ~30 GB headroom), and it's the minimum cost to find out whether step 11 stands on its own. If step 11 still fails, we'll have a real log for the first time and can iterate (e.g., move CUDA to a larger runner).

## Version bumps to 0.9.39
\`pyproject.toml\`, \`rust/kernel/pyproject.toml\`, \`rust/kernel/Cargo.toml\`, \`Cargo.lock\`, \`packages/nexus-api-client/package.json\`, \`packages/nexus-tui/package.json\`

## Test plan

- [ ] Merge, tag \`v0.9.39\`, push tag.
- [ ] Release workflow: \`build-docker (cuda)\` completes (first time ever).
- [ ] \`ghcr.io/nexi-lab/nexus:0.9.39-cuda\` appears on GHCR.
- [ ] \`Create GitHub Release\` job runs (first time in 10+ tags).