### PR TITLE
release: v0.9.40 — pin free-disk-space action to SHA (supply-chain)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -473,7 +473,11 @@ jobs:
       # use in this job.
       - name: Free disk space (CUDA variant)
         if: matrix.variant == 'cuda'
-        uses: jlumbroso/free-disk-space@main
+        # Pinned to the v1.3.1 release commit. `@main` would let an
+        # upstream push execute inside this release job (contents:write,
+        # packages:write, id-token:write, attestations:write). Bump the
+        # SHA via PR after reviewing upstream commits.
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
         with:
           tool-cache: false
           android: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "kernel"
-version = "0.9.39"
+version = "0.9.40"
 dependencies = [
  "ahash",
  "blake3",

--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/api-client",
-  "version": "0.9.39",
+  "version": "0.9.40",
   "description": "Shared HTTP client for Nexus APIs — retry, auth, error mapping, case transform",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/tui",
-  "version": "0.9.39",
+  "version": "0.9.40",
   "description": "Terminal UI for Nexus \u2014 file explorer, API inspector, and monitoring dashboard",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.39"
+version = "0.9.40"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/rust/kernel/Cargo.toml
+++ b/rust/kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel"
-version = "0.9.39"
+version = "0.9.40"
 edition = "2021"
 
 [lib]

--- a/rust/kernel/pyproject.toml
+++ b/rust/kernel/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-kernel"
-version = "0.9.39"
+version = "0.9.40"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
 requires-python = ">=3.14"
 classifiers = [


### PR DESCRIPTION
## Why v0.9.40 and not v0.9.39

v0.9.39 was merged to develop but **never tagged**. An adversarial review flagged that the CUDA disk-cleanup step I added in PR #3869 pulled \`jlumbroso/free-disk-space@main\` — an **unpinned, mutable third-party action**.

\`release.yml\` has these workflow-level write scopes:

\`\`\`
contents: write
packages: write
id-token: write
attestations: write
\`\`\`

Any upstream push to that action's \`main\` would execute inside the release job with publish + OIDC authority. Supply-chain hole.

Rather than tag v0.9.39 with that hole open, skipping it entirely and bundling the pin into a fresh bump.

## Fix

Pin to the v1.3.1 release commit SHA (current HEAD of upstream \`main\`, confirmed clean):

\`\`\`yaml
uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
\`\`\`

Inline comment in the workflow notes the rationale + bump procedure so a future reader doesn't "update" it back to \`@main\` by reflex.

## Version bumps to 0.9.40
\`pyproject.toml\`, \`rust/kernel/pyproject.toml\`, \`rust/kernel/Cargo.toml\`, \`Cargo.lock\`, \`packages/nexus-api-client/package.json\`, \`packages/nexus-tui/package.json\`

## Test plan

- [ ] Merge, tag \`v0.9.40\`, push tag (skip \`v0.9.39\` — don't push that tag).
- [ ] Release workflow: \`build-docker (cuda)\` completes (first CUDA publish).
- [ ] \`ghcr.io/nexi-lab/nexus:0.9.40-cuda\` appears on GHCR.
- [ ] \`Create GitHub Release\` job runs.