### PR TITLE
feat(auth): server-side credential consumption (#3818)

### DIFF
--- a/.pre-commit-hooks/check_file_size.py
+++ b/.pre-commit-hooks/check_file_size.py
@@ -37,6 +37,7 @@ EXCEPTIONS = [
     "src/nexus/services/memory/memory_api.py",  # 3,012 lines - moved from core/, split tracked
     "src/nexus/bricks/search/daemon.py",  # ~2,300 lines - Issue #3698 additions; split tracked as follow-up
     "src/nexus/bricks/mcp/server.py",  # 2,157 lines - was 2,136 pre-#3731; auth helpers extracted to auth_bridge.py
+    "src/nexus/bricks/auth/postgres_profile_store.py",  # 2,009 lines - #3818 read-path additions; split tracked as follow-up
 ]
 
 

--- a/docs/guides/auth-envelope-encryption.md
+++ b/docs/guides/auth-envelope-encryption.md
@@ -63,3 +63,90 @@ Low-cardinality by design: `principal_id` and `profile_id` are deliberately not 
 - **`kek_version` downgrade** — each provider binds `kek_version` into the wrap path (Vault Transit: `key_version` on decrypt; AWS KMS: version embedded in the opaque blob; `InMemoryEncryptionProvider`: mixed into the derivation AAD). Claiming a wrapped DEK was produced at a different version fails.
 - **Plaintext in logs / errors** — every `EnvelopeError` subclass has a `__repr__` that carries only `(tenant_id, profile_id, kek_version, cause)`; a test regex asserts no 16+ byte base64/hex blob appears in error text.
 - **Transient KMS/Vault errors** — the DEK cache never caches negative results, so a temporary IAM blip does not pin decrypt-failed for the TTL window.
+
+## Token exchange (server-side credential consumption)
+
+The `/v1/auth/token-exchange` endpoint exposes envelope-stored credentials to authenticated daemons via RFC 8693 token exchange. Issue: #3818. Spec: `docs/superpowers/specs/2026-04-23-issue-3818-server-credential-consumption-design.md`.
+
+### Environment variables
+
+- `NEXUS_TOKEN_EXCHANGE_ENABLED` — default `0` (off). Set to `1`, `true`, or `yes` to mount the read path.
+- `NEXUS_JWT_SIGNING_KEY` — filesystem path to the ES256 private key PEM used to validate daemon subject tokens (prereq from PR #3816).
+- `NEXUS_ENROLL_TOKEN_SECRET` — HMAC secret for daemon enrollment (prereq from PR #3816).
+
+Wire a production-grade `EncryptionProvider` on the FastAPI app state before `create_app` returns:
+
+```python
+# In your startup hook (before create_app returns):
+from nexus.bricks.auth.envelope_providers.aws_kms import AwsKmsProvider
+app.state.encryption_provider = AwsKmsProvider(key_id="arn:aws:kms:...")
+```
+
+**CRITICAL WARNING — InMemoryEncryptionProvider footgun.** Enabling `NEXUS_TOKEN_EXCHANGE_ENABLED=1` WITHOUT wiring `app.state.encryption_provider` falls back to `InMemoryEncryptionProvider`, which generates a fresh random KEK per process. This means:
+
+- In multi-worker deployments (e.g. `uvicorn --workers 4`), each worker has a different KEK — daemon-written envelopes will fail `WrappedDEKInvalid` on any other worker.
+- On server restart, every existing envelope row becomes unreadable because the KEK is lost.
+
+For production use you MUST wire Vault Transit or AWS KMS via `app.state.encryption_provider`. Single-worker dev/test deployments can use the default.
+
+### What it does
+
+Implements RFC 8693 token exchange on a single endpoint. The router accepts a daemon JWT as the `subject_token`, validates it against `NEXUS_JWT_SIGNING_KEY`, reads the envelope row for `(tenant_id, principal_id, provider)`, unwraps the DEK via the configured `EncryptionProvider`, decrypts the profile plaintext with AES-GCM (AAD bound to tenant/principal/profile), and returns the provider-native bearer:
+
+- `github`: `access_token` is the PAT.
+- `aws`: multi-part credentials — `access_token` holds the `session_token`; a sibling `nexus_credential_metadata` field carries `access_key_id`, `secret_access_key`, `expiration`, and (if present) `region`.
+
+See the spec file for wire-format examples and the full state machine.
+
+### Audit / SOC 2
+
+Every resolve writes to the `auth_profile_reads` table — 100% on cache-miss, 1% sampled on cache-hit. The table is partitioned monthly (default partition `auth_profile_reads_default` holds everything until ops provisions per-month partitions).
+
+Sample query for "who read credential X when":
+
+```sql
+SET LOCAL app.current_tenant = '<tenant-uuid>';
+SELECT read_at, principal_id, provider, caller_machine_id, caller_kind, purpose, cache_hit
+FROM auth_profile_reads
+WHERE auth_profile_id = 'github-default'
+ORDER BY read_at DESC
+LIMIT 20;
+```
+
+The `purpose` column is capped at 256 characters. Deployment guide warns callers MUST NOT include credentials or PII in the scope string (see next section).
+
+### `purpose` field discipline
+
+Callers pass the RFC 8693 `scope` field on the exchange request; the router stores it verbatim in `auth_profile_reads.purpose`. This is freetext and will be retained indefinitely, so callers MUST NOT pass credentials, PII, or other sensitive data. The router truncates at 256 characters but does not otherwise sanitize.
+
+Use descriptive, low-cardinality purpose strings:
+
+- Good: `"list-repos"`, `"s3-backup-nightly"`, `"ci-fetch-artifacts"`.
+- Bad: `"user token abc123"`, `"retry for user@example.com"`, anything containing a secret.
+
+### Cache architecture
+
+Two in-process, per-worker caches front the envelope read path:
+
+- `DEKCache` — caches unwrapped DEKs with a 5-minute TTL (default 300s). Keyed on `(tenant_id, principal_id, profile_id, kek_version)`.
+- `ResolvedCredCache` — caches the final materialized credential with TTL = `min(300s, expires_at - 60s)`. Short-lived AWS STS tokens cap their own TTL; static GitHub PATs use the 300s ceiling.
+
+Multi-worker deployments have independent caches per worker — cache-hit ratio degrades with worker count but correctness is unaffected. In production, consider `mlockall(MCL_FUTURE)` at process startup to prevent swap-to-disk of plaintext credentials sitting in the caches.
+
+### Provider scope
+
+Currently wired adapters:
+
+- `aws` — STS payload → `MaterializedCredential` with multi-part metadata.
+- `github` — PAT payload → `MaterializedCredential`.
+
+`gmail` and `gcloud` adapters are planned follow-ups (tracked under separate issues). The `ProviderAdapter` Protocol at `nexus.bricks.auth.consumer_providers.base.ProviderAdapter` is open for extension — new providers drop in by implementing the Protocol and registering with the router.
+
+### Failure modes and remediation
+
+| HTTP status | `error` | Meaning | Remediation |
+|---|---|---|---|
+| 401 | `invalid_token` | Daemon JWT signature, expiry, or issuer check failed | Daemon should refresh its token; verify signer key rotation on the daemon side matches the server's `NEXUS_JWT_SIGNING_KEY`. |
+| 403 | `access_denied` | No envelope row for `(tenant_id, principal_id, provider)` | Verify the daemon has pushed that provider for that principal; inspect `auth_profiles` directly. |
+| 409 | `stale_source` | Envelope row present but `last_synced_at + sync_ttl_seconds` is in the past | Daemon is offline or failing — check daemon logs. Self-heals on the next successful push. |
+| 500 | `envelope_error` | KMS unreachable, AAD tamper, or AES-GCM tag failure | Check server logs — `repr()` masks plaintext; inspect the `envelope_error` cause field to distinguish KMS-transient vs. tamper. |

--- a/docs/superpowers/plans/2026-04-23-issue-3818-server-credential-consumption.md
+++ b/docs/superpowers/plans/2026-04-23-issue-3818-server-credential-consumption.md
@@ -1,0 +1,2970 @@
+# Issue #3818 — Server-side Credential Consumption Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement the read path for the multi-tenant Postgres-backed auth epic so that `/v1/auth/token-exchange` (RFC 8693) accepts a daemon JWT, decrypts the matching `auth_profiles` envelope, materializes a provider-native bearer (AWS or GitHub), writes a read-audit row, and returns the credential to the caller.
+
+**Architecture:** New `CredentialConsumer` orchestrator inside `bricks/auth/` reuses the existing `EncryptionProvider`, `DEKCache`, `JwtSigner`, and `PostgresAuthProfileStore` infra from PRs #3802/#3809/#3816. Two provider adapters (AWS, GitHub) handle envelope-payload-shape decoding. A new `auth_profile_reads` partitioned table records every credential access (100% on cache-miss, 1% sample on cache-hit). The `token_exchange.py` router gets gutted and rewritten to wire JWT verify → consumer → audit → response.
+
+**Tech Stack:** Python 3.13, FastAPI, SQLAlchemy 2.x, PyJWT (ES256), `cryptography` (AES-256-GCM, already used by envelope), pytest, prometheus-client. Test infra adds `localstack` and `responses` (mocking) on top of existing patterns.
+
+**Spec:** `docs/superpowers/specs/2026-04-23-issue-3818-server-credential-consumption-design.md`
+
+---
+
+## File structure
+
+**Create:**
+- `src/nexus/bricks/auth/consumer.py` — `MaterializedCredential` dataclass, `CredentialConsumer.resolve()`, `ConsumerError` taxonomy
+- `src/nexus/bricks/auth/consumer_cache.py` — `ResolvedCredCache` with TTL = `min(300, expires_at-60)`
+- `src/nexus/bricks/auth/consumer_providers/__init__.py` — `default_adapters()` registry
+- `src/nexus/bricks/auth/consumer_providers/base.py` — `ProviderAdapter` Protocol
+- `src/nexus/bricks/auth/consumer_providers/aws.py` — AWS payload → `MaterializedCredential`
+- `src/nexus/bricks/auth/consumer_providers/github.py` — GitHub payload → `MaterializedCredential`
+- `src/nexus/bricks/auth/read_audit.py` — `ReadAuditWriter` w/ 1% cache-hit sampling
+- `src/nexus/bricks/auth/consumer_metrics.py` — Prometheus counters/histograms
+- `src/nexus/bricks/auth/tests/test_consumer.py`
+- `src/nexus/bricks/auth/tests/test_consumer_cache.py`
+- `src/nexus/bricks/auth/tests/test_consumer_providers_aws.py`
+- `src/nexus/bricks/auth/tests/test_consumer_providers_github.py`
+- `src/nexus/bricks/auth/tests/test_read_audit.py`
+- `src/nexus/bricks/auth/tests/test_postgres_decrypt_integration.py`
+- `tests/e2e/auth_consumption/__init__.py`
+- `tests/e2e/auth_consumption/test_s3_as_user.py`
+- `tests/e2e/auth_consumption/test_github_as_user.py`
+
+**Modify:**
+- `src/nexus/bricks/auth/postgres_profile_store.py` — add `decrypt_profile()` method, append `auth_profile_reads` to `_DDL_STATEMENTS` + `_RLS_STATEMENTS`
+- `src/nexus/server/api/v1/routers/token_exchange.py` — full rewrite (was 501 stub)
+- `src/nexus/server/api/v1/tests/test_token_exchange_router.py` — full rewrite
+- `src/nexus/server/fastapi_server.py` — pass new deps to `make_token_exchange_router`
+
+---
+
+## Task 1: Add `auth_profile_reads` schema (DDL only)
+
+**Files:**
+- Modify: `src/nexus/bricks/auth/postgres_profile_store.py` (append to `_DDL_STATEMENTS` near line 261; append to `_RLS_STATEMENTS` near line 280)
+- Modify: `src/nexus/bricks/auth/tests/test_postgres_decrypt_integration.py` (create)
+
+- [ ] **Step 1.1: Write the failing test**
+
+Create `src/nexus/bricks/auth/tests/test_postgres_decrypt_integration.py`:
+
+```python
+"""Integration tests for read-path additions to PostgresAuthProfileStore (#3818).
+
+Requires a running Postgres (env: NEXUS_TEST_DATABASE_URL). Skip cleanly when absent.
+"""
+
+from __future__ import annotations
+
+import os
+import uuid
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from nexus.bricks.auth.postgres_profile_store import (
+    PostgresAuthProfileStore,
+    ensure_schema,
+)
+
+
+@pytest.fixture
+def engine():
+    url = os.environ.get("NEXUS_TEST_DATABASE_URL")
+    if not url:
+        pytest.skip("NEXUS_TEST_DATABASE_URL not set")
+    eng = create_engine(url, future=True)
+    ensure_schema(eng)
+    yield eng
+    eng.dispose()
+
+
+def test_auth_profile_reads_table_exists(engine):
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'auth_profile_reads' ORDER BY ordinal_position"
+            )
+        ).fetchall()
+    cols = [r[0] for r in rows]
+    assert cols == [
+        "id",
+        "read_at",
+        "tenant_id",
+        "principal_id",
+        "auth_profile_id",
+        "caller_machine_id",
+        "caller_kind",
+        "provider",
+        "purpose",
+        "cache_hit",
+        "kek_version",
+    ]
+
+
+def test_auth_profile_reads_has_rls_enabled(engine):
+    with engine.connect() as conn:
+        row = conn.execute(
+            text(
+                "SELECT relrowsecurity, relforcerowsecurity FROM pg_class "
+                "WHERE relname = 'auth_profile_reads'"
+            )
+        ).fetchone()
+    assert row == (True, True)
+```
+
+- [ ] **Step 1.2: Run test to verify it fails**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_postgres_decrypt_integration.py -v`
+Expected: FAIL with column list mismatch (table doesn't exist or missing columns).
+
+- [ ] **Step 1.3: Append the DDL**
+
+In `src/nexus/bricks/auth/postgres_profile_store.py`, append to `_DDL_STATEMENTS` tuple (immediately after the `auth_profile_writes` index entry near line 260; insertion ordered before the closing `)`):
+
+```python
+    """
+    CREATE TABLE IF NOT EXISTS auth_profile_reads (
+        id                BIGSERIAL,
+        read_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        tenant_id         UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+        principal_id      UUID NOT NULL,
+        auth_profile_id   TEXT NOT NULL,
+        caller_machine_id UUID NOT NULL,
+        caller_kind       TEXT NOT NULL,
+        provider          TEXT NOT NULL,
+        purpose           TEXT NOT NULL,
+        cache_hit         BOOLEAN NOT NULL,
+        kek_version       INTEGER NOT NULL,
+        PRIMARY KEY (read_at, id)
+    ) PARTITION BY RANGE (read_at)
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS auth_profile_reads_default
+        PARTITION OF auth_profile_reads DEFAULT
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_auth_profile_reads_tenant_principal_provider "
+    "ON auth_profile_reads(tenant_id, principal_id, provider, read_at DESC)",
+```
+
+In the `_RLS_STATEMENTS` tuple (around line 280, after the `auth_profile_writes` FORCE entry):
+
+```python
+    "ALTER TABLE auth_profile_reads ENABLE ROW LEVEL SECURITY",
+    "ALTER TABLE auth_profile_reads FORCE ROW LEVEL SECURITY",
+    """
+    CREATE POLICY auth_profile_reads_tenant_isolation ON auth_profile_reads
+        USING (tenant_id = current_setting('app.current_tenant')::UUID)
+    """,
+```
+
+Note: the `CREATE POLICY` may already exist on a re-run — wrap it in a `DO $$ BEGIN ... EXCEPTION WHEN duplicate_object THEN NULL; END $$` block matching whatever pattern PR 3 used for the other `CREATE POLICY` statements (search for `CREATE POLICY auth_profile_writes` to copy the same idempotency wrapper).
+
+- [ ] **Step 1.4: Run test to verify it passes**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_postgres_decrypt_integration.py -v`
+Expected: PASS (both tests).
+
+- [ ] **Step 1.5: Commit**
+
+```bash
+git add src/nexus/bricks/auth/postgres_profile_store.py src/nexus/bricks/auth/tests/test_postgres_decrypt_integration.py
+git commit -m "feat(#3818): add auth_profile_reads partitioned table + RLS"
+```
+
+---
+
+## Task 2: `decrypt_profile()` helper on `PostgresAuthProfileStore`
+
+**Files:**
+- Modify: `src/nexus/bricks/auth/postgres_profile_store.py` (append a method to the class)
+- Modify: `src/nexus/bricks/auth/tests/test_postgres_decrypt_integration.py` (extend)
+
+- [ ] **Step 2.1: Write the failing test**
+
+Append to `test_postgres_decrypt_integration.py`:
+
+```python
+from datetime import UTC, datetime, timedelta
+
+from nexus.bricks.auth.envelope import (
+    AESGCMEnvelope,
+    DEKCache,
+)
+from nexus.bricks.auth.envelope_providers.in_memory import InMemoryEncryptionProvider
+
+
+def _seed_envelope_row(
+    *,
+    engine,
+    tenant_id: uuid.UUID,
+    principal_id: uuid.UUID,
+    profile_id: str,
+    provider: str,
+    plaintext: bytes,
+    encryption,
+):
+    """Helper: seed a fully-formed envelope row for decrypt tests."""
+    aad = (
+        str(tenant_id).encode() + b"|" + str(principal_id).encode() + b"|" + profile_id.encode()
+    )
+    dek = b"\x00" * 32  # AES-256 zero key — fine for an in-memory test fake
+    nonce, ciphertext = AESGCMEnvelope().encrypt(dek, plaintext, aad=aad)
+    wrapped, kek_version = encryption.wrap_dek(dek, tenant_id=tenant_id, aad=aad)
+    with engine.begin() as conn:
+        conn.execute(
+            text("SET LOCAL app.current_tenant = :t"),
+            {"t": str(tenant_id)},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO tenants (id, name) VALUES (:id, :n) ON CONFLICT DO NOTHING"
+            ),
+            {"id": str(tenant_id), "n": "test"},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO principals (id, tenant_id, kind) VALUES (:id, :t, 'human') "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {"id": str(principal_id), "t": str(tenant_id)},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO auth_profiles "
+                "(tenant_id, principal_id, id, provider, account_identifier, "
+                " backend, backend_key, last_synced_at, sync_ttl_seconds, "
+                " ciphertext, wrapped_dek, nonce, aad, kek_version) "
+                "VALUES (:t, :p, :id, :prov, 'acct', 'envelope', 'k', NOW(), 300, "
+                " :ct, :wd, :no, :aad, :kv)"
+            ),
+            {
+                "t": str(tenant_id),
+                "p": str(principal_id),
+                "id": profile_id,
+                "prov": provider,
+                "ct": ciphertext,
+                "wd": wrapped,
+                "no": nonce,
+                "aad": aad,
+                "kv": kek_version,
+            },
+        )
+
+
+def test_decrypt_profile_returns_plaintext_and_kek_version(engine):
+    tenant_id = uuid.uuid4()
+    principal_id = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    plaintext = b'{"token":"ghp_test"}'
+    _seed_envelope_row(
+        engine=engine,
+        tenant_id=tenant_id,
+        principal_id=principal_id,
+        profile_id="github-default",
+        provider="github",
+        plaintext=plaintext,
+        encryption=encryption,
+    )
+
+    store = PostgresAuthProfileStore(engine=engine, tenant_id=tenant_id)
+    out = store.decrypt_profile(
+        principal_id=principal_id,
+        provider="github",
+        encryption=encryption,
+        dek_cache=DEKCache(),
+    )
+
+    assert out.plaintext == plaintext
+    assert out.profile_id == "github-default"
+    assert out.kek_version == 1
+    assert out.last_synced_at is not None
+
+
+def test_decrypt_profile_raises_profile_not_found(engine):
+    from nexus.bricks.auth.postgres_profile_store import ProfileNotFound
+
+    tenant_id = uuid.uuid4()
+    principal_id = uuid.uuid4()
+    # Seed tenant but no profile
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant_id)})
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, 'tx') ON CONFLICT DO NOTHING"),
+            {"id": str(tenant_id)},
+        )
+
+    store = PostgresAuthProfileStore(engine=engine, tenant_id=tenant_id)
+    encryption = InMemoryEncryptionProvider()
+    with pytest.raises(ProfileNotFound):
+        store.decrypt_profile(
+            principal_id=principal_id,
+            provider="aws",
+            encryption=encryption,
+            dek_cache=DEKCache(),
+        )
+```
+
+- [ ] **Step 2.2: Run to verify failure**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_postgres_decrypt_integration.py::test_decrypt_profile_returns_plaintext_and_kek_version -v`
+Expected: FAIL with `AttributeError: PostgresAuthProfileStore has no attribute 'decrypt_profile'`.
+
+- [ ] **Step 2.3: Implement `decrypt_profile()`**
+
+In `src/nexus/bricks/auth/postgres_profile_store.py`:
+
+Add near the top (alongside `CrossPrincipalConflict`):
+
+```python
+class ProfileNotFound(Exception):
+    """No envelope-carrying auth_profile row for (tenant, principal, provider)."""
+
+    def __init__(self, *, tenant_id: uuid.UUID, principal_id: uuid.UUID, provider: str):
+        self.tenant_id = tenant_id
+        self.principal_id = principal_id
+        self.provider = provider
+        super().__init__(
+            f"no auth_profile row tenant={tenant_id} principal={principal_id} "
+            f"provider={provider}"
+        )
+
+
+@dataclass(frozen=True)
+class DecryptedProfile:
+    """Output of ``PostgresAuthProfileStore.decrypt_profile``.
+
+    ``plaintext`` is the daemon-pushed envelope payload (provider-specific JSON).
+    Caller (CredentialConsumer) hands this to the matching ProviderAdapter.
+
+    ``last_synced_at`` lets the consumer return 409 stale_source when the row
+    is older than ``sync_ttl_seconds``.
+    """
+
+    plaintext: bytes
+    profile_id: str
+    kek_version: int
+    last_synced_at: datetime
+    sync_ttl_seconds: int
+```
+
+Add a method on `PostgresAuthProfileStore` (locate the class body — append after the existing `upsert_with_credential` method):
+
+```python
+    def decrypt_profile(
+        self,
+        *,
+        principal_id: uuid.UUID,
+        provider: str,
+        encryption: EncryptionProvider,
+        dek_cache: DEKCache,
+    ) -> DecryptedProfile:
+        """Decrypt the envelope row matching (tenant, principal, provider).
+
+        Selects the most-recently-updated row for that triple (the daemon may
+        have pushed multiple over time; we always read newest). Raises
+        ``ProfileNotFound`` if no row exists.
+
+        DEK is unwrapped via ``encryption.unwrap_dek`` with cache-through on
+        ``dek_cache``. AES-GCM decrypt failures bubble as ``EnvelopeError``
+        subclasses (no plaintext in repr).
+        """
+        with self._tenant_scoped_connection() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT id, ciphertext, wrapped_dek, nonce, aad, kek_version, "
+                    "       last_synced_at, sync_ttl_seconds "
+                    "FROM auth_profiles "
+                    "WHERE tenant_id = :t AND principal_id = :p AND provider = :prov "
+                    "  AND ciphertext IS NOT NULL "
+                    "ORDER BY updated_at DESC LIMIT 1"
+                ),
+                {"t": str(self._tenant_id), "p": str(principal_id), "prov": provider},
+            ).fetchone()
+
+        if row is None:
+            raise ProfileNotFound(
+                tenant_id=self._tenant_id,
+                principal_id=principal_id,
+                provider=provider,
+            )
+
+        profile_id, ciphertext, wrapped_dek, nonce, aad, kek_version, lsa, sttl = row
+        cache_key = DEKCache.make_key(
+            tenant_id=self._tenant_id,
+            kek_version=kek_version,
+            wrapped_dek=bytes(wrapped_dek),
+        )
+        dek = dek_cache.get(cache_key)
+        if dek is None:
+            dek = encryption.unwrap_dek(
+                bytes(wrapped_dek),
+                tenant_id=self._tenant_id,
+                aad=bytes(aad),
+                kek_version=kek_version,
+            )
+            dek_cache.put(cache_key, dek)
+
+        plaintext = AESGCMEnvelope().decrypt(
+            dek, bytes(nonce), bytes(ciphertext), aad=bytes(aad)
+        )
+        return DecryptedProfile(
+            plaintext=plaintext,
+            profile_id=profile_id,
+            kek_version=kek_version,
+            last_synced_at=lsa,
+            sync_ttl_seconds=sttl,
+        )
+```
+
+If `_tenant_scoped_connection()` doesn't exist by that name, search the file for the existing pattern (look for `SET LOCAL app.current_tenant`) and reuse the same context-manager helper. If it's inlined elsewhere, factor it out as a private method on the class (`@contextmanager def _tenant_scoped_connection(self)`) so this new method and existing methods share one path.
+
+- [ ] **Step 2.4: Run tests to verify they pass**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_postgres_decrypt_integration.py -v`
+Expected: all tests PASS.
+
+- [ ] **Step 2.5: Commit**
+
+```bash
+git add src/nexus/bricks/auth/postgres_profile_store.py src/nexus/bricks/auth/tests/test_postgres_decrypt_integration.py
+git commit -m "feat(#3818): add decrypt_profile() helper on PostgresAuthProfileStore"
+```
+
+---
+
+## Task 3: `MaterializedCredential` + `ProviderAdapter` Protocol
+
+**Files:**
+- Create: `src/nexus/bricks/auth/consumer.py`
+- Create: `src/nexus/bricks/auth/consumer_providers/__init__.py`
+- Create: `src/nexus/bricks/auth/consumer_providers/base.py`
+
+This task lays down the typed contracts. No tests yet — these are pure Protocol/dataclass definitions; they'll be exercised by Tasks 4-7.
+
+- [ ] **Step 3.1: Create `consumer.py` with `MaterializedCredential`**
+
+```python
+"""CredentialConsumer: server-side read path for envelope-encrypted auth profiles (#3818).
+
+The consumer is the orchestrator that ties together:
+  - PostgresAuthProfileStore.decrypt_profile() — envelope → plaintext
+  - ProviderAdapter.materialize() — plaintext → MaterializedCredential
+  - ResolvedCredCache — TTL = min(300, expires_at - 60)
+  - ReadAuditWriter — auth_profile_reads row per resolve
+
+Callers: ``/v1/auth/token-exchange`` router (wire path), and any in-process
+server-side agent that needs to act as a user.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nexus.bricks.auth.consumer_cache import ResolvedCredCache
+    from nexus.bricks.auth.consumer_providers.base import ProviderAdapter
+    from nexus.bricks.auth.envelope import DEKCache, EncryptionProvider
+    from nexus.bricks.auth.postgres_profile_store import PostgresAuthProfileStore
+    from nexus.bricks.auth.read_audit import ReadAuditWriter
+    from nexus.server.api.v1.jwt_signer import DaemonClaims
+
+
+@dataclass(frozen=True)
+class MaterializedCredential:
+    """Provider-native credential ready for the wire / in-process use.
+
+    ``access_token`` is the time-bounded part (AWS session_token, GitHub PAT).
+    For multi-part credentials (AWS), ``metadata`` carries the static parts
+    (access_key_id, secret_access_key, region, account_id) — the wire response
+    surfaces these under ``nexus_credential_metadata``.
+
+    ``__repr__`` masks ``access_token`` to keep it out of logs / tracebacks.
+    """
+
+    provider: str
+    access_token: str
+    expires_at: datetime | None
+    metadata: dict[str, str] = field(default_factory=dict)
+
+    def __repr__(self) -> str:
+        return (
+            f"MaterializedCredential(provider={self.provider!r}, "
+            f"access_token='***', expires_at={self.expires_at!r}, "
+            f"metadata_keys={sorted(self.metadata)!r})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Error taxonomy — no plaintext / token bytes ever in repr
+# ---------------------------------------------------------------------------
+
+
+class ConsumerError(Exception):
+    """Root of every CredentialConsumer error."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        tenant_id: uuid.UUID | None = None,
+        principal_id: uuid.UUID | None = None,
+        provider: str | None = None,
+        cause: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.tenant_id = tenant_id
+        self.principal_id = principal_id
+        self.provider = provider
+        self.cause = cause
+
+    @classmethod
+    def from_row(
+        cls,
+        *,
+        tenant_id: uuid.UUID,
+        principal_id: uuid.UUID,
+        provider: str,
+        cause: str,
+    ) -> "ConsumerError":
+        return cls(
+            f"{cls.__name__} tenant={tenant_id} principal={principal_id} "
+            f"provider={provider} cause={cause}",
+            tenant_id=tenant_id,
+            principal_id=principal_id,
+            provider=provider,
+            cause=cause,
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"{type(self).__name__}(tenant_id={self.tenant_id!s}, "
+            f"principal_id={self.principal_id!s}, provider={self.provider!r}, "
+            f"cause={self.cause!r})"
+        )
+
+
+class ProfileNotFoundForCaller(ConsumerError):
+    """Tenant/principal/provider triple has no envelope row."""
+
+
+class ProviderNotConfigured(ConsumerError):
+    """No ProviderAdapter registered for this provider name."""
+
+
+class StaleSource(ConsumerError):
+    """Envelope row's ``last_synced_at`` is past ``sync_ttl_seconds`` —
+    daemon is offline; caller should retry once daemon catches up.
+    """
+
+
+class AdapterMaterializeFailed(ConsumerError):
+    """Provider adapter raised while decoding the envelope payload."""
+
+
+# ---------------------------------------------------------------------------
+# CredentialConsumer (orchestrator) — implementation in Task 7
+# ---------------------------------------------------------------------------
+
+
+class CredentialConsumer:
+    """Implementation lands in Task 7. Type-only declaration here so other
+    modules can import the symbol without circular references.
+    """
+```
+
+- [ ] **Step 3.2: Create `consumer_providers/base.py`**
+
+```python
+"""ProviderAdapter Protocol — provider-specific envelope-payload decoders.
+
+Each adapter is pure deserialization: takes envelope plaintext bytes (JSON,
+provider-shape), returns a ``MaterializedCredential``. No network calls, no
+state. Adapters are registered in ``consumer_providers/__init__.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from nexus.bricks.auth.consumer import MaterializedCredential
+
+
+@runtime_checkable
+class ProviderAdapter(Protocol):
+    """Pure-function interface: envelope plaintext → MaterializedCredential."""
+
+    name: str  # "aws" | "github" | future providers
+
+    def materialize(self, plaintext_payload: bytes) -> MaterializedCredential:
+        """Decode envelope plaintext into a MaterializedCredential.
+
+        Raises:
+            ValueError | KeyError on malformed payload — CredentialConsumer
+            wraps these as AdapterMaterializeFailed before exiting.
+        """
+        ...
+```
+
+- [ ] **Step 3.3: Create `consumer_providers/__init__.py`**
+
+```python
+"""Provider adapter registry. Updated by each adapter task."""
+
+from __future__ import annotations
+
+from nexus.bricks.auth.consumer_providers.base import ProviderAdapter
+
+
+def default_adapters() -> dict[str, ProviderAdapter]:
+    """Return the adapter registry used by CredentialConsumer.
+
+    Adapters are imported lazily so missing optional deps (e.g. AWS payload
+    parsing only needs stdlib ``json``, but future providers may need boto3)
+    don't cascade-break unrelated code paths.
+    """
+    from nexus.bricks.auth.consumer_providers.aws import AwsProviderAdapter
+    from nexus.bricks.auth.consumer_providers.github import GithubProviderAdapter
+
+    return {
+        AwsProviderAdapter.name: AwsProviderAdapter(),
+        GithubProviderAdapter.name: GithubProviderAdapter(),
+    }
+```
+
+(`AwsProviderAdapter` and `GithubProviderAdapter` are added in Tasks 4 and 5; the import will fail until then. That's fine — `default_adapters()` is only called from the consumer wiring in Task 7.)
+
+- [ ] **Step 3.4: Verify it imports**
+
+Run: `python -c "from nexus.bricks.auth.consumer import MaterializedCredential, ConsumerError, ProfileNotFoundForCaller, ProviderNotConfigured, StaleSource, AdapterMaterializeFailed; print('OK')"`
+Expected: `OK`.
+
+- [ ] **Step 3.5: Commit**
+
+```bash
+git add src/nexus/bricks/auth/consumer.py src/nexus/bricks/auth/consumer_providers/__init__.py src/nexus/bricks/auth/consumer_providers/base.py
+git commit -m "feat(#3818): add MaterializedCredential + ConsumerError taxonomy + adapter Protocol"
+```
+
+---
+
+## Task 4: AWS provider adapter
+
+**Files:**
+- Create: `src/nexus/bricks/auth/consumer_providers/aws.py`
+- Create: `src/nexus/bricks/auth/tests/test_consumer_providers_aws.py`
+
+- [ ] **Step 4.1: Write the failing test**
+
+```python
+"""Tests for AwsProviderAdapter — pure JSON → MaterializedCredential decoding (#3818)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime, timedelta
+
+import pytest
+
+from nexus.bricks.auth.consumer_providers.aws import AwsProviderAdapter
+
+
+def test_materialize_extracts_session_token_and_metadata():
+    payload = json.dumps(
+        {
+            "access_key_id": "ASIA1234",
+            "secret_access_key": "wJalrXUtnFEMI",
+            "session_token": "FwoGZXIvYXdz...",
+            "expiration": "2026-04-23T18:00:00+00:00",
+            "region": "us-west-2",
+            "account_id": "123456789012",
+        }
+    ).encode()
+
+    out = AwsProviderAdapter().materialize(payload)
+
+    assert out.provider == "aws"
+    assert out.access_token == "FwoGZXIvYXdz..."
+    assert out.expires_at == datetime(2026, 4, 23, 18, 0, 0, tzinfo=UTC)
+    assert out.metadata == {
+        "access_key_id": "ASIA1234",
+        "secret_access_key": "wJalrXUtnFEMI",
+        "region": "us-west-2",
+        "account_id": "123456789012",
+    }
+
+
+def test_materialize_handles_missing_optional_fields():
+    payload = json.dumps(
+        {
+            "access_key_id": "ASIA1234",
+            "secret_access_key": "wJalrXUtnFEMI",
+            "session_token": "tok",
+            "expiration": "2026-04-23T18:00:00+00:00",
+            "region": "us-east-1",
+        }
+    ).encode()
+    out = AwsProviderAdapter().materialize(payload)
+    assert "account_id" not in out.metadata
+
+
+def test_materialize_rejects_malformed_json():
+    with pytest.raises(ValueError):
+        AwsProviderAdapter().materialize(b"not json")
+
+
+def test_materialize_rejects_missing_required_field():
+    payload = json.dumps({"access_key_id": "x"}).encode()
+    with pytest.raises(KeyError):
+        AwsProviderAdapter().materialize(payload)
+
+
+def test_repr_masks_access_token():
+    payload = json.dumps(
+        {
+            "access_key_id": "ASIA1234",
+            "secret_access_key": "wJalrXUtnFEMI",
+            "session_token": "supersecret",
+            "expiration": "2026-04-23T18:00:00+00:00",
+            "region": "us-east-1",
+        }
+    ).encode()
+    out = AwsProviderAdapter().materialize(payload)
+    assert "supersecret" not in repr(out)
+    assert "***" in repr(out)
+```
+
+- [ ] **Step 4.2: Run to verify failure**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_consumer_providers_aws.py -v`
+Expected: FAIL with `ImportError`.
+
+- [ ] **Step 4.3: Implement `aws.py`**
+
+```python
+"""AWS provider adapter — daemon-pushed STS payload → MaterializedCredential (#3818).
+
+Payload shape (JSON, daemon-pushed by aws sso login / aws sts get-caller-identity):
+    {
+      "access_key_id":     "ASIA...",       # required
+      "secret_access_key": "...",           # required
+      "session_token":     "...",           # required (the time-bounded part)
+      "expiration":        "ISO 8601",      # required (UTC)
+      "region":            "us-...",        # required
+      "account_id":        "123456789012"   # optional
+    }
+
+The wire response carries ``session_token`` in ``access_token`` and the rest
+in ``nexus_credential_metadata``. Caller-side SDK builds ``boto3.Session``
+from the pair.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from nexus.bricks.auth.consumer import MaterializedCredential
+
+
+class AwsProviderAdapter:
+    name: str = "aws"
+
+    def materialize(self, plaintext_payload: bytes) -> MaterializedCredential:
+        data = json.loads(plaintext_payload.decode("utf-8"))
+        # Required fields — KeyError surfaces as AdapterMaterializeFailed in the consumer.
+        session_token = data["session_token"]
+        access_key_id = data["access_key_id"]
+        secret_access_key = data["secret_access_key"]
+        expiration_iso = data["expiration"]
+        region = data["region"]
+
+        expires_at = datetime.fromisoformat(expiration_iso)
+
+        metadata = {
+            "access_key_id": access_key_id,
+            "secret_access_key": secret_access_key,
+            "region": region,
+        }
+        if "account_id" in data:
+            metadata["account_id"] = data["account_id"]
+
+        return MaterializedCredential(
+            provider=self.name,
+            access_token=session_token,
+            expires_at=expires_at,
+            metadata=metadata,
+        )
+```
+
+- [ ] **Step 4.4: Run tests to verify pass**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_consumer_providers_aws.py -v`
+Expected: 5 PASS.
+
+- [ ] **Step 4.5: Commit**
+
+```bash
+git add src/nexus/bricks/auth/consumer_providers/aws.py src/nexus/bricks/auth/tests/test_consumer_providers_aws.py
+git commit -m "feat(#3818): add AwsProviderAdapter — STS payload → MaterializedCredential"
+```
+
+---
+
+## Task 5: GitHub provider adapter
+
+**Files:**
+- Create: `src/nexus/bricks/auth/consumer_providers/github.py`
+- Create: `src/nexus/bricks/auth/tests/test_consumer_providers_github.py`
+
+- [ ] **Step 5.1: Write the failing test**
+
+```python
+"""Tests for GithubProviderAdapter — pure JSON → MaterializedCredential decoding (#3818)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from nexus.bricks.auth.consumer_providers.github import GithubProviderAdapter
+
+
+def test_materialize_classic_pat_no_expiry():
+    payload = json.dumps(
+        {"token": "ghp_classic", "scopes": ["repo", "read:user"]}
+    ).encode()
+    out = GithubProviderAdapter().materialize(payload)
+    assert out.provider == "github"
+    assert out.access_token == "ghp_classic"
+    assert out.expires_at is None
+    assert out.metadata == {"scopes_csv": "repo,read:user", "token_type": "classic"}
+
+
+def test_materialize_fine_grained_with_expiry():
+    payload = json.dumps(
+        {
+            "token": "github_pat_xyz",
+            "scopes": [],
+            "expires_at": "2026-07-01T00:00:00+00:00",
+            "token_type": "fine_grained",
+        }
+    ).encode()
+    out = GithubProviderAdapter().materialize(payload)
+    assert out.access_token == "github_pat_xyz"
+    assert out.expires_at == datetime(2026, 7, 1, 0, 0, 0, tzinfo=UTC)
+    assert out.metadata["token_type"] == "fine_grained"
+    assert out.metadata["scopes_csv"] == ""
+
+
+def test_materialize_rejects_missing_token():
+    with pytest.raises(KeyError):
+        GithubProviderAdapter().materialize(json.dumps({"scopes": []}).encode())
+
+
+def test_materialize_rejects_malformed_json():
+    with pytest.raises(ValueError):
+        GithubProviderAdapter().materialize(b"<html>not json</html>")
+
+
+def test_repr_masks_token():
+    payload = json.dumps({"token": "ghp_supersecret", "scopes": []}).encode()
+    out = GithubProviderAdapter().materialize(payload)
+    assert "ghp_supersecret" not in repr(out)
+```
+
+- [ ] **Step 5.2: Run to verify failure**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_consumer_providers_github.py -v`
+Expected: FAIL with `ImportError`.
+
+- [ ] **Step 5.3: Implement `github.py`**
+
+```python
+"""GitHub provider adapter — daemon-pushed `gh auth token` payload → MaterializedCredential (#3818).
+
+Payload shape (JSON, daemon-pushed by `gh auth token`):
+    {
+      "token":      "ghp_..." | "github_pat_...",   # required
+      "scopes":     ["repo", "read:user", ...],     # required (may be [])
+      "expires_at": "ISO 8601",                     # optional (fine-grained PATs)
+      "token_type": "classic" | "fine_grained"      # optional, defaults "classic"
+    }
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from nexus.bricks.auth.consumer import MaterializedCredential
+
+
+class GithubProviderAdapter:
+    name: str = "github"
+
+    def materialize(self, plaintext_payload: bytes) -> MaterializedCredential:
+        data = json.loads(plaintext_payload.decode("utf-8"))
+        token = data["token"]  # KeyError → AdapterMaterializeFailed
+        scopes = data.get("scopes", [])
+        token_type = data.get("token_type", "classic")
+
+        expires_at: datetime | None = None
+        if "expires_at" in data and data["expires_at"]:
+            expires_at = datetime.fromisoformat(data["expires_at"])
+
+        return MaterializedCredential(
+            provider=self.name,
+            access_token=token,
+            expires_at=expires_at,
+            metadata={
+                "scopes_csv": ",".join(scopes),
+                "token_type": token_type,
+            },
+        )
+```
+
+- [ ] **Step 5.4: Run tests**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_consumer_providers_github.py -v`
+Expected: 5 PASS.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add src/nexus/bricks/auth/consumer_providers/github.py src/nexus/bricks/auth/tests/test_consumer_providers_github.py
+git commit -m "feat(#3818): add GithubProviderAdapter — PAT payload → MaterializedCredential"
+```
+
+---
+
+## Task 6: `ResolvedCredCache` with bounded TTL
+
+**Files:**
+- Create: `src/nexus/bricks/auth/consumer_cache.py`
+- Create: `src/nexus/bricks/auth/tests/test_consumer_cache.py`
+
+- [ ] **Step 6.1: Write the failing test**
+
+```python
+"""Tests for ResolvedCredCache — TTL = min(300, expires_at - 60) (#3818)."""
+
+from __future__ import annotations
+
+import threading
+from datetime import UTC, datetime, timedelta
+
+from nexus.bricks.auth.consumer import MaterializedCredential
+from nexus.bricks.auth.consumer_cache import ResolvedCredCache, _compute_ttl_seconds
+
+
+def _cred(*, expires_at: datetime | None = None) -> MaterializedCredential:
+    return MaterializedCredential(
+        provider="github",
+        access_token="t",
+        expires_at=expires_at,
+        metadata={},
+    )
+
+
+def test_compute_ttl_uses_ceiling_when_no_expiry():
+    assert _compute_ttl_seconds(now=datetime.now(UTC), expires_at=None) == 300
+
+
+def test_compute_ttl_caps_at_expiry_minus_60():
+    now = datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)
+    exp = now + timedelta(seconds=200)
+    assert _compute_ttl_seconds(now=now, expires_at=exp) == 140
+
+
+def test_compute_ttl_clamps_to_zero_when_already_near_expiry():
+    now = datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)
+    exp = now + timedelta(seconds=30)
+    assert _compute_ttl_seconds(now=now, expires_at=exp) == 0
+
+
+def test_get_returns_cached_then_evicts_after_ttl():
+    cache = ResolvedCredCache(ceiling_seconds=300)
+    key = ("t1", "p1", "github")
+    now = datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)
+    cred = _cred(expires_at=now + timedelta(seconds=200))
+
+    cache.put(key, cred, now=now)
+    # Hit immediately
+    assert cache.get(key, now=now) is cred
+    # 140s later: still warm (ttl is 200-60 = 140)
+    assert cache.get(key, now=now + timedelta(seconds=139)) is cred
+    # Just after TTL boundary: expired
+    assert cache.get(key, now=now + timedelta(seconds=141)) is None
+
+
+def test_put_with_no_expiry_uses_ceiling():
+    cache = ResolvedCredCache(ceiling_seconds=300)
+    key = ("t1", "p1", "github")
+    now = datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)
+    cache.put(key, _cred(expires_at=None), now=now)
+    assert cache.get(key, now=now + timedelta(seconds=299)) is not None
+    assert cache.get(key, now=now + timedelta(seconds=301)) is None
+
+
+def test_thread_safe_concurrent_put_get():
+    cache = ResolvedCredCache(ceiling_seconds=300)
+    now = datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)
+    cred = _cred(expires_at=now + timedelta(seconds=600))
+
+    def worker(i: int):
+        for _ in range(50):
+            cache.put((f"t{i}", "p", "github"), cred, now=now)
+            cache.get((f"t{i}", "p", "github"), now=now)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    # No exception = pass
+```
+
+- [ ] **Step 6.2: Run to verify failure**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_consumer_cache.py -v`
+Expected: FAIL with `ImportError`.
+
+- [ ] **Step 6.3: Implement `consumer_cache.py`**
+
+```python
+"""ResolvedCredCache: TTL = min(ceiling, expires_at - 60s).
+
+Holds plaintext access_tokens in memory bounded by both a ceiling (default
+300s, matching DEKCache) and the upstream credential's own ``expires_at``.
+This caps plaintext lifetime regardless of which bound triggers first.
+
+Keyed by ``(tenant_id_str, principal_id_str, provider)``. Tenant in the key
+is belt-and-braces against any future bug that forgets to ``SET LOCAL
+app.current_tenant`` before calling the consumer.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass
+from datetime import datetime
+
+from nexus.bricks.auth.consumer import MaterializedCredential
+
+_REFRESH_HEADROOM_SECONDS = 60
+
+
+def _compute_ttl_seconds(*, now: datetime, expires_at: datetime | None) -> int:
+    """TTL = min(ceiling, expires_at - 60s). Clamped to >= 0.
+
+    The 60s headroom means we evict before the upstream cred actually expires,
+    so callers never see a 401 from the upstream provider mid-call.
+
+    Ceiling is applied by the caller (``ResolvedCredCache.put``) — this helper
+    only computes the expires-at-bound. Returns the smaller of the two there.
+    """
+    if expires_at is None:
+        return 10**9  # effectively unbounded; ceiling will dominate
+    delta = (expires_at - now).total_seconds() - _REFRESH_HEADROOM_SECONDS
+    return max(0, int(delta))
+
+
+@dataclass(frozen=True)
+class _Entry:
+    cred: MaterializedCredential
+    expires_at_monotonic: float
+
+
+class ResolvedCredCache:
+    """Thread-safe TTL+LRU for MaterializedCredentials.
+
+    Tests inject ``now`` for determinism; production calls pass
+    ``datetime.now(UTC)``.
+    """
+
+    def __init__(self, *, ceiling_seconds: int = 300, max_entries: int = 1024) -> None:
+        self._ceiling = ceiling_seconds
+        self._max = max_entries
+        self._store: OrderedDict[tuple[str, str, str], _Entry] = OrderedDict()
+        self._lock = threading.Lock()
+
+    def get(
+        self,
+        key: tuple[str, str, str],
+        *,
+        now: datetime,
+    ) -> MaterializedCredential | None:
+        now_ts = now.timestamp()
+        with self._lock:
+            entry = self._store.get(key)
+            if entry is None:
+                return None
+            if now_ts >= entry.expires_at_monotonic:
+                self._store.pop(key, None)
+                return None
+            self._store.move_to_end(key)
+            return entry.cred
+
+    def put(
+        self,
+        key: tuple[str, str, str],
+        cred: MaterializedCredential,
+        *,
+        now: datetime,
+    ) -> None:
+        ttl = min(
+            self._ceiling,
+            _compute_ttl_seconds(now=now, expires_at=cred.expires_at),
+        )
+        with self._lock:
+            self._store[key] = _Entry(
+                cred=cred,
+                expires_at_monotonic=now.timestamp() + ttl,
+            )
+            self._store.move_to_end(key)
+            while len(self._store) > self._max:
+                self._store.popitem(last=False)
+```
+
+- [ ] **Step 6.4: Run tests**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_consumer_cache.py -v`
+Expected: 6 PASS.
+
+- [ ] **Step 6.5: Commit**
+
+```bash
+git add src/nexus/bricks/auth/consumer_cache.py src/nexus/bricks/auth/tests/test_consumer_cache.py
+git commit -m "feat(#3818): add ResolvedCredCache — TTL = min(ceiling, expires_at-60s)"
+```
+
+---
+
+## Task 7: `ReadAuditWriter` with 1% cache-hit sampling
+
+**Files:**
+- Create: `src/nexus/bricks/auth/read_audit.py`
+- Create: `src/nexus/bricks/auth/tests/test_read_audit.py`
+
+- [ ] **Step 7.1: Write the failing test**
+
+```python
+"""Tests for ReadAuditWriter — 100% on cache-miss, 1% sample on cache-hit (#3818)."""
+
+from __future__ import annotations
+
+import os
+import random
+import uuid
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from nexus.bricks.auth.postgres_profile_store import ensure_schema
+from nexus.bricks.auth.read_audit import ReadAuditWriter
+
+
+@pytest.fixture
+def engine():
+    url = os.environ.get("NEXUS_TEST_DATABASE_URL")
+    if not url:
+        pytest.skip("NEXUS_TEST_DATABASE_URL not set")
+    eng = create_engine(url, future=True)
+    ensure_schema(eng)
+    yield eng
+    eng.dispose()
+
+
+def _seed_tenant_principal(engine, tenant_id, principal_id):
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant_id)})
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, 'rt') ON CONFLICT DO NOTHING"),
+            {"id": str(tenant_id)},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO principals (id, tenant_id, kind) VALUES (:id, :t, 'human') "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {"id": str(principal_id), "t": str(tenant_id)},
+        )
+
+
+def _count_reads(engine, tenant_id):
+    with engine.connect() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant_id)})
+        return conn.execute(text("SELECT COUNT(*) FROM auth_profile_reads")).scalar()
+
+
+def test_writes_100_percent_on_cache_miss(engine):
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    machine = uuid.uuid4()
+    _seed_tenant_principal(engine, tenant, principal)
+    writer = ReadAuditWriter(engine=engine, hit_sample_rate=0.01)
+
+    for _ in range(20):
+        writer.write(
+            tenant_id=tenant,
+            principal_id=principal,
+            auth_profile_id="github-default",
+            caller_machine_id=machine,
+            caller_kind="daemon",
+            provider="github",
+            purpose="test",
+            cache_hit=False,
+            kek_version=1,
+        )
+
+    assert _count_reads(engine, tenant) == 20
+
+
+def test_samples_one_percent_on_cache_hit(engine):
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    machine = uuid.uuid4()
+    _seed_tenant_principal(engine, tenant, principal)
+    # Fixed RNG: with seed 42, first 100 random() values include exactly N
+    # below 0.01 — count them, then verify the writer wrote exactly N rows.
+    rng = random.Random(42)
+    expected = sum(1 for _ in range(100) if rng.random() < 0.01)
+
+    writer = ReadAuditWriter(engine=engine, hit_sample_rate=0.01, rng=random.Random(42))
+    for _ in range(100):
+        writer.write(
+            tenant_id=tenant,
+            principal_id=principal,
+            auth_profile_id="github-default",
+            caller_machine_id=machine,
+            caller_kind="daemon",
+            provider="github",
+            purpose="test",
+            cache_hit=True,
+            kek_version=1,
+        )
+
+    assert _count_reads(engine, tenant) == expected
+
+
+def test_truncates_purpose_to_256_chars(engine):
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    machine = uuid.uuid4()
+    _seed_tenant_principal(engine, tenant, principal)
+    writer = ReadAuditWriter(engine=engine, hit_sample_rate=0.01)
+
+    long_purpose = "x" * 1000
+    writer.write(
+        tenant_id=tenant,
+        principal_id=principal,
+        auth_profile_id="github-default",
+        caller_machine_id=machine,
+        caller_kind="daemon",
+        provider="github",
+        purpose=long_purpose,
+        cache_hit=False,
+        kek_version=1,
+    )
+
+    with engine.connect() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        row = conn.execute(text("SELECT purpose FROM auth_profile_reads")).fetchone()
+    assert len(row[0]) == 256
+```
+
+- [ ] **Step 7.2: Run to verify failure**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_read_audit.py -v`
+Expected: FAIL with `ImportError`.
+
+- [ ] **Step 7.3: Implement `read_audit.py`**
+
+```python
+"""ReadAuditWriter — auth_profile_reads row per credential resolution (#3818).
+
+Sampling: 100% on cache-miss (real KMS unwrap → real credential access),
+1% on cache-hit (operational telemetry, not access). Sampling rule documented
+in deployment guide; deviation should be a deliberate operator choice.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import uuid
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+logger = logging.getLogger(__name__)
+
+_PURPOSE_MAX_LEN = 256
+
+
+class ReadAuditWriter:
+    """Inserts ``auth_profile_reads`` rows. Caller passes RLS-set engine.
+
+    Failures are logged and swallowed. We never block a credential resolution
+    on audit-row insert — losing a single row is preferable to a blocked
+    caller, and the cache-miss path will retry naturally on the next resolve.
+    """
+
+    def __init__(
+        self,
+        *,
+        engine: Engine,
+        hit_sample_rate: float = 0.01,
+        rng: random.Random | None = None,
+    ) -> None:
+        self._engine = engine
+        self._hit_sample_rate = hit_sample_rate
+        self._rng = rng or random.Random()
+
+    def write(
+        self,
+        *,
+        tenant_id: uuid.UUID,
+        principal_id: uuid.UUID,
+        auth_profile_id: str,
+        caller_machine_id: uuid.UUID,
+        caller_kind: str,
+        provider: str,
+        purpose: str,
+        cache_hit: bool,
+        kek_version: int,
+    ) -> None:
+        if cache_hit and self._rng.random() >= self._hit_sample_rate:
+            return  # sampled out
+
+        truncated_purpose = purpose[:_PURPOSE_MAX_LEN]
+
+        try:
+            with self._engine.begin() as conn:
+                conn.execute(
+                    text("SET LOCAL app.current_tenant = :t"),
+                    {"t": str(tenant_id)},
+                )
+                conn.execute(
+                    text(
+                        "INSERT INTO auth_profile_reads "
+                        "(tenant_id, principal_id, auth_profile_id, caller_machine_id, "
+                        " caller_kind, provider, purpose, cache_hit, kek_version) "
+                        "VALUES (:t, :p, :ap, :cm, :ck, :prov, :pur, :hit, :kv)"
+                    ),
+                    {
+                        "t": str(tenant_id),
+                        "p": str(principal_id),
+                        "ap": auth_profile_id,
+                        "cm": str(caller_machine_id),
+                        "ck": caller_kind,
+                        "prov": provider,
+                        "pur": truncated_purpose,
+                        "hit": cache_hit,
+                        "kv": kek_version,
+                    },
+                )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "auth_profile_reads insert failed tenant=%s principal=%s provider=%s",
+                tenant_id,
+                principal_id,
+                provider,
+            )
+```
+
+- [ ] **Step 7.4: Run tests**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_read_audit.py -v`
+Expected: 3 PASS.
+
+- [ ] **Step 7.5: Commit**
+
+```bash
+git add src/nexus/bricks/auth/read_audit.py src/nexus/bricks/auth/tests/test_read_audit.py
+git commit -m "feat(#3818): add ReadAuditWriter — 100% miss, 1% hit sampling"
+```
+
+---
+
+## Task 8: `CredentialConsumer.resolve()` orchestrator
+
+**Files:**
+- Modify: `src/nexus/bricks/auth/consumer.py` (replace the stub `class CredentialConsumer:` from Task 3)
+- Create: `src/nexus/bricks/auth/tests/test_consumer.py`
+
+- [ ] **Step 8.1: Write the failing test**
+
+```python
+"""Tests for CredentialConsumer.resolve — orchestrator covering happy / cache /
+stale / errors (#3818)."""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from nexus.bricks.auth.consumer import (
+    AdapterMaterializeFailed,
+    CredentialConsumer,
+    ProfileNotFoundForCaller,
+    ProviderNotConfigured,
+    StaleSource,
+)
+from nexus.bricks.auth.consumer_cache import ResolvedCredCache
+from nexus.bricks.auth.consumer_providers.github import GithubProviderAdapter
+from nexus.bricks.auth.envelope import AESGCMEnvelope, DEKCache
+from nexus.bricks.auth.envelope_providers.in_memory import InMemoryEncryptionProvider
+from nexus.bricks.auth.postgres_profile_store import (
+    PostgresAuthProfileStore,
+    ensure_schema,
+)
+from nexus.bricks.auth.read_audit import ReadAuditWriter
+from nexus.server.api.v1.jwt_signer import DaemonClaims
+
+
+@pytest.fixture
+def engine():
+    url = os.environ.get("NEXUS_TEST_DATABASE_URL")
+    if not url:
+        pytest.skip("NEXUS_TEST_DATABASE_URL not set")
+    eng = create_engine(url, future=True)
+    ensure_schema(eng)
+    yield eng
+    eng.dispose()
+
+
+def _seed_github_envelope(*, engine, tenant_id, principal_id, encryption, sync_ttl=300, lsa_offset_seconds=0):
+    """Seed a github profile with a pushed envelope."""
+    payload = json.dumps({"token": "ghp_test", "scopes": ["repo"]}).encode()
+    aad = (
+        str(tenant_id).encode()
+        + b"|" + str(principal_id).encode()
+        + b"|" + b"github-default"
+    )
+    dek = b"\x01" * 32
+    nonce, ct = AESGCMEnvelope().encrypt(dek, payload, aad=aad)
+    wrapped, kv = encryption.wrap_dek(dek, tenant_id=tenant_id, aad=aad)
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant_id)})
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, 'tx') ON CONFLICT DO NOTHING"),
+            {"id": str(tenant_id)},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO principals (id, tenant_id, kind) VALUES (:id, :t, 'human') "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {"id": str(principal_id), "t": str(tenant_id)},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO auth_profiles "
+                "(tenant_id, principal_id, id, provider, account_identifier, "
+                " backend, backend_key, last_synced_at, sync_ttl_seconds, "
+                " ciphertext, wrapped_dek, nonce, aad, kek_version) "
+                "VALUES (:t, :p, 'github-default', 'github', 'me', 'envelope', 'k', "
+                " NOW() - (:off || ' seconds')::INTERVAL, :ttl, :ct, :wd, :no, :aad, :kv)"
+            ),
+            {
+                "t": str(tenant_id),
+                "p": str(principal_id),
+                "off": str(lsa_offset_seconds),
+                "ttl": sync_ttl,
+                "ct": ct,
+                "wd": wrapped,
+                "no": nonce,
+                "aad": aad,
+                "kv": kv,
+            },
+        )
+
+
+def _make_consumer(engine, tenant_id, encryption=None, cache=None):
+    encryption = encryption or InMemoryEncryptionProvider()
+    cache = cache or ResolvedCredCache(ceiling_seconds=300)
+    store = PostgresAuthProfileStore(engine=engine, tenant_id=tenant_id)
+    return CredentialConsumer(
+        store=store,
+        encryption=encryption,
+        dek_cache=DEKCache(),
+        cred_cache=cache,
+        adapters={"github": GithubProviderAdapter()},
+        audit=ReadAuditWriter(engine=engine, hit_sample_rate=0.01),
+    )
+
+
+def _claims(tenant_id, principal_id):
+    return DaemonClaims(
+        tenant_id=tenant_id,
+        principal_id=principal_id,
+        machine_id=uuid.uuid4(),
+    )
+
+
+def test_resolve_happy_path_returns_materialized_cred(engine):
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
+    )
+    consumer = _make_consumer(engine, tenant, encryption=encryption)
+
+    out = consumer.resolve(
+        claims=_claims(tenant, principal),
+        provider="github",
+        purpose="list-repos",
+    )
+    assert out.access_token == "ghp_test"
+    assert out.metadata["scopes_csv"] == "repo"
+
+
+def test_resolve_warm_cache_skips_decrypt(engine):
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
+    )
+    consumer = _make_consumer(engine, tenant, encryption=encryption)
+
+    first = consumer.resolve(
+        claims=_claims(tenant, principal), provider="github", purpose="x"
+    )
+    # Drop the row so a second decrypt would fail
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(text("DELETE FROM auth_profiles WHERE tenant_id = :t"), {"t": str(tenant)})
+
+    second = consumer.resolve(
+        claims=_claims(tenant, principal), provider="github", purpose="x"
+    )
+    assert second is first  # cached, same object
+
+
+def test_resolve_force_refresh_bypasses_cache(engine):
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
+    )
+    consumer = _make_consumer(engine, tenant, encryption=encryption)
+
+    first = consumer.resolve(
+        claims=_claims(tenant, principal), provider="github", purpose="x"
+    )
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(text("DELETE FROM auth_profiles WHERE tenant_id = :t"), {"t": str(tenant)})
+
+    with pytest.raises(ProfileNotFoundForCaller):
+        consumer.resolve(
+            claims=_claims(tenant, principal),
+            provider="github",
+            purpose="x",
+            force_refresh=True,
+        )
+
+
+def test_resolve_raises_profile_not_found(engine):
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, 'tx') ON CONFLICT DO NOTHING"),
+            {"id": str(tenant)},
+        )
+    consumer = _make_consumer(engine, tenant)
+
+    with pytest.raises(ProfileNotFoundForCaller):
+        consumer.resolve(
+            claims=_claims(tenant, principal), provider="github", purpose="x"
+        )
+
+
+def test_resolve_raises_provider_not_configured(engine):
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    consumer = _make_consumer(engine, tenant)
+    with pytest.raises(ProviderNotConfigured):
+        consumer.resolve(
+            claims=_claims(tenant, principal),
+            provider="unknown",
+            purpose="x",
+        )
+
+
+def test_resolve_raises_stale_source_when_last_synced_past_ttl(engine):
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    _seed_github_envelope(
+        engine=engine,
+        tenant_id=tenant,
+        principal_id=principal,
+        encryption=encryption,
+        sync_ttl=60,
+        lsa_offset_seconds=120,  # 2 minutes ago, TTL is 60s → stale
+    )
+    consumer = _make_consumer(engine, tenant, encryption=encryption)
+    with pytest.raises(StaleSource):
+        consumer.resolve(
+            claims=_claims(tenant, principal), provider="github", purpose="x"
+        )
+```
+
+- [ ] **Step 8.2: Run to verify failure**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_consumer.py -v`
+Expected: FAIL — `CredentialConsumer.resolve` undefined.
+
+- [ ] **Step 8.3: Replace the stub `CredentialConsumer` in `consumer.py`**
+
+In `src/nexus/bricks/auth/consumer.py`, REPLACE the `class CredentialConsumer:` stub from Task 3 with:
+
+```python
+class CredentialConsumer:
+    """Orchestrates: cache lookup → decrypt → materialize → cache write → audit.
+
+    All errors raised by this class are subclasses of ``ConsumerError`` and
+    carry no plaintext / token bytes in repr.
+    """
+
+    def __init__(
+        self,
+        *,
+        store: "PostgresAuthProfileStore",
+        encryption: "EncryptionProvider",
+        dek_cache: "DEKCache",
+        cred_cache: "ResolvedCredCache",
+        adapters: dict[str, "ProviderAdapter"],
+        audit: "ReadAuditWriter",
+    ) -> None:
+        self._store = store
+        self._encryption = encryption
+        self._dek_cache = dek_cache
+        self._cred_cache = cred_cache
+        self._adapters = adapters
+        self._audit = audit
+
+    def resolve(
+        self,
+        *,
+        claims: "DaemonClaims",
+        provider: str,
+        purpose: str,
+        force_refresh: bool = False,
+    ) -> MaterializedCredential:
+        from datetime import UTC, datetime  # local import to keep top clean
+
+        from nexus.bricks.auth.postgres_profile_store import ProfileNotFound
+
+        adapter = self._adapters.get(provider)
+        if adapter is None:
+            raise ProviderNotConfigured.from_row(
+                tenant_id=claims.tenant_id,
+                principal_id=claims.principal_id,
+                provider=provider,
+                cause="adapter_not_registered",
+            )
+
+        cache_key = (
+            str(claims.tenant_id),
+            str(claims.principal_id),
+            provider,
+        )
+        now = datetime.now(UTC)
+        cache_hit = False
+        kek_version = 0
+
+        if not force_refresh:
+            cached = self._cred_cache.get(cache_key, now=now)
+            if cached is not None:
+                cache_hit = True
+                # We don't know the original kek_version on a cache hit; use 0
+                # as a sentinel ("unknown — cache hit") in the audit row.
+                self._audit.write(
+                    tenant_id=claims.tenant_id,
+                    principal_id=claims.principal_id,
+                    auth_profile_id="cached",
+                    caller_machine_id=claims.machine_id,
+                    caller_kind="daemon",
+                    provider=provider,
+                    purpose=purpose,
+                    cache_hit=True,
+                    kek_version=0,
+                )
+                return cached
+
+        try:
+            decrypted = self._store.decrypt_profile(
+                principal_id=claims.principal_id,
+                provider=provider,
+                encryption=self._encryption,
+                dek_cache=self._dek_cache,
+            )
+        except ProfileNotFound as exc:
+            raise ProfileNotFoundForCaller.from_row(
+                tenant_id=claims.tenant_id,
+                principal_id=claims.principal_id,
+                provider=provider,
+                cause="no_envelope_row",
+            ) from exc
+
+        # Stale-source check: last_synced_at + sync_ttl must be in the future.
+        from datetime import timedelta
+
+        ttl_window = timedelta(seconds=decrypted.sync_ttl_seconds)
+        if decrypted.last_synced_at + ttl_window < now:
+            raise StaleSource.from_row(
+                tenant_id=claims.tenant_id,
+                principal_id=claims.principal_id,
+                provider=provider,
+                cause=f"last_synced_at_age={int((now - decrypted.last_synced_at).total_seconds())}s",
+            )
+
+        kek_version = decrypted.kek_version
+        try:
+            materialized = adapter.materialize(decrypted.plaintext)
+        except (ValueError, KeyError) as exc:
+            raise AdapterMaterializeFailed.from_row(
+                tenant_id=claims.tenant_id,
+                principal_id=claims.principal_id,
+                provider=provider,
+                cause=f"{type(exc).__name__}",
+            ) from exc
+
+        self._cred_cache.put(cache_key, materialized, now=now)
+        self._audit.write(
+            tenant_id=claims.tenant_id,
+            principal_id=claims.principal_id,
+            auth_profile_id=decrypted.profile_id,
+            caller_machine_id=claims.machine_id,
+            caller_kind="daemon",
+            provider=provider,
+            purpose=purpose,
+            cache_hit=False,
+            kek_version=kek_version,
+        )
+        return materialized
+```
+
+- [ ] **Step 8.4: Run tests**
+
+Run: `pytest src/nexus/bricks/auth/tests/test_consumer.py -v`
+Expected: 6 PASS.
+
+- [ ] **Step 8.5: Commit**
+
+```bash
+git add src/nexus/bricks/auth/consumer.py src/nexus/bricks/auth/tests/test_consumer.py
+git commit -m "feat(#3818): implement CredentialConsumer.resolve orchestrator"
+```
+
+---
+
+## Task 9: Prometheus metrics
+
+**Files:**
+- Create: `src/nexus/bricks/auth/consumer_metrics.py`
+- Modify: `src/nexus/bricks/auth/consumer.py` (call into metrics)
+
+- [ ] **Step 9.1: Create `consumer_metrics.py`**
+
+```python
+"""Prometheus metrics for the read path (#3818).
+
+Low-cardinality labels only:
+  - provider ∈ {aws, github}
+  - result ∈ {ok, stale, denied, invalid_token, envelope_error}
+  - cache ∈ {hit, miss}
+  - reason (cache evictions) ∈ {ttl, lru, expires_at}
+"""
+
+from __future__ import annotations
+
+from prometheus_client import Counter, Gauge, Histogram
+
+TOKEN_EXCHANGE_REQUESTS = Counter(
+    "nexus_token_exchange_requests_total",
+    "RFC 8693 token-exchange requests by outcome",
+    labelnames=("provider", "result"),
+)
+
+TOKEN_EXCHANGE_LATENCY = Histogram(
+    "nexus_token_exchange_latency_seconds",
+    "Latency of /v1/auth/token-exchange end-to-end",
+    labelnames=("provider", "cache"),
+)
+
+CONSUMER_CACHE_SIZE = Gauge(
+    "nexus_consumer_cache_size",
+    "Current entries in ResolvedCredCache",
+)
+
+CONSUMER_CACHE_EVICTIONS = Counter(
+    "nexus_consumer_cache_evictions_total",
+    "ResolvedCredCache evictions by reason",
+    labelnames=("reason",),
+)
+
+READ_AUDIT_WRITES = Counter(
+    "nexus_read_audit_writes_total",
+    "Auth-profile-read audit rows written",
+    labelnames=("cache",),
+)
+```
+
+- [ ] **Step 9.2: Wire metrics into `consumer.py` and `read_audit.py`**
+
+In `consumer.py`, add at the top:
+
+```python
+from nexus.bricks.auth.consumer_metrics import (
+    TOKEN_EXCHANGE_LATENCY,
+    TOKEN_EXCHANGE_REQUESTS,
+)
+```
+
+In `CredentialConsumer.resolve`, wrap the body in a Histogram timer and record outcomes. Replace the existing `def resolve(...)` body's outermost block with:
+
+```python
+        from datetime import UTC, datetime
+        import time
+
+        start = time.monotonic()
+        cache_label = "miss"
+        result_label = "ok"
+        try:
+            # ... [keep the existing resolve() body unchanged here] ...
+            # (where the body returns ``cached``, set cache_label="hit")
+            # (where the body returns ``materialized``, leave cache_label="miss")
+        except ProfileNotFoundForCaller:
+            result_label = "denied"
+            raise
+        except ProviderNotConfigured:
+            result_label = "denied"
+            raise
+        except StaleSource:
+            result_label = "stale"
+            raise
+        except AdapterMaterializeFailed:
+            result_label = "envelope_error"
+            raise
+        finally:
+            TOKEN_EXCHANGE_LATENCY.labels(
+                provider=provider, cache=cache_label
+            ).observe(time.monotonic() - start)
+            TOKEN_EXCHANGE_REQUESTS.labels(
+                provider=provider, result=result_label
+            ).inc()
+```
+
+(The existing return-cached path needs to set `cache_label = "hit"` before returning. Easiest: pull both return points into the try block and assign the label just before returning.)
+
+In `read_audit.py`, add at the top:
+
+```python
+from nexus.bricks.auth.consumer_metrics import READ_AUDIT_WRITES
+```
+
+In `ReadAuditWriter.write`, after the successful `INSERT` (before the `except`), add:
+
+```python
+            READ_AUDIT_WRITES.labels(cache="hit" if cache_hit else "miss").inc()
+```
+
+- [ ] **Step 9.3: Verify imports + smoke test**
+
+Run: `python -c "from nexus.bricks.auth.consumer_metrics import TOKEN_EXCHANGE_REQUESTS; TOKEN_EXCHANGE_REQUESTS.labels(provider='github', result='ok').inc(); print('OK')"`
+Expected: `OK`.
+
+Re-run the consumer tests: `pytest src/nexus/bricks/auth/tests/test_consumer.py -v` — should still pass (metrics are additive).
+
+- [ ] **Step 9.4: Commit**
+
+```bash
+git add src/nexus/bricks/auth/consumer_metrics.py src/nexus/bricks/auth/consumer.py src/nexus/bricks/auth/read_audit.py
+git commit -m "feat(#3818): add Prometheus metrics for read path"
+```
+
+---
+
+## Task 10: Rewrite `/v1/auth/token-exchange` router
+
+**Files:**
+- Modify: `src/nexus/server/api/v1/routers/token_exchange.py` (full rewrite)
+- Modify: `src/nexus/server/api/v1/tests/test_token_exchange_router.py` (full rewrite)
+
+- [ ] **Step 10.1: Write the failing test**
+
+Replace the entire contents of `src/nexus/server/api/v1/tests/test_token_exchange_router.py` with:
+
+```python
+"""Tests for /v1/auth/token-exchange router (#3818)."""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import timedelta
+from unittest.mock import MagicMock
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+
+from nexus.bricks.auth.consumer import CredentialConsumer
+from nexus.bricks.auth.consumer_cache import ResolvedCredCache
+from nexus.bricks.auth.consumer_providers.aws import AwsProviderAdapter
+from nexus.bricks.auth.consumer_providers.github import GithubProviderAdapter
+from nexus.bricks.auth.envelope import AESGCMEnvelope, DEKCache
+from nexus.bricks.auth.envelope_providers.in_memory import InMemoryEncryptionProvider
+from nexus.bricks.auth.postgres_profile_store import (
+    PostgresAuthProfileStore,
+    ensure_schema,
+)
+from nexus.bricks.auth.read_audit import ReadAuditWriter
+from nexus.server.api.v1.jwt_signer import DaemonClaims, JwtSigner
+from nexus.server.api.v1.routers.token_exchange import make_token_exchange_router
+
+
+def _make_signer():
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives import serialization
+
+    pk = ec.generate_private_key(ec.SECP256R1())
+    pem = pk.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return JwtSigner.from_pem(pem, issuer="https://test.local")
+
+
+@pytest.fixture
+def engine():
+    url = os.environ.get("NEXUS_TEST_DATABASE_URL")
+    if not url:
+        pytest.skip("NEXUS_TEST_DATABASE_URL not set")
+    eng = create_engine(url, future=True)
+    ensure_schema(eng)
+    yield eng
+    eng.dispose()
+
+
+def _build_app(engine, tenant_id):
+    encryption = InMemoryEncryptionProvider()
+    signer = _make_signer()
+    consumer = CredentialConsumer(
+        store=PostgresAuthProfileStore(engine=engine, tenant_id=tenant_id),
+        encryption=encryption,
+        dek_cache=DEKCache(),
+        cred_cache=ResolvedCredCache(),
+        adapters={
+            "aws": AwsProviderAdapter(),
+            "github": GithubProviderAdapter(),
+        },
+        audit=ReadAuditWriter(engine=engine, hit_sample_rate=0.01),
+    )
+    app = FastAPI()
+    app.include_router(
+        make_token_exchange_router(
+            enabled=True, signer=signer, consumer=consumer, encryption=encryption,
+        )
+    )
+    return app, signer, encryption
+
+
+def _seed_github(engine, tenant, principal, encryption):
+    payload = json.dumps({"token": "ghp_real", "scopes": ["repo"]}).encode()
+    aad = (
+        str(tenant).encode() + b"|" + str(principal).encode() + b"|" + b"github-default"
+    )
+    dek = b"\x02" * 32
+    nonce, ct = AESGCMEnvelope().encrypt(dek, payload, aad=aad)
+    wrapped, kv = encryption.wrap_dek(dek, tenant_id=tenant, aad=aad)
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, 'tx') ON CONFLICT DO NOTHING"),
+            {"id": str(tenant)},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO principals (id, tenant_id, kind) VALUES (:id, :t, 'human') "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {"id": str(principal), "t": str(tenant)},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO auth_profiles "
+                "(tenant_id, principal_id, id, provider, account_identifier, "
+                " backend, backend_key, last_synced_at, sync_ttl_seconds, "
+                " ciphertext, wrapped_dek, nonce, aad, kek_version) "
+                "VALUES (:t, :p, 'github-default', 'github', 'me', 'envelope', 'k', "
+                " NOW(), 300, :ct, :wd, :no, :aad, :kv)"
+            ),
+            {
+                "t": str(tenant), "p": str(principal),
+                "ct": ct, "wd": wrapped, "no": nonce, "aad": aad, "kv": kv,
+            },
+        )
+
+
+def test_token_exchange_happy_path_returns_200_with_bearer(engine):
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    machine = uuid.uuid4()
+    app, signer, encryption = _build_app(engine, tenant)
+    _seed_github(engine, tenant, principal, encryption)
+    jwt = signer.sign(
+        DaemonClaims(tenant_id=tenant, principal_id=principal, machine_id=machine),
+        ttl=timedelta(hours=1),
+    )
+
+    client = TestClient(app)
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": jwt,
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "resource": "urn:nexus:provider:github",
+            "scope": "list-repos",
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["access_token"] == "ghp_real"
+    assert body["token_type"] == "Bearer"
+    assert body["issued_token_type"] == "urn:ietf:params:oauth:token-type:access_token"
+    assert "nexus_credential_metadata" in body
+    assert body["nexus_credential_metadata"]["scopes_csv"] == "repo"
+
+
+def test_token_exchange_invalid_jwt_returns_401(engine):
+    tenant = uuid.uuid4()
+    app, _, _ = _build_app(engine, tenant)
+    client = TestClient(app)
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": "garbage",
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "resource": "urn:nexus:provider:github",
+            "scope": "x",
+        },
+    )
+    assert r.status_code == 401
+    assert r.json()["error"] == "invalid_token"
+
+
+def test_token_exchange_unknown_resource_returns_400(engine):
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    app, signer, _ = _build_app(engine, tenant)
+    jwt = signer.sign(
+        DaemonClaims(tenant_id=tenant, principal_id=principal, machine_id=uuid.uuid4()),
+        ttl=timedelta(hours=1),
+    )
+    client = TestClient(app)
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": jwt,
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "resource": "urn:nexus:provider:slack",  # unknown
+            "scope": "x",
+        },
+    )
+    assert r.status_code == 400
+    assert r.json()["error"] == "invalid_request"
+
+
+def test_token_exchange_no_profile_returns_403(engine):
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    app, signer, _ = _build_app(engine, tenant)
+    # Seed tenant + principal but no profile
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, 'tx') ON CONFLICT DO NOTHING"),
+            {"id": str(tenant)},
+        )
+    jwt = signer.sign(
+        DaemonClaims(tenant_id=tenant, principal_id=principal, machine_id=uuid.uuid4()),
+        ttl=timedelta(hours=1),
+    )
+    client = TestClient(app)
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": jwt,
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "resource": "urn:nexus:provider:github",
+            "scope": "x",
+        },
+    )
+    assert r.status_code == 403
+    assert r.json()["error"] == "access_denied"
+
+
+def test_token_exchange_disabled_returns_501(engine):
+    tenant = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    signer = _make_signer()
+    consumer = CredentialConsumer(
+        store=PostgresAuthProfileStore(engine=engine, tenant_id=tenant),
+        encryption=encryption,
+        dek_cache=DEKCache(),
+        cred_cache=ResolvedCredCache(),
+        adapters={"github": GithubProviderAdapter()},
+        audit=ReadAuditWriter(engine=engine),
+    )
+    app = FastAPI()
+    app.include_router(
+        make_token_exchange_router(
+            enabled=False, signer=signer, consumer=consumer, encryption=encryption,
+        )
+    )
+    client = TestClient(app)
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": "x", "subject_token_type": "x",
+            "resource": "urn:nexus:provider:github", "scope": "x",
+        },
+    )
+    assert r.status_code == 501
+```
+
+- [ ] **Step 10.2: Run to verify failure**
+
+Run: `pytest src/nexus/server/api/v1/tests/test_token_exchange_router.py -v`
+Expected: FAIL — `make_token_exchange_router` signature mismatch.
+
+- [ ] **Step 10.3: Replace `token_exchange.py`**
+
+Replace the entire contents of `src/nexus/server/api/v1/routers/token_exchange.py` with:
+
+```python
+"""FastAPI router: POST /v1/auth/token-exchange (RFC 8693, #3818).
+
+Verifies the daemon's JWT (subject_token), looks up the matching envelope row
+via CredentialConsumer, and returns a provider-native bearer token. Errors
+follow RFC 6749 §5.2 shape: ``{"error": "...", "error_description": "..."}``.
+
+When ``enabled=False`` (default until ops verifies KMS/Vault wiring) the route
+returns 501 regardless of the request — the consumer/signer args are still
+required so tests and dev wiring stay symmetric.
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, Form, HTTPException, status
+from fastapi.responses import JSONResponse
+
+from nexus.bricks.auth.consumer import (
+    AdapterMaterializeFailed,
+    CredentialConsumer,
+    ProfileNotFoundForCaller,
+    ProviderNotConfigured,
+    StaleSource,
+)
+from nexus.bricks.auth.envelope import EncryptionProvider, EnvelopeError
+from nexus.server.api.v1.jwt_signer import JwtSigner, JwtVerifyError
+
+logger = logging.getLogger(__name__)
+
+_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
+_SUBJECT_TYPE_JWT = "urn:ietf:params:oauth:token-type:jwt"
+_ISSUED_TYPE = "urn:ietf:params:oauth:token-type:access_token"
+
+_RESOURCE_TO_PROVIDER = {
+    "urn:nexus:provider:aws": "aws",
+    "urn:nexus:provider:github": "github",
+}
+
+
+def _err(http_status: int, code: str, description: str) -> JSONResponse:
+    return JSONResponse(
+        status_code=http_status,
+        content={"error": code, "error_description": description},
+    )
+
+
+def make_token_exchange_router(
+    *,
+    enabled: bool,
+    signer: JwtSigner,
+    consumer: CredentialConsumer,
+    encryption: EncryptionProvider,  # for symmetry — not used directly here
+) -> APIRouter:
+    """Build the ``/v1/auth/token-exchange`` router.
+
+    When ``enabled=False`` the route returns 501 — gives ops a single env-var
+    flag to flip the read path on/off without redeploying.
+    """
+    del encryption  # Reserved for future direct-decrypt fallbacks; unused for now.
+    router = APIRouter(prefix="/v1/auth", tags=["auth"])
+
+    @router.post("/token-exchange")
+    def exchange(
+        grant_type: str = Form(...),
+        subject_token: str = Form(...),
+        subject_token_type: str = Form(...),
+        resource: str = Form(...),
+        scope: str = Form(...),
+        audience: str | None = Form(None),
+        nexus_force_refresh: str = Form("false"),
+    ) -> Any:
+        if not enabled:
+            return _err(
+                status.HTTP_501_NOT_IMPLEMENTED,
+                "not_implemented",
+                "token-exchange disabled (NEXUS_TOKEN_EXCHANGE_ENABLED=0)",
+            )
+
+        del audience  # MVP ignores audience field (always bound by JWT verify).
+
+        if grant_type != _GRANT_TYPE:
+            return _err(400, "invalid_request", f"unknown grant_type: {grant_type!r}")
+        if subject_token_type != _SUBJECT_TYPE_JWT:
+            return _err(
+                400, "invalid_request",
+                f"unsupported subject_token_type: {subject_token_type!r}"
+            )
+        provider = _RESOURCE_TO_PROVIDER.get(resource)
+        if provider is None:
+            return _err(400, "invalid_request", f"unknown resource: {resource!r}")
+
+        try:
+            claims = signer.verify(subject_token)
+        except JwtVerifyError as exc:
+            return _err(401, "invalid_token", str(exc))
+
+        force_refresh = nexus_force_refresh.lower() in ("1", "true", "yes")
+
+        try:
+            cred = consumer.resolve(
+                claims=claims,
+                provider=provider,
+                purpose=scope,
+                force_refresh=force_refresh,
+            )
+        except (ProfileNotFoundForCaller, ProviderNotConfigured) as exc:
+            return _err(403, "access_denied", exc.cause or "")
+        except StaleSource as exc:
+            return _err(409, "stale_source", exc.cause or "")
+        except (AdapterMaterializeFailed, EnvelopeError) as exc:
+            logger.warning("envelope_error: %r", exc)  # __repr__ masks plaintext
+            return _err(500, "envelope_error", "see server logs")
+
+        expires_in = 0
+        if cred.expires_at is not None:
+            expires_in = max(0, int((cred.expires_at - datetime.now(UTC)).total_seconds()))
+
+        return {
+            "access_token": cred.access_token,
+            "issued_token_type": _ISSUED_TYPE,
+            "token_type": "Bearer",
+            "expires_in": expires_in,
+            "nexus_credential_metadata": cred.metadata,
+        }
+
+    return router
+```
+
+- [ ] **Step 10.4: Run tests**
+
+Run: `pytest src/nexus/server/api/v1/tests/test_token_exchange_router.py -v`
+Expected: 5 PASS.
+
+- [ ] **Step 10.5: Commit**
+
+```bash
+git add src/nexus/server/api/v1/routers/token_exchange.py src/nexus/server/api/v1/tests/test_token_exchange_router.py
+git commit -m "feat(#3818): rewrite /v1/auth/token-exchange — RFC 8693 read path"
+```
+
+---
+
+## Task 11: Wire consumer + new router signature into `fastapi_server.py`
+
+**Files:**
+- Modify: `src/nexus/server/fastapi_server.py` (token-exchange wiring block, around lines 992-1006)
+
+- [ ] **Step 11.1: Read the existing wiring block**
+
+Re-read `src/nexus/server/fastapi_server.py` lines 992-1075 to confirm the surrounding context (daemon router setup happens immediately after; we want token-exchange to share `_v1_engine`, `_v1_signer`).
+
+- [ ] **Step 11.2: Move the token-exchange include INSIDE the `if _v1_signer is not None` block**
+
+Locate the existing `make_token_exchange_router(enabled=_token_exchange_enabled)` call (line ~1003) and DELETE that block (lines ~992-1006). The new wiring goes inside the `if _v1_signer is not None:` block right after the `make_jwks_router` line.
+
+Add this block immediately after `app.include_router(make_jwks_router(signer=_v1_signer))` (line ~1072):
+
+```python
+                    # Token-exchange: read path requires the same engine + signer
+                    # as the daemon router, plus an EncryptionProvider for envelope
+                    # decrypt. Default off (NEXUS_TOKEN_EXCHANGE_ENABLED) until ops
+                    # verifies KMS/Vault wiring.
+                    try:
+                        from nexus.bricks.auth.consumer import CredentialConsumer
+                        from nexus.bricks.auth.consumer_cache import ResolvedCredCache
+                        from nexus.bricks.auth.consumer_providers import (
+                            default_adapters,
+                        )
+                        from nexus.bricks.auth.envelope import DEKCache
+                        from nexus.bricks.auth.envelope_providers.in_memory import (
+                            InMemoryEncryptionProvider,
+                        )
+                        from nexus.bricks.auth.postgres_profile_store import (
+                            PostgresAuthProfileStore,
+                        )
+                        from nexus.bricks.auth.read_audit import ReadAuditWriter
+                        from nexus.server.api.v1.routers.token_exchange import (
+                            make_token_exchange_router,
+                        )
+                    except ImportError as e:
+                        logger.warning(
+                            "v1 token-exchange disabled: import failed (%s)", e
+                        )
+                    else:
+                        _token_exchange_enabled = (
+                            os.environ.get("NEXUS_TOKEN_EXCHANGE_ENABLED", "")
+                            .lower() in ("1", "true", "yes")
+                        )
+                        # MVP: InMemoryEncryptionProvider unless an operator has
+                        # already wired Vault/KMS via app.state. Production
+                        # deployments override this in their startup hook.
+                        _enc = getattr(app.state, "encryption_provider", None) or (
+                            InMemoryEncryptionProvider()
+                        )
+                        # Tenant-id stamping happens per-request inside
+                        # PostgresAuthProfileStore via SET LOCAL; the singleton
+                        # used here gets re-tenanted by the consumer per call.
+                        # If the existing store API does not support per-call
+                        # tenant rebinding, instantiate the store inside the
+                        # consumer's resolve() instead — adjust to whichever
+                        # pattern auth_profiles.py / daemon.py already uses.
+                        _store = PostgresAuthProfileStore(
+                            engine=_v1_engine,
+                            tenant_id=None,  # set per request in consumer
+                        )
+                        _consumer = CredentialConsumer(
+                            store=_store,
+                            encryption=_enc,
+                            dek_cache=DEKCache(),
+                            cred_cache=ResolvedCredCache(),
+                            adapters=default_adapters(),
+                            audit=ReadAuditWriter(engine=_v1_engine),
+                        )
+                        app.include_router(
+                            make_token_exchange_router(
+                                enabled=_token_exchange_enabled,
+                                signer=_v1_signer,
+                                consumer=_consumer,
+                                encryption=_enc,
+                            )
+                        )
+                        logger.info(
+                            "v1 token-exchange route registered (enabled=%s)",
+                            _token_exchange_enabled,
+                        )
+```
+
+**Note on `tenant_id=None` and per-request rebinding:** PR 3 (`make_auth_profiles_router(engine=_v1_engine, signer=_v1_signer)`) shows the existing pattern reads tenant from the verified JWT and sets RLS per request. Read `src/nexus/server/api/v1/routers/auth_profiles.py` to copy how it instantiates `PostgresAuthProfileStore` per request, then mirror that pattern in `token_exchange.py` and `consumer.py` if needed. If the existing `PostgresAuthProfileStore.__init__` requires a non-None `tenant_id`, the cleanest fix is to construct the store inside `CredentialConsumer.resolve` using `claims.tenant_id` — defer this construction by passing the engine to the consumer instead of the store.
+
+- [ ] **Step 11.3: Adapt store construction if necessary**
+
+If Step 11.2's `tenant_id=None` doesn't work, modify `CredentialConsumer.__init__` to accept `engine: Engine` instead of `store`, and construct `PostgresAuthProfileStore(engine=engine, tenant_id=claims.tenant_id)` at the top of every `resolve()` call. Update `test_consumer.py` accordingly.
+
+- [ ] **Step 11.4: Smoke test the import chain**
+
+Run: `python -c "from nexus.server.fastapi_server import create_app; print('imports OK')"`
+Expected: `imports OK` (no ImportError, no startup error from the new wiring path — it's all lazy under the `if _v1_signer is not None` guard).
+
+- [ ] **Step 11.5: Run all auth tests**
+
+Run: `pytest src/nexus/bricks/auth/tests/ src/nexus/server/api/v1/tests/ -v --tb=short`
+Expected: all PASS (Postgres-gated tests skip cleanly when `NEXUS_TEST_DATABASE_URL` is unset).
+
+- [ ] **Step 11.6: Commit**
+
+```bash
+git add src/nexus/server/fastapi_server.py src/nexus/bricks/auth/consumer.py src/nexus/bricks/auth/tests/test_consumer.py
+git commit -m "feat(#3818): wire CredentialConsumer + token-exchange router into create_app"
+```
+
+---
+
+## Task 12: E2E test — AWS via LocalStack
+
+**Files:**
+- Create: `tests/e2e/auth_consumption/__init__.py` (empty)
+- Create: `tests/e2e/auth_consumption/test_s3_as_user.py`
+
+- [ ] **Step 12.1: Create the empty `__init__.py`**
+
+```bash
+touch tests/e2e/auth_consumption/__init__.py
+```
+
+- [ ] **Step 12.2: Write the e2e test**
+
+```python
+"""E2E: daemon push → /v1/auth/token-exchange → real S3 list-buckets (#3818).
+
+PR-CI variant: uses LocalStack S3 (deterministic, no live AWS).
+Nightly variant: set NEXUS_TEST_AWS_LIVE=1 to exercise live STS + S3.
+
+Requires:
+  - NEXUS_TEST_DATABASE_URL (Postgres)
+  - LOCALSTACK_ENDPOINT (e.g. http://localhost:4566) — falls back to skip
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+
+from nexus.bricks.auth.consumer import CredentialConsumer
+from nexus.bricks.auth.consumer_cache import ResolvedCredCache
+from nexus.bricks.auth.consumer_providers.aws import AwsProviderAdapter
+from nexus.bricks.auth.envelope import AESGCMEnvelope, DEKCache
+from nexus.bricks.auth.envelope_providers.in_memory import InMemoryEncryptionProvider
+from nexus.bricks.auth.postgres_profile_store import (
+    PostgresAuthProfileStore,
+    ensure_schema,
+)
+from nexus.bricks.auth.read_audit import ReadAuditWriter
+from nexus.server.api.v1.jwt_signer import DaemonClaims, JwtSigner
+from nexus.server.api.v1.routers.token_exchange import make_token_exchange_router
+
+
+def _maybe_skip():
+    if not os.environ.get("NEXUS_TEST_DATABASE_URL"):
+        pytest.skip("NEXUS_TEST_DATABASE_URL not set")
+    if not (os.environ.get("LOCALSTACK_ENDPOINT") or os.environ.get("NEXUS_TEST_AWS_LIVE")):
+        pytest.skip("LOCALSTACK_ENDPOINT or NEXUS_TEST_AWS_LIVE required")
+
+
+def _make_signer():
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives import serialization
+    pk = ec.generate_private_key(ec.SECP256R1())
+    return JwtSigner.from_pem(
+        pk.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ),
+        issuer="https://e2e.local",
+    )
+
+
+def test_s3_list_buckets_as_user_via_token_exchange():
+    _maybe_skip()
+    import boto3
+
+    endpoint = os.environ.get("LOCALSTACK_ENDPOINT")
+    using_live = os.environ.get("NEXUS_TEST_AWS_LIVE") == "1"
+
+    # 1. Provision creds — for LocalStack the canonical "test" creds work.
+    if using_live:
+        # User / CI must export AWS creds for the sandbox account.
+        aws_creds = {
+            "access_key_id": os.environ["AWS_ACCESS_KEY_ID"],
+            "secret_access_key": os.environ["AWS_SECRET_ACCESS_KEY"],
+            "session_token": os.environ.get("AWS_SESSION_TOKEN", ""),
+            "expiration": (datetime.now(UTC) + timedelta(hours=1)).isoformat(),
+            "region": os.environ.get("AWS_REGION", "us-east-1"),
+        }
+    else:
+        aws_creds = {
+            "access_key_id": "test",
+            "secret_access_key": "test",
+            "session_token": "test",
+            "expiration": (datetime.now(UTC) + timedelta(hours=1)).isoformat(),
+            "region": "us-east-1",
+        }
+
+    # 2. Set up DB + envelope + app stack.
+    engine = create_engine(os.environ["NEXUS_TEST_DATABASE_URL"], future=True)
+    ensure_schema(engine)
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    machine = uuid.uuid4()
+
+    encryption = InMemoryEncryptionProvider()
+    payload = json.dumps(aws_creds).encode()
+    aad = (
+        str(tenant).encode() + b"|" + str(principal).encode() + b"|" + b"aws-default"
+    )
+    dek = b"\x09" * 32
+    nonce, ct = AESGCMEnvelope().encrypt(dek, payload, aad=aad)
+    wrapped, kv = encryption.wrap_dek(dek, tenant_id=tenant, aad=aad)
+
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, 'e2e') ON CONFLICT DO NOTHING"),
+            {"id": str(tenant)},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO principals (id, tenant_id, kind) VALUES (:id, :t, 'human') "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {"id": str(principal), "t": str(tenant)},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO auth_profiles "
+                "(tenant_id, principal_id, id, provider, account_identifier, "
+                " backend, backend_key, last_synced_at, sync_ttl_seconds, "
+                " ciphertext, wrapped_dek, nonce, aad, kek_version) "
+                "VALUES (:t, :p, 'aws-default', 'aws', 'me', 'envelope', 'k', "
+                " NOW(), 300, :ct, :wd, :no, :aad, :kv)"
+            ),
+            {
+                "t": str(tenant), "p": str(principal),
+                "ct": ct, "wd": wrapped, "no": nonce, "aad": aad, "kv": kv,
+            },
+        )
+
+    signer = _make_signer()
+    consumer = CredentialConsumer(
+        store=PostgresAuthProfileStore(engine=engine, tenant_id=tenant),
+        encryption=encryption,
+        dek_cache=DEKCache(),
+        cred_cache=ResolvedCredCache(),
+        adapters={"aws": AwsProviderAdapter()},
+        audit=ReadAuditWriter(engine=engine),
+    )
+    app = FastAPI()
+    app.include_router(
+        make_token_exchange_router(
+            enabled=True, signer=signer, consumer=consumer, encryption=encryption,
+        )
+    )
+
+    # 3. Call token-exchange.
+    jwt = signer.sign(
+        DaemonClaims(tenant_id=tenant, principal_id=principal, machine_id=machine),
+        ttl=timedelta(hours=1),
+    )
+    client = TestClient(app)
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": jwt,
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "resource": "urn:nexus:provider:aws",
+            "scope": "list-buckets",
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    meta = body["nexus_credential_metadata"]
+
+    # 4. Build a real boto3 session and call S3.
+    s3_kwargs = dict(
+        aws_access_key_id=meta["access_key_id"],
+        aws_secret_access_key=meta["secret_access_key"],
+        aws_session_token=body["access_token"],
+        region_name=meta["region"],
+    )
+    if endpoint:
+        s3_kwargs["endpoint_url"] = endpoint
+
+    s3 = boto3.client("s3", **s3_kwargs)
+    # In LocalStack: empty bucket list is fine — the call succeeding is the win.
+    resp = s3.list_buckets()
+    assert "Buckets" in resp
+
+    engine.dispose()
+```
+
+- [ ] **Step 12.3: Run when env is set**
+
+```bash
+LOCALSTACK_ENDPOINT=http://localhost:4566 \
+NEXUS_TEST_DATABASE_URL=postgresql://nexus@localhost/nexus_test \
+pytest tests/e2e/auth_consumption/test_s3_as_user.py -v
+```
+
+Expected: PASS when both env vars set; SKIP otherwise.
+
+- [ ] **Step 12.4: Commit**
+
+```bash
+git add tests/e2e/auth_consumption/__init__.py tests/e2e/auth_consumption/test_s3_as_user.py
+git commit -m "test(#3818): e2e — daemon-push → token-exchange → S3 list-buckets via LocalStack"
+```
+
+---
+
+## Task 13: E2E test — GitHub via real PAT
+
+**Files:**
+- Create: `tests/e2e/auth_consumption/test_github_as_user.py`
+
+- [ ] **Step 13.1: Write the e2e test**
+
+```python
+"""E2E: daemon push → /v1/auth/token-exchange → real GitHub /user (#3818).
+
+Requires:
+  - NEXUS_TEST_DATABASE_URL (Postgres)
+  - NEXUS_TEST_GITHUB_PAT (a real PAT with read:user) — falls back to skip.
+
+The PAT is the "daemon-pushed" credential. We push it, exchange it, and
+prove the returned token authenticates against GitHub's /user endpoint.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import timedelta
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+
+from nexus.bricks.auth.consumer import CredentialConsumer
+from nexus.bricks.auth.consumer_cache import ResolvedCredCache
+from nexus.bricks.auth.consumer_providers.github import GithubProviderAdapter
+from nexus.bricks.auth.envelope import AESGCMEnvelope, DEKCache
+from nexus.bricks.auth.envelope_providers.in_memory import InMemoryEncryptionProvider
+from nexus.bricks.auth.postgres_profile_store import (
+    PostgresAuthProfileStore,
+    ensure_schema,
+)
+from nexus.bricks.auth.read_audit import ReadAuditWriter
+from nexus.server.api.v1.jwt_signer import DaemonClaims, JwtSigner
+from nexus.server.api.v1.routers.token_exchange import make_token_exchange_router
+
+
+def _maybe_skip():
+    if not os.environ.get("NEXUS_TEST_DATABASE_URL"):
+        pytest.skip("NEXUS_TEST_DATABASE_URL not set")
+    if not os.environ.get("NEXUS_TEST_GITHUB_PAT"):
+        pytest.skip("NEXUS_TEST_GITHUB_PAT not set")
+
+
+def _make_signer():
+    from cryptography.hazmat.primitives.asymmetric import ec
+    from cryptography.hazmat.primitives import serialization
+    pk = ec.generate_private_key(ec.SECP256R1())
+    return JwtSigner.from_pem(
+        pk.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ),
+        issuer="https://e2e.local",
+    )
+
+
+def test_github_user_endpoint_as_user_via_token_exchange():
+    _maybe_skip()
+
+    pat = os.environ["NEXUS_TEST_GITHUB_PAT"]
+    engine = create_engine(os.environ["NEXUS_TEST_DATABASE_URL"], future=True)
+    ensure_schema(engine)
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    machine = uuid.uuid4()
+
+    encryption = InMemoryEncryptionProvider()
+    payload = json.dumps(
+        {"token": pat, "scopes": ["read:user"], "token_type": "classic"}
+    ).encode()
+    aad = (
+        str(tenant).encode() + b"|" + str(principal).encode() + b"|" + b"github-default"
+    )
+    dek = b"\x0a" * 32
+    nonce, ct = AESGCMEnvelope().encrypt(dek, payload, aad=aad)
+    wrapped, kv = encryption.wrap_dek(dek, tenant_id=tenant, aad=aad)
+
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, 'e2e') ON CONFLICT DO NOTHING"),
+            {"id": str(tenant)},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO principals (id, tenant_id, kind) VALUES (:id, :t, 'human') "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {"id": str(principal), "t": str(tenant)},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO auth_profiles "
+                "(tenant_id, principal_id, id, provider, account_identifier, "
+                " backend, backend_key, last_synced_at, sync_ttl_seconds, "
+                " ciphertext, wrapped_dek, nonce, aad, kek_version) "
+                "VALUES (:t, :p, 'github-default', 'github', 'me', 'envelope', 'k', "
+                " NOW(), 300, :ct, :wd, :no, :aad, :kv)"
+            ),
+            {
+                "t": str(tenant), "p": str(principal),
+                "ct": ct, "wd": wrapped, "no": nonce, "aad": aad, "kv": kv,
+            },
+        )
+
+    signer = _make_signer()
+    consumer = CredentialConsumer(
+        store=PostgresAuthProfileStore(engine=engine, tenant_id=tenant),
+        encryption=encryption,
+        dek_cache=DEKCache(),
+        cred_cache=ResolvedCredCache(),
+        adapters={"github": GithubProviderAdapter()},
+        audit=ReadAuditWriter(engine=engine),
+    )
+    app = FastAPI()
+    app.include_router(
+        make_token_exchange_router(
+            enabled=True, signer=signer, consumer=consumer, encryption=encryption,
+        )
+    )
+
+    jwt = signer.sign(
+        DaemonClaims(tenant_id=tenant, principal_id=principal, machine_id=machine),
+        ttl=timedelta(hours=1),
+    )
+    client = TestClient(app)
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": jwt,
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "resource": "urn:nexus:provider:github",
+            "scope": "get-user",
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    bearer = body["access_token"]
+
+    # Real GitHub call.
+    gh = httpx.get(
+        "https://api.github.com/user",
+        headers={"Authorization": f"Bearer {bearer}", "User-Agent": "nexus-e2e"},
+        timeout=10.0,
+    )
+    assert gh.status_code == 200, gh.text
+    assert "login" in gh.json()
+
+    engine.dispose()
+```
+
+- [ ] **Step 13.2: Run when env is set**
+
+```bash
+NEXUS_TEST_GITHUB_PAT=ghp_yourtoken \
+NEXUS_TEST_DATABASE_URL=postgresql://nexus@localhost/nexus_test \
+pytest tests/e2e/auth_consumption/test_github_as_user.py -v
+```
+
+Expected: PASS when env set; SKIP otherwise.
+
+- [ ] **Step 13.3: Commit**
+
+```bash
+git add tests/e2e/auth_consumption/test_github_as_user.py
+git commit -m "test(#3818): e2e — daemon-push → token-exchange → GitHub /user via real PAT"
+```
+
+---
+
+## Task 14: Documentation updates
+
+**Files:**
+- Modify: existing deploy guide for envelope encryption (`docs/guides/auth-envelope-encryption.md`) — add a new section on token-exchange wiring
+- (Or, if cleaner) Create: `docs/guides/auth-token-exchange.md`
+
+- [ ] **Step 14.1: Decide which doc to extend**
+
+Read `docs/guides/auth-envelope-encryption.md`. If it has a clean "Operator runbook" structure with one section per env-var, append a sibling section. If it's narrative, create the new file `docs/guides/auth-token-exchange.md`.
+
+- [ ] **Step 14.2: Write the operator-facing content**
+
+Cover:
+1. **Env vars to set:**
+   - `NEXUS_TOKEN_EXCHANGE_ENABLED=1` (default off)
+   - Confirms `NEXUS_JWT_SIGNING_KEY` and `NEXUS_ENROLL_TOKEN_SECRET` already set (from PR 3)
+   - KMS/Vault: how to swap `InMemoryEncryptionProvider` for `VaultTransitProvider` or `AwsKmsProvider` via `app.state.encryption_provider`
+
+2. **What it does:** one paragraph linking to the spec.
+
+3. **Audit / SOC 2:** point to `auth_profile_reads` table; document the 100%/1% sampling rule and how to query it (sample SQL).
+
+4. **`purpose` field warning:** callers MUST NOT include credentials/PII; truncated at 256 chars.
+
+5. **`mlockall(MCL_FUTURE)` recommendation** for production.
+
+6. **Provider scope:** AWS + GitHub only; Gmail/gcloud follow-ups.
+
+- [ ] **Step 14.3: Commit**
+
+```bash
+git add docs/guides/auth-token-exchange.md  # or auth-envelope-encryption.md if extended
+git commit -m "docs(#3818): operator guide for /v1/auth/token-exchange"
+```
+
+---
+
+## Task 15: Final verification + PR prep
+
+- [ ] **Step 15.1: Run the full auth test suite**
+
+Run: `pytest src/nexus/bricks/auth/ src/nexus/server/api/v1/ -v --tb=short`
+Expected: all PASS (Postgres + provider tests skip cleanly when their envs are unset; everything else passes).
+
+- [ ] **Step 15.2: Run mypy / ruff if the project uses them**
+
+Run: `pre-commit run --all-files` (or whichever lint command the repo uses — check `.pre-commit-config.yaml`).
+Expected: no errors on changed files.
+
+- [ ] **Step 15.3: Manual smoke against a running server**
+
+```bash
+# Terminal 1: bring up a Postgres-backed Nexus stack with token-exchange enabled
+NEXUS_AUTH_STORE=postgres \
+NEXUS_TOKEN_EXCHANGE_ENABLED=1 \
+NEXUS_JWT_SIGNING_KEY=$HOME/.nexus/dev_jwt.pem \
+NEXUS_ENROLL_TOKEN_SECRET=$(openssl rand -hex 32) \
+nexus serve
+
+# Terminal 2: enroll daemon, push a fake github profile, then exchange
+nexus daemon join --enroll-token <minted-token>
+# (push happens automatically; or seed via direct DB insert)
+curl -X POST http://localhost:8000/v1/auth/token-exchange \
+  -d "grant_type=urn:ietf:params:oauth:grant-type:token-exchange" \
+  -d "subject_token=$(cat ~/.nexus/daemons/default/jwt)" \
+  -d "subject_token_type=urn:ietf:params:oauth:token-type:jwt" \
+  -d "resource=urn:nexus:provider:github" \
+  -d "scope=manual-smoke"
+# Expect: 200 + JSON body containing access_token
+```
+
+If running this manually is impractical in your environment (e.g. no AWS sandbox handy), document why in the PR description and rely on the integration + e2e suite.
+
+- [ ] **Step 15.4: Open the PR**
+
+```bash
+gh pr create --title "feat(auth): server-side credential consumption (#3818)" --body "$(cat <<'EOF'
+Closes #3818. Final piece of the multi-tenant Postgres-backed auth epic (#3788) — the read path.
+
+## Summary
+
+Implements RFC 8693 token-exchange against daemon-pushed envelopes. A caller presents a daemon JWT (`subject_token`); the server verifies it, decrypts the matching `auth_profiles` envelope, materializes a provider-native bearer (AWS or GitHub), writes a `auth_profile_reads` row, and returns the credential.
+
+## What's new
+
+- `CredentialConsumer` orchestrator (cache → decrypt → adapter → audit)
+- `ResolvedCredCache` with TTL = `min(300s, expires_at - 60s)`
+- AWS + GitHub provider adapters (pure JSON → `MaterializedCredential`)
+- `auth_profile_reads` partitioned table + RLS (mirror of `auth_profile_writes`)
+- 1% cache-hit / 100% cache-miss audit sampling
+- `/v1/auth/token-exchange` rewritten from 501 stub to live (gated by `NEXUS_TOKEN_EXCHANGE_ENABLED`)
+- E2E tests: LocalStack S3 list-buckets, real GitHub `/user` (both gated)
+- Operator guide updates
+
+## What's deferred (separate issues)
+
+- Gmail adapter (OAuth refresh via `TokenManager`)
+- gcloud adapter
+- Service-identity JWTs (caller_kind beyond "daemon")
+- Server-driven OAuth refresh (option B from spec)
+
+## Spec
+
+`docs/superpowers/specs/2026-04-23-issue-3818-server-credential-consumption-design.md`
+
+## Test plan
+
+- [x] Unit: consumer / cache / adapters / audit / metrics
+- [x] Integration (Postgres): `decrypt_profile()` honors RLS, returns plaintext + kek_version
+- [x] Router: all HTTP error mappings, force_refresh, 501-when-disabled
+- [x] E2E (LocalStack): daemon-push → token-exchange → real S3 call
+- [x] E2E (live PAT): daemon-push → token-exchange → GitHub `/user`
+- [ ] Reviewer: confirm `mlockall` recommendation + `purpose`-PII warning are in the operator guide
+- [ ] Reviewer: confirm token-exchange OFF-by-default in default env (NEXUS_TOKEN_EXCHANGE_ENABLED)
+EOF
+)"
+```
+
+- [ ] **Step 15.5: Move issue to in-review**
+
+```bash
+# (if your workflow uses Linear / GH project columns, transition #3818 here)
+```
+
+---
+
+## Spec coverage checklist
+
+- ✅ `/v1/auth/token-exchange` (RFC 8693): Tasks 10, 11
+- ✅ `CredentialConsumer.resolve()`: Task 8
+- ✅ `ResolvedCredCache` with `min(300, exp-60)` TTL: Task 6
+- ✅ AWS + GitHub adapters: Tasks 4, 5
+- ✅ `auth_profile_reads` partitioned + RLS: Task 1
+- ✅ 100% miss / 1% hit sampling: Task 7
+- ✅ `decrypt_profile()` on store: Task 2
+- ✅ Daemon-driven refresh (StaleSource → 409 → daemon catches up): Task 8 + Task 10 (router error map)
+- ✅ E2E LocalStack + nightly live: Tasks 12, 13
+- ✅ Prometheus metrics: Task 9
+- ✅ Operator guide: Task 14
+- ✅ Final verification + PR: Task 15

--- a/docs/superpowers/specs/2026-04-23-issue-3818-server-credential-consumption-design.md
+++ b/docs/superpowers/specs/2026-04-23-issue-3818-server-credential-consumption-design.md
@@ -1,0 +1,351 @@
+# Issue #3818 — Server-side Credential Consumption (Read Path)
+
+**Status:** Draft (brainstorm-approved 2026-04-23)
+**Epic:** #3788 (multi-tenant Postgres-backed auth)
+**Predecessors:** #3802 (PR 1: schema), #3809 (PR 2: envelope encryption), #3816 (PR 3: nexus-bot daemon write path)
+**Successors:** Gmail + gcloud adapters (separate issues), OIDC device-code join, Windows daemon
+
+## Problem
+
+PR 3 (#3816) shipped the daemon write path: local CLI auth (`~/.codex/auth.json`, `gcloud`, `gh`, `gws`) is envelope-encrypted on the laptop and pushed to `auth_profiles`. The server can persist these envelopes but cannot consume them. `/v1/auth/token-exchange` returns HTTP 501. No code path exists to:
+
+1. Authenticate a caller asking for a credential
+2. Decrypt the envelope and materialize a provider-native bearer
+3. Hand the bearer to the caller
+4. Refresh the upstream credential when it nears expiry
+5. Record an audit row for the read
+
+Until this lands, the daemon is observable but not useful — server-side workloads cannot act as the user.
+
+## Scope
+
+**In:**
+- `/v1/auth/token-exchange` (RFC 8693) — daemon JWT as `subject_token`, returns provider-native bearer
+- `CredentialConsumer` in `bricks/auth/consumer.py` — orchestrates decrypt → adapter → cache → audit
+- `ResolvedCredCache` — TTL = `min(300s, expires_at - 60s)`
+- AWS + GitHub provider adapters (validates two distinct credential shapes: STS short-lived vs PAT long-lived)
+- `auth_profile_reads` table mirroring `auth_profile_writes` — 100% on cache-miss, 1% sample on cache-hit
+- `decrypt_profile()` helper on `PostgresAuthProfileStore`
+- Daemon-driven refresh: server returns 409 `stale_source` when envelope's `last_synced_at` is past TTL; daemon's existing watcher re-pushes
+- E2E tests (LocalStack + PAT in PR CI; live AWS + GitHub nightly)
+
+**Deferred (separate issues):**
+- Gmail adapter (OAuth refresh via existing `TokenManager`)
+- gcloud adapter (token refresh via daemon CLI re-poll)
+- Cross-machine sync ("log in on laptop A → authed on laptop B")
+- Delegation chains (agent-A asks agent-B to call upstream on user's behalf)
+- UI for revocation / audit inspection
+- Server-driven OAuth refresh (option B from brainstorm — not needed if A is sufficient)
+- Service identities distinct from daemon JWTs (option B from brainstorm Q1)
+
+## Architectural decisions
+
+| # | Decision | Reasoning |
+|---|----------|-----------|
+| 1 | Caller identity = daemon JWT (`JwtSigner.verify`) | Reuses existing infra. `DaemonClaims` already carries `(tenant_id, principal_id, machine_id)`. No new identity issuer. |
+| 2 | Refresh = daemon-driven (push-to-refresh) | Refresh stays on user's actual machine. No long-lived `refresh_token` storage server-side. AWS STS doesn't have refresh_tokens anyway. |
+| 3 | Provider scope = AWS + GitHub | Two distinct shapes (STS vs PAT). Smallest cut that exercises full wire. Gmail/gcloud follow-ups become trivial after framework lands. |
+| 4 | Decrypted-cred cache TTL = `min(300s, expires_at - 60s)` | Bounds plaintext lifetime by both ceiling and upstream expiry. Matches `DEKCache` ceiling. |
+| 5 | Read-audit retention = indefinite + monthly partitions; 100% miss + 1% hit sample | Cache misses are real credential access. Cache hits are operational telemetry. Sampling keeps storage bounded without losing audit story. |
+| 6 | E2E infra = LocalStack + PAT in PR CI; nightly live | Same skip-when-env-absent pattern as PR 2's `VaultTransitProvider` / `AwsKmsProvider` tests. |
+| 7 | Layout = `bricks/auth/consumer*` (not `server/auth/resolve`) | Reuses `brick_factory.py` wiring for `EncryptionProvider` / `DEKCache` / `PostgresAuthProfileStore`. Keeps `server/auth/` focused on OAuth handshake. |
+
+## Components & file layout
+
+```
+src/nexus/bricks/auth/
+  consumer.py                       # ResolvedCredential, CredentialConsumer
+  consumer_cache.py                 # ResolvedCredCache
+  consumer_providers/
+    __init__.py
+    base.py                         # ProviderAdapter Protocol
+    aws.py                          # boto3-shaped payload → bearer
+    github.py                       # PAT/fine-grained payload → bearer
+  read_audit.py                     # write_read_audit() w/ 1% sampling
+  postgres_profile_store.py         # +decrypt_profile() helper, +auth_profile_reads schema
+  brick_factory.py                  # +CredentialConsumer wiring
+
+src/nexus/server/api/v1/routers/
+  token_exchange.py                 # rewrite: verify JWT → consumer.resolve → audit → respond
+
+src/nexus/bricks/auth/tests/
+  test_consumer.py
+  test_consumer_cache.py
+  test_consumer_providers_aws.py    # LocalStack-gated (LOCALSTACK_ENDPOINT=...)
+  test_consumer_providers_github.py # PAT-gated (NEXUS_TEST_GITHUB_PAT=...)
+  test_read_audit.py
+  test_postgres_decrypt_integration.py  # decrypt_profile() against running PG
+
+src/nexus/server/api/v1/tests/
+  test_token_exchange_router.py     # rewrite (was 501-only)
+
+tests/e2e/auth_consumption/
+  test_s3_as_user.py                # nightly, live AWS sandbox sub-account
+  test_github_as_user.py            # nightly, live GitHub PAT
+```
+
+## Schema
+
+One migration in `postgres_profile_store.ensure_schema()` — same idempotent `CREATE TABLE IF NOT EXISTS` pattern used by PR 1/2/3.
+
+```sql
+CREATE TABLE IF NOT EXISTS auth_profile_reads (
+    id                 BIGSERIAL,
+    read_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    tenant_id          UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+    principal_id       UUID NOT NULL,
+    auth_profile_id    TEXT NOT NULL,
+    caller_machine_id  UUID NOT NULL,            -- from daemon JWT (attested)
+    caller_kind        TEXT NOT NULL,            -- "daemon" for MVP
+    provider           TEXT NOT NULL,            -- "aws" | "github"
+    purpose            TEXT NOT NULL,            -- RFC 8693 scope, capped 256 chars
+    cache_hit          BOOLEAN NOT NULL,
+    kek_version        INTEGER NOT NULL,         -- which KEK unwrapped this read
+    PRIMARY KEY (read_at, id)
+) PARTITION BY RANGE (read_at);
+
+CREATE TABLE IF NOT EXISTS auth_profile_reads_default
+    PARTITION OF auth_profile_reads DEFAULT;
+
+ALTER TABLE auth_profile_reads ENABLE ROW LEVEL SECURITY;
+ALTER TABLE auth_profile_reads FORCE ROW LEVEL SECURITY;
+
+CREATE POLICY auth_profile_reads_tenant_isolation ON auth_profile_reads
+    USING (tenant_id = current_setting('app.current_tenant')::UUID);
+
+CREATE INDEX IF NOT EXISTS idx_auth_profile_reads_tenant_principal_provider
+    ON auth_profile_reads(tenant_id, principal_id, provider, read_at DESC);
+```
+
+Monthly partition creation is operator/cron concern; default partition catches all writes until a partition manager is wired (same posture as `auth_profile_writes`).
+
+## Wire contract — `POST /v1/auth/token-exchange`
+
+**Request (`application/x-www-form-urlencoded`, RFC 8693 §2.1):**
+
+| Field | Required | Value |
+|---|---|---|
+| `grant_type` | yes | `urn:ietf:params:oauth:grant-type:token-exchange` |
+| `subject_token` | yes | Daemon JWT (ES256, audience matches `JwtSigner` config) |
+| `subject_token_type` | yes | `urn:ietf:params:oauth:token-type:jwt` |
+| `resource` | yes | `urn:nexus:provider:aws` or `urn:nexus:provider:github` |
+| `scope` | yes | Freetext purpose ≤256 chars; truncated, never rejected |
+| `audience` | no | Ignored for MVP |
+
+**Custom extension:**
+
+| Field | Value |
+|---|---|
+| `nexus_force_refresh` | `"true"` to bypass `ResolvedCredCache` (still hits envelope decrypt). Honored only when subject_token came from bound-keypair flow (the only path today). |
+
+**Response 200:**
+```json
+{
+  "access_token": "<provider-native bearer>",
+  "issued_token_type": "urn:ietf:params:oauth:token-type:access_token",
+  "token_type": "Bearer",
+  "expires_in": 3287,
+  "nexus_credential_metadata": {
+    "...provider-specific fields..."
+  }
+}
+```
+
+**Multi-part credentials (AWS):** RFC 8693 mandates a single `access_token` string. AWS needs a 3-tuple (`access_key_id`, `secret_access_key`, `session_token`). Resolution:
+
+- `access_token` carries the `session_token` (the time-bounded part)
+- `nexus_credential_metadata` carries `{access_key_id, secret_access_key, region, account_id}` as a sibling object — non-RFC extension, namespaced to avoid collision
+- The Nexus client SDK builds `boto3.Session(aws_access_key_id=meta.access_key_id, aws_secret_access_key=meta.secret_access_key, aws_session_token=access_token, region_name=meta.region)` from this pair
+- Documented as an explicit RFC 8693 extension; non-Nexus callers asking for AWS get the same response shape but must know to read both fields
+
+For GitHub (single bearer), `nexus_credential_metadata` carries `{scopes_csv, token_type}` — informational only, not required to use the token.
+
+**Errors:**
+
+| HTTP | RFC code (body `error`) | Cause |
+|---|---|---|
+| 400 | `invalid_request` | Missing/unknown grant_type, missing subject_token, unknown `resource` |
+| 401 | `invalid_token` | JWT signature / exp / issuer / audience fail |
+| 403 | `access_denied` | Principal has no profile for that provider |
+| 409 | `stale_source` | Envelope present but `last_synced_at` past TTL → daemon offline |
+| 500 | `envelope_error` | KMS/Vault unreachable, AAD mismatch, ciphertext corrupt — body has no internals |
+| 503 | `provider_unreachable` | Reserved; MVP adapters do no upstream call |
+
+Errors follow RFC 8693 §2.2.2 / RFC 6749 §5.2 shape: `{"error": "...", "error_description": "..."}`.
+
+## Public Python surfaces
+
+```python
+# bricks/auth/consumer.py
+@dataclass(frozen=True)
+class ResolvedCredential:
+    provider: str
+    access_token: str
+    expires_at: datetime | None
+    metadata: dict[str, str]
+
+class CredentialConsumer:
+    def __init__(
+        self, *,
+        store: PostgresAuthProfileStore,
+        encryption: EncryptionProvider,
+        dek_cache: DEKCache,
+        cred_cache: ResolvedCredCache,
+        adapters: dict[str, ProviderAdapter],
+        audit: ReadAuditWriter,
+    ) -> None: ...
+
+    def resolve(
+        self, *,
+        claims: DaemonClaims,
+        provider: str,
+        purpose: str,
+        force_refresh: bool = False,
+    ) -> ResolvedCredential: ...
+```
+
+```python
+# bricks/auth/consumer_providers/base.py
+class ProviderAdapter(Protocol):
+    name: str
+
+    def materialize(self, plaintext_payload: bytes) -> ResolvedCredential:
+        """Pure deserialization. No network calls."""
+```
+
+**AWS adapter** — payload JSON: `{access_key_id, secret_access_key, session_token, expiration, region, account_id?}`. Returns `ResolvedCredential(access_token=session_token, expires_at=expiration, metadata={region, account_id, access_key_id})`. Caller side is responsible for assembling `boto3.Session(aws_access_key_id=..., aws_secret_access_key=..., aws_session_token=session_token)`.
+
+**GitHub adapter** — payload JSON: `{token, scopes, expires_at?, token_type?}`. Returns `ResolvedCredential(access_token=token, expires_at=expires_at_or_none, metadata={scopes_csv, token_type})`.
+
+## Data flow
+
+### Write path (existing, for context)
+```
+daemon → POST /v1/auth-profiles → PostgresAuthProfileStore.upsert() → auth_profile_writes
+```
+
+### Read path (this issue)
+```
+caller
+  ↓ POST /v1/auth/token-exchange (subject_token=daemon JWT, resource, scope)
+router (token_exchange.py)
+  ↓ JwtSigner.verify(subject_token) → DaemonClaims
+  ↓ SET LOCAL app.current_tenant = claims.tenant_id
+consumer.resolve(claims, provider, purpose, force_refresh)
+  ↓ key = (claims.tenant_id, claims.principal_id, provider)
+  ↓ cred_cache.get(key)
+    → hit + (now < expires_at - 60): return cached
+  ↓ store.decrypt_profile(claims, provider)
+    → row = SELECT ... WHERE (tenant_id, principal_id, provider) = ...
+    → if row.last_synced_at < (now - sync_ttl_seconds): raise StaleSource
+    → wrapped_dek_key = DEKCache.make_key(...)
+    → dek = dek_cache.get(...) or encryption.unwrap_dek(...)
+    → plaintext = AESGCMEnvelope().decrypt(dek, nonce, ciphertext, aad=row.aad)
+    → return (plaintext, row.kek_version, row.profile_id)
+  ↓ adapter = adapters[provider]
+  ↓ resolved = adapter.materialize(plaintext)
+  ↓ ttl = min(300, (resolved.expires_at - now).total_seconds() - 60) if expires_at else 300
+  ↓ cred_cache.put(key, resolved, ttl)
+router
+  ↓ audit.write(claims, profile_id, provider, purpose, cache_hit=False, kek_version)
+  ↓ return 200 {access_token, ...}
+
+stale upstream cred (caller's downstream call returns 401):
+  ↓ caller retries token-exchange with nexus_force_refresh=true
+  ↓ consumer skips cred_cache, re-runs decrypt + materialize
+  ↓ if last_synced_at also stale → 409 stale_source → daemon catches up via fsnotify
+```
+
+## Error taxonomy
+
+```
+ConsumerError
+  ├─ ProfileNotFound          → 403 access_denied
+  ├─ ProviderNotConfigured    → 403 access_denied
+  ├─ StaleSource              → 409 stale_source
+  └─ AdapterMaterializeFailed → 500 envelope_error
+
+EnvelopeError (from PR 2, unchanged)
+  ├─ AADMismatch          → 500 envelope_error
+  ├─ WrappedDEKInvalid    → 500 envelope_error
+  └─ CiphertextCorrupted  → 500 envelope_error
+
+JwtVerifyError (from PR 3, unchanged) → 401 invalid_token
+```
+
+All `ConsumerError` subclasses implement `from_row(*, tenant_id, principal_id, provider, cause)` classmethod — same no-plaintext-in-repr discipline as `EnvelopeError`. Inline f-strings forbidden.
+
+## Security properties
+
+- **JWT verify before any DB hit.** Invalid token → 401, no `app.current_tenant` set, no audit row written, no cache lookup.
+- **Tenant isolation via RLS.** `SET LOCAL app.current_tenant = claims.tenant_id` before every consumer query. Tests use `NOSUPERUSER NOBYPASSRLS` role to prove isolation (same posture as PR 3).
+- **Cache key includes tenant_id.** Prevents cross-tenant cache poisoning even if a future bug forgets RLS.
+- **No plaintext in repr/logs.** Adapters / consumer errors use `from_row` constructors. `ResolvedCredential.__repr__` masks `access_token` (`"***"`).
+- **Plaintext lifetime ≤ min(300s, expires_at-60s).** Document `mlockall(MCL_FUTURE)` recommendation in deployment guide for production.
+- **`nexus_force_refresh` honored only for bound-keypair JWTs** — currently the only path; future service-identity JWTs (Q1 option B) would need explicit opt-in.
+- **Audit `purpose` is freetext.** Deployment guide MUST warn callers to never include credentials/PII. Truncated to 256 chars (not rejected — fail-open on length).
+- **Replay surface unchanged.** Subject_token = daemon JWT with its own 1h `exp`. Token-exchange does not introduce new replay vectors.
+
+## Observability
+
+Prometheus metrics (low-cardinality labels only):
+
+| Metric | Labels | Purpose |
+|---|---|---|
+| `nexus_token_exchange_requests_total` | `provider, result` | Result ∈ `ok\|stale\|denied\|invalid_token\|envelope_error` |
+| `nexus_token_exchange_latency_seconds` | `provider, cache` | Cache ∈ `hit\|miss` |
+| `nexus_consumer_cache_size` | (none) | Gauge of resolved-cred cache size |
+| `nexus_consumer_cache_evictions_total` | `reason` | Reason ∈ `ttl\|lru\|expires_at` |
+| `nexus_read_audit_writes_total` | `cache` | Confirms 1% sampling actually samples |
+
+Existing `nexus_dek_cache_*` and `nexus_envelope_unwrap_*` from PR 2 cover envelope path; no duplication.
+
+Tracing: one span per `/v1/auth/token-exchange`; child spans `verify_jwt`, `cache_lookup`, `decrypt_profile`, `adapter_materialize`, `audit_write`. Span attrs: `tenant_id`, `provider`, `cache_hit`, `kek_version`. No token bytes.
+
+## Test plan
+
+| File | Type | What it proves |
+|---|---|---|
+| `test_consumer.py` | unit | resolve happy / force_refresh / not-found / stale / adapter raise / AAD mismatch propagation |
+| `test_consumer_cache.py` | unit | TTL cap, expires_at cap, LRU eviction, thread-safety |
+| `test_read_audit.py` | unit | 100% on miss, 1% sample on hit (seeded RNG), partition routing |
+| `test_postgres_decrypt_integration.py` | integration (PG) | `decrypt_profile()` honors RLS, returns plaintext + kek_version |
+| `test_consumer_providers_aws.py` | unit (LocalStack-gated) | AWS payload JSON → ResolvedCredential; metadata fields populated |
+| `test_consumer_providers_github.py` | unit (PAT-gated) | GitHub payload JSON → ResolvedCredential; expires_at None vs date |
+| `test_token_exchange_router.py` | router | All HTTP error mappings; RLS-set-tenant assertion; force_refresh path |
+| `tests/e2e/auth_consumption/test_s3_as_user.py` | e2e (nightly, live AWS) | daemon push → token-exchange → real `s3.list_buckets()` returns ≥1 bucket |
+| `tests/e2e/auth_consumption/test_github_as_user.py` | e2e (nightly, live GitHub) | daemon push → token-exchange → real `octokit /user` returns expected login |
+
+E2E gating: skip cleanly when env absent, run when `LOCALSTACK_ENDPOINT` / `NEXUS_TEST_GITHUB_PAT` / `NEXUS_TEST_AWS_LIVE=1` set.
+
+## Migration / rollout
+
+1. Schema migration is additive — `auth_profile_reads` is a new table; `decrypt_profile()` reads existing envelope columns
+2. `/v1/auth/token-exchange` flips from 501 to live; existing `enabled` flag (`NEXUS_TOKEN_EXCHANGE_ENABLED`) gates the new behavior. Default off until ops verifies KMS/Vault wiring in their environment.
+3. No daemon changes required — daemon already pushes the envelope shape this consumer expects.
+4. Provider adapters are loaded lazily via `consumer_providers/__init__.py` registry; missing provider name = `ProviderNotConfigured` (403), not import error.
+
+## Out-of-scope (explicit, with justification)
+
+- **Server-driven OAuth refresh** — option B from Q2 brainstorm. Adds `refresh_token` storage burden and per-provider refresh code. Q2 picked A; revisit if daemon offline becomes a bottleneck.
+- **Service-identity JWTs** — option B from Q1. Daemon JWT is sufficient for MVP. Add `caller_kind="service"` to audit when this lands.
+- **Gmail / gcloud adapters** — separate issues. Gmail needs OAuth refresh path; gcloud needs gcloud CLI shape decoded. Framework supports both via `ProviderAdapter` Protocol.
+- **Delegation chains** — agent A asks agent B to call upstream as user. RFC 8693 supports `actor_token`; defer until a real use case exists.
+- **UI for revocation / audit inspection** — raw SQL is the MVP interface.
+
+## SOC 2 mapping
+
+- **CC6.1** logical access → tenant RLS + principal scoping on every read
+- **CC6.7** transmission → TLS termination upstream of router; envelope still encrypted in DB at rest
+- **CC7.2** monitoring → `auth_profile_reads` row per credential access (with caller machine_id attested by Ed25519 keypair from PR 3)
+- **CC6.8** malicious software → plaintext capped at `min(300s, expires_at-60s)` in process; no plaintext on disk; `force_refresh` requires bound-keypair JWT
+
+## References
+
+- Epic: #3788
+- Predecessor: #3816 (daemon write path)
+- Stub being replaced: `src/nexus/server/api/v1/routers/token_exchange.py`
+- RFC 8693: https://datatracker.ietf.org/doc/html/rfc8693
+- RFC 6749 §5.2 (error response shape): https://datatracker.ietf.org/doc/html/rfc6749#section-5.2
+- PR 2 envelope spec: `docs/superpowers/specs/2026-04-18-issue-3803-envelope-encryption-design.md`
+- PR 3 daemon spec: `docs/superpowers/specs/2026-04-19-nexus-bot-daemon-design.md`

--- a/nexus-stack.yml
+++ b/nexus-stack.yml
@@ -129,6 +129,8 @@ services:
       # endpoint is NOT registered even if NEXUS_ALLOW_ADMIN_BYPASS=true.
       # `nexus up --with-daemon` injects a fresh random token.
       NEXUS_ADMIN_BOOTSTRAP_TOKEN: ${NEXUS_ADMIN_BOOTSTRAP_TOKEN:-}
+      # Token-exchange (#3818) read-path gate. Off by default until ops verifies KMS/Vault wiring.
+      NEXUS_TOKEN_EXCHANGE_ENABLED: ${NEXUS_TOKEN_EXCHANGE_ENABLED:-}
       # Config
       NEXUS_CONFIG_FILE: ${NEXUS_CONFIG_FILE:-/app/configs/config.demo.yaml}
       # Cache

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,11 @@ dependencies = [
     # HTTP server (FastAPI + ASGI)
     "fastapi>=0.124.0",
     "uvicorn>=0.38.0", # ASGI server (base profile; use [server-standard] for full stack)
+    # Required by FastAPI's Form(...) — token-exchange (#3818) parses
+    # application/x-www-form-urlencoded per RFC 6749 §3.2 / RFC 8693 §2.1.
+    # FastAPI raises at route registration time without this; declared
+    # directly so we don't depend on `mcp` (current transitive owner).
+    "python-multipart>=0.0.20",
     # File watching (cross-platform, Rust-backed via notify crate)
     "watchdog>=4.0.0",  # fsnotify wrapper for daemon source watchers (#3804)
     "keyring>=25.0.0",  # OS keychain/secret service for daemon JWT cache (#3804)

--- a/src/nexus/bricks/auth/consumer.py
+++ b/src/nexus/bricks/auth/consumer.py
@@ -531,6 +531,16 @@ class CredentialConsumer:
         except AuditWriteFailed:
             result_label = "audit_write_failed"
             raise
+        except Exception:
+            # F30: catch-all so EnvelopeError (KMS unwrap failure, AAD
+            # mismatch, ciphertext corruption — all bubble to the router
+            # as 500 envelope_error) is counted as a failure in the
+            # primary token-exchange metric, not as ``ok``. Without this,
+            # a KMS outage would show 100% success in
+            # nexus_token_exchange_requests_total even while every
+            # client was getting 500s.
+            result_label = "envelope_error"
+            raise
         finally:
             TOKEN_EXCHANGE_LATENCY.labels(provider=provider, cache=cache_label).observe(
                 time.monotonic() - start

--- a/src/nexus/bricks/auth/consumer.py
+++ b/src/nexus/bricks/auth/consumer.py
@@ -15,6 +15,15 @@ from __future__ import annotations
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nexus.bricks.auth.consumer_cache import ResolvedCredCache
+    from nexus.bricks.auth.consumer_providers.base import ProviderAdapter
+    from nexus.bricks.auth.envelope import DEKCache, EncryptionProvider
+    from nexus.bricks.auth.postgres_profile_store import PostgresAuthProfileStore
+    from nexus.bricks.auth.read_audit import ReadAuditWriter
+    from nexus.server.api.v1.jwt_signer import DaemonClaims
 
 
 @dataclass(frozen=True)
@@ -115,6 +124,119 @@ class AdapterMaterializeFailed(ConsumerError):
 
 
 class CredentialConsumer:
-    """Implementation lands in Task 8. Type-only declaration here so other
-    modules can import the symbol without circular references.
+    """Orchestrates: cache lookup → decrypt → materialize → cache write → audit.
+
+    All errors raised by this class are subclasses of ``ConsumerError`` and
+    carry no plaintext / token bytes in repr.
     """
+
+    def __init__(
+        self,
+        *,
+        store: "PostgresAuthProfileStore",
+        encryption: "EncryptionProvider",
+        dek_cache: "DEKCache",
+        cred_cache: "ResolvedCredCache",
+        adapters: dict[str, "ProviderAdapter"],
+        audit: "ReadAuditWriter",
+    ) -> None:
+        self._store = store
+        self._encryption = encryption
+        self._dek_cache = dek_cache
+        self._cred_cache = cred_cache
+        self._adapters = adapters
+        self._audit = audit
+
+    def resolve(
+        self,
+        *,
+        claims: "DaemonClaims",
+        provider: str,
+        purpose: str,
+        force_refresh: bool = False,
+    ) -> MaterializedCredential:
+        from datetime import UTC, datetime, timedelta
+
+        from nexus.bricks.auth.postgres_profile_store import ProfileNotFound
+
+        adapter = self._adapters.get(provider)
+        if adapter is None:
+            raise ProviderNotConfigured.from_row(
+                tenant_id=claims.tenant_id,
+                principal_id=claims.principal_id,
+                provider=provider,
+                cause="adapter_not_registered",
+            )
+
+        cache_key = (
+            str(claims.tenant_id),
+            str(claims.principal_id),
+            provider,
+        )
+        now = datetime.now(UTC)
+
+        if not force_refresh:
+            cached = self._cred_cache.get(cache_key, now=now)
+            if cached is not None:
+                # Cache hit — log sampled audit row, no decrypt
+                self._audit.write(
+                    tenant_id=claims.tenant_id,
+                    principal_id=claims.principal_id,
+                    auth_profile_id="cached",
+                    caller_machine_id=claims.machine_id,
+                    caller_kind="daemon",
+                    provider=provider,
+                    purpose=purpose,
+                    cache_hit=True,
+                    kek_version=0,  # unknown on cache hit; sentinel value
+                )
+                return cached
+
+        try:
+            decrypted = self._store.decrypt_profile(
+                principal_id=claims.principal_id,
+                provider=provider,
+                encryption=self._encryption,
+                dek_cache=self._dek_cache,
+            )
+        except ProfileNotFound as exc:
+            raise ProfileNotFoundForCaller.from_row(
+                tenant_id=claims.tenant_id,
+                principal_id=claims.principal_id,
+                provider=provider,
+                cause="no_envelope_row",
+            ) from exc
+
+        # Stale-source check: last_synced_at + sync_ttl must be in the future.
+        ttl_window = timedelta(seconds=decrypted.sync_ttl_seconds)
+        if decrypted.last_synced_at + ttl_window < now:
+            raise StaleSource.from_row(
+                tenant_id=claims.tenant_id,
+                principal_id=claims.principal_id,
+                provider=provider,
+                cause=f"last_synced_at_age={int((now - decrypted.last_synced_at).total_seconds())}s",
+            )
+
+        try:
+            materialized = adapter.materialize(decrypted.plaintext)
+        except (ValueError, KeyError) as exc:
+            raise AdapterMaterializeFailed.from_row(
+                tenant_id=claims.tenant_id,
+                principal_id=claims.principal_id,
+                provider=provider,
+                cause=f"{type(exc).__name__}",
+            ) from exc
+
+        self._cred_cache.put(cache_key, materialized, now=now)
+        self._audit.write(
+            tenant_id=claims.tenant_id,
+            principal_id=claims.principal_id,
+            auth_profile_id=decrypted.profile_id,
+            caller_machine_id=claims.machine_id,
+            caller_kind="daemon",
+            provider=provider,
+            purpose=purpose,
+            cache_hit=False,
+            kek_version=decrypted.kek_version,
+        )
+        return materialized

--- a/src/nexus/bricks/auth/consumer.py
+++ b/src/nexus/bricks/auth/consumer.py
@@ -392,18 +392,14 @@ class CredentialConsumer:
                         # if the underlying envelope is also stale).
                         self._cred_cache.evict(cache_key)
                     else:
-                        # F25 + F26: bracket the audit.write with TWO
-                        # daemon-revocation checks. The first catches a
-                        # revoke committed before audit started; the
-                        # second (after audit) catches a revoke committed
-                        # WHILE audit was running. Together they shrink the
-                        # post-revoke read race down to the gap between the
-                        # second SELECT and the JSONResponse send.
-                        self._get_store(claims).assert_machine_active(
-                            principal_id=claims.principal_id,
-                            machine_id=claims.machine_id,
-                        )
-                        # Cache hit — log sampled audit row, no decrypt.
+                        # F25 + F26: revocation enforcement now lives
+                        # inside audit.write (SELECT FOR SHARE on
+                        # daemon_machines + audit INSERT in one tx).
+                        # Concurrent revoke either commits BEFORE the
+                        # audit's SHARE-lock SELECT (we get
+                        # MachineUnknownOrRevoked + nothing returned) or
+                        # AFTER our audit COMMIT (we returned this one
+                        # credential, next request denied). No race window.
                         cache_label = "hit"
                         self._audit.write(
                             tenant_id=claims.tenant_id,
@@ -415,10 +411,6 @@ class CredentialConsumer:
                             purpose=purpose,
                             cache_hit=True,
                             kek_version=cached_fp.kek_version,
-                        )
-                        self._get_store(claims).assert_machine_active(
-                            principal_id=claims.principal_id,
-                            machine_id=claims.machine_id,
                         )
                         return cached_cred
 
@@ -485,20 +477,15 @@ class CredentialConsumer:
                         cause="materialized_credential_expired_or_near_expiry",
                     )
 
-            # F25: Double-check machine_active immediately before audit/cache.
-            # The first assert_machine_active was at the top of resolve;
-            # between that and here we held no lock while running KMS
-            # unwrap_dek (potentially hundreds of ms for AWS KMS / Vault).
-            # A revoke that committed in that window would otherwise be
-            # missed and the daemon would receive one more upstream
-            # credential after revocation. This second check shrinks the
-            # race to the (microsecond) gap between the SELECT and the
-            # JSONResponse send.
-            self._get_store(claims).assert_machine_active(
-                principal_id=claims.principal_id,
-                machine_id=claims.machine_id,
-            )
-
+            # F25 + F26: revocation enforcement is atomic with the audit
+            # write — audit.write does SELECT FOR SHARE on daemon_machines
+            # before INSERTing the audit row, in one transaction. A
+            # concurrent revoke either commits BEFORE our SHARE-lock
+            # SELECT (we get MachineUnknownOrRevoked, no credential
+            # cached or returned) or AFTER our audit COMMIT (this one
+            # credential is returned + cached; next request denied). No
+            # race window between the gate and the cache.put / return.
+            #
             # IMPORTANT: write audit BEFORE caching so a failed mandatory
             # cache-miss audit doesn't poison the cache. Without this order,
             # an audit failure raises AuditWriteFailed → router 503, but the
@@ -514,20 +501,6 @@ class CredentialConsumer:
                 purpose=purpose,
                 cache_hit=False,
                 kek_version=decrypted.kek_version,
-            )
-
-            # F26: Third machine_active check after audit, before cache+return.
-            # audit.write opens its own short transaction (potentially tens of
-            # ms under load); a revoke that commits during that window would
-            # otherwise slip past F25's pre-audit check and the daemon would
-            # both end up with an audit row for a permitted read AND get the
-            # credential cached. This third check fails the request closed if
-            # the daemon was revoked while audit was running. The audit row
-            # itself stays — that's correct: a revoked daemon DID try to read,
-            # and the audit log is meant to capture every attempt.
-            self._get_store(claims).assert_machine_active(
-                principal_id=claims.principal_id,
-                machine_id=claims.machine_id,
             )
 
             self._cred_cache.put(

--- a/src/nexus/bricks/auth/consumer.py
+++ b/src/nexus/bricks/auth/consumer.py
@@ -392,12 +392,13 @@ class CredentialConsumer:
                         # if the underlying envelope is also stale).
                         self._cred_cache.evict(cache_key)
                     else:
-                        # F25: re-check daemon revocation right before the
-                        # response. The first assert_machine_active was at
-                        # the top of resolve; a revoke that committed in
-                        # the gap between that check and here would
-                        # otherwise be missed and this cache hit would hand
-                        # back a credential to a now-revoked daemon.
+                        # F25 + F26: bracket the audit.write with TWO
+                        # daemon-revocation checks. The first catches a
+                        # revoke committed before audit started; the
+                        # second (after audit) catches a revoke committed
+                        # WHILE audit was running. Together they shrink the
+                        # post-revoke read race down to the gap between the
+                        # second SELECT and the JSONResponse send.
                         self._get_store(claims).assert_machine_active(
                             principal_id=claims.principal_id,
                             machine_id=claims.machine_id,
@@ -415,13 +416,25 @@ class CredentialConsumer:
                             cache_hit=True,
                             kek_version=cached_fp.kek_version,
                         )
+                        self._get_store(claims).assert_machine_active(
+                            principal_id=claims.principal_id,
+                            machine_id=claims.machine_id,
+                        )
                         return cached_cred
 
             try:
+                # F27: scope decrypt by the precheck's matched profile_id,
+                # not the user-provided one. Without this, decrypt_profile
+                # re-queries with provider-only filtering and sees the
+                # active row + any stale siblings (which assert_profile_active
+                # already filtered out) — raising MultipleProfilesForProvider
+                # when the request is actually unambiguous. Using fp_pre's
+                # profile_id pins the decrypt query to the exact row we
+                # validated, even if the caller passed profile_id=None.
                 decrypted = self._get_store(claims).decrypt_profile(
                     principal_id=claims.principal_id,
                     provider=provider,
-                    profile_id=profile_id,
+                    profile_id=fp_pre.profile_id,
                     encryption=self._encryption,
                     dek_cache=self._dek_cache,
                 )
@@ -501,6 +514,20 @@ class CredentialConsumer:
                 purpose=purpose,
                 cache_hit=False,
                 kek_version=decrypted.kek_version,
+            )
+
+            # F26: Third machine_active check after audit, before cache+return.
+            # audit.write opens its own short transaction (potentially tens of
+            # ms under load); a revoke that commits during that window would
+            # otherwise slip past F25's pre-audit check and the daemon would
+            # both end up with an audit row for a permitted read AND get the
+            # credential cached. This third check fails the request closed if
+            # the daemon was revoked while audit was running. The audit row
+            # itself stays — that's correct: a revoked daemon DID try to read,
+            # and the audit log is meant to capture every attempt.
+            self._get_store(claims).assert_machine_active(
+                principal_id=claims.principal_id,
+                machine_id=claims.machine_id,
             )
 
             self._cred_cache.put(

--- a/src/nexus/bricks/auth/consumer.py
+++ b/src/nexus/bricks/auth/consumer.py
@@ -12,15 +12,19 @@ server-side agent that needs to act as a user.
 
 from __future__ import annotations
 
+import logging
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING
 
 from nexus.bricks.auth.consumer_metrics import (
+    CROSS_MACHINE_READS,
     TOKEN_EXCHANGE_LATENCY,
     TOKEN_EXCHANGE_REQUESTS,
 )
+
+_logger = logging.getLogger(__name__)
 
 if TYPE_CHECKING:
     from sqlalchemy.engine import Engine
@@ -311,7 +315,32 @@ class CredentialConsumer:
                     cause=f"{type(exc).__name__}",
                 ) from exc
 
-            self._cred_cache.put(cache_key, materialized, now=now)
+            # Cross-machine read detection: this daemon reads a credential
+            # pushed by a different daemon (same principal, different machine).
+            # Allowed today (no explicit sharing model in the wire contract)
+            # but operationally suspicious — log + metric so operators can
+            # detect implicit sharing. A future enforcement flag can flip
+            # this from log-warning to fail-closed without API changes.
+            if (
+                decrypted.writer_machine_id is not None
+                and decrypted.writer_machine_id != claims.machine_id
+            ):
+                _logger.warning(
+                    "cross_machine_read tenant=%s principal=%s provider=%s "
+                    "reader=%s writer=%s — implicit credential sharing across daemons",
+                    claims.tenant_id,
+                    claims.principal_id,
+                    provider,
+                    claims.machine_id,
+                    decrypted.writer_machine_id,
+                )
+                CROSS_MACHINE_READS.labels(provider=provider).inc()
+
+            # IMPORTANT: write audit BEFORE caching so a failed mandatory
+            # cache-miss audit doesn't poison the cache. Without this order,
+            # an audit failure raises AuditWriteFailed → router 503, but the
+            # credential is already in cred_cache and the next request hits
+            # cache (no audit attempted) → silent forensics gap.
             self._audit.write(
                 tenant_id=claims.tenant_id,
                 principal_id=claims.principal_id,
@@ -323,6 +352,7 @@ class CredentialConsumer:
                 cache_hit=False,
                 kek_version=decrypted.kek_version,
             )
+            self._cred_cache.put(cache_key, materialized, now=now)
             return materialized
 
         except (ProfileNotFoundForCaller, ProviderNotConfigured, MachineUnknownOrRevoked):

--- a/src/nexus/bricks/auth/consumer.py
+++ b/src/nexus/bricks/auth/consumer.py
@@ -23,6 +23,8 @@ from nexus.bricks.auth.consumer_metrics import (
 )
 
 if TYPE_CHECKING:
+    from sqlalchemy.engine import Engine
+
     from nexus.bricks.auth.consumer_cache import ResolvedCredCache
     from nexus.bricks.auth.consumer_providers.base import ProviderAdapter
     from nexus.bricks.auth.envelope import DEKCache, EncryptionProvider
@@ -138,19 +140,48 @@ class CredentialConsumer:
     def __init__(
         self,
         *,
-        store: "PostgresAuthProfileStore",
         encryption: "EncryptionProvider",
         dek_cache: "DEKCache",
         cred_cache: "ResolvedCredCache",
         adapters: dict[str, "ProviderAdapter"],
         audit: "ReadAuditWriter",
+        store: "PostgresAuthProfileStore | None" = None,
+        engine: "Engine | None" = None,
     ) -> None:
+        # Either ``store`` (single-tenant, used by tests that pre-bind a tenant)
+        # OR ``engine`` (multi-tenant, used by the server which scopes per-request
+        # via JWT claims). When both are provided, ``store`` wins — tests get
+        # deterministic behaviour without having to drop the engine.
+        if store is None and engine is None:
+            raise ValueError("CredentialConsumer requires either store=... or engine=...")
         self._store = store
+        self._engine = engine
         self._encryption = encryption
         self._dek_cache = dek_cache
         self._cred_cache = cred_cache
         self._adapters = adapters
         self._audit = audit
+
+    def _get_store(self, claims: "DaemonClaims") -> "PostgresAuthProfileStore":
+        """Return a store scoped to ``claims.tenant_id``.
+
+        - If a pre-bound store was supplied at construction (test path), return
+          it as-is. Tests bind the store to a known tenant; we don't second-guess.
+        - Otherwise, construct a fresh store using ``claims.tenant_id`` so the
+          underlying ``decrypt_profile`` SQL filters by the JWT-verified tenant
+          rather than a boot-time placeholder.
+        """
+        if self._store is not None:
+            return self._store
+        # Local import to avoid a circular dep at module load time.
+        from nexus.bricks.auth.postgres_profile_store import PostgresAuthProfileStore
+
+        return PostgresAuthProfileStore(
+            "",
+            tenant_id=claims.tenant_id,
+            principal_id=claims.principal_id,
+            engine=self._engine,
+        )
 
     def resolve(
         self,
@@ -204,7 +235,7 @@ class CredentialConsumer:
                     return cached
 
             try:
-                decrypted = self._store.decrypt_profile(
+                decrypted = self._get_store(claims).decrypt_profile(
                     principal_id=claims.principal_id,
                     provider=provider,
                     encryption=self._encryption,

--- a/src/nexus/bricks/auth/consumer.py
+++ b/src/nexus/bricks/auth/consumer.py
@@ -247,10 +247,17 @@ class CredentialConsumer:
                     cause="adapter_not_registered",
                 )
 
+            # machine_id is part of the key so a warm cache cannot return
+            # another daemon's credential under cross-machine read enforcement.
+            # Without this, machine A pushes + caches; machine B's request
+            # passes assert_machine_active + assert_profile_active and gets
+            # A's plaintext from cache without ever reaching the
+            # writer_machine_id check on the decrypt path.
             cache_key = (
                 str(claims.tenant_id),
                 str(claims.principal_id),
                 provider,
+                str(claims.machine_id),
             )
             now = datetime.now(UTC)
 
@@ -285,7 +292,11 @@ class CredentialConsumer:
                             provider=provider,
                             cause="profile_disabled_or_cooldown",
                         ) from exc
-                    except MultipleProfilesForProvider:
+                    except (MultipleProfilesForProvider, StaleSource):
+                        # Stale source on a warm cache means the daemon
+                        # stopped pushing for longer than sync_ttl_seconds —
+                        # serving the cached plaintext would mask a stuck
+                        # daemon. Evict + propagate so the router 409s.
                         self._cred_cache.evict(cache_key)
                         raise
 

--- a/src/nexus/bricks/auth/consumer.py
+++ b/src/nexus/bricks/auth/consumer.py
@@ -17,6 +17,11 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import TYPE_CHECKING
 
+from nexus.bricks.auth.consumer_metrics import (
+    TOKEN_EXCHANGE_LATENCY,
+    TOKEN_EXCHANGE_REQUESTS,
+)
+
 if TYPE_CHECKING:
     from nexus.bricks.auth.consumer_cache import ResolvedCredCache
     from nexus.bricks.auth.consumer_providers.base import ProviderAdapter
@@ -155,88 +160,109 @@ class CredentialConsumer:
         purpose: str,
         force_refresh: bool = False,
     ) -> MaterializedCredential:
+        import time
         from datetime import UTC, datetime, timedelta
 
         from nexus.bricks.auth.postgres_profile_store import ProfileNotFound
 
-        adapter = self._adapters.get(provider)
-        if adapter is None:
-            raise ProviderNotConfigured.from_row(
-                tenant_id=claims.tenant_id,
-                principal_id=claims.principal_id,
-                provider=provider,
-                cause="adapter_not_registered",
-            )
-
-        cache_key = (
-            str(claims.tenant_id),
-            str(claims.principal_id),
-            provider,
-        )
-        now = datetime.now(UTC)
-
-        if not force_refresh:
-            cached = self._cred_cache.get(cache_key, now=now)
-            if cached is not None:
-                # Cache hit — log sampled audit row, no decrypt
-                self._audit.write(
+        start = time.monotonic()
+        cache_label = "miss"
+        result_label = "ok"
+        try:
+            adapter = self._adapters.get(provider)
+            if adapter is None:
+                raise ProviderNotConfigured.from_row(
                     tenant_id=claims.tenant_id,
                     principal_id=claims.principal_id,
-                    auth_profile_id="cached",
-                    caller_machine_id=claims.machine_id,
-                    caller_kind="daemon",
                     provider=provider,
-                    purpose=purpose,
-                    cache_hit=True,
-                    kek_version=0,  # unknown on cache hit; sentinel value
+                    cause="adapter_not_registered",
                 )
-                return cached
 
-        try:
-            decrypted = self._store.decrypt_profile(
-                principal_id=claims.principal_id,
-                provider=provider,
-                encryption=self._encryption,
-                dek_cache=self._dek_cache,
+            cache_key = (
+                str(claims.tenant_id),
+                str(claims.principal_id),
+                provider,
             )
-        except ProfileNotFound as exc:
-            raise ProfileNotFoundForCaller.from_row(
-                tenant_id=claims.tenant_id,
-                principal_id=claims.principal_id,
-                provider=provider,
-                cause="no_envelope_row",
-            ) from exc
+            now = datetime.now(UTC)
 
-        # Stale-source check: last_synced_at + sync_ttl must be in the future.
-        ttl_window = timedelta(seconds=decrypted.sync_ttl_seconds)
-        if decrypted.last_synced_at + ttl_window < now:
-            raise StaleSource.from_row(
+            if not force_refresh:
+                cached = self._cred_cache.get(cache_key, now=now)
+                if cached is not None:
+                    # Cache hit — log sampled audit row, no decrypt
+                    cache_label = "hit"
+                    self._audit.write(
+                        tenant_id=claims.tenant_id,
+                        principal_id=claims.principal_id,
+                        auth_profile_id="cached",
+                        caller_machine_id=claims.machine_id,
+                        caller_kind="daemon",
+                        provider=provider,
+                        purpose=purpose,
+                        cache_hit=True,
+                        kek_version=0,  # unknown on cache hit; sentinel value
+                    )
+                    return cached
+
+            try:
+                decrypted = self._store.decrypt_profile(
+                    principal_id=claims.principal_id,
+                    provider=provider,
+                    encryption=self._encryption,
+                    dek_cache=self._dek_cache,
+                )
+            except ProfileNotFound as exc:
+                raise ProfileNotFoundForCaller.from_row(
+                    tenant_id=claims.tenant_id,
+                    principal_id=claims.principal_id,
+                    provider=provider,
+                    cause="no_envelope_row",
+                ) from exc
+
+            # Stale-source check: last_synced_at + sync_ttl must be in the future.
+            ttl_window = timedelta(seconds=decrypted.sync_ttl_seconds)
+            if decrypted.last_synced_at + ttl_window < now:
+                raise StaleSource.from_row(
+                    tenant_id=claims.tenant_id,
+                    principal_id=claims.principal_id,
+                    provider=provider,
+                    cause=f"last_synced_at_age={int((now - decrypted.last_synced_at).total_seconds())}s",
+                )
+
+            try:
+                materialized = adapter.materialize(decrypted.plaintext)
+            except (ValueError, KeyError) as exc:
+                raise AdapterMaterializeFailed.from_row(
+                    tenant_id=claims.tenant_id,
+                    principal_id=claims.principal_id,
+                    provider=provider,
+                    cause=f"{type(exc).__name__}",
+                ) from exc
+
+            self._cred_cache.put(cache_key, materialized, now=now)
+            self._audit.write(
                 tenant_id=claims.tenant_id,
                 principal_id=claims.principal_id,
+                auth_profile_id=decrypted.profile_id,
+                caller_machine_id=claims.machine_id,
+                caller_kind="daemon",
                 provider=provider,
-                cause=f"last_synced_at_age={int((now - decrypted.last_synced_at).total_seconds())}s",
+                purpose=purpose,
+                cache_hit=False,
+                kek_version=decrypted.kek_version,
             )
+            return materialized
 
-        try:
-            materialized = adapter.materialize(decrypted.plaintext)
-        except (ValueError, KeyError) as exc:
-            raise AdapterMaterializeFailed.from_row(
-                tenant_id=claims.tenant_id,
-                principal_id=claims.principal_id,
-                provider=provider,
-                cause=f"{type(exc).__name__}",
-            ) from exc
-
-        self._cred_cache.put(cache_key, materialized, now=now)
-        self._audit.write(
-            tenant_id=claims.tenant_id,
-            principal_id=claims.principal_id,
-            auth_profile_id=decrypted.profile_id,
-            caller_machine_id=claims.machine_id,
-            caller_kind="daemon",
-            provider=provider,
-            purpose=purpose,
-            cache_hit=False,
-            kek_version=decrypted.kek_version,
-        )
-        return materialized
+        except (ProfileNotFoundForCaller, ProviderNotConfigured):
+            result_label = "denied"
+            raise
+        except StaleSource:
+            result_label = "stale"
+            raise
+        except AdapterMaterializeFailed:
+            result_label = "envelope_error"
+            raise
+        finally:
+            TOKEN_EXCHANGE_LATENCY.labels(provider=provider, cache=cache_label).observe(
+                time.monotonic() - start
+            )
+            TOKEN_EXCHANGE_REQUESTS.labels(provider=provider, result=result_label).inc()

--- a/src/nexus/bricks/auth/consumer.py
+++ b/src/nexus/bricks/auth/consumer.py
@@ -147,6 +147,17 @@ class MultipleProfilesForProvider(ConsumerError):
     """
 
 
+class AuditWriteFailed(ConsumerError):
+    """The mandatory cache-miss audit row could not be written.
+
+    Resolving a credential without a durable record of the read would
+    create a forensics blind spot exactly when something went wrong in
+    the database. Fail closed: the caller gets a 503, no credential
+    leaves the server, the operator sees both the audit-table failure
+    AND the missing read in metrics.
+    """
+
+
 # ---------------------------------------------------------------------------
 # CredentialConsumer (orchestrator) — implementation in Task 8
 # ---------------------------------------------------------------------------
@@ -325,6 +336,9 @@ class CredentialConsumer:
             raise
         except AdapterMaterializeFailed:
             result_label = "envelope_error"
+            raise
+        except AuditWriteFailed:
+            result_label = "audit_write_failed"
             raise
         finally:
             TOKEN_EXCHANGE_LATENCY.labels(provider=provider, cache=cache_label).observe(

--- a/src/nexus/bricks/auth/consumer.py
+++ b/src/nexus/bricks/auth/consumer.py
@@ -1,0 +1,120 @@
+"""CredentialConsumer: server-side read path for envelope-encrypted auth profiles (#3818).
+
+The consumer is the orchestrator that ties together:
+  - PostgresAuthProfileStore.decrypt_profile() — envelope → plaintext
+  - ProviderAdapter.materialize() — plaintext → MaterializedCredential
+  - ResolvedCredCache — TTL = min(300, expires_at - 60)
+  - ReadAuditWriter — auth_profile_reads row per resolve
+
+Callers: ``/v1/auth/token-exchange`` router (wire path), and any in-process
+server-side agent that needs to act as a user.
+"""
+
+from __future__ import annotations
+
+import uuid
+from dataclasses import dataclass, field
+from datetime import datetime
+
+
+@dataclass(frozen=True)
+class MaterializedCredential:
+    """Provider-native credential ready for the wire / in-process use.
+
+    ``access_token`` is the time-bounded part (AWS session_token, GitHub PAT).
+    For multi-part credentials (AWS), ``metadata`` carries the static parts
+    (access_key_id, secret_access_key, region, account_id) — the wire response
+    surfaces these under ``nexus_credential_metadata``.
+
+    ``__repr__`` masks ``access_token`` to keep it out of logs / tracebacks.
+    """
+
+    provider: str
+    access_token: str
+    expires_at: datetime | None
+    metadata: dict[str, str] = field(default_factory=dict)
+
+    def __repr__(self) -> str:
+        return (
+            f"MaterializedCredential(provider={self.provider!r}, "
+            f"access_token='***', expires_at={self.expires_at!r}, "
+            f"metadata_keys={sorted(self.metadata)!r})"
+        )
+
+
+# ---------------------------------------------------------------------------
+# Error taxonomy — no plaintext / token bytes ever in repr
+# ---------------------------------------------------------------------------
+
+
+class ConsumerError(Exception):
+    """Root of every CredentialConsumer error."""
+
+    def __init__(
+        self,
+        message: str,
+        *,
+        tenant_id: uuid.UUID | None = None,
+        principal_id: uuid.UUID | None = None,
+        provider: str | None = None,
+        cause: str | None = None,
+    ) -> None:
+        super().__init__(message)
+        self.tenant_id = tenant_id
+        self.principal_id = principal_id
+        self.provider = provider
+        self.cause = cause
+
+    @classmethod
+    def from_row(
+        cls,
+        *,
+        tenant_id: uuid.UUID,
+        principal_id: uuid.UUID,
+        provider: str,
+        cause: str,
+    ) -> "ConsumerError":
+        return cls(
+            f"{cls.__name__} tenant={tenant_id} principal={principal_id} "
+            f"provider={provider} cause={cause}",
+            tenant_id=tenant_id,
+            principal_id=principal_id,
+            provider=provider,
+            cause=cause,
+        )
+
+    def __repr__(self) -> str:
+        return (
+            f"{type(self).__name__}(tenant_id={self.tenant_id!s}, "
+            f"principal_id={self.principal_id!s}, provider={self.provider!r}, "
+            f"cause={self.cause!r})"
+        )
+
+
+class ProfileNotFoundForCaller(ConsumerError):
+    """Tenant/principal/provider triple has no envelope row."""
+
+
+class ProviderNotConfigured(ConsumerError):
+    """No ProviderAdapter registered for this provider name."""
+
+
+class StaleSource(ConsumerError):
+    """Envelope row's ``last_synced_at`` is past ``sync_ttl_seconds`` —
+    daemon is offline; caller should retry once daemon catches up.
+    """
+
+
+class AdapterMaterializeFailed(ConsumerError):
+    """Provider adapter raised while decoding the envelope payload."""
+
+
+# ---------------------------------------------------------------------------
+# CredentialConsumer (orchestrator) — implementation in Task 8
+# ---------------------------------------------------------------------------
+
+
+class CredentialConsumer:
+    """Implementation lands in Task 8. Type-only declaration here so other
+    modules can import the symbol without circular references.
+    """

--- a/src/nexus/bricks/auth/consumer.py
+++ b/src/nexus/bricks/auth/consumer.py
@@ -27,6 +27,13 @@ from nexus.bricks.auth.consumer_metrics import (
 
 _logger = logging.getLogger(__name__)
 
+# Mirror ResolvedCredCache's _REFRESH_HEADROOM_SECONDS — a credential whose
+# expires_at is inside this window from now is treated as already-expired
+# for the purpose of returning to the caller. Avoids handing back tokens
+# that the upstream provider will start rejecting before the client can
+# meaningfully use them.
+_MATERIALIZED_REFRESH_HEADROOM_SECONDS = 60
+
 if TYPE_CHECKING:
     from sqlalchemy.engine import Engine
 
@@ -276,7 +283,7 @@ class CredentialConsumer:
         active row exists for the triple.
         """
         import time
-        from datetime import UTC, datetime
+        from datetime import UTC, datetime, timedelta
 
         from nexus.bricks.auth.postgres_profile_store import ProfileFingerprint, ProfileNotFound
 
@@ -367,13 +374,34 @@ class CredentialConsumer:
                     # provider/account), or a bumped last_synced_at (daemon
                     # pushed a fresh envelope, possibly rotating the upstream
                     # credential). Any difference → cached plaintext is stale.
+                    cached_cred = entry.cred
+                    cached_expired = cached_cred.expires_at is not None and (
+                        cached_cred.expires_at
+                        <= now + timedelta(seconds=_MATERIALIZED_REFRESH_HEADROOM_SECONDS)
+                    )
                     if (
                         fp_pre.profile_id != cached_fp.profile_id
                         or fp_pre.writer_machine_id != cached_fp.writer_machine_id
                         or fp_pre.last_synced_at != cached_fp.last_synced_at
+                        or cached_expired
                     ):
+                        # Row rewrite OR the cached materialized credential's
+                        # own expiry has caught up to the refresh-headroom.
+                        # Evict and fall through to the decrypt path so we
+                        # serve a fresh credential (or surface StaleSource
+                        # if the underlying envelope is also stale).
                         self._cred_cache.evict(cache_key)
                     else:
+                        # F25: re-check daemon revocation right before the
+                        # response. The first assert_machine_active was at
+                        # the top of resolve; a revoke that committed in
+                        # the gap between that check and here would
+                        # otherwise be missed and this cache hit would hand
+                        # back a credential to a now-revoked daemon.
+                        self._get_store(claims).assert_machine_active(
+                            principal_id=claims.principal_id,
+                            machine_id=claims.machine_id,
+                        )
                         # Cache hit — log sampled audit row, no decrypt.
                         cache_label = "hit"
                         self._audit.write(
@@ -387,7 +415,7 @@ class CredentialConsumer:
                             cache_hit=True,
                             kek_version=cached_fp.kek_version,
                         )
-                        return entry.cred
+                        return cached_cred
 
             try:
                 decrypted = self._get_store(claims).decrypt_profile(
@@ -424,6 +452,38 @@ class CredentialConsumer:
                 writer_machine_id=decrypted.writer_machine_id,
                 claims=claims,
                 provider=provider,
+            )
+
+            # The materialized credential's own expires_at is independent of
+            # last_synced_at: AWS STS could mint a 15-min token that's
+            # already past mid-life by the time the daemon pushed it, and
+            # fine-grained PATs may carry an explicit expiry that's already
+            # in the refresh-headroom window. Returning ``expires_in: 0`` to
+            # the caller would cause downstream 401 loops instead of a
+            # deterministic refresh signal — fail closed with StaleSource so
+            # the daemon re-pushes a fresh credential before we serve it.
+            if materialized.expires_at is not None:
+                refresh_deadline = now + timedelta(seconds=_MATERIALIZED_REFRESH_HEADROOM_SECONDS)
+                if materialized.expires_at <= refresh_deadline:
+                    raise StaleSource.from_row(
+                        tenant_id=claims.tenant_id,
+                        principal_id=claims.principal_id,
+                        provider=provider,
+                        cause="materialized_credential_expired_or_near_expiry",
+                    )
+
+            # F25: Double-check machine_active immediately before audit/cache.
+            # The first assert_machine_active was at the top of resolve;
+            # between that and here we held no lock while running KMS
+            # unwrap_dek (potentially hundreds of ms for AWS KMS / Vault).
+            # A revoke that committed in that window would otherwise be
+            # missed and the daemon would receive one more upstream
+            # credential after revocation. This second check shrinks the
+            # race to the (microsecond) gap between the SELECT and the
+            # JSONResponse send.
+            self._get_store(claims).assert_machine_active(
+                principal_id=claims.principal_id,
+                machine_id=claims.machine_id,
             )
 
             # IMPORTANT: write audit BEFORE caching so a failed mandatory

--- a/src/nexus/bricks/auth/consumer.py
+++ b/src/nexus/bricks/auth/consumer.py
@@ -221,6 +221,43 @@ class CredentialConsumer:
             engine=self._engine,
         )
 
+    def _enforce_cross_machine(
+        self,
+        *,
+        writer_machine_id: "uuid.UUID | None",
+        claims: "DaemonClaims",
+        provider: str,
+    ) -> None:
+        """Reject cross-machine reads unless the operator opted in.
+
+        Raises ``MachineUnknownOrRevoked(cross_machine_read_disallowed)``
+        when reader != writer and ``NEXUS_AUTH_ALLOW_CROSS_MACHINE_READ``
+        is not enabled. Always logs + metrics on cross-machine reads
+        (allowed or denied) so implicit sharing is visible.
+        """
+        if writer_machine_id is None or writer_machine_id == claims.machine_id:
+            return
+        _logger.warning(
+            "cross_machine_read tenant=%s principal=%s provider=%s reader=%s writer=%s",
+            claims.tenant_id,
+            claims.principal_id,
+            provider,
+            claims.machine_id,
+            writer_machine_id,
+        )
+        CROSS_MACHINE_READS.labels(provider=provider).inc()
+        if os.environ.get("NEXUS_AUTH_ALLOW_CROSS_MACHINE_READ", "").lower() not in (
+            "1",
+            "true",
+            "yes",
+        ):
+            raise MachineUnknownOrRevoked.from_row(
+                tenant_id=claims.tenant_id,
+                principal_id=claims.principal_id,
+                provider=provider,
+                cause="cross_machine_read_disallowed",
+            )
+
     def resolve(
         self,
         *,
@@ -230,9 +267,9 @@ class CredentialConsumer:
         force_refresh: bool = False,
     ) -> MaterializedCredential:
         import time
-        from datetime import UTC, datetime, timedelta
+        from datetime import UTC, datetime
 
-        from nexus.bricks.auth.postgres_profile_store import ProfileNotFound
+        from nexus.bricks.auth.postgres_profile_store import ProfileFingerprint, ProfileNotFound
 
         start = time.monotonic()
         cache_label = "miss"
@@ -270,51 +307,54 @@ class CredentialConsumer:
                 machine_id=claims.machine_id,
             )
 
+            # All policy gates run BEFORE decrypt. Without this order, a
+            # disallowed cross-machine read or a stale row would still
+            # cause the server to KMS-unwrap the DEK and AES-GCM decrypt
+            # the payload — pulling another daemon's plaintext into
+            # process memory just to throw it away. Move stale + cross-
+            # machine to the front so the rejection happens against
+            # ciphertext + indexed metadata only.
+            try:
+                fp_pre = self._get_store(claims).assert_profile_active(
+                    principal_id=claims.principal_id,
+                    provider=provider,
+                )
+            except ProfileNotFound as exc:
+                # Cache may have an entry pointing at the now-missing row.
+                self._cred_cache.evict(cache_key)
+                raise ProfileNotFoundForCaller.from_row(
+                    tenant_id=claims.tenant_id,
+                    principal_id=claims.principal_id,
+                    provider=provider,
+                    cause="no_active_profile",
+                ) from exc
+            except (MultipleProfilesForProvider, StaleSource):
+                # Either condition invalidates whatever was cached; evict
+                # before bubbling so the next request goes through the
+                # full miss path against any new state.
+                self._cred_cache.evict(cache_key)
+                raise
+
+            self._enforce_cross_machine(
+                writer_machine_id=fp_pre.writer_machine_id,
+                claims=claims,
+                provider=provider,
+            )
+
             if not force_refresh:
                 entry = self._cred_cache.get(cache_key, now=now)
                 if entry is not None:
-                    # Cache hit must STILL re-check profile state — operator
-                    # disable, automatic cooldown, freshly-pushed ambiguous
-                    # second envelope, stale source, OR a row rewrite by a
-                    # different daemon all need to take effect within ms
-                    # instead of waiting for the cache TTL. The check is one
-                    # indexed query (COUNT FILTER + LIMIT 1); no decrypt,
-                    # no payload read.
-                    try:
-                        current = self._get_store(claims).assert_profile_active(
-                            principal_id=claims.principal_id,
-                            provider=provider,
-                        )
-                    except ProfileNotFound as exc:
-                        self._cred_cache.evict(cache_key)
-                        raise ProfileNotFoundForCaller.from_row(
-                            tenant_id=claims.tenant_id,
-                            principal_id=claims.principal_id,
-                            provider=provider,
-                            cause="profile_disabled_or_cooldown",
-                        ) from exc
-                    except (MultipleProfilesForProvider, StaleSource):
-                        # Stale source on a warm cache means the daemon
-                        # stopped pushing for longer than sync_ttl_seconds —
-                        # serving the cached plaintext would mask a stuck
-                        # daemon. Evict + propagate so the router 409s.
-                        self._cred_cache.evict(cache_key)
-                        raise
-
                     cached_fp = entry.fingerprint
                     # Detect a row rewrite since the cache was primed: a
                     # different profile_id (deleted + replaced), a different
                     # writer machine (another daemon overwrote the same
                     # provider/account), or a bumped last_synced_at (daemon
                     # pushed a fresh envelope, possibly rotating the upstream
-                    # credential). Any difference → cached plaintext is stale
-                    # AND the cross-machine read policy must be re-evaluated
-                    # against the new writer. Evict + fall through to the
-                    # decrypt path which re-applies all policy gates.
+                    # credential). Any difference → cached plaintext is stale.
                     if (
-                        current.profile_id != cached_fp.profile_id
-                        or current.writer_machine_id != cached_fp.writer_machine_id
-                        or current.last_synced_at != cached_fp.last_synced_at
+                        fp_pre.profile_id != cached_fp.profile_id
+                        or fp_pre.writer_machine_id != cached_fp.writer_machine_id
+                        or fp_pre.last_synced_at != cached_fp.last_synced_at
                     ):
                         self._cred_cache.evict(cache_key)
                     else:
@@ -348,16 +388,6 @@ class CredentialConsumer:
                     cause="no_envelope_row",
                 ) from exc
 
-            # Stale-source check: last_synced_at + sync_ttl must be in the future.
-            ttl_window = timedelta(seconds=decrypted.sync_ttl_seconds)
-            if decrypted.last_synced_at + ttl_window < now:
-                raise StaleSource.from_row(
-                    tenant_id=claims.tenant_id,
-                    principal_id=claims.principal_id,
-                    provider=provider,
-                    cause=f"last_synced_at_age={int((now - decrypted.last_synced_at).total_seconds())}s",
-                )
-
             try:
                 materialized = adapter.materialize(decrypted.plaintext)
             except (ValueError, KeyError) as exc:
@@ -368,38 +398,16 @@ class CredentialConsumer:
                     cause=f"{type(exc).__name__}",
                 ) from exc
 
-            # Cross-machine read enforcement: by default the daemon that
-            # reads must be the same daemon that pushed the envelope. A
-            # compromised secondary daemon for the same principal could
-            # otherwise exchange another machine's GitHub PAT or AWS keys
-            # without an explicit sharing grant. Operators with legitimate
-            # fleet patterns (CI runners, multi-bot deployments) can opt
-            # out via NEXUS_AUTH_ALLOW_CROSS_MACHINE_READ=1; we still log
-            # + metric so the implicit sharing is visible.
-            if (
-                decrypted.writer_machine_id is not None
-                and decrypted.writer_machine_id != claims.machine_id
-            ):
-                _logger.warning(
-                    "cross_machine_read tenant=%s principal=%s provider=%s reader=%s writer=%s",
-                    claims.tenant_id,
-                    claims.principal_id,
-                    provider,
-                    claims.machine_id,
-                    decrypted.writer_machine_id,
-                )
-                CROSS_MACHINE_READS.labels(provider=provider).inc()
-                if os.environ.get("NEXUS_AUTH_ALLOW_CROSS_MACHINE_READ", "").lower() not in (
-                    "1",
-                    "true",
-                    "yes",
-                ):
-                    raise MachineUnknownOrRevoked.from_row(
-                        tenant_id=claims.tenant_id,
-                        principal_id=claims.principal_id,
-                        provider=provider,
-                        cause="cross_machine_read_disallowed",
-                    )
+            # Defense-in-depth: re-apply cross-machine policy against the
+            # decrypted row's writer_machine_id. Catches the (rare) race
+            # where the row was rewritten between assert_profile_active
+            # and decrypt_profile — the pre-check passed against the OLD
+            # writer but the row we actually decrypted has a different one.
+            self._enforce_cross_machine(
+                writer_machine_id=decrypted.writer_machine_id,
+                claims=claims,
+                provider=provider,
+            )
 
             # IMPORTANT: write audit BEFORE caching so a failed mandatory
             # cache-miss audit doesn't poison the cache. Without this order,
@@ -417,7 +425,6 @@ class CredentialConsumer:
                 cache_hit=False,
                 kek_version=decrypted.kek_version,
             )
-            from nexus.bricks.auth.postgres_profile_store import ProfileFingerprint
 
             self._cred_cache.put(
                 cache_key,

--- a/src/nexus/bricks/auth/consumer.py
+++ b/src/nexus/bricks/auth/consumer.py
@@ -264,8 +264,17 @@ class CredentialConsumer:
         claims: "DaemonClaims",
         provider: str,
         purpose: str,
+        profile_id: str | None = None,
         force_refresh: bool = False,
     ) -> MaterializedCredential:
+        """Resolve a provider credential for ``claims``.
+
+        ``profile_id`` selects a specific envelope row when the principal has
+        more than one profile for ``provider`` (e.g. two GitHub accounts).
+        Without it, the call falls back to the legacy "single active row"
+        contract and raises ``MultipleProfilesForProvider`` if more than one
+        active row exists for the triple.
+        """
         import time
         from datetime import UTC, datetime
 
@@ -290,11 +299,17 @@ class CredentialConsumer:
             # passes assert_machine_active + assert_profile_active and gets
             # A's plaintext from cache without ever reaching the
             # writer_machine_id check on the decrypt path.
+            #
+            # profile_id is in the key so a multi-account principal's two
+            # profiles do not share a cache slot — also keeps the implicit
+            # "default" form (profile_id=None) separate from any explicit
+            # selection of the same row.
             cache_key = (
                 str(claims.tenant_id),
                 str(claims.principal_id),
                 provider,
                 str(claims.machine_id),
+                profile_id or "",
             )
             now = datetime.now(UTC)
 
@@ -318,6 +333,7 @@ class CredentialConsumer:
                 fp_pre = self._get_store(claims).assert_profile_active(
                     principal_id=claims.principal_id,
                     provider=provider,
+                    profile_id=profile_id,
                 )
             except ProfileNotFound as exc:
                 # Cache may have an entry pointing at the now-missing row.
@@ -377,6 +393,7 @@ class CredentialConsumer:
                 decrypted = self._get_store(claims).decrypt_profile(
                     principal_id=claims.principal_id,
                     provider=provider,
+                    profile_id=profile_id,
                     encryption=self._encryption,
                     dek_cache=self._dek_cache,
                 )

--- a/src/nexus/bricks/auth/consumer.py
+++ b/src/nexus/bricks/auth/consumer.py
@@ -125,6 +125,28 @@ class AdapterMaterializeFailed(ConsumerError):
     """Provider adapter raised while decoding the envelope payload."""
 
 
+class MachineUnknownOrRevoked(ConsumerError):
+    """Daemon machine row absent or has revoked_at set.
+
+    Distinct from a JWT verification failure — the JWT is cryptographically
+    valid but the daemon has been revoked (or its row deleted) since the
+    token was issued. Router maps this to 401 invalid_token so a compromised
+    daemon stops minting upstream creds the moment its row is revoked.
+    """
+
+
+class MultipleProfilesForProvider(ConsumerError):
+    """More than one envelope row exists for (tenant, principal, provider).
+
+    The wire contract today maps ``resource=urn:nexus:provider:<name>`` to a
+    single provider name with no profile_id discriminator, so we cannot
+    deterministically pick one row. Fail closed instead of silently picking
+    the most-recently-updated row, which could hand back the wrong account's
+    credentials. Operators must collapse to one active envelope per provider
+    or upgrade the wire contract.
+    """
+
+
 # ---------------------------------------------------------------------------
 # CredentialConsumer (orchestrator) — implementation in Task 8
 # ---------------------------------------------------------------------------
@@ -216,6 +238,15 @@ class CredentialConsumer:
             )
             now = datetime.now(UTC)
 
+            # Revocation gate (BEFORE cache lookup): a JWT minted before the
+            # daemon row was revoked must not keep handing out cached
+            # credentials until natural expiry. Per-request indexed lookup —
+            # one row, one column, one ms.
+            self._get_store(claims).assert_machine_active(
+                principal_id=claims.principal_id,
+                machine_id=claims.machine_id,
+            )
+
             if not force_refresh:
                 cached = self._cred_cache.get(cache_key, now=now)
                 if cached is not None:
@@ -283,8 +314,11 @@ class CredentialConsumer:
             )
             return materialized
 
-        except (ProfileNotFoundForCaller, ProviderNotConfigured):
+        except (ProfileNotFoundForCaller, ProviderNotConfigured, MachineUnknownOrRevoked):
             result_label = "denied"
+            raise
+        except MultipleProfilesForProvider:
+            result_label = "ambiguous"
             raise
         except StaleSource:
             result_label = "stale"

--- a/src/nexus/bricks/auth/consumer.py
+++ b/src/nexus/bricks/auth/consumer.py
@@ -13,6 +13,7 @@ server-side agent that needs to act as a user.
 from __future__ import annotations
 
 import logging
+import os
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -265,6 +266,29 @@ class CredentialConsumer:
             if not force_refresh:
                 cached = self._cred_cache.get(cache_key, now=now)
                 if cached is not None:
+                    # Cache hit must STILL re-check profile state — operator
+                    # disable, automatic cooldown, or a freshly-pushed second
+                    # ambiguous envelope must take effect within ms instead
+                    # of waiting for the cache TTL. The check is one indexed
+                    # COUNT(*), no decrypt, no payload read. Failure evicts
+                    # the cache entry and bubbles up.
+                    try:
+                        self._get_store(claims).assert_profile_active(
+                            principal_id=claims.principal_id,
+                            provider=provider,
+                        )
+                    except ProfileNotFound as exc:
+                        self._cred_cache.evict(cache_key)
+                        raise ProfileNotFoundForCaller.from_row(
+                            tenant_id=claims.tenant_id,
+                            principal_id=claims.principal_id,
+                            provider=provider,
+                            cause="profile_disabled_or_cooldown",
+                        ) from exc
+                    except MultipleProfilesForProvider:
+                        self._cred_cache.evict(cache_key)
+                        raise
+
                     # Cache hit — log sampled audit row, no decrypt
                     cache_label = "hit"
                     self._audit.write(
@@ -315,19 +339,20 @@ class CredentialConsumer:
                     cause=f"{type(exc).__name__}",
                 ) from exc
 
-            # Cross-machine read detection: this daemon reads a credential
-            # pushed by a different daemon (same principal, different machine).
-            # Allowed today (no explicit sharing model in the wire contract)
-            # but operationally suspicious — log + metric so operators can
-            # detect implicit sharing. A future enforcement flag can flip
-            # this from log-warning to fail-closed without API changes.
+            # Cross-machine read enforcement: by default the daemon that
+            # reads must be the same daemon that pushed the envelope. A
+            # compromised secondary daemon for the same principal could
+            # otherwise exchange another machine's GitHub PAT or AWS keys
+            # without an explicit sharing grant. Operators with legitimate
+            # fleet patterns (CI runners, multi-bot deployments) can opt
+            # out via NEXUS_AUTH_ALLOW_CROSS_MACHINE_READ=1; we still log
+            # + metric so the implicit sharing is visible.
             if (
                 decrypted.writer_machine_id is not None
                 and decrypted.writer_machine_id != claims.machine_id
             ):
                 _logger.warning(
-                    "cross_machine_read tenant=%s principal=%s provider=%s "
-                    "reader=%s writer=%s — implicit credential sharing across daemons",
+                    "cross_machine_read tenant=%s principal=%s provider=%s reader=%s writer=%s",
                     claims.tenant_id,
                     claims.principal_id,
                     provider,
@@ -335,6 +360,17 @@ class CredentialConsumer:
                     decrypted.writer_machine_id,
                 )
                 CROSS_MACHINE_READS.labels(provider=provider).inc()
+                if os.environ.get("NEXUS_AUTH_ALLOW_CROSS_MACHINE_READ", "").lower() not in (
+                    "1",
+                    "true",
+                    "yes",
+                ):
+                    raise MachineUnknownOrRevoked.from_row(
+                        tenant_id=claims.tenant_id,
+                        principal_id=claims.principal_id,
+                        provider=provider,
+                        cause="cross_machine_read_disallowed",
+                    )
 
             # IMPORTANT: write audit BEFORE caching so a failed mandatory
             # cache-miss audit doesn't poison the cache. Without this order,

--- a/src/nexus/bricks/auth/consumer.py
+++ b/src/nexus/bricks/auth/consumer.py
@@ -271,16 +271,17 @@ class CredentialConsumer:
             )
 
             if not force_refresh:
-                cached = self._cred_cache.get(cache_key, now=now)
-                if cached is not None:
+                entry = self._cred_cache.get(cache_key, now=now)
+                if entry is not None:
                     # Cache hit must STILL re-check profile state — operator
-                    # disable, automatic cooldown, or a freshly-pushed second
-                    # ambiguous envelope must take effect within ms instead
-                    # of waiting for the cache TTL. The check is one indexed
-                    # COUNT(*), no decrypt, no payload read. Failure evicts
-                    # the cache entry and bubbles up.
+                    # disable, automatic cooldown, freshly-pushed ambiguous
+                    # second envelope, stale source, OR a row rewrite by a
+                    # different daemon all need to take effect within ms
+                    # instead of waiting for the cache TTL. The check is one
+                    # indexed query (COUNT FILTER + LIMIT 1); no decrypt,
+                    # no payload read.
                     try:
-                        self._get_store(claims).assert_profile_active(
+                        current = self._get_store(claims).assert_profile_active(
                             principal_id=claims.principal_id,
                             provider=provider,
                         )
@@ -300,20 +301,37 @@ class CredentialConsumer:
                         self._cred_cache.evict(cache_key)
                         raise
 
-                    # Cache hit — log sampled audit row, no decrypt
-                    cache_label = "hit"
-                    self._audit.write(
-                        tenant_id=claims.tenant_id,
-                        principal_id=claims.principal_id,
-                        auth_profile_id="cached",
-                        caller_machine_id=claims.machine_id,
-                        caller_kind="daemon",
-                        provider=provider,
-                        purpose=purpose,
-                        cache_hit=True,
-                        kek_version=0,  # unknown on cache hit; sentinel value
-                    )
-                    return cached
+                    cached_fp = entry.fingerprint
+                    # Detect a row rewrite since the cache was primed: a
+                    # different profile_id (deleted + replaced), a different
+                    # writer machine (another daemon overwrote the same
+                    # provider/account), or a bumped last_synced_at (daemon
+                    # pushed a fresh envelope, possibly rotating the upstream
+                    # credential). Any difference → cached plaintext is stale
+                    # AND the cross-machine read policy must be re-evaluated
+                    # against the new writer. Evict + fall through to the
+                    # decrypt path which re-applies all policy gates.
+                    if (
+                        current.profile_id != cached_fp.profile_id
+                        or current.writer_machine_id != cached_fp.writer_machine_id
+                        or current.last_synced_at != cached_fp.last_synced_at
+                    ):
+                        self._cred_cache.evict(cache_key)
+                    else:
+                        # Cache hit — log sampled audit row, no decrypt.
+                        cache_label = "hit"
+                        self._audit.write(
+                            tenant_id=claims.tenant_id,
+                            principal_id=claims.principal_id,
+                            auth_profile_id=cached_fp.profile_id,
+                            caller_machine_id=claims.machine_id,
+                            caller_kind="daemon",
+                            provider=provider,
+                            purpose=purpose,
+                            cache_hit=True,
+                            kek_version=cached_fp.kek_version,
+                        )
+                        return entry.cred
 
             try:
                 decrypted = self._get_store(claims).decrypt_profile(
@@ -399,7 +417,19 @@ class CredentialConsumer:
                 cache_hit=False,
                 kek_version=decrypted.kek_version,
             )
-            self._cred_cache.put(cache_key, materialized, now=now)
+            from nexus.bricks.auth.postgres_profile_store import ProfileFingerprint
+
+            self._cred_cache.put(
+                cache_key,
+                materialized,
+                now=now,
+                fingerprint=ProfileFingerprint(
+                    profile_id=decrypted.profile_id,
+                    writer_machine_id=decrypted.writer_machine_id,
+                    kek_version=decrypted.kek_version,
+                    last_synced_at=decrypted.last_synced_at,
+                ),
+            )
             return materialized
 
         except (ProfileNotFoundForCaller, ProviderNotConfigured, MachineUnknownOrRevoked):

--- a/src/nexus/bricks/auth/consumer_cache.py
+++ b/src/nexus/bricks/auth/consumer_cache.py
@@ -4,9 +4,12 @@ Holds plaintext access_tokens in memory bounded by both a ceiling (default
 300s, matching DEKCache) and the upstream credential's own ``expires_at``.
 This caps plaintext lifetime regardless of which bound triggers first.
 
-Keyed by ``(tenant_id_str, principal_id_str, provider)``. Tenant in the key
-is belt-and-braces against any future bug that forgets to ``SET LOCAL
-app.current_tenant`` before calling the consumer.
+Keyed by ``(tenant_id_str, principal_id_str, provider, machine_id_str)``.
+Tenant in the key is belt-and-braces against any future bug that forgets
+to ``SET LOCAL app.current_tenant`` before calling the consumer. Machine
+id in the key keeps each daemon's view isolated so a warm cache cannot
+hand back another machine's plaintext, which would silently bypass the
+cross-machine read check that only fires on the decrypt path.
 """
 
 from __future__ import annotations
@@ -52,12 +55,12 @@ class ResolvedCredCache:
     def __init__(self, *, ceiling_seconds: int = 300, max_entries: int = 1024) -> None:
         self._ceiling = ceiling_seconds
         self._max = max_entries
-        self._store: OrderedDict[tuple[str, str, str], _Entry] = OrderedDict()
+        self._store: OrderedDict[tuple[str, str, str, str], _Entry] = OrderedDict()
         self._lock = threading.Lock()
 
     def get(
         self,
-        key: tuple[str, str, str],
+        key: tuple[str, str, str, str],
         *,
         now: datetime,
     ) -> MaterializedCredential | None:
@@ -74,7 +77,7 @@ class ResolvedCredCache:
 
     def put(
         self,
-        key: tuple[str, str, str],
+        key: tuple[str, str, str, str],
         cred: MaterializedCredential,
         *,
         now: datetime,
@@ -92,7 +95,7 @@ class ResolvedCredCache:
             while len(self._store) > self._max:
                 self._store.popitem(last=False)
 
-    def evict(self, key: tuple[str, str, str]) -> None:
+    def evict(self, key: tuple[str, str, str, str]) -> None:
         """Drop an entry. Called by the consumer when a cache-hit state check
         finds the underlying profile is no longer usable (disabled, cooldown,
         or ambiguous), so the next request goes through the full miss path

--- a/src/nexus/bricks/auth/consumer_cache.py
+++ b/src/nexus/bricks/auth/consumer_cache.py
@@ -4,12 +4,16 @@ Holds plaintext access_tokens in memory bounded by both a ceiling (default
 300s, matching DEKCache) and the upstream credential's own ``expires_at``.
 This caps plaintext lifetime regardless of which bound triggers first.
 
-Keyed by ``(tenant_id_str, principal_id_str, provider, machine_id_str)``.
-Tenant in the key is belt-and-braces against any future bug that forgets
-to ``SET LOCAL app.current_tenant`` before calling the consumer. Machine
-id in the key keeps each daemon's view isolated so a warm cache cannot
-hand back another machine's plaintext, which would silently bypass the
-cross-machine read check that only fires on the decrypt path.
+Keyed by ``(tenant_id_str, principal_id_str, provider, machine_id_str,
+profile_id_str)`` where ``profile_id_str`` is the wire-contract selector
+or ``""`` for the default-profile form. Tenant in the key is belt-and-
+braces against any future bug that forgets to ``SET LOCAL
+app.current_tenant`` before calling the consumer. Machine id in the key
+keeps each daemon's view isolated so a warm cache cannot hand back
+another machine's plaintext, which would silently bypass the cross-
+machine read check that only fires on the decrypt path. Profile id in
+the key keeps a multi-account principal's two profiles (e.g. two GitHub
+accounts) from sharing a slot.
 """
 
 from __future__ import annotations
@@ -62,12 +66,12 @@ class ResolvedCredCache:
     def __init__(self, *, ceiling_seconds: int = 300, max_entries: int = 1024) -> None:
         self._ceiling = ceiling_seconds
         self._max = max_entries
-        self._store: OrderedDict[tuple[str, str, str, str], _Entry] = OrderedDict()
+        self._store: OrderedDict[tuple[str, str, str, str, str], _Entry] = OrderedDict()
         self._lock = threading.Lock()
 
     def get(
         self,
-        key: tuple[str, str, str, str],
+        key: tuple[str, str, str, str, str],
         *,
         now: datetime,
     ) -> _Entry | None:
@@ -89,7 +93,7 @@ class ResolvedCredCache:
 
     def put(
         self,
-        key: tuple[str, str, str, str],
+        key: tuple[str, str, str, str, str],
         cred: MaterializedCredential,
         *,
         now: datetime,
@@ -109,7 +113,7 @@ class ResolvedCredCache:
             while len(self._store) > self._max:
                 self._store.popitem(last=False)
 
-    def evict(self, key: tuple[str, str, str, str]) -> None:
+    def evict(self, key: tuple[str, str, str, str, str]) -> None:
         """Drop an entry. Called by the consumer when a cache-hit state check
         finds the underlying profile is no longer usable (disabled, cooldown,
         or ambiguous), so the next request goes through the full miss path

--- a/src/nexus/bricks/auth/consumer_cache.py
+++ b/src/nexus/bricks/auth/consumer_cache.py
@@ -20,6 +20,7 @@ from dataclasses import dataclass
 from datetime import datetime
 
 from nexus.bricks.auth.consumer import MaterializedCredential
+from nexus.bricks.auth.postgres_profile_store import ProfileFingerprint
 
 _REFRESH_HEADROOM_SECONDS = 60
 
@@ -43,6 +44,12 @@ def _compute_ttl_seconds(*, now: datetime, expires_at: datetime | None) -> int:
 class _Entry:
     cred: MaterializedCredential
     expires_at_monotonic: float
+    # Identity of the source row at the time we cached. The cache-hit branch
+    # in CredentialConsumer compares this against the current row's fingerprint
+    # so a rewrite (different profile_id, different writer machine, or bumped
+    # last_synced_at) evicts and re-runs the decrypt path — which re-applies
+    # the cross-machine read policy against the NEW writer.
+    fingerprint: ProfileFingerprint
 
 
 class ResolvedCredCache:
@@ -63,7 +70,12 @@ class ResolvedCredCache:
         key: tuple[str, str, str, str],
         *,
         now: datetime,
-    ) -> MaterializedCredential | None:
+    ) -> _Entry | None:
+        """Return the full entry (credential + cached fingerprint) or None.
+
+        Returning the entry rather than just the credential lets the caller
+        compare cached vs current ``ProfileFingerprint`` and evict on rewrite.
+        """
         now_ts = now.timestamp()
         with self._lock:
             entry = self._store.get(key)
@@ -73,7 +85,7 @@ class ResolvedCredCache:
                 self._store.pop(key, None)
                 return None
             self._store.move_to_end(key)
-            return entry.cred
+            return entry
 
     def put(
         self,
@@ -81,6 +93,7 @@ class ResolvedCredCache:
         cred: MaterializedCredential,
         *,
         now: datetime,
+        fingerprint: ProfileFingerprint,
     ) -> None:
         ttl = min(
             self._ceiling,
@@ -90,6 +103,7 @@ class ResolvedCredCache:
             self._store[key] = _Entry(
                 cred=cred,
                 expires_at_monotonic=now.timestamp() + ttl,
+                fingerprint=fingerprint,
             )
             self._store.move_to_end(key)
             while len(self._store) > self._max:

--- a/src/nexus/bricks/auth/consumer_cache.py
+++ b/src/nexus/bricks/auth/consumer_cache.py
@@ -91,3 +91,11 @@ class ResolvedCredCache:
             self._store.move_to_end(key)
             while len(self._store) > self._max:
                 self._store.popitem(last=False)
+
+    def evict(self, key: tuple[str, str, str]) -> None:
+        """Drop an entry. Called by the consumer when a cache-hit state check
+        finds the underlying profile is no longer usable (disabled, cooldown,
+        or ambiguous), so the next request goes through the full miss path
+        instead of returning the stale cached credential."""
+        with self._lock:
+            self._store.pop(key, None)

--- a/src/nexus/bricks/auth/consumer_cache.py
+++ b/src/nexus/bricks/auth/consumer_cache.py
@@ -1,0 +1,93 @@
+"""ResolvedCredCache: TTL = min(ceiling, expires_at - 60s).
+
+Holds plaintext access_tokens in memory bounded by both a ceiling (default
+300s, matching DEKCache) and the upstream credential's own ``expires_at``.
+This caps plaintext lifetime regardless of which bound triggers first.
+
+Keyed by ``(tenant_id_str, principal_id_str, provider)``. Tenant in the key
+is belt-and-braces against any future bug that forgets to ``SET LOCAL
+app.current_tenant`` before calling the consumer.
+"""
+
+from __future__ import annotations
+
+import threading
+from collections import OrderedDict
+from dataclasses import dataclass
+from datetime import datetime
+
+from nexus.bricks.auth.consumer import MaterializedCredential
+
+_REFRESH_HEADROOM_SECONDS = 60
+
+
+def _compute_ttl_seconds(*, now: datetime, expires_at: datetime | None) -> int:
+    """TTL = min(ceiling, expires_at - 60s). Clamped to >= 0.
+
+    The 60s headroom means we evict before the upstream cred actually expires,
+    so callers never see a 401 from the upstream provider mid-call.
+
+    Ceiling is applied by the caller (``ResolvedCredCache.put``) — this helper
+    only computes the expires-at-bound. Returns the smaller of the two there.
+    """
+    if expires_at is None:
+        return 10**9  # effectively unbounded; ceiling will dominate
+    delta = (expires_at - now).total_seconds() - _REFRESH_HEADROOM_SECONDS
+    return max(0, int(delta))
+
+
+@dataclass(frozen=True)
+class _Entry:
+    cred: MaterializedCredential
+    expires_at_monotonic: float
+
+
+class ResolvedCredCache:
+    """Thread-safe TTL+LRU for MaterializedCredentials.
+
+    Tests inject ``now`` for determinism; production calls pass
+    ``datetime.now(UTC)``.
+    """
+
+    def __init__(self, *, ceiling_seconds: int = 300, max_entries: int = 1024) -> None:
+        self._ceiling = ceiling_seconds
+        self._max = max_entries
+        self._store: OrderedDict[tuple[str, str, str], _Entry] = OrderedDict()
+        self._lock = threading.Lock()
+
+    def get(
+        self,
+        key: tuple[str, str, str],
+        *,
+        now: datetime,
+    ) -> MaterializedCredential | None:
+        now_ts = now.timestamp()
+        with self._lock:
+            entry = self._store.get(key)
+            if entry is None:
+                return None
+            if now_ts >= entry.expires_at_monotonic:
+                self._store.pop(key, None)
+                return None
+            self._store.move_to_end(key)
+            return entry.cred
+
+    def put(
+        self,
+        key: tuple[str, str, str],
+        cred: MaterializedCredential,
+        *,
+        now: datetime,
+    ) -> None:
+        ttl = min(
+            self._ceiling,
+            _compute_ttl_seconds(now=now, expires_at=cred.expires_at),
+        )
+        with self._lock:
+            self._store[key] = _Entry(
+                cred=cred,
+                expires_at_monotonic=now.timestamp() + ttl,
+            )
+            self._store.move_to_end(key)
+            while len(self._store) > self._max:
+                self._store.popitem(last=False)

--- a/src/nexus/bricks/auth/consumer_metrics.py
+++ b/src/nexus/bricks/auth/consumer_metrics.py
@@ -39,3 +39,13 @@ READ_AUDIT_WRITES = Counter(
     "Auth-profile-read audit rows written",
     labelnames=("cache",),
 )
+
+CROSS_MACHINE_READS = Counter(
+    "nexus_cross_machine_reads_total",
+    (
+        "Reads where the caller daemon's machine_id differs from the daemon "
+        "that pushed the envelope. Implicit credential sharing — operators "
+        "should investigate whether intentional or a stale/compromised daemon."
+    ),
+    labelnames=("provider",),
+)

--- a/src/nexus/bricks/auth/consumer_metrics.py
+++ b/src/nexus/bricks/auth/consumer_metrics.py
@@ -1,0 +1,41 @@
+"""Prometheus metrics for the read path (#3818).
+
+Low-cardinality labels only:
+  - provider ∈ {aws, github}
+  - result ∈ {ok, stale, denied, invalid_token, envelope_error}
+  - cache ∈ {hit, miss}
+  - reason (cache evictions) ∈ {ttl, lru, expires_at}
+"""
+
+from __future__ import annotations
+
+from prometheus_client import Counter, Gauge, Histogram
+
+TOKEN_EXCHANGE_REQUESTS = Counter(
+    "nexus_token_exchange_requests_total",
+    "RFC 8693 token-exchange requests by outcome",
+    labelnames=("provider", "result"),
+)
+
+TOKEN_EXCHANGE_LATENCY = Histogram(
+    "nexus_token_exchange_latency_seconds",
+    "Latency of /v1/auth/token-exchange end-to-end",
+    labelnames=("provider", "cache"),
+)
+
+CONSUMER_CACHE_SIZE = Gauge(
+    "nexus_consumer_cache_size",
+    "Current entries in ResolvedCredCache",
+)
+
+CONSUMER_CACHE_EVICTIONS = Counter(
+    "nexus_consumer_cache_evictions_total",
+    "ResolvedCredCache evictions by reason",
+    labelnames=("reason",),
+)
+
+READ_AUDIT_WRITES = Counter(
+    "nexus_read_audit_writes_total",
+    "Auth-profile-read audit rows written",
+    labelnames=("cache",),
+)

--- a/src/nexus/bricks/auth/consumer_providers/__init__.py
+++ b/src/nexus/bricks/auth/consumer_providers/__init__.py
@@ -1,0 +1,21 @@
+"""Provider adapter registry. Updated by each adapter task."""
+
+from __future__ import annotations
+
+from nexus.bricks.auth.consumer_providers.base import ProviderAdapter
+
+
+def default_adapters() -> dict[str, ProviderAdapter]:
+    """Return the adapter registry used by CredentialConsumer.
+
+    Adapters are imported lazily so missing optional deps (e.g. AWS payload
+    parsing only needs stdlib ``json``, but future providers may need boto3)
+    don't cascade-break unrelated code paths.
+    """
+    from nexus.bricks.auth.consumer_providers.aws import AwsProviderAdapter
+    from nexus.bricks.auth.consumer_providers.github import GithubProviderAdapter
+
+    return {
+        AwsProviderAdapter.name: AwsProviderAdapter(),
+        GithubProviderAdapter.name: GithubProviderAdapter(),
+    }

--- a/src/nexus/bricks/auth/consumer_providers/aws.py
+++ b/src/nexus/bricks/auth/consumer_providers/aws.py
@@ -1,0 +1,53 @@
+"""AWS provider adapter — daemon-pushed STS payload → MaterializedCredential (#3818).
+
+Payload shape (JSON, daemon-pushed by aws sso login / aws sts get-caller-identity):
+    {
+      "access_key_id":     "ASIA...",       # required
+      "secret_access_key": "...",           # required
+      "session_token":     "...",           # required (the time-bounded part)
+      "expiration":        "ISO 8601",      # required (UTC)
+      "region":            "us-...",        # required
+      "account_id":        "123456789012"   # optional
+    }
+
+The wire response carries ``session_token`` in ``access_token`` and the rest
+in ``nexus_credential_metadata``. Caller-side SDK builds ``boto3.Session``
+from the pair.
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from nexus.bricks.auth.consumer import MaterializedCredential
+
+
+class AwsProviderAdapter:
+    name: str = "aws"
+
+    def materialize(self, plaintext_payload: bytes) -> MaterializedCredential:
+        data = json.loads(plaintext_payload.decode("utf-8"))
+        # Required fields — KeyError surfaces as AdapterMaterializeFailed in the consumer.
+        session_token = data["session_token"]
+        access_key_id = data["access_key_id"]
+        secret_access_key = data["secret_access_key"]
+        expiration_iso = data["expiration"]
+        region = data["region"]
+
+        expires_at = datetime.fromisoformat(expiration_iso)
+
+        metadata = {
+            "access_key_id": access_key_id,
+            "secret_access_key": secret_access_key,
+            "region": region,
+        }
+        if "account_id" in data:
+            metadata["account_id"] = data["account_id"]
+
+        return MaterializedCredential(
+            provider=self.name,
+            access_token=session_token,
+            expires_at=expires_at,
+            metadata=metadata,
+        )

--- a/src/nexus/bricks/auth/consumer_providers/base.py
+++ b/src/nexus/bricks/auth/consumer_providers/base.py
@@ -1,0 +1,28 @@
+"""ProviderAdapter Protocol — provider-specific envelope-payload decoders.
+
+Each adapter is pure deserialization: takes envelope plaintext bytes (JSON,
+provider-shape), returns a ``MaterializedCredential``. No network calls, no
+state. Adapters are registered in ``consumer_providers/__init__.py``.
+"""
+
+from __future__ import annotations
+
+from typing import Protocol, runtime_checkable
+
+from nexus.bricks.auth.consumer import MaterializedCredential
+
+
+@runtime_checkable
+class ProviderAdapter(Protocol):
+    """Pure-function interface: envelope plaintext → MaterializedCredential."""
+
+    name: str  # "aws" | "github" | future providers
+
+    def materialize(self, plaintext_payload: bytes) -> MaterializedCredential:
+        """Decode envelope plaintext into a MaterializedCredential.
+
+        Raises:
+            ValueError | KeyError on malformed payload — CredentialConsumer
+            wraps these as AdapterMaterializeFailed before exiting.
+        """
+        ...

--- a/src/nexus/bricks/auth/consumer_providers/github.py
+++ b/src/nexus/bricks/auth/consumer_providers/github.py
@@ -1,12 +1,24 @@
 """GitHub provider adapter — daemon-pushed `gh auth token` payload → MaterializedCredential (#3818).
 
-Payload shape (JSON, daemon-pushed by `gh auth token`):
-    {
-      "token":      "ghp_..." | "github_pat_...",   # required
-      "scopes":     ["repo", "read:user", ...],     # required (may be [])
-      "expires_at": "ISO 8601",                     # optional (fine-grained PATs)
-      "token_type": "classic" | "fine_grained"      # optional, defaults "classic"
-    }
+Accepted payload shapes (daemon may push either):
+
+  1. **Raw token bytes** — what the default daemon actually emits today: the
+     stdout of ``gh auth token`` is a single line like ``ghp_xxx`` or
+     ``github_pat_xxx``. No metadata is available (no scopes, no expiry).
+
+  2. **JSON object** — preferred shape for richer metadata when the daemon
+     wraps the token. Schema::
+
+         {
+           "token":      "ghp_..." | "github_pat_...",   # required
+           "scopes":     ["repo", "read:user", ...],     # required (may be [])
+           "expires_at": "ISO 8601",                     # optional (fine-grained PATs)
+           "token_type": "classic" | "fine_grained"      # optional, defaults "classic"
+         }
+
+We try JSON first, then fall back to treating the bytes as a raw token.
+This keeps the read path working with the existing daemon push without
+forcing a daemon-side migration.
 """
 
 from __future__ import annotations
@@ -16,26 +28,54 @@ from datetime import datetime
 
 from nexus.bricks.auth.consumer import MaterializedCredential
 
+# Accepted PAT prefixes (classic + fine-grained + GitHub-issued tokens).
+# Used to validate raw-bytes fallback so we don't materialize garbage
+# (e.g. an empty file or HTML error page) as a credential.
+_GITHUB_TOKEN_PREFIXES: tuple[str, ...] = (
+    "ghp_",  # classic personal access token
+    "github_pat_",  # fine-grained PAT
+    "gho_",  # OAuth user-to-server
+    "ghu_",  # GitHub App user-to-server
+    "ghs_",  # GitHub App server-to-server
+    "ghr_",  # refresh token
+)
+
 
 class GithubProviderAdapter:
     name: str = "github"
 
     def materialize(self, plaintext_payload: bytes) -> MaterializedCredential:
-        data = json.loads(plaintext_payload.decode("utf-8"))
-        token = data["token"]  # KeyError → AdapterMaterializeFailed
-        scopes = data.get("scopes", [])
-        token_type = data.get("token_type", "classic")
+        text = plaintext_payload.decode("utf-8").strip()
 
-        expires_at: datetime | None = None
-        if "expires_at" in data and data["expires_at"]:
-            expires_at = datetime.fromisoformat(data["expires_at"])
+        # Shape 2: JSON object with token + metadata (preferred).
+        try:
+            data = json.loads(text)
+            if isinstance(data, dict) and "token" in data:
+                token = data["token"]
+                scopes = data.get("scopes", [])
+                token_type = data.get("token_type", "classic")
+                expires_at: datetime | None = None
+                if "expires_at" in data and data["expires_at"]:
+                    expires_at = datetime.fromisoformat(data["expires_at"])
+                return MaterializedCredential(
+                    provider=self.name,
+                    access_token=token,
+                    expires_at=expires_at,
+                    metadata={
+                        "scopes_csv": ",".join(scopes),
+                        "token_type": token_type,
+                    },
+                )
+        except (json.JSONDecodeError, ValueError):
+            pass  # fall through to raw-token shape
 
+        # Shape 1: raw token bytes (default daemon push for `gh auth token`).
+        # Validate prefix so we don't accept arbitrary plaintext as a credential.
+        if not text.startswith(_GITHUB_TOKEN_PREFIXES):
+            raise ValueError("payload is neither a recognized JSON shape nor a GitHub token prefix")
         return MaterializedCredential(
             provider=self.name,
-            access_token=token,
-            expires_at=expires_at,
-            metadata={
-                "scopes_csv": ",".join(scopes),
-                "token_type": token_type,
-            },
+            access_token=text,
+            expires_at=None,
+            metadata={"scopes_csv": "", "token_type": "classic"},
         )

--- a/src/nexus/bricks/auth/consumer_providers/github.py
+++ b/src/nexus/bricks/auth/consumer_providers/github.py
@@ -1,0 +1,41 @@
+"""GitHub provider adapter — daemon-pushed `gh auth token` payload → MaterializedCredential (#3818).
+
+Payload shape (JSON, daemon-pushed by `gh auth token`):
+    {
+      "token":      "ghp_..." | "github_pat_...",   # required
+      "scopes":     ["repo", "read:user", ...],     # required (may be [])
+      "expires_at": "ISO 8601",                     # optional (fine-grained PATs)
+      "token_type": "classic" | "fine_grained"      # optional, defaults "classic"
+    }
+"""
+
+from __future__ import annotations
+
+import json
+from datetime import datetime
+
+from nexus.bricks.auth.consumer import MaterializedCredential
+
+
+class GithubProviderAdapter:
+    name: str = "github"
+
+    def materialize(self, plaintext_payload: bytes) -> MaterializedCredential:
+        data = json.loads(plaintext_payload.decode("utf-8"))
+        token = data["token"]  # KeyError → AdapterMaterializeFailed
+        scopes = data.get("scopes", [])
+        token_type = data.get("token_type", "classic")
+
+        expires_at: datetime | None = None
+        if "expires_at" in data and data["expires_at"]:
+            expires_at = datetime.fromisoformat(data["expires_at"])
+
+        return MaterializedCredential(
+            provider=self.name,
+            access_token=token,
+            expires_at=expires_at,
+            metadata={
+                "scopes_csv": ",".join(scopes),
+                "token_type": token_type,
+            },
+        )

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -258,6 +258,34 @@ _TABLE_STATEMENTS: tuple[str, ...] = (
     """,
     "CREATE INDEX IF NOT EXISTS idx_auth_profile_writes_tenant_profile "
     "ON auth_profile_writes(tenant_id, principal_id, auth_profile_id, written_at DESC)",
+    # Read-path audit log (#3818). Same partitioning + RLS posture as
+    # auth_profile_writes — every server-side credential resolution via
+    # /v1/auth/token-exchange appends a row here (via Task 7's
+    # ReadAuditWriter, sampled at 1%). Range-partitioned by read_at so the
+    # partition key is part of the PK; default partition catches every row
+    # until per-month partitions are provisioned in production.
+    """
+    CREATE TABLE IF NOT EXISTS auth_profile_reads (
+        id                BIGSERIAL,
+        read_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        tenant_id         UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+        principal_id      UUID NOT NULL,
+        auth_profile_id   TEXT NOT NULL,
+        caller_machine_id UUID NOT NULL,
+        caller_kind       TEXT NOT NULL,
+        provider          TEXT NOT NULL,
+        purpose           TEXT NOT NULL,
+        cache_hit         BOOLEAN NOT NULL,
+        kek_version       INTEGER NOT NULL,
+        PRIMARY KEY (read_at, id)
+    ) PARTITION BY RANGE (read_at)
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS auth_profile_reads_default
+        PARTITION OF auth_profile_reads DEFAULT
+    """,
+    "CREATE INDEX IF NOT EXISTS idx_auth_profile_reads_tenant_principal_provider "
+    "ON auth_profile_reads(tenant_id, principal_id, provider, read_at DESC)",
 )
 
 # RLS statements. Run LAST so the backfill in _upgrade_shape_in_place is not
@@ -279,6 +307,8 @@ _RLS_STATEMENTS: tuple[str, ...] = (
     "ALTER TABLE daemon_refresh_nonces FORCE ROW LEVEL SECURITY",
     "ALTER TABLE auth_profile_writes ENABLE ROW LEVEL SECURITY",
     "ALTER TABLE auth_profile_writes FORCE ROW LEVEL SECURITY",
+    "ALTER TABLE auth_profile_reads ENABLE ROW LEVEL SECURITY",
+    "ALTER TABLE auth_profile_reads FORCE ROW LEVEL SECURITY",
 )
 
 # Policies are separate because ``CREATE POLICY`` lacks IF NOT EXISTS in
@@ -322,6 +352,11 @@ _POLICY_STATEMENTS: tuple[str, ...] = (
     "DROP POLICY IF EXISTS tenant_isolation_auth_profile_writes ON auth_profile_writes",
     """
     CREATE POLICY tenant_isolation_auth_profile_writes ON auth_profile_writes
+        USING (tenant_id = current_setting('app.current_tenant', true)::UUID)
+    """,
+    "DROP POLICY IF EXISTS auth_profile_reads_tenant_isolation ON auth_profile_reads",
+    """
+    CREATE POLICY auth_profile_reads_tenant_isolation ON auth_profile_reads
         USING (tenant_id = current_setting('app.current_tenant', true)::UUID)
     """,
 )

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -129,6 +129,33 @@ class DecryptedProfile:
     writer_machine_id: uuid.UUID | None = None
 
 
+@dataclass(frozen=True)
+class ProfileFingerprint:
+    """Identity columns of the single usable envelope row at lookup time.
+
+    Returned by ``PostgresAuthProfileStore.assert_profile_active`` so the
+    cache-hit branch in ``CredentialConsumer.resolve`` can detect a row
+    REWRITE since the cache was primed: a different ``profile_id`` (the
+    old row was deleted and replaced), a different ``writer_machine_id``
+    (a second daemon overwrote the same provider/account), or a bumped
+    ``last_synced_at`` (the daemon pushed a fresh envelope, possibly
+    rotating the upstream credential).
+
+    A mismatch in any of these means the cached plaintext is stale —
+    the consumer evicts and re-runs the decrypt path, which also
+    re-applies the cross-machine read policy against the current writer.
+
+    Carries ``profile_id`` and ``kek_version`` so cache-hit audit rows
+    can name the credential that was served instead of falling back to
+    sentinel placeholders.
+    """
+
+    profile_id: str
+    writer_machine_id: uuid.UUID | None
+    kek_version: int
+    last_synced_at: datetime
+
+
 # ---------------------------------------------------------------------------
 # Schema (idempotent CREATE TABLE IF NOT EXISTS + RLS policies)
 # ---------------------------------------------------------------------------
@@ -1441,8 +1468,10 @@ class PostgresAuthProfileStore:
         )
         return profile, self._deserialize_credential(plaintext)
 
-    def assert_profile_active(self, *, principal_id: uuid.UUID, provider: str) -> None:
-        """Cheap predicate-only check: a usable envelope exists right now.
+    def assert_profile_active(
+        self, *, principal_id: uuid.UUID, provider: str
+    ) -> "ProfileFingerprint":
+        """Cheap predicate-only check + fingerprint of the single usable row.
 
         Cache-hit paths call this BEFORE returning the cached credential so an
         operator disable, an automatic cooldown, a freshly-pushed ambiguous
@@ -1452,20 +1481,23 @@ class PostgresAuthProfileStore:
         ciphertext, not disabled, not cooled-down, not stale) but reads no
         payload.
 
-        Single round trip returning two counts:
-          - ``usable``: rows that pass every gate including freshness
-          - ``stale_only``: rows that pass disable/cooldown but failed freshness
+        Returns a ``ProfileFingerprint`` for the single usable row so the
+        caller can detect a row REWRITE since the cache was primed (different
+        ``profile_id``, different writer ``machine_id``, or bumped
+        ``last_synced_at``). Without this, the cache-hit branch would keep
+        serving an old machine's plaintext for the rest of the cache TTL after
+        another daemon overwrote the same provider/account.
 
         Mapping:
           - ``usable > 1``  → MultipleProfilesForProvider (fail closed)
-          - ``usable == 1`` → ok
+          - ``usable == 1`` → return ProfileFingerprint
           - ``usable == 0`` and ``stale_only >= 1`` → StaleSource
           - ``usable == 0`` and ``stale_only == 0`` → ProfileNotFound
         """
         from nexus.bricks.auth.consumer import MultipleProfilesForProvider, StaleSource
 
         with self._scoped() as conn:
-            row = conn.execute(
+            counts = conn.execute(
                 text(
                     "SELECT "
                     "  COUNT(*) FILTER (WHERE "
@@ -1484,24 +1516,56 @@ class PostgresAuthProfileStore:
                 ),
                 {"t": str(self._tenant_id), "p": str(principal_id), "prov": provider},
             ).fetchone()
-        usable = int(row.usable) if row else 0
-        stale_only = int(row.stale_only) if row else 0
-        if usable > 1:
-            raise MultipleProfilesForProvider.from_row(
-                tenant_id=self._tenant_id,
-                principal_id=principal_id,
-                provider=provider,
-                cause=f"{usable}+ active envelopes; collapse to one or upgrade wire contract",
-            )
-        if usable == 1:
-            return
-        if stale_only >= 1:
-            raise StaleSource.from_row(
-                tenant_id=self._tenant_id,
-                principal_id=principal_id,
-                provider=provider,
-                cause="last_synced_at_past_sync_ttl",
-            )
+            usable = int(counts.usable) if counts else 0
+            stale_only = int(counts.stale_only) if counts else 0
+            if usable > 1:
+                raise MultipleProfilesForProvider.from_row(
+                    tenant_id=self._tenant_id,
+                    principal_id=principal_id,
+                    provider=provider,
+                    cause=f"{usable}+ active envelopes; collapse to one or upgrade wire contract",
+                )
+            if usable == 1:
+                # Re-fetch the single usable row's identity columns so the
+                # consumer can detect a rewrite vs the cached entry. Same
+                # predicate as the count above; LIMIT 1 because we already
+                # know exactly one row matches.
+                fp = conn.execute(
+                    text(
+                        "SELECT id, machine_id, kek_version, last_synced_at "
+                        "FROM auth_profiles "
+                        "WHERE tenant_id = :t AND principal_id = :p AND provider = :prov "
+                        "  AND ciphertext IS NOT NULL "
+                        "  AND (disabled_until IS NULL OR disabled_until <= NOW()) "
+                        "  AND (cooldown_until IS NULL OR cooldown_until <= NOW()) "
+                        "  AND last_synced_at IS NOT NULL "
+                        "  AND last_synced_at + (sync_ttl_seconds || ' seconds')::INTERVAL > NOW() "
+                        "LIMIT 1"
+                    ),
+                    {"t": str(self._tenant_id), "p": str(principal_id), "prov": provider},
+                ).fetchone()
+                if fp is None:
+                    # Row vanished between the COUNT and the LIMIT 1 (operator
+                    # action mid-call, or concurrent rewrite). Treat as not
+                    # found rather than serving the now-cached plaintext.
+                    raise ProfileNotFound(
+                        tenant_id=self._tenant_id,
+                        principal_id=principal_id,
+                        provider=provider,
+                    )
+                return ProfileFingerprint(
+                    profile_id=str(fp.id),
+                    writer_machine_id=fp.machine_id,
+                    kek_version=int(fp.kek_version),
+                    last_synced_at=fp.last_synced_at,
+                )
+            if stale_only >= 1:
+                raise StaleSource.from_row(
+                    tenant_id=self._tenant_id,
+                    principal_id=principal_id,
+                    provider=provider,
+                    cause="last_synced_at_past_sync_ttl",
+                )
         raise ProfileNotFound(
             tenant_id=self._tenant_id,
             principal_id=principal_id,

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -1445,21 +1445,38 @@ class PostgresAuthProfileStore:
         """Cheap predicate-only check: a usable envelope exists right now.
 
         Cache-hit paths call this BEFORE returning the cached credential so an
-        operator disable, an automatic cooldown, or a freshly-pushed ambiguous
-        second envelope all take effect within ~ms instead of waiting for the
-        cache TTL. Mirrors the SQL predicates in ``decrypt_profile`` (active
-        ciphertext, not disabled, not cooled-down) but reads no payload.
+        operator disable, an automatic cooldown, a freshly-pushed ambiguous
+        second envelope, OR a daemon that stopped pushing for longer than its
+        ``sync_ttl_seconds`` all take effect within ~ms instead of waiting for
+        the cache TTL. Mirrors the SQL predicates in ``decrypt_profile`` (active
+        ciphertext, not disabled, not cooled-down, not stale) but reads no
+        payload.
 
-        Raises ``ProfileNotFound`` (no usable row) or
-        ``MultipleProfilesForProvider`` (>1 active rows — same fail-closed
-        behavior as decrypt_profile).
+        Single round trip returning two counts:
+          - ``usable``: rows that pass every gate including freshness
+          - ``stale_only``: rows that pass disable/cooldown but failed freshness
+
+        Mapping:
+          - ``usable > 1``  → MultipleProfilesForProvider (fail closed)
+          - ``usable == 1`` → ok
+          - ``usable == 0`` and ``stale_only >= 1`` → StaleSource
+          - ``usable == 0`` and ``stale_only == 0`` → ProfileNotFound
         """
-        from nexus.bricks.auth.consumer import MultipleProfilesForProvider
+        from nexus.bricks.auth.consumer import MultipleProfilesForProvider, StaleSource
 
         with self._scoped() as conn:
-            count_row = conn.execute(
+            row = conn.execute(
                 text(
-                    "SELECT COUNT(*) FROM auth_profiles "
+                    "SELECT "
+                    "  COUNT(*) FILTER (WHERE "
+                    "    last_synced_at IS NOT NULL "
+                    "    AND last_synced_at + (sync_ttl_seconds || ' seconds')::INTERVAL > NOW()"
+                    "  ) AS usable, "
+                    "  COUNT(*) FILTER (WHERE "
+                    "    last_synced_at IS NULL "
+                    "    OR last_synced_at + (sync_ttl_seconds || ' seconds')::INTERVAL <= NOW()"
+                    "  ) AS stale_only "
+                    "FROM auth_profiles "
                     "WHERE tenant_id = :t AND principal_id = :p AND provider = :prov "
                     "  AND ciphertext IS NOT NULL "
                     "  AND (disabled_until IS NULL OR disabled_until <= NOW()) "
@@ -1467,20 +1484,29 @@ class PostgresAuthProfileStore:
                 ),
                 {"t": str(self._tenant_id), "p": str(principal_id), "prov": provider},
             ).fetchone()
-        active = int(count_row[0]) if count_row else 0
-        if active == 0:
-            raise ProfileNotFound(
-                tenant_id=self._tenant_id,
-                principal_id=principal_id,
-                provider=provider,
-            )
-        if active > 1:
+        usable = int(row.usable) if row else 0
+        stale_only = int(row.stale_only) if row else 0
+        if usable > 1:
             raise MultipleProfilesForProvider.from_row(
                 tenant_id=self._tenant_id,
                 principal_id=principal_id,
                 provider=provider,
-                cause=f"{active}+ active envelopes; collapse to one or upgrade wire contract",
+                cause=f"{usable}+ active envelopes; collapse to one or upgrade wire contract",
             )
+        if usable == 1:
+            return
+        if stale_only >= 1:
+            raise StaleSource.from_row(
+                tenant_id=self._tenant_id,
+                principal_id=principal_id,
+                provider=provider,
+                cause="last_synced_at_past_sync_ttl",
+            )
+        raise ProfileNotFound(
+            tenant_id=self._tenant_id,
+            principal_id=principal_id,
+            provider=provider,
+        )
 
     def assert_machine_active(self, *, principal_id: uuid.UUID, machine_id: uuid.UUID) -> None:
         """Reject if the daemon's machine row is missing or revoked.

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -90,6 +90,36 @@ class CrossPrincipalConflict(Exception):
         )
 
 
+class ProfileNotFound(Exception):
+    """No envelope-carrying auth_profile row for (tenant, principal, provider)."""
+
+    def __init__(self, *, tenant_id: uuid.UUID, principal_id: uuid.UUID, provider: str):
+        self.tenant_id = tenant_id
+        self.principal_id = principal_id
+        self.provider = provider
+        super().__init__(
+            f"no auth_profile row tenant={tenant_id} principal={principal_id} provider={provider}"
+        )
+
+
+@dataclass(frozen=True)
+class DecryptedProfile:
+    """Output of ``PostgresAuthProfileStore.decrypt_profile``.
+
+    ``plaintext`` is the daemon-pushed envelope payload (provider-specific JSON).
+    Caller (CredentialConsumer) hands this to the matching ProviderAdapter.
+
+    ``last_synced_at`` lets the consumer return 409 stale_source when the row
+    is older than ``sync_ttl_seconds``.
+    """
+
+    plaintext: bytes
+    profile_id: str
+    kek_version: int
+    last_synced_at: datetime
+    sync_ttl_seconds: int
+
+
 # ---------------------------------------------------------------------------
 # Schema (idempotent CREATE TABLE IF NOT EXISTS + RLS policies)
 # ---------------------------------------------------------------------------
@@ -1401,6 +1431,69 @@ class PostgresAuthProfileStore:
             dek, bytes(row.nonce), bytes(row.ciphertext), aad=expected_aad
         )
         return profile, self._deserialize_credential(plaintext)
+
+    def decrypt_profile(
+        self,
+        *,
+        principal_id: uuid.UUID,
+        provider: str,
+        encryption: EncryptionProvider,
+        dek_cache: DEKCache,
+    ) -> DecryptedProfile:
+        """Decrypt the envelope row matching (tenant, principal, provider).
+
+        Selects the most-recently-updated row for that triple (the daemon may
+        have pushed multiple over time; we always read newest). Raises
+        ``ProfileNotFound`` if no row exists.
+
+        DEK is unwrapped via ``encryption.unwrap_dek`` with cache-through on
+        ``dek_cache``. AES-GCM decrypt failures bubble as ``EnvelopeError``
+        subclasses (no plaintext in repr).
+        """
+        with self._scoped() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT id, ciphertext, wrapped_dek, nonce, aad, kek_version, "
+                    "       last_synced_at, sync_ttl_seconds "
+                    "FROM auth_profiles "
+                    "WHERE tenant_id = :t AND principal_id = :p AND provider = :prov "
+                    "  AND ciphertext IS NOT NULL "
+                    "ORDER BY updated_at DESC LIMIT 1"
+                ),
+                {"t": str(self._tenant_id), "p": str(principal_id), "prov": provider},
+            ).fetchone()
+
+        if row is None:
+            raise ProfileNotFound(
+                tenant_id=self._tenant_id,
+                principal_id=principal_id,
+                provider=provider,
+            )
+
+        profile_id, ciphertext, wrapped_dek, nonce, aad, kek_version, lsa, sttl = row
+        cache_key = DEKCache.make_key(
+            tenant_id=self._tenant_id,
+            kek_version=kek_version,
+            wrapped_dek=bytes(wrapped_dek),
+        )
+        dek = dek_cache.get(cache_key)
+        if dek is None:
+            dek = encryption.unwrap_dek(
+                bytes(wrapped_dek),
+                tenant_id=self._tenant_id,
+                aad=bytes(aad),
+                kek_version=kek_version,
+            )
+            dek_cache.put(cache_key, dek)
+
+        plaintext = AESGCMEnvelope().decrypt(dek, bytes(nonce), bytes(ciphertext), aad=bytes(aad))
+        return DecryptedProfile(
+            plaintext=plaintext,
+            profile_id=profile_id,
+            kek_version=kek_version,
+            last_synced_at=lsa,
+            sync_ttl_seconds=sttl,
+        )
 
     # ------------------------------------------------------------------
     # Tenant-wide helpers (migration/admin only — outside normal Protocol)

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -1441,6 +1441,47 @@ class PostgresAuthProfileStore:
         )
         return profile, self._deserialize_credential(plaintext)
 
+    def assert_profile_active(self, *, principal_id: uuid.UUID, provider: str) -> None:
+        """Cheap predicate-only check: a usable envelope exists right now.
+
+        Cache-hit paths call this BEFORE returning the cached credential so an
+        operator disable, an automatic cooldown, or a freshly-pushed ambiguous
+        second envelope all take effect within ~ms instead of waiting for the
+        cache TTL. Mirrors the SQL predicates in ``decrypt_profile`` (active
+        ciphertext, not disabled, not cooled-down) but reads no payload.
+
+        Raises ``ProfileNotFound`` (no usable row) or
+        ``MultipleProfilesForProvider`` (>1 active rows — same fail-closed
+        behavior as decrypt_profile).
+        """
+        from nexus.bricks.auth.consumer import MultipleProfilesForProvider
+
+        with self._scoped() as conn:
+            count_row = conn.execute(
+                text(
+                    "SELECT COUNT(*) FROM auth_profiles "
+                    "WHERE tenant_id = :t AND principal_id = :p AND provider = :prov "
+                    "  AND ciphertext IS NOT NULL "
+                    "  AND (disabled_until IS NULL OR disabled_until <= NOW()) "
+                    "  AND (cooldown_until IS NULL OR cooldown_until <= NOW())"
+                ),
+                {"t": str(self._tenant_id), "p": str(principal_id), "prov": provider},
+            ).fetchone()
+        active = int(count_row[0]) if count_row else 0
+        if active == 0:
+            raise ProfileNotFound(
+                tenant_id=self._tenant_id,
+                principal_id=principal_id,
+                provider=provider,
+            )
+        if active > 1:
+            raise MultipleProfilesForProvider.from_row(
+                tenant_id=self._tenant_id,
+                principal_id=principal_id,
+                provider=provider,
+                cause=f"{active}+ active envelopes; collapse to one or upgrade wire contract",
+            )
+
     def assert_machine_active(self, *, principal_id: uuid.UUID, machine_id: uuid.UUID) -> None:
         """Reject if the daemon's machine row is missing or revoked.
 

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -1436,6 +1436,44 @@ class PostgresAuthProfileStore:
         )
         return profile, self._deserialize_credential(plaintext)
 
+    def assert_machine_active(self, *, principal_id: uuid.UUID, machine_id: uuid.UUID) -> None:
+        """Reject if the daemon's machine row is missing or revoked.
+
+        Mirrors the check the auth-profiles push router performs: a JWT
+        cryptographically valid is not enough — the daemon's row must still
+        be present and unrevoked at the time of every credential read. Without
+        this, a JWT minted before revocation can keep returning provider
+        bearers until natural expiry. Raises ``MachineUnknownOrRevoked``.
+        """
+        from nexus.bricks.auth.consumer import MachineUnknownOrRevoked
+
+        with self._scoped() as conn:
+            row = conn.execute(
+                text(
+                    "SELECT revoked_at FROM daemon_machines "
+                    "WHERE tenant_id = :t AND principal_id = :p AND id = :m"
+                ),
+                {
+                    "t": str(self._tenant_id),
+                    "p": str(principal_id),
+                    "m": str(machine_id),
+                },
+            ).fetchone()
+        if row is None:
+            raise MachineUnknownOrRevoked.from_row(
+                tenant_id=self._tenant_id,
+                principal_id=principal_id,
+                provider="-",
+                cause="machine_unknown",
+            )
+        if row.revoked_at is not None:
+            raise MachineUnknownOrRevoked.from_row(
+                tenant_id=self._tenant_id,
+                principal_id=principal_id,
+                provider="-",
+                cause="machine_revoked",
+            )
+
     def decrypt_profile(
         self,
         *,
@@ -1446,35 +1484,47 @@ class PostgresAuthProfileStore:
     ) -> DecryptedProfile:
         """Decrypt the envelope row matching (tenant, principal, provider).
 
-        Selects the most-recently-updated row for that triple (the daemon may
-        have pushed multiple over time; we always read newest). Raises
-        ``ProfileNotFound`` if no row exists.
+        Fetches up to 2 rows for that triple. If 2 rows are returned the
+        request is ambiguous — the wire contract has no profile_id field
+        to disambiguate, so we fail closed with
+        ``MultipleProfilesForProvider`` rather than silently pick the
+        newest (which could hand back the wrong account's credentials).
+        Raises ``ProfileNotFound`` if no row exists.
 
         DEK is unwrapped via ``encryption.unwrap_dek`` with cache-through on
         ``dek_cache``. AES-GCM decrypt failures bubble as ``EnvelopeError``
         subclasses (no plaintext in repr).
         """
+        from nexus.bricks.auth.consumer import MultipleProfilesForProvider
+
         with self._scoped() as conn:
-            row = conn.execute(
+            rows = conn.execute(
                 text(
                     "SELECT id, ciphertext, wrapped_dek, nonce, aad, kek_version, "
                     "       last_synced_at, sync_ttl_seconds "
                     "FROM auth_profiles "
                     "WHERE tenant_id = :t AND principal_id = :p AND provider = :prov "
                     "  AND ciphertext IS NOT NULL "
-                    "ORDER BY updated_at DESC LIMIT 1"
+                    "ORDER BY updated_at DESC LIMIT 2"
                 ),
                 {"t": str(self._tenant_id), "p": str(principal_id), "prov": provider},
-            ).fetchone()
+            ).fetchall()
 
-        if row is None:
+        if not rows:
             raise ProfileNotFound(
                 tenant_id=self._tenant_id,
                 principal_id=principal_id,
                 provider=provider,
             )
+        if len(rows) > 1:
+            raise MultipleProfilesForProvider.from_row(
+                tenant_id=self._tenant_id,
+                principal_id=principal_id,
+                provider=provider,
+                cause=f"{len(rows)}+ active envelopes; collapse to one or upgrade wire contract",
+            )
 
-        profile_id, ciphertext, wrapped_dek, nonce, aad, kek_version, lsa, sttl = row
+        profile_id, ciphertext, wrapped_dek, nonce, aad, kek_version, lsa, sttl = rows[0]
 
         # Defense-in-depth: cross-check the row's stored AAD against the
         # tenant|principal|profile_id format that writers use. AES-GCM tag

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -1469,7 +1469,11 @@ class PostgresAuthProfileStore:
         return profile, self._deserialize_credential(plaintext)
 
     def assert_profile_active(
-        self, *, principal_id: uuid.UUID, provider: str
+        self,
+        *,
+        principal_id: uuid.UUID,
+        provider: str,
+        profile_id: str | None = None,
     ) -> "ProfileFingerprint":
         """Cheap predicate-only check + fingerprint of the single usable row.
 
@@ -1481,6 +1485,11 @@ class PostgresAuthProfileStore:
         ciphertext, not disabled, not cooled-down, not stale) but reads no
         payload.
 
+        ``profile_id`` selects a specific envelope row when the principal has
+        more than one profile for ``provider``. Without it, the legacy
+        single-row contract applies and ``MultipleProfilesForProvider`` fires
+        when more than one active row exists.
+
         Returns a ``ProfileFingerprint`` for the single usable row so the
         caller can detect a row REWRITE since the cache was primed (different
         ``profile_id``, different writer ``machine_id``, or bumped
@@ -1489,13 +1498,26 @@ class PostgresAuthProfileStore:
         another daemon overwrote the same provider/account.
 
         Mapping:
-          - ``usable > 1``  → MultipleProfilesForProvider (fail closed)
+          - ``usable > 1``  → MultipleProfilesForProvider (only possible when
+            ``profile_id`` is None; an explicit selector matches at most one)
           - ``usable == 1`` → return ProfileFingerprint
           - ``usable == 0`` and ``stale_only >= 1`` → StaleSource
           - ``usable == 0`` and ``stale_only == 0`` → ProfileNotFound
         """
         from nexus.bricks.auth.consumer import MultipleProfilesForProvider, StaleSource
 
+        # Optional profile_id filter — single literal appended to both the
+        # COUNT and the LIMIT 1 sub-queries when supplied. Empty string
+        # binding is fine because the param is unused unless the WHERE
+        # mentions :pid.
+        pid_filter = " AND id = :pid" if profile_id is not None else ""
+        params: dict[str, str] = {
+            "t": str(self._tenant_id),
+            "p": str(principal_id),
+            "prov": provider,
+        }
+        if profile_id is not None:
+            params["pid"] = profile_id
         with self._scoped() as conn:
             counts = conn.execute(
                 text(
@@ -1512,9 +1534,9 @@ class PostgresAuthProfileStore:
                     "WHERE tenant_id = :t AND principal_id = :p AND provider = :prov "
                     "  AND ciphertext IS NOT NULL "
                     "  AND (disabled_until IS NULL OR disabled_until <= NOW()) "
-                    "  AND (cooldown_until IS NULL OR cooldown_until <= NOW())"
+                    "  AND (cooldown_until IS NULL OR cooldown_until <= NOW())" + pid_filter
                 ),
-                {"t": str(self._tenant_id), "p": str(principal_id), "prov": provider},
+                params,
             ).fetchone()
             usable = int(counts.usable) if counts else 0
             stale_only = int(counts.stale_only) if counts else 0
@@ -1539,10 +1561,11 @@ class PostgresAuthProfileStore:
                         "  AND (disabled_until IS NULL OR disabled_until <= NOW()) "
                         "  AND (cooldown_until IS NULL OR cooldown_until <= NOW()) "
                         "  AND last_synced_at IS NOT NULL "
-                        "  AND last_synced_at + (sync_ttl_seconds || ' seconds')::INTERVAL > NOW() "
-                        "LIMIT 1"
+                        "  AND last_synced_at + (sync_ttl_seconds || ' seconds')::INTERVAL > NOW()"
+                        + pid_filter
+                        + " LIMIT 1"
                     ),
-                    {"t": str(self._tenant_id), "p": str(principal_id), "prov": provider},
+                    params,
                 ).fetchone()
                 if fp is None:
                     # Row vanished between the COUNT and the LIMIT 1 (operator
@@ -1617,15 +1640,21 @@ class PostgresAuthProfileStore:
         provider: str,
         encryption: EncryptionProvider,
         dek_cache: DEKCache,
+        profile_id: str | None = None,
     ) -> DecryptedProfile:
         """Decrypt the envelope row matching (tenant, principal, provider).
 
         Fetches up to 2 rows for that triple. If 2 rows are returned the
-        request is ambiguous — the wire contract has no profile_id field
-        to disambiguate, so we fail closed with
-        ``MultipleProfilesForProvider`` rather than silently pick the
-        newest (which could hand back the wrong account's credentials).
+        request is ambiguous — caller must pass ``profile_id`` to select one
+        explicitly or collapse to a single active row. We fail closed with
+        ``MultipleProfilesForProvider`` rather than silently pick the newest
+        (which could hand back the wrong account's credentials).
         Raises ``ProfileNotFound`` if no row exists.
+
+        ``profile_id`` selects a specific envelope row (multi-account form
+        of the wire contract). When supplied the SQL filters on ``id`` too,
+        so the caller gets either the named row or ``ProfileNotFound`` —
+        never another account's credential.
 
         DEK is unwrapped via ``encryption.unwrap_dek`` with cache-through on
         ``dek_cache``. AES-GCM decrypt failures bubble as ``EnvelopeError``
@@ -1633,6 +1662,14 @@ class PostgresAuthProfileStore:
         """
         from nexus.bricks.auth.consumer import MultipleProfilesForProvider
 
+        pid_filter = " AND id = :pid" if profile_id is not None else ""
+        params: dict[str, str] = {
+            "t": str(self._tenant_id),
+            "p": str(principal_id),
+            "prov": provider,
+        }
+        if profile_id is not None:
+            params["pid"] = profile_id
         with self._scoped() as conn:
             # Filter out disabled (operator hard-stop) and cooled-down
             # (auto-circuit-breaker) profiles in SQL so neither path leaks
@@ -1648,10 +1685,11 @@ class PostgresAuthProfileStore:
                     "WHERE tenant_id = :t AND principal_id = :p AND provider = :prov "
                     "  AND ciphertext IS NOT NULL "
                     "  AND (disabled_until IS NULL OR disabled_until <= NOW()) "
-                    "  AND (cooldown_until IS NULL OR cooldown_until <= NOW()) "
-                    "ORDER BY updated_at DESC LIMIT 2"
+                    "  AND (cooldown_until IS NULL OR cooldown_until <= NOW())"
+                    + pid_filter
+                    + " ORDER BY updated_at DESC LIMIT 2"
                 ),
-                {"t": str(self._tenant_id), "p": str(principal_id), "prov": provider},
+                params,
             ).fetchall()
 
         if not rows:

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -122,6 +122,11 @@ class DecryptedProfile:
     kek_version: int
     last_synced_at: datetime
     sync_ttl_seconds: int
+    # Daemon machine that pushed this envelope (audit stamp from #3804).
+    # NULL for legacy rows pushed before the stamp existed. Consumer logs
+    # a warning when reader.machine_id != writer_machine_id so operators
+    # can detect implicit cross-machine credential sharing.
+    writer_machine_id: uuid.UUID | None = None
 
 
 # ---------------------------------------------------------------------------
@@ -1498,13 +1503,21 @@ class PostgresAuthProfileStore:
         from nexus.bricks.auth.consumer import MultipleProfilesForProvider
 
         with self._scoped() as conn:
+            # Filter out disabled (operator hard-stop) and cooled-down
+            # (auto-circuit-breaker) profiles in SQL so neither path leaks
+            # past the cache-miss boundary. Cache hits inside ResolvedCredCache
+            # may still serve a credential for up to its TTL after a state
+            # change — the deployment guide notes this lag and recommends
+            # NEXUS_AUTH_CRED_CACHE_TTL be tuned for the operator's tolerance.
             rows = conn.execute(
                 text(
                     "SELECT id, ciphertext, wrapped_dek, nonce, aad, kek_version, "
-                    "       last_synced_at, sync_ttl_seconds "
+                    "       last_synced_at, sync_ttl_seconds, machine_id "
                     "FROM auth_profiles "
                     "WHERE tenant_id = :t AND principal_id = :p AND provider = :prov "
                     "  AND ciphertext IS NOT NULL "
+                    "  AND (disabled_until IS NULL OR disabled_until <= NOW()) "
+                    "  AND (cooldown_until IS NULL OR cooldown_until <= NOW()) "
                     "ORDER BY updated_at DESC LIMIT 2"
                 ),
                 {"t": str(self._tenant_id), "p": str(principal_id), "prov": provider},
@@ -1524,7 +1537,7 @@ class PostgresAuthProfileStore:
                 cause=f"{len(rows)}+ active envelopes; collapse to one or upgrade wire contract",
             )
 
-        profile_id, ciphertext, wrapped_dek, nonce, aad, kek_version, lsa, sttl = rows[0]
+        profile_id, ciphertext, wrapped_dek, nonce, aad, kek_version, lsa, sttl, wmid = rows[0]
 
         # Defense-in-depth: cross-check the row's stored AAD against the
         # tenant|principal|profile_id format that writers use. AES-GCM tag
@@ -1562,6 +1575,7 @@ class PostgresAuthProfileStore:
             kek_version=kek_version,
             last_synced_at=lsa,
             sync_ttl_seconds=sttl,
+            writer_machine_id=wmid,
         )
 
     # ------------------------------------------------------------------

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -40,7 +40,7 @@ import secrets
 import uuid
 from collections.abc import Iterator
 from contextlib import contextmanager
-from dataclasses import asdict, dataclass
+from dataclasses import asdict, dataclass, field
 from datetime import datetime
 from typing import Any
 
@@ -111,9 +111,13 @@ class DecryptedProfile:
 
     ``last_synced_at`` lets the consumer return 409 stale_source when the row
     is older than ``sync_ttl_seconds``.
+
+    ``plaintext`` is marked ``repr=False`` so the credential bytes never appear
+    in default ``__repr__`` output (which is what ``log.info("decrypted %s", out)``
+    or an unhandled-exception locals frame would emit).
     """
 
-    plaintext: bytes
+    plaintext: bytes = field(repr=False)
     profile_id: str
     kek_version: int
     last_synced_at: datetime
@@ -1471,6 +1475,21 @@ class PostgresAuthProfileStore:
             )
 
         profile_id, ciphertext, wrapped_dek, nonce, aad, kek_version, lsa, sttl = row
+
+        # Defense-in-depth: cross-check the row's stored AAD against the
+        # tenant|principal|profile_id format that writers use. AES-GCM tag
+        # verification alone won't catch a tampered ``aad`` column — the
+        # tag was bound to whatever AAD landed in the row. Mirror what
+        # ``get_with_credential`` already enforces (see lines ~1397-1404).
+        expected_aad = self._aad_for(profile_id)
+        if bytes(aad) != expected_aad:
+            raise AADMismatch.from_row(
+                tenant_id=self._tenant_id,
+                profile_id=profile_id,
+                kek_version=kek_version,
+                cause="stored AAD does not match tenant|principal|profile_id",
+            )
+
         cache_key = DEKCache.make_key(
             tenant_id=self._tenant_id,
             kek_version=kek_version,
@@ -1481,12 +1500,12 @@ class PostgresAuthProfileStore:
             dek = encryption.unwrap_dek(
                 bytes(wrapped_dek),
                 tenant_id=self._tenant_id,
-                aad=bytes(aad),
+                aad=expected_aad,
                 kek_version=kek_version,
             )
             dek_cache.put(cache_key, dek)
 
-        plaintext = AESGCMEnvelope().decrypt(dek, bytes(nonce), bytes(ciphertext), aad=bytes(aad))
+        plaintext = AESGCMEnvelope().decrypt(dek, bytes(nonce), bytes(ciphertext), aad=expected_aad)
         return DecryptedProfile(
             plaintext=plaintext,
             profile_id=profile_id,

--- a/src/nexus/bricks/auth/postgres_profile_store.py
+++ b/src/nexus/bricks/auth/postgres_profile_store.py
@@ -1671,16 +1671,19 @@ class PostgresAuthProfileStore:
         if profile_id is not None:
             params["pid"] = profile_id
         with self._scoped() as conn:
-            # Filter out disabled (operator hard-stop) and cooled-down
-            # (auto-circuit-breaker) profiles in SQL so neither path leaks
-            # past the cache-miss boundary. Cache hits inside ResolvedCredCache
-            # may still serve a credential for up to its TTL after a state
-            # change — the deployment guide notes this lag and recommends
-            # NEXUS_AUTH_CRED_CACHE_TTL be tuned for the operator's tolerance.
+            # SQL filters out disabled/cooled-down rows so cache-miss never
+            # leaks them; cache hits may still serve them up to TTL (see
+            # NEXUS_AUTH_CRED_CACHE_TTL). F31: ``is_fresh`` derived in the
+            # same SELECT so the freshness predicate uses the same NOW() as
+            # the row read — closes the gap between assert_profile_active
+            # at T0 and decrypt at T1 where the row could cross its TTL.
             rows = conn.execute(
                 text(
                     "SELECT id, ciphertext, wrapped_dek, nonce, aad, kek_version, "
-                    "       last_synced_at, sync_ttl_seconds, machine_id "
+                    "       last_synced_at, sync_ttl_seconds, machine_id, "
+                    "       (last_synced_at IS NOT NULL "
+                    "        AND last_synced_at + (sync_ttl_seconds || ' seconds')::INTERVAL "
+                    "            > NOW()) AS is_fresh "
                     "FROM auth_profiles "
                     "WHERE tenant_id = :t AND principal_id = :p AND provider = :prov "
                     "  AND ciphertext IS NOT NULL "
@@ -1706,7 +1709,30 @@ class PostgresAuthProfileStore:
                 cause=f"{len(rows)}+ active envelopes; collapse to one or upgrade wire contract",
             )
 
-        profile_id, ciphertext, wrapped_dek, nonce, aad, kek_version, lsa, sttl, wmid = rows[0]
+        (
+            profile_id,
+            ciphertext,
+            wrapped_dek,
+            nonce,
+            aad,
+            kek_version,
+            lsa,
+            sttl,
+            wmid,
+            is_fresh,
+        ) = rows[0]
+        if not is_fresh:
+            # F31: row crossed its TTL between assert_profile_active and now.
+            # Fail closed with StaleSource (retryable after the daemon pushes
+            # a fresh envelope), not ProfileNotFound (operator-deleted).
+            from nexus.bricks.auth.consumer import StaleSource
+
+            raise StaleSource.from_row(
+                tenant_id=self._tenant_id,
+                principal_id=principal_id,
+                provider=provider,
+                cause="last_synced_at_past_sync_ttl_at_decrypt",
+            )
 
         # Defense-in-depth: cross-check the row's stored AAD against the
         # tenant|principal|profile_id format that writers use. AES-GCM tag

--- a/src/nexus/bricks/auth/read_audit.py
+++ b/src/nexus/bricks/auth/read_audit.py
@@ -78,8 +78,11 @@ class ReadAuditWriter:
         (sampled) still observe the revocation gate but swallow audit
         insert failures so operational telemetry blips don't block reads.
         """
-        if cache_hit and self._rng.random() >= self._hit_sample_rate:
-            return  # sampled out
+        # Sampling decision — but the revocation gate STILL runs for
+        # sampled-out cache hits. Without that, the 99% of hits that
+        # don't get an audit row would also skip the SHARE-lock SELECT
+        # and be vulnerable to the F26 race the gate exists to close.
+        sampled_out = cache_hit and self._rng.random() >= self._hit_sample_rate
 
         truncated_purpose = purpose[:_PURPOSE_MAX_LEN]
         # Local imports — read_audit is imported at module load by the
@@ -115,6 +118,11 @@ class ReadAuditWriter:
                         provider=provider,
                         cause="machine_revoked",
                     )
+                if sampled_out:
+                    # Gate passed; skip the audit INSERT since this hit
+                    # was sampled out. The SHARE lock is released on
+                    # COMMIT below — same atomicity guarantee, no audit row.
+                    return
                 conn.execute(
                     text(
                         "INSERT INTO auth_profile_reads "

--- a/src/nexus/bricks/auth/read_audit.py
+++ b/src/nexus/bricks/auth/read_audit.py
@@ -54,10 +54,37 @@ class ReadAuditWriter:
         cache_hit: bool,
         kek_version: int,
     ) -> None:
+        """Atomically check-then-audit the credential issuance.
+
+        The transaction:
+          1. SELECT ... FOR SHARE on the caller's daemon_machines row,
+             scoped to ``revoked_at IS NULL``. The SHARE lock blocks any
+             concurrent revoke (which needs ROW EXCLUSIVE) until we commit.
+          2. INSERT the audit row.
+          3. COMMIT, releasing the SHARE lock.
+
+        With this layout, a revoke transaction can only commit BEFORE
+        step 1 (we see no row → raise MachineUnknownOrRevoked, no credential
+        returned) or AFTER our COMMIT (the audit row exists for a permitted
+        read — that's correct, the read was permitted at the moment it
+        happened — and the next request from the now-revoked daemon will
+        be denied at its own step 1). The race window codex flagged in
+        F26 (revoke between assert#3 and JSONResponse send) collapses to
+        zero because the revocation gate now lives inside the audit tx.
+
+        Cache-miss writes are fail-closed: a failure raises
+        ``AuditWriteFailed`` (audit table problem) or
+        ``MachineUnknownOrRevoked`` (revoke detected). Cache-hit writes
+        (sampled) still observe the revocation gate but swallow audit
+        insert failures so operational telemetry blips don't block reads.
+        """
         if cache_hit and self._rng.random() >= self._hit_sample_rate:
             return  # sampled out
 
         truncated_purpose = purpose[:_PURPOSE_MAX_LEN]
+        # Local imports — read_audit is imported at module load by the
+        # consumer, so top-level imports would create a cycle.
+        from nexus.bricks.auth.consumer import AuditWriteFailed, MachineUnknownOrRevoked
 
         try:
             with self._engine.begin() as conn:
@@ -65,6 +92,29 @@ class ReadAuditWriter:
                     text("SET LOCAL app.current_tenant = :t"),
                     {"t": str(tenant_id)},
                 )
+                # Atomic revocation gate (F26). FOR SHARE so concurrent
+                # reads for the same machine don't serialize against each
+                # other; only revoke (which takes ROW EXCLUSIVE) blocks.
+                row = conn.execute(
+                    text(
+                        "SELECT 1 FROM daemon_machines "
+                        "WHERE tenant_id = :t AND principal_id = :p AND id = :m "
+                        "  AND revoked_at IS NULL "
+                        "FOR SHARE"
+                    ),
+                    {
+                        "t": str(tenant_id),
+                        "p": str(principal_id),
+                        "m": str(caller_machine_id),
+                    },
+                ).fetchone()
+                if row is None:
+                    raise MachineUnknownOrRevoked.from_row(
+                        tenant_id=tenant_id,
+                        principal_id=principal_id,
+                        provider=provider,
+                        cause="machine_revoked",
+                    )
                 conn.execute(
                     text(
                         "INSERT INTO auth_profile_reads "
@@ -85,6 +135,10 @@ class ReadAuditWriter:
                     },
                 )
                 READ_AUDIT_WRITES.labels(cache="hit" if cache_hit else "miss").inc()
+        except MachineUnknownOrRevoked:
+            # Don't wrap — the revocation gate is its own well-defined
+            # failure mode, distinct from an audit-table failure.
+            raise
         except Exception as exc:  # noqa: BLE001
             logger.exception(
                 "auth_profile_reads insert failed tenant=%s principal=%s provider=%s",
@@ -93,10 +147,6 @@ class ReadAuditWriter:
                 provider,
             )
             if not cache_hit:
-                # Local import — read_audit is imported at module load by the
-                # consumer, so a top-level import would create a cycle.
-                from nexus.bricks.auth.consumer import AuditWriteFailed
-
                 raise AuditWriteFailed.from_row(
                     tenant_id=tenant_id,
                     principal_id=principal_id,

--- a/src/nexus/bricks/auth/read_audit.py
+++ b/src/nexus/bricks/auth/read_audit.py
@@ -1,0 +1,90 @@
+"""ReadAuditWriter — auth_profile_reads row per credential resolution (#3818).
+
+Sampling: 100% on cache-miss (real KMS unwrap → real credential access),
+1% on cache-hit (operational telemetry, not access). Sampling rule documented
+in deployment guide; deviation should be a deliberate operator choice.
+"""
+
+from __future__ import annotations
+
+import logging
+import random
+import uuid
+
+from sqlalchemy import text
+from sqlalchemy.engine import Engine
+
+logger = logging.getLogger(__name__)
+
+_PURPOSE_MAX_LEN = 256
+
+
+class ReadAuditWriter:
+    """Inserts ``auth_profile_reads`` rows. Caller passes RLS-set engine.
+
+    Failures are logged and swallowed. We never block a credential resolution
+    on audit-row insert — losing a single row is preferable to a blocked
+    caller, and the cache-miss path will retry naturally on the next resolve.
+    """
+
+    def __init__(
+        self,
+        *,
+        engine: Engine,
+        hit_sample_rate: float = 0.01,
+        rng: random.Random | None = None,
+    ) -> None:
+        self._engine = engine
+        self._hit_sample_rate = hit_sample_rate
+        self._rng = rng or random.Random()
+
+    def write(
+        self,
+        *,
+        tenant_id: uuid.UUID,
+        principal_id: uuid.UUID,
+        auth_profile_id: str,
+        caller_machine_id: uuid.UUID,
+        caller_kind: str,
+        provider: str,
+        purpose: str,
+        cache_hit: bool,
+        kek_version: int,
+    ) -> None:
+        if cache_hit and self._rng.random() >= self._hit_sample_rate:
+            return  # sampled out
+
+        truncated_purpose = purpose[:_PURPOSE_MAX_LEN]
+
+        try:
+            with self._engine.begin() as conn:
+                conn.execute(
+                    text("SET LOCAL app.current_tenant = :t"),
+                    {"t": str(tenant_id)},
+                )
+                conn.execute(
+                    text(
+                        "INSERT INTO auth_profile_reads "
+                        "(tenant_id, principal_id, auth_profile_id, caller_machine_id, "
+                        " caller_kind, provider, purpose, cache_hit, kek_version) "
+                        "VALUES (:t, :p, :ap, :cm, :ck, :prov, :pur, :hit, :kv)"
+                    ),
+                    {
+                        "t": str(tenant_id),
+                        "p": str(principal_id),
+                        "ap": auth_profile_id,
+                        "cm": str(caller_machine_id),
+                        "ck": caller_kind,
+                        "prov": provider,
+                        "pur": truncated_purpose,
+                        "hit": cache_hit,
+                        "kv": kek_version,
+                    },
+                )
+        except Exception:  # noqa: BLE001
+            logger.exception(
+                "auth_profile_reads insert failed tenant=%s principal=%s provider=%s",
+                tenant_id,
+                principal_id,
+                provider,
+            )

--- a/src/nexus/bricks/auth/read_audit.py
+++ b/src/nexus/bricks/auth/read_audit.py
@@ -14,6 +14,8 @@ import uuid
 from sqlalchemy import text
 from sqlalchemy.engine import Engine
 
+from nexus.bricks.auth.consumer_metrics import READ_AUDIT_WRITES
+
 logger = logging.getLogger(__name__)
 
 _PURPOSE_MAX_LEN = 256
@@ -81,6 +83,7 @@ class ReadAuditWriter:
                         "kv": kek_version,
                     },
                 )
+                READ_AUDIT_WRITES.labels(cache="hit" if cache_hit else "miss").inc()
         except Exception:  # noqa: BLE001
             logger.exception(
                 "auth_profile_reads insert failed tenant=%s principal=%s provider=%s",

--- a/src/nexus/bricks/auth/read_audit.py
+++ b/src/nexus/bricks/auth/read_audit.py
@@ -89,6 +89,11 @@ class ReadAuditWriter:
         # consumer, so top-level imports would create a cycle.
         from nexus.bricks.auth.consumer import AuditWriteFailed, MachineUnknownOrRevoked
 
+        # F28: Track whether the SHARE-lock gate proved an unrevoked row.
+        # Errors BEFORE the gate proves machine state must always fail
+        # closed — even for cache hits. Only errors AFTER the gate are
+        # candidates for the cache-hit best-effort swallow.
+        gate_passed = False
         try:
             with self._engine.begin() as conn:
                 conn.execute(
@@ -118,6 +123,7 @@ class ReadAuditWriter:
                         provider=provider,
                         cause="machine_revoked",
                     )
+                gate_passed = True
                 if sampled_out:
                     # Gate passed; skip the audit INSERT since this hit
                     # was sampled out. The SHARE lock is released on
@@ -149,12 +155,19 @@ class ReadAuditWriter:
             raise
         except Exception as exc:  # noqa: BLE001
             logger.exception(
-                "auth_profile_reads insert failed tenant=%s principal=%s provider=%s",
+                "auth_profile_reads insert failed tenant=%s principal=%s provider=%s "
+                "gate_passed=%s",
                 tenant_id,
                 principal_id,
                 provider,
+                gate_passed,
             )
-            if not cache_hit:
+            # Cache-miss: always raise. Cache-hit before gate proven:
+            # raise too — we cannot return a credential we haven't
+            # confirmed the daemon is still allowed to read. Cache-hit
+            # AFTER gate proven: best-effort swallow (operational
+            # telemetry blip on the audit INSERT only).
+            if not cache_hit or not gate_passed:
                 raise AuditWriteFailed.from_row(
                     tenant_id=tenant_id,
                     principal_id=principal_id,

--- a/src/nexus/bricks/auth/read_audit.py
+++ b/src/nexus/bricks/auth/read_audit.py
@@ -24,9 +24,10 @@ _PURPOSE_MAX_LEN = 256
 class ReadAuditWriter:
     """Inserts ``auth_profile_reads`` rows. Caller passes RLS-set engine.
 
-    Failures are logged and swallowed. We never block a credential resolution
-    on audit-row insert — losing a single row is preferable to a blocked
-    caller, and the cache-miss path will retry naturally on the next resolve.
+    Cache-miss writes are fail-closed: a failure raises ``AuditWriteFailed``
+    so the caller never returns a credential that has no durable audit
+    trail. Cache-hit writes (1% sampled) are best-effort — we log + swallow
+    so operational telemetry blips don't block a credential resolution.
     """
 
     def __init__(
@@ -84,10 +85,21 @@ class ReadAuditWriter:
                     },
                 )
                 READ_AUDIT_WRITES.labels(cache="hit" if cache_hit else "miss").inc()
-        except Exception:  # noqa: BLE001
+        except Exception as exc:  # noqa: BLE001
             logger.exception(
                 "auth_profile_reads insert failed tenant=%s principal=%s provider=%s",
                 tenant_id,
                 principal_id,
                 provider,
             )
+            if not cache_hit:
+                # Local import — read_audit is imported at module load by the
+                # consumer, so a top-level import would create a cycle.
+                from nexus.bricks.auth.consumer import AuditWriteFailed
+
+                raise AuditWriteFailed.from_row(
+                    tenant_id=tenant_id,
+                    principal_id=principal_id,
+                    provider=provider,
+                    cause=f"{type(exc).__name__}",
+                ) from exc

--- a/src/nexus/bricks/auth/tests/test_consumer.py
+++ b/src/nexus/bricks/auth/tests/test_consumer.py
@@ -751,3 +751,99 @@ def test_resolve_rejects_when_multiple_profiles_for_provider(engine):
     consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
     with pytest.raises(MultipleProfilesForProvider):
         consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
+
+
+def _seed_two_github_envelopes(engine, encryption):
+    """Helper for F21 multi-account tests: seed 'github-default' and 'github-other'
+    rows under the same (tenant, principal). Returns (tenant, principal, machine)."""
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
+    )
+    payload = json.dumps({"token": "ghp_other", "scopes": ["repo"]}).encode()
+    aad = str(tenant).encode() + b"|" + str(principal).encode() + b"|" + b"github-other"
+    dek = b"\x02" * 32
+    nonce, ct = AESGCMEnvelope().encrypt(dek, payload, aad=aad)
+    wrapped, kv = encryption.wrap_dek(dek, tenant_id=tenant, aad=aad)
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text(
+                "INSERT INTO auth_profiles "
+                "(tenant_id, principal_id, id, provider, account_identifier, "
+                " backend, backend_key, last_synced_at, sync_ttl_seconds, "
+                " ciphertext, wrapped_dek, nonce, aad, kek_version) "
+                "VALUES (:t, :p, 'github-other', 'github', 'other', 'envelope', 'k', "
+                " NOW(), 300, :ct, :wd, :no, :aad, :kv)"
+            ),
+            {
+                "t": str(tenant),
+                "p": str(principal),
+                "ct": ct,
+                "wd": wrapped,
+                "no": nonce,
+                "aad": aad,
+                "kv": kv,
+            },
+        )
+    machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+    return tenant, principal, machine
+
+
+def test_resolve_with_explicit_profile_id_picks_named_row(engine):
+    """Two profiles for one provider; explicit profile_id selects the right one.
+
+    Regression for codex round-7 finding F21 — proves the multi-account
+    contract upgrade actually disambiguates instead of always 409.
+    """
+    encryption = InMemoryEncryptionProvider()
+    tenant, principal, machine = _seed_two_github_envelopes(engine, encryption)
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+
+    default_cred = consumer.resolve(
+        claims=_claims(tenant, principal, machine),
+        provider="github",
+        profile_id="github-default",
+        purpose="x",
+    )
+    other_cred = consumer.resolve(
+        claims=_claims(tenant, principal, machine),
+        provider="github",
+        profile_id="github-other",
+        purpose="x",
+    )
+    assert default_cred.access_token == "ghp_test"
+    assert other_cred.access_token == "ghp_other"
+
+
+def test_resolve_two_profiles_without_profile_id_still_ambiguous(engine):
+    """Without profile_id (legacy form), two rows still yield 409. The new
+    selector is opt-in — back-compat for single-profile callers is preserved
+    by failing closed when the contract is under-specified."""
+    encryption = InMemoryEncryptionProvider()
+    tenant, principal, machine = _seed_two_github_envelopes(engine, encryption)
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+    with pytest.raises(MultipleProfilesForProvider):
+        consumer.resolve(
+            claims=_claims(tenant, principal, machine),
+            provider="github",
+            purpose="x",
+        )
+
+
+def test_resolve_with_unknown_profile_id_returns_not_found(engine):
+    """Explicit profile_id that matches no row → ProfileNotFoundForCaller.
+
+    Critical: must NOT silently fall back to another profile (which would
+    re-introduce the multi-account leak this fix exists to prevent)."""
+    encryption = InMemoryEncryptionProvider()
+    tenant, principal, machine = _seed_two_github_envelopes(engine, encryption)
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+    with pytest.raises(ProfileNotFoundForCaller):
+        consumer.resolve(
+            claims=_claims(tenant, principal, machine),
+            provider="github",
+            profile_id="nonexistent",
+            purpose="x",
+        )

--- a/src/nexus/bricks/auth/tests/test_consumer.py
+++ b/src/nexus/bricks/auth/tests/test_consumer.py
@@ -1,0 +1,216 @@
+"""Tests for CredentialConsumer.resolve — orchestrator covering happy / cache /
+stale / errors (#3818)."""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from nexus.bricks.auth.consumer import (
+    CredentialConsumer,
+    ProfileNotFoundForCaller,
+    ProviderNotConfigured,
+    StaleSource,
+)
+from nexus.bricks.auth.consumer_cache import ResolvedCredCache
+from nexus.bricks.auth.consumer_providers.github import GithubProviderAdapter
+from nexus.bricks.auth.envelope import AESGCMEnvelope, DEKCache
+from nexus.bricks.auth.envelope_providers.in_memory import InMemoryEncryptionProvider
+from nexus.bricks.auth.postgres_profile_store import (
+    PostgresAuthProfileStore,
+    ensure_schema,
+)
+from nexus.bricks.auth.read_audit import ReadAuditWriter
+from nexus.server.api.v1.jwt_signer import DaemonClaims
+
+
+@pytest.fixture
+def engine():
+    url = os.environ.get("NEXUS_TEST_DATABASE_URL")
+    if not url:
+        pytest.skip("NEXUS_TEST_DATABASE_URL not set")
+    eng = create_engine(url, future=True)
+    ensure_schema(eng)
+    yield eng
+    eng.dispose()
+
+
+def _seed_github_envelope(
+    *, engine, tenant_id, principal_id, encryption, sync_ttl=300, lsa_offset_seconds=0
+):
+    """Seed a github profile with a pushed envelope."""
+    payload = json.dumps({"token": "ghp_test", "scopes": ["repo"]}).encode()
+    aad = str(tenant_id).encode() + b"|" + str(principal_id).encode() + b"|" + b"github-default"
+    dek = b"\x01" * 32
+    nonce, ct = AESGCMEnvelope().encrypt(dek, payload, aad=aad)
+    wrapped, kv = encryption.wrap_dek(dek, tenant_id=tenant_id, aad=aad)
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant_id)})
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, :n) ON CONFLICT DO NOTHING"),
+            {"id": str(tenant_id), "n": f"tx-{tenant_id}"},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO principals (id, tenant_id, kind) VALUES (:id, :t, 'human') "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {"id": str(principal_id), "t": str(tenant_id)},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO auth_profiles "
+                "(tenant_id, principal_id, id, provider, account_identifier, "
+                " backend, backend_key, last_synced_at, sync_ttl_seconds, "
+                " ciphertext, wrapped_dek, nonce, aad, kek_version) "
+                "VALUES (:t, :p, 'github-default', 'github', 'me', 'envelope', 'k', "
+                " NOW() - (:off || ' seconds')::INTERVAL, :ttl, :ct, :wd, :no, :aad, :kv)"
+            ),
+            {
+                "t": str(tenant_id),
+                "p": str(principal_id),
+                "off": str(lsa_offset_seconds),
+                "ttl": sync_ttl,
+                "ct": ct,
+                "wd": wrapped,
+                "no": nonce,
+                "aad": aad,
+                "kv": kv,
+            },
+        )
+
+
+def _make_consumer(engine, tenant_id, principal_id=None, encryption=None, cache=None):
+    encryption = encryption or InMemoryEncryptionProvider()
+    cache = cache or ResolvedCredCache(ceiling_seconds=300)
+    # PostgresAuthProfileStore requires db_url (empty when engine is provided) and principal_id
+    # The store's bound principal_id is unused by decrypt_profile (which takes its own principal_id arg).
+    bound_principal = principal_id or uuid.uuid4()
+    store = PostgresAuthProfileStore(
+        "", tenant_id=tenant_id, principal_id=bound_principal, engine=engine
+    )
+    return CredentialConsumer(
+        store=store,
+        encryption=encryption,
+        dek_cache=DEKCache(),
+        cred_cache=cache,
+        adapters={"github": GithubProviderAdapter()},
+        audit=ReadAuditWriter(engine=engine, hit_sample_rate=0.01),
+    )
+
+
+def _claims(tenant_id, principal_id):
+    return DaemonClaims(
+        tenant_id=tenant_id,
+        principal_id=principal_id,
+        machine_id=uuid.uuid4(),
+    )
+
+
+def test_resolve_happy_path_returns_materialized_cred(engine):
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
+    )
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+
+    out = consumer.resolve(
+        claims=_claims(tenant, principal),
+        provider="github",
+        purpose="list-repos",
+    )
+    assert out.access_token == "ghp_test"
+    assert out.metadata["scopes_csv"] == "repo"
+
+
+def test_resolve_warm_cache_skips_decrypt(engine):
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
+    )
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+
+    first = consumer.resolve(claims=_claims(tenant, principal), provider="github", purpose="x")
+    # Drop the row so a second decrypt would fail
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(text("DELETE FROM auth_profiles WHERE tenant_id = :t"), {"t": str(tenant)})
+
+    second = consumer.resolve(claims=_claims(tenant, principal), provider="github", purpose="x")
+    assert second is first  # cached, same object
+
+
+def test_resolve_force_refresh_bypasses_cache(engine):
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
+    )
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+
+    # Prime the cache.
+    consumer.resolve(claims=_claims(tenant, principal), provider="github", purpose="x")
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(text("DELETE FROM auth_profiles WHERE tenant_id = :t"), {"t": str(tenant)})
+
+    with pytest.raises(ProfileNotFoundForCaller):
+        consumer.resolve(
+            claims=_claims(tenant, principal),
+            provider="github",
+            purpose="x",
+            force_refresh=True,
+        )
+
+
+def test_resolve_raises_profile_not_found(engine):
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, :n) ON CONFLICT DO NOTHING"),
+            {"id": str(tenant), "n": f"tx-{tenant}"},
+        )
+    consumer = _make_consumer(engine, tenant, principal)
+
+    with pytest.raises(ProfileNotFoundForCaller):
+        consumer.resolve(claims=_claims(tenant, principal), provider="github", purpose="x")
+
+
+def test_resolve_raises_provider_not_configured(engine):
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    consumer = _make_consumer(engine, tenant, principal)
+    with pytest.raises(ProviderNotConfigured):
+        consumer.resolve(
+            claims=_claims(tenant, principal),
+            provider="unknown",
+            purpose="x",
+        )
+
+
+def test_resolve_raises_stale_source_when_last_synced_past_ttl(engine):
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    _seed_github_envelope(
+        engine=engine,
+        tenant_id=tenant,
+        principal_id=principal,
+        encryption=encryption,
+        sync_ttl=60,
+        lsa_offset_seconds=120,  # 2 minutes ago, TTL is 60s → stale
+    )
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+    with pytest.raises(StaleSource):
+        consumer.resolve(claims=_claims(tenant, principal), provider="github", purpose="x")

--- a/src/nexus/bricks/auth/tests/test_consumer.py
+++ b/src/nexus/bricks/auth/tests/test_consumer.py
@@ -945,6 +945,50 @@ def test_warm_cache_unsampled_hit_still_runs_revocation_gate(engine):
         object.__setattr__(store, monkeypatched_attr, real_assert)
 
 
+def test_envelope_error_is_counted_as_failure_not_ok(engine):
+    """KMS outage / AAD mismatch / ciphertext corruption all surface as
+    EnvelopeError, which the router maps to 500. The token-exchange
+    metric MUST count these as failures (``envelope_error`` label), not
+    silently roll them up under ``ok``. Otherwise a KMS provider outage
+    looks like 100% success in
+    ``nexus_token_exchange_requests_total`` while every client is
+    getting 500s.
+
+    Regression for codex round-14 finding F30.
+    """
+    from nexus.bricks.auth.consumer_metrics import TOKEN_EXCHANGE_REQUESTS
+    from nexus.bricks.auth.envelope import EnvelopeError
+
+    encryption = InMemoryEncryptionProvider()
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
+    )
+    machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+    store = consumer._store
+    assert store is not None
+
+    def _decrypt_raises_envelope_error(*args, **kwargs):  # noqa: ARG001
+        raise EnvelopeError("simulated KMS outage")
+
+    object.__setattr__(store, "decrypt_profile", _decrypt_raises_envelope_error)
+
+    before = TOKEN_EXCHANGE_REQUESTS.labels(provider="github", result="ok")._value.get()  # noqa: SLF001
+    err_before = TOKEN_EXCHANGE_REQUESTS.labels(
+        provider="github", result="envelope_error"
+    )._value.get()  # noqa: SLF001
+    with pytest.raises(EnvelopeError):
+        consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
+    after = TOKEN_EXCHANGE_REQUESTS.labels(provider="github", result="ok")._value.get()  # noqa: SLF001
+    err_after = TOKEN_EXCHANGE_REQUESTS.labels(
+        provider="github", result="envelope_error"
+    )._value.get()  # noqa: SLF001
+    assert after == before, "EnvelopeError must NOT increment result=ok"
+    assert err_after == err_before + 1, "EnvelopeError must increment result=envelope_error"
+
+
 def test_audit_write_atomically_rejects_revoked_machine(engine):
     """ReadAuditWriter.write itself enforces the revocation gate inside
     its own transaction (SELECT FOR SHARE on daemon_machines + audit

--- a/src/nexus/bricks/auth/tests/test_consumer.py
+++ b/src/nexus/bricks/auth/tests/test_consumer.py
@@ -753,33 +753,46 @@ def test_resolve_rejects_when_multiple_profiles_for_provider(engine):
         consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
 
 
-def _seed_two_github_envelopes(engine, encryption):
-    """Helper for F21 multi-account tests: seed 'github-default' and 'github-other'
-    rows under the same (tenant, principal). Returns (tenant, principal, machine)."""
-    tenant = uuid.uuid4()
-    principal = uuid.uuid4()
-    _seed_github_envelope(
-        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
-    )
-    payload = json.dumps({"token": "ghp_other", "scopes": ["repo"]}).encode()
-    aad = str(tenant).encode() + b"|" + str(principal).encode() + b"|" + b"github-other"
-    dek = b"\x02" * 32
+def _seed_named_github_profile(
+    *, engine, tenant_id, principal_id, encryption, profile_id, account_identifier, token
+):
+    """Insert a github envelope row with caller-chosen profile_id (F23).
+
+    Mirrors the daemon's ``Pusher.push_source`` shape — profile_id is
+    ``<provider>/<account_identifier>`` and may contain ``/``, ``.``, ``@``.
+    """
+    payload = json.dumps({"token": token, "scopes": ["repo"]}).encode()
+    aad = str(tenant_id).encode() + b"|" + str(principal_id).encode() + b"|" + profile_id.encode()
+    dek = bytes([profile_id.__hash__() & 0xFF]) * 32
     nonce, ct = AESGCMEnvelope().encrypt(dek, payload, aad=aad)
-    wrapped, kv = encryption.wrap_dek(dek, tenant_id=tenant, aad=aad)
+    wrapped, kv = encryption.wrap_dek(dek, tenant_id=tenant_id, aad=aad)
     with engine.begin() as conn:
-        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant_id)})
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, :n) ON CONFLICT DO NOTHING"),
+            {"id": str(tenant_id), "n": f"tx-{tenant_id}"},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO principals (id, tenant_id, kind) VALUES (:id, :t, 'human') "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {"id": str(principal_id), "t": str(tenant_id)},
+        )
         conn.execute(
             text(
                 "INSERT INTO auth_profiles "
                 "(tenant_id, principal_id, id, provider, account_identifier, "
                 " backend, backend_key, last_synced_at, sync_ttl_seconds, "
                 " ciphertext, wrapped_dek, nonce, aad, kek_version) "
-                "VALUES (:t, :p, 'github-other', 'github', 'other', 'envelope', 'k', "
+                "VALUES (:t, :p, :pid, 'github', :acct, 'envelope', 'k', "
                 " NOW(), 300, :ct, :wd, :no, :aad, :kv)"
             ),
             {
-                "t": str(tenant),
-                "p": str(principal),
+                "t": str(tenant_id),
+                "p": str(principal_id),
+                "pid": profile_id,
+                "acct": account_identifier,
                 "ct": ct,
                 "wd": wrapped,
                 "no": nonce,
@@ -787,34 +800,65 @@ def _seed_two_github_envelopes(engine, encryption):
                 "kv": kv,
             },
         )
+
+
+def _seed_two_real_daemon_envelopes(engine, encryption):
+    """Two github profiles with REAL daemon-style IDs containing /, ., @.
+    Returns (tenant, principal, machine, alice_pid, email_pid)."""
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    alice_pid = "github/github.com/alice"
+    email_pid = "github/u@example.com"
+    _seed_named_github_profile(
+        engine=engine,
+        tenant_id=tenant,
+        principal_id=principal,
+        encryption=encryption,
+        profile_id=alice_pid,
+        account_identifier="github.com/alice",
+        token="ghp_alice",
+    )
+    _seed_named_github_profile(
+        engine=engine,
+        tenant_id=tenant,
+        principal_id=principal,
+        encryption=encryption,
+        profile_id=email_pid,
+        account_identifier="u@example.com",
+        token="ghp_email",
+    )
     machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
-    return tenant, principal, machine
+    return tenant, principal, machine, alice_pid, email_pid
 
 
 def test_resolve_with_explicit_profile_id_picks_named_row(engine):
-    """Two profiles for one provider; explicit profile_id selects the right one.
+    """Two profiles for one provider with daemon-style IDs (containing
+    ``/``, ``.``, ``@``); explicit profile_id selects the right one.
 
-    Regression for codex round-7 finding F21 — proves the multi-account
-    contract upgrade actually disambiguates instead of always 409.
+    Regression for codex round-7 F21 + round-8 F23: proves multi-account
+    disambiguation works against profile IDs the real daemon writer
+    actually produces, not just synthetic single-segment slugs.
     """
     encryption = InMemoryEncryptionProvider()
-    tenant, principal, machine = _seed_two_github_envelopes(engine, encryption)
+    tenant, principal, machine, alice_pid, email_pid = _seed_two_real_daemon_envelopes(
+        engine, encryption
+    )
     consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
 
-    default_cred = consumer.resolve(
+    alice = consumer.resolve(
         claims=_claims(tenant, principal, machine),
         provider="github",
-        profile_id="github-default",
+        profile_id=alice_pid,
         purpose="x",
     )
-    other_cred = consumer.resolve(
+    email = consumer.resolve(
         claims=_claims(tenant, principal, machine),
         provider="github",
-        profile_id="github-other",
+        profile_id=email_pid,
         purpose="x",
     )
-    assert default_cred.access_token == "ghp_test"
-    assert other_cred.access_token == "ghp_other"
+    assert alice.access_token == "ghp_alice"
+    assert email.access_token == "ghp_email"
 
 
 def test_resolve_two_profiles_without_profile_id_still_ambiguous(engine):
@@ -822,7 +866,7 @@ def test_resolve_two_profiles_without_profile_id_still_ambiguous(engine):
     selector is opt-in — back-compat for single-profile callers is preserved
     by failing closed when the contract is under-specified."""
     encryption = InMemoryEncryptionProvider()
-    tenant, principal, machine = _seed_two_github_envelopes(engine, encryption)
+    tenant, principal, machine, _, _ = _seed_two_real_daemon_envelopes(engine, encryption)
     consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
     with pytest.raises(MultipleProfilesForProvider):
         consumer.resolve(
@@ -838,12 +882,12 @@ def test_resolve_with_unknown_profile_id_returns_not_found(engine):
     Critical: must NOT silently fall back to another profile (which would
     re-introduce the multi-account leak this fix exists to prevent)."""
     encryption = InMemoryEncryptionProvider()
-    tenant, principal, machine = _seed_two_github_envelopes(engine, encryption)
+    tenant, principal, machine, _, _ = _seed_two_real_daemon_envelopes(engine, encryption)
     consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
     with pytest.raises(ProfileNotFoundForCaller):
         consumer.resolve(
             claims=_claims(tenant, principal, machine),
             provider="github",
-            profile_id="nonexistent",
+            profile_id="github/nonexistent",
             purpose="x",
         )

--- a/src/nexus/bricks/auth/tests/test_consumer.py
+++ b/src/nexus/bricks/auth/tests/test_consumer.py
@@ -177,6 +177,10 @@ def test_resolve_happy_path_returns_materialized_cred(engine):
 
 
 def test_resolve_warm_cache_skips_decrypt(engine):
+    """Cache hit returns the same materialized object without re-running
+    envelope decryption. (Cache hits still re-check profile state via
+    assert_profile_active — see test_cache_hit_evicts_when_disabled.)
+    """
     tenant = uuid.uuid4()
     principal = uuid.uuid4()
     encryption = InMemoryEncryptionProvider()
@@ -189,14 +193,11 @@ def test_resolve_warm_cache_skips_decrypt(engine):
     first = consumer.resolve(
         claims=_claims(tenant, principal, machine), provider="github", purpose="x"
     )
-    # Drop the row so a second decrypt would fail
-    with engine.begin() as conn:
-        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
-        conn.execute(text("DELETE FROM auth_profiles WHERE tenant_id = :t"), {"t": str(tenant)})
-
+    unwraps_after_first = encryption.unwrap_count
     second = consumer.resolve(
         claims=_claims(tenant, principal, machine), provider="github", purpose="x"
     )
+    assert encryption.unwrap_count == unwraps_after_first, "second call must not unwrap"
     assert second is first  # cached, same object
 
 
@@ -403,21 +404,16 @@ def test_resolve_skips_cooled_down_profile(engine):
         consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
 
 
-def test_resolve_logs_warning_on_cross_machine_read(engine, caplog):
-    """Reader machine_id != writer machine_id → log warning + cross-machine metric."""
-    import logging
-
+def _setup_cross_machine_envelope(engine, encryption):
+    """Helper: envelope pushed by daemon X, reader is daemon Y on same principal."""
     tenant = uuid.uuid4()
     principal = uuid.uuid4()
-    encryption = InMemoryEncryptionProvider()
     _seed_github_envelope(
         engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
     )
     writer_machine = uuid.uuid4()
-    # Stamp the envelope with a writer machine_id different from the reader.
     with engine.begin() as conn:
         conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
-        # Insert writer_machine row (FK constraint)
         conn.execute(
             text(
                 "INSERT INTO daemon_machines (id, tenant_id, principal_id, pubkey) "
@@ -435,14 +431,65 @@ def test_resolve_logs_warning_on_cross_machine_read(engine, caplog):
             {"m": str(writer_machine), "t": str(tenant)},
         )
     reader_machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+    return tenant, principal, reader_machine, writer_machine
+
+
+def test_resolve_rejects_cross_machine_read_by_default(engine, monkeypatch):
+    """Default: reader.machine_id != writer.machine_id → MachineUnknownOrRevoked.
+    Prevents a compromised secondary daemon from exchanging another
+    machine's pushed credential."""
+    monkeypatch.delenv("NEXUS_AUTH_ALLOW_CROSS_MACHINE_READ", raising=False)
+    encryption = InMemoryEncryptionProvider()
+    tenant, principal, reader_machine, _ = _setup_cross_machine_envelope(engine, encryption)
     consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
-    with caplog.at_level(logging.WARNING, logger="nexus.bricks.auth.consumer"):
+    with pytest.raises(MachineUnknownOrRevoked) as exc:
         consumer.resolve(
             claims=_claims(tenant, principal, reader_machine), provider="github", purpose="x"
         )
-    assert any("cross_machine_read" in rec.message for rec in caplog.records), (
-        f"expected cross_machine_read warning, got: {[r.message for r in caplog.records]}"
+    assert exc.value.cause == "cross_machine_read_disallowed"
+
+
+def test_resolve_allows_cross_machine_read_when_opted_in(engine, monkeypatch, caplog):
+    """Opt-in via env: cross-machine read succeeds; warning + metric still fire."""
+    import logging
+
+    monkeypatch.setenv("NEXUS_AUTH_ALLOW_CROSS_MACHINE_READ", "1")
+    encryption = InMemoryEncryptionProvider()
+    tenant, principal, reader_machine, _ = _setup_cross_machine_envelope(engine, encryption)
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+    with caplog.at_level(logging.WARNING, logger="nexus.bricks.auth.consumer"):
+        out = consumer.resolve(
+            claims=_claims(tenant, principal, reader_machine), provider="github", purpose="x"
+        )
+    assert out.access_token == "ghp_test"
+    assert any("cross_machine_read" in rec.message for rec in caplog.records)
+
+
+def test_cache_hit_evicts_when_profile_disabled_after_caching(engine):
+    """A profile disabled AFTER cache prime must take effect within ms, not
+    wait for the cache TTL."""
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
     )
+    machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+    consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
+    # Operator disables the profile while the cache is still warm.
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text(
+                "UPDATE auth_profiles SET disabled_until = NOW() + INTERVAL '1 hour' "
+                "WHERE tenant_id = :t"
+            ),
+            {"t": str(tenant)},
+        )
+    with pytest.raises(ProfileNotFoundForCaller) as exc:
+        consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
+    assert exc.value.cause == "profile_disabled_or_cooldown"
 
 
 def test_resolve_rejects_when_multiple_profiles_for_provider(engine):

--- a/src/nexus/bricks/auth/tests/test_consumer.py
+++ b/src/nexus/bricks/auth/tests/test_consumer.py
@@ -891,6 +891,99 @@ def test_resolve_rejects_revoke_committed_after_initial_machine_check(engine):
         store.decrypt_profile = real_decrypt
 
 
+def test_resolve_rejects_revoke_committed_during_audit_write(engine):
+    """A revoke that commits between audit.write start and the post-audit
+    check must still be observed and reject the call. The audit row is
+    expected to remain (revoked daemon DID try to read; audit log captures
+    every attempt).
+
+    Wraps audit.write to commit a revoke from a separate connection while
+    audit's own transaction is still in flight; the third
+    assert_machine_active call (F26) must catch it.
+    """
+    encryption = InMemoryEncryptionProvider()
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
+    )
+    machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+
+    real_audit_write = consumer._audit.write  # noqa: SLF001 — test introspection
+
+    def _audit_then_revoke(*args, **kwargs):
+        result = real_audit_write(*args, **kwargs)
+        with engine.begin() as conn:
+            conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+            conn.execute(
+                text("UPDATE daemon_machines SET revoked_at = NOW() WHERE id = :m"),
+                {"m": str(machine)},
+            )
+        return result
+
+    consumer._audit.write = _audit_then_revoke
+    try:
+        with pytest.raises(MachineUnknownOrRevoked) as exc:
+            consumer.resolve(
+                claims=_claims(tenant, principal, machine), provider="github", purpose="x"
+            )
+        assert exc.value.cause == "machine_revoked"
+    finally:
+        consumer._audit.write = real_audit_write
+
+
+def test_resolve_succeeds_with_active_plus_stale_sibling_profile(engine):
+    """A single active default profile + a stale sibling row must NOT
+    trigger 409 ambiguous_profile. assert_profile_active filters out the
+    stale one, but decrypt_profile used to re-query without that filter
+    and see both rows. F27: decrypt is now scoped to the precheck's
+    matched profile_id so stale siblings can't widen the query.
+    """
+    encryption = InMemoryEncryptionProvider()
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    # Active row pushed fresh.
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
+    )
+    # Sibling row, same provider, last_synced_at past sync_ttl_seconds (300).
+    payload = json.dumps({"token": "ghp_stale", "scopes": ["repo"]}).encode()
+    aad = str(tenant).encode() + b"|" + str(principal).encode() + b"|" + b"github-stale"
+    dek = b"\x09" * 32
+    nonce, ct = AESGCMEnvelope().encrypt(dek, payload, aad=aad)
+    wrapped, kv = encryption.wrap_dek(dek, tenant_id=tenant, aad=aad)
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text(
+                "INSERT INTO auth_profiles "
+                "(tenant_id, principal_id, id, provider, account_identifier, "
+                " backend, backend_key, last_synced_at, sync_ttl_seconds, "
+                " ciphertext, wrapped_dek, nonce, aad, kek_version) "
+                "VALUES (:t, :p, 'github-stale', 'github', 'stale', 'envelope', 'k', "
+                " NOW() - INTERVAL '1 hour', 300, :ct, :wd, :no, :aad, :kv)"
+            ),
+            {
+                "t": str(tenant),
+                "p": str(principal),
+                "ct": ct,
+                "wd": wrapped,
+                "no": nonce,
+                "aad": aad,
+                "kv": kv,
+            },
+        )
+    machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+    # No profile_id → precheck filters to the one active row, decrypt scoped
+    # to that row's id, no ambiguity even though a stale sibling exists.
+    out = consumer.resolve(
+        claims=_claims(tenant, principal, machine), provider="github", purpose="x"
+    )
+    assert out.access_token == "ghp_test"
+
+
 def _seed_named_github_profile(
     *, engine, tenant_id, principal_id, encryption, profile_id, account_identifier, token
 ):

--- a/src/nexus/bricks/auth/tests/test_consumer.py
+++ b/src/nexus/bricks/auth/tests/test_consumer.py
@@ -891,6 +891,60 @@ def test_resolve_rejects_revoke_committed_after_initial_machine_check(engine):
         store.decrypt_profile = real_decrypt
 
 
+def test_warm_cache_unsampled_hit_still_runs_revocation_gate(engine):
+    """The 99% common case (warm cache, audit sampled out) must STILL run
+    the SHARE-lock revocation gate inside audit.write, not skip it via
+    early return.
+
+    Setup: hit_sample_rate=0.0 so every cache hit is sampled out. Prime
+    cache, revoke daemon, request again. Even with no audit row written,
+    the gate must fire and raise MachineUnknownOrRevoked. Closes the
+    last F26 sub-finding (sampled-out cache hits bypass the gate).
+    """
+    encryption = InMemoryEncryptionProvider()
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
+    )
+    machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+    # Force every hit to be sampled out so the gate is the ONLY thing
+    # the audit.write call does on the hit path.
+    consumer = CredentialConsumer(
+        store=PostgresAuthProfileStore("", tenant_id=tenant, principal_id=principal, engine=engine),
+        encryption=encryption,
+        dek_cache=DEKCache(),
+        cred_cache=ResolvedCredCache(ceiling_seconds=300),
+        adapters={"github": GithubProviderAdapter()},
+        audit=ReadAuditWriter(engine=engine, hit_sample_rate=0.0),
+    )
+    # Prime the cache with a legit request.
+    consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
+    # Revoke the daemon. The next resolve will hit the cache, fingerprint
+    # will match, and would early-return without the gate. With the gate,
+    # audit.write's SHARE-lock SELECT sees revoked_at IS NOT NULL → raises.
+    _revoke_machine(engine=engine, tenant_id=tenant, machine_id=machine)
+    # The top-of-resolve assert_machine_active will catch this too —
+    # neutralise it via monkeypatch so we exercise the cache-hit gate
+    # (the audit.write SHARE-lock SELECT) specifically.
+    store = consumer._store
+    assert store is not None
+
+    def _passthrough(*args, **kwargs):  # noqa: ARG001
+        pass
+
+    monkeypatched_attr = "assert_machine_active"
+    real_assert = getattr(store, monkeypatched_attr)
+    object.__setattr__(store, monkeypatched_attr, _passthrough)
+    try:
+        with pytest.raises(MachineUnknownOrRevoked):
+            consumer.resolve(
+                claims=_claims(tenant, principal, machine), provider="github", purpose="x"
+            )
+    finally:
+        object.__setattr__(store, monkeypatched_attr, real_assert)
+
+
 def test_audit_write_atomically_rejects_revoked_machine(engine):
     """ReadAuditWriter.write itself enforces the revocation gate inside
     its own transaction (SELECT FOR SHARE on daemon_machines + audit

--- a/src/nexus/bricks/auth/tests/test_consumer.py
+++ b/src/nexus/bricks/auth/tests/test_consumer.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import os
 import uuid
+from datetime import timedelta
 
 import pytest
 from sqlalchemy import create_engine, text
@@ -751,6 +752,143 @@ def test_resolve_rejects_when_multiple_profiles_for_provider(engine):
     consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
     with pytest.raises(MultipleProfilesForProvider):
         consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
+
+
+def _seed_github_envelope_with_expiry(*, engine, tenant_id, principal_id, encryption, expires_at):
+    """Seed a github profile whose materialized credential carries an
+    explicit expires_at — used to drive F24 (expired-cred rejection)."""
+    payload = json.dumps(
+        {"token": "ghp_expired", "scopes": ["repo"], "expires_at": expires_at.isoformat()}
+    ).encode()
+    aad = str(tenant_id).encode() + b"|" + str(principal_id).encode() + b"|" + b"github-default"
+    dek = b"\x07" * 32
+    nonce, ct = AESGCMEnvelope().encrypt(dek, payload, aad=aad)
+    wrapped, kv = encryption.wrap_dek(dek, tenant_id=tenant_id, aad=aad)
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant_id)})
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, :n) ON CONFLICT DO NOTHING"),
+            {"id": str(tenant_id), "n": f"tx-{tenant_id}"},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO principals (id, tenant_id, kind) VALUES (:id, :t, 'human') "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {"id": str(principal_id), "t": str(tenant_id)},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO auth_profiles "
+                "(tenant_id, principal_id, id, provider, account_identifier, "
+                " backend, backend_key, last_synced_at, sync_ttl_seconds, "
+                " ciphertext, wrapped_dek, nonce, aad, kek_version) "
+                "VALUES (:t, :p, 'github-default', 'github', 'me', 'envelope', 'k', "
+                " NOW(), 300, :ct, :wd, :no, :aad, :kv)"
+            ),
+            {
+                "t": str(tenant_id),
+                "p": str(principal_id),
+                "ct": ct,
+                "wd": wrapped,
+                "no": nonce,
+                "aad": aad,
+                "kv": kv,
+            },
+        )
+
+
+def test_resolve_rejects_expired_materialized_credential(engine):
+    """A decrypted PAT/STS payload whose own expires_at is already past
+    must surface as StaleSource, not a 200 with ``expires_in: 0``.
+
+    Regression for codex round-9 finding F24.
+    """
+    from datetime import UTC, datetime
+
+    encryption = InMemoryEncryptionProvider()
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    _seed_github_envelope_with_expiry(
+        engine=engine,
+        tenant_id=tenant,
+        principal_id=principal,
+        encryption=encryption,
+        expires_at=datetime.now(UTC) - timedelta(minutes=5),
+    )
+    machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+    with pytest.raises(StaleSource) as exc:
+        consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
+    assert "expired" in (exc.value.cause or "")
+
+
+def test_resolve_rejects_credential_inside_refresh_headroom(engine):
+    """Tokens whose expiry is within the 60s refresh-headroom window are
+    treated as already-expired — clients shouldn't get a token they have
+    less than a minute to use before the upstream provider rejects it."""
+    from datetime import UTC, datetime
+
+    encryption = InMemoryEncryptionProvider()
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    _seed_github_envelope_with_expiry(
+        engine=engine,
+        tenant_id=tenant,
+        principal_id=principal,
+        encryption=encryption,
+        expires_at=datetime.now(UTC) + timedelta(seconds=30),  # inside headroom
+    )
+    machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+    with pytest.raises(StaleSource):
+        consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
+
+
+def test_resolve_rejects_revoke_committed_after_initial_machine_check(engine):
+    """A revoke that commits AFTER the top-of-resolve assert_machine_active
+    but BEFORE the response must still be observed and reject the call.
+
+    Approach: monkey-patch ``decrypt_profile`` so that the moment it runs
+    (between the two assert_machine_active calls) we revoke the daemon
+    out-of-band. The second assert (F25's double-check) must catch the
+    revocation and raise MachineUnknownOrRevoked.
+
+    Regression for codex round-9 finding F25.
+    """
+    encryption = InMemoryEncryptionProvider()
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
+    )
+    machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+
+    store = consumer._store  # noqa: SLF001 — test introspection
+    real_decrypt = store.decrypt_profile
+
+    def _decrypt_then_revoke(*args, **kwargs):
+        result = real_decrypt(*args, **kwargs)
+        # Out-of-band revocation in a SEPARATE engine connection so we
+        # commit while the resolve call is mid-flight.
+        with engine.begin() as conn:
+            conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+            conn.execute(
+                text("UPDATE daemon_machines SET revoked_at = NOW() WHERE id = :m"),
+                {"m": str(machine)},
+            )
+        return result
+
+    store.decrypt_profile = _decrypt_then_revoke
+    try:
+        with pytest.raises(MachineUnknownOrRevoked) as exc:
+            consumer.resolve(
+                claims=_claims(tenant, principal, machine), provider="github", purpose="x"
+            )
+        assert exc.value.cause == "machine_revoked"
+    finally:
+        store.decrypt_profile = real_decrypt
 
 
 def _seed_named_github_profile(

--- a/src/nexus/bricks/auth/tests/test_consumer.py
+++ b/src/nexus/bricks/auth/tests/test_consumer.py
@@ -12,6 +12,8 @@ from sqlalchemy import create_engine, text
 
 from nexus.bricks.auth.consumer import (
     CredentialConsumer,
+    MachineUnknownOrRevoked,
+    MultipleProfilesForProvider,
     ProfileNotFoundForCaller,
     ProviderNotConfigured,
     StaleSource,
@@ -84,6 +86,50 @@ def _seed_github_envelope(
         )
 
 
+def _seed_active_machine(*, engine, tenant_id, principal_id) -> uuid.UUID:
+    """Insert a tenant/principal/active-daemon row; return the machine UUID.
+
+    Required because consumer.resolve now performs a daemon_machines
+    revocation check before any cache lookup or decrypt.
+    """
+    machine_id = uuid.uuid4()
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant_id)})
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, :n) ON CONFLICT DO NOTHING"),
+            {"id": str(tenant_id), "n": f"tx-{tenant_id}"},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO principals (id, tenant_id, kind) VALUES (:id, :t, 'human') "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {"id": str(principal_id), "t": str(tenant_id)},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO daemon_machines (id, tenant_id, principal_id, pubkey) "
+                "VALUES (:m, :t, :p, :pk) ON CONFLICT DO NOTHING"
+            ),
+            {
+                "m": str(machine_id),
+                "t": str(tenant_id),
+                "p": str(principal_id),
+                "pk": b"test-pubkey-" + machine_id.bytes,
+            },
+        )
+    return machine_id
+
+
+def _revoke_machine(*, engine, tenant_id, machine_id) -> None:
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant_id)})
+        conn.execute(
+            text("UPDATE daemon_machines SET revoked_at = NOW() WHERE id = :m"),
+            {"m": str(machine_id)},
+        )
+
+
 def _make_consumer(engine, tenant_id, principal_id=None, encryption=None, cache=None):
     encryption = encryption or InMemoryEncryptionProvider()
     cache = cache or ResolvedCredCache(ceiling_seconds=300)
@@ -103,11 +149,11 @@ def _make_consumer(engine, tenant_id, principal_id=None, encryption=None, cache=
     )
 
 
-def _claims(tenant_id, principal_id):
+def _claims(tenant_id, principal_id, machine_id=None):
     return DaemonClaims(
         tenant_id=tenant_id,
         principal_id=principal_id,
-        machine_id=uuid.uuid4(),
+        machine_id=machine_id or uuid.uuid4(),
     )
 
 
@@ -118,10 +164,11 @@ def test_resolve_happy_path_returns_materialized_cred(engine):
     _seed_github_envelope(
         engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
     )
+    machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
     consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
 
     out = consumer.resolve(
-        claims=_claims(tenant, principal),
+        claims=_claims(tenant, principal, machine),
         provider="github",
         purpose="list-repos",
     )
@@ -136,15 +183,20 @@ def test_resolve_warm_cache_skips_decrypt(engine):
     _seed_github_envelope(
         engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
     )
+    machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
     consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
 
-    first = consumer.resolve(claims=_claims(tenant, principal), provider="github", purpose="x")
+    first = consumer.resolve(
+        claims=_claims(tenant, principal, machine), provider="github", purpose="x"
+    )
     # Drop the row so a second decrypt would fail
     with engine.begin() as conn:
         conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
         conn.execute(text("DELETE FROM auth_profiles WHERE tenant_id = :t"), {"t": str(tenant)})
 
-    second = consumer.resolve(claims=_claims(tenant, principal), provider="github", purpose="x")
+    second = consumer.resolve(
+        claims=_claims(tenant, principal, machine), provider="github", purpose="x"
+    )
     assert second is first  # cached, same object
 
 
@@ -155,17 +207,18 @@ def test_resolve_force_refresh_bypasses_cache(engine):
     _seed_github_envelope(
         engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
     )
+    machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
     consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
 
     # Prime the cache.
-    consumer.resolve(claims=_claims(tenant, principal), provider="github", purpose="x")
+    consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
     with engine.begin() as conn:
         conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
         conn.execute(text("DELETE FROM auth_profiles WHERE tenant_id = :t"), {"t": str(tenant)})
 
     with pytest.raises(ProfileNotFoundForCaller):
         consumer.resolve(
-            claims=_claims(tenant, principal),
+            claims=_claims(tenant, principal, machine),
             provider="github",
             purpose="x",
             force_refresh=True,
@@ -175,16 +228,11 @@ def test_resolve_force_refresh_bypasses_cache(engine):
 def test_resolve_raises_profile_not_found(engine):
     tenant = uuid.uuid4()
     principal = uuid.uuid4()
-    with engine.begin() as conn:
-        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
-        conn.execute(
-            text("INSERT INTO tenants (id, name) VALUES (:id, :n) ON CONFLICT DO NOTHING"),
-            {"id": str(tenant), "n": f"tx-{tenant}"},
-        )
+    machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
     consumer = _make_consumer(engine, tenant, principal)
 
     with pytest.raises(ProfileNotFoundForCaller):
-        consumer.resolve(claims=_claims(tenant, principal), provider="github", purpose="x")
+        consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
 
 
 def test_resolve_raises_provider_not_configured(engine):
@@ -211,6 +259,84 @@ def test_resolve_raises_stale_source_when_last_synced_past_ttl(engine):
         sync_ttl=60,
         lsa_offset_seconds=120,  # 2 minutes ago, TTL is 60s → stale
     )
+    machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
     consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
     with pytest.raises(StaleSource):
+        consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
+
+
+def test_resolve_rejects_unknown_machine(engine):
+    """JWT-valid but no daemon_machines row → MachineUnknownOrRevoked."""
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
+    )
+    # No _seed_active_machine — claims carry a fresh machine_id with no row.
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+    with pytest.raises(MachineUnknownOrRevoked) as exc:
         consumer.resolve(claims=_claims(tenant, principal), provider="github", purpose="x")
+    assert exc.value.cause == "machine_unknown"
+
+
+def test_resolve_rejects_revoked_machine_even_when_cached(engine):
+    """Revoking the daemon row mid-cache must invalidate further reads."""
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
+    )
+    machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+
+    # Prime cache.
+    consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
+    # Revoke after cache populated.
+    _revoke_machine(engine=engine, tenant_id=tenant, machine_id=machine)
+    with pytest.raises(MachineUnknownOrRevoked) as exc:
+        consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
+    assert exc.value.cause == "machine_revoked"
+
+
+def test_resolve_rejects_when_multiple_profiles_for_provider(engine):
+    """Two envelope rows for same (tenant, principal, provider) → fail closed."""
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    # First profile — uses the helper which writes 'github-default'.
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
+    )
+    # Second profile, different id, same provider — manually inserted.
+    payload = json.dumps({"token": "ghp_other", "scopes": ["repo"]}).encode()
+    aad = str(tenant).encode() + b"|" + str(principal).encode() + b"|" + b"github-other"
+    dek = b"\x02" * 32
+    nonce, ct = AESGCMEnvelope().encrypt(dek, payload, aad=aad)
+    wrapped, kv = encryption.wrap_dek(dek, tenant_id=tenant, aad=aad)
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text(
+                "INSERT INTO auth_profiles "
+                "(tenant_id, principal_id, id, provider, account_identifier, "
+                " backend, backend_key, last_synced_at, sync_ttl_seconds, "
+                " ciphertext, wrapped_dek, nonce, aad, kek_version) "
+                "VALUES (:t, :p, 'github-other', 'github', 'other', 'envelope', 'k', "
+                " NOW(), 300, :ct, :wd, :no, :aad, :kv)"
+            ),
+            {
+                "t": str(tenant),
+                "p": str(principal),
+                "ct": ct,
+                "wd": wrapped,
+                "no": nonce,
+                "aad": aad,
+                "kv": kv,
+            },
+        )
+    machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+    with pytest.raises(MultipleProfilesForProvider):
+        consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")

--- a/src/nexus/bricks/auth/tests/test_consumer.py
+++ b/src/nexus/bricks/auth/tests/test_consumer.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 import json
 import os
 import uuid
-from datetime import timedelta
+from datetime import UTC, timedelta
 
 import pytest
 from sqlalchemy import create_engine, text
@@ -987,6 +987,53 @@ def test_envelope_error_is_counted_as_failure_not_ok(engine):
     )._value.get()  # noqa: SLF001
     assert after == before, "EnvelopeError must NOT increment result=ok"
     assert err_after == err_before + 1, "EnvelopeError must increment result=envelope_error"
+
+
+def test_decrypt_rejects_row_that_went_stale_after_precheck(engine):
+    """Race window between assert_profile_active (T0) and decrypt_profile
+    (T1): the row was fresh at T0 but crossed its sync_ttl boundary by T1.
+    decrypt_profile MUST evaluate freshness atomically with the row read
+    so we fail closed with StaleSource instead of decrypting and serving
+    a credential past its declared sync_ttl_seconds.
+
+    Simulated by seeding an already-stale row (lsa = NOW - 120s, ttl = 60s)
+    and monkey-patching assert_profile_active to return a fingerprint as
+    if the precheck succeeded — the fix has to live in decrypt_profile.
+
+    Regression for codex round-15 finding F31.
+    """
+    from datetime import datetime
+
+    from nexus.bricks.auth.postgres_profile_store import ProfileFingerprint
+
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    _seed_github_envelope(
+        engine=engine,
+        tenant_id=tenant,
+        principal_id=principal,
+        encryption=encryption,
+        sync_ttl=60,
+        lsa_offset_seconds=120,
+    )
+    machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+    store = consumer._store
+    assert store is not None
+
+    def _passthrough_precheck(*, principal_id, provider, profile_id=None):  # noqa: ARG001
+        return ProfileFingerprint(
+            profile_id="github-default",
+            writer_machine_id=None,
+            kek_version=1,
+            last_synced_at=datetime.now(UTC),
+        )
+
+    object.__setattr__(store, "assert_profile_active", _passthrough_precheck)
+
+    with pytest.raises(StaleSource):
+        consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
 
 
 def test_audit_write_atomically_rejects_revoked_machine(engine):

--- a/src/nexus/bricks/auth/tests/test_consumer.py
+++ b/src/nexus/bricks/auth/tests/test_consumer.py
@@ -496,6 +496,55 @@ def test_warm_cache_evicts_when_source_goes_stale(engine):
         consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
 
 
+def test_cross_machine_denial_does_not_decrypt_payload(engine, monkeypatch):
+    """Disallowed cross-machine read must reject BEFORE the envelope is
+    unwrapped — we never want another daemon's plaintext to land in
+    process memory just to be discarded.
+
+    Counts ``encryption.unwrap_count`` and proves it stays at 0 across
+    a denied request. Regression for codex round-7 finding F22.
+    """
+    monkeypatch.delenv("NEXUS_AUTH_ALLOW_CROSS_MACHINE_READ", raising=False)
+    encryption = InMemoryEncryptionProvider()
+    tenant, principal, reader_machine, _ = _setup_cross_machine_envelope(engine, encryption)
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+    before = encryption.unwrap_count
+    with pytest.raises(MachineUnknownOrRevoked) as exc:
+        consumer.resolve(
+            claims=_claims(tenant, principal, reader_machine), provider="github", purpose="x"
+        )
+    assert exc.value.cause == "cross_machine_read_disallowed"
+    assert encryption.unwrap_count == before, (
+        "DEK was unwrapped despite the cross-machine policy denying the read"
+    )
+
+
+def test_stale_source_does_not_decrypt_payload(engine):
+    """Stale-source rejection on cache miss must reject BEFORE decrypt —
+    a stuck daemon's last envelope must never be materialized just to
+    return 409 stale_source. Regression for codex round-7 finding F22.
+    """
+    encryption = InMemoryEncryptionProvider()
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    # Seed the row with last_synced_at already past sync_ttl_seconds (300).
+    _seed_github_envelope(
+        engine=engine,
+        tenant_id=tenant,
+        principal_id=principal,
+        encryption=encryption,
+        lsa_offset_seconds=3600,  # one hour stale
+    )
+    machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+    before = encryption.unwrap_count
+    with pytest.raises(StaleSource):
+        consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
+    assert encryption.unwrap_count == before, (
+        "DEK was unwrapped despite the row being known stale before decrypt"
+    )
+
+
 def test_cache_hit_audit_row_names_real_profile_and_kek_version(engine):
     """Sampled cache-hit audit rows must name the credential that was served
     (profile_id + kek_version from the cached fingerprint), not a sentinel
@@ -657,7 +706,9 @@ def test_cache_hit_evicts_when_profile_disabled_after_caching(engine):
         )
     with pytest.raises(ProfileNotFoundForCaller) as exc:
         consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
-    assert exc.value.cause == "profile_disabled_or_cooldown"
+    # Unified cause name — assert_profile_active runs at the front of every
+    # request now, raising ProfileNotFound for disable/cooldown/missing alike.
+    assert exc.value.cause == "no_active_profile"
 
 
 def test_resolve_rejects_when_multiple_profiles_for_provider(engine):

--- a/src/nexus/bricks/auth/tests/test_consumer.py
+++ b/src/nexus/bricks/auth/tests/test_consumer.py
@@ -300,6 +300,151 @@ def test_resolve_rejects_revoked_machine_even_when_cached(engine):
     assert exc.value.cause == "machine_revoked"
 
 
+def test_audit_failure_evicts_cred_from_cache(engine):
+    """A failed cache-miss audit must NOT pollute cred_cache. If it did, the
+    next request would hit cache (no audit attempted) and silently return a
+    credential with no durable read record — exactly the gap F8 plugged.
+    Asserts the order: audit.write happens BEFORE cred_cache.put.
+    """
+    from unittest.mock import MagicMock
+
+    from nexus.bricks.auth.consumer import AuditWriteFailed
+
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
+    )
+    machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+
+    bound_principal = principal
+    store = PostgresAuthProfileStore(
+        "", tenant_id=tenant, principal_id=bound_principal, engine=engine
+    )
+    cache = ResolvedCredCache(ceiling_seconds=300)
+    audit = MagicMock()
+    audit.write.side_effect = AuditWriteFailed.from_row(
+        tenant_id=tenant,
+        principal_id=principal,
+        provider="github",
+        cause="forced",
+    )
+    consumer = CredentialConsumer(
+        store=store,
+        encryption=encryption,
+        dek_cache=DEKCache(),
+        cred_cache=cache,
+        adapters={"github": GithubProviderAdapter()},
+        audit=audit,
+    )
+
+    with pytest.raises(AuditWriteFailed):
+        consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
+
+    # Cache must NOT contain the materialized cred — second call must
+    # re-attempt audit (and fail again), NOT silently return from cache.
+    audit.write.reset_mock()
+    audit.write.side_effect = AuditWriteFailed.from_row(
+        tenant_id=tenant,
+        principal_id=principal,
+        provider="github",
+        cause="still failing",
+    )
+    with pytest.raises(AuditWriteFailed):
+        consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
+    assert audit.write.call_count == 1, "second resolve must re-attempt audit, not hit cache"
+
+
+def test_resolve_skips_disabled_profile(engine):
+    """A profile with disabled_until in the future must not be returned."""
+
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
+    )
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text(
+                "UPDATE auth_profiles SET disabled_until = NOW() + INTERVAL '1 hour' "
+                "WHERE tenant_id = :t"
+            ),
+            {"t": str(tenant)},
+        )
+    machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+    with pytest.raises(ProfileNotFoundForCaller):
+        consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
+
+
+def test_resolve_skips_cooled_down_profile(engine):
+    """A profile with cooldown_until in the future must not be returned."""
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
+    )
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text(
+                "UPDATE auth_profiles SET cooldown_until = NOW() + INTERVAL '5 minutes' "
+                "WHERE tenant_id = :t"
+            ),
+            {"t": str(tenant)},
+        )
+    machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+    with pytest.raises(ProfileNotFoundForCaller):
+        consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
+
+
+def test_resolve_logs_warning_on_cross_machine_read(engine, caplog):
+    """Reader machine_id != writer machine_id → log warning + cross-machine metric."""
+    import logging
+
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
+    )
+    writer_machine = uuid.uuid4()
+    # Stamp the envelope with a writer machine_id different from the reader.
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        # Insert writer_machine row (FK constraint)
+        conn.execute(
+            text(
+                "INSERT INTO daemon_machines (id, tenant_id, principal_id, pubkey) "
+                "VALUES (:m, :t, :p, :pk) ON CONFLICT DO NOTHING"
+            ),
+            {
+                "m": str(writer_machine),
+                "t": str(tenant),
+                "p": str(principal),
+                "pk": b"writer-pk-" + writer_machine.bytes,
+            },
+        )
+        conn.execute(
+            text("UPDATE auth_profiles SET machine_id = :m WHERE tenant_id = :t"),
+            {"m": str(writer_machine), "t": str(tenant)},
+        )
+    reader_machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+    with caplog.at_level(logging.WARNING, logger="nexus.bricks.auth.consumer"):
+        consumer.resolve(
+            claims=_claims(tenant, principal, reader_machine), provider="github", purpose="x"
+        )
+    assert any("cross_machine_read" in rec.message for rec in caplog.records), (
+        f"expected cross_machine_read warning, got: {[r.message for r in caplog.records]}"
+    )
+
+
 def test_resolve_rejects_when_multiple_profiles_for_provider(engine):
     """Two envelope rows for same (tenant, principal, provider) → fail closed."""
     tenant = uuid.uuid4()

--- a/src/nexus/bricks/auth/tests/test_consumer.py
+++ b/src/nexus/bricks/auth/tests/test_consumer.py
@@ -891,46 +891,53 @@ def test_resolve_rejects_revoke_committed_after_initial_machine_check(engine):
         store.decrypt_profile = real_decrypt
 
 
-def test_resolve_rejects_revoke_committed_during_audit_write(engine):
-    """A revoke that commits between audit.write start and the post-audit
-    check must still be observed and reject the call. The audit row is
-    expected to remain (revoked daemon DID try to read; audit log captures
-    every attempt).
+def test_audit_write_atomically_rejects_revoked_machine(engine):
+    """ReadAuditWriter.write itself enforces the revocation gate inside
+    its own transaction (SELECT FOR SHARE on daemon_machines + audit
+    INSERT, atomic). Direct test against the writer proves a revoke
+    committed BEFORE audit.write starts → MachineUnknownOrRevoked, and
+    no audit row gets written.
 
-    Wraps audit.write to commit a revoke from a separate connection while
-    audit's own transaction is still in flight; the third
-    assert_machine_active call (F26) must catch it.
+    The previous regression test wrapped audit.write to commit a revoke
+    AFTER it returned; that race-window scenario is now impossible by
+    construction (SHARE lock means concurrent revoke blocks until our tx
+    commits). This direct-against-writer test pins the new atomic
+    semantic. F26 closure.
     """
-    encryption = InMemoryEncryptionProvider()
+    from nexus.bricks.auth.read_audit import ReadAuditWriter
+
     tenant = uuid.uuid4()
     principal = uuid.uuid4()
-    _seed_github_envelope(
-        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
-    )
     machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
-    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+    # Revoke before any audit attempt.
+    _revoke_machine(engine=engine, tenant_id=tenant, machine_id=machine)
 
-    real_audit_write = consumer._audit.write  # noqa: SLF001 — test introspection
+    writer = ReadAuditWriter(engine=engine, hit_sample_rate=1.0)
+    with pytest.raises(MachineUnknownOrRevoked) as exc:
+        writer.write(
+            tenant_id=tenant,
+            principal_id=principal,
+            auth_profile_id="github-default",
+            caller_machine_id=machine,
+            caller_kind="daemon",
+            provider="github",
+            purpose="x",
+            cache_hit=False,
+            kek_version=1,
+        )
+    assert exc.value.cause == "machine_revoked"
 
-    def _audit_then_revoke(*args, **kwargs):
-        result = real_audit_write(*args, **kwargs)
-        with engine.begin() as conn:
-            conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
-            conn.execute(
-                text("UPDATE daemon_machines SET revoked_at = NOW() WHERE id = :m"),
-                {"m": str(machine)},
-            )
-        return result
-
-    consumer._audit.write = _audit_then_revoke
-    try:
-        with pytest.raises(MachineUnknownOrRevoked) as exc:
-            consumer.resolve(
-                claims=_claims(tenant, principal, machine), provider="github", purpose="x"
-            )
-        assert exc.value.cause == "machine_revoked"
-    finally:
-        consumer._audit.write = real_audit_write
+    # No audit row written for the revoked attempt.
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        count = conn.execute(
+            text(
+                "SELECT COUNT(*) FROM auth_profile_reads "
+                "WHERE tenant_id = :t AND caller_machine_id = :m"
+            ),
+            {"t": str(tenant), "m": str(machine)},
+        ).scalar_one()
+    assert count == 0
 
 
 def test_resolve_succeeds_with_active_plus_stale_sibling_profile(engine):

--- a/src/nexus/bricks/auth/tests/test_consumer.py
+++ b/src/nexus/bricks/auth/tests/test_consumer.py
@@ -496,6 +496,105 @@ def test_warm_cache_evicts_when_source_goes_stale(engine):
         consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
 
 
+def test_cache_hit_audit_row_names_real_profile_and_kek_version(engine):
+    """Sampled cache-hit audit rows must name the credential that was served
+    (profile_id + kek_version from the cached fingerprint), not a sentinel
+    ``'cached'`` / ``0`` that breaks incident review and rotation forensics.
+
+    Regression for codex round-6 finding F20.
+    """
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
+    )
+    machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+    # Force every cache-hit to be sampled so we can assert on the row.
+    consumer = CredentialConsumer(
+        store=PostgresAuthProfileStore("", tenant_id=tenant, principal_id=principal, engine=engine),
+        encryption=encryption,
+        dek_cache=DEKCache(),
+        cred_cache=ResolvedCredCache(ceiling_seconds=300),
+        adapters={"github": GithubProviderAdapter()},
+        audit=ReadAuditWriter(engine=engine, hit_sample_rate=1.0),
+    )
+    # Prime cache (records cache-miss audit) then re-read (records sampled hit).
+    consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
+    consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
+
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        rows = list(
+            conn.execute(
+                text(
+                    "SELECT auth_profile_id, kek_version, cache_hit "
+                    "FROM auth_profile_reads WHERE tenant_id = :t "
+                    "ORDER BY read_at"
+                ),
+                {"t": str(tenant)},
+            )
+        )
+    miss = next(r for r in rows if r.cache_hit is False)
+    hit = next(r for r in rows if r.cache_hit is True)
+    # Both rows name the same real credential; the cache-hit row no longer
+    # uses sentinel placeholders.
+    assert hit.auth_profile_id == miss.auth_profile_id == "github-default"
+    assert hit.kek_version == miss.kek_version
+    assert hit.kek_version > 0
+
+
+def test_warm_cache_evicts_when_row_rewritten_by_other_machine(engine, monkeypatch):
+    """Daemon A primes the cache. Daemon B then overwrites the row's
+    machine_id (a fresh push from B for the same principal/provider). A's
+    next request must NOT return its cached plaintext: the cache entry's
+    fingerprint no longer matches the row, so the consumer evicts and
+    re-runs the decrypt path — which then re-applies the cross-machine
+    read policy against B as the new writer.
+
+    Without this, A keeps serving its cached plaintext for the rest of the
+    cache TTL even after the row was replaced. Regression for codex round-6
+    finding F19.
+    """
+    monkeypatch.delenv("NEXUS_AUTH_ALLOW_CROSS_MACHINE_READ", raising=False)
+    encryption = InMemoryEncryptionProvider()
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
+    )
+    machine_a = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+    machine_b = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+    # Stamp the existing row with A as the writer so A's first read is in-machine.
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text("UPDATE auth_profiles SET machine_id = :m WHERE tenant_id = :t"),
+            {"m": str(machine_a), "t": str(tenant)},
+        )
+
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+    consumer.resolve(claims=_claims(tenant, principal, machine_a), provider="github", purpose="x")
+    # B overwrites the row's writer machine_id AND bumps last_synced_at to
+    # simulate "B re-pushed the same provider for the same principal".
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text(
+                "UPDATE auth_profiles SET machine_id = :m, last_synced_at = NOW() "
+                "WHERE tenant_id = :t"
+            ),
+            {"m": str(machine_b), "t": str(tenant)},
+        )
+    # A's next request: cache key still matches, but fingerprint differs →
+    # evict + decrypt path → cross-machine check rejects (writer is now B).
+    with pytest.raises(MachineUnknownOrRevoked) as exc:
+        consumer.resolve(
+            claims=_claims(tenant, principal, machine_a), provider="github", purpose="x"
+        )
+    assert exc.value.cause == "cross_machine_read_disallowed"
+
+
 def test_warm_cache_does_not_bypass_cross_machine_check(engine, monkeypatch):
     """Daemon A primes the cache; Daemon B (different machine_id) must NOT
     inherit A's plaintext from the warm cache.

--- a/src/nexus/bricks/auth/tests/test_consumer.py
+++ b/src/nexus/bricks/auth/tests/test_consumer.py
@@ -465,6 +465,75 @@ def test_resolve_allows_cross_machine_read_when_opted_in(engine, monkeypatch, ca
     assert any("cross_machine_read" in rec.message for rec in caplog.records)
 
 
+def test_warm_cache_evicts_when_source_goes_stale(engine):
+    """Daemon primes cache, then stops pushing past sync_ttl. Next read on the
+    warm cache must surface StaleSource (and evict) instead of returning
+    the cached plaintext for the rest of the cache TTL.
+
+    Regression for codex round-5 finding F15.
+    """
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
+    )
+    machine = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+    # Prime the cache.
+    consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
+    # Push the row's last_synced_at past sync_ttl_seconds (default 300s in helper).
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text(
+                "UPDATE auth_profiles SET last_synced_at = NOW() - INTERVAL '1 hour' "
+                "WHERE tenant_id = :t"
+            ),
+            {"t": str(tenant)},
+        )
+    with pytest.raises(StaleSource):
+        consumer.resolve(claims=_claims(tenant, principal, machine), provider="github", purpose="x")
+
+
+def test_warm_cache_does_not_bypass_cross_machine_check(engine, monkeypatch):
+    """Daemon A primes the cache; Daemon B (different machine_id) must NOT
+    inherit A's plaintext from the warm cache.
+
+    Without machine_id in the cache key, B passes assert_machine_active and
+    assert_profile_active, then returns A's cached credential — silently
+    skipping the writer_machine_id check on the decrypt path. Regression for
+    codex round-5 finding F14.
+    """
+    monkeypatch.delenv("NEXUS_AUTH_ALLOW_CROSS_MACHINE_READ", raising=False)
+    encryption = InMemoryEncryptionProvider()
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    _seed_github_envelope(
+        engine=engine, tenant_id=tenant, principal_id=principal, encryption=encryption
+    )
+    machine_a = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+    # Stamp the envelope row's writer_machine_id to A so A's read is in-machine.
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text("UPDATE auth_profiles SET machine_id = :m WHERE tenant_id = :t"),
+            {"m": str(machine_a), "t": str(tenant)},
+        )
+    machine_b = _seed_active_machine(engine=engine, tenant_id=tenant, principal_id=principal)
+
+    consumer = _make_consumer(engine, tenant, principal, encryption=encryption)
+    # Prime the cache as daemon A — happy path, in-machine read.
+    consumer.resolve(claims=_claims(tenant, principal, machine_a), provider="github", purpose="x")
+    # Daemon B requests with the cache hot — must NOT be served from cache;
+    # decrypt path must fire and the cross-machine check must reject.
+    with pytest.raises(MachineUnknownOrRevoked) as exc:
+        consumer.resolve(
+            claims=_claims(tenant, principal, machine_b), provider="github", purpose="x"
+        )
+    assert exc.value.cause == "cross_machine_read_disallowed"
+
+
 def test_cache_hit_evicts_when_profile_disabled_after_caching(engine):
     """A profile disabled AFTER cache prime must take effect within ms, not
     wait for the cache TTL."""

--- a/src/nexus/bricks/auth/tests/test_consumer_cache.py
+++ b/src/nexus/bricks/auth/tests/test_consumer_cache.py
@@ -3,10 +3,12 @@
 from __future__ import annotations
 
 import threading
+import uuid
 from datetime import UTC, datetime, timedelta
 
 from nexus.bricks.auth.consumer import MaterializedCredential
 from nexus.bricks.auth.consumer_cache import ResolvedCredCache, _compute_ttl_seconds
+from nexus.bricks.auth.postgres_profile_store import ProfileFingerprint
 
 
 def _cred(*, expires_at: datetime | None = None) -> MaterializedCredential:
@@ -15,6 +17,15 @@ def _cred(*, expires_at: datetime | None = None) -> MaterializedCredential:
         access_token="t",
         expires_at=expires_at,
         metadata={},
+    )
+
+
+def _fp(*, last_synced_at: datetime | None = None) -> ProfileFingerprint:
+    return ProfileFingerprint(
+        profile_id="profile-1",
+        writer_machine_id=uuid.UUID("00000000-0000-0000-0000-000000000001"),
+        kek_version=1,
+        last_synced_at=last_synced_at or datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC),
     )
 
 
@@ -40,11 +51,13 @@ def test_get_returns_cached_then_evicts_after_ttl():
     now = datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)
     cred = _cred(expires_at=now + timedelta(seconds=200))
 
-    cache.put(key, cred, now=now)
+    cache.put(key, cred, now=now, fingerprint=_fp())
     # Hit immediately
-    assert cache.get(key, now=now) is cred
+    hit = cache.get(key, now=now)
+    assert hit is not None and hit.cred is cred
     # 139s later: still warm (ttl is 200-60 = 140)
-    assert cache.get(key, now=now + timedelta(seconds=139)) is cred
+    warm = cache.get(key, now=now + timedelta(seconds=139))
+    assert warm is not None and warm.cred is cred
     # Just after TTL boundary: expired
     assert cache.get(key, now=now + timedelta(seconds=141)) is None
 
@@ -53,7 +66,7 @@ def test_put_with_no_expiry_uses_ceiling():
     cache = ResolvedCredCache(ceiling_seconds=300)
     key = ("t1", "p1", "github", "m1")
     now = datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)
-    cache.put(key, _cred(expires_at=None), now=now)
+    cache.put(key, _cred(expires_at=None), now=now, fingerprint=_fp())
     assert cache.get(key, now=now + timedelta(seconds=299)) is not None
     assert cache.get(key, now=now + timedelta(seconds=301)) is None
 
@@ -72,8 +85,9 @@ def test_cache_keys_are_scoped_per_machine():
     key_a = ("t1", "p1", "github", "m-a")
     key_b = ("t1", "p1", "github", "m-b")
 
-    cache.put(key_a, cred_a, now=now)
-    assert cache.get(key_a, now=now) is cred_a
+    cache.put(key_a, cred_a, now=now, fingerprint=_fp())
+    a_hit = cache.get(key_a, now=now)
+    assert a_hit is not None and a_hit.cred is cred_a
     assert cache.get(key_b, now=now) is None
 
 
@@ -82,9 +96,11 @@ def test_thread_safe_concurrent_put_get():
     now = datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)
     cred = _cred(expires_at=now + timedelta(seconds=600))
 
+    fp = _fp()
+
     def worker(i: int):
         for _ in range(50):
-            cache.put((f"t{i}", "p", "github", "m"), cred, now=now)
+            cache.put((f"t{i}", "p", "github", "m"), cred, now=now, fingerprint=fp)
             cache.get((f"t{i}", "p", "github", "m"), now=now)
 
     threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]

--- a/src/nexus/bricks/auth/tests/test_consumer_cache.py
+++ b/src/nexus/bricks/auth/tests/test_consumer_cache.py
@@ -36,7 +36,7 @@ def test_compute_ttl_clamps_to_zero_when_already_near_expiry():
 
 def test_get_returns_cached_then_evicts_after_ttl():
     cache = ResolvedCredCache(ceiling_seconds=300)
-    key = ("t1", "p1", "github")
+    key = ("t1", "p1", "github", "m1")
     now = datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)
     cred = _cred(expires_at=now + timedelta(seconds=200))
 
@@ -51,11 +51,30 @@ def test_get_returns_cached_then_evicts_after_ttl():
 
 def test_put_with_no_expiry_uses_ceiling():
     cache = ResolvedCredCache(ceiling_seconds=300)
-    key = ("t1", "p1", "github")
+    key = ("t1", "p1", "github", "m1")
     now = datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)
     cache.put(key, _cred(expires_at=None), now=now)
     assert cache.get(key, now=now + timedelta(seconds=299)) is not None
     assert cache.get(key, now=now + timedelta(seconds=301)) is None
+
+
+def test_cache_keys_are_scoped_per_machine():
+    """A second machine for the same tenant/principal/provider gets its own
+    slot — proves the key tuple's machine_id segment isolates daemons.
+
+    Without this, daemon B inherits daemon A's plaintext from cache and
+    bypasses the cross-machine read check (which only fires on the decrypt
+    path). Regression for codex round-5 finding F14.
+    """
+    cache = ResolvedCredCache(ceiling_seconds=300)
+    now = datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)
+    cred_a = _cred(expires_at=now + timedelta(seconds=600))
+    key_a = ("t1", "p1", "github", "m-a")
+    key_b = ("t1", "p1", "github", "m-b")
+
+    cache.put(key_a, cred_a, now=now)
+    assert cache.get(key_a, now=now) is cred_a
+    assert cache.get(key_b, now=now) is None
 
 
 def test_thread_safe_concurrent_put_get():
@@ -65,8 +84,8 @@ def test_thread_safe_concurrent_put_get():
 
     def worker(i: int):
         for _ in range(50):
-            cache.put((f"t{i}", "p", "github"), cred, now=now)
-            cache.get((f"t{i}", "p", "github"), now=now)
+            cache.put((f"t{i}", "p", "github", "m"), cred, now=now)
+            cache.get((f"t{i}", "p", "github", "m"), now=now)
 
     threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
     for t in threads:

--- a/src/nexus/bricks/auth/tests/test_consumer_cache.py
+++ b/src/nexus/bricks/auth/tests/test_consumer_cache.py
@@ -47,7 +47,7 @@ def test_compute_ttl_clamps_to_zero_when_already_near_expiry():
 
 def test_get_returns_cached_then_evicts_after_ttl():
     cache = ResolvedCredCache(ceiling_seconds=300)
-    key = ("t1", "p1", "github", "m1")
+    key = ("t1", "p1", "github", "m1", "")
     now = datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)
     cred = _cred(expires_at=now + timedelta(seconds=200))
 
@@ -64,7 +64,7 @@ def test_get_returns_cached_then_evicts_after_ttl():
 
 def test_put_with_no_expiry_uses_ceiling():
     cache = ResolvedCredCache(ceiling_seconds=300)
-    key = ("t1", "p1", "github", "m1")
+    key = ("t1", "p1", "github", "m1", "")
     now = datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)
     cache.put(key, _cred(expires_at=None), now=now, fingerprint=_fp())
     assert cache.get(key, now=now + timedelta(seconds=299)) is not None
@@ -82,8 +82,8 @@ def test_cache_keys_are_scoped_per_machine():
     cache = ResolvedCredCache(ceiling_seconds=300)
     now = datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)
     cred_a = _cred(expires_at=now + timedelta(seconds=600))
-    key_a = ("t1", "p1", "github", "m-a")
-    key_b = ("t1", "p1", "github", "m-b")
+    key_a = ("t1", "p1", "github", "m-a", "")
+    key_b = ("t1", "p1", "github", "m-b", "")
 
     cache.put(key_a, cred_a, now=now, fingerprint=_fp())
     a_hit = cache.get(key_a, now=now)
@@ -100,8 +100,8 @@ def test_thread_safe_concurrent_put_get():
 
     def worker(i: int):
         for _ in range(50):
-            cache.put((f"t{i}", "p", "github", "m"), cred, now=now, fingerprint=fp)
-            cache.get((f"t{i}", "p", "github", "m"), now=now)
+            cache.put((f"t{i}", "p", "github", "m", ""), cred, now=now, fingerprint=fp)
+            cache.get((f"t{i}", "p", "github", "m", ""), now=now)
 
     threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
     for t in threads:

--- a/src/nexus/bricks/auth/tests/test_consumer_cache.py
+++ b/src/nexus/bricks/auth/tests/test_consumer_cache.py
@@ -1,0 +1,76 @@
+"""Tests for ResolvedCredCache — TTL = min(300, expires_at - 60) (#3818)."""
+
+from __future__ import annotations
+
+import threading
+from datetime import UTC, datetime, timedelta
+
+from nexus.bricks.auth.consumer import MaterializedCredential
+from nexus.bricks.auth.consumer_cache import ResolvedCredCache, _compute_ttl_seconds
+
+
+def _cred(*, expires_at: datetime | None = None) -> MaterializedCredential:
+    return MaterializedCredential(
+        provider="github",
+        access_token="t",
+        expires_at=expires_at,
+        metadata={},
+    )
+
+
+def test_compute_ttl_uses_ceiling_when_no_expiry():
+    assert _compute_ttl_seconds(now=datetime.now(UTC), expires_at=None) == 10**9
+
+
+def test_compute_ttl_caps_at_expiry_minus_60():
+    now = datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)
+    exp = now + timedelta(seconds=200)
+    assert _compute_ttl_seconds(now=now, expires_at=exp) == 140
+
+
+def test_compute_ttl_clamps_to_zero_when_already_near_expiry():
+    now = datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)
+    exp = now + timedelta(seconds=30)
+    assert _compute_ttl_seconds(now=now, expires_at=exp) == 0
+
+
+def test_get_returns_cached_then_evicts_after_ttl():
+    cache = ResolvedCredCache(ceiling_seconds=300)
+    key = ("t1", "p1", "github")
+    now = datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)
+    cred = _cred(expires_at=now + timedelta(seconds=200))
+
+    cache.put(key, cred, now=now)
+    # Hit immediately
+    assert cache.get(key, now=now) is cred
+    # 139s later: still warm (ttl is 200-60 = 140)
+    assert cache.get(key, now=now + timedelta(seconds=139)) is cred
+    # Just after TTL boundary: expired
+    assert cache.get(key, now=now + timedelta(seconds=141)) is None
+
+
+def test_put_with_no_expiry_uses_ceiling():
+    cache = ResolvedCredCache(ceiling_seconds=300)
+    key = ("t1", "p1", "github")
+    now = datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)
+    cache.put(key, _cred(expires_at=None), now=now)
+    assert cache.get(key, now=now + timedelta(seconds=299)) is not None
+    assert cache.get(key, now=now + timedelta(seconds=301)) is None
+
+
+def test_thread_safe_concurrent_put_get():
+    cache = ResolvedCredCache(ceiling_seconds=300)
+    now = datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)
+    cred = _cred(expires_at=now + timedelta(seconds=600))
+
+    def worker(i: int):
+        for _ in range(50):
+            cache.put((f"t{i}", "p", "github"), cred, now=now)
+            cache.get((f"t{i}", "p", "github"), now=now)
+
+    threads = [threading.Thread(target=worker, args=(i,)) for i in range(8)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+    # No exception = pass

--- a/src/nexus/bricks/auth/tests/test_consumer_providers_aws.py
+++ b/src/nexus/bricks/auth/tests/test_consumer_providers_aws.py
@@ -1,0 +1,75 @@
+"""Tests for AwsProviderAdapter — pure JSON → MaterializedCredential decoding (#3818)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from nexus.bricks.auth.consumer_providers.aws import AwsProviderAdapter
+
+
+def test_materialize_extracts_session_token_and_metadata():
+    payload = json.dumps(
+        {
+            "access_key_id": "ASIA1234",
+            "secret_access_key": "wJalrXUtnFEMI",
+            "session_token": "FwoGZXIvYXdz...",
+            "expiration": "2026-04-23T18:00:00+00:00",
+            "region": "us-west-2",
+            "account_id": "123456789012",
+        }
+    ).encode()
+
+    out = AwsProviderAdapter().materialize(payload)
+
+    assert out.provider == "aws"
+    assert out.access_token == "FwoGZXIvYXdz..."
+    assert out.expires_at == datetime(2026, 4, 23, 18, 0, 0, tzinfo=UTC)
+    assert out.metadata == {
+        "access_key_id": "ASIA1234",
+        "secret_access_key": "wJalrXUtnFEMI",
+        "region": "us-west-2",
+        "account_id": "123456789012",
+    }
+
+
+def test_materialize_handles_missing_optional_fields():
+    payload = json.dumps(
+        {
+            "access_key_id": "ASIA1234",
+            "secret_access_key": "wJalrXUtnFEMI",
+            "session_token": "tok",
+            "expiration": "2026-04-23T18:00:00+00:00",
+            "region": "us-east-1",
+        }
+    ).encode()
+    out = AwsProviderAdapter().materialize(payload)
+    assert "account_id" not in out.metadata
+
+
+def test_materialize_rejects_malformed_json():
+    with pytest.raises(ValueError):
+        AwsProviderAdapter().materialize(b"not json")
+
+
+def test_materialize_rejects_missing_required_field():
+    payload = json.dumps({"access_key_id": "x"}).encode()
+    with pytest.raises(KeyError):
+        AwsProviderAdapter().materialize(payload)
+
+
+def test_repr_masks_access_token():
+    payload = json.dumps(
+        {
+            "access_key_id": "ASIA1234",
+            "secret_access_key": "wJalrXUtnFEMI",
+            "session_token": "supersecret",
+            "expiration": "2026-04-23T18:00:00+00:00",
+            "region": "us-east-1",
+        }
+    ).encode()
+    out = AwsProviderAdapter().materialize(payload)
+    assert "supersecret" not in repr(out)
+    assert "***" in repr(out)

--- a/src/nexus/bricks/auth/tests/test_consumer_providers_github.py
+++ b/src/nexus/bricks/auth/tests/test_consumer_providers_github.py
@@ -36,7 +36,9 @@ def test_materialize_fine_grained_with_expiry():
 
 
 def test_materialize_rejects_missing_token():
-    with pytest.raises(KeyError):
+    # JSON without "token" falls through to raw-bytes parse; the JSON object
+    # itself starts with "{" so prefix check fails → ValueError.
+    with pytest.raises(ValueError):
         GithubProviderAdapter().materialize(json.dumps({"scopes": []}).encode())
 
 
@@ -45,7 +47,37 @@ def test_materialize_rejects_malformed_json():
         GithubProviderAdapter().materialize(b"<html>not json</html>")
 
 
+def test_materialize_accepts_raw_classic_pat():
+    """Daemon's `gh auth token` stdout is raw bytes, not JSON."""
+    out = GithubProviderAdapter().materialize(b"ghp_rawclassictoken123")
+    assert out.access_token == "ghp_rawclassictoken123"
+    assert out.metadata == {"scopes_csv": "", "token_type": "classic"}
+    assert out.expires_at is None
+
+
+def test_materialize_accepts_raw_fine_grained_pat():
+    out = GithubProviderAdapter().materialize(b"github_pat_finegrained_abc")
+    assert out.access_token == "github_pat_finegrained_abc"
+
+
+def test_materialize_strips_trailing_whitespace_in_raw_token():
+    """`gh auth token` output usually ends with a newline."""
+    out = GithubProviderAdapter().materialize(b"ghp_withnewline\n")
+    assert out.access_token == "ghp_withnewline"
+
+
+def test_materialize_rejects_unknown_prefix_raw_bytes():
+    """Don't accept arbitrary plaintext — must look like a GitHub token."""
+    with pytest.raises(ValueError):
+        GithubProviderAdapter().materialize(b"random-secret-not-a-pat")
+
+
 def test_repr_masks_token():
     payload = json.dumps({"token": "ghp_supersecret", "scopes": []}).encode()
     out = GithubProviderAdapter().materialize(payload)
     assert "ghp_supersecret" not in repr(out)
+
+
+def test_repr_masks_raw_token():
+    out = GithubProviderAdapter().materialize(b"ghp_rawsecret_xyz")
+    assert "ghp_rawsecret_xyz" not in repr(out)

--- a/src/nexus/bricks/auth/tests/test_consumer_providers_github.py
+++ b/src/nexus/bricks/auth/tests/test_consumer_providers_github.py
@@ -1,0 +1,51 @@
+"""Tests for GithubProviderAdapter — pure JSON → MaterializedCredential decoding (#3818)."""
+
+from __future__ import annotations
+
+import json
+from datetime import UTC, datetime
+
+import pytest
+
+from nexus.bricks.auth.consumer_providers.github import GithubProviderAdapter
+
+
+def test_materialize_classic_pat_no_expiry():
+    payload = json.dumps({"token": "ghp_classic", "scopes": ["repo", "read:user"]}).encode()
+    out = GithubProviderAdapter().materialize(payload)
+    assert out.provider == "github"
+    assert out.access_token == "ghp_classic"
+    assert out.expires_at is None
+    assert out.metadata == {"scopes_csv": "repo,read:user", "token_type": "classic"}
+
+
+def test_materialize_fine_grained_with_expiry():
+    payload = json.dumps(
+        {
+            "token": "github_pat_xyz",
+            "scopes": [],
+            "expires_at": "2026-07-01T00:00:00+00:00",
+            "token_type": "fine_grained",
+        }
+    ).encode()
+    out = GithubProviderAdapter().materialize(payload)
+    assert out.access_token == "github_pat_xyz"
+    assert out.expires_at == datetime(2026, 7, 1, 0, 0, 0, tzinfo=UTC)
+    assert out.metadata["token_type"] == "fine_grained"
+    assert out.metadata["scopes_csv"] == ""
+
+
+def test_materialize_rejects_missing_token():
+    with pytest.raises(KeyError):
+        GithubProviderAdapter().materialize(json.dumps({"scopes": []}).encode())
+
+
+def test_materialize_rejects_malformed_json():
+    with pytest.raises(ValueError):
+        GithubProviderAdapter().materialize(b"<html>not json</html>")
+
+
+def test_repr_masks_token():
+    payload = json.dumps({"token": "ghp_supersecret", "scopes": []}).encode()
+    out = GithubProviderAdapter().materialize(payload)
+    assert "ghp_supersecret" not in repr(out)

--- a/src/nexus/bricks/auth/tests/test_postgres_decrypt_integration.py
+++ b/src/nexus/bricks/auth/tests/test_postgres_decrypt_integration.py
@@ -6,11 +6,18 @@ Requires a running Postgres (env: NEXUS_TEST_DATABASE_URL). Skip cleanly when ab
 from __future__ import annotations
 
 import os
+import uuid
 
 import pytest
 from sqlalchemy import create_engine, text
 
+from nexus.bricks.auth.envelope import (
+    AESGCMEnvelope,
+    DEKCache,
+)
+from nexus.bricks.auth.envelope_providers.in_memory import InMemoryEncryptionProvider
 from nexus.bricks.auth.postgres_profile_store import (
+    PostgresAuthProfileStore,
     ensure_schema,
 )
 
@@ -59,3 +66,130 @@ def test_auth_profile_reads_has_rls_enabled(engine):
             )
         ).fetchone()
     assert row == (True, True)
+
+
+# ---------------------------------------------------------------------------
+# Task 2: decrypt_profile() helper
+# ---------------------------------------------------------------------------
+
+
+def _seed_envelope_row(
+    *,
+    engine,
+    tenant_id: uuid.UUID,
+    principal_id: uuid.UUID,
+    profile_id: str,
+    provider: str,
+    plaintext: bytes,
+    encryption,
+):
+    """Helper: seed a fully-formed envelope row for decrypt tests."""
+    aad = str(tenant_id).encode() + b"|" + str(principal_id).encode() + b"|" + profile_id.encode()
+    dek = b"\x00" * 32  # AES-256 zero key — fine for an in-memory test fake
+    nonce, ciphertext = AESGCMEnvelope().encrypt(dek, plaintext, aad=aad)
+    wrapped, kek_version = encryption.wrap_dek(dek, tenant_id=tenant_id, aad=aad)
+    with engine.begin() as conn:
+        conn.execute(
+            text("SET LOCAL app.current_tenant = :t"),
+            {"t": str(tenant_id)},
+        )
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, :n) ON CONFLICT DO NOTHING"),
+            {"id": str(tenant_id), "n": f"test-{tenant_id}"},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO principals (id, tenant_id, kind) VALUES (:id, :t, 'human') "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {"id": str(principal_id), "t": str(tenant_id)},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO auth_profiles "
+                "(tenant_id, principal_id, id, provider, account_identifier, "
+                " backend, backend_key, last_synced_at, sync_ttl_seconds, "
+                " ciphertext, wrapped_dek, nonce, aad, kek_version) "
+                "VALUES (:t, :p, :id, :prov, 'acct', 'envelope', 'k', NOW(), 300, "
+                " :ct, :wd, :no, :aad, :kv)"
+            ),
+            {
+                "t": str(tenant_id),
+                "p": str(principal_id),
+                "id": profile_id,
+                "prov": provider,
+                "ct": ciphertext,
+                "wd": wrapped,
+                "no": nonce,
+                "aad": aad,
+                "kv": kek_version,
+            },
+        )
+
+
+def test_decrypt_profile_returns_plaintext_and_kek_version(engine):
+    tenant_id = uuid.uuid4()
+    principal_id = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    plaintext = b'{"token":"ghp_test"}'
+    _seed_envelope_row(
+        engine=engine,
+        tenant_id=tenant_id,
+        principal_id=principal_id,
+        profile_id="github-default",
+        provider="github",
+        plaintext=plaintext,
+        encryption=encryption,
+    )
+
+    # NOTE: The store's __init__ requires a principal_id; the new
+    # ``decrypt_profile`` method takes its own ``principal_id`` parameter
+    # because in the server-side consumer path one store may resolve
+    # credentials for many principals in the tenant. We pass the seeded
+    # principal_id at construction so RLS / scoping helpers stay consistent.
+    store = PostgresAuthProfileStore(
+        "",  # db_url unused when engine is supplied
+        tenant_id=tenant_id,
+        principal_id=principal_id,
+        engine=engine,
+    )
+    out = store.decrypt_profile(
+        principal_id=principal_id,
+        provider="github",
+        encryption=encryption,
+        dek_cache=DEKCache(),
+    )
+
+    assert out.plaintext == plaintext
+    assert out.profile_id == "github-default"
+    assert out.kek_version == 1
+    assert out.last_synced_at is not None
+
+
+def test_decrypt_profile_raises_profile_not_found(engine):
+    from nexus.bricks.auth.postgres_profile_store import ProfileNotFound
+
+    tenant_id = uuid.uuid4()
+    principal_id = uuid.uuid4()
+    # Seed tenant but no profile
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant_id)})
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, :n) ON CONFLICT DO NOTHING"),
+            {"id": str(tenant_id), "n": f"tx-{tenant_id}"},
+        )
+
+    store = PostgresAuthProfileStore(
+        "",  # db_url unused when engine is supplied
+        tenant_id=tenant_id,
+        principal_id=principal_id,
+        engine=engine,
+    )
+    encryption = InMemoryEncryptionProvider()
+    with pytest.raises(ProfileNotFound):
+        store.decrypt_profile(
+            principal_id=principal_id,
+            provider="aws",
+            encryption=encryption,
+            dek_cache=DEKCache(),
+        )

--- a/src/nexus/bricks/auth/tests/test_postgres_decrypt_integration.py
+++ b/src/nexus/bricks/auth/tests/test_postgres_decrypt_integration.py
@@ -1,0 +1,61 @@
+"""Integration tests for read-path additions to PostgresAuthProfileStore (#3818).
+
+Requires a running Postgres (env: NEXUS_TEST_DATABASE_URL). Skip cleanly when absent.
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from nexus.bricks.auth.postgres_profile_store import (
+    ensure_schema,
+)
+
+
+@pytest.fixture
+def engine():
+    url = os.environ.get("NEXUS_TEST_DATABASE_URL")
+    if not url:
+        pytest.skip("NEXUS_TEST_DATABASE_URL not set")
+    eng = create_engine(url, future=True)
+    ensure_schema(eng)
+    yield eng
+    eng.dispose()
+
+
+def test_auth_profile_reads_table_exists(engine):
+    with engine.connect() as conn:
+        rows = conn.execute(
+            text(
+                "SELECT column_name FROM information_schema.columns "
+                "WHERE table_name = 'auth_profile_reads' ORDER BY ordinal_position"
+            )
+        ).fetchall()
+    cols = [r[0] for r in rows]
+    assert cols == [
+        "id",
+        "read_at",
+        "tenant_id",
+        "principal_id",
+        "auth_profile_id",
+        "caller_machine_id",
+        "caller_kind",
+        "provider",
+        "purpose",
+        "cache_hit",
+        "kek_version",
+    ]
+
+
+def test_auth_profile_reads_has_rls_enabled(engine):
+    with engine.connect() as conn:
+        row = conn.execute(
+            text(
+                "SELECT relrowsecurity, relforcerowsecurity FROM pg_class "
+                "WHERE relname = 'auth_profile_reads'"
+            )
+        ).fetchone()
+    assert row == (True, True)

--- a/src/nexus/bricks/auth/tests/test_postgres_decrypt_integration.py
+++ b/src/nexus/bricks/auth/tests/test_postgres_decrypt_integration.py
@@ -193,3 +193,102 @@ def test_decrypt_profile_raises_profile_not_found(engine):
             encryption=encryption,
             dek_cache=DEKCache(),
         )
+
+
+def test_decrypted_profile_repr_masks_plaintext(engine):
+    """The DecryptedProfile dataclass must NOT print plaintext in its repr.
+
+    A Task-8 caller that ``log.info("decrypted %s", out)`` or hits an
+    unhandled exception (locals frame) must not leak the credential JSON.
+    """
+    from nexus.bricks.auth.postgres_profile_store import DecryptedProfile
+
+    tenant_id = uuid.uuid4()
+    principal_id = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    plaintext = b'{"token":"super_secret_value"}'
+    _seed_envelope_row(
+        engine=engine,
+        tenant_id=tenant_id,
+        principal_id=principal_id,
+        profile_id="github-default",
+        provider="github",
+        plaintext=plaintext,
+        encryption=encryption,
+    )
+    store = PostgresAuthProfileStore(
+        "",
+        tenant_id=tenant_id,
+        principal_id=principal_id,
+        engine=engine,
+    )
+    out = store.decrypt_profile(
+        principal_id=principal_id,
+        provider="github",
+        encryption=encryption,
+        dek_cache=DEKCache(),
+    )
+    assert isinstance(out, DecryptedProfile)
+    # Sanity: plaintext is recoverable via the field, just not via repr.
+    assert out.plaintext == plaintext
+    rendered = repr(out)
+    assert "super_secret_value" not in rendered
+    assert b"super_secret_value" not in rendered.encode()
+
+
+def test_decrypt_profile_rejects_tampered_aad(engine):
+    """Defense-in-depth: a row whose aad column has been tampered with
+    (different from what writers compute) must be rejected even if the
+    AES-GCM tag verifies under the tampered AAD."""
+    from nexus.bricks.auth.envelope import AADMismatch
+
+    tenant_id = uuid.uuid4()
+    principal_id = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    plaintext = b'{"token":"x"}'
+    _seed_envelope_row(
+        engine=engine,
+        tenant_id=tenant_id,
+        principal_id=principal_id,
+        profile_id="github-default",
+        provider="github",
+        plaintext=plaintext,
+        encryption=encryption,
+    )
+    # Tamper: rewrite aad to a different (but well-formed) value, AND
+    # re-encrypt with the new AAD so the AES-GCM tag still verifies.
+    # The defense-in-depth check should catch this.
+    tampered_aad = str(tenant_id).encode() + b"|" + str(principal_id).encode() + b"|other-profile"
+    dek = b"\x00" * 32
+    nonce, new_ct = AESGCMEnvelope().encrypt(dek, plaintext, aad=tampered_aad)
+    new_wrapped, _ = encryption.wrap_dek(dek, tenant_id=tenant_id, aad=tampered_aad)
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant_id)})
+        conn.execute(
+            text(
+                "UPDATE auth_profiles SET aad = :aad, ciphertext = :ct, "
+                "wrapped_dek = :wd, nonce = :no "
+                "WHERE tenant_id = :t AND id = 'github-default'"
+            ),
+            {
+                "aad": tampered_aad,
+                "ct": new_ct,
+                "wd": new_wrapped,
+                "no": nonce,
+                "t": str(tenant_id),
+            },
+        )
+
+    store = PostgresAuthProfileStore(
+        "",
+        tenant_id=tenant_id,
+        principal_id=principal_id,
+        engine=engine,
+    )
+    with pytest.raises(AADMismatch):
+        store.decrypt_profile(
+            principal_id=principal_id,
+            provider="github",
+            encryption=encryption,
+            dek_cache=DEKCache(),
+        )

--- a/src/nexus/bricks/auth/tests/test_read_audit.py
+++ b/src/nexus/bricks/auth/tests/test_read_audit.py
@@ -1,0 +1,128 @@
+"""Tests for ReadAuditWriter — 100% on cache-miss, 1% sample on cache-hit (#3818)."""
+
+from __future__ import annotations
+
+import os
+import random
+import uuid
+
+import pytest
+from sqlalchemy import create_engine, text
+
+from nexus.bricks.auth.postgres_profile_store import ensure_schema
+from nexus.bricks.auth.read_audit import ReadAuditWriter
+
+
+@pytest.fixture
+def engine():
+    url = os.environ.get("NEXUS_TEST_DATABASE_URL")
+    if not url:
+        pytest.skip("NEXUS_TEST_DATABASE_URL not set")
+    eng = create_engine(url, future=True)
+    ensure_schema(eng)
+    yield eng
+    eng.dispose()
+
+
+def _seed_tenant_principal(engine, tenant_id, principal_id):
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant_id)})
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, :n) ON CONFLICT DO NOTHING"),
+            {"id": str(tenant_id), "n": f"rt-{tenant_id}"},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO principals (id, tenant_id, kind) VALUES (:id, :t, 'human') "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {"id": str(principal_id), "t": str(tenant_id)},
+        )
+
+
+def _count_reads(engine, tenant_id):
+    # RLS is bypassed for superusers, so scope the count explicitly by
+    # tenant_id to avoid cross-test contamination in a shared test DB.
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant_id)})
+        return conn.execute(
+            text("SELECT COUNT(*) FROM auth_profile_reads WHERE tenant_id = :t"),
+            {"t": str(tenant_id)},
+        ).scalar()
+
+
+def test_writes_100_percent_on_cache_miss(engine):
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    machine = uuid.uuid4()
+    _seed_tenant_principal(engine, tenant, principal)
+    writer = ReadAuditWriter(engine=engine, hit_sample_rate=0.01)
+
+    for _ in range(20):
+        writer.write(
+            tenant_id=tenant,
+            principal_id=principal,
+            auth_profile_id="github-default",
+            caller_machine_id=machine,
+            caller_kind="daemon",
+            provider="github",
+            purpose="test",
+            cache_hit=False,
+            kek_version=1,
+        )
+
+    assert _count_reads(engine, tenant) == 20
+
+
+def test_samples_one_percent_on_cache_hit(engine):
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    machine = uuid.uuid4()
+    _seed_tenant_principal(engine, tenant, principal)
+    rng = random.Random(42)
+    expected = sum(1 for _ in range(100) if rng.random() < 0.01)
+
+    writer = ReadAuditWriter(engine=engine, hit_sample_rate=0.01, rng=random.Random(42))
+    for _ in range(100):
+        writer.write(
+            tenant_id=tenant,
+            principal_id=principal,
+            auth_profile_id="github-default",
+            caller_machine_id=machine,
+            caller_kind="daemon",
+            provider="github",
+            purpose="test",
+            cache_hit=True,
+            kek_version=1,
+        )
+
+    assert _count_reads(engine, tenant) == expected
+
+
+def test_truncates_purpose_to_256_chars(engine):
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    machine = uuid.uuid4()
+    _seed_tenant_principal(engine, tenant, principal)
+    writer = ReadAuditWriter(engine=engine, hit_sample_rate=0.01)
+
+    long_purpose = "x" * 1000
+    writer.write(
+        tenant_id=tenant,
+        principal_id=principal,
+        auth_profile_id="github-default",
+        caller_machine_id=machine,
+        caller_kind="daemon",
+        provider="github",
+        purpose=long_purpose,
+        cache_hit=False,
+        kek_version=1,
+    )
+
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        row = conn.execute(
+            text("SELECT purpose FROM auth_profile_reads WHERE tenant_id = :t"),
+            {"t": str(tenant)},
+        ).fetchone()
+    assert len(row[0]) == 256

--- a/src/nexus/bricks/auth/tests/test_read_audit.py
+++ b/src/nexus/bricks/auth/tests/test_read_audit.py
@@ -24,7 +24,14 @@ def engine():
     eng.dispose()
 
 
-def _seed_tenant_principal(engine, tenant_id, principal_id):
+def _seed_tenant_principal_and_machine(engine, tenant_id, principal_id, machine_id):
+    """Seed tenant + principal + an unrevoked daemon_machines row.
+
+    The machine row is required because ReadAuditWriter.write now opens
+    every transaction with a SELECT ... FOR SHARE on daemon_machines
+    (atomic revocation gate, F26). Without an active row the writer
+    raises MachineUnknownOrRevoked before any audit insert.
+    """
     with engine.begin() as conn:
         conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant_id)})
         conn.execute(
@@ -37,6 +44,18 @@ def _seed_tenant_principal(engine, tenant_id, principal_id):
                 "ON CONFLICT DO NOTHING"
             ),
             {"id": str(principal_id), "t": str(tenant_id)},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO daemon_machines (id, tenant_id, principal_id, pubkey) "
+                "VALUES (:m, :t, :p, :pk) ON CONFLICT DO NOTHING"
+            ),
+            {
+                "m": str(machine_id),
+                "t": str(tenant_id),
+                "p": str(principal_id),
+                "pk": b"rt-pubkey-" + machine_id.bytes,
+            },
         )
 
 
@@ -55,7 +74,7 @@ def test_writes_100_percent_on_cache_miss(engine):
     tenant = uuid.uuid4()
     principal = uuid.uuid4()
     machine = uuid.uuid4()
-    _seed_tenant_principal(engine, tenant, principal)
+    _seed_tenant_principal_and_machine(engine, tenant, principal, machine)
     writer = ReadAuditWriter(engine=engine, hit_sample_rate=0.01)
 
     for _ in range(20):
@@ -78,7 +97,7 @@ def test_samples_one_percent_on_cache_hit(engine):
     tenant = uuid.uuid4()
     principal = uuid.uuid4()
     machine = uuid.uuid4()
-    _seed_tenant_principal(engine, tenant, principal)
+    _seed_tenant_principal_and_machine(engine, tenant, principal, machine)
     rng = random.Random(42)
     expected = sum(1 for _ in range(100) if rng.random() < 0.01)
 
@@ -103,7 +122,7 @@ def test_truncates_purpose_to_256_chars(engine):
     tenant = uuid.uuid4()
     principal = uuid.uuid4()
     machine = uuid.uuid4()
-    _seed_tenant_principal(engine, tenant, principal)
+    _seed_tenant_principal_and_machine(engine, tenant, principal, machine)
     writer = ReadAuditWriter(engine=engine, hit_sample_rate=0.01)
 
     long_purpose = "x" * 1000
@@ -154,23 +173,66 @@ def test_cache_miss_insert_failure_raises_audit_write_failed():
         )
 
 
-def test_cache_hit_insert_failure_is_swallowed():
-    """Cache-hit audit is best-effort telemetry; failure must not block the
-    caller (cache-hit means the credential was already audited at miss-time)."""
+def test_cache_hit_pre_gate_failure_raises_audit_write_failed():
+    """Cache-hit failure BEFORE the SHARE-lock gate proves the daemon row
+    is unrevoked must fail closed. Otherwise a connection-loss or
+    statement-timeout against ``SET LOCAL`` / ``SELECT FOR SHARE`` would
+    let the consumer silently treat the gate as passed and return the
+    cached credential — bypassing the very protection F26 added.
+
+    Regression for codex round-13 finding F28.
+    """
     from unittest.mock import MagicMock
+
+    from nexus.bricks.auth.consumer import AuditWriteFailed
 
     bad_engine = MagicMock()
     bad_engine.begin.side_effect = RuntimeError("transient db blip")
-    # rng forced to 0 → always sampled; attempt + swallow.
     writer = ReadAuditWriter(engine=bad_engine, hit_sample_rate=1.0)
-    writer.write(  # no raise
-        tenant_id=uuid.uuid4(),
-        principal_id=uuid.uuid4(),
+    with pytest.raises(AuditWriteFailed):
+        writer.write(
+            tenant_id=uuid.uuid4(),
+            principal_id=uuid.uuid4(),
+            auth_profile_id="x",
+            caller_machine_id=uuid.uuid4(),
+            caller_kind="daemon",
+            provider="github",
+            purpose="t",
+            cache_hit=True,
+            kek_version=1,
+        )
+
+
+def test_cache_hit_post_gate_insert_failure_is_swallowed(engine):
+    """Cache-hit failure AFTER the gate is proven (the audit INSERT itself
+    fails) is best-effort telemetry — the SHARE-lock SELECT already proved
+    the daemon is allowed to read, and the cached credential's first-time
+    audit was written at miss-time. Operational telemetry blip on the
+    sampled INSERT must not block the caller."""
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    machine = uuid.uuid4()
+    _seed_tenant_principal_and_machine(engine, tenant, principal, machine)
+
+    # auth_profile_reads.kek_version is INTEGER NOT NULL; passing a value
+    # the column can't store (a string, sneaked past the type checker
+    # via Any) makes psycopg2 raise during INSERT — after SET LOCAL +
+    # SELECT FOR SHARE have already succeeded, so we exercise the
+    # post-gate cache-hit swallow path specifically.
+    from typing import Any
+
+    bad_kek: Any = "not-an-int"
+    writer = ReadAuditWriter(engine=engine, hit_sample_rate=1.0)
+    writer.write(  # no raise — gate passed, INSERT failure swallowed
+        tenant_id=tenant,
+        principal_id=principal,
         auth_profile_id="x",
-        caller_machine_id=uuid.uuid4(),
+        caller_machine_id=machine,
         caller_kind="daemon",
         provider="github",
         purpose="t",
         cache_hit=True,
-        kek_version=1,
+        kek_version=bad_kek,
     )
+    # Confirm no row was inserted (INSERT failed) but no exception bubbled.
+    assert _count_reads(engine, tenant) == 0

--- a/src/nexus/bricks/auth/tests/test_read_audit.py
+++ b/src/nexus/bricks/auth/tests/test_read_audit.py
@@ -126,3 +126,51 @@ def test_truncates_purpose_to_256_chars(engine):
             {"t": str(tenant)},
         ).fetchone()
     assert len(row[0]) == 256
+
+
+def test_cache_miss_insert_failure_raises_audit_write_failed():
+    """Cache-miss audit MUST fail closed — drop a credential without a record
+    of who read it would create a forensics blind spot. The router maps the
+    raised exception to 503 so the caller never sees the credential."""
+    from unittest.mock import MagicMock
+
+    from nexus.bricks.auth.consumer import AuditWriteFailed
+
+    bad_engine = MagicMock()
+    bad_engine.begin.side_effect = RuntimeError("partition exhausted")
+    writer = ReadAuditWriter(engine=bad_engine, hit_sample_rate=0.0)
+
+    with pytest.raises(AuditWriteFailed):
+        writer.write(
+            tenant_id=uuid.uuid4(),
+            principal_id=uuid.uuid4(),
+            auth_profile_id="x",
+            caller_machine_id=uuid.uuid4(),
+            caller_kind="daemon",
+            provider="github",
+            purpose="t",
+            cache_hit=False,
+            kek_version=1,
+        )
+
+
+def test_cache_hit_insert_failure_is_swallowed():
+    """Cache-hit audit is best-effort telemetry; failure must not block the
+    caller (cache-hit means the credential was already audited at miss-time)."""
+    from unittest.mock import MagicMock
+
+    bad_engine = MagicMock()
+    bad_engine.begin.side_effect = RuntimeError("transient db blip")
+    # rng forced to 0 → always sampled; attempt + swallow.
+    writer = ReadAuditWriter(engine=bad_engine, hit_sample_rate=1.0)
+    writer.write(  # no raise
+        tenant_id=uuid.uuid4(),
+        principal_id=uuid.uuid4(),
+        auth_profile_id="x",
+        caller_machine_id=uuid.uuid4(),
+        caller_kind="daemon",
+        provider="github",
+        purpose="t",
+        cache_hit=True,
+        kek_version=1,
+    )

--- a/src/nexus/cli/commands/stack.py
+++ b/src/nexus/cli/commands/stack.py
@@ -697,10 +697,19 @@ def up(
     # Default: pull prebuilt image.  Only build when explicitly requested
     # via --build (local dev iteration).
     if build is None:
-        # Reuse local build if previous state says so (and not --pull)
         if prev_state.get("build_mode") == "local" and force_pull is not True:
+            # Reuse local build if previous state says so (and not --pull)
             using_local_build = True
-        build = False
+            build = False
+        elif _compose_has_build(cf) and force_pull is not True:
+            # Repo-checkout default: compose file has a `build:` directive AND
+            # no remembered local-build state. Default to local build so we
+            # don't silently pull a stale GHCR image and overwrite worktree
+            # edits. Matches the docstring promise that "repo-checkout stacks
+            # rebuild automatically".
+            build = True
+        else:
+            build = False
 
     # --pull clears local build mode
     if force_pull:

--- a/src/nexus/server/api/v1/routers/token_exchange.py
+++ b/src/nexus/server/api/v1/routers/token_exchange.py
@@ -20,6 +20,7 @@ from fastapi.responses import JSONResponse
 
 from nexus.bricks.auth.consumer import (
     AdapterMaterializeFailed,
+    AuditWriteFailed,
     CredentialConsumer,
     MachineUnknownOrRevoked,
     MultipleProfilesForProvider,
@@ -124,6 +125,13 @@ def make_token_exchange_router(
             return _err(409, "ambiguous_profile", exc.cause or "")
         except StaleSource as exc:
             return _err(409, "stale_source", exc.cause or "")
+        except AuditWriteFailed as exc:
+            # Cache-miss audit could not be written. Refusing the credential
+            # avoids a forensics blind spot — the operator must clear the
+            # audit-table failure (partition exhaustion, RLS misconfig, etc)
+            # before reads resume.
+            logger.error("audit_write_failed on cache miss: %r", exc)
+            return _err(503, "audit_unavailable", exc.cause or "")
         except (AdapterMaterializeFailed, EnvelopeError) as exc:
             logger.warning("envelope_error: %r", exc)  # __repr__ masks plaintext
             return _err(500, "envelope_error", "see server logs")

--- a/src/nexus/server/api/v1/routers/token_exchange.py
+++ b/src/nexus/server/api/v1/routers/token_exchange.py
@@ -12,6 +12,7 @@ required so tests and dev wiring stay symmetric.
 from __future__ import annotations
 
 import logging
+import re
 from datetime import UTC, datetime
 from typing import Any
 
@@ -41,10 +42,39 @@ _GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
 _SUBJECT_TYPE_JWT = "urn:ietf:params:oauth:token-type:jwt"
 _ISSUED_TYPE = "urn:ietf:params:oauth:token-type:access_token"
 
-_RESOURCE_TO_PROVIDER = {
-    "urn:nexus:provider:aws": "aws",
-    "urn:nexus:provider:github": "github",
-}
+_KNOWN_PROVIDERS = frozenset({"aws", "github"})
+
+# Profile_id slug — matches the slugs writers use ("github-default",
+# "aws-prod", etc.). Strict character set keeps URI parsing predictable
+# and prevents accidental injection into log lines / SQL parameters.
+_PROFILE_ID_RE = re.compile(r"^[a-zA-Z0-9_-]{1,128}$")
+
+
+def _parse_resource(resource: str) -> tuple[str | None, str | None, str | None]:
+    """Parse the RFC 8693 ``resource`` URI to (provider, profile_id, error).
+
+    Accepted forms:
+      ``urn:nexus:provider:<provider>`` — default profile (single-row)
+      ``urn:nexus:provider:<provider>/<profile_id>`` — explicit selection
+
+    Returns ``(provider, profile_id, None)`` on success or
+    ``(None, None, error_description)`` on parse failure. ``profile_id``
+    is ``None`` when the caller did not specify one.
+    """
+    prefix = "urn:nexus:provider:"
+    if not resource.startswith(prefix):
+        return None, None, f"unknown resource: {resource!r}"
+    suffix = resource[len(prefix) :]
+    if "/" in suffix:
+        provider, _, profile_id = suffix.partition("/")
+        if not provider or provider not in _KNOWN_PROVIDERS:
+            return None, None, f"unknown provider in resource: {resource!r}"
+        if not profile_id or not _PROFILE_ID_RE.match(profile_id):
+            return None, None, f"invalid profile_id in resource: {resource!r}"
+        return provider, profile_id, None
+    if suffix not in _KNOWN_PROVIDERS:
+        return None, None, f"unknown provider in resource: {resource!r}"
+    return suffix, None, None
 
 
 def _err(http_status: int, code: str, description: str) -> JSONResponse:
@@ -95,9 +125,10 @@ def make_token_exchange_router(
             return _err(
                 400, "invalid_request", f"unsupported subject_token_type: {subject_token_type!r}"
             )
-        provider = _RESOURCE_TO_PROVIDER.get(resource)
-        if provider is None:
-            return _err(400, "invalid_request", f"unknown resource: {resource!r}")
+        provider, profile_id, parse_err = _parse_resource(resource)
+        if parse_err is not None:
+            return _err(400, "invalid_request", parse_err)
+        assert provider is not None  # mypy — parse_err is None implies provider set
 
         try:
             claims = signer.verify(subject_token)
@@ -110,6 +141,7 @@ def make_token_exchange_router(
             cred = consumer.resolve(
                 claims=claims,
                 provider=provider,
+                profile_id=profile_id,
                 purpose=scope,
                 force_refresh=force_refresh,
             )

--- a/src/nexus/server/api/v1/routers/token_exchange.py
+++ b/src/nexus/server/api/v1/routers/token_exchange.py
@@ -12,7 +12,6 @@ required so tests and dev wiring stay symmetric.
 from __future__ import annotations
 
 import logging
-import re
 from datetime import UTC, datetime
 from typing import Any
 
@@ -44,37 +43,45 @@ _ISSUED_TYPE = "urn:ietf:params:oauth:token-type:access_token"
 
 _KNOWN_PROVIDERS = frozenset({"aws", "github"})
 
-# Profile_id slug — matches the slugs writers use ("github-default",
-# "aws-prod", etc.). Strict character set keeps URI parsing predictable
-# and prevents accidental injection into log lines / SQL parameters.
-_PROFILE_ID_RE = re.compile(r"^[a-zA-Z0-9_-]{1,128}$")
+# Outer bound on profile_id length. The daemon writes IDs as
+# ``<provider>/<account_identifier>`` and account_identifier is free-form
+# user input (email, github.com path, etc.). 256 is generous for any
+# realistic case without unbounding the input.
+_PROFILE_ID_MAX_LEN = 256
 
 
-def _parse_resource(resource: str) -> tuple[str | None, str | None, str | None]:
-    """Parse the RFC 8693 ``resource`` URI to (provider, profile_id, error).
+def _parse_resource(resource: str) -> tuple[str | None, str | None]:
+    """Parse the RFC 8693 ``resource`` URI to (provider, error).
 
-    Accepted forms:
-      ``urn:nexus:provider:<provider>`` — default profile (single-row)
-      ``urn:nexus:provider:<provider>/<profile_id>`` — explicit selection
-
-    Returns ``(provider, profile_id, None)`` on success or
-    ``(None, None, error_description)`` on parse failure. ``profile_id``
-    is ``None`` when the caller did not specify one.
+    Only accepts ``urn:nexus:provider:<provider>``. Multi-account selection
+    rides on the ``nexus_profile_id`` form field instead of being embedded
+    in the URI — daemon-written profile IDs contain ``/``, ``.``, ``@``
+    (e.g. ``github/github.com/alice``) which collide with any
+    URI-segment encoding we could pick.
     """
     prefix = "urn:nexus:provider:"
     if not resource.startswith(prefix):
-        return None, None, f"unknown resource: {resource!r}"
+        return None, f"unknown resource: {resource!r}"
     suffix = resource[len(prefix) :]
-    if "/" in suffix:
-        provider, _, profile_id = suffix.partition("/")
-        if not provider or provider not in _KNOWN_PROVIDERS:
-            return None, None, f"unknown provider in resource: {resource!r}"
-        if not profile_id or not _PROFILE_ID_RE.match(profile_id):
-            return None, None, f"invalid profile_id in resource: {resource!r}"
-        return provider, profile_id, None
     if suffix not in _KNOWN_PROVIDERS:
-        return None, None, f"unknown provider in resource: {resource!r}"
-    return suffix, None, None
+        return None, f"unknown provider in resource: {resource!r}"
+    return suffix, None
+
+
+def _validate_profile_id(profile_id: str) -> str | None:
+    """Reject empty, oversize, or control-char-bearing profile_ids.
+
+    SQL is parameterized so injection isn't a concern. The bounds exist
+    so log lines stay readable and a malicious caller can't ship a
+    multi-MB string through the form parser.
+    """
+    if not profile_id:
+        return "nexus_profile_id is empty"
+    if len(profile_id) > _PROFILE_ID_MAX_LEN:
+        return f"nexus_profile_id exceeds {_PROFILE_ID_MAX_LEN} chars"
+    if any(ord(c) < 0x20 or ord(c) == 0x7F for c in profile_id):
+        return "nexus_profile_id contains control characters"
+    return None
 
 
 def _err(http_status: int, code: str, description: str) -> JSONResponse:
@@ -109,6 +116,7 @@ def make_token_exchange_router(
         scope: str = Form(...),
         audience: str | None = Form(None),
         nexus_force_refresh: str = Form("false"),
+        nexus_profile_id: str = Form(""),
     ) -> Any:
         if not enabled:
             return _err(
@@ -125,10 +133,17 @@ def make_token_exchange_router(
             return _err(
                 400, "invalid_request", f"unsupported subject_token_type: {subject_token_type!r}"
             )
-        provider, profile_id, parse_err = _parse_resource(resource)
+        provider, parse_err = _parse_resource(resource)
         if parse_err is not None:
             return _err(400, "invalid_request", parse_err)
         assert provider is not None  # mypy — parse_err is None implies provider set
+
+        profile_id: str | None = None
+        if nexus_profile_id:
+            profile_err = _validate_profile_id(nexus_profile_id)
+            if profile_err is not None:
+                return _err(400, "invalid_request", profile_err)
+            profile_id = nexus_profile_id
 
         try:
             claims = signer.verify(subject_token)

--- a/src/nexus/server/api/v1/routers/token_exchange.py
+++ b/src/nexus/server/api/v1/routers/token_exchange.py
@@ -1,65 +1,128 @@
-"""FastAPI router: POST /v1/auth/token-exchange (RFC 8693 stub, #3804).
+"""FastAPI router: POST /v1/auth/token-exchange (RFC 8693, #3818).
 
-This route exposes the RFC 8693 OAuth 2.0 Token Exchange contract so that
-client code (daemon, admin CLI, agents) can be written against the wire
-shape now, while the full implementation is deferred to a follow-up. For
-the MVP the handler always returns HTTP 501, regardless of the ``enabled``
-flag — the flag is threaded through from ``create_app`` via the
-``NEXUS_TOKEN_EXCHANGE_ENABLED`` env var so the follow-up can flip it on
-without another router signature change.
+Verifies the daemon's JWT (subject_token), looks up the matching envelope row
+via CredentialConsumer, and returns a provider-native bearer token. Errors
+follow RFC 6749 §5.2 shape: ``{"error": "...", "error_description": "..."}``.
 
-See epic #3788 for the RFC 8693 implementation plan.
+When ``enabled=False`` (default until ops verifies KMS/Vault wiring) the route
+returns 501 regardless of the request — the consumer/signer args are still
+required so tests and dev wiring stay symmetric.
 """
 
 from __future__ import annotations
 
-from fastapi import APIRouter, HTTPException, status
-from pydantic import BaseModel
+import logging
+from datetime import UTC, datetime
+from typing import Any
+
+from fastapi import APIRouter, Form, status
+from fastapi.responses import JSONResponse
+
+from nexus.bricks.auth.consumer import (
+    AdapterMaterializeFailed,
+    CredentialConsumer,
+    ProfileNotFoundForCaller,
+    ProviderNotConfigured,
+    StaleSource,
+)
+from nexus.bricks.auth.envelope import EncryptionProvider, EnvelopeError
+from nexus.server.api.v1.jwt_signer import JwtSigner, JwtVerifyError
+
+logger = logging.getLogger(__name__)
+
+_GRANT_TYPE = "urn:ietf:params:oauth:grant-type:token-exchange"
+_SUBJECT_TYPE_JWT = "urn:ietf:params:oauth:token-type:jwt"
+_ISSUED_TYPE = "urn:ietf:params:oauth:token-type:access_token"
+
+_RESOURCE_TO_PROVIDER = {
+    "urn:nexus:provider:aws": "aws",
+    "urn:nexus:provider:github": "github",
+}
 
 
-class TokenExchangeRequest(BaseModel):
-    grant_type: str
-    subject_token: str
-    subject_token_type: str
-    resource: str | None = None
-    scope: str | None = None
-    audience: str | None = None
+def _err(http_status: int, code: str, description: str) -> JSONResponse:
+    return JSONResponse(
+        status_code=http_status,
+        content={"error": code, "error_description": description},
+    )
 
 
-class TokenExchangeResponse(BaseModel):
-    access_token: str
-    issued_token_type: str
-    token_type: str
-    expires_in: int
-
-
-def make_token_exchange_router(*, enabled: bool) -> APIRouter:
+def make_token_exchange_router(
+    *,
+    enabled: bool,
+    signer: JwtSigner,
+    consumer: CredentialConsumer,
+    encryption: EncryptionProvider,
+) -> APIRouter:
     """Build the ``/v1/auth/token-exchange`` router.
 
-    Parameters
-    ----------
-    enabled:
-        Reserved for future flag-gating. For this MVP both flag states
-        return 501; the argument is preserved so the follow-up that
-        implements RFC 8693 can switch behaviour without changing the
-        public surface.
+    When ``enabled=False`` the route returns 501 — gives ops a single env-var
+    flag to flip the read path on/off without redeploying.
     """
-    del enabled  # Reserved; both flag states return 501 for the MVP.
+    del encryption  # Reserved for future direct-decrypt fallbacks; unused for now.
     router = APIRouter(prefix="/v1/auth", tags=["auth"])
 
-    @router.post(
-        "/token-exchange",
-        response_model=TokenExchangeResponse,
-        status_code=status.HTTP_501_NOT_IMPLEMENTED,
-    )
-    def exchange(req: TokenExchangeRequest) -> TokenExchangeResponse:
-        del req  # Unused — handler is a stub.
-        raise HTTPException(
-            status_code=status.HTTP_501_NOT_IMPLEMENTED,
-            detail=(
-                "token exchange deferred to follow-up; "
-                "see epic #3788 for RFC 8693 implementation plan"
-            ),
-        )
+    @router.post("/token-exchange")
+    def exchange(
+        grant_type: str = Form(...),
+        subject_token: str = Form(...),
+        subject_token_type: str = Form(...),
+        resource: str = Form(...),
+        scope: str = Form(...),
+        audience: str | None = Form(None),
+        nexus_force_refresh: str = Form("false"),
+    ) -> Any:
+        if not enabled:
+            return _err(
+                status.HTTP_501_NOT_IMPLEMENTED,
+                "not_implemented",
+                "token-exchange disabled (NEXUS_TOKEN_EXCHANGE_ENABLED=0)",
+            )
+
+        del audience  # MVP ignores audience field (always bound by JWT verify).
+
+        if grant_type != _GRANT_TYPE:
+            return _err(400, "invalid_request", f"unknown grant_type: {grant_type!r}")
+        if subject_token_type != _SUBJECT_TYPE_JWT:
+            return _err(
+                400, "invalid_request", f"unsupported subject_token_type: {subject_token_type!r}"
+            )
+        provider = _RESOURCE_TO_PROVIDER.get(resource)
+        if provider is None:
+            return _err(400, "invalid_request", f"unknown resource: {resource!r}")
+
+        try:
+            claims = signer.verify(subject_token)
+        except JwtVerifyError as exc:
+            return _err(401, "invalid_token", str(exc))
+
+        force_refresh = nexus_force_refresh.lower() in ("1", "true", "yes")
+
+        try:
+            cred = consumer.resolve(
+                claims=claims,
+                provider=provider,
+                purpose=scope,
+                force_refresh=force_refresh,
+            )
+        except (ProfileNotFoundForCaller, ProviderNotConfigured) as exc:
+            return _err(403, "access_denied", exc.cause or "")
+        except StaleSource as exc:
+            return _err(409, "stale_source", exc.cause or "")
+        except (AdapterMaterializeFailed, EnvelopeError) as exc:
+            logger.warning("envelope_error: %r", exc)  # __repr__ masks plaintext
+            return _err(500, "envelope_error", "see server logs")
+
+        expires_in = 0
+        if cred.expires_at is not None:
+            expires_in = max(0, int((cred.expires_at - datetime.now(UTC)).total_seconds()))
+
+        return {
+            "access_token": cred.access_token,
+            "issued_token_type": _ISSUED_TYPE,
+            "token_type": "Bearer",
+            "expires_in": expires_in,
+            "nexus_credential_metadata": cred.metadata,
+        }
 
     return router

--- a/src/nexus/server/api/v1/routers/token_exchange.py
+++ b/src/nexus/server/api/v1/routers/token_exchange.py
@@ -21,12 +21,18 @@ from fastapi.responses import JSONResponse
 from nexus.bricks.auth.consumer import (
     AdapterMaterializeFailed,
     CredentialConsumer,
+    MachineUnknownOrRevoked,
+    MultipleProfilesForProvider,
     ProfileNotFoundForCaller,
     ProviderNotConfigured,
     StaleSource,
 )
 from nexus.bricks.auth.envelope import EncryptionProvider, EnvelopeError
 from nexus.server.api.v1.jwt_signer import JwtSigner, JwtVerifyError
+
+# RFC 6749 §5.1 — token responses MUST NOT be cached. Applied to both
+# success and error responses since either may carry sensitive data.
+_NO_STORE_HEADERS = {"Cache-Control": "no-store", "Pragma": "no-cache"}
 
 logger = logging.getLogger(__name__)
 
@@ -44,6 +50,7 @@ def _err(http_status: int, code: str, description: str) -> JSONResponse:
     return JSONResponse(
         status_code=http_status,
         content={"error": code, "error_description": description},
+        headers=_NO_STORE_HEADERS,
     )
 
 
@@ -105,8 +112,16 @@ def make_token_exchange_router(
                 purpose=scope,
                 force_refresh=force_refresh,
             )
+        except MachineUnknownOrRevoked as exc:
+            # Cryptographically valid JWT but the daemon row is missing or
+            # revoked — treat as 401 invalid_token so a compromised daemon's
+            # JWT stops working the moment its row is revoked, even if the
+            # JWT has not yet expired.
+            return _err(401, "invalid_token", exc.cause or "machine_revoked")
         except (ProfileNotFoundForCaller, ProviderNotConfigured) as exc:
             return _err(403, "access_denied", exc.cause or "")
+        except MultipleProfilesForProvider as exc:
+            return _err(409, "ambiguous_profile", exc.cause or "")
         except StaleSource as exc:
             return _err(409, "stale_source", exc.cause or "")
         except (AdapterMaterializeFailed, EnvelopeError) as exc:
@@ -117,12 +132,15 @@ def make_token_exchange_router(
         if cred.expires_at is not None:
             expires_in = max(0, int((cred.expires_at - datetime.now(UTC)).total_seconds()))
 
-        return {
-            "access_token": cred.access_token,
-            "issued_token_type": _ISSUED_TYPE,
-            "token_type": "Bearer",
-            "expires_in": expires_in,
-            "nexus_credential_metadata": cred.metadata,
-        }
+        return JSONResponse(
+            content={
+                "access_token": cred.access_token,
+                "issued_token_type": _ISSUED_TYPE,
+                "token_type": "Bearer",
+                "expires_in": expires_in,
+                "nexus_credential_metadata": cred.metadata,
+            },
+            headers=_NO_STORE_HEADERS,
+        )
 
     return router

--- a/src/nexus/server/api/v1/routers/token_exchange.py
+++ b/src/nexus/server/api/v1/routers/token_exchange.py
@@ -136,19 +136,18 @@ def make_token_exchange_router(
             logger.warning("envelope_error: %r", exc)  # __repr__ masks plaintext
             return _err(500, "envelope_error", "see server logs")
 
-        expires_in = 0
+        # RFC 6749 §5.1: expires_in is OPTIONAL. Omit it for non-expiring
+        # credentials (e.g. GitHub classic PATs) — emitting expires_in=0
+        # signals "already expired" and clients drop the credential.
+        body: dict[str, object] = {
+            "access_token": cred.access_token,
+            "issued_token_type": _ISSUED_TYPE,
+            "token_type": "Bearer",
+            "nexus_credential_metadata": cred.metadata,
+        }
         if cred.expires_at is not None:
-            expires_in = max(0, int((cred.expires_at - datetime.now(UTC)).total_seconds()))
+            body["expires_in"] = max(0, int((cred.expires_at - datetime.now(UTC)).total_seconds()))
 
-        return JSONResponse(
-            content={
-                "access_token": cred.access_token,
-                "issued_token_type": _ISSUED_TYPE,
-                "token_type": "Bearer",
-                "expires_in": expires_in,
-                "nexus_credential_metadata": cred.metadata,
-            },
-            headers=_NO_STORE_HEADERS,
-        )
+        return JSONResponse(content=body, headers=_NO_STORE_HEADERS)
 
     return router

--- a/src/nexus/server/api/v1/tests/test_token_exchange_router.py
+++ b/src/nexus/server/api/v1/tests/test_token_exchange_router.py
@@ -193,6 +193,88 @@ def test_token_exchange_happy_path_returns_200_with_bearer(engine: Engine) -> No
     # RFC 6749 §5.1: token responses MUST NOT be cached.
     assert r.headers.get("cache-control") == "no-store"
     assert r.headers.get("pragma") == "no-cache"
+    # RFC 6749 §5.1: expires_in is OPTIONAL. Classic GitHub PATs have no
+    # expiry — the field must be omitted, not emitted as 0 (which clients
+    # interpret as "already expired"). Regression for codex round-5 F16.
+    assert "expires_in" not in body
+
+
+def test_token_exchange_emits_expires_in_when_credential_has_expiry(
+    engine: Engine,
+) -> None:
+    """Fine-grained PATs / STS creds carry expires_at — the wire response
+    MUST include expires_in. Companion to the classic-PAT happy path which
+    asserts the field is OMITTED. Together they pin RFC 6749 §5.1 semantics.
+    """
+    from datetime import UTC, datetime
+
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    app, signer, encryption = _build_app(engine, tenant, principal)
+
+    # Seed a github profile whose envelope payload carries expires_at.
+    expires_at = datetime.now(UTC) + timedelta(minutes=30)
+    payload = json.dumps(
+        {"token": "github_pat_real", "scopes": ["repo"], "expires_at": expires_at.isoformat()}
+    ).encode()
+    aad = str(tenant).encode() + b"|" + str(principal).encode() + b"|" + b"github-default"
+    dek = b"\x03" * 32
+    nonce, ct = AESGCMEnvelope().encrypt(dek, payload, aad=aad)
+    wrapped, kv = encryption.wrap_dek(dek, tenant_id=tenant, aad=aad)
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, :n) ON CONFLICT DO NOTHING"),
+            {"id": str(tenant), "n": f"tx-{tenant}"},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO principals (id, tenant_id, kind) VALUES (:id, :t, 'human') "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {"id": str(principal), "t": str(tenant)},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO auth_profiles "
+                "(tenant_id, principal_id, id, provider, account_identifier, "
+                " backend, backend_key, last_synced_at, sync_ttl_seconds, "
+                " ciphertext, wrapped_dek, nonce, aad, kek_version) "
+                "VALUES (:t, :p, 'github-default', 'github', 'me', 'envelope', 'k', "
+                " NOW(), 300, :ct, :wd, :no, :aad, :kv)"
+            ),
+            {
+                "t": str(tenant),
+                "p": str(principal),
+                "ct": ct,
+                "wd": wrapped,
+                "no": nonce,
+                "aad": aad,
+                "kv": kv,
+            },
+        )
+    machine = _seed_active_machine(engine, tenant, principal)
+    jwt = signer.sign(
+        DaemonClaims(tenant_id=tenant, principal_id=principal, machine_id=machine),
+        ttl=timedelta(hours=1),
+    )
+
+    client = TestClient(app)
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": jwt,
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "resource": "urn:nexus:provider:github",
+            "scope": "list-repos",
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert "expires_in" in body
+    # ~30 minutes minus a few seconds of test elapsed time
+    assert 1500 <= body["expires_in"] <= 1800
 
 
 def test_token_exchange_revoked_machine_returns_401(engine: Engine) -> None:

--- a/src/nexus/server/api/v1/tests/test_token_exchange_router.py
+++ b/src/nexus/server/api/v1/tests/test_token_exchange_router.py
@@ -319,6 +319,107 @@ def test_token_exchange_no_profile_returns_403(engine: Engine) -> None:
     assert r.json()["error"] == "access_denied"
 
 
+def test_token_exchange_audit_write_failed_returns_503() -> None:
+    """Cache-miss audit insert failure must surface as 503, not silently
+    return the credential without an audit row."""
+    from unittest.mock import MagicMock
+
+    from nexus.bricks.auth.consumer import AuditWriteFailed
+
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    machine = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    signer = _make_signer()
+    fake_consumer = MagicMock()
+    fake_consumer.resolve.side_effect = AuditWriteFailed.from_row(
+        tenant_id=tenant,
+        principal_id=principal,
+        provider="github",
+        cause="OperationalError",
+    )
+    app = FastAPI()
+    app.include_router(
+        make_token_exchange_router(
+            enabled=True,
+            signer=signer,
+            consumer=fake_consumer,
+            encryption=encryption,
+        )
+    )
+    jwt = signer.sign(
+        DaemonClaims(tenant_id=tenant, principal_id=principal, machine_id=machine),
+        ttl=timedelta(hours=1),
+    )
+    client = TestClient(app)
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": jwt,
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "resource": "urn:nexus:provider:github",
+            "scope": "x",
+        },
+    )
+    assert r.status_code == 503
+    assert r.json()["error"] == "audit_unavailable"
+    assert r.headers.get("cache-control") == "no-store"
+
+
+def test_token_exchange_multiple_profiles_returns_409(engine: Engine) -> None:
+    """Two envelope rows for the same (tenant, principal, provider) → 409."""
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    app, signer, encryption = _build_app(engine, tenant, principal)
+    _seed_github(engine, tenant, principal, encryption)
+    # Insert second profile under a different id but same provider.
+    payload = json.dumps({"token": "ghp_other", "scopes": []}).encode()
+    aad = str(tenant).encode() + b"|" + str(principal).encode() + b"|" + b"github-other"
+    dek = b"\x05" * 32
+    nonce, ct = AESGCMEnvelope().encrypt(dek, payload, aad=aad)
+    wrapped, kv = encryption.wrap_dek(dek, tenant_id=tenant, aad=aad)
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text(
+                "INSERT INTO auth_profiles "
+                "(tenant_id, principal_id, id, provider, account_identifier, "
+                " backend, backend_key, last_synced_at, sync_ttl_seconds, "
+                " ciphertext, wrapped_dek, nonce, aad, kek_version) "
+                "VALUES (:t, :p, 'github-other', 'github', 'other', 'envelope', 'k', "
+                " NOW(), 300, :ct, :wd, :no, :aad, :kv)"
+            ),
+            {
+                "t": str(tenant),
+                "p": str(principal),
+                "ct": ct,
+                "wd": wrapped,
+                "no": nonce,
+                "aad": aad,
+                "kv": kv,
+            },
+        )
+    machine = _seed_active_machine(engine, tenant, principal)
+    jwt = signer.sign(
+        DaemonClaims(tenant_id=tenant, principal_id=principal, machine_id=machine),
+        ttl=timedelta(hours=1),
+    )
+    client = TestClient(app)
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": jwt,
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "resource": "urn:nexus:provider:github",
+            "scope": "x",
+        },
+    )
+    assert r.status_code == 409
+    assert r.json()["error"] == "ambiguous_profile"
+
+
 def test_token_exchange_disabled_returns_501(engine: Engine) -> None:
     tenant = uuid.uuid4()
     principal = uuid.uuid4()

--- a/src/nexus/server/api/v1/tests/test_token_exchange_router.py
+++ b/src/nexus/server/api/v1/tests/test_token_exchange_router.py
@@ -1,57 +1,269 @@
-"""Tests for src/nexus/server/api/v1/routers/token_exchange.py."""
+"""Tests for /v1/auth/token-exchange router (#3818)."""
 
 from __future__ import annotations
+
+import json
+import os
+import uuid
+from collections.abc import Iterator
+from datetime import timedelta
 
 import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+from sqlalchemy.engine import Engine
 
+from nexus.bricks.auth.consumer import CredentialConsumer
+from nexus.bricks.auth.consumer_cache import ResolvedCredCache
+from nexus.bricks.auth.consumer_providers.aws import AwsProviderAdapter
+from nexus.bricks.auth.consumer_providers.github import GithubProviderAdapter
+from nexus.bricks.auth.envelope import AESGCMEnvelope, DEKCache
+from nexus.bricks.auth.envelope_providers.in_memory import InMemoryEncryptionProvider
+from nexus.bricks.auth.postgres_profile_store import (
+    PostgresAuthProfileStore,
+    ensure_schema,
+)
+from nexus.bricks.auth.read_audit import ReadAuditWriter
+from nexus.server.api.v1.jwt_signer import DaemonClaims, JwtSigner
 from nexus.server.api.v1.routers.token_exchange import make_token_exchange_router
 
 
-@pytest.fixture
-def app_flag_off() -> FastAPI:
-    a = FastAPI()
-    a.include_router(make_token_exchange_router(enabled=False))
-    return a
+def _make_signer() -> JwtSigner:
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    pk = ec.generate_private_key(ec.SECP256R1())
+    pem = pk.private_bytes(
+        encoding=serialization.Encoding.PEM,
+        format=serialization.PrivateFormat.PKCS8,
+        encryption_algorithm=serialization.NoEncryption(),
+    )
+    return JwtSigner.from_pem(pem, issuer="https://test.local")
 
 
 @pytest.fixture
-def app_flag_on() -> FastAPI:
-    a = FastAPI()
-    a.include_router(make_token_exchange_router(enabled=True))
-    return a
+def engine() -> Iterator[Engine]:
+    url = os.environ.get("NEXUS_TEST_DATABASE_URL")
+    if not url:
+        pytest.skip("NEXUS_TEST_DATABASE_URL not set")
+    eng = create_engine(url, future=True)
+    ensure_schema(eng)
+    yield eng
+    eng.dispose()
 
 
-def _rfc8693_payload() -> dict[str, str]:
-    return {
-        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
-        "subject_token": "some-daemon-jwt",
-        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
-        "resource": "urn:nexus:gmail",
-    }
+def _build_app(
+    engine: Engine,
+    tenant_id: uuid.UUID,
+    principal_id: uuid.UUID | None = None,
+) -> tuple[FastAPI, JwtSigner, InMemoryEncryptionProvider]:
+    encryption = InMemoryEncryptionProvider()
+    signer = _make_signer()
+    bound_principal = principal_id or uuid.uuid4()
+    consumer = CredentialConsumer(
+        store=PostgresAuthProfileStore(
+            "", tenant_id=tenant_id, principal_id=bound_principal, engine=engine
+        ),
+        encryption=encryption,
+        dek_cache=DEKCache(),
+        cred_cache=ResolvedCredCache(),
+        adapters={
+            "aws": AwsProviderAdapter(),
+            "github": GithubProviderAdapter(),
+        },
+        audit=ReadAuditWriter(engine=engine, hit_sample_rate=0.01),
+    )
+    app = FastAPI()
+    app.include_router(
+        make_token_exchange_router(
+            enabled=True,
+            signer=signer,
+            consumer=consumer,
+            encryption=encryption,
+        )
+    )
+    return app, signer, encryption
 
 
-def test_flag_off_returns_501(app_flag_off: FastAPI) -> None:
-    client = TestClient(app_flag_off)
-    r = client.post("/v1/auth/token-exchange", json=_rfc8693_payload())
-    assert r.status_code == 501, r.text
-    assert "deferred" in r.json()["detail"]
-    assert "#3788" in r.json()["detail"]
+def _seed_github(
+    engine: Engine,
+    tenant: uuid.UUID,
+    principal: uuid.UUID,
+    encryption: InMemoryEncryptionProvider,
+) -> None:
+    payload = json.dumps({"token": "ghp_real", "scopes": ["repo"]}).encode()
+    aad = str(tenant).encode() + b"|" + str(principal).encode() + b"|" + b"github-default"
+    dek = b"\x02" * 32
+    nonce, ct = AESGCMEnvelope().encrypt(dek, payload, aad=aad)
+    wrapped, kv = encryption.wrap_dek(dek, tenant_id=tenant, aad=aad)
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, :n) ON CONFLICT DO NOTHING"),
+            {"id": str(tenant), "n": f"tx-{tenant}"},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO principals (id, tenant_id, kind) VALUES (:id, :t, 'human') "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {"id": str(principal), "t": str(tenant)},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO auth_profiles "
+                "(tenant_id, principal_id, id, provider, account_identifier, "
+                " backend, backend_key, last_synced_at, sync_ttl_seconds, "
+                " ciphertext, wrapped_dek, nonce, aad, kek_version) "
+                "VALUES (:t, :p, 'github-default', 'github', 'me', 'envelope', 'k', "
+                " NOW(), 300, :ct, :wd, :no, :aad, :kv)"
+            ),
+            {
+                "t": str(tenant),
+                "p": str(principal),
+                "ct": ct,
+                "wd": wrapped,
+                "no": nonce,
+                "aad": aad,
+                "kv": kv,
+            },
+        )
 
 
-def test_flag_on_still_returns_501_with_schema(app_flag_on: FastAPI) -> None:
-    client = TestClient(app_flag_on)
-    r = client.post("/v1/auth/token-exchange", json=_rfc8693_payload())
-    assert r.status_code == 501, r.text
-    assert "deferred" in r.json()["detail"]
+def test_token_exchange_happy_path_returns_200_with_bearer(engine: Engine) -> None:
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    machine = uuid.uuid4()
+    app, signer, encryption = _build_app(engine, tenant, principal)
+    _seed_github(engine, tenant, principal, encryption)
+    jwt = signer.sign(
+        DaemonClaims(tenant_id=tenant, principal_id=principal, machine_id=machine),
+        ttl=timedelta(hours=1),
+    )
+
+    client = TestClient(app)
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": jwt,
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "resource": "urn:nexus:provider:github",
+            "scope": "list-repos",
+        },
+    )
+    assert r.status_code == 200
+    body = r.json()
+    assert body["access_token"] == "ghp_real"
+    assert body["token_type"] == "Bearer"
+    assert body["issued_token_type"] == "urn:ietf:params:oauth:token-type:access_token"
+    assert "nexus_credential_metadata" in body
+    assert body["nexus_credential_metadata"]["scopes_csv"] == "repo"
 
 
-def test_missing_body_field_422(app_flag_off: FastAPI) -> None:
-    client = TestClient(app_flag_off)
-    # Drop the required ``subject_token`` field — Pydantic validation fires
-    # before the handler, so we get 422 not 501 even with the flag off.
-    payload = _rfc8693_payload()
-    del payload["subject_token"]
-    r = client.post("/v1/auth/token-exchange", json=payload)
-    assert r.status_code == 422, r.text
+def test_token_exchange_invalid_jwt_returns_401(engine: Engine) -> None:
+    tenant = uuid.uuid4()
+    app, _, _ = _build_app(engine, tenant)
+    client = TestClient(app)
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": "garbage",
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "resource": "urn:nexus:provider:github",
+            "scope": "x",
+        },
+    )
+    assert r.status_code == 401
+    assert r.json()["error"] == "invalid_token"
+
+
+def test_token_exchange_unknown_resource_returns_400(engine: Engine) -> None:
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    app, signer, _ = _build_app(engine, tenant, principal)
+    jwt = signer.sign(
+        DaemonClaims(tenant_id=tenant, principal_id=principal, machine_id=uuid.uuid4()),
+        ttl=timedelta(hours=1),
+    )
+    client = TestClient(app)
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": jwt,
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "resource": "urn:nexus:provider:slack",  # unknown
+            "scope": "x",
+        },
+    )
+    assert r.status_code == 400
+    assert r.json()["error"] == "invalid_request"
+
+
+def test_token_exchange_no_profile_returns_403(engine: Engine) -> None:
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    app, signer, _ = _build_app(engine, tenant, principal)
+    # Seed tenant + principal but no profile
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, :n) ON CONFLICT DO NOTHING"),
+            {"id": str(tenant), "n": f"tx-{tenant}"},
+        )
+    jwt = signer.sign(
+        DaemonClaims(tenant_id=tenant, principal_id=principal, machine_id=uuid.uuid4()),
+        ttl=timedelta(hours=1),
+    )
+    client = TestClient(app)
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": jwt,
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "resource": "urn:nexus:provider:github",
+            "scope": "x",
+        },
+    )
+    assert r.status_code == 403
+    assert r.json()["error"] == "access_denied"
+
+
+def test_token_exchange_disabled_returns_501(engine: Engine) -> None:
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    encryption = InMemoryEncryptionProvider()
+    signer = _make_signer()
+    consumer = CredentialConsumer(
+        store=PostgresAuthProfileStore("", tenant_id=tenant, principal_id=principal, engine=engine),
+        encryption=encryption,
+        dek_cache=DEKCache(),
+        cred_cache=ResolvedCredCache(),
+        adapters={"github": GithubProviderAdapter()},
+        audit=ReadAuditWriter(engine=engine),
+    )
+    app = FastAPI()
+    app.include_router(
+        make_token_exchange_router(
+            enabled=False,
+            signer=signer,
+            consumer=consumer,
+            encryption=encryption,
+        )
+    )
+    client = TestClient(app)
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": "x",
+            "subject_token_type": "x",
+            "resource": "urn:nexus:provider:github",
+            "scope": "x",
+        },
+    )
+    assert r.status_code == 501

--- a/src/nexus/server/api/v1/tests/test_token_exchange_router.py
+++ b/src/nexus/server/api/v1/tests/test_token_exchange_router.py
@@ -131,12 +131,42 @@ def _seed_github(
         )
 
 
+def _seed_active_machine(engine: Engine, tenant: uuid.UUID, principal: uuid.UUID) -> uuid.UUID:
+    machine_id = uuid.uuid4()
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, :n) ON CONFLICT DO NOTHING"),
+            {"id": str(tenant), "n": f"tx-{tenant}"},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO principals (id, tenant_id, kind) VALUES (:id, :t, 'human') "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {"id": str(principal), "t": str(tenant)},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO daemon_machines (id, tenant_id, principal_id, pubkey) "
+                "VALUES (:m, :t, :p, :pk) ON CONFLICT DO NOTHING"
+            ),
+            {
+                "m": str(machine_id),
+                "t": str(tenant),
+                "p": str(principal),
+                "pk": b"test-pubkey-" + machine_id.bytes,
+            },
+        )
+    return machine_id
+
+
 def test_token_exchange_happy_path_returns_200_with_bearer(engine: Engine) -> None:
     tenant = uuid.uuid4()
     principal = uuid.uuid4()
-    machine = uuid.uuid4()
     app, signer, encryption = _build_app(engine, tenant, principal)
     _seed_github(engine, tenant, principal, encryption)
+    machine = _seed_active_machine(engine, tenant, principal)
     jwt = signer.sign(
         DaemonClaims(tenant_id=tenant, principal_id=principal, machine_id=machine),
         ttl=timedelta(hours=1),
@@ -160,6 +190,67 @@ def test_token_exchange_happy_path_returns_200_with_bearer(engine: Engine) -> No
     assert body["issued_token_type"] == "urn:ietf:params:oauth:token-type:access_token"
     assert "nexus_credential_metadata" in body
     assert body["nexus_credential_metadata"]["scopes_csv"] == "repo"
+    # RFC 6749 §5.1: token responses MUST NOT be cached.
+    assert r.headers.get("cache-control") == "no-store"
+    assert r.headers.get("pragma") == "no-cache"
+
+
+def test_token_exchange_revoked_machine_returns_401(engine: Engine) -> None:
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    app, signer, encryption = _build_app(engine, tenant, principal)
+    _seed_github(engine, tenant, principal, encryption)
+    machine = _seed_active_machine(engine, tenant, principal)
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text("UPDATE daemon_machines SET revoked_at = NOW() WHERE id = :m"),
+            {"m": str(machine)},
+        )
+    jwt = signer.sign(
+        DaemonClaims(tenant_id=tenant, principal_id=principal, machine_id=machine),
+        ttl=timedelta(hours=1),
+    )
+    client = TestClient(app)
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": jwt,
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "resource": "urn:nexus:provider:github",
+            "scope": "x",
+        },
+    )
+    assert r.status_code == 401
+    assert r.json()["error"] == "invalid_token"
+    assert "machine_revoked" in r.json()["error_description"]
+
+
+def test_token_exchange_unknown_machine_returns_401(engine: Engine) -> None:
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    app, signer, encryption = _build_app(engine, tenant, principal)
+    _seed_github(engine, tenant, principal, encryption)
+    # Don't seed daemon_machines — JWT carries an unknown machine_id.
+    jwt = signer.sign(
+        DaemonClaims(tenant_id=tenant, principal_id=principal, machine_id=uuid.uuid4()),
+        ttl=timedelta(hours=1),
+    )
+    client = TestClient(app)
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": jwt,
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "resource": "urn:nexus:provider:github",
+            "scope": "x",
+        },
+    )
+    assert r.status_code == 401
+    assert r.json()["error"] == "invalid_token"
+    assert "machine_unknown" in r.json()["error_description"]
 
 
 def test_token_exchange_invalid_jwt_returns_401(engine: Engine) -> None:
@@ -207,15 +298,10 @@ def test_token_exchange_no_profile_returns_403(engine: Engine) -> None:
     tenant = uuid.uuid4()
     principal = uuid.uuid4()
     app, signer, _ = _build_app(engine, tenant, principal)
-    # Seed tenant + principal but no profile
-    with engine.begin() as conn:
-        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
-        conn.execute(
-            text("INSERT INTO tenants (id, name) VALUES (:id, :n) ON CONFLICT DO NOTHING"),
-            {"id": str(tenant), "n": f"tx-{tenant}"},
-        )
+    # Seed tenant + principal + active machine but no envelope profile
+    machine = _seed_active_machine(engine, tenant, principal)
     jwt = signer.sign(
-        DaemonClaims(tenant_id=tenant, principal_id=principal, machine_id=uuid.uuid4()),
+        DaemonClaims(tenant_id=tenant, principal_id=principal, machine_id=machine),
         ttl=timedelta(hours=1),
     )
     client = TestClient(app)

--- a/src/nexus/server/api/v1/tests/test_token_exchange_router.py
+++ b/src/nexus/server/api/v1/tests/test_token_exchange_router.py
@@ -377,77 +377,107 @@ def test_token_exchange_unknown_resource_returns_400(engine: Engine) -> None:
 
 
 def test_parse_resource_accepts_known_provider() -> None:
-    """Bare provider URI parses to (provider, profile_id=None)."""
+    """Bare provider URI parses to (provider, None)."""
     from nexus.server.api.v1.routers.token_exchange import _parse_resource
 
-    assert _parse_resource("urn:nexus:provider:github") == ("github", None, None)
-    assert _parse_resource("urn:nexus:provider:aws") == ("aws", None, None)
-
-
-def test_parse_resource_accepts_provider_with_profile_id() -> None:
-    """``urn:nexus:provider:<provider>/<profile_id>`` form parses both segments."""
-    from nexus.server.api.v1.routers.token_exchange import _parse_resource
-
-    assert _parse_resource("urn:nexus:provider:github/work") == ("github", "work", None)
-    assert _parse_resource("urn:nexus:provider:aws/aws-prod") == ("aws", "aws-prod", None)
+    assert _parse_resource("urn:nexus:provider:github") == ("github", None)
+    assert _parse_resource("urn:nexus:provider:aws") == ("aws", None)
 
 
 def test_parse_resource_rejects_unknown_provider() -> None:
     from nexus.server.api.v1.routers.token_exchange import _parse_resource
 
-    p, pid, err = _parse_resource("urn:nexus:provider:slack")
-    assert p is None and pid is None and err is not None
-    p, pid, err = _parse_resource("urn:nexus:provider:slack/work")
-    assert p is None and pid is None and err is not None
+    p, err = _parse_resource("urn:nexus:provider:slack")
+    assert p is None and err is not None
+    p, err = _parse_resource("urn:nexus:provider:")
+    assert p is None and err is not None
 
 
-def test_parse_resource_rejects_invalid_profile_id() -> None:
-    """Profile_id must match ``[a-zA-Z0-9_-]{1,128}`` — keeps the URI parser
-    deterministic and prevents accidental injection into log lines."""
+def test_parse_resource_rejects_non_nexus_uri() -> None:
+    """``resource`` URI scheme is fixed; non-Nexus URNs return parse_err."""
     from nexus.server.api.v1.routers.token_exchange import _parse_resource
 
-    for bad in (
-        "urn:nexus:provider:github/",  # empty profile_id
-        "urn:nexus:provider:github/has space",
-        "urn:nexus:provider:github/has/slash",
-        "urn:nexus:provider:github/has;semi",
-        "urn:nexus:provider:github/" + "x" * 129,  # too long
+    p, err = _parse_resource("https://example.com/api")
+    assert p is None and err is not None
+
+
+def test_validate_profile_id_accepts_real_daemon_ids() -> None:
+    """Real daemon-written profile IDs use ``<provider>/<account_identifier>``
+    where account_identifier may contain ``/``, ``.``, ``@``, etc. The
+    validator must accept these verbatim — that's the whole reason F23
+    moved profile_id off the resource URI and onto its own form field."""
+    from nexus.server.api.v1.routers.token_exchange import _validate_profile_id
+
+    for ok in (
+        "github-default",
+        "github/github.com/alice",
+        "codex/u@example.com",
+        "aws/123456789012",
+        "github/org-name/sub-org/account",  # deeply nested daemon path
     ):
-        p, pid, err = _parse_resource(bad)
-        assert p is None and pid is None and err is not None, f"should reject {bad!r}"
+        assert _validate_profile_id(ok) is None, f"should accept {ok!r}"
 
 
-def test_token_exchange_with_profile_id_picks_named_envelope(engine: Engine) -> None:
-    """End-to-end: 2 GitHub envelopes for the same principal; the named one
-    via ``urn:nexus:provider:github/<id>`` returns its own access_token.
+def test_validate_profile_id_rejects_empty_oversize_or_control_chars() -> None:
+    from nexus.server.api.v1.routers.token_exchange import (
+        _PROFILE_ID_MAX_LEN,
+        _validate_profile_id,
+    )
 
-    This is the wire-contract proof for codex round-7 finding F21.
+    assert _validate_profile_id("") is not None
+    assert _validate_profile_id("x" * (_PROFILE_ID_MAX_LEN + 1)) is not None
+    assert _validate_profile_id("has\x00null") is not None
+    assert _validate_profile_id("has\nnewline") is not None
+    assert _validate_profile_id("has\x7fdel") is not None
+
+
+def _seed_github_profile(
+    engine: Engine,
+    tenant: uuid.UUID,
+    principal: uuid.UUID,
+    encryption: InMemoryEncryptionProvider,
+    *,
+    profile_id: str,
+    account_identifier: str,
+    token: str,
+) -> None:
+    """Insert one github envelope row with a caller-chosen profile_id.
+
+    Mirrors the daemon's ``Pusher.push_source`` shape — profile_id is
+    ``<provider>/<account_identifier>`` and may contain ``/``, ``.``, ``@``.
     """
-    tenant = uuid.uuid4()
-    principal = uuid.uuid4()
-    app, signer, encryption = _build_app(engine, tenant, principal)
-    _seed_github(engine, tenant, principal, encryption)  # writes 'github-default' / 'ghp_real'
-
-    # Add a second profile 'github-other' under the same principal.
-    payload = json.dumps({"token": "ghp_alt", "scopes": ["repo"]}).encode()
-    aad = str(tenant).encode() + b"|" + str(principal).encode() + b"|" + b"github-other"
-    dek = b"\x05" * 32
+    payload = json.dumps({"token": token, "scopes": ["repo"]}).encode()
+    aad = str(tenant).encode() + b"|" + str(principal).encode() + b"|" + profile_id.encode()
+    dek = bytes([profile_id.__hash__() & 0xFF]) * 32  # arbitrary distinct key per row
     nonce, ct = AESGCMEnvelope().encrypt(dek, payload, aad=aad)
     wrapped, kv = encryption.wrap_dek(dek, tenant_id=tenant, aad=aad)
     with engine.begin() as conn:
         conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, :n) ON CONFLICT DO NOTHING"),
+            {"id": str(tenant), "n": f"tx-{tenant}"},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO principals (id, tenant_id, kind) VALUES (:id, :t, 'human') "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {"id": str(principal), "t": str(tenant)},
+        )
         conn.execute(
             text(
                 "INSERT INTO auth_profiles "
                 "(tenant_id, principal_id, id, provider, account_identifier, "
                 " backend, backend_key, last_synced_at, sync_ttl_seconds, "
                 " ciphertext, wrapped_dek, nonce, aad, kek_version) "
-                "VALUES (:t, :p, 'github-other', 'github', 'other', 'envelope', 'k', "
+                "VALUES (:t, :p, :pid, 'github', :acct, 'envelope', 'k', "
                 " NOW(), 300, :ct, :wd, :no, :aad, :kv)"
             ),
             {
                 "t": str(tenant),
                 "p": str(principal),
+                "pid": profile_id,
+                "acct": account_identifier,
                 "ct": ct,
                 "wd": wrapped,
                 "no": nonce,
@@ -455,6 +485,38 @@ def test_token_exchange_with_profile_id_picks_named_envelope(engine: Engine) -> 
                 "kv": kv,
             },
         )
+
+
+def test_token_exchange_with_profile_id_picks_named_envelope(engine: Engine) -> None:
+    """End-to-end: 2 GitHub envelopes with REAL daemon-style profile IDs;
+    the named one via the ``nexus_profile_id`` form field returns its own
+    access_token.
+
+    Uses ``github/github.com/alice`` and ``codex/u@example.com`` shapes —
+    proves the F23 fix actually addresses production daemon writes (vs
+    the synthetic ``github-default`` slugs the original F21 test used).
+    """
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    app, signer, encryption = _build_app(engine, tenant, principal)
+    _seed_github_profile(
+        engine,
+        tenant,
+        principal,
+        encryption,
+        profile_id="github/github.com/alice",
+        account_identifier="github.com/alice",
+        token="ghp_alice",
+    )
+    _seed_github_profile(
+        engine,
+        tenant,
+        principal,
+        encryption,
+        profile_id="github/u@example.com",
+        account_identifier="u@example.com",
+        token="ghp_email",
+    )
     machine = _seed_active_machine(engine, tenant, principal)
     jwt = signer.sign(
         DaemonClaims(tenant_id=tenant, principal_id=principal, machine_id=machine),
@@ -462,47 +524,54 @@ def test_token_exchange_with_profile_id_picks_named_envelope(engine: Engine) -> 
     )
     client = TestClient(app)
 
-    # Bare resource → 409 ambiguous_profile (back-compat, fail closed).
-    r = client.post(
-        "/v1/auth/token-exchange",
-        data={
-            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
-            "subject_token": jwt,
-            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
-            "resource": "urn:nexus:provider:github",
-            "scope": "x",
-        },
-    )
+    base = {
+        "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+        "subject_token": jwt,
+        "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+        "resource": "urn:nexus:provider:github",
+        "scope": "x",
+    }
+
+    # Bare resource (no profile_id form field) → 409 ambiguous_profile.
+    r = client.post("/v1/auth/token-exchange", data=base)
     assert r.status_code == 409
     assert r.json()["error"] == "ambiguous_profile"
 
-    # Explicit /github-default → returns the default credential.
+    # nexus_profile_id selects the alice account.
     r = client.post(
         "/v1/auth/token-exchange",
-        data={
-            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
-            "subject_token": jwt,
-            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
-            "resource": "urn:nexus:provider:github/github-default",
-            "scope": "x",
-        },
+        data={**base, "nexus_profile_id": "github/github.com/alice"},
     )
-    assert r.status_code == 200
-    assert r.json()["access_token"] == "ghp_real"
+    assert r.status_code == 200, r.text
+    assert r.json()["access_token"] == "ghp_alice"
 
-    # Explicit /github-other → returns the other credential.
+    # nexus_profile_id selects the email-shaped account.
     r = client.post(
         "/v1/auth/token-exchange",
-        data={
-            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
-            "subject_token": jwt,
-            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
-            "resource": "urn:nexus:provider:github/github-other",
-            "scope": "x",
-        },
+        data={**base, "nexus_profile_id": "github/u@example.com"},
     )
-    assert r.status_code == 200
-    assert r.json()["access_token"] == "ghp_alt"
+    assert r.status_code == 200, r.text
+    assert r.json()["access_token"] == "ghp_email"
+
+    # Unknown nexus_profile_id → 403 access_denied (no silent fallback).
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={**base, "nexus_profile_id": "github/no-such-account"},
+    )
+    assert r.status_code == 403
+    assert r.json()["error"] == "access_denied"
+
+    # Empty form field is treated as "not provided" — same path as bare.
+    r = client.post("/v1/auth/token-exchange", data={**base, "nexus_profile_id": ""})
+    assert r.status_code == 409  # back to ambiguous
+
+    # Control-char-bearing profile_id → 400 invalid_request before resolve runs.
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={**base, "nexus_profile_id": "has\nnewline"},
+    )
+    assert r.status_code == 400
+    assert r.json()["error"] == "invalid_request"
 
 
 def test_token_exchange_no_profile_returns_403(engine: Engine) -> None:

--- a/src/nexus/server/api/v1/tests/test_token_exchange_router.py
+++ b/src/nexus/server/api/v1/tests/test_token_exchange_router.py
@@ -376,6 +376,135 @@ def test_token_exchange_unknown_resource_returns_400(engine: Engine) -> None:
     assert r.json()["error"] == "invalid_request"
 
 
+def test_parse_resource_accepts_known_provider() -> None:
+    """Bare provider URI parses to (provider, profile_id=None)."""
+    from nexus.server.api.v1.routers.token_exchange import _parse_resource
+
+    assert _parse_resource("urn:nexus:provider:github") == ("github", None, None)
+    assert _parse_resource("urn:nexus:provider:aws") == ("aws", None, None)
+
+
+def test_parse_resource_accepts_provider_with_profile_id() -> None:
+    """``urn:nexus:provider:<provider>/<profile_id>`` form parses both segments."""
+    from nexus.server.api.v1.routers.token_exchange import _parse_resource
+
+    assert _parse_resource("urn:nexus:provider:github/work") == ("github", "work", None)
+    assert _parse_resource("urn:nexus:provider:aws/aws-prod") == ("aws", "aws-prod", None)
+
+
+def test_parse_resource_rejects_unknown_provider() -> None:
+    from nexus.server.api.v1.routers.token_exchange import _parse_resource
+
+    p, pid, err = _parse_resource("urn:nexus:provider:slack")
+    assert p is None and pid is None and err is not None
+    p, pid, err = _parse_resource("urn:nexus:provider:slack/work")
+    assert p is None and pid is None and err is not None
+
+
+def test_parse_resource_rejects_invalid_profile_id() -> None:
+    """Profile_id must match ``[a-zA-Z0-9_-]{1,128}`` — keeps the URI parser
+    deterministic and prevents accidental injection into log lines."""
+    from nexus.server.api.v1.routers.token_exchange import _parse_resource
+
+    for bad in (
+        "urn:nexus:provider:github/",  # empty profile_id
+        "urn:nexus:provider:github/has space",
+        "urn:nexus:provider:github/has/slash",
+        "urn:nexus:provider:github/has;semi",
+        "urn:nexus:provider:github/" + "x" * 129,  # too long
+    ):
+        p, pid, err = _parse_resource(bad)
+        assert p is None and pid is None and err is not None, f"should reject {bad!r}"
+
+
+def test_token_exchange_with_profile_id_picks_named_envelope(engine: Engine) -> None:
+    """End-to-end: 2 GitHub envelopes for the same principal; the named one
+    via ``urn:nexus:provider:github/<id>`` returns its own access_token.
+
+    This is the wire-contract proof for codex round-7 finding F21.
+    """
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    app, signer, encryption = _build_app(engine, tenant, principal)
+    _seed_github(engine, tenant, principal, encryption)  # writes 'github-default' / 'ghp_real'
+
+    # Add a second profile 'github-other' under the same principal.
+    payload = json.dumps({"token": "ghp_alt", "scopes": ["repo"]}).encode()
+    aad = str(tenant).encode() + b"|" + str(principal).encode() + b"|" + b"github-other"
+    dek = b"\x05" * 32
+    nonce, ct = AESGCMEnvelope().encrypt(dek, payload, aad=aad)
+    wrapped, kv = encryption.wrap_dek(dek, tenant_id=tenant, aad=aad)
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text(
+                "INSERT INTO auth_profiles "
+                "(tenant_id, principal_id, id, provider, account_identifier, "
+                " backend, backend_key, last_synced_at, sync_ttl_seconds, "
+                " ciphertext, wrapped_dek, nonce, aad, kek_version) "
+                "VALUES (:t, :p, 'github-other', 'github', 'other', 'envelope', 'k', "
+                " NOW(), 300, :ct, :wd, :no, :aad, :kv)"
+            ),
+            {
+                "t": str(tenant),
+                "p": str(principal),
+                "ct": ct,
+                "wd": wrapped,
+                "no": nonce,
+                "aad": aad,
+                "kv": kv,
+            },
+        )
+    machine = _seed_active_machine(engine, tenant, principal)
+    jwt = signer.sign(
+        DaemonClaims(tenant_id=tenant, principal_id=principal, machine_id=machine),
+        ttl=timedelta(hours=1),
+    )
+    client = TestClient(app)
+
+    # Bare resource → 409 ambiguous_profile (back-compat, fail closed).
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": jwt,
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "resource": "urn:nexus:provider:github",
+            "scope": "x",
+        },
+    )
+    assert r.status_code == 409
+    assert r.json()["error"] == "ambiguous_profile"
+
+    # Explicit /github-default → returns the default credential.
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": jwt,
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "resource": "urn:nexus:provider:github/github-default",
+            "scope": "x",
+        },
+    )
+    assert r.status_code == 200
+    assert r.json()["access_token"] == "ghp_real"
+
+    # Explicit /github-other → returns the other credential.
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": jwt,
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "resource": "urn:nexus:provider:github/github-other",
+            "scope": "x",
+        },
+    )
+    assert r.status_code == 200
+    assert r.json()["access_token"] == "ghp_alt"
+
+
 def test_token_exchange_no_profile_returns_403(engine: Engine) -> None:
     tenant = uuid.uuid4()
     principal = uuid.uuid4()

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -714,6 +714,52 @@ def create_app(
     return app
 
 
+def _build_envelope_provider_from_env(choice: str) -> tuple[Any, str]:
+    """Construct an EncryptionProvider from env vars (#3818).
+
+    Returns ``(provider, kind)`` where kind is one of:
+      ``inmemory`` — fresh per-process key (dev only).
+      ``vault_transit`` — Vault Transit via NEXUS_VAULT_ADDR/TOKEN/KEY/MOUNT.
+      ``aws_kms`` — AWS KMS via NEXUS_AWS_KMS_KEY_ID/REGION.
+
+    Raises on missing required env vars or import failures so the caller
+    can disable the route with a clear log line instead of silently
+    falling through to a non-functional in-memory KEK.
+    """
+    if choice == "inmemory":
+        from nexus.bricks.auth.envelope_providers.in_memory import InMemoryEncryptionProvider
+
+        return InMemoryEncryptionProvider(), "inmemory"
+    if choice == "vault_transit":
+        import hvac  # raises ImportError → caller logs + disables
+
+        from nexus.bricks.auth.envelope_providers.vault_transit import VaultTransitProvider
+
+        addr = os.environ.get("NEXUS_VAULT_ADDR") or ""
+        token = os.environ.get("NEXUS_VAULT_TOKEN") or ""
+        key = os.environ.get("NEXUS_VAULT_TRANSIT_KEY") or ""
+        mount = os.environ.get("NEXUS_VAULT_TRANSIT_MOUNT", "transit")
+        if not (addr and token and key):
+            raise ValueError(
+                "vault_transit requires NEXUS_VAULT_ADDR, NEXUS_VAULT_TOKEN, "
+                "NEXUS_VAULT_TRANSIT_KEY"
+            )
+        client = hvac.Client(url=addr, token=token)
+        return VaultTransitProvider(client, key, mount_point=mount), "vault_transit"
+    if choice == "aws_kms":
+        import boto3
+
+        from nexus.bricks.auth.envelope_providers.aws_kms import AwsKmsProvider
+
+        key_id = os.environ.get("NEXUS_AWS_KMS_KEY_ID") or ""
+        region = os.environ.get("NEXUS_AWS_REGION") or os.environ.get("AWS_REGION", "")
+        if not (key_id and region):
+            raise ValueError("aws_kms requires NEXUS_AWS_KMS_KEY_ID and NEXUS_AWS_REGION")
+        kms = boto3.client("kms", region_name=region)
+        return AwsKmsProvider(kms, key_id), "aws_kms"
+    raise ValueError(f"unknown NEXUS_ENVELOPE_PROVIDER: {choice!r}")
+
+
 def _register_routes(app: FastAPI) -> None:
     """Register all routes."""
 
@@ -1114,27 +1160,57 @@ def _register_routes(app: FastAPI) -> None:
                         _token_exchange_enabled = os.environ.get(
                             "NEXUS_TOKEN_EXCHANGE_ENABLED", ""
                         ).lower() in ("1", "true", "yes")
-                        # When the operator opts in via env var the production
-                        # provider (Vault transit / AWS KMS) MUST already be on
-                        # app.state. Falling back to InMemoryEncryptionProvider
-                        # would generate a per-process random KEK that cannot
-                        # unwrap any envelope a daemon pushed — every read would
-                        # 500 with envelope_error, silent and confusing. Fail
-                        # closed at startup so the misconfiguration is visible.
+
+                        # Provider resolution order:
+                        #   1. app.state.encryption_provider (pre-wired by host
+                        #      that imports create_app — wins for tests + custom
+                        #      embeddings).
+                        #   2. NEXUS_ENVELOPE_PROVIDER env var (vault_transit /
+                        #      aws_kms / inmemory).
+                        #   3. InMemoryEncryptionProvider (dev default).
                         _enc = getattr(app.state, "encryption_provider", None)
-                        if _token_exchange_enabled and _enc is None:
+                        _enc_kind = "preset"
+                        if _enc is None:
+                            _provider_choice = os.environ.get(
+                                "NEXUS_ENVELOPE_PROVIDER", "inmemory"
+                            ).lower()
+                            try:
+                                _enc, _enc_kind = _build_envelope_provider_from_env(
+                                    _provider_choice
+                                )
+                            except Exception as e:  # noqa: BLE001
+                                logger.error(
+                                    "v1 token-exchange refused: failed to construct "
+                                    "encryption provider %r from env (%s: %s)",
+                                    _provider_choice,
+                                    type(e).__name__,
+                                    e,
+                                )
+                                _token_exchange_enabled = False
+                                _enc = InMemoryEncryptionProvider()
+                                _enc_kind = "inmemory_fallback"
+
+                        # Production safety: in-memory KEK cannot unwrap
+                        # envelopes a daemon pushed (different per-process key).
+                        # Operators MUST opt-in explicitly to acknowledge
+                        # this is a dev-only configuration.
+                        _dev_ok = os.environ.get(
+                            "NEXUS_TOKEN_EXCHANGE_DEV_INMEMORY_OK", ""
+                        ).lower() in ("1", "true", "yes")
+                        if (
+                            _token_exchange_enabled
+                            and _enc_kind in ("inmemory", "inmemory_fallback")
+                            and not _dev_ok
+                        ):
                             logger.error(
-                                "v1 token-exchange refused: NEXUS_TOKEN_EXCHANGE_ENABLED=1 "
-                                "but app.state.encryption_provider is unset. Wire a durable "
-                                "EncryptionProvider (Vault/KMS) before enabling, or unset "
-                                "the env var to keep the route at 501."
+                                "v1 token-exchange refused: enabled=1 but envelope "
+                                "provider is in-memory (per-process random KEK can't "
+                                "unwrap daemon-pushed envelopes). Set "
+                                "NEXUS_ENVELOPE_PROVIDER=vault_transit|aws_kms or "
+                                "explicitly accept dev-only behaviour with "
+                                "NEXUS_TOKEN_EXCHANGE_DEV_INMEMORY_OK=1."
                             )
                             _token_exchange_enabled = False
-                        if _enc is None:
-                            # Disabled-route case: in-memory keeps tests +
-                            # disabled-flag wiring symmetric without affecting
-                            # real reads (handler returns 501 before touching it).
-                            _enc = InMemoryEncryptionProvider()
                         _consumer = CredentialConsumer(
                             engine=_v1_engine,
                             encryption=_enc,

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -1114,12 +1114,27 @@ def _register_routes(app: FastAPI) -> None:
                         _token_exchange_enabled = os.environ.get(
                             "NEXUS_TOKEN_EXCHANGE_ENABLED", ""
                         ).lower() in ("1", "true", "yes")
-                        # MVP: InMemoryEncryptionProvider unless an operator wires
-                        # Vault/KMS via app.state.encryption_provider. Production
-                        # deployments override this in their startup hook.
-                        _enc = getattr(app.state, "encryption_provider", None) or (
-                            InMemoryEncryptionProvider()
-                        )
+                        # When the operator opts in via env var the production
+                        # provider (Vault transit / AWS KMS) MUST already be on
+                        # app.state. Falling back to InMemoryEncryptionProvider
+                        # would generate a per-process random KEK that cannot
+                        # unwrap any envelope a daemon pushed — every read would
+                        # 500 with envelope_error, silent and confusing. Fail
+                        # closed at startup so the misconfiguration is visible.
+                        _enc = getattr(app.state, "encryption_provider", None)
+                        if _token_exchange_enabled and _enc is None:
+                            logger.error(
+                                "v1 token-exchange refused: NEXUS_TOKEN_EXCHANGE_ENABLED=1 "
+                                "but app.state.encryption_provider is unset. Wire a durable "
+                                "EncryptionProvider (Vault/KMS) before enabling, or unset "
+                                "the env var to keep the route at 501."
+                            )
+                            _token_exchange_enabled = False
+                        if _enc is None:
+                            # Disabled-route case: in-memory keeps tests +
+                            # disabled-flag wiring symmetric without affecting
+                            # real reads (handler returns 501 before touching it).
+                            _enc = InMemoryEncryptionProvider()
                         _consumer = CredentialConsumer(
                             engine=_v1_engine,
                             encryption=_enc,

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -1024,6 +1024,9 @@ def _register_routes(app: FastAPI) -> None:
             try:
                 from sqlalchemy import create_engine
 
+                from nexus.bricks.auth.postgres_profile_store import (
+                    ensure_schema as _ensure_v1_schema,
+                )
                 from nexus.server.api.v1.jwt_signer import JwtSigner
                 from nexus.server.api.v1.routers.auth_profiles import (
                     make_auth_profiles_router,
@@ -1040,6 +1043,11 @@ def _register_routes(app: FastAPI) -> None:
                 # the whole API server down during startup.
                 try:
                     _v1_engine = create_engine(_database_url, future=True)
+                    # Idempotent: creates tenants / principals / auth_profiles /
+                    # daemon_machines / auth_profile_reads / RLS policies if absent.
+                    # Without this a fresh stack returns 500 ProgrammingError on the
+                    # first /v1/admin/daemon-bootstrap call.
+                    _ensure_v1_schema(_v1_engine)
                     _v1_signer = JwtSigner.from_path(
                         _jwt_signing_key,
                         issuer=os.environ.get("NEXUS_JWT_ISSUER", "https://nexus.local"),

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -1011,21 +1011,6 @@ def _register_routes(app: FastAPI) -> None:
         logger.warning(f"Failed to import secrets router: {e}")
 
     # ---- /v1 (nexus-bot daemon, #3804) ----
-    # Token-exchange stub — always registered; flag controls behavior
-    # (route currently always returns 501, so there's no gating risk).
-    try:
-        from nexus.server.api.v1.routers.token_exchange import make_token_exchange_router
-
-        _token_exchange_enabled = os.environ.get("NEXUS_TOKEN_EXCHANGE_ENABLED", "").lower() in (
-            "1",
-            "true",
-            "yes",
-        )
-        app.include_router(make_token_exchange_router(enabled=_token_exchange_enabled))
-        logger.info("v1 token-exchange route registered (enabled=%s)", _token_exchange_enabled)
-    except ImportError as e:
-        logger.warning(f"Failed to import v1 token-exchange router: {e}")
-
     # Daemon enroll/refresh + auth-profiles routers — gated on JWT signing key
     # + enroll-token secret. If either env var is missing, skip with a warning;
     # deployments that don't use the nexus-bot daemon are unaffected.
@@ -1092,6 +1077,61 @@ def _register_routes(app: FastAPI) -> None:
                     )
                     app.include_router(make_jwks_router(signer=_v1_signer))
                     logger.info("v1 daemon + auth-profiles + jwks routes registered")
+
+                    # Token-exchange (#3818): read path. Reuses _v1_engine + _v1_signer
+                    # from the daemon block. Adds an EncryptionProvider (envelope
+                    # decrypt) and a CredentialConsumer orchestrator. Default off
+                    # until ops verifies KMS/Vault wiring (NEXUS_TOKEN_EXCHANGE_ENABLED).
+                    # The consumer is constructed with engine=_v1_engine — it builds
+                    # a fresh tenant-scoped PostgresAuthProfileStore per request from
+                    # the JWT-verified DaemonClaims, so there's no boot-time tenant
+                    # placeholder leaking into the SQL WHERE clause.
+                    try:
+                        from nexus.bricks.auth.consumer import CredentialConsumer
+                        from nexus.bricks.auth.consumer_cache import ResolvedCredCache
+                        from nexus.bricks.auth.consumer_providers import (
+                            default_adapters,
+                        )
+                        from nexus.bricks.auth.envelope import DEKCache
+                        from nexus.bricks.auth.envelope_providers.in_memory import (
+                            InMemoryEncryptionProvider,
+                        )
+                        from nexus.bricks.auth.read_audit import ReadAuditWriter
+                        from nexus.server.api.v1.routers.token_exchange import (
+                            make_token_exchange_router,
+                        )
+                    except ImportError as e:
+                        logger.warning("v1 token-exchange disabled: import failed (%s)", e)
+                    else:
+                        _token_exchange_enabled = os.environ.get(
+                            "NEXUS_TOKEN_EXCHANGE_ENABLED", ""
+                        ).lower() in ("1", "true", "yes")
+                        # MVP: InMemoryEncryptionProvider unless an operator wires
+                        # Vault/KMS via app.state.encryption_provider. Production
+                        # deployments override this in their startup hook.
+                        _enc = getattr(app.state, "encryption_provider", None) or (
+                            InMemoryEncryptionProvider()
+                        )
+                        _consumer = CredentialConsumer(
+                            engine=_v1_engine,
+                            encryption=_enc,
+                            dek_cache=DEKCache(),
+                            cred_cache=ResolvedCredCache(),
+                            adapters=default_adapters(),
+                            audit=ReadAuditWriter(engine=_v1_engine),
+                        )
+                        app.include_router(
+                            make_token_exchange_router(
+                                enabled=_token_exchange_enabled,
+                                signer=_v1_signer,
+                                consumer=_consumer,
+                                encryption=_enc,
+                            )
+                        )
+                        logger.info(
+                            "v1 token-exchange route registered (enabled=%s)",
+                            _token_exchange_enabled,
+                        )
 
                     # Dev-loop convenience: mint tenant/principal/enroll-token in
                     # one call. Requires admin-bypass explicitly on AND a

--- a/tests/e2e/auth_consumption/test_github_as_user.py
+++ b/tests/e2e/auth_consumption/test_github_as_user.py
@@ -1,0 +1,157 @@
+"""E2E: daemon push → /v1/auth/token-exchange → real GitHub /user (#3818).
+
+Requires:
+  - NEXUS_TEST_DATABASE_URL (Postgres)
+  - NEXUS_TEST_GITHUB_PAT (a real PAT with read:user) — falls back to skip.
+
+The PAT is the "daemon-pushed" credential. We push it, exchange it, and
+prove the returned token authenticates against GitHub's /user endpoint.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import timedelta
+
+import httpx
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+
+from nexus.bricks.auth.consumer import CredentialConsumer
+from nexus.bricks.auth.consumer_cache import ResolvedCredCache
+from nexus.bricks.auth.consumer_providers.github import GithubProviderAdapter
+from nexus.bricks.auth.envelope import AESGCMEnvelope, DEKCache
+from nexus.bricks.auth.envelope_providers.in_memory import InMemoryEncryptionProvider
+from nexus.bricks.auth.postgres_profile_store import (
+    PostgresAuthProfileStore,
+    ensure_schema,
+)
+from nexus.bricks.auth.read_audit import ReadAuditWriter
+from nexus.server.api.v1.jwt_signer import DaemonClaims, JwtSigner
+from nexus.server.api.v1.routers.token_exchange import make_token_exchange_router
+
+
+def _maybe_skip():
+    if not os.environ.get("NEXUS_TEST_DATABASE_URL"):
+        pytest.skip("NEXUS_TEST_DATABASE_URL not set")
+    if not os.environ.get("NEXUS_TEST_GITHUB_PAT"):
+        pytest.skip("NEXUS_TEST_GITHUB_PAT not set")
+
+
+def _make_signer():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    pk = ec.generate_private_key(ec.SECP256R1())
+    return JwtSigner.from_pem(
+        pk.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ),
+        issuer="https://e2e.local",
+    )
+
+
+def test_github_user_endpoint_as_user_via_token_exchange():
+    _maybe_skip()
+
+    pat = os.environ["NEXUS_TEST_GITHUB_PAT"]
+    engine = create_engine(os.environ["NEXUS_TEST_DATABASE_URL"], future=True)
+    ensure_schema(engine)
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    machine = uuid.uuid4()
+
+    encryption = InMemoryEncryptionProvider()
+    payload = json.dumps({"token": pat, "scopes": ["read:user"], "token_type": "classic"}).encode()
+    aad = str(tenant).encode() + b"|" + str(principal).encode() + b"|" + b"github-default"
+    dek = b"\x0a" * 32
+    nonce, ct = AESGCMEnvelope().encrypt(dek, payload, aad=aad)
+    wrapped, kv = encryption.wrap_dek(dek, tenant_id=tenant, aad=aad)
+
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, :n) ON CONFLICT DO NOTHING"),
+            {"id": str(tenant), "n": f"e2e-{tenant}"},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO principals (id, tenant_id, kind) VALUES (:id, :t, 'human') "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {"id": str(principal), "t": str(tenant)},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO auth_profiles "
+                "(tenant_id, principal_id, id, provider, account_identifier, "
+                " backend, backend_key, last_synced_at, sync_ttl_seconds, "
+                " ciphertext, wrapped_dek, nonce, aad, kek_version) "
+                "VALUES (:t, :p, 'github-default', 'github', 'me', 'envelope', 'k', "
+                " NOW(), 300, :ct, :wd, :no, :aad, :kv)"
+            ),
+            {
+                "t": str(tenant),
+                "p": str(principal),
+                "ct": ct,
+                "wd": wrapped,
+                "no": nonce,
+                "aad": aad,
+                "kv": kv,
+            },
+        )
+
+    signer = _make_signer()
+    consumer = CredentialConsumer(
+        store=PostgresAuthProfileStore("", tenant_id=tenant, principal_id=principal, engine=engine),
+        encryption=encryption,
+        dek_cache=DEKCache(),
+        cred_cache=ResolvedCredCache(),
+        adapters={"github": GithubProviderAdapter()},
+        audit=ReadAuditWriter(engine=engine),
+    )
+    app = FastAPI()
+    app.include_router(
+        make_token_exchange_router(
+            enabled=True,
+            signer=signer,
+            consumer=consumer,
+            encryption=encryption,
+        )
+    )
+
+    jwt = signer.sign(
+        DaemonClaims(tenant_id=tenant, principal_id=principal, machine_id=machine),
+        ttl=timedelta(hours=1),
+    )
+    client = TestClient(app)
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": jwt,
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "resource": "urn:nexus:provider:github",
+            "scope": "get-user",
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    bearer = body["access_token"]
+
+    # Real GitHub call.
+    gh = httpx.get(
+        "https://api.github.com/user",
+        headers={"Authorization": f"Bearer {bearer}", "User-Agent": "nexus-e2e"},
+        timeout=10.0,
+    )
+    assert gh.status_code == 200, gh.text
+    assert "login" in gh.json()
+
+    engine.dispose()

--- a/tests/e2e/auth_consumption/test_github_as_user.py
+++ b/tests/e2e/auth_consumption/test_github_as_user.py
@@ -89,6 +89,18 @@ def test_github_user_endpoint_as_user_via_token_exchange():
         )
         conn.execute(
             text(
+                "INSERT INTO daemon_machines (id, tenant_id, principal_id, pubkey) "
+                "VALUES (:m, :t, :p, :pk) ON CONFLICT DO NOTHING"
+            ),
+            {
+                "m": str(machine),
+                "t": str(tenant),
+                "p": str(principal),
+                "pk": b"e2e-pubkey-" + machine.bytes,
+            },
+        )
+        conn.execute(
+            text(
                 "INSERT INTO auth_profiles "
                 "(tenant_id, principal_id, id, provider, account_identifier, "
                 " backend, backend_key, last_synced_at, sync_ttl_seconds, "

--- a/tests/e2e/auth_consumption/test_s3_as_user.py
+++ b/tests/e2e/auth_consumption/test_s3_as_user.py
@@ -110,6 +110,18 @@ def test_s3_list_buckets_as_user_via_token_exchange():
         )
         conn.execute(
             text(
+                "INSERT INTO daemon_machines (id, tenant_id, principal_id, pubkey) "
+                "VALUES (:m, :t, :p, :pk) ON CONFLICT DO NOTHING"
+            ),
+            {
+                "m": str(machine),
+                "t": str(tenant),
+                "p": str(principal),
+                "pk": b"e2e-pubkey-" + machine.bytes,
+            },
+        )
+        conn.execute(
+            text(
                 "INSERT INTO auth_profiles "
                 "(tenant_id, principal_id, id, provider, account_identifier, "
                 " backend, backend_key, last_synced_at, sync_ttl_seconds, "

--- a/tests/e2e/auth_consumption/test_s3_as_user.py
+++ b/tests/e2e/auth_consumption/test_s3_as_user.py
@@ -1,0 +1,185 @@
+"""E2E: daemon push → /v1/auth/token-exchange → real S3 list-buckets (#3818).
+
+PR-CI variant: uses LocalStack S3 (deterministic, no live AWS).
+Nightly variant: set NEXUS_TEST_AWS_LIVE=1 to exercise live STS + S3.
+
+Requires:
+  - NEXUS_TEST_DATABASE_URL (Postgres)
+  - LOCALSTACK_ENDPOINT (e.g. http://localhost:4566) — falls back to skip
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import create_engine, text
+
+from nexus.bricks.auth.consumer import CredentialConsumer
+from nexus.bricks.auth.consumer_cache import ResolvedCredCache
+from nexus.bricks.auth.consumer_providers.aws import AwsProviderAdapter
+from nexus.bricks.auth.envelope import AESGCMEnvelope, DEKCache
+from nexus.bricks.auth.envelope_providers.in_memory import InMemoryEncryptionProvider
+from nexus.bricks.auth.postgres_profile_store import (
+    PostgresAuthProfileStore,
+    ensure_schema,
+)
+from nexus.bricks.auth.read_audit import ReadAuditWriter
+from nexus.server.api.v1.jwt_signer import DaemonClaims, JwtSigner
+from nexus.server.api.v1.routers.token_exchange import make_token_exchange_router
+
+
+def _maybe_skip():
+    if not os.environ.get("NEXUS_TEST_DATABASE_URL"):
+        pytest.skip("NEXUS_TEST_DATABASE_URL not set")
+    if not (os.environ.get("LOCALSTACK_ENDPOINT") or os.environ.get("NEXUS_TEST_AWS_LIVE")):
+        pytest.skip("LOCALSTACK_ENDPOINT or NEXUS_TEST_AWS_LIVE required")
+
+
+def _make_signer():
+    from cryptography.hazmat.primitives import serialization
+    from cryptography.hazmat.primitives.asymmetric import ec
+
+    pk = ec.generate_private_key(ec.SECP256R1())
+    return JwtSigner.from_pem(
+        pk.private_bytes(
+            encoding=serialization.Encoding.PEM,
+            format=serialization.PrivateFormat.PKCS8,
+            encryption_algorithm=serialization.NoEncryption(),
+        ),
+        issuer="https://e2e.local",
+    )
+
+
+def test_s3_list_buckets_as_user_via_token_exchange():
+    _maybe_skip()
+    import boto3
+
+    endpoint = os.environ.get("LOCALSTACK_ENDPOINT")
+    using_live = os.environ.get("NEXUS_TEST_AWS_LIVE") == "1"
+
+    # 1. Provision creds — for LocalStack the canonical "test" creds work.
+    if using_live:
+        aws_creds = {
+            "access_key_id": os.environ["AWS_ACCESS_KEY_ID"],
+            "secret_access_key": os.environ["AWS_SECRET_ACCESS_KEY"],
+            "session_token": os.environ.get("AWS_SESSION_TOKEN", ""),
+            "expiration": (datetime.now(UTC) + timedelta(hours=1)).isoformat(),
+            "region": os.environ.get("AWS_REGION", "us-east-1"),
+        }
+    else:
+        aws_creds = {
+            "access_key_id": "test",
+            "secret_access_key": "test",
+            "session_token": "test",
+            "expiration": (datetime.now(UTC) + timedelta(hours=1)).isoformat(),
+            "region": "us-east-1",
+        }
+
+    # 2. Set up DB + envelope + app stack.
+    engine = create_engine(os.environ["NEXUS_TEST_DATABASE_URL"], future=True)
+    ensure_schema(engine)
+    tenant = uuid.uuid4()
+    principal = uuid.uuid4()
+    machine = uuid.uuid4()
+
+    encryption = InMemoryEncryptionProvider()
+    payload = json.dumps(aws_creds).encode()
+    aad = str(tenant).encode() + b"|" + str(principal).encode() + b"|" + b"aws-default"
+    dek = b"\x09" * 32
+    nonce, ct = AESGCMEnvelope().encrypt(dek, payload, aad=aad)
+    wrapped, kv = encryption.wrap_dek(dek, tenant_id=tenant, aad=aad)
+
+    with engine.begin() as conn:
+        conn.execute(text("SET LOCAL app.current_tenant = :t"), {"t": str(tenant)})
+        conn.execute(
+            text("INSERT INTO tenants (id, name) VALUES (:id, :n) ON CONFLICT DO NOTHING"),
+            {"id": str(tenant), "n": f"e2e-{tenant}"},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO principals (id, tenant_id, kind) VALUES (:id, :t, 'human') "
+                "ON CONFLICT DO NOTHING"
+            ),
+            {"id": str(principal), "t": str(tenant)},
+        )
+        conn.execute(
+            text(
+                "INSERT INTO auth_profiles "
+                "(tenant_id, principal_id, id, provider, account_identifier, "
+                " backend, backend_key, last_synced_at, sync_ttl_seconds, "
+                " ciphertext, wrapped_dek, nonce, aad, kek_version) "
+                "VALUES (:t, :p, 'aws-default', 'aws', 'me', 'envelope', 'k', "
+                " NOW(), 300, :ct, :wd, :no, :aad, :kv)"
+            ),
+            {
+                "t": str(tenant),
+                "p": str(principal),
+                "ct": ct,
+                "wd": wrapped,
+                "no": nonce,
+                "aad": aad,
+                "kv": kv,
+            },
+        )
+
+    signer = _make_signer()
+    consumer = CredentialConsumer(
+        store=PostgresAuthProfileStore("", tenant_id=tenant, principal_id=principal, engine=engine),
+        encryption=encryption,
+        dek_cache=DEKCache(),
+        cred_cache=ResolvedCredCache(),
+        adapters={"aws": AwsProviderAdapter()},
+        audit=ReadAuditWriter(engine=engine),
+    )
+    app = FastAPI()
+    app.include_router(
+        make_token_exchange_router(
+            enabled=True,
+            signer=signer,
+            consumer=consumer,
+            encryption=encryption,
+        )
+    )
+
+    # 3. Call token-exchange.
+    jwt = signer.sign(
+        DaemonClaims(tenant_id=tenant, principal_id=principal, machine_id=machine),
+        ttl=timedelta(hours=1),
+    )
+    client = TestClient(app)
+    r = client.post(
+        "/v1/auth/token-exchange",
+        data={
+            "grant_type": "urn:ietf:params:oauth:grant-type:token-exchange",
+            "subject_token": jwt,
+            "subject_token_type": "urn:ietf:params:oauth:token-type:jwt",
+            "resource": "urn:nexus:provider:aws",
+            "scope": "list-buckets",
+        },
+    )
+    assert r.status_code == 200, r.text
+    body = r.json()
+    meta = body["nexus_credential_metadata"]
+
+    # 4. Build a real boto3 session and call S3.
+    s3_kwargs = {
+        "aws_access_key_id": meta["access_key_id"],
+        "aws_secret_access_key": meta["secret_access_key"],
+        "aws_session_token": body["access_token"],
+        "region_name": meta["region"],
+    }
+    if endpoint:
+        s3_kwargs["endpoint_url"] = endpoint
+
+    s3 = boto3.client("s3", **s3_kwargs)
+    # In LocalStack: empty bucket list is fine — the call succeeding is the win.
+    resp = s3.list_buckets()
+    assert "Buckets" in resp
+
+    engine.dispose()

--- a/uv.lock
+++ b/uv.lock
@@ -744,7 +744,7 @@ name = "cuda-bindings"
 version = "13.2.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cuda-pathfinder" },
+    { name = "cuda-pathfinder", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c0/87/87a014f045b77c6de5c8527b0757fe644417b184e5367db977236a141602/cuda_bindings-13.2.0-cp314-cp314-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:a6464b30f46692d6c7f65d4a0e0450d81dd29de3afc1bb515653973d01c2cd6e", size = 5685673, upload-time = "2026-03-11T00:12:56.371Z" },
@@ -771,37 +771,37 @@ wheels = [
 
 [package.optional-dependencies]
 cublas = [
-    { name = "nvidia-cublas", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cublas", marker = "sys_platform == 'linux'" },
 ]
 cudart = [
-    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-runtime", marker = "sys_platform == 'linux'" },
 ]
 cufft = [
-    { name = "nvidia-cufft", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cufft", marker = "sys_platform == 'linux'" },
 ]
 cufile = [
     { name = "nvidia-cufile", marker = "sys_platform == 'linux'" },
 ]
 cupti = [
-    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-cupti", marker = "sys_platform == 'linux'" },
 ]
 curand = [
-    { name = "nvidia-curand", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-curand", marker = "sys_platform == 'linux'" },
 ]
 cusolver = [
-    { name = "nvidia-cusolver", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusolver", marker = "sys_platform == 'linux'" },
 ]
 cusparse = [
-    { name = "nvidia-cusparse", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform == 'linux'" },
 ]
 nvjitlink = [
-    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform == 'linux'" },
 ]
 nvrtc = [
-    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-cuda-nvrtc", marker = "sys_platform == 'linux'" },
 ]
 nvtx = [
-    { name = "nvidia-nvtx", marker = "sys_platform == 'linux' or sys_platform == 'win32'" },
+    { name = "nvidia-nvtx", marker = "sys_platform == 'linux'" },
 ]
 
 [[package]]
@@ -2610,6 +2610,7 @@ dependencies = [
     { name = "pyjwt" },
     { name = "pyotp" },
     { name = "pyroaring" },
+    { name = "python-multipart" },
     { name = "pyyaml" },
     { name = "rapidfuzz" },
     { name = "redis" },
@@ -2957,6 +2958,7 @@ requires-dist = [
     { name = "pytest-timeout", marker = "extra == 'dev'", specifier = ">=2.3.0" },
     { name = "pytest-xdist", marker = "extra == 'dev'", specifier = ">=3.8.0" },
     { name = "pytest-xdist", marker = "extra == 'test'", specifier = ">=3.5.0" },
+    { name = "python-multipart", specifier = ">=0.0.20" },
     { name = "pyyaml", specifier = ">=6.0.1" },
     { name = "rapidfuzz", specifier = ">=3.0.0" },
     { name = "redis", specifier = ">=7.0.0" },
@@ -3092,7 +3094,7 @@ name = "nvidia-cudnn-cu13"
 version = "9.19.0.56"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f1/84/26025437c1e6b61a707442184fa0c03d083b661adf3a3eecfd6d21677740/nvidia_cudnn_cu13-9.19.0.56-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:6ed29ffaee1176c612daf442e4dd6cfeb6a0caa43ddcbeb59da94953030b1be4", size = 433781201, upload-time = "2026-02-03T20:40:53.805Z" },
@@ -3104,7 +3106,7 @@ name = "nvidia-cufft"
 version = "12.0.0.61"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8b/ae/f417a75c0259e85c1d2f83ca4e960289a5f814ed0cea74d18c353d3e989d/nvidia_cufft-12.0.0.61-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:2708c852ef8cd89d1d2068bdbece0aa188813a0c934db3779b9b1faa8442e5f5", size = 214053554, upload-time = "2025-09-04T08:31:38.196Z" },
@@ -3134,9 +3136,9 @@ name = "nvidia-cusolver"
 version = "12.0.4.66"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-cublas" },
-    { name = "nvidia-cusparse" },
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-cublas", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-cusparse", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c8/c3/b30c9e935fc01e3da443ec0116ed1b2a009bb867f5324d3f2d7e533e776b/nvidia_cusolver-12.0.4.66-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:02c2457eaa9e39de20f880f4bd8820e6a1cfb9f9a34f820eb12a155aa5bc92d2", size = 223467760, upload-time = "2025-09-04T08:33:04.222Z" },
@@ -3148,7 +3150,7 @@ name = "nvidia-cusparse"
 version = "12.6.3.3"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "nvidia-nvjitlink" },
+    { name = "nvidia-nvjitlink", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 wheels = [
     { url = "https://files.pythonhosted.org/packages/f8/94/5c26f33738ae35276672f12615a64bd008ed5be6d1ebcb23579285d960a9/nvidia_cusparse-12.6.3.3-py3-none-manylinux2014_aarch64.manylinux_2_17_aarch64.whl", hash = "sha256:80bcc4662f23f1054ee334a15c72b8940402975e0eab63178fc7e670aa59472c", size = 162155568, upload-time = "2025-09-04T08:33:42.864Z" },
@@ -4597,8 +4599,8 @@ name = "secretstorage"
 version = "3.5.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "cryptography" },
-    { name = "jeepney" },
+    { name = "cryptography", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
+    { name = "jeepney", marker = "sys_platform != 'emscripten' and sys_platform != 'win32'" },
 ]
 sdist = { url = "https://files.pythonhosted.org/packages/1c/03/e834bcd866f2f8a49a85eaff47340affa3bfa391ee9912a952a1faa68c7b/secretstorage-3.5.0.tar.gz", hash = "sha256:f04b8e4689cbce351744d5537bf6b1329c6fc68f91fa666f60a380edddcd11be", size = 19884, upload-time = "2025-11-23T19:02:53.191Z" }
 wheels = [


### PR DESCRIPTION
Closes #3818. Final piece of the multi-tenant Postgres-backed auth epic (#3788) — the read path.

## Summary

Implements RFC 8693 token-exchange against daemon-pushed envelopes. A caller presents a daemon JWT (`subject_token`); the server verifies it, decrypts the matching `auth_profiles` envelope, materializes a provider-native bearer (AWS or GitHub), writes a `auth_profile_reads` row, and returns the credential.

## What's new

- `CredentialConsumer` orchestrator (cache → decrypt → adapter → audit) in `bricks/auth/consumer.py`
- `ResolvedCredCache` with TTL = `min(300s, expires_at - 60s)` in `bricks/auth/consumer_cache.py`
- AWS + GitHub provider adapters (pure JSON → `MaterializedCredential`) in `bricks/auth/consumer_providers/`
- `auth_profile_reads` partitioned table + RLS (mirror of `auth_profile_writes`)
- 1% cache-hit / 100% cache-miss audit sampling via `ReadAuditWriter`
- `/v1/auth/token-exchange` rewritten from 501 stub to live (gated by `NEXUS_TOKEN_EXCHANGE_ENABLED`)
- AWS multi-part credential extension via `nexus_credential_metadata` sibling field (RFC 8693 single-token limitation)
- Per-request `PostgresAuthProfileStore` construction with JWT-verified `tenant_id` + `principal_id` scope
- Prometheus metrics (`nexus_token_exchange_requests_total`, `nexus_token_exchange_latency_seconds`, `nexus_read_audit_writes_total`)
- E2E tests: LocalStack S3 list-buckets, real GitHub `/user` (both env-gated)
- Operator guide section in `docs/guides/auth-envelope-encryption.md`

## What's deferred (separate issues)

- Gmail adapter (OAuth refresh via existing `TokenManager`)
- gcloud adapter
- Service-identity JWTs (`caller_kind` beyond `"daemon"`)
- Server-driven OAuth refresh (option B from brainstorm — currently A = daemon-driven)

## Security properties

- Daemon JWT verified via existing `JwtSigner` (PR #3816) before any DB hit
- Per-request RLS scoping: `SET LOCAL app.current_tenant = claims.tenant_id` via `_scoped()` helper
- AAD cross-check in `decrypt_profile()` (mirrors `get_with_credential` — rejects tampered-AAD rows even if AES-GCM tag verifies)
- `DecryptedProfile.plaintext` and `MaterializedCredential.access_token` masked in `__repr__` — no plaintext in logs/tracebacks
- `ConsumerError.from_row()` discipline: no inline f-strings, no envelope material in errors
- Plaintext lifetime bounded by `min(300s, expires_at - 60s)` in process
- `purpose` freetext truncated at 256 chars (operator guide warns callers not to include PII)

## Spec + plan

- Design spec: `docs/superpowers/specs/2026-04-23-issue-3818-server-credential-consumption-design.md`
- Implementation plan: `docs/superpowers/plans/2026-04-23-issue-3818-server-credential-consumption.md`

## Test plan

- [x] Unit: consumer / cache / adapters / audit / metrics (36 tests)
- [x] Integration (Postgres): `decrypt_profile()` honors RLS + AAD cross-check, returns plaintext + kek_version
- [x] Router: all HTTP error mappings (200/400/401/403/501), `force_refresh` path, `501` when `NEXUS_TOKEN_EXCHANGE_ENABLED=0`
- [x] Server boot: `from nexus.server.fastapi_server import create_app` imports cleanly with new wiring
- [x] E2E (LocalStack / GitHub): skip cleanly when env absent; run when `LOCALSTACK_ENDPOINT` / `NEXUS_TEST_GITHUB_PAT` set
- [ ] Reviewer: confirm `InMemoryEncryptionProvider` warning + `purpose`-PII warning in operator guide
- [ ] Reviewer: confirm `NEXUS_TOKEN_EXCHANGE_ENABLED` defaults to off so existing deployments are unaffected

## Commits

17 commits, each one task from the plan. TDD throughout — failing test → implementation → verification → commit.