### PR TITLE
release: v0.9.41 — fix stale ZoneManager import + pyinstaller protoc

### DIFF
--- a/.github/workflows/conda-pack.yml
+++ b/.github/workflows/conda-pack.yml
@@ -159,7 +159,7 @@ jobs:
         if: matrix.os != 'windows-latest'
         shell: bash -el {0}
         run: |
-          conda run -n nexus python -c "from nexus_kernel import Metastore, ZoneManager; print('nexus_kernel OK')"
+          conda run -n nexus python -c "from nexus_kernel import Metastore; print('nexus_kernel OK')"
 
       # ── conda-pack ───────────────────────────────────────────────────────
       - name: Install conda-pack into base environment

--- a/.github/workflows/pyinstaller-cluster.yml
+++ b/.github/workflows/pyinstaller-cluster.yml
@@ -119,6 +119,30 @@ jobs:
       - name: Setup Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
 
+      # ── protoc for raft-proto transitive build script ────────────────────
+      # rust/kernel pulls in raft → raft-proto, whose build script uses
+      # protobuf-build 0.14.1 and only accepts classic 3.x protoc. brew's
+      # current `protobuf` formula ships 34.x which is rejected. Pin 3.20.2
+      # (the last classic 3.x release with an arm64 macOS asset — 3.20.3
+      # dropped arm64) and prepend to PATH.
+      - name: Install protoc (macOS)
+        if: runner.os == 'macOS'
+        shell: bash
+        run: |
+          set -euo pipefail
+          PROTOC_VERSION=3.20.2
+          case "$(uname -m)" in
+            arm64) ARCH=aarch_64 ;;
+            x86_64) ARCH=x86_64 ;;
+            *) echo "Unsupported arch: $(uname -m)" >&2; exit 1 ;;
+          esac
+          mkdir -p "$HOME/protoc"
+          curl -fsSL -o /tmp/protoc.zip \
+            "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-osx-${ARCH}.zip"
+          unzip -o /tmp/protoc.zip -d "$HOME/protoc"
+          echo "$HOME/protoc/bin" >> "$GITHUB_PATH"
+          "$HOME/protoc/bin/protoc" --version
+
       - name: Rust build cache
         uses: Swatinem/rust-cache@v2
         with:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "kernel"
-version = "0.9.40"
+version = "0.9.41"
 dependencies = [
  "ahash",
  "blake3",

--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/api-client",
-  "version": "0.9.40",
+  "version": "0.9.41",
   "description": "Shared HTTP client for Nexus APIs — retry, auth, error mapping, case transform",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/tui",
-  "version": "0.9.40",
+  "version": "0.9.41",
   "description": "Terminal UI for Nexus \u2014 file explorer, API inspector, and monitoring dashboard",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.40"
+version = "0.9.41"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/rust/kernel/Cargo.toml
+++ b/rust/kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel"
-version = "0.9.40"
+version = "0.9.41"
 edition = "2021"
 
 [lib]

--- a/rust/kernel/pyproject.toml
+++ b/rust/kernel/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-kernel"
-version = "0.9.40"
+version = "0.9.41"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
 requires-python = ">=3.14"
 classifiers = [


### PR DESCRIPTION
## Summary

v0.9.40 tag surfaced two fresh macOS failures:

### 1. Conda Pack macos-arm64 + macos-x86_64

\`\`\`
ImportError: cannot import name 'ZoneManager' from 'nexus_kernel'
\`\`\`

My v0.9.37 rewrite of the verify step assumed \`Metastore\` **and** \`ZoneManager\` were re-registered into \`nexus_kernel\`. Only \`Metastore\` is. Looking at [\`rust/raft/src/pyo3_bindings.rs::register_python_classes\`](../blob/develop/rust/raft/src/pyo3_bindings.rs) — it registers \`PyMetastore\`, \`PyLockState\`, \`PyLockInfo\`, \`PyHolderInfo\` (plus optional tofu classes). The same file has a comment \`R20.18.6: PyZoneManager + PyZoneHandle pyclass shells deleted\`. Drop \`ZoneManager\` from the conda-pack verify import.

### 2. PyInstaller Cluster macos-arm64

\`\`\`
error: failed to run custom build command for `raft-proto v0.7.0`
No suitable `protoc` (>= 3.1.0) found in PATH
\`\`\`

Same protoc-on-macOS bug we fixed for \`release.yml\` (v0.9.36) and \`conda-pack.yml\` (v0.9.37) — \`pyinstaller-cluster.yml\` doesn't install protoc, macos-14 ships none, and brew's \`protobuf\` formula is 34.x (rejected by \`protobuf-build 0.14.1\`). Add the same 3.20.2-from-GitHub-release install step, gated on \`runner.os == 'macOS'\`.

## Out of scope

\`pyinstaller-cluster.yml\` still has stale \`_nexus_raft\` plumbing:
- \`maturin build -m rust/raft/Cargo.toml\` on a crate that's now rlib-only
- \`find_so("_nexus_raft")\` in the spec-patch step
- \`pyinstaller_spec_cluster.py\` hidden imports for \`_nexus_raft\`

These will fail **after** the kernel build succeeds, but v0.9.40 bailed earlier on protoc so they haven't surfaced. Untangling the spec file correctly (what \`.so\` paths the onedir bundle actually needs now that \`Metastore\` / locks live inside \`nexus_kernel.so\`) is non-trivial and doesn't gate PyPI / Docker publishes — tracking for a follow-up PR.

## Version bumps to 0.9.41
\`pyproject.toml\`, \`rust/kernel/pyproject.toml\`, \`rust/kernel/Cargo.toml\`, \`Cargo.lock\`, \`packages/nexus-api-client/package.json\`, \`packages/nexus-tui/package.json\`

## Test plan

- [ ] Merge, tag \`v0.9.41\`, push tag.
- [ ] Conda Pack: macos-arm64 + macos-x86_64 green.
- [ ] PyInstaller Cluster: macos-arm64 gets past \`maturin build rust/kernel\` (may still fail later on stale \`_nexus_raft\` plumbing — that's a separate PR).