### PR TITLE
release: v0.9.42 — split Docker multi-arch across native runners (no QEMU)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -22,15 +22,83 @@ env:
   IMAGE_NAME: ${{ github.repository_owner }}/nexus
 
 jobs:
+  # Fan out amd64 and arm64 onto native GitHub-hosted runners; emit one
+  # push-by-digest image per platform. QEMU-emulated multi-arch on a
+  # single ubuntu-latest runner is 5-10x slower than native and times
+  # out on heavy images. `ubuntu-24.04-arm` is free for public repos
+  # (GA early 2025) and private repos (GA 2026-01-29).
+  # See docs: https://docs.docker.com/build/ci/github-actions/multi-platform/
+  build-platform:
+    name: Build ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: ubuntu-latest
+          - platform: linux/arm64
+            runner: ubuntu-24.04-arm
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Normalize platform pair (for artifact name)
+        id: pair
+        run: |
+          pair="${{ matrix.platform }}"
+          echo "value=${pair//\//-}" >> "$GITHUB_OUTPUT"
+
+      - name: Build and push by digest
+        id: build
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: ./Dockerfile
+          platforms: ${{ matrix.platform }}
+          outputs: type=image,name=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }},push-by-digest=true,name-canonical=true,push=true,oci-mediatypes=true
+          cache-from: type=gha,scope=${{ github.ref_name }}-${{ steps.pair.outputs.value }}
+          cache-to: type=gha,mode=max,scope=${{ github.ref_name }}-${{ steps.pair.outputs.value }}
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-docker-publish-${{ steps.pair.outputs.value }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
   build-and-push:
     name: Build & push multi-arch image
+    needs: [build-platform]
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
 
-      - name: Set up QEMU (for cross-platform builds)
-        uses: docker/setup-qemu-action@v3
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-docker-publish-*
+          merge-multiple: true
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -58,17 +126,16 @@ jobs:
             type=raw,value=${{ github.event.inputs.tag }},enable=${{ github.event.inputs.tag != '' }}
             type=sha,prefix=,enable=${{ github.event.inputs.tag == '' }}
 
-      - name: Build and push multi-arch image
-        uses: docker/build-push-action@v6
-        with:
-          context: .
-          file: ./Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create \
+            $(jq -cr '.tags | map("-t " + .) | join(" ")' <<< "$DOCKER_METADATA_OUTPUT_JSON") \
+            $(printf '${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}@sha256:%s ' *)
+
+      - name: Inspect
+        run: |
+          docker buildx imagetools inspect "${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ steps.meta.outputs.version }}"
 
   # ---------------------------------------------------------------------------
   # E2E smoke tests against the edge image (develop only)

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -444,51 +444,47 @@ jobs:
             npm publish --access public
           fi
 
-  # Docker build, smoke test, and GHCR push — inline in release.yml so
-  # create-release can depend on it directly (Issue #2946 atomic release).
-  # docker-publish.yml handles branch pushes (develop/main) separately.
-  build-docker:
-    name: Build & push Docker (${{ matrix.variant }})
+  # Docker build, smoke test, and GHCR push.
+  #
+  # Why this shape (fan-out per platform, then merge manifests):
+  #   Earlier versions did a single multi-arch build per variant on
+  #   one ubuntu-latest runner using QEMU to emulate arm64. CUDA
+  #   repeatedly tripped the 2-hour job timeout because emulated
+  #   arm64 on x86_64 is 5-10x slower than native. GitHub now ships
+  #   free `ubuntu-24.04-arm` hosted runners (GA for public repos
+  #   since early 2025; private repos since 2026-01-29), so the
+  #   correct pattern is matrix-per-platform on native hardware +
+  #   a merge job that stitches the per-platform digests into one
+  #   multi-arch manifest with `docker buildx imagetools create`.
+  #   See docs: https://docs.docker.com/build/ci/github-actions/multi-platform/
+  #
+  # docker-publish.yml handles branch pushes (develop/main) via the
+  # same pattern (kept in sync).
+  build-docker-platform:
+    name: Build ${{ matrix.variant }} / ${{ matrix.platform }}
     needs: [verify-version]
-    runs-on: ubuntu-latest
-    timeout-minutes: 120
+    runs-on: ${{ matrix.runner }}
+    timeout-minutes: 90
     strategy:
+      fail-fast: false
       matrix:
         include:
           - variant: cpu
-            suffix: ""
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - variant: cpu
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
           - variant: cuda
-            suffix: "-cuda"
+            platform: linux/amd64
+            runner: ubuntu-latest
+          - variant: cuda
+            platform: linux/arm64
+            runner: ubuntu-24.04-arm
 
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-
-      # Reclaim ~30 GB from the hosted runner before the build. CUDA
-      # variant pulls torch-cuda (~2 GB), txtai + sentence-transformers,
-      # and builds a multi-arch image (amd64 + arm64 via QEMU) — that
-      # combined layer store repeatedly blew past ubuntu-latest's
-      # ~14 GB post-checkout budget and got the runner killed. Removes
-      # tooling (Android SDK, .NET, Haskell, CodeQL, etc.) we don't
-      # use in this job.
-      - name: Free disk space (CUDA variant)
-        if: matrix.variant == 'cuda'
-        # Pinned to the v1.3.1 release commit. `@main` would let an
-        # upstream push execute inside this release job (contents:write,
-        # packages:write, id-token:write, attestations:write). Bump the
-        # SHA via PR after reviewing upstream commits.
-        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be  # v1.3.1
-        with:
-          tool-cache: false
-          android: true
-          dotnet: true
-          haskell: true
-          large-packages: true
-          docker-images: false
-          swap-storage: true
-
-      - name: Set up QEMU (multi-arch)
-        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -500,43 +496,31 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # NOTE: The March 13, 2026 v0.9.2 "denied: write_package" failure was caused
-      # by the GHCR package not being linked to the repo. Fixed by deleting the
-      # orphaned package — next push auto-creates it with correct repo linkage.
-      # If this recurs: GitHub Settings → Packages → nexus → Manage Actions access.
-
-      - name: Extract version metadata
-        id: meta
+      - name: Normalize platform pair (for artifact name)
+        id: pair
         run: |
-          VERSION="${GITHUB_REF#refs/tags/v}"
-          SUFFIX="${{ matrix.suffix }}"
-          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
-          echo "tags=ghcr.io/nexi-lab/nexus:${VERSION}${SUFFIX},ghcr.io/nexi-lab/nexus:stable${SUFFIX},ghcr.io/nexi-lab/nexus:latest${SUFFIX}" >> "$GITHUB_OUTPUT"
+          pair="${{ matrix.platform }}"
+          echo "value=${pair//\//-}" >> "$GITHUB_OUTPUT"
 
-      # Local-load build is ONLY needed to run the CPU-gated smoke tests
-      # below. The CUDA variant skips all of those tests (PyTorch CUDA
-      # wheels ship AVX-512 binaries that SIGILL on hosted runners), so
-      # materializing a ~8-10 GB CUDA image into the local Docker store
-      # is wasted work AND blows past the standard ubuntu-latest runner's
-      # ~14 GB disk budget (it competes with the later multi-arch layer
-      # store in "Build and push to GHCR"). Scope this step to CPU only;
-      # CUDA goes straight to the registry-cached multi-arch push.
-      - name: Build image (local load for smoke tests)
-        if: matrix.variant == 'cpu'
+      # Local-load build + smoke tests, amd64 CPU only. Exists to catch
+      # build-time regressions and runtime ImportErrors BEFORE we publish
+      # the final manifest. Other matrix cells go straight to push-by-
+      # digest: CUDA images ship AVX-512 binaries that SIGILL on hosted
+      # runners, and arm64 cells on ubuntu-24.04-arm don't need their own
+      # copy of the smoke tests (same image content, different arch).
+      - name: Build image for smoke tests (amd64 CPU only)
+        if: matrix.variant == 'cpu' && matrix.platform == 'linux/amd64'
         uses: docker/build-push-action@v6
         with:
           context: .
           load: true
           tags: ghcr.io/nexi-lab/nexus:smoke-test
           build-args: TORCH_VARIANT=${{ matrix.variant }}
-          cache-from: type=registry,ref=ghcr.io/nexi-lab/nexus:buildcache-release-${{ matrix.variant }}
-          cache-to: type=registry,ref=ghcr.io/nexi-lab/nexus:buildcache-release-${{ matrix.variant }},mode=max,ignore-error=true
+          cache-from: type=registry,ref=ghcr.io/nexi-lab/nexus:buildcache-release-${{ matrix.variant }}-${{ steps.pair.outputs.value }}
+          cache-to: type=registry,ref=ghcr.io/nexi-lab/nexus:buildcache-release-${{ matrix.variant }}-${{ steps.pair.outputs.value }},mode=max,ignore-error=true
 
-      # Smoke tests run on CPU only — CUDA PyTorch ships binaries with
-      # instructions (e.g. AVX-512) not available on GitHub Actions runners,
-      # causing SIGILL.  CUDA images are validated on GPU machines post-release.
       - name: Smoke test — critical imports
-        if: matrix.variant == 'cpu'
+        if: matrix.variant == 'cpu' && matrix.platform == 'linux/amd64'
         run: |
           docker run --rm --entrypoint "" \
             -e GLIBC_TUNABLES=glibc.rtld.optional_static_tls=16384 \
@@ -553,14 +537,14 @@ jobs:
           "
 
       - name: Smoke test — CLI entrypoints
-        if: matrix.variant == 'cpu'
+        if: matrix.variant == 'cpu' && matrix.platform == 'linux/amd64'
         run: |
           docker run --rm --entrypoint "" \
             ghcr.io/nexi-lab/nexus:smoke-test \
             sh -c "nexus --version && nexusd --help > /dev/null 2>&1 && echo 'CLI OK'"
 
       - name: Smoke test — env-var config (no config file)
-        if: matrix.variant == 'cpu'
+        if: matrix.variant == 'cpu' && matrix.platform == 'linux/amd64'
         run: |
           docker run --rm --entrypoint "" \
             ghcr.io/nexi-lab/nexus:smoke-test \
@@ -571,25 +555,97 @@ jobs:
           print(f'Config OK: profile={cfg.profile}')
           "
 
-      - name: Build and push to GHCR
+      # Push-by-digest: produces a single-platform image in the registry
+      # and emits its digest so the merge job can assemble the multi-arch
+      # manifest. name-canonical=true keeps the reference stable.
+      - name: Build and push by digest
+        id: build
         uses: docker/build-push-action@v6
         with:
           context: .
-          platforms: linux/amd64,linux/arm64
-          push: true
+          platforms: ${{ matrix.platform }}
           provenance: false
           sbom: false
-          tags: ${{ steps.meta.outputs.tags }}
           build-args: TORCH_VARIANT=${{ matrix.variant }}
-          cache-from: type=registry,ref=ghcr.io/nexi-lab/nexus:buildcache-release-${{ matrix.variant }}
-          cache-to: type=registry,ref=ghcr.io/nexi-lab/nexus:buildcache-release-${{ matrix.variant }},mode=max,ignore-error=true
+          outputs: type=image,name=ghcr.io/nexi-lab/nexus,push-by-digest=true,name-canonical=true,push=true,oci-mediatypes=true
+          cache-from: type=registry,ref=ghcr.io/nexi-lab/nexus:buildcache-release-${{ matrix.variant }}-${{ steps.pair.outputs.value }}
+          cache-to: type=registry,ref=ghcr.io/nexi-lab/nexus:buildcache-release-${{ matrix.variant }}-${{ steps.pair.outputs.value }},mode=max,ignore-error=true
+
+      - name: Export digest
+        run: |
+          mkdir -p /tmp/digests
+          digest="${{ steps.build.outputs.digest }}"
+          touch "/tmp/digests/${digest#sha256:}"
+
+      - name: Upload digest
+        uses: actions/upload-artifact@v4
+        with:
+          name: digests-release-${{ matrix.variant }}-${{ steps.pair.outputs.value }}
+          path: /tmp/digests/*
+          if-no-files-found: error
+          retention-days: 1
+
+  # Merge the per-platform digests (amd64 + arm64) into one multi-arch
+  # manifest per variant and push the user-facing tags (:<version>,
+  # :stable, :latest, plus -cuda suffixes).
+  merge-docker-manifests:
+    name: Merge manifests (${{ matrix.variant }})
+    needs: [build-docker-platform]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - variant: cpu
+            suffix: ""
+          - variant: cuda
+            suffix: "-cuda"
+
+    steps:
+      - name: Download digests
+        uses: actions/download-artifact@v4
+        with:
+          path: /tmp/digests
+          pattern: digests-release-${{ matrix.variant }}-*
+          merge-multiple: true
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build tag list
+        id: tags
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          SUFFIX="${{ matrix.suffix }}"
+          {
+            echo "args=-t ghcr.io/nexi-lab/nexus:${VERSION}${SUFFIX} -t ghcr.io/nexi-lab/nexus:stable${SUFFIX} -t ghcr.io/nexi-lab/nexus:latest${SUFFIX}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Create manifest list and push
+        working-directory: /tmp/digests
+        run: |
+          docker buildx imagetools create ${{ steps.tags.outputs.args }} \
+            $(printf 'ghcr.io/nexi-lab/nexus@sha256:%s ' *)
+
+      - name: Inspect
+        run: |
+          VERSION="${GITHUB_REF#refs/tags/v}"
+          SUFFIX="${{ matrix.suffix }}"
+          docker buildx imagetools inspect "ghcr.io/nexi-lab/nexus:${VERSION}${SUFFIX}"
 
   # GitHub Release is created ONLY after both PyPI and Docker succeed.
   # This is the user-visible "released" signal — without it, the version
   # doesn't appear on the releases page or trigger notifications.
   create-release:
     name: Create GitHub Release
-    needs: [publish-pypi, publish-rust, publish-nexus-fs, publish-ts-packages, build-docker]
+    needs: [publish-pypi, publish-rust, publish-nexus-fs, publish-ts-packages, merge-docker-manifests]
     runs-on: ubuntu-latest
 
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1319,7 +1319,7 @@ dependencies = [
 
 [[package]]
 name = "kernel"
-version = "0.9.41"
+version = "0.9.42"
 dependencies = [
  "ahash",
  "blake3",

--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/api-client",
-  "version": "0.9.41",
+  "version": "0.9.42",
   "description": "Shared HTTP client for Nexus APIs — retry, auth, error mapping, case transform",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/tui",
-  "version": "0.9.41",
+  "version": "0.9.42",
   "description": "Terminal UI for Nexus \u2014 file explorer, API inspector, and monitoring dashboard",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.41"
+version = "0.9.42"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/rust/kernel/Cargo.toml
+++ b/rust/kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel"
-version = "0.9.41"
+version = "0.9.42"
 edition = "2021"
 
 [lib]

--- a/rust/kernel/pyproject.toml
+++ b/rust/kernel/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-kernel"
-version = "0.9.41"
+version = "0.9.42"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
 requires-python = ">=3.14"
 classifiers = [


### PR DESCRIPTION
## Why

Every tag since **v0.9.29** has tripped the CUDA Docker build in \`release.yml\`. Root cause is the canonical anti-pattern: one runner doing a single multi-arch build (linux/amd64 + linux/arm64) via QEMU emulation. Emulated arm64 on x86_64 is **5–10× slower than native** — the CUDA image repeatedly hit the 2-hour job timeout. Earlier fixes (free-disk-space, skipping the local-load step, bumping timeouts) were treating symptoms.

## The correct pattern (2026)

GitHub-hosted \`ubuntu-24.04-arm\` runners are **free**:
- Public repos: GA early 2025
- Private repos: GA 2026-01-29

Docker's official recommendation for multi-arch on GHA is:

1. **Matrix-per-platform**, each on its native runner, using \`push-by-digest=true, oci-mediatypes=true\`.
2. **Merge job** that downloads all digests and calls \`docker buildx imagetools create\` to publish the user-facing tags.

Docs: https://docs.docker.com/build/ci/github-actions/multi-platform/

## Changes

### \`release.yml\`

- \`build-docker\` (variant matrix on one runner with QEMU) → \`build-docker-platform\` (**4-cell matrix** \`{cpu, cuda} × {linux/amd64, linux/arm64}\` on native runners) + \`merge-docker-manifests\` (variant matrix that stitches per-platform digests into the final tags: \`:<version>[-cuda]\`, \`:stable[-cuda]\`, \`:latest[-cuda]\`).
- amd64 CPU cell still runs local-load + the three smoke tests before pushing by digest. Other cells go straight to the registry (CUDA wheels SIGILL on hosted runners; arm64 CPU doesn't need a redundant smoke — same image content, different arch).
- Per-platform registry cache (\`buildcache-release-<variant>-linux-<arch>\`) so native runners don't contend on a single cache index.
- **Drops** the free-disk-space + QEMU setup entirely: each platform gets its own runner with fresh disk.
- \`create-release\` now depends on \`merge-docker-manifests\`.

### \`docker-publish.yml\`

- Same refactor for the develop/main/tag path: \`build-platform\` matrix (amd64 native + arm64 native) emits digests; \`build-and-push\` becomes the merge job that publishes the full tag set via \`imagetools create\`.
- Separate per-platform gha cache scopes.

## Expected outcome

- **CUDA Docker push succeeds end-to-end**, first time in 10+ releases. \`Create GitHub Release\` runs.
- **CPU Docker push** also moves to the native pattern — fewer cache collisions, less QEMU fragility.
- Total wall-clock per variant = \`max(amd64_time, arm64_time)\` instead of \`amd64 + emulated_arm64\`. CUDA variant goes from timeout-at-2h to an expected ~15–30 min.

## Test plan

- [ ] Merge, tag \`v0.9.42\`, push tag.
- [ ] \`ubuntu-24.04-arm\` runners pick up the arm64 cells (no "unknown runner label" errors).
- [ ] \`build-docker-platform\` matrix: 4/4 green within the 90-min timeout.
- [ ] \`merge-docker-manifests\`: 2/2 green.
- [ ] \`ghcr.io/nexi-lab/nexus:0.9.42\` AND \`ghcr.io/nexi-lab/nexus:0.9.42-cuda\` appear on GHCR with both \`linux/amd64\` + \`linux/arm64\` in their manifest lists.
- [ ] \`Create GitHub Release\` runs (first time in 10+ tags).

## Rollback

If arm64 hosted runners turn out to be queued/unavailable, temporary fallback is to change \`runner: ubuntu-24.04-arm\` back to \`ubuntu-latest\` for the arm64 cells — they'll QEMU-emulate like before but on their own runner (still a small win over the old single-runner pattern).