### PR TITLE
fix: reuse main Kernel's redb connection in legacy OAuth key migration

### DIFF
--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -945,7 +945,15 @@ def _register_routes(app: FastAPI) -> None:
                 # One-shot upgrade path: copy OAuth key from a legacy
                 # ~/.nexus/metastore[.redb] file into SQL if present. Idempotent;
                 # no-ops once SQL already has the key.
-                migrate_legacy_oauth_key(_settings_store)
+                # Pass the main NexusFS metastore so migration reuses the
+                # Kernel's existing redb connection instead of creating a
+                # second Kernel() that would hit the exclusive file lock.
+                _nx_fs = getattr(app.state, "nexus_fs", None)
+                _existing_metastore = getattr(_nx_fs, "metadata", None) if _nx_fs else None
+                migrate_legacy_oauth_key(
+                    _settings_store,
+                    existing_metastore=_existing_metastore,
+                )
                 _oauth_crypto = OAuthCrypto(settings_store=_settings_store)
                 _audit_logger = SecretsAuditLogger(record_store=_sa_rs)
                 _secrets_service_instance = SecretsService(

--- a/src/nexus/storage/auth_stores/legacy_oauth_key_migration.py
+++ b/src/nexus/storage/auth_stores/legacy_oauth_key_migration.py
@@ -27,6 +27,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
+from typing import Any
 
 from nexus.contracts.auth_store_protocols import SystemSettingsStoreProtocol
 from nexus.lib.oauth.crypto import OAUTH_ENCRYPTION_KEY_NAME
@@ -44,8 +45,19 @@ def _legacy_redb_candidates() -> list[Path]:
     ]
 
 
-def migrate_legacy_oauth_key(sql_settings_store: SystemSettingsStoreProtocol) -> bool:
+def migrate_legacy_oauth_key(
+    sql_settings_store: SystemSettingsStoreProtocol,
+    *,
+    existing_metastore: Any | None = None,
+) -> bool:
     """Copy the OAuth key from a legacy redb file into the SQL settings store.
+
+    Args:
+        sql_settings_store: The SQL-backed settings store to write the key into.
+        existing_metastore: An already-open ``MetastoreABC`` (typically the main
+            Kernel's ``RustMetastoreProxy``).  When provided the key is read
+            through this connection, avoiding a second ``Kernel()`` that would
+            hit the redb exclusive-file-lock held by the main Kernel.
 
     Returns:
         True if a migration actually happened this call; False if the SQL
@@ -67,7 +79,7 @@ def migrate_legacy_oauth_key(sql_settings_store: SystemSettingsStoreProtocol) ->
     for path in _legacy_redb_candidates():
         if not path.exists():
             continue
-        key = _read_oauth_key_from_redb(path)
+        key = _read_oauth_key_from_redb(path, existing_metastore=existing_metastore)
         if key is None:
             continue
         sql_settings_store.set_setting(
@@ -87,17 +99,51 @@ def migrate_legacy_oauth_key(sql_settings_store: SystemSettingsStoreProtocol) ->
     return False
 
 
-def _read_oauth_key_from_redb(path: Path) -> str | None:
-    """Open a legacy redb file one-shot, read the OAuth key, close.
+def _read_oauth_key_from_redb(
+    path: Path,
+    *,
+    existing_metastore: Any | None = None,
+) -> str | None:
+    """Read the OAuth encryption key from a legacy metastore file.
+
+    When *existing_metastore* is provided (a ``RustMetastoreProxy`` backed
+    by the main Kernel), the key is read through that connection — avoiding
+    a second ``Kernel()`` that would hit the redb exclusive-file-lock.
+
+    For the pre-redb ``~/.nexus/metastore`` path (Python RaftMetadataStore
+    format) the main Kernel's ``LocalMetastore`` cannot read it, but neither
+    could the old standalone ``Kernel()`` approach (``Database::create``
+    fails on a non-redb file).  Returns ``None`` with a log line in that case.
 
     Returns ``None`` when the file can't be opened, when the Rust kernel
     isn't importable in this process, or when the key isn't present. A
     log line at WARNING level is emitted for unexpected failures so an
     operator looking into a data-loss incident has something to grep.
     """
-    # nexus.core.metastore + nexus_kernel are kernel-tier imports — allowed
-    # from nexus.storage (this module) by the five-tier architecture; they
-    # would be disallowed from nexus.lib. See import-linter config.
+    # Fast path: reuse the main Kernel's metastore connection.
+    if existing_metastore is not None:
+        try:
+            from nexus.storage.auth_stores.metastore_settings_store import (
+                MetastoreSettingsStore,
+            )
+
+            store = MetastoreSettingsStore(existing_metastore)
+            dto = store.get_setting(OAUTH_ENCRYPTION_KEY_NAME)
+            if dto is None:
+                return None
+            return dto.value
+        except Exception as exc:
+            logger.warning(
+                "Legacy OAuth key migration could not read via existing metastore for %s: %s",
+                path,
+                exc,
+            )
+            return None
+
+    # Slow path (original): open the redb file with a standalone Kernel().
+    # This will fail with "Database already open" if the main Kernel
+    # already holds the lock — acceptable for CLI / test callers that
+    # don't have a main Kernel.
     try:
         from nexus.core.metastore import RustMetastoreProxy
         from nexus.storage.auth_stores.metastore_settings_store import (

--- a/tests/unit/storage/test_legacy_oauth_key_migration.py
+++ b/tests/unit/storage/test_legacy_oauth_key_migration.py
@@ -43,7 +43,7 @@ def _patch_candidates(monkeypatch: pytest.MonkeyPatch, paths: list[Path]) -> Non
 
 
 def _patch_reader(monkeypatch: pytest.MonkeyPatch, result_by_path: dict[Path, Any]) -> None:
-    def _fake_read(path: Path) -> str | None:
+    def _fake_read(path: Path, **kwargs: Any) -> str | None:
         return result_by_path.get(path)
 
     monkeypatch.setattr(legacy_oauth_key_migration, "_read_oauth_key_from_redb", _fake_read)
@@ -170,3 +170,80 @@ class TestFreshInstall:
 
         assert migrated is False
         assert store.get_setting(OAUTH_ENCRYPTION_KEY_NAME) is None
+
+
+class _FakeMetastore:
+    """Lightweight MetastoreABC stand-in that returns preloaded FileMetadata."""
+
+    def __init__(self, entries: dict[str, str]) -> None:
+        self._entries = entries
+
+    def get(self, path: str) -> Any:
+        from nexus.contracts.metadata import FileMetadata
+
+        value = self._entries.get(path)
+        if value is None:
+            return None
+        import json
+
+        return FileMetadata(
+            path=path,
+            backend_name="_config",
+            physical_path=json.dumps({"v": value}),
+            size=0,
+        )
+
+
+class TestExistingMetastore:
+    def test_uses_existing_metastore_when_provided(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """When existing_metastore is passed, _read_oauth_key_from_redb
+        must read through it instead of creating a new Kernel()."""
+        store = _FakeSettingsStore()
+        candidate = tmp_path / "metastore.redb"
+        candidate.touch()
+
+        fake_ms = _FakeMetastore({f"cfg:{OAUTH_ENCRYPTION_KEY_NAME}": "existing-ms-key"})
+        _patch_candidates(monkeypatch, [candidate])
+        # Do NOT patch _read_oauth_key_from_redb — exercise the real fast path.
+
+        migrated = migrate_legacy_oauth_key(store, existing_metastore=fake_ms)
+
+        assert migrated is True
+        dto = store.get_setting(OAUTH_ENCRYPTION_KEY_NAME)
+        assert dto is not None and dto.value == "existing-ms-key"
+
+    def test_existing_metastore_returns_none_when_no_key(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """When the existing metastore has no OAuth key, migration should
+        fall through and return False (no migration happened)."""
+        store = _FakeSettingsStore()
+        candidate = tmp_path / "metastore.redb"
+        candidate.touch()
+
+        fake_ms = _FakeMetastore({})
+        _patch_candidates(monkeypatch, [candidate])
+
+        migrated = migrate_legacy_oauth_key(store, existing_metastore=fake_ms)
+
+        assert migrated is False
+        assert store.get_setting(OAUTH_ENCRYPTION_KEY_NAME) is None
+
+    def test_existing_metastore_none_falls_back_to_slow_path(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """When existing_metastore is None, the original slow path is used."""
+        store = _FakeSettingsStore()
+        candidate = tmp_path / "metastore.redb"
+        candidate.touch()
+
+        _patch_candidates(monkeypatch, [candidate])
+        _patch_reader(monkeypatch, {candidate: "slow-path-key"})
+
+        migrated = migrate_legacy_oauth_key(store, existing_metastore=None)
+
+        assert migrated is True
+        dto = store.get_setting(OAUTH_ENCRYPTION_KEY_NAME)
+        assert dto is not None and dto.value == "slow-path-key"


### PR DESCRIPTION
## Summary

- Fix redb exclusive-file-lock conflict in `legacy_oauth_key_migration.py` by passing the main Kernel's `RustMetastoreProxy` to the migration function instead of creating a second `Kernel()`
- Add `existing_metastore` parameter (optional, backward-compatible) with a fast path that reads through the existing connection, preserving the slow path as fallback for CLI/test callers
- Wire the metastore through from `fastapi_server.py` via `app.state.nexus_fs.metadata`
- Add unit tests covering the new fast path, no-key case, and slow-path fallback

## Problem

Upgrading from v0.9.33 silently lost all stored secrets. The root cause: `legacy_oauth_key_migration.py` created a standalone `Kernel()` to open `~/.nexus/metastore.redb`, which was already locked by the main Kernel. The lock error was caught silently, the OAuth encryption key was never migrated to SQL, and `_load_or_create_key()` then generated a new random key — making all previously-encrypted secrets permanently undecryptable.

## Test plan

- [x] Unit tests: 3 new cases in `TestExistingMetastore` + existing tests pass unchanged
- [x] Migration integration test: redb → SQL key migration verified with matching key values
- [x] Secret persistence: secrets encrypted pre-migration are correctly decrypted post-migration
- [x] Restart resilience: key persists across graceful restarts, no ephemeral key generated
- [ ] CI pipeline passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)