### PR TITLE
fix(kernel,remote): 3 regressions on develop tip (pwrite offset / dead remote_metastore import / E2E bootstrap)

### DIFF
--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -350,30 +350,36 @@ def connect(
             tls_config=_tls_config,
         )
 
-        # RemoteBackend + RemoteMetastore — stateless proxies, server is SSOT.
-        from nexus.backends.storage.remote import RemoteBackend
-        from nexus.storage.remote_metastore import RemoteMetastore
-
-        remote_backend = RemoteBackend(transport)
-        remote_metastore = RemoteMetastore(transport)
-
-        # Build a lightweight NexusFS directly — no factory, no bricks.
-        # Server is SSOT; client just proxies calls via gRPC.
-        # No parser registries — remote delegates all parsing to the server.
+        # Rust-native remote wiring (Issue #1134 Phase 4, a803a9d63):
+        # the root mount carries backend_type="remote" + connection params,
+        # and PyKernel::sys_setattr constructs both the Rust RemoteBackend
+        # and the Rust RemoteMetastore from those params — no Python shim.
+        # Metastore is a stock RustMetastoreProxy: the single Rust kernel
+        # routes per-mount reads/writes to the remote backend it built.
+        from nexus.contracts.metadata import DT_MOUNT
         from nexus.contracts.types import OperationContext as _RemoteOC
         from nexus.core.config import PermissionConfig as _PermissionConfig
         from nexus.core.nexus_fs import NexusFS as _RemoteNexusFS
 
+        remote_metastore = _open_local_metastore(":memory:")
         nfs = _RemoteNexusFS(
             metadata_store=remote_metastore,
             permissions=_PermissionConfig(enforce=False),
             init_cred=_RemoteOC(user_id="remote", groups=[], is_admin=False),
         )
 
-        # Mount root backend — Rust kernel is SSOT for routing (F2).
-        from nexus.contracts.metadata import DT_MOUNT
-
-        nfs.sys_setattr("/", entry_type=DT_MOUNT, backend=remote_backend)
+        nfs.sys_setattr(
+            "/",
+            entry_type=DT_MOUNT,
+            backend_type="remote",
+            backend_name="remote",
+            server_address=grpc_address,
+            remote_auth_token=api_key,
+            remote_ca_pem=(_tls_config.ca_pem.decode() if _tls_config else None),
+            remote_cert_pem=(_tls_config.node_cert_pem.decode() if _tls_config else None),
+            remote_key_pem=(_tls_config.node_key_pem.decode() if _tls_config else None),
+            remote_timeout=float(timeout),
+        )
 
         # Wire service proxies for REMOTE profile (Issue #1171).
         # Fills all 25+ service slots with RemoteServiceProxy — forwards

--- a/src/nexus/core/nexus_fs_content.py
+++ b/src/nexus/core/nexus_fs_content.py
@@ -766,7 +766,6 @@ class ContentMixin:
             Dict with metadata (etag, version, modified_at, size).
         """
         del consistency  # threaded via context.metadata_consistency; kernel owns it now.
-        del offset  # Rust sys_write handles offset natively.
 
         if isinstance(buf, str):
             buf = buf.encode("utf-8")
@@ -793,7 +792,7 @@ class ContentMixin:
         # Capture old metadata BEFORE write for audit snapshot_hash (old_etag)
         _old_meta = self.metadata.get(path)
 
-        result = self._kernel.sys_write(path, _rust_ctx, buf)
+        result = self._kernel.sys_write(path, _rust_ctx, buf, offset)
 
         # POST-INTERCEPT hooks
         zone_id, agent_id, _ = self._get_context_identity(context)

--- a/tests/e2e/docker/test_federation_e2e.py
+++ b/tests/e2e/docker/test_federation_e2e.py
@@ -2121,22 +2121,18 @@ def _bootstrap_standalone_fs(tmp_path):
     No RPC surface is added — the test drives kernel syscalls in-process
     via the PyO3 bindings (the pattern validated for R20.14).
     """
-    import asyncio
-
     from nexus.backends.storage.cas_local import CASLocalBackend
     from nexus.core.config import ParseConfig, PermissionConfig
     from nexus.factory import create_nexus_fs
     from nexus.storage.record_store import SQLAlchemyRecordStore
     from tests.helpers.dict_metastore import DictMetastore
 
-    return asyncio.run(
-        create_nexus_fs(
-            backend=CASLocalBackend(tmp_path / "data"),
-            metadata_store=DictMetastore(),
-            record_store=SQLAlchemyRecordStore(db_path=tmp_path / "meta.db"),
-            parsing=ParseConfig(auto_parse=False),
-            permissions=PermissionConfig(enforce=False),
-        )
+    return create_nexus_fs(
+        backend=CASLocalBackend(tmp_path / "data"),
+        metadata_store=DictMetastore(),
+        record_store=SQLAlchemyRecordStore(db_path=tmp_path / "meta.db"),
+        parsing=ParseConfig(auto_parse=False),
+        permissions=PermissionConfig(enforce=False),
     )
 
 


### PR DESCRIPTION
## Summary

Docker federation E2E fell from 50/0/0 to **5 failed / 4 skipped** on develop tip 0.9.42. Three distinct regressions landed across the recent §12b async-kernel refactor. One fix each, all in one PR per debug-session policy.

### 1. pwrite data loss (2 tests: \`TestScatterGatherChunkedRead::*\`)
\`NexusFS.write(..., offset=)\` deleted the \`offset\` local var before calling \`Kernel::sys_write\`, silently collapsing every non-zero offset into PyO3 default \`offset=0\`.

pwrite at offset=5 of \`"ab"\` with payload \`"xyz"\` returned \`b"xyz"\` (truncated) instead of \`b"ab\x00\x00\x00xyz"\`. The scatter/gather test's gRPC UNAVAILABLE cascade was secondary — the same truncation corrupted the CAS manifest, which broke node-2's cross-node fetch.

One-line fix:

\`\`\`diff
- del offset  # Rust sys_write handles offset natively.
  ...
- result = self._kernel.sys_write(path, _rust_ctx, buf)
+ result = self._kernel.sys_write(path, _rust_ctx, buf, offset)
\`\`\`

### 2. Dead \`RemoteMetastore\` import (4 tests: \`TestFederationCLISurface::*\`, \`TestZoneSnapshotExportImport::test_export_import_roundtrip\`)
\`a803a9d63\` deleted \`src/nexus/storage/remote_metastore.py\` but left the import in \`nexus.connect()\`. Every \`nexus <subcommand>\` CLI invocation crashed with \`ModuleNotFoundError\` before reaching the server.

Replaced the dead Python-side \`RemoteMetastore\` wiring with the Rust-native path the same refactor introduced: \`sys_setattr(entry_type=DT_MOUNT, backend_type="remote", server_address=..., remote_auth_token=..., remote_ca_pem=..., remote_cert_pem=..., remote_key_pem=..., remote_timeout=...)\`. PyKernel constructs Rust RemoteBackend + RemoteMetastore natively — zero Python shim. Metastore flows through \`RustMetastoreProxy\`.

### 3. Stale \`asyncio.run\` wrapper (3 tests: 2×\`Test*BackendRustCAS::test_streaming_round_trip\`, \`TestLLMSessionEndToEnd::test_three_turn_conversation\`)
\`729dfe3c4\` flipped \`create_nexus_fs\` from async to sync but the docker E2E file's \`_bootstrap_standalone_fs\` helper still wrapped it in \`asyncio.run(...)\`, which raised \`TypeError: An asyncio.Future, a coroutine or an awaitable is required\` on a plain \`NexusFS\` return.

## Verification

Docker federation E2E on develop tip \`e7dc41f43\` + these 3 fixes:

| Run | Result | Time |
|---|---|---|
| 1 | 50 passed / 0 failed / 0 skipped | 62.8 s |
| 2 | 50 passed / 0 failed / 0 skipped | 61.0 s |
| 3 | 50 passed / 0 failed / 0 skipped | 63.6 s |

## Test plan

- [x] Docker federation E2E 50/0/0 × 3 back-to-back
- [x] pwrite zero-fill semantics verified: \`b"ab\x00\x00\x00xyz"\` for pwrite("xyz", offset=5) over \`"ab"\`
- [x] CLI commands (\`nexus federation status\`, \`nexus federation zones\`, \`nexus zone list\`) now succeed against the server
- [x] LLM streaming (OpenAI, Anthropic, 3-turn) bootstraps without asyncio TypeError

Scope: three small bug fixes to different files found by the same regression audit. No refactoring.
