### PR TITLE
fix(e2e): add compose profile to test service — eliminate concurrent pytest race

### DIFF
--- a/dockerfiles/docker-compose.dynamic-federation-test.yml
+++ b/dockerfiles/docker-compose.dynamic-federation-test.yml
@@ -205,10 +205,20 @@ services:
 
   # ==========================================================================
   # E2E Test Runner — dynamic federation tests
+  #
+  # profiles=["run"] opts the service out of default `docker compose up`.
+  # Without this, `up -d` spawns a background pytest container that races
+  # with any manual `docker compose run --rm test` against the same cluster
+  # (both call container.stop(nexus-dyn-node-1) during the failover tests —
+  # 4 stops instead of 2, witness redb lock conflicts, cascade of gRPC
+  # UNAVAILABLE failures). Explicit profile → `up -d` only brings up the
+  # cluster; tests are opt-in via `run --rm test` or `--profile run up`.
   # ==========================================================================
   test:
     image: nexus-fullnode:latest
     container_name: nexus-dyn-test
+    profiles:
+      - run
     dns:
       - 8.8.8.8
       - 1.1.1.1


### PR DESCRIPTION
## Summary

Cold-start docker federation E2E was intermittently failing with 2–6 test failures, all `gRPC UNAVAILABLE / Connection refused` to nexus-1.

## Root cause

`dockerfiles/docker-compose.dynamic-federation-test.yml` defined the `test` service with an always-run `command: bash -c 'pip install ...; pytest ...'`. So `docker compose up -d` spawned a **background pytest container** in addition to any manual `docker compose run --rm test` the operator ran. Two pytest processes concurrently hammered the same cluster — each calling `container.stop("nexus-dyn-node-1")` on the two failover tests. That's **4 stops instead of the 2** the test code writes.

During the overlapping restart windows, witness's redb metastore rejected new zone auto-joins with `redb database error: Database already open. Cannot acquire lock`, cascading into Connection refused on :2028 for the next ~10s of cluster tests.

## Evidence

- `docker events --filter container=nexus-dyn-node-1` logged **4 `kill 15`** events in a single failing cold run (code has only 2 explicit `.stop()` calls)
- `docker logs nexus-dyn-test` (auto-spawned) showed an overlapping pytest with its own `1 failed, 49 passed` result while the manual run was mid-test
- Warm runs (where the auto-spawned container had already exited) had exactly 2 `kill 15` events → always passed 50/0/0
- Cold runs (fresh volumes + auto-spawned pytest + manual pytest overlapping) had 4 kills → 14%-25% failure rate

## Fix

Add `profiles: ["run"]` to the `test` service. Compose does not start services in named profiles unless `--profile` is passed, so `docker compose up -d` now brings up cluster + sidecars only (dragonfly, sse-mock, witness, nexus-1, nexus-2). Tests remain opt-in via the existing `docker compose run --rm test`.

## Verification (develop tip `39f486703`)

| Scenario | Before fix | After fix |
|---|---|---|
| Cold start (fresh volumes) | 2–6 failed / 44–48 passed (flaky ~20%) | **50/0/0** |
| Warm run 1 | 50/0/0 | **50/0/0** |
| Warm run 2 | 50/0/0 | **50/0/0** |

Post-fix `docker events` now shows exactly 2 `kill 15` events per run, matching the 2 `.stop()` calls in the test code — the concurrency race is eliminated.

## Test plan

- [x] Cold start (down -v + up -d + run --rm test): 50/0/0
- [x] 2 consecutive warm runs: 50/0/0, 50/0/0
- [x] `docker ps -a` after `up -d` confirms no `nexus-dyn-test` auto-start
