### PR TITLE
fix: legacy OAuth key migration falls through to slow path

### DIFF
--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/api-client",
-  "version": "0.9.42",
+  "version": "0.9.43",
   "description": "Shared HTTP client for Nexus APIs — retry, auth, error mapping, case transform",
   "type": "module",
   "main": "./dist/index.cjs",

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@nexus-ai-fs/tui",
-  "version": "0.9.42",
+  "version": "0.9.43",
   "description": "Terminal UI for Nexus \u2014 file explorer, API inspector, and monitoring dashboard",
   "type": "module",
   "bin": {

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,7 +1,7 @@
 # Nexus AI Filesystem
 [project]
 name = "nexus-ai-fs"
-version = "0.9.42"
+version = "0.9.43"
 description = "Nexus = filesystem/context plane."
 readme = "README.md"
 requires-python = ">=3.14"

--- a/rust/kernel/Cargo.toml
+++ b/rust/kernel/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "kernel"
-version = "0.9.42"
+version = "0.9.43"
 edition = "2021"
 
 [lib]

--- a/rust/kernel/pyproject.toml
+++ b/rust/kernel/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "maturin"
 
 [project]
 name = "nexus-kernel"
-version = "0.9.42"
+version = "0.9.43"
 description = "Fast Rust-based ReBAC permission computation for Nexus"
 requires-python = ">=3.14"
 classifiers = [

--- a/src/nexus/storage/auth_stores/legacy_oauth_key_migration.py
+++ b/src/nexus/storage/auth_stores/legacy_oauth_key_migration.py
@@ -121,6 +121,11 @@ def _read_oauth_key_from_redb(
     operator looking into a data-loss incident has something to grep.
     """
     # Fast path: reuse the main Kernel's metastore connection.
+    # Only valid when the candidate *path* matches the file backing
+    # existing_metastore (typically metastore.redb).  When it doesn't
+    # match (e.g. the pre-R20.18.5 "metastore" no-ext candidate), the
+    # fast path reads the wrong file and returns None — we must fall
+    # through to the slow path which opens *path* directly.
     if existing_metastore is not None:
         try:
             from nexus.storage.auth_stores.metastore_settings_store import (
@@ -129,9 +134,10 @@ def _read_oauth_key_from_redb(
 
             store = MetastoreSettingsStore(existing_metastore)
             dto = store.get_setting(OAUTH_ENCRYPTION_KEY_NAME)
-            if dto is None:
-                return None
-            return dto.value
+            if dto is not None:
+                return dto.value
+            # Key not found via existing connection — fall through to
+            # slow path which opens the specific candidate file.
         except Exception as exc:
             logger.warning(
                 "Legacy OAuth key migration could not read via existing metastore for %s: %s",

--- a/tests/unit/storage/test_legacy_oauth_key_migration.py
+++ b/tests/unit/storage/test_legacy_oauth_key_migration.py
@@ -231,6 +231,29 @@ class TestExistingMetastore:
         assert migrated is False
         assert store.get_setting(OAUTH_ENCRYPTION_KEY_NAME) is None
 
+    def test_falls_through_to_slow_path_when_key_in_noext_file(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """When existing_metastore is provided but has no key, and the
+        legacy key lives in the no-extension ``metastore`` file, migration
+        must fall through the fast path and read via the slow path
+        (standalone Kernel) from that file."""
+        store = _FakeSettingsStore()
+        redb = tmp_path / "metastore.redb"
+        noext = tmp_path / "metastore"
+        redb.touch()
+        noext.touch()
+
+        fake_ms = _FakeMetastore({})  # existing metastore has no key
+        _patch_candidates(monkeypatch, [redb, noext])
+        _patch_reader(monkeypatch, {noext: "pre-redb-era-key"})
+
+        migrated = migrate_legacy_oauth_key(store, existing_metastore=fake_ms)
+
+        assert migrated is True
+        dto = store.get_setting(OAUTH_ENCRYPTION_KEY_NAME)
+        assert dto is not None and dto.value == "pre-redb-era-key"
+
     def test_existing_metastore_none_falls_back_to_slow_path(
         self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
     ) -> None:


### PR DESCRIPTION
## Summary
- Fix legacy OAuth key migration: fast path now falls through to slow path when key not found in existing_metastore, allowing the standalone Kernel() to open the pre-R20.18.5 metastore (no extension) and read the legacy OAuth encryption key
- Add test test_falls_through_to_slow_path_when_key_in_noext_file to cover the two-candidate + existing_metastore scenario
- Bump version to 0.9.43

## Problem
_read_oauth_key_from_redb fast path always read from existing_metastore (backed by metastore.redb), ignoring the path parameter. When iterating the second candidate metastore (no extension, containing the old key), the fast path read the wrong file, returned None, and the slow path was never reached — making the migration silently fail.

## Test plan
- pytest tests/unit/storage/test_legacy_oauth_key_migration.py -v — all 12 tests pass
- ruff check + ruff format --check — all pass