### PR TITLE
refactor: ServiceRegistry Rust↔Python cleanup — remove duplication + dead code

### DIFF
--- a/rust/kernel/src/service_registry.rs
+++ b/rust/kernel/src/service_registry.rs
@@ -121,9 +121,6 @@ impl ServiceRegistry {
             }
         }
 
-        // Auto-capture hooks via duck-typed hook_spec()
-        self.auto_capture_hooks(py, name, instance)?;
-
         Ok(())
     }
 
@@ -174,7 +171,7 @@ impl ServiceRegistry {
     /// Hot-swap a service: drain → replace (hook management done by caller).
     pub(crate) fn swap(
         &self,
-        py: Python<'_>,
+        _py: Python<'_>,
         name: &str,
         new_instance: &Bound<'_, PyAny>,
         exports: Vec<String>,
@@ -219,10 +216,6 @@ impl ServiceRegistry {
             exports: final_exports,
         };
         self.services.insert(name.to_string(), entry);
-
-        // Step 4: Auto-capture hooks on new instance (caller handles
-        // unregistering old hooks + registering new ones via dispatch)
-        self.auto_capture_hooks(py, name, new_instance)?;
 
         Ok(())
     }
@@ -376,35 +369,6 @@ impl ServiceRegistry {
             }
         }
         result
-    }
-
-    // ── Hook auto-capture (duck-typed hook_spec) ─────────────────────
-
-    /// Check for hook_spec() and auto-capture. Returns the HookSpec if found.
-    fn auto_capture_hooks(
-        &self,
-        py: Python<'_>,
-        _name: &str,
-        instance: &Bound<'_, PyAny>,
-    ) -> PyResult<()> {
-        // Use inspect.getattr_static to avoid __getattr__ proxies
-        let inspect = py.import("inspect")?;
-        let getattr_static = inspect.getattr("getattr_static")?;
-
-        let has_spec = match getattr_static.call1((instance, "hook_spec")) {
-            Ok(attr) => attr.is_callable(),
-            Err(_) => false,
-        };
-
-        if !has_spec {
-            return Ok(());
-        }
-
-        // hook_spec exists and is callable — the dispatch-side hook
-        // registration is handled by the Python enlist() caller which
-        // calls _register_hooks_for_spec on the dispatch object.
-        // We just verified it exists here.
-        Ok(())
     }
 }
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -394,7 +394,7 @@ class NexusFS(  # type: ignore[misc]
         return self
 
     # Services accessed via self.service("name") → Rust kernel (Issue #1452).
-    # Registered by factory via enlist_wired_services() at link().
+    # Registered by factory via enlist_services() at link().
 
     @property
     def service_coordinator(self) -> Any:

--- a/src/nexus/factory/_background.py
+++ b/src/nexus/factory/_background.py
@@ -12,25 +12,16 @@ def _start_background_services(system: dict[str, Any]) -> None:
     Deferred from tier construction so that all services are wired before
     any background I/O begins.
 
-    Issue #2193: deferred_permission_buffer and write_observer moved from
-    kernel dict to system dict (they are now system-tier services).
+    DeferredPermissionBuffer and EventDeliveryWorker implement
+    BackgroundService and are auto-started by the Rust kernel's
+    service_start_all() at bootstrap(). No manual start needed here.
 
     Args:
         system: Services dict from ``_boot_system_services()``.
     """
-    # Deferred Permission Buffer (former kernel tier, now system tier)
-    dpb = system.get("deferred_permission_buffer")
-    if dpb is not None and hasattr(dpb, "start"):
-        dpb.start()
-        logger.debug("[BOOT:BG] DeferredPermissionBuffer started")
-
     # Write Observer — RecordStoreWriteObserver (OBSERVE-phase) has no
     # start(). It is registered via hook_spec at factory enlist time.
     # The sync RecordStoreWriteObserver (SQLite fallback) also has no start().
-
-    # Event Delivery Worker (system tier)
-    # Issue #3193: start() is now async — auto-started by
-    # ServiceRegistry.start_background_services() (Q3).
 
     # Zone Lifecycle — load Terminating zones from DB (Issue #2061)
     zl = system.get("zone_lifecycle")

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -189,7 +189,7 @@ def _wire_services(
     # write_observer directly from service registry via nx.service("write_observer").
 
     # rebac_manager.close() and audit_store.close() are now handled by
-    # ServiceRegistry.close_all_services() — no manual callbacks needed.
+    # Rust kernel service_close_all() — no manual callbacks needed.
 
     # Issue #1792: AgentRegistry, EvictionManager, AcpService are now
     # constructed in _boot_post_kernel_services (_wired.py) by the services

--- a/src/nexus/factory/service_routing.py
+++ b/src/nexus/factory/service_routing.py
@@ -106,37 +106,27 @@ _CANONICAL_NAMES: dict[str, str] = {
 }
 
 
-def enlist_services(nx_or_coordinator: Any, services: dict[str, Any]) -> int:
+def enlist_services(nx: Any, services: dict[str, Any]) -> int:
     """Enlist services via sys_setattr("/__sys__/services/X") (#1708).
 
     Factory is the first user — uses syscalls like everyone else.
-    Accepts NexusFS (preferred, uses syscall) or ServiceRegistry (legacy compat).
     For each non-None service, resolves canonical name and exports, then registers.
 
     Returns the number of services enlisted.
     """
     count = 0
-    _use_syscall = hasattr(nx_or_coordinator, "sys_setattr")
 
     for src_key, val in services.items():
         if val is None:
             continue
         canonical: str = _CANONICAL_NAMES.get(src_key, src_key)
         exports = _CANONICAL_EXPORTS.get(canonical, ())
-        if _use_syscall:
-            nx_or_coordinator.sys_setattr(
-                f"/__sys__/services/{canonical}",
-                service=val,
-                exports=exports,
-                allow_overwrite=True,
-            )
-        else:
-            nx_or_coordinator.enlist(
-                canonical,
-                val,
-                exports=exports,
-                allow_overwrite=True,
-            )
+        nx.sys_setattr(
+            f"/__sys__/services/{canonical}",
+            service=val,
+            exports=exports,
+            allow_overwrite=True,
+        )
         count += 1
 
     return count

--- a/src/nexus/server/lifespan/services.py
+++ b/src/nexus/server/lifespan/services.py
@@ -610,7 +610,7 @@ async def _startup_pipe_consumers(app: "FastAPI", svc: "LifespanServices") -> No
         app.state.write_observer = wo
         logger.info("[OBSERVE] RecordStoreWriteObserver registered (OBSERVE-phase)")
 
-    # Issue #3193: EventDeliveryWorker is started by ServiceRegistry
+    # Issue #3193: EventDeliveryWorker is started by the Rust kernel
     # (BackgroundService auto-start). We only expose it + event_signal on
     # app.state so the API layer (EventReplayService) can access the signal.
     if svc.delivery_worker is not None:
@@ -682,7 +682,7 @@ async def _shutdown_pipe_consumers(app: "FastAPI") -> None:
     """Stop DT_PIPE consumers (Issue #809, #810).
 
     Note: EventDeliveryWorker (Issue #3193) is stopped by
-    ServiceRegistry.stop_background_services() — no
+    the Rust kernel's service_stop_all() — no
     explicit stop here to avoid double-stop.
     """
     # Issue #809: RecordStoreWriteObserver (OBSERVE-phase)

--- a/tests/unit/test_factory.py
+++ b/tests/unit/test_factory.py
@@ -415,6 +415,7 @@ class TestStartBackgroundServices:
     """Tests for _start_background_services (Issue #2193: system dict only)."""
 
     def test_start_called_on_deferred_buffer(self) -> None:
+        """DPB start is handled by Rust kernel service_start_all() — not called here."""
         from nexus.factory import _start_background_services
 
         dpb = MagicMock()
@@ -424,7 +425,7 @@ class TestStartBackgroundServices:
             "delivery_worker": None,
         }
         _start_background_services(system)
-        dpb.start.assert_called_once()
+        dpb.start.assert_not_called()
 
     def test_delivery_worker_not_started_in_background(self) -> None:
         """Issue #3193: delivery worker is now async — started by coordinator, not here."""


### PR DESCRIPTION
## Summary

- **Rust**: Delete redundant `auto_capture_hooks()` from `service_registry.rs` — it called `inspect.getattr_static()` via GIL to check if `hook_spec` exists, then did nothing. Python side already performs the check AND registers hooks.
- **Python**: Delete legacy `enlist()` fallback in `service_routing.py` — the `else` branch calling old Python `ServiceRegistry.enlist()` was unreachable since Rust migration (NexusFS always has `sys_setattr`).
- **Python**: Delete DPB double-start in `_background.py` — `dpb.start()` was called explicitly, but DPB implements `BackgroundService` and is auto-started by Rust kernel's `service_start_all()` at bootstrap.
- **Comments**: Update stale "ServiceRegistry" references across 4 files to reference Rust kernel equivalents.
- **mypy**: Fix pre-existing mypy errors in `bitmap_cache.py` — redis-py sync client return types need `cast()`.

## Test plan

- [x] `cargo check -p kernel` — pass
- [x] `cargo clippy -p kernel -- -D warnings` — pass
- [x] `python3 scripts/codegen_kernel_abi.py --check` — pass
- [x] `ruff check` on changed files — pass
- [x] `mypy` on changed files — pass
- [ ] Full CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)