### PR TITLE
fix(#3894): per-loop asyncio locks in TxtaiBackend

### DIFF
--- a/src/nexus/bricks/search/txtai_backend.py
+++ b/src/nexus/bricks/search/txtai_backend.py
@@ -16,8 +16,10 @@ from __future__ import annotations
 import asyncio
 import contextlib
 import logging
+import threading
 import time
 import weakref
+from collections.abc import AsyncIterator
 from typing import Any, Protocol, cast, runtime_checkable
 
 from nexus.bricks.search.results import BaseSearchResult
@@ -144,65 +146,107 @@ class TxtaiBackend:
         self._reranker: Any = None
         self.last_rerank_ms: float = 0.0
         self._started = False
-        self._startup_task: asyncio.Task[None] | None = None
         self._reranker_task: asyncio.Task[None] | None = None
         # Path for txtai config.json — needed for pgvector persistence.
         # txtai stores index metadata (dimensions, offset) in a local file
         # and reads it back on load() to reconnect to pgvector tables.
         self._config_path = data_path or "/app/data/.txtai-index"
-        # Per-loop locks (Issue #3894). asyncio.Lock binds to the running loop
-        # on first acquire (Python 3.11+); a single instance reused across loops
-        # raises "bound to a different event loop" and never recovers. Keys are
-        # weak so locks GC with their loop.
+        # Locking strategy (Issue #3894):
+        #   1. Per-loop asyncio.Lock — fair FIFO queueing of coroutines on
+        #      *the same* event loop. Required because asyncio.Lock binds to
+        #      the running loop on first acquire (Python 3.11+); a single
+        #      instance reused from a different loop raises
+        #      "bound to a different event loop" and the daemon wedges.
+        #   2. Process-wide threading.Lock — serialises native txtai/faiss/
+        #      SQLAlchemy work *across* event loops, restoring the global
+        #      mutual-exclusion contract that the original single asyncio.Lock
+        #      provided in single-loop deployments. Acquired inside
+        #      asyncio.to_thread so the event loop never blocks waiting for
+        #      it; threading.Lock permits release from any thread.
         self._locks: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock] = (
             weakref.WeakKeyDictionary()
         )
-        self._startup_locks: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock] = (
-            weakref.WeakKeyDictionary()
-        )
+        self._native_lock = threading.Lock()
+        # Startup gate — only one loop runs _startup_impl; others poll
+        # ``_started``. Plain threading.Lock so it is loop-agnostic.
+        self._startup_native_lock = threading.Lock()
+        self._startup_running = False
 
     def _get_lock(self) -> asyncio.Lock:
-        # Serialises access to _embeddings / _reranker on the current loop.
-        # faiss (used by txtai) is NOT thread-safe for concurrent search+write,
-        # and asyncio.to_thread() dispatches to a thread pool, so concurrent
-        # coroutines on the same loop must be serialised here.
+        # Same-loop coroutine fairness layer; cross-loop exclusion is provided
+        # by ``_native_lock`` inside ``_exclusive``.
         loop = asyncio.get_running_loop()
+        # Lazy GC: asyncio.Lock keeps a strong reference to its bound loop after
+        # contention, so the WeakKeyDictionary's weak key alone cannot collect
+        # closed loops. Drop entries whose loop is closed before we lookup.
+        for dead in [k for k in list(self._locks) if k.is_closed()]:
+            self._locks.pop(dead, None)
         lock = self._locks.get(loop)
         if lock is None:
             lock = self._locks.setdefault(loop, asyncio.Lock())
         return lock
 
-    def _get_startup_lock(self) -> asyncio.Lock:
-        loop = asyncio.get_running_loop()
-        lock = self._startup_locks.get(loop)
-        if lock is None:
-            lock = self._startup_locks.setdefault(loop, asyncio.Lock())
-        return lock
+    @contextlib.asynccontextmanager
+    async def _exclusive(self) -> AsyncIterator[None]:
+        """Take the per-loop async lock + the cross-loop native lock.
+
+        Replaces the original ``async with self._lock:`` contract. The native
+        section serialises faiss/SQLAlchemy work across every event loop in
+        the process; the per-loop async lock keeps same-loop coroutines fair
+        without spawning a worker thread per attempt.
+        """
+        async with self._get_lock():
+            await asyncio.to_thread(self._native_lock.acquire)
+            try:
+                yield
+            finally:
+                self._native_lock.release()
 
     async def startup(self) -> None:
-        """Initialize txtai resources once."""
+        """Initialize txtai resources once across any number of event loops."""
         if self._started or self._embeddings is not None:
             if self._embeddings is not None:
                 self._started = True
             return
 
-        async with self._get_startup_lock():
+        # Decide which loop owns initialisation. The threading.Lock makes this
+        # decision atomic across loops; we never hand a Task created on one
+        # loop to a coroutine running on another (which would raise
+        # "Task ... attached to a different loop").
+        should_init = False
+        with self._startup_native_lock:
             if self._started:
                 return
-            if self._startup_task is None or self._startup_task.done():
-                self._startup_task = asyncio.create_task(self._startup_impl())
-            task = self._startup_task
+            if not self._startup_running:
+                self._startup_running = True
+                should_init = True
 
-        await task
+        if should_init:
+            try:
+                await self._startup_impl()
+            finally:
+                with self._startup_native_lock:
+                    self._startup_running = False
+        else:
+            # Another loop owns init; poll until it flips ``_started``. Polling
+            # is intentionally simple — there is no cross-loop async primitive
+            # we can wait on safely.
+            while not self._started:
+                await asyncio.sleep(0.05)
 
     def kickoff_startup(self) -> None:
-        """Begin backend startup in the background without blocking app readiness."""
+        """Begin backend startup in the background without blocking app readiness.
+
+        Spawns a task on the current loop. The new ``startup`` flow uses a
+        threading.Lock gate so concurrent kickoffs from different loops cannot
+        run ``_startup_impl`` more than once — the duplicate callers will
+        observe ``_startup_running`` and poll for completion instead.
+        """
         if self._started or self._embeddings is not None:
             if self._embeddings is not None:
                 self._started = True
             return
-        if self._startup_task is None or self._startup_task.done():
-            self._startup_task = asyncio.create_task(self._startup_impl())
+        asyncio.create_task(self.startup())
 
     @staticmethod
     def _configure_litellm() -> None:
@@ -426,7 +470,7 @@ class TxtaiBackend:
             reranker = await asyncio.to_thread(
                 lambda: Similarity(path=self._reranker_model, crossencode=True)
             )
-            async with self._get_lock():
+            async with self._exclusive():
                 self._reranker = reranker
             logger.info("Reranker initialized: %s", self._reranker_model)
         except Exception:
@@ -435,7 +479,7 @@ class TxtaiBackend:
                 self._reranker_model,
                 exc_info=True,
             )
-            async with self._get_lock():
+            async with self._exclusive():
                 self._reranker = None
 
     async def shutdown(self) -> None:
@@ -445,7 +489,7 @@ class TxtaiBackend:
             with contextlib.suppress(asyncio.CancelledError):
                 await self._reranker_task
         self._reranker_task = None
-        async with self._get_lock():
+        async with self._exclusive():
             self._reranker = None
             if self._embeddings is not None:
                 await asyncio.to_thread(self._save)
@@ -502,7 +546,7 @@ class TxtaiBackend:
 
         stamped = _stamp_zone_id(documents, zone_id)
         rows = [(doc["id"], doc, None) for doc in stamped]
-        async with self._get_lock():
+        async with self._exclusive():
             if not self._embeddings:
                 return 0
             try:
@@ -567,7 +611,7 @@ class TxtaiBackend:
         stamped = _stamp_zone_id(documents, zone_id)
         rows = [(doc["id"], doc, None) for doc in stamped]
 
-        async with self._get_lock():
+        async with self._exclusive():
             if not self._embeddings:
                 return 0
             for attempt in range(2):
@@ -685,7 +729,7 @@ class TxtaiBackend:
             return 0
         await self.startup()
 
-        async with self._get_lock():
+        async with self._exclusive():
             if not self._embeddings:
                 return 0
             try:
@@ -746,7 +790,7 @@ class TxtaiBackend:
         # Concurrent search() and upsert()/index() calls would touch the same
         # mutable DB session from different threads, causing PendingRollback
         # errors and inconsistent results.
-        async with self._get_lock():
+        async with self._exclusive():
             if not self._embeddings:
                 return []
             raw: list[dict[str, Any]] = await asyncio.to_thread(self._embeddings.search, sql)
@@ -814,7 +858,7 @@ class TxtaiBackend:
         # across search and write paths, so concurrent batchsearch + upsert
         # corrupts the session (InFailedSqlTransaction / PendingRollback).
         try:
-            async with self._get_lock():
+            async with self._exclusive():
                 if not self._embeddings:
                     return [[] for _ in queries]
                 raw_results = await asyncio.to_thread(self._embeddings.batchsearch, sqls)
@@ -858,7 +902,7 @@ class TxtaiBackend:
             return results[:limit]
 
         # txtai Similarity returns [(index, score), ...] sorted by score desc
-        async with self._get_lock():
+        async with self._exclusive():
             if not self._reranker:
                 return results[:limit]
             try:
@@ -905,7 +949,7 @@ class TxtaiBackend:
         # Build SQL with zone_id + optional path filter (same as regular search)
         sql = _build_search_sql(query, zone_id=zone_id, path_filter=path_filter, limit=limit)
 
-        async with self._get_lock():
+        async with self._exclusive():
             if not self._embeddings or not getattr(self._embeddings, "graph", None):
                 return []
             # txtai's Embeddings.search() uses graph as boost when graph is configured

--- a/src/nexus/bricks/search/txtai_backend.py
+++ b/src/nexus/bricks/search/txtai_backend.py
@@ -17,6 +17,7 @@ import asyncio
 import contextlib
 import logging
 import time
+import weakref
 from typing import Any, Protocol, cast, runtime_checkable
 
 from nexus.bricks.search.results import BaseSearchResult
@@ -143,18 +144,40 @@ class TxtaiBackend:
         self._reranker: Any = None
         self.last_rerank_ms: float = 0.0
         self._started = False
-        self._startup_lock = asyncio.Lock()
         self._startup_task: asyncio.Task[None] | None = None
         self._reranker_task: asyncio.Task[None] | None = None
         # Path for txtai config.json — needed for pgvector persistence.
         # txtai stores index metadata (dimensions, offset) in a local file
         # and reads it back on load() to reconnect to pgvector tables.
         self._config_path = data_path or "/app/data/.txtai-index"
-        # Serialise all access to _embeddings / _reranker across coroutines.
-        # faiss (used by txtai) is NOT thread-safe for concurrent search+write
-        # operations. Since asyncio.to_thread() dispatches to a thread pool,
-        # concurrent coroutines without this lock cause native segfaults.
-        self._lock = asyncio.Lock()
+        # Per-loop locks (Issue #3894). asyncio.Lock binds to the running loop
+        # on first acquire (Python 3.11+); a single instance reused across loops
+        # raises "bound to a different event loop" and never recovers. Keys are
+        # weak so locks GC with their loop.
+        self._locks: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock] = (
+            weakref.WeakKeyDictionary()
+        )
+        self._startup_locks: weakref.WeakKeyDictionary[asyncio.AbstractEventLoop, asyncio.Lock] = (
+            weakref.WeakKeyDictionary()
+        )
+
+    def _get_lock(self) -> asyncio.Lock:
+        # Serialises access to _embeddings / _reranker on the current loop.
+        # faiss (used by txtai) is NOT thread-safe for concurrent search+write,
+        # and asyncio.to_thread() dispatches to a thread pool, so concurrent
+        # coroutines on the same loop must be serialised here.
+        loop = asyncio.get_running_loop()
+        lock = self._locks.get(loop)
+        if lock is None:
+            lock = self._locks.setdefault(loop, asyncio.Lock())
+        return lock
+
+    def _get_startup_lock(self) -> asyncio.Lock:
+        loop = asyncio.get_running_loop()
+        lock = self._startup_locks.get(loop)
+        if lock is None:
+            lock = self._startup_locks.setdefault(loop, asyncio.Lock())
+        return lock
 
     async def startup(self) -> None:
         """Initialize txtai resources once."""
@@ -163,7 +186,7 @@ class TxtaiBackend:
                 self._started = True
             return
 
-        async with self._startup_lock:
+        async with self._get_startup_lock():
             if self._started:
                 return
             if self._startup_task is None or self._startup_task.done():
@@ -403,7 +426,7 @@ class TxtaiBackend:
             reranker = await asyncio.to_thread(
                 lambda: Similarity(path=self._reranker_model, crossencode=True)
             )
-            async with self._lock:
+            async with self._get_lock():
                 self._reranker = reranker
             logger.info("Reranker initialized: %s", self._reranker_model)
         except Exception:
@@ -412,7 +435,7 @@ class TxtaiBackend:
                 self._reranker_model,
                 exc_info=True,
             )
-            async with self._lock:
+            async with self._get_lock():
                 self._reranker = None
 
     async def shutdown(self) -> None:
@@ -422,7 +445,7 @@ class TxtaiBackend:
             with contextlib.suppress(asyncio.CancelledError):
                 await self._reranker_task
         self._reranker_task = None
-        async with self._lock:
+        async with self._get_lock():
             self._reranker = None
             if self._embeddings is not None:
                 await asyncio.to_thread(self._save)
@@ -479,7 +502,7 @@ class TxtaiBackend:
 
         stamped = _stamp_zone_id(documents, zone_id)
         rows = [(doc["id"], doc, None) for doc in stamped]
-        async with self._lock:
+        async with self._get_lock():
             if not self._embeddings:
                 return 0
             try:
@@ -544,7 +567,7 @@ class TxtaiBackend:
         stamped = _stamp_zone_id(documents, zone_id)
         rows = [(doc["id"], doc, None) for doc in stamped]
 
-        async with self._lock:
+        async with self._get_lock():
             if not self._embeddings:
                 return 0
             for attempt in range(2):
@@ -662,7 +685,7 @@ class TxtaiBackend:
             return 0
         await self.startup()
 
-        async with self._lock:
+        async with self._get_lock():
             if not self._embeddings:
                 return 0
             try:
@@ -723,7 +746,7 @@ class TxtaiBackend:
         # Concurrent search() and upsert()/index() calls would touch the same
         # mutable DB session from different threads, causing PendingRollback
         # errors and inconsistent results.
-        async with self._lock:
+        async with self._get_lock():
             if not self._embeddings:
                 return []
             raw: list[dict[str, Any]] = await asyncio.to_thread(self._embeddings.search, sql)
@@ -791,7 +814,7 @@ class TxtaiBackend:
         # across search and write paths, so concurrent batchsearch + upsert
         # corrupts the session (InFailedSqlTransaction / PendingRollback).
         try:
-            async with self._lock:
+            async with self._get_lock():
                 if not self._embeddings:
                     return [[] for _ in queries]
                 raw_results = await asyncio.to_thread(self._embeddings.batchsearch, sqls)
@@ -835,7 +858,7 @@ class TxtaiBackend:
             return results[:limit]
 
         # txtai Similarity returns [(index, score), ...] sorted by score desc
-        async with self._lock:
+        async with self._get_lock():
             if not self._reranker:
                 return results[:limit]
             try:
@@ -882,7 +905,7 @@ class TxtaiBackend:
         # Build SQL with zone_id + optional path filter (same as regular search)
         sql = _build_search_sql(query, zone_id=zone_id, path_filter=path_filter, limit=limit)
 
-        async with self._lock:
+        async with self._get_lock():
             if not self._embeddings or not getattr(self._embeddings, "graph", None):
                 return []
             # txtai's Embeddings.search() uses graph as boost when graph is configured

--- a/src/nexus/bricks/search/txtai_backend.py
+++ b/src/nexus/bricks/search/txtai_backend.py
@@ -167,10 +167,12 @@ class TxtaiBackend:
             weakref.WeakKeyDictionary()
         )
         self._native_lock = threading.Lock()
-        # Startup gate — only one loop runs _startup_impl; others poll
-        # ``_started``. Plain threading.Lock so it is loop-agnostic.
+        # Startup gate — only one loop runs _startup_impl; others wait on
+        # ``_startup_done`` (an Event so we wake on either success OR error).
         self._startup_native_lock = threading.Lock()
         self._startup_running = False
+        self._startup_done = threading.Event()
+        self._startup_error: BaseException | None = None
 
     def _get_lock(self) -> asyncio.Lock:
         # Same-loop coroutine fairness layer; cross-loop exclusion is provided
@@ -196,17 +198,28 @@ class TxtaiBackend:
         without spawning a worker thread per attempt.
         """
         async with self._get_lock():
-            await asyncio.to_thread(self._native_lock.acquire)
+            # Cancellation-safe acquire (round 2 review): poll without parking
+            # a default-executor worker thread. If this coroutine is cancelled
+            # mid-poll we never hold the lock, so there is nothing to leak,
+            # and we never starve native-section holders by saturating the
+            # threadpool with waiters.
+            while not self._native_lock.acquire(blocking=False):
+                await asyncio.sleep(0.005)
             try:
                 yield
             finally:
                 self._native_lock.release()
 
     async def startup(self) -> None:
-        """Initialize txtai resources once across any number of event loops."""
-        if self._started or self._embeddings is not None:
-            if self._embeddings is not None:
-                self._started = True
+        """Initialize txtai resources once across any number of event loops.
+
+        Readiness is signalled solely by ``_started`` — never by
+        ``_embeddings is not None``. ``_startup_impl`` assigns ``_embeddings``
+        before downstream steps such as ``_sync_offset_from_db``, so treating
+        the embeddings handle as readiness would let other loops issue
+        upserts/searches against a half-initialised backend.
+        """
+        if self._started:
             return
 
         # Decide which loop owns initialisation. The threading.Lock makes this
@@ -219,20 +232,37 @@ class TxtaiBackend:
                 return
             if not self._startup_running:
                 self._startup_running = True
+                self._startup_done.clear()
+                self._startup_error = None
                 should_init = True
 
         if should_init:
             try:
                 await self._startup_impl()
+            except BaseException as exc:
+                with self._startup_native_lock:
+                    self._startup_error = exc
+                raise
             finally:
+                # Always wake waiters, success or failure, so they can
+                # re-raise the stored error or retry. Without this, a crashed
+                # owner would leave every other loop polling forever.
                 with self._startup_native_lock:
                     self._startup_running = False
+                self._startup_done.set()
         else:
-            # Another loop owns init; poll until it flips ``_started``. Polling
-            # is intentionally simple — there is no cross-loop async primitive
-            # we can wait on safely.
-            while not self._started:
+            # Another loop owns init. Poll the Event so we wake on either
+            # success or failure rather than spinning on ``_started``.
+            while not self._startup_done.is_set():
                 await asyncio.sleep(0.05)
+            if self._startup_error is not None:
+                raise self._startup_error
+            if not self._started:
+                # Owner finished without exception but did not flip _started
+                # (e.g. _startup_impl returned early for a missing dependency).
+                # The cleanest behaviour for the caller is to surface this so
+                # they can fall back to non-search paths.
+                raise RuntimeError("txtai backend startup did not complete")
 
     def kickoff_startup(self) -> None:
         """Begin backend startup in the background without blocking app readiness.
@@ -240,11 +270,9 @@ class TxtaiBackend:
         Spawns a task on the current loop. The new ``startup`` flow uses a
         threading.Lock gate so concurrent kickoffs from different loops cannot
         run ``_startup_impl`` more than once — the duplicate callers will
-        observe ``_startup_running`` and poll for completion instead.
+        observe ``_startup_running`` and wait on ``_startup_done`` instead.
         """
-        if self._started or self._embeddings is not None:
-            if self._embeddings is not None:
-                self._started = True
+        if self._started:
             return
         asyncio.create_task(self.startup())
 

--- a/src/nexus/bricks/search/txtai_backend.py
+++ b/src/nexus/bricks/search/txtai_backend.py
@@ -167,12 +167,15 @@ class TxtaiBackend:
             weakref.WeakKeyDictionary()
         )
         self._native_lock = threading.Lock()
-        # Startup gate — only one loop runs _startup_impl; others wait on
-        # ``_startup_done`` (an Event so we wake on either success OR error).
+        # Startup gate. Each call to ``startup()`` that observes
+        # ``_startup_running == False`` claims the next *generation*; all
+        # state is keyed by that generation so a later retry cannot clobber
+        # the completion signal that earlier waiters are still parked on.
         self._startup_native_lock = threading.Lock()
         self._startup_running = False
-        self._startup_done = threading.Event()
-        self._startup_error: BaseException | None = None
+        self._startup_generation = 0
+        self._startup_events: dict[int, threading.Event] = {}
+        self._startup_errors: dict[int, BaseException | None] = {}
 
     def _get_lock(self) -> asyncio.Lock:
         # Same-loop coroutine fairness layer; cross-loop exclusion is provided
@@ -190,25 +193,34 @@ class TxtaiBackend:
 
     @contextlib.asynccontextmanager
     async def _exclusive(self) -> AsyncIterator[None]:
-        """Take the per-loop async lock + the cross-loop native lock.
+        """Per-loop coroutine fairness only.
 
-        Replaces the original ``async with self._lock:`` contract. The native
-        section serialises faiss/SQLAlchemy work across every event loop in
-        the process; the per-loop async lock keeps same-loop coroutines fair
-        without spawning a worker thread per attempt.
+        Cross-loop mutual exclusion lives inside ``_run_native``: the
+        threading.Lock there is taken *inside* the worker thread so a cancelled
+        asyncio caller cannot release it while the worker is still in the
+        native section (round 3 review feedback). Multi-step bodies that need
+        cross-loop atomicity must batch their work into a single ``_run_native``
+        callable; back-to-back ``_run_native`` calls within one ``_exclusive``
+        block are atomic on the same loop but can be interleaved across loops.
         """
         async with self._get_lock():
-            # Cancellation-safe acquire (round 2 review): poll without parking
-            # a default-executor worker thread. If this coroutine is cancelled
-            # mid-poll we never hold the lock, so there is nothing to leak,
-            # and we never starve native-section holders by saturating the
-            # threadpool with waiters.
-            while not self._native_lock.acquire(blocking=False):
-                await asyncio.sleep(0.005)
-            try:
-                yield
-            finally:
-                self._native_lock.release()
+            yield
+
+    async def _run_native(self, fn: Any, /, *args: Any, **kwargs: Any) -> Any:
+        """Execute ``fn`` in a worker thread under the cross-loop native lock.
+
+        The lock is acquired and released *inside* the worker thread, so a
+        cancelled asyncio caller cannot leave the lock held with no owner —
+        the worker simply finishes ``fn`` and releases on its way out.
+        Subsequent ``_run_native`` calls block on lock acquisition inside their
+        own worker thread until the previous ``fn`` completes.
+        """
+
+        def _inner() -> Any:
+            with self._native_lock:
+                return fn(*args, **kwargs)
+
+        return await asyncio.to_thread(_inner)
 
     async def startup(self) -> None:
         """Initialize txtai resources once across any number of event loops.
@@ -222,46 +234,57 @@ class TxtaiBackend:
         if self._started:
             return
 
-        # Decide which loop owns initialisation. The threading.Lock makes this
-        # decision atomic across loops; we never hand a Task created on one
-        # loop to a coroutine running on another (which would raise
-        # "Task ... attached to a different loop").
+        # Claim the next generation. Each generation owns its own Event +
+        # error slot so a retry that follows a failure cannot stomp on the
+        # signal that earlier waiters are blocked on.
         should_init = False
+        my_gen: int
+        my_event: threading.Event
         with self._startup_native_lock:
             if self._started:
                 return
             if not self._startup_running:
                 self._startup_running = True
-                self._startup_done.clear()
-                self._startup_error = None
+                self._startup_generation += 1
+                self._startup_events[self._startup_generation] = threading.Event()
+                self._startup_errors[self._startup_generation] = None
                 should_init = True
+            my_gen = self._startup_generation
+            my_event = self._startup_events[my_gen]
 
         if should_init:
             try:
                 await self._startup_impl()
             except BaseException as exc:
                 with self._startup_native_lock:
-                    self._startup_error = exc
+                    self._startup_errors[my_gen] = exc
                 raise
             finally:
-                # Always wake waiters, success or failure, so they can
-                # re-raise the stored error or retry. Without this, a crashed
-                # owner would leave every other loop polling forever.
+                # Set the per-generation event under the same mutex that
+                # controls ``_startup_running`` so a retry cannot enter and
+                # clear the slot before this set() runs.
                 with self._startup_native_lock:
                     self._startup_running = False
-                self._startup_done.set()
+                    my_event.set()
         else:
-            # Another loop owns init. Poll the Event so we wake on either
-            # success or failure rather than spinning on ``_started``.
-            while not self._startup_done.is_set():
+            while not my_event.is_set():
                 await asyncio.sleep(0.05)
-            if self._startup_error is not None:
-                raise self._startup_error
-            if not self._started:
-                # Owner finished without exception but did not flip _started
-                # (e.g. _startup_impl returned early for a missing dependency).
-                # The cleanest behaviour for the caller is to surface this so
-                # they can fall back to non-search paths.
+            with self._startup_native_lock:
+                error = self._startup_errors.get(my_gen)
+                started = self._started
+                # Trim the per-generation slots — the result has been observed
+                # by every waiter that holds ``my_event``. Use ``pop`` with a
+                # default so concurrent waiters are tolerated.
+                if my_event.is_set():
+                    self._startup_errors.pop(my_gen, None)
+                    self._startup_events.pop(my_gen, None)
+            if error is not None:
+                raise error
+            if not started:
+                # Owner returned without exception but did not flip _started
+                # (e.g. _startup_impl took the degraded path for a missing
+                # dependency). Surface as RuntimeError so callers can fall
+                # back to non-search paths.
                 raise RuntimeError("txtai backend startup did not complete")
 
     def kickoff_startup(self) -> None:
@@ -520,8 +543,8 @@ class TxtaiBackend:
         async with self._exclusive():
             self._reranker = None
             if self._embeddings is not None:
-                await asyncio.to_thread(self._save)
-                await asyncio.to_thread(self._embeddings.close)
+                await self._run_native(self._save)
+                await self._run_native(self._embeddings.close)
                 self._embeddings = None
             self._started = False
         logger.info("txtai backend shut down")
@@ -578,11 +601,11 @@ class TxtaiBackend:
             if not self._embeddings:
                 return 0
             try:
-                await asyncio.to_thread(self._embeddings.index, rows)
-                await asyncio.to_thread(self._save)
+                await self._run_native(self._embeddings.index, rows)
+                await self._run_native(self._save)
             except Exception:
                 logger.error("index failed, rolling back sessions", exc_info=True)
-                await asyncio.to_thread(self._rollback_db_sessions)
+                await self._run_native(self._rollback_db_sessions)
                 raise
         return len(rows)
 
@@ -669,13 +692,13 @@ class TxtaiBackend:
                                 "rebuilding (would drop table)"
                             )
                             self._embeddings.load(self._config_path)
-                            await asyncio.to_thread(self._embeddings.upsert, rows)
+                            await self._run_native(self._embeddings.upsert, rows)
                         else:
-                            await asyncio.to_thread(self._embeddings.index, rows)
+                            await self._run_native(self._embeddings.index, rows)
                     else:
                         # Incremental: append to existing index (no table drop)
-                        await asyncio.to_thread(self._embeddings.upsert, rows)
-                    await asyncio.to_thread(self._save)
+                        await self._run_native(self._embeddings.upsert, rows)
+                    await self._run_native(self._save)
                     return len(rows)
                 except Exception:
                     if attempt == 0:
@@ -683,8 +706,8 @@ class TxtaiBackend:
                             "upsert failed, rolling back and syncing offset",
                             exc_info=True,
                         )
-                        await asyncio.to_thread(self._rollback_ann_session)
-                        await asyncio.to_thread(self._sync_offset_from_db)
+                        await self._run_native(self._rollback_ann_session)
+                        await self._run_native(self._sync_offset_from_db)
                     else:
                         raise
         return 0
@@ -761,8 +784,8 @@ class TxtaiBackend:
             if not self._embeddings:
                 return 0
             try:
-                await asyncio.to_thread(self._embeddings.delete, ids)
-                await asyncio.to_thread(self._save)
+                await self._run_native(self._embeddings.delete, ids)
+                await self._run_native(self._save)
             except Exception:
                 logger.error(
                     "txtai delete failed for %d ids; rolling back, "
@@ -770,13 +793,13 @@ class TxtaiBackend:
                     len(ids),
                     exc_info=True,
                 )
-                await asyncio.to_thread(self._rollback_db_sessions)
+                await self._run_native(self._rollback_db_sessions)
                 # Restore the in-memory state from durable storage so
                 # subsequent searches don't see a phantom delete that
                 # never persisted, AND so the next successful _save()
                 # cannot accidentally durable-ize the failed delete.
                 try:
-                    await asyncio.to_thread(self._embeddings.load, self._config_path)
+                    await self._run_native(self._embeddings.load, self._config_path)
                 except Exception:
                     # If reload itself fails, the only safe move is to
                     # mark the embeddings unusable so the worker stops
@@ -821,7 +844,7 @@ class TxtaiBackend:
         async with self._exclusive():
             if not self._embeddings:
                 return []
-            raw: list[dict[str, Any]] = await asyncio.to_thread(self._embeddings.search, sql)
+            raw: list[dict[str, Any]] = await self._run_native(self._embeddings.search, sql)
 
         results: list[BaseSearchResult] = []
         for r in raw:
@@ -889,10 +912,10 @@ class TxtaiBackend:
             async with self._exclusive():
                 if not self._embeddings:
                     return [[] for _ in queries]
-                raw_results = await asyncio.to_thread(self._embeddings.batchsearch, sqls)
+                raw_results = await self._run_native(self._embeddings.batchsearch, sqls)
         except Exception:
             logger.warning("batch_search failed, rolling back session", exc_info=True)
-            await asyncio.to_thread(self._rollback_db_sessions)
+            await self._run_native(self._rollback_db_sessions)
             return [[] for _ in queries]
 
         # Convert each query's raw results into BaseSearchResult lists
@@ -934,7 +957,7 @@ class TxtaiBackend:
             if not self._reranker:
                 return results[:limit]
             try:
-                scored: list[tuple[int, float]] = await asyncio.to_thread(
+                scored: list[tuple[int, float]] = await self._run_native(
                     self._reranker,
                     query,
                     texts,
@@ -981,7 +1004,7 @@ class TxtaiBackend:
             if not self._embeddings or not getattr(self._embeddings, "graph", None):
                 return []
             # txtai's Embeddings.search() uses graph as boost when graph is configured
-            raw: list[dict[str, Any]] = await asyncio.to_thread(self._embeddings.search, sql)
+            raw: list[dict[str, Any]] = await self._run_native(self._embeddings.search, sql)
 
         results: list[BaseSearchResult] = []
         for r in raw:

--- a/tests/integration/bricks/search/test_txtai_backend.py
+++ b/tests/integration/bricks/search/test_txtai_backend.py
@@ -527,8 +527,12 @@ class TestTxtaiBackendConcurrency:
         assert seen[0] is not seen[1]
 
     def test_native_section_serialises_across_loops(self) -> None:
-        """Issue #3894 review: cross-loop work must not overlap inside the
-        native section, otherwise faiss/SQLAlchemy state can race.
+        """Issue #3894 review: cross-loop native work must not overlap.
+
+        With the round-3 design the cross-loop lock lives inside the worker
+        thread that ``_run_native`` dispatches onto, so this test exercises
+        ``_run_native`` (the new public surface for native execution) rather
+        than ``_exclusive`` (which is now per-loop fairness only).
         """
         import threading
         import time as _time
@@ -539,17 +543,19 @@ class TestTxtaiBackendConcurrency:
         active_lock = threading.Lock()
         errors: list[BaseException] = []
 
-        async def critical() -> None:
+        def native_op() -> None:
             nonlocal active, max_active
-            async with backend._exclusive():
-                with active_lock:
-                    active += 1
-                    if active > max_active:
-                        max_active = active
-                # Force an interleaving window.
-                await asyncio.sleep(0.05)
-                with active_lock:
-                    active -= 1
+            with active_lock:
+                active += 1
+                if active > max_active:
+                    max_active = active
+            # Hold long enough that an overlapping caller would be observable.
+            _time.sleep(0.05)
+            with active_lock:
+                active -= 1
+
+        async def critical() -> None:
+            await backend._run_native(native_op)
 
         def runner() -> None:
             try:
@@ -567,8 +573,67 @@ class TestTxtaiBackendConcurrency:
 
         assert errors == [], f"native section raised: {errors!r}"
         assert max_active == 1, f"cross-loop critical sections overlapped: max={max_active}"
-        # Four sleeps of 0.05s, fully serialised, must take at least ~0.18s.
+        # Four 0.05s native ops, fully serialised, must take at least ~0.18s.
         assert elapsed >= 0.18, f"sections did not serialise: elapsed={elapsed:.3f}s"
+
+    def test_run_native_cancellation_holds_until_worker_returns(self) -> None:
+        """Issue #3894 round 3: cancelling the awaiting coroutine must NOT let
+        a second native op enter the section while the first worker thread is
+        still executing ``fn``. The lock is acquired/released inside the worker
+        so cancellation cannot strand it.
+        """
+        import threading
+        import time as _time
+
+        backend = TxtaiBackend()
+        running = threading.Event()
+        finish = threading.Event()
+        second_started_at: list[float] = []
+        second_observed_first_running: list[bool] = []
+
+        def slow_fn() -> None:
+            running.set()
+            finish.wait(timeout=5)
+
+        def fast_fn() -> None:
+            second_started_at.append(_time.perf_counter())
+            # If serialisation is intact, this only runs after slow_fn returns.
+            second_observed_first_running.append(running.is_set() and not finish.is_set())
+
+        async def cancelled_caller() -> None:
+            await backend._run_native(slow_fn)
+
+        async def driver() -> None:
+            t = asyncio.create_task(cancelled_caller())
+            # Give the worker a chance to acquire the lock and start slow_fn.
+            await asyncio.to_thread(running.wait, 5)
+            assert running.is_set()
+            t.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await t
+
+        import contextlib
+
+        # Caller path: cancel the slow operation while it is mid-flight.
+        async def submit_second_after_cancel() -> None:
+            await driver()
+            # The slow worker is still holding the native lock; submit a second
+            # native call and verify it is serialised behind the first.
+            second = asyncio.create_task(backend._run_native(fast_fn))
+            # Sleep briefly to let the second op queue up. It should NOT run
+            # until ``finish`` is set, so the time delta will reveal overlap.
+            await asyncio.sleep(0.05)
+            assert not second.done(), "second native op ran while first still in flight"
+            # Release the slow op, then wait for the second to finish.
+            finish.set()
+            await second
+
+        asyncio.run(submit_second_after_cancel())
+        assert second_started_at, "fast_fn never ran"
+        # If the second op overlapped with the first, this would be True.
+        assert second_observed_first_running == [False], (
+            f"second op overlapped first: {second_observed_first_running!r}"
+        )
 
     def test_startup_owner_failure_propagates_to_waiters(self) -> None:
         """Issue #3894 round 2: if the owning loop's startup raises, every
@@ -623,50 +688,95 @@ class TestTxtaiBackendConcurrency:
         # to acquire ownership and re-attempt, but neither may hang).
         assert all(isinstance(e, RuntimeError) for e in waiter_errors)
 
-    def test_exclusive_cancellation_does_not_leak_native_lock(self) -> None:
-        """Issue #3894 round 2: cancelling a coroutine while it is waiting on
-        the native lock must not leave the lock held by an absent owner.
+    def test_startup_retry_after_failure_isolates_generations(self) -> None:
+        """Issue #3894 round 3: a retry that follows a startup failure must
+        not stomp on the completion signal that earlier waiters are blocked
+        on. Waiters from generation N see generation N's error; later
+        generations have their own per-generation Event.
         """
         import threading
 
         backend = TxtaiBackend()
+        first_boom = RuntimeError("gen 1 boom")
+        second_boom = RuntimeError("gen 2 boom")
+        gen2_can_start = threading.Event()
 
-        # Pre-acquire the native lock from a worker thread so the next coroutine
-        # is forced to poll. Release it after the coroutine is cancelled.
-        held = threading.Event()
-        release = threading.Event()
+        call_count = 0
+        call_count_lock = threading.Lock()
 
-        def holder() -> None:
-            backend._native_lock.acquire()
-            held.set()
-            release.wait(timeout=5)
-            backend._native_lock.release()
+        async def impl() -> None:
+            nonlocal call_count
+            with call_count_lock:
+                call_count += 1
+                attempt = call_count
+            if attempt == 1:
+                # Hold long enough that the generation-1 waiter is parked and
+                # the retry can start during this window.
+                await asyncio.sleep(0.1)
+                raise first_boom
+            # Generation 2: wait for the test to release us, then fail with a
+            # distinct error. If the implementation conflates generations,
+            # generation-1 waiters would observe second_boom.
+            await asyncio.to_thread(gen2_can_start.wait, 5)
+            raise second_boom
 
-        async def waiter() -> None:
-            async with backend._exclusive():
-                pass  # never reaches here while holder is active
+        backend._startup_impl = impl
 
-        async def driver() -> None:
-            t = asyncio.create_task(waiter())
-            await asyncio.sleep(0.02)
-            t.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
-                await t
+        gen1_owner_err: list[BaseException] = []
+        gen1_waiter_err: list[BaseException] = []
+        gen2_owner_err: list[BaseException] = []
 
-        import contextlib
+        def gen1_owner() -> None:
+            try:
+                asyncio.run(backend.startup())
+            except BaseException as exc:
+                gen1_owner_err.append(exc)
 
-        h = threading.Thread(target=holder)
-        h.start()
-        held.wait(timeout=5)
-        try:
-            asyncio.run(driver())
-        finally:
-            release.set()
-            h.join(timeout=5)
+        def gen1_waiter() -> None:
+            # Enter while gen1 owner is still inside _startup_impl.
+            import time as _t
 
-        # After cancellation + release, the native lock must be free.
-        assert backend._native_lock.acquire(blocking=False), "native lock leaked after cancellation"
-        backend._native_lock.release()
+            _t.sleep(0.005)
+            try:
+                asyncio.run(backend.startup())
+            except BaseException as exc:
+                gen1_waiter_err.append(exc)
+
+        def gen2_owner() -> None:
+            # Enter AFTER gen1 owner has finished raising — i.e. after gen1
+            # waiter has unblocked. We deliberately race start of gen2 with
+            # the tail of gen1 to exercise the generation-isolation contract.
+            import time as _t
+
+            _t.sleep(0.15)
+            try:
+                asyncio.run(backend.startup())
+            except BaseException as exc:
+                gen2_owner_err.append(exc)
+
+        threads = [
+            threading.Thread(target=gen1_owner),
+            threading.Thread(target=gen1_waiter),
+            threading.Thread(target=gen2_owner),
+        ]
+        for t in threads:
+            t.start()
+        # Let gen2 actually fail rather than block forever.
+        gen2_can_start.set()
+        for t in threads:
+            t.join(timeout=10)
+            assert not t.is_alive(), "thread deadlocked"
+
+        # Gen1 owner must see gen1's error.
+        assert gen1_owner_err and gen1_owner_err[0] is first_boom
+        # Gen1 waiter must see gen1's error too (NOT gen2's error). This is
+        # the contract the per-generation Event protects.
+        assert gen1_waiter_err
+        assert gen1_waiter_err[0] is first_boom, (
+            f"gen1 waiter saw wrong error: {gen1_waiter_err[0]!r}"
+        )
+        # Gen2 owner sees its own error.
+        assert gen2_owner_err and gen2_owner_err[0] is second_boom
 
     def test_startup_runs_once_across_loops(self) -> None:
         """Issue #3894 review: only one loop should run _startup_impl, even when

--- a/tests/integration/bricks/search/test_txtai_backend.py
+++ b/tests/integration/bricks/search/test_txtai_backend.py
@@ -570,6 +570,104 @@ class TestTxtaiBackendConcurrency:
         # Four sleeps of 0.05s, fully serialised, must take at least ~0.18s.
         assert elapsed >= 0.18, f"sections did not serialise: elapsed={elapsed:.3f}s"
 
+    def test_startup_owner_failure_propagates_to_waiters(self) -> None:
+        """Issue #3894 round 2: if the owning loop's startup raises, every
+        waiting loop must wake and re-raise the same error instead of polling
+        forever on ``_started``.
+        """
+        import threading
+
+        backend = TxtaiBackend()
+        boom = RuntimeError("startup boom")
+
+        async def failing_impl() -> None:
+            await asyncio.sleep(0.05)
+            raise boom
+
+        backend._startup_impl = failing_impl
+
+        owner_error: list[BaseException] = []
+        waiter_errors: list[BaseException] = []
+
+        def owner() -> None:
+            try:
+                asyncio.run(backend.startup())
+            except BaseException as exc:
+                owner_error.append(exc)
+
+        def waiter() -> None:
+            try:
+                # Give the owner time to enter _startup_running.
+                import time as _t
+
+                _t.sleep(0.005)
+                asyncio.run(backend.startup())
+            except BaseException as exc:
+                waiter_errors.append(exc)
+
+        t_owner = threading.Thread(target=owner)
+        t_waiter1 = threading.Thread(target=waiter)
+        t_waiter2 = threading.Thread(target=waiter)
+        t_owner.start()
+        t_waiter1.start()
+        t_waiter2.start()
+        t_owner.join(timeout=5)
+        t_waiter1.join(timeout=5)
+        t_waiter2.join(timeout=5)
+
+        assert not t_owner.is_alive(), "owner deadlocked"
+        assert not t_waiter1.is_alive(), "waiter 1 deadlocked"
+        assert not t_waiter2.is_alive(), "waiter 2 deadlocked"
+        assert owner_error and owner_error[0] is boom
+        # At least one waiter saw the same error (race: both might also race
+        # to acquire ownership and re-attempt, but neither may hang).
+        assert all(isinstance(e, RuntimeError) for e in waiter_errors)
+
+    def test_exclusive_cancellation_does_not_leak_native_lock(self) -> None:
+        """Issue #3894 round 2: cancelling a coroutine while it is waiting on
+        the native lock must not leave the lock held by an absent owner.
+        """
+        import threading
+
+        backend = TxtaiBackend()
+
+        # Pre-acquire the native lock from a worker thread so the next coroutine
+        # is forced to poll. Release it after the coroutine is cancelled.
+        held = threading.Event()
+        release = threading.Event()
+
+        def holder() -> None:
+            backend._native_lock.acquire()
+            held.set()
+            release.wait(timeout=5)
+            backend._native_lock.release()
+
+        async def waiter() -> None:
+            async with backend._exclusive():
+                pass  # never reaches here while holder is active
+
+        async def driver() -> None:
+            t = asyncio.create_task(waiter())
+            await asyncio.sleep(0.02)
+            t.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await t
+
+        import contextlib
+
+        h = threading.Thread(target=holder)
+        h.start()
+        held.wait(timeout=5)
+        try:
+            asyncio.run(driver())
+        finally:
+            release.set()
+            h.join(timeout=5)
+
+        # After cancellation + release, the native lock must be free.
+        assert backend._native_lock.acquire(blocking=False), "native lock leaked after cancellation"
+        backend._native_lock.release()
+
     def test_startup_runs_once_across_loops(self) -> None:
         """Issue #3894 review: only one loop should run _startup_impl, even when
         startup() is called concurrently from multiple loops.

--- a/tests/integration/bricks/search/test_txtai_backend.py
+++ b/tests/integration/bricks/search/test_txtai_backend.py
@@ -526,6 +526,88 @@ class TestTxtaiBackendConcurrency:
         assert len(seen) == 2
         assert seen[0] is not seen[1]
 
+    def test_native_section_serialises_across_loops(self) -> None:
+        """Issue #3894 review: cross-loop work must not overlap inside the
+        native section, otherwise faiss/SQLAlchemy state can race.
+        """
+        import threading
+        import time as _time
+
+        backend = TxtaiBackend()
+        active = 0
+        max_active = 0
+        active_lock = threading.Lock()
+        errors: list[BaseException] = []
+
+        async def critical() -> None:
+            nonlocal active, max_active
+            async with backend._exclusive():
+                with active_lock:
+                    active += 1
+                    if active > max_active:
+                        max_active = active
+                # Force an interleaving window.
+                await asyncio.sleep(0.05)
+                with active_lock:
+                    active -= 1
+
+        def runner() -> None:
+            try:
+                asyncio.run(critical())
+            except BaseException as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=runner) for _ in range(4)]
+        t0 = _time.perf_counter()
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+        elapsed = _time.perf_counter() - t0
+
+        assert errors == [], f"native section raised: {errors!r}"
+        assert max_active == 1, f"cross-loop critical sections overlapped: max={max_active}"
+        # Four sleeps of 0.05s, fully serialised, must take at least ~0.18s.
+        assert elapsed >= 0.18, f"sections did not serialise: elapsed={elapsed:.3f}s"
+
+    def test_startup_runs_once_across_loops(self) -> None:
+        """Issue #3894 review: only one loop should run _startup_impl, even when
+        startup() is called concurrently from multiple loops.
+        """
+        import threading
+
+        backend = TxtaiBackend()
+        impl_calls = 0
+        impl_lock = threading.Lock()
+        errors: list[BaseException] = []
+
+        async def fake_impl() -> None:
+            nonlocal impl_calls
+            with impl_lock:
+                impl_calls += 1
+            # Hold long enough for the other loop to enter startup() and see
+            # _startup_running.
+            await asyncio.sleep(0.1)
+            backend._started = True
+
+        backend._startup_impl = fake_impl
+
+        def runner() -> None:
+            try:
+                asyncio.run(backend.startup())
+            except BaseException as exc:
+                errors.append(exc)
+
+        threads = [threading.Thread(target=runner) for _ in range(3)]
+        for t in threads:
+            t.start()
+        for t in threads:
+            t.join()
+
+        assert errors == [], f"startup raised: {errors!r}"
+        assert impl_calls == 1, f"_startup_impl ran {impl_calls} times, expected 1"
+        assert backend._started is True
+
     @pytest.mark.asyncio
     async def test_search_during_shutdown_returns_empty(self) -> None:
         """search() must not dereference None if shutdown() clears _embeddings."""

--- a/tests/integration/bricks/search/test_txtai_backend.py
+++ b/tests/integration/bricks/search/test_txtai_backend.py
@@ -494,8 +494,37 @@ class TestTxtaiBackendConcurrency:
     @pytest.mark.asyncio
     async def test_lock_exists_on_backend(self) -> None:
         backend = TxtaiBackend()
-        assert hasattr(backend, "_lock")
-        assert isinstance(backend._lock, asyncio.Lock)
+        assert isinstance(backend._get_lock(), asyncio.Lock)
+        assert backend._get_lock() is backend._get_lock()
+
+    def test_lock_is_distinct_per_event_loop(self) -> None:
+        # Issue #3894: a single TxtaiBackend instance reused across event loops
+        # must not raise "bound to a different event loop" on lock acquire.
+        import threading
+
+        backend = TxtaiBackend()
+        seen: list[asyncio.Lock] = []
+        errors: list[BaseException] = []
+
+        async def acquire_once() -> None:
+            async with backend._get_lock():
+                seen.append(backend._get_lock())
+
+        def runner() -> None:
+            try:
+                asyncio.run(acquire_once())
+            except BaseException as exc:
+                errors.append(exc)
+
+        t1 = threading.Thread(target=runner)
+        t2 = threading.Thread(target=runner)
+        t1.start()
+        t2.start()
+        t1.join()
+        t2.join()
+        assert errors == [], f"acquire raised across loops: {errors!r}"
+        assert len(seen) == 2
+        assert seen[0] is not seen[1]
 
     @pytest.mark.asyncio
     async def test_search_during_shutdown_returns_empty(self) -> None:


### PR DESCRIPTION
## Summary

- Fixes #3894. `asyncio.Lock()` constructed in `TxtaiBackend.__init__` binds to the running loop on first acquire (Python 3.11+); when the backend instance is later touched from a different loop, every acquire raises `RuntimeError: ... is bound to a different event loop` and the daemon wedges until redeploy.
- Replaces the two single locks (`_lock`, `_startup_lock`) with `weakref.WeakKeyDictionary[loop, asyncio.Lock]` and looks them up lazily via `_get_lock()` / `_get_startup_lock()`. Per-loop entries auto-GC when the loop is collected. On-loop serialisation (faiss thread-safety) preserved.
- Adds a regression test that runs `asyncio.run` from two threads and asserts distinct lock instances per loop with no cross-loop `RuntimeError`.

## Test plan

- [x] `pytest tests/integration/bricks/search/test_txtai_backend.py -k test_lock` (`test_lock_exists_on_backend`, `test_lock_is_distinct_per_event_loop`) — both pass.
- [x] Manual repro: two threads with separate `asyncio.run()` get distinct `asyncio.Lock` instances; no `RuntimeError`.
- [ ] Run full search backend integration suite in CI to confirm no concurrency regressions on the active loop path.
- [ ] Soak test against the original repro (sequential `POST /api/v2/files/write` + `POST /api/v2/search/index` at ~4 req/s) to confirm 500s stop and the lock no longer wedges across reloads.