### PR TITLE
fix(#3900): dedupe hybrid search rows by id in txtai backend

### DIFF
--- a/src/nexus/bricks/search/txtai_backend.py
+++ b/src/nexus/bricks/search/txtai_backend.py
@@ -833,7 +833,10 @@ class TxtaiBackend:
 
         # Over-fetch when reranker is available so it has enough candidates.
         # 2x balances rerank quality vs CPU latency (~10ms per candidate).
-        fetch_limit = limit * 2 if self._reranker else limit
+        # Issue #3900: also over-fetch in hybrid mode where txtai's BM25 and
+        # dense scorers can each emit the same id, so a `limit`-row page can
+        # collapse to <limit unique results after dedupe.
+        fetch_limit = limit * 2 if (self._reranker or search_type == "hybrid") else limit
 
         sql = _build_search_sql(query, zone_id=zone_id, path_filter=path_filter, limit=fetch_limit)
         # Even with pgvector, we must serialize against writes because txtai
@@ -848,8 +851,8 @@ class TxtaiBackend:
 
         # Issue #3900: in hybrid mode, txtai concatenates BM25 and dense
         # rankings without dedup, so the same id can appear twice. Collapse
-        # by id, keeping the highest score and the row order it first
-        # appeared at.
+        # by id, keeping the highest score. The over-fetch above ensures we
+        # still have enough unique rows to fill the caller's limit.
         deduped: dict[str, dict[str, Any]] = {}
         for r in raw:
             key = str(r.get("id", "")) or f"{r.get('path', '')}:{r.get('text', '')}"
@@ -873,6 +876,10 @@ class TxtaiBackend:
                 result.keyword_score = score
                 result.vector_score = score
             results.append(result)
+
+        # Sort by score desc so the post-dedupe slice keeps the best rows
+        # when over-fetch returned more unique ids than the caller asked for.
+        results.sort(key=lambda r: r.score, reverse=True)
 
         # Cross-encoder reranking
         if self._reranker and results:
@@ -907,12 +914,20 @@ class TxtaiBackend:
 
         # Build SQL queries — txtai's batchsearch handles embedding internally
         # in one batch call to litellm (which calls OpenAI once with all texts)
+        # Issue #3900: hybrid mode emits the same id twice (BM25 + dense), so
+        # over-fetch and dedupe-then-slice to honour the caller's limit.
         sqls = []
+        per_query_limits: list[int] = []
         for q_spec in queries:
             q_text = q_spec.get("q", "")
             limit = int(q_spec.get("limit", 10))
+            per_query_limits.append(limit)
             path_filter = q_spec.get("path")
-            sql = _build_search_sql(q_text, zone_id=zone_id, path_filter=path_filter, limit=limit)
+            q_type = str(q_spec.get("type", "hybrid"))
+            fetch_limit = limit * 2 if q_type == "hybrid" else limit
+            sql = _build_search_sql(
+                q_text, zone_id=zone_id, path_filter=path_filter, limit=fetch_limit
+            )
             sqls.append(sql)
 
         # txtai.batchsearch() embeds all queries in ONE API call internally.
@@ -931,9 +946,10 @@ class TxtaiBackend:
 
         # Convert each query's raw results into BaseSearchResult lists.
         # Issue #3900: dedupe by id so hybrid BM25+dense rows don't surface
-        # the same chunk twice.
+        # the same chunk twice; sort by score and slice to the per-query
+        # limit so over-fetched candidates are trimmed to the caller's ask.
         all_results: list[list[BaseSearchResult]] = []
-        for raw in raw_results:
+        for raw, q_limit in zip(raw_results, per_query_limits, strict=True):
             deduped: dict[str, dict[str, Any]] = {}
             for r in raw:
                 if not isinstance(r, dict):
@@ -956,7 +972,8 @@ class TxtaiBackend:
                         vector_score=score,
                     )
                 )
-            all_results.append(results)
+            results.sort(key=lambda r: r.score, reverse=True)
+            all_results.append(results[:q_limit])
 
         return all_results
 
@@ -1018,8 +1035,11 @@ class TxtaiBackend:
         """
         await self.startup()
 
-        # Build SQL with zone_id + optional path filter (same as regular search)
-        sql = _build_search_sql(query, zone_id=zone_id, path_filter=path_filter, limit=limit)
+        # Build SQL with zone_id + optional path filter (same as regular search).
+        # Issue #3900: graph mode runs on top of hybrid retrieval, so the same
+        # id can appear twice; over-fetch and dedupe-then-slice to honour limit.
+        fetch_limit = limit * 2
+        sql = _build_search_sql(query, zone_id=zone_id, path_filter=path_filter, limit=fetch_limit)
 
         async with self._exclusive():
             if not self._embeddings or not getattr(self._embeddings, "graph", None):
@@ -1048,7 +1068,8 @@ class TxtaiBackend:
                     vector_score=score,
                 )
             )
-        return results
+        results.sort(key=lambda r: r.score, reverse=True)
+        return results[:limit]
 
     async def get_entity_neighbors(
         self,

--- a/src/nexus/bricks/search/txtai_backend.py
+++ b/src/nexus/bricks/search/txtai_backend.py
@@ -846,8 +846,19 @@ class TxtaiBackend:
                 return []
             raw: list[dict[str, Any]] = await self._run_native(self._embeddings.search, sql)
 
-        results: list[BaseSearchResult] = []
+        # Issue #3900: in hybrid mode, txtai concatenates BM25 and dense
+        # rankings without dedup, so the same id can appear twice. Collapse
+        # by id, keeping the highest score and the row order it first
+        # appeared at.
+        deduped: dict[str, dict[str, Any]] = {}
         for r in raw:
+            key = str(r.get("id", "")) or f"{r.get('path', '')}:{r.get('text', '')}"
+            existing = deduped.get(key)
+            if existing is None or float(r.get("score", 0.0)) > float(existing.get("score", 0.0)):
+                deduped[key] = r
+
+        results: list[BaseSearchResult] = []
+        for r in deduped.values():
             score = float(r.get("score", 0.0))
             result = BaseSearchResult(
                 path=r.get("path", ""),
@@ -918,13 +929,23 @@ class TxtaiBackend:
             await self._run_native(self._rollback_db_sessions)
             return [[] for _ in queries]
 
-        # Convert each query's raw results into BaseSearchResult lists
+        # Convert each query's raw results into BaseSearchResult lists.
+        # Issue #3900: dedupe by id so hybrid BM25+dense rows don't surface
+        # the same chunk twice.
         all_results: list[list[BaseSearchResult]] = []
         for raw in raw_results:
-            results: list[BaseSearchResult] = []
+            deduped: dict[str, dict[str, Any]] = {}
             for r in raw:
                 if not isinstance(r, dict):
                     continue
+                key = str(r.get("id", "")) or f"{r.get('path', '')}:{r.get('text', '')}"
+                existing = deduped.get(key)
+                if existing is None or float(r.get("score", 0.0)) > float(
+                    existing.get("score", 0.0)
+                ):
+                    deduped[key] = r
+            results: list[BaseSearchResult] = []
+            for r in deduped.values():
                 score = float(r.get("score", 0.0))
                 results.append(
                     BaseSearchResult(
@@ -1006,8 +1027,17 @@ class TxtaiBackend:
             # txtai's Embeddings.search() uses graph as boost when graph is configured
             raw: list[dict[str, Any]] = await self._run_native(self._embeddings.search, sql)
 
-        results: list[BaseSearchResult] = []
+        # Issue #3900: dedupe by id so hybrid BM25+dense rows don't surface
+        # the same chunk twice in graph-augmented mode either.
+        deduped: dict[str, dict[str, Any]] = {}
         for r in raw:
+            key = str(r.get("id", "")) or f"{r.get('path', '')}:{r.get('text', '')}"
+            existing = deduped.get(key)
+            if existing is None or float(r.get("score", 0.0)) > float(existing.get("score", 0.0)):
+                deduped[key] = r
+
+        results: list[BaseSearchResult] = []
+        for r in deduped.values():
             score = float(r.get("score", 0.0))
             results.append(
                 BaseSearchResult(

--- a/tests/integration/bricks/search/test_txtai_backend.py
+++ b/tests/integration/bricks/search/test_txtai_backend.py
@@ -297,7 +297,9 @@ class TestTxtaiBackendSearch:
     async def test_search_builds_sql_with_zone_id(self) -> None:
         backend, mock_emb = self._make_backend_with_mock()
         mock_emb.search.return_value = []
-        await backend.search("test query", zone_id="corp", limit=5)
+        # search_type="keyword" so the hybrid over-fetch (Issue #3900) doesn't
+        # mask the limit assertion.
+        await backend.search("test query", zone_id="corp", limit=5, search_type="keyword")
         call_args = mock_emb.search.call_args[0][0]
         assert "zone_id = 'corp'" in call_args
         assert "LIMIT 5" in call_args
@@ -354,6 +356,47 @@ class TestTxtaiBackendSearch:
         results = await backend.search("q", zone_id="z", search_type="hybrid")
         assert [r.path for r in results] == ["/p/demo-1", "/p/demo-2"]
         assert results[0].score == 0.55  # higher of the two demo-1 scores
+
+    @pytest.mark.asyncio
+    async def test_search_hybrid_overfetches_to_avoid_underfill(self) -> None:
+        """Issue #3900: hybrid SQL must over-fetch so dedupe doesn't underfill.
+
+        If we ask txtai for exactly `limit` rows and every row pair is the
+        same id, post-dedupe we'd return < limit unique results when more
+        unique matches existed beyond the SQL LIMIT. The backend should
+        over-fetch in hybrid mode and slice to limit *after* dedupe.
+        """
+        backend, mock_emb = self._make_backend_with_mock()
+
+        # Simulate txtai returning 2*limit rows (the over-fetch), where
+        # ids 1-3 are duplicated by both BM25 and dense scorers and id 4
+        # appears only once. With limit=3 and naive limit-then-dedupe,
+        # we'd see [1, 1, 2] → 2 unique. With over-fetch + dedupe-then-slice,
+        # we should see all three unique ids.
+        mock_emb.search.return_value = [
+            {"id": "1", "path": "/a", "text": "a", "score": 0.90, "zone_id": "z"},
+            {"id": "1", "path": "/a", "text": "a", "score": 0.85, "zone_id": "z"},
+            {"id": "2", "path": "/b", "text": "b", "score": 0.80, "zone_id": "z"},
+            {"id": "2", "path": "/b", "text": "b", "score": 0.75, "zone_id": "z"},
+            {"id": "3", "path": "/c", "text": "c", "score": 0.70, "zone_id": "z"},
+            {"id": "3", "path": "/c", "text": "c", "score": 0.65, "zone_id": "z"},
+        ]
+        results = await backend.search("q", zone_id="z", search_type="hybrid", limit=3)
+        # Backend asked for an over-fetched LIMIT in the SQL.
+        sql = mock_emb.search.call_args[0][0]
+        assert "LIMIT 6" in sql
+        # All three unique ids surface, ordered by score, sliced to limit.
+        assert len(results) == 3
+        assert [r.path for r in results] == ["/a", "/b", "/c"]
+
+    @pytest.mark.asyncio
+    async def test_search_keyword_does_not_overfetch(self) -> None:
+        """Keyword-only search has no dedupe risk and should not over-fetch."""
+        backend, mock_emb = self._make_backend_with_mock()
+        mock_emb.search.return_value = []
+        await backend.search("q", zone_id="z", search_type="keyword", limit=5)
+        sql = mock_emb.search.call_args[0][0]
+        assert "LIMIT 5" in sql
 
 
 # =============================================================================

--- a/tests/integration/bricks/search/test_txtai_backend.py
+++ b/tests/integration/bricks/search/test_txtai_backend.py
@@ -337,6 +337,24 @@ class TestTxtaiBackendSearch:
         results = await backend.search("nothing", zone_id="z")
         assert results == []
 
+    @pytest.mark.asyncio
+    async def test_search_dedupes_hybrid_duplicates(self) -> None:
+        """Issue #3900: hybrid mode must not surface the same id twice.
+
+        txtai's hybrid scorer returns one row per scorer (BM25 + dense), so
+        the same chunk can appear in `raw` more than once. The backend must
+        collapse rows by id and keep the best score.
+        """
+        backend, mock_emb = self._make_backend_with_mock()
+        mock_emb.search.return_value = [
+            {"id": "demo-1", "path": "/p/demo-1", "text": "t", "score": 0.55, "zone_id": "z"},
+            {"id": "demo-1", "path": "/p/demo-1", "text": "t", "score": 0.40, "zone_id": "z"},
+            {"id": "demo-2", "path": "/p/demo-2", "text": "u", "score": 0.30, "zone_id": "z"},
+        ]
+        results = await backend.search("q", zone_id="z", search_type="hybrid")
+        assert [r.path for r in results] == ["/p/demo-1", "/p/demo-2"]
+        assert results[0].score == 0.55  # higher of the two demo-1 scores
+
 
 # =============================================================================
 # TxtaiBackend index operations


### PR DESCRIPTION
## Summary
- Hybrid mode (`type=hybrid`) was returning the same chunk twice when both BM25 and dense scorers matched the same id. Issue #3900 captures the repro: two adjacent hits with byte-for-byte identical `path`, `chunkIndex`, `score`, `keywordScore`, `vectorScore`.
- Root cause: txtai's hybrid scorer concatenates BM25 and dense rankings without dedup, so `embeddings.search(SQL)` emits one row per scorer for the same id. The current `txtai_backend.search()` constructs a `BaseSearchResult` per raw row, surfacing the duplicates downstream.
- Fix: collapse raw rows by id (txtai's unique chunk key) at the backend boundary, keeping the row with the higher score. Same dedup applied to `search`, `batch_search`, and `graph_search` for consistency.

## Test plan
- [x] Added `test_search_dedupes_hybrid_duplicates` covering 2 same-id rows + 1 distinct id; asserts collapsed to 2 results, higher score wins.
- [x] Existing `TestTxtaiBackendSearch` cases still pass against the modified backend.
- [ ] (Reviewer) Confirm no regression in hybrid recall on the HERB QA gate (`scripts/test_build_perf_e2e.py`, section 6).

Fixes #3900