### PR TITLE
proto+docs: PasswordVaultService gRPC contract + integration plan

### DIFF
--- a/docs/architecture/password-vault-integration.md
+++ b/docs/architecture/password-vault-integration.md
@@ -1,0 +1,153 @@
+# PasswordVaultService integration — consumer / implementer split
+
+> Why this doc exists: a kernel-arch transition email landed at password-agent
+> asking the consumer to choose Rust vs Python for the SecretsService rewrite.
+> password-agent is the *consumer*, not the *implementer* of SecretsService /
+> PasswordVaultService — both live in this nexus repo. Capturing the split
+> here so future cross-repo coordination doesn't get the role wrong.
+
+## Who owns what
+
+| Component | Repo | Path |
+|---|---|---|
+| `SecretsService` (encrypted KV brick — Fernet, versioning, audit, soft-delete) | nexus | `src/nexus/bricks/secrets/service.py` |
+| `PasswordVaultService` (domain wrapper, namespace="passwords", VaultEntry schema validation) | nexus | `src/nexus/services/password_vault/{service,schema}.py` |
+| REST router `/api/v2/password_vault/*` | nexus | `src/nexus/server/api/v2/routers/password_vault.py` |
+| gRPC service contract (this PR) | nexus | `proto/nexus/password_vault/v1/password_vault.proto` |
+| `NexusClient` HTTP client | password-agent (sudoprivacy/password-agent) | `src/password_agent/nexus_client.py` |
+| Tier-3 admin CLIs (vault_*, auth_*, quip_*) | password-agent | `tools/*.py` |
+| Tier-1/2 agent tools (`pwd_login`, `pwd_rotate`, ...) — *future* | sudowork (sudoprivacy/sudowork) | TBD |
+
+password-agent talks to PasswordVaultService over HTTP today. Sudowork's
+Tier-1 `pwd_login` tools (when they ship) will talk to the same service —
+the design intent is one server-side surface used by all consumer tiers.
+
+## Why a dedicated PasswordVaultService instead of generic SecretService
+
+`PasswordVaultService` is a thin layer over `SecretsService` with
+`NAMESPACE = "passwords"`, but the layer earns its keep:
+
+1. **Domain schema (`VaultEntry`)** — title/username/password/url/notes/
+   tags/totp_secret/extra. Consumers serialize against this. Without the
+   wrapper, every consumer (password-agent, sudowork's pwd_login, future
+   integrations) re-implements the JSON envelope for the
+   "blob inside SecretsService.value" round-trip.
+
+2. **Server-side TOTP generation (PR #3847)** — `POST /{title}/totp`
+   computes a one-shot HOTP from the entry's stored seed and returns 6
+   digits + window remaining. Seed never leaves the server (oracle
+   rate-limited 30s LRU per `(subject_id, entry_id, window_index)`).
+   This is fundamentally domain-specific; generic SecretService can't host it.
+
+3. **Domain-typed audit (`access_context` enum)** — admin_cli /
+   auto_login / auto_rotate / reveal_approved / agent_direct. Lets
+   downstream rate-limit / ACL / alerting branch on caller intent.
+   Generic SecretsService audit is a single "secret_read" line.
+
+4. **Tier 1/2/3 routing affordance** — sudowork's pwd_login is in scope
+   to call the same service password-agent does. A domain service makes
+   the contract obvious; "call SecretService with namespace=passwords"
+   leaks SecretsService internals to consumer surface.
+
+So even after the SecretsService gRPC migration, PasswordVaultService
+keeps being its own thing — it's a peer service that *uses* SecretService
+internally, not a routing alias.
+
+## Migration plan (proposed)
+
+### Phase 0 — proto contract (this PR)
+
+- `proto/nexus/password_vault/v1/password_vault.proto` lands. No code
+  changes; pure contract artifact.
+- nexus-side and password-agent-side teams agree the shape matches
+  current REST 1:1 plus the access_context bits.
+
+### Phase 1 — gRPC server (nexus side, Rust preferred)
+
+**Implementation language: Rust where feasible.** The kernel-arch direction
+is a single ~5–8 MB nexusd-cluster Rust binary; new services should land in
+the Rust workspace from day one rather than rewriting later.
+
+Concrete shape (matches the rust/services/ peer-crate pattern from PR #3921):
+
+- `rust/services/src/password_vault/` peer crate.
+  - Depends only on `kernel` + `contracts` (preserves §services⊥backends
+    invariant per `docs/architecture/KERNEL-ARCHITECTURE.md` §6).
+  - Storage: same redb tables SecretsService uses (namespace="passwords"),
+    or pass-through to a Rust SecretsService once that lands.
+  - Crypto: `aes-gcm` (Fernet-equivalent) with master-key derivation —
+    coordinate with the SecretsService Rust port so master key handling
+    stays SSOT (currently OAuthCrypto reads from `system_settings` SQL
+    per #3850).
+  - Audit hook: `kernel.register_native_hook(POST_WRITE)` for
+    `access_context`-tagged events; matches AuditHook pattern.
+- gRPC binding lives next to the impl, exposed via the same gRPC server
+  scaffold the SecretsService Rust port uses (or `start_vfs_grpc_server`
+  if that's still the integration point).
+- Binary delta target: **< 250 KB** (200 KB cited for SecretsService;
+  this layer is thinner — proto + dispatch + JSON envelope).
+
+**Python fallback (only if Rust resources are the gating constraint):**
+- Keep the existing Python `PasswordVaultService` class as the impl.
+- Add a thin Python gRPC handler (`grpc.aio.server` or piggyback on the
+  existing `start_vfs_grpc_server` `Call(method, payload)` dispatcher).
+- Treated as a temporary bridge; flagged `# DEPRECATED — port to Rust`.
+- Means sudowork's wheel still bundles Python for this surface, blocking
+  the pure-Rust binary goal. Don't ship this unless Rust is genuinely
+  blocked.
+
+**REST router stays for one minor release** in either path, so password-agent
+has an overlap window to migrate. Mark it `Deprecated` in OpenAPI.
+
+### Phase 2 — gRPC client (password-agent side)
+
+- password-agent depends on the published proto (subscription mechanism
+  TBD — see open question below).
+- Generate Python gRPC stubs.
+- Replace `NexusClient` (urllib HTTP) with a gRPC-backed one. Same
+  external interface to `vault.py` so the 16 tools and 314 vault entries
+  carry over without consumer-side schema changes.
+- Verify against dev nexusd first, then v0.10.x sudowork-shipped binary
+  with gRPC enabled.
+
+### Phase 3 — REST removal
+
+- After password-agent is on gRPC end-to-end (and any other REST
+  consumers we discover), nexus drops the REST router.
+
+## Open questions (for nexus kernel team to answer)
+
+1. **Proto distribution mechanism**. How will password-agent (and other
+   downstream consumers) consume `proto/nexus/password_vault/v1/`? Options:
+   a. nexus repo publishes generated Python stubs to a private PyPI / artifact registry.
+   b. password-agent vendors the .proto files and runs codegen at build time.
+   c. buf module / Connect-RPC distribution.
+
+   Whatever the answer, it should match what SecretsService gRPC does so
+   we don't have two patterns.
+
+2. **Transport endpoint**. Is gRPC served on the same port (12012) as REST,
+   or a separate gRPC port? sudowork's `DynamicNexusService` will need to
+   know how to expose / proxy it.
+
+3. **HTTP REST deprecation timeline**. password-agent just switched to
+   v0.9.43 binary's REST surface. Need at least one minor release window
+   where both REST and gRPC are available, or a flagged opt-in for gRPC.
+
+4. **`access_context` enforcement**. Current REST treats unknown values
+   as 400. gRPC uses a typed enum; is it OK to treat
+   `ACCESS_CONTEXT_UNSPECIFIED` as the default `ADMIN_CLI` (matches
+   current REST default-when-omitted), or should server reject?
+
+## What this PR does
+
+- Adds the proto file (`proto/nexus/password_vault/v1/password_vault.proto`).
+- Adds this doc.
+- **Does not** change REST router, services/, or bricks/.
+- **Does not** generate stubs. (Codegen wiring depends on Q1 above.)
+
+## What this PR does NOT block
+
+- password-agent's current M2 work (auth_login + cookie injection over REST).
+  We keep the REST surface live until the gRPC migration is end-to-end
+  ready on both sides.

--- a/proto/nexus/password_vault/v1/password_vault.proto
+++ b/proto/nexus/password_vault/v1/password_vault.proto
@@ -1,0 +1,211 @@
+// PasswordVaultService gRPC contract.
+//
+// Domain-typed wrapper over SecretsService (namespace="passwords") that
+// password-agent (sudoprivacy/password-agent) consumes today over REST at
+// /api/v2/password_vault/*. Forwarding to this proto for the kernel-arch
+// gRPC migration so password-agent has a concrete consumer-side target.
+//
+// Three reasons to keep this as its own service rather than have password-
+// agent call SecretService directly with namespace="passwords":
+//
+//   1. VaultEntry schema (title/username/password/url/notes/tags/totp_secret/
+//      extra) is a stable contract password-agent already serializes against.
+//      Hiding it behind a generic SecretService blob means re-implementing
+//      JSON envelope handling on every consumer.
+//   2. POST /{title}/totp computes a one-shot HOTP server-side and returns
+//      6 digits + window remaining (PR #3847). That stays on the server side
+//      because the seed shouldn't cross the boundary; doesn't fit a generic
+//      get/put SecretService surface.
+//   3. access_context audit fields (admin_cli / auto_login / auto_rotate /
+//      reveal_approved / agent_direct, plus client_id + agent_session) are
+//      domain-specific; SecretService's generic audit doesn't know about
+//      them.
+//
+// REST surface is preserved 1:1 below for parity. Once gRPC ships and
+// password-agent's NexusClient is rewritten, the FastAPI router at
+// src/nexus/server/api/v2/routers/password_vault.py becomes deletable.
+//
+// Protocol version: 2026.1
+
+syntax = "proto3";
+
+package nexus.password_vault.v1;
+
+import "google/protobuf/timestamp.proto";
+
+// PasswordVaultService — credential store with versioning, soft-delete,
+// audit, and server-side TOTP generation. namespace="passwords".
+service PasswordVaultService {
+  // Create or update an entry. If `title` exists, server creates a new
+  // version (old retained for rollback). Maps to PUT /{title}.
+  rpc PutEntry(PutEntryRequest) returns (PutEntryResponse);
+
+  // Fetch a single entry, latest version by default. Maps to
+  // GET /{title} and GET /{title}?version=N.
+  rpc GetEntry(GetEntryRequest) returns (GetEntryResponse);
+
+  // List all entries the calling subject has access to (per
+  // SecretsService._base_query subject_id filter). Maps to GET /.
+  rpc ListEntries(ListEntriesRequest) returns (ListEntriesResponse);
+
+  // Soft-delete (tombstone). Recoverable via RestoreEntry until full purge.
+  // Maps to DELETE /{title}.
+  rpc DeleteEntry(DeleteEntryRequest) returns (DeleteEntryResponse);
+
+  // Restore a soft-deleted entry. Maps to POST /{title}/restore.
+  rpc RestoreEntry(RestoreEntryRequest) returns (RestoreEntryResponse);
+
+  // List all versions of an entry (rotation history). Maps to
+  // GET /{title}/versions.
+  rpc ListVersions(ListVersionsRequest) returns (ListVersionsResponse);
+
+  // Compute current TOTP code from the entry's stored totp_secret. The
+  // seed never leaves the server. 30s LRU caches by (subject_id, entry_id,
+  // window_index) so a hostile read-only client can't oracle-hammer.
+  // Maps to POST /{title}/totp.
+  rpc GenerateTotp(GenerateTotpRequest) returns (GenerateTotpResponse);
+}
+
+// VaultEntry — single credential. Mirrors
+// nexus.services.password_vault.schema.VaultEntry pydantic model.
+message VaultEntry {
+  // Stable identifier; SecretsService key. Required, min length 1.
+  string title = 1;
+
+  string username = 2;
+  string password = 3;
+  string url = 4;
+  string notes = 5;
+
+  // Comma-separated list (not repeated) — mirrors current pydantic shape.
+  string tags = 6;
+
+  // Base32-encoded TOTP seed. Server uses it to compute codes via
+  // GenerateTotp; never returned to clients in REST today (redacted in
+  // GetEntry response). gRPC keeps the same redaction semantics — see
+  // GetEntry's omit_secrets default.
+  string totp_secret = 7;
+
+  // Free-form JSON for site-specific fields (bank PINs, recovery codes,
+  // saved cookies for auto-login). Encoded as canonical JSON string for
+  // wire stability across language clients.
+  string extra_json = 8;
+}
+
+// AccessAuditContext — what kind of caller is reading credentials and why.
+// Recorded in audit log; rate-limit / ACL hooks can branch on it later.
+// PR #3847 enum.
+enum AccessContext {
+  ACCESS_CONTEXT_UNSPECIFIED = 0;  // server treats as ADMIN_CLI default
+  ACCESS_CONTEXT_ADMIN_CLI = 1;     // direct human (password-agent CLIs)
+  ACCESS_CONTEXT_AUTO_LOGIN = 2;    // sudowork pwd_login filling a form
+  ACCESS_CONTEXT_AUTO_ROTATE = 3;   // sudowork pwd_rotate changing a pw
+  ACCESS_CONTEXT_REVEAL_APPROVED = 4; // sudowork UI showing pw to human
+  ACCESS_CONTEXT_AGENT_DIRECT = 5;  // agent tool got plaintext directly
+}
+
+message AuditContext {
+  AccessContext access_context = 1;
+  // Free-form. e.g., "sudowork", "password-agent". Not validated.
+  string client_id = 2;
+  // Free-form. Sudowork's agent session id when relevant.
+  string agent_session = 3;
+}
+
+// --- Request / Response messages ---
+
+message PutEntryRequest {
+  VaultEntry entry = 1;
+  AuditContext audit = 2;
+}
+
+message PutEntryResponse {
+  string id = 1;
+  string title = 2;
+  int32 version = 3;
+  google.protobuf.Timestamp created_at = 4;
+}
+
+message GetEntryRequest {
+  string title = 1;
+  // 0 = latest. Otherwise a specific historical version from ListVersions.
+  int32 version = 2;
+  // If true, totp_secret is returned (admin / Tier-3 only). REST default
+  // is false (redacted) so consumers must opt in. Maps to ?show_totp=1.
+  bool show_totp = 3;
+  AuditContext audit = 4;
+}
+
+message GetEntryResponse {
+  VaultEntry entry = 1;
+  int32 version = 2;
+}
+
+message ListEntriesRequest {
+  // Optional substring filter (case-insensitive over title/username/url/tags).
+  // Currently REST does this client-side; server-side filter is fine.
+  string query = 1;
+  // 0 = no limit. REST defaults vary per consumer; gRPC explicit.
+  int32 limit = 2;
+  AuditContext audit = 3;
+}
+
+message ListEntriesResponse {
+  repeated VaultEntry entries = 1;
+  int32 total_in_vault = 2;  // before query filter
+  int32 matched = 3;          // after query filter
+}
+
+message DeleteEntryRequest {
+  string title = 1;
+  AuditContext audit = 2;
+}
+
+message DeleteEntryResponse {
+  string title = 1;
+  bool deleted = 2;
+}
+
+message RestoreEntryRequest {
+  string title = 1;
+  AuditContext audit = 2;
+}
+
+message RestoreEntryResponse {
+  string title = 1;
+  bool restored = 2;
+  int32 current_version = 3;
+}
+
+message Version {
+  int32 version = 1;
+  google.protobuf.Timestamp created_at = 2;
+  // True if this version was the active one when the entry was soft-deleted.
+  bool tombstoned = 3;
+}
+
+message ListVersionsRequest {
+  string title = 1;
+  AuditContext audit = 2;
+}
+
+message ListVersionsResponse {
+  string title = 1;
+  int32 count = 2;
+  repeated Version versions = 3;
+}
+
+message GenerateTotpRequest {
+  string title = 1;
+  AuditContext audit = 2;
+}
+
+message GenerateTotpResponse {
+  // 6-digit code. Always exactly 6 chars (RFC 6238 default).
+  string code = 1;
+  // Seconds until the current 30s window closes; clients that see < 3
+  // typically wait and re-fetch to avoid race with input.
+  int32 expires_in_seconds = 2;
+  // Fixed 30 per RFC 6238; returned explicitly so clients don't bake it in.
+  int32 period_seconds = 3;
+}


### PR DESCRIPTION
## Summary
- Adds `proto/nexus/password_vault/v1/password_vault.proto` — gRPC service contract mirroring the current REST 8 endpoints + access_context audit enum + GenerateTotp from #3847.
- Adds `docs/architecture/password-vault-integration.md` — who-owns-what across nexus / password-agent / sudowork, why `PasswordVaultService` stays a peer service instead of collapsing into `SecretService` routing, 4-phase migration plan, and open questions for the kernel team.

## Why this PR exists
A kernel-arch transition email landed at password-agent (sudoprivacy/password-agent — the *consumer*) asking us to choose Rust vs Python for the SecretsService rewrite. password-agent is HTTP client only; both `SecretsService` and `PasswordVaultService` are owned in this repo. Capturing the role split here so future cross-repo coordination doesn't ping the wrong side.

## Phase 1 implementation preference
Biased toward **Rust** per kernel-arch direction (`rust/services/` peer crate pattern, services⊥backends invariant, ~250 KB binary delta target). Python fallback documented as a bridge-only path that should not ship unless Rust is genuinely blocked.

## Open questions (for kernel team)
1. Proto distribution mechanism — should match SecretsService gRPC pattern.
2. Transport endpoint — same port as REST or separate gRPC port.
3. REST deprecation timeline — password-agent just switched to v0.9.43 binary's REST surface; needs at least one minor overlap.
4. `ACCESS_CONTEXT_UNSPECIFIED` semantics — default to `ADMIN_CLI` or reject.

## Test plan
- [ ] `buf lint` / equivalent against the new proto file.
- [ ] No-op against existing REST surface (this PR doesn't touch routers, services/, or bricks/).
- [ ] Doc cross-checks — file paths reference live files; PR numbers (#3847, #3921, #3850) match.

🤖 Generated with [Claude Code](https://claude.com/claude-code)