### PR TITLE
refactor(vfs-router): delete dead LPM duplication + fix TUI mount listing

### DIFF
--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -114,9 +114,14 @@ class ContextualNexusFS:
         return result
 
     def list_mounts(self) -> list[str]:
-        mounts = self._kernel._driver_coordinator.mount_points()
-        filtered = [mount for mount in mounts if mount != "/"]
-        return filtered or mounts
+        # Use public syscall: readdir("/") returns top-level entries including mounts.
+        _rk = getattr(self._kernel, "_kernel", None)
+        if _rk is not None:
+            entries = _rk.readdir("/", self._kernel._zone_id, True)
+            mounts = [path for path, _etype in entries if path != "/"]
+            return mounts or ["/"]
+        result: list[str] = self._kernel._driver_coordinator.mount_points()
+        return result
 
     async def close(self) -> None:
         return None

--- a/src/nexus/services/gateway.py
+++ b/src/nexus/services/gateway.py
@@ -503,33 +503,6 @@ class NexusFSGateway:
             )
         return sorted(mounts, key=lambda m: m["mount_point"])
 
-    def get_mount_for_path(self, path: str) -> dict[str, Any] | None:
-        """Get mount info and backend-relative path for a virtual path.
-
-        Resolve mount info and backend-relative path for a virtual path.
-        Mounts are checked longest-prefix-first so that more-specific mounts
-        (e.g. ``/mnt/foo``) match before less-specific ones (e.g. ``/``).
-
-        Args:
-            path: Virtual file path
-
-        Returns:
-            Dict with mount_point, backend, backend_path keys,
-            or None if no mount matches.
-        """
-
-        dlc = self._fs._driver_coordinator
-        all_mounts = sorted(dlc.mount_points(), key=len, reverse=True)
-        for mp in all_mounts:
-            if path == mp or path.startswith(mp + "/") or mp == "/":
-                backend_path = path.lstrip("/") if mp == "/" else path[len(mp) :].lstrip("/")
-                return {
-                    "mount_point": mp,
-                    "backend": None,
-                    "backend_path": backend_path,
-                }
-        return None
-
     # =========================================================================
     # Search Operations (Issue #1287: replaces 8 Callable[..., Any] params)
     # =========================================================================

--- a/tests/unit/services/test_gateway.py
+++ b/tests/unit/services/test_gateway.py
@@ -399,28 +399,3 @@ class TestMountOperations:
         assert result[0]["mount_point"] == "/mnt/test"
         assert result[0]["backend_type"] == "rust-native"
         assert result[0]["backend"] is None
-
-    def test_get_mount_for_path_found(self, gateway, mock_fs):
-        """get_mount_for_path returns mount info."""
-        mock_fs._driver_coordinator.mount_points.return_value = ["/mnt"]
-
-        result = gateway.get_mount_for_path("/mnt/subdir/file.txt")
-        assert result is not None
-        assert result["mount_point"] == "/mnt"
-        assert result["backend_path"] == "subdir/file.txt"
-        assert result["backend"] is None
-
-    def test_get_mount_for_path_root(self, gateway, mock_fs):
-        """get_mount_for_path handles root mount."""
-        mock_fs._driver_coordinator.mount_points.return_value = ["/"]
-
-        result = gateway.get_mount_for_path("/any/path")
-        assert result is not None
-        assert result["mount_point"] == "/"
-        assert result["backend"] is None
-
-    def test_get_mount_for_path_not_found(self, gateway, mock_fs):
-        """get_mount_for_path returns None when no mount matches."""
-        mock_fs._driver_coordinator.mount_points.return_value = []
-        result = gateway.get_mount_for_path("/orphan/path")
-        assert result is None


### PR DESCRIPTION
## Summary
- Delete `gateway.get_mount_for_path()` — zero callers, reimplemented LPM routing already 100% in Rust `VFSRouter::route()`
- Delete 3 associated tests (method deleted)
- TUI `list_mounts`: use `readdir("/")` public syscall instead of reaching into DLC internals (`_driver_coordinator.mount_points()`)

VFSRouter audit confirmed: routing primitive is 100% Rust. These are the last two cleanup items.

## Test plan
- [x] All pre-commit hooks pass (ruff, mypy, format, etc.)
- [ ] CI full test suite

🤖 Generated with [Claude Code](https://claude.com/claude-code)