### PR TITLE
[codex] fix FUSE cache coherence and readahead

### DIFF
--- a/src/nexus/fuse/filters.py
+++ b/src/nexus/fuse/filters.py
@@ -6,12 +6,16 @@ because only FUSE handlers use it.
 """
 
 import fnmatch
+import importlib
 from typing import Any
 
 # RUST_FALLBACK: filter_paths
-import nexus_kernel
+try:
+    nexus_kernel: Any | None = importlib.import_module("nexus_kernel")
+except ImportError:
+    nexus_kernel = None
 
-RUST_AVAILABLE = True
+RUST_AVAILABLE = nexus_kernel is not None
 
 # OS-generated metadata file patterns
 # These files are automatically created by operating systems and should be
@@ -72,7 +76,7 @@ def filter_os_metadata(files: list[str]) -> list[str]:
         ['file.txt']
     """
     # Use Rust for bulk filtering if available (5-10x faster)
-    if RUST_AVAILABLE and len(files) >= 10:
+    if RUST_AVAILABLE and nexus_kernel is not None and len(files) >= 10:
         try:
             result: list[str] = nexus_kernel.filter_paths(files, OS_METADATA_PATTERNS)
             return result

--- a/src/nexus/fuse/ops/_shared.py
+++ b/src/nexus/fuse/ops/_shared.py
@@ -9,6 +9,7 @@ This module contains:
 
 import errno
 import functools
+import inspect
 import logging
 import os
 import stat
@@ -422,12 +423,39 @@ def read_range_from_backend(ctx: FUSESharedContext, path: str, offset: int, size
     from nexus.lib.sync_bridge import run_sync as _run_sync
 
     try:
+        end = offset + size
+        read_range = getattr(ctx.nexus_fs, "read_range", None)
+        if callable(read_range):
+            if _accepts_context(read_range):
+                return cast("bytes", read_range(path, offset, end, context=ctx.context))
+            return cast("bytes", read_range(path, offset, end))
+
+        sys_read = getattr(ctx.nexus_fs, "sys_read", None)
+        if callable(sys_read):
+            if _accepts_context(sys_read):
+                return cast(
+                    "bytes",
+                    sys_read(path, count=size, offset=offset, context=ctx.context),
+                )
+            content = cast("bytes", sys_read(path))
+            return content[offset:end]
+
         content = _run_sync(get_file_content(ctx, path, None))
-        end = min(offset + size, len(content))
         return content[offset:end]
     except Exception as e:
         logger.warning(f"[FUSE-READAHEAD] Failed to read {path}:{offset}+{size}: {e}")
         return b""
+
+
+def _accepts_context(func: Callable[..., Any]) -> bool:
+    """Return whether a callable accepts a ``context=`` keyword argument."""
+    try:
+        params = inspect.signature(func).parameters.values()
+    except (TypeError, ValueError):
+        return True
+    return any(
+        param.name == "context" or param.kind == inspect.Parameter.VAR_KEYWORD for param in params
+    )
 
 
 def get_from_local_disk_cache(ctx: FUSESharedContext, path: str) -> bytes | None:
@@ -482,7 +510,10 @@ def put_to_local_disk_cache(
 async def get_metadata(ctx: FUSESharedContext, path: str) -> Any:
     """Get file/directory metadata from filesystem."""
     if hasattr(ctx.nexus_fs, "sys_stat"):
-        metadata_dict = ctx.nexus_fs.sys_stat(path)
+        if _accepts_context(ctx.nexus_fs.sys_stat):
+            metadata_dict = ctx.nexus_fs.sys_stat(path, context=ctx.context)
+        else:
+            metadata_dict = ctx.nexus_fs.sys_stat(path)
         if metadata_dict:
             return MetadataObj.from_dict(metadata_dict)
     return None
@@ -496,7 +527,10 @@ def stat_size_fallback(ctx: FUSESharedContext, path: str) -> int:
     """
     if hasattr(ctx.nexus_fs, "stat"):
         try:
-            stat_result = ctx.nexus_fs.stat(path)
+            if _accepts_context(ctx.nexus_fs.stat):
+                stat_result = ctx.nexus_fs.stat(path, context=ctx.context)
+            else:
+                stat_result = ctx.nexus_fs.stat(path)
             if stat_result:
                 stat_size = stat_result.get("st_size") or stat_result.get("size", 0)
                 if stat_size and stat_size > 0:

--- a/src/nexus/fuse/ops/attr_handler.py
+++ b/src/nexus/fuse/ops/attr_handler.py
@@ -42,9 +42,10 @@ class AttrHandler:
         permission_bits = mode & 0o777
         ctx.nexus_fs.sys_setattr(original_path, context=ctx.context, mode=permission_bits)
 
-        ctx.cache.invalidate_path(original_path)
+        invalidation_paths = [original_path]
         if path != original_path:
-            ctx.cache.invalidate_path(path)
+            invalidation_paths.append(path)
+        ctx.cache.invalidate_and_revoke(invalidation_paths)
 
         if HAS_EVENT_BUS and FileEventType is not None:
             ctx.events.fire(FileEventType.METADATA_CHANGE, original_path)
@@ -85,9 +86,10 @@ class AttrHandler:
         if attrs:
             ctx.nexus_fs.sys_setattr(original_path, context=ctx.context, **attrs)
 
-        ctx.cache.invalidate_path(original_path)
+        invalidation_paths = [original_path]
         if path != original_path:
-            ctx.cache.invalidate_path(path)
+            invalidation_paths.append(path)
+        ctx.cache.invalidate_and_revoke(invalidation_paths)
 
         if HAS_EVENT_BUS and FileEventType is not None:
             ctx.events.fire(FileEventType.METADATA_CHANGE, original_path)
@@ -114,9 +116,13 @@ class AttrHandler:
 
         ctx.nexus_fs.write(original_path, content, context=ctx.context)
 
-        ctx.cache.invalidate_path(original_path)
+        invalidation_paths = [original_path]
         if path != original_path:
-            ctx.cache.invalidate_path(path)
+            invalidation_paths.append(path)
+        ctx.cache.invalidate_and_revoke(invalidation_paths)
+
+        if ctx.readahead:
+            ctx.readahead.invalidate_path(original_path)
 
         if HAS_EVENT_BUS and FileEventType is not None:
             ctx.events.fire(FileEventType.FILE_WRITE, original_path, size=length)

--- a/tests/unit/fuse/test_attr_handler.py
+++ b/tests/unit/fuse/test_attr_handler.py
@@ -22,7 +22,7 @@ class TestChmod:
     ) -> None:
         fuse_ops.cache = mock_cache
         fuse_ops.chmod("/file.txt", 0o644)
-        mock_cache.invalidate_path.assert_called_with("/file.txt")
+        mock_cache.invalidate_and_revoke.assert_called_once_with(["/file.txt"])
 
     def test_chmod_rejects_virtual_view(self, fuse_ops: Any) -> None:
         with patch.object(fuse_ops, "_parse_virtual_path", return_value=("/f.xlsx", "md")):
@@ -41,6 +41,16 @@ class TestChown:
             # Just verify it doesn't crash — uid/gid mapping is platform-specific
             mock_chown.return_value = None
             mock_chown(fuse_ops, "/file.txt", os.getuid(), os.getgid())
+
+    def test_chown_invalidates_and_revokes(
+        self, fuse_ops: Any, mock_nexus_fs: MagicMock, mock_cache: MagicMock
+    ) -> None:
+        fuse_ops.cache = mock_cache
+        mock_nexus_fs.access.return_value = True
+
+        fuse_ops.chown("/file.txt", 123456, -1)
+
+        mock_cache.invalidate_and_revoke.assert_called_once_with(["/file.txt"])
 
     def test_chown_rejects_virtual_view(self, fuse_ops: Any) -> None:
         with patch.object(fuse_ops, "_parse_virtual_path", return_value=("/f.xlsx", "md")):
@@ -75,7 +85,16 @@ class TestTruncate:
         mock_nexus_fs.sys_read.return_value = b"data"
 
         fuse_ops.truncate("/file.txt", 2)
-        mock_cache.invalidate_path.assert_called()
+        mock_cache.invalidate_and_revoke.assert_called_once_with(["/file.txt"])
+
+    def test_truncate_invalidates_readahead(self, fuse_ops: Any, mock_nexus_fs: MagicMock) -> None:
+        mock_nexus_fs.access.return_value = True
+        mock_nexus_fs.sys_read.return_value = b"data"
+        fuse_ops._readahead = MagicMock()
+
+        fuse_ops.truncate("/file.txt", 2)
+
+        fuse_ops._readahead.invalidate_path.assert_called_once_with("/file.txt")
 
 
 class TestUtimens:

--- a/tests/unit/fuse/test_filters.py
+++ b/tests/unit/fuse/test_filters.py
@@ -1,0 +1,33 @@
+"""Tests for FUSE path filtering helpers."""
+
+import builtins
+import importlib
+import sys
+import types
+
+
+def test_filters_import_and_fallback_without_rust_kernel(monkeypatch) -> None:
+    real_import = builtins.__import__
+    existing_kernel = sys.modules.get("nexus_kernel")
+    sys.modules["nexus_kernel"] = types.ModuleType("nexus_kernel")
+
+    def fake_import(name, *args, **kwargs):
+        if name == "nexus_kernel":
+            raise ImportError(name)
+        return real_import(name, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "__import__", fake_import)
+    sys.modules.pop("nexus.fuse.filters", None)
+    sys.modules.pop("nexus_kernel", None)
+    try:
+        filters = importlib.import_module("nexus.fuse.filters")
+
+        assert filters.RUST_AVAILABLE is False
+        assert filters.is_os_metadata_file(".DS_Store")
+        assert filters.filter_os_metadata(["keep.txt", ".DS_Store", "._keep.txt"]) == ["keep.txt"]
+    finally:
+        sys.modules.pop("nexus.fuse.filters", None)
+        if existing_kernel is not None:
+            sys.modules["nexus_kernel"] = existing_kernel
+        else:
+            sys.modules.pop("nexus_kernel", None)

--- a/tests/unit/fuse/test_metadata_handler.py
+++ b/tests/unit/fuse/test_metadata_handler.py
@@ -1,5 +1,6 @@
 """Tests for getattr and readdir metadata operations."""
 
+import asyncio
 import errno
 import stat
 from typing import Any
@@ -9,6 +10,7 @@ import pytest
 from fuse import FuseOSError
 
 from nexus.fuse.cache import FUSECacheManager
+from nexus.fuse.ops._shared import get_metadata, stat_size_fallback
 from nexus.fuse.ops.metadata_handler import (
     _PARSED_SIZE_MULTIPLIER,
     _VIRTUAL_VIEW_DEFAULT_SIZE,
@@ -258,6 +260,30 @@ class TestCacheGetParsedSize:
 
         assert cache.get_parsed_size("/file.xlsx", "md") == 5
         assert cache.get_parsed_size("/file.xlsx", "txt") == 20
+
+
+class TestContextAwareMetadataHelpers:
+    """Metadata helpers preserve the mount operation context."""
+
+    def test_get_metadata_passes_context_to_sys_stat(self) -> None:
+        ctx = MagicMock()
+        ctx.context = object()
+        ctx.nexus_fs.sys_stat.return_value = {"path": "/file.txt", "size": 9}
+
+        result = asyncio.run(get_metadata(ctx, "/file.txt"))
+
+        assert result.size == 9
+        ctx.nexus_fs.sys_stat.assert_called_once_with("/file.txt", context=ctx.context)
+
+    def test_stat_size_fallback_passes_context_to_stat(self) -> None:
+        ctx = MagicMock()
+        ctx.context = object()
+        ctx.nexus_fs.stat.return_value = {"st_size": 123}
+
+        result = stat_size_fallback(ctx, "/file.txt")
+
+        assert result == 123
+        ctx.nexus_fs.stat.assert_called_once_with("/file.txt", context=ctx.context)
 
     def test_returns_none_after_invalidation(self) -> None:
         cache = FUSECacheManager()

--- a/tests/unit/fuse/test_readahead.py
+++ b/tests/unit/fuse/test_readahead.py
@@ -7,6 +7,7 @@ profile-driven windowing variants were dropped with the knob.
 
 from unittest.mock import MagicMock
 
+from nexus.fuse.ops._shared import read_range_from_backend
 from nexus.fuse.readahead import ReadaheadConfig, ReadaheadManager, ReadSession
 
 
@@ -48,3 +49,23 @@ class TestReadaheadManagerOnOpen:
         assert session is not None
         # Uses manager's default config
         assert session.max_window == manager._config.max_window
+
+
+class TestReadRangeFromBackend:
+    """Regression coverage for FUSE readahead range fetches."""
+
+    def test_uses_nexus_read_range_without_full_file_read(self) -> None:
+        ctx = MagicMock()
+        ctx.context = object()
+        ctx.nexus_fs.read_range.return_value = b"chunk"
+
+        result = read_range_from_backend(ctx, "/large.bin", 8, 5)
+
+        assert result == b"chunk"
+        ctx.nexus_fs.read_range.assert_called_once_with(
+            "/large.bin",
+            8,
+            13,
+            context=ctx.context,
+        )
+        ctx.nexus_fs.sys_read.assert_not_called()


### PR DESCRIPTION
## Summary
- make FUSE metadata filtering import without requiring `nexus_kernel`
- use byte-range reads for readahead instead of fetching full file content
- preserve FUSE operation context for metadata/stat helpers
- revoke lease-backed caches and readahead buffers after attr mutations

## Root Cause
The Python FUSE path assumed optional Rust acceleration was always importable, used full-file content reads for readahead prefetches, and some metadata/attribute paths bypassed the lease/context handling used elsewhere in FUSE operations.

## Validation
- `uv run --with ruff ruff check src/nexus/fuse/filters.py src/nexus/fuse/ops/_shared.py src/nexus/fuse/ops/attr_handler.py tests/unit/fuse/test_filters.py tests/unit/fuse/test_readahead.py tests/unit/fuse/test_attr_handler.py tests/unit/fuse/test_metadata_handler.py`
- `uv run pytest tests/unit/fuse/test_filters.py tests/unit/fuse/test_readahead.py tests/unit/fuse/test_attr_handler.py tests/unit/fuse/test_metadata_handler.py::TestContextAwareMetadataHelpers -q -n 0`
- `uv run pytest tests/unit/fuse -q -n 0`
