### PR TITLE
fix(migrations): add missing zone_id column to rebac_changelog

### DIFF
--- a/alembic/versions/3b2a1c5d7e8f_add_zone_id_to_rebac_changelog.py
+++ b/alembic/versions/3b2a1c5d7e8f_add_zone_id_to_rebac_changelog.py
@@ -1,0 +1,81 @@
+"""add zone_id to rebac_changelog
+
+The ``ReBACChangelogModel`` declares a non-nullable ``zone_id`` column
+indexed for cache invalidation lookups, but the original create-table
+migration (``a16e1db56def``) predates that field and no follow-up has
+added it. Fresh databases initialised via ``alembic upgrade heads``
+therefore lack the column, and any code path that writes a changelog
+row (``rebac.utils.changelog.insert_changelog_entry`` — exercised by
+``mounts add``) fails with::
+
+    column "zone_id" of relation "rebac_changelog" does not exist
+
+This migration adds the column nullable, backfills existing rows to the
+root zone sentinel, then enforces NOT NULL with the model's default and
+creates the supporting index. SQLite is handled via batch_alter_table.
+
+Revision ID: 3b2a1c5d7e8f
+Revises: 04188c0bbb28
+Create Date: 2026-04-27 19:30:00.000000
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "3b2a1c5d7e8f"
+down_revision: str | Sequence[str] | None = "04188c0bbb28"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+ROOT_ZONE_ID = "root"
+
+
+def _has_column(table: str, column: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return any(c["name"] == column for c in inspector.get_columns(table))
+
+
+def _has_index(table: str, name: str) -> bool:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    return any(idx["name"] == name for idx in inspector.get_indexes(table))
+
+
+def upgrade() -> None:
+    """Add zone_id to rebac_changelog (idempotent)."""
+    if not _has_column("rebac_changelog", "zone_id"):
+        op.add_column(
+            "rebac_changelog",
+            sa.Column("zone_id", sa.String(255), nullable=True),
+        )
+        op.execute(
+            sa.text(f"UPDATE rebac_changelog SET zone_id = '{ROOT_ZONE_ID}' WHERE zone_id IS NULL")
+        )
+        with op.batch_alter_table("rebac_changelog") as batch:
+            batch.alter_column(
+                "zone_id",
+                existing_type=sa.String(255),
+                nullable=False,
+                server_default=ROOT_ZONE_ID,
+            )
+
+    if not _has_index("rebac_changelog", "ix_rebac_changelog_zone_id"):
+        op.create_index(
+            "ix_rebac_changelog_zone_id",
+            "rebac_changelog",
+            ["zone_id"],
+        )
+
+
+def downgrade() -> None:
+    """Remove zone_id column and its index."""
+    if _has_index("rebac_changelog", "ix_rebac_changelog_zone_id"):
+        op.drop_index("ix_rebac_changelog_zone_id", table_name="rebac_changelog")
+    if _has_column("rebac_changelog", "zone_id"):
+        op.drop_column("rebac_changelog", "zone_id")


### PR DESCRIPTION
## Summary

`ReBACChangelogModel` declares a non-nullable `zone_id` column indexed for cache invalidation, but no migration ever added it. Fresh databases initialised via `alembic upgrade heads` lack the column, and the first ReBAC write — exercised by `nexus mounts add` — crashes with:

```
column "zone_id" of relation "rebac_changelog" does not exist
LINE 4:     relation, object_type, object_id, zone_id, created_at
```

Reproduces on the current `develop` tip with a fresh `nexus up` shared/demo stack.

## What this migration does

1. `add_column rebac_changelog.zone_id VARCHAR(255) NULLABLE` — safe on populated tables.
2. Backfill existing rows to `'root'` (the `ROOT_ZONE_ID` constant).
3. `alter_column ... NOT NULL DEFAULT 'root'` to match the model.
4. Create `ix_rebac_changelog_zone_id` index.

Idempotent: `_has_column`/`_has_index` guards let partially-patched databases upgrade cleanly. SQLite is routed through `batch_alter_table` for the `NOT NULL` step.

## Test plan
- [x] Fresh PostgreSQL stack: `nexus down --volumes && nexus up --build` ran the new revision; `\d rebac_changelog` shows `zone_id varchar(255) NOT NULL DEFAULT 'root'` + `ix_rebac_changelog_zone_id` index; alembic version pinned to `3b2a1c5d7e8f`.
- [x] `nexus mounts add /test-hn hn_connector '{}'` succeeds (previously failed with the UndefinedColumn error).
- [ ] PostgreSQL upgrade-from-existing path (CI's migration suite covers this).
- [ ] SQLite upgrade-from-existing path.

## Surfaced from
PR #3927 — the `.readme/` overlay feature mounts a connector during validation, which triggers the changelog write. Fixing the schema independently so the migration can land without the feature work.