### PR TITLE
DT_STREAM/DT_PIPE federation: sys_read dict + WalPipeCore + tail/size kernel API

### DIFF
--- a/rust/kernel/src/core/pipe/manager.rs
+++ b/rust/kernel/src/core/pipe/manager.rs
@@ -258,6 +258,14 @@ impl PipeManager {
         self.buffers.get(path).map(|r| Arc::clone(r.value()))
     }
 
+    /// Queued bytes pending in a registered pipe.
+    ///
+    /// Returns `None` if no pipe is registered at `path`. `Some(0)` means
+    /// the pipe exists but has no pending payload.
+    pub(crate) fn size(&self, path: &str) -> Option<usize> {
+        self.buffers.get(path).map(|b| b.size())
+    }
+
     /// List all pipe paths.
     pub(crate) fn list(&self) -> Vec<String> {
         self.buffers.iter().map(|r| r.key().clone()).collect()
@@ -354,6 +362,35 @@ mod tests {
     use std::sync::Arc;
     use std::thread;
     use std::time::Duration;
+
+    #[test]
+    fn test_size_empty_pipe() {
+        let mgr = PipeManager::new();
+        mgr.create("/p/empty", 1024).unwrap();
+        assert_eq!(mgr.size("/p/empty"), Some(0));
+    }
+
+    #[test]
+    fn test_size_tracks_used_bytes() {
+        // size() reports queued payload bytes, NOT including the 4B frame
+        // header — pipes are destructive (pop drains), so size() shrinks
+        // back to 0 once readers consume everything.
+        let mgr = PipeManager::new();
+        mgr.create("/p/q", 1024).unwrap();
+        mgr.write_nowait("/p/q", b"hello").unwrap();
+        assert_eq!(mgr.size("/p/q"), Some(5));
+        mgr.write_nowait("/p/q", b"!!!").unwrap();
+        assert_eq!(mgr.size("/p/q"), Some(8));
+        let popped = mgr.read_nowait("/p/q").unwrap();
+        assert_eq!(popped.as_deref(), Some(b"hello".as_ref()));
+        assert_eq!(mgr.size("/p/q"), Some(3));
+    }
+
+    #[test]
+    fn test_size_missing_path_returns_none() {
+        let mgr = PipeManager::new();
+        assert_eq!(mgr.size("/p/nope"), None);
+    }
 
     /// Regression test for the lost-wakeup race fixed in this commit.
     ///

--- a/rust/kernel/src/core/pipe/mod.rs
+++ b/rust/kernel/src/core/pipe/mod.rs
@@ -27,6 +27,7 @@ pub mod remote;
 pub mod shm;
 #[cfg(unix)]
 pub mod stdio;
+pub mod wal;
 
 use std::cell::UnsafeCell;
 use std::sync::atomic::{AtomicBool, AtomicU64, AtomicUsize, Ordering};

--- a/rust/kernel/src/core/pipe/wal.rs
+++ b/rust/kernel/src/core/pipe/wal.rs
@@ -1,0 +1,262 @@
+//! Durable DT_PIPE backed by Raft-replicated entries (`io_profile="wal"`).
+//!
+//! Composes `WalStreamCore` to reuse the raft `AppendStreamEntry` /
+//! `get_stream_entry` plumbing. The pipe-only state — a per-replica head
+//! cursor — lives locally; each replica advances its own head as it
+//! `pop()`s entries it has not seen yet.
+//!
+//! ## Single-consumer assumption
+//!
+//! Each replica maintains its own head pointer. A `pop()` on replica A
+//! does not advance the head on replica B. For the AI-coordination use
+//! case this is intended: `/shared/coord/win-to-mac.pipe` is only popped
+//! on Mac, `/shared/coord/mac-to-win.pipe` is only popped on Win — each
+//! pipe has exactly one consumer node, so per-replica heads behave as a
+//! true destructive queue from that consumer's view.
+//!
+//! Entries remain in the raft state machine after pop; GC is intentionally
+//! deferred (cheap on the read path, simplifies semantics, lets late
+//! consumers replay if useful). Wire `Command::DeleteStreamEntry` later
+//! if memory pressure becomes a concern.
+//!
+//! Wire layout: keys are `/__wal_pipe__/<id>/<seq>` so they share the
+//! state machine's `TREE_STREAM_ENTRIES` table with WAL streams without
+//! key collision (stream prefix is `/__wal_stream__/<id>/<seq>`).
+
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::sync::Arc;
+
+use crate::pipe::{PipeBackend, PipeError};
+use crate::stream::StreamBackend;
+use crate::wal_stream::{WalConsensus, WalStreamCore};
+
+/// WAL-replicated DT_PIPE backend. See module docs for semantics.
+pub(crate) struct WalPipeCore {
+    inner: WalStreamCore,
+    /// Per-replica head cursor — next seq to pop. Independent of the
+    /// stream's tail; pop() advances it, push() never touches it.
+    head: AtomicU64,
+}
+
+impl WalPipeCore {
+    pub(crate) fn new(consensus: Arc<dyn WalConsensus>, pipe_id: String) -> Self {
+        // `__wal_pipe__/<id>` instead of `__wal_stream__/<id>` so the two
+        // share `TREE_STREAM_ENTRIES` without key collision.
+        let inner = WalStreamCore::new(consensus, format!("__wal_pipe__/{pipe_id}"));
+        Self {
+            inner,
+            head: AtomicU64::new(0),
+        }
+    }
+}
+
+impl PipeBackend for WalPipeCore {
+    fn push(&self, data: &[u8]) -> Result<usize, PipeError> {
+        // Reuse stream push; raft replicates the entry. Empty payload is a
+        // no-op for streams; mirror that here to match MemoryPipeBackend.
+        if data.is_empty() {
+            return Ok(0);
+        }
+        match StreamBackend::push(&self.inner, data) {
+            Ok(_) => Ok(data.len()),
+            Err(_) => Err(PipeError::Closed("wal pipe closed")),
+        }
+    }
+
+    fn pop(&self) -> Result<Vec<u8>, PipeError> {
+        let head = self.head.load(Ordering::Acquire);
+        match StreamBackend::read_at(&self.inner, head as usize) {
+            Ok((data, _next)) => {
+                // Advance head past the popped entry. CAS guards against
+                // a concurrent pop on the same replica; if another thread
+                // beat us to it, retry from its new head.
+                self.head
+                    .compare_exchange(head, head + 1, Ordering::AcqRel, Ordering::Acquire)
+                    .map_err(|_| PipeError::Empty)?;
+                Ok(data)
+            }
+            Err(crate::stream::StreamError::Empty) => Err(PipeError::Empty),
+            Err(crate::stream::StreamError::ClosedEmpty) => Err(PipeError::ClosedEmpty),
+            Err(_) => Err(PipeError::Empty),
+        }
+    }
+
+    fn close(&self) {
+        StreamBackend::close(&self.inner);
+    }
+
+    fn is_closed(&self) -> bool {
+        StreamBackend::is_closed(&self.inner)
+    }
+
+    fn is_empty(&self) -> bool {
+        // Empty from this replica's view: head has caught up to the
+        // stream tail. Other replicas may have a different head.
+        let tail = StreamBackend::tail_offset(&self.inner) as u64;
+        self.head.load(Ordering::Acquire) >= tail
+    }
+
+    fn size(&self) -> usize {
+        // Pending payload bytes — unknown without summing entry sizes,
+        // and the WAL stream API doesn't surface that cheaply. Report 0
+        // to match the `RemotePipeBackend` convention; consumers that
+        // care use `msg_count` instead.
+        0
+    }
+
+    fn msg_count(&self) -> usize {
+        let tail = StreamBackend::tail_offset(&self.inner) as u64;
+        let head = self.head.load(Ordering::Acquire);
+        tail.saturating_sub(head) as usize
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tests — in-memory WalConsensus mock, no raft runtime needed.
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use parking_lot::Mutex;
+    use std::collections::BTreeMap;
+
+    struct MemConsensus {
+        inner: Mutex<BTreeMap<String, Vec<u8>>>,
+    }
+
+    impl MemConsensus {
+        fn new() -> Self {
+            Self {
+                inner: Mutex::new(BTreeMap::new()),
+            }
+        }
+    }
+
+    impl WalConsensus for MemConsensus {
+        fn append(&self, key: &str, data: &[u8]) -> Result<(), String> {
+            self.inner.lock().insert(key.to_string(), data.to_vec());
+            Ok(())
+        }
+        fn get(&self, key: &str) -> Result<Option<Vec<u8>>, String> {
+            Ok(self.inner.lock().get(key).cloned())
+        }
+    }
+
+    fn pipe(id: &str) -> WalPipeCore {
+        WalPipeCore::new(Arc::new(MemConsensus::new()), id.to_string())
+    }
+
+    #[test]
+    fn push_then_pop_roundtrip() {
+        let p = pipe("t1");
+        assert_eq!(p.push(b"hello").unwrap(), 5);
+        assert_eq!(p.pop().unwrap(), b"hello");
+    }
+
+    #[test]
+    fn pop_empty_pipe_returns_empty_error() {
+        let p = pipe("t2");
+        assert!(matches!(p.pop(), Err(PipeError::Empty)));
+    }
+
+    #[test]
+    fn fifo_ordering_preserved() {
+        let p = pipe("t3");
+        for i in 0u8..5 {
+            p.push(&[i]).unwrap();
+        }
+        for i in 0u8..5 {
+            assert_eq!(p.pop().unwrap(), vec![i]);
+        }
+        assert!(matches!(p.pop(), Err(PipeError::Empty)));
+    }
+
+    #[test]
+    fn msg_count_reflects_unconsumed_only() {
+        let p = pipe("t4");
+        p.push(b"a").unwrap();
+        p.push(b"b").unwrap();
+        p.push(b"c").unwrap();
+        assert_eq!(p.msg_count(), 3);
+        p.pop().unwrap();
+        assert_eq!(p.msg_count(), 2);
+        p.pop().unwrap();
+        p.pop().unwrap();
+        assert_eq!(p.msg_count(), 0);
+    }
+
+    #[test]
+    fn is_empty_tracks_local_head_vs_tail() {
+        let p = pipe("t5");
+        assert!(p.is_empty());
+        p.push(b"x").unwrap();
+        assert!(!p.is_empty());
+        p.pop().unwrap();
+        assert!(p.is_empty());
+    }
+
+    #[test]
+    fn close_then_pop_drains_then_signals_closed_empty() {
+        let p = pipe("t6");
+        p.push(b"final").unwrap();
+        p.close();
+        assert!(p.is_closed());
+        assert_eq!(p.pop().unwrap(), b"final");
+        assert!(matches!(p.pop(), Err(PipeError::ClosedEmpty)));
+    }
+
+    #[test]
+    fn empty_push_is_noop() {
+        let p = pipe("t7");
+        assert_eq!(p.push(b"").unwrap(), 0);
+        assert_eq!(p.msg_count(), 0);
+    }
+
+    #[test]
+    fn binary_payload_with_null_bytes_roundtrip() {
+        let p = pipe("t8");
+        let payload = vec![0u8, 1, 0, 2, 0xff, 0x00, 0xfe];
+        p.push(&payload).unwrap();
+        assert_eq!(p.pop().unwrap(), payload);
+    }
+
+    /// Two `WalPipeCore` instances over the same consensus mock represent
+    /// two replicas. Each maintains its own head — a pop on replica A
+    /// does NOT advance B's head, so B can replay the same message. This
+    /// is the documented "single-consumer" semantic.
+    ///
+    /// Replica B can only see A's push after the bg flush thread has
+    /// committed it to the shared consensus (B has its own inflight map
+    /// so A's pre-flush state is invisible). Poll briefly to dodge the
+    /// async-flush race rather than sleeping a fixed duration.
+    #[test]
+    fn per_replica_heads_diverge_under_concurrent_consumers() {
+        use std::time::{Duration, Instant};
+        let consensus = Arc::new(MemConsensus::new());
+        let a = WalPipeCore::new(
+            Arc::clone(&consensus) as Arc<dyn WalConsensus>,
+            "shared".into(),
+        );
+        let b = WalPipeCore::new(
+            Arc::clone(&consensus) as Arc<dyn WalConsensus>,
+            "shared".into(),
+        );
+        a.push(b"msg-1").unwrap();
+        assert_eq!(a.pop().unwrap(), b"msg-1");
+
+        let deadline = Instant::now() + Duration::from_secs(2);
+        loop {
+            match b.pop() {
+                Ok(data) => {
+                    assert_eq!(data, b"msg-1");
+                    return;
+                }
+                Err(PipeError::Empty) if Instant::now() < deadline => {
+                    std::thread::sleep(Duration::from_millis(5));
+                }
+                other => panic!("expected Ok(msg-1) within 2s, got {other:?}"),
+            }
+        }
+    }
+}

--- a/rust/kernel/src/core/stream/manager.rs
+++ b/rust/kernel/src/core/stream/manager.rs
@@ -285,6 +285,15 @@ impl StreamManager {
         self.buffers.get(path).map(|r| Arc::clone(r.value()))
     }
 
+    /// Current tail (write offset) of a registered stream.
+    ///
+    /// Returns `None` if no stream is registered at `path`. Callers use
+    /// this for the seek-to-end pattern: `cursor = tail(path)` then
+    /// `read_at(path, cursor)` skips all history and blocks for new data.
+    pub fn tail(&self, path: &str) -> Option<usize> {
+        self.buffers.get(path).map(|b| b.tail_offset())
+    }
+
     /// Append all entries from `from` (starting at `from_offset`) into `to`.
     ///
     /// Analogous to a read-then-write splice between two DT_STREAMs. `to` must
@@ -420,6 +429,31 @@ mod tests {
         let sm = StreamManager::new();
         let result = sm.collect_all_payloads("/s/nope");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_tail_empty_stream() {
+        let sm = StreamManager::new();
+        sm.create("/s/empty", 1024).unwrap();
+        assert_eq!(sm.tail("/s/empty"), Some(0));
+    }
+
+    #[test]
+    fn test_tail_after_push() {
+        // Frame layout is [4B u32 LE length][N bytes payload]; tail tracks
+        // the post-frame write offset, so after one 5-byte push it lands at 9.
+        let sm = StreamManager::new();
+        sm.create("/s/one", 1024).unwrap();
+        sm.write_nowait("/s/one", b"hello").unwrap();
+        assert_eq!(sm.tail("/s/one"), Some(4 + 5));
+        sm.write_nowait("/s/one", b"world!").unwrap();
+        assert_eq!(sm.tail("/s/one"), Some(4 + 5 + 4 + 6));
+    }
+
+    #[test]
+    fn test_tail_missing_path_returns_none() {
+        let sm = StreamManager::new();
+        assert_eq!(sm.tail("/s/nope"), None);
     }
 
     /// Regression test for the lost-wakeup race.

--- a/rust/kernel/src/core/stream/mod.rs
+++ b/rust/kernel/src/core/stream/mod.rs
@@ -1,11 +1,19 @@
 //! Linear append-only buffer for DT_STREAM kernel IPC (Task #1574).
 //!
-//! Unlike `pipe.rs` (circular ring, destructive pop), MemoryStreamBackend is a
-//! linear append-only buffer where reads are non-destructive and offset-based.
-//! Multiple readers maintain independent cursors (fan-out).
+//! Semantic: log/topic (Kafka, Redis Streams, NATS JetStream). Reads are
+//! non-destructive and offset-based; the caller owns the cursor. Multiple
+//! readers fan out from independent offsets. This is the inverse of
+//! DT_PIPE (FIFO, destructive pop, single consumer): a stream replays.
 //!
 //! Message framing: `[4B u32 LE length][N bytes payload]`.
 //! No sentinel, no wrap-around — fundamentally simpler than the ring buffer.
+//!
+//! Read contract from Python: ``sys_read(path, offset)`` on a DT_STREAM
+//! returns ``{"data": bytes, "next_offset": int}`` so callers can advance
+//! their cursor without decoding the 4-byte LE frame header. ``next_offset``
+//! is the byte offset of the *next* frame, suitable to pass back as
+//! ``offset`` on the following ``sys_read``. DT_REG / DT_PIPE return raw
+//! bytes — the dict shape is gated on the DT_STREAM entry type.
 //!
 //! Error encoding: Rust raises `RuntimeError("StreamFull:…")` etc. Python
 //! translates to the matching exception class.

--- a/rust/kernel/src/kernel.rs
+++ b/rust/kernel/src/kernel.rs
@@ -1847,6 +1847,7 @@ impl Kernel {
     /// - `"memory"` (default) → MemoryPipeBackend
     /// - `"shared_memory"` → SharedMemoryPipeBackend (mmap, cross-process)
     /// - `"stdio"` → StdioPipeBackend (subprocess fd, newline-framed)
+    /// - `"wal"` → WalPipeCore (raft-replicated, cross-node, single-consumer)
     #[allow(unused_variables)]
     fn setattr_pipe(
         &self,
@@ -1914,6 +1915,26 @@ impl Kernel {
             {
                 return Err(KernelError::IOError("stdio pipes require unix".into()));
             }
+        } else if io_profile == "wal" {
+            // Raft-replicated DT_PIPE — mirrors the `setattr_stream`
+            // wal branch. Single-consumer semantics (each replica owns
+            // its head cursor); see `core/pipe/wal.rs` for the contract.
+            let zm = self.zone_manager_arc().ok_or_else(|| {
+                KernelError::IOError("io_profile=wal requires federation (set NEXUS_PEERS)".into())
+            })?;
+            let root_zone = "root";
+            let consensus = zm.registry().get_node(root_zone).ok_or_else(|| {
+                KernelError::IOError(format!("io_profile=wal: zone {root_zone} not loaded"))
+            })?;
+            let runtime = zm.runtime_handle();
+            let wal_consensus: Arc<dyn crate::wal_stream::WalConsensus> =
+                Arc::new(crate::wal_stream::RaftWalConsensus::new(consensus, runtime));
+            let backend = crate::core::pipe::wal::WalPipeCore::new(wal_consensus, path.to_string());
+            self.pipe_manager
+                .register(path, Arc::new(backend))
+                .map_err(pipe_mgr_err)?;
+            self.write_pipe_inode(path, capacity)?;
+            (None, None, None)
         } else {
             self.create_pipe(path, capacity)?;
             (None, None, None)

--- a/rust/kernel/src/kernel.rs
+++ b/rust/kernel/src/kernel.rs
@@ -2634,6 +2634,16 @@ impl Kernel {
         self.pipe_manager.has(path)
     }
 
+    /// Queued bytes pending in a DT_PIPE.
+    ///
+    /// Returns `KernelError::FileNotFound` if no pipe is registered at `path`.
+    /// `Ok(0)` means the pipe exists but has nothing to pop.
+    pub fn pipe_size(&self, path: &str) -> Result<usize, KernelError> {
+        self.pipe_manager
+            .size(path)
+            .ok_or_else(|| KernelError::FileNotFound(path.to_string()))
+    }
+
     /// Non-blocking write to a pipe. Returns bytes written.
     pub fn pipe_write_nowait(&self, path: &str, data: &[u8]) -> Result<usize, KernelError> {
         self.pipe_manager
@@ -2710,6 +2720,18 @@ impl Kernel {
     /// Check if a stream exists.
     pub fn has_stream(&self, path: &str) -> bool {
         self.stream_manager.has(path)
+    }
+
+    /// Current tail (write offset) of a DT_STREAM.
+    ///
+    /// Returns `KernelError::FileNotFound` if no stream is registered at
+    /// `path`. Callers use this for the seek-to-end pattern: read the tail,
+    /// then pass it as the offset to `stream_read_at_blocking` to skip
+    /// history and block until new data arrives.
+    pub fn stream_tail(&self, path: &str) -> Result<usize, KernelError> {
+        self.stream_manager
+            .tail(path)
+            .ok_or_else(|| KernelError::FileNotFound(path.to_string()))
     }
 
     /// Non-blocking write to a stream. Returns byte offset.

--- a/src/nexus/bricks/filesystem/scoped_filesystem.py
+++ b/src/nexus/bricks/filesystem/scoped_filesystem.py
@@ -80,8 +80,12 @@ class ScopedFilesystem(ScopedPathMixin):
         count: int | None = None,
         offset: int = 0,
         context: OperationContext | None = None,
-    ) -> bytes:
-        """Read file content as bytes (POSIX pread)."""
+    ) -> bytes | dict[str, Any]:
+        """Read file content as bytes (POSIX pread).
+
+        DT_STREAM returns ``{"data": bytes, "next_offset": int}``;
+        DT_REG / DT_PIPE return ``bytes``.
+        """
         return self._fs.sys_read(
             self._scope_path(path), count=count, offset=offset, context=context
         )

--- a/src/nexus/bricks/task_manager/dispatch_consumer.py
+++ b/src/nexus/bricks/task_manager/dispatch_consumer.py
@@ -192,6 +192,9 @@ class TaskDispatchPipeConsumer:
                 await asyncio.sleep(0.01)
                 continue
 
+            # DT_PIPE returns raw bytes (only DT_STREAM uses the dict shape).
+            assert isinstance(data, bytes)
+
             try:
                 msg = json.loads(data)
                 await self._dispatch(msg)

--- a/src/nexus/core/nexus_fs_content.py
+++ b/src/nexus/core/nexus_fs_content.py
@@ -68,8 +68,12 @@ class ContentMixin:
         count: int | None = None,
         offset: int = 0,
         context: OperationContext | None = None,
-    ) -> bytes:
+    ) -> bytes | dict[str, Any]:
         """Read file content as bytes (POSIX pread(2)).
+
+        DT_REG / DT_PIPE return ``bytes``. DT_STREAM returns
+        ``{"data": bytes, "next_offset": int}`` so consumers can advance
+        their cursor without decoding the 4-byte LE frame header.
 
         Thin async wrapper around Rust Kernel.sys_read (pure Rust, zero GIL).
         DT_PIPE/DT_STREAM, resolve, and hooks are [TRANSITIONAL] — migrates
@@ -127,14 +131,17 @@ class ContentMixin:
                 _data = _data[offset : offset + count] if count is not None else _data[offset:]
             return bytes(_data)
 
-        # DT_STREAM: blocking reads with offset tracking
+        # DT_STREAM: blocking reads with offset tracking. Returns dict so
+        # the caller can advance its cursor without manually decoding the
+        # 4-byte LE frame header.
         if result.entry_type == 4:  # DT_STREAM
             _result = self._kernel.stream_read_at(path, offset)
             if _result is not None:
-                return bytes(_result[0])
+                _data, _next = _result
+                return {"data": bytes(_data), "next_offset": _next}
             # Slow path — block in Rust (GIL-free)
             _data, _next = self._kernel.stream_read_at_blocking(path, offset, 30000)
-            return bytes(_data)
+            return {"data": bytes(_data), "next_offset": _next}
 
         # DT_REG: Rust guarantees data is set on success.
         data = result.data or b""
@@ -404,6 +411,8 @@ class ContentMixin:
 
         # Use Rust sys_read with offset/count for range reads
         content = self.sys_read(path, count=end, offset=0, context=context)
+        # read_range targets DT_REG; the dict shape is DT_STREAM-only.
+        assert isinstance(content, bytes)
         return content[start:end]
 
     @rpc_expose(description="Stream file content in chunks")
@@ -449,6 +458,8 @@ class ContentMixin:
         # Route through sys_read — Rust handles pre-hooks, CAS, federation,
         # external connector dispatch.  Chunked Rust reads are future work.
         data = self.sys_read(path, context=context)
+        # stream() chunks DT_REG content; the dict shape is DT_STREAM-only.
+        assert isinstance(data, bytes)
         for pos in range(0, len(data), chunk_size):
             yield data[pos : pos + chunk_size]
 
@@ -489,6 +500,8 @@ class ContentMixin:
         # Route through sys_read with offset/count — Rust handles hooks,
         # CAS routing, federation, external connectors.
         data = self.sys_read(path, count=end - start + 1, offset=start, context=context)
+        # stream_range targets DT_REG; the dict shape is DT_STREAM-only.
+        assert isinstance(data, bytes)
         for pos in range(0, len(data), chunk_size):
             yield data[pos : pos + chunk_size]
 

--- a/src/nexus/factory/zoekt_pipe_consumer.py
+++ b/src/nexus/factory/zoekt_pipe_consumer.py
@@ -189,6 +189,8 @@ class ZoektPipeConsumer:
                 except NexusFileNotFoundError:
                     logger.debug("Zoekt pipe closed, consumer exiting")
                     break
+                # DT_PIPE returns raw bytes (only DT_STREAM uses the dict shape).
+                assert isinstance(first, bytes)
                 msg = json.loads(first)
                 if msg["type"] == "write":
                     pending_paths.add(msg["path"])
@@ -203,6 +205,7 @@ class ZoektPipeConsumer:
                     break
                 try:
                     data = await asyncio.to_thread(nx.sys_read, _ZOEKT_PIPE_PATH)
+                    assert isinstance(data, bytes)
                     msg = json.loads(data)
                     if msg["type"] == "write":
                         pending_paths.add(msg["path"])

--- a/src/nexus/fs/_fsspec.py
+++ b/src/nexus/fs/_fsspec.py
@@ -268,7 +268,10 @@ class NexusFileSystem(AbstractFileSystem):
                 f"Use open() for streaming access."
             )
 
-        return self._kernel.sys_read(path, context=LOCAL_CONTEXT)
+        result = self._kernel.sys_read(path, context=LOCAL_CONTEXT)
+        # _cat_file targets DT_REG; the dict shape is DT_STREAM-only.
+        assert isinstance(result, bytes)
+        return result
 
     # -- Write -----------------------------------------------------------------
 

--- a/src/nexus/fs/_helpers.py
+++ b/src/nexus/fs/_helpers.py
@@ -237,6 +237,10 @@ def _LEGACY_grep(
             content = kernel.sys_read(fp, context=LOCAL_CONTEXT)
         except Exception:
             continue
+        if not isinstance(content, bytes):
+            # DT_STREAM returns {data, next_offset} — grep only scans
+            # regular files, so skip non-bytes payloads.
+            continue
         try:
             text = content.decode("utf-8", errors="replace")
         except Exception:

--- a/src/nexus/server/rpc/handlers/delta.py
+++ b/src/nexus/server/rpc/handlers/delta.py
@@ -39,6 +39,8 @@ async def handle_delta_read(nexus_fs: "NexusFS", params: Any, context: Any) -> d
     content = nexus_fs.sys_read(params.path, context=context)
     if isinstance(content, str):
         content = content.encode("utf-8")
+    # delta handler operates on DT_REG; the dict shape is DT_STREAM-only.
+    assert isinstance(content, bytes)
 
     server_hash = hash_content(content)
 
@@ -143,6 +145,8 @@ async def handle_delta_write(nexus_fs: "NexusFS", params: Any, context: Any) -> 
     except Exception as e:
         raise ValueError("Cannot apply delta to non-existent file. Use write() instead.") from e
 
+    # delta handler operates on DT_REG; the dict shape is DT_STREAM-only.
+    assert isinstance(current_content, bytes)
     current_hash = hash_content(current_content)
     if current_hash != base_hash:
         return {

--- a/src/nexus/server/rpc/handlers/filesystem.py
+++ b/src/nexus/server/rpc/handlers/filesystem.py
@@ -72,11 +72,14 @@ async def handle_read_async(
         if result:
             return result
 
-    # Plain sys_read (Tier 1) — no metadata, no parsing
+    # Plain sys_read (Tier 1) — no metadata, no parsing.
+    # DT_REG / DT_PIPE return bytes; DT_STREAM returns
+    # ``{"data": bytes, "next_offset": int}`` so JSON-RPC consumers can
+    # advance their cursor without decoding the frame header.
     if not parsed and not return_metadata:
         _count = getattr(params, "count", None)
         _offset = getattr(params, "offset", 0) or 0
-        read_result: bytes = nexus_fs.sys_read(
+        read_result: bytes | dict[str, Any] = nexus_fs.sys_read(
             params.path,
             count=_count,
             offset=_offset,

--- a/src/nexus/services/gateway.py
+++ b/src/nexus/services/gateway.py
@@ -125,7 +125,7 @@ class NexusFSGateway:
         path: str,
         *,
         context: "OperationContext | None" = None,
-    ) -> bytes:
+    ) -> bytes | dict[str, Any]:
         """Read file content as bytes (POSIX pread(2)).
 
         Args:
@@ -133,7 +133,8 @@ class NexusFSGateway:
             context: Operation context for permissions
 
         Returns:
-            File content as bytes.
+            File content as bytes for DT_REG / DT_PIPE.
+            DT_STREAM returns ``{"data": bytes, "next_offset": int}``.
         """
         return self._fs.sys_read(path, context=context)
 

--- a/src/nexus/services/lifecycle/workflow_dispatch_service.py
+++ b/src/nexus/services/lifecycle/workflow_dispatch_service.py
@@ -207,6 +207,9 @@ class WorkflowDispatchService:
                 await asyncio.sleep(0.01)
                 continue
 
+            # DT_PIPE returns raw bytes (only DT_STREAM uses the dict shape).
+            assert isinstance(data, bytes)
+
             try:
                 msg = json.loads(data)
                 await engine.fire_event(msg["type"], msg["ctx"])

--- a/src/nexus/task_manager/dispatch_consumer.py
+++ b/src/nexus/task_manager/dispatch_consumer.py
@@ -194,6 +194,10 @@ class TaskDispatchPipeConsumer:
                 await asyncio.sleep(0.01)
                 continue
 
+            # _TASK_DISPATCH_PIPE_PATH is a DT_PIPE — sys_read returns
+            # raw bytes for DT_PIPE (only DT_STREAM returns the dict shape).
+            assert isinstance(data, bytes)
+
             try:
                 msg = json.loads(data)
                 await self._dispatch(msg)

--- a/tests/unit/core/test_nexus_fs_dt_stream_read.py
+++ b/tests/unit/core/test_nexus_fs_dt_stream_read.py
@@ -1,0 +1,97 @@
+"""sys_read DT_STREAM dict-return contract.
+
+Covers the Python wrapper at ``nexus_fs_content.py`` where DT_STREAM reads
+return ``{"data": bytes, "next_offset": int}`` so consumers can advance
+their cursor without manually decoding the 4-byte LE frame header.
+DT_REG / DT_PIPE return shapes are unchanged (bytes only).
+"""
+
+from __future__ import annotations
+
+import contextlib
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.types import OperationContext
+from nexus.core.nexus_fs import NexusFS
+
+
+class _StubFS:
+    """Minimal NexusFS double exercising only the sys_read DT_STREAM path."""
+
+    def __init__(self, kernel: MagicMock) -> None:
+        self._kernel = kernel
+        self._zone_id = ROOT_ZONE_ID
+        self._enforce_permissions = False
+        self._init_cred = OperationContext(user_id="test", groups=[], zone_id=ROOT_ZONE_ID)
+        self.resolve_read = MagicMock(return_value=(False, None))
+
+    def _validate_path(self, path: str) -> str:
+        return path
+
+    def _parse_context(self, context):
+        return context
+
+    def _build_rust_ctx(self, context, is_admin):
+        return SimpleNamespace(zone_id=self._zone_id, is_admin=is_admin)
+
+    @contextlib.contextmanager
+    def _vfs_locked(self, path, mode):
+        yield
+
+
+# Graft the real NexusFS.sys_read so we exercise the production dispatch.
+_StubFS.sys_read = NexusFS.sys_read
+
+
+class TestSysReadDtStream:
+    def test_returns_dict_with_next_offset_when_data_available(self):
+        kernel = MagicMock()
+        # entry_type=4 selects the DT_STREAM branch.
+        kernel.sys_read.return_value = SimpleNamespace(
+            entry_type=4, data=None, content_id=None, post_hook_needed=False
+        )
+        # Hot path: stream_read_at returns (data, next_offset); next_offset
+        # is `4-byte frame header + payload length` past the request offset.
+        kernel.stream_read_at.return_value = (b"hello", 9)
+
+        fs = _StubFS(kernel)
+        result = fs.sys_read("/s/test", offset=0)
+
+        assert result == {"data": b"hello", "next_offset": 9}
+        # next_offset must equal 4 (frame header) + len(payload) past the
+        # request offset, so a follow-up read at next_offset advances cleanly.
+        assert result["next_offset"] == 4 + len(result["data"])
+        kernel.stream_read_at.assert_called_once_with("/s/test", 0)
+        kernel.stream_read_at_blocking.assert_not_called()
+
+    def test_falls_back_to_blocking_read_when_stream_empty(self):
+        kernel = MagicMock()
+        kernel.sys_read.return_value = SimpleNamespace(
+            entry_type=4, data=None, content_id=None, post_hook_needed=False
+        )
+        # Hot path returns None → wrapper blocks in Rust (GIL-free).
+        kernel.stream_read_at.return_value = None
+        kernel.stream_read_at_blocking.return_value = (b"world", 16)
+
+        fs = _StubFS(kernel)
+        result = fs.sys_read("/s/test", offset=7)
+
+        assert result == {"data": b"world", "next_offset": 16}
+        kernel.stream_read_at.assert_called_once_with("/s/test", 7)
+        kernel.stream_read_at_blocking.assert_called_once_with("/s/test", 7, 30000)
+
+    def test_dt_reg_path_still_returns_bytes(self):
+        # Regression: the dict shape is gated on entry_type==4 (DT_STREAM)
+        # only — DT_REG must keep returning raw bytes so existing callers
+        # are not silently broken.
+        kernel = MagicMock()
+        kernel.sys_read.return_value = SimpleNamespace(
+            entry_type=1, data=b"file-bytes", content_id=None, post_hook_needed=False
+        )
+
+        fs = _StubFS(kernel)
+        result = fs.sys_read("/regular/file.txt")
+
+        assert result == b"file-bytes"


### PR DESCRIPTION
## Summary

Brings the DT_STREAM / DT_PIPE primitives to feature-parity for cross-node federation:

- **`sys_read` on DT_STREAM** now returns `{"data": bytes, "next_offset": int}` instead of raw bytes — RPC consumers can advance their cursor without recomputing `offset + 4 + len(data)` (which leaks the 4-byte LE frame header into client code).
- **`Kernel::stream_tail` / `Kernel::pipe_size`** surfaced as **kernel-internal** Rust APIs (no PyO3, no Python syscall) for future Rust consumers (federation forwarders, WAL replicator).
- **`WalPipeCore` + `sys_setattr(io_profile="wal")` for DT_PIPE** — DT_PIPE now has the same federated path as DT_STREAM (`io_profile="wal"`). Composes `WalStreamCore` + a per-replica head cursor; reuses the existing raft `Command::AppendStreamEntry`, no new consensus surface.
- Stream module header rewritten to position DT_STREAM as a log/topic primitive (Kafka / Redis Streams / NATS JetStream) with the dict-return contract pinned.

DT_REG and DT_PIPE return shapes from `sys_read` are unchanged (raw bytes). The DT_STREAM dict shape is gated on `entry_type == 4`.

## Why this PR

Stepping stone for Win↔macOS AI-coordination over the federated `/shared` zone. Without `next_offset` in the read result, a JSON-RPC consumer cannot advance its DT_STREAM cursor at all — the prior contract was effectively unusable for any client outside the kernel process. WAL pipe gives the AI coord a destructive single-consumer queue alternative to the non-destructive WAL stream — both replicated cross-node, lets us measure which fits the chat workflow better.

## Wire-format break

Existing DT_STREAM RPC consumers that expected raw bytes will break. Per exploration, no test asserts the bytes-only shape and no current caller could actually advance its cursor under the old contract — so this is a fix, not a regression. No alias / no compatibility shim.

## WAL pipe — single-consumer semantic

`WalPipeCore` reuses `WalStreamCore` (raft `AppendStreamEntry`) for push, and maintains a **per-replica `head` cursor** for pop. Each replica owns its head independently — a `pop` on replica A does not advance replica B's head. For the AI-coord case this is intended:

```
/shared/coord/win-to-mac.pipe  — pushed by Win, popped by Mac only
/shared/coord/mac-to-win.pipe  — pushed by Mac, popped by Win only
```

One consumer per pipe, so per-replica heads behave as a destructive queue from the consumer's view. Multi-consumer pop on the same pipe will replay from each consumer's head — caller responsibility, documented in the module header.

Storage prefix `/__wal_pipe__/<id>/<seq>` shares the state machine's `TREE_STREAM_ENTRIES` with WAL streams without key collision (stream prefix is `/__wal_stream__/<id>/<seq>`). **No new redb tables, no new raft `Command` variants, no consensus core changes.** GC is intentionally deferred — entries stay in the state machine after pop.

## Test plan

- [x] `cargo check --workspace --all-features` clean
- [x] Rust unit tests: `core::stream::manager::tests::test_tail_*` (3) + `core::pipe::manager::tests::test_size_*` (3) + `core::pipe::wal::tests` (9) pass
- [x] Codegen idempotent: `codegen_kernel_abi.py --check` + `generate_rpc_params.py --check` OK
- [x] Python tests: `tests/unit/core/test_nexus_fs_dt_stream_read.py` (3) pass; `test_nexus_fs_stream_range.py` no regressions
- [x] Mypy clean on touched files (system / nexus_env Python; the `.venv` errors are pre-existing on develop tip — see commit message on `feat(vfs)`)
- [x] Win-side single-node smoke (build cp313 wheel via `maturin build --release --interpreter nexus_env/python.exe`, install with `pip install --ignore-requires-python`): memory DT_STREAM dict-return contract verified end-to-end (sys_read returns `{data, next_offset}`, advancing cursor works); DT_REG regression guard pass (still returns bytes). WAL DT_STREAM and WAL DT_PIPE branches both correctly raise `OSError: io_profile=wal requires federation (set NEXUS_PEERS)` on single-node — confirms the wal code path is reachable + errors gracefully without federation. Cross-node WAL smoke is exercised by the in-process `WalConsensus` mock in `core/pipe/wal::tests::per_replica_heads_diverge_under_concurrent_consumers` and deferred to post-#3932 macOS↔Win raft cluster.

## Out of scope (separate follow-up)

- Federation wiring for `Kernel::create_stream` / `create_pipe` — original "F1" plan, dropped because `io_profile="wal"` already gives cross-node behaviour without auto-pick.
- `Command::DeleteStreamEntry` GC for popped WAL pipe entries — deferred until memory pressure observed.
- Pre-commit `.venv` mypy environment fix (missing types-cachetools / types-aiofiles, mypy 1.20.2 INTERNAL ERROR — unrelated, exists on develop tip).

## Coordination — PR #3932 rebase

PR #3932 (Phase 3 workspace finalization) currently bases on pre-#3926. After this PR merges, #3932 will hit conflicts on:

1. **`rust/kernel/src/core/pipe/mod.rs`** — new `pub mod wal;` declaration.
2. **`rust/kernel/src/kernel.rs`** — `setattr_pipe` gains an `io_profile == "wal"` branch (next to the existing `shared_memory` / `stdio` branches). New `Kernel::stream_tail` / `Kernel::pipe_size` methods on the IPC registry section.
3. **`rust/kernel/src/core/stream/manager.rs`** — new `StreamManager::tail` method.
4. **`rust/kernel/src/core/pipe/manager.rs`** — new `PipeManager::size` method.
5. **`rust/kernel/src/core/stream/mod.rs`** — module header rewritten.
6. **`src/nexus/core/nexus_fs_content.py:131`** — `sys_read` DT_STREAM branch now returns dict; signature is `bytes | dict[str, Any]`.
7. **11 Python callers** — type-narrowed with `assert isinstance(_, bytes)` (DT_REG/DT_PIPE call sites). If #3932 touches `read_range`, `stream`, `stream_range`, `_fsspec._cat_file`, the delta/filesystem RPC handlers, or the zoekt/workflow/task-manager DT_PIPE consumers, watch for the assert.
8. **`tests/unit/core/test_nexus_fs_dt_stream_read.py`** — new test file.

If #3932 introduces its own `setattr_pipe` change, ensure the `io_profile=="wal"` branch survives the rebase (between `stdio` and the default `else`). Same for `setattr_stream`'s `wal` branch — already on develop.

### #3932 author confirmed structural moves landing in their branch

Acked from #3932 author — the rebase has known migration tasks because Phase G/H landed there:

- **Phase G — `kernel.rs` split.** The monolithic `rust/kernel/src/kernel.rs` is replaced with `kernel/{mod,io,ipc,locks,dispatch,observability}.rs`. After rebase: this PR's `setattr_pipe` `io_profile == "wal"` branch lives in `kernel/mod.rs`; `Kernel::stream_tail` / `Kernel::pipe_size` belong in `kernel/ipc.rs`. Codegen scanner already understands the split — no `#[pyo3]` exposure regression.
- **Phase H — `core/stream/wal.rs` moved to `rust/raft/src/wal_stream_backend.rs`.** This PR's `core/stream/mod.rs` doc rewrite still has `pub mod wal;` (kernel-internal in develop tip). After rebase: keep this PR's docs, drop the `pub mod wal;` line (the kernel-side module is gone). This PR's *new* `core/pipe/wal.rs` is unaffected — pipe-side, no symbol collision via the namespaced `__wal_pipe__/<id>/<seq>` prefix.
- **Phase H — kernel↔raft Cargo edge flipped.** Kernel no longer depends on `nexus_raft`. Federation goes through a new `kernel::hal::federation::FederationProvider` trait implemented by `nexus_raft::federation_provider::RaftFederationProvider`. After rebase: `setattr_pipe`'s WAL branch (currently does `crate::wal_stream::RaftWalConsensus::new(...)`) and `WalPipeCore`'s `use crate::wal_stream::{WalConsensus, WalStreamCore};` need to migrate to either `nexus_raft::wal_stream_backend::*` or, preferably, route through `FederationProvider`. #3932 author offered to extend the trait if the WAL pipe path needs surface that isn't exposed yet.
- **Wheel rename `nexus_kernel.so` → `nexus_runtime.so`.** This PR's only test file (`test_nexus_fs_dt_stream_read.py`) does not import `nexus_kernel` — only `from nexus.core...` paths. No change needed.

Conclusion for this PR: **no preemptive code changes** — every Phase G/H delta is post-rebase work that the #3932 author absorbs when rebasing on top. This PR stays at the develop-tip surface (single-file `kernel.rs`, kernel-internal `wal_stream` module, `kernel → raft` Cargo edge intact).

## Commits

1. `feat(kernel): expose StreamManager::tail / PipeManager::size as kernel-internal helpers` — Rust kernel-internal APIs + 6 Rust unit tests. No PyO3 surface.
2. `feat(vfs): sys_read DT_STREAM returns {data, next_offset} dict` — Python wrapper change + 11-file caller fan-out (DT_REG / DT_PIPE callers narrowed via `assert isinstance`) + 3 Python tests.
3. `docs(stream): document log/topic semantic and sys_read dict-return contract` — module header rewrite.
4. `feat(pipe): add WalPipeCore + sys_setattr(io_profile=wal) for DT_PIPE` — `WalPipeCore` impl + setattr_pipe wiring + 9 Rust unit tests.

