### PR TITLE
perf(sandbox): lazy MCP imports drop default RSS 197MB → 145MB

### DIFF
--- a/src/nexus/bricks/discovery/tool_index.py
+++ b/src/nexus/bricks/discovery/tool_index.py
@@ -9,9 +9,10 @@ Issue: #484
 
 import re
 from dataclasses import dataclass, field
-from typing import Any
+from typing import TYPE_CHECKING, Any
 
-import bm25s
+if TYPE_CHECKING:
+    import bm25s
 
 
 @dataclass
@@ -71,7 +72,7 @@ class ToolIndex:
         # BM25S index state
         self._tool_names: list[str] = []
         self._corpus_tokens: list[list[str]] = []
-        self._retriever: bm25s.BM25 | None = None
+        self._retriever: "bm25s.BM25 | None" = None
         self._dirty: bool = False
 
     def add_tool(self, tool: ToolInfo) -> None:
@@ -126,6 +127,8 @@ class ToolIndex:
             self._dirty = False
             return
 
+        import bm25s
+
         self._retriever = bm25s.BM25(k1=self.k1, b=self.b)
         self._retriever.index(self._corpus_tokens)
         self._dirty = False
@@ -144,6 +147,8 @@ class ToolIndex:
         query_tokens = self._tokenize(query)
         if not query_tokens:
             return []
+
+        import bm25s
 
         k = min(top_k, len(self._tool_names))
         query_tokenized = bm25s.tokenize([" ".join(query_tokens)])

--- a/src/nexus/bricks/mcp/__init__.py
+++ b/src/nexus/bricks/mcp/__init__.py
@@ -41,34 +41,97 @@ Usage:
     klavis = KlavisClient(api_key="...")
 """
 
-from nexus.bricks.mcp.connection_manager import (
-    MCPConnection,
-    MCPConnectionError,
-    MCPConnectionManager,
-)
-from nexus.bricks.mcp.exporter import MCPToolExporter
-from nexus.bricks.mcp.klavis_client import (
-    KlavisClient,
-    KlavisError,
-    KlavisMCPInstance,
-    KlavisOAuthResult,
-)
-from nexus.bricks.mcp.models import MCPMount, MCPToolConfig, MCPToolDefinition, MCPToolExample
-from nexus.bricks.mcp.mount import MCPMountError, MCPMountManager
-from nexus.bricks.mcp.provider_registry import (
-    BackendConfig,
-    MCPConfig,
-    MCPProviderRegistry,
-    OAuthConfig,
-    ProviderConfig,
-    ProviderType,
-)
-from nexus.bricks.mcp.server import (
-    create_mcp_server,
-    get_request_api_key,
-    reset_request_api_key,
-    set_request_api_key,
-)
+# PEP 562 lazy re-exports: keep `from nexus.bricks.mcp import X` working
+# without forcing fastmcp/mcp/beartype/rich/griffe/opentelemetry to load
+# at brick discovery time. Each symbol resolves on first attribute access
+# and caches into module globals.
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from nexus.bricks.mcp.connection_manager import (
+        MCPConnection,
+        MCPConnectionError,
+        MCPConnectionManager,
+    )
+    from nexus.bricks.mcp.exporter import MCPToolExporter
+    from nexus.bricks.mcp.klavis_client import (
+        KlavisClient,
+        KlavisError,
+        KlavisMCPInstance,
+        KlavisOAuthResult,
+    )
+    from nexus.bricks.mcp.models import (
+        MCPMount,
+        MCPToolConfig,
+        MCPToolDefinition,
+        MCPToolExample,
+    )
+    from nexus.bricks.mcp.mount import MCPMountError, MCPMountManager
+    from nexus.bricks.mcp.provider_registry import (
+        BackendConfig,
+        MCPConfig,
+        MCPProviderRegistry,
+        OAuthConfig,
+        ProviderConfig,
+        ProviderType,
+    )
+    from nexus.bricks.mcp.server import (
+        create_mcp_server,
+        get_request_api_key,
+        reset_request_api_key,
+        set_request_api_key,
+    )
+
+_LAZY_MAP: dict[str, str] = {
+    # Server
+    "create_mcp_server": "nexus.bricks.mcp.server",
+    "set_request_api_key": "nexus.bricks.mcp.server",
+    "get_request_api_key": "nexus.bricks.mcp.server",
+    "reset_request_api_key": "nexus.bricks.mcp.server",
+    # Connection manager
+    "MCPConnection": "nexus.bricks.mcp.connection_manager",
+    "MCPConnectionError": "nexus.bricks.mcp.connection_manager",
+    "MCPConnectionManager": "nexus.bricks.mcp.connection_manager",
+    # Klavis client
+    "KlavisClient": "nexus.bricks.mcp.klavis_client",
+    "KlavisError": "nexus.bricks.mcp.klavis_client",
+    "KlavisMCPInstance": "nexus.bricks.mcp.klavis_client",
+    "KlavisOAuthResult": "nexus.bricks.mcp.klavis_client",
+    # Models
+    "MCPMount": "nexus.bricks.mcp.models",
+    "MCPToolConfig": "nexus.bricks.mcp.models",
+    "MCPToolDefinition": "nexus.bricks.mcp.models",
+    "MCPToolExample": "nexus.bricks.mcp.models",
+    # Mount
+    "MCPMountError": "nexus.bricks.mcp.mount",
+    "MCPMountManager": "nexus.bricks.mcp.mount",
+    # Provider registry
+    "BackendConfig": "nexus.bricks.mcp.provider_registry",
+    "MCPConfig": "nexus.bricks.mcp.provider_registry",
+    "MCPProviderRegistry": "nexus.bricks.mcp.provider_registry",
+    "OAuthConfig": "nexus.bricks.mcp.provider_registry",
+    "ProviderConfig": "nexus.bricks.mcp.provider_registry",
+    "ProviderType": "nexus.bricks.mcp.provider_registry",
+    # Exporter
+    "MCPToolExporter": "nexus.bricks.mcp.exporter",
+}
+
+
+def __getattr__(name: str) -> object:  # PEP 562
+    target = _LAZY_MAP.get(name)
+    if target is None:
+        raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
+    import importlib
+
+    mod = importlib.import_module(target)
+    value = getattr(mod, name)
+    globals()[name] = value
+    return value
+
+
+def __dir__() -> list[str]:
+    return sorted(set(list(globals().keys()) + list(_LAZY_MAP.keys())))
+
 
 __all__ = [
     # Server

--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -311,7 +311,16 @@ async def create_mcp_server(
     # Add the middleware to FastMCP
     mcp.add_middleware(APIKeyExtractionMiddleware())
 
-    # Add tool namespace middleware if provided (Issue #1272)
+    # Add tool namespace middleware if provided (Issue #1272). The factory
+    # may pass a zero-arg callable that builds the middleware on demand —
+    # this defers the fastmcp/beartype import until an MCP server is
+    # actually started, keeping ``nexus.connect()`` lightweight.
+    if (
+        tool_namespace_middleware is not None
+        and not hasattr(tool_namespace_middleware, "on_call_tool")
+        and callable(tool_namespace_middleware)
+    ):
+        tool_namespace_middleware = tool_namespace_middleware()
     if tool_namespace_middleware is not None:
         mcp.add_middleware(tool_namespace_middleware)
 

--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -315,12 +315,23 @@ async def create_mcp_server(
     # may pass a zero-arg callable that builds the middleware on demand —
     # this defers the fastmcp/beartype import until an MCP server is
     # actually started, keeping ``nexus.connect()`` lightweight.
+    # Preserves the prior guarded-boot failure policy: on ImportError the
+    # optional middleware is skipped with a WARNING rather than failing
+    # MCP server creation outright.
     if (
         tool_namespace_middleware is not None
         and not hasattr(tool_namespace_middleware, "on_call_tool")
         and callable(tool_namespace_middleware)
     ):
-        tool_namespace_middleware = tool_namespace_middleware()
+        try:
+            tool_namespace_middleware = tool_namespace_middleware()
+        except ImportError as _e:
+            logger.warning(
+                "ToolNamespaceMiddleware unavailable (deferred import failed: %s); "
+                "MCP server starting without per-tool ReBAC filtering",
+                _e,
+            )
+            tool_namespace_middleware = None
     if tool_namespace_middleware is not None:
         mcp.add_middleware(tool_namespace_middleware)
 

--- a/src/nexus/factory/_bricks.py
+++ b/src/nexus/factory/_bricks.py
@@ -286,19 +286,29 @@ def _boot_independent_bricks(
         logger.debug("[BOOT:BRICK] MCP/Manifest brick disabled by profile")
 
     # --- Tool Namespace Middleware (Issue #1272) ---
-    tool_namespace_middleware = None
+    # Stored as a deferred callable so brick boot does not import fastmcp /
+    # mcp / beartype unless an MCP server is actually started. Consumers in
+    # ``nexus.bricks.mcp.server`` materialize via ``_resolve_tool_ns_middleware``.
+    tool_namespace_middleware: Any = None
     if _on("mcp"):
-        try:
+        _rebac_manager = system["rebac_manager"]
+        _zone_id = ctx.zone_id
+        _cache_ttl = ctx.cache_ttl_seconds or 300
+
+        def _build_tool_namespace_middleware() -> Any:
             from nexus.bricks.mcp.middleware import ToolNamespaceMiddleware
 
-            tool_namespace_middleware = ToolNamespaceMiddleware(
-                rebac_manager=system["rebac_manager"],
-                zone_id=ctx.zone_id,
-                cache_ttl=ctx.cache_ttl_seconds or 300,
+            return ToolNamespaceMiddleware(
+                rebac_manager=_rebac_manager,
+                zone_id=_zone_id,
+                cache_ttl=_cache_ttl,
             )
-            logger.debug("[BOOT:BRICK] ToolNamespaceMiddleware created (zone_id=%s)", ctx.zone_id)
-        except ImportError as _e:
-            logger.debug("[BOOT:BRICK] ToolNamespaceMiddleware unavailable: %s", _e)
+
+        tool_namespace_middleware = _build_tool_namespace_middleware
+        logger.debug(
+            "[BOOT:BRICK] ToolNamespaceMiddleware factory registered (zone_id=%s, deferred)",
+            ctx.zone_id,
+        )
 
     # --- Chunked Upload Service (Issue #788) ---
     chunked_upload_service: Any = None

--- a/tests/unit/bricks/mcp/test_deferred_middleware.py
+++ b/tests/unit/bricks/mcp/test_deferred_middleware.py
@@ -1,0 +1,92 @@
+"""Tests for deferred ToolNamespaceMiddleware factory in create_mcp_server.
+
+The factory may pass a zero-arg callable instead of a real middleware
+instance to defer the fastmcp/beartype import cost until an MCP server
+is actually started. These tests verify:
+
+* Direct-instance pass-through (backward compat)
+* Deferred-callable success path (factory invoked once, instance installed)
+* Deferred-callable ImportError path (graceful degradation, no crash)
+"""
+
+import logging
+from unittest.mock import Mock
+
+import pytest
+
+from nexus.bricks.mcp.server import create_mcp_server
+
+
+@pytest.fixture
+def mock_nx():
+    nx = Mock()
+    nx.read = Mock(return_value=b"")
+    nx.write = Mock()
+    nx.list = Mock(return_value=[])
+    nx.glob = Mock(return_value=[])
+    nx.grep = Mock(return_value=[])
+    nx.exists = Mock(return_value=True)
+    nx.is_directory = Mock(return_value=False)
+    nx.edit = Mock(
+        return_value={"success": True, "diff": "", "applied_count": 0, "matches": [], "errors": []}
+    )
+    return nx
+
+
+def _real_looking_middleware() -> Mock:
+    """Mock instance that looks like a real ToolNamespaceMiddleware.
+
+    The detection branch in server.py keys on the ``on_call_tool`` attr
+    (every fastmcp Middleware subclass has it), so the test mock must
+    expose that attribute to be treated as an instance, not a factory.
+    """
+    mw = Mock()
+    mw.on_call_tool = Mock()  # marker — pass-through path
+    mw.resolve_visible_tools = Mock(return_value=None)
+    return mw
+
+
+class TestDeferredMiddleware:
+    async def test_direct_instance_passes_through(self, mock_nx):
+        """Real middleware instances are not invoked as a callable."""
+        instance = _real_looking_middleware()
+        server = await create_mcp_server(nx=mock_nx, tool_namespace_middleware=instance)
+        assert server is not None
+        # Sanity: instance was not called as a factory
+        instance.assert_not_called()
+
+    async def test_deferred_callable_materializes_once(self, mock_nx):
+        """A zero-arg callable without on_call_tool is invoked exactly once."""
+        invocations: list[int] = []
+
+        def factory():
+            invocations.append(1)
+            return _real_looking_middleware()
+
+        server = await create_mcp_server(nx=mock_nx, tool_namespace_middleware=factory)
+        assert server is not None
+        assert len(invocations) == 1, "factory must be invoked exactly once"
+
+    async def test_deferred_callable_import_error_degrades(self, mock_nx, caplog):
+        """ImportError from the factory is logged and MCP server still creates.
+
+        Mirrors the prior eager-boot policy in factory/_bricks.py where a
+        missing middleware module skipped the optional brick wiring instead
+        of failing the whole connect path.
+        """
+
+        def bad_factory():
+            raise ImportError("simulated missing fastmcp")
+
+        with caplog.at_level(logging.WARNING, logger="nexus.bricks.mcp.server"):
+            server = await create_mcp_server(nx=mock_nx, tool_namespace_middleware=bad_factory)
+
+        assert server is not None, "create_mcp_server must not crash on factory ImportError"
+        assert any(
+            "ToolNamespaceMiddleware unavailable" in rec.message for rec in caplog.records
+        ), "expected WARNING about deferred middleware import failure"
+
+    async def test_none_passes_through(self, mock_nx):
+        """None is the no-op case — server creates without middleware."""
+        server = await create_mcp_server(nx=mock_nx, tool_namespace_middleware=None)
+        assert server is not None


### PR DESCRIPTION
## Summary

- Brick auto-discovery imports every brick's `__init__.py` to read its `TIER` / `RESULT_KEY` metadata. Eager re-exports in `nexus.bricks.mcp.__init__.py` chained `fastmcp` + `beartype` + `rich` + `griffe` + `opentelemetry` (~700 modules) into every `nexus.connect()`, regardless of feature flags.
- The factory also constructed `ToolNamespaceMiddleware` eagerly for an MCP server that, in the SDK path, is never started — paying the `fastmcp` import cost for a dead reference (CLI's `create_mcp_server` call doesn't pass it).
- Net: **default sandbox RSS drops from 197 MB → 145 MB (−53 MB, −1220 modules) with no public API change.**

## Changes

| file | change |
|---|---|
| `src/nexus/bricks/mcp/__init__.py` | PEP 562 `__getattr__` lazy re-exports for the 24 public symbols. `from nexus.bricks.mcp import X` still works; modules load on first attribute access. |
| `src/nexus/bricks/discovery/tool_index.py` | Defer `import bm25s` from module top-level into `_rebuild()` and `search()`. `TYPE_CHECKING` preserves the type annotation. `ToolInfo` / `ToolMatch` dataclasses no longer pull `bm25s` + `numpy`. |
| `src/nexus/factory/_bricks.py` | Register `ToolNamespaceMiddleware` as a zero-arg deferred callable in the `system` dict instead of constructing it eagerly. |
| `src/nexus/bricks/mcp/server.py` | Materialize the deferred middleware factory on first use in `create_mcp_server`. Real instances pass through unchanged (detected via `on_call_tool` attr). |

## Measured Impact

M-series macOS, py3.14, release kernel:

| scenario | before | after | Δ |
|---|---|---|---|
| `import nexus` | 38.8 MB | 38.5 MB | flat |
| `connect(profile=sandbox)` default | 197.2 MB | **144.7 MB** | **−53 MB** |
| `sys.modules` in default sandbox | 2585 | **1365** | **−1220** |

Heavy deps no longer loaded in default sandbox: `fastmcp` (104 mods), `mcp` (92), `beartype` (344), `bm25s`, `rich` (57), `griffe` (43), `opentelemetry` (24), `requests`, `httpx`.

Boot time: ~4.5 s → ~1.5 s (estimated; benchmark next).

## Why This Is Safe

- **Public API is identical.** `from nexus.bricks.mcp import create_mcp_server` works; `dir(nexus.bricks.mcp)` lists all 24 symbols; `AttributeError` for unknown names is preserved.
- **Middleware behavior preserved.** Existing tests (`test_discovery_namespace.py`, `test_tool_namespace_integration.py`, `test_mcp_tool_namespace_e2e.py`) pass real `ToolNamespaceMiddleware` instances; the new `hasattr(..., "on_call_tool")` check forwards them through unchanged. Only the factory's deferred-callable goes through the materialization branch.
- **No feature-flag semantics changed.** `features.mcp=False` still gates runtime; this PR just stops paying the import cost when the middleware (or any MCP class) is never reached.

## Test plan

- [x] `pytest tests/unit/bricks/mcp/ tests/unit/discovery/test_tool_index.py` — 343 passed, 1 pre-existing skip
- [x] Public-API regression check: `from nexus.bricks.mcp import {create_mcp_server, MCPConnectionManager, ...}`, `dir(M)`, AttributeError on bad name
- [x] Functional check: `create_mcp_server(tool_namespace_middleware=callable)` materializes the factory exactly once and `fastmcp` enters `sys.modules` only at that point
- [x] RSS benchmark: 197 → 145 MB (this branch)
- [ ] CI green
- [ ] Reviewer spot-check: `nexus mcp serve --transport stdio` boots and serves tools (e2e)

## Follow-ups (not in this PR)

- `numpy` (84 mods), `markdown_it` (62), `aiohttp` (40) still load via search/parsers/workflows brick init paths — same lazy-`__init__.py` pattern would chase another ~30 MB.
- `tests/test_idle_rss.py` regression guard so this doesn't silently regress.
- `nexus.preflight()` opt-in eager-load helper for prod servers that want fail-fast at startup.