### PR TITLE
Fix edge permission schema drift

### DIFF
--- a/alembic/versions/c7d9a0f4b8e2_repair_edge_permission_schema_drift.py
+++ b/alembic/versions/c7d9a0f4b8e2_repair_edge_permission_schema_drift.py
@@ -309,6 +309,9 @@ def upgrade() -> None:
         _widen_varchar_if_needed(bind, inspector, "file_paths", "content_id", 255)
         _widen_varchar_if_needed(bind, inspector, "file_paths", "indexed_content_id", 255)
 
+    if "version_history" in table_names:
+        _widen_varchar_if_needed(bind, inspector, "version_history", "content_id", 255)
+
     if "tiger_cache" in table_names:
         tiger_cache_columns = set(_table_columns(inspector, "tiger_cache"))
         _add_zone_column(

--- a/alembic/versions/c7d9a0f4b8e2_repair_edge_permission_schema_drift.py
+++ b/alembic/versions/c7d9a0f4b8e2_repair_edge_permission_schema_drift.py
@@ -1,0 +1,346 @@
+"""Repair edge permission schema drift missed by zone bootstrap.
+
+Revision ID: c7d9a0f4b8e2
+Revises: b6f4a8d9c2e1
+Create Date: 2026-04-29
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Any
+
+import sqlalchemy as sa
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "c7d9a0f4b8e2"
+down_revision: str | Sequence[str] | None = "b6f4a8d9c2e1"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+ROOT_ZONE_ID = "root"
+
+
+def _table_columns(inspector: Any, table_name: str) -> dict[str, dict[str, Any]]:
+    return {column["name"]: column for column in inspector.get_columns(table_name)}
+
+
+def _add_zone_column(
+    table_name: str,
+    columns: set[str],
+    sql_type: sa.TypeEngine,
+    *,
+    backfill_from: str | None = None,
+) -> None:
+    if "zone_id" in columns:
+        return
+
+    op.add_column(
+        table_name,
+        sa.Column("zone_id", sql_type, nullable=False, server_default=ROOT_ZONE_ID),
+    )
+    columns.add("zone_id")
+
+    if backfill_from and backfill_from in columns:
+        op.execute(
+            sa.text(
+                f"""
+                UPDATE {table_name}
+                SET zone_id = COALESCE({backfill_from}, :root_zone)
+                WHERE {backfill_from} IS NOT NULL
+                """
+            ).bindparams(root_zone=ROOT_ZONE_ID)
+        )
+
+
+def _set_tenant_default(bind: Any, table_name: str, columns: set[str]) -> None:
+    if bind.dialect.name != "postgresql" or "tenant_id" not in columns:
+        return
+
+    op.execute(
+        sa.text(
+            f"""
+            ALTER TABLE {table_name}
+            ALTER COLUMN tenant_id SET DEFAULT 'root'
+            """
+        )
+    )
+
+
+def _drop_not_null_if_needed(
+    bind: Any,
+    inspector: Any,
+    table_name: str,
+    column_name: str,
+) -> None:
+    if bind.dialect.name != "postgresql":
+        return
+
+    column = _table_columns(inspector, table_name).get(column_name)
+    if not column or column.get("nullable") is not False:
+        return
+
+    op.execute(
+        sa.text(
+            f"""
+            ALTER TABLE {table_name}
+            ALTER COLUMN {column_name} DROP NOT NULL
+            """
+        )
+    )
+
+
+def _widen_varchar_if_needed(
+    bind: Any,
+    inspector: Any,
+    table_name: str,
+    column_name: str,
+    target_length: int,
+) -> None:
+    if bind.dialect.name != "postgresql":
+        return
+
+    column = _table_columns(inspector, table_name).get(column_name)
+    if not column:
+        return
+
+    current_length = getattr(column["type"], "length", None)
+    if current_length is None or current_length >= target_length:
+        return
+
+    op.execute(
+        sa.text(
+            f"""
+            ALTER TABLE {table_name}
+            ALTER COLUMN {column_name} TYPE VARCHAR({target_length})
+            """
+        )
+    )
+
+
+def _replace_tiger_cache_shape(bind: Any, columns: set[str]) -> None:
+    if bind.dialect.name != "postgresql":
+        return
+    if not {"subject_type", "subject_id", "permission", "resource_type", "zone_id"}.issubset(
+        columns
+    ):
+        return
+
+    op.execute(
+        sa.text(
+            """
+            DO $$
+            DECLARE
+                current_columns text[];
+                current_index_columns text[];
+            BEGIN
+                SELECT array_agg(att.attname ORDER BY keys.ordinality)
+                INTO current_columns
+                FROM pg_constraint con
+                JOIN unnest(con.conkey) WITH ORDINALITY AS keys(attnum, ordinality)
+                  ON true
+                JOIN pg_attribute att
+                  ON att.attrelid = con.conrelid
+                 AND att.attnum = keys.attnum
+                WHERE con.conrelid = 'tiger_cache'::regclass
+                  AND con.conname = 'uq_tiger_cache'
+                  AND con.contype = 'u';
+
+                IF current_columns IS DISTINCT FROM ARRAY[
+                    'subject_type',
+                    'subject_id',
+                    'permission',
+                    'resource_type',
+                    'zone_id'
+                ] THEN
+                    IF current_columns IS NOT NULL THEN
+                        ALTER TABLE tiger_cache
+                        DROP CONSTRAINT uq_tiger_cache;
+                    END IF;
+
+                    ALTER TABLE tiger_cache
+                    ADD CONSTRAINT uq_tiger_cache
+                    UNIQUE (
+                        subject_type,
+                        subject_id,
+                        permission,
+                        resource_type,
+                        zone_id
+                    );
+                END IF;
+
+                SELECT array_agg(att.attname ORDER BY keys.ordinality)
+                INTO current_index_columns
+                FROM pg_class idx
+                JOIN pg_index ind
+                  ON ind.indexrelid = idx.oid
+                JOIN unnest(ind.indkey) WITH ORDINALITY AS keys(attnum, ordinality)
+                  ON true
+                JOIN pg_attribute att
+                  ON att.attrelid = ind.indrelid
+                 AND att.attnum = keys.attnum
+                WHERE idx.relname = 'idx_tiger_cache_lookup'
+                  AND ind.indrelid = 'tiger_cache'::regclass;
+
+                IF current_index_columns IS DISTINCT FROM ARRAY[
+                    'zone_id',
+                    'subject_type',
+                    'subject_id',
+                    'permission',
+                    'resource_type'
+                ] THEN
+                    DROP INDEX IF EXISTS idx_tiger_cache_lookup;
+                    CREATE INDEX idx_tiger_cache_lookup
+                    ON tiger_cache (
+                        zone_id,
+                        subject_type,
+                        subject_id,
+                        permission,
+                        resource_type
+                    );
+                END IF;
+            END $$;
+            """
+        )
+    )
+
+
+def _replace_group_closure_shape(bind: Any, columns: set[str]) -> None:
+    if bind.dialect.name != "postgresql":
+        return
+    if not {"member_type", "member_id", "group_type", "group_id", "zone_id"}.issubset(columns):
+        return
+
+    op.execute(
+        sa.text(
+            """
+            DO $$
+            DECLARE
+                current_columns text[];
+                member_index_columns text[];
+                group_index_columns text[];
+            BEGIN
+                SELECT array_agg(att.attname ORDER BY keys.ordinality)
+                INTO current_columns
+                FROM pg_constraint con
+                JOIN unnest(con.conkey) WITH ORDINALITY AS keys(attnum, ordinality)
+                  ON true
+                JOIN pg_attribute att
+                  ON att.attrelid = con.conrelid
+                 AND att.attnum = keys.attnum
+                WHERE con.conrelid = 'rebac_group_closure'::regclass
+                  AND con.contype = 'p';
+
+                IF current_columns IS DISTINCT FROM ARRAY[
+                    'member_type',
+                    'member_id',
+                    'group_type',
+                    'group_id',
+                    'zone_id'
+                ] THEN
+                    ALTER TABLE rebac_group_closure
+                    DROP CONSTRAINT IF EXISTS rebac_group_closure_pkey;
+
+                    ALTER TABLE rebac_group_closure
+                    ADD PRIMARY KEY (member_type, member_id, group_type, group_id, zone_id);
+                END IF;
+
+                SELECT array_agg(att.attname ORDER BY keys.ordinality)
+                INTO member_index_columns
+                FROM pg_class idx
+                JOIN pg_index ind
+                  ON ind.indexrelid = idx.oid
+                JOIN unnest(ind.indkey) WITH ORDINALITY AS keys(attnum, ordinality)
+                  ON true
+                JOIN pg_attribute att
+                  ON att.attrelid = ind.indrelid
+                 AND att.attnum = keys.attnum
+                WHERE idx.relname = 'idx_closure_member'
+                  AND ind.indrelid = 'rebac_group_closure'::regclass;
+
+                IF member_index_columns IS DISTINCT FROM ARRAY[
+                    'zone_id',
+                    'member_type',
+                    'member_id'
+                ] THEN
+                    DROP INDEX IF EXISTS idx_closure_member;
+                    CREATE INDEX idx_closure_member
+                    ON rebac_group_closure (zone_id, member_type, member_id);
+                END IF;
+
+                SELECT array_agg(att.attname ORDER BY keys.ordinality)
+                INTO group_index_columns
+                FROM pg_class idx
+                JOIN pg_index ind
+                  ON ind.indexrelid = idx.oid
+                JOIN unnest(ind.indkey) WITH ORDINALITY AS keys(attnum, ordinality)
+                  ON true
+                JOIN pg_attribute att
+                  ON att.attrelid = ind.indrelid
+                 AND att.attnum = keys.attnum
+                WHERE idx.relname = 'idx_closure_group'
+                  AND ind.indrelid = 'rebac_group_closure'::regclass;
+
+                IF group_index_columns IS DISTINCT FROM ARRAY[
+                    'zone_id',
+                    'group_type',
+                    'group_id'
+                ] THEN
+                    DROP INDEX IF EXISTS idx_closure_group;
+                    CREATE INDEX idx_closure_group
+                    ON rebac_group_closure (zone_id, group_type, group_id);
+                END IF;
+            END $$;
+            """
+        )
+    )
+
+
+def upgrade() -> None:
+    bind = op.get_bind()
+    inspector = sa.inspect(bind)
+    table_names = set(inspector.get_table_names())
+
+    if "file_paths" in table_names:
+        _drop_not_null_if_needed(bind, inspector, "file_paths", "backend_id")
+        _drop_not_null_if_needed(bind, inspector, "file_paths", "physical_path")
+        _widen_varchar_if_needed(bind, inspector, "file_paths", "content_id", 255)
+        _widen_varchar_if_needed(bind, inspector, "file_paths", "indexed_content_id", 255)
+
+    if "tiger_cache" in table_names:
+        tiger_cache_columns = set(_table_columns(inspector, "tiger_cache"))
+        _add_zone_column(
+            "tiger_cache",
+            tiger_cache_columns,
+            sa.String(255),
+            backfill_from="tenant_id",
+        )
+        _set_tenant_default(bind, "tiger_cache", tiger_cache_columns)
+        _replace_tiger_cache_shape(bind, tiger_cache_columns)
+
+    if "tiger_cache_queue" in table_names:
+        queue_columns = set(_table_columns(inspector, "tiger_cache_queue"))
+        _add_zone_column(
+            "tiger_cache_queue",
+            queue_columns,
+            sa.String(255),
+            backfill_from="tenant_id",
+        )
+        _set_tenant_default(bind, "tiger_cache_queue", queue_columns)
+
+    if "rebac_group_closure" in table_names:
+        closure_columns = set(_table_columns(inspector, "rebac_group_closure"))
+        _add_zone_column(
+            "rebac_group_closure",
+            closure_columns,
+            sa.String(255),
+            backfill_from="tenant_id",
+        )
+        _set_tenant_default(bind, "rebac_group_closure", closure_columns)
+        _replace_group_closure_shape(bind, closure_columns)
+
+
+def downgrade() -> None:
+    """No destructive downgrade for a compatibility repair migration."""

--- a/src/nexus/storage/models/file_path.py
+++ b/src/nexus/storage/models/file_path.py
@@ -41,7 +41,7 @@ class FilePathModel(Base):
     # File properties
     file_type: Mapped[str | None] = mapped_column(String(50), nullable=True)
     size_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)
-    content_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    content_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
 
     # Timestamps
     created_at: Mapped[datetime] = mapped_column(
@@ -57,7 +57,7 @@ class FilePathModel(Base):
     deleted_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     # Semantic search indexing tracking (Issue #865)
-    indexed_content_id: Mapped[str | None] = mapped_column(String(64), nullable=True)
+    indexed_content_id: Mapped[str | None] = mapped_column(String(255), nullable=True)
     last_indexed_at: Mapped[datetime | None] = mapped_column(DateTime, nullable=True)
 
     # Locking for concurrent access

--- a/src/nexus/storage/models/version_history.py
+++ b/src/nexus/storage/models/version_history.py
@@ -46,7 +46,7 @@ class VersionHistoryModel(Base):
 
     # Version information
     version_number: Mapped[int] = mapped_column(Integer, nullable=False)
-    content_id: Mapped[str] = mapped_column(String(64), nullable=False)
+    content_id: Mapped[str] = mapped_column(String(255), nullable=False)
 
     # Content metadata
     size_bytes: Mapped[int] = mapped_column(BigInteger, nullable=False, default=0)

--- a/src/nexus/storage/schema_invariants.py
+++ b/src/nexus/storage/schema_invariants.py
@@ -92,20 +92,60 @@ def _ensure_tenant_column_default(
     )
 
 
-def _ensure_rebac_id_lengths(conn: Any, inspector: Any, table_names: set[str]) -> None:
-    for table_name in ("rebac_tuples", "rebac_changelog"):
+def _ensure_nullable_column(
+    conn: Any,
+    inspector: Any,
+    table_names: set[str],
+    table_name: str,
+    column_name: str,
+) -> None:
+    if table_name not in table_names:
+        return
+
+    for column in inspector.get_columns(table_name):
+        if column["name"] != column_name:
+            continue
+
+        # Unit-test fakes only expose column names. Treat them as legacy so
+        # the regression test can verify the repair SQL without a live PG DB.
+        if "nullable" not in column or column["nullable"] is False:
+            conn.execute(
+                text(
+                    f"""
+                    ALTER TABLE {table_name}
+                    ALTER COLUMN {column_name} DROP NOT NULL
+                    """
+                )
+            )
+        return
+
+
+def _ensure_varchar_lengths(
+    conn: Any,
+    inspector: Any,
+    table_names: set[str],
+    checks: tuple[tuple[str, str, int], ...],
+) -> None:
+    for table_name, column_name, min_length in checks:
         if table_name not in table_names:
             continue
-        for column_name in ("subject_id", "object_id"):
-            if _column_needs_varchar_widen(inspector, table_name, column_name, 255):
-                conn.execute(
-                    text(
-                        f"""
-                        ALTER TABLE {table_name}
-                        ALTER COLUMN {column_name} TYPE VARCHAR(255)
-                        """
-                    )
+        if _column_needs_varchar_widen(inspector, table_name, column_name, min_length):
+            conn.execute(
+                text(
+                    f"""
+                    ALTER TABLE {table_name}
+                    ALTER COLUMN {column_name} TYPE VARCHAR({min_length})
+                    """
                 )
+            )
+
+
+def _ensure_rebac_id_lengths(conn: Any, inspector: Any, table_names: set[str]) -> None:
+    checks: list[tuple[str, str, int]] = []
+    for table_name in ("rebac_tuples", "rebac_changelog"):
+        for column_name in ("subject_id", "object_id"):
+            checks.append((table_name, column_name, 255))
+    _ensure_varchar_lengths(conn, inspector, table_names, tuple(checks))
 
 
 def _ensure_zone_indexes(conn: Any, columns_by_table: dict[str, set[str]]) -> None:
@@ -191,6 +231,183 @@ def _ensure_zone_indexes(conn: Any, columns_by_table: dict[str, set[str]]) -> No
                 """
             )
         )
+
+
+def _ensure_tiger_cache_constraint(conn: Any, columns_by_table: dict[str, set[str]]) -> None:
+    required = {"subject_type", "subject_id", "permission", "resource_type", "zone_id"}
+    if not required.issubset(columns_by_table.get("tiger_cache", set())):
+        return
+
+    conn.execute(
+        text(
+            """
+            DO $$
+            DECLARE
+                current_columns text[];
+                current_index_columns text[];
+            BEGIN
+                SELECT array_agg(att.attname ORDER BY keys.ordinality)
+                INTO current_columns
+                FROM pg_constraint con
+                JOIN unnest(con.conkey) WITH ORDINALITY AS keys(attnum, ordinality)
+                  ON true
+                JOIN pg_attribute att
+                  ON att.attrelid = con.conrelid
+                 AND att.attnum = keys.attnum
+                WHERE con.conrelid = 'tiger_cache'::regclass
+                  AND con.conname = 'uq_tiger_cache'
+                  AND con.contype = 'u';
+
+                IF current_columns IS DISTINCT FROM ARRAY[
+                    'subject_type',
+                    'subject_id',
+                    'permission',
+                    'resource_type',
+                    'zone_id'
+                ] THEN
+                    IF current_columns IS NOT NULL THEN
+                        ALTER TABLE tiger_cache
+                        DROP CONSTRAINT uq_tiger_cache;
+                    END IF;
+
+                    ALTER TABLE tiger_cache
+                    ADD CONSTRAINT uq_tiger_cache
+                    UNIQUE (
+                        subject_type,
+                        subject_id,
+                        permission,
+                        resource_type,
+                        zone_id
+                    );
+                END IF;
+
+                SELECT array_agg(att.attname ORDER BY keys.ordinality)
+                INTO current_index_columns
+                FROM pg_class idx
+                JOIN pg_index ind
+                  ON ind.indexrelid = idx.oid
+                JOIN unnest(ind.indkey) WITH ORDINALITY AS keys(attnum, ordinality)
+                  ON true
+                JOIN pg_attribute att
+                  ON att.attrelid = ind.indrelid
+                 AND att.attnum = keys.attnum
+                WHERE idx.relname = 'idx_tiger_cache_lookup'
+                  AND ind.indrelid = 'tiger_cache'::regclass;
+
+                IF current_index_columns IS DISTINCT FROM ARRAY[
+                    'zone_id',
+                    'subject_type',
+                    'subject_id',
+                    'permission',
+                    'resource_type'
+                ] THEN
+                    DROP INDEX IF EXISTS idx_tiger_cache_lookup;
+                    CREATE INDEX idx_tiger_cache_lookup
+                    ON tiger_cache (
+                        zone_id,
+                        subject_type,
+                        subject_id,
+                        permission,
+                        resource_type
+                    );
+                END IF;
+            END $$;
+            """
+        )
+    )
+
+
+def _ensure_rebac_group_closure_shape(
+    conn: Any,
+    columns_by_table: dict[str, set[str]],
+) -> None:
+    required = {"member_type", "member_id", "group_type", "group_id", "zone_id"}
+    if not required.issubset(columns_by_table.get("rebac_group_closure", set())):
+        return
+
+    conn.execute(
+        text(
+            """
+            DO $$
+            DECLARE
+                current_columns text[];
+                member_index_columns text[];
+                group_index_columns text[];
+            BEGIN
+                SELECT array_agg(att.attname ORDER BY keys.ordinality)
+                INTO current_columns
+                FROM pg_constraint con
+                JOIN unnest(con.conkey) WITH ORDINALITY AS keys(attnum, ordinality)
+                  ON true
+                JOIN pg_attribute att
+                  ON att.attrelid = con.conrelid
+                 AND att.attnum = keys.attnum
+                WHERE con.conrelid = 'rebac_group_closure'::regclass
+                  AND con.contype = 'p';
+
+                IF current_columns IS DISTINCT FROM ARRAY[
+                    'member_type',
+                    'member_id',
+                    'group_type',
+                    'group_id',
+                    'zone_id'
+                ] THEN
+                    ALTER TABLE rebac_group_closure
+                    DROP CONSTRAINT IF EXISTS rebac_group_closure_pkey;
+
+                    ALTER TABLE rebac_group_closure
+                    ADD PRIMARY KEY (member_type, member_id, group_type, group_id, zone_id);
+                END IF;
+
+                SELECT array_agg(att.attname ORDER BY keys.ordinality)
+                INTO member_index_columns
+                FROM pg_class idx
+                JOIN pg_index ind
+                  ON ind.indexrelid = idx.oid
+                JOIN unnest(ind.indkey) WITH ORDINALITY AS keys(attnum, ordinality)
+                  ON true
+                JOIN pg_attribute att
+                  ON att.attrelid = ind.indrelid
+                 AND att.attnum = keys.attnum
+                WHERE idx.relname = 'idx_closure_member'
+                  AND ind.indrelid = 'rebac_group_closure'::regclass;
+
+                IF member_index_columns IS DISTINCT FROM ARRAY[
+                    'zone_id',
+                    'member_type',
+                    'member_id'
+                ] THEN
+                    DROP INDEX IF EXISTS idx_closure_member;
+                    CREATE INDEX idx_closure_member
+                    ON rebac_group_closure (zone_id, member_type, member_id);
+                END IF;
+
+                SELECT array_agg(att.attname ORDER BY keys.ordinality)
+                INTO group_index_columns
+                FROM pg_class idx
+                JOIN pg_index ind
+                  ON ind.indexrelid = idx.oid
+                JOIN unnest(ind.indkey) WITH ORDINALITY AS keys(attnum, ordinality)
+                  ON true
+                JOIN pg_attribute att
+                  ON att.attrelid = ind.indrelid
+                 AND att.attnum = keys.attnum
+                WHERE idx.relname = 'idx_closure_group'
+                  AND ind.indrelid = 'rebac_group_closure'::regclass;
+
+                IF group_index_columns IS DISTINCT FROM ARRAY[
+                    'zone_id',
+                    'group_type',
+                    'group_id'
+                ] THEN
+                    DROP INDEX IF EXISTS idx_closure_group;
+                    CREATE INDEX idx_closure_group
+                    ON rebac_group_closure (zone_id, group_type, group_id);
+                END IF;
+            END $$;
+            """
+        )
+    )
 
 
 def _ensure_tiger_directory_grants_constraint(
@@ -299,6 +516,27 @@ def ensure_postgres_schema_invariants(engine: Engine) -> None:
         _ensure_zone_column(
             conn,
             columns_by_table,
+            "tiger_cache",
+            "VARCHAR(255)",
+            backfill_from="tenant_id",
+        )
+        _ensure_zone_column(
+            conn,
+            columns_by_table,
+            "tiger_cache_queue",
+            "VARCHAR(255)",
+            backfill_from="tenant_id",
+        )
+        _ensure_zone_column(
+            conn,
+            columns_by_table,
+            "rebac_group_closure",
+            "VARCHAR(255)",
+            backfill_from="tenant_id",
+        )
+        _ensure_zone_column(
+            conn,
+            columns_by_table,
             "tiger_directory_grants",
             "VARCHAR(255)",
             backfill_from="tenant_id",
@@ -311,10 +549,26 @@ def ensure_postgres_schema_invariants(engine: Engine) -> None:
             backfill_from="tenant_id",
         )
 
+        _ensure_tenant_column_default(conn, columns_by_table, "tiger_cache")
+        _ensure_tenant_column_default(conn, columns_by_table, "tiger_cache_queue")
+        _ensure_tenant_column_default(conn, columns_by_table, "rebac_group_closure")
         _ensure_tenant_column_default(conn, columns_by_table, "tiger_directory_grants")
         _ensure_tenant_column_default(conn, columns_by_table, "subscriptions")
+        _ensure_nullable_column(conn, inspector, table_names, "file_paths", "backend_id")
+        _ensure_nullable_column(conn, inspector, table_names, "file_paths", "physical_path")
         _ensure_rebac_id_lengths(conn, inspector, table_names)
+        _ensure_varchar_lengths(
+            conn,
+            inspector,
+            table_names,
+            (
+                ("file_paths", "content_id", 255),
+                ("file_paths", "indexed_content_id", 255),
+            ),
+        )
         _ensure_zone_indexes(conn, columns_by_table)
+        _ensure_tiger_cache_constraint(conn, columns_by_table)
+        _ensure_rebac_group_closure_shape(conn, columns_by_table)
         _ensure_tiger_directory_grants_constraint(conn, columns_by_table)
 
         if "metadata_change_log" in table_names:

--- a/src/nexus/storage/schema_invariants.py
+++ b/src/nexus/storage/schema_invariants.py
@@ -564,6 +564,7 @@ def ensure_postgres_schema_invariants(engine: Engine) -> None:
             (
                 ("file_paths", "content_id", 255),
                 ("file_paths", "indexed_content_id", 255),
+                ("version_history", "content_id", 255),
             ),
         )
         _ensure_zone_indexes(conn, columns_by_table)

--- a/tests/unit/storage/test_schema_invariants.py
+++ b/tests/unit/storage/test_schema_invariants.py
@@ -69,7 +69,14 @@ def test_postgres_schema_invariants_repair_zone_schema_gaps(monkeypatch) -> None
     inspector = _FakeInspector(
         {
             "metadata_change_log": {"sequence_number"},
-            "file_paths": {"path_id", "virtual_path", "content_id"},
+            "file_paths": {
+                "path_id",
+                "virtual_path",
+                "content_id",
+                "indexed_content_id",
+                "backend_id",
+                "physical_path",
+            },
             "rebac_changelog": {
                 "change_id",
                 "subject_id",
@@ -84,7 +91,31 @@ def test_postgres_schema_invariants_repair_zone_schema_gaps(monkeypatch) -> None
                 "subject_zone_id",
                 "object_zone_id",
             },
+            "rebac_group_closure": {
+                "member_type",
+                "member_id",
+                "group_type",
+                "group_id",
+                "tenant_id",
+                "depth",
+            },
             "subscriptions": {"subscription_id", "tenant_id"},
+            "tiger_cache": {
+                "cache_id",
+                "subject_type",
+                "subject_id",
+                "permission",
+                "resource_type",
+                "tenant_id",
+            },
+            "tiger_cache_queue": {
+                "queue_id",
+                "subject_type",
+                "subject_id",
+                "permission",
+                "resource_type",
+                "tenant_id",
+            },
             "tiger_directory_grants": {"grant_id", "tenant_id", "directory_path"},
         }
     )
@@ -112,6 +143,32 @@ def test_postgres_schema_invariants_repair_zone_schema_gaps(monkeypatch) -> None
     assert "ALTER TABLE rebac_tuples ALTER COLUMN object_id TYPE VARCHAR(255)" in executed_sql
     assert "ALTER TABLE rebac_changelog ALTER COLUMN subject_id TYPE VARCHAR(255)" in executed_sql
     assert "ALTER TABLE rebac_changelog ALTER COLUMN object_id TYPE VARCHAR(255)" in executed_sql
+    assert "ALTER TABLE file_paths ALTER COLUMN content_id TYPE VARCHAR(255)" in executed_sql
+    assert (
+        "ALTER TABLE file_paths ALTER COLUMN indexed_content_id TYPE VARCHAR(255)" in executed_sql
+    )
+    assert "ALTER TABLE file_paths ALTER COLUMN backend_id DROP NOT NULL" in executed_sql
+    assert "ALTER TABLE file_paths ALTER COLUMN physical_path DROP NOT NULL" in executed_sql
+    assert "ALTER TABLE tiger_cache ADD COLUMN zone_id VARCHAR(255) NOT NULL DEFAULT 'root'" in (
+        executed_sql
+    )
+    assert (
+        "ALTER TABLE tiger_cache_queue ADD COLUMN zone_id VARCHAR(255) NOT NULL DEFAULT 'root'"
+        in executed_sql
+    )
+    assert (
+        "ALTER TABLE rebac_group_closure ADD COLUMN zone_id VARCHAR(255) NOT NULL DEFAULT 'root'"
+        in executed_sql
+    )
+    assert "ALTER TABLE tiger_cache ALTER COLUMN tenant_id SET DEFAULT 'root'" in executed_sql
+    assert "ALTER TABLE tiger_cache_queue ALTER COLUMN tenant_id SET DEFAULT 'root'" in executed_sql
+    assert (
+        "ALTER TABLE rebac_group_closure ALTER COLUMN tenant_id SET DEFAULT 'root'" in executed_sql
+    )
+    assert "DROP CONSTRAINT uq_tiger_cache" in executed_sql
+    assert "ADD CONSTRAINT uq_tiger_cache UNIQUE" in executed_sql
+    assert "DROP CONSTRAINT IF EXISTS rebac_group_closure_pkey" in executed_sql
+    assert "ADD PRIMARY KEY (member_type, member_id, group_type, group_id, zone_id)" in executed_sql
     assert (
         "ALTER TABLE tiger_directory_grants ALTER COLUMN tenant_id SET DEFAULT 'root'"
         in executed_sql

--- a/tests/unit/storage/test_schema_invariants.py
+++ b/tests/unit/storage/test_schema_invariants.py
@@ -77,6 +77,13 @@ def test_postgres_schema_invariants_repair_zone_schema_gaps(monkeypatch) -> None
                 "backend_id",
                 "physical_path",
             },
+            "version_history": {
+                "version_id",
+                "resource_type",
+                "resource_id",
+                "version_number",
+                "content_id",
+            },
             "rebac_changelog": {
                 "change_id",
                 "subject_id",
@@ -147,6 +154,7 @@ def test_postgres_schema_invariants_repair_zone_schema_gaps(monkeypatch) -> None
     assert (
         "ALTER TABLE file_paths ALTER COLUMN indexed_content_id TYPE VARCHAR(255)" in executed_sql
     )
+    assert "ALTER TABLE version_history ALTER COLUMN content_id TYPE VARCHAR(255)" in executed_sql
     assert "ALTER TABLE file_paths ALTER COLUMN backend_id DROP NOT NULL" in executed_sql
     assert "ALTER TABLE file_paths ALTER COLUMN physical_path DROP NOT NULL" in executed_sql
     assert "ALTER TABLE tiger_cache ADD COLUMN zone_id VARCHAR(255) NOT NULL DEFAULT 'root'" in (


### PR DESCRIPTION
## Summary
- add an Alembic repair for edge Postgres schemas missing zone-aware Tiger cache and ReBAC closure columns
- make legacy file_paths backend columns nullable and widen content/index tracking IDs to match current writes
- extend boot-time schema invariants and regression coverage for the Docker edge smoke failure

## Validation
- uv run pytest tests/unit/storage/test_schema_invariants.py tests/unit/core/test_boot_indexer.py -q
- uv run --with ruff ruff check src/nexus/storage/schema_invariants.py src/nexus/storage/models/file_path.py tests/unit/storage/test_schema_invariants.py alembic/versions/c7d9a0f4b8e2_repair_edge_permission_schema_drift.py
- uv run --with ruff ruff format --check src/nexus/storage/schema_invariants.py src/nexus/storage/models/file_path.py tests/unit/storage/test_schema_invariants.py alembic/versions/c7d9a0f4b8e2_repair_edge_permission_schema_drift.py
- uv run alembic -c alembic/alembic.ini heads
- live PostgreSQL stale-schema Alembic upgrade simulation from b6f4a8d9c2e1 to head, including long content_id insert and zone_id ReBAC query
- live PostgreSQL stale-schema ensure_postgres_schema_invariants simulation, including long content_id insert and zone_id ReBAC query

Note: the Docker Publish edge workflow only runs on develop/tags, so this PR cannot execute that exact job until merged or manually dispatched against develop-equivalent code.