### PR TITLE
Fix edge readiness when federation peers are unset

### DIFF
--- a/src/nexus/server/health/probes.py
+++ b/src/nexus/server/health/probes.py
@@ -16,6 +16,7 @@ Failure policy (Issue #3063):
 """
 
 import logging
+import os
 from typing import Any
 
 from fastapi import APIRouter, Request
@@ -46,10 +47,12 @@ def _check_raft_topology(request: Request) -> tuple[bool, str]:
         # ``nexus_runtime.federation_is_initialized`` module helper —
         # the kernel itself no longer exposes a ``mount_reconciliation_done``
         # PyO3 method (zone lifecycle is kernel-internal HAL state).
-        # Fails open when the helper is unavailable (slim builds,
-        # federation env vars unset).
+        # Fails open when the helper is unavailable (slim builds) or
+        # federation is disabled by leaving NEXUS_PEERS unset.
         kernel = getattr(nx_fs, "_kernel", None)
         if kernel is None:
+            return True, ""
+        if not os.environ.get("NEXUS_PEERS"):
             return True, ""
         try:
             import nexus_runtime as _nr

--- a/tests/unit/server/health/test_probes.py
+++ b/tests/unit/server/health/test_probes.py
@@ -85,6 +85,30 @@ class TestReadinessProbe:
         assert body["status"] == "ready"
         assert "uptime_seconds" in body
 
+    def test_200_when_federation_disabled_even_if_kernel_reports_not_ready(
+        self, monkeypatch
+    ) -> None:
+        tracker = StartupTracker()
+        for phase in _REQUIRED_FOR_READY:
+            tracker.complete(phase)
+
+        import sys
+        from types import SimpleNamespace
+
+        monkeypatch.delenv("NEXUS_PEERS", raising=False)
+        fake = SimpleNamespace(federation_is_initialized=lambda _k: False)
+        monkeypatch.setitem(sys.modules, "nexus_runtime", fake)
+
+        mock_fs = MagicMock()
+        mock_fs._kernel = MagicMock()
+
+        app = _make_app(tracker)
+        app.state.nexus_fs = mock_fs
+        client = TestClient(app)
+        resp = client.get("/healthz/ready")
+        assert resp.status_code == 200
+        assert resp.json()["status"] == "ready"
+
     def test_503_on_raft_not_ready(self, monkeypatch) -> None:
         tracker = StartupTracker()
         for phase in _REQUIRED_FOR_READY:
@@ -99,6 +123,7 @@ class TestReadinessProbe:
         import sys
         from types import SimpleNamespace
 
+        monkeypatch.setenv("NEXUS_PEERS", "node-a,node-b")
         fake = SimpleNamespace(federation_is_initialized=lambda _k: False)
         monkeypatch.setitem(sys.modules, "nexus_runtime", fake)
 


### PR DESCRIPTION
## Summary
- Treat `/healthz/ready` as federation-disabled when `NEXUS_PEERS` is unset, matching `/health`
- Add a regression test for the Docker edge smoke condition where `federation_is_initialized()` is false but peers are not configured
- Keep the federation-enabled not-ready test pinned by explicitly setting `NEXUS_PEERS`

## Validation
- `/Users/tafeng/.local/bin/uv run pytest tests/unit/server/health/test_probes.py tests/unit/server/test_federation_rpc_gating.py -q`
- `/Users/tafeng/.local/bin/uv run --extra dev ruff check src/nexus/server/health/probes.py tests/unit/server/health/test_probes.py`
- `/Users/tafeng/.local/bin/uv run --extra dev ruff format --check src/nexus/server/health/probes.py tests/unit/server/health/test_probes.py`
- `git diff --check`

## Notes
The failed Docker Publish job started the edge container successfully and `/health` returned 200, but `/healthz/ready` stayed 503 because the readiness probe still required federation initialization even though the job does not set `NEXUS_PEERS`.