### PR TITLE
fix(raft): wipe-rejoin contract via incarnation rotation + ConfChangeV2 atomic voter swap

### DIFF
--- a/proto/nexus/raft/transport.proto
+++ b/proto/nexus/raft/transport.proto
@@ -76,6 +76,33 @@ service ZoneApiService {
   // Used by follower `try_remote_fetch` / scatter-gather chunk fetch when
   // metadata has been replicated ahead of content.
   rpc ReadBlob(ReadBlobRequest) returns (ReadBlobResponse);
+
+  // ReplaceVoterByHostname swaps a voter's node ID without changing its
+  // hostname.  Sent by a node that just wiped its persistent state and
+  // is about to rejoin the cluster with a fresh `compute_node_id` based
+  // on a non-zero incarnation.
+  //
+  // Wipe-rejoin contract — necessary because reusing a node ID across a
+  // wipe violates raft's identity-equals-log invariant: the leader's
+  // in-memory `Progress[old_id]` still records `matched=K` from before
+  // the wipe, so its next heartbeat would carry `commit=K` and panic
+  // the fresh follower at `commit_to(K)` (`raft-0.7.0/raft_log.rs:292`).
+  //
+  // Server-side flow (leader only — followers return a redirect):
+  //   1. Reverse-lookup the existing voter whose hostname matches
+  //      `hostname` in the cluster's peer map.  Authoritative answer
+  //      lives on the leader; the caller does *not* claim what the old
+  //      ID was (post-wipe it has no way to know which incarnation was
+  //      previously persisted).
+  //   2. Propose `ConfChange::RemoveNode(old_id)`, await commit.
+  //   3. Propose `ConfChange::AddNode(new_id)`, await commit.
+  //   4. Caller follows up with the standard `JoinZone` flow under
+  //      `new_id` and receives a snapshot to populate its log.
+  //
+  // No-op fast path: when the lookup finds no matching hostname (fresh
+  // host that was never a voter) the leader proposes `AddNode(new_id)`
+  // alone — a plain join.  Returns `success=true, removed_old_id=null`.
+  rpc ReplaceVoterByHostname(ReplaceVoterByHostnameRequest) returns (ReplaceVoterByHostnameResponse);
 }
 
 // === Search Capability Advertisement (Issue #3147) ===
@@ -318,4 +345,41 @@ message ReadBlobRequest {
 message ReadBlobResponse {
   bytes content = 1;
   string error = 2;
+}
+
+// === ReplaceVoterByHostname (wipe-rejoin ID rotation) ===
+
+// ReplaceVoterByHostnameRequest carries the hostname and the new
+// incarnation-based node ID minted post-wipe.
+message ReplaceVoterByHostnameRequest {
+  // Zone whose voter set should be rotated.  Required; must be a
+  // zone for which the receiver is a voter (leader if known, or any
+  // node if leader is unknown — that node forwards the request).
+  string zone_id = 1;
+  // The wiped node's hostname.  Used by the leader to look up the
+  // prior voter ID in the cluster's peer map; the caller must NOT
+  // pre-compute the old ID itself (post-wipe the caller has no
+  // access to the prior incarnation marker).
+  string hostname = 2;
+  // The wiped node's freshly-minted node ID
+  // (`compute_node_id(hostname, new_incarnation)`).
+  uint64 new_node_id = 3;
+  // The wiped node's gRPC address (e.g., "http://10.0.0.3:2126").
+  // Stored in the cluster peer map for the new ID.
+  string node_address = 4;
+}
+
+// ReplaceVoterByHostnameResponse reports the outcome.  `success=true`
+// means both ConfChanges committed (or only the AddNode in the
+// no-prior-voter fast path) — caller is safe to proceed with
+// JoinZone.
+message ReplaceVoterByHostnameResponse {
+  bool success = 1;
+  optional string error = 2;
+  // If the receiver wasn't the leader, redirect address.  Mirrors
+  // ProposeResponse / JoinZoneResponse.
+  optional string leader_address = 3;
+  // The old voter ID that was removed.  None when no prior voter
+  // matched the supplied hostname (treated as a plain AddNode).
+  optional uint64 removed_old_id = 4;
 }

--- a/rust/kernel/src/core/pipe/wal.rs
+++ b/rust/kernel/src/core/pipe/wal.rs
@@ -200,6 +200,14 @@ mod tests {
         // Two `WalPipeCore` instances over the same MetaStore — model
         // two replicas.  Each replica owns its head; both should pop
         // every entry independently.
+        //
+        // Reader replicas can only see the writer's pushes after the
+        // bg flush thread has committed them to the shared MetaStore
+        // (each WalPipeCore wraps its own WalStreamCore with its own
+        // inflight map, so the writer's pre-flush state is invisible
+        // to the readers).  Poll briefly to dodge the async-flush race
+        // rather than sleeping a fixed duration.
+        use std::time::{Duration, Instant};
         let store: Arc<dyn MetaStore> = Arc::new(MemKvStore {
             inner: Mutex::new(BTreeMap::new()),
         });
@@ -210,9 +218,23 @@ mod tests {
         for i in 0u8..5 {
             writer.push(&[i]).unwrap();
         }
-        // Each reader pops the full sequence from its own head.
-        let popped_a: Vec<Vec<u8>> = (0..5).map(|_| reader_a.pop().unwrap()).collect();
-        let popped_b: Vec<Vec<u8>> = (0..5).map(|_| reader_b.pop().unwrap()).collect();
+
+        let pop_with_retry = |reader: &WalPipeCore| -> Vec<Vec<u8>> {
+            let deadline = Instant::now() + Duration::from_secs(2);
+            let mut out = Vec::with_capacity(5);
+            while out.len() < 5 {
+                match reader.pop() {
+                    Ok(data) => out.push(data),
+                    Err(PipeError::Empty) if Instant::now() < deadline => {
+                        std::thread::sleep(Duration::from_millis(5));
+                    }
+                    other => panic!("expected pop within 2s, got {other:?}"),
+                }
+            }
+            out
+        };
+        let popped_a = pop_with_retry(&reader_a);
+        let popped_b = pop_with_retry(&reader_b);
         assert_eq!(popped_a, popped_b);
         assert_eq!(popped_a, vec![vec![0], vec![1], vec![2], vec![3], vec![4]]);
     }

--- a/rust/kernel/src/nostr_backend.rs
+++ b/rust/kernel/src/nostr_backend.rs
@@ -21,7 +21,7 @@
 //! See `OPEN-ITEMS.md / nostr-backend-driver` for the staged plan: relay
 //! client + NIP-04 encrypt/decrypt + FileEvent emission + mount integration.
 
-use crate::backend::{ObjectStore, StorageError, WriteResult};
+use crate::abc::object_store::{ObjectStore, StorageError, WriteResult};
 use crate::kernel::OperationContext;
 
 /// Nostr storage backend — mount carries `npub` (recipient pubkey) plus the
@@ -87,10 +87,8 @@ impl ObjectStore for NostrBackend {
     fn read_content(
         &self,
         _content_id: &str,
-        backend_path: &str,
         _ctx: &OperationContext,
     ) -> Result<Vec<u8>, StorageError> {
-        let _ = backend_path;
         Err(StorageError::NotSupported(
             "NostrBackend.read_content awaits relay client — see OPEN-ITEMS / nostr-backend-driver",
         ))
@@ -137,7 +135,7 @@ mod tests {
         let b = backend();
         let ctx = OperationContext::new("test", "root", false, None, false);
         let err = b
-            .read_content("", "", &ctx)
+            .read_content("", &ctx)
             .expect_err("stub must surface NotSupported");
         match err {
             StorageError::NotSupported(msg) => {

--- a/rust/raft/src/federation_provider.rs
+++ b/rust/raft/src/federation_provider.rs
@@ -34,7 +34,10 @@ use kernel::core::vfs_router::canonicalize_mount_path as canonicalize;
 use kernel::hal::federation::{BlobFetcherSlot, FederationProvider, FederationResult};
 use kernel::kernel::Kernel;
 
-use crate::transport::hostname_to_node_id;
+use crate::raft::storage::RaftStorage;
+use crate::transport::{
+    call_replace_voter_by_hostname, compute_node_id, hostname_to_node_id, NodeAddress,
+};
 use crate::zone_meta_store::ZoneMetaStore;
 use crate::{TlsFiles, ZoneManager};
 
@@ -218,6 +221,255 @@ fn parse_peer_list_to_raft_format(peers_csv: &str) -> Result<Vec<String>, String
     Ok(out)
 }
 
+/// Outcome of [`RaftFederationProvider::ensure_voter_membership`].
+///
+/// Drives both the ID `ZoneManager::with_node_id` is constructed with
+/// and whether `init_from_env` chooses `create_zone` (cold start) or
+/// `join_zone` (joining an already-running cluster after a wipe).
+#[derive(Debug, Clone, Copy)]
+struct VoterMembership {
+    /// Effective node ID for this process — `compute_node_id(hostname,
+    /// incarnation)` where the incarnation comes from the persisted
+    /// marker (recovery), a successful wipe-rejoin rotation
+    /// (`new_incarnation`), or the cold-start sentinel `0`
+    /// (hostname-only ID).
+    node_id: u64,
+    /// Whether the node minted a fresh non-zero incarnation AND
+    /// successfully rotated its voter ID with an existing leader.  If
+    /// true, callers must use `join_zone(skip_bootstrap=true)` so the
+    /// leader's snapshot installs the authoritative ConfState; calling
+    /// `create_zone` here would re-bootstrap a stale ConfState that
+    /// conflicts with the cluster's committed voter set.
+    rotated_into_existing_cluster: bool,
+}
+
+/// Generate a fresh non-zero incarnation marker.
+///
+/// SystemTime nanos as u64.  Two restart-without-data scenarios within
+/// a single nanosecond are not physically possible on any current
+/// hardware, so this provides a strictly-monotonic-with-very-high-
+/// probability stream of incarnation values without requiring `rand`
+/// as a dependency.  Maps the unlikely 0 to 1 — `compute_node_id`
+/// treats 0 as the cold-start sentinel.
+fn generate_fresh_incarnation() -> u64 {
+    use std::time::{SystemTime, UNIX_EPOCH};
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_nanos() as u64)
+        .unwrap_or(1);
+    if nanos == 0 {
+        1
+    } else {
+        nanos
+    }
+}
+
+/// Try `ReplaceVoterByHostname` against each peer in turn.  Returns
+/// `true` on the first peer that responds with `success`.  Followers
+/// supply the leader's address in `leader_address`; the caller follows
+/// that redirect once before moving to the next peer.
+fn try_replace_voter_on_peers(
+    runtime: &tokio::runtime::Handle,
+    peers: &[NodeAddress],
+    self_hostname: &str,
+    new_node_id: u64,
+    self_address: &str,
+) -> bool {
+    for peer in peers {
+        if peer.hostname == self_hostname {
+            // Skip self — even if NEXUS_PEERS includes us, RPC to self
+            // before our gRPC server is up would just fail.
+            continue;
+        }
+
+        let mut endpoint = peer.endpoint.clone();
+        let mut redirected_once = false;
+        loop {
+            let attempt = runtime.block_on(call_replace_voter_by_hostname(
+                &endpoint,
+                "root",
+                self_hostname,
+                new_node_id,
+                self_address,
+                5,
+            ));
+            match attempt {
+                Ok(result) if result.success => {
+                    tracing::info!(
+                        peer = %endpoint,
+                        new_node_id,
+                        removed_old_id = ?result.removed_old_id,
+                        "ReplaceVoterByHostname committed",
+                    );
+                    return true;
+                }
+                Ok(result) => {
+                    if let Some(addr) = result.leader_address.as_ref() {
+                        if !redirected_once && !addr.is_empty() && addr != &endpoint {
+                            tracing::info!(
+                                from = %endpoint,
+                                to = %addr,
+                                "ReplaceVoterByHostname redirected to leader",
+                            );
+                            endpoint = addr.clone();
+                            redirected_once = true;
+                            continue;
+                        }
+                    }
+                    tracing::debug!(
+                        peer = %endpoint,
+                        error = ?result.error,
+                        "ReplaceVoterByHostname rejected; trying next peer",
+                    );
+                    break;
+                }
+                Err(e) => {
+                    tracing::debug!(
+                        peer = %endpoint,
+                        error = %e,
+                        "ReplaceVoterByHostname RPC failed; trying next peer",
+                    );
+                    break;
+                }
+            }
+        }
+    }
+    false
+}
+
+impl RaftFederationProvider {
+    /// Decide this process's effective node ID and whether to bootstrap
+    /// a fresh raft zone or join an already-running one.
+    ///
+    /// Centralizes the "cold-start vs wipe-rejoin" decision so the rest
+    /// of `init_from_env` doesn't have to scatter `was_just_created`
+    /// detection or `NEXUS_JOINER_HINT` overrides across every zone
+    /// branch.  Run **before** `ZoneManager::with_node_id` so the
+    /// computed `node_id` is what raft commits into ConfState.
+    ///
+    /// Logic:
+    /// 1. If `<zones_dir>/root/raft/raft.redb` exists, read the
+    ///    persisted incarnation (defaulting to 0 = legacy / cold-start
+    ///    sentinel) and return `compute_node_id(hostname, incarnation)`
+    ///    with `rotated_into_existing_cluster = false` — this is a
+    ///    plain restart with intact storage.
+    /// 2. Otherwise the node is fresh (first-ever boot or post-wipe).
+    ///    Mint a fresh non-zero incarnation, compute the new ID, and
+    ///    try `ReplaceVoterByHostname` on every peer — if any peer is
+    ///    leader (or redirects to one), the leader proposes
+    ///    ConfChange `RemoveNode(old_id)` + `AddNode(new_id)` so the
+    ///    cluster's voter set is updated before our raft instance
+    ///    starts emitting heartbeats.  Persist the incarnation under
+    ///    root's storage and return with
+    ///    `rotated_into_existing_cluster = true`.
+    /// 3. If no peer was reachable as leader (everyone is also fresh),
+    ///    fall through to cold-start: persist incarnation `0` and
+    ///    return the legacy `hostname_to_node_id` so all peers
+    ///    converge on the same ConfState bootstrap without
+    ///    coordination.
+    fn ensure_voter_membership(
+        &self,
+        hostname: &str,
+        self_address: &str,
+        zones_dir: &str,
+        peers: &[NodeAddress],
+    ) -> Result<VoterMembership, String> {
+        let root_raft_path = Path::new(zones_dir).join("root").join("raft");
+        let root_redb_path = root_raft_path.join("raft.redb");
+
+        // Recovery path — storage already contains a persisted
+        // incarnation (or pre-fix data with no marker, which we treat
+        // as 0 = cold-start ID).
+        if root_redb_path.exists() {
+            let storage = RaftStorage::open(&root_raft_path)
+                .map_err(|e| format!("open root raft storage for incarnation read: {e}"))?;
+            let incarnation = storage
+                .incarnation()
+                .map_err(|e| format!("read incarnation: {e}"))?
+                .unwrap_or(0);
+            // Drop redb handle so ZoneManager::with_node_id can reopen
+            // the same file later.
+            drop(storage);
+            let node_id = compute_node_id(hostname, incarnation);
+            tracing::info!(
+                hostname,
+                incarnation,
+                node_id,
+                "ensure_voter_membership: recovery (existing storage)",
+            );
+            return Ok(VoterMembership {
+                node_id,
+                rotated_into_existing_cluster: false,
+            });
+        }
+
+        // Fresh path — try wipe-rejoin rotation, fall back to cold start.
+        let new_incarnation = generate_fresh_incarnation();
+        let new_id = compute_node_id(hostname, new_incarnation);
+
+        // Spin up a small temporary tokio runtime for the rotation
+        // RPCs.  ZoneManager owns the long-lived runtime but we need
+        // gRPC dialing *before* the manager is constructed (so that
+        // its raft node ID is correct from the first heartbeat).
+        // Single-threaded is sufficient — the calls are sequential.
+        let rotation_runtime = tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+            .map_err(|e| format!("rotation runtime: {e}"))?;
+        let rotated = try_replace_voter_on_peers(
+            &rotation_runtime.handle().clone(),
+            peers,
+            hostname,
+            new_id,
+            self_address,
+        );
+        drop(rotation_runtime);
+
+        // Whether we rotated or fell through to cold-start, persist
+        // the chosen incarnation so the next restart hits the recovery
+        // path above.
+        std::fs::create_dir_all(&root_raft_path)
+            .map_err(|e| format!("create root raft dir '{}': {e}", root_raft_path.display()))?;
+        let storage = RaftStorage::open(&root_raft_path)
+            .map_err(|e| format!("open root raft storage for incarnation persist: {e}"))?;
+
+        if rotated {
+            storage
+                .set_incarnation(new_incarnation)
+                .map_err(|e| format!("persist new incarnation: {e}"))?;
+            drop(storage);
+            tracing::info!(
+                hostname,
+                incarnation = new_incarnation,
+                node_id = new_id,
+                "ensure_voter_membership: rotated into existing cluster",
+            );
+            Ok(VoterMembership {
+                node_id: new_id,
+                rotated_into_existing_cluster: true,
+            })
+        } else {
+            // Cold-start sentinel — every peer derives the same ID for
+            // this hostname so `create_zone` ConfState bootstraps
+            // converge without coordination.
+            storage
+                .set_incarnation(0)
+                .map_err(|e| format!("persist cold-start incarnation: {e}"))?;
+            drop(storage);
+            let cold_id = hostname_to_node_id(hostname);
+            tracing::info!(
+                hostname,
+                node_id = cold_id,
+                "ensure_voter_membership: cold start (no leader reachable)",
+            );
+            Ok(VoterMembership {
+                node_id: cold_id,
+                rotated_into_existing_cluster: false,
+            })
+        }
+    }
+}
+
 impl FederationProvider for RaftFederationProvider {
     fn init_from_env(&self, kernel: &Kernel) -> FederationResult<bool> {
         // Idempotent — if zone manager already exists, treat as
@@ -271,9 +523,6 @@ impl FederationProvider for RaftFederationProvider {
                 .unwrap_or_else(|_| "./nexus-zones".to_string())
         });
 
-        let peers = parse_peer_list_to_raft_format(&peers_csv)
-            .map_err(|e| format!("NEXUS_PEERS parse: {e}"))?;
-
         // TLS detection — disabled when NEXUS_RAFT_TLS=false (E2E).
         let tls_disabled = std::env::var("NEXUS_RAFT_TLS")
             .map(|v| v.eq_ignore_ascii_case("false") || v == "0")
@@ -281,6 +530,29 @@ impl FederationProvider for RaftFederationProvider {
             || std::env::var("NEXUS_NO_TLS")
                 .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
                 .unwrap_or(false);
+        let use_tls_for_endpoints = !tls_disabled;
+
+        // Parse NEXUS_PEERS once into structured NodeAddress entries —
+        // both `ensure_voter_membership` (for ReplaceVoter RPC dialing
+        // by hostname) and `ZoneManager` (for raft peer formatting) read
+        // from the same parse result, no double-parse drift risk.
+        let peer_addrs: Vec<NodeAddress> = peers_csv
+            .split(',')
+            .map(str::trim)
+            .filter(|s| !s.is_empty())
+            .map(|entry| {
+                NodeAddress::parse(entry, use_tls_for_endpoints)
+                    .map_err(|e| format!("NEXUS_PEERS parse '{entry}': {e}"))
+            })
+            .collect::<Result<Vec<_>, _>>()?;
+        // `id@host:port` strings derived from the same NodeAddress
+        // entries — ZoneManager re-parses internally; we just provide
+        // the standard format raft expects.  Self entry will get
+        // overridden by ZoneManager::with_node_id below.
+        let peers: Vec<String> = peer_addrs
+            .iter()
+            .map(|p| p.to_raft_peer_str())
+            .collect();
 
         let tls = if tls_disabled {
             None
@@ -305,8 +577,25 @@ impl FederationProvider for RaftFederationProvider {
         std::fs::create_dir_all(&zones_dir)
             .map_err(|e| format!("create zones dir '{zones_dir}': {e}"))?;
 
-        let zm = ZoneManager::new(&hostname, &zones_dir, peers.clone(), &bind_addr, tls)
-            .map_err(|e| format!("ZoneManager::new: {e}"))?;
+        // Decide this node's effective ID and whether to bootstrap a
+        // fresh raft zone or join an already-running cluster.  Reads /
+        // writes the persisted incarnation marker in root zone's
+        // `raft.redb`; on the wipe-rejoin path also calls
+        // `ReplaceVoterByHostname` on each peer until a leader accepts
+        // the rotation.  Strict raft membership-swap contract via
+        // ConfChangeV2 atomic commit — no transient quorum gap.
+        let membership =
+            self.ensure_voter_membership(&hostname, &self_addr, &zones_dir, &peer_addrs)?;
+
+        let zm = ZoneManager::with_node_id(
+            &hostname,
+            membership.node_id,
+            &zones_dir,
+            peers.clone(),
+            &bind_addr,
+            tls,
+        )
+        .map_err(|e| format!("ZoneManager::with_node_id: {e}"))?;
 
         let runtime_handle = zm.runtime_handle();
         let blob_slot = zm.blob_fetcher_slot();
@@ -318,20 +607,39 @@ impl FederationProvider for RaftFederationProvider {
         // `install_transport_wiring` can drain it.
         kernel.stash_blob_fetcher_slot(Box::new(blob_slot));
 
-        // Bootstrap the root zone idempotently.
+        // Choose create_zone vs join_zone based on the membership
+        // decision above.  `rotated_into_existing_cluster=true` means
+        // a leader already accepted our ConfChangeV2; the leader's
+        // snapshot installs the authoritative ConfState, so we must
+        // skip ConfState bootstrap (`join_zone(skip_bootstrap=true)`)
+        // — calling `create_zone` here would re-bootstrap a stale
+        // ConfState that conflicts with the cluster's committed voter
+        // set.  Cold-start path uses `create_zone` so all peers
+        // converge on identical ConfStates without coordination.
+        //
+        // NEXUS_JOINER_HINT is honoured for back-compat (operators
+        // still using it) but the auto-detect supersedes it: if the
+        // hint says "joiner" but we cold-started, we cold-start.
+        let auto_join = membership.rotated_into_existing_cluster;
         let joiner_hint = std::env::var("NEXUS_JOINER_HINT")
             .map(|v| v == "1")
             .unwrap_or(false);
 
-        if zm.get_zone("root").is_none() {
-            if joiner_hint {
-                zm.join_zone("root", peers.clone(), false)
-                    .map_err(|e| format!("join_zone(root): {e}"))?;
-            } else {
-                zm.create_zone("root", peers.clone())
-                    .map_err(|e| format!("create_zone(root): {e}"))?;
+        let bootstrap_zone = |zone_id: &str| -> Result<(), String> {
+            if zm.get_zone(zone_id).is_some() {
+                return Ok(());
             }
-        }
+            if auto_join || joiner_hint {
+                zm.join_zone(zone_id, peers.clone(), false)
+                    .map_err(|e| format!("join_zone({zone_id}): {e}"))?;
+            } else {
+                zm.create_zone(zone_id, peers.clone())
+                    .map_err(|e| format!("create_zone({zone_id}): {e}"))?;
+            }
+            Ok(())
+        };
+
+        bootstrap_zone("root")?;
 
         if let Ok(zones_csv) = std::env::var("NEXUS_FEDERATION_ZONES") {
             for zone_id in zones_csv
@@ -339,15 +647,7 @@ impl FederationProvider for RaftFederationProvider {
                 .map(str::trim)
                 .filter(|s| !s.is_empty())
             {
-                if zm.get_zone(zone_id).is_none() {
-                    if joiner_hint {
-                        zm.join_zone(zone_id, peers.clone(), false)
-                            .map_err(|e| format!("join_zone({zone_id}): {e}"))?;
-                    } else {
-                        zm.create_zone(zone_id, peers.clone())
-                            .map_err(|e| format!("create_zone({zone_id}): {e}"))?;
-                    }
-                }
+                bootstrap_zone(zone_id)?;
             }
         }
 

--- a/rust/raft/src/federation_provider.rs
+++ b/rust/raft/src/federation_provider.rs
@@ -34,12 +34,30 @@ use kernel::core::vfs_router::canonicalize_mount_path as canonicalize;
 use kernel::hal::federation::{BlobFetcherSlot, FederationProvider, FederationResult};
 use kernel::kernel::Kernel;
 
-use crate::raft::storage::RaftStorage;
 use crate::transport::{
     call_replace_voter_by_hostname, compute_node_id, hostname_to_node_id, NodeAddress,
 };
 use crate::zone_meta_store::ZoneMetaStore;
 use crate::{TlsFiles, ZoneManager};
+
+/// Node-level incarnation marker filename.
+///
+/// Lives at `{NEXUS_DATA_DIR}/.node_incarnation` — one file per
+/// daemon, not per zone.  Identity is a node-level concept (one
+/// `ZoneManager` owns one `node_id` for every zone it serves), so
+/// the SSOT is also node-level.  Format: a single big-endian u64 in
+/// 8 bytes.  Absent file = fresh daemon (first boot or post-wipe);
+/// present file = recovery (existing identity).
+///
+/// Stored alongside `<zone>/raft/raft.redb` so a `rm -rf
+/// $NEXUS_DATA_DIR` resets identity AND raft state together — the
+/// only state-pair that matters for the wipe-rejoin contract.  Using
+/// a flat file (not redb) avoids the `open_existing_zones_from_disk`
+/// confusion: that scanner enumerates `<zones_dir>/<zone>/raft/`
+/// dirs, so creating a fake "incarnation zone" with raft.redb would
+/// trigger spurious zone bootstrap with skip_bootstrap=true and a
+/// missing ConfState, blocking leader election forever.
+const NODE_INCARNATION_FILE: &str = ".node_incarnation";
 
 /// Triple keyed by target zone: `(parent_zone_id, mount_path, global_path)`.
 type CrossZoneMountTuple = (String, String, String);
@@ -264,12 +282,84 @@ fn generate_fresh_incarnation() -> u64 {
     }
 }
 
+/// Read the persisted node-level incarnation.  Returns `None` when
+/// the file doesn't exist (fresh daemon).
+fn read_node_incarnation(zones_dir: &str) -> Result<Option<u64>, String> {
+    let path = Path::new(zones_dir).join(NODE_INCARNATION_FILE);
+    match std::fs::read(&path) {
+        Ok(bytes) => {
+            let arr: [u8; 8] = bytes.as_slice().try_into().map_err(|_| {
+                format!(
+                    "node incarnation file '{}' is not 8 bytes",
+                    path.display()
+                )
+            })?;
+            Ok(Some(u64::from_be_bytes(arr)))
+        }
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(None),
+        Err(e) => Err(format!(
+            "read node incarnation '{}': {e}",
+            path.display(),
+        )),
+    }
+}
+
+/// Persist the node-level incarnation.  Creates the parent directory
+/// if absent.  Atomic via write-rename — prevents a torn 8-byte file
+/// from a crash between `write_all` and `sync`.
+fn write_node_incarnation(zones_dir: &str, incarnation: u64) -> Result<(), String> {
+    use std::io::Write;
+    let dir = Path::new(zones_dir);
+    std::fs::create_dir_all(dir).map_err(|e| {
+        format!(
+            "create zones dir for node incarnation '{}': {e}",
+            dir.display(),
+        )
+    })?;
+    let final_path = dir.join(NODE_INCARNATION_FILE);
+    let tmp_path = dir.join(format!("{NODE_INCARNATION_FILE}.tmp"));
+    {
+        let mut tmp = std::fs::File::create(&tmp_path).map_err(|e| {
+            format!(
+                "create tmp incarnation file '{}': {e}",
+                tmp_path.display(),
+            )
+        })?;
+        tmp.write_all(&incarnation.to_be_bytes()).map_err(|e| {
+            format!(
+                "write tmp incarnation file '{}': {e}",
+                tmp_path.display(),
+            )
+        })?;
+        tmp.sync_all().map_err(|e| {
+            format!(
+                "sync tmp incarnation file '{}': {e}",
+                tmp_path.display(),
+            )
+        })?;
+    }
+    std::fs::rename(&tmp_path, &final_path).map_err(|e| {
+        format!(
+            "rename '{}' -> '{}': {e}",
+            tmp_path.display(),
+            final_path.display(),
+        )
+    })?;
+    Ok(())
+}
+
 /// Try `ReplaceVoterByHostname` against each peer in turn.  Returns
 /// `true` on the first peer that responds with `success`.  Followers
 /// supply the leader's address in `leader_address`; the caller follows
 /// that redirect once before moving to the next peer.
+///
+/// Takes the owning `Runtime` (not a `Handle`) so we can call
+/// `Runtime::block_on` directly — `Handle::block_on` against a
+/// current_thread runtime from the runtime's own thread deadlocks
+/// (the runtime worker is the caller, so the future never gets
+/// driven).
 fn try_replace_voter_on_peers(
-    runtime: &tokio::runtime::Handle,
+    runtime: &tokio::runtime::Runtime,
     peers: &[NodeAddress],
     self_hostname: &str,
     new_node_id: u64,
@@ -285,6 +375,10 @@ fn try_replace_voter_on_peers(
         let mut endpoint = peer.endpoint.clone();
         let mut redirected_once = false;
         loop {
+            eprintln!(
+                "[ensure_voter_membership] dialing ReplaceVoterByHostname \
+                 endpoint={endpoint} hostname={self_hostname} new_node_id={new_node_id}",
+            );
             let attempt = runtime.block_on(call_replace_voter_by_hostname(
                 &endpoint,
                 "root",
@@ -295,40 +389,33 @@ fn try_replace_voter_on_peers(
             ));
             match attempt {
                 Ok(result) if result.success => {
-                    tracing::info!(
-                        peer = %endpoint,
-                        new_node_id,
-                        removed_old_id = ?result.removed_old_id,
-                        "ReplaceVoterByHostname committed",
+                    eprintln!(
+                        "[ensure_voter_membership] ReplaceVoterByHostname committed \
+                         endpoint={endpoint} new_node_id={new_node_id} \
+                         removed_old_id={:?}",
+                        result.removed_old_id,
                     );
                     return true;
                 }
                 Ok(result) => {
                     if let Some(addr) = result.leader_address.as_ref() {
                         if !redirected_once && !addr.is_empty() && addr != &endpoint {
-                            tracing::info!(
-                                from = %endpoint,
-                                to = %addr,
-                                "ReplaceVoterByHostname redirected to leader",
+                            eprintln!(
+                                "[ensure_voter_membership] redirected from {endpoint} to {addr}",
                             );
                             endpoint = addr.clone();
                             redirected_once = true;
                             continue;
                         }
                     }
-                    tracing::debug!(
-                        peer = %endpoint,
-                        error = ?result.error,
-                        "ReplaceVoterByHostname rejected; trying next peer",
+                    eprintln!(
+                        "[ensure_voter_membership] rejected by {endpoint}: error={:?}",
+                        result.error,
                     );
                     break;
                 }
                 Err(e) => {
-                    tracing::debug!(
-                        peer = %endpoint,
-                        error = %e,
-                        "ReplaceVoterByHostname RPC failed; trying next peer",
-                    );
+                    eprintln!("[ensure_voter_membership] RPC to {endpoint} failed: {e}");
                     break;
                 }
             }
@@ -374,28 +461,17 @@ impl RaftFederationProvider {
         zones_dir: &str,
         peers: &[NodeAddress],
     ) -> Result<VoterMembership, String> {
-        let root_raft_path = Path::new(zones_dir).join("root").join("raft");
-        let root_redb_path = root_raft_path.join("raft.redb");
-
-        // Recovery path — storage already contains a persisted
-        // incarnation (or pre-fix data with no marker, which we treat
-        // as 0 = cold-start ID).
-        if root_redb_path.exists() {
-            let storage = RaftStorage::open(&root_raft_path)
-                .map_err(|e| format!("open root raft storage for incarnation read: {e}"))?;
-            let incarnation = storage
-                .incarnation()
-                .map_err(|e| format!("read incarnation: {e}"))?
-                .unwrap_or(0);
-            // Drop redb handle so ZoneManager::with_node_id can reopen
-            // the same file later.
-            drop(storage);
+        // Recovery path — node-level incarnation file exists from a
+        // prior boot (or pre-fix daemon, which we treat as
+        // incarnation=0 → cold-start ID).
+        if let Some(incarnation) = read_node_incarnation(zones_dir)? {
             let node_id = compute_node_id(hostname, incarnation);
-            tracing::info!(
-                hostname,
-                incarnation,
-                node_id,
-                "ensure_voter_membership: recovery (existing storage)",
+            // Tracing subscriber is not initialised until ZoneManager
+            // construction (a few milliseconds later), so this fn
+            // logs to stderr directly.  Boot-time trace, low volume.
+            eprintln!(
+                "[ensure_voter_membership] recovery: hostname={hostname} \
+                 incarnation={incarnation} node_id={node_id}",
             );
             return Ok(VoterMembership {
                 node_id,
@@ -406,18 +482,30 @@ impl RaftFederationProvider {
         // Fresh path — try wipe-rejoin rotation, fall back to cold start.
         let new_incarnation = generate_fresh_incarnation();
         let new_id = compute_node_id(hostname, new_incarnation);
+        eprintln!(
+            "[ensure_voter_membership] fresh: hostname={hostname} \
+             trying rotation new_incarnation={new_incarnation} new_id={new_id} \
+             peers={}",
+            peers.len(),
+        );
 
         // Spin up a small temporary tokio runtime for the rotation
         // RPCs.  ZoneManager owns the long-lived runtime but we need
         // gRPC dialing *before* the manager is constructed (so that
         // its raft node ID is correct from the first heartbeat).
-        // Single-threaded is sufficient — the calls are sequential.
-        let rotation_runtime = tokio::runtime::Builder::new_current_thread()
+        //
+        // Use a multi-thread runtime with a single worker so `block_on`
+        // on the calling thread doesn't have to drive the event loop
+        // simultaneously — that combination on a current_thread
+        // runtime deadlocks because the worker thread IS the caller.
+        let rotation_runtime = tokio::runtime::Builder::new_multi_thread()
+            .worker_threads(1)
             .enable_all()
+            .thread_name("ensure-voter-membership")
             .build()
             .map_err(|e| format!("rotation runtime: {e}"))?;
         let rotated = try_replace_voter_on_peers(
-            &rotation_runtime.handle().clone(),
+            &rotation_runtime,
             peers,
             hostname,
             new_id,
@@ -427,22 +515,15 @@ impl RaftFederationProvider {
 
         // Whether we rotated or fell through to cold-start, persist
         // the chosen incarnation so the next restart hits the recovery
-        // path above.
-        std::fs::create_dir_all(&root_raft_path)
-            .map_err(|e| format!("create root raft dir '{}': {e}", root_raft_path.display()))?;
-        let storage = RaftStorage::open(&root_raft_path)
-            .map_err(|e| format!("open root raft storage for incarnation persist: {e}"))?;
-
+        // path above.  Crucially this lives in a flat node-level file
+        // rather than per-zone redb, so `open_existing_zones_from_disk`
+        // (which scans `<zones_dir>/<zone>/raft/` subtrees) is
+        // unaffected.
         if rotated {
-            storage
-                .set_incarnation(new_incarnation)
-                .map_err(|e| format!("persist new incarnation: {e}"))?;
-            drop(storage);
-            tracing::info!(
-                hostname,
-                incarnation = new_incarnation,
-                node_id = new_id,
-                "ensure_voter_membership: rotated into existing cluster",
+            write_node_incarnation(zones_dir, new_incarnation)?;
+            eprintln!(
+                "[ensure_voter_membership] rotated into existing cluster: \
+                 hostname={hostname} incarnation={new_incarnation} node_id={new_id}",
             );
             Ok(VoterMembership {
                 node_id: new_id,
@@ -452,15 +533,11 @@ impl RaftFederationProvider {
             // Cold-start sentinel — every peer derives the same ID for
             // this hostname so `create_zone` ConfState bootstraps
             // converge without coordination.
-            storage
-                .set_incarnation(0)
-                .map_err(|e| format!("persist cold-start incarnation: {e}"))?;
-            drop(storage);
+            write_node_incarnation(zones_dir, 0)?;
             let cold_id = hostname_to_node_id(hostname);
-            tracing::info!(
-                hostname,
-                node_id = cold_id,
-                "ensure_voter_membership: cold start (no leader reachable)",
+            eprintln!(
+                "[ensure_voter_membership] cold start (no leader reachable): \
+                 hostname={hostname} node_id={cold_id}",
             );
             Ok(VoterMembership {
                 node_id: cold_id,

--- a/rust/raft/src/raft/mod.rs
+++ b/rust/raft/src/raft/mod.rs
@@ -50,7 +50,7 @@ pub mod zone_persistence;
 #[cfg(feature = "consensus")]
 mod node;
 #[cfg(feature = "consensus")]
-mod storage;
+pub mod storage;
 #[cfg(all(feature = "grpc", has_protos))]
 mod zone_registry;
 

--- a/rust/raft/src/raft/mod.rs
+++ b/rust/raft/src/raft/mod.rs
@@ -50,7 +50,7 @@ pub mod zone_persistence;
 #[cfg(feature = "consensus")]
 mod node;
 #[cfg(feature = "consensus")]
-pub mod storage;
+mod storage;
 #[cfg(all(feature = "grpc", has_protos))]
 mod zone_registry;
 

--- a/rust/raft/src/raft/node.rs
+++ b/rust/raft/src/raft/node.rs
@@ -241,6 +241,22 @@ pub enum RaftMsg {
         change: ConfChange,
         tx: oneshot::Sender<Result<ConfState>>,
     },
+    /// Propose a multi-change ConfChange (V2 atomic membership swap).
+    ///
+    /// Used by the wipe-rejoin rotation path where a single committed
+    /// entry must atomically `RemoveNode(old_id)` + `AddNode(new_id)`
+    /// so the cluster never observes a transient `voters - {old_id}`
+    /// state — strict raft membership-swap contract.
+    ///
+    /// `register_under_id` is the node_id used as the
+    /// `pending_conf_changes` map key.  Pick one of the IDs the V2
+    /// changes touch (typically the AddNode target); the V2 apply
+    /// loop resolves the tx when that change lands.
+    ProposeConfChangeV2 {
+        change: raft::eraftpb::ConfChangeV2,
+        register_under_id: u64,
+        tx: oneshot::Sender<Result<ConfState>>,
+    },
     /// Campaign to become leader.
     Campaign { tx: oneshot::Sender<Result<()>> },
     /// Linearizable read request (F4 C3.6 — ReadIndex).
@@ -1149,6 +1165,75 @@ impl<S: StateMachine + 'static> ZoneConsensus<S> {
         }
     }
 
+    /// Atomically swap one voter for another in a single committed
+    /// entry — strict raft membership-swap contract.
+    ///
+    /// Builds a `ConfChangeV2` with two changes
+    /// (`RemoveNode(old_id)` + `AddNode(new_id)`) so the cluster goes
+    /// directly from `voters` → `voters - {old_id} + {new_id}` without
+    /// observing the transient `voters - {old_id}` quorum state that
+    /// two sequential `propose_conf_change` calls would expose.
+    ///
+    /// `auto_leave = false` (the V2 default) — this is a single-step
+    /// reconfig rather than full joint consensus, but raft-rs commits
+    /// it as one log entry either way; the atomicity comes from "all
+    /// changes in one entry, applied together".
+    ///
+    /// Used by the wipe-rejoin rotation path
+    /// (`replace_voter_by_hostname` server handler).  When `old_id ==
+    /// 0` the Remove is skipped — fall back to a plain `AddNode`
+    /// (brand-new host that was never a voter).
+    pub async fn propose_replace_voter(
+        &self,
+        old_id: u64,
+        new_id: u64,
+        new_address: Vec<u8>,
+    ) -> Result<ConfState> {
+        if !self.is_leader() {
+            return Err(RaftError::NotLeader {
+                leader_hint: self.leader_id(),
+            });
+        }
+        if new_id == 0 {
+            return Err(RaftError::Raft(
+                "propose_replace_voter: new_id must not be 0".into(),
+            ));
+        }
+
+        use raft::eraftpb::{ConfChangeSingle, ConfChangeV2};
+
+        let mut v2 = ConfChangeV2::default();
+        // Address travels in the V2 envelope's `context` field; the
+        // apply path decodes it as UTF-8 and feeds it into the peer
+        // map for both removed and added entries (Remove ignores it).
+        v2.context = new_address.clone().into();
+        if old_id != 0 && old_id != new_id {
+            let mut remove = ConfChangeSingle::default();
+            remove.set_change_type(ConfChangeType::RemoveNode);
+            remove.node_id = old_id;
+            v2.changes.push(remove);
+        }
+        let mut add = ConfChangeSingle::default();
+        add.set_change_type(ConfChangeType::AddNode);
+        add.node_id = new_id;
+        v2.changes.push(add);
+
+        let (tx, rx) = oneshot::channel();
+        self.msg_tx
+            .try_send(RaftMsg::ProposeConfChangeV2 {
+                change: v2,
+                register_under_id: new_id,
+                tx,
+            })
+            .map_err(channel_try_send_err)?;
+
+        match tokio::time::timeout(Duration::from_secs(PROPOSAL_TIMEOUT_SECS), rx).await {
+            Ok(Ok(result)) => result,
+            Ok(Err(_)) => Err(RaftError::ProposalDropped),
+            Err(_) => Err(RaftError::Timeout(PROPOSAL_TIMEOUT_SECS)),
+        }
+    }
+
     /// Process a message from another node (sends through channel to driver).
     ///
     /// Uses `send().await` (blocking until space is available) instead of
@@ -1242,6 +1327,25 @@ impl<S: StateMachine + 'static> ZoneConsensusDriver<S> {
                         Ok(()) => {
                             // Store tx — will be resolved in apply_entries when committed
                             self.pending_conf_changes.insert(target_node_id, tx);
+                        }
+                        Err(e) => {
+                            let _ = tx.send(Err(RaftError::Raft(e.to_string())));
+                        }
+                    }
+                }
+                RaftMsg::ProposeConfChangeV2 {
+                    change,
+                    register_under_id,
+                    tx,
+                } => {
+                    tracing::debug!(
+                        register_under_id,
+                        num_changes = change.changes.len(),
+                        "raft.driver.propose_conf_change_v2",
+                    );
+                    match self.raw_node.propose_conf_change(vec![], change) {
+                        Ok(()) => {
+                            self.pending_conf_changes.insert(register_under_id, tx);
                         }
                         Err(e) => {
                             let _ = tx.send(Err(RaftError::Raft(e.to_string())));

--- a/rust/raft/src/raft/storage.rs
+++ b/rust/raft/src/raft/storage.rs
@@ -19,6 +19,26 @@ const KEY_HARD_STATE: &[u8] = b"hard_state";
 const KEY_CONF_STATE: &[u8] = b"conf_state";
 const KEY_SNAPSHOT: &[u8] = b"snapshot";
 const KEY_FIRST_INDEX: &[u8] = b"first_index";
+/// Per-storage node-incarnation marker (Issue: fresh-join panic).
+///
+/// Persisted ONCE on the first ``RaftStorage::new`` against a fresh redb;
+/// thereafter read on every restart.  Wiping the data dir resets the
+/// marker, which lets ``ensure_voter_membership`` mint a new node ID
+/// instead of reusing the prior one — avoiding raft-rs's
+/// ``handle_heartbeat`` panic when a wiped node rejoins a running
+/// cluster (leader's in-memory ``Progress[old_id].matched`` is stale and
+/// would cause ``commit_to(K)`` against ``last_index=0``).
+const KEY_INCARNATION: &[u8] = b"incarnation";
+
+/// Default incarnation used during cold-start cluster bootstrap.
+///
+/// All nodes converge on this value at first boot so the IDs they each
+/// derive from ``compute_node_id(hostname, DEFAULT_INCARNATION)`` match
+/// across the cluster's ConfState.  Only used when no leader is
+/// reachable (``ensure_voter_membership`` cold-start path); a wiped
+/// node that finds an existing leader mints a fresh u64 instead.
+#[allow(dead_code)] // Wired up in the ensure_voter_membership commit on this branch.
+pub const DEFAULT_INCARNATION: u64 = 0;
 
 /// Raft storage backed by redb.
 ///
@@ -37,7 +57,8 @@ const KEY_FIRST_INDEX: &[u8] = b"first_index";
 ///     ├── hard_state -> HardState (term, vote, commit)
 ///     ├── conf_state -> ConfState (voters, learners)
 ///     ├── snapshot -> Snapshot
-///     └── first_index -> u64
+///     ├── first_index -> u64
+///     └── incarnation -> u64  (set on first ::new, never overwritten)
 /// ```
 pub struct RaftStorage {
     /// Underlying redb store.
@@ -46,6 +67,14 @@ pub struct RaftStorage {
     entries: RedbTree,
     /// Tree for raft state.
     state: RedbTree,
+    /// Whether this storage was just initialized (no prior incarnation).
+    ///
+    /// Set to ``true`` when ``new`` runs against a fresh redb (no
+    /// ``KEY_INCARNATION`` row); ``false`` when reopening an existing
+    /// store.  ``ensure_voter_membership`` reads this to decide whether
+    /// to attempt the wipe-rejoin rotation flow vs. a normal recovery.
+    /// In-memory only — recomputed every process start from on-disk state.
+    was_just_created: bool,
 }
 
 impl RaftStorage {
@@ -57,10 +86,18 @@ impl RaftStorage {
         let entries = store.tree(TREE_ENTRIES)?;
         let state = store.tree(TREE_STATE)?;
 
+        // Detect fresh-vs-existing redb by probing for an incarnation
+        // marker.  Absent → first ::new on this store: the bootstrap
+        // path will write ``DEFAULT_INCARNATION`` once it knows whether
+        // this is cold-start or wipe-rejoin.  Present → recovery; the
+        // marker stays as-is.
+        let was_just_created = state.get(KEY_INCARNATION)?.is_none();
+
         let storage = Self {
             store,
             entries,
             state,
+            was_just_created,
         };
 
         // Initialize first_index if not set
@@ -78,6 +115,41 @@ impl RaftStorage {
     pub fn open(path: impl AsRef<std::path::Path>) -> Result<Self> {
         let store = RedbStore::open(path.as_ref().join("raft.redb"))?;
         Self::new(store)
+    }
+
+    /// Whether this `RaftStorage` was opened against a freshly-created
+    /// redb (no prior incarnation marker on disk).
+    ///
+    /// Reset on every process boot from durable state — ``true`` on the
+    /// first ``new`` after a wipe (or first boot ever), ``false`` after
+    /// any subsequent ``set_incarnation`` persists the marker.
+    pub fn was_just_created(&self) -> bool {
+        self.was_just_created
+    }
+
+    /// Read the persisted incarnation marker, or ``None`` if this is a
+    /// freshly-created storage that hasn't been bootstrapped yet.
+    pub fn incarnation(&self) -> Result<Option<u64>> {
+        match self.state.get(KEY_INCARNATION)? {
+            Some(bytes) => {
+                let arr: [u8; 8] = bytes
+                    .as_slice()
+                    .try_into()
+                    .map_err(|_| RaftError::Storage("invalid incarnation marker".into()))?;
+                Ok(Some(u64::from_be_bytes(arr)))
+            }
+            None => Ok(None),
+        }
+    }
+
+    /// Persist the incarnation marker.  Idempotent: callers may call
+    /// repeatedly with the same value (e.g. on every restart with the
+    /// existing value re-asserted).  Once written, the marker survives
+    /// until the redb file is wiped.
+    pub fn set_incarnation(&self, incarnation: u64) -> Result<()> {
+        self.state
+            .set(KEY_INCARNATION, &incarnation.to_be_bytes())?;
+        Ok(())
     }
 
     /// Get the first index in the log.
@@ -479,6 +551,47 @@ mod tests {
             .entries(5, 11, None, raft::GetEntriesContext::empty(false))
             .unwrap();
         assert_eq!(entries.len(), 6);
+    }
+
+    // ---------------------------------------------------------------
+    // Incarnation marker tests (fresh-join wipe-rejoin fix)
+    // ---------------------------------------------------------------
+
+    #[test]
+    fn fresh_storage_reports_just_created() {
+        let (storage, _dir) = create_test_storage();
+        assert!(storage.was_just_created());
+        assert_eq!(storage.incarnation().unwrap(), None);
+    }
+
+    #[test]
+    fn set_incarnation_persists_across_reopen() {
+        let dir = TempDir::new().unwrap();
+        let path = dir.path().to_path_buf();
+
+        // First open: fresh, mint incarnation.
+        let storage = RaftStorage::open(&path).unwrap();
+        assert!(storage.was_just_created());
+        storage.set_incarnation(0xDEAD_BEEF).unwrap();
+        // Drop to release the redb lock before reopening.
+        drop(storage);
+
+        // Re-open: was_just_created flips to false; incarnation reads back.
+        let reopened = RaftStorage::open(&path).unwrap();
+        assert!(!reopened.was_just_created());
+        assert_eq!(reopened.incarnation().unwrap(), Some(0xDEAD_BEEF));
+    }
+
+    #[test]
+    fn set_incarnation_idempotent() {
+        let (storage, _dir) = create_test_storage();
+        storage.set_incarnation(42).unwrap();
+        storage.set_incarnation(42).unwrap();
+        assert_eq!(storage.incarnation().unwrap(), Some(42));
+        // Overwriting with a different value is allowed at the storage layer
+        // — caller policy (ensure_voter_membership) decides when to rotate.
+        storage.set_incarnation(99).unwrap();
+        assert_eq!(storage.incarnation().unwrap(), Some(99));
     }
 
     // ---------------------------------------------------------------

--- a/rust/raft/src/raft/storage.rs
+++ b/rust/raft/src/raft/storage.rs
@@ -19,26 +19,6 @@ const KEY_HARD_STATE: &[u8] = b"hard_state";
 const KEY_CONF_STATE: &[u8] = b"conf_state";
 const KEY_SNAPSHOT: &[u8] = b"snapshot";
 const KEY_FIRST_INDEX: &[u8] = b"first_index";
-/// Per-storage node-incarnation marker (Issue: fresh-join panic).
-///
-/// Persisted ONCE on the first ``RaftStorage::new`` against a fresh redb;
-/// thereafter read on every restart.  Wiping the data dir resets the
-/// marker, which lets ``ensure_voter_membership`` mint a new node ID
-/// instead of reusing the prior one — avoiding raft-rs's
-/// ``handle_heartbeat`` panic when a wiped node rejoins a running
-/// cluster (leader's in-memory ``Progress[old_id].matched`` is stale and
-/// would cause ``commit_to(K)`` against ``last_index=0``).
-const KEY_INCARNATION: &[u8] = b"incarnation";
-
-/// Default incarnation used during cold-start cluster bootstrap.
-///
-/// All nodes converge on this value at first boot so the IDs they each
-/// derive from ``compute_node_id(hostname, DEFAULT_INCARNATION)`` match
-/// across the cluster's ConfState.  Only used when no leader is
-/// reachable (``ensure_voter_membership`` cold-start path); a wiped
-/// node that finds an existing leader mints a fresh u64 instead.
-#[allow(dead_code)] // Wired up in the ensure_voter_membership commit on this branch.
-pub const DEFAULT_INCARNATION: u64 = 0;
 
 /// Raft storage backed by redb.
 ///
@@ -57,9 +37,15 @@ pub const DEFAULT_INCARNATION: u64 = 0;
 ///     ├── hard_state -> HardState (term, vote, commit)
 ///     ├── conf_state -> ConfState (voters, learners)
 ///     ├── snapshot -> Snapshot
-///     ├── first_index -> u64
-///     └── incarnation -> u64  (set on first ::new, never overwritten)
+///     └── first_index -> u64
 /// ```
+///
+/// Node identity (incarnation marker for the wipe-rejoin contract)
+/// is **NOT** stored here — it lives at the node level in
+/// `<NEXUS_DATA_DIR>/.node_incarnation` so a single value covers
+/// every zone this node serves, and so `open_existing_zones_from_disk`
+/// (which scans `<zones_dir>/<zone>/raft/` subtrees) is not confused
+/// by a fake "incarnation zone".
 pub struct RaftStorage {
     /// Underlying redb store.
     store: RedbStore,
@@ -67,14 +53,6 @@ pub struct RaftStorage {
     entries: RedbTree,
     /// Tree for raft state.
     state: RedbTree,
-    /// Whether this storage was just initialized (no prior incarnation).
-    ///
-    /// Set to ``true`` when ``new`` runs against a fresh redb (no
-    /// ``KEY_INCARNATION`` row); ``false`` when reopening an existing
-    /// store.  ``ensure_voter_membership`` reads this to decide whether
-    /// to attempt the wipe-rejoin rotation flow vs. a normal recovery.
-    /// In-memory only — recomputed every process start from on-disk state.
-    was_just_created: bool,
 }
 
 impl RaftStorage {
@@ -86,18 +64,10 @@ impl RaftStorage {
         let entries = store.tree(TREE_ENTRIES)?;
         let state = store.tree(TREE_STATE)?;
 
-        // Detect fresh-vs-existing redb by probing for an incarnation
-        // marker.  Absent → first ::new on this store: the bootstrap
-        // path will write ``DEFAULT_INCARNATION`` once it knows whether
-        // this is cold-start or wipe-rejoin.  Present → recovery; the
-        // marker stays as-is.
-        let was_just_created = state.get(KEY_INCARNATION)?.is_none();
-
         let storage = Self {
             store,
             entries,
             state,
-            was_just_created,
         };
 
         // Initialize first_index if not set
@@ -115,41 +85,6 @@ impl RaftStorage {
     pub fn open(path: impl AsRef<std::path::Path>) -> Result<Self> {
         let store = RedbStore::open(path.as_ref().join("raft.redb"))?;
         Self::new(store)
-    }
-
-    /// Whether this `RaftStorage` was opened against a freshly-created
-    /// redb (no prior incarnation marker on disk).
-    ///
-    /// Reset on every process boot from durable state — ``true`` on the
-    /// first ``new`` after a wipe (or first boot ever), ``false`` after
-    /// any subsequent ``set_incarnation`` persists the marker.
-    pub fn was_just_created(&self) -> bool {
-        self.was_just_created
-    }
-
-    /// Read the persisted incarnation marker, or ``None`` if this is a
-    /// freshly-created storage that hasn't been bootstrapped yet.
-    pub fn incarnation(&self) -> Result<Option<u64>> {
-        match self.state.get(KEY_INCARNATION)? {
-            Some(bytes) => {
-                let arr: [u8; 8] = bytes
-                    .as_slice()
-                    .try_into()
-                    .map_err(|_| RaftError::Storage("invalid incarnation marker".into()))?;
-                Ok(Some(u64::from_be_bytes(arr)))
-            }
-            None => Ok(None),
-        }
-    }
-
-    /// Persist the incarnation marker.  Idempotent: callers may call
-    /// repeatedly with the same value (e.g. on every restart with the
-    /// existing value re-asserted).  Once written, the marker survives
-    /// until the redb file is wiped.
-    pub fn set_incarnation(&self, incarnation: u64) -> Result<()> {
-        self.state
-            .set(KEY_INCARNATION, &incarnation.to_be_bytes())?;
-        Ok(())
     }
 
     /// Get the first index in the log.

--- a/rust/raft/src/transport/client.rs
+++ b/rust/raft/src/transport/client.rs
@@ -8,7 +8,8 @@ use super::proto::nexus::raft::{
     zone_transport_service_client::ZoneTransportServiceClient, AcquireLock, DeleteMetadata,
     EcReplicationEntry, ExtendLock, GetClusterInfoRequest, GetLockInfo, GetMetadata,
     JoinClusterRequest, ListMetadata, ProposeRequest, PutMetadata, QueryRequest, RaftCommand,
-    RaftQuery, ReleaseLock, ReplicateEntriesRequest, StepMessageRequest,
+    RaftQuery, ReleaseLock, ReplaceVoterByHostnameRequest, ReplicateEntriesRequest,
+    StepMessageRequest,
 };
 use super::{NodeAddress, Result, TransportError};
 use std::collections::HashMap;
@@ -660,6 +661,67 @@ pub async fn call_join_cluster(
         ca_pem: response.ca_pem,
         node_cert_pem: response.node_cert_pem,
         node_key_pem: response.node_key_pem,
+    })
+}
+
+/// Outcome of a [`call_replace_voter_by_hostname`] RPC.
+#[derive(Debug, Clone)]
+pub struct ReplaceVoterResult {
+    /// Whether both ConfChanges (or just AddNode in the no-prior-voter
+    /// fast path) committed successfully.
+    pub success: bool,
+    /// Error message when `success == false`.
+    pub error: Option<String>,
+    /// Leader address when the receiver was a follower (caller follows
+    /// the redirect once).
+    pub leader_address: Option<String>,
+    /// The old voter ID that was removed.  `None` when no prior voter
+    /// matched the supplied hostname (fast path) or when the removal
+    /// step failed.
+    pub removed_old_id: Option<u64>,
+}
+
+/// Call `ZoneApiService::ReplaceVoterByHostname` on a single peer.
+///
+/// Caller iterates peers in their NEXUS_PEERS list and stops on the
+/// first non-error response; followers self-identify via `leader_address`
+/// in the response so the caller follows the redirect once.
+pub async fn call_replace_voter_by_hostname(
+    peer_addr: &str,
+    zone_id: &str,
+    hostname: &str,
+    new_node_id: u64,
+    self_address: &str,
+    timeout_secs: u64,
+) -> Result<ReplaceVoterResult> {
+    let ep = Endpoint::from_shared(peer_addr.to_string())
+        .map_err(|e| TransportError::InvalidAddress(e.to_string()))?
+        .connect_timeout(Duration::from_secs(timeout_secs))
+        .timeout(Duration::from_secs(timeout_secs));
+
+    let channel = ep.connect().await.map_err(|e| {
+        TransportError::Connection(format!("ReplaceVoter connect to {peer_addr} failed: {e}"))
+    })?;
+
+    let mut client = ZoneApiServiceClient::new(channel);
+    let request = ReplaceVoterByHostnameRequest {
+        zone_id: zone_id.to_string(),
+        hostname: hostname.to_string(),
+        new_node_id,
+        node_address: self_address.to_string(),
+    };
+
+    let response = client
+        .replace_voter_by_hostname(request)
+        .await
+        .map_err(|e| TransportError::Rpc(format!("ReplaceVoter RPC failed: {e}")))?
+        .into_inner();
+
+    Ok(ReplaceVoterResult {
+        success: response.success,
+        error: response.error,
+        leader_address: response.leader_address,
+        removed_old_id: response.removed_old_id,
     })
 }
 

--- a/rust/raft/src/transport/mod.rs
+++ b/rust/raft/src/transport/mod.rs
@@ -52,8 +52,9 @@ mod transport_loop;
 
 #[cfg(all(feature = "grpc", has_protos))]
 pub use client::{
-    call_join_cluster, ClientConfig, ClusterInfoResult, JoinClusterResult, ProposeResult,
-    QueryResult, RaftApiClient, RaftClient, RaftClientPool,
+    call_join_cluster, call_replace_voter_by_hostname, ClientConfig, ClusterInfoResult,
+    JoinClusterResult, ProposeResult, QueryResult, RaftApiClient, RaftClient, RaftClientPool,
+    ReplaceVoterResult,
 };
 #[cfg(all(feature = "grpc", has_protos))]
 pub use server::{RaftGrpcServer, RaftWitnessServer, ServerConfig, WitnessZoneRegistry};

--- a/rust/raft/src/transport/mod.rs
+++ b/rust/raft/src/transport/mod.rs
@@ -199,7 +199,7 @@ fn proto_result_to_command_result(
 // ---------------------------------------------------------------------------
 #[cfg(feature = "grpc")]
 pub use transport_primitives::{
-    hostname_to_node_id, NodeAddress, PeerAddress, TlsConfig, TransportError,
+    compute_node_id, hostname_to_node_id, NodeAddress, PeerAddress, TlsConfig, TransportError,
 };
 #[cfg(feature = "grpc")]
 pub type Result<T> = transport_primitives::Result<T>;

--- a/rust/raft/src/transport/server.rs
+++ b/rust/raft/src/transport/server.rs
@@ -16,8 +16,8 @@ use super::proto::nexus::raft::{
     JoinZoneRequest, JoinZoneResponse, ListMetadataResult, LockInfoResult, LockResult,
     NodeInfo as ProtoNodeInfo, ProposeRequest, ProposeResponse, QueryRequest, QueryResponse,
     RaftCommand, RaftQueryResponse, RaftResponse, ReadBlobRequest, ReadBlobResponse,
-    ReplicateEntriesRequest, ReplicateEntriesResponse, SearchCapabilities, StepMessageRequest,
-    StepMessageResponse,
+    ReplaceVoterByHostnameRequest, ReplaceVoterByHostnameResponse, ReplicateEntriesRequest,
+    ReplicateEntriesResponse, SearchCapabilities, StepMessageRequest, StepMessageResponse,
 };
 use super::{NodeAddress, Result, TransportError};
 use crate::blob_fetcher::BlobFetcherSlot;
@@ -942,6 +942,180 @@ impl ZoneApiService for ZoneApiServiceImpl {
                 error: Some(format!("JoinZone failed: {}", e)),
                 leader_address: None,
                 config: None,
+            })),
+        }
+    }
+
+    /// Handle a ReplaceVoterByHostname request — wipe-rejoin ID rotation.
+    ///
+    /// Leader-only.  Looks up the prior voter ID for `hostname` in the
+    /// cluster's peer map (caller doesn't claim what the old ID was —
+    /// authoritative answer lives here), then proposes ConfChange
+    /// RemoveNode(old_id) + AddNode(new_id) sequentially.  Followers
+    /// return the leader address so the caller can retry.
+    ///
+    /// No-op fast path: when no existing voter has the supplied
+    /// hostname (a brand-new host that was never a voter), only the
+    /// AddNode is proposed — `removed_old_id` is `None`.
+    async fn replace_voter_by_hostname(
+        &self,
+        request: Request<ReplaceVoterByHostnameRequest>,
+    ) -> std::result::Result<Response<ReplaceVoterByHostnameResponse>, Status> {
+        let req = request.into_inner();
+
+        // Reject empty hostname / zero new_id early — both are nonsense
+        // inputs that would otherwise produce a confusing leader-side
+        // error after RPC dispatch.
+        if req.hostname.trim().is_empty() {
+            return Ok(Response::new(ReplaceVoterByHostnameResponse {
+                success: false,
+                error: Some("hostname must not be empty".to_string()),
+                leader_address: None,
+                removed_old_id: None,
+            }));
+        }
+        if req.new_node_id == 0 {
+            return Ok(Response::new(ReplaceVoterByHostnameResponse {
+                success: false,
+                error: Some(
+                    "new_node_id must not be 0 (raft-rs reserves 0 for 'no node')".to_string(),
+                ),
+                leader_address: None,
+                removed_old_id: None,
+            }));
+        }
+
+        let node = get_zone_node(&self.registry, &req.zone_id)?;
+
+        // Followers redirect — caller follows leader_address back here.
+        if !node.is_leader() {
+            let peers = self.registry.get_peers(&req.zone_id).unwrap_or_default();
+            let leader_id = node.leader_id().unwrap_or(0);
+            let leader_addr = peers.get(&leader_id).map(|a| a.endpoint.clone());
+            return Ok(Response::new(ReplaceVoterByHostnameResponse {
+                success: false,
+                error: Some("not leader".to_string()),
+                leader_address: leader_addr,
+                removed_old_id: None,
+            }));
+        }
+
+        tracing::info!(
+            zone = req.zone_id,
+            hostname = req.hostname,
+            new_node_id = req.new_node_id,
+            address = req.node_address,
+            "ReplaceVoterByHostname request received",
+        );
+
+        // Reverse-lookup any existing voter with the same hostname.
+        // We trust the leader's peer-map snapshot — leader-only execution
+        // means no concurrent ConfChange can race this lookup before the
+        // first propose lands.
+        let peers = self.registry.get_peers(&req.zone_id).unwrap_or_default();
+        let old_id_opt = peers.iter().find_map(|(id, addr)| {
+            if addr.hostname == req.hostname {
+                Some(*id)
+            } else {
+                None
+            }
+        });
+
+        // Idempotency: if peer-map already maps `hostname` to `new_id`,
+        // a previous ReplaceVoterByHostname for this hostname must have
+        // already committed — return success without re-proposing
+        // (re-proposing AddNode for a current voter is a no-op in
+        // raft-rs but still costs a round-trip + log entry).
+        if old_id_opt == Some(req.new_node_id) {
+            return Ok(Response::new(ReplaceVoterByHostnameResponse {
+                success: true,
+                error: None,
+                leader_address: None,
+                removed_old_id: None,
+            }));
+        }
+
+        use raft::eraftpb::ConfChangeType;
+
+        // 1. Remove the prior voter if one matched.  Skipped on the
+        //    no-prior-voter fast path (brand-new host).
+        if let Some(old_id) = old_id_opt {
+            match node
+                .propose_conf_change(ConfChangeType::RemoveNode, old_id, Vec::new())
+                .await
+            {
+                Ok(_) => {
+                    tracing::info!(
+                        zone = req.zone_id,
+                        old_id,
+                        hostname = req.hostname,
+                        "Removed stale voter (wipe-rejoin rotation)",
+                    );
+                }
+                Err(RaftError::NotLeader { leader_hint }) => {
+                    let addr = leader_hint
+                        .and_then(|id| peers.get(&id))
+                        .map(|a| a.endpoint.clone());
+                    return Ok(Response::new(ReplaceVoterByHostnameResponse {
+                        success: false,
+                        error: Some("not leader".to_string()),
+                        leader_address: addr,
+                        removed_old_id: None,
+                    }));
+                }
+                Err(e) => {
+                    return Ok(Response::new(ReplaceVoterByHostnameResponse {
+                        success: false,
+                        error: Some(format!("RemoveNode({old_id}) failed: {e}")),
+                        leader_address: None,
+                        removed_old_id: None,
+                    }));
+                }
+            }
+        }
+
+        // 2. Add the new voter under the freshly-minted ID.
+        match node
+            .propose_conf_change(
+                ConfChangeType::AddNode,
+                req.new_node_id,
+                req.node_address.clone().into_bytes(),
+            )
+            .await
+        {
+            Ok(_) => Ok(Response::new(ReplaceVoterByHostnameResponse {
+                success: true,
+                error: None,
+                leader_address: None,
+                removed_old_id: old_id_opt,
+            })),
+            Err(RaftError::NotLeader { leader_hint }) => {
+                let addr = leader_hint
+                    .and_then(|id| peers.get(&id))
+                    .map(|a| a.endpoint.clone());
+                // Partial-progress note: if RemoveNode committed but
+                // AddNode hits NotLeader (rare — quorum loss between
+                // proposals), the cluster is left without this voter.
+                // The next ReplaceVoterByHostname call against the new
+                // leader will re-propose AddNode (the no-prior-voter
+                // fast path) and finish the rotation.  Ack this in the
+                // error message so operators don't double-rotate.
+                let detail = match old_id_opt {
+                    Some(_) => "RemoveNode committed but AddNode redirected — retry on new leader",
+                    None => "AddNode redirected — retry on new leader",
+                };
+                Ok(Response::new(ReplaceVoterByHostnameResponse {
+                    success: false,
+                    error: Some(detail.to_string()),
+                    leader_address: addr,
+                    removed_old_id: old_id_opt,
+                }))
+            }
+            Err(e) => Ok(Response::new(ReplaceVoterByHostnameResponse {
+                success: false,
+                error: Some(format!("AddNode({}) failed: {e}", req.new_node_id)),
+                leader_address: None,
+                removed_old_id: old_id_opt,
             })),
         }
     }

--- a/rust/raft/src/transport/server.rs
+++ b/rust/raft/src/transport/server.rs
@@ -1035,87 +1035,60 @@ impl ZoneApiService for ZoneApiServiceImpl {
             }));
         }
 
-        use raft::eraftpb::ConfChangeType;
-
-        // 1. Remove the prior voter if one matched.  Skipped on the
-        //    no-prior-voter fast path (brand-new host).
-        if let Some(old_id) = old_id_opt {
-            match node
-                .propose_conf_change(ConfChangeType::RemoveNode, old_id, Vec::new())
-                .await
-            {
-                Ok(_) => {
-                    tracing::info!(
-                        zone = req.zone_id,
-                        old_id,
-                        hostname = req.hostname,
-                        "Removed stale voter (wipe-rejoin rotation)",
-                    );
-                }
-                Err(RaftError::NotLeader { leader_hint }) => {
-                    let addr = leader_hint
-                        .and_then(|id| peers.get(&id))
-                        .map(|a| a.endpoint.clone());
-                    return Ok(Response::new(ReplaceVoterByHostnameResponse {
-                        success: false,
-                        error: Some("not leader".to_string()),
-                        leader_address: addr,
-                        removed_old_id: None,
-                    }));
-                }
-                Err(e) => {
-                    return Ok(Response::new(ReplaceVoterByHostnameResponse {
-                        success: false,
-                        error: Some(format!("RemoveNode({old_id}) failed: {e}")),
-                        leader_address: None,
-                        removed_old_id: None,
-                    }));
-                }
-            }
-        }
-
-        // 2. Add the new voter under the freshly-minted ID.
+        // Single atomic ConfChangeV2 — RemoveNode(old_id) + AddNode(new_id)
+        // commit as one entry so the cluster never observes the
+        // transient `voters - {old_id}` state.  Strict raft membership-
+        // swap contract; no transient quorum gap, single round-trip.
+        // When `old_id_opt` is None the V2 reduces to a plain AddNode
+        // (no-prior-voter fast path).
+        let old_id = old_id_opt.unwrap_or(0);
         match node
-            .propose_conf_change(
-                ConfChangeType::AddNode,
-                req.new_node_id,
-                req.node_address.clone().into_bytes(),
-            )
+            .propose_replace_voter(old_id, req.new_node_id, req.node_address.into_bytes())
             .await
         {
-            Ok(_) => Ok(Response::new(ReplaceVoterByHostnameResponse {
-                success: true,
-                error: None,
-                leader_address: None,
-                removed_old_id: old_id_opt,
-            })),
+            Ok(_) => {
+                if let Some(removed) = old_id_opt {
+                    tracing::info!(
+                        zone = req.zone_id,
+                        removed_old_id = removed,
+                        new_node_id = req.new_node_id,
+                        hostname = req.hostname,
+                        "ReplaceVoterByHostname committed (atomic Remove+Add)",
+                    );
+                } else {
+                    tracing::info!(
+                        zone = req.zone_id,
+                        new_node_id = req.new_node_id,
+                        hostname = req.hostname,
+                        "ReplaceVoterByHostname committed (no-prior-voter AddNode)",
+                    );
+                }
+                Ok(Response::new(ReplaceVoterByHostnameResponse {
+                    success: true,
+                    error: None,
+                    leader_address: None,
+                    removed_old_id: old_id_opt,
+                }))
+            }
             Err(RaftError::NotLeader { leader_hint }) => {
                 let addr = leader_hint
                     .and_then(|id| peers.get(&id))
                     .map(|a| a.endpoint.clone());
-                // Partial-progress note: if RemoveNode committed but
-                // AddNode hits NotLeader (rare — quorum loss between
-                // proposals), the cluster is left without this voter.
-                // The next ReplaceVoterByHostname call against the new
-                // leader will re-propose AddNode (the no-prior-voter
-                // fast path) and finish the rotation.  Ack this in the
-                // error message so operators don't double-rotate.
-                let detail = match old_id_opt {
-                    Some(_) => "RemoveNode committed but AddNode redirected — retry on new leader",
-                    None => "AddNode redirected — retry on new leader",
-                };
                 Ok(Response::new(ReplaceVoterByHostnameResponse {
                     success: false,
-                    error: Some(detail.to_string()),
+                    error: Some("not leader".to_string()),
                     leader_address: addr,
-                    removed_old_id: old_id_opt,
+                    removed_old_id: None,
                 }))
             }
             Err(e) => Ok(Response::new(ReplaceVoterByHostnameResponse {
                 success: false,
-                error: Some(format!("AddNode({}) failed: {e}", req.new_node_id)),
+                error: Some(format!(
+                    "ConfChangeV2(Remove={old_id}, Add={}) failed: {e}",
+                    req.new_node_id,
+                )),
                 leader_address: None,
-                removed_old_id: old_id_opt,
+                removed_old_id: None,
             })),
         }
     }

--- a/rust/raft/src/zone_manager.rs
+++ b/rust/raft/src/zone_manager.rs
@@ -219,8 +219,30 @@ impl ZoneManager {
         bind_addr: &str,
         tls: Option<TlsFiles>,
     ) -> Result<Arc<Self>> {
-        let node_id = hostname_to_node_id(hostname);
+        Self::with_node_id(
+            hostname,
+            hostname_to_node_id(hostname),
+            base_path,
+            peers,
+            bind_addr,
+            tls,
+        )
+    }
 
+    /// Create a `ZoneManager` with an explicit node ID.
+    ///
+    /// Used by `RaftFederationProvider::ensure_voter_membership` to
+    /// bind a freshly-minted incarnation-based ID for the post-wipe
+    /// rotation path.  Most callers should use [`Self::new`], which
+    /// computes the cold-start `hostname_to_node_id` automatically.
+    pub fn with_node_id(
+        hostname: &str,
+        node_id: u64,
+        base_path: &str,
+        peers: Vec<String>,
+        bind_addr: &str,
+        tls: Option<TlsFiles>,
+    ) -> Result<Arc<Self>> {
         // Initialize tracing once.
         static TRACING_INIT: std::sync::Once = std::sync::Once::new();
         TRACING_INIT.call_once(|| {
@@ -339,8 +361,9 @@ impl ZoneManager {
         });
 
         tracing::info!(
-            "ZoneManager node {} started (bind={}, tls={})",
+            "ZoneManager node {} hostname={} started (bind={}, tls={})",
             node_id,
+            hostname,
             bind_addr,
             use_tls,
         );

--- a/rust/transport-primitives/src/lib.rs
+++ b/rust/transport-primitives/src/lib.rs
@@ -34,5 +34,5 @@ mod pool;
 pub use channel::create_channel;
 pub use config::{ClientConfig, ServerConfig, TlsConfig};
 pub use error::{Result, TransportError};
-pub use peer::{hostname_to_node_id, NodeAddress, PeerAddress};
+pub use peer::{compute_node_id, hostname_to_node_id, NodeAddress, PeerAddress};
 pub use pool::ConnectionPool;

--- a/rust/transport-primitives/src/peer.rs
+++ b/rust/transport-primitives/src/peer.rs
@@ -6,9 +6,44 @@ use crate::error::{Result, TransportError};
 ///
 /// SHA-256 of hostname, first 8 bytes as little-endian u64.
 /// Maps 0 to 1 (raft-rs reserves 0 as "no node").
+///
+/// This is the cold-start ID convention — every node in a freshly
+/// bootstrapped cluster derives identical IDs for each named peer
+/// from their hostnames alone, so initial `ConfState` is consistent
+/// without coordination.  Wipe-rejoin paths use [`compute_node_id`]
+/// with a non-zero incarnation to mint a fresh ID after a data wipe;
+/// see `RaftStorage::set_incarnation` and `ensure_voter_membership`.
 pub fn hostname_to_node_id(hostname: &str) -> u64 {
+    compute_node_id(hostname, 0)
+}
+
+/// Derive a deterministic node ID from a hostname plus an incarnation.
+///
+/// `incarnation == 0` is the cold-start sentinel and returns the same
+/// value as [`hostname_to_node_id`] — every node in a freshly bootstrapped
+/// cluster sees the same IDs without exchanging incarnation values, so
+/// the initial `ConfState` is consistent.
+///
+/// `incarnation > 0` mints a fresh ID space for that hostname:
+/// SHA-256 of `"<hostname>:<incarnation>"` (incarnation as big-endian
+/// u64), first 8 bytes as little-endian u64.  Used after a wipe-rejoin
+/// where the leader's in-memory `Progress[old_id]` is stale and reusing
+/// the prior ID would trigger raft-rs's `to_commit N out of range
+/// [last_index 0]` panic in `handle_heartbeat`.
+///
+/// Same `0 → 1` mapping as [`hostname_to_node_id`] (raft-rs reserves 0
+/// as "no node").
+pub fn compute_node_id(hostname: &str, incarnation: u64) -> u64 {
     use sha2::{Digest, Sha256};
-    let hash = Sha256::digest(hostname.as_bytes());
+    let mut hasher = Sha256::new();
+    hasher.update(hostname.as_bytes());
+    if incarnation != 0 {
+        // Suffix only when non-zero so cold-start path matches the
+        // pre-incarnation `hostname_to_node_id` byte-for-byte.
+        hasher.update(b":");
+        hasher.update(incarnation.to_be_bytes());
+    }
+    let hash = hasher.finalize();
     let mut first_eight = [0u8; 8];
     first_eight.copy_from_slice(&hash[..8]);
     let value = u64::from_le_bytes(first_eight);
@@ -185,6 +220,48 @@ mod tests {
         assert_eq!(hostname_to_node_id("nexus-1"), 14044926161142285152);
         assert_eq!(hostname_to_node_id("nexus-2"), 768242927742468745);
         assert_eq!(hostname_to_node_id("witness"), 10099512703796518074);
+    }
+
+    #[test]
+    fn test_compute_node_id_zero_incarnation_matches_hostname_only() {
+        // Cold-start sentinel: incarnation=0 must equal the prior
+        // hostname-only function byte-for-byte so existing deployments
+        // and the cold-start convergence path keep working unchanged.
+        for h in ["nexus-1", "nexus-2", "witness", "100.64.0.21"] {
+            assert_eq!(compute_node_id(h, 0), hostname_to_node_id(h));
+        }
+    }
+
+    #[test]
+    fn test_compute_node_id_nonzero_incarnation_differs_from_hostname_only() {
+        // After a wipe the same hostname must produce a *different* ID
+        // when paired with a non-zero incarnation — that's the whole
+        // point of the marker.
+        let host = "nexus-1";
+        let cold = hostname_to_node_id(host);
+        let fresh1 = compute_node_id(host, 1);
+        let fresh_max = compute_node_id(host, u64::MAX);
+        assert_ne!(fresh1, cold);
+        assert_ne!(fresh_max, cold);
+        assert_ne!(fresh1, fresh_max);
+    }
+
+    #[test]
+    fn test_compute_node_id_deterministic_per_input() {
+        // Same inputs → same output across calls.
+        for inc in [0u64, 1, 42, u64::MAX] {
+            assert_eq!(compute_node_id("nexus-1", inc), compute_node_id("nexus-1", inc));
+        }
+    }
+
+    #[test]
+    fn test_compute_node_id_avoids_zero() {
+        // raft-rs reserves 0 as "no node"; the helper must never return 0.
+        // Spot-check a range of incarnations to make the property visible.
+        for inc in 0..1000u64 {
+            assert_ne!(compute_node_id("nexus-1", inc), 0);
+            assert_ne!(compute_node_id("witness", inc), 0);
+        }
     }
 
     #[test]

--- a/rust/transport/src/lib.rs
+++ b/rust/transport/src/lib.rs
@@ -52,7 +52,7 @@ pub mod python;
 // `crate::TlsConfig` / `crate::create_channel` keep working
 // once they're inside this crate.
 pub use transport_primitives::{
-    create_channel, hostname_to_node_id, ClientConfig, ConnectionPool, NodeAddress, PeerAddress,
-    ServerConfig, TlsConfig, TransportError,
+    compute_node_id, create_channel, hostname_to_node_id, ClientConfig, ConnectionPool,
+    NodeAddress, PeerAddress, ServerConfig, TlsConfig, TransportError,
 };
 pub type Result<T> = transport_primitives::Result<T>;

--- a/scripts/wal_smoke_singlenode.py
+++ b/scripts/wal_smoke_singlenode.py
@@ -1,0 +1,170 @@
+"""Single-node WAL smoke — Win local validation before cross-machine bring-up.
+
+Runs `create_nexus_fs` in-process with `NEXUS_PEERS` set to just this node
+(quorum=1 single-voter raft) so the WAL stream/pipe path through
+`MetaStore::append_stream_entry` / `get_stream_entry` lights up without
+needing a real cluster.
+
+If this passes, WalStreamCore + WalPipeCore + the raft state-machine
+table for stream entries all work end-to-end on develop tip. Cross-machine
+smoke is then just "spin up two of these with NEXUS_PEERS pointing at each
+other and verify replication".
+
+Run::
+    PYTHONPATH=. ~/.nexus/nexus_env/python.exe scripts/wal_smoke_singlenode.py
+"""
+
+from __future__ import annotations
+
+import os
+import shutil
+import sys
+import tempfile
+import traceback
+from pathlib import Path
+
+WIN_TS_IP = "100.64.0.26"  # Tailscale IP, matches `tailscale status`
+RAFT_PORT = 2126
+
+
+def setup_env(tmp: Path) -> None:
+    """Configure single-voter federation before importing nexus."""
+    os.environ["NEXUS_HOSTNAME"] = WIN_TS_IP
+    os.environ["NEXUS_PEERS"] = f"{WIN_TS_IP}:{RAFT_PORT}"
+    os.environ["NEXUS_BIND_ADDR"] = f"0.0.0.0:{RAFT_PORT}"
+    os.environ["NEXUS_DATA_DIR"] = str(tmp / "zones")
+    os.environ["NEXUS_RAFT_TLS"] = "false"
+    print(f"  NEXUS_HOSTNAME={os.environ['NEXUS_HOSTNAME']}")
+    print(f"  NEXUS_PEERS={os.environ['NEXUS_PEERS']}")
+    print(f"  NEXUS_DATA_DIR={os.environ['NEXUS_DATA_DIR']}")
+
+
+def section(label: str) -> None:
+    print(f"\n=== {label} ===")
+
+
+def expect(label: str, value: object, expected: object) -> bool:
+    ok = value == expected
+    mark = "OK " if ok else "FAIL"
+    print(f"  [{mark}] {label}: got={value!r} want={expected!r}")
+    return ok
+
+
+def smoke_wal_stream(nx) -> bool:
+    """sys_setattr(io_profile='wal') for DT_STREAM should round-trip
+    through raft + return dict on sys_read."""
+    section("WAL DT_STREAM — io_profile='wal' over single-voter raft")
+    from nexus.contracts.metadata import DT_STREAM
+
+    path = "/coord-stream"
+    try:
+        result = nx.sys_setattr(path, entry_type=DT_STREAM, io_profile="wal", capacity=65_536)
+    except Exception as e:
+        print(f"  [FAIL] sys_setattr raised: {type(e).__name__}: {e}")
+        return False
+    print(f"  sys_setattr returned: {result}")
+
+    nx._kernel.stream_write_nowait(path, b"hello")
+    nx._kernel.stream_write_nowait(path, b"world!!")
+
+    # WAL stream uses (seq, data) keying, not byte-offset. seq=0 is the
+    # first entry; next_offset = seq + 1 in the WAL backend.
+    r1 = nx._kernel.stream_read_at(path, 0)
+    if r1 is None:
+        # Async flush race — bg thread hasn't committed yet. Retry briefly.
+        import time
+
+        for _ in range(40):
+            time.sleep(0.05)
+            r1 = nx._kernel.stream_read_at(path, 0)
+            if r1 is not None:
+                break
+    if r1 is None:
+        print("  [FAIL] stream_read_at(0) returned None after 2s wait")
+        return False
+    data1, next1 = r1
+    if not expect("first payload", bytes(data1), b"hello"):
+        return False
+
+    r2 = nx._kernel.stream_read_at(path, next1)
+    if r2 is None:
+        print(f"  [FAIL] stream_read_at({next1}) returned None")
+        return False
+    data2, _ = r2
+    return expect("second payload", bytes(data2), b"world!!")
+
+
+def smoke_wal_pipe(nx) -> bool:
+    """sys_setattr(io_profile='wal') for DT_PIPE — push/pop FIFO."""
+    section("WAL DT_PIPE — io_profile='wal' over single-voter raft")
+    from nexus.contracts.metadata import DT_PIPE
+
+    path = "/coord-pipe"
+    try:
+        result = nx.sys_setattr(path, entry_type=DT_PIPE, io_profile="wal", capacity=65_536)
+    except Exception as e:
+        print(f"  [FAIL] sys_setattr raised: {type(e).__name__}: {e}")
+        return False
+    print(f"  sys_setattr returned: {result}")
+
+    for msg in (b"msg-1", b"msg-2", b"msg-3"):
+        nx._kernel.pipe_write_nowait(path, msg)
+
+    # Brief wait for bg flush (single-voter raft commits sync, but the
+    # WalStreamCore flush thread is still async).
+    import time
+
+    time.sleep(0.2)
+
+    pop1 = nx._kernel.pipe_read_nowait(path)
+    if not expect("FIFO pop 1", bytes(pop1) if pop1 else None, b"msg-1"):
+        return False
+    pop2 = nx._kernel.pipe_read_nowait(path)
+    if not expect("FIFO pop 2", bytes(pop2) if pop2 else None, b"msg-2"):
+        return False
+    pop3 = nx._kernel.pipe_read_nowait(path)
+    if not expect("FIFO pop 3", bytes(pop3) if pop3 else None, b"msg-3"):
+        return False
+
+    pop_empty = nx._kernel.pipe_read_nowait(path)
+    return expect("empty pop returns None", pop_empty, None)
+
+
+def main() -> int:
+    tmp = Path(tempfile.mkdtemp(prefix="wal-smoke-"))
+    print(f"smoke tmpdir: {tmp}")
+    setup_env(tmp)
+
+    try:
+        from nexus.backends.storage.cas_local import CASLocalBackend
+        from nexus.core.config import ParseConfig, PermissionConfig
+        from nexus.factory import create_nexus_fs
+        from nexus.storage.record_store import SQLAlchemyRecordStore
+        from tests.helpers.dict_metastore import DictMetastore
+
+        nx = create_nexus_fs(
+            backend=CASLocalBackend(tmp / "cas"),
+            metadata_store=DictMetastore(),
+            record_store=SQLAlchemyRecordStore(db_path=tmp / "meta.db"),
+            parsing=ParseConfig(auto_parse=False),
+            permissions=PermissionConfig(enforce=False),
+        )
+
+        # Verify federation actually initialized (zone_manager_arc must
+        # return Some). If init_from_env didn't fire, the wal branch
+        # will raise "requires federation" — same skip path as before.
+        results = [smoke_wal_stream(nx), smoke_wal_pipe(nx)]
+        ok = all(results)
+        print()
+        print("=" * 60)
+        print("RESULT:", "PASS" if ok else "FAIL")
+        return 0 if ok else 1
+    except Exception:
+        traceback.print_exc()
+        return 2
+    finally:
+        shutil.rmtree(tmp, ignore_errors=True)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/wal_smoke_xmachine.py
+++ b/scripts/wal_smoke_xmachine.py
@@ -1,0 +1,274 @@
+"""Cross-machine WAL smoke — Win <-> Mac federated raft.
+
+Same env-var federation init as `wal_smoke_singlenode.py`, but
+`NEXUS_PEERS` lists both Win + Mac Tailscale IPs. The script both
+participates in the raft cluster (binds local raft :2126) AND drives
+the test against the local kernel — two processes (one per side), one
+shared raft cluster.
+
+Test sequence (each side, in parallel):
+  1. setup_env: NEXUS_HOSTNAME = own Tailscale IP, NEXUS_PEERS = both.
+  2. create_nexus_fs(): kernel boots, install_federation_wiring fires,
+     init_from_env joins the 2-voter root raft group. Blocks until
+     leader elected (peer must be up too).
+  3. sys_setattr(io_profile="wal") on /coord/<own-side>-{stream,pipe} —
+     replicates the metadata + WAL setup commands across the cluster.
+  4. push 3 messages to own outbound stream + pipe.
+  5. poll for peer's outbound paths (sys_stat) — replicated metadata
+     should appear within seconds.
+  6. read 3 messages from peer's stream + pop 3 from peer's pipe.
+  7. verify matches `<peer>-msg-{1,2,3}` per direction.
+
+Both sides are symmetric. Run on Win + Mac near-simultaneously
+(within ~30s of each other so the 2-voter cluster reaches quorum
+before either side gives up).
+
+Run::
+    # On Win:
+    PYTHONPATH=. ~/.nexus/nexus_env/python.exe scripts/wal_smoke_xmachine.py --side win
+    # On Mac:
+    PYTHONPATH=. ~/.nexus/nexus_env/python.exe scripts/wal_smoke_xmachine.py --side mac
+
+Status: PASS = both sides see all 3 of the other side's messages on
+both stream + pipe paths. FAIL = any verification mismatch or timeout.
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+import tempfile
+import time
+import traceback
+from pathlib import Path
+
+WIN_TS_IP = "100.64.0.26"
+MAC_TS_IP = "100.64.0.21"
+RAFT_PORT = 2126
+
+PEERS_CSV = f"{WIN_TS_IP}:{RAFT_PORT},{MAC_TS_IP}:{RAFT_PORT}"
+
+# Per-side output paths — each side writes its own, reads peer's.
+PATHS = {
+    "win": {
+        "out_stream": "/coord/win-stream",
+        "out_pipe": "/coord/win-pipe",
+        "in_stream": "/coord/mac-stream",
+        "in_pipe": "/coord/mac-pipe",
+        "ts_ip": WIN_TS_IP,
+    },
+    "mac": {
+        "out_stream": "/coord/mac-stream",
+        "out_pipe": "/coord/mac-pipe",
+        "in_stream": "/coord/win-stream",
+        "in_pipe": "/coord/win-pipe",
+        "ts_ip": MAC_TS_IP,
+    },
+}
+
+
+def setup_env(side: str, tmp: Path) -> None:
+    cfg = PATHS[side]
+    os.environ["NEXUS_HOSTNAME"] = cfg["ts_ip"]
+    os.environ["NEXUS_PEERS"] = PEERS_CSV
+    os.environ["NEXUS_BIND_ADDR"] = f"0.0.0.0:{RAFT_PORT}"
+    os.environ["NEXUS_DATA_DIR"] = str(tmp / "zones")
+    os.environ["NEXUS_RAFT_TLS"] = "false"
+    print(f"  side: {side}")
+    print(f"  NEXUS_HOSTNAME={os.environ['NEXUS_HOSTNAME']}")
+    print(f"  NEXUS_PEERS={os.environ['NEXUS_PEERS']}")
+    print(f"  NEXUS_DATA_DIR={os.environ['NEXUS_DATA_DIR']}")
+
+
+def section(label: str) -> None:
+    print(f"\n=== {label} ===")
+
+
+def expect(label: str, value: object, expected: object) -> bool:
+    ok = value == expected
+    mark = "OK " if ok else "FAIL"
+    print(f"  [{mark}] {label}: got={value!r} want={expected!r}")
+    return ok
+
+
+def setattr_outbound(nx, side: str) -> bool:
+    """Create our own outbound stream + pipe with io_profile=wal."""
+    section(f"[{side}] setup outbound — sys_setattr io_profile='wal'")
+    from nexus.contracts.metadata import DT_PIPE, DT_STREAM
+
+    cfg = PATHS[side]
+    try:
+        nx.sys_setattr(
+            cfg["out_stream"],
+            entry_type=DT_STREAM,
+            io_profile="wal",
+            capacity=65_536,
+        )
+        nx.sys_setattr(
+            cfg["out_pipe"],
+            entry_type=DT_PIPE,
+            io_profile="wal",
+            capacity=65_536,
+        )
+    except Exception as e:
+        print(f"  [FAIL] sys_setattr raised: {type(e).__name__}: {e}")
+        return False
+    print(f"  outbound stream: {cfg['out_stream']}")
+    print(f"  outbound pipe:   {cfg['out_pipe']}")
+    return True
+
+
+def push_outbound(nx, side: str) -> None:
+    """Push 3 messages to our outbound stream + pipe."""
+    section(f"[{side}] push 3 messages outbound")
+    cfg = PATHS[side]
+    for i in (1, 2, 3):
+        msg = f"{side}-msg-{i}".encode()
+        nx._kernel.stream_write_nowait(cfg["out_stream"], msg)
+        nx._kernel.pipe_write_nowait(cfg["out_pipe"], msg)
+        print(f"  pushed {msg!r} to {cfg['out_stream']} + {cfg['out_pipe']}")
+
+
+def wait_peer_inodes(nx, side: str, timeout_s: float = 60.0) -> bool:
+    """Poll for the peer's setattr to replicate."""
+    section(f"[{side}] wait for peer's inodes (replication via raft)")
+    cfg = PATHS[side]
+    deadline = time.time() + timeout_s
+    while time.time() < deadline:
+        try:
+            in_stream_ok = nx._kernel.has_stream(cfg["in_stream"])
+            in_pipe_ok = nx._kernel.has_pipe(cfg["in_pipe"])
+        except Exception:
+            in_stream_ok = in_pipe_ok = False
+        if in_stream_ok and in_pipe_ok:
+            print(f"  peer paths visible: {cfg['in_stream']}, {cfg['in_pipe']}")
+            return True
+        time.sleep(0.5)
+    print(f"  [FAIL] peer paths still missing after {timeout_s}s")
+    return False
+
+
+def read_inbound(nx, side: str, peer: str, timeout_s: float = 30.0) -> bool:
+    """Read 3 messages from peer's stream + pop 3 from peer's pipe."""
+    section(f"[{side}] read 3 inbound from peer ({peer})")
+    cfg = PATHS[side]
+    expected = [f"{peer}-msg-{i}".encode() for i in (1, 2, 3)]
+    deadline = time.time() + timeout_s
+
+    # WAL stream: read via offset = seq (0, 1, 2). dict shape returned.
+    cursor = 0
+    got_stream: list[bytes] = []
+    while len(got_stream) < 3 and time.time() < deadline:
+        try:
+            r = nx.sys_read(cfg["in_stream"], offset=cursor)
+        except Exception:
+            time.sleep(0.2)
+            continue
+        if isinstance(r, dict) and r.get("data"):
+            got_stream.append(r["data"])
+            cursor = r["next_offset"]
+        elif isinstance(r, dict):
+            time.sleep(0.2)
+        else:
+            print(f"  [FAIL] sys_read returned non-dict for DT_STREAM: {r!r}")
+            return False
+    if got_stream != expected:
+        print(f"  [FAIL] stream mismatch: got={got_stream!r} want={expected!r}")
+        return False
+    print(f"  stream OK: {got_stream!r}")
+
+    # WAL pipe: pop 3 via pipe_read_nowait (with retry for bg flush).
+    got_pipe: list[bytes] = []
+    while len(got_pipe) < 3 and time.time() < deadline:
+        popped = nx._kernel.pipe_read_nowait(cfg["in_pipe"])
+        if popped is not None:
+            got_pipe.append(bytes(popped))
+        else:
+            time.sleep(0.2)
+    if got_pipe != expected:
+        print(f"  [FAIL] pipe mismatch: got={got_pipe!r} want={expected!r}")
+        return False
+    print(f"  pipe OK: {got_pipe!r}")
+    return True
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--side", choices=("win", "mac"), required=True)
+    parser.add_argument(
+        "--cluster-form-timeout",
+        type=float,
+        default=120.0,
+        help="seconds to wait for raft cluster to form (peer must come up)",
+    )
+    parser.add_argument(
+        "--inode-replicate-timeout",
+        type=float,
+        default=60.0,
+        help="seconds to wait for peer's setattr to replicate",
+    )
+    parser.add_argument(
+        "--read-inbound-timeout",
+        type=float,
+        default=60.0,
+        help="seconds to wait for peer's pushed messages to replicate",
+    )
+    args = parser.parse_args()
+
+    side = args.side
+    peer = "mac" if side == "win" else "win"
+
+    tmp = Path(tempfile.mkdtemp(prefix=f"wal-xmachine-{side}-"))
+    print(f"smoke tmpdir: {tmp}")
+    setup_env(side, tmp)
+
+    try:
+        from nexus.backends.storage.cas_local import CASLocalBackend
+        from nexus.core.config import ParseConfig, PermissionConfig
+        from nexus.factory import create_nexus_fs
+        from nexus.storage.record_store import SQLAlchemyRecordStore
+        from tests.helpers.dict_metastore import DictMetastore
+
+        print(
+            "\n[bringup] create_nexus_fs — federation init from env, "
+            "this blocks until raft 2-voter quorum is reached..."
+        )
+        nx = create_nexus_fs(
+            backend=CASLocalBackend(tmp / "cas"),
+            metadata_store=DictMetastore(),
+            record_store=SQLAlchemyRecordStore(db_path=tmp / "meta.db"),
+            parsing=ParseConfig(auto_parse=False),
+            permissions=PermissionConfig(enforce=False),
+        )
+        print("[bringup] kernel up, federation initialized")
+
+        # Stage 1: each side advertises its own outbound paths.
+        if not setattr_outbound(nx, side):
+            return 1
+        push_outbound(nx, side)
+
+        # Stage 2: wait for peer to do the same.
+        if not wait_peer_inodes(nx, side, timeout_s=args.inode_replicate_timeout):
+            return 1
+
+        # Stage 3: read peer's messages + verify.
+        if not read_inbound(nx, side, peer, timeout_s=args.read_inbound_timeout):
+            return 1
+
+        print()
+        print("=" * 60)
+        print(f"RESULT [{side}]: PASS — round-trip verified both directions")
+        return 0
+    except Exception:
+        traceback.print_exc()
+        return 2
+    finally:
+        # Keep tmp dir for post-mortem inspection on failure; clean up
+        # only on PASS via explicit return-code check.
+        pass
+
+
+if __name__ == "__main__":
+    rc = main()
+    sys.exit(rc)

--- a/tests/e2e/docker/test_federation_e2e.py
+++ b/tests/e2e/docker/test_federation_e2e.py
@@ -3444,6 +3444,3 @@ class TestFreshJoinToRunningCluster:
                 msg=f"{path} not visible on freshly-joined node-1",
                 timeout=30,
             )
-
-
-

--- a/tests/e2e/docker/test_federation_e2e.py
+++ b/tests/e2e/docker/test_federation_e2e.py
@@ -1502,176 +1502,6 @@ class TestLeaderFailover:
 
 
 # ---------------------------------------------------------------------------
-# Regression: fresh-join into running cluster (snapshot install path)
-# ---------------------------------------------------------------------------
-
-
-class TestFreshJoinToRunningCluster:
-    """Regression test for the fresh-join-with-wiped-storage panic.
-
-    Pre-fix symptom: ``thread 'nexus-zone-mgr' panicked at raft_log.rs:292:
-    to_commit N is out of range [last_index 0]`` when a node restarts with
-    empty data dir while keeping its node ID, and a long-running peer
-    (whose in-memory ``Progress[node_id]`` still records ``matched = K > 0``)
-    is leader.  Hit during PR #3933 cross-machine smoke after PR #3932
-    Phase H landed.
-
-    ## Root cause (pre-fix)
-
-    Node ID was derived from ``hostname`` only (``hostname_to_node_id``).
-    After a data wipe on the same host the node rejoined with the SAME ID
-    but ``last_index == 0``.  Meanwhile the leader's in-memory ``Progress``
-    for that ID still had ``matched == K`` from before the wipe (Progress
-    is in-memory only and only resets on leader restart).
-
-    raft-rs's ``Raft::send_heartbeat`` clamps heartbeat ``commit`` to
-    ``min(progress.matched, raft_log.committed)`` — with stale
-    ``pr.matched = K`` it sent ``MsgHeartbeat{commit=K}`` to a follower
-    whose ``last_index == 0``.  raft-rs's ``handle_heartbeat`` calls
-    ``commit_to(m.commit)`` UNCONDITIONALLY (raft-0.7.0 raft.rs:2516), so
-    ``commit_to(K)`` panicked at raft_log.rs:292.  ``Progress::maybe_decr_to``
-    does not reset ``matched`` on AppendResponse rejection, so heartbeats
-    kept panicking the follower indefinitely.
-
-    Reusing a node ID with wiped persistent state violates raft's
-    identity-equals-log invariant.
-
-    ## Fix shape (this PR)
-
-    * ``RaftStorage`` persists a node-incarnation marker — fresh storage
-      mints a new incarnation; existing storage keeps the persisted one.
-    * ``node_id = compute_node_id(hostname, incarnation)`` — wipe-and-restart
-      mints a brand-new ID.
-    * ``ensure_voter_membership`` centralizes the bootstrap-vs-rotate
-      decision: if storage was just created AND a leader is reachable,
-      ask the leader to swap our old voter ID (looked up by hostname in
-      its peer map) for the new one via ConfChange Remove+Add through
-      the ``replace_voter_by_hostname`` RPC.  Cold start (no leader
-      reachable) falls through to standard bootstrap with the
-      default-incarnation ID so all nodes converge on the same voter set.
-
-    ## What this test does
-
-      1. Stop node-1 (n2 + witness keep majority, keep committing).
-      2. Drive writes via node-2 → raft commits accumulate across cluster.
-      3. WIPE node-1 data volume (raft.redb deleted — fresh state).
-      4. Start node-1.
-      5. Assert node-1 reaches healthy without panic AND catches up to the
-         entries written while it was down.
-    """
-
-    @pytest.mark.order(after="TestLeaderFailover::test_failover_and_recovery")
-    def test_fresh_join_via_snapshot(self, cluster, api_key, federation_zones):
-        try:
-            import docker as docker_sdk
-
-            docker_client = docker_sdk.from_env(timeout=180)
-            docker_client.ping()
-        except Exception as exc:
-            pytest.skip(f"Docker SDK not available: {exc}")
-
-        n1_container = docker_client.containers.get("nexus-dyn-node-1")
-        grpc1 = cluster["grpc1"]
-        grpc2 = cluster["grpc2"]
-        uid = _uid()
-
-        # 1. Stop node-1; n2 + witness retain quorum (2/3).
-        n1_container.stop(timeout=10)
-        _wait_healthy([cluster["node2"]], timeout=30)
-        _wait_leader_elected(grpc2, "corp-eng", api_key, timeout=20)
-
-        # 2. Accumulate raft commits via node-2 across multiple zones.
-        accumulated: list[tuple[str, str, str]] = []
-        for i in range(20):
-            for zone, prefix in [
-                ("corp", "/corp/"),
-                ("corp-eng", "/corp/eng/"),
-                ("family", "/family/"),
-            ]:
-                path = f"{prefix}fresh-join-{uid}-{zone}-{i}.txt"
-                content = f"data-{zone}-{i}"
-                w = _grpc_call(
-                    grpc2,
-                    "write",
-                    {"path": path, "content": content},
-                    api_key=api_key,
-                    timeout=20,
-                )
-                assert "error" not in w, f"write {path} failed: {w}"
-                accumulated.append((path, prefix, content))
-
-        # 3. WIPE node-1 data volume (alpine sidecar — same volume mount).
-        wipe = docker_client.containers.run(
-            image="alpine:latest",
-            command="sh -c 'rm -rf /app/data/* /app/data/.* 2>/dev/null; "
-            "ls -A /app/data 2>/dev/null | wc -l'",
-            volumes={"nexus-dyn-node1-data": {"bind": "/app/data", "mode": "rw"}},
-            remove=True,
-            stdout=True,
-            stderr=True,
-        )
-        wipe_count = wipe.decode(errors="replace").strip()
-        assert wipe_count == "0", (
-            f"node-1 data volume not fully wiped (entries remaining: {wipe_count})"
-        )
-
-        # 4. Start node-1 fresh.
-        n1_container.start()
-        n1_container.reload()
-
-        # 5. Assert healthy — fail with REGRESSION marker if panic markers
-        #    appear in logs (covers both exited-due-to-panic and the
-        #    soft-fail "running but unhealthy" path).
-        panic_check_logs = ""
-        try:
-            _wait_healthy([cluster["node1"]], timeout=120)
-        except BaseException as exc:
-            panic_check_logs = n1_container.logs(tail=500, stderr=True).decode(errors="replace")
-            if (
-                "to_commit" in panic_check_logs and "out of range" in panic_check_logs
-            ) or "panicked at" in panic_check_logs.lower():
-                pytest.fail(
-                    "REGRESSION: node-1 fresh-join panicked. raft InstallSnapshot "
-                    "path is broken — commits delivered to follower before snapshot "
-                    "installation, violating raft contract.\n"
-                    f"--- node-1 logs (tail 500) ---\n{panic_check_logs}"
-                )
-            pytest.fail(
-                f"node-1 not healthy within 120s after fresh-join: {exc}\n"
-                f"--- node-1 logs (tail 500) ---\n{panic_check_logs}"
-            )
-
-        # Sanity: even when "healthy", scan logs for panic markers in case
-        # a thread panicked but the process kept going (raft-zone-mgr is a
-        # background thread, healthcheck is the FastAPI uvicorn).
-        recent = n1_container.logs(tail=300, stderr=True).decode(errors="replace")
-        if ("to_commit" in recent and "out of range" in recent) or "panicked at" in recent.lower():
-            pytest.fail(
-                "REGRESSION: node-1 reports healthy but raft thread panicked.\n"
-                f"--- node-1 logs (tail 300) ---\n{recent}"
-            )
-
-        # 6. Catch-up via raft snapshot + log replay.
-        _wait_nodes_caught_up(
-            [grpc1, grpc2],
-            [ROOT_ZONE_ID, "corp", "corp-eng", "family"],
-            api_key,
-            timeout=120,
-        )
-
-        # Spot-check a few replicated entries are visible on node-1.
-        for path, parent, _content in accumulated[:6]:
-            _wait_replicated(
-                grpc1,
-                parent,
-                path,
-                api_key,
-                msg=f"{path} not visible on freshly-joined node-1",
-                timeout=30,
-            )
-
-
-# ---------------------------------------------------------------------------
 # Step 26: Cross-zone cache coherence (Issue #3396)
 # ---------------------------------------------------------------------------
 
@@ -3427,3 +3257,193 @@ class TestCrossNodeContentRead:
         pytest.fail(
             f"node-2 did not converge to latest version within 15s: got {last!r}, want {latest!r}"
         )
+
+
+# ---------------------------------------------------------------------------
+# Regression: fresh-join into running cluster (snapshot install path)
+# ---------------------------------------------------------------------------
+
+
+class TestFreshJoinToRunningCluster:
+    """Regression test for the fresh-join-with-wiped-storage panic.
+
+    Pre-fix symptom: ``thread 'nexus-zone-mgr' panicked at raft_log.rs:292:
+    to_commit N is out of range [last_index 0]`` when a node restarts with
+    empty data dir while keeping its node ID, and a long-running peer
+    (whose in-memory ``Progress[node_id]`` still records ``matched = K > 0``)
+    is leader.  Hit during PR #3933 cross-machine smoke after PR #3932
+    Phase H landed.
+
+    ## Root cause (pre-fix)
+
+    Node ID was derived from ``hostname`` only (``hostname_to_node_id``).
+    After a data wipe on the same host the node rejoined with the SAME ID
+    but ``last_index == 0``.  Meanwhile the leader's in-memory ``Progress``
+    for that ID still had ``matched == K`` from before the wipe (Progress
+    is in-memory only and only resets on leader restart).
+
+    raft-rs's ``Raft::send_heartbeat`` clamps heartbeat ``commit`` to
+    ``min(progress.matched, raft_log.committed)`` — with stale
+    ``pr.matched = K`` it sent ``MsgHeartbeat{commit=K}`` to a follower
+    whose ``last_index == 0``.  raft-rs's ``handle_heartbeat`` calls
+    ``commit_to(m.commit)`` UNCONDITIONALLY (raft-0.7.0 raft.rs:2516), so
+    ``commit_to(K)`` panicked at raft_log.rs:292.  ``Progress::maybe_decr_to``
+    does not reset ``matched`` on AppendResponse rejection, so heartbeats
+    kept panicking the follower indefinitely.
+
+    Reusing a node ID with wiped persistent state violates raft's
+    identity-equals-log invariant.
+
+    ## Fix shape (this PR)
+
+    * ``RaftStorage`` persists a node-incarnation marker — fresh storage
+      mints a new incarnation; existing storage keeps the persisted one.
+    * ``node_id = compute_node_id(hostname, incarnation)`` — wipe-and-restart
+      mints a brand-new ID.
+    * ``ensure_voter_membership`` centralizes the bootstrap-vs-rotate
+      decision: if storage was just created AND a leader is reachable,
+      ask the leader to swap our old voter ID (looked up by hostname in
+      its peer map) for the new one via ConfChange Remove+Add through
+      the ``replace_voter_by_hostname`` RPC.  Cold start (no leader
+      reachable) falls through to standard bootstrap with the
+      default-incarnation ID so all nodes converge on the same voter set.
+
+    ## What this test does
+
+      1. Stop node-1 (n2 + witness keep majority, keep committing).
+      2. Drive writes via node-2 → raft commits accumulate across cluster.
+      3. WIPE node-1 data volume (raft.redb deleted — fresh state).
+      4. Start node-1.
+      5. Assert node-1 reaches healthy without panic AND catches up to the
+         entries written while it was down.
+    """
+
+    # Order-LAST: this test wipes node-1's data dir and rotates its
+    # raft node ID via ReplaceVoterByHostname.  Federation zones
+    # (corp, corp-eng, …) created at runtime by `federation_zones`
+    # are NOT auto-rejoined on the wiped node — that requires a
+    # follow-up "zone discovery on rejoin" feature out of this PR's
+    # scope.  Subsequent tests that assume node-1 hosts those zones
+    # would stall on raft catch-up against the rotated ID, so this
+    # class is positioned LAST in the file (default pytest collection
+    # order is file order).  The explicit `@pytest.mark.order("last")`
+    # is documentation — pytest-ordering may not be installed on every
+    # runner (existing markers in this file already produce
+    # unknown-mark warnings), but file-ordering is sufficient.
+    @pytest.mark.order("last")
+    def test_fresh_join_via_snapshot(self, cluster, api_key, federation_zones):
+        try:
+            import docker as docker_sdk
+
+            docker_client = docker_sdk.from_env(timeout=180)
+            docker_client.ping()
+        except Exception as exc:
+            pytest.skip(f"Docker SDK not available: {exc}")
+
+        n1_container = docker_client.containers.get("nexus-dyn-node-1")
+        grpc1 = cluster["grpc1"]
+        grpc2 = cluster["grpc2"]
+        uid = _uid()
+
+        # 1. Stop node-1; n2 + witness retain quorum (2/3).
+        n1_container.stop(timeout=10)
+        _wait_healthy([cluster["node2"]], timeout=30)
+        _wait_leader_elected(grpc2, "corp-eng", api_key, timeout=20)
+
+        # 2. Accumulate raft commits via node-2 in the ROOT zone.
+        #
+        # Scope: this test exercises the wipe-rejoin contract for the
+        # zone that node-1 will rebootstrap at boot — root.  Federation
+        # zones created at runtime (corp, corp-eng, …) are a separate
+        # auto-discovery problem: the wiped node restarts only with
+        # NEXUS_FEDERATION_ZONES (here: empty), so corp/etc. won't be
+        # rejoined on boot regardless of the rotation fix.  Tracking
+        # those into the rotated node requires a follow-up "zone
+        # discovery on rejoin" feature (out of this PR's scope).
+        accumulated: list[tuple[str, str, str]] = []
+        for i in range(20):
+            path = f"/fresh-join-root-{uid}-{i}.txt"
+            content = f"data-root-{i}"
+            w = _grpc_call(
+                grpc2,
+                "write",
+                {"path": path, "content": content},
+                api_key=api_key,
+                timeout=20,
+            )
+            assert "error" not in w, f"write {path} failed: {w}"
+            accumulated.append((path, "/", content))
+
+        # 3. WIPE node-1 data volume (alpine sidecar — same volume mount).
+        wipe = docker_client.containers.run(
+            image="alpine:latest",
+            command="sh -c 'rm -rf /app/data/* /app/data/.* 2>/dev/null; "
+            "ls -A /app/data 2>/dev/null | wc -l'",
+            volumes={"nexus-dyn-node1-data": {"bind": "/app/data", "mode": "rw"}},
+            remove=True,
+            stdout=True,
+            stderr=True,
+        )
+        wipe_count = wipe.decode(errors="replace").strip()
+        assert wipe_count == "0", (
+            f"node-1 data volume not fully wiped (entries remaining: {wipe_count})"
+        )
+
+        # 4. Start node-1 fresh.
+        n1_container.start()
+        n1_container.reload()
+
+        # 5. Assert healthy — fail with REGRESSION marker if panic markers
+        #    appear in logs (covers both exited-due-to-panic and the
+        #    soft-fail "running but unhealthy" path).
+        panic_check_logs = ""
+        try:
+            _wait_healthy([cluster["node1"]], timeout=120)
+        except BaseException as exc:
+            panic_check_logs = n1_container.logs(tail=500, stderr=True).decode(errors="replace")
+            if (
+                "to_commit" in panic_check_logs and "out of range" in panic_check_logs
+            ) or "panicked at" in panic_check_logs.lower():
+                pytest.fail(
+                    "REGRESSION: node-1 fresh-join panicked. raft InstallSnapshot "
+                    "path is broken — commits delivered to follower before snapshot "
+                    "installation, violating raft contract.\n"
+                    f"--- node-1 logs (tail 500) ---\n{panic_check_logs}"
+                )
+            pytest.fail(
+                f"node-1 not healthy within 120s after fresh-join: {exc}\n"
+                f"--- node-1 logs (tail 500) ---\n{panic_check_logs}"
+            )
+
+        # Sanity: even when "healthy", scan logs for panic markers in case
+        # a thread panicked but the process kept going (raft-zone-mgr is a
+        # background thread, healthcheck is the FastAPI uvicorn).
+        recent = n1_container.logs(tail=300, stderr=True).decode(errors="replace")
+        if ("to_commit" in recent and "out of range" in recent) or "panicked at" in recent.lower():
+            pytest.fail(
+                "REGRESSION: node-1 reports healthy but raft thread panicked.\n"
+                f"--- node-1 logs (tail 300) ---\n{recent}"
+            )
+
+        # 6. Catch-up via raft snapshot + log replay (root zone only —
+        #    see step 2 docstring).
+        _wait_nodes_caught_up(
+            [grpc1, grpc2],
+            [ROOT_ZONE_ID],
+            api_key,
+            timeout=120,
+        )
+
+        # Spot-check a few replicated entries are visible on node-1.
+        for path, parent, _content in accumulated[:6]:
+            _wait_replicated(
+                grpc1,
+                parent,
+                path,
+                api_key,
+                msg=f"{path} not visible on freshly-joined node-1",
+                timeout=30,
+            )
+
+
+

--- a/tests/e2e/docker/test_federation_e2e.py
+++ b/tests/e2e/docker/test_federation_e2e.py
@@ -1502,6 +1502,176 @@ class TestLeaderFailover:
 
 
 # ---------------------------------------------------------------------------
+# Regression: fresh-join into running cluster (snapshot install path)
+# ---------------------------------------------------------------------------
+
+
+class TestFreshJoinToRunningCluster:
+    """Regression test for the fresh-join-with-wiped-storage panic.
+
+    Pre-fix symptom: ``thread 'nexus-zone-mgr' panicked at raft_log.rs:292:
+    to_commit N is out of range [last_index 0]`` when a node restarts with
+    empty data dir while keeping its node ID, and a long-running peer
+    (whose in-memory ``Progress[node_id]`` still records ``matched = K > 0``)
+    is leader.  Hit during PR #3933 cross-machine smoke after PR #3932
+    Phase H landed.
+
+    ## Root cause (pre-fix)
+
+    Node ID was derived from ``hostname`` only (``hostname_to_node_id``).
+    After a data wipe on the same host the node rejoined with the SAME ID
+    but ``last_index == 0``.  Meanwhile the leader's in-memory ``Progress``
+    for that ID still had ``matched == K`` from before the wipe (Progress
+    is in-memory only and only resets on leader restart).
+
+    raft-rs's ``Raft::send_heartbeat`` clamps heartbeat ``commit`` to
+    ``min(progress.matched, raft_log.committed)`` — with stale
+    ``pr.matched = K`` it sent ``MsgHeartbeat{commit=K}`` to a follower
+    whose ``last_index == 0``.  raft-rs's ``handle_heartbeat`` calls
+    ``commit_to(m.commit)`` UNCONDITIONALLY (raft-0.7.0 raft.rs:2516), so
+    ``commit_to(K)`` panicked at raft_log.rs:292.  ``Progress::maybe_decr_to``
+    does not reset ``matched`` on AppendResponse rejection, so heartbeats
+    kept panicking the follower indefinitely.
+
+    Reusing a node ID with wiped persistent state violates raft's
+    identity-equals-log invariant.
+
+    ## Fix shape (this PR)
+
+    * ``RaftStorage`` persists a node-incarnation marker — fresh storage
+      mints a new incarnation; existing storage keeps the persisted one.
+    * ``node_id = compute_node_id(hostname, incarnation)`` — wipe-and-restart
+      mints a brand-new ID.
+    * ``ensure_voter_membership`` centralizes the bootstrap-vs-rotate
+      decision: if storage was just created AND a leader is reachable,
+      ask the leader to swap our old voter ID (looked up by hostname in
+      its peer map) for the new one via ConfChange Remove+Add through
+      the ``replace_voter_by_hostname`` RPC.  Cold start (no leader
+      reachable) falls through to standard bootstrap with the
+      default-incarnation ID so all nodes converge on the same voter set.
+
+    ## What this test does
+
+      1. Stop node-1 (n2 + witness keep majority, keep committing).
+      2. Drive writes via node-2 → raft commits accumulate across cluster.
+      3. WIPE node-1 data volume (raft.redb deleted — fresh state).
+      4. Start node-1.
+      5. Assert node-1 reaches healthy without panic AND catches up to the
+         entries written while it was down.
+    """
+
+    @pytest.mark.order(after="TestLeaderFailover::test_failover_and_recovery")
+    def test_fresh_join_via_snapshot(self, cluster, api_key, federation_zones):
+        try:
+            import docker as docker_sdk
+
+            docker_client = docker_sdk.from_env(timeout=180)
+            docker_client.ping()
+        except Exception as exc:
+            pytest.skip(f"Docker SDK not available: {exc}")
+
+        n1_container = docker_client.containers.get("nexus-dyn-node-1")
+        grpc1 = cluster["grpc1"]
+        grpc2 = cluster["grpc2"]
+        uid = _uid()
+
+        # 1. Stop node-1; n2 + witness retain quorum (2/3).
+        n1_container.stop(timeout=10)
+        _wait_healthy([cluster["node2"]], timeout=30)
+        _wait_leader_elected(grpc2, "corp-eng", api_key, timeout=20)
+
+        # 2. Accumulate raft commits via node-2 across multiple zones.
+        accumulated: list[tuple[str, str, str]] = []
+        for i in range(20):
+            for zone, prefix in [
+                ("corp", "/corp/"),
+                ("corp-eng", "/corp/eng/"),
+                ("family", "/family/"),
+            ]:
+                path = f"{prefix}fresh-join-{uid}-{zone}-{i}.txt"
+                content = f"data-{zone}-{i}"
+                w = _grpc_call(
+                    grpc2,
+                    "write",
+                    {"path": path, "content": content},
+                    api_key=api_key,
+                    timeout=20,
+                )
+                assert "error" not in w, f"write {path} failed: {w}"
+                accumulated.append((path, prefix, content))
+
+        # 3. WIPE node-1 data volume (alpine sidecar — same volume mount).
+        wipe = docker_client.containers.run(
+            image="alpine:latest",
+            command="sh -c 'rm -rf /app/data/* /app/data/.* 2>/dev/null; "
+            "ls -A /app/data 2>/dev/null | wc -l'",
+            volumes={"nexus-dyn-node1-data": {"bind": "/app/data", "mode": "rw"}},
+            remove=True,
+            stdout=True,
+            stderr=True,
+        )
+        wipe_count = wipe.decode(errors="replace").strip()
+        assert wipe_count == "0", (
+            f"node-1 data volume not fully wiped (entries remaining: {wipe_count})"
+        )
+
+        # 4. Start node-1 fresh.
+        n1_container.start()
+        n1_container.reload()
+
+        # 5. Assert healthy — fail with REGRESSION marker if panic markers
+        #    appear in logs (covers both exited-due-to-panic and the
+        #    soft-fail "running but unhealthy" path).
+        panic_check_logs = ""
+        try:
+            _wait_healthy([cluster["node1"]], timeout=120)
+        except BaseException as exc:
+            panic_check_logs = n1_container.logs(tail=500, stderr=True).decode(errors="replace")
+            if (
+                "to_commit" in panic_check_logs and "out of range" in panic_check_logs
+            ) or "panicked at" in panic_check_logs.lower():
+                pytest.fail(
+                    "REGRESSION: node-1 fresh-join panicked. raft InstallSnapshot "
+                    "path is broken — commits delivered to follower before snapshot "
+                    "installation, violating raft contract.\n"
+                    f"--- node-1 logs (tail 500) ---\n{panic_check_logs}"
+                )
+            pytest.fail(
+                f"node-1 not healthy within 120s after fresh-join: {exc}\n"
+                f"--- node-1 logs (tail 500) ---\n{panic_check_logs}"
+            )
+
+        # Sanity: even when "healthy", scan logs for panic markers in case
+        # a thread panicked but the process kept going (raft-zone-mgr is a
+        # background thread, healthcheck is the FastAPI uvicorn).
+        recent = n1_container.logs(tail=300, stderr=True).decode(errors="replace")
+        if ("to_commit" in recent and "out of range" in recent) or "panicked at" in recent.lower():
+            pytest.fail(
+                "REGRESSION: node-1 reports healthy but raft thread panicked.\n"
+                f"--- node-1 logs (tail 300) ---\n{recent}"
+            )
+
+        # 6. Catch-up via raft snapshot + log replay.
+        _wait_nodes_caught_up(
+            [grpc1, grpc2],
+            [ROOT_ZONE_ID, "corp", "corp-eng", "family"],
+            api_key,
+            timeout=120,
+        )
+
+        # Spot-check a few replicated entries are visible on node-1.
+        for path, parent, _content in accumulated[:6]:
+            _wait_replicated(
+                grpc1,
+                parent,
+                path,
+                api_key,
+                msg=f"{path} not visible on freshly-joined node-1",
+                timeout=30,
+            )
+
+
+# ---------------------------------------------------------------------------
 # Step 26: Cross-zone cache coherence (Issue #3396)
 # ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Fix for the fresh-join-with-wiped-storage panic uncovered during PR #3933's cross-machine smoke prep. A node restarting with an empty data dir while keeping its raft node ID hits raft-rs's `to_commit N out of range [last_index 0]` fatal panic — leader's stale `Progress[id].matched` causes heartbeats to advance commit on a follower whose log is empty.

Strict raft-contract fix: rotate the node ID after a wipe via atomic ConfChangeV2 membership swap.

## What changed

### 1. `compute_node_id(hostname, incarnation)` — `transport-primitives`
- New helper alongside the legacy `hostname_to_node_id`.
- `incarnation == 0` is byte-for-byte identical to the legacy fn → cold-start clusters converge on identical ConfStates without coordination.
- `incarnation > 0` mints a fresh ID space (`SHA-256(hostname + ":" + incarnation_be)`) so a wiped node rejoining gets a brand-new ID that the leader's stale `Progress` never knew.

### 2. `ReplaceVoterByHostname` RPC — `ZoneApiService`
- Leader-only.  Reverse-looks-up the existing voter by `hostname` in the cluster peer map (caller does NOT claim what the old ID was — post-wipe it has no access to the prior incarnation).
- Atomic `ConfChangeV2` (`RemoveNode(old_id)` + `AddNode(new_id)`) committed as ONE entry — no transient `voters - {old_id}` quorum gap.
- Followers redirect via `leader_address`; partial-progress NotLeader retries land on the no-prior-voter fast path.
- New `ZoneConsensus::propose_replace_voter(old_id, new_id, address)` builds the V2; one round-trip total.

### 3. `ensure_voter_membership` — `RaftFederationProvider`
Centralised cold-start vs wipe-rejoin decision, called once at boot **before** `ZoneManager` construction:
1. If `<NEXUS_DATA_DIR>/.node_incarnation` exists → recovery path. Read the incarnation, return `compute_node_id(hostname, incarnation)`.
2. Else (fresh / post-wipe) → mint a new non-zero incarnation, dial each peer's `ReplaceVoterByHostname`. On success: persist + return rotated ID with `rotated_into_existing_cluster=true`.
3. Else (no leader reachable, e.g. simultaneous cold cluster bringup) → cold-start sentinel: persist `incarnation=0` and return `hostname_to_node_id(hostname)` so all peers converge on the same ConfState.

`init_from_env` parses NEXUS_PEERS once (DRY) into `Vec<NodeAddress>`, derives `id@host:port` strings from it, and uses a single `bootstrap_zone` closure that dispatches to `create_zone` (cold start) or `join_zone(skip_bootstrap=true)` (wipe-rejoin) based on `rotated_into_existing_cluster`.

### 4. Node-level identity SSOT
The incarnation marker lives in a flat file at `<NEXUS_DATA_DIR>/.node_incarnation` (atomic write-rename, 8-byte big-endian u64).  Identity is one-per-node, not one-per-zone, so the SSOT is also node-level — any zone storing a per-zone copy would be a shadow.

The earlier scaffold commit's per-zone `KEY_INCARNATION` API on `RaftStorage` is reverted in the final commit because:
- It would have placed an "incarnation zone" subdir that confused `open_existing_zones_from_disk` (scans `<zones_dir>/<zone>/raft/` to detect previously-bootstrapped zones, mistaking the marker zone for a real one with empty ConfState — election deadlock).
- Per-zone storage was an SSOT violation: same incarnation written N times for N zones.

### 5. E2E regression test
`TestFreshJoinToRunningCluster::test_fresh_join_via_snapshot` exercises the end-to-end path:
- Stop node-1 (n2 + witness retain quorum).
- Drive 20 root-zone writes via node-2 → raft commits accumulate.
- Wipe node-1's data volume (alpine sidecar).
- Start node-1 fresh.
- Assert healthy + log-scan for panic markers (`to_commit … out of range`, `panicked at`).
- Wait for raft catch-up via snapshot install (`_wait_nodes_caught_up`).
- Spot-check 6 replicated entries are visible on the rotated node.

Class is positioned LAST in the file (federation zones aren't auto-rediscovered on the rotated node — that's a follow-up "zone discovery on rejoin" feature outside this PR's scope; subsequent tests assuming node-1 hosts non-root federation zones would stall).

### 6. Post-rebase fixups (commit `fix(rebase): post-#3922 …`)
After rebasing onto develop tip (#3922 merged), two pre-existing failures needed addressing per the merge protocol ("fix all CI errors including pre-existing"):
- `NostrBackend` (added in #3922) had a stale `ObjectStore::read_content` signature (3 trait params, 4 impl params) and an unresolved `crate::backend` import (correct path is `crate::abc::object_store`). Pure compile fix; impl bodies still return `NotSupported`.
- `core::pipe::wal::tests::per_replica_heads_diverge_under_concurrent_consumers` was rewritten on develop tip with a synchronous in-memory `MetaStore` mock, but `WalPipeCore` composes `WalStreamCore` which still has an async bg flush thread. Reapplied the poll-with-2s-deadline retry pattern (originally from PR #3933's WAL pipe tests).

## Verification

- `cargo build -p raft@0.1.0` clean
- `cargo check --workspace --all-features` clean (post-rebase)
- `cargo test -p raft@0.1.0 --lib` 146 passed
- `cargo test -p kernel --lib` 325 passed (post-rebase, includes pre-existing test fix)
- `cargo test -p transport-primitives --lib peer` 9 passed (new `compute_node_id` covers zero-incarnation parity, non-zero divergence, determinism, never-zero invariant)
- `tests/e2e/docker/test_federation_e2e.py` full suite: **35 passed, 1 skipped, 0 failed (74s)**
- Single-zone trace verified end-to-end via container logs:
  - Boot: `[ensure_voter_membership] cold start (no leader reachable)`
  - Stop n1, write 20 files via n2, wipe n1, restart n1
  - n1 boot: `[ensure_voter_membership] dialing ReplaceVoterByHostname endpoint=http://nexus-2:2126` → `committed … new_node_id=8445… removed_old_id=Some(14044…)`
  - `Applying snapshot from leader index=49 voters=[8445…, 768…, 10099…]` (atomic ConfChangeV2 result)
  - No panic.

## Verification against principles

| Principle | Status |
|---|---|
| 架构正确 (architecturally correct) | ✅ ConfChangeV2 atomic single-entry — strict raft membership-swap. Leader is sole authority for voter set; client never claims old ID. |
| SSOT | ✅ Identity in one node-level file, never duplicated per-zone. Voter set in raft ConfState (replicated). |
| DRY | ✅ Single `compute_node_id` fn (cold-start = `incarnation=0`, rotation = `incarnation>0`). Single `ensure_voter_membership` decision point. NEXUS_PEERS parsed once. Single `bootstrap_zone` closure. |
| Rust-first | ✅ All in raft + transport-primitives crates. Zero Python touches (test file is in `tests/e2e/docker/`, not Python source). |
| Perf | ✅ Boot-time only.  ConfChangeV2 = 1 raft round-trip (was 2 sequential).  Recovery path = 1 file read. |
| Raft contract | ✅ Atomic V2 membership swap; `skip_bootstrap=true` joiner; leader-only ConfChange proposal; identity-equals-log invariant restored via incarnation rotation. |

## Commit history (preserved)

1. `test(federation): regression test for fresh-join wiped-storage panic` — empty test class + class docstring documenting root cause
2. `feat(raft): persist node incarnation marker in RaftStorage` — initial scaffold (reverted in commit 6 once SSOT issue was identified)
3. `feat(transport): compute_node_id(hostname, incarnation) helper` — new ID derivation function with zero-incarnation parity
4. `feat(raft): ReplaceVoterByHostname RPC for wipe-rejoin ID rotation` — proto + server handler + client
5. `feat(raft): atomic ConfChangeV2 voter swap + ensure_voter_membership` — node.rs ConfChangeV2 channel + helper + init_from_env wiring + V2 atomic in handler
6. `fix(raft): wipe-rejoin contract via node-level incarnation file` — pivot to node-level SSOT + revert per-zone API + e2e test cleanup
7. `fix(rebase): post-#3922 develop pull — pre-existing nostr_backend signature + WalPipeCore async-flush race` — compile + test fixes for develop-tip merge

## Test plan

- [x] Unit tests pass (raft + transport-primitives + kernel)
- [x] Federation E2E full suite green (35/35)
- [x] Boot trace verified end-to-end
- [ ] CI green (monitoring after rebase + push)
