### PR TITLE
[codex] Fix edge build perf schema drift

### DIFF
--- a/alembic/versions/c7d9a0f4b8e2_repair_edge_permission_schema_drift.py
+++ b/alembic/versions/c7d9a0f4b8e2_repair_edge_permission_schema_drift.py
@@ -304,6 +304,8 @@ def upgrade() -> None:
     table_names = set(inspector.get_table_names())
 
     if "file_paths" in table_names:
+        file_path_columns = set(_table_columns(inspector, "file_paths"))
+        _set_tenant_default(bind, "file_paths", file_path_columns)
         _drop_not_null_if_needed(bind, inspector, "file_paths", "backend_id")
         _drop_not_null_if_needed(bind, inspector, "file_paths", "physical_path")
         _widen_varchar_if_needed(bind, inspector, "file_paths", "content_id", 255)

--- a/src/nexus/storage/mcl_recorder.py
+++ b/src/nexus/storage/mcl_recorder.py
@@ -17,7 +17,7 @@ from collections.abc import Iterator
 from datetime import UTC, datetime
 from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import func, select, text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
@@ -60,14 +60,19 @@ class MCLRecorder:
         current_max = int(result) if result is not None else 0
         return max(time_based, current_max + 1)
 
-    def _allocate_sequence(self) -> int | None:
+    def _next_sequence_postgres(self) -> int:
+        """Allocate from the PostgreSQL sequence before ORM insert."""
+        result = self._session.execute(text("SELECT nextval('mcl_sequence_number_seq')"))
+        return int(result.scalar_one())
+
+    def _allocate_sequence(self) -> int:
         """Allocate a sequence number.
 
-        Returns None on PostgreSQL (server_default handles it),
-        or a Python-generated value for other dialects.
+        PostgreSQL has a database sequence, but assigning the value explicitly
+        avoids ORM inserts sending NULL when the mapped column has no server_default.
         """
         if self._is_postgres():
-            return None  # Let the DB sequence handle it
+            return self._next_sequence_postgres()
         return self._next_sequence_fallback()
 
     def _record(self, mcl_kwargs: dict[str, Any], label: str) -> None:
@@ -77,20 +82,16 @@ class MCLRecorder:
         fallback allocator can race under concurrency; retrying with a
         fresh value resolves it (Issue #3062).
         """
-        seq = self._allocate_sequence()
         for attempt in range(_MAX_SEQUENCE_RETRIES):
             try:
-                if seq is not None:
-                    mcl_kwargs["sequence_number"] = seq
+                mcl_kwargs["sequence_number"] = self._allocate_sequence()
                 mcl = MetadataChangeLogModel(**mcl_kwargs)
                 self._session.add(mcl)
                 self._session.flush()
                 return
             except IntegrityError:
                 self._session.rollback()
-                if attempt < _MAX_SEQUENCE_RETRIES - 1:
-                    seq = self._next_sequence_fallback()
-                else:
+                if attempt == _MAX_SEQUENCE_RETRIES - 1:
                     logger.warning("MCL %s failed after %d retries", label, _MAX_SEQUENCE_RETRIES)
             except Exception:
                 logger.warning("MCL %s failed", label, exc_info=True)

--- a/src/nexus/storage/schema_invariants.py
+++ b/src/nexus/storage/schema_invariants.py
@@ -550,6 +550,7 @@ def ensure_postgres_schema_invariants(engine: Engine) -> None:
         )
 
         _ensure_tenant_column_default(conn, columns_by_table, "tiger_cache")
+        _ensure_tenant_column_default(conn, columns_by_table, "file_paths")
         _ensure_tenant_column_default(conn, columns_by_table, "tiger_cache_queue")
         _ensure_tenant_column_default(conn, columns_by_table, "rebac_group_closure")
         _ensure_tenant_column_default(conn, columns_by_table, "tiger_directory_grants")

--- a/tests/unit/storage/test_schema_invariants.py
+++ b/tests/unit/storage/test_schema_invariants.py
@@ -76,6 +76,7 @@ def test_postgres_schema_invariants_repair_zone_schema_gaps(monkeypatch) -> None
                 "indexed_content_id",
                 "backend_id",
                 "physical_path",
+                "tenant_id",
             },
             "version_history": {
                 "version_id",
@@ -169,6 +170,7 @@ def test_postgres_schema_invariants_repair_zone_schema_gaps(monkeypatch) -> None
         in executed_sql
     )
     assert "ALTER TABLE tiger_cache ALTER COLUMN tenant_id SET DEFAULT 'root'" in executed_sql
+    assert "ALTER TABLE file_paths ALTER COLUMN tenant_id SET DEFAULT 'root'" in executed_sql
     assert "ALTER TABLE tiger_cache_queue ALTER COLUMN tenant_id SET DEFAULT 'root'" in executed_sql
     assert (
         "ALTER TABLE rebac_group_closure ALTER COLUMN tenant_id SET DEFAULT 'root'" in executed_sql

--- a/tests/unit/test_mcl.py
+++ b/tests/unit/test_mcl.py
@@ -1,6 +1,8 @@
 """Tests for MCL recorder — metadata change log integration (Issue #2929)."""
 
 import json
+from types import SimpleNamespace
+from typing import Any
 
 import pytest
 from sqlalchemy import create_engine, select
@@ -113,6 +115,49 @@ class TestMCLRecorder:
 
 class TestMCLSequenceAllocation:
     """Issue #3062: Sequence allocation should produce unique, monotonic values."""
+
+    def test_postgres_sequence_number_allocated_before_flush(self) -> None:
+        """PostgreSQL inserts should not rely on a server default SQLAlchemy omits."""
+
+        class _FakeScalarResult:
+            def __init__(self, value: int) -> None:
+                self._value = value
+
+            def scalar_one(self) -> int:
+                return self._value
+
+        class _FakePostgresSession:
+            bind = SimpleNamespace(dialect=SimpleNamespace(name="postgresql"))
+
+            def __init__(self) -> None:
+                self.executed: list[str] = []
+                self.added: list[MetadataChangeLogModel] = []
+                self.flushed = False
+
+            def execute(self, statement: Any) -> _FakeScalarResult:
+                self.executed.append(str(statement))
+                return _FakeScalarResult(42)
+
+            def add(self, obj: MetadataChangeLogModel) -> None:
+                self.added.append(obj)
+
+            def flush(self) -> None:
+                self.flushed = True
+
+            def rollback(self) -> None:
+                raise AssertionError("rollback should not be called")
+
+        session = _FakePostgresSession()
+
+        MCLRecorder(session).record_file_write(
+            entity_urn="urn:nexus:file:root:id1",
+            metadata_dict={"path": "/workspace/demo/plan.md"},
+            zone_id="root",
+        )
+
+        assert session.flushed
+        assert session.added[0].sequence_number == 42
+        assert "nextval('mcl_sequence_number_seq')" in session.executed[0]
 
     def test_multiple_writes_get_unique_sequences(self, db_session) -> None:
         """Concurrent-style writes should each get a unique sequence number."""


### PR DESCRIPTION
## Summary
- Repair legacy Postgres `file_paths.tenant_id` schema drift by setting the root default in both runtime invariants and the Alembic repair migration.
- Allocate metadata change log sequence numbers explicitly from `mcl_sequence_number_seq` before SQLAlchemy flushes Postgres rows.
- Add focused regressions for the `file_paths` tenant default and Postgres MCL sequence allocation.

## Root Cause
The edge build perf E2E failed while seeding/indexing because the Postgres schema still had legacy `file_paths.tenant_id NOT NULL` without a default, while current ORM writes only `zone_id`. That rejected `file_paths` inserts and cascaded into search indexing misses. The logs also showed MCL inserts sending `sequence_number=NULL`; the recorder assumed a database default would apply, but the mapped column had no SQLAlchemy `server_default`.

## Validation
- `PYTHONPATH=src /tmp/nexus-ci-fix-venv/bin/python -m pytest tests/unit/storage/test_schema_invariants.py tests/unit/test_mcl.py -q`
- Commit hooks: trailing whitespace, EOF, merge conflict, ruff, ruff format, mypy, file size, type-ignore, brick import checks

Could not rerun the Docker edge E2E locally because `docker` is not installed in this environment.
