### PR TITLE
[codex] Fix CI search indexing failures

### DIFF
--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -2264,7 +2264,7 @@ class SearchDaemon:
 
         if self._chunk_store is not None:
             for mutation in resolved:
-                if mutation.path_id != mutation.virtual_path:
+                if self._has_resolved_path_id(mutation):
                     await self._chunk_store.delete_document_chunks(mutation.path_id)
 
         if self._backend is not None:
@@ -2327,6 +2327,40 @@ class SearchDaemon:
                 result.append(p)
 
         return result
+
+    @staticmethod
+    def _has_resolved_path_id(mutation: ResolvedMutation) -> bool:
+        return bool(
+            getattr(
+                mutation,
+                "path_id_resolved",
+                mutation.path_id != mutation.virtual_path,
+            )
+        )
+
+    @staticmethod
+    def _path_lookup_candidates(zone_id: str, scoped_path: str, virtual_path: str) -> list[str]:
+        candidates: list[str] = []
+
+        def add(candidate: str) -> None:
+            if candidate and candidate not in candidates:
+                candidates.append(candidate)
+
+        add(virtual_path)
+        add(scoped_path)
+        if virtual_path.startswith("/"):
+            add(f"/zone/{zone_id}{virtual_path}")
+        return candidates
+
+    @staticmethod
+    def _build_path_lookup_values(candidates: list[str]) -> tuple[str, dict[str, str | int]]:
+        params: dict[str, str | int] = {}
+        values_parts: list[str] = []
+        for idx, candidate in enumerate(candidates):
+            params[f"candidate_{idx}"] = candidate
+            params[f"rank_{idx}"] = idx
+            values_parts.append(f"(:candidate_{idx}, :rank_{idx})")
+        return ", ".join(values_parts), params
 
     @staticmethod
     def _build_naive_chunks(content: str, chunk_size: int = 1000) -> list[ChunkRecord]:
@@ -2664,10 +2698,12 @@ class SearchDaemon:
                 # When embedding consumer is active, it owns deletes for
                 # document_chunks (Issue #3708). FTS only handles deletes
                 # when it is the sole writer.
-                if not embedding_active:
+                if not embedding_active and self._has_resolved_path_id(mutation):
                     await self._chunk_store.delete_document_chunks(mutation.path_id)
                 continue
             if mutation.content:
+                if not self._has_resolved_path_id(mutation):
+                    continue
                 # When embedding is active, skip in-scope paths — the
                 # embedding consumer writes strictly better chunks for
                 # those. Keep FTS as the writer for out-of-scope paths
@@ -2695,10 +2731,12 @@ class SearchDaemon:
             # document_chunks writer when active (Issue #3708), so it must
             # propagate DELETE ops that the FTS consumer used to handle.
             if mutation.event.op == SearchMutationOp.DELETE:
-                if self._chunk_store is not None:
+                if self._chunk_store is not None and self._has_resolved_path_id(mutation):
                     await self._chunk_store.delete_document_chunks(mutation.path_id)
                 continue
             if not mutation.content:
+                continue
+            if not self._has_resolved_path_id(mutation):
                 continue
             # Early-skip for out-of-scope paths (Issue #3698). The central
             # gate in IndexingPipeline.index_documents would also catch
@@ -2789,9 +2827,12 @@ class SearchDaemon:
             try:
                 # Strip /zone/{zone_id} prefix for DB virtual_path lookup
                 virtual_path = strip_zone_prefix(path)
+                zone_id = extract_zone_id(path)
+                lookup_candidates = self._path_lookup_candidates(zone_id, path, virtual_path)
 
                 # Read file content via file reader or database
                 content: str | None = None
+                content_path_id: str | None = None
                 if self._file_reader:
                     import contextlib
 
@@ -2806,23 +2847,31 @@ class SearchDaemon:
                 # Fallback: read from content_cache table
                 if not content and self._async_session:
                     try:
-                        from sqlalchemy import text as sa_text
-
                         async with self._async_session() as sess:
+                            values_sql, params = self._build_path_lookup_values(lookup_candidates)
+                            params["zone_id"] = zone_id
                             row = (
                                 await sess.execute(
                                     sa_text(
-                                        "SELECT cc.content_text FROM content_cache cc "
-                                        "JOIN file_paths fp ON cc.path_id = fp.path_id "
-                                        "WHERE fp.virtual_path = :vp "
+                                        "WITH lookup(virtual_path, lookup_rank) AS "
+                                        f"(VALUES {values_sql}) "
+                                        "SELECT cc.content_text, fp.path_id FROM lookup l "
+                                        "JOIN file_paths fp "
+                                        "ON fp.zone_id = :zone_id "
+                                        "AND fp.virtual_path = l.virtual_path "
+                                        "JOIN content_cache cc ON cc.path_id = fp.path_id "
+                                        "WHERE fp.deleted_at IS NULL "
                                         "AND cc.content_text IS NOT NULL "
+                                        "ORDER BY l.lookup_rank "
                                         "LIMIT 1"
                                     ),
-                                    {"vp": virtual_path},
+                                    params,
                                 )
                             ).first()
                             if row and row[0]:
                                 content = str(row[0])
+                                if len(row) > 1 and row[1]:
+                                    content_path_id = str(row[1])
                     except Exception as db_err:
                         logger.debug("DB content read failed for %s: %s", path, db_err)
 
@@ -2832,22 +2881,34 @@ class SearchDaemon:
 
                 # Resolve path_id from file_paths table
                 path_id = virtual_path  # fallback
-                if self._async_session:
+                path_id_resolved = False
+                if content_path_id is not None:
+                    path_id = content_path_id
+                    path_id_resolved = True
+                elif self._async_session:
                     try:
-                        from sqlalchemy import text as sa_text
-
                         async with self._async_session() as sess:
+                            values_sql, params = self._build_path_lookup_values(lookup_candidates)
+                            params["zone_id"] = zone_id
                             row = (
                                 await sess.execute(
                                     sa_text(
-                                        "SELECT path_id FROM file_paths "
-                                        "WHERE virtual_path = :vp LIMIT 1"
+                                        "WITH lookup(virtual_path, lookup_rank) AS "
+                                        f"(VALUES {values_sql}) "
+                                        "SELECT fp.path_id FROM lookup l "
+                                        "JOIN file_paths fp "
+                                        "ON fp.zone_id = :zone_id "
+                                        "AND fp.virtual_path = l.virtual_path "
+                                        "WHERE fp.deleted_at IS NULL "
+                                        "ORDER BY l.lookup_rank "
+                                        "LIMIT 1"
                                     ),
-                                    {"vp": virtual_path},
+                                    params,
                                 )
                             ).first()
                             if row:
                                 path_id = row[0]
+                                path_id_resolved = True
                     except Exception as e:
                         logger.debug("path_id lookup failed for %s: %s", virtual_path, e)
 
@@ -2868,21 +2929,22 @@ class SearchDaemon:
                 )
 
                 if embedding_active and self._indexing_pipeline is not None:
-                    try:
-                        result = await self._indexing_pipeline.index_document(
-                            path, content, path_id
-                        )
-                        if result.error:
-                            logger.warning(
-                                "Embedding pipeline failed for %s: %s — falling back to FTS",
-                                path,
-                                result.error,
+                    if path_id_resolved:
+                        try:
+                            result = await self._indexing_pipeline.index_document(
+                                path, content, path_id
                             )
+                            if result.error:
+                                logger.warning(
+                                    "Embedding pipeline failed for %s: %s — falling back to FTS",
+                                    path,
+                                    result.error,
+                                )
+                                await self._index_to_document_chunks(path_id, path, content)
+                        except Exception as ie:
+                            logger.warning("Indexing pipeline error for %s: %s", path, ie)
                             await self._index_to_document_chunks(path_id, path, content)
-                    except Exception as ie:
-                        logger.warning("Indexing pipeline error for %s: %s", path, ie)
-                        await self._index_to_document_chunks(path_id, path, content)
-                elif self._async_session:
+                elif self._async_session and path_id_resolved:
                     await self._index_to_document_chunks(path_id, path, content)
 
                 indexed_count += 1
@@ -2891,14 +2953,13 @@ class SearchDaemon:
                 if self._backend is not None and path_in_scope:
                     # Fixed DRY bug (Issue #3698): use the shared
                     # extract_zone_id helper instead of an inline regex.
-                    _zone = extract_zone_id(path)
-                    _doc_id = f"{_zone}:{virtual_path}" if _zone != "root" else virtual_path
-                    _txtai_batch.setdefault(_zone, []).append(
+                    _doc_id = f"{zone_id}:{virtual_path}" if zone_id != "root" else virtual_path
+                    _txtai_batch.setdefault(zone_id, []).append(
                         {
                             "id": _doc_id,
                             "text": content,
                             "path": virtual_path,
-                            "zone_id": _zone,
+                            "zone_id": zone_id,
                         }
                     )
 
@@ -2932,8 +2993,6 @@ class SearchDaemon:
             # BM25S not available — count from DB document_chunks table
             session_factory = self._async_session
             try:
-                from sqlalchemy import text as sa_text
-
                 async with session_factory() as sess:
                     row = (
                         await sess.execute(

--- a/src/nexus/bricks/search/indexing_service.py
+++ b/src/nexus/bricks/search/indexing_service.py
@@ -12,12 +12,17 @@ Key design decisions:
   - Comprehensive error handling with structured logging
 """
 
+import hashlib
 import logging
+import posixpath
+import uuid
 from datetime import UTC, datetime
 from typing import Any
 
 from sqlalchemy import delete, func, select
+from sqlalchemy.exc import IntegrityError
 
+from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.lib.virtual_views import is_parseable_path
 
 # Removed: txtai handles this (Issue #2663)
@@ -37,6 +42,38 @@ from nexus.bricks.search.models import DocumentChunkModel, FilePathModel
 from nexus.bricks.search.protocols import FileReaderProtocol
 
 logger = logging.getLogger(__name__)
+
+
+def _looks_like_virtual_readme(path: str) -> bool:
+    """Heuristic: does ``path`` match a virtual ``.readme/`` overlay entry?
+
+    Issue #3728: the virtual ``.readme/`` tree has no metastore rows.
+    When ``_query_file_model`` misses on a path under ``.readme/``, this
+    helper lets the indexer treat it as a virtual-doc candidate and
+    synthesize a path_id instead of silently dropping the file.
+
+    The check is intentionally path-shape-only — the router /
+    backend introspection that would give us definitive "is this
+    virtual?" answers isn't available from ``IndexingService``
+    (which only holds a ``FileReaderProtocol``).  False positives
+    are bounded: a user-created real ``.readme/`` folder whose row
+    happens to be missing would index with a synthetic ``virtual:``
+    path_id which doesn't collide with real path_ids.
+    """
+    normalized = posixpath.normpath(path)
+    segments = normalized.split("/")
+    return any(seg == ".readme" for seg in segments)
+
+
+def _virtual_path_id(path: str) -> str:
+    """Deterministic synthetic path_id for a virtual readme path.
+
+    ``document_chunks.path_id`` is a 36-character FK to ``file_paths``, so
+    row-less virtual documents still need a UUID-shaped identifier. UUID5
+    keeps the value stable across runs so re-indexing replaces the previous
+    chunks via the pipeline's path_id-keyed upsert.
+    """
+    return str(uuid.uuid5(uuid.NAMESPACE_URL, f"nexus:virtual-readme:{path}"))
 
 
 # Binary extensions excluded from directory indexing.
@@ -345,7 +382,24 @@ class IndexingService:
                         documents.append(
                             (file_path, content, file_model.path_id),
                         )
-
+                    elif _looks_like_virtual_readme(file_path):
+                        # Issue #3728: virtual ``.readme/`` overlay paths
+                        # are served from class metadata at read time.  The
+                        # chunk tables still enforce a FK to file_paths, so
+                        # persist a minimal deterministic row before handing
+                        # the document to the indexing pipeline.
+                        #
+                        # Known limitation: when the connector class
+                        # metadata changes (e.g. a nexus upgrade), the
+                        # synthetic path_id stays the same but the
+                        # embeddings become stale.  Users need to
+                        # re-trigger indexing (remount) to refresh.
+                        virtual_model = self._ensure_virtual_readme_file_model(
+                            session,
+                            file_path,
+                            content,
+                        )
+                        documents.append((file_path, content, virtual_model.path_id))
                 except Exception:
                     logger.warning(
                         "[INDEXING-SVC] Skipping %s: failed to read or resolve",
@@ -450,3 +504,61 @@ class IndexingService:
             .where(DocumentChunkModel.path_id == path_id)
         )
         return session.execute(stmt).scalar() or 0
+
+    @staticmethod
+    def _ensure_virtual_readme_file_model(
+        session: Any,
+        path: str,
+        content: str,
+    ) -> Any:
+        """Create or refresh the synthetic file_paths row for a virtual readme."""
+        path_id = _virtual_path_id(path)
+        content_id = hashlib.sha256(content.encode("utf-8")).hexdigest()
+        now = datetime.now(UTC)
+
+        file_model = session.get(FilePathModel, path_id)
+        if file_model is None:
+            file_model = session.execute(
+                select(FilePathModel).where(
+                    FilePathModel.zone_id == ROOT_ZONE_ID,
+                    FilePathModel.virtual_path == path,
+                    FilePathModel.deleted_at.is_(None),
+                )
+            ).scalar_one_or_none()
+
+        if file_model is None:
+            file_model = FilePathModel(
+                path_id=path_id,
+                zone_id=ROOT_ZONE_ID,
+                virtual_path=path,
+                file_type="text/markdown",
+                size_bytes=len(content.encode("utf-8")),
+                content_id=content_id,
+                created_at=now,
+                updated_at=now,
+            )
+            session.add(file_model)
+        else:
+            file_model.content_id = content_id
+            file_model.size_bytes = len(content.encode("utf-8"))
+            file_model.file_type = file_model.file_type or "text/markdown"
+            file_model.updated_at = now
+            file_model.deleted_at = None
+
+        try:
+            session.commit()
+        except IntegrityError:
+            session.rollback()
+            file_model = session.get(FilePathModel, path_id)
+            if file_model is None:
+                file_model = session.execute(
+                    select(FilePathModel).where(
+                        FilePathModel.zone_id == ROOT_ZONE_ID,
+                        FilePathModel.virtual_path == path,
+                        FilePathModel.deleted_at.is_(None),
+                    )
+                ).scalar_one_or_none()
+            if file_model is None:
+                raise
+
+        return file_model

--- a/src/nexus/bricks/search/mutation_resolver.py
+++ b/src/nexus/bricks/search/mutation_resolver.py
@@ -29,6 +29,7 @@ class ResolvedMutation:
     path_id: str
     doc_id: str
     content: str | None = None
+    path_id_resolved: bool = True
 
 
 class MutationResolver:
@@ -72,7 +73,7 @@ class MutationResolver:
         now = time.monotonic()
         resolved: list[ResolvedMutation | None] = [None] * len(events)
         unresolved_indices: list[int] = []
-        unresolved_keys: list[tuple[str, str]] = []
+        lookup_candidates: list[tuple[str, str, str, int]] = []
 
         for idx, event in enumerate(events):
             cached = self._cache.get(event.event_id)
@@ -80,15 +81,17 @@ class MutationResolver:
                 resolved[idx] = cached[1]
                 continue
             unresolved_indices.append(idx)
-            unresolved_keys.append(self._path_key(event.zone_id, event.virtual_path))
+            lookup_candidates.extend(self._lookup_candidates(event))
 
-        path_id_map = await self._lookup_path_ids(unresolved_keys)
+        path_id_map = await self._lookup_path_ids(lookup_candidates)
         content_map = await self._lookup_content(events, unresolved_indices)
 
         for idx in unresolved_indices:
             event = events[idx]
             virtual_path = event.virtual_path
-            path_id = path_id_map.get(self._path_key(event.zone_id, virtual_path), virtual_path)
+            resolved_path_id = path_id_map.get(self._path_key(event.zone_id, virtual_path))
+            path_id_resolved = resolved_path_id is not None
+            path_id = resolved_path_id if resolved_path_id is not None else virtual_path
             zone_id = event.zone_id
             doc_id = f"{zone_id}:{virtual_path}" if zone_id != ROOT_ZONE_ID else virtual_path
             mutation = ResolvedMutation(
@@ -98,6 +101,7 @@ class MutationResolver:
                 path_id=path_id,
                 doc_id=doc_id,
                 content=content_map.get(event.event_id),
+                path_id_resolved=path_id_resolved,
             )
             self._cache[event.event_id] = (now, mutation)
             resolved[idx] = mutation
@@ -106,35 +110,42 @@ class MutationResolver:
 
     async def _lookup_path_ids(
         self,
-        path_keys: list[tuple[str, str]],
+        lookup_candidates: list[tuple[str, str, str, int]],
     ) -> dict[tuple[str, str], str]:
-        if not path_keys or self._async_session_factory is None:
+        if not lookup_candidates or self._async_session_factory is None:
             return {}
 
         path_id_map: dict[tuple[str, str], str] = {}
-        unique_keys = list(dict.fromkeys(path_keys))
+        unique_candidates = list(dict.fromkeys(lookup_candidates))
         async with self._async_session_factory() as session:
-            for offset in range(0, len(unique_keys), self._lookup_batch_size):
-                batch = unique_keys[offset : offset + self._lookup_batch_size]
+            for offset in range(0, len(unique_candidates), self._lookup_batch_size):
+                batch = unique_candidates[offset : offset + self._lookup_batch_size]
                 values_sql, params = self._build_lookup_values(batch)
                 result = await session.execute(
                     sa_text(
                         f"""
-                        WITH lookup(zone_id, virtual_path) AS (
+                        WITH lookup(
+                            zone_id,
+                            virtual_path,
+                            canonical_virtual_path,
+                            lookup_rank
+                        ) AS (
                             VALUES {values_sql}
                         )
-                        SELECT fp.zone_id, fp.virtual_path, fp.path_id
+                        SELECT l.zone_id, l.canonical_virtual_path, fp.path_id
                         FROM file_paths fp
                         JOIN lookup l
                           ON fp.zone_id = l.zone_id
                          AND fp.virtual_path = l.virtual_path
                         WHERE fp.deleted_at IS NULL
+                        ORDER BY l.lookup_rank
                         """
                     ),
                     params,
                 )
                 for row in result.fetchall():
-                    path_id_map[self._path_key(str(row[0]), str(row[1]))] = str(row[2])
+                    key = self._path_key(str(row[0]), str(row[1]))
+                    path_id_map.setdefault(key, str(row[2]))
         return path_id_map
 
     async def _lookup_content(
@@ -158,9 +169,10 @@ class MutationResolver:
                 missing_events.append(event)
 
         if missing_events and self._async_session_factory is not None:
-            db_content = await self._lookup_content_cache(
-                [self._path_key(event.zone_id, event.virtual_path) for event in missing_events]
-            )
+            lookup_candidates: list[tuple[str, str, str, int]] = []
+            for event in missing_events:
+                lookup_candidates.extend(self._lookup_candidates(event))
+            db_content = await self._lookup_content_cache(lookup_candidates)
             for event in missing_events:
                 content = db_content.get(self._path_key(event.zone_id, event.virtual_path))
                 if content:
@@ -183,25 +195,30 @@ class MutationResolver:
 
     async def _lookup_content_cache(
         self,
-        path_keys: list[tuple[str, str]],
+        lookup_candidates: list[tuple[str, str, str, int]],
     ) -> dict[tuple[str, str], str]:
-        if not path_keys or self._async_session_factory is None:
+        if not lookup_candidates or self._async_session_factory is None:
             return {}
 
         content_map: dict[tuple[str, str], str] = {}
-        unique_keys = list(dict.fromkeys(path_keys))
+        unique_candidates = list(dict.fromkeys(lookup_candidates))
         async with self._async_session_factory() as session:
             try:
-                for offset in range(0, len(unique_keys), self._lookup_batch_size):
-                    batch = unique_keys[offset : offset + self._lookup_batch_size]
+                for offset in range(0, len(unique_candidates), self._lookup_batch_size):
+                    batch = unique_candidates[offset : offset + self._lookup_batch_size]
                     values_sql, params = self._build_lookup_values(batch)
                     result = await session.execute(
                         sa_text(
                             f"""
-                            WITH lookup(zone_id, virtual_path) AS (
+                            WITH lookup(
+                                zone_id,
+                                virtual_path,
+                                canonical_virtual_path,
+                                lookup_rank
+                            ) AS (
                                 VALUES {values_sql}
                             )
-                            SELECT fp.zone_id, fp.virtual_path, cc.content_text
+                            SELECT l.zone_id, l.canonical_virtual_path, cc.content_text
                             FROM lookup l
                             JOIN file_paths fp
                               ON fp.zone_id = l.zone_id
@@ -210,26 +227,68 @@ class MutationResolver:
                               ON cc.path_id = fp.path_id
                             WHERE fp.deleted_at IS NULL
                               AND cc.content_text IS NOT NULL
+                            ORDER BY l.lookup_rank
                             """
                         ),
                         params,
                     )
                     for row in result.fetchall():
                         if row[2]:
-                            content_map[self._path_key(str(row[0]), str(row[1]))] = str(row[2])
+                            content_map.setdefault(
+                                self._path_key(str(row[0]), str(row[1])),
+                                str(row[2]),
+                            )
             except ProgrammingError as exc:
                 if self._is_missing_table_error(exc):
                     return {}
                 raise
         return content_map
 
-    def _build_lookup_values(self, path_keys: list[tuple[str, str]]) -> tuple[str, dict[str, str]]:
-        params: dict[str, str] = {}
+    @staticmethod
+    def _lookup_candidates(event: SearchMutationEvent) -> list[tuple[str, str, str, int]]:
+        return MutationResolver._build_path_lookup_candidates(
+            event.zone_id,
+            event.path,
+            event.virtual_path,
+        )
+
+    @staticmethod
+    def _build_path_lookup_candidates(
+        zone_id: str,
+        scoped_path: str,
+        virtual_path: str,
+    ) -> list[tuple[str, str, str, int]]:
+        canonical = virtual_path
+        candidates: list[str] = []
+
+        def add(candidate: str) -> None:
+            if candidate and candidate not in candidates:
+                candidates.append(candidate)
+
+        add(canonical)
+        add(scoped_path)
+        if canonical.startswith("/"):
+            add(f"/zone/{zone_id}{canonical}")
+
+        return [(zone_id, candidate, canonical, rank) for rank, candidate in enumerate(candidates)]
+
+    def _build_lookup_values(
+        self,
+        lookup_candidates: list[tuple[str, str, str, int]],
+    ) -> tuple[str, dict[str, str | int]]:
+        params: dict[str, str | int] = {}
         values_parts: list[str] = []
-        for idx, (zone_id, virtual_path) in enumerate(path_keys):
+        for idx, (zone_id, virtual_path, canonical_virtual_path, lookup_rank) in enumerate(
+            lookup_candidates
+        ):
             params[f"zone_id_{idx}"] = zone_id
             params[f"virtual_path_{idx}"] = virtual_path
-            values_parts.append(f"(:zone_id_{idx}, :virtual_path_{idx})")
+            params[f"canonical_virtual_path_{idx}"] = canonical_virtual_path
+            params[f"lookup_rank_{idx}"] = lookup_rank
+            values_parts.append(
+                f"(:zone_id_{idx}, :virtual_path_{idx}, "
+                f":canonical_virtual_path_{idx}, :lookup_rank_{idx})"
+            )
         return ", ".join(values_parts), params
 
     @staticmethod

--- a/src/nexus/storage/record_store.py
+++ b/src/nexus/storage/record_store.py
@@ -229,7 +229,9 @@ class SQLAlchemyRecordStore(RecordStoreABC):
                          When None, uses _build_pool_kwargs defaults (30 primary, 10 with replica).
         """
         from sqlalchemy import create_engine, event
+        from sqlalchemy.engine import make_url
         from sqlalchemy.orm import sessionmaker
+        from sqlalchemy.pool import StaticPool
 
         # Resolve database URL
         _resolved = self._resolve_db_url(db_url, db_path)
@@ -255,6 +257,9 @@ class SQLAlchemyRecordStore(RecordStoreABC):
         engine_kwargs: dict[str, Any] = {}
         if not self._is_postgresql:
             engine_kwargs["connect_args"] = {"check_same_thread": False}
+            url = make_url(self.database_url)
+            if url.database in (None, "", ":memory:"):
+                engine_kwargs["poolclass"] = StaticPool
         else:
             _default_pool = (
                 pool_size if pool_size is not None else (10 if self._has_read_replica else 20)

--- a/tests/integration/bricks/search/test_indexing_service.py
+++ b/tests/integration/bricks/search/test_indexing_service.py
@@ -569,7 +569,9 @@ class TestVirtualReadmeIndexing:
         assert _looks_like_virtual_readme("/work/my.readme/file.md") is False
         assert _looks_like_virtual_readme("/work/.readmex/file.md") is False
 
-    def test_virtual_path_id_is_deterministic_and_prefixed(self) -> None:
+    def test_virtual_path_id_is_deterministic_uuid(self) -> None:
+        import uuid
+
         from nexus.bricks.search.indexing_service import _virtual_path_id
 
         a = _virtual_path_id("/gws/gmail/.readme/README.md")
@@ -577,14 +579,13 @@ class TestVirtualReadmeIndexing:
         c = _virtual_path_id("/gws/gmail/.readme/schemas/send.yaml")
         assert a == b  # deterministic
         assert a != c  # different paths → different ids
-        assert a.startswith("virtual:")
-        # Uses SHA-256 (64 hex chars after the prefix)
-        assert len(a) == len("virtual:") + 64
+        assert str(uuid.UUID(a)) == a
+        assert len(a) == 36
 
     @pytest.mark.asyncio
     async def test_index_directory_indexes_virtual_readme_paths_without_row(self) -> None:
         """Virtual ``.readme/`` files have no FilePathModel but should still
-        be indexed via a synthetic ``virtual:`` path_id."""
+        be indexed via a synthetic file_paths row."""
         # Session returns None for every FilePathModel query → simulates
         # a post-mount indexing run over a skill backend where only the
         # virtual tree has entries and the metastore has no rows for
@@ -619,8 +620,9 @@ class TestVirtualReadmeIndexing:
         for doc_path, content, path_id in docs:
             assert doc_path in file_list
             assert content == "# Gmail\n\nsend_email schema ..."
-            # Synthetic path_id is used instead of a real FilePathModel id
-            assert path_id.startswith("virtual:")
+            # Synthetic path_id is UUID-shaped for document_chunks FK compatibility.
+            assert len(path_id) == 36
+        assert session.add.call_count == 2
 
     @pytest.mark.asyncio
     async def test_index_directory_still_skips_rowless_non_readme_paths(self) -> None:

--- a/tests/integration/bricks/search/test_mutation_resolver.py
+++ b/tests/integration/bricks/search/test_mutation_resolver.py
@@ -153,7 +153,9 @@ async def test_resolver_uses_values_lookup_batches_instead_of_or_chains() -> Non
     session = _SessionCtx(
         [
             [("root", "/docs/a.txt", "pid-a")],
+            [],
             [("root", "/docs/b.txt", "pid-b")],
+            [],
         ]
     )
     resolver = MutationResolver(
@@ -185,8 +187,8 @@ async def test_resolver_uses_values_lookup_batches_instead_of_or_chains() -> Non
     resolved = await resolver.resolve_batch(events)
 
     assert [item.path_id for item in resolved] == ["pid-a", "pid-b"]
-    assert len(session.statements) == 2
-    assert all("WITH lookup(zone_id, virtual_path) AS" in stmt for stmt in session.statements)
+    assert len(session.statements) == 4
+    assert all("WITH lookup(" in stmt for stmt in session.statements)
     assert all(" OR " not in stmt for stmt in session.statements)
 
 
@@ -225,3 +227,102 @@ async def test_resolver_ignores_missing_content_cache_table() -> None:
 
     assert len(resolved) == 1
     assert resolved[0].content is None
+
+
+@pytest.mark.asyncio
+async def test_resolver_preserves_first_content_cache_candidate() -> None:
+    file_reader = AsyncMock()
+    file_reader.read_text.side_effect = [OSError("missing"), OSError("missing")]
+    session_factory = _SequentialSessionFactory(
+        [
+            _SessionCtx(
+                [
+                    [
+                        ("tenant", "/docs/readme.md", "pid-canonical"),
+                        ("tenant", "/docs/readme.md", "pid-scoped"),
+                    ]
+                ]
+            ),
+            _SessionCtx(
+                [
+                    [
+                        ("tenant", "/docs/readme.md", "canonical content"),
+                        ("tenant", "/docs/readme.md", "scoped content"),
+                    ]
+                ]
+            ),
+        ]
+    )
+    resolver = MutationResolver(
+        file_reader=file_reader,
+        async_session_factory=session_factory,
+    )
+    event = SearchMutationEvent(
+        event_id="evt-tenant",
+        operation_id="op-tenant",
+        op=SearchMutationOp.UPSERT,
+        path="/zone/tenant/docs/readme.md",
+        zone_id="tenant",
+        timestamp=SimpleNamespace(tzinfo=None),
+        sequence_number=1,
+    )
+
+    resolved = await resolver.resolve_batch([event])
+
+    assert resolved[0].path_id == "pid-canonical"
+    assert resolved[0].content == "canonical content"
+
+
+@pytest.mark.asyncio
+async def test_resolver_includes_scoped_candidate_for_unscoped_event_paths() -> None:
+    file_reader = AsyncMock()
+    file_reader.read_text.return_value = "hello"
+    session = _SessionCtx(
+        [
+            [("tenant", "/shared-readonly-test/readme.txt", "pid-readme")],
+        ]
+    )
+
+    resolver = MutationResolver(
+        file_reader=file_reader,
+        async_session_factory=lambda: session,
+    )
+    event = SearchMutationEvent(
+        event_id="evt-tenant",
+        operation_id="op-tenant",
+        op=SearchMutationOp.UPSERT,
+        path="/shared-readonly-test/readme.txt",
+        zone_id="tenant",
+        timestamp=SimpleNamespace(tzinfo=None),
+        sequence_number=1,
+    )
+
+    resolved = await resolver.resolve_batch([event])
+
+    assert resolved[0].path_id == "pid-readme"
+    assert resolved[0].path_id_resolved is True
+    assert "/zone/tenant/shared-readonly-test/readme.txt" in session.params[0].values()
+
+
+@pytest.mark.asyncio
+async def test_resolver_marks_unresolved_path_id_fallback() -> None:
+    file_reader = AsyncMock()
+    file_reader.read_text.return_value = "hello"
+    resolver = MutationResolver(
+        file_reader=file_reader,
+        async_session_factory=lambda: _SessionCtx([[]]),
+    )
+    event = SearchMutationEvent(
+        event_id="evt-missing",
+        operation_id="op-missing",
+        op=SearchMutationOp.UPSERT,
+        path="/missing.txt",
+        zone_id=ROOT_ZONE_ID,
+        timestamp=SimpleNamespace(tzinfo=None),
+        sequence_number=1,
+    )
+
+    resolved = await resolver.resolve_batch([event])
+
+    assert resolved[0].path_id == "/missing.txt"
+    assert resolved[0].path_id_resolved is False

--- a/tests/integration/bricks/search/test_search_mutation_flow.py
+++ b/tests/integration/bricks/search/test_search_mutation_flow.py
@@ -70,9 +70,67 @@ async def test_legacy_delete_paths_call_delete_backends() -> None:
     daemon._backend.delete.assert_awaited_once_with(["/docs/readme.md"], zone_id=ROOT_ZONE_ID)
 
 
+@pytest.mark.asyncio
+async def test_legacy_delete_skips_document_chunks_when_path_id_unresolved() -> None:
+    daemon = SearchDaemon()
+    daemon._chunk_store = AsyncMock()
+    daemon._backend = AsyncMock()
+    daemon._resolve_mutations = AsyncMock(
+        return_value=[
+            SimpleNamespace(
+                zone_id=ROOT_ZONE_ID,
+                doc_id="/docs/readme.md",
+                path_id="/docs/readme.md",
+                virtual_path="/docs/readme.md",
+                path_id_resolved=False,
+            )
+        ]
+    )
+
+    await daemon._delete_indexes_for_paths(["/zone/root/docs/readme.md"])
+
+    daemon._chunk_store.delete_document_chunks.assert_not_awaited()
+    daemon._backend.delete.assert_awaited_once_with(["/docs/readme.md"], zone_id=ROOT_ZONE_ID)
+
+
+@pytest.mark.asyncio
+async def test_fts_mutation_skips_document_chunks_when_path_id_unresolved() -> None:
+    daemon = SearchDaemon()
+    daemon._chunk_store = AsyncMock()
+    event = SearchMutationEvent(
+        event_id="evt-1",
+        operation_id="op-1",
+        op=SearchMutationOp.UPSERT,
+        path="/docs/readme.md",
+        zone_id=ROOT_ZONE_ID,
+        timestamp=datetime.now(UTC).replace(tzinfo=None),
+        sequence_number=1,
+    )
+    daemon._resolve_mutations = AsyncMock(
+        return_value=[
+            SimpleNamespace(
+                event=event,
+                zone_id=ROOT_ZONE_ID,
+                doc_id="/docs/readme.md",
+                path_id="/docs/readme.md",
+                virtual_path="/docs/readme.md",
+                content="hello",
+                path_id_resolved=False,
+            )
+        ]
+    )
+
+    await daemon._consume_fts_mutations([event])
+
+    daemon._chunk_store.replace_document_chunks.assert_not_awaited()
+
+
 class _RowsResult:
     def __init__(self, rows):
         self._rows = rows
+
+    def first(self):
+        return self._rows[0] if self._rows else None
 
     def fetchall(self):
         return self._rows
@@ -92,6 +150,37 @@ class _SessionCtx:
     async def execute(self, _stmt, _params=None):
         self.execute_count += 1
         return _RowsResult(self._rows)
+
+
+class _SequentialSessionFactory:
+    def __init__(self, sessions):
+        self._sessions = list(sessions)
+
+    def __call__(self):
+        return self._sessions.pop(0)
+
+
+@pytest.mark.asyncio
+async def test_refresh_indexes_reuses_cached_content_path_id() -> None:
+    daemon = SearchDaemon()
+    daemon._indexing_pipeline = AsyncMock()
+    daemon._indexing_pipeline.index_document.return_value = SimpleNamespace(error=None)
+    daemon._embedding_provider = object()
+    daemon._async_session = _SequentialSessionFactory(
+        [
+            _SessionCtx([("scoped content", "pid-scoped")]),
+            _SessionCtx([("pid-canonical",)]),
+            _SessionCtx([(1,)]),
+        ]
+    )
+
+    await daemon._refresh_indexes(["/zone/tenant/docs/readme.md"])
+
+    daemon._indexing_pipeline.index_document.assert_awaited_once_with(
+        "/zone/tenant/docs/readme.md",
+        "scoped content",
+        "pid-scoped",
+    )
 
 
 @pytest.mark.asyncio

--- a/tests/unit/storage/test_record_store.py
+++ b/tests/unit/storage/test_record_store.py
@@ -153,6 +153,18 @@ class TestRecordStorePoolConfig:
             call_kwargs = mock_create.call_args[1]
             assert call_kwargs["pool_pre_ping"] is True
 
+    def test_sqlite_memory_uses_static_pool(self):
+        """In-memory SQLite uses one shared connection across TestClient threads."""
+        from sqlalchemy.pool import StaticPool
+
+        from nexus.storage.record_store import SQLAlchemyRecordStore
+
+        store = SQLAlchemyRecordStore(db_url="sqlite:///:memory:", create_tables=False)
+        try:
+            assert isinstance(store.engine.pool, StaticPool)
+        finally:
+            store.close()
+
 
 class TestRecordStoreAsyncURLConversion:
     """Tests for sync→async URL conversion."""


### PR DESCRIPTION
## Summary
- Use `StaticPool` for in-memory SQLite record stores to avoid TestClient shutdown races in the watch API E2E job.
- Resolve search mutation path IDs from canonical, scoped, and zone-scoped candidates, and skip `document_chunks` writes when no FK-backed `file_paths` row exists.
- Give virtual `.readme` documents deterministic UUID-shaped IDs and minimal `file_paths` rows before chunk insertion.

## Root Cause
- SQLAlchemy defaulted `sqlite:///:memory:` to `SingletonThreadPool`; shutdown could dispose the pool while background threads mutated its connection set.
- Search indexing could write raw virtual paths or oversized synthetic IDs into `document_chunks.path_id`, which is both 36 characters and foreign-keyed to `file_paths.path_id`.

## Validation
- `pytest tests/e2e/self_contained/test_watch_api_e2e.py::TestWatchAPIEndpoint::test_watch_with_glob_pattern -q -o addopts=`
- `pytest tests/unit/storage/test_record_store.py::TestRecordStorePoolConfig::test_sqlite_memory_uses_static_pool -q -o addopts=`
- `pytest tests/integration/bricks/search/test_mutation_resolver.py -q -o addopts=`
- Targeted daemon and virtual-readme indexing regression tests
- `ruff check` on changed files
- `git diff --check`

Fixes CI failures from:
- https://github.com/nexi-lab/nexus/actions/runs/25143619089/job/73699764910
- https://github.com/nexi-lab/nexus/actions/runs/25143619099/job/73699032075