### PR TITLE
docs(raft): refresh stale RaftFederationProvider doc comment

### DIFF
--- a/rust/raft/src/zone_manager.rs
+++ b/rust/raft/src/zone_manager.rs
@@ -273,7 +273,7 @@ impl ZoneManager {
 
     /// Create a `ZoneManager` with an explicit node ID.
     ///
-    /// Used by `RaftFederationProvider::ensure_voter_membership` to
+    /// Used by `RaftDistributedCoordinator::ensure_voter_membership` to
     /// bind a freshly-minted incarnation-based ID for the post-wipe
     /// rotation path.  Most callers should use [`Self::new`], which
     /// computes the cold-start `hostname_to_node_id` automatically.


### PR DESCRIPTION
Post-PR-#3938 audit caught one missed mechanical rename: doc comment on `ZoneManager::with_node_id` referenced the pre-rename `RaftFederationProvider::ensure_voter_membership`. Updated to `RaftDistributedCoordinator`.

Code paths unchanged; pure comment fix. cargo check + 925/0 tests green.

## Test plan
- [x] cargo check --workspace --tests
- [x] cargo test --workspace --lib (925/0)
- [x] grep -r 'FederationProvider\|RaftFederationProvider' rust returns 0