### PR TITLE
feat(#3791): activity event foundation

### DIFF
--- a/.pre-commit-hooks/check_brick_imports.py
+++ b/.pre-commit-hooks/check_brick_imports.py
@@ -133,6 +133,8 @@ KNOWN_CORE_EXCEPTIONS: dict[str, list[str]] = {
     "nexus.bricks.search.federated_search": ["nexus.services"],
     # rebac.enforcer emits activity events (#3791) via nexus.services.activity.
     "nexus.bricks.rebac.enforcer": ["nexus.services"],
+    # approvals.service emits activity events (#3791) via nexus.services.activity.
+    "nexus.bricks.approvals.service": ["nexus.services"],
     # dispatch_consumer needs core.pipe + core.pipe_manager for DT_PIPE lifecycle
     "nexus.bricks.task_manager.dispatch_consumer": ["nexus.core"],
 }

--- a/.pre-commit-hooks/check_brick_imports.py
+++ b/.pre-commit-hooks/check_brick_imports.py
@@ -131,6 +131,8 @@ KNOWN_CORE_EXCEPTIONS: dict[str, list[str]] = {
     "nexus.bricks.search.search_service": ["nexus.core", "nexus.services"],
     # federated_search emits activity events (#3791) via nexus.services.activity.
     "nexus.bricks.search.federated_search": ["nexus.services"],
+    # rebac.enforcer emits activity events (#3791) via nexus.services.activity.
+    "nexus.bricks.rebac.enforcer": ["nexus.services"],
     # dispatch_consumer needs core.pipe + core.pipe_manager for DT_PIPE lifecycle
     "nexus.bricks.task_manager.dispatch_consumer": ["nexus.core"],
 }

--- a/.pre-commit-hooks/check_brick_imports.py
+++ b/.pre-commit-hooks/check_brick_imports.py
@@ -129,6 +129,8 @@ KNOWN_CORE_EXCEPTIONS: dict[str, list[str]] = {
     # search_service moved from services/ — needs core.metastore, core.router, core.path_utils,
     # and services.gateway (TYPE_CHECKING + lazy imports)
     "nexus.bricks.search.search_service": ["nexus.core", "nexus.services"],
+    # federated_search emits activity events (#3791) via nexus.services.activity.
+    "nexus.bricks.search.federated_search": ["nexus.services"],
     # dispatch_consumer needs core.pipe + core.pipe_manager for DT_PIPE lifecycle
     "nexus.bricks.task_manager.dispatch_consumer": ["nexus.core"],
 }

--- a/.pre-commit-hooks/check_brick_imports.py
+++ b/.pre-commit-hooks/check_brick_imports.py
@@ -129,14 +129,6 @@ KNOWN_CORE_EXCEPTIONS: dict[str, list[str]] = {
     # search_service moved from services/ — needs core.metastore, core.router, core.path_utils,
     # and services.gateway (TYPE_CHECKING + lazy imports)
     "nexus.bricks.search.search_service": ["nexus.core", "nexus.services"],
-    # federated_search emits activity events (#3791) via nexus.services.activity.
-    "nexus.bricks.search.federated_search": ["nexus.services"],
-    # rebac.enforcer emits activity events (#3791) via nexus.services.activity.
-    "nexus.bricks.rebac.enforcer": ["nexus.services"],
-    # approvals.service emits activity events (#3791) via nexus.services.activity.
-    "nexus.bricks.approvals.service": ["nexus.services"],
-    # mcp.middleware_audit emits activity events (#3791) via nexus.services.activity.
-    "nexus.bricks.mcp.middleware_audit": ["nexus.services"],
     # dispatch_consumer needs core.pipe + core.pipe_manager for DT_PIPE lifecycle
     "nexus.bricks.task_manager.dispatch_consumer": ["nexus.core"],
 }

--- a/.pre-commit-hooks/check_brick_imports.py
+++ b/.pre-commit-hooks/check_brick_imports.py
@@ -135,6 +135,8 @@ KNOWN_CORE_EXCEPTIONS: dict[str, list[str]] = {
     "nexus.bricks.rebac.enforcer": ["nexus.services"],
     # approvals.service emits activity events (#3791) via nexus.services.activity.
     "nexus.bricks.approvals.service": ["nexus.services"],
+    # mcp.middleware_audit emits activity events (#3791) via nexus.services.activity.
+    "nexus.bricks.mcp.middleware_audit": ["nexus.services"],
     # dispatch_consumer needs core.pipe + core.pipe_manager for DT_PIPE lifecycle
     "nexus.bricks.task_manager.dispatch_consumer": ["nexus.core"],
 }

--- a/benchmarks/activity/bench_emit.py
+++ b/benchmarks/activity/bench_emit.py
@@ -1,0 +1,30 @@
+"""Bench: emit() p50/p99 — must be < 10 µs / < 50 µs respectively."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from nexus.services.activity import EventKind, Result
+from nexus.services.activity.emitter import QueueEmitter
+
+
+@pytest.mark.benchmark(group="activity-emit")
+def test_emit_hot_path(benchmark) -> None:
+    queue: asyncio.Queue = asyncio.Queue(maxsize=10_000)
+    emitter = QueueEmitter(queue=queue)
+
+    def _do_emit() -> None:
+        emitter.emit(
+            kind=EventKind.SEARCH,
+            result=Result.OK,
+            actor_token_hash="abc1234567890def",
+            subject_zone="eng",
+            latency_ms=42,
+        )
+
+    benchmark(_do_emit)
+    stats = benchmark.stats.stats
+    # CI-friendly threshold (allow noise on shared runners)
+    assert stats.median * 1e6 < 25.0, f"emit p50 {stats.median * 1e6:.1f} µs > 25 µs"

--- a/benchmarks/activity/bench_search_with_activity.py
+++ b/benchmarks/activity/bench_search_with_activity.py
@@ -1,0 +1,46 @@
+"""Bench: confirm activity wrapper does not add measurable overhead.
+
+Synthetic — invokes the emit + timing wrapper around a no-op coroutine
+to isolate activity overhead from real search work.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from nexus.services.activity import EventKind, Result, set_emitter
+from nexus.services.activity.emitter import NoopEmitter, QueueEmitter
+from nexus.services.activity.events import ActivityEvent
+
+
+async def _wrapped_search(emit_fn) -> int:
+    start = time.monotonic()
+    result = 1
+    emit_fn(kind=EventKind.SEARCH, result=Result.OK, latency_ms=int((time.monotonic() - start) * 1000))
+    return result
+
+
+@pytest.mark.benchmark(group="activity-search-overhead")
+def test_search_with_noop_emitter(benchmark) -> None:
+    set_emitter(NoopEmitter())
+    from nexus.services.activity import emit
+
+    def _run() -> None:
+        asyncio.run(_wrapped_search(emit))
+
+    benchmark(_run)
+
+
+@pytest.mark.benchmark(group="activity-search-overhead")
+def test_search_with_queue_emitter(benchmark) -> None:
+    queue: asyncio.Queue[ActivityEvent] = asyncio.Queue(maxsize=10_000)
+    set_emitter(QueueEmitter(queue=queue))
+    from nexus.services.activity import emit
+
+    def _run() -> None:
+        asyncio.run(_wrapped_search(emit))
+
+    benchmark(_run)

--- a/docs/superpowers/plans/2026-04-30-3791-activity-event-foundation.md
+++ b/docs/superpowers/plans/2026-04-30-3791-activity-event-foundation.md
@@ -1,0 +1,2887 @@
+# Activity Event Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the activity event foundation for issue #3791 — schema, emitter, SQLite sink, retention, metrics catalog, lifespan wiring, and five emission callsites.
+
+**Architecture:** New self-contained `nexus.services.activity` package. Module-level `Emitter` singleton (NoopEmitter by default). Hot-path callsites invoke `emit(...)` which updates Prom metrics inline and `put_nowait`s into a bounded `asyncio.Queue` (drop on overflow). Background `ActivityWorker` drains the queue in batches into `SQLiteSink` (default) at `$NEXUS_ACTIVITY_DB_PATH`. `RetentionTask` periodically prunes rows older than `NEXUS_ACTIVITY_RETENTION_DAYS`. Lifespan integration via a new `ActivityComponent` registered in `nexus.server.lifespan.observability`.
+
+**Tech Stack:** Python 3.14, stdlib (`asyncio`, `sqlite3`, `dataclasses`, `enum`), `prometheus_client`, `pytest`, `pytest-asyncio`, `pytest-benchmark`. No new third-party deps.
+
+**Spec:** `docs/superpowers/specs/2026-04-30-3791-activity-event-foundation-design.md`
+
+---
+
+## File Structure
+
+**Production code (new package):**
+
+| Path | Responsibility |
+|---|---|
+| `src/nexus/services/activity/__init__.py` | Public re-exports: `emit`, `get_emitter`, `set_emitter`, `ActivityEvent`, `EventKind`, `Result`, `Actor`, `Subject` |
+| `src/nexus/services/activity/events.py` | `EventKind`, `Result` enums; `Actor`, `Subject`, `ActivityEvent` dataclasses |
+| `src/nexus/services/activity/emitter.py` | `Emitter` Protocol; `NoopEmitter`; `QueueEmitter`; module-level singleton + `get_emitter`/`set_emitter` accessors; `emit()` convenience wrapper |
+| `src/nexus/services/activity/metrics.py` | Prom Counter/Histogram/Gauge instances + helper `record_metrics(event)` invoked from `QueueEmitter.emit` |
+| `src/nexus/services/activity/sinks/__init__.py` | Re-exports |
+| `src/nexus/services/activity/sinks/protocol.py` | `SinkProtocol` (write_batch, close) |
+| `src/nexus/services/activity/sinks/noop.py` | `NoopSink` |
+| `src/nexus/services/activity/sinks/recording.py` | `RecordingSink` for tests (in-memory) |
+| `src/nexus/services/activity/sinks/sqlite.py` | `SQLiteSink` — schema bootstrap, PRAGMAs, batch insert |
+| `src/nexus/services/activity/worker.py` | `ActivityWorker` — drain loop with batching/timeout |
+| `src/nexus/services/activity/retention.py` | `RetentionTask` — periodic prune + VACUUM |
+| `src/nexus/services/activity/config.py` | `ActivityConfig` dataclass + `from_env()` |
+| `src/nexus/services/activity/lifespan.py` | `setup_activity` / `shutdown_activity` (sync entry points usable from `FunctionPairComponent`) |
+
+**Production code (modified):**
+
+| Path | Change |
+|---|---|
+| `src/nexus/server/lifespan/observability.py` | Add `("activity", "nexus.services.activity.lifespan", "setup_activity", "shutdown_activity")` to `_OBSERVABILITY_PROVIDERS` |
+| `src/nexus/bricks/search/search_service.py` | Wrap `SearchService.search` body with timing + `emit(EventKind.SEARCH, ...)` |
+| `src/nexus/bricks/search/federated_search.py` | Wrap `FederatedSearch.search` body with timing + `emit(EventKind.SEARCH, ...)` |
+| `src/nexus/bricks/rebac/enforcer.py` | After `check()` returns deny verdict, `emit(EventKind.ZONE_ACCESS or POLICY_BLOCK, result=BLOCKED, ...)` |
+| `src/nexus/bricks/approvals/service.py` | `emit(EventKind.APPROVAL, result=PENDING_APPROVAL)` on creation; `emit(EventKind.APPROVAL, result=OK or BLOCKED)` on `decide()` |
+| `src/nexus/bricks/mcp/middleware_audit.py` | After existing stdout/Redis emits, `emit(EventKind.MCP_TOOL_CALL, ...)` |
+
+**Tests:**
+
+| Path | Coverage |
+|---|---|
+| `tests/unit/services/activity/__init__.py` | empty marker |
+| `tests/unit/services/activity/test_events.py` | dataclass roundtrip, enum values |
+| `tests/unit/services/activity/test_emitter.py` | NoopEmitter, QueueEmitter, drop counter, set_emitter swap |
+| `tests/unit/services/activity/test_metrics.py` | counters/histogram/gauge labels, record_metrics paths |
+| `tests/unit/services/activity/test_sqlite_sink.py` | schema, PRAGMAs, batch insert, corrupt fallback |
+| `tests/unit/services/activity/test_recording_sink.py` | record + clear |
+| `tests/unit/services/activity/test_worker.py` | drain batching, timeout, sink error isolation, shutdown drain |
+| `tests/unit/services/activity/test_retention.py` | prune by ts, retention=0 noop, vacuum trigger |
+| `tests/unit/services/activity/test_config.py` | env parsing, defaults, invalid value rejection |
+| `tests/integration/services/activity/__init__.py` | empty marker |
+| `tests/integration/services/activity/test_emit_to_sqlite_e2e.py` | full pipeline through lifespan |
+| `tests/integration/services/activity/test_emission_callsites.py` | each of 5 callsites recorded by RecordingSink |
+| `tests/integration/services/activity/test_lifespan_supervision.py` | worker restart on crash |
+| `tests/integration/services/activity/test_metrics_endpoint.py` | scrape `/metrics` after emits |
+| `benchmarks/activity/__init__.py` | empty marker |
+| `benchmarks/activity/bench_emit.py` | p50/p99 of `emit()` |
+| `benchmarks/activity/bench_search_with_activity.py` | search overhead with activity ON vs OFF |
+
+**Test runner convention:** `uv run pytest <path> -v`. Async tests use `pytest-asyncio`. Benches use `pytest-benchmark`.
+
+**Commit convention:** `feat(#3791): <subject>` or `test(#3791): <subject>`. Each task ends with one commit.
+
+---
+
+## Task 1: Scaffold package + `ActivityEvent` schema and enums
+
+**Files:**
+- Create: `src/nexus/services/activity/__init__.py`
+- Create: `src/nexus/services/activity/events.py`
+- Create: `tests/unit/services/activity/__init__.py`
+- Create: `tests/unit/services/activity/test_events.py`
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/unit/services/activity/test_events.py`:
+
+```python
+"""Unit tests for ActivityEvent schema and enums."""
+
+from __future__ import annotations
+
+from nexus.services.activity.events import (
+    ActivityEvent,
+    Actor,
+    EventKind,
+    Result,
+    Subject,
+)
+
+
+def test_event_kinds_match_issue_schema() -> None:
+    expected = {"search", "fetch", "mcp_tool_call", "zone_access", "policy_block", "approval"}
+    assert {k.value for k in EventKind} == expected
+
+
+def test_results_match_issue_schema() -> None:
+    expected = {"ok", "blocked", "pending_approval"}
+    assert {r.value for r in Result} == expected
+
+
+def test_actor_subject_default_none() -> None:
+    actor = Actor()
+    assert actor.token_hash is None
+    assert actor.agent is None
+    assert actor.user is None
+    subject = Subject()
+    assert subject.zone is None
+    assert subject.extra is None
+
+
+def test_activity_event_minimal_construction() -> None:
+    ev = ActivityEvent(
+        id="01ABCDEFGHJKMNPQRSTVWXYZ00",
+        ts="2026-04-30T12:00:00Z",
+        kind=EventKind.SEARCH,
+        result=Result.OK,
+    )
+    assert ev.kind is EventKind.SEARCH
+    assert ev.result is Result.OK
+    assert ev.actor.token_hash is None
+    assert ev.subject.zone is None
+    assert ev.latency_ms is None
+    assert ev.trace_id is None
+    assert ev.meta is None
+
+
+def test_activity_event_full_construction() -> None:
+    ev = ActivityEvent(
+        id="01ABCDEFGHJKMNPQRSTVWXYZ00",
+        ts="2026-04-30T12:00:00Z",
+        kind=EventKind.MCP_TOOL_CALL,
+        result=Result.OK,
+        latency_ms=42,
+        trace_id="trace-1",
+        actor=Actor(token_hash="abc1234567890def", agent="claude", user="alice"),
+        subject=Subject(zone="eng", extra={"tool": "search"}),
+        meta={"k": "v"},
+    )
+    assert ev.actor.token_hash == "abc1234567890def"
+    assert ev.subject.extra == {"tool": "search"}
+    assert ev.meta == {"k": "v"}
+
+
+def test_activity_event_is_frozen() -> None:
+    import dataclasses
+
+    ev = ActivityEvent(
+        id="x", ts="t", kind=EventKind.SEARCH, result=Result.OK,
+    )
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        ev.kind = EventKind.FETCH  # type: ignore[misc]
+
+
+import pytest  # noqa: E402  (placed late so the FrozenInstanceError test reads naturally)
+```
+
+`tests/unit/services/activity/__init__.py`:
+
+```python
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/services/activity/test_events.py -v`
+Expected: FAIL — module `nexus.services.activity.events` not found.
+
+- [ ] **Step 3: Implement events module**
+
+`src/nexus/services/activity/events.py`:
+
+```python
+"""ActivityEvent schema for issue #3791 foundation slice.
+
+Frozen dataclasses + enums. No I/O, no side effects — safe to import from
+any layer. ``actor.token_hash`` is the SHA256[:16] of the raw bearer token
+(matches ``bricks/mcp/middleware_audit.py``); raw tokens are NEVER stored.
+"""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class EventKind(str, enum.Enum):
+    SEARCH = "search"
+    FETCH = "fetch"
+    MCP_TOOL_CALL = "mcp_tool_call"
+    ZONE_ACCESS = "zone_access"
+    POLICY_BLOCK = "policy_block"
+    APPROVAL = "approval"
+
+
+class Result(str, enum.Enum):
+    OK = "ok"
+    BLOCKED = "blocked"
+    PENDING_APPROVAL = "pending_approval"
+
+
+@dataclass(frozen=True, slots=True)
+class Actor:
+    token_hash: str | None = None
+    agent: str | None = None
+    user: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Subject:
+    zone: str | None = None
+    extra: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ActivityEvent:
+    id: str
+    ts: str
+    kind: EventKind
+    result: Result
+    latency_ms: int | None = None
+    trace_id: str | None = None
+    actor: Actor = field(default_factory=Actor)
+    subject: Subject = field(default_factory=Subject)
+    meta: dict[str, Any] | None = None
+```
+
+`src/nexus/services/activity/__init__.py`:
+
+```python
+"""Activity event subsystem (issue #3791 foundation slice).
+
+See ``docs/superpowers/specs/2026-04-30-3791-activity-event-foundation-design.md``.
+"""
+
+from nexus.services.activity.events import (
+    ActivityEvent,
+    Actor,
+    EventKind,
+    Result,
+    Subject,
+)
+
+__all__ = [
+    "ActivityEvent",
+    "Actor",
+    "EventKind",
+    "Result",
+    "Subject",
+]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/services/activity/test_events.py -v`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/services/activity/__init__.py \
+        src/nexus/services/activity/events.py \
+        tests/unit/services/activity/__init__.py \
+        tests/unit/services/activity/test_events.py
+git commit -m "feat(#3791): activity event schema + enums"
+```
+
+---
+
+## Task 2: Emitter interface + NoopEmitter + module-level singleton
+
+**Files:**
+- Create: `src/nexus/services/activity/emitter.py`
+- Modify: `src/nexus/services/activity/__init__.py`
+- Create: `tests/unit/services/activity/test_emitter.py`
+
+- [ ] **Step 1: Write the failing test (NoopEmitter + singleton swap only — QueueEmitter in Task 3)**
+
+`tests/unit/services/activity/test_emitter.py`:
+
+```python
+"""Unit tests for the Emitter singleton and NoopEmitter."""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.services.activity import EventKind, Result, emit, get_emitter, set_emitter
+from nexus.services.activity.emitter import NoopEmitter
+
+
+@pytest.fixture(autouse=True)
+def _restore_emitter():
+    saved = get_emitter()
+    yield
+    set_emitter(saved)
+
+
+def test_default_emitter_is_noop() -> None:
+    assert isinstance(get_emitter(), NoopEmitter)
+
+
+def test_noop_emitter_drops_silently() -> None:
+    emitter = NoopEmitter()
+    # Must not raise, must not return anything observable
+    emitter.emit(
+        kind=EventKind.SEARCH,
+        result=Result.OK,
+        actor_token_hash=None,
+        actor_agent=None,
+        actor_user=None,
+        subject_zone=None,
+        subject_extra=None,
+        latency_ms=None,
+        trace_id=None,
+        meta=None,
+    )
+
+
+def test_set_emitter_swaps_singleton() -> None:
+    custom = NoopEmitter()
+    set_emitter(custom)
+    assert get_emitter() is custom
+
+
+def test_emit_function_calls_current_emitter() -> None:
+    class _Recording(NoopEmitter):
+        def __init__(self) -> None:
+            self.calls: list[tuple] = []
+
+        def emit(self, **kw) -> None:
+            self.calls.append(tuple(kw.items()))
+
+    rec = _Recording()
+    set_emitter(rec)
+    emit(kind=EventKind.SEARCH, result=Result.OK)
+    assert len(rec.calls) == 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/services/activity/test_emitter.py -v`
+Expected: FAIL — `emit`, `get_emitter`, `set_emitter`, `NoopEmitter` not importable.
+
+- [ ] **Step 3: Implement emitter scaffolding**
+
+`src/nexus/services/activity/emitter.py`:
+
+```python
+"""Emitter singleton + NoopEmitter.
+
+``QueueEmitter`` (added in Task 3) is the production implementation that
+batches into the activity queue. ``NoopEmitter`` is the default — installed
+at process import so that any code calling ``emit(...)`` before lifespan
+startup is a safe no-op.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Protocol
+
+from nexus.services.activity.events import EventKind, Result
+
+
+class Emitter(Protocol):
+    """Contract for emitter implementations.
+
+    Implementations MUST NOT raise, MUST NOT block, and SHOULD return in
+    well under 50 µs even at p99.
+    """
+
+    def emit(
+        self,
+        *,
+        kind: EventKind,
+        result: Result,
+        actor_token_hash: str | None = None,
+        actor_agent: str | None = None,
+        actor_user: str | None = None,
+        subject_zone: str | None = None,
+        subject_extra: dict[str, Any] | None = None,
+        latency_ms: int | None = None,
+        trace_id: str | None = None,
+        meta: dict[str, Any] | None = None,
+    ) -> None: ...
+
+
+class NoopEmitter:
+    """Discards every event. Default emitter pre-startup and when disabled."""
+
+    def emit(self, **_: Any) -> None:
+        return None
+
+
+_LOCK = threading.Lock()
+_EMITTER: Emitter = NoopEmitter()
+
+
+def get_emitter() -> Emitter:
+    return _EMITTER
+
+
+def set_emitter(emitter: Emitter) -> None:
+    global _EMITTER
+    with _LOCK:
+        _EMITTER = emitter
+
+
+def emit(
+    *,
+    kind: EventKind,
+    result: Result,
+    actor_token_hash: str | None = None,
+    actor_agent: str | None = None,
+    actor_user: str | None = None,
+    subject_zone: str | None = None,
+    subject_extra: dict[str, Any] | None = None,
+    latency_ms: int | None = None,
+    trace_id: str | None = None,
+    meta: dict[str, Any] | None = None,
+) -> None:
+    """Module-level convenience that delegates to the current emitter."""
+    _EMITTER.emit(
+        kind=kind,
+        result=result,
+        actor_token_hash=actor_token_hash,
+        actor_agent=actor_agent,
+        actor_user=actor_user,
+        subject_zone=subject_zone,
+        subject_extra=subject_extra,
+        latency_ms=latency_ms,
+        trace_id=trace_id,
+        meta=meta,
+    )
+```
+
+`src/nexus/services/activity/__init__.py` — extend re-exports:
+
+```python
+"""Activity event subsystem (issue #3791 foundation slice)."""
+
+from nexus.services.activity.emitter import (
+    Emitter,
+    NoopEmitter,
+    emit,
+    get_emitter,
+    set_emitter,
+)
+from nexus.services.activity.events import (
+    ActivityEvent,
+    Actor,
+    EventKind,
+    Result,
+    Subject,
+)
+
+__all__ = [
+    "ActivityEvent",
+    "Actor",
+    "Emitter",
+    "EventKind",
+    "NoopEmitter",
+    "Result",
+    "Subject",
+    "emit",
+    "get_emitter",
+    "set_emitter",
+]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/services/activity/test_emitter.py -v`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/services/activity/emitter.py \
+        src/nexus/services/activity/__init__.py \
+        tests/unit/services/activity/test_emitter.py
+git commit -m "feat(#3791): activity emitter singleton + NoopEmitter"
+```
+
+---
+
+## Task 3: QueueEmitter with bounded queue + drop counter
+
+**Files:**
+- Modify: `src/nexus/services/activity/emitter.py`
+- Modify: `tests/unit/services/activity/test_emitter.py`
+
+- [ ] **Step 1: Append failing tests for QueueEmitter**
+
+Append to `tests/unit/services/activity/test_emitter.py`:
+
+```python
+import asyncio
+
+from nexus.services.activity.emitter import QueueEmitter
+
+
+def _drain(q: asyncio.Queue) -> list:
+    out = []
+    while not q.empty():
+        out.append(q.get_nowait())
+    return out
+
+
+def test_queue_emitter_enqueues_event() -> None:
+    q: asyncio.Queue = asyncio.Queue(maxsize=10)
+    emitter = QueueEmitter(queue=q)
+    emitter.emit(kind=EventKind.SEARCH, result=Result.OK, subject_zone="eng", latency_ms=5)
+    events = _drain(q)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.kind is EventKind.SEARCH
+    assert ev.subject.zone == "eng"
+    assert ev.latency_ms == 5
+    assert ev.id  # non-empty ULID
+    assert ev.ts  # non-empty ISO ts
+
+
+def test_queue_emitter_drops_on_overflow() -> None:
+    q: asyncio.Queue = asyncio.Queue(maxsize=2)
+    emitter = QueueEmitter(queue=q)
+    emitter.emit(kind=EventKind.SEARCH, result=Result.OK)
+    emitter.emit(kind=EventKind.SEARCH, result=Result.OK)
+    emitter.emit(kind=EventKind.SEARCH, result=Result.OK)  # overflow → drop
+    assert emitter.drop_count == 1
+    assert q.qsize() == 2
+
+
+def test_queue_emitter_never_raises() -> None:
+    q: asyncio.Queue = asyncio.Queue(maxsize=1)
+    emitter = QueueEmitter(queue=q)
+    # Fill the queue, then emit two more — must not raise
+    for _ in range(5):
+        emitter.emit(kind=EventKind.SEARCH, result=Result.OK)
+    assert emitter.drop_count == 4
+
+
+def test_queue_emitter_works_without_running_loop() -> None:
+    """Caller may emit from sync context — put_nowait does not require a loop."""
+    q: asyncio.Queue = asyncio.Queue(maxsize=10)
+    emitter = QueueEmitter(queue=q)
+    emitter.emit(kind=EventKind.SEARCH, result=Result.OK)
+    assert q.qsize() == 1
+
+
+def test_queue_emitter_id_is_unique() -> None:
+    q: asyncio.Queue = asyncio.Queue(maxsize=10)
+    emitter = QueueEmitter(queue=q)
+    for _ in range(5):
+        emitter.emit(kind=EventKind.SEARCH, result=Result.OK)
+    events = _drain(q)
+    assert len({e.id for e in events}) == 5
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `uv run pytest tests/unit/services/activity/test_emitter.py -v -k QueueEmitter`
+Expected: FAIL — `QueueEmitter` not importable.
+
+- [ ] **Step 3: Implement QueueEmitter**
+
+Append to `src/nexus/services/activity/emitter.py`:
+
+```python
+import asyncio
+import time
+import uuid
+from datetime import UTC, datetime
+
+from nexus.services.activity.events import ActivityEvent, Actor, Subject
+
+
+def _new_id() -> str:
+    """Sortable, unique id. Uses ULID-like lexical order: ms timestamp + random.
+
+    Avoids a third-party ULID dep — sortability is sufficient for activity logs.
+    """
+    ms = int(time.time() * 1000)
+    rand = uuid.uuid4().hex[:16]
+    return f"{ms:013d}{rand}"
+
+
+def _now_iso() -> str:
+    return datetime.now(tz=UTC).isoformat(timespec="microseconds")
+
+
+class QueueEmitter:
+    """Production emitter — non-blocking ``put_nowait`` with drop counter.
+
+    Thread-safe: ``asyncio.Queue.put_nowait`` is safe from non-loop threads
+    when only the worker awaits ``get`` on the loop's thread (the typical
+    server layout — Starlette handlers run on the loop thread).
+    """
+
+    def __init__(self, *, queue: asyncio.Queue[ActivityEvent]) -> None:
+        self._queue = queue
+        self._drop_count = 0
+
+    @property
+    def drop_count(self) -> int:
+        return self._drop_count
+
+    def emit(
+        self,
+        *,
+        kind: EventKind,
+        result: Result,
+        actor_token_hash: str | None = None,
+        actor_agent: str | None = None,
+        actor_user: str | None = None,
+        subject_zone: str | None = None,
+        subject_extra: dict[str, Any] | None = None,
+        latency_ms: int | None = None,
+        trace_id: str | None = None,
+        meta: dict[str, Any] | None = None,
+    ) -> None:
+        event = ActivityEvent(
+            id=_new_id(),
+            ts=_now_iso(),
+            kind=kind,
+            result=result,
+            latency_ms=latency_ms,
+            trace_id=trace_id,
+            actor=Actor(token_hash=actor_token_hash, agent=actor_agent, user=actor_user),
+            subject=Subject(zone=subject_zone, extra=subject_extra),
+            meta=meta,
+        )
+        try:
+            self._queue.put_nowait(event)
+        except asyncio.QueueFull:
+            self._drop_count += 1
+```
+
+Update `__init__.py` to export `QueueEmitter`:
+
+```python
+from nexus.services.activity.emitter import (
+    Emitter,
+    NoopEmitter,
+    QueueEmitter,
+    emit,
+    get_emitter,
+    set_emitter,
+)
+
+# Add "QueueEmitter" to __all__ alphabetically.
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/services/activity/test_emitter.py -v`
+Expected: PASS, 9 tests total.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/services/activity/emitter.py \
+        src/nexus/services/activity/__init__.py \
+        tests/unit/services/activity/test_emitter.py
+git commit -m "feat(#3791): QueueEmitter with bounded queue and drop counter"
+```
+
+---
+
+## Task 4: Sink protocol + NoopSink + RecordingSink
+
+**Files:**
+- Create: `src/nexus/services/activity/sinks/__init__.py`
+- Create: `src/nexus/services/activity/sinks/protocol.py`
+- Create: `src/nexus/services/activity/sinks/noop.py`
+- Create: `src/nexus/services/activity/sinks/recording.py`
+- Create: `tests/unit/services/activity/test_recording_sink.py`
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/unit/services/activity/test_recording_sink.py`:
+
+```python
+"""Unit tests for sink protocol + NoopSink + RecordingSink."""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.services.activity.events import ActivityEvent, EventKind, Result
+from nexus.services.activity.sinks import NoopSink, RecordingSink
+
+
+def _ev(kind: EventKind = EventKind.SEARCH) -> ActivityEvent:
+    return ActivityEvent(id="x", ts="t", kind=kind, result=Result.OK)
+
+
+@pytest.mark.asyncio
+async def test_noop_sink_accepts_writes() -> None:
+    sink = NoopSink()
+    await sink.write_batch([_ev(), _ev()])
+    await sink.close()
+
+
+@pytest.mark.asyncio
+async def test_recording_sink_collects_events() -> None:
+    sink = RecordingSink()
+    await sink.write_batch([_ev(EventKind.SEARCH), _ev(EventKind.FETCH)])
+    assert len(sink.events) == 2
+    assert sink.events[0].kind is EventKind.SEARCH
+    assert sink.events[1].kind is EventKind.FETCH
+
+
+@pytest.mark.asyncio
+async def test_recording_sink_clear() -> None:
+    sink = RecordingSink()
+    await sink.write_batch([_ev()])
+    sink.clear()
+    assert sink.events == []
+
+
+@pytest.mark.asyncio
+async def test_recording_sink_filter() -> None:
+    sink = RecordingSink()
+    await sink.write_batch([_ev(EventKind.SEARCH), _ev(EventKind.FETCH), _ev(EventKind.SEARCH)])
+    matches = sink.events_of(EventKind.SEARCH)
+    assert len(matches) == 2
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/services/activity/test_recording_sink.py -v`
+Expected: FAIL — `NoopSink`, `RecordingSink` not importable.
+
+- [ ] **Step 3: Implement sinks**
+
+`src/nexus/services/activity/sinks/protocol.py`:
+
+```python
+"""Sink protocol for the activity worker."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol, runtime_checkable
+
+from nexus.services.activity.events import ActivityEvent
+
+
+@runtime_checkable
+class SinkProtocol(Protocol):
+    """Where the ``ActivityWorker`` flushes batches.
+
+    Implementations MUST be safe to call concurrently with ``close``: the
+    worker serializes ``write_batch`` calls but may issue ``close`` from
+    a different task.
+    """
+
+    async def write_batch(self, events: Sequence[ActivityEvent]) -> None: ...
+
+    async def close(self) -> None: ...
+```
+
+`src/nexus/services/activity/sinks/noop.py`:
+
+```python
+"""Noop sink — accepts all writes, persists nothing."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from nexus.services.activity.events import ActivityEvent
+
+
+class NoopSink:
+    async def write_batch(self, events: Sequence[ActivityEvent]) -> None:  # noqa: ARG002
+        return None
+
+    async def close(self) -> None:
+        return None
+```
+
+`src/nexus/services/activity/sinks/recording.py`:
+
+```python
+"""Recording sink — keeps every received event in memory. Tests only."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from nexus.services.activity.events import ActivityEvent, EventKind
+
+
+class RecordingSink:
+    def __init__(self) -> None:
+        self._events: list[ActivityEvent] = []
+
+    @property
+    def events(self) -> list[ActivityEvent]:
+        return list(self._events)
+
+    def clear(self) -> None:
+        self._events.clear()
+
+    def events_of(self, kind: EventKind) -> list[ActivityEvent]:
+        return [e for e in self._events if e.kind is kind]
+
+    async def write_batch(self, events: Sequence[ActivityEvent]) -> None:
+        self._events.extend(events)
+
+    async def close(self) -> None:
+        return None
+```
+
+`src/nexus/services/activity/sinks/__init__.py`:
+
+```python
+from nexus.services.activity.sinks.noop import NoopSink
+from nexus.services.activity.sinks.protocol import SinkProtocol
+from nexus.services.activity.sinks.recording import RecordingSink
+
+__all__ = ["NoopSink", "RecordingSink", "SinkProtocol"]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/services/activity/test_recording_sink.py -v`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/services/activity/sinks/ \
+        tests/unit/services/activity/test_recording_sink.py
+git commit -m "feat(#3791): sink protocol + NoopSink + RecordingSink"
+```
+
+---
+
+## Task 5: SQLiteSink — schema bootstrap, PRAGMAs, batch insert
+
+**Files:**
+- Create: `src/nexus/services/activity/sinks/sqlite.py`
+- Modify: `src/nexus/services/activity/sinks/__init__.py`
+- Create: `tests/unit/services/activity/test_sqlite_sink.py`
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/unit/services/activity/test_sqlite_sink.py`:
+
+```python
+"""Unit tests for SQLiteSink."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from nexus.services.activity.events import ActivityEvent, Actor, EventKind, Result, Subject
+from nexus.services.activity.sinks.sqlite import SQLiteSink
+
+
+@pytest.mark.asyncio
+async def test_schema_bootstrapped_on_open(tmp_path: Path) -> None:
+    db = tmp_path / "activity.db"
+    sink = SQLiteSink(path=db)
+    try:
+        conn = sqlite3.connect(db)
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='activity_events'"
+        )
+        assert cursor.fetchone() is not None
+        # Indexes
+        idx = {row[0] for row in conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='activity_events'"
+        )}
+        assert "idx_ae_ts" in idx
+        assert "idx_ae_kind_ts" in idx
+        assert "idx_ae_token_ts" in idx
+        assert "idx_ae_zone_ts" in idx
+        conn.close()
+    finally:
+        await sink.close()
+
+
+@pytest.mark.asyncio
+async def test_pragmas_applied(tmp_path: Path) -> None:
+    db = tmp_path / "activity.db"
+    sink = SQLiteSink(path=db)
+    try:
+        conn = sqlite3.connect(db)
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+        assert conn.execute("PRAGMA synchronous").fetchone()[0] == 1  # NORMAL
+        conn.close()
+    finally:
+        await sink.close()
+
+
+@pytest.mark.asyncio
+async def test_batch_insert_roundtrip(tmp_path: Path) -> None:
+    db = tmp_path / "activity.db"
+    sink = SQLiteSink(path=db)
+    try:
+        events = [
+            ActivityEvent(
+                id="1", ts="2026-04-30T00:00:00Z", kind=EventKind.SEARCH,
+                result=Result.OK, latency_ms=10, trace_id="t1",
+                actor=Actor(token_hash="aaa", agent="claude", user="alice"),
+                subject=Subject(zone="eng", extra={"q": "foo"}),
+                meta={"x": 1},
+            ),
+            ActivityEvent(
+                id="2", ts="2026-04-30T00:00:01Z", kind=EventKind.MCP_TOOL_CALL,
+                result=Result.OK,
+            ),
+        ]
+        await sink.write_batch(events)
+    finally:
+        await sink.close()
+
+    conn = sqlite3.connect(db)
+    rows = list(conn.execute("SELECT id, kind, result, subject_zone, subject_extra, meta "
+                              "FROM activity_events ORDER BY id"))
+    assert rows[0][0] == "1"
+    assert rows[0][1] == "search"
+    assert rows[0][3] == "eng"
+    assert json.loads(rows[0][4]) == {"q": "foo"}
+    assert json.loads(rows[0][5]) == {"x": 1}
+    assert rows[1][0] == "2"
+    assert rows[1][3] is None
+    assert rows[1][4] is None
+    conn.close()
+
+
+@pytest.mark.asyncio
+async def test_open_idempotent_on_existing_db(tmp_path: Path) -> None:
+    db = tmp_path / "activity.db"
+    sink1 = SQLiteSink(path=db)
+    await sink1.close()
+    # Re-opening the same file must not error.
+    sink2 = SQLiteSink(path=db)
+    await sink2.close()
+
+
+@pytest.mark.asyncio
+async def test_corrupt_file_raises(tmp_path: Path) -> None:
+    db = tmp_path / "activity.db"
+    db.write_bytes(b"not a sqlite file")
+    with pytest.raises(sqlite3.DatabaseError):
+        SQLiteSink(path=db)
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/services/activity/test_sqlite_sink.py -v`
+Expected: FAIL — `SQLiteSink` not importable.
+
+- [ ] **Step 3: Implement SQLiteSink**
+
+`src/nexus/services/activity/sinks/sqlite.py`:
+
+```python
+"""Append-only SQLite sink for activity events.
+
+Single-writer connection (``check_same_thread=False`` to allow the worker
+to await ``write_batch`` while the connection lives on a different thread
+in tests). Caller is the activity worker, which serializes calls.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from collections.abc import Sequence
+from pathlib import Path
+
+from nexus.services.activity.events import ActivityEvent
+
+logger = logging.getLogger(__name__)
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS activity_events (
+    id              TEXT PRIMARY KEY,
+    ts              TEXT NOT NULL,
+    kind            TEXT NOT NULL,
+    result          TEXT NOT NULL,
+    latency_ms      INTEGER,
+    trace_id        TEXT,
+    actor_token_hash TEXT,
+    actor_agent     TEXT,
+    actor_user      TEXT,
+    subject_zone    TEXT,
+    subject_extra   TEXT,
+    meta            TEXT
+) STRICT;
+"""
+
+_INDEXES = (
+    "CREATE INDEX IF NOT EXISTS idx_ae_ts        ON activity_events(ts)",
+    "CREATE INDEX IF NOT EXISTS idx_ae_kind_ts   ON activity_events(kind, ts)",
+    "CREATE INDEX IF NOT EXISTS idx_ae_token_ts  ON activity_events(actor_token_hash, ts)",
+    "CREATE INDEX IF NOT EXISTS idx_ae_zone_ts   ON activity_events(subject_zone, ts)",
+)
+
+_PRAGMAS = (
+    "PRAGMA journal_mode=WAL",
+    "PRAGMA synchronous=NORMAL",
+    "PRAGMA temp_store=MEMORY",
+    "PRAGMA busy_timeout=5000",
+)
+
+
+class SQLiteSink:
+    """Durable append-only sink. Schema bootstrap is idempotent."""
+
+    def __init__(self, *, path: Path | str) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(self._path, check_same_thread=False, isolation_level=None)
+        try:
+            for pragma in _PRAGMAS:
+                self._conn.execute(pragma)
+            self._conn.execute(_SCHEMA)
+            for stmt in _INDEXES:
+                self._conn.execute(stmt)
+        except sqlite3.Error:
+            self._conn.close()
+            raise
+
+    async def write_batch(self, events: Sequence[ActivityEvent]) -> None:
+        if not events:
+            return
+        rows = [
+            (
+                e.id,
+                e.ts,
+                e.kind.value,
+                e.result.value,
+                e.latency_ms,
+                e.trace_id,
+                e.actor.token_hash,
+                e.actor.agent,
+                e.actor.user,
+                e.subject.zone,
+                json.dumps(e.subject.extra) if e.subject.extra is not None else None,
+                json.dumps(e.meta) if e.meta is not None else None,
+            )
+            for e in events
+        ]
+        try:
+            self._conn.executemany(
+                "INSERT OR IGNORE INTO activity_events "
+                "(id, ts, kind, result, latency_ms, trace_id, "
+                " actor_token_hash, actor_agent, actor_user, "
+                " subject_zone, subject_extra, meta) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                rows,
+            )
+        except sqlite3.Error:
+            logger.warning("activity SQLiteSink batch insert failed", exc_info=True)
+            raise
+
+    async def close(self) -> None:
+        try:
+            self._conn.close()
+        except sqlite3.Error:
+            logger.warning("activity SQLiteSink close failed", exc_info=True)
+```
+
+Update `src/nexus/services/activity/sinks/__init__.py`:
+
+```python
+from nexus.services.activity.sinks.noop import NoopSink
+from nexus.services.activity.sinks.protocol import SinkProtocol
+from nexus.services.activity.sinks.recording import RecordingSink
+from nexus.services.activity.sinks.sqlite import SQLiteSink
+
+__all__ = ["NoopSink", "RecordingSink", "SQLiteSink", "SinkProtocol"]
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/services/activity/test_sqlite_sink.py -v`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/services/activity/sinks/sqlite.py \
+        src/nexus/services/activity/sinks/__init__.py \
+        tests/unit/services/activity/test_sqlite_sink.py
+git commit -m "feat(#3791): SQLiteSink with WAL PRAGMAs and indexed schema"
+```
+
+---
+
+## Task 6: ActivityWorker — drain loop with batching/timeout
+
+**Files:**
+- Create: `src/nexus/services/activity/worker.py`
+- Modify: `src/nexus/services/activity/__init__.py`
+- Create: `tests/unit/services/activity/test_worker.py`
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/unit/services/activity/test_worker.py`:
+
+```python
+"""Unit tests for ActivityWorker."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from nexus.services.activity.events import ActivityEvent, EventKind, Result
+from nexus.services.activity.sinks import RecordingSink
+from nexus.services.activity.worker import ActivityWorker
+
+
+def _ev(i: int) -> ActivityEvent:
+    return ActivityEvent(id=str(i), ts=f"t{i}", kind=EventKind.SEARCH, result=Result.OK)
+
+
+@pytest.mark.asyncio
+async def test_drains_queue_to_sink() -> None:
+    queue: asyncio.Queue[ActivityEvent] = asyncio.Queue()
+    sink = RecordingSink()
+    worker = ActivityWorker(queue=queue, sinks=[sink], batch_size=10, batch_timeout_s=0.01)
+    await worker.start()
+    for i in range(5):
+        queue.put_nowait(_ev(i))
+    await asyncio.sleep(0.1)
+    await worker.stop(timeout=1.0)
+    assert len(sink.events) == 5
+
+
+@pytest.mark.asyncio
+async def test_batches_up_to_batch_size() -> None:
+    queue: asyncio.Queue[ActivityEvent] = asyncio.Queue()
+    sink = RecordingSink()
+    write_call_sizes: list[int] = []
+
+    class _CountingSink(RecordingSink):
+        async def write_batch(self, events) -> None:  # type: ignore[override]
+            write_call_sizes.append(len(events))
+            await super().write_batch(events)
+
+    sink = _CountingSink()
+    worker = ActivityWorker(queue=queue, sinks=[sink], batch_size=3, batch_timeout_s=1.0)
+    await worker.start()
+    for i in range(7):
+        queue.put_nowait(_ev(i))
+    await asyncio.sleep(0.1)
+    await worker.stop(timeout=1.0)
+    # Expect 2 batches of 3 + 1 flush of 1 (or any chunking that respects batch_size <= 3)
+    assert all(s <= 3 for s in write_call_sizes)
+    assert sum(write_call_sizes) == 7
+
+
+@pytest.mark.asyncio
+async def test_flushes_partial_batch_on_timeout() -> None:
+    queue: asyncio.Queue[ActivityEvent] = asyncio.Queue()
+    sink = RecordingSink()
+    worker = ActivityWorker(queue=queue, sinks=[sink], batch_size=100, batch_timeout_s=0.05)
+    await worker.start()
+    queue.put_nowait(_ev(1))
+    await asyncio.sleep(0.2)  # > batch_timeout
+    assert len(sink.events) == 1
+    await worker.stop(timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_sink_error_isolated() -> None:
+    queue: asyncio.Queue[ActivityEvent] = asyncio.Queue()
+
+    class _Flaky:
+        calls = 0
+
+        async def write_batch(self, events) -> None:
+            type(self).calls += 1
+            raise RuntimeError("boom")
+
+        async def close(self) -> None:
+            return None
+
+    flaky = _Flaky()
+    sink_ok = RecordingSink()
+    worker = ActivityWorker(queue=queue, sinks=[flaky, sink_ok], batch_size=10, batch_timeout_s=0.01)
+    await worker.start()
+    for i in range(3):
+        queue.put_nowait(_ev(i))
+    await asyncio.sleep(0.1)
+    await worker.stop(timeout=1.0)
+    # Worker survives; second sink still receives the batch
+    assert _Flaky.calls > 0
+    assert len(sink_ok.events) == 3
+
+
+@pytest.mark.asyncio
+async def test_stop_drains_remaining_queue() -> None:
+    queue: asyncio.Queue[ActivityEvent] = asyncio.Queue()
+    sink = RecordingSink()
+    worker = ActivityWorker(queue=queue, sinks=[sink], batch_size=2, batch_timeout_s=10.0)
+    await worker.start()
+    for i in range(5):
+        queue.put_nowait(_ev(i))
+    await worker.stop(timeout=1.0)
+    assert len(sink.events) == 5
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/services/activity/test_worker.py -v`
+Expected: FAIL — `ActivityWorker` not importable.
+
+- [ ] **Step 3: Implement worker**
+
+`src/nexus/services/activity/worker.py`:
+
+```python
+"""Background worker that drains the activity queue into sinks."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Sequence
+
+from nexus.services.activity.events import ActivityEvent
+from nexus.services.activity.sinks.protocol import SinkProtocol
+
+logger = logging.getLogger(__name__)
+
+
+class ActivityWorker:
+    """Drain ``queue`` into ``sinks`` with batching/timeout.
+
+    Lifecycle:
+    - ``start()`` creates the consumer asyncio.Task.
+    - ``stop(timeout)`` signals shutdown, drains pending events, awaits exit.
+    """
+
+    def __init__(
+        self,
+        *,
+        queue: asyncio.Queue[ActivityEvent],
+        sinks: Sequence[SinkProtocol],
+        batch_size: int = 200,
+        batch_timeout_s: float = 0.5,
+    ) -> None:
+        self._queue = queue
+        self._sinks = list(sinks)
+        self._batch_size = batch_size
+        self._batch_timeout_s = batch_timeout_s
+        self._stopping = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
+        self._stopping.clear()
+        self._task = asyncio.create_task(self._consume())
+
+    async def stop(self, *, timeout: float = 5.0) -> None:
+        self._stopping.set()
+        if self._task is None:
+            return
+        try:
+            await asyncio.wait_for(self._task, timeout=timeout)
+        except TimeoutError:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+        self._task = None
+        for sink in self._sinks:
+            with contextlib.suppress(Exception):
+                await sink.close()
+
+    async def _consume(self) -> None:
+        while not self._stopping.is_set():
+            batch = await self._collect_batch()
+            if batch:
+                await self._flush(batch)
+        # Drain remaining events once stopping is set.
+        remainder: list[ActivityEvent] = []
+        while not self._queue.empty():
+            try:
+                remainder.append(self._queue.get_nowait())
+            except asyncio.QueueEmpty:
+                break
+            if len(remainder) >= self._batch_size:
+                await self._flush(remainder)
+                remainder = []
+        if remainder:
+            await self._flush(remainder)
+
+    async def _collect_batch(self) -> list[ActivityEvent]:
+        try:
+            first = await asyncio.wait_for(self._queue.get(), timeout=self._batch_timeout_s)
+        except TimeoutError:
+            return []
+        batch = [first]
+        deadline = asyncio.get_event_loop().time() + self._batch_timeout_s
+        while len(batch) < self._batch_size:
+            remaining = deadline - asyncio.get_event_loop().time()
+            if remaining <= 0:
+                break
+            try:
+                batch.append(await asyncio.wait_for(self._queue.get(), timeout=remaining))
+            except TimeoutError:
+                break
+        return batch
+
+    async def _flush(self, batch: list[ActivityEvent]) -> None:
+        for sink in self._sinks:
+            try:
+                await sink.write_batch(batch)
+            except Exception:
+                logger.warning("activity sink %s failed batch write", type(sink).__name__, exc_info=True)
+```
+
+Update `src/nexus/services/activity/__init__.py` re-exports to include `ActivityWorker`:
+
+```python
+from nexus.services.activity.worker import ActivityWorker
+
+# Add "ActivityWorker" to __all__ alphabetically.
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/services/activity/test_worker.py -v`
+Expected: PASS, 5 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/services/activity/worker.py \
+        src/nexus/services/activity/__init__.py \
+        tests/unit/services/activity/test_worker.py
+git commit -m "feat(#3791): ActivityWorker drain loop with batching"
+```
+
+---
+
+## Task 7: RetentionTask — periodic prune
+
+**Files:**
+- Create: `src/nexus/services/activity/retention.py`
+- Create: `tests/unit/services/activity/test_retention.py`
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/unit/services/activity/test_retention.py`:
+
+```python
+"""Unit tests for RetentionTask."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+import pytest
+
+from nexus.services.activity.retention import prune_older_than
+
+
+def _seed(db: Path) -> None:
+    conn = sqlite3.connect(db)
+    conn.execute(
+        """CREATE TABLE activity_events (
+            id TEXT PRIMARY KEY, ts TEXT NOT NULL, kind TEXT, result TEXT,
+            latency_ms INTEGER, trace_id TEXT, actor_token_hash TEXT,
+            actor_agent TEXT, actor_user TEXT, subject_zone TEXT,
+            subject_extra TEXT, meta TEXT
+        ) STRICT"""
+    )
+    now = datetime.now(tz=UTC)
+    rows = [
+        ("old1", (now - timedelta(days=40)).isoformat(), "search", "ok", None, None, None, None, None, None, None, None),
+        ("old2", (now - timedelta(days=31)).isoformat(), "search", "ok", None, None, None, None, None, None, None, None),
+        ("new1", (now - timedelta(days=10)).isoformat(), "search", "ok", None, None, None, None, None, None, None, None),
+        ("new2", now.isoformat(), "search", "ok", None, None, None, None, None, None, None, None),
+    ]
+    conn.executemany(
+        "INSERT INTO activity_events VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)", rows,
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_prune_deletes_rows_older_than_threshold(tmp_path: Path) -> None:
+    db = tmp_path / "activity.db"
+    _seed(db)
+    deleted = prune_older_than(db_path=db, retention_days=30)
+    assert deleted == 2
+    conn = sqlite3.connect(db)
+    remaining = {row[0] for row in conn.execute("SELECT id FROM activity_events")}
+    assert remaining == {"new1", "new2"}
+    conn.close()
+
+
+def test_prune_retention_zero_is_noop(tmp_path: Path) -> None:
+    db = tmp_path / "activity.db"
+    _seed(db)
+    deleted = prune_older_than(db_path=db, retention_days=0)
+    assert deleted == 0
+    conn = sqlite3.connect(db)
+    count = conn.execute("SELECT COUNT(*) FROM activity_events").fetchone()[0]
+    assert count == 4
+    conn.close()
+
+
+def test_prune_handles_missing_db(tmp_path: Path) -> None:
+    db = tmp_path / "missing.db"
+    deleted = prune_older_than(db_path=db, retention_days=30)
+    assert deleted == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/services/activity/test_retention.py -v`
+Expected: FAIL — `prune_older_than` not importable.
+
+- [ ] **Step 3: Implement retention**
+
+`src/nexus/services/activity/retention.py`:
+
+```python
+"""Periodic prune of activity_events older than the retention threshold."""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def prune_older_than(*, db_path: Path | str, retention_days: int) -> int:
+    """Synchronously delete rows older than ``now - retention_days``.
+
+    Returns the number of rows deleted. ``retention_days <= 0`` is a no-op.
+    Missing DB returns 0 silently.
+    """
+    if retention_days <= 0:
+        return 0
+    db = Path(db_path)
+    if not db.exists():
+        return 0
+    threshold = (datetime.now(tz=UTC) - timedelta(days=retention_days)).isoformat()
+    try:
+        conn = sqlite3.connect(db)
+        try:
+            cursor = conn.execute(
+                "DELETE FROM activity_events WHERE ts < ?", (threshold,),
+            )
+            deleted = cursor.rowcount or 0
+            conn.commit()
+            return deleted
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        logger.warning("activity retention prune failed", exc_info=True)
+        return 0
+
+
+class RetentionTask:
+    """Async task wrapping ``prune_older_than`` on a fixed cadence."""
+
+    def __init__(
+        self,
+        *,
+        db_path: Path | str,
+        retention_days: int,
+        interval_s: float = 3600.0,
+    ) -> None:
+        self._db_path = db_path
+        self._retention_days = retention_days
+        self._interval_s = interval_s
+        self._stopping = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+        self._total_pruned = 0
+
+    @property
+    def total_pruned(self) -> int:
+        return self._total_pruned
+
+    async def start(self) -> None:
+        if self._retention_days <= 0:
+            logger.info("activity retention disabled (retention_days=%d)", self._retention_days)
+            return
+        if self._task is not None and not self._task.done():
+            return
+        self._stopping.clear()
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        self._stopping.set()
+        if self._task is not None:
+            self._task.cancel()
+            try:
+                await self._task
+            except (asyncio.CancelledError, Exception):
+                pass
+            self._task = None
+
+    async def _run(self) -> None:
+        while not self._stopping.is_set():
+            try:
+                deleted = await asyncio.to_thread(
+                    prune_older_than,
+                    db_path=self._db_path,
+                    retention_days=self._retention_days,
+                )
+                self._total_pruned += deleted
+            except Exception:
+                logger.warning("activity retention loop tick failed", exc_info=True)
+            try:
+                await asyncio.wait_for(self._stopping.wait(), timeout=self._interval_s)
+            except TimeoutError:
+                continue
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/services/activity/test_retention.py -v`
+Expected: PASS, 3 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/services/activity/retention.py \
+        tests/unit/services/activity/test_retention.py
+git commit -m "feat(#3791): activity retention task"
+```
+
+---
+
+## Task 8: Metrics catalog + inline updates from emit
+
+**Files:**
+- Create: `src/nexus/services/activity/metrics.py`
+- Modify: `src/nexus/services/activity/emitter.py` (call `record_metrics` from `QueueEmitter.emit`)
+- Create: `tests/unit/services/activity/test_metrics.py`
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/unit/services/activity/test_metrics.py`:
+
+```python
+"""Unit tests for the activity metrics catalog."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from prometheus_client import REGISTRY
+
+from nexus.services.activity import EventKind, Result
+from nexus.services.activity.emitter import QueueEmitter
+from nexus.services.activity.metrics import (
+    ACTIVITY_DROPS,
+    APPROVALS_PENDING,
+    MCP_TOOL_CALLS,
+    POLICY_BLOCKS,
+    SEARCH_LATENCY,
+    SEARCH_REQUESTS,
+)
+
+
+def _sample(metric, **labels) -> float:
+    """Return the current value of a Prom metric for the given label set."""
+    for fam in REGISTRY.collect():
+        for s in fam.samples:
+            if s.name.startswith(metric._name) and all(s.labels.get(k) == v for k, v in labels.items()):
+                return s.value
+    return 0.0
+
+
+def test_search_request_increments_counter() -> None:
+    before = _sample(SEARCH_REQUESTS, zone="eng", token_hash="x", status="ok")
+    SEARCH_REQUESTS.labels(zone="eng", token_hash="x", status="ok").inc()
+    after = _sample(SEARCH_REQUESTS, zone="eng", token_hash="x", status="ok")
+    assert after == before + 1
+
+
+def test_search_latency_observed() -> None:
+    SEARCH_LATENCY.labels(zone="eng").observe(0.05)
+
+
+def test_mcp_tool_calls_counter_present() -> None:
+    MCP_TOOL_CALLS.labels(tool="search", status="ok").inc()
+
+
+def test_policy_blocks_counter_present() -> None:
+    POLICY_BLOCKS.labels(kind="zone_access").inc()
+
+
+def test_approvals_pending_gauge_inc_dec_balanced() -> None:
+    APPROVALS_PENDING.inc()
+    APPROVALS_PENDING.dec()
+    # No assertion on absolute value (other tests may have changed it);
+    # this checks the API exists and is usable.
+
+
+def test_activity_drops_counter_present() -> None:
+    ACTIVITY_DROPS.inc()
+
+
+@pytest.mark.asyncio
+async def test_queue_emitter_records_metrics() -> None:
+    q: asyncio.Queue = asyncio.Queue(maxsize=10)
+    emitter = QueueEmitter(queue=q)
+    before_search = _sample(SEARCH_REQUESTS, zone="eng", token_hash="abc", status="ok")
+    emitter.emit(
+        kind=EventKind.SEARCH,
+        result=Result.OK,
+        actor_token_hash="abc",
+        subject_zone="eng",
+        latency_ms=42,
+    )
+    after_search = _sample(SEARCH_REQUESTS, zone="eng", token_hash="abc", status="ok")
+    assert after_search == before_search + 1
+
+
+@pytest.mark.asyncio
+async def test_queue_emitter_drops_increment_drop_metric() -> None:
+    q: asyncio.Queue = asyncio.Queue(maxsize=1)
+    emitter = QueueEmitter(queue=q)
+    before = _sample(ACTIVITY_DROPS)
+    emitter.emit(kind=EventKind.SEARCH, result=Result.OK)
+    emitter.emit(kind=EventKind.SEARCH, result=Result.OK)  # overflow → drop
+    after = _sample(ACTIVITY_DROPS)
+    assert after == before + 1
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/services/activity/test_metrics.py -v`
+Expected: FAIL — `nexus.services.activity.metrics` not found.
+
+- [ ] **Step 3: Implement metrics module**
+
+`src/nexus/services/activity/metrics.py`:
+
+```python
+"""Prometheus metrics catalog for issue #3791 foundation slice.
+
+Registered at import time on the global ``prometheus_client.REGISTRY``.
+``record_metrics(...)`` is invoked from ``QueueEmitter.emit`` so the Prom
+state stays accurate even if the SQLite sink drops batches.
+"""
+
+from __future__ import annotations
+
+from prometheus_client import Counter, Gauge, Histogram
+
+from nexus.services.activity.events import EventKind, Result
+
+# ── Issue's named catalog ─────────────────────────────────────────────────────
+
+SEARCH_REQUESTS = Counter(
+    "nexus_search_requests_total",
+    "Total Nexus search requests",
+    ["zone", "token_hash", "status"],
+)
+
+SEARCH_LATENCY = Histogram(
+    "nexus_search_latency_seconds",
+    "Nexus search request latency in seconds",
+    ["zone"],
+)
+
+MCP_TOOL_CALLS = Counter(
+    "nexus_mcp_tool_calls_total",
+    "Total MCP tool calls dispatched",
+    ["tool", "status"],
+)
+
+POLICY_BLOCKS = Counter(
+    "nexus_policy_blocks_total",
+    "Total ReBAC/zone-access denials",
+    ["kind"],
+)
+
+APPROVALS_PENDING = Gauge(
+    "nexus_approvals_pending",
+    "Number of approval requests currently in PENDING state",
+)
+
+# ── Internal subsystem health ─────────────────────────────────────────────────
+
+ACTIVITY_DROPS = Counter(
+    "nexus_activity_drops_total",
+    "Activity events dropped due to queue overflow",
+)
+
+ACTIVITY_SINK_ERRORS = Counter(
+    "nexus_activity_sink_errors_total",
+    "Activity sink batch-write errors",
+    ["sink"],
+)
+
+ACTIVITY_RETENTION_PRUNED = Counter(
+    "nexus_activity_retention_pruned_total",
+    "Activity events pruned by retention task",
+)
+
+
+def record_metrics(
+    *,
+    kind: EventKind,
+    result: Result,
+    actor_token_hash: str | None,
+    subject_zone: str | None,
+    subject_extra: dict | None,
+    latency_ms: int | None,
+) -> None:
+    """Update the Prom catalog for one emitted event."""
+    zone = subject_zone or "unknown"
+    token = actor_token_hash or "anonymous"
+
+    if kind is EventKind.SEARCH:
+        SEARCH_REQUESTS.labels(zone=zone, token_hash=token, status=result.value).inc()
+        if latency_ms is not None:
+            SEARCH_LATENCY.labels(zone=zone).observe(latency_ms / 1000.0)
+    elif kind is EventKind.MCP_TOOL_CALL:
+        tool = (subject_extra or {}).get("tool", "unknown")
+        MCP_TOOL_CALLS.labels(tool=tool, status=result.value).inc()
+    elif kind in (EventKind.ZONE_ACCESS, EventKind.POLICY_BLOCK):
+        if result is Result.BLOCKED:
+            POLICY_BLOCKS.labels(kind=kind.value).inc()
+    elif kind is EventKind.APPROVAL:
+        if result is Result.PENDING_APPROVAL:
+            APPROVALS_PENDING.inc()
+        else:
+            APPROVALS_PENDING.dec()
+    # FETCH currently has no metric in the catalog.
+```
+
+- [ ] **Step 4: Wire metrics into QueueEmitter**
+
+Modify `src/nexus/services/activity/emitter.py` `QueueEmitter.emit` body — call `record_metrics` BEFORE `put_nowait`, and call `ACTIVITY_DROPS.inc()` on overflow:
+
+Replace the `try / except QueueFull` block with:
+
+```python
+        try:
+            from nexus.services.activity.metrics import ACTIVITY_DROPS, record_metrics
+
+            record_metrics(
+                kind=kind,
+                result=result,
+                actor_token_hash=actor_token_hash,
+                subject_zone=subject_zone,
+                subject_extra=subject_extra,
+                latency_ms=latency_ms,
+            )
+        except Exception:  # metrics must never break the hot path
+            pass
+        try:
+            self._queue.put_nowait(event)
+        except asyncio.QueueFull:
+            self._drop_count += 1
+            try:
+                from nexus.services.activity.metrics import ACTIVITY_DROPS
+
+                ACTIVITY_DROPS.inc()
+            except Exception:
+                pass
+```
+
+(The `from ... import` is intentionally local to avoid metric registration ordering issues during tests that monkey-patch the registry.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `uv run pytest tests/unit/services/activity/test_metrics.py tests/unit/services/activity/test_emitter.py -v`
+Expected: PASS, all green.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/nexus/services/activity/metrics.py \
+        src/nexus/services/activity/emitter.py \
+        tests/unit/services/activity/test_metrics.py
+git commit -m "feat(#3791): activity metrics catalog + emitter wiring"
+```
+
+---
+
+## Task 9: ActivityConfig from environment
+
+**Files:**
+- Create: `src/nexus/services/activity/config.py`
+- Create: `tests/unit/services/activity/test_config.py`
+
+- [ ] **Step 1: Write the failing test**
+
+`tests/unit/services/activity/test_config.py`:
+
+```python
+"""Unit tests for ActivityConfig env parsing."""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.services.activity.config import ActivityConfig
+
+
+def test_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "NEXUS_ACTIVITY_ENABLED",
+        "NEXUS_ACTIVITY_DB_PATH",
+        "NEXUS_ACTIVITY_RETENTION_DAYS",
+        "NEXUS_ACTIVITY_QUEUE_SIZE",
+        "NEXUS_ACTIVITY_BATCH_SIZE",
+        "NEXUS_ACTIVITY_BATCH_TIMEOUT_S",
+        "NEXUS_DATA_DIR",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    cfg = ActivityConfig.from_env()
+    assert cfg.enabled is True
+    assert cfg.retention_days == 30
+    assert cfg.queue_size == 10000
+    assert cfg.batch_size == 200
+    assert cfg.batch_timeout_s == 0.5
+    assert cfg.db_path.name == "activity.db"
+
+
+def test_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEXUS_ACTIVITY_ENABLED", "0")
+    monkeypatch.setenv("NEXUS_ACTIVITY_DB_PATH", "/tmp/activity-test.db")
+    monkeypatch.setenv("NEXUS_ACTIVITY_RETENTION_DAYS", "7")
+    monkeypatch.setenv("NEXUS_ACTIVITY_QUEUE_SIZE", "100")
+    monkeypatch.setenv("NEXUS_ACTIVITY_BATCH_SIZE", "5")
+    monkeypatch.setenv("NEXUS_ACTIVITY_BATCH_TIMEOUT_S", "0.1")
+    cfg = ActivityConfig.from_env()
+    assert cfg.enabled is False
+    assert str(cfg.db_path) == "/tmp/activity-test.db"
+    assert cfg.retention_days == 7
+    assert cfg.queue_size == 100
+    assert cfg.batch_size == 5
+    assert cfg.batch_timeout_s == 0.1
+
+
+def test_invalid_int_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEXUS_ACTIVITY_QUEUE_SIZE", "not-a-number")
+    with pytest.raises(ValueError, match="NEXUS_ACTIVITY_QUEUE_SIZE"):
+        ActivityConfig.from_env()
+
+
+def test_negative_retention_disables(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEXUS_ACTIVITY_RETENTION_DAYS", "0")
+    cfg = ActivityConfig.from_env()
+    assert cfg.retention_days == 0
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `uv run pytest tests/unit/services/activity/test_config.py -v`
+Expected: FAIL — `ActivityConfig` not importable.
+
+- [ ] **Step 3: Implement config**
+
+`src/nexus/services/activity/config.py`:
+
+```python
+"""Env-driven configuration for the activity subsystem."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def _parse_bool(raw: str | None, default: bool) -> bool:
+    if raw is None:
+        return default
+    return raw.strip().lower() not in {"0", "false", "no", "off", ""}
+
+
+def _parse_int(name: str, raw: str | None, default: int) -> int:
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer, got {raw!r}") from exc
+
+
+def _parse_float(name: str, raw: str | None, default: float) -> float:
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be a float, got {raw!r}") from exc
+
+
+@dataclass(frozen=True)
+class ActivityConfig:
+    enabled: bool = True
+    db_path: Path = Path("./activity.db")
+    retention_days: int = 30
+    queue_size: int = 10_000
+    batch_size: int = 200
+    batch_timeout_s: float = 0.5
+
+    @classmethod
+    def from_env(cls) -> ActivityConfig:
+        data_dir = os.environ.get("NEXUS_DATA_DIR", ".")
+        default_db = Path(data_dir) / "activity.db"
+        return cls(
+            enabled=_parse_bool(os.environ.get("NEXUS_ACTIVITY_ENABLED"), True),
+            db_path=Path(os.environ.get("NEXUS_ACTIVITY_DB_PATH", str(default_db))),
+            retention_days=_parse_int(
+                "NEXUS_ACTIVITY_RETENTION_DAYS",
+                os.environ.get("NEXUS_ACTIVITY_RETENTION_DAYS"),
+                30,
+            ),
+            queue_size=_parse_int(
+                "NEXUS_ACTIVITY_QUEUE_SIZE",
+                os.environ.get("NEXUS_ACTIVITY_QUEUE_SIZE"),
+                10_000,
+            ),
+            batch_size=_parse_int(
+                "NEXUS_ACTIVITY_BATCH_SIZE",
+                os.environ.get("NEXUS_ACTIVITY_BATCH_SIZE"),
+                200,
+            ),
+            batch_timeout_s=_parse_float(
+                "NEXUS_ACTIVITY_BATCH_TIMEOUT_S",
+                os.environ.get("NEXUS_ACTIVITY_BATCH_TIMEOUT_S"),
+                0.5,
+            ),
+        )
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `uv run pytest tests/unit/services/activity/test_config.py -v`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/services/activity/config.py \
+        tests/unit/services/activity/test_config.py
+git commit -m "feat(#3791): ActivityConfig env parser"
+```
+
+---
+
+## Task 10: Lifespan setup/shutdown
+
+**Files:**
+- Create: `src/nexus/services/activity/lifespan.py`
+- Modify: `src/nexus/services/activity/__init__.py` (re-export `setup_activity`, `shutdown_activity`)
+
+- [ ] **Step 1: Implement lifespan (no test in this task — covered by integration in Task 18)**
+
+`src/nexus/services/activity/lifespan.py`:
+
+```python
+"""Setup / shutdown hooks for the activity subsystem.
+
+Both functions are synchronous so they can be registered on
+``FunctionPairComponent`` from ``nexus.server.lifespan.observability``.
+The asyncio tasks they spawn require a running event loop — which is
+present because the registry calls them inside ``async def start()``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from nexus.services.activity.config import ActivityConfig
+from nexus.services.activity.emitter import (
+    NoopEmitter,
+    QueueEmitter,
+    set_emitter,
+)
+from nexus.services.activity.events import ActivityEvent
+from nexus.services.activity.retention import RetentionTask
+from nexus.services.activity.sinks import NoopSink, SQLiteSink
+from nexus.services.activity.sinks.protocol import SinkProtocol
+from nexus.services.activity.worker import ActivityWorker
+
+logger = logging.getLogger(__name__)
+
+_STATE: dict[str, object] = {"worker": None, "retention": None, "queue": None}
+
+
+def setup_activity() -> None:
+    """Start activity worker + retention task. Safe to call once per process."""
+    cfg = ActivityConfig.from_env()
+    if not cfg.enabled:
+        set_emitter(NoopEmitter())
+        logger.info("activity subsystem disabled by NEXUS_ACTIVITY_ENABLED=0")
+        return
+
+    queue: asyncio.Queue[ActivityEvent] = asyncio.Queue(maxsize=cfg.queue_size)
+
+    sinks: list[SinkProtocol] = []
+    try:
+        sinks.append(SQLiteSink(path=cfg.db_path))
+        logger.info("activity SQLite sink open at %s", cfg.db_path)
+    except Exception:
+        logger.error(
+            "activity SQLiteSink failed to open at %s — falling back to NoopSink",
+            cfg.db_path, exc_info=True,
+        )
+        sinks.append(NoopSink())
+
+    worker = ActivityWorker(
+        queue=queue,
+        sinks=sinks,
+        batch_size=cfg.batch_size,
+        batch_timeout_s=cfg.batch_timeout_s,
+    )
+    retention = RetentionTask(db_path=cfg.db_path, retention_days=cfg.retention_days)
+
+    loop = asyncio.get_event_loop()
+    loop.create_task(worker.start())
+    loop.create_task(retention.start())
+
+    set_emitter(QueueEmitter(queue=queue))
+
+    _STATE["worker"] = worker
+    _STATE["retention"] = retention
+    _STATE["queue"] = queue
+
+
+def shutdown_activity() -> None:
+    """Stop worker + retention. Safe to call when setup_activity skipped."""
+    set_emitter(NoopEmitter())  # stop accepting new events first
+    worker = _STATE.pop("worker", None)
+    retention = _STATE.pop("retention", None)
+    _STATE.pop("queue", None)
+    loop = asyncio.get_event_loop()
+    if isinstance(worker, ActivityWorker):
+        loop.create_task(worker.stop(timeout=5.0))
+    if isinstance(retention, RetentionTask):
+        loop.create_task(retention.stop())
+```
+
+Update `src/nexus/services/activity/__init__.py`:
+
+```python
+from nexus.services.activity.lifespan import setup_activity, shutdown_activity
+
+# Add "setup_activity", "shutdown_activity" to __all__ alphabetically.
+```
+
+- [ ] **Step 2: Run smoke import**
+
+Run: `uv run python -c "from nexus.services.activity import setup_activity, shutdown_activity"`
+Expected: No output (clean import).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/nexus/services/activity/lifespan.py \
+        src/nexus/services/activity/__init__.py
+git commit -m "feat(#3791): activity lifespan setup/shutdown hooks"
+```
+
+---
+
+## Task 11: Wire activity into observability registry
+
+**Files:**
+- Modify: `src/nexus/server/lifespan/observability.py`
+
+- [ ] **Step 1: Add the entry**
+
+In `_OBSERVABILITY_PROVIDERS`, append after the `prometheus` row:
+
+```python
+_OBSERVABILITY_PROVIDERS: list[tuple[str, str, str, str]] = [
+    ("logging", "nexus.server.logging_config", "configure_logging", "shutdown_logging"),
+    ("otel-tracing", "nexus.server.telemetry", "setup_telemetry", "shutdown_telemetry"),
+    ("sentry", "nexus.server.sentry", "setup_sentry", "shutdown_sentry"),
+    ("pyroscope", "nexus.server.profiling", "setup_profiling", "shutdown_profiling"),
+    ("prometheus", "nexus.server.metrics", "setup_prometheus", "shutdown_prometheus"),
+    ("activity", "nexus.services.activity.lifespan", "setup_activity", "shutdown_activity"),
+]
+```
+
+- [ ] **Step 2: Run smoke server import**
+
+Run: `uv run python -c "from nexus.server.lifespan.observability import create_registry; r = create_registry(); print(sorted(n for n, *_ in r._components))"`
+Expected: List includes `activity`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/nexus/server/lifespan/observability.py
+git commit -m "feat(#3791): register activity in observability lifespan"
+```
+
+---
+
+## Task 12: Emission point — `SearchService.search`
+
+**Files:**
+- Modify: `src/nexus/bricks/search/search_service.py`
+
+The exact instrumentation pattern: wall-clock timing around the public `search` body, build `actor_token_hash` from request context if available (else `None`), emit `EventKind.SEARCH`.
+
+- [ ] **Step 1: Locate `SearchService.search`**
+
+Run: `grep -n "async def search" src/nexus/bricks/search/search_service.py | head -5`
+Expected: lines with `async def search(...)` — note the line number for the public method (the topmost one inside `class SearchService`).
+
+- [ ] **Step 2: Add a thin emission wrapper**
+
+Modify the public `async def search(self, ...)` body. Wrap the existing logic with timing + emit. Concrete pattern (adapt arg names to whatever the current signature uses):
+
+```python
+async def search(self, request, *args, **kwargs):
+    import time as _time
+
+    from nexus.services.activity import EventKind, Result, emit
+
+    _start = _time.monotonic()
+    _zone = getattr(request, "zone_id", None) or getattr(request, "zone", None)
+    _token_hash = getattr(request, "token_hash", None)
+    try:
+        result = await self._do_search(request, *args, **kwargs)  # rename existing body
+    except Exception:
+        emit(
+            kind=EventKind.SEARCH,
+            result=Result.BLOCKED,
+            actor_token_hash=_token_hash,
+            subject_zone=_zone,
+            latency_ms=int((_time.monotonic() - _start) * 1000),
+        )
+        raise
+    emit(
+        kind=EventKind.SEARCH,
+        result=Result.OK,
+        actor_token_hash=_token_hash,
+        subject_zone=_zone,
+        subject_extra={"hits": len(result) if hasattr(result, "__len__") else None},
+        latency_ms=int((_time.monotonic() - _start) * 1000),
+    )
+    return result
+```
+
+If introducing `_do_search` is intrusive, alternative: leave the body in place and put the emit inside a `try/finally` around it, capturing `result` after success. Either works — keep the diff small.
+
+- [ ] **Step 3: Run search tests**
+
+Run: `uv run pytest tests/unit/services/test_search_service.py -v`
+Expected: All existing tests still PASS (emission is additive; default emitter is Noop).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/nexus/bricks/search/search_service.py
+git commit -m "feat(#3791): emit activity events from SearchService.search"
+```
+
+---
+
+## Task 13: Emission point — `FederatedSearch.search`
+
+**Files:**
+- Modify: `src/nexus/bricks/search/federated_search.py`
+
+- [ ] **Step 1: Apply the same wrapper pattern**
+
+Apply the same wall-clock-timing + emit wrapper to `FederatedSearch.search` (line ~438). Same signature pattern; `subject_zone` may be the federation root zone or `"federated"` if there is no single zone.
+
+```python
+async def search(self, request, *args, **kwargs):
+    import time as _time
+
+    from nexus.services.activity import EventKind, Result, emit
+
+    _start = _time.monotonic()
+    _token_hash = getattr(request, "token_hash", None)
+    try:
+        result = await self._do_search_federated(request, *args, **kwargs)
+    except Exception:
+        emit(
+            kind=EventKind.SEARCH,
+            result=Result.BLOCKED,
+            actor_token_hash=_token_hash,
+            subject_zone="federated",
+            latency_ms=int((_time.monotonic() - _start) * 1000),
+        )
+        raise
+    emit(
+        kind=EventKind.SEARCH,
+        result=Result.OK,
+        actor_token_hash=_token_hash,
+        subject_zone="federated",
+        subject_extra={"hits": len(result) if hasattr(result, "__len__") else None},
+        latency_ms=int((_time.monotonic() - _start) * 1000),
+    )
+    return result
+```
+
+- [ ] **Step 2: Run federated search tests**
+
+Run: `uv run pytest tests/integration/services/test_federated_search.py tests/unit/services/test_federated_search.py -v 2>/dev/null || uv run pytest -k federated_search -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/nexus/bricks/search/federated_search.py
+git commit -m "feat(#3791): emit activity events from FederatedSearch.search"
+```
+
+---
+
+## Task 14: Emission point — `RebacChecker.check` deny path
+
+**Files:**
+- Modify: `src/nexus/bricks/rebac/enforcer.py`
+
+- [ ] **Step 1: Locate the deny return path of `RebacChecker.check`**
+
+Run: `grep -n "def check\b\|return False\|return.*Decision\|raise PermissionError" src/nexus/bricks/rebac/enforcer.py | head -20`
+
+- [ ] **Step 2: Emit on deny**
+
+At every deny return point of `check()` (and `_log_bypass_denied`), insert an emit before returning:
+
+```python
+from nexus.services.activity import EventKind, Result, emit
+
+emit(
+    kind=EventKind.ZONE_ACCESS,  # or EventKind.POLICY_BLOCK for bypass-denied
+    result=Result.BLOCKED,
+    actor_token_hash=getattr(context, "token_hash", None),
+    actor_user=getattr(context, "user_id", None),
+    subject_zone=getattr(context, "zone_id", None),
+    subject_extra={"reason": str(reason)} if reason else None,
+)
+```
+
+If `RebacChecker.check` returns a Decision dataclass, gate the emit on `decision.allowed is False`. Inspect the actual function shape and adapt — the goal is one emit per blocked decision.
+
+- [ ] **Step 3: Run rebac tests**
+
+Run: `uv run pytest tests/unit/services/permissions/ -v -k rebac`
+Expected: PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/nexus/bricks/rebac/enforcer.py
+git commit -m "feat(#3791): emit activity events on ReBAC deny"
+```
+
+---
+
+## Task 15: Emission point — `ApprovalService.request_and_wait` + `decide`
+
+**Files:**
+- Modify: `src/nexus/bricks/approvals/service.py`
+
+- [ ] **Step 1: Emit on approval creation**
+
+In `request_and_wait(self, ...)` (line ~211), after the request row is persisted (i.e., the request is officially pending), add:
+
+```python
+from nexus.services.activity import EventKind, Result, emit
+
+emit(
+    kind=EventKind.APPROVAL,
+    result=Result.PENDING_APPROVAL,
+    actor_user=getattr(req, "requester_id", None),
+    subject_zone=getattr(req, "zone_id", None),
+    subject_extra={"request_id": req.request_id, "kind": getattr(req, "kind", None)},
+)
+```
+
+- [ ] **Step 2: Emit on approval decision**
+
+In `decide(self, ...)` (line ~583), after the decision is persisted, add:
+
+```python
+from nexus.services.activity import EventKind, Result, emit
+
+emit(
+    kind=EventKind.APPROVAL,
+    result=Result.OK if decision_value == "approved" else Result.BLOCKED,
+    actor_user=getattr(decision, "decider_id", None),
+    subject_zone=getattr(req, "zone_id", None),
+    subject_extra={"request_id": req.request_id, "decision": decision_value},
+)
+```
+
+(Adapt attribute names to the actual model — current spec asserts existence of `request_id`, `zone_id`, `requester_id`, `decider_id`. If they differ, use whatever is in the model.)
+
+- [ ] **Step 3: Run approval tests**
+
+Run: `uv run pytest tests/unit/services/test_approvals_service.py -v 2>/dev/null || uv run pytest -k approvals -v`
+Expected: PASS. (Pending gauge inc/dec balance is verified in integration test 21.)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/nexus/bricks/approvals/service.py
+git commit -m "feat(#3791): emit activity events from ApprovalService"
+```
+
+---
+
+## Task 16: Emission point — `MCPAuditLogMiddleware`
+
+**Files:**
+- Modify: `src/nexus/bricks/mcp/middleware_audit.py`
+
+- [ ] **Step 1: Add activity emit after the existing audit record**
+
+In `_record_from_scope` after `_emit_stdout_record(record)` and before scheduling `_safe_publish`, add:
+
+```python
+from nexus.services.activity import EventKind, Result, emit
+
+emit(
+    kind=EventKind.MCP_TOOL_CALL,
+    result=Result.OK if 200 <= status < 400 else Result.BLOCKED,
+    actor_token_hash=token_hash,
+    subject_zone=zone_id,
+    subject_extra={"tool": tool_name, "rpc_method": rpc_method},
+    latency_ms=record["latency_ms"],
+    trace_id=None,
+)
+```
+
+The existing stdout/Redis audit code stays untouched.
+
+- [ ] **Step 2: Run MCP audit tests**
+
+Run: `uv run pytest tests/unit/services/ -v -k mcp_audit 2>/dev/null || uv run pytest -k mcp_audit -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add src/nexus/bricks/mcp/middleware_audit.py
+git commit -m "feat(#3791): emit activity events from MCP audit middleware"
+```
+
+---
+
+## Task 17: Integration — emit → SQLite end-to-end
+
+**Files:**
+- Create: `tests/integration/services/activity/__init__.py`
+- Create: `tests/integration/services/activity/test_emit_to_sqlite_e2e.py`
+
+- [ ] **Step 1: Write the test**
+
+`tests/integration/services/activity/__init__.py`:
+
+```python
+```
+
+`tests/integration/services/activity/test_emit_to_sqlite_e2e.py`:
+
+```python
+"""End-to-end: setup_activity → emit → drained to SQLite → queryable."""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from nexus.services.activity import EventKind, Result, emit
+from nexus.services.activity.emitter import NoopEmitter
+from nexus.services.activity.lifespan import setup_activity, shutdown_activity
+
+
+@pytest.mark.asyncio
+async def test_emit_to_sqlite_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = tmp_path / "activity.db"
+    monkeypatch.setenv("NEXUS_ACTIVITY_ENABLED", "1")
+    monkeypatch.setenv("NEXUS_ACTIVITY_DB_PATH", str(db))
+    monkeypatch.setenv("NEXUS_ACTIVITY_RETENTION_DAYS", "0")  # disable prune
+    monkeypatch.setenv("NEXUS_ACTIVITY_QUEUE_SIZE", "1024")
+    monkeypatch.setenv("NEXUS_ACTIVITY_BATCH_SIZE", "10")
+    monkeypatch.setenv("NEXUS_ACTIVITY_BATCH_TIMEOUT_S", "0.01")
+
+    setup_activity()
+    try:
+        for i in range(50):
+            emit(
+                kind=EventKind.SEARCH,
+                result=Result.OK,
+                actor_token_hash=f"tok{i % 3}",
+                subject_zone=f"zone{i % 2}",
+                latency_ms=i,
+            )
+        # Allow the worker to drain.
+        await asyncio.sleep(0.5)
+    finally:
+        shutdown_activity()
+        await asyncio.sleep(0.2)  # let shutdown drain
+
+    conn = sqlite3.connect(db)
+    rows = list(conn.execute("SELECT kind, result, subject_zone FROM activity_events"))
+    conn.close()
+    assert len(rows) == 50
+    assert all(r[0] == "search" and r[1] == "ok" for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_disabled_installs_noop(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEXUS_ACTIVITY_ENABLED", "0")
+    setup_activity()
+    try:
+        from nexus.services.activity import get_emitter
+        assert isinstance(get_emitter(), NoopEmitter)
+    finally:
+        shutdown_activity()
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `uv run pytest tests/integration/services/activity/test_emit_to_sqlite_e2e.py -v`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/services/activity/__init__.py \
+        tests/integration/services/activity/test_emit_to_sqlite_e2e.py
+git commit -m "test(#3791): activity e2e emit-to-sqlite integration"
+```
+
+---
+
+## Task 18: Integration — emission callsites recorded
+
+**Files:**
+- Create: `tests/integration/services/activity/test_emission_callsites.py`
+
+This test wires a `RecordingSink` into a live `QueueEmitter`, invokes each callsite, and asserts events.
+
+- [ ] **Step 1: Write the test**
+
+`tests/integration/services/activity/test_emission_callsites.py`:
+
+```python
+"""Integration: each emission callsite produces the expected event."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from nexus.services.activity import EventKind, Result, set_emitter
+from nexus.services.activity.emitter import QueueEmitter
+from nexus.services.activity.events import ActivityEvent
+from nexus.services.activity.sinks.recording import RecordingSink
+from nexus.services.activity.worker import ActivityWorker
+
+
+@pytest.fixture
+async def recording():
+    queue: asyncio.Queue[ActivityEvent] = asyncio.Queue(maxsize=1024)
+    sink = RecordingSink()
+    worker = ActivityWorker(queue=queue, sinks=[sink], batch_size=10, batch_timeout_s=0.01)
+    await worker.start()
+    set_emitter(QueueEmitter(queue=queue))
+    try:
+        yield sink
+    finally:
+        await worker.stop(timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_search_service_emits(recording: RecordingSink) -> None:
+    """Direct emit instead of full SearchService — that test belongs to the
+    search suite. Here we verify the emission contract holds when
+    SearchService.search calls ``emit(...)`` with the expected fields."""
+    from nexus.services.activity import emit
+
+    emit(
+        kind=EventKind.SEARCH,
+        result=Result.OK,
+        actor_token_hash="tok",
+        subject_zone="eng",
+        latency_ms=12,
+    )
+    await asyncio.sleep(0.1)
+    matches = recording.events_of(EventKind.SEARCH)
+    assert len(matches) == 1
+    assert matches[0].subject.zone == "eng"
+    assert matches[0].latency_ms == 12
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_call_emits(recording: RecordingSink) -> None:
+    from nexus.services.activity import emit
+
+    emit(
+        kind=EventKind.MCP_TOOL_CALL,
+        result=Result.OK,
+        actor_token_hash="tok",
+        subject_extra={"tool": "search", "rpc_method": "tools/call"},
+        latency_ms=8,
+    )
+    await asyncio.sleep(0.1)
+    matches = recording.events_of(EventKind.MCP_TOOL_CALL)
+    assert len(matches) == 1
+
+
+@pytest.mark.asyncio
+async def test_zone_access_block_emits(recording: RecordingSink) -> None:
+    from nexus.services.activity import emit
+
+    emit(
+        kind=EventKind.ZONE_ACCESS,
+        result=Result.BLOCKED,
+        actor_user="alice",
+        subject_zone="legal",
+        subject_extra={"reason": "no_scope"},
+    )
+    await asyncio.sleep(0.1)
+    matches = recording.events_of(EventKind.ZONE_ACCESS)
+    assert len(matches) == 1
+    assert matches[0].result is Result.BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_approval_pending_then_decided(recording: RecordingSink) -> None:
+    from nexus.services.activity import emit
+
+    emit(kind=EventKind.APPROVAL, result=Result.PENDING_APPROVAL, subject_zone="eng",
+         subject_extra={"request_id": "r1"})
+    emit(kind=EventKind.APPROVAL, result=Result.OK, subject_zone="eng",
+         subject_extra={"request_id": "r1", "decision": "approved"})
+    await asyncio.sleep(0.1)
+    matches = recording.events_of(EventKind.APPROVAL)
+    assert len(matches) == 2
+    assert matches[0].result is Result.PENDING_APPROVAL
+    assert matches[1].result is Result.OK
+```
+
+> Why direct emit instead of invoking the full callsite? The instrumented services (`SearchService`, `FederatedSearch`, `RebacChecker`, `ApprovalService`, `MCPAuditLogMiddleware`) have heavy real dependencies (Postgres, raft, MCP server). Their suites are the source of truth for end-to-end behavior; this integration test verifies the **emission → sink** contract that downstream slices rely on.
+
+- [ ] **Step 2: Run the test**
+
+Run: `uv run pytest tests/integration/services/activity/test_emission_callsites.py -v`
+Expected: PASS, 4 tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/services/activity/test_emission_callsites.py
+git commit -m "test(#3791): integration tests for emission callsites"
+```
+
+---
+
+## Task 19: Integration — lifespan supervision
+
+**Files:**
+- Create: `tests/integration/services/activity/test_lifespan_supervision.py`
+
+The observability registry restart-on-crash behavior is owned by `ObservabilityRegistry`; here we just verify our component is wired correctly so that its crash does not abort startup (it's `required=False`).
+
+- [ ] **Step 1: Write the test**
+
+`tests/integration/services/activity/test_lifespan_supervision.py`:
+
+```python
+"""Integration: activity component is wired as optional and survives crashes."""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.server.lifespan.observability import create_registry
+
+
+def test_activity_registered_as_optional() -> None:
+    registry = create_registry()
+    names = [n for n, *_ in registry._components]
+    assert "activity" in names
+    # required tuple is (name, component, required); index 2 is the bool
+    activity_entry = next(t for t in registry._components if t[0] == "activity")
+    assert activity_entry[2] is False  # optional
+
+
+@pytest.mark.asyncio
+async def test_activity_failure_does_not_abort_startup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force setup_activity to raise; registry must continue (component=optional)."""
+    monkeypatch.setenv("NEXUS_ACTIVITY_DB_PATH", "/nonexistent/forbidden/path/activity.db")
+    # SQLiteSink will fail to mkdir — but lifespan logs and falls back to NoopSink,
+    # so setup_activity returns successfully even on this error path.
+    from nexus.services.activity.lifespan import setup_activity, shutdown_activity
+
+    setup_activity()
+    shutdown_activity()
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `uv run pytest tests/integration/services/activity/test_lifespan_supervision.py -v`
+Expected: PASS, 2 tests.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/services/activity/test_lifespan_supervision.py
+git commit -m "test(#3791): integration tests for activity lifespan registration"
+```
+
+---
+
+## Task 20: Integration — `/metrics` endpoint scrape
+
+**Files:**
+- Create: `tests/integration/services/activity/test_metrics_endpoint.py`
+
+- [ ] **Step 1: Write the test**
+
+`tests/integration/services/activity/test_metrics_endpoint.py`:
+
+```python
+"""Integration: activity metrics are exposed at /metrics after emits."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from prometheus_client import generate_latest
+
+from nexus.services.activity import EventKind, Result, emit
+from nexus.services.activity.lifespan import setup_activity, shutdown_activity
+
+
+@pytest.mark.asyncio
+async def test_metrics_exposed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = tmp_path / "activity.db"
+    monkeypatch.setenv("NEXUS_ACTIVITY_ENABLED", "1")
+    monkeypatch.setenv("NEXUS_ACTIVITY_DB_PATH", str(db))
+    monkeypatch.setenv("NEXUS_ACTIVITY_RETENTION_DAYS", "0")
+
+    setup_activity()
+    try:
+        emit(kind=EventKind.SEARCH, result=Result.OK, actor_token_hash="t", subject_zone="eng", latency_ms=5)
+        emit(kind=EventKind.MCP_TOOL_CALL, result=Result.OK, subject_extra={"tool": "search"})
+        emit(kind=EventKind.ZONE_ACCESS, result=Result.BLOCKED, subject_zone="legal")
+        emit(kind=EventKind.APPROVAL, result=Result.PENDING_APPROVAL)
+        await asyncio.sleep(0.2)
+    finally:
+        shutdown_activity()
+        await asyncio.sleep(0.1)
+
+    body = generate_latest().decode()
+    assert "nexus_search_requests_total" in body
+    assert "nexus_search_latency_seconds" in body
+    assert "nexus_mcp_tool_calls_total" in body
+    assert "nexus_policy_blocks_total" in body
+    assert "nexus_approvals_pending" in body
+    assert "nexus_activity_drops_total" in body
+```
+
+- [ ] **Step 2: Run the test**
+
+Run: `uv run pytest tests/integration/services/activity/test_metrics_endpoint.py -v`
+Expected: PASS.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/integration/services/activity/test_metrics_endpoint.py
+git commit -m "test(#3791): integration test for activity metrics endpoint"
+```
+
+---
+
+## Task 21: Bench — emit hot-path latency
+
+**Files:**
+- Create: `benchmarks/activity/__init__.py`
+- Create: `benchmarks/activity/bench_emit.py`
+
+- [ ] **Step 1: Write the bench**
+
+`benchmarks/activity/__init__.py`:
+
+```python
+```
+
+`benchmarks/activity/bench_emit.py`:
+
+```python
+"""Bench: ``emit()`` p50/p99 — must be < 10 µs / < 50 µs respectively."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from nexus.services.activity import EventKind, Result
+from nexus.services.activity.emitter import QueueEmitter
+
+
+@pytest.mark.benchmark(group="activity-emit")
+def test_emit_hot_path(benchmark) -> None:
+    queue: asyncio.Queue = asyncio.Queue(maxsize=10_000)
+    emitter = QueueEmitter(queue=queue)
+
+    def _do_emit() -> None:
+        emitter.emit(
+            kind=EventKind.SEARCH,
+            result=Result.OK,
+            actor_token_hash="abc1234567890def",
+            subject_zone="eng",
+            latency_ms=42,
+        )
+
+    benchmark(_do_emit)
+    stats = benchmark.stats.stats
+    # Loose CI-friendly thresholds (allow noise on shared runners)
+    assert stats.median * 1e6 < 25.0, f"emit p50 {stats.median*1e6:.1f} µs > 25 µs"
+```
+
+- [ ] **Step 2: Run the bench**
+
+Run: `uv run pytest benchmarks/activity/bench_emit.py -v --benchmark-only`
+Expected: Bench runs; assertion on p50 holds.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add benchmarks/activity/__init__.py benchmarks/activity/bench_emit.py
+git commit -m "test(#3791): bench emit hot-path latency"
+```
+
+---
+
+## Task 22: Bench — search overhead with activity ON vs OFF
+
+**Files:**
+- Create: `benchmarks/activity/bench_search_with_activity.py`
+
+This is a **smoke** bench — the real cost is verified inside the SearchService unit suite by asserting `emit()` is called once per search. The bench exercises the wrapper code path.
+
+- [ ] **Step 1: Write the bench**
+
+`benchmarks/activity/bench_search_with_activity.py`:
+
+```python
+"""Bench: confirm activity wrapper does not add measurable overhead.
+
+Synthetic — invokes the emit + timing wrapper around a no-op coroutine
+to isolate activity overhead from real search work.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import time
+
+import pytest
+
+from nexus.services.activity import EventKind, Result, set_emitter
+from nexus.services.activity.emitter import NoopEmitter, QueueEmitter
+from nexus.services.activity.events import ActivityEvent
+
+
+async def _wrapped_search(emit_fn) -> int:
+    start = time.monotonic()
+    # simulated body: do nothing
+    result = 1
+    emit_fn(kind=EventKind.SEARCH, result=Result.OK, latency_ms=int((time.monotonic() - start) * 1000))
+    return result
+
+
+@pytest.mark.benchmark(group="activity-search-overhead")
+def test_search_with_noop_emitter(benchmark) -> None:
+    set_emitter(NoopEmitter())
+    from nexus.services.activity import emit
+
+    def _run() -> None:
+        asyncio.run(_wrapped_search(emit))
+
+    benchmark(_run)
+
+
+@pytest.mark.benchmark(group="activity-search-overhead")
+def test_search_with_queue_emitter(benchmark) -> None:
+    queue: asyncio.Queue[ActivityEvent] = asyncio.Queue(maxsize=10_000)
+    set_emitter(QueueEmitter(queue=queue))
+    from nexus.services.activity import emit
+
+    def _run() -> None:
+        asyncio.run(_wrapped_search(emit))
+
+    benchmark(_run)
+```
+
+- [ ] **Step 2: Run the bench**
+
+Run: `uv run pytest benchmarks/activity/bench_search_with_activity.py -v --benchmark-only`
+Expected: Both benches run; queue-emitter overhead < 50 µs over noop.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add benchmarks/activity/bench_search_with_activity.py
+git commit -m "test(#3791): bench search wrapper overhead"
+```
+
+---
+
+## Task 23: Verification + final commit
+
+**Files:** (none — verification only)
+
+- [ ] **Step 1: Run the full activity test suite**
+
+Run: `uv run pytest tests/unit/services/activity/ tests/integration/services/activity/ -v`
+Expected: All PASS.
+
+- [ ] **Step 2: Run the SearchService + ApprovalService + ReBAC + MCP suites to verify no regressions**
+
+Run: `uv run pytest tests/unit/services/test_search_service.py tests/unit/services/test_approvals_service.py tests/unit/services/permissions/ -v -k 'not slow'`
+Expected: All PASS (or already-failing tests unchanged).
+
+- [ ] **Step 3: Run benches**
+
+Run: `uv run pytest benchmarks/activity/ --benchmark-only -v`
+Expected: All benches run within thresholds.
+
+- [ ] **Step 4: Smoke server start**
+
+Run: `uv run python -c "from nexus.server.lifespan.observability import create_registry; r = create_registry(); print('activity' in [n for n, *_ in r._components])"`
+Expected: `True`.
+
+- [ ] **Step 5: Self-check acceptance criteria from spec**
+
+Confirm each row in the spec's "Acceptance criteria (foundation slice)" section maps to a green test.
+
+- [ ] **Step 6: No final commit needed if previous tasks were committed individually**
+
+Inspect: `git log --oneline | head -25`
+Expected: 22 commits prefixed `feat(#3791):` or `test(#3791):`.

--- a/docs/superpowers/specs/2026-04-30-3791-activity-event-foundation-design.md
+++ b/docs/superpowers/specs/2026-04-30-3791-activity-event-foundation-design.md
@@ -1,0 +1,333 @@
+# Activity Event Foundation — Design Spec (Issue #3791, Foundation Slice)
+
+**Issue:** [#3791 — feat(P3-6): activity event stream + audit log + /metrics](https://github.com/nexi-lab/nexus/issues/3791)
+**Date:** 2026-04-30
+**Scope:** Foundation slice only. TUI (`nexus term`), `nexus logs --follow`, `nexus stats`, hash-chained audit, OTEL exporter — deferred to follow-up specs.
+
+## Context
+
+Issue #3791 calls for first-class server-side observability across hub-mode Nexus deployments: structured activity events, hash-chained audit, Prometheus metrics, operator TUI, and CLI surfaces (`logs`/`audit`/`stats`). With #3784 (hub mode) and #3785 (zone scoping) closed, operators need a way to see who is doing what across many connected agents.
+
+This spec covers the **foundation slice** that everything else consumes — the activity event schema, in-process emitter, durable SQLite sink, and the metrics catalog. Downstream slices (TUI, log/stats CLI, hash-chained audit, OTEL) build on this contract and will be specced separately to avoid churning the schema mid-build.
+
+## Goals (foundation slice)
+
+1. Define a stable `ActivityEvent` schema covering the issue's six event kinds (`search`, `fetch`, `mcp_tool_call`, `zone_access`, `policy_block`, `approval`).
+2. Provide an in-process emission API callable from any Nexus service with no hot-path performance impact.
+3. Persist events to a durable, queryable SQLite store (default sink).
+4. Expose the issue's Prometheus metric catalog at the existing `/metrics` endpoint.
+5. Wire emission at five concrete callsites so downstream slices have real data to consume.
+
+## Non-goals (explicit)
+
+- Operator TUI (`nexus term`) — separate slice.
+- `nexus logs --follow`, `nexus stats` CLI — separate slice (consumers of this sink).
+- Hash-chained tamper-evident audit log + `nexus audit export --from --to` — separate slice. Activity events are observability, not legal record.
+- OTEL/JSONL/webhook sinks — separate slice (multi-sink config schema).
+- `fetch` event kind on the record_store read path — deferred. Fetch via MCP `read_file` tool will be observable as `mcp_tool_call` in foundation; a true `fetch` kind covering kernel-level reads ships with the audit slice.
+- Phase-labelled `nexus_search_latency_seconds{phase=…}` — needs search-internals plumbing; ships with a follow-up slice.
+
+## Survey of existing infra (why this is a new subsystem)
+
+| Module | Purpose | Why not extend |
+|---|---|---|
+| `services/event_bus` + `services/event_log` | FileEvent (FS CRUD) pub/sub + transactional outbox + Kafka/NATS/PubSub exporters | File-op semantics, not search/tool/policy. Different schema, different consumers. |
+| `services/audit_node` + Rust `install_audit_hook` | Kernel-level WAL audit; `/audit/traces/` DT_STREAM raft-replicated, drained into central zone | Wrong layer (sys_write traces, not app ops). Reused later for hash-chained audit slice. |
+| `bricks/mcp/middleware_audit.py` | Per-MCP-HTTP-request audit → stdout JSON + Redis pub `nexus:audit:mcp` + Redis QPS counters | Closest existing surface; foundation extends this middleware to also emit `mcp_tool_call` activity events. Transport-level audit stays in place. |
+| `/metrics` endpoint + `prometheus_client` patterns | Prom exposure, used by auth/sandbox/manifest | Reused — foundation registers new metrics at the same endpoint. |
+
+The activity subsystem is therefore additive: it sits above existing infra, depends only on stdlib + `prometheus_client` + SQLite, and does not touch `event_bus` / `event_log` / `audit_node`.
+
+## Design
+
+### Architecture
+
+```
+        ┌──────────────────── emission callsites ──────────────────────┐
+        │  SearchService.search                                         │
+        │  FederatedSearch.search                                       │
+        │  RebacChecker.check  (deny path)                              │
+        │  ApprovalService.request_and_wait                             │
+        │  MCPAuditLogMiddleware  (per request → mcp_tool_call)         │
+        └──────────────┬────────────────────────────────────────────────┘
+                       │  emit(kind, actor, subject, result, latency_ms, trace_id)
+                       ▼
+        ┌──────────────────────────────────────────────────────────────┐
+        │  nexus.services.activity                                      │
+        │  ┌────────────────┐    ┌──────────────────────┐              │
+        │  │  Emitter       │───▶│  bounded asyncio.Queue│             │
+        │  │  (singleton)   │    │  (default 10k)        │             │
+        │  │  + drop_count  │    └──────────┬───────────┘              │
+        │  │  + prom hooks  │               │ drain                     │
+        │  └────────────────┘               ▼                            │
+        │                          ┌──────────────────┐                 │
+        │                          │  Worker          │                 │
+        │                          │  drain→batch→    │                 │
+        │                          │  sinks.write()   │                 │
+        │                          └──────┬───────────┘                 │
+        │                                 ▼                              │
+        │                          ┌──────────────────┐                 │
+        │                          │  SinkProtocol    │                 │
+        │                          │  └─ SQLiteSink   │ ← default       │
+        │                          │  └─ NoopSink     │ ← tests/disabled│
+        │                          └──────────────────┘                 │
+        │                                                                │
+        │  + RetentionTask (periodic prune > N days)                     │
+        │  + Prom Counters/Histograms updated at emit() callsites        │
+        └────────────────────────────────────────────────────────────────┘
+
+        Lifespan: setup_activity()/shutdown_activity() in
+                  src/nexus/server/lifespan/observability.py
+```
+
+### Module layout
+
+Under `src/nexus/services/activity/`:
+
+| File | Purpose |
+|---|---|
+| `__init__.py` | Public API: `emit`, `get_emitter`, `set_emitter`, `ActivityEvent`, `EventKind`, `Result` |
+| `events.py` | `ActivityEvent` dataclass, `Actor`, `Subject`, enums (`EventKind`, `Result`) |
+| `emitter.py` | `Emitter` interface + `NoopEmitter`; `QueueEmitter` impl with bounded queue and drop counter |
+| `worker.py` | `ActivityWorker` — drain queue, batch insert, pluggable sinks |
+| `sinks/protocol.py` | `SinkProtocol`: `async write_batch(events) -> None`, `async close() -> None` |
+| `sinks/sqlite.py` | `SQLiteSink` — schema bootstrap, batch insert, indexed |
+| `sinks/noop.py` | `NoopSink` for tests / disabled mode |
+| `retention.py` | `RetentionTask` — periodic prune by `ts < now - retention_days` + VACUUM |
+| `metrics.py` | Prom Counter / Histogram / Gauge instances per the catalog below |
+| `config.py` | Env-var parsing → `ActivityConfig` dataclass |
+| `lifespan.py` | `setup_activity(config) -> Emitter`, `shutdown_activity()` |
+
+Tests under `tests/unit/services/activity/` and `tests/integration/services/activity/` (see Testing).
+
+### Public API
+
+```python
+from nexus.services.activity import emit, EventKind, Result
+
+emit(
+    kind=EventKind.SEARCH,
+    actor_token_hash=token_hash,        # 16-char sha256 prefix; never raw token
+    actor_agent="claude-myapp",
+    actor_user="alice",
+    subject_zone="eng",
+    subject_extra={"query_len": 18, "hits": 12},
+    result=Result.OK,
+    latency_ms=42,
+    trace_id="abc123",
+)
+```
+
+`emit()` is non-async, never raises, never blocks. Internally:
+- Builds `ActivityEvent` (ULID id, current UTC ts).
+- Updates the matching Prom metric inline.
+- Calls `queue.put_nowait(event)`; on `QueueFull`, increments `nexus_activity_drops_total` and returns.
+
+Singleton resolution: module-level `_EMITTER` initialized to `NoopEmitter()`; `setup_activity()` swaps in a `QueueEmitter` at server startup. Tests use `set_emitter()` to install `NoopEmitter` (unit) or keep `QueueEmitter` and swap in a `RecordingSink` (integration).
+
+`emit()` works without a running event loop (`queue.put_nowait` is synchronous on `asyncio.Queue`); the worker is the only component that requires the loop.
+
+### Event schema
+
+`ActivityEvent` (frozen dataclass):
+
+| Field | Type | Notes |
+|---|---|---|
+| `id` | `str` | ULID, sortable, unique |
+| `ts` | `str` | ISO-8601 UTC, microsecond precision |
+| `kind` | `EventKind` | `SEARCH` \| `FETCH` \| `MCP_TOOL_CALL` \| `ZONE_ACCESS` \| `POLICY_BLOCK` \| `APPROVAL` |
+| `result` | `Result` | `OK` \| `BLOCKED` \| `PENDING_APPROVAL` |
+| `latency_ms` | `int \| None` | Elapsed since operation start |
+| `trace_id` | `str \| None` | OTEL trace id when available |
+| `actor_token_hash` | `str \| None` | sha256(raw_token)[:16] — matches `MCPAuditLogMiddleware` |
+| `actor_agent` | `str \| None` | Agent name (e.g. `claude-myapp`) |
+| `actor_user` | `str \| None` | Owner user id |
+| `subject_zone` | `str \| None` | Target zone id |
+| `subject_extra` | `dict \| None` | Per-kind: `doc_id`, `tool`, `query`, etc. |
+| `meta` | `dict \| None` | Catch-all for forward-compat fields |
+
+### SQLite schema
+
+```sql
+CREATE TABLE activity_events (
+  id              TEXT PRIMARY KEY,        -- ULID
+  ts              TEXT NOT NULL,           -- ISO-8601 UTC
+  kind            TEXT NOT NULL,
+  result          TEXT NOT NULL,
+  latency_ms      INTEGER,
+  trace_id        TEXT,
+  actor_token_hash TEXT,
+  actor_agent     TEXT,
+  actor_user      TEXT,
+  subject_zone    TEXT,
+  subject_extra   TEXT,                    -- JSON
+  meta            TEXT                     -- JSON
+) STRICT;
+
+CREATE INDEX idx_ae_ts          ON activity_events(ts);
+CREATE INDEX idx_ae_kind_ts     ON activity_events(kind, ts);
+CREATE INDEX idx_ae_token_ts    ON activity_events(actor_token_hash, ts);
+CREATE INDEX idx_ae_zone_ts     ON activity_events(subject_zone, ts);
+```
+
+Open-time PRAGMAs: `journal_mode=WAL`, `synchronous=NORMAL`, `temp_store=MEMORY`, `busy_timeout=5000`.
+
+Schema bootstrap is idempotent (`CREATE TABLE IF NOT EXISTS`, `CREATE INDEX IF NOT EXISTS`). The activity DB is **separate** from the main Nexus DB — no alembic migration needed; lives at `$NEXUS_ACTIVITY_DB_PATH` (default `$NEXUS_DATA_DIR/activity.db`).
+
+### Metrics catalog
+
+Registered at module import (in `metrics.py`) on the global `prometheus_client.REGISTRY`:
+
+| Metric | Type | Labels | Updated at |
+|---|---|---|---|
+| `nexus_search_requests_total` | Counter | `zone`, `token_hash`, `status` | `emit(kind=SEARCH, ...)` |
+| `nexus_search_latency_seconds` | Histogram | `zone` | `emit(kind=SEARCH, ...)` (no phase label in foundation) |
+| `nexus_mcp_tool_calls_total` | Counter | `tool`, `status` | `emit(kind=MCP_TOOL_CALL, ...)` |
+| `nexus_policy_blocks_total` | Counter | `kind` | `emit(kind=ZONE_ACCESS\|POLICY_BLOCK, result=BLOCKED, ...)` |
+| `nexus_approvals_pending` | Gauge | — | `+1` on `emit(kind=APPROVAL, result=PENDING_APPROVAL)`; `-1` when approval decided (also emitted) |
+
+Plus internal subsystem metrics:
+
+| Metric | Type | Purpose |
+|---|---|---|
+| `nexus_activity_drops_total` | Counter | Queue overflow drops; alertable |
+| `nexus_activity_sink_errors_total{sink}` | Counter | Sink write failures |
+| `nexus_activity_sink_status{sink, state}` | Gauge | 1 = healthy, 0 = degraded |
+| `nexus_activity_retention_pruned_total` | Counter | Rows deleted by retention task |
+
+Activity-disabled mode (`NEXUS_ACTIVITY_ENABLED=0`) installs `NoopEmitter`, which skips both queue insertion and metric updates — the catalog ships and unships as a unit.
+
+### Emission callsites (foundation)
+
+| Kind | File / function | Notes |
+|---|---|---|
+| `SEARCH` | `bricks/search/search_service.py:178` `SearchService.search()` and `bricks/search/federated_search.py:438` `FederatedSearch.search()` | Both paths emit; latency = wall time of the public method |
+| `MCP_TOOL_CALL` | `bricks/mcp/middleware_audit.py` `MCPAuditLogMiddleware._record_from_scope` | Adds an `emit()` call alongside existing stdout/Redis records; transport-level audit unchanged |
+| `ZONE_ACCESS` / `POLICY_BLOCK` | `bricks/rebac/enforcer.py:404` `RebacChecker.check()` deny path (and `_log_bypass_denied`) | Single emit at decision point covers both kinds; `kind` label distinguishes |
+| `APPROVAL` | `bricks/approvals/service.py:211` `ApprovalService.request_and_wait()` (creation → `PENDING_APPROVAL`) and `:583` `decide()` (resolution → `OK`/`BLOCKED`) | Two emit points keep the gauge balanced |
+
+`fetch` kind is intentionally not wired in foundation; MCP `read_file` calls show up as `mcp_tool_call` events. A dedicated kernel-read instrumentation lands with the audit slice.
+
+### Configuration (env vars only in foundation, per Q12c)
+
+| Env var | Default | Purpose |
+|---|---|---|
+| `NEXUS_ACTIVITY_ENABLED` | `1` | Master switch; `0` installs NoopEmitter |
+| `NEXUS_ACTIVITY_DB_PATH` | `$NEXUS_DATA_DIR/activity.db` | SQLite file path |
+| `NEXUS_ACTIVITY_RETENTION_DAYS` | `30` | Prune threshold; `0` disables retention task (unbounded growth) |
+| `NEXUS_ACTIVITY_QUEUE_SIZE` | `10000` | Bounded queue capacity |
+| `NEXUS_ACTIVITY_BATCH_SIZE` | `200` | Worker batch size |
+| `NEXUS_ACTIVITY_BATCH_TIMEOUT_S` | `0.5` | Worker batch flush timeout |
+| `NEXUS_ACTIVITY_DROP_ON_OVERFLOW` | `1` | If `0`, callers block on `put` (debug only — violates SLA) |
+
+Multi-sink config (`[activity]` config-file block) lands with the OTEL/JSONL/webhook slice.
+
+### Lifespan integration
+
+Add an entry to `src/nexus/server/lifespan/observability.py`:
+
+```python
+("activity", "nexus.services.activity.lifespan", "setup_activity", "shutdown_activity"),
+```
+
+`setup_activity()`:
+1. Read `ActivityConfig` from env.
+2. If disabled → install `NoopEmitter`, return.
+3. Open SQLite, bootstrap schema with PRAGMAs.
+4. Construct `QueueEmitter`, `ActivityWorker(sinks=[SQLiteSink])`, `RetentionTask`.
+5. Start worker + retention as supervised asyncio tasks (existing supervisor pattern).
+6. `set_emitter(QueueEmitter(...))`.
+
+`shutdown_activity()`:
+1. `set_emitter(NoopEmitter())` (stop accepting new events).
+2. Await worker drain with 5 s timeout.
+3. Cancel retention task.
+4. Close SQLite.
+
+### Error handling
+
+| Failure | Response | Visibility |
+|---|---|---|
+| Queue full | Drop event, `nexus_activity_drops_total += 1`. Never raise to caller. | Metric (alertable) |
+| SQLite write fails | Log warn, `nexus_activity_sink_errors_total{sink="sqlite"} += 1`. Drop the batch (no retry queue — best-effort telemetry). | Metric + log |
+| SQLite file missing/corrupt at startup | Log error, fall back to `NoopSink`. Server continues. | Log + `nexus_activity_sink_status` |
+| Worker task crashes | Lifespan supervisor restarts task with backoff. | Log + restart counter |
+| Retention task fails | Log warn, retry next tick. | Log |
+| Activity disabled | `NoopEmitter` no-ops emit + metrics. | n/a |
+| `emit()` from sync context (no loop) | `queue.put_nowait` is sync-safe; only worker needs the loop. | n/a |
+
+### Performance budget
+
+Hot-path target (issue SLA): no measurable impact on search.
+
+`emit()` cost at SEARCH callsite:
+1. ULID gen — ~500 ns
+2. ActivityEvent dataclass build — ~1 µs
+3. Prom Counter `.labels(...).inc()` — ~3 µs
+4. Prom Histogram `.observe()` — ~3 µs
+5. `queue.put_nowait(event)` — ~1 µs
+
+Total: **<10 µs per emit** vs. typical search 10–100 ms ⇒ ≤0.1% overhead. CI bench gates regressions.
+
+Backpressure stance: drop, never block. Telemetry must not stall the operation.
+
+Crash safety: SQLite WAL fsyncs per commit; crash loses in-flight queued events only (≤10k = ≤MB-scale). Acceptable for telemetry.
+
+## Testing
+
+### Unit (`tests/unit/services/activity/`)
+
+| File | Covers |
+|---|---|
+| `test_emitter.py` | Singleton get/set; NoopEmitter discards; QueueEmitter.put_nowait; drop counter on overflow; set_emitter swap; emit from sync context |
+| `test_events.py` | ActivityEvent serialization roundtrip; enum values match issue schema; subject_extra arbitrary JSON |
+| `test_worker.py` | Drain loop batches up to N; flushes on timeout below batch size; sink exception doesn't kill worker; shutdown drains queue then exits |
+| `test_sqlite_sink.py` | Schema bootstrap idempotent; batch insert; STRICT-mode enforcement; PRAGMAs applied; corrupt-file fallback |
+| `test_retention.py` | Deletes rows older than threshold; retains newer; VACUUM triggered above row threshold; no-op when retention=0 |
+| `test_metrics.py` | Counters/Histogram/Gauge exposed; labels match catalog; `nexus_approvals_pending` inc/dec balanced |
+| `test_config.py` | Env var parsing; defaults; invalid values rejected with clear error |
+
+### Integration (`tests/integration/services/activity/`)
+
+| Test | Covers |
+|---|---|
+| `test_emit_to_sqlite_e2e.py` | `setup_activity()` with tmp DB; emit 1000 events from multiple async tasks; await drain; query DB for counts/contents/indexes |
+| `test_emission_callsites.py` | Wire `RecordingSink`; exercise SearchService.search, FederatedSearch.search, RebacChecker.check deny, ApprovalService.request_and_wait, MCPAuditLogMiddleware → assert expected event recorded |
+| `test_lifespan_supervision.py` | Worker task killed externally; lifespan restarts it; new events still recorded |
+| `test_metrics_endpoint.py` | After emits, scrape `/metrics`; assert all five catalog metrics present with expected labels |
+
+### Perf bench (`benchmarks/activity/`)
+
+| Bench | Target |
+|---|---|
+| `bench_emit.py` | `emit()` p50 < 10 µs / p99 < 50 µs |
+| `bench_search_with_activity.py` | SearchService.search with activity ON vs OFF — overhead < 1 % on p50 |
+
+### Test doubles
+
+`RecordingSink` (in-memory list), `FlakySink` (raises N % of writes), `SlowSink` (sleeps in `write_batch` — exercises queue overflow path).
+
+## Acceptance criteria (foundation slice)
+
+- [ ] `nexus.services.activity` package exists with public API per spec; `emit()` callable from any service; `NoopEmitter` is the default.
+- [ ] `ActivityEvent` schema covers all six event kinds with the fields above.
+- [ ] `SQLiteSink` durably persists batched events to `$NEXUS_ACTIVITY_DB_PATH` with the indexed schema.
+- [ ] `RetentionTask` prunes rows older than `NEXUS_ACTIVITY_RETENTION_DAYS`.
+- [ ] All five issue-named metrics exposed at `/metrics` with labels per the catalog.
+- [ ] Five emission callsites wired (SearchService, FederatedSearch, RebacChecker deny, ApprovalService create+decide, MCPAuditLogMiddleware).
+- [ ] `emit()` p50 < 10 µs / p99 < 50 µs (CI bench enforced).
+- [ ] No measurable impact on SearchService.search p50 (CI bench enforced).
+- [ ] `NEXUS_ACTIVITY_ENABLED=0` installs NoopEmitter cleanly with no leftover prom registrations.
+- [ ] Lifespan supervisor restarts the worker on crash.
+
+## Out-of-slice (tracked for follow-ups)
+
+| Item | Slice |
+|---|---|
+| `nexus term` operator TUI | Slice 2 (consumer of activity sink) |
+| `nexus logs --follow [--sandbox]` | Slice 2 |
+| `nexus stats` summary | Slice 2 |
+| Hash-chained tamper-evident audit + `nexus audit export --from --to` | Slice 3 (independent; builds on `audit_node` + this sink) |
+| `fetch` kind on kernel read path | Slice 3 |
+| Phase-labelled `nexus_search_latency_seconds{phase}` | Slice 4 |
+| OTEL / JSONL / webhook sinks + multi-sink config block | Slice 5 |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -898,6 +898,7 @@ ignore = [
 "src/nexus/raft/__init__.py" = ["E402"]  # Conditional imports require try/except after TYPE_CHECKING
 "src/nexus/server/rpc/handlers/filesystem.py" = ["ARG001"]  # Handler signature requires context param
 "src/nexus/storage/raft_metadata_store.py" = ["ARG002", "SIM105", "SIM108", "SIM102"]  # Interface + datetime parsing + style
+"src/nexus/services/activity/emitter.py" = ["ARG002"]  # NoopEmitter discards all args — full typed signature required by Emitter Protocol
 "scripts/*.py" = ["ARG001"]  # Utility scripts
 
 [tool.ruff.lint.isort]

--- a/src/nexus/bricks/approvals/repository.py
+++ b/src/nexus/bricks/approvals/repository.py
@@ -11,7 +11,7 @@ from __future__ import annotations
 from datetime import datetime
 from typing import Any
 
-from sqlalchemy import insert, select, text, update
+from sqlalchemy import func, insert, select, text, update
 from sqlalchemy.dialects.postgresql import insert as pg_insert
 from sqlalchemy.ext.asyncio import AsyncSession, async_sessionmaker
 
@@ -148,6 +148,23 @@ class ApprovalRepository:
                 stmt = stmt.where(ApprovalRequestModel.zone_id == zone_id)
             rows = (await session.execute(stmt)).scalars().all()
             return [_to_domain(r) for r in rows]
+
+    async def count_pending(self, zone_id: str | None = None) -> int:
+        """Return PENDING row count without materializing the rows.
+
+        Used by the activity gauge reseed (#3791) to keep
+        APPROVALS_PENDING authoritative without scanning every row on
+        every transition.
+        """
+        async with self._session_factory() as session:
+            stmt = (
+                select(func.count())
+                .select_from(ApprovalRequestModel)
+                .where(ApprovalRequestModel.status == ApprovalRequestStatus.PENDING.value)
+            )
+            if zone_id is not None:
+                stmt = stmt.where(ApprovalRequestModel.zone_id == zone_id)
+            return int((await session.execute(stmt)).scalar_one())
 
     async def transition(
         self,

--- a/src/nexus/bricks/approvals/service.py
+++ b/src/nexus/bricks/approvals/service.py
@@ -28,6 +28,7 @@ from nexus.bricks.approvals.models import (
 )
 from nexus.bricks.approvals.repository import ApprovalRepository
 from nexus.bricks.approvals.sweeper import Sweeper
+from nexus.services.activity import EventKind, Result, emit
 
 logger = logging.getLogger(__name__)
 
@@ -347,6 +348,22 @@ class ApprovalService:
                 )
             except Exception:
                 logger.warning("notify(approvals_new) failed; queue still durable", exc_info=True)
+
+            # Activity event (#3791): mark a fresh pending row queued so the
+            # APPROVALS_PENDING gauge increments. Only emitted when the row
+            # was newly inserted (not coalesced) and inheritance did not
+            # short-circuit it — those paths do not generate operator wait.
+            emit(
+                kind=EventKind.APPROVAL,
+                result=Result.PENDING_APPROVAL,
+                actor_user=getattr(req, "agent_id", None),
+                subject_zone=getattr(req, "zone_id", None),
+                subject_extra={
+                    "request_id": getattr(req, "id", None),
+                    "kind": getattr(getattr(req, "kind", None), "value", None)
+                    or getattr(req, "kind", None),
+                },
+            )
 
         fut = self._dispatcher.register(req.id, session_id=session_id)
 
@@ -686,6 +703,23 @@ class ApprovalService:
                 request_id,
                 exc_info=True,
             )
+
+        # Activity event (#3791): pair the pending emit with a terminal
+        # resolution emit so the APPROVALS_PENDING gauge decrements. The
+        # paired emit is only fired by the worker that calls ``decide``
+        # — sweeper-driven expiry and inherited-decision paths bypass
+        # this method (see service docstring / report).
+        decision_value = decision.value  # "approved" | "denied"
+        emit(
+            kind=EventKind.APPROVAL,
+            result=Result.OK if decision_value == "approved" else Result.BLOCKED,
+            actor_user=decided_by,
+            subject_zone=getattr(updated, "zone_id", None),
+            subject_extra={
+                "request_id": getattr(updated, "id", None) or request_id,
+                "decision": decision_value,
+            },
+        )
 
         return updated
 

--- a/src/nexus/bricks/approvals/service.py
+++ b/src/nexus/bricks/approvals/service.py
@@ -28,7 +28,12 @@ from nexus.bricks.approvals.models import (
 )
 from nexus.bricks.approvals.repository import ApprovalRepository
 from nexus.bricks.approvals.sweeper import Sweeper
-from nexus.services.activity import EventKind, Result, emit
+from nexus.contracts.protocols.activity import (
+    EventKind,
+    Result,
+    emit,
+    reseed_approvals_pending,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -136,6 +141,21 @@ class ApprovalService:
         """Public accessor — used by PolicyGate (Task 13) for session_allow."""
         return self._repo
 
+    async def _reseed_pending_gauge(self) -> None:
+        """Reseed the APPROVALS_PENDING gauge from durable state.
+
+        Called at every transition (create / decide / expire / cross-worker
+        NOTIFY / reconcile) so each process's /metrics matches the current
+        database row count. Uses an indexed COUNT(*) instead of materializing
+        rows so this stays O(1) regardless of pending queue depth.
+        Best-effort: telemetry must never break the approval flow.
+        """
+        try:
+            count = await self._repo.count_pending()
+            reseed_approvals_pending(count)
+        except Exception:
+            logger.debug("approvals: APPROVALS_PENDING reseed failed", exc_info=True)
+
     # ------------------------------------------------------------------
     # Lifecycle
     # ------------------------------------------------------------------
@@ -156,6 +176,11 @@ class ApprovalService:
             on_reconnect=self.reconcile_in_flight,
         )
         await self._sweeper.start()
+        # Activity gauge (#3791): seed APPROVALS_PENDING from durable state
+        # so /metrics reflects the live row count from the moment the
+        # service starts. Subsequent reseeds at every transition keep the
+        # gauge authoritative across restarts and cross-worker decisions.
+        await self._reseed_pending_gauge()
         # F3 (#3790): start the reconcile watchdog if configured. The
         # watchdog runs at ``reconcile_interval_seconds`` cadence and
         # makes cross-worker decisions converge even when NOTIFY drops a
@@ -349,10 +374,10 @@ class ApprovalService:
             except Exception:
                 logger.warning("notify(approvals_new) failed; queue still durable", exc_info=True)
 
-            # Activity event (#3791): mark a fresh pending row queued so the
-            # APPROVALS_PENDING gauge increments. Only emitted when the row
-            # was newly inserted (not coalesced) and inheritance did not
-            # short-circuit it — those paths do not generate operator wait.
+            # Activity event (#3791): mark a fresh pending row queued so
+            # the audit stream records operator wait. Only emitted when the
+            # row was newly inserted (not coalesced) and inheritance did
+            # not short-circuit it.
             emit(
                 kind=EventKind.APPROVAL,
                 result=Result.PENDING_APPROVAL,
@@ -364,6 +389,7 @@ class ApprovalService:
                     or getattr(req, "kind", None),
                 },
             )
+            await self._reseed_pending_gauge()
 
         fut = self._dispatcher.register(req.id, session_id=session_id)
 
@@ -452,6 +478,22 @@ class ApprovalService:
                 _expired_ok = _expired_row is not None
 
                 if _expired_ok:
+                    # Activity event (#3791): local-timeout path resolved the
+                    # row to EXPIRED — emit the paired terminal event so the
+                    # APPROVALS_PENDING gauge balances against the PENDING
+                    # emit from request_and_wait's insert path.
+                    emit(
+                        kind=EventKind.APPROVAL,
+                        result=Result.BLOCKED,
+                        actor_user="system",
+                        subject_zone=getattr(_expired_row, "zone_id", None),
+                        subject_extra={
+                            "request_id": req.id,
+                            "decision": "expired",
+                            "source": "local_timeout",
+                        },
+                    )
+                    await self._reseed_pending_gauge()
                     # Round-4 (#3790): wake coalesced waiters so they do
                     # not block until the watchdog or their own timeout.
                     # Mirrors ``_on_expired_ids`` but scoped to this row.
@@ -704,11 +746,9 @@ class ApprovalService:
                 exc_info=True,
             )
 
-        # Activity event (#3791): pair the pending emit with a terminal
-        # resolution emit so the APPROVALS_PENDING gauge decrements. The
-        # paired emit is only fired by the worker that calls ``decide``
-        # — sweeper-driven expiry and inherited-decision paths bypass
-        # this method (see service docstring / report).
+        # Activity event (#3791): record the terminal decision in the audit
+        # stream. The APPROVALS_PENDING gauge is reseeded from durable state
+        # immediately after.
         decision_value = decision.value  # "approved" | "denied"
         emit(
             kind=EventKind.APPROVAL,
@@ -720,6 +760,7 @@ class ApprovalService:
                 "decision": decision_value,
             },
         )
+        await self._reseed_pending_gauge()
 
         return updated
 
@@ -786,6 +827,10 @@ class ApprovalService:
                 ApprovalRequestStatus.EXPIRED,
             ):
                 self._dispatcher.resolve(rid, Decision.DENIED)
+        # Activity gauge (#3791): reconcile may have observed cross-worker
+        # transitions. Reseed APPROVALS_PENDING from durable state so the
+        # gauge converges with the database after a missed-NOTIFY recovery.
+        await self._reseed_pending_gauge()
 
     async def watch(self, zone_id: str | None) -> AsyncIterator[WatchEvent]:
         q: asyncio.Queue[WatchEvent] = asyncio.Queue(maxsize=self._cfg.watch_buffer_size)
@@ -813,6 +858,20 @@ class ApprovalService:
         now that we carry the actual zone_id instead of the empty string.
         """
         for rid, zone in rows:
+            # Activity event (#3791): sweeper-driven expiry is a terminal
+            # transition. Emit the paired event so the APPROVALS_PENDING
+            # gauge balances against the PENDING emit from request_and_wait.
+            emit(
+                kind=EventKind.APPROVAL,
+                result=Result.BLOCKED,
+                actor_user="system",
+                subject_zone=zone,
+                subject_extra={
+                    "request_id": rid,
+                    "decision": "expired",
+                    "source": "sweeper",
+                },
+            )
             self._dispatcher.resolve(rid, Decision.DENIED)
             self._broadcast(
                 WatchEvent(type="decided", request_id=rid, zone_id=zone, decision="expired")
@@ -829,6 +888,8 @@ class ApprovalService:
                     zone,
                     exc_info=True,
                 )
+        if rows:
+            await self._reseed_pending_gauge()
 
     # ------------------------------------------------------------------
     # NOTIFY handlers
@@ -853,6 +914,12 @@ class ApprovalService:
         if row is None or row.status is ApprovalRequestStatus.PENDING:
             # No durable terminal decision yet — ignore.
             return
+
+        # Activity gauge (#3791): cross-worker decision — reseed our
+        # local APPROVALS_PENDING from the durable count so this process's
+        # /metrics reflects the post-decision state, not the pre-decision
+        # delta from when we created the row.
+        await self._reseed_pending_gauge()
 
         if row.status is ApprovalRequestStatus.APPROVED:
             decision = Decision.APPROVED

--- a/src/nexus/bricks/mcp/middleware_audit.py
+++ b/src/nexus/bricks/mcp/middleware_audit.py
@@ -13,6 +13,8 @@ from typing import Any
 
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
+from nexus.services.activity import EventKind, Result, emit
+
 logger = logging.getLogger("nexus.mcp.audit")
 
 
@@ -232,6 +234,19 @@ class MCPAuditLogMiddleware:
             _emit_stdout_record(record)
         except Exception:
             logger.warning("audit stdout emit failed", exc_info=True)
+
+        emit(
+            kind=EventKind.MCP_TOOL_CALL,
+            result=Result.OK if 200 <= status < 400 else Result.BLOCKED,
+            actor_token_hash=token_hash,
+            subject_zone=zone_id,
+            subject_extra={
+                "tool": tool_name or rpc_method or "unknown",
+                "rpc_method": rpc_method,
+            },
+            latency_ms=record["latency_ms"],
+            trace_id=None,
+        )
 
         # Schedule fire-and-forget publish and RETAIN the task reference
         # so it isn't garbage-collected mid-flight (asyncio docs warn about this).

--- a/src/nexus/bricks/mcp/middleware_audit.py
+++ b/src/nexus/bricks/mcp/middleware_audit.py
@@ -13,7 +13,7 @@ from typing import Any
 
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
-from nexus.services.activity import EventKind, Result, emit
+from nexus.contracts.protocols.activity import EventKind, Result, emit
 
 logger = logging.getLogger("nexus.mcp.audit")
 

--- a/src/nexus/bricks/rebac/enforcer.py
+++ b/src/nexus/bricks/rebac/enforcer.py
@@ -28,6 +28,7 @@ from nexus.lib.zone_perms_cache import (  # noqa: F401 — re-export
 from nexus.lib.zone_perms_cache import (
     lookup_zone_perms as _lookup_zone_perms,
 )
+from nexus.services.activity import EventKind, Result, emit
 
 
 def check_stale_session(agent_registry: Any, context: OperationContext) -> None:
@@ -457,7 +458,12 @@ class PermissionEnforcer:
                     context, path, permission_str, "admin", "kill_switch_disabled"
                 )
                 # Fall through to ReBAC check instead of denying
-                return self._check_rebac(path, permission, context)
+                _r = self._check_rebac(path, permission, context)
+                if not _r:
+                    self._emit_zone_access_block(
+                        context, path, permission_str, "rebac_deny_after_bypass_disabled"
+                    )
+                return _r
 
             # P0-4: Check path-based allowlist (scoped bypass)
             if self.admin_bypass_paths and not self._path_matches_allowlist(
@@ -467,7 +473,12 @@ class PermissionEnforcer:
                     context, path, permission_str, "admin", "path_not_in_allowlist"
                 )
                 # Fall through to ReBAC check
-                return self._check_rebac(path, permission, context)
+                _r = self._check_rebac(path, permission, context)
+                if not _r:
+                    self._emit_zone_access_block(
+                        context, path, permission_str, "rebac_deny_after_path_not_in_allowlist"
+                    )
+                return _r
 
             # Import AdminCapability here to avoid circular imports
             from nexus.bricks.rebac.permissions_enhanced import AdminCapability
@@ -521,7 +532,12 @@ class PermissionEnforcer:
                     f"missing_capability_{required_capability}",
                 )
                 # Fall through to ReBAC check
-                return self._check_rebac(path, permission, context)
+                _r = self._check_rebac(path, permission, context)
+                if not _r:
+                    self._emit_zone_access_block(
+                        context, path, permission_str, "rebac_deny_after_missing_capability"
+                    )
+                return _r
 
             self._log_bypass(context, path, permission_str, "admin", allowed=True)
             return True
@@ -569,8 +585,15 @@ class PermissionEnforcer:
                 perm_char = "w" if permission == Permission.WRITE else "r"
                 for zone, perms in _effective_zone_perms:
                     if zone == _zp_path_zone:
-                        return perm_char in perms or "x" in perms
+                        if perm_char in perms or "x" in perms:
+                            return True
+                        # Zone in allow-list but lacks the requested perm.
+                        self._emit_zone_access_block(
+                            context, path, permission_str, "zone_perms_insufficient"
+                        )
+                        return False
                 # Zone not in token's allow-list
+                self._emit_zone_access_block(context, path, permission_str, "zone_not_in_allowlist")
                 return False
 
         # Issue #1239: Namespace visibility check (Agent OS Phase 0)
@@ -591,7 +614,11 @@ class PermissionEnforcer:
         check_stale_session(self.agent_registry, context)
 
         # Normal ReBAC check
-        return self._check_rebac(path, permission, context)
+        result = self._check_rebac(path, permission, context)
+        if not result:
+            # Issue #3791: Emit ZONE_ACCESS block for the normal-flow deny.
+            self._emit_zone_access_block(context, path, permission_str, "rebac_deny")
+        return result
 
     def _check_rebac(
         self,
@@ -970,6 +997,28 @@ class PermissionEnforcer:
         reason: str,
     ) -> None:
         """Log denied bypass attempt (P0-4)."""
+        # Issue #3791: Emit activity event for every bypass denial. Done here
+        # (not at every call site) so it covers all paths in `check()` that
+        # funnel through this method. Suppressed so emit failures never break
+        # the enforcement path.
+        import contextlib
+
+        with contextlib.suppress(Exception):
+            emit(
+                kind=EventKind.POLICY_BLOCK,
+                result=Result.BLOCKED,
+                actor_token_hash=getattr(context, "token_hash", None),
+                actor_user=getattr(context, "user_id", None),
+                actor_agent=getattr(context, "agent_id", None),
+                subject_zone=getattr(context, "zone_id", None),
+                subject_extra={
+                    "path": path,
+                    "permission": permission,
+                    "bypass_type": bypass_type,
+                    "reason": reason,
+                },
+            )
+
         if not self.audit_store:
             return
 
@@ -991,6 +1040,37 @@ class PermissionEnforcer:
         )
 
         self.audit_store.log_bypass(entry)
+
+    def _emit_zone_access_block(
+        self,
+        context: OperationContext,
+        path: str,
+        permission: str,
+        reason: str,
+    ) -> None:
+        """Issue #3791: Emit ZONE_ACCESS block event for ReBAC deny.
+
+        Centralized helper so every deny return path in `check()` /
+        `_check_rebac*` can record an activity event without duplicating
+        field extraction. Suppressed so emit failures never break
+        enforcement.
+        """
+        import contextlib
+
+        with contextlib.suppress(Exception):
+            emit(
+                kind=EventKind.ZONE_ACCESS,
+                result=Result.BLOCKED,
+                actor_token_hash=getattr(context, "token_hash", None),
+                actor_user=getattr(context, "user_id", None),
+                actor_agent=getattr(context, "agent_id", None),
+                subject_zone=getattr(context, "zone_id", None),
+                subject_extra={
+                    "path": path,
+                    "permission": permission,
+                    "reason": reason,
+                },
+            )
 
     def _permission_to_string(self, permission: Permission) -> str:
         """Convert Permission enum to string."""

--- a/src/nexus/bricks/rebac/enforcer.py
+++ b/src/nexus/bricks/rebac/enforcer.py
@@ -12,6 +12,7 @@ from typing import TYPE_CHECKING, Any
 from sqlalchemy.exc import OperationalError
 
 from nexus.contracts.constants import ROOT_ZONE_ID, SYSTEM_PATH_PREFIX
+from nexus.contracts.protocols.activity import EventKind, Result, emit
 from nexus.contracts.types import OperationContext, Permission
 
 # Issue #3786: Zone-perms resurrection cache primitives live in
@@ -28,7 +29,6 @@ from nexus.lib.zone_perms_cache import (  # noqa: F401 — re-export
 from nexus.lib.zone_perms_cache import (
     lookup_zone_perms as _lookup_zone_perms,
 )
-from nexus.services.activity import EventKind, Result, emit
 
 
 def check_stale_session(agent_registry: Any, context: OperationContext) -> None:

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -27,6 +27,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from nexus.bricks.search.fusion import rrf_multi_fusion
+from nexus.services.activity import EventKind, Result, emit
 
 logger = logging.getLogger(__name__)
 
@@ -436,6 +437,59 @@ class FederatedSearchDispatcher:
         )
 
     async def search(
+        self,
+        query: str,
+        subject: tuple[str, str],
+        search_type: str = "hybrid",
+        limit: int = 10,
+        path_filter: str | None = None,
+        alpha: float = 0.5,
+        fusion_method: str = "rrf",
+        zone_filter: frozenset[str] | None = None,  # NEW (#3785)
+    ) -> FederatedSearchResponse:
+        """Public federated search entry point with activity-event instrumentation (#3791).
+
+        Wraps :meth:`_search_impl` to record SEARCH events on success and
+        BLOCKED events on exceptions. Wall-clock latency is captured via
+        ``time.monotonic``. ``subject_zone`` is set to ``"federated"``
+        because the call spans zones; ``token_hash`` is not currently
+        extractable from the ``subject`` tuple so it is left as ``None``.
+        """
+        _start = time.monotonic()
+        try:
+            response = await self._search_impl(
+                query=query,
+                subject=subject,
+                search_type=search_type,
+                limit=limit,
+                path_filter=path_filter,
+                alpha=alpha,
+                fusion_method=fusion_method,
+                zone_filter=zone_filter,
+            )
+        except Exception:
+            emit(
+                kind=EventKind.SEARCH,
+                result=Result.BLOCKED,
+                actor_token_hash=None,
+                subject_zone="federated",
+                latency_ms=int((time.monotonic() - _start) * 1000),
+            )
+            raise
+        emit(
+            kind=EventKind.SEARCH,
+            result=Result.OK,
+            actor_token_hash=None,
+            subject_zone="federated",
+            subject_extra={
+                "hits": len(response.results) if hasattr(response, "results") else None,
+                "federated": True,
+            },
+            latency_ms=int((time.monotonic() - _start) * 1000),
+        )
+        return response
+
+    async def _search_impl(
         self,
         query: str,
         subject: tuple[str, str],

--- a/src/nexus/bricks/search/federated_search.py
+++ b/src/nexus/bricks/search/federated_search.py
@@ -27,7 +27,7 @@ from dataclasses import dataclass, field
 from typing import Any
 
 from nexus.bricks.search.fusion import rrf_multi_fusion
-from nexus.services.activity import EventKind, Result, emit
+from nexus.contracts.protocols.activity import EventKind, Result, emit
 
 logger = logging.getLogger(__name__)
 

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -25,6 +25,7 @@ from cachetools import TTLCache
 from nexus.bricks.search.primitives import glob_helpers, trigram_fast
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.exceptions import PermissionDeniedError
+from nexus.contracts.protocols.activity import EventKind, Result, emit
 from nexus.contracts.search_types import (
     GLOB_RUST_THRESHOLD,
     GREP_CACHED_TEXT_RATIO,
@@ -38,7 +39,6 @@ from nexus.contracts.search_types import (
 )
 from nexus.contracts.types import Permission
 from nexus.lib.rpc_decorator import rpc_expose
-from nexus.services.activity import EventKind, Result, emit
 
 # List directory traversal thresholds (Issue #901)
 # Issue #2071: LIST_PARALLEL_WORKERS now sourced from ProfileTuning.search.list_parallel_workers
@@ -3492,6 +3492,60 @@ class SearchService:
 
     @rpc_expose(description="Search documents using natural language queries")
     async def semantic_search(
+        self,
+        query: str,
+        path: str = "/",
+        limit: int = 10,
+        filters: dict[str, Any] | None = None,
+        search_mode: str = "semantic",
+        context: "OperationContext | None" = None,
+    ) -> builtins.list[dict[str, Any]]:
+        """Public semantic-search entry point with activity-event instrumentation (#3791).
+
+        Wraps :meth:`_semantic_search_impl` to record SEARCH events on
+        success and BLOCKED events on exceptions. Mirrors the ``grep``
+        wrapper pattern so all primary SearchService surfaces feed the
+        same activity stream.
+        """
+        _start = time.monotonic()
+        _zone: str | None = None
+        try:
+            _zone, _, _ = self._get_routing_params(context)
+        except Exception:  # pragma: no cover - never fail emit setup
+            _zone = None
+        try:
+            result = await self._semantic_search_impl(
+                query=query,
+                path=path,
+                limit=limit,
+                filters=filters,
+                search_mode=search_mode,
+                context=context,
+            )
+        except Exception:
+            emit(
+                kind=EventKind.SEARCH,
+                result=Result.BLOCKED,
+                actor_token_hash=None,
+                subject_zone=_zone,
+                subject_extra={"mode": search_mode},
+                latency_ms=int((time.monotonic() - _start) * 1000),
+            )
+            raise
+        emit(
+            kind=EventKind.SEARCH,
+            result=Result.OK,
+            actor_token_hash=None,
+            subject_zone=_zone,
+            subject_extra={
+                "mode": search_mode,
+                "hits": len(result) if hasattr(result, "__len__") else None,
+            },
+            latency_ms=int((time.monotonic() - _start) * 1000),
+        )
+        return result
+
+    async def _semantic_search_impl(
         self,
         query: str,
         path: str = "/",

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -38,6 +38,7 @@ from nexus.contracts.search_types import (
 )
 from nexus.contracts.types import Permission
 from nexus.lib.rpc_decorator import rpc_expose
+from nexus.services.activity import EventKind, Result, emit
 
 # List directory traversal thresholds (Issue #901)
 # Issue #2071: LIST_PARALLEL_WORKERS now sourced from ProfileTuning.search.list_parallel_workers
@@ -1883,6 +1884,69 @@ class SearchService:
 
     @rpc_expose(description="Search file contents")
     async def grep(
+        self,
+        pattern: str,
+        path: str = "/",
+        file_pattern: str | None = None,
+        ignore_case: bool = False,
+        max_results: int = 100,
+        search_mode: str = "auto",
+        context: Any = None,
+        before_context: int = 0,
+        after_context: int = 0,
+        invert_match: bool = False,
+        files: builtins.list[str] | None = None,
+        block_type: str | None = None,
+    ) -> builtins.list[dict[str, Any]]:
+        """Public grep entry point with activity-event instrumentation (#3791).
+
+        Wraps :meth:`_grep_impl` to record SEARCH events on success and
+        BLOCKED events on exceptions.  Wall-clock latency is captured.
+        ``zone_id`` is derived from the operation context when available;
+        ``token_hash`` is not currently extractable from the search
+        ``context`` object so it is left as ``None``.
+        """
+        _start = time.monotonic()
+        _zone: str | None = None
+        try:
+            _zone, _, _ = self._get_routing_params(context)
+        except Exception:  # pragma: no cover - never fail emit setup
+            _zone = None
+        try:
+            result = await self._grep_impl(
+                pattern=pattern,
+                path=path,
+                file_pattern=file_pattern,
+                ignore_case=ignore_case,
+                max_results=max_results,
+                search_mode=search_mode,
+                context=context,
+                before_context=before_context,
+                after_context=after_context,
+                invert_match=invert_match,
+                files=files,
+                block_type=block_type,
+            )
+        except Exception:
+            emit(
+                kind=EventKind.SEARCH,
+                result=Result.BLOCKED,
+                actor_token_hash=None,
+                subject_zone=_zone,
+                latency_ms=int((time.monotonic() - _start) * 1000),
+            )
+            raise
+        emit(
+            kind=EventKind.SEARCH,
+            result=Result.OK,
+            actor_token_hash=None,
+            subject_zone=_zone,
+            subject_extra={"hits": len(result) if hasattr(result, "__len__") else None},
+            latency_ms=int((time.monotonic() - _start) * 1000),
+        )
+        return result
+
+    async def _grep_impl(
         self,
         pattern: str,
         path: str = "/",

--- a/src/nexus/contracts/protocols/activity.py
+++ b/src/nexus/contracts/protocols/activity.py
@@ -1,0 +1,148 @@
+"""Brick-facing emit API for the activity subsystem (issue #3791).
+
+Bricks call ``emit(...)`` from this module. The implementation registered
+via ``set_emitter`` lives in ``nexus.services.activity`` (lifespan owns it),
+but bricks must never import that module — this contract is the only
+dependency they need.
+
+Hot-path contract (binds every Emitter implementation):
+- MUST NOT raise.
+- MUST NOT block.
+- SHOULD return well under 50µs at p99.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import threading
+from collections.abc import Callable
+from enum import StrEnum
+from typing import Any, Protocol, runtime_checkable
+
+
+class EventKind(StrEnum):
+    SEARCH = "search"
+    FETCH = "fetch"
+    MCP_TOOL_CALL = "mcp_tool_call"
+    ZONE_ACCESS = "zone_access"
+    POLICY_BLOCK = "policy_block"
+    APPROVAL = "approval"
+
+
+class Result(StrEnum):
+    OK = "ok"
+    BLOCKED = "blocked"
+    PENDING_APPROVAL = "pending_approval"
+
+
+@runtime_checkable
+class Emitter(Protocol):
+    """Contract for emitter implementations."""
+
+    def emit(
+        self,
+        *,
+        kind: EventKind,
+        result: Result,
+        actor_token_hash: str | None = None,
+        actor_agent: str | None = None,
+        actor_user: str | None = None,
+        subject_zone: str | None = None,
+        subject_extra: dict[str, Any] | None = None,
+        latency_ms: int | None = None,
+        trace_id: str | None = None,
+        meta: dict[str, Any] | None = None,
+    ) -> None: ...
+
+
+class NoopEmitter:
+    """Discards every event. Default emitter pre-startup and when disabled."""
+
+    def emit(
+        self,
+        *,
+        kind: EventKind,  # noqa: ARG002
+        result: Result,  # noqa: ARG002
+        actor_token_hash: str | None = None,  # noqa: ARG002
+        actor_agent: str | None = None,  # noqa: ARG002
+        actor_user: str | None = None,  # noqa: ARG002
+        subject_zone: str | None = None,  # noqa: ARG002
+        subject_extra: dict[str, Any] | None = None,  # noqa: ARG002
+        latency_ms: int | None = None,  # noqa: ARG002
+        trace_id: str | None = None,  # noqa: ARG002
+        meta: dict[str, Any] | None = None,  # noqa: ARG002
+    ) -> None:
+        return None
+
+
+_LOCK = threading.Lock()
+_EMITTER: Emitter = NoopEmitter()
+
+
+def get_emitter() -> Emitter:
+    return _EMITTER
+
+
+def set_emitter(emitter: Emitter) -> None:
+    global _EMITTER
+    with _LOCK:
+        _EMITTER = emitter
+
+
+def emit(
+    *,
+    kind: EventKind,
+    result: Result,
+    actor_token_hash: str | None = None,
+    actor_agent: str | None = None,
+    actor_user: str | None = None,
+    subject_zone: str | None = None,
+    subject_extra: dict[str, Any] | None = None,
+    latency_ms: int | None = None,
+    trace_id: str | None = None,
+    meta: dict[str, Any] | None = None,
+) -> None:
+    """Module-level convenience that delegates to the current emitter."""
+    _EMITTER.emit(
+        kind=kind,
+        result=result,
+        actor_token_hash=actor_token_hash,
+        actor_agent=actor_agent,
+        actor_user=actor_user,
+        subject_zone=subject_zone,
+        subject_extra=subject_extra,
+        latency_ms=latency_ms,
+        trace_id=trace_id,
+        meta=meta,
+    )
+
+
+_PendingGaugeSetter = Callable[[int], None]
+_pending_gauge_setter: _PendingGaugeSetter | None = None
+
+
+def register_approvals_pending_gauge(setter: _PendingGaugeSetter) -> None:
+    """Register the gauge setter from the services layer.
+
+    The contracts layer cannot import from nexus.services (architecture
+    boundary). The services activity package calls this at module import
+    time so brick callers can reseed the gauge through ``reseed_approvals_pending``
+    without crossing the boundary.
+    """
+    global _pending_gauge_setter
+    _pending_gauge_setter = setter
+
+
+def reseed_approvals_pending(count: int) -> None:
+    """Reset the APPROVALS_PENDING gauge from durable repository state.
+
+    Bricks call this from ApprovalService at startup and after every
+    transition so the gauge matches the database. No-op until the
+    services layer registers a setter — this is intentional so the
+    contracts module can be loaded standalone without importing services.
+    """
+    if _pending_gauge_setter is None:
+        return
+    # Telemetry must never break the approval flow — swallow any setter error.
+    with contextlib.suppress(Exception):
+        _pending_gauge_setter(count)

--- a/src/nexus/server/lifespan/observability.py
+++ b/src/nexus/server/lifespan/observability.py
@@ -26,6 +26,7 @@ _OBSERVABILITY_PROVIDERS: list[tuple[str, str, str, str]] = [
     ("sentry", "nexus.server.sentry", "setup_sentry", "shutdown_sentry"),
     ("pyroscope", "nexus.server.profiling", "setup_profiling", "shutdown_profiling"),
     ("prometheus", "nexus.server.metrics", "setup_prometheus", "shutdown_prometheus"),
+    ("activity", "nexus.services.activity.lifespan", "setup_activity", "shutdown_activity"),
 ]
 
 

--- a/src/nexus/server/lifespan/observability.py
+++ b/src/nexus/server/lifespan/observability.py
@@ -30,22 +30,30 @@ _OBSERVABILITY_PROVIDERS: list[tuple[str, str, str, str]] = [
 ]
 
 
-def _make_start(mod: str, fn: str) -> Callable[..., None]:
-    """Factory for lazy-import start functions (avoids closure-over-loop-variable bugs)."""
+def _make_start(mod: str, fn: str) -> Callable[..., Any]:
+    """Factory for lazy-import start functions (avoids closure-over-loop-variable bugs).
 
-    def _start(**kwargs: Any) -> None:
+    Returns the invocation result so async providers (whose setup_fn is a
+    coroutine function) propagate the awaitable up to FunctionPairComponent.
+    """
+
+    def _start(**kwargs: Any) -> Any:
         module = importlib.import_module(mod)
-        getattr(module, fn)(**kwargs)
+        return getattr(module, fn)(**kwargs)
 
     return _start
 
 
-def _make_stop(mod: str, fn: str) -> Callable[[], None]:
-    """Factory for lazy-import stop functions (avoids closure-over-loop-variable bugs)."""
+def _make_stop(mod: str, fn: str) -> Callable[[], Any]:
+    """Factory for lazy-import stop functions (avoids closure-over-loop-variable bugs).
 
-    def _stop() -> None:
+    Returns the invocation result so async providers' shutdown coroutines are
+    awaited by FunctionPairComponent rather than silently discarded.
+    """
+
+    def _stop() -> Any:
         module = importlib.import_module(mod)
-        getattr(module, fn)()
+        return getattr(module, fn)()
 
     return _stop
 

--- a/src/nexus/server/observability/components.py
+++ b/src/nexus/server/observability/components.py
@@ -7,6 +7,7 @@ FunctionPairComponent replaces 5 near-identical adapter classes with a
 single generic class parameterized by start/shutdown callables.
 """
 
+import inspect
 import logging
 from collections.abc import Callable
 from typing import TYPE_CHECKING, Any
@@ -25,8 +26,11 @@ class FunctionPairComponent:
 
     Args:
         component_name: Human-readable name for logging.
-        start_fn: Callable invoked during ``start()``.
-        stop_fn: Optional callable invoked during ``shutdown()``.
+        start_fn: Callable invoked during ``start()``. May be sync or async;
+            an awaitable return value is awaited so providers can perform
+            real async setup (e.g. await a worker's start coroutine).
+        stop_fn: Optional callable invoked during ``shutdown()``. May be sync
+            or async — see ``start_fn``.
         start_kwargs: Keyword arguments forwarded to ``start_fn``.
     """
 
@@ -49,7 +53,9 @@ class FunctionPairComponent:
         return self._name
 
     async def start(self) -> None:
-        self._start_fn(**self._start_kwargs)
+        result = self._start_fn(**self._start_kwargs)
+        if inspect.isawaitable(result):
+            await result
         self._started = True
 
     async def shutdown(self, timeout_ms: int = 5000) -> None:  # noqa: ARG002
@@ -57,7 +63,9 @@ class FunctionPairComponent:
             return
         if self._stop_fn is not None:
             try:
-                self._stop_fn()
+                result = self._stop_fn()
+                if inspect.isawaitable(result):
+                    await result
             except Exception:
                 logger.warning("Error in %s shutdown", self._name, exc_info=True)
         self._started = False

--- a/src/nexus/services/activity/__init__.py
+++ b/src/nexus/services/activity/__init__.py
@@ -3,6 +3,13 @@
 See ``docs/superpowers/specs/2026-04-30-3791-activity-event-foundation-design.md``.
 """
 
+from nexus.services.activity.emitter import (
+    Emitter,
+    NoopEmitter,
+    emit,
+    get_emitter,
+    set_emitter,
+)
 from nexus.services.activity.events import (
     ActivityEvent,
     Actor,
@@ -14,7 +21,12 @@ from nexus.services.activity.events import (
 __all__ = [
     "ActivityEvent",
     "Actor",
+    "Emitter",
     "EventKind",
+    "NoopEmitter",
     "Result",
     "Subject",
+    "emit",
+    "get_emitter",
+    "set_emitter",
 ]

--- a/src/nexus/services/activity/__init__.py
+++ b/src/nexus/services/activity/__init__.py
@@ -6,6 +6,7 @@ See ``docs/superpowers/specs/2026-04-30-3791-activity-event-foundation-design.md
 from nexus.services.activity.emitter import (
     Emitter,
     NoopEmitter,
+    QueueEmitter,
     emit,
     get_emitter,
     set_emitter,
@@ -24,6 +25,7 @@ __all__ = [
     "Emitter",
     "EventKind",
     "NoopEmitter",
+    "QueueEmitter",
     "Result",
     "Subject",
     "emit",

--- a/src/nexus/services/activity/__init__.py
+++ b/src/nexus/services/activity/__init__.py
@@ -3,6 +3,11 @@
 See ``docs/superpowers/specs/2026-04-30-3791-activity-event-foundation-design.md``.
 """
 
+# Side-effect import: registers the APPROVALS_PENDING gauge setter with the
+# contracts-side reseed entrypoint so brick callers can update the gauge
+# without crossing the contracts→services boundary. Imported here (not lazily)
+# so the wiring is in place before any brick calls reseed_approvals_pending().
+from nexus.services.activity import metrics as _metrics  # noqa: F401
 from nexus.services.activity.emitter import (
     Emitter,
     NoopEmitter,

--- a/src/nexus/services/activity/__init__.py
+++ b/src/nexus/services/activity/__init__.py
@@ -1,0 +1,17 @@
+"""Activity event subsystem (issue #3791 foundation slice)."""
+
+from nexus.services.activity.events import (
+    ActivityEvent,
+    Actor,
+    EventKind,
+    Result,
+    Subject,
+)
+
+__all__ = [
+    "ActivityEvent",
+    "Actor",
+    "EventKind",
+    "Result",
+    "Subject",
+]

--- a/src/nexus/services/activity/__init__.py
+++ b/src/nexus/services/activity/__init__.py
@@ -18,9 +18,11 @@ from nexus.services.activity.events import (
     Result,
     Subject,
 )
+from nexus.services.activity.worker import ActivityWorker
 
 __all__ = [
     "ActivityEvent",
+    "ActivityWorker",
     "Actor",
     "Emitter",
     "EventKind",

--- a/src/nexus/services/activity/__init__.py
+++ b/src/nexus/services/activity/__init__.py
@@ -18,6 +18,7 @@ from nexus.services.activity.events import (
     Result,
     Subject,
 )
+from nexus.services.activity.lifespan import setup_activity, shutdown_activity
 from nexus.services.activity.worker import ActivityWorker
 
 __all__ = [
@@ -33,4 +34,6 @@ __all__ = [
     "emit",
     "get_emitter",
     "set_emitter",
+    "setup_activity",
+    "shutdown_activity",
 ]

--- a/src/nexus/services/activity/__init__.py
+++ b/src/nexus/services/activity/__init__.py
@@ -1,4 +1,7 @@
-"""Activity event subsystem (issue #3791 foundation slice)."""
+"""Activity event subsystem (issue #3791 foundation slice).
+
+See ``docs/superpowers/specs/2026-04-30-3791-activity-event-foundation-design.md``.
+"""
 
 from nexus.services.activity.events import (
     ActivityEvent,

--- a/src/nexus/services/activity/config.py
+++ b/src/nexus/services/activity/config.py
@@ -1,0 +1,70 @@
+"""Env-driven configuration for the activity subsystem."""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from pathlib import Path
+
+
+def _parse_bool(raw: str | None, default: bool) -> bool:
+    if raw is None:
+        return default
+    return raw.strip().lower() not in {"0", "false", "no", "off", ""}
+
+
+def _parse_int(name: str, raw: str | None, default: int) -> int:
+    if raw is None:
+        return default
+    try:
+        return int(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be an integer, got {raw!r}") from exc
+
+
+def _parse_float(name: str, raw: str | None, default: float) -> float:
+    if raw is None:
+        return default
+    try:
+        return float(raw)
+    except ValueError as exc:
+        raise ValueError(f"{name} must be a float, got {raw!r}") from exc
+
+
+@dataclass(frozen=True)
+class ActivityConfig:
+    enabled: bool = True
+    db_path: Path = Path("./activity.db")
+    retention_days: int = 30
+    queue_size: int = 10_000
+    batch_size: int = 200
+    batch_timeout_s: float = 0.5
+
+    @classmethod
+    def from_env(cls) -> ActivityConfig:
+        data_dir = os.environ.get("NEXUS_DATA_DIR", ".")
+        default_db = Path(data_dir) / "activity.db"
+        return cls(
+            enabled=_parse_bool(os.environ.get("NEXUS_ACTIVITY_ENABLED"), True),
+            db_path=Path(os.environ.get("NEXUS_ACTIVITY_DB_PATH", str(default_db))),
+            retention_days=_parse_int(
+                "NEXUS_ACTIVITY_RETENTION_DAYS",
+                os.environ.get("NEXUS_ACTIVITY_RETENTION_DAYS"),
+                30,
+            ),
+            queue_size=_parse_int(
+                "NEXUS_ACTIVITY_QUEUE_SIZE",
+                os.environ.get("NEXUS_ACTIVITY_QUEUE_SIZE"),
+                10_000,
+            ),
+            batch_size=_parse_int(
+                "NEXUS_ACTIVITY_BATCH_SIZE",
+                os.environ.get("NEXUS_ACTIVITY_BATCH_SIZE"),
+                200,
+            ),
+            batch_timeout_s=_parse_float(
+                "NEXUS_ACTIVITY_BATCH_TIMEOUT_S",
+                os.environ.get("NEXUS_ACTIVITY_BATCH_TIMEOUT_S"),
+                0.5,
+            ),
+        )

--- a/src/nexus/services/activity/config.py
+++ b/src/nexus/services/activity/config.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import math
 import os
 from dataclasses import dataclass
 from pathlib import Path
@@ -39,6 +40,27 @@ class ActivityConfig:
     queue_size: int = 10_000
     batch_size: int = 200
     batch_timeout_s: float = 0.5
+
+    def __post_init__(self) -> None:
+        # Bounded-queue contract: a non-positive queue_size disables
+        # asyncio.Queue back-pressure (treated as unbounded), which would let
+        # bursts grow memory without hitting the drop counter. Reject early
+        # with a clear error rather than silently breaking the contract.
+        if self.queue_size <= 0:
+            raise ValueError(f"NEXUS_ACTIVITY_QUEUE_SIZE must be > 0, got {self.queue_size}")
+        if self.batch_size <= 0:
+            raise ValueError(f"NEXUS_ACTIVITY_BATCH_SIZE must be > 0, got {self.batch_size}")
+        if self.batch_timeout_s <= 0 or not math.isfinite(self.batch_timeout_s):
+            # NaN passes <= 0 (NaN comparisons are False); inf would prevent
+            # partial-batch flushes. Both break the worker contract.
+            raise ValueError(
+                "NEXUS_ACTIVITY_BATCH_TIMEOUT_S must be a finite positive "
+                f"float, got {self.batch_timeout_s}"
+            )
+        if self.retention_days < 0:
+            raise ValueError(
+                f"NEXUS_ACTIVITY_RETENTION_DAYS must be >= 0, got {self.retention_days}"
+            )
 
     @classmethod
     def from_env(cls) -> ActivityConfig:

--- a/src/nexus/services/activity/emitter.py
+++ b/src/nexus/services/activity/emitter.py
@@ -1,8 +1,12 @@
-"""Emitter singleton + NoopEmitter.
+"""Service-side emitter implementations.
 
-QueueEmitter (added in Task 3) is the production implementation. NoopEmitter
-is the default — installed at process import so any code calling emit(...)
-before lifespan startup is a safe no-op.
+The brick-facing API (Emitter Protocol, NoopEmitter, set_emitter, get_emitter,
+emit, EventKind, Result) lives in ``nexus.contracts.protocols.activity`` so
+bricks can call ``emit(...)`` without crossing the brick / services boundary.
+This module owns the production ``QueueEmitter`` that lifespan installs, plus
+small helpers for ID and timestamp generation. ``Emitter``, ``NoopEmitter``,
+``set_emitter``, ``get_emitter``, ``emit`` are re-exported here so existing
+service-side imports keep working.
 """
 
 from __future__ import annotations
@@ -12,95 +16,27 @@ import threading
 import time
 import uuid
 from datetime import UTC, datetime
-from typing import Any, Protocol, runtime_checkable
+from typing import Any
 
-from nexus.services.activity.events import ActivityEvent, Actor, EventKind, Result, Subject
+from nexus.contracts.protocols.activity import (
+    Emitter,
+    EventKind,
+    NoopEmitter,
+    Result,
+    emit,
+    get_emitter,
+    set_emitter,
+)
+from nexus.services.activity.events import ActivityEvent, Actor, Subject
 
-
-@runtime_checkable
-class Emitter(Protocol):
-    """Contract for emitter implementations.
-
-    Implementations MUST NOT raise, MUST NOT block, and SHOULD return in
-    well under 50 µs even at p99.
-    """
-
-    def emit(
-        self,
-        *,
-        kind: EventKind,
-        result: Result,
-        actor_token_hash: str | None = None,
-        actor_agent: str | None = None,
-        actor_user: str | None = None,
-        subject_zone: str | None = None,
-        subject_extra: dict[str, Any] | None = None,
-        latency_ms: int | None = None,
-        trace_id: str | None = None,
-        meta: dict[str, Any] | None = None,
-    ) -> None: ...
-
-
-class NoopEmitter:
-    """Discards every event. Default emitter pre-startup and when disabled."""
-
-    def emit(
-        self,
-        *,
-        kind: EventKind,
-        result: Result,
-        actor_token_hash: str | None = None,
-        actor_agent: str | None = None,
-        actor_user: str | None = None,
-        subject_zone: str | None = None,
-        subject_extra: dict[str, Any] | None = None,
-        latency_ms: int | None = None,
-        trace_id: str | None = None,
-        meta: dict[str, Any] | None = None,
-    ) -> None:
-        return None
-
-
-_LOCK = threading.Lock()
-_EMITTER: Emitter = NoopEmitter()
-
-
-def get_emitter() -> Emitter:
-    return _EMITTER
-
-
-def set_emitter(emitter: Emitter) -> None:
-    global _EMITTER
-    with _LOCK:
-        _EMITTER = emitter
-
-
-def emit(
-    *,
-    kind: EventKind,
-    result: Result,
-    actor_token_hash: str | None = None,
-    actor_agent: str | None = None,
-    actor_user: str | None = None,
-    subject_zone: str | None = None,
-    subject_extra: dict[str, Any] | None = None,
-    latency_ms: int | None = None,
-    trace_id: str | None = None,
-    meta: dict[str, Any] | None = None,
-) -> None:
-    """Module-level convenience that delegates to the current emitter."""
-    _EMITTER.emit(
-        kind=kind,
-        result=result,
-        actor_token_hash=actor_token_hash,
-        actor_agent=actor_agent,
-        actor_user=actor_user,
-        subject_zone=subject_zone,
-        subject_extra=subject_extra,
-        latency_ms=latency_ms,
-        trace_id=trace_id,
-        meta=meta,
-    )
+__all__ = [
+    "Emitter",
+    "NoopEmitter",
+    "QueueEmitter",
+    "emit",
+    "get_emitter",
+    "set_emitter",
+]
 
 
 def _new_id() -> str:
@@ -119,21 +55,72 @@ def _now_iso() -> str:
 
 
 class QueueEmitter:
-    """Production emitter — non-blocking put_nowait with drop counter.
+    """Production emitter — non-blocking enqueue with drop counter.
 
-    Must be called from the event loop thread. asyncio.Queue is not
-    thread-safe; put_nowait() from a non-loop thread while the worker
-    awaits get() is a data race. Off-loop callers must use
-    loop.call_soon_threadsafe().
+    Thread-safe when constructed with a ``loop``: off-loop callers are
+    bridged through ``loop.call_soon_threadsafe`` so the ``asyncio.Queue``
+    is only mutated by the loop thread. Lifespan registration always
+    supplies the running loop. ``loop=None`` is supported for unit tests
+    that run synchronously with no concurrent consumer; in that mode the
+    emitter performs a direct ``put_nowait`` and the caller is responsible
+    for staying on a single thread.
+
+    Lifecycle: a single ``_inflight`` counter guarded by ``_lock`` covers
+    both active ``emit()`` calls (before they have scheduled or enqueued)
+    and scheduled-but-not-run callbacks. ``quiesce_pending()`` flips the
+    closing flag (rejecting new emits) and waits for that counter to
+    reach zero so shutdown cannot orphan an in-flight emission.
     """
 
-    def __init__(self, *, queue: asyncio.Queue[ActivityEvent]) -> None:
+    def __init__(
+        self,
+        *,
+        queue: asyncio.Queue[ActivityEvent],
+        loop: asyncio.AbstractEventLoop | None = None,
+    ) -> None:
         self._queue = queue
+        self._loop = loop
         self._drop_count = 0
+        self._lock = threading.Lock()
+        self._inflight = 0
+        self._closing = False
+        # Bound in-flight emissions to the queue's nominal capacity so a
+        # threadpool burst cannot pile up unbounded ActivityEvent objects
+        # in scheduled callbacks before drops are recorded.
+        self._max_inflight = max(1, queue.maxsize) if queue.maxsize > 0 else 0
 
     @property
     def drop_count(self) -> int:
         return self._drop_count
+
+    @property
+    def pending_off_loop(self) -> int:
+        # Backward-compatible name: counts both active emits and scheduled
+        # callbacks. Tests that asserted bound on the burst pattern still
+        # see the same upper bound (queue capacity).
+        return self._inflight
+
+    async def quiesce_pending(self, *, timeout: float = 2.0) -> None:
+        """Mark closing and wait for all in-flight emissions to land.
+
+        After installing NoopEmitter at shutdown, lifespan calls this so
+        existing emitters (which threads may still be inside) finish
+        scheduling and the loop runs the resulting callbacks before the
+        worker drains the queue. The closing flag rejects late submissions
+        once quiesce starts — they count as drops instead of orphaning.
+        """
+        with self._lock:
+            self._closing = True
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            return
+        deadline = loop.time() + timeout
+        while loop.time() < deadline:
+            with self._lock:
+                if self._inflight == 0:
+                    return
+            await asyncio.sleep(0.005)
 
     def emit(
         self,
@@ -149,37 +136,101 @@ class QueueEmitter:
         trace_id: str | None = None,
         meta: dict[str, Any] | None = None,
     ) -> None:
-        event = ActivityEvent(
-            id=_new_id(),
-            ts=_now_iso(),
-            kind=kind,
-            result=result,
-            latency_ms=latency_ms,
-            trace_id=trace_id,
-            actor=Actor(token_hash=actor_token_hash, agent=actor_agent, user=actor_user),
-            subject=Subject(zone=subject_zone, extra=subject_extra),
-            meta=meta,
-        )
-        try:
-            from nexus.services.activity.metrics import record_metrics
+        # Lifecycle + capacity gate. Closing emitters or saturated queues
+        # admit nothing new — the event is counted as a drop and we exit
+        # before constructing the ActivityEvent or recording metrics.
+        # Capacity check is `inflight + already-queued >= max` so a stalled
+        # worker (queue full, no scheduled callbacks pending) still drops
+        # before paying construction + metrics cost on the hot path.
+        with self._lock:
+            if self._closing:
+                self._record_drop_locked()
+                return
+            if self._max_inflight > 0:
+                queued = self._queue.qsize()
+                if self._inflight + queued >= self._max_inflight:
+                    self._record_drop_locked()
+                    return
+            self._inflight += 1
 
-            record_metrics(
+        scheduled = False
+        try:
+            event = ActivityEvent(
+                id=_new_id(),
+                ts=_now_iso(),
                 kind=kind,
                 result=result,
-                actor_token_hash=actor_token_hash,
-                subject_zone=subject_zone,
-                subject_extra=subject_extra,
                 latency_ms=latency_ms,
+                trace_id=trace_id,
+                actor=Actor(token_hash=actor_token_hash, agent=actor_agent, user=actor_user),
+                subject=Subject(zone=subject_zone, extra=subject_extra),
+                meta=meta,
             )
-        except Exception:  # metrics must never break the hot path
-            pass
+            try:
+                from nexus.services.activity.metrics import record_metrics
+
+                record_metrics(
+                    kind=kind,
+                    result=result,
+                    actor_token_hash=actor_token_hash,
+                    subject_zone=subject_zone,
+                    subject_extra=subject_extra,
+                    latency_ms=latency_ms,
+                )
+            except Exception:  # metrics must never break the hot path
+                pass
+            if self._loop is None:
+                self._enqueue(event)
+                return
+            try:
+                running = asyncio.get_running_loop()
+            except RuntimeError:
+                running = None
+            if running is self._loop:
+                self._enqueue(event)
+            else:
+                # Off-loop: transfer the inflight slot to the scheduled
+                # callback. The callback decrements after enqueuing.
+                try:
+                    self._loop.call_soon_threadsafe(self._enqueue_from_thread, event)
+                    scheduled = True
+                except RuntimeError:
+                    # Loop closed — drop and let the finally clause
+                    # decrement the slot.
+                    self._record_drop()
+        finally:
+            if not scheduled:
+                with self._lock:
+                    self._inflight -= 1
+
+    def _enqueue_from_thread(self, event: ActivityEvent) -> None:
+        try:
+            self._enqueue(event)
+        finally:
+            with self._lock:
+                self._inflight -= 1
+
+    def _enqueue(self, event: ActivityEvent) -> None:
         try:
             self._queue.put_nowait(event)
         except asyncio.QueueFull:
-            self._drop_count += 1
-            try:
-                from nexus.services.activity.metrics import ACTIVITY_DROPS
+            self._record_drop()
 
-                ACTIVITY_DROPS.inc()
-            except Exception:
-                pass
+    def _record_drop(self) -> None:
+        self._drop_count += 1
+        try:
+            from nexus.services.activity.metrics import ACTIVITY_DROPS
+
+            ACTIVITY_DROPS.inc()
+        except Exception:
+            pass
+
+    def _record_drop_locked(self) -> None:
+        # Called while self._lock is held — same logic as _record_drop.
+        self._drop_count += 1
+        try:
+            from nexus.services.activity.metrics import ACTIVITY_DROPS
+
+            ACTIVITY_DROPS.inc()
+        except Exception:
+            pass

--- a/src/nexus/services/activity/emitter.py
+++ b/src/nexus/services/activity/emitter.py
@@ -161,6 +161,25 @@ class QueueEmitter:
             meta=meta,
         )
         try:
+            from nexus.services.activity.metrics import record_metrics
+
+            record_metrics(
+                kind=kind,
+                result=result,
+                actor_token_hash=actor_token_hash,
+                subject_zone=subject_zone,
+                subject_extra=subject_extra,
+                latency_ms=latency_ms,
+            )
+        except Exception:  # metrics must never break the hot path
+            pass
+        try:
             self._queue.put_nowait(event)
         except asyncio.QueueFull:
             self._drop_count += 1
+            try:
+                from nexus.services.activity.metrics import ACTIVITY_DROPS
+
+                ACTIVITY_DROPS.inc()
+            except Exception:
+                pass

--- a/src/nexus/services/activity/emitter.py
+++ b/src/nexus/services/activity/emitter.py
@@ -8,11 +8,12 @@ before lifespan startup is a safe no-op.
 from __future__ import annotations
 
 import threading
-from typing import Any, Protocol
+from typing import Any, Protocol, runtime_checkable
 
 from nexus.services.activity.events import EventKind, Result
 
 
+@runtime_checkable
 class Emitter(Protocol):
     """Contract for emitter implementations.
 
@@ -39,7 +40,20 @@ class Emitter(Protocol):
 class NoopEmitter:
     """Discards every event. Default emitter pre-startup and when disabled."""
 
-    def emit(self, **_: Any) -> None:
+    def emit(
+        self,
+        *,
+        kind: EventKind,
+        result: Result,
+        actor_token_hash: str | None = None,
+        actor_agent: str | None = None,
+        actor_user: str | None = None,
+        subject_zone: str | None = None,
+        subject_extra: dict[str, Any] | None = None,
+        latency_ms: int | None = None,
+        trace_id: str | None = None,
+        meta: dict[str, Any] | None = None,
+    ) -> None:
         return None
 
 

--- a/src/nexus/services/activity/emitter.py
+++ b/src/nexus/services/activity/emitter.py
@@ -104,7 +104,11 @@ def emit(
 
 
 def _new_id() -> str:
-    """Sortable id: ms-timestamp prefix + random suffix (no third-party dep)."""
+    """Sortable id: ms-timestamp prefix + random suffix (no third-party dep).
+
+    IDs from different milliseconds sort in time order. IDs within the
+    same millisecond have no time-order guarantee.
+    """
     ms = int(time.time() * 1000)
     rand = uuid.uuid4().hex[:16]
     return f"{ms:013d}{rand}"
@@ -117,8 +121,10 @@ def _now_iso() -> str:
 class QueueEmitter:
     """Production emitter — non-blocking put_nowait with drop counter.
 
-    Thread-safe: asyncio.Queue.put_nowait is safe from non-loop threads
-    when only the worker awaits get() on the loop thread.
+    Must be called from the event loop thread. asyncio.Queue is not
+    thread-safe; put_nowait() from a non-loop thread while the worker
+    awaits get() is a data race. Off-loop callers must use
+    loop.call_soon_threadsafe().
     """
 
     def __init__(self, *, queue: asyncio.Queue[ActivityEvent]) -> None:

--- a/src/nexus/services/activity/emitter.py
+++ b/src/nexus/services/activity/emitter.py
@@ -7,10 +7,14 @@ before lifespan startup is a safe no-op.
 
 from __future__ import annotations
 
+import asyncio
 import threading
+import time
+import uuid
+from datetime import UTC, datetime
 from typing import Any, Protocol, runtime_checkable
 
-from nexus.services.activity.events import EventKind, Result
+from nexus.services.activity.events import ActivityEvent, Actor, EventKind, Result, Subject
 
 
 @runtime_checkable
@@ -97,3 +101,60 @@ def emit(
         trace_id=trace_id,
         meta=meta,
     )
+
+
+def _new_id() -> str:
+    """Sortable id: ms-timestamp prefix + random suffix (no third-party dep)."""
+    ms = int(time.time() * 1000)
+    rand = uuid.uuid4().hex[:16]
+    return f"{ms:013d}{rand}"
+
+
+def _now_iso() -> str:
+    return datetime.now(tz=UTC).isoformat(timespec="microseconds")
+
+
+class QueueEmitter:
+    """Production emitter — non-blocking put_nowait with drop counter.
+
+    Thread-safe: asyncio.Queue.put_nowait is safe from non-loop threads
+    when only the worker awaits get() on the loop thread.
+    """
+
+    def __init__(self, *, queue: asyncio.Queue[ActivityEvent]) -> None:
+        self._queue = queue
+        self._drop_count = 0
+
+    @property
+    def drop_count(self) -> int:
+        return self._drop_count
+
+    def emit(
+        self,
+        *,
+        kind: EventKind,
+        result: Result,
+        actor_token_hash: str | None = None,
+        actor_agent: str | None = None,
+        actor_user: str | None = None,
+        subject_zone: str | None = None,
+        subject_extra: dict[str, Any] | None = None,
+        latency_ms: int | None = None,
+        trace_id: str | None = None,
+        meta: dict[str, Any] | None = None,
+    ) -> None:
+        event = ActivityEvent(
+            id=_new_id(),
+            ts=_now_iso(),
+            kind=kind,
+            result=result,
+            latency_ms=latency_ms,
+            trace_id=trace_id,
+            actor=Actor(token_hash=actor_token_hash, agent=actor_agent, user=actor_user),
+            subject=Subject(zone=subject_zone, extra=subject_extra),
+            meta=meta,
+        )
+        try:
+            self._queue.put_nowait(event)
+        except asyncio.QueueFull:
+            self._drop_count += 1

--- a/src/nexus/services/activity/emitter.py
+++ b/src/nexus/services/activity/emitter.py
@@ -1,0 +1,85 @@
+"""Emitter singleton + NoopEmitter.
+
+QueueEmitter (added in Task 3) is the production implementation. NoopEmitter
+is the default — installed at process import so any code calling emit(...)
+before lifespan startup is a safe no-op.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Protocol
+
+from nexus.services.activity.events import EventKind, Result
+
+
+class Emitter(Protocol):
+    """Contract for emitter implementations.
+
+    Implementations MUST NOT raise, MUST NOT block, and SHOULD return in
+    well under 50 µs even at p99.
+    """
+
+    def emit(
+        self,
+        *,
+        kind: EventKind,
+        result: Result,
+        actor_token_hash: str | None = None,
+        actor_agent: str | None = None,
+        actor_user: str | None = None,
+        subject_zone: str | None = None,
+        subject_extra: dict[str, Any] | None = None,
+        latency_ms: int | None = None,
+        trace_id: str | None = None,
+        meta: dict[str, Any] | None = None,
+    ) -> None: ...
+
+
+class NoopEmitter:
+    """Discards every event. Default emitter pre-startup and when disabled."""
+
+    def emit(self, **_: Any) -> None:
+        return None
+
+
+_LOCK = threading.Lock()
+_EMITTER: Emitter = NoopEmitter()
+
+
+def get_emitter() -> Emitter:
+    return _EMITTER
+
+
+def set_emitter(emitter: Emitter) -> None:
+    global _EMITTER
+    with _LOCK:
+        _EMITTER = emitter
+
+
+def emit(
+    *,
+    kind: EventKind,
+    result: Result,
+    actor_token_hash: str | None = None,
+    actor_agent: str | None = None,
+    actor_user: str | None = None,
+    subject_zone: str | None = None,
+    subject_extra: dict[str, Any] | None = None,
+    latency_ms: int | None = None,
+    trace_id: str | None = None,
+    meta: dict[str, Any] | None = None,
+) -> None:
+    """Module-level convenience that delegates to the current emitter."""
+    _EMITTER.emit(
+        kind=kind,
+        result=result,
+        actor_token_hash=actor_token_hash,
+        actor_agent=actor_agent,
+        actor_user=actor_user,
+        subject_zone=subject_zone,
+        subject_extra=subject_extra,
+        latency_ms=latency_ms,
+        trace_id=trace_id,
+        meta=meta,
+    )

--- a/src/nexus/services/activity/events.py
+++ b/src/nexus/services/activity/events.py
@@ -1,13 +1,18 @@
-"""ActivityEvent schema for issue #3791 foundation slice."""
+"""ActivityEvent schema for issue #3791 foundation slice.
+
+Frozen dataclasses + enums. No I/O, no side effects — safe to import from
+any layer. ``actor.token_hash`` is the SHA256[:16] of the raw bearer token
+(matches ``bricks/mcp/middleware_audit.py``); raw tokens are NEVER stored.
+"""
 
 from __future__ import annotations
 
-import enum
 from dataclasses import dataclass, field
+from enum import StrEnum
 from typing import Any
 
 
-class EventKind(str, enum.Enum):
+class EventKind(StrEnum):
     SEARCH = "search"
     FETCH = "fetch"
     MCP_TOOL_CALL = "mcp_tool_call"
@@ -16,7 +21,7 @@ class EventKind(str, enum.Enum):
     APPROVAL = "approval"
 
 
-class Result(str, enum.Enum):
+class Result(StrEnum):
     OK = "ok"
     BLOCKED = "blocked"
     PENDING_APPROVAL = "pending_approval"

--- a/src/nexus/services/activity/events.py
+++ b/src/nexus/services/activity/events.py
@@ -1,30 +1,21 @@
 """ActivityEvent schema for issue #3791 foundation slice.
 
-Frozen dataclasses + enums. No I/O, no side effects — safe to import from
-any layer. ``actor.token_hash`` is the SHA256[:16] of the raw bearer token
-(matches ``bricks/mcp/middleware_audit.py``); raw tokens are NEVER stored.
+Frozen dataclasses for the wire/storage shape of events. ``EventKind`` and
+``Result`` live in ``nexus.contracts.protocols.activity`` so bricks can
+import them without touching ``nexus.services``; this module re-exports
+them for service-side imports. ``actor.token_hash`` is the SHA256[:16] of
+the raw bearer token (matches ``bricks/mcp/middleware_audit.py``); raw
+tokens are NEVER stored.
 """
 
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from enum import StrEnum
 from typing import Any
 
+from nexus.contracts.protocols.activity import EventKind, Result
 
-class EventKind(StrEnum):
-    SEARCH = "search"
-    FETCH = "fetch"
-    MCP_TOOL_CALL = "mcp_tool_call"
-    ZONE_ACCESS = "zone_access"
-    POLICY_BLOCK = "policy_block"
-    APPROVAL = "approval"
-
-
-class Result(StrEnum):
-    OK = "ok"
-    BLOCKED = "blocked"
-    PENDING_APPROVAL = "pending_approval"
+__all__ = ["ActivityEvent", "Actor", "EventKind", "Result", "Subject"]
 
 
 @dataclass(frozen=True, slots=True)

--- a/src/nexus/services/activity/events.py
+++ b/src/nexus/services/activity/events.py
@@ -1,0 +1,48 @@
+"""ActivityEvent schema for issue #3791 foundation slice."""
+
+from __future__ import annotations
+
+import enum
+from dataclasses import dataclass, field
+from typing import Any
+
+
+class EventKind(str, enum.Enum):
+    SEARCH = "search"
+    FETCH = "fetch"
+    MCP_TOOL_CALL = "mcp_tool_call"
+    ZONE_ACCESS = "zone_access"
+    POLICY_BLOCK = "policy_block"
+    APPROVAL = "approval"
+
+
+class Result(str, enum.Enum):
+    OK = "ok"
+    BLOCKED = "blocked"
+    PENDING_APPROVAL = "pending_approval"
+
+
+@dataclass(frozen=True, slots=True)
+class Actor:
+    token_hash: str | None = None
+    agent: str | None = None
+    user: str | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class Subject:
+    zone: str | None = None
+    extra: dict[str, Any] | None = None
+
+
+@dataclass(frozen=True, slots=True)
+class ActivityEvent:
+    id: str
+    ts: str
+    kind: EventKind
+    result: Result
+    latency_ms: int | None = None
+    trace_id: str | None = None
+    actor: Actor = field(default_factory=Actor)
+    subject: Subject = field(default_factory=Subject)
+    meta: dict[str, Any] | None = None

--- a/src/nexus/services/activity/lifespan.py
+++ b/src/nexus/services/activity/lifespan.py
@@ -59,8 +59,14 @@ def setup_activity() -> None:
     retention = RetentionTask(db_path=cfg.db_path, retention_days=cfg.retention_days)
 
     loop = asyncio.get_running_loop()
-    loop.create_task(worker.start())
-    loop.create_task(retention.start())
+    startup_tasks: set[asyncio.Task[None]] = set()
+    t1 = loop.create_task(worker.start())
+    t2 = loop.create_task(retention.start())
+    startup_tasks.add(t1)
+    startup_tasks.add(t2)
+    t1.add_done_callback(startup_tasks.discard)
+    t2.add_done_callback(startup_tasks.discard)
+    _STATE["startup_tasks"] = startup_tasks
 
     set_emitter(QueueEmitter(queue=queue))
 
@@ -75,8 +81,15 @@ def shutdown_activity() -> None:
     worker = _STATE.pop("worker", None)
     retention = _STATE.pop("retention", None)
     _STATE.pop("queue", None)
-    loop = asyncio.get_running_loop()
-    if isinstance(worker, ActivityWorker):
-        loop.create_task(worker.stop(timeout=5.0))
-    if isinstance(retention, RetentionTask):
-        loop.create_task(retention.stop())
+    shutdown_tasks: set[asyncio.Task[None]] = set()
+    if isinstance(worker, ActivityWorker) or isinstance(retention, RetentionTask):
+        loop = asyncio.get_running_loop()
+        if isinstance(worker, ActivityWorker):
+            t = loop.create_task(worker.stop(timeout=5.0))
+            shutdown_tasks.add(t)
+            t.add_done_callback(shutdown_tasks.discard)
+        if isinstance(retention, RetentionTask):
+            t = loop.create_task(retention.stop())
+            shutdown_tasks.add(t)
+            t.add_done_callback(shutdown_tasks.discard)
+    _STATE["shutdown_tasks"] = shutdown_tasks

--- a/src/nexus/services/activity/lifespan.py
+++ b/src/nexus/services/activity/lifespan.py
@@ -1,0 +1,82 @@
+"""Setup / shutdown hooks for the activity subsystem.
+
+Both functions are synchronous so they can be registered on
+``FunctionPairComponent`` from ``nexus.server.lifespan.observability``.
+The asyncio tasks they spawn require a running event loop — which is
+present because the registry calls them inside ``async def start()``.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+
+from nexus.services.activity.config import ActivityConfig
+from nexus.services.activity.emitter import (
+    NoopEmitter,
+    QueueEmitter,
+    set_emitter,
+)
+from nexus.services.activity.events import ActivityEvent
+from nexus.services.activity.retention import RetentionTask
+from nexus.services.activity.sinks import NoopSink, SQLiteSink
+from nexus.services.activity.sinks.protocol import SinkProtocol
+from nexus.services.activity.worker import ActivityWorker
+
+logger = logging.getLogger(__name__)
+
+_STATE: dict[str, object] = {"worker": None, "retention": None, "queue": None}
+
+
+def setup_activity() -> None:
+    """Start activity worker + retention task. Safe to call once per process."""
+    cfg = ActivityConfig.from_env()
+    if not cfg.enabled:
+        set_emitter(NoopEmitter())
+        logger.info("activity subsystem disabled by NEXUS_ACTIVITY_ENABLED=0")
+        return
+
+    queue: asyncio.Queue[ActivityEvent] = asyncio.Queue(maxsize=cfg.queue_size)
+
+    sinks: list[SinkProtocol] = []
+    try:
+        sinks.append(SQLiteSink(path=cfg.db_path))
+        logger.info("activity SQLite sink open at %s", cfg.db_path)
+    except Exception:
+        logger.error(
+            "activity SQLiteSink failed to open at %s — falling back to NoopSink",
+            cfg.db_path,
+            exc_info=True,
+        )
+        sinks.append(NoopSink())
+
+    worker = ActivityWorker(
+        queue=queue,
+        sinks=sinks,
+        batch_size=cfg.batch_size,
+        batch_timeout_s=cfg.batch_timeout_s,
+    )
+    retention = RetentionTask(db_path=cfg.db_path, retention_days=cfg.retention_days)
+
+    loop = asyncio.get_running_loop()
+    loop.create_task(worker.start())
+    loop.create_task(retention.start())
+
+    set_emitter(QueueEmitter(queue=queue))
+
+    _STATE["worker"] = worker
+    _STATE["retention"] = retention
+    _STATE["queue"] = queue
+
+
+def shutdown_activity() -> None:
+    """Stop worker + retention. Safe to call when setup_activity skipped."""
+    set_emitter(NoopEmitter())  # stop accepting new events first
+    worker = _STATE.pop("worker", None)
+    retention = _STATE.pop("retention", None)
+    _STATE.pop("queue", None)
+    loop = asyncio.get_running_loop()
+    if isinstance(worker, ActivityWorker):
+        loop.create_task(worker.stop(timeout=5.0))
+    if isinstance(retention, RetentionTask):
+        loop.create_task(retention.stop())

--- a/src/nexus/services/activity/lifespan.py
+++ b/src/nexus/services/activity/lifespan.py
@@ -1,9 +1,9 @@
 """Setup / shutdown hooks for the activity subsystem.
 
-Both functions are synchronous so they can be registered on
-``FunctionPairComponent`` from ``nexus.server.lifespan.observability``.
-The asyncio tasks they spawn require a running event loop — which is
-present because the registry calls them inside ``async def start()``.
+Both functions are async so ``FunctionPairComponent`` (the registry-side
+adapter) can await them. Awaiting matters at shutdown: the worker has
+queued events that must drain to the SQLite sink before the registry
+declares the component stopped.
 """
 
 from __future__ import annotations
@@ -28,7 +28,7 @@ logger = logging.getLogger(__name__)
 _STATE: dict[str, object] = {"worker": None, "retention": None, "queue": None}
 
 
-def setup_activity() -> None:
+async def setup_activity() -> None:
     """Start activity worker + retention task. Safe to call once per process."""
     cfg = ActivityConfig.from_env()
     if not cfg.enabled:
@@ -44,10 +44,20 @@ def setup_activity() -> None:
         logger.info("activity SQLite sink open at %s", cfg.db_path)
     except Exception:
         logger.error(
-            "activity SQLiteSink failed to open at %s — falling back to NoopSink",
+            "activity SQLiteSink failed to open at %s — falling back to NoopSink. "
+            "Durable activity_events store is DISABLED for this process.",
             cfg.db_path,
             exc_info=True,
         )
+        # Surface the degradation in /metrics so operators have an alertable
+        # signal — without this, ACTIVITY_SINK_ERRORS stays at 0 while every
+        # event is silently discarded.
+        try:
+            from nexus.services.activity.metrics import ACTIVITY_SINK_ERRORS
+
+            ACTIVITY_SINK_ERRORS.labels(sink="SQLiteSink").inc()
+        except Exception:
+            pass
         sinks.append(NoopSink())
 
     worker = ActivityWorker(
@@ -59,37 +69,47 @@ def setup_activity() -> None:
     retention = RetentionTask(db_path=cfg.db_path, retention_days=cfg.retention_days)
 
     loop = asyncio.get_running_loop()
-    startup_tasks: set[asyncio.Task[None]] = set()
-    t1 = loop.create_task(worker.start())
-    t2 = loop.create_task(retention.start())
-    startup_tasks.add(t1)
-    startup_tasks.add(t2)
-    t1.add_done_callback(startup_tasks.discard)
-    t2.add_done_callback(startup_tasks.discard)
-    _STATE["startup_tasks"] = startup_tasks
+    await worker.start()
+    await retention.start()
 
-    set_emitter(QueueEmitter(queue=queue))
+    queue_emitter = QueueEmitter(queue=queue, loop=loop)
+    set_emitter(queue_emitter)
 
     _STATE["worker"] = worker
     _STATE["retention"] = retention
     _STATE["queue"] = queue
+    _STATE["emitter"] = queue_emitter
 
 
-def shutdown_activity() -> None:
-    """Stop worker + retention. Safe to call when setup_activity skipped."""
+async def shutdown_activity() -> None:
+    """Stop worker + retention. Safe to call when setup_activity skipped.
+
+    Order matters:
+    1. Install NoopEmitter so new emit() calls become no-ops.
+    2. Quiesce the previous QueueEmitter — off-loop emits schedule
+       call_soon_threadsafe callbacks that have not yet enqueued, and
+       must run before the worker drain closes the queue.
+    3. Stop retention BEFORE the worker so retention's VACUUM cannot
+       hold the SQLite write lock during the final drain.
+    4. Stop the worker and close sinks.
+    """
+    prev_emitter = _STATE.pop("emitter", None)
     set_emitter(NoopEmitter())  # stop accepting new events first
     worker = _STATE.pop("worker", None)
     retention = _STATE.pop("retention", None)
     _STATE.pop("queue", None)
-    shutdown_tasks: set[asyncio.Task[None]] = set()
-    if isinstance(worker, ActivityWorker) or isinstance(retention, RetentionTask):
-        loop = asyncio.get_running_loop()
-        if isinstance(worker, ActivityWorker):
-            t = loop.create_task(worker.stop(timeout=5.0))
-            shutdown_tasks.add(t)
-            t.add_done_callback(shutdown_tasks.discard)
-        if isinstance(retention, RetentionTask):
-            t = loop.create_task(retention.stop())
-            shutdown_tasks.add(t)
-            t.add_done_callback(shutdown_tasks.discard)
-    _STATE["shutdown_tasks"] = shutdown_tasks
+    if isinstance(prev_emitter, QueueEmitter):
+        try:
+            await prev_emitter.quiesce_pending(timeout=2.0)
+        except Exception:
+            logger.warning("activity emitter quiesce failed", exc_info=True)
+    if isinstance(retention, RetentionTask):
+        try:
+            await retention.stop()
+        except Exception:
+            logger.warning("activity retention stop failed", exc_info=True)
+    if isinstance(worker, ActivityWorker):
+        try:
+            await worker.stop(timeout=10.0)
+        except Exception:
+            logger.warning("activity worker stop failed", exc_info=True)

--- a/src/nexus/services/activity/metrics.py
+++ b/src/nexus/services/activity/metrics.py
@@ -11,6 +11,7 @@ from typing import Any
 
 from prometheus_client import Counter, Gauge, Histogram
 
+from nexus.contracts.protocols.activity import register_approvals_pending_gauge
 from nexus.services.activity.events import EventKind, Result
 
 # Issue's named catalog ───────────────────────────────────────────────────────
@@ -18,7 +19,7 @@ from nexus.services.activity.events import EventKind, Result
 SEARCH_REQUESTS = Counter(
     "nexus_search_requests_total",
     "Total Nexus search requests",
-    ["zone", "token_hash", "status"],
+    ["zone", "status"],
 )
 
 SEARCH_LATENCY = Histogram(
@@ -43,6 +44,11 @@ APPROVALS_PENDING = Gauge(
     "nexus_approvals_pending",
     "Number of approval requests currently in PENDING state",
 )
+
+# Wire the contracts-side reseed entrypoint to this gauge so brick callers
+# (which only import nexus.contracts.protocols.activity) can update it
+# without crossing the contracts→services boundary.
+register_approvals_pending_gauge(APPROVALS_PENDING.set)
 
 # Internal subsystem health ───────────────────────────────────────────────────
 
@@ -74,24 +80,27 @@ def record_metrics(
 ) -> None:
     """Update the Prom catalog for one emitted event.
 
-    APPROVALS_PENDING contract: producers MUST emit exactly one
-    PENDING_APPROVAL when an approval is created and exactly one
-    non-PENDING result (OK | BLOCKED) when it resolves. Across a
-    process restart the gauge may go negative for in-flight approvals
-    that resolve after restart — Task 15 (ApprovalService wiring)
-    should reseed APPROVALS_PENDING from a DB count at startup if
-    accuracy is required.
+    Token attribution lives in the SQLite activity event payload, not in
+    Prometheus labels — token rotation produces unbounded series otherwise.
+
+    APPROVALS_PENDING is NOT updated here. The gauge is authoritative —
+    ``ApprovalService`` reseeds it from the durable ``list_pending`` count
+    at startup and after every transition (create / decide / local-timeout
+    expire / sweeper expire / cross-worker NOTIFY / reconcile) via
+    ``reseed_approvals_pending``. Event-delta accounting cannot stay
+    consistent across cross-worker decisions where the decrement and the
+    increment happen in different processes.
 
     MCP_TOOL_CALL contract: producers MUST populate
     ``subject_extra={"tool": ...}`` for the MCP_TOOL_CALLS counter
     label to reflect the actual tool name (otherwise it falls back
     to "unknown").
     """
+    _ = actor_token_hash  # retained for SQLite payload; not a Prom label
     zone = subject_zone or "unknown"
-    token = actor_token_hash or "anonymous"
 
     if kind is EventKind.SEARCH:
-        SEARCH_REQUESTS.labels(zone=zone, token_hash=token, status=result.value).inc()
+        SEARCH_REQUESTS.labels(zone=zone, status=result.value).inc()
         if latency_ms is not None:
             SEARCH_LATENCY.labels(zone=zone).observe(latency_ms / 1000.0)
     elif kind is EventKind.MCP_TOOL_CALL:
@@ -100,9 +109,5 @@ def record_metrics(
     elif kind in (EventKind.ZONE_ACCESS, EventKind.POLICY_BLOCK):
         if result is Result.BLOCKED:
             POLICY_BLOCKS.labels(kind=kind.value).inc()
-    elif kind is EventKind.APPROVAL:
-        if result is Result.PENDING_APPROVAL:
-            APPROVALS_PENDING.inc()
-        else:
-            APPROVALS_PENDING.dec()
+    # APPROVAL: gauge is reseeded from durable state by the producer.
     # FETCH currently has no metric in the catalog.

--- a/src/nexus/services/activity/metrics.py
+++ b/src/nexus/services/activity/metrics.py
@@ -1,0 +1,94 @@
+"""Prometheus metrics catalog for issue #3791 foundation slice.
+
+Registered at import time on the global ``prometheus_client.REGISTRY``.
+``record_metrics(...)`` is invoked from ``QueueEmitter.emit`` so the Prom
+state stays accurate even if the SQLite sink drops batches.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+from prometheus_client import Counter, Gauge, Histogram
+
+from nexus.services.activity.events import EventKind, Result
+
+# Issue's named catalog ───────────────────────────────────────────────────────
+
+SEARCH_REQUESTS = Counter(
+    "nexus_search_requests_total",
+    "Total Nexus search requests",
+    ["zone", "token_hash", "status"],
+)
+
+SEARCH_LATENCY = Histogram(
+    "nexus_search_latency_seconds",
+    "Nexus search request latency in seconds",
+    ["zone"],
+)
+
+MCP_TOOL_CALLS = Counter(
+    "nexus_mcp_tool_calls_total",
+    "Total MCP tool calls dispatched",
+    ["tool", "status"],
+)
+
+POLICY_BLOCKS = Counter(
+    "nexus_policy_blocks_total",
+    "Total ReBAC/zone-access denials",
+    ["kind"],
+)
+
+APPROVALS_PENDING = Gauge(
+    "nexus_approvals_pending",
+    "Number of approval requests currently in PENDING state",
+)
+
+# Internal subsystem health ───────────────────────────────────────────────────
+
+ACTIVITY_DROPS = Counter(
+    "nexus_activity_drops_total",
+    "Activity events dropped due to queue overflow",
+)
+
+ACTIVITY_SINK_ERRORS = Counter(
+    "nexus_activity_sink_errors_total",
+    "Activity sink batch-write errors",
+    ["sink"],
+)
+
+ACTIVITY_RETENTION_PRUNED = Counter(
+    "nexus_activity_retention_pruned_total",
+    "Activity events pruned by retention task",
+)
+
+
+def record_metrics(
+    *,
+    kind: EventKind,
+    result: Result,
+    actor_token_hash: str | None,
+    subject_zone: str | None,
+    subject_extra: dict[str, Any] | None,
+    latency_ms: int | None,
+) -> None:
+    """Update the Prom catalog for one emitted event."""
+    zone = subject_zone or "unknown"
+    token = actor_token_hash or "anonymous"
+
+    if kind is EventKind.SEARCH:
+        SEARCH_REQUESTS.labels(zone=zone, token_hash=token, status=result.value).inc()
+        if latency_ms is not None:
+            SEARCH_LATENCY.labels(zone=zone).observe(latency_ms / 1000.0)
+    elif kind is EventKind.MCP_TOOL_CALL:
+        tool = (subject_extra or {}).get("tool", "unknown")
+        MCP_TOOL_CALLS.labels(tool=tool, status=result.value).inc()
+    elif kind in (EventKind.ZONE_ACCESS, EventKind.POLICY_BLOCK):
+        if result is Result.BLOCKED:
+            POLICY_BLOCKS.labels(kind=kind.value).inc()
+    elif kind is EventKind.APPROVAL:
+        if result is Result.PENDING_APPROVAL:
+            APPROVALS_PENDING.inc()
+        else:
+            APPROVALS_PENDING.dec()
+    # FETCH currently has no metric in the catalog.

--- a/src/nexus/services/activity/metrics.py
+++ b/src/nexus/services/activity/metrics.py
@@ -72,7 +72,21 @@ def record_metrics(
     subject_extra: dict[str, Any] | None,
     latency_ms: int | None,
 ) -> None:
-    """Update the Prom catalog for one emitted event."""
+    """Update the Prom catalog for one emitted event.
+
+    APPROVALS_PENDING contract: producers MUST emit exactly one
+    PENDING_APPROVAL when an approval is created and exactly one
+    non-PENDING result (OK | BLOCKED) when it resolves. Across a
+    process restart the gauge may go negative for in-flight approvals
+    that resolve after restart — Task 15 (ApprovalService wiring)
+    should reseed APPROVALS_PENDING from a DB count at startup if
+    accuracy is required.
+
+    MCP_TOOL_CALL contract: producers MUST populate
+    ``subject_extra={"tool": ...}`` for the MCP_TOOL_CALLS counter
+    label to reflect the actual tool name (otherwise it falls back
+    to "unknown").
+    """
     zone = subject_zone or "unknown"
     token = actor_token_hash or "anonymous"
 

--- a/src/nexus/services/activity/retention.py
+++ b/src/nexus/services/activity/retention.py
@@ -12,11 +12,20 @@ from pathlib import Path
 logger = logging.getLogger(__name__)
 
 
-def prune_older_than(*, db_path: Path | str, retention_days: int) -> int:
+def prune_older_than(
+    *,
+    db_path: Path | str,
+    retention_days: int,
+    vacuum_threshold: int = 1000,
+) -> int:
     """Synchronously delete rows older than now - retention_days.
 
+    ts is always YYYY-MM-DDTHH:MM:SS.ffffff+00:00 (see emitter._now_iso),
+    so lexicographic comparison matches chronological order.
+
     Returns the number of rows deleted. retention_days <= 0 is a no-op.
-    Missing DB returns 0 silently.
+    Missing DB returns 0 silently. Runs VACUUM after deleting more than
+    vacuum_threshold rows (default 1000) to reclaim disk space.
     """
     if retention_days <= 0:
         return 0
@@ -25,14 +34,18 @@ def prune_older_than(*, db_path: Path | str, retention_days: int) -> int:
         return 0
     threshold = (datetime.now(tz=UTC) - timedelta(days=retention_days)).isoformat()
     try:
-        conn = sqlite3.connect(db)
+        conn = sqlite3.connect(db, isolation_level=None)  # autocommit needed for VACUUM
         try:
             cursor = conn.execute(
                 "DELETE FROM activity_events WHERE ts < ?",
                 (threshold,),
             )
             deleted = cursor.rowcount or 0
-            conn.commit()
+            if deleted >= vacuum_threshold:
+                try:
+                    conn.execute("VACUUM")
+                except sqlite3.Error:
+                    logger.warning("activity retention VACUUM failed", exc_info=True)
             return deleted
         finally:
             conn.close()
@@ -50,10 +63,12 @@ class RetentionTask:
         db_path: Path | str,
         retention_days: int,
         interval_s: float = 3600.0,
+        vacuum_threshold: int = 1000,
     ) -> None:
         self._db_path = db_path
         self._retention_days = retention_days
         self._interval_s = interval_s
+        self._vacuum_threshold = vacuum_threshold
         self._stopping = asyncio.Event()
         self._task: asyncio.Task[None] | None = None
         self._total_pruned = 0
@@ -86,6 +101,7 @@ class RetentionTask:
                     prune_older_than,
                     db_path=self._db_path,
                     retention_days=self._retention_days,
+                    vacuum_threshold=self._vacuum_threshold,
                 )
                 self._total_pruned += deleted
             except Exception:

--- a/src/nexus/services/activity/retention.py
+++ b/src/nexus/services/activity/retention.py
@@ -1,0 +1,96 @@
+"""Periodic prune of activity_events older than the retention threshold."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def prune_older_than(*, db_path: Path | str, retention_days: int) -> int:
+    """Synchronously delete rows older than now - retention_days.
+
+    Returns the number of rows deleted. retention_days <= 0 is a no-op.
+    Missing DB returns 0 silently.
+    """
+    if retention_days <= 0:
+        return 0
+    db = Path(db_path)
+    if not db.exists():
+        return 0
+    threshold = (datetime.now(tz=UTC) - timedelta(days=retention_days)).isoformat()
+    try:
+        conn = sqlite3.connect(db)
+        try:
+            cursor = conn.execute(
+                "DELETE FROM activity_events WHERE ts < ?",
+                (threshold,),
+            )
+            deleted = cursor.rowcount or 0
+            conn.commit()
+            return deleted
+        finally:
+            conn.close()
+    except sqlite3.Error:
+        logger.warning("activity retention prune failed", exc_info=True)
+        return 0
+
+
+class RetentionTask:
+    """Async task wrapping prune_older_than on a fixed cadence."""
+
+    def __init__(
+        self,
+        *,
+        db_path: Path | str,
+        retention_days: int,
+        interval_s: float = 3600.0,
+    ) -> None:
+        self._db_path = db_path
+        self._retention_days = retention_days
+        self._interval_s = interval_s
+        self._stopping = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+        self._total_pruned = 0
+
+    @property
+    def total_pruned(self) -> int:
+        return self._total_pruned
+
+    async def start(self) -> None:
+        if self._retention_days <= 0:
+            logger.info("activity retention disabled (retention_days=%d)", self._retention_days)
+            return
+        if self._task is not None and not self._task.done():
+            return
+        self._stopping.clear()
+        self._task = asyncio.create_task(self._run())
+
+    async def stop(self) -> None:
+        self._stopping.set()
+        if self._task is not None:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError, Exception):
+                await self._task
+            self._task = None
+
+    async def _run(self) -> None:
+        while not self._stopping.is_set():
+            try:
+                deleted = await asyncio.to_thread(
+                    prune_older_than,
+                    db_path=self._db_path,
+                    retention_days=self._retention_days,
+                )
+                self._total_pruned += deleted
+            except Exception:
+                logger.warning("activity retention loop tick failed", exc_info=True)
+            try:
+                await asyncio.wait_for(self._stopping.wait(), timeout=self._interval_s)
+            except TimeoutError:
+                continue

--- a/src/nexus/services/activity/retention.py
+++ b/src/nexus/services/activity/retention.py
@@ -87,10 +87,19 @@ class RetentionTask:
         self._task = asyncio.create_task(self._run())
 
     async def stop(self) -> None:
+        """Wait for the in-flight prune (if any) to finish, then exit.
+
+        Cancellation cannot stop the executor thread mid-VACUUM, so a
+        cancel here would let the thread keep holding the SQLite write
+        lock after stop() returns — and the worker's final drain would
+        then race that lock. Setting the stopping flag is sufficient:
+        ``_run`` checks the flag between iterations and waits on it
+        instead of sleeping, so the loop exits as soon as the current
+        prune finishes.
+        """
         self._stopping.set()
         if self._task is not None:
-            self._task.cancel()
-            with contextlib.suppress(asyncio.CancelledError, Exception):
+            with contextlib.suppress(Exception):
                 await self._task
             self._task = None
 

--- a/src/nexus/services/activity/sinks/__init__.py
+++ b/src/nexus/services/activity/sinks/__init__.py
@@ -1,0 +1,5 @@
+from nexus.services.activity.sinks.noop import NoopSink
+from nexus.services.activity.sinks.protocol import SinkProtocol
+from nexus.services.activity.sinks.recording import RecordingSink
+
+__all__ = ["NoopSink", "RecordingSink", "SinkProtocol"]

--- a/src/nexus/services/activity/sinks/__init__.py
+++ b/src/nexus/services/activity/sinks/__init__.py
@@ -1,5 +1,8 @@
+"""Activity sink implementations: SinkProtocol, NoopSink, RecordingSink, SQLiteSink."""
+
 from nexus.services.activity.sinks.noop import NoopSink
 from nexus.services.activity.sinks.protocol import SinkProtocol
 from nexus.services.activity.sinks.recording import RecordingSink
+from nexus.services.activity.sinks.sqlite import SQLiteSink
 
-__all__ = ["NoopSink", "RecordingSink", "SinkProtocol"]
+__all__ = ["NoopSink", "RecordingSink", "SQLiteSink", "SinkProtocol"]

--- a/src/nexus/services/activity/sinks/noop.py
+++ b/src/nexus/services/activity/sinks/noop.py
@@ -1,0 +1,15 @@
+"""Noop sink — accepts all writes, persists nothing."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from nexus.services.activity.events import ActivityEvent
+
+
+class NoopSink:
+    async def write_batch(self, events: Sequence[ActivityEvent]) -> None:  # noqa: ARG002
+        return None
+
+    async def close(self) -> None:
+        return None

--- a/src/nexus/services/activity/sinks/protocol.py
+++ b/src/nexus/services/activity/sinks/protocol.py
@@ -1,0 +1,22 @@
+"""Sink protocol for the activity worker."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from typing import Protocol, runtime_checkable
+
+from nexus.services.activity.events import ActivityEvent
+
+
+@runtime_checkable
+class SinkProtocol(Protocol):
+    """Where the ActivityWorker flushes batches.
+
+    Implementations must be safe to call concurrently with close(): the
+    worker serializes write_batch calls but may issue close() from
+    a different task.
+    """
+
+    async def write_batch(self, events: Sequence[ActivityEvent]) -> None: ...
+
+    async def close(self) -> None: ...

--- a/src/nexus/services/activity/sinks/recording.py
+++ b/src/nexus/services/activity/sinks/recording.py
@@ -1,0 +1,28 @@
+"""Recording sink — keeps every received event in memory. Tests only."""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from nexus.services.activity.events import ActivityEvent, EventKind
+
+
+class RecordingSink:
+    def __init__(self) -> None:
+        self._events: list[ActivityEvent] = []
+
+    @property
+    def events(self) -> list[ActivityEvent]:
+        return list(self._events)
+
+    def clear(self) -> None:
+        self._events.clear()
+
+    def events_of(self, kind: EventKind) -> list[ActivityEvent]:
+        return [e for e in self._events if e.kind is kind]
+
+    async def write_batch(self, events: Sequence[ActivityEvent]) -> None:
+        self._events.extend(events)
+
+    async def close(self) -> None:
+        return None

--- a/src/nexus/services/activity/sinks/sqlite.py
+++ b/src/nexus/services/activity/sinks/sqlite.py
@@ -1,0 +1,107 @@
+"""Append-only SQLite sink for activity events.
+
+Single-writer connection (``check_same_thread=False`` to allow the worker
+to await ``write_batch`` while the connection lives on a different thread
+in tests). Caller is the activity worker, which serializes calls.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import sqlite3
+from collections.abc import Sequence
+from pathlib import Path
+
+from nexus.services.activity.events import ActivityEvent
+
+logger = logging.getLogger(__name__)
+
+
+_SCHEMA = """
+CREATE TABLE IF NOT EXISTS activity_events (
+    id              TEXT PRIMARY KEY,
+    ts              TEXT NOT NULL,
+    kind            TEXT NOT NULL,
+    result          TEXT NOT NULL,
+    latency_ms      INTEGER,
+    trace_id        TEXT,
+    actor_token_hash TEXT,
+    actor_agent     TEXT,
+    actor_user      TEXT,
+    subject_zone    TEXT,
+    subject_extra   TEXT,
+    meta            TEXT
+) STRICT;
+"""
+
+_INDEXES = (
+    "CREATE INDEX IF NOT EXISTS idx_ae_ts        ON activity_events(ts)",
+    "CREATE INDEX IF NOT EXISTS idx_ae_kind_ts   ON activity_events(kind, ts)",
+    "CREATE INDEX IF NOT EXISTS idx_ae_token_ts  ON activity_events(actor_token_hash, ts)",
+    "CREATE INDEX IF NOT EXISTS idx_ae_zone_ts   ON activity_events(subject_zone, ts)",
+)
+
+_PRAGMAS = (
+    "PRAGMA journal_mode=WAL",
+    "PRAGMA synchronous=NORMAL",
+    "PRAGMA temp_store=MEMORY",
+    "PRAGMA busy_timeout=5000",
+)
+
+
+class SQLiteSink:
+    """Durable append-only sink. Schema bootstrap is idempotent."""
+
+    def __init__(self, *, path: Path | str) -> None:
+        self._path = Path(path)
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn = sqlite3.connect(self._path, check_same_thread=False, isolation_level=None)
+        try:
+            for pragma in _PRAGMAS:
+                self._conn.execute(pragma)
+            self._conn.execute(_SCHEMA)
+            for stmt in _INDEXES:
+                self._conn.execute(stmt)
+        except sqlite3.Error:
+            self._conn.close()
+            raise
+
+    async def write_batch(self, events: Sequence[ActivityEvent]) -> None:
+        if not events:
+            return
+        rows = [
+            (
+                e.id,
+                e.ts,
+                e.kind.value,
+                e.result.value,
+                e.latency_ms,
+                e.trace_id,
+                e.actor.token_hash,
+                e.actor.agent,
+                e.actor.user,
+                e.subject.zone,
+                json.dumps(e.subject.extra) if e.subject.extra is not None else None,
+                json.dumps(e.meta) if e.meta is not None else None,
+            )
+            for e in events
+        ]
+        try:
+            self._conn.executemany(
+                "INSERT OR IGNORE INTO activity_events "
+                "(id, ts, kind, result, latency_ms, trace_id, "
+                " actor_token_hash, actor_agent, actor_user, "
+                " subject_zone, subject_extra, meta) "
+                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+                rows,
+            )
+        except sqlite3.Error:
+            logger.warning("activity SQLiteSink batch insert failed", exc_info=True)
+            raise
+
+    async def close(self) -> None:
+        try:
+            self._conn.close()
+        except sqlite3.Error:
+            logger.warning("activity SQLiteSink close failed", exc_info=True)

--- a/src/nexus/services/activity/sinks/sqlite.py
+++ b/src/nexus/services/activity/sinks/sqlite.py
@@ -1,12 +1,16 @@
 """Append-only SQLite sink for activity events.
 
-Single-writer connection (``check_same_thread=False`` to allow the worker
-to await ``write_batch`` while the connection lives on a different thread
-in tests). Caller is the activity worker, which serializes calls.
+Single-writer connection (``check_same_thread=False`` because writes are
+dispatched via ``asyncio.to_thread`` so the executor thread, not the loop
+thread, owns each ``executemany`` call). Caller is the activity worker,
+which serializes calls — there is never more than one writer thread at a
+time. Keeping I/O off the loop ensures a SQLite busy-wait (e.g. against
+the retention VACUUM connection) cannot stall unrelated request handlers.
 """
 
 from __future__ import annotations
 
+import asyncio
 import json
 import logging
 import sqlite3
@@ -87,21 +91,29 @@ class SQLiteSink:
             )
             for e in events
         ]
+        # Shield the executor write from task cancellation: the to_thread
+        # future cannot stop the underlying thread, so cancelling here would
+        # leave a partial executemany running while shutdown closes the same
+        # connection in close(). asyncio.shield ensures the future completes
+        # before the awaiter is cancelled.
         try:
-            self._conn.executemany(
-                "INSERT OR IGNORE INTO activity_events "
-                "(id, ts, kind, result, latency_ms, trace_id, "
-                " actor_token_hash, actor_agent, actor_user, "
-                " subject_zone, subject_extra, meta) "
-                "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
-                rows,
-            )
+            await asyncio.shield(asyncio.to_thread(self._executemany, rows))
         except sqlite3.Error:
             logger.warning("activity SQLiteSink batch insert failed", exc_info=True)
             raise
 
+    def _executemany(self, rows: Sequence[tuple[object, ...]]) -> None:
+        self._conn.executemany(
+            "INSERT OR IGNORE INTO activity_events "
+            "(id, ts, kind, result, latency_ms, trace_id, "
+            " actor_token_hash, actor_agent, actor_user, "
+            " subject_zone, subject_extra, meta) "
+            "VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+            rows,
+        )
+
     async def close(self) -> None:
         try:
-            self._conn.close()
+            await asyncio.to_thread(self._conn.close)
         except sqlite3.Error:
             logger.warning("activity SQLiteSink close failed", exc_info=True)

--- a/src/nexus/services/activity/worker.py
+++ b/src/nexus/services/activity/worker.py
@@ -81,8 +81,8 @@ class ActivityWorker:
         Wakes early if the stopping event fires; cancels the queue get without
         losing items that landed in flight.
         """
-        getter = asyncio.ensure_future(self._queue.get())
-        stopper = asyncio.ensure_future(self._stopping.wait())
+        getter = asyncio.create_task(self._queue.get())
+        stopper = asyncio.create_task(self._stopping.wait())
         try:
             await asyncio.wait(
                 {getter, stopper},
@@ -107,9 +107,10 @@ class ActivityWorker:
         if first is None:
             return []
         batch = [first]
-        deadline = asyncio.get_event_loop().time() + self._batch_timeout_s
+        loop = asyncio.get_running_loop()
+        deadline = loop.time() + self._batch_timeout_s
         while len(batch) < self._batch_size:
-            remaining = deadline - asyncio.get_event_loop().time()
+            remaining = deadline - loop.time()
             if remaining <= 0:
                 break
             nxt = await self._get_with_stop(remaining)

--- a/src/nexus/services/activity/worker.py
+++ b/src/nexus/services/activity/worker.py
@@ -41,16 +41,59 @@ class ActivityWorker:
             return
         self._stopping.clear()
         self._task = asyncio.create_task(self._consume())
+        self._task.add_done_callback(self._on_task_done)
 
-    async def stop(self, *, timeout: float = 5.0) -> None:
+    def _on_task_done(self, task: asyncio.Task[None]) -> None:
+        """Surface unexpected worker death via the sink-errors counter.
+
+        ``stop()`` sets ``_stopping`` before letting the task exit, so a
+        completion with the flag clear is a crash. The component-level
+        health flag and /metrics need an alertable signal so operators
+        notice that activity persistence stopped happening.
+        """
+        if self._stopping.is_set():
+            return
+        if task.cancelled():
+            logger.warning("activity worker cancelled unexpectedly")
+        else:
+            exc = task.exception()
+            if exc is not None:
+                logger.error("activity worker died unexpectedly", exc_info=exc)
+            else:
+                logger.warning("activity worker exited without stop signal")
+        try:
+            from nexus.services.activity.metrics import ACTIVITY_SINK_ERRORS
+
+            ACTIVITY_SINK_ERRORS.labels(sink="ActivityWorker").inc()
+        except Exception:
+            pass
+
+    def is_healthy(self) -> bool:
+        return self._task is not None and not self._task.done()
+
+    async def stop(self, *, timeout: float = 10.0) -> None:
+        """Drain the queue and close sinks.
+
+        Cancellation cannot stop the SQLite executor thread mid-write, so
+        cancelling the consumer task while it is awaiting ``write_batch``
+        would let the thread keep using the connection while ``close()``
+        runs against it. Instead we set the stopping flag and wait for the
+        consumer to exit naturally — it polls the flag between batches and
+        terminates after the current flush completes. ``timeout`` is a
+        soft budget: when it elapses we log a warning and keep waiting,
+        because closing under a wedged write is the worse failure mode.
+        """
         self._stopping.set()
         if self._task is None:
             return
         try:
-            await asyncio.wait_for(self._task, timeout=timeout)
+            await asyncio.wait_for(asyncio.shield(self._task), timeout=timeout)
         except TimeoutError:
-            self._task.cancel()
-            with contextlib.suppress(asyncio.CancelledError):
+            logger.warning(
+                "activity worker drain exceeded %ss; waiting for in-flight write to finish",
+                timeout,
+            )
+            with contextlib.suppress(Exception):
                 await self._task
         self._task = None
         for sink in self._sinks:
@@ -124,6 +167,12 @@ class ActivityWorker:
             try:
                 await sink.write_batch(batch)
             except Exception:
+                try:
+                    from nexus.services.activity.metrics import ACTIVITY_SINK_ERRORS
+
+                    ACTIVITY_SINK_ERRORS.labels(sink=type(sink).__name__).inc()
+                except Exception:
+                    pass
                 logger.warning(
                     "activity sink %s failed batch write", type(sink).__name__, exc_info=True
                 )

--- a/src/nexus/services/activity/worker.py
+++ b/src/nexus/services/activity/worker.py
@@ -1,0 +1,128 @@
+"""Background worker that drains the activity queue into sinks."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+import logging
+from collections.abc import Sequence
+
+from nexus.services.activity.events import ActivityEvent
+from nexus.services.activity.sinks.protocol import SinkProtocol
+
+logger = logging.getLogger(__name__)
+
+
+class ActivityWorker:
+    """Drain queue into sinks with batching/timeout.
+
+    Lifecycle:
+    - start() creates the consumer asyncio.Task.
+    - stop(timeout) signals shutdown, drains pending events, awaits exit.
+    """
+
+    def __init__(
+        self,
+        *,
+        queue: asyncio.Queue[ActivityEvent],
+        sinks: Sequence[SinkProtocol],
+        batch_size: int = 200,
+        batch_timeout_s: float = 0.5,
+    ) -> None:
+        self._queue = queue
+        self._sinks = list(sinks)
+        self._batch_size = batch_size
+        self._batch_timeout_s = batch_timeout_s
+        self._stopping = asyncio.Event()
+        self._task: asyncio.Task[None] | None = None
+
+    async def start(self) -> None:
+        if self._task is not None and not self._task.done():
+            return
+        self._stopping.clear()
+        self._task = asyncio.create_task(self._consume())
+
+    async def stop(self, *, timeout: float = 5.0) -> None:
+        self._stopping.set()
+        if self._task is None:
+            return
+        try:
+            await asyncio.wait_for(self._task, timeout=timeout)
+        except TimeoutError:
+            self._task.cancel()
+            with contextlib.suppress(asyncio.CancelledError):
+                await self._task
+        self._task = None
+        for sink in self._sinks:
+            with contextlib.suppress(Exception):
+                await sink.close()
+
+    async def _consume(self) -> None:
+        while not self._stopping.is_set():
+            batch = await self._collect_batch()
+            if batch:
+                await self._flush(batch)
+        # Drain remaining events once stopping is set.
+        remainder: list[ActivityEvent] = []
+        while not self._queue.empty():
+            try:
+                remainder.append(self._queue.get_nowait())
+            except asyncio.QueueEmpty:
+                break
+            if len(remainder) >= self._batch_size:
+                await self._flush(remainder)
+                remainder = []
+        if remainder:
+            await self._flush(remainder)
+
+    async def _get_with_stop(self, timeout: float) -> ActivityEvent | None:
+        """Get one event, returning None on timeout or when stopping is set.
+
+        Wakes early if the stopping event fires; cancels the queue get without
+        losing items that landed in flight.
+        """
+        getter = asyncio.ensure_future(self._queue.get())
+        stopper = asyncio.ensure_future(self._stopping.wait())
+        try:
+            await asyncio.wait(
+                {getter, stopper},
+                timeout=timeout,
+                return_when=asyncio.FIRST_COMPLETED,
+            )
+        finally:
+            if not stopper.done():
+                stopper.cancel()
+                with contextlib.suppress(asyncio.CancelledError):
+                    await stopper
+        if getter.done():
+            return getter.result()
+        # Timeout or stop fired before queue produced — cancel the getter.
+        getter.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await getter
+        return None
+
+    async def _collect_batch(self) -> list[ActivityEvent]:
+        first = await self._get_with_stop(self._batch_timeout_s)
+        if first is None:
+            return []
+        batch = [first]
+        deadline = asyncio.get_event_loop().time() + self._batch_timeout_s
+        while len(batch) < self._batch_size:
+            remaining = deadline - asyncio.get_event_loop().time()
+            if remaining <= 0:
+                break
+            nxt = await self._get_with_stop(remaining)
+            if nxt is None:
+                break
+            batch.append(nxt)
+        return batch
+
+    async def _flush(self, batch: list[ActivityEvent]) -> None:
+        for sink in self._sinks:
+            try:
+                await sink.write_batch(batch)
+            except Exception:
+                logger.warning(
+                    "activity sink %s failed batch write", type(sink).__name__, exc_info=True
+                )

--- a/tests/integration/services/activity/test_emission_callsites.py
+++ b/tests/integration/services/activity/test_emission_callsites.py
@@ -1,0 +1,108 @@
+"""Integration: each emission pattern produces the expected event in the sink.
+
+This test verifies the emit() -> queue -> worker -> sink contract that all
+five callsites (SearchService.grep, FederatedSearch.search, RebacChecker
+deny path, ApprovalService request_and_wait/decide, MCPAuditLogMiddleware)
+rely on. The instrumented services have heavy real dependencies; their
+own unit/integration suites cover the wiring of these emit() calls.
+Here we lock the downstream contract.
+"""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+
+from nexus.services.activity import EventKind, Result, set_emitter
+from nexus.services.activity.emitter import QueueEmitter
+from nexus.services.activity.events import ActivityEvent
+from nexus.services.activity.sinks.recording import RecordingSink
+from nexus.services.activity.worker import ActivityWorker
+
+
+@pytest.fixture
+async def recording():
+    queue: asyncio.Queue[ActivityEvent] = asyncio.Queue(maxsize=1024)
+    sink = RecordingSink()
+    worker = ActivityWorker(queue=queue, sinks=[sink], batch_size=10, batch_timeout_s=0.01)
+    await worker.start()
+    set_emitter(QueueEmitter(queue=queue))
+    try:
+        yield sink
+    finally:
+        await worker.stop(timeout=2.0)
+
+
+@pytest.mark.asyncio
+async def test_search_emit_recorded(recording: RecordingSink) -> None:
+    from nexus.services.activity import emit
+
+    emit(
+        kind=EventKind.SEARCH,
+        result=Result.OK,
+        actor_token_hash="tok",
+        subject_zone="eng",
+        latency_ms=12,
+    )
+    await asyncio.sleep(0.1)
+    matches = recording.events_of(EventKind.SEARCH)
+    assert len(matches) == 1
+    assert matches[0].subject.zone == "eng"
+    assert matches[0].latency_ms == 12
+
+
+@pytest.mark.asyncio
+async def test_mcp_tool_call_emit_recorded(recording: RecordingSink) -> None:
+    from nexus.services.activity import emit
+
+    emit(
+        kind=EventKind.MCP_TOOL_CALL,
+        result=Result.OK,
+        actor_token_hash="tok",
+        subject_extra={"tool": "search", "rpc_method": "tools/call"},
+        latency_ms=8,
+    )
+    await asyncio.sleep(0.1)
+    matches = recording.events_of(EventKind.MCP_TOOL_CALL)
+    assert len(matches) == 1
+
+
+@pytest.mark.asyncio
+async def test_zone_access_block_emit_recorded(recording: RecordingSink) -> None:
+    from nexus.services.activity import emit
+
+    emit(
+        kind=EventKind.ZONE_ACCESS,
+        result=Result.BLOCKED,
+        actor_user="alice",
+        subject_zone="legal",
+        subject_extra={"reason": "no_scope"},
+    )
+    await asyncio.sleep(0.1)
+    matches = recording.events_of(EventKind.ZONE_ACCESS)
+    assert len(matches) == 1
+    assert matches[0].result is Result.BLOCKED
+
+
+@pytest.mark.asyncio
+async def test_approval_pending_then_decided_emit_recorded(recording: RecordingSink) -> None:
+    from nexus.services.activity import emit
+
+    emit(
+        kind=EventKind.APPROVAL,
+        result=Result.PENDING_APPROVAL,
+        subject_zone="eng",
+        subject_extra={"request_id": "r1"},
+    )
+    emit(
+        kind=EventKind.APPROVAL,
+        result=Result.OK,
+        subject_zone="eng",
+        subject_extra={"request_id": "r1", "decision": "approved"},
+    )
+    await asyncio.sleep(0.1)
+    matches = recording.events_of(EventKind.APPROVAL)
+    assert len(matches) == 2
+    assert matches[0].result is Result.PENDING_APPROVAL
+    assert matches[1].result is Result.OK

--- a/tests/integration/services/activity/test_emit_to_sqlite_e2e.py
+++ b/tests/integration/services/activity/test_emit_to_sqlite_e2e.py
@@ -1,0 +1,57 @@
+"""End-to-end: setup_activity → emit → drained to SQLite → queryable."""
+
+from __future__ import annotations
+
+import asyncio
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from nexus.services.activity import EventKind, Result, emit
+from nexus.services.activity.emitter import NoopEmitter
+from nexus.services.activity.lifespan import setup_activity, shutdown_activity
+
+
+@pytest.mark.asyncio
+async def test_emit_to_sqlite_roundtrip(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = tmp_path / "activity.db"
+    monkeypatch.setenv("NEXUS_ACTIVITY_ENABLED", "1")
+    monkeypatch.setenv("NEXUS_ACTIVITY_DB_PATH", str(db))
+    monkeypatch.setenv("NEXUS_ACTIVITY_RETENTION_DAYS", "0")  # disable prune
+    monkeypatch.setenv("NEXUS_ACTIVITY_QUEUE_SIZE", "1024")
+    monkeypatch.setenv("NEXUS_ACTIVITY_BATCH_SIZE", "10")
+    monkeypatch.setenv("NEXUS_ACTIVITY_BATCH_TIMEOUT_S", "0.01")
+
+    setup_activity()
+    try:
+        for i in range(50):
+            emit(
+                kind=EventKind.SEARCH,
+                result=Result.OK,
+                actor_token_hash=f"tok{i % 3}",
+                subject_zone=f"zone{i % 2}",
+                latency_ms=i,
+            )
+        await asyncio.sleep(0.5)
+    finally:
+        shutdown_activity()
+        await asyncio.sleep(0.2)
+
+    conn = sqlite3.connect(db)
+    rows = list(conn.execute("SELECT kind, result, subject_zone FROM activity_events"))
+    conn.close()
+    assert len(rows) == 50
+    assert all(r[0] == "search" and r[1] == "ok" for r in rows)
+
+
+@pytest.mark.asyncio
+async def test_disabled_installs_noop(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEXUS_ACTIVITY_ENABLED", "0")
+    setup_activity()
+    try:
+        from nexus.services.activity import get_emitter
+
+        assert isinstance(get_emitter(), NoopEmitter)
+    finally:
+        shutdown_activity()

--- a/tests/integration/services/activity/test_emit_to_sqlite_e2e.py
+++ b/tests/integration/services/activity/test_emit_to_sqlite_e2e.py
@@ -23,7 +23,7 @@ async def test_emit_to_sqlite_roundtrip(tmp_path: Path, monkeypatch: pytest.Monk
     monkeypatch.setenv("NEXUS_ACTIVITY_BATCH_SIZE", "10")
     monkeypatch.setenv("NEXUS_ACTIVITY_BATCH_TIMEOUT_S", "0.01")
 
-    setup_activity()
+    await setup_activity()
     try:
         for i in range(50):
             emit(
@@ -35,8 +35,7 @@ async def test_emit_to_sqlite_roundtrip(tmp_path: Path, monkeypatch: pytest.Monk
             )
         await asyncio.sleep(0.5)
     finally:
-        shutdown_activity()
-        await asyncio.sleep(0.2)
+        await shutdown_activity()
 
     conn = sqlite3.connect(db)
     rows = list(conn.execute("SELECT kind, result, subject_zone FROM activity_events"))
@@ -46,12 +45,57 @@ async def test_emit_to_sqlite_roundtrip(tmp_path: Path, monkeypatch: pytest.Monk
 
 
 @pytest.mark.asyncio
+async def test_off_loop_emit_then_shutdown_does_not_lose_event(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """An off-loop emit scheduled immediately before shutdown must either
+    persist to SQLite or count as dropped — never silently disappear.
+    Regression for the call_soon_threadsafe vs worker.stop race."""
+    import threading
+
+    db = tmp_path / "activity.db"
+    monkeypatch.setenv("NEXUS_ACTIVITY_ENABLED", "1")
+    monkeypatch.setenv("NEXUS_ACTIVITY_DB_PATH", str(db))
+    monkeypatch.setenv("NEXUS_ACTIVITY_RETENTION_DAYS", "0")
+
+    await setup_activity()
+    try:
+        from nexus.contracts.protocols.activity import get_emitter
+
+        emitter = get_emitter()
+        ready = threading.Event()
+
+        def _emit_off_loop() -> None:
+            ready.set()
+            emitter.emit(
+                kind=EventKind.SEARCH,
+                result=Result.OK,
+                subject_zone="off-loop",
+            )
+
+        t = threading.Thread(target=_emit_off_loop)
+        t.start()
+        ready.wait()
+        t.join()
+    finally:
+        await shutdown_activity()
+
+    # The event must be in the durable store (the QueueEmitter quiesce
+    # step in shutdown_activity guarantees it).
+    conn = sqlite3.connect(db)
+    rows = list(conn.execute("SELECT subject_zone FROM activity_events"))
+    conn.close()
+    zones = [r[0] for r in rows]
+    assert "off-loop" in zones, f"off-loop event missing from durable store; got {zones}"
+
+
+@pytest.mark.asyncio
 async def test_disabled_installs_noop(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("NEXUS_ACTIVITY_ENABLED", "0")
-    setup_activity()
+    await setup_activity()
     try:
         from nexus.services.activity import get_emitter
 
         assert isinstance(get_emitter(), NoopEmitter)
     finally:
-        shutdown_activity()
+        await shutdown_activity()

--- a/tests/integration/services/activity/test_lifespan_supervision.py
+++ b/tests/integration/services/activity/test_lifespan_supervision.py
@@ -1,0 +1,26 @@
+"""Integration: activity component is wired as optional and tolerates failures."""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.server.lifespan.observability import create_registry
+
+
+def test_activity_registered_as_optional() -> None:
+    registry = create_registry()
+    names = [n for n, *_ in registry._components]  # noqa: SLF001
+    assert "activity" in names
+    activity_entry = next(t for t in registry._components if t[0] == "activity")  # noqa: SLF001
+    assert activity_entry[2] is False  # optional
+
+
+@pytest.mark.asyncio
+async def test_activity_failure_does_not_abort_startup(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Force SQLiteSink to fail by passing a forbidden path; lifespan must
+    fall back to NoopSink and setup_activity returns without raising."""
+    monkeypatch.setenv("NEXUS_ACTIVITY_DB_PATH", "/nonexistent/forbidden/path/activity.db")
+    from nexus.services.activity.lifespan import setup_activity, shutdown_activity
+
+    setup_activity()
+    shutdown_activity()

--- a/tests/integration/services/activity/test_lifespan_supervision.py
+++ b/tests/integration/services/activity/test_lifespan_supervision.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+from pathlib import Path
+
 import pytest
 
 from nexus.server.lifespan.observability import create_registry
@@ -22,5 +24,30 @@ async def test_activity_failure_does_not_abort_startup(monkeypatch: pytest.Monke
     monkeypatch.setenv("NEXUS_ACTIVITY_DB_PATH", "/nonexistent/forbidden/path/activity.db")
     from nexus.services.activity.lifespan import setup_activity, shutdown_activity
 
-    setup_activity()
-    shutdown_activity()
+    await setup_activity()
+    await shutdown_activity()
+
+
+@pytest.mark.asyncio
+async def test_registry_path_installs_queue_emitter(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Server-startup path: registry.start_all() must actually install the
+    QueueEmitter (not silently discard the setup coroutine), and shutdown_all()
+    must restore NoopEmitter after draining the worker. Catches the regression
+    where _make_start/_make_stop wrappers swallowed async return values."""
+    from nexus.contracts.protocols.activity import NoopEmitter, get_emitter
+    from nexus.services.activity.emitter import QueueEmitter
+
+    db = tmp_path / "registry-activity.db"
+    monkeypatch.setenv("NEXUS_ACTIVITY_ENABLED", "1")
+    monkeypatch.setenv("NEXUS_ACTIVITY_DB_PATH", str(db))
+    monkeypatch.setenv("NEXUS_ACTIVITY_RETENTION_DAYS", "0")
+
+    registry = create_registry()
+    await registry.start_all()
+    try:
+        assert isinstance(get_emitter(), QueueEmitter)
+    finally:
+        await registry.shutdown_all()
+    assert isinstance(get_emitter(), NoopEmitter)

--- a/tests/integration/services/activity/test_metrics_endpoint.py
+++ b/tests/integration/services/activity/test_metrics_endpoint.py
@@ -1,0 +1,45 @@
+"""Integration: activity metrics are exposed via the global Prom REGISTRY after emits."""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+
+import pytest
+from prometheus_client import generate_latest
+
+from nexus.services.activity import EventKind, Result, emit
+from nexus.services.activity.lifespan import setup_activity, shutdown_activity
+
+
+@pytest.mark.asyncio
+async def test_metrics_exposed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
+    db = tmp_path / "activity.db"
+    monkeypatch.setenv("NEXUS_ACTIVITY_ENABLED", "1")
+    monkeypatch.setenv("NEXUS_ACTIVITY_DB_PATH", str(db))
+    monkeypatch.setenv("NEXUS_ACTIVITY_RETENTION_DAYS", "0")
+
+    setup_activity()
+    try:
+        emit(
+            kind=EventKind.SEARCH,
+            result=Result.OK,
+            actor_token_hash="t",
+            subject_zone="eng",
+            latency_ms=5,
+        )
+        emit(kind=EventKind.MCP_TOOL_CALL, result=Result.OK, subject_extra={"tool": "search"})
+        emit(kind=EventKind.ZONE_ACCESS, result=Result.BLOCKED, subject_zone="legal")
+        emit(kind=EventKind.APPROVAL, result=Result.PENDING_APPROVAL)
+        await asyncio.sleep(0.2)
+    finally:
+        shutdown_activity()
+        await asyncio.sleep(0.1)
+
+    body = generate_latest().decode()
+    assert "nexus_search_requests_total" in body
+    assert "nexus_search_latency_seconds" in body
+    assert "nexus_mcp_tool_calls_total" in body
+    assert "nexus_policy_blocks_total" in body
+    assert "nexus_approvals_pending" in body
+    assert "nexus_activity_drops_total" in body

--- a/tests/integration/services/activity/test_metrics_endpoint.py
+++ b/tests/integration/services/activity/test_metrics_endpoint.py
@@ -19,7 +19,7 @@ async def test_metrics_exposed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
     monkeypatch.setenv("NEXUS_ACTIVITY_DB_PATH", str(db))
     monkeypatch.setenv("NEXUS_ACTIVITY_RETENTION_DAYS", "0")
 
-    setup_activity()
+    await setup_activity()
     try:
         emit(
             kind=EventKind.SEARCH,
@@ -33,8 +33,7 @@ async def test_metrics_exposed(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) 
         emit(kind=EventKind.APPROVAL, result=Result.PENDING_APPROVAL)
         await asyncio.sleep(0.2)
     finally:
-        shutdown_activity()
-        await asyncio.sleep(0.1)
+        await shutdown_activity()
 
     body = generate_latest().decode()
     assert "nexus_search_requests_total" in body

--- a/tests/unit/server/test_observability_registry.py
+++ b/tests/unit/server/test_observability_registry.py
@@ -337,7 +337,7 @@ class TestCreateRegistry:
     """Tests for create_registry() wiring (Issue #2072)."""
 
     def test_registers_all_providers(self) -> None:
-        """create_registry() should register 5 observability providers."""
+        """create_registry() should register 6 observability providers."""
         from nexus.server.lifespan.observability import create_registry
 
         registry = create_registry()
@@ -347,7 +347,8 @@ class TestCreateRegistry:
         assert "sentry" in names
         assert "pyroscope" in names
         assert "prometheus" in names
-        assert len(names) == 5
+        assert "activity" in names
+        assert len(names) == 6
 
     def test_registration_order_matches_dependency_order(self) -> None:
         from nexus.server.lifespan.observability import create_registry

--- a/tests/unit/services/activity/test_config.py
+++ b/tests/unit/services/activity/test_config.py
@@ -53,3 +53,45 @@ def test_negative_retention_disables(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("NEXUS_ACTIVITY_RETENTION_DAYS", "0")
     cfg = ActivityConfig.from_env()
     assert cfg.retention_days == 0
+
+
+def test_zero_queue_size_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A non-positive queue_size makes asyncio.Queue unbounded — that breaks
+    the bounded-telemetry contract and prevents drop accounting."""
+    monkeypatch.setenv("NEXUS_ACTIVITY_QUEUE_SIZE", "0")
+    with pytest.raises(ValueError, match="NEXUS_ACTIVITY_QUEUE_SIZE"):
+        ActivityConfig.from_env()
+
+
+def test_negative_queue_size_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEXUS_ACTIVITY_QUEUE_SIZE", "-1")
+    with pytest.raises(ValueError, match="NEXUS_ACTIVITY_QUEUE_SIZE"):
+        ActivityConfig.from_env()
+
+
+def test_zero_batch_size_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEXUS_ACTIVITY_BATCH_SIZE", "0")
+    with pytest.raises(ValueError, match="NEXUS_ACTIVITY_BATCH_SIZE"):
+        ActivityConfig.from_env()
+
+
+def test_zero_batch_timeout_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEXUS_ACTIVITY_BATCH_TIMEOUT_S", "0")
+    with pytest.raises(ValueError, match="NEXUS_ACTIVITY_BATCH_TIMEOUT_S"):
+        ActivityConfig.from_env()
+
+
+def test_negative_retention_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    """retention_days=0 disables prune (valid); negative is invalid."""
+    monkeypatch.setenv("NEXUS_ACTIVITY_RETENTION_DAYS", "-1")
+    with pytest.raises(ValueError, match="NEXUS_ACTIVITY_RETENTION_DAYS"):
+        ActivityConfig.from_env()
+
+
+@pytest.mark.parametrize("bad_value", ["nan", "inf", "-inf"])
+def test_non_finite_batch_timeout_rejected(monkeypatch: pytest.MonkeyPatch, bad_value: str) -> None:
+    """NaN passes <=0 (NaN comparisons are False); inf would prevent partial-
+    batch flushes. Both must be rejected at config-parse time."""
+    monkeypatch.setenv("NEXUS_ACTIVITY_BATCH_TIMEOUT_S", bad_value)
+    with pytest.raises(ValueError, match="NEXUS_ACTIVITY_BATCH_TIMEOUT_S"):
+        ActivityConfig.from_env()

--- a/tests/unit/services/activity/test_config.py
+++ b/tests/unit/services/activity/test_config.py
@@ -1,0 +1,55 @@
+"""Unit tests for ActivityConfig env parsing."""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.services.activity.config import ActivityConfig
+
+
+def test_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    for key in (
+        "NEXUS_ACTIVITY_ENABLED",
+        "NEXUS_ACTIVITY_DB_PATH",
+        "NEXUS_ACTIVITY_RETENTION_DAYS",
+        "NEXUS_ACTIVITY_QUEUE_SIZE",
+        "NEXUS_ACTIVITY_BATCH_SIZE",
+        "NEXUS_ACTIVITY_BATCH_TIMEOUT_S",
+        "NEXUS_DATA_DIR",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    cfg = ActivityConfig.from_env()
+    assert cfg.enabled is True
+    assert cfg.retention_days == 30
+    assert cfg.queue_size == 10000
+    assert cfg.batch_size == 200
+    assert cfg.batch_timeout_s == 0.5
+    assert cfg.db_path.name == "activity.db"
+
+
+def test_overrides(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEXUS_ACTIVITY_ENABLED", "0")
+    monkeypatch.setenv("NEXUS_ACTIVITY_DB_PATH", "/tmp/activity-test.db")
+    monkeypatch.setenv("NEXUS_ACTIVITY_RETENTION_DAYS", "7")
+    monkeypatch.setenv("NEXUS_ACTIVITY_QUEUE_SIZE", "100")
+    monkeypatch.setenv("NEXUS_ACTIVITY_BATCH_SIZE", "5")
+    monkeypatch.setenv("NEXUS_ACTIVITY_BATCH_TIMEOUT_S", "0.1")
+    cfg = ActivityConfig.from_env()
+    assert cfg.enabled is False
+    assert str(cfg.db_path) == "/tmp/activity-test.db"
+    assert cfg.retention_days == 7
+    assert cfg.queue_size == 100
+    assert cfg.batch_size == 5
+    assert cfg.batch_timeout_s == 0.1
+
+
+def test_invalid_int_rejected(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEXUS_ACTIVITY_QUEUE_SIZE", "not-a-number")
+    with pytest.raises(ValueError, match="NEXUS_ACTIVITY_QUEUE_SIZE"):
+        ActivityConfig.from_env()
+
+
+def test_negative_retention_disables(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEXUS_ACTIVITY_RETENTION_DAYS", "0")
+    cfg = ActivityConfig.from_env()
+    assert cfg.retention_days == 0

--- a/tests/unit/services/activity/test_emitter.py
+++ b/tests/unit/services/activity/test_emitter.py
@@ -3,11 +3,13 @@
 from __future__ import annotations
 
 import asyncio
+import threading
 
 import pytest
 
 from nexus.services.activity import EventKind, Result, emit, get_emitter, set_emitter
 from nexus.services.activity.emitter import NoopEmitter, QueueEmitter
+from nexus.services.activity.events import ActivityEvent
 
 
 @pytest.fixture(autouse=True)
@@ -64,6 +66,19 @@ def _drain(q: asyncio.Queue) -> list:
     return out
 
 
+def _event(zone: str | None = None):
+    """Construct a bare ActivityEvent for queue pre-fill in tests."""
+    from nexus.services.activity.events import ActivityEvent, Subject
+
+    return ActivityEvent(
+        id="test",
+        ts="t",
+        kind=EventKind.SEARCH,
+        result=Result.OK,
+        subject=Subject(zone=zone),
+    )
+
+
 def test_queue_emitter_enqueues_event() -> None:
     q: asyncio.Queue = asyncio.Queue(maxsize=10)
     emitter = QueueEmitter(queue=q)
@@ -111,3 +126,97 @@ def test_queue_emitter_id_is_unique() -> None:
         emitter.emit(kind=EventKind.SEARCH, result=Result.OK)
     events = _drain(q)
     assert len({e.id for e in events}) == 5
+
+
+@pytest.mark.asyncio
+async def test_off_loop_emit_is_bounded_by_queue_capacity() -> None:
+    """A burst of off-loop emits must not accumulate unbounded scheduled
+    callbacks before any drop counter increments. The cap is the queue's
+    nominal maxsize, so total in-flight memory stays O(maxsize)."""
+    loop = asyncio.get_running_loop()
+    q: asyncio.Queue = asyncio.Queue(maxsize=4)
+    emitter = QueueEmitter(queue=q, loop=loop)
+
+    burst_size = 50
+    barrier = threading.Event()
+
+    def _burst() -> None:
+        barrier.wait()
+        for _ in range(burst_size):
+            emitter.emit(kind=EventKind.SEARCH, result=Result.OK)
+
+    threads = [threading.Thread(target=_burst) for _ in range(2)]
+    for t in threads:
+        t.start()
+    barrier.set()
+    for t in threads:
+        t.join()
+
+    # No loop tick yet — callbacks haven't run. In-flight count (active
+    # emits + scheduled callbacks) must be bounded by queue capacity (4),
+    # not the burst size.
+    assert emitter._inflight <= q.maxsize  # noqa: SLF001
+    # Drops should reflect that the rest were rejected at submit time.
+    assert emitter.drop_count >= (burst_size * 2) - q.maxsize
+
+
+@pytest.mark.asyncio
+async def test_full_queue_drops_before_constructing_event_or_recording_metrics() -> None:
+    """A stalled worker with a full queue must drop hot-path emits at the
+    capacity gate — before ActivityEvent construction or record_metrics —
+    so back-pressured emit() does not record metrics for events that
+    were never accepted."""
+    from prometheus_client import REGISTRY
+
+    from nexus.services.activity.metrics import SEARCH_REQUESTS
+
+    def _sample_search(zone: str) -> float:
+        for fam in REGISTRY.collect():
+            for s in fam.samples:
+                if s.name.startswith(SEARCH_REQUESTS._name) and s.labels.get("zone") == zone:
+                    return s.value
+        return 0.0
+
+    loop = asyncio.get_running_loop()
+    q: asyncio.Queue[ActivityEvent] = asyncio.Queue(maxsize=2)
+    # Pre-fill the queue so the worker is "stalled" from emit's perspective.
+    q.put_nowait(_event(zone="filler"))
+    q.put_nowait(_event(zone="filler"))
+
+    emitter = QueueEmitter(queue=q, loop=loop)
+    metric_before = _sample_search("dropped")
+    drops_before = emitter.drop_count
+
+    emitter.emit(kind=EventKind.SEARCH, result=Result.OK, subject_zone="dropped")
+
+    # Drop accounted, but no SEARCH_REQUESTS{zone="dropped"} counter increment.
+    assert emitter.drop_count == drops_before + 1
+    assert _sample_search("dropped") == metric_before
+
+
+@pytest.mark.asyncio
+async def test_emit_after_quiesce_is_dropped() -> None:
+    """Once quiesce_pending starts, late off-loop emits must be counted as
+    drops instead of being scheduled — otherwise they could land in an
+    orphaned queue after shutdown closes the worker."""
+    loop = asyncio.get_running_loop()
+    q: asyncio.Queue = asyncio.Queue(maxsize=10)
+    emitter = QueueEmitter(queue=q, loop=loop)
+
+    await emitter.quiesce_pending(timeout=0.05)
+
+    drops_before = emitter.drop_count
+    # A late emit from another thread must not enqueue.
+    done = threading.Event()
+
+    def _late_emit() -> None:
+        emitter.emit(kind=EventKind.SEARCH, result=Result.OK)
+        done.set()
+
+    threading.Thread(target=_late_emit).start()
+    done.wait(timeout=1.0)
+    # Yield once to let any (incorrectly) scheduled callback run.
+    await asyncio.sleep(0.02)
+
+    assert q.qsize() == 0, "late emit must not enqueue after quiesce"
+    assert emitter.drop_count == drops_before + 1

--- a/tests/unit/services/activity/test_emitter.py
+++ b/tests/unit/services/activity/test_emitter.py
@@ -2,10 +2,12 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 
 from nexus.services.activity import EventKind, Result, emit, get_emitter, set_emitter
-from nexus.services.activity.emitter import NoopEmitter
+from nexus.services.activity.emitter import NoopEmitter, QueueEmitter
 
 
 @pytest.fixture(autouse=True)
@@ -53,3 +55,59 @@ def test_emit_function_calls_current_emitter() -> None:
     set_emitter(rec)
     emit(kind=EventKind.SEARCH, result=Result.OK)
     assert len(rec.calls) == 1
+
+
+def _drain(q: asyncio.Queue) -> list:
+    out = []
+    while not q.empty():
+        out.append(q.get_nowait())
+    return out
+
+
+def test_queue_emitter_enqueues_event() -> None:
+    q: asyncio.Queue = asyncio.Queue(maxsize=10)
+    emitter = QueueEmitter(queue=q)
+    emitter.emit(kind=EventKind.SEARCH, result=Result.OK, subject_zone="eng", latency_ms=5)
+    events = _drain(q)
+    assert len(events) == 1
+    ev = events[0]
+    assert ev.kind is EventKind.SEARCH
+    assert ev.subject.zone == "eng"
+    assert ev.latency_ms == 5
+    assert ev.id  # non-empty id
+    assert ev.ts  # non-empty ISO ts
+
+
+def test_queue_emitter_drops_on_overflow() -> None:
+    q: asyncio.Queue = asyncio.Queue(maxsize=2)
+    emitter = QueueEmitter(queue=q)
+    emitter.emit(kind=EventKind.SEARCH, result=Result.OK)
+    emitter.emit(kind=EventKind.SEARCH, result=Result.OK)
+    emitter.emit(kind=EventKind.SEARCH, result=Result.OK)  # overflow → drop
+    assert emitter.drop_count == 1
+    assert q.qsize() == 2
+
+
+def test_queue_emitter_never_raises() -> None:
+    q: asyncio.Queue = asyncio.Queue(maxsize=1)
+    emitter = QueueEmitter(queue=q)
+    for _ in range(5):
+        emitter.emit(kind=EventKind.SEARCH, result=Result.OK)
+    assert emitter.drop_count == 4
+
+
+def test_queue_emitter_works_without_running_loop() -> None:
+    """Caller may emit from sync context — put_nowait does not require a loop."""
+    q: asyncio.Queue = asyncio.Queue(maxsize=10)
+    emitter = QueueEmitter(queue=q)
+    emitter.emit(kind=EventKind.SEARCH, result=Result.OK)
+    assert q.qsize() == 1
+
+
+def test_queue_emitter_id_is_unique() -> None:
+    q: asyncio.Queue = asyncio.Queue(maxsize=10)
+    emitter = QueueEmitter(queue=q)
+    for _ in range(5):
+        emitter.emit(kind=EventKind.SEARCH, result=Result.OK)
+    events = _drain(q)
+    assert len({e.id for e in events}) == 5

--- a/tests/unit/services/activity/test_emitter.py
+++ b/tests/unit/services/activity/test_emitter.py
@@ -1,0 +1,55 @@
+"""Unit tests for the Emitter singleton and NoopEmitter."""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.services.activity import EventKind, Result, emit, get_emitter, set_emitter
+from nexus.services.activity.emitter import NoopEmitter
+
+
+@pytest.fixture(autouse=True)
+def _restore_emitter():
+    saved = get_emitter()
+    yield
+    set_emitter(saved)
+
+
+def test_default_emitter_is_noop() -> None:
+    assert isinstance(get_emitter(), NoopEmitter)
+
+
+def test_noop_emitter_drops_silently() -> None:
+    emitter = NoopEmitter()
+    emitter.emit(
+        kind=EventKind.SEARCH,
+        result=Result.OK,
+        actor_token_hash=None,
+        actor_agent=None,
+        actor_user=None,
+        subject_zone=None,
+        subject_extra=None,
+        latency_ms=None,
+        trace_id=None,
+        meta=None,
+    )
+
+
+def test_set_emitter_swaps_singleton() -> None:
+    custom = NoopEmitter()
+    set_emitter(custom)
+    assert get_emitter() is custom
+
+
+def test_emit_function_calls_current_emitter() -> None:
+    class _Recording(NoopEmitter):
+        def __init__(self) -> None:
+            self.calls: list[tuple] = []
+
+        def emit(self, **kw) -> None:
+            self.calls.append(tuple(kw.items()))
+
+    rec = _Recording()
+    set_emitter(rec)
+    emit(kind=EventKind.SEARCH, result=Result.OK)
+    assert len(rec.calls) == 1

--- a/tests/unit/services/activity/test_events.py
+++ b/tests/unit/services/activity/test_events.py
@@ -1,0 +1,81 @@
+"""Unit tests for ActivityEvent schema and enums."""
+
+from __future__ import annotations
+
+import dataclasses
+
+import pytest
+
+from nexus.services.activity.events import (
+    ActivityEvent,
+    Actor,
+    EventKind,
+    Result,
+    Subject,
+)
+
+
+def test_event_kinds_match_issue_schema() -> None:
+    expected = {"search", "fetch", "mcp_tool_call", "zone_access", "policy_block", "approval"}
+    assert {k.value for k in EventKind} == expected
+
+
+def test_results_match_issue_schema() -> None:
+    expected = {"ok", "blocked", "pending_approval"}
+    assert {r.value for r in Result} == expected
+
+
+def test_actor_subject_default_none() -> None:
+    actor = Actor()
+    assert actor.token_hash is None
+    assert actor.agent is None
+    assert actor.user is None
+    subject = Subject()
+    assert subject.zone is None
+    assert subject.extra is None
+
+
+def test_activity_event_minimal_construction() -> None:
+    ev = ActivityEvent(
+        id="01ABCDEFGHJKMNPQRSTVWXYZ00",
+        ts="2026-04-30T12:00:00Z",
+        kind=EventKind.SEARCH,
+        result=Result.OK,
+    )
+    assert ev.kind is EventKind.SEARCH
+    assert ev.result is Result.OK
+    assert ev.actor.token_hash is None
+    assert ev.subject.zone is None
+    assert ev.latency_ms is None
+    assert ev.trace_id is None
+    assert ev.meta is None
+
+
+def test_activity_event_full_construction() -> None:
+    ev = ActivityEvent(
+        id="01ABCDEFGHJKMNPQRSTVWXYZ00",
+        ts="2026-04-30T12:00:00Z",
+        kind=EventKind.MCP_TOOL_CALL,
+        result=Result.OK,
+        latency_ms=42,
+        trace_id="trace-1",
+        actor=Actor(token_hash="abc1234567890def", agent="claude", user="alice"),
+        subject=Subject(zone="eng", extra={"tool": "search"}),
+        meta={"k": "v"},
+    )
+    assert ev.actor.token_hash == "abc1234567890def"
+    assert ev.subject.extra == {"tool": "search"}
+    assert ev.meta == {"k": "v"}
+
+
+def test_activity_event_is_frozen() -> None:
+    ev = ActivityEvent(
+        id="x",
+        ts="t",
+        kind=EventKind.SEARCH,
+        result=Result.OK,
+    )
+    # object.__setattr__ bypasses frozen on CPython 3.14+; direct assignment
+    # goes through the descriptor machinery and correctly raises FrozenInstanceError.
+    with pytest.raises(dataclasses.FrozenInstanceError):
+        ev.kind = EventKind.FETCH

--- a/tests/unit/services/activity/test_metrics.py
+++ b/tests/unit/services/activity/test_metrics.py
@@ -32,9 +32,9 @@ def _sample(metric, **labels) -> float:
 
 
 def test_search_request_increments_counter() -> None:
-    before = _sample(SEARCH_REQUESTS, zone="eng", token_hash="x", status="ok")
-    SEARCH_REQUESTS.labels(zone="eng", token_hash="x", status="ok").inc()
-    after = _sample(SEARCH_REQUESTS, zone="eng", token_hash="x", status="ok")
+    before = _sample(SEARCH_REQUESTS, zone="eng", status="ok")
+    SEARCH_REQUESTS.labels(zone="eng", status="ok").inc()
+    after = _sample(SEARCH_REQUESTS, zone="eng", status="ok")
     assert after == before + 1
 
 
@@ -63,7 +63,7 @@ def test_activity_drops_counter_present() -> None:
 async def test_queue_emitter_records_metrics() -> None:
     q: asyncio.Queue = asyncio.Queue(maxsize=10)
     emitter = QueueEmitter(queue=q)
-    before_search = _sample(SEARCH_REQUESTS, zone="eng", token_hash="abc", status="ok")
+    before_search = _sample(SEARCH_REQUESTS, zone="eng", status="ok")
     emitter.emit(
         kind=EventKind.SEARCH,
         result=Result.OK,
@@ -71,7 +71,7 @@ async def test_queue_emitter_records_metrics() -> None:
         subject_zone="eng",
         latency_ms=42,
     )
-    after_search = _sample(SEARCH_REQUESTS, zone="eng", token_hash="abc", status="ok")
+    after_search = _sample(SEARCH_REQUESTS, zone="eng", status="ok")
     assert after_search == before_search + 1
 
 
@@ -87,7 +87,7 @@ async def test_queue_emitter_drops_increment_drop_metric() -> None:
 
 
 def test_record_metrics_dispatches_search() -> None:
-    before = _sample(SEARCH_REQUESTS, zone="d-eng", token_hash="d-tok", status="ok")
+    before = _sample(SEARCH_REQUESTS, zone="d-eng", status="ok")
     record_metrics(
         kind=EventKind.SEARCH,
         result=Result.OK,
@@ -96,7 +96,7 @@ def test_record_metrics_dispatches_search() -> None:
         subject_extra=None,
         latency_ms=10,
     )
-    after = _sample(SEARCH_REQUESTS, zone="d-eng", token_hash="d-tok", status="ok")
+    after = _sample(SEARCH_REQUESTS, zone="d-eng", status="ok")
     assert after == before + 1
 
 
@@ -157,32 +157,37 @@ def test_record_metrics_zone_access_ok_does_not_increment_blocks() -> None:
     assert after == before
 
 
-def test_record_metrics_dispatches_approval_pending_inc() -> None:
+def test_record_metrics_does_not_mutate_approvals_pending() -> None:
+    """APPROVALS_PENDING is reseeded from durable state by ApprovalService at
+    every transition (and at startup); record_metrics must not touch it.
+    Otherwise per-process delta accounting drifts on cross-worker decisions.
+    """
     before = _sample(APPROVALS_PENDING)
-    record_metrics(
-        kind=EventKind.APPROVAL,
-        result=Result.PENDING_APPROVAL,
-        actor_token_hash=None,
-        subject_zone=None,
-        subject_extra=None,
-        latency_ms=None,
-    )
+    for result in (Result.PENDING_APPROVAL, Result.OK, Result.BLOCKED):
+        record_metrics(
+            kind=EventKind.APPROVAL,
+            result=result,
+            actor_token_hash=None,
+            subject_zone=None,
+            subject_extra=None,
+            latency_ms=None,
+        )
     after = _sample(APPROVALS_PENDING)
-    assert after == before + 1
+    assert after == before
 
 
-def test_record_metrics_dispatches_approval_resolved_dec() -> None:
-    before = _sample(APPROVALS_PENDING)
-    record_metrics(
-        kind=EventKind.APPROVAL,
-        result=Result.OK,
-        actor_token_hash=None,
-        subject_zone=None,
-        subject_extra=None,
-        latency_ms=None,
-    )
-    after = _sample(APPROVALS_PENDING)
-    assert after == before - 1
+def test_reseed_approvals_pending_sets_gauge_authoritatively() -> None:
+    """The contracts-layer reseed function must overwrite the gauge with the
+    durable count, not increment/decrement."""
+    from nexus.contracts.protocols.activity import reseed_approvals_pending
+
+    reseed_approvals_pending(0)
+    assert _sample(APPROVALS_PENDING) == 0
+    reseed_approvals_pending(7)
+    assert _sample(APPROVALS_PENDING) == 7
+    reseed_approvals_pending(3)
+    assert _sample(APPROVALS_PENDING) == 3
+    reseed_approvals_pending(0)
 
 
 def test_record_metrics_fetch_is_noop() -> None:

--- a/tests/unit/services/activity/test_metrics.py
+++ b/tests/unit/services/activity/test_metrics.py
@@ -16,6 +16,7 @@ from nexus.services.activity.metrics import (
     POLICY_BLOCKS,
     SEARCH_LATENCY,
     SEARCH_REQUESTS,
+    record_metrics,
 )
 
 
@@ -83,3 +84,114 @@ async def test_queue_emitter_drops_increment_drop_metric() -> None:
     emitter.emit(kind=EventKind.SEARCH, result=Result.OK)  # overflow → drop
     after = _sample(ACTIVITY_DROPS)
     assert after == before + 1
+
+
+def test_record_metrics_dispatches_search() -> None:
+    before = _sample(SEARCH_REQUESTS, zone="d-eng", token_hash="d-tok", status="ok")
+    record_metrics(
+        kind=EventKind.SEARCH,
+        result=Result.OK,
+        actor_token_hash="d-tok",
+        subject_zone="d-eng",
+        subject_extra=None,
+        latency_ms=10,
+    )
+    after = _sample(SEARCH_REQUESTS, zone="d-eng", token_hash="d-tok", status="ok")
+    assert after == before + 1
+
+
+def test_record_metrics_dispatches_mcp_tool_call() -> None:
+    before = _sample(MCP_TOOL_CALLS, tool="d-tool", status="ok")
+    record_metrics(
+        kind=EventKind.MCP_TOOL_CALL,
+        result=Result.OK,
+        actor_token_hash=None,
+        subject_zone=None,
+        subject_extra={"tool": "d-tool"},
+        latency_ms=None,
+    )
+    after = _sample(MCP_TOOL_CALLS, tool="d-tool", status="ok")
+    assert after == before + 1
+
+
+def test_record_metrics_dispatches_zone_access_blocked() -> None:
+    before = _sample(POLICY_BLOCKS, kind="zone_access")
+    record_metrics(
+        kind=EventKind.ZONE_ACCESS,
+        result=Result.BLOCKED,
+        actor_token_hash=None,
+        subject_zone="d-eng",
+        subject_extra=None,
+        latency_ms=None,
+    )
+    after = _sample(POLICY_BLOCKS, kind="zone_access")
+    assert after == before + 1
+
+
+def test_record_metrics_dispatches_policy_block_blocked() -> None:
+    before = _sample(POLICY_BLOCKS, kind="policy_block")
+    record_metrics(
+        kind=EventKind.POLICY_BLOCK,
+        result=Result.BLOCKED,
+        actor_token_hash=None,
+        subject_zone=None,
+        subject_extra=None,
+        latency_ms=None,
+    )
+    after = _sample(POLICY_BLOCKS, kind="policy_block")
+    assert after == before + 1
+
+
+def test_record_metrics_zone_access_ok_does_not_increment_blocks() -> None:
+    """ZONE_ACCESS with result=OK must NOT increment POLICY_BLOCKS."""
+    before = _sample(POLICY_BLOCKS, kind="zone_access")
+    record_metrics(
+        kind=EventKind.ZONE_ACCESS,
+        result=Result.OK,
+        actor_token_hash=None,
+        subject_zone="d-eng",
+        subject_extra=None,
+        latency_ms=None,
+    )
+    after = _sample(POLICY_BLOCKS, kind="zone_access")
+    assert after == before
+
+
+def test_record_metrics_dispatches_approval_pending_inc() -> None:
+    before = _sample(APPROVALS_PENDING)
+    record_metrics(
+        kind=EventKind.APPROVAL,
+        result=Result.PENDING_APPROVAL,
+        actor_token_hash=None,
+        subject_zone=None,
+        subject_extra=None,
+        latency_ms=None,
+    )
+    after = _sample(APPROVALS_PENDING)
+    assert after == before + 1
+
+
+def test_record_metrics_dispatches_approval_resolved_dec() -> None:
+    before = _sample(APPROVALS_PENDING)
+    record_metrics(
+        kind=EventKind.APPROVAL,
+        result=Result.OK,
+        actor_token_hash=None,
+        subject_zone=None,
+        subject_extra=None,
+        latency_ms=None,
+    )
+    after = _sample(APPROVALS_PENDING)
+    assert after == before - 1
+
+
+def test_record_metrics_fetch_is_noop() -> None:
+    """FETCH currently has no metric — record_metrics must not raise."""
+    record_metrics(
+        kind=EventKind.FETCH,
+        result=Result.OK,
+        actor_token_hash=None,
+        subject_zone=None,
+        subject_extra=None,
+        latency_ms=None,
+    )

--- a/tests/unit/services/activity/test_metrics.py
+++ b/tests/unit/services/activity/test_metrics.py
@@ -1,0 +1,85 @@
+"""Unit tests for the activity metrics catalog."""
+
+from __future__ import annotations
+
+import asyncio
+
+import pytest
+from prometheus_client import REGISTRY
+
+from nexus.services.activity import EventKind, Result
+from nexus.services.activity.emitter import QueueEmitter
+from nexus.services.activity.metrics import (
+    ACTIVITY_DROPS,
+    APPROVALS_PENDING,
+    MCP_TOOL_CALLS,
+    POLICY_BLOCKS,
+    SEARCH_LATENCY,
+    SEARCH_REQUESTS,
+)
+
+
+def _sample(metric, **labels) -> float:
+    """Return the current value of a Prom metric for the given label set."""
+    for fam in REGISTRY.collect():
+        for s in fam.samples:
+            if s.name.startswith(metric._name) and all(
+                s.labels.get(k) == v for k, v in labels.items()
+            ):
+                return s.value
+    return 0.0
+
+
+def test_search_request_increments_counter() -> None:
+    before = _sample(SEARCH_REQUESTS, zone="eng", token_hash="x", status="ok")
+    SEARCH_REQUESTS.labels(zone="eng", token_hash="x", status="ok").inc()
+    after = _sample(SEARCH_REQUESTS, zone="eng", token_hash="x", status="ok")
+    assert after == before + 1
+
+
+def test_search_latency_observed() -> None:
+    SEARCH_LATENCY.labels(zone="eng").observe(0.05)
+
+
+def test_mcp_tool_calls_counter_present() -> None:
+    MCP_TOOL_CALLS.labels(tool="search", status="ok").inc()
+
+
+def test_policy_blocks_counter_present() -> None:
+    POLICY_BLOCKS.labels(kind="zone_access").inc()
+
+
+def test_approvals_pending_gauge_inc_dec_balanced() -> None:
+    APPROVALS_PENDING.inc()
+    APPROVALS_PENDING.dec()
+
+
+def test_activity_drops_counter_present() -> None:
+    ACTIVITY_DROPS.inc()
+
+
+@pytest.mark.asyncio
+async def test_queue_emitter_records_metrics() -> None:
+    q: asyncio.Queue = asyncio.Queue(maxsize=10)
+    emitter = QueueEmitter(queue=q)
+    before_search = _sample(SEARCH_REQUESTS, zone="eng", token_hash="abc", status="ok")
+    emitter.emit(
+        kind=EventKind.SEARCH,
+        result=Result.OK,
+        actor_token_hash="abc",
+        subject_zone="eng",
+        latency_ms=42,
+    )
+    after_search = _sample(SEARCH_REQUESTS, zone="eng", token_hash="abc", status="ok")
+    assert after_search == before_search + 1
+
+
+@pytest.mark.asyncio
+async def test_queue_emitter_drops_increment_drop_metric() -> None:
+    q: asyncio.Queue = asyncio.Queue(maxsize=1)
+    emitter = QueueEmitter(queue=q)
+    before = _sample(ACTIVITY_DROPS)
+    emitter.emit(kind=EventKind.SEARCH, result=Result.OK)
+    emitter.emit(kind=EventKind.SEARCH, result=Result.OK)  # overflow → drop
+    after = _sample(ACTIVITY_DROPS)
+    assert after == before + 1

--- a/tests/unit/services/activity/test_recording_sink.py
+++ b/tests/unit/services/activity/test_recording_sink.py
@@ -1,0 +1,44 @@
+"""Unit tests for sink protocol + NoopSink + RecordingSink."""
+
+from __future__ import annotations
+
+import pytest
+
+from nexus.services.activity.events import ActivityEvent, EventKind, Result
+from nexus.services.activity.sinks import NoopSink, RecordingSink
+
+
+def _ev(kind: EventKind = EventKind.SEARCH) -> ActivityEvent:
+    return ActivityEvent(id="x", ts="t", kind=kind, result=Result.OK)
+
+
+@pytest.mark.asyncio
+async def test_noop_sink_accepts_writes() -> None:
+    sink = NoopSink()
+    await sink.write_batch([_ev(), _ev()])
+    await sink.close()
+
+
+@pytest.mark.asyncio
+async def test_recording_sink_collects_events() -> None:
+    sink = RecordingSink()
+    await sink.write_batch([_ev(EventKind.SEARCH), _ev(EventKind.FETCH)])
+    assert len(sink.events) == 2
+    assert sink.events[0].kind is EventKind.SEARCH
+    assert sink.events[1].kind is EventKind.FETCH
+
+
+@pytest.mark.asyncio
+async def test_recording_sink_clear() -> None:
+    sink = RecordingSink()
+    await sink.write_batch([_ev()])
+    sink.clear()
+    assert sink.events == []
+
+
+@pytest.mark.asyncio
+async def test_recording_sink_filter() -> None:
+    sink = RecordingSink()
+    await sink.write_batch([_ev(EventKind.SEARCH), _ev(EventKind.FETCH), _ev(EventKind.SEARCH)])
+    matches = sink.events_of(EventKind.SEARCH)
+    assert len(matches) == 2

--- a/tests/unit/services/activity/test_retention.py
+++ b/tests/unit/services/activity/test_retention.py
@@ -2,11 +2,14 @@
 
 from __future__ import annotations
 
+import asyncio
 import sqlite3
 from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
-from nexus.services.activity.retention import prune_older_than
+import pytest
+
+from nexus.services.activity.retention import RetentionTask, prune_older_than
 
 
 def _seed(db: Path) -> None:
@@ -99,3 +102,59 @@ def test_prune_handles_missing_db(tmp_path: Path) -> None:
     db = tmp_path / "missing.db"
     deleted = prune_older_than(db_path=db, retention_days=30)
     assert deleted == 0
+
+
+def test_prune_runs_vacuum_above_threshold(tmp_path: Path) -> None:
+    """vacuum_threshold=1 forces VACUUM after a single deletion."""
+    db = tmp_path / "activity.db"
+    _seed(db)
+    deleted = prune_older_than(db_path=db, retention_days=30, vacuum_threshold=1)
+    assert deleted == 2
+    # File still readable after VACUUM
+    conn = sqlite3.connect(db)
+    count = conn.execute("SELECT COUNT(*) FROM activity_events").fetchone()[0]
+    assert count == 2
+    conn.close()
+
+
+@pytest.mark.asyncio
+async def test_retention_task_zero_disables_start(tmp_path: Path) -> None:
+    db = tmp_path / "activity.db"
+    _seed(db)
+    task = RetentionTask(db_path=db, retention_days=0, interval_s=0.01)
+    await task.start()
+    assert task._task is None  # noqa: SLF001
+    await task.stop()
+
+
+@pytest.mark.asyncio
+async def test_retention_task_runs_and_prunes(tmp_path: Path) -> None:
+    db = tmp_path / "activity.db"
+    _seed(db)
+    task = RetentionTask(db_path=db, retention_days=30, interval_s=0.05, vacuum_threshold=1)
+    await task.start()
+    await asyncio.sleep(0.2)
+    await task.stop()
+    assert task.total_pruned == 2
+    conn = sqlite3.connect(db)
+    remaining = {row[0] for row in conn.execute("SELECT id FROM activity_events")}
+    assert remaining == {"new1", "new2"}
+    conn.close()
+
+
+@pytest.mark.asyncio
+async def test_retention_task_stop_before_start_is_safe(tmp_path: Path) -> None:
+    task = RetentionTask(db_path=tmp_path / "activity.db", retention_days=30, interval_s=0.01)
+    await task.stop()  # must not raise
+
+
+@pytest.mark.asyncio
+async def test_retention_task_double_start_is_idempotent(tmp_path: Path) -> None:
+    db = tmp_path / "activity.db"
+    _seed(db)
+    task = RetentionTask(db_path=db, retention_days=30, interval_s=0.01)
+    await task.start()
+    first_task = task._task  # noqa: SLF001
+    await task.start()
+    assert task._task is first_task  # noqa: SLF001
+    await task.stop()

--- a/tests/unit/services/activity/test_retention.py
+++ b/tests/unit/services/activity/test_retention.py
@@ -133,7 +133,14 @@ async def test_retention_task_runs_and_prunes(tmp_path: Path) -> None:
     _seed(db)
     task = RetentionTask(db_path=db, retention_days=30, interval_s=0.05, vacuum_threshold=1)
     await task.start()
-    await asyncio.sleep(0.2)
+    # Poll for the first prune to complete instead of relying on a fixed
+    # sleep — under heavy parallel load (xdist) the asyncio scheduler may
+    # not run the task body within a small window, making any hard-coded
+    # delay flaky.
+    for _ in range(200):
+        if task.total_pruned >= 2:
+            break
+        await asyncio.sleep(0.02)
     await task.stop()
     assert task.total_pruned == 2
     conn = sqlite3.connect(db)

--- a/tests/unit/services/activity/test_retention.py
+++ b/tests/unit/services/activity/test_retention.py
@@ -1,0 +1,101 @@
+"""Unit tests for RetentionTask."""
+
+from __future__ import annotations
+
+import sqlite3
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from nexus.services.activity.retention import prune_older_than
+
+
+def _seed(db: Path) -> None:
+    conn = sqlite3.connect(db)
+    conn.execute(
+        """CREATE TABLE activity_events (
+            id TEXT PRIMARY KEY, ts TEXT NOT NULL, kind TEXT, result TEXT,
+            latency_ms INTEGER, trace_id TEXT, actor_token_hash TEXT,
+            actor_agent TEXT, actor_user TEXT, subject_zone TEXT,
+            subject_extra TEXT, meta TEXT
+        ) STRICT"""
+    )
+    now = datetime.now(tz=UTC)
+    rows = [
+        (
+            "old1",
+            (now - timedelta(days=40)).isoformat(),
+            "search",
+            "ok",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+        (
+            "old2",
+            (now - timedelta(days=31)).isoformat(),
+            "search",
+            "ok",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+        (
+            "new1",
+            (now - timedelta(days=10)).isoformat(),
+            "search",
+            "ok",
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+            None,
+        ),
+        ("new2", now.isoformat(), "search", "ok", None, None, None, None, None, None, None, None),
+    ]
+    conn.executemany(
+        "INSERT INTO activity_events VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)",
+        rows,
+    )
+    conn.commit()
+    conn.close()
+
+
+def test_prune_deletes_rows_older_than_threshold(tmp_path: Path) -> None:
+    db = tmp_path / "activity.db"
+    _seed(db)
+    deleted = prune_older_than(db_path=db, retention_days=30)
+    assert deleted == 2
+    conn = sqlite3.connect(db)
+    remaining = {row[0] for row in conn.execute("SELECT id FROM activity_events")}
+    assert remaining == {"new1", "new2"}
+    conn.close()
+
+
+def test_prune_retention_zero_is_noop(tmp_path: Path) -> None:
+    db = tmp_path / "activity.db"
+    _seed(db)
+    deleted = prune_older_than(db_path=db, retention_days=0)
+    assert deleted == 0
+    conn = sqlite3.connect(db)
+    count = conn.execute("SELECT COUNT(*) FROM activity_events").fetchone()[0]
+    assert count == 4
+    conn.close()
+
+
+def test_prune_handles_missing_db(tmp_path: Path) -> None:
+    db = tmp_path / "missing.db"
+    deleted = prune_older_than(db_path=db, retention_days=30)
+    assert deleted == 0

--- a/tests/unit/services/activity/test_sqlite_sink.py
+++ b/tests/unit/services/activity/test_sqlite_sink.py
@@ -1,0 +1,115 @@
+"""Unit tests for SQLiteSink."""
+
+from __future__ import annotations
+
+import json
+import sqlite3
+from pathlib import Path
+
+import pytest
+
+from nexus.services.activity.events import ActivityEvent, Actor, EventKind, Result, Subject
+from nexus.services.activity.sinks.sqlite import SQLiteSink
+
+
+@pytest.mark.asyncio
+async def test_schema_bootstrapped_on_open(tmp_path: Path) -> None:
+    db = tmp_path / "activity.db"
+    sink = SQLiteSink(path=db)
+    try:
+        conn = sqlite3.connect(db)
+        cursor = conn.execute(
+            "SELECT name FROM sqlite_master WHERE type='table' AND name='activity_events'"
+        )
+        assert cursor.fetchone() is not None
+        idx = {
+            row[0]
+            for row in conn.execute(
+                "SELECT name FROM sqlite_master WHERE type='index' AND tbl_name='activity_events'"
+            )
+        }
+        assert "idx_ae_ts" in idx
+        assert "idx_ae_kind_ts" in idx
+        assert "idx_ae_token_ts" in idx
+        assert "idx_ae_zone_ts" in idx
+        conn.close()
+    finally:
+        await sink.close()
+
+
+@pytest.mark.asyncio
+async def test_pragmas_applied(tmp_path: Path) -> None:
+    db = tmp_path / "activity.db"
+    sink = SQLiteSink(path=db)
+    try:
+        # journal_mode is persistent in the DB file; synchronous is per-connection
+        # so we query it through the sink's own connection.
+        conn = sqlite3.connect(db)
+        assert conn.execute("PRAGMA journal_mode").fetchone()[0].lower() == "wal"
+        conn.close()
+        assert sink._conn.execute("PRAGMA synchronous").fetchone()[0] == 1  # NORMAL
+    finally:
+        await sink.close()
+
+
+@pytest.mark.asyncio
+async def test_batch_insert_roundtrip(tmp_path: Path) -> None:
+    db = tmp_path / "activity.db"
+    sink = SQLiteSink(path=db)
+    try:
+        events = [
+            ActivityEvent(
+                id="1",
+                ts="2026-04-30T00:00:00Z",
+                kind=EventKind.SEARCH,
+                result=Result.OK,
+                latency_ms=10,
+                trace_id="t1",
+                actor=Actor(token_hash="aaa", agent="claude", user="alice"),
+                subject=Subject(zone="eng", extra={"q": "foo"}),
+                meta={"x": 1},
+            ),
+            ActivityEvent(
+                id="2",
+                ts="2026-04-30T00:00:01Z",
+                kind=EventKind.MCP_TOOL_CALL,
+                result=Result.OK,
+            ),
+        ]
+        await sink.write_batch(events)
+    finally:
+        await sink.close()
+
+    conn = sqlite3.connect(db)
+    rows = list(
+        conn.execute(
+            "SELECT id, kind, result, subject_zone, subject_extra, meta "
+            "FROM activity_events ORDER BY id"
+        )
+    )
+    assert rows[0][0] == "1"
+    assert rows[0][1] == "search"
+    assert rows[0][3] == "eng"
+    assert json.loads(rows[0][4]) == {"q": "foo"}
+    assert json.loads(rows[0][5]) == {"x": 1}
+    assert rows[1][0] == "2"
+    assert rows[1][3] is None
+    assert rows[1][4] is None
+    conn.close()
+
+
+@pytest.mark.asyncio
+async def test_open_idempotent_on_existing_db(tmp_path: Path) -> None:
+    db = tmp_path / "activity.db"
+    sink1 = SQLiteSink(path=db)
+    await sink1.close()
+    sink2 = SQLiteSink(path=db)
+    await sink2.close()
+
+
+@pytest.mark.asyncio
+async def test_corrupt_file_raises(tmp_path: Path) -> None:
+    db = tmp_path / "activity.db"
+    db.write_bytes(b"not a sqlite file")
+    with pytest.raises(sqlite3.DatabaseError):
+        SQLiteSink(path=db)

--- a/tests/unit/services/activity/test_worker.py
+++ b/tests/unit/services/activity/test_worker.py
@@ -1,0 +1,102 @@
+"""Unit tests for ActivityWorker."""
+
+from __future__ import annotations
+
+import asyncio
+from collections.abc import Sequence
+
+import pytest
+
+from nexus.services.activity.events import ActivityEvent, EventKind, Result
+from nexus.services.activity.sinks import RecordingSink
+from nexus.services.activity.worker import ActivityWorker
+
+
+def _ev(i: int) -> ActivityEvent:
+    return ActivityEvent(id=str(i), ts=f"t{i}", kind=EventKind.SEARCH, result=Result.OK)
+
+
+@pytest.mark.asyncio
+async def test_drains_queue_to_sink() -> None:
+    queue: asyncio.Queue[ActivityEvent] = asyncio.Queue()
+    sink = RecordingSink()
+    worker = ActivityWorker(queue=queue, sinks=[sink], batch_size=10, batch_timeout_s=0.01)
+    await worker.start()
+    for i in range(5):
+        queue.put_nowait(_ev(i))
+    await asyncio.sleep(0.1)
+    await worker.stop(timeout=1.0)
+    assert len(sink.events) == 5
+
+
+@pytest.mark.asyncio
+async def test_batches_up_to_batch_size() -> None:
+    queue: asyncio.Queue[ActivityEvent] = asyncio.Queue()
+    write_call_sizes: list[int] = []
+
+    class _CountingSink(RecordingSink):
+        async def write_batch(self, events: Sequence[ActivityEvent]) -> None:
+            write_call_sizes.append(len(events))
+            await super().write_batch(events)
+
+    sink = _CountingSink()
+    worker = ActivityWorker(queue=queue, sinks=[sink], batch_size=3, batch_timeout_s=1.0)
+    await worker.start()
+    for i in range(7):
+        queue.put_nowait(_ev(i))
+    await asyncio.sleep(0.1)
+    await worker.stop(timeout=1.0)
+    assert all(s <= 3 for s in write_call_sizes)
+    assert sum(write_call_sizes) == 7
+
+
+@pytest.mark.asyncio
+async def test_flushes_partial_batch_on_timeout() -> None:
+    queue: asyncio.Queue[ActivityEvent] = asyncio.Queue()
+    sink = RecordingSink()
+    worker = ActivityWorker(queue=queue, sinks=[sink], batch_size=100, batch_timeout_s=0.05)
+    await worker.start()
+    queue.put_nowait(_ev(1))
+    await asyncio.sleep(0.2)
+    assert len(sink.events) == 1
+    await worker.stop(timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_sink_error_isolated() -> None:
+    queue: asyncio.Queue[ActivityEvent] = asyncio.Queue()
+
+    class _Flaky:
+        calls = 0
+
+        async def write_batch(self, events: Sequence[ActivityEvent]) -> None:
+            type(self).calls += 1
+            raise RuntimeError("boom")
+
+        async def close(self) -> None:
+            return None
+
+    flaky = _Flaky()
+    sink_ok = RecordingSink()
+    worker = ActivityWorker(
+        queue=queue, sinks=[flaky, sink_ok], batch_size=10, batch_timeout_s=0.01
+    )
+    await worker.start()
+    for i in range(3):
+        queue.put_nowait(_ev(i))
+    await asyncio.sleep(0.1)
+    await worker.stop(timeout=1.0)
+    assert _Flaky.calls > 0
+    assert len(sink_ok.events) == 3
+
+
+@pytest.mark.asyncio
+async def test_stop_drains_remaining_queue() -> None:
+    queue: asyncio.Queue[ActivityEvent] = asyncio.Queue()
+    sink = RecordingSink()
+    worker = ActivityWorker(queue=queue, sinks=[sink], batch_size=2, batch_timeout_s=10.0)
+    await worker.start()
+    for i in range(5):
+        queue.put_nowait(_ev(i))
+    await worker.stop(timeout=1.0)
+    assert len(sink.events) == 5

--- a/tests/unit/services/activity/test_worker.py
+++ b/tests/unit/services/activity/test_worker.py
@@ -103,6 +103,89 @@ async def test_stop_drains_remaining_queue() -> None:
 
 
 @pytest.mark.asyncio
+async def test_worker_unexpected_death_surfaces_via_metrics() -> None:
+    """If the consumer task dies without stop() being called, the
+    component health flag must drop and ACTIVITY_SINK_ERRORS must
+    increment so /metrics carries an alertable signal — otherwise
+    activity persistence can be dead while the registry reports OK."""
+    from prometheus_client import REGISTRY
+
+    from nexus.services.activity.metrics import ACTIVITY_SINK_ERRORS
+
+    def _sample_worker_errors() -> float:
+        for fam in REGISTRY.collect():
+            for s in fam.samples:
+                if (
+                    s.name.startswith(ACTIVITY_SINK_ERRORS._name)
+                    and s.labels.get("sink") == "ActivityWorker"
+                ):
+                    return s.value
+        return 0.0
+
+    queue: asyncio.Queue[ActivityEvent] = asyncio.Queue()
+
+    class _Crasher:
+        async def write_batch(self, events: Sequence[ActivityEvent]) -> None:
+            raise BaseException("worker-killing failure")
+
+        async def close(self) -> None:
+            return None
+
+    worker = ActivityWorker(queue=queue, sinks=[_Crasher()], batch_size=1, batch_timeout_s=0.01)
+    before = _sample_worker_errors()
+    await worker.start()
+    queue.put_nowait(_ev(0))
+    # Wait for the BaseException to take down the consumer task.
+    for _ in range(100):
+        if worker._task is not None and worker._task.done():  # noqa: SLF001
+            break
+        await asyncio.sleep(0.01)
+
+    assert not worker.is_healthy()
+    assert _sample_worker_errors() == before + 1
+
+
+@pytest.mark.asyncio
+async def test_stop_waits_for_inflight_write_instead_of_cancelling() -> None:
+    """A wedged write must not be cancelled — cancellation cannot stop a
+    running executor thread, so close() would race the same connection.
+    Instead stop() must wait for the in-flight write to finish naturally,
+    then close the sink only after the write completes.
+    """
+    queue: asyncio.Queue[ActivityEvent] = asyncio.Queue()
+    write_started = asyncio.Event()
+    release_write = asyncio.Event()
+    close_observations: list[bool] = []
+
+    class _SlowSink:
+        def __init__(self) -> None:
+            self.write_done = False
+
+        async def write_batch(self, events: Sequence[ActivityEvent]) -> None:
+            write_started.set()
+            await release_write.wait()
+            self.write_done = True
+
+        async def close(self) -> None:
+            close_observations.append(self.write_done)
+
+    sink = _SlowSink()
+    queue.put_nowait(_ev(0))
+    worker = ActivityWorker(queue=queue, sinks=[sink], batch_size=10, batch_timeout_s=0.01)
+    await worker.start()
+    await write_started.wait()
+
+    stop_task = asyncio.create_task(worker.stop(timeout=0.05))
+    await asyncio.sleep(0.1)  # let soft timeout elapse
+    assert not stop_task.done(), "stop() must wait for the in-flight write"
+    release_write.set()
+    await stop_task
+
+    # close() must have observed the completed write — never the in-flight state.
+    assert close_observations == [True]
+
+
+@pytest.mark.asyncio
 async def test_double_stop_is_safe() -> None:
     queue: asyncio.Queue[ActivityEvent] = asyncio.Queue()
     sink = RecordingSink()

--- a/tests/unit/services/activity/test_worker.py
+++ b/tests/unit/services/activity/test_worker.py
@@ -100,3 +100,54 @@ async def test_stop_drains_remaining_queue() -> None:
         queue.put_nowait(_ev(i))
     await worker.stop(timeout=1.0)
     assert len(sink.events) == 5
+
+
+@pytest.mark.asyncio
+async def test_double_stop_is_safe() -> None:
+    queue: asyncio.Queue[ActivityEvent] = asyncio.Queue()
+    sink = RecordingSink()
+    worker = ActivityWorker(queue=queue, sinks=[sink], batch_size=10, batch_timeout_s=0.01)
+    await worker.start()
+    queue.put_nowait(_ev(0))
+    await worker.stop(timeout=1.0)
+    await worker.stop(timeout=1.0)  # second stop must not raise
+    assert len(sink.events) == 1
+
+
+@pytest.mark.asyncio
+async def test_start_after_stop_resumes() -> None:
+    queue: asyncio.Queue[ActivityEvent] = asyncio.Queue()
+    sink = RecordingSink()
+    worker = ActivityWorker(queue=queue, sinks=[sink], batch_size=10, batch_timeout_s=0.01)
+    await worker.start()
+    queue.put_nowait(_ev(1))
+    await asyncio.sleep(0.1)
+    await worker.stop(timeout=1.0)
+    # Restart and verify it actually consumes again
+    await worker.start()
+    queue.put_nowait(_ev(2))
+    await asyncio.sleep(0.1)
+    await worker.stop(timeout=1.0)
+    assert len(sink.events) == 2
+
+
+@pytest.mark.asyncio
+async def test_stop_before_start_is_safe() -> None:
+    queue: asyncio.Queue[ActivityEvent] = asyncio.Queue()
+    sink = RecordingSink()
+    worker = ActivityWorker(queue=queue, sinks=[sink], batch_size=10, batch_timeout_s=0.01)
+    # stop() before start() must be a no-op, not raise
+    await worker.stop(timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_double_start_is_idempotent() -> None:
+    queue: asyncio.Queue[ActivityEvent] = asyncio.Queue()
+    sink = RecordingSink()
+    worker = ActivityWorker(queue=queue, sinks=[sink], batch_size=10, batch_timeout_s=0.01)
+    await worker.start()
+    await worker.start()  # second start must not create a duplicate task
+    queue.put_nowait(_ev(0))
+    await asyncio.sleep(0.1)
+    await worker.stop(timeout=1.0)
+    assert len(sink.events) == 1


### PR DESCRIPTION
## Summary

Foundation slice of issue #3791 — server-side activity events, emitter, sinks, retention, metrics catalog, lifespan integration, and 5 emission callsites. TUI / hash-chained audit / OTEL / log+stats CLIs are deferred to follow-up slices per the design spec.

- New `nexus.services.activity` package: schema, queue+worker emitter (drop-on-overflow), `SQLiteSink` (WAL/STRICT/indexed), `RetentionTask` with VACUUM, env-driven `ActivityConfig`, sync `setup_activity` / `shutdown_activity` hooks
- Prometheus catalog at existing `/metrics`: `nexus_search_requests_total`, `nexus_search_latency_seconds`, `nexus_mcp_tool_calls_total`, `nexus_policy_blocks_total`, `nexus_approvals_pending` + internal `nexus_activity_drops_total/sink_errors_total/retention_pruned_total`
- Wired emit at: `bricks/search/search_service.grep`, `bricks/search/federated_search.search`, `bricks/rebac/enforcer` deny paths (POLICY_BLOCK + ZONE_ACCESS), `bricks/approvals/service` (PENDING + decide), `bricks/mcp/middleware_audit`
- Spec: `docs/superpowers/specs/2026-04-30-3791-activity-event-foundation-design.md`
- Plan: `docs/superpowers/plans/2026-04-30-3791-activity-event-foundation.md`

70/70 unit + integration tests pass. Bench p50 emit ~8 µs (under 10 µs target).

## Test plan

- [ ] `uv run pytest tests/unit/services/activity/ tests/integration/services/activity/` — 70 tests pass
- [ ] `uv run python -c "from nexus.server.lifespan.observability import create_registry; r = create_registry(); print('activity' in [n for n,*_ in r._components])"` prints `True`
- [ ] `uv run pytest -o addopts='' -n0 benchmarks/activity/bench_emit.py --benchmark-only` — emit p50 < 25 µs (note: pyproject xdist default disables benchmarks; the `-o addopts='' -n0` override is required)
- [ ] Existing search/rebac/approvals/mcp suites still green (default emitter is NoopEmitter; emission is observability-only)
- [ ] Sanity: with `NEXUS_ACTIVITY_ENABLED=0`, `setup_activity` installs `NoopEmitter` and no SQLite file is created

## Out-of-slice (tracked for follow-ups)

- `nexus term` operator TUI (slice 2)
- `nexus logs --follow [--sandbox]` and `nexus stats` CLIs (slice 2)
- Hash-chained tamper-evident audit + `nexus audit export --from --to` (slice 3, builds on `audit_node`)
- `fetch` event kind on kernel read path (slice 3)
- Phase-labelled `nexus_search_latency_seconds{phase}` (slice 4)
- OTEL / JSONL / webhook sinks + multi-sink config block (slice 5)
- Sweeper-driven approval expiry doesn't emit (gauge balance edge case)
- `semantic_search` not yet instrumented (only `grep`)