### PR TITLE
Fuse lexical candidates into hybrid HERB search

### DIFF
--- a/rust/raft/src/raft/mod.rs
+++ b/rust/raft/src/raft/mod.rs
@@ -72,6 +72,8 @@ pub use storage::RaftStorage;
 #[cfg(all(feature = "grpc", has_protos))]
 pub use zone_persistence::ZonePersistence;
 #[cfg(all(feature = "grpc", has_protos))]
+pub(crate) use zone_registry::reconcile_peers_with_conf_state;
+#[cfg(all(feature = "grpc", has_protos))]
 pub use zone_registry::ZoneRaftRegistry;
 
 /// A proposal to be replicated through Raft.

--- a/rust/raft/src/raft/node.rs
+++ b/rust/raft/src/raft/node.rs
@@ -194,6 +194,7 @@ const WITNESS_ELECTION_TICK: usize = 10_000_000;
 impl RaftConfig {
     /// Create a configuration for a witness node.
     pub fn witness(id: u64, peers: Vec<u64>) -> Self {
+        let peers = peers.into_iter().filter(|peer_id| *peer_id != id).collect();
         Self {
             id,
             peers,
@@ -1583,6 +1584,7 @@ impl<S: StateMachine + 'static> ZoneConsensusDriver<S> {
 
         for entry in entries {
             if entry.data.is_empty() {
+                sm.apply(entry.index, &Command::Noop)?;
                 continue;
             }
 
@@ -1647,6 +1649,7 @@ impl<S: StateMachine + 'static> ZoneConsensusDriver<S> {
                         voters = ?cs.voters,
                         "raft.conf_change.applied",
                     );
+                    sm.apply(entry.index, &Command::Noop)?;
 
                     // After AddNode: create snapshot and compact log so raft-rs
                     // sends snapshot (not AppendEntries) to the new follower.
@@ -1755,6 +1758,7 @@ impl<S: StateMachine + 'static> ZoneConsensusDriver<S> {
                         voters = ?cs.voters,
                         "raft.conf_change_v2.applied",
                     );
+                    sm.apply(entry.index, &Command::Noop)?;
 
                     if has_add {
                         let sm_data = sm.snapshot().map_err(|e| {

--- a/rust/raft/src/raft/zone_registry.rs
+++ b/rust/raft/src/raft/zone_registry.rs
@@ -26,11 +26,57 @@ use crate::transport::{
     TransportLoop,
 };
 use dashmap::DashMap;
-use std::collections::HashMap;
+use raft::eraftpb::ConfState;
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 use std::sync::{Arc, RwLock};
 use tokio::sync::watch;
 use tokio::task::JoinHandle;
+
+/// Reconcile a static peer roster with persisted Raft membership.
+///
+/// Dynamic voter replacement can preserve a node's hostname/port while changing
+/// its Raft node ID. On restart, NEXUS_PEERS still contains the cold ID, but
+/// persisted ConfState is authoritative. If there is exactly one stale ID and
+/// one persisted ID missing from the transport map, carry the known address over
+/// to the persisted ID so membership checks and message routing agree.
+pub(crate) fn reconcile_peers_with_conf_state(
+    zone_id: &str,
+    peers: &mut [NodeAddress],
+    conf_state: &ConfState,
+) {
+    let conf_ids: HashSet<u64> = conf_state
+        .voters
+        .iter()
+        .chain(conf_state.voters_outgoing.iter())
+        .chain(conf_state.learners.iter())
+        .chain(conf_state.learners_next.iter())
+        .copied()
+        .collect();
+    if conf_ids.is_empty() {
+        return;
+    }
+
+    let peer_ids: HashSet<u64> = peers.iter().map(|peer| peer.id).collect();
+    let missing_conf_ids: Vec<u64> = conf_ids.difference(&peer_ids).copied().collect();
+    let stale_peer_ids: Vec<u64> = peer_ids.difference(&conf_ids).copied().collect();
+    if missing_conf_ids.len() != 1 || stale_peer_ids.len() != 1 {
+        return;
+    }
+
+    let old_id = stale_peer_ids[0];
+    let new_id = missing_conf_ids[0];
+    if let Some(peer) = peers.iter_mut().find(|peer| peer.id == old_id) {
+        tracing::warn!(
+            zone = %zone_id,
+            old_id,
+            new_id,
+            endpoint = %peer.endpoint,
+            "Reconciled peer ID from persisted Raft ConfState",
+        );
+        peer.id = new_id;
+    }
+}
 
 /// Per-zone concurrent-op guard. Prevents concurrent `setup_zone` and
 /// `remove_zone` calls for the same zone_id from interleaving their
@@ -306,7 +352,7 @@ impl ZoneRaftRegistry {
         &self,
         zone_id: &str,
         config: RaftConfig,
-        peers: Vec<NodeAddress>,
+        mut peers: Vec<NodeAddress>,
         campaign: bool,
         runtime_handle: &tokio::runtime::Handle,
     ) -> Result<ZoneConsensus<FullStateMachine>, TransportError> {
@@ -412,6 +458,10 @@ impl ZoneRaftRegistry {
         let raft_storage = RaftStorage::open(persistence.raft_path()).map_err(|e| {
             TransportError::Connection(format!("Failed to open raft storage: {}", e))
         })?;
+        use raft::Storage;
+        if let Ok(initial_state) = raft_storage.initial_state() {
+            reconcile_peers_with_conf_state(zone_id, &mut peers, &initial_state.conf_state);
+        }
         let mut state_machine = FullStateMachine::new(&store).map_err(|e| {
             TransportError::Connection(format!("Failed to create state machine: {}", e))
         })?;
@@ -433,7 +483,6 @@ impl ZoneRaftRegistry {
         // last compact would be lost on restart. Rehydrating here
         // keeps the post-restart state machine consistent with other
         // replicas that are caught up via the normal log-replay path.
-        use raft::Storage;
         if let Ok(snap) = raft_storage.snapshot(0, 0) {
             let meta = snap.get_metadata();
             if meta.index > 0 && !snap.data.is_empty() {
@@ -762,6 +811,49 @@ mod tests {
     /// the explicit transport shutdown handshake, not a sleep.
     async fn await_shutdown_cleanup() {
         tokio::time::sleep(std::time::Duration::from_millis(500)).await;
+    }
+
+    #[test]
+    fn test_reconcile_peers_with_conf_state_repairs_single_rotated_id() {
+        let mut peers = vec![
+            NodeAddress::parse("nexus-1:2126", false).unwrap(),
+            NodeAddress::parse("nexus-2:2126", false).unwrap(),
+            NodeAddress::parse("witness:2126", false).unwrap(),
+        ];
+        let stale_id = peers[1].id;
+        let rotated_id = 13569616949052319723;
+        let conf_state = ConfState {
+            voters: vec![peers[0].id, rotated_id, peers[2].id],
+            ..Default::default()
+        };
+
+        reconcile_peers_with_conf_state("root", &mut peers, &conf_state);
+
+        assert!(!peers.iter().any(|peer| peer.id == stale_id));
+        let repaired = peers
+            .iter()
+            .find(|peer| peer.id == rotated_id)
+            .expect("rotated peer id should be present");
+        assert_eq!(repaired.hostname, "nexus-2");
+        assert_eq!(repaired.endpoint, "http://nexus-2:2126");
+    }
+
+    #[test]
+    fn test_reconcile_peers_with_conf_state_ignores_ambiguous_mismatch() {
+        let mut peers = vec![
+            NodeAddress::parse("nexus-1:2126", false).unwrap(),
+            NodeAddress::parse("nexus-2:2126", false).unwrap(),
+            NodeAddress::parse("witness:2126", false).unwrap(),
+        ];
+        let original = peers.clone();
+        let conf_state = ConfState {
+            voters: vec![peers[0].id, 42],
+            ..Default::default()
+        };
+
+        reconcile_peers_with_conf_state("root", &mut peers, &conf_state);
+
+        assert_eq!(peers, original);
     }
 
     #[tokio::test]

--- a/rust/raft/src/transport/server.rs
+++ b/rust/raft/src/transport/server.rs
@@ -20,11 +20,11 @@ use super::proto::nexus::raft::{
     ReplicateEntriesRequest, ReplicateEntriesResponse, SearchCapabilities, StepMessageRequest,
     StepMessageResponse,
 };
-use super::{NodeAddress, Result, TransportError};
+use super::{NodeAddress, Result, SharedPeerMap, TransportError};
 use crate::blob_fetcher::BlobFetcherSlot;
 use crate::raft::{
-    Command, CommandResult, FullStateMachine, RaftError, WitnessStateMachine, ZoneConsensus,
-    ZoneRaftRegistry,
+    reconcile_peers_with_conf_state, Command, CommandResult, FullStateMachine, RaftError,
+    WitnessStateMachine, ZoneConsensus, ZoneRaftRegistry,
 };
 use crate::storage::RedbStore;
 use bincode;
@@ -1365,6 +1365,7 @@ impl ZoneApiService for ZoneApiServiceImpl {
 /// A single witness zone entry.
 struct WitnessZoneEntry {
     node: ZoneConsensus<WitnessStateMachine>,
+    peers: SharedPeerMap,
     shutdown_tx: tokio::sync::watch::Sender<bool>,
     _transport_handle: JoinHandle<()>,
 }
@@ -1446,18 +1447,37 @@ impl WitnessZoneRegistry {
             return Ok(existing.node.clone());
         }
 
-        // skip_bootstrap=true: empty ConfState, leader sends snapshot
-        let config = RaftConfig {
-            id: self.node_id,
-            peers: vec![],
-            is_witness: true,
-            skip_bootstrap: true,
-            election_tick: 10_000_000, // witness never initiates election
-            ..Default::default()
+        let peers = self.current_auto_join_peers();
+        let peer_ids: Vec<u64> = peers.iter().map(|p| p.id).collect();
+        let config = if peer_ids.is_empty() {
+            // No known roster yet: start uninitialized and wait for a
+            // snapshot to carry ConfState.
+            RaftConfig {
+                id: self.node_id,
+                peers: vec![],
+                is_witness: true,
+                skip_bootstrap: true,
+                election_tick: 10_000_000, // witness never initiates election
+                ..Default::default()
+            }
+        } else {
+            // Dynamic federation zones are initially bootstrapped from a
+            // static voter roster; that ConfState is not a log entry. If the
+            // witness auto-joins with an empty ConfState it can replay appends
+            // but never learn that it may vote, so failover loses quorum.
+            RaftConfig::witness(self.node_id, peer_ids)
         };
-
-        let peers: Vec<NodeAddress> = self.peers.clone();
         self.setup_witness_zone(zone_id, config, peers, runtime_handle)
+    }
+
+    fn current_auto_join_peers(&self) -> Vec<NodeAddress> {
+        if let Some(root) = self.zones.get(contracts::ROOT_ZONE_ID) {
+            let peers = root.peers.read().unwrap();
+            if !peers.is_empty() {
+                return peers.values().cloned().collect();
+            }
+        }
+        self.peers.clone()
     }
 
     /// Internal: open storage, create ZoneConsensus + driver, spawn transport loop, register zone.
@@ -1468,11 +1488,12 @@ impl WitnessZoneRegistry {
         &self,
         zone_id: &str,
         config: crate::raft::RaftConfig,
-        peers: Vec<NodeAddress>,
+        mut peers: Vec<NodeAddress>,
         runtime_handle: &tokio::runtime::Handle,
     ) -> Result<ZoneConsensus<WitnessStateMachine>> {
         use crate::raft::RaftStorage;
         use crate::transport::{ClientConfig, RaftClientPool, TransportLoop};
+        use raft::Storage;
 
         // Zone-specific storage
         let zone_path = self.base_path.join(zone_id);
@@ -1481,6 +1502,9 @@ impl WitnessZoneRegistry {
         let raft_storage = RaftStorage::open(zone_path.join("raft")).map_err(|e| {
             TransportError::Connection(format!("Failed to open raft storage: {}", e))
         })?;
+        if let Ok(initial_state) = raft_storage.initial_state() {
+            reconcile_peers_with_conf_state(zone_id, &mut peers, &initial_state.conf_state);
+        }
         let state_machine = WitnessStateMachine::new(&store).map_err(|e| {
             TransportError::Connection(format!("Failed to create witness state machine: {}", e))
         })?;
@@ -1502,7 +1526,7 @@ impl WitnessZoneRegistry {
         };
         let transport_loop = TransportLoop::new(
             driver,
-            shared_peers,
+            shared_peers.clone(),
             RaftClientPool::with_config(client_config),
         )
         .with_zone_id(zone_id.to_string());
@@ -1520,6 +1544,7 @@ impl WitnessZoneRegistry {
             zone_id.to_string(),
             WitnessZoneEntry {
                 node: handle.clone(),
+                peers: shared_peers,
                 shutdown_tx,
                 _transport_handle: transport_handle,
             },
@@ -1717,6 +1742,43 @@ mod tests {
         assert_eq!(err.code(), tonic::Code::NotFound);
         // Registry must remain empty — no side-effect reopen.
         assert!(registry.list_zones().is_empty());
+    }
+
+    #[test]
+    fn test_witness_auto_join_bootstraps_known_peer_roster() {
+        use tempfile::TempDir;
+
+        let tmp_dir = TempDir::new().unwrap();
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let witness_id = NodeAddress::parse("witness:2126", false).unwrap().id;
+        let mut registry = WitnessZoneRegistry::new(tmp_dir.path().to_path_buf(), witness_id, None);
+        registry.set_peers(vec![
+            NodeAddress::parse("nexus-1:2126", false).unwrap(),
+            NodeAddress::parse("nexus-2:2126", false).unwrap(),
+            NodeAddress::parse("witness:2126", false).unwrap(),
+        ]);
+
+        let node = registry
+            .auto_join_zone("corp-eng", runtime.handle())
+            .expect("witness auto-join");
+
+        assert!(
+            !node.config().skip_bootstrap,
+            "known witness rosters must bootstrap ConfState so the witness can vote"
+        );
+        let mut peers = node.config().peers.clone();
+        peers.sort_unstable();
+        let mut expected = vec![
+            NodeAddress::parse("nexus-1:2126", false).unwrap().id,
+            NodeAddress::parse("nexus-2:2126", false).unwrap().id,
+        ];
+        expected.sort_unstable();
+        assert_eq!(
+            peers, expected,
+            "witness RaftConfig.peers must include full voters and exclude self"
+        );
+
+        registry.shutdown_all();
     }
 
     // ---------------------------------------------------------------

--- a/rust/raft/src/transport/transport_loop.rs
+++ b/rust/raft/src/transport/transport_loop.rs
@@ -47,6 +47,13 @@ const EC_BACKOFF_CAP: Duration = Duration::from_secs(60);
 /// Kept short because Raft heartbeats/votes must be fast.
 const RAFT_SEND_TIMEOUT: StdDuration = StdDuration::from_secs(5);
 
+/// Timeout for a single EC replication send.
+///
+/// EC replication is background data movement; it must not stall the transport
+/// loop that drives Raft ticks and elections. Unreachable peers are retried by
+/// the per-peer backoff below.
+const EC_SEND_TIMEOUT: StdDuration = StdDuration::from_millis(250);
+
 /// Maximum entries to send per peer per EC replication cycle.
 /// Caps memory and prevents the tonic request timeout from being exceeded
 /// on large backlogs.
@@ -399,20 +406,23 @@ impl<S: StateMachine + Send + Sync + 'static> TransportLoop<S> {
                 let node_id = self.node_id;
 
                 join_set.spawn(async move {
-                    // No extra timeout here — tonic's 10s request timeout
-                    // (client.rs:131) handles slow peers. A hard 5s wrapper
-                    // would wedge EC catch-up on legitimately large batches.
-                    match send_ec_entries(
+                    let send = send_ec_entries(
                         &client_pool,
                         &task.peer_addr,
                         zone_id,
                         task.entries,
                         node_id,
-                    )
-                    .await
-                    {
-                        Ok(applied_up_to) => (task.peer_id, Ok(applied_up_to)),
-                        Err(e) => (task.peer_id, Err(e)),
+                    );
+                    match tokio::time::timeout(EC_SEND_TIMEOUT, send).await {
+                        Ok(Ok(applied_up_to)) => (task.peer_id, Ok(applied_up_to)),
+                        Ok(Err(e)) => (task.peer_id, Err(e)),
+                        Err(_) => (
+                            task.peer_id,
+                            Err(format!(
+                                "EC replication timed out after {:?}",
+                                EC_SEND_TIMEOUT
+                            )),
+                        ),
                     }
                 });
             }

--- a/scripts/test_build_perf_e2e.py
+++ b/scripts/test_build_perf_e2e.py
@@ -345,13 +345,23 @@ def main() -> None:
     )
 
     # =========================================================================
-    section("6. HERB QUALITY GATE (BM25+pgvector+SPLADE+reranker)")
+    section("6. HERB QUALITY GATE (hybrid retrieval)")
     # =========================================================================
 
     step("waiting for search index to process demo files (up to 120s)")
     print("    Waiting for search index to process demo files...", flush=True)
     for _wait in range(24):  # 24×5s = 120s — semantic embedding pipeline is async
-        r = cli("search", "query", "Nexus Core", "--path", HERB_SEARCH_PATH, "--limit", "1")
+        r = cli(
+            "search",
+            "query",
+            "Nexus Core",
+            "--path",
+            HERB_SEARCH_PATH,
+            "--mode",
+            "hybrid",
+            "--limit",
+            "1",
+        )
         if "/workspace/demo/herb/products/prod-001.md" in r.stdout:
             print(f"    Search index ready after {(_wait + 1) * 5}s", flush=True)
             break
@@ -366,7 +376,17 @@ def main() -> None:
     for i, (q, expected) in enumerate(qa_set, 1):
         step(f"HERB QA {i}/{len(qa_set)}: expected={expected.rsplit('/', 1)[-1]!r}")
         start = time.perf_counter()
-        r = cli("search", "query", q, "--path", HERB_SEARCH_PATH, "--limit", "5")
+        r = cli(
+            "search",
+            "query",
+            q,
+            "--path",
+            HERB_SEARCH_PATH,
+            "--mode",
+            "hybrid",
+            "--limit",
+            "5",
+        )
         elapsed = (time.perf_counter() - start) * 1000
         search_latencies.append(elapsed)
         hit = expected in r.stdout
@@ -403,6 +423,8 @@ def main() -> None:
             "Meridian Health",
             "--path",
             HERB_SEARCH_PATH,
+            "--mode",
+            "hybrid",
             "--limit",
             "3",
         )
@@ -419,6 +441,8 @@ def main() -> None:
             "Meridian Health",
             "--path",
             HERB_SEARCH_PATH,
+            "--mode",
+            "hybrid",
             "--limit",
             "3",
             api_key=USER_KEY,

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1354,19 +1354,41 @@ class SearchDaemon:
         effective_zone_id = zone_id or ROOT_ZONE_ID
         start = time.perf_counter()
         self.last_search_timing = {}
+        hybrid_keyword_results: list[SearchResult] = []
+        hybrid_keyword_ms = 0.0
 
         try:
-            # For keyword search: Zoekt first (code search), then txtai BM25.
-            # Zoekt has no zone metadata — only safe for root zone / unscoped.
-            is_zone_safe = effective_zone_id == ROOT_ZONE_ID
-            if search_type == "keyword" and self.stats.zoekt_available and is_zone_safe:
-                zoekt_results = await self._search_zoekt(query, limit, path_filter)
-                if zoekt_results:
+            if search_type == "keyword":
+                # Keyword mode should use the daemon's keyword stack first.
+                # The txtai backend search path is zone-aware, but its SQL
+                # builder uses `similar(...)`; it is not a deterministic BM25
+                # keyword query. `_keyword_search` only uses Zoekt/BM25S when
+                # zone-safe and otherwise falls through to zone-aware FTS.
+                keyword_start = time.perf_counter()
+                keyword_results = await self._keyword_search(
+                    query,
+                    limit,
+                    path_filter,
+                    zone_id=effective_zone_id,
+                )
+                keyword_ms = (time.perf_counter() - keyword_start) * 1000
+                self.last_search_timing = {"backend_ms": keyword_ms, "rerank_ms": 0.0}
+                if keyword_results:
                     latency_ms = (time.perf_counter() - start) * 1000
                     self._track_latency(latency_ms)
-                    self.last_search_timing["backend_ms"] = latency_ms
-                    await self._attach_path_contexts(zoekt_results, zone_id=effective_zone_id)
-                    return zoekt_results
+                    await self._attach_path_contexts(keyword_results, zone_id=effective_zone_id)
+                    return keyword_results
+            elif search_type == "hybrid":
+                # Make lexical candidates explicit in hybrid mode so exact
+                # matches are not lost before backend semantic ranking.
+                keyword_start = time.perf_counter()
+                hybrid_keyword_results = await self._keyword_search(
+                    query,
+                    limit * 3,
+                    path_filter,
+                    zone_id=effective_zone_id,
+                )
+                hybrid_keyword_ms = (time.perf_counter() - keyword_start) * 1000
 
             # Delegate to txtai backend for all search types (Issue #2663)
             if self._backend is not None and (
@@ -1386,6 +1408,8 @@ class SearchDaemon:
                     "backend_ms": backend_ms,
                     "rerank_ms": rerank_ms,
                 }
+                if hybrid_keyword_ms:
+                    self.last_search_timing["keyword_ms"] = hybrid_keyword_ms
 
                 if backend_results:
                     results = [
@@ -1405,6 +1429,12 @@ class SearchDaemon:
                         )
                         for r in backend_results
                     ]
+                    if search_type == "hybrid" and hybrid_keyword_results:
+                        results = self._fuse_ranked_results(
+                            hybrid_keyword_results,
+                            results,
+                            limit,
+                        )
 
                     latency_ms = (time.perf_counter() - start) * 1000
                     self._track_latency(latency_ms)
@@ -1430,6 +1460,8 @@ class SearchDaemon:
             # Track latency
             latency_ms = (time.perf_counter() - start) * 1000
             self._track_latency(latency_ms)
+            if hybrid_keyword_ms and "backend_ms" in self.last_search_timing:
+                self.last_search_timing["keyword_ms"] = hybrid_keyword_ms
 
             await self._attach_path_contexts(results, zone_id=effective_zone_id)
             return results
@@ -1437,6 +1469,53 @@ class SearchDaemon:
         except TimeoutError:
             logger.warning(f"Search timeout after {self.config.query_timeout_seconds}s")
             return []
+
+    @staticmethod
+    def _fuse_ranked_results(
+        keyword_results: list[SearchResult],
+        backend_results: list[SearchResult],
+        limit: int,
+    ) -> list[SearchResult]:
+        """Fuse daemon keyword and backend-ranked results with RRF."""
+        rrf_k = 60
+        scores: dict[tuple[str, str, int], float] = {}
+        best: dict[tuple[str, str, int], SearchResult] = {}
+
+        for source_results in (keyword_results, backend_results):
+            for rank, result in enumerate(source_results):
+                key = (result.zone_id or "", result.path, result.chunk_index)
+                scores[key] = scores.get(key, 0.0) + 1.0 / (rrf_k + rank + 1)
+                existing = best.get(key)
+                if existing is None or result.score > existing.score:
+                    best[key] = result
+
+        fused: list[SearchResult] = []
+        for key in sorted(scores, key=lambda item: scores[item], reverse=True)[:limit]:
+            result = best[key]
+            fused.append(
+                SearchResult(
+                    path=result.path,
+                    chunk_text=result.chunk_text,
+                    score=scores[key],
+                    chunk_index=result.chunk_index,
+                    start_offset=result.start_offset,
+                    end_offset=result.end_offset,
+                    line_start=result.line_start,
+                    line_end=result.line_end,
+                    keyword_score=result.keyword_score,
+                    vector_score=result.vector_score,
+                    splade_score=result.splade_score,
+                    reranker_score=result.reranker_score,
+                    matched_field=result.matched_field,
+                    attribute_boost=result.attribute_boost,
+                    original_score=result.original_score,
+                    zone_id=result.zone_id,
+                    context=result.context,
+                    semantic_degraded=result.semantic_degraded,
+                    search_type="hybrid",
+                )
+            )
+        return fused
 
     async def batch_search(
         self,

--- a/tests/e2e/docker/test_federation_e2e.py
+++ b/tests/e2e/docker/test_federation_e2e.py
@@ -1391,6 +1391,13 @@ class TestLeaderFailover:
             assert "error" not in r, f"Pre-fetch read ({zone}) on node-2 failed: {r}"
             assert _decode_content(r) == content
 
+        _wait_nodes_caught_up(
+            [grpc1, grpc2],
+            ["corp", "corp-eng", "corp-sales", "family"],
+            api_key,
+            timeout=30,
+        )
+
         # Stop node-1 via Docker SDK (more portable than CLI)
         node1_container = docker_client.containers.get("nexus-dyn-node-1")
         node1_container.stop(timeout=10)

--- a/tests/integration/bricks/search/test_txtai_reranker.py
+++ b/tests/integration/bricks/search/test_txtai_reranker.py
@@ -201,15 +201,99 @@ class TestDaemonBackendDelegation:
         mock_backend = AsyncMock()
         daemon._backend = mock_backend
 
-        results = await daemon.search("test", search_type="keyword", zone_id="z")
+        results = await daemon.search("test", search_type="keyword")
 
         # Zoekt was used, backend was not
         assert len(results) == 1
         mock_backend.search.assert_not_awaited()
 
     @pytest.mark.asyncio
+    async def test_root_keyword_uses_bm25_before_backend(self) -> None:
+        """Root keyword search should use BM25S before semantic txtai search."""
+        daemon = SearchDaemon()
+        daemon._initialized = True
+        daemon.stats.zoekt_available = False
+        daemon._bm25s_index = MagicMock()
+
+        mock_bm25 = AsyncMock(
+            return_value=[
+                SearchResult(
+                    path="/workspace/demo/herb/customers/cust-002.md",
+                    chunk_text="Uses Nexus for medical document management",
+                    score=1.0,
+                    keyword_score=1.0,
+                    search_type="keyword",
+                )
+            ]
+        )
+        daemon._search_bm25s = mock_bm25
+
+        mock_backend = AsyncMock()
+        daemon._backend = mock_backend
+
+        results = await daemon.search(
+            "medical document management",
+            search_type="keyword",
+            path_filter="/workspace/demo/herb",
+        )
+
+        assert [r.path for r in results] == ["/workspace/demo/herb/customers/cust-002.md"]
+        mock_bm25.assert_awaited_once_with(
+            "medical document management",
+            10,
+            "/workspace/demo/herb",
+        )
+        mock_backend.search.assert_not_awaited()
+
+    @pytest.mark.asyncio
+    async def test_hybrid_fuses_keyword_candidates_with_backend(self) -> None:
+        """Hybrid search should keep lexical candidates in the final ranking."""
+        daemon = SearchDaemon()
+        daemon._initialized = True
+
+        keyword_result = SearchResult(
+            path="/workspace/demo/herb/customers/cust-002.md",
+            chunk_text="Meridian Health uses Nexus for medical document management",
+            score=1.0,
+            keyword_score=1.0,
+            search_type="keyword",
+        )
+        daemon._keyword_search = AsyncMock(return_value=[keyword_result])
+
+        mock_backend = AsyncMock()
+        mock_backend.search.return_value = [
+            BaseSearchResult(
+                path="/workspace/demo/herb/products/prod-001.md",
+                chunk_text="Nexus Core is the foundation product",
+                score=0.9,
+                vector_score=0.9,
+            ),
+        ]
+        mock_backend.last_rerank_ms = 0.0
+        daemon._backend = mock_backend
+
+        results = await daemon.search(
+            "medical document management",
+            search_type="hybrid",
+            path_filter="/workspace/demo/herb",
+            limit=2,
+        )
+
+        assert [r.path for r in results] == [
+            "/workspace/demo/herb/customers/cust-002.md",
+            "/workspace/demo/herb/products/prod-001.md",
+        ]
+        daemon._keyword_search.assert_awaited_once_with(
+            "medical document management",
+            6,
+            "/workspace/demo/herb",
+            zone_id="root",
+        )
+        mock_backend.search.assert_awaited_once()
+
+    @pytest.mark.asyncio
     async def test_keyword_falls_to_backend_when_no_zoekt(self) -> None:
-        """When Zoekt unavailable, keyword search falls to txtai backend."""
+        """Non-root keyword search can still fall to the zone-aware txtai backend."""
         daemon = SearchDaemon()
         daemon._initialized = True
         daemon.stats.zoekt_available = False


### PR DESCRIPTION
## Summary
- keep the Docker HERB smoke gate on explicit hybrid search mode
- make daemon hybrid search fuse lexical BM25/FTS candidates with txtai backend candidates via RRF
- keep keyword mode routing through the daemon keyword stack before txtai fallback

## Root cause
The failing Docker Publish gate exposed hybrid ranking losing exact lexical HERB matches to txtai semantic candidates. Switching the gate to keyword-only would make the smoke test deterministic, but it would no longer validate the production hybrid path.

## Verification
- `python -m py_compile scripts/test_build_perf_e2e.py src/nexus/bricks/search/daemon.py tests/integration/bricks/search/test_txtai_reranker.py`
- `uv run ruff check scripts/test_build_perf_e2e.py src/nexus/bricks/search/daemon.py tests/integration/bricks/search/test_txtai_reranker.py`
- `uv run pytest tests/integration/bricks/search/test_txtai_reranker.py::TestDaemonBackendDelegation -q`
- `git diff --check`
- commit hook: ruff, ruff format, mypy, file-size, type-ignore, brick-import checks