### PR TITLE
Fix HERB smoke BM25 path filtering

### DIFF
--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -3014,7 +3014,7 @@ class SearchDaemon:
 
                 # Index to BM25S if available
                 if self._bm25s_index:
-                    await self._bm25s_index.index_document(path_id, path, content)
+                    await self._bm25s_index.index_document(path_id, virtual_path, content)
 
                 # Single-writer policy for document_chunks (Issue #3708):
                 # when embedding pipeline is active AND the path is in

--- a/tests/integration/bricks/search/test_search_mutation_flow.py
+++ b/tests/integration/bricks/search/test_search_mutation_flow.py
@@ -160,6 +160,19 @@ class _SequentialSessionFactory:
         return self._sessions.pop(0)
 
 
+class _FakeFileReader:
+    async def read_text(self, _path: str) -> str:
+        return "priority account: renewal escalation"
+
+
+class _CapturingBM25SIndex:
+    def __init__(self) -> None:
+        self.indexed_documents: list[tuple[str, str, str]] = []
+
+    async def index_document(self, path_id: str, path: str, content: str) -> None:
+        self.indexed_documents.append((path_id, path, content))
+
+
 @pytest.mark.asyncio
 async def test_refresh_indexes_reuses_cached_content_path_id() -> None:
     daemon = SearchDaemon()
@@ -181,6 +194,23 @@ async def test_refresh_indexes_reuses_cached_content_path_id() -> None:
         "scoped content",
         "pid-scoped",
     )
+
+
+@pytest.mark.asyncio
+async def test_refresh_indexes_indexes_bm25s_with_virtual_path() -> None:
+    daemon = SearchDaemon()
+    daemon._file_reader = _FakeFileReader()
+    daemon._bm25s_index = _CapturingBM25SIndex()
+
+    await daemon._refresh_indexes(["/zone/root/workspace/demo/herb/customers/cust-002.md"])
+
+    assert daemon._bm25s_index.indexed_documents == [
+        (
+            "/workspace/demo/herb/customers/cust-002.md",
+            "/workspace/demo/herb/customers/cust-002.md",
+            "priority account: renewal escalation",
+        )
+    ]
 
 
 def test_refresh_index_lookup_values_cast_rank_for_asyncpg() -> None:


### PR DESCRIPTION
## Summary
- Index BM25S refresh documents under canonical virtual paths instead of scoped mutation paths.
- Add a regression test covering scoped mutation paths feeding BM25S.

## Why
The Docker Publish HERB smoke gate runs hybrid search with `--path /workspace/demo/herb`. When BM25S stored `/zone/root/...` paths from mutation refreshes, BM25 candidates were filtered out and the gate depended on txtai ranking, producing low hit rates like 2/8.

## Verification
- `.venv/bin/python -m pytest -n 0 tests/integration/bricks/search/test_search_mutation_flow.py::test_refresh_indexes_reuses_cached_content_path_id tests/integration/bricks/search/test_search_mutation_flow.py::test_refresh_indexes_indexes_bm25s_with_virtual_path -q`
- `git diff --check`
- Local BM25S HERB path-filter simulation: canonical paths score 8/8; scoped `/zone/root` paths are 0/8 visible under `/workspace/demo/herb`.