### PR TITLE
[codex] Fix HERB BM25 mutation paths

### DIFF
--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -2782,7 +2782,7 @@ class SearchDaemon:
                 continue
             await self._bm25s_index.index_document(
                 mutation.path_id,
-                mutation.event.path,
+                mutation.virtual_path,
                 mutation.content,
             )
 

--- a/tests/integration/bricks/search/test_search_mutation_flow.py
+++ b/tests/integration/bricks/search/test_search_mutation_flow.py
@@ -213,6 +213,44 @@ async def test_refresh_indexes_indexes_bm25s_with_virtual_path() -> None:
     ]
 
 
+@pytest.mark.asyncio
+async def test_bm25_mutation_consumer_indexes_virtual_path() -> None:
+    daemon = SearchDaemon()
+    daemon._bm25s_index = _CapturingBM25SIndex()
+    event = SearchMutationEvent(
+        event_id="evt-1",
+        operation_id="op-1",
+        op=SearchMutationOp.UPSERT,
+        path="/zone/default/workspace/demo/herb/customers/cust-002.md",
+        zone_id="default",
+        timestamp=datetime.now(UTC).replace(tzinfo=None),
+        sequence_number=1,
+    )
+    daemon._resolve_mutations = AsyncMock(
+        return_value=[
+            SimpleNamespace(
+                event=event,
+                zone_id="default",
+                doc_id="default:/workspace/demo/herb/customers/cust-002.md",
+                path_id="pid-cust-002",
+                virtual_path="/workspace/demo/herb/customers/cust-002.md",
+                content="Uses Nexus for medical document management",
+                path_id_resolved=True,
+            )
+        ]
+    )
+
+    await daemon._consume_bm25_mutations([event])
+
+    assert daemon._bm25s_index.indexed_documents == [
+        (
+            "pid-cust-002",
+            "/workspace/demo/herb/customers/cust-002.md",
+            "Uses Nexus for medical document management",
+        )
+    ]
+
+
 def test_refresh_index_lookup_values_cast_rank_for_asyncpg() -> None:
     values_sql, params = SearchDaemon._build_path_lookup_values(
         ["/docs/readme.md", "/zone/root/docs/readme.md"]


### PR DESCRIPTION
## Summary
- Store BM25 mutation-consumer documents under the resolved canonical virtual path instead of the zone-scoped event path.
- Add a regression covering scoped HERB-style mutation events so path-filtered hybrid search can keep lexical candidates.

## Root cause
Docker Publish seeds HERB through scoped operation-log mutations such as `/zone/default/workspace/demo/herb/...`. The BM25 mutation consumer indexed those scoped paths, while user search filters use canonical paths like `/workspace/demo/herb`. That made the hybrid gate lose BM25 lexical candidates and fall back to product-heavy txtai results, producing the 2/8 HERB hit rate.

## Validation
- `/opt/homebrew/bin/uv run pytest tests/integration/bricks/search/test_search_mutation_flow.py::test_bm25_mutation_consumer_indexes_virtual_path -q`
- `/opt/homebrew/bin/uv run pytest tests/integration/bricks/search/test_search_mutation_flow.py::test_refresh_indexes_indexes_bm25s_with_virtual_path tests/integration/bricks/search/test_search_mutation_flow.py::test_bm25_mutation_consumer_indexes_virtual_path tests/integration/bricks/search/test_txtai_reranker.py::TestDaemonBackendDelegation::test_hybrid_fuses_keyword_candidates_with_backend -q -n0`
- `/opt/homebrew/bin/uv run --extra dev ruff check src/nexus/bricks/search/daemon.py tests/integration/bricks/search/test_search_mutation_flow.py`
- pre-commit hooks during commit: ruff, ruff format, mypy, and custom repo checks passed
