### PR TITLE
fix(#3989): binary roundtrip via /api/v2/files

### DIFF
--- a/src/nexus/bricks/search/chunk_store.py
+++ b/src/nexus/bricks/search/chunk_store.py
@@ -10,6 +10,20 @@ from typing import Any
 from sqlalchemy import text
 
 
+def _strip_null_bytes(value: str | None) -> str | None:
+    """Strip NUL (0x00) bytes — Postgres TEXT/VARCHAR rejects them (SQLSTATE 22021).
+
+    Defensive last-line-of-defense before INSERT. Upstream readers normally
+    sanitize via ``_sanitize_for_index``, but the indexing pipeline has
+    several entry points (mutation resolver, RPC PipelineIndexer fallback,
+    naive-chunk fallback) and any leak would put the asyncpg session into
+    PendingRollbackError until the worker recycles (Issue #3989).
+    """
+    if value is None or "\x00" not in value:
+        return value
+    return value.replace("\x00", "")
+
+
 @dataclass(frozen=True)
 class ChunkRecord:
     """Normalized document chunk row payload."""
@@ -77,14 +91,14 @@ class ChunkStore:
             "chunk_id": str(uuid.uuid4()),
             "path_id": path_id,
             "chunk_index": index,
-            "chunk_text": chunk.chunk_text,
+            "chunk_text": _strip_null_bytes(chunk.chunk_text),
             "chunk_tokens": chunk.chunk_tokens,
             "start_offset": chunk.start_offset,
             "end_offset": chunk.end_offset,
             "line_start": chunk.line_start,
             "line_end": chunk.line_end,
             "embedding_model": chunk.embedding_model,
-            "chunk_context": chunk.chunk_context,
+            "chunk_context": _strip_null_bytes(chunk.chunk_context),
             "chunk_position": chunk.chunk_position,
             "source_document_id": chunk.source_document_id,
             "created_at": now,

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1624,18 +1624,24 @@ class SearchDaemon:
         from nexus.contracts.constants import ROOT_ZONE_ID
 
         effective_zone_id = zone_id or ROOT_ZONE_ID
-        # Strip NUL bytes from any string field — Postgres TEXT (used by the
-        # txtai content store) rejects them with SQLSTATE 22021 and would
-        # otherwise leave the asyncpg session in PendingRollbackError until
-        # worker recycle (Issue #3989).
-        scrubbed: list[dict[str, Any]] = []
-        for doc in documents:
-            scrubbed.append(
-                {
-                    k: (v.replace("\x00", "") if isinstance(v, str) and "\x00" in v else v)
-                    for k, v in doc.items()
-                }
-            )
+
+        # Strip NUL bytes from EVERY string in the document tree, not just
+        # top-level fields — txtai persists the full document object and
+        # nested metadata (e.g. {"metadata": {"title": "a\x00b"}}) would
+        # otherwise leak NULs into Postgres TEXT and reproduce the
+        # PendingRollbackError this fix is closing (Issue #3989, codex r2).
+        def _scrub(value: Any) -> Any:
+            if isinstance(value, str):
+                return value.replace("\x00", "") if "\x00" in value else value
+            if isinstance(value, dict):
+                return {k: _scrub(v) for k, v in value.items()}
+            if isinstance(value, list):
+                return [_scrub(v) for v in value]
+            if isinstance(value, tuple):
+                return tuple(_scrub(v) for v in value)
+            return value
+
+        scrubbed: list[dict[str, Any]] = [_scrub(doc) for doc in documents]
         count = int(await self._backend.upsert(scrubbed, zone_id=effective_zone_id))
         if count:
             self.stats.last_index_refresh = time.time()

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -2991,6 +2991,14 @@ class SearchDaemon:
                     logger.debug("No content found for %s", path)
                     continue
 
+                # Scrub NUL bytes — PG TEXT rejects them (SQLSTATE 22021) and
+                # this legacy refresh path bypasses MutationResolver's central
+                # scrub (Issue #3989). Done once here so every downstream
+                # consumer below (BM25S, embedding pipeline, naive FTS chunks,
+                # txtai batch) sees clean content.
+                if "\x00" in content:
+                    content = content.replace("\x00", "")
+
                 # Resolve path_id from file_paths table
                 path_id = virtual_path  # fallback
                 path_id_resolved = False

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1624,7 +1624,19 @@ class SearchDaemon:
         from nexus.contracts.constants import ROOT_ZONE_ID
 
         effective_zone_id = zone_id or ROOT_ZONE_ID
-        count = int(await self._backend.upsert(documents, zone_id=effective_zone_id))
+        # Strip NUL bytes from any string field — Postgres TEXT (used by the
+        # txtai content store) rejects them with SQLSTATE 22021 and would
+        # otherwise leave the asyncpg session in PendingRollbackError until
+        # worker recycle (Issue #3989).
+        scrubbed: list[dict[str, Any]] = []
+        for doc in documents:
+            scrubbed.append(
+                {
+                    k: (v.replace("\x00", "") if isinstance(v, str) and "\x00" in v else v)
+                    for k, v in doc.items()
+                }
+            )
+        count = int(await self._backend.upsert(scrubbed, zone_id=effective_zone_id))
         if count:
             self.stats.last_index_refresh = time.time()
         return count

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1634,7 +1634,10 @@ class SearchDaemon:
             if isinstance(value, str):
                 return value.replace("\x00", "") if "\x00" in value else value
             if isinstance(value, dict):
-                return {k: _scrub(v) for k, v in value.items()}
+                # Scrub keys AND values — txtai persists the full document
+                # object, so a NUL-bearing metadata key would still poison
+                # Postgres TEXT/JSON storage (codex r4, finding 3).
+                return {_scrub(k): _scrub(v) for k, v in value.items()}
             if isinstance(value, list):
                 return [_scrub(v) for v in value]
             if isinstance(value, tuple):

--- a/src/nexus/bricks/search/mutation_resolver.py
+++ b/src/nexus/bricks/search/mutation_resolver.py
@@ -22,6 +22,17 @@ from nexus.contracts.constants import ROOT_ZONE_ID
 logger = logging.getLogger(__name__)
 
 
+def _strip_null_bytes(value: str) -> str:
+    """Scrub NUL (0x00) bytes — Postgres TEXT and most embedding HTTP libs reject them.
+
+    Central chokepoint (Issue #3989). Every downstream consumer (bm25, fts,
+    embedding pipeline, txtai, naive-chunk fallback) reads ``mutation.content``,
+    so scrubbing here covers all paths in one place — even if a future reader
+    or a content_cache writer leaks a NUL upstream.
+    """
+    return value.replace("\x00", "") if "\x00" in value else value
+
+
 @dataclass(frozen=True)
 class ResolvedMutation:
     """Resolved mutation payload shared across search consumers."""
@@ -203,7 +214,7 @@ class MutationResolver:
         for event in update_events:
             content = await self._read_content(event.path, event.virtual_path)
             if content:
-                content_map[event.event_id] = content
+                content_map[event.event_id] = _strip_null_bytes(content)
             else:
                 missing_events.append(event)
 
@@ -215,7 +226,7 @@ class MutationResolver:
             for event in missing_events:
                 content = db_content.get(self._path_key(event.zone_id, event.virtual_path))
                 if content:
-                    content_map[event.event_id] = content
+                    content_map[event.event_id] = _strip_null_bytes(content)
 
         return content_map
 

--- a/src/nexus/bricks/search/pipeline_indexer.py
+++ b/src/nexus/bricks/search/pipeline_indexer.py
@@ -118,9 +118,11 @@ class PipelineIndexer:
                 try:
                     raw = self._file_reader(fp)
                     if isinstance(raw, bytes):
-                        text_map[fp] = raw.decode("utf-8", errors="ignore")
+                        decoded = raw.decode("utf-8", errors="ignore")
                     else:
-                        text_map[fp] = str(raw)
+                        decoded = str(raw)
+                    # Strip NUL bytes — Postgres TEXT rejects them (Issue #3989).
+                    text_map[fp] = decoded.replace("\x00", "") if "\x00" in decoded else decoded
                 except Exception as exc:
                     logger.warning("Failed to read %s for indexing: %s", fp, exc)
 

--- a/src/nexus/bricks/snapshot/snapshot_hook.py
+++ b/src/nexus/bricks/snapshot/snapshot_hook.py
@@ -52,6 +52,12 @@ class SnapshotWriteHook:
                 "size": old.size,
                 "version": old.version,
                 "modified_at": old.modified_at.isoformat() if old.modified_at else None,
+                # Capture the address of the node that last wrote the
+                # *pre-mutation* content so historical reads of
+                # ``original_hash`` after a cross-node overwrite can scatter-
+                # gather chunks from the original writer rather than the
+                # current one (Issue #3989, codex r8).
+                "last_writer_address": old.last_writer_address,
             }
         self._svc.track_write(
             txn_id,
@@ -72,10 +78,14 @@ class SnapshotWriteHook:
         # backend_name/physical_path were dropped from FileMetadata; the
         # kernel resolves a file's physical location at read time via the
         # mount/route layer, so the snapshot only needs content_id + path-level
-        # facts to restore a file from CAS.
+        # facts to restore a file from CAS. ``last_writer_address`` is
+        # preserved so post-delete historical reads of the snapshot hash
+        # can still scatter-gather from the writer's node when local
+        # chunks are missing (Issue #3989, codex r8).
         metadata_snapshot: dict[str, Any] = {
             "size": meta.size,
             "version": meta.version,
             "modified_at": meta.modified_at.isoformat() if meta.modified_at else None,
+            "last_writer_address": meta.last_writer_address,
         }
         self._svc.track_delete(txn_id, ctx.path, snapshot_hash, metadata_snapshot)

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -27,6 +27,7 @@ All operations pass user context for permission enforcement.
 
 import asyncio
 import base64
+import functools
 import json
 import logging
 from collections.abc import AsyncIterator, Iterator
@@ -948,19 +949,42 @@ def create_async_files_router(
                             f"no such mount resolved for {path!r}."
                         ),
                     )
+
+                # Plumb a federation origin hint into ``cas_read`` so chunked
+                # manifests whose blocks live on the writer node (replication
+                # window not yet closed, or a peer-only origin) can still
+                # scatter-gather. ``last_writer_address`` from the path's
+                # current stat is the most likely peer to hold any remote-only
+                # chunk for this file's recorded versions; it's a hint only —
+                # ``cas_read`` BLAKE3-verifies every fetched chunk before
+                # composition, so a stale/wrong address can never cause us to
+                # serve corrupt bytes (Issue #3989, codex r6).
+                _origins: list[str] = []
+                try:
+                    _stat = await asyncio.to_thread(fs.sys_stat, path, context=context)
+                    _writer = (_stat or {}).get("last_writer_address")
+                    if isinstance(_writer, str) and _writer.strip():
+                        _origins = [_writer.strip()]
+                except Exception:
+                    _origins = []
+
                 try:
                     raw = await asyncio.to_thread(
-                        _py_kernel.cas_read,
-                        _mount_point,
-                        _caller_zone_kernel,
-                        version,
+                        functools.partial(
+                            _py_kernel.cas_read,
+                            _mount_point,
+                            _caller_zone_kernel,
+                            version,
+                            origins=_origins,
+                        )
                     )
                 except Exception as cas_err:
                     logger.debug(
-                        "cas_read(%s, %s, %s) failed: %s",
+                        "cas_read(%s, %s, %s, origins=%s) failed: %s",
                         _mount_point,
                         _caller_zone_kernel,
                         version,
+                        _origins,
                         cas_err,
                     )
                     raise HTTPException(

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -892,12 +892,24 @@ def create_async_files_router(
                         detail=f"version is not recorded for this path in transaction {transaction_id!r}",
                     )
                 # --- Enforce standard read authorization via the VFS path ---
-                try:
-                    _accessible = fs.access(path, context=context)
-                except NexusPermissionError as e:
-                    raise HTTPException(status_code=403, detail=str(e)) from e
-                if not _accessible:
-                    raise NexusFileNotFoundError(path)
+                # For *delete* entries the live path no longer exists, so
+                # ``fs.access`` would reject every historical read of a
+                # deleted file's snapshot — even though the caller is
+                # authorized for the transaction's zone and the bytes are
+                # still in CAS (Issue #3989, codex r9). Authorization for
+                # delete entries has already been established by the
+                # transaction zone-ownership check + entry-hash binding
+                # above, so we skip the live-path access probe in that
+                # case. Write entries continue to require live-path
+                # access since the path is still expected to resolve.
+                _entry_op = getattr(_matched_entry, "operation", None)
+                if _entry_op != "delete":
+                    try:
+                        _accessible = fs.access(path, context=context)
+                    except NexusPermissionError as e:
+                        raise HTTPException(status_code=403, detail=str(e)) from e
+                    if not _accessible:
+                        raise NexusFileNotFoundError(path)
                 _py_kernel = getattr(fs, "_kernel", None)
                 if _py_kernel is None:
                     raise NexusFileNotFoundError(f"{path} (version {version})")

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -912,6 +912,26 @@ def create_async_files_router(
                 if _py_kernel is None:
                     raise NexusFileNotFoundError(f"{path} (version {version})")
                 raw: bytes = await asyncio.to_thread(_py_kernel.sys_read_raw, path, "root")
+                # Verify the bytes actually match the requested content hash.
+                # ``sys_read_raw`` returns the CURRENT bytes at ``path`` — there
+                # is no kernel API plumbed through here that reads by
+                # content_id. Without this check, a request for an old version
+                # after the file has changed would return the current bytes
+                # labeled with the historical hash, silently corrupting diff /
+                # rollback consumers (Issue #3989 — exposed once base64
+                # encoding made the lossy decode mask the bug).
+                from nexus.core.hash_fast import hash_content as _hash_content
+
+                _actual_hash = _hash_content(raw)
+                if _actual_hash != version:
+                    raise HTTPException(
+                        status_code=410,
+                        detail=(
+                            f"Historical version {version!r} no longer retrievable at {path!r}: "
+                            f"content has changed (current hash {_actual_hash!r}). "
+                            "Hash-keyed CAS reads are not yet plumbed through this endpoint."
+                        ),
+                    )
                 content_v, enc_v = _encode_read_payload(raw, encoding)
                 resp_v = ReadResponse(content=content_v, encoding=enc_v, content_id=version)
                 return Response(
@@ -1040,6 +1060,11 @@ def create_async_files_router(
                     media_type="application/json",
                 )
 
+        except HTTPException:
+            # Preserve explicit HTTP status codes (e.g., 400 transaction_id
+            # required, 410 hash mismatch) — don't let the catch-all below
+            # rewrite them as 500.
+            raise
         except AuthenticationError:
             # Preserve structured re-auth signal (see /list handler above).
             raise

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -911,25 +911,65 @@ def create_async_files_router(
                 _py_kernel = getattr(fs, "_kernel", None)
                 if _py_kernel is None:
                     raise NexusFileNotFoundError(f"{path} (version {version})")
-                raw: bytes = await asyncio.to_thread(_py_kernel.sys_read_raw, path, "root")
-                # Verify the bytes actually match the requested content hash.
-                # ``sys_read_raw`` returns the CURRENT bytes at ``path`` — there
-                # is no kernel API plumbed through here that reads by
-                # content_id. Without this check, a request for an old version
-                # after the file has changed would return the current bytes
-                # labeled with the historical hash, silently corrupting diff /
-                # rollback consumers (Issue #3989 — exposed once base64
-                # encoding made the lossy decode mask the bug).
+                # Resolve the mount that owns ``path`` so we can issue a true
+                # content-addressed read. Longest-prefix match against the
+                # active mount table — falls back to the legacy current-bytes
+                # read only when no mount matches (e.g. virtual / synthetic
+                # paths) and verifies the hash before returning.
                 from nexus.core.hash_fast import hash_content as _hash_content
 
+                _mount_point: str | None = None
+                try:
+                    _mount_entries = fs.list_mounts(context=context)
+                    _candidates = sorted(
+                        (m["mount_point"] for m in _mount_entries if m.get("mount_point")),
+                        key=len,
+                        reverse=True,
+                    )
+                    for _mp in _candidates:
+                        _mp_norm = _mp.rstrip("/") or "/"
+                        if path == _mp_norm or path.startswith(_mp_norm + "/"):
+                            _mount_point = _mp_norm
+                            break
+                except Exception:
+                    _mount_point = None
+
+                raw: bytes | None = None
+                if _mount_point is not None and hasattr(_py_kernel, "cas_read"):
+                    try:
+                        raw = await asyncio.to_thread(
+                            _py_kernel.cas_read, _mount_point, "root", version
+                        )
+                    except Exception as cas_err:
+                        # Backend doesn't have this content_id, or CAS read
+                        # failed for another reason — fall through to
+                        # current-path read + hash verify so the historical
+                        # blob can still be served when it happens to match
+                        # the live bytes.
+                        logger.debug(
+                            "cas_read(%s, root, %s) failed: %s; falling back",
+                            _mount_point,
+                            version,
+                            cas_err,
+                        )
+                        raw = None
+
+                if raw is None:
+                    raw = await asyncio.to_thread(_py_kernel.sys_read_raw, path, "root")
+
+                # Always verify hash — guards against a backend that returns
+                # the wrong blob, and against the legacy fallback returning
+                # current bytes when the historical version is gone. Returns
+                # 410 on mismatch so diff/rollback consumers fail loud
+                # instead of trusting mislabeled content (Issue #3989).
                 _actual_hash = _hash_content(raw)
                 if _actual_hash != version:
                     raise HTTPException(
                         status_code=410,
                         detail=(
                             f"Historical version {version!r} no longer retrievable at {path!r}: "
-                            f"content has changed (current hash {_actual_hash!r}). "
-                            "Hash-keyed CAS reads are not yet plumbed through this endpoint."
+                            f"current hash {_actual_hash!r} does not match. "
+                            "The content_id may have been GC'd or the backend lacks CAS support."
                         ),
                     )
                 content_v, enc_v = _encode_read_payload(raw, encoding)

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -875,11 +875,18 @@ def create_async_files_router(
                     )
                 # --- Validate hash belongs to path in this transaction ---
                 _entries = await _snap_svc.list_entries(transaction_id)
-                _valid = any(
-                    e.path == path and (e.original_hash == version or e.new_hash == version)
-                    for e in _entries
-                )
-                if not _valid:
+                _matched_entry: Any = None
+                _matched_side: str | None = None  # "original" or "new"
+                for _e in _entries:
+                    if _e.path != path:
+                        continue
+                    if _e.original_hash == version:
+                        _matched_entry, _matched_side = _e, "original"
+                        break
+                    if _e.new_hash == version:
+                        _matched_entry, _matched_side = _e, "new"
+                        break
+                if _matched_entry is None:
                     raise HTTPException(
                         status_code=403,
                         detail=f"version is not recorded for this path in transaction {transaction_id!r}",
@@ -950,23 +957,56 @@ def create_async_files_router(
                         ),
                     )
 
-                # Plumb a federation origin hint into ``cas_read`` so chunked
-                # manifests whose blocks live on the writer node (replication
-                # window not yet closed, or a peer-only origin) can still
-                # scatter-gather. ``last_writer_address`` from the path's
-                # current stat is the most likely peer to hold any remote-only
-                # chunk for this file's recorded versions; it's a hint only —
-                # ``cas_read`` BLAKE3-verifies every fetched chunk before
-                # composition, so a stale/wrong address can never cause us to
-                # serve corrupt bytes (Issue #3989, codex r6).
+                # Plumb federation origin hints into ``cas_read`` so chunked
+                # manifests whose blocks live on a peer node (replication
+                # window not yet closed, or peer-only origin) can still
+                # scatter-gather. The hash we're reading was either captured
+                # *before* the in-flight transaction (``original_hash``) or
+                # produced *by* it (``new_hash``); a different node may own
+                # each side, so we collect both candidates:
+                #
+                # 1. If the entry's serialized ``original_metadata`` carries
+                #    a writer address (from the pre-write snapshot), prefer
+                #    it for ``original_hash`` reads — that's the node that
+                #    last produced the *recorded* bytes.
+                # 2. The path's current ``last_writer_address`` is appended
+                #    as a fallback. For ``new_hash`` (post-write) it is the
+                #    direct producer; for ``original_hash`` it is still a
+                #    plausible peer if replication has fanned out at all.
+                #
+                # Origin hints affect *fetch reachability* only — every
+                # fetched chunk is BLAKE3-verified before composition, so
+                # stale/wrong/duplicate addresses can never cause us to
+                # serve corrupt bytes (Issue #3989, codex r6/r7).
                 _origins: list[str] = []
+
+                def _push_origin(addr: object) -> None:
+                    if not isinstance(addr, str):
+                        return
+                    s = addr.strip()
+                    if s and s not in _origins:
+                        _origins.append(s)
+
+                if _matched_side == "original":
+                    _orig_meta_raw = getattr(_matched_entry, "original_metadata", None)
+                    if isinstance(_orig_meta_raw, str) and _orig_meta_raw:
+                        try:
+                            _orig_meta = json.loads(_orig_meta_raw)
+                        except (TypeError, ValueError):
+                            _orig_meta = None
+                    elif isinstance(_orig_meta_raw, dict):
+                        _orig_meta = _orig_meta_raw
+                    else:
+                        _orig_meta = None
+                    if isinstance(_orig_meta, dict):
+                        _push_origin(_orig_meta.get("last_writer_address"))
+                        _push_origin(_orig_meta.get("writer_address"))
+
                 try:
                     _stat = await asyncio.to_thread(fs.sys_stat, path, context=context)
-                    _writer = (_stat or {}).get("last_writer_address")
-                    if isinstance(_writer, str) and _writer.strip():
-                        _origins = [_writer.strip()]
+                    _push_origin((_stat or {}).get("last_writer_address"))
                 except Exception:
-                    _origins = []
+                    pass
 
                 try:
                     raw = await asyncio.to_thread(

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -904,7 +904,9 @@ def create_async_files_router(
 
                 # Resolve the mount that owns ``path`` so we can issue a real
                 # content-addressed read via the Rust kernel. Longest-prefix
-                # match against the caller's visible mount table.
+                # match against the caller's visible mount table; the root
+                # mount ("/") is always a valid candidate so files under a
+                # root-only deployment still take the cas_read path.
                 _mount_point: str | None = None
                 try:
                     _mount_entries = fs.list_mounts(context=context)
@@ -915,14 +917,19 @@ def create_async_files_router(
                     )
                     for _mp in _candidates:
                         _mp_norm = _mp.rstrip("/") or "/"
-                        if path == _mp_norm or path.startswith(_mp_norm + "/"):
+                        # Root mount matches every absolute path; non-root
+                        # mounts match only if ``path`` equals the mount or
+                        # is a descendant. Without the root special-case,
+                        # production deployments that mount at ``/`` would
+                        # silently skip cas_read for every historical read
+                        # (Issue #3989, codex r4).
+                        if _mp_norm == "/" or path == _mp_norm or path.startswith(_mp_norm + "/"):
                             _mount_point = _mp_norm
                             break
                 except Exception:
                     _mount_point = None
 
                 raw: bytes | None = None
-                _read_via_cas = False
                 if _mount_point is not None and hasattr(_py_kernel, "cas_read"):
                     try:
                         raw = await asyncio.to_thread(
@@ -931,17 +938,14 @@ def create_async_files_router(
                             _caller_zone_kernel,
                             version,
                         )
-                        _read_via_cas = True
                     except Exception as cas_err:
-                        # Distinguish "backend lacks CAS" (capability error)
-                        # from "blob not found" (history GC'd) — both bubble
-                        # up to the live-bytes fallback below, but only the
-                        # latter is acceptable: the fallback then verifies
-                        # the live content_id matches ``version`` before
-                        # returning, so a non-CAS backend can never fake a
-                        # historical read.
+                        # cas_read failed — backend may lack CAS support, or
+                        # the content_id was GC'd. Fall through to the live
+                        # path read with stat-then-read-then-restat fence
+                        # below; that path refuses to serve mismatched
+                        # bytes regardless of why cas_read failed.
                         logger.debug(
-                            "cas_read(%s, %s, %s) failed: %s; falling back to live bytes",
+                            "cas_read(%s, %s, %s) failed: %s; falling back",
                             _mount_point,
                             _caller_zone_kernel,
                             version,
@@ -950,40 +954,55 @@ def create_async_files_router(
                         raw = None
 
                 if raw is None:
-                    # Fallback: gate on the live ``content_id`` matching
-                    # the requested ``version`` BEFORE reading bytes. This
-                    # is the only safe way to serve a historical version
-                    # without a working CAS-by-hash path — and it works for
-                    # CDC-chunked content where ``hash_content(raw)`` would
-                    # not match (the manifest hash differs from the
-                    # reassembled-bytes hash) (Issue #3989, codex r3).
-                    _live_meta = _py_kernel.sys_stat(path, _caller_zone_kernel)
-                    _live_cid = (
-                        _live_meta.get("content_id")
-                        if isinstance(_live_meta, dict)
-                        else getattr(_live_meta, "content_id", None)
-                    )
-                    if _live_cid != version:
+                    # Fallback: stat → read → restat fence. The stat-only
+                    # gate previously used here was racy — a concurrent
+                    # overwrite between sys_stat and sys_read_raw would let
+                    # us return current bytes labeled with the requested
+                    # historical hash. The restat after read closes that
+                    # window: if the live content_id didn't equal ``version``
+                    # for the entire stat→read→stat duration, refuse to
+                    # serve mislabeled bytes (Issue #3989, codex r4).
+                    def _live_content_id(meta: Any) -> str | None:
+                        if meta is None:
+                            return None
+                        if isinstance(meta, dict):
+                            return meta.get("content_id")
+                        return getattr(meta, "content_id", None)
+
+                    _pre_cid = _live_content_id(_py_kernel.sys_stat(path, _caller_zone_kernel))
+                    if _pre_cid != version:
                         raise HTTPException(
                             status_code=410,
                             detail=(
                                 f"Historical version {version!r} no longer retrievable at {path!r}: "
-                                f"live content_id is {_live_cid!r}. The backend may not support "
+                                f"live content_id is {_pre_cid!r}. The backend may not support "
                                 "content-addressed history, or this revision has been garbage collected."
                             ),
                         )
                     raw = await asyncio.to_thread(
                         _py_kernel.sys_read_raw, path, _caller_zone_kernel
                     )
+                    _post_cid = _live_content_id(_py_kernel.sys_stat(path, _caller_zone_kernel))
+                    if _post_cid != version:
+                        # Concurrent overwrite raced between stat and read.
+                        # Don't serve potentially-current bytes labeled with
+                        # the requested historical hash.
+                        raise HTTPException(
+                            status_code=409,
+                            detail=(
+                                f"Historical version {version!r} read raced with a concurrent "
+                                f"overwrite at {path!r} (post-read content_id {_post_cid!r}). "
+                                "Retry the request."
+                            ),
+                        )
 
-                # When the read came from cas_read, the backend already keyed
-                # the lookup by content_id, so the bytes are by-construction
-                # the requested revision — including for CDC-chunked content
-                # where reassembled-byte hashing differs from the manifest
-                # hash. We DON'T re-hash in that case (codex r3, finding 1).
-                # The fallback path verifies via live content_id before
-                # reading, so no extra check is needed here either.
-                del _read_via_cas
+                # When cas_read succeeded the bytes were keyed by content_id
+                # at the backend (works for CDC-chunked content too, where
+                # reassembled-byte hash != manifest hash). When the fallback
+                # served them, the stat→read→stat fence above proved the
+                # live content_id equaled ``version`` across the entire
+                # window. Either way, the response can safely advertise
+                # ``content_id=version``.
                 content_v, enc_v = _encode_read_payload(raw, encoding)
                 resp_v = ReadResponse(content=content_v, encoding=enc_v, content_id=version)
                 return Response(

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -244,6 +244,24 @@ def _metadata_timestamp(meta: Any, name: str) -> str | None:
     return str(value)
 
 
+def _encode_read_payload(
+    raw: str | bytes,
+    encoding: str | None,
+) -> tuple[str, str | None]:
+    """Encode read payload for the response based on the requested ``encoding``.
+
+    Returns ``(content_str, encoding_field)`` where ``encoding_field`` is set
+    on the response so SDKs can detect the format. ``encoding=None`` keeps
+    the legacy lossy UTF-8 string behavior for backward compat (Issue #3989).
+    """
+    if encoding == "base64":
+        raw_bytes = raw.encode("utf-8") if isinstance(raw, str) else raw
+        return base64.b64encode(raw_bytes).decode("ascii"), "base64"
+    if isinstance(raw, bytes):
+        return raw.decode("utf-8", errors="replace"), None
+    return raw, None
+
+
 def _to_metadata_response(meta: Any, fallback_path: str) -> "MetadataResponse":
     is_directory = _metadata_field(
         meta,
@@ -289,6 +307,7 @@ class ReadResponse(BaseModel):
     """Response model for read operation."""
 
     content: str
+    encoding: str | None = None
     content_id: str | None = None
     version: int | None = None
     modified_at: str | None = None
@@ -792,6 +811,13 @@ def create_async_files_router(
             None,
             description="(Markdown only) Filter by block type within section: 'code' or 'table'",
         ),
+        encoding: str | None = Query(
+            None,
+            description=(
+                "Response content encoding. 'base64' returns raw bytes losslessly; "
+                "default UTF-8 string (lossy for non-text) preserved for backward compat."
+            ),
+        ),
         zone: str | None = Query(
             None,
             description="Override zone (must be in token's zone_set).",
@@ -812,6 +838,15 @@ def create_async_files_router(
         `path` in that transaction, preventing cross-path blob reads.
         """
         context = _apply_zone_override(context, zone, auth_result, required_perm="r")
+        if encoding is not None and encoding not in ("base64", "utf8", "utf-8"):
+            raise HTTPException(
+                status_code=400,
+                detail=f"Unsupported encoding {encoding!r}; supported: 'base64', 'utf8'",
+            )
+        # Normalize utf8 alias to None (legacy default) so response.encoding
+        # is only set when the caller explicitly requested base64.
+        if encoding in ("utf8", "utf-8"):
+            encoding = None
         try:
             fs = await _get_fs()
 
@@ -877,8 +912,8 @@ def create_async_files_router(
                 if _py_kernel is None:
                     raise NexusFileNotFoundError(f"{path} (version {version})")
                 raw: bytes = await asyncio.to_thread(_py_kernel.sys_read_raw, path, "root")
-                text_v = raw.decode("utf-8", errors="replace")
-                resp_v = ReadResponse(content=text_v, content_id=version)
+                content_v, enc_v = _encode_read_payload(raw, encoding)
+                resp_v = ReadResponse(content=content_v, encoding=enc_v, content_id=version)
                 return Response(
                     content=resp_v.model_dump_json(),
                     media_type="application/json",
@@ -922,21 +957,25 @@ def create_async_files_router(
                 if section and path.endswith(".md"):
                     partial = _md_partial_read(fs, path, connector_content, section, block_type)
                     if partial is not None:
+                        partial_str, partial_enc = _encode_read_payload(partial, encoding)
                         return Response(
-                            content=ReadResponse(content=partial).model_dump_json(),
+                            content=ReadResponse(
+                                content=partial_str, encoding=partial_enc
+                            ).model_dump_json(),
                             media_type="application/json",
                         )
-                text = connector_content.decode("utf-8", errors="replace")
+                content_str, enc_str = _encode_read_payload(connector_content, encoding)
                 if include_metadata:
                     resp = ReadResponse(
-                        content=text,
+                        content=content_str,
+                        encoding=enc_str,
                         content_id=None,
                         version=None,
                         modified_at=None,
                         size=len(connector_content),
                     )
                 else:
-                    resp = ReadResponse(content=text)
+                    resp = ReadResponse(content=content_str, encoding=enc_str)
                 return Response(
                     content=resp.model_dump_json(),
                     media_type="application/json",
@@ -958,8 +997,11 @@ def create_async_files_router(
 
                 partial = _md_partial_read(fs, path, raw_content, section, block_type)
                 if partial is not None:
+                    partial_str, partial_enc = _encode_read_payload(partial, encoding)
                     return Response(
-                        content=ReadResponse(content=partial).model_dump_json(),
+                        content=ReadResponse(
+                            content=partial_str, encoding=partial_enc
+                        ).model_dump_json(),
                         media_type="application/json",
                     )
                 # Section explicitly requested but not found — don't leak full doc.
@@ -970,12 +1012,12 @@ def create_async_files_router(
                 )
 
             if include_metadata and isinstance(result, dict):
-                file_content: str = result["content"]
-                if isinstance(file_content, bytes):
-                    file_content = file_content.decode("utf-8", errors="replace")
+                raw_content_md = result["content"]
+                file_content, enc_md = _encode_read_payload(raw_content_md, encoding)
 
                 response_data = ReadResponse(
                     content=file_content,
+                    encoding=enc_md,
                     content_id=result.get("content_id"),
                     version=result.get("version"),
                     modified_at=result.get("modified_at"),
@@ -989,17 +1031,12 @@ def create_async_files_router(
                 )
             else:
                 # Simple content response
-                plain: str = (
-                    result
-                    if isinstance(result, str)
-                    else (
-                        result.decode("utf-8", errors="replace")
-                        if isinstance(result, bytes)
-                        else str(result)
-                    )
-                )
+                if isinstance(result, (str, bytes)):
+                    plain, enc_plain = _encode_read_payload(result, encoding)
+                else:
+                    plain, enc_plain = _encode_read_payload(str(result), encoding)
                 return Response(
-                    content=ReadResponse(content=plain).model_dump_json(),
+                    content=ReadResponse(content=plain, encoding=enc_plain).model_dump_json(),
                     media_type="application/json",
                 )
 

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -894,16 +894,20 @@ def create_async_files_router(
                 # --- Enforce standard read authorization via the VFS path ---
                 # For *delete* entries the live path no longer exists, so
                 # ``fs.access`` would reject every historical read of a
-                # deleted file's snapshot — even though the caller is
-                # authorized for the transaction's zone and the bytes are
-                # still in CAS (Issue #3989, codex r9). Authorization for
-                # delete entries has already been established by the
-                # transaction zone-ownership check + entry-hash binding
-                # above, so we skip the live-path access probe in that
-                # case. Write entries continue to require live-path
-                # access since the path is still expected to resolve.
+                # deleted snapshot — even though the bytes are still in
+                # CAS. Skipping ``access`` would also drop the file-level
+                # READ ACL gate (the only place that runs READ permission
+                # hooks for that path), so a caller who never had file
+                # READ permission could otherwise recover deleted content
+                # via the snapshot endpoint (Issue #3989, codex r10).
+                # Compromise: keep the carve-out only for admins, who are
+                # the intended rollback consumers. Regular callers must
+                # use a write-side snapshot or get a 404 for the
+                # missing live path.
                 _entry_op = getattr(_matched_entry, "operation", None)
-                if _entry_op != "delete":
+                _is_admin = bool(getattr(context, "is_admin", False))
+                _skip_access = _entry_op == "delete" and _is_admin
+                if not _skip_access:
                     try:
                         _accessible = fs.access(path, context=context)
                     except NexusPermissionError as e:

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -890,34 +890,21 @@ def create_async_files_router(
                     raise HTTPException(status_code=403, detail=str(e)) from e
                 if not _accessible:
                     raise NexusFileNotFoundError(path)
-                # --- Gate on CAS-capable backend via sys_stat ---
-                _py_kernel_stat = getattr(fs, "_kernel", None)
-                if _py_kernel_stat is not None:
-                    _stat_d = _py_kernel_stat.sys_stat(path, "root")
-                    _bn = (
-                        (_stat_d.get("backend_name", "") if isinstance(_stat_d, dict) else "")
-                        if _stat_d
-                        else ""
-                    )
-                    if _bn and not _bn.startswith("cas"):
-                        raise HTTPException(
-                            status_code=422,
-                            detail=(
-                                f"Historical version reads are only supported on CAS-addressed backends; "
-                                f"backend for {path!r} does not support content-addressed history"
-                            ),
-                        )
-                # Read via kernel — Rust backend handles CAS read.
                 _py_kernel = getattr(fs, "_kernel", None)
                 if _py_kernel is None:
                     raise NexusFileNotFoundError(f"{path} (version {version})")
-                # Resolve the mount that owns ``path`` so we can issue a true
-                # content-addressed read. Longest-prefix match against the
-                # active mount table — falls back to the legacy current-bytes
-                # read only when no mount matches (e.g. virtual / synthetic
-                # paths) and verifies the hash before returning.
-                from nexus.core.hash_fast import hash_content as _hash_content
 
+                # Use the validated caller zone for all kernel calls — the
+                # snapshot/transaction check above already proved the caller
+                # is authorized for this zone. Hard-coding "root" would route
+                # the read through the wrong mount table for non-root zones
+                # and turn this into a privilege-escalation TOCTOU window
+                # (Issue #3989, codex r3).
+                _caller_zone_kernel = _caller_zone or "root"
+
+                # Resolve the mount that owns ``path`` so we can issue a real
+                # content-addressed read via the Rust kernel. Longest-prefix
+                # match against the caller's visible mount table.
                 _mount_point: str | None = None
                 try:
                     _mount_entries = fs.list_mounts(context=context)
@@ -935,43 +922,68 @@ def create_async_files_router(
                     _mount_point = None
 
                 raw: bytes | None = None
+                _read_via_cas = False
                 if _mount_point is not None and hasattr(_py_kernel, "cas_read"):
                     try:
                         raw = await asyncio.to_thread(
-                            _py_kernel.cas_read, _mount_point, "root", version
-                        )
-                    except Exception as cas_err:
-                        # Backend doesn't have this content_id, or CAS read
-                        # failed for another reason — fall through to
-                        # current-path read + hash verify so the historical
-                        # blob can still be served when it happens to match
-                        # the live bytes.
-                        logger.debug(
-                            "cas_read(%s, root, %s) failed: %s; falling back",
+                            _py_kernel.cas_read,
                             _mount_point,
+                            _caller_zone_kernel,
+                            version,
+                        )
+                        _read_via_cas = True
+                    except Exception as cas_err:
+                        # Distinguish "backend lacks CAS" (capability error)
+                        # from "blob not found" (history GC'd) — both bubble
+                        # up to the live-bytes fallback below, but only the
+                        # latter is acceptable: the fallback then verifies
+                        # the live content_id matches ``version`` before
+                        # returning, so a non-CAS backend can never fake a
+                        # historical read.
+                        logger.debug(
+                            "cas_read(%s, %s, %s) failed: %s; falling back to live bytes",
+                            _mount_point,
+                            _caller_zone_kernel,
                             version,
                             cas_err,
                         )
                         raw = None
 
                 if raw is None:
-                    raw = await asyncio.to_thread(_py_kernel.sys_read_raw, path, "root")
-
-                # Always verify hash — guards against a backend that returns
-                # the wrong blob, and against the legacy fallback returning
-                # current bytes when the historical version is gone. Returns
-                # 410 on mismatch so diff/rollback consumers fail loud
-                # instead of trusting mislabeled content (Issue #3989).
-                _actual_hash = _hash_content(raw)
-                if _actual_hash != version:
-                    raise HTTPException(
-                        status_code=410,
-                        detail=(
-                            f"Historical version {version!r} no longer retrievable at {path!r}: "
-                            f"current hash {_actual_hash!r} does not match. "
-                            "The content_id may have been GC'd or the backend lacks CAS support."
-                        ),
+                    # Fallback: gate on the live ``content_id`` matching
+                    # the requested ``version`` BEFORE reading bytes. This
+                    # is the only safe way to serve a historical version
+                    # without a working CAS-by-hash path — and it works for
+                    # CDC-chunked content where ``hash_content(raw)`` would
+                    # not match (the manifest hash differs from the
+                    # reassembled-bytes hash) (Issue #3989, codex r3).
+                    _live_meta = _py_kernel.sys_stat(path, _caller_zone_kernel)
+                    _live_cid = (
+                        _live_meta.get("content_id")
+                        if isinstance(_live_meta, dict)
+                        else getattr(_live_meta, "content_id", None)
                     )
+                    if _live_cid != version:
+                        raise HTTPException(
+                            status_code=410,
+                            detail=(
+                                f"Historical version {version!r} no longer retrievable at {path!r}: "
+                                f"live content_id is {_live_cid!r}. The backend may not support "
+                                "content-addressed history, or this revision has been garbage collected."
+                            ),
+                        )
+                    raw = await asyncio.to_thread(
+                        _py_kernel.sys_read_raw, path, _caller_zone_kernel
+                    )
+
+                # When the read came from cas_read, the backend already keyed
+                # the lookup by content_id, so the bytes are by-construction
+                # the requested revision — including for CDC-chunked content
+                # where reassembled-byte hashing differs from the manifest
+                # hash. We DON'T re-hash in that case (codex r3, finding 1).
+                # The fallback path verifies via live content_id before
+                # reading, so no extra check is needed here either.
+                del _read_via_cas
                 content_v, enc_v = _encode_read_payload(raw, encoding)
                 resp_v = ReadResponse(content=content_v, encoding=enc_v, content_id=version)
                 return Response(

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -929,80 +929,48 @@ def create_async_files_router(
                 except Exception:
                     _mount_point = None
 
-                raw: bytes | None = None
-                if _mount_point is not None and hasattr(_py_kernel, "cas_read"):
-                    try:
-                        raw = await asyncio.to_thread(
-                            _py_kernel.cas_read,
-                            _mount_point,
-                            _caller_zone_kernel,
-                            version,
-                        )
-                    except Exception as cas_err:
-                        # cas_read failed — backend may lack CAS support, or
-                        # the content_id was GC'd. Fall through to the live
-                        # path read with stat-then-read-then-restat fence
-                        # below; that path refuses to serve mismatched
-                        # bytes regardless of why cas_read failed.
-                        logger.debug(
-                            "cas_read(%s, %s, %s) failed: %s; falling back",
-                            _mount_point,
-                            _caller_zone_kernel,
-                            version,
-                            cas_err,
-                        )
-                        raw = None
-
-                if raw is None:
-                    # Fallback: stat → read → restat fence. The stat-only
-                    # gate previously used here was racy — a concurrent
-                    # overwrite between sys_stat and sys_read_raw would let
-                    # us return current bytes labeled with the requested
-                    # historical hash. The restat after read closes that
-                    # window: if the live content_id didn't equal ``version``
-                    # for the entire stat→read→stat duration, refuse to
-                    # serve mislabeled bytes (Issue #3989, codex r4).
-                    def _live_content_id(meta: Any) -> str | None:
-                        if meta is None:
-                            return None
-                        if isinstance(meta, dict):
-                            return meta.get("content_id")
-                        return getattr(meta, "content_id", None)
-
-                    _pre_cid = _live_content_id(_py_kernel.sys_stat(path, _caller_zone_kernel))
-                    if _pre_cid != version:
-                        raise HTTPException(
-                            status_code=410,
-                            detail=(
-                                f"Historical version {version!r} no longer retrievable at {path!r}: "
-                                f"live content_id is {_pre_cid!r}. The backend may not support "
-                                "content-addressed history, or this revision has been garbage collected."
-                            ),
-                        )
-                    raw = await asyncio.to_thread(
-                        _py_kernel.sys_read_raw, path, _caller_zone_kernel
+                # Historical reads are CAS-only. ``cas_read`` keys the
+                # lookup by ``content_id`` at the backend, which is the
+                # only safe way to bind the returned bytes to the
+                # requested ``version`` — including for CDC-chunked
+                # content where reassembled-byte hash != manifest hash.
+                # A live-path fallback ``sys_read_raw`` was tempting for
+                # the "live cid == version" case, but is unsound under an
+                # ABA race (writer flips A→B→A between pre-stat and
+                # read; we'd serve B labeled as A). When cas_read fails
+                # we return 410 — the backend either lacks CAS or has
+                # GC'd the revision (Issue #3989, codex r5).
+                if _mount_point is None or not hasattr(_py_kernel, "cas_read"):
+                    raise HTTPException(
+                        status_code=422,
+                        detail=(
+                            f"Historical version reads require a CAS-capable mount; "
+                            f"no such mount resolved for {path!r}."
+                        ),
                     )
-                    _post_cid = _live_content_id(_py_kernel.sys_stat(path, _caller_zone_kernel))
-                    if _post_cid != version:
-                        # Concurrent overwrite raced between stat and read.
-                        # Don't serve potentially-current bytes labeled with
-                        # the requested historical hash.
-                        raise HTTPException(
-                            status_code=409,
-                            detail=(
-                                f"Historical version {version!r} read raced with a concurrent "
-                                f"overwrite at {path!r} (post-read content_id {_post_cid!r}). "
-                                "Retry the request."
-                            ),
-                        )
+                try:
+                    raw = await asyncio.to_thread(
+                        _py_kernel.cas_read,
+                        _mount_point,
+                        _caller_zone_kernel,
+                        version,
+                    )
+                except Exception as cas_err:
+                    logger.debug(
+                        "cas_read(%s, %s, %s) failed: %s",
+                        _mount_point,
+                        _caller_zone_kernel,
+                        version,
+                        cas_err,
+                    )
+                    raise HTTPException(
+                        status_code=410,
+                        detail=(
+                            f"Historical version {version!r} no longer retrievable at {path!r}: "
+                            "the backend lacks CAS support or this revision has been garbage collected."
+                        ),
+                    ) from cas_err
 
-                # When cas_read succeeded the bytes were keyed by content_id
-                # at the backend (works for CDC-chunked content too, where
-                # reassembled-byte hash != manifest hash). When the fallback
-                # served them, the stat→read→stat fence above proved the
-                # live content_id equaled ``version`` across the entire
-                # window. Either way, the response can safely advertise
-                # ``content_id=version``.
                 content_v, enc_v = _encode_read_payload(raw, encoding)
                 resp_v = ReadResponse(content=content_v, encoding=enc_v, content_id=version)
                 return Response(

--- a/tests/e2e/self_contained/test_files_binary_roundtrip_e2e.py
+++ b/tests/e2e/self_contained/test_files_binary_roundtrip_e2e.py
@@ -338,3 +338,118 @@ def test_versioned_read_passes_writer_address_as_origin(
     assert resp.status_code == 200, resp.text
     assert captured["origins"] == ["peer-1:2126"], captured
     assert captured["content_id"] == hash_a
+
+
+def test_versioned_read_uses_recorded_origin_for_original_hash(
+    real_fs: NexusFS, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When the requested version is the entry's ``original_hash``, the
+    federation origin hint must prefer the writer address recorded in the
+    snapshot's ``original_metadata`` ahead of the path's *current*
+    writer. Otherwise a follower reading the original side after a
+    cross-node overwrite would only contact the new writer and miss the
+    node holding the original chunks (Issue #3989, codex r7)."""
+    import json as _json
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    payload = b"y"
+
+    setup_app = FastAPI()
+    setup_app.include_router(create_async_files_router(nexus_fs=real_fs))
+    setup_app.dependency_overrides[get_auth_result] = lambda: {
+        "authenticated": True,
+        "user_id": "e2e-user",
+        "groups": [],
+        "zone_id": "root",
+        "is_admin": True,
+    }
+    setup_client = TestClient(setup_app)
+    write_resp = setup_client.post(
+        "/write",
+        json={"path": "/files/recorded_origin.bin", "content": "y"},
+    )
+    assert write_resp.status_code == 200, write_resp.text
+    original_hash = write_resp.json()["content_id"]
+
+    # Current writer differs from the recorded original writer.
+    real_stat = real_fs.sys_stat
+
+    def _stat(path: str, **kw: object) -> dict[str, object] | None:
+        result = real_stat(path, **kw)
+        if result is not None:
+            result["last_writer_address"] = "current-writer:2126"
+        return result
+
+    monkeypatch.setattr(real_fs, "sys_stat", _stat)
+    monkeypatch.setattr(
+        real_fs,
+        "list_mounts",
+        lambda context=None: [{"mount_point": "/files"}],
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_cas_read(
+        mount_point: str,
+        zone_id: str,
+        content_id: str,
+        *,
+        origins: list[str] | None = None,
+    ) -> bytes:
+        captured["origins"] = list(origins or [])
+        return payload
+
+    real_kernel = real_fs._kernel
+
+    class _KernelProxy:
+        cas_read = staticmethod(_fake_cas_read)
+
+        def __getattr__(self, name: str) -> object:
+            return getattr(real_kernel, name)
+
+    monkeypatch.setattr(real_fs, "_kernel", _KernelProxy())
+
+    # Snapshot entry whose original_metadata records the original-writer.
+    snap_svc = MagicMock()
+    snap_svc.get_transaction = AsyncMock(return_value=SimpleNamespace(zone_id="root"))
+    snap_svc.list_entries = AsyncMock(
+        return_value=[
+            SimpleNamespace(
+                path="/files/recorded_origin.bin",
+                original_hash=original_hash,
+                new_hash="0" * 64,  # post-write hash; irrelevant
+                original_metadata=_json.dumps({"last_writer_address": "original-writer:2126"}),
+            )
+        ]
+    )
+
+    app = FastAPI()
+    router = create_async_files_router(nexus_fs=real_fs)
+    app.state.transactional_snapshot_service = snap_svc
+    app.include_router(router)
+    app.dependency_overrides[get_auth_result] = lambda: {
+        "authenticated": True,
+        "user_id": "e2e-user",
+        "groups": [],
+        "zone_id": "root",
+        "is_admin": True,
+    }
+    client = TestClient(app)
+
+    resp = client.get(
+        "/read",
+        params={
+            "path": "/files/recorded_origin.bin",
+            "version": original_hash,
+            "transaction_id": "txn-stub",
+            "encoding": "base64",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    # Recorded original writer comes first; current writer is appended as a
+    # fallback. De-dup must not drop either, and the recorded one must lead.
+    assert captured["origins"] == [
+        "original-writer:2126",
+        "current-writer:2126",
+    ], captured

--- a/tests/e2e/self_contained/test_files_binary_roundtrip_e2e.py
+++ b/tests/e2e/self_contained/test_files_binary_roundtrip_e2e.py
@@ -166,3 +166,54 @@ def test_read_rejects_unknown_encoding(client: TestClient) -> None:
     resp = client.get("/read", params={"path": "/files/x.txt", "encoding": "hex"})
     assert resp.status_code == 400
     assert "encoding" in resp.json()["detail"].lower()
+
+
+def test_versioned_read_rejects_stale_hash(client: TestClient) -> None:
+    """When a file has been overwritten, a request for the old content hash
+    must NOT return current bytes labeled with the historical hash. The
+    endpoint reads by path (no CAS-by-hash plumbing yet), so we verify the
+    hash and refuse mismatched reads to avoid corrupting diff/rollback
+    consumers (Issue #3989 — codex review)."""
+    import base64
+    import hashlib
+
+    # Write A
+    payload_a = b"\x00\x01alpha\x00"
+    write_a = client.post(
+        "/write",
+        json={
+            "path": "/files/versioned.bin",
+            "content": base64.b64encode(payload_a).decode("ascii"),
+            "encoding": "base64",
+        },
+    )
+    assert write_a.status_code == 200
+    hash_a = write_a.json()["content_id"]
+    # BLAKE3 hash from kernel; ensure non-empty
+    assert hash_a
+
+    # Overwrite with B
+    payload_b = b"\x00\x02beta\x00\x00"
+    assert hashlib.sha256(payload_b).digest() != hashlib.sha256(payload_a).digest()
+    write_b = client.post(
+        "/write",
+        json={
+            "path": "/files/versioned.bin",
+            "content": base64.b64encode(payload_b).decode("ascii"),
+            "encoding": "base64",
+        },
+    )
+    assert write_b.status_code == 200
+
+    # Note: ?version=<hash_a> requires transaction_id wiring that isn't
+    # available in this lightweight TestClient setup. We assert the
+    # query-param validation remains strict (the no-transaction guard
+    # already covers this) and rely on the production-stack live test for
+    # full hash-mismatch coverage.
+    resp = client.get(
+        "/read",
+        params={"path": "/files/versioned.bin", "version": hash_a},
+    )
+    # Without transaction_id we get 400 — the existing guard.
+    assert resp.status_code == 400
+    assert "transaction_id" in resp.json()["detail"].lower()

--- a/tests/e2e/self_contained/test_files_binary_roundtrip_e2e.py
+++ b/tests/e2e/self_contained/test_files_binary_roundtrip_e2e.py
@@ -217,3 +217,124 @@ def test_versioned_read_rejects_stale_hash(client: TestClient) -> None:
     # Without transaction_id we get 400 — the existing guard.
     assert resp.status_code == 400
     assert "transaction_id" in resp.json()["detail"].lower()
+
+
+def test_versioned_read_passes_writer_address_as_origin(
+    real_fs: NexusFS, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """When ``cas_read`` is invoked for a historical version, the endpoint
+    must plumb the path's ``last_writer_address`` as a federation origin.
+    Otherwise chunked manifests whose chunks live on a peer (replication
+    window not yet closed) become unrecoverable on follower nodes
+    (Issue #3989, codex r6).
+
+    We patch the kernel's ``cas_read`` to capture kwargs and stub the
+    snapshot service so the version-validation gate is satisfied without
+    needing a real transactional snapshot."""
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    payload = b"x"
+    write_resp_app = FastAPI()
+    write_resp_app.include_router(create_async_files_router(nexus_fs=real_fs))
+    write_resp_app.dependency_overrides[get_auth_result] = lambda: {
+        "authenticated": True,
+        "user_id": "e2e-user",
+        "groups": [],
+        "zone_id": "root",
+        "is_admin": True,
+    }
+    setup_client = TestClient(write_resp_app)
+    write_resp = setup_client.post(
+        "/write",
+        json={"path": "/files/origin_probe.bin", "content": "x"},
+    )
+    assert write_resp.status_code == 200, write_resp.text
+    hash_a = write_resp.json()["content_id"]
+    assert hash_a
+
+    # Stub sys_stat so last_writer_address is a known sentinel.
+    real_stat = real_fs.sys_stat
+
+    def _stat(path: str, **kw: object) -> dict[str, object] | None:
+        result = real_stat(path, **kw)
+        if result is not None:
+            result["last_writer_address"] = "peer-1:2126"
+        return result
+
+    monkeypatch.setattr(real_fs, "sys_stat", _stat)
+
+    # The router resolves the owning mount via fs.list_mounts(); this minimal
+    # NexusFS fixture has no mount_service wired, so stub it to expose /files.
+    monkeypatch.setattr(
+        real_fs,
+        "list_mounts",
+        lambda context=None: [{"mount_point": "/files"}],
+    )
+
+    # Capture cas_read kwargs and short-circuit with the recorded payload.
+    captured: dict[str, object] = {}
+
+    def _fake_cas_read(
+        mount_point: str,
+        zone_id: str,
+        content_id: str,
+        *,
+        origins: list[str] | None = None,
+    ) -> bytes:
+        captured["mount_point"] = mount_point
+        captured["zone_id"] = zone_id
+        captured["content_id"] = content_id
+        captured["origins"] = list(origins or [])
+        return payload
+
+    # The Rust pyo3 kernel's attributes are read-only, so wrap the kernel
+    # with a proxy that overrides cas_read while delegating everything else.
+    real_kernel = real_fs._kernel
+
+    class _KernelProxy:
+        cas_read = staticmethod(_fake_cas_read)
+
+        def __getattr__(self, name: str) -> object:
+            return getattr(real_kernel, name)
+
+    monkeypatch.setattr(real_fs, "_kernel", _KernelProxy())
+
+    # Stub the snapshot service so version validation passes.
+    snap_svc = MagicMock()
+    snap_svc.get_transaction = AsyncMock(return_value=SimpleNamespace(zone_id="root"))
+    snap_svc.list_entries = AsyncMock(
+        return_value=[
+            SimpleNamespace(
+                path="/files/origin_probe.bin",
+                original_hash=hash_a,
+                new_hash=hash_a,
+            )
+        ]
+    )
+
+    app = FastAPI()
+    router = create_async_files_router(nexus_fs=real_fs)
+    app.state.transactional_snapshot_service = snap_svc
+    app.include_router(router)
+    app.dependency_overrides[get_auth_result] = lambda: {
+        "authenticated": True,
+        "user_id": "e2e-user",
+        "groups": [],
+        "zone_id": "root",
+        "is_admin": True,
+    }
+    client = TestClient(app)
+
+    resp = client.get(
+        "/read",
+        params={
+            "path": "/files/origin_probe.bin",
+            "version": hash_a,
+            "transaction_id": "txn-stub",
+            "encoding": "base64",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert captured["origins"] == ["peer-1:2126"], captured
+    assert captured["content_id"] == hash_a

--- a/tests/e2e/self_contained/test_files_binary_roundtrip_e2e.py
+++ b/tests/e2e/self_contained/test_files_binary_roundtrip_e2e.py
@@ -1,0 +1,168 @@
+"""E2E binary roundtrip for /api/v2/files/{write,read} (Issue #3989).
+
+Two regressions covered:
+
+1. NUL bytes in write payloads must NOT poison the indexing pipeline. Real
+   binary file formats (PNG, PDF, zip, …) virtually always contain 0x00 in
+   headers, padding, or compressed streams. Postgres TEXT/VARCHAR rejects
+   embedded NULs (SQLSTATE 22021), and unsanitized chunk inserts would
+   leave the asyncpg session in PendingRollbackError until worker recycle.
+2. ``GET /read?encoding=base64`` must return content losslessly. The
+   default UTF-8 path replaces non-text bytes with U+FFFD, so binary data
+   cannot be recovered byte-for-byte.
+
+The test wires a FastAPI TestClient to a real NexusFS (SQLite metastore +
+CASLocalBackend) — same fixture shape as the batch_write_read e2e — and
+asserts a SHA-256 match end-to-end.
+"""
+
+from __future__ import annotations
+
+import base64
+import hashlib
+from pathlib import Path
+
+import pytest
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.metadata import DT_MOUNT
+from nexus.contracts.types import OperationContext
+from nexus.core.config import PermissionConfig
+from nexus.core.nexus_fs import NexusFS
+from nexus.fs import _make_mount_entry
+from nexus.fs._sqlite_meta import SQLiteMetastore
+from nexus.server.api.v2.routers.async_files import create_async_files_router
+from nexus.server.dependencies import get_auth_result
+
+# Real PNG header — IHDR chunk + signature, contains multiple 0x00 bytes
+# in the magic bytes (89 50 4E 47 0D 0A 1A 0A) and the IHDR length field.
+_PNG_HEADER = bytes.fromhex(
+    "89504e470d0a1a0a"  # PNG signature (contains 0x00s)
+    "0000000d49484452"  # IHDR length=13 + chunk type
+    "00000001"  # width=1
+    "00000001"  # height=1
+    "0806000000"  # bit depth=8, color=6, compression=0, filter=0, interlace=0
+    "1f15c489"  # IHDR CRC
+)
+
+
+@pytest.fixture()
+def real_fs(tmp_path: Path) -> NexusFS:
+    from nexus.backends.storage.cas_local import CASLocalBackend
+
+    db_path = str(tmp_path / "meta.db")
+    metastore = SQLiteMetastore(db_path)
+
+    data_dir = tmp_path / "data"
+    data_dir.mkdir()
+    backend = CASLocalBackend(root_path=data_dir)
+
+    kernel = NexusFS(
+        metadata_store=metastore,
+        permissions=PermissionConfig(enforce=False),
+    )
+    kernel._init_cred = OperationContext(
+        user_id="e2e-user",
+        groups=[],
+        zone_id=ROOT_ZONE_ID,
+        is_admin=True,
+    )
+    kernel.sys_setattr("/files", entry_type=DT_MOUNT, backend=backend)
+    metastore.put(_make_mount_entry("/files", backend.name))
+
+    return kernel
+
+
+@pytest.fixture()
+def client(real_fs: NexusFS) -> TestClient:
+    app = FastAPI()
+    router = create_async_files_router(nexus_fs=real_fs)
+    app.include_router(router)
+    app.dependency_overrides[get_auth_result] = lambda: {
+        "authenticated": True,
+        "user_id": "e2e-user",
+        "groups": [],
+        "zone_id": "root",
+        "is_admin": True,
+    }
+    return TestClient(app)
+
+
+def test_write_then_read_png_roundtrips_byte_for_byte(client: TestClient) -> None:
+    """Real PNG bytes (with NULs) must roundtrip via base64 with SHA-256 equality."""
+    payload = _PNG_HEADER
+    expected_sha = hashlib.sha256(payload).hexdigest()
+
+    write_resp = client.post(
+        "/write",
+        json={
+            "path": "/files/probe.png",
+            "content": base64.b64encode(payload).decode("ascii"),
+            "encoding": "base64",
+        },
+    )
+    assert write_resp.status_code == 200, write_resp.text
+    assert write_resp.json()["size"] == len(payload)
+
+    read_resp = client.get("/read", params={"path": "/files/probe.png", "encoding": "base64"})
+    assert read_resp.status_code == 200, read_resp.text
+    body = read_resp.json()
+    assert body["encoding"] == "base64"
+    decoded = base64.b64decode(body["content"])
+    assert hashlib.sha256(decoded).hexdigest() == expected_sha
+    assert decoded == payload
+
+
+def test_read_default_encoding_is_unset_for_text(client: TestClient) -> None:
+    """Backward-compat: omitting ``encoding`` returns a UTF-8 string with no
+    ``encoding`` field (legacy SDK shape)."""
+    write_resp = client.post(
+        "/write",
+        json={"path": "/files/text.txt", "content": "hello world"},
+    )
+    assert write_resp.status_code == 200, write_resp.text
+
+    read_resp = client.get("/read", params={"path": "/files/text.txt"})
+    assert read_resp.status_code == 200
+    body = read_resp.json()
+    assert body["content"] == "hello world"
+    assert body.get("encoding") is None
+
+
+def test_subsequent_write_succeeds_after_nul_payload(client: TestClient) -> None:
+    """Writing NUL-bearing content must not break later writes/reads on the
+    same client/worker (Issue #3989 — the indexing pipeline used to leave
+    asyncpg in PendingRollbackError until recycle)."""
+    nul_blob = b"\x00\x01\x02\x00\x03\x00binary"
+
+    first = client.post(
+        "/write",
+        json={
+            "path": "/files/blob1.bin",
+            "content": base64.b64encode(nul_blob).decode("ascii"),
+            "encoding": "base64",
+        },
+    )
+    assert first.status_code == 200, first.text
+
+    second = client.post(
+        "/write",
+        json={"path": "/files/follow.txt", "content": "still working"},
+    )
+    assert second.status_code == 200, second.text
+
+    read_back = client.get("/read", params={"path": "/files/blob1.bin", "encoding": "base64"})
+    assert read_back.status_code == 200
+    assert base64.b64decode(read_back.json()["content"]) == nul_blob
+
+
+def test_read_rejects_unknown_encoding(client: TestClient) -> None:
+    client.post(
+        "/write",
+        json={"path": "/files/x.txt", "content": "x"},
+    )
+    resp = client.get("/read", params={"path": "/files/x.txt", "encoding": "hex"})
+    assert resp.status_code == 400
+    assert "encoding" in resp.json()["detail"].lower()

--- a/tests/e2e/self_contained/test_files_binary_roundtrip_e2e.py
+++ b/tests/e2e/self_contained/test_files_binary_roundtrip_e2e.py
@@ -453,3 +453,114 @@ def test_versioned_read_uses_recorded_origin_for_original_hash(
         "original-writer:2126",
         "current-writer:2126",
     ], captured
+
+
+def test_versioned_read_serves_deleted_path_from_cas(
+    real_fs: NexusFS, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Historical reads of a *deleted* path must succeed via CAS even
+    though the live VFS path no longer resolves. Without this carve-out,
+    diff/preview/rollback consumers cannot recover a snapshot of a file
+    that has since been deleted (Issue #3989, codex r9)."""
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    payload = b"deleted-bytes"
+    target = "/files/gone.bin"
+
+    # Write then delete via the API so the live path no longer exists.
+    setup_app = FastAPI()
+    setup_app.include_router(create_async_files_router(nexus_fs=real_fs))
+    setup_app.dependency_overrides[get_auth_result] = lambda: {
+        "authenticated": True,
+        "user_id": "e2e-user",
+        "groups": [],
+        "zone_id": "root",
+        "is_admin": True,
+    }
+    setup_client = TestClient(setup_app)
+    write_resp = setup_client.post(
+        "/write",
+        json={
+            "path": target,
+            "content": base64.b64encode(payload).decode("ascii"),
+            "encoding": "base64",
+        },
+    )
+    assert write_resp.status_code == 200, write_resp.text
+    deleted_hash = write_resp.json()["content_id"]
+
+    # Confirm fs.access returns False after delete (i.e. the live path is
+    # gone) by directly removing the metadata via the kernel.
+    real_fs.sys_unlink(target)
+    assert real_fs.access(target) is False
+
+    monkeypatch.setattr(
+        real_fs,
+        "list_mounts",
+        lambda context=None: [{"mount_point": "/files"}],
+    )
+
+    captured: dict[str, object] = {}
+
+    def _fake_cas_read(
+        mount_point: str,
+        zone_id: str,
+        content_id: str,
+        *,
+        origins: list[str] | None = None,
+    ) -> bytes:
+        captured["content_id"] = content_id
+        return payload
+
+    real_kernel = real_fs._kernel
+
+    class _KernelProxy:
+        cas_read = staticmethod(_fake_cas_read)
+
+        def __getattr__(self, name: str) -> object:
+            return getattr(real_kernel, name)
+
+    monkeypatch.setattr(real_fs, "_kernel", _KernelProxy())
+
+    # Snapshot entry recorded for the (now-deleted) path with operation=delete.
+    snap_svc = MagicMock()
+    snap_svc.get_transaction = AsyncMock(return_value=SimpleNamespace(zone_id="root"))
+    snap_svc.list_entries = AsyncMock(
+        return_value=[
+            SimpleNamespace(
+                path=target,
+                operation="delete",
+                original_hash=deleted_hash,
+                new_hash=None,
+                original_metadata=None,
+            )
+        ]
+    )
+
+    app = FastAPI()
+    router = create_async_files_router(nexus_fs=real_fs)
+    app.state.transactional_snapshot_service = snap_svc
+    app.include_router(router)
+    app.dependency_overrides[get_auth_result] = lambda: {
+        "authenticated": True,
+        "user_id": "e2e-user",
+        "groups": [],
+        "zone_id": "root",
+        "is_admin": True,
+    }
+    client = TestClient(app)
+
+    resp = client.get(
+        "/read",
+        params={
+            "path": target,
+            "version": deleted_hash,
+            "transaction_id": "txn-stub",
+            "encoding": "base64",
+        },
+    )
+    assert resp.status_code == 200, resp.text
+    assert captured["content_id"] == deleted_hash
+    decoded = base64.b64decode(resp.json()["content"])
+    assert decoded == payload

--- a/tests/e2e/self_contained/test_files_binary_roundtrip_e2e.py
+++ b/tests/e2e/self_contained/test_files_binary_roundtrip_e2e.py
@@ -564,3 +564,80 @@ def test_versioned_read_serves_deleted_path_from_cas(
     assert captured["content_id"] == deleted_hash
     decoded = base64.b64decode(resp.json()["content"])
     assert decoded == payload
+
+
+def test_versioned_read_deleted_path_denied_for_non_admin(
+    real_fs: NexusFS, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A non-admin caller must NOT be able to recover deleted-file
+    snapshots via the historical read endpoint. Without the live VFS
+    path, file-level READ permission hooks no longer run; the only
+    safe carve-out is admin-only — otherwise a caller who can enumerate
+    transactions could read deleted content they never had READ
+    permission for (Issue #3989, codex r10)."""
+    from types import SimpleNamespace
+    from unittest.mock import AsyncMock, MagicMock
+
+    target = "/files/secret_gone.bin"
+    setup_app = FastAPI()
+    setup_app.include_router(create_async_files_router(nexus_fs=real_fs))
+    setup_app.dependency_overrides[get_auth_result] = lambda: {
+        "authenticated": True,
+        "user_id": "e2e-user",
+        "groups": [],
+        "zone_id": "root",
+        "is_admin": True,
+    }
+    setup_client = TestClient(setup_app)
+    write_resp = setup_client.post(
+        "/write",
+        json={"path": target, "content": "secret"},
+    )
+    assert write_resp.status_code == 200, write_resp.text
+    deleted_hash = write_resp.json()["content_id"]
+    real_fs.sys_unlink(target)
+
+    monkeypatch.setattr(
+        real_fs,
+        "list_mounts",
+        lambda context=None: [{"mount_point": "/files"}],
+    )
+    snap_svc = MagicMock()
+    snap_svc.get_transaction = AsyncMock(return_value=SimpleNamespace(zone_id="root"))
+    snap_svc.list_entries = AsyncMock(
+        return_value=[
+            SimpleNamespace(
+                path=target,
+                operation="delete",
+                original_hash=deleted_hash,
+                new_hash=None,
+                original_metadata=None,
+            )
+        ]
+    )
+
+    app = FastAPI()
+    router = create_async_files_router(nexus_fs=real_fs)
+    app.state.transactional_snapshot_service = snap_svc
+    app.include_router(router)
+    # Non-admin caller in the same zone.
+    app.dependency_overrides[get_auth_result] = lambda: {
+        "authenticated": True,
+        "user_id": "regular-user",
+        "groups": [],
+        "zone_id": "root",
+        "is_admin": False,
+    }
+    client = TestClient(app)
+
+    resp = client.get(
+        "/read",
+        params={
+            "path": target,
+            "version": deleted_hash,
+            "transaction_id": "txn-stub",
+        },
+    )
+    # Live path no longer exists → access() returns False → 404. Critically
+    # the request must NOT succeed via the delete carve-out.
+    assert resp.status_code == 404, resp.text

--- a/tests/integration/bricks/search/test_chunk_store.py
+++ b/tests/integration/bricks/search/test_chunk_store.py
@@ -60,3 +60,36 @@ async def test_chunk_store_deletes_document_chunks() -> None:
 
     session.execute.assert_awaited_once()
     session.commit.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_chunk_store_strips_null_bytes_before_insert() -> None:
+    """NUL bytes must be scrubbed before INSERT — Postgres TEXT rejects them
+    (SQLSTATE 22021) and an unsanitized payload would put the asyncpg session
+    in PendingRollbackError until the worker is recycled (Issue #3989)."""
+    session = AsyncMock()
+    ctx = AsyncMock()
+    ctx.__aenter__.return_value = session
+    ctx.__aexit__.return_value = False
+    session_factory = MagicMock(return_value=ctx)
+
+    store = ChunkStore(async_session_factory=session_factory, db_type="postgresql")
+    await store.replace_document_chunks(
+        "pid-1",
+        [
+            ChunkRecord(
+                chunk_text="alpha\x00beta\x00gamma",
+                chunk_tokens=3,
+                chunk_context="ctx\x00with\x00nuls",
+                line_start=1,
+                line_end=1,
+            )
+        ],
+    )
+
+    insert_call = session.execute.await_args_list[1]
+    rows = insert_call.args[1]
+    assert "\x00" not in rows[0]["chunk_text"]
+    assert rows[0]["chunk_text"] == "alphabetagamma"
+    assert "\x00" not in rows[0]["chunk_context"]
+    assert rows[0]["chunk_context"] == "ctxwithnuls"

--- a/tests/integration/bricks/search/test_error_paths.py
+++ b/tests/integration/bricks/search/test_error_paths.py
@@ -76,6 +76,38 @@ class TestSearchDaemonErrors:
         assert daemon.stats.last_index_refresh is not None
 
     @pytest.mark.asyncio
+    async def test_index_documents_recursively_strips_nuls(self) -> None:
+        """NULs nested inside metadata dicts/lists must also be scrubbed —
+        txtai persists the full doc object so nested NULs would still poison
+        Postgres (Issue #3989, codex r2)."""
+        from nexus.bricks.search.daemon import SearchDaemon
+        from nexus.contracts.constants import ROOT_ZONE_ID
+
+        daemon = SearchDaemon()
+        daemon._initialized = True
+        daemon._backend = AsyncMock()
+        daemon._backend.upsert.return_value = 1
+
+        docs = [
+            {
+                "id": "doc-1",
+                "text": "hello",
+                "path": "/x.md",
+                "metadata": {
+                    "title": "a\x00b",
+                    "tags": ["safe", "with\x00nul", {"deep": "x\x00y"}],
+                },
+            }
+        ]
+        await daemon.index_documents(docs)
+
+        forwarded = daemon._backend.upsert.await_args.args[0]
+        assert forwarded[0]["metadata"]["title"] == "ab"
+        assert forwarded[0]["metadata"]["tags"][1] == "withnul"
+        assert forwarded[0]["metadata"]["tags"][2]["deep"] == "xy"
+        assert daemon._backend.upsert.await_args.kwargs["zone_id"] == ROOT_ZONE_ID
+
+    @pytest.mark.asyncio
     async def test_delete_documents_uses_backend_delete(self) -> None:
         """Explicit deletion should delegate to the active backend."""
         from nexus.bricks.search.daemon import SearchDaemon

--- a/tests/integration/bricks/search/test_error_paths.py
+++ b/tests/integration/bricks/search/test_error_paths.py
@@ -108,6 +108,32 @@ class TestSearchDaemonErrors:
         assert daemon._backend.upsert.await_args.kwargs["zone_id"] == ROOT_ZONE_ID
 
     @pytest.mark.asyncio
+    async def test_index_documents_scrubs_dict_keys_too(self) -> None:
+        """Dict KEYS containing NULs must also be scrubbed — txtai persists
+        the full document object so a NUL-bearing metadata key would still
+        poison Postgres TEXT/JSON (codex r4)."""
+        from nexus.bricks.search.daemon import SearchDaemon
+
+        daemon = SearchDaemon()
+        daemon._initialized = True
+        daemon._backend = AsyncMock()
+        daemon._backend.upsert.return_value = 1
+
+        docs = [
+            {
+                "id": "doc-1",
+                "text": "hi",
+                "metadata": {"key\x00with\x00nul": "value"},
+            }
+        ]
+        await daemon.index_documents(docs)
+
+        forwarded = daemon._backend.upsert.await_args.args[0]
+        keys = list(forwarded[0]["metadata"].keys())
+        assert all("\x00" not in k for k in keys), keys
+        assert keys == ["keywithnul"]
+
+    @pytest.mark.asyncio
     async def test_delete_documents_uses_backend_delete(self) -> None:
         """Explicit deletion should delegate to the active backend."""
         from nexus.bricks.search.daemon import SearchDaemon

--- a/tests/integration/bricks/search/test_mutation_resolver.py
+++ b/tests/integration/bricks/search/test_mutation_resolver.py
@@ -379,3 +379,36 @@ async def test_resolver_includes_soft_deleted_rows_for_delete_events() -> None:
     # expression in ORDER BY may still reference deleted_at to prefer
     # live rows when both exist, which is fine.)
     assert "WHERE fp.deleted_at IS NULL" not in session.statements[0]
+
+
+@pytest.mark.asyncio
+async def test_resolver_strips_null_bytes_from_content() -> None:
+    """NUL (0x00) bytes must be scrubbed before they reach any downstream
+    consumer (bm25, fts, embedding, txtai, naive-fallback). Postgres TEXT
+    rejects them with SQLSTATE 22021 and would otherwise leave the asyncpg
+    session in PendingRollbackError until worker recycle (Issue #3989).
+    """
+    file_reader = AsyncMock()
+    file_reader.read_text.side_effect = ["alpha\x00beta\x00gamma"]
+
+    session_factory = lambda: _SessionCtx(  # noqa: E731
+        [[("root", "/blob.bin", "pid-blob")]]
+    )
+    resolver = MutationResolver(
+        file_reader=file_reader,
+        async_session_factory=session_factory,
+    )
+    event = SearchMutationEvent(
+        event_id="evt-nul",
+        operation_id="op-nul",
+        op=SearchMutationOp.UPSERT,
+        path="/zone/root/blob.bin",
+        zone_id=ROOT_ZONE_ID,
+        timestamp=SimpleNamespace(tzinfo=None),
+        sequence_number=1,
+    )
+
+    resolved = await resolver.resolve_batch([event])
+    assert resolved[0].content is not None
+    assert "\x00" not in resolved[0].content
+    assert resolved[0].content == "alphabetagamma"

--- a/tests/integration/bricks/search/test_search_mutation_flow.py
+++ b/tests/integration/bricks/search/test_search_mutation_flow.py
@@ -1,6 +1,7 @@
 import asyncio
 from datetime import UTC, datetime
 from types import SimpleNamespace
+from typing import Any
 from unittest.mock import AsyncMock
 
 import pytest
@@ -385,3 +386,45 @@ async def test_txtai_consumer_collapses_duplicate_document_mutations() -> None:
         ],
         zone_id=ROOT_ZONE_ID,
     )
+
+
+class _FakeFileReaderWithNuls:
+    async def read_text(self, _path: str) -> str:
+        return "alpha\x00beta\x00gamma"
+
+
+@pytest.mark.asyncio
+async def test_refresh_indexes_strips_null_bytes_before_txtai_upsert() -> None:
+    """Legacy refresh fallback used to feed raw content (with NULs) to txtai
+    and Postgres, leaving the asyncpg session in PendingRollbackError until
+    worker recycle. Verify scrub happens before BM25S, embedding pipeline,
+    naive chunks, and txtai backend (Issue #3989, codex review)."""
+
+    class _CapturingBackend:
+        def __init__(self) -> None:
+            self.upserts: list[tuple[list[dict[str, Any]], str]] = []
+
+        async def upsert(self, docs: list[dict[str, Any]], *, zone_id: str) -> None:
+            self.upserts.append((list(docs), zone_id))
+
+    captured_bm25 = _CapturingBM25SIndex()
+    backend = _CapturingBackend()
+
+    daemon = SearchDaemon()
+    daemon._file_reader = _FakeFileReaderWithNuls()
+    daemon._bm25s_index = captured_bm25
+    daemon._backend = backend
+    # path_in_scope returns True by default (no scope filter wired)
+    daemon._async_session = None
+
+    await daemon._refresh_indexes(["/zone/root/blob.bin"])
+
+    assert captured_bm25.indexed_documents, "BM25S must receive content"
+    for _pid, _path, content in captured_bm25.indexed_documents:
+        assert "\x00" not in content, f"NUL leaked to BM25S: {content!r}"
+
+    assert backend.upserts, "txtai backend must receive an upsert"
+    for docs, _zone in backend.upserts:
+        for doc in docs:
+            assert "\x00" not in doc["text"], f"NUL leaked to txtai: {doc['text']!r}"
+            assert doc["text"] == "alphabetagamma"

--- a/tests/unit/bricks/snapshot/test_snapshot_hook.py
+++ b/tests/unit/bricks/snapshot/test_snapshot_hook.py
@@ -27,6 +27,7 @@ def _make_meta(**overrides: object) -> MagicMock:
     meta.size = overrides.get("size", 1024)
     meta.version = overrides.get("version", 3)
     meta.modified_at = overrides.get("modified_at", datetime(2026, 1, 1, tzinfo=UTC))
+    meta.last_writer_address = overrides.get("last_writer_address")
     return meta
 
 
@@ -69,9 +70,30 @@ class TestOnPostWrite:
                 "size": 1024,
                 "version": 3,
                 "modified_at": "2026-01-01T00:00:00+00:00",
+                "last_writer_address": None,
             },
             "new-hash",
         )
+
+    def test_captures_pre_write_writer_address(
+        self, hook: SnapshotWriteHook, mock_svc: MagicMock
+    ) -> None:
+        """Capture the original writer's address with ``original_metadata``
+        so historical reads of ``original_hash`` after a cross-node
+        overwrite can scatter-gather chunks from the original writer
+        rather than just the current one (Issue #3989, codex r8)."""
+        mock_svc.is_tracked.return_value = "txn-x"
+        old = _make_meta(last_writer_address="original-writer:2126")
+        ctx = WriteHookContext(
+            path="/file.txt",
+            content=b"data",
+            context=None,
+            old_metadata=old,
+            content_id="new-hash",
+        )
+        hook.on_post_write(ctx)
+        captured_meta = mock_svc.track_write.call_args.args[3]
+        assert captured_meta["last_writer_address"] == "original-writer:2126"
 
     def test_skips_when_no_transaction(self, hook: SnapshotWriteHook, mock_svc: MagicMock) -> None:
         mock_svc.is_tracked.return_value = None
@@ -128,8 +150,23 @@ class TestOnPostDelete:
                 "size": 1024,
                 "version": 3,
                 "modified_at": "2026-01-01T00:00:00+00:00",
+                "last_writer_address": None,
             },
         )
+
+    def test_captures_pre_delete_writer_address(
+        self, hook: SnapshotWriteHook, mock_svc: MagicMock
+    ) -> None:
+        """Pre-delete ``last_writer_address`` must be captured so a
+        post-delete historical read of the snapshot hash can scatter-gather
+        chunks from the writer's node when local chunks are missing
+        (Issue #3989, codex r8)."""
+        mock_svc.is_tracked.return_value = "txn-y"
+        meta = _make_meta(last_writer_address="writer-7:2126")
+        ctx = DeleteHookContext(path="/file.txt", context=None, metadata=meta)
+        hook.on_post_delete(ctx)
+        captured_meta = mock_svc.track_delete.call_args.args[3]
+        assert captured_meta["last_writer_address"] == "writer-7:2126"
 
     def test_skips_when_no_transaction(self, hook: SnapshotWriteHook, mock_svc: MagicMock) -> None:
         mock_svc.is_tracked.return_value = None


### PR DESCRIPTION
## Summary

Closes #3989. Two regressions blocked binary content (PNG/PDF/zip/...) on `/api/v2/files`:

1. **NUL bytes in write payloads poisoned the indexing pipeline.** PG TEXT rejects `0x00` (SQLSTATE 22021); asyncpg then left the session in `PendingRollbackError` until worker recycle.
2. **`/read` always returned content as UTF-8-decoded string** with `U+FFFD` replacements; `?encoding=base64` was silently ignored.

## Changes

**NUL-byte scrub** — every entry point feeding content downstream:
- `mutation_resolver._lookup_content` — central chokepoint (covers bm25, fts, embedding, txtai, naive-fallback in one place)
- `daemon.index_documents` — RPC `/api/v2/search/index` scrubs all string fields
- `chunk_store._build_insert_params` — last-line-of-defense before INSERT
- `pipeline_indexer._prepare_documents` — RPC fallback after raw-bytes UTF-8 decode

**Lossless read encoding**:
- `ReadResponse` gains `encoding: str | None`
- `read_file` accepts `?encoding=base64` and returns `{"content": <b64>, "encoding": "base64"}`
- All 4 return paths (CAS-version, connector, markdown-partial, standard VFS) honor the param via shared `_encode_read_payload` helper
- Default behavior preserved (legacy SDKs unaffected); `?encoding=hex` → 400

## Test plan

Unit + integration:
- [x] `tests/integration/bricks/search/test_chunk_store.py` — new test asserts NUL stripped pre-INSERT
- [x] `tests/integration/bricks/search/test_mutation_resolver.py` — new test asserts NUL stripped on `mutation.content`
- [x] `tests/e2e/self_contained/test_files_binary_roundtrip_e2e.py` — new file: PNG roundtrip with SHA-256 equality, NUL-bearing write doesn't break follow-up writes, default-encoding backcompat, unknown-encoding → 400
- [x] All 30 related tests pass (4 chunk_store + 10 mutation_resolver + 4 binary roundtrip + 11 batch_write_read + unit router)

Live stack (`nexus up --build` from this branch):
- [x] 1.33 MB binary w/ 267,752 NUL bytes — byte-equal SHA-256 roundtrip via `?encoding=base64`
- [x] 40 concurrent writes (10 threads, NUL+text interleaved) — 0 errors
- [x] `/api/v2/search/index` with NUL-bearing text — accepted, indexed text returned as `foobarbaz` (NULs stripped)
- [x] `docker logs | grep -ciE "rollback|22021|invalidtext|null.character"` → 0