### PR TITLE
fix(daemon): catch OSError in _is_nexusd_process for Windows stale PID

### DIFF
--- a/src/nexus/daemon/main.py
+++ b/src/nexus/daemon/main.py
@@ -51,10 +51,12 @@ def _is_nexusd_process(pid: int) -> bool:
     cmdline check prevents false positives after PID reuse — common in Docker
     containers with small PID namespaces after a segfault/crash restart.
     """
-    # Fast path: process doesn't exist at all
+    # Fast path: process doesn't exist at all. On Windows, os.kill(pid, 0)
+    # raises plain OSError (e.g. WinError 87 "invalid parameter") rather
+    # than ProcessLookupError when the PID is dead, so catch OSError too.
     try:
         os.kill(pid, 0)
-    except (ProcessLookupError, PermissionError):
+    except (ProcessLookupError, PermissionError, OSError):
         return False
 
     # On Linux, verify the process is actually nexusd


### PR DESCRIPTION
## Summary

`_is_nexusd_process(pid)` calls `os.kill(pid, 0)` to detect a stale PID file. On Windows, `os.kill` raises plain `OSError` (e.g. `WinError 87 \"invalid parameter\"`) when the PID is dead, **not** `ProcessLookupError`. The pre-existing handler caught only `(ProcessLookupError, PermissionError)`, so a stale PID file (common after a Windows reboot — the prior nexusd's PID is now reused or invalid) crashes daemon startup with `WinError 87` instead of being recognized as stale and cleared.

## Fix

Add `OSError` to the exception tuple. `OSError` is the parent of both `ProcessLookupError` and `PermissionError`, so behavior is unchanged on POSIX (those subclasses are matched first); on Windows it now correctly treats any `os.kill` failure as \"process not present\" and clears the stale file.

Repro on Win:
1. Start nexusd, reboot before clean shutdown.
2. Old PID file persists at `~/.nexus/nexusd.pid`.
3. New nexusd start crashes with `OSError: [WinError 87] 参数错误。` from `_is_nexusd_process`.

After the fix, the stale file is cleared on the same path that handled the Linux \"process gone\" case.

## Test plan

- [x] Reproduced the crash on Windows + verified the fix unblocks `nexusd` startup with a stale PID file.
- [ ] CI green.