### PR TITLE
feat: scaffold @nexus-ai-fs/grpc-client TypeScript package

### DIFF
--- a/buf.gen.yaml
+++ b/buf.gen.yaml
@@ -8,3 +8,13 @@ plugins:
     out: docs/protocol
     opt:
       - naming=proto
+  # TypeScript message classes (Connect-ES)
+  - remote: buf.build/bufbuild/es
+    out: packages/nexus-grpc-ts/src/gen
+    opt:
+      - target=ts
+  # TypeScript service descriptors / Connect-RPC client
+  - remote: buf.build/connectrpc/es
+    out: packages/nexus-grpc-ts/src/gen
+    opt:
+      - target=ts

--- a/packages/nexus-grpc-ts/.gitignore
+++ b/packages/nexus-grpc-ts/.gitignore
@@ -1,0 +1,6 @@
+node_modules/
+dist/
+# Generated protobuf / Connect-RPC stubs — produced by `npm run generate`
+# (runs `buf generate` against the repo-root buf.gen.yaml).
+src/gen/
+*.tsbuildinfo

--- a/packages/nexus-grpc-ts/README.md
+++ b/packages/nexus-grpc-ts/README.md
@@ -1,0 +1,71 @@
+# @nexus-ai-fs/grpc-client
+
+TypeScript client for the Nexus VFS gRPC service (`:2028`).
+
+Counterpart to the Rust client in `rust/kernel/src/rpc_transport.rs` —
+same `.proto`, same wire contract. Built on
+[Connect-RPC](https://connectrpc.com/) so the same package works in
+Node and (with a different transport) in browsers.
+
+## Install
+
+```sh
+npm install @nexus-ai-fs/grpc-client
+```
+
+## Generate stubs
+
+The `.proto` files live at the repo root under `proto/`. Stubs are
+produced by `buf generate` (config: `buf.gen.yaml` at the repo root)
+and land in `src/gen/`.
+
+```sh
+# from the repo root
+buf generate
+
+# or from this package
+npm run generate
+```
+
+`src/gen/` is gitignored — regenerate before building.
+
+## Usage (Node / Electron main process)
+
+```ts
+import { readFileSync } from "node:fs";
+import { createNexusClient } from "@nexus-ai-fs/grpc-client";
+
+const client = createNexusClient({
+  baseUrl: "https://nexus:2028",
+  authToken: process.env.NEXUS_TOKEN!,
+  tls: {
+    ca: readFileSync("/etc/nexus/ca.pem"),
+    cert: readFileSync("/etc/nexus/client.pem"),
+    key: readFileSync("/etc/nexus/client.key"),
+  },
+});
+
+const resp = await client.read({ path: "/foo", contentId: "" });
+console.log(resp.size, resp.contentId);
+```
+
+The transport stamps `authToken` onto every request body automatically
+(the Nexus server reads auth from the message body, not gRPC metadata)
+and retries on transient failures (`UNAVAILABLE`, `DEADLINE_EXCEEDED`)
+with the same backoff schedule as the Rust client.
+
+## Architecture for Electron apps
+
+Renderer processes can't speak native HTTP/2 gRPC. The recommended
+pattern is to keep this client in the **main** process and expose typed
+IPC handlers to the renderer:
+
+```ts
+// main.ts
+const vfs = createNexusClient({ baseUrl, authToken, tls });
+ipcMain.handle("vfs:read", (_e, path: string) =>
+  vfs.read({ path, authToken: "", contentId: "" }),
+);
+```
+
+The renderer never sees the gRPC channel or the mTLS private key.

--- a/packages/nexus-grpc-ts/package.json
+++ b/packages/nexus-grpc-ts/package.json
@@ -1,0 +1,66 @@
+{
+  "name": "@nexus-ai-fs/grpc-client",
+  "version": "0.1.0",
+  "description": "TypeScript gRPC/Connect-RPC client for the Nexus VFS service (port 2028) — autogen stubs + thin transport wrapper",
+  "type": "module",
+  "main": "./dist/index.cjs",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "import": {
+        "types": "./dist/index.d.ts",
+        "default": "./dist/index.js"
+      },
+      "require": {
+        "types": "./dist/index.d.cts",
+        "default": "./dist/index.cjs"
+      }
+    }
+  },
+  "files": [
+    "dist",
+    "README.md"
+  ],
+  "scripts": {
+    "generate": "buf generate",
+    "build": "tsup",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "tsc --noEmit",
+    "clean": "rm -rf dist src/gen"
+  },
+  "engines": {
+    "node": ">=18"
+  },
+  "dependencies": {
+    "@bufbuild/protobuf": "^1.10.0",
+    "@connectrpc/connect": "^1.4.0",
+    "@connectrpc/connect-node": "^1.4.0"
+  },
+  "devDependencies": {
+    "@bufbuild/buf": "^1.39.0",
+    "@bufbuild/protoc-gen-es": "^1.10.0",
+    "@connectrpc/protoc-gen-connect-es": "^1.4.0",
+    "@types/node": "^25.4.0",
+    "tsup": "^8.0.0",
+    "typescript": "^5.5.0",
+    "vitest": "^2.0.0"
+  },
+  "keywords": [
+    "nexus",
+    "grpc",
+    "connect-rpc",
+    "client",
+    "sdk"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/nexi-lab/nexus",
+    "directory": "packages/nexus-grpc-ts"
+  }
+}

--- a/packages/nexus-grpc-ts/src/index.ts
+++ b/packages/nexus-grpc-ts/src/index.ts
@@ -1,0 +1,26 @@
+export {
+  createNexusClient,
+  DEFAULT_TIMEOUT_MS,
+} from "./transport.js";
+export type {
+  NexusClient,
+  NexusClientOptions,
+  TlsConfig,
+} from "./transport.js";
+
+// Re-export the generated service descriptor and message types so
+// consumers can construct requests / inspect schemas without reaching
+// into the `gen/` tree directly.
+export { NexusVFSService } from "./gen/nexus/grpc/vfs/vfs_connect.js";
+export {
+  CallRequest,
+  CallResponse,
+  DeleteRequest,
+  DeleteResponse,
+  PingRequest,
+  PingResponse,
+  ReadRequest,
+  ReadResponse,
+  WriteRequest,
+  WriteResponse,
+} from "./gen/nexus/grpc/vfs/vfs_pb.js";

--- a/packages/nexus-grpc-ts/src/transport.ts
+++ b/packages/nexus-grpc-ts/src/transport.ts
@@ -1,0 +1,126 @@
+// Thin wrapper around Connect-RPC's gRPC transport for the Nexus VFS service.
+//
+// Mirrors the Rust `RpcTransport` (rust/kernel/src/rpc_transport.rs):
+//   - holds a single channel keyed by base URL
+//   - stamps `auth_token` onto every outbound request body (server reads
+//     auth from the message body, not gRPC metadata — see
+//     rust/transport/src/grpc.rs:125)
+//   - retries on transient gRPC failures (UNAVAILABLE / DEADLINE_EXCEEDED)
+//     up to 2 times with exponential backoff (200ms, 400ms)
+//   - optional mTLS via Node `tls` PEM material
+//
+// Generated stubs live under `./gen/nexus/grpc/vfs/` after `npm run generate`.
+
+import { Code, ConnectError, createPromiseClient } from "@connectrpc/connect";
+import type { Interceptor, PromiseClient } from "@connectrpc/connect";
+import { createGrpcTransport } from "@connectrpc/connect-node";
+
+import { NexusVFSService } from "./gen/nexus/grpc/vfs/vfs_connect.js";
+
+export interface TlsConfig {
+  /** PEM-encoded CA bundle the server cert is verified against. */
+  ca: Buffer | string;
+  /** Optional client certificate (mTLS). When set, `key` is required. */
+  cert?: Buffer | string;
+  /** Optional client private key (mTLS). When set, `cert` is required. */
+  key?: Buffer | string;
+}
+
+export interface NexusClientOptions {
+  /** e.g. "https://nexus:2028" or "http://127.0.0.1:2028". */
+  baseUrl: string;
+  /** Bearer token forwarded as `auth_token` on every request body. */
+  authToken: string;
+  /** Optional mTLS material. Omit for plaintext HTTP/2. */
+  tls?: TlsConfig;
+  /** Per-request deadline in milliseconds. Default: 60s (matches server). */
+  timeoutMs?: number;
+}
+
+export type NexusClient = PromiseClient<typeof NexusVFSService>;
+
+const DEFAULT_TIMEOUT_MS = 60_000;
+const MAX_RETRIES = 2;
+
+/**
+ * Create a typed client for the Nexus VFS gRPC service.
+ *
+ * The returned client exposes one method per RPC declared in
+ * `proto/nexus/grpc/vfs/vfs.proto` (`call`, `read`, `write`, `delete`,
+ * `ping`). All requests are unary today; if streaming RPCs are added to
+ * the proto they appear automatically after regenerating stubs.
+ */
+export function createNexusClient(opts: NexusClientOptions): NexusClient {
+  if (opts.tls?.cert && !opts.tls.key) {
+    throw new Error("createNexusClient: tls.cert provided without tls.key");
+  }
+  if (opts.tls?.key && !opts.tls.cert) {
+    throw new Error("createNexusClient: tls.key provided without tls.cert");
+  }
+
+  const transport = createGrpcTransport({
+    baseUrl: opts.baseUrl,
+    httpVersion: "2",
+    nodeOptions: opts.tls
+      ? { ca: opts.tls.ca, cert: opts.tls.cert, key: opts.tls.key }
+      : undefined,
+    interceptors: [attachAuthToken(opts.authToken), retryTransient()],
+  });
+
+  return createPromiseClient(NexusVFSService, transport);
+}
+
+/**
+ * Inject `auth_token` into every outbound request body. The Nexus VFS
+ * server reads auth from the message body (so static API keys and OIDC
+ * tokens flow through the same field), not from gRPC metadata.
+ */
+function attachAuthToken(token: string): Interceptor {
+  return (next) => async (req) => {
+    const message = req.message as Record<string, unknown>;
+    if (
+      message &&
+      typeof message === "object" &&
+      "authToken" in message &&
+      !message["authToken"]
+    ) {
+      message["authToken"] = token;
+    }
+    return next(req);
+  };
+}
+
+/**
+ * Retry on transient gRPC failures only — UNAVAILABLE and DEADLINE_EXCEEDED.
+ * Backoff matches the Rust client: 200ms, 400ms.
+ */
+function retryTransient(): Interceptor {
+  return (next) => async (req) => {
+    let attempt = 0;
+    while (true) {
+      try {
+        return await next(req);
+      } catch (err) {
+        if (attempt >= MAX_RETRIES || !isRetryable(err)) {
+          throw err;
+        }
+        attempt += 1;
+        const delayMs = 100 * (1 << attempt);
+        await sleep(delayMs);
+      }
+    }
+  };
+}
+
+function isRetryable(err: unknown): boolean {
+  if (!(err instanceof ConnectError)) {
+    return false;
+  }
+  return err.code === Code.Unavailable || err.code === Code.DeadlineExceeded;
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+export { DEFAULT_TIMEOUT_MS };

--- a/packages/nexus-grpc-ts/tsconfig.json
+++ b/packages/nexus-grpc-ts/tsconfig.json
@@ -1,0 +1,26 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "lib": ["ES2022"],
+    "outDir": "./dist",
+    "rootDir": "./src",
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "strict": true,
+    "noUncheckedIndexedAccess": true,
+    "noImplicitOverride": true,
+    "noPropertyAccessFromIndexSignature": true,
+    "exactOptionalPropertyTypes": false,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "verbatimModuleSyntax": true,
+    "skipLibCheck": true,
+    "esModuleInterop": true,
+    "resolveJsonModule": true
+  },
+  "include": ["src/**/*.ts"],
+  "exclude": ["node_modules", "dist", "tests"]
+}

--- a/packages/nexus-grpc-ts/tsup.config.ts
+++ b/packages/nexus-grpc-ts/tsup.config.ts
@@ -1,0 +1,11 @@
+import { defineConfig } from "tsup";
+
+export default defineConfig({
+  entry: ["src/index.ts"],
+  format: ["esm", "cjs"],
+  dts: true,
+  clean: true,
+  sourcemap: true,
+  splitting: false,
+  treeshake: true,
+});

--- a/packages/nexus-grpc-ts/vitest.config.ts
+++ b/packages/nexus-grpc-ts/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from "vitest/config";
+
+export default defineConfig({
+  test: {
+    environment: "node",
+    include: ["tests/**/*.test.ts"],
+  },
+});


### PR DESCRIPTION
## Summary

Adds a TypeScript gRPC client for the Nexus VFS service (`:2028`) — counterpart to the Rust tonic client in `rust/kernel/src/rpc_transport.rs`, sharing the same `proto/nexus/grpc/vfs/vfs.proto` wire contract.

- **`buf.gen.yaml`**: adds `protoc-gen-es` (messages) and `protoc-gen-connect-es` (service descriptors) plugins. Both emit into `packages/nexus-grpc-ts/src/gen/`.
- **`packages/nexus-grpc-ts/`**: new package skeleton (package.json, tsconfig, tsup, vitest) following the existing `nexus-api-client` layout.
- **`src/transport.ts`**: thin `createNexusClient()` wrapper around Connect-RPC's Node gRPC transport. Mirrors `RpcTransport` semantics:
  - stamps `auth_token` onto every outbound request body (server reads auth from the message body, not gRPC metadata — `rust/transport/src/grpc.rs:125`)
  - retries on `UNAVAILABLE` / `DEADLINE_EXCEEDED` with 200ms / 400ms backoff
  - optional mTLS via Node `tls` PEMs
- **README** documents the `buf generate` workflow and the recommended Electron pattern (gRPC client lives in main process; renderer talks to it via typed IPC handlers — never sees the channel or mTLS keys).

Generated stubs (`src/gen/`) are gitignored; run `npm run generate` (or `buf generate` from the repo root) before `npm run build`. Matches how the Python `_pb2` stubs are handled.

## Test plan

- [ ] `cd packages/nexus-grpc-ts && npm install`
- [ ] `npm run generate` — verify `src/gen/nexus/grpc/vfs/{vfs_pb,vfs_connect}.ts` are produced
- [ ] `npm run lint` — TypeScript clean
- [ ] `npm run build` — esm + cjs outputs in `dist/`
- [ ] Smoke test against a running `nexusd` on `:2028`: `client.ping({})` returns version + zone_id + uptime
- [ ] Confirm retry interceptor backs off on a stopped server (UNAVAILABLE)

https://claude.ai/code/session_01QpeZ2mNvTnTD5P2VWWzV6e

---
_Generated by [Claude Code](https://claude.ai/code/session_01QpeZ2mNvTnTD5P2VWWzV6e)_