### PR TITLE
[codex] Fix Docker Publish edge smoke timeout

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -148,7 +148,7 @@ jobs:
     needs: build-and-push
     if: github.ref == 'refs/heads/develop' || startsWith(github.ref, 'refs/tags/v')
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
     services:
       postgres:
         image: pgvector/pgvector:pg16
@@ -248,15 +248,15 @@ jobs:
             -e NEXUS_PROFILE=remote \
             -e NEXUS_GRPC_PORT=2028 \
             -e NEXUS_GRPC_TLS=false \
-            nexus-e2e nexus demo init
+            nexus-e2e nexus demo init --skip-semantic
 
       - name: Seed search index
         run: |
-          # nexus demo init writes files but does NOT trigger the semantic embedding
-          # pipeline.  Run both:
+          # Docker Publish uses `nexus demo init --skip-semantic` above to keep
+          # demo data seeding fast. Seed search here in one place:
           #   1. nexus reindex --target search  — rebuilds BM25 keyword index from MCL
           #   2. nexus search index /workspace/demo — generates vector embeddings
-          # Both are required for `nexus search query` (HERB QA) to return results.
+          # Both are required for HERB hybrid retrieval.
 
           # Step 1: Rebuild BM25 keyword index from MCL
           echo "Step 1: Rebuilding BM25 keyword index..."
@@ -284,40 +284,13 @@ jobs:
             http://localhost:2026/api/v2/search/stats 2>/dev/null \
             | python3 -c "import sys,json; d=json.load(sys.stdin); print(f\"  backend={d.get('backend')} bm25_docs={d.get('bm25_documents')} txtai_model={d.get('txtai_model')} last_refresh={d.get('last_index_refresh')}\")" 2>/dev/null || true
 
-          # Step 4: Wait for txtai mutation consumer to index demo files.
-          # The txtai model (sentence-transformers/all-MiniLM-L6-v2) downloads and loads
-          # asynchronously after server start (~2-5 min on a cold CI runner).
-          # The mutation consumer auto-indexes new files once the model is loaded.
-          # We poll last_index_refresh (set when any mutation consumer processes events)
-          # AND nexus search query until the demo files appear in results.
-          # Timeout: 60×5s = 300s (5 min) — covers cold model download.
-          echo "Step 4: Waiting for txtai mutation consumer + model load (up to 5 min)..."
-          for i in $(seq 1 60); do
-            result=$(docker exec \
-              -e NEXUS_URL=http://localhost:2026 \
-              -e NEXUS_API_KEY="${NEXUS_API_KEY}" \
-              -e NEXUS_PROFILE=remote \
-              nexus-e2e nexus search query "Nexus Core" --limit 1 2>/dev/null || true)
-            if echo "$result" | grep -q "prod-001"; then
-              echo "  Mutation consumer indexed files after ${i}×5s"
-              break
-            fi
-            # Show refresh status every 12 attempts (1 min)
-            if [ $(( i % 12 )) -eq 0 ]; then
-              curl -sf \
-                -H "Authorization: Bearer ${NEXUS_API_KEY}" \
-                http://localhost:2026/api/v2/search/stats 2>/dev/null \
-                | python3 -c "import sys,json; d=json.load(sys.stdin); print(f\"  [{i*5}s] backend={d.get('backend')} bm25={d.get('bm25_documents')} refresh={d.get('last_index_refresh')}\")" 2>/dev/null || true
-            fi
-            sleep 5
-          done
-
-          # Step 5: Explicit search index as belt-and-suspenders (retry up to 3×).
-          # If the mutation consumer already indexed the files, this is a fast no-op.
-          # If not (model failed to load or mutation consumer is behind), retry.
-          echo "Step 5: Explicit search index (with 3-attempt retry)..."
+          # Step 4: Explicit search index (retry up to 3×).
+          # Do this before readiness queries: on cold runners, querying hybrid
+          # search while txtai is still warming can block long enough to burn
+          # the workflow timeout before explicit indexing ever runs.
+          echo "Step 4: Explicit search index (with 3-attempt retry)..."
           for i in $(seq 1 3); do
-            idx_out=$(docker exec \
+            idx_out=$(timeout 300s docker exec \
               -e NEXUS_URL=http://localhost:2026 \
               -e NEXUS_API_KEY="${NEXUS_API_KEY}" \
               -e NEXUS_PROFILE=remote \
@@ -330,22 +303,22 @@ jobs:
               echo "  Indexing succeeded on attempt ${i}"
               break
             fi
-            echo "  0 files — waiting 60s before retry (model may still be loading)..."
-            sleep 60
+            echo "  0 files — waiting 30s before retry (model may still be loading)..."
+            sleep 30
           done
 
-          # Step 6: Final diagnostics and readiness check
-          echo "Step 6: Final search daemon stats..."
+          # Step 5: Final diagnostics and readiness check
+          echo "Step 5: Final search daemon stats..."
           curl -sf \
             -H "Authorization: Bearer ${NEXUS_API_KEY}" \
             http://localhost:2026/api/v2/search/stats 2>/dev/null \
             | python3 -c "import sys,json; d=json.load(sys.stdin); print(f\"  backend={d.get('backend')} bm25={d.get('bm25_documents')} refresh={d.get('last_index_refresh')}\")" 2>/dev/null || true
           # Final status (non-fatal — test script enforces the HERB gate)
-          docker exec \
+          timeout 30s docker exec \
             -e NEXUS_URL=http://localhost:2026 \
             -e NEXUS_API_KEY="${NEXUS_API_KEY}" \
             -e NEXUS_PROFILE=remote \
-            nexus-e2e nexus search query "Nexus Core" --limit 1 || true
+            nexus-e2e nexus search query "Nexus Core" --path /workspace/demo/herb --mode hybrid --limit 1 || true
 
       - name: Copy test scripts into container
         run: |
@@ -371,7 +344,7 @@ jobs:
             nexus-e2e python3 /tmp/test_build_perf_e2e.py
 
       - name: Collect container logs on failure
-        if: failure()
+        if: failure() || cancelled()
         run: |
           docker inspect nexus-e2e --format 'exit_code={{.State.ExitCode}} status={{.State.Status}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}} started_at={{.State.StartedAt}} finished_at={{.State.FinishedAt}} error={{json .State.Error}}' || true
           echo "Crash signatures from container logs:"

--- a/src/nexus/cli/commands/demo.py
+++ b/src/nexus/cli/commands/demo.py
@@ -10,6 +10,7 @@ Seeding is idempotent by default.  A manifest file
 
 from __future__ import annotations
 
+import base64
 import contextlib
 import json
 import logging
@@ -118,6 +119,23 @@ class _RestApiNexusClient:
     def write(self, path: str, content: bytes) -> None:
         text = content.decode("utf-8", errors="replace")
         self._client.post("/api/v2/files/write", json_body={"path": path, "content": text})
+
+    def write_batch(self, files: list[tuple[str, bytes]]) -> list[dict[str, Any]]:
+        payload = {
+            "files": [
+                {
+                    "path": path,
+                    "content_base64": base64.b64encode(content).decode("ascii"),
+                }
+                for path, content in files
+            ]
+        }
+        result = self._client.post("/api/v2/files/batch/write", json_body=payload)
+        if isinstance(result, dict):
+            raw_results = result.get("results", [])
+            if isinstance(raw_results, list):
+                return raw_results
+        return []
 
     def mkdir(self, path: str, *, parents: bool = False, exist_ok: bool = False) -> None:  # noqa: ARG002
         try:
@@ -368,6 +386,7 @@ async def _seed_files(
 
     # Seed both core demo files and HERB-derived corpus
     all_files = list(DEMO_FILES) + list(HERB_CORPUS)
+    pending: list[tuple[str, str, str]] = []
     for path, content, _description in all_files:
         if path in seeded:
             try:
@@ -381,6 +400,34 @@ async def _seed_files(
             parent = "/".join(path.split("/")[:-1])
             if parent:
                 nx.mkdir(parent, parents=True, exist_ok=True)
+        except Exception as e:
+            console.print(
+                f"  [nexus.warning]Warning:[/nexus.warning] Could not create parent for {path}: {e}"
+            )
+            continue
+        pending.append((path, content, _description))
+
+    if pending and hasattr(nx, "write_batch"):
+        try:
+            batch_results = nx.write_batch(
+                [(path, content.encode()) for path, content, _ in pending]
+            )
+            if len(batch_results) == len(pending):
+                for path, _content, _description in pending:
+                    seeded.append(path)
+                    created += 1
+                manifest["files"] = seeded
+                return created
+            logger.debug(
+                "Batch demo file seed returned %d results for %d files; falling back",
+                len(batch_results),
+                len(pending),
+            )
+        except Exception as e:
+            logger.debug("Batch demo file seed failed; falling back to sequential writes: %s", e)
+
+    for path, content, _description in pending:
+        try:
             nx.write(path, content.encode())
             seeded.append(path)
             created += 1

--- a/tests/unit/cli/test_demo_seeds.py
+++ b/tests/unit/cli/test_demo_seeds.py
@@ -1,6 +1,69 @@
 """Tests for demo seed functions — _seed_catalog and _seed_aspects (Issue #2930)."""
 
+import asyncio
+import base64
 from unittest.mock import MagicMock, patch
+
+
+class TestSeedFiles:
+    """Tests for _seed_files()."""
+
+    def test_uses_batch_write_when_available(self) -> None:
+        from nexus.cli.commands.demo import _seed_files
+        from nexus.cli.commands.demo_data import DEMO_FILES, HERB_CORPUS
+
+        class BatchClient:
+            def __init__(self) -> None:
+                self.batch_files: list[tuple[str, bytes]] = []
+
+            def access(self, _path: str) -> bool:
+                return False
+
+            def mkdir(self, _path: str, *, parents: bool, exist_ok: bool) -> None:
+                assert parents is True
+                assert exist_ok is True
+
+            def write_batch(self, files: list[tuple[str, bytes]]) -> list[dict[str, object]]:
+                self.batch_files = list(files)
+                return [{"path": path, "content_id": "cid"} for path, _content in files]
+
+            def write(self, _path: str, _content: bytes) -> None:
+                raise AssertionError("sequential write fallback should not run")
+
+        client = BatchClient()
+        manifest: dict = {}
+
+        created = asyncio.run(_seed_files(client, manifest))
+
+        expected_paths = [path for path, _content, _desc in list(DEMO_FILES) + list(HERB_CORPUS)]
+        assert created == len(expected_paths)
+        assert [path for path, _content in client.batch_files] == expected_paths
+        assert manifest["files"] == expected_paths
+
+    @patch("nexus.cli.api_client.NexusApiClient")
+    def test_rest_client_batch_write_encodes_payload(self, mock_client_cls) -> None:
+        from nexus.cli.commands.demo import _RestApiNexusClient
+
+        mock_client = MagicMock()
+        mock_client.post.return_value = {"results": [{"path": "/workspace/demo/a.bin"}]}
+        mock_client_cls.return_value = mock_client
+
+        client = _RestApiNexusClient("http://localhost:2026", "test-key")
+        result = client.write_batch([("/workspace/demo/a.bin", b"\x00demo")])
+
+        assert result == [{"path": "/workspace/demo/a.bin"}]
+        mock_client.post.assert_called_once()
+        endpoint = mock_client.post.call_args.args[0]
+        payload = mock_client.post.call_args.kwargs["json_body"]
+        assert endpoint == "/api/v2/files/batch/write"
+        assert payload == {
+            "files": [
+                {
+                    "path": "/workspace/demo/a.bin",
+                    "content_base64": base64.b64encode(b"\x00demo").decode("ascii"),
+                }
+            ]
+        }
 
 
 class TestSeedCatalog:


### PR DESCRIPTION
## Summary
- batch `nexus demo init` REST file seeding through `/api/v2/files/batch/write`
- make Docker Publish seed demo data with `--skip-semantic`, then seed hybrid search explicitly once
- remove the pre-index hybrid search polling that hung until the 30-minute job timeout
- increase the edge smoke timeout to 45 minutes and collect container logs on cancellation

## Root cause
Docker Publish run 25264219304 was canceled by the job-level 30-minute timeout. `Seed demo workspace` took ~23.5 minutes and logged per-file write timeouts; `Seed search index` then started a hybrid readiness query before explicit indexing and was killed by the timeout.

## Verification
- `/opt/homebrew/bin/uv run pytest tests/unit/cli/test_demo_seeds.py -q -n0`
- `/opt/homebrew/bin/uv run --extra dev ruff check src/nexus/cli/commands/demo.py tests/unit/cli/test_demo_seeds.py`
- `git diff --check`

Local Docker is not installed in this Codex environment, so the exact Docker Publish smoke job needs GitHub Actions validation.
