### PR TITLE
[codex] test: create Nexus testkit

### DIFF
--- a/docs/development/testkit.md
+++ b/docs/development/testkit.md
@@ -1,0 +1,122 @@
+# Nexus Testkit
+
+`tests/testkit` is the shared helper package for Nexus tests. It is importable
+as `testkit` during pytest runs because `pyproject.toml` adds `tests` to
+`pythonpath`. Keep testkit code under `tests/`; do not move it into `src/`
+unless the project intentionally creates an installed testing API.
+
+## Package Boundary
+
+Use testkit for reusable test doubles, auth contexts, deployment profile
+matrices, optional-service probes, and high-signal assertions. Keep one-off
+fixtures close to the suite that owns them.
+
+Testkit modules must not import production-only optional dependencies at module
+import time. For example, `testkit.containers` can probe a NATS TCP port, but it
+must not import `nats` until a test that explicitly needs the NATS client does so.
+
+## Fake Backend
+
+```python
+from testkit.backends import InMemoryBackend
+
+
+def test_roundtrip() -> None:
+    backend = InMemoryBackend()
+    result = backend.write_content(b"hello")
+
+    assert backend.read_content(result.content_id) == b"hello"
+```
+
+Use `FactoryStubBackend` when a test only needs a connector class that satisfies
+registration and factory conformance checks.
+
+```python
+from nexus.backends.base.registry import register_connector
+from nexus.backends.base.runtime_deps import PythonDep
+from testkit.backends import FactoryStubBackend
+
+
+@register_connector("stub_ok", runtime_deps=(PythonDep("json"),))
+class StubOK(FactoryStubBackend):
+    pass
+```
+
+Existing helpers such as `DictMetastore`, `InMemoryNexusFS`,
+`InMemoryRecordStore`, and `FailingBackend` are re-exported from
+`testkit.backends` for new tests.
+
+## Auth Contexts
+
+```python
+from testkit.auth import make_context, make_zone_context
+
+
+ctx = make_context(user_id="alice", groups=["eng"], zone_id="zone-a")
+zone_ctx = make_zone_context("zone-b", user_id="bob", perms="r")
+```
+
+Use `TEST_CONTEXT` and `TEST_ADMIN_CONTEXT` for the default shared identities.
+Use builders when a test needs a specific user, group, zone, or admin flag.
+
+## Profile Matrices
+
+```python
+import pytest
+
+from testkit.profiles import ProfileCase, local_profile_params
+
+
+@pytest.mark.parametrize("case", local_profile_params())
+def test_profile_defaults(case: ProfileCase) -> None:
+    assert case.expected_bricks == case.profile.default_bricks()
+    assert case.expected_drivers == case.profile.default_drivers()
+```
+
+Use `all_profile_params()` when a test genuinely covers every deployment profile.
+Use `local_profile_params()` for tests that should avoid remote, federation, or
+cloud-service assumptions.
+
+## Optional Services
+
+```python
+from testkit.containers import postgres_probe, require_service
+
+
+def test_pg_backed_feature() -> None:
+    probe = require_service(postgres_probe())
+    assert probe.url is not None
+```
+
+Supported environment conventions:
+
+| Service | Environment variables |
+|---|---|
+| Postgres | `NEXUS_DATABASE_URL`, `POSTGRES_URL`, `DATABASE_URL` |
+| Redis/Dragonfly | `NEXUS_DRAGONFLY_URL`, `REDIS_URL`, `NEXUS_DRAGONFLY_COORDINATION_URL` |
+| NATS | `NEXUS_NATS_URL` |
+
+## Assertions
+
+```python
+from testkit.assertions import assert_missing_dependency_error
+
+
+assert_missing_dependency_error(
+    err,
+    backend="stub_missing_py",
+    count=1,
+    missing_names=("definitely_not_a_real_module_xyz",),
+    install_hints=("pip install nexus-fs[gcs]",),
+)
+```
+
+Prefer assertion helpers when they make failure output clearer than raw string
+checks in individual tests.
+
+## Migration Guidance
+
+When touching a suite that already imports from `tests.helpers`, leave unrelated
+imports alone. Move only helpers needed by the current change into `testkit` or
+switch to existing testkit exports. This keeps migrations small and reduces merge
+conflicts across the large test tree.

--- a/docs/development/testkit.md
+++ b/docs/development/testkit.md
@@ -46,6 +46,29 @@ Existing helpers such as `DictMetastore`, `InMemoryNexusFS`,
 `InMemoryRecordStore`, and `FailingBackend` are re-exported from
 `testkit.backends` for new tests.
 
+## Fake Bricks
+
+```python
+import pytest
+
+from testkit.bricks import FakeSearchBrick, probe_service_lifecycle
+
+
+@pytest.mark.asyncio
+async def test_search_brick_lifecycle() -> None:
+    brick = FakeSearchBrick(results=[{"path": "/docs/a.txt"}])
+
+    probe = await probe_service_lifecycle(brick)
+
+    assert probe.started_after_start is True
+    assert probe.healthy_after_start is True
+    assert probe.started_after_stop is False
+```
+
+Use `FakeLifecycleBrick` when a test only needs start/stop/health behavior. Use
+`FakeSearchBrick` when a test needs a lightweight object satisfying
+`SearchBrickProtocol` without starting search indexes or external services.
+
 ## Auth Contexts
 
 ```python

--- a/docs/superpowers/plans/2026-05-02-issue-3968-nexus-testkit.md
+++ b/docs/superpowers/plans/2026-05-02-issue-3968-nexus-testkit.md
@@ -1,0 +1,1615 @@
+# Nexus Testkit Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create the first incremental `tests/testkit` package for reusable Nexus test fakes, auth contexts, profile matrices, optional-service helpers, and assertions.
+
+**Architecture:** Keep the package under `tests/testkit` so it is pytest-only and not installed as production API. Add focused modules for profiles, auth, containers, backends, and assertions, re-exporting stable helpers from `tests/helpers` where useful. Migrate `tests/integration/backends/test_factory_dep_check.py` and add `tests/unit/backends/test_profile_matrix.py` as the first backend-suite consumers.
+
+**Tech Stack:** Python 3.14, pytest, Nexus test helpers, `nexus.contracts.deployment_profile`, `nexus.contracts.types.OperationContext`, `nexus.backends.base` contracts.
+
+---
+
+## File Structure
+
+- Create `tests/testkit/__init__.py`: package docstring and public module boundary.
+- Create `tests/testkit/profiles.py`: `ProfileCase` dataclass and profile matrix constructors/pytest params.
+- Create `tests/testkit/auth.py`: auth context re-exports and builders.
+- Create `tests/testkit/containers.py`: env URL helpers, TCP probes, skip helper, and smoke config builders.
+- Create `tests/testkit/backends.py`: in-memory backend, factory stub backend, and compatibility re-exports from `tests/helpers`.
+- Create `tests/testkit/assertions.py`: missing dependency, event, metadata, and permission assertion helpers.
+- Create `tests/unit/testkit/test_profiles.py`: unit tests for profile matrix behavior.
+- Create `tests/unit/testkit/test_auth.py`: unit tests for context builders.
+- Create `tests/unit/testkit/test_containers.py`: unit tests for env/probe/skip helpers.
+- Create `tests/unit/testkit/test_backends.py`: unit tests for in-memory backend and re-exports.
+- Create `tests/unit/testkit/test_assertions.py`: unit tests for common assertion helpers.
+- Create `tests/unit/backends/test_profile_matrix.py`: backend-suite consumer of `testkit.profiles`.
+- Modify `tests/integration/backends/test_factory_dep_check.py`: replace local stub/assertion logic with testkit imports.
+- Create `docs/development/testkit.md`: usage guide for new tests.
+
+---
+
+### Task 1: Profile Matrix Testkit
+
+**Files:**
+- Create: `tests/testkit/__init__.py`
+- Create: `tests/testkit/profiles.py`
+- Create: `tests/unit/testkit/test_profiles.py`
+- Create: `tests/unit/backends/test_profile_matrix.py`
+
+- [ ] **Step 1: Write failing profile matrix tests**
+
+Create `tests/unit/testkit/test_profiles.py`:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from nexus.contracts.deployment_profile import DeploymentProfile
+from testkit.profiles import (
+    ProfileCase,
+    all_profile_cases,
+    all_profile_params,
+    local_profile_cases,
+    local_profile_params,
+    profile_params,
+    remote_profile_cases,
+    service_profile_cases,
+)
+
+
+def test_all_profile_cases_cover_deployment_profiles_in_stable_order() -> None:
+    assert [case.profile for case in all_profile_cases()] == [
+        DeploymentProfile.CLUSTER,
+        DeploymentProfile.EMBEDDED,
+        DeploymentProfile.LITE,
+        DeploymentProfile.SANDBOX,
+        DeploymentProfile.FULL,
+        DeploymentProfile.CLOUD,
+        DeploymentProfile.REMOTE,
+    ]
+
+
+def test_profile_cases_mirror_deployment_profile_defaults() -> None:
+    for case in all_profile_cases():
+        assert isinstance(case, ProfileCase)
+        assert case.id == case.profile.value
+        assert case.expected_bricks == case.profile.default_bricks()
+        assert case.expected_drivers == case.profile.default_drivers()
+
+
+def test_profile_subsets_are_explicit() -> None:
+    assert [case.profile for case in local_profile_cases()] == [
+        DeploymentProfile.EMBEDDED,
+        DeploymentProfile.LITE,
+        DeploymentProfile.SANDBOX,
+        DeploymentProfile.FULL,
+    ]
+    assert [case.profile for case in remote_profile_cases()] == [DeploymentProfile.REMOTE]
+    assert [case.profile for case in service_profile_cases()] == [
+        DeploymentProfile.CLUSTER,
+        DeploymentProfile.CLOUD,
+    ]
+
+
+def test_profile_params_keep_stable_pytest_ids() -> None:
+    params = all_profile_params()
+    assert [param.id for param in params] == [case.id for case in all_profile_cases()]
+
+
+def test_local_profile_params_keep_stable_pytest_ids() -> None:
+    params = local_profile_params()
+    assert [param.id for param in params] == [case.id for case in local_profile_cases()]
+
+
+def test_profile_params_can_skip_external_service_cases() -> None:
+    params = profile_params(service_profile_cases(), skip_external=True)
+    by_id = {param.id: param for param in params}
+
+    for profile_id in ("cluster", "cloud"):
+        mark_names = [mark.name for mark in by_id[profile_id].marks]
+        assert "skip" in mark_names
+
+
+@pytest.mark.parametrize("case", all_profile_params())
+def test_param_values_are_profile_cases(case: ProfileCase) -> None:
+    assert case.expected_bricks == case.profile.default_bricks()
+    assert case.expected_drivers == case.profile.default_drivers()
+```
+
+Create `tests/unit/backends/test_profile_matrix.py`:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from testkit.profiles import ProfileCase, all_profile_params
+
+
+@pytest.mark.parametrize("case", all_profile_params())
+def test_backend_profile_matrix_tracks_profile_defaults(case: ProfileCase) -> None:
+    assert case.expected_bricks == case.profile.default_bricks()
+    assert case.expected_drivers == case.profile.default_drivers()
+```
+
+- [ ] **Step 2: Run profile tests to verify RED**
+
+Run:
+
+```bash
+pytest tests/unit/testkit/test_profiles.py tests/unit/backends/test_profile_matrix.py -q
+```
+
+Expected: FAIL with `ModuleNotFoundError: No module named 'testkit'`.
+
+- [ ] **Step 3: Add minimal package and profile matrix implementation**
+
+Create `tests/testkit/__init__.py`:
+
+```python
+"""Reusable pytest-only helpers for Nexus tests."""
+```
+
+Create `tests/testkit/profiles.py`:
+
+```python
+"""Deployment profile matrices for Nexus tests."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+import pytest
+
+from nexus.contracts.deployment_profile import DeploymentProfile
+
+
+@dataclass(frozen=True, slots=True)
+class ProfileCase:
+    """Explicit deployment-profile case for parametrized tests."""
+
+    profile: DeploymentProfile
+    id: str
+    expected_bricks: frozenset[str]
+    expected_drivers: frozenset[str]
+    external_services: tuple[str, ...] = ()
+    marks: tuple[pytest.MarkDecorator, ...] = ()
+
+    def param(self, *, skip_external: bool = False) -> object:
+        marks = list(self.marks)
+        if skip_external and self.external_services:
+            services = ", ".join(self.external_services)
+            marks.append(
+                pytest.mark.skip(
+                    reason=f"profile {self.id} requires optional service(s): {services}"
+                )
+            )
+        return pytest.param(self, id=self.id, marks=marks)
+
+
+_ALL_PROFILES: tuple[DeploymentProfile, ...] = (
+    DeploymentProfile.CLUSTER,
+    DeploymentProfile.EMBEDDED,
+    DeploymentProfile.LITE,
+    DeploymentProfile.SANDBOX,
+    DeploymentProfile.FULL,
+    DeploymentProfile.CLOUD,
+    DeploymentProfile.REMOTE,
+)
+
+_LOCAL_PROFILES: tuple[DeploymentProfile, ...] = (
+    DeploymentProfile.EMBEDDED,
+    DeploymentProfile.LITE,
+    DeploymentProfile.SANDBOX,
+    DeploymentProfile.FULL,
+)
+
+_REMOTE_PROFILES: tuple[DeploymentProfile, ...] = (DeploymentProfile.REMOTE,)
+
+_SERVICE_PROFILES: tuple[DeploymentProfile, ...] = (
+    DeploymentProfile.CLUSTER,
+    DeploymentProfile.CLOUD,
+)
+
+_EXTERNAL_SERVICES: dict[DeploymentProfile, tuple[str, ...]] = {
+    DeploymentProfile.CLUSTER: ("federation",),
+    DeploymentProfile.CLOUD: ("postgres", "redis", "nats"),
+}
+
+
+def profile_case(profile: DeploymentProfile) -> ProfileCase:
+    """Build a `ProfileCase` from the production profile defaults."""
+
+    return ProfileCase(
+        profile=profile,
+        id=profile.value,
+        expected_bricks=profile.default_bricks(),
+        expected_drivers=profile.default_drivers(),
+        external_services=_EXTERNAL_SERVICES.get(profile, ()),
+    )
+
+
+def profile_cases(profiles: Iterable[DeploymentProfile]) -> tuple[ProfileCase, ...]:
+    """Build profile cases in the caller-provided order."""
+
+    return tuple(profile_case(profile) for profile in profiles)
+
+
+def all_profile_cases() -> tuple[ProfileCase, ...]:
+    """Return every known deployment profile in stable enum order."""
+
+    return profile_cases(_ALL_PROFILES)
+
+
+def local_profile_cases() -> tuple[ProfileCase, ...]:
+    """Return profiles that run without remote/client or service-cluster semantics."""
+
+    return profile_cases(_LOCAL_PROFILES)
+
+
+def remote_profile_cases() -> tuple[ProfileCase, ...]:
+    """Return remote-client profile cases."""
+
+    return profile_cases(_REMOTE_PROFILES)
+
+
+def service_profile_cases() -> tuple[ProfileCase, ...]:
+    """Return profiles associated with federation or external services."""
+
+    return profile_cases(_SERVICE_PROFILES)
+
+
+def profile_params(
+    cases: Iterable[ProfileCase],
+    *,
+    skip_external: bool = False,
+) -> list[object]:
+    """Convert profile cases into pytest parameters with stable IDs."""
+
+    return [case.param(skip_external=skip_external) for case in cases]
+
+
+def all_profile_params(*, skip_external: bool = False) -> list[object]:
+    """Return pytest params for every deployment profile."""
+
+    return profile_params(all_profile_cases(), skip_external=skip_external)
+
+
+def local_profile_params(*, skip_external: bool = False) -> list[object]:
+    """Return pytest params for local deployment profiles."""
+
+    return profile_params(local_profile_cases(), skip_external=skip_external)
+```
+
+- [ ] **Step 4: Run profile tests to verify GREEN**
+
+Run:
+
+```bash
+pytest tests/unit/testkit/test_profiles.py tests/unit/backends/test_profile_matrix.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit profile matrix slice**
+
+Run:
+
+```bash
+git add tests/testkit/__init__.py tests/testkit/profiles.py tests/unit/testkit/test_profiles.py tests/unit/backends/test_profile_matrix.py
+git commit -m "test: add profile matrix testkit"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 2: Auth and Optional-Service Helpers
+
+**Files:**
+- Create: `tests/testkit/auth.py`
+- Create: `tests/testkit/containers.py`
+- Create: `tests/unit/testkit/test_auth.py`
+- Create: `tests/unit/testkit/test_containers.py`
+
+- [ ] **Step 1: Write failing auth helper tests**
+
+Create `tests/unit/testkit/test_auth.py`:
+
+```python
+from __future__ import annotations
+
+from testkit.auth import (
+    TEST_ADMIN_CONTEXT,
+    TEST_CONTEXT,
+    make_admin_context,
+    make_context,
+    make_zone_context,
+)
+
+
+def test_shared_contexts_are_reexported() -> None:
+    assert TEST_CONTEXT.user_id == "test"
+    assert TEST_CONTEXT.is_admin is False
+    assert TEST_ADMIN_CONTEXT.user_id == "test-admin"
+    assert TEST_ADMIN_CONTEXT.is_admin is True
+
+
+def test_make_context_builds_user_context() -> None:
+    ctx = make_context(user_id="alice", groups=["eng"], zone_id="zone-a")
+    assert ctx.user_id == "alice"
+    assert ctx.groups == ["eng"]
+    assert ctx.zone_id == "zone-a"
+    assert ctx.zone_set == ("zone-a",)
+    assert ctx.zone_perms == (("zone-a", "rw"),)
+    assert ctx.is_admin is False
+
+
+def test_make_admin_context_sets_admin_flag() -> None:
+    ctx = make_admin_context(user_id="root", groups=["ops"])
+    assert ctx.user_id == "root"
+    assert ctx.groups == ["ops"]
+    assert ctx.is_admin is True
+
+
+def test_make_zone_context_sets_zone_permissions() -> None:
+    ctx = make_zone_context("zone-b", user_id="bob", perms="r")
+    assert ctx.user_id == "bob"
+    assert ctx.zone_id == "zone-b"
+    assert ctx.zone_set == ("zone-b",)
+    assert ctx.zone_perms == (("zone-b", "r"),)
+```
+
+- [ ] **Step 2: Write failing optional-service helper tests**
+
+Create `tests/unit/testkit/test_containers.py`:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from testkit.containers import (
+    ServiceProbe,
+    get_env_url,
+    nats_url,
+    parse_host_port,
+    postgres_probe,
+    postgres_url,
+    probe_tcp_service,
+    redis_url,
+    require_service,
+    server_smoke_config,
+)
+
+
+def test_get_env_url_returns_first_configured_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ONE", raising=False)
+    monkeypatch.setenv("TWO", "value-two")
+    monkeypatch.setenv("THREE", "value-three")
+
+    assert get_env_url(("ONE", "TWO", "THREE")) == "value-two"
+
+
+def test_postgres_url_uses_existing_env_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NEXUS_DATABASE_URL", raising=False)
+    monkeypatch.setenv("POSTGRES_URL", "postgresql://u:p@db:5432/nexus")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://ignored")
+
+    assert postgres_url() == "postgresql://u:p@db:5432/nexus"
+
+
+def test_redis_url_uses_dragonfly_before_redis(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEXUS_DRAGONFLY_URL", "redis://dragonfly:6379/0")
+    monkeypatch.setenv("REDIS_URL", "redis://redis:6379/0")
+
+    assert redis_url() == "redis://dragonfly:6379/0"
+
+
+def test_nats_url_defaults_to_localhost(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NEXUS_NATS_URL", raising=False)
+
+    assert nats_url() == "nats://localhost:4222"
+
+
+def test_parse_host_port_supports_scheme_and_bare_host() -> None:
+    assert parse_host_port("postgresql://u:p@db.example:5433/nexus", 5432) == (
+        "db.example",
+        5433,
+    )
+    assert parse_host_port("localhost:4222", 4222) == ("localhost", 4222)
+
+
+def test_postgres_probe_reports_missing_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in ("NEXUS_DATABASE_URL", "POSTGRES_URL", "DATABASE_URL"):
+        monkeypatch.delenv(name, raising=False)
+
+    probe = postgres_probe()
+    assert probe.name == "postgres"
+    assert probe.available is False
+    assert "NEXUS_DATABASE_URL" in probe.reason
+
+
+def test_probe_tcp_service_reports_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[tuple[str, int], float]] = []
+
+    class _Conn:
+        def close(self) -> None:
+            pass
+
+    def fake_create_connection(address: tuple[str, int], timeout: float) -> _Conn:
+        calls.append((address, timeout))
+        return _Conn()
+
+    monkeypatch.setattr("socket.create_connection", fake_create_connection)
+
+    probe = probe_tcp_service("nats", "nats://localhost:4222", 4222, timeout=0.1)
+
+    assert probe == ServiceProbe(
+        name="nats",
+        url="nats://localhost:4222",
+        host="localhost",
+        port=4222,
+        available=True,
+        reason="available",
+    )
+    assert calls == [(("localhost", 4222), 0.1)]
+
+
+def test_require_service_skips_when_probe_is_unavailable() -> None:
+    probe = ServiceProbe(
+        name="postgres",
+        url=None,
+        host=None,
+        port=None,
+        available=False,
+        reason="set NEXUS_DATABASE_URL",
+    )
+
+    with pytest.raises(pytest.skip.Exception) as exc_info:
+        require_service(probe)
+
+    assert "set NEXUS_DATABASE_URL" in str(exc_info.value)
+
+
+def test_server_smoke_config_is_explicit() -> None:
+    assert server_smoke_config(port=2028, api_key="key") == {
+        "host": "127.0.0.1",
+        "port": 2028,
+        "base_url": "http://127.0.0.1:2028",
+        "api_key": "key",
+    }
+```
+
+- [ ] **Step 3: Run auth/container tests to verify RED**
+
+Run:
+
+```bash
+pytest tests/unit/testkit/test_auth.py tests/unit/testkit/test_containers.py -q
+```
+
+Expected: FAIL with import errors for `testkit.auth` and `testkit.containers`.
+
+- [ ] **Step 4: Implement auth helpers**
+
+Create `tests/testkit/auth.py`:
+
+```python
+"""Auth and identity fixtures for Nexus tests."""
+
+from __future__ import annotations
+
+from nexus.contracts.types import OperationContext
+from tests.helpers.test_context import TEST_ADMIN_CONTEXT, TEST_CONTEXT
+
+
+def make_context(
+    *,
+    user_id: str = "test",
+    groups: list[str] | None = None,
+    zone_id: str | None = None,
+    zone_set: tuple[str, ...] = (),
+    zone_perms: tuple[tuple[str, str], ...] = (),
+    agent_id: str | None = None,
+    subject_type: str = "user",
+    subject_id: str | None = None,
+    is_admin: bool = False,
+    is_system: bool = False,
+) -> OperationContext:
+    """Build an `OperationContext` with explicit identity fields."""
+
+    return OperationContext(
+        user_id=user_id,
+        groups=list(groups or []),
+        zone_id=zone_id,
+        zone_set=zone_set,
+        zone_perms=zone_perms,
+        agent_id=agent_id,
+        subject_type=subject_type,
+        subject_id=subject_id,
+        is_admin=is_admin,
+        is_system=is_system,
+    )
+
+
+def make_admin_context(
+    *,
+    user_id: str = "test-admin",
+    groups: list[str] | None = None,
+    zone_id: str | None = None,
+) -> OperationContext:
+    """Build an admin `OperationContext` for tests."""
+
+    return make_context(
+        user_id=user_id,
+        groups=groups,
+        zone_id=zone_id,
+        is_admin=True,
+    )
+
+
+def make_zone_context(
+    zone_id: str,
+    *,
+    user_id: str = "test",
+    groups: list[str] | None = None,
+    perms: str = "rw",
+    is_admin: bool = False,
+) -> OperationContext:
+    """Build a context scoped to one zone with the provided permission string."""
+
+    return make_context(
+        user_id=user_id,
+        groups=groups,
+        zone_id=zone_id,
+        zone_perms=((zone_id, perms),),
+        is_admin=is_admin,
+    )
+```
+
+- [ ] **Step 5: Implement optional-service helpers**
+
+Create `tests/testkit/containers.py`:
+
+```python
+"""Optional-service probes and smoke-test config helpers."""
+
+from __future__ import annotations
+
+import os
+import socket
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+import pytest
+
+POSTGRES_ENV_VARS: tuple[str, ...] = (
+    "NEXUS_DATABASE_URL",
+    "POSTGRES_URL",
+    "DATABASE_URL",
+)
+
+REDIS_ENV_VARS: tuple[str, ...] = (
+    "NEXUS_DRAGONFLY_URL",
+    "REDIS_URL",
+    "NEXUS_DRAGONFLY_COORDINATION_URL",
+)
+
+NATS_ENV_VARS: tuple[str, ...] = ("NEXUS_NATS_URL",)
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceProbe:
+    """Result of checking whether an optional service is reachable."""
+
+    name: str
+    url: str | None
+    host: str | None
+    port: int | None
+    available: bool
+    reason: str
+
+
+def get_env_url(names: tuple[str, ...]) -> str | None:
+    """Return the first non-empty URL from the provided environment names."""
+
+    for name in names:
+        value = os.environ.get(name)
+        if value:
+            return value
+    return None
+
+
+def postgres_url() -> str | None:
+    """Return the configured Postgres URL, if present."""
+
+    return get_env_url(POSTGRES_ENV_VARS)
+
+
+def redis_url() -> str | None:
+    """Return the configured Redis or Dragonfly URL, if present."""
+
+    return get_env_url(REDIS_ENV_VARS)
+
+
+def nats_url(default: str = "nats://localhost:4222") -> str:
+    """Return the configured NATS URL, defaulting to localhost."""
+
+    return get_env_url(NATS_ENV_VARS) or default
+
+
+def parse_host_port(url: str, default_port: int) -> tuple[str, int]:
+    """Extract host and port from a service URL or `host:port` string."""
+
+    raw = url if "://" in url else f"//{url}"
+    parsed = urlparse(raw)
+    if parsed.hostname is None:
+        raise ValueError(f"service URL has no host: {url!r}")
+    return parsed.hostname, parsed.port or default_port
+
+
+def _missing_probe(name: str, env_names: tuple[str, ...]) -> ServiceProbe:
+    return ServiceProbe(
+        name=name,
+        url=None,
+        host=None,
+        port=None,
+        available=False,
+        reason=f"set one of {', '.join(env_names)}",
+    )
+
+
+def probe_tcp_service(
+    name: str,
+    url: str,
+    default_port: int,
+    *,
+    timeout: float = 0.25,
+) -> ServiceProbe:
+    """Probe a TCP service without importing the service's Python client."""
+
+    host, port = parse_host_port(url, default_port)
+    try:
+        conn = socket.create_connection((host, port), timeout=timeout)
+        conn.close()
+    except OSError as exc:
+        return ServiceProbe(
+            name=name,
+            url=url,
+            host=host,
+            port=port,
+            available=False,
+            reason=f"{name} unavailable at {host}:{port}: {exc}",
+        )
+    return ServiceProbe(
+        name=name,
+        url=url,
+        host=host,
+        port=port,
+        available=True,
+        reason="available",
+    )
+
+
+def postgres_probe(*, timeout: float = 0.25) -> ServiceProbe:
+    """Probe configured Postgres, or return an unavailable probe when unset."""
+
+    url = postgres_url()
+    if url is None:
+        return _missing_probe("postgres", POSTGRES_ENV_VARS)
+    return probe_tcp_service("postgres", url, 5432, timeout=timeout)
+
+
+def redis_probe(*, timeout: float = 0.25) -> ServiceProbe:
+    """Probe configured Redis or Dragonfly, or return unavailable when unset."""
+
+    url = redis_url()
+    if url is None:
+        return _missing_probe("redis", REDIS_ENV_VARS)
+    return probe_tcp_service("redis", url, 6379, timeout=timeout)
+
+
+def nats_probe(*, timeout: float = 0.25) -> ServiceProbe:
+    """Probe configured NATS, defaulting to localhost."""
+
+    return probe_tcp_service("nats", nats_url(), 4222, timeout=timeout)
+
+
+def require_service(probe: ServiceProbe) -> ServiceProbe:
+    """Skip the current pytest test when the probe is unavailable."""
+
+    if not probe.available:
+        pytest.skip(probe.reason)
+    return probe
+
+
+def server_smoke_config(
+    *,
+    host: str = "127.0.0.1",
+    port: int,
+    api_key: str = "test-api-key",
+) -> dict[str, object]:
+    """Build a small server-smoke config dictionary."""
+
+    return {
+        "host": host,
+        "port": port,
+        "base_url": f"http://{host}:{port}",
+        "api_key": api_key,
+    }
+```
+
+- [ ] **Step 6: Run auth/container tests to verify GREEN**
+
+Run:
+
+```bash
+pytest tests/unit/testkit/test_auth.py tests/unit/testkit/test_containers.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit auth/container slice**
+
+Run:
+
+```bash
+git add tests/testkit/auth.py tests/testkit/containers.py tests/unit/testkit/test_auth.py tests/unit/testkit/test_containers.py
+git commit -m "test: add auth and service testkit helpers"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 3: Backend Fakes and Assertion Helpers
+
+**Files:**
+- Create: `tests/testkit/backends.py`
+- Create: `tests/testkit/assertions.py`
+- Create: `tests/unit/testkit/test_backends.py`
+- Create: `tests/unit/testkit/test_assertions.py`
+
+- [ ] **Step 1: Write failing backend helper tests**
+
+Create `tests/unit/testkit/test_backends.py`:
+
+```python
+from __future__ import annotations
+
+import pytest
+
+from nexus.contracts.exceptions import NexusFileNotFoundError
+from testkit.backends import (
+    DictMetastore,
+    FactoryStubBackend,
+    FailingBackend,
+    InMemoryBackend,
+    InMemoryNexusFS,
+    InMemoryRecordStore,
+)
+
+
+def test_in_memory_backend_round_trips_content() -> None:
+    backend = InMemoryBackend()
+    result = backend.write_content(b"hello")
+
+    assert result.content_id
+    assert result.version == result.content_id
+    assert result.size == 5
+    assert backend.read_content(result.content_id) == b"hello"
+    assert backend.content_exists(result.content_id) is True
+    assert backend.get_content_size(result.content_id) == 5
+
+
+def test_in_memory_backend_raises_for_missing_content() -> None:
+    backend = InMemoryBackend()
+
+    with pytest.raises(NexusFileNotFoundError):
+        backend.read_content("missing")
+
+
+def test_in_memory_backend_tracks_directories() -> None:
+    backend = InMemoryBackend()
+
+    backend.mkdir("/a/b", parents=True, exist_ok=True)
+
+    assert backend.is_directory("/a") is True
+    assert backend.is_directory("/a/b") is True
+    assert backend.list_dir("/") == ["a"]
+    assert backend.list_dir("/a") == ["b"]
+
+
+def test_factory_stub_backend_accepts_arbitrary_kwargs() -> None:
+    backend = FactoryStubBackend(token="secret")
+
+    assert backend.kwargs == {"token": "secret"}
+    assert backend.name == "stub"
+    assert backend.has_feature("anything") is False
+
+
+def test_existing_helpers_are_reexported() -> None:
+    assert callable(DictMetastore)
+    assert callable(InMemoryNexusFS)
+    assert callable(InMemoryRecordStore)
+    assert callable(FailingBackend)
+```
+
+- [ ] **Step 2: Write failing assertion helper tests**
+
+Create `tests/unit/testkit/test_assertions.py`:
+
+```python
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from nexus.backends.base.runtime_deps import BinaryDep, PythonDep
+from nexus.contracts.exceptions import MissingDependencyError
+from testkit.assertions import (
+    assert_event_payload,
+    assert_metadata_contains,
+    assert_missing_dependency_error,
+    assert_permission_decision,
+)
+
+
+def _missing_error() -> MissingDependencyError:
+    return MissingDependencyError(
+        backend="stub_backend",
+        missing=[
+            (
+                PythonDep("missing_module", extras=("gcs",)),
+                "python 'missing_module': install with: pip install nexus-fs[gcs]",
+            ),
+            (
+                BinaryDep("missing_bin", "brew install missing-bin"),
+                "binary 'missing_bin': not on PATH - install with: brew install missing-bin",
+            ),
+        ],
+    )
+
+
+def test_assert_missing_dependency_error_accepts_expected_details() -> None:
+    assert_missing_dependency_error(
+        _missing_error(),
+        backend="stub_backend",
+        count=2,
+        missing_names=("missing_module", "missing_bin"),
+        install_hints=("pip install nexus-fs[gcs]", "brew install missing-bin"),
+    )
+
+
+def test_assert_missing_dependency_error_rejects_wrong_backend() -> None:
+    with pytest.raises(AssertionError, match="expected backend"):
+        assert_missing_dependency_error(_missing_error(), backend="other")
+
+
+def test_assert_event_payload_supports_dicts() -> None:
+    assert_event_payload(
+        {"event_type": "file_write", "path": "/docs/a.txt", "zone_id": "zone-a"},
+        event_type="file_write",
+        path="/docs/a.txt",
+        zone_id="zone-a",
+    )
+
+
+def test_assert_event_payload_supports_objects() -> None:
+    event = SimpleNamespace(type="file_delete", path="/docs/b.txt", zone_id="zone-b")
+
+    assert_event_payload(event, event_type="file_delete", path="/docs/b.txt", zone_id="zone-b")
+
+
+def test_assert_metadata_contains_checks_subset() -> None:
+    assert_metadata_contains(
+        {"path": "/docs/a.txt", "content_type": "text/plain", "size": 12},
+        {"path": "/docs/a.txt", "size": 12},
+    )
+
+
+def test_assert_permission_decision_supports_bool_and_objects() -> None:
+    assert_permission_decision(True, allowed=True)
+    assert_permission_decision(SimpleNamespace(allowed=False), allowed=False)
+
+
+def test_assert_permission_decision_rejects_wrong_state() -> None:
+    with pytest.raises(AssertionError, match="permission decision"):
+        assert_permission_decision(False, allowed=True)
+```
+
+- [ ] **Step 3: Run backend/assertion tests to verify RED**
+
+Run:
+
+```bash
+pytest tests/unit/testkit/test_backends.py tests/unit/testkit/test_assertions.py -q
+```
+
+Expected: FAIL with import errors for `testkit.backends` and `testkit.assertions`.
+
+- [ ] **Step 4: Implement backend helpers**
+
+Create `tests/testkit/backends.py`:
+
+```python
+"""Backend and storage fakes for Nexus tests."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+from nexus.backends.base.backend import Backend, HandlerStatusResponse
+from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
+from nexus.core.object_store import WriteResult
+from tests.helpers.dict_metastore import DictMetastore
+from tests.helpers.failing_backend import FailingBackend
+from tests.helpers.in_memory_record_store import InMemoryRecordStore
+from tests.helpers.inmemory_nexus_fs import InMemoryNexusFS
+
+
+def _normalize_dir(path: str) -> str:
+    if not path or path == "/":
+        return "/"
+    return "/" + path.strip("/")
+
+
+class InMemoryBackend(Backend):
+    """Small in-memory backend for backend contract and wrapper tests."""
+
+    def __init__(self, *, name: str = "memory") -> None:
+        self._name = name
+        self._content: dict[str, bytes] = {}
+        self._dirs: set[str] = {"/"}
+
+    @property
+    def name(self) -> str:
+        return self._name
+
+    def write_content(
+        self,
+        content: bytes,
+        content_id: str = "",
+        *,
+        offset: int = 0,
+        context: Any = None,
+    ) -> WriteResult:
+        if content_id and offset:
+            if content_id not in self._content:
+                raise NexusFileNotFoundError(content_id)
+            existing = self._content[content_id]
+            content = existing[:offset] + content + existing[offset + len(content) :]
+        stored_id = content_id or hashlib.sha256(content).hexdigest()
+        self._content[stored_id] = bytes(content)
+        return WriteResult(content_id=stored_id, version=stored_id, size=len(content))
+
+    def read_content(self, content_id: str, context: Any = None) -> bytes:
+        if content_id not in self._content:
+            raise NexusFileNotFoundError(content_id)
+        return self._content[content_id]
+
+    def delete_content(self, content_id: str, context: Any = None) -> None:
+        if content_id not in self._content:
+            raise NexusFileNotFoundError(content_id)
+        del self._content[content_id]
+
+    def content_exists(self, content_id: str, context: Any = None) -> bool:
+        return content_id in self._content
+
+    def get_content_size(self, content_id: str, context: Any = None) -> int:
+        return len(self.read_content(content_id, context=context))
+
+    def mkdir(
+        self,
+        path: str,
+        parents: bool = False,
+        exist_ok: bool = False,
+        context: Any = None,
+    ) -> None:
+        normalized = _normalize_dir(path)
+        if normalized in self._dirs and not exist_ok:
+            raise BackendError("Directory exists", backend=self.name, path=normalized)
+        if parents:
+            parts = normalized.strip("/").split("/")
+            current = ""
+            for part in parts:
+                current = f"{current}/{part}" if current else f"/{part}"
+                self._dirs.add(current)
+        self._dirs.add(normalized)
+
+    def rmdir(self, path: str, recursive: bool = False, context: Any = None) -> None:
+        normalized = _normalize_dir(path)
+        if normalized not in self._dirs:
+            raise NexusFileNotFoundError(normalized)
+        children = {d for d in self._dirs if d != normalized and d.startswith(normalized + "/")}
+        if children and not recursive:
+            raise BackendError("Directory not empty", backend=self.name, path=normalized)
+        self._dirs.difference_update(children)
+        if normalized != "/":
+            self._dirs.remove(normalized)
+
+    def is_directory(self, path: str, context: Any = None) -> bool:
+        return _normalize_dir(path) in self._dirs
+
+    def list_dir(self, path: str, context: Any = None) -> list[str]:
+        normalized = _normalize_dir(path)
+        prefix = normalized if normalized == "/" else normalized + "/"
+        children: set[str] = set()
+        for directory in self._dirs:
+            if directory == normalized or not directory.startswith(prefix):
+                continue
+            rest = directory[len(prefix) :].strip("/")
+            if rest:
+                children.add(rest.split("/", 1)[0])
+        return sorted(children)
+
+    def check_connection(self, context: Any = None) -> HandlerStatusResponse:
+        return HandlerStatusResponse(success=True)
+
+
+class FactoryStubBackend:
+    """Minimal connector class for BackendFactory registration tests."""
+
+    name = "stub"
+    user_scoped = False
+    is_connected = True
+    has_root_path = False
+    has_token_manager = False
+    backend_features: frozenset[Any] = frozenset()
+
+    def __init__(self, **kwargs: Any) -> None:
+        self.kwargs = kwargs
+
+    def write_content(
+        self,
+        content: bytes,
+        content_id: str = "stub",
+        *,
+        offset: int = 0,
+        context: Any = None,
+    ) -> WriteResult:
+        stored_id = content_id or "stub"
+        return WriteResult(content_id=stored_id, version=stored_id, size=len(content))
+
+    def read_content(self, content_id: str, context: Any = None) -> bytes:
+        return b""
+
+    def delete_content(self, content_id: str, context: Any = None) -> None:
+        return None
+
+    def content_exists(self, content_id: str, context: Any = None) -> bool:
+        return True
+
+    def get_content_size(self, content_id: str, context: Any = None) -> int:
+        return 0
+
+    def mkdir(
+        self,
+        path: str,
+        parents: bool = False,
+        exist_ok: bool = False,
+        context: Any = None,
+    ) -> None:
+        return None
+
+    def rmdir(self, path: str, recursive: bool = False, context: Any = None) -> None:
+        return None
+
+    def is_directory(self, path: str, context: Any = None) -> bool:
+        return False
+
+    def check_connection(self, context: Any = None) -> HandlerStatusResponse:
+        return HandlerStatusResponse(success=True)
+
+    def has_feature(self, feature: Any) -> bool:
+        return False
+```
+
+- [ ] **Step 5: Implement assertion helpers**
+
+Create `tests/testkit/assertions.py`:
+
+```python
+"""Common assertions for Nexus tests."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from nexus.contracts.exceptions import MissingDependencyError
+
+
+def _value(obj: Any, *names: str) -> Any:
+    for name in names:
+        if isinstance(obj, Mapping) and name in obj:
+            return obj[name]
+        if hasattr(obj, name):
+            return getattr(obj, name)
+    return None
+
+
+def assert_missing_dependency_error(
+    err: MissingDependencyError,
+    *,
+    backend: str,
+    count: int | None = None,
+    missing_names: tuple[str, ...] = (),
+    install_hints: tuple[str, ...] = (),
+) -> None:
+    """Assert structured and rendered details on `MissingDependencyError`."""
+
+    assert err.backend == backend, f"expected backend {backend!r}, got {err.backend!r}"
+    if count is not None:
+        assert len(err.missing) == count, f"expected {count} missing deps, got {len(err.missing)}"
+
+    message = str(err)
+    for name in missing_names:
+        assert name in message, f"missing dependency name {name!r} not found in {message!r}"
+    for hint in install_hints:
+        assert hint in message, f"install hint {hint!r} not found in {message!r}"
+
+
+def assert_event_payload(
+    event: Any,
+    *,
+    event_type: str | None = None,
+    path: str | None = None,
+    zone_id: str | None = None,
+) -> None:
+    """Assert common event payload fields on dict-like or object-like events."""
+
+    if event_type is not None:
+        actual_type = _value(event, "event_type", "type")
+        assert actual_type == event_type, f"expected event type {event_type!r}, got {actual_type!r}"
+    if path is not None:
+        actual_path = _value(event, "path")
+        assert actual_path == path, f"expected event path {path!r}, got {actual_path!r}"
+    if zone_id is not None:
+        actual_zone = _value(event, "zone_id", "zone")
+        assert actual_zone == zone_id, f"expected event zone {zone_id!r}, got {actual_zone!r}"
+
+
+def assert_metadata_contains(actual: Mapping[str, Any], expected: Mapping[str, Any]) -> None:
+    """Assert that metadata contains an expected subset."""
+
+    for key, value in expected.items():
+        assert key in actual, f"metadata missing key {key!r}"
+        assert actual[key] == value, f"metadata {key!r}: expected {value!r}, got {actual[key]!r}"
+
+
+def assert_permission_decision(decision: Any, *, allowed: bool) -> None:
+    """Assert allow/deny state on bool or object decisions."""
+
+    actual = decision if isinstance(decision, bool) else _value(decision, "allowed", "allow")
+    assert actual is allowed, f"permission decision expected allowed={allowed!r}, got {actual!r}"
+```
+
+- [ ] **Step 6: Run backend/assertion tests to verify GREEN**
+
+Run:
+
+```bash
+pytest tests/unit/testkit/test_backends.py tests/unit/testkit/test_assertions.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit backend/assertion slice**
+
+Run:
+
+```bash
+git add tests/testkit/backends.py tests/testkit/assertions.py tests/unit/testkit/test_backends.py tests/unit/testkit/test_assertions.py
+git commit -m "test: add backend fakes and testkit assertions"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 4: Migrate Factory Dependency Check Suite
+
+**Files:**
+- Modify: `tests/integration/backends/test_factory_dep_check.py`
+
+- [ ] **Step 1: Run existing suite before migration**
+
+Run:
+
+```bash
+pytest tests/integration/backends/test_factory_dep_check.py -q
+```
+
+Expected: PASS before the refactor.
+
+- [ ] **Step 2: Replace local stub and dependency assertions with testkit imports**
+
+Modify `tests/integration/backends/test_factory_dep_check.py` to this content:
+
+```python
+"""Integration test: BackendFactory.create() raises MissingDependencyError.
+
+Covers Issue #3830 - typed runtime-dep check at mount time.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from nexus.backends.base.factory import BackendFactory
+from nexus.backends.base.registry import ConnectorRegistry, register_connector
+from nexus.backends.base.runtime_deps import BinaryDep, PythonDep
+from nexus.contracts.exceptions import MissingDependencyError
+from testkit.assertions import assert_missing_dependency_error
+from testkit.backends import FactoryStubBackend
+
+
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Any:
+    # Snapshot + restore so we do not affect other tests in the integration run.
+    names_before = set(ConnectorRegistry.list_available())
+    yield
+    for nm in set(ConnectorRegistry.list_available()) - names_before:
+        ConnectorRegistry._base._items.pop(nm, None)
+
+
+class TestFactoryDepCheck:
+    def test_satisfied_deps_allow_instantiation(self) -> None:
+        @register_connector(
+            "stub_ok",
+            runtime_deps=(PythonDep("json"),),  # stdlib - always present
+        )
+        class _OK(FactoryStubBackend):
+            pass
+
+        instance = BackendFactory.create("stub_ok", {})
+        assert isinstance(instance, _OK)
+
+    def test_missing_python_dep_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Force slim-install hint formatting. Otherwise the raw module
+        # name is emitted under the monorepo's full distribution.
+        monkeypatch.setattr(
+            "nexus.backends.base.runtime_deps._nexus_fs_extras_available",
+            lambda: True,
+        )
+
+        @register_connector(
+            "stub_missing_py",
+            runtime_deps=(PythonDep("definitely_not_a_real_module_xyz", extras=("gcs",)),),
+        )
+        class _M(FactoryStubBackend):
+            pass
+
+        with pytest.raises(MissingDependencyError) as exc_info:
+            BackendFactory.create("stub_missing_py", {})
+
+        assert_missing_dependency_error(
+            exc_info.value,
+            backend="stub_missing_py",
+            count=1,
+            missing_names=("definitely_not_a_real_module_xyz",),
+            install_hints=("pip install nexus-fs[gcs]",),
+        )
+
+    def test_missing_binary_dep_raises(self) -> None:
+        @register_connector(
+            "stub_missing_bin",
+            runtime_deps=(BinaryDep("definitely_not_a_real_binary_xyz", "brew install xyz"),),
+        )
+        class _M(FactoryStubBackend):
+            pass
+
+        with pytest.raises(MissingDependencyError) as exc_info:
+            BackendFactory.create("stub_missing_bin", {})
+
+        assert_missing_dependency_error(
+            exc_info.value,
+            backend="stub_missing_bin",
+            count=1,
+            missing_names=("definitely_not_a_real_binary_xyz",),
+            install_hints=("brew install xyz",),
+        )
+
+    def test_all_missing_enumerated_together(self) -> None:
+        @register_connector(
+            "stub_many_missing",
+            runtime_deps=(
+                PythonDep("definitely_not_a_real_module_xyz", extras=("gws",)),
+                BinaryDep("definitely_not_a_real_binary_xyz", "brew install xyz"),
+            ),
+        )
+        class _M(FactoryStubBackend):
+            pass
+
+        with pytest.raises(MissingDependencyError) as exc_info:
+            BackendFactory.create("stub_many_missing", {})
+
+        assert_missing_dependency_error(
+            exc_info.value,
+            backend="stub_many_missing",
+            count=2,
+            missing_names=(
+                "definitely_not_a_real_module_xyz",
+                "definitely_not_a_real_binary_xyz",
+            ),
+        )
+```
+
+- [ ] **Step 3: Run migrated suite to verify GREEN**
+
+Run:
+
+```bash
+pytest tests/integration/backends/test_factory_dep_check.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run all testkit tests with migrated consumer**
+
+Run:
+
+```bash
+pytest tests/unit/testkit tests/unit/backends/test_profile_matrix.py tests/integration/backends/test_factory_dep_check.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit migrated suite**
+
+Run:
+
+```bash
+git add tests/integration/backends/test_factory_dep_check.py
+git commit -m "test: migrate backend dep checks to testkit"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 5: Testkit Documentation
+
+**Files:**
+- Create: `docs/development/testkit.md`
+
+- [ ] **Step 1: Create documentation directory**
+
+Run:
+
+```bash
+mkdir -p docs/development
+```
+
+Expected: directory exists.
+
+- [ ] **Step 2: Add testkit usage guide**
+
+Create `docs/development/testkit.md`:
+
+```markdown
+# Nexus Testkit
+
+`tests/testkit` is the shared helper package for Nexus tests. It is importable
+as `testkit` during pytest runs because `pyproject.toml` adds `tests` to
+`pythonpath`. Keep testkit code under `tests/`; do not move it into `src/`
+unless the project intentionally creates an installed testing API.
+
+## Package Boundary
+
+Use testkit for reusable test doubles, auth contexts, deployment profile
+matrices, optional-service probes, and high-signal assertions. Keep one-off
+fixtures close to the suite that owns them.
+
+Testkit modules must not import production-only optional dependencies at module
+import time. For example, `testkit.containers` can probe a NATS TCP port, but it
+must not import `nats` until a test that explicitly needs the NATS client does so.
+
+## Fake Backend
+
+```python
+from testkit.backends import InMemoryBackend
+
+
+def test_roundtrip() -> None:
+    backend = InMemoryBackend()
+    result = backend.write_content(b"hello")
+
+    assert backend.read_content(result.content_id) == b"hello"
+```
+
+Use `FactoryStubBackend` when a test only needs a connector class that satisfies
+registration and factory conformance checks.
+
+```python
+from nexus.backends.base.registry import register_connector
+from nexus.backends.base.runtime_deps import PythonDep
+from testkit.backends import FactoryStubBackend
+
+
+@register_connector("stub_ok", runtime_deps=(PythonDep("json"),))
+class StubOK(FactoryStubBackend):
+    pass
+```
+
+Existing helpers such as `DictMetastore`, `InMemoryNexusFS`,
+`InMemoryRecordStore`, and `FailingBackend` are re-exported from
+`testkit.backends` for new tests.
+
+## Auth Contexts
+
+```python
+from testkit.auth import make_context, make_zone_context
+
+
+ctx = make_context(user_id="alice", groups=["eng"], zone_id="zone-a")
+zone_ctx = make_zone_context("zone-b", user_id="bob", perms="r")
+```
+
+Use `TEST_CONTEXT` and `TEST_ADMIN_CONTEXT` for the default shared identities.
+Use builders when a test needs a specific user, group, zone, or admin flag.
+
+## Profile Matrices
+
+```python
+import pytest
+
+from testkit.profiles import ProfileCase, local_profile_params
+
+
+@pytest.mark.parametrize("case", local_profile_params())
+def test_profile_defaults(case: ProfileCase) -> None:
+    assert case.expected_bricks == case.profile.default_bricks()
+    assert case.expected_drivers == case.profile.default_drivers()
+```
+
+Use `all_profile_params()` when a test genuinely covers every deployment profile.
+Use `local_profile_params()` for tests that should avoid remote, federation, or
+cloud-service assumptions.
+
+## Optional Services
+
+```python
+from testkit.containers import postgres_probe, require_service
+
+
+def test_pg_backed_feature() -> None:
+    probe = require_service(postgres_probe())
+    assert probe.url is not None
+```
+
+Supported environment conventions:
+
+| Service | Environment variables |
+|---|---|
+| Postgres | `NEXUS_DATABASE_URL`, `POSTGRES_URL`, `DATABASE_URL` |
+| Redis/Dragonfly | `NEXUS_DRAGONFLY_URL`, `REDIS_URL`, `NEXUS_DRAGONFLY_COORDINATION_URL` |
+| NATS | `NEXUS_NATS_URL` |
+
+## Assertions
+
+```python
+from testkit.assertions import assert_missing_dependency_error
+
+
+assert_missing_dependency_error(
+    err,
+    backend="stub_missing_py",
+    count=1,
+    missing_names=("definitely_not_a_real_module_xyz",),
+    install_hints=("pip install nexus-fs[gcs]",),
+)
+```
+
+Prefer assertion helpers when they make failure output clearer than raw string
+checks in individual tests.
+
+## Migration Guidance
+
+When touching a suite that already imports from `tests.helpers`, leave unrelated
+imports alone. Move only helpers needed by the current change into `testkit` or
+switch to existing testkit exports. This keeps migrations small and reduces merge
+conflicts across the large test tree.
+```
+
+- [ ] **Step 3: Run documentation diff check**
+
+Run:
+
+```bash
+git diff --check -- docs/development/testkit.md
+```
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 4: Commit docs**
+
+Run:
+
+```bash
+git add docs/development/testkit.md
+git commit -m "docs: add nexus testkit guide"
+```
+
+Expected: commit succeeds.
+
+---
+
+### Task 6: Final Verification
+
+**Files:**
+- Verify all files changed by Tasks 1-5.
+
+- [ ] **Step 1: Run targeted testkit verification**
+
+Run:
+
+```bash
+pytest tests/unit/testkit -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run backend profile matrix consumer**
+
+Run:
+
+```bash
+pytest tests/unit/backends/test_profile_matrix.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run migrated backend dependency suite**
+
+Run:
+
+```bash
+pytest tests/integration/backends/test_factory_dep_check.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run combined target set**
+
+Run:
+
+```bash
+pytest tests/unit/testkit tests/unit/backends/test_profile_matrix.py tests/integration/backends/test_factory_dep_check.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Run whitespace and status checks**
+
+Run:
+
+```bash
+git diff --check
+git status --short --branch
+```
+
+Expected: `git diff --check` exits 0. `git status --short --branch` shows the current branch and no unstaged changes after all commits.
+
+---
+
+## Spec Coverage Checklist
+
+- `tests/testkit` package: Task 1 creates the package and Task 2/3 fill modules.
+- Fake/in-memory backend helpers: Task 3 adds `InMemoryBackend`, `FactoryStubBackend`, and helper re-exports.
+- Fake auth/profile providers: Task 2 adds auth builders; Task 1 adds profile cases.
+- Profile matrix used in backend suite: Task 1 creates `tests/unit/backends/test_profile_matrix.py`.
+- Container fixture helpers: Task 2 adds env/probe/skip helpers without optional client imports.
+- Assertion helpers: Task 3 adds dependency, event, metadata, and permission assertions.
+- Representative migration: Task 4 migrates `tests/integration/backends/test_factory_dep_check.py`.
+- Documentation: Task 5 adds `docs/development/testkit.md`.
+- Optional dependency import rule: Task 2 uses only stdlib socket/env parsing and pytest.

--- a/docs/superpowers/specs/2026-05-02-issue-3968-nexus-testkit-design.md
+++ b/docs/superpowers/specs/2026-05-02-issue-3968-nexus-testkit-design.md
@@ -1,0 +1,212 @@
+# Nexus Testkit Package Design (#3968)
+
+**Issue:** [#3968](https://github.com/nexi-lab/nexus/issues/3968) - test: create Nexus testkit for fake backends, bricks, and profile matrices
+**Date:** 2026-05-02
+**Status:** design approved in chat for an incremental first slice
+
+## Context
+
+The test tree already has useful reusable pieces, but they are scattered:
+
+- `tests/helpers/` contains in-memory filesystem, metastore, record-store, context, websocket, edge-case, and failure helpers.
+- Root and nested `conftest.py` files provide server, database, auth, and e2e fixtures.
+- Backend and connector suites define local fake implementations inline, such as the contract-test `_MockBackend` and factory-dependency `_StubBackend`.
+- Profile behavior is tested directly against `DeploymentProfile`, but there is no reusable matrix object for tests that need to run across embedded, lite, sandbox, full, cloud, remote, and cluster/federation-like cases.
+- Optional-service tests probe Postgres, Redis/Dragonfly, NATS, and server endpoints independently.
+
+The first testkit slice should create a stable home for common test doubles and matrices without moving the entire test tree at once.
+
+## Goals
+
+- Define `tests/testkit` as the reusable pytest-only package for Nexus tests.
+- Provide fake/in-memory backends, auth contexts, profile matrices, optional-service helpers, and common assertions.
+- Reuse or re-export existing helpers where they are already correct.
+- Migrate one representative backend or connector test suite to prove the new package API.
+- Document how new tests should use fake backends, profile matrices, and optional-service helpers.
+- Keep testkit imports lightweight: no production-only optional dependencies at module import time.
+
+## Non-Goals
+
+- Moving every helper from `tests/helpers` in this first branch.
+- Publishing `nexus.testing` or any installed production-facing testkit API.
+- Introducing `testcontainers` or Docker Python clients as required test dependencies.
+- Rewriting e2e service fixtures wholesale.
+- Changing production behavior outside of imports needed to support tests.
+
+## Decisions
+
+| Decision | Choice |
+|---|---|
+| Package location | `tests/testkit`, imported as `testkit` through existing pytest `pythonpath = ["tests"]` |
+| Migration strategy | Additive compatibility first; migrate one representative suite |
+| Existing helpers | Re-export stable helpers instead of duplicating them |
+| Optional services | Probe URLs/env lazily and skip with explicit reasons |
+| Profile matrix | Explicit case dataclasses plus pytest param helpers |
+| Container helpers | Config/probe helpers only, with no unconditional Docker or client imports |
+
+## Architecture
+
+`tests/testkit` is a pytest-only package with small modules grouped by testing concern.
+
+```
+tests/testkit/
+├── __init__.py
+├── backends.py
+├── auth.py
+├── profiles.py
+├── containers.py
+└── assertions.py
+```
+
+### `testkit.backends`
+
+Responsibilities:
+
+- Export a reusable in-memory backend implementing the common `Backend` contract methods used by unit and integration tests.
+- Export the existing `FailingBackend` wrapper from `tests.helpers.failing_backend`.
+- Export existing lightweight helpers such as `DictMetastore`, `InMemoryNexusFS`, and `InMemoryRecordStore` through stable names.
+- Provide a minimal connector/backend stub usable for factory and runtime-dependency tests.
+
+The in-memory backend should avoid optional cloud libraries. It may import core Nexus backend contracts because tests already depend on the local package under test.
+
+### `testkit.auth`
+
+Responsibilities:
+
+- Export `TEST_CONTEXT` and `TEST_ADMIN_CONTEXT` from `tests.helpers.test_context`.
+- Provide small builders for operation contexts with custom `user_id`, groups, admin state, and zone-like metadata when tests need variants.
+- Keep auth fixtures as pure data builders; do not import FastAPI auth routers or OAuth provider SDKs at module import time.
+
+### `testkit.profiles`
+
+Responsibilities:
+
+- Define `ProfileCase`, an explicit dataclass that describes a deployment profile test case.
+- Provide matrix constructors for:
+  - local lightweight profiles: `embedded`, `lite`, `sandbox`, `full`
+  - remote/client profile: `remote`
+  - server/cloud profile: `cloud`
+  - federation-capable profile: `cluster`
+- Provide helpers that convert cases into `pytest.param(...)` with stable IDs and skip marks when a profile requires optional external services.
+
+Shape:
+
+```python
+@dataclass(frozen=True)
+class ProfileCase:
+    profile: DeploymentProfile
+    id: str
+    expected_bricks: frozenset[str]
+    expected_drivers: frozenset[str]
+    external_services: tuple[str, ...] = ()
+    marks: tuple[pytest.MarkDecorator, ...] = ()
+
+    def param(self) -> pytest.ParameterSet:
+        return pytest.param(self, id=self.id, marks=list(self.marks))
+```
+
+Tests should be able to select a subset without understanding the full profile hierarchy:
+
+```python
+@pytest.mark.parametrize("case", local_profile_params())
+def test_enabled_bricks(case: ProfileCase) -> None:
+    assert case.expected_bricks == case.profile.default_bricks()
+```
+
+### `testkit.containers`
+
+Responsibilities:
+
+- Centralize optional-service probing and config construction for Postgres, Redis/Dragonfly, NATS, and server smoke tests.
+- Read URLs from existing environment conventions:
+  - Postgres: `NEXUS_DATABASE_URL`, `POSTGRES_URL`, `DATABASE_URL`
+  - Redis/Dragonfly: `NEXUS_DRAGONFLY_URL`, `REDIS_URL`, `NEXUS_DRAGONFLY_COORDINATION_URL`
+  - NATS: `NEXUS_NATS_URL`
+- Provide skip helpers with clear reasons.
+- Provide simple network port probes and env-derived config dictionaries.
+
+This module must not import `psycopg2`, `asyncpg`, `redis`, `nats`, `docker`, or `testcontainers` at import time. Tests that need a real client import the client inside the test or fixture after the helper says the service is available.
+
+### `testkit.assertions`
+
+Responsibilities:
+
+- Provide high-signal assertions for common patterns:
+  - missing dependency errors include backend name, missing item names, and install hints
+  - event payloads include expected path, event type, and zone fields
+  - metadata dictionaries include expected keys and values without requiring exact equality
+  - permission decisions match expected allow/deny state
+- Keep assertions generic and dependency-light.
+
+## Data Flow
+
+1. A test imports a focused testkit helper, for example `from testkit.profiles import local_profile_params`.
+2. The helper returns plain Python objects or pytest parameter sets.
+3. The test passes those objects into production code or existing pytest fixtures.
+4. Optional-service helpers check environment variables and network reachability before the test imports optional client packages or starts service-specific setup.
+5. Compatibility re-exports keep existing helpers available while new tests move to the clearer `testkit` namespace.
+
+## Error Handling
+
+- Optional-service helpers return or raise pytest skips with explicit service names and required environment variables.
+- Missing dependency assertion helpers should compare structured fields on `MissingDependencyError` where available, then check the message for install hints.
+- Profile matrices should fail fast if a case's expected bricks or drivers drift from `DeploymentProfile.default_bricks()` or `.default_drivers()` in the testkit's own tests.
+- Testkit modules should avoid broad side effects at import time. Environment reads are allowed only in helper functions.
+
+## Migration Plan
+
+The first implementation migrates one representative suite, preferably `tests/integration/backends/test_factory_dep_check.py`, because it already has a local connector stub and dependency assertions that belong in the testkit. The migrated suite should:
+
+- Import the reusable stub backend from `testkit.backends`.
+- Import a dependency assertion helper from `testkit.assertions`.
+- Use the new testkit API without changing the tested production behavior.
+
+The first implementation should also add a backend-suite consumer for the profile matrix at `tests/unit/backends/test_profile_matrix.py`. That test should import `testkit.profiles` and assert each `ProfileCase` mirrors `DeploymentProfile.default_drivers()` and `default_bricks()`. Keeping this under `tests/unit/backends` satisfies the connector/backend-suite acceptance criterion without forcing unrelated connector tests to grow profile concerns.
+
+Existing `tests/helpers` modules remain in place. Follow-up migrations can move backend contract fakes, event-bus helpers, server smoke helpers, and duplicated auth fixtures in smaller branches.
+
+## Documentation
+
+Add `docs/development/testkit.md` with:
+
+- Purpose and package boundary.
+- Fake backend example.
+- Auth context example.
+- Profile matrix example.
+- Optional-service probe and skip example.
+- Migration guidance from `tests/helpers` to `testkit`.
+- Rule that testkit modules must not import optional production dependencies at module import time.
+
+## Testing Strategy
+
+Add focused tests for the testkit itself:
+
+- `tests/unit/testkit/test_profiles.py` verifies matrix cases mirror `DeploymentProfile` defaults and produce stable pytest IDs.
+- `tests/unit/testkit/test_containers.py` verifies env-derived URLs, probe result shapes, and skip reasons using monkeypatching.
+- `tests/unit/testkit/test_assertions.py` verifies dependency assertion helpers catch wrong backend names, missing item names, and install hints.
+- `tests/unit/backends/test_profile_matrix.py` verifies a backend-suite consumer can use the profile matrix.
+- The migrated backend/connector dependency suite proves real consumers can use backend fakes and assertions from the package.
+
+Targeted verification commands:
+
+```bash
+pytest tests/unit/testkit -q
+pytest tests/unit/backends/test_profile_matrix.py -q
+pytest tests/integration/backends/test_factory_dep_check.py -q
+```
+
+## Acceptance Criteria Mapping
+
+| Acceptance criterion | Design coverage |
+|---|---|
+| Define `tests/testkit` or package equivalent | Create `tests/testkit` package |
+| Migrate existing helper implementations into testkit without breaking current tests | Re-export existing helpers and migrate one representative suite |
+| Add profile matrix helper and use it in at least one connector/backend test suite | Provide `testkit.profiles`; use it in `tests/unit/backends/test_profile_matrix.py` |
+| Add docs for fake backends/profile matrices | Add `docs/development/testkit.md` |
+| Avoid production-only optional deps unless requested | Lazy optional-service imports and module-level dependency rule |
+
+## Risks
+
+- A broad migration would produce noisy diffs and merge conflicts. The first slice intentionally avoids that.
+- Re-exporting helpers from `tests.helpers` can preserve legacy names longer than ideal. This is acceptable because follow-up migrations can retire compatibility exports once callers move.
+- Profile expectations can drift when `DeploymentProfile` changes. Testkit tests should assert each case mirrors production defaults so drift is caught quickly.

--- a/tests/integration/backends/test_factory_dep_check.py
+++ b/tests/integration/backends/test_factory_dep_check.py
@@ -1,6 +1,6 @@
 """Integration test: BackendFactory.create() raises MissingDependencyError.
 
-Covers Issue #3830 — typed runtime-dep check at mount time.
+Covers Issue #3830 - typed runtime-dep check at mount time.
 """
 
 from __future__ import annotations
@@ -8,6 +8,8 @@ from __future__ import annotations
 from typing import Any
 
 import pytest
+from testkit.assertions import assert_missing_dependency_error
+from testkit.backends import FactoryStubBackend
 
 from nexus.backends.base.factory import BackendFactory
 from nexus.backends.base.registry import ConnectorRegistry, register_connector
@@ -15,31 +17,9 @@ from nexus.backends.base.runtime_deps import BinaryDep, PythonDep
 from nexus.contracts.exceptions import MissingDependencyError
 
 
-class _StubBackend:
-    """Minimal ConnectorProtocol-compliant stub."""
-
-    name = "stub"
-    write_content = read_content = delete_content = content_exists = None
-    get_content_size = mkdir = rmdir = is_directory = None
-    user_scoped = False
-    is_connected = True
-    has_root_path = False
-    has_token_manager = False
-    backend_features: frozenset = frozenset()
-
-    def check_connection(self) -> None:
-        return None
-
-    def has_feature(self, f: Any) -> bool:
-        return False
-
-    def __init__(self, **kwargs: Any) -> None:
-        pass
-
-
 @pytest.fixture(autouse=True)
 def _clean_registry() -> Any:
-    # Snapshot + restore so we don't affect other tests in the integration run.
+    # Snapshot + restore so we do not affect other tests in the integration run.
     names_before = set(ConnectorRegistry.list_available())
     yield
     for nm in set(ConnectorRegistry.list_available()) - names_before:
@@ -50,16 +30,16 @@ class TestFactoryDepCheck:
     def test_satisfied_deps_allow_instantiation(self) -> None:
         @register_connector(
             "stub_ok",
-            runtime_deps=(PythonDep("json"),),  # stdlib — always present
+            runtime_deps=(PythonDep("json"),),  # stdlib - always present
         )
-        class _OK(_StubBackend):
+        class _OK(FactoryStubBackend):
             pass
 
         instance = BackendFactory.create("stub_ok", {})
         assert isinstance(instance, _OK)
 
     def test_missing_python_dep_raises(self, monkeypatch: pytest.MonkeyPatch) -> None:
-        # Force slim-install hint formatting — otherwise the raw module
+        # Force slim-install hint formatting. Otherwise the raw module
         # name is emitted under the monorepo's full distribution.
         monkeypatch.setattr(
             "nexus.backends.base.runtime_deps._nexus_fs_extras_available",
@@ -70,27 +50,38 @@ class TestFactoryDepCheck:
             "stub_missing_py",
             runtime_deps=(PythonDep("definitely_not_a_real_module_xyz", extras=("gcs",)),),
         )
-        class _M(_StubBackend):
+        class _M(FactoryStubBackend):
             pass
 
         with pytest.raises(MissingDependencyError) as exc_info:
             BackendFactory.create("stub_missing_py", {})
-        err = exc_info.value
-        assert err.backend == "stub_missing_py"
-        assert len(err.missing) == 1
-        assert "pip install nexus-fs[gcs]" in str(err)
+
+        assert_missing_dependency_error(
+            exc_info.value,
+            backend="stub_missing_py",
+            count=1,
+            missing_names=("definitely_not_a_real_module_xyz",),
+            install_hints=("pip install nexus-fs[gcs]",),
+        )
 
     def test_missing_binary_dep_raises(self) -> None:
         @register_connector(
             "stub_missing_bin",
             runtime_deps=(BinaryDep("definitely_not_a_real_binary_xyz", "brew install xyz"),),
         )
-        class _M(_StubBackend):
+        class _M(FactoryStubBackend):
             pass
 
         with pytest.raises(MissingDependencyError) as exc_info:
             BackendFactory.create("stub_missing_bin", {})
-        assert "brew install xyz" in str(exc_info.value)
+
+        assert_missing_dependency_error(
+            exc_info.value,
+            backend="stub_missing_bin",
+            count=1,
+            missing_names=("definitely_not_a_real_binary_xyz",),
+            install_hints=("brew install xyz",),
+        )
 
     def test_all_missing_enumerated_together(self) -> None:
         @register_connector(
@@ -100,13 +91,18 @@ class TestFactoryDepCheck:
                 BinaryDep("definitely_not_a_real_binary_xyz", "brew install xyz"),
             ),
         )
-        class _M(_StubBackend):
+        class _M(FactoryStubBackend):
             pass
 
         with pytest.raises(MissingDependencyError) as exc_info:
             BackendFactory.create("stub_many_missing", {})
-        err = exc_info.value
-        assert len(err.missing) == 2
-        msg = str(err)
-        assert "definitely_not_a_real_module_xyz" in msg
-        assert "definitely_not_a_real_binary_xyz" in msg
+
+        assert_missing_dependency_error(
+            exc_info.value,
+            backend="stub_many_missing",
+            count=2,
+            missing_names=(
+                "definitely_not_a_real_module_xyz",
+                "definitely_not_a_real_binary_xyz",
+            ),
+        )

--- a/tests/testkit/__init__.py
+++ b/tests/testkit/__init__.py
@@ -1,0 +1,1 @@
+"""Reusable pytest-only helpers for Nexus tests."""

--- a/tests/testkit/assertions.py
+++ b/tests/testkit/assertions.py
@@ -14,11 +14,19 @@ __all__ = [
     "assert_permission_decision",
 ]
 
+_MISSING = object()
+
 
 def _value(obj: Any, key: str, default: Any = None) -> Any:
     if isinstance(obj, Mapping):
         return obj.get(key, default)
     return getattr(obj, key, default)
+
+
+def _metadata_value(obj: Any, key: str) -> Any:
+    if isinstance(obj, Mapping):
+        return obj.get(key, _MISSING)
+    return getattr(obj, key, _MISSING)
 
 
 def assert_missing_dependency_error(
@@ -69,9 +77,9 @@ def assert_metadata_contains(metadata: Any, expected: Mapping[str, Any]) -> None
     """Assert that metadata contains an expected subset."""
 
     for key, value in expected.items():
-        assert _value(metadata, key) == value, (
-            f"expected metadata {key!r} to be {value!r}, got {_value(metadata, key)!r}"
-        )
+        actual = _metadata_value(metadata, key)
+        assert actual is not _MISSING, f"expected metadata to contain missing key {key!r}"
+        assert actual == value, f"expected metadata {key!r} to be {value!r}, got {actual!r}"
 
 
 def assert_permission_decision(decision: Any, *, allowed: bool) -> None:

--- a/tests/testkit/assertions.py
+++ b/tests/testkit/assertions.py
@@ -1,0 +1,81 @@
+"""Assertion helpers for Nexus tests."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from nexus.contracts.exceptions import MissingDependencyError
+
+__all__ = [
+    "assert_event_payload",
+    "assert_metadata_contains",
+    "assert_missing_dependency_error",
+    "assert_permission_decision",
+]
+
+
+def _value(obj: Any, key: str, default: Any = None) -> Any:
+    if isinstance(obj, Mapping):
+        return obj.get(key, default)
+    return getattr(obj, key, default)
+
+
+def assert_missing_dependency_error(
+    error: MissingDependencyError,
+    *,
+    backend: str | None = None,
+    count: int | None = None,
+    missing_names: tuple[str, ...] = (),
+    install_hints: tuple[str, ...] = (),
+) -> None:
+    """Assert stable details on a `MissingDependencyError`."""
+
+    if backend is not None:
+        assert error.backend == backend, f"expected backend {backend!r}, got {error.backend!r}"
+    if count is not None:
+        assert len(error.missing) == count, (
+            f"expected {count} missing deps, got {len(error.missing)}"
+        )
+
+    reasons = [reason for _, reason in error.missing]
+    rendered = "\n".join(reasons)
+    names = {getattr(dep, "module", None) or getattr(dep, "name", None) for dep, _ in error.missing}
+
+    for name in missing_names:
+        assert name in names, f"expected missing dependency {name!r} in {names!r}"
+    for hint in install_hints:
+        assert hint in rendered, f"expected install hint {hint!r} in {rendered!r}"
+
+
+def assert_event_payload(
+    event: Any,
+    *,
+    event_type: str,
+    path: str | None = None,
+    zone_id: str | None = None,
+) -> None:
+    """Assert common event payload fields on dicts or objects."""
+
+    actual_type = _value(event, "event_type", _value(event, "type"))
+    assert actual_type == event_type, f"expected event type {event_type!r}, got {actual_type!r}"
+    if path is not None:
+        assert _value(event, "path") == path
+    if zone_id is not None:
+        assert _value(event, "zone_id") == zone_id
+
+
+def assert_metadata_contains(metadata: Any, expected: Mapping[str, Any]) -> None:
+    """Assert that metadata contains an expected subset."""
+
+    for key, value in expected.items():
+        assert _value(metadata, key) == value, (
+            f"expected metadata {key!r} to be {value!r}, got {_value(metadata, key)!r}"
+        )
+
+
+def assert_permission_decision(decision: Any, *, allowed: bool) -> None:
+    """Assert a permission decision bool or object has the expected state."""
+
+    actual = decision if isinstance(decision, bool) else _value(decision, "allowed")
+    assert actual is allowed, f"permission decision expected allowed={allowed!r}, got {actual!r}"

--- a/tests/testkit/auth.py
+++ b/tests/testkit/auth.py
@@ -29,12 +29,6 @@ def make_context(
 ) -> OperationContext:
     """Build an `OperationContext` with explicit identity fields."""
 
-    if zone_id is not None:
-        if not zone_set:
-            zone_set = (zone_id,)
-        if not zone_perms:
-            zone_perms = ((zone_id, "rw"),)
-
     return OperationContext(
         user_id=user_id,
         groups=list(groups or []),

--- a/tests/testkit/auth.py
+++ b/tests/testkit/auth.py
@@ -1,0 +1,85 @@
+"""Auth and identity fixtures for Nexus tests."""
+
+from __future__ import annotations
+
+from nexus.contracts.types import OperationContext
+from tests.helpers.test_context import TEST_ADMIN_CONTEXT, TEST_CONTEXT
+
+__all__ = [
+    "TEST_ADMIN_CONTEXT",
+    "TEST_CONTEXT",
+    "make_admin_context",
+    "make_context",
+    "make_zone_context",
+]
+
+
+def make_context(
+    *,
+    user_id: str = "test",
+    groups: list[str] | None = None,
+    zone_id: str | None = None,
+    zone_set: tuple[str, ...] = (),
+    zone_perms: tuple[tuple[str, str], ...] = (),
+    agent_id: str | None = None,
+    subject_type: str = "user",
+    subject_id: str | None = None,
+    is_admin: bool = False,
+    is_system: bool = False,
+) -> OperationContext:
+    """Build an `OperationContext` with explicit identity fields."""
+
+    if zone_id is not None:
+        if not zone_set:
+            zone_set = (zone_id,)
+        if not zone_perms:
+            zone_perms = ((zone_id, "rw"),)
+
+    return OperationContext(
+        user_id=user_id,
+        groups=list(groups or []),
+        zone_id=zone_id,
+        zone_set=zone_set,
+        zone_perms=zone_perms,
+        agent_id=agent_id,
+        subject_type=subject_type,
+        subject_id=subject_id,
+        is_admin=is_admin,
+        is_system=is_system,
+    )
+
+
+def make_admin_context(
+    *,
+    user_id: str = "test-admin",
+    groups: list[str] | None = None,
+    zone_id: str | None = None,
+) -> OperationContext:
+    """Build an admin `OperationContext` for tests."""
+
+    return make_context(
+        user_id=user_id,
+        groups=groups,
+        zone_id=zone_id,
+        is_admin=True,
+    )
+
+
+def make_zone_context(
+    zone_id: str,
+    *,
+    user_id: str = "test",
+    groups: list[str] | None = None,
+    perms: str = "rw",
+    is_admin: bool = False,
+) -> OperationContext:
+    """Build a context scoped to one zone with the provided permission string."""
+
+    return make_context(
+        user_id=user_id,
+        groups=groups,
+        zone_id=zone_id,
+        zone_set=(zone_id,),
+        zone_perms=((zone_id, perms),),
+        is_admin=is_admin,
+    )

--- a/tests/testkit/backends.py
+++ b/tests/testkit/backends.py
@@ -53,9 +53,15 @@ class InMemoryBackend(Backend):
         offset: int = 0,
         context: "OperationContext | None" = None,
     ) -> WriteResult:
-        if offset:
-            existing = self.read_content(content_id, context=context)
-            content = existing[:offset] + content
+        if offset < 0:
+            raise BackendError("Offset must be non-negative", backend=self.name)
+        if offset > 0:
+            if not content_id:
+                raise BackendError("Offset writes require content_id", backend=self.name)
+            existing = self._content.get(content_id, b"")
+            if offset > len(existing):
+                existing = existing + b"\x00" * (offset - len(existing))
+            content = existing[:offset] + content + existing[offset + len(content) :]
         key = content_id or hashlib.sha256(content).hexdigest()
         self._content[key] = bytes(content)
         return WriteResult(content_id=key, version=key, size=len(content))
@@ -104,7 +110,7 @@ class InMemoryBackend(Backend):
         if directory in self._dirs:
             if exist_ok:
                 return
-            return
+            raise BackendError(f"Directory already exists: {directory}", backend=self.name)
 
         if parents:
             current = ""

--- a/tests/testkit/backends.py
+++ b/tests/testkit/backends.py
@@ -1,0 +1,173 @@
+"""Backend fakes and compatibility re-exports for Nexus tests."""
+
+from __future__ import annotations
+
+import hashlib
+from typing import TYPE_CHECKING, Any
+
+from nexus.backends.base.backend import Backend
+from nexus.contracts.exceptions import NexusFileNotFoundError
+from nexus.core.object_store import WriteResult
+from tests.helpers.dict_metastore import DictMetastore
+from tests.helpers.failing_backend import FailingBackend
+from tests.helpers.in_memory_record_store import InMemoryRecordStore
+from tests.helpers.inmemory_nexus_fs import InMemoryNexusFS
+
+if TYPE_CHECKING:
+    from nexus.contracts.types import OperationContext
+
+__all__ = [
+    "DictMetastore",
+    "FactoryStubBackend",
+    "FailingBackend",
+    "InMemoryBackend",
+    "InMemoryNexusFS",
+    "InMemoryRecordStore",
+]
+
+
+def _normalize_dir(path: str) -> str:
+    """Normalize a directory path to an absolute path without trailing slash."""
+
+    if not path or path == "/":
+        return "/"
+    return "/" + path.strip("/")
+
+
+class InMemoryBackend(Backend):
+    """Minimal in-memory backend for unit tests."""
+
+    def __init__(self) -> None:
+        self._content: dict[str, bytes] = {}
+        self._dirs: set[str] = {"/"}
+
+    @property
+    def name(self) -> str:
+        return "memory"
+
+    def write_content(
+        self,
+        content: bytes,
+        content_id: str = "",
+        *,
+        offset: int = 0,
+        context: "OperationContext | None" = None,
+    ) -> WriteResult:
+        if offset:
+            existing = self.read_content(content_id, context=context)
+            content = existing[:offset] + content
+        key = content_id or hashlib.sha256(content).hexdigest()
+        self._content[key] = bytes(content)
+        return WriteResult(content_id=key, version=key, size=len(content))
+
+    def read_content(
+        self,
+        content_id: str,
+        context: "OperationContext | None" = None,
+    ) -> bytes:
+        try:
+            return self._content[content_id]
+        except KeyError as exc:
+            raise NexusFileNotFoundError(content_id, "Content not found") from exc
+
+    def delete_content(
+        self,
+        content_id: str,
+        context: "OperationContext | None" = None,
+    ) -> None:
+        if content_id not in self._content:
+            raise NexusFileNotFoundError(content_id, "Content not found")
+        del self._content[content_id]
+
+    def content_exists(
+        self,
+        content_id: str,
+        context: "OperationContext | None" = None,
+    ) -> bool:
+        return content_id in self._content
+
+    def get_content_size(
+        self,
+        content_id: str,
+        context: "OperationContext | None" = None,
+    ) -> int:
+        return len(self.read_content(content_id, context=context))
+
+    def mkdir(
+        self,
+        path: str,
+        parents: bool = False,
+        exist_ok: bool = False,
+        context: "OperationContext | None" = None,
+    ) -> None:
+        directory = _normalize_dir(path)
+        if directory in self._dirs:
+            if exist_ok:
+                return
+            return
+
+        if parents:
+            current = ""
+            for part in directory.strip("/").split("/"):
+                current = f"{current}/{part}"
+                self._dirs.add(current)
+            return
+
+        parent = _normalize_dir(directory.rsplit("/", 1)[0] or "/")
+        if parent not in self._dirs:
+            raise NexusFileNotFoundError(parent, "Directory not found")
+        self._dirs.add(directory)
+
+    def rmdir(
+        self,
+        path: str,
+        recursive: bool = False,
+        context: "OperationContext | None" = None,
+    ) -> None:
+        directory = _normalize_dir(path)
+        if directory not in self._dirs:
+            raise NexusFileNotFoundError(directory, "Directory not found")
+        if directory == "/":
+            return
+        if recursive:
+            prefix = f"{directory}/"
+            self._dirs = {
+                item for item in self._dirs if item != directory and not item.startswith(prefix)
+            }
+            return
+        self._dirs.remove(directory)
+
+    def is_directory(
+        self,
+        path: str,
+        context: "OperationContext | None" = None,
+    ) -> bool:
+        return _normalize_dir(path) in self._dirs
+
+    def list_dir(
+        self,
+        path: str,
+        context: "OperationContext | None" = None,
+    ) -> list[str]:
+        directory = _normalize_dir(path)
+        if directory not in self._dirs:
+            raise NexusFileNotFoundError(directory, "Directory not found")
+        prefix = "/" if directory == "/" else f"{directory}/"
+        names = {
+            candidate[len(prefix) :].split("/", 1)[0]
+            for candidate in self._dirs
+            if candidate != directory and candidate.startswith(prefix)
+        }
+        return sorted(names)
+
+
+class FactoryStubBackend(InMemoryBackend):
+    """Backend test double that records arbitrary factory kwargs."""
+
+    def __init__(self, **kwargs: Any) -> None:
+        super().__init__()
+        self.kwargs = kwargs
+
+    @property
+    def name(self) -> str:
+        return "stub"

--- a/tests/testkit/backends.py
+++ b/tests/testkit/backends.py
@@ -6,7 +6,7 @@ import hashlib
 from typing import TYPE_CHECKING, Any
 
 from nexus.backends.base.backend import Backend
-from nexus.contracts.exceptions import NexusFileNotFoundError
+from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 from nexus.core.object_store import WriteResult
 from tests.helpers.dict_metastore import DictMetastore
 from tests.helpers.failing_backend import FailingBackend
@@ -129,12 +129,14 @@ class InMemoryBackend(Backend):
             raise NexusFileNotFoundError(directory, "Directory not found")
         if directory == "/":
             return
+        prefix = f"{directory}/"
         if recursive:
-            prefix = f"{directory}/"
             self._dirs = {
                 item for item in self._dirs if item != directory and not item.startswith(prefix)
             }
             return
+        if any(item.startswith(prefix) for item in self._dirs):
+            raise BackendError(f"Directory not empty: {directory}", backend=self.name)
         self._dirs.remove(directory)
 
     def is_directory(
@@ -153,12 +155,12 @@ class InMemoryBackend(Backend):
         if directory not in self._dirs:
             raise NexusFileNotFoundError(directory, "Directory not found")
         prefix = "/" if directory == "/" else f"{directory}/"
-        names = {
-            candidate[len(prefix) :].split("/", 1)[0]
+        entries = {
+            f"{candidate[len(prefix) :].split('/', 1)[0]}/"
             for candidate in self._dirs
             if candidate != directory and candidate.startswith(prefix)
         }
-        return sorted(names)
+        return sorted(entries)
 
 
 class FactoryStubBackend(InMemoryBackend):

--- a/tests/testkit/bricks.py
+++ b/tests/testkit/bricks.py
@@ -1,0 +1,212 @@
+"""Fake bricks and lifecycle probes for Nexus tests."""
+
+from __future__ import annotations
+
+from collections.abc import Mapping, Sequence
+from dataclasses import dataclass
+from inspect import isawaitable
+from typing import Any
+
+__all__ = [
+    "FakeLifecycleBrick",
+    "FakeSearchBrick",
+    "ServiceLifecycleProbe",
+    "probe_service_lifecycle",
+]
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceLifecycleProbe:
+    """Result from exercising a service or brick lifecycle."""
+
+    name: str
+    started_after_start: bool | None
+    healthy_after_start: bool | None
+    started_after_stop: bool | None
+    healthy_after_stop: bool | None
+    events: tuple[str, ...] = ()
+
+
+async def _maybe_await(value: Any) -> Any:
+    if isawaitable(value):
+        return await value
+    return value
+
+
+async def _call_first(service: Any, names: tuple[str, ...]) -> str:
+    for name in names:
+        method = getattr(service, name, None)
+        if callable(method):
+            await _maybe_await(method())
+            return name
+    raise AttributeError(f"{type(service).__name__} has none of: {', '.join(names)}")
+
+
+def _started_state(service: Any) -> bool | None:
+    for name in ("started", "is_initialized", "is_running"):
+        value = getattr(service, name, None)
+        if value is not None and not callable(value):
+            return bool(value)
+    return None
+
+
+def _coerce_health(value: Any) -> bool:
+    if isinstance(value, Mapping):
+        if "healthy" in value:
+            return bool(value["healthy"])
+        status = str(value.get("status", "")).lower()
+        if status:
+            return status in {"healthy", "ok", "ready", "running"}
+        if "initialized" in value:
+            return bool(value["initialized"])
+    return bool(value)
+
+
+async def _health_state(service: Any) -> bool | None:
+    for name in ("health_check", "get_health"):
+        method = getattr(service, name, None)
+        if callable(method):
+            return _coerce_health(await _maybe_await(method()))
+    return None
+
+
+def _event_log(service: Any) -> tuple[str, ...]:
+    events = getattr(service, "events", ())
+    return tuple(events)
+
+
+async def probe_service_lifecycle(
+    service: Any, *, name: str | None = None
+) -> ServiceLifecycleProbe:
+    """Start, health-check, and stop a service/brick with common lifecycle names."""
+
+    await _call_first(service, ("start", "startup", "initialize"))
+    started_after_start = _started_state(service)
+    healthy_after_start = await _health_state(service)
+
+    await _call_first(service, ("stop", "shutdown", "close"))
+    started_after_stop = _started_state(service)
+    healthy_after_stop = await _health_state(service)
+
+    return ServiceLifecycleProbe(
+        name=name or getattr(service, "name", type(service).__name__),
+        started_after_start=started_after_start,
+        healthy_after_start=healthy_after_start,
+        started_after_stop=started_after_stop,
+        healthy_after_stop=healthy_after_stop,
+        events=_event_log(service),
+    )
+
+
+class FakeLifecycleBrick:
+    """Small async lifecycle fake for brick and background-service tests."""
+
+    def __init__(self, *, name: str = "fake", healthy: bool = True) -> None:
+        self.name = name
+        self.healthy = healthy
+        self.started = False
+        self.start_calls = 0
+        self.stop_calls = 0
+        self._events: list[str] = []
+
+    @property
+    def events(self) -> tuple[str, ...]:
+        return tuple(self._events)
+
+    @property
+    def is_initialized(self) -> bool:
+        return self.started
+
+    async def start(self) -> None:
+        self.start_calls += 1
+        if self.started:
+            return
+        self.started = True
+        self._events.append("start")
+
+    async def stop(self) -> None:
+        self.stop_calls += 1
+        if not self.started:
+            return
+        self.started = False
+        self._events.append("stop")
+
+    async def startup(self) -> None:
+        await self.start()
+
+    async def shutdown(self) -> None:
+        await self.stop()
+
+    async def initialize(self) -> None:
+        await self.start()
+
+    async def close(self) -> None:
+        await self.stop()
+
+    async def health_check(self) -> bool:
+        return self.started and self.healthy
+
+
+class FakeSearchBrick(FakeLifecycleBrick):
+    """Search brick fake that satisfies `SearchBrickProtocol` structurally."""
+
+    def __init__(
+        self,
+        *,
+        results: Sequence[Any] = (),
+        name: str = "search",
+        healthy: bool = True,
+    ) -> None:
+        super().__init__(name=name, healthy=healthy)
+        self._results = tuple(results)
+        self._queries: list[dict[str, Any]] = []
+        self._notifications: list[tuple[str, str]] = []
+
+    @property
+    def queries(self) -> tuple[dict[str, Any], ...]:
+        return tuple(self._queries)
+
+    @property
+    def notifications(self) -> tuple[tuple[str, str], ...]:
+        return tuple(self._notifications)
+
+    async def search(
+        self,
+        query: str,
+        search_type: str = "hybrid",
+        limit: int = 10,
+        path_filter: str | None = None,
+        alpha: float = 0.5,
+        fusion_method: str = "rrf",
+        adaptive_k: bool = False,
+        zone_id: str | None = None,
+    ) -> list[Any]:
+        self._queries.append(
+            {
+                "query": query,
+                "search_type": search_type,
+                "limit": limit,
+                "path_filter": path_filter,
+                "alpha": alpha,
+                "fusion_method": fusion_method,
+                "adaptive_k": adaptive_k,
+                "zone_id": zone_id,
+            }
+        )
+        return list(self._results[:limit])
+
+    def get_stats(self) -> dict[str, Any]:
+        return {
+            "queries": len(self._queries),
+            "notifications": len(self._notifications),
+            "started": self.started,
+        }
+
+    def get_health(self) -> dict[str, Any]:
+        return {
+            "status": "healthy" if self.started and self.healthy else "unhealthy",
+            "initialized": self.is_initialized,
+        }
+
+    async def notify_file_change(self, path: str, change_type: str = "update") -> None:
+        self._notifications.append((path, change_type))

--- a/tests/testkit/bricks.py
+++ b/tests/testkit/bricks.py
@@ -81,10 +81,12 @@ async def probe_service_lifecycle(
     """Start, health-check, and stop a service/brick with common lifecycle names."""
 
     await _call_first(service, ("start", "startup", "initialize"))
-    started_after_start = _started_state(service)
-    healthy_after_start = await _health_state(service)
+    try:
+        started_after_start = _started_state(service)
+        healthy_after_start = await _health_state(service)
+    finally:
+        await _call_first(service, ("stop", "shutdown", "close"))
 
-    await _call_first(service, ("stop", "shutdown", "close"))
     started_after_stop = _started_state(service)
     healthy_after_stop = await _health_state(service)
 

--- a/tests/testkit/containers.py
+++ b/tests/testkit/containers.py
@@ -1,0 +1,165 @@
+"""Optional-service probes and smoke-test config helpers."""
+
+from __future__ import annotations
+
+import os
+import socket
+from dataclasses import dataclass
+from urllib.parse import urlparse
+
+import pytest
+
+POSTGRES_ENV_VARS: tuple[str, ...] = (
+    "NEXUS_DATABASE_URL",
+    "POSTGRES_URL",
+    "DATABASE_URL",
+)
+
+REDIS_ENV_VARS: tuple[str, ...] = (
+    "NEXUS_DRAGONFLY_URL",
+    "REDIS_URL",
+    "NEXUS_DRAGONFLY_COORDINATION_URL",
+)
+
+NATS_ENV_VARS: tuple[str, ...] = ("NEXUS_NATS_URL",)
+
+
+@dataclass(frozen=True, slots=True)
+class ServiceProbe:
+    """Result of checking whether an optional service is reachable."""
+
+    name: str
+    url: str | None
+    host: str | None
+    port: int | None
+    available: bool
+    reason: str
+
+
+def get_env_url(names: tuple[str, ...]) -> str | None:
+    """Return the first non-empty URL from the provided environment names."""
+
+    for name in names:
+        value = os.environ.get(name)
+        if value:
+            return value
+    return None
+
+
+def postgres_url() -> str | None:
+    """Return the configured Postgres URL, if present."""
+
+    return get_env_url(POSTGRES_ENV_VARS)
+
+
+def redis_url() -> str | None:
+    """Return the configured Redis or Dragonfly URL, if present."""
+
+    return get_env_url(REDIS_ENV_VARS)
+
+
+def nats_url(default: str = "nats://localhost:4222") -> str:
+    """Return the configured NATS URL, defaulting to localhost."""
+
+    return get_env_url(NATS_ENV_VARS) or default
+
+
+def parse_host_port(url: str, default_port: int) -> tuple[str, int]:
+    """Extract host and port from a service URL or `host:port` string."""
+
+    raw = url if "://" in url else f"//{url}"
+    parsed = urlparse(raw)
+    if parsed.hostname is None:
+        raise ValueError(f"service URL has no host: {url!r}")
+    return parsed.hostname, parsed.port or default_port
+
+
+def _missing_probe(name: str, env_names: tuple[str, ...]) -> ServiceProbe:
+    return ServiceProbe(
+        name=name,
+        url=None,
+        host=None,
+        port=None,
+        available=False,
+        reason=f"set one of {', '.join(env_names)}",
+    )
+
+
+def probe_tcp_service(
+    name: str,
+    url: str,
+    default_port: int,
+    *,
+    timeout: float = 0.25,
+) -> ServiceProbe:
+    """Probe a TCP service without importing the service's Python client."""
+
+    host, port = parse_host_port(url, default_port)
+    try:
+        conn = socket.create_connection((host, port), timeout=timeout)
+        conn.close()
+    except OSError as exc:
+        return ServiceProbe(
+            name=name,
+            url=url,
+            host=host,
+            port=port,
+            available=False,
+            reason=f"{name} unavailable at {host}:{port}: {exc}",
+        )
+    return ServiceProbe(
+        name=name,
+        url=url,
+        host=host,
+        port=port,
+        available=True,
+        reason="available",
+    )
+
+
+def postgres_probe(*, timeout: float = 0.25) -> ServiceProbe:
+    """Probe configured Postgres, or return an unavailable probe when unset."""
+
+    url = postgres_url()
+    if url is None:
+        return _missing_probe("postgres", POSTGRES_ENV_VARS)
+    return probe_tcp_service("postgres", url, 5432, timeout=timeout)
+
+
+def redis_probe(*, timeout: float = 0.25) -> ServiceProbe:
+    """Probe configured Redis or Dragonfly, or return unavailable when unset."""
+
+    url = redis_url()
+    if url is None:
+        return _missing_probe("redis", REDIS_ENV_VARS)
+    return probe_tcp_service("redis", url, 6379, timeout=timeout)
+
+
+def nats_probe(*, timeout: float = 0.25) -> ServiceProbe:
+    """Probe configured NATS, defaulting to localhost."""
+
+    return probe_tcp_service("nats", nats_url(), 4222, timeout=timeout)
+
+
+def require_service(probe: ServiceProbe) -> ServiceProbe:
+    """Skip the current pytest test when the probe is unavailable."""
+
+    if not probe.available:
+        pytest.skip(probe.reason)
+    return probe
+
+
+def server_smoke_config(
+    *,
+    host: str = "127.0.0.1",
+    port: int,
+    api_key: str = "test-api-key",
+) -> dict[str, object]:
+    """Build a small server-smoke config dictionary."""
+
+    return {
+        "host": host,
+        "port": port,
+        "base_url": f"http://{host}:{port}",
+        "api_key": api_key,
+    }

--- a/tests/testkit/profiles.py
+++ b/tests/testkit/profiles.py
@@ -1,0 +1,127 @@
+"""Deployment profile matrices for Nexus tests."""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+import pytest
+
+from nexus.contracts.deployment_profile import DeploymentProfile
+
+
+@dataclass(frozen=True, slots=True)
+class ProfileCase:
+    """Explicit deployment-profile case for parametrized tests."""
+
+    profile: DeploymentProfile
+    id: str
+    expected_bricks: frozenset[str]
+    expected_drivers: frozenset[str]
+    external_services: tuple[str, ...] = ()
+    marks: tuple[pytest.MarkDecorator, ...] = ()
+
+    def param(self, *, skip_external: bool = False) -> object:
+        marks = list(self.marks)
+        if skip_external and self.external_services:
+            services = ", ".join(self.external_services)
+            marks.append(
+                pytest.mark.skip(
+                    reason=f"profile {self.id} requires optional service(s): {services}"
+                )
+            )
+        return pytest.param(self, id=self.id, marks=marks)
+
+
+_ALL_PROFILES: tuple[DeploymentProfile, ...] = (
+    DeploymentProfile.CLUSTER,
+    DeploymentProfile.EMBEDDED,
+    DeploymentProfile.LITE,
+    DeploymentProfile.SANDBOX,
+    DeploymentProfile.FULL,
+    DeploymentProfile.CLOUD,
+    DeploymentProfile.REMOTE,
+)
+
+_LOCAL_PROFILES: tuple[DeploymentProfile, ...] = (
+    DeploymentProfile.EMBEDDED,
+    DeploymentProfile.LITE,
+    DeploymentProfile.SANDBOX,
+    DeploymentProfile.FULL,
+)
+
+_REMOTE_PROFILES: tuple[DeploymentProfile, ...] = (DeploymentProfile.REMOTE,)
+
+_SERVICE_PROFILES: tuple[DeploymentProfile, ...] = (
+    DeploymentProfile.CLUSTER,
+    DeploymentProfile.CLOUD,
+)
+
+_EXTERNAL_SERVICES: dict[DeploymentProfile, tuple[str, ...]] = {
+    DeploymentProfile.CLUSTER: ("federation",),
+    DeploymentProfile.CLOUD: ("postgres", "redis", "nats"),
+}
+
+
+def profile_case(profile: DeploymentProfile) -> ProfileCase:
+    """Build a `ProfileCase` from the production profile defaults."""
+
+    return ProfileCase(
+        profile=profile,
+        id=profile.value,
+        expected_bricks=profile.default_bricks(),
+        expected_drivers=profile.default_drivers(),
+        external_services=_EXTERNAL_SERVICES.get(profile, ()),
+    )
+
+
+def profile_cases(profiles: Iterable[DeploymentProfile]) -> tuple[ProfileCase, ...]:
+    """Build profile cases in the caller-provided order."""
+
+    return tuple(profile_case(profile) for profile in profiles)
+
+
+def all_profile_cases() -> tuple[ProfileCase, ...]:
+    """Return every known deployment profile in stable enum order."""
+
+    return profile_cases(_ALL_PROFILES)
+
+
+def local_profile_cases() -> tuple[ProfileCase, ...]:
+    """Return profiles that run without remote/client or service-cluster semantics."""
+
+    return profile_cases(_LOCAL_PROFILES)
+
+
+def remote_profile_cases() -> tuple[ProfileCase, ...]:
+    """Return remote-client profile cases."""
+
+    return profile_cases(_REMOTE_PROFILES)
+
+
+def service_profile_cases() -> tuple[ProfileCase, ...]:
+    """Return profiles associated with federation or external services."""
+
+    return profile_cases(_SERVICE_PROFILES)
+
+
+def profile_params(
+    cases: Iterable[ProfileCase],
+    *,
+    skip_external: bool = False,
+) -> list[object]:
+    """Convert profile cases into pytest parameters with stable IDs."""
+
+    return [case.param(skip_external=skip_external) for case in cases]
+
+
+def all_profile_params(*, skip_external: bool = False) -> list[object]:
+    """Return pytest params for every deployment profile."""
+
+    return profile_params(all_profile_cases(), skip_external=skip_external)
+
+
+def local_profile_params(*, skip_external: bool = False) -> list[object]:
+    """Return pytest params for local deployment profiles."""
+
+    return profile_params(local_profile_cases(), skip_external=skip_external)

--- a/tests/unit/backends/test_profile_matrix.py
+++ b/tests/unit/backends/test_profile_matrix.py
@@ -1,0 +1,10 @@
+from __future__ import annotations
+
+import pytest
+from testkit.profiles import ProfileCase, all_profile_params
+
+
+@pytest.mark.parametrize("case", all_profile_params())
+def test_backend_profile_matrix_tracks_profile_defaults(case: ProfileCase) -> None:
+    assert case.expected_bricks == case.profile.default_bricks()
+    assert case.expected_drivers == case.profile.default_drivers()

--- a/tests/unit/testkit/test_assertions.py
+++ b/tests/unit/testkit/test_assertions.py
@@ -72,6 +72,16 @@ def test_assert_metadata_contains_checks_subset() -> None:
     )
 
 
+def test_assert_metadata_contains_rejects_missing_none_value_from_mapping() -> None:
+    with pytest.raises(AssertionError, match="missing"):
+        assert_metadata_contains({"path": "/docs/a.txt"}, {"nullable": None})
+
+
+def test_assert_metadata_contains_rejects_missing_none_value_from_object() -> None:
+    with pytest.raises(AssertionError, match="missing"):
+        assert_metadata_contains(SimpleNamespace(path="/docs/a.txt"), {"nullable": None})
+
+
 def test_assert_permission_decision_supports_bool_and_objects() -> None:
     assert_permission_decision(True, allowed=True)
     assert_permission_decision(SimpleNamespace(allowed=False), allowed=False)

--- a/tests/unit/testkit/test_assertions.py
+++ b/tests/unit/testkit/test_assertions.py
@@ -1,0 +1,82 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+from testkit.assertions import (
+    assert_event_payload,
+    assert_metadata_contains,
+    assert_missing_dependency_error,
+    assert_permission_decision,
+)
+
+from nexus.backends.base.runtime_deps import BinaryDep, PythonDep
+from nexus.contracts.exceptions import MissingDependencyError
+
+
+def _missing_error() -> MissingDependencyError:
+    return MissingDependencyError(
+        backend="stub_backend",
+        missing=[
+            (
+                PythonDep("missing_module", extras=("gcs",)),
+                "python 'missing_module': install with: pip install nexus-fs[gcs]",
+            ),
+            (
+                BinaryDep("missing_bin", "brew install missing-bin"),
+                "binary 'missing_bin': not on PATH - install with: brew install missing-bin",
+            ),
+        ],
+    )
+
+
+def test_assert_missing_dependency_error_accepts_expected_details() -> None:
+    assert_missing_dependency_error(
+        _missing_error(),
+        backend="stub_backend",
+        count=2,
+        missing_names=("missing_module", "missing_bin"),
+        install_hints=("pip install nexus-fs[gcs]", "brew install missing-bin"),
+    )
+
+
+def test_assert_missing_dependency_error_rejects_wrong_backend() -> None:
+    with pytest.raises(AssertionError, match="expected backend"):
+        assert_missing_dependency_error(_missing_error(), backend="other")
+
+
+def test_assert_event_payload_supports_dicts() -> None:
+    assert_event_payload(
+        {"event_type": "file_write", "path": "/docs/a.txt", "zone_id": "zone-a"},
+        event_type="file_write",
+        path="/docs/a.txt",
+        zone_id="zone-a",
+    )
+
+
+def test_assert_event_payload_supports_objects() -> None:
+    event = SimpleNamespace(type="file_delete", path="/docs/b.txt", zone_id="zone-b")
+
+    assert_event_payload(
+        event,
+        event_type="file_delete",
+        path="/docs/b.txt",
+        zone_id="zone-b",
+    )
+
+
+def test_assert_metadata_contains_checks_subset() -> None:
+    assert_metadata_contains(
+        {"path": "/docs/a.txt", "content_type": "text/plain", "size": 12},
+        {"path": "/docs/a.txt", "size": 12},
+    )
+
+
+def test_assert_permission_decision_supports_bool_and_objects() -> None:
+    assert_permission_decision(True, allowed=True)
+    assert_permission_decision(SimpleNamespace(allowed=False), allowed=False)
+
+
+def test_assert_permission_decision_rejects_wrong_state() -> None:
+    with pytest.raises(AssertionError, match="permission decision"):
+        assert_permission_decision(False, allowed=True)

--- a/tests/unit/testkit/test_auth.py
+++ b/tests/unit/testkit/test_auth.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+
+from testkit.auth import (
+    TEST_ADMIN_CONTEXT,
+    TEST_CONTEXT,
+    make_admin_context,
+    make_context,
+    make_zone_context,
+)
+
+
+def test_shared_contexts_are_reexported() -> None:
+    assert TEST_CONTEXT.user_id == "test"
+    assert TEST_CONTEXT.is_admin is False
+    assert TEST_ADMIN_CONTEXT.user_id == "test-admin"
+    assert TEST_ADMIN_CONTEXT.is_admin is True
+
+
+def test_make_context_builds_user_context() -> None:
+    ctx = make_context(user_id="alice", groups=["eng"], zone_id="zone-a")
+    assert ctx.user_id == "alice"
+    assert ctx.groups == ["eng"]
+    assert ctx.zone_id == "zone-a"
+    assert ctx.zone_set == ("zone-a",)
+    assert ctx.zone_perms == (("zone-a", "rw"),)
+    assert ctx.is_admin is False
+
+
+def test_make_admin_context_sets_admin_flag() -> None:
+    ctx = make_admin_context(user_id="root", groups=["ops"])
+    assert ctx.user_id == "root"
+    assert ctx.groups == ["ops"]
+    assert ctx.is_admin is True
+
+
+def test_make_zone_context_sets_zone_permissions() -> None:
+    ctx = make_zone_context("zone-b", user_id="bob", perms="r")
+    assert ctx.user_id == "bob"
+    assert ctx.zone_id == "zone-b"
+    assert ctx.zone_set == ("zone-b",)
+    assert ctx.zone_perms == (("zone-b", "r"),)

--- a/tests/unit/testkit/test_auth.py
+++ b/tests/unit/testkit/test_auth.py
@@ -26,6 +26,18 @@ def test_make_context_builds_user_context() -> None:
     assert ctx.is_admin is False
 
 
+def test_make_context_preserves_custom_zone_set_with_zone_id() -> None:
+    ctx = make_context(
+        user_id="alice",
+        zone_id="zone-a",
+        zone_set=("zone-a", "zone-b"),
+    )
+
+    assert ctx.zone_id == "zone-a"
+    assert ctx.zone_set == ("zone-a", "zone-b")
+    assert ctx.zone_perms == (("zone-a", "rw"), ("zone-b", "rw"))
+
+
 def test_make_admin_context_sets_admin_flag() -> None:
     ctx = make_admin_context(user_id="root", groups=["ops"])
     assert ctx.user_id == "root"

--- a/tests/unit/testkit/test_backends.py
+++ b/tests/unit/testkit/test_backends.py
@@ -10,7 +10,7 @@ from testkit.backends import (
     InMemoryRecordStore,
 )
 
-from nexus.contracts.exceptions import NexusFileNotFoundError
+from nexus.contracts.exceptions import BackendError, NexusFileNotFoundError
 
 
 def test_in_memory_backend_round_trips_content() -> None:
@@ -39,8 +39,29 @@ def test_in_memory_backend_tracks_directories() -> None:
 
     assert backend.is_directory("/a") is True
     assert backend.is_directory("/a/b") is True
-    assert backend.list_dir("/") == ["a"]
-    assert backend.list_dir("/a") == ["b"]
+    assert backend.list_dir("/") == ["a/"]
+    assert backend.list_dir("/a") == ["b/"]
+
+
+def test_in_memory_backend_rmdir_rejects_non_empty_directory() -> None:
+    backend = InMemoryBackend()
+    backend.mkdir("/a/b", parents=True, exist_ok=True)
+
+    with pytest.raises(BackendError):
+        backend.rmdir("/a")
+
+    assert backend.is_directory("/a") is True
+    assert backend.is_directory("/a/b") is True
+
+
+def test_in_memory_backend_rmdir_recursive_removes_children() -> None:
+    backend = InMemoryBackend()
+    backend.mkdir("/a/b", parents=True, exist_ok=True)
+
+    backend.rmdir("/a", recursive=True)
+
+    assert backend.is_directory("/a") is False
+    assert backend.is_directory("/a/b") is False
 
 
 def test_factory_stub_backend_accepts_arbitrary_kwargs() -> None:

--- a/tests/unit/testkit/test_backends.py
+++ b/tests/unit/testkit/test_backends.py
@@ -25,6 +25,26 @@ def test_in_memory_backend_round_trips_content() -> None:
     assert backend.get_content_size(result.content_id) == 5
 
 
+def test_in_memory_backend_offset_write_preserves_existing_tail() -> None:
+    backend = InMemoryBackend()
+    backend.write_content(b"abcdef", content_id="file")
+
+    result = backend.write_content(b"XY", content_id="file", offset=2)
+
+    assert result.content_id == "file"
+    assert result.size == 6
+    assert backend.read_content("file") == b"abXYef"
+
+
+def test_in_memory_backend_offset_write_zero_fills_gap() -> None:
+    backend = InMemoryBackend()
+    backend.write_content(b"ab", content_id="file")
+
+    backend.write_content(b"z", content_id="file", offset=4)
+
+    assert backend.read_content("file") == b"ab\x00\x00z"
+
+
 def test_in_memory_backend_raises_for_missing_content() -> None:
     backend = InMemoryBackend()
 
@@ -41,6 +61,14 @@ def test_in_memory_backend_tracks_directories() -> None:
     assert backend.is_directory("/a/b") is True
     assert backend.list_dir("/") == ["a/"]
     assert backend.list_dir("/a") == ["b/"]
+
+
+def test_in_memory_backend_mkdir_rejects_existing_directory_without_exist_ok() -> None:
+    backend = InMemoryBackend()
+    backend.mkdir("/a")
+
+    with pytest.raises(BackendError, match="already exists"):
+        backend.mkdir("/a")
 
 
 def test_in_memory_backend_rmdir_rejects_non_empty_directory() -> None:

--- a/tests/unit/testkit/test_backends.py
+++ b/tests/unit/testkit/test_backends.py
@@ -1,0 +1,58 @@
+from __future__ import annotations
+
+import pytest
+from testkit.backends import (
+    DictMetastore,
+    FactoryStubBackend,
+    FailingBackend,
+    InMemoryBackend,
+    InMemoryNexusFS,
+    InMemoryRecordStore,
+)
+
+from nexus.contracts.exceptions import NexusFileNotFoundError
+
+
+def test_in_memory_backend_round_trips_content() -> None:
+    backend = InMemoryBackend()
+    result = backend.write_content(b"hello")
+
+    assert result.content_id
+    assert result.version == result.content_id
+    assert result.size == 5
+    assert backend.read_content(result.content_id) == b"hello"
+    assert backend.content_exists(result.content_id) is True
+    assert backend.get_content_size(result.content_id) == 5
+
+
+def test_in_memory_backend_raises_for_missing_content() -> None:
+    backend = InMemoryBackend()
+
+    with pytest.raises(NexusFileNotFoundError):
+        backend.read_content("missing")
+
+
+def test_in_memory_backend_tracks_directories() -> None:
+    backend = InMemoryBackend()
+
+    backend.mkdir("/a/b", parents=True, exist_ok=True)
+
+    assert backend.is_directory("/a") is True
+    assert backend.is_directory("/a/b") is True
+    assert backend.list_dir("/") == ["a"]
+    assert backend.list_dir("/a") == ["b"]
+
+
+def test_factory_stub_backend_accepts_arbitrary_kwargs() -> None:
+    backend = FactoryStubBackend(token="secret")
+
+    assert backend.kwargs == {"token": "secret"}
+    assert backend.name == "stub"
+    assert backend.has_feature("anything") is False
+
+
+def test_existing_helpers_are_reexported() -> None:
+    assert callable(DictMetastore)
+    assert callable(InMemoryNexusFS)
+    assert callable(InMemoryRecordStore)
+    assert callable(FailingBackend)

--- a/tests/unit/testkit/test_bricks.py
+++ b/tests/unit/testkit/test_bricks.py
@@ -39,6 +39,21 @@ async def test_probe_service_lifecycle_exercises_start_health_and_stop() -> None
 
 
 @pytest.mark.asyncio
+async def test_probe_service_lifecycle_stops_after_health_failure() -> None:
+    class _FailingHealthBrick(FakeLifecycleBrick):
+        async def health_check(self) -> bool:
+            raise RuntimeError("health failed")
+
+    brick = _FailingHealthBrick(name="scheduler")
+
+    with pytest.raises(RuntimeError, match="health failed"):
+        await probe_service_lifecycle(brick)
+
+    assert brick.started is False
+    assert brick.events == ("start", "stop")
+
+
+@pytest.mark.asyncio
 async def test_fake_search_brick_satisfies_search_protocol_and_records_calls() -> None:
     brick = FakeSearchBrick(results=[{"path": "/docs/a.txt"}, {"path": "/docs/b.txt"}])
 

--- a/tests/unit/testkit/test_bricks.py
+++ b/tests/unit/testkit/test_bricks.py
@@ -1,0 +1,69 @@
+from __future__ import annotations
+
+import pytest
+from testkit.bricks import FakeLifecycleBrick, FakeSearchBrick, probe_service_lifecycle
+
+from nexus.contracts.protocols.search import SearchBrickProtocol
+
+
+@pytest.mark.asyncio
+async def test_fake_lifecycle_brick_records_idempotent_lifecycle() -> None:
+    brick = FakeLifecycleBrick(name="cache")
+
+    await brick.start()
+    await brick.start()
+    assert brick.started is True
+    assert brick.start_calls == 2
+    assert brick.events == ("start",)
+    assert await brick.health_check() is True
+
+    await brick.stop()
+    await brick.stop()
+    assert brick.started is False
+    assert brick.stop_calls == 2
+    assert brick.events == ("start", "stop")
+
+
+@pytest.mark.asyncio
+async def test_probe_service_lifecycle_exercises_start_health_and_stop() -> None:
+    brick = FakeLifecycleBrick(name="scheduler")
+
+    result = await probe_service_lifecycle(brick)
+
+    assert result.name == "scheduler"
+    assert result.started_after_start is True
+    assert result.healthy_after_start is True
+    assert result.started_after_stop is False
+    assert result.healthy_after_stop is False
+    assert result.events == ("start", "stop")
+
+
+@pytest.mark.asyncio
+async def test_fake_search_brick_satisfies_search_protocol_and_records_calls() -> None:
+    brick = FakeSearchBrick(results=[{"path": "/docs/a.txt"}, {"path": "/docs/b.txt"}])
+
+    assert isinstance(brick, SearchBrickProtocol)
+
+    await brick.startup()
+    results = await brick.search("docs", limit=1, zone_id="zone-a")
+    await brick.notify_file_change("/docs/a.txt", "update")
+
+    assert results == [{"path": "/docs/a.txt"}]
+    assert brick.queries == (
+        {
+            "query": "docs",
+            "search_type": "hybrid",
+            "limit": 1,
+            "path_filter": None,
+            "alpha": 0.5,
+            "fusion_method": "rrf",
+            "adaptive_k": False,
+            "zone_id": "zone-a",
+        },
+    )
+    assert brick.notifications == (("/docs/a.txt", "update"),)
+    assert brick.get_stats()["queries"] == 1
+    assert brick.get_health()["status"] == "healthy"
+
+    await brick.shutdown()
+    assert brick.is_initialized is False

--- a/tests/unit/testkit/test_containers.py
+++ b/tests/unit/testkit/test_containers.py
@@ -1,0 +1,113 @@
+from __future__ import annotations
+
+import pytest
+from testkit.containers import (
+    ServiceProbe,
+    get_env_url,
+    nats_url,
+    parse_host_port,
+    postgres_probe,
+    postgres_url,
+    probe_tcp_service,
+    redis_url,
+    require_service,
+    server_smoke_config,
+)
+
+
+def test_get_env_url_returns_first_configured_value(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("ONE", raising=False)
+    monkeypatch.setenv("TWO", "value-two")
+    monkeypatch.setenv("THREE", "value-three")
+
+    assert get_env_url(("ONE", "TWO", "THREE")) == "value-two"
+
+
+def test_postgres_url_uses_existing_env_order(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NEXUS_DATABASE_URL", raising=False)
+    monkeypatch.setenv("POSTGRES_URL", "postgresql://u:p@db:5432/nexus")
+    monkeypatch.setenv("DATABASE_URL", "postgresql://ignored")
+
+    assert postgres_url() == "postgresql://u:p@db:5432/nexus"
+
+
+def test_redis_url_uses_dragonfly_before_redis(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEXUS_DRAGONFLY_URL", "redis://dragonfly:6379/0")
+    monkeypatch.setenv("REDIS_URL", "redis://redis:6379/0")
+
+    assert redis_url() == "redis://dragonfly:6379/0"
+
+
+def test_nats_url_defaults_to_localhost(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NEXUS_NATS_URL", raising=False)
+
+    assert nats_url() == "nats://localhost:4222"
+
+
+def test_parse_host_port_supports_scheme_and_bare_host() -> None:
+    assert parse_host_port("postgresql://u:p@db.example:5433/nexus", 5432) == (
+        "db.example",
+        5433,
+    )
+    assert parse_host_port("localhost:4222", 4222) == ("localhost", 4222)
+
+
+def test_postgres_probe_reports_missing_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
+    for name in ("NEXUS_DATABASE_URL", "POSTGRES_URL", "DATABASE_URL"):
+        monkeypatch.delenv(name, raising=False)
+
+    probe = postgres_probe()
+    assert probe.name == "postgres"
+    assert probe.available is False
+    assert "NEXUS_DATABASE_URL" in probe.reason
+
+
+def test_probe_tcp_service_reports_success(monkeypatch: pytest.MonkeyPatch) -> None:
+    calls: list[tuple[tuple[str, int], float]] = []
+
+    class _Conn:
+        def close(self) -> None:
+            pass
+
+    def fake_create_connection(address: tuple[str, int], timeout: float) -> _Conn:
+        calls.append((address, timeout))
+        return _Conn()
+
+    monkeypatch.setattr("socket.create_connection", fake_create_connection)
+
+    probe = probe_tcp_service("nats", "nats://localhost:4222", 4222, timeout=0.1)
+
+    assert probe == ServiceProbe(
+        name="nats",
+        url="nats://localhost:4222",
+        host="localhost",
+        port=4222,
+        available=True,
+        reason="available",
+    )
+    assert calls == [(("localhost", 4222), 0.1)]
+
+
+def test_require_service_skips_when_probe_is_unavailable() -> None:
+    probe = ServiceProbe(
+        name="postgres",
+        url=None,
+        host=None,
+        port=None,
+        available=False,
+        reason="set NEXUS_DATABASE_URL",
+    )
+
+    with pytest.raises(pytest.skip.Exception) as exc_info:
+        require_service(probe)
+
+    assert "set NEXUS_DATABASE_URL" in str(exc_info.value)
+
+
+def test_server_smoke_config_is_explicit() -> None:
+    assert server_smoke_config(port=2028, api_key="key") == {
+        "host": "127.0.0.1",
+        "port": 2028,
+        "base_url": "http://127.0.0.1:2028",
+        "api_key": "key",
+    }

--- a/tests/unit/testkit/test_profiles.py
+++ b/tests/unit/testkit/test_profiles.py
@@ -1,0 +1,74 @@
+from __future__ import annotations
+
+import pytest
+from testkit.profiles import (
+    ProfileCase,
+    all_profile_cases,
+    all_profile_params,
+    local_profile_cases,
+    local_profile_params,
+    profile_params,
+    remote_profile_cases,
+    service_profile_cases,
+)
+
+from nexus.contracts.deployment_profile import DeploymentProfile
+
+
+def test_all_profile_cases_cover_deployment_profiles_in_stable_order() -> None:
+    assert [case.profile for case in all_profile_cases()] == [
+        DeploymentProfile.CLUSTER,
+        DeploymentProfile.EMBEDDED,
+        DeploymentProfile.LITE,
+        DeploymentProfile.SANDBOX,
+        DeploymentProfile.FULL,
+        DeploymentProfile.CLOUD,
+        DeploymentProfile.REMOTE,
+    ]
+
+
+def test_profile_cases_mirror_deployment_profile_defaults() -> None:
+    for case in all_profile_cases():
+        assert isinstance(case, ProfileCase)
+        assert case.id == case.profile.value
+        assert case.expected_bricks == case.profile.default_bricks()
+        assert case.expected_drivers == case.profile.default_drivers()
+
+
+def test_profile_subsets_are_explicit() -> None:
+    assert [case.profile for case in local_profile_cases()] == [
+        DeploymentProfile.EMBEDDED,
+        DeploymentProfile.LITE,
+        DeploymentProfile.SANDBOX,
+        DeploymentProfile.FULL,
+    ]
+    assert [case.profile for case in remote_profile_cases()] == [DeploymentProfile.REMOTE]
+    assert [case.profile for case in service_profile_cases()] == [
+        DeploymentProfile.CLUSTER,
+        DeploymentProfile.CLOUD,
+    ]
+
+
+def test_profile_params_keep_stable_pytest_ids() -> None:
+    params = all_profile_params()
+    assert [param.id for param in params] == [case.id for case in all_profile_cases()]
+
+
+def test_local_profile_params_keep_stable_pytest_ids() -> None:
+    params = local_profile_params()
+    assert [param.id for param in params] == [case.id for case in local_profile_cases()]
+
+
+def test_profile_params_can_skip_external_service_cases() -> None:
+    params = profile_params(service_profile_cases(), skip_external=True)
+    by_id = {param.id: param for param in params}
+
+    for profile_id in ("cluster", "cloud"):
+        mark_names = [mark.name for mark in by_id[profile_id].marks]
+        assert "skip" in mark_names
+
+
+@pytest.mark.parametrize("case", all_profile_params())
+def test_param_values_are_profile_cases(case: ProfileCase) -> None:
+    assert case.expected_bricks == case.profile.default_bricks()
+    assert case.expected_drivers == case.profile.default_drivers()


### PR DESCRIPTION
## Summary

- Adds a reusable pytest-only `tests/testkit` package for profile matrices, auth contexts, optional service probes, backend fakes, fake bricks, lifecycle probes, and assertion helpers.
- Migrates the backend factory dependency check suite to shared testkit helpers and adds a backend profile-matrix consumer.
- Documents testkit boundaries and usage in `docs/development/testkit.md`.

Closes #3968.

## Test Plan

- `./.venv/bin/pytest tests/unit/testkit -q`
- `./.venv/bin/pytest tests/unit/backends/test_profile_matrix.py -q`
- `./.venv/bin/pytest tests/integration/backends/test_factory_dep_check.py -q`
- `./.venv/bin/pytest tests/unit/testkit tests/unit/backends/test_profile_matrix.py tests/integration/backends/test_factory_dep_check.py -q`
- `python3 -m ruff check tests/testkit tests/unit/testkit`
- `python3 -m ruff format --check tests/testkit tests/unit/testkit`
- `git diff --check`