### PR TITLE
fix(#4002): delete_batch literal-key results + sys_unlink delegation

### DIFF
--- a/src/nexus/core/nexus_fs_metadata.py
+++ b/src/nexus/core/nexus_fs_metadata.py
@@ -833,9 +833,16 @@ class MetadataMixin:
                 logger.info("sys_unlink: unmounted external connector %s", path)
             return {}
 
-        # Unknown entry type — should not happen
-        logger.warning("sys_unlink: unexpected entry_type=%d for %s", et, path)
-        return {}
+        # Unknown entry type — kernel reported a non-hit with a nonzero
+        # entry_type (e.g. write-lock timeout, internal abort).  Treating
+        # this as success would silently leave files on disk while
+        # callers proceed under a false-clean signal (Codex review,
+        # Issue #4002 round 2).  Surface it so batch APIs can record a
+        # real per-item failure instead of phantom success.
+        raise BackendError(
+            f"sys_unlink: kernel returned non-hit with entry_type={et}",
+            path=path,
+        )
 
     # @rpc_expose removed — kernel syscall, served by the thin dispatcher.
     def sys_rename(
@@ -1416,7 +1423,28 @@ class MetadataMixin:
                 self.sys_unlink(normalized, recursive=recursive, context=context)
                 results[path] = {"success": True}
             except NexusFileNotFoundError:
-                results[path] = {"success": False, "error": "File not found"}
+                # Rust kernel doesn't see implicit directories (paths with
+                # children but no explicit inode). Fall back to the same
+                # is_implicit_directory check stat/list use, so a directory
+                # that exists_batch reports True for is also deletable
+                # (Codex review, Issue #4002 round 2).
+                if self.metadata.is_implicit_directory(normalized):
+                    if not recursive:
+                        results[path] = {
+                            "success": False,
+                            "error": "Directory not empty",
+                        }
+                        continue
+                    try:
+                        for child in list(
+                            self.metadata.list_iter(prefix=normalized, recursive=True)
+                        ):
+                            self.sys_unlink(child.path, context=context)
+                        results[path] = {"success": True}
+                    except Exception as e:
+                        results[path] = {"success": False, "error": str(e)}
+                else:
+                    results[path] = {"success": False, "error": "File not found"}
             except Exception as e:
                 results[path] = {"success": False, "error": str(e)}
         return results

--- a/src/nexus/core/nexus_fs_metadata.py
+++ b/src/nexus/core/nexus_fs_metadata.py
@@ -778,10 +778,12 @@ class MetadataMixin:
         # Without this, SnapshotWriteHook.on_post_delete returns early
         # on ctx.metadata=None and never records original_hash for
         # transactional rollback (Codex review, Issue #4002 round 4).
-        try:
-            _pre_delete_meta = self.metadata.get(path)
-        except Exception:  # noqa: BLE001 — best-effort capture
-            _pre_delete_meta = None
+        # Let metastore errors propagate (Codex review, round 9): if
+        # the probe fails we cannot prove the delete is observable,
+        # so refuse rather than silently lose rollback data.  None is
+        # still legitimate (implicit dirs / external storage entries
+        # carry no metastore row).
+        _pre_delete_meta = self.metadata.get(path)
 
         # ── Call Rust — handles DT_REG, DT_PIPE, DT_STREAM, DT_DIR, DT_MOUNT ──
         zone_id, agent_id, is_admin = self._get_context_identity(context)
@@ -830,34 +832,51 @@ class MetadataMixin:
         # ── Rust miss: only DT_EXTERNAL_STORAGE (5) or not-found ─────
         et = _unlink_result.entry_type
         if et == 0:
-            # Stranded-mount recovery (Codex review, Issue #4002 round 5):
-            # if a previous teardown deleted metadata but failed to
-            # remove the kernel mount route, the kernel now reports
-            # not-found while the route is still live.  Attempt cleanup
-            # before raising so this API stays self-healing instead of
-            # leaving an invisible orphan.
-            try:
-                stranded = self._kernel.has_mount(path, zone_id)
-            except Exception:  # noqa: BLE001 — best-effort verify
-                stranded = False
-            if stranded:
-                # Pass the caller's zone_id so non-root tenant mounts
-                # are torn down in the correct zone instead of
-                # no-op'ing against ROOT_ZONE_ID (Codex review,
-                # Issue #4002 round 7).
-                self._driver_coordinator.unmount(path, zone_id or ROOT_ZONE_ID)
+            # Stranded-mount recovery (Codex review, Issue #4002
+            # rounds 5 + 8): if a previous teardown deleted metadata
+            # but failed to remove the kernel mount route, the kernel
+            # now reports not-found while the route is still live.
+            # Probe the caller's zone first, then fall back to root —
+            # mount routes are keyed by the *mounted* zone, which can
+            # differ from the caller's zone.
+            # Fail-closed on probe errors (Codex review, round 10):
+            # in the et=0 retry path, an unverifiable route presence
+            # means we cannot prove the path is clean, so we must
+            # raise rather than treat as 'gone'.
+            stranded_zone: str | None = None
+            for candidate in (zone_id, ROOT_ZONE_ID):
+                if candidate is None:
+                    continue
                 try:
-                    still_present = self._kernel.has_mount(path, zone_id)
-                except Exception:  # noqa: BLE001 — best-effort verify
-                    still_present = False
+                    present = self._kernel.has_mount(path, candidate)
+                except Exception as probe_exc:
+                    raise BackendError(
+                        f"sys_unlink: cannot verify mount route in zone "
+                        f"{candidate!r} for {path!r}: {probe_exc}",
+                        path=path,
+                    ) from probe_exc
+                if present:
+                    stranded_zone = candidate
+                    break
+            if stranded_zone is not None:
+                self._driver_coordinator.unmount(path, stranded_zone)
+                try:
+                    still_present = self._kernel.has_mount(path, stranded_zone)
+                except Exception as verify_exc:
+                    raise BackendError(
+                        f"sys_unlink: cannot verify stranded mount route "
+                        f"teardown for {path!r}: {verify_exc}",
+                        path=path,
+                    ) from verify_exc
                 if still_present:
                     raise BackendError(
                         f"sys_unlink: stranded mount route remains for {path!r}",
                         path=path,
                     )
                 logger.info(
-                    "sys_unlink: cleaned up stranded mount route for %s",
+                    "sys_unlink: cleaned up stranded mount route for %s in zone %s",
                     path,
+                    stranded_zone,
                 )
                 return {}
             raise NexusFileNotFoundError(path)
@@ -876,19 +895,29 @@ class MetadataMixin:
             ctx = self._resolve_cred(context)
             from nexus.contracts.vfs_hooks import RmdirHookContext
 
+            # Resolve the mount-route zone from pre-delete metadata
+            # (Codex review, Issue #4002 round 8). Mount routes are
+            # keyed by the *mounted* zone, which can differ from the
+            # caller's zone — e.g. an admin context deleting a tenant
+            # mount.  Fall back to caller zone if metadata is missing
+            # the field (older entries) and finally to ROOT_ZONE_ID.
+            route_zone = getattr(_pre_delete_meta, "zone_id", None) or zone_id or ROOT_ZONE_ID
             self._kernel.dispatch_pre_hooks("rmdir", RmdirHookContext(path=path, context=ctx))
             self.metadata.delete(path)
-            # Zone-aware teardown so tenant-scoped external mounts are
-            # torn down in their own zone, not ROOT_ZONE_ID (Codex
-            # review, Issue #4002 round 7).
-            removed = self._driver_coordinator.unmount(path, zone_id or ROOT_ZONE_ID)
+            removed = self._driver_coordinator.unmount(path, route_zone)
             # Verify the kernel mount route is actually gone so a real
             # teardown failure surfaces even when unmount() reports
             # already-cleared (Codex review, Issue #4002 round 4).
+            # Fail-closed on verification errors after metadata is
+            # committed (Codex review, round 9): we can't risk
+            # reporting success while a route may still be live.
             try:
-                mount_remains = self._kernel.has_mount(path, zone_id)
-            except Exception:  # noqa: BLE001 — best-effort verify
-                mount_remains = False
+                mount_remains = self._kernel.has_mount(path, route_zone)
+            except Exception as verify_exc:
+                raise BackendError(
+                    f"sys_unlink: cannot verify mount route teardown for {path!r}: {verify_exc}",
+                    path=path,
+                ) from verify_exc
             if mount_remains:
                 raise BackendError(
                     f"sys_unlink: mount route remains after teardown for {path!r}",

--- a/src/nexus/core/nexus_fs_metadata.py
+++ b/src/nexus/core/nexus_fs_metadata.py
@@ -773,6 +773,16 @@ class MetadataMixin:
         if _handled:
             return _result
 
+        # Capture pre-delete metadata so post-delete hooks (snapshot
+        # rollback, audit, etc.) receive the original FileMetadata.
+        # Without this, SnapshotWriteHook.on_post_delete returns early
+        # on ctx.metadata=None and never records original_hash for
+        # transactional rollback (Codex review, Issue #4002 round 4).
+        try:
+            _pre_delete_meta = self.metadata.get(path)
+        except Exception:  # noqa: BLE001 — best-effort capture
+            _pre_delete_meta = None
+
         # ── Call Rust — handles DT_REG, DT_PIPE, DT_STREAM, DT_DIR, DT_MOUNT ──
         zone_id, agent_id, is_admin = self._get_context_identity(context)
         _rust_ctx = self._build_rust_ctx(context, is_admin)
@@ -799,6 +809,7 @@ class MetadataMixin:
                             zone_id=zone_id,
                             agent_id=agent_id,
                             recursive=recursive,
+                            metadata=_pre_delete_meta,
                         ),
                     )
                 else:
@@ -811,6 +822,7 @@ class MetadataMixin:
                             context=context,
                             zone_id=zone_id,
                             agent_id=agent_id,
+                            metadata=_pre_delete_meta,
                         ),
                     )
             return {}
@@ -818,18 +830,77 @@ class MetadataMixin:
         # ── Rust miss: only DT_EXTERNAL_STORAGE (5) or not-found ─────
         et = _unlink_result.entry_type
         if et == 0:
+            # Stranded-mount recovery (Codex review, Issue #4002 round 5):
+            # if a previous teardown deleted metadata but failed to
+            # remove the kernel mount route, the kernel now reports
+            # not-found while the route is still live.  Attempt cleanup
+            # before raising so this API stays self-healing instead of
+            # leaving an invisible orphan.
+            try:
+                stranded = self._kernel.has_mount(path, zone_id)
+            except Exception:  # noqa: BLE001 — best-effort verify
+                stranded = False
+            if stranded:
+                # Pass the caller's zone_id so non-root tenant mounts
+                # are torn down in the correct zone instead of
+                # no-op'ing against ROOT_ZONE_ID (Codex review,
+                # Issue #4002 round 7).
+                self._driver_coordinator.unmount(path, zone_id or ROOT_ZONE_ID)
+                try:
+                    still_present = self._kernel.has_mount(path, zone_id)
+                except Exception:  # noqa: BLE001 — best-effort verify
+                    still_present = False
+                if still_present:
+                    raise BackendError(
+                        f"sys_unlink: stranded mount route remains for {path!r}",
+                        path=path,
+                    )
+                logger.info(
+                    "sys_unlink: cleaned up stranded mount route for %s",
+                    path,
+                )
+                return {}
             raise NexusFileNotFoundError(path)
 
         # DT_EXTERNAL_STORAGE (5): unmount via DLC (Python service-tier,
-        # connector teardown / token revocation).
+        # connector teardown / token revocation).  Retry-safety
+        # (Codex review, Issue #4002 round 3): commit the metadata
+        # delete FIRST so a partial failure between teardown and
+        # metadata cleanup cannot leave a stuck entry.  After
+        # metadata.delete succeeds, the kernel no longer reports et=5
+        # for this path, so a retry simply short-circuits.  Connector
+        # teardown becomes best-effort; a False return is logged but
+        # does not raise, since we cannot distinguish "real teardown
+        # failure" from "already unmounted by an earlier attempt".
         if et == 5:
             ctx = self._resolve_cred(context)
             from nexus.contracts.vfs_hooks import RmdirHookContext
 
             self._kernel.dispatch_pre_hooks("rmdir", RmdirHookContext(path=path, context=ctx))
-            removed = self._driver_coordinator.unmount(path)
-            if removed:
-                self.metadata.delete(path)
+            self.metadata.delete(path)
+            # Zone-aware teardown so tenant-scoped external mounts are
+            # torn down in their own zone, not ROOT_ZONE_ID (Codex
+            # review, Issue #4002 round 7).
+            removed = self._driver_coordinator.unmount(path, zone_id or ROOT_ZONE_ID)
+            # Verify the kernel mount route is actually gone so a real
+            # teardown failure surfaces even when unmount() reports
+            # already-cleared (Codex review, Issue #4002 round 4).
+            try:
+                mount_remains = self._kernel.has_mount(path, zone_id)
+            except Exception:  # noqa: BLE001 — best-effort verify
+                mount_remains = False
+            if mount_remains:
+                raise BackendError(
+                    f"sys_unlink: mount route remains after teardown for {path!r}",
+                    path=path,
+                )
+            if not removed:
+                logger.warning(
+                    "sys_unlink: connector teardown returned False for %s "
+                    "(metadata + route already cleared; retry-safe)",
+                    path,
+                )
+            else:
                 logger.info("sys_unlink: unmounted external connector %s", path)
             return {}
 
@@ -1427,20 +1498,76 @@ class MetadataMixin:
                 # children but no explicit inode). Fall back to the same
                 # is_implicit_directory check stat/list use, so a directory
                 # that exists_batch reports True for is also deletable
-                # (Codex review, Issue #4002 round 2).
-                if self.metadata.is_implicit_directory(normalized):
+                # (Codex review, Issue #4002 round 2). Wrap the probe +
+                # enumeration in a per-path try so a degraded metastore
+                # doesn't abort the whole batch (round 3 finding).
+                try:
+                    is_implicit = self.metadata.is_implicit_directory(normalized)
+                except Exception as e:
+                    results[path] = {"success": False, "error": str(e)}
+                    continue
+                if is_implicit:
                     if not recursive:
                         results[path] = {
                             "success": False,
                             "error": "Directory not empty",
                         }
                         continue
+                    # Slash-bounded prefix prevents sibling-path leakage
+                    # (e.g. /parent must not match /parent2/x). Defensive
+                    # post-filter guards against backends that ignore the
+                    # boundary or return the directory entry itself.
+                    boundary = normalized.rstrip("/") + "/"
                     try:
-                        for child in list(
-                            self.metadata.list_iter(prefix=normalized, recursive=True)
-                        ):
-                            self.sys_unlink(child.path, context=context)
-                        results[path] = {"success": True}
+                        # Sort deepest-first so any explicit child
+                        # directory's descendants are gone by the time
+                        # we unlink the directory itself.  Pass
+                        # recursive=True so explicit dirs we couldn't
+                        # pre-drain still tear down, and tolerate
+                        # already-deleted entries (Codex review,
+                        # Issue #4002 round 3).
+                        children = sorted(
+                            (
+                                child
+                                for child in self.metadata.list_iter(
+                                    prefix=boundary, recursive=True
+                                )
+                                if child.path.startswith(boundary)
+                            ),
+                            key=lambda c: c.path.count("/"),
+                            reverse=True,
+                        )
+                        for child in children:
+                            try:
+                                self.sys_unlink(child.path, recursive=True, context=context)
+                            except NexusFileNotFoundError:
+                                continue
+                        # Strict recheck (Codex review, Issue #4002
+                        # round 6): probe explicit inode AND implicit
+                        # directory directly via metadata. If either
+                        # probe RAISES we cannot prove absence, so we
+                        # must surface failure instead of letting
+                        # access() collapse infrastructure errors into
+                        # a "looks empty" verdict.  Success requires
+                        # both probes to confirm absence.
+                        try:
+                            explicit_after = self.metadata.get(normalized)
+                            implicit_after = self.metadata.is_implicit_directory(normalized)
+                        except Exception as e:
+                            results[path] = {
+                                "success": False,
+                                "error": f"Could not verify recursive delete: {e}",
+                            }
+                            continue
+                        if explicit_after is not None or implicit_after:
+                            results[path] = {
+                                "success": False,
+                                "error": (
+                                    "Path recreated during recursive delete (concurrent write)"
+                                ),
+                            }
+                        else:
+                            results[path] = {"success": True}
                     except Exception as e:
                         results[path] = {"success": False, "error": str(e)}
                 else:

--- a/src/nexus/core/nexus_fs_metadata.py
+++ b/src/nexus/core/nexus_fs_metadata.py
@@ -1399,44 +1399,26 @@ class MetadataMixin:
             ...     else:
             ...         print(f"Failed {path}: {result['error']}")
         """
-        # Validate all paths first
-        validated: list[str] = []
+        # Delegate each delete to sys_unlink so the lookup uses the same
+        # source of truth as access()/exists_batch (Rust dcache → metastore →
+        # implicit-dir detection) instead of a raw metastore.get_batch that
+        # can lag behind. Result keys preserve the caller's literal path so
+        # response shape matches write_batch / exists_batch / read_bulk; the
+        # normalized form is only used for the syscall itself.
         results: dict[str, dict] = {}
         for path in paths:
             try:
-                validated.append(self._validate_path(path))
+                normalized = self._validate_path(path)
             except Exception as e:
                 results[path] = {"success": False, "error": str(e)}
-
-        if not validated:
-            return results
-
-        # Batch metadata lookup (single query instead of N)
-        batch_meta = self.metadata.get_batch(validated)
-
-        for path in validated:
+                continue
             try:
-                meta = batch_meta.get(path)
-
-                # Check for implicit directory (exists because it has files beneath it)
-                is_implicit_dir = meta is None and self.metadata.is_implicit_directory(path)
-
-                if meta is None and not is_implicit_dir:
-                    results[path] = {"success": False, "error": "File not found"}
-                    continue
-
-                # Check if this is a directory (explicit or implicit)
-                is_dir = is_implicit_dir or (meta and meta.mime_type == "inode/directory")
-
-                if is_dir:
-                    self.sys_unlink(path, recursive=recursive, context=context)
-                else:
-                    self.sys_unlink(path, context=context)
-
+                self.sys_unlink(normalized, recursive=recursive, context=context)
                 results[path] = {"success": True}
+            except NexusFileNotFoundError:
+                results[path] = {"success": False, "error": "File not found"}
             except Exception as e:
                 results[path] = {"success": False, "error": str(e)}
-
         return results
 
     def _rmdir_internal(

--- a/tests/unit/core/test_nexus_fs_delete_batch.py
+++ b/tests/unit/core/test_nexus_fs_delete_batch.py
@@ -438,6 +438,153 @@ class TestImplicitRecursiveRaceRecheck:
         assert "concurrent" in result["/parent"]["error"].lower()
 
 
+class TestPreDeleteMetadataFailClosed:
+    """Codex round-9 finding: pre-delete metadata.get() must fail-closed.
+    A metastore error during the probe means rollback hooks would never
+    record original_hash — so refuse the delete instead of silently
+    proceeding with metadata=None."""
+
+    def test_metastore_failure_aborts_delete(self, nx, monkeypatch):
+        nx.write_batch([("/tracked.txt", b"x")])
+
+        def flaky_get(p):
+            if p == "/tracked.txt":
+                raise RuntimeError("metastore degraded")
+            return None
+
+        monkeypatch.setattr(nx.metadata, "get", flaky_get)
+
+        result = nx.delete_batch(["/tracked.txt"])
+
+        assert result["/tracked.txt"]["success"] is False
+        assert "metastore degraded" in result["/tracked.txt"]["error"]
+
+
+class TestMountVerifyFailClosed:
+    """Codex round-9 finding: has_mount errors after metadata.delete
+    must fail-closed (raise) rather than silently masking a possibly
+    live route as 'gone'."""
+
+    def test_has_mount_failure_raises(self, nx, monkeypatch):
+        from nexus.contracts.exceptions import BackendError
+        from nexus.contracts.metadata import FileMetadata
+
+        class _ExternalResult:
+            hit = False
+            entry_type = 5
+            post_hook_needed = False
+
+        class _UnverifiableKernel:
+            def __init__(self, real):
+                self._real = real
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def sys_unlink(self, *_a, **_kw):
+                return _ExternalResult()
+
+            def dispatch_pre_hooks(self, *_a, **_kw):
+                return None
+
+            def has_mount(self, *_a, **_kw):
+                raise RuntimeError("kernel verification crashed")
+
+        meta = FileMetadata(
+            path="/unverifiable",
+            content_id=None,
+            mime_type="inode/external_storage",
+            size=0,
+            zone_id="root",
+        )
+        monkeypatch.setattr(nx.metadata, "get", lambda _p: meta)
+        monkeypatch.setattr(nx, "_kernel", _UnverifiableKernel(nx._kernel))
+
+        with pytest.raises(BackendError, match="cannot verify mount route teardown"):
+            nx.sys_unlink("/unverifiable")
+
+
+class TestStrandedMountVerifyFailClosed:
+    """Codex round-10 finding: et=0 stranded-mount recovery must
+    fail-closed when has_mount can't be evaluated. Probe AND
+    post-teardown verification both raise BackendError instead of
+    silently treating verification failure as 'route absent'."""
+
+    def test_stranded_probe_failure_raises(self, nx, monkeypatch):
+        """has_mount raises during the initial probe — must surface
+        BackendError, not fall through to NexusFileNotFoundError."""
+        from nexus.contracts.exceptions import BackendError
+
+        class _FlakyProbeKernel:
+            def __init__(self, real):
+                self._real = real
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def sys_unlink(self, *_a, **_kw):
+                class R:
+                    hit = False
+                    entry_type = 0
+                    post_hook_needed = False
+
+                return R()
+
+            def has_mount(self, *_a, **_kw):
+                raise RuntimeError("kernel routing degraded")
+
+        monkeypatch.setattr(nx, "_kernel", _FlakyProbeKernel(nx._kernel))
+
+        with pytest.raises(BackendError, match="cannot verify mount route"):
+            nx.sys_unlink("/probe-fails")
+
+    def test_stranded_post_unmount_verify_failure_raises(self, nx, monkeypatch):
+        """has_mount succeeds for the initial probe (route is live)
+        but the post-teardown re-check raises — must surface
+        BackendError, not silently report success."""
+        from nexus.contracts.exceptions import BackendError
+
+        class _PostUnmountFlakyKernel:
+            def __init__(self, real):
+                self._real = real
+                self._calls = 0
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def sys_unlink(self, *_a, **_kw):
+                class R:
+                    hit = False
+                    entry_type = 0
+                    post_hook_needed = False
+
+                return R()
+
+            def has_mount(self, *_a, **_kw):
+                self._calls += 1
+                if self._calls == 1:
+                    return True  # route is live → recovery triggers
+                raise RuntimeError("kernel verification crashed")
+
+        class _RecoveringCoordinator:
+            def __init__(self, real):
+                self._real = real
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def unmount(self, _p, _z=None):
+                return True
+
+        monkeypatch.setattr(nx, "_kernel", _PostUnmountFlakyKernel(nx._kernel))
+        monkeypatch.setattr(
+            nx, "_driver_coordinator", _RecoveringCoordinator(nx._driver_coordinator)
+        )
+
+        with pytest.raises(BackendError, match="cannot verify stranded mount route"):
+            nx.sys_unlink("/post-unmount-fails")
+
+
 class TestImplicitRecursiveStrictRecheck:
     """Codex round-6 finding: post-drain recheck must distinguish
     'verified absent' from 'cannot verify'. A degraded metastore that
@@ -523,6 +670,71 @@ class TestStrandedMountRecovery:
 
         assert result == {}
         assert unmount_calls == ["/stranded-mount"]
+
+    def test_unmount_uses_metadata_zone_not_caller_zone(self, nx, monkeypatch):
+        """Codex round-8 finding: route zone must come from pre-delete
+        FileMetadata, not the caller context. An admin operating from
+        the root zone deleting a tenant mount must tear down the route
+        in the tenant's zone, not in root."""
+        from nexus.contracts.metadata import FileMetadata
+
+        captured: list = []
+
+        class _ExternalResult:
+            hit = False
+            entry_type = 5
+            post_hook_needed = False
+
+        class _ZoneRecordingKernel:
+            def __init__(self, real):
+                self._real = real
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def sys_unlink(self, *_a, **_kw):
+                return _ExternalResult()
+
+            def dispatch_pre_hooks(self, *_a, **_kw):
+                return None
+
+            def has_mount(self, p, z):
+                captured.append(("has_mount", p, z))
+                return False
+
+        class _ZoneRecordingCoordinator:
+            def __init__(self, real):
+                self._real = real
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def unmount(self, p, z=None):
+                captured.append(("unmount", p, z))
+                return True
+
+        # Pre-delete metadata reports the mount lives in tenant-A.
+        tenant_meta = FileMetadata(
+            path="/tenant-mount",
+            content_id=None,
+            mime_type="inode/external_storage",
+            size=0,
+            zone_id="tenant-A",
+        )
+        monkeypatch.setattr(nx.metadata, "get", lambda _p: tenant_meta)
+        monkeypatch.setattr(nx, "_kernel", _ZoneRecordingKernel(nx._kernel))
+        monkeypatch.setattr(
+            nx, "_driver_coordinator", _ZoneRecordingCoordinator(nx._driver_coordinator)
+        )
+
+        nx.sys_unlink("/tenant-mount")
+
+        unmount_calls = [c for c in captured if c[0] == "unmount"]
+        has_mount_calls = [c for c in captured if c[0] == "has_mount"]
+        assert unmount_calls == [("unmount", "/tenant-mount", "tenant-A")]
+        assert all(c[2] == "tenant-A" for c in has_mount_calls), (
+            "has_mount must probe the metadata zone, not caller zone"
+        )
 
     def test_zone_id_propagated_to_unmount_external_storage(self, nx, monkeypatch):
         """Codex round-7 finding: external-storage teardown must pass

--- a/tests/unit/core/test_nexus_fs_delete_batch.py
+++ b/tests/unit/core/test_nexus_fs_delete_batch.py
@@ -1,0 +1,73 @@
+"""Regression tests for NexusFS.delete_batch() — Issue #4002.
+
+Covers:
+- Result keys preserve the caller's literal request path (no leading-slash
+  rewrite), matching write_batch / exists_batch / read_bulk shape.
+- Files written via write_batch are actually deleted (no divergence between
+  the existence check inside delete_batch and the rest of the API).
+- Missing files report "File not found" under the literal request key.
+- Mixed present/missing batches return one entry per input path.
+"""
+
+import pytest
+
+from tests.conftest import make_test_nexus
+
+
+@pytest.fixture()
+def nx(tmp_path):
+    return make_test_nexus(tmp_path)
+
+
+class TestDeleteBatchRoundTrip:
+    def test_write_then_delete_then_exists(self, nx):
+        path = "delete-test-fresh.json"
+        nx.write_batch([(path, b"hello")])
+        assert nx.exists_batch([path]) == {path: True}
+
+        result = nx.delete_batch([path])
+
+        assert result == {path: {"success": True}}
+        assert nx.exists_batch([path]) == {path: False}
+
+    def test_response_key_matches_request_key_without_leading_slash(self, nx):
+        path = "no-slash.json"
+        nx.write_batch([(path, b"x")])
+
+        result = nx.delete_batch([path])
+
+        assert list(result.keys()) == [path]
+        assert "/" + path not in result
+
+    def test_response_key_matches_request_key_with_leading_slash(self, nx):
+        path = "/with-slash.json"
+        nx.write_batch([(path, b"x")])
+
+        result = nx.delete_batch([path])
+
+        assert list(result.keys()) == [path]
+
+
+class TestDeleteBatchMissing:
+    def test_missing_file_reports_not_found_under_request_key(self, nx):
+        path = "never-existed.json"
+
+        result = nx.delete_batch([path])
+
+        assert result == {path: {"success": False, "error": "File not found"}}
+
+    def test_mixed_present_and_missing(self, nx):
+        present = "exists.json"
+        missing = "ghost.json"
+        nx.write_batch([(present, b"data")])
+
+        result = nx.delete_batch([present, missing])
+
+        assert result[present] == {"success": True}
+        assert result[missing] == {"success": False, "error": "File not found"}
+        assert set(result.keys()) == {present, missing}
+
+
+class TestDeleteBatchEmpty:
+    def test_empty_input_returns_empty_dict(self, nx):
+        assert nx.delete_batch([]) == {}

--- a/tests/unit/core/test_nexus_fs_delete_batch.py
+++ b/tests/unit/core/test_nexus_fs_delete_batch.py
@@ -71,3 +71,78 @@ class TestDeleteBatchMissing:
 class TestDeleteBatchEmpty:
     def test_empty_input_returns_empty_dict(self, nx):
         assert nx.delete_batch([]) == {}
+
+
+class TestDeleteBatchImplicitDirectory:
+    """Codex review: implicit directories (paths with children but no
+    explicit inode) must be deletable through delete_batch when recursive."""
+
+    def test_implicit_dir_recursive_delete(self, nx):
+        nx.write_batch(
+            [
+                ("/parent/child1.txt", b"a"),
+                ("/parent/child2.txt", b"b"),
+            ]
+        )
+        assert nx.exists_batch(["/parent"]) == {"/parent": True}
+
+        result = nx.delete_batch(["/parent"], recursive=True)
+
+        assert result == {"/parent": {"success": True}}
+        assert nx.exists_batch(["/parent/child1.txt", "/parent/child2.txt"]) == {
+            "/parent/child1.txt": False,
+            "/parent/child2.txt": False,
+        }
+
+    def test_implicit_dir_non_recursive_reports_not_empty(self, nx):
+        nx.write_batch([("/parent/child.txt", b"a")])
+
+        result = nx.delete_batch(["/parent"])
+
+        assert result["/parent"]["success"] is False
+        assert "not empty" in result["/parent"]["error"].lower()
+        assert nx.exists_batch(["/parent/child.txt"]) == {"/parent/child.txt": True}
+
+
+class _NonHitResult:
+    hit = False
+    entry_type = 99  # not 0 (not-found) and not 5 (external storage)
+    post_hook_needed = False
+
+
+class _NonHitKernelWrapper:
+    """Wraps the real kernel but forces sys_unlink to return a non-hit
+    with a nonzero entry_type — simulates write-lock timeout / internal
+    abort that Codex flagged as a silent-success path."""
+
+    def __init__(self, real):
+        self._real = real
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+    def sys_unlink(self, *_args, **_kwargs):
+        return _NonHitResult()
+
+
+class TestSysUnlinkNonHit:
+    """Codex review: sys_unlink must surface non-hit kernel results so
+    delete_batch records a real failure instead of phantom success."""
+
+    def test_unknown_entry_type_raises(self, nx, monkeypatch):
+        from nexus.contracts.exceptions import BackendError
+
+        nx.write_batch([("/lock-timeout.txt", b"x")])
+        monkeypatch.setattr(nx, "_kernel", _NonHitKernelWrapper(nx._kernel))
+
+        with pytest.raises(BackendError, match="entry_type=99"):
+            nx.sys_unlink("/lock-timeout.txt")
+
+    def test_delete_batch_reports_failure_on_non_hit(self, nx, monkeypatch):
+        nx.write_batch([("/lock-timeout.txt", b"x")])
+        monkeypatch.setattr(nx, "_kernel", _NonHitKernelWrapper(nx._kernel))
+
+        result = nx.delete_batch(["/lock-timeout.txt"])
+
+        assert result["/lock-timeout.txt"]["success"] is False
+        assert "entry_type=99" in result["/lock-timeout.txt"]["error"]

--- a/tests/unit/core/test_nexus_fs_delete_batch.py
+++ b/tests/unit/core/test_nexus_fs_delete_batch.py
@@ -146,3 +146,539 @@ class TestSysUnlinkNonHit:
 
         assert result["/lock-timeout.txt"]["success"] is False
         assert "entry_type=99" in result["/lock-timeout.txt"]["error"]
+
+
+class TestDeleteBatchSiblingPrefixSafety:
+    """Codex round-2 finding: implicit-dir recursive delete must not leak
+    into sibling paths that share a string prefix."""
+
+    def test_implicit_dir_recursive_does_not_touch_siblings(self, nx):
+        nx.write_batch(
+            [
+                ("/parent/inside.txt", b"a"),
+                ("/parent2/sibling.txt", b"b"),
+                ("/parent-old/legacy.txt", b"c"),
+            ]
+        )
+
+        result = nx.delete_batch(["/parent"], recursive=True)
+
+        assert result == {"/parent": {"success": True}}
+        # Only /parent/* should be gone; siblings sharing the string prefix survive.
+        assert nx.exists_batch(
+            ["/parent/inside.txt", "/parent2/sibling.txt", "/parent-old/legacy.txt"]
+        ) == {
+            "/parent/inside.txt": False,
+            "/parent2/sibling.txt": True,
+            "/parent-old/legacy.txt": True,
+        }
+
+
+class _FailingUnmountCoordinator:
+    def __init__(self, real):
+        self._real = real
+
+    def __getattr__(self, name):
+        return getattr(self._real, name)
+
+    def unmount(self, _path, _zone_id=None):
+        return False
+
+
+class TestDeleteBatchExternalRetrySafety:
+    """Codex round-3 finding: external-storage cleanup must be retry-safe.
+    metadata.delete is committed before the connector teardown so a
+    partial failure cannot leave a stuck mount entry."""
+
+    def test_metadata_deleted_before_unmount(self, nx, monkeypatch):
+        class _ExternalResult:
+            hit = False
+            entry_type = 5
+            post_hook_needed = False
+
+        class _ExternalKernel:
+            def __init__(self, real):
+                self._real = real
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def sys_unlink(self, *_a, **_kw):
+                return _ExternalResult()
+
+            def dispatch_pre_hooks(self, *_a, **_kw):
+                return None
+
+        order: list[str] = []
+        original_delete = nx.metadata.delete
+
+        def tracking_delete(p):
+            order.append("metadata.delete")
+            return original_delete(p)
+
+        class _TrackingCoordinator:
+            def __init__(self, real):
+                self._real = real
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def unmount(self, _p, _z=None):
+                order.append("unmount")
+                return True
+
+        monkeypatch.setattr(nx, "_kernel", _ExternalKernel(nx._kernel))
+        monkeypatch.setattr(nx.metadata, "delete", tracking_delete)
+        monkeypatch.setattr(nx, "_driver_coordinator", _TrackingCoordinator(nx._driver_coordinator))
+
+        nx.sys_unlink("/external-mount")
+
+        assert order == ["metadata.delete", "unmount"]
+
+    def test_unmount_false_after_metadata_delete_succeeds(self, nx, monkeypatch):
+        """If teardown returns False after the metadata commit, the call
+        still succeeds (idempotent retry path) — kernel won't see et=5
+        on a subsequent call."""
+
+        class _ExternalResult:
+            hit = False
+            entry_type = 5
+            post_hook_needed = False
+
+        class _ExternalKernel:
+            def __init__(self, real):
+                self._real = real
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def sys_unlink(self, *_a, **_kw):
+                return _ExternalResult()
+
+            def dispatch_pre_hooks(self, *_a, **_kw):
+                return None
+
+        monkeypatch.setattr(nx, "_kernel", _ExternalKernel(nx._kernel))
+        monkeypatch.setattr(
+            nx, "_driver_coordinator", _FailingUnmountCoordinator(nx._driver_coordinator)
+        )
+
+        # Should NOT raise — metadata is committed, teardown is best-effort.
+        result = nx.sys_unlink("/external-mount")
+        assert result == {}
+
+
+class TestDeleteBatchImplicitNestedExplicit:
+    """Codex round-3 finding: implicit recursive delete must drain
+    explicit child directories leaf-first so it doesn't fail with
+    Directory not empty halfway through."""
+
+    def test_implicit_parent_with_explicit_nested_dir(self, nx):
+        # /implicit-parent has no explicit inode, but contains an
+        # explicit child dir (/implicit-parent/sub) with files.
+        nx.write_batch(
+            [
+                ("/implicit-parent/sub/leaf1.txt", b"a"),
+                ("/implicit-parent/sub/leaf2.txt", b"b"),
+                ("/implicit-parent/top.txt", b"c"),
+            ]
+        )
+
+        result = nx.delete_batch(["/implicit-parent"], recursive=True)
+
+        assert result == {"/implicit-parent": {"success": True}}
+        assert nx.exists_batch(
+            [
+                "/implicit-parent/sub/leaf1.txt",
+                "/implicit-parent/sub/leaf2.txt",
+                "/implicit-parent/top.txt",
+            ]
+        ) == {
+            "/implicit-parent/sub/leaf1.txt": False,
+            "/implicit-parent/sub/leaf2.txt": False,
+            "/implicit-parent/top.txt": False,
+        }
+
+
+class TestDeleteHookMetadataPropagation:
+    """Codex round-4 finding: post-delete hook must receive pre-delete
+    FileMetadata so SnapshotWriteHook (and other rollback hooks) can
+    record original state instead of returning early on metadata=None."""
+
+    def test_delete_hook_receives_pre_delete_metadata(self, nx, monkeypatch):
+        nx.write_batch([("/tracked.txt", b"original-bytes")])
+        captured: list = []
+
+        class _CapturingKernel:
+            def __init__(self, real):
+                self._real = real
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def dispatch_post_hooks(self, name, ctx):
+                captured.append((name, ctx))
+                return self._real.dispatch_post_hooks(name, ctx)
+
+        monkeypatch.setattr(nx, "_kernel", _CapturingKernel(nx._kernel))
+
+        nx.delete_batch(["/tracked.txt"])
+
+        delete_calls = [c for c in captured if c[0] == "delete"]
+        assert delete_calls, "post-delete hook was not dispatched"
+        ctx = delete_calls[0][1]
+        assert ctx.metadata is not None, "DeleteHookContext.metadata must be populated"
+        assert ctx.metadata.path == "/tracked.txt"
+        assert ctx.metadata.size == len(b"original-bytes")
+
+
+class TestExternalRouteRemainsFailure:
+    """Codex round-4 finding: if mount route remains after teardown the
+    sys_unlink must surface the failure even when metadata is committed,
+    so callers can detect a real teardown failure instead of phantom
+    success."""
+
+    def test_route_remains_raises_backend_error(self, nx, monkeypatch):
+        from nexus.contracts.exceptions import BackendError
+
+        class _ExternalResult:
+            hit = False
+            entry_type = 5
+            post_hook_needed = False
+
+        class _LingeringMountKernel:
+            def __init__(self, real):
+                self._real = real
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def sys_unlink(self, *_a, **_kw):
+                return _ExternalResult()
+
+            def dispatch_pre_hooks(self, *_a, **_kw):
+                return None
+
+            def has_mount(self, *_a, **_kw):
+                return True  # route still active after "teardown"
+
+        monkeypatch.setattr(nx, "_kernel", _LingeringMountKernel(nx._kernel))
+        monkeypatch.setattr(
+            nx, "_driver_coordinator", _FailingUnmountCoordinator(nx._driver_coordinator)
+        )
+
+        with pytest.raises(BackendError, match="mount route remains"):
+            nx.sys_unlink("/lingering-mount")
+
+
+class TestImplicitRecursiveRaceRecheck:
+    """Codex round-4 finding: implicit recursive delete must re-check
+    is_implicit_directory after draining children. A concurrent writer
+    that adds a descendant between list_iter and finalize must surface
+    as a per-item failure, not phantom success."""
+
+    def test_concurrent_descendant_addition_is_reported(self, nx, monkeypatch):
+        nx.write_batch([("/parent/leaf.txt", b"a")])
+
+        original_unlink = nx.sys_unlink
+        race_triggered = {"done": False}
+
+        def racing_unlink(p, **kw):
+            result = original_unlink(p, **kw)
+            # After we've unlinked the only original child, simulate a
+            # concurrent writer adding a new descendant.
+            if not race_triggered["done"] and p == "/parent/leaf.txt":
+                race_triggered["done"] = True
+                nx.write_batch([("/parent/sneaked-in.txt", b"b")])
+            return result
+
+        monkeypatch.setattr(nx, "sys_unlink", racing_unlink)
+
+        result = nx.delete_batch(["/parent"], recursive=True)
+
+        assert result["/parent"]["success"] is False
+        assert "concurrent" in result["/parent"]["error"].lower()
+
+    def test_concurrent_explicit_inode_recreation_is_reported(self, nx, monkeypatch):
+        """Round-5 broadened race: a writer can also create an explicit
+        inode at the target itself between drain and the finalize
+        re-check. is_implicit_directory alone wouldn't catch that;
+        metadata.get does. Simulate the race by stubbing metadata.get
+        to return a fake explicit entry AFTER the drain runs, so we
+        exercise the re-check logic without needing real-time
+        concurrency."""
+        nx.write_batch([("/parent/leaf.txt", b"a")])
+
+        original_get = nx.metadata.get
+        children_drained = {"done": False}
+
+        class _FakeMeta:
+            path = "/parent"
+            mime_type = "application/octet-stream"
+
+        def post_drain_get(p):
+            if children_drained["done"] and p == "/parent":
+                return _FakeMeta()
+            return original_get(p)
+
+        original_unlink = nx.sys_unlink
+
+        def tracking_unlink(p, **kw):
+            result = original_unlink(p, **kw)
+            if p == "/parent/leaf.txt":
+                children_drained["done"] = True
+            return result
+
+        monkeypatch.setattr(nx.metadata, "get", post_drain_get)
+        monkeypatch.setattr(nx, "sys_unlink", tracking_unlink)
+
+        result = nx.delete_batch(["/parent"], recursive=True)
+
+        assert result["/parent"]["success"] is False
+        assert "concurrent" in result["/parent"]["error"].lower()
+
+
+class TestImplicitRecursiveStrictRecheck:
+    """Codex round-6 finding: post-drain recheck must distinguish
+    'verified absent' from 'cannot verify'. A degraded metastore that
+    raises during the probe must NOT be reported as success."""
+
+    def test_recheck_metastore_failure_reported_as_failure(self, nx, monkeypatch):
+        nx.write_batch([("/parent/leaf.txt", b"a")])
+
+        original_get = nx.metadata.get
+        children_drained = {"done": False}
+
+        def flaky_get(p):
+            if children_drained["done"] and p == "/parent":
+                raise RuntimeError("metastore degraded")
+            return original_get(p)
+
+        original_unlink = nx.sys_unlink
+
+        def tracking_unlink(p, **kw):
+            result = original_unlink(p, **kw)
+            if p == "/parent/leaf.txt":
+                children_drained["done"] = True
+            return result
+
+        monkeypatch.setattr(nx.metadata, "get", flaky_get)
+        monkeypatch.setattr(nx, "sys_unlink", tracking_unlink)
+
+        result = nx.delete_batch(["/parent"], recursive=True)
+
+        assert result["/parent"]["success"] is False
+        assert "could not verify" in result["/parent"]["error"].lower()
+        assert "metastore degraded" in result["/parent"]["error"]
+
+
+class TestStrandedMountRecovery:
+    """Codex round-5 finding: et=0 (kernel reports not-found) plus a
+    live mount route is the signature of an earlier partial teardown.
+    sys_unlink should clean up the stranded route instead of raising
+    NexusFileNotFoundError and leaving an invisible orphan."""
+
+    def test_stranded_mount_is_cleaned_up(self, nx, monkeypatch):
+        unmount_calls: list[str] = []
+
+        class _StrandedMountKernel:
+            def __init__(self, real):
+                self._real = real
+                self._has_mount_calls = 0
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def sys_unlink(self, *_a, **_kw):
+                class R:
+                    hit = False
+                    entry_type = 0  # kernel sees no entry
+                    post_hook_needed = False
+
+                return R()
+
+            def has_mount(self, *_a, **_kw):
+                # First call (probe) returns True → recovery triggers.
+                # After unmount() runs, route is gone → False.
+                self._has_mount_calls += 1
+                return self._has_mount_calls == 1
+
+        class _RecoveringCoordinator:
+            def __init__(self, real):
+                self._real = real
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def unmount(self, p, _z=None):
+                unmount_calls.append(p)
+                return True
+
+        monkeypatch.setattr(nx, "_kernel", _StrandedMountKernel(nx._kernel))
+        monkeypatch.setattr(
+            nx, "_driver_coordinator", _RecoveringCoordinator(nx._driver_coordinator)
+        )
+
+        result = nx.sys_unlink("/stranded-mount")
+
+        assert result == {}
+        assert unmount_calls == ["/stranded-mount"]
+
+    def test_zone_id_propagated_to_unmount_external_storage(self, nx, monkeypatch):
+        """Codex round-7 finding: external-storage teardown must pass
+        the caller's zone_id so non-root tenant mounts are torn down
+        in their own zone instead of no-op'ing against ROOT_ZONE_ID."""
+        captured: list = []
+
+        class _ExternalResult:
+            hit = False
+            entry_type = 5
+            post_hook_needed = False
+
+        class _ZoneCheckingKernel:
+            def __init__(self, real):
+                self._real = real
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def sys_unlink(self, *_a, **_kw):
+                return _ExternalResult()
+
+            def dispatch_pre_hooks(self, *_a, **_kw):
+                return None
+
+            def has_mount(self, _p, _z):
+                return False  # cleanly torn down
+
+        class _ZoneRecordingCoordinator:
+            def __init__(self, real):
+                self._real = real
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def unmount(self, p, z=None):
+                captured.append((p, z))
+                return True
+
+        monkeypatch.setattr(nx, "_kernel", _ZoneCheckingKernel(nx._kernel))
+        monkeypatch.setattr(
+            nx, "_driver_coordinator", _ZoneRecordingCoordinator(nx._driver_coordinator)
+        )
+
+        nx.sys_unlink("/tenant-mount")
+
+        assert len(captured) == 1
+        assert captured[0][0] == "/tenant-mount"
+        # Should pass *some* zone_id (resolved from context); never call
+        # without zone or the DLC default ROOT swallows tenant mounts.
+        assert captured[0][1] is not None
+
+    def test_zone_id_propagated_to_unmount_stranded_recovery(self, nx, monkeypatch):
+        """Stranded-mount recovery path also propagates zone_id."""
+        captured: list = []
+
+        class _StrandedKernel:
+            def __init__(self, real):
+                self._real = real
+                self._has_mount_calls = 0
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def sys_unlink(self, *_a, **_kw):
+                class R:
+                    hit = False
+                    entry_type = 0
+                    post_hook_needed = False
+
+                return R()
+
+            def has_mount(self, *_a, **_kw):
+                self._has_mount_calls += 1
+                return self._has_mount_calls == 1
+
+        class _ZoneRecordingCoordinator:
+            def __init__(self, real):
+                self._real = real
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def unmount(self, p, z=None):
+                captured.append((p, z))
+                return True
+
+        monkeypatch.setattr(nx, "_kernel", _StrandedKernel(nx._kernel))
+        monkeypatch.setattr(
+            nx, "_driver_coordinator", _ZoneRecordingCoordinator(nx._driver_coordinator)
+        )
+
+        nx.sys_unlink("/stranded-tenant-mount")
+
+        assert len(captured) == 1
+        assert captured[0][1] is not None  # zone_id was passed
+
+    def test_stranded_mount_recovery_failure_raises(self, nx, monkeypatch):
+        from nexus.contracts.exceptions import BackendError
+
+        class _PersistentlyStrandedKernel:
+            def __init__(self, real):
+                self._real = real
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def sys_unlink(self, *_a, **_kw):
+                class R:
+                    hit = False
+                    entry_type = 0
+                    post_hook_needed = False
+
+                return R()
+
+            def has_mount(self, *_a, **_kw):
+                return True  # route never goes away
+
+        class _NoOpUnmount:
+            def __init__(self, real):
+                self._real = real
+
+            def __getattr__(self, name):
+                return getattr(self._real, name)
+
+            def unmount(self, _p, _z=None):
+                return True  # claims success but route remains
+
+        monkeypatch.setattr(nx, "_kernel", _PersistentlyStrandedKernel(nx._kernel))
+        monkeypatch.setattr(nx, "_driver_coordinator", _NoOpUnmount(nx._driver_coordinator))
+
+        with pytest.raises(BackendError, match="stranded mount route remains"):
+            nx.sys_unlink("/persistently-stranded")
+
+
+class TestDeleteBatchImplicitDirProbeFailure:
+    """Codex round-2 finding: a degraded is_implicit_directory probe must
+    record per-path failure, not abort the rest of the batch."""
+
+    def test_implicit_dir_probe_failure_isolated(self, nx, monkeypatch):
+        nx.write_batch([("/keeper.txt", b"x")])
+
+        original_probe = nx.metadata.is_implicit_directory
+
+        def flaky_probe(p):
+            if p == "/ghost":
+                raise RuntimeError("metastore degraded")
+            return original_probe(p)
+
+        monkeypatch.setattr(nx.metadata, "is_implicit_directory", flaky_probe)
+
+        # /ghost doesn't exist → sys_unlink raises NexusFileNotFoundError →
+        # the probe runs and raises. Must record per-item failure and
+        # still process /keeper.txt.
+        result = nx.delete_batch(["/ghost", "/keeper.txt"])
+
+        assert result["/ghost"]["success"] is False
+        assert "metastore degraded" in result["/ghost"]["error"]
+        assert result["/keeper.txt"] == {"success": True}


### PR DESCRIPTION
## Summary

- Result keys now preserve the caller's literal request path, matching `write_batch` / `exists_batch` / `read_bulk` (issue #4002 bug 1).
- Existence check delegated to `sys_unlink`, which routes through the same Rust dcache → metastore → implicit-dir path as `access` / `exists_batch`, eliminating the divergence where `exists_batch` saw the file but `delete_batch` reported "File not found" and left it on disk (issue #4002 bug 2).

## Test plan

- [x] `python -m pytest tests/unit/core/test_nexus_fs_delete_batch.py` — 6 new cases pass (round-trip, leading-slash parity, missing under literal key, mixed batch, empty input).
- [x] `python -m pytest tests/unit/core/test_nexus_fs_core.py tests/unit/core/test_nexus_fs_write_batch.py tests/unit/core/test_nexus_fs_read_batch.py tests/unit/services/test_ttl_volume_sweeper.py tests/unit/services/test_mount_service.py tests/unit/bricks/mount/test_mount_core_service.py` — 171 adjacent tests pass, no regressions.

Closes #4002.