### PR TITLE
perf(#3997): right-size _FULL_TUNING + BM25 fast-path + RPC dispatch fixes

### DIFF
--- a/.github/workflows/demo-memory.yml
+++ b/.github/workflows/demo-memory.yml
@@ -1,0 +1,76 @@
+name: Demo Memory Regression
+
+# Issue #3997: idle nexusd RSS regression test for the demo profile.
+# Builds the image, boots nexus-stack compose, polls /healthz/ready,
+# parses /proc/$pid/status from inside the container, asserts the
+# acceptance thresholds (VmRSS<450MB, Threads<20, VmData<4GB).
+#
+# Not blocking PR CI by default — runs on develop push, nightly cron,
+# and manual dispatch. Promote to required-status once stable.
+
+on:
+  push:
+    branches: [develop]
+    paths:
+      - 'Dockerfile'
+      - 'dockerfiles/**'
+      - 'nexus-stack.yml'
+      - 'src/nexus/lib/performance_tuning.py'
+      - 'src/nexus/server/lifespan/**'
+      - 'src/nexus/bricks/search/txtai_backend.py'
+      - 'src/nexus/bricks/search/daemon.py'
+      - 'tests/integration/test_demo_memory.py'
+      - '.github/workflows/demo-memory.yml'
+  schedule:
+    - cron: "0 7 * * *"  # 07:00 UTC nightly
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  demo-memory:
+    name: nexusd demo idle RSS <= 450 MB
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Sync project (test extras)
+        run: uv sync --frozen --extra test
+
+      - name: Build nexus image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          load: true
+          tags: nexus-server:latest
+          build-args: |
+            NEXUS_PROFILE_EXTRAS=all,performance,monitoring,docker,event-streaming,sentry,pay
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Run demo memory regression
+        run: uv run pytest -m demo_memory tests/integration/test_demo_memory.py -v -s
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: |
+          for c in $(docker ps -a --format '{{.Names}}' | grep '^nexus-demo-mem-'); do
+            echo "=== $c ==="
+            docker logs --tail 200 "$c" || true
+          done
+          docker ps -a | grep '^nexus-demo-mem-' || true

--- a/Dockerfile
+++ b/Dockerfile
@@ -177,6 +177,7 @@ RUN set -eux; \
         netcat-openbsd \
         ca-certificates \
         libgomp1 \
+        libjemalloc2 \
         gosu \
     && rm -rf /var/lib/apt/lists/*
 
@@ -190,17 +191,39 @@ RUN set -eux; \
 RUN set -eux; \
     if [ "${TARGETARCH}" = "arm64" ]; then \
         ln -sf /usr/lib/aarch64-linux-gnu/libgomp.so.1 /usr/lib/libgomp.so.1; \
+        ln -sf /usr/lib/aarch64-linux-gnu/libjemalloc.so.2 /usr/lib/libjemalloc.so.2; \
     elif [ "${TARGETARCH}" = "amd64" ]; then \
         ln -sf /usr/lib/x86_64-linux-gnu/libgomp.so.1 /usr/lib/libgomp.so.1; \
+        ln -sf /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 /usr/lib/libjemalloc.so.2; \
     fi; \
     # torch is only installed when extras include 'all' — skip symlink on SANDBOX (#3778).
     if [ -f /usr/local/lib/python3.14/site-packages/torch/lib/libc10.so ]; then \
         ln -sf /usr/local/lib/python3.14/site-packages/torch/lib/libc10.so /usr/lib/libc10.so; \
     fi
-# LD_PRELOAD: libgomp only (always safe). When torch is installed, the entrypoint
-# extends LD_PRELOAD to include libc10.so (see docker-entrypoint.sh).
-ENV LD_PRELOAD="/usr/lib/libgomp.so.1"
+# LD_PRELOAD: jemalloc first (intercepts allocator calls before any other lib),
+# then libgomp. When torch is installed, the entrypoint extends LD_PRELOAD to
+# include libc10.so (see docker-entrypoint.sh). The entrypoint also strips
+# jemalloc from LD_PRELOAD if the .so is missing at runtime (defensive — see T6).
+ENV LD_PRELOAD="/usr/lib/libjemalloc.so.2:/usr/lib/libgomp.so.1"
 ENV GLIBC_TUNABLES="glibc.rtld.optional_static_tls=16384"
+
+# Issue #3997: cap glibc arenas (default 8*cpu_count -> 200-400 MB RSS bloat
+# on threaded Python) and lower trim threshold so free() returns pages to
+# the kernel.
+ENV MALLOC_ARENA_MAX=2 \
+    MALLOC_TRIM_THRESHOLD_=131072
+
+# Issue #3997: cap BLAS worker threads. numpy/torch/sentence-transformers spawn
+# cpu_count BLAS threads at first import; each = 8 MB pthread stack + glibc arena.
+# Caps must be set BEFORE Python imports numpy/torch -> Dockerfile ENV (entrypoint
+# is too late for some import paths). Users opting into local embeddings should
+# override at `docker run -e OMP_NUM_THREADS=N` for throughput.
+# OMP_NUM_THREADS and MKL_ENABLE_INSTRUCTIONS are set in docker-entrypoint.sh
+# (already at value 1) for compatibility with the faiss/torch SIMD-portability
+# defaults, so they are not duplicated here.
+ENV OPENBLAS_NUM_THREADS=1 \
+    NUMEXPR_NUM_THREADS=1 \
+    VECLIB_MAXIMUM_THREADS=1
 
 # ---------- CLI connectors: gws + gh (Issue #3148) ----------
 # gws: Google Workspace CLI for Gmail/Calendar/Drive/Sheets/Docs/Chat connectors
@@ -325,8 +348,11 @@ ENV PYTHONUNBUFFERED=1 \
     NEXUS_PORT=2026 \
     NEXUS_PROFILE=full \
     NEXUS_DATA_DIR=/app/data \
-    NEXUS_TXTAI_RERANKER=cross-encoder/ms-marco-MiniLM-L-2-v2 \
     NEXUS_TXTAI_SPARSE=false
+# Issue #3997: NEXUS_TXTAI_RERANKER is no longer set by default — the
+# cross-encoder/ms-marco model loaded ~300 MB unconditionally. Operators
+# wanting reranking opt in:
+#   -e NEXUS_TXTAI_RERANKER=cross-encoder/ms-marco-MiniLM-L-2-v2
 
 EXPOSE 2026 2126
 

--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -54,6 +54,27 @@ export MKL_ENABLE_INSTRUCTIONS="${MKL_ENABLE_INSTRUCTIONS:-SSE4_2}"
 export ATEN_CPU_CAPABILITY="${ATEN_CPU_CAPABILITY:-default}"
 
 # ---------------------------------------------------------------------------
+# jemalloc safety net (Issue #3997)
+# Dockerfile prepends /usr/lib/libjemalloc.so.2 to LD_PRELOAD via a symlink
+# (per-arch). If the file is missing at runtime (custom base image, broken
+# layer, mount issue), strip it from LD_PRELOAD so the dynamic linker
+# doesn't abort every command in the container. Glibc + MALLOC_ARENA_MAX=2
+# fallback still saves 400-800 MB RSS.
+# ---------------------------------------------------------------------------
+_jemalloc_path="/usr/lib/libjemalloc.so.2"
+if [ -n "${LD_PRELOAD:-}" ] && [ ! -e "$_jemalloc_path" ]; then
+    case ":${LD_PRELOAD}:" in
+        *":${_jemalloc_path}:"*)
+            echo "WARN: ${_jemalloc_path} missing; stripping from LD_PRELOAD (glibc fallback)" >&2
+            export LD_PRELOAD="${LD_PRELOAD//${_jemalloc_path}:/}"
+            export LD_PRELOAD="${LD_PRELOAD//:${_jemalloc_path}/}"
+            export LD_PRELOAD="${LD_PRELOAD//${_jemalloc_path}/}"
+            ;;
+    esac
+fi
+unset _jemalloc_path
+
+# ---------------------------------------------------------------------------
 # LD_PRELOAD fallback (CPU-only)
 # Preloading the system libgomp helps libraries other than faiss that link
 # against the system copy.  On CUDA, LD_PRELOAD conflicts with NVIDIA's

--- a/docs/superpowers/plans/2026-05-02-nexus-idle-rss-tuning.md
+++ b/docs/superpowers/plans/2026-05-02-nexus-idle-rss-tuning.md
@@ -1,0 +1,1289 @@
+# Nexus Idle RSS Tuning Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Drop nexusd demo-profile cold-start RSS from 1.5 GB → ≤450 MB by skipping heavy ML model loads when not opted in, right-sizing pool defaults, capping BLAS threads + glibc arenas, and adding a regression test.
+
+**Architecture:** Six change surfaces — search runtime three-way auto resolver (env-driven default = BM25), txtai BM25 fast-path, `_FULL_TUNING` pool right-sizing, lifespan boot hygiene (stack_size + gc + idle trimmer), Dockerfile allocator/BLAS envs + jemalloc, docker-entrypoint safety net. Backed by a `pytest -m demo_memory` integration test booting the demo compose stack and asserting `/proc/$pid/status` thresholds.
+
+**Tech Stack:** Python 3.14, FastAPI, anyio, SQLAlchemy + asyncpg, txtai (BM25 + pgvector), Docker (Debian slim), glibc, jemalloc, pytest.
+
+**Spec:** `docs/superpowers/specs/2026-05-02-nexus-idle-rss-tuning-design.md`
+**Issue:** #3997
+
+**File map:**
+- Modify: `src/nexus/lib/performance_tuning.py:572-625` (`_FULL_TUNING` numbers)
+- Modify: `tests/unit/core/test_performance_tuning.py:280-347` (assertion updates)
+- Modify: `src/nexus/server/lifespan/search.py:27-49` (three-way resolver)
+- Modify: `src/nexus/server/lifespan/search.py:69-96` (boot-mode log line)
+- Create: `tests/unit/server/lifespan/test_search_runtime_config.py`
+- Modify: `src/nexus/bricks/search/daemon.py:137` (`txtai_model: str | None`)
+- Modify: `src/nexus/bricks/search/txtai_backend.py:_startup_impl` (BM25 fast-path)
+- Create: `tests/unit/bricks/search/test_txtai_backend_bm25_only.py`
+- Modify: `src/nexus/server/lifespan/__init__.py` (boot tweaks + idle trimmer)
+- Create: `tests/unit/server/lifespan/test_boot_tweaks.py`
+- Modify: `Dockerfile:200-203` (jemalloc + LD_PRELOAD + MALLOC + BLAS envs)
+- Modify: `Dockerfile:328-329` (drop NEXUS_TXTAI_RERANKER)
+- Modify: `dockerfiles/docker-entrypoint.sh:62-66` (jemalloc safety net)
+- Create: `tests/integration/test_demo_memory.py`
+- Create: `.github/workflows/demo-memory.yml`
+
+---
+
+## Task 1: Update `_FULL_TUNING` pool numbers
+
+**Files:**
+- Modify: `src/nexus/lib/performance_tuning.py:572-625`
+- Modify: `tests/unit/core/test_performance_tuning.py:287-347`
+
+**Why:** `_FULL_TUNING` defaults are sized for multi-tenant workload but apply to single-process demo. Drop to web-evidence backed values: `thread_pool_size=40` (anyio default), `db_pool=5+5` (Cloud SQL sample), `httpx_max_connections=20`, `connector_max_workers=6`. `_CLOUD_TUNING` untouched — already sized for multi-tenant.
+
+- [ ] **Step 1: Update existing FULL profile assertions to new values**
+
+Edit `tests/unit/core/test_performance_tuning.py` lines 287-347 to assert the new targets. Replace each old number:
+
+```python
+def test_full_concurrency(self) -> None:
+    c = DeploymentProfile.FULL.tuning().concurrency
+    assert c.default_workers == 4
+    assert c.thread_pool_size == 40  # was 200; anyio upstream default (#3997)
+    assert c.max_async_concurrency == 10
+    assert c.task_runner_workers == 4
+
+def test_full_storage(self) -> None:
+    s = DeploymentProfile.FULL.tuning().storage
+    assert s.write_buffer_flush_ms == 100
+    assert s.write_buffer_max_size == 100
+    assert s.changelog_chunk_size == 500
+    assert s.db_pool_size == 5  # was 20; Cloud SQL sample sizing (#3997)
+    assert s.db_max_overflow == 5  # was 30; single-tenant burst (#3997)
+
+def test_full_connector(self) -> None:
+    cn = DeploymentProfile.FULL.tuning().connector
+    assert cn.blob_operation_timeout == 60.0
+    assert cn.large_upload_timeout == 300.0
+    assert cn.connector_max_workers == 6  # was 20; blob ops are I/O-bound (#3997)
+
+def test_full_pool(self) -> None:
+    p = DeploymentProfile.FULL.tuning().pool
+    assert p.asyncpg_min_size == 2
+    assert p.asyncpg_max_size == 5
+    assert p.httpx_max_connections == 20  # was 100; HTTP/2 collapses anyway (#3997)
+    assert p.remote_pool_maxsize == 10  # was 20 (#3997)
+```
+
+- [ ] **Step 2: Run the failing tests**
+
+Run: `uv run pytest tests/unit/core/test_performance_tuning.py::TestConcreteValues -v`
+Expected: 4 failures (concurrency, storage, connector, pool) — values still 200/20+30/20/100+20.
+
+- [ ] **Step 3: Update `_FULL_TUNING` numbers**
+
+Edit `src/nexus/lib/performance_tuning.py:572-625`. Change the six fields:
+
+```python
+_FULL_TUNING = ProfileTuning(
+    concurrency=ConcurrencyTuning(
+        default_workers=4,
+        thread_pool_size=40,  # Issue #3997: was 200; anyio upstream default
+        max_async_concurrency=10,
+        task_runner_workers=4,
+    ),
+    network=NetworkTuning(
+        default_http_timeout=30.0,
+        webhook_timeout=10.0,
+        long_operation_timeout=120.0,
+    ),
+    storage=StorageTuning(
+        write_buffer_flush_ms=100,
+        write_buffer_max_size=100,
+        changelog_chunk_size=500,
+        db_pool_size=5,  # Issue #3997: was 20; Cloud SQL sample
+        db_max_overflow=5,  # Issue #3997: was 30; single-tenant burst
+    ),
+    search=SearchTuning(
+        grep_parallel_workers=4,
+        list_parallel_workers=10,
+        search_max_concurrency=10,
+        vector_pool_workers=2,
+    ),
+    cache=CacheTuning(
+        tiger_max_workers=4,
+        tiger_batch_size=100,
+    ),
+    background_task=BackgroundTaskTuning(
+        sandbox_cleanup_interval=300,
+        session_cleanup_interval=3600,
+        daily_gc_interval=86400,
+        heartbeat_flush_interval=60,
+        stale_agent_check_interval=300,
+        stale_agent_threshold=300,
+    ),
+    resiliency=ResiliencyTuning(
+        default_max_retries=3,
+        retry_base_backoff_ms=50,
+        circuit_breaker_failure_threshold=5,
+        circuit_breaker_timeout=30.0,
+    ),
+    connector=ConnectorTuning(
+        blob_operation_timeout=60.0,
+        large_upload_timeout=300.0,
+        connector_max_workers=6,  # Issue #3997: was 20; I/O-bound
+    ),
+    pool=PoolTuning(
+        asyncpg_min_size=2,
+        asyncpg_max_size=5,
+        httpx_max_connections=20,  # Issue #3997: was 100; HTTP/2 collapses
+        remote_pool_maxsize=10,  # Issue #3997: was 20
+    ),
+    eviction=EvictionTuning(
+        memory_high_watermark_pct=85,
+        memory_low_watermark_pct=75,
+        max_active_agents=1000,
+        eviction_batch_size=20,
+        checkpoint_timeout_seconds=10.0,
+        eviction_cooldown_seconds=60,
+        eviction_poll_interval_seconds=120,
+        checkpoint_cleanup_interval_seconds=3600,
+        checkpoint_max_age_seconds=86400,
+        max_concurrent_transitions=10,
+    ),
+    qos=QoSTuning(
+        premium=QoSClassConfig(
+            max_concurrent_tasks=20, scheduling_weight=3, eviction_priority=2, preemptible=False
+        ),
+        standard=QoSClassConfig(
+            max_concurrent_tasks=10, scheduling_weight=1, eviction_priority=1, preemptible=False
+        ),
+        spot=QoSClassConfig(
+            max_concurrent_tasks=5, scheduling_weight=1, eviction_priority=0, preemptible=True
+        ),
+    ),
+)
+```
+
+- [ ] **Step 4: Run the test, verify pass**
+
+Run: `uv run pytest tests/unit/core/test_performance_tuning.py -v`
+Expected: PASS (all profiles, including monotonicity check `embedded ≤ lite ≤ full ≤ cloud` — full's `thread_pool_size=40` is still ≥ lite's smaller values, ≤ cloud's 400; storage `db_pool_size=5` ≥ embedded's 3 ≥ lite, ≤ cloud's 30 — verify the monotonicity test passes).
+
+If monotonicity fails (lite has higher value than new full), inspect `_LITE_TUNING` at the same file. Expected: lite has 4 thread_pool_size, 2 db_pool_size — both ≤ new full values, so OK.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/lib/performance_tuning.py tests/unit/core/test_performance_tuning.py
+git commit -m "perf(profile): right-size _FULL_TUNING pools for single-tenant (#3997)
+
+thread_pool_size 200→40 (anyio upstream default)
+db_pool_size 20→5, db_max_overflow 30→5 (Cloud SQL sample)
+httpx_max_connections 100→20, remote_pool_maxsize 20→10
+connector_max_workers 20→6"
+```
+
+---
+
+## Task 2: Search runtime three-way auto resolver
+
+**Files:**
+- Modify: `src/nexus/server/lifespan/search.py:27-49`
+- Create: `tests/unit/server/lifespan/test_search_runtime_config.py`
+
+**Why:** Today `_resolve_txtai_runtime_config` always returns a model string (defaults to `sentence-transformers/all-MiniLM-L6-v2` → 900 MB at boot). After this task: returns `(None, None)` when no key + no explicit local model — txtai backend (Task 3) takes BM25 fast-path. OpenAI key → API embeddings. Explicit local → opt-in heavy.
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `tests/unit/server/lifespan/test_search_runtime_config.py`:
+
+```python
+"""Three-way auto-resolution for txtai runtime (Issue #3997).
+
+Default (no env): BM25 keyword-only — no model load.
+OPENAI_API_KEY set: API embeddings — ~0 RAM.
+NEXUS_TXTAI_MODEL=local: opt-in heavy load.
+"""
+
+import pytest
+
+from nexus.server.lifespan.search import _resolve_txtai_runtime_config
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    for k in (
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+        "NEXUS_TXTAI_MODEL",
+        "NEXUS_TXTAI_USE_API_EMBEDDINGS",
+    ):
+        monkeypatch.delenv(k, raising=False)
+
+
+def test_default_returns_bm25():
+    """No env -> (None, None) -> BM25 keyword-only path."""
+    assert _resolve_txtai_runtime_config() == (None, None)
+
+
+def test_openai_key_only(monkeypatch):
+    """OPENAI_API_KEY alone -> openai/text-embedding-3-small with key."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    model, vectors = _resolve_txtai_runtime_config()
+    assert model == "openai/text-embedding-3-small"
+    assert vectors == {"api_key": "sk-test"}
+
+
+def test_openai_key_with_base_url(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://proxy.example/v1")
+    model, vectors = _resolve_txtai_runtime_config()
+    assert model == "openai/text-embedding-3-small"
+    assert vectors == {"api_key": "sk-test", "api_base": "https://proxy.example/v1"}
+
+
+def test_explicit_local_model_wins_over_key(monkeypatch):
+    """User-set local model overrides API mode even when key is present."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("NEXUS_TXTAI_MODEL", "sentence-transformers/all-MiniLM-L6-v2")
+    model, vectors = _resolve_txtai_runtime_config()
+    assert model == "sentence-transformers/all-MiniLM-L6-v2"
+    assert vectors is None
+
+
+def test_explicit_local_model_no_key(monkeypatch):
+    """User-set local model without key still loads locally."""
+    monkeypatch.setenv("NEXUS_TXTAI_MODEL", "sentence-transformers/all-mpnet-base-v2")
+    model, vectors = _resolve_txtai_runtime_config()
+    assert model == "sentence-transformers/all-mpnet-base-v2"
+    assert vectors is None
+
+
+def test_explicit_openai_model_uses_key(monkeypatch):
+    """Explicit openai/* model + key -> use API."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("NEXUS_TXTAI_MODEL", "openai/text-embedding-3-large")
+    model, vectors = _resolve_txtai_runtime_config()
+    assert model == "openai/text-embedding-3-large"
+    assert vectors == {"api_key": "sk-test"}
+
+
+def test_use_api_flag_with_key(monkeypatch):
+    """NEXUS_TXTAI_USE_API_EMBEDDINGS=true + key -> default openai model."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("NEXUS_TXTAI_USE_API_EMBEDDINGS", "true")
+    model, vectors = _resolve_txtai_runtime_config()
+    assert model == "openai/text-embedding-3-small"
+    assert vectors == {"api_key": "sk-test"}
+
+
+def test_use_api_flag_no_key(monkeypatch):
+    """NEXUS_TXTAI_USE_API_EMBEDDINGS=true without key -> still BM25 (no key to use)."""
+    monkeypatch.setenv("NEXUS_TXTAI_USE_API_EMBEDDINGS", "true")
+    assert _resolve_txtai_runtime_config() == (None, None)
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+Run: `uv run pytest tests/unit/server/lifespan/test_search_runtime_config.py -v`
+Expected: FAILS — `test_default_returns_bm25` returns `("sentence-transformers/all-MiniLM-L6-v2", None)` instead of `(None, None)`. Several others fail similarly.
+
+- [ ] **Step 3: Update the resolver**
+
+Replace `_resolve_txtai_runtime_config` at `src/nexus/server/lifespan/search.py:27-49` with:
+
+```python
+def _resolve_txtai_runtime_config() -> tuple[str | None, dict[str, str] | None]:
+    """Resolve embedding model + vectors config from env (Issue #3997).
+
+    Three-way auto:
+    - explicit local model (sentence-transformers/...) wins; opt-in to ~900 MB
+    - OPENAI_API_KEY present: API embeddings (~0 RAM)
+    - neither: returns (None, None) -> txtai BM25 keyword-only fast-path
+    """
+    explicit_model = os.environ.get("NEXUS_TXTAI_MODEL", "").strip()
+    openai_api_key = os.environ.get("OPENAI_API_KEY", "").strip()
+    openai_base_url = os.environ.get("OPENAI_BASE_URL", "").strip()
+    use_api_explicit = _env_truthy("NEXUS_TXTAI_USE_API_EMBEDDINGS")
+
+    # Explicit local model wins (heavy opt-in)
+    if explicit_model and not explicit_model.startswith("openai/"):
+        return explicit_model, None
+
+    # OpenAI key present -> API embeddings, ~0 RAM
+    if openai_api_key and (use_api_explicit or not explicit_model or explicit_model.startswith("openai/")):
+        model = explicit_model or "openai/text-embedding-3-small"
+        vectors: dict[str, str] = {"api_key": openai_api_key}
+        if openai_base_url:
+            vectors["api_base"] = openai_base_url
+        return model, vectors
+
+    # No key, no explicit local model -> BM25 keyword-only
+    return None, None
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `uv run pytest tests/unit/server/lifespan/test_search_runtime_config.py -v`
+Expected: 8 PASS.
+
+- [ ] **Step 5: Add boot-mode log line in startup_search**
+
+Edit `src/nexus/server/lifespan/search.py` after `txtai_model, txtai_vectors = _resolve_txtai_runtime_config()` (line 69):
+
+```python
+        txtai_model, txtai_vectors = _resolve_txtai_runtime_config()
+        # Issue #3997: surface mode in boot logs so operators see whether
+        # heavy local model, remote API embeddings, or BM25-only is active.
+        if txtai_model is None:
+            _mode = "bm25-only"
+        elif txtai_model.startswith("openai/"):
+            _mode = "openai-api"
+        else:
+            _mode = "local"
+        logger.info("Search backend mode: %s (model=%s)", _mode, txtai_model or "<none>")
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/nexus/server/lifespan/search.py tests/unit/server/lifespan/test_search_runtime_config.py
+git commit -m "feat(search): three-way runtime config auto-resolve (#3997)
+
+Default (no env) returns (None, None) -> BM25 keyword-only.
+OPENAI_API_KEY -> API embeddings.
+NEXUS_TXTAI_MODEL=sentence-transformers/... -> opt-in local."
+```
+
+---
+
+## Task 3: txtai backend BM25 fast-path
+
+**Files:**
+- Modify: `src/nexus/bricks/search/daemon.py:137` (relax type)
+- Modify: `src/nexus/bricks/search/txtai_backend.py` (`_startup_impl` early branch)
+- Create: `tests/unit/bricks/search/test_txtai_backend_bm25_only.py`
+
+**Why:** When `_resolve_txtai_runtime_config` returns `(None, None)` (Task 2), the backend must skip `Embeddings(config_with_path)` entirely and start in BM25-only mode. Current code unconditionally builds the heavy hybrid config and only falls back to BM25 via try/except. Take the BM25 path intentionally when `model is None`.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/bricks/search/test_txtai_backend_bm25_only.py`:
+
+```python
+"""txtai backend BM25-only fast-path when model is None (Issue #3997)."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.fixture
+def fake_embeddings(monkeypatch):
+    """Replace txtai.Embeddings with a recording mock."""
+    captured: list[dict] = []
+
+    class _FakeEmbeddings:
+        def __init__(self, config=None):
+            captured.append(dict(config) if isinstance(config, dict) else {"_path_form": config})
+
+        def exists(self, *_a, **_kw):  # pragma: no cover - probe path
+            return False
+
+        def load(self, *_a, **_kw):  # pragma: no cover
+            return None
+
+        def count(self):
+            return 0
+
+        def close(self):
+            return None
+
+    fake_module = MagicMock()
+    fake_module.Embeddings = _FakeEmbeddings
+    monkeypatch.setattr("txtai.Embeddings", _FakeEmbeddings, raising=False)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_bm25_only_path_when_model_is_none(fake_embeddings):
+    """model=None -> single Embeddings({keyword:True, ...}) call, no model path."""
+    from nexus.bricks.search.txtai_backend import TxtaiBackend
+
+    backend = TxtaiBackend(
+        model=None,
+        vectors=None,
+        reranker=None,
+        sparse=False,
+        graph=False,
+        database_url=None,
+    )
+    await backend._startup_impl()
+
+    # Exactly one Embeddings(...) call, with BM25 config (no "path" key).
+    assert len(fake_embeddings) == 1
+    cfg = fake_embeddings[0]
+    assert cfg.get("keyword") is True
+    assert "path" not in cfg
+    assert backend._hybrid is False
+    assert backend._started is True
+
+
+@pytest.mark.asyncio
+async def test_model_set_takes_normal_path(fake_embeddings):
+    """model='openai/...' -> Embeddings(config_with_path) called normally."""
+    from nexus.bricks.search.txtai_backend import TxtaiBackend
+
+    backend = TxtaiBackend(
+        model="openai/text-embedding-3-small",
+        vectors={"api_key": "sk-x"},
+        reranker=None,
+        sparse=False,
+        graph=False,
+        database_url=None,
+    )
+    await backend._startup_impl()
+
+    # First call should include "path" (heavy mode), not just keyword=True.
+    assert any("path" in c for c in fake_embeddings)
+```
+
+Adjust the `TxtaiBackend(...)` constructor argument names to match the actual class signature — read `src/nexus/bricks/search/txtai_backend.py` for the `__init__` signature first if these don't match.
+
+- [ ] **Step 2: Run test, verify failure**
+
+Run: `uv run pytest tests/unit/bricks/search/test_txtai_backend_bm25_only.py -v`
+Expected: FAIL — current code calls `Embeddings(config_with_path=...)` even when model=None (today model defaults to sentence-transformers).
+
+- [ ] **Step 3: Relax `DaemonConfig.txtai_model` type**
+
+Edit `src/nexus/bricks/search/daemon.py:137`:
+
+```python
+    # txtai backend config (Issue #2663, #3997: optional for BM25-only mode)
+    txtai_model: str | None = None  # None -> BM25 keyword-only fast-path
+    txtai_vectors: dict[str, Any] | None = None
+```
+
+(Default flipped from `"sentence-transformers/all-MiniLM-L6-v2"` to `None`. Reason: with the resolver fix, the default-None case is the most common one; explicit string callers still work.)
+
+- [ ] **Step 4: Add BM25 fast-path branch in `_startup_impl`**
+
+Edit `src/nexus/bricks/search/txtai_backend.py:_startup_impl`. After the `try: from txtai import Embeddings` block (after line 357) and before the GPU detection block (line 359), insert:
+
+```python
+        # Issue #3997: BM25 fast-path. When no embedding model is configured
+        # (resolver returned (None, None) — typical default deploy), skip the
+        # heavy Embeddings(path=...) load and start txtai with keyword-only
+        # config directly. Saves ~900 MB RSS at boot.
+        if self._model is None:
+            content_store: bool | str = self._database_url or True
+            bm25_config: dict[str, Any] = {
+                "keyword": True,
+                "content": content_store,
+                "objects": True,
+            }
+            try:
+                self._embeddings = Embeddings(bm25_config)
+                self._hybrid = False
+                self._started = True
+                self._configure_litellm()
+                logger.info(
+                    "txtai backend started in BM25-only mode "
+                    "(no embedding model configured)"
+                )
+                return
+            except Exception:
+                logger.error(
+                    "BM25-only init failed; entering degraded mode (no results).",
+                    exc_info=True,
+                )
+                self._embeddings = None
+                self._started = True
+                return
+```
+
+- [ ] **Step 5: Run test, verify pass**
+
+Run: `uv run pytest tests/unit/bricks/search/test_txtai_backend_bm25_only.py -v`
+Expected: 2 PASS.
+
+- [ ] **Step 6: Run wider txtai tests to ensure no regression**
+
+Run: `uv run pytest tests/unit/bricks/search/ tests/integration/bricks/search/ -v -x`
+Expected: PASS. If any test asserts model is always set, update it to allow `None`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/nexus/bricks/search/daemon.py src/nexus/bricks/search/txtai_backend.py tests/unit/bricks/search/test_txtai_backend_bm25_only.py
+git commit -m "feat(search): BM25-only fast-path when no model configured (#3997)
+
+DaemonConfig.txtai_model now Optional[str], default None.
+TxtaiBackend._startup_impl skips Embeddings(path=...) when model is None,
+goes straight to keyword+content+objects config. Saves ~900 MB RSS at boot."
+```
+
+---
+
+## Task 4: Lifespan boot tweaks (stack_size, gc, idle trimmer)
+
+**Files:**
+- Modify: `src/nexus/server/lifespan/__init__.py` (add to lifespan ctx + new helper)
+- Create: `tests/unit/server/lifespan/test_boot_tweaks.py`
+
+**Why:** Cap pthread stack 8 MB → 1 MB, reduce GC frequency, freeze boot-time heap, run a 60s idle trimmer that calls `gc.collect()` + `malloc_trim(0)` to release memory back to the kernel during long-running idle periods.
+
+- [ ] **Step 1: Write the failing test**
+
+Create `tests/unit/server/lifespan/test_boot_tweaks.py`:
+
+```python
+"""Lifespan boot-time memory tweaks (Issue #3997)."""
+
+import asyncio
+import gc
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_apply_boot_tweaks_sets_stack_size_and_gc_threshold():
+    """_apply_boot_tweaks sets 1 MB stack and adjusted GC threshold."""
+    from nexus.server.lifespan import _apply_boot_tweaks
+
+    orig_stack = threading.stack_size()
+    orig_thresh = gc.get_threshold()
+    try:
+        _apply_boot_tweaks()
+        assert threading.stack_size() == 1 << 20
+        assert gc.get_threshold() == (50_000, 10, 10)
+    finally:
+        # Restore for other tests
+        threading.stack_size(orig_stack)
+        gc.set_threshold(*orig_thresh)
+
+
+@pytest.mark.asyncio
+async def test_idle_trimmer_invokes_gc_and_malloc_trim():
+    """_idle_trimmer calls gc.collect + libc.malloc_trim per tick."""
+    from nexus.server.lifespan import _idle_trimmer
+
+    fake_libc = MagicMock()
+    fake_libc.malloc_trim = MagicMock(return_value=1)
+
+    with patch("ctypes.CDLL", return_value=fake_libc), patch(
+        "asyncio.sleep", side_effect=[None, asyncio.CancelledError()]
+    ):
+        with patch("gc.collect") as mock_collect:
+            with pytest.raises(asyncio.CancelledError):
+                await _idle_trimmer()
+            assert mock_collect.call_count >= 1
+            assert fake_libc.malloc_trim.call_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_idle_trimmer_disabled_when_libc_unavailable():
+    """_idle_trimmer exits cleanly when libc.so.6 not loadable (musl/Alpine)."""
+    from nexus.server.lifespan import _idle_trimmer
+
+    with patch("ctypes.CDLL", side_effect=OSError("no libc")):
+        # Should return normally without hanging or raising
+        await asyncio.wait_for(_idle_trimmer(), timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_idle_trimmer_disabled_when_malloc_trim_missing():
+    """_idle_trimmer exits when symbol absent (not glibc)."""
+    from nexus.server.lifespan import _idle_trimmer
+
+    fake_libc = MagicMock()
+    # Simulate AttributeError on probe
+    type(fake_libc).malloc_trim = property(
+        fget=lambda self: (_ for _ in ()).throw(AttributeError("no symbol"))
+    )
+
+    with patch("ctypes.CDLL", return_value=fake_libc):
+        await asyncio.wait_for(_idle_trimmer(), timeout=1.0)
+```
+
+- [ ] **Step 2: Run test, verify failure**
+
+Run: `uv run pytest tests/unit/server/lifespan/test_boot_tweaks.py -v`
+Expected: FAIL — `_apply_boot_tweaks` and `_idle_trimmer` don't exist.
+
+- [ ] **Step 3: Add helpers + wire into lifespan**
+
+Edit `src/nexus/server/lifespan/__init__.py`. At the top of the file (after existing imports), add:
+
+```python
+import ctypes
+import gc
+import threading
+```
+
+Add these helpers between the existing `_wire_query_observer` function (line 105) and the `@asynccontextmanager`-decorated `lifespan` (line 127):
+
+```python
+def _apply_boot_tweaks() -> None:
+    """Apply Python-level memory hygiene at lifespan startup (Issue #3997).
+
+    Must be called before the first thread is spawned and before any heavy
+    module is imported, so the new stack size and GC threshold take effect
+    for everything that follows.
+
+    - threading.stack_size(1 << 20): cap pthread stack 8 MB -> 1 MB
+      (~250 MB VmData savings over 32 threads, near-zero RSS impact).
+    - gc.set_threshold(50_000, 10, 10): fewer GC pauses (~20% latency win).
+    """
+    threading.stack_size(1 << 20)
+    gc.set_threshold(50_000, 10, 10)
+
+
+async def _idle_trimmer() -> None:
+    """Background task: every 60s, gc.collect() + malloc_trim(0) (Issue #3997).
+
+    Releases freed heap pages back to the kernel during long-running idle
+    periods. Glibc-only (no-op on musl/Alpine).
+    """
+    try:
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        _probe = libc.malloc_trim  # raises AttributeError if symbol missing
+    except (OSError, AttributeError):
+        logger.info("malloc_trim unavailable, idle trimmer disabled")
+        return
+
+    while True:
+        await asyncio.sleep(60)
+        try:
+            gc.collect()
+            libc.malloc_trim(0)
+        except Exception:
+            logger.exception("idle_trimmer iteration failed")
+```
+
+Then modify the `lifespan` async context manager. After line 147 `bg_tasks: list[asyncio.Task] = []`, insert as the very first action:
+
+```python
+    # Issue #3997: apply boot-time memory hygiene before any thread spawn or
+    # heavy import. Must run before svc init since LifespanServices.from_app
+    # may touch threadpool state.
+    _apply_boot_tweaks()
+```
+
+After the existing `_wire_query_observer(app, svc)` call (line 216) and immediately before the `yield` (line 218), insert:
+
+```python
+    # Issue #3997: idle trimmer + freeze boot-time heap.
+    # gc.freeze() moves all currently-tracked objects to a permanent generation
+    # so they are not scanned by future GC cycles. Must run AFTER all warmup
+    # imports/services have completed.
+    bg_tasks.append(asyncio.create_task(_idle_trimmer(), name="idle_trimmer"))
+    gc.freeze()
+```
+
+- [ ] **Step 4: Run test, verify pass**
+
+Run: `uv run pytest tests/unit/server/lifespan/test_boot_tweaks.py -v`
+Expected: 4 PASS.
+
+- [ ] **Step 5: Run wider lifespan tests**
+
+Run: `uv run pytest tests/unit/server/lifespan/ tests/integration/server/lifespan/ -v -x`
+Expected: PASS. If any existing test holds reference to `gc.get_threshold()` defaults, update or skip it.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/nexus/server/lifespan/__init__.py tests/unit/server/lifespan/test_boot_tweaks.py
+git commit -m "perf(lifespan): boot tweaks + idle trimmer (#3997)
+
+threading.stack_size 8M->1M, gc.set_threshold tuned, gc.freeze after warmup,
+60s background _idle_trimmer (gc.collect + malloc_trim) for long-running
+idle release. Glibc-only; no-op on musl/Alpine."
+```
+
+---
+
+## Task 5: Dockerfile — jemalloc + MALLOC + BLAS envs, drop reranker
+
+**Files:**
+- Modify: `Dockerfile:180-203` (add libjemalloc2 install + MALLOC + BLAS envs)
+- Modify: `Dockerfile:328-329` (drop NEXUS_TXTAI_RERANKER hardcode)
+
+**Why:** Image-level allocator + thread caps. `MALLOC_ARENA_MAX=2` saves 400-800 MB RSS by capping glibc arenas (default `8 × cpu_count`). jemalloc preload saves another 300-600 MB by replacing glibc malloc entirely. BLAS thread caps prevent numpy/torch from spawning `cpu_count` worker threads at import (each = 8 MB stack + arena). Drop hardcoded reranker — opt-in only when user sets `NEXUS_TXTAI_RERANKER`.
+
+- [ ] **Step 1: Add libjemalloc2 to apt install**
+
+Edit `Dockerfile:180`. Find the `apt-get install -y --no-install-recommends \` block ending around line 181 with `gosu`. Add `libjemalloc2` to the list. Current code:
+
+```dockerfile
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        # ... existing packages ...
+        gosu \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+Append `libjemalloc2`:
+
+```dockerfile
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        # ... existing packages ...
+        gosu \
+        libjemalloc2 \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+(If you can't see the exact existing list, run: `sed -n '175,185p' Dockerfile` to confirm the block, then insert `libjemalloc2 \` before the `&& rm -rf` line.)
+
+- [ ] **Step 2: Update LD_PRELOAD + add MALLOC + BLAS envs**
+
+Edit `Dockerfile:200-203`. Replace:
+
+```dockerfile
+# LD_PRELOAD: libgomp only (always safe). When torch is installed, the entrypoint
+# extends LD_PRELOAD to include libc10.so (see docker-entrypoint.sh).
+ENV LD_PRELOAD="/usr/lib/libgomp.so.1"
+ENV GLIBC_TUNABLES="glibc.rtld.optional_static_tls=16384"
+```
+
+With:
+
+```dockerfile
+# LD_PRELOAD: jemalloc first (must intercept allocator calls before any other lib),
+# then libgomp. When torch is installed, the entrypoint extends LD_PRELOAD to
+# include libc10.so (see docker-entrypoint.sh). The entrypoint also strips
+# jemalloc from LD_PRELOAD if the .so is missing at runtime (defensive).
+ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libjemalloc.so.2:/usr/lib/libgomp.so.1"
+ENV GLIBC_TUNABLES="glibc.rtld.optional_static_tls=16384"
+
+# Issue #3997: cap glibc arenas (default 8*cpu_count -> 200-400 MB RSS bloat
+# on threaded Python) and lower trim threshold so free() returns pages to
+# the kernel.
+ENV MALLOC_ARENA_MAX=2 \
+    MALLOC_TRIM_THRESHOLD_=131072
+
+# Issue #3997: cap BLAS worker threads. numpy/torch/sentence-transformers spawn
+# cpu_count BLAS threads at first import; each = 8 MB pthread stack + glibc arena.
+# Caps must be set BEFORE Python imports numpy/torch -> Dockerfile ENV (entrypoint
+# is too late for some import paths). Users opting into local embeddings should
+# override at `docker run -e OMP_NUM_THREADS=N` for throughput.
+ENV OPENBLAS_NUM_THREADS=1 \
+    NUMEXPR_NUM_THREADS=1 \
+    VECLIB_MAXIMUM_THREADS=1
+# Note: OMP_NUM_THREADS and MKL_ENABLE_INSTRUCTIONS are set in
+# docker-entrypoint.sh (already at value 1) for compatibility with the
+# faiss/torch SIMD-portability defaults.
+```
+
+- [ ] **Step 3: Drop the NEXUS_TXTAI_RERANKER hardcode**
+
+Edit `Dockerfile:322-329`. Current:
+
+```dockerfile
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    NEXUS_HOST=0.0.0.0 \
+    NEXUS_PORT=2026 \
+    NEXUS_PROFILE=full \
+    NEXUS_DATA_DIR=/app/data \
+    NEXUS_TXTAI_RERANKER=cross-encoder/ms-marco-MiniLM-L-2-v2 \
+    NEXUS_TXTAI_SPARSE=false
+```
+
+Change to:
+
+```dockerfile
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    NEXUS_HOST=0.0.0.0 \
+    NEXUS_PORT=2026 \
+    NEXUS_PROFILE=full \
+    NEXUS_DATA_DIR=/app/data \
+    NEXUS_TXTAI_SPARSE=false
+# Issue #3997: NEXUS_TXTAI_RERANKER is no longer set by default — the
+# cross-encoder/ms-marco model loaded ~300 MB unconditionally. Operators
+# wanting reranking opt in: -e NEXUS_TXTAI_RERANKER=cross-encoder/ms-marco-MiniLM-L-2-v2
+```
+
+- [ ] **Step 4: Build and confirm jemalloc package present**
+
+Run: `docker build --target builder -t nexus:rss-test . 2>&1 | tail -20`
+Expected: builds without error.
+
+Then: `docker build -t nexus:rss-test .` (full build).
+
+Confirm jemalloc:
+```bash
+docker run --rm nexus:rss-test ls -la /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+```
+Expected: file exists, ~600 KB.
+
+Confirm envs:
+```bash
+docker run --rm nexus:rss-test env | grep -E "MALLOC|OPENBLAS|NUMEXPR|VECLIB|LD_PRELOAD" | sort
+```
+Expected:
+```
+LD_PRELOAD=/usr/lib/x86_64-linux-gnu/libjemalloc.so.2:/usr/lib/libgomp.so.1
+MALLOC_ARENA_MAX=2
+MALLOC_TRIM_THRESHOLD_=131072
+NUMEXPR_NUM_THREADS=1
+OPENBLAS_NUM_THREADS=1
+VECLIB_MAXIMUM_THREADS=1
+```
+
+Confirm reranker dropped:
+```bash
+docker run --rm nexus:rss-test env | grep NEXUS_TXTAI_RERANKER
+```
+Expected: empty output.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add Dockerfile
+git commit -m "perf(docker): jemalloc + MALLOC + BLAS caps; drop reranker hardcode (#3997)
+
+Install libjemalloc2, prepend to LD_PRELOAD. Cap glibc arenas
+(MALLOC_ARENA_MAX=2) + lower trim threshold. Cap OPENBLAS/NUMEXPR/
+VECLIB to 1 thread. Drop hardcoded NEXUS_TXTAI_RERANKER (~300 MB
+unconditional load) — operators opt in instead."
+```
+
+---
+
+## Task 6: Entrypoint safety net — strip jemalloc if missing
+
+**Files:**
+- Modify: `dockerfiles/docker-entrypoint.sh:60-67`
+
+**Why:** If `libjemalloc.so.2` is missing at runtime (custom image, base diverges, mount issue), the dynamic linker would fail every binary in the container. Defensive check: probe the file, log warning, strip from LD_PRELOAD before continuing. Falls back to glibc + arena cap (which still saves 400-800 MB).
+
+- [ ] **Step 1: Add safety net at top of entrypoint**
+
+Edit `dockerfiles/docker-entrypoint.sh`. Insert this block at line 56 (after the SIMD/OMP defaults at lines 51-54, before the existing `# LD_PRELOAD fallback` block at line 57):
+
+```bash
+# ---------------------------------------------------------------------------
+# jemalloc safety net (Issue #3997)
+# Dockerfile prepends /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 to LD_PRELOAD.
+# If the file is missing at runtime (custom base image, broken layer, etc.),
+# strip it so the dynamic linker doesn't abort every command in the container.
+# Glibc + MALLOC_ARENA_MAX=2 fallback still saves 400-800 MB RSS.
+# ---------------------------------------------------------------------------
+_jemalloc_path="/usr/lib/x86_64-linux-gnu/libjemalloc.so.2"
+if [ -n "${LD_PRELOAD:-}" ] && [ ! -e "$_jemalloc_path" ]; then
+    case ":${LD_PRELOAD}:" in
+        *":${_jemalloc_path}:"*)
+            echo "WARN: ${_jemalloc_path} missing; stripping from LD_PRELOAD (glibc fallback)" >&2
+            export LD_PRELOAD="${LD_PRELOAD//${_jemalloc_path}:/}"
+            export LD_PRELOAD="${LD_PRELOAD//:${_jemalloc_path}/}"
+            export LD_PRELOAD="${LD_PRELOAD//${_jemalloc_path}/}"
+            ;;
+    esac
+fi
+unset _jemalloc_path
+```
+
+- [ ] **Step 2: Smoke test the strip logic locally**
+
+Run a quick bash test (no Docker needed):
+
+```bash
+bash -c '
+LD_PRELOAD="/missing/jemalloc.so.2:/real/libgomp.so.1"
+_jemalloc_path="/missing/jemalloc.so.2"
+if [ -n "${LD_PRELOAD:-}" ] && [ ! -e "$_jemalloc_path" ]; then
+    case ":${LD_PRELOAD}:" in
+        *":${_jemalloc_path}:"*)
+            export LD_PRELOAD="${LD_PRELOAD//${_jemalloc_path}:/}"
+            export LD_PRELOAD="${LD_PRELOAD//:${_jemalloc_path}/}"
+            export LD_PRELOAD="${LD_PRELOAD//${_jemalloc_path}/}"
+            ;;
+    esac
+fi
+echo "Result: $LD_PRELOAD"
+'
+```
+Expected output: `Result: /real/libgomp.so.1`.
+
+- [ ] **Step 3: Build image and confirm jemalloc still loads end-to-end**
+
+Run: `docker build -t nexus:rss-test .`
+
+Boot a quick container and confirm the entrypoint did NOT strip jemalloc (because it exists):
+```bash
+docker run --rm nexus:rss-test sh -c 'ls -la /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 && echo "LD_PRELOAD=$LD_PRELOAD"'
+```
+Expected: file present + LD_PRELOAD includes both jemalloc and libgomp.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add dockerfiles/docker-entrypoint.sh
+git commit -m "fix(docker): strip jemalloc from LD_PRELOAD if missing (#3997)
+
+Defensive: if /usr/lib/.../libjemalloc.so.2 is missing at runtime
+(custom base, layer issue), strip it from LD_PRELOAD before exec
+so dynamic linker doesn't abort every command. Glibc + arena cap
+fallback still saves 400-800 MB RSS."
+```
+
+---
+
+## Task 7: Demo memory regression test
+
+**Files:**
+- Create: `tests/integration/test_demo_memory.py`
+
+**Why:** Acceptance criterion from issue #3997: pytest test boots demo via Docker, sleeps 30s, asserts `VmRSS_kB < 450 * 1024`, `Threads < 20`, `VmData_kB < 4 * 1024 * 1024`. Marker `@pytest.mark.demo_memory` so it doesn't run in default suite.
+
+- [ ] **Step 1: Register the pytest marker**
+
+Edit `pyproject.toml` (search for `[tool.pytest.ini_options]` or wherever markers are declared). Add `demo_memory` to the markers list:
+
+```toml
+[tool.pytest.ini_options]
+# ... existing config ...
+markers = [
+    # ... existing markers ...
+    "demo_memory: nexusd demo profile RSS regression (slow, requires Docker)",
+]
+```
+
+If markers aren't currently declared, add the section. Verify the existing config block first with: `grep -n "markers" pyproject.toml`.
+
+- [ ] **Step 2: Write the test**
+
+Create `tests/integration/test_demo_memory.py`:
+
+```python
+"""Demo profile cold-start memory regression (Issue #3997).
+
+Boots the demo compose stack, waits for readiness, then reads
+/proc/$pid/status from inside the container and asserts that idle
+RSS, VmData, and thread count are within the targets agreed in the
+issue:
+
+    VmRSS  <= 450 MB
+    VmData <= 4 GB
+    Threads <= 20
+
+Skipped by default. Run with:
+    uv run pytest -m demo_memory tests/integration/test_demo_memory.py -v
+"""
+
+import os
+import shutil
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEMO_COMPOSE = REPO_ROOT / "nexus-stack.yml"  # adjust if demo compose is elsewhere
+PROJECT_PREFIX = "nexus-demo-mem"
+READINESS_TIMEOUT = 60  # seconds
+LAZY_INIT_BUFFER = 30  # seconds (matches issue reproduction)
+RSS_LIMIT_KB = 450 * 1024
+VMDATA_LIMIT_KB = 4 * 1024 * 1024
+THREADS_LIMIT = 20
+
+
+def _docker_available() -> bool:
+    return shutil.which("docker") is not None
+
+
+@pytest.mark.demo_memory
+@pytest.mark.skipif(not _docker_available(), reason="docker CLI not available")
+def test_demo_idle_rss_under_limit():
+    project = f"{PROJECT_PREFIX}-{uuid.uuid4().hex[:8]}"
+    container = f"{project}-nexus-1"
+
+    env = os.environ.copy()
+
+    try:
+        subprocess.check_call(
+            ["docker", "compose", "-p", project, "-f", str(DEMO_COMPOSE), "up", "-d"],
+            env=env,
+            cwd=REPO_ROOT,
+        )
+
+        # Poll readiness up to READINESS_TIMEOUT seconds
+        deadline = time.time() + READINESS_TIMEOUT
+        ready = False
+        while time.time() < deadline:
+            rc = subprocess.call(
+                ["docker", "exec", container, "curl", "-fsS",
+                 "http://localhost:2026/healthz/ready"],
+                stdout=subprocess.DEVNULL, stderr=subprocess.DEVNULL,
+            )
+            if rc == 0:
+                ready = True
+                break
+            time.sleep(2)
+        assert ready, f"{container} did not become ready within {READINESS_TIMEOUT}s"
+
+        # Lazy bg init (skeleton indexer, search daemon hooks)
+        time.sleep(LAZY_INIT_BUFFER)
+
+        # Pull /proc/$pid/status from inside container
+        status = subprocess.check_output(
+            ["docker", "exec", container, "sh", "-c",
+             "pid=$(pgrep -f nexusd | head -1); cat /proc/$pid/status"]
+        ).decode()
+
+        metrics = _parse_proc_status(status)
+
+        # Diagnostics on failure: dump full status + first 20 lines of maps
+        def _diag():
+            try:
+                maps = subprocess.check_output(
+                    ["docker", "exec", container, "sh", "-c",
+                     "pid=$(pgrep -f nexusd | head -1); head -20 /proc/$pid/maps"]
+                ).decode()
+            except Exception as e:
+                maps = f"<diag failed: {e}>"
+            return f"\n--- /proc/$pid/status ---\n{status}\n--- /proc/$pid/maps (head) ---\n{maps}"
+
+        assert metrics["VmRSS_kB"] < RSS_LIMIT_KB, (
+            f"VmRSS={metrics['VmRSS_kB']} kB exceeds {RSS_LIMIT_KB} kB" + _diag()
+        )
+        assert metrics["Threads"] < THREADS_LIMIT, (
+            f"Threads={metrics['Threads']} exceeds {THREADS_LIMIT}" + _diag()
+        )
+        assert metrics["VmData_kB"] < VMDATA_LIMIT_KB, (
+            f"VmData={metrics['VmData_kB']} kB exceeds {VMDATA_LIMIT_KB} kB" + _diag()
+        )
+
+    finally:
+        subprocess.call(
+            ["docker", "compose", "-p", project, "-f", str(DEMO_COMPOSE), "down", "-v"],
+            env=env,
+            cwd=REPO_ROOT,
+        )
+
+
+def _parse_proc_status(blob: str) -> dict[str, int]:
+    """Parse /proc/$pid/status into {VmRSS_kB, VmData_kB, Threads}."""
+    out: dict[str, int] = {}
+    for line in blob.splitlines():
+        if line.startswith("VmRSS:"):
+            out["VmRSS_kB"] = int(line.split()[1])
+        elif line.startswith("VmData:"):
+            out["VmData_kB"] = int(line.split()[1])
+        elif line.startswith("Threads:"):
+            out["Threads"] = int(line.split()[1])
+    missing = {"VmRSS_kB", "VmData_kB", "Threads"} - out.keys()
+    assert not missing, f"could not parse {missing} from /proc/$pid/status"
+    return out
+```
+
+Verify the demo compose path: `ls nexus-stack.yml` from repo root. If demo uses a different file (e.g. `compose.demo.yml`), adjust `DEMO_COMPOSE` accordingly. Look at how the issue reproduces it: `docker compose -p nexus-demo up -d`.
+
+- [ ] **Step 3: Run the test (full Docker round-trip)**
+
+Run: `uv run pytest -m demo_memory tests/integration/test_demo_memory.py -v -s`
+Expected: PASS — VmRSS reported in stdout under 450 MB, threads under 20.
+
+If it fails: read the diagnostic dump in the assertion message. Common causes:
+- jemalloc not preloaded (check LD_PRELOAD inside container)
+- BLAS env not active before numpy import (verify `pip show numpy` location)
+- search daemon still loading model (check `docker logs <container> | grep "Search backend mode"`)
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/integration/test_demo_memory.py pyproject.toml
+git commit -m "test(memory): demo profile RSS regression test (#3997)
+
+pytest -m demo_memory boots demo compose, polls /healthz/ready,
+parses /proc/\$pid/status from inside container.
+Asserts VmRSS<450MB, Threads<20, VmData<4GB.
+Diagnostic dump on failure (full status + maps head)."
+```
+
+---
+
+## Task 8: CI workflow for memory regression
+
+**Files:**
+- Create: `.github/workflows/demo-memory.yml`
+
+**Why:** Run the regression test on `develop` push + nightly cron + manual dispatch. Not blocking PR CI by default — operators can promote to required-status when stable.
+
+- [ ] **Step 1: Inspect existing workflow patterns**
+
+Run: `ls .github/workflows/ | head -10`
+Expected: list of existing workflow files. Pick one (e.g. an integration-test workflow) and read its docker-setup steps to follow the established pattern.
+
+Run: `head -40 .github/workflows/$(ls .github/workflows/ | grep -i 'integration\|test' | head -1)`
+Expected: example of how runners are declared, how docker buildx is set up, how compose-using tests are launched.
+
+- [ ] **Step 2: Create the workflow**
+
+Create `.github/workflows/demo-memory.yml` (adjust runner labels and Python setup steps to match the patterns from Step 1):
+
+```yaml
+name: Demo Memory Regression
+
+on:
+  push:
+    branches: [develop]
+  schedule:
+    - cron: "0 7 * * *"  # 07:00 UTC nightly
+  workflow_dispatch:
+
+jobs:
+  demo-memory:
+    name: nexusd demo idle RSS <= 450 MB
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.14"
+
+      - name: Install uv
+        run: pip install uv
+
+      - name: Install project (test extras only)
+        run: uv sync --frozen --extra test
+
+      - name: Build nexus image
+        run: docker build -t nexus:demo-mem .
+
+      - name: Run demo memory regression
+        run: uv run pytest -m demo_memory tests/integration/test_demo_memory.py -v -s
+        env:
+          # Test target image tag
+          NEXUS_TEST_IMAGE: nexus:demo-mem
+
+      - name: Dump container logs on failure
+        if: failure()
+        run: |
+          for c in $(docker ps -a --format '{{.Names}}' | grep nexus-demo-mem); do
+            echo "=== $c ==="
+            docker logs --tail 200 "$c" || true
+          done
+```
+
+If the test references the locally-built image differently (e.g. compose pulls from registry by default), update `nexus-stack.yml` indirection or pass the image via env override in the test. Match the pattern used by other integration workflows in the repo.
+
+- [ ] **Step 3: Validate the YAML**
+
+Run: `uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/demo-memory.yml'))"`
+Expected: no output (no error).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/demo-memory.yml
+git commit -m "ci: nightly + on-push demo memory regression workflow (#3997)
+
+Runs pytest -m demo_memory against built image. develop push +
+07:00 UTC cron + manual dispatch. Not blocking PR CI by default."
+```
+
+---
+
+## Task 9: End-to-end manual verification
+
+**Files:**
+- None (verification only)
+
+**Why:** Confirm the full stack matches acceptance criteria before opening PR. Catches integration gaps unit tests miss (entrypoint env propagation, compose env passthrough, etc.).
+
+- [ ] **Step 1: Build fresh image**
+
+```bash
+docker build -t nexus:rss-final .
+```
+Expected: clean build.
+
+- [ ] **Step 2: Boot demo, sleep 30, measure**
+
+```bash
+docker compose -p nexus-rss-verify up -d
+sleep 30
+docker exec nexus-rss-verify-nexus-1 sh -c \
+    'pid=$(pgrep -f nexusd | head -1); cat /proc/$pid/status | grep -E "^(VmRSS|VmHWM|VmData|Threads)"'
+```
+Expected: `VmRSS < 460000` (kB), `Threads < 20`, `VmData < 4194304`.
+
+- [ ] **Step 3: Confirm jemalloc loaded**
+
+```bash
+docker exec nexus-rss-verify-nexus-1 sh -c \
+    'pid=$(pgrep -f nexusd | head -1); grep -c jemalloc /proc/$pid/maps'
+```
+Expected: count > 0.
+
+- [ ] **Step 4: Confirm BM25-only mode in logs**
+
+```bash
+docker logs nexus-rss-verify-nexus-1 2>&1 | grep -i "search backend mode"
+```
+Expected: `Search backend mode: bm25-only (model=<none>)`.
+
+- [ ] **Step 5: Confirm no reranker loaded**
+
+```bash
+docker logs nexus-rss-verify-nexus-1 2>&1 | grep -i reranker
+```
+Expected: empty output (or only "Reranker init failed" suppressed because `_reranker_model` is None).
+
+- [ ] **Step 6: Confirm BLAS caps active**
+
+```bash
+docker exec nexus-rss-verify-nexus-1 env | grep -E "OMP|OPENBLAS|MKL|NUMEXPR|VECLIB"
+```
+Expected: all =1.
+
+- [ ] **Step 7: Functional smoke — search still works**
+
+```bash
+ADMIN_KEY=$(docker logs nexus-rss-verify-nexus-1 2>&1 | grep "API Key:" | head -1 | sed -n 's/.*API Key: *//p')
+curl -fsS -H "Authorization: Bearer $ADMIN_KEY" \
+    "http://localhost:2026/api/v2/search/query?q=test&zone_id=root"
+```
+Expected: 200 response with empty or sample results — proves BM25 path works end-to-end.
+
+- [ ] **Step 8: Tear down**
+
+```bash
+docker compose -p nexus-rss-verify down -v
+```
+
+- [ ] **Step 9: If any check fails, capture diagnostic and STOP**
+
+Don't open a PR with failing manual verification. Loop back to the relevant earlier task.
+
+---
+
+## Self-Review
+
+After completing all tasks, this plan has been reviewed against the spec:
+
+**Spec coverage:**
+- Six change surfaces (Section 1) → Tasks 1-6
+- Boot data flow (Section 2) → Tasks 2, 3, 4
+- Component interfaces (Section 3) → Tasks 1-6 produce them
+- Error handling (Section 4) → Task 6 (entrypoint), Task 4 (idle trimmer fallback), Task 3 (BM25 fallback already exists)
+- Testing strategy (Section 5) → Tasks 1-4 (unit), Task 7 (integration), Task 8 (CI)
+
+**Gaps:** None identified. The "behavioral envelopes" table in spec is verified by Task 9.
+
+**Type consistency:** `_resolve_txtai_runtime_config() -> tuple[str | None, dict[str, str] | None]` consistent in Task 2 (signature) and Task 3 (caller passes `model: str | None` to `DaemonConfig.txtai_model: str | None`).
+
+**Placeholder scan:** No "TBD"/"TODO"/"similar to". Each step has actual code or actual command.

--- a/docs/superpowers/specs/2026-05-02-nexus-idle-rss-tuning-design.md
+++ b/docs/superpowers/specs/2026-05-02-nexus-idle-rss-tuning-design.md
@@ -1,0 +1,328 @@
+# Nexus Idle RSS Tuning — Design (Issue #3997)
+
+**Date:** 2026-05-02
+**Issue:** [#3997 — perf: nexusd idle RSS ~1.5 GB on demo profile](https://github.com/nexi-lab/nexus/issues/3997)
+**Status:** Approved design, pending implementation plan
+
+## Problem
+
+`nexusd --config configs/config.demo.yaml` idle RSS = 1.5 GB, VmData = 14 GB, 37 threads. Roughly 4× the sandbox profile target (<400 MB). Single-process Python 3.14 + uvicorn + asyncio in Docker.
+
+## Goal
+
+Demo profile cold-start idle RSS ≤ 450 MB. Idle threads ≤ 20. VmData ≤ 4 GB. Search remains enabled by default (search:true in demo config), but heavy ML models load only when explicitly opted in.
+
+## Root Causes (verified, with citations)
+
+1. **Eager local embedding model load** — `Embeddings(path="sentence-transformers/all-MiniLM-L6-v2")` at `src/nexus/bricks/search/txtai_backend.py:465`, awaited at `src/nexus/server/lifespan/search.py:176`. ~900 MB.
+2. **Eager cross-encoder reranker** — `Dockerfile:328` hardcodes `NEXUS_TXTAI_RERANKER`. ~300 MB.
+3. **Oversized `_FULL_TUNING` pools** — `src/nexus/lib/performance_tuning.py:572-625`: `thread_pool_size=200`, `db_pool_size=20+30 overflow`, `httpx_max_connections=100`, `connector_max_workers=20`.
+4. **No allocator tuning** — glibc default `M_ARENA_MAX = 8 × cpu_count` causes 200-400 MB RSS bloat. `Dockerfile:200-203` sets `LD_PRELOAD`/`GLIBC_TUNABLES` but not arenas.
+5. **BLAS thread inflation** — numpy/torch/sentence-transformers spawn `cpu_count` BLAS threads at import; each = 8 MB pthread stack + glibc arena. Likely accounts for most of the 37 idle threads.
+
+## Design
+
+### Six change surfaces
+
+```
+┌─ Dockerfile + docker-entrypoint.sh ────────────────────────┐
+│ • Add libjemalloc2 apt package                             │
+│ • LD_PRELOAD: prepend libjemalloc.so.2                     │
+│ • ENV MALLOC_ARENA_MAX=2 MALLOC_TRIM_THRESHOLD_=131072     │
+│ • ENV OMP/OPENBLAS/MKL/NUMEXPR/VECLIB_MAXIMUM_THREADS=1    │
+│ • DROP NEXUS_TXTAI_RERANKER hardcode                       │
+│ • entrypoint: strip jemalloc from LD_PRELOAD if missing    │
+└────────────────────────────────────────────────────────────┘
+┌─ src/nexus/lib/performance_tuning.py ──────────────────────┐
+│ • _FULL_TUNING: thread_pool 200→40, db 20+30→5+5,          │
+│   httpx 100→20, connector 20→6                             │
+│ • _CLOUD_TUNING: untouched (already sized for multi-tenant)│
+└────────────────────────────────────────────────────────────┘
+┌─ src/nexus/server/lifespan/__init__.py ────────────────────┐
+│ • threading.stack_size(1<<20) before any thread spawn      │
+│ • gc.set_threshold(50_000, 10, 10) at boot                 │
+│ • gc.freeze() after services start                         │
+│ • Add idle trimmer bg_task (60s gc.collect+malloc_trim)    │
+└────────────────────────────────────────────────────────────┘
+┌─ src/nexus/server/lifespan/search.py ──────────────────────┐
+│ • _resolve_txtai_runtime_config: three-way auto            │
+│   (no key→BM25 None, key→openai API, explicit→local)       │
+└────────────────────────────────────────────────────────────┘
+┌─ src/nexus/bricks/search/txtai_backend.py ─────────────────┐
+│ • _startup_impl: branch on model is None → BM25 fast-path  │
+│   (skip Embeddings(config) entirely, use existing BM25     │
+│   fallback config from line 472-480 as primary)            │
+└────────────────────────────────────────────────────────────┘
+┌─ tests/integration/test_demo_memory.py ────────────────────┐
+│ • pytest marker @pytest.mark.demo_memory                   │
+│ • docker compose up demo, sleep 30, parse /proc/$pid/status│
+│ • assert VmRSS < 450 MB, Threads < 20, VmData < 4 GB       │
+└────────────────────────────────────────────────────────────┘
+```
+
+### Pool size changes (`_FULL_TUNING` only; `_CLOUD_TUNING` untouched)
+
+| Field | Now | New | Source |
+|---|---|---|---|
+| `thread_pool_size` | 200 | **40** | Starlette/anyio upstream default ([FastAPI #8587](https://github.com/fastapi/fastapi/discussions/8587), [Kludex/fastapi-tips](https://github.com/Kludex/fastapi-tips)) |
+| `httpx_max_connections` | 100 | **20** | [httpx Resource Limits](https://www.python-httpx.org/advanced/resource-limits/) |
+| `remote_pool_maxsize` | 20 | **10** | Per-host pool, HTTP/2 collapses anyway |
+| `connector_max_workers` | 20 | **6** | Blob ops I/O-bound; 6 saturates network |
+| `db_pool_size` | 20 | **5** | [Cloud SQL sample](https://cloud.google.com/sql/docs/postgres/samples/cloud-sql-postgres-sqlalchemy-limit) |
+| `db_max_overflow` | 30 | **5** | Single-tenant burst; PG idle conn ≈ 10 MB ([AWS](https://aws.amazon.com/blogs/database/resources-consumed-by-idle-postgresql-connections/)) |
+
+### Dockerfile additions (`Dockerfile:202-203` area)
+
+```dockerfile
+RUN apt-get update && apt-get install -y --no-install-recommends libjemalloc2 \
+    && rm -rf /var/lib/apt/lists/*
+
+ENV LD_PRELOAD="/usr/lib/x86_64-linux-gnu/libjemalloc.so.2:/usr/lib/libgomp.so.1"
+ENV MALLOC_ARENA_MAX=2 \
+    MALLOC_TRIM_THRESHOLD_=131072 \
+    OMP_NUM_THREADS=1 \
+    OPENBLAS_NUM_THREADS=1 \
+    MKL_NUM_THREADS=1 \
+    NUMEXPR_NUM_THREADS=1 \
+    VECLIB_MAXIMUM_THREADS=1
+```
+
+`Dockerfile:328` — DROP the line:
+```
+NEXUS_TXTAI_RERANKER=cross-encoder/ms-marco-MiniLM-L-2-v2 \
+```
+
+LD_PRELOAD ordering: jemalloc **first** (intercepts allocator calls before any other lib). Existing `libgomp.so.1` chained second. Entrypoint conditionally appends `libc10.so` for torch — that chain remains correct.
+
+Sources: [Battle of the Mallocators 2025](http://smalldatum.blogspot.com/2025/04/battle-of-mallocators.html), [Heroku — Tuning glibc Memory Behavior](https://devcenter.heroku.com/articles/tuning-glibc-memory-behavior), [Software at Scale — malloc_trim](https://www.softwareatscale.dev/p/run-python-servers-more-efficiently), [numpy #17856 — OpenBLAS at import](https://github.com/numpy/numpy/issues/17856).
+
+### Search runtime resolver — three-way auto
+
+`src/nexus/server/lifespan/search.py:27-49`:
+
+```python
+def _resolve_txtai_runtime_config() -> tuple[str | None, dict[str, str] | None]:
+    """Resolve embedding model + vectors config from env.
+
+    Returns (None, None) when no model should be loaded — txtai backend then
+    runs in BM25-only mode (keyword search over content + objects).
+    """
+    explicit_model = os.environ.get("NEXUS_TXTAI_MODEL", "").strip()
+    openai_api_key = os.environ.get("OPENAI_API_KEY", "").strip()
+    openai_base_url = os.environ.get("OPENAI_BASE_URL", "").strip()
+    use_api_explicit = _env_truthy("NEXUS_TXTAI_USE_API_EMBEDDINGS")
+
+    # Explicit local model wins (opt-in to ~900 MB)
+    if explicit_model and not explicit_model.startswith("openai/"):
+        return explicit_model, None
+
+    # OpenAI key present → API embeddings, ~0 RAM
+    if openai_api_key and (use_api_explicit or not explicit_model):
+        model = explicit_model or "openai/text-embedding-3-small"
+        vectors: dict[str, str] = {"api_key": openai_api_key}
+        if openai_base_url:
+            vectors["api_base"] = openai_base_url
+        return model, vectors
+
+    # No key, no explicit local model → BM25 keyword-only
+    return None, None
+```
+
+Add boot-log line:
+```python
+mode = "bm25-only" if model is None else ("openai-api" if model.startswith("openai/") else "local")
+logger.info("Search backend mode: %s (model=%s)", mode, model)
+```
+
+### Backend BM25 fast-path
+
+`src/nexus/bricks/search/txtai_backend.py:_startup_impl` — early branch when `self._model is None`:
+
+```python
+if self._model is None:
+    bm25_config = {
+        "keyword": True,
+        "content": content_store,
+        "objects": True,
+    }
+    self._embeddings = Embeddings(bm25_config)
+    self._hybrid = False
+    logger.info("txtai backend started in BM25-only mode (no embedding model)")
+    self._started = True
+    self._configure_litellm()
+    return
+```
+
+Reuses the existing fallback config block (lines 472-480) but takes it intentionally instead of via exception.
+
+### Lifespan boot tweaks
+
+`src/nexus/server/lifespan/__init__.py` — add at very top of `lifespan()` async ctx, before any other work:
+
+```python
+import threading, gc, ctypes
+threading.stack_size(1 << 20)
+gc.set_threshold(50_000, 10, 10)
+```
+
+After all startup phases complete, before `yield`:
+```python
+gc.freeze()
+bg_tasks.append(asyncio.create_task(_idle_trimmer(), name="idle_trimmer"))
+yield
+```
+
+`_idle_trimmer` helper:
+```python
+async def _idle_trimmer() -> None:
+    try:
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        libc.malloc_trim  # probe
+    except (OSError, AttributeError):
+        logger.info("malloc_trim unavailable, idle trimmer disabled")
+        return
+    while True:
+        await asyncio.sleep(60)
+        try:
+            gc.collect()
+            libc.malloc_trim(0)
+        except Exception:
+            logger.exception("idle_trimmer iteration failed")
+```
+
+### Entrypoint safety net
+
+`docker-entrypoint.sh` — strip jemalloc from LD_PRELOAD if missing at runtime (defensive, in case base image diverges):
+
+```sh
+if [ ! -f /usr/lib/x86_64-linux-gnu/libjemalloc.so.2 ]; then
+    echo "WARN: libjemalloc.so.2 not found, falling back to glibc+arena cap" >&2
+    export LD_PRELOAD="${LD_PRELOAD#*libjemalloc.so.2:}"
+fi
+```
+
+## Data Flow (boot path)
+
+```
+docker compose up
+   ↓
+docker-entrypoint.sh
+   ├─ LD_PRELOAD = libjemalloc.so.2 : libgomp.so.1 [: libc10.so if torch]
+   ├─ MALLOC_ARENA_MAX=2 (active for all subsequent allocs)
+   ├─ OMP/OPENBLAS/MKL=1 (locks BLAS thread spawn at first numpy import)
+   └─ exec nexusd
+        ↓
+   uvicorn boot
+        ↓
+   FastAPI lifespan startup
+        ├─ threading.stack_size(1<<20)        ← FIRST, before any thread
+        ├─ gc.set_threshold(50_000, 10, 10)
+        ├─ nx.bootstrap (NexusFS)
+        ├─ startup_observability
+        ├─ limiter.total_tokens = 40           ← was 200
+        ├─ startup_search
+        │     ├─ _resolve_txtai_runtime_config → (model, vectors)
+        │     │     ├─ OPENAI_API_KEY set?  → ("openai/text-embedding-3-small", {api_key})
+        │     │     ├─ NEXUS_TXTAI_MODEL=local?  → (model, None)  [opt-in heavy path]
+        │     │     └─ neither               → (None, None)        [BM25 default]
+        │     └─ SearchDaemon.startup
+        │           └─ txtai_backend._startup_impl
+        │                 ├─ model is None → BM25 fast-path, no model load
+        │                 ├─ model startswith "openai/" → API embeddings, ~0 RAM
+        │                 └─ model startswith "sentence-transformers/" → local load
+        │                 └─ NEXUS_TXTAI_RERANKER set? → load reranker (opt-in only)
+        ├─ startup_services
+        ├─ ... other startups
+        ├─ start idle_trimmer bg_task (60s loop)   ← new
+        ├─ gc.freeze()                              ← AFTER all warmup imports
+        └─ yield → serving
+```
+
+## Behavioral envelopes
+
+| Setup | Search mode | Idle RSS (target) |
+|---|---|---|
+| No `OPENAI_API_KEY`, no model env | BM25 keyword (full-text + title) | **~350 MB** |
+| `OPENAI_API_KEY` set | Hybrid BM25 + remote API embeddings | ~400 MB |
+| `NEXUS_TXTAI_MODEL=sentence-transformers/...` | Hybrid local (opt-in) | ~1.3 GB |
+| `+ NEXUS_TXTAI_RERANKER=...` | + cross-encoder reranker | +300 MB |
+
+Demo `configs/config.demo.yaml:130` keeps `search: true`. No config change needed.
+
+## Error handling
+
+| Scenario | Mitigation |
+|---|---|
+| **jemalloc preload missing at runtime** | `docker-entrypoint.sh` checks file exists; strips from LD_PRELOAD with WARN log if missing. App still gets `MALLOC_ARENA_MAX=2`. |
+| **BLAS=1 regresses unforeseen workload** | Document in CHANGELOG + sandbox-profile.md. Users override via `docker run -e OMP_NUM_THREADS=N` (last write wins). |
+| **Operator forgot OPENAI_API_KEY, expected embeddings** | INFO log at boot: `"Search backend mode: %s (model=%s)"`. Visible in `docker logs`. |
+| **txtai BM25-only path raises** | Existing try/except at `txtai_backend.py:482-487` catches → degraded mode (`_embeddings = None`). App stays up. |
+| **Idle trimmer fails (Alpine/musl, missing libc)** | Probe `libc.malloc_trim` at task start; if unavailable, log once and exit task. App unaffected. |
+| **`gc.freeze()` interaction** | Call only at end of startup, before `yield`. Documented constraint: no module-level global rebinds at runtime (hot reload, monkeypatching). |
+| **Threads spawned before stack_size cap** | `threading.stack_size()` is the first lifespan line. C extensions that pre-spawn at import are accepted loss; anyio worker pool dominates. |
+| **Demo regression test flakes** | Unique compose project name, random ports, poll `/healthz/ready` (60s timeout) + 15s extra for lazy init, `try/finally` teardown. |
+
+## Testing strategy
+
+### Layer 1: Unit tests (fast, no I/O)
+
+- `test_performance_tuning.py` — assert `_FULL_TUNING` field values + JSON snapshot fixture.
+- `test_search_runtime_config.py` (new) — parametrized matrix over env permutations, assert tuple return.
+- `test_txtai_backend_bm25_only.py` (new) — pass `model=None`, assert BM25 config used, no model download.
+- `test_lifespan_boot_tweaks.py` (new) — assert `threading.stack_size()`, `gc.get_threshold()`, `idle_trimmer` task registered.
+
+### Layer 2: Integration test (slow, Docker)
+
+`tests/integration/test_demo_memory.py` — `@pytest.mark.demo_memory`:
+- Boot demo via `docker compose -p nexus-demo-test-{uuid} up -d`
+- Poll `/healthz/ready` (60s timeout) + 15s lazy-init buffer
+- Read `/proc/$pid/status` from inside container
+- Assert `VmRSS_kB < 450 * 1024`, `Threads < 20`, `VmData_kB < 4 * 1024 * 1024`
+- Log full status + first 20 lines of maps on failure
+- `try/finally` `docker compose down -v` teardown
+
+### Layer 3: CI wiring
+
+- Unit tests: existing PR CI suite (~<1s added).
+- Integration: new `.github/workflows/demo-memory.yml`, runs on `develop` push + nightly cron + manual dispatch. Not blocking PR by default.
+
+### Manual verification (per PR)
+
+```sh
+docker build -t nexus:test .
+docker run --rm nexus:test ls -la /usr/lib/x86_64-linux-gnu/libjemalloc.so.2
+docker compose -p nexus-demo up -d
+sleep 30
+docker exec nexus-demo-nexus-1 sh -c \
+    'pid=$(pgrep -f nexusd | head -1); cat /proc/$pid/status | grep -E "^(VmRSS|VmData|Threads)"'
+docker exec nexus-demo-nexus-1 sh -c \
+    'pid=$(pgrep -f nexusd | head -1); cat /proc/$pid/maps | grep -i jemalloc | head -3'
+docker exec nexus-demo-nexus-1 env | grep -E "OMP|OPENBLAS|MKL"
+docker logs nexus-demo-nexus-1 2>&1 | grep -i "search backend mode"
+```
+
+## Acceptance criteria (from issue #3997)
+
+- Demo profile cold-start idle RSS ≤ 450 MB
+- Idle thread count ≤ 20
+- VmData ≤ 4 GB virtual
+- First `/api/v2/search/query` may pay one-time 2-5 s model-load latency *only when local model opted in* — BM25 default has no model-load latency.
+- New regression test (`pytest -m demo_memory`) measuring RSS 30 s after boot, asserting `rss_mb < 450`
+
+## Out of scope
+
+- PGO Python build (issue's Option E) — separate follow-up if RSS still misses target after Tier 1 changes.
+- `gc.set_threshold` is in scope (latency win bundled with memory work). If it causes regressions, revert independently.
+- Removing the legacy `nexus.bricks.search.embeddings` module — already deleted per code comment at search.py:171.
+- New profile (`demo-lite`) — issue's Option D suggested this; we tune `_FULL_TUNING` directly instead, so demo + production-full both benefit. `_CLOUD_TUNING` untouched.
+
+## References
+
+- [Issue #3997](https://github.com/nexi-lab/nexus/issues/3997)
+- [glibc mallopt(3)](https://man7.org/linux/man-pages/man3/mallopt.3.html), [malloc_trim(3)](https://man7.org/linux/man-pages/man3/malloc_trim.3.html)
+- [AnyIO threads](https://anyio.readthedocs.io/en/stable/threads.html)
+- [SQLAlchemy 2.0 pooling](https://docs.sqlalchemy.org/en/20/core/pooling.html)
+- [PostgreSQL Resource Consumption](https://www.postgresql.org/docs/current/runtime-config-resource.html)
+- [PyTorch performance tuning](https://docs.pytorch.org/tutorials/recipes/recipes/tuning_guide.html)
+- [scikit-learn parallelism](https://scikit-learn.org/1.1/computing/parallelism.html)
+- [Uvicorn Settings](https://uvicorn.dev/settings/)

--- a/nexus-stack.yml
+++ b/nexus-stack.yml
@@ -85,8 +85,12 @@ services:
       # Database
       NEXUS_DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-nexus}@postgres:5432/${POSTGRES_DB:-nexus}
       TOKEN_MANAGER_DB: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-nexus}@postgres:5432/${POSTGRES_DB:-nexus}
-      NEXUS_DB_POOL_SIZE: ${NEXUS_DB_POOL_SIZE:-20}
-      NEXUS_DB_MAX_OVERFLOW: ${NEXUS_DB_MAX_OVERFLOW:-30}
+      # #3997: right-sized for single-tenant demo (was 20/30). The values
+      # mirror ProfileTuning.storage.db_pool_size/db_max_overflow on the
+      # FULL profile; ``NEXUS_DB_*`` env vars are still the runtime SSOT
+      # consumed by ``SQLAlchemyRecordStore._build_pool_kwargs``.
+      NEXUS_DB_POOL_SIZE: ${NEXUS_DB_POOL_SIZE:-5}
+      NEXUS_DB_MAX_OVERFLOW: ${NEXUS_DB_MAX_OVERFLOW:-5}
       # Auth
       NEXUS_ADMIN_USER: ${NEXUS_ADMIN_USER:-admin}
       NEXUS_API_KEY: ${NEXUS_API_KEY:-}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -458,6 +458,7 @@ markers = [
     "vault: marks tests that require a running Vault dev server (opt-in, see docs/guides/auth-envelope-encryption.md)",
     "kms: marks tests that require a reachable AWS KMS endpoint (opt-in, real AWS or LocalStack)",
     "sandbox_memory: SANDBOX memory benchmark (skipped by default; run with -m sandbox_memory)",
+    "demo_memory: nexusd demo profile RSS regression (slow, requires Docker; Issue #3997)",
 ]
 
 [tool.coverage.run]

--- a/scripts/codegen_kernel_abi.py
+++ b/scripts/codegen_kernel_abi.py
@@ -5083,6 +5083,13 @@ _KERNEL_SYSCALL_ALIASES: dict[str, str] = {
     "rename": "sys_rename",
     "exists": "access",
     "list": "sys_readdir",
+    # #4005 round-2: ``sys_readdir`` is the canonical wire name CLI clients
+    # use directly (no rewrite). PyKernel exposes only ``sys_readdir_backend``
+    # so the allowlist scan filters it out — register the identity alias here
+    # so KERNEL_SYSCALL_NAMES (built from alias keys) includes it and the
+    # gRPC servicer routes ``sys_readdir`` straight to NexusFS.sys_readdir
+    # rather than dropping it into the legacy "Unknown method" path.
+    "sys_readdir": "sys_readdir",
     # PyKernel says sys_mkdir / sys_rmdir; NexusFS Tier 2 says mkdir / rmdir.
     "sys_mkdir": "mkdir",
     "sys_rmdir": "rmdir",
@@ -5467,7 +5474,10 @@ async def _occ_write_dispatch(
             if_none_match=if_none_match,
             offset=offset,
         )
-    return nexus_fs.write(params["path"], content, context=context, offset=offset)
+    # #4005 round-2: NexusFS.write is sync — offload like dispatch_kernel_syscall.
+    return await asyncio.to_thread(
+        nexus_fs.write, params["path"], content, context=context, offset=offset
+    )
 
 
 def _apply_pre_call_defaults(method: str, params: dict[str, Any]) -> dict[str, Any]:
@@ -5549,7 +5559,11 @@ async def dispatch_kernel_syscall(
         if asyncio.iscoroutinefunction(func):
             raw_result = await func(**kwargs)
         else:
-            raw_result = func(**kwargs)
+            # #4005 round-2: NexusFS sys_* methods are sync and may do
+            # blocking I/O (DB hits, large reads). Calling them inline
+            # would park the asyncio loop — same DoS class that justified
+            # excluding sys_watch. Offload to the default thread pool.
+            raw_result = await asyncio.to_thread(func, **kwargs)
 
     result = _apply_result_adapter(method, raw_result, params)
 

--- a/src/nexus/bricks/rebac/tuples/writer.py
+++ b/src/nexus/bricks/rebac/tuples/writer.py
@@ -768,21 +768,24 @@ class TupleWriter:
         subject_relation: str | None,
         relation: str,
         object_entity: Entity,
-        zone_id: str | None,  # noqa: ARG002 — kept for caller-API stability
+        zone_id: str | None,
     ) -> str | None:
         """Check if a tuple already exists (idempotency). Returns tuple_id or None.
 
-        Mirrors ``idx_rebac_tuple_unique`` exactly — that index is zone-agnostic
-        and uses ``COALESCE(subject_relation, '')``, so the lookup must be
-        zone-agnostic too. Filtering by zone_id here let the auto-grant tuple
-        from a post-mkdir hook (zone="root") slip past the check, after which
-        the explicit ``rebac create`` (zone=None) hit a unique-constraint
-        violation in PostgreSQL.
+        Zone-aware idempotency that still catches the auto-grant
+        duplicate scenario fixed in #3997: a post-mkdir hook writes the
+        tuple with ``zone_id="root"`` while the explicit ``rebac create``
+        omits the zone (``zone_id=None``); both shapes resolve to the
+        same row under ``idx_rebac_tuple_unique`` (zone-agnostic), so
+        treating ``None`` and ``"root"`` as equivalent here lets the
+        explicit call no-op instead of crashing on the unique-constraint
+        violation. Distinct named zones (``zone-a`` vs ``zone-b``) keep
+        their own idempotency contracts.
         """
         cursor.execute(
             self._fix_sql(
                 """
-                SELECT tuple_id FROM rebac_tuples
+                SELECT tuple_id, zone_id FROM rebac_tuples
                 WHERE subject_type = ? AND subject_id = ?
                 AND COALESCE(subject_relation, '') = COALESCE(?, '')
                 AND relation = ?
@@ -798,9 +801,27 @@ class TupleWriter:
                 object_entity.entity_id,
             ),
         )
-        existing = cursor.fetchone()
-        if existing:
-            return cast(str, existing[0] if isinstance(existing, tuple) else existing["tuple_id"])
+        rows = cursor.fetchall()
+
+        def _zone_of(row: Any) -> str | None:
+            if isinstance(row, tuple):
+                return row[1]
+            return row.get("zone_id") if hasattr(row, "get") else row["zone_id"]
+
+        def _tid_of(row: Any) -> str:
+            if isinstance(row, tuple):
+                return cast(str, row[0])
+            return cast(str, row["tuple_id"])
+
+        # Treat ``None`` and ``"root"`` as the same zone (auto-grant vs
+        # explicit-create alias) — anything else must match exactly.
+        def _norm(z: str | None) -> str:
+            return "root" if z is None else z
+
+        target = _norm(zone_id)
+        for row in rows:
+            if _norm(_zone_of(row)) == target:
+                return _tid_of(row)
         return None
 
 

--- a/src/nexus/bricks/rebac/tuples/writer.py
+++ b/src/nexus/bricks/rebac/tuples/writer.py
@@ -768,30 +768,34 @@ class TupleWriter:
         subject_relation: str | None,
         relation: str,
         object_entity: Entity,
-        zone_id: str | None,
+        zone_id: str | None,  # noqa: ARG002 — kept for caller-API stability
     ) -> str | None:
-        """Check if a tuple already exists (idempotency). Returns tuple_id or None."""
+        """Check if a tuple already exists (idempotency). Returns tuple_id or None.
+
+        Mirrors ``idx_rebac_tuple_unique`` exactly — that index is zone-agnostic
+        and uses ``COALESCE(subject_relation, '')``, so the lookup must be
+        zone-agnostic too. Filtering by zone_id here let the auto-grant tuple
+        from a post-mkdir hook (zone="root") slip past the check, after which
+        the explicit ``rebac create`` (zone=None) hit a unique-constraint
+        violation in PostgreSQL.
+        """
         cursor.execute(
             self._fix_sql(
                 """
                 SELECT tuple_id FROM rebac_tuples
                 WHERE subject_type = ? AND subject_id = ?
-                AND (subject_relation = ? OR (subject_relation IS NULL AND ? IS NULL))
+                AND COALESCE(subject_relation, '') = COALESCE(?, '')
                 AND relation = ?
                 AND object_type = ? AND object_id = ?
-                AND (zone_id = ? OR (zone_id IS NULL AND ? IS NULL))
                 """
             ),
             (
                 subject_entity.entity_type,
                 subject_entity.entity_id,
                 subject_relation,
-                subject_relation,
                 relation,
                 object_entity.entity_type,
                 object_entity.entity_id,
-                zone_id,
-                zone_id,
             ),
         )
         existing = cursor.fetchone()

--- a/src/nexus/bricks/rebac/tuples/writer.py
+++ b/src/nexus/bricks/rebac/tuples/writer.py
@@ -805,8 +805,9 @@ class TupleWriter:
 
         def _zone_of(row: Any) -> str | None:
             if isinstance(row, tuple):
-                return row[1]
-            return row.get("zone_id") if hasattr(row, "get") else row["zone_id"]
+                return cast("str | None", row[1])
+            value = row.get("zone_id") if hasattr(row, "get") else row["zone_id"]
+            return cast("str | None", value)
 
         def _tid_of(row: Any) -> str:
             if isinstance(row, tuple):

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -133,8 +133,11 @@ class DaemonConfig:
     entropy_threshold: float = 0.35  # SimpleMem's τ_redundant
     entropy_alpha: float = 0.5  # Balance entity vs semantic novelty
 
-    # txtai backend config (Issue #2663)
-    txtai_model: str = "sentence-transformers/all-MiniLM-L6-v2"
+    # txtai backend config (Issue #2663). ``None`` -> BM25 keyword-only
+    # fast-path (Issue #3997 T2 resolver returns None when no key + no
+    # explicit local model); the daemon skips embeddings load entirely.
+    # The actual fast-path branching is wired in #3997 T3.
+    txtai_model: str | None = "sentence-transformers/all-MiniLM-L6-v2"
     txtai_vectors: dict[str, Any] | None = None
     txtai_reranker: str | None = None  # e.g. "cross-encoder/ms-marco-MiniLM-L-2-v2"
     txtai_sparse: bool = False  # Enable SPLADE learned sparse retrieval
@@ -656,9 +659,14 @@ class SearchDaemon:
                 with contextlib.suppress(Exception):
                     _emb_cache = self._cache_brick.embedding_cache
 
+            # Issue #3997 T2 widened ``txtai_model`` to ``str | None``. The
+            # BM25 fast-path that consumes ``None`` lands in T3 — until then,
+            # coalesce to the historical default so this branch keeps loading
+            # the local embedding model exactly like before.
+            _model = self.config.txtai_model or "sentence-transformers/all-MiniLM-L6-v2"
             self._backend = TxtaiBackend(
                 database_url=self.config.database_url,
-                model=self.config.txtai_model,
+                model=_model,
                 vectors=self.config.txtai_vectors,
                 hybrid=True,
                 graph=self.config.txtai_graph,

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -134,9 +134,10 @@ class DaemonConfig:
     entropy_alpha: float = 0.5  # Balance entity vs semantic novelty
 
     # txtai backend config (Issue #2663). ``None`` -> BM25 keyword-only
-    # fast-path (Issue #3997 T2 resolver returns None when no key + no
-    # explicit local model); the daemon skips embeddings load entirely.
-    # The actual fast-path branching is wired in #3997 T3.
+    # fast-path (Issue #3997: resolver returns ``None`` when there is no
+    # API key and no explicit local model). ``TxtaiBackend._startup_impl``
+    # detects ``model=None`` and skips ``Embeddings(path=...)`` entirely,
+    # saving ~900 MB RSS at boot for default deploys.
     txtai_model: str | None = "sentence-transformers/all-MiniLM-L6-v2"
     txtai_vectors: dict[str, Any] | None = None
     txtai_reranker: str | None = None  # e.g. "cross-encoder/ms-marco-MiniLM-L-2-v2"
@@ -659,14 +660,9 @@ class SearchDaemon:
                 with contextlib.suppress(Exception):
                     _emb_cache = self._cache_brick.embedding_cache
 
-            # Issue #3997 T2 widened ``txtai_model`` to ``str | None``. The
-            # BM25 fast-path that consumes ``None`` lands in T3 — until then,
-            # coalesce to the historical default so this branch keeps loading
-            # the local embedding model exactly like before.
-            _model = self.config.txtai_model or "sentence-transformers/all-MiniLM-L6-v2"
             self._backend = TxtaiBackend(
                 database_url=self.config.database_url,
-                model=_model,
+                model=self.config.txtai_model,
                 vectors=self.config.txtai_vectors,
                 hybrid=True,
                 graph=self.config.txtai_graph,
@@ -3336,6 +3332,10 @@ class SearchDaemon:
             },
             # Issue #2663: txtai backend
             "backend": "txtai" if self._backend is not None else "legacy",
+            # Issue #3997: ``None`` (serialised as JSON ``null``) means the
+            # backend is in BM25 keyword-only mode — no embedding model was
+            # configured, so the heavy ``Embeddings(path=...)`` load was
+            # skipped to save RSS at boot.
             "txtai_model": self.config.txtai_model,
             "txtai_reranker": self.config.txtai_reranker,
             "txtai_graph": self.config.txtai_graph,

--- a/src/nexus/bricks/search/txtai_backend.py
+++ b/src/nexus/bricks/search/txtai_backend.py
@@ -158,7 +158,9 @@ class TxtaiBackend:
         self,
         *,
         database_url: str | None = None,
-        model: str = "sentence-transformers/all-MiniLM-L6-v2",
+        # Issue #3997: ``None`` activates the BM25 keyword-only fast-path in
+        # ``_startup_impl`` — no embedding model is loaded.
+        model: str | None = "sentence-transformers/all-MiniLM-L6-v2",
         vectors: dict[str, Any] | None = None,
         hybrid: bool = True,
         graph: bool = True,
@@ -420,7 +422,11 @@ class TxtaiBackend:
     async def _startup_impl(self) -> None:
         """Initialize txtai Embeddings with pgvector backend (with fallback).
 
-        Fallback chain:
+        Fast-path (Issue #3997): when ``model is None`` (no embedding model
+        configured), start in keyword-only BM25 mode immediately and skip
+        the dense-vector setup entirely (saves ~900 MB RSS at boot).
+
+        Fallback chain (when ``model`` is set):
         1. Full hybrid (BM25 + dense embeddings) with pgvector storage
         2. Full hybrid with in-memory storage (pgvector unavailable)
         3. Keyword-only BM25 (embedding model fails to load)
@@ -431,6 +437,37 @@ class TxtaiBackend:
         except ModuleNotFoundError:
             logger.warning("txtai package not installed; starting in degraded search mode")
             self._embeddings = None
+            self._started = True
+            return
+
+        # Issue #3997: BM25 keyword-only fast-path. When no embedding model is
+        # configured (resolver returned ``(None, None)`` because no API key
+        # and no explicit local model — the typical default-deploy case), skip
+        # the heavy ``Embeddings(path=...)`` load entirely and start txtai
+        # with a keyword-only config directly. Saves ~900 MB RSS at boot.
+        # Skips GPU detection, pgvector probe, hybrid build, and load probe
+        # because none of them apply when there is no dense vector model.
+        if self._model is None:
+            bm25_content_store: bool | str = self._database_url or True
+            bm25_only_config: dict[str, Any] = {
+                "keyword": True,
+                "content": bm25_content_store,
+                "objects": True,
+            }
+            try:
+                self._embeddings = Embeddings(bm25_only_config)
+                self._hybrid = False
+                self._configure_litellm()
+                logger.info(
+                    "txtai backend started in BM25-only mode "
+                    "(no embedding model configured; Issue #3997)"
+                )
+            except Exception:
+                logger.error(
+                    "BM25-only init failed; entering degraded mode (no results).",
+                    exc_info=True,
+                )
+                self._embeddings = None
             self._started = True
             return
 

--- a/src/nexus/core/nexus_fs_content.py
+++ b/src/nexus/core/nexus_fs_content.py
@@ -1115,10 +1115,50 @@ class ContentMixin:
             ...     {"old_str": "def foo():", "new_str": "def bar():", "hint_line": 42}
             ... ], fuzzy_threshold=0.8)
         """
-        from nexus.utils.edit_engine import EditEngine
-        from nexus.utils.edit_engine import EditOperation as EditOp
 
         path = self._validate_path(path)
+
+        # #4005 round-8: serialize the if_match read-modify-write under the
+        # same per-path OCC lock occ_write_sync uses. Without this, a
+        # concurrent write could commit between our content_id check and
+        # the final write below, lost-updating the caller's intent.
+        # Plain edits (no if_match) skip the lock — same fast path as
+        # occ_write_sync.
+        if if_match is None:
+            return self._edit_locked(
+                path,
+                edits,
+                context=context,
+                if_match=if_match,
+                preview=preview,
+                fuzzy_threshold=fuzzy_threshold,
+            )
+
+        from nexus.lib.occ import _occ_path_lock
+
+        with _occ_path_lock(path):
+            return self._edit_locked(
+                path,
+                edits,
+                context=context,
+                if_match=if_match,
+                preview=preview,
+                fuzzy_threshold=fuzzy_threshold,
+            )
+
+    def _edit_locked(
+        self,
+        path: str,
+        edits: list,
+        *,
+        context: object | None = None,
+        if_match: str | None = None,
+        preview: bool = False,
+        fuzzy_threshold: float = 1.0,
+    ) -> dict:
+        """Inner edit body — caller holds ``_occ_path_lock(path)`` when if_match."""
+        from nexus.utils.edit_engine import EditEngine
+        from nexus.utils.edit_engine import EditOperation as EditOp
 
         # Read current content with metadata (via Tier 2 convenience)
         result = self.read(path, context=context, return_metadata=True)

--- a/src/nexus/core/nexus_fs_content.py
+++ b/src/nexus/core/nexus_fs_content.py
@@ -708,6 +708,31 @@ class ContentMixin:
         if count is not None:
             buf = buf[:count]
 
+        # #4005 round-9: serialize same-path writes under the OCC per-path
+        # RLock so an edit(if_match=...) read-modify-write is atomic against
+        # plain writes too. Without this, a plain ``write`` committed
+        # between an edit's content_id check and its final write would
+        # silently lose the edit's intended state. RLock means OCC callers
+        # that already hold the lock pass through without deadlocking.
+        # NOTE: develop (#12f) dropped the explicit self._validate_path here
+        # — Rust kernel re-canonicalizes via path_utils.validate_path before
+        # sys_write. _occ_path_lock canonicalizes its own key internally
+        # (lib.occ._canonical_lock_key) so surface aliases hash identically.
+        from nexus.lib.occ import _occ_path_lock
+
+        with _occ_path_lock(path):
+            return self._write_locked(path, buf, offset=offset, context=context, ttl=ttl)
+
+    def _write_locked(
+        self,
+        path: str,
+        buf: bytes,
+        *,
+        offset: int = 0,
+        context: OperationContext | None = None,
+        ttl: float | None = None,
+    ) -> dict[str, Any]:
+        """Inner write body — caller holds ``_occ_path_lock(path)``."""
         # PRE-DISPATCH: virtual path resolvers (e.g. /__sys__ writers).
         _handled, _result = self.resolve_write(path, buf, context=context)
         if _handled:

--- a/src/nexus/core/nexus_fs_content.py
+++ b/src/nexus/core/nexus_fs_content.py
@@ -1011,53 +1011,56 @@ class ContentMixin:
 
         path = self._validate_path(path)
 
-        # Try to read existing content if file exists
-        # For non-existent files, we'll create them (existing_content stays empty)
-        existing_content = b""
-        try:
-            result = self.read(path, context=context, return_metadata=True)
-            # Tier 2 read(return_metadata=True) always returns dict
-            assert isinstance(result, dict), "Expected dict when return_metadata=True"
+        # #4005 round-10: append is read-modify-write — always serialize
+        # the whole sequence under the per-path OCC lock so a concurrent
+        # plain write or write_batch can't commit between our read and
+        # the final write. Inner write() reuses the same RLock so this is
+        # reentrant. Plain (no if_match, no force) appends still benefit:
+        # without the lock, two concurrent appends could both read the
+        # same pre-state and produce content that drops one append.
+        from nexus.lib.occ import _occ_path_lock
 
-            existing_content = result["content"]
+        with _occ_path_lock(path):
+            # Try to read existing content if file exists
+            # For non-existent files, we'll create them (existing_content stays empty)
+            existing_content = b""
+            try:
+                result = self.read(path, context=context, return_metadata=True)
+                # Tier 2 read(return_metadata=True) always returns dict
+                assert isinstance(result, dict), "Expected dict when return_metadata=True"
 
-            # If if_match is provided, verify it matches current content_id
-            # (the write call will also check, but we check here to fail fast)
-            if if_match is not None and not force:
-                current_content_id = result.get("content_id")
-                if current_content_id != if_match:
-                    from nexus.contracts.exceptions import ConflictError
+                existing_content = result["content"]
 
-                    raise ConflictError(
-                        path=path,
-                        expected_content_id=if_match,
-                        current_content_id=current_content_id or "(no content_id)",
-                    )
-        except Exception as e:
-            # If file doesn't exist, treat as empty (will create new file)
-            from nexus.contracts.exceptions import NexusFileNotFoundError
+                # If if_match is provided, verify it matches current content_id.
+                if if_match is not None and not force:
+                    current_content_id = result.get("content_id")
+                    if current_content_id != if_match:
+                        from nexus.contracts.exceptions import ConflictError
 
-            if not isinstance(e, NexusFileNotFoundError):
-                # Re-raise unexpected errors (including PermissionError)
-                raise
-            # For FileNotFoundError, continue with empty content
-            # write() will check if user has permission to create the file
+                        raise ConflictError(
+                            path=path,
+                            expected_content_id=if_match,
+                            current_content_id=current_content_id or "(no content_id)",
+                        )
+            except Exception as e:
+                # If file doesn't exist, treat as empty (will create new file)
+                from nexus.contracts.exceptions import NexusFileNotFoundError
 
-        # Combine existing content with new content
-        final_content = existing_content + content
+                if not isinstance(e, NexusFileNotFoundError):
+                    # Re-raise unexpected errors (including PermissionError)
+                    raise
+                # For FileNotFoundError, continue with empty content
+                # write() will check if user has permission to create the file
 
-        # Use the existing write method to handle all the complexity:
-        # - Permission checking
-        # - Version management
-        # - Audit logging
-        # - Workflow triggers
-        # - Parent tuple creation
-        # OCC check already done above (line 2985-2996), so just write.
-        return self.write(
-            path,
-            final_content,
-            context=context,
-        )
+            # Combine existing content with new content
+            final_content = existing_content + content
+
+            # Use the existing write method (acquires the same RLock — reentrant).
+            return self.write(
+                path,
+                final_content,
+                context=context,
+            )
 
     @rpc_expose(description="Apply surgical search/replace edits to a file")
     def edit(
@@ -1361,6 +1364,35 @@ class ContentMixin:
         zone_id, agent_id, is_admin = self._get_context_identity(context)
         paths = [p for p, _ in validated_files]
 
+        # #4005 round-10: write_batch is a public mutation entrypoint and
+        # must participate in the same per-path OCC lock contract that
+        # write/edit use, otherwise a concurrent edit(if_match=...) on one
+        # of these paths can be silently overwritten between its
+        # content_id check and its final write. Acquire each unique path
+        # lock in deterministic sorted order to avoid lock-ordering
+        # deadlocks across concurrent batch writers, then run the batch
+        # body under all of them via ExitStack.
+        from contextlib import ExitStack
+
+        from nexus.lib.occ import _occ_path_lock
+
+        with ExitStack() as _stack:
+            for _p in sorted(set(paths)):
+                _stack.enter_context(_occ_path_lock(_p))
+            return self._write_batch_locked(
+                validated_files, paths, context, zone_id, agent_id, is_admin
+            )
+
+    def _write_batch_locked(
+        self,
+        validated_files: list[tuple[str, bytes]],
+        paths: list[str],
+        context: OperationContext | None,
+        zone_id: str | None,
+        agent_id: str | None,
+        is_admin: bool,
+    ) -> list[dict[str, Any]]:
+        """Inner write_batch body — caller holds _occ_path_lock for every path."""
         # Get existing metadata for pre-hooks and is_new detection
         existing_metadata = self.metadata.get_batch(paths)
 

--- a/src/nexus/lib/occ.py
+++ b/src/nexus/lib/occ.py
@@ -25,14 +25,13 @@ but a standard composition of kernel syscalls.
 
 from __future__ import annotations
 
-import asyncio
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext
 
 
-async def occ_write(
+def occ_write_sync(
     fs: Any,
     path: str,
     buf: bytes | str,
@@ -63,13 +62,16 @@ async def occ_write(
         FileExistsError: if_none_match=True and file exists.
         ConflictError: if_match provided and etag doesn't match.
     """
+    # #4005 round-3 review: keep stat + write inside the same call frame
+    # (no await between them) so two same-process callers can't both
+    # observe the pre-state and both commit. Async callers must offload
+    # the entire ``occ_write_sync`` via ``asyncio.to_thread`` (see
+    # _kernel_syscall_dispatch._occ_write_dispatch). True cross-process
+    # atomicity still requires a backend lock — out of scope here.
     if if_match is not None or if_none_match:
         from nexus.contracts.exceptions import ConflictError
 
-        # #4005 round-2: NexusFS.sys_stat / .write are sync — offload to a
-        # thread so the async OCC path doesn't park the asyncio loop on
-        # slow connectors / large writes (DoS class).
-        meta = await asyncio.to_thread(fs.sys_stat, path, context=context)
+        meta = fs.sys_stat(path, context=context)
 
         if if_none_match and meta is not None:
             raise FileExistsError(f"File already exists: {path}")
@@ -93,7 +95,34 @@ async def occ_write(
                     current_content_id=current_content_id or "(no content_id)",
                 )
 
-    result: dict[str, Any] = await asyncio.to_thread(
-        fs.write, path, buf, context=context, offset=offset
-    )
+    result: dict[str, Any] = fs.write(path, buf, context=context, offset=offset)
     return result
+
+
+# #4005 round-3: ``occ_write`` was the original async name. Keep it as a
+# thin async-friendly shim that offloads the whole sync compare-and-write
+# inside one ``to_thread`` so the check + write run atomically (no await
+# between them) AND the asyncio loop never blocks on the sync call.
+async def occ_write(
+    fs: Any,
+    path: str,
+    buf: bytes | str,
+    *,
+    context: OperationContext | None = None,
+    if_match: str | None = None,
+    if_none_match: bool = False,
+    offset: int = 0,
+) -> dict[str, Any]:
+    """Async wrapper around :func:`occ_write_sync` (offloaded to a thread)."""
+    import asyncio
+
+    return await asyncio.to_thread(
+        occ_write_sync,
+        fs,
+        path,
+        buf,
+        context=context,
+        if_match=if_match,
+        if_none_match=if_none_match,
+        offset=offset,
+    )

--- a/src/nexus/lib/occ.py
+++ b/src/nexus/lib/occ.py
@@ -51,7 +51,10 @@ class _OccLockEntry:
     __slots__ = ("lock", "refs")
 
     def __init__(self) -> None:
-        self.lock = threading.Lock()
+        # #4005 round-9: RLock lets the same thread that acquired the
+        # OCC lock for a check+write call into NexusFS.write (which
+        # itself acquires the same per-path lock) without deadlocking.
+        self.lock = threading.RLock()
         self.refs = 0
 
 

--- a/src/nexus/lib/occ.py
+++ b/src/nexus/lib/occ.py
@@ -25,6 +25,7 @@ but a standard composition of kernel syscalls.
 
 from __future__ import annotations
 
+import asyncio
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
@@ -65,7 +66,10 @@ async def occ_write(
     if if_match is not None or if_none_match:
         from nexus.contracts.exceptions import ConflictError
 
-        meta = fs.sys_stat(path, context=context)
+        # #4005 round-2: NexusFS.sys_stat / .write are sync — offload to a
+        # thread so the async OCC path doesn't park the asyncio loop on
+        # slow connectors / large writes (DoS class).
+        meta = await asyncio.to_thread(fs.sys_stat, path, context=context)
 
         if if_none_match and meta is not None:
             raise FileExistsError(f"File already exists: {path}")
@@ -89,5 +93,7 @@ async def occ_write(
                     current_content_id=current_content_id or "(no content_id)",
                 )
 
-    result: dict[str, Any] = fs.write(path, buf, context=context, offset=offset)
+    result: dict[str, Any] = await asyncio.to_thread(
+        fs.write, path, buf, context=context, offset=offset
+    )
     return result

--- a/src/nexus/lib/occ.py
+++ b/src/nexus/lib/occ.py
@@ -26,35 +26,58 @@ but a standard composition of kernel syscalls.
 from __future__ import annotations
 
 import threading
+from contextlib import contextmanager
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from collections.abc import Iterator
+
     from nexus.contracts.types import OperationContext
 
 
-# #4005 round-5: per-(zone, path) lock pool so two worker threads cannot
-# both observe the same pre-state and both commit. The lock pool is
-# unbounded in the worst case, but each lock is tiny and only paths
-# under active OCC contention live here. Cleanup on idle is intentional
-# punted: a once-per-N writes prune is brittle and the steady-state
-# memory cost is negligible compared to the correctness win. Cross-
-# process atomicity still requires a backend constraint (Issue #1323).
-_OCC_LOCKS: dict[tuple[str, str], threading.Lock] = {}
-_OCC_LOCKS_GUARD = threading.Lock()
+# #4005 round-6: per-path refcounted lock pool. Round-5 used (zone_id,
+# path) keys, but the path is *already* zone-scoped by the time it
+# reaches occ_write_sync (scope_params_for_zone runs at the RPC layer,
+# prepending ``/zone/<id>/`` for non-root callers). Adding caller
+# zone_id to the key let a tenant-scoped caller and a root caller
+# acquire different locks for the same canonical object, defeating the
+# serialization. Key by the (already-canonicalized) path alone.
+#
+# Refcount cleanup: every entry is removed from the pool when no caller
+# holds it. This bounds the pool to (concurrent OCC ops in flight) and
+# closes the auth-DoS path where unauthorized callers spamming unique
+# paths could grow the dict forever.
+class _OccLockEntry:
+    __slots__ = ("lock", "refs")
+
+    def __init__(self) -> None:
+        self.lock = threading.Lock()
+        self.refs = 0
 
 
-def _occ_lock_for(path: str, zone_id: str) -> threading.Lock:
-    """Return the threading.Lock for ``(zone_id, path)`` (creating on demand)."""
-    key = (zone_id, path)
-    lock = _OCC_LOCKS.get(key)
-    if lock is not None:
-        return lock
-    with _OCC_LOCKS_GUARD:
-        lock = _OCC_LOCKS.get(key)
-        if lock is None:
-            lock = threading.Lock()
-            _OCC_LOCKS[key] = lock
-        return lock
+_OCC_ENTRIES: dict[str, _OccLockEntry] = {}
+_OCC_GUARD = threading.Lock()
+
+
+@contextmanager
+def _occ_path_lock(path: str) -> Iterator[None]:
+    """Acquire the per-path OCC lock; release + GC the entry on exit."""
+    with _OCC_GUARD:
+        entry = _OCC_ENTRIES.get(path)
+        if entry is None:
+            entry = _OccLockEntry()
+            _OCC_ENTRIES[path] = entry
+        entry.refs += 1
+    try:
+        with entry.lock:
+            yield
+    finally:
+        with _OCC_GUARD:
+            entry.refs -= 1
+            if entry.refs == 0:
+                # Last holder leaves — drop the entry so the pool stays
+                # bounded by live contention.
+                _OCC_ENTRIES.pop(path, None)
 
 
 def occ_write_sync(
@@ -101,8 +124,7 @@ def occ_write_sync(
 
     from nexus.contracts.exceptions import ConflictError
 
-    zone_id = getattr(context, "zone_id", None) or "_root"
-    with _occ_lock_for(path, str(zone_id)):
+    with _occ_path_lock(path):
         meta = fs.sys_stat(path, context=context)
 
         if if_none_match and meta is not None:

--- a/src/nexus/lib/occ.py
+++ b/src/nexus/lib/occ.py
@@ -25,10 +25,36 @@ but a standard composition of kernel syscalls.
 
 from __future__ import annotations
 
+import threading
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext
+
+
+# #4005 round-5: per-(zone, path) lock pool so two worker threads cannot
+# both observe the same pre-state and both commit. The lock pool is
+# unbounded in the worst case, but each lock is tiny and only paths
+# under active OCC contention live here. Cleanup on idle is intentional
+# punted: a once-per-N writes prune is brittle and the steady-state
+# memory cost is negligible compared to the correctness win. Cross-
+# process atomicity still requires a backend constraint (Issue #1323).
+_OCC_LOCKS: dict[tuple[str, str], threading.Lock] = {}
+_OCC_LOCKS_GUARD = threading.Lock()
+
+
+def _occ_lock_for(path: str, zone_id: str) -> threading.Lock:
+    """Return the threading.Lock for ``(zone_id, path)`` (creating on demand)."""
+    key = (zone_id, path)
+    lock = _OCC_LOCKS.get(key)
+    if lock is not None:
+        return lock
+    with _OCC_LOCKS_GUARD:
+        lock = _OCC_LOCKS.get(key)
+        if lock is None:
+            lock = threading.Lock()
+            _OCC_LOCKS[key] = lock
+        return lock
 
 
 def occ_write_sync(
@@ -62,15 +88,21 @@ def occ_write_sync(
         FileExistsError: if_none_match=True and file exists.
         ConflictError: if_match provided and etag doesn't match.
     """
-    # #4005 round-3 review: keep stat + write inside the same call frame
-    # (no await between them) so two same-process callers can't both
-    # observe the pre-state and both commit. Async callers must offload
-    # the entire ``occ_write_sync`` via ``asyncio.to_thread`` (see
-    # _kernel_syscall_dispatch._occ_write_dispatch). True cross-process
-    # atomicity still requires a backend lock — out of scope here.
-    if if_match is not None or if_none_match:
-        from nexus.contracts.exceptions import ConflictError
+    # #4005 round-5: serialize the stat+write across worker threads
+    # via a per-(zone, path) lock. Without this, two callers offloaded
+    # via ``asyncio.to_thread`` could both observe the same pre-state
+    # in different threads and both commit (lost updates / double-create
+    # under if_match / if_none_match). Same-process serialization only;
+    # cross-process atomicity still requires backend constraints.
+    if if_match is None and not if_none_match:
+        # Plain write — no compare phase, no lock needed.
+        plain: dict[str, Any] = fs.write(path, buf, context=context, offset=offset)
+        return plain
 
+    from nexus.contracts.exceptions import ConflictError
+
+    zone_id = getattr(context, "zone_id", None) or "_root"
+    with _occ_lock_for(path, str(zone_id)):
         meta = fs.sys_stat(path, context=context)
 
         if if_none_match and meta is not None:
@@ -95,8 +127,8 @@ def occ_write_sync(
                     current_content_id=current_content_id or "(no content_id)",
                 )
 
-    result: dict[str, Any] = fs.write(path, buf, context=context, offset=offset)
-    return result
+        result: dict[str, Any] = fs.write(path, buf, context=context, offset=offset)
+        return result
 
 
 # #4005 round-3: ``occ_write`` was the original async name. Keep it as a

--- a/src/nexus/lib/occ.py
+++ b/src/nexus/lib/occ.py
@@ -62,9 +62,33 @@ _OCC_ENTRIES: dict[str, _OccLockEntry] = {}
 _OCC_GUARD = threading.Lock()
 
 
+def _canonical_lock_key(path: str) -> str:
+    """Inline canonicalization for OCC lock keys.
+
+    Collapses duplicate slashes, ensures a leading ``/``, and strips a
+    trailing ``/``. Mirrors enough of ``nexus.core.path_utils.validate_path``
+    that the surface forms ``foo``, ``/foo``, ``/foo/``, ``//foo`` all
+    hash to the same entry, without importing from ``nexus.core`` (the
+    five-tier architecture forbids ``lib`` -> ``core``).
+    """
+    if not path:
+        return "/"
+    canonical = path.strip()
+    if not canonical:
+        return "/"
+    while "//" in canonical:
+        canonical = canonical.replace("//", "/")
+    if not canonical.startswith("/"):
+        canonical = "/" + canonical
+    if len(canonical) > 1 and canonical.endswith("/"):
+        canonical = canonical.rstrip("/") or "/"
+    return canonical
+
+
 @contextmanager
 def _occ_path_lock(path: str) -> Iterator[None]:
     """Acquire the per-path OCC lock; release + GC the entry on exit."""
+    path = _canonical_lock_key(path)
     with _OCC_GUARD:
         entry = _OCC_ENTRIES.get(path)
         if entry is None:
@@ -127,20 +151,9 @@ def occ_write_sync(
 
     from nexus.contracts.exceptions import ConflictError
 
-    # #4005 round-7: canonicalize the path before keying the lock so
-    # ``foo``, ``/foo``, ``/foo/``, ``//foo`` all resolve to the same
-    # OCC entry. Without this two ``if_match`` writes targeting the same
-    # storage object via different surface forms would acquire different
-    # locks and both commit. Falls back to the raw path if validation
-    # fails — sys_stat below will surface the same error.
-    try:
-        from nexus.core.path_utils import validate_path
-
-        canonical_path = validate_path(path)
-    except Exception:
-        canonical_path = path
-
-    with _occ_path_lock(canonical_path):
+    # _occ_path_lock canonicalizes internally via _canonical_lock_key so
+    # surface aliases (foo, /foo, /foo/, //foo) all hash to one entry.
+    with _occ_path_lock(path):
         meta = fs.sys_stat(path, context=context)
 
         if if_none_match and meta is not None:

--- a/src/nexus/lib/occ.py
+++ b/src/nexus/lib/occ.py
@@ -124,7 +124,20 @@ def occ_write_sync(
 
     from nexus.contracts.exceptions import ConflictError
 
-    with _occ_path_lock(path):
+    # #4005 round-7: canonicalize the path before keying the lock so
+    # ``foo``, ``/foo``, ``/foo/``, ``//foo`` all resolve to the same
+    # OCC entry. Without this two ``if_match`` writes targeting the same
+    # storage object via different surface forms would acquire different
+    # locks and both commit. Falls back to the raw path if validation
+    # fails — sys_stat below will surface the same error.
+    try:
+        from nexus.core.path_utils import validate_path
+
+        canonical_path = validate_path(path)
+    except Exception:
+        canonical_path = path
+
+    with _occ_path_lock(canonical_path):
         meta = fs.sys_stat(path, context=context)
 
         if if_none_match and meta is not None:

--- a/src/nexus/lib/performance_tuning.py
+++ b/src/nexus/lib/performance_tuning.py
@@ -572,7 +572,7 @@ _SANDBOX_TUNING = ProfileTuning(
 _FULL_TUNING = ProfileTuning(
     concurrency=ConcurrencyTuning(
         default_workers=4,
-        thread_pool_size=200,
+        thread_pool_size=40,  # Issue #3997: was 200; anyio upstream default for single-tenant
         max_async_concurrency=10,
         task_runner_workers=4,
     ),
@@ -585,8 +585,8 @@ _FULL_TUNING = ProfileTuning(
         write_buffer_flush_ms=100,
         write_buffer_max_size=100,
         changelog_chunk_size=500,
-        db_pool_size=20,
-        db_max_overflow=30,
+        db_pool_size=5,  # Issue #3997: was 20; Cloud SQL sample sizing for single-tenant
+        db_max_overflow=5,  # Issue #3997: was 30; single-tenant burst headroom
     ),
     search=SearchTuning(
         grep_parallel_workers=4,
@@ -615,13 +615,13 @@ _FULL_TUNING = ProfileTuning(
     connector=ConnectorTuning(
         blob_operation_timeout=60.0,
         large_upload_timeout=300.0,
-        connector_max_workers=20,
+        connector_max_workers=6,  # Issue #3997: was 20; blob ops are I/O-bound
     ),
     pool=PoolTuning(
         asyncpg_min_size=2,
         asyncpg_max_size=5,
-        httpx_max_connections=100,
-        remote_pool_maxsize=20,
+        httpx_max_connections=20,  # Issue #3997: was 100; HTTP/2 collapses anyway
+        remote_pool_maxsize=10,  # Issue #3997: was 20; single-tenant sizing
     ),
     eviction=EvictionTuning(
         memory_high_watermark_pct=85,

--- a/src/nexus/lib/zone_scoping.py
+++ b/src/nexus/lib/zone_scoping.py
@@ -103,3 +103,39 @@ def scope_params_for_zone(params: Any, zone_id: str) -> None:
             attr,
             [scope_single_path(p, prefix, zone_id) for p in value if isinstance(p, str)],
         )
+
+    # #4005 round-7: nested batch payloads — write_batch.files (list of
+    # ``(path, content)`` tuples) and rename_batch.renames (list of
+    # ``(old_path, new_path)`` tuples). Without scoping these, a tenant
+    # caller could embed ``/zone/<other>/...`` paths inside a batch
+    # element and bypass the mismatched-zone rejection in
+    # ``scope_single_path``.
+    files = getattr(params, "files", None)
+    if isinstance(files, (list, tuple)):
+        scoped_files = [
+            (scope_single_path(item[0], prefix, zone_id), *item[1:])
+            if (isinstance(item, (list, tuple)) and len(item) >= 1 and isinstance(item[0], str))
+            else item
+            for item in files
+        ]
+        params.files = type(files)(scoped_files)
+
+    renames = getattr(params, "renames", None)
+    if isinstance(renames, (list, tuple)):
+        scoped_renames = []
+        for item in renames:
+            if isinstance(item, (list, tuple)) and len(item) >= 2:
+                old_p = (
+                    scope_single_path(item[0], prefix, zone_id)
+                    if isinstance(item[0], str)
+                    else item[0]
+                )
+                new_p = (
+                    scope_single_path(item[1], prefix, zone_id)
+                    if isinstance(item[1], str)
+                    else item[1]
+                )
+                scoped_renames.append((old_p, new_p, *item[2:]))
+            else:
+                scoped_renames.append(item)
+        params.renames = type(renames)(scoped_renames)

--- a/src/nexus/lib/zone_scoping.py
+++ b/src/nexus/lib/zone_scoping.py
@@ -112,12 +112,20 @@ def scope_params_for_zone(params: Any, zone_id: str) -> None:
     # ``scope_single_path``.
     files = getattr(params, "files", None)
     if isinstance(files, (list, tuple)):
-        scoped_files = [
-            (scope_single_path(item[0], prefix, zone_id), *item[1:])
-            if (isinstance(item, (list, tuple)) and len(item) >= 1 and isinstance(item[0], str))
-            else item
-            for item in files
-        ]
+        scoped_files: list[Any] = []
+        for item in files:
+            # #4005 round-8: ``files`` has two real shapes:
+            #   - ``list[str]`` for GrepParams / GlobParams (path-only)
+            #   - ``list[tuple[str, bytes]]`` for WriteBatchParams
+            # Without scoping the str shape, a tenant caller can submit
+            # ``["/zone/<other>/x"]`` to grep / glob and bypass the
+            # mismatched-zone rejection.
+            if isinstance(item, str):
+                scoped_files.append(scope_single_path(item, prefix, zone_id))
+            elif isinstance(item, (list, tuple)) and len(item) >= 1 and isinstance(item[0], str):
+                scoped_files.append((scope_single_path(item[0], prefix, zone_id), *item[1:]))
+            else:
+                scoped_files.append(item)
         params.files = type(files)(scoped_files)
 
     renames = getattr(params, "renames", None)

--- a/src/nexus/lib/zone_scoping.py
+++ b/src/nexus/lib/zone_scoping.py
@@ -48,21 +48,32 @@ def scope_single_path(path: str, prefix: str, caller_zone_id: str) -> str:
         ZoneScopingError: If the path has a zone prefix that doesn't match
             the caller's zone.
     """
-    if path.startswith("/zone/"):
+    # #4005 round-9: collapse duplicate slashes BEFORE the prefix decision
+    # so callers cannot bypass the embedded-zone check by slipping an
+    # empty zone segment (``/zone//other/secret.txt`` would otherwise
+    # parse with ``embedded_zone=""`` and skip the mismatch check, then
+    # downstream canonicalization turns it into ``/zone/other/...``).
+    canonical = path
+    while "//" in canonical:
+        canonical = canonical.replace("//", "/")
+
+    if canonical.startswith("/zone/"):
         # Validate embedded zone matches caller's zone
-        embedded_zone = path[6:].split("/", 1)[0]
-        if embedded_zone and embedded_zone != caller_zone_id:
+        embedded_zone = canonical[6:].split("/", 1)[0]
+        if not embedded_zone:
+            raise ZoneScopingError(f"Path '{path}' has empty zone segment after /zone/ — refusing")
+        if embedded_zone != caller_zone_id:
             raise ZoneScopingError(
                 f"Path zone '{embedded_zone}' does not match caller zone '{caller_zone_id}'"
             )
-        return path
+        return canonical
 
-    if path.startswith("/tenant:"):
-        return path
+    if canonical.startswith("/tenant:"):
+        return canonical
 
-    if path.startswith("/"):
-        return f"{prefix}{path}"
-    return f"{prefix}/{path}"
+    if canonical.startswith("/"):
+        return f"{prefix}{canonical}"
+    return f"{prefix}/{canonical}"
 
 
 def scope_params_for_zone(params: Any, zone_id: str) -> None:

--- a/src/nexus/lib/zone_scoping.py
+++ b/src/nexus/lib/zone_scoping.py
@@ -17,7 +17,11 @@ from nexus.contracts.constants import ROOT_ZONE_ID
 logger = logging.getLogger(__name__)
 
 # Path attributes on RPC param dataclasses that must be zone-scoped.
-ZONE_PATH_ATTRS = ("path", "old_path", "new_path")
+# #4005 round-2 review: ``src_path`` / ``dst_path`` cover ``sys_copy`` (and
+# any future copy-shaped syscall) — without them a non-root caller's
+# sys_copy would reach NexusFS with unprefixed paths and bypass the
+# zone-prefix isolation guard for a mutation operation.
+ZONE_PATH_ATTRS = ("path", "old_path", "new_path", "src_path", "dst_path")
 # Bulk/list path attributes that also need zone-scoping.
 ZONE_PATH_LIST_ATTRS = ("paths", "patterns")
 

--- a/src/nexus/server/_kernel_syscall_dispatch.py
+++ b/src/nexus/server/_kernel_syscall_dispatch.py
@@ -64,6 +64,7 @@ KERNEL_SYSCALL_NAMES: frozenset[str] = frozenset(
         "sys_stat",
         "sys_unlink",
         "sys_unlock",
+        "sys_watch",
         "sys_write",
         "write",
     }

--- a/src/nexus/server/_kernel_syscall_dispatch.py
+++ b/src/nexus/server/_kernel_syscall_dispatch.py
@@ -81,6 +81,7 @@ _ALIASES: dict[str, str] = {
     "rename": "sys_rename",
     "rmdir": "rmdir",
     "sys_mkdir": "mkdir",
+    "sys_readdir": "sys_readdir",
     "sys_rmdir": "rmdir",
     "sys_write": "write",
     "write": "write",
@@ -316,7 +317,10 @@ async def _occ_write_dispatch(
             if_none_match=if_none_match,
             offset=offset,
         )
-    return nexus_fs.write(params["path"], content, context=context, offset=offset)
+    # #4005 round-2: NexusFS.write is sync — offload like dispatch_kernel_syscall.
+    return await asyncio.to_thread(
+        nexus_fs.write, params["path"], content, context=context, offset=offset
+    )
 
 
 def _apply_pre_call_defaults(method: str, params: dict[str, Any]) -> dict[str, Any]:
@@ -398,7 +402,11 @@ async def dispatch_kernel_syscall(
         if asyncio.iscoroutinefunction(func):
             raw_result = await func(**kwargs)
         else:
-            raw_result = func(**kwargs)
+            # #4005 round-2: NexusFS sys_* methods are sync and may do
+            # blocking I/O (DB hits, large reads). Calling them inline
+            # would park the asyncio loop — same DoS class that justified
+            # excluding sys_watch. Offload to the default thread pool.
+            raw_result = await asyncio.to_thread(func, **kwargs)
 
     result = _apply_result_adapter(method, raw_result, params)
 

--- a/src/nexus/server/_kernel_syscall_dispatch.py
+++ b/src/nexus/server/_kernel_syscall_dispatch.py
@@ -64,7 +64,6 @@ KERNEL_SYSCALL_NAMES: frozenset[str] = frozenset(
         "sys_stat",
         "sys_unlink",
         "sys_unlock",
-        "sys_watch",
         "sys_write",
         "write",
     }

--- a/src/nexus/server/_rpc_params_generated.py
+++ b/src/nexus/server/_rpc_params_generated.py
@@ -10,24 +10,128 @@ after this module by ``protocol.py``.
 from __future__ import annotations
 
 from dataclasses import dataclass
+from typing import Any
 
 __all__ = [
     "AccessShareLinkParams",
+    "AddMountParams",
+    "AgentHeartbeatParams",
+    "AgentListByZoneParams",
+    "AgentTransitionParams",
+    "AppendParams",
+    "AuditExportParams",
+    "AuditListParams",
+    "BackfillDirectoryIndexParams",
     "CreateShareLinkParams",
+    "DeleteAgentParams",
+    "DeleteBatchParams",
+    "DeleteConnectorParams",
+    "DeleteSavedMountParams",
+    "DeprovisionUserParams",
+    "DiffVersionsParams",
+    "EditParams",
+    "EventsReplayParams",
+    "ExistsBatchParams",
+    "FederationClientWhoamiParams",
+    "FederationClusterInfoParams",
+    "FederationCreateZoneParams",
+    "FederationExportZoneParams",
+    "FederationImportZoneParams",
+    "FederationJoinParams",
+    "FederationListZonesParams",
+    "FederationMountParams",
+    "FederationRemoveZoneParams",
+    "FederationShareParams",
+    "FederationUnmountParams",
+    "FlushWriteObserverParams",
+    "GetAgentParams",
+    "GetContentIdParams",
+    "GetMountParams",
     "GetShareLinkAccessLogsParams",
     "GetShareLinkParams",
+    "GetTopLevelMountsParams",
+    "GetVersionParams",
+    "GetWorkspaceInfoParams",
+    "GlobBatchParams",
+    "GlobParams",
+    "GovernanceAlertsParams",
+    "GovernanceRingsParams",
+    "GovernanceStatusParams",
+    "GrepParams",
+    "HasMountParams",
+    "ListAgentsParams",
+    "ListConnectorsParams",
+    "ListIncomingSharesParams",
+    "ListMountsParams",
+    "ListOutgoingSharesParams",
+    "ListParams",
+    "ListSavedMountsParams",
     "ListShareLinksParams",
+    "ListVersionsParams",
+    "ListWorkspacesParams",
+    "LoadMountParams",
+    "LoadWorkspaceConfigParams",
     "MCPConnectParams",
     "MCPListMountsParams",
     "MCPListToolsParams",
     "MCPMountParams",
     "MCPSyncParams",
     "MCPUnmountParams",
+    "MakePrivateParams",
+    "MakePublicParams",
+    "MetadataBatchParams",
+    "NamespaceDeleteParams",
+    "NamespaceListParams",
     "OAuthListCredentialsParams",
     "OAuthListProvidersParams",
     "OAuthRevokeCredentialParams",
     "OAuthTestCredentialParams",
+    "PayBalanceParams",
+    "PayHistoryParams",
+    "PayTransferParams",
+    "ProvisionUserParams",
+    "ReadBatchParams",
+    "ReadBulkParams",
+    "ReauthMountParams",
+    "RebacCheckParams",
+    "RebacCreateParams",
+    "RebacDeleteParams",
+    "RebacExpandParams",
+    "RebacExplainParams",
+    "RebacListObjectsParams",
+    "RebacListTuplesParams",
+    "RegisterAgentParams",
+    "RegisterWorkspaceParams",
+    "RemoveMountParams",
+    "RenameBatchParams",
+    "RevokeShareByIdParams",
     "RevokeShareLinkParams",
+    "RevokeShareParams",
+    "RollbackParams",
+    "SaveMountParams",
+    "SemanticSearchIndexParams",
+    "SemanticSearchParams",
+    "ShareWithUserParams",
+    "SnapshotBeginParams",
+    "SnapshotCommitParams",
+    "SnapshotCreateParams",
+    "SnapshotGetParams",
+    "SnapshotListEntriesParams",
+    "SnapshotListParams",
+    "SnapshotRestoreParams",
+    "SnapshotRollbackParams",
+    "StatBulkParams",
+    "StatParams",
+    "SysWatchParams",
+    "UnregisterWorkspaceParams",
+    "UpdateAgentParams",
+    "UpdateMountParams",
+    "UpdateWorkspaceParams",
+    "WorkspaceDiffParams",
+    "WorkspaceLogParams",
+    "WorkspaceRestoreParams",
+    "WorkspaceSnapshotParams",
+    "WriteBatchParams",
 ]
 
 
@@ -42,6 +146,81 @@ class AccessShareLinkParams:
 
 
 @dataclass
+class AddMountParams:
+    """Parameters for add_mount(): Add a dynamic backend mount to the filesystem."""
+
+    mount_point: str
+    backend_type: str
+    backend_config: dict[str, Any]
+
+
+@dataclass
+class AgentHeartbeatParams:
+    """Parameters for agent_heartbeat(): Record a heartbeat for an active agent."""
+
+    agent_id: str
+    context: dict | None = None
+
+
+@dataclass
+class AgentListByZoneParams:
+    """Parameters for agent_list_by_zone(): List agents in a zone, optionally filtered by state."""
+
+    zone_id: str
+    state: str | None = None
+    context: dict | None = None
+
+
+@dataclass
+class AgentTransitionParams:
+    """Parameters for agent_transition(): Transition an agent's lifecycle state with optimistic locking."""
+
+    agent_id: str
+    target_state: str
+    expected_generation: int | None = None
+    context: dict | None = None
+
+
+@dataclass
+class AppendParams:
+    """Parameters for append(): Append content to an existing file or create a new file if it doesn't exist."""
+
+    path: str
+    content: bytes | str
+    if_match: str | None = None
+    force: bool = False
+
+
+@dataclass
+class AuditExportParams:
+    """Parameters for audit_export() method."""
+
+    fmt: str = "json"
+    since: str | None = None
+    until: str | None = None
+
+
+@dataclass
+class AuditListParams:
+    """Parameters for audit_list() method."""
+
+    since: str | None = None
+    until: str | None = None
+    agent_id: str | None = None
+    action: str | None = None
+    limit: int = 50
+    cursor: str | None = None
+
+
+@dataclass
+class BackfillDirectoryIndexParams:
+    """Parameters for backfill_directory_index(): Backfill sparse directory index from existing files."""
+
+    prefix: str = "/"
+    zone_id: str | None = None
+
+
+@dataclass
 class CreateShareLinkParams:
     """Parameters for create_share_link(): Create a shareable link for a file or directory."""
 
@@ -50,6 +229,223 @@ class CreateShareLinkParams:
     expires_in_hours: int | None = None
     max_access_count: int | None = None
     password: str | None = None
+
+
+@dataclass
+class DeleteAgentParams:
+    """Parameters for delete_agent(): Delete a registered agent."""
+
+    agent_id: str
+
+
+@dataclass
+class DeleteBatchParams:
+    """Parameters for delete_batch(): Delete multiple files or directories in a single operation."""
+
+    paths: list[str]
+    recursive: bool = False
+
+
+@dataclass
+class DeleteConnectorParams:
+    """Parameters for delete_connector(): Delete a connector completely with bundled operations."""
+
+    mount_point: str
+    revoke_oauth: bool = False
+    provider: str | None = None
+    user_email: str | None = None
+
+
+@dataclass
+class DeleteSavedMountParams:
+    """Parameters for delete_saved_mount(): Delete a saved mount configuration from the database."""
+
+    mount_point: str
+
+
+@dataclass
+class DeprovisionUserParams:
+    """Parameters for deprovision_user(): Deprovision a user and remove all their resources."""
+
+    user_id: str
+    zone_id: str | None = None
+    delete_user_record: bool = False
+    force: bool = False
+
+
+@dataclass
+class DiffVersionsParams:
+    """Parameters for diff_versions(): Compare two versions of a file."""
+
+    path: str
+    v1: int
+    v2: int
+    mode: str = "metadata"
+
+
+@dataclass
+class EditParams:
+    """Parameters for edit(): Apply surgical search/replace edits to a file."""
+
+    path: str
+    edits: list[tuple[str, str]] | list[dict[str, Any]] | list[Any]
+    if_match: str | None = None
+    fuzzy_threshold: float = 0.85
+    preview: bool = False
+
+    def __post_init__(self) -> None:
+        """Convert lists to tuples (JSON deserializes tuples as lists)."""
+        if isinstance(self.edits, list):
+            object.__setattr__(self, "edits", tuple(self.edits))
+
+
+@dataclass
+class EventsReplayParams:
+    """Parameters for events_replay() method."""
+
+    since: str | None = None
+    event_type: str | None = None
+    path: str | None = None
+    limit: int = 50
+
+
+@dataclass
+class ExistsBatchParams:
+    """Parameters for exists_batch(): Check existence of multiple paths in a single call (Issue #859)."""
+
+    paths: list[str]
+
+
+@dataclass
+class FederationClientWhoamiParams:
+    """Parameters for federation_client_whoami(): Return the caller's zone grants for federation handshake."""
+
+    pass
+
+
+@dataclass
+class FederationClusterInfoParams:
+    """Parameters for federation_cluster_info() method."""
+
+    zone_id: str
+
+
+@dataclass
+class FederationCreateZoneParams:
+    """Parameters for federation_create_zone() method."""
+
+    zone_id: str
+
+
+@dataclass
+class FederationExportZoneParams:
+    """Parameters for federation_export_zone(): Export a raft-backed zone to a .nexus bundle on the server's"""
+
+    zone_id: str
+    output_path: str
+    include_content: bool = True
+    include_permissions: bool = True
+    include_embeddings: bool = False
+    include_deleted: bool = False
+    path_prefix: str | None = None
+    sign: bool = False
+    strip_credentials: bool = False
+    after_time: str | None = None
+    before_time: str | None = None
+
+
+@dataclass
+class FederationImportZoneParams:
+    """Parameters for federation_import_zone(): Import a zone bundle from the server's filesystem."""
+
+    bundle_path: str
+    target_zone: str | None = None
+    conflict: str = "skip"
+    preserve_timestamps: bool = True
+    import_permissions: bool = True
+    path_prefix_remap: dict[str, str] | None = None
+    force: bool = False
+    rebuild_embeddings: bool = False
+    injections: dict[str, str] | None = None
+    require_no_placeholders: bool = True
+
+
+@dataclass
+class FederationJoinParams:
+    """Parameters for federation_join(): Join a zone advertised by a peer at `remote_path` and mount"""
+
+    peer_addr: str
+    remote_path: str
+    local_path: str
+
+
+@dataclass
+class FederationListZonesParams:
+    """Parameters for federation_list_zones() method."""
+
+    pass
+
+
+@dataclass
+class FederationMountParams:
+    """Parameters for federation_mount(): Mount ``target_zone`` at ``path`` (global VFS) inside"""
+
+    parent_zone: str
+    path: str
+    target_zone: str
+    source: str | None = None
+
+
+@dataclass
+class FederationRemoveZoneParams:
+    """Parameters for federation_remove_zone() method."""
+
+    zone_id: str
+    force: bool = False
+
+
+@dataclass
+class FederationShareParams:
+    """Parameters for federation_share(): Publish `local_path`'s subtree as a standalone federation zone."""
+
+    local_path: str
+    zone_id: str | None = None
+
+
+@dataclass
+class FederationUnmountParams:
+    """Parameters for federation_unmount() method."""
+
+    parent_zone: str
+    path: str
+
+
+@dataclass
+class FlushWriteObserverParams:
+    """Parameters for flush_write_observer(): Flush the write observer so pending version/audit records are committed."""
+
+    pass
+
+
+@dataclass
+class GetAgentParams:
+    """Parameters for get_agent(): Get information about a registered agent."""
+
+    agent_id: str
+
+
+@dataclass
+class GetContentIdParams:
+    """Parameters for get_content_id(): Get content hash for HTTP If-None-Match checks."""
+
+    path: str
+
+
+@dataclass
+class GetMountParams:
+    """Parameters for get_mount(): Get details about a specific mount."""
+
+    mount_point: str
 
 
 @dataclass
@@ -68,12 +464,223 @@ class GetShareLinkAccessLogsParams:
 
 
 @dataclass
+class GetTopLevelMountsParams:
+    """Parameters for get_top_level_mounts(): Return top-level mount names visible to the current user."""
+
+    pass
+
+
+@dataclass
+class GetVersionParams:
+    """Parameters for get_version(): Get a specific version of a file."""
+
+    path: str
+    version: int
+
+
+@dataclass
+class GetWorkspaceInfoParams:
+    """Parameters for get_workspace_info(): Get information about a registered workspace."""
+
+    path: str
+
+
+@dataclass
+class GlobParams:
+    """Parameters for glob(): Find files matching a glob pattern."""
+
+    pattern: str
+    path: str = "/"
+    context: Any = None
+    files: list[str] | None = None
+
+
+@dataclass
+class GlobBatchParams:
+    """Parameters for glob_batch(): Execute multiple glob patterns in a single call (Issue #859)."""
+
+    patterns: list[str]
+    path: str = "/"
+    context: Any = None
+
+
+@dataclass
+class GovernanceAlertsParams:
+    """Parameters for governance_alerts() method."""
+
+    severity: str | None = None
+    limit: int = 50
+
+
+@dataclass
+class GovernanceRingsParams:
+    """Parameters for governance_rings() method."""
+
+    pass
+
+
+@dataclass
+class GovernanceStatusParams:
+    """Parameters for governance_status() method."""
+
+    pass
+
+
+@dataclass
+class GrepParams:
+    """Parameters for grep(): Public grep entry point with activity-event instrumentation (#3791)."""
+
+    pattern: str
+    path: str = "/"
+    file_pattern: str | None = None
+    ignore_case: bool = False
+    max_results: int = 100
+    search_mode: str = "auto"
+    context: Any = None
+    before_context: int = 0
+    after_context: int = 0
+    invert_match: bool = False
+    files: list[str] | None = None
+    block_type: str | None = None
+
+
+@dataclass
+class HasMountParams:
+    """Parameters for has_mount(): Check if a mount exists at the given path."""
+
+    mount_point: str
+
+
+@dataclass
+class ListParams:
+    """Parameters for list(): List files in a directory."""
+
+    path: str = "/"
+    recursive: bool = True
+    details: bool = False
+    show_parsed: bool = True
+    context: Any = None
+    limit: int | None = None
+    cursor: str | None = None
+
+
+@dataclass
+class ListAgentsParams:
+    """Parameters for list_agents(): List all registered agents."""
+
+    pass
+
+
+@dataclass
+class ListConnectorsParams:
+    """Parameters for list_connectors(): List all available connector types that can be used with add_mount()."""
+
+    category: str | None = None
+
+
+@dataclass
+class ListIncomingSharesParams:
+    """Parameters for list_incoming_shares(): List all resources shared with a subject."""
+
+    subject: tuple[str, str]
+    object_type: str = "file"
+    zone_id: str | None = None
+
+    def __post_init__(self) -> None:
+        """Convert lists to tuples (JSON deserializes tuples as lists)."""
+        if isinstance(self.subject, list):
+            object.__setattr__(self, "subject", tuple(self.subject))
+
+
+@dataclass
+class ListMountsParams:
+    """Parameters for list_mounts(): List all active backend mounts that the user has permission to access."""
+
+    pass
+
+
+@dataclass
+class ListOutgoingSharesParams:
+    """Parameters for list_outgoing_shares(): List all shares granted on a resource."""
+
+    resource: tuple[str, str]
+    zone_id: str | None = None
+
+    def __post_init__(self) -> None:
+        """Convert lists to tuples (JSON deserializes tuples as lists)."""
+        if isinstance(self.resource, list):
+            object.__setattr__(self, "resource", tuple(self.resource))
+
+
+@dataclass
+class ListSavedMountsParams:
+    """Parameters for list_saved_mounts(): List mount configurations saved in the database."""
+
+    owner_user_id: str | None = None
+    zone_id: str | None = None
+
+
+@dataclass
 class ListShareLinksParams:
     """Parameters for list_share_links(): List share links created by the current user."""
 
     path: str | None = None
     include_revoked: bool = False
     include_expired: bool = False
+
+
+@dataclass
+class ListVersionsParams:
+    """Parameters for list_versions(): List all versions of a file."""
+
+    path: str
+
+
+@dataclass
+class ListWorkspacesParams:
+    """Parameters for list_workspaces(): List all registered workspaces for the current user."""
+
+    context: Any | None = None
+
+
+@dataclass
+class LoadMountParams:
+    """Parameters for load_mount(): Load a saved mount configuration and activate it."""
+
+    mount_point: str
+
+
+@dataclass
+class LoadWorkspaceConfigParams:
+    """Parameters for load_workspace_config(): Load workspaces from configuration."""
+
+    workspaces: list[dict] | None = None
+
+
+@dataclass
+class MakePrivateParams:
+    """Parameters for make_private(): Remove public (wildcard) access from a resource."""
+
+    resource: tuple[str, str]
+    zone_id: str | None = None
+
+    def __post_init__(self) -> None:
+        """Convert lists to tuples (JSON deserializes tuples as lists)."""
+        if isinstance(self.resource, list):
+            object.__setattr__(self, "resource", tuple(self.resource))
+
+
+@dataclass
+class MakePublicParams:
+    """Parameters for make_public(): Make a resource publicly accessible (wildcard viewer)."""
+
+    resource: tuple[str, str]
+    zone_id: str | None = None
+
+    def __post_init__(self) -> None:
+        """Convert lists to tuples (JSON deserializes tuples as lists)."""
+        if isinstance(self.resource, list):
+            object.__setattr__(self, "resource", tuple(self.resource))
 
 
 @dataclass
@@ -129,6 +736,28 @@ class MCPUnmountParams:
 
 
 @dataclass
+class MetadataBatchParams:
+    """Parameters for metadata_batch(): Get metadata for multiple paths in a single call (Issue #859)."""
+
+    paths: list[str]
+
+
+@dataclass
+class NamespaceDeleteParams:
+    """Parameters for namespace_delete(): Delete all tuples for a namespace's object type."""
+
+    object_type: str
+    zone_id: str | None = None
+
+
+@dataclass
+class NamespaceListParams:
+    """Parameters for namespace_list(): List all registered namespace configurations."""
+
+    pass
+
+
+@dataclass
 class OAuthListCredentialsParams:
     """Parameters for oauth_list_credentials(): List all OAuth credentials for the current user."""
 
@@ -160,27 +789,604 @@ class OAuthTestCredentialParams:
 
 
 @dataclass
+class PayBalanceParams:
+    """Parameters for pay_balance() method."""
+
+    agent_id: str | None = None
+
+
+@dataclass
+class PayHistoryParams:
+    """Parameters for pay_history() method."""
+
+    since: str | None = None
+    limit: int = 50
+    cursor: str | None = None
+
+
+@dataclass
+class PayTransferParams:
+    """Parameters for pay_transfer() method."""
+
+    to: str
+    amount: str
+    memo: str = ""
+    method: str = "auto"
+    from_agent: str = "anonymous"
+
+
+@dataclass
+class ProvisionUserParams:
+    """Parameters for provision_user(): Provision a new user with all default resources (Issue #820)."""
+
+    user_id: str
+    email: str
+    display_name: str | None = None
+    zone_id: str | None = None
+    zone_name: str | None = None
+    create_api_key: bool = True
+    api_key_name: str | None = None
+    api_key_expires_at: str | None = None
+    create_agents: bool = True
+    import_skills: bool = False
+
+
+@dataclass
+class ReadBatchParams:
+    """Parameters for read_batch(): Read multiple files in a single round-trip for improved performance."""
+
+    paths: list[str]
+    partial: bool = False
+
+
+@dataclass
+class ReadBulkParams:
+    """Parameters for read_bulk(): Read multiple files in a single RPC call for improved performance."""
+
+    paths: list[str]
+    return_metadata: bool = False
+    skip_errors: bool = True
+
+
+@dataclass
+class ReauthMountParams:
+    """Parameters for reauth_mount(): Refresh or rotate OAuth credentials for a mounted connector."""
+
+    mount_point: str
+    provider: str | None = None
+    user_email: str | None = None
+
+
+@dataclass
+class RebacCheckParams:
+    """Parameters for rebac_check(): Check if subject has permission on object."""
+
+    subject: tuple[str, str]
+    permission: str
+    object: tuple[str, str]
+    context: Any = None
+    zone_id: str | None = None
+
+    def __post_init__(self) -> None:
+        """Convert lists to tuples (JSON deserializes tuples as lists)."""
+        if isinstance(self.subject, list):
+            object.__setattr__(self, "subject", tuple(self.subject))
+        if isinstance(self.object, list):
+            object.__setattr__(self, "object", tuple(self.object))
+
+
+@dataclass
+class RebacCreateParams:
+    """Parameters for rebac_create(): Create a ReBAC relationship tuple (Issue #1081)."""
+
+    subject: tuple[str, str]
+    relation: str
+    object: tuple[str, str]
+    expires_at: str | None = None
+    zone_id: str | None = None
+    context: Any = None
+    column_config: dict[str, Any] | None = None
+    conditions: dict[str, Any] | None = None
+
+    def __post_init__(self) -> None:
+        """Convert lists to tuples (JSON deserializes tuples as lists)."""
+        if isinstance(self.subject, list):
+            object.__setattr__(self, "subject", tuple(self.subject))
+        if isinstance(self.object, list):
+            object.__setattr__(self, "object", tuple(self.object))
+
+
+@dataclass
+class RebacDeleteParams:
+    """Parameters for rebac_delete(): Delete a relationship tuple by ID."""
+
+    tuple_id: str
+
+
+@dataclass
+class RebacExpandParams:
+    """Parameters for rebac_expand(): Find all subjects that have a permission on an object."""
+
+    permission: str
+    object: tuple[str, str]
+    zone_id: str | None = None
+
+    def __post_init__(self) -> None:
+        """Convert lists to tuples (JSON deserializes tuples as lists)."""
+        if isinstance(self.object, list):
+            object.__setattr__(self, "object", tuple(self.object))
+
+
+@dataclass
+class RebacExplainParams:
+    """Parameters for rebac_explain(): Explain why a subject has or doesn't have permission."""
+
+    subject: tuple[str, str]
+    permission: str
+    object: tuple[str, str]
+    zone_id: str | None = None
+    context: Any = None
+
+    def __post_init__(self) -> None:
+        """Convert lists to tuples (JSON deserializes tuples as lists)."""
+        if isinstance(self.subject, list):
+            object.__setattr__(self, "subject", tuple(self.subject))
+        if isinstance(self.object, list):
+            object.__setattr__(self, "object", tuple(self.object))
+
+
+@dataclass
+class RebacListObjectsParams:
+    """Parameters for rebac_list_objects(): List objects that a subject has a given relation to."""
+
+    relation: str
+    subject: tuple[str, str]
+    zone_id: str | None = None
+
+    def __post_init__(self) -> None:
+        """Convert lists to tuples (JSON deserializes tuples as lists)."""
+        if isinstance(self.subject, list):
+            object.__setattr__(self, "subject", tuple(self.subject))
+
+
+@dataclass
+class RebacListTuplesParams:
+    """Parameters for rebac_list_tuples(): List relationship tuples with optional filters."""
+
+    subject: tuple[str, str] | None = None
+    relation: str | None = None
+    object: tuple[str, str] | None = None
+    relation_in: list[str] | None = None
+
+    def __post_init__(self) -> None:
+        """Convert lists to tuples (JSON deserializes tuples as lists)."""
+        if isinstance(self.subject, list):
+            object.__setattr__(self, "subject", tuple(self.subject))
+        if isinstance(self.object, list):
+            object.__setattr__(self, "object", tuple(self.object))
+
+
+@dataclass
+class RegisterAgentParams:
+    """Parameters for register_agent(): Register an AI agent."""
+
+    agent_id: str
+    name: str
+    description: str | None = None
+    generate_api_key: bool = False
+    metadata: dict | None = None
+    capabilities: list[str] | None = None
+    context: dict | None = None
+
+
+@dataclass
+class RegisterWorkspaceParams:
+    """Parameters for register_workspace(): Register a directory as a workspace."""
+
+    path: str
+    name: str | None = None
+    description: str | None = None
+    created_by: str | None = None
+    tags: list[str] | None = None
+    metadata: dict[str, Any] | None = None
+    session_id: str | None = None
+    ttl: str | None = None
+    context: Any | None = None
+
+
+@dataclass
+class RemoveMountParams:
+    """Parameters for remove_mount(): Remove a backend mount from the filesystem."""
+
+    mount_point: str
+
+
+@dataclass
+class RenameBatchParams:
+    """Parameters for rename_batch(): Rename/move multiple files in a single operation."""
+
+    renames: list[tuple[str, str]]
+
+    def __post_init__(self) -> None:
+        """Convert lists to tuples (JSON deserializes tuples as lists)."""
+        if isinstance(self.renames, list):
+            object.__setattr__(self, "renames", tuple(self.renames))
+
+
+@dataclass
+class RevokeShareParams:
+    """Parameters for revoke_share(): Revoke a specific share (find and delete the matching tuple)."""
+
+    resource: tuple[str, str]
+    target: tuple[str, str]
+    permission: str = "viewer"
+    zone_id: str | None = None
+    context: Any = None
+
+    def __post_init__(self) -> None:
+        """Convert lists to tuples (JSON deserializes tuples as lists)."""
+        if isinstance(self.resource, list):
+            object.__setattr__(self, "resource", tuple(self.resource))
+        if isinstance(self.target, list):
+            object.__setattr__(self, "target", tuple(self.target))
+
+
+@dataclass
+class RevokeShareByIdParams:
+    """Parameters for revoke_share_by_id(): Revoke a share by its tuple ID."""
+
+    tuple_id: str
+    context: Any = None
+
+
+@dataclass
 class RevokeShareLinkParams:
     """Parameters for revoke_share_link(): Revoke a share link, immediately disabling access."""
 
     link_id: str
 
 
+@dataclass
+class RollbackParams:
+    """Parameters for rollback(): Rollback file to a previous version."""
+
+    path: str
+    version: int
+
+
+@dataclass
+class SaveMountParams:
+    """Parameters for save_mount(): Save a mount configuration to the database for persistence."""
+
+    mount_point: str
+    backend_type: str
+    backend_config: dict[str, Any]
+    owner_user_id: str | None = None
+    zone_id: str | None = None
+    description: str | None = None
+
+
+@dataclass
+class SemanticSearchParams:
+    """Parameters for semantic_search(): Public semantic-search entry point with activity-event instrumentation (#3791)."""
+
+    query: str
+    path: str = "/"
+    limit: int = 10
+    filters: dict[str, Any] | None = None
+    search_mode: str = "semantic"
+
+
+@dataclass
+class SemanticSearchIndexParams:
+    """Parameters for semantic_search_index(): Index documents for semantic search."""
+
+    path: str = "/"
+    recursive: bool = True
+
+
+@dataclass
+class ShareWithUserParams:
+    """Parameters for share_with_user(): Share a resource with a specific user."""
+
+    resource: tuple[str, str]
+    target_user: str
+    permission: str = "viewer"
+    zone_id: str | None = None
+    context: Any = None
+
+    def __post_init__(self) -> None:
+        """Convert lists to tuples (JSON deserializes tuples as lists)."""
+        if isinstance(self.resource, list):
+            object.__setattr__(self, "resource", tuple(self.resource))
+
+
+@dataclass
+class SnapshotBeginParams:
+    """Parameters for snapshot_begin(): Begin a transactional snapshot."""
+
+    agent_id: str | None = None
+    zone_id: str | None = None
+    description: str | None = None
+    ttl_seconds: int = 3600
+
+
+@dataclass
+class SnapshotCommitParams:
+    """Parameters for snapshot_commit() method."""
+
+    transaction_id: str
+
+
+@dataclass
+class SnapshotCreateParams:
+    """Parameters for snapshot_create() method."""
+
+    description: str | None = None
+    ttl_seconds: int = 3600
+
+
+@dataclass
+class SnapshotGetParams:
+    """Parameters for snapshot_get() method."""
+
+    transaction_id: str
+
+
+@dataclass
+class SnapshotListParams:
+    """Parameters for snapshot_list() method."""
+
+    pass
+
+
+@dataclass
+class SnapshotListEntriesParams:
+    """Parameters for snapshot_list_entries() method."""
+
+    transaction_id: str
+
+
+@dataclass
+class SnapshotRestoreParams:
+    """Parameters for snapshot_restore() method."""
+
+    txn_id: str
+
+
+@dataclass
+class SnapshotRollbackParams:
+    """Parameters for snapshot_rollback(): Rollback a snapshot — restore paths to pre-snapshot state."""
+
+    snapshot_id: str
+
+
+@dataclass
+class StatParams:
+    """Parameters for stat(): Get file metadata without reading the file content."""
+
+    path: str
+
+
+@dataclass
+class StatBulkParams:
+    """Parameters for stat_bulk(): Get metadata for multiple files in a single RPC call."""
+
+    paths: list[str]
+    skip_errors: bool = True
+
+
+@dataclass
+class SysWatchParams:
+    """Parameters for sys_watch(): Wait for file changes (inotify(7)). Returns FileEvent dict or None on timeout."""
+
+    path: str
+    timeout: float = 30.0
+    recursive: bool = False
+
+
+@dataclass
+class UnregisterWorkspaceParams:
+    """Parameters for unregister_workspace(): Unregister a workspace (does NOT delete files)."""
+
+    path: str
+
+
+@dataclass
+class UpdateAgentParams:
+    """Parameters for update_agent(): Update an existing agent's configuration."""
+
+    agent_id: str
+    name: str | None = None
+    description: str | None = None
+    metadata: dict | None = None
+    context: dict | None = None
+
+
+@dataclass
+class UpdateMountParams:
+    """Parameters for update_mount(): Update a mount's backend configuration without removing it."""
+
+    mount_point: str
+    backend_config: dict[str, Any]
+
+
+@dataclass
+class UpdateWorkspaceParams:
+    """Parameters for update_workspace(): Update an existing workspace configuration."""
+
+    path: str
+    name: str | None = None
+    description: str | None = None
+    metadata: dict | None = None
+
+
+@dataclass
+class WorkspaceDiffParams:
+    """Parameters for workspace_diff(): Compare two workspace snapshots."""
+
+    snapshot_1: int
+    snapshot_2: int
+    workspace_path: str | None = None
+
+
+@dataclass
+class WorkspaceLogParams:
+    """Parameters for workspace_log(): List snapshot history for workspace."""
+
+    workspace_path: str | None = None
+    limit: int = 100
+
+
+@dataclass
+class WorkspaceRestoreParams:
+    """Parameters for workspace_restore(): Restore workspace to a previous snapshot."""
+
+    snapshot_number: int
+    workspace_path: str | None = None
+
+
+@dataclass
+class WorkspaceSnapshotParams:
+    """Parameters for workspace_snapshot(): Create a snapshot of a registered workspace."""
+
+    workspace_path: str | None = None
+    description: str | None = None
+    tags: list[str] | None = None
+    created_by: str | None = None
+    context: dict | None = None
+
+
+@dataclass
+class WriteBatchParams:
+    """Parameters for write_batch(): Write multiple files in a single round-trip for improved performance."""
+
+    files: list[tuple[str, bytes]]
+
+    def __post_init__(self) -> None:
+        """Convert lists to tuples (JSON deserializes tuples as lists)."""
+        if isinstance(self.files, list):
+            object.__setattr__(self, "files", tuple(self.files))
+
+
 METHOD_PARAMS: dict[str, type] = {
     "access_share_link": AccessShareLinkParams,
+    "add_mount": AddMountParams,
+    "agent_heartbeat": AgentHeartbeatParams,
+    "agent_list_by_zone": AgentListByZoneParams,
+    "agent_transition": AgentTransitionParams,
+    "append": AppendParams,
+    "audit_export": AuditExportParams,
+    "audit_list": AuditListParams,
+    "backfill_directory_index": BackfillDirectoryIndexParams,
     "create_share_link": CreateShareLinkParams,
+    "delete_agent": DeleteAgentParams,
+    "delete_batch": DeleteBatchParams,
+    "delete_connector": DeleteConnectorParams,
+    "delete_saved_mount": DeleteSavedMountParams,
+    "deprovision_user": DeprovisionUserParams,
+    "diff_versions": DiffVersionsParams,
+    "edit": EditParams,
+    "events_replay": EventsReplayParams,
+    "exists_batch": ExistsBatchParams,
+    "federation_client_whoami": FederationClientWhoamiParams,
+    "federation_cluster_info": FederationClusterInfoParams,
+    "federation_create_zone": FederationCreateZoneParams,
+    "federation_export_zone": FederationExportZoneParams,
+    "federation_import_zone": FederationImportZoneParams,
+    "federation_join": FederationJoinParams,
+    "federation_list_zones": FederationListZonesParams,
+    "federation_mount": FederationMountParams,
+    "federation_remove_zone": FederationRemoveZoneParams,
+    "federation_share": FederationShareParams,
+    "federation_unmount": FederationUnmountParams,
+    "flush_write_observer": FlushWriteObserverParams,
+    "get_agent": GetAgentParams,
+    "get_content_id": GetContentIdParams,
+    "get_mount": GetMountParams,
     "get_share_link": GetShareLinkParams,
     "get_share_link_access_logs": GetShareLinkAccessLogsParams,
+    "get_top_level_mounts": GetTopLevelMountsParams,
+    "get_version": GetVersionParams,
+    "get_workspace_info": GetWorkspaceInfoParams,
+    "glob": GlobParams,
+    "glob_batch": GlobBatchParams,
+    "governance_alerts": GovernanceAlertsParams,
+    "governance_rings": GovernanceRingsParams,
+    "governance_status": GovernanceStatusParams,
+    "grep": GrepParams,
+    "has_mount": HasMountParams,
+    "list": ListParams,
+    "list_agents": ListAgentsParams,
+    "list_connectors": ListConnectorsParams,
+    "list_incoming_shares": ListIncomingSharesParams,
+    "list_mounts": ListMountsParams,
+    "list_outgoing_shares": ListOutgoingSharesParams,
+    "list_saved_mounts": ListSavedMountsParams,
     "list_share_links": ListShareLinksParams,
+    "list_versions": ListVersionsParams,
+    "list_workspaces": ListWorkspacesParams,
+    "load_mount": LoadMountParams,
+    "load_workspace_config": LoadWorkspaceConfigParams,
+    "make_private": MakePrivateParams,
+    "make_public": MakePublicParams,
     "mcp_connect": MCPConnectParams,
     "mcp_list_mounts": MCPListMountsParams,
     "mcp_list_tools": MCPListToolsParams,
     "mcp_mount": MCPMountParams,
     "mcp_sync": MCPSyncParams,
     "mcp_unmount": MCPUnmountParams,
+    "metadata_batch": MetadataBatchParams,
+    "namespace_delete": NamespaceDeleteParams,
+    "namespace_list": NamespaceListParams,
     "oauth_list_credentials": OAuthListCredentialsParams,
     "oauth_list_providers": OAuthListProvidersParams,
     "oauth_revoke_credential": OAuthRevokeCredentialParams,
     "oauth_test_credential": OAuthTestCredentialParams,
+    "pay_balance": PayBalanceParams,
+    "pay_history": PayHistoryParams,
+    "pay_transfer": PayTransferParams,
+    "provision_user": ProvisionUserParams,
+    "read_batch": ReadBatchParams,
+    "read_bulk": ReadBulkParams,
+    "reauth_mount": ReauthMountParams,
+    "rebac_check": RebacCheckParams,
+    "rebac_create": RebacCreateParams,
+    "rebac_delete": RebacDeleteParams,
+    "rebac_expand": RebacExpandParams,
+    "rebac_explain": RebacExplainParams,
+    "rebac_list_objects": RebacListObjectsParams,
+    "rebac_list_tuples": RebacListTuplesParams,
+    "register_agent": RegisterAgentParams,
+    "register_workspace": RegisterWorkspaceParams,
+    "remove_mount": RemoveMountParams,
+    "rename_batch": RenameBatchParams,
+    "revoke_share": RevokeShareParams,
+    "revoke_share_by_id": RevokeShareByIdParams,
     "revoke_share_link": RevokeShareLinkParams,
+    "rollback": RollbackParams,
+    "save_mount": SaveMountParams,
+    "semantic_search": SemanticSearchParams,
+    "semantic_search_index": SemanticSearchIndexParams,
+    "share_with_user": ShareWithUserParams,
+    "snapshot_begin": SnapshotBeginParams,
+    "snapshot_commit": SnapshotCommitParams,
+    "snapshot_create": SnapshotCreateParams,
+    "snapshot_get": SnapshotGetParams,
+    "snapshot_list": SnapshotListParams,
+    "snapshot_list_entries": SnapshotListEntriesParams,
+    "snapshot_restore": SnapshotRestoreParams,
+    "snapshot_rollback": SnapshotRollbackParams,
+    "stat": StatParams,
+    "stat_bulk": StatBulkParams,
+    "sys_watch": SysWatchParams,
+    "unregister_workspace": UnregisterWorkspaceParams,
+    "update_agent": UpdateAgentParams,
+    "update_mount": UpdateMountParams,
+    "update_workspace": UpdateWorkspaceParams,
+    "workspace_diff": WorkspaceDiffParams,
+    "workspace_log": WorkspaceLogParams,
+    "workspace_restore": WorkspaceRestoreParams,
+    "workspace_snapshot": WorkspaceSnapshotParams,
+    "write_batch": WriteBatchParams,
 }

--- a/src/nexus/server/api/core/rpc.py
+++ b/src/nexus/server/api/core/rpc.py
@@ -54,6 +54,10 @@ async def rpc_endpoint(
     """
     import time as _time
 
+    from nexus.server._kernel_syscall_dispatch import (
+        KERNEL_SYSCALL_NAMES,
+        dispatch_kernel_syscall,
+    )
     from nexus.server.dependencies import get_operation_context
     from nexus.server.rpc.dispatch import dispatch_method
 
@@ -79,6 +83,44 @@ async def rpc_endpoint(
         # Set method from URL if not in body
         if not rpc_request.method:
             rpc_request.method = method
+
+        # #4005 review: kernel syscalls (sys_readdir, sys_stat, etc.) have no
+        # generated Params dataclass — they go through the inspect.signature
+        # dispatcher in ``_kernel_syscall_dispatch``. Mirror what the gRPC
+        # ``Call`` servicer does: short-circuit BEFORE ``parse_method_params``
+        # so HTTP RPC clients (legacy CLI/proxy) don't get rejected with
+        # "Unknown method: sys_readdir".
+        if method in KERNEL_SYSCALL_NAMES:
+            from types import SimpleNamespace
+
+            context = get_operation_context(auth_result)
+            raw_params = dict(rpc_request.params or {})
+            # ``scope_params_for_zone`` mutates via setattr — mirror the gRPC
+            # servicer pattern (``servicer.py`` ~line 227): wrap in
+            # SimpleNamespace, scope, then unwrap back to dict for
+            # ``dispatch_kernel_syscall`` (which decodes via inspect.signature).
+            _params_ns = SimpleNamespace(**raw_params)
+            scope_params_for_zone(_params_ns, context.zone_id)
+            raw_params = vars(_params_ns)
+            state = request.app.state
+            result = await dispatch_kernel_syscall(
+                state.nexus_fs,
+                method,
+                raw_params,
+                context,
+                subscription_manager=state.subscription_manager,
+            )
+            headers = get_cache_headers(method, result)
+            headers["Deprecation"] = "true"
+            headers["Sunset"] = "Wed, 25 Jun 2026 00:00:00 GMT"
+            headers["X-Migration-Guide"] = "Use gRPC Call RPC (Issue #1133)"
+            success_response = {
+                "jsonrpc": "2.0",
+                "id": rpc_request.id,
+                "result": result,
+            }
+            encoded = encode_rpc_message(success_response)
+            return Response(content=encoded, media_type="application/json", headers=headers)
 
         # Parse parameters — fall through to SimpleNamespace for dynamically
         # discovered @rpc_expose methods that lack pre-generated Params classes

--- a/src/nexus/server/api/core/rpc.py
+++ b/src/nexus/server/api/core/rpc.py
@@ -129,30 +129,14 @@ async def rpc_endpoint(
             raw_params = vars(_params_ns)
             state = request.app.state
 
-            # Early 304 for read-shaped syscalls (mirrors the legacy path
-            # below). Avoid running the (potentially large) read at all when
-            # the client's ETag still matches.
+            # #4005 round-5: NO early 304 in the kernel branch.
+            # ``state.nexus_fs.get_content_id`` ignores OperationContext
+            # (see nexus_fs_metadata.py: ``noqa: ARG002`` on the context
+            # argument), so a preflight 304 would bypass the read
+            # permission hooks that ``sys_read`` / ``read`` enforce. The
+            # late 304 below (after dispatch) is safe — the read had to
+            # succeed first, and matching ETags then suppress the body.
             if_none_match = request.headers.get("If-None-Match")
-            if (
-                method in ("read", "sys_read")
-                and if_none_match
-                and "path" in raw_params
-                and state.nexus_fs
-            ):
-                try:
-                    cached_content_id = state.nexus_fs.get_content_id(
-                        raw_params["path"], context=context
-                    )
-                    if cached_content_id and if_none_match.strip('"') == cached_content_id:
-                        return Response(
-                            status_code=304,
-                            headers={
-                                "ETag": f'"{cached_content_id}"',
-                                "Cache-Control": "private, max-age=60",
-                            },
-                        )
-                except Exception as e:
-                    logger.debug("Early ETag check failed for %s: %s", raw_params.get("path"), e)
 
             _dispatch_coro = dispatch_kernel_syscall(
                 state.nexus_fs,
@@ -345,7 +329,13 @@ async def rpc_endpoint(
 # their cache-friendly arms; lock primitives are no-cache.
 _KERNEL_CACHE_CATEGORY: dict[str, str] = {
     "sys_read": "read",
-    "sys_stat": "read",
+    # #4005 round-5: ``sys_stat`` returns metadata + content_id, but
+    # ``sys_setattr`` can mutate metadata (mtime, mode) WITHOUT changing
+    # content_id. Synthesizing an ETag from content_id alone would let
+    # a revalidating client get 304 and keep stale stat metadata across
+    # touch / chmod-like ops. Use ``get_metadata``'s arm (Cache-Control
+    # only, no ETag) until we have a metadata-versioned validator.
+    "sys_stat": "get_metadata",
     "sys_readdir": "list",
     "sys_write": "write",
     "sys_unlink": "delete",
@@ -366,18 +356,9 @@ def _kernel_cache_headers(method: str, result: Any) -> dict[str, str]:
     ``get_cache_headers`` understands so mutating syscalls get
     ``no-store``, reads get an ETag from ``content_id`` / bytes,
     and ``sys_readdir`` aligns with ``list``.
-
-    For ``sys_stat``: the dispatcher's adapter wraps metadata in
-    ``{"metadata": ...}``; lift ``content_id`` to the top level so
-    the existing ``read`` arm can mint an ETag.
     """
     canonical = _KERNEL_CACHE_CATEGORY.get(method, method)
-    cache_result: Any = result
-    if method == "sys_stat" and isinstance(result, dict):
-        meta = result.get("metadata")
-        if isinstance(meta, dict) and "content_id" in meta:
-            cache_result = {"content_id": meta["content_id"]}
-    return get_cache_headers(canonical, cache_result)
+    return get_cache_headers(canonical, result)
 
 
 def get_cache_headers(method: str, result: Any) -> dict[str, str]:

--- a/src/nexus/server/api/core/rpc.py
+++ b/src/nexus/server/api/core/rpc.py
@@ -54,12 +54,35 @@ async def rpc_endpoint(
     """
     import time as _time
 
-    from nexus.server._kernel_syscall_dispatch import (
-        KERNEL_SYSCALL_NAMES,
-        dispatch_kernel_syscall,
-    )
+    from nexus.server._kernel_syscall_dispatch import dispatch_kernel_syscall
     from nexus.server.dependencies import get_operation_context
     from nexus.server.rpc.dispatch import dispatch_method
+
+    # #4005 round-2 review: short-circuit ONLY the canonical sys_* methods
+    # that lack a generated Params dataclass. Legacy aliases (read/write/
+    # list/delete/mkdir/rmdir/rename/access/exists/lock_acquire) keep flowing
+    # through the existing dispatch_method path which wraps sync NexusFS
+    # methods with ``to_thread_with_timeout`` (Issue #932). Routing them
+    # through the kernel-syscall dispatcher would call sync methods inline
+    # on the FastAPI loop and reintroduce the DoS class we removed sys_watch
+    # for. The gRPC ``Call`` servicer accepts the same risk by design;
+    # HTTP RPC keeps its safer path.
+    _HTTP_KERNEL_SHORTCIRCUIT: frozenset[str] = frozenset(
+        {
+            "sys_copy",
+            "sys_lock",
+            "sys_mkdir",
+            "sys_read",
+            "sys_readdir",
+            "sys_rename",
+            "sys_rmdir",
+            "sys_setattr",
+            "sys_stat",
+            "sys_unlink",
+            "sys_unlock",
+            "sys_write",
+        }
+    )
 
     logger.debug("Deprecated HTTP RPC called: method=%s (use gRPC Call RPC instead)", method)
     _rpc_start = _time.time()
@@ -84,13 +107,14 @@ async def rpc_endpoint(
         if not rpc_request.method:
             rpc_request.method = method
 
-        # #4005 review: kernel syscalls (sys_readdir, sys_stat, etc.) have no
-        # generated Params dataclass — they go through the inspect.signature
-        # dispatcher in ``_kernel_syscall_dispatch``. Mirror what the gRPC
-        # ``Call`` servicer does: short-circuit BEFORE ``parse_method_params``
-        # so HTTP RPC clients (legacy CLI/proxy) don't get rejected with
-        # "Unknown method: sys_readdir".
-        if method in KERNEL_SYSCALL_NAMES:
+        # #4005 review: canonical sys_* kernel syscalls have no generated
+        # Params dataclass — short-circuit BEFORE ``parse_method_params`` so
+        # HTTP RPC clients (legacy CLI/proxy) don't get rejected with
+        # "Unknown method: sys_readdir". The set is intentionally narrower
+        # than the gRPC ``KERNEL_SYSCALL_NAMES`` (see _HTTP_KERNEL_SHORTCIRCUIT
+        # comment above) — legacy aliases keep their to_thread_with_timeout
+        # wrapping via ``dispatch_method``.
+        if method in _HTTP_KERNEL_SHORTCIRCUIT:
             from types import SimpleNamespace
 
             context = get_operation_context(auth_result)

--- a/src/nexus/server/api/core/rpc.py
+++ b/src/nexus/server/api/core/rpc.py
@@ -3,6 +3,7 @@
 Extracted from fastapi_server.py (#1602).
 """
 
+import asyncio
 import logging
 from typing import Any
 
@@ -54,35 +55,22 @@ async def rpc_endpoint(
     """
     import time as _time
 
-    from nexus.server._kernel_syscall_dispatch import dispatch_kernel_syscall
+    from nexus.server._kernel_syscall_dispatch import (
+        KERNEL_SYSCALL_NAMES,
+        dispatch_kernel_syscall,
+    )
     from nexus.server.dependencies import get_operation_context
     from nexus.server.rpc.dispatch import dispatch_method
 
-    # #4005 round-2 review: short-circuit ONLY the canonical sys_* methods
-    # that lack a generated Params dataclass. Legacy aliases (read/write/
-    # list/delete/mkdir/rmdir/rename/access/exists/lock_acquire) keep flowing
-    # through the existing dispatch_method path which wraps sync NexusFS
-    # methods with ``to_thread_with_timeout`` (Issue #932). Routing them
-    # through the kernel-syscall dispatcher would call sync methods inline
-    # on the FastAPI loop and reintroduce the DoS class we removed sys_watch
-    # for. The gRPC ``Call`` servicer accepts the same risk by design;
-    # HTTP RPC keeps its safer path.
-    _HTTP_KERNEL_SHORTCIRCUIT: frozenset[str] = frozenset(
-        {
-            "sys_copy",
-            "sys_lock",
-            "sys_mkdir",
-            "sys_read",
-            "sys_readdir",
-            "sys_rename",
-            "sys_rmdir",
-            "sys_setattr",
-            "sys_stat",
-            "sys_unlink",
-            "sys_unlock",
-            "sys_write",
-        }
-    )
+    # #4005 round-3: route the full kernel-syscall set through the thin
+    # dispatcher. Round-2 narrowing was unsafe in two ways: (1) legacy
+    # aliases (read/write/list/delete/mkdir/rmdir/rename/access/exists/
+    # lock_acquire) have NO METHOD_PARAMS entry on develop, so they would
+    # die in parse_method_params before ever reaching dispatch_method
+    # (silent compatibility break for HTTP RPC clients), and (2) the
+    # round-2 to_thread offload inside dispatch_kernel_syscall now makes
+    # the safer path equivalent to dispatch_method's to_thread_with_timeout
+    # (minus the timeout — enforced below via ``asyncio.wait_for``).
 
     logger.debug("Deprecated HTTP RPC called: method=%s (use gRPC Call RPC instead)", method)
     _rpc_start = _time.time()
@@ -107,14 +95,12 @@ async def rpc_endpoint(
         if not rpc_request.method:
             rpc_request.method = method
 
-        # #4005 review: canonical sys_* kernel syscalls have no generated
-        # Params dataclass — short-circuit BEFORE ``parse_method_params`` so
-        # HTTP RPC clients (legacy CLI/proxy) don't get rejected with
-        # "Unknown method: sys_readdir". The set is intentionally narrower
-        # than the gRPC ``KERNEL_SYSCALL_NAMES`` (see _HTTP_KERNEL_SHORTCIRCUIT
-        # comment above) — legacy aliases keep their to_thread_with_timeout
-        # wrapping via ``dispatch_method``.
-        if method in _HTTP_KERNEL_SHORTCIRCUIT:
+        # #4005 round-3: route ALL kernel syscall wire names (sys_* +
+        # legacy aliases) through dispatch_kernel_syscall before
+        # parse_method_params. Wraps with asyncio.wait_for so a slow
+        # backend can't tie up an HTTP request indefinitely (parity
+        # with dispatch_method's to_thread_with_timeout).
+        if method in KERNEL_SYSCALL_NAMES:
             from types import SimpleNamespace
 
             context = get_operation_context(auth_result)
@@ -127,12 +113,16 @@ async def rpc_endpoint(
             scope_params_for_zone(_params_ns, context.zone_id)
             raw_params = vars(_params_ns)
             state = request.app.state
-            result = await dispatch_kernel_syscall(
-                state.nexus_fs,
-                method,
-                raw_params,
-                context,
-                subscription_manager=state.subscription_manager,
+            _timeout = getattr(state, "operation_timeout", 30.0)
+            result = await asyncio.wait_for(
+                dispatch_kernel_syscall(
+                    state.nexus_fs,
+                    method,
+                    raw_params,
+                    context,
+                    subscription_manager=state.subscription_manager,
+                ),
+                timeout=_timeout,
             )
             headers = get_cache_headers(method, result)
             headers["Deprecation"] = "true"
@@ -244,6 +234,15 @@ async def rpc_endpoint(
 
         return Response(content=encoded, media_type="application/json", headers=headers)
 
+    except TimeoutError:
+        # #4005 round-3: HTTP kernel-syscall short-circuit timeout —
+        # surface as INTERNAL_ERROR matching the legacy
+        # ``to_thread_with_timeout`` behavior in dispatch_method.
+        return _error_response(
+            None,
+            RPCErrorCode.INTERNAL_ERROR,
+            f"Operation timed out (method={method})",
+        )
     except ZoneScopingError as e:
         return _error_response(None, RPCErrorCode.PERMISSION_ERROR, str(e))
     except ValueError as e:

--- a/src/nexus/server/api/core/rpc.py
+++ b/src/nexus/server/api/core/rpc.py
@@ -63,14 +63,29 @@ async def rpc_endpoint(
     from nexus.server.rpc.dispatch import dispatch_method
 
     # #4005 round-3: route the full kernel-syscall set through the thin
-    # dispatcher. Round-2 narrowing was unsafe in two ways: (1) legacy
-    # aliases (read/write/list/delete/mkdir/rmdir/rename/access/exists/
-    # lock_acquire) have NO METHOD_PARAMS entry on develop, so they would
-    # die in parse_method_params before ever reaching dispatch_method
-    # (silent compatibility break for HTTP RPC clients), and (2) the
-    # round-2 to_thread offload inside dispatch_kernel_syscall now makes
-    # the safer path equivalent to dispatch_method's to_thread_with_timeout
-    # (minus the timeout — enforced below via ``asyncio.wait_for``).
+    # dispatcher. Round-2 narrowing silently broke read/write/list/...
+    # (no METHOD_PARAMS entry on develop). Round-2 to_thread offload
+    # already prevents loop-park, so the broader path is safe.
+    #
+    # #4005 round-4: only idempotent reads get an asyncio.wait_for
+    # timeout. Cancelling a wait_for does NOT cancel the worker thread
+    # asyncio.to_thread spawned, so a mutating syscall could time out
+    # at the HTTP layer while the underlying write/delete/rename still
+    # commits — the caller would then retry and double-mutate. For the
+    # mutating set we accept the same "no per-request timeout" stance
+    # the gRPC ``Call`` servicer already takes; per-backend deadlines
+    # remain the right place to bound long-running mutations.
+    _HTTP_TIMEOUT_SAFE_SYSCALLS: frozenset[str] = frozenset(
+        {
+            "access",
+            "exists",
+            "list",
+            "read",
+            "sys_read",
+            "sys_readdir",
+            "sys_stat",
+        }
+    )
 
     logger.debug("Deprecated HTTP RPC called: method=%s (use gRPC Call RPC instead)", method)
     _rpc_start = _time.time()
@@ -113,21 +128,65 @@ async def rpc_endpoint(
             scope_params_for_zone(_params_ns, context.zone_id)
             raw_params = vars(_params_ns)
             state = request.app.state
-            _timeout = getattr(state, "operation_timeout", 30.0)
-            result = await asyncio.wait_for(
-                dispatch_kernel_syscall(
-                    state.nexus_fs,
-                    method,
-                    raw_params,
-                    context,
-                    subscription_manager=state.subscription_manager,
-                ),
-                timeout=_timeout,
+
+            # Early 304 for read-shaped syscalls (mirrors the legacy path
+            # below). Avoid running the (potentially large) read at all when
+            # the client's ETag still matches.
+            if_none_match = request.headers.get("If-None-Match")
+            if (
+                method in ("read", "sys_read")
+                and if_none_match
+                and "path" in raw_params
+                and state.nexus_fs
+            ):
+                try:
+                    cached_content_id = state.nexus_fs.get_content_id(
+                        raw_params["path"], context=context
+                    )
+                    if cached_content_id and if_none_match.strip('"') == cached_content_id:
+                        return Response(
+                            status_code=304,
+                            headers={
+                                "ETag": f'"{cached_content_id}"',
+                                "Cache-Control": "private, max-age=60",
+                            },
+                        )
+                except Exception as e:
+                    logger.debug("Early ETag check failed for %s: %s", raw_params.get("path"), e)
+
+            _dispatch_coro = dispatch_kernel_syscall(
+                state.nexus_fs,
+                method,
+                raw_params,
+                context,
+                subscription_manager=state.subscription_manager,
             )
-            headers = get_cache_headers(method, result)
+            if method in _HTTP_TIMEOUT_SAFE_SYSCALLS:
+                _timeout = getattr(state, "operation_timeout", 30.0)
+                result = await asyncio.wait_for(_dispatch_coro, timeout=_timeout)
+            else:
+                # Mutating syscalls: no wait_for — see comment above.
+                result = await _dispatch_coro
+
+            headers = _kernel_cache_headers(method, result)
             headers["Deprecation"] = "true"
             headers["Sunset"] = "Wed, 25 Jun 2026 00:00:00 GMT"
             headers["X-Migration-Guide"] = "Use gRPC Call RPC (Issue #1133)"
+
+            # Late 304 (after dispatch) so a fresh ETag still suppresses body.
+            if (
+                if_none_match
+                and "ETag" in headers
+                and if_none_match.strip('"') == headers["ETag"].strip('"')
+            ):
+                return Response(
+                    status_code=304,
+                    headers={
+                        "ETag": headers["ETag"],
+                        "Cache-Control": headers.get("Cache-Control", ""),
+                    },
+                )
+
             success_response = {
                 "jsonrpc": "2.0",
                 "id": rpc_request.id,
@@ -278,6 +337,47 @@ async def rpc_endpoint(
     except Exception:
         logger.exception(f"Error executing method {method}")
         return _error_response(None, RPCErrorCode.INTERNAL_ERROR, "Internal server error")
+
+
+# #4005 round-4: kernel syscall wire-name → legacy cache category so the
+# new HTTP short-circuit reuses ``get_cache_headers`` semantics correctly.
+# Mutating sys_* must land in the ``no-store`` arm; reads/stat/list keep
+# their cache-friendly arms; lock primitives are no-cache.
+_KERNEL_CACHE_CATEGORY: dict[str, str] = {
+    "sys_read": "read",
+    "sys_stat": "read",
+    "sys_readdir": "list",
+    "sys_write": "write",
+    "sys_unlink": "delete",
+    "sys_rename": "rename",
+    "sys_copy": "copy",
+    "sys_mkdir": "mkdir",
+    "sys_rmdir": "rmdir",
+    "sys_setattr": "write",
+    "sys_lock": "lock_acquire",
+    "sys_unlock": "lock_acquire",
+}
+
+
+def _kernel_cache_headers(method: str, result: Any) -> dict[str, str]:
+    """Cache headers for the kernel-syscall HTTP short-circuit.
+
+    Re-keys sys_* wire names onto the legacy categories that
+    ``get_cache_headers`` understands so mutating syscalls get
+    ``no-store``, reads get an ETag from ``content_id`` / bytes,
+    and ``sys_readdir`` aligns with ``list``.
+
+    For ``sys_stat``: the dispatcher's adapter wraps metadata in
+    ``{"metadata": ...}``; lift ``content_id`` to the top level so
+    the existing ``read`` arm can mint an ETag.
+    """
+    canonical = _KERNEL_CACHE_CATEGORY.get(method, method)
+    cache_result: Any = result
+    if method == "sys_stat" and isinstance(result, dict):
+        meta = result.get("metadata")
+        if isinstance(meta, dict) and "content_id" in meta:
+            cache_result = {"content_id": meta["content_id"]}
+    return get_cache_headers(canonical, cache_result)
 
 
 def get_cache_headers(method: str, result: Any) -> dict[str, str]:

--- a/src/nexus/server/lifespan/__init__.py
+++ b/src/nexus/server/lifespan/__init__.py
@@ -10,7 +10,10 @@ Each initializer function:
 """
 
 import asyncio
+import ctypes
+import gc
 import logging
+import threading
 from collections.abc import AsyncIterator
 from contextlib import asynccontextmanager, suppress
 from typing import TYPE_CHECKING
@@ -124,6 +127,45 @@ def _wire_query_observer(_app: "FastAPI", svc: LifespanServices) -> None:
         logger.info("QueryObserverComponent registration skipped: %s", exc)
 
 
+def _apply_boot_tweaks() -> None:
+    """Apply Python-level memory hygiene at lifespan startup (Issue #3997).
+
+    Must be called before the first thread is spawned and before any heavy
+    module is imported, so the new stack size and GC threshold take effect
+    for everything that follows.
+
+    - threading.stack_size(1 << 20): cap pthread stack 8 MB -> 1 MB
+      (~250 MB VmData savings over 32 threads, near-zero RSS impact).
+    - gc.set_threshold(50_000, 10): fewer GC pauses (~20% latency win).
+      Python 3.14 reduced GC to two generations; the obsolete third
+      threshold is ignored (gc.get_threshold() returns 0 for it).
+    """
+    threading.stack_size(1 << 20)
+    gc.set_threshold(50_000, 10)
+
+
+async def _idle_trimmer() -> None:
+    """Background task: every 60s, gc.collect() + malloc_trim(0) (Issue #3997).
+
+    Releases freed heap pages back to the kernel during long-running idle
+    periods. Glibc-only (no-op on musl/Alpine).
+    """
+    try:
+        libc = ctypes.CDLL("libc.so.6", use_errno=True)
+        _probe = libc.malloc_trim  # raises AttributeError if symbol missing
+    except (OSError, AttributeError):
+        logger.info("malloc_trim unavailable, idle trimmer disabled")
+        return
+
+    while True:
+        await asyncio.sleep(60)
+        try:
+            gc.collect()
+            libc.malloc_trim(0)
+        except Exception:
+            logger.exception("idle_trimmer iteration failed")
+
+
 @asynccontextmanager
 async def lifespan(app: "FastAPI") -> AsyncIterator[None]:
     """Application lifespan manager.
@@ -145,6 +187,11 @@ async def lifespan(app: "FastAPI") -> AsyncIterator[None]:
 
     # Collect all background tasks for clean shutdown
     bg_tasks: list[asyncio.Task] = []
+
+    # Issue #3997: apply boot-time memory hygiene before any thread spawn or
+    # heavy import. Must run before svc init since LifespanServices.from_app
+    # may touch threadpool state.
+    _apply_boot_tweaks()
 
     # Extract typed service container once
     svc = LifespanServices.from_app(app)
@@ -214,6 +261,13 @@ async def lifespan(app: "FastAPI") -> AsyncIterator[None]:
 
     # Wire QueryObserverComponent into registry after services start (Issue #2072)
     _wire_query_observer(app, svc)
+
+    # Issue #3997: idle trimmer + freeze boot-time heap.
+    # gc.freeze() moves all currently-tracked objects to a permanent generation
+    # so they are not scanned by future GC cycles. Must run AFTER all warmup
+    # imports/services have completed.
+    bg_tasks.append(asyncio.create_task(_idle_trimmer(), name="idle_trimmer"))
+    gc.freeze()
 
     yield
 

--- a/src/nexus/server/lifespan/search.py
+++ b/src/nexus/server/lifespan/search.py
@@ -20,8 +20,22 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 
+_TRUTHY = ("true", "1", "yes")
+_FALSY = ("false", "0", "no")
+
+
 def _env_truthy(name: str) -> bool:
-    return os.environ.get(name, "").strip().lower() in ("true", "1", "yes")
+    return os.environ.get(name, "").strip().lower() in _TRUTHY
+
+
+def _env_tristate(name: str) -> bool | None:
+    """Return True/False if the env var is set to a recognized value, else None."""
+    raw = os.environ.get(name, "").strip().lower()
+    if raw in _TRUTHY:
+        return True
+    if raw in _FALSY:
+        return False
+    return None
 
 
 # pgvector hnsw indexes cap at 2000 dims for full-precision `vector` columns
@@ -55,13 +69,11 @@ def _resolve_txtai_runtime_config() -> tuple[str, dict[str, str | int] | None]:
     # matches the prevailing production storage dim (1536 truncated via Matryoshka)
     # and beats local MiniLM (384d) on retrieval quality across MTEB.
     # Operators can force local with ``NEXUS_TXTAI_USE_API_EMBEDDINGS=false``.
-    api_env = os.environ.get("NEXUS_TXTAI_USE_API_EMBEDDINGS", "").strip().lower()
-    if api_env in ("true", "1", "yes"):
-        use_api_embeddings = True
-    elif api_env in ("false", "0", "no"):
-        use_api_embeddings = False
-    else:
+    use_api = _env_tristate("NEXUS_TXTAI_USE_API_EMBEDDINGS")
+    if use_api is None:
         use_api_embeddings = bool(openai_api_key)
+    else:
+        use_api_embeddings = use_api
 
     model = configured_model or (
         "openai/text-embedding-3-large"

--- a/src/nexus/server/lifespan/search.py
+++ b/src/nexus/server/lifespan/search.py
@@ -49,44 +49,37 @@ _OPENAI_EMBEDDING_NATIVE_DIMENSIONS = {
 }
 
 
-def _resolve_txtai_runtime_config() -> tuple[str, dict[str, str | int] | None]:
+def _resolve_txtai_runtime_config() -> tuple[str | None, dict[str, str | int] | None]:
     """Resolve txtai embedding model and optional vectors config from env.
 
-    Supports an explicit API-backed mode for Docker/demo stacks so users can
-    avoid local embedding model startup when they already have OpenAI creds.
-
-    For OpenAI text-embedding-3 models (Matryoshka-trained), passes a
-    ``dimensions`` parameter to the API for quality-preserving truncation. The
-    default of 1536 for text-embedding-3-large keeps the daemon under the
-    pgvector hnsw 2000-dim cap; operators can override with
-    NEXUS_TXTAI_DIMENSIONS.
+    Three-way auto:
+    - explicit local model (sentence-transformers/...) wins; opt-in to ~900 MB
+    - OPENAI_API_KEY present AND NEXUS_TXTAI_USE_API_EMBEDDINGS not opted-out:
+      API embeddings (~0 RAM) — defaults to text-embedding-3-large with
+      Matryoshka truncation to 1536d (pgvector hnsw cap)
+    - neither: returns (None, None) -> txtai BM25 keyword-only fast-path
     """
     configured_model = os.environ.get("NEXUS_TXTAI_MODEL", "").strip()
     openai_api_key = os.environ.get("OPENAI_API_KEY", "").strip()
     openai_base_url = os.environ.get("OPENAI_BASE_URL", "").strip()
-    # Auto-prefer OpenAI when a key is available — local sentence-transformers
-    # is the fallback for keyless dev setups, not the default. ``text-embedding-3-large``
-    # matches the prevailing production storage dim (1536 truncated via Matryoshka)
-    # and beats local MiniLM (384d) on retrieval quality across MTEB.
-    # Operators can force local with ``NEXUS_TXTAI_USE_API_EMBEDDINGS=false``.
     use_api = _env_tristate("NEXUS_TXTAI_USE_API_EMBEDDINGS")
-    use_api_embeddings = bool(openai_api_key) if use_api is None else use_api
 
-    model = configured_model or (
-        "openai/text-embedding-3-large"
-        if use_api_embeddings and openai_api_key
-        else "sentence-transformers/all-MiniLM-L6-v2"
-    )
-    vectors: dict[str, str | int] | None = None
+    # Explicit local model wins (heavy opt-in)
+    if configured_model and not configured_model.startswith("openai/"):
+        return configured_model, None
 
-    if use_api_embeddings and model.startswith("openai/") and openai_api_key:
-        vectors = {"api_key": openai_api_key}
-        if openai_base_url:
-            vectors["api_base"] = openai_base_url
+    # Hard opt-out or no key -> BM25 keyword-only fast path (no model load)
+    if use_api is False or not openai_api_key:
+        return None, None
 
-        dim = _resolve_embedding_dimensions(model)
-        if dim is not None:
-            vectors["dimensions"] = dim
+    model = configured_model or "openai/text-embedding-3-large"
+    vectors: dict[str, str | int] = {"api_key": openai_api_key}
+    if openai_base_url:
+        vectors["api_base"] = openai_base_url
+
+    dim = _resolve_embedding_dimensions(model)
+    if dim is not None:
+        vectors["dimensions"] = dim
 
     return model, vectors
 

--- a/src/nexus/server/lifespan/search.py
+++ b/src/nexus/server/lifespan/search.py
@@ -79,7 +79,7 @@ def _resolve_txtai_runtime_config() -> tuple[str, dict[str, str | int] | None]:
         if dim is not None:
             vectors["dimensions"] = dim
 
-    return model, vectors or None
+    return model, vectors
 
 
 def _resolve_embedding_dimensions(model: str) -> int | None:
@@ -150,6 +150,15 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
         from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon
 
         txtai_model, txtai_vectors = _resolve_txtai_runtime_config()
+        # Issue #3997: surface mode in boot logs so operators see whether
+        # heavy local model, remote API embeddings, or BM25-only is active.
+        if txtai_model is None:
+            _mode = "bm25-only"
+        elif txtai_model.startswith("openai/"):
+            _mode = "openai-api"
+        else:
+            _mode = "local"
+        logger.info("Search backend mode: %s (model=%s)", _mode, txtai_model or "<none>")
         _path_ctx_max_zones_env = os.environ.get("NEXUS_PATH_CONTEXT_MAX_ZONES")
         _path_ctx_max_zones = 2048
         if _path_ctx_max_zones_env:

--- a/src/nexus/server/lifespan/search.py
+++ b/src/nexus/server/lifespan/search.py
@@ -70,10 +70,7 @@ def _resolve_txtai_runtime_config() -> tuple[str, dict[str, str | int] | None]:
     # and beats local MiniLM (384d) on retrieval quality across MTEB.
     # Operators can force local with ``NEXUS_TXTAI_USE_API_EMBEDDINGS=false``.
     use_api = _env_tristate("NEXUS_TXTAI_USE_API_EMBEDDINGS")
-    if use_api is None:
-        use_api_embeddings = bool(openai_api_key)
-    else:
-        use_api_embeddings = use_api
+    use_api_embeddings = bool(openai_api_key) if use_api is None else use_api
 
     model = configured_model or (
         "openai/text-embedding-3-large"

--- a/tests/e2e/self_contained/test_performance_tuning_e2e.py
+++ b/tests/e2e/self_contained/test_performance_tuning_e2e.py
@@ -66,9 +66,9 @@ class TestPerformanceTuningOnAppState:
     def test_full_profile_tuning_set(self, app_full_profile: FastAPI) -> None:
         tuning = app_full_profile.state.profile_tuning
         assert tuning.concurrency.default_workers == 4
-        assert tuning.concurrency.thread_pool_size == 200
+        assert tuning.concurrency.thread_pool_size == 40
         assert tuning.network.default_http_timeout == 30.0
-        assert tuning.storage.db_pool_size == 20
+        assert tuning.storage.db_pool_size == 5
 
     def test_full_profile_new_slices(self, app_full_profile: FastAPI) -> None:
         tuning = app_full_profile.state.profile_tuning
@@ -107,11 +107,11 @@ class TestFeaturesEndpointWithTuning:
         assert "performance_tuning" in data
         pt = data["performance_tuning"]
         assert pt is not None
-        assert pt["thread_pool_size"] == 200
+        assert pt["thread_pool_size"] == 40
         assert pt["default_workers"] == 4
         assert pt["task_runner_workers"] == 4
         assert pt["default_http_timeout"] == 30.0
-        assert pt["db_pool_size"] == 20
+        assert pt["db_pool_size"] == 5
         assert pt["search_max_concurrency"] == 10
 
     def test_full_features_includes_new_slices(self, app_full_profile: FastAPI) -> None:

--- a/tests/integration/test_demo_memory.py
+++ b/tests/integration/test_demo_memory.py
@@ -98,7 +98,7 @@ def test_demo_idle_rss_under_limit():
                 container,
                 "sh",
                 "-c",
-                "pid=$(pgrep -f nexusd | head -1); cat /proc/$pid/status",
+                "pid=$(grep -l nexusd /proc/[0-9]*/comm 2>/dev/null | head -1 | cut -d/ -f3); cat /proc/$pid/status",
             ]
         ).decode()
         metrics = _parse_proc_status(status)
@@ -112,7 +112,7 @@ def test_demo_idle_rss_under_limit():
                         container,
                         "sh",
                         "-c",
-                        "pid=$(pgrep -f nexusd | head -1); head -20 /proc/$pid/maps",
+                        "pid=$(grep -l nexusd /proc/[0-9]*/comm 2>/dev/null | head -1 | cut -d/ -f3); head -20 /proc/$pid/maps",
                     ]
                 ).decode()
             except Exception as e:

--- a/tests/integration/test_demo_memory.py
+++ b/tests/integration/test_demo_memory.py
@@ -61,7 +61,28 @@ def test_demo_idle_rss_under_limit():
 
     try:
         subprocess.check_call(
-            ["docker", "compose", "-p", project, "-f", str(DEMO_COMPOSE), "up", "-d"],
+            [
+                "docker",
+                "compose",
+                "-p",
+                project,
+                "-f",
+                str(DEMO_COMPOSE),
+                # #4005 review: nexus-stack.yml gates services behind compose
+                # profiles (core/cache/search/...). Without --profile flags
+                # ``up -d`` only starts services with no profile attribute,
+                # which excludes ``nexus`` itself — readiness poll then hangs
+                # until READINESS_TIMEOUT and the test reports a misleading
+                # "did not become ready" error instead of testing memory.
+                "--profile",
+                "core",
+                "--profile",
+                "cache",
+                "--profile",
+                "search",
+                "up",
+                "-d",
+            ],
             env=env,
             cwd=str(REPO_ROOT),
         )
@@ -137,6 +158,14 @@ def test_demo_idle_rss_under_limit():
                 project,
                 "-f",
                 str(DEMO_COMPOSE),
+                # Match the profile set used at ``up`` so ``down -v`` can see
+                # and tear down every container/volume the test created.
+                "--profile",
+                "core",
+                "--profile",
+                "cache",
+                "--profile",
+                "search",
                 "down",
                 "-v",
             ],

--- a/tests/integration/test_demo_memory.py
+++ b/tests/integration/test_demo_memory.py
@@ -1,0 +1,145 @@
+"""Demo profile cold-start memory regression (Issue #3997).
+
+Boots the nexus-stack compose, waits for readiness, then reads
+/proc/$pid/status from inside the container and asserts that idle
+RSS, VmData, and thread count are within the targets agreed in the
+issue:
+
+    VmRSS  <= 450 MB
+    VmData <= 4 GB
+    Threads <= 20
+
+Skipped by default. Run with:
+    uv run pytest -m demo_memory tests/integration/test_demo_memory.py -v
+"""
+
+import os
+import shutil
+import subprocess
+import time
+import uuid
+from pathlib import Path
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+DEMO_COMPOSE = REPO_ROOT / "nexus-stack.yml"
+PROJECT_PREFIX = "nexus-demo-mem"
+SERVICE = "nexus"
+READINESS_TIMEOUT = 90  # seconds — image build + DB init + service start
+LAZY_INIT_BUFFER = 30  # seconds (matches issue reproduction)
+RSS_LIMIT_KB = 450 * 1024
+VMDATA_LIMIT_KB = 4 * 1024 * 1024
+THREADS_LIMIT = 20
+
+
+def _docker_available() -> bool:
+    return shutil.which("docker") is not None
+
+
+def _parse_proc_status(blob: str) -> dict[str, int]:
+    """Parse /proc/$pid/status into {VmRSS_kB, VmData_kB, Threads}."""
+    out: dict[str, int] = {}
+    for line in blob.splitlines():
+        if line.startswith("VmRSS:"):
+            out["VmRSS_kB"] = int(line.split()[1])
+        elif line.startswith("VmData:"):
+            out["VmData_kB"] = int(line.split()[1])
+        elif line.startswith("Threads:"):
+            out["Threads"] = int(line.split()[1])
+    missing = {"VmRSS_kB", "VmData_kB", "Threads"} - out.keys()
+    assert not missing, f"could not parse {missing} from /proc/$pid/status"
+    return out
+
+
+@pytest.mark.demo_memory
+@pytest.mark.skipif(not _docker_available(), reason="docker CLI not available")
+def test_demo_idle_rss_under_limit():
+    project = f"{PROJECT_PREFIX}-{uuid.uuid4().hex[:8]}"
+    container = f"{project}-{SERVICE}-1"
+    env = os.environ.copy()
+
+    try:
+        subprocess.check_call(
+            ["docker", "compose", "-p", project, "-f", str(DEMO_COMPOSE), "up", "-d"],
+            env=env,
+            cwd=str(REPO_ROOT),
+        )
+
+        # Poll readiness up to READINESS_TIMEOUT seconds via container's healthz.
+        deadline = time.time() + READINESS_TIMEOUT
+        ready = False
+        while time.time() < deadline:
+            rc = subprocess.call(
+                [
+                    "docker",
+                    "exec",
+                    container,
+                    "curl",
+                    "-fsS",
+                    "http://localhost:2026/healthz/ready",
+                ],
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            if rc == 0:
+                ready = True
+                break
+            time.sleep(2)
+        assert ready, f"{container} did not become ready within {READINESS_TIMEOUT}s"
+
+        # Lazy bg init (skeleton indexer, search daemon hooks, etc.)
+        time.sleep(LAZY_INIT_BUFFER)
+
+        status = subprocess.check_output(
+            [
+                "docker",
+                "exec",
+                container,
+                "sh",
+                "-c",
+                "pid=$(pgrep -f nexusd | head -1); cat /proc/$pid/status",
+            ]
+        ).decode()
+        metrics = _parse_proc_status(status)
+
+        def _diag() -> str:
+            try:
+                maps = subprocess.check_output(
+                    [
+                        "docker",
+                        "exec",
+                        container,
+                        "sh",
+                        "-c",
+                        "pid=$(pgrep -f nexusd | head -1); head -20 /proc/$pid/maps",
+                    ]
+                ).decode()
+            except Exception as e:
+                maps = f"<diag failed: {e}>"
+            return f"\n--- /proc/$pid/status ---\n{status}\n--- /proc/$pid/maps (head) ---\n{maps}"
+
+        assert metrics["VmRSS_kB"] < RSS_LIMIT_KB, (
+            f"VmRSS={metrics['VmRSS_kB']} kB exceeds {RSS_LIMIT_KB} kB" + _diag()
+        )
+        assert metrics["Threads"] < THREADS_LIMIT, (
+            f"Threads={metrics['Threads']} exceeds {THREADS_LIMIT}" + _diag()
+        )
+        assert metrics["VmData_kB"] < VMDATA_LIMIT_KB, (
+            f"VmData={metrics['VmData_kB']} kB exceeds {VMDATA_LIMIT_KB} kB" + _diag()
+        )
+    finally:
+        subprocess.call(
+            [
+                "docker",
+                "compose",
+                "-p",
+                project,
+                "-f",
+                str(DEMO_COMPOSE),
+                "down",
+                "-v",
+            ],
+            env=env,
+            cwd=str(REPO_ROOT),
+        )

--- a/tests/unit/bricks/search/test_txtai_backend_bm25_only.py
+++ b/tests/unit/bricks/search/test_txtai_backend_bm25_only.py
@@ -1,0 +1,110 @@
+"""txtai backend BM25-only fast-path when model is None (Issue #3997).
+
+When the search lifespan resolver returns ``(None, None)`` because the
+operator hasn't opted into either an API embedding model (no key) or a
+local model, the txtai backend must skip the heavy
+``Embeddings(path="sentence-transformers/...")`` load entirely (~900 MB
+RSS) and start in keyword-only BM25 mode.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+@pytest.fixture
+def fake_embeddings(monkeypatch: pytest.MonkeyPatch) -> list[dict[str, Any]]:
+    """Inject a fake ``txtai`` module exposing a recording ``Embeddings``.
+
+    The real ``txtai`` package is not always installed in the unit-test env;
+    the backend imports it lazily inside ``_startup_impl``. We register a
+    stub module so ``from txtai import Embeddings`` resolves to the fake.
+    Returns the list of configs each constructed instance was given.
+    """
+    import sys
+    import types
+
+    captured: list[dict[str, Any]] = []
+
+    class _FakeEmbeddings:
+        def __init__(self, config: Any = None) -> None:
+            if isinstance(config, dict):
+                captured.append(dict(config))
+            elif config is None:
+                captured.append({})
+            else:
+                captured.append({"_path_form": config})
+
+        def exists(self, *_a: Any, **_kw: Any) -> bool:  # pragma: no cover
+            return False
+
+        def load(self, *_a: Any, **_kw: Any) -> None:  # pragma: no cover
+            return None
+
+        def count(self) -> int:  # pragma: no cover
+            return 0
+
+        def close(self) -> None:  # pragma: no cover
+            return None
+
+    fake_txtai = types.ModuleType("txtai")
+    # ``setattr`` instead of attribute assignment avoids mypy's
+    # ``[attr-defined]`` complaint on the freshly-minted module type.
+    fake_txtai.Embeddings = _FakeEmbeddings
+    monkeypatch.setitem(sys.modules, "txtai", fake_txtai)
+    return captured
+
+
+@pytest.mark.asyncio
+async def test_bm25_only_path_when_model_is_none(
+    fake_embeddings: list[dict[str, Any]],
+) -> None:
+    """model=None -> single Embeddings({keyword:True, ...}) call, no model path."""
+    from nexus.bricks.search.txtai_backend import TxtaiBackend
+
+    backend = TxtaiBackend(
+        database_url=None,
+        model=None,
+        vectors=None,
+        hybrid=True,
+        graph=False,
+        reranker_model=None,
+        sparse=False,
+    )
+    await backend._startup_impl()
+
+    # Exactly one Embeddings(...) call — no probe, no path-mode build.
+    assert len(fake_embeddings) == 1, fake_embeddings
+    cfg = fake_embeddings[0]
+    assert cfg.get("keyword") is True
+    assert "path" not in cfg
+    # BM25-only: hybrid is forced off, no reranker task, backend ready.
+    assert backend._hybrid is False
+    assert backend._started is True
+
+
+@pytest.mark.asyncio
+async def test_model_set_takes_normal_path(
+    fake_embeddings: list[dict[str, Any]],
+) -> None:
+    """model='openai/...' -> Embeddings(config_with_path) called normally."""
+    from nexus.bricks.search.txtai_backend import TxtaiBackend
+
+    backend = TxtaiBackend(
+        database_url=None,
+        model="openai/text-embedding-3-small",
+        vectors={"api_key": "sk-x"},
+        hybrid=True,
+        graph=False,
+        reranker_model=None,
+        sparse=False,
+    )
+    await backend._startup_impl()
+
+    # The non-fast-path always builds a config dict that includes ``path``.
+    assert any(
+        "path" in c and c["path"] == "openai/text-embedding-3-small" for c in fake_embeddings
+    )
+    assert backend._started is True

--- a/tests/unit/core/test_performance_tuning.py
+++ b/tests/unit/core/test_performance_tuning.py
@@ -133,7 +133,29 @@ class TestAllProfilesHaveTuning:
 
 
 class TestHierarchyMonotonicity:
-    """Resource-scaling fields must not decrease as profiles grow."""
+    """Resource-scaling fields must not decrease as profiles grow.
+
+    Issue #3997: monotonicity (embedded ≤ lite ≤ full ≤ cloud) was relaxed
+    for the fields listed in ``_RELAXED_MONOTONIC_FIELDS`` because pool /
+    concurrency sizing is now driven by deployment shape (single-tenant vs
+    multi-tenant) rather than purely by feature richness. LITE
+    (lightweight feature set, but still potentially shared) and CLOUD
+    (multi-tenant) can both legitimately have larger pools than FULL
+    (single-tenant default; see issue #3997 right-sizing). Those fields
+    are therefore omitted from the parametrize lists below.
+    """
+
+    # Fields whose monotonicity invariant has been intentionally relaxed
+    # (deployment-shape driven, not feature-richness driven). See class
+    # docstring for rationale; do not re-add without revisiting #3997.
+    _RELAXED_MONOTONIC_FIELDS = frozenset(
+        {
+            "concurrency.thread_pool_size",
+            "storage.db_pool_size",
+            "storage.db_max_overflow",
+            "pool.httpx_max_connections",
+        }
+    )
 
     PROFILES_ORDERED = [
         DeploymentProfile.EMBEDDED,
@@ -146,7 +168,7 @@ class TestHierarchyMonotonicity:
         "field",
         [
             "default_workers",
-            "thread_pool_size",
+            # "thread_pool_size" — relaxed (#3997, see class docstring)
             "max_async_concurrency",
             "task_runner_workers",
         ],
@@ -179,8 +201,8 @@ class TestHierarchyMonotonicity:
     @pytest.mark.parametrize(
         "field",
         [
-            "db_pool_size",
-            "db_max_overflow",
+            # "db_pool_size" — relaxed (#3997, see class docstring)
+            # "db_max_overflow" — relaxed (#3997, see class docstring)
             "write_buffer_max_size",
             "changelog_chunk_size",
         ],
@@ -263,7 +285,7 @@ class TestHierarchyMonotonicity:
         [
             "asyncpg_min_size",
             "asyncpg_max_size",
-            "httpx_max_connections",
+            # "httpx_max_connections" — relaxed (#3997, see class docstring)
             "remote_pool_maxsize",
         ],
     )
@@ -287,7 +309,7 @@ class TestConcreteValues:
     def test_full_concurrency(self) -> None:
         c = DeploymentProfile.FULL.tuning().concurrency
         assert c.default_workers == 4
-        assert c.thread_pool_size == 200
+        assert c.thread_pool_size == 40  # was 200; anyio upstream default (#3997)
         assert c.max_async_concurrency == 10
         assert c.task_runner_workers == 4
 
@@ -302,8 +324,8 @@ class TestConcreteValues:
         assert s.write_buffer_flush_ms == 100
         assert s.write_buffer_max_size == 100
         assert s.changelog_chunk_size == 500
-        assert s.db_pool_size == 20
-        assert s.db_max_overflow == 30
+        assert s.db_pool_size == 5  # was 20; Cloud SQL sample sizing (#3997)
+        assert s.db_max_overflow == 5  # was 30; single-tenant burst (#3997)
 
     def test_full_search(self) -> None:
         s = DeploymentProfile.FULL.tuning().search
@@ -337,14 +359,14 @@ class TestConcreteValues:
         cn = DeploymentProfile.FULL.tuning().connector
         assert cn.blob_operation_timeout == 60.0
         assert cn.large_upload_timeout == 300.0
-        assert cn.connector_max_workers == 20
+        assert cn.connector_max_workers == 6  # was 20; blob ops are I/O-bound (#3997)
 
     def test_full_pool(self) -> None:
         p = DeploymentProfile.FULL.tuning().pool
         assert p.asyncpg_min_size == 2
         assert p.asyncpg_max_size == 5
-        assert p.httpx_max_connections == 100
-        assert p.remote_pool_maxsize == 20
+        assert p.httpx_max_connections == 20  # was 100; HTTP/2 collapses anyway (#3997)
+        assert p.remote_pool_maxsize == 10  # was 20 (#3997)
 
     def test_embedded_minimal(self) -> None:
         """Embedded should have the smallest resource allocation."""
@@ -375,12 +397,12 @@ class TestFullProfileMatchesPreviousDefaults:
     """
 
     def test_db_pool_size_matches_record_store_default(self) -> None:
-        """record_store.py _build_pool_kwargs default_pool_size=20."""
-        assert DeploymentProfile.FULL.tuning().storage.db_pool_size == 20
+        """record_store.py _build_pool_kwargs (Issue #3997: was 20, now 5 — Cloud SQL sample sizing)."""
+        assert DeploymentProfile.FULL.tuning().storage.db_pool_size == 5
 
     def test_db_max_overflow_matches_record_store_default(self) -> None:
-        """record_store.py _build_pool_kwargs default_max_overflow=30."""
-        assert DeploymentProfile.FULL.tuning().storage.db_max_overflow == 30
+        """record_store.py _build_pool_kwargs (Issue #3997: was 30, now 5 — single-tenant burst)."""
+        assert DeploymentProfile.FULL.tuning().storage.db_max_overflow == 5
 
     def test_task_runner_workers_matches_lifespan_default(self) -> None:
         """services.py AsyncTaskRunner max_workers=4."""

--- a/tests/unit/server/lifespan/test_boot_tweaks.py
+++ b/tests/unit/server/lifespan/test_boot_tweaks.py
@@ -1,0 +1,75 @@
+"""Lifespan boot-time memory tweaks (Issue #3997)."""
+
+import asyncio
+import gc
+import threading
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.asyncio
+async def test_apply_boot_tweaks_sets_stack_size_and_gc_threshold():
+    """_apply_boot_tweaks sets 1 MB stack and adjusted GC threshold.
+
+    Python 3.14 reduced GC to two generations; the third threshold value
+    is always 0 in get_threshold() output regardless of what was passed.
+    """
+    from nexus.server.lifespan import _apply_boot_tweaks
+
+    orig_stack = threading.stack_size()
+    orig_thresh = gc.get_threshold()
+    try:
+        _apply_boot_tweaks()
+        assert threading.stack_size() == 1 << 20
+        # Python 3.14: third element is always 0 (obsolete generation)
+        thresh = gc.get_threshold()
+        assert thresh[0] == 50_000
+        assert thresh[1] == 10
+    finally:
+        # Restore for other tests
+        threading.stack_size(orig_stack)
+        gc.set_threshold(*orig_thresh)
+
+
+@pytest.mark.asyncio
+async def test_idle_trimmer_invokes_gc_and_malloc_trim():
+    """_idle_trimmer calls gc.collect + libc.malloc_trim per tick."""
+    from nexus.server.lifespan import _idle_trimmer
+
+    fake_libc = MagicMock()
+    fake_libc.malloc_trim = MagicMock(return_value=1)
+
+    with (
+        patch("ctypes.CDLL", return_value=fake_libc),
+        patch("asyncio.sleep", side_effect=[None, asyncio.CancelledError()]),
+        patch("gc.collect") as mock_collect,
+    ):
+        with pytest.raises(asyncio.CancelledError):
+            await _idle_trimmer()
+        assert mock_collect.call_count >= 1
+        assert fake_libc.malloc_trim.call_count >= 1
+
+
+@pytest.mark.asyncio
+async def test_idle_trimmer_disabled_when_libc_unavailable():
+    """_idle_trimmer exits cleanly when libc.so.6 not loadable (musl/Alpine)."""
+    from nexus.server.lifespan import _idle_trimmer
+
+    with patch("ctypes.CDLL", side_effect=OSError("no libc")):
+        # Should return normally without hanging or raising
+        await asyncio.wait_for(_idle_trimmer(), timeout=1.0)
+
+
+@pytest.mark.asyncio
+async def test_idle_trimmer_disabled_when_malloc_trim_missing():
+    """_idle_trimmer exits when symbol absent (not glibc)."""
+    from nexus.server.lifespan import _idle_trimmer
+
+    # Plain object with no malloc_trim attribute → AttributeError on probe.
+    # MagicMock auto-creates attributes, so we need a real object.
+    class _FakeLibc:
+        pass
+
+    with patch("ctypes.CDLL", return_value=_FakeLibc()):
+        await asyncio.wait_for(_idle_trimmer(), timeout=1.0)

--- a/tests/unit/server/lifespan/test_search_lifespan.py
+++ b/tests/unit/server/lifespan/test_search_lifespan.py
@@ -6,14 +6,18 @@ from nexus.server.lifespan.search import _resolve_txtai_runtime_config
 
 
 class TestResolveTxtaiRuntimeConfig:
-    def test_defaults_to_local_model(self) -> None:
+    def test_defaults_to_bm25_only(self) -> None:
+        # Issue #3997: default (no env) -> (None, None) -> BM25 keyword-only
+        # path; no heavy local model loaded at boot.
         with patch.dict("os.environ", {}, clear=True):
             model, vectors = _resolve_txtai_runtime_config()
 
-        assert model == "sentence-transformers/all-MiniLM-L6-v2"
+        assert model is None
         assert vectors is None
 
-    def test_keeps_local_default_without_openai_key(self) -> None:
+    def test_keeps_bm25_only_without_openai_key(self) -> None:
+        # Issue #3997: NEXUS_TXTAI_USE_API_EMBEDDINGS=true without a key
+        # has nothing to call -> still (None, None) -> BM25 keyword-only.
         with patch.dict(
             "os.environ",
             {
@@ -23,7 +27,7 @@ class TestResolveTxtaiRuntimeConfig:
         ):
             model, vectors = _resolve_txtai_runtime_config()
 
-        assert model == "sentence-transformers/all-MiniLM-L6-v2"
+        assert model is None
         assert vectors is None
 
     def test_enables_openai_api_embeddings_when_opted_in(self) -> None:

--- a/tests/unit/server/lifespan/test_search_runtime_config.py
+++ b/tests/unit/server/lifespan/test_search_runtime_config.py
@@ -1,0 +1,83 @@
+"""Three-way auto-resolution for txtai runtime (Issue #3997).
+
+Default (no env): BM25 keyword-only — no model load.
+OPENAI_API_KEY set: API embeddings — ~0 RAM.
+NEXUS_TXTAI_MODEL=local: opt-in heavy load.
+"""
+
+import pytest
+
+from nexus.server.lifespan.search import _resolve_txtai_runtime_config
+
+
+@pytest.fixture(autouse=True)
+def _clear_env(monkeypatch):
+    for k in (
+        "OPENAI_API_KEY",
+        "OPENAI_BASE_URL",
+        "NEXUS_TXTAI_MODEL",
+        "NEXUS_TXTAI_USE_API_EMBEDDINGS",
+    ):
+        monkeypatch.delenv(k, raising=False)
+
+
+def test_default_returns_bm25():
+    """No env -> (None, None) -> BM25 keyword-only path."""
+    assert _resolve_txtai_runtime_config() == (None, None)
+
+
+def test_openai_key_only(monkeypatch):
+    """OPENAI_API_KEY alone -> openai/text-embedding-3-small with key."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    model, vectors = _resolve_txtai_runtime_config()
+    assert model == "openai/text-embedding-3-small"
+    assert vectors == {"api_key": "sk-test"}
+
+
+def test_openai_key_with_base_url(monkeypatch):
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("OPENAI_BASE_URL", "https://proxy.example/v1")
+    model, vectors = _resolve_txtai_runtime_config()
+    assert model == "openai/text-embedding-3-small"
+    assert vectors == {"api_key": "sk-test", "api_base": "https://proxy.example/v1"}
+
+
+def test_explicit_local_model_wins_over_key(monkeypatch):
+    """User-set local model overrides API mode even when key is present."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("NEXUS_TXTAI_MODEL", "sentence-transformers/all-MiniLM-L6-v2")
+    model, vectors = _resolve_txtai_runtime_config()
+    assert model == "sentence-transformers/all-MiniLM-L6-v2"
+    assert vectors is None
+
+
+def test_explicit_local_model_no_key(monkeypatch):
+    """User-set local model without key still loads locally."""
+    monkeypatch.setenv("NEXUS_TXTAI_MODEL", "sentence-transformers/all-mpnet-base-v2")
+    model, vectors = _resolve_txtai_runtime_config()
+    assert model == "sentence-transformers/all-mpnet-base-v2"
+    assert vectors is None
+
+
+def test_explicit_openai_model_uses_key(monkeypatch):
+    """Explicit openai/* model + key -> use API."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("NEXUS_TXTAI_MODEL", "openai/text-embedding-3-large")
+    model, vectors = _resolve_txtai_runtime_config()
+    assert model == "openai/text-embedding-3-large"
+    assert vectors == {"api_key": "sk-test"}
+
+
+def test_use_api_flag_with_key(monkeypatch):
+    """NEXUS_TXTAI_USE_API_EMBEDDINGS=true + key -> default openai model."""
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("NEXUS_TXTAI_USE_API_EMBEDDINGS", "true")
+    model, vectors = _resolve_txtai_runtime_config()
+    assert model == "openai/text-embedding-3-small"
+    assert vectors == {"api_key": "sk-test"}
+
+
+def test_use_api_flag_no_key(monkeypatch):
+    """NEXUS_TXTAI_USE_API_EMBEDDINGS=true without key -> still BM25 (no key to use)."""
+    monkeypatch.setenv("NEXUS_TXTAI_USE_API_EMBEDDINGS", "true")
+    assert _resolve_txtai_runtime_config() == (None, None)

--- a/tests/unit/server/lifespan/test_search_runtime_config.py
+++ b/tests/unit/server/lifespan/test_search_runtime_config.py
@@ -27,19 +27,23 @@ def test_default_returns_bm25():
 
 
 def test_openai_key_only(monkeypatch):
-    """OPENAI_API_KEY alone -> openai/text-embedding-3-small with key."""
+    """OPENAI_API_KEY alone -> openai/text-embedding-3-large with Matryoshka 1536d."""
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     model, vectors = _resolve_txtai_runtime_config()
-    assert model == "openai/text-embedding-3-small"
-    assert vectors == {"api_key": "sk-test"}
+    assert model == "openai/text-embedding-3-large"
+    assert vectors == {"api_key": "sk-test", "dimensions": 1536}
 
 
 def test_openai_key_with_base_url(monkeypatch):
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     monkeypatch.setenv("OPENAI_BASE_URL", "https://proxy.example/v1")
     model, vectors = _resolve_txtai_runtime_config()
-    assert model == "openai/text-embedding-3-small"
-    assert vectors == {"api_key": "sk-test", "api_base": "https://proxy.example/v1"}
+    assert model == "openai/text-embedding-3-large"
+    assert vectors == {
+        "api_key": "sk-test",
+        "api_base": "https://proxy.example/v1",
+        "dimensions": 1536,
+    }
 
 
 def test_explicit_local_model_wins_over_key(monkeypatch):
@@ -60,21 +64,21 @@ def test_explicit_local_model_no_key(monkeypatch):
 
 
 def test_explicit_openai_model_uses_key(monkeypatch):
-    """Explicit openai/* model + key -> use API."""
+    """Explicit openai/* model + key -> use API. 3-large gets Matryoshka 1536d."""
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     monkeypatch.setenv("NEXUS_TXTAI_MODEL", "openai/text-embedding-3-large")
     model, vectors = _resolve_txtai_runtime_config()
     assert model == "openai/text-embedding-3-large"
-    assert vectors == {"api_key": "sk-test"}
+    assert vectors == {"api_key": "sk-test", "dimensions": 1536}
 
 
 def test_use_api_flag_with_key(monkeypatch):
-    """NEXUS_TXTAI_USE_API_EMBEDDINGS=true + key -> default openai model."""
+    """NEXUS_TXTAI_USE_API_EMBEDDINGS=true + key -> default openai 3-large model."""
     monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
     monkeypatch.setenv("NEXUS_TXTAI_USE_API_EMBEDDINGS", "true")
     model, vectors = _resolve_txtai_runtime_config()
-    assert model == "openai/text-embedding-3-small"
-    assert vectors == {"api_key": "sk-test"}
+    assert model == "openai/text-embedding-3-large"
+    assert vectors == {"api_key": "sk-test", "dimensions": 1536}
 
 
 def test_use_api_flag_no_key(monkeypatch):


### PR DESCRIPTION
## Summary
- **Issue #3997 work:** trim ``_FULL_TUNING`` pools for single-tenant (thread_pool 200→40, db_pool 20→5+5, httpx 100→20, connector 20→6); BM25-only fast-path skips ``Embeddings(path=...)`` when no model is configured (saves ~80MB model weights at boot); three-way auto-resolver (BM25 default / OpenAI API / explicit local); Dockerfile picks up libjemalloc2 + ``MALLOC_ARENA_MAX=2`` + BLAS caps; lifespan boot tweaks (``threading.stack_size(1<<20)``, ``gc.set_threshold(50_000, 10)``, ``gc.freeze()`` after warmup, idle ``malloc_trim`` trimmer); drops the hardcoded ``NEXUS_TXTAI_RERANKER``; demo-memory regression test + nightly workflow.
- **Bundled (drift fixes the user demanded):** ``permissions_demo_enhanced.sh`` and ``scripts/test_build_perf_e2e.py`` were broken on develop independently of #3997. Three RPC-layer fixes unblock both: regen ``_rpc_params_generated.py`` (May-1 codegen revert silently dropped 121 service-tier param classes including ``SemanticSearchParams`` and ``RebacCreateParams``); add ``sys_readdir`` + ``sys_watch`` to ``KERNEL_SYSCALL_NAMES`` (CLI calls the canonical names directly, not the wire aliases); make ``_check_existing_tuple`` zone-agnostic so it matches ``idx_rebac_tuple_unique`` (post-mkdir auto-grant in zone="root" was getting hit by the unique-index INSERT when the explicit ``rebac create`` ran with zone=None).

**Honest scope of the perf claim:** cold-start RSS lands ~984MB vs the 450MB target in the regression test; verified wins are ~67MB from dropping the reranker default and ~80MB from skipping the embedding-model load, plus thread-count and VmData reductions. The remaining gap is ~500-700MB of ``txtai → torch/transformers/faiss`` library imports — those need lazy-imports or a slim Docker variant, neither of which is in this PR. The regression test stays at 450MB so the gap is visible, not hidden.

## Test plan
- [x] ``permissions_demo_enhanced.sh`` — all 10 sections green ("All tests passed! ReBAC system is production-ready.")
- [x] ``scripts/test_build_perf_e2e.py`` — **22 passed, 0 failed** (HERB hit rate 8/8, auto-index after edit ✓, file-indexed-before-delete ✓, deleted-file-removed-from-search ✓)
- [x] ``uv run pytest tests/unit/core/test_performance_tuning.py tests/unit/server/lifespan/test_boot_tweaks.py tests/unit/server/lifespan/test_search_runtime_config.py`` — pass
- [x] Docker build green (``nexus-server:rss-after-fix2``); image boots, ``/healthz/ready`` returns 200, federation bootstraps cleanly on a fresh data dir
- [ ] CI: ``Demo Memory Regression`` workflow (nightly) — currently expected to fail at the 450MB threshold; promote to required only after the lazy-import / slim-image follow-up lands