### PR TITLE
fix(nexusd-cluster): spawn_blocking around bootstrap_or_join_root (nested-tokio panic)

### DIFF
--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -331,13 +331,33 @@ async fn run_daemon(common: CommonArgs) -> Result<()> {
     let bootstrap_new = std::env::var("NEXUS_BOOTSTRAP_NEW")
         .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true"))
         .unwrap_or(false);
-    bootstrap_or_join_root(
-        zm.as_ref(),
-        node_id,
-        &self_address,
-        &peer_addrs,
-        bootstrap_new,
-    )
+
+    // `bootstrap_or_join_root` is a sync helper that, in branch 3
+    // (wait-and-join), spins a nested `tokio::runtime` to drive the
+    // JoinZone retry loop's RPCs.  Python `nexusd::init_from_env`
+    // calls it from a sync PyO3 entry point — no outer runtime — so
+    // the nested-runtime build is allowed.  `nexusd-cluster::main` is
+    // `#[tokio::main]`, so calling the sync helper from this `async`
+    // function would build the nested runtime *inside* the outer
+    // worker pool and trip tokio's "Cannot start a runtime from
+    // within a runtime" panic.  Move the call to `spawn_blocking`:
+    // the blocking thread is outside the worker pool, so nested
+    // runtime creation is allowed (and the worker pool is not held
+    // while branch 3 retries indefinitely).
+    let zm_for_bootstrap = zm.clone();
+    let self_addr_for_bootstrap = self_address.clone();
+    let peer_addrs_for_bootstrap = peer_addrs.clone();
+    tokio::task::spawn_blocking(move || {
+        bootstrap_or_join_root(
+            zm_for_bootstrap.as_ref(),
+            node_id,
+            &self_addr_for_bootstrap,
+            &peer_addrs_for_bootstrap,
+            bootstrap_new,
+        )
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("bootstrap join task panicked: {}", e))?
     .map_err(|e| anyhow::anyhow!("bootstrap_or_join_root: {}", e))?;
 
     // `bootstrap_static` — invoked below when federation env vars are


### PR DESCRIPTION
## Summary

Mac-side smoke against PR #4008's nexusd-cluster crashed with
``Cannot start a runtime from within a runtime`` right after
``Zone 'root' registered (peers=1)``.  Root cause: PR #4008 wired
the sync ``bootstrap_or_join_root`` helper into the async
``run_daemon``; the helper builds a nested ``tokio::runtime`` for
its JoinZone retry loop, which is fine for Python ``nexusd``
(sync PyO3 entry, no outer runtime) but panics under
``nexusd-cluster::main`` (``#[tokio::main]``, outer worker pool).

Wrap the helper call in ``tokio::task::spawn_blocking`` — the
blocking thread pool is outside the worker pool, so nested-runtime
creation is allowed.  Branch 3's indefinite retry loop also no
longer holds a worker thread hostage.

## Test plan

- [x] `cargo check -p nexus-cluster` clean
- [x] `cargo clippy -p nexus-cluster -- -D warnings` clean
- [x] Local founder smoke (``NEXUS_BOOTSTRAP_NEW=1``):
      ``Bootstrapped ConfState with voters: [N]``, no panic
- [x] Local joiner smoke (no flag, unreachable peer):
      ``empty storage and NEXUS_BOOTSTRAP_NEW unset — retrying
      JoinZone against NEXUS_PEERS indefinitely``, no panic,
      retries forever as designed
- [ ] CI green
- [ ] Post-merge: re-run cross-machine static-mode L1 with
      ``cluster_smoke_xmachine.py`` from PR #4008