### PR TITLE
fix(raft): NEXUS_PEERS lists OTHER peers only — fail-loud on self

### DIFF
--- a/dockerfiles/docker-compose.dynamic-federation-test.yml
+++ b/dockerfiles/docker-compose.dynamic-federation-test.yml
@@ -68,11 +68,14 @@ services:
       # Raft
       NEXUS_BIND_ADDR: 0.0.0.0:2126
       NEXUS_ADVERTISE_ADDR: nexus-1:2126
-      NEXUS_PEERS: "nexus-1:2126,nexus-2:2126,witness:2126"
+      # Address book lists OTHER nodes only — self enters the cluster
+      # via NEXUS_BOOTSTRAP_NEW=1 (founder) or AddNode (joiner), not
+      # the address book.  See docs/architecture/federation-memo.md
+      # §6.3.1 and `validate_peers_excludes_self`.
+      NEXUS_PEERS: "nexus-2:2126,witness:2126"
       NEXUS_RAFT_TLS: "false"
       # Founder of the cluster under the opaque-ID contract: creates
       # a 1-voter `root` zone; nexus-2 + witness JoinZone into it.
-      # See docs/architecture/federation-memo.md §6.3.1.
       NEXUS_BOOTSTRAP_NEW: "1"
 
       # gRPC VFS (bind 0.0.0.0 for cross-container access)
@@ -129,7 +132,9 @@ services:
 
       NEXUS_BIND_ADDR: 0.0.0.0:2126
       NEXUS_ADVERTISE_ADDR: nexus-2:2126
-      NEXUS_PEERS: "nexus-1:2126,nexus-2:2126,witness:2126"
+      # Address book = other peers only.  Joiner: AddNode through
+      # nexus-1 (the founder) under the JoinZone retry-loop branch.
+      NEXUS_PEERS: "nexus-1:2126,witness:2126"
       NEXUS_RAFT_TLS: "false"
       NEXUS_GRPC_BIND_ALL: "true"
 
@@ -168,6 +173,12 @@ services:
         condition: service_healthy
     environment:
       NEXUS_BIND_ADDR: 0.0.0.0:2126
+      # Witness needs self in its NEXUS_PEERS so `bin/witness.rs` can
+      # find its own entry by hostname-derived `node_id` and publish
+      # the matching advertise address (`StepMessage.sender_address`
+      # carrier).  The `validate_peers_excludes_self` contract only
+      # applies to `init_from_env` / `nexusd-cluster::open_zone_manager`
+      # — witness has its own boot path with id-based self-detection.
       NEXUS_PEERS: "nexus-1:2126,nexus-2:2126,witness:2126"
       NEXUS_DATA_DIR: /home/nexus/data
       RUST_LOG: info,nexus_raft=debug

--- a/docs/architecture/federation-memo.md
+++ b/docs/architecture/federation-memo.md
@@ -171,7 +171,7 @@ Path resolution across zones is **all local** (~5us per hop) because mounting = 
 Etcd / TiKV-style opaque IDs + leader-driven `AddNode`.
 
 - **Identity** — `node_id` is an opaque random `u64` minted at first daemon boot, persisted as 8 bytes BE u64 to `<NEXUS_DATA_DIR>/.node_id`.  Decoupling identity from hostname lets a wiped follower rejoin under a fresh ID; the leader's `Progress[new_id]` is created with `matched=0` by `AddNode`, so the first heartbeat carries `m.commit=0` — within `RaftLog::commit_to`'s safe range on a fresh follower (`last_index=0`).  Pinned by [`test_handle_heartbeat_on_empty_follower_with_stale_commit_panics`](../../rust/raft/src/raft/storage.rs).
-- **Address book** — `NEXUS_PEERS` is a hostname → endpoint mapping that seeds the transport peer map.  `ConfState` lives in raft storage and is mutated only by `ConfChange` (AddNode / RemoveNode) driven by JoinZone.
+- **Address book** — `NEXUS_PEERS` is a hostname → endpoint mapping for OTHER nodes only that seeds the transport peer map.  Self joins the cluster through `create_zone(self)` (founder) or `AddNode(self)` on the leader (joiner) — never through the address book.  Boot fails loud (`peer list contains self ...`) when `NEXUS_PEERS` includes the local node so the joiner-loop self-RPC stall surfaces at parse time, not after `Zone 'root' registered`.  `ConfState` lives in raft storage and is mutated only by `ConfChange` (AddNode / RemoveNode) driven by JoinZone.
 - **Bootstrap dispatch** ([`bootstrap_or_join_root`](../../rust/raft/src/distributed_coordinator.rs)):
 
   | State                                         | Action                                                       |

--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -27,7 +27,9 @@ use kernel::abc::object_store::ObjectStore;
 use kernel::core::dcache::DT_MOUNT;
 use kernel::kernel::Kernel;
 
-use nexus_raft::distributed_coordinator::{bootstrap_or_join_root, read_or_mint_node_id};
+use nexus_raft::distributed_coordinator::{
+    bootstrap_or_join_root, read_or_mint_node_id, validate_peers_excludes_self,
+};
 use nexus_raft::federation::{parse_federation_env, ENV_FEDERATION_MOUNTS, ENV_FEDERATION_ZONES};
 use nexus_raft::transport::{bootstrap_tls, NodeAddress};
 use nexus_raft::{TlsFiles, ZoneManager};
@@ -280,6 +282,12 @@ fn open_zone_manager(common: &CommonArgs) -> Result<ZoneManagerBundle> {
         .and_then(|(_, p)| p.parse::<u16>().ok())
         .unwrap_or(2126);
     let self_address = format!("{hostname}:{bind_port}");
+
+    // Reject "self listed in --peers" early — see
+    // `validate_peers_excludes_self` for why this is a hard error
+    // under the PR #3996 opaque-ID contract.
+    validate_peers_excludes_self(&peer_addrs, &self_address)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
 
     let zm = ZoneManager::with_node_id(
         &hostname,

--- a/rust/raft/src/distributed_coordinator.rs
+++ b/rust/raft/src/distributed_coordinator.rs
@@ -302,6 +302,44 @@ pub fn read_or_mint_node_id(zones_dir: &str) -> Result<u64, String> {
     }
 }
 
+/// Validate that the parsed peer address book excludes `self_address`.
+///
+/// Contract under PR #3996+: `NEXUS_PEERS` (or `--peers` for
+/// `nexusd-cluster`) lists OTHER nodes only.  Self goes in the
+/// ConfState via `create_zone(self)` on the founder or `AddNode(self)`
+/// on a joiner — not via the address book.  Listing self inside the
+/// address book was a vestige of the pre-#3996 contract where
+/// `peer_addrs` doubled as the ConfState voter list, and today it is
+/// a footgun: if `self_address` does not exactly string-match the
+/// self entry (e.g. operator passed an IP for the peer entry but the
+/// hostname-derived `self_address` falls back to the OS hostname),
+/// the JoinZone retry loop tries to RPC self, registers the zone
+/// locally with `skip_bootstrap=true`, and stalls because there is no
+/// real leader to grant `AddNode`.
+///
+/// Fail-loud here so the misconfiguration surfaces at boot rather
+/// than as a silent stall after `Zone 'root' registered (peers=1)`.
+pub fn validate_peers_excludes_self(
+    peer_addrs: &[NodeAddress],
+    self_address: &str,
+) -> Result<(), String> {
+    for peer in peer_addrs {
+        let peer_hostport = peer
+            .endpoint
+            .trim_start_matches("https://")
+            .trim_start_matches("http://");
+        if peer_hostport == self_address {
+            return Err(format!(
+                "peer list contains self ('{self_address}'); under the PR #3996 \
+                 opaque-ID contract NEXUS_PEERS / --peers must list OTHER nodes \
+                 only.  Self joins the cluster via NEXUS_BOOTSTRAP_NEW=1 \
+                 (founder) or AddNode-on-leader (joiner), not the address book.",
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Bring root zone online — dispatch table for the three bootstrap
 /// branches under the opaque-ID contract.
 ///
@@ -394,16 +432,13 @@ pub fn bootstrap_or_join_root(
 
     loop {
         for peer in peer_addrs {
-            // Skip self by endpoint-string compare.  `self_address` is
-            // "host:port"; `peer.endpoint` is "<scheme>://host:port".
-            let peer_hostport = peer
-                .endpoint
-                .trim_start_matches("https://")
-                .trim_start_matches("http://");
-            if peer_hostport == self_address {
-                continue;
-            }
-
+            // No self-skip here.  Contract: `peer_addrs` lists OTHER
+            // nodes only.  Operator-input that includes self is
+            // rejected at parse time by the boot path that owns the
+            // address book (see `validate_peers_excludes_self` in
+            // `init_from_env` and `nexusd-cluster::open_zone_manager`)
+            // so by the time we reach the JoinZone retry loop,
+            // every entry is a remote peer worth contacting.
             let mut endpoint = peer.endpoint.clone();
             let mut redirected_once = false;
             loop {
@@ -586,6 +621,12 @@ impl RaftDistributedCoordinator {
                     .map_err(|e| format!("NEXUS_PEERS parse '{entry}': {e}"))
             })
             .collect::<Result<Vec<_>, _>>()?;
+
+        // Reject "self listed in NEXUS_PEERS" early — the only way
+        // self enters the cluster post-#3996 is through `create_zone`
+        // (founder) or AddNode-on-leader (joiner).  See
+        // `validate_peers_excludes_self` for the full rationale.
+        validate_peers_excludes_self(&peer_addrs, &self_addr)?;
 
         let tls = if tls_disabled {
             None
@@ -1569,5 +1610,50 @@ mod tests {
         std::fs::write(&path, [0u8; 8]).expect("write zero");
         let result = read_or_mint_node_id(dir.path().to_str().expect("utf-8"));
         assert!(result.is_err(), "must reject zero id on disk");
+    }
+
+    fn parse_peer(s: &str) -> NodeAddress {
+        NodeAddress::parse(s, /* use_tls */ false).expect("parse peer")
+    }
+
+    #[test]
+    fn validate_peers_excludes_self_accepts_other_peers_only() {
+        // Address book lists OTHER nodes — happy path under the
+        // PR #3996 contract.
+        let peers = vec![parse_peer("100.64.0.21:2126")];
+        validate_peers_excludes_self(&peers, "100.64.0.26:2126")
+            .expect("other-peers-only must be accepted");
+    }
+
+    #[test]
+    fn validate_peers_excludes_self_rejects_self_in_list() {
+        // Operator pasted self into NEXUS_PEERS — fail-loud at parse
+        // time rather than letting the JoinZone retry loop stall on
+        // a self-RPC that never gets a leader.
+        let peers = vec![
+            parse_peer("100.64.0.26:2126"),
+            parse_peer("100.64.0.21:2126"),
+        ];
+        let err = validate_peers_excludes_self(&peers, "100.64.0.26:2126")
+            .expect_err("self-in-peers must be rejected");
+        assert!(
+            err.contains("contains self"),
+            "error must name the contract violation, got: {err}",
+        );
+    }
+
+    #[test]
+    fn validate_peers_excludes_self_handles_explicit_id_prefix() {
+        // `id@host:port` form: same self-detection logic must apply.
+        let peers = vec![parse_peer("9999@100.64.0.26:2126")];
+        let err = validate_peers_excludes_self(&peers, "100.64.0.26:2126")
+            .expect_err("self-in-peers must be rejected even with explicit id prefix");
+        assert!(err.contains("contains self"));
+    }
+
+    #[test]
+    fn validate_peers_excludes_self_empty_list_is_ok() {
+        // Founder mode with no other peers yet.
+        validate_peers_excludes_self(&[], "100.64.0.26:2126").expect("empty list ok");
     }
 }

--- a/scripts/cluster_smoke_xmachine.py
+++ b/scripts/cluster_smoke_xmachine.py
@@ -22,19 +22,31 @@ contract pin this script provides.
 
 Run:
 
-    # On the founder side (Win):
+    # On the founder side (Win, IP 100.64.0.26):
     PYTHONPATH=. python scripts/cluster_smoke_xmachine.py \\
         --side win --bootstrap-new \\
-        --peers 100.64.0.26:2126,100.64.0.21:2126
+        --hostname 100.64.0.26 \\
+        --peers 100.64.0.21:2126
 
-    # On the joiner side (Mac):
+    # On the joiner side (Mac, IP 100.64.0.21):
     PYTHONPATH=. python scripts/cluster_smoke_xmachine.py \\
         --side mac \\
-        --peers 100.64.0.26:2126,100.64.0.21:2126
+        --hostname 100.64.0.21 \\
+        --peers 100.64.0.26:2126
 
-Exactly one side must pass ``--bootstrap-new`` — the contract
-forbids two founders, and zero founders means neither side ever
-creates the cluster (deadlock).
+Two contract guarantees the boot path enforces and the operator
+must respect:
+
+  1. **One founder.** Exactly one side passes ``--bootstrap-new``;
+     two founders create disjoint clusters, zero founders means
+     neither side ever creates the cluster (joiner-loop deadlock).
+  2. **--peers lists OTHER nodes only.**  Self enters the cluster
+     via ``--bootstrap-new`` (founder) or AddNode-on-leader
+     (joiner) — not the address book.  The Rust side fails loud
+     (``peer list contains self ...``) if self leaks into
+     ``--peers``.  Pair ``--hostname <self_ip>`` with
+     ``--peers <other_ip>:port,...`` so the self-detection match
+     is unambiguous.
 """
 
 from __future__ import annotations


### PR DESCRIPTION
## Summary

Today's cross-machine static-mode L1 smoke surfaced a footgun:
``bootstrap_or_join_root``'s JoinZone retry loop skipped self by
``peer.endpoint`` vs ``self_address`` string-compare.  When the two
were spelled differently (operator passed ``--peers
100.64.0.21:2126`` but ``self_address == "ethan-mbp.local:2126"``
because ``NEXUS_HOSTNAME`` defaulted to OS hostname), self-skip
failed.  Mac registered ``root`` locally, fired JoinZone against
itself, got no leader, and stalled silently — retry RPC errors
were debug-level so the daemon looked stuck at ``Zone 'root'
registered (peers=1)``.

The simpler contract: ``NEXUS_PEERS`` (and ``--peers`` for
``nexusd-cluster``) lists OTHER nodes only.  Self enters the
cluster through ``create_zone(self)`` (founder) or ``AddNode``
(joiner), never through the address book — the pre-#3996 listing
was vestigial.  Reject self at parse time so misconfiguration
surfaces at boot rather than as a silent stall.

## Test plan

- [x] ``cargo test -p raft@0.1.0 --lib --features grpc validate_peers``: 4/4 green
- [x] ``cargo check -p nexus-cluster`` clean
- [x] Local smoke: ``--peers 127.0.0.1:2126,127.0.0.1:2127`` (self included) → boot fails with the contract-violation error
- [x] Local smoke: ``--peers 127.0.0.1:2127`` (other only) + ``--bootstrap-new`` → 1-voter ConfState, normal startup
- [ ] CI green
- [ ] Post-merge: cross-machine static L1 with ``--peers <other_only>`` — should reproduce yesterday's PASS without the self-RPC stall workaround