### PR TITLE
feat(services): Matrix C-S adapter D1 — skeleton + auth surface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,18 +177,50 @@ checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
 name = "axum"
+version = "0.7.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
+dependencies = [
+ "async-trait",
+ "axum-core 0.4.5",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "itoa",
+ "matchit 0.7.3",
+ "memchr",
+ "mime",
+ "percent-encoding",
+ "pin-project-lite",
+ "rustversion",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "sync_wrapper",
+ "tokio",
+ "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
- "axum-core",
+ "axum-core 0.5.6",
  "bytes",
  "futures-util",
  "http",
  "http-body",
  "http-body-util",
  "itoa",
- "matchit",
+ "matchit 0.8.4",
  "memchr",
  "mime",
  "percent-encoding",
@@ -196,6 +228,26 @@ dependencies = [
  "serde_core",
  "sync_wrapper",
  "tower",
+ "tower-layer",
+ "tower-service",
+]
+
+[[package]]
+name = "axum-core"
+version = "0.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "mime",
+ "pin-project-lite",
+ "rustversion",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
 ]
@@ -260,6 +312,12 @@ dependencies = [
  "tracing",
  "uuid",
 ]
+
+[[package]]
+name = "base32"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "022dfe9eb35f19ebbcb51e0b40a5ab759f46ad60cadf7297e0bd085afb50e076"
 
 [[package]]
 name = "base64"
@@ -1651,6 +1709,12 @@ dependencies = [
 
 [[package]]
 name = "matchit"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
+
+[[package]]
+name = "matchit"
 version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "47e1ffaa40ddd1f3ed91f717a33c8c0ee23fff369e3aa8772b9605cc1d22f4c3"
@@ -2770,6 +2834,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_path_to_error"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10a9ff822e371bb5403e391ecd83e182e0e77ba7f6fe0160b795797109d1b457"
+dependencies = [
+ "itoa",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
 name = "serde_urlencoded"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2785,6 +2860,9 @@ dependencies = [
 name = "services"
 version = "0.1.0"
 dependencies = [
+ "async-trait",
+ "axum 0.7.9",
+ "base32",
  "bincode",
  "chrono",
  "contracts",
@@ -2801,6 +2879,7 @@ dependencies = [
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tower",
  "tracing",
  "uuid",
 ]
@@ -3199,7 +3278,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
 dependencies = [
  "async-trait",
- "axum",
+ "axum 0.8.9",
  "base64",
  "bytes",
  "h2",

--- a/rust/services/Cargo.toml
+++ b/rust/services/Cargo.toml
@@ -21,6 +21,11 @@ service-managed-agent = []
 service-acp = []
 service-tasks = []
 service-permission = []
+# Matrix Client-Server v3 adapter — exposes nexus chat-with-me
+# DT_STREAMs as Matrix rooms so stock chat clients (Element /
+# FluffyChat / Cinny) can join conversations without a bespoke
+# nexus client. End-state spec: sudowork-2/docs/tech/nexus-integration-architecture.md §4.2.
+service-matrix-adapter = ["dep:axum", "dep:base32", "dep:tower"]
 
 # Optional PyO3 surface — `services::python::register(m)` aggregates
 # every PyO3 entry point (`install_audit_hook`, …) into one fn the
@@ -36,6 +41,9 @@ python = [
     "service-acp",
     "service-tasks",
     "service-permission",
+    # service-matrix-adapter intentionally NOT in `python` — it has no
+    # PyO3 surface; nexus-cdylib opts in separately when shipping the
+    # adapter alongside the Python wheel.
 ]
 
 [dependencies]
@@ -80,6 +88,22 @@ futures = "0.3"
 # pyo3 feature unioned by cargo when nexus-cdylib enables `extension-module`
 # on its own pyo3 dep — services does not need to set extension-module here.
 pyo3 = { version = "0.27.2", features = ["hashbrown"], optional = true }
+# Matrix C-S adapter HTTP surface. Lazily pulled in by the
+# `service-matrix-adapter` feature so non-adapter builds (cluster
+# binary, raft-witness, slim WASM) do not pay the axum compile time.
+axum = { version = "0.7", default-features = false, features = ["json", "http1", "tokio", "matched-path"], optional = true }
+tower = { version = "0.5", features = ["util"], optional = true }
+# base32 alphabet for Matrix room-id encoding (`!{base32(stream_path)}:nexus.local`).
+base32 = { version = "0.5", optional = true }
+# `async_trait` lets the `AuthBackend` trait expose async methods —
+# axum handlers are async, and the production AuthService backend will
+# do an async lookup. Used by every adapter feature gate, so we pull
+# it unconditionally rather than wrapping each impl in a
+# cfg(feature) hop.
+async-trait = "0.1"
 
 [dev-dependencies]
 tempfile = "3"
+# Test the adapter's HTTP surface end-to-end against an in-memory
+# axum router via `tower::Service::call`.
+tower = { version = "0.5", features = ["util"] }

--- a/rust/services/src/lib.rs
+++ b/rust/services/src/lib.rs
@@ -69,6 +69,14 @@ pub mod tasks;
 // Kernel registration of §11 PermissionHook is scaffolded here only.
 #[cfg(all(feature = "service-permission", feature = "python"))]
 pub mod permission;
+// Matrix Client-Server v3 adapter — exposes nexus chat-with-me
+// DT_STREAMs as Matrix rooms so stock chat clients (Element /
+// FluffyChat / Cinny) participate in nexus conversations through the
+// existing kernel surface. End-state spec lives in
+// `sudowork-2/docs/tech/nexus-integration-architecture.md` §4.2; D1
+// here lands skeleton + auth (`login` / `logout` / `whoami`).
+#[cfg(feature = "service-matrix-adapter")]
+pub mod matrix_adapter;
 
 #[cfg(feature = "python")]
 pub mod python;

--- a/rust/services/src/matrix_adapter/auth.rs
+++ b/rust/services/src/matrix_adapter/auth.rs
@@ -1,0 +1,158 @@
+//! Auth surface — abstracts the AuthService contract the adapter
+//! consumes so the same router composes against (a) the production
+//! AuthService (D2-onward, when the Rust shim lands) and (b) a stub
+//! backend for tests.
+//!
+//! The adapter stays the only place that translates between Matrix
+//! login JSON / bearer tokens and the kernel's `OperationContext`
+//! identity stamp. Every other endpoint reads `OperationContext` from
+//! request extensions populated by the access-token middleware.
+
+use std::sync::Arc;
+
+use async_trait::async_trait;
+
+/// Resolved Matrix session — what `login` returns and what the
+/// access-token middleware looks up on every request.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AuthSession {
+    /// Matrix-formatted user id (`@local-part:server-name`). Today
+    /// `local-part` matches nexus's `OperationContext.user_id`.
+    pub user_id: String,
+    /// Opaque bearer token Matrix clients send back as
+    /// `Authorization: Bearer ...`. Mirrors the AuthService session
+    /// token; stable for the lifetime of the session.
+    pub access_token: String,
+    /// Matrix `device_id` echoed back to the client. Today nexus
+    /// assigns one device per token; the adapter keeps the value
+    /// opaque.
+    pub device_id: String,
+}
+
+/// Adapter's view of the AuthService surface. D1 wires a stub impl
+/// for tests; D2 onwards swaps in a Rust shim that delegates to the
+/// real AuthService.
+#[async_trait]
+pub trait AuthBackend: Send + Sync + 'static {
+    /// Validate `m.login.password` credentials and return the resolved
+    /// session, or `Err(AuthError::Forbidden)` on rejection. Other
+    /// flows (`m.login.token`, SSO) come later — the trait is
+    /// extensible without breaking call sites.
+    async fn login_password(
+        &self,
+        identifier: &str,
+        password: &str,
+    ) -> Result<AuthSession, AuthError>;
+
+    /// Resolve a bearer access token to an `AuthSession`. Returns
+    /// `Err(AuthError::UnknownToken)` for tokens the backend doesn't
+    /// recognise.
+    async fn resolve_token(&self, token: &str) -> Result<AuthSession, AuthError>;
+
+    /// Invalidate a session token. Idempotent: logging out an unknown
+    /// token returns `Ok(())` so logout is safe to retry.
+    async fn logout(&self, token: &str) -> Result<(), AuthError>;
+}
+
+/// Auth-side error. The adapter HTTP layer translates these into the
+/// matching `AdapterError` (`M_FORBIDDEN`, `M_UNKNOWN_TOKEN`, …) when
+/// surfacing to the client.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum AuthError {
+    Forbidden(String),
+    UnknownToken,
+    Backend(String),
+}
+
+impl std::fmt::Display for AuthError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Forbidden(m) => write!(f, "auth forbidden: {m}"),
+            Self::UnknownToken => write!(f, "auth: unknown token"),
+            Self::Backend(m) => write!(f, "auth backend: {m}"),
+        }
+    }
+}
+
+impl std::error::Error for AuthError {}
+
+/// Convenience type — the adapter passes around `Arc<dyn AuthBackend>`
+/// so multiple handlers can share a single backend without lifetime
+/// gymnastics.
+pub type AuthBackendRef = Arc<dyn AuthBackend>;
+
+#[cfg(test)]
+pub(crate) mod stub {
+    //! In-memory stub backend used by adapter integration tests. Not
+    //! wired into production builds.
+
+    use super::*;
+    use parking_lot::RwLock;
+    use std::collections::HashMap;
+
+    /// Toy auth backend — accepts a fixed set of `(user, password)`
+    /// pairs and mints deterministic tokens. Tests pre-seed the map
+    /// with the credentials they want accepted.
+    pub struct StubAuthBackend {
+        passwords: RwLock<HashMap<String, String>>, // user → password
+        tokens: RwLock<HashMap<String, AuthSession>>, // token → session
+        server_name: String,
+    }
+
+    impl StubAuthBackend {
+        pub fn new(server_name: impl Into<String>) -> Self {
+            Self {
+                passwords: RwLock::new(HashMap::new()),
+                tokens: RwLock::new(HashMap::new()),
+                server_name: server_name.into(),
+            }
+        }
+
+        pub fn add_user(&self, user: &str, password: &str) {
+            self.passwords
+                .write()
+                .insert(user.to_string(), password.to_string());
+        }
+    }
+
+    #[async_trait]
+    impl AuthBackend for StubAuthBackend {
+        async fn login_password(
+            &self,
+            identifier: &str,
+            password: &str,
+        ) -> Result<AuthSession, AuthError> {
+            let stored = self
+                .passwords
+                .read()
+                .get(identifier)
+                .cloned()
+                .ok_or_else(|| AuthError::Forbidden(format!("unknown user {identifier:?}")))?;
+            if stored != password {
+                return Err(AuthError::Forbidden("password mismatch".into()));
+            }
+            let session = AuthSession {
+                user_id: format!("@{}:{}", identifier, self.server_name),
+                access_token: format!("stub-token-{identifier}"),
+                device_id: format!("stub-device-{identifier}"),
+            };
+            self.tokens
+                .write()
+                .insert(session.access_token.clone(), session.clone());
+            Ok(session)
+        }
+
+        async fn resolve_token(&self, token: &str) -> Result<AuthSession, AuthError> {
+            self.tokens
+                .read()
+                .get(token)
+                .cloned()
+                .ok_or(AuthError::UnknownToken)
+        }
+
+        async fn logout(&self, token: &str) -> Result<(), AuthError> {
+            self.tokens.write().remove(token);
+            Ok(())
+        }
+    }
+}

--- a/rust/services/src/matrix_adapter/error.rs
+++ b/rust/services/src/matrix_adapter/error.rs
@@ -1,0 +1,78 @@
+//! Adapter-wide error type. Surfaces as Matrix-spec error JSON via the
+//! axum `IntoResponse` impl.
+
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
+use serde_json::json;
+
+/// Adapter-level error. Each variant maps to a Matrix `errcode` (the
+/// stable string Matrix clients dispatch on) plus the HTTP status the
+/// spec mandates for that error.
+#[derive(Debug, Clone)]
+pub enum AdapterError {
+    /// `M_FORBIDDEN` — credentials were missing or rejected.
+    Forbidden(String),
+    /// `M_UNKNOWN_TOKEN` — bearer token did not resolve to a session.
+    UnknownToken,
+    /// `M_MISSING_TOKEN` — request reached a token-protected endpoint
+    /// without an `Authorization` header.
+    MissingToken,
+    /// `M_BAD_JSON` — request body failed to parse.
+    BadJson(String),
+    /// `M_UNRECOGNIZED` — endpoint exists but the requested
+    /// login type / flow is not implemented yet.
+    Unrecognized(String),
+    /// `M_UNKNOWN` — anything else; the message goes into the response.
+    Internal(String),
+}
+
+impl AdapterError {
+    fn errcode(&self) -> &'static str {
+        match self {
+            Self::Forbidden(_) => "M_FORBIDDEN",
+            Self::UnknownToken => "M_UNKNOWN_TOKEN",
+            Self::MissingToken => "M_MISSING_TOKEN",
+            Self::BadJson(_) => "M_BAD_JSON",
+            Self::Unrecognized(_) => "M_UNRECOGNIZED",
+            Self::Internal(_) => "M_UNKNOWN",
+        }
+    }
+
+    fn status(&self) -> StatusCode {
+        match self {
+            Self::Forbidden(_) => StatusCode::FORBIDDEN,
+            Self::UnknownToken | Self::MissingToken => StatusCode::UNAUTHORIZED,
+            Self::BadJson(_) | Self::Unrecognized(_) => StatusCode::BAD_REQUEST,
+            Self::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
+        }
+    }
+
+    fn error_message(&self) -> String {
+        match self {
+            Self::Forbidden(m) | Self::BadJson(m) | Self::Unrecognized(m) | Self::Internal(m) => {
+                m.clone()
+            }
+            Self::UnknownToken => "access token unknown".to_string(),
+            Self::MissingToken => "missing access token".to_string(),
+        }
+    }
+}
+
+impl std::fmt::Display for AdapterError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {}", self.errcode(), self.error_message())
+    }
+}
+
+impl std::error::Error for AdapterError {}
+
+impl IntoResponse for AdapterError {
+    fn into_response(self) -> Response {
+        let body = json!({
+            "errcode": self.errcode(),
+            "error": self.error_message(),
+        });
+        (self.status(), Json(body)).into_response()
+    }
+}

--- a/rust/services/src/matrix_adapter/middleware.rs
+++ b/rust/services/src/matrix_adapter/middleware.rs
@@ -1,0 +1,54 @@
+//! Access-token middleware — turns `Authorization: Bearer ...` into
+//! a resolved [`AuthSession`] stored in request extensions. Downstream
+//! handlers read it back via `Extension<AuthSession>`.
+//!
+//! Public endpoints (`login`) skip this layer; the router applies the
+//! middleware only to handler groups that require an authenticated
+//! caller. The middleware never panics: missing / unknown tokens
+//! short-circuit with the matching `AdapterError` JSON response.
+
+use axum::{
+    extract::{Request, State},
+    http::header,
+    middleware::Next,
+    response::Response,
+};
+
+use crate::matrix_adapter::auth::AuthSession;
+use crate::matrix_adapter::error::AdapterError;
+use crate::matrix_adapter::router::AdapterState;
+
+/// Extract the bearer token from an `Authorization` header. Returns
+/// `None` for missing / malformed headers — the caller decides whether
+/// the absence is fatal.
+pub fn parse_bearer(headers: &axum::http::HeaderMap) -> Option<&str> {
+    let value = headers.get(header::AUTHORIZATION)?.to_str().ok()?;
+    let trimmed = value.strip_prefix("Bearer ")?.trim();
+    if trimmed.is_empty() {
+        None
+    } else {
+        Some(trimmed)
+    }
+}
+
+/// Axum `from_fn_with_state` middleware. Reads the bearer token,
+/// resolves it through the [`AuthBackend`], stamps the resolved
+/// [`AuthSession`] into request extensions, and delegates to `next`.
+pub async fn require_access_token(
+    State(state): State<AdapterState>,
+    mut req: Request,
+    next: Next,
+) -> Result<Response, AdapterError> {
+    let token = parse_bearer(req.headers()).ok_or(AdapterError::MissingToken)?;
+    let session = state
+        .auth
+        .resolve_token(token)
+        .await
+        .map_err(|e| match e {
+            crate::matrix_adapter::auth::AuthError::UnknownToken => AdapterError::UnknownToken,
+            crate::matrix_adapter::auth::AuthError::Forbidden(m) => AdapterError::Forbidden(m),
+            crate::matrix_adapter::auth::AuthError::Backend(m) => AdapterError::Internal(m),
+        })?;
+    req.extensions_mut().insert::<AuthSession>(session);
+    Ok(next.run(req).await)
+}

--- a/rust/services/src/matrix_adapter/mod.rs
+++ b/rust/services/src/matrix_adapter/mod.rs
@@ -1,0 +1,31 @@
+//! Matrix Client-Server v3 adapter — exposes nexus chat-with-me
+//! DT_STREAMs as Matrix rooms so stock chat clients (Element,
+//! FluffyChat, Cinny) participate in nexus conversations without a
+//! bespoke client. End-state spec lives in
+//! `sudowork-2/docs/tech/nexus-integration-architecture.md` §4.2.
+//!
+//! D1 lands the skeleton + auth surface:
+//!
+//!   * `axum::Router` exposing `/_matrix/client/v3/login`,
+//!     `/_matrix/client/v3/logout`, `/_matrix/client/v3/account/whoami`.
+//!   * `AuthBackend` trait abstracting credential verification + token
+//!     resolution so the same router composes against the production
+//!     `AuthService` (D2-onward) and a stub backend for tests.
+//!   * Access-token middleware that turns `Authorization: Bearer ...`
+//!     into an `OperationContext` extension on the request, ready for
+//!     D2's room read/write handlers to stamp into kernel syscalls.
+//!
+//! The adapter is stateless: the kernel's metastore + WalStreamBackend
+//! hold the SSOT, so the only in-process state the adapter keeps is
+//! `/sync` long-poll registrations + an access-token cache (D3
+//! responsibility).
+
+pub mod auth;
+pub mod error;
+pub mod middleware;
+pub mod router;
+pub mod types;
+
+pub use auth::{AuthBackend, AuthError, AuthSession};
+pub use error::AdapterError;
+pub use router::{build_router, AdapterState};

--- a/rust/services/src/matrix_adapter/router.rs
+++ b/rust/services/src/matrix_adapter/router.rs
@@ -1,0 +1,309 @@
+//! Axum router assembly + endpoint handlers for the auth surface.
+
+use std::sync::Arc;
+
+use axum::extract::{Extension, Json, State};
+use axum::middleware::from_fn_with_state;
+use axum::response::IntoResponse;
+use axum::routing::{get, post};
+use axum::Router;
+
+use crate::matrix_adapter::auth::{AuthBackendRef, AuthError, AuthSession};
+use crate::matrix_adapter::error::AdapterError;
+use crate::matrix_adapter::middleware::require_access_token;
+use crate::matrix_adapter::types::{
+    EmptyResponse, LoginRequest, LoginResponse, WhoAmIResponse,
+};
+
+/// Shared adapter state — composed once at boot and cloned into each
+/// handler. Cheap to clone (`Arc` and `String`).
+#[derive(Clone)]
+pub struct AdapterState {
+    pub auth: AuthBackendRef,
+    /// Matrix server-name suffix for the homeserver. Used in
+    /// `LoginResponse.home_server` and downstream room-id encoding
+    /// (D2). Configured at adapter boot.
+    pub server_name: Arc<str>,
+}
+
+/// Build the adapter's Matrix C-S router. Composes the public auth
+/// endpoints with the token-protected ones; downstream PRs (D2/D3)
+/// add room read/write + sync routes underneath the same shared
+/// state without restructuring the boot wire-up.
+pub fn build_router(state: AdapterState) -> Router {
+    // Public — no token middleware. `login` is the only way to get one.
+    let public = Router::new().route("/_matrix/client/v3/login", post(login));
+
+    // Token-protected. `whoami` is the canonical "is my token still
+    // valid?" probe; `logout` invalidates the token in the backend.
+    let protected = Router::new()
+        .route("/_matrix/client/v3/account/whoami", get(whoami))
+        .route("/_matrix/client/v3/logout", post(logout))
+        .route_layer(from_fn_with_state(state.clone(), require_access_token));
+
+    public.merge(protected).with_state(state)
+}
+
+async fn login(
+    State(state): State<AdapterState>,
+    Json(req): Json<LoginRequest>,
+) -> Result<Json<LoginResponse>, AdapterError> {
+    if req.login_type != "m.login.password" {
+        return Err(AdapterError::Unrecognized(format!(
+            "login type {:?} not supported (only m.login.password at D1)",
+            req.login_type
+        )));
+    }
+    if req.identifier.id_type != "m.id.user" {
+        return Err(AdapterError::Unrecognized(format!(
+            "identifier type {:?} not supported (only m.id.user at D1)",
+            req.identifier.id_type
+        )));
+    }
+    let user = req
+        .identifier
+        .user
+        .ok_or_else(|| AdapterError::BadJson("identifier.user is required".into()))?;
+    let password = req
+        .password
+        .ok_or_else(|| AdapterError::BadJson("password is required".into()))?;
+
+    let session = state
+        .auth
+        .login_password(&user, &password)
+        .await
+        .map_err(map_auth_err)?;
+
+    Ok(Json(LoginResponse {
+        user_id: session.user_id,
+        access_token: session.access_token,
+        device_id: session.device_id,
+        home_server: state.server_name.to_string(),
+    }))
+}
+
+async fn logout(
+    State(state): State<AdapterState>,
+    Extension(session): Extension<AuthSession>,
+) -> Result<Json<EmptyResponse>, AdapterError> {
+    state
+        .auth
+        .logout(&session.access_token)
+        .await
+        .map_err(map_auth_err)?;
+    Ok(Json(EmptyResponse::default()))
+}
+
+async fn whoami(
+    Extension(session): Extension<AuthSession>,
+) -> Json<WhoAmIResponse> {
+    Json(WhoAmIResponse {
+        user_id: session.user_id,
+        device_id: session.device_id,
+        is_guest: false,
+    })
+}
+
+fn map_auth_err(err: AuthError) -> AdapterError {
+    match err {
+        AuthError::Forbidden(m) => AdapterError::Forbidden(m),
+        AuthError::UnknownToken => AdapterError::UnknownToken,
+        AuthError::Backend(m) => AdapterError::Internal(m),
+    }
+}
+
+// Suppress unused-import warning when the adapter is built without
+// callers — the `IntoResponse` import is used by the trait bound on
+// `AdapterError` through the handlers' return types.
+const _: fn() = || {
+    fn assert_into_response<T: IntoResponse>() {}
+    assert_into_response::<AdapterError>();
+};
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::matrix_adapter::auth::stub::StubAuthBackend;
+    use axum::body::{to_bytes, Body};
+    use axum::http::{header, Request, StatusCode};
+    use serde_json::{json, Value};
+    use tower::ServiceExt;
+
+    const SERVER_NAME: &str = "nexus.local";
+
+    fn fixture(seed_users: &[(&str, &str)]) -> Router {
+        let backend = Arc::new(StubAuthBackend::new(SERVER_NAME));
+        for (user, pw) in seed_users {
+            backend.add_user(user, pw);
+        }
+        let state = AdapterState {
+            auth: backend,
+            server_name: Arc::from(SERVER_NAME),
+        };
+        build_router(state)
+    }
+
+    async fn json_body(resp: axum::response::Response) -> Value {
+        let body = to_bytes(resp.into_body(), 64 * 1024)
+            .await
+            .expect("body bytes");
+        serde_json::from_slice(&body).expect("response is JSON")
+    }
+
+    fn login_request(user: &str, password: &str) -> Request<Body> {
+        let payload = json!({
+            "type": "m.login.password",
+            "identifier": {"type": "m.id.user", "user": user},
+            "password": password,
+        });
+        Request::builder()
+            .method("POST")
+            .uri("/_matrix/client/v3/login")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(payload.to_string()))
+            .unwrap()
+    }
+
+    #[tokio::test]
+    async fn login_password_success_returns_access_token() {
+        let app = fixture(&[("ethan", "hunter2")]);
+        let resp = app
+            .oneshot(login_request("ethan", "hunter2"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+        assert_eq!(body["user_id"], "@ethan:nexus.local");
+        assert_eq!(body["device_id"], "stub-device-ethan");
+        assert_eq!(body["home_server"], "nexus.local");
+        assert_eq!(body["access_token"], "stub-token-ethan");
+    }
+
+    #[tokio::test]
+    async fn login_wrong_password_is_forbidden() {
+        let app = fixture(&[("ethan", "hunter2")]);
+        let resp = app
+            .oneshot(login_request("ethan", "wrong"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+        let body = json_body(resp).await;
+        assert_eq!(body["errcode"], "M_FORBIDDEN");
+    }
+
+    #[tokio::test]
+    async fn login_unknown_user_is_forbidden() {
+        let app = fixture(&[]);
+        let resp = app
+            .oneshot(login_request("ghost", "x"))
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+    }
+
+    #[tokio::test]
+    async fn unsupported_login_type_returns_unrecognized() {
+        let app = fixture(&[("ethan", "hunter2")]);
+        let payload = json!({
+            "type": "m.login.token",
+            "identifier": {"type": "m.id.user", "user": "ethan"},
+            "token": "x",
+        });
+        let req = Request::builder()
+            .method("POST")
+            .uri("/_matrix/client/v3/login")
+            .header(header::CONTENT_TYPE, "application/json")
+            .body(Body::from(payload.to_string()))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+        let body = json_body(resp).await;
+        assert_eq!(body["errcode"], "M_UNRECOGNIZED");
+    }
+
+    #[tokio::test]
+    async fn whoami_with_valid_token_returns_session_identity() {
+        let app = fixture(&[("ethan", "hunter2")]);
+        let login_resp = app
+            .clone()
+            .oneshot(login_request("ethan", "hunter2"))
+            .await
+            .unwrap();
+        let login_json = json_body(login_resp).await;
+        let token = login_json["access_token"].as_str().unwrap().to_string();
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/_matrix/client/v3/account/whoami")
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = json_body(resp).await;
+        assert_eq!(body["user_id"], "@ethan:nexus.local");
+        assert_eq!(body["is_guest"], false);
+    }
+
+    #[tokio::test]
+    async fn whoami_without_token_is_unauthorized() {
+        let app = fixture(&[]);
+        let req = Request::builder()
+            .method("GET")
+            .uri("/_matrix/client/v3/account/whoami")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        let body = json_body(resp).await;
+        assert_eq!(body["errcode"], "M_MISSING_TOKEN");
+    }
+
+    #[tokio::test]
+    async fn whoami_with_unknown_token_is_unauthorized() {
+        let app = fixture(&[]);
+        let req = Request::builder()
+            .method("GET")
+            .uri("/_matrix/client/v3/account/whoami")
+            .header(header::AUTHORIZATION, "Bearer not-a-real-token")
+            .body(Body::empty())
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNAUTHORIZED);
+        let body = json_body(resp).await;
+        assert_eq!(body["errcode"], "M_UNKNOWN_TOKEN");
+    }
+
+    #[tokio::test]
+    async fn logout_invalidates_token_so_followup_whoami_fails() {
+        let app = fixture(&[("ethan", "hunter2")]);
+        let login_resp = app
+            .clone()
+            .oneshot(login_request("ethan", "hunter2"))
+            .await
+            .unwrap();
+        let token = json_body(login_resp).await["access_token"]
+            .as_str()
+            .unwrap()
+            .to_string();
+
+        let logout_req = Request::builder()
+            .method("POST")
+            .uri("/_matrix/client/v3/logout")
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap();
+        let logout_resp = app.clone().oneshot(logout_req).await.unwrap();
+        assert_eq!(logout_resp.status(), StatusCode::OK);
+
+        // Token should no longer resolve.
+        let probe_req = Request::builder()
+            .method("GET")
+            .uri("/_matrix/client/v3/account/whoami")
+            .header(header::AUTHORIZATION, format!("Bearer {token}"))
+            .body(Body::empty())
+            .unwrap();
+        let probe_resp = app.oneshot(probe_req).await.unwrap();
+        assert_eq!(probe_resp.status(), StatusCode::UNAUTHORIZED);
+    }
+}

--- a/rust/services/src/matrix_adapter/types.rs
+++ b/rust/services/src/matrix_adapter/types.rs
@@ -1,0 +1,56 @@
+//! Matrix Client-Server v3 request / response shapes for the auth
+//! surface. Field names match the spec verbatim — Matrix clients
+//! dispatch on JSON keys, not Rust types, so any rename breaks the
+//! contract.
+
+use serde::{Deserialize, Serialize};
+
+/// `POST /_matrix/client/v3/login` request body.
+///
+/// Today the adapter accepts the `m.login.password` flow only; other
+/// flows return `M_UNRECOGNIZED` so clients downgrade gracefully. The
+/// `identifier` shape matches the spec's `UserIdentifier` object —
+/// only the `m.id.user` variant is honoured at D1.
+#[derive(Debug, Clone, Deserialize)]
+pub struct LoginRequest {
+    #[serde(rename = "type")]
+    pub login_type: String,
+    pub identifier: UserIdentifier,
+    pub password: Option<String>,
+    /// Matrix lets clients pin a device id across reconnects so push
+    /// notifications survive token rotation. Optional at D1.
+    pub device_id: Option<String>,
+    pub initial_device_display_name: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub struct UserIdentifier {
+    #[serde(rename = "type")]
+    pub id_type: String,
+    pub user: Option<String>,
+}
+
+/// `POST /_matrix/client/v3/login` response.
+#[derive(Debug, Clone, Serialize)]
+pub struct LoginResponse {
+    pub user_id: String,
+    pub access_token: String,
+    pub device_id: String,
+    pub home_server: String,
+}
+
+/// `POST /_matrix/client/v3/logout` response. Matrix returns an empty
+/// JSON object; serialising a unit struct with `serde_json` produces
+/// `null`, so use a dedicated empty struct.
+#[derive(Debug, Clone, Serialize, Default)]
+pub struct EmptyResponse {}
+
+/// `GET /_matrix/client/v3/account/whoami` response.
+#[derive(Debug, Clone, Serialize)]
+pub struct WhoAmIResponse {
+    pub user_id: String,
+    pub device_id: String,
+    /// Matrix spec optional flag — the adapter never issues guest
+    /// tokens, so it's always `false`. Required by some clients.
+    pub is_guest: bool,
+}


### PR DESCRIPTION
## Summary

First slice of the Matrix Client-Server v3 adapter. End-state spec: [\`sudowork-2/docs/tech/nexus-integration-architecture.md\` §4.2](https://github.com/sudoprivacy/sudowork/blob/main/docs/tech/nexus-integration-architecture.md). D1 lands the crate scaffold + the three auth endpoints stock chat clients hit before any room interaction:

- \`POST /_matrix/client/v3/login\` (\`m.login.password\` / \`m.id.user\`)
- \`POST /_matrix/client/v3/logout\`
- \`GET  /_matrix/client/v3/account/whoami\`

Module layout under \`rust/services/src/matrix_adapter/\`:

- \`mod.rs\` — module root, public re-exports
- \`error.rs\` — \`AdapterError\` → Matrix errcode JSON (\`M_FORBIDDEN\`, \`M_UNKNOWN_TOKEN\`, \`M_MISSING_TOKEN\`, \`M_BAD_JSON\`, \`M_UNRECOGNIZED\`, \`M_UNKNOWN\`)
- \`auth.rs\` — \`AuthBackend\` trait abstracting AuthService; \`StubAuthBackend\` for tests under \`#[cfg(test)]\`
- \`types.rs\` — Matrix login/whoami request/response shapes, field names verbatim from the spec
- \`middleware.rs\` — bearer-token middleware that resolves \`Authorization: Bearer ...\` into an \`AuthSession\` stamped into request extensions
- \`router.rs\` — axum Router builder + endpoint handlers + 8 e2e tests against \`StubAuthBackend\` via \`tower::ServiceExt::oneshot\`

Feature-gated behind \`service-matrix-adapter\`; pulled deps (axum 0.7, base32 0.5, tower 0.5) are optional so non-adapter builds (cluster binary, slim WASM) keep their compile cost. \`async-trait\` is unconditional because future feature gates inside the adapter (e.g. the production AuthService shim) will reuse the same trait surface.

D2 (room read/write + PDU translation) and D3 (sync long-poll + media + push) come as separate PRs on top of this one.

## Test plan

- [x] \`cargo test -p services --features service-matrix-adapter matrix_adapter\` — 8/8 passing (login success/forbidden/unrecognized, whoami valid/missing/unknown-token, logout invalidation)
- [x] \`cargo check -p services --features service-matrix-adapter\` — clean
- [x] \`cargo check --workspace --all-features\` — clean (no regressions on existing services)
- [x] \`cargo check -p services --no-default-features\` — clean (adapter off)
- [ ] D2 follow-up: PDU envelope translator + room read/write

🤖 Generated with [Claude Code](https://claude.com/claude-code)