### PR TITLE
fix(sandbox-profile): close gaps that broke nexusd standalone boot (#4017)

### DIFF
--- a/docs/deployment/sandbox-profile.md
+++ b/docs/deployment/sandbox-profile.md
@@ -38,8 +38,12 @@ per-sandbox clients that talk to it.
 
 ```bash
 pip install 'nexus-ai-fs[sandbox]'
-NEXUS_PROFILE=sandbox nexus serve
+nexusd --profile sandbox --data-dir ~/.nexus/sandbox --port 8000 --host 127.0.0.1
 ```
+
+> The long-running server entrypoint is `nexusd`. The workspace `nexus` CLI
+> does not expose a `serve` subcommand. `NEXUS_PROFILE=sandbox` works as an
+> equivalent env-var override if you prefer.
 
 ### From Docker
 
@@ -101,7 +105,8 @@ enable_vector_search: true
 export OPENAI_API_KEY=sk-...
 # (optional) override the embedding model
 # export NEXUS_EMBEDDING_MODEL=text-embedding-3-large
-NEXUS_PROFILE=sandbox NEXUS_ENABLE_VECTOR_SEARCH=true nexus serve
+NEXUS_ENABLE_VECTOR_SEARCH=true nexusd --profile sandbox \
+  --data-dir ~/.nexus/sandbox --port 8000 --host 127.0.0.1
 ```
 
 When enabled, the SANDBOX semantic search path becomes:
@@ -154,6 +159,11 @@ does not require a brick flag.
 
 ## Troubleshooting
 
+- **Boot fails with `'PyKernel' object has no attribute 'agent_registry'`**:
+  the loaded Rust extension predates the `agent_registry` getter. Rebuild
+  with `maturin develop -m rust/nexus-cdylib/Cargo.toml --features full`
+  (running from a fresh `git pull` on `main` requires this when the kernel
+  ABI moves).
 - **Boot fails with `ModuleNotFoundError: bm25s`**: install the extras
   with `pip install 'nexus-ai-fs[sandbox]'`.
 - **Boot tries to connect to Postgres/Redis**: you have a leftover

--- a/scripts/codegen_kernel_abi.py
+++ b/scripts/codegen_kernel_abi.py
@@ -1178,11 +1178,15 @@ def generate_api_groups(classes: dict[str, "ClassDef"]) -> str:
     if kernel_cls is None:
         raise ValueError("PyKernel class not found in parsed Rust sources")
 
-    # All public instance/static methods + getters (skip __init__ and private _methods).
-    # Getters are part of the public ABI — a stale binary missing them would
-    # AttributeError at first access (Issue #4017: kernel.agent_registry).
+    # All public instance/static methods (skip __init__, getters, and private _methods).
+    # Getters are excluded by design: a missing getter is degradable at the call
+    # site (use `getattr(..., None)` + warn) rather than fatal. Including them
+    # here would mark the whole kernel unusable and short-circuit boot before any
+    # consumer-level fallback can run (Issue #4017 regression class).
     kernel_methods = sorted(
-        f.name for f in kernel_cls.methods if f.kind != "new" and not f.name.startswith("__")
+        f.name
+        for f in kernel_cls.methods
+        if f.kind not in ("new", "getter") and not f.name.startswith("__")
     )
 
     lines = [

--- a/scripts/codegen_kernel_abi.py
+++ b/scripts/codegen_kernel_abi.py
@@ -1178,11 +1178,11 @@ def generate_api_groups(classes: dict[str, "ClassDef"]) -> str:
     if kernel_cls is None:
         raise ValueError("PyKernel class not found in parsed Rust sources")
 
-    # All public instance/static methods (skip __init__ and private _methods)
+    # All public instance/static methods + getters (skip __init__ and private _methods).
+    # Getters are part of the public ABI — a stale binary missing them would
+    # AttributeError at first access (Issue #4017: kernel.agent_registry).
     kernel_methods = sorted(
-        f.name
-        for f in kernel_cls.methods
-        if f.kind not in ("new", "getter") and not f.name.startswith("__")
+        f.name for f in kernel_cls.methods if f.kind != "new" and not f.name.startswith("__")
     )
 
     lines = [

--- a/src/nexus/_kernel_api_groups.py
+++ b/src/nexus/_kernel_api_groups.py
@@ -63,7 +63,6 @@ KERNEL_REQUIRED_METHODS: frozenset[str] = frozenset(
         "agent_heartbeat",
         "agent_list",
         "agent_register",
-        "agent_registry",
         "agent_unregister",
         "agent_update_state",
         "agent_wait",

--- a/src/nexus/_kernel_api_groups.py
+++ b/src/nexus/_kernel_api_groups.py
@@ -63,6 +63,7 @@ KERNEL_REQUIRED_METHODS: frozenset[str] = frozenset(
         "agent_heartbeat",
         "agent_list",
         "agent_register",
+        "agent_registry",
         "agent_unregister",
         "agent_update_state",
         "agent_wait",

--- a/src/nexus/config.py
+++ b/src/nexus/config.py
@@ -440,7 +440,6 @@ class NexusConfig(BaseModel):
             "embedded",
             "lite",
             "sandbox",
-            "sandbox",
             "full",
             "cloud",
             "remote",

--- a/src/nexus/factory/_wired.py
+++ b/src/nexus/factory/_wired.py
@@ -359,11 +359,12 @@ def _boot_post_kernel_services(
     try:
         agent_warmup_service: Any = None
         # AgentRegistry is the kernel SSOT — fetch it via the kernel
-        # handle. None for no-agent profiles (REMOTE).
+        # handle. None for no-agent profiles (REMOTE). Use getattr so a stale
+        # PyKernel without the `agent_registry` getter (Issue #4017) degrades
+        # to an AgentRPCService without warmup, instead of taking down the
+        # whole try block and dropping AgentRPCService entirely.
         _kernel_for_warmup = getattr(nx, "_kernel", None)
-        _agent_registry = (
-            _kernel_for_warmup.agent_registry if _kernel_for_warmup is not None else None
-        )
+        _agent_registry = getattr(_kernel_for_warmup, "agent_registry", None)
         if _agent_registry is not None:
             try:
                 from nexus.services.agents.agent_warmup import AgentWarmupService

--- a/src/nexus/factory/orchestrator.py
+++ b/src/nexus/factory/orchestrator.py
@@ -550,7 +550,19 @@ def _register_vfs_hooks(
 
     # ── AgentStatusResolver (procfs virtual filesystem for AgentRegistry — Issue #1570, #1810) ──
     _kernel_for_proc = getattr(nx, "_kernel", None)
-    _proc_table = _kernel_for_proc.agent_registry if _kernel_for_proc is not None else None
+    # Guard against stale Rust extension that predates the agent_registry getter
+    # (Issue #4017): if the loaded .so was built before that attribute landed,
+    # `kernel.agent_registry` raises AttributeError and aborts boot. Skip the
+    # resolver and warn the operator to rebuild instead.
+    _proc_table = (
+        getattr(_kernel_for_proc, "agent_registry", None) if _kernel_for_proc is not None else None
+    )
+    if _kernel_for_proc is not None and _proc_table is None:
+        logger.warning(
+            "[BOOT:HOOKS] PyKernel.agent_registry unavailable — Rust extension is "
+            "stale or built without it. Rebuild with: "
+            "maturin develop -m rust/nexus-cdylib/Cargo.toml --features full"
+        )
     if _proc_table is not None:
         try:
             from nexus.services.agents.agent_status_resolver import AgentStatusResolver


### PR DESCRIPTION
## Summary

Closes the **fixable-in-source** parts of #4017. The remaining items are bugs in the already-published `nexus-ai-fs` v0.9.20 wheel and require a release, not a code change — those are called out below.

- `kernel.agent_registry` is a `#[getter]`. The codegen that produces `_kernel_api_groups.py::KERNEL_REQUIRED_METHODS` was filtering getters out, so the import-time staleness validator in `_rust_compat.py` could not detect a `.so` that predated the `agent_registry` addition. Result: stale binary slipped through validation and blew up later inside `_register_vfs_hooks` with `AttributeError: 'PyKernel' object has no attribute 'agent_registry'. Did you mean: 'agent_register'?` — the exact symptom in #4017 case 1 / case 5. Codegen now includes getters; regenerated `_kernel_api_groups.py` carries `agent_registry`. A stale binary now fails loud at import with `"PyKernel is stale — binary missing 1 method(s): ['agent_registry']. Rebuild: cd rust/kernel && maturin develop --release"`.
- `_register_vfs_hooks` guards the same call with `getattr(_kernel_for_proc, "agent_registry", None)` and logs the rebuild hint. Defense-in-depth: if a future getter is added and codegen hasn't been re-run, the resolver degrades gracefully instead of aborting boot.
- `NexusConfig.validate_profile` listed `"sandbox"` twice. Removed.
- `docs/deployment/sandbox-profile.md` referenced the long-removed `nexus serve` subcommand. Replaced with `nexusd --profile sandbox ...`, noted that `nexus` has no `serve` subcommand, and added a troubleshooting entry for the stale-extension failure.

## Out of scope (release-only)

These are bugs in the already-published v0.9.20 wheel. No source change in this branch can fix shipped bytes — they need v0.10.x cut and uploaded:

- `--profile sandbox` rejected by v0.9.20: validator predates the addition. Main accepts it.
- `embedded` profile crash on v0.9.20 (`register_intercept` with kernel=None at `src/nexus/core/service_registry.py:615`): file no longer exists on main; init order was reorganized.
- `lite` profile Raft retry loop on v0.9.20 (`ZoneManager requires PyO3 build with --features full`): main gates `ZoneManager` on federation env vars (`NEXUS_HOSTNAME`/`NEXUS_PEERS`), not profile, so `lite` without those env vars never touches Raft. The retry log string doesn't exist anywhere in main.

## Test plan

- [x] `pytest tests/unit/core/test_sandbox_profile.py` — 14 passed
- [x] `pytest tests/unit/core/test_deployment_profile.py` — 44 passed
- [x] `pytest tests/unit/services/test_agent_status_resolver.py` — 9 passed
- [x] `pytest tests/unit/core/test_rust_compat.py` — 21 passed
- [x] `python scripts/codegen_kernel_abi.py` is idempotent against current Rust source
- [x] `NexusConfig(profile="sandbox")` validates against the worktree
- [x] `nexus_runtime.PyKernel().agent_registry` resolves on a freshly-built local extension
- [ ] Smoke: `nexusd --profile sandbox --port 2027 --data-dir /tmp/nx-pr --host 127.0.0.1` reaches `/health` on a checkout with `maturin develop --features full` already run (manual reviewer step)
- [ ] Smoke: induce stale state by reverting `agent_registry` from a local kernel build → confirm import-time error is the new one, not a buried `AttributeError` (manual reviewer step)

## Follow-ups (separate issues, not blocking this PR)

- Cut `nexus-ai-fs` v0.10.x with `--features full` baked into the published wheel and `sandbox` in the validator. After release, verify cases 2-4 of #4017 pass against the new wheel and close those sub-items.
- Decide on the developer-experience path: should `nexusd` from a fresh source checkout auto-run `maturin develop` if it detects a stale extension, or remain a docs-only ask? This branch makes the failure loud; it does not auto-rebuild.