### PR TITLE
Fix Docker Publish edge ReBAC smoke

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -187,6 +187,18 @@ jobs:
             -e NEXUS_GRPC_PORT=2028 \
             -e NEXUS_GRPC_TLS=false \
             -e NEXUS_PROFILE=full \
+            -e NEXUS_ENFORCE_PERMISSIONS=true \
+            -e NEXUS_ALLOW_ADMIN_BYPASS=true \
+            -e NEXUS_DB_ASYNC_USE_POOL=1 \
+            -e NEXUS_DB_POOL_SIZE=5 \
+            -e NEXUS_DB_MAX_OVERFLOW=10 \
+            -e NEXUS_THREAD_POOL_SIZE=24 \
+            -e NEXUS_INDEX_MAX_CONCURRENCY=2 \
+            -e NEXUS_INDEX_MAX_EMBEDDING_CONCURRENCY=1 \
+            -e NEXUS_ML_WORKERS=1 \
+            -e NEXUS_VDB_WORKERS=1 \
+            -e NEXUS_SEARCH_POOL_MIN=2 \
+            -e NEXUS_SEARCH_POOL_MAX=8 \
             -v /tmp/nexus-data:/app/data \
             ghcr.io/nexi-lab/nexus:edge
 
@@ -250,6 +262,19 @@ jobs:
             -e NEXUS_GRPC_TLS=false \
             nexus-e2e nexus demo init --skip-semantic
 
+      - name: Copy test scripts into container
+        run: |
+          docker cp permissions_demo_enhanced.sh nexus-e2e:/tmp/
+          docker cp scripts/test_build_perf_e2e.py nexus-e2e:/tmp/
+
+      - name: Run permissions demo
+        run: |
+          docker exec \
+            -e NEXUS_URL=http://localhost:2026 \
+            -e NEXUS_API_KEY="${NEXUS_API_KEY}" \
+            -e NEXUS_PROFILE=remote \
+            nexus-e2e bash /tmp/permissions_demo_enhanced.sh
+
       - name: Seed search index
         run: |
           # Docker Publish uses `nexus demo init --skip-semantic` above to keep
@@ -270,12 +295,19 @@ jobs:
           # nexus search index queries file_paths WHERE virtual_path LIKE '/workspace/demo/%';
           # if this table is empty the index step returns "Files indexed: 0".
           echo "Step 2: Checking file_paths table after demo init..."
-          docker exec nexus-e2e psql postgresql://postgres:nexus@localhost/nexus \
-            -c "SELECT count(*) AS demo_files, min(zone_id) AS zone FROM file_paths WHERE virtual_path LIKE '/workspace/demo%' AND deleted_at IS NULL;" \
-            2>/dev/null || echo "  (psql unavailable — skipping diagnostic)"
-          docker exec nexus-e2e psql postgresql://postgres:nexus@localhost/nexus \
-            -c "SELECT count(*) AS op_log_rows FROM operation_log WHERE path LIKE '/workspace/demo%';" \
-            2>/dev/null || true
+          docker exec -i nexus-e2e python3 - <<'PY' || echo "  (SQL diagnostic unavailable — skipping)"
+          from sqlalchemy import create_engine, text
+          eng = create_engine("postgresql://postgres:nexus@localhost/nexus")
+          with eng.connect() as conn:
+              row = conn.execute(text(
+                  "SELECT count(*) AS demo_files, min(zone_id) AS min_zone, max(zone_id) AS max_zone "
+                  "FROM file_paths WHERE virtual_path LIKE '/workspace/demo%' AND deleted_at IS NULL"
+              )).mappings().one()
+              op_rows = conn.execute(text(
+                  "SELECT count(*) FROM operation_log WHERE path LIKE '/workspace/demo%'"
+              )).scalar()
+          print(f"  demo_files={row['demo_files']} zones={row['min_zone']}..{row['max_zone']} op_log_rows={op_rows}")
+          PY
 
           # Step 3: Show search daemon stats for diagnostics
           echo "Step 3: Search daemon stats..."
@@ -319,19 +351,6 @@ jobs:
             -e NEXUS_API_KEY="${NEXUS_API_KEY}" \
             -e NEXUS_PROFILE=remote \
             nexus-e2e nexus search query "Nexus Core" --path /workspace/demo/herb --mode hybrid --limit 1 || true
-
-      - name: Copy test scripts into container
-        run: |
-          docker cp permissions_demo_enhanced.sh nexus-e2e:/tmp/
-          docker cp scripts/test_build_perf_e2e.py nexus-e2e:/tmp/
-
-      - name: Run permissions demo
-        run: |
-          docker exec \
-            -e NEXUS_URL=http://localhost:2026 \
-            -e NEXUS_API_KEY="${NEXUS_API_KEY}" \
-            -e NEXUS_PROFILE=remote \
-            nexus-e2e bash /tmp/permissions_demo_enhanced.sh
 
       - name: Run build perf e2e
         run: |

--- a/permissions_demo_enhanced.sh
+++ b/permissions_demo_enhanced.sh
@@ -324,48 +324,47 @@ nexus rmdir -r -f /shared-readonly-test >/dev/null 2>&1 || true
 nexus_python << 'CLEANUP'
 import sys, os
 sys.path.insert(0, os.path.join(os.environ['NEXUS_REPO_ROOT'], 'src'))
-import nexus
 
-nx = nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY'), "grpc_address": os.getenv('NEXUS_GRPC_HOST')})
-rebac = nx.service("rebac")
 base = os.getenv('DEMO_BASE')
 
-# 1. Delete all tuples related to demo paths (file objects, parent relationships)
-print("  Deleting file object tuples...")
-all_tuples = rebac.rebac_list_tuples_sync()
-demo_tuples = [t for t in all_tuples if
-               base in str(t.get('object_id', '')) or
-               base in str(t.get('subject_id', '')) or
-               '/shared-readonly-test' in str(t.get('object_id', '')) or
-               '/shared-readonly-test' in str(t.get('subject_id', ''))]
-for t in demo_tuples:
-    try:
-        rebac.rebac_delete_sync(t['tuple_id'])
-    except:
-        pass
-print(f"  Deleted {len(demo_tuples)} tuples related to demo paths")
+# 1. Delete stale demo ReBAC tuples directly. Avoid an unfiltered
+# rebac_list_tuples RPC here: on CI runners it can scan enough data to hit the
+# 30s gRPC deadline before the actual demo starts.
+print("  Deleting stale ReBAC tuples...")
+try:
+    import psycopg2
 
-# 2. Delete all tuples for test users to ensure clean state
-print("  Deleting test user tuples...")
-for user in ['alice', 'bob', 'charlie', 'acme_user']:
-    tuples = rebac.rebac_list_tuples_sync(subject=("user", user))
-    for t in tuples:
-        try:
-            rebac.rebac_delete_sync(t['tuple_id'])
-        except:
-            pass
+    db_url = os.getenv('NEXUS_DATABASE_URL', 'postgresql://postgres:nexus@localhost/nexus')
+    users = ['alice', 'bob', 'charlie', 'acme_user']
+    groups = ['project1-editors', 'project1-viewers']
 
-# 3. Delete group tuples
-print("  Deleting group tuples...")
-for group in ['project1-editors', 'project1-viewers']:
-    tuples = rebac.rebac_list_tuples_sync(subject=("group", group))
-    for t in tuples:
-        try:
-            rebac.rebac_delete_sync(t['tuple_id'])
-        except:
-            pass
+    with psycopg2.connect(db_url) as conn:
+        with conn.cursor() as cursor:
+            cursor.execute(
+                """DELETE FROM rebac_tuples
+                   WHERE object_id LIKE %s
+                      OR subject_id LIKE %s
+                      OR object_id LIKE %s
+                      OR subject_id LIKE %s
+                      OR (subject_type = 'user' AND subject_id = ANY(%s))
+                      OR (subject_type = 'group' AND subject_id = ANY(%s))
+                      OR (object_type = 'group' AND object_id = ANY(%s))""",
+                (
+                    f"{base}%",
+                    f"{base}%",
+                    "/shared-readonly-test%",
+                    "/shared-readonly-test%",
+                    users,
+                    groups,
+                    groups,
+                ),
+            )
+            print(f"  Deleted {cursor.rowcount} ReBAC tuples")
+        conn.commit()
+except Exception as e:
+    print(f"  ⚠ Could not clean ReBAC tuples directly: {e}")
 
-# 4. Clean up stale version history and file_paths from database
+# 2. Clean up stale version history and file_paths from database
 print("  Cleaning version history...")
 try:
     # Use direct database access to clean version history
@@ -417,6 +416,11 @@ except Exception as e:
     print(f"  ⚠ Could not clean version history: {e}")
 
 print("✓ Cleaned up stale tuples")
+
+import nexus
+
+nx = nexus.connect(config={"profile": "remote", "url": os.getenv('NEXUS_URL', 'http://localhost:2026'), "api_key": os.getenv('NEXUS_API_KEY'), "grpc_address": os.getenv('NEXUS_GRPC_HOST')})
+rebac = nx.service("rebac")
 
 # Bootstrap ReBAC namespaces — ensure relation→permission expansion rules are loaded.
 # On fresh servers (or after Raft leader election), namespaces may not be initialized

--- a/src/nexus/server/rpc/handlers/admin.py
+++ b/src/nexus/server/rpc/handlers/admin.py
@@ -201,7 +201,15 @@ def handle_admin_write_permission(nexus_fs: Any, params: Any, context: Any) -> d
 
     require_admin(context)
 
-    rebac = getattr(nexus_fs, "_rebac_manager", None) or getattr(nexus_fs, "rebac_manager", None)
+    rebac = None
+    service = getattr(nexus_fs, "service", None)
+    if service is not None:
+        rebac = service("rebac_manager")
+    rebac = (
+        rebac
+        or getattr(nexus_fs, "_rebac_manager", None)
+        or getattr(nexus_fs, "rebac_manager", None)
+    )
     if rebac is None:
         raise ConfigurationError("ReBAC manager not available on this server")
 

--- a/tests/unit/server/test_admin_handlers.py
+++ b/tests/unit/server/test_admin_handlers.py
@@ -26,6 +26,7 @@ from nexus.server.rpc.handlers.admin import (
     handle_admin_list_keys,
     handle_admin_revoke_key,
     handle_admin_update_key,
+    handle_admin_write_permission,
     require_admin,
     require_database_auth,
 )
@@ -120,6 +121,36 @@ class TestRequireAdmin:
 
         with pytest.raises(NexusPermissionError):
             require_admin(None)
+
+
+class TestHandleAdminWritePermission:
+    def test_uses_service_registry_rebac_manager(self, admin_context):
+        """Should use the canonical ServiceRegistry lookup for ReBAC writes."""
+        rebac = MagicMock()
+        nx = MagicMock()
+        nx.service.side_effect = lambda name: rebac if name == "rebac_manager" else None
+        nx._rebac_manager = None
+        nx.rebac_manager = None
+        params = FakeParams(
+            tuples=[
+                {
+                    "subject": ("user", "alice"),
+                    "relation": "direct_viewer",
+                    "object": ("file", "/workspace/demo"),
+                    "zone_id": "root",
+                }
+            ]
+        )
+
+        result = handle_admin_write_permission(nx, params, admin_context)
+
+        assert result == {"created": 1}
+        rebac.rebac_write.assert_called_once_with(
+            subject=("user", "alice"),
+            relation="direct_viewer",
+            object=("file", "/workspace/demo"),
+            zone_id="root",
+        )
 
 
 # ── require_database_auth Tests ──────────────────────────


### PR DESCRIPTION
## Summary
- resolve admin_write_permission through the ServiceRegistry ReBAC manager
- run the permissions smoke before expensive search warmup in Docker Publish
- bound CI DB/search concurrency and replace the permissions cleanup's unfiltered ReBAC scan with targeted SQL cleanup

## Verification
- /Users/tafeng/.local/bin/uv run pytest -o addopts='' tests/unit/server/test_admin_handlers.py -q
- bash -n permissions_demo_enhanced.sh
- git diff --check
- /Users/tafeng/.local/bin/uv run python -c "import yaml; yaml.safe_load(open('.github/workflows/docker-publish.yml')); print('yaml ok')"

Note: Docker is not installed in this local environment, so the Docker Publish smoke itself must run in GitHub Actions.