### PR TITLE
[codex] fix review correctness and build issues

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,5 @@
+[env]
+# Cargo passes this to dependency build scripts before crate-local build.rs files run.
+# The wrapper keeps old protobuf-build version parsing compatible with modern
+# libprotoc versions while still executing the real compiler.
+PROTOC = { value = "scripts/protoc-compat.py", relative = true }

--- a/.gitignore
+++ b/.gitignore
@@ -235,8 +235,11 @@ aws-credentials
 CLAUDE.md
 docs/plans/
 
-# Cargo local config (Windows MSVC linker path is dev-machine specific)
-.cargo/
+# Cargo local config (Windows MSVC linker path is dev-machine specific).
+# Keep the project Cargo config tracked for shared build environment defaults.
+.cargo/*
+!.cargo/
+!.cargo/config.toml
 NUL
 NUL
 

--- a/packages/nexus-api-client/package.json
+++ b/packages/nexus-api-client/package.json
@@ -24,6 +24,7 @@
   ],
   "scripts": {
     "build": "tsup",
+    "prepare": "npm run build",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",

--- a/packages/nexus-fs/pyproject.toml
+++ b/packages/nexus-fs/pyproject.toml
@@ -84,6 +84,7 @@ dev = [
     "pytest>=8.0",
     "pytest-asyncio>=0.23",
     "pytest-cov>=5.0",
+    "pytest-examples>=0.0.10",
     "pytest-textual-snapshot>=1.0",
     "moto[s3]>=5.0",
     "ruff>=0.4",

--- a/packages/nexus-pay-ts/package.json
+++ b/packages/nexus-pay-ts/package.json
@@ -23,11 +23,15 @@
     "README.md"
   ],
   "scripts": {
+    "build:api-client": "sh -c 'test -d ../nexus-api-client/node_modules || npm --prefix ../nexus-api-client ci; npm --prefix ../nexus-api-client run build'",
+    "prebuild": "npm run build:api-client",
     "build": "tsup",
+    "pretest": "npm run build:api-client",
     "test": "vitest run",
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "test:e2e": "vitest run tests/e2e.test.ts",
+    "prelint": "npm run build:api-client",
     "lint": "tsc --noEmit",
     "clean": "rm -rf dist"
   },

--- a/packages/nexus-tui/bun.lock
+++ b/packages/nexus-tui/bun.lock
@@ -9,7 +9,7 @@
         "@opentui/core": "0.1.96",
         "@opentui/solid": "0.1.96",
         "anser": "^2.3.5",
-        "solid-js": "^1.9.12",
+        "solid-js": "1.9.11",
         "zustand": "^5.0.0",
       },
       "devDependencies": {
@@ -605,7 +605,7 @@
 
     "simple-xml-to-json": ["simple-xml-to-json@1.2.3", "", {}, "sha512-kWJDCr9EWtZ+/EYYM5MareWj2cRnZGF93YDNpH4jQiHB+hBIZnfPFSQiVMzZOdk+zXWqTZ/9fTeQNu2DqeiudA=="],
 
-    "solid-js": ["solid-js@1.9.12", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.0", "seroval-plugins": "~1.5.0" } }, "sha512-QzKaSJq2/iDrWR1As6MHZQ8fQkdOBf8GReYb7L5iKwMGceg7HxDcaOHk0at66tNgn9U2U7dXo8ZZpLIAmGMzgw=="],
+    "solid-js": ["solid-js@1.9.11", "", { "dependencies": { "csstype": "^3.1.0", "seroval": "~1.5.0", "seroval-plugins": "~1.5.0" } }, "sha512-WEJtcc5mkh/BnHA6Yrg4whlF8g6QwpmXXRg4P2ztPmcKeHHlH4+djYecBLhSpecZY2RRECXYUwIc/C2r3yzQ4Q=="],
 
     "source-map": ["source-map@0.7.6", "", {}, "sha512-i5uvt8C3ikiWeNZSVZNWcfZPItFQOsYTUAOkcUPGd8DqDy1uOUikjt5dG+uRlwyvR108Fb9DOd4GvXfT0N2/uQ=="],
 

--- a/packages/nexus-tui/package.json
+++ b/packages/nexus-tui/package.json
@@ -23,7 +23,7 @@
     "@opentui/core": "0.1.96",
     "@opentui/solid": "0.1.96",
     "anser": "^2.3.5",
-    "solid-js": "^1.9.12",
+    "solid-js": "1.9.11",
     "zustand": "^5.0.0"
   },
   "devDependencies": {

--- a/packages/nexus-tui/scripts/patch-jsx-types.cjs
+++ b/packages/nexus-tui/scripts/patch-jsx-types.cjs
@@ -1,14 +1,41 @@
 const fs = require("fs");
 const path = require("path");
 const dtsPath = path.join(__dirname, "..", "node_modules", "@opentui", "solid", "jsx-runtime.d.ts");
-if (!fs.existsSync(dtsPath)) process.exit(0);
-const content = fs.readFileSync(dtsPath, "utf8");
-if (content.includes("export function jsx")) process.exit(0);
-const patch = [
-  "export function jsx(type: any, props: any, key?: any): any;",
-  "export function jsxs(type: any, props: any, key?: any): any;",
-  "export function jsxDEV(type: any, props: any, key?: any): any;",
-  "export function Fragment(props: { children?: any }): any;",
-  "",
-].join("\n");
-fs.writeFileSync(dtsPath, patch + content);
+
+if (fs.existsSync(dtsPath)) {
+  const content = fs.readFileSync(dtsPath, "utf8");
+  if (!content.includes("export function jsx")) {
+    const patch = [
+      "export function jsx(type: any, props: any, key?: any): any;",
+      "export function jsxs(type: any, props: any, key?: any): any;",
+      "export function jsxDEV(type: any, props: any, key?: any): any;",
+      "export function Fragment(props: { children?: any }): any;",
+      "",
+    ].join("\n");
+    fs.writeFileSync(dtsPath, patch + content);
+  }
+}
+
+const elementTypesPath = path.join(
+  __dirname,
+  "..",
+  "node_modules",
+  "@opentui",
+  "solid",
+  "src",
+  "types",
+  "elements.d.ts",
+);
+
+if (fs.existsSync(elementTypesPath)) {
+  let content = fs.readFileSync(elementTypesPath, "utf8");
+  content = content.replace(
+    "export type ElementProps<TRenderable = unknown> = {\n    ref?: Ref<TRenderable>;\n};",
+    "export type ElementProps<TRenderable = unknown> = {\n    key?: string | number;\n    ref?: Ref<TRenderable>;\n};",
+  );
+  content = content.replace(
+    "export type SpanProps = ComponentProps<{}, TextNodeRenderable> & {",
+    "export type SpanProps = ComponentProps<TextNodeOptions, TextNodeRenderable> & {",
+  );
+  fs.writeFileSync(elementTypesPath, content);
+}

--- a/packages/nexus-tui/src/worker/worker-client.ts
+++ b/packages/nexus-tui/src/worker/worker-client.ts
@@ -52,6 +52,25 @@ function serializeOptions(
   return Object.keys(out).length > 0 ? (out as SerializableRequestOptions) : undefined;
 }
 
+function stableStringify(value: unknown): string {
+  if (value === undefined) return "undefined";
+  if (value === null || typeof value !== "object") return JSON.stringify(value);
+  if (Array.isArray(value)) return `[${value.map((item) => stableStringify(item)).join(",")}]`;
+  const entries = Object.entries(value as Record<string, unknown>)
+    .filter(([, item]) => item !== undefined)
+    .sort(([a], [b]) => a.localeCompare(b));
+  return `{${entries.map(([key, item]) => `${JSON.stringify(key)}:${stableStringify(item)}`).join(",")}}`;
+}
+
+function dedupKeyFor(
+  path: string,
+  options: SerializableRequestOptions | undefined,
+  signal: AbortSignal | undefined,
+): string | undefined {
+  if (signal) return undefined;
+  return `${path}\0${stableStringify(options ?? {})}`;
+}
+
 // ─── WorkerFetchClient ────────────────────────────────────────────────────────
 
 interface Pending {
@@ -62,7 +81,7 @@ interface Pending {
 export class WorkerFetchClient {
   private worker: Worker;
   private readonly pending = new Map<string, Pending>();
-  /** In-flight GET requests keyed by path — deduplicated (Issue 14A). */
+  /** In-flight GET requests keyed by path and request options. */
   private readonly dedup = new Map<string, Promise<unknown>>();
   /**
    * Resolves when the worker has acknowledged 'init'.
@@ -129,18 +148,22 @@ export class WorkerFetchClient {
     options: RequestOptions | undefined,
     kind: RequestKind,
   ): Promise<T> {
-    // Issue 14A: deduplicate concurrent identical GET requests.
-    // Checked before the readyInternal gate so concurrent same-path GETs
-    // share one in-flight promise immediately.
-    if (kind === "json" && method === "GET") {
-      const existing = this.dedup.get(path);
-      if (existing) return existing as Promise<T>;
-    }
-
     const id = nextId();
     const serializableOpts = serializeOptions(options);
     const timeoutMs = options?.timeout ?? DEFAULT_TIMEOUT_MS;
     const signal = options?.signal;
+    const dedupKey =
+      kind === "json" && method === "GET"
+        ? dedupKeyFor(path, serializableOpts, signal)
+        : undefined;
+
+    // Issue 14A: deduplicate concurrent identical GET requests.
+    // Checked before the readyInternal gate so concurrent same-path GETs
+    // share one in-flight promise immediately.
+    if (dedupKey) {
+      const existing = this.dedup.get(dedupKey);
+      if (existing) return existing as Promise<T>;
+    }
 
     // Issue 16A: already-aborted signal — reject immediately without any setup.
     if (signal?.aborted) {
@@ -222,10 +245,10 @@ export class WorkerFetchClient {
     // Register in dedup map; remove on settle (Issue 14A).
     // `.finally()` propagates rejection to the derived promise, so we must
     // attach `.catch(() => {})` to that derived promise too.
-    if (kind === "json" && method === "GET") {
-      this.dedup.set(path, promise);
+    if (dedupKey) {
+      this.dedup.set(dedupKey, promise);
       void promise.finally(() => {
-        if (this.dedup.get(path) === promise) this.dedup.delete(path);
+        if (this.dedup.get(dedupKey) === promise) this.dedup.delete(dedupKey);
       }).catch(() => {});
     }
 

--- a/packages/nexus-tui/tests/stores/worker-client.test.ts
+++ b/packages/nexus-tui/tests/stores/worker-client.test.ts
@@ -185,6 +185,25 @@ describe("WorkerFetchClient", () => {
     expect(await p2).toBe("deduped");
   });
 
+  it("same-path GET requests with different headers are not deduplicated", async () => {
+    const p1 = client.get("/api/v2/same", { headers: { "X-Nexus-Zone-ID": "zone-a" } });
+    const p2 = client.get("/api/v2/same", { headers: { "X-Nexus-Zone-ID": "zone-b" } });
+    await tick();
+
+    const requests = worker.sent.filter((m) => m.type === "request");
+    expect(requests.length).toBe(2);
+    const [req1, req2] = requests;
+    if (req1.type !== "request" || req2.type !== "request") return;
+    expect(req1.options?.headers?.["X-Nexus-Zone-ID"]).toBe("zone-a");
+    expect(req2.options?.headers?.["X-Nexus-Zone-ID"]).toBe("zone-b");
+
+    worker.reply({ type: "response", id: req1.id, result: "A" });
+    worker.reply({ type: "response", id: req2.id, result: "B" });
+
+    expect(await p1).toBe("A");
+    expect(await p2).toBe("B");
+  });
+
   it("sequential GET requests (after first resolves) are not deduplicated", async () => {
     const p1 = client.get("/api/v2/same");
     await tick();

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -945,10 +945,14 @@ name = "Bricks must not import from each other (LEGO Principle 3)"
 type = "independence"
 modules = [
     "nexus.bricks.access_manifest",
+    "nexus.bricks.approvals",
+    "nexus.bricks.archive",
     "nexus.bricks.auth",
+    "nexus.bricks.catalog",
     "nexus.bricks.context_manifest",
     "nexus.bricks.delegation",
     "nexus.bricks.discovery",
+    "nexus.bricks.filesystem",
     "nexus.bricks.governance",
     "nexus.bricks.identity",
     "nexus.bricks.mcp",
@@ -959,8 +963,14 @@ modules = [
     "nexus.bricks.rebac",
     "nexus.bricks.sandbox",
     "nexus.bricks.search",
+    "nexus.bricks.secrets",
+    "nexus.bricks.share_link",
     "nexus.bricks.snapshot",
+    "nexus.bricks.task_manager",
+    "nexus.bricks.upload",
+    "nexus.bricks.versioning",
     "nexus.bricks.workflows",
+    "nexus.bricks.workspace",
 ]
 # Known violations — ratchet baseline. Remove entries as fixes land.
 ignore_imports = [
@@ -974,10 +984,6 @@ ignore_imports = [
     # search -> rebac: permission enforcement + entity registry in search_service (moved from services/)
     "nexus.bricks.search.search_service -> nexus.bricks.rebac.enforcer",
     "nexus.bricks.search.search_service -> nexus.bricks.rebac.manager",
-    # search -> gateway (TYPE_CHECKING): NexusFSGateway type hint — transitive to workflows/parsers
-    "nexus.bricks.search.search_service -> nexus.services.gateway",
-    # mount -> permission_utils -> gateway: transitive chain to workflows/parsers
-    "nexus.lib.permission_utils -> nexus.services.gateway",
     # parsers -> sandbox: TYPE_CHECKING imports for sandbox provider (Issue #2429)
     "nexus.bricks.parsers.validation.runner -> nexus.bricks.sandbox.sandbox_provider",
     "nexus.bricks.parsers.validation.detector -> nexus.bricks.sandbox.sandbox_provider",
@@ -985,6 +991,27 @@ ignore_imports = [
     "nexus.bricks.portability.export_service -> nexus",
     # mcp -> nexus: server.py imports top-level nexus package — same transitive hub pattern
     "nexus.bricks.mcp.server -> nexus",
+    # Ratchet entries exposed by expanding the module list to all active bricks.
+    "nexus.bricks.approvals.grpc_auth -> nexus.bricks.auth.types",
+    "nexus.bricks.archive.cli_glue -> nexus.cli.utils",
+    "nexus.bricks.archive.cli_glue -> nexus.bricks.portability.export_service",
+    "nexus.bricks.archive.cli_glue -> nexus.bricks.portability.import_service",
+    "nexus.bricks.archive.cli_glue -> nexus.bricks.portability.models",
+    "nexus.bricks.archive.cli_glue -> nexus.bricks.portability.signer",
+    "nexus.bricks.archive.cli_glue -> nexus.bricks.portability.trust",
+    "nexus.bricks.archive.orchestrator -> nexus.bricks.portability.models",
+    "nexus.bricks.archive.tests.unit.test_verify -> nexus.bricks.portability.signer",
+    "nexus.bricks.archive.verify -> nexus.bricks.portability.signer",
+    "nexus.bricks.mcp.connection_manager -> nexus.bricks.approvals.policy_gate",
+    "nexus.bricks.mcp.mcp_service -> nexus.bricks.approvals.policy_gate",
+    "nexus.bricks.mcp.mount -> nexus.bricks.approvals.models",
+    "nexus.bricks.mcp.mount -> nexus.bricks.approvals.policy_gate",
+    "nexus.bricks.mcp.server -> nexus.bricks.approvals.policy_gate",
+    "nexus.bricks.portability.import_service -> nexus.bricks.archive.errors",
+    "nexus.bricks.portability.signer -> nexus.bricks.archive.errors",
+    "nexus.bricks.portability.tests.test_import_embedding -> nexus.bricks.archive.errors",
+    "nexus.bricks.portability.tests.test_import_target_guard -> nexus.bricks.archive.errors",
+    "nexus.bricks.portability.tests.test_signer -> nexus.bricks.archive.errors",
 ]
 unmatched_ignore_imports_alerting = "warn"
 

--- a/scripts/protoc-compat.py
+++ b/scripts/protoc-compat.py
@@ -58,13 +58,13 @@ def _real_protoc() -> str:
     if override:
         return override
 
-    system_protoc = shutil.which("protoc")
-    if system_protoc:
-        return system_protoc
-
     vendored = _find_vendored_protoc()
     if vendored:
         return vendored
+
+    system_protoc = shutil.which("protoc")
+    if system_protoc:
+        return system_protoc
 
     raise SystemExit(
         "Unable to locate protoc. Install protobuf-compiler, set NEXUS_REAL_PROTOC, "

--- a/scripts/protoc-compat.py
+++ b/scripts/protoc-compat.py
@@ -1,0 +1,86 @@
+#!/usr/bin/env python3
+"""Compatibility shim for crates that reject modern libprotoc versions.
+
+protobuf-build 0.14 accepts only 3.x in its PROTOC preflight check, but recent
+protobuf releases report calendar-style versions such as 31.1. Cargo config
+points PROTOC at this script so dependency build scripts see an acceptable
+version before this workspace's build.rs files run.
+"""
+
+from __future__ import annotations
+
+import os
+import platform
+import shutil
+import sys
+from pathlib import Path
+
+
+def _platform_package() -> str | None:
+    system = platform.system().lower()
+    machine = platform.machine().lower()
+    if system == "darwin":
+        if machine == "arm64":
+            return "protoc-bin-vendored-macos-aarch_64"
+        return "protoc-bin-vendored-macos-x86_64"
+    if system == "linux":
+        if machine in {"x86_64", "amd64"}:
+            return "protoc-bin-vendored-linux-x86_64"
+        if machine in {"aarch64", "arm64"}:
+            return "protoc-bin-vendored-linux-aarch_64"
+        if machine in {"i386", "i686", "x86"}:
+            return "protoc-bin-vendored-linux-x86_32"
+        if machine in {"ppc64le", "powerpc64le"}:
+            return "protoc-bin-vendored-linux-ppcle_64"
+        if machine == "s390x":
+            return "protoc-bin-vendored-linux-s390_64"
+    if system == "windows":
+        return "protoc-bin-vendored-win32"
+    return None
+
+
+def _find_vendored_protoc() -> str | None:
+    package = _platform_package()
+    if package is None:
+        return None
+
+    cargo_home = Path(os.environ.get("CARGO_HOME", Path.home() / ".cargo"))
+    registry_src = cargo_home / "registry" / "src"
+    candidates = sorted(registry_src.glob(f"*/{package}-*/bin/protoc*"), reverse=True)
+    for candidate in candidates:
+        if candidate.is_file():
+            return str(candidate)
+    return None
+
+
+def _real_protoc() -> str:
+    override = os.environ.get("NEXUS_REAL_PROTOC")
+    if override:
+        return override
+
+    system_protoc = shutil.which("protoc")
+    if system_protoc:
+        return system_protoc
+
+    vendored = _find_vendored_protoc()
+    if vendored:
+        return vendored
+
+    raise SystemExit(
+        "Unable to locate protoc. Install protobuf-compiler, set NEXUS_REAL_PROTOC, "
+        "or run cargo fetch so protoc-bin-vendored is available."
+    )
+
+
+def main() -> int:
+    if sys.argv[1:] == ["--version"]:
+        print("libprotoc 3.21.12")
+        return 0
+
+    real_protoc = _real_protoc()
+    os.execv(real_protoc, [real_protoc, *sys.argv[1:]])
+    return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/nexus/bricks/archive/tests/unit/test_verify.py
+++ b/src/nexus/bricks/archive/tests/unit/test_verify.py
@@ -1,11 +1,14 @@
 """Tests for archive verifier."""
 
 import json
+import sys
 import tarfile
+from importlib.metadata import PackageNotFoundError
 from pathlib import Path
 
 import pytest
 
+from nexus.bricks.archive import verify as archive_verify
 from nexus.bricks.archive.errors import (
     ArchiveError,
     ArchiveSignatureError,
@@ -134,3 +137,12 @@ def test_verify_min_version_rejected(tmp_path):
     )
     with pytest.raises(ArchiveVersionIncompatible):
         verify_archive(bundle, strict=True)
+
+
+def test_current_version_falls_back_to_source_version(monkeypatch):
+    def missing_distribution(_name: str) -> str:
+        raise PackageNotFoundError("nexus-ai-fs")
+
+    monkeypatch.setattr(archive_verify, "version", missing_distribution)
+
+    assert archive_verify._current_nexus_version() == sys.modules["nexus"].__version__

--- a/src/nexus/bricks/archive/verify.py
+++ b/src/nexus/bricks/archive/verify.py
@@ -16,15 +16,22 @@ from __future__ import annotations
 
 import json
 import tarfile
+from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
-import nexus
 from nexus.bricks.archive.errors import (
     ArchiveError,
     ArchiveSignatureError,
     ArchiveVersionIncompatible,
 )
 from nexus.bricks.portability.signer import ArchiveSigner, canonical_json_bytes
+
+
+def _current_nexus_version() -> str:
+    try:
+        return version("nexus-ai-fs")
+    except PackageNotFoundError:
+        return "0.0.0"
 
 
 def _parse_semver(s: str) -> tuple[int, int, int]:
@@ -96,7 +103,7 @@ def verify_archive(file: Path, *, strict: bool = False) -> None:
 
         # --- min_nexus_version check ---
         min_required: str = manifest.get("min_nexus_version", "0.0.0")
-        current: str = nexus.__version__
+        current = _current_nexus_version()
         if _parse_semver(min_required) > _parse_semver(current):
             raise ArchiveVersionIncompatible(required=min_required, current=current)
 
@@ -122,4 +129,4 @@ def verify_archive(file: Path, *, strict: bool = False) -> None:
                 )
 
 
-__all__ = ["_parse_semver", "verify_archive"]
+__all__ = ["_current_nexus_version", "_parse_semver", "verify_archive"]

--- a/src/nexus/bricks/archive/verify.py
+++ b/src/nexus/bricks/archive/verify.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import json
 import tarfile
+from importlib import import_module
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
 
@@ -31,7 +32,10 @@ def _current_nexus_version() -> str:
     try:
         return version("nexus-ai-fs")
     except PackageNotFoundError:
-        return "0.0.0"
+        try:
+            return str(import_module("nexus").__version__)
+        except Exception:
+            return "0.0.0"
 
 
 def _parse_semver(s: str) -> tuple[int, int, int]:

--- a/src/nexus/bricks/upload/chunked_upload_service.py
+++ b/src/nexus/bricks/upload/chunked_upload_service.py
@@ -93,10 +93,12 @@ class ChunkedUploadService:
         backend: "ConnectorProtocol",
         metadata_store: Any = None,
         config: ChunkedUploadConfig | None = None,
+        nexus_fs: Any = None,
     ):
         self._session_factory = record_store.session_factory
         self._backend = backend
         self._metadata_store = metadata_store
+        self._nexus_fs = nexus_fs
         # Pull the kernel out of the proxy so the metadata put inside
         # ``finalize`` lands on ``kernel.metastore_*`` (survives W3).
         self._kernel = metadata_store
@@ -110,6 +112,10 @@ class ChunkedUploadService:
 
     # --- Public API ---
 
+    def attach_filesystem(self, nexus_fs: Any) -> None:
+        """Attach NexusFS so completed uploads use the normal write pipeline."""
+        self._nexus_fs = nexus_fs
+
     async def create_upload(
         self,
         target_path: str,
@@ -119,6 +125,7 @@ class ChunkedUploadService:
         zone_id: str = ROOT_ZONE_ID,
         user_id: str = "anonymous",
         checksum_algorithm: str | None = None,
+        context: Any | None = None,
     ) -> UploadSession:
         """Create a new upload session.
 
@@ -148,6 +155,8 @@ class ChunkedUploadService:
         # Lazy cleanup on create
         await self._lazy_cleanup()
 
+        await self._enforce_write_permission(target_path, context)
+
         # Acquire semaphore (non-blocking — return 429 if full)
         if not self._semaphore.locked():
             await self._semaphore.acquire()
@@ -160,10 +169,13 @@ class ChunkedUploadService:
             now = datetime.now(UTC)
             expires_at = now + timedelta(hours=self._config.session_ttl_hours)
 
-            # Initialize backend multipart if supported
+            # Initialize backend multipart only for standalone services. When
+            # NexusFS is attached, completed uploads must flow through
+            # NexusFS.write so permission, metadata, and audit hooks match
+            # ordinary writes.
             backend_upload_id: str | None = None
             backend_name: str | None = None
-            if self._supports_multipart():
+            if self._nexus_fs is None and self._supports_multipart():
                 mixin = cast("MultipartUpload", self._backend)
                 backend_upload_id = await asyncio.to_thread(
                     mixin.init_multipart,
@@ -189,6 +201,7 @@ class ChunkedUploadService:
                 expires_at=expires_at,
                 backend_upload_id=backend_upload_id,
                 backend_name=backend_name,
+                parts=(),
             )
 
             await self._persist_session(session)
@@ -213,6 +226,7 @@ class ChunkedUploadService:
         offset: int,
         chunk_data: bytes,
         checksum_header: str | None = None,
+        context: Any | None = None,
     ) -> UploadSession:
         """Receive and store a chunk of data.
 
@@ -243,6 +257,8 @@ class ChunkedUploadService:
             if session.is_expired:
                 await self._expire_session(session)
                 raise UploadExpiredError(upload_id)
+
+            await self._enforce_write_permission(session.target_path, context)
 
             # Validate offset
             if offset != session.upload_offset:
@@ -278,7 +294,7 @@ class ChunkedUploadService:
             part_number = session.parts_received + 1
             part_info = await self._store_chunk(session, part_number, chunk_data)
 
-            parts = self._parts_registry.get(upload_id, [])
+            parts = list(session.parts)
             parts.append(part_info)
             self._parts_registry[upload_id] = parts
 
@@ -301,6 +317,7 @@ class ChunkedUploadService:
                 backend_upload_id=session.backend_upload_id,
                 backend_name=session.backend_name,
                 parts_received=part_number,
+                parts=tuple(parts),
                 content_id=session.content_id,
             )
 
@@ -308,7 +325,7 @@ class ChunkedUploadService:
 
             # If upload is complete, assemble and write
             if updated.is_complete:
-                updated = await self._assemble_and_write(updated, parts)
+                updated = await self._assemble_and_write(updated, parts, context=context)
 
             return updated
 
@@ -382,6 +399,7 @@ class ChunkedUploadService:
             backend_upload_id=session.backend_upload_id,
             backend_name=session.backend_name,
             parts_received=session.parts_received,
+            parts=session.parts,
             content_id=session.content_id,
         )
         await self._update_session(terminated)
@@ -542,6 +560,10 @@ class ChunkedUploadService:
                 model.parts_received = s.parts_received
                 model.content_id = s.content_id
                 model.backend_upload_id = s.backend_upload_id
+                model.metadata_json = UploadSessionModel.encode_metadata_state(
+                    s.metadata,
+                    s.parts,
+                )
                 db.commit()
             except Exception:
                 db.rollback()
@@ -603,6 +625,8 @@ class ChunkedUploadService:
         self,
         session: UploadSession,
         parts: list[dict[str, Any]],
+        *,
+        context: Any | None = None,
     ) -> UploadSession:
         """Assemble chunks and write the final file.
 
@@ -615,6 +639,7 @@ class ChunkedUploadService:
         content_id: str
 
         if self._supports_multipart() and session.backend_upload_id:
+            await self._enforce_write_permission(session.target_path, context)
             mixin = cast("MultipartUpload", self._backend)
             content_id = await asyncio.to_thread(
                 mixin.complete_multipart,
@@ -634,13 +659,22 @@ class ChunkedUploadService:
 
             # Write assembled content to CAS
             content = bytes(assembled)
-            _write = self._backend.write_content
-            result = await asyncio.to_thread(_write, content)
-            content_id = result.content_id
+            if self._nexus_fs is not None:
+                result = await asyncio.to_thread(
+                    self._nexus_fs.write,
+                    session.target_path,
+                    content,
+                    context=context,
+                )
+                content_id = result["content_id"]
+            else:
+                _write = self._backend.write_content
+                result = await asyncio.to_thread(_write, content)
+                content_id = result.content_id
 
-            # Link content to target_path via metadata store so the file is
-            # reachable (multipart backends do this inside complete_multipart).
-            if self._kernel is not None:
+            # Link content to target_path via metadata store when NexusFS is not
+            # attached. NexusFS.write handles metadata, hooks, and observers.
+            if self._nexus_fs is None and self._kernel is not None:
                 from nexus.contracts.metadata import FileMetadata
 
                 metadata = FileMetadata(
@@ -648,7 +682,10 @@ class ChunkedUploadService:
                     size=len(content),
                     content_id=content_id,
                 )
-                await asyncio.to_thread(self._kernel.metastore_put, metadata)
+                write_metadata = getattr(self._kernel, "metastore_put", None)
+                if write_metadata is None:
+                    write_metadata = self._kernel.put
+                await asyncio.to_thread(write_metadata, metadata)
 
         # Update session to completed
         completed = UploadSession(
@@ -666,6 +703,7 @@ class ChunkedUploadService:
             backend_upload_id=session.backend_upload_id,
             backend_name=session.backend_name,
             parts_received=session.parts_received,
+            parts=tuple(parts),
             content_id=content_id,
         )
         await self._update_session(completed)
@@ -716,6 +754,7 @@ class ChunkedUploadService:
             backend_upload_id=session.backend_upload_id,
             backend_name=session.backend_name,
             parts_received=session.parts_received,
+            parts=session.parts,
             content_id=session.content_id,
         )
 
@@ -740,6 +779,13 @@ class ChunkedUploadService:
                 await self.cleanup_expired()
             except Exception as e:
                 logger.warning("Lazy cleanup failed: %s", e)
+
+    async def _enforce_write_permission(self, path: str, context: Any | None) -> None:
+        if context is None or self._nexus_fs is None:
+            return
+        enforce = getattr(self._nexus_fs, "_enforce_lock_write_permission", None)
+        if callable(enforce):
+            await asyncio.to_thread(enforce, path, context)
 
     @staticmethod
     def _verify_checksum(

--- a/src/nexus/bricks/upload/upload_session.py
+++ b/src/nexus/bricks/upload/upload_session.py
@@ -41,6 +41,7 @@ class UploadSession:
         backend_upload_id: Backend-specific multipart upload ID (e.g. S3 UploadId).
         backend_name: Name of the backend handling this upload.
         parts_received: Number of chunk parts received so far.
+        parts: Backend part metadata received so far.
         content_id: Final content hash after assembly (BLAKE3).
     """
 
@@ -58,6 +59,7 @@ class UploadSession:
     backend_upload_id: str | None = None
     backend_name: str | None = None
     parts_received: int = 0
+    parts: tuple[dict[str, Any], ...] = field(default_factory=tuple)
     content_id: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
@@ -77,6 +79,7 @@ class UploadSession:
             "backend_upload_id": self.backend_upload_id,
             "backend_name": self.backend_name,
             "parts_received": self.parts_received,
+            "parts": [dict(part) for part in self.parts],
             "content_id": self.content_id,
         }
 
@@ -114,6 +117,7 @@ class UploadSession:
             backend_upload_id=data.get("backend_upload_id"),
             backend_name=data.get("backend_name"),
             parts_received=data.get("parts_received", 0),
+            parts=tuple(dict(part) for part in data.get("parts", ())),
             content_id=data.get("content_id"),
         )
 

--- a/src/nexus/factory/_lifecycle.py
+++ b/src/nexus/factory/_lifecycle.py
@@ -133,6 +133,10 @@ def _wire_services(
     # Canonical name mapping consolidated in service_routing.py.
     enlist_services(nx, _svc)
 
+    _upload_svc = _svc.get("chunked_upload_service")
+    if _upload_svc is not None and hasattr(_upload_svc, "attach_filesystem"):
+        _upload_svc.attach_filesystem(nx)
+
     # R20.18.5: federation is kernel-internal now. The federation
     # parameter is vestigial (always None post-cutover). Kernel::new()
     # reads env vars and bootstraps raft::ZoneManager in Rust. DLC

--- a/src/nexus/server/api/v2/routers/tus_uploads.py
+++ b/src/nexus/server/api/v2/routers/tus_uploads.py
@@ -331,7 +331,7 @@ def create_tus_uploads_router(
         auth_result: dict = Depends(require_auth),
     ) -> Response:
         """Terminate an upload and release resources (tus termination extension)."""
-        from nexus.contracts.exceptions import UploadNotFoundError
+        from nexus.contracts.exceptions import UploadExpiredError, UploadNotFoundError
 
         service = _get_service()
 
@@ -341,6 +341,8 @@ def create_tus_uploads_router(
             await service.terminate_upload(upload_id)
         except UploadNotFoundError as e:
             raise HTTPException(status_code=404, detail=f"Upload not found: {upload_id}") from e
+        except UploadExpiredError as e:
+            raise HTTPException(status_code=410, detail=f"Upload expired: {upload_id}") from e
 
         return Response(
             status_code=204,

--- a/src/nexus/server/api/v2/routers/tus_uploads.py
+++ b/src/nexus/server/api/v2/routers/tus_uploads.py
@@ -13,7 +13,7 @@ Every endpoint (except OPTIONS) validates the Tus-Resumable header.
 import base64
 import logging
 import os
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response
 
@@ -70,6 +70,21 @@ def _parse_upload_metadata(raw: str | None) -> dict[str, str]:
             value = ""
         result[key] = value
     return result
+
+
+def _authorize_upload_access(session: Any, auth_result: dict[str, Any]) -> Any:
+    """Return request context if caller owns the upload session or is admin."""
+    from nexus.server.dependencies import get_operation_context
+
+    ctx = get_operation_context(auth_result)
+    if getattr(ctx, "is_admin", False):
+        return ctx
+
+    request_zone = ctx.zone_id or ROOT_ZONE_ID
+    request_user = ctx.user_id or "anonymous"
+    if session.zone_id != request_zone or session.user_id != request_user:
+        raise HTTPException(status_code=403, detail="Upload session is not owned by caller")
+    return ctx
 
 
 def create_tus_uploads_router(
@@ -129,7 +144,7 @@ def create_tus_uploads_router(
         auth_result: dict = Depends(require_auth),
     ) -> Response:
         """Create a new upload session (tus creation extension)."""
-        from nexus.contracts.exceptions import ValidationError
+        from nexus.contracts.exceptions import NexusPermissionError, ValidationError
         from nexus.server.dependencies import get_operation_context
 
         service = _get_service()
@@ -161,6 +176,7 @@ def create_tus_uploads_router(
                 metadata=metadata,
                 zone_id=zone_id,
                 user_id=user_id,
+                context=ctx,
             )
         except RuntimeError as e:
             if "Too many concurrent" in str(e):
@@ -168,6 +184,8 @@ def create_tus_uploads_router(
             raise
         except ValidationError as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
+        except NexusPermissionError as e:
+            raise HTTPException(status_code=403, detail=str(e)) from e
 
         # Build Location URL
         location = str(request.url).rstrip("/") + f"/{session.upload_id}"
@@ -188,9 +206,11 @@ def create_tus_uploads_router(
         upload_id: str,
         request: Request,
         _tus_resumable: str = Depends(_validate_tus_resumable),
+        auth_result: dict = Depends(require_auth),
     ) -> Response:
         """Upload a chunk of data (tus core protocol)."""
         from nexus.contracts.exceptions import (
+            NexusPermissionError,
             UploadChecksumMismatchError,
             UploadExpiredError,
             UploadNotFoundError,
@@ -199,6 +219,14 @@ def create_tus_uploads_router(
         )
 
         service = _get_service()
+
+        try:
+            current = await service.get_upload_status(upload_id)
+            ctx = _authorize_upload_access(current, auth_result)
+        except UploadNotFoundError as e:
+            raise HTTPException(status_code=404, detail=f"Upload not found: {upload_id}") from e
+        except UploadExpiredError as e:
+            raise HTTPException(status_code=410, detail=f"Upload expired: {upload_id}") from e
 
         # Validate Content-Type
         content_type = request.headers.get("Content-Type", "")
@@ -232,6 +260,7 @@ def create_tus_uploads_router(
                 offset=offset,
                 chunk_data=chunk_data,
                 checksum_header=checksum_header,
+                context=ctx,
             )
         except UploadNotFoundError as e:
             raise HTTPException(status_code=404, detail=f"Upload not found: {upload_id}") from e
@@ -249,6 +278,8 @@ def create_tus_uploads_router(
             ) from e
         except ValidationError as e:
             raise HTTPException(status_code=400, detail=str(e)) from e
+        except NexusPermissionError as e:
+            raise HTTPException(status_code=403, detail=str(e)) from e
 
         headers = {
             "Tus-Resumable": TUS_RESUMABLE,
@@ -265,6 +296,7 @@ def create_tus_uploads_router(
     async def tus_get_offset(
         upload_id: str,
         _tus_resumable: str = Depends(_validate_tus_resumable),
+        auth_result: dict = Depends(require_auth),
     ) -> Response:
         """Get the current offset of an upload (for resumption)."""
         from nexus.contracts.exceptions import UploadExpiredError, UploadNotFoundError
@@ -273,6 +305,7 @@ def create_tus_uploads_router(
 
         try:
             session = await service.get_upload_status(upload_id)
+            _authorize_upload_access(session, auth_result)
         except UploadNotFoundError as e:
             raise HTTPException(status_code=404, detail=f"Upload not found: {upload_id}") from e
         except UploadExpiredError as e:
@@ -295,6 +328,7 @@ def create_tus_uploads_router(
     async def tus_terminate(
         upload_id: str,
         _tus_resumable: str = Depends(_validate_tus_resumable),
+        auth_result: dict = Depends(require_auth),
     ) -> Response:
         """Terminate an upload and release resources (tus termination extension)."""
         from nexus.contracts.exceptions import UploadNotFoundError
@@ -302,6 +336,8 @@ def create_tus_uploads_router(
         service = _get_service()
 
         try:
+            session = await service.get_upload_status(upload_id)
+            _authorize_upload_access(session, auth_result)
             await service.terminate_upload(upload_id)
         except UploadNotFoundError as e:
             raise HTTPException(status_code=404, detail=f"Upload not found: {upload_id}") from e

--- a/src/nexus/server/lifespan/uploads.py
+++ b/src/nexus/server/lifespan/uploads.py
@@ -59,6 +59,7 @@ async def startup_uploads(app: "FastAPI", svc: "LifespanServices") -> list[async
                     backend=_backend,
                     metadata_store=getattr(svc.nexus_fs, "metadata", None),
                     config=ChunkedUploadConfig(**_upload_kwargs),
+                    nexus_fs=svc.nexus_fs,
                 )
                 cleanup_task = asyncio.create_task(
                     app.state.chunked_upload_service.start_cleanup_loop()

--- a/src/nexus/storage/mcl_recorder.py
+++ b/src/nexus/storage/mcl_recorder.py
@@ -210,10 +210,11 @@ class MCLRecorder:
         if aspect_name is not None:
             stmt = stmt.where(MetadataChangeLogModel.aspect_name == aspect_name)
 
-        offset = 0
+        last_sequence = from_sequence - 1
         while True:
-            batch = list(self._session.execute(stmt.limit(batch_size).offset(offset)).scalars())
+            page_stmt = stmt.where(MetadataChangeLogModel.sequence_number > last_sequence)
+            batch = list(self._session.execute(page_stmt.limit(batch_size)).scalars())
             if not batch:
                 break
             yield from batch
-            offset += batch_size
+            last_sequence = batch[-1].sequence_number

--- a/src/nexus/storage/models/upload_session.py
+++ b/src/nexus/storage/models/upload_session.py
@@ -13,6 +13,8 @@ from sqlalchemy.orm import Mapped, mapped_column
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.storage.models._base import Base, _generate_uuid, _get_uuid_server_default
 
+_UPLOAD_METADATA_STATE_VERSION = 1
+
 
 class UploadSessionModel(Base):
     """Persistent storage for chunked upload sessions.
@@ -72,9 +74,7 @@ class UploadSessionModel(Base):
 
     def to_session_dict(self) -> dict[str, Any]:
         """Convert to dict compatible with UploadSession.from_dict()."""
-        metadata: dict[str, str] = {}
-        if self.metadata_json:
-            metadata = json.loads(self.metadata_json)
+        metadata, parts = self._decode_metadata_state(self.metadata_json)
 
         return {
             "upload_id": self.upload_id,
@@ -91,13 +91,17 @@ class UploadSessionModel(Base):
             "backend_upload_id": self.backend_upload_id,
             "backend_name": self.backend_name,
             "parts_received": self.parts_received,
+            "parts": parts,
             "content_id": self.content_id,
         }
 
     @classmethod
     def from_upload_session(cls, session: Any) -> "UploadSessionModel":
         """Create model from an UploadSession dataclass."""
-        metadata_json = json.dumps(session.metadata) if session.metadata else None
+        metadata_json = cls.encode_metadata_state(
+            session.metadata,
+            getattr(session, "parts", ()),
+        )
         return cls(
             upload_id=session.upload_id,
             target_path=session.target_path,
@@ -114,6 +118,43 @@ class UploadSessionModel(Base):
             backend_name=session.backend_name,
             parts_received=session.parts_received,
             content_id=session.content_id,
+        )
+
+    @classmethod
+    def encode_metadata_state(
+        cls,
+        metadata: dict[str, str] | None,
+        parts: tuple[dict[str, Any], ...] | list[dict[str, Any]] | None,
+    ) -> str:
+        """Encode tus metadata plus server-owned part state into one legacy column."""
+        return json.dumps(
+            {
+                "_nexus_upload_state_version": _UPLOAD_METADATA_STATE_VERSION,
+                "metadata": metadata or {},
+                "parts": [dict(part) for part in (parts or ())],
+            },
+            separators=(",", ":"),
+        )
+
+    @staticmethod
+    def _decode_metadata_state(raw: str | None) -> tuple[dict[str, str], list[dict[str, Any]]]:
+        if not raw:
+            return {}, []
+
+        payload = json.loads(raw)
+        if (
+            isinstance(payload, dict)
+            and payload.get("_nexus_upload_state_version") == _UPLOAD_METADATA_STATE_VERSION
+        ):
+            metadata = payload.get("metadata") or {}
+            parts = payload.get("parts") or []
+        else:
+            metadata = payload if isinstance(payload, dict) else {}
+            parts = []
+
+        return (
+            {str(key): str(value) for key, value in metadata.items()},
+            [dict(part) for part in parts if isinstance(part, dict)],
         )
 
     def __repr__(self) -> str:

--- a/tests/e2e/self_contained/test_tus_protocol.py
+++ b/tests/e2e/self_contained/test_tus_protocol.py
@@ -50,7 +50,12 @@ def upload_service(tmp_backend: CASLocalBackend) -> ChunkedUploadService:
 
 
 @pytest.fixture
-def app(upload_service: ChunkedUploadService) -> FastAPI:
+def auth_state() -> dict[str, object]:
+    return {"authenticated": True, "is_admin": False, "subject_id": "test-user"}
+
+
+@pytest.fixture
+def app(upload_service: ChunkedUploadService, auth_state: dict[str, object]) -> FastAPI:
     """Create a FastAPI app with the tus router."""
     _app = FastAPI()
     public_router, auth_router = create_tus_uploads_router(
@@ -59,8 +64,7 @@ def app(upload_service: ChunkedUploadService) -> FastAPI:
     _app.include_router(public_router, prefix="/api/v2/uploads")
     _app.include_router(auth_router, prefix="/api/v2/uploads")
     # Override require_auth for functional tests
-    _auth_result = {"authenticated": True, "is_admin": False, "subject_id": "test-user"}
-    _app.dependency_overrides[require_auth] = lambda: _auth_result
+    _app.dependency_overrides[require_auth] = lambda: auth_state
     return _app
 
 
@@ -265,6 +269,31 @@ class TestResumeAfterDisconnect:
         )
         assert patch2.status_code == 204
         assert patch2.headers["Upload-Offset"] == str(len(full_content))
+
+    @pytest.mark.asyncio
+    async def test_different_user_cannot_resume_upload(
+        self,
+        client: AsyncClient,
+        auth_state: dict[str, object],
+    ) -> None:
+        create_resp = await client.post(
+            "/api/v2/uploads",
+            headers={**TUS_HEADERS, "Upload-Length": "4"},
+        )
+        upload_path = create_resp.headers["Location"].replace("http://test", "")
+
+        auth_state["subject_id"] = "other-user"
+        patch_resp = await client.patch(
+            upload_path,
+            headers={
+                **TUS_HEADERS,
+                "Upload-Offset": "0",
+                "Content-Type": "application/offset+octet-stream",
+            },
+            content=b"data",
+        )
+
+        assert patch_resp.status_code == 403
 
 
 class TestChecksumEndpoints:

--- a/tests/e2e/self_contained/test_tus_protocol.py
+++ b/tests/e2e/self_contained/test_tus_protocol.py
@@ -6,11 +6,13 @@ tus uploads router with a real service and in-memory SQLite backend.
 
 import base64
 import hashlib
+from datetime import UTC, datetime, timedelta
 from pathlib import Path
 
 import pytest
 from fastapi import FastAPI
 from httpx import ASGITransport, AsyncClient
+from sqlalchemy import select
 
 from nexus.backends.storage.cas_local import CASLocalBackend
 from nexus.bricks.upload.chunked_upload_service import (
@@ -19,6 +21,7 @@ from nexus.bricks.upload.chunked_upload_service import (
 )
 from nexus.server.api.v2.routers.tus_uploads import create_tus_uploads_router
 from nexus.server.dependencies import require_auth
+from nexus.storage.models.upload_session import UploadSessionModel
 
 # --- Test fixtures ---
 
@@ -405,6 +408,32 @@ class TestTerminateEndpoint:
             headers=TUS_HEADERS,
         )
         assert resp.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_terminate_expired_upload_returns_410(
+        self,
+        client: AsyncClient,
+        upload_service: ChunkedUploadService,
+    ) -> None:
+        create_resp = await client.post(
+            "/api/v2/uploads",
+            headers={**TUS_HEADERS, "Upload-Length": "100"},
+        )
+        upload_path = create_resp.headers["Location"].replace("http://test", "")
+        upload_id = upload_path.rsplit("/", 1)[-1]
+
+        db = upload_service._session_factory()
+        try:
+            model = db.execute(
+                select(UploadSessionModel).filter_by(upload_id=upload_id)
+            ).scalar_one()
+            model.expires_at = datetime.now(UTC) - timedelta(seconds=1)
+            db.commit()
+        finally:
+            db.close()
+
+        resp = await client.delete(upload_path, headers=TUS_HEADERS)
+        assert resp.status_code == 410
 
 
 class TestZeroByteUpload:

--- a/tests/unit/bricks/test_chunked_upload_service.py
+++ b/tests/unit/bricks/test_chunked_upload_service.py
@@ -1,0 +1,175 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+import pytest
+
+from nexus.backends.engines.multipart import MultipartUpload
+from nexus.bricks.upload.chunked_upload_service import ChunkedUploadConfig, ChunkedUploadService
+from nexus.contracts.types import OperationContext
+from tests.helpers.in_memory_record_store import InMemoryRecordStore
+
+
+@dataclass(frozen=True)
+class _WriteResult:
+    content_id: str
+
+
+class _MemoryBackend:
+    def __init__(self) -> None:
+        self._content: dict[str, bytes] = {}
+        self._next = 0
+
+    def write_content(self, data: bytes) -> _WriteResult:
+        self._next += 1
+        content_id = f"content-{self._next}"
+        self._content[content_id] = data
+        return _WriteResult(content_id=content_id)
+
+    def read_content(self, content_id: str) -> bytes:
+        return self._content[content_id]
+
+
+class _MetadataStore:
+    def __init__(self) -> None:
+        self.writes: list[Any] = []
+
+    def put(self, metadata: Any) -> None:
+        self.writes.append(metadata)
+
+
+class _MultipartMemoryBackend(_MemoryBackend, MultipartUpload):
+    def __init__(self) -> None:
+        super().__init__()
+        self.init_calls = 0
+        self.uploaded_parts: list[bytes] = []
+        self.completed = False
+
+    def init_multipart(
+        self,
+        backend_path: str,
+        content_type: str = "application/octet-stream",
+        metadata: dict[str, str] | None = None,
+    ) -> str:
+        self.init_calls += 1
+        return "multipart-upload"
+
+    def upload_part(
+        self,
+        backend_path: str,
+        upload_id: str,
+        part_number: int,
+        data: bytes,
+    ) -> dict[str, Any]:
+        self.uploaded_parts.append(data)
+        return {"etag": f"part-{part_number}", "part_number": part_number}
+
+    def complete_multipart(
+        self,
+        backend_path: str,
+        upload_id: str,
+        parts: list[dict[str, Any]],
+    ) -> str:
+        self.completed = True
+        return "multipart-content"
+
+    def abort_multipart(self, backend_path: str, upload_id: str) -> None:
+        pass
+
+
+class _NexusFS:
+    def __init__(self) -> None:
+        self.writes: list[dict[str, Any]] = []
+
+    def write(
+        self,
+        path: str,
+        buf: bytes,
+        *,
+        context: OperationContext | None = None,
+    ) -> dict[str, Any]:
+        self.writes.append({"path": path, "buf": buf, "context": context})
+        return {
+            "content_id": "fs-content",
+            "version": 1,
+            "modified_at": None,
+            "size": len(buf),
+        }
+
+
+def _service(
+    record_store: InMemoryRecordStore,
+    backend: _MemoryBackend,
+    metadata_store: _MetadataStore | None = None,
+    *,
+    nexus_fs: _NexusFS | None = None,
+) -> ChunkedUploadService:
+    kwargs: dict[str, Any] = {}
+    if nexus_fs is not None:
+        kwargs["nexus_fs"] = nexus_fs
+    return ChunkedUploadService(
+        record_store=record_store,
+        backend=backend,
+        metadata_store=metadata_store,
+        config=ChunkedUploadConfig(min_chunk_size=1, max_chunk_size=1024),
+        **kwargs,
+    )
+
+
+@pytest.mark.asyncio
+async def test_resume_after_service_restart_uses_persisted_part_metadata() -> None:
+    record_store = InMemoryRecordStore()
+    backend = _MemoryBackend()
+    metadata_store = _MetadataStore()
+    first_service = _service(record_store, backend, metadata_store)
+
+    upload = await first_service.create_upload("/uploads/restarted.txt", upload_length=10)
+    await first_service.receive_chunk(upload.upload_id, 0, b"hello")
+
+    restarted_service = _service(record_store, backend, metadata_store)
+    completed = await restarted_service.receive_chunk(upload.upload_id, 5, b"world")
+
+    assert completed.content_id is not None
+    assert backend.read_content(completed.content_id) == b"helloworld"
+    assert metadata_store.writes[-1].size == 10
+
+
+@pytest.mark.asyncio
+async def test_completed_upload_uses_attached_filesystem_write_path() -> None:
+    record_store = InMemoryRecordStore()
+    backend = _MemoryBackend()
+    metadata_store = _MetadataStore()
+    nexus_fs = _NexusFS()
+    service = _service(record_store, backend, metadata_store, nexus_fs=nexus_fs)
+    context = OperationContext(user_id="alice", groups=[])
+
+    upload = await service.create_upload(
+        "/uploads/through-fs.txt",
+        upload_length=4,
+        user_id="alice",
+    )
+    completed = await service.receive_chunk(upload.upload_id, 0, b"data", context=context)
+
+    assert completed.content_id == "fs-content"
+    assert nexus_fs.writes == [
+        {"path": "/uploads/through-fs.txt", "buf": b"data", "context": context}
+    ]
+    assert metadata_store.writes == []
+
+
+@pytest.mark.asyncio
+async def test_attached_filesystem_disables_backend_multipart_path() -> None:
+    record_store = InMemoryRecordStore()
+    backend = _MultipartMemoryBackend()
+    nexus_fs = _NexusFS()
+    service = _service(record_store, backend, nexus_fs=nexus_fs)
+
+    upload = await service.create_upload("/uploads/multipart.txt", upload_length=4)
+    completed = await service.receive_chunk(upload.upload_id, 0, b"data")
+
+    assert upload.backend_upload_id is None
+    assert completed.content_id == "fs-content"
+    assert backend.init_calls == 0
+    assert backend.uploaded_parts == []
+    assert not backend.completed

--- a/tests/unit/test_mcl.py
+++ b/tests/unit/test_mcl.py
@@ -304,6 +304,39 @@ class TestMCLReplay:
         replayed = list(recorder.replay_changes(from_sequence=mid_seq))
         assert len(replayed) == 3
 
+    def test_replay_changes_uses_sequence_cursor_not_offset(self, db_session) -> None:
+        from sqlalchemy import event
+
+        recorder = MCLRecorder(db_session)
+        for i in range(5):
+            recorder.record_file_write(
+                entity_urn=f"urn:nexus:file:z1:id{i}",
+                metadata_dict={"path": f"/file{i}"},
+            )
+        db_session.commit()
+
+        statements: list[tuple[str, tuple[object, ...]]] = []
+
+        def collect_sql(_conn, _cursor, statement, _parameters, _context, _executemany) -> None:
+            if "metadata_change_log" in statement and statement.lstrip().upper().startswith(
+                "SELECT"
+            ):
+                statements.append((statement.upper(), tuple(_parameters)))
+
+        event.listen(db_session.bind, "before_cursor_execute", collect_sql)
+        try:
+            replayed = list(recorder.replay_changes(batch_size=2))
+        finally:
+            event.remove(db_session.bind, "before_cursor_execute", collect_sql)
+
+        assert len(replayed) == 5
+        assert statements
+        # SQLite's LIMIT syntax includes an OFFSET placeholder even when SQLAlchemy
+        # does not request an offset; the important regression guard is that the
+        # offset parameter never advances through the log.
+        assert all(parameters[-1] == 0 for _statement, parameters in statements)
+        assert all("SEQUENCE_NUMBER >" in statement for statement, _parameters in statements)
+
 
 class TestURNLocator:
     """Tests for URN locator pattern (Issue #2929 Key Decision #3).

--- a/tests/unit/test_protoc_compat.py
+++ b/tests/unit/test_protoc_compat.py
@@ -1,0 +1,46 @@
+"""Tests for the protoc compatibility wrapper."""
+
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+
+def _load_protoc_compat() -> ModuleType:
+    script = Path(__file__).resolve().parents[2] / "scripts" / "protoc-compat.py"
+    spec = importlib.util.spec_from_file_location("protoc_compat", script)
+    assert spec is not None
+    assert spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_real_protoc_prefers_vendored_before_path(monkeypatch, tmp_path):
+    module = _load_protoc_compat()
+    cargo_home = tmp_path / "cargo"
+    vendored = (
+        cargo_home
+        / "registry"
+        / "src"
+        / "index"
+        / "protoc-bin-vendored-linux-x86_64-3.2.0"
+        / "bin"
+        / "protoc"
+    )
+    vendored.parent.mkdir(parents=True)
+    vendored.write_text("#!/bin/sh\n")
+
+    path_bin = tmp_path / "bin"
+    path_bin.mkdir()
+    system_protoc = path_bin / "protoc"
+    system_protoc.write_text("#!/bin/sh\n")
+
+    monkeypatch.setenv("CARGO_HOME", str(cargo_home))
+    monkeypatch.setenv("PATH", str(path_bin))
+    monkeypatch.delenv("NEXUS_REAL_PROTOC", raising=False)
+    monkeypatch.setattr(module.platform, "system", lambda: "Linux")
+    monkeypatch.setattr(module.platform, "machine", lambda: "x86_64")
+
+    assert module._real_protoc() == str(vendored)


### PR DESCRIPTION
## Summary

Addresses the review findings around resumable uploads, TUS authorization, package build hygiene, architecture guardrails, raft protobuf builds, slim package test dependencies, and MCL replay performance.

## Changes

- Persist upload part metadata so resumed uploads survive process restarts.
- Authorize TUS resume/status/terminate requests by upload owner and zone, enforce write permissions on create/write, and route Nexus-attached completion through `NexusFS.write`.
- Fix TUI GET dedupe to account for request options and avoid deduping abortable requests.
- Expand the import-linter brick independence contract to cover active brick packages and ratchet known existing exceptions.
- Fix package build edges: pay now builds api-client first; api-client has a prepare build; TUI pins OpenTUI's Solid peer and patches local OpenTUI types consistently.
- Add Cargo-level `PROTOC` configuration with a compatibility shim so raft dependency build scripts see a valid protoc before crate-local build scripts run.
- Add missing `pytest-examples` dev dependency for the slim `nexus-fs` package.
- Replace MCL replay OFFSET pagination with sequence cursor pagination.

## Validation

- `uv run --frozen --extra dev pytest -n0 tests/unit/bricks/test_chunked_upload_service.py tests/e2e/self_contained/test_tus_protocol.py::TestResumeAfterDisconnect::test_different_user_cannot_resume_upload tests/unit/test_mcl.py::TestMCLReplay::test_replay_changes_uses_sequence_cursor_not_offset -q`
- `uv run --frozen --extra dev ruff check ...`
- `uv run --frozen --extra dev lint-imports --contract brick-independence`
- `cargo check --workspace --all-targets`
- `npm install --no-package-lock` and `npm run lint` in `packages/nexus-tui`
- `npm test` in `packages/nexus-api-client`
- `npm test` in `packages/nexus-pay-ts`
- Commit pre-hooks: whitespace, ruff, ruff format, mypy, brick zero-core-imports, and other configured checks

## Notes

`packages/nexus-tui npm test` still requires Bun, which is not installed in this environment. The slim `packages/nexus-fs` docs-test command is blocked before collection because `nexus-runtime>=0.10,<0.11` is not resolvable from the configured package index.
