### PR TITLE
Avoid txtai startup in BM25-only search mode

### DIFF
--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -133,11 +133,10 @@ class DaemonConfig:
     entropy_threshold: float = 0.35  # SimpleMem's τ_redundant
     entropy_alpha: float = 0.5  # Balance entity vs semantic novelty
 
-    # txtai backend config (Issue #2663). ``None`` -> BM25 keyword-only
-    # fast-path (Issue #3997: resolver returns ``None`` when there is no
-    # API key and no explicit local model). ``TxtaiBackend._startup_impl``
-    # detects ``model=None`` and skips ``Embeddings(path=...)`` entirely,
-    # saving ~900 MB RSS at boot for default deploys.
+    # txtai backend config (Issue #2663). ``None`` disables the txtai backend
+    # and uses the daemon's legacy BM25/FTS keyword path only. This is the
+    # default when there is no API key and no explicit local model, avoiding
+    # native txtai/faiss startup in default Docker deployments.
     txtai_model: str | None = "sentence-transformers/all-MiniLM-L6-v2"
     txtai_vectors: dict[str, Any] | None = None
     txtai_reranker: str | None = None  # e.g. "cross-encoder/ms-marco-MiniLM-L-2-v2"
@@ -648,42 +647,50 @@ class SearchDaemon:
         # synchronously — do NOT kick off as a background task.
         await self._load_index_scope()
 
-        # Initialize txtai backend for semantic/hybrid/graph search (Issue #2663)
-        try:
-            from nexus.bricks.search.txtai_backend import TxtaiBackend
-
-            # Pass embedding cache so txtai can skip redundant API calls
-            _emb_cache = None
-            if self._cache_brick:
-                import contextlib
-
-                with contextlib.suppress(Exception):
-                    _emb_cache = self._cache_brick.embedding_cache
-
-            self._backend = TxtaiBackend(
-                database_url=self.config.database_url,
-                model=self.config.txtai_model,
-                vectors=self.config.txtai_vectors,
-                hybrid=True,
-                graph=self.config.txtai_graph,
-                reranker_model=self.config.txtai_reranker,
-                sparse=self.config.txtai_sparse,
-                embedding_cache=_emb_cache,
-                data_path=self.config.data_path if hasattr(self.config, "data_path") else None,
-                page_aggregation=self.config.page_aggregation,
-                chunks_per_page=self.config.chunks_per_page,
-                page_bm25=self.config.page_bm25,
-                page_bm25_rrf_k=self.config.page_bm25_rrf_k,
-            )
-            self._backend.kickoff_startup()
-            self._txtai_bootstrap_task = asyncio.create_task(self._bootstrap_txtai_backend())
-            logger.info("txtai backend startup kicked off in background")
-        except Exception:
-            logger.warning(
-                "txtai backend init failed, falling back to legacy search", exc_info=True
-            )
+        # Initialize txtai backend for semantic/hybrid/graph search (Issue #2663).
+        # ``txtai_model=None`` means BM25-only mode: avoid importing txtai/faiss
+        # at all, because native FAISS wheels can SIGILL on older CI/edge CPUs.
+        if self.config.txtai_model is None:
             self._backend = None
-            self._txtai_bootstrapped = False
+            self._txtai_bootstrap_task = None
+            self._txtai_bootstrapped = True
+            logger.info("txtai backend disabled; using BM25/FTS keyword search only")
+        else:
+            try:
+                from nexus.bricks.search.txtai_backend import TxtaiBackend
+
+                # Pass embedding cache so txtai can skip redundant API calls
+                _emb_cache = None
+                if self._cache_brick:
+                    import contextlib
+
+                    with contextlib.suppress(Exception):
+                        _emb_cache = self._cache_brick.embedding_cache
+
+                self._backend = TxtaiBackend(
+                    database_url=self.config.database_url,
+                    model=self.config.txtai_model,
+                    vectors=self.config.txtai_vectors,
+                    hybrid=True,
+                    graph=self.config.txtai_graph,
+                    reranker_model=self.config.txtai_reranker,
+                    sparse=self.config.txtai_sparse,
+                    embedding_cache=_emb_cache,
+                    data_path=self.config.data_path if hasattr(self.config, "data_path") else None,
+                    page_aggregation=self.config.page_aggregation,
+                    chunks_per_page=self.config.chunks_per_page,
+                    page_bm25=self.config.page_bm25,
+                    page_bm25_rrf_k=self.config.page_bm25_rrf_k,
+                )
+                self._backend.kickoff_startup()
+                self._txtai_bootstrap_task = asyncio.create_task(self._bootstrap_txtai_backend())
+                logger.info("txtai backend startup kicked off in background")
+            except Exception:
+                logger.warning(
+                    "txtai backend init failed, falling back to legacy search", exc_info=True
+                )
+                self._backend = None
+                self._txtai_bootstrapped = False
 
         # Initialize entropy-aware chunker if enabled (Issue #1024)
         if self.config.entropy_filtering:
@@ -3332,10 +3339,9 @@ class SearchDaemon:
             },
             # Issue #2663: txtai backend
             "backend": "txtai" if self._backend is not None else "legacy",
-            # Issue #3997: ``None`` (serialised as JSON ``null``) means the
-            # backend is in BM25 keyword-only mode — no embedding model was
-            # configured, so the heavy ``Embeddings(path=...)`` load was
-            # skipped to save RSS at boot.
+            # Issue #3997: ``None`` (serialised as JSON ``null``) means no
+            # embedding model was configured, so the txtai/faiss backend is
+            # not imported and queries use legacy BM25/FTS keyword search.
             "txtai_model": self.config.txtai_model,
             "txtai_reranker": self.config.txtai_reranker,
             "txtai_graph": self.config.txtai_graph,

--- a/tests/unit/bricks/search/test_daemon_bm25_only.py
+++ b/tests/unit/bricks/search/test_daemon_bm25_only.py
@@ -1,0 +1,83 @@
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon
+
+
+@pytest.mark.asyncio
+async def test_bm25_only_startup_does_not_construct_txtai_backend(monkeypatch: pytest.MonkeyPatch):
+    import nexus.bricks.search.txtai_backend as txtai_backend
+
+    constructed = False
+
+    class FakeTxtaiBackend:
+        def __init__(self, **_: Any) -> None:
+            nonlocal constructed
+            constructed = True
+
+        def kickoff_startup(self) -> None:
+            pass
+
+        async def shutdown(self) -> None:
+            pass
+
+    monkeypatch.setattr(txtai_backend, "TxtaiBackend", FakeTxtaiBackend)
+
+    daemon = SearchDaemon(
+        DaemonConfig(
+            database_url=None,
+            txtai_model=None,
+            vector_warmup_enabled=False,
+            refresh_enabled=False,
+            scope_refresh_seconds=0,
+        )
+    )
+
+    try:
+        await daemon.startup()
+
+        assert constructed is False
+        assert daemon._backend is None
+        assert daemon.get_health()["backend"] == "legacy"
+    finally:
+        await daemon.shutdown()
+
+
+@pytest.mark.asyncio
+async def test_configured_txtai_model_still_constructs_backend(monkeypatch: pytest.MonkeyPatch):
+    import nexus.bricks.search.txtai_backend as txtai_backend
+
+    constructed_with: dict[str, Any] = {}
+
+    class FakeTxtaiBackend:
+        def __init__(self, **kwargs: Any) -> None:
+            constructed_with.update(kwargs)
+
+        def kickoff_startup(self) -> None:
+            pass
+
+        async def shutdown(self) -> None:
+            pass
+
+    monkeypatch.setattr(txtai_backend, "TxtaiBackend", FakeTxtaiBackend)
+
+    daemon = SearchDaemon(
+        DaemonConfig(
+            database_url=None,
+            txtai_model="openai/text-embedding-3-small",
+            vector_warmup_enabled=False,
+            refresh_enabled=False,
+            scope_refresh_seconds=0,
+        )
+    )
+
+    try:
+        await daemon.startup()
+
+        assert constructed_with["model"] == "openai/text-embedding-3-small"
+        assert daemon._backend is not None
+    finally:
+        await daemon.shutdown()


### PR DESCRIPTION
## Summary
- skip SearchDaemon txtai backend construction when runtime config resolves to BM25-only mode
- keep explicit embedding-model deployments on the txtai/hybrid path
- add regression coverage for both BM25-only and configured-model startup

## Root cause
Docker Publish job 74162018203 failed in the "Start Nexus edge container" step. The container logged `Search backend mode: bm25-only`, then started the txtai backend anyway and loaded FAISS before exiting with `Illegal instruction (core dumped)`. In default Docker deployments with no API key or explicit local embedding model, BM25-only mode should use the daemon BM25/FTS keyword path and avoid txtai/faiss native startup entirely.

## Verification
- `/Users/tafeng/.local/bin/uv run pytest -o addopts='' tests/unit/server/lifespan/test_search_lifespan.py tests/unit/bricks/search/test_daemon_bm25_only.py -q`
- `/Users/tafeng/.local/bin/uv run ruff check src/nexus/bricks/search/daemon.py tests/unit/bricks/search/test_daemon_bm25_only.py`
- `git diff --check`
- commit hook: pre-commit suite passed, including ruff format and mypy