### PR TITLE
fix(nexusd-cluster): share/join CLI subcommands actually drive raft contract

### DIFF
--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -481,6 +481,27 @@ async fn run_share(
         zm.create_zone(new_zone_id, peers_str)
             .map_err(|e| anyhow::anyhow!("create_zone({}): {}", new_zone_id, e))?;
     }
+
+    // ``share_subtree_core`` is a leader-required raft proposal
+    // against ``parent_zone``.  The freshly-opened ZoneManager has
+    // not finished election yet, so without this wait we hit
+    // ``NotLeader { leader_hint: Some(self_id) }`` — surfaced today
+    // during cross-machine smoke (PR #4014 follow-up).  10 s covers
+    // a few election timeouts; if we still are not leader, quorum
+    // for ``parent_zone`` is unreachable and the operator must
+    // resolve that before retrying.
+    let parent_handle = zm.get_zone(parent_zone).ok_or_else(|| {
+        anyhow::anyhow!("share: parent zone '{}' not found in storage", parent_zone)
+    })?;
+    if !parent_handle.wait_for_leader(std::time::Duration::from_secs(10)) {
+        anyhow::bail!(
+            "share: did not become leader of '{}' within 10s (leader hint: {:?}); \
+             quorum for parent zone is unreachable from this node",
+            parent_zone,
+            parent_handle.leader_id(),
+        );
+    }
+
     let copied = zm
         .share_subtree_core(parent_zone, path, new_zone_id)
         .map_err(|e| anyhow::anyhow!("share_subtree: {}", e))?;

--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -28,7 +28,7 @@ use kernel::core::dcache::DT_MOUNT;
 use kernel::kernel::Kernel;
 
 use nexus_raft::distributed_coordinator::{
-    bootstrap_or_join_root, read_or_mint_node_id, validate_peers_excludes_self,
+    bootstrap_or_join_zone, read_or_mint_node_id, validate_peers_excludes_self,
 };
 use nexus_raft::federation::{parse_federation_env, ENV_FEDERATION_MOUNTS, ENV_FEDERATION_ZONES};
 use nexus_raft::transport::{bootstrap_tls, NodeAddress};
@@ -207,7 +207,7 @@ async fn main() -> Result<()> {
 /// `node_id` minted/loaded from `<data_dir>/.node_id` plus the
 /// structured peer address book and self-address derived from
 /// `--bind-addr`/`--hostname`.  `run_daemon` hands the lot to
-/// [`bootstrap_or_join_root`] which owns the actual root-zone
+/// [`bootstrap_or_join_zone`] which owns the actual root-zone
 /// dispatch.
 struct ZoneManagerBundle {
     zm: std::sync::Arc<ZoneManager>,
@@ -268,7 +268,7 @@ fn open_zone_manager(common: &CommonArgs) -> Result<ZoneManagerBundle> {
     // Parse `--peers` into structured `NodeAddress` entries — address
     // book only.  ZoneManager seeds its transport peer map from this;
     // ConfState is independent (mutated only by ConfChange via
-    // JoinZone driven by `bootstrap_or_join_root`).
+    // JoinZone driven by `bootstrap_or_join_zone`).
     let peer_addrs: Vec<NodeAddress> = NodeAddress::parse_peer_list(&common.peers, use_tls)
         .map_err(|e| anyhow::anyhow!("--peers/NEXUS_PEERS parse: {}", e))?;
     let peers_str: Vec<String> = peer_addrs.iter().map(NodeAddress::to_raft_peer_str).collect();
@@ -340,7 +340,7 @@ async fn run_daemon(common: CommonArgs) -> Result<()> {
         .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true"))
         .unwrap_or(false);
 
-    // `bootstrap_or_join_root` is a sync helper that, in branch 3
+    // `bootstrap_or_join_zone` is a sync helper that, in branch 3
     // (wait-and-join), spins a nested `tokio::runtime` to drive the
     // JoinZone retry loop's RPCs.  Python `nexusd::init_from_env`
     // calls it from a sync PyO3 entry point — no outer runtime — so
@@ -356,17 +356,19 @@ async fn run_daemon(common: CommonArgs) -> Result<()> {
     let self_addr_for_bootstrap = self_address.clone();
     let peer_addrs_for_bootstrap = peer_addrs.clone();
     tokio::task::spawn_blocking(move || {
-        bootstrap_or_join_root(
+        bootstrap_or_join_zone(
             zm_for_bootstrap.as_ref(),
+            "root",
             node_id,
             &self_addr_for_bootstrap,
             &peer_addrs_for_bootstrap,
             bootstrap_new,
+            /* max_attempts */ None, // daemon boot — retry forever
         )
     })
     .await
     .map_err(|e| anyhow::anyhow!("bootstrap join task panicked: {}", e))?
-    .map_err(|e| anyhow::anyhow!("bootstrap_or_join_root: {}", e))?;
+    .map_err(|e| anyhow::anyhow!("bootstrap_or_join_zone: {}", e))?;
 
     // `bootstrap_static` — invoked below when federation env vars are
     // set — is `NEXUS_FEDERATION_ZONES`/`_MOUNTS` driven and only

--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -610,17 +610,57 @@ async fn run_join(
     local_path: &str,
     parent_zone: &str,
 ) -> Result<()> {
-    let ZoneManagerBundle { zm, .. } = open_zone_manager(&common)?;
-    // Treat the supplied peer as the only known voter; raft will
-    // discover the rest via the remote's ConfState once we propose.
-    let peers = vec![peer_addr.to_string()];
+    let ZoneManagerBundle {
+        zm,
+        node_id,
+        self_address,
+        ..
+    } = open_zone_manager(&common)?;
 
-    if zm.get_zone(remote_zone_id).is_none() {
-        // CLI `join` defaults to full voter; learner promotion is reserved
-        // for the gRPC path (PyZoneManager.join_zone exposes the flag).
-        zm.join_zone(remote_zone_id, peers, false)
-            .map_err(|e| anyhow::anyhow!("join_zone({}): {}", remote_zone_id, e))?;
-    }
+    // Pre-#3996 (and pre-this commit) ``run_join`` only invoked
+    // ``zm.join_zone(remote_zone_id, peers, false)`` — that registers
+    // the zone locally with ``skip_bootstrap=true`` but never tells
+    // the leader on ``peer_addr`` "I want in".  No JoinZone RPC fires,
+    // no AddNode commits, the joiner waits forever after restart.
+    //
+    // Drive the same SSOT machinery ``init_from_env`` and
+    // ``run_daemon`` use for the root zone:
+    // ``bootstrap_or_join_zone`` with ``bootstrap_new=false``.  That
+    // (a) registers the zone locally with ``skip_bootstrap=true`` so
+    // the local gRPC server can serve append-entries from the leader
+    // once AddNode commits, then (b) sends ``JoinZone`` RPC to
+    // ``peer_addr``, then (c) returns once the leader's response
+    // confirms AddNode + the snapshot has installed authoritative
+    // ConfState locally.
+    //
+    // ``max_attempts=Some(15)`` × ``JOIN_ZONE_RETRY_INTERVAL`` (2 s)
+    // ≈ 30 s upper bound on the operator command — long enough to
+    // absorb a leader election round on the remote, short enough that
+    // a stuck command terminates with a clear error rather than
+    // hanging forever like the daemon-boot path does.
+    let use_tls = !common.no_tls;
+    let peer = NodeAddress::parse(peer_addr, use_tls)
+        .map_err(|e| anyhow::anyhow!("--peer-addr parse '{}': {}", peer_addr, e))?;
+    let peer_addrs = vec![peer];
+
+    let zm_for_join = zm.clone();
+    let self_addr_for_join = self_address.clone();
+    let zone_id_for_join = remote_zone_id.to_string();
+    tokio::task::spawn_blocking(move || {
+        nexus_raft::distributed_coordinator::bootstrap_or_join_zone(
+            zm_for_join.as_ref(),
+            &zone_id_for_join,
+            node_id,
+            &self_addr_for_join,
+            &peer_addrs,
+            /* bootstrap_new */ false,
+            /* max_attempts */ Some(15),
+        )
+    })
+    .await
+    .map_err(|e| anyhow::anyhow!("join task panicked: {}", e))?
+    .map_err(|e| anyhow::anyhow!("bootstrap_or_join_zone({}): {}", remote_zone_id, e))?;
+
     zm.mount(parent_zone, local_path, remote_zone_id, true)
         .map_err(|e| anyhow::anyhow!("mount: {}", e))?;
 

--- a/rust/raft/src/distributed_coordinator.rs
+++ b/rust/raft/src/distributed_coordinator.rs
@@ -49,7 +49,7 @@ use crate::{TlsFiles, ZoneManager};
 /// Architecture: `docs/architecture/federation-memo.md` § 6.3.1.
 const NODE_ID_FILE: &str = ".node_id";
 
-/// Cadence for `bootstrap_or_join_root`'s JoinZone retry loop when
+/// Cadence for `bootstrap_or_join_zone`'s JoinZone retry loop when
 /// every peer in NEXUS_PEERS is unreachable.  Indefinite by design —
 /// the daemon waits for the operator to bring up the first peer with
 /// `NEXUS_BOOTSTRAP_NEW=1`; any deadline here would just make the
@@ -240,7 +240,7 @@ impl Default for RaftDistributedCoordinator {
 ///
 /// Public so non-`init_from_env` boot paths (cluster-profile binary
 /// `nexusd-cluster::run_daemon`) share the same SSOT for raft node
-/// identity.  See `bootstrap_or_join_root` for why opaque random IDs
+/// identity.  See `bootstrap_or_join_zone` for why opaque random IDs
 /// are required under raft-rs 0.7's stale-`Progress` heartbeat
 /// invariant.
 pub fn read_or_mint_node_id(zones_dir: &str) -> Result<u64, String> {
@@ -340,40 +340,60 @@ pub fn validate_peers_excludes_self(
     Ok(())
 }
 
-/// Bring root zone online — dispatch table for the three bootstrap
-/// branches under the opaque-ID contract.
+/// Bring a zone online — dispatch table for the three bootstrap
+/// branches under the opaque-ID contract.  Generalised over `zone_id`
+/// so the same SSOT machinery serves:
 ///
-///   1. **Restart** — `zm.get_zone("root").is_some()` means
+///   * `init_from_env` and `nexusd-cluster::run_daemon` for the root
+///     zone (`zone_id="root"`, `max_attempts=None` — daemon boot path
+///     wants forever-retry on misconfig).
+///   * `nexusd-cluster::run_join` for non-root zones via the offline
+///     `join` subcommand (`zone_id=<remote_zone>`,
+///     `max_attempts=Some(N)` — CLI must terminate, so cap retries).
+///   * Future Python `nexusd` `federation_create_zone` /
+///     `federation_join` RPC handlers can call the same helper.
+///
+/// Branches:
+///
+///   1. **Restart** — `zm.get_zone(zone_id).is_some()` means
 ///      `open_existing_zones_from_disk` already loaded the local
-///      replica from `<zones_dir>/root/raft/raft.redb`.  Persisted
+///      replica from `<zones_dir>/<zone_id>/raft/raft.redb`.  Persisted
 ///      ConfState is authoritative; we just resume from it.
 ///
-///   2. **Fresh create** — `bootstrap_new=true` (operator set
-///      `NEXUS_BOOTSTRAP_NEW=1`).  Create a 1-voter cluster
-///      consisting of `self.node_id` only.  Other nodes will land in
-///      branch 3 and JoinZone here.  Without the operator flag this
-///      path is forbidden — accidentally creating a second 1-voter
-///      cluster on a joiner would partition the federation.
+///   2. **Fresh create** — `bootstrap_new=true`.  Create a 1-voter
+///      cluster consisting of `self.node_id` only.  Other nodes will
+///      land in branch 3 and JoinZone here.  Without the operator
+///      flag this path is forbidden — accidentally creating a second
+///      1-voter cluster on a joiner would partition the federation.
 ///
-///   3. **Wait-and-join** — empty storage, no flag.  Loop forever
-///      calling JoinZone RPC against each peer in the address book.
-///      The leader's response commits a `ConfChangeV2(AddNode(self))`;
-///      we then locally `join_zone(skip_bootstrap=true)` so the
+///   3. **Wait-and-join** — empty storage, no flag.  Loop calling
+///      JoinZone RPC against each peer in the address book.  The
+///      leader's response commits a `ConfChangeV2(AddNode(self))`;
+///      we locally `join_zone(skip_bootstrap=true)` first so the
 ///      leader's snapshot installs the authoritative ConfState.
-///      No deadline by design — misconfig surfaces as "daemon stays
-///      up retrying" rather than a silent exit.
-pub fn bootstrap_or_join_root(
+///      `max_attempts=None` retries forever (daemon boot — misconfig
+///      surfaces as "daemon stays up retrying" rather than a silent
+///      exit); `max_attempts=Some(N)` bounds the loop to N rounds
+///      (CLI — operator command must terminate).
+///
+/// Returns `Err` with a descriptive string if `max_attempts` was
+/// exhausted without a successful JoinZone — caller surfaces this to
+/// the operator.
+pub fn bootstrap_or_join_zone(
     zm: &ZoneManager,
+    zone_id: &str,
     node_id: u64,
     self_address: &str,
     peer_addrs: &[NodeAddress],
     bootstrap_new: bool,
+    max_attempts: Option<u32>,
 ) -> Result<(), String> {
     // Branch 1: zone already loaded from disk.
-    if zm.get_zone("root").is_some() {
+    if zm.get_zone(zone_id).is_some() {
         tracing::info!(
             node_id,
-            "root zone loaded from persisted storage; resuming from ConfState",
+            zone = %zone_id,
+            "zone loaded from persisted storage; resuming from ConfState",
         );
         return Ok(());
     }
@@ -382,13 +402,14 @@ pub fn bootstrap_or_join_root(
     if bootstrap_new {
         tracing::warn!(
             node_id,
+            zone = %zone_id,
             self_address = %self_address,
-            "NEXUS_BOOTSTRAP_NEW honored; creating 1-voter root zone. \
+            "NEXUS_BOOTSTRAP_NEW honored; creating 1-voter zone. \
              Other nodes must JoinZone."
         );
         let self_peer = format!("{node_id}@{self_address}");
-        zm.create_zone("root", vec![self_peer])
-            .map_err(|e| format!("create_zone(root): {e}"))?;
+        zm.create_zone(zone_id, vec![self_peer])
+            .map_err(|e| format!("create_zone({zone_id}): {e}"))?;
         return Ok(());
     }
 
@@ -397,7 +418,7 @@ pub fn bootstrap_or_join_root(
     // Empty peer_addrs (no NEXUS_PEERS) + flag unset = "no cluster
     // intent yet" — daemon comes up federation-active but zoneless.
     // An operator can later set NEXUS_BOOTSTRAP_NEW=1 + restart, or
-    // call `coordinator.create_zone("root")` via RPC under the
+    // call `coordinator.create_zone(zone_id)` via RPC under the
     // dynamic-bootstrap mode.  Without this early return, branch 3
     // loops forever with no targets — a hang for any test or
     // single-node deployment that constructs a kernel without
@@ -405,16 +426,18 @@ pub fn bootstrap_or_join_root(
     if peer_addrs.is_empty() {
         tracing::info!(
             node_id,
-            "empty storage, no NEXUS_PEERS, no NEXUS_BOOTSTRAP_NEW — \
-             federation up but rootless; operator drives create_zone later",
+            zone = %zone_id,
+            "empty storage, no peers, no NEXUS_BOOTSTRAP_NEW — \
+             federation up but zoneless; operator drives create_zone later",
         );
         return Ok(());
     }
     tracing::info!(
         node_id,
+        zone = %zone_id,
         peer_count = peer_addrs.len(),
-        "empty storage and NEXUS_BOOTSTRAP_NEW unset — \
-         retrying JoinZone against NEXUS_PEERS indefinitely",
+        max_attempts = ?max_attempts,
+        "empty storage and NEXUS_BOOTSTRAP_NEW unset — retrying JoinZone",
     );
 
     // Spin a small temporary multi-thread runtime for the JoinZone
@@ -430,6 +453,7 @@ pub fn bootstrap_or_join_root(
         .build()
         .map_err(|e| format!("bootstrap join runtime: {e}"))?;
 
+    let mut attempts: u32 = 0;
     loop {
         for peer in peer_addrs {
             // No self-skip here.  Contract: `peer_addrs` lists OTHER
@@ -450,11 +474,12 @@ pub fn bootstrap_or_join_root(
                 // times out the JoinZone RPC.  Local register is
                 // idempotent — calling it on every retry costs only a
                 // hashmap lookup.
-                if zm.get_zone("root").is_none() {
+                if zm.get_zone(zone_id).is_none() {
                     let zone_peers = vec![peer.to_raft_peer_str()];
-                    if let Err(e) = zm.join_zone("root", zone_peers, /* learner */ false) {
+                    if let Err(e) = zm.join_zone(zone_id, zone_peers, /* learner */ false) {
                         tracing::warn!(
                             endpoint = %endpoint,
+                            zone = %zone_id,
                             error = %e,
                             "local join_zone setup failed; will retry next peer",
                         );
@@ -463,7 +488,7 @@ pub fn bootstrap_or_join_root(
                 }
                 let attempt = join_runtime.block_on(crate::transport::call_join_zone_rpc(
                     &endpoint,
-                    "root",
+                    zone_id,
                     node_id,
                     self_address,
                     /* as_learner */ false,
@@ -473,8 +498,9 @@ pub fn bootstrap_or_join_root(
                     Ok(result) if result.success => {
                         tracing::info!(
                             endpoint = %endpoint,
+                            zone = %zone_id,
                             node_id,
-                            "joined root zone via leader",
+                            "joined zone via leader",
                         );
                         return Ok(());
                     }
@@ -484,6 +510,7 @@ pub fn bootstrap_or_join_root(
                                 tracing::info!(
                                     from = %endpoint,
                                     to = %addr,
+                                    zone = %zone_id,
                                     "JoinZone redirect to leader",
                                 );
                                 endpoint = addr.clone();
@@ -493,6 +520,7 @@ pub fn bootstrap_or_join_root(
                         }
                         tracing::debug!(
                             endpoint = %endpoint,
+                            zone = %zone_id,
                             error = ?result.error,
                             "JoinZone non-success; trying next peer",
                         );
@@ -501,12 +529,22 @@ pub fn bootstrap_or_join_root(
                     Err(e) => {
                         tracing::debug!(
                             endpoint = %endpoint,
+                            zone = %zone_id,
                             error = %e,
                             "JoinZone RPC error; trying next peer",
                         );
                         break;
                     }
                 }
+            }
+        }
+        attempts = attempts.saturating_add(1);
+        if let Some(max) = max_attempts {
+            if attempts >= max {
+                return Err(format!(
+                    "JoinZone({zone_id}): no peer accepted after {attempts} attempts; \
+                     leader unreachable or quorum lost on remote zone",
+                ));
             }
         }
         std::thread::sleep(JOIN_ZONE_RETRY_INTERVAL);
@@ -546,7 +584,7 @@ impl RaftDistributedCoordinator {
         //      flag unset → block on JoinZone forever.  Non-empty
         //      storage → resume from persisted ConfState.
         //
-        // See `bootstrap_or_join_root` for the dispatch table.
+        // See `bootstrap_or_join_zone` for the dispatch table.
         let peers_csv = std::env::var("NEXUS_PEERS").unwrap_or_default();
         let bootstrap_new = std::env::var("NEXUS_BOOTSTRAP_NEW")
             .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
@@ -692,10 +730,19 @@ impl RaftDistributedCoordinator {
 
         // Bring root zone online — restart-from-disk, fresh-create, or
         // wait-and-join, depending on storage state and the operator
-        // flag.  Blocks indefinitely under the join branch (no deadline)
-        // so misconfig surfaces as "daemon stays up retrying" rather
-        // than "daemon exits after timeout".  See `bootstrap_or_join_root`.
-        bootstrap_or_join_root(zm.as_ref(), node_id, &self_addr, &peer_addrs, bootstrap_new)?;
+        // flag.  `max_attempts=None` blocks indefinitely under the join
+        // branch (no deadline) so misconfig surfaces as "daemon stays
+        // up retrying" rather than "daemon exits after timeout".
+        // See `bootstrap_or_join_zone`.
+        bootstrap_or_join_zone(
+            zm.as_ref(),
+            "root",
+            node_id,
+            &self_addr,
+            &peer_addrs,
+            bootstrap_new,
+            /* max_attempts */ None,
+        )?;
 
         // Federation zones listed in `NEXUS_FEDERATION_ZONES` are
         // brought up only when this node bootstrapped root (1-voter

--- a/rust/raft/src/zone_handle.rs
+++ b/rust/raft/src/zone_handle.rs
@@ -67,6 +67,30 @@ impl ZoneHandle {
         self.node.leader_id()
     }
 
+    /// Block until this node becomes leader of the zone, or the
+    /// timeout elapses.  Returns `true` if leader, `false` on timeout.
+    ///
+    /// `is_leader()` is an atomic read on a cached value updated by
+    /// the raft driver thread, so the poll is cheap (no channel, no
+    /// lock).  Used by leader-required raft proposals (e.g.
+    /// ``share_subtree_core`` invoked from offline operator
+    /// subcommands) that open a fresh ZoneManager and must wait for
+    /// election to settle before issuing a propose.
+    ///
+    /// Sleep interval is 50 ms — small enough that even a snappy
+    /// ~150 ms election window is caught quickly, large enough that
+    /// the polling cost is invisible.
+    pub fn wait_for_leader(&self, timeout: std::time::Duration) -> bool {
+        let deadline = std::time::Instant::now() + timeout;
+        while std::time::Instant::now() < deadline {
+            if self.node.is_leader() {
+                return true;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        self.node.is_leader()
+    }
+
     pub fn commit_index(&self) -> u64 {
         self.node.commit_index()
     }


### PR DESCRIPTION
## Summary

Cross-machine dynamic-bootstrap smoke (Layer 3, Win+Mac) found that
``nexusd-cluster``'s offline ``share`` and ``join`` subcommands have
been incomplete: ``share`` reliably failed with NotLeader because it
proposed against the parent zone before raft elected; ``join`` never
sent a JoinZone RPC at all, so the leader on ``peer_addr`` never
proposed AddNode and the joiner waited forever on restart.

Both fixes share one structural change: generalize
``bootstrap_or_join_root`` (already SSOT for Python ``nexusd``'s
``init_from_env`` and ``nexusd-cluster::run_daemon``) over
``zone_id`` and ``max_attempts``, then drive the same machinery
from the CLI subcommands.

## Commits

1. ``refactor(raft)``: generalize ``bootstrap_or_join_root`` →
   ``bootstrap_or_join_zone(zone_id, max_attempts: Option<u32>)``.
   Existing callers pass ``("root", None)`` — no behaviour change.
2. ``feat(raft)``: ``ZoneHandle::wait_for_leader(timeout)`` —
   atomic-poll helper for leader-required raft proposals.
3. ``fix(nexusd-cluster)``: ``run_share`` waits up to 10 s on
   ``parent_handle.wait_for_leader`` before issuing
   ``share_subtree_core``. Fail-loud if not leader within window
   (quorum unreachable from this side).
4. ``fix(nexusd-cluster)``: ``run_join`` calls
   ``bootstrap_or_join_zone`` with ``max_attempts=Some(15)``,
   wrapped in ``spawn_blocking`` (mirrors PR #4011's pattern for
   nested-runtime safety). Now actually fires JoinZone RPC against
   ``peer_addr`` and waits for AddNode + snapshot before exiting.

## Test plan

- [x] ``cargo check -p raft@0.1.0 --features grpc`` clean
- [x] ``cargo check -p nexus-cluster`` clean
- [x] ``cargo clippy -p nexus-cluster -p raft@0.1.0 --features grpc -- -D warnings`` clean
- [x] Local smoke: ``nexusd-cluster join 9999@127.0.0.1:9999 sharedzone /shared`` (unreachable peer) → error after 15 attempts (~59s) with clear "leader unreachable" message rather than hanging forever
- [ ] CI green (raft, federation E2E, lint, slim wheel)
- [ ] Post-merge: cross-machine dynamic ``share``/``join`` cycle on Win + Mac — should now form 2-voter ConfState for ``sharedzone``

## Why this is the right shape (verified against the principles)

- **SSOT**: ``bootstrap_or_join_zone`` is the single retry-loop
  machine for any zone (root + non-root + future Python
  ``federation_create_zone``). ``run_share`` and ``run_join`` are
  thin orchestrators on top.
- **DRY**: deletes the duplicate ``zm.join_zone(...)`` direct call
  in ``run_join``.
- **No boundary leak**: raft helpers stay in raft crate; CLI passes
  ``max_attempts`` and consumes ``Result``.
- **Simpler contract**: the prior approach (raft helper forever-retries,
  CLI wraps with ``tokio::time::timeout``) was patch-over-patch —
  std::thread::sleep inside the loop ignores ``timeout``'s cancel.
  Making retry behaviour an input parameter is one mechanism, not two.
- **Raft contract**: leader-required proposals wait for leadership;
  joiner uses the standard JoinZone → AddNode pattern.
- **Perf**: ``is_leader()`` is an atomic read on a cached value, no
  channel.  Sleep-based retry doesn't burn CPU.

## Followups (out of scope)

- F5 — auto-GC of stale voters in ConfState (independent plan
  followup; surfaced separately during cross-machine smoke)
- Long-flow E2E tests via integration-test-generator (covers the
  share/join round-trip end-to-end; will pin this PR's contract
  alongside the static + wipe-rejoin scenarios)