### PR TITLE
fix(scripts): cluster_smoke_xmachine regex post-PR-#4023 log rename

### DIFF
--- a/scripts/cluster_smoke_xmachine.py
+++ b/scripts/cluster_smoke_xmachine.py
@@ -231,14 +231,14 @@ def main() -> int:
         if args.bootstrap_new:
             line = wait_for_marker(
                 log_path,
-                re.compile(r"NEXUS_BOOTSTRAP_NEW honored.*creating 1-voter root zone"),
+                re.compile(r"NEXUS_BOOTSTRAP_NEW honored.*creating 1-voter zone"),
                 timeout_s=30.0,
                 label="founder create 1-voter zone",
             )
         else:
             line = wait_for_marker(
                 log_path,
-                re.compile(r"retrying JoinZone against NEXUS_PEERS|joined root zone via leader"),
+                re.compile(r"retrying JoinZone|joined zone via leader"),
                 timeout_s=30.0,
                 label="joiner enters retry-or-join",
             )
@@ -259,7 +259,7 @@ def main() -> int:
         else:
             line = wait_for_marker(
                 log_path,
-                re.compile(r"joined root zone via leader|raft\.conf_change\.applied"),
+                re.compile(r"joined zone via leader|raft\.conf_change\.applied"),
                 timeout_s=args.cluster_form_timeout,
                 label="joiner sees AddNode applied",
             )


### PR DESCRIPTION
## Summary

PR #4023 generalised ``bootstrap_or_join_root`` to
``bootstrap_or_join_zone(zone_id, ...)`` and dropped the
now-misleading ``"root"`` qualifier from three log strings.  The
smoke script's stage-2 / stage-3 regex still grepped the old
strings, so cross-machine smoke after #4023 reported "joined zone
marker absent" even when the daemon had successfully joined.

Aligns the regex with the current log wording.  No daemon
behaviour change — pure script-side fix.

## Test plan

- [x] Syntax check
- [ ] CI green
- [ ] Re-run cross-machine static-bootstrap smoke after merge — stage 2/3 markers should match without timing out