### PR TITLE
refactor(kernel): collapse commit_metadata/commit_delete; metastore_put derives zone from meta

### DIFF
--- a/rust/kernel/src/kernel/io.rs
+++ b/rust/kernel/src/kernel/io.rs
@@ -639,11 +639,18 @@ impl Kernel {
                     created_at_ms,
                     Some(now_ms),
                 );
-                // Atomic commit — metastore (raft) first, dcache on
-                // success. Releases the VFS lock before propagating
-                // so the next caller doesn't block on stale state if
-                // raft propose fails.
-                if let Err(e) = self.commit_metadata(path, &route.mount_point, meta) {
+                // Atomic commit — metastore (raft) write. Releases the VFS
+                // lock before propagating so the next caller doesn't block
+                // on stale state if raft propose fails. Hot path: bypass
+                // the routing wrapper and dispatch through the trait via
+                // route.metastore (already resolved above).
+                let put_res = self
+                    .with_metastore_route(&route, |ms| ms.put(path, meta))
+                    .ok_or_else(|| KernelError::IOError("no metastore wired".into()))
+                    .and_then(|r| {
+                        r.map_err(|e| KernelError::IOError(format!("metastore_put({path}): {e:?}")))
+                    });
+                if let Err(e) = put_res {
                     self.lock_manager.do_release(lock_handle);
                     return Err(e);
                 }
@@ -1020,7 +1027,13 @@ impl Kernel {
         // from a failed backend delete are collected by a background GC sweep.
         // The inverse ordering (backend-first) risks deleting bytes while leaving
         // live metadata if the metastore call fails — unrecoverable data loss.
-        if let Err(e) = self.commit_delete(path, &route.mount_point) {
+        let del_res = self
+            .with_metastore_route(&route, |ms| ms.delete(path))
+            .ok_or_else(|| KernelError::IOError("no metastore wired".into()))
+            .and_then(|r| {
+                r.map_err(|e| KernelError::IOError(format!("metastore_delete({path}): {e:?}")))
+            });
+        if let Err(e) = del_res {
             self.lock_manager.do_release(lock_handle);
             return Err(e);
         }
@@ -1743,7 +1756,7 @@ impl Kernel {
         // parent path (caught by tests/unit/core/test_mount_directory_creation).
         if route.backend_path.is_empty() {
             if parents {
-                self.ensure_parent_directories(path, ctx, &route.mount_point)?;
+                self.ensure_parent_directories(path, ctx, &route)?;
             }
             return Ok(SysMkdirResult {
                 hit: true,
@@ -1773,7 +1786,7 @@ impl Kernel {
             // Implicit dir: fall through to create explicit DT_DIR entry.
             if explicit_exists {
                 if parents {
-                    self.ensure_parent_directories(path, ctx, &route.mount_point)?;
+                    self.ensure_parent_directories(path, ctx, &route)?;
                 }
                 return Ok(SysMkdirResult {
                     hit: true,
@@ -1789,7 +1802,7 @@ impl Kernel {
 
         // 5. Ensure parent directories
         if parents {
-            self.ensure_parent_directories(path, ctx, &route.mount_point)?;
+            self.ensure_parent_directories(path, ctx, &route)?;
         }
 
         // 6. Create directory metadata in metastore (per-mount or global) — full path
@@ -1804,8 +1817,10 @@ impl Kernel {
             None,
             None,
         );
-        // 7. Atomic commit — metastore (raft) first, dcache on success.
-        self.commit_metadata(path, &route.mount_point, meta)?;
+        // 7. Atomic commit via the per-mount metastore Arc on RouteResult.
+        self.with_metastore_route(&route, |ms| ms.put(path, meta))
+            .ok_or_else(|| KernelError::IOError("no metastore wired".into()))?
+            .map_err(|e| KernelError::IOError(format!("metastore_put({path}): {e:?}")))?;
 
         // 8. OBSERVE-phase dispatch (§11 OBSERVE): queue DirCreate.
         // Only fires on the newly-created path — the early return at
@@ -1830,7 +1845,7 @@ impl Kernel {
         &self,
         path: &str,
         ctx: &OperationContext,
-        mount_point: &str,
+        route: &crate::vfs_router::RouteResult,
     ) -> Result<(), KernelError> {
         // Walk up path from parent to root, collecting missing dirs.
         let mut cur = path;
@@ -1844,7 +1859,7 @@ impl Kernel {
                         break;
                     }
                     let exists = self
-                        .with_metastore(mount_point, |ms| ms.exists(cur).unwrap_or(true))
+                        .with_metastore_route(route, |ms| ms.exists(cur).unwrap_or(true))
                         .unwrap_or(true);
                     if !exists {
                         to_create.push(cur.to_string());
@@ -1869,7 +1884,9 @@ impl Kernel {
                 None,
                 None,
             );
-            self.commit_metadata(dir_ref, mount_point, meta)?;
+            self.with_metastore_route(route, |ms| ms.put(dir_ref, meta))
+                .ok_or_else(|| KernelError::IOError("no metastore wired".into()))?
+                .map_err(|e| KernelError::IOError(format!("metastore_put({dir_ref}): {e:?}")))?;
         }
         Ok(())
     }
@@ -1947,9 +1964,11 @@ impl Kernel {
 
         // 7. Atomic delete — metastore is the SSOT. Per-key cache
         // invalidation already happened: ``delete_batch`` invalidated
-        // each child's cache row, and ``commit_delete`` → ``ms.delete``
-        // invalidates the parent's. No kernel-global cache to evict.
-        self.commit_delete(path, &route.mount_point)?;
+        // each child's cache row, and ``ms.delete`` invalidates the
+        // parent's. No kernel-global cache to evict.
+        self.with_metastore_route(&route, |ms| ms.delete(path))
+            .ok_or_else(|| KernelError::IOError("no metastore wired".into()))?
+            .map_err(|e| KernelError::IOError(format!("metastore_delete({path}): {e:?}")))?;
 
         // 9. OBSERVE-phase dispatch (§11 OBSERVE): queue DirDelete.
         // Like sys_mkdir, only the top-level rmdir event fires —
@@ -2144,14 +2163,12 @@ impl Kernel {
             }
         }
 
-        // 4b. Atomic per-item commit. Per-mount items go through
-        // commit_metadata (raft propose, ms.put then dcache). Global
-        // items (no per-mount metastore) collect into a batch put
-        // since the global LocalMetaStore can do that as one redb
-        // txn — but we still update dcache only after the txn lands.
-        // Failures flip the corresponding result entry from
-        // hit=true → hit=false so the caller learns which items
-        // actually committed.
+        // 4b. Atomic per-item commit. Per-mount items dispatch through the
+        // mount's own metastore (raft propose for federation zones); global
+        // items (no per-mount metastore) collect into a batch put since the
+        // global LocalMetaStore can do that as one redb txn. Failures flip
+        // the corresponding result entry from hit=true → hit=false so the
+        // caller learns which items actually committed.
         if !batch_meta.is_empty() {
             let mut global_items: Vec<(String, crate::meta_store::FileMetadata)> = Vec::new();
             let mut global_idx: Vec<usize> = Vec::new();
@@ -2162,7 +2179,11 @@ impl Kernel {
                     .map(|e| e.metastore.is_some())
                     .unwrap_or(false);
                 if has_per_mount {
-                    if let Err(_e) = self.commit_metadata(&path, &mp, meta) {
+                    let put_res = self
+                        .with_metastore(&mp, move |ms| ms.put(&path, meta))
+                        .ok_or_else(|| KernelError::IOError("no metastore wired".into()))
+                        .and_then(|r| r.map_err(|e| KernelError::IOError(format!("{e:?}"))));
+                    if let Err(_e) = put_res {
                         // Mark this batch entry as not-hit so the
                         // caller knows the propose didn't commit.
                         if let Some(r) = results.get_mut(idx) {

--- a/rust/kernel/src/kernel/ipc.rs
+++ b/rust/kernel/src/kernel/ipc.rs
@@ -12,15 +12,13 @@ impl Kernel {
 
     /// Create a pipe buffer in the IPC registry.
     ///
-    /// PipeManager owns the buffer; Kernel persists DT_PIPE inode to
-    /// metastore + dcache so sys_read/sys_write dispatch to IPC fast-path.
+    /// PipeManager owns the buffer; Kernel persists DT_PIPE inode so
+    /// sys_read/sys_write dispatch to IPC fast-path.
     pub fn create_pipe(&self, path: &str, capacity: usize) -> Result<(), KernelError> {
         self.pipe_manager
             .create(path, capacity)
             .map_err(pipe_mgr_err)?;
 
-        // Persist DT_PIPE inode (best-effort — metastore may not be wired in tests).
-        let mount_point = self.resolve_mount_point(path, contracts::ROOT_ZONE_ID);
         let meta = self.build_metadata(
             path,
             contracts::ROOT_ZONE_ID,
@@ -32,7 +30,7 @@ impl Kernel {
             None,
             None,
         );
-        self.commit_metadata(path, &mount_point, meta)?;
+        self.metastore_put(path, meta)?;
 
         Ok(())
     }
@@ -41,10 +39,7 @@ impl Kernel {
     pub fn destroy_pipe(&self, path: &str) -> Result<(), KernelError> {
         self.pipe_manager.destroy(path).map_err(pipe_mgr_err)?;
 
-        // Atomic delete — metastore (raft) first, dcache eviction on
-        // success.
-        let mount_point = self.resolve_mount_point(path, contracts::ROOT_ZONE_ID);
-        self.commit_delete(path, &mount_point)?;
+        self.metastore_delete(path)?;
 
         Ok(())
     }
@@ -109,7 +104,6 @@ impl Kernel {
             .create(path, capacity)
             .map_err(stream_mgr_err)?;
 
-        let mount_point = self.resolve_mount_point(path, contracts::ROOT_ZONE_ID);
         let meta = self.build_metadata(
             path,
             contracts::ROOT_ZONE_ID,
@@ -121,7 +115,7 @@ impl Kernel {
             None,
             None,
         );
-        self.commit_metadata(path, &mount_point, meta)?;
+        self.metastore_put(path, meta)?;
 
         Ok(())
     }
@@ -130,10 +124,7 @@ impl Kernel {
     pub fn destroy_stream(&self, path: &str) -> Result<(), KernelError> {
         self.stream_manager.destroy(path).map_err(stream_mgr_err)?;
 
-        // Atomic delete — metastore (raft) first, dcache eviction on
-        // success.
-        let mount_point = self.resolve_mount_point(path, contracts::ROOT_ZONE_ID);
-        self.commit_delete(path, &mount_point)?;
+        self.metastore_delete(path)?;
 
         Ok(())
     }

--- a/rust/kernel/src/kernel/mod.rs
+++ b/rust/kernel/src/kernel/mod.rs
@@ -853,57 +853,6 @@ impl Kernel {
         }
     }
 
-    /// Atomic metadata commit — propose to metastore.
-    ///
-    /// Replaces the legacy "best-effort metastore put + eager dcache
-    /// update" pattern that scattered across 10+ sys_* paths. That
-    /// pattern silently lost data on raft propose failure: leader's
-    /// dcache held the entry but it was never committed to the
-    /// state machine, so followers caught up to leader's
-    /// applied_index without ever seeing the file
-    /// (TestPartialReplicationFailure::test_partition_then_heal CI
-    /// regression — see PR #3890 for the full diagnostic).
-    ///
-    /// MetaStore is the SSOT. Each impl owns an internal cache that
-    /// the `put` write-through populates — there is no longer a
-    /// separate kernel-global cache to keep in sync.
-    pub(crate) fn commit_metadata(
-        &self,
-        path: &str,
-        mount_point: &str,
-        meta: crate::meta_store::FileMetadata,
-    ) -> Result<(), KernelError> {
-        let put_result = self
-            .with_metastore(mount_point, move |ms| ms.put(path, meta))
-            .ok_or_else(|| {
-                KernelError::IOError(format!(
-                    "commit_metadata({path}): no metastore wired for mount {mount_point}"
-                ))
-            })?;
-        put_result.map_err(|e| {
-            KernelError::IOError(format!("commit_metadata({path}): metastore.put: {e:?}"))
-        })?;
-        Ok(())
-    }
-
-    /// Atomic metadata delete — same pattern as `commit_metadata` but
-    /// for the unlink path. The metastore impl invalidates its own
-    /// internal cache before the store delete, so concurrent readers
-    /// never observe a stale hit after the store delete.
-    pub(crate) fn commit_delete(&self, path: &str, mount_point: &str) -> Result<bool, KernelError> {
-        let del_result = self
-            .with_metastore(mount_point, move |ms| ms.delete(path))
-            .ok_or_else(|| {
-                KernelError::IOError(format!(
-                    "commit_delete({path}): no metastore wired for mount {mount_point}"
-                ))
-            })?;
-        let removed = del_result.map_err(|e| {
-            KernelError::IOError(format!("commit_delete({path}): metastore.delete: {e:?}"))
-        })?;
-        Ok(removed)
-    }
-
     /// Resolve metastore for a syscall: per-mount first, then global fallback.
     ///
     /// In federation mode each mount has its own state machine (Raft-backed
@@ -1038,12 +987,21 @@ impl Kernel {
         }
     }
 
+    /// Persist a metadata row.
+    ///
+    /// Routing zone is derived from ``metadata.zone_id`` — the row IS the
+    /// SSOT for which zone owns it, so callers don't pass a separate zone
+    /// parameter. ``None``/``"root"`` falls back to the root namespace.
     pub fn metastore_put(
         &self,
         path: &str,
         mut metadata: crate::meta_store::FileMetadata,
     ) -> Result<(), KernelError> {
-        let mount_point = self.resolve_mount_point(path, contracts::ROOT_ZONE_ID);
+        let zone = metadata
+            .zone_id
+            .as_deref()
+            .unwrap_or(contracts::ROOT_ZONE_ID);
+        let mount_point = self.resolve_mount_point(path, zone);
         metadata.path = path.to_string();
         match self.with_metastore(&mount_point, move |ms| ms.put(path, metadata)) {
             Some(result) => {
@@ -1878,7 +1836,6 @@ impl Kernel {
     /// Write DT_PIPE inode to metastore + dcache (shared by create_pipe and SHM path).
     #[allow(dead_code)]
     fn write_pipe_inode(&self, path: &str, capacity: usize) -> Result<(), KernelError> {
-        let mount_point = self.resolve_mount_point(path, contracts::ROOT_ZONE_ID);
         let meta = self.build_metadata(
             path,
             contracts::ROOT_ZONE_ID,
@@ -1890,13 +1847,12 @@ impl Kernel {
             None,
             None,
         );
-        self.commit_metadata(path, &mount_point, meta)
+        self.metastore_put(path, meta)
     }
 
-    /// Write DT_STREAM inode to metastore + dcache (shared by create_stream and SHM path).
+    /// Write DT_STREAM inode to metastore (shared by create_stream and SHM path).
     #[allow(dead_code)]
     fn write_stream_inode(&self, path: &str, capacity: usize) -> Result<(), KernelError> {
-        let mount_point = self.resolve_mount_point(path, contracts::ROOT_ZONE_ID);
         let meta = self.build_metadata(
             path,
             contracts::ROOT_ZONE_ID,
@@ -1908,22 +1864,20 @@ impl Kernel {
             None,
             None,
         );
-        self.commit_metadata(path, &mount_point, meta)
+        self.metastore_put(path, meta)
     }
 
-    /// DT_DIR: create directory inode via metastore + dcache.
+    /// DT_DIR: create directory inode via metastore.
     fn setattr_create_dir(
         &self,
         path: &str,
         zone_id: &str,
     ) -> Result<SysSetAttrResult, KernelError> {
-        // Route first to locate the right per-mount metastore.
-        let mount_point = self.resolve_mount_point(path, zone_id);
-
         // Idempotent: if DT_DIR (or DT_MOUNT, which is directory-like since
         // a mount point IS a directory) already exists, no-op. This matches
         // ``mkdir(exist_ok=True)`` semantics — a mount creates the directory
         // slot, so a follow-up mkdir on the same path shouldn't fail.
+        let mount_point = self.resolve_mount_point(path, zone_id);
         let existing = self
             .with_metastore(&mount_point, |ms| ms.get(path).ok().flatten())
             .flatten();
@@ -1963,8 +1917,9 @@ impl Kernel {
             Some(now_ms),
             Some(now_ms),
         );
-        // Atomic commit — metastore (raft) first, dcache on success.
-        self.commit_metadata(path, &mount_point, meta)?;
+        // metastore_put derives routing zone from meta.zone_id — set it
+        // above (build_metadata writes zone_id), so this is zone-aware.
+        self.metastore_put(path, meta)?;
 
         Ok(SysSetAttrResult {
             path: path.to_string(),


### PR DESCRIPTION
## Summary

Kernel had two metastore-write entry points doing the same op:

- `metastore_put(path, meta)` — public ABI, **hardcoded `ROOT_ZONE_ID`** for routing (couldn't see federation-zone paths)
- `commit_metadata(path, mount_point, meta)` — `pub(crate)` wrapper that took a pre-resolved `mount_point: &str` so callers with a `RouteResult` in hand could skip a re-route

This is a contract violation:
- **Two functions, same op** — duplicated entry points for "put metadata"
- **Boundary leak** — `mount_point: &str` is a routing-tier artifact bleeding into the metastore API
- **SSOT fuzziness** — both `meta.zone_id` and `mount_point` encoded "which zone owns this row"; the wrapper relied on caller keeping them in sync

## Single resolution (under 6 principles: 简化contract / 架构正确 / SSOT / DRY / Rust-first / perf)

1. **`metastore_put` derives routing zone from `meta.zone_id`** — `meta.zone_id.as_deref().unwrap_or(ROOT)`. The row IS the SSOT for ownership; no separate zone channel.
2. **Delete `commit_metadata` and `commit_delete` entirely.** 13 callers split:
   - **Cold-path** (5 sites: `ipc.rs` 4 + `mod.rs` 2) that did `resolve_mount_point + commit_metadata` back-to-back → plain `self.metastore_put(path, meta)` / `self.metastore_delete(path)`. Same perf, cleaner code.
   - **Hot-path** (6 sites in `io.rs` with `route` already in scope from syscall's earlier `vfs_router.route()`) → `with_metastore_route(&route, \|ms\| ms.put/delete(path, ...))`. This is the existing per-mount Arc routing-tier helper (NOT a metastore-API duplicate); dispatches through the pre-resolved metastore Arc on `RouteResult`, skipping the redundant DashMap re-lookup the wrapper did.
   - **`setattr_create_dir`** → `metastore_put(path, meta)` (now zone-aware via meta).
3. **`ensure_parent_directories` signature** changed from `mount_point: &str` → `route: &RouteResult` so it re-uses `with_metastore_route` for both existence probe and create commit. 3 callers updated.

## End state

- Kernel metastore API: **`metastore_put` + `metastore_delete`** — strictly orthogonal, fully self-routing
- Hot paths bypass the wrapper by calling the trait method through the routing-tier helper (zero extra DashMap lookups vs. before)
- No `mount_point: &str` boundary leak anywhere
- Net **−33 lines** (3 files changed: 71 insertions, 104 deletions)

## Test plan
- [x] `cargo check -p kernel` clean
- [x] `cargo clippy -p kernel --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` (only unrelated `services/` pre-existing diffs)
- [x] `cargo test -p kernel --lib` — 339 passed
- [x] `cargo test -p raft@0.1.0 --lib` — 153 passed
- [ ] CI green