### PR TITLE
feat(raft): explicit BootstrapMode — kill silent mode-mixing footgun

### DIFF
--- a/dockerfiles/docker-compose.dynamic-federation-test.yml
+++ b/dockerfiles/docker-compose.dynamic-federation-test.yml
@@ -77,6 +77,9 @@ services:
       # Founder of the cluster under the opaque-ID contract: creates
       # a 1-voter `root` zone; nexus-2 + witness JoinZone into it.
       NEXUS_BOOTSTRAP_NEW: "1"
+      # Explicit bootstrap intent — `static` for env-driven cluster
+      # formation.  See `BootstrapMode` in `nexus_raft`.
+      NEXUS_BOOTSTRAP_MODE: "static"
 
       # gRPC VFS (bind 0.0.0.0 for cross-container access)
       NEXUS_GRPC_BIND_ALL: "true"
@@ -137,6 +140,9 @@ services:
       NEXUS_PEERS: "nexus-1:2126,witness:2126"
       NEXUS_RAFT_TLS: "false"
       NEXUS_GRPC_BIND_ALL: "true"
+      # Explicit bootstrap intent — `static` for env-driven cluster
+      # formation.  See `BootstrapMode` in `nexus_raft`.
+      NEXUS_BOOTSTRAP_MODE: "static"
 
       NEXUS_DRAGONFLY_URL: ${NEXUS_DRAGONFLY_URL:-redis://dragonfly:6379}
       NEXUS_API_KEY: ${NEXUS_API_KEY:-sk-test-dynamic-federation-key}

--- a/docs/architecture/federation-memo.md
+++ b/docs/architecture/federation-memo.md
@@ -172,13 +172,13 @@ Etcd / TiKV-style opaque IDs + leader-driven `AddNode`.
 
 - **Identity** — `node_id` is an opaque random `u64` minted at first daemon boot, persisted as 8 bytes BE u64 to `<NEXUS_DATA_DIR>/.node_id`.  Decoupling identity from hostname lets a wiped follower rejoin under a fresh ID; the leader's `Progress[new_id]` is created with `matched=0` by `AddNode`, so the first heartbeat carries `m.commit=0` — within `RaftLog::commit_to`'s safe range on a fresh follower (`last_index=0`).  Pinned by [`test_handle_heartbeat_on_empty_follower_with_stale_commit_panics`](../../rust/raft/src/raft/storage.rs).
 - **Address book** — `NEXUS_PEERS` is a hostname → endpoint mapping for OTHER nodes only that seeds the transport peer map.  Self joins the cluster through `create_zone(self)` (founder) or `AddNode(self)` on the leader (joiner) — never through the address book.  Boot fails loud (`peer list contains self ...`) when `NEXUS_PEERS` includes the local node so the joiner-loop self-RPC stall surfaces at parse time, not after `Zone 'root' registered`.  `ConfState` lives in raft storage and is mutated only by `ConfChange` (AddNode / RemoveNode) driven by JoinZone.
-- **Bootstrap dispatch** ([`bootstrap_or_join_root`](../../rust/raft/src/distributed_coordinator.rs)):
+- **Bootstrap mode** — operator declares intent up front via `NEXUS_BOOTSTRAP_MODE` (or `--bootstrap-mode` for `nexusd-cluster`).  The validator runs once at boot and rejects any state × flag combination that does not match the declared mode, so misconfiguration surfaces before the gRPC server starts rather than as a silent stall later.  See [`BootstrapMode`](../../rust/raft/src/distributed_coordinator.rs).
 
-  | State                                         | Action                                                       |
-  |-----------------------------------------------|--------------------------------------------------------------|
-  | Storage holds a `root` zone                   | Resume from persisted ConfState                              |
-  | Empty storage + `NEXUS_BOOTSTRAP_NEW=1`       | `create_zone("root")` — 1-voter cluster                      |
-  | Empty storage                                  | Loop on JoinZone RPC against `NEXUS_PEERS`, indefinite       |
+  | Mode | Required state | Required flags | Forbidden flags | Bootstrap dispatch |
+  |------|---------------|----------------|-----------------|---------------------|
+  | `static` | Empty data dir | `NEXUS_BOOTSTRAP_NEW=1` (founder) **or** `NEXUS_PEERS` non-empty (joiner) | — | Founder: `create_zone("root")` 1-voter.  Joiner: loop on JoinZone RPC against `NEXUS_PEERS`, indefinite |
+  | `dynamic` | Empty data dir | — | `NEXUS_BOOTSTRAP_NEW`, `NEXUS_PEERS` | Daemon comes up rootless; runtime API (`nexusd-cluster share`/`join`, Python `federation_create_zone`) drives zone formation |
+  | `restart` | Data dir holds `<dir>/root/raft/` | — | `NEXUS_BOOTSTRAP_NEW`, `NEXUS_PEERS` | Resume from persisted ConfState — state on disk is the SSOT, env flags would be ambiguous |
 
 - **Wipe-rejoin** — wiping `<NEXUS_DATA_DIR>` mints a fresh `node_id` on the next boot; the daemon JoinZones, the leader commits `AddNode(new_id)`.
 

--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -28,7 +28,8 @@ use kernel::kernel::Kernel;
 use kernel::meta_store::DT_MOUNT;
 
 use nexus_raft::distributed_coordinator::{
-    bootstrap_or_join_zone, read_or_mint_node_id, validate_peers_excludes_self,
+    bootstrap_or_join_zone, read_or_mint_node_id, validate_bootstrap_mode,
+    validate_peers_excludes_self, BootstrapMode,
 };
 use nexus_raft::federation::{parse_federation_env, ENV_FEDERATION_MOUNTS, ENV_FEDERATION_ZONES};
 use nexus_raft::transport::{bootstrap_tls, NodeAddress};
@@ -85,6 +86,16 @@ struct CommonArgs {
     /// Defaults to `<data_dir>/root` for self-contained operation.
     #[arg(long, env = "NEXUS_ROOT_FS", global = true)]
     root_path: Option<PathBuf>,
+
+    /// Bootstrap mode declaration — `static`, `dynamic`, or `restart`.
+    ///
+    /// Operator must declare intent at startup so the daemon does not
+    /// silently mix scenarios.  See `BootstrapMode` in `nexus_raft`
+    /// for the full contract.  Required for the daemon mode (no
+    /// subcommand) — share/join/mount/unmount subcommands skip the
+    /// validator since they always operate on existing state.
+    #[arg(long, env = "NEXUS_BOOTSTRAP_MODE", global = true)]
+    bootstrap_mode: Option<String>,
 }
 
 impl CommonArgs {
@@ -327,6 +338,45 @@ async fn run_daemon(common: CommonArgs) -> Result<()> {
         "nexusd-cluster starting (daemon mode)",
     );
 
+    let bootstrap_new = std::env::var("NEXUS_BOOTSTRAP_NEW")
+        .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true"))
+        .unwrap_or(false);
+
+    let peers_non_empty = common.peers.split(',').any(|s| !s.trim().is_empty());
+
+    // `<data_dir>/root/raft/` — caller-side check the validator
+    // uses to detect "this is actually a restart, not a fresh
+    // bootstrap".  Cheap filesystem stat.
+    let data_dir_has_root = common.data_dir.join("root").join("raft").exists();
+
+    // Operator MUST declare bootstrap intent when federation is in
+    // play — `BootstrapMode` doc has the contract.  "Federation in
+    // play" = any of: data dir already holds a root zone (restart),
+    // `--bootstrap-new` (static founder), or non-empty `--peers`
+    // (static joiner).  CLI invocations with none of those signals
+    // skip the validator (no federation intent yet).
+    let federation_in_play = data_dir_has_root || bootstrap_new || peers_non_empty;
+    if federation_in_play {
+        let mode_str = common.bootstrap_mode.as_deref().ok_or_else(|| {
+            anyhow::anyhow!(
+                "--bootstrap-mode (or NEXUS_BOOTSTRAP_MODE) is required when bootstrapping \
+                 federation (data dir holds root, --bootstrap-new set, or --peers \
+                 non-empty).  Pass one of: static, dynamic, restart.  \
+                 See BootstrapMode docs in nexus_raft.",
+            )
+        })?;
+        let mode = BootstrapMode::parse(mode_str).map_err(|e| anyhow::anyhow!("{}", e))?;
+        validate_bootstrap_mode(mode, data_dir_has_root, bootstrap_new, peers_non_empty)
+            .map_err(|e| anyhow::anyhow!("{}", e))?;
+        tracing::info!(
+            mode = mode.as_str(),
+            bootstrap_new,
+            peers_non_empty,
+            data_dir_has_root,
+            "bootstrap mode validated",
+        );
+    }
+
     let ZoneManagerBundle {
         zm,
         node_id,
@@ -334,8 +384,9 @@ async fn run_daemon(common: CommonArgs) -> Result<()> {
         peer_addrs,
     } = open_zone_manager(&common)?;
 
-    // Bring root zone online via the same dispatcher Python `nexusd`
-    // uses (`init_from_env`).  Three branches by storage state:
+    // Bring root zone online via `bootstrap_or_join_zone` — the SSOT
+    // dispatch Python `nexusd::init_from_env` and this binary share.
+    // Three branches by storage state:
     //
     //   1. restart — persisted ConfState resumes;
     //   2. fresh create — `NEXUS_BOOTSTRAP_NEW=1` honored, 1-voter
@@ -343,12 +394,9 @@ async fn run_daemon(common: CommonArgs) -> Result<()> {
     //   3. wait-and-join — empty storage + flag unset + non-empty
     //      peer list = retry JoinZone forever (no deadline).
     //
-    // Without this, the previous unconditional `zm.create_zone(...)`
-    // produced a fresh 1-voter zone on every joiner, partitioning
-    // the federation into disjoint single-node clusters.
-    let bootstrap_new = std::env::var("NEXUS_BOOTSTRAP_NEW")
-        .map(|v| matches!(v.to_ascii_lowercase().as_str(), "1" | "true"))
-        .unwrap_or(false);
+    // BootstrapMode validation above already gates which of these
+    // branches is reachable for the declared mode, so no in-helper
+    // fall-through happens silently.
 
     // `bootstrap_or_join_zone` is a sync helper that, in branch 3
     // (wait-and-join), spins a nested `tokio::runtime` to drive the

--- a/rust/raft/src/distributed_coordinator.rs
+++ b/rust/raft/src/distributed_coordinator.rs
@@ -217,6 +217,169 @@ impl Default for RaftDistributedCoordinator {
     }
 }
 
+/// Bootstrap mode declared by the operator at daemon start.
+///
+/// Pre-this-enum, `bootstrap_or_join_zone` would dispatch its three
+/// branches purely from runtime state inference (data-dir empty?
+/// `NEXUS_BOOTSTRAP_NEW=1`?  peers non-empty?).  That implicit
+/// dispatch made it possible to mix scenarios — point a `share`
+/// command's `--data-dir` at a static-bootstrap data dir and the CLI
+/// would happily treat it as runtime state of an in-progress dynamic
+/// cluster.  Empirically caused leadership-chase confusion during
+/// cross-machine smoke and conflated two intent layers.
+///
+/// Now operator must declare intent up front:
+///
+///   * `Static` — env-driven cluster formation. `NEXUS_PEERS` /
+///     `--peers` and `NEXUS_BOOTSTRAP_NEW` / `--bootstrap-new` are
+///     consumed at startup. Data dir MUST be empty.
+///   * `Dynamic` — daemon comes up rootless; operator drives zone
+///     formation via runtime API (`nexusd-cluster share` / `join`,
+///     or Python `nexusd federation_create_zone`). Env vars and
+///     `--peers` related to bootstrap are REJECTED. Data dir MUST be
+///     empty.
+///   * `Restart` — data dir holds persisted ConfState from a prior
+///     boot; resume from it. Bootstrap-related env vars / flags are
+///     REJECTED (state on disk is the SSOT).
+///
+/// Validation runs once at boot and fails loud on any contradiction
+/// — operator gets a clear error rather than discovering implicit
+/// behaviour months later.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BootstrapMode {
+    Static,
+    Dynamic,
+    Restart,
+}
+
+impl BootstrapMode {
+    /// Parse a textual mode declaration.  Accepts case-insensitive
+    /// `"static"` / `"dynamic"` / `"restart"`.
+    pub fn parse(s: &str) -> Result<Self, String> {
+        match s.trim().to_ascii_lowercase().as_str() {
+            "static" => Ok(BootstrapMode::Static),
+            "dynamic" => Ok(BootstrapMode::Dynamic),
+            "restart" => Ok(BootstrapMode::Restart),
+            other => Err(format!(
+                "invalid bootstrap mode '{other}' — expected one of: static, dynamic, restart",
+            )),
+        }
+    }
+
+    /// Human-readable name (lowercase) for log lines and error messages.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            BootstrapMode::Static => "static",
+            BootstrapMode::Dynamic => "dynamic",
+            BootstrapMode::Restart => "restart",
+        }
+    }
+}
+
+/// Validate that the declared bootstrap mode is consistent with
+/// runtime state and operator inputs.  Fails loud at boot time so
+/// misconfiguration surfaces before the daemon's gRPC server starts
+/// rather than as a silent stall later.
+///
+/// Inputs:
+///   * `mode` — operator declaration (CLI flag or env var).
+///   * `data_dir_has_root` — `<data_dir>/root/raft/` exists, i.e.
+///     persisted ConfState is present.  Caller checks the filesystem.
+///   * `bootstrap_new_set` — operator passed `NEXUS_BOOTSTRAP_NEW=1`
+///     or equivalent CLI flag.
+///   * `peers_non_empty` — operator passed `NEXUS_PEERS` /
+///     `--peers` with at least one entry (after
+///     `validate_peers_excludes_self`).
+///
+/// Rules:
+///   * `Static`: data dir MUST be empty (would-be restart);
+///     `bootstrap_new_set` OR `peers_non_empty` MUST hold (otherwise
+///     nothing tells the daemon which way to bootstrap).
+///   * `Dynamic`: data dir MUST be empty (no persisted state);
+///     `bootstrap_new_set` and `peers_non_empty` MUST both be false
+///     (runtime API drives, not env).
+///   * `Restart`: data dir MUST be non-empty (state to resume);
+///     `bootstrap_new_set` and `peers_non_empty` MUST both be false
+///     (state on disk is authoritative).
+pub fn validate_bootstrap_mode(
+    mode: BootstrapMode,
+    data_dir_has_root: bool,
+    bootstrap_new_set: bool,
+    peers_non_empty: bool,
+) -> Result<(), String> {
+    match mode {
+        BootstrapMode::Static => {
+            if data_dir_has_root {
+                return Err(
+                    "bootstrap mode = static, but data dir already holds a 'root' zone — \
+                     this is a restart scenario.  Either pass mode = restart, or wipe the \
+                     data dir to bootstrap fresh."
+                        .to_string(),
+                );
+            }
+            if !bootstrap_new_set && !peers_non_empty {
+                return Err(
+                    "bootstrap mode = static requires either NEXUS_BOOTSTRAP_NEW=1 (founder) \
+                     or NEXUS_PEERS/--peers (joiner).  Neither is set."
+                        .to_string(),
+                );
+            }
+            Ok(())
+        }
+        BootstrapMode::Dynamic => {
+            if data_dir_has_root {
+                return Err(
+                    "bootstrap mode = dynamic, but data dir already holds a 'root' zone — \
+                     dynamic mode requires a fresh data dir; runtime share/join builds the \
+                     cluster from scratch.  Either pass mode = restart, or wipe the data dir."
+                        .to_string(),
+                );
+            }
+            if bootstrap_new_set {
+                return Err(
+                    "bootstrap mode = dynamic forbids NEXUS_BOOTSTRAP_NEW — that flag belongs \
+                     to static mode.  Drop the flag, or switch to mode = static."
+                        .to_string(),
+                );
+            }
+            if peers_non_empty {
+                return Err(
+                    "bootstrap mode = dynamic forbids NEXUS_PEERS / --peers — peer addresses \
+                     enter via runtime share/join commands, not env.  Drop the flag, or \
+                     switch to mode = static."
+                        .to_string(),
+                );
+            }
+            Ok(())
+        }
+        BootstrapMode::Restart => {
+            if !data_dir_has_root {
+                return Err(
+                    "bootstrap mode = restart, but data dir is empty — there is no persisted \
+                     state to resume from.  Either pass mode = static (with peers/flag) or \
+                     mode = dynamic (clean start)."
+                        .to_string(),
+                );
+            }
+            if bootstrap_new_set {
+                return Err(
+                    "bootstrap mode = restart forbids NEXUS_BOOTSTRAP_NEW — persisted state \
+                     is the source of truth.  Drop the flag."
+                        .to_string(),
+                );
+            }
+            if peers_non_empty {
+                return Err(
+                    "bootstrap mode = restart forbids NEXUS_PEERS / --peers — persisted \
+                     ConfState carries the address book.  Drop the flag."
+                        .to_string(),
+                );
+            }
+            Ok(())
+        }
+    }
+}
+
 /// Read the persisted node ID, or mint a fresh random one and persist it.
 ///
 /// SSOT for raft node identity under the opaque-ID contract.  See
@@ -1643,5 +1806,119 @@ mod tests {
     fn validate_peers_excludes_self_empty_list_is_ok() {
         // Founder mode with no other peers yet.
         validate_peers_excludes_self(&[], "100.64.0.26:2126").expect("empty list ok");
+    }
+
+    // ── BootstrapMode parsing + validation ─────────────────────────────
+
+    #[test]
+    fn bootstrap_mode_parse_accepts_canonical_names() {
+        assert_eq!(
+            BootstrapMode::parse("static").unwrap(),
+            BootstrapMode::Static
+        );
+        assert_eq!(
+            BootstrapMode::parse("dynamic").unwrap(),
+            BootstrapMode::Dynamic
+        );
+        assert_eq!(
+            BootstrapMode::parse("restart").unwrap(),
+            BootstrapMode::Restart
+        );
+        // Case-insensitive
+        assert_eq!(
+            BootstrapMode::parse("STATIC").unwrap(),
+            BootstrapMode::Static
+        );
+        // Trims whitespace
+        assert_eq!(
+            BootstrapMode::parse("  dynamic  ").unwrap(),
+            BootstrapMode::Dynamic
+        );
+    }
+
+    #[test]
+    fn bootstrap_mode_parse_rejects_unknown() {
+        let err = BootstrapMode::parse("auto").expect_err("unknown mode rejected");
+        assert!(err.contains("static, dynamic, restart"));
+    }
+
+    #[test]
+    fn validate_static_happy_paths() {
+        // Founder: BOOTSTRAP_NEW set, peers may be empty, data dir empty.
+        validate_bootstrap_mode(BootstrapMode::Static, false, true, false).expect("founder ok");
+        // Joiner: peers non-empty, BOOTSTRAP_NEW unset, data dir empty.
+        validate_bootstrap_mode(BootstrapMode::Static, false, false, true).expect("joiner ok");
+        // Belt-and-suspenders: both set is OK (founder with peer hint).
+        validate_bootstrap_mode(BootstrapMode::Static, false, true, true).expect("both ok");
+    }
+
+    #[test]
+    fn validate_static_rejects_existing_state() {
+        let err = validate_bootstrap_mode(BootstrapMode::Static, true, true, false)
+            .expect_err("existing state under static is restart-in-disguise");
+        assert!(err.contains("restart"));
+    }
+
+    #[test]
+    fn validate_static_rejects_empty_intent() {
+        // No flag, no peers — daemon has no signal which way to go.
+        let err = validate_bootstrap_mode(BootstrapMode::Static, false, false, false)
+            .expect_err("static without flag or peers must be rejected");
+        assert!(err.contains("BOOTSTRAP_NEW") && err.contains("PEERS"));
+    }
+
+    #[test]
+    fn validate_dynamic_happy_path() {
+        // Pure dynamic: empty state, no flags.
+        validate_bootstrap_mode(BootstrapMode::Dynamic, false, false, false)
+            .expect("clean dynamic ok");
+    }
+
+    #[test]
+    fn validate_dynamic_rejects_existing_state() {
+        let err = validate_bootstrap_mode(BootstrapMode::Dynamic, true, false, false)
+            .expect_err("dynamic on existing state must be rejected");
+        assert!(err.contains("dynamic mode requires a fresh data dir"));
+    }
+
+    #[test]
+    fn validate_dynamic_rejects_bootstrap_new() {
+        let err = validate_bootstrap_mode(BootstrapMode::Dynamic, false, true, false)
+            .expect_err("dynamic + BOOTSTRAP_NEW must be rejected");
+        assert!(err.contains("forbids NEXUS_BOOTSTRAP_NEW"));
+    }
+
+    #[test]
+    fn validate_dynamic_rejects_peers() {
+        let err = validate_bootstrap_mode(BootstrapMode::Dynamic, false, false, true)
+            .expect_err("dynamic + peers must be rejected");
+        assert!(err.contains("forbids NEXUS_PEERS"));
+    }
+
+    #[test]
+    fn validate_restart_happy_path() {
+        validate_bootstrap_mode(BootstrapMode::Restart, true, false, false)
+            .expect("restart with state ok");
+    }
+
+    #[test]
+    fn validate_restart_rejects_empty_state() {
+        let err = validate_bootstrap_mode(BootstrapMode::Restart, false, false, false)
+            .expect_err("restart on empty state must be rejected");
+        assert!(err.contains("data dir is empty"));
+    }
+
+    #[test]
+    fn validate_restart_rejects_bootstrap_new() {
+        let err = validate_bootstrap_mode(BootstrapMode::Restart, true, true, false)
+            .expect_err("restart + BOOTSTRAP_NEW must be rejected");
+        assert!(err.contains("forbids NEXUS_BOOTSTRAP_NEW"));
+    }
+
+    #[test]
+    fn validate_restart_rejects_peers() {
+        let err = validate_bootstrap_mode(BootstrapMode::Restart, true, false, true)
+            .expect_err("restart + peers must be rejected");
+        assert!(err.contains("forbids NEXUS_PEERS"));
     }
 }

--- a/rust/raft/src/distributed_coordinator.rs
+++ b/rust/raft/src/distributed_coordinator.rs
@@ -824,6 +824,44 @@ impl RaftDistributedCoordinator {
         // `validate_peers_excludes_self` for the full rationale.
         validate_peers_excludes_self(&peer_addrs, &self_addr)?;
 
+        // Operator MUST declare bootstrap intent when federation is in
+        // play — `BootstrapMode` doc has the contract.  Implicit
+        // dispatch (state-driven) was the source of the silent
+        // mode-mixing that surfaced in cross-machine smoke; explicit
+        // declaration kills that footgun.
+        //
+        // "Federation in play" = any of: data dir already holds a
+        // root zone (restart), `NEXUS_BOOTSTRAP_NEW=1` (static
+        // founder), or non-empty peers (static joiner).  Tests /
+        // single-node dev workflows that touch none of those signals
+        // skip the validator entirely — no federation intent, nothing
+        // to validate.
+        let data_dir_has_root = Path::new(&zones_dir).join("root").join("raft").exists();
+        let federation_in_play = data_dir_has_root || bootstrap_new || !peer_addrs.is_empty();
+        if federation_in_play {
+            let mode_str = std::env::var("NEXUS_BOOTSTRAP_MODE").map_err(|_| {
+                "NEXUS_BOOTSTRAP_MODE is required when bootstrapping federation \
+                 (NEXUS_PEERS, NEXUS_BOOTSTRAP_NEW, or persisted root zone state \
+                 detected).  Pass one of: static, dynamic, restart.  \
+                 See BootstrapMode docs in nexus_raft."
+                    .to_string()
+            })?;
+            let mode = BootstrapMode::parse(&mode_str)?;
+            validate_bootstrap_mode(
+                mode,
+                data_dir_has_root,
+                bootstrap_new,
+                !peer_addrs.is_empty(),
+            )?;
+            tracing::info!(
+                mode = mode.as_str(),
+                bootstrap_new,
+                peers_non_empty = !peer_addrs.is_empty(),
+                data_dir_has_root,
+                "bootstrap mode validated",
+            );
+        }
+
         let tls = if tls_disabled {
             None
         } else {

--- a/scripts/cluster_smoke_xmachine.py
+++ b/scripts/cluster_smoke_xmachine.py
@@ -108,6 +108,10 @@ def launch_daemon(
     if hostname:
         env["NEXUS_HOSTNAME"] = hostname
     env["NEXUS_NO_TLS"] = "1"  # plaintext gRPC for the smoke; mTLS is a separate test
+    # Explicit bootstrap mode declaration — required by daemon since
+    # the BootstrapMode validator gate landed.  Smoke always uses
+    # static mode (env-driven cluster formation).
+    env["NEXUS_BOOTSTRAP_MODE"] = "static"
 
     cmd = [
         str(binary),
@@ -118,6 +122,8 @@ def launch_daemon(
         "--peers",
         peers,
         "--no-tls",
+        "--bootstrap-mode",
+        "static",
     ]
     print(f"[{side}] launch: {' '.join(cmd)}", flush=True)
     print(f"[{side}] data_dir={data_dir} log={log_path} bootstrap_new={bootstrap_new}", flush=True)

--- a/tests/e2e/docker/test_federation_e2e.py
+++ b/tests/e2e/docker/test_federation_e2e.py
@@ -3833,12 +3833,22 @@ class TestFreshJoinToRunningCluster:
 
     ## What this test does
 
+      0. Capture node-1's pre-wipe `node_id` via `cluster_info` —
+         baseline for the rotation assertion at step 7.
       1. Stop node-1 (n2 + witness keep majority, keep committing).
       2. Drive writes via node-2 → raft commits accumulate across cluster.
       3. WIPE node-1 data volume (raft.redb deleted — fresh state).
       4. Start node-1.
       5. Assert node-1 reaches healthy without panic AND catches up to the
          entries written while it was down.
+      6. Spot-check replicated entries are visible on node-1.
+      7. Assert node-1's post-rejoin `node_id` ≠ pre-wipe id (opaque-ID
+         rotation contract — without rotation the heartbeat panic path
+         is reachable; with rotation `Progress[new_id].matched=0`
+         keeps `m.commit=0` on first heartbeat).
+      8. Assert ConfState `voter_count >= 3` post-rejoin (old voter
+         retained per F5-deferred auto-GC plan; canary against an
+         unwanted auto-RemoveNode regression).
     """
 
     # Order-LAST: this test wipes node-1's data dir and rejoins under
@@ -3867,6 +3877,27 @@ class TestFreshJoinToRunningCluster:
         grpc1 = cluster["grpc1"]
         grpc2 = cluster["grpc2"]
         uid = _uid()
+
+        # 0. Capture node-1's PRE-WIPE node_id from its own root-zone
+        #    view.  PR #3996 contract: post-wipe restart MUST mint a
+        #    fresh opaque random `node_id` (`bootstrap_or_join_zone`'s
+        #    `read_or_mint_node_id` only loads when `<data>/.node_id`
+        #    exists — wiped data dir forces a mint).  Capturing the
+        #    pre-wipe id lets the post-rejoin assertion pin "the id
+        #    actually rotated", which `_wait_healthy` alone does not.
+        pre_wipe_info = _grpc_call(
+            grpc1,
+            "federation_cluster_info",
+            {"zone_id": ROOT_ZONE_ID},
+            api_key=api_key,
+            timeout=10,
+        )
+        assert "error" not in pre_wipe_info, f"pre-wipe cluster_info: {pre_wipe_info}"
+        old_n1_id = pre_wipe_info["result"]["node_id"]
+        assert old_n1_id != 0, (
+            f"pre-wipe node_id is 0 (raft reserves 0 — opaque-ID contract violated): "
+            f"{pre_wipe_info}"
+        )
 
         # 1. Stop node-1; n2 + witness retain quorum (2/3).
         n1_container.stop(timeout=10)
@@ -3974,3 +4005,49 @@ class TestFreshJoinToRunningCluster:
                 msg=f"{path} not visible on freshly-joined node-1",
                 timeout=30,
             )
+
+        # 7. PR #3996 opaque-ID rotation contract pin.  After wipe +
+        #    fresh-join, node-1's `node_id` MUST be a freshly minted
+        #    random `u64`, distinct from `old_n1_id` captured at step 0.
+        #    Without rotation the leader's `Progress[old_id].matched`
+        #    carries pre-wipe history while the local log starts at
+        #    index 0 — `MsgHeartbeat{commit=K}` arrives, raft-rs
+        #    `commit_to(K)` panics on `last_index=0`.  The rotated id
+        #    means leader writes a fresh `Progress[new_id]` from
+        #    `AddNode`, so heartbeats carry `m.commit=0` first and the
+        #    panic path is unreachable.
+        post_wipe_info = _grpc_call(
+            grpc1,
+            "federation_cluster_info",
+            {"zone_id": ROOT_ZONE_ID},
+            api_key=api_key,
+            timeout=10,
+        )
+        assert "error" not in post_wipe_info, f"post-rejoin cluster_info: {post_wipe_info}"
+        new_n1_id = post_wipe_info["result"]["node_id"]
+        assert new_n1_id != 0, (
+            f"post-rejoin node_id is 0 — opaque-ID mint contract violated: {post_wipe_info}"
+        )
+        assert new_n1_id != old_n1_id, (
+            f"REGRESSION: node-1 reused its old node_id after wipe-rejoin "
+            f"(old={old_n1_id}, new={new_n1_id}).  PR #3996 opaque-ID "
+            f"contract says the wiped node MUST mint a fresh random id; "
+            f"reusing the old one re-arms the raft-rs heartbeat panic."
+        )
+
+        # 8. Stale-voter-retained pin.  Per PR #3996 plan §F5 (deferred
+        #    auto-GC), the OLD node_id stays in ConfState — leader has
+        #    not seen any explicit `RemoveNode(old_n1_id)`, so quorum
+        #    arithmetic includes both the dead old voter and the live
+        #    new voter.  Verifying voter_count grew by exactly 1
+        #    (pre-wipe was 2 voters in root: n1+n2; post-wipe is 3:
+        #    old_n1_stale + n2 + new_n1) catches a future regression
+        #    where someone sneaks in an auto-RemoveNode on AddNode
+        #    without the explicit F5 design.
+        new_voter_count = post_wipe_info["result"].get("voter_count", 0)
+        assert new_voter_count >= 3, (
+            f"REGRESSION: post-rejoin voter_count={new_voter_count}, expected >=3 "
+            f"(old_n1 stale + n2 + new_n1).  Either the new voter was not "
+            f"AddNode-d, or someone implemented stale-voter auto-GC without "
+            f"the F5 plan — this assertion is the canary either way."
+        )


### PR DESCRIPTION
## Summary

Cross-machine smoke caught implicit dispatch in
``bootstrap_or_join_zone`` letting scenarios mix silently:
operator pointed a CLI at a static-bootstrap data dir for a
"dynamic" test; daemon followed the persisted ConfState as if it
were a runtime-driven cluster; PR #4023's fail-loud caught the
share-as-follower symptom but the root cause — implicit mode
inference from runtime state — stayed.

Operator now declares intent up front via ``BootstrapMode``:

  * **Static** — env-driven, data dir MUST be empty
  * **Dynamic** — daemon comes up rootless; runtime API drives,
    env bootstrap vars rejected, data dir MUST be empty
  * **Restart** — data dir holds persisted state, env bootstrap
    vars rejected (state on disk is SSOT)

Validator runs once at boot and fails loud on any contradiction.
Surfaces misconfiguration before the gRPC server starts rather
than as a 10-second ``wait_for_leader`` stall ten minutes later.

The validator only fires when **federation is in play**: data
dir already holds a root zone, bootstrap-new flag set, or
non-empty peers.  Single-node test fixtures and dev workflows
that touch none of those signals skip the validator (no
federation intent, nothing to validate).  Backward compat
preserved without weakening the strict contract for federation
operators.

## Commits

1. ``feat(raft): explicit BootstrapMode enum + validation gate
   (12 unit tests)`` — pure addition; existing helpers
   unchanged.
2. ``feat: wire BootstrapMode validator into nexusd-cluster +
   Python init_from_env`` — hooks the validator into the two
   federation boot paths; updates docker-compose, smoke script,
   federation-memo doc.

## Test plan

- [x] ``cargo test -p raft@0.1.0 --lib --features grpc`` —
      166 tests green (12 new BootstrapMode tests)
- [x] ``cargo check -p raft@0.1.0 -p nexus-cluster`` clean
- [x] ``cargo clippy -p raft@0.1.0 --features grpc -p nexus-cluster
      --tests -- -D warnings`` clean
- [x] Local smoke: 5 contract paths verified
      * static + bootstrap-new + clean → ok
      * static + bootstrap-new + existing root → "this is a restart"
      * dynamic + bootstrap-new → "dynamic forbids NEXUS_BOOTSTRAP_NEW"
      * restart + clean → "data dir is empty"
      * restart + existing root → ok
- [ ] CI green (Federation E2E exercises ``NEXUS_BOOTSTRAP_MODE=static``)
- [ ] Post-merge: cross-machine static + dynamic smoke — clean
      retest with explicit mode declarations on both sides