### PR TITLE
refactor(locks): collapse install_locks + drop dual-storage state slot + unify GC semantics

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -569,6 +569,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 name = "contracts"
 version = "0.1.0"
 dependencies = [
+ "parking_lot",
  "serde",
 ]
 

--- a/rust/contracts/Cargo.toml
+++ b/rust/contracts/Cargo.toml
@@ -13,3 +13,9 @@ crate-type = ["rlib"]
 # raft-rs's bincode pipeline). Kept behind a dep on a tiny subset of serde
 # to avoid pulling the full macro crate into every dependent.
 serde = { version = "1.0", features = ["derive"] }
+# Mutex type used in the ``Locks::shared_state_arc`` trait method. Both
+# kernel and raft already use ``parking_lot::Mutex<LockState>`` to wrap
+# the SSOT; expressing that in the trait signature keeps install-time
+# wiring type-safe (no caller-side mismatch between backend Arc and
+# state Arc).
+parking_lot = "0.12"

--- a/rust/contracts/src/lock_state.rs
+++ b/rust/contracts/src/lock_state.rs
@@ -15,7 +15,9 @@
 //! advisory locks.
 
 use std::collections::BTreeMap;
+use std::sync::Arc;
 
+use parking_lot::Mutex;
 use serde::{Deserialize, Serialize};
 
 // ── Types ───────────────────────────────────────────────────────────
@@ -305,6 +307,17 @@ impl LockState {
     }
 
     // ── Reads ────────────────────────────────────────────────────────
+    //
+    // Reads do not prune expired holders. Apply paths
+    // (``apply_acquire``/``apply_extend``) prune before each
+    // mutation, so any stale entry that survives is by definition
+    // an unmutated path that nobody currently cares about. A
+    // periodic background sweeper (or an explicit ``gc_expired``
+    // call) handles long-term cleanup. Doing an O(N) full-table
+    // sweep on every read was the previous shape and produced both
+    // a perf hit and a SSOT divergence (``LocalLocks::get_lock``
+    // skipped the sweep, the federation-side impl did it on every
+    // call).
 
     pub fn get_lock(&self, path: &str) -> Option<LockInfo> {
         self.locks.get(path).and_then(|entry| {
@@ -338,8 +351,9 @@ impl LockState {
     }
 
     /// Public read-side helper for expiry pruning (used by tests and
-    /// future background reapers). apply_* already inline this on their
-    /// own paths.
+    /// future background reapers). apply_* paths already inline this
+    /// on their own writes; this is the cold-path "compact the map"
+    /// hook for callers who want explicit cleanup.
     pub fn gc_expired(&mut self, now_secs: u64) {
         self.prune_expired(now_secs);
     }
@@ -392,10 +406,26 @@ pub trait Locks: Send + Sync {
     fn extend(&self, path: &str, lock_id: &str, ttl_secs: u32) -> Result<bool, String>;
 
     /// Read the full advisory lock record (or ``None`` if unlocked).
+    /// Implementations should route through ``LockState::get_lock`` so
+    /// expiry pruning is uniform across backends.
     fn get_lock(&self, path: &str) -> Option<LockInfo>;
 
     /// Enumerate locks under ``prefix``, capped at ``limit``.
+    /// Implementations should route through ``LockState::list_locks``
+    /// so expiry pruning is uniform across backends.
     fn list_locks(&self, prefix: &str, limit: usize) -> Vec<LockInfo>;
+
+    /// Return the shared advisory state Arc this backend reads and
+    /// writes against.
+    ///
+    /// ``LockManager::install_locks`` uses this to atomically swap the
+    /// kernel's read-side state Arc together with the backend — the
+    /// two MUST stay paired (every backend's reads/writes target its
+    /// own state Arc). Exposing it on the trait lets the install path
+    /// derive the new state Arc from the backend itself, removing a
+    /// caller-side mismatch foot-gun where the caller would otherwise
+    /// have to remember to pass the matching state Arc separately.
+    fn shared_state_arc(&self) -> Arc<Mutex<LockState>>;
 }
 
 // ── Tests ───────────────────────────────────────────────────────────

--- a/rust/kernel/src/core/lock/locks.rs
+++ b/rust/kernel/src/core/lock/locks.rs
@@ -1,18 +1,14 @@
-//! Advisory-lock backends for the kernel's ``LockManager``.
+//! Local advisory-lock backend for the kernel's ``LockManager``.
 //!
-//! Two impls live in the tree today:
-//!   - ``LocalLocks`` (this file) — direct mutation of the shared
-//!     ``Arc<Mutex<LockState>>``, no replication.
-//!   - ``nexus_raft::federation::DistributedLocks`` — proposes a
-//!     ``Command::{Acquire,Release,Force,Extend}Lock`` through a raft
-//!     ``ZoneConsensus``; apply mutates the same shared map on every
-//!     peer.
-//!
-//! ``LockManager`` stores the backend as ``Arc<dyn contracts::Locks>``
-//! so the kernel has no dependency on any raft concrete type. The
-//! default backend is ``LocalLocks``; federation DI swaps in
-//! ``DistributedLocks`` via ``Kernel::install_locks`` at nexus init
-//! time (first-wins; idempotent).
+//! ``LocalLocks`` mutates the shared ``Arc<Mutex<LockState>>`` directly
+//! — no replication. It is the kernel's default backend, used in
+//! standalone deployments and as the boot-time default before the
+//! distributed-coordinator HAL installs a replicated backend (if
+//! configured). The trait boundary ``Arc<dyn contracts::Locks>``
+//! keeps the kernel free of any HAL-impl concrete type — replicated
+//! backends live in their own crate and are wired in via
+//! ``Kernel::install_locks`` at nexus init time (first-wins,
+//! idempotent).
 
 use std::sync::Arc;
 
@@ -24,8 +20,8 @@ use crate::lock_manager::lock_now_secs;
 
 /// Local-mode advisory lock backend: one Arc-wrapped ``LockState``
 /// mutated directly on every call. Never proposes anything — used by
-/// standalone deployments and as the kernel's default before
-/// federation DI fires.
+/// standalone deployments and as the kernel's default before any
+/// replicated HAL backend installs.
 pub struct LocalLocks {
     state: Arc<Mutex<LockState>>,
 }
@@ -33,16 +29,16 @@ pub struct LocalLocks {
 impl LocalLocks {
     /// Construct a LocalLocks that shares ``state`` with whoever owns
     /// the Arc (typically the kernel's own ``LockManager``). When the
-    /// backend is later swapped for ``DistributedLocks``, the kernel
-    /// passes the current state Arc along so existing holders are not
-    /// lost — the federation-side impl merges them into the state
-    /// machine's map under the same mutex discipline.
+    /// backend is later swapped for a replicated HAL impl, the kernel
+    /// hands the current state Arc to that impl's constructor so
+    /// existing holders are not lost — the impl merges them into its
+    /// own map under the same mutex discipline.
     pub fn new(state: Arc<Mutex<LockState>>) -> Self {
         Self { state }
     }
 
-    /// Snapshot the shared state Arc — used by federation setup to
-    /// migrate local holders into the raft state machine's map.
+    /// Snapshot the shared state Arc — kept for symmetry with the
+    /// trait method ``shared_state_arc``; both surface the same Arc.
     pub fn state(&self) -> Arc<Mutex<LockState>> {
         self.state.clone()
     }
@@ -84,6 +80,10 @@ impl Locks for LocalLocks {
 
     fn list_locks(&self, prefix: &str, limit: usize) -> Vec<LockInfo> {
         self.state.lock().list_locks(prefix, limit)
+    }
+
+    fn shared_state_arc(&self) -> Arc<Mutex<LockState>> {
+        self.state.clone()
     }
 }
 

--- a/rust/kernel/src/core/lock/mod.rs
+++ b/rust/kernel/src/core/lock/mod.rs
@@ -212,34 +212,35 @@ impl std::fmt::Display for LockError {
 // LockManager — unified I/O + advisory lock primitive
 // ═══════════════════════════════════════════════════════════════════
 
-/// Unified lock manager: I/O lock + advisory lock + optional Raft.
+/// Unified lock manager: I/O lock + advisory lock + swappable advisory
+/// backend (HAL).
 ///
 /// I/O locks live in a local ``Mutex<IOLockState>`` — they never
-/// replicate. Advisory locks go through an ``Arc<dyn Locks>`` backend
-/// — the kernel's default ``LocalLocks`` mutates a shared
-/// ``Arc<Mutex<LockState>>`` directly; federation DI swaps in
-/// ``nexus_raft::federation::DistributedLocks`` via
-/// ``Kernel::install_locks`` (idempotent, first-wins per process).
-///
-/// The trait boundary here keeps the kernel free of any raft concrete
-/// type — the federation backend lives entirely in `nexus_raft`.
+/// replicate. Advisory locks go through an ``Arc<dyn Locks>`` HAL
+/// backend — the kernel's default ``LocalLocks`` mutates a shared
+/// ``Arc<Mutex<LockState>>`` directly. The distributed-coordinator HAL
+/// can swap in a replicated impl via ``Kernel::install_locks``
+/// (idempotent, first-wins per process). Kernel never names the
+/// concrete replicated impl — the trait boundary is the contract.
 ///
 /// Shared via ``Arc`` between Kernel and VFSLockManager PyO3 wrapper.
 pub struct LockManager {
     io_state: Mutex<IOLockState>,
-    /// Advisory backend (``LocalLocks`` by default; ``DistributedLocks``
-    /// after federation DI). Wrapped in ``RwLock`` so ``install_locks``
-    /// can swap atomically without blocking concurrent readers beyond
-    /// one Arc clone.
+    /// Advisory backend HAL slot (``LocalLocks`` by default; replaced by
+    /// the distributed-coordinator HAL impl when ``install_locks`` runs).
+    /// Wrapped in ``RwLock`` so the install-time swap is atomic without
+    /// blocking concurrent readers beyond one Arc clone.
+    ///
+    /// The shared advisory-state Arc is NOT stored separately — it
+    /// lives inside the backend and is reached via
+    /// ``Locks::shared_state_arc``. The previous ``RwLock<Arc<Mutex
+    /// <LockState>>>`` field was a dual-storage SSOT violation: the
+    /// install path had to update both the backend slot and the state
+    /// slot in the right order, and a caller passing a mismatched
+    /// state Arc to ``install_locks`` would corrupt the read-side.
     locks: RwLock<Arc<dyn Locks>>,
-    /// Shared advisory state Arc. Owned here so the kernel controls
-    /// the mutex discipline and so federation-side migration can pull
-    /// the current holders BEFORE swapping backends (the federation
-    /// path adopts the state machine's Arc and merges into it under
-    /// its own mutex).
-    advisory_state: RwLock<Arc<Mutex<SharedLockState>>>,
-    /// First-wins guard for ``install_locks``. Once the federation
-    /// backend is wired, further installs are no-ops.
+    /// First-wins guard for ``install_locks``. Once the replicated
+    /// HAL backend is wired, further installs are no-ops.
     installed: std::sync::atomic::AtomicBool,
     notify: Condvar,        // for blocking I/O acquire (paired with io_state)
     next_handle: AtomicU64, // for auto-generated I/O lock handles
@@ -255,12 +256,10 @@ pub struct LockManager {
 impl LockManager {
     pub fn new() -> Self {
         let state = Arc::new(Mutex::new(SharedLockState::new()));
-        let default_backend: Arc<dyn Locks> =
-            Arc::new(crate::locks::LocalLocks::new(state.clone()));
+        let default_backend: Arc<dyn Locks> = Arc::new(crate::locks::LocalLocks::new(state));
         Self {
             io_state: Mutex::new(IOLockState::default()),
             locks: RwLock::new(default_backend),
-            advisory_state: RwLock::new(state),
             installed: std::sync::atomic::AtomicBool::new(false),
             notify: Condvar::new(),
             next_handle: AtomicU64::new(0),
@@ -272,43 +271,36 @@ impl LockManager {
         }
     }
 
-    /// Install a new advisory backend (federation DI).
+    /// Install a replicated advisory backend (called by the
+    /// distributed-coordinator HAL during its setup path).
     ///
-    /// Idempotent by caller discipline: federation's ``setup_zone``
-    /// drives exactly one install per process — the ``installed``
-    /// flag guards against a second caller racing in. Mirrors the old
-    /// ``upgrade_to_distributed`` first-wins contract: lock state
-    /// lives in ONE specific zone's state machine (the first
-    /// replicated mount the kernel sees); swapping backends
-    /// mid-flight would orphan raft-committed holders.
+    /// First-wins: the HAL drives exactly one install per process —
+    /// the ``installed`` flag rejects a second install. Replicated
+    /// lock state is anchored to ONE specific consensus group (the
+    /// first replicated mount the kernel sees); swapping HAL backends
+    /// mid-flight would orphan committed holders.
     ///
-    /// ``new_state`` becomes the kernel's new authoritative advisory
-    /// state Arc — callers (federation) are responsible for merging
-    /// any existing local holders into it BEFORE the swap (the
-    /// federation path does this inside ``DistributedLocks::new``).
+    /// The backend's ``shared_state_arc()`` is the new authoritative
+    /// advisory-state Arc — the HAL impl is responsible for merging
+    /// any existing local holders into it BEFORE the swap (the impl
+    /// does this in its own constructor).
     ///
     /// Returns ``true`` if the backend was installed, ``false`` if a
     /// previous backend was already in place.
-    pub fn install_locks(
-        &self,
-        backend: Arc<dyn Locks>,
-        new_state: Arc<Mutex<SharedLockState>>,
-    ) -> bool {
-        let mut slot = self.locks.write();
+    pub fn install_locks(&self, backend: Arc<dyn Locks>) -> bool {
         if self.installed.swap(true, Ordering::AcqRel) {
             return false;
         }
-        let mut state_slot = self.advisory_state.write();
-        *state_slot = new_state;
-        *slot = backend;
+        *self.locks.write() = backend;
         true
     }
 
-    /// Snapshot the current advisory-state Arc (federation setup
-    /// calls this to merge local holders into the state machine's
-    /// map before swapping backends).
+    /// Snapshot the current advisory-state Arc — the distributed-
+    /// coordinator HAL setup path calls this to merge any existing
+    /// local holders into its own (replicated) map before the
+    /// install swap.
     pub fn advisory_state_arc(&self) -> Arc<Mutex<SharedLockState>> {
-        self.advisory_state.read().clone()
+        self.locks.read().shared_state_arc()
     }
 
     /// True once ``install_locks`` has been called. Fast-path gate
@@ -585,10 +577,10 @@ impl LockManager {
     ///
     /// All four mutation methods delegate to the installed ``Locks``
     /// backend — ``LocalLocks`` (default) mutates the shared map
-    /// directly; ``DistributedLocks`` (federation) proposes through
-    /// ``ZoneConsensus`` and apply-path writes into the same shared
-    /// map. Either way, there is one state transition and one mutex
-    /// acquisition observed from outside.
+    /// directly; the replicated HAL backend proposes a state-transition
+    /// through its consensus mechanism and the apply-path writes into
+    /// the same shared map. Either way, there is one state transition
+    /// and one mutex acquisition observed from outside.
     pub fn acquire_lock(
         &self,
         path: &str,
@@ -634,11 +626,11 @@ impl LockManager {
     /// Read the full advisory lock record for a path (or ``None`` if
     /// unlocked).
     ///
-    /// Reads always go through the current backend. Both ``LocalLocks``
-    /// and ``DistributedLocks`` read from the same shared
-    /// ``Arc<Mutex<LockState>>`` — a committed raft write is visible
-    /// here as soon as apply returns, so no ReadIndex round-trip is
-    /// needed.
+    /// Reads always go through the currently installed ``Locks`` HAL
+    /// backend. Both the default and the replicated backend read
+    /// from the same shared ``Arc<Mutex<LockState>>`` — a committed
+    /// replicated write is visible here as soon as apply returns, so
+    /// no read-quorum round-trip is needed.
     pub fn get_lock_info(&self, path: &str) -> Result<Option<KernelLockInfo>, LockError> {
         Ok(self
             .locks_backend()

--- a/rust/raft/src/distributed_coordinator.rs
+++ b/rust/raft/src/distributed_coordinator.rs
@@ -1034,7 +1034,7 @@ impl DistributedCoordinator for RaftDistributedCoordinator {
             .get_node(zone_id)
             .ok_or_else(|| format!("zone '{zone_id}' not loaded locally"))?;
         let kernel_state = kernel.lock_manager_arc().advisory_state_arc();
-        let (backend, _shared) =
+        let backend =
             crate::federation::DistributedLocks::new(consensus, runtime.clone(), kernel_state);
         Ok(Arc::new(backend))
     }
@@ -1548,12 +1548,12 @@ fn wire_mount_core(
                     "wire_mount: installing distributed locks bound to ROOT zone"
                 );
                 let kernel_state = lock_manager.advisory_state_arc();
-                let (backend, shared_state) = crate::federation::DistributedLocks::new(
+                let backend = crate::federation::DistributedLocks::new(
                     root_consensus,
                     runtime.clone(),
                     kernel_state,
                 );
-                lock_manager.install_locks(Arc::new(backend), shared_state);
+                lock_manager.install_locks(Arc::new(backend));
             }
             None => {
                 tracing::warn!(

--- a/rust/raft/src/federation/distributed_locks.rs
+++ b/rust/raft/src/federation/distributed_locks.rs
@@ -26,13 +26,6 @@ fn now_secs() -> u64 {
     FullStateMachine::now()
 }
 
-fn local_now_secs() -> u64 {
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
-}
-
 /// Distributed ``Locks`` backend — raft-replicated advisory locks.
 ///
 /// Wraps a ``ZoneConsensus<FullStateMachine>`` + its tokio runtime +
@@ -59,14 +52,16 @@ impl DistributedLocks {
     /// constructed; never overwrite raft-owned paths with stale
     /// local data).
     ///
-    /// Returns ``(backend, shared_state_arc)`` — callers pass the
-    /// second tuple element to ``LockManager::install_locks`` so the
-    /// kernel swaps its read-side Arc alongside the backend.
+    /// The returned backend exposes its shared state via the
+    /// ``Locks::shared_state_arc`` trait method, so callers don't pass
+    /// a separate state Arc to ``LockManager::install_locks`` — the
+    /// kernel pulls it back through the trait, eliminating the misuse
+    /// risk of mismatching backend/state Arcs at install time.
     pub fn new(
         node: ZoneConsensus<FullStateMachine>,
         runtime: tokio::runtime::Handle,
         kernel_local_state: Arc<Mutex<LockState>>,
-    ) -> (Self, Arc<Mutex<LockState>>) {
+    ) -> Self {
         // Adopt the state machine's shared advisory Arc.  Two callers
         // reach this path:
         //
@@ -119,12 +114,11 @@ impl DistributedLocks {
             }
         }
 
-        let backend = Self {
+        Self {
             node,
             runtime,
-            shared_state: shared_state.clone(),
-        };
-        (backend, shared_state)
+            shared_state,
+        }
     }
 }
 
@@ -222,17 +216,18 @@ impl Locks for DistributedLocks {
     }
 
     fn get_lock(&self, path: &str) -> Option<LockInfo> {
-        // GC expired holders in-line so callers never observe a stale
-        // record that the raft apply path hasn't had reason to touch
-        // (committed writes prune on apply; reads don't).
-        let mut guard = self.shared_state.lock();
-        guard.gc_expired(local_now_secs());
-        guard.get_lock(path)
+        // Reads share semantics with ``LocalLocks`` post-fix: no
+        // read-side GC. ``apply_*`` paths prune expired holders on
+        // every write, so unmutated rows that survive are by
+        // definition cold and never block live decisions.
+        self.shared_state.lock().get_lock(path)
     }
 
     fn list_locks(&self, prefix: &str, limit: usize) -> Vec<LockInfo> {
-        let mut guard = self.shared_state.lock();
-        guard.gc_expired(local_now_secs());
-        guard.list_locks(prefix, limit)
+        self.shared_state.lock().list_locks(prefix, limit)
+    }
+
+    fn shared_state_arc(&self) -> Arc<Mutex<LockState>> {
+        self.shared_state.clone()
     }
 }


### PR DESCRIPTION
## Summary

Three audit findings on the advisory-locks subsystem, all fixed in one pass.

### Issue 1: read-side GC asymmetry (correctness / SSOT violation)

`LocalLocks::get_lock` returned the underlying state with no GC.
The distributed-coordinator HAL impl GC'd on every read (`O(N)` full-table sweep).
Trait `Locks` didn't specify which was correct.

Apply paths (`apply_acquire`/`apply_extend`) already prune expired holders inline before each mutation, so the read-side GC was redundant + a perf bug. **Both impls now read with no GC.** Cold-path cleanup goes through `gc_expired` or the apply paths.

### Issue 2: dual-storage advisory state (SSOT violation)

`LockManager` kept the same Arc in two RwLocks:
```rust
locks: RwLock<Arc<dyn Locks>>,                      // backend slot
advisory_state: RwLock<Arc<Mutex<LockState>>>,      // read-side slot
```
Both had to stay in lock-step. `install_locks` took both as args and trusted the caller to pass matching Arcs.

**Fix**: add `Locks::shared_state_arc()` to the trait. Single `Arc<dyn Locks>` slot is sufficient — `advisory_state_arc()` pulls the Arc back through the trait, can never drift.

### Issue 3: install_locks signature foot-gun

`install_locks(backend, state_arc)` — caller had to pass two Arcs, mismatch silently corrupted reads.

**Fix**: `install_locks(backend)` — single arg, state derived through the trait. `DistributedLocks::new` also collapsed from returning `(Self, Arc)` tuple to just `Self`.

## Side wins

- `LockManager` docstrings purged of `federation`/`DistributedLocks` naming. Kernel was referring to an HAL impl by its concrete name (boundary leak); now describes the abstraction layer ("distributed-coordinator HAL") without naming the impl.
- Drops one `parking_lot::RwLock` from `LockManager`.

## Issue 4 (measured, not addressed)

I/O-lock `descendants` range scan perf, on this commit:

| descendants under root | per acquire+release |
|---|---|
| 0 | 305 ns |
| 100 | 529 ns |
| 1,000 | 1,766 ns |
| 10,000 | 21,679 ns |

Linear-ish, ~2 ns per descendant. At realistic lock table sizes (hundreds) the overhead is sub-1 µs — adding a subtree-count index is not worth the complexity.

## Test plan
- [x] `cargo check --workspace --tests` clean
- [x] `cargo clippy -p kernel -p contracts -p raft --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] contracts: 16 lib tests green
- [x] kernel: 339 lib tests green
- [x] raft: 153 lib tests green
- [ ] CI green