### PR TITLE
[codex] add remote hub admin cli

### DIFF
--- a/docs/superpowers/plans/2026-05-04-issue-3872-remote-hub-admin-cli.md
+++ b/docs/superpowers/plans/2026-05-04-issue-3872-remote-hub-admin-cli.md
@@ -1,0 +1,936 @@
+# Issue 3872 Remote Hub Admin CLI Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `--remote` workstation support for `nexus hub token create/list/revoke` and `nexus hub status` through admin-only MCP tools.
+
+**Architecture:** The public workstation path is CLI -> MCP HTTP `/mcp` -> MCP admin tool -> hub backend RPC -> DB-backed shared hub operations. The extra backend RPC hop is required because the supported hub runtime runs the MCP frontend as a remote client of the RPC service; direct database access from the MCP frontend is not available in that deployment.
+
+**Tech Stack:** Python, Click, FastMCP, httpx, SQLAlchemy, existing Nexus gRPC/RPC dispatch, pytest.
+
+---
+
+## File Map
+
+- Create `src/nexus/hub/__init__.py`: package marker for shared hub admin code.
+- Create `src/nexus/hub/admin_ops.py`: DB-backed token/status operations shared by local CLI and backend RPC handlers.
+- Create `src/nexus/cli/commands/_hub_remote.py`: synchronous MCP HTTP client for remote hub admin tool calls.
+- Create `src/nexus/server/rpc/handlers/hub_admin.py`: backend RPC handlers that require admin context and call `admin_ops`.
+- Modify `src/nexus/cli/commands/hub.py`: add `--remote` and `--admin-token`, delegate local DB work to `admin_ops`, render remote payloads with existing output shapes.
+- Modify `src/nexus/bricks/mcp/server.py`: register `nexus_hub_token_create`, `nexus_hub_token_list`, `nexus_hub_token_revoke`, and `nexus_hub_status` tools.
+- Modify `src/nexus/server/_rpc_param_overrides.py`: add params for the new `hub_admin_*` backend RPC methods.
+- Modify `src/nexus/server/rpc/dispatch.py`: add dispatch table entries for the new backend RPC methods.
+- Modify `src/nexus/__init__.py`: expose the remote profile transport call as `nfs._nexus_remote_call_rpc` so MCP tools can forward admin RPCs through the per-request remote `NexusFS`.
+- Test `tests/unit/hub/test_admin_ops.py`: shared operation behavior.
+- Test `tests/unit/cli/test_hub_remote.py`: remote CLI flags, URL normalization, tool routing, and output rendering.
+- Test `tests/unit/server/rpc/handlers/test_hub_admin.py`: backend RPC admin enforcement and operation delegation.
+- Test `tests/unit/bricks/mcp/test_hub_admin_tools.py`: MCP tool registration, non-admin rejection, and remote RPC forwarding.
+- Update existing hub CLI tests only where import paths change because behavior moved into `admin_ops`.
+
+## Implementation Note From Code Inspection
+
+The approved design described MCP tools resolving a database auth provider directly. The repo now rejects embedded DB-backed HTTP MCP mode in `src/nexus/cli/commands/mcp.py`, and `nexus up` runs a two-service hub. To make the accepted `nexus up --build` verification meaningful, implement MCP tools as public admin tools that forward to new backend `hub_admin_*` RPC handlers. Those handlers run beside the database auth provider and enforce `is_admin` through the existing RPC context.
+
+## Task 1: Shared Hub Operation Tests
+
+**Files:**
+- Create: `tests/unit/hub/test_admin_ops.py`
+- Later create: `src/nexus/hub/admin_ops.py`
+
+- [ ] **Step 1: Write failing tests for shared create/list/revoke/status operations**
+
+Add this test file:
+
+```python
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from nexus.hub import admin_ops
+from nexus.storage.api_key_ops import create_api_key
+from nexus.storage.models._base import Base
+from nexus.storage.models.auth import ZoneModel
+
+
+@pytest.fixture
+def session_factory(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'hub.db'}")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    with SessionLocal() as session:
+        for zone_id in ("eng", "ops"):
+            session.add(ZoneModel(zone_id=zone_id, name=zone_id, phase="Active"))
+        session.commit()
+
+    @contextmanager
+    def _factory():
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    return _factory
+
+
+def test_create_hub_token_supports_multi_zone_permissions(session_factory):
+    result = admin_ops.create_hub_token(
+        session_factory,
+        name="remote-admin",
+        zones_csv="eng:r,ops:rw",
+        zones_glob=None,
+        is_admin=True,
+        expires=None,
+        user_id=None,
+    )
+
+    assert result["key_id"].startswith("nk_")
+    assert result["token"].startswith("sk_")
+    assert result["name"] == "remote-admin"
+    assert result["admin"] is True
+    assert result["zones"] == [{"zone_id": "eng", "permission": "r"}, {"zone_id": "ops", "permission": "rw"}]
+
+
+def test_list_hub_tokens_returns_local_cli_payload_shape(session_factory):
+    with session_factory() as session:
+        key_id, _ = create_api_key(
+            session,
+            user_id="alice",
+            name="alice-token",
+            zones=["eng", ("ops", "rw")],
+            is_admin=False,
+        )
+        session.commit()
+
+    payload = admin_ops.list_hub_tokens(session_factory, show_revoked=False)
+
+    assert payload["tokens"][0]["key_id"] == key_id
+    assert payload["tokens"][0]["name"] == "alice-token"
+    assert payload["tokens"][0]["zone"] == "eng"
+    assert payload["tokens"][0]["zones"] == [
+        {"zone_id": "eng", "permission": "rw"},
+        {"zone_id": "ops", "permission": "rw"},
+    ]
+
+
+def test_revoke_hub_token_matches_local_message(session_factory):
+    with session_factory() as session:
+        key_id, _ = create_api_key(session, user_id="alice", name="revoke-me", zones=["eng"])
+        session.commit()
+
+    result = admin_ops.revoke_hub_token(session_factory, identifier=key_id[:12])
+
+    assert result["key_id"] == key_id
+    assert result["name"] == "revoke-me"
+    assert result["message"] == f"revoked revoke-me ({key_id}). Effective within 60s (auth cache TTL)."
+
+
+def test_get_hub_status_reports_postgres_and_token_counts(session_factory, monkeypatch):
+    monkeypatch.setenv("NEXUS_MCP_HOST", "127.0.0.1")
+    monkeypatch.setenv("NEXUS_MCP_PORT", "8081")
+
+    with session_factory() as session:
+        create_api_key(session, user_id="admin", name="admin", zones=[], is_admin=True)
+        session.commit()
+
+    payload = admin_ops.get_hub_status(session_factory, redis_stats=lambda: {"status": "n/a"})
+
+    assert payload["postgres"] == "ok"
+    assert payload["tokens"] == {"active": 1, "revoked": 0}
+    assert payload["endpoint"] == "http://127.0.0.1:8081/mcp"
+```
+
+- [ ] **Step 2: Run the tests and verify they fail because `nexus.hub` does not exist**
+
+Run:
+
+```bash
+pytest tests/unit/hub/test_admin_ops.py -q
+```
+
+Expected: collection fails with `ModuleNotFoundError: No module named 'nexus.hub'`.
+
+## Task 2: Shared Hub Operations Implementation
+
+**Files:**
+- Create: `src/nexus/hub/__init__.py`
+- Create: `src/nexus/hub/admin_ops.py`
+- Modify: `src/nexus/cli/commands/hub.py`
+
+- [ ] **Step 1: Add the shared hub package and operations**
+
+Create `src/nexus/hub/__init__.py`:
+
+```python
+"""Shared hub administration helpers."""
+```
+
+Create `src/nexus/hub/admin_ops.py` with these public interfaces and move the matching complete logic from `src/nexus/cli/commands/hub.py`:
+
+```python
+class HubAdminError(Exception):
+    """Raised for user-facing hub admin failures."""
+
+
+class HubAdminAmbiguousTargetError(HubAdminError):
+    """Raised when a revoke identifier matches multiple active keys."""
+
+    def __init__(self, matches: list[tuple[str, str]]) -> None:
+        self.matches = matches
+        super().__init__("ambiguous token identifier")
+
+
+def parse_zones_csv(raw: str | None) -> list[str | tuple[str, str]]:
+    """Parse zone CSV values accepted by `nexus hub token create --zones`."""
+
+
+def parse_expires_at(raw: str | None) -> datetime | None:
+    """Convert CLI duration text into an absolute expiry timestamp."""
+
+
+def create_hub_token(
+    session_factory: Callable[[], ContextManager[Any]],
+    *,
+    name: str,
+    zones_csv: str | None,
+    zones_glob: str | None,
+    is_admin: bool,
+    expires: str | None,
+    user_id: str | None,
+) -> dict[str, Any]:
+    """Create a hub token and return the one-time token payload."""
+
+
+def list_hub_tokens(
+    session_factory: Callable[[], ContextManager[Any]],
+    *,
+    show_revoked: bool,
+) -> dict[str, Any]:
+    """Return the token list payload consumed by local and remote CLI output."""
+
+
+def revoke_hub_token(
+    session_factory: Callable[[], ContextManager[Any]],
+    *,
+    identifier: str,
+) -> dict[str, Any]:
+    """Revoke a token by exact key id, key id prefix, or name."""
+
+
+def get_hub_status(
+    session_factory: Callable[[], ContextManager[Any]],
+    *,
+    redis_stats: Callable[[], dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Return the hub status payload consumed by local and remote CLI output."""
+```
+
+Move the current local logic from `src/nexus/cli/commands/hub.py` into those functions without changing payload keys. Use `HubAdminError` instead of `click.ClickException`; keep `HubAdminAmbiguousTargetError.matches` so Click can print ambiguous matches before exiting 2.
+
+- [ ] **Step 2: Update local CLI paths to call `admin_ops`**
+
+In `src/nexus/cli/commands/hub.py`:
+
+```python
+from nexus.hub.admin_ops import (
+    HubAdminAmbiguousTargetError,
+    HubAdminError,
+    create_hub_token,
+    get_hub_status,
+    list_hub_tokens,
+    revoke_hub_token,
+)
+```
+
+Use the shared helpers in `token_create`, `token_list`, `token_revoke`, and `hub_status`. Convert `HubAdminError` to `click.ClickException`. Convert `HubAdminAmbiguousTargetError` by echoing the exact ambiguous rows to stderr and raising `SystemExit(2)`.
+
+- [ ] **Step 3: Verify shared operation and existing hub tests pass**
+
+Run:
+
+```bash
+pytest tests/unit/hub/test_admin_ops.py tests/unit/cli/test_hub.py tests/unit/cli/test_hub_token_list_primary_alias.py -q
+```
+
+Expected: all selected tests pass.
+
+## Task 3: Remote CLI Client Tests
+
+**Files:**
+- Create: `tests/unit/cli/test_hub_remote.py`
+- Later create: `src/nexus/cli/commands/_hub_remote.py`
+- Later modify: `src/nexus/cli/commands/hub.py`
+
+- [ ] **Step 1: Write failing remote CLI tests**
+
+Add `tests/unit/cli/test_hub_remote.py`:
+
+```python
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from nexus.cli.main import cli
+from nexus.cli.commands import _hub_remote
+
+
+def test_normalize_remote_url_appends_mcp_path():
+    assert _hub_remote.normalize_mcp_url("https://nexus.example.com") == "https://nexus.example.com/mcp"
+    assert _hub_remote.normalize_mcp_url("https://nexus.example.com/mcp") == "https://nexus.example.com/mcp"
+    assert _hub_remote.normalize_mcp_url("https://nexus.example.com/") == "https://nexus.example.com/mcp"
+
+
+def test_remote_list_requires_admin_token(monkeypatch):
+    monkeypatch.delenv("NEXUS_HUB_ADMIN_TOKEN", raising=False)
+
+    result = CliRunner().invoke(cli, ["hub", "token", "list", "--remote", "https://hub.example"])
+
+    assert result.exit_code != 0
+    assert "--admin-token or NEXUS_HUB_ADMIN_TOKEN is required with --remote" in result.output
+
+
+def test_remote_list_uses_env_token_and_renders_json(monkeypatch):
+    calls = []
+
+    def fake_call(remote, token, tool_name, arguments):
+        calls.append((remote, token, tool_name, arguments))
+        return {
+            "tokens": [
+                {
+                    "key_id": "nk_123",
+                    "name": "admin",
+                    "zone": None,
+                    "zones": [],
+                    "admin": True,
+                    "created": "2026-05-04T12:00:00",
+                    "last_used": None,
+                    "revoked": False,
+                    "revoked_at": None,
+                }
+            ]
+        }
+
+    monkeypatch.setenv("NEXUS_HUB_ADMIN_TOKEN", "sk_env")
+    monkeypatch.setattr("nexus.cli.commands.hub.call_hub_admin_tool", fake_call)
+
+    result = CliRunner().invoke(
+        cli,
+        ["hub", "token", "list", "--remote", "https://hub.example", "--json"],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [("https://hub.example", "sk_env", "nexus_hub_token_list", {"show_revoked": False})]
+    assert json.loads(result.output)["tokens"][0]["key_id"] == "nk_123"
+
+
+def test_remote_create_calls_mcp_tool_and_prints_one_time_token(monkeypatch):
+    calls = []
+
+    def fake_call(remote, token, tool_name, arguments):
+        calls.append((remote, token, tool_name, arguments))
+        return {"key_id": "nk_new", "token": "sk_new", "name": "ci", "admin": False, "zones": [{"zone_id": "eng", "permission": "rw"}]}
+
+    monkeypatch.setattr("nexus.cli.commands.hub.call_hub_admin_tool", fake_call)
+
+    result = CliRunner().invoke(
+        cli,
+        [
+            "hub",
+            "token",
+            "create",
+            "--name",
+            "ci",
+            "--zones",
+            "eng:rw",
+            "--remote",
+            "https://hub.example/mcp",
+            "--admin-token",
+            "sk_admin",
+        ],
+    )
+
+    assert result.exit_code == 0
+    assert calls[0] == (
+        "https://hub.example/mcp",
+        "sk_admin",
+        "nexus_hub_token_create",
+        {"name": "ci", "zones": "eng:rw", "zones_glob": None, "admin": False, "expires": None, "user_id": None},
+    )
+    assert "key_id: nk_new" in result.output
+    assert "token:  sk_new" in result.output
+
+
+def test_remote_revoke_calls_mcp_tool(monkeypatch):
+    calls = []
+
+    def fake_call(remote, token, tool_name, arguments):
+        calls.append((remote, token, tool_name, arguments))
+        return {"key_id": "nk_old", "name": "old", "message": "revoked old (nk_old). Effective within 60s (auth cache TTL)."}
+
+    monkeypatch.setattr("nexus.cli.commands.hub.call_hub_admin_tool", fake_call)
+
+    result = CliRunner().invoke(
+        cli,
+        ["hub", "token", "revoke", "old", "--remote", "https://hub.example", "--admin-token", "sk_admin"],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [("https://hub.example", "sk_admin", "nexus_hub_token_revoke", {"identifier": "old"})]
+    assert "revoked old (nk_old)" in result.output
+
+
+def test_remote_status_calls_mcp_tool_and_renders_json(monkeypatch):
+    calls = []
+
+    def fake_call(remote, token, tool_name, arguments):
+        calls.append((remote, token, tool_name, arguments))
+        return {"endpoint": "https://hub.example/mcp", "profile": "full", "postgres": "ok", "redis": "n/a", "tokens": {"active": 1, "revoked": 0}, "connections": None, "qps_5m": None}
+
+    monkeypatch.setattr("nexus.cli.commands.hub.call_hub_admin_tool", fake_call)
+
+    result = CliRunner().invoke(
+        cli,
+        ["hub", "status", "--remote", "https://hub.example", "--admin-token", "sk_admin", "--json"],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [("https://hub.example", "sk_admin", "nexus_hub_status", {})]
+    assert json.loads(result.output)["postgres"] == "ok"
+```
+
+- [ ] **Step 2: Run the tests and verify they fail on missing `_hub_remote` or missing options**
+
+Run:
+
+```bash
+pytest tests/unit/cli/test_hub_remote.py -q
+```
+
+Expected: failure from missing `nexus.cli.commands._hub_remote` or missing `--remote` options.
+
+## Task 4: Remote CLI Client Implementation
+
+**Files:**
+- Create: `src/nexus/cli/commands/_hub_remote.py`
+- Modify: `src/nexus/cli/commands/hub.py`
+
+- [ ] **Step 1: Implement MCP HTTP helper**
+
+Create `src/nexus/cli/commands/_hub_remote.py` with:
+
+```python
+from __future__ import annotations
+
+import json
+import uuid
+from typing import Any
+from urllib.parse import urlparse, urlunparse
+
+import httpx
+
+
+class HubRemoteError(Exception):
+    pass
+
+
+def normalize_mcp_url(remote: str) -> str:
+    parsed = urlparse(remote)
+    if not parsed.scheme or not parsed.netloc:
+        raise HubRemoteError(f"invalid remote URL: {remote}")
+    path = parsed.path.rstrip("/")
+    if path in ("", "/"):
+        path = "/mcp"
+    elif path != "/mcp":
+        path = f"{path}/mcp"
+    return urlunparse((parsed.scheme, parsed.netloc, path, "", "", ""))
+
+
+def call_hub_admin_tool(remote: str, admin_token: str, tool_name: str, arguments: dict[str, Any]) -> dict[str, Any]:
+    url = normalize_mcp_url(remote)
+    headers = {"Authorization": f"Bearer {admin_token}", "Accept": "application/json, text/event-stream"}
+    with httpx.Client(timeout=30.0) as client:
+        session_id = _initialize(client, url, headers)
+        headers["Mcp-Session-Id"] = session_id
+        _notify_initialized(client, url, headers)
+        envelope = _post_json_rpc(
+            client,
+            url,
+            headers,
+            {"jsonrpc": "2.0", "id": 2, "method": "tools/call", "params": {"name": tool_name, "arguments": arguments}},
+        )
+    return _extract_tool_payload(envelope)
+```
+
+Also add private helpers `_initialize`, `_notify_initialized`, `_post_json_rpc`, `_decode_sse_json`, and `_extract_tool_payload`. `_extract_tool_payload` must raise `HubRemoteError` when the MCP envelope has `error`, when tool text starts with `Error:`, or when content is not valid JSON.
+
+- [ ] **Step 2: Wire remote options into hub commands**
+
+Add `--remote` and `--admin-token` to the scoped commands only. Use:
+
+```python
+def _resolve_remote_admin_token(admin_token: str | None, remote: str | None) -> str | None:
+    if not remote:
+        return None
+    token = admin_token or os.environ.get("NEXUS_HUB_ADMIN_TOKEN")
+    if not token:
+        raise click.ClickException("--admin-token or NEXUS_HUB_ADMIN_TOKEN is required with --remote")
+    return token
+```
+
+In each command, branch before local DB work:
+
+```python
+if remote:
+    token = _resolve_remote_admin_token(admin_token, remote)
+    payload = call_hub_admin_tool(remote, token, "nexus_hub_token_list", {"show_revoked": show_revoked})
+    _render_token_list(payload, as_json=as_json)
+    return
+```
+
+Use equivalent tool names and argument dictionaries from the tests for create, revoke, and status.
+
+- [ ] **Step 3: Verify remote CLI tests pass**
+
+Run:
+
+```bash
+pytest tests/unit/cli/test_hub_remote.py -q
+```
+
+Expected: all tests pass.
+
+## Task 5: Backend Hub Admin RPC Tests
+
+**Files:**
+- Create: `tests/unit/server/rpc/handlers/test_hub_admin.py`
+- Later create: `src/nexus/server/rpc/handlers/hub_admin.py`
+- Later modify: `src/nexus/server/_rpc_param_overrides.py`
+- Later modify: `src/nexus/server/rpc/dispatch.py`
+
+- [ ] **Step 1: Write failing backend RPC handler tests**
+
+Add `tests/unit/server/rpc/handlers/test_hub_admin.py`:
+
+```python
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from nexus.contracts.exceptions import NexusPermissionError
+from nexus.server.rpc.handlers import hub_admin
+
+
+def test_hub_admin_list_requires_admin_before_operation(monkeypatch):
+    called = False
+
+    def fake_list(*args, **kwargs):
+        nonlocal called
+        called = True
+        return {"tokens": []}
+
+    monkeypatch.setattr(hub_admin.admin_ops, "list_hub_tokens", fake_list)
+
+    with pytest.raises(NexusPermissionError):
+        hub_admin.handle_hub_admin_token_list(
+            SimpleNamespace(session_factory=lambda: None),
+            SimpleNamespace(show_revoked=False),
+            SimpleNamespace(is_admin=False, user_id="bob"),
+        )
+
+    assert called is False
+
+
+def test_hub_admin_create_delegates_to_shared_ops(monkeypatch):
+    calls = []
+
+    def fake_create(session_factory, **kwargs):
+        calls.append((session_factory, kwargs))
+        return {"key_id": "nk_1", "token": "sk_1"}
+
+    monkeypatch.setattr(hub_admin.admin_ops, "create_hub_token", fake_create)
+    auth_provider = SimpleNamespace(session_factory="factory")
+
+    result = hub_admin.handle_hub_admin_token_create(
+        auth_provider,
+        SimpleNamespace(name="ci", zones="eng:rw", zones_glob=None, admin=True, expires="7d", user_id="u1"),
+        SimpleNamespace(is_admin=True, user_id="admin"),
+    )
+
+    assert result == {"key_id": "nk_1", "token": "sk_1"}
+    assert calls == [
+        (
+            "factory",
+            {"name": "ci", "zones_csv": "eng:rw", "zones_glob": None, "is_admin": True, "expires": "7d", "user_id": "u1"},
+        )
+    ]
+
+
+def test_hub_admin_revoke_delegates_to_shared_ops(monkeypatch):
+    calls = []
+
+    def fake_revoke(session_factory, **kwargs):
+        calls.append((session_factory, kwargs))
+        return {"key_id": "nk_1", "name": "old", "message": "revoked old (nk_1). Effective within 60s (auth cache TTL)."}
+
+    monkeypatch.setattr(hub_admin.admin_ops, "revoke_hub_token", fake_revoke)
+
+    result = hub_admin.handle_hub_admin_token_revoke(
+        SimpleNamespace(session_factory="factory"),
+        SimpleNamespace(identifier="old"),
+        SimpleNamespace(is_admin=True, user_id="admin"),
+    )
+
+    assert result["key_id"] == "nk_1"
+    assert calls == [("factory", {"identifier": "old"})]
+```
+
+- [ ] **Step 2: Run the tests and verify they fail on missing handler module**
+
+Run:
+
+```bash
+pytest tests/unit/server/rpc/handlers/test_hub_admin.py -q
+```
+
+Expected: import failure for `nexus.server.rpc.handlers.hub_admin`.
+
+## Task 6: Backend Hub Admin RPC Implementation
+
+**Files:**
+- Create: `src/nexus/server/rpc/handlers/hub_admin.py`
+- Modify: `src/nexus/server/_rpc_param_overrides.py`
+- Modify: `src/nexus/server/rpc/dispatch.py`
+
+- [ ] **Step 1: Implement handler module**
+
+Create `src/nexus/server/rpc/handlers/hub_admin.py`:
+
+```python
+from __future__ import annotations
+
+from typing import Any
+
+from nexus.hub import admin_ops
+from nexus.server.rpc.handlers.admin import require_admin, require_database_auth
+
+
+def _session_factory(auth_provider: Any) -> Any:
+    require_database_auth(auth_provider)
+    return auth_provider.session_factory
+
+
+def handle_hub_admin_token_create(auth_provider: Any, params: Any, context: Any) -> dict[str, Any]:
+    require_admin(context)
+    return admin_ops.create_hub_token(
+        _session_factory(auth_provider),
+        name=params.name,
+        zones_csv=getattr(params, "zones", None),
+        zones_glob=getattr(params, "zones_glob", None),
+        is_admin=bool(getattr(params, "admin", False)),
+        expires=getattr(params, "expires", None),
+        user_id=getattr(params, "user_id", None),
+    )
+
+
+def handle_hub_admin_token_list(auth_provider: Any, params: Any, context: Any) -> dict[str, Any]:
+    require_admin(context)
+    return admin_ops.list_hub_tokens(_session_factory(auth_provider), show_revoked=bool(getattr(params, "show_revoked", False)))
+
+
+def handle_hub_admin_token_revoke(auth_provider: Any, params: Any, context: Any) -> dict[str, Any]:
+    require_admin(context)
+    return admin_ops.revoke_hub_token(_session_factory(auth_provider), identifier=params.identifier)
+
+
+def handle_hub_admin_status(auth_provider: Any, params: Any, context: Any) -> dict[str, Any]:
+    require_admin(context)
+    return admin_ops.get_hub_status(_session_factory(auth_provider))
+```
+
+- [ ] **Step 2: Add RPC params and dispatch entries**
+
+In `src/nexus/server/_rpc_param_overrides.py`, add dataclasses and entries:
+
+```python
+@dataclass
+class HubAdminTokenCreateParams:
+    name: str
+    zones: str | None = None
+    zones_glob: str | None = None
+    admin: bool = False
+    expires: str | None = None
+    user_id: str | None = None
+
+
+@dataclass
+class HubAdminTokenListParams:
+    show_revoked: bool = False
+
+
+@dataclass
+class HubAdminTokenRevokeParams:
+    identifier: str
+
+
+@dataclass
+class HubAdminStatusParams:
+    pass
+```
+
+Add `OVERRIDE_METHOD_PARAMS` entries for `hub_admin_token_create`, `hub_admin_token_list`, `hub_admin_token_revoke`, and `hub_admin_status`.
+
+In `src/nexus/server/rpc/dispatch.py`, import the four handlers inside `build_dispatch_table()` and add:
+
+```python
+"hub_admin_token_create": DispatchEntry(handle_hub_admin_token_create, pass_auth_provider=True),
+"hub_admin_token_list": DispatchEntry(handle_hub_admin_token_list, pass_auth_provider=True),
+"hub_admin_token_revoke": DispatchEntry(handle_hub_admin_token_revoke, pass_auth_provider=True),
+"hub_admin_status": DispatchEntry(handle_hub_admin_status, pass_auth_provider=True),
+```
+
+- [ ] **Step 3: Verify backend RPC tests pass**
+
+Run:
+
+```bash
+pytest tests/unit/server/rpc/handlers/test_hub_admin.py -q
+```
+
+Expected: all tests pass.
+
+## Task 7: MCP Hub Admin Tool Tests
+
+**Files:**
+- Create: `tests/unit/bricks/mcp/test_hub_admin_tools.py`
+- Later modify: `src/nexus/bricks/mcp/server.py`
+- Later modify: `src/nexus/__init__.py`
+
+- [ ] **Step 1: Write failing MCP tool tests**
+
+Add `tests/unit/bricks/mcp/test_hub_admin_tools.py`:
+
+```python
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from nexus.bricks.mcp.server import create_mcp_server
+
+
+async def _get_tool(server, name):
+    tools = await server.get_tools()
+    return tools[name].fn
+
+
+@pytest.mark.asyncio
+async def test_hub_admin_tool_forwards_to_remote_rpc():
+    calls = []
+
+    def fake_call_rpc(method, params):
+        calls.append((method, params))
+        return {"tokens": [{"key_id": "nk_1", "name": "admin"}]}
+
+    nx = SimpleNamespace(is_admin=True, _nexus_remote_call_rpc=fake_call_rpc)
+    server = await create_mcp_server(nx=nx)
+    tool = await _get_tool(server, "nexus_hub_token_list")
+
+    result = await tool(show_revoked=True)
+
+    assert calls == [("hub_admin_token_list", {"show_revoked": True})]
+    assert json.loads(result)["tokens"][0]["key_id"] == "nk_1"
+
+
+@pytest.mark.asyncio
+async def test_hub_admin_tool_rejects_non_admin_before_rpc():
+    calls = []
+
+    def fake_call_rpc(method, params):
+        calls.append((method, params))
+        return {"tokens": []}
+
+    nx = SimpleNamespace(is_admin=False, _nexus_remote_call_rpc=fake_call_rpc)
+    server = await create_mcp_server(nx=nx)
+    tool = await _get_tool(server, "nexus_hub_token_list")
+
+    result = await tool(show_revoked=False)
+
+    assert calls == []
+    assert result.startswith("Error:")
+    assert "Admin privileges required" in result
+```
+
+- [ ] **Step 2: Run the tests and verify they fail because the MCP tools are not registered**
+
+Run:
+
+```bash
+pytest tests/unit/bricks/mcp/test_hub_admin_tools.py -q
+```
+
+Expected: `KeyError: 'nexus_hub_token_list'`.
+
+## Task 8: MCP Hub Admin Tool Implementation
+
+**Files:**
+- Modify: `src/nexus/bricks/mcp/server.py`
+- Modify: `src/nexus/__init__.py`
+
+- [ ] **Step 1: Expose remote RPC transport on remote NexusFS**
+
+In the `cfg.profile == "remote"` branch of `src/nexus/__init__.py`, after `install_remote_kernel_rpc_overrides(nfs, transport)`, add:
+
+```python
+cast(Any, nfs)._nexus_remote_call_rpc = transport.call_rpc
+```
+
+This gives MCP tools a stable private hook to call backend hub-admin RPC methods through the same per-request remote connection they already use for filesystem operations.
+
+- [ ] **Step 2: Register MCP admin tools**
+
+In `src/nexus/bricks/mcp/server.py`, add a small helper near the tool definitions:
+
+```python
+def _require_hub_admin(nx_instance: Any) -> None:
+    op_context = _resolve_mcp_operation_context(nx_instance, auth_provider=auth_provider)
+    if not getattr(op_context, "is_admin", False):
+        raise PermissionError("Admin privileges required for hub administration")
+```
+
+Add tools:
+
+```python
+@mcp.tool()
+@handle_tool_errors
+async def nexus_hub_token_list(show_revoked: bool = False) -> str:
+    nx_instance = await _get_nexus_instance()
+    _require_hub_admin(nx_instance)
+    call_rpc = getattr(nx_instance, "_nexus_remote_call_rpc", None)
+    if call_rpc is None:
+        raise RuntimeError("hub admin tools require a remote hub backend")
+    return json.dumps(call_rpc("hub_admin_token_list", {"show_revoked": show_revoked}))
+```
+
+Add equivalent tools for create, revoke, and status:
+
+```python
+call_rpc("hub_admin_token_create", {"name": name, "zones": zones, "zones_glob": zones_glob, "admin": admin, "expires": expires, "user_id": user_id})
+call_rpc("hub_admin_token_revoke", {"identifier": identifier})
+call_rpc("hub_admin_status", {})
+```
+
+- [ ] **Step 3: Verify MCP tool tests pass**
+
+Run:
+
+```bash
+pytest tests/unit/bricks/mcp/test_hub_admin_tools.py -q
+```
+
+Expected: all tests pass.
+
+## Task 9: Full Targeted Verification
+
+**Files:**
+- All files changed in Tasks 1-8.
+
+- [ ] **Step 1: Run the targeted unit suite**
+
+Run:
+
+```bash
+pytest \
+  tests/unit/hub/test_admin_ops.py \
+  tests/unit/cli/test_hub.py \
+  tests/unit/cli/test_hub_remote.py \
+  tests/unit/cli/test_hub_token_list_primary_alias.py \
+  tests/unit/server/rpc/handlers/test_hub_admin.py \
+  tests/unit/server/rpc/handlers/test_admin_primary_alias.py \
+  tests/unit/server/rpc/handlers/test_admin_junction_filter.py \
+  tests/unit/bricks/mcp/test_hub_admin_tools.py \
+  tests/unit/bricks/mcp/test_mcp_server_tools.py \
+  tests/unit/cli/test_mcp_embedded_hub_rejection.py \
+  -q
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 2: Run lint/type checks used by this repo if available**
+
+Run:
+
+```bash
+python -m compileall src/nexus/hub src/nexus/cli/commands/_hub_remote.py src/nexus/server/rpc/handlers/hub_admin.py
+```
+
+Expected: command exits 0.
+
+- [ ] **Step 3: Commit the tested implementation**
+
+Run:
+
+```bash
+git status --short
+git add src/nexus/hub src/nexus/cli/commands/_hub_remote.py src/nexus/cli/commands/hub.py src/nexus/bricks/mcp/server.py src/nexus/server/_rpc_param_overrides.py src/nexus/server/rpc/dispatch.py src/nexus/server/rpc/handlers/hub_admin.py src/nexus/__init__.py tests/unit/hub/test_admin_ops.py tests/unit/cli/test_hub_remote.py tests/unit/server/rpc/handlers/test_hub_admin.py tests/unit/bricks/mcp/test_hub_admin_tools.py
+git commit -m "feat: add remote hub admin cli"
+```
+
+Expected: commit succeeds.
+
+## Task 10: Stack Smoke Verification
+
+**Files:**
+- No source edits expected.
+
+- [ ] **Step 1: Start the local hub stack from this branch**
+
+Run:
+
+```bash
+nexus up --build
+```
+
+Expected: stack starts and prints MCP/RPC endpoint information. If port conflicts occur, stop the conflicting prior stack with the repo's documented stop command and rerun `nexus up --build`.
+
+- [ ] **Step 2: Bootstrap an admin token locally**
+
+Run with the stack's database URL from the generated environment:
+
+```bash
+nexus hub token create --name workstation-admin --admin
+```
+
+Expected: output contains `key_id:` and one-time `token:`.
+
+- [ ] **Step 3: Verify remote list, create, revoke, and status**
+
+Run with the token from Step 2:
+
+```bash
+nexus hub token list --remote http://localhost:8081 --admin-token <admin-token>
+nexus hub token create --remote http://localhost:8081 --admin-token <admin-token> --name remote-ci --zones '*'
+nexus hub token revoke remote-ci --remote http://localhost:8081 --admin-token <admin-token>
+nexus hub status --remote http://localhost:8081 --admin-token <admin-token>
+```
+
+Expected: list and status exit 0, create prints a one-time token, revoke prints the standard revoke message.
+
+- [ ] **Step 4: Verify non-admin denial**
+
+Use the non-admin token created in Step 3:
+
+```bash
+nexus hub token list --remote http://localhost:8081 --admin-token <non-admin-token>
+```
+
+Expected: command exits non-zero and includes `Admin privileges required`.

--- a/docs/superpowers/specs/2026-05-04-issue-3872-remote-hub-admin-cli-design.md
+++ b/docs/superpowers/specs/2026-05-04-issue-3872-remote-hub-admin-cli-design.md
@@ -1,0 +1,171 @@
+# Issue #3872 - Remote Hub Admin CLI Design
+
+**Date**: 2026-05-04
+**Issue**: [#3872](https://github.com/nexi-lab/nexus/issues/3872) - feat: remote admin CLI for hub mode
+**Follow-up to**: [#3784](https://github.com/nexi-lab/nexus/issues/3784) - hub mode
+
+## Context
+
+The current `nexus hub token` CLI is a local operator tool. It uses
+`NEXUS_DATABASE_URL` through `src/nexus/cli/commands/_hub_common.py` and
+therefore must run on the hub host or inside the hub container. Issue #3872
+adds workstation administration:
+
+```bash
+nexus hub token create --remote https://nexus.example.com --admin-token sk-...
+nexus hub token list --remote https://nexus.example.com --admin-token sk-...
+nexus hub token revoke <id-or-name> --remote https://nexus.example.com --admin-token sk-...
+nexus hub status --remote https://nexus.example.com --admin-token sk-...
+```
+
+The hub deployment already exposes MCP HTTP at `/mcp`, and the MCP middleware
+already extracts bearer tokens into the request context. Existing server-side
+admin RPC handlers (`admin_create_key`, `admin_list_keys`, `admin_revoke_key`)
+already require `is_admin`, but they are gRPC/internal RPC surfaces, not the
+public MCP endpoint requested by this issue.
+
+## Decision
+
+Implement remote hub administration over the existing MCP HTTP endpoint. The
+CLI's `--remote` flag targets the hub MCP endpoint, and `--admin-token` is sent
+as a bearer token. The MCP server exposes admin tools that wrap the same token
+operations as the local CLI path. Each admin MCP tool resolves the caller from
+the request token and refuses non-admin callers with a 403-equivalent MCP tool
+error.
+
+This keeps day-to-day administration on the same public hub URL used by agents,
+while preserving the bootstrap model: the first admin token is still created
+locally, then copied to the workstation.
+
+## Non-goals
+
+- Do not expose the gRPC port or require workstation gRPC access.
+- Do not replace the existing local `NEXUS_DATABASE_URL` path.
+- Do not add token storage on the workstation.
+- Do not add multi-zone token features beyond the behavior already present from
+  issue #3871.
+- Do not add a broader management API beyond create, list, revoke, and status.
+
+## Architecture
+
+### Shared Hub Operations
+
+Add a focused helper module for hub token operations, for example
+`src/nexus/cli/commands/_hub_token_ops.py`. It owns the DB-backed behavior
+currently embedded in `hub.py`:
+
+- parse zone CSV and permissions
+- validate duplicate names and active zones
+- create tokens through `nexus.storage.api_key_ops.create_api_key`
+- list tokens with primary zone and zone allow-list
+- resolve and revoke tokens by key ID prefix or name
+- build the status payload from Postgres and Redis
+
+The local CLI and MCP admin tools both call these helpers. The helpers receive a
+SQLAlchemy session factory and return structured dictionaries. `hub.py` remains
+responsible for Click options and human output.
+
+### MCP Admin Tools
+
+Add admin-only MCP tools inside `src/nexus/bricks/mcp/server.py`, or in a small
+helper imported by that module if the local file size becomes too large:
+
+- `nexus_hub_token_create`
+- `nexus_hub_token_list`
+- `nexus_hub_token_revoke`
+- `nexus_hub_status`
+
+Each tool:
+
+1. Reads the per-request API key from the existing MCP context variable.
+2. Authenticates it with the existing `auth_provider`.
+3. Requires `authenticated=True` and `is_admin=True`.
+4. Resolves a DB session factory from the database auth provider.
+5. Calls the shared hub operation helper.
+6. Returns JSON strings so the CLI can parse a stable machine contract.
+
+If no auth provider or DB session factory is available, the tools return a
+configuration error. If authentication fails or the token is non-admin, they
+return a permission error. Non-admin tokens must not reach the DB operation.
+
+### Remote CLI Client
+
+Add `--remote` and `--admin-token` to:
+
+- `nexus hub token create`
+- `nexus hub token list`
+- `nexus hub token revoke`
+- `nexus hub status`
+
+When `--remote` is absent, behavior stays unchanged and uses local DB access.
+When `--remote` is present:
+
+- `--admin-token` is required unless `NEXUS_HUB_ADMIN_TOKEN` is set.
+- `https://host` normalizes to `https://host/mcp`.
+- `https://host/mcp` is used unchanged.
+- The CLI performs one MCP initialize handshake, sends
+  `notifications/initialized`, then calls the relevant admin tool with
+  `tools/call`.
+- The CLI reuses existing local output formatting so remote `list` and local
+  `list` look the same.
+
+`--admin-token` is accepted as requested by the issue. The environment variable
+exists to keep tokens out of shell history for operators who prefer that.
+
+## Data Flow
+
+Create:
+
+```text
+CLI --remote/--admin-token
+  -> MCP HTTP /mcp Authorization: Bearer <admin-token>
+  -> tool nexus_hub_token_create
+  -> authenticate request token via auth_provider
+  -> require is_admin
+  -> shared create helper
+  -> api_keys and api_key_zones rows
+  -> JSON result with key_id and one-time raw token
+  -> CLI prints same output as local create
+```
+
+List, revoke, and status follow the same path, replacing the helper operation.
+
+## Error Handling
+
+- Missing `--admin-token` with `--remote`: Click error.
+- Bad remote URL or HTTP failure: Click error with remote URL and status.
+- MCP tool error: Click error with the tool error message.
+- Non-admin token: MCP tool returns permission error; CLI exits non-zero.
+- Missing DB-backed auth provider on the MCP server: configuration error.
+- Ambiguous revoke target: preserve local behavior and exit code semantics as
+  closely as Click allows.
+
+## Testing
+
+Unit tests first:
+
+- Remote CLI builds the correct MCP tool call for create, list, revoke, and
+  status.
+- `--remote` normalizes host URLs to `/mcp`.
+- `--remote` requires `--admin-token` or `NEXUS_HUB_ADMIN_TOKEN`.
+- MCP admin helpers reject non-admin auth results before invoking operations.
+- MCP admin helpers call the shared operation with an admin auth result.
+- Local hub token tests continue passing against the shared helper extraction.
+
+Integration/E2E:
+
+- Start a fresh local stack with `nexus up --build`.
+- Bootstrap one admin token locally.
+- `nexus hub token list --remote http://localhost:<mcp-port> --admin-token <admin>`
+  returns the same token rows as local list.
+- A non-admin token calling remote admin receives a permission failure.
+- `--remote` works for create, list, revoke, and status.
+
+## Acceptance Mapping
+
+- `nexus hub token list --remote https://... --admin-token sk-...` returns the
+  same output as local list: shared operation helper plus reused CLI formatter.
+- Non-admin tokens receive 403 from the admin RPC: MCP admin tools require
+  `is_admin` before calling hub operations.
+- `--remote` works for create, list, revoke, status: each command receives a
+  remote branch and maps to an MCP admin tool.

--- a/nexus-stack.yml
+++ b/nexus-stack.yml
@@ -295,7 +295,7 @@ services:
   # MCP Server (optional add-on)
   # ============================================================================
   mcp-server:
-    image: ${NEXUS_IMAGE_REF:-nexus-server:latest}
+    image: ${NEXUS_IMAGE_REF:-ghcr.io/nexi-lab/nexus:latest}
     restart: unless-stopped
     profiles:
       - mcp

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -447,6 +447,7 @@ def connect(
 
         _boot_remote_services(nfs, call_rpc=transport.call_rpc)
         install_remote_kernel_rpc_overrides(nfs, transport)
+        cast(Any, nfs)._nexus_remote_call_rpc = transport.call_rpc
         nfs._register_runtime_closeable(transport)
 
         return nfs

--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -410,6 +410,104 @@ async def create_mcp_server(
         return hook.get_structure_listing(path, content=content, content_id=content_id)
 
     # =========================================================================
+    # HUB ADMIN TOOLS
+    # =========================================================================
+
+    async def _call_hub_admin_rpc(
+        nx_instance: Any,
+        method: str,
+        params: dict[str, Any],
+    ) -> str:
+        call_rpc = getattr(nx_instance, "_nexus_remote_call_rpc", None)
+        op_context = _resolve_mcp_operation_context(nx_instance, auth_provider=auth_provider)
+        if not getattr(op_context, "is_admin", False):
+            request_key = _request_api_key.get()
+            if not request_key or call_rpc is None:
+                return tool_error(
+                    "permission_denied",
+                    "Admin privileges required for hub administration",
+                )
+
+        if call_rpc is None:
+            return tool_error(
+                "unavailable",
+                "Hub admin tools require a remote hub backend",
+            )
+
+        try:
+            result = call_rpc(method, params)
+        except Exception as exc:
+            from nexus.contracts.exceptions import NexusPermissionError
+
+            if isinstance(exc, NexusPermissionError):
+                return tool_error("permission_denied", str(exc))
+            raise
+        if inspect.isawaitable(result):
+            result = await result
+        return json.dumps(result)
+
+    @mcp.tool()
+    @handle_tool_errors("listing hub tokens")
+    async def nexus_hub_token_list(
+        show_revoked: bool = False,
+        ctx: Context | None = None,
+    ) -> str:
+        """List hub API tokens. Requires a global admin token."""
+        nx_instance = _get_nexus_instance(ctx)
+        return await _call_hub_admin_rpc(
+            nx_instance,
+            "hub_admin_token_list",
+            {"show_revoked": show_revoked},
+        )
+
+    @mcp.tool()
+    @handle_tool_errors("creating hub token")
+    async def nexus_hub_token_create(
+        name: str,
+        zones: str | None = None,
+        zones_glob: str | None = None,
+        admin: bool = False,
+        expires: str | None = None,
+        user_id: str | None = None,
+        ctx: Context | None = None,
+    ) -> str:
+        """Create a hub API token and return its one-time secret. Requires admin."""
+        nx_instance = _get_nexus_instance(ctx)
+        return await _call_hub_admin_rpc(
+            nx_instance,
+            "hub_admin_token_create",
+            {
+                "name": name,
+                "zones": zones,
+                "zones_glob": zones_glob,
+                "admin": admin,
+                "expires": expires,
+                "user_id": user_id,
+            },
+        )
+
+    @mcp.tool()
+    @handle_tool_errors("revoking hub token")
+    async def nexus_hub_token_revoke(
+        identifier: str,
+        ctx: Context | None = None,
+    ) -> str:
+        """Revoke a hub API token by id, id prefix, or name. Requires admin."""
+        nx_instance = _get_nexus_instance(ctx)
+        return await _call_hub_admin_rpc(
+            nx_instance,
+            "hub_admin_token_revoke",
+            {"identifier": identifier},
+        )
+
+    @mcp.tool()
+    @handle_tool_errors("reading hub status")
+    async def nexus_hub_status(ctx: Context | None = None) -> str:
+        """Read hub status. Requires admin."""
+        nx_instance = _get_nexus_instance(ctx)
+        return await _call_hub_admin_rpc(nx_instance, "hub_admin_status", {})
+
+    # =========================================================================
     # FILE OPERATIONS TOOLS
     # =========================================================================
 

--- a/src/nexus/cli/commands/_hub_remote.py
+++ b/src/nexus/cli/commands/_hub_remote.py
@@ -1,0 +1,156 @@
+"""MCP HTTP client helpers for remote `nexus hub` administration."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.parse import urlparse, urlunparse
+
+import httpx
+
+
+class HubRemoteError(Exception):
+    """Raised for user-facing remote hub administration failures."""
+
+
+def normalize_mcp_url(remote: str) -> str:
+    """Normalize a hub base URL to its MCP streamable HTTP endpoint."""
+    parsed = urlparse(remote)
+    if not parsed.scheme or not parsed.netloc:
+        raise HubRemoteError(f"invalid remote URL: {remote}")
+
+    path = parsed.path.rstrip("/")
+    if path in ("", "/"):
+        path = "/mcp"
+    elif path != "/mcp":
+        path = f"{path}/mcp"
+    return urlunparse((parsed.scheme, parsed.netloc, path, "", "", ""))
+
+
+def call_hub_admin_tool(
+    remote: str,
+    admin_token: str,
+    tool_name: str,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    """Call one hub admin MCP tool and return its JSON object payload."""
+    url = normalize_mcp_url(remote)
+    headers = {
+        "Authorization": f"Bearer {admin_token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+
+    try:
+        with httpx.Client(timeout=30.0) as client:
+            session_id = _initialize(client, url, headers)
+            session_headers = {**headers, "Mcp-Session-Id": session_id}
+            _notify_initialized(client, url, session_headers)
+            envelope = _post_json_rpc(
+                client,
+                url,
+                session_headers,
+                {
+                    "jsonrpc": "2.0",
+                    "id": 2,
+                    "method": "tools/call",
+                    "params": {"name": tool_name, "arguments": arguments},
+                },
+            )
+    except httpx.HTTPStatusError as exc:
+        raise HubRemoteError(
+            f"remote hub request failed: {exc.response.status_code} {exc.response.reason_phrase}"
+        ) from exc
+    except httpx.HTTPError as exc:
+        raise HubRemoteError(f"remote hub request failed: {exc}") from exc
+
+    return _extract_tool_payload(envelope)
+
+
+def _initialize(client: httpx.Client, url: str, headers: dict[str, str]) -> str:
+    envelope = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "nexus-hub-cli", "version": "1"},
+        },
+    }
+    with client.stream("POST", url, headers=headers, json=envelope) as response:
+        response.raise_for_status()
+        session_id_raw = response.headers.get("mcp-session-id") or response.headers.get(
+            "Mcp-Session-Id"
+        )
+        for _line in response.iter_lines():
+            pass
+    if not isinstance(session_id_raw, str) or not session_id_raw:
+        raise HubRemoteError("remote hub MCP initialize did not return a session id")
+    return session_id_raw
+
+
+def _notify_initialized(client: httpx.Client, url: str, headers: dict[str, str]) -> None:
+    response = client.post(
+        url,
+        headers=headers,
+        json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+    )
+    response.raise_for_status()
+
+
+def _post_json_rpc(
+    client: httpx.Client,
+    url: str,
+    headers: dict[str, str],
+    envelope: dict[str, Any],
+) -> dict[str, Any]:
+    with client.stream("POST", url, headers=headers, json=envelope) as response:
+        response.raise_for_status()
+        for line in response.iter_lines():
+            if line.startswith("data: "):
+                return _decode_sse_json(line)
+    raise HubRemoteError("remote hub MCP response did not include a data event")
+
+
+def _decode_sse_json(line: str) -> dict[str, Any]:
+    try:
+        payload = json.loads(line[6:])
+    except json.JSONDecodeError as exc:
+        raise HubRemoteError("remote hub MCP response contained invalid JSON") from exc
+    if not isinstance(payload, dict):
+        raise HubRemoteError("remote hub MCP response was not a JSON object")
+    return payload
+
+
+def _extract_tool_payload(envelope: dict[str, Any]) -> dict[str, Any]:
+    if envelope.get("error") is not None:
+        error = envelope["error"]
+        message = (error.get("message") or str(error)) if isinstance(error, dict) else str(error)
+        raise HubRemoteError(message)
+
+    result = envelope.get("result")
+    if not isinstance(result, dict):
+        raise HubRemoteError("remote hub MCP response did not include a tool result")
+
+    content = result.get("content")
+    if not isinstance(content, list) or not content:
+        raise HubRemoteError("remote hub MCP tool result did not include content")
+
+    first = content[0]
+    if not isinstance(first, dict):
+        raise HubRemoteError("remote hub MCP tool content was malformed")
+
+    text = first.get("text")
+    if not isinstance(text, str):
+        raise HubRemoteError("remote hub MCP tool content was not text")
+    if text.startswith("Error:"):
+        raise HubRemoteError(text.removeprefix("Error:").strip())
+
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise HubRemoteError("remote hub MCP tool returned invalid JSON") from exc
+    if not isinstance(payload, dict):
+        raise HubRemoteError("remote hub MCP tool returned non-object JSON")
+    return payload

--- a/src/nexus/cli/commands/hub.py
+++ b/src/nexus/cli/commands/hub.py
@@ -20,12 +20,19 @@ from sqlalchemy import func, select
 from nexus.cli.commands._hub_common import (
     format_table,
     get_session_factory,
-    parse_duration,
+)
+from nexus.cli.commands._hub_remote import HubRemoteError, call_hub_admin_tool
+from nexus.hub.admin_ops import (
+    HubAdminAmbiguousTargetError,
+    HubAdminError,
+    create_hub_token,
+    list_hub_tokens,
+    parse_zones_csv,
+    revoke_hub_token,
 )
 from nexus.storage.api_key_ops import (
     add_zone_to_key,
     create_api_key,
-    get_primary_zones_for_keys,
     get_zone_perms_for_key,
     remove_zone_from_key,
 )
@@ -40,26 +47,10 @@ def _parse_zones_csv(raw: str) -> list[str | tuple[str, str]]:
     Bare entries (no colon) default to ``"rw"`` and are returned as plain
     strings so ``create_api_key`` records the default uniformly.
     """
-    out: list[str | tuple[str, str]] = []
-    for chunk in raw.split(","):
-        item = chunk.strip()
-        if not item:
-            continue
-        if ":" in item:
-            zid, perms = item.split(":", 1)
-            zid = zid.strip()
-            perms = perms.strip()
-            if not zid:
-                raise click.ClickException(f"empty zone id in {chunk!r}")
-            if perms not in _VALID_PERMS:
-                raise click.ClickException(
-                    f"invalid permissions {perms!r} for zone {zid!r}; "
-                    f"expected one of {', '.join(_VALID_PERMS)}"
-                )
-            out.append((zid, perms))
-        else:
-            out.append(item)
-    return out
+    try:
+        return parse_zones_csv(raw)
+    except HubAdminError as exc:
+        raise click.ClickException(str(exc)) from exc
 
 
 @click.group()
@@ -104,6 +95,8 @@ def token() -> None:
     help="Expiry duration (e.g. 90d, 24h, 30m).",
 )
 @click.option("--user-id", default=None, help="Owner user_id. Defaults to --name.")
+@click.option("--remote", default=None, help="Remote hub base URL or MCP URL.")
+@click.option("--admin-token", default=None, help="Admin token for --remote.")
 def token_create(
     name: str,
     zones_csv: str | None,
@@ -112,9 +105,10 @@ def token_create(
     is_admin: bool,
     expires: str | None,
     user_id: str | None,
+    remote: str | None,
+    admin_token: str | None,
 ) -> None:
     """Create a new bearer token. Prints the raw key once; not retrievable after."""
-    # Mutually-exclusive validation
     sources = [s for s in (zones_csv, zone_alias, zones_glob) if s is not None]
     if len(sources) == 0:
         raise click.ClickException("One of --zones, --zone, or --zones-glob is required.")
@@ -123,125 +117,45 @@ def token_create(
             "--zones, --zone, and --zones-glob are mutually exclusive; pass only one."
         )
 
+    if remote:
+        token = _resolve_remote_admin_token(admin_token, remote)
+        payload = _call_remote_admin_tool(
+            remote,
+            token,
+            "nexus_hub_token_create",
+            {
+                "name": name,
+                "zones": zones_csv if zones_csv is not None else zone_alias,
+                "zones_glob": zones_glob,
+                "admin": is_admin,
+                "expires": expires,
+                "user_id": user_id,
+            },
+        )
+        _render_token_create(payload)
+        return
+
     factory = get_session_factory()
-    expires_at: datetime | None = None
-    if expires:
-        try:
-            expires_at = datetime.now(UTC) + parse_duration(expires)
-        except ValueError as exc:
-            raise click.ClickException(str(exc)) from exc
-
-    with factory() as session, session.begin():
-        existing = (
-            session.execute(
-                select(APIKeyModel).where(APIKeyModel.name == name).where(APIKeyModel.revoked == 0)
-            )
-            .scalars()
-            .first()
-        )
-        if existing is not None and getattr(existing, "name", None) == name:
-            raise click.ClickException(
-                f"token named {name!r} already exists (key_id={existing.key_id}). "
-                "Revoke it first or use a different --name."
-            )
-
-        # Bootstrap escape: if the zones table is completely empty,
-        # allow the first admin token to be minted for any zone so
-        # a fresh hub can be bootstrapped before any zone is
-        # created. After that, every zone must refer to an active,
-        # non-deleted row.
-        any_zone = session.execute(select(ZoneModel).limit(1)).scalars().first()
-
-        zones: list[str | tuple[str, str]]
-        if zones_glob is not None:
-            import fnmatch
-
-            active = (
-                session.execute(
-                    select(ZoneModel)
-                    .where(ZoneModel.phase == "Active")
-                    .where(ZoneModel.deleted_at.is_(None))
-                )
-                .scalars()
-                .all()
-            )
-            matched = sorted(z.zone_id for z in active if fnmatch.fnmatch(z.zone_id, zones_glob))
-            if not matched:
-                known = [z.zone_id for z in active]
-                raise click.ClickException(
-                    f"--zones-glob {zones_glob!r}: no active zones match this pattern. "
-                    f"Active zones: {', '.join(sorted(known)) or '(none)'}."
-                )
-            # Glob can't carry per-zone perms; everything resolves to default rw.
-            zones = list(matched)
-        else:
-            if zones_csv is not None:
-                zones = _parse_zones_csv(zones_csv)
-            else:
-                zones = (
-                    [z.strip() for z in zone_alias.split(",") if z.strip()] if zone_alias else []
-                )
-            if not zones:
-                raise click.ClickException("--zones must contain at least one non-empty zone.")
-            # Validate zone lifecycle state against the authoritative registry
-            # so a typo ("proud" instead of "prod") or a deleted/terminating
-            # zone can't silently mint a credential bound to a zone the
-            # operator intended to isolate or remove (#3784 rounds 6/9).
-            if any_zone is not None:
-                for entry in zones:
-                    zid = entry[0] if isinstance(entry, tuple) else entry
-                    active_zone = (
-                        session.execute(
-                            select(ZoneModel)
-                            .where(ZoneModel.zone_id == zid)
-                            .where(ZoneModel.phase == "Active")
-                            .where(ZoneModel.deleted_at.is_(None))
-                        )
-                        .scalars()
-                        .first()
-                    )
-                    if active_zone is None:
-                        known = [
-                            z.zone_id
-                            for z in session.execute(
-                                select(ZoneModel)
-                                .where(ZoneModel.phase == "Active")
-                                .where(ZoneModel.deleted_at.is_(None))
-                            )
-                            .scalars()
-                            .all()
-                        ]
-                        raise click.ClickException(
-                            f"zone {zid!r} is not active (not found, deleted, or "
-                            f"terminating). Active zones: "
-                            f"{', '.join(sorted(known)) or '(none)'}. "
-                            "Create it first with `nexus zone create` or use --zones <existing>."
-                        )
-
-        # #3871 round 4: bootstrap path — auto-create missing ZoneModel rows
-        # so the api_key_zones FK insert below doesn't fail with IntegrityError.
-        # The validation block above only runs when any_zone is not None; in
-        # the bootstrap escape path (empty zones table) the requested zones
-        # may not exist yet, but create_api_key will still insert junction
-        # rows whose zone_id has a FK to zones.zone_id.
-        if any_zone is None:
-            for entry in zones:
-                zid = entry[0] if isinstance(entry, tuple) else entry
-                if not session.scalar(select(ZoneModel).where(ZoneModel.zone_id == zid)):
-                    session.add(ZoneModel(zone_id=zid, name=zid, phase="Active"))
-            session.flush()
-
-        key_id, raw_key = create_api_key(
-            session,
-            user_id=user_id or name,
+    try:
+        payload = create_hub_token(
+            factory,
             name=name,
-            zones=zones,
+            zones_csv=zones_csv if zones_csv is not None else zone_alias,
+            zones_glob=zones_glob,
             is_admin=is_admin,
-            expires_at=expires_at,
+            expires=expires,
+            user_id=user_id,
+            create_api_key_fn=create_api_key,
         )
+    except HubAdminError as exc:
+        raise click.ClickException(str(exc)) from exc
 
-    click.echo(f"key_id: {key_id}")
-    click.echo(f"token:  {raw_key}")
+    _render_token_create(payload)
+
+
+def _render_token_create(payload: dict[str, Any]) -> None:
+    click.echo(f"key_id: {payload['key_id']}")
+    click.echo(f"token:  {payload['token']}")
     click.echo("")
     click.echo("Save this token now — it will not be shown again.")
 
@@ -259,127 +173,87 @@ def token_create(
     is_flag=True,
     help="Emit JSON instead of a text table.",
 )
-def token_list(show_revoked: bool, as_json: bool) -> None:
+@click.option("--remote", default=None, help="Remote hub base URL or MCP URL.")
+@click.option("--admin-token", default=None, help="Admin token for --remote.")
+def token_list(
+    show_revoked: bool,
+    as_json: bool,
+    remote: str | None,
+    admin_token: str | None,
+) -> None:
     """List tokens (active by default)."""
-    import json as _json
-
-    factory = get_session_factory()
-    with factory() as session:
-        stmt = select(APIKeyModel).order_by(APIKeyModel.created_at.desc())
-        if not show_revoked:
-            stmt = stmt.where(APIKeyModel.revoked == 0)
-        rows = session.execute(stmt).scalars().all()
-
-        # Single batched junction query — not N+1 (#3785).
-        key_ids = [r.key_id for r in rows]
-        junction_rows: list[APIKeyZoneModel] = []
-        if key_ids:
-            junction_rows = list(
-                session.execute(select(APIKeyZoneModel).where(APIKeyZoneModel.key_id.in_(key_ids)))
-                .scalars()
-                .all()
-            )
-
-        # Batch-fetch primary zones from junction (#3871).
-        primary_by_key: dict[str, str | None] = dict.fromkeys(key_ids)
-        if key_ids:
-            primary_by_key.update(get_primary_zones_for_keys(session, key_ids))
-
-    # Build zones_by_key: primary zone first, then sorted others.
-    zones_by_key: dict[str, list[str]] = {}
-    for jr in junction_rows:
-        zones_by_key.setdefault(jr.key_id, []).append(jr.zone_id)
-    for kid in zones_by_key:
-        primary = primary_by_key.get(kid)
-        others = sorted(z for z in zones_by_key[kid] if z != primary)
-        zones_by_key[kid] = ([primary] if primary else []) + others
-
-    def _zones(r: APIKeyModel) -> list[str]:
-        """Return zones list for a token row, falling back to primary zone if no junction rows."""
-        if r.key_id in zones_by_key:
-            return zones_by_key[r.key_id]
-        fallback = primary_by_key.get(r.key_id)
-        return [fallback] if fallback is not None else []
-
-    def _iso(dt: datetime | None) -> str:
-        return dt.isoformat() if dt else "-"
-
-    if as_json:
-        payload = {
-            "tokens": [
-                {
-                    "key_id": r.key_id,
-                    "name": r.name,
-                    "zone": primary_by_key.get(
-                        r.key_id
-                    ),  # deprecated: use 'zones' (kept one release for compat)
-                    "zones": _zones(r),
-                    "admin": bool(r.is_admin),
-                    "created": _iso(r.created_at),
-                    "last_used": _iso(r.last_used_at),
-                    "revoked": bool(r.revoked),
-                    "revoked_at": _iso(r.revoked_at),
-                }
-                for r in rows
-            ]
-        }
-        click.echo(_json.dumps(payload, indent=2))
+    if remote:
+        token = _resolve_remote_admin_token(admin_token, remote)
+        payload = _call_remote_admin_tool(
+            remote,
+            token,
+            "nexus_hub_token_list",
+            {"show_revoked": show_revoked},
+        )
+        _render_token_list(payload, as_json=as_json)
         return
 
+    factory = get_session_factory()
+    payload = list_hub_tokens(factory, show_revoked=show_revoked)
+    _render_token_list(payload, as_json=as_json)
+
+
+def _render_token_list(payload: dict[str, Any], *, as_json: bool) -> None:
+    import json as _json
+
+    if as_json:
+        click.echo(_json.dumps(payload, indent=2))
+        return
     body = format_table(
         headers=["key_id", "name", "zone", "zones", "admin", "created", "last_used", "revoked_at"],
         rows=[
             [
-                r.key_id[:12] + "…" if len(r.key_id) > 12 else r.key_id,
-                r.name,
-                primary_by_key.get(r.key_id) or "-",
-                ",".join(_zones(r)),
-                "yes" if r.is_admin else "no",
-                _iso(r.created_at),
-                _iso(r.last_used_at),
-                _iso(r.revoked_at),
+                row["key_id"][:12] + "…" if len(row["key_id"]) > 12 else row["key_id"],
+                row["name"],
+                row["zone"] or "-",
+                ",".join(_zone_ids(row["zones"])),
+                "yes" if row["admin"] else "no",
+                row["created"],
+                row["last_used"],
+                row["revoked_at"],
             ]
-            for r in rows
+            for row in payload["tokens"]
         ],
     )
     click.echo(body)
 
 
+def _zone_ids(zones: list[Any]) -> list[str]:
+    return [zone["zone_id"] if isinstance(zone, dict) else zone for zone in zones]
+
+
 @token.command("revoke")
 @click.argument("identifier")
-def token_revoke(identifier: str) -> None:
+@click.option("--remote", default=None, help="Remote hub base URL or MCP URL.")
+@click.option("--admin-token", default=None, help="Admin token for --remote.")
+def token_revoke(identifier: str, remote: str | None, admin_token: str | None) -> None:
     """Revoke a token by key_id prefix or name. Soft-delete (audit trail preserved)."""
-    factory = get_session_factory()
-    with factory() as session, session.begin():
-        # Match by exact key_id, key_id prefix, or name (all must be non-revoked).
-        matches = (
-            session.execute(
-                select(APIKeyModel)
-                .where(APIKeyModel.revoked == 0)
-                .where(
-                    (APIKeyModel.key_id == identifier)
-                    | (APIKeyModel.key_id.startswith(identifier))
-                    | (APIKeyModel.name == identifier)
-                )
-            )
-            .scalars()
-            .all()
+    if remote:
+        token = _resolve_remote_admin_token(admin_token, remote)
+        payload = _call_remote_admin_tool(
+            remote,
+            token,
+            "nexus_hub_token_revoke",
+            {"identifier": identifier},
         )
-        if len(matches) == 0:
-            raise click.ClickException(f"no active token matches {identifier!r}")
-        if len(matches) > 1:
-            names = ", ".join(f"{m.name} ({m.key_id})" for m in matches)
-            click.echo(
-                f"ambiguous: {len(matches)} tokens match {identifier!r} — {names}",
-                err=True,
-            )
-            raise SystemExit(2)
+        click.echo(payload["message"])
+        return
 
-        row = matches[0]
-        row.revoked = 1
-        row.revoked_at = datetime.now(UTC)
+    factory = get_session_factory()
+    try:
+        payload = revoke_hub_token(factory, identifier=identifier)
+    except HubAdminAmbiguousTargetError as exc:
+        click.echo(str(exc), err=True)
+        raise SystemExit(2) from exc
+    except HubAdminError as exc:
+        raise click.ClickException(str(exc)) from exc
 
-    click.echo(f"revoked {row.name} ({row.key_id}). Effective within 60s (auth cache TTL).")
+    click.echo(payload["message"])
 
 
 @token.group("zones")
@@ -546,9 +420,22 @@ def _read_redis_stats() -> dict[str, Any]:
     is_flag=True,
     help="Include per-zone, per-token, rate-limit, and search detail.",
 )
-def hub_status(as_json: bool, detail: bool) -> None:
+@click.option("--remote", default=None, help="Remote hub base URL or MCP URL.")
+@click.option("--admin-token", default=None, help="Admin token for --remote.")
+def hub_status(
+    as_json: bool,
+    detail: bool,
+    remote: str | None,
+    admin_token: str | None,
+) -> None:
     """Show hub health: postgres, redis, tokens, connections, qps."""
-    import json as _json
+    if remote:
+        if detail:
+            raise click.ClickException("--detail is only available for local hub status")
+        token = _resolve_remote_admin_token(admin_token, remote)
+        payload = _call_remote_admin_tool(remote, token, "nexus_hub_status", {})
+        _render_status(payload, as_json=as_json)
+        return
 
     postgres_status = _collect_postgres_status(detail=detail)
     payload = _base_status_payload(postgres_status)
@@ -559,6 +446,12 @@ def hub_status(as_json: bool, detail: bool) -> None:
         payload.update(
             _collect_status_detail(zone_ids, postgres_status["tokens_detail"], redis_detail)
         )
+
+    _render_status(payload, as_json=as_json, detail=detail)
+
+
+def _render_status(payload: dict[str, Any], *, as_json: bool, detail: bool = False) -> None:
+    import json as _json
 
     if as_json:
         click.echo(_json.dumps(payload, indent=2))
@@ -943,3 +836,26 @@ def _emit_detail_status_text(payload: dict[str, Any]) -> None:
             ],
         )
     )
+
+
+def _resolve_remote_admin_token(admin_token: str | None, remote: str | None) -> str:
+    if not remote:
+        raise click.ClickException("internal error: remote token requested without --remote")
+    token = admin_token or os.environ.get("NEXUS_HUB_ADMIN_TOKEN")
+    if not token:
+        raise click.ClickException(
+            "--admin-token or NEXUS_HUB_ADMIN_TOKEN is required with --remote"
+        )
+    return token
+
+
+def _call_remote_admin_tool(
+    remote: str,
+    admin_token: str,
+    tool_name: str,
+    arguments: dict[str, Any],
+) -> dict[str, Any]:
+    try:
+        return call_hub_admin_tool(remote, admin_token, tool_name, arguments)
+    except HubRemoteError as exc:
+        raise click.ClickException(str(exc)) from exc

--- a/src/nexus/factory/adapters.py
+++ b/src/nexus/factory/adapters.py
@@ -1,6 +1,7 @@
 """Factory adapters — NexusFSFileReader, DaemonSkeletonBM25, WorkflowLifecycleAdapter."""
 
 import asyncio
+import inspect
 import logging
 from collections.abc import Callable
 from typing import Any
@@ -235,6 +236,15 @@ class _NexusFSFileReader:
         self._nx = nx
         self._parse_fn = parse_fn
 
+    async def _sys_read(self, path: str, **kwargs: Any) -> Any:
+        read_fn = self._nx.sys_read
+        if inspect.iscoroutinefunction(read_fn):
+            return await read_fn(path, **kwargs)
+        result = await asyncio.to_thread(read_fn, path, **kwargs)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
     async def read_text(self, path: str) -> str:
         # Read with admin context so the search daemon can index all files
         # regardless of per-user ReBAC permissions.
@@ -246,9 +256,7 @@ class _NexusFSFileReader:
             is_admin=True,
             is_system=True,
         )
-        # sys_read blocks the event loop (Rust kernel pread + pipe waits).
-        # Run it in a worker thread.
-        content_raw = await asyncio.to_thread(self._nx.sys_read, path, context=admin_ctx)
+        content_raw = await self._sys_read(path, context=admin_ctx)
 
         # Look up the backend-tracked content_id (``file_paths.content_id``)
         # so the parse cache is keyed with the same string downstream
@@ -405,13 +413,7 @@ class _NexusFSFileReader:
             is_system=True,
         )
         try:
-            # sys_read is synchronous Rust; use a worker thread.
-            content = await asyncio.to_thread(
-                self._nx.sys_read,
-                path,
-                count=max_bytes,
-                context=admin_ctx,
-            )
+            content = await self._sys_read(path, count=max_bytes, context=admin_ctx)
             if isinstance(content, bytes):
                 return content
             return str(content).encode("utf-8", errors="ignore")

--- a/src/nexus/grpc/servicer.py
+++ b/src/nexus/grpc/servicer.py
@@ -37,7 +37,7 @@ import logging
 from types import SimpleNamespace
 from typing import Any
 
-from nexus.contracts.exceptions import NexusError
+from nexus.contracts.exceptions import NexusError, NexusPermissionError
 from nexus.contracts.rpc_types import RPCErrorCode
 from nexus.lib.rpc_codec import decode_rpc_message, encode_rpc_message
 from nexus.lib.zone_scoping import ZoneScopingError, scope_params_for_zone
@@ -276,6 +276,8 @@ class VFSCallDispatcher:
             return True, _error_payload(RPCErrorCode.PERMISSION_ERROR, str(exc))
         except ValueError as exc:
             return True, _error_payload(RPCErrorCode.INVALID_PARAMS, f"Invalid parameters: {exc}")
+        except NexusPermissionError as exc:
+            return True, _error_payload(RPCErrorCode.PERMISSION_ERROR, str(exc))
         except NexusError as exc:
             return True, _error_payload(RPCErrorCode.INTERNAL_ERROR, str(exc))
         except Exception as exc:

--- a/src/nexus/hub/__init__.py
+++ b/src/nexus/hub/__init__.py
@@ -1,0 +1,1 @@
+"""Shared hub administration helpers."""

--- a/src/nexus/hub/admin_ops.py
+++ b/src/nexus/hub/admin_ops.py
@@ -1,0 +1,390 @@
+"""DB-backed hub administration operations."""
+
+from __future__ import annotations
+
+import fnmatch
+import os
+from collections.abc import Callable
+from datetime import UTC, datetime
+from typing import Any
+
+from sqlalchemy import func, select
+
+from nexus.cli.commands._hub_common import parse_duration
+from nexus.storage.api_key_ops import (
+    create_api_key,
+    get_primary_zones_for_keys,
+    get_zone_perms_for_key,
+)
+from nexus.storage.models import APIKeyModel, APIKeyZoneModel, ZoneModel
+
+_VALID_PERMS = ("r", "w", "rw", "rwx")
+
+
+class HubAdminError(Exception):
+    """Raised for user-facing hub admin failures."""
+
+
+class HubAdminAmbiguousTargetError(HubAdminError):
+    """Raised when a revoke target matches multiple active keys."""
+
+    def __init__(self, identifier: str, matches: list[tuple[str, str]]) -> None:
+        self.identifier = identifier
+        self.matches = matches
+        names = ", ".join(f"{name} ({key_id})" for name, key_id in matches)
+        super().__init__(f"ambiguous: {len(matches)} tokens match {identifier!r} - {names}")
+
+
+def parse_zones_csv(raw: str) -> list[str | tuple[str, str]]:
+    """Parse ``eng:rw,ops:r`` into the shape accepted by ``create_api_key``."""
+    out: list[str | tuple[str, str]] = []
+    for chunk in raw.split(","):
+        item = chunk.strip()
+        if not item:
+            continue
+        if ":" in item:
+            zid, perms = item.split(":", 1)
+            zid = zid.strip()
+            perms = perms.strip()
+            if not zid:
+                raise HubAdminError(f"empty zone id in {chunk!r}")
+            if perms not in _VALID_PERMS:
+                raise HubAdminError(
+                    f"invalid permissions {perms!r} for zone {zid!r}; "
+                    f"expected one of {', '.join(_VALID_PERMS)}"
+                )
+            out.append((zid, perms))
+        else:
+            out.append(item)
+    return out
+
+
+def parse_expires_at(raw: str | None) -> datetime | None:
+    """Parse a relative duration into an absolute UTC expiry."""
+    if raw is None:
+        return None
+    try:
+        return datetime.now(UTC) + parse_duration(raw)
+    except ValueError as exc:
+        raise HubAdminError(str(exc)) from exc
+
+
+def create_hub_token(
+    session_factory: Callable[[], Any],
+    *,
+    name: str,
+    zones_csv: str | None,
+    zones_glob: str | None,
+    is_admin: bool,
+    expires: str | None,
+    user_id: str | None,
+    create_api_key_fn: Callable[..., tuple[str, str]] = create_api_key,
+) -> dict[str, Any]:
+    """Create a hub token and return the one-time raw token payload."""
+    if zones_csv is None and zones_glob is None:
+        raise HubAdminError("One of --zones, --zone, or --zones-glob is required.")
+    if zones_csv is not None and zones_glob is not None:
+        raise HubAdminError(
+            "--zones, --zone, and --zones-glob are mutually exclusive; pass only one."
+        )
+
+    expires_at = parse_expires_at(expires)
+
+    with session_factory() as session, session.begin():
+        existing = (
+            session.execute(
+                select(APIKeyModel).where(APIKeyModel.name == name).where(APIKeyModel.revoked == 0)
+            )
+            .scalars()
+            .first()
+        )
+        if existing is not None and getattr(existing, "name", None) == name:
+            raise HubAdminError(
+                f"token named {name!r} already exists (key_id={existing.key_id}). "
+                "Revoke it first or use a different --name."
+            )
+
+        any_zone = session.execute(select(ZoneModel).limit(1)).scalars().first()
+        zones = _resolve_create_zones(
+            session,
+            any_zone=any_zone,
+            zones_csv=zones_csv,
+            zones_glob=zones_glob,
+        )
+
+        if any_zone is None:
+            for entry in zones:
+                zid = entry[0] if isinstance(entry, tuple) else entry
+                if not session.scalar(select(ZoneModel).where(ZoneModel.zone_id == zid)):
+                    session.add(ZoneModel(zone_id=zid, name=zid, phase="Active"))
+            session.flush()
+
+        try:
+            key_id, raw_key = create_api_key_fn(
+                session,
+                user_id=user_id or name,
+                name=name,
+                zones=zones,
+                is_admin=is_admin,
+                expires_at=expires_at,
+            )
+        except ValueError as exc:
+            raise HubAdminError(str(exc)) from exc
+
+        zone_payload = [
+            {
+                "zone_id": entry[0] if isinstance(entry, tuple) else entry,
+                "permission": entry[1] if isinstance(entry, tuple) else "rw",
+            }
+            for entry in zones
+        ]
+
+    return {
+        "key_id": key_id,
+        "token": raw_key,
+        "name": name,
+        "admin": bool(is_admin),
+        "zones": zone_payload,
+    }
+
+
+def _resolve_create_zones(
+    session: Any,
+    *,
+    any_zone: ZoneModel | None,
+    zones_csv: str | None,
+    zones_glob: str | None,
+) -> list[str | tuple[str, str]]:
+    if zones_glob is not None:
+        active = (
+            session.execute(
+                select(ZoneModel)
+                .where(ZoneModel.phase == "Active")
+                .where(ZoneModel.deleted_at.is_(None))
+            )
+            .scalars()
+            .all()
+        )
+        matched = sorted(z.zone_id for z in active if fnmatch.fnmatch(z.zone_id, zones_glob))
+        if not matched:
+            known = [z.zone_id for z in active]
+            raise HubAdminError(
+                f"--zones-glob {zones_glob!r}: no active zones match this pattern. "
+                f"Active zones: {', '.join(sorted(known)) or '(none)'}."
+            )
+        return list(matched)
+
+    zones = parse_zones_csv(zones_csv or "")
+    if not zones:
+        raise HubAdminError("--zones must contain at least one non-empty zone.")
+
+    if any_zone is not None:
+        _validate_active_zones(session, zones)
+    return zones
+
+
+def _validate_active_zones(session: Any, zones: list[str | tuple[str, str]]) -> None:
+    for entry in zones:
+        zid = entry[0] if isinstance(entry, tuple) else entry
+        active_zone = (
+            session.execute(
+                select(ZoneModel)
+                .where(ZoneModel.zone_id == zid)
+                .where(ZoneModel.phase == "Active")
+                .where(ZoneModel.deleted_at.is_(None))
+            )
+            .scalars()
+            .first()
+        )
+        if active_zone is not None:
+            continue
+        known = [
+            z.zone_id
+            for z in session.execute(
+                select(ZoneModel)
+                .where(ZoneModel.phase == "Active")
+                .where(ZoneModel.deleted_at.is_(None))
+            )
+            .scalars()
+            .all()
+        ]
+        raise HubAdminError(
+            f"zone {zid!r} is not active (not found, deleted, or terminating). "
+            f"Active zones: {', '.join(sorted(known)) or '(none)'}. "
+            "Create it first with `nexus zone create` or use --zones <existing>."
+        )
+
+
+def list_hub_tokens(
+    session_factory: Callable[[], Any],
+    *,
+    show_revoked: bool,
+) -> dict[str, Any]:
+    """Return token rows in the existing local CLI JSON payload shape."""
+    with session_factory() as session:
+        stmt = select(APIKeyModel).order_by(APIKeyModel.created_at.desc())
+        if not show_revoked:
+            stmt = stmt.where(APIKeyModel.revoked == 0)
+        rows = session.execute(stmt).scalars().all()
+
+        key_ids = [r.key_id for r in rows]
+        junction_rows: list[APIKeyZoneModel] = []
+        if key_ids:
+            junction_rows = list(
+                session.execute(select(APIKeyZoneModel).where(APIKeyZoneModel.key_id.in_(key_ids)))
+                .scalars()
+                .all()
+            )
+
+        primary_by_key: dict[str, str | None] = dict.fromkeys(key_ids)
+        if key_ids:
+            primary_by_key.update(get_primary_zones_for_keys(session, key_ids))
+
+    zones_by_key: dict[str, list[str]] = {}
+    for jr in junction_rows:
+        zones_by_key.setdefault(jr.key_id, []).append(jr.zone_id)
+    for kid in zones_by_key:
+        primary = primary_by_key.get(kid)
+        others = sorted(z for z in zones_by_key[kid] if z != primary)
+        zones_by_key[kid] = ([primary] if primary else []) + others
+
+    def _zones(row: APIKeyModel) -> list[str]:
+        if row.key_id in zones_by_key:
+            return zones_by_key[row.key_id]
+        fallback = primary_by_key.get(row.key_id)
+        return [fallback] if fallback is not None else []
+
+    return {
+        "tokens": [
+            {
+                "key_id": row.key_id,
+                "name": row.name,
+                "zone": primary_by_key.get(row.key_id),
+                "zones": _zones(row),
+                "admin": bool(row.is_admin),
+                "created": _iso(row.created_at),
+                "last_used": _iso(row.last_used_at),
+                "revoked": bool(row.revoked),
+                "revoked_at": _iso(row.revoked_at),
+            }
+            for row in rows
+        ]
+    }
+
+
+def revoke_hub_token(session_factory: Callable[[], Any], *, identifier: str) -> dict[str, Any]:
+    """Revoke a token by exact key id, key id prefix, or name."""
+    with session_factory() as session, session.begin():
+        matches = (
+            session.execute(
+                select(APIKeyModel)
+                .where(APIKeyModel.revoked == 0)
+                .where(
+                    (APIKeyModel.key_id == identifier)
+                    | (APIKeyModel.key_id.startswith(identifier))
+                    | (APIKeyModel.name == identifier)
+                )
+            )
+            .scalars()
+            .all()
+        )
+        if len(matches) == 0:
+            raise HubAdminError(f"no active token matches {identifier!r}")
+        if len(matches) > 1:
+            raise HubAdminAmbiguousTargetError(
+                identifier,
+                [(match.name, match.key_id) for match in matches],
+            )
+
+        row = matches[0]
+        row.revoked = 1
+        row.revoked_at = datetime.now(UTC)
+        key_id = row.key_id
+        name = row.name
+
+    message = f"revoked {name} ({key_id}). Effective within 60s (auth cache TTL)."
+    return {"key_id": key_id, "name": name, "message": message}
+
+
+def get_hub_status(
+    session_factory: Callable[[], Any],
+    *,
+    redis_stats: Callable[[], dict[str, Any]] | None = None,
+) -> dict[str, Any]:
+    """Return hub health information used by local and remote CLI output."""
+    host = os.environ.get("NEXUS_MCP_HOST", "0.0.0.0")
+    port = os.environ.get("NEXUS_MCP_PORT", "8081")
+    profile = os.environ.get("NEXUS_PROFILE", "full")
+    endpoint = f"http://{host}:{port}/mcp"
+
+    pg_state = "ok"
+    active = revoked = 0
+    try:
+        with session_factory() as session:
+            active = (
+                session.execute(
+                    select(func.count()).select_from(APIKeyModel).where(APIKeyModel.revoked == 0)
+                ).scalar()
+                or 0
+            )
+            revoked = (
+                session.execute(
+                    select(func.count()).select_from(APIKeyModel).where(APIKeyModel.revoked == 1)
+                ).scalar()
+                or 0
+            )
+    except Exception:  # noqa: BLE001
+        pg_state = "err"
+
+    metrics = redis_stats() if redis_stats is not None else read_redis_stats()
+    return {
+        "endpoint": endpoint,
+        "profile": profile,
+        "postgres": pg_state,
+        "redis": metrics["redis"],
+        "tokens": {"active": int(active), "revoked": int(revoked)},
+        "connections": metrics.get("connections"),
+        "qps_5m": metrics.get("qps_5m"),
+    }
+
+
+def read_redis_stats() -> dict[str, Any]:
+    """Read best-effort hub metrics from Redis/Dragonfly."""
+    import time
+
+    url = os.environ.get("NEXUS_REDIS_URL") or os.environ.get("DRAGONFLY_URL")
+    if not url:
+        return {"qps_5m": None, "connections": None, "redis": "n/a"}
+    try:
+        import redis
+    except ImportError:
+        return {"qps_5m": None, "connections": None, "redis": "n/a"}
+
+    try:
+        client = redis.from_url(url, socket_timeout=2)
+        client.ping()
+        now_min = int(time.time()) // 60
+        minute_keys = [f"nexus:hub:qps:{now_min - i}" for i in range(5)]
+        active_key = f"nexus:hub:active:{now_min}"
+        values = client.mget(minute_keys)
+        total = sum(int(v) for v in values if v is not None)
+        active = client.scard(active_key)
+        return {
+            "qps_5m": round(total / 300.0, 2),
+            "connections": int(active),
+            "redis": "ok",
+        }
+    except Exception:  # noqa: BLE001
+        return {"qps_5m": None, "connections": None, "redis": "n/a"}
+
+
+def get_zone_payload_for_key(session: Any, key_id: str) -> list[dict[str, str]]:
+    """Return zone permissions for a token, primary zone first."""
+    return [
+        {"zone_id": zone_id, "permission": permission}
+        for zone_id, permission in get_zone_perms_for_key(session, key_id)
+    ]
+
+
+def _iso(dt: datetime | None) -> str:
+    return dt.isoformat() if dt else "-"

--- a/src/nexus/hub/admin_ops.py
+++ b/src/nexus/hub/admin_ops.py
@@ -6,9 +6,11 @@ import fnmatch
 import os
 from collections.abc import Callable
 from datetime import UTC, datetime
+from functools import lru_cache
 from typing import Any
 
-from sqlalchemy import func, select
+from sqlalchemy import create_engine, func, select
+from sqlalchemy.orm import Session, sessionmaker
 
 from nexus.cli.commands._hub_common import parse_duration
 from nexus.storage.api_key_ops import (
@@ -33,6 +35,33 @@ class HubAdminAmbiguousTargetError(HubAdminError):
         self.matches = matches
         names = ", ".join(f"{name} ({key_id})" for name, key_id in matches)
         super().__init__(f"ambiguous: {len(matches)} tokens match {identifier!r} - {names}")
+
+
+def get_env_session_factory() -> Callable[[], Session]:
+    """Build a hub DB session factory from the server environment."""
+    db_url = (
+        os.environ.get("NEXUS_DATABASE_URL")
+        or os.environ.get("POSTGRES_URL")
+        or os.environ.get("DATABASE_URL")
+    )
+    if not db_url:
+        from nexus.contracts.exceptions import ConfigurationError
+
+        raise ConfigurationError(
+            "Hub admin operations require a database-backed auth provider or "
+            "NEXUS_DATABASE_URL/POSTGRES_URL/DATABASE_URL to be set"
+        )
+    return _build_env_session_factory(_sync_database_url(db_url))
+
+
+@lru_cache(maxsize=4)
+def _build_env_session_factory(db_url: str) -> Callable[[], Session]:
+    engine = create_engine(db_url, future=True)
+    return sessionmaker(bind=engine, future=True, expire_on_commit=False)
+
+
+def _sync_database_url(db_url: str) -> str:
+    return db_url.replace("postgresql+asyncpg://", "postgresql://", 1)
 
 
 def parse_zones_csv(raw: str) -> list[str | tuple[str, str]]:

--- a/src/nexus/server/_rpc_param_overrides.py
+++ b/src/nexus/server/_rpc_param_overrides.py
@@ -116,6 +116,39 @@ class AdminWritePermissionParams:
 
 
 @dataclass
+class HubAdminTokenCreateParams:
+    """Parameters for hub_admin_token_create() method."""
+
+    name: str
+    zones: str | None = None
+    zones_glob: str | None = None
+    admin: bool = False
+    expires: str | None = None
+    user_id: str | None = None
+
+
+@dataclass
+class HubAdminTokenListParams:
+    """Parameters for hub_admin_token_list() method."""
+
+    show_revoked: bool = False
+
+
+@dataclass
+class HubAdminTokenRevokeParams:
+    """Parameters for hub_admin_token_revoke() method."""
+
+    identifier: str
+
+
+@dataclass
+class HubAdminStatusParams:
+    """Parameters for hub_admin_status() method."""
+
+    pass
+
+
+@dataclass
 class AdminGcVersionsParams:
     """Parameters for admin_gc_versions() method."""
 
@@ -190,6 +223,10 @@ OVERRIDE_METHOD_PARAMS: dict[str, type] = {
     "admin_revoke_key": AdminRevokeKeyParams,
     "admin_update_key": AdminUpdateKeyParams,
     "admin_write_permission": AdminWritePermissionParams,
+    "hub_admin_token_create": HubAdminTokenCreateParams,
+    "hub_admin_token_list": HubAdminTokenListParams,
+    "hub_admin_token_revoke": HubAdminTokenRevokeParams,
+    "hub_admin_status": HubAdminStatusParams,
     "admin_gc_versions": AdminGcVersionsParams,
     "admin_gc_versions_stats": AdminGcVersionsStatsParams,
     # Namespace

--- a/src/nexus/server/rpc/dispatch.py
+++ b/src/nexus/server/rpc/dispatch.py
@@ -78,6 +78,12 @@ def build_dispatch_table() -> dict[str, DispatchEntry]:
         handle_semantic_search,
         handle_semantic_search_index,
     )
+    from nexus.server.rpc.handlers.hub_admin import (
+        handle_hub_admin_status,
+        handle_hub_admin_token_create,
+        handle_hub_admin_token_list,
+        handle_hub_admin_token_revoke,
+    )
 
     # Kernel syscalls (sys_*, mkdir, rmdir, access, is_directory, locks
     # + aliases) are NOT in this table — they're routed by the thin
@@ -108,6 +114,19 @@ def build_dispatch_table() -> dict[str, DispatchEntry]:
         "admin_get_key": DispatchEntry(handle_admin_get_key, pass_auth_provider=True),
         "admin_revoke_key": DispatchEntry(handle_admin_revoke_key, pass_auth_provider=True),
         "admin_update_key": DispatchEntry(handle_admin_update_key, pass_auth_provider=True),
+        "hub_admin_token_create": DispatchEntry(
+            handle_hub_admin_token_create,
+            pass_auth_provider=True,
+        ),
+        "hub_admin_token_list": DispatchEntry(
+            handle_hub_admin_token_list,
+            pass_auth_provider=True,
+        ),
+        "hub_admin_token_revoke": DispatchEntry(
+            handle_hub_admin_token_revoke,
+            pass_auth_provider=True,
+        ),
+        "hub_admin_status": DispatchEntry(handle_hub_admin_status, pass_auth_provider=True),
     }
 
 

--- a/src/nexus/server/rpc/handlers/hub_admin.py
+++ b/src/nexus/server/rpc/handlers/hub_admin.py
@@ -5,12 +5,14 @@ from __future__ import annotations
 from typing import Any
 
 from nexus.hub import admin_ops
-from nexus.server.rpc.handlers.admin import require_admin, require_database_auth
+from nexus.server.rpc.handlers.admin import require_admin
 
 
 def _session_factory(auth_provider: Any) -> Any:
-    require_database_auth(auth_provider)
-    return auth_provider.session_factory
+    factory = getattr(auth_provider, "session_factory", None)
+    if callable(factory):
+        return factory
+    return admin_ops.get_env_session_factory()
 
 
 def handle_hub_admin_token_create(

--- a/src/nexus/server/rpc/handlers/hub_admin.py
+++ b/src/nexus/server/rpc/handlers/hub_admin.py
@@ -1,0 +1,67 @@
+"""Hub admin RPC handlers used by public MCP admin tools."""
+
+from __future__ import annotations
+
+from typing import Any
+
+from nexus.hub import admin_ops
+from nexus.server.rpc.handlers.admin import require_admin, require_database_auth
+
+
+def _session_factory(auth_provider: Any) -> Any:
+    require_database_auth(auth_provider)
+    return auth_provider.session_factory
+
+
+def handle_hub_admin_token_create(
+    auth_provider: Any,
+    params: Any,
+    context: Any,
+) -> dict[str, Any]:
+    """Create a hub token through the shared DB-backed operation."""
+    require_admin(context)
+    return admin_ops.create_hub_token(
+        _session_factory(auth_provider),
+        name=params.name,
+        zones_csv=getattr(params, "zones", None),
+        zones_glob=getattr(params, "zones_glob", None),
+        is_admin=bool(getattr(params, "admin", False)),
+        expires=getattr(params, "expires", None),
+        user_id=getattr(params, "user_id", None),
+    )
+
+
+def handle_hub_admin_token_list(
+    auth_provider: Any,
+    params: Any,
+    context: Any,
+) -> dict[str, Any]:
+    """List hub tokens through the shared DB-backed operation."""
+    require_admin(context)
+    return admin_ops.list_hub_tokens(
+        _session_factory(auth_provider),
+        show_revoked=bool(getattr(params, "show_revoked", False)),
+    )
+
+
+def handle_hub_admin_token_revoke(
+    auth_provider: Any,
+    params: Any,
+    context: Any,
+) -> dict[str, Any]:
+    """Revoke a hub token through the shared DB-backed operation."""
+    require_admin(context)
+    return admin_ops.revoke_hub_token(
+        _session_factory(auth_provider),
+        identifier=params.identifier,
+    )
+
+
+def handle_hub_admin_status(
+    auth_provider: Any,
+    _params: Any,
+    context: Any,
+) -> dict[str, Any]:
+    """Read hub status through the shared DB-backed operation."""
+    require_admin(context)
+    return admin_ops.get_hub_status(_session_factory(auth_provider))

--- a/tests/unit/bricks/mcp/test_hub_admin_tools.py
+++ b/tests/unit/bricks/mcp/test_hub_admin_tools.py
@@ -1,0 +1,88 @@
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from nexus.bricks.mcp.server import create_mcp_server, reset_request_api_key, set_request_api_key
+
+
+def _get_tool(server, tool_name: str):
+    if hasattr(server, "_local_provider"):
+        for key, component in server._local_provider._components.items():
+            if key.startswith("tool:") and component.name == tool_name:
+                return component
+    return server._tool_manager._tools[tool_name]
+
+
+@pytest.mark.asyncio
+async def test_hub_admin_tool_forwards_to_remote_rpc():
+    calls = []
+
+    def fake_call_rpc(method, params):
+        calls.append((method, params))
+        return {"tokens": [{"key_id": "nk_1", "name": "admin"}]}
+
+    nx = SimpleNamespace(
+        subject_id="admin",
+        zone_id="root",
+        is_admin=True,
+        _nexus_remote_call_rpc=fake_call_rpc,
+    )
+    server = await create_mcp_server(nx=nx)
+    tool = _get_tool(server, "nexus_hub_token_list")
+
+    result = await tool.fn(show_revoked=True)
+
+    assert calls == [("hub_admin_token_list", {"show_revoked": True})]
+    assert json.loads(result)["tokens"][0]["key_id"] == "nk_1"
+
+
+@pytest.mark.asyncio
+async def test_hub_admin_tool_rejects_non_admin_before_rpc():
+    calls = []
+
+    def fake_call_rpc(method, params):
+        calls.append((method, params))
+        return {"tokens": []}
+
+    nx = SimpleNamespace(
+        subject_id="alice",
+        zone_id="root",
+        is_admin=False,
+        _nexus_remote_call_rpc=fake_call_rpc,
+    )
+    server = await create_mcp_server(nx=nx)
+    tool = _get_tool(server, "nexus_hub_token_list")
+
+    result = await tool.fn(show_revoked=False)
+
+    assert calls == []
+    assert result.startswith("Error:")
+    assert "Admin privileges required" in result
+
+
+@pytest.mark.asyncio
+async def test_hub_admin_tool_delegates_admin_check_for_per_request_remote_connection():
+    calls = []
+
+    def fake_call_rpc(method, params):
+        calls.append((method, params))
+        return {"tokens": []}
+
+    nx = SimpleNamespace(
+        _init_cred=SimpleNamespace(user_id="remote", is_admin=False),
+        _nexus_remote_call_rpc=fake_call_rpc,
+    )
+    server = await create_mcp_server(nx=nx)
+    tool = _get_tool(server, "nexus_hub_token_list")
+
+    token = set_request_api_key("sk-admin")
+    try:
+        result = await tool.fn(show_revoked=False)
+    finally:
+        reset_request_api_key(token)
+
+    assert calls == [("hub_admin_token_list", {"show_revoked": False})]
+    assert json.loads(result) == {"tokens": []}

--- a/tests/unit/cli/test_hub_remote.py
+++ b/tests/unit/cli/test_hub_remote.py
@@ -1,0 +1,179 @@
+from __future__ import annotations
+
+import json
+
+from click.testing import CliRunner
+
+from nexus.cli.commands import _hub_remote
+from nexus.cli.commands.hub import hub
+
+
+def test_normalize_remote_url_appends_mcp_path():
+    assert (
+        _hub_remote.normalize_mcp_url("https://nexus.example.com")
+        == "https://nexus.example.com/mcp"
+    )
+    assert (
+        _hub_remote.normalize_mcp_url("https://nexus.example.com/mcp")
+        == "https://nexus.example.com/mcp"
+    )
+    assert (
+        _hub_remote.normalize_mcp_url("https://nexus.example.com/")
+        == "https://nexus.example.com/mcp"
+    )
+
+
+def test_remote_list_requires_admin_token(monkeypatch):
+    monkeypatch.delenv("NEXUS_HUB_ADMIN_TOKEN", raising=False)
+
+    result = CliRunner().invoke(hub, ["token", "list", "--remote", "https://hub.example"])
+
+    assert result.exit_code != 0
+    assert "--admin-token or NEXUS_HUB_ADMIN_TOKEN is required with --remote" in result.output
+
+
+def test_remote_list_uses_env_token_and_renders_json(monkeypatch):
+    calls = []
+
+    def fake_call(remote, token, tool_name, arguments):
+        calls.append((remote, token, tool_name, arguments))
+        return {
+            "tokens": [
+                {
+                    "key_id": "nk_123",
+                    "name": "admin",
+                    "zone": None,
+                    "zones": [],
+                    "admin": True,
+                    "created": "2026-05-04T12:00:00",
+                    "last_used": "-",
+                    "revoked": False,
+                    "revoked_at": "-",
+                }
+            ]
+        }
+
+    monkeypatch.setenv("NEXUS_HUB_ADMIN_TOKEN", "sk-env")
+    monkeypatch.setattr("nexus.cli.commands.hub.call_hub_admin_tool", fake_call)
+
+    result = CliRunner().invoke(
+        hub,
+        ["token", "list", "--remote", "https://hub.example", "--json"],
+    )
+
+    assert result.exit_code == 0
+    assert calls == [
+        ("https://hub.example", "sk-env", "nexus_hub_token_list", {"show_revoked": False})
+    ]
+    assert json.loads(result.output)["tokens"][0]["key_id"] == "nk_123"
+
+
+def test_remote_create_calls_mcp_tool_and_prints_one_time_token(monkeypatch):
+    calls = []
+
+    def fake_call(remote, token, tool_name, arguments):
+        calls.append((remote, token, tool_name, arguments))
+        return {
+            "key_id": "nk_new",
+            "token": "sk-new",
+            "name": "ci",
+            "admin": False,
+            "zones": [{"zone_id": "eng", "permission": "rw"}],
+        }
+
+    monkeypatch.setattr("nexus.cli.commands.hub.call_hub_admin_tool", fake_call)
+
+    result = CliRunner().invoke(
+        hub,
+        [
+            "token",
+            "create",
+            "--name",
+            "ci",
+            "--zones",
+            "eng:rw",
+            "--remote",
+            "https://hub.example/mcp",
+            "--admin-token",
+            "sk-admin",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        (
+            "https://hub.example/mcp",
+            "sk-admin",
+            "nexus_hub_token_create",
+            {
+                "name": "ci",
+                "zones": "eng:rw",
+                "zones_glob": None,
+                "admin": False,
+                "expires": None,
+                "user_id": None,
+            },
+        )
+    ]
+    assert "key_id: nk_new" in result.output
+    assert "token:  sk-new" in result.output
+
+
+def test_remote_revoke_calls_mcp_tool(monkeypatch):
+    calls = []
+
+    def fake_call(remote, token, tool_name, arguments):
+        calls.append((remote, token, tool_name, arguments))
+        return {
+            "key_id": "nk_old",
+            "name": "old",
+            "message": "revoked old (nk_old). Effective within 60s (auth cache TTL).",
+        }
+
+    monkeypatch.setattr("nexus.cli.commands.hub.call_hub_admin_tool", fake_call)
+
+    result = CliRunner().invoke(
+        hub,
+        [
+            "token",
+            "revoke",
+            "old",
+            "--remote",
+            "https://hub.example",
+            "--admin-token",
+            "sk-admin",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [
+        ("https://hub.example", "sk-admin", "nexus_hub_token_revoke", {"identifier": "old"})
+    ]
+    assert "revoked old (nk_old)" in result.output
+
+
+def test_remote_status_calls_mcp_tool_and_renders_json(monkeypatch):
+    calls = []
+
+    def fake_call(remote, token, tool_name, arguments):
+        calls.append((remote, token, tool_name, arguments))
+        return {
+            "endpoint": "https://hub.example/mcp",
+            "profile": "full",
+            "postgres": "ok",
+            "redis": "n/a",
+            "tokens": {"active": 1, "revoked": 0},
+            "connections": None,
+            "qps_5m": None,
+        }
+
+    monkeypatch.setattr("nexus.cli.commands.hub.call_hub_admin_tool", fake_call)
+
+    result = CliRunner().invoke(
+        hub,
+        ["status", "--remote", "https://hub.example", "--admin-token", "sk-admin", "--json"],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert calls == [("https://hub.example", "sk-admin", "nexus_hub_status", {})]
+    assert json.loads(result.output)["postgres"] == "ok"

--- a/tests/unit/cli/test_stack.py
+++ b/tests/unit/cli/test_stack.py
@@ -66,6 +66,13 @@ def shared_config(tmp_path: Path) -> Path:
 # ---------------------------------------------------------------------------
 
 
+def test_stack_mcp_sidecar_uses_same_default_image_as_nexus() -> None:
+    repo_root = Path(__file__).resolve().parents[3]
+    stack = yaml.safe_load((repo_root / "nexus-stack.yml").read_text())
+
+    assert stack["services"]["mcp-server"]["image"] == stack["services"]["nexus"]["image"]
+
+
 class TestConfigLoading:
     def test_load_project_config(self, shared_config: Path) -> None:
         with patch(

--- a/tests/unit/factory/test_adapters.py
+++ b/tests/unit/factory/test_adapters.py
@@ -1,6 +1,7 @@
 """Tests for factory adapters — Issue #2180."""
 
 import asyncio
+import threading
 import time
 from unittest.mock import MagicMock, patch
 
@@ -62,6 +63,22 @@ class TestNexusFSFileReader:
         nx.sys_read = MagicMock(return_value="hello world")
         reader = _NexusFSFileReader(nx)
         assert await reader.read_text("/test.txt") == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_read_head_offloads_sync_sys_read_from_event_loop(self) -> None:
+        loop_thread_id = threading.get_ident()
+        read_thread_ids: list[int] = []
+
+        class SyncNexusFS:
+            def sys_read(self, path, *, count, context):
+                read_thread_ids.append(threading.get_ident())
+                return b"heading"
+
+        reader = _NexusFSFileReader(SyncNexusFS())
+
+        assert await reader.read_head("/test.txt", 16) == b"heading"
+        assert read_thread_ids
+        assert read_thread_ids[0] != loop_thread_id
 
     def test_get_path_id_with_session(self) -> None:
         nx = MagicMock()

--- a/tests/unit/grpc/test_servicer_error_mapping.py
+++ b/tests/unit/grpc/test_servicer_error_mapping.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.contracts.exceptions import NexusPermissionError
+from nexus.contracts.rpc_types import RPCErrorCode
+from nexus.grpc.servicer import VFSCallDispatcher
+from nexus.lib.rpc_codec import decode_rpc_message, encode_rpc_message
+
+
+@pytest.mark.asyncio
+async def test_dispatch_async_maps_permission_errors(monkeypatch):
+    async def deny(*_args, **_kwargs):
+        raise NexusPermissionError("Admin privileges required for this operation")
+
+    monkeypatch.setattr("nexus.server.rpc.dispatch.dispatch_method", deny)
+    dispatcher = VFSCallDispatcher(
+        nexus_fs=MagicMock(),
+        exposed_methods={},
+        loop=MagicMock(),
+        auth_provider=MagicMock(),
+    )
+
+    is_error, payload = await dispatcher._dispatch_async(
+        "hub_admin_token_list",
+        encode_rpc_message({"show_revoked": False}),
+        {
+            "authenticated": True,
+            "subject_type": "user",
+            "subject_id": "bob",
+            "is_admin": False,
+        },
+    )
+
+    assert is_error is True
+    error = decode_rpc_message(payload)
+    assert error["code"] == RPCErrorCode.PERMISSION_ERROR.value
+    assert "Admin privileges required for this operation" in error["message"]

--- a/tests/unit/hub/test_admin_ops.py
+++ b/tests/unit/hub/test_admin_ops.py
@@ -1,0 +1,102 @@
+from __future__ import annotations
+
+from contextlib import contextmanager
+
+import pytest
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+
+from nexus.hub import admin_ops
+from nexus.storage.api_key_ops import create_api_key
+from nexus.storage.models._base import Base
+from nexus.storage.models.auth import ZoneModel
+
+
+@pytest.fixture
+def session_factory(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'hub.db'}")
+    Base.metadata.create_all(engine)
+    SessionLocal = sessionmaker(bind=engine)
+    with SessionLocal() as session:
+        for zone_id in ("eng", "ops"):
+            session.add(ZoneModel(zone_id=zone_id, name=zone_id, phase="Active"))
+        session.commit()
+
+    @contextmanager
+    def _factory():
+        session = SessionLocal()
+        try:
+            yield session
+        finally:
+            session.close()
+
+    return _factory
+
+
+def test_create_hub_token_supports_multi_zone_permissions(session_factory):
+    result = admin_ops.create_hub_token(
+        session_factory,
+        name="remote-admin",
+        zones_csv="eng:r,ops:rw",
+        zones_glob=None,
+        is_admin=True,
+        expires=None,
+        user_id=None,
+    )
+
+    assert result["key_id"]
+    assert result["token"].startswith("sk-")
+    assert result["name"] == "remote-admin"
+    assert result["admin"] is True
+    assert result["zones"] == [
+        {"zone_id": "eng", "permission": "r"},
+        {"zone_id": "ops", "permission": "rw"},
+    ]
+
+
+def test_list_hub_tokens_returns_local_cli_payload_shape(session_factory):
+    with session_factory() as session:
+        key_id, _ = create_api_key(
+            session,
+            user_id="alice",
+            name="alice-token",
+            zones=["eng", ("ops", "rw")],
+            is_admin=False,
+        )
+        session.commit()
+
+    payload = admin_ops.list_hub_tokens(session_factory, show_revoked=False)
+
+    assert payload["tokens"][0]["key_id"] == key_id
+    assert payload["tokens"][0]["name"] == "alice-token"
+    assert payload["tokens"][0]["zone"] == "eng"
+    assert payload["tokens"][0]["zones"] == ["eng", "ops"]
+
+
+def test_revoke_hub_token_matches_local_message(session_factory):
+    with session_factory() as session:
+        key_id, _ = create_api_key(session, user_id="alice", name="revoke-me", zones=["eng"])
+        session.commit()
+
+    result = admin_ops.revoke_hub_token(session_factory, identifier=key_id[:12])
+
+    assert result["key_id"] == key_id
+    assert result["name"] == "revoke-me"
+    assert (
+        result["message"] == f"revoked revoke-me ({key_id}). Effective within 60s (auth cache TTL)."
+    )
+
+
+def test_get_hub_status_reports_postgres_and_token_counts(session_factory, monkeypatch):
+    monkeypatch.setenv("NEXUS_MCP_HOST", "127.0.0.1")
+    monkeypatch.setenv("NEXUS_MCP_PORT", "8081")
+
+    with session_factory() as session:
+        create_api_key(session, user_id="admin", name="admin", is_admin=True)
+        session.commit()
+
+    payload = admin_ops.get_hub_status(session_factory, redis_stats=lambda: {"redis": "n/a"})
+
+    assert payload["postgres"] == "ok"
+    assert payload["tokens"] == {"active": 1, "revoked": 0}
+    assert payload["endpoint"] == "http://127.0.0.1:8081/mcp"

--- a/tests/unit/server/api/core/test_health.py
+++ b/tests/unit/server/api/core/test_health.py
@@ -1,0 +1,39 @@
+"""Tests for core health endpoints."""
+
+import sys
+from types import SimpleNamespace
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nexus.server.api.core.health import router
+
+
+def _app_with_health(nexus_fs: object) -> FastAPI:
+    app = FastAPI()
+    app.include_router(router)
+    app.state.nexus_fs = nexus_fs
+    app.state.api_key = None
+    app.state.auth_provider = None
+    return app
+
+
+def test_health_does_not_probe_federation_when_peers_unset(monkeypatch):
+    monkeypatch.delenv("NEXUS_PEERS", raising=False)
+    calls = []
+
+    fake_runtime = SimpleNamespace(
+        federation_is_initialized=lambda kernel: calls.append(kernel) or False
+    )
+    monkeypatch.setitem(sys.modules, "nexus_runtime", fake_runtime)
+
+    fs = SimpleNamespace(
+        _kernel=object(),
+        _perm_config=SimpleNamespace(enforce=True),
+        _enforce_zone_isolation=True,
+    )
+    response = TestClient(_app_with_health(fs)).get("/health")
+
+    assert response.status_code == 200
+    assert response.json()["status"] == "healthy"
+    assert calls == []

--- a/tests/unit/server/rpc/handlers/test_hub_admin.py
+++ b/tests/unit/server/rpc/handlers/test_hub_admin.py
@@ -1,0 +1,90 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+
+import pytest
+
+from nexus.contracts.exceptions import NexusPermissionError
+from nexus.server.rpc.handlers import hub_admin
+
+
+def test_hub_admin_list_requires_admin_before_operation(monkeypatch):
+    called = False
+
+    def fake_list(*args, **kwargs):
+        nonlocal called
+        called = True
+        return {"tokens": []}
+
+    monkeypatch.setattr(hub_admin.admin_ops, "list_hub_tokens", fake_list)
+
+    with pytest.raises(NexusPermissionError):
+        hub_admin.handle_hub_admin_token_list(
+            SimpleNamespace(session_factory=lambda: None),
+            SimpleNamespace(show_revoked=False),
+            SimpleNamespace(is_admin=False, user_id="bob"),
+        )
+
+    assert called is False
+
+
+def test_hub_admin_create_delegates_to_shared_ops(monkeypatch):
+    calls = []
+
+    def fake_create(session_factory, **kwargs):
+        calls.append((session_factory, kwargs))
+        return {"key_id": "nk_1", "token": "sk-1"}
+
+    monkeypatch.setattr(hub_admin.admin_ops, "create_hub_token", fake_create)
+    auth_provider = SimpleNamespace(session_factory="factory")
+
+    result = hub_admin.handle_hub_admin_token_create(
+        auth_provider,
+        SimpleNamespace(
+            name="ci",
+            zones="eng:rw",
+            zones_glob=None,
+            admin=True,
+            expires="7d",
+            user_id="u1",
+        ),
+        SimpleNamespace(is_admin=True, user_id="admin"),
+    )
+
+    assert result == {"key_id": "nk_1", "token": "sk-1"}
+    assert calls == [
+        (
+            "factory",
+            {
+                "name": "ci",
+                "zones_csv": "eng:rw",
+                "zones_glob": None,
+                "is_admin": True,
+                "expires": "7d",
+                "user_id": "u1",
+            },
+        )
+    ]
+
+
+def test_hub_admin_revoke_delegates_to_shared_ops(monkeypatch):
+    calls = []
+
+    def fake_revoke(session_factory, **kwargs):
+        calls.append((session_factory, kwargs))
+        return {
+            "key_id": "nk_1",
+            "name": "old",
+            "message": "revoked old (nk_1). Effective within 60s (auth cache TTL).",
+        }
+
+    monkeypatch.setattr(hub_admin.admin_ops, "revoke_hub_token", fake_revoke)
+
+    result = hub_admin.handle_hub_admin_token_revoke(
+        SimpleNamespace(session_factory="factory"),
+        SimpleNamespace(identifier="old"),
+        SimpleNamespace(is_admin=True, user_id="admin"),
+    )
+
+    assert result["key_id"] == "nk_1"
+    assert calls == [("factory", {"identifier": "old"})]

--- a/tests/unit/server/rpc/handlers/test_hub_admin.py
+++ b/tests/unit/server/rpc/handlers/test_hub_admin.py
@@ -31,12 +31,15 @@ def test_hub_admin_list_requires_admin_before_operation(monkeypatch):
 def test_hub_admin_create_delegates_to_shared_ops(monkeypatch):
     calls = []
 
+    def session_factory():
+        return None
+
     def fake_create(session_factory, **kwargs):
         calls.append((session_factory, kwargs))
         return {"key_id": "nk_1", "token": "sk-1"}
 
     monkeypatch.setattr(hub_admin.admin_ops, "create_hub_token", fake_create)
-    auth_provider = SimpleNamespace(session_factory="factory")
+    auth_provider = SimpleNamespace(session_factory=session_factory)
 
     result = hub_admin.handle_hub_admin_token_create(
         auth_provider,
@@ -54,7 +57,7 @@ def test_hub_admin_create_delegates_to_shared_ops(monkeypatch):
     assert result == {"key_id": "nk_1", "token": "sk-1"}
     assert calls == [
         (
-            "factory",
+            session_factory,
             {
                 "name": "ci",
                 "zones_csv": "eng:rw",
@@ -70,6 +73,9 @@ def test_hub_admin_create_delegates_to_shared_ops(monkeypatch):
 def test_hub_admin_revoke_delegates_to_shared_ops(monkeypatch):
     calls = []
 
+    def session_factory():
+        return None
+
     def fake_revoke(session_factory, **kwargs):
         calls.append((session_factory, kwargs))
         return {
@@ -81,10 +87,32 @@ def test_hub_admin_revoke_delegates_to_shared_ops(monkeypatch):
     monkeypatch.setattr(hub_admin.admin_ops, "revoke_hub_token", fake_revoke)
 
     result = hub_admin.handle_hub_admin_token_revoke(
-        SimpleNamespace(session_factory="factory"),
+        SimpleNamespace(session_factory=session_factory),
         SimpleNamespace(identifier="old"),
         SimpleNamespace(is_admin=True, user_id="admin"),
     )
 
     assert result["key_id"] == "nk_1"
-    assert calls == [("factory", {"identifier": "old"})]
+    assert calls == [(session_factory, {"identifier": "old"})]
+
+
+def test_hub_admin_list_uses_env_db_when_static_auth_has_no_session_factory(monkeypatch):
+    calls = []
+
+    def fake_list(session_factory, **kwargs):
+        calls.append((session_factory, kwargs))
+        return {"tokens": []}
+
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+    monkeypatch.setattr(hub_admin.admin_ops, "list_hub_tokens", fake_list)
+
+    result = hub_admin.handle_hub_admin_token_list(
+        SimpleNamespace(),
+        SimpleNamespace(show_revoked=False),
+        SimpleNamespace(is_admin=True, user_id="admin"),
+    )
+
+    assert result == {"tokens": []}
+    assert len(calls) == 1
+    assert callable(calls[0][0])
+    assert calls[0][1] == {"show_revoked": False}


### PR DESCRIPTION
## Summary
- Adds `--remote` and `--admin-token` support for `nexus hub token create/list/revoke` and `nexus hub status`.
- Exposes admin-only MCP hub tools that forward to backend `hub_admin_*` RPC handlers in the two-service hub deployment.
- Extracts shared DB-backed hub token/status operations so local CLI, backend RPC, and remote MCP paths share output semantics.

## Validation
- `/Users/tafeng/.local/bin/uv run python -m pytest tests/unit/hub/test_admin_ops.py tests/unit/cli/test_hub.py tests/unit/cli/test_hub_remote.py tests/unit/cli/test_hub_token_list_primary_alias.py tests/unit/server/rpc/handlers/test_hub_admin.py tests/unit/server/rpc/handlers/test_admin_primary_alias.py tests/unit/server/rpc/handlers/test_admin_junction_filter.py tests/unit/bricks/mcp/test_hub_admin_tools.py tests/unit/bricks/mcp/test_mcp_server_tools.py tests/unit/cli/test_mcp_embedded_hub_rejection.py -q -o addopts=`
- Pre-commit hooks passed on commit, including ruff, ruff format, and mypy.
- `nexus up --build` was attempted locally but could not run because Docker Compose is not installed in the environment.