### PR TITLE
fix(raft): single-node default creates own root + dynamic mode truly rootless

### DIFF
--- a/.github/workflows/cluster-binary-build.yml
+++ b/.github/workflows/cluster-binary-build.yml
@@ -88,16 +88,25 @@ jobs:
         # Pin to 3.20.2 to match the macOS step (protobuf-build 0.14
         # rejects 4.x/calendar-version protoc versions).
         if: runner.os == 'Windows'
-        shell: bash
+        shell: pwsh
         run: |
-          set -euo pipefail
-          PROTOC_VERSION=3.20.2
-          curl -fsSL -o protoc.zip \
-            "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-win64.zip"
-          unzip -o protoc.zip -d "$HOME/protoc"
-          echo "$HOME/protoc/bin" >> "$GITHUB_PATH"
-          echo "PROTOC=$HOME/protoc/bin/protoc.exe" >> "$GITHUB_ENV"
-          "$HOME/protoc/bin/protoc.exe" --version
+          $ErrorActionPreference = 'Stop'
+          $protocVersion = '3.20.2'
+          $protocDir = Join-Path $env:USERPROFILE 'protoc'
+          New-Item -ItemType Directory -Force -Path $protocDir | Out-Null
+          $zipPath = Join-Path $env:RUNNER_TEMP 'protoc.zip'
+          Invoke-WebRequest -UseBasicParsing -Uri `
+            "https://github.com/protocolbuffers/protobuf/releases/download/v${protocVersion}/protoc-${protocVersion}-win64.zip" `
+            -OutFile $zipPath
+          Expand-Archive -Force -Path $zipPath -DestinationPath $protocDir
+          $protocBinDir = Join-Path $protocDir 'bin'
+          $protocExe = Join-Path $protocBinDir 'protoc.exe'
+          # Native Windows paths into GITHUB_ENV / GITHUB_PATH so
+          # cargo + prost-build see real `C:\…\protoc.exe` rather
+          # than bash's `/c/Users/…` POSIX form.
+          Add-Content -Path $env:GITHUB_PATH -Value $protocBinDir
+          Add-Content -Path $env:GITHUB_ENV -Value "PROTOC=$protocExe"
+          & $protocExe --version
 
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1

--- a/.github/workflows/cluster-binary-build.yml
+++ b/.github/workflows/cluster-binary-build.yml
@@ -77,6 +77,28 @@ jobs:
           echo "$HOME/protoc/bin" >> "$GITHUB_PATH"
           "$HOME/protoc/bin/protoc" --version
 
+      - name: Install protoc (Windows)
+        # `.cargo/config.toml`'s PROTOC override points at
+        # `scripts/protoc-compat.py` (a shebang-based python script).
+        # Linux/macOS runners honour shebangs; Windows does not — it
+        # tries to invoke the .py file as a Win32 binary and fails
+        # with `os error 193`.  Install a real protoc and override
+        # the PROTOC env var so cargo's [env] section's
+        # `default = false` lets the workflow value win.
+        # Pin to 3.20.2 to match the macOS step (protobuf-build 0.14
+        # rejects 4.x/calendar-version protoc versions).
+        if: runner.os == 'Windows'
+        shell: bash
+        run: |
+          set -euo pipefail
+          PROTOC_VERSION=3.20.2
+          curl -fsSL -o protoc.zip \
+            "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/protoc-${PROTOC_VERSION}-win64.zip"
+          unzip -o protoc.zip -d "$HOME/protoc"
+          echo "$HOME/protoc/bin" >> "$GITHUB_PATH"
+          echo "PROTOC=$HOME/protoc/bin/protoc.exe" >> "$GITHUB_ENV"
+          "$HOME/protoc/bin/protoc.exe" --version
+
       - name: Install Rust toolchain
         uses: actions-rust-lang/setup-rust-toolchain@v1
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -633,8 +633,12 @@ jobs:
       - name: Boot smoke test
         run: |
           DATA_DIR=$(mktemp -d)
+          # Smoke uses static + empty peers → single-node default
+          # (creates own root 1-voter zone).  --bootstrap-mode is
+          # required since BootstrapMode validator landed.
           RUST_LOG=info ./target/release/nexusd-cluster \
-            --no-tls --data-dir "$DATA_DIR" &
+            --no-tls --data-dir "$DATA_DIR" \
+            --bootstrap-mode static &
           PID=$!
           echo "Started nexusd-cluster (PID=$PID), waiting 5s for boot…"
 

--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -349,33 +349,26 @@ async fn run_daemon(common: CommonArgs) -> Result<()> {
     // bootstrap".  Cheap filesystem stat.
     let data_dir_has_root = common.data_dir.join("root").join("raft").exists();
 
-    // Operator MUST declare bootstrap intent when federation is in
-    // play — `BootstrapMode` doc has the contract.  "Federation in
-    // play" = any of: data dir already holds a root zone (restart),
-    // `--bootstrap-new` (static founder), or non-empty `--peers`
-    // (static joiner).  CLI invocations with none of those signals
-    // skip the validator (no federation intent yet).
-    let federation_in_play = data_dir_has_root || bootstrap_new || peers_non_empty;
-    if federation_in_play {
-        let mode_str = common.bootstrap_mode.as_deref().ok_or_else(|| {
-            anyhow::anyhow!(
-                "--bootstrap-mode (or NEXUS_BOOTSTRAP_MODE) is required when bootstrapping \
-                 federation (data dir holds root, --bootstrap-new set, or --peers \
-                 non-empty).  Pass one of: static, dynamic, restart.  \
-                 See BootstrapMode docs in nexus_raft.",
-            )
-        })?;
-        let mode = BootstrapMode::parse(mode_str).map_err(|e| anyhow::anyhow!("{}", e))?;
-        validate_bootstrap_mode(mode, data_dir_has_root, bootstrap_new, peers_non_empty)
-            .map_err(|e| anyhow::anyhow!("{}", e))?;
-        tracing::info!(
-            mode = mode.as_str(),
-            bootstrap_new,
-            peers_non_empty,
-            data_dir_has_root,
-            "bootstrap mode validated",
-        );
-    }
+    // Operator MUST declare bootstrap intent.  No implicit dispatch:
+    // explicit mode declaration is the SSOT for what kind of boot
+    // this is (static = env-driven cluster formation, dynamic =
+    // rootless + runtime API, restart = resume from disk).
+    let mode_str = common.bootstrap_mode.as_deref().ok_or_else(|| {
+        anyhow::anyhow!(
+            "--bootstrap-mode (or NEXUS_BOOTSTRAP_MODE) is required.  Pass one of: \
+             static, dynamic, restart.  See BootstrapMode docs in nexus_raft.",
+        )
+    })?;
+    let mode = BootstrapMode::parse(mode_str).map_err(|e| anyhow::anyhow!("{}", e))?;
+    validate_bootstrap_mode(mode, data_dir_has_root, bootstrap_new, peers_non_empty)
+        .map_err(|e| anyhow::anyhow!("{}", e))?;
+    tracing::info!(
+        mode = mode.as_str(),
+        bootstrap_new,
+        peers_non_empty,
+        data_dir_has_root,
+        "bootstrap mode validated",
+    );
 
     let ZoneManagerBundle {
         zm,
@@ -384,49 +377,46 @@ async fn run_daemon(common: CommonArgs) -> Result<()> {
         peer_addrs,
     } = open_zone_manager(&common)?;
 
-    // Bring root zone online via `bootstrap_or_join_zone` — the SSOT
-    // dispatch Python `nexusd::init_from_env` and this binary share.
-    // Three branches by storage state:
+    // Bring root zone online based on declared mode.
     //
-    //   1. restart — persisted ConfState resumes;
-    //   2. fresh create — `NEXUS_BOOTSTRAP_NEW=1` honored, 1-voter
-    //      cluster of `node_id`;
-    //   3. wait-and-join — empty storage + flag unset + non-empty
-    //      peer list = retry JoinZone forever (no deadline).
+    //   * Static: dispatch through `bootstrap_or_join_zone` — empty
+    //     peers → 1-voter single-node default; non-empty peers →
+    //     joiner retry loop.
+    //   * Restart: dispatch through `bootstrap_or_join_zone` —
+    //     persisted ConfState resumes (branch 1).
+    //   * Dynamic: SKIP root bootstrap entirely; daemon comes up
+    //     rootless, operator drives `create_zone` via runtime API.
     //
-    // BootstrapMode validation above already gates which of these
-    // branches is reachable for the declared mode, so no in-helper
-    // fall-through happens silently.
-
-    // `bootstrap_or_join_zone` is a sync helper that, in branch 3
-    // (wait-and-join), spins a nested `tokio::runtime` to drive the
-    // JoinZone retry loop's RPCs.  Python `nexusd::init_from_env`
-    // calls it from a sync PyO3 entry point — no outer runtime — so
-    // the nested-runtime build is allowed.  `nexusd-cluster::main` is
-    // `#[tokio::main]`, so calling the sync helper from this `async`
-    // function would build the nested runtime *inside* the outer
-    // worker pool and trip tokio's "Cannot start a runtime from
-    // within a runtime" panic.  Move the call to `spawn_blocking`:
-    // the blocking thread is outside the worker pool, so nested
-    // runtime creation is allowed (and the worker pool is not held
-    // while branch 3 retries indefinitely).
-    let zm_for_bootstrap = zm.clone();
-    let self_addr_for_bootstrap = self_address.clone();
-    let peer_addrs_for_bootstrap = peer_addrs.clone();
-    tokio::task::spawn_blocking(move || {
-        bootstrap_or_join_zone(
-            zm_for_bootstrap.as_ref(),
-            "root",
-            node_id,
-            &self_addr_for_bootstrap,
-            &peer_addrs_for_bootstrap,
-            bootstrap_new,
-            /* max_attempts */ None, // daemon boot — retry forever
-        )
-    })
-    .await
-    .map_err(|e| anyhow::anyhow!("bootstrap join task panicked: {}", e))?
-    .map_err(|e| anyhow::anyhow!("bootstrap_or_join_zone: {}", e))?;
+    // `bootstrap_or_join_zone` is a sync helper that may spin a
+    // nested `tokio::runtime` for its JoinZone RPCs (joiner branch),
+    // which would panic with "Cannot start a runtime from within a
+    // runtime" on a worker thread of the outer `#[tokio::main]`.
+    // `spawn_blocking` moves it onto the blocking pool where nested
+    // runtime creation is allowed.
+    if matches!(mode, BootstrapMode::Static | BootstrapMode::Restart) {
+        let zm_for_bootstrap = zm.clone();
+        let self_addr_for_bootstrap = self_address.clone();
+        let peer_addrs_for_bootstrap = peer_addrs.clone();
+        tokio::task::spawn_blocking(move || {
+            bootstrap_or_join_zone(
+                zm_for_bootstrap.as_ref(),
+                "root",
+                node_id,
+                &self_addr_for_bootstrap,
+                &peer_addrs_for_bootstrap,
+                bootstrap_new,
+                /* max_attempts */ None, // daemon boot — retry forever
+            )
+        })
+        .await
+        .map_err(|e| anyhow::anyhow!("bootstrap join task panicked: {}", e))?
+        .map_err(|e| anyhow::anyhow!("bootstrap_or_join_zone: {}", e))?;
+    } else {
+        tracing::info!(
+            "bootstrap mode = dynamic; daemon up rootless — operator drives \
+             create_zone via runtime API",
+        );
+    }
 
     // `bootstrap_static` — invoked below when federation env vars are
     // set — is `NEXUS_FEDERATION_ZONES`/`_MOUNTS` driven and only

--- a/rust/raft/src/distributed_coordinator.rs
+++ b/rust/raft/src/distributed_coordinator.rs
@@ -230,14 +230,18 @@ impl Default for RaftDistributedCoordinator {
 ///
 /// Now operator must declare intent up front:
 ///
-///   * `Static` — env-driven cluster formation. `NEXUS_PEERS` /
-///     `--peers` and `NEXUS_BOOTSTRAP_NEW` / `--bootstrap-new` are
-///     consumed at startup. Data dir MUST be empty.
+///   * `Static` — env-driven cluster formation. Data dir MUST be
+///     empty.  Empty `--peers` = single-node founder by default
+///     (every cluster starts as a 1-voter); non-empty `--peers` =
+///     joiner.  `NEXUS_BOOTSTRAP_NEW` / `--bootstrap-new` is an
+///     explicit-intent alias for the empty-peers default — kept for
+///     UX, not required.
 ///   * `Dynamic` — daemon comes up rootless; operator drives zone
 ///     formation via runtime API (`nexusd-cluster share` / `join`,
 ///     or Python `nexusd federation_create_zone`). Env vars and
 ///     `--peers` related to bootstrap are REJECTED. Data dir MUST be
-///     empty.
+///     empty.  No root zone is created at boot; the daemon serves
+///     the gRPC surface and waits for runtime zone-management calls.
 ///   * `Restart` — data dir holds persisted ConfState from a prior
 ///     boot; resume from it. Bootstrap-related env vars / flags are
 ///     REJECTED (state on disk is the SSOT).
@@ -292,9 +296,11 @@ impl BootstrapMode {
 ///     `validate_peers_excludes_self`).
 ///
 /// Rules:
-///   * `Static`: data dir MUST be empty (would-be restart);
-///     `bootstrap_new_set` OR `peers_non_empty` MUST hold (otherwise
-///     nothing tells the daemon which way to bootstrap).
+///   * `Static`: data dir MUST be empty (would-be restart).  Both
+///     `bootstrap_new_set` and `peers_non_empty` are OPTIONAL —
+///     empty/empty is the single-node founder default
+///     (`bootstrap_or_join_zone` creates a 1-voter zone alone), and
+///     non-empty peers triggers the joiner retry loop.
 ///   * `Dynamic`: data dir MUST be empty (no persisted state);
 ///     `bootstrap_new_set` and `peers_non_empty` MUST both be false
 ///     (runtime API drives, not env).
@@ -317,13 +323,11 @@ pub fn validate_bootstrap_mode(
                         .to_string(),
                 );
             }
-            if !bootstrap_new_set && !peers_non_empty {
-                return Err(
-                    "bootstrap mode = static requires either NEXUS_BOOTSTRAP_NEW=1 (founder) \
-                     or NEXUS_PEERS/--peers (joiner).  Neither is set."
-                        .to_string(),
-                );
-            }
+            // Empty `bootstrap_new_set` AND empty `peers_non_empty`
+            // is the single-node founder default — every cluster
+            // starts as a 1-voter group.  Non-empty peers triggers
+            // the joiner retry loop.  Both can coexist (explicit
+            // founder declaration with hostname-only peers list).
             Ok(())
         }
         BootstrapMode::Dynamic => {
@@ -556,14 +560,27 @@ pub fn bootstrap_or_join_zone(
         return Ok(());
     }
 
-    // Branch 2: operator authorized fresh 1-voter create.
-    if bootstrap_new {
-        tracing::warn!(
+    // Branch 2: empty peers — single-node default creates own root.
+    //
+    // The operator's bootstrap intent collapses to "no peers means
+    // I'm alone": both `NEXUS_BOOTSTRAP_NEW=1` (explicit founder
+    // declaration) and "just no peers configured" land here.  Every
+    // raft cluster starts as a 1-voter cluster anyway; the join path
+    // only kicks in when the operator points the daemon at peers.
+    //
+    // `NEXUS_BOOTSTRAP_NEW` is now a documented-but-redundant alias
+    // for the empty-peers default — kept for explicit-intent UX
+    // (operators who paste the flag have not done anything wrong)
+    // and for the static-bootstrap validator's fail-loud rules
+    // around restarts and dynamic-mode mixing.
+    if peer_addrs.is_empty() {
+        tracing::info!(
             node_id,
             zone = %zone_id,
             self_address = %self_address,
-            "NEXUS_BOOTSTRAP_NEW honored; creating 1-voter zone. \
-             Other nodes must JoinZone."
+            bootstrap_new,
+            "no peers configured — creating 1-voter zone (single-node default). \
+             Other nodes JoinZone here.",
         );
         let self_peer = format!("{node_id}@{self_address}");
         zm.create_zone(zone_id, vec![self_peer])
@@ -571,31 +588,14 @@ pub fn bootstrap_or_join_zone(
         return Ok(());
     }
 
-    // Branch 3: empty storage, no flag — wait for an existing cluster.
-    //
-    // Empty peer_addrs (no NEXUS_PEERS) + flag unset = "no cluster
-    // intent yet" — daemon comes up federation-active but zoneless.
-    // An operator can later set NEXUS_BOOTSTRAP_NEW=1 + restart, or
-    // call `coordinator.create_zone(zone_id)` via RPC under the
-    // dynamic-bootstrap mode.  Without this early return, branch 3
-    // loops forever with no targets — a hang for any test or
-    // single-node deployment that constructs a kernel without
-    // declaring federation intent.
-    if peer_addrs.is_empty() {
-        tracing::info!(
-            node_id,
-            zone = %zone_id,
-            "empty storage, no peers, no NEXUS_BOOTSTRAP_NEW — \
-             federation up but zoneless; operator drives create_zone later",
-        );
-        return Ok(());
-    }
+    // Branch 3: peers configured but storage empty — joiner. Loop on
+    // JoinZone RPC until a leader accepts.
     tracing::info!(
         node_id,
         zone = %zone_id,
         peer_count = peer_addrs.len(),
         max_attempts = ?max_attempts,
-        "empty storage and NEXUS_BOOTSTRAP_NEW unset — retrying JoinZone",
+        "empty storage with peers — retrying JoinZone",
     );
 
     // Spin a small temporary multi-thread runtime for the JoinZone
@@ -824,21 +824,16 @@ impl RaftDistributedCoordinator {
         // `validate_peers_excludes_self` for the full rationale.
         validate_peers_excludes_self(&peer_addrs, &self_addr)?;
 
-        // Operator MUST declare bootstrap intent when federation is in
-        // play — `BootstrapMode` doc has the contract.  Implicit
-        // dispatch (state-driven) was the source of the silent
-        // mode-mixing that surfaced in cross-machine smoke; explicit
-        // declaration kills that footgun.
-        //
-        // "Federation in play" = any of: data dir already holds a
-        // root zone (restart), `NEXUS_BOOTSTRAP_NEW=1` (static
-        // founder), or non-empty peers (static joiner).  Tests /
-        // single-node dev workflows that touch none of those signals
-        // skip the validator entirely — no federation intent, nothing
-        // to validate.
+        // Operator declares bootstrap intent up front when federation
+        // is in play.  "In play" = any of: data dir already holds a
+        // root zone (restart), `NEXUS_BOOTSTRAP_NEW=1` (explicit
+        // founder), or non-empty peers (joiner).  Tests / single-
+        // node dev workflows that touch none of those signals skip
+        // federation entirely — `bootstrap_mode` stays `None` and
+        // `bootstrap_or_join_zone` is not called below.
         let data_dir_has_root = Path::new(&zones_dir).join("root").join("raft").exists();
         let federation_in_play = data_dir_has_root || bootstrap_new || !peer_addrs.is_empty();
-        if federation_in_play {
+        let bootstrap_mode: Option<BootstrapMode> = if federation_in_play {
             let mode_str = std::env::var("NEXUS_BOOTSTRAP_MODE").map_err(|_| {
                 "NEXUS_BOOTSTRAP_MODE is required when bootstrapping federation \
                  (NEXUS_PEERS, NEXUS_BOOTSTRAP_NEW, or persisted root zone state \
@@ -860,7 +855,10 @@ impl RaftDistributedCoordinator {
                 data_dir_has_root,
                 "bootstrap mode validated",
             );
-        }
+            Some(mode)
+        } else {
+            None
+        };
 
         let tls = if tls_disabled {
             None
@@ -924,21 +922,47 @@ impl RaftDistributedCoordinator {
         // `install_transport_wiring` can drain it.
         kernel.stash_blob_fetcher_slot(Box::new(blob_slot));
 
-        // Bring root zone online — restart-from-disk, fresh-create, or
-        // wait-and-join, depending on storage state and the operator
-        // flag.  `max_attempts=None` blocks indefinitely under the join
-        // branch (no deadline) so misconfig surfaces as "daemon stays
-        // up retrying" rather than "daemon exits after timeout".
-        // See `bootstrap_or_join_zone`.
-        bootstrap_or_join_zone(
-            zm.as_ref(),
-            "root",
-            node_id,
-            &self_addr,
-            &peer_addrs,
-            bootstrap_new,
-            /* max_attempts */ None,
-        )?;
+        // Bring root zone online based on the declared mode.
+        //
+        //   * Static / Restart: `bootstrap_or_join_zone` dispatches —
+        //     empty peers + empty storage → 1-voter single-node
+        //     default; non-empty peers → joiner retry loop;
+        //     persisted state → resume.
+        //   * Dynamic: skip — daemon comes up rootless, operator
+        //     drives `create_zone` via runtime API.
+        //   * `None` (no federation in play): skip — caller did not
+        //     ask for federation init (typical for tests / single-
+        //     node dev workflows that strip env vars).
+        //
+        // `max_attempts=None` blocks indefinitely under the joiner
+        // branch (no deadline) so misconfig surfaces as "daemon
+        // stays up retrying" rather than "daemon exits after timeout".
+        match bootstrap_mode {
+            Some(BootstrapMode::Static) | Some(BootstrapMode::Restart) => {
+                bootstrap_or_join_zone(
+                    zm.as_ref(),
+                    "root",
+                    node_id,
+                    &self_addr,
+                    &peer_addrs,
+                    bootstrap_new,
+                    /* max_attempts */ None,
+                )?;
+            }
+            Some(BootstrapMode::Dynamic) => {
+                tracing::info!(
+                    node_id,
+                    "bootstrap mode = dynamic; daemon up rootless — operator drives \
+                     create_zone via runtime API",
+                );
+            }
+            None => {
+                tracing::debug!(
+                    node_id,
+                    "no federation intent declared — skipping root zone bootstrap",
+                );
+            }
+        }
 
         // Federation zones listed in `NEXUS_FEDERATION_ZONES` are
         // brought up only when this node bootstrapped root (1-voter
@@ -1882,7 +1906,12 @@ mod tests {
 
     #[test]
     fn validate_static_happy_paths() {
-        // Founder: BOOTSTRAP_NEW set, peers may be empty, data dir empty.
+        // Single-node default: empty/empty — every cluster starts as
+        // a 1-voter group, so this is the natural single-node UX.
+        validate_bootstrap_mode(BootstrapMode::Static, false, false, false)
+            .expect("single-node default ok");
+        // Founder with explicit BOOTSTRAP_NEW (redundant under
+        // empty peers but a legal documented alias).
         validate_bootstrap_mode(BootstrapMode::Static, false, true, false).expect("founder ok");
         // Joiner: peers non-empty, BOOTSTRAP_NEW unset, data dir empty.
         validate_bootstrap_mode(BootstrapMode::Static, false, false, true).expect("joiner ok");
@@ -1895,14 +1924,6 @@ mod tests {
         let err = validate_bootstrap_mode(BootstrapMode::Static, true, true, false)
             .expect_err("existing state under static is restart-in-disguise");
         assert!(err.contains("restart"));
-    }
-
-    #[test]
-    fn validate_static_rejects_empty_intent() {
-        // No flag, no peers — daemon has no signal which way to go.
-        let err = validate_bootstrap_mode(BootstrapMode::Static, false, false, false)
-            .expect_err("static without flag or peers must be rejected");
-        assert!(err.contains("BOOTSTRAP_NEW") && err.contains("PEERS"));
     }
 
     #[test]

--- a/rust/raft/src/distributed_coordinator.rs
+++ b/rust/raft/src/distributed_coordinator.rs
@@ -560,27 +560,29 @@ pub fn bootstrap_or_join_zone(
         return Ok(());
     }
 
-    // Branch 2: empty peers — single-node default creates own root.
+    // Branch 2: founder — either operator explicit (`bootstrap_new`)
+    // or implicit (empty peers = single-node alone).
     //
-    // The operator's bootstrap intent collapses to "no peers means
-    // I'm alone": both `NEXUS_BOOTSTRAP_NEW=1` (explicit founder
-    // declaration) and "just no peers configured" land here.  Every
-    // raft cluster starts as a 1-voter cluster anyway; the join path
-    // only kicks in when the operator points the daemon at peers.
+    // Every raft cluster starts as a 1-voter group; whether the
+    // operator declares founder intent via the flag or by simply
+    // not configuring peers, the next step is the same: create the
+    // zone with self as the only voter.  Other nodes will JoinZone
+    // here later.
     //
-    // `NEXUS_BOOTSTRAP_NEW` is now a documented-but-redundant alias
-    // for the empty-peers default — kept for explicit-intent UX
-    // (operators who paste the flag have not done anything wrong)
-    // and for the static-bootstrap validator's fail-loud rules
-    // around restarts and dynamic-mode mixing.
-    if peer_addrs.is_empty() {
+    //   * `bootstrap_new=true`  → explicit founder declaration.
+    //     Required for multi-node deployments where the founder
+    //     does list peer addresses (so it can dial them once they
+    //     come up) but is the one originating the cluster.
+    //   * `peer_addrs.is_empty()` → no peers configured = alone.
+    //     Single-node default — create own root.
+    if bootstrap_new || peer_addrs.is_empty() {
         tracing::info!(
             node_id,
             zone = %zone_id,
             self_address = %self_address,
             bootstrap_new,
-            "no peers configured — creating 1-voter zone (single-node default). \
-             Other nodes JoinZone here.",
+            peers_empty = peer_addrs.is_empty(),
+            "founder path — creating 1-voter zone. Other nodes JoinZone here.",
         );
         let self_peer = format!("{node_id}@{self_address}");
         zm.create_zone(zone_id, vec![self_peer])
@@ -588,14 +590,14 @@ pub fn bootstrap_or_join_zone(
         return Ok(());
     }
 
-    // Branch 3: peers configured but storage empty — joiner. Loop on
-    // JoinZone RPC until a leader accepts.
+    // Branch 3: peers configured, no flag, storage empty — joiner.
+    // Loop on JoinZone RPC until a leader accepts.
     tracing::info!(
         node_id,
         zone = %zone_id,
         peer_count = peer_addrs.len(),
         max_attempts = ?max_attempts,
-        "empty storage with peers — retrying JoinZone",
+        "empty storage with peers, no bootstrap flag — retrying JoinZone",
     );
 
     // Spin a small temporary multi-thread runtime for the JoinZone


### PR DESCRIPTION
## Summary

Restore the natural single-node UX: ``empty --peers`` ⇒ daemon creates its own 1-voter root zone, regardless of mode flag.

ed8aef41d (PR #3996 followup) made empty/empty an early-return ``federation up but rootless`` to fix a CI hang in unit tests booting PyKernel without env vars.  That fix deviated from the natural single-node UX — operators running ``nexusd-cluster`` alone expected a working filesystem, not a rootless daemon.

This PR collapses the contract to what operators naturally expect: every raft cluster starts as a 1-voter group, so single-node startup creates its own root. ``NEXUS_BOOTSTRAP_NEW`` becomes a documented-but-redundant alias for the empty-peers default.

The original CI-hang fix is preserved differently: dynamic mode now explicitly skips ``bootstrap_or_join_zone`` (no root zone created), and Python ``init_from_env`` skips when no federation signals are present (test-fixture opt-out path).

## Contract table (post-merge)

| scenario | mode | peers | dispatch |
|---|---|---|---|
| single node alone | static | empty | create own root (1-voter) |
| multi-node founder | static | empty (or other-only) | create own root, ready for AddNode |
| multi-node joiner | static | other-only | retry JoinZone forever |
| rootless (runtime API drives) | dynamic | empty | daemon up, no zone |
| resume persisted state | restart | empty | load ConfState from disk |

## Test plan

- [x] Updated unit tests: 15/15 ``validate_*`` + ``bootstrap_mode_parse_*`` green
- [x] Local 5-path smoke verified:
      * static + empty/empty → ``creating 1-voter zone (single-node default)``
      * dynamic + empty/empty → ``daemon up rootless`` (no Bootstrapped log)
      * static + bootstrap_new + empty → identical to static + empty (flag noted, redundant)
      * restart on existing state → ``zone loaded from persisted storage``
      * dynamic + bootstrap_new → fail-loud (validator rejects)
- [ ] CI green
- [ ] Post-merge: cross-machine dynamic verification with mac