### PR TITLE
fix(storage): dispose async DB engines on origin loop (#3775)

### DIFF
--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -847,15 +847,15 @@ class SearchDaemon:
         self._txtai_bootstrapped = False
 
         # Close database connections (only if we created them).
-        # Issue #3775: must use aclose() to dispose async engines on this loop;
-        # sync close() now skips async dispose to avoid cross-loop futures.
+        # Issue #3775: aclose() disposes async engines on this loop (their
+        # origin); close() then disposes the sync engine. Daemon owns no
+        # close-callback chain so the two can run back-to-back.
         if self._owns_engine:
             if self._record_store is not None:
                 aclose_fn = getattr(self._record_store, "aclose", None)
                 if aclose_fn is not None:
                     await aclose_fn()
-                else:
-                    self._record_store.close()
+                self._record_store.close()
                 self._record_store = None
             elif self._async_engine:
                 await self._async_engine.dispose()

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -846,10 +846,16 @@ class SearchDaemon:
             self._backend = None
         self._txtai_bootstrapped = False
 
-        # Close database connections (only if we created them)
+        # Close database connections (only if we created them).
+        # Issue #3775: must use aclose() to dispose async engines on this loop;
+        # sync close() now skips async dispose to avoid cross-loop futures.
         if self._owns_engine:
             if self._record_store is not None:
-                self._record_store.close()
+                aclose_fn = getattr(self._record_store, "aclose", None)
+                if aclose_fn is not None:
+                    await aclose_fn()
+                else:
+                    self._record_store.close()
                 self._record_store = None
             elif self._async_engine:
                 await self._async_engine.dispose()

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -849,16 +849,40 @@ class SearchDaemon:
         # Close database connections (only if we created them).
         # Issue #3775: aclose() disposes async engines on this loop (their
         # origin); close() then disposes the sync engine. Daemon owns no
-        # close-callback chain so the two can run back-to-back.
+        # close-callback chain so the two can run back-to-back. Wrap aclose
+        # in try/finally so a dispose failure does not abort the rest of
+        # teardown (sync close, daemon state clear, path-context cleanup) —
+        # otherwise _shutting_down stays set and a retry early-exits, making
+        # this a persistent leak.
         if self._owns_engine:
             if self._record_store is not None:
                 aclose_fn = getattr(self._record_store, "aclose", None)
-                if aclose_fn is not None:
-                    await aclose_fn()
-                self._record_store.close()
-                self._record_store = None
+                try:
+                    if aclose_fn is not None:
+                        await aclose_fn()
+                except Exception:
+                    logger.warning(
+                        "record_store.aclose failed during daemon shutdown; "
+                        "continuing with sync close",
+                        exc_info=True,
+                    )
+                finally:
+                    try:
+                        self._record_store.close()
+                    except Exception:
+                        logger.warning(
+                            "record_store.close failed during daemon shutdown",
+                            exc_info=True,
+                        )
+                    self._record_store = None
             elif self._async_engine:
-                await self._async_engine.dispose()
+                try:
+                    await self._async_engine.dispose()
+                except Exception:
+                    logger.warning(
+                        "async_engine.dispose failed during daemon shutdown",
+                        exc_info=True,
+                    )
         self._async_engine = None
         self._async_session = None
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -859,23 +859,40 @@ class NexusFS(  # type: ignore[misc]
         connections (asyncpg ``InternalClientError``).
 
         FastAPI lifespan must await this on its own loop *before* invoking
-        ``aclose`` via ``run_in_executor``. After this returns,
-        ``self._record_store`` is None, so the subsequent sync close() skips
-        the record-store branch.
+        ``aclose`` via ``run_in_executor``. On success, ``self._record_store``
+        is cleared so the subsequent sync ``close()`` skips the record-store
+        branch. On failure the reference is **preserved** so ``close()`` can
+        still attempt sync teardown (best-effort dispose with preserved refs)
+        rather than silently orphaning the store.
         """
         if self._record_store is None:
             return
         aclose_fn = getattr(self._record_store, "aclose", None)
-        if aclose_fn is not None:
-            try:
-                await aclose_fn()
-            except Exception:
-                logger.debug("record_store.aclose failed (best-effort)", exc_info=True)
-        else:
+        if aclose_fn is None:
+            # Legacy stores without aclose — fall back to sync close on this
+            # loop. Safe iff async engine is uninitialized; close() preserves
+            # refs on dispose failure so an initialized engine remains
+            # recoverable.
             try:
                 self._record_store.close()
+                self._record_store = None
             except Exception:
-                logger.debug("record_store.close failed (best-effort)", exc_info=True)
+                logger.warning(
+                    "record_store.close failed; store retained for recovery",
+                    exc_info=True,
+                )
+            return
+        try:
+            await aclose_fn()
+        except Exception:
+            # Don't orphan the store: leave self._record_store attached so
+            # the subsequent sync close() in aclose() can attempt cleanup
+            # (best-effort dispose, refs preserved on its own failure).
+            logger.warning(
+                "record_store.aclose failed; store retained for sync close fallback",
+                exc_info=True,
+            )
+            return
         self._record_store = None
 
     # ── IPC primitives (inlined from IPCMixin) ─────────────────────────

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -826,6 +826,14 @@ class NexusFS(  # type: ignore[misc]
 
         Calls kernel lifecycle methods first, then
         delegates to close() for sync resource cleanup.
+
+        Sync rather than async because ``kernel.service_stop_all`` invokes
+        ``asyncio.run()`` for Python BackgroundService coroutines, which
+        cannot run on an already-active loop. The FastAPI lifespan dispatches
+        this via ``run_in_executor`` for that reason. To dispose async DB
+        engines on the lifespan loop (Issue #3775), call
+        :meth:`adispose_async_engines` *before* dispatching ``aclose`` to a
+        worker thread.
         """
         # Issue #3391: drain deferred OBSERVE background tasks before tearing down.
         self.shutdown()
@@ -839,6 +847,36 @@ class NexusFS(  # type: ignore[misc]
                     _unregister_hooks_for_spec(self, spec)
             self._hook_specs.clear()
         self.close()
+
+    async def adispose_async_engines(self) -> None:
+        """Dispose async DB engines on the current loop (Issue #3775).
+
+        Async engines hold asyncpg connections whose pending futures are
+        bound to the loop that created the pool. Disposing via
+        ``sync_engine.dispose()`` from a worker thread (where ``aclose`` runs)
+        await-only's into a different loop, producing
+        ``RuntimeError: Future attached to a different loop`` and leaks
+        connections (asyncpg ``InternalClientError``).
+
+        FastAPI lifespan must await this on its own loop *before* invoking
+        ``aclose`` via ``run_in_executor``. After this returns,
+        ``self._record_store`` is None, so the subsequent sync close() skips
+        the record-store branch.
+        """
+        if self._record_store is None:
+            return
+        aclose_fn = getattr(self._record_store, "aclose", None)
+        if aclose_fn is not None:
+            try:
+                await aclose_fn()
+            except Exception:
+                logger.debug("record_store.aclose failed (best-effort)", exc_info=True)
+        else:
+            try:
+                self._record_store.close()
+            except Exception:
+                logger.debug("record_store.close failed (best-effort)", exc_info=True)
+        self._record_store = None
 
     # ── IPC primitives (inlined from IPCMixin) ─────────────────────────
 

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -849,51 +849,39 @@ class NexusFS(  # type: ignore[misc]
         self.close()
 
     async def adispose_async_engines(self) -> None:
-        """Dispose async DB engines on the current loop (Issue #3775).
+        """Dispose record store's async DB engines on the current loop (Issue #3775).
 
         Async engines hold asyncpg connections whose pending futures are
         bound to the loop that created the pool. Disposing via
-        ``sync_engine.dispose()`` from a worker thread (where ``aclose`` runs)
+        ``sync_engine.dispose()`` from a worker thread (where ``close()`` runs)
         await-only's into a different loop, producing
         ``RuntimeError: Future attached to a different loop`` and leaks
         connections (asyncpg ``InternalClientError``).
 
-        FastAPI lifespan must await this on its own loop *before* invoking
-        ``aclose`` via ``run_in_executor``. On success, ``self._record_store``
-        is cleared so the subsequent sync ``close()`` skips the record-store
-        branch. On failure the reference is **preserved** so ``close()`` can
-        still attempt sync teardown (best-effort dispose with preserved refs)
-        rather than silently orphaning the store.
+        Disposes **only** the async engines. The record store stays attached
+        and its sync engine usable so that ``NexusFS.close()`` callbacks
+        (e.g. write observer ``flush_sync``) can still write through the sync
+        ``session_factory``. Sync engine teardown happens later in
+        ``record_store.close()`` *after* those callbacks have run.
+
+        FastAPI lifespan must await this on its own loop before dispatching
+        ``aclose`` to a worker thread. Failure preserves the store and is
+        logged at warning level; the subsequent sync ``close()`` will still
+        run callbacks and attempt best-effort sync dispose of the (still
+        live) async engine — better than silently orphaning the store.
         """
         if self._record_store is None:
             return
         aclose_fn = getattr(self._record_store, "aclose", None)
         if aclose_fn is None:
-            # Legacy stores without aclose — fall back to sync close on this
-            # loop. Safe iff async engine is uninitialized; close() preserves
-            # refs on dispose failure so an initialized engine remains
-            # recoverable.
-            try:
-                self._record_store.close()
-                self._record_store = None
-            except Exception:
-                logger.warning(
-                    "record_store.close failed; store retained for recovery",
-                    exc_info=True,
-                )
-            return
+            return  # legacy store without aclose — close() will handle sync dispose
         try:
             await aclose_fn()
         except Exception:
-            # Don't orphan the store: leave self._record_store attached so
-            # the subsequent sync close() in aclose() can attempt cleanup
-            # (best-effort dispose, refs preserved on its own failure).
             logger.warning(
-                "record_store.aclose failed; store retained for sync close fallback",
+                "record_store.aclose failed; sync close() will attempt fallback",
                 exc_info=True,
             )
-            return
-        self._record_store = None
 
     # ── IPC primitives (inlined from IPCMixin) ─────────────────────────
 

--- a/src/nexus/server/lifespan/__init__.py
+++ b/src/nexus/server/lifespan/__init__.py
@@ -301,6 +301,17 @@ async def lifespan(app: "FastAPI") -> AsyncIterator[None]:
     if app.state.nexus_fs:
         import inspect
 
+        # Issue #3775: dispose async DB engines on the lifespan loop *before*
+        # dispatching aclose to a worker thread. Async engines hold asyncpg
+        # connections bound to this loop; disposing them from another thread
+        # raises "Future attached to a different loop".
+        adispose = getattr(app.state.nexus_fs, "adispose_async_engines", None)
+        if adispose is not None:
+            try:
+                await adispose()
+            except Exception:
+                logger.debug("adispose_async_engines failed", exc_info=True)
+
         close_fn = getattr(app.state.nexus_fs, "aclose", None)
         if close_fn is None:
             close_fn = getattr(app.state.nexus_fs, "close", None)

--- a/src/nexus/storage/record_store.py
+++ b/src/nexus/storage/record_store.py
@@ -304,6 +304,11 @@ class SQLAlchemyRecordStore(RecordStoreABC):
         self._async_engine: Any = None
         self._async_session_factory_instance: Any = None
         self._async_init_lock = threading.Lock()
+        # Issue #3775: set after aclose() to block lazy re-creation of async
+        # engines via the factory property — otherwise a stale consumer
+        # holding ``record_store.async_session_factory`` would silently
+        # rebuild a fresh asyncpg pool that nothing later disposes.
+        self._async_closed: bool = False
 
         # Read replica engine/session (Issue #725)
         self._read_engine: Any = None
@@ -546,6 +551,14 @@ class SQLAlchemyRecordStore(RecordStoreABC):
             with self._async_init_lock:
                 # Double-check after acquiring lock
                 if self._async_session_factory_instance is None:
+                    if self._async_closed:
+                        # Issue #3775: post-aclose, refuse to rebuild a pool
+                        # that no shutdown path will dispose.
+                        raise RuntimeError(
+                            "SQLAlchemyRecordStore.async_session_factory accessed "
+                            "after aclose(); the async engine has been disposed. "
+                            "Construct a new RecordStore for further async use."
+                        )
                     from sqlalchemy.ext.asyncio import (
                         AsyncSession,
                         async_sessionmaker,
@@ -650,6 +663,14 @@ class SQLAlchemyRecordStore(RecordStoreABC):
             with self._async_read_init_lock:
                 # Double-check after acquiring lock
                 if self._async_read_session_factory_instance is None:
+                    if self._async_closed:
+                        # Issue #3775: post-aclose, refuse to rebuild a pool
+                        # that no shutdown path will dispose.
+                        raise RuntimeError(
+                            "SQLAlchemyRecordStore.async_read_session_factory accessed "
+                            "after aclose(); the async read engine has been disposed. "
+                            "Construct a new RecordStore for further async use."
+                        )
                     from sqlalchemy.ext.asyncio import (
                         AsyncSession,
                         async_sessionmaker,
@@ -796,17 +817,29 @@ class SQLAlchemyRecordStore(RecordStoreABC):
         caller must subsequently invoke :meth:`close` to dispose sync engines
         once those callbacks have run.
 
+        Sets ``_async_closed = True`` so subsequent property access raises
+        rather than silently rebuilding a pool that nothing will dispose.
+        SQLAlchemy ``Engine.dispose()`` only clears the pool — the engine
+        remains usable and would lazily build a fresh pool on next checkout.
+
+        The async engine references are **retained** (not nulled) after
+        dispose so that ``close()`` can re-dispose them if any retained
+        ``async_sessionmaker`` reference checked out a connection between
+        ``aclose`` and the final ``close``. (External consumers that cached
+        the factory from before aclose can still call into the engine; the
+        sentinel only protects fresh property accesses.)
+
         Must be awaited from the same loop that created the async engine
         (typically the loop that first accessed ``async_session_factory``);
         calling from a different loop reproduces the original cross-loop bug.
         """
+        # Set the sentinel first so that even a dispose failure leaves the
+        # store unable to silently re-create a new pool via the property.
+        self._async_closed = True
         if self._async_engine is not None:
             await self._async_engine.dispose()
-            self._async_engine = None
-            self._async_session_factory_instance = None
+            # Retain ref — close() will re-dispose to catch reopened pools.
         if self._async_read_engine is not None:
             await self._async_read_engine.dispose()
-            self._async_read_engine = None
-            self._async_read_session_factory_instance = None
 
         logger.info("SQLAlchemyRecordStore async engines disposed")

--- a/src/nexus/storage/record_store.py
+++ b/src/nexus/storage/record_store.py
@@ -731,22 +731,58 @@ class SQLAlchemyRecordStore(RecordStoreABC):
         )
 
     def close(self) -> None:
-        """Close all engines and release connections."""
+        """Close sync engines; drop async engine references (Issue #3775).
+
+        Async engines are NOT disposed here — disposing an ``AsyncEngine`` via
+        ``sync_engine.dispose()`` greenlet-awaits ``_terminate_graceful_close``
+        on whatever loop is running, but asyncpg connections bind their pending
+        futures to the loop where the pool was created. When ``close()`` runs
+        on a different loop or thread (FastAPI lifespan dispatches NexusFS
+        ``aclose`` via ``run_in_executor``), the cross-loop await produces
+        ``RuntimeError: Future attached to a different loop`` and orphans
+        connections (asyncpg ``InternalClientError: unknown protocol state``).
+
+        Callers that own an async engine must use :meth:`aclose` from the
+        engine's origin loop. Sync callers that never accessed the async
+        session factory leave ``_async_engine is None`` and are unaffected;
+        for those, dropping the (None) reference is a no-op.
+        """
         self._engine.dispose()
-        if self._async_engine is not None:
-            # Async engine dispose is sync-safe in SQLAlchemy 2.0+
-            self._async_engine.sync_engine.dispose()
-            self._async_engine = None
-            self._async_session_factory_instance = None
+        # Drop async refs without dispose — origin loop required for proper close.
+        self._async_engine = None
+        self._async_session_factory_instance = None
 
         # Dispose read replica engines (Issue #725)
         if self._read_engine is not None:
             self._read_engine.dispose()
             self._read_engine = None
             self._read_session_factory_instance = None
+        self._async_read_engine = None
+        self._async_read_session_factory_instance = None
+
+        logger.info("SQLAlchemyRecordStore closed")
+
+    async def aclose(self) -> None:
+        """Async close — disposes async engines on the current loop (Issue #3775).
+
+        Must be awaited from the same loop that created the async engine
+        (typically the loop that first accessed ``async_session_factory``).
+        Calling from a different loop reproduces the original cross-loop bug.
+        """
+        if self._async_engine is not None:
+            await self._async_engine.dispose()
+            self._async_engine = None
+            self._async_session_factory_instance = None
         if self._async_read_engine is not None:
-            self._async_read_engine.sync_engine.dispose()
+            await self._async_read_engine.dispose()
             self._async_read_engine = None
             self._async_read_session_factory_instance = None
 
-        logger.info("SQLAlchemyRecordStore closed")
+        # Sync engines are safe to dispose from any context.
+        self._engine.dispose()
+        if self._read_engine is not None:
+            self._read_engine.dispose()
+            self._read_engine = None
+            self._read_session_factory_instance = None
+
+        logger.info("SQLAlchemyRecordStore closed (async)")

--- a/src/nexus/storage/record_store.py
+++ b/src/nexus/storage/record_store.py
@@ -787,11 +787,18 @@ class SQLAlchemyRecordStore(RecordStoreABC):
         logger.info("SQLAlchemyRecordStore closed")
 
     async def aclose(self) -> None:
-        """Async close — disposes async engines on the current loop (Issue #3775).
+        """Dispose async engines on the current loop (Issue #3775).
+
+        Disposes only the async engines — leaves sync engines and the store
+        usable so that close-callback flush paths (e.g. write observer
+        ``flush_sync`` registered via ``NexusFS._close_callbacks``) can still
+        write through the sync ``session_factory`` after this returns. The
+        caller must subsequently invoke :meth:`close` to dispose sync engines
+        once those callbacks have run.
 
         Must be awaited from the same loop that created the async engine
-        (typically the loop that first accessed ``async_session_factory``).
-        Calling from a different loop reproduces the original cross-loop bug.
+        (typically the loop that first accessed ``async_session_factory``);
+        calling from a different loop reproduces the original cross-loop bug.
         """
         if self._async_engine is not None:
             await self._async_engine.dispose()
@@ -802,11 +809,4 @@ class SQLAlchemyRecordStore(RecordStoreABC):
             self._async_read_engine = None
             self._async_read_session_factory_instance = None
 
-        # Sync engines are safe to dispose from any context.
-        self._engine.dispose()
-        if self._read_engine is not None:
-            self._read_engine.dispose()
-            self._read_engine = None
-            self._read_session_factory_instance = None
-
-        logger.info("SQLAlchemyRecordStore closed (async)")
+        logger.info("SQLAlchemyRecordStore async engines disposed")

--- a/src/nexus/storage/record_store.py
+++ b/src/nexus/storage/record_store.py
@@ -547,13 +547,20 @@ class SQLAlchemyRecordStore(RecordStoreABC):
         to ``create_async_engine`` so that connection creation goes through the
         custom factory (e.g. Cloud SQL Python Connector).
         """
+        # Issue #3775: enforce sentinel even on the cache-hit path. After
+        # aclose() the cached factory still references the disposed engine,
+        # which would lazily rebuild a fresh pool on next checkout.
+        if self._async_closed:
+            raise RuntimeError(
+                "SQLAlchemyRecordStore.async_session_factory accessed "
+                "after aclose(); the async engine has been disposed. "
+                "Construct a new RecordStore for further async use."
+            )
         if self._async_session_factory_instance is None:
             with self._async_init_lock:
                 # Double-check after acquiring lock
                 if self._async_session_factory_instance is None:
                     if self._async_closed:
-                        # Issue #3775: post-aclose, refuse to rebuild a pool
-                        # that no shutdown path will dispose.
                         raise RuntimeError(
                             "SQLAlchemyRecordStore.async_session_factory accessed "
                             "after aclose(); the async engine has been disposed. "
@@ -659,13 +666,19 @@ class SQLAlchemyRecordStore(RecordStoreABC):
         if not self._has_read_replica:
             return self.async_session_factory
 
+        # Issue #3775: enforce sentinel even on the cache-hit path. After
+        # aclose() the cached factory still references the disposed engine.
+        if self._async_closed:
+            raise RuntimeError(
+                "SQLAlchemyRecordStore.async_read_session_factory accessed "
+                "after aclose(); the async read engine has been disposed. "
+                "Construct a new RecordStore for further async use."
+            )
         if self._async_read_session_factory_instance is None:
             with self._async_read_init_lock:
                 # Double-check after acquiring lock
                 if self._async_read_session_factory_instance is None:
                     if self._async_closed:
-                        # Issue #3775: post-aclose, refuse to rebuild a pool
-                        # that no shutdown path will dispose.
                         raise RuntimeError(
                             "SQLAlchemyRecordStore.async_read_session_factory accessed "
                             "after aclose(); the async read engine has been disposed. "

--- a/src/nexus/storage/record_store.py
+++ b/src/nexus/storage/record_store.py
@@ -731,34 +731,58 @@ class SQLAlchemyRecordStore(RecordStoreABC):
         )
 
     def close(self) -> None:
-        """Close sync engines; drop async engine references (Issue #3775).
+        """Close engines and release connections (Issue #3775).
 
-        Async engines are NOT disposed here — disposing an ``AsyncEngine`` via
-        ``sync_engine.dispose()`` greenlet-awaits ``_terminate_graceful_close``
-        on whatever loop is running, but asyncpg connections bind their pending
-        futures to the loop where the pool was created. When ``close()`` runs
-        on a different loop or thread (FastAPI lifespan dispatches NexusFS
-        ``aclose`` via ``run_in_executor``), the cross-loop await produces
-        ``RuntimeError: Future attached to a different loop`` and orphans
-        connections (asyncpg ``InternalClientError: unknown protocol state``).
+        Async engines disposed best-effort via ``sync_engine.dispose()``. This
+        is correct for sync-only callers (CLI, tests) whose async engine —
+        if ever initialized — was created on a sync thread with no live
+        event loop. It is **not** correct when ``close()`` runs on a worker
+        thread while asyncpg connections are bound to a *different* live loop;
+        that path produces ``RuntimeError: Future attached to a different
+        loop``. Callers who own such an engine must use :meth:`aclose` from
+        the engine's origin loop instead — see ``NexusFS.adispose_async_engines``.
 
-        Callers that own an async engine must use :meth:`aclose` from the
-        engine's origin loop. Sync callers that never accessed the async
-        session factory leave ``_async_engine is None`` and are unaffected;
-        for those, dropping the (None) reference is a no-op.
+        On dispose failure the reference is preserved (not nulled), so the
+        caller can attempt explicit recovery via ``aclose`` rather than
+        silently leaking the pool.
         """
         self._engine.dispose()
-        # Drop async refs without dispose — origin loop required for proper close.
-        self._async_engine = None
-        self._async_session_factory_instance = None
+
+        # Async engines: best-effort sync dispose. Preserve refs on failure
+        # so the caller can recover via aclose() — never null a live engine
+        # we did not actually dispose.
+        if self._async_engine is not None:
+            try:
+                self._async_engine.sync_engine.dispose()
+            except Exception:
+                logger.warning(
+                    "Sync dispose of async engine failed in close(); engine "
+                    "reference preserved. Use aclose() from the engine's "
+                    "origin loop to release connections.",
+                    exc_info=True,
+                )
+            else:
+                self._async_engine = None
+                self._async_session_factory_instance = None
 
         # Dispose read replica engines (Issue #725)
         if self._read_engine is not None:
             self._read_engine.dispose()
             self._read_engine = None
             self._read_session_factory_instance = None
-        self._async_read_engine = None
-        self._async_read_session_factory_instance = None
+        if self._async_read_engine is not None:
+            try:
+                self._async_read_engine.sync_engine.dispose()
+            except Exception:
+                logger.warning(
+                    "Sync dispose of async read engine failed in close(); "
+                    "engine reference preserved. Use aclose() from the "
+                    "engine's origin loop to release connections.",
+                    exc_info=True,
+                )
+            else:
+                self._async_read_engine = None
+                self._async_read_session_factory_instance = None
 
         logger.info("SQLAlchemyRecordStore closed")
 

--- a/tests/unit/bricks/search/test_daemon_shutdown_aclose_failure.py
+++ b/tests/unit/bricks/search/test_daemon_shutdown_aclose_failure.py
@@ -1,0 +1,65 @@
+"""Regression: SearchDaemon.shutdown completes despite record_store.aclose failure (Issue #3775).
+
+A previous patch awaited ``record_store.aclose()`` directly inside
+``shutdown``. If that raised, the rest of teardown — sync ``close()``,
+daemon-state clearing, path-context engine cleanup — was skipped, and
+``_shutting_down`` stayed set so retries early-exited. Persistent leak.
+
+The shutdown code now wraps aclose in try/except/finally so sync close and
+state clearing always run.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon
+
+
+@pytest.mark.asyncio
+async def test_shutdown_completes_when_record_store_aclose_raises():
+    daemon = SearchDaemon(
+        DaemonConfig(
+            database_url=None,
+            txtai_model=None,
+            vector_warmup_enabled=False,
+            refresh_enabled=False,
+            scope_refresh_seconds=0,
+        )
+    )
+
+    # Mark daemon as initialized so shutdown's early-exit guard does not skip.
+    daemon._initialized = True
+    daemon._owns_engine = True
+
+    # Stub record store: aclose raises, but close() must still run.
+    aclose_called = False
+    close_called = False
+
+    class FailingStore:
+        async def aclose(self) -> None:
+            nonlocal aclose_called
+            aclose_called = True
+            raise RuntimeError("simulated cross-loop dispose failure")
+
+        def close(self) -> None:
+            nonlocal close_called
+            close_called = True
+
+    daemon._record_store = FailingStore()
+    daemon._async_engine = MagicMock()
+    daemon._async_session: Any = MagicMock()
+
+    # Must not raise.
+    await daemon.shutdown()
+
+    # All teardown steps must have run despite aclose failure.
+    assert aclose_called
+    assert close_called
+    assert daemon._record_store is None
+    assert daemon._async_engine is None
+    assert daemon._async_session is None
+    assert daemon._initialized is False

--- a/tests/unit/core/test_nexus_fs_adispose.py
+++ b/tests/unit/core/test_nexus_fs_adispose.py
@@ -20,8 +20,14 @@ def _make_stub_nexus_fs(record_store):
 
 
 @pytest.mark.asyncio
-async def test_adispose_clears_record_store_on_success():
-    """Successful aclose clears self._record_store so close() skips it."""
+async def test_adispose_keeps_record_store_attached_on_success():
+    """Issue #3775: adispose disposes only async engines; the store stays attached.
+
+    ``NexusFS.close()`` runs close-callbacks (e.g. write-observer
+    ``flush_sync``) that use the sync ``session_factory``. If the record
+    store were detached or its sync engine disposed here, those callbacks
+    would either fail or reopen a fresh pool that nothing later disposes.
+    """
     rs = MagicMock()
     rs.aclose = AsyncMock()
     nx = _make_stub_nexus_fs(rs)
@@ -29,52 +35,36 @@ async def test_adispose_clears_record_store_on_success():
     await nx.adispose_async_engines()
 
     rs.aclose.assert_awaited_once()
-    assert nx._record_store is None
+    # Store must remain attached so close() runs sync dispose AFTER callbacks.
+    assert nx._record_store is rs
+    # Sync close() must NOT have run here.
+    rs.close.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_adispose_preserves_record_store_on_aclose_failure():
-    """Issue #3775: aclose failure must NOT orphan the record store.
-
-    Previously a failure was caught at debug level and ``self._record_store``
-    was set to ``None`` regardless. That hid disposal failures and made the
-    sync ``close()`` skip the store entirely, leaking both async and sync
-    resources with no recovery handle.
-    """
+async def test_adispose_keeps_record_store_attached_on_aclose_failure():
+    """aclose failure must not orphan the store; close() will attempt fallback."""
     rs = MagicMock()
     rs.aclose = AsyncMock(side_effect=RuntimeError("simulated dispose failure"))
     nx = _make_stub_nexus_fs(rs)
 
     await nx.adispose_async_engines()  # must not raise
 
-    # Store must remain attached — caller (NexusFS.close) needs the handle
-    # to attempt sync teardown and surface the failure.
     assert nx._record_store is rs
     rs.aclose.assert_awaited_once()
+    rs.close.assert_not_called()
 
 
 @pytest.mark.asyncio
-async def test_adispose_falls_back_to_sync_close_when_aclose_missing():
-    """Legacy stores without aclose() get sync close on success."""
+async def test_adispose_noop_for_legacy_store_without_aclose():
+    """Legacy stores without aclose() are left to close() entirely."""
     rs = MagicMock(spec=["close"])
     rs.close = MagicMock()
     nx = _make_stub_nexus_fs(rs)
 
-    await nx.adispose_async_engines()
-
-    rs.close.assert_called_once()
-    assert nx._record_store is None
-
-
-@pytest.mark.asyncio
-async def test_adispose_preserves_record_store_when_legacy_close_fails():
-    """Legacy fallback failure also preserves the store for recovery."""
-    rs = MagicMock(spec=["close"])
-    rs.close = MagicMock(side_effect=RuntimeError("simulated close failure"))
-    nx = _make_stub_nexus_fs(rs)
-
     await nx.adispose_async_engines()  # must not raise
 
+    rs.close.assert_not_called()  # close() runs later in NexusFS.close
     assert nx._record_store is rs
 
 

--- a/tests/unit/core/test_nexus_fs_adispose.py
+++ b/tests/unit/core/test_nexus_fs_adispose.py
@@ -1,0 +1,85 @@
+"""Tests for NexusFS.adispose_async_engines (Issue #3775).
+
+Covers ownership semantics: on success the record store is cleared; on
+failure the store remains attached so a sync close fallback can run and the
+caller can recover, rather than orphaning a live async pool.
+"""
+
+from unittest.mock import AsyncMock, MagicMock
+
+import pytest
+
+from nexus.core.nexus_fs import NexusFS
+
+
+def _make_stub_nexus_fs(record_store):
+    """Build a minimal NexusFS shell wired only with what adispose touches."""
+    nx = NexusFS.__new__(NexusFS)
+    nx._record_store = record_store
+    return nx
+
+
+@pytest.mark.asyncio
+async def test_adispose_clears_record_store_on_success():
+    """Successful aclose clears self._record_store so close() skips it."""
+    rs = MagicMock()
+    rs.aclose = AsyncMock()
+    nx = _make_stub_nexus_fs(rs)
+
+    await nx.adispose_async_engines()
+
+    rs.aclose.assert_awaited_once()
+    assert nx._record_store is None
+
+
+@pytest.mark.asyncio
+async def test_adispose_preserves_record_store_on_aclose_failure():
+    """Issue #3775: aclose failure must NOT orphan the record store.
+
+    Previously a failure was caught at debug level and ``self._record_store``
+    was set to ``None`` regardless. That hid disposal failures and made the
+    sync ``close()`` skip the store entirely, leaking both async and sync
+    resources with no recovery handle.
+    """
+    rs = MagicMock()
+    rs.aclose = AsyncMock(side_effect=RuntimeError("simulated dispose failure"))
+    nx = _make_stub_nexus_fs(rs)
+
+    await nx.adispose_async_engines()  # must not raise
+
+    # Store must remain attached — caller (NexusFS.close) needs the handle
+    # to attempt sync teardown and surface the failure.
+    assert nx._record_store is rs
+    rs.aclose.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_adispose_falls_back_to_sync_close_when_aclose_missing():
+    """Legacy stores without aclose() get sync close on success."""
+    rs = MagicMock(spec=["close"])
+    rs.close = MagicMock()
+    nx = _make_stub_nexus_fs(rs)
+
+    await nx.adispose_async_engines()
+
+    rs.close.assert_called_once()
+    assert nx._record_store is None
+
+
+@pytest.mark.asyncio
+async def test_adispose_preserves_record_store_when_legacy_close_fails():
+    """Legacy fallback failure also preserves the store for recovery."""
+    rs = MagicMock(spec=["close"])
+    rs.close = MagicMock(side_effect=RuntimeError("simulated close failure"))
+    nx = _make_stub_nexus_fs(rs)
+
+    await nx.adispose_async_engines()  # must not raise
+
+    assert nx._record_store is rs
+
+
+@pytest.mark.asyncio
+async def test_adispose_noop_when_record_store_absent():
+    nx = _make_stub_nexus_fs(None)
+    await nx.adispose_async_engines()  # must not raise
+    assert nx._record_store is None

--- a/tests/unit/server/test_rpc_parity.py
+++ b/tests/unit/server/test_rpc_parity.py
@@ -224,6 +224,7 @@ def test_all_public_methods_are_exposed_or_excluded():
         "notify",  # Internal - OBSERVE dispatch
         "has_hooks",  # Internal - hook existence check
         "shutdown",  # Internal - background task drain
+        "adispose_async_engines",  # Internal - lifespan async DB engine dispose (Issue #3775)
         # ABC compliance stubs (Issue #2033 LEGO decomposition)
         # These delegate to extracted services which already have @rpc_expose.
         # NexusFS defines them only to satisfy NexusFS ABC requirements.

--- a/tests/unit/storage/test_record_store.py
+++ b/tests/unit/storage/test_record_store.py
@@ -351,15 +351,8 @@ class TestRecordStoreAsyncSessionFactory:
 class TestRecordStoreLifecycle:
     """Tests for store lifecycle management."""
 
-    def test_close_drops_async_refs_without_dispose(self):
-        """close() drops async engine refs but does NOT dispose them (Issue #3775).
-
-        Disposing async engines from sync ``close()`` is unsafe — it
-        greenlet-awaits asyncpg cleanup on whatever loop is running, which
-        produces cross-loop futures when ``close()`` runs in a worker thread.
-        ``close()`` must drop refs only; callers that own the async engine
-        must use ``aclose()`` from the engine's origin loop.
-        """
+    def test_close_disposes_async_engine_when_safe(self):
+        """close() best-effort disposes async engine and nulls ref on success."""
         from nexus.storage.record_store import SQLAlchemyRecordStore
 
         store = SQLAlchemyRecordStore(create_tables=False)
@@ -367,8 +360,36 @@ class TestRecordStoreLifecycle:
         assert store._async_engine is not None
 
         store.close()
+        # SQLite + aiosqlite with no live loop: sync dispose succeeds, ref nulled.
         assert store._async_engine is None
         assert store._async_session_factory_instance is None
+
+    def test_close_preserves_ref_on_dispose_failure(self):
+        """Issue #3775: a failed sync dispose must NOT null the async engine ref.
+
+        Regression: previously ``close()`` nulled refs unconditionally, losing
+        the only handle to a live async pool. Callers can then never recover
+        via ``aclose()``. With preserved refs, the caller can retry.
+        """
+        from nexus.storage.record_store import SQLAlchemyRecordStore
+
+        store = SQLAlchemyRecordStore(create_tables=False)
+        _ = store.async_session_factory
+        assert store._async_engine is not None
+
+        # Force sync dispose to fail.
+        original_engine = store._async_engine
+        original_factory = store._async_session_factory_instance
+
+        def _boom():
+            raise RuntimeError("simulated cross-loop dispose failure")
+
+        with patch.object(original_engine.sync_engine, "dispose", side_effect=_boom):
+            store.close()  # Must not raise
+
+        # Ref must remain — caller needs to recover via aclose().
+        assert store._async_engine is original_engine
+        assert store._async_session_factory_instance is original_factory
 
     def test_close_without_async_engine(self):
         """close() works even when async engine was never initialized."""

--- a/tests/unit/storage/test_record_store.py
+++ b/tests/unit/storage/test_record_store.py
@@ -351,17 +351,22 @@ class TestRecordStoreAsyncSessionFactory:
 class TestRecordStoreLifecycle:
     """Tests for store lifecycle management."""
 
-    def test_close_disposes_both_engines(self):
-        """close() disposes sync engine and async engine (if initialized)."""
+    def test_close_drops_async_refs_without_dispose(self):
+        """close() drops async engine refs but does NOT dispose them (Issue #3775).
+
+        Disposing async engines from sync ``close()`` is unsafe — it
+        greenlet-awaits asyncpg cleanup on whatever loop is running, which
+        produces cross-loop futures when ``close()`` runs in a worker thread.
+        ``close()`` must drop refs only; callers that own the async engine
+        must use ``aclose()`` from the engine's origin loop.
+        """
         from nexus.storage.record_store import SQLAlchemyRecordStore
 
         store = SQLAlchemyRecordStore(create_tables=False)
-        # Access async factory to initialize async engine
         _ = store.async_session_factory
         assert store._async_engine is not None
 
         store.close()
-        # After close, async engine should be cleaned up
         assert store._async_engine is None
         assert store._async_session_factory_instance is None
 
@@ -372,6 +377,35 @@ class TestRecordStoreLifecycle:
         store = SQLAlchemyRecordStore(create_tables=False)
         assert store._async_engine is None
         store.close()  # Should not raise
+
+    @pytest.mark.asyncio
+    async def test_aclose_disposes_async_engine_on_origin_loop(self):
+        """aclose() disposes async engine on the current loop (Issue #3775).
+
+        Regression: previously ``close()`` invoked
+        ``_async_engine.sync_engine.dispose()`` which await-only'd onto a
+        possibly-different loop, producing
+        ``RuntimeError: Future attached to a different loop`` on shutdown.
+        """
+        from nexus.storage.record_store import SQLAlchemyRecordStore
+
+        store = SQLAlchemyRecordStore(create_tables=False)
+        # Force async engine creation on this loop.
+        _ = store.async_session_factory
+        assert store._async_engine is not None
+
+        await store.aclose()
+        assert store._async_engine is None
+        assert store._async_session_factory_instance is None
+
+    @pytest.mark.asyncio
+    async def test_aclose_without_async_engine(self):
+        """aclose() is safe when async engine was never initialized."""
+        from nexus.storage.record_store import SQLAlchemyRecordStore
+
+        store = SQLAlchemyRecordStore(create_tables=False)
+        assert store._async_engine is None
+        await store.aclose()  # Should not raise
 
 
 class TestReadReplicaConfiguration:

--- a/tests/unit/storage/test_record_store.py
+++ b/tests/unit/storage/test_record_store.py
@@ -428,21 +428,27 @@ class TestRecordStoreLifecycle:
 
     @pytest.mark.asyncio
     async def test_async_session_factory_raises_after_aclose(self):
-        """Property must raise after aclose so callers cannot rebuild a pool.
+        """Property must raise after aclose even on the cache-hit path (Issue #3775).
 
         SQLAlchemy ``Engine.dispose()`` does not render an engine unusable —
-        the next checkout silently builds a fresh pool. Without this guard,
-        a stale consumer holding ``record_store.async_session_factory``
-        would create connections nothing later disposes (Issue #3775).
+        the next checkout silently builds a fresh pool. The cached
+        ``async_sessionmaker`` references the engine; if the property
+        returned it post-aclose, a stale consumer could create connections
+        nothing later disposes. The sentinel must fire on both
+        cold (cache empty) and warm (cache populated) accesses.
         """
         from nexus.storage.record_store import SQLAlchemyRecordStore
 
         store = SQLAlchemyRecordStore(create_tables=False)
-        _ = store.async_session_factory  # warm
+        _ = store.async_session_factory  # warm — cached factory present
+        assert store._async_session_factory_instance is not None
         await store.aclose()
 
-        # The cached factory ref still exists, but fresh property access raises.
-        # First clear the cache to simulate a consumer that lost its handle.
+        # Warm cache present — sentinel must still fire.
+        with pytest.raises(RuntimeError, match="after aclose"):
+            _ = store.async_session_factory
+
+        # Cold cache (consumer cleared its handle) — must also fire.
         store._async_session_factory_instance = None
         with pytest.raises(RuntimeError, match="after aclose"):
             _ = store.async_session_factory

--- a/tests/unit/storage/test_record_store.py
+++ b/tests/unit/storage/test_record_store.py
@@ -420,6 +420,34 @@ class TestRecordStoreLifecycle:
         assert store._async_session_factory_instance is None
 
     @pytest.mark.asyncio
+    async def test_aclose_leaves_sync_engine_usable(self):
+        """Issue #3775 ordering: aclose must not dispose the sync engine.
+
+        ``NexusFS`` close-callbacks (write-observer ``flush_sync``, etc.)
+        run after ``adispose_async_engines()`` and use the sync
+        ``session_factory`` to flush pending DB writes. If ``aclose`` also
+        disposed the sync engine, those callbacks would fail or silently
+        reopen a fresh pool that nothing later disposes.
+        """
+        from nexus.storage.record_store import SQLAlchemyRecordStore
+
+        store = SQLAlchemyRecordStore(create_tables=False)
+        _ = store.async_session_factory  # force async engine creation
+        assert store._async_engine is not None
+
+        await store.aclose()
+
+        # Sync engine + session factory still usable after aclose.
+        assert store._engine is not None
+        with store.session_factory() as sess:
+            from sqlalchemy import text
+
+            assert sess.execute(text("SELECT 1")).scalar() == 1
+
+        # Final sync close disposes the sync engine.
+        store.close()
+
+    @pytest.mark.asyncio
     async def test_aclose_without_async_engine(self):
         """aclose() is safe when async engine was never initialized."""
         from nexus.storage.record_store import SQLAlchemyRecordStore

--- a/tests/unit/storage/test_record_store.py
+++ b/tests/unit/storage/test_record_store.py
@@ -407,7 +407,13 @@ class TestRecordStoreLifecycle:
         ``_async_engine.sync_engine.dispose()`` which await-only'd onto a
         possibly-different loop, producing
         ``RuntimeError: Future attached to a different loop`` on shutdown.
+
+        The engine reference is retained (not nulled) so a subsequent
+        ``close()`` can re-dispose any pool that consumers with a cached
+        ``async_sessionmaker`` reopened between aclose and close.
         """
+        from sqlalchemy.ext.asyncio import AsyncEngine
+
         from nexus.storage.record_store import SQLAlchemyRecordStore
 
         store = SQLAlchemyRecordStore(create_tables=False)
@@ -416,8 +422,30 @@ class TestRecordStoreLifecycle:
         assert store._async_engine is not None
 
         await store.aclose()
-        assert store._async_engine is None
-        assert store._async_session_factory_instance is None
+        # Sentinel is set; engine ref retained for re-dispose in close().
+        assert store._async_closed is True
+        assert isinstance(store._async_engine, AsyncEngine)
+
+    @pytest.mark.asyncio
+    async def test_async_session_factory_raises_after_aclose(self):
+        """Property must raise after aclose so callers cannot rebuild a pool.
+
+        SQLAlchemy ``Engine.dispose()`` does not render an engine unusable —
+        the next checkout silently builds a fresh pool. Without this guard,
+        a stale consumer holding ``record_store.async_session_factory``
+        would create connections nothing later disposes (Issue #3775).
+        """
+        from nexus.storage.record_store import SQLAlchemyRecordStore
+
+        store = SQLAlchemyRecordStore(create_tables=False)
+        _ = store.async_session_factory  # warm
+        await store.aclose()
+
+        # The cached factory ref still exists, but fresh property access raises.
+        # First clear the cache to simulate a consumer that lost its handle.
+        store._async_session_factory_instance = None
+        with pytest.raises(RuntimeError, match="after aclose"):
+            _ = store.async_session_factory
 
     @pytest.mark.asyncio
     async def test_aclose_leaves_sync_engine_usable(self):


### PR DESCRIPTION
## Summary

Fixes #3775. `SQLAlchemyRecordStore.close()` invoked `_async_engine.sync_engine.dispose()`, which greenlet-awaits asyncpg `_terminate_graceful_close` on whatever loop is running. When close ran on a worker thread (FastAPI lifespan dispatches `NexusFS.aclose` via `run_in_executor`) or any loop other than the one that created the asyncpg pool, the cross-loop await produced `RuntimeError: Future attached to a different loop` and orphan futures surfaced as `asyncpg.InternalClientError: unknown protocol state` — ~2 errors per server startup, flagged `should_alert=True`.

## Changes

- `record_store.close()` drops async engine refs without dispose (sync dispose is unsafe across loops/threads).
- `record_store.aclose()` (new) awaits `engine.dispose()` on the current loop. Sync engines disposed too.
- `NexusFS.adispose_async_engines()` (new) runs on the lifespan loop and disposes the record store's async engines before sync teardown is dispatched to a worker thread. `aclose()` itself stays sync because `kernel.service_stop_all` uses `asyncio.run()` and cannot run on an active loop.
- FastAPI lifespan calls `await nexus_fs.adispose_async_engines()` before `run_in_executor(nexus_fs.aclose)`.
- `SearchDaemon.shutdown` awaits `record_store.aclose()` (daemon owns the loop the async pool was created on).
- Regression tests for both `close()` (no async dispose) and `aclose()` (async dispose succeeds).

## Test plan

- [x] `tests/unit/storage/test_record_store.py` — 46 pass (+2 new regression tests)
- [x] `tests/unit/bricks/search/` daemon tests — 31 pass
- [x] `tests/unit/server/lifespan/` — 51 pass
- [x] Broader `tests/unit/storage/` — 545 pass (1 unrelated pre-existing fail: stale PyKernel binary)
- [ ] Validate startup logs are clean on `nexus up` (requires running stack)

## Untouched callers

Sync `close()` callers (`token_manager.close`, `async_bridge.stop`, CLI/tests) only access sync engines, so the new no-op-on-async-refs behavior is safe — `_async_engine` is `None` in those paths.