### PR TITLE
fix(search): startup reconciliation for unindexed files (#4016)

### DIFF
--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -2340,6 +2340,10 @@ class SearchDaemon:
             "txtai": self._consume_txtai_mutations,
         }
         self._consumer_names = tuple(consumer_specs.keys())
+        # #4016: reconcile pre-existing unindexed files BEFORE consumers
+        # snap their checkpoints to MAX(sequence_number). Skipped on warm
+        # restarts (any consumer already has a persisted checkpoint).
+        await self._reconcile_unindexed_paths_at_startup()
         for consumer_name in self._consumer_names:
             if consumer_name not in self._consumer_last_sequence:
                 self._consumer_last_sequence[
@@ -2725,6 +2729,97 @@ class SearchDaemon:
                 max_sequence = int(row[0]) if row and row[0] is not None else 0
         await self._save_consumer_checkpoint(consumer_name, max_sequence)
         return max_sequence
+
+    async def _reconcile_unindexed_paths_at_startup(self) -> None:
+        """Index live files that pre-date the daemon's first start (#4016).
+
+        On first start, ``_initialize_consumer_checkpoint`` skips past every
+        historical write by capturing ``MAX(operation_log.sequence_number)``.
+        Files written before the daemon ever ran have no ``document_chunks``
+        row — without this method, they'd stay unindexed until something
+        else touches them (a manual ``semantic_search_index`` call, a fresh
+        write to the same path, or a mount-content scan).
+
+        Skipped on warm starts: if ANY consumer has a persisted checkpoint,
+        historical writes have already been processed (or explicitly
+        skipped) and re-running reconciliation would duplicate work.
+
+        Replay-from-zero is intentionally rejected — the issue (#4016) calls
+        out the rename/delete churn and historical-replay cost. Synthesizing
+        events from current ``file_paths`` state stays bounded by live data.
+        """
+        if self._async_session is None or not self._consumer_names:
+            return
+
+        for name in self._consumer_names:
+            if await self._read_persisted_checkpoint(name) is not None:
+                return
+
+        events = await self._fetch_unindexed_path_events()
+        if not events:
+            return
+
+        logger.info(
+            "Search startup reconciliation: replaying %d unindexed live file(s).",
+            len(events),
+        )
+
+        handlers = (
+            self._consume_bm25_mutations,
+            self._consume_fts_mutations,
+            self._consume_embedding_mutations,
+            self._consume_txtai_mutations,
+        )
+        for handler in handlers:
+            try:
+                await handler(events)
+            except Exception as exc:
+                logger.warning(
+                    "Startup reconciliation handler %s failed: %s",
+                    handler.__name__,
+                    exc,
+                )
+
+    async def _fetch_unindexed_path_events(self) -> list[SearchMutationEvent]:
+        """Synthesize UPSERT events for live ``file_paths`` rows missing/stale chunks."""
+        if self._async_session is None:
+            return []
+
+        async with self._async_session() as session:
+            result = await session.execute(
+                sa_text(
+                    "SELECT zone_id, virtual_path, path_id "
+                    "FROM file_paths "
+                    "WHERE deleted_at IS NULL "
+                    "AND (indexed_content_id IS NULL "
+                    "OR indexed_content_id != content_id)"
+                )
+            )
+            rows = result.fetchall()
+
+        events: list[SearchMutationEvent] = []
+        now = datetime.now(UTC).replace(tzinfo=None)
+        for row in rows:
+            zone_id = str(row[0])
+            virtual_path = str(row[1])
+            path_id = str(row[2])
+            scoped_path = (
+                virtual_path
+                if virtual_path.startswith("/zone/")
+                else f"/zone/{zone_id}{virtual_path}"
+            )
+            events.append(
+                SearchMutationEvent(
+                    event_id=f"reconcile:{path_id}",
+                    operation_id=f"reconcile:{path_id}",
+                    op=SearchMutationOp.UPSERT,
+                    path=scoped_path,
+                    zone_id=zone_id,
+                    timestamp=now,
+                    sequence_number=0,
+                )
+            )
+        return events
 
     async def _save_consumer_checkpoint(self, consumer_name: str, sequence_number: int) -> None:
         self._consumer_last_sequence[consumer_name] = sequence_number

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -2813,6 +2813,18 @@ class SearchDaemon:
                 continue
             if await self._reconciliation_completed(name):
                 continue
+            # Codex round-2: gate marker on the consumer's backend being
+            # live. If the backend hasn't initialized yet (transient
+            # startup failure), the handler would early-return without
+            # work — marking it reconciled would permanently close the
+            # recovery path on next restart.
+            if not self._consumer_backend_ready(name):
+                logger.info(
+                    "Startup reconciliation: backend for %s not ready, "
+                    "deferring — marker will not be set",
+                    name,
+                )
+                continue
             pending.append((name, handler))
 
         if not pending:
@@ -2847,6 +2859,24 @@ class SearchDaemon:
                 )
                 continue
             await self._mark_reconciliation_completed(name)
+
+    def _consumer_backend_ready(self, consumer_name: str) -> bool:
+        """Whether ``consumer_name``'s backend is live enough to do real work.
+
+        Mirrors the early-return guards in each ``_consume_*_mutations``
+        handler. Needed by ``_reconcile_unindexed_paths_at_startup`` so
+        we don't write a reconciliation marker for a consumer whose
+        handler would silently no-op (Codex round-2).
+        """
+        if consumer_name == "bm25":
+            return self._bm25s_index is not None
+        if consumer_name == "fts":
+            return self._chunk_store is not None
+        if consumer_name == "embedding":
+            return self._indexing_pipeline is not None and self._embedding_provider is not None
+        if consumer_name == "txtai":
+            return self._backend is not None
+        return False
 
     async def _fetch_unindexed_path_events(self) -> list[SearchMutationEvent]:
         """Synthesize UPSERT events for live ``file_paths`` rows missing/stale chunks."""

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -2730,8 +2730,49 @@ class SearchDaemon:
         await self._save_consumer_checkpoint(consumer_name, max_sequence)
         return max_sequence
 
+    def _reconciliation_marker_key(self, consumer_name: str) -> str:
+        """Distinct namespace from ``_checkpoint_key`` so a snapped checkpoint
+        on its own does NOT imply reconciliation has run (Codex round-1)."""
+        return f"search_mutation_reconciled_v1:{consumer_name}"
+
+    async def _reconciliation_completed(self, consumer_name: str) -> bool:
+        if self._settings_store is not None:
+            try:
+                setting = self._settings_store.get_setting(
+                    self._reconciliation_marker_key(consumer_name)
+                )
+                if setting is not None:
+                    return True
+            except Exception as exc:
+                logger.warning(
+                    "Reconciliation marker read falling back to file storage: %s",
+                    exc,
+                )
+        async with self._checkpoint_lock:
+            checkpoints = await self._load_checkpoint_file()
+        return self._reconciliation_marker_key(consumer_name) in checkpoints
+
+    async def _mark_reconciliation_completed(self, consumer_name: str) -> None:
+        if self._settings_store is not None:
+            try:
+                self._settings_store.set_setting(
+                    self._reconciliation_marker_key(consumer_name),
+                    "1",
+                    description=f"Search reconciliation completed for {consumer_name}",
+                )
+                return
+            except Exception as exc:
+                logger.warning(
+                    "Reconciliation marker write falling back to file storage: %s",
+                    exc,
+                )
+        async with self._checkpoint_lock:
+            checkpoints = await self._load_checkpoint_file()
+            checkpoints[self._reconciliation_marker_key(consumer_name)] = 1
+            await self._write_checkpoint_file(checkpoints)
+
     async def _reconcile_unindexed_paths_at_startup(self) -> None:
-        """Index live files that pre-date the daemon's first start (#4016).
+        """Index live files that pre-date the daemon's first reconciliation (#4016).
 
         On first start, ``_initialize_consumer_checkpoint`` skips past every
         historical write by capturing ``MAX(operation_log.sequence_number)``.
@@ -2740,9 +2781,17 @@ class SearchDaemon:
         else touches them (a manual ``semantic_search_index`` call, a fresh
         write to the same path, or a mount-content scan).
 
-        Skipped on warm starts: if ANY consumer has a persisted checkpoint,
-        historical writes have already been processed (or explicitly
-        skipped) and re-running reconciliation would duplicate work.
+        Idempotent and per-consumer (Codex round-1):
+        - Each consumer carries a ``search_mutation_reconciled_v1:<name>``
+          marker, separate from its mutation checkpoint. Reconciliation
+          runs whenever any consumer is missing the marker — even if its
+          mutation checkpoint has already snapped to MAX. This is critical
+          for the upgrade path: deployments running a prior version
+          already have checkpoints from the buggy MAX-snap, but no marker,
+          so they STILL recover their unindexed live files on the first
+          start with this fix.
+        - A handler that raises does NOT set its marker. The next daemon
+          start retries the same set of unindexed paths for that consumer.
 
         Replay-from-zero is intentionally rejected — the issue (#4016) calls
         out the rename/delete churn and historical-replay cost. Synthesizing
@@ -2751,34 +2800,53 @@ class SearchDaemon:
         if self._async_session is None or not self._consumer_names:
             return
 
+        handlers_by_name: dict[str, Any] = {
+            "bm25": self._consume_bm25_mutations,
+            "fts": self._consume_fts_mutations,
+            "embedding": self._consume_embedding_mutations,
+            "txtai": self._consume_txtai_mutations,
+        }
+        pending: list[tuple[str, Any]] = []
         for name in self._consumer_names:
-            if await self._read_persisted_checkpoint(name) is not None:
-                return
+            handler = handlers_by_name.get(name)
+            if handler is None:
+                continue
+            if await self._reconciliation_completed(name):
+                continue
+            pending.append((name, handler))
+
+        if not pending:
+            return
 
         events = await self._fetch_unindexed_path_events()
         if not events:
+            # No unindexed live files — nothing to recover. Mark all
+            # pending consumers reconciled so we don't re-scan on every
+            # warm start.
+            for name, _ in pending:
+                await self._mark_reconciliation_completed(name)
             return
 
         logger.info(
-            "Search startup reconciliation: replaying %d unindexed live file(s).",
+            "Search startup reconciliation: replaying %d unindexed live "
+            "file(s) for %d consumer(s) (%s).",
             len(events),
+            len(pending),
+            ",".join(name for name, _ in pending),
         )
 
-        handlers = (
-            self._consume_bm25_mutations,
-            self._consume_fts_mutations,
-            self._consume_embedding_mutations,
-            self._consume_txtai_mutations,
-        )
-        for handler in handlers:
+        for name, handler in pending:
             try:
                 await handler(events)
             except Exception as exc:
                 logger.warning(
-                    "Startup reconciliation handler %s failed: %s",
-                    handler.__name__,
+                    "Startup reconciliation handler %s failed: %s — "
+                    "marker not set, will retry on next daemon start",
+                    name,
                     exc,
                 )
+                continue
+            await self._mark_reconciliation_completed(name)
 
     async def _fetch_unindexed_path_events(self) -> list[SearchMutationEvent]:
         """Synthesize UPSERT events for live ``file_paths`` rows missing/stale chunks."""

--- a/tests/integration/bricks/search/test_search_mutation_flow.py
+++ b/tests/integration/bricks/search/test_search_mutation_flow.py
@@ -434,13 +434,40 @@ async def test_refresh_indexes_strips_null_bytes_before_txtai_upsert() -> None:
 # ─── Issue #4016: startup reconciliation ──────────────────────────────
 
 
+def _set_all_reconciled(settings_store: _SettingsStore, names: tuple[str, ...]) -> None:
+    for name in names:
+        settings_store.set_setting(f"search_mutation_reconciled_v1:{name}", "1")
+
+
+def _make_session_factory(rows: list[tuple[str, str, str]]):
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a):
+            return False
+
+        async def execute(self, _stmt):
+            class _Result:
+                @staticmethod
+                def fetchall():
+                    return list(rows)
+
+            return _Result()
+
+    def _factory():
+        return _FakeSession()
+
+    return _factory
+
+
 @pytest.mark.asyncio
-async def test_reconcile_unindexed_paths_skips_when_warm_start() -> None:
-    """If any consumer has a persisted checkpoint, do not run reconciliation."""
+async def test_reconcile_unindexed_paths_skips_when_all_markers_set() -> None:
+    """All consumers reconciled → reconciliation is a no-op."""
     settings_store = _SettingsStore()
-    settings_store.set_setting("search_mutation_checkpoint:bm25", "42")
     daemon = SearchDaemon(settings_store=settings_store)
     daemon._consumer_names = ("bm25", "fts", "embedding", "txtai")
+    _set_all_reconciled(settings_store, daemon._consumer_names)
     daemon._async_session = AsyncMock()  # would crash if SQL ran
     daemon._consume_bm25_mutations = AsyncMock()
     daemon._consume_fts_mutations = AsyncMock()
@@ -458,29 +485,12 @@ async def test_reconcile_unindexed_paths_skips_when_warm_start() -> None:
 @pytest.mark.asyncio
 async def test_reconcile_unindexed_paths_runs_handlers_with_synthesized_events() -> None:
     """Cold start with unindexed file_paths rows → all four handlers see events."""
-    daemon = SearchDaemon()
+    settings_store = _SettingsStore()
+    daemon = SearchDaemon(settings_store=settings_store)
     daemon._consumer_names = ("bm25", "fts", "embedding", "txtai")
-
-    class _FakeSession:
-        async def __aenter__(self):
-            return self
-
-        async def __aexit__(self, *_a):
-            return False
-
-        async def execute(self, _stmt):
-            class _Result:
-                @staticmethod
-                def fetchall():
-                    return [("root", "/foo.md", "pid-1"), ("zone-b", "/bar.md", "pid-2")]
-
-            return _Result()
-
-    def _fake_session_factory():
-        return _FakeSession()
-
-    daemon._async_session = _fake_session_factory
-    daemon._read_persisted_checkpoint = AsyncMock(return_value=None)
+    daemon._async_session = _make_session_factory(
+        [("root", "/foo.md", "pid-1"), ("zone-b", "/bar.md", "pid-2")]
+    )
     daemon._consume_bm25_mutations = AsyncMock()
     daemon._consume_fts_mutations = AsyncMock()
     daemon._consume_embedding_mutations = AsyncMock()
@@ -501,6 +511,76 @@ async def test_reconcile_unindexed_paths_runs_handlers_with_synthesized_events()
         assert events_arg[0].path == "/zone/root/foo.md"
         assert events_arg[0].operation_id == "reconcile:pid-1"
         assert events_arg[1].path == "/zone/zone-b/bar.md"
+    # Markers persisted for all consumers after success.
+    for name in daemon._consumer_names:
+        assert settings_store.get_setting(f"search_mutation_reconciled_v1:{name}") is not None
+
+
+@pytest.mark.asyncio
+async def test_reconcile_runs_when_marker_unset_even_with_existing_checkpoint() -> None:
+    """Codex round-1 finding 1: upgrade path — a checkpoint without a
+    reconciliation marker still triggers reconciliation, so deployments
+    running the prior buggy version recover their unindexed live files."""
+    settings_store = _SettingsStore()
+    # Old daemon left a checkpoint behind (the bug) but no marker.
+    for name in ("bm25", "fts", "embedding", "txtai"):
+        settings_store.set_setting(f"search_mutation_checkpoint:{name}", "9999")
+
+    daemon = SearchDaemon(settings_store=settings_store)
+    daemon._consumer_names = ("bm25", "fts", "embedding", "txtai")
+    daemon._async_session = _make_session_factory([("root", "/foo.md", "pid-1")])
+    daemon._consume_bm25_mutations = AsyncMock()
+    daemon._consume_fts_mutations = AsyncMock()
+    daemon._consume_embedding_mutations = AsyncMock()
+    daemon._consume_txtai_mutations = AsyncMock()
+
+    await daemon._reconcile_unindexed_paths_at_startup()
+
+    daemon._consume_bm25_mutations.assert_awaited_once()
+    daemon._consume_fts_mutations.assert_awaited_once()
+    daemon._consume_embedding_mutations.assert_awaited_once()
+    daemon._consume_txtai_mutations.assert_awaited_once()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_skips_marker_when_handler_fails() -> None:
+    """Codex round-1 finding 2: a failing handler must NOT set its marker;
+    other handlers proceed independently and DO set theirs."""
+    settings_store = _SettingsStore()
+    daemon = SearchDaemon(settings_store=settings_store)
+    daemon._consumer_names = ("bm25", "fts", "embedding", "txtai")
+    daemon._async_session = _make_session_factory([("root", "/foo.md", "pid-1")])
+    daemon._consume_bm25_mutations = AsyncMock(side_effect=RuntimeError("bm25 down"))
+    daemon._consume_fts_mutations = AsyncMock()
+    daemon._consume_embedding_mutations = AsyncMock()
+    daemon._consume_txtai_mutations = AsyncMock()
+
+    await daemon._reconcile_unindexed_paths_at_startup()
+
+    # Failing handler: marker NOT set → next start retries.
+    assert settings_store.get_setting("search_mutation_reconciled_v1:bm25") is None
+    # Other handlers all ran and set their markers.
+    for name in ("fts", "embedding", "txtai"):
+        assert settings_store.get_setting(f"search_mutation_reconciled_v1:{name}") is not None
+
+
+@pytest.mark.asyncio
+async def test_reconcile_marks_consumers_when_no_unindexed_rows() -> None:
+    """Empty result set still records markers, so warm starts skip the SQL scan."""
+    settings_store = _SettingsStore()
+    daemon = SearchDaemon(settings_store=settings_store)
+    daemon._consumer_names = ("bm25", "fts", "embedding", "txtai")
+    daemon._async_session = _make_session_factory([])
+    daemon._consume_bm25_mutations = AsyncMock()
+    daemon._consume_fts_mutations = AsyncMock()
+    daemon._consume_embedding_mutations = AsyncMock()
+    daemon._consume_txtai_mutations = AsyncMock()
+
+    await daemon._reconcile_unindexed_paths_at_startup()
+
+    daemon._consume_bm25_mutations.assert_not_awaited()
+    for name in daemon._consumer_names:
+        assert settings_store.get_setting(f"search_mutation_reconciled_v1:{name}") is not None
 
 
 @pytest.mark.asyncio

--- a/tests/integration/bricks/search/test_search_mutation_flow.py
+++ b/tests/integration/bricks/search/test_search_mutation_flow.py
@@ -1,4 +1,5 @@
 import asyncio
+import contextlib
 from datetime import UTC, datetime
 from types import SimpleNamespace
 from typing import Any
@@ -428,3 +429,105 @@ async def test_refresh_indexes_strips_null_bytes_before_txtai_upsert() -> None:
         for doc in docs:
             assert "\x00" not in doc["text"], f"NUL leaked to txtai: {doc['text']!r}"
             assert doc["text"] == "alphabetagamma"
+
+
+# ─── Issue #4016: startup reconciliation ──────────────────────────────
+
+
+@pytest.mark.asyncio
+async def test_reconcile_unindexed_paths_skips_when_warm_start() -> None:
+    """If any consumer has a persisted checkpoint, do not run reconciliation."""
+    settings_store = _SettingsStore()
+    settings_store.set_setting("search_mutation_checkpoint:bm25", "42")
+    daemon = SearchDaemon(settings_store=settings_store)
+    daemon._consumer_names = ("bm25", "fts", "embedding", "txtai")
+    daemon._async_session = AsyncMock()  # would crash if SQL ran
+    daemon._consume_bm25_mutations = AsyncMock()
+    daemon._consume_fts_mutations = AsyncMock()
+    daemon._consume_embedding_mutations = AsyncMock()
+    daemon._consume_txtai_mutations = AsyncMock()
+
+    await daemon._reconcile_unindexed_paths_at_startup()
+
+    daemon._consume_bm25_mutations.assert_not_awaited()
+    daemon._consume_fts_mutations.assert_not_awaited()
+    daemon._consume_embedding_mutations.assert_not_awaited()
+    daemon._consume_txtai_mutations.assert_not_awaited()
+
+
+@pytest.mark.asyncio
+async def test_reconcile_unindexed_paths_runs_handlers_with_synthesized_events() -> None:
+    """Cold start with unindexed file_paths rows → all four handlers see events."""
+    daemon = SearchDaemon()
+    daemon._consumer_names = ("bm25", "fts", "embedding", "txtai")
+
+    class _FakeSession:
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, *_a):
+            return False
+
+        async def execute(self, _stmt):
+            class _Result:
+                @staticmethod
+                def fetchall():
+                    return [("root", "/foo.md", "pid-1"), ("zone-b", "/bar.md", "pid-2")]
+
+            return _Result()
+
+    def _fake_session_factory():
+        return _FakeSession()
+
+    daemon._async_session = _fake_session_factory
+    daemon._read_persisted_checkpoint = AsyncMock(return_value=None)
+    daemon._consume_bm25_mutations = AsyncMock()
+    daemon._consume_fts_mutations = AsyncMock()
+    daemon._consume_embedding_mutations = AsyncMock()
+    daemon._consume_txtai_mutations = AsyncMock()
+
+    await daemon._reconcile_unindexed_paths_at_startup()
+
+    for handler in (
+        daemon._consume_bm25_mutations,
+        daemon._consume_fts_mutations,
+        daemon._consume_embedding_mutations,
+        daemon._consume_txtai_mutations,
+    ):
+        handler.assert_awaited_once()
+        events_arg = handler.await_args.args[0]
+        assert len(events_arg) == 2
+        assert events_arg[0].op == SearchMutationOp.UPSERT
+        assert events_arg[0].path == "/zone/root/foo.md"
+        assert events_arg[0].operation_id == "reconcile:pid-1"
+        assert events_arg[1].path == "/zone/zone-b/bar.md"
+
+
+@pytest.mark.asyncio
+async def test_index_refresh_loop_reconciles_before_initializing_checkpoints() -> None:
+    """`_index_refresh_loop` calls reconciliation BEFORE consumer init."""
+    daemon = SearchDaemon()
+    call_order: list[str] = []
+
+    async def _reconcile():
+        call_order.append("reconcile")
+
+    async def _init_checkpoint(name):
+        call_order.append(f"init:{name}")
+        return 0
+
+    daemon._reconcile_unindexed_paths_at_startup = _reconcile
+    daemon._initialize_consumer_checkpoint = _init_checkpoint
+    daemon._consume_bm25_mutations = AsyncMock()
+    daemon._consume_fts_mutations = AsyncMock()
+    daemon._consume_embedding_mutations = AsyncMock()
+    daemon._consume_txtai_mutations = AsyncMock()
+    # Cancel the gather so the loop exits without driving consumers.
+    daemon._run_mutation_consumer = AsyncMock(side_effect=asyncio.CancelledError())
+
+    with contextlib.suppress(asyncio.CancelledError):
+        await daemon._index_refresh_loop()
+
+    assert call_order, "loop never ran"
+    assert call_order[0] == "reconcile", f"expected reconcile first, got {call_order}"
+    assert all(call.startswith("init:") for call in call_order[1:]), call_order

--- a/tests/integration/bricks/search/test_search_mutation_flow.py
+++ b/tests/integration/bricks/search/test_search_mutation_flow.py
@@ -439,6 +439,20 @@ def _set_all_reconciled(settings_store: _SettingsStore, names: tuple[str, ...]) 
         settings_store.set_setting(f"search_mutation_reconciled_v1:{name}", "1")
 
 
+def _enable_all_backends(daemon: SearchDaemon) -> None:
+    """Make every consumer's backend live so reconciliation pre-checks pass.
+
+    Codex round-2: ``_consumer_backend_ready`` gates marker writes on
+    backend presence. Tests covering the success path need the backends
+    set, otherwise reconciliation skips the consumer and no handler runs.
+    """
+    daemon._bm25s_index = AsyncMock()
+    daemon._chunk_store = AsyncMock()
+    daemon._indexing_pipeline = AsyncMock()
+    daemon._embedding_provider = object()
+    daemon._backend = AsyncMock()
+
+
 def _make_session_factory(rows: list[tuple[str, str, str]]):
     class _FakeSession:
         async def __aenter__(self):
@@ -488,6 +502,7 @@ async def test_reconcile_unindexed_paths_runs_handlers_with_synthesized_events()
     settings_store = _SettingsStore()
     daemon = SearchDaemon(settings_store=settings_store)
     daemon._consumer_names = ("bm25", "fts", "embedding", "txtai")
+    _enable_all_backends(daemon)
     daemon._async_session = _make_session_factory(
         [("root", "/foo.md", "pid-1"), ("zone-b", "/bar.md", "pid-2")]
     )
@@ -528,6 +543,7 @@ async def test_reconcile_runs_when_marker_unset_even_with_existing_checkpoint() 
 
     daemon = SearchDaemon(settings_store=settings_store)
     daemon._consumer_names = ("bm25", "fts", "embedding", "txtai")
+    _enable_all_backends(daemon)
     daemon._async_session = _make_session_factory([("root", "/foo.md", "pid-1")])
     daemon._consume_bm25_mutations = AsyncMock()
     daemon._consume_fts_mutations = AsyncMock()
@@ -549,6 +565,7 @@ async def test_reconcile_skips_marker_when_handler_fails() -> None:
     settings_store = _SettingsStore()
     daemon = SearchDaemon(settings_store=settings_store)
     daemon._consumer_names = ("bm25", "fts", "embedding", "txtai")
+    _enable_all_backends(daemon)
     daemon._async_session = _make_session_factory([("root", "/foo.md", "pid-1")])
     daemon._consume_bm25_mutations = AsyncMock(side_effect=RuntimeError("bm25 down"))
     daemon._consume_fts_mutations = AsyncMock()
@@ -565,11 +582,46 @@ async def test_reconcile_skips_marker_when_handler_fails() -> None:
 
 
 @pytest.mark.asyncio
+async def test_reconcile_skips_marker_when_backend_not_ready() -> None:
+    """Codex round-2 finding: a consumer whose backend is None must NOT
+    get its marker set. Otherwise a transient backend init failure on
+    first start permanently closes the recovery path on next restart."""
+    settings_store = _SettingsStore()
+    daemon = SearchDaemon(settings_store=settings_store)
+    daemon._consumer_names = ("bm25", "fts", "embedding", "txtai")
+    # Backends start unset on a fresh SearchDaemon; only enable some.
+    daemon._chunk_store = AsyncMock()  # fts ready
+    daemon._backend = AsyncMock()  # txtai ready
+    # bm25 (_bm25s_index) and embedding (_indexing_pipeline /
+    # _embedding_provider) remain None → not ready.
+    daemon._async_session = _make_session_factory([("root", "/foo.md", "pid-1")])
+    daemon._consume_bm25_mutations = AsyncMock()
+    daemon._consume_fts_mutations = AsyncMock()
+    daemon._consume_embedding_mutations = AsyncMock()
+    daemon._consume_txtai_mutations = AsyncMock()
+
+    await daemon._reconcile_unindexed_paths_at_startup()
+
+    # Ready backends ran AND got their markers.
+    daemon._consume_fts_mutations.assert_awaited_once()
+    daemon._consume_txtai_mutations.assert_awaited_once()
+    assert settings_store.get_setting("search_mutation_reconciled_v1:fts") is not None
+    assert settings_store.get_setting("search_mutation_reconciled_v1:txtai") is not None
+    # Unready backends: handler NOT invoked AND no marker set, so a
+    # later restart with the backend up will recover the unindexed files.
+    daemon._consume_bm25_mutations.assert_not_awaited()
+    daemon._consume_embedding_mutations.assert_not_awaited()
+    assert settings_store.get_setting("search_mutation_reconciled_v1:bm25") is None
+    assert settings_store.get_setting("search_mutation_reconciled_v1:embedding") is None
+
+
+@pytest.mark.asyncio
 async def test_reconcile_marks_consumers_when_no_unindexed_rows() -> None:
     """Empty result set still records markers, so warm starts skip the SQL scan."""
     settings_store = _SettingsStore()
     daemon = SearchDaemon(settings_store=settings_store)
     daemon._consumer_names = ("bm25", "fts", "embedding", "txtai")
+    _enable_all_backends(daemon)
     daemon._async_session = _make_session_factory([])
     daemon._consume_bm25_mutations = AsyncMock()
     daemon._consume_fts_mutations = AsyncMock()


### PR DESCRIPTION
## Summary

- Search daemon's first startup captured `MAX(operation_log.sequence_number)` for every consumer (`bm25` / `fts` / `embedding` / `txtai`), skipping every historical write — files written before the daemon ever ran stayed unindexed until something else touched them (#4016).
- New `_reconcile_unindexed_paths_at_startup` scans `file_paths` (deleted_at IS NULL, `indexed_content_id` NULL or stale), synthesizes UPSERT `SearchMutationEvent`s, and runs all four consumer handlers before the per-consumer checkpoint init advances past them.
- Skipped on warm restarts (any consumer with a persisted checkpoint) so we don't re-run on every reboot.
- Replay-from-zero rejected per the issue — synthesizing from current `file_paths` state stays bounded by live data and avoids rename/delete churn.

## Test plan

- [x] New tests in `tests/integration/bricks/search/test_search_mutation_flow.py`:
  - `test_reconcile_unindexed_paths_skips_when_warm_start` — any persisted checkpoint short-circuits reconciliation.
  - `test_reconcile_unindexed_paths_runs_handlers_with_synthesized_events` — cold start fans synthesized events out to all four handlers, with correct path scoping.
  - `test_index_refresh_loop_reconciles_before_initializing_checkpoints` — reconciliation runs before consumer checkpoint init.
- [x] Pre-existing failures in this file (`test_fts_mutation_skips_document_chunks_when_path_id_unresolved`, `test_bm25_mutation_consumer_indexes_virtual_path`) reproduce on develop tip without this change — unrelated stale `SimpleNamespace` mocks missing `content_resolved`.

Closes #4016.