### PR TITLE
Fix Docker demo init preflight timeout

### DIFF
--- a/src/nexus/cli/commands/demo.py
+++ b/src/nexus/cli/commands/demo.py
@@ -318,15 +318,18 @@ def _get_nexus_client(config: dict[str, Any]) -> Any:
         # which populate the PostgreSQL file_paths table (required for semantic
         # search indexing). gRPC writes go to the Rust kernel natively and
         # bypass Python observers, so HERB files end up in Redb only.
-        # Probe an authenticated endpoint so a bad API key fails fast instead of
-        # silently producing a partial seed.
+        # Probe a lightweight authenticated endpoint so a bad API key fails
+        # fast without exercising root VFS metadata.  On edge containers under
+        # startup load, ``/api/v2/files/metadata?path=/`` can block long enough
+        # to trip the CLI timeout even while the HTTP service is otherwise
+        # ready; actual file writes below still validate the file API path.
         try:
             import httpx as _httpx
 
             from nexus.cli.api_client import NexusApiClient
 
             test_client = NexusApiClient(url=url, api_key=api_key)
-            test_client.get("/api/v2/files/metadata", params={"path": "/"})
+            test_client.get("/api/v2/connectors")
             logger.info("demo preset: server reachable at %s — using REST API for seeding", url)
             return _RestApiNexusClient(url, api_key)
         except _httpx.HTTPStatusError:

--- a/tests/unit/cli/test_demo_preflight.py
+++ b/tests/unit/cli/test_demo_preflight.py
@@ -1,0 +1,17 @@
+"""Static checks for demo init remote preflight behavior."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+DEMO_COMMAND = Path(__file__).resolve().parents[3] / "src/nexus/cli/commands/demo.py"
+
+
+def test_remote_demo_preflight_avoids_root_metadata_probe() -> None:
+    text = DEMO_COMMAND.read_text()
+    remote_block = text[
+        text.index('if preset in ("shared", "demo"):') : text.index("# Local preset")
+    ]
+
+    assert 'test_client.get("/api/v2/connectors")' in remote_block
+    assert 'test_client.get("/api/v2/files/metadata", params={"path": "/"})' not in remote_block


### PR DESCRIPTION
## Summary
- avoid using root file metadata as the demo init remote preflight
- use a lightweight authenticated connectors endpoint before REST seeding
- add a regression check so the preflight does not regress to /api/v2/files/metadata?path=/

## Verification
- direct runtime preflight check with mocked NexusApiClient
- direct static preflight check
- uv run ruff check src/nexus/cli/commands/demo.py tests/unit/cli/test_demo_preflight.py
- uv run ruff format --check src/nexus/cli/commands/demo.py tests/unit/cli/test_demo_preflight.py
- git diff --check
- commit hook passed

Note: local pytest CLI hung in this worktree even for pytest --version, so I used direct focused Python checks for the regression.