### PR TITLE
fix(kernel): VFS Router + MetaStore audit cleanup

### DIFF
--- a/rust/kernel/src/abc/meta_store.rs
+++ b/rust/kernel/src/abc/meta_store.rs
@@ -32,7 +32,6 @@ pub const DT_DIR: u8 = 1;
 pub const DT_MOUNT: u8 = 2;
 pub const DT_PIPE: u8 = 3;
 pub const DT_STREAM: u8 = 4;
-#[allow(dead_code)]
 pub const DT_EXTERNAL_STORAGE: u8 = 5;
 pub const DT_LINK: u8 = 6;
 
@@ -197,8 +196,14 @@ pub trait MetaStore: Send + Sync {
     /// field reflects the state after this call (caller can use the
     /// mismatch case to rebuild a retry).
     ///
-    /// Default impl is racy (get → compare → put). Redb overrides with a
-    /// single write txn; ZoneMetaStore overrides with a raft propose.
+    /// # Atomicity
+    ///
+    /// **Default impl is NOT atomic** (get → compare → put). Concurrent
+    /// writers may interleave causing lost updates. Implementations SHOULD
+    /// override this with a single transaction:
+    /// - `LocalMetaStore`: overrides with a redb write txn (atomic).
+    /// - `ZoneMetaStore`: overrides with a raft propose (linearizable).
+    /// - `RemoteMetaStore`: falls through to this default — **racy**.
     fn put_if_version(
         &self,
         metadata: FileMetadata,
@@ -381,11 +386,13 @@ pub trait MetaStore: Send + Sync {
 
     /// Append a raw byte entry at `key` to the metastore's
     /// stream-entries side table.  Used by `WalStreamCore` /
-    /// `WalPipeCore` (the durable DT_STREAM / DT_PIPE backends) to
+    /// **Optional capability** — only `ZoneMetaStore` implements this.
+    /// Other impls return `Err(NotSupported)` and callers fall back to
+    /// in-memory stream/pipe backends.
+    ///
+    /// Used by `WalPipeCore` (the durable DT_STREAM / DT_PIPE backends) to
     /// persist an entry through whatever replication the metastore
-    /// happens to provide — ``LocalMetaStore`` has no replication and
-    /// returns ``NotSupported`` (callers fall back to the in-memory
-    /// stream/pipe backends), ``ZoneMetaStore`` proposes
+    /// happens to provide — ``ZoneMetaStore`` proposes
     /// ``Command::AppendStreamEntry`` so peers see the entry via
     /// raft commit.
     ///

--- a/rust/kernel/src/core/meta_store/mod.rs
+++ b/rust/kernel/src/core/meta_store/mod.rs
@@ -527,7 +527,11 @@ impl MetaStore for LocalMetaStore {
         let mut results = Vec::with_capacity(paths.len());
         for path in paths {
             match table.get(path.as_str()) {
-                Ok(Some(guard)) => results.push(Some(deserialize_metadata(guard.value())?)),
+                Ok(Some(guard)) => {
+                    let meta = deserialize_metadata(guard.value())?;
+                    self.cache.insert(path.clone(), meta.clone());
+                    results.push(Some(meta));
+                }
                 Ok(None) => results.push(None),
                 Err(e) => return Err(MetaStoreError::IOError(format!("redb get_batch: {e}"))),
             }

--- a/rust/kernel/src/core/meta_store/remote.rs
+++ b/rust/kernel/src/core/meta_store/remote.rs
@@ -85,6 +85,10 @@ impl MetaStore for RemoteMetaStore {
                 "zone_id": metadata.zone_id,
                 "mime_type": metadata.mime_type,
                 "last_writer_address": metadata.last_writer_address,
+                "created_at_ms": metadata.created_at_ms,
+                "modified_at_ms": metadata.modified_at_ms,
+                "target_zone_id": metadata.target_zone_id,
+                "link_target": metadata.link_target,
             },
         });
         let bytes =

--- a/rust/kernel/src/core/vfs_router.rs
+++ b/rust/kernel/src/core/vfs_router.rs
@@ -1,23 +1,16 @@
-//! Kernel mount table — single SSOT for mount entries (Rust port).
+//! Kernel mount table — SSOT for **runtime routing state**.
 //!
-//! Mirrors Python `nexus.core.vfs_router` (the canonical kernel-namespace
-//! placement for this data type). Each `MountEntry` is the in-memory record
-//! for one mount: storage backend and optional per-mount metastore.
-//! Together they form `VFSRouter`, an LPM-routable container keyed by
-//! zone-canonical paths. Access control lives one layer up (rebac); the
-//! mount table is pure routing.
+//! Each `MountEntry` is the in-memory record for one mount: storage backend
+//! and optional per-mount metastore. Together they form `VFSRouter`, an
+//! LPM-routable container keyed by zone-canonical paths.
 //!
-//! Replaces the older split where:
-//!   - `rust/kernel/src/router.rs::PathRouter` owned a `HashMap<String,
-//!     MountEntry>` of backends-only
-//!   - `rust/kernel/src/kernel.rs::Kernel::mount_metastores` was a *separate*
-//!     `DashMap<String, Arc<dyn MetaStore>>` keyed by the same canonical paths
+//! **SSOT scope**: VFSRouter is authoritative for runtime path→backend
+//! routing. DT_MOUNT *metadata* (the fact that a mount exists, its zone_id,
+//! backend_name) is additionally persisted in the parent zone's metastore
+//! so federation can replicate mount topology via raft. VFSRouter is
+//! populated on boot from those metastore records + DLC.mount() calls.
 //!
-//! Both halves now live in `MountEntry`, so callers no longer have to keep
-//! the two maps consistent. The Python side's `VFSRouter._entries` Python-
-//! ref shadow cache disappears as `_write_content` and friends migrate to
-//! call `kernel.sys_*` directly (no need to hold Python backend/metastore
-//! refs anymore).
+//! Access control lives one layer up (rebac); the mount table is pure routing.
 //!
 //! Concurrency: `DashMap` for lock-free reads on the syscall hot path. Add/
 //! remove are rare (mount-lifecycle events) so the per-shard write lock is
@@ -202,10 +195,6 @@ impl std::fmt::Debug for RouteResult {
     }
 }
 
-/// Legacy alias retained so callers naming `RustRouteResult` keep
-/// compiling. Prefer `RouteResult` in new code.
-pub type RustRouteResult = RouteResult;
-
 // ---------------------------------------------------------------------------
 // VFSRouter — kernel-owned mount registry
 // ---------------------------------------------------------------------------
@@ -334,14 +323,6 @@ impl VFSRouter {
     ) -> Option<dashmap::mapref::one::Ref<'_, String, MountEntry>> {
         let canonical = canonicalize_mount_path(mount_point, zone_id);
         self.entries.get(&canonical)
-    }
-
-    /// Borrow the entry mutably under an exact canonical key.
-    pub fn entries_get_mut(
-        &self,
-        canonical_key: &str,
-    ) -> Option<dashmap::mapref::one::RefMut<'_, String, MountEntry>> {
-        self.entries.get_mut(canonical_key)
     }
 
     /// True if a mount exists under `(mount_point, zone_id)`.
@@ -501,8 +482,7 @@ impl VFSRouter {
             }
         }
         Err(RouteError::NotMounted(format!(
-            "No mount found for path: {}",
-            path
+            "No mount found for path: {path} (zone={zone_id})"
         )))
     }
 

--- a/rust/kernel/src/kernel/io.rs
+++ b/rust/kernel/src/kernel/io.rs
@@ -1723,8 +1723,8 @@ impl Kernel {
     /// Internal: copy content via read_content + write_content (cross-mount or fallback).
     fn copy_via_read_write(
         &self,
-        src_route: &crate::vfs_router::RustRouteResult,
-        dst_route: &crate::vfs_router::RustRouteResult,
+        src_route: &crate::vfs_router::RouteResult,
+        dst_route: &crate::vfs_router::RouteResult,
         src_meta: &FileMetadata,
         ctx: &OperationContext,
     ) -> Result<(String, u64), KernelError> {

--- a/rust/kernel/src/kernel/mod.rs
+++ b/rust/kernel/src/kernel/mod.rs
@@ -24,7 +24,7 @@ use crate::meta_store::LocalMetaStore;
 use crate::meta_store::DT_REG;
 use crate::meta_store::{DT_DIR, DT_LINK, DT_MOUNT, DT_PIPE, DT_STREAM};
 use crate::vfs_router::{
-    canonicalize_mount_path as canonicalize, RouteError, RustRouteResult, VFSRouter,
+    canonicalize_mount_path as canonicalize, RouteError, RouteResult, VFSRouter,
 };
 use dashmap::DashMap;
 use parking_lot::{Condvar, Mutex, RwLock, RwLockReadGuard};

--- a/rust/kernel/src/kernel/mount.rs
+++ b/rust/kernel/src/kernel/mount.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use crate::vfs_router::canonicalize_mount_path as canonicalize;
 
-use super::{Kernel, KernelError, RustRouteResult};
+use super::{Kernel, KernelError, RouteResult};
 
 impl Kernel {
     // ── Mount-table primitives (composed by sys_setattr DT_MOUNT) ──────
@@ -119,7 +119,7 @@ impl Kernel {
     }
 
     /// Zone-canonical LPM routing.
-    pub fn route(&self, path: &str, zone_id: &str) -> Result<RustRouteResult, KernelError> {
+    pub fn route(&self, path: &str, zone_id: &str) -> Result<RouteResult, KernelError> {
         self.vfs_router
             .route(path, zone_id)
             .map_err(KernelError::from)


### PR DESCRIPTION
## Summary
- Delete dead `entries_get_mut()` from VFS Router (zero callers)
- Rename `RustRouteResult` → `RouteResult` (delete Python-era legacy alias)
- Fix `RemoteMetaStore.put()` silently dropping `created_at_ms`, `modified_at_ms`, `target_zone_id`, `link_target` on round-trip
- Fix `LocalMetaStore.get_batch()` not populating cache (asymmetric with put_batch)
- Improve route error messages, trait doc warnings, SSOT header clarification
- Remove stale `#[allow(dead_code)]` on `DT_EXTERNAL_STORAGE`

## Test plan
- [x] `cargo check -p kernel -p nexus-cdylib -p services -p nexus-cluster` — clean
- [x] `cargo test -p kernel --lib` — 362 tests pass
- [x] Pre-commit hooks (fmt, clippy, codegen sync) — all pass
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)