### PR TITLE
[codex] Add detailed hub status diagnostics

### DIFF
--- a/docs/superpowers/plans/2026-05-05-issue-3874-hub-status-detail.md
+++ b/docs/superpowers/plans/2026-05-05-issue-3874-hub-status-detail.md
@@ -1,0 +1,1196 @@
+# Hub Status Detail Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add `nexus hub status --detail` with richer local hub diagnostics while preserving default `nexus hub status` output.
+
+**Architecture:** Keep the hub status command local-first. `hub.py` owns payload assembly and text/JSON rendering; existing MCP audit and rate-limit middleware write small best-effort Redis counters that the CLI reads. Detail metrics degrade to `null`/`n/a`, while Postgres remains the only hard health dependency.
+
+**Tech Stack:** Python, Click, SQLAlchemy, Redis/Dragonfly, Starlette middleware, pytest.
+
+---
+
+## File Structure
+
+- Modify `src/nexus/cli/commands/hub.py`: add `--detail`, split status payload/render helpers, collect Postgres token/zone details, read detail Redis counters, and compute local Zoekt index metadata.
+- Modify `src/nexus/bricks/mcp/middleware_audit.py`: add per-zone QPS and active-client counters.
+- Modify `src/nexus/bricks/mcp/middleware_ratelimit.py`: add best-effort per-tier 429 counters.
+- Modify `tests/unit/cli/test_hub.py`: cover default output preservation, detail JSON/text shape, token last-seen, Redis detail aggregation, and search metadata.
+- Modify `tests/unit/bricks/mcp/test_middleware_audit_metrics.py`: cover per-zone counter writes.
+- Modify `tests/unit/bricks/mcp/test_middleware_ratelimit.py`: cover 429 counter recording.
+
+## Task 1: Preserve Base Status Contract And Add `--detail` Flag
+
+**Files:**
+- Modify: `tests/unit/cli/test_hub.py`
+- Modify: `src/nexus/cli/commands/hub.py`
+
+- [ ] **Step 1: Add a failing contract test for default text output**
+
+Add this test near the existing hub status tests in `tests/unit/cli/test_hub.py`:
+
+```python
+def test_hub_status_text_unchanged_without_detail(monkeypatch):
+    monkeypatch.setenv("NEXUS_MCP_HOST", "0.0.0.0")
+    monkeypatch.setenv("NEXUS_MCP_PORT", "8081")
+    monkeypatch.setenv("NEXUS_PROFILE", "full")
+
+    session = MagicMock()
+    session.execute.return_value.scalar.side_effect = [5, 2]
+    monkeypatch.setattr(
+        "nexus.cli.commands.hub.get_session_factory",
+        lambda: _mock_session_ctx(session),
+    )
+    monkeypatch.setattr(
+        "nexus.cli.commands.hub._read_redis_stats",
+        lambda: {"qps_5m": 3.5, "connections": 4, "redis": "ok"},
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(hub, ["status"])
+    assert result.exit_code == 0, result.output
+    assert result.output == (
+        "endpoint:    http://0.0.0.0:8081/mcp\n"
+        "profile:     full\n"
+        "postgres:    ok\n"
+        "redis:       ok\n"
+        "tokens:      5 active, 2 revoked\n"
+        "connections: 4\n"
+        "qps (5m):    3.5\n"
+    )
+```
+
+- [ ] **Step 2: Run the contract test and verify it passes before refactor**
+
+Run:
+
+```bash
+pytest tests/unit/cli/test_hub.py::test_hub_status_text_unchanged_without_detail -v
+```
+
+Expected: `PASSED`. If it fails, stop and inspect the current output before refactoring.
+
+- [ ] **Step 3: Add a failing test that the new flag is accepted**
+
+Add this test after `test_hub_status_text_unchanged_without_detail`:
+
+```python
+def test_hub_status_detail_flag_is_accepted(monkeypatch):
+    session = MagicMock()
+    session.execute.return_value.scalar.side_effect = [0, 0]
+    monkeypatch.setattr(
+        "nexus.cli.commands.hub.get_session_factory",
+        lambda: _mock_session_ctx(session),
+    )
+    monkeypatch.setattr(
+        "nexus.cli.commands.hub._read_redis_stats",
+        lambda: {"qps_5m": None, "connections": None, "redis": "n/a"},
+    )
+    monkeypatch.setattr(
+        "nexus.cli.commands.hub._collect_status_detail",
+        lambda _zone_ids, _tokens_detail, _redis_detail: {
+            "zones": [],
+            "tokens_detail": [],
+            "rate_limits": {"window_seconds": 300, "hits_by_tier": {}},
+            "search": {"zones": []},
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "nexus.cli.commands.hub._read_redis_detail_stats",
+        lambda _zone_ids: {
+            "zones": [],
+            "rate_limits": {"window_seconds": 300, "hits_by_tier": {}},
+        },
+        raising=False,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(hub, ["status", "--detail", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["detail"] is True
+```
+
+- [ ] **Step 4: Run the flag test and verify it fails**
+
+Run:
+
+```bash
+pytest tests/unit/cli/test_hub.py::test_hub_status_detail_flag_is_accepted -v
+```
+
+Expected: `FAILED` with Click reporting `No such option: --detail`.
+
+- [ ] **Step 5: Refactor `hub_status` minimally and add the flag**
+
+In `src/nexus/cli/commands/hub.py`, replace the current `hub_status` function with helpers plus a `detail` option. Keep `_read_redis_stats()` unchanged.
+
+```python
+def _display_status_value(value: Any) -> str:
+    return "n/a" if value is None else str(value)
+
+
+def _collect_postgres_status() -> dict[str, Any]:
+    pg_state = "ok"
+    active = revoked = 0
+    try:
+        factory = get_session_factory()
+        with factory() as session:
+            active = (
+                session.execute(
+                    select(func.count()).select_from(APIKeyModel).where(APIKeyModel.revoked == 0)
+                ).scalar()
+                or 0
+            )
+            revoked = (
+                session.execute(
+                    select(func.count()).select_from(APIKeyModel).where(APIKeyModel.revoked == 1)
+                ).scalar()
+                or 0
+            )
+    except Exception:  # noqa: BLE001
+        pg_state = "err"
+    return {
+        "postgres": pg_state,
+        "tokens": {"active": int(active), "revoked": int(revoked)},
+        "zone_ids": [],
+        "tokens_detail": [],
+    }
+
+
+def _base_status_payload() -> dict[str, Any]:
+    host = os.environ.get("NEXUS_MCP_HOST", "0.0.0.0")
+    port = os.environ.get("NEXUS_MCP_PORT", "8081")
+    profile = os.environ.get("NEXUS_PROFILE", "full")
+    endpoint = f"http://{host}:{port}/mcp"
+
+    postgres_status = _collect_postgres_status()
+    redis_stats = _read_redis_stats()
+    payload = {
+        "endpoint": endpoint,
+        "profile": profile,
+        "postgres": postgres_status["postgres"],
+        "redis": redis_stats["redis"],
+        "tokens": postgres_status["tokens"],
+        "connections": redis_stats["connections"],
+        "qps_5m": redis_stats["qps_5m"],
+    }
+    return payload
+
+
+def _emit_base_status_text(payload: dict[str, Any]) -> None:
+    click.echo(f"endpoint:    {payload['endpoint']}")
+    click.echo(f"profile:     {payload['profile']}")
+    click.echo(f"postgres:    {payload['postgres']}")
+    click.echo(f"redis:       {payload['redis']}")
+    click.echo(
+        f"tokens:      {payload['tokens']['active']} active, "
+        f"{payload['tokens']['revoked']} revoked"
+    )
+    click.echo("connections: " f"{_display_status_value(payload['connections'])}")
+    click.echo(f"qps (5m):    {_display_status_value(payload['qps_5m'])}")
+
+
+def _read_redis_detail_stats(zone_ids: list[str]) -> dict[str, Any]:
+    return {
+        "zones": [{"zone_id": zone_id, "clients": None, "qps_5m": None} for zone_id in zone_ids],
+        "rate_limits": {"window_seconds": 300, "hits_by_tier": {}},
+    }
+
+
+def _collect_status_detail(
+    zone_ids: list[str],
+    tokens_detail: list[dict[str, Any]],
+    redis_detail: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "zones": redis_detail["zones"],
+        "tokens_detail": tokens_detail,
+        "rate_limits": redis_detail["rate_limits"],
+        "search": _collect_search_detail(zone_ids),
+    }
+
+
+def _collect_search_detail(zone_ids: list[str]) -> dict[str, Any]:
+    return {
+        "zones": [
+            {
+                "zone_id": zone_id,
+                "zoekt_index_size_bytes": None,
+                "zoekt_index_size_display": None,
+                "zoekt_last_indexed": None,
+                "txtai_queue_depth": None,
+                "last_indexed": None,
+            }
+            for zone_id in zone_ids
+        ]
+    }
+
+
+def _emit_detail_status_text(payload: dict[str, Any]) -> None:
+    click.echo("")
+    click.echo("zones:")
+    click.echo(
+        format_table(
+            headers=["zone", "clients", "qps_5m"],
+            rows=[
+                [
+                    row["zone_id"],
+                    _display_status_value(row.get("clients")),
+                    _display_status_value(row.get("qps_5m")),
+                ]
+                for row in payload.get("zones", [])
+            ],
+        )
+    )
+    click.echo("")
+    click.echo("tokens:")
+    click.echo(
+        format_table(
+            headers=["key_id", "name", "zones", "admin", "last_seen"],
+            rows=[
+                [
+                    row["key_id"],
+                    row["name"],
+                    ",".join(row.get("zones", [])),
+                    "yes" if row.get("admin") else "no",
+                    _display_status_value(row.get("last_seen")),
+                ]
+                for row in payload.get("tokens_detail", [])
+            ],
+        )
+    )
+    click.echo("")
+    click.echo("rate limits:")
+    hits = payload.get("rate_limits", {}).get("hits_by_tier", {})
+    click.echo(
+        format_table(
+            headers=["tier", "hits_5m"],
+            rows=[[tier, _display_status_value(hits[tier])] for tier in sorted(hits)],
+        )
+    )
+    click.echo("")
+    click.echo("search:")
+    click.echo(
+        format_table(
+            headers=["zone", "zoekt_size", "zoekt_last_indexed", "txtai_queue_depth", "last_indexed"],
+            rows=[
+                [
+                    row["zone_id"],
+                    _display_status_value(row.get("zoekt_index_size_display")),
+                    _display_status_value(row.get("zoekt_last_indexed")),
+                    _display_status_value(row.get("txtai_queue_depth")),
+                    _display_status_value(row.get("last_indexed")),
+                ]
+                for row in payload.get("search", {}).get("zones", [])
+            ],
+        )
+    )
+
+
+@hub.command("status")
+@click.option("--json", "as_json", is_flag=True, help="Emit JSON.")
+@click.option("--detail", is_flag=True, help="Include per-zone, per-token, rate-limit, and search detail.")
+def hub_status(as_json: bool, detail: bool) -> None:
+    """Show hub health: postgres, redis, tokens, connections, qps."""
+    import json as _json
+
+    payload = _base_status_payload()
+    if detail:
+        redis_detail = _read_redis_detail_stats([])
+        payload["detail"] = True
+        payload.update(_collect_status_detail([], [], redis_detail))
+
+    if as_json:
+        click.echo(_json.dumps(payload, indent=2))
+    else:
+        _emit_base_status_text(payload)
+        if detail:
+            _emit_detail_status_text(payload)
+
+    if payload["postgres"] != "ok":
+        raise SystemExit(2)
+```
+
+- [ ] **Step 6: Run status tests and verify the contract still passes**
+
+Run:
+
+```bash
+pytest tests/unit/cli/test_hub.py -v -k status
+```
+
+Expected: all selected tests pass, including the new default-output contract test.
+
+- [ ] **Step 7: Commit Task 1**
+
+```bash
+git add src/nexus/cli/commands/hub.py tests/unit/cli/test_hub.py
+git commit -m "feat(#3874): add hub status detail flag scaffold"
+```
+
+## Task 2: Add Postgres Detail Rows For Zones And Tokens
+
+**Files:**
+- Modify: `tests/unit/cli/test_hub.py`
+- Modify: `src/nexus/cli/commands/hub.py`
+
+- [ ] **Step 1: Add a failing SQLite-backed detail JSON test**
+
+Add this test near the status tests:
+
+```python
+def test_hub_status_detail_json_includes_token_last_seen_and_zones(monkeypatch):
+    from datetime import datetime
+
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    from nexus.storage.models import APIKeyModel, APIKeyZoneModel, Base, ZoneModel
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, future=True, expire_on_commit=False)
+    created = datetime(2026, 5, 5, 13, 0)
+    last_seen = datetime(2026, 5, 5, 14, 20, 10)
+
+    with Session() as s, s.begin():
+        s.add(ZoneModel(zone_id="eng", name="eng", phase="Active"))
+        s.add(ZoneModel(zone_id="ops", name="ops", phase="Active"))
+        s.add(
+            APIKeyModel(
+                key_id="kid_alice",
+                key_hash="hash_alice",
+                user_id="alice",
+                name="alice",
+                is_admin=0,
+                created_at=created,
+                last_used_at=last_seen,
+                revoked=0,
+            )
+        )
+        s.add(APIKeyZoneModel(key_id="kid_alice", zone_id="eng", permissions="rw"))
+        s.add(APIKeyZoneModel(key_id="kid_alice", zone_id="ops", permissions="r"))
+
+    monkeypatch.setattr("nexus.cli.commands.hub.get_session_factory", lambda: Session)
+    monkeypatch.setattr(
+        "nexus.cli.commands.hub._read_redis_stats",
+        lambda: {"qps_5m": 0.0, "connections": 0, "redis": "ok"},
+    )
+    monkeypatch.setattr(
+        "nexus.cli.commands.hub._read_redis_detail_stats",
+        lambda zone_ids: {
+            "zones": [{"zone_id": zone_id, "clients": None, "qps_5m": None} for zone_id in zone_ids],
+            "rate_limits": {"window_seconds": 300, "hits_by_tier": {}},
+        },
+    )
+    monkeypatch.setattr(
+        "nexus.cli.commands.hub._collect_search_detail",
+        lambda zone_ids: {"zones": [{"zone_id": zone_id, "txtai_queue_depth": None} for zone_id in zone_ids]},
+        raising=False,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(hub, ["status", "--detail", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert [row["zone_id"] for row in payload["zones"]] == ["eng", "ops"]
+    assert payload["tokens_detail"] == [
+        {
+            "key_id": "kid_alice",
+            "name": "alice",
+            "zones": ["eng", "ops"],
+            "admin": False,
+            "created": created.isoformat(),
+            "last_seen": last_seen.isoformat(),
+            "revoked": False,
+            "revoked_at": None,
+        }
+    ]
+```
+
+- [ ] **Step 2: Run the new test and verify it fails**
+
+Run:
+
+```bash
+pytest tests/unit/cli/test_hub.py::test_hub_status_detail_json_includes_token_last_seen_and_zones -v
+```
+
+Expected: `FAILED` because `tokens_detail` is empty and zone IDs are not passed into Redis/search detail helpers yet.
+
+- [ ] **Step 3: Implement Postgres detail collection**
+
+In `src/nexus/cli/commands/hub.py`, add these helpers near the status helpers:
+
+```python
+def _iso_or_none(dt: datetime | None) -> str | None:
+    return dt.isoformat() if dt else None
+
+
+def _collect_zone_ids(session: Any) -> list[str]:
+    rows = (
+        session.execute(
+            select(ZoneModel.zone_id)
+            .where(ZoneModel.phase == "Active")
+            .where(ZoneModel.deleted_at.is_(None))
+            .order_by(ZoneModel.zone_id.asc())
+        )
+        .scalars()
+        .all()
+    )
+    return [str(zone_id) for zone_id in rows]
+
+
+def _token_zones_by_key(session: Any, key_ids: list[str]) -> dict[str, list[str]]:
+    if not key_ids:
+        return {}
+    rows = (
+        session.execute(
+            select(APIKeyZoneModel.key_id, APIKeyZoneModel.zone_id)
+            .where(APIKeyZoneModel.key_id.in_(key_ids))
+            .order_by(APIKeyZoneModel.granted_at.asc(), APIKeyZoneModel.zone_id.asc())
+        )
+        .all()
+    )
+    zones_by_key: dict[str, list[str]] = {key_id: [] for key_id in key_ids}
+    for key_id, zone_id in rows:
+        zones_by_key.setdefault(key_id, []).append(zone_id)
+    return zones_by_key
+
+
+def _collect_token_detail(session: Any) -> list[dict[str, Any]]:
+    rows = (
+        session.execute(select(APIKeyModel).order_by(APIKeyModel.created_at.desc()))
+        .scalars()
+        .all()
+    )
+    key_ids = [row.key_id for row in rows]
+    zones_by_key = _token_zones_by_key(session, key_ids)
+    return [
+        {
+            "key_id": row.key_id,
+            "name": row.name,
+            "zones": zones_by_key.get(row.key_id, []),
+            "admin": bool(row.is_admin),
+            "created": _iso_or_none(row.created_at),
+            "last_seen": _iso_or_none(row.last_used_at),
+            "revoked": bool(row.revoked),
+            "revoked_at": _iso_or_none(row.revoked_at),
+        }
+        for row in rows
+    ]
+```
+
+Then replace `_collect_postgres_status` with a detail-aware version that performs every DB read inside the session context:
+
+```python
+def _collect_postgres_status(detail: bool = False) -> dict[str, Any]:
+    pg_state = "ok"
+    active = revoked = 0
+    zone_ids: list[str] = []
+    tokens_detail: list[dict[str, Any]] = []
+    try:
+        factory = get_session_factory()
+        with factory() as session:
+            active = (
+                session.execute(
+                    select(func.count()).select_from(APIKeyModel).where(APIKeyModel.revoked == 0)
+                ).scalar()
+                or 0
+            )
+            revoked = (
+                session.execute(
+                    select(func.count()).select_from(APIKeyModel).where(APIKeyModel.revoked == 1)
+                ).scalar()
+                or 0
+            )
+            if detail:
+                zone_ids = _collect_zone_ids(session)
+                tokens_detail = _collect_token_detail(session)
+    except Exception:  # noqa: BLE001
+        pg_state = "err"
+    return {
+        "postgres": pg_state,
+        "tokens": {"active": int(active), "revoked": int(revoked)},
+        "zone_ids": zone_ids,
+        "tokens_detail": tokens_detail,
+    }
+```
+
+Then change `_base_status_payload` so it accepts the already-collected Postgres status:
+
+```python
+def _base_status_payload(postgres_status: dict[str, Any]) -> dict[str, Any]:
+    host = os.environ.get("NEXUS_MCP_HOST", "0.0.0.0")
+    port = os.environ.get("NEXUS_MCP_PORT", "8081")
+    profile = os.environ.get("NEXUS_PROFILE", "full")
+    endpoint = f"http://{host}:{port}/mcp"
+
+    redis_stats = _read_redis_stats()
+    return {
+        "endpoint": endpoint,
+        "profile": profile,
+        "postgres": postgres_status["postgres"],
+        "redis": redis_stats["redis"],
+        "tokens": postgres_status["tokens"],
+        "connections": redis_stats["connections"],
+        "qps_5m": redis_stats["qps_5m"],
+    }
+```
+
+Keep `_collect_status_detail` session-free:
+
+```python
+def _collect_status_detail(
+    zone_ids: list[str],
+    tokens_detail: list[dict[str, Any]],
+    redis_detail: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "zones": redis_detail["zones"],
+        "tokens_detail": tokens_detail,
+        "rate_limits": redis_detail["rate_limits"],
+        "search": _collect_search_detail(zone_ids),
+    }
+```
+
+Update `hub_status` so DB detail is collected before Redis/search detail:
+
+```python
+    postgres_status = _collect_postgres_status(detail=detail)
+    payload = _base_status_payload(postgres_status)
+    if detail:
+        zone_ids = postgres_status["zone_ids"]
+        redis_detail = _read_redis_detail_stats(zone_ids)
+        payload["detail"] = True
+        payload.update(
+            _collect_status_detail(zone_ids, postgres_status["tokens_detail"], redis_detail)
+        )
+```
+
+- [ ] **Step 4: Verify the temporary search detail stub still exists**
+
+Task 1 added this helper. Keep it in place so Task 2 is independently green:
+
+```python
+def _collect_search_detail(zone_ids: list[str]) -> dict[str, Any]:
+    return {
+        "zones": [
+            {
+                "zone_id": zone_id,
+                "zoekt_index_size_bytes": None,
+                "zoekt_index_size_display": None,
+                "zoekt_last_indexed": None,
+                "txtai_queue_depth": None,
+                "last_indexed": None,
+            }
+            for zone_id in zone_ids
+        ]
+    }
+```
+
+- [ ] **Step 5: Run the detail Postgres test**
+
+Run:
+
+```bash
+pytest tests/unit/cli/test_hub.py::test_hub_status_detail_json_includes_token_last_seen_and_zones -v
+```
+
+Expected: `PASSED`.
+
+- [ ] **Step 6: Run all status tests**
+
+Run:
+
+```bash
+pytest tests/unit/cli/test_hub.py -v -k status
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 7: Commit Task 2**
+
+```bash
+git add src/nexus/cli/commands/hub.py tests/unit/cli/test_hub.py
+git commit -m "feat(#3874): include token and zone detail in hub status"
+```
+
+## Task 3: Read Per-Zone And Rate-Limit Detail From Redis
+
+**Files:**
+- Modify: `tests/unit/cli/test_hub.py`
+- Modify: `src/nexus/cli/commands/hub.py`
+
+- [ ] **Step 1: Add a failing unit test for Redis detail aggregation**
+
+Add this test near the status tests:
+
+```python
+def test_read_redis_detail_stats_aggregates_zone_and_rate_limit_counts(monkeypatch):
+    import nexus.cli.commands.hub as hub_module
+
+    class FakeRedis:
+        def __init__(self):
+            self.mget_calls = []
+            self.scard_calls = []
+
+        def ping(self):
+            return True
+
+        def mget(self, keys):
+            self.mget_calls.append(keys)
+            values = {
+                "nexus:hub:qps:zone:eng:100": b"120",
+                "nexus:hub:qps:zone:eng:99": b"30",
+                "nexus:hub:qps:zone:ops:100": b"60",
+                "nexus:hub:rate_limit:anonymous:100": b"2",
+                "nexus:hub:rate_limit:authenticated:100": b"4",
+            }
+            return [values.get(key) for key in keys]
+
+        def scard(self, key):
+            self.scard_calls.append(key)
+            return {"nexus:hub:active:zone:eng:100": 3, "nexus:hub:active:zone:ops:100": 1}.get(key, 0)
+
+    fake = FakeRedis()
+    monkeypatch.setenv("NEXUS_REDIS_URL", "redis://localhost:6379")
+    monkeypatch.setattr("redis.from_url", lambda *_args, **_kwargs: fake)
+    monkeypatch.setattr(hub_module.time, "time", lambda: 100 * 60)
+
+    detail = hub_module._read_redis_detail_stats(["eng", "ops"])
+
+    assert detail["zones"] == [
+        {"zone_id": "eng", "clients": 3, "qps_5m": 0.5},
+        {"zone_id": "ops", "clients": 1, "qps_5m": 0.2},
+    ]
+    assert detail["rate_limits"] == {
+        "window_seconds": 300,
+        "hits_by_tier": {"anonymous": 2, "authenticated": 4, "premium": 0},
+    }
+```
+
+- [ ] **Step 2: Run the Redis detail test and verify it fails**
+
+Run:
+
+```bash
+pytest tests/unit/cli/test_hub.py::test_read_redis_detail_stats_aggregates_zone_and_rate_limit_counts -v
+```
+
+Expected: `FAILED` because `_read_redis_detail_stats` returns stub `None` values.
+
+- [ ] **Step 3: Import module-level `time` in `hub.py`**
+
+At the top of `src/nexus/cli/commands/hub.py`, add:
+
+```python
+import time
+```
+
+Then remove the inner `import time` from `_read_redis_stats()` so tests can monkeypatch `nexus.cli.commands.hub.time.time`.
+
+- [ ] **Step 4: Replace `_read_redis_detail_stats` with Redis-backed implementation**
+
+Replace the stub helper with:
+
+```python
+_RATE_LIMIT_TIERS = ("anonymous", "authenticated", "premium")
+
+
+def _decode_int(value: Any) -> int:
+    if value is None:
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
+def _read_redis_detail_stats(zone_ids: list[str]) -> dict[str, Any]:
+    url = os.environ.get("NEXUS_REDIS_URL") or os.environ.get("DRAGONFLY_URL")
+    empty_zones = [{"zone_id": zone_id, "clients": None, "qps_5m": None} for zone_id in zone_ids]
+    empty = {
+        "zones": empty_zones,
+        "rate_limits": {
+            "window_seconds": 300,
+            "hits_by_tier": {tier: None for tier in _RATE_LIMIT_TIERS},
+        },
+    }
+    if not url:
+        return empty
+    try:
+        import redis
+    except ImportError:
+        return empty
+
+    try:
+        client = redis.from_url(url, socket_timeout=2)
+        client.ping()
+        now_min = int(time.time()) // 60
+        zones: list[dict[str, Any]] = []
+        for zone_id in zone_ids:
+            minute_keys = [
+                f"nexus:hub:qps:zone:{zone_id}:{now_min - i}" for i in range(5)
+            ]
+            total = sum(_decode_int(v) for v in client.mget(minute_keys))
+            active = client.scard(f"nexus:hub:active:zone:{zone_id}:{now_min}")
+            zones.append(
+                {
+                    "zone_id": zone_id,
+                    "clients": int(active),
+                    "qps_5m": round(total / 300.0, 2),
+                }
+            )
+
+        hits_by_tier: dict[str, int] = {}
+        for tier in _RATE_LIMIT_TIERS:
+            minute_keys = [
+                f"nexus:hub:rate_limit:{tier}:{now_min - i}" for i in range(5)
+            ]
+            hits_by_tier[tier] = sum(_decode_int(v) for v in client.mget(minute_keys))
+
+        return {
+            "zones": zones,
+            "rate_limits": {"window_seconds": 300, "hits_by_tier": hits_by_tier},
+        }
+    except Exception:  # noqa: BLE001
+        return empty
+```
+
+- [ ] **Step 5: Run the Redis detail test**
+
+Run:
+
+```bash
+pytest tests/unit/cli/test_hub.py::test_read_redis_detail_stats_aggregates_zone_and_rate_limit_counts -v
+```
+
+Expected: `PASSED`.
+
+- [ ] **Step 6: Run status tests**
+
+Run:
+
+```bash
+pytest tests/unit/cli/test_hub.py -v -k status
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 7: Commit Task 3**
+
+```bash
+git add src/nexus/cli/commands/hub.py tests/unit/cli/test_hub.py
+git commit -m "feat(#3874): read hub status detail counters from redis"
+```
+
+## Task 4: Write Per-Zone Counters From Audit Middleware
+
+**Files:**
+- Modify: `tests/unit/bricks/mcp/test_middleware_audit_metrics.py`
+- Modify: `src/nexus/bricks/mcp/middleware_audit.py`
+
+- [ ] **Step 1: Add a failing test for per-zone counter writes**
+
+Add this test after `test_record_metrics_increments_qps_and_sadds_active`:
+
+```python
+@pytest.mark.asyncio
+async def test_record_metrics_increments_per_zone_counters(monkeypatch):
+    monkeypatch.setenv("NEXUS_REDIS_URL", "redis://localhost:6379")
+
+    fake_client = AsyncMock()
+    fake_client.incr = AsyncMock(return_value=1)
+    fake_client.sadd = AsyncMock(return_value=1)
+    fake_client.expire = AsyncMock(return_value=True)
+    fake_client.close = AsyncMock()
+
+    monkeypatch.setattr(_redis_async, "from_url", lambda _url: fake_client)
+
+    await mw._record_metrics(
+        {"subject_id": "kid_abc", "token_hash": "deadbeef", "zone_id": "eng"}
+    )
+
+    incr_keys = [call.args[0] for call in fake_client.incr.await_args_list]
+    sadd_keys = [call.args[0] for call in fake_client.sadd.await_args_list]
+
+    assert any(key.startswith("nexus:hub:qps:") for key in incr_keys)
+    assert any(key.startswith("nexus:hub:qps:zone:eng:") for key in incr_keys)
+    assert any(key.startswith("nexus:hub:active:") for key in sadd_keys)
+    assert any(key.startswith("nexus:hub:active:zone:eng:") for key in sadd_keys)
+    assert fake_client.expire.await_count == 4
+```
+
+- [ ] **Step 2: Run the new audit test and verify it fails**
+
+Run:
+
+```bash
+pytest tests/unit/bricks/mcp/test_middleware_audit_metrics.py::test_record_metrics_increments_per_zone_counters -v
+```
+
+Expected: `FAILED` because only aggregate counters are written.
+
+- [ ] **Step 3: Add per-zone counter writes**
+
+In `src/nexus/bricks/mcp/middleware_audit.py`, inside `_record_metrics`, after the aggregate `active_key` expire call, add:
+
+```python
+        zone_id = record.get("zone_id")
+        if isinstance(zone_id, str) and zone_id:
+            zone_qps_key = f"nexus:hub:qps:zone:{zone_id}:{epoch_min}"
+            zone_active_key = f"nexus:hub:active:zone:{zone_id}:{epoch_min}"
+            await client.incr(zone_qps_key)
+            await client.expire(zone_qps_key, 600)
+            _zone_sadd_r = client.sadd(zone_active_key, member)
+            if not isinstance(_zone_sadd_r, int):
+                await _zone_sadd_r
+            await client.expire(zone_active_key, 600)
+```
+
+Keep all writes inside the existing `try` block so audit remains fire-and-forget.
+
+- [ ] **Step 4: Run audit middleware tests**
+
+Run:
+
+```bash
+pytest tests/unit/bricks/mcp/test_middleware_audit_metrics.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 5: Commit Task 4**
+
+```bash
+git add src/nexus/bricks/mcp/middleware_audit.py tests/unit/bricks/mcp/test_middleware_audit_metrics.py
+git commit -m "feat(#3874): record per-zone hub activity counters"
+```
+
+## Task 5: Write Rate-Limit Hit Counters By Tier
+
+**Files:**
+- Modify: `tests/unit/bricks/mcp/test_middleware_ratelimit.py`
+- Modify: `src/nexus/bricks/mcp/middleware_ratelimit.py`
+
+- [ ] **Step 1: Add a failing test that 429 records the tier**
+
+Add this test after `test_429_response_shape`:
+
+```python
+def test_429_records_rate_limit_hit_tier(monkeypatch, app: Starlette) -> None:
+    hits: list[str] = []
+
+    async def fake_record(tier: str) -> None:
+        hits.append(tier)
+
+    monkeypatch.setattr(
+        "nexus.bricks.mcp.middleware_ratelimit._record_rate_limit_hit",
+        fake_record,
+        raising=False,
+    )
+
+    client = TestClient(app)
+    for _ in range(3):
+        assert client.post("/mcp").status_code == 200
+    assert client.post("/mcp").status_code == 429
+    assert hits == ["anonymous"]
+```
+
+- [ ] **Step 2: Run the new rate-limit test and verify it fails**
+
+Run:
+
+```bash
+pytest tests/unit/bricks/mcp/test_middleware_ratelimit.py::test_429_records_rate_limit_hit_tier -v
+```
+
+Expected: `FAILED` because `_record_rate_limit_hit` is not called.
+
+- [ ] **Step 3: Add the best-effort counter helper**
+
+In `src/nexus/bricks/mcp/middleware_ratelimit.py`, add this helper above `_MCPRateLimitMiddleware`:
+
+```python
+async def _record_rate_limit_hit(tier: str) -> None:
+    """Best-effort Redis counter for `nexus hub status --detail`."""
+    url = os.environ.get("NEXUS_REDIS_URL") or os.environ.get("DRAGONFLY_URL")
+    if not url or url == "memory://":
+        return
+    try:
+        import redis.asyncio as redis
+    except ImportError:
+        return
+
+    client = redis.from_url(url)
+    try:
+        epoch_min = int(time.time()) // 60
+        key = f"nexus:hub:rate_limit:{tier}:{epoch_min}"
+        await client.incr(key)
+        await client.expire(key, 600)
+    except Exception:  # noqa: BLE001
+        return
+    finally:
+        await client.close()
+```
+
+- [ ] **Step 4: Call the helper when rejecting a request**
+
+In `_MCPRateLimitMiddleware.dispatch`, inside the `if not allowed:` branch and before `return JSONResponse(...)`, add:
+
+```python
+            await _record_rate_limit_hit(tier)
+```
+
+- [ ] **Step 5: Run rate-limit tests**
+
+Run:
+
+```bash
+pytest tests/unit/bricks/mcp/test_middleware_ratelimit.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit Task 5**
+
+```bash
+git add src/nexus/bricks/mcp/middleware_ratelimit.py tests/unit/bricks/mcp/test_middleware_ratelimit.py
+git commit -m "feat(#3874): record hub rate-limit hits by tier"
+```
+
+## Task 6: Add Local Search Metadata For Detail Output
+
+**Files:**
+- Modify: `tests/unit/cli/test_hub.py`
+- Modify: `src/nexus/cli/commands/hub.py`
+
+- [ ] **Step 1: Add a failing test for Zoekt index metadata**
+
+Add this test near the status helper tests:
+
+```python
+def test_collect_search_detail_reports_zoekt_size_and_latest_mtime(monkeypatch, tmp_path):
+    import os
+    from datetime import UTC, datetime
+
+    import nexus.cli.commands.hub as hub_module
+
+    base = tmp_path / "zoekt"
+    zone_dir = base / "eng"
+    zone_dir.mkdir(parents=True)
+    first = zone_dir / "one.idx"
+    second = zone_dir / "two.idx"
+    first.write_bytes(b"a" * 10)
+    second.write_bytes(b"b" * 20)
+    latest_ts = datetime(2026, 5, 5, 14, 18, tzinfo=UTC).timestamp()
+    older_ts = latest_ts - 60
+    os.utime(first, (older_ts, older_ts))
+    os.utime(second, (latest_ts, latest_ts))
+
+    monkeypatch.setenv("NEXUS_ZOEKT_INDEX_DIR", str(base))
+
+    detail = hub_module._collect_search_detail(["eng", "ops"])
+
+    assert detail["zones"][0]["zone_id"] == "eng"
+    assert detail["zones"][0]["zoekt_index_size_bytes"] == 30
+    assert detail["zones"][0]["zoekt_index_size_display"] == "30 B"
+    assert detail["zones"][0]["zoekt_last_indexed"] == datetime.fromtimestamp(
+        latest_ts, tz=UTC
+    ).isoformat()
+    assert detail["zones"][0]["last_indexed"] == detail["zones"][0]["zoekt_last_indexed"]
+    assert detail["zones"][0]["txtai_queue_depth"] is None
+    assert detail["zones"][1]["zone_id"] == "ops"
+    assert detail["zones"][1]["zoekt_index_size_bytes"] is None
+```
+
+- [ ] **Step 2: Run the search metadata test and verify it fails**
+
+Run:
+
+```bash
+pytest tests/unit/cli/test_hub.py::test_collect_search_detail_reports_zoekt_size_and_latest_mtime -v
+```
+
+Expected: `FAILED` because `_collect_search_detail` is still a stub.
+
+- [ ] **Step 3: Import `Path`**
+
+At the top of `src/nexus/cli/commands/hub.py`, add:
+
+```python
+from pathlib import Path
+```
+
+- [ ] **Step 4: Replace search detail stub with local filesystem implementation**
+
+Replace `_collect_search_detail` with:
+
+```python
+def _format_bytes(num_bytes: int | None) -> str | None:
+    if num_bytes is None:
+        return None
+    units = ("B", "KiB", "MiB", "GiB")
+    value = float(num_bytes)
+    for unit in units:
+        if value < 1024 or unit == units[-1]:
+            if unit == "B":
+                return f"{int(value)} B"
+            return f"{value:.1f} {unit}"
+        value /= 1024
+    return f"{num_bytes} B"
+
+
+def _zone_index_path(base: Path, zone_id: str) -> Path | None:
+    direct = base / zone_id
+    if direct.exists():
+        return direct
+    if not base.exists() or not base.is_dir():
+        return None
+    matches = sorted(
+        child
+        for child in base.iterdir()
+        if child.name.startswith(f"{zone_id}.") or child.name.startswith(f"{zone_id}-")
+    )
+    return matches[0] if len(matches) == 1 else None
+
+
+def _index_path_stats(path: Path) -> tuple[int | None, str | None]:
+    try:
+        if path.is_file():
+            stat = path.stat()
+            return stat.st_size, datetime.fromtimestamp(stat.st_mtime, tz=UTC).isoformat()
+        total = 0
+        latest: float | None = None
+        for child in path.rglob("*"):
+            if not child.is_file():
+                continue
+            stat = child.stat()
+            total += stat.st_size
+            latest = stat.st_mtime if latest is None else max(latest, stat.st_mtime)
+        if latest is None:
+            return 0, None
+        return total, datetime.fromtimestamp(latest, tz=UTC).isoformat()
+    except OSError:
+        return None, None
+
+
+def _collect_search_detail(zone_ids: list[str]) -> dict[str, Any]:
+    base = Path(os.environ.get("NEXUS_ZOEKT_INDEX_DIR", "/app/data/.zoekt-index"))
+    rows: list[dict[str, Any]] = []
+    for zone_id in zone_ids:
+        zone_path = _zone_index_path(base, zone_id)
+        size_bytes: int | None = None
+        zoekt_last_indexed: str | None = None
+        if zone_path is not None:
+            size_bytes, zoekt_last_indexed = _index_path_stats(zone_path)
+        rows.append(
+            {
+                "zone_id": zone_id,
+                "zoekt_index_size_bytes": size_bytes,
+                "zoekt_index_size_display": _format_bytes(size_bytes),
+                "zoekt_last_indexed": zoekt_last_indexed,
+                "txtai_queue_depth": None,
+                "last_indexed": zoekt_last_indexed,
+            }
+        )
+    return {"zones": rows}
+```
+
+- [ ] **Step 5: Run the search metadata test**
+
+Run:
+
+```bash
+pytest tests/unit/cli/test_hub.py::test_collect_search_detail_reports_zoekt_size_and_latest_mtime -v
+```
+
+Expected: `PASSED`.
+
+- [ ] **Step 6: Run all status tests**
+
+Run:
+
+```bash
+pytest tests/unit/cli/test_hub.py -v -k status
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 7: Commit Task 6**
+
+```bash
+git add src/nexus/cli/commands/hub.py tests/unit/cli/test_hub.py
+git commit -m "feat(#3874): include local search metadata in hub status detail"
+```
+
+## Task 7: Final Verification
+
+**Files:**
+- Verify only.
+
+- [ ] **Step 1: Run focused CLI tests**
+
+Run:
+
+```bash
+pytest tests/unit/cli/test_hub.py -v -k status
+```
+
+Expected: all selected tests pass.
+
+- [ ] **Step 2: Run audit metrics tests**
+
+Run:
+
+```bash
+pytest tests/unit/bricks/mcp/test_middleware_audit_metrics.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 3: Run rate-limit tests**
+
+Run:
+
+```bash
+pytest tests/unit/bricks/mcp/test_middleware_ratelimit.py -v
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Run pre-commit on touched files**
+
+Run:
+
+```bash
+pre-commit run --files \
+  src/nexus/cli/commands/hub.py \
+  src/nexus/bricks/mcp/middleware_audit.py \
+  src/nexus/bricks/mcp/middleware_ratelimit.py \
+  tests/unit/cli/test_hub.py \
+  tests/unit/bricks/mcp/test_middleware_audit_metrics.py \
+  tests/unit/bricks/mcp/test_middleware_ratelimit.py
+```
+
+Expected: all hooks pass.
+
+- [ ] **Step 5: Inspect final diff**
+
+Run:
+
+```bash
+git diff --stat HEAD~6..HEAD
+git status --short
+```
+
+Expected: diff includes only the planned files, and `git status --short` is empty.
+
+## Self-Review Notes
+
+- Spec coverage: the plan covers `--detail`, default output preservation, per-zone Redis counters, per-token `last_used_at`, rate-limit hits by tier, local Zoekt metadata, txtai `n/a`, and fail-soft missing detail data.
+- Scope: no migrations, no HTTP status dependency, no Prometheus endpoint, and no remote admin status.
+- Type consistency: detail payload uses `zones`, `tokens_detail`, `rate_limits`, and `search` consistently across tests and helpers.

--- a/docs/superpowers/specs/2026-05-05-issue-3874-hub-status-detail-design.md
+++ b/docs/superpowers/specs/2026-05-05-issue-3874-hub-status-detail-design.md
@@ -1,0 +1,255 @@
+# Issue #3874 - Hub Status Detail Design
+
+**Date**: 2026-05-05
+**Issue**: [#3874](https://github.com/nexi-lab/nexus/issues/3874) - feat: richer nexus hub status output
+**Follows**: [#3784](https://github.com/nexi-lab/nexus/issues/3784) - hub mode MVP
+
+## Context
+
+Issue #3784 shipped `nexus hub status` as a local admin diagnostic for hub hosts. The command currently reports endpoint, profile, Postgres health, Redis health, token counts, active clients, and 5-minute QPS. It reads Postgres directly via `get_session_factory()` and reads lightweight Redis counters written by `middleware_audit._record_metrics`.
+
+Issue #3874 asks for richer operator detail without changing the default output:
+
+- Zoekt index size and last-indexed timestamp per zone.
+- txtai embed queue depth.
+- Per-zone breakdown of active clients and QPS.
+- Per-token last-seen, already stored as `APIKeyModel.last_used_at`.
+- Rate-limit hit counts per tier.
+
+## Decision
+
+Add `nexus hub status --detail` and keep the existing `nexus hub status` output unchanged.
+
+The detailed view stays local-first: it reads Postgres, Redis, and local filesystem/index metadata from the hub host. It does not depend on the MCP or API HTTP endpoint being healthy. This preserves `hub status` as a diagnostic command instead of turning it into a client of the service it is diagnosing.
+
+## Non-goals
+
+1. Remote admin/status queries over HTTP.
+2. Prometheus metrics or a new `/metrics` endpoint.
+3. New database tables for historical status data.
+4. Exact persistent socket counting for MCP HTTP. Existing active-client metrics remain behavioral: clients seen in recent request counters.
+5. A full search daemon control plane. Search fields are best-effort status facts surfaced through the hub CLI.
+
+## CLI
+
+Existing command:
+
+```bash
+nexus hub status [--json]
+```
+
+New flag:
+
+```bash
+nexus hub status --detail [--json]
+```
+
+Default, non-detail text output remains unchanged:
+
+```text
+endpoint:    http://0.0.0.0:8081/mcp
+profile:     full
+postgres:    ok
+redis:       ok
+tokens:      12 active, 3 revoked
+connections: 7
+qps (5m):    4.2
+```
+
+Detailed text output appends sections after the existing lines:
+
+```text
+
+zones:
+zone        clients  qps_5m
+eng         5        2.10
+ops         2        0.80
+
+tokens:
+key_id        name      zones    admin  last_seen
+6a1f...       alice     eng,ops  no     2026-05-05T14:20:10
+
+rate limits:
+tier           hits_5m
+anonymous      3
+authenticated  12
+premium        0
+
+search:
+zone        zoekt_size  zoekt_last_indexed  txtai_queue_depth  last_indexed
+eng         184.2 MiB   2026-05-05T14:18:00 n/a                2026-05-05T14:18:00
+ops         n/a         n/a                 n/a                n/a
+```
+
+The exact table widths follow the existing `format_table` helper.
+
+## JSON Shape
+
+Without `--detail`, the JSON payload is unchanged:
+
+```json
+{
+  "endpoint": "http://0.0.0.0:8081/mcp",
+  "profile": "full",
+  "postgres": "ok",
+  "redis": "ok",
+  "tokens": {"active": 12, "revoked": 3},
+  "connections": 7,
+  "qps_5m": 4.2
+}
+```
+
+With `--detail`, the payload gains additive fields:
+
+```json
+{
+  "detail": true,
+  "zones": [
+    {"zone_id": "eng", "clients": 5, "qps_5m": 2.1},
+    {"zone_id": "ops", "clients": 2, "qps_5m": 0.8}
+  ],
+  "tokens_detail": [
+    {
+      "key_id": "6a1f...",
+      "name": "alice",
+      "zones": ["eng", "ops"],
+      "admin": false,
+      "created": "2026-05-05T13:00:00",
+      "last_seen": "2026-05-05T14:20:10",
+      "revoked": false,
+      "revoked_at": null
+    }
+  ],
+  "rate_limits": {
+    "window_seconds": 300,
+    "hits_by_tier": {"anonymous": 3, "authenticated": 12, "premium": 0}
+  },
+  "search": {
+    "zones": [
+      {
+        "zone_id": "eng",
+        "zoekt_index_size_bytes": 193147208,
+        "zoekt_last_indexed": "2026-05-05T14:18:00",
+        "txtai_queue_depth": null,
+        "last_indexed": "2026-05-05T14:18:00"
+      }
+    ]
+  }
+}
+```
+
+All detail fields are best-effort. Missing Redis/search data is represented as `null` in JSON and `n/a` in text.
+
+## Data Sources
+
+### Postgres
+
+`hub status --detail` reuses the same session opened by the base command and reads:
+
+- token counts from `APIKeyModel.revoked`
+- token detail rows from `APIKeyModel`
+- token zones from `APIKeyZoneModel`
+- active zones from `ZoneModel`
+
+Token rows include `last_seen` sourced directly from `APIKeyModel.last_used_at`.
+
+Postgres remains the only hard health dependency. If the DB is unavailable, the command still emits a parseable payload with `postgres: err` and exits 2, matching the current behavior.
+
+### Redis
+
+Existing aggregate counters remain:
+
+- `nexus:hub:qps:<epoch-minute>`
+- `nexus:hub:active:<epoch-minute>`
+
+Add per-zone counters to `middleware_audit._record_metrics`:
+
+- `nexus:hub:qps:zone:<zone_id>:<epoch-minute>`
+- `nexus:hub:active:zone:<zone_id>:<epoch-minute>`
+
+Each key gets the same 10-minute TTL as the existing counters. The zone identifier comes from `record["zone_id"]` when present; otherwise the middleware skips only the per-zone counters and still records aggregate counters.
+
+Add rate-limit breach counters to `middleware_ratelimit._MCPRateLimitMiddleware` when a request is rejected:
+
+- `nexus:hub:rate_limit:<tier>:<epoch-minute>`
+
+These counters use the same Redis/Dragonfly URL as the rate limiter and expire after 10 minutes. If the limiter uses memory storage or Redis is unavailable, counters are best-effort and may be `n/a` in status output.
+
+### Search/Index Metadata
+
+Search detail is intentionally local and best-effort.
+
+Zoekt:
+
+- Use `NEXUS_ZOEKT_INDEX_DIR` when set; otherwise use the local default already used by `ZoektIndexManager` (`/app/data/.zoekt-index`).
+- For each active zone, look for a zone-specific subdirectory or file prefix when present.
+- If no per-zone path exists, report aggregate index metadata under a synthetic `all` zone only when it can be computed without guessing.
+- `zoekt_index_size_bytes` is the recursive file size.
+- `zoekt_last_indexed` is the newest mtime in the relevant index path.
+
+txtai:
+
+- The current repo does not expose a durable, CLI-readable txtai/embed queue depth.
+- Initial implementation reports the field explicitly as `null`/`n/a`.
+- Do not add a new database table or call the HTTP API to satisfy this field. A future search-daemon metric can populate the same JSON field without changing the CLI contract.
+
+Last indexed:
+
+- Prefer an existing zone-specific index timestamp if one exists.
+- Otherwise use the best available local index mtime.
+- Otherwise report `null`/`n/a`.
+
+## Error Handling
+
+- Postgres unavailable: same as today, output includes `postgres: err`, exit code 2.
+- Redis unavailable: output includes `redis: n/a`; detail Redis fields are `null`/`n/a`; exit code remains 0 if Postgres is healthy.
+- Search metadata unavailable: search fields are `null`/`n/a`; exit code remains 0 if Postgres is healthy.
+- Malformed Redis values: ignore bad values for that key and continue.
+- Permission errors while walking index directories: mark the affected zone as unavailable and continue.
+
+## Implementation Boundaries
+
+Most code stays in `src/nexus/cli/commands/hub.py`:
+
+- Add `--detail` option to `hub_status`.
+- Split payload construction into helpers so base and detail payloads can be tested without duplicating command logic.
+- Add helper to fetch token rows and token-zone mappings in batched queries.
+- Add helper to read Redis aggregate, per-zone, and rate-limit counters.
+- Add helper to compute local index directory size and latest mtime.
+
+Middleware changes are small and metric-only:
+
+- `src/nexus/bricks/mcp/middleware_audit.py`: write per-zone QPS/active-client counters.
+- `src/nexus/bricks/mcp/middleware_ratelimit.py`: write per-tier 429 counters on rejection.
+
+No migration is required.
+
+## Testing
+
+Unit tests:
+
+1. Existing `hub status --json` output remains unchanged without `--detail`.
+2. `hub status --detail --json` includes `zones`, `tokens_detail`, `rate_limits`, and `search`.
+3. Per-token `last_seen` reflects `APIKeyModel.last_used_at`.
+4. Per-zone Redis counters are aggregated over the same 5-minute window as aggregate QPS.
+5. Rate-limit counters are incremented by tier when the middleware returns 429.
+6. Search metadata helper reports size and latest mtime for a temporary index directory.
+7. Detail mode degrades to `null`/`n/a` when Redis or search metadata is missing.
+8. Postgres error behavior and exit code 2 remain unchanged.
+
+Target commands:
+
+```bash
+pytest tests/unit/cli/test_hub.py -v -k status
+pytest tests/unit/bricks/mcp/test_middleware_audit_metrics.py -v
+pytest tests/unit/bricks/mcp/test_middleware_ratelimit.py -v
+```
+
+## Acceptance Mapping
+
+- `nexus hub status --detail` shows requested richer data: implemented through additive detail sections and JSON fields.
+- Default `nexus hub status` output is unchanged: protected by an explicit unit test.
+- Per-token last-seen: sourced from `APIKeyModel.last_used_at`.
+- Per-zone active clients and QPS: sourced from new per-zone Redis counters.
+- Rate-limit hit counts per tier: sourced from new best-effort Redis counters on 429.
+- Zoekt/txtai metadata: surfaced where local sources exist, otherwise explicit `n/a` instead of silently omitting the fields.

--- a/nexus-stack.yml
+++ b/nexus-stack.yml
@@ -80,8 +80,8 @@ services:
       NEXUS_PORT: "2026"
       NEXUS_DATA_DIR: /app/data
       NEXUS_MODE: standalone
-      # Rate limiting uses Dragonfly — disable if connection issues cause 500s
-      NEXUS_RATE_LIMIT_ENABLED: ${NEXUS_RATE_LIMIT_ENABLED:-true}
+      # Rate limiting uses Dragonfly when explicitly enabled.
+      NEXUS_RATE_LIMIT_ENABLED: ${NEXUS_RATE_LIMIT_ENABLED:-false}
       # Database
       NEXUS_DATABASE_URL: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-nexus}@postgres:5432/${POSTGRES_DB:-nexus}
       TOKEN_MANAGER_DB: postgresql://${POSTGRES_USER:-postgres}:${POSTGRES_PASSWORD:-nexus}@postgres:5432/${POSTGRES_DB:-nexus}

--- a/scripts/check_api_key.py
+++ b/scripts/check_api_key.py
@@ -41,12 +41,43 @@ def check_api_key(database_url: str, api_key: str) -> str:
         key_hash = DatabaseAPIKeyAuth._hash_key(api_key)
 
         with SessionFactory() as session:
-            result = session.execute(
-                text("SELECT 1 FROM api_keys WHERE key_hash = :hash"),
+            row = session.execute(
+                text(
+                    """
+                    SELECT key_id, zone_id, is_admin, revoked
+                    FROM api_keys
+                    WHERE key_hash = :hash
+                    """
+                ),
                 {"hash": key_hash},
             ).fetchone()
 
-            return "EXISTS" if result else "MISSING"
+            if not row or int(row.revoked or 0) != 0:
+                return "MISSING"
+
+            if row.zone_id is not None:
+                matching_zone = session.execute(
+                    text(
+                        """
+                        SELECT 1
+                        FROM api_key_zones
+                        WHERE key_id = :key_id AND zone_id = :zone_id
+                        """
+                    ),
+                    {"key_id": row.key_id, "zone_id": row.zone_id},
+                ).fetchone()
+                if not matching_zone:
+                    return "MISSING"
+
+            if int(row.is_admin or 0) == 0:
+                any_zone = session.execute(
+                    text("SELECT 1 FROM api_key_zones WHERE key_id = :key_id"),
+                    {"key_id": row.key_id},
+                ).fetchone()
+                if not any_zone:
+                    return "MISSING"
+
+            return "EXISTS"
     except Exception:
         return "MISSING"
 

--- a/scripts/create_admin_key.py
+++ b/scripts/create_admin_key.py
@@ -14,8 +14,6 @@ Output:
     Prints "API Key: <key>" on success
 """
 
-import hashlib
-import hmac
 import os
 import sys
 from datetime import UTC, datetime, timedelta
@@ -31,7 +29,8 @@ from sqlalchemy.orm import sessionmaker  # noqa: E402
 
 from nexus.bricks.auth.providers.database_key import DatabaseAPIKeyAuth  # noqa: E402
 from nexus.bricks.rebac.entity_registry import EntityRegistry  # noqa: E402
-from nexus.storage.models import APIKeyModel  # noqa: E402
+from nexus.storage.models import APIKeyModel, APIKeyZoneModel  # noqa: E402
+from nexus.storage.zone_bootstrap import ensure_root_zone  # noqa: E402
 
 
 def create_admin_key(
@@ -57,6 +56,7 @@ def create_admin_key(
     try:
         engine = create_engine(database_url)
         SessionFactory = sessionmaker(bind=engine)
+        ensure_root_zone(SessionFactory)
 
         # Register user in entity registry (for agent permission inheritance)
         # Skip if NEXUS_SKIP_PERMISSIONS is set to true
@@ -80,18 +80,26 @@ def create_admin_key(
 
             if custom_key:
                 # Use custom API key from environment
-                # Hash the key for storage (same as DatabaseAPIKeyAuth does)
-                # Uses HMAC-SHA256 with salt (same as nexus.server.auth.database_key)
-                HMAC_SALT = "nexus-api-key-v1"
-                key_hash = hmac.new(
-                    HMAC_SALT.encode("utf-8"), custom_key.encode("utf-8"), hashlib.sha256
-                ).hexdigest()
+                key_hash = DatabaseAPIKeyAuth._hash_key(custom_key)
 
                 # Check if this specific key already exists (by hash)
                 existing = session.execute(
                     select(APIKeyModel).where(APIKeyModel.key_hash == key_hash)
                 ).scalar_one_or_none()
                 if existing:
+                    if existing.zone_id is not None:
+                        existing.zone_id = None
+                    if zone_id:
+                        zone_row = session.get(APIKeyZoneModel, (existing.key_id, zone_id))
+                        if zone_row is None:
+                            session.add(
+                                APIKeyZoneModel(
+                                    key_id=existing.key_id,
+                                    zone_id=zone_id,
+                                    permissions="rw",
+                                )
+                            )
+                    session.commit()
                     print(f"API Key: {custom_key}", file=sys.stdout)
                     print(
                         f"Custom API key already registered for user: {admin_user}",
@@ -104,7 +112,7 @@ def create_admin_key(
                         user_id=admin_user,
                         key_hash=key_hash,
                         name="Admin key (from environment)",
-                        zone_id=zone_id,
+                        zone_id=None,
                         is_admin=1,  # PostgreSQL expects integer, not boolean
                         subject_type="user",
                         subject_id=admin_user,
@@ -114,6 +122,15 @@ def create_admin_key(
                         expires_at=expires_at,
                     )
                     session.add(api_key)
+                    session.flush()
+                    if zone_id:
+                        session.add(
+                            APIKeyZoneModel(
+                                key_id=api_key.key_id,
+                                zone_id=zone_id,
+                                permissions="rw",
+                            )
+                        )
                     session.commit()
 
                     print(f"API Key: {custom_key}", file=sys.stdout)

--- a/src/nexus/bricks/mcp/middleware_audit.py
+++ b/src/nexus/bricks/mcp/middleware_audit.py
@@ -73,6 +73,16 @@ async def _record_metrics(record: dict[str, Any]) -> None:
         if not isinstance(_sadd_r, int):
             await _sadd_r
         await client.expire(active_key, 600)
+        zone_id = record.get("zone_id")
+        if isinstance(zone_id, str) and zone_id:
+            zone_qps_key = f"nexus:hub:qps:zone:{zone_id}:{epoch_min}"
+            zone_active_key = f"nexus:hub:active:zone:{zone_id}:{epoch_min}"
+            await client.incr(zone_qps_key)
+            await client.expire(zone_qps_key, 600)
+            _zone_sadd_r = client.sadd(zone_active_key, member)
+            if not isinstance(_zone_sadd_r, int):
+                await _zone_sadd_r
+            await client.expire(zone_active_key, 600)
     except Exception:  # noqa: BLE001 — fire-and-forget
         return
     finally:

--- a/src/nexus/bricks/mcp/middleware_ratelimit.py
+++ b/src/nexus/bricks/mcp/middleware_ratelimit.py
@@ -26,6 +26,7 @@ import hashlib
 import logging
 import os
 import time
+from contextlib import suppress
 from functools import lru_cache
 from typing import Any
 
@@ -138,8 +139,9 @@ async def _record_rate_limit_hit(tier: str) -> None:
     except ImportError:
         return
 
-    client = redis.from_url(url)
+    client = None
     try:
+        client = redis.from_url(url)
         epoch_min = int(time.time()) // 60
         key = f"nexus:hub:rate_limit:{tier}:{epoch_min}"
         await client.incr(key)
@@ -147,7 +149,9 @@ async def _record_rate_limit_hit(tier: str) -> None:
     except Exception:  # noqa: BLE001
         return
     finally:
-        await client.close()
+        if client is not None:
+            with suppress(Exception):
+                await client.close()
 
 
 class _MCPRateLimitMiddleware(BaseHTTPMiddleware):

--- a/src/nexus/bricks/mcp/middleware_ratelimit.py
+++ b/src/nexus/bricks/mcp/middleware_ratelimit.py
@@ -22,6 +22,7 @@ wrapper.
 
 from __future__ import annotations
 
+import asyncio
 import hashlib
 import logging
 import os
@@ -128,6 +129,14 @@ def _dynamic_limit(request: Request) -> str:
 # Custom middleware
 # ---------------------------------------------------------------------------
 
+_RATE_LIMIT_METRIC_TTL_SECONDS = 600
+_RATE_LIMIT_METRIC_TIMEOUT_SECONDS = 2
+
+
+async def _write_rate_limit_hit(client: Any, key: str) -> None:
+    await client.incr(key)
+    await client.expire(key, _RATE_LIMIT_METRIC_TTL_SECONDS)
+
 
 async def _record_rate_limit_hit(tier: str) -> None:
     """Best-effort Redis counter for `nexus hub status --detail`."""
@@ -141,11 +150,17 @@ async def _record_rate_limit_hit(tier: str) -> None:
 
     client = None
     try:
-        client = redis.from_url(url)
+        client = redis.from_url(
+            url,
+            socket_connect_timeout=_RATE_LIMIT_METRIC_TIMEOUT_SECONDS,
+            socket_timeout=_RATE_LIMIT_METRIC_TIMEOUT_SECONDS,
+        )
         epoch_min = int(time.time()) // 60
         key = f"nexus:hub:ratelimit:tier:{tier}:{epoch_min}"
-        await client.incr(key)
-        await client.expire(key, 600)
+        await asyncio.wait_for(
+            _write_rate_limit_hit(client, key),
+            timeout=_RATE_LIMIT_METRIC_TIMEOUT_SECONDS,
+        )
     except Exception:  # noqa: BLE001
         return
     finally:

--- a/src/nexus/bricks/mcp/middleware_ratelimit.py
+++ b/src/nexus/bricks/mcp/middleware_ratelimit.py
@@ -143,7 +143,7 @@ async def _record_rate_limit_hit(tier: str) -> None:
     try:
         client = redis.from_url(url)
         epoch_min = int(time.time()) // 60
-        key = f"nexus:hub:rate_limit:{tier}:{epoch_min}"
+        key = f"nexus:hub:ratelimit:tier:{tier}:{epoch_min}"
         await client.incr(key)
         await client.expire(key, 600)
     except Exception:  # noqa: BLE001

--- a/src/nexus/bricks/mcp/middleware_ratelimit.py
+++ b/src/nexus/bricks/mcp/middleware_ratelimit.py
@@ -128,6 +128,28 @@ def _dynamic_limit(request: Request) -> str:
 # ---------------------------------------------------------------------------
 
 
+async def _record_rate_limit_hit(tier: str) -> None:
+    """Best-effort Redis counter for `nexus hub status --detail`."""
+    url = os.environ.get("NEXUS_REDIS_URL") or os.environ.get("DRAGONFLY_URL")
+    if not url or url == "memory://":
+        return
+    try:
+        import redis.asyncio as redis
+    except ImportError:
+        return
+
+    client = redis.from_url(url)
+    try:
+        epoch_min = int(time.time()) // 60
+        key = f"nexus:hub:rate_limit:{tier}:{epoch_min}"
+        await client.incr(key)
+        await client.expire(key, 600)
+    except Exception:  # noqa: BLE001
+        return
+    finally:
+        await client.close()
+
+
 class _MCPRateLimitMiddleware(BaseHTTPMiddleware):
     """ASGI rate-limit middleware driven directly by the ``limits`` library.
 
@@ -164,6 +186,7 @@ class _MCPRateLimitMiddleware(BaseHTTPMiddleware):
         if not allowed:
             stats = self._strategy.get_window_stats(limit_item, key)
             retry_after = max(0, int(stats.reset_time - time.time()))
+            await _record_rate_limit_hit(tier)
             return JSONResponse(
                 status_code=429,
                 content={

--- a/src/nexus/cli/commands/hub.py
+++ b/src/nexus/cli/commands/hub.py
@@ -835,25 +835,46 @@ def _index_path_stats(path: Path) -> tuple[int | None, str | None]:
     return total_size, last_indexed
 
 
+def _zoekt_index_base() -> Path:
+    raw = (
+        os.environ.get("NEXUS_ZOEKT_INDEX_DIR")
+        or os.environ.get("ZOEKT_INDEX_DIR")
+        or "/app/data/.zoekt-index"
+    )
+    return Path(raw)
+
+
+def _search_detail_row(
+    zone_id: str,
+    size_bytes: int | None,
+    last_indexed: str | None,
+) -> dict[str, Any]:
+    return {
+        "zone_id": zone_id,
+        "zoekt_index_size_bytes": size_bytes,
+        "zoekt_index_size_display": _format_bytes(size_bytes),
+        "zoekt_last_indexed": last_indexed,
+        "txtai_queue_depth": None,
+        "last_indexed": last_indexed,
+    }
+
+
 def _collect_search_detail(zone_ids: list[str]) -> dict[str, Any]:
-    base = Path(os.environ.get("NEXUS_ZOEKT_INDEX_DIR", "/app/data/.zoekt-index"))
+    base = _zoekt_index_base()
     zones = []
+    matched_zone_index = False
     for zone_id in zone_ids:
         index_path = _zone_index_path(base, zone_id)
         size_bytes: int | None = None
         last_indexed: str | None = None
         if index_path is not None:
+            matched_zone_index = True
             size_bytes, last_indexed = _index_path_stats(index_path)
-        zones.append(
-            {
-                "zone_id": zone_id,
-                "zoekt_index_size_bytes": size_bytes,
-                "zoekt_index_size_display": _format_bytes(size_bytes),
-                "zoekt_last_indexed": last_indexed,
-                "txtai_queue_depth": None,
-                "last_indexed": last_indexed,
-            }
-        )
+        zones.append(_search_detail_row(zone_id, size_bytes, last_indexed))
+    if not matched_zone_index and base.exists():
+        size_bytes, last_indexed = _index_path_stats(base)
+        if size_bytes is not None:
+            zones.append(_search_detail_row("all", size_bytes, last_indexed))
     return {"zones": zones}
 
 

--- a/src/nexus/cli/commands/hub.py
+++ b/src/nexus/cli/commands/hub.py
@@ -549,11 +549,15 @@ def hub_status(as_json: bool, detail: bool) -> None:
     """Show hub health: postgres, redis, tokens, connections, qps."""
     import json as _json
 
-    payload = _base_status_payload()
+    postgres_status = _collect_postgres_status(detail=detail)
+    payload = _base_status_payload(postgres_status)
     if detail:
-        redis_detail = _read_redis_detail_stats([])
+        zone_ids = postgres_status["zone_ids"]
+        redis_detail = _read_redis_detail_stats(zone_ids)
         payload["detail"] = True
-        payload.update(_collect_status_detail([], [], redis_detail))
+        payload.update(
+            _collect_status_detail(zone_ids, postgres_status["tokens_detail"], redis_detail)
+        )
 
     if as_json:
         click.echo(_json.dumps(payload, indent=2))
@@ -576,9 +580,64 @@ def _display_status_value(value: Any) -> str:
     return "n/a" if value is None else str(value)
 
 
-def _collect_postgres_status() -> dict[str, Any]:
+def _iso_or_none(dt: datetime | None) -> str | None:
+    return dt.isoformat() if dt else None
+
+
+def _collect_zone_ids(session: Any) -> list[str]:
+    rows = (
+        session.execute(
+            select(ZoneModel.zone_id)
+            .where(ZoneModel.phase == "Active")
+            .where(ZoneModel.deleted_at.is_(None))
+            .order_by(ZoneModel.zone_id.asc())
+        )
+        .scalars()
+        .all()
+    )
+    return [str(zone_id) for zone_id in rows]
+
+
+def _token_zones_by_key(session: Any, key_ids: list[str]) -> dict[str, list[str]]:
+    if not key_ids:
+        return {}
+    rows = session.execute(
+        select(APIKeyZoneModel.key_id, APIKeyZoneModel.zone_id)
+        .where(APIKeyZoneModel.key_id.in_(key_ids))
+        .order_by(APIKeyZoneModel.granted_at.asc(), APIKeyZoneModel.zone_id.asc())
+    ).all()
+    zones_by_key: dict[str, list[str]] = {key_id: [] for key_id in key_ids}
+    for key_id, zone_id in rows:
+        zones_by_key.setdefault(key_id, []).append(zone_id)
+    return zones_by_key
+
+
+def _collect_token_detail(session: Any) -> list[dict[str, Any]]:
+    rows = (
+        session.execute(select(APIKeyModel).order_by(APIKeyModel.created_at.desc())).scalars().all()
+    )
+    key_ids = [row.key_id for row in rows]
+    zones_by_key = _token_zones_by_key(session, key_ids)
+    return [
+        {
+            "key_id": row.key_id,
+            "name": row.name,
+            "zones": zones_by_key.get(row.key_id, []),
+            "admin": bool(row.is_admin),
+            "created": _iso_or_none(row.created_at),
+            "last_seen": _iso_or_none(row.last_used_at),
+            "revoked": bool(row.revoked),
+            "revoked_at": _iso_or_none(row.revoked_at),
+        }
+        for row in rows
+    ]
+
+
+def _collect_postgres_status(detail: bool = False) -> dict[str, Any]:
     pg_state = "ok"
     active = revoked = 0
+    zone_ids: list[str] = []
+    tokens_detail: list[dict[str, Any]] = []
     try:
         factory = get_session_factory()
         with factory() as session:
@@ -594,23 +653,25 @@ def _collect_postgres_status() -> dict[str, Any]:
                 ).scalar()
                 or 0
             )
+            if detail:
+                zone_ids = _collect_zone_ids(session)
+                tokens_detail = _collect_token_detail(session)
     except Exception:  # noqa: BLE001
         pg_state = "err"
     return {
         "postgres": pg_state,
         "tokens": {"active": int(active), "revoked": int(revoked)},
-        "zone_ids": [],
-        "tokens_detail": [],
+        "zone_ids": zone_ids,
+        "tokens_detail": tokens_detail,
     }
 
 
-def _base_status_payload() -> dict[str, Any]:
+def _base_status_payload(postgres_status: dict[str, Any]) -> dict[str, Any]:
     host = os.environ.get("NEXUS_MCP_HOST", "0.0.0.0")
     port = os.environ.get("NEXUS_MCP_PORT", "8081")
     profile = os.environ.get("NEXUS_PROFILE", "full")
     endpoint = f"http://{host}:{port}/mcp"
 
-    postgres_status = _collect_postgres_status()
     redis_stats = _read_redis_stats()
     return {
         "endpoint": endpoint,

--- a/src/nexus/cli/commands/hub.py
+++ b/src/nexus/cli/commands/hub.py
@@ -11,6 +11,7 @@ import os
 import time
 from contextlib import suppress
 from datetime import UTC, datetime
+from pathlib import Path
 from typing import Any
 
 import click
@@ -777,20 +778,83 @@ def _collect_status_detail(
     }
 
 
+def _format_bytes(num_bytes: int | None) -> str | None:
+    if num_bytes is None:
+        return None
+    if num_bytes < 1024:
+        return f"{num_bytes} B"
+    value = float(num_bytes)
+    for unit in ("KiB", "MiB", "GiB"):
+        value /= 1024.0
+        if value < 1024.0 or unit == "GiB":
+            return f"{value:.1f} {unit}"
+    return None
+
+
+def _zone_index_path(base: Path, zone_id: str) -> Path | None:
+    direct = base / zone_id
+    try:
+        if direct.exists():
+            return direct
+        if not base.is_dir():
+            return None
+        matches = [
+            child
+            for child in base.iterdir()
+            if child.name.startswith(f"{zone_id}.") or child.name.startswith(f"{zone_id}-")
+        ]
+    except OSError:
+        return None
+    return matches[0] if len(matches) == 1 else None
+
+
+def _index_path_stats(path: Path) -> tuple[int | None, str | None]:
+    try:
+        if path.is_file():
+            stat = path.stat()
+            return stat.st_size, datetime.fromtimestamp(stat.st_mtime, tz=UTC).isoformat()
+
+        total_size = 0
+        latest_mtime: float | None = None
+        for child in path.rglob("*"):
+            if not child.is_file():
+                continue
+            stat = child.stat()
+            total_size += stat.st_size
+            latest_mtime = (
+                stat.st_mtime if latest_mtime is None else max(latest_mtime, stat.st_mtime)
+            )
+    except OSError:
+        return None, None
+
+    last_indexed = (
+        datetime.fromtimestamp(latest_mtime, tz=UTC).isoformat()
+        if latest_mtime is not None
+        else None
+    )
+    return total_size, last_indexed
+
+
 def _collect_search_detail(zone_ids: list[str]) -> dict[str, Any]:
-    return {
-        "zones": [
+    base = Path(os.environ.get("NEXUS_ZOEKT_INDEX_DIR", "/app/data/.zoekt-index"))
+    zones = []
+    for zone_id in zone_ids:
+        index_path = _zone_index_path(base, zone_id)
+        size_bytes: int | None = None
+        last_indexed: str | None = None
+        if index_path is not None:
+            size_bytes, last_indexed = _index_path_stats(index_path)
+        zones.append(
             {
                 "zone_id": zone_id,
-                "zoekt_index_size_bytes": None,
-                "zoekt_index_size_display": None,
-                "zoekt_last_indexed": None,
+                "zoekt_index_size_bytes": size_bytes,
+                "zoekt_index_size_display": _format_bytes(size_bytes),
+                "zoekt_last_indexed": last_indexed,
                 "txtai_queue_depth": None,
-                "last_indexed": None,
+                "last_indexed": last_indexed,
             }
-            for zone_id in zone_ids
-        ]
-    }
+        )
+    return {"zones": zones}
 
 
 def _emit_detail_status_text(payload: dict[str, Any]) -> None:

--- a/src/nexus/cli/commands/hub.py
+++ b/src/nexus/cli/commands/hub.py
@@ -614,7 +614,11 @@ def _token_zones_by_key(session: Any, key_ids: list[str]) -> dict[str, list[str]
 
 def _collect_token_detail(session: Any) -> list[dict[str, Any]]:
     rows = (
-        session.execute(select(APIKeyModel).order_by(APIKeyModel.created_at.desc())).scalars().all()
+        session.execute(
+            select(APIKeyModel).order_by(APIKeyModel.created_at.desc(), APIKeyModel.key_id.asc())
+        )
+        .scalars()
+        .all()
     )
     key_ids = [row.key_id for row in rows]
     zones_by_key = _token_zones_by_key(session, key_ids)

--- a/src/nexus/cli/commands/hub.py
+++ b/src/nexus/cli/commands/hub.py
@@ -749,7 +749,7 @@ def _read_redis_detail_stats(zone_ids: list[str]) -> dict[str, Any]:
 
         hits_by_tier: dict[str, int] = {}
         for tier in _RATE_LIMIT_TIERS:
-            minute_keys = [f"nexus:hub:rate_limit:{tier}:{now_min - i}" for i in range(5)]
+            minute_keys = [f"nexus:hub:ratelimit:tier:{tier}:{now_min - i}" for i in range(5)]
             hits_by_tier[tier] = sum(_decode_int(v) for v in client.mget(minute_keys))
 
         return {

--- a/src/nexus/cli/commands/hub.py
+++ b/src/nexus/cli/commands/hub.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import os
 import time
+from contextlib import suppress
 from datetime import UTC, datetime
 from typing import Any
 
@@ -728,6 +729,7 @@ def _read_redis_detail_stats(zone_ids: list[str]) -> dict[str, Any]:
     except ImportError:
         return empty
 
+    client = None
     try:
         client = redis.from_url(url, socket_timeout=2)
         client.ping()
@@ -756,6 +758,10 @@ def _read_redis_detail_stats(zone_ids: list[str]) -> dict[str, Any]:
         }
     except Exception:  # noqa: BLE001
         return empty
+    finally:
+        if client is not None:
+            with suppress(Exception):
+                client.close()
 
 
 def _collect_status_detail(

--- a/src/nexus/cli/commands/hub.py
+++ b/src/nexus/cli/commands/hub.py
@@ -540,15 +540,43 @@ def _read_redis_stats() -> dict[str, Any]:
 
 @hub.command("status")
 @click.option("--json", "as_json", is_flag=True, help="Emit JSON.")
-def hub_status(as_json: bool) -> None:
+@click.option(
+    "--detail",
+    is_flag=True,
+    help="Include per-zone, per-token, rate-limit, and search detail.",
+)
+def hub_status(as_json: bool, detail: bool) -> None:
     """Show hub health: postgres, redis, tokens, connections, qps."""
     import json as _json
 
-    host = os.environ.get("NEXUS_MCP_HOST", "0.0.0.0")
-    port = os.environ.get("NEXUS_MCP_PORT", "8081")
-    profile = os.environ.get("NEXUS_PROFILE", "full")
-    endpoint = f"http://{host}:{port}/mcp"
+    payload = _base_status_payload()
+    if detail:
+        redis_detail = _read_redis_detail_stats([])
+        payload["detail"] = True
+        payload.update(_collect_status_detail([], [], redis_detail))
 
+    if as_json:
+        click.echo(_json.dumps(payload, indent=2))
+    else:
+        _emit_base_status_text(payload)
+        if detail:
+            _emit_detail_status_text(payload)
+
+    # Postgres is the source of truth for tokens and zones. A broken
+    # auth DB must block rollout / trip paging — exit non-zero so
+    # shell-style health guards (`nexus hub status && …`) fail closed
+    # instead of reading "ok" off a silently-green exit code (#3784
+    # round 9). Redis is best-effort (metrics only) so we don't fail
+    # on `redis: n/a`.
+    if payload["postgres"] != "ok":
+        raise SystemExit(2)
+
+
+def _display_status_value(value: Any) -> str:
+    return "n/a" if value is None else str(value)
+
+
+def _collect_postgres_status() -> dict[str, Any]:
     pg_state = "ok"
     active = revoked = 0
     try:
@@ -568,41 +596,143 @@ def hub_status(as_json: bool) -> None:
             )
     except Exception:  # noqa: BLE001
         pg_state = "err"
+    return {
+        "postgres": pg_state,
+        "tokens": {"active": int(active), "revoked": int(revoked)},
+        "zone_ids": [],
+        "tokens_detail": [],
+    }
 
+
+def _base_status_payload() -> dict[str, Any]:
+    host = os.environ.get("NEXUS_MCP_HOST", "0.0.0.0")
+    port = os.environ.get("NEXUS_MCP_PORT", "8081")
+    profile = os.environ.get("NEXUS_PROFILE", "full")
+    endpoint = f"http://{host}:{port}/mcp"
+
+    postgres_status = _collect_postgres_status()
     redis_stats = _read_redis_stats()
-
-    payload = {
+    return {
         "endpoint": endpoint,
         "profile": profile,
-        "postgres": pg_state,
+        "postgres": postgres_status["postgres"],
         "redis": redis_stats["redis"],
-        "tokens": {"active": int(active), "revoked": int(revoked)},
+        "tokens": postgres_status["tokens"],
         "connections": redis_stats["connections"],
         "qps_5m": redis_stats["qps_5m"],
     }
 
-    if as_json:
-        click.echo(_json.dumps(payload, indent=2))
-    else:
-        click.echo(f"endpoint:    {payload['endpoint']}")
-        click.echo(f"profile:     {payload['profile']}")
-        click.echo(f"postgres:    {payload['postgres']}")
-        click.echo(f"redis:       {payload['redis']}")
-        click.echo(
-            f"tokens:      {payload['tokens']['active']} active, "
-            f"{payload['tokens']['revoked']} revoked"
-        )
-        click.echo(
-            "connections: "
-            f"{payload['connections'] if payload['connections'] is not None else 'n/a'}"
-        )
-        click.echo(f"qps (5m):    {payload['qps_5m'] if payload['qps_5m'] is not None else 'n/a'}")
 
-    # Postgres is the source of truth for tokens and zones. A broken
-    # auth DB must block rollout / trip paging — exit non-zero so
-    # shell-style health guards (`nexus hub status && …`) fail closed
-    # instead of reading "ok" off a silently-green exit code (#3784
-    # round 9). Redis is best-effort (metrics only) so we don't fail
-    # on `redis: n/a`.
-    if pg_state != "ok":
-        raise SystemExit(2)
+def _emit_base_status_text(payload: dict[str, Any]) -> None:
+    click.echo(f"endpoint:    {payload['endpoint']}")
+    click.echo(f"profile:     {payload['profile']}")
+    click.echo(f"postgres:    {payload['postgres']}")
+    click.echo(f"redis:       {payload['redis']}")
+    click.echo(
+        f"tokens:      {payload['tokens']['active']} active, {payload['tokens']['revoked']} revoked"
+    )
+    click.echo(f"connections: {_display_status_value(payload['connections'])}")
+    click.echo(f"qps (5m):    {_display_status_value(payload['qps_5m'])}")
+
+
+def _read_redis_detail_stats(zone_ids: list[str]) -> dict[str, Any]:
+    return {
+        "zones": [{"zone_id": zone_id, "clients": None, "qps_5m": None} for zone_id in zone_ids],
+        "rate_limits": {"window_seconds": 300, "hits_by_tier": {}},
+    }
+
+
+def _collect_status_detail(
+    zone_ids: list[str],
+    tokens_detail: list[dict[str, Any]],
+    redis_detail: dict[str, Any],
+) -> dict[str, Any]:
+    return {
+        "zones": redis_detail["zones"],
+        "tokens_detail": tokens_detail,
+        "rate_limits": redis_detail["rate_limits"],
+        "search": _collect_search_detail(zone_ids),
+    }
+
+
+def _collect_search_detail(zone_ids: list[str]) -> dict[str, Any]:
+    return {
+        "zones": [
+            {
+                "zone_id": zone_id,
+                "zoekt_index_size_bytes": None,
+                "zoekt_index_size_display": None,
+                "zoekt_last_indexed": None,
+                "txtai_queue_depth": None,
+                "last_indexed": None,
+            }
+            for zone_id in zone_ids
+        ]
+    }
+
+
+def _emit_detail_status_text(payload: dict[str, Any]) -> None:
+    click.echo("")
+    click.echo("zones:")
+    click.echo(
+        format_table(
+            headers=["zone", "clients", "qps_5m"],
+            rows=[
+                [
+                    row["zone_id"],
+                    _display_status_value(row.get("clients")),
+                    _display_status_value(row.get("qps_5m")),
+                ]
+                for row in payload.get("zones", [])
+            ],
+        )
+    )
+    click.echo("")
+    click.echo("tokens:")
+    click.echo(
+        format_table(
+            headers=["key_id", "name", "zones", "admin", "last_seen"],
+            rows=[
+                [
+                    row["key_id"],
+                    row["name"],
+                    ",".join(row.get("zones", [])),
+                    "yes" if row.get("admin") else "no",
+                    _display_status_value(row.get("last_seen")),
+                ]
+                for row in payload.get("tokens_detail", [])
+            ],
+        )
+    )
+    click.echo("")
+    click.echo("rate limits:")
+    hits = payload.get("rate_limits", {}).get("hits_by_tier", {})
+    click.echo(
+        format_table(
+            headers=["tier", "hits_5m"],
+            rows=[[tier, _display_status_value(hits[tier])] for tier in sorted(hits)],
+        )
+    )
+    click.echo("")
+    click.echo("search:")
+    click.echo(
+        format_table(
+            headers=[
+                "zone",
+                "zoekt_size",
+                "zoekt_last_indexed",
+                "txtai_queue_depth",
+                "last_indexed",
+            ],
+            rows=[
+                [
+                    row["zone_id"],
+                    _display_status_value(row.get("zoekt_index_size_display")),
+                    _display_status_value(row.get("zoekt_last_indexed")),
+                    _display_status_value(row.get("txtai_queue_depth")),
+                    _display_status_value(row.get("last_indexed")),
+                ]
+                for row in payload.get("search", {}).get("zones", [])
+            ],
+        )
+    )

--- a/src/nexus/cli/commands/hub.py
+++ b/src/nexus/cli/commands/hub.py
@@ -8,6 +8,7 @@ Remote admin is tracked as a follow-up to issue #3784.
 from __future__ import annotations
 
 import os
+import time
 from datetime import UTC, datetime
 from typing import Any
 
@@ -510,8 +511,6 @@ def _read_redis_stats() -> dict[str, Any]:
 
     Returns a dict with `qps_5m`, `connections`, `redis` ∈ {"ok", "n/a"}.
     """
-    import time
-
     url = os.environ.get("NEXUS_REDIS_URL") or os.environ.get("DRAGONFLY_URL")
     if not url:
         return {"qps_5m": None, "connections": None, "redis": "n/a"}
@@ -700,11 +699,63 @@ def _emit_base_status_text(payload: dict[str, Any]) -> None:
     click.echo(f"qps (5m):    {_display_status_value(payload['qps_5m'])}")
 
 
+_RATE_LIMIT_TIERS = ("anonymous", "authenticated", "premium")
+
+
+def _decode_int(value: Any) -> int:
+    if value is None:
+        return 0
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return 0
+
+
 def _read_redis_detail_stats(zone_ids: list[str]) -> dict[str, Any]:
-    return {
-        "zones": [{"zone_id": zone_id, "clients": None, "qps_5m": None} for zone_id in zone_ids],
-        "rate_limits": {"window_seconds": 300, "hits_by_tier": {}},
+    url = os.environ.get("NEXUS_REDIS_URL") or os.environ.get("DRAGONFLY_URL")
+    empty_zones = [{"zone_id": zone_id, "clients": None, "qps_5m": None} for zone_id in zone_ids]
+    empty = {
+        "zones": empty_zones,
+        "rate_limits": {
+            "window_seconds": 300,
+            "hits_by_tier": dict.fromkeys(_RATE_LIMIT_TIERS),
+        },
     }
+    if not url:
+        return empty
+    try:
+        import redis
+    except ImportError:
+        return empty
+
+    try:
+        client = redis.from_url(url, socket_timeout=2)
+        client.ping()
+        now_min = int(time.time()) // 60
+        zones: list[dict[str, Any]] = []
+        for zone_id in zone_ids:
+            minute_keys = [f"nexus:hub:qps:zone:{zone_id}:{now_min - i}" for i in range(5)]
+            total = sum(_decode_int(v) for v in client.mget(minute_keys))
+            active = client.scard(f"nexus:hub:active:zone:{zone_id}:{now_min}")
+            zones.append(
+                {
+                    "zone_id": zone_id,
+                    "clients": int(active),
+                    "qps_5m": round(total / 300.0, 2),
+                }
+            )
+
+        hits_by_tier: dict[str, int] = {}
+        for tier in _RATE_LIMIT_TIERS:
+            minute_keys = [f"nexus:hub:rate_limit:{tier}:{now_min - i}" for i in range(5)]
+            hits_by_tier[tier] = sum(_decode_int(v) for v in client.mget(minute_keys))
+
+        return {
+            "zones": zones,
+            "rate_limits": {"window_seconds": 300, "hits_by_tier": hits_by_tier},
+        }
+    except Exception:  # noqa: BLE001
+        return empty
 
 
 def _collect_status_detail(

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -71,6 +71,12 @@ logger = logging.getLogger(__name__)
 # Module-level limiter instance; initialized in create_app().
 limiter: Limiter
 
+
+def _rate_limit_enabled_from_env() -> bool:
+    """Return whether HTTP rate limiting was explicitly enabled."""
+    return os.environ.get("NEXUS_RATE_LIMIT_ENABLED", "").lower() in ("1", "true", "yes")
+
+
 # ============================================================================
 # Thread Pool Utilities (Issue #932)
 # ============================================================================
@@ -580,11 +586,7 @@ def create_app(
     import nexus.server.rate_limiting as _rate_limiting_mod
 
     global limiter
-    rate_limit_enabled = os.environ.get("NEXUS_RATE_LIMIT_ENABLED", "true").lower() not in (
-        "false",
-        "0",
-        "no",
-    )
+    rate_limit_enabled = _rate_limit_enabled_from_env()
     from nexus.lib.env import get_dragonfly_url, get_redis_url
 
     redis_url = get_redis_url() or get_dragonfly_url()

--- a/src/nexus/storage/persistent_view_postgres.py
+++ b/src/nexus/storage/persistent_view_postgres.py
@@ -18,6 +18,7 @@ from datetime import UTC, datetime
 from typing import TYPE_CHECKING, Any
 
 from sqlalchemy import text
+from sqlalchemy.exc import OperationalError
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.persistent_view import PersistentView
@@ -82,6 +83,14 @@ _CREATE_TABLE = text("""
 """)
 
 
+def _is_missing_view_table_error(exc: OperationalError) -> bool:
+    """Return whether an OperationalError means the view table is absent."""
+    message = str(exc).lower()
+    return "persistent_namespace_views" in message and (
+        "no such table" in message or "does not exist" in message or "undefinedtable" in message
+    )
+
+
 class PostgresPersistentViewStore:
     """PostgreSQL-backed persistent namespace view store.
 
@@ -105,6 +114,13 @@ class PostgresPersistentViewStore:
         with engine.begin() as conn:
             conn.execute(_CREATE_TABLE)
 
+    def _recover_missing_table(self, exc: OperationalError) -> bool:
+        if not _is_missing_view_table_error(exc):
+            return False
+        logger.warning("[L3] persistent_namespace_views table missing; recreating before retry")
+        self._ensure_table(self._engine)
+        return True
+
     def save_view(
         self,
         subject_type: str,
@@ -125,20 +141,28 @@ class PostgresPersistentViewStore:
             "zone_id": effective_zone,
         }
 
-        with self._engine.begin() as conn:
-            conn.execute(_DELETE_EXACT, params)
-            conn.execute(
-                _INSERT_VIEW,
-                {
-                    **params,
-                    "id": view_id,
-                    "mount_paths_json": json.dumps(mount_paths),
-                    "grants_hash": grants_hash,
-                    "revision_bucket": revision_bucket,
-                    "created_at": now,
-                    "updated_at": now,
-                },
-            )
+        def _save_once() -> None:
+            with self._engine.begin() as conn:
+                conn.execute(_DELETE_EXACT, params)
+                conn.execute(
+                    _INSERT_VIEW,
+                    {
+                        **params,
+                        "id": view_id,
+                        "mount_paths_json": json.dumps(mount_paths),
+                        "grants_hash": grants_hash,
+                        "revision_bucket": revision_bucket,
+                        "created_at": now,
+                        "updated_at": now,
+                    },
+                )
+
+        try:
+            _save_once()
+        except OperationalError as exc:
+            if not self._recover_missing_table(exc):
+                raise
+            _save_once()
 
     def load_view(
         self,
@@ -149,16 +173,22 @@ class PostgresPersistentViewStore:
         """Load a persisted namespace view."""
         effective_zone = zone_id or ROOT_ZONE_ID
 
-        with self._engine.connect() as conn:
-            result = conn.execute(
-                _LOAD_VIEW,
-                {
-                    "subject_type": subject_type,
-                    "subject_id": subject_id,
-                    "zone_id": effective_zone,
-                },
-            )
-            row = result.fetchone()
+        params = {
+            "subject_type": subject_type,
+            "subject_id": subject_id,
+            "zone_id": effective_zone,
+        }
+
+        try:
+            with self._engine.connect() as conn:
+                result = conn.execute(_LOAD_VIEW, params)
+                row = result.fetchone()
+        except OperationalError as exc:
+            if not self._recover_missing_table(exc):
+                raise
+            with self._engine.connect() as conn:
+                result = conn.execute(_LOAD_VIEW, params)
+                row = result.fetchone()
 
         if row is None:
             return None
@@ -190,18 +220,26 @@ class PostgresPersistentViewStore:
         subject_id: str,
     ) -> int:
         """Delete all persisted views for a subject (all zones)."""
-        with self._engine.begin() as conn:
-            result = conn.execute(
-                _DELETE_SUBJECT,
-                {
-                    "subject_type": subject_type,
-                    "subject_id": subject_id,
-                },
-            )
-            return result.rowcount or 0
+        params = {
+            "subject_type": subject_type,
+            "subject_id": subject_id,
+        }
+        try:
+            with self._engine.begin() as conn:
+                result = conn.execute(_DELETE_SUBJECT, params)
+                return result.rowcount or 0
+        except OperationalError as exc:
+            if not self._recover_missing_table(exc):
+                raise
+            return 0
 
     def delete_all_views(self) -> int:
         """Delete all persisted views across all subjects and zones."""
-        with self._engine.begin() as conn:
-            result = conn.execute(_DELETE_ALL)
-            return result.rowcount or 0
+        try:
+            with self._engine.begin() as conn:
+                result = conn.execute(_DELETE_ALL)
+                return result.rowcount or 0
+        except OperationalError as exc:
+            if not self._recover_missing_table(exc):
+                raise
+            return 0

--- a/tests/e2e/self_contained/test_persistent_view_store.py
+++ b/tests/e2e/self_contained/test_persistent_view_store.py
@@ -171,6 +171,28 @@ class TestDelete:
         assert store.load_view("user", "alice", "zone-b") is None
 
 
+class TestMissingTableRecovery:
+    """Tests for SQLite connection replacement and lazy table recovery."""
+
+    def test_load_view_recovers_missing_table_as_cache_miss(self, engine, store):
+        """If SQLite loses the table after init, load_view recreates it and misses."""
+        with engine.begin() as conn:
+            conn.exec_driver_sql("DROP TABLE persistent_namespace_views")
+
+        assert store.load_view("user", "alice", None) is None
+
+    def test_save_view_recovers_missing_table_and_persists(self, engine, store):
+        """If SQLite loses the table after init, save_view recreates it before insert."""
+        with engine.begin() as conn:
+            conn.exec_driver_sql("DROP TABLE persistent_namespace_views")
+
+        store.save_view("user", "alice", None, ["/workspace"], "hash_recovered12", 1)
+
+        view = store.load_view("user", "alice", None)
+        assert view is not None
+        assert view.mount_paths == ("/workspace",)
+
+
 # ---------------------------------------------------------------------------
 # Zone Isolation
 # ---------------------------------------------------------------------------

--- a/tests/unit/bricks/mcp/test_middleware_audit_metrics.py
+++ b/tests/unit/bricks/mcp/test_middleware_audit_metrics.py
@@ -37,6 +37,30 @@ async def test_record_metrics_increments_qps_and_sadds_active(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_record_metrics_increments_per_zone_counters(monkeypatch):
+    monkeypatch.setenv("NEXUS_REDIS_URL", "redis://localhost:6379")
+
+    fake_client = AsyncMock()
+    fake_client.incr = AsyncMock(return_value=1)
+    fake_client.sadd = AsyncMock(return_value=1)
+    fake_client.expire = AsyncMock(return_value=True)
+    fake_client.close = AsyncMock()
+
+    monkeypatch.setattr(_redis_async, "from_url", lambda _url: fake_client)
+
+    await mw._record_metrics({"subject_id": "kid_abc", "token_hash": "deadbeef", "zone_id": "eng"})
+
+    incr_keys = [call.args[0] for call in fake_client.incr.await_args_list]
+    sadd_keys = [call.args[0] for call in fake_client.sadd.await_args_list]
+
+    assert any(key.startswith("nexus:hub:qps:") for key in incr_keys)
+    assert any(key.startswith("nexus:hub:qps:zone:eng:") for key in incr_keys)
+    assert any(key.startswith("nexus:hub:active:") for key in sadd_keys)
+    assert any(key.startswith("nexus:hub:active:zone:eng:") for key in sadd_keys)
+    assert fake_client.expire.await_count == 4
+
+
+@pytest.mark.asyncio
 async def test_record_metrics_no_redis_url_is_noop(monkeypatch):
     monkeypatch.delenv("NEXUS_REDIS_URL", raising=False)
     monkeypatch.delenv("DRAGONFLY_URL", raising=False)

--- a/tests/unit/bricks/mcp/test_middleware_audit_metrics.py
+++ b/tests/unit/bricks/mcp/test_middleware_audit_metrics.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+import re
 from unittest.mock import AsyncMock
 
 import pytest
@@ -50,14 +51,19 @@ async def test_record_metrics_increments_per_zone_counters(monkeypatch):
 
     await mw._record_metrics({"subject_id": "kid_abc", "token_hash": "deadbeef", "zone_id": "eng"})
 
+    assert fake_client.incr.await_count == 2
+    assert fake_client.sadd.await_count == 2
+
     incr_keys = [call.args[0] for call in fake_client.incr.await_args_list]
     sadd_keys = [call.args[0] for call in fake_client.sadd.await_args_list]
+    expire_keys = [call.args[0] for call in fake_client.expire.await_args_list]
 
-    assert any(key.startswith("nexus:hub:qps:") for key in incr_keys)
-    assert any(key.startswith("nexus:hub:qps:zone:eng:") for key in incr_keys)
-    assert any(key.startswith("nexus:hub:active:") for key in sadd_keys)
-    assert any(key.startswith("nexus:hub:active:zone:eng:") for key in sadd_keys)
+    assert sum(1 for key in incr_keys if re.fullmatch(r"nexus:hub:qps:\d+", key)) == 1
+    assert sum(1 for key in incr_keys if re.fullmatch(r"nexus:hub:qps:zone:eng:\d+", key)) == 1
+    assert sum(1 for key in sadd_keys if re.fullmatch(r"nexus:hub:active:\d+", key)) == 1
+    assert sum(1 for key in sadd_keys if re.fullmatch(r"nexus:hub:active:zone:eng:\d+", key)) == 1
     assert fake_client.expire.await_count == 4
+    assert set(expire_keys) == set(incr_keys + sadd_keys)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/bricks/mcp/test_middleware_ratelimit.py
+++ b/tests/unit/bricks/mcp/test_middleware_ratelimit.py
@@ -52,22 +52,32 @@ def test_429_response_shape(app: Starlette) -> None:
 
 
 def test_429_records_rate_limit_hit_tier(monkeypatch, app: Starlette) -> None:
-    hits: list[str] = []
+    redis = pytest.importorskip("redis.asyncio")
+    calls: list[tuple[str, object, object | None]] = []
 
-    async def fake_record(tier: str) -> None:
-        hits.append(tier)
+    class FakeRedisClient:
+        async def incr(self, key: str) -> None:
+            calls.append(("incr", key, None))
 
-    monkeypatch.setattr(
-        "nexus.bricks.mcp.middleware_ratelimit._record_rate_limit_hit",
-        fake_record,
-        raising=False,
-    )
+        async def expire(self, key: str, ttl: int) -> None:
+            calls.append(("expire", key, ttl))
+
+        async def close(self) -> None:
+            calls.append(("close", None, None))
+
+    monkeypatch.setenv("NEXUS_REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setattr(redis, "from_url", lambda _url: FakeRedisClient())
+    monkeypatch.setattr(middleware_ratelimit.time, "time", lambda: 123 * 60)
 
     client = TestClient(app)
     for _ in range(3):
         assert client.post("/mcp").status_code == 200
     assert client.post("/mcp").status_code == 429
-    assert hits == ["anonymous"]
+    assert calls == [
+        ("incr", "nexus:hub:ratelimit:tier:anonymous:123", None),
+        ("expire", "nexus:hub:ratelimit:tier:anonymous:123", 600),
+        ("close", None, None),
+    ]
 
 
 def test_record_rate_limit_hit_swallows_redis_client_creation_errors(monkeypatch) -> None:
@@ -99,6 +109,35 @@ def test_record_rate_limit_hit_swallows_redis_close_errors(monkeypatch) -> None:
     monkeypatch.setattr(redis, "from_url", lambda _url: CloseFailingClient())
 
     asyncio.run(middleware_ratelimit._record_rate_limit_hit("anonymous"))
+
+
+@pytest.mark.parametrize("failing_method", ["incr", "expire"])
+def test_record_rate_limit_hit_swallows_redis_write_errors(
+    monkeypatch, failing_method: str
+) -> None:
+    redis = pytest.importorskip("redis.asyncio")
+    monkeypatch.setenv("NEXUS_REDIS_URL", "redis://localhost:6379/0")
+    calls: list[str] = []
+
+    class WriteFailingClient:
+        async def incr(self, _key: str) -> None:
+            calls.append("incr")
+            if failing_method == "incr":
+                raise RuntimeError("redis incr failed")
+
+        async def expire(self, _key: str, _ttl: int) -> None:
+            calls.append("expire")
+            if failing_method == "expire":
+                raise RuntimeError("redis expire failed")
+
+        async def close(self) -> None:
+            calls.append("close")
+
+    monkeypatch.setattr(redis, "from_url", lambda _url: WriteFailingClient())
+
+    asyncio.run(middleware_ratelimit._record_rate_limit_hit("anonymous"))
+
+    assert "close" in calls
 
 
 def test_different_tokens_limited_independently(app: Starlette) -> None:

--- a/tests/unit/bricks/mcp/test_middleware_ratelimit.py
+++ b/tests/unit/bricks/mcp/test_middleware_ratelimit.py
@@ -48,6 +48,25 @@ def test_429_response_shape(app: Starlette) -> None:
     assert "retry_after" in body
 
 
+def test_429_records_rate_limit_hit_tier(monkeypatch, app: Starlette) -> None:
+    hits: list[str] = []
+
+    async def fake_record(tier: str) -> None:
+        hits.append(tier)
+
+    monkeypatch.setattr(
+        "nexus.bricks.mcp.middleware_ratelimit._record_rate_limit_hit",
+        fake_record,
+        raising=False,
+    )
+
+    client = TestClient(app)
+    for _ in range(3):
+        assert client.post("/mcp").status_code == 200
+    assert client.post("/mcp").status_code == 429
+    assert hits == ["anonymous"]
+
+
 def test_different_tokens_limited_independently(app: Starlette) -> None:
     # sk-z_u1_k_a → zone="z", user="u1" → bucket "user:z:u1"
     # sk-z_u2_k_b → zone="z", user="u2" → bucket "user:z:u2"

--- a/tests/unit/bricks/mcp/test_middleware_ratelimit.py
+++ b/tests/unit/bricks/mcp/test_middleware_ratelimit.py
@@ -2,6 +2,8 @@
 
 from __future__ import annotations
 
+import asyncio
+
 import pytest
 from starlette.applications import Starlette
 from starlette.requests import Request
@@ -9,6 +11,7 @@ from starlette.responses import JSONResponse
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
+from nexus.bricks.mcp import middleware_ratelimit
 from nexus.bricks.mcp.middleware_ratelimit import install_rate_limit
 
 
@@ -65,6 +68,37 @@ def test_429_records_rate_limit_hit_tier(monkeypatch, app: Starlette) -> None:
         assert client.post("/mcp").status_code == 200
     assert client.post("/mcp").status_code == 429
     assert hits == ["anonymous"]
+
+
+def test_record_rate_limit_hit_swallows_redis_client_creation_errors(monkeypatch) -> None:
+    redis = pytest.importorskip("redis.asyncio")
+    monkeypatch.setenv("NEXUS_REDIS_URL", "redis://localhost:6379/0")
+
+    def raise_from_url(_url: str):
+        raise RuntimeError("redis client creation failed")
+
+    monkeypatch.setattr(redis, "from_url", raise_from_url)
+
+    asyncio.run(middleware_ratelimit._record_rate_limit_hit("anonymous"))
+
+
+def test_record_rate_limit_hit_swallows_redis_close_errors(monkeypatch) -> None:
+    redis = pytest.importorskip("redis.asyncio")
+    monkeypatch.setenv("NEXUS_REDIS_URL", "redis://localhost:6379/0")
+
+    class CloseFailingClient:
+        async def incr(self, _key: str) -> None:
+            return None
+
+        async def expire(self, _key: str, _ttl: int) -> None:
+            return None
+
+        async def close(self) -> None:
+            raise RuntimeError("redis close failed")
+
+    monkeypatch.setattr(redis, "from_url", lambda _url: CloseFailingClient())
+
+    asyncio.run(middleware_ratelimit._record_rate_limit_hit("anonymous"))
 
 
 def test_different_tokens_limited_independently(app: Starlette) -> None:

--- a/tests/unit/bricks/mcp/test_middleware_ratelimit.py
+++ b/tests/unit/bricks/mcp/test_middleware_ratelimit.py
@@ -92,7 +92,11 @@ def test_429_records_rate_limit_hit_tier(monkeypatch, app: Starlette) -> None:
             calls.append(("close", None, None))
 
     monkeypatch.setenv("NEXUS_REDIS_URL", "redis://localhost:6379/0")
-    monkeypatch.setattr(redis, "from_url", lambda _url: FakeRedisClient())
+
+    def from_url(_url: str, **_kwargs: object) -> FakeRedisClient:
+        return FakeRedisClient()
+
+    monkeypatch.setattr(redis, "from_url", from_url)
     monkeypatch.setattr(middleware_ratelimit.time, "time", lambda: 123 * 60)
 
     client = TestClient(app)
@@ -101,16 +105,61 @@ def test_429_records_rate_limit_hit_tier(monkeypatch, app: Starlette) -> None:
     assert client.post("/mcp").status_code == 429
     assert calls == [
         ("incr", "nexus:hub:ratelimit:tier:anonymous:123", None),
-        ("expire", "nexus:hub:ratelimit:tier:anonymous:123", 600),
+        (
+            "expire",
+            "nexus:hub:ratelimit:tier:anonymous:123",
+            middleware_ratelimit._RATE_LIMIT_METRIC_TTL_SECONDS,
+        ),
         ("close", None, None),
     ]
+
+
+def test_record_rate_limit_hit_uses_bounded_redis_write(monkeypatch) -> None:
+    redis = pytest.importorskip("redis.asyncio")
+    monkeypatch.setenv("NEXUS_REDIS_URL", "redis://localhost:6379/0")
+    from_url_calls: list[tuple[str, dict[str, object]]] = []
+    wait_for_timeouts: list[float] = []
+
+    class FakeRedisClient:
+        async def incr(self, _key: str) -> None:
+            return None
+
+        async def expire(self, _key: str, _ttl: int) -> None:
+            return None
+
+        async def close(self) -> None:
+            return None
+
+    def from_url(url: str, **kwargs: object) -> FakeRedisClient:
+        from_url_calls.append((url, kwargs))
+        return FakeRedisClient()
+
+    async def fake_wait_for(awaitable, timeout: float):
+        wait_for_timeouts.append(timeout)
+        return await awaitable
+
+    monkeypatch.setattr(redis, "from_url", from_url)
+    monkeypatch.setattr(middleware_ratelimit.asyncio, "wait_for", fake_wait_for)
+
+    asyncio.run(middleware_ratelimit._record_rate_limit_hit("anonymous"))
+
+    assert from_url_calls == [
+        (
+            "redis://localhost:6379/0",
+            {
+                "socket_connect_timeout": middleware_ratelimit._RATE_LIMIT_METRIC_TIMEOUT_SECONDS,
+                "socket_timeout": middleware_ratelimit._RATE_LIMIT_METRIC_TIMEOUT_SECONDS,
+            },
+        )
+    ]
+    assert wait_for_timeouts == [middleware_ratelimit._RATE_LIMIT_METRIC_TIMEOUT_SECONDS]
 
 
 def test_record_rate_limit_hit_swallows_redis_client_creation_errors(monkeypatch) -> None:
     redis = pytest.importorskip("redis.asyncio")
     monkeypatch.setenv("NEXUS_REDIS_URL", "redis://localhost:6379/0")
 
-    def raise_from_url(_url: str):
+    def raise_from_url(_url: str, **_kwargs: object):
         raise RuntimeError("redis client creation failed")
 
     monkeypatch.setattr(redis, "from_url", raise_from_url)
@@ -132,7 +181,7 @@ def test_record_rate_limit_hit_swallows_redis_close_errors(monkeypatch) -> None:
         async def close(self) -> None:
             raise RuntimeError("redis close failed")
 
-    monkeypatch.setattr(redis, "from_url", lambda _url: CloseFailingClient())
+    monkeypatch.setattr(redis, "from_url", lambda _url, **_kwargs: CloseFailingClient())
 
     asyncio.run(middleware_ratelimit._record_rate_limit_hit("anonymous"))
 
@@ -159,7 +208,7 @@ def test_record_rate_limit_hit_swallows_redis_write_errors(
         async def close(self) -> None:
             calls.append("close")
 
-    monkeypatch.setattr(redis, "from_url", lambda _url: WriteFailingClient())
+    monkeypatch.setattr(redis, "from_url", lambda _url, **_kwargs: WriteFailingClient())
 
     asyncio.run(middleware_ratelimit._record_rate_limit_hit("anonymous"))
 

--- a/tests/unit/bricks/mcp/test_middleware_ratelimit.py
+++ b/tests/unit/bricks/mcp/test_middleware_ratelimit.py
@@ -51,6 +51,32 @@ def test_429_response_shape(app: Starlette) -> None:
     assert "retry_after" in body
 
 
+def test_allowed_request_does_not_record_rate_limit_hit(monkeypatch, app: Starlette) -> None:
+    redis = pytest.importorskip("redis.asyncio")
+    calls: list[str] = []
+
+    class FakeRedisClient:
+        async def incr(self, _key: str) -> None:
+            calls.append("incr")
+
+        async def expire(self, _key: str, _ttl: int) -> None:
+            calls.append("expire")
+
+        async def close(self) -> None:
+            calls.append("close")
+
+    def from_url(_url: str) -> FakeRedisClient:
+        calls.append("from_url")
+        return FakeRedisClient()
+
+    monkeypatch.setenv("NEXUS_REDIS_URL", "redis://localhost:6379/0")
+    monkeypatch.setattr(redis, "from_url", from_url)
+
+    client = TestClient(app)
+    assert client.post("/mcp").status_code == 200
+    assert calls == []
+
+
 def test_429_records_rate_limit_hit_tier(monkeypatch, app: Starlette) -> None:
     redis = pytest.importorskip("redis.asyncio")
     calls: list[tuple[str, object, object | None]] = []

--- a/tests/unit/cli/test_hub.py
+++ b/tests/unit/cli/test_hub.py
@@ -599,9 +599,13 @@ def test_read_redis_detail_stats_aggregates_zone_and_rate_limit_counts(monkeypat
         def __init__(self):
             self.mget_calls = []
             self.scard_calls = []
+            self.closed = False
 
         def ping(self):
             return True
+
+        def close(self):
+            self.closed = True
 
         def mget(self, keys):
             self.mget_calls.append(keys)
@@ -635,6 +639,7 @@ def test_read_redis_detail_stats_aggregates_zone_and_rate_limit_counts(monkeypat
         "window_seconds": 300,
         "hits_by_tier": {"anonymous": 2, "authenticated": 4, "premium": 0},
     }
+    assert fake.closed is True
 
 
 def test_hub_status_detail_flag_is_accepted(monkeypatch):

--- a/tests/unit/cli/test_hub.py
+++ b/tests/unit/cli/test_hub.py
@@ -677,6 +677,43 @@ def test_collect_search_detail_reports_zoekt_size_and_latest_mtime(tmp_path, mon
     assert detail["zones"][1]["zoekt_index_size_bytes"] is None
 
 
+def test_collect_search_detail_reports_aggregate_zoekt_index(tmp_path, monkeypatch):
+    from datetime import UTC, datetime
+
+    import nexus.cli.commands.hub as hub_module
+
+    base = tmp_path / "zoekt"
+    base.mkdir()
+    index_file = base / "index.zoekt"
+    index_file.write_bytes(b"x" * 12)
+    indexed_at = datetime(2026, 5, 5, 14, 22, tzinfo=UTC)
+    indexed_ts = indexed_at.timestamp()
+    os.utime(index_file, (indexed_ts, indexed_ts))
+    monkeypatch.delenv("NEXUS_ZOEKT_INDEX_DIR", raising=False)
+    monkeypatch.setenv("ZOEKT_INDEX_DIR", str(base))
+
+    detail = hub_module._collect_search_detail(["eng"])
+
+    assert detail["zones"] == [
+        {
+            "zone_id": "eng",
+            "zoekt_index_size_bytes": None,
+            "zoekt_index_size_display": None,
+            "zoekt_last_indexed": None,
+            "txtai_queue_depth": None,
+            "last_indexed": None,
+        },
+        {
+            "zone_id": "all",
+            "zoekt_index_size_bytes": 12,
+            "zoekt_index_size_display": "12 B",
+            "zoekt_last_indexed": indexed_at.isoformat(),
+            "txtai_queue_depth": None,
+            "last_indexed": indexed_at.isoformat(),
+        },
+    ]
+
+
 def test_hub_status_detail_flag_is_accepted(monkeypatch):
     session = MagicMock()
     session.execute.return_value.scalar.side_effect = [0, 0]

--- a/tests/unit/cli/test_hub.py
+++ b/tests/unit/cli/test_hub.py
@@ -496,6 +496,79 @@ def test_hub_status_text_unchanged_without_detail(monkeypatch):
     )
 
 
+def test_hub_status_detail_json_includes_token_last_seen_and_zones(monkeypatch):
+    from datetime import datetime
+
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    from nexus.storage.models import APIKeyModel, APIKeyZoneModel, Base, ZoneModel
+
+    engine = create_engine("sqlite:///:memory:")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, future=True, expire_on_commit=False)
+    created = datetime(2026, 5, 5, 13, 0)
+    last_seen = datetime(2026, 5, 5, 14, 20, 10)
+
+    with Session() as s, s.begin():
+        s.add(ZoneModel(zone_id="eng", name="eng", phase="Active"))
+        s.add(ZoneModel(zone_id="ops", name="ops", phase="Active"))
+        s.add(
+            APIKeyModel(
+                key_id="kid_alice",
+                key_hash="hash_alice",
+                user_id="alice",
+                name="alice",
+                is_admin=0,
+                created_at=created,
+                last_used_at=last_seen,
+                revoked=0,
+            )
+        )
+        s.add(APIKeyZoneModel(key_id="kid_alice", zone_id="eng", permissions="rw"))
+        s.add(APIKeyZoneModel(key_id="kid_alice", zone_id="ops", permissions="r"))
+
+    monkeypatch.setattr("nexus.cli.commands.hub.get_session_factory", lambda: Session)
+    monkeypatch.setattr(
+        "nexus.cli.commands.hub._read_redis_stats",
+        lambda: {"qps_5m": 0.0, "connections": 0, "redis": "ok"},
+    )
+    monkeypatch.setattr(
+        "nexus.cli.commands.hub._read_redis_detail_stats",
+        lambda zone_ids: {
+            "zones": [
+                {"zone_id": zone_id, "clients": None, "qps_5m": None} for zone_id in zone_ids
+            ],
+            "rate_limits": {"window_seconds": 300, "hits_by_tier": {}},
+        },
+    )
+    monkeypatch.setattr(
+        "nexus.cli.commands.hub._collect_search_detail",
+        lambda zone_ids: {
+            "zones": [{"zone_id": zone_id, "txtai_queue_depth": None} for zone_id in zone_ids]
+        },
+        raising=False,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(hub, ["status", "--detail", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert [row["zone_id"] for row in payload["zones"]] == ["eng", "ops"]
+    assert payload["tokens_detail"] == [
+        {
+            "key_id": "kid_alice",
+            "name": "alice",
+            "zones": ["eng", "ops"],
+            "admin": False,
+            "created": created.isoformat(),
+            "last_seen": last_seen.isoformat(),
+            "revoked": False,
+            "revoked_at": None,
+        }
+    ]
+
+
 def test_hub_status_detail_flag_is_accepted(monkeypatch):
     session = MagicMock()
     session.execute.return_value.scalar.side_effect = [0, 0]

--- a/tests/unit/cli/test_hub.py
+++ b/tests/unit/cli/test_hub.py
@@ -466,6 +466,73 @@ def test_hub_status_json_includes_expected_fields(monkeypatch):
     assert payload["postgres"] == "ok"
 
 
+def test_hub_status_text_unchanged_without_detail(monkeypatch):
+    monkeypatch.setenv("NEXUS_MCP_HOST", "0.0.0.0")
+    monkeypatch.setenv("NEXUS_MCP_PORT", "8081")
+    monkeypatch.setenv("NEXUS_PROFILE", "full")
+
+    session = MagicMock()
+    session.execute.return_value.scalar.side_effect = [5, 2]
+    monkeypatch.setattr(
+        "nexus.cli.commands.hub.get_session_factory",
+        lambda: _mock_session_ctx(session),
+    )
+    monkeypatch.setattr(
+        "nexus.cli.commands.hub._read_redis_stats",
+        lambda: {"qps_5m": 3.5, "connections": 4, "redis": "ok"},
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(hub, ["status"])
+    assert result.exit_code == 0, result.output
+    assert result.output == (
+        "endpoint:    http://0.0.0.0:8081/mcp\n"
+        "profile:     full\n"
+        "postgres:    ok\n"
+        "redis:       ok\n"
+        "tokens:      5 active, 2 revoked\n"
+        "connections: 4\n"
+        "qps (5m):    3.5\n"
+    )
+
+
+def test_hub_status_detail_flag_is_accepted(monkeypatch):
+    session = MagicMock()
+    session.execute.return_value.scalar.side_effect = [0, 0]
+    monkeypatch.setattr(
+        "nexus.cli.commands.hub.get_session_factory",
+        lambda: _mock_session_ctx(session),
+    )
+    monkeypatch.setattr(
+        "nexus.cli.commands.hub._read_redis_stats",
+        lambda: {"qps_5m": None, "connections": None, "redis": "n/a"},
+    )
+    monkeypatch.setattr(
+        "nexus.cli.commands.hub._collect_status_detail",
+        lambda _zone_ids, _tokens_detail, _redis_detail: {
+            "zones": [],
+            "tokens_detail": [],
+            "rate_limits": {"window_seconds": 300, "hits_by_tier": {}},
+            "search": {"zones": []},
+        },
+        raising=False,
+    )
+    monkeypatch.setattr(
+        "nexus.cli.commands.hub._read_redis_detail_stats",
+        lambda _zone_ids: {
+            "zones": [],
+            "rate_limits": {"window_seconds": 300, "hits_by_tier": {}},
+        },
+        raising=False,
+    )
+
+    runner = CliRunner()
+    result = runner.invoke(hub, ["status", "--detail", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    assert payload["detail"] is True
+
+
 def test_hub_status_postgres_unreachable_marks_err(monkeypatch):
     """Broken auth DB must exit non-zero so shell-style health guards fail
     closed. JSON payload still emits `postgres: err` for parseable consumers."""

--- a/tests/unit/cli/test_hub.py
+++ b/tests/unit/cli/test_hub.py
@@ -613,8 +613,8 @@ def test_read_redis_detail_stats_aggregates_zone_and_rate_limit_counts(monkeypat
                 "nexus:hub:qps:zone:eng:100": b"120",
                 "nexus:hub:qps:zone:eng:99": b"30",
                 "nexus:hub:qps:zone:ops:100": b"60",
-                "nexus:hub:rate_limit:anonymous:100": b"2",
-                "nexus:hub:rate_limit:authenticated:100": b"4",
+                "nexus:hub:ratelimit:tier:anonymous:100": b"2",
+                "nexus:hub:ratelimit:tier:authenticated:100": b"4",
             }
             return [values.get(key) for key in keys]
 

--- a/tests/unit/cli/test_hub.py
+++ b/tests/unit/cli/test_hub.py
@@ -525,6 +525,19 @@ def test_hub_status_detail_json_includes_token_last_seen_and_zones(monkeypatch):
                 revoked=0,
             )
         )
+        s.add(
+            APIKeyModel(
+                key_id="kid_aaron",
+                key_hash="hash_aaron",
+                user_id="aaron",
+                name="aaron",
+                is_admin=0,
+                created_at=created,
+                last_used_at=None,
+                revoked=0,
+            )
+        )
+        s.add(APIKeyZoneModel(key_id="kid_aaron", zone_id="ops", permissions="r"))
         s.add(APIKeyZoneModel(key_id="kid_alice", zone_id="eng", permissions="rw"))
         s.add(APIKeyZoneModel(key_id="kid_alice", zone_id="ops", permissions="r"))
 
@@ -557,6 +570,16 @@ def test_hub_status_detail_json_includes_token_last_seen_and_zones(monkeypatch):
     assert [row["zone_id"] for row in payload["zones"]] == ["eng", "ops"]
     assert payload["tokens_detail"] == [
         {
+            "key_id": "kid_aaron",
+            "name": "aaron",
+            "zones": ["ops"],
+            "admin": False,
+            "created": created.isoformat(),
+            "last_seen": None,
+            "revoked": False,
+            "revoked_at": None,
+        },
+        {
             "key_id": "kid_alice",
             "name": "alice",
             "zones": ["eng", "ops"],
@@ -565,7 +588,7 @@ def test_hub_status_detail_json_includes_token_last_seen_and_zones(monkeypatch):
             "last_seen": last_seen.isoformat(),
             "revoked": False,
             "revoked_at": None,
-        }
+        },
     ]
 
 

--- a/tests/unit/cli/test_hub.py
+++ b/tests/unit/cli/test_hub.py
@@ -592,6 +592,51 @@ def test_hub_status_detail_json_includes_token_last_seen_and_zones(monkeypatch):
     ]
 
 
+def test_read_redis_detail_stats_aggregates_zone_and_rate_limit_counts(monkeypatch):
+    import nexus.cli.commands.hub as hub_module
+
+    class FakeRedis:
+        def __init__(self):
+            self.mget_calls = []
+            self.scard_calls = []
+
+        def ping(self):
+            return True
+
+        def mget(self, keys):
+            self.mget_calls.append(keys)
+            values = {
+                "nexus:hub:qps:zone:eng:100": b"120",
+                "nexus:hub:qps:zone:eng:99": b"30",
+                "nexus:hub:qps:zone:ops:100": b"60",
+                "nexus:hub:rate_limit:anonymous:100": b"2",
+                "nexus:hub:rate_limit:authenticated:100": b"4",
+            }
+            return [values.get(key) for key in keys]
+
+        def scard(self, key):
+            self.scard_calls.append(key)
+            return {"nexus:hub:active:zone:eng:100": 3, "nexus:hub:active:zone:ops:100": 1}.get(
+                key, 0
+            )
+
+    fake = FakeRedis()
+    monkeypatch.setenv("NEXUS_REDIS_URL", "redis://localhost:6379")
+    monkeypatch.setattr("redis.from_url", lambda *_args, **_kwargs: fake)
+    monkeypatch.setattr(hub_module.time, "time", lambda: 100 * 60)
+
+    detail = hub_module._read_redis_detail_stats(["eng", "ops"])
+
+    assert detail["zones"] == [
+        {"zone_id": "eng", "clients": 3, "qps_5m": 0.5},
+        {"zone_id": "ops", "clients": 1, "qps_5m": 0.2},
+    ]
+    assert detail["rate_limits"] == {
+        "window_seconds": 300,
+        "hits_by_tier": {"anonymous": 2, "authenticated": 4, "premium": 0},
+    }
+
+
 def test_hub_status_detail_flag_is_accepted(monkeypatch):
     session = MagicMock()
     session.execute.return_value.scalar.side_effect = [0, 0]

--- a/tests/unit/cli/test_hub.py
+++ b/tests/unit/cli/test_hub.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import json
+import os
 from unittest.mock import MagicMock
 
 from click.testing import CliRunner
@@ -640,6 +641,40 @@ def test_read_redis_detail_stats_aggregates_zone_and_rate_limit_counts(monkeypat
         "hits_by_tier": {"anonymous": 2, "authenticated": 4, "premium": 0},
     }
     assert fake.closed is True
+
+
+def test_collect_search_detail_reports_zoekt_size_and_latest_mtime(tmp_path, monkeypatch):
+    from datetime import UTC, datetime
+
+    import nexus.cli.commands.hub as hub_module
+
+    base = tmp_path / "zoekt"
+    eng = base / "eng"
+    eng.mkdir(parents=True)
+    one = eng / "one.idx"
+    two = eng / "two.idx"
+    one.write_bytes(b"1" * 10)
+    two.write_bytes(b"2" * 20)
+
+    one_ts = datetime(2026, 5, 5, 14, 17, tzinfo=UTC).timestamp()
+    two_dt = datetime(2026, 5, 5, 14, 18, tzinfo=UTC)
+    two_ts = two_dt.timestamp()
+    os.utime(one, (one_ts, one_ts))
+    os.utime(two, (two_ts, two_ts))
+    monkeypatch.setenv("NEXUS_ZOEKT_INDEX_DIR", str(base))
+
+    detail = hub_module._collect_search_detail(["eng", "ops"])
+
+    assert detail["zones"][0] == {
+        "zone_id": "eng",
+        "zoekt_index_size_bytes": 30,
+        "zoekt_index_size_display": "30 B",
+        "zoekt_last_indexed": two_dt.isoformat(),
+        "txtai_queue_depth": None,
+        "last_indexed": two_dt.isoformat(),
+    }
+    assert detail["zones"][1]["zone_id"] == "ops"
+    assert detail["zones"][1]["zoekt_index_size_bytes"] is None
 
 
 def test_hub_status_detail_flag_is_accepted(monkeypatch):

--- a/tests/unit/scripts/test_admin_key_bootstrap.py
+++ b/tests/unit/scripts/test_admin_key_bootstrap.py
@@ -1,0 +1,150 @@
+"""Admin API key bootstrap must preserve post-#3871 key invariants."""
+
+from __future__ import annotations
+
+import asyncio
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from nexus.bricks.auth.providers.database_key import DatabaseAPIKeyAuth
+from nexus.storage.models import APIKeyModel, APIKeyZoneModel, Base, ZoneModel
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+
+
+def _load_script(name: str) -> Any:
+    path = REPO_ROOT / "scripts" / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture()
+def db_url_and_factory(tmp_path):
+    db_path = tmp_path / "nexus.db"
+    db_url = f"sqlite:///{db_path}"
+    engine = create_engine(db_url)
+    Base.metadata.create_all(engine)
+    SessionFactory = sessionmaker(bind=engine)
+    with SessionFactory() as session:
+        session.add(ZoneModel(zone_id="root", name="Root", phase="Active"))
+        session.commit()
+    return db_url, SessionFactory
+
+
+def _auth_result(SessionFactory, raw_key: str):
+    provider = DatabaseAPIKeyAuth(SimpleNamespace(session_factory=SessionFactory))
+    return asyncio.run(provider.authenticate(raw_key))
+
+
+def test_custom_admin_key_writes_junction_and_null_legacy_zone(db_url_and_factory, monkeypatch):
+    monkeypatch.delenv("NEXUS_API_KEY_SECRET", raising=False)
+    db_url, SessionFactory = db_url_and_factory
+    create_admin_key = _load_script("create_admin_key")
+    raw_key = "sk-e2e-custom-admin-key-for-bootstrap"
+
+    returned, success = create_admin_key.create_admin_key(
+        db_url,
+        "admin",
+        custom_key=raw_key,
+        skip_permissions=True,
+    )
+
+    assert success is True
+    assert returned == raw_key
+    key_hash = DatabaseAPIKeyAuth._hash_key(raw_key)
+    with SessionFactory() as session:
+        row = session.scalar(select(APIKeyModel).where(APIKeyModel.key_hash == key_hash))
+        assert row is not None
+        assert row.zone_id is None
+        zones = session.scalars(
+            select(APIKeyZoneModel.zone_id).where(APIKeyZoneModel.key_id == row.key_id)
+        ).all()
+        assert zones == ["root"]
+
+    result = _auth_result(SessionFactory, raw_key)
+    assert result.authenticated is True
+    assert result.is_admin is True
+    assert result.zone_set == ("root",)
+
+
+def test_existing_custom_admin_key_is_repaired_when_legacy_zone_is_unbackfilled(
+    db_url_and_factory,
+    monkeypatch,
+):
+    monkeypatch.delenv("NEXUS_API_KEY_SECRET", raising=False)
+    db_url, SessionFactory = db_url_and_factory
+    create_admin_key = _load_script("create_admin_key")
+    raw_key = "sk-e2e-existing-legacy-admin-key"
+    key_hash = DatabaseAPIKeyAuth._hash_key(raw_key)
+
+    with SessionFactory() as session:
+        session.add(
+            APIKeyModel(
+                user_id="admin",
+                key_hash=key_hash,
+                name="Admin key (from environment)",
+                zone_id="root",
+                is_admin=1,
+                subject_type="user",
+                subject_id="admin",
+                inherit_permissions=0,
+                revoked=0,
+            )
+        )
+        session.commit()
+
+    returned, success = create_admin_key.create_admin_key(
+        db_url,
+        "admin",
+        custom_key=raw_key,
+        skip_permissions=True,
+    )
+
+    assert success is True
+    assert returned == raw_key
+    with SessionFactory() as session:
+        row = session.scalar(select(APIKeyModel).where(APIKeyModel.key_hash == key_hash))
+        assert row is not None
+        assert row.zone_id is None
+        zones = session.scalars(
+            select(APIKeyZoneModel.zone_id).where(APIKeyZoneModel.key_id == row.key_id)
+        ).all()
+        assert zones == ["root"]
+
+    assert _auth_result(SessionFactory, raw_key).authenticated is True
+
+
+def test_check_api_key_rejects_legacy_unbackfilled_admin_key(db_url_and_factory, monkeypatch):
+    monkeypatch.delenv("NEXUS_API_KEY_SECRET", raising=False)
+    db_url, SessionFactory = db_url_and_factory
+    check_api_key = _load_script("check_api_key")
+    raw_key = "sk-e2e-check-legacy-admin-key"
+    key_hash = DatabaseAPIKeyAuth._hash_key(raw_key)
+
+    with SessionFactory() as session:
+        session.add(
+            APIKeyModel(
+                user_id="admin",
+                key_hash=key_hash,
+                name="Admin key (from environment)",
+                zone_id="root",
+                is_admin=1,
+                subject_type="user",
+                subject_id="admin",
+                inherit_permissions=0,
+                revoked=0,
+            )
+        )
+        session.commit()
+
+    assert check_api_key.check_api_key(db_url, raw_key) == "MISSING"

--- a/tests/unit/server/test_fastapi_rate_limit_env.py
+++ b/tests/unit/server/test_fastapi_rate_limit_env.py
@@ -1,0 +1,30 @@
+"""Rate limiting must remain opt-in for the default stack."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import yaml
+
+from nexus.server.fastapi_server import _rate_limit_enabled_from_env
+
+
+def test_rate_limiting_disabled_when_env_unset(monkeypatch):
+    monkeypatch.delenv("NEXUS_RATE_LIMIT_ENABLED", raising=False)
+
+    assert _rate_limit_enabled_from_env() is False
+
+
+def test_rate_limiting_enabled_only_by_explicit_truthy_env(monkeypatch):
+    monkeypatch.setenv("NEXUS_RATE_LIMIT_ENABLED", "true")
+
+    assert _rate_limit_enabled_from_env() is True
+
+
+def test_default_compose_stack_does_not_enable_rate_limiting():
+    repo_root = Path(__file__).resolve().parents[3]
+    stack = yaml.safe_load((repo_root / "nexus-stack.yml").read_text())
+
+    value = stack["services"]["nexus"]["environment"]["NEXUS_RATE_LIMIT_ENABLED"]
+
+    assert value == "${NEXUS_RATE_LIMIT_ENABLED:-false}"


### PR DESCRIPTION
## Summary
- Add `nexus hub status --detail` while preserving default `nexus hub status` output.
- Surface zone/token diagnostics, per-zone Redis activity counters, rate-limit hit counters by tier, and local Zoekt index metadata.
- Add fail-soft metric collection paths and focused tests for CLI status, audit middleware, and rate-limit middleware.

## Test Plan
- `env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/unit/cli/test_hub.py -v -o addopts=`
- `env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest -p pytest_asyncio.plugin tests/unit/bricks/mcp/test_middleware_audit_metrics.py -v -o addopts=`
- `env PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/python -m pytest tests/unit/bricks/mcp/test_middleware_ratelimit.py -v -o addopts=`
- `/Users/tafeng/nexus/.venv/bin/python3 -m pre_commit run --files src/nexus/cli/commands/hub.py src/nexus/bricks/mcp/middleware_audit.py src/nexus/bricks/mcp/middleware_ratelimit.py tests/unit/cli/test_hub.py tests/unit/bricks/mcp/test_middleware_audit_metrics.py tests/unit/bricks/mcp/test_middleware_ratelimit.py`

Fixes #3874