### PR TITLE
[codex] Add Prometheus metrics for MCP hub

### DIFF
--- a/docker-compose.hub.yml
+++ b/docker-compose.hub.yml
@@ -105,6 +105,8 @@ services:
       # Intentionally DO NOT set NEXUS_API_KEY here — we want
       # unauthenticated requests (no bearer) to fail at the RPC layer
       # rather than fall through to an ambient "frontend" identity.
+      # Expose Prometheus-format hub frontend metrics at GET /metrics.
+      NEXUS_MCP_METRICS_ENABLED: "true"
     ports:
       - "8081:8081"
     depends_on:

--- a/docs/deployment/mcp-hub-mode.md
+++ b/docs/deployment/mcp-hub-mode.md
@@ -15,8 +15,18 @@ The MCP server (`nexus.bricks.mcp.server`) supports three transports — `stdio`
 | `NEXUS_MCP_RATE_LIMIT_PREMIUM` | `1000/minute` | Quota for admin / premium tokens |
 | `NEXUS_REDIS_URL` | unset | Redis/Dragonfly URL for rate limiter + audit publish |
 | `DRAGONFLY_URL` | unset | Alternative to `NEXUS_REDIS_URL` (both accepted) |
+| `NEXUS_MCP_METRICS_ENABLED` | unset | Set to `1` / `true` to expose Prometheus metrics at `/metrics` |
 
 Rate limiting falls back to in-process `memory://` storage when the Redis URL is unset or unreachable. Rate-limit checks fail open on runtime Redis errors so infrastructure outages don't block legitimate traffic.
+
+## Prometheus metrics
+
+When `NEXUS_MCP_METRICS_ENABLED=true`, the MCP HTTP server exposes
+Prometheus text format at `GET /metrics`. The endpoint reports
+`nexus_mcp_requests_total`, `nexus_mcp_request_latency_seconds`,
+`nexus_mcp_active_clients`, and `nexus_mcp_errors_total`. Existing
+Redis counters continue to back `nexus hub status` as a compatibility
+fallback.
 
 ## Audit log
 

--- a/docs/hub-deploy.md
+++ b/docs/hub-deploy.md
@@ -94,6 +94,10 @@ URL + one of the headers above.
 - **Audit logs** — every MCP request emits a JSON line to stdout
   (`docker compose logs -f nexus`) and publishes to Redis channel
   `nexus:audit:mcp` for external consumers.
+- **Prometheus metrics** — the reference hub compose enables
+  `NEXUS_MCP_METRICS_ENABLED=true`; scrape
+  `http://<hub-host>:8081/metrics` for MCP request counts, latency,
+  active clients, and errors.
 - **Rate limits** — configured per tier in the existing rate-limit
   middleware. See `src/nexus/bricks/mcp/middleware_ratelimit.py`.
 
@@ -154,6 +158,5 @@ Tracked as follow-up issues to #3784:
 
 - Multi-zone tokens
 - Remote admin CLI (admin over MCP with a bootstrap token)
-- Prometheus `/metrics` endpoint
 - Richer `hub status` (Zoekt/txtai queue depth, per-zone breakdown)
 - Kubernetes/Helm deploy

--- a/src/nexus/bricks/mcp/metrics.py
+++ b/src/nexus/bricks/mcp/metrics.py
@@ -1,0 +1,141 @@
+"""Prometheus metrics for the MCP HTTP hub frontend (#3873)."""
+
+from __future__ import annotations
+
+import os
+import threading
+import time
+from typing import Any
+
+from prometheus_client import CONTENT_TYPE_LATEST, Counter, Gauge, Histogram, generate_latest
+from starlette.responses import Response
+
+MCP_REQUESTS = Counter(
+    "nexus_mcp_requests_total",
+    "Total MCP HTTP requests observed by the hub frontend",
+    labelnames=["rpc_method", "tool_name", "status"],
+)
+
+MCP_REQUEST_LATENCY = Histogram(
+    "nexus_mcp_request_latency_seconds",
+    "MCP HTTP request latency in seconds observed by the hub frontend",
+    labelnames=["rpc_method", "tool_name", "status"],
+    buckets=(0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0),
+)
+
+MCP_ACTIVE_CLIENTS = Gauge(
+    "nexus_mcp_active_clients",
+    "Distinct MCP hub clients seen in the active window",
+)
+
+MCP_ERRORS = Counter(
+    "nexus_mcp_errors_total",
+    "Total MCP HTTP error responses observed by the hub frontend",
+    labelnames=["rpc_method", "tool_name", "status"],
+)
+
+_ACTIVE_CLIENT_TTL_SECONDS = 60.0
+_active_clients: dict[str, float] = {}
+_active_clients_lock = threading.Lock()
+
+
+def metrics_enabled() -> bool:
+    """Return whether the MCP /metrics route should be registered."""
+    return os.environ.get("NEXUS_MCP_METRICS_ENABLED", "").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _label(value: Any) -> str:
+    if value is None:
+        return "unknown"
+    text = str(value).strip()
+    return text if text else "unknown"
+
+
+def _status_group(status_code: Any) -> str:
+    try:
+        status = int(status_code)
+    except (TypeError, ValueError):
+        status = 500
+    return f"{status // 100}xx"
+
+
+def _client_id(record: dict[str, Any]) -> str:
+    return _label(record.get("subject_id") or record.get("token_hash") or "anonymous")
+
+
+def _refresh_active_clients(now: float | None = None) -> None:
+    current = time.monotonic() if now is None else now
+    cutoff = current - _ACTIVE_CLIENT_TTL_SECONDS
+    with _active_clients_lock:
+        stale = [client_id for client_id, seen_at in _active_clients.items() if seen_at < cutoff]
+        for client_id in stale:
+            _active_clients.pop(client_id, None)
+        MCP_ACTIVE_CLIENTS.set(len(_active_clients))
+
+
+def record_request_metrics(record: dict[str, Any]) -> None:
+    """Record one MCP audit record into the Prometheus registry."""
+    rpc_method = _label(record.get("rpc_method"))
+    tool_name = _label(record.get("tool_name"))
+    status = _status_group(record.get("status_code"))
+    labels = {
+        "rpc_method": rpc_method,
+        "tool_name": tool_name,
+        "status": status,
+    }
+
+    try:
+        latency_seconds = max(0.0, float(record.get("latency_ms", 0)) / 1000.0)
+    except (TypeError, ValueError):
+        latency_seconds = 0.0
+
+    MCP_REQUESTS.labels(**labels).inc()
+    MCP_REQUEST_LATENCY.labels(**labels).observe(latency_seconds)
+    if status.startswith(("4", "5")):
+        MCP_ERRORS.labels(**labels).inc()
+
+    with _active_clients_lock:
+        _active_clients[_client_id(record)] = time.monotonic()
+    _refresh_active_clients()
+
+
+def render_metrics() -> bytes:
+    """Render the current global Prometheus registry."""
+    _refresh_active_clients()
+    return generate_latest()
+
+
+def install_metrics_route(mcp_server: Any) -> bool:
+    """Register GET /metrics on a FastMCP server when enabled by env."""
+    if not metrics_enabled():
+        return False
+
+    @mcp_server.custom_route("/metrics", methods=["GET"])
+    async def metrics_endpoint(_request: Any) -> Response:
+        return Response(content=render_metrics(), media_type=CONTENT_TYPE_LATEST)
+
+    return True
+
+
+def _reset_for_tests() -> None:
+    """Reset in-process MCP metric state for focused unit tests."""
+    for metric in (MCP_REQUESTS, MCP_REQUEST_LATENCY, MCP_ERRORS):
+        children = metric._metrics
+        children.clear()
+    with _active_clients_lock:
+        _active_clients.clear()
+    MCP_ACTIVE_CLIENTS.set(0)
+
+
+__all__ = [
+    "CONTENT_TYPE_LATEST",
+    "install_metrics_route",
+    "metrics_enabled",
+    "record_request_metrics",
+    "render_metrics",
+]

--- a/src/nexus/bricks/mcp/middleware_audit.py
+++ b/src/nexus/bricks/mcp/middleware_audit.py
@@ -47,13 +47,24 @@ async def _publish_record(record: dict[str, Any]) -> None:
 
 
 async def _record_metrics(record: dict[str, Any]) -> None:
-    """Write lightweight Redis counters used by `nexus hub status` (#3784).
+    """Record MCP hub metrics for Prometheus and the Redis CLI fallback.
+
+    Prometheus metrics back the MCP ``/metrics`` endpoint (#3873).
+    Redis counters remain as the compatibility path for
+    ``nexus hub status`` (#3784).
 
     - ``nexus:hub:qps:<epoch-minute>``: INCR per audited request (10 min TTL).
     - ``nexus:hub:active:<epoch-minute>``: SADD subject_id (10 min TTL).
 
     Fire-and-forget: errors are swallowed so audit stays on the happy path.
     """
+    try:
+        from nexus.bricks.mcp.metrics import record_request_metrics
+
+        record_request_metrics(record)
+    except Exception:  # noqa: BLE001 — metrics must never break audit
+        logger.warning("mcp prometheus metrics failed", exc_info=True)
+
     try:
         import redis.asyncio as redis  # local import — optional
     except ImportError:

--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -2301,6 +2301,16 @@ async def _async_main() -> None:
     #   3. APIKey    — set `_request_api_key` contextvar for tool handlers
     if transport in ["http", "sse"]:
         try:
+            from nexus.bricks.mcp.metrics import install_metrics_route
+
+            install_metrics_route(mcp)
+        except Exception as e:
+            import logging
+
+            logger_ = logging.getLogger(__name__)
+            logger_.warning("Failed to add MCP metrics route: %s", e)
+
+        try:
             from starlette.middleware.base import BaseHTTPMiddleware
 
             from nexus.bricks.mcp.middleware_audit import MCPAuditLogMiddleware

--- a/src/nexus/cli/commands/mcp.py
+++ b/src/nexus/cli/commands/mcp.py
@@ -72,7 +72,8 @@ class _APIKeyMiddleware(BaseHTTPMiddleware):
     / profile credentials. This prevents unauthenticated requests from
     executing as the frontend's ambient identity on two-service hub
     deployments. ``/health`` is always allowed through so container
-    healthchecks keep working.
+    healthchecks keep working. ``/metrics`` is also allowed through so
+    Prometheus can scrape the opt-in hub metrics endpoint (#3873).
     """
 
     async def dispatch(self, request: "Request", call_next: Any) -> "Response":
@@ -88,7 +89,7 @@ class _APIKeyMiddleware(BaseHTTPMiddleware):
             "true",
             "yes",
         )
-        if require_bearer and not api_key and request.url.path != "/health":
+        if require_bearer and not api_key and request.url.path not in {"/health", "/metrics"}:
             from starlette.responses import JSONResponse
 
             return cast(
@@ -552,6 +553,13 @@ async def _async_serve(
         # Starlette instance per call, so post-hoc add_middleware is lost.
         if transport in ["http", "sse"]:
             _add_health_check_route(mcp_server)
+            try:
+                from nexus.bricks.mcp.metrics import install_metrics_route
+
+                if install_metrics_route(mcp_server):
+                    log_msg("  Metrics: /metrics enabled")
+            except Exception as e:
+                log_msg(f"Warning: Failed to add metrics route: {e}")
 
         return mcp_server
 

--- a/tests/unit/bricks/mcp/test_middleware_audit_metrics.py
+++ b/tests/unit/bricks/mcp/test_middleware_audit_metrics.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock
 import pytest
 import redis.asyncio as _redis_async
 
+from nexus.bricks.mcp import metrics as hub_metrics
 from nexus.bricks.mcp import middleware_audit as mw
 
 
@@ -85,3 +86,50 @@ async def test_record_metrics_swallows_redis_errors(monkeypatch):
 
     # Must not raise — audit is fire-and-forget.
     await mw._record_metrics({"subject_id": "kid_abc"})
+
+
+@pytest.mark.asyncio
+async def test_record_metrics_updates_prometheus_without_redis(monkeypatch):
+    monkeypatch.delenv("NEXUS_REDIS_URL", raising=False)
+    monkeypatch.delenv("DRAGONFLY_URL", raising=False)
+    hub_metrics._reset_for_tests()
+
+    await mw._record_metrics(
+        {
+            "subject_id": "kid_abc",
+            "token_hash": "deadbeef",
+            "rpc_method": "tools/call",
+            "tool_name": "nexus_grep",
+            "status_code": 200,
+            "latency_ms": 125,
+        }
+    )
+
+    body = hub_metrics.render_metrics().decode()
+    assert "nexus_mcp_requests_total" in body
+    assert "nexus_mcp_request_latency_seconds_bucket" in body
+    assert 'rpc_method="tools/call"' in body
+    assert 'tool_name="nexus_grep"' in body
+    assert 'status="2xx"' in body
+    assert "nexus_mcp_active_clients 1.0" in body
+
+
+@pytest.mark.asyncio
+async def test_record_metrics_updates_prometheus_error_counter(monkeypatch):
+    monkeypatch.delenv("NEXUS_REDIS_URL", raising=False)
+    monkeypatch.delenv("DRAGONFLY_URL", raising=False)
+    hub_metrics._reset_for_tests()
+
+    await mw._record_metrics(
+        {
+            "subject_id": "kid_abc",
+            "rpc_method": "tools/call",
+            "tool_name": "nexus_write_file",
+            "status_code": 500,
+            "latency_ms": 7,
+        }
+    )
+
+    body = hub_metrics.render_metrics().decode()
+    assert "nexus_mcp_errors_total" in body
+    assert 'status="5xx"' in body

--- a/tests/unit/cli/test_mcp_embedded_hub_rejection.py
+++ b/tests/unit/cli/test_mcp_embedded_hub_rejection.py
@@ -17,6 +17,7 @@ silently unsafe deployment.
 
 from __future__ import annotations
 
+import asyncio
 from typing import Any
 
 import click
@@ -26,6 +27,7 @@ from starlette.responses import PlainTextResponse
 from starlette.routing import Route
 from starlette.testclient import TestClient
 
+from nexus.bricks.mcp.metrics import CONTENT_TYPE_LATEST, install_metrics_route
 from nexus.cli.commands.mcp import _APIKeyMiddleware, _reject_embedded_hub_mode
 
 
@@ -148,12 +150,32 @@ async def _health(_request: Any) -> Any:
     return PlainTextResponse("healthy")
 
 
+async def _metrics(_request: Any) -> Any:
+    return PlainTextResponse("metrics")
+
+
 def _client() -> TestClient:
     app = Starlette(
-        routes=[Route("/mcp", _ok, methods=["POST"]), Route("/health", _health)],
+        routes=[
+            Route("/mcp", _ok, methods=["POST"]),
+            Route("/health", _health),
+            Route("/metrics", _metrics),
+        ],
     )
     app.add_middleware(_APIKeyMiddleware)
     return TestClient(app)
+
+
+class _FakeMCPServer:
+    def __init__(self) -> None:
+        self.routes: dict[tuple[str, tuple[str, ...]], Any] = {}
+
+    def custom_route(self, path: str, methods: list[str]) -> Any:
+        def _decorator(func: Any) -> Any:
+            self.routes[(path, tuple(methods))] = func
+            return func
+
+        return _decorator
 
 
 class TestResolvedRemoteUrlPropagation:
@@ -424,8 +446,35 @@ class TestRequireBearerGate:
         resp = _client().get("/health")
         assert resp.status_code == 200
 
+    def test_metrics_always_passes_without_bearer(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Prometheus scrapes must not need a hub bearer token."""
+        monkeypatch.setenv("NEXUS_MCP_REQUIRE_BEARER", "true")
+        resp = _client().get("/metrics")
+        assert resp.status_code == 200
+
     def test_false_values_disable_gate(self, monkeypatch: pytest.MonkeyPatch) -> None:
         for val in ("false", "0", "no", "", "off"):
             monkeypatch.setenv("NEXUS_MCP_REQUIRE_BEARER", val)
             resp = _client().post("/mcp")
             assert resp.status_code == 200, f"val={val!r} should not gate"
+
+
+class TestMCPMetricsRoute:
+    def test_metrics_route_is_not_added_by_default(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.delenv("NEXUS_MCP_METRICS_ENABLED", raising=False)
+        server = _FakeMCPServer()
+
+        assert install_metrics_route(server) is False
+        assert server.routes == {}
+
+    def test_metrics_route_is_added_when_enabled(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        monkeypatch.setenv("NEXUS_MCP_METRICS_ENABLED", "1")
+        server = _FakeMCPServer()
+
+        assert install_metrics_route(server) is True
+        endpoint = server.routes[("/metrics", ("GET",))]
+        response = asyncio.run(endpoint(None))
+
+        assert response.status_code == 200
+        assert response.media_type == CONTENT_TYPE_LATEST
+        assert b"# HELP" in response.body


### PR DESCRIPTION
## Summary

Adds an opt-in Prometheus `/metrics` endpoint for the MCP hub frontend, covering issue #3873.

- adds MCP hub Prometheus metrics for request count, latency histogram, active clients, and errors
- wires `/metrics` into both `nexus mcp serve` and the direct MCP server entrypoint when `NEXUS_MCP_METRICS_ENABLED=true`
- keeps bearer auth required for `/mcp` while allowing unauthenticated Prometheus scrapes of `/metrics`
- preserves the existing Redis-backed `nexus hub status` metrics path and documents the new scrape endpoint

Fixes #3873.

## Validation

- Live local E2E with `nexusd` + `nexus mcp serve`:
  - `GET /health` -> 200
  - unauthenticated `POST /mcp` -> 401
  - authenticated MCP `initialize` -> 200
  - `GET /metrics` -> 200 Prometheus text including request counter, latency histogram, active clients, errors, `rpc_method="initialize"`, `status="2xx"`, and `status="4xx"`
  - `nexus hub status --json` -> exit 0 with `postgres: "ok"`
- Focused unit tests before publishing: `27 passed`
- Commit hooks: ruff, ruff format, mypy, type-ignore policy, and repo safety checks all passed

## Notes

This local machine did not have Docker, Redis, or Postgres available, so Redis-backed hub status was validated through unit coverage and the live status check used an isolated SQLite auth DB.