### PR TITLE
Fix Docker Publish demo preflight

### DIFF
--- a/src/nexus/cli/commands/demo.py
+++ b/src/nexus/cli/commands/demo.py
@@ -318,18 +318,18 @@ def _get_nexus_client(config: dict[str, Any]) -> Any:
         # which populate the PostgreSQL file_paths table (required for semantic
         # search indexing). gRPC writes go to the Rust kernel natively and
         # bypass Python observers, so HERB files end up in Redb only.
-        # Probe a lightweight authenticated endpoint so a bad API key fails
-        # fast without exercising root VFS metadata.  On edge containers under
-        # startup load, ``/api/v2/files/metadata?path=/`` can block long enough
-        # to trip the CLI timeout even while the HTTP service is otherwise
-        # ready; actual file writes below still validate the file API path.
+        # Probe readiness before seeding.  On edge containers under startup
+        # load, data-plane endpoints such as ``/api/v2/files/metadata`` and
+        # ``/api/v2/connectors`` can block long enough to trip the CLI timeout
+        # even while the HTTP service is otherwise ready; actual file writes
+        # below still validate the API key and file API path.
         try:
             import httpx as _httpx
 
             from nexus.cli.api_client import NexusApiClient
 
             test_client = NexusApiClient(url=url, api_key=api_key)
-            test_client.get("/api/v2/connectors")
+            test_client.get("/healthz/ready")
             logger.info("demo preset: server reachable at %s — using REST API for seeding", url)
             return _RestApiNexusClient(url, api_key)
         except _httpx.HTTPStatusError:

--- a/tests/unit/cli/test_demo_preflight.py
+++ b/tests/unit/cli/test_demo_preflight.py
@@ -13,5 +13,6 @@ def test_remote_demo_preflight_avoids_root_metadata_probe() -> None:
         text.index('if preset in ("shared", "demo"):') : text.index("# Local preset")
     ]
 
-    assert 'test_client.get("/api/v2/connectors")' in remote_block
+    assert 'test_client.get("/healthz/ready")' in remote_block
+    assert 'test_client.get("/api/v2/connectors")' not in remote_block
     assert 'test_client.get("/api/v2/files/metadata", params={"path": "/"})' not in remote_block


### PR DESCRIPTION
## Summary
- switch `nexus demo init` remote preflight from `/api/v2/connectors` to `/healthz/ready`
- keep actual demo writes responsible for validating API key and file API behavior
- update the regression test so the preflight avoids startup-sensitive data-plane endpoints

## Verification
- `/opt/homebrew/bin/uv run --frozen python -m pytest tests/unit/cli/test_demo_preflight.py tests/unit/cli/test_demo.py -q -o addopts=`
- `/opt/homebrew/bin/uvx ruff check src/nexus/cli/commands/demo.py tests/unit/cli/test_demo_preflight.py`
- `/opt/homebrew/bin/uvx ruff format --check src/nexus/cli/commands/demo.py tests/unit/cli/test_demo_preflight.py`
- `git diff --check`