### PR TITLE
fix(#3947): drop ServiceDep token_manager from OAuth connectors

### DIFF
--- a/src/nexus/backends/_manifest.py
+++ b/src/nexus/backends/_manifest.py
@@ -27,7 +27,6 @@ from nexus.backends.base.runtime_deps import (
     BinaryDep,
     PythonDep,
     RuntimeDep,
-    ServiceDep,
 )
 
 
@@ -122,12 +121,18 @@ CONNECTOR_MANIFEST: tuple[ConnectorManifestEntry, ...] = (
     ),
     # --- OAuth / API connectors ---
     # Every OAuth connector uses OAuthConnectorMixin / OAuthConnectorBase,
-    # which lazily imports ``nexus.bricks.auth.oauth.factory`` at
-    # instantiation time (see src/nexus/backends/connectors/oauth_base.py).
-    # ``nexus.bricks`` is excluded from the slim wheel, so declaring
-    # ``ServiceDep("token_manager")`` here gates the mount with a clean
-    # ``MissingDependencyError`` on slim instead of leaking a raw
-    # ModuleNotFoundError from deep inside the OAuth factory call.
+    # which lazily imports ``nexus.bricks.auth.oauth.token_manager`` (and
+    # ``nexus.bricks.auth.oauth.factory``) at instantiation time (see
+    # src/nexus/backends/connectors/oauth_base.py and connectors/oauth.py).
+    # The slim wheel force-includes the auth/oauth bricks subtree (see
+    # packages/nexus-fs/pyproject.toml ``force-include``), and each OAuth
+    # connector extra (gdrive/gmail/gcalendar/slack/x) pins ``sqlalchemy``
+    # — together that means the lazy import succeeds whenever the matching
+    # extra is installed. The PythonDep entries below already gate on the
+    # extra-specific packages, so the connectors do **not** carry a
+    # ``ServiceDep("token_manager")`` — that gate would falsely advertise
+    # "requires a full nexus install" on slim even though slim ships
+    # everything the connector needs (Issue #3947).
     ConnectorManifestEntry(
         name="gdrive_connector",
         module_path="nexus.backends.connectors.gdrive.connector",
@@ -137,7 +142,6 @@ CONNECTOR_MANIFEST: tuple[ConnectorManifestEntry, ...] = (
         runtime_deps=(
             PythonDep("googleapiclient", extras=("gdrive",), package="google-api-python-client"),
             PythonDep("google_auth_oauthlib", extras=("gdrive",), package="google-auth-oauthlib"),
-            ServiceDep("token_manager"),
         ),
         service_name="google-drive",
     ),
@@ -150,7 +154,6 @@ CONNECTOR_MANIFEST: tuple[ConnectorManifestEntry, ...] = (
         runtime_deps=(
             PythonDep("googleapiclient", extras=("gmail",), package="google-api-python-client"),
             PythonDep("google_auth_oauthlib", extras=("gmail",), package="google-auth-oauthlib"),
-            ServiceDep("token_manager"),
         ),
         service_name="gmail",
     ),
@@ -165,7 +168,6 @@ CONNECTOR_MANIFEST: tuple[ConnectorManifestEntry, ...] = (
             PythonDep(
                 "google_auth_oauthlib", extras=("gcalendar",), package="google-auth-oauthlib"
             ),
-            ServiceDep("token_manager"),
         ),
         service_name="google-calendar",
     ),
@@ -180,7 +182,6 @@ CONNECTOR_MANIFEST: tuple[ConnectorManifestEntry, ...] = (
             PythonDep(
                 "google_auth_oauthlib", extras=("gcalendar",), package="google-auth-oauthlib"
             ),
-            ServiceDep("token_manager"),
         ),
         service_name="google-calendar",
     ),
@@ -190,10 +191,7 @@ CONNECTOR_MANIFEST: tuple[ConnectorManifestEntry, ...] = (
         class_name="PathXBackend",
         description="X (Twitter) API with OAuth 2.0 PKCE",
         category="api",
-        runtime_deps=(
-            PythonDep("requests_oauthlib", extras=("x",), package="requests-oauthlib"),
-            ServiceDep("token_manager"),
-        ),
+        runtime_deps=(PythonDep("requests_oauthlib", extras=("x",), package="requests-oauthlib"),),
         service_name="x",
     ),
     ConnectorManifestEntry(
@@ -202,10 +200,7 @@ CONNECTOR_MANIFEST: tuple[ConnectorManifestEntry, ...] = (
         class_name="PathSlackBackend",
         description="Slack workspace with OAuth 2.0 authentication",
         category="oauth",
-        runtime_deps=(
-            PythonDep("slack_sdk", extras=("slack",), package="slack-sdk"),
-            ServiceDep("token_manager"),
-        ),
+        runtime_deps=(PythonDep("slack_sdk", extras=("slack",), package="slack-sdk"),),
         service_name="slack",
     ),
     ConnectorManifestEntry(

--- a/src/nexus/backends/base/runtime_deps.py
+++ b/src/nexus/backends/base/runtime_deps.py
@@ -86,14 +86,20 @@ def _server_available() -> bool:
 # Per-service probe mapping. Each entry maps a ``ServiceDep.name`` to the
 # dotted module path that implements the service. When ``check_runtime_deps``
 # evaluates a ``ServiceDep``, it tests the specific module rather than
-# ``nexus.server`` as a whole — so a connector that only needs
-# ``token_manager`` doesn't get falsely gated out when the server package
-# is present but the auth module isn't (or vice versa).
+# ``nexus.server`` as a whole — so a connector that only needs e.g.
+# ``record_store`` doesn't get falsely gated out when the server package
+# is present but the storage module isn't (or vice versa).
 #
 # Services without an entry here fall back to ``_server_available()``, the
 # coarser "full install present" check.
+#
+# ``token_manager`` intentionally has no entry: the auth/oauth bricks are
+# force-included into the slim wheel (see packages/nexus-fs/pyproject.toml),
+# so the OAuth connectors mount fine on slim and don't need a service gate
+# (Issue #3947).  Restoring it here would re-introduce an implicit
+# dependency on ``nexus.bricks`` from runtime dep checks, which slim is
+# explicitly trying to avoid.
 _SERVICE_MODULES: dict[str, str] = {
-    "token_manager": "nexus.bricks.auth.oauth.token_manager",
     "kernel": "nexus.core.kernel",
     "record_store": "nexus.storage.record_store",
     "metastore": "nexus.storage",

--- a/src/nexus/backends/base/runtime_deps.py
+++ b/src/nexus/backends/base/runtime_deps.py
@@ -84,26 +84,131 @@ def _server_available() -> bool:
 
 
 # Per-service probe mapping. Each entry maps a ``ServiceDep.name`` to the
-# dotted module path that implements the service. When ``check_runtime_deps``
-# evaluates a ``ServiceDep``, it tests the specific module rather than
-# ``nexus.server`` as a whole — so a connector that only needs e.g.
-# ``record_store`` doesn't get falsely gated out when the server package
-# is present but the storage module isn't (or vice versa).
+# tuple of dotted module paths that must all resolve before the service is
+# usable. When ``check_runtime_deps`` evaluates a ``ServiceDep``, it probes
+# every module in the tuple instead of ``nexus.server`` as a whole — so a
+# connector that only needs e.g. ``token_manager`` doesn't get falsely
+# gated out when the server package is present but the auth module isn't
+# (or vice versa).
 #
 # Services without an entry here fall back to ``_server_available()``, the
 # coarser "full install present" check.
 #
-# ``token_manager`` intentionally has no entry: the auth/oauth bricks are
-# force-included into the slim wheel (see packages/nexus-fs/pyproject.toml),
-# so the OAuth connectors mount fine on slim and don't need a service gate
-# (Issue #3947).  Restoring it here would re-introduce an implicit
-# dependency on ``nexus.bricks`` from runtime dep checks, which slim is
-# explicitly trying to avoid.
-_SERVICE_MODULES: dict[str, str] = {
-    "kernel": "nexus.core.kernel",
-    "record_store": "nexus.storage.record_store",
-    "metastore": "nexus.storage",
+# ``token_manager`` keeps a per-module probe so that any external or
+# legacy connector / extension manifest that still declares
+# ``ServiceDep("token_manager")`` resolves against the auth/oauth bricks
+# that the slim wheel force-includes (see packages/nexus-fs/pyproject.toml)
+# — the probe must not fall through to the coarser server-runtime check
+# (Issue #3947). The probe tuple also lists ``sqlalchemy`` because the
+# token_manager module imports it at top level: a base slim install ships
+# the bricks file but not sqlalchemy (it lives in the OAuth connector
+# extras), so a presence-only probe would falsely report the service
+# satisfied and the consumer would hit a raw ``ModuleNotFoundError`` at
+# instantiation time. Built-in OAuth manifest entries no longer carry this
+# ServiceDep — their PythonDep gates already cover what slim users see —
+# but the mapping stays so third-party plugins keep working.
+_SERVICE_MODULES: dict[str, tuple[str, ...]] = {
+    "token_manager": ("nexus.bricks.auth.oauth.token_manager", "sqlalchemy"),
+    "kernel": ("nexus.core.kernel",),
+    "record_store": ("nexus.storage.record_store",),
+    "metastore": ("nexus.storage",),
 }
+
+
+# Minimum installed-distribution versions per service. Each entry maps
+# ``ServiceDep.name`` → ``{distribution_name: (major, minor, ...)}``. A
+# service that lists a distribution here is satisfied only when the
+# matching entry from ``importlib.metadata.version`` parses to a tuple
+# ``>= min_version``. ``find_spec`` alone cannot distinguish SQLAlchemy
+# 1.x (compatible API gone) from 2.x — token_manager imports
+# ``nexus.storage.models`` which uses ``sqlalchemy.orm.mapped_column``
+# and other 2.x-only symbols, so a SQLAlchemy 1.x install would pass the
+# presence probe and crash at import time. Pinning the minimum here
+# turns that into a clean ``MissingDependencyError`` (Issue #3947).
+_SERVICE_MIN_VERSIONS: dict[str, dict[str, tuple[int, ...]]] = {
+    "token_manager": {"sqlalchemy": (2, 0)},
+}
+
+
+def _parse_version_prefix(text: str) -> tuple[int, ...]:
+    """Parse a leading dotted-int prefix from a PEP 440 version string.
+
+    Returns ``(major, minor, patch, ...)`` for whatever leading
+    integer-only segments exist (``"2.0.30"`` → ``(2, 0, 30)``,
+    ``"2.0.0rc3"`` → ``(2, 0, 0)``). Non-integer / pre-release / post-
+    release suffixes stop parsing — we only need the comparable numeric
+    head for our minimum-version probes, and pulling in ``packaging`` as
+    a slim base dep would inflate the wheel for one comparison.
+    """
+    parts: list[int] = []
+    for chunk in text.split("."):
+        digits = ""
+        for ch in chunk:
+            if ch.isdigit():
+                digits += ch
+            else:
+                break
+        if not digits:
+            break
+        parts.append(int(digits))
+    return tuple(parts)
+
+
+def _is_prerelease(text: str) -> bool:
+    """Return True for PEP 440 prerelease / dev versions.
+
+    Per PEP 440, ``X.Y.Z<marker>`` (e.g. ``2.0.0rc1``, ``2.0.0a3``,
+    ``2.0.0.dev0``) sorts strictly **before** the corresponding final
+    release ``X.Y.Z``. Post-releases (``X.Y.Z.postN``) and local
+    versions (``X.Y.Z+local``) sort at-or-after the final, so they are
+    not flagged here. We avoid pulling in ``packaging`` to keep the
+    slim wheel's base dependency list thin.
+    """
+    i = 0
+    while i < len(text) and (text[i].isdigit() or text[i] == "."):
+        i += 1
+    suffix = text[i:].lower()
+    if not suffix:
+        return False
+    if suffix.startswith("+"):
+        return False
+    if suffix.startswith("post"):
+        return False
+    if suffix.startswith("dev"):
+        return True
+    return suffix[0].isalpha()
+
+
+def _meets_min_version(distribution: str, minimum: tuple[int, ...]) -> bool:
+    """Return True when ``distribution`` reports a version ≥ ``minimum``.
+
+    Returns False on lookup / parse failure so the service is reported
+    missing rather than silently passing an unverifiable install.
+    Prereleases of the minimum (e.g. ``2.0.0rc1`` against minimum
+    ``(2, 0)``) are rejected — they sort strictly below the final
+    release and may lack the APIs the consumer expects (Issue #3947).
+    """
+    try:
+        installed_text = importlib.metadata.version(distribution)
+    except importlib.metadata.PackageNotFoundError:
+        return False
+    installed = _parse_version_prefix(installed_text)
+    if not installed:
+        return False
+    # Normalize both sides with trailing zeros so PEP 440 implicit-zero
+    # padding lines up: minimum ``(2, 0)`` means the same release as
+    # ``2.0.0``, so an installed ``(2, 0, 0)`` must compare equal to it.
+    width = max(len(installed), len(minimum))
+    installed_padded = installed + (0,) * (width - len(installed))
+    minimum_padded = minimum + (0,) * (width - len(minimum))
+    if _is_prerelease(installed_text):
+        # Prerelease X.Y.Z<marker> sorts strictly below X.Y.Z final, so
+        # require strict greater-than the minimum:
+        #   * 2.0.0rc1  → (2, 0, 0) ≯ (2, 0, 0) → reject
+        #   * 2.0.1rc1  → (2, 0, 1) >  (2, 0, 0) → accept (already past 2.0.0)
+        #   * 2.5.0rc1  → (2, 5, 0) >  (2, 0, 0) → accept
+        return installed_padded > minimum_padded
+    return installed_padded >= minimum_padded
 
 
 @functools.cache
@@ -129,16 +234,37 @@ def _nexus_fs_extras_available() -> bool:
     return dist_set == {"nexus-fs"}
 
 
-@functools.cache
 def _service_available(name: str) -> bool:
-    """Return True when the named service's implementing module is importable."""
-    module_path = _SERVICE_MODULES.get(name)
-    if module_path is None:
+    """Return True when the named service's implementing modules are importable.
+
+    Every module listed in ``_SERVICE_MODULES[name]`` must resolve **and**
+    every distribution in ``_SERVICE_MIN_VERSIONS[name]`` must report a
+    version ≥ its minimum for the service to count as available. Services
+    without an entry fall back to ``_server_available()``, the coarser
+    "full install present" check.
+
+    The result is intentionally **not** cached: a service probe may include
+    an installable third-party dep (e.g. ``sqlalchemy`` for the token
+    manager) which can appear mid-process when users ``pip install`` an
+    OAuth extra. Caching would freeze the negative answer and break the
+    retry-after-install path. The fallback ``_server_available`` is still
+    cached because ``nexus.server`` cannot appear without a process
+    restart (Issue #3947).
+    """
+    module_paths = _SERVICE_MODULES.get(name)
+    if module_paths is None:
         return _server_available()
-    try:
-        return importlib.util.find_spec(module_path) is not None
-    except (ImportError, ModuleNotFoundError, ValueError):
-        return False
+    for module_path in module_paths:
+        try:
+            spec = importlib.util.find_spec(module_path)
+        except (ImportError, ModuleNotFoundError, ValueError):
+            return False
+        if spec is None:
+            return False
+    for distribution, minimum in _SERVICE_MIN_VERSIONS.get(name, {}).items():
+        if not _meets_min_version(distribution, minimum):
+            return False
+    return True
 
 
 def check_runtime_deps(
@@ -190,14 +316,49 @@ def check_runtime_deps(
                     server_available if server_available is not None else _service_available(name)
                 )
                 if not available:
-                    missing.append(
-                        (
-                            dep,
-                            f"service '{name}': requires a full nexus install "
-                            f"(slim wheel has no server runtime)",
-                        )
-                    )
+                    missing.append((dep, _service_dep_reason(name, server_available)))
     return missing
+
+
+def _service_dep_reason(name: str, server_available_override: bool | None) -> str:
+    """Build a human-readable reason for a missing ``ServiceDep``.
+
+    When the override forces unavailability, the failure is by definition
+    "no server runtime" so the legacy message stands. Otherwise, identify
+    the specific module that didn't resolve. If it looks like an
+    installable third-party package (no ``nexus.`` prefix), point the user
+    at ``pip install <pkg>``; otherwise fall back to the "requires a full
+    nexus install" message that matches the existing semantics for
+    server-only services (Issue #3947).
+    """
+    if server_available_override is False:
+        return f"service '{name}': requires a full nexus install (slim wheel has no server runtime)"
+    module_paths = _SERVICE_MODULES.get(name)
+    if module_paths:
+        for module_path in module_paths:
+            try:
+                spec = importlib.util.find_spec(module_path)
+            except (ImportError, ModuleNotFoundError, ValueError):
+                spec = None
+            if spec is None:
+                if not module_path.startswith("nexus."):
+                    return (
+                        f"service '{name}': missing python '{module_path}' — "
+                        f"install with: pip install {module_path}"
+                    )
+                return (
+                    f"service '{name}': missing module '{module_path}' "
+                    f"(requires a full nexus install)"
+                )
+        for distribution, minimum in _SERVICE_MIN_VERSIONS.get(name, {}).items():
+            if not _meets_min_version(distribution, minimum):
+                spec_str = ".".join(str(part) for part in minimum)
+                return (
+                    f"service '{name}': '{distribution}' version too old "
+                    f"(need >= {spec_str}) — "
+                    f"install with: pip install '{distribution}>={spec_str}'"
+                )
+    return f"service '{name}': requires a full nexus install (slim wheel has no server runtime)"
 
 
 __all__ = [

--- a/tests/integration/slim/test_slim_install_smoke.py
+++ b/tests/integration/slim/test_slim_install_smoke.py
@@ -190,6 +190,71 @@ def test_slim_connector_imports(slim_venv: Path, connector_module: str) -> None:
     assert "OK" in result.stdout
 
 
+def test_slim_base_service_dep_token_manager_unsatisfied(slim_base_venv: Path) -> None:
+    """Issue #3947: on a base slim install (no OAuth extras),
+    ``ServiceDep("token_manager")`` must report missing — sqlalchemy is
+    only declared in the OAuth connector extras, and a presence-only probe
+    against the force-included token_manager.py would otherwise mark the
+    service satisfied even though importing it would raise
+    ``ModuleNotFoundError: sqlalchemy`` at instantiation time.
+    """
+    script = """
+from nexus.backends.base.runtime_deps import (
+    ServiceDep,
+    check_runtime_deps,
+)
+
+missing = check_runtime_deps((ServiceDep("token_manager"),))
+assert missing, "ServiceDep(\\"token_manager\\") falsely satisfied on base slim"
+_, reason = missing[0]
+assert "service \\"token_manager\\"" in reason or "service 'token_manager'" in reason, reason
+print("BASE-SLIM-TOKEN-MANAGER-UNSATISFIED-OK")
+"""
+    result = run_in_slim_venv(slim_base_venv, script)
+    assert result.returncode == 0, (
+        f"base-slim ServiceDep(token_manager) audit failed:\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+    assert "BASE-SLIM-TOKEN-MANAGER-UNSATISFIED-OK" in result.stdout
+
+
+def test_slim_service_dep_token_manager_is_satisfied(slim_venv: Path) -> None:
+    """Issue #3947: legacy / third-party manifests that still declare
+    ``ServiceDep("token_manager")`` must be reported as *satisfied* in a
+    slim install, because the auth/oauth bricks are force-included.
+
+    Without the per-module probe in ``_SERVICE_MODULES`` the check falls
+    through to ``_server_available()`` and falsely raises "requires a full
+    nexus install" — even though the slim wheel ships the token manager.
+    Pin that mapping with an end-to-end check that runs inside the slim
+    venv (no full server runtime present).
+    """
+    script = """
+from nexus.backends.base.runtime_deps import (
+    ServiceDep,
+    _server_available,
+    check_runtime_deps,
+)
+
+# Sanity: nexus.server is not available in a slim install.
+_server_available.cache_clear()
+assert not _server_available(), "slim venv unexpectedly has nexus.server"
+
+# token_manager probe must hit the per-module path, not the server fallback.
+missing = check_runtime_deps((ServiceDep("token_manager"),))
+assert not missing, (
+    f"ServiceDep(\\"token_manager\\") falsely reported missing on slim: {missing}"
+)
+print("TOKEN-MANAGER-SERVICE-OK")
+"""
+    result = run_in_slim_venv(slim_venv, script)
+    assert result.returncode == 0, (
+        f"ServiceDep(token_manager) slim probe failed:\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+    assert "TOKEN-MANAGER-SERVICE-OK" in result.stdout
+
+
 def test_slim_oauth_extras_independent_of_bricks(slim_venv: Path) -> None:
     """Issue #3947: each advertised OAuth/API extra must import and pass
     runtime-dep checks without ``nexus.bricks`` being importable.

--- a/tests/integration/slim/test_slim_install_smoke.py
+++ b/tests/integration/slim/test_slim_install_smoke.py
@@ -188,3 +188,86 @@ def test_slim_connector_imports(slim_venv: Path, connector_module: str) -> None:
         f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
     )
     assert "OK" in result.stdout
+
+
+def test_slim_oauth_extras_independent_of_bricks(slim_venv: Path) -> None:
+    """Issue #3947: each advertised OAuth/API extra must import and pass
+    runtime-dep checks without ``nexus.bricks`` being importable.
+
+    The slim wheel ships the auth/oauth bricks subtree so OAuth connectors
+    work end-to-end; the runtime-dep contract is the *advertised* gate
+    users hit when a mount fails.  Encoding a ``nexus.bricks`` dependency
+    in that gate would falsely advertise "requires a full nexus install"
+    even though the slim wheel + OAuth extras already ship everything the
+    connector needs.
+
+    This test installs the ``meta_path`` blocker before any backend module
+    has been touched, then verifies:
+
+    1. The connector module itself imports (top-level imports must not
+       reach into ``nexus.bricks``).
+    2. The manifest entry carries no ``ServiceDep`` (token_manager service
+       gate would smuggle a bricks probe back in).
+    3. ``check_runtime_deps`` for the entry returns no missing deps —
+       so the only failure modes left are real external creds / packages.
+    """
+    script = '''
+import sys
+
+class _BlockBricks:
+    """Reject any import of nexus.bricks.* — proves the runtime-dep
+    check does not transitively need the bricks tree."""
+
+    def find_spec(self, name, path=None, target=None):
+        if name == "nexus.bricks" or name.startswith("nexus.bricks."):
+            raise ModuleNotFoundError(f"blocked by test: {name}")
+        return None
+
+sys.meta_path.insert(0, _BlockBricks())
+
+# Manifest must import without touching bricks.
+from nexus.backends._manifest import CONNECTOR_MANIFEST
+from nexus.backends.base.runtime_deps import (
+    PythonDep,
+    ServiceDep,
+    check_runtime_deps,
+)
+
+oauth_names = {
+    "gdrive_connector",
+    "gmail_connector",
+    "calendar_connector",
+    "gcalendar_connector",
+    "x_connector",
+    "slack_connector",
+}
+seen = set()
+for entry in CONNECTOR_MANIFEST:
+    if entry.name not in oauth_names:
+        continue
+    seen.add(entry.name)
+    for dep in entry.runtime_deps:
+        assert not isinstance(dep, ServiceDep), (
+            f"{entry.name} carries ServiceDep({dep.name!r}); the OAuth "
+            "extras must not gate on a server-side service probe."
+        )
+        if isinstance(dep, PythonDep):
+            assert "nexus.bricks" not in dep.module, (
+                f"{entry.name} declares PythonDep({dep.module!r}); runtime-dep "
+                "checks must not target the bricks tree."
+            )
+    missing = check_runtime_deps(entry.runtime_deps)
+    assert not missing, (
+        f"{entry.name} reports missing runtime deps even with the matching "
+        f"extra installed: {missing}"
+    )
+
+assert seen == oauth_names, f"manifest is missing OAuth entries: {oauth_names - seen}"
+print("OAUTH-DEPS-OK")
+'''
+    result = run_in_slim_venv(slim_venv, script)
+    assert result.returncode == 0, (
+        f"OAuth extras manifest dep audit failed:\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+    assert "OAUTH-DEPS-OK" in result.stdout

--- a/tests/unit/backends/test_runtime_deps.py
+++ b/tests/unit/backends/test_runtime_deps.py
@@ -145,26 +145,232 @@ class TestCheckRuntimeDeps:
         assert "brew install xyz" in reason
 
     def test_service_dep_satisfied_when_server_available(self) -> None:
-        missing = check_runtime_deps((ServiceDep("kernel"),), server_available=True)
+        missing = check_runtime_deps((ServiceDep("token_manager"),), server_available=True)
         assert missing == []
 
     def test_service_dep_missing_when_slim(self) -> None:
-        missing = check_runtime_deps((ServiceDep("kernel"),), server_available=False)
+        missing = check_runtime_deps((ServiceDep("token_manager"),), server_available=False)
         assert len(missing) == 1
         _, reason = missing[0]
-        assert "service 'kernel'" in reason
+        assert "service 'token_manager'" in reason
         assert "full nexus install" in reason
 
-    def test_token_manager_not_in_service_map(self) -> None:
-        """``token_manager`` must not be a registered service: the auth/oauth
-        bricks are force-included in the slim wheel, so OAuth connectors
-        rely on the shipped module rather than a server-side service probe
-        (Issue #3947).  Re-introducing the entry would smuggle a
-        ``nexus.bricks`` dependency back into the slim runtime-dep path.
+    def test_token_manager_service_probe_includes_sqlalchemy(self) -> None:
+        """``token_manager`` keeps a per-module probe so legacy / third-party
+        manifests that still declare ``ServiceDep("token_manager")`` resolve
+        against the actually-shipped module rather than falling through to
+        ``_server_available()``, which would falsely report missing on slim
+        even though the auth/oauth bricks are force-included (Issue #3947).
+
+        The probe tuple lists ``sqlalchemy`` alongside the bricks module
+        because token_manager imports sqlalchemy at top level: a base slim
+        install ships the bricks file but not sqlalchemy, so a
+        presence-only probe would mark the service satisfied and the
+        consumer would hit a raw ``ModuleNotFoundError`` later.
         """
         from nexus.backends.base.runtime_deps import _SERVICE_MODULES
 
-        assert "token_manager" not in _SERVICE_MODULES
+        modules = _SERVICE_MODULES["token_manager"]
+        assert "nexus.bricks.auth.oauth.token_manager" in modules
+        assert "sqlalchemy" in modules
+
+    def test_service_dep_unsatisfied_when_partial_modules_missing(self) -> None:
+        """A multi-module service must fail when *any* module is missing —
+        otherwise consumers see a false-positive availability and crash at
+        import time on a real-world dep gap (Issue #3947).
+        """
+        from unittest.mock import patch
+
+        from nexus.backends.base.runtime_deps import _service_available
+
+        def _fake_find_spec(name: str) -> object | None:
+            # Pretend the bricks module is shipped but sqlalchemy is not —
+            # this is exactly the base-slim shape.
+            if name == "nexus.bricks.auth.oauth.token_manager":
+                return object()
+            if name == "sqlalchemy":
+                return None
+            return object()
+
+        with patch(
+            "nexus.backends.base.runtime_deps.importlib.util.find_spec",
+            side_effect=_fake_find_spec,
+        ):
+            assert not _service_available("token_manager")
+
+    def test_service_dep_reevaluates_after_install(self) -> None:
+        """Retry-after-install must work: a process that hits a missing
+        ``sqlalchemy`` once, then has it installed mid-run, must see the
+        next ``check_runtime_deps`` call report the service satisfied
+        (Issue #3947). A cached negative would freeze the bad answer.
+        """
+        from unittest.mock import patch
+
+        # Phase 1: sqlalchemy not yet installed.
+        def _missing(name: str) -> object | None:
+            if name == "sqlalchemy":
+                return None
+            return object()
+
+        with patch(
+            "nexus.backends.base.runtime_deps.importlib.util.find_spec",
+            side_effect=_missing,
+        ):
+            phase1 = check_runtime_deps((ServiceDep("token_manager"),))
+        assert phase1, "expected ServiceDep('token_manager') to be missing pre-install"
+
+        # Phase 2: same process, sqlalchemy now resolves.
+        def _present(name: str) -> object | None:
+            return object()
+
+        with patch(
+            "nexus.backends.base.runtime_deps.importlib.util.find_spec",
+            side_effect=_present,
+        ):
+            phase2 = check_runtime_deps((ServiceDep("token_manager"),))
+        assert not phase2, f"ServiceDep('token_manager') still missing after install: {phase2}"
+
+    def test_service_dep_rejects_old_sqlalchemy(self) -> None:
+        """A SQLAlchemy 1.x install is importable but missing 2.x APIs that
+        ``token_manager`` (via ``nexus.storage.models``) needs. The probe
+        must report the service missing rather than passing on presence
+        alone (Issue #3947).
+        """
+        from unittest.mock import patch
+
+        with (
+            patch(
+                "nexus.backends.base.runtime_deps.importlib.util.find_spec",
+                side_effect=lambda _name: object(),
+            ),
+            patch(
+                "nexus.backends.base.runtime_deps.importlib.metadata.version",
+                lambda dist: "1.4.49" if dist == "sqlalchemy" else "0.0",
+            ),
+        ):
+            missing = check_runtime_deps((ServiceDep("token_manager"),))
+        assert len(missing) == 1
+        _, reason = missing[0]
+        assert "sqlalchemy" in reason
+        assert ">= 2.0" in reason
+        assert "pip install 'sqlalchemy>=2.0'" in reason
+
+    def test_service_dep_accepts_sqlalchemy_2x_and_newer(self) -> None:
+        """Pinning a minimum must not lock out forward-compatible majors.
+        Both ``2.0.30`` and ``2.5.0`` should satisfy ``>= 2.0``.
+        """
+        from unittest.mock import patch
+
+        for installed in ("2.0.30", "2.5.0"):
+            with (
+                patch(
+                    "nexus.backends.base.runtime_deps.importlib.util.find_spec",
+                    side_effect=lambda _name: object(),
+                ),
+                patch(
+                    "nexus.backends.base.runtime_deps.importlib.metadata.version",
+                    lambda dist, _v=installed: _v if dist == "sqlalchemy" else "0.0",
+                ),
+            ):
+                missing = check_runtime_deps((ServiceDep("token_manager"),))
+            assert not missing, f"sqlalchemy {installed} should satisfy: {missing}"
+
+    def test_parse_version_prefix_handles_pre_release(self) -> None:
+        """Version-prefix parser must tolerate PEP 440 suffixes (rc, post,
+        dev, etc.) without failing the comparison."""
+        from nexus.backends.base.runtime_deps import _parse_version_prefix
+
+        assert _parse_version_prefix("2.0.0rc3") == (2, 0, 0)
+        assert _parse_version_prefix("2.1.dev0") == (2, 1)
+        assert _parse_version_prefix("2.0.30") == (2, 0, 30)
+        assert _parse_version_prefix("not-a-version") == ()
+
+    def test_is_prerelease_classifies_pep440_suffixes(self) -> None:
+        """PEP 440 prerelease / dev suffixes must be recognized so the
+        version probe can reject them when their numeric prefix equals
+        the required final release (Issue #3947)."""
+        from nexus.backends.base.runtime_deps import _is_prerelease
+
+        assert _is_prerelease("2.0.0rc1")
+        assert _is_prerelease("2.0.0a1")
+        assert _is_prerelease("2.0.0b1")
+        assert _is_prerelease("2.0.0.dev0")
+        assert _is_prerelease("2.0.0alpha1")
+        assert _is_prerelease("2.0.0beta1")
+        # Post-releases and local versions count as final.
+        assert not _is_prerelease("2.0.0")
+        assert not _is_prerelease("2.0.0.post1")
+        assert not _is_prerelease("2.0.0+local")
+
+    def test_service_dep_rejects_prerelease_at_minimum(self) -> None:
+        """A prerelease whose numeric prefix matches the minimum sorts
+        strictly below the final release — token_manager must reject it
+        because it might be missing 2.0 final APIs (Issue #3947).
+        """
+        from unittest.mock import patch
+
+        for prerelease in ("2.0.0rc1", "2.0.0a1", "2.0.0b1", "2.0.0.dev0"):
+            with (
+                patch(
+                    "nexus.backends.base.runtime_deps.importlib.util.find_spec",
+                    side_effect=lambda _name: object(),
+                ),
+                patch(
+                    "nexus.backends.base.runtime_deps.importlib.metadata.version",
+                    lambda dist, _v=prerelease: _v if dist == "sqlalchemy" else "0.0",
+                ),
+            ):
+                missing = check_runtime_deps((ServiceDep("token_manager"),))
+            assert missing, f"prerelease {prerelease} must not satisfy >= 2.0"
+            _, reason = missing[0]
+            assert ">= 2.0" in reason
+
+    def test_service_dep_accepts_prerelease_above_minimum(self) -> None:
+        """A prerelease whose numeric position is strictly above the
+        minimum may legitimately ship the required APIs — the probe must
+        accept it. ``2.5.0rc1`` covers next-minor; ``2.0.1rc1`` and
+        ``2.0.30rc1`` cover same-minor patch prereleases that PEP 440
+        sorts above ``2.0.0`` final (Issue #3947).
+        """
+        from unittest.mock import patch
+
+        for prerelease in ("2.5.0rc1", "2.0.1rc1", "2.0.30rc1"):
+            with (
+                patch(
+                    "nexus.backends.base.runtime_deps.importlib.util.find_spec",
+                    side_effect=lambda _name: object(),
+                ),
+                patch(
+                    "nexus.backends.base.runtime_deps.importlib.metadata.version",
+                    lambda dist, _v=prerelease: _v if dist == "sqlalchemy" else "0.0",
+                ),
+            ):
+                missing = check_runtime_deps((ServiceDep("token_manager"),))
+            assert not missing, f"prerelease {prerelease} should satisfy >= 2.0: {missing}"
+
+    def test_service_dep_reason_points_at_missing_python_dep(self) -> None:
+        """When a service probe fails because of an installable third-party
+        module (e.g. ``sqlalchemy``), the reason text must point users at
+        ``pip install <pkg>`` rather than the misleading "full nexus
+        install" message (Issue #3947).
+        """
+        from unittest.mock import patch
+
+        def _bricks_present_sqlalchemy_missing(name: str) -> object | None:
+            if name == "sqlalchemy":
+                return None
+            return object()
+
+        with patch(
+            "nexus.backends.base.runtime_deps.importlib.util.find_spec",
+            side_effect=_bricks_present_sqlalchemy_missing,
+        ):
+            missing = check_runtime_deps((ServiceDep("token_manager"),))
+        assert len(missing) == 1
+        _, reason = missing[0]
+        assert "sqlalchemy" in reason
+        assert "pip install sqlalchemy" in reason
+        assert "full nexus install" not in reason
 
     def test_aggregates_all_missing(self) -> None:
         deps: tuple[RuntimeDep, ...] = (

--- a/tests/unit/backends/test_runtime_deps.py
+++ b/tests/unit/backends/test_runtime_deps.py
@@ -145,15 +145,26 @@ class TestCheckRuntimeDeps:
         assert "brew install xyz" in reason
 
     def test_service_dep_satisfied_when_server_available(self) -> None:
-        missing = check_runtime_deps((ServiceDep("token_manager"),), server_available=True)
+        missing = check_runtime_deps((ServiceDep("kernel"),), server_available=True)
         assert missing == []
 
     def test_service_dep_missing_when_slim(self) -> None:
-        missing = check_runtime_deps((ServiceDep("token_manager"),), server_available=False)
+        missing = check_runtime_deps((ServiceDep("kernel"),), server_available=False)
         assert len(missing) == 1
         _, reason = missing[0]
-        assert "service 'token_manager'" in reason
+        assert "service 'kernel'" in reason
         assert "full nexus install" in reason
+
+    def test_token_manager_not_in_service_map(self) -> None:
+        """``token_manager`` must not be a registered service: the auth/oauth
+        bricks are force-included in the slim wheel, so OAuth connectors
+        rely on the shipped module rather than a server-side service probe
+        (Issue #3947).  Re-introducing the entry would smuggle a
+        ``nexus.bricks`` dependency back into the slim runtime-dep path.
+        """
+        from nexus.backends.base.runtime_deps import _SERVICE_MODULES
+
+        assert "token_manager" not in _SERVICE_MODULES
 
     def test_aggregates_all_missing(self) -> None:
         deps: tuple[RuntimeDep, ...] = (


### PR DESCRIPTION
## Summary
- Drops `ServiceDep(\"token_manager\")` from the 6 OAuth connector manifest entries (gdrive/gmail/calendar/gcalendar/x/slack). The slim wheel force-includes `nexus.bricks.auth.oauth.*` since #3944, so the gate is redundant — and worse, it encodes a `nexus.bricks` dependency into the runtime-dep contract itself, falsely advertising \"requires a full nexus install\" on a slim wheel that already ships everything the connector needs.
- Removes the matching `\"token_manager\"` entry from `_SERVICE_MODULES` in `runtime_deps.py` (no consumers left in the manifest); refreshes the stale comment claiming bricks is excluded from slim.
- Adds a slim integration test that meta-path-blocks `nexus.bricks` and verifies each OAuth manifest entry has no `ServiceDep`, no bricks-targeted `PythonDep`, and `check_runtime_deps` returns no missing deps when the matching extra is installed.
- Closes #3947.

## Acceptance criteria from the issue
- [x] Slim OAuth extras either mount with the standalone token store or fail only for real missing external credentials/deps. Verified E2E: instantiation surfaces `EphemeralOAuthKeyRefused` / missing-oauth.yaml-provider errors only — both real config issues.
- [x] Runtime dependency checks do not require `nexus.bricks` in the `nexus-fs` distribution. The `_SERVICE_MODULES` map no longer references the bricks tree.
- [x] A slim wheel test blocks `nexus.bricks` imports while validating each advertised OAuth/API extra's import and dependency behavior. New `test_slim_oauth_extras_independent_of_bricks` does exactly that.

## Test plan
- [x] `pytest tests/unit/backends/` — 30+ unit tests pass (including new `test_token_manager_not_in_service_map` regression guard).
- [x] `pytest tests/integration/slim/` — all 81 slim integration tests pass with worktree-built wheel.
- [x] E2E in fresh slim venv (`nexus_fs[x,gdrive,gmail,gcalendar,slack]`):
    - `check_runtime_deps` clean for all 6 OAuth entries
    - `BackendFactory.create()` instantiates `PathGmailBackend` / `PathGDriveBackend` / `PathCalendarBackend` (×2 alias) / `PathXBackend` / `PathSlackBackend` with `NEXUS_ALLOW_EPHEMERAL_OAUTH_KEY=1`
    - Without ephemeral key: surfaces `EphemeralOAuthKeyRefused` (real config issue, not a slim contract failure)
- [x] `ruff check` / `ruff format` / `mypy` clean (pre-commit hooks pass).