### PR TITLE
[codex] Fix Docker Publish loopback client

### DIFF
--- a/src/nexus/cli/api_client.py
+++ b/src/nexus/cli/api_client.py
@@ -19,6 +19,7 @@ import logging
 import os
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse, urlunparse
 
 import httpx
 
@@ -26,6 +27,26 @@ logger = logging.getLogger(__name__)
 
 DEFAULT_BASE_URL = "http://localhost:2026"
 DEFAULT_TIMEOUT = 30.0
+
+
+def _normalize_loopback_url(url: str) -> str:
+    """Prefer IPv4 loopback for local Nexus URLs."""
+    parsed = urlparse(url)
+    if parsed.hostname != "localhost":
+        return url
+    try:
+        port = parsed.port
+    except ValueError:
+        return url
+    netloc = "127.0.0.1"
+    if port is not None:
+        netloc = f"{netloc}:{port}"
+    return urlunparse(parsed._replace(netloc=netloc))
+
+
+def _is_loopback_url(url: str) -> bool:
+    parsed = urlparse(url)
+    return parsed.hostname in {"localhost", "127.0.0.1", "::1"}
 
 
 class NexusApiClient:
@@ -39,9 +60,10 @@ class NexusApiClient:
         timeout: float = DEFAULT_TIMEOUT,
     ) -> None:
         resolved = url or os.environ.get("NEXUS_URL") or DEFAULT_BASE_URL
-        self._base_url = resolved.rstrip("/")
+        self._base_url = _normalize_loopback_url(resolved.rstrip("/"))
         self._api_key = api_key or os.environ.get("NEXUS_API_KEY", "")
         self._timeout = timeout
+        self._trust_env = not _is_loopback_url(self._base_url)
 
     def _headers(self) -> dict[str, str]:
         headers: dict[str, str] = {"Accept": "application/json"}
@@ -52,21 +74,39 @@ class NexusApiClient:
     def get(self, path: str, params: dict[str, Any] | None = None) -> Any:
         """GET request. Returns parsed JSON response."""
         url = f"{self._base_url}{path}"
-        resp = httpx.get(url, headers=self._headers(), params=params, timeout=self._timeout)
+        resp = httpx.get(
+            url,
+            headers=self._headers(),
+            params=params,
+            timeout=self._timeout,
+            trust_env=self._trust_env,
+        )
         resp.raise_for_status()
         return resp.json()
 
     def put(self, path: str, json_body: dict[str, Any]) -> Any:
         """PUT request. Returns parsed JSON response."""
         url = f"{self._base_url}{path}"
-        resp = httpx.put(url, headers=self._headers(), json=json_body, timeout=self._timeout)
+        resp = httpx.put(
+            url,
+            headers=self._headers(),
+            json=json_body,
+            timeout=self._timeout,
+            trust_env=self._trust_env,
+        )
         resp.raise_for_status()
         return resp.json()
 
     def post(self, path: str, json_body: dict[str, Any] | None = None) -> Any:
         """POST request. Returns parsed JSON response."""
         url = f"{self._base_url}{path}"
-        resp = httpx.post(url, headers=self._headers(), json=json_body, timeout=self._timeout)
+        resp = httpx.post(
+            url,
+            headers=self._headers(),
+            json=json_body,
+            timeout=self._timeout,
+            trust_env=self._trust_env,
+        )
         resp.raise_for_status()
         return resp.json()
 
@@ -80,7 +120,13 @@ class NexusApiClient:
         from other failures without reaching into private internals.
         """
         url = f"{self._base_url}{path}"
-        resp = httpx.delete(url, headers=self._headers(), params=params, timeout=self._timeout)
+        resp = httpx.delete(
+            url,
+            headers=self._headers(),
+            params=params,
+            timeout=self._timeout,
+            trust_env=self._trust_env,
+        )
         resp.raise_for_status()
         if resp.status_code == 204 or not resp.content:
             return None

--- a/tests/unit/cli/test_api_client.py
+++ b/tests/unit/cli/test_api_client.py
@@ -1,0 +1,77 @@
+"""Tests for the CLI REST API client."""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+
+from nexus.cli.api_client import NexusApiClient
+
+
+class _Response:
+    def raise_for_status(self) -> None:
+        return None
+
+    def json(self) -> dict[str, str]:
+        return {"status": "ready"}
+
+
+def test_loopback_localhost_uses_ipv4_without_proxy_env(monkeypatch: Any) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_get(
+        url: str,
+        *,
+        headers: dict[str, str],
+        params: dict[str, Any] | None,
+        timeout: float,
+        trust_env: bool,
+    ) -> _Response:
+        calls.append(
+            {
+                "url": url,
+                "headers": headers,
+                "params": params,
+                "timeout": timeout,
+                "trust_env": trust_env,
+            }
+        )
+        return _Response()
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    client = NexusApiClient(url="http://localhost:2026", api_key="sk-test")
+    assert client.get("/healthz/ready") == {"status": "ready"}
+
+    assert calls == [
+        {
+            "url": "http://127.0.0.1:2026/healthz/ready",
+            "headers": {"Accept": "application/json", "Authorization": "Bearer sk-test"},
+            "params": None,
+            "timeout": 30.0,
+            "trust_env": False,
+        }
+    ]
+
+
+def test_remote_url_keeps_proxy_env_trust(monkeypatch: Any) -> None:
+    calls: list[dict[str, Any]] = []
+
+    def fake_get(
+        url: str,
+        *,
+        headers: dict[str, str],
+        params: dict[str, Any] | None,
+        timeout: float,
+        trust_env: bool,
+    ) -> _Response:
+        calls.append({"url": url, "trust_env": trust_env})
+        return _Response()
+
+    monkeypatch.setattr(httpx, "get", fake_get)
+
+    client = NexusApiClient(url="https://nexus.example.com", api_key="sk-test")
+    client.get("/healthz/ready")
+
+    assert calls == [{"url": "https://nexus.example.com/healthz/ready", "trust_env": True}]


### PR DESCRIPTION
## Summary
- Normalize CLI REST client loopback URLs from `localhost` to `127.0.0.1`.
- Disable HTTP proxy environment use for loopback REST calls while preserving proxy support for remote Nexus URLs.
- Add unit coverage for loopback and remote URL behavior.

## Root cause
The Docker Publish smoke job still failed in `nexus demo init` after PR #4045 because the CLI preflight was an `httpx` request to `localhost` from inside the edge container. The app never logged a completed request for that preflight, while host-side `curl` readiness checks succeeded, which points to the client-side loopback path rather than the server route.

## Validation
- `uv run --frozen python -m pytest tests/unit/cli/test_api_client.py -q -o addopts=`
- `uv run --frozen python -m pytest tests/unit/cli/test_api_client.py tests/unit/cli/test_demo_preflight.py tests/unit/cli/test_demo.py -q -o addopts=`
- `uvx ruff check src/nexus/cli/api_client.py tests/unit/cli/test_api_client.py`
- `uvx ruff format --check src/nexus/cli/api_client.py tests/unit/cli/test_api_client.py`
- `git diff --check`
- local smoke with `HTTP_PROXY`/`HTTPS_PROXY` pointed at a dead proxy and a local HTTP server behind `http://localhost:<port>`
