### PR TITLE
Fix Docker Publish loopback smoke URL

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -223,13 +223,13 @@ jobs:
               docker logs nexus-e2e 2>&1 | tail -200 || true
               exit 1
             fi
-            if curl -sf http://localhost:2026/healthz/ready > /dev/null 2>&1; then
+            if curl --max-time 5 -sf http://127.0.0.1:2026/healthz/ready > /dev/null 2>&1; then
               echo "Nexus is ready (${i}s)"
               break
             fi
             sleep 1
           done
-          if ! curl -sf http://localhost:2026/healthz/ready > /dev/null 2>&1; then
+          if ! curl --max-time 5 -sf http://127.0.0.1:2026/healthz/ready > /dev/null 2>&1; then
             echo "::error::nexus-e2e never became healthy within 180 seconds"
             docker inspect nexus-e2e --format 'exit_code={{.State.ExitCode}} status={{.State.Status}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}} started_at={{.State.StartedAt}} finished_at={{.State.FinishedAt}} error={{json .State.Error}}' || true
             echo "Crash signatures from container logs:"
@@ -244,7 +244,7 @@ jobs:
           # Container startup already runs docker-entrypoint.sh, initializes the
           # database, and writes /app/data/.admin-api-key. Re-running the
           # entrypoint via docker exec starts a second long-running server path.
-          ADMIN_KEY=$(curl -sf http://localhost:2026/api/admin/bootstrap 2>/dev/null \
+          ADMIN_KEY=$(curl --max-time 5 -sf http://127.0.0.1:2026/api/admin/bootstrap 2>/dev/null \
             | python3 -c "import sys,json; print(json.load(sys.stdin).get('api_key',''))" 2>/dev/null || true)
           if [ -z "$ADMIN_KEY" ]; then
             echo "Bootstrap not available, reading admin key from container..."
@@ -264,17 +264,17 @@ jobs:
             docker inspect nexus-e2e --format 'exit_code={{.State.ExitCode}} status={{.State.Status}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' || true
             exit 1
           fi
-          echo "NEXUS_URL=http://localhost:2026" >> "$GITHUB_ENV"
+          echo "NEXUS_URL=http://127.0.0.1:2026" >> "$GITHUB_ENV"
           echo "NEXUS_API_KEY=${ADMIN_KEY}" >> "$GITHUB_ENV"
           echo "Admin key obtained: ${ADMIN_KEY:0:10}..."
 
       - name: Seed demo workspace
         run: |
           # nexus demo init needs a nexus.yaml — create a minimal one
-          docker exec nexus-e2e sh -c "printf 'preset: demo\nserver_url: http://localhost:2026\ndata_dir: /app/data\nports:\n  http: 2026\n  grpc: 2028\n' > /app/nexus.yaml"
+          docker exec nexus-e2e sh -c "printf 'preset: demo\nserver_url: http://127.0.0.1:2026\ndata_dir: /app/data\nports:\n  http: 2026\n  grpc: 2028\n' > /app/nexus.yaml"
           docker exec \
             -w /app \
-            -e NEXUS_URL=http://localhost:2026 \
+            -e NEXUS_URL=http://127.0.0.1:2026 \
             -e NEXUS_API_KEY="${NEXUS_API_KEY}" \
             -e NEXUS_PROFILE=remote \
             -e NEXUS_GRPC_PORT=2028 \
@@ -289,7 +289,7 @@ jobs:
       - name: Run permissions demo
         run: |
           docker exec \
-            -e NEXUS_URL=http://localhost:2026 \
+            -e NEXUS_URL=http://127.0.0.1:2026 \
             -e NEXUS_API_KEY="${NEXUS_API_KEY}" \
             -e NEXUS_PROFILE=remote \
             nexus-e2e bash /tmp/permissions_demo_enhanced.sh
@@ -305,7 +305,7 @@ jobs:
           # Step 1: Rebuild BM25 keyword index from MCL
           echo "Step 1: Rebuilding BM25 keyword index..."
           docker exec \
-            -e NEXUS_URL=http://localhost:2026 \
+            -e NEXUS_URL=http://127.0.0.1:2026 \
             -e NEXUS_API_KEY="${NEXUS_API_KEY}" \
             -e NEXUS_PROFILE=remote \
             nexus-e2e nexus reindex --target search || true
@@ -330,9 +330,9 @@ jobs:
 
           # Step 3: Show search daemon stats for diagnostics
           echo "Step 3: Search daemon stats..."
-          curl -sf \
+          curl --max-time 5 -sf \
             -H "Authorization: Bearer ${NEXUS_API_KEY}" \
-            http://localhost:2026/api/v2/search/stats 2>/dev/null \
+            http://127.0.0.1:2026/api/v2/search/stats 2>/dev/null \
             | python3 -c "import sys,json; d=json.load(sys.stdin); print(f\"  backend={d.get('backend')} bm25_docs={d.get('bm25_documents')} txtai_model={d.get('txtai_model')} last_refresh={d.get('last_index_refresh')}\")" 2>/dev/null || true
 
           # Step 4: Explicit search index (retry up to 3×).
@@ -342,7 +342,7 @@ jobs:
           echo "Step 4: Explicit search index (with 3-attempt retry)..."
           for i in $(seq 1 3); do
             idx_out=$(timeout 300s docker exec \
-              -e NEXUS_URL=http://localhost:2026 \
+              -e NEXUS_URL=http://127.0.0.1:2026 \
               -e NEXUS_API_KEY="${NEXUS_API_KEY}" \
               -e NEXUS_PROFILE=remote \
               -e NEXUS_GRPC_PORT=2028 \
@@ -360,13 +360,13 @@ jobs:
 
           # Step 5: Final diagnostics and readiness check
           echo "Step 5: Final search daemon stats..."
-          curl -sf \
+          curl --max-time 5 -sf \
             -H "Authorization: Bearer ${NEXUS_API_KEY}" \
-            http://localhost:2026/api/v2/search/stats 2>/dev/null \
+            http://127.0.0.1:2026/api/v2/search/stats 2>/dev/null \
             | python3 -c "import sys,json; d=json.load(sys.stdin); print(f\"  backend={d.get('backend')} bm25={d.get('bm25_documents')} refresh={d.get('last_index_refresh')}\")" 2>/dev/null || true
           # Final status (non-fatal — test script enforces the HERB gate)
           timeout 30s docker exec \
-            -e NEXUS_URL=http://localhost:2026 \
+            -e NEXUS_URL=http://127.0.0.1:2026 \
             -e NEXUS_API_KEY="${NEXUS_API_KEY}" \
             -e NEXUS_PROFILE=remote \
             nexus-e2e nexus search query "Nexus Core" --path /workspace/demo/herb --mode hybrid --limit 1 || true
@@ -374,7 +374,7 @@ jobs:
       - name: Run build perf e2e
         run: |
           docker exec \
-            -e NEXUS_URL=http://localhost:2026 \
+            -e NEXUS_URL=http://127.0.0.1:2026 \
             -e NEXUS_API_KEY="${NEXUS_API_KEY}" \
             -e NEXUS_PROFILE=remote \
             -e NEXUS_GRPC_PORT=2028 \

--- a/src/nexus/cli/commands/demo.py
+++ b/src/nexus/cli/commands/demo.py
@@ -219,12 +219,32 @@ def _resolve_runtime_connection(config: dict[str, Any]) -> dict[str, Any]:
     if not api_key:
         api_key = _resolve_admin_key(config)
 
+    http_port = ports.get("http", 2026)
+
     return {
-        "http_port": ports.get("http", 2026),
+        "http_port": http_port,
         "grpc_port": grpc_port,
-        "base_url": conn.get("NEXUS_URL", f"http://localhost:{ports.get('http', 2026)}"),
+        "base_url": _resolve_demo_http_url(config, conn, http_port),
         "api_key": api_key,
     }
+
+
+def _resolve_demo_http_url(
+    config: dict[str, Any],
+    conn: dict[str, str],
+    http_port: int,
+) -> str:
+    """Resolve the HTTP base URL used by demo/shared REST seeding helpers."""
+    if config.get("preset") in ("shared", "demo"):
+        env_url = os.environ.get("NEXUS_URL")
+        if env_url:
+            return env_url
+
+        server_url = config.get("server_url")
+        if server_url:
+            return str(server_url)
+
+    return conn.get("NEXUS_URL", f"http://localhost:{http_port}")
 
 
 def _resolve_admin_key(config: dict[str, Any]) -> str:
@@ -311,8 +331,7 @@ def _get_nexus_client(config: dict[str, Any]) -> Any:
 
         api_key = _resolve_admin_key(config)
 
-        # Use the scheme from resolve_connection_env (https if TLS)
-        url = conn.get("NEXUS_URL", f"http://localhost:{http_port}")
+        url = _resolve_demo_http_url(config, conn, http_port)
 
         # Prefer REST API for seeding: REST writes go through Python VFS hooks
         # which populate the PostgreSQL file_paths table (required for semantic

--- a/tests/unit/cli/test_demo_preflight.py
+++ b/tests/unit/cli/test_demo_preflight.py
@@ -16,3 +16,38 @@ def test_remote_demo_preflight_avoids_root_metadata_probe() -> None:
     assert 'test_client.get("/healthz/ready")' in remote_block
     assert 'test_client.get("/api/v2/connectors")' not in remote_block
     assert 'test_client.get("/api/v2/files/metadata", params={"path": "/"})' not in remote_block
+
+
+def test_runtime_connection_prefers_nexus_url_env(monkeypatch, tmp_path) -> None:
+    from nexus.cli.commands.demo import _resolve_runtime_connection
+
+    monkeypatch.setenv("NEXUS_URL", "http://127.0.0.1:2026")
+
+    runtime = _resolve_runtime_connection(
+        {
+            "preset": "demo",
+            "data_dir": str(tmp_path),
+            "ports": {"http": 2026, "grpc": 2028},
+            "api_key": "sk-test",
+        }
+    )
+
+    assert runtime["base_url"] == "http://127.0.0.1:2026"
+
+
+def test_runtime_connection_prefers_server_url_config(monkeypatch, tmp_path) -> None:
+    from nexus.cli.commands.demo import _resolve_runtime_connection
+
+    monkeypatch.delenv("NEXUS_URL", raising=False)
+
+    runtime = _resolve_runtime_connection(
+        {
+            "preset": "demo",
+            "server_url": "http://127.0.0.1:2026",
+            "data_dir": str(tmp_path),
+            "ports": {"http": 2026, "grpc": 2028},
+            "api_key": "sk-test",
+        }
+    )
+
+    assert runtime["base_url"] == "http://127.0.0.1:2026"


### PR DESCRIPTION
## Summary
- Use `127.0.0.1:2026` consistently in Docker Publish edge smoke steps and cap curl probes with `--max-time 5`
- Make demo/shared runtime URL resolution honor `NEXUS_URL` and `server_url` before the synthesized localhost fallback
- Add unit coverage for the demo runtime URL resolution used by seed helpers

## Tests
- `uv run --frozen python -m pytest tests/unit/cli/test_demo_preflight.py tests/unit/cli/test_api_client.py -q -o addopts=`
- `uv run --frozen python -m pytest tests/unit/cli/test_demo_seeds.py tests/unit/cli/test_state.py -q -o addopts=`
- `uvx ruff check src/nexus/cli/commands/demo.py tests/unit/cli/test_demo_preflight.py`
- `uvx ruff format --check src/nexus/cli/commands/demo.py tests/unit/cli/test_demo_preflight.py`
- `actionlint .github/workflows/docker-publish.yml`
- `git diff --check`
