### PR TITLE
[codex] Fix optional Rust fallbacks and stack validation

### DIFF
--- a/scripts/codegen_kernel_abi.py
+++ b/scripts/codegen_kernel_abi.py
@@ -221,6 +221,20 @@ CAPABILITY_GROUP_CONFIG: dict[str, tuple[str, ...]] = {
     "hash": ("hash_content_py", "hash_content_smart_py"),
     "io": ("read_file", "read_files_bulk"),
     "search": ("grep_bulk", "grep_files_mmap", "glob_match_bulk"),
+    "trigram": (
+        "build_trigram_index",
+        "build_trigram_index_from_entries",
+        "invalidate_trigram_cache",
+        "trigram_grep",
+        "trigram_index_stats",
+        "trigram_search_candidates",
+    ),
+    "rebac": (
+        "compute_permission_single",
+        "compute_permissions_bulk",
+        "expand_subjects",
+        "list_objects_for_subject",
+    ),
     "storage": (
         "BloomFilter",
         "BlobPackEngine",
@@ -229,7 +243,16 @@ CAPABILITY_GROUP_CONFIG: dict[str, tuple[str, ...]] = {
     # (rebac visibility, descendant_access, enforcer batch). Gating them here
     # ensures stale/version-skew binaries fall back to the Python implementation
     # in _prefix_helpers.py instead of silently returning wrong auth results.
-    "prefix": ("any_path_starts_with", "batch_prefix_check"),
+    "prefix": ("any_path_starts_with", "batch_prefix_check", "filter_paths_by_prefix"),
+    "tiger": (
+        "any_path_accessible_tiger_cache",
+        "check_permission_bitmap",
+        "check_permission_bitmap_batch",
+        "filter_paths_with_tiger_cache",
+        "filter_paths_with_tiger_cache_parallel",
+        "intersect_paths_with_tiger_cache",
+        "tiger_cache_bitmap_stats",
+    ),
 }
 
 # ── Return-type overrides ──────────────────────────────────────────
@@ -5628,6 +5651,23 @@ async def dispatch_kernel_syscall(
 # ── Main ──────────────────────────────────────────────────────────
 
 
+def _ruff_cmd() -> list[str] | None:
+    """Return a ruff command usable from plain and pre-commit hook envs."""
+    import shutil
+
+    ruff = shutil.which("ruff")
+    if ruff:
+        return [ruff]
+    uv = shutil.which("uv")
+    if not uv:
+        uv_path = Path.home() / ".local" / "bin" / "uv"
+        if uv_path.exists():
+            uv = str(uv_path)
+    if uv:
+        return [uv, "run", "--extra", "dev", "ruff"]
+    return None
+
+
 def main() -> int:
     check_mode = "--check" in sys.argv
 
@@ -5654,7 +5694,7 @@ def main() -> int:
         import subprocess
         import tempfile
 
-        ruff = shutil.which("ruff")
+        ruff = _ruff_cmd()
 
         rustfmt = shutil.which("rustfmt")
 
@@ -5669,7 +5709,7 @@ def main() -> int:
                 with tempfile.NamedTemporaryFile(mode="wb", suffix=suffix, delete=False) as f:
                     f.write(content.encode("utf-8"))
                     f.flush()
-                    subprocess.run([ruff, "format", f.name], capture_output=True)
+                    subprocess.run([*ruff, "format", f.name], capture_output=True)
                     return Path(f.name).read_bytes().decode("utf-8")
             if rustfmt and suffix == ".rs":
                 with tempfile.NamedTemporaryFile(mode="wb", suffix=suffix, delete=False) as f:
@@ -5690,8 +5730,11 @@ def main() -> int:
             if actual != expected:
                 print(f"STALE: {path.relative_to(ROOT)}")
                 # Show first differing line
+                from itertools import zip_longest
+
                 for i, (a, e) in enumerate(
-                    zip(actual.splitlines(), expected.splitlines(), strict=False), 1
+                    zip_longest(actual.splitlines(), expected.splitlines(), fillvalue=""),
+                    1,
                 ):
                     if a != e:
                         print(f"  line {i}:")
@@ -5716,14 +5759,12 @@ def main() -> int:
                 py_files.append(path)
         # Auto-format generated Python files so codegen --check matches ruff format
         if py_files:
-            import shutil
-
-            ruff = shutil.which("ruff")
+            ruff = _ruff_cmd()
             if ruff:
                 import subprocess
 
                 subprocess.run(
-                    [ruff, "format", *[str(p) for p in py_files]],
+                    [*ruff, "format", *[str(p) for p in py_files]],
                     capture_output=True,
                 )
         # Auto-format generated Rust files so codegen --check matches cargo fmt

--- a/src/nexus/_kernel_api_groups.py
+++ b/src/nexus/_kernel_api_groups.py
@@ -39,6 +39,20 @@ MODULE_CAPABILITY_GROUPS: dict[str, tuple[str, ...]] = {
         "grep_files_mmap",
         "glob_match_bulk",
     ),
+    "trigram": (
+        "build_trigram_index",
+        "build_trigram_index_from_entries",
+        "invalidate_trigram_cache",
+        "trigram_grep",
+        "trigram_index_stats",
+        "trigram_search_candidates",
+    ),
+    "rebac": (
+        "compute_permission_single",
+        "compute_permissions_bulk",
+        "expand_subjects",
+        "list_objects_for_subject",
+    ),
     "storage": (
         "BloomFilter",
         "BlobPackEngine",
@@ -46,6 +60,16 @@ MODULE_CAPABILITY_GROUPS: dict[str, tuple[str, ...]] = {
     "prefix": (
         "any_path_starts_with",
         "batch_prefix_check",
+        "filter_paths_by_prefix",
+    ),
+    "tiger": (
+        "any_path_accessible_tiger_cache",
+        "check_permission_bitmap",
+        "check_permission_bitmap_batch",
+        "filter_paths_with_tiger_cache",
+        "filter_paths_with_tiger_cache_parallel",
+        "intersect_paths_with_tiger_cache",
+        "tiger_cache_bitmap_stats",
     ),
 }
 

--- a/src/nexus/_rust_compat.py
+++ b/src/nexus/_rust_compat.py
@@ -222,6 +222,12 @@ hash_content_smart_py = _get("hash_content_smart_py")
 read_file = _get("read_file")
 read_files_bulk = _get("read_files_bulk")
 
+# ReBAC helpers
+compute_permission_single = _get("compute_permission_single")
+compute_permissions_bulk = _get("compute_permissions_bulk")
+expand_subjects = _get("expand_subjects")
+list_objects_for_subject = _get("list_objects_for_subject")
+
 # Mount table helpers
 canonicalize_path = _get("canonicalize_path")
 extract_zone_id = _get("extract_zone_id")
@@ -231,6 +237,24 @@ grep_bulk = _get("grep_bulk")
 grep_files_mmap = _get("grep_files_mmap")
 glob_match_bulk = _get("glob_match_bulk")
 
+# Trigram search
+build_trigram_index = _get("build_trigram_index")
+build_trigram_index_from_entries = _get("build_trigram_index_from_entries")
+invalidate_trigram_cache = _get("invalidate_trigram_cache")
+trigram_grep = _get("trigram_grep")
+trigram_index_stats = _get("trigram_index_stats")
+trigram_search_candidates = _get("trigram_search_candidates")
+
 # Prefix / bitmap helpers (Issue #3951)
 any_path_starts_with = _get("any_path_starts_with")
 batch_prefix_check = _get("batch_prefix_check")
+filter_paths_by_prefix = _get("filter_paths_by_prefix")
+
+# Tiger bitmap helpers
+any_path_accessible_tiger_cache = _get("any_path_accessible_tiger_cache")
+check_permission_bitmap = _get("check_permission_bitmap")
+check_permission_bitmap_batch = _get("check_permission_bitmap_batch")
+filter_paths_with_tiger_cache = _get("filter_paths_with_tiger_cache")
+filter_paths_with_tiger_cache_parallel = _get("filter_paths_with_tiger_cache_parallel")
+intersect_paths_with_tiger_cache = _get("intersect_paths_with_tiger_cache")
+tiger_cache_bitmap_stats = _get("tiger_cache_bitmap_stats")

--- a/src/nexus/bricks/rebac/utils/fast.py
+++ b/src/nexus/bricks/rebac/utils/fast.py
@@ -1,18 +1,27 @@
 """
 Fast ReBAC permission checking with Rust acceleration.
 
-This module provides Rust-accelerated permission checking via nexus_runtime.
+This module provides a drop-in replacement for Python-based permission checking
+with significant performance improvements for bulk operations.
 
 Performance characteristics:
 - Single check: ~50x speedup (but Python overhead may dominate)
 - 10-100 checks: ~70-80x speedup
 - 1000+ checks: ~85x speedup (~6µs per check vs ~500µs in Python)
+
+The module automatically falls back to Python implementation if Rust is unavailable.
 """
 
 import logging
 from typing import TYPE_CHECKING, Any
 
-import nexus_runtime as _rust_module
+# RUST_FALLBACK: rebac — optional Rust symbols are routed through
+# nexus._rust_compat so absent/stale binaries fall back at call time
+# instead of failing during module import.
+from nexus._rust_compat import compute_permission_single as _compute_permission_single
+from nexus._rust_compat import compute_permissions_bulk as _compute_permissions_bulk
+from nexus._rust_compat import expand_subjects as _expand_subjects
+from nexus._rust_compat import list_objects_for_subject as _list_objects_for_subject
 
 if TYPE_CHECKING:
     from nexus.bricks.rebac.domain import Entity
@@ -23,9 +32,20 @@ NamespaceConfigDict = dict[str, Any]  # Contains 'relations' and 'permissions' k
 
 logger = logging.getLogger(__name__)
 
-_internal_module: Any = _rust_module
-_external_module: Any = _rust_module
-logger.info("Rust acceleration available (nexus_runtime)")
+RUST_AVAILABLE = _compute_permissions_bulk is not None
+if RUST_AVAILABLE:
+    logger.info("Rust acceleration available (nexus_runtime)")
+else:
+    logger.debug("Rust acceleration unavailable; using Python ReBAC fallback")
+
+
+def is_rust_available() -> bool:
+    """Check if Rust acceleration is available.
+
+    Returns:
+        True if nexus_runtime Rust extension is loaded, False otherwise
+    """
+    return RUST_AVAILABLE
 
 
 def check_permissions_bulk_rust(
@@ -74,22 +94,25 @@ def check_permissions_bulk_rust(
         RuntimeError: If Rust extension is not available
         ValueError: If input data format is invalid
     """
+    if not RUST_AVAILABLE:
+        raise RuntimeError(
+            "Rust acceleration not available. Install with: cd rust/kernel && maturin develop"
+        )
+
     try:
-        # Prefer internal module (faster), fallback to external
-        module = _internal_module or _external_module
-        if module is None:
-            raise RuntimeError("No Rust module available")
+        if _compute_permissions_bulk is None:
+            raise RuntimeError("Rust bulk permission check not available")
 
         # Try with tuple_version first (newer API)
         try:
-            result: Any = module.compute_permissions_bulk(
+            result: Any = _compute_permissions_bulk(
                 checks, tuples, namespace_configs, tuple_version
             )
         except TypeError as te:
             # Fallback to old API without tuple_version parameter
             if "takes 3 positional arguments" in str(te):
                 logger.debug("Rust module uses old API (3 args), calling without tuple_version")
-                result = module.compute_permissions_bulk(checks, tuples, namespace_configs)
+                result = _compute_permissions_bulk(checks, tuples, namespace_configs)
             else:
                 raise
 
@@ -132,7 +155,7 @@ def check_permissions_bulk_with_fallback(
         >>> results = check_permissions_bulk_with_fallback(checks, tuples, configs)
         >>> results[("user", "alice", "read", "file", "doc1")]  # True/False
     """
-    if not force_python:
+    if RUST_AVAILABLE and not force_python:
         try:
             import time
 
@@ -263,9 +286,9 @@ def get_performance_stats() -> dict[str, Any]:
         Dict with performance metrics
     """
     return {
-        "rust_available": True,
-        "expected_speedup": "85x for bulk operations",
-        "recommended_batch_size": "100-10000 checks",
+        "rust_available": RUST_AVAILABLE,
+        "expected_speedup": "85x for bulk operations" if RUST_AVAILABLE else "N/A",
+        "recommended_batch_size": "100-10000 checks" if RUST_AVAILABLE else "N/A",
     }
 
 
@@ -304,8 +327,12 @@ def check_permission_single_rust(
     Raises:
         RuntimeError: If Rust extension is not available
     """
-    # compute_permission_single is only in the external module
-    if _external_module is None:
+    if not RUST_AVAILABLE:
+        raise RuntimeError(
+            "Rust acceleration not available. Install with: cd rust/kernel && maturin develop"
+        )
+
+    if _compute_permission_single is None:
         raise RuntimeError(
             "Rust single permission check not available. "
             "Install nexus_runtime: cd rust/kernel && maturin develop"
@@ -315,7 +342,7 @@ def check_permission_single_rust(
         import time
 
         start = time.perf_counter()
-        result: bool = _external_module.compute_permission_single(
+        result: bool = _compute_permission_single(
             subject_type,
             subject_id,
             permission,
@@ -365,7 +392,7 @@ def check_permission_single_with_fallback(
     Returns:
         True if permission is granted, False otherwise
     """
-    if _external_module is not None and not force_python:
+    if _compute_permission_single is not None and not force_python:
         try:
             return check_permission_single_rust(
                 subject_type,
@@ -398,6 +425,9 @@ def estimate_speedup(num_checks: int) -> float:
     Returns:
         Expected speedup factor (e.g., 85.0 means 85x faster)
     """
+    if not RUST_AVAILABLE:
+        return 1.0
+
     # Empirical speedup curve
     if num_checks < 10:
         return 20.0  # ~20x for small batches (Python overhead)
@@ -434,8 +464,12 @@ def expand_subjects_rust(
     Raises:
         RuntimeError: If Rust extension is not available
     """
-    # Use external module which has expand_subjects
-    if _external_module is None:
+    if not RUST_AVAILABLE:
+        raise RuntimeError(
+            "Rust acceleration not available. Install with: cd rust/kernel && maturin develop"
+        )
+
+    if _expand_subjects is None:
         raise RuntimeError(
             "Rust expand_subjects not available. "
             "Install nexus_runtime: cd rust/kernel && maturin develop"
@@ -445,7 +479,7 @@ def expand_subjects_rust(
         import time
 
         start = time.perf_counter()
-        result = _external_module.expand_subjects(
+        result = _expand_subjects(
             permission,
             object_type,
             object_id,
@@ -489,7 +523,7 @@ def expand_subjects_with_fallback(
     Returns:
         List of (subject_type, subject_id) tuples
     """
-    if _external_module is not None and not force_python:
+    if _expand_subjects is not None and not force_python:
         try:
             return expand_subjects_rust(
                 permission,
@@ -547,8 +581,12 @@ def list_objects_for_subject_rust(
     Raises:
         RuntimeError: If Rust extension is not available
     """
-    # Use external module which has list_objects_for_subject
-    if _external_module is None:
+    if not RUST_AVAILABLE:
+        raise RuntimeError(
+            "Rust acceleration not available. Install with: cd rust/kernel && maturin develop"
+        )
+
+    if _list_objects_for_subject is None:
         raise RuntimeError(
             "Rust list_objects_for_subject not available. "
             "Install nexus_runtime: cd rust/kernel && maturin develop"
@@ -558,7 +596,7 @@ def list_objects_for_subject_rust(
         import time
 
         start = time.perf_counter()
-        result = _external_module.list_objects_for_subject(
+        result = _list_objects_for_subject(
             subject_type,
             subject_id,
             permission,
@@ -615,7 +653,7 @@ def list_objects_for_subject_with_fallback(
     Returns:
         List of (object_type, object_id) tuples
     """
-    if _external_module is not None and not force_python:
+    if _list_objects_for_subject is not None and not force_python:
         try:
             return list_objects_for_subject_rust(
                 subject_type,

--- a/src/nexus/bricks/search/primitives/glob_helpers.py
+++ b/src/nexus/bricks/search/primitives/glob_helpers.py
@@ -6,7 +6,7 @@ query-side concerns (static-prefix extraction for directory pruning,
 include/exclude filter composition, single-pattern matching) that
 belong in the search brick rather than as kernel surface.
 
-The Rust-accelerated primitives go through `nexus_runtime` directly:
+The Rust-accelerated primitives go through `nexus._rust_compat`:
 
     from nexus._rust_compat import glob_match_bulk
 
@@ -18,6 +18,7 @@ internals need.
 
 from __future__ import annotations
 
+import fnmatch
 import re
 from typing import TYPE_CHECKING
 
@@ -27,6 +28,20 @@ if TYPE_CHECKING:
 
 # Glob special characters that indicate a non-static part of the pattern
 _GLOB_SPECIAL_CHARS = re.compile(r"[*?\[\]{}]")
+
+
+def _match_python(path: str, pattern: str) -> bool:
+    path_for_match = path[1:] if path.startswith("/") else path
+    pattern_for_match = pattern[1:] if pattern.startswith("/") else pattern
+    return fnmatch.fnmatch(path_for_match, pattern_for_match)
+
+
+def _glob_match_bulk_or_python(patterns: list[str], paths: list[str]) -> list[str]:
+    from nexus._rust_compat import glob_match_bulk
+
+    if glob_match_bulk is not None:
+        return list(glob_match_bulk(patterns, paths))
+    return [path for path in paths if any(_match_python(path, pattern) for pattern in patterns)]
 
 
 def glob_match(path: str, patterns: list[str]) -> bool:
@@ -41,9 +56,7 @@ def glob_match(path: str, patterns: list[str]) -> bool:
     if not patterns:
         return False
 
-    from nexus._rust_compat import glob_match_bulk
-
-    matches = glob_match_bulk(patterns, [path])
+    matches = _glob_match_bulk_or_python(patterns, [path])
     return len(matches) > 0
 
 
@@ -63,15 +76,13 @@ def glob_filter(
     if not paths:
         return []
 
-    from nexus._rust_compat import glob_match_bulk
-
     result = paths
 
     if include_patterns:
-        result = list(glob_match_bulk(include_patterns, result))
+        result = _glob_match_bulk_or_python(include_patterns, result)
 
     if exclude_patterns:
-        excluded = set(glob_match_bulk(exclude_patterns, result))
+        excluded = set(_glob_match_bulk_or_python(exclude_patterns, result))
         result = [p for p in result if p not in excluded]
 
     return result

--- a/src/nexus/bricks/search/primitives/glob_helpers.py
+++ b/src/nexus/bricks/search/primitives/glob_helpers.py
@@ -36,12 +36,83 @@ def _match_python(path: str, pattern: str) -> bool:
     return fnmatch.fnmatch(path_for_match, pattern_for_match)
 
 
+def _brace_span(pattern: str) -> tuple[int, int] | None:
+    in_class = False
+    escaped = False
+    open_idx: int | None = None
+
+    for idx, char in enumerate(pattern):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == "[":
+            in_class = True
+            continue
+        if char == "]":
+            in_class = False
+            continue
+        if in_class:
+            continue
+        if char == "{" and open_idx is None:
+            open_idx = idx
+        elif char == "}" and open_idx is not None:
+            return open_idx, idx
+    return None
+
+
+def _split_brace_alternates(body: str) -> list[str]:
+    parts: list[str] = []
+    start = 0
+    in_class = False
+    escaped = False
+
+    for idx, char in enumerate(body):
+        if escaped:
+            escaped = False
+            continue
+        if char == "\\":
+            escaped = True
+            continue
+        if char == "[":
+            in_class = True
+            continue
+        if char == "]":
+            in_class = False
+            continue
+        if char == "," and not in_class:
+            parts.append(body[start:idx])
+            start = idx + 1
+    parts.append(body[start:])
+    return parts
+
+
+def _expand_brace_alternates(pattern: str) -> list[str]:
+    span = _brace_span(pattern)
+    if span is None:
+        return [pattern]
+
+    start, end = span
+    choices = _split_brace_alternates(pattern[start + 1 : end])
+    if len(choices) <= 1:
+        return [pattern]
+
+    prefix = pattern[:start]
+    suffixes = _expand_brace_alternates(pattern[end + 1 :])
+    return [f"{prefix}{choice}{suffix}" for choice in choices for suffix in suffixes]
+
+
 def _glob_match_bulk_or_python(patterns: list[str], paths: list[str]) -> list[str]:
     from nexus._rust_compat import glob_match_bulk
 
     if glob_match_bulk is not None:
         return list(glob_match_bulk(patterns, paths))
-    return [path for path in paths if any(_match_python(path, pattern) for pattern in patterns)]
+    expanded_patterns = [p for pattern in patterns for p in _expand_brace_alternates(pattern)]
+    return [
+        path for path in paths if any(_match_python(path, pattern) for pattern in expanded_patterns)
+    ]
 
 
 def glob_match(path: str, patterns: list[str]) -> bool:

--- a/src/nexus/bricks/search/primitives/trigram_fast.py
+++ b/src/nexus/bricks/search/primitives/trigram_fast.py
@@ -12,33 +12,44 @@ Pattern follows grep_fast.py.
 
 import logging
 import os
-from typing import Any
+from typing import Any, cast
 
-# RUST_FALLBACK: trigram_fast — build_trigram_index, trigram_grep, etc. have Rust equivalents in nexus_runtime.
-from nexus_runtime import (
+# RUST_FALLBACK: trigram_fast — all optional Rust symbols come through
+# nexus._rust_compat so absent/stale binaries disable this accelerator
+# without breaking module imports.
+from nexus._rust_compat import (
     build_trigram_index as _build_trigram_index,
 )
-from nexus_runtime import (
+from nexus._rust_compat import (
     build_trigram_index_from_entries as _build_trigram_index_from_entries,
 )
-from nexus_runtime import (
+from nexus._rust_compat import (
     invalidate_trigram_cache as _invalidate_trigram_cache,
 )
-from nexus_runtime import (
+from nexus._rust_compat import (
     trigram_grep as _trigram_grep,
 )
-from nexus_runtime import (
+from nexus._rust_compat import (
     trigram_index_stats as _trigram_index_stats,
 )
-from nexus_runtime import (
+from nexus._rust_compat import (
     trigram_search_candidates as _trigram_search_candidates,
 )
-
 from nexus.contracts.constants import ROOT_ZONE_ID
 
 logger = logging.getLogger(__name__)
 
-TRIGRAM_AVAILABLE = True
+TRIGRAM_AVAILABLE = all(
+    symbol is not None
+    for symbol in (
+        _build_trigram_index,
+        _build_trigram_index_from_entries,
+        _invalidate_trigram_cache,
+        _trigram_grep,
+        _trigram_index_stats,
+        _trigram_search_candidates,
+    )
+)
 
 
 def is_available() -> bool:
@@ -193,7 +204,7 @@ def search_candidates(
         return None
 
     try:
-        return _trigram_search_candidates(index_path, pattern, ignore_case)
+        return cast(list[str], _trigram_search_candidates(index_path, pattern, ignore_case))
     except (OSError, ValueError, RuntimeError):
         logger.warning(
             "Trigram candidate search failed for pattern %r on %s",

--- a/src/nexus/bricks/search/search_service.py
+++ b/src/nexus/bricks/search/search_service.py
@@ -1785,7 +1785,14 @@ class SearchService:
             rust_pattern = full_pattern if full_pattern.startswith("/") else "/" + full_pattern
             from nexus._rust_compat import glob_match_bulk
 
-            matches = glob_match_bulk([rust_pattern], accessible_files)
+            if glob_match_bulk is not None:
+                matches = list(glob_match_bulk([rust_pattern], accessible_files))
+            else:
+                strategy = (
+                    GlobStrategy.REGEX_COMPILED
+                    if "**" in full_pattern
+                    else GlobStrategy.FNMATCH_SIMPLE
+                )
 
         if strategy == GlobStrategy.REGEX_COMPILED and not matches:
             matches = self._glob_regex_match(full_pattern, accessible_files)
@@ -1888,7 +1895,12 @@ class SearchService:
                 rust_pattern = full_pattern if full_pattern.startswith("/") else "/" + full_pattern
                 from nexus._rust_compat import glob_match_bulk
 
-                results[pattern] = sorted(glob_match_bulk([rust_pattern], accessible_files))
+                if glob_match_bulk is not None:
+                    results[pattern] = sorted(glob_match_bulk([rust_pattern], accessible_files))
+                else:
+                    results[pattern] = sorted(
+                        glob_helpers.glob_filter(accessible_files, include_patterns=[rust_pattern])
+                    )
             except Exception:
                 logger.debug("glob_batch pattern failed: %s", pattern, exc_info=True)
                 results[pattern] = []
@@ -2481,8 +2493,6 @@ class SearchService:
         fallback) does honour.
         """
         results: builtins.list[dict[str, Any]] = []
-        mmap_used = False
-
         # Try mmap-accelerated grep first (Issue #893). Skipped when the
         # caller asked for context/invert flags — mmap doesn't honour
         # them and would silently drop them.
@@ -2506,7 +2516,6 @@ class SearchService:
                             disk_path = match.get("file", "")
                             match["file"] = disk_to_virtual.get(disk_path, disk_path)
                         results.extend(mmap_results)
-                        mmap_used = True
                         files_needing_raw = [f for f in files_needing_raw if f not in disk_paths]
                         remaining_results = remaining_results - len(results)
             except Exception as e:
@@ -2522,17 +2531,19 @@ class SearchService:
             }
             from nexus._rust_compat import grep_bulk
 
-            rust_results = grep_bulk(
-                pattern,
-                file_contents,
-                ignore_case=ignore_case,
-                max_results=remaining_results,
-            )
-            if rust_results is not None:
-                results.extend(rust_results)
+            if grep_bulk is not None:
+                rust_results = grep_bulk(
+                    pattern,
+                    file_contents,
+                    ignore_case=ignore_case,
+                    max_results=remaining_results,
+                )
+                if rust_results is not None:
+                    results.extend(rust_results)
+                    files_needing_raw = []
 
         # Python sequential fallback
-        elif not mmap_used and files_needing_raw:
+        if files_needing_raw:
             for file_path in files_needing_raw:
                 if len(results) >= remaining_results:
                     break
@@ -2928,7 +2939,10 @@ class SearchService:
             if zoekt_available:
                 return SearchStrategy.ZOEKT_INDEX
         # Issue #3711: Rust bulk (400x) >> Python parallel pool (4x).
-        # Rust grep is always available (kernel binary is mandatory).
+        from nexus._rust_compat import grep_bulk
+
+        if grep_bulk is None:
+            return SearchStrategy.SEQUENTIAL
         return SearchStrategy.RUST_BULK
 
     def _select_glob_strategy(self, pattern: str, file_count: int) -> GlobStrategy:

--- a/src/nexus/bricks/search/skeleton_pipe_consumer.py
+++ b/src/nexus/bricks/search/skeleton_pipe_consumer.py
@@ -25,7 +25,7 @@ import contextlib
 import json
 import logging
 from collections import deque
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from nexus.contracts.types import OperationContext
 
@@ -237,15 +237,18 @@ class SkeletonPipeConsumer:
 
         def _read() -> bytes:
             try:
-                return nx.sys_read(
-                    _SKELETON_PIPE_PATH,
-                    context=self._pipe_context,
-                    timeout_ms=0,
+                return cast(
+                    bytes,
+                    nx.sys_read(
+                        _SKELETON_PIPE_PATH,
+                        context=self._pipe_context,
+                        timeout_ms=0,
+                    ),
                 )
             except TypeError as exc:
                 if "timeout_ms" not in str(exc):
                     raise
-                return nx.sys_read(_SKELETON_PIPE_PATH, context=self._pipe_context)
+                return cast(bytes, nx.sys_read(_SKELETON_PIPE_PATH, context=self._pipe_context))
 
         return await asyncio.to_thread(_read)
 

--- a/src/nexus/bricks/search/skeleton_pipe_consumer.py
+++ b/src/nexus/bricks/search/skeleton_pipe_consumer.py
@@ -35,6 +35,7 @@ if TYPE_CHECKING:
 logger = logging.getLogger(__name__)
 
 _SKELETON_PIPE_PATH = "/nexus/pipes/skeleton-writes"
+_INTERNAL_PIPE_PREFIX = "/nexus/pipes/"
 _SKELETON_PIPE_CAPACITY = 65_536  # 64KB
 
 # Number of events processed concurrently in a single asyncio.gather call (15A).
@@ -230,37 +231,50 @@ class SkeletonPipeConsumer:
     # Background consumer with debounce + micro-batching (15A)
     # ------------------------------------------------------------------
 
+    async def _read_pipe(self) -> bytes:
+        nx = self._nx
+        assert nx is not None
+
+        def _read() -> bytes:
+            try:
+                return nx.sys_read(
+                    _SKELETON_PIPE_PATH,
+                    context=self._pipe_context,
+                    timeout_ms=0,
+                )
+            except TypeError as exc:
+                if "timeout_ms" not in str(exc):
+                    raise
+                return nx.sys_read(_SKELETON_PIPE_PATH, context=self._pipe_context)
+
+        return await asyncio.to_thread(_read)
+
     async def _consume(self) -> None:
         # sys_read returns b"" for empty DT_PIPE (POSIX non-blocking semantics).
         # NexusFileNotFoundError signals pipe destroyed (stop() signal).
         from nexus.contracts.exceptions import NexusFileNotFoundError
 
         assert self._nx is not None
-        nx = self._nx
         _POLL = 0.01  # 10ms poll interval
 
         pending: list[dict[str, Any]] = []
+        read_task: asyncio.Task[bytes] | None = None
 
         while True:
             # Block until first event: poll with sleep
             if not pending:
                 while True:
+                    if read_task is None:
+                        read_task = asyncio.create_task(self._read_pipe())
                     try:
-                        # Issue #3699: timeout_ms=0 (O_NONBLOCK) so empty
-                        # pipe returns instantly. Without this, each empty
-                        # poll blocks the asyncio event loop for the
-                        # kernel's 5 s pipe-read default, starving
-                        # uvicorn's accept loop.
-                        data = nx.sys_read(
-                            _SKELETON_PIPE_PATH,
-                            context=self._pipe_context,
-                            timeout_ms=0,
-                        )
+                        data = await read_task
                     except NexusFileNotFoundError:
                         logger.debug("[SKELETON] pipe closed, consumer exiting")
                         return
                     except Exception:
                         return
+                    finally:
+                        read_task = None
                     if data:
                         pending.append(json.loads(data))
                         break
@@ -272,16 +286,20 @@ class SkeletonPipeConsumer:
                 remaining = deadline - asyncio.get_event_loop().time()
                 if remaining <= 0:
                     break
+                if read_task is None:
+                    read_task = asyncio.create_task(self._read_pipe())
+                done, _ = await asyncio.wait({read_task}, timeout=remaining)
+                if read_task not in done:
+                    break
                 try:
-                    data = nx.sys_read(
-                        _SKELETON_PIPE_PATH,
-                        context=self._pipe_context,
-                        timeout_ms=0,
-                    )
+                    data = read_task.result()
                 except NexusFileNotFoundError:
+                    read_task = None
                     break
                 except Exception:
+                    read_task = None
                     break
+                read_task = None
                 if data:
                     pending.append(json.loads(data))
                 else:
@@ -308,6 +326,12 @@ class SkeletonPipeConsumer:
     async def _dispatch_single(self, msg: dict[str, Any]) -> None:
         """Route a single event to the appropriate SkeletonIndexer method."""
         t = msg.get("type")
+        if _message_targets_internal_pipe(msg):
+            logger.debug(
+                "[SKELETON] skipping internal pipe event for %s",
+                msg.get("path") or msg.get("new_path") or msg.get("old_path", "?"),
+            )
+            return
         try:
             if t == "write":
                 await self._indexer.index_file(
@@ -338,3 +362,12 @@ class SkeletonPipeConsumer:
                 logger.debug("[SKELETON] unknown event type: %s", t)
         except Exception as e:
             logger.warning("[SKELETON] dispatch error for %s: %s", t, e)
+
+
+def _message_targets_internal_pipe(msg: dict[str, Any]) -> bool:
+    """Return True for VFS events that target Nexus internal pipe paths."""
+    for key in ("path", "old_path", "new_path"):
+        value = msg.get(key)
+        if isinstance(value, str) and value.startswith(_INTERNAL_PIPE_PREFIX):
+            return True
+    return False

--- a/src/nexus/cli/commands/stack.py
+++ b/src/nexus/cli/commands/stack.py
@@ -177,6 +177,12 @@ def _docker_build_args(extra_env: dict[str, str]) -> list[str]:
     ]
 
 
+def _local_build_image_ref(compose_env: dict[str, str]) -> str:
+    """Return the per-project image tag used for local Docker builds."""
+    project_hash = compose_env["COMPOSE_PROJECT_NAME"].split("-")[-1]
+    return f"nexus:local-{project_hash}"
+
+
 def _resolve_profiles(
     config: dict[str, Any],
     cli_addons: tuple[str, ...] = (),
@@ -951,11 +957,10 @@ def up(
 
     # When --build is requested, build with a local-only tag
     if build:
-        project_hash = compose_env["COMPOSE_PROJECT_NAME"].split("-")[-1]
-        local_tag = f"nexus:local-{project_hash}"
+        local_tag = _local_build_image_ref(compose_env)
 
         if _compose_has_build(cf):
-            compose_env.pop("NEXUS_IMAGE_REF", None)
+            compose_env["NEXUS_IMAGE_REF"] = local_tag
             effective_build_mode = "local"
             effective_image_used = local_tag
         else:
@@ -1382,7 +1387,7 @@ def restart(build: bool | None) -> None:
     # Same --build / --pull logic as `up`
     if build:
         if _compose_has_build(cf):
-            compose_env.pop("NEXUS_IMAGE_REF", None)
+            compose_env["NEXUS_IMAGE_REF"] = _local_build_image_ref(compose_env)
         else:
             console.print(
                 "[nexus.warning]Warning:[/nexus.warning] --build ignored — compose file "

--- a/src/nexus/cli/commands/status.py
+++ b/src/nexus/cli/commands/status.py
@@ -74,6 +74,17 @@ def _server_health(
     Falls back to the public ``/health`` endpoint when the detailed
     endpoint requires authentication and no *api_key* is provided.
     """
+
+    def public_health(client: Any) -> dict[str, Any] | None:
+        try:
+            fallback = client.get(f"{base_url}/health")
+        except Exception:
+            return None
+        if fallback.status_code == 200:
+            fb_result: dict[str, Any] = fallback.json()
+            return fb_result
+        return {"status": "error", "http_status": fallback.status_code}
+
     try:
         import httpx
 
@@ -82,17 +93,20 @@ def _server_health(
             headers["Authorization"] = f"Bearer {api_key}"
 
         with httpx.Client(timeout=timeout, headers=headers) as client:
-            resp = client.get(f"{base_url}/health/detailed")
+            if not api_key:
+                return public_health(client)
+
+            try:
+                resp = client.get(f"{base_url}/health/detailed")
+            except (httpx.TimeoutException, httpx.RequestError):
+                return public_health(client)
             if resp.status_code == 200:
                 result: dict[str, Any] = resp.json()
                 return result
             # Detailed endpoint may require admin auth — fall back to
             # the public /health endpoint so we still report "healthy".
             if resp.status_code in (401, 403):
-                fallback = client.get(f"{base_url}/health")
-                if fallback.status_code == 200:
-                    fb_result: dict[str, Any] = fallback.json()
-                    return fb_result
+                return public_health(client)
             return {"status": "error", "http_status": resp.status_code}
     except Exception:
         return None

--- a/src/nexus/fs/_helpers.py
+++ b/src/nexus/fs/_helpers.py
@@ -13,7 +13,7 @@ import contextlib
 import logging
 import os
 import threading
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.types import OperationContext
@@ -110,7 +110,10 @@ def _maybe_build_trigram_background(
 
     def _build() -> None:
         try:
-            from nexus_runtime import build_trigram_index_from_entries
+            from nexus._rust_compat import build_trigram_index_from_entries
+
+            if build_trigram_index_from_entries is None:
+                return
 
             entries: list[tuple[str, bytes]] = []
             for fp in file_paths:
@@ -150,9 +153,9 @@ def _ensure_trigram_index(kernel: NexusFS, file_paths: list[str], zone_id: str) 
 def _trigram_candidates(
     index_path: str, pattern: str, path: str, ignore_case: bool
 ) -> list[str] | None:
-    try:
-        from nexus_runtime import trigram_search_candidates
-    except (ImportError, OSError):
+    from nexus._rust_compat import trigram_search_candidates
+
+    if trigram_search_candidates is None:
         return None
     try:
         candidates = trigram_search_candidates(index_path, pattern, ignore_case)
@@ -163,7 +166,7 @@ def _trigram_candidates(
     if path != "/":
         prefix = path if path.endswith("/") else path + "/"
         candidates = [c for c in candidates if c.startswith(prefix) or c == path]
-    return candidates
+    return cast(list[str], candidates)
 
 
 def grep(

--- a/tests/unit/bricks/search/test_rust_optional_fallback.py
+++ b/tests/unit/bricks/search/test_rust_optional_fallback.py
@@ -59,3 +59,20 @@ def test_glob_helpers_fall_back_when_rust_glob_is_unavailable(monkeypatch) -> No
         include_patterns=["**/*.py"],
         exclude_patterns=["**/test_*.py"],
     ) == ["/src/main.py"]
+
+
+def test_glob_helpers_python_fallback_supports_brace_alternation(monkeypatch) -> None:
+    """The no-Rust fallback should preserve globset's {a,b} alternation."""
+    import nexus._rust_compat as rust_compat
+    from nexus.bricks.search.primitives import glob_helpers
+
+    monkeypatch.setattr(rust_compat, "glob_match_bulk", None)
+
+    paths = ["/src/main.py", "/src/app.ts", "/src/readme.md", "/src/app.test.ts"]
+
+    assert glob_helpers.glob_match("/src/main.py", ["**/*.{py,ts}"]) is True
+    assert glob_helpers.glob_filter(
+        paths,
+        include_patterns=["**/*.{py,ts}"],
+        exclude_patterns=["**/*.test.{py,ts}"],
+    ) == ["/src/main.py", "/src/app.ts"]

--- a/tests/unit/bricks/search/test_rust_optional_fallback.py
+++ b/tests/unit/bricks/search/test_rust_optional_fallback.py
@@ -1,0 +1,61 @@
+"""Tests for optional Rust search accelerator fallback."""
+
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from typing import cast
+from unittest.mock import patch
+
+
+def test_trigram_fast_imports_without_nexus_runtime() -> None:
+    """Absent Rust runtime should disable trigram acceleration, not imports."""
+    module_names = (
+        "nexus_runtime",
+        "nexus._rust_compat",
+        "nexus.bricks.search.primitives",
+        "nexus.bricks.search.primitives.trigram_fast",
+    )
+    saved = {name: sys.modules.get(name) for name in module_names}
+    try:
+        for name in module_names:
+            sys.modules.pop(name, None)
+
+        with patch.dict(sys.modules, {"nexus_runtime": cast(types.ModuleType, None)}):
+            trigram_fast = importlib.import_module("nexus.bricks.search.primitives.trigram_fast")
+
+            assert trigram_fast.is_available() is False
+            assert trigram_fast.build_index(["/tmp/input.txt"], "/tmp/out.trgm") is False
+            assert (
+                trigram_fast.build_index_from_entries(
+                    [("/tmp/input.txt", b"hello")], "/tmp/out.trgm"
+                )
+                is False
+            )
+            assert trigram_fast.grep("/tmp/out.trgm", "hello") is None
+            assert trigram_fast.search_candidates("/tmp/out.trgm", "hello") is None
+            assert trigram_fast.get_stats("/tmp/out.trgm") is None
+            trigram_fast.invalidate_cache("/tmp/out.trgm")
+    finally:
+        for name, mod in saved.items():
+            if mod is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = mod
+
+
+def test_glob_helpers_fall_back_when_rust_glob_is_unavailable(monkeypatch) -> None:
+    """Glob helpers are documented as Python helpers and must not require Rust."""
+    import nexus._rust_compat as rust_compat
+    from nexus.bricks.search.primitives import glob_helpers
+
+    monkeypatch.setattr(rust_compat, "glob_match_bulk", None)
+
+    assert glob_helpers.glob_match("/src/main.py", ["**/*.py"]) is True
+    assert glob_helpers.glob_match("/README.md", ["**/*.py"]) is False
+    assert glob_helpers.glob_filter(
+        ["/src/main.py", "/src/main.txt", "/src/test_main.py"],
+        include_patterns=["**/*.py"],
+        exclude_patterns=["**/test_*.py"],
+    ) == ["/src/main.py"]

--- a/tests/unit/bricks/search/test_skeleton_pipe_consumer.py
+++ b/tests/unit/bricks/search/test_skeleton_pipe_consumer.py
@@ -1,6 +1,8 @@
 """Tests for DT_PIPE-backed skeleton indexing consumer."""
 
 import asyncio
+import contextlib
+import time
 from typing import TYPE_CHECKING, Any, cast
 
 import pytest
@@ -19,6 +21,18 @@ class _FakeIndexer:
 
     async def delete_file(self, *, path_id: str | None, virtual_path: str, zone_id: str) -> None:
         return None
+
+
+class _RecordingIndexer:
+    def __init__(self) -> None:
+        self.indexed: list[str] = []
+        self.deleted: list[str] = []
+
+    async def index_file(self, *, path_id: str | None, virtual_path: str, zone_id: str) -> None:
+        self.indexed.append(virtual_path)
+
+    async def delete_file(self, *, path_id: str | None, virtual_path: str, zone_id: str) -> None:
+        self.deleted.append(virtual_path)
 
 
 def _indexer() -> "SkeletonIndexer":
@@ -53,6 +67,12 @@ class _FakeNx:
     def sys_write(self, path: str, data: bytes, *, context: Any | None = None) -> dict[str, Any]:
         self.write_calls.append((path, data, context))
         return {"path": path, "bytes_written": len(data)}
+
+
+class _SlowReadNx:
+    def sys_read(self, path: str, *, context: Any | None = None) -> bytes:
+        time.sleep(0.15)
+        return b""
 
 
 @pytest.mark.asyncio
@@ -103,3 +123,38 @@ async def test_flush_uses_system_context_for_pipe_writes() -> None:
     finally:
         await consumer.stop()
         await asyncio.sleep(0)
+
+
+@pytest.mark.asyncio
+async def test_dispatch_skips_internal_pipe_paths() -> None:
+    indexer = _RecordingIndexer()
+    consumer = SkeletonPipeConsumer(indexer=cast("SkeletonIndexer", indexer))
+
+    await consumer._dispatch_single(  # noqa: SLF001
+        {
+            "type": "write",
+            "path": "/nexus/pipes/skeleton-writes",
+            "path_id": None,
+            "zone_id": "root",
+        }
+    )
+
+    assert indexer.indexed == []
+    assert indexer.deleted == []
+
+
+@pytest.mark.asyncio
+async def test_consumer_does_not_block_event_loop_while_waiting_for_pipe() -> None:
+    consumer = SkeletonPipeConsumer(indexer=_indexer())
+    consumer.bind_fs(_SlowReadNx())
+
+    task = asyncio.create_task(consumer._consume())  # noqa: SLF001
+    started = asyncio.get_running_loop().time()
+    try:
+        await asyncio.sleep(0.01)
+        elapsed = asyncio.get_running_loop().time() - started
+        assert elapsed < 0.08
+    finally:
+        task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await task

--- a/tests/unit/cli/test_stack.py
+++ b/tests/unit/cli/test_stack.py
@@ -258,6 +258,53 @@ class TestUpCommand:
             assert result.exit_code != 0
             assert "not found" in result.output
 
+    def test_build_uses_local_image_ref_for_compose_build(
+        self, runner: CliRunner, tmp_path: Path
+    ) -> None:
+        data_dir = tmp_path / "nexus-data"
+        compose_path = tmp_path / "nexus-stack.yml"
+        compose_path.write_text(
+            yaml.dump(
+                {
+                    "services": {
+                        "nexus": {
+                            "image": "${NEXUS_IMAGE_REF:-ghcr.io/nexi-lab/nexus:latest}",
+                            "build": {"context": ".", "dockerfile": "Dockerfile"},
+                        }
+                    }
+                }
+            )
+        )
+        cfg_path = tmp_path / "nexus.yaml"
+        with open(cfg_path, "w") as f:
+            yaml.dump(
+                {
+                    "preset": "shared",
+                    "data_dir": str(data_dir),
+                    "compose_file": str(compose_path),
+                    "compose_profiles": [],
+                    "services": [],
+                    "ports": {},
+                    "image_ref": "ghcr.io/nexi-lab/nexus:latest",
+                },
+                f,
+            )
+
+        mock_result = MagicMock()
+        mock_result.returncode = 0
+        with (
+            patch(_CONFIG_PATCH, (str(cfg_path),)),
+            patch(
+                "nexus.cli.commands.stack._run_compose", return_value=mock_result
+            ) as mock_compose,
+        ):
+            result = runner.invoke(up, ["--build", "--no-detach"])
+
+        assert result.exit_code == 0
+        compose_env = mock_compose.call_args.kwargs["extra_env"]
+        project_hash = compose_env["COMPOSE_PROJECT_NAME"].split("-")[-1]
+        assert compose_env["NEXUS_IMAGE_REF"] == f"nexus:local-{project_hash}"
+
 
 # ---------------------------------------------------------------------------
 # _derive_project_env tests

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import json
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 from click.testing import CliRunner
 
@@ -42,10 +43,45 @@ class TestServerHealth:
         assert result["status"] == "healthy"
 
     @patch("httpx.Client")
+    def test_uses_public_health_without_api_key(self, mock_client_cls: MagicMock) -> None:
+        mock_client = MagicMock()
+        mock_resp = MagicMock(status_code=200)
+        mock_resp.json.return_value = {"status": "healthy", "service": "nexus-rpc"}
+        mock_client.get.return_value = mock_resp
+        mock_client.__enter__ = lambda s: mock_client
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        result = _server_health("http://localhost:2026")
+
+        assert result == {"status": "healthy", "service": "nexus-rpc"}
+        mock_client.get.assert_called_once_with("http://localhost:2026/health")
+
+    @patch("httpx.Client")
     def test_returns_none_on_connection_error(self, mock_client_cls: MagicMock) -> None:
         mock_client_cls.side_effect = Exception("Connection refused")
         result = _server_health("http://localhost:2026")
         assert result is None
+
+    @patch("httpx.Client")
+    def test_falls_back_to_public_health_when_detailed_times_out(
+        self, mock_client_cls: MagicMock
+    ) -> None:
+        mock_client = MagicMock()
+        fallback_resp = MagicMock(status_code=200)
+        fallback_resp.json.return_value = {"status": "healthy", "service": "nexus-rpc"}
+        mock_client.get.side_effect = [
+            httpx.TimeoutException("detailed health timed out"),
+            fallback_resp,
+        ]
+        mock_client.__enter__ = lambda s: mock_client
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        result = _server_health("http://localhost:2026", api_key="sk-test")
+
+        assert result == {"status": "healthy", "service": "nexus-rpc"}
+        assert mock_client.get.call_count == 2
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/core/test_rust_compat.py
+++ b/tests/unit/core/test_rust_compat.py
@@ -208,6 +208,95 @@ class TestNonCoreMissing:
         assert compat.RUST_AVAILABLE is True
 
 
+class TestOptionalAcceleratorGroups:
+    """Optional accelerator groups degrade independently when stale."""
+
+    def test_trigram_group_is_declared_and_reexported(self) -> None:
+        from nexus._kernel_api_groups import MODULE_CAPABILITY_GROUPS
+
+        assert MODULE_CAPABILITY_GROUPS["trigram"] == (
+            "build_trigram_index",
+            "build_trigram_index_from_entries",
+            "invalidate_trigram_cache",
+            "trigram_grep",
+            "trigram_index_stats",
+            "trigram_search_candidates",
+        )
+
+        mod = _make_fake_module()
+        compat = _reload_rust_compat(mod)
+        assert compat.trigram_grep is not None
+        assert compat.build_trigram_index_from_entries is not None
+
+    def test_missing_trigram_symbol_disables_only_trigram_group(self) -> None:
+        mod = _make_fake_module(missing_module_symbols=["trigram_grep"])
+        compat = _reload_rust_compat(mod)
+
+        assert compat.RUST_AVAILABLE is True
+        assert compat.trigram_grep is None
+        assert compat.trigram_search_candidates is None
+        assert compat.grep_bulk is not None
+        assert compat.batch_prefix_check is not None
+
+    def test_rebac_group_is_declared_and_reexported(self) -> None:
+        from nexus._kernel_api_groups import MODULE_CAPABILITY_GROUPS
+
+        assert MODULE_CAPABILITY_GROUPS["rebac"] == (
+            "compute_permission_single",
+            "compute_permissions_bulk",
+            "expand_subjects",
+            "list_objects_for_subject",
+        )
+
+        mod = _make_fake_module()
+        compat = _reload_rust_compat(mod)
+        assert compat.compute_permissions_bulk is not None
+        assert compat.list_objects_for_subject is not None
+
+    def test_missing_rebac_symbol_disables_only_rebac_group(self) -> None:
+        mod = _make_fake_module(missing_module_symbols=["compute_permissions_bulk"])
+        compat = _reload_rust_compat(mod)
+
+        assert compat.RUST_AVAILABLE is True
+        assert compat.compute_permissions_bulk is None
+        assert compat.compute_permission_single is None
+        assert compat.trigram_grep is not None
+        assert compat.batch_prefix_check is not None
+
+    def test_tiger_group_is_declared_and_reexported(self) -> None:
+        from nexus._kernel_api_groups import MODULE_CAPABILITY_GROUPS
+
+        assert MODULE_CAPABILITY_GROUPS["prefix"] == (
+            "any_path_starts_with",
+            "batch_prefix_check",
+            "filter_paths_by_prefix",
+        )
+        assert MODULE_CAPABILITY_GROUPS["tiger"] == (
+            "any_path_accessible_tiger_cache",
+            "check_permission_bitmap",
+            "check_permission_bitmap_batch",
+            "filter_paths_with_tiger_cache",
+            "filter_paths_with_tiger_cache_parallel",
+            "intersect_paths_with_tiger_cache",
+            "tiger_cache_bitmap_stats",
+        )
+
+        mod = _make_fake_module()
+        compat = _reload_rust_compat(mod)
+        assert compat.filter_paths_with_tiger_cache is not None
+        assert compat.tiger_cache_bitmap_stats is not None
+
+    def test_missing_tiger_symbol_disables_only_tiger_group(self) -> None:
+        mod = _make_fake_module(missing_module_symbols=["filter_paths_with_tiger_cache"])
+        compat = _reload_rust_compat(mod)
+
+        assert compat.RUST_AVAILABLE is True
+        assert compat.filter_paths_with_tiger_cache is None
+        assert compat.tiger_cache_bitmap_stats is None
+        assert compat.batch_prefix_check is not None
+        assert compat.compute_permissions_bulk is not None
+
+
 # ---------------------------------------------------------------------------
 # Tests: Kernel class method validation (the Issue #3712 regression case)
 # ---------------------------------------------------------------------------

--- a/tests/unit/services/permissions/test_rebac_fast_fallback.py
+++ b/tests/unit/services/permissions/test_rebac_fast_fallback.py
@@ -1,5 +1,52 @@
 """Tests for optional Rust acceleration fallback in ReBAC helpers."""
 
+from __future__ import annotations
+
+import importlib
+import sys
+import types
+from typing import cast
+from unittest.mock import patch
+
+
+def test_rebac_fast_imports_without_nexus_runtime_and_uses_python_fallback() -> None:
+    """Absent Rust runtime should disable acceleration without breaking imports."""
+    module_names = (
+        "nexus_runtime",
+        "nexus._rust_compat",
+        "nexus.bricks.rebac.utils.fast",
+    )
+    saved = {name: sys.modules.get(name) for name in module_names}
+    try:
+        for name in module_names:
+            sys.modules.pop(name, None)
+
+        with patch.dict(sys.modules, {"nexus_runtime": cast(types.ModuleType, None)}):
+            fast = importlib.import_module("nexus.bricks.rebac.utils.fast")
+
+            assert fast.is_rust_available() is False
+            result = fast.check_permissions_bulk_with_fallback(
+                [(("user", "alice"), "read", ("file", "/doc.txt"))],
+                [
+                    {
+                        "subject_type": "user",
+                        "subject_id": "alice",
+                        "subject_relation": None,
+                        "relation": "read",
+                        "object_type": "file",
+                        "object_id": "/doc.txt",
+                    }
+                ],
+                {},
+            )
+            assert result[("user", "alice", "read", "file", "/doc.txt")] is True
+    finally:
+        for name, mod in saved.items():
+            if mod is None:
+                sys.modules.pop(name, None)
+            else:
+                sys.modules[name] = mod
+
 
 def test_python_fallback_does_not_treat_userset_subject_as_direct_grant() -> None:
     """group:eng#member grants must not grant group:eng itself."""


### PR DESCRIPTION
## Summary

Fixes #3950 by routing optional Rust accelerator imports through `nexus._rust_compat` and making search/ReBAC callers degrade when optional symbols are absent or stale.

This also fixes two stack-validation blockers found while running the actual Nexus stack with `nexus up --build` on OrbStack:

- `nexus up --build` now tags compose builds with the per-project local image ref so the rebuilt image is the one that runs.
- The skeleton pipe consumer no longer blocks the event loop while waiting on pipe reads, and it ignores internal pipe paths.
- `nexus status` uses public `/health` when no API key is provided, avoiding false unreachable status from slower detailed health probes.

## Validation

- `PATH="$HOME/.orbstack/bin:$PATH" uv run nexus up --build --timeout 240`
- Live `/health`: HTTP 200 in ~0.04s
- Live `/healthz/ready`: HTTP 200 in ~0.03s
- `uv run nexus status`: `server_reachable: true`
- Container live check: Rust compatibility symbols available; trigram/ReBAC available; glob helpers work
- `uv run pytest -q -o addopts='' tests/unit/core/test_rust_compat.py tests/unit/bricks/search/test_rust_optional_fallback.py tests/unit/services/permissions/test_rebac_fast_fallback.py`
- `uv run pytest -q -o addopts='' tests/unit/bricks/search/test_skeleton_pipe_consumer.py tests/unit/cli/test_stack.py tests/unit/cli/test_status.py`
- Commit hooks passed: ruff, ruff-format, mypy, codegen sync, and repository checks
