### PR TITLE
[codex] Isolate S3 and Slack connector metadata

### DIFF
--- a/docs/superpowers/plans/2026-05-06-issue-3964-connector-package-isolation.md
+++ b/docs/superpowers/plans/2026-05-06-issue-3964-connector-package-isolation.md
@@ -1,0 +1,665 @@
+# Connector Package Isolation Pilot Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add metadata-complete S3 and Slack connector manifests that prove optional connector metadata can be discovered without importing optional SDKs or implementation modules.
+
+**Architecture:** Keep the #3830 runtime registry and mount-time dependency checker unchanged. Add metadata-only `_manifest.py` modules under `src/nexus/backends/connectors/` so the extension store and generated `extensions.json` can discover S3 and Slack metadata before importing `boto3`, `slack_sdk`, or connector implementation modules.
+
+**Tech Stack:** Python 3.14, Pydantic v2 manifest models, pytest, `nexus.extensions.index`, existing slim-wheel smoke fixtures.
+
+---
+
+## File Structure
+
+- Create `src/nexus/backends/connectors/s3/__init__.py`: metadata-only package marker for the S3 connector bundle pilot.
+- Create `src/nexus/backends/connectors/s3/_manifest.py`: S3 `ConnectorManifest` pointing at existing `nexus.backends.storage.path_s3.PathS3Backend`.
+- Create `src/nexus/backends/connectors/slack/_manifest.py`: Slack `ConnectorManifest` for `PathSlackBackend`.
+- Modify `tests/extensions/test_store.py`: tests that S3 and Slack are metadata-complete and discovery does not import optional SDKs or implementation modules.
+- Modify `tests/integration/slim/test_slim_install_smoke.py`: base slim wheel test for no-extras connector metadata discovery.
+- Modify `src/nexus/extensions/_index/extensions.json`: generated index updated through `python -m nexus.extensions.index build`.
+
+### Task 1: Metadata Discovery Tests
+
+**Files:**
+- Modify: `tests/extensions/test_store.py`
+
+- [ ] **Step 1: Write failing tests for S3 and Slack metadata completeness**
+
+Append this class after `TestLegacyAdapterMetadataCompleteness` in `tests/extensions/test_store.py`:
+
+```python
+class TestConnectorPackageIsolationPilot:
+    """Issue #3964 pilot: S3 and Slack expose metadata-complete manifests
+    without importing optional connector SDKs or implementation modules."""
+
+    def test_s3_and_slack_manifests_are_metadata_complete(self):
+        from nexus.extensions.store import get_store, reset_store
+
+        reset_store()
+        store = get_store()
+
+        s3 = store.get("path_s3", kind="connector")
+        assert s3.metadata_complete is True
+        assert s3.service_name == "s3"
+        assert s3.module == "nexus.backends.storage.path_s3"
+        assert s3.factory == "PathS3Backend"
+        assert {d.name for d in s3.runtime_deps} == {"boto3"}
+        assert s3.import_probes == ("boto3",)
+        assert "bucket_name" in s3.connection_args
+        assert s3.connection_args["bucket_name"].config_key == "bucket"
+        assert "signed_url" in s3.capabilities
+        assert "multipart_upload" in s3.capabilities
+
+        slack = store.get("slack_connector", kind="connector")
+        assert slack.metadata_complete is True
+        assert slack.service_name == "slack"
+        assert slack.module == "nexus.backends.connectors.slack.connector"
+        assert slack.factory == "PathSlackBackend"
+        assert {d.name for d in slack.runtime_deps} == {"slack-sdk", "token_manager"}
+        assert slack.import_probes == ("slack_sdk",)
+        assert slack.user_scoped is True
+        assert "token_manager_db" in slack.connection_args
+        assert slack.connection_args["provider"].default == "slack"
+        assert "oauth" in slack.capabilities
+        assert "readme_doc" in slack.capabilities
+
+        reset_store()
+```
+
+- [ ] **Step 2: Write failing test for no implementation imports during discovery**
+
+Append this method inside `TestConnectorPackageIsolationPilot`:
+
+```python
+    def test_pilot_manifest_discovery_does_not_import_optional_sdks_or_impls(self):
+        import sys
+
+        from nexus.extensions.store import get_store, reset_store
+
+        forbidden_modules = {
+            "boto3",
+            "slack_sdk",
+            "nexus.backends.storage.path_s3",
+            "nexus.backends.transports.s3_transport",
+            "nexus.backends.connectors.slack.connector",
+            "nexus.backends.connectors.slack.transport",
+        }
+        for module_name in forbidden_modules:
+            sys.modules.pop(module_name, None)
+
+        reset_store()
+        store = get_store()
+        assert store.get("path_s3", kind="connector").metadata_complete is True
+        assert store.get("slack_connector", kind="connector").metadata_complete is True
+
+        imported = forbidden_modules.intersection(sys.modules)
+        assert imported == set()
+
+        reset_store()
+```
+
+- [ ] **Step 3: Run the focused tests and verify they fail for the right reason**
+
+Run:
+
+```bash
+pytest tests/extensions/test_store.py::TestConnectorPackageIsolationPilot -q
+```
+
+Expected: the first test fails because `path_s3` and `slack_connector` still come from the legacy adapter with `metadata_complete is False`, or because `slack_connector` has no metadata-complete `_manifest.py` yet. The second test may also fail because the first assertion cannot find metadata-complete manifests.
+
+- [ ] **Step 4: Commit the failing tests**
+
+```bash
+git add tests/extensions/test_store.py
+git commit -m "test: pin connector package metadata discovery"
+```
+
+### Task 2: S3 Metadata Manifest
+
+**Files:**
+- Create: `src/nexus/backends/connectors/s3/__init__.py`
+- Create: `src/nexus/backends/connectors/s3/_manifest.py`
+- Test: `tests/extensions/test_store.py`
+
+- [ ] **Step 1: Add the S3 metadata package marker**
+
+Create `src/nexus/backends/connectors/s3/__init__.py`:
+
+```python
+"""S3 connector metadata package.
+
+The implementation remains in nexus.backends.storage.path_s3 during the
+Issue #3964 pilot. This package owns metadata-only discovery for the future
+installable connector bundle.
+"""
+
+__all__: list[str] = []
+```
+
+- [ ] **Step 2: Add the S3 metadata-only manifest**
+
+Create `src/nexus/backends/connectors/s3/_manifest.py`:
+
+```python
+"""S3 connector manifest (extension store discovery).
+
+Imported by ``nexus.extensions.store`` for metadata-only enumeration without
+loading boto3 or the S3 backend implementation. Runtime mounting continues to
+use ``nexus.backends._manifest.CONNECTOR_MANIFEST`` during the #3964 pilot.
+"""
+
+from __future__ import annotations
+
+from nexus.extensions.manifest import ConnectorManifest, RuntimeDep
+from nexus.extensions.types import ArgType, ConnectionArg
+
+MANIFEST = ConnectorManifest(
+    name="path_s3",
+    module="nexus.backends.storage.path_s3",
+    factory="PathS3Backend",
+    description="AWS S3 with direct path mapping",
+    service_name="s3",
+    runtime_deps=(
+        RuntimeDep(
+            kind="python",
+            name="boto3",
+            extras=("s3",),
+            install_hint="pip install nexus-fs[s3]",
+        ),
+    ),
+    import_probes=("boto3",),
+    capabilities=frozenset(
+        {
+            "rename",
+            "directory_listing",
+            "path_delete",
+            "streaming",
+            "batch_content",
+            "signed_url",
+            "multipart_upload",
+            "native_versioning",
+            "resumable_upload",
+        }
+    ),
+    connection_args={
+        "bucket_name": ConnectionArg(
+            type=ArgType.STRING,
+            description="S3 bucket name",
+            required=True,
+            config_key="bucket",
+        ),
+        "region_name": ConnectionArg(
+            type=ArgType.STRING,
+            description="AWS region (e.g., us-east-1)",
+            required=False,
+            env_var="AWS_DEFAULT_REGION",
+        ),
+        "credentials_path": ConnectionArg(
+            type=ArgType.PATH,
+            description="Path to AWS credentials JSON file",
+            required=False,
+            secret=True,
+        ),
+        "prefix": ConnectionArg(
+            type=ArgType.STRING,
+            description="Path prefix for all files in bucket",
+            required=False,
+            default="",
+        ),
+        "access_key_id": ConnectionArg(
+            type=ArgType.SECRET,
+            description="AWS access key ID",
+            required=False,
+            secret=True,
+            env_var="AWS_ACCESS_KEY_ID",
+        ),
+        "secret_access_key": ConnectionArg(
+            type=ArgType.PASSWORD,
+            description="AWS secret access key",
+            required=False,
+            secret=True,
+            env_var="AWS_SECRET_ACCESS_KEY",
+        ),
+        "session_token": ConnectionArg(
+            type=ArgType.SECRET,
+            description="AWS session token (for temporary credentials)",
+            required=False,
+            secret=True,
+            env_var="AWS_SESSION_TOKEN",
+        ),
+    },
+    config_mapping={"bucket": "bucket_name"},
+)
+```
+
+- [ ] **Step 3: Run S3-focused metadata assertions**
+
+Run:
+
+```bash
+pytest tests/extensions/test_store.py::TestConnectorPackageIsolationPilot::test_s3_and_slack_manifests_are_metadata_complete -q
+```
+
+Expected: S3 assertions pass, Slack assertions still fail because `slack_connector` remains metadata-incomplete.
+
+- [ ] **Step 4: Commit the S3 manifest**
+
+```bash
+git add src/nexus/backends/connectors/s3 tests/extensions/test_store.py
+git commit -m "feat: add metadata manifest for s3 connector"
+```
+
+### Task 3: Slack Metadata Manifest
+
+**Files:**
+- Create: `src/nexus/backends/connectors/slack/_manifest.py`
+- Test: `tests/extensions/test_store.py`
+
+- [ ] **Step 1: Add the Slack metadata-only manifest**
+
+Create `src/nexus/backends/connectors/slack/_manifest.py`:
+
+```python
+"""Slack connector manifest (extension store discovery).
+
+Imported by ``nexus.extensions.store`` for metadata-only enumeration without
+loading slack_sdk or the Slack connector implementation. Runtime mounting
+continues to use ``nexus.backends._manifest.CONNECTOR_MANIFEST`` during the
+#3964 pilot.
+"""
+
+from __future__ import annotations
+
+from nexus.extensions.manifest import ConnectorManifest, RuntimeDep
+from nexus.extensions.types import ArgType, ConnectionArg
+
+MANIFEST = ConnectorManifest(
+    name="slack_connector",
+    module="nexus.backends.connectors.slack.connector",
+    factory="PathSlackBackend",
+    description="Slack workspace with OAuth 2.0 authentication",
+    service_name="slack",
+    runtime_deps=(
+        RuntimeDep(
+            kind="python",
+            name="slack-sdk",
+            extras=("slack",),
+            install_hint="pip install nexus-fs[slack]",
+        ),
+        RuntimeDep(kind="service", name="token_manager"),
+    ),
+    import_probes=("slack_sdk",),
+    capabilities=frozenset({"user_scoped", "token_manager", "oauth", "readme_doc"}),
+    connection_args={
+        "token_manager_db": ConnectionArg(
+            type=ArgType.PATH,
+            description="Path to TokenManager database or database URL",
+            required=True,
+        ),
+        "user_email": ConnectionArg(
+            type=ArgType.STRING,
+            description="User email for OAuth lookup (None for multi-user from context)",
+            required=False,
+        ),
+        "provider": ConnectionArg(
+            type=ArgType.STRING,
+            description="OAuth provider name from config",
+            required=False,
+            default="slack",
+        ),
+        "max_messages_per_channel": ConnectionArg(
+            type=ArgType.INTEGER,
+            description="Maximum number of messages to fetch per channel",
+            required=False,
+            default=100,
+        ),
+    },
+    user_scoped=True,
+)
+```
+
+- [ ] **Step 2: Run the connector package isolation store tests**
+
+Run:
+
+```bash
+pytest tests/extensions/test_store.py::TestConnectorPackageIsolationPilot -q
+```
+
+Expected: both tests pass. `get_store()` finds metadata-complete S3 and Slack manifests, and `sys.modules` does not contain the forbidden optional SDK or implementation module names after discovery.
+
+- [ ] **Step 3: Run the broader extension store tests**
+
+Run:
+
+```bash
+pytest tests/extensions/test_store.py -q
+```
+
+Expected: all tests in `tests/extensions/test_store.py` pass.
+
+- [ ] **Step 4: Commit the Slack manifest**
+
+```bash
+git add src/nexus/backends/connectors/slack/_manifest.py tests/extensions/test_store.py
+git commit -m "feat: add metadata manifest for slack connector"
+```
+
+### Task 4: Generated Extension Index
+
+**Files:**
+- Modify: `src/nexus/extensions/_index/extensions.json`
+- Test: `tests/extensions/test_index.py`
+
+- [ ] **Step 1: Verify the index is stale before regenerating**
+
+Run:
+
+```bash
+python -m nexus.extensions.index verify
+```
+
+Expected: FAIL with `DRIFT:` because S3 and Slack manifests exist but are not yet present in `src/nexus/extensions/_index/extensions.json`.
+
+- [ ] **Step 2: Regenerate the index**
+
+Run:
+
+```bash
+python -m nexus.extensions.index build
+```
+
+Expected: command prints a line beginning with `Wrote ` and ending with `src/nexus/extensions/_index/extensions.json`.
+
+- [ ] **Step 3: Verify the regenerated index**
+
+Run:
+
+```bash
+python -m nexus.extensions.index verify
+```
+
+Expected: PASS with a line beginning with `OK: ` and ending with `src/nexus/extensions/_index/extensions.json is up to date`.
+
+- [ ] **Step 4: Run index tests**
+
+Run:
+
+```bash
+pytest tests/extensions/test_index.py -q
+```
+
+Expected: all tests pass, including deterministic serialization and strict duplicate detection.
+
+- [ ] **Step 5: Commit the generated index**
+
+```bash
+git add src/nexus/extensions/_index/extensions.json
+git commit -m "chore: refresh extension index for connector manifests"
+```
+
+### Task 5: Mount-Time Dependency Hint Regression Tests
+
+**Files:**
+- Modify: `tests/integration/backends/test_factory_dep_check.py`
+
+- [ ] **Step 1: Write failing real-connector dependency tests**
+
+First replace the existing `_clean_registry` fixture in `tests/integration/backends/test_factory_dep_check.py` with a snapshot/restore fixture that also restores the optional-backend registration flag. Real connector factory calls register built-in placeholders; leaving `_optional_backends_registered=True` while clearing those placeholders would make later tests order-dependent.
+
+```python
+@pytest.fixture(autouse=True)
+def _clean_registry() -> Any:
+    # Snapshot + restore so real connector registration does not leak across
+    # tests. BackendFactory.create("path_s3", config) triggers optional backend
+    # registration, so restore both the registry contents and the one-shot flag.
+    import nexus.backends as backends_mod
+
+    items_before = dict(ConnectorRegistry._base._items)
+    registered_before = backends_mod._optional_backends_registered
+    yield
+    ConnectorRegistry._base._items.clear()
+    ConnectorRegistry._base._items.update(items_before)
+    backends_mod._optional_backends_registered = registered_before
+```
+
+Then append these methods to `TestFactoryDepCheck` in the same file:
+
+```python
+    def test_path_s3_missing_boto3_uses_s3_extra_hint(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import importlib.util
+
+        real_find_spec = importlib.util.find_spec
+
+        def fake_find_spec(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "boto3":
+                return None
+            return real_find_spec(name, *args, **kwargs)
+
+        monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+        monkeypatch.setattr(
+            "nexus.backends.base.runtime_deps._nexus_fs_extras_available",
+            lambda: True,
+        )
+
+        with pytest.raises(MissingDependencyError) as exc_info:
+            BackendFactory.create("path_s3", {"bucket": "example"})
+
+        msg = str(exc_info.value)
+        assert "path_s3" in msg
+        assert "boto3" in msg
+        assert "pip install nexus-fs[s3]" in msg
+
+    def test_slack_missing_sdk_and_token_manager_are_enumerated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import importlib.util
+
+        real_find_spec = importlib.util.find_spec
+
+        def fake_find_spec(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "slack_sdk":
+                return None
+            return real_find_spec(name, *args, **kwargs)
+
+        monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+        monkeypatch.setattr(
+            "nexus.backends.base.runtime_deps._nexus_fs_extras_available",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "nexus.backends.base.runtime_deps._service_available",
+            lambda name: False if name == "token_manager" else True,
+        )
+
+        with pytest.raises(MissingDependencyError) as exc_info:
+            BackendFactory.create("slack_connector", {"token_manager_db": "tokens.db"})
+
+        msg = str(exc_info.value)
+        assert "slack_connector" in msg
+        assert "slack_sdk" in msg
+        assert "pip install nexus-fs[slack]" in msg
+        assert "service 'token_manager'" in msg
+```
+
+- [ ] **Step 2: Run the real-connector dependency tests**
+
+Run:
+
+```bash
+pytest tests/integration/backends/test_factory_dep_check.py::TestFactoryDepCheck::test_path_s3_missing_boto3_uses_s3_extra_hint tests/integration/backends/test_factory_dep_check.py::TestFactoryDepCheck::test_slack_missing_sdk_and_token_manager_are_enumerated -q
+```
+
+Expected: tests pass because the existing #3830 mount-time dependency checker already gates both connectors through `CONNECTOR_MANIFEST`.
+
+- [ ] **Step 3: Run the full factory dependency check file**
+
+Run:
+
+```bash
+pytest tests/integration/backends/test_factory_dep_check.py -q
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 4: Commit the dependency hint tests**
+
+```bash
+git add tests/integration/backends/test_factory_dep_check.py
+git commit -m "test: pin connector dependency hints for s3 and slack"
+```
+
+### Task 6: Slim No-Extras Discovery Coverage
+
+**Files:**
+- Modify: `tests/integration/slim/test_slim_install_smoke.py`
+
+- [ ] **Step 1: Write failing slim-base discovery test**
+
+Append this test after `test_slim_base_module_imports` in `tests/integration/slim/test_slim_install_smoke.py`:
+
+```python
+def test_slim_base_connector_metadata_discovery_without_optional_deps(
+    slim_base_venv: Path,
+) -> None:
+    """Base slim install lists S3 and Slack metadata without connector extras."""
+    script = """
+import sys
+
+for name in (
+    "boto3",
+    "slack_sdk",
+    "nexus.backends.storage.path_s3",
+    "nexus.backends.transports.s3_transport",
+    "nexus.backends.connectors.slack.connector",
+    "nexus.backends.connectors.slack.transport",
+):
+    sys.modules.pop(name, None)
+
+import nexus
+import nexus.backends
+from nexus.extensions.store import get_store, reset_store
+
+reset_store()
+store = get_store()
+s3 = store.get("path_s3", kind="connector")
+slack = store.get("slack_connector", kind="connector")
+
+assert s3.metadata_complete is True
+assert s3.service_name == "s3"
+assert "boto3" in {d.name for d in s3.runtime_deps}
+assert slack.metadata_complete is True
+assert slack.service_name == "slack"
+assert "slack-sdk" in {d.name for d in slack.runtime_deps}
+
+for name in (
+    "boto3",
+    "slack_sdk",
+    "nexus.backends.storage.path_s3",
+    "nexus.backends.transports.s3_transport",
+    "nexus.backends.connectors.slack.connector",
+    "nexus.backends.connectors.slack.transport",
+):
+    assert name not in sys.modules, name
+
+print("DISCOVERY OK")
+"""
+    result = run_in_slim_venv(slim_base_venv, script)
+    assert result.returncode == 0, (
+        "slim base connector metadata discovery failed:\\n"
+        f"STDOUT:\\n{result.stdout}\\nSTDERR:\\n{result.stderr}"
+    )
+    assert "DISCOVERY OK" in result.stdout
+```
+
+- [ ] **Step 2: Run the slim-base discovery test**
+
+Run:
+
+```bash
+pytest tests/integration/slim/test_slim_install_smoke.py::test_slim_base_connector_metadata_discovery_without_optional_deps -v --override-ini="addopts="
+```
+
+Expected: test passes after the manifests and generated index are in place. It may take several minutes because the fixture builds and installs the slim wheel.
+
+- [ ] **Step 3: Commit slim discovery coverage**
+
+```bash
+git add tests/integration/slim/test_slim_install_smoke.py
+git commit -m "test: cover slim connector metadata without extras"
+```
+
+### Task 7: Final Verification
+
+**Files:**
+- Verify: `src/nexus/backends/connectors/s3/__init__.py`
+- Verify: `src/nexus/backends/connectors/s3/_manifest.py`
+- Verify: `src/nexus/backends/connectors/slack/_manifest.py`
+- Verify: `tests/extensions/test_store.py`
+- Verify: `tests/integration/backends/test_factory_dep_check.py`
+- Verify: `tests/integration/slim/test_slim_install_smoke.py`
+- Verify: `src/nexus/extensions/_index/extensions.json`
+
+- [ ] **Step 1: Run focused extension tests**
+
+Run:
+
+```bash
+pytest tests/extensions/test_store.py::TestConnectorPackageIsolationPilot tests/extensions/test_index.py -q
+```
+
+Expected: all selected extension tests pass.
+
+- [ ] **Step 2: Run mount-time dependency tests**
+
+Run:
+
+```bash
+pytest tests/integration/backends/test_factory_dep_check.py -q
+```
+
+Expected: all factory dependency tests pass.
+
+- [ ] **Step 3: Verify generated extension index**
+
+Run:
+
+```bash
+python -m nexus.extensions.index verify
+```
+
+Expected: a line beginning with `OK: ` and ending with `src/nexus/extensions/_index/extensions.json is up to date`.
+
+- [ ] **Step 4: Run slim no-extras discovery test**
+
+Run:
+
+```bash
+pytest tests/integration/slim/test_slim_install_smoke.py::test_slim_base_connector_metadata_discovery_without_optional_deps -v --override-ini="addopts="
+```
+
+Expected: the test passes with `DISCOVERY OK` in subprocess stdout.
+
+- [ ] **Step 5: Check formatting and whitespace**
+
+Run:
+
+```bash
+git diff --check
+```
+
+Expected: no output and exit code 0.
+
+- [ ] **Step 6: Inspect final diff**
+
+Run:
+
+```bash
+git diff --stat HEAD
+```
+
+Expected: diff includes only the S3/Slack manifest files, connector metadata tests, slim discovery test, and generated extension index.

--- a/docs/superpowers/specs/2026-05-05-issue-3964-connector-package-isolation-design.md
+++ b/docs/superpowers/specs/2026-05-05-issue-3964-connector-package-isolation-design.md
@@ -1,0 +1,166 @@
+# Connector Package Isolation Pilot - Design
+
+**Issue:** [#3964](https://github.com/nexi-lab/nexus/issues/3964) - refactor: isolate optional connector dependencies behind installable connector packages
+**Date:** 2026-05-05
+**Pilot connectors:** S3 (`path_s3`) and Slack (`slack_connector`)
+
+## Context
+
+Issue #3830 delivered the shared connector catalog foundation: built-in connector entries live in `src/nexus/backends/_manifest.py`, optional implementation modules are imported lazily, typed runtime dependencies are checked at mount time, and slim/full installs share the same runtime registry. Issue #3962 added the extension metadata layer so connector metadata can eventually be listed without importing implementation modules.
+
+The remaining #3964 problem is package-boundary isolation. Optional connector code still ships inside the same Python namespace and wheel surface, and most built-in connectors are only represented in the extension store through the partial legacy adapter. That means connector discovery can list names and runtime deps, but it does not yet expose complete install metadata, connection args, or capabilities for most connector packages without binding to the legacy runtime inventory.
+
+## Goal
+
+Define the installable connector package layout and migrate one storage connector plus one API/OAuth connector as a low-risk pilot. The pilot must preserve the unified connector registry while proving that connector metadata is discoverable without importing optional SDK modules.
+
+## Non-Goals
+
+- Moving every connector into separate distributions in one PR.
+- Removing `CONNECTOR_MANIFEST` as the runtime mount catalog.
+- Replacing `BackendFactory.create()` or the existing `@register_connector` runtime binding path.
+- Redesigning OAuth authorization UX.
+- Making Slack or S3 work without their declared runtime dependencies.
+
+## Decisions
+
+| Decision | Choice |
+|---|---|
+| Pilot pair | S3 (`path_s3`) and Slack (`slack_connector`) |
+| First package boundary | Manifest-first package bundle contract, not immediate file movement |
+| Runtime registry | Keep `CONNECTOR_MANIFEST` authoritative for mount-time lookup during the pilot |
+| Metadata discovery | Add metadata-complete `_manifest.py` files for migrated connectors |
+| Install hints | Declare hints in extension `RuntimeDep` records and keep mount-time hints in legacy runtime deps |
+| CI strategy | Add focused no-optional-deps import/discovery tests first; add per-package wheel jobs once packages physically split |
+
+## Package Layout
+
+The target connector bundle layout is:
+
+```text
+packages/nexus-connector-s3/
+  pyproject.toml
+  src/nexus_connector_s3/
+    _manifest.py
+    runtime.py
+
+packages/nexus-connector-slack/
+  pyproject.toml
+  src/nexus_connector_slack/
+    _manifest.py
+    runtime.py
+```
+
+Each package exposes a manifest entry point:
+
+```toml
+[project.entry-points."nexus.connectors"]
+s3 = "nexus_connector_s3._manifest:MANIFEST"
+slack = "nexus_connector_slack._manifest:MANIFEST"
+```
+
+The manifest module imports only `nexus.extensions.manifest`, `nexus.extensions.types`, and standard-library modules. It must not import `boto3`, `slack_sdk`, or the connector implementation module. The runtime module owns the connector class import/registration when the connector is actually mounted.
+
+During the pilot PR, in-tree connectors keep their current file locations. The in-tree `_manifest.py` files use the same shape as the future package manifests so they can be moved into connector packages later without changing the metadata contract.
+
+## Metadata Model
+
+Add metadata-complete connector manifests for:
+
+- `src/nexus/backends/connectors/s3/_manifest.py`, a metadata-only connector package that points at the existing `nexus.backends.storage.path_s3` implementation. This location matches the current extension index scanner, which walks `src/nexus/backends/connectors/*/_manifest.py`.
+- `src/nexus/backends/connectors/slack/_manifest.py`.
+
+The S3 manifest declares:
+
+- `name="path_s3"`
+- `module="nexus.backends.storage.path_s3"`
+- `factory="PathS3Backend"`
+- `service_name="s3"`
+- `runtime_deps=(RuntimeDep(kind="python", name="boto3", extras=("s3",), install_hint="pip install nexus-fs[s3]"),)`
+- `import_probes=("boto3",)`
+- connection args matching `PathS3Backend.CONNECTION_ARGS`
+- capabilities `{"rename", "directory_listing", "path_delete", "streaming", "batch_content", "signed_url", "multipart_upload", "native_versioning", "resumable_upload"}`
+
+The Slack manifest declares:
+
+- `name="slack_connector"`
+- `module="nexus.backends.connectors.slack.connector"`
+- `factory="PathSlackBackend"`
+- `service_name="slack"`
+- `runtime_deps=(RuntimeDep(kind="python", name="slack-sdk", extras=("slack",), install_hint="pip install nexus-fs[slack]"), RuntimeDep(kind="service", name="token_manager"))`
+- `import_probes=("slack_sdk",)`
+- connection args for the public mount configuration fields accepted by `PathSlackBackend` (`token_manager_db`, `user_email`, `provider`, and `max_messages_per_channel`). Slack does not currently declare a `CONNECTION_ARGS` class attribute, so the metadata manifest becomes the discovery source for these fields.
+- `user_scoped=True`
+- capabilities `{"user_scoped", "token_manager", "oauth", "readme_doc"}`
+
+The extension store should prefer these metadata-complete manifests over the partial legacy adapter entries. Existing tests already assert that migrated records report `metadata_complete=True`; this pilot extends that coverage to S3 and Slack.
+
+## Runtime Flow
+
+Runtime mounting remains unchanged:
+
+1. `BackendFactory.create("path_s3", config)` calls `_ensure_optional_backends_registered()`.
+2. `_register_optional_backends()` registers placeholders from `CONNECTOR_MANIFEST`.
+3. Runtime deps are checked through `check_runtime_deps(info.runtime_deps)`.
+4. Missing dependencies raise `MissingDependencyError` with install hints before connector construction.
+5. If deps are present, the implementation module imports and binds the connector class to the placeholder.
+
+This keeps #3830 behavior stable while #3964 moves metadata and package ownership forward.
+
+## Error Handling
+
+Discovery-time errors remain isolated:
+
+- Broken `_manifest.py` files are skipped in non-strict runtime loading and fail loudly in strict index verification.
+- Optional SDK absence must not affect `import nexus`, `import nexus.backends`, or extension listing.
+- Mounting `path_s3` without `boto3` must mention `pip install nexus-fs[s3]` when the active install supports `nexus-fs` extras, or the raw package fallback otherwise.
+- Mounting `slack_connector` without `slack_sdk` or `token_manager` must enumerate all missing requirements.
+
+## Tests
+
+Add unit tests around the pilot manifests:
+
+- `tests/extensions/test_store.py`: `path_s3` and `slack_connector` return `metadata_complete=True` from `get_store()` and retain their service names.
+- `tests/extensions/test_store.py`: metadata discovery does not import `boto3`, `slack_sdk`, or the S3/Slack implementation modules.
+- `tests/extensions/test_index.py`: duplicate or malformed connector manifests still fail strict index generation.
+- `tests/unit/backends/test_runtime_deps.py` or a focused factory test: missing S3 and Slack deps produce actionable install hints through the existing mount-time checker.
+
+Add slim import/discovery coverage:
+
+- In a base slim wheel with no connector extras, import `nexus`, `nexus.backends`, and `nexus.extensions.store`.
+- List connector manifests and verify `path_s3` and `slack_connector` metadata is present.
+- Assert the optional SDK modules are not imported as a side effect.
+
+## CI
+
+Extend `.github/workflows/slim-wheel-smoke.yml` first because it already builds a base slim wheel and installs it without connector extras. Add a focused test or test parameter that verifies core imports and connector metadata discovery with no optional connector deps installed.
+
+Once physical connector packages exist, add a separate connector-package matrix:
+
+| Package | Install command | Smoke |
+|---|---|---|
+| `nexus-connector-s3` | `pip install ./packages/nexus-connector-s3` | manifest discovery and missing-credential mount check |
+| `nexus-connector-slack` | `pip install ./packages/nexus-connector-slack` | manifest discovery and missing-token mount check |
+
+## Rollout
+
+1. Land the manifest-first S3 and Slack pilot in-tree.
+2. Add CI proving no-optional-deps import and metadata discovery.
+3. Split the pilot manifests and runtimes into `packages/nexus-connector-s3` and `packages/nexus-connector-slack`.
+4. Convert remaining target connectors after the pilot package contract is stable: GCS, Google Workspace/Drive/Gmail/Calendar, and GitHub.
+5. Retire legacy adapter coverage only after every built-in connector has a metadata-complete manifest.
+
+## Acceptance Criteria Mapping
+
+| #3964 criterion | Pilot coverage |
+|---|---|
+| Define connector package/bundle layout | This design defines package directories, manifest entry points, and runtime module boundaries |
+| Add install hints to connector metadata | S3 and Slack extension manifests carry explicit runtime dep install hints |
+| Add mount-time dependency checks | Existing #3830 checker remains the enforcement point; tests pin S3/Slack behavior |
+| Convert one storage and one API/OAuth connector | S3 and Slack are the pilot migrations |
+| Add CI for core import with no optional deps | Slim-wheel smoke extends base no-extras coverage |
+| Add CI for migrated packages/bundles | Deferred until physical packages are created after the in-tree pilot |
+
+## Open Follow-Up
+
+The one deliberate deferral is the physical package split. The pilot first proves the metadata and CI contract in-tree. Moving files into separate distributions should be a follow-up PR because it changes wheel ownership, package data, and release automation at the same time.

--- a/docs/superpowers/specs/2026-05-05-issue-3964-connector-package-isolation-design.md
+++ b/docs/superpowers/specs/2026-05-05-issue-3964-connector-package-isolation-design.md
@@ -55,8 +55,8 @@ Each package exposes a manifest entry point:
 
 ```toml
 [project.entry-points."nexus.connectors"]
-s3 = "nexus_connector_s3._manifest:MANIFEST"
-slack = "nexus_connector_slack._manifest:MANIFEST"
+path_s3 = "nexus_connector_s3._manifest"
+slack_connector = "nexus_connector_slack._manifest"
 ```
 
 The manifest module imports only `nexus.extensions.manifest`, `nexus.extensions.types`, and standard-library modules. It must not import `boto3`, `slack_sdk`, or the connector implementation module. The runtime module owns the connector class import/registration when the connector is actually mounted.

--- a/src/nexus/backends/connectors/s3/__init__.py
+++ b/src/nexus/backends/connectors/s3/__init__.py
@@ -1,0 +1,8 @@
+"""S3 connector metadata package.
+
+The implementation remains in nexus.backends.storage.path_s3 during the
+Issue #3964 pilot. This package owns metadata-only discovery for the future
+installable connector bundle.
+"""
+
+__all__: list[str] = []

--- a/src/nexus/backends/connectors/s3/_manifest.py
+++ b/src/nexus/backends/connectors/s3/_manifest.py
@@ -1,0 +1,89 @@
+"""S3 connector manifest (extension store discovery).
+
+Imported by ``nexus.extensions.store`` for metadata-only enumeration without
+loading boto3 or the S3 backend implementation. Runtime mounting continues to
+use ``nexus.backends._manifest.CONNECTOR_MANIFEST`` during the #3964 pilot.
+"""
+
+from __future__ import annotations
+
+from nexus.extensions.manifest import ConnectorManifest, RuntimeDep
+from nexus.extensions.types import ArgType, ConnectionArg
+
+MANIFEST = ConnectorManifest(
+    name="path_s3",
+    module="nexus.backends.storage.path_s3",
+    factory="PathS3Backend",
+    description="AWS S3 with direct path mapping",
+    service_name="s3",
+    runtime_deps=(
+        RuntimeDep(
+            kind="python",
+            name="boto3",
+            extras=("s3",),
+            install_hint="pip install nexus-fs[s3]",
+        ),
+    ),
+    import_probes=("boto3",),
+    capabilities=frozenset(
+        {
+            "rename",
+            "directory_listing",
+            "path_delete",
+            "streaming",
+            "batch_content",
+            "signed_url",
+            "multipart_upload",
+            "native_versioning",
+            "resumable_upload",
+        }
+    ),
+    connection_args={
+        "bucket_name": ConnectionArg(
+            type=ArgType.STRING,
+            description="S3 bucket name",
+            required=True,
+            config_key="bucket",
+        ),
+        "region_name": ConnectionArg(
+            type=ArgType.STRING,
+            description="AWS region (e.g., us-east-1)",
+            required=False,
+            env_var="AWS_DEFAULT_REGION",
+        ),
+        "credentials_path": ConnectionArg(
+            type=ArgType.PATH,
+            description="Path to AWS credentials JSON file",
+            required=False,
+            secret=True,
+        ),
+        "prefix": ConnectionArg(
+            type=ArgType.STRING,
+            description="Path prefix for all files in bucket",
+            required=False,
+            default="",
+        ),
+        "access_key_id": ConnectionArg(
+            type=ArgType.SECRET,
+            description="AWS access key ID",
+            required=False,
+            secret=True,
+            env_var="AWS_ACCESS_KEY_ID",
+        ),
+        "secret_access_key": ConnectionArg(
+            type=ArgType.PASSWORD,
+            description="AWS secret access key",
+            required=False,
+            secret=True,
+            env_var="AWS_SECRET_ACCESS_KEY",
+        ),
+        "session_token": ConnectionArg(
+            type=ArgType.SECRET,
+            description="AWS session token (for temporary credentials)",
+            required=False,
+            secret=True,
+            env_var="AWS_SESSION_TOKEN",
+        ),
+    },
+    config_mapping={"bucket": "bucket_name"},
+)

--- a/src/nexus/backends/connectors/slack/_manifest.py
+++ b/src/nexus/backends/connectors/slack/_manifest.py
@@ -1,0 +1,56 @@
+"""Slack connector manifest (extension store discovery).
+
+Imported by ``nexus.extensions.store`` for metadata-only enumeration without
+loading slack_sdk or the Slack connector implementation. Runtime mounting
+continues to use ``nexus.backends._manifest.CONNECTOR_MANIFEST`` during the
+#3964 pilot.
+"""
+
+from __future__ import annotations
+
+from nexus.extensions.manifest import ConnectorManifest, RuntimeDep
+from nexus.extensions.types import ArgType, ConnectionArg
+
+MANIFEST = ConnectorManifest(
+    name="slack_connector",
+    module="nexus.backends.connectors.slack.connector",
+    factory="PathSlackBackend",
+    description="Slack workspace with OAuth 2.0 authentication",
+    service_name="slack",
+    runtime_deps=(
+        RuntimeDep(
+            kind="python",
+            name="slack-sdk",
+            extras=("slack",),
+            install_hint="pip install nexus-fs[slack]",
+        ),
+        RuntimeDep(kind="service", name="token_manager"),
+    ),
+    import_probes=("slack_sdk",),
+    capabilities=frozenset({"user_scoped", "token_manager", "oauth", "readme_doc"}),
+    connection_args={
+        "token_manager_db": ConnectionArg(
+            type=ArgType.PATH,
+            description="Path to TokenManager database or database URL",
+            required=True,
+        ),
+        "user_email": ConnectionArg(
+            type=ArgType.STRING,
+            description="User email for OAuth lookup (None for multi-user from context)",
+            required=False,
+        ),
+        "provider": ConnectionArg(
+            type=ArgType.STRING,
+            description="OAuth provider name from config",
+            required=False,
+            default="slack",
+        ),
+        "max_messages_per_channel": ConnectionArg(
+            type=ArgType.INTEGER,
+            description="Maximum number of messages to fetch per channel",
+            required=False,
+            default=100,
+        ),
+    },
+    user_scoped=True,
+)

--- a/src/nexus/backends/connectors/slack/_manifest.py
+++ b/src/nexus/backends/connectors/slack/_manifest.py
@@ -24,7 +24,6 @@ MANIFEST = ConnectorManifest(
             extras=("slack",),
             install_hint="pip install nexus-fs[slack]",
         ),
-        RuntimeDep(kind="service", name="token_manager"),
     ),
     import_probes=("slack_sdk",),
     capabilities=frozenset({"user_scoped", "token_manager", "oauth", "readme_doc"}),

--- a/src/nexus/extensions/_index/extensions.json
+++ b/src/nexus/extensions/_index/extensions.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-06T01:10:47Z",
+  "generated_at": "2026-05-06T06:30:29Z",
   "manifests": [
     {
       "config_schema": null,
@@ -235,12 +235,6 @@
           "install_hint": "pip install nexus-fs[slack]",
           "kind": "python",
           "name": "slack-sdk"
-        },
-        {
-          "extras": [],
-          "install_hint": null,
-          "kind": "service",
-          "name": "token_manager"
         }
       ],
       "service_name": "slack",

--- a/src/nexus/extensions/_index/extensions.json
+++ b/src/nexus/extensions/_index/extensions.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-01T03:57:57Z",
+  "generated_at": "2026-05-06T01:10:47Z",
   "manifests": [
     {
       "config_schema": null,
@@ -65,6 +65,186 @@
       "runtime_deps": [],
       "service_name": "hackernews",
       "user_scoped": false
+    },
+    {
+      "capabilities": [
+        "batch_content",
+        "directory_listing",
+        "multipart_upload",
+        "native_versioning",
+        "path_delete",
+        "rename",
+        "resumable_upload",
+        "signed_url",
+        "streaming"
+      ],
+      "config_mapping": {
+        "bucket": "bucket_name"
+      },
+      "config_schema": null,
+      "connection_args": {
+        "access_key_id": {
+          "config_key": null,
+          "default": null,
+          "description": "AWS access key ID",
+          "env_var": "AWS_ACCESS_KEY_ID",
+          "required": false,
+          "secret": true,
+          "type": "secret"
+        },
+        "bucket_name": {
+          "config_key": "bucket",
+          "default": null,
+          "description": "S3 bucket name",
+          "env_var": null,
+          "required": true,
+          "secret": false,
+          "type": "string"
+        },
+        "credentials_path": {
+          "config_key": null,
+          "default": null,
+          "description": "Path to AWS credentials JSON file",
+          "env_var": null,
+          "required": false,
+          "secret": true,
+          "type": "path"
+        },
+        "prefix": {
+          "config_key": null,
+          "default": "",
+          "description": "Path prefix for all files in bucket",
+          "env_var": null,
+          "required": false,
+          "secret": false,
+          "type": "string"
+        },
+        "region_name": {
+          "config_key": null,
+          "default": null,
+          "description": "AWS region (e.g., us-east-1)",
+          "env_var": "AWS_DEFAULT_REGION",
+          "required": false,
+          "secret": false,
+          "type": "string"
+        },
+        "secret_access_key": {
+          "config_key": null,
+          "default": null,
+          "description": "AWS secret access key",
+          "env_var": "AWS_SECRET_ACCESS_KEY",
+          "required": false,
+          "secret": true,
+          "type": "password"
+        },
+        "session_token": {
+          "config_key": null,
+          "default": null,
+          "description": "AWS session token (for temporary credentials)",
+          "env_var": "AWS_SESSION_TOKEN",
+          "required": false,
+          "secret": true,
+          "type": "secret"
+        }
+      },
+      "description": "AWS S3 with direct path mapping",
+      "factory": "PathS3Backend",
+      "import_probes": [
+        "boto3"
+      ],
+      "kind": "connector",
+      "metadata_complete": true,
+      "module": "nexus.backends.storage.path_s3",
+      "name": "path_s3",
+      "profile_gate": null,
+      "runtime_deps": [
+        {
+          "extras": [
+            "s3"
+          ],
+          "install_hint": "pip install nexus-fs[s3]",
+          "kind": "python",
+          "name": "boto3"
+        }
+      ],
+      "service_name": "s3",
+      "user_scoped": false
+    },
+    {
+      "capabilities": [
+        "oauth",
+        "readme_doc",
+        "token_manager",
+        "user_scoped"
+      ],
+      "config_mapping": {},
+      "config_schema": null,
+      "connection_args": {
+        "max_messages_per_channel": {
+          "config_key": null,
+          "default": 100,
+          "description": "Maximum number of messages to fetch per channel",
+          "env_var": null,
+          "required": false,
+          "secret": false,
+          "type": "integer"
+        },
+        "provider": {
+          "config_key": null,
+          "default": "slack",
+          "description": "OAuth provider name from config",
+          "env_var": null,
+          "required": false,
+          "secret": false,
+          "type": "string"
+        },
+        "token_manager_db": {
+          "config_key": null,
+          "default": null,
+          "description": "Path to TokenManager database or database URL",
+          "env_var": null,
+          "required": true,
+          "secret": false,
+          "type": "path"
+        },
+        "user_email": {
+          "config_key": null,
+          "default": null,
+          "description": "User email for OAuth lookup (None for multi-user from context)",
+          "env_var": null,
+          "required": false,
+          "secret": false,
+          "type": "string"
+        }
+      },
+      "description": "Slack workspace with OAuth 2.0 authentication",
+      "factory": "PathSlackBackend",
+      "import_probes": [
+        "slack_sdk"
+      ],
+      "kind": "connector",
+      "metadata_complete": true,
+      "module": "nexus.backends.connectors.slack.connector",
+      "name": "slack_connector",
+      "profile_gate": null,
+      "runtime_deps": [
+        {
+          "extras": [
+            "slack"
+          ],
+          "install_hint": "pip install nexus-fs[slack]",
+          "kind": "python",
+          "name": "slack-sdk"
+        },
+        {
+          "extras": [],
+          "install_hint": null,
+          "kind": "service",
+          "name": "token_manager"
+        }
+      ],
+      "service_name": "slack",
+      "user_scoped": true
     }
   ],
   "schema_version": 1

--- a/tests/extensions/test_store.py
+++ b/tests/extensions/test_store.py
@@ -1318,34 +1318,35 @@ class TestConnectorPackageIsolationPilot:
         from nexus.extensions.store import get_store, reset_store
 
         reset_store()
-        store = get_store()
+        try:
+            store = get_store()
 
-        s3 = store.get("path_s3", kind="connector")
-        assert s3.metadata_complete is True
-        assert s3.service_name == "s3"
-        assert s3.module == "nexus.backends.storage.path_s3"
-        assert s3.factory == "PathS3Backend"
-        assert {d.name for d in s3.runtime_deps} == {"boto3"}
-        assert s3.import_probes == ("boto3",)
-        assert "bucket_name" in s3.connection_args
-        assert s3.connection_args["bucket_name"].config_key == "bucket"
-        assert "signed_url" in s3.capabilities
-        assert "multipart_upload" in s3.capabilities
+            s3 = store.get("path_s3", kind="connector")
+            assert s3.metadata_complete is True
+            assert s3.service_name == "s3"
+            assert s3.module == "nexus.backends.storage.path_s3"
+            assert s3.factory == "PathS3Backend"
+            assert {d.name for d in s3.runtime_deps} == {"boto3"}
+            assert s3.import_probes == ("boto3",)
+            assert "bucket_name" in s3.connection_args
+            assert s3.connection_args["bucket_name"].config_key == "bucket"
+            assert "signed_url" in s3.capabilities
+            assert "multipart_upload" in s3.capabilities
 
-        slack = store.get("slack_connector", kind="connector")
-        assert slack.metadata_complete is True
-        assert slack.service_name == "slack"
-        assert slack.module == "nexus.backends.connectors.slack.connector"
-        assert slack.factory == "PathSlackBackend"
-        assert {d.name for d in slack.runtime_deps} == {"slack-sdk", "token_manager"}
-        assert slack.import_probes == ("slack_sdk",)
-        assert slack.user_scoped is True
-        assert "token_manager_db" in slack.connection_args
-        assert slack.connection_args["provider"].default == "slack"
-        assert "oauth" in slack.capabilities
-        assert "readme_doc" in slack.capabilities
-
-        reset_store()
+            slack = store.get("slack_connector", kind="connector")
+            assert slack.metadata_complete is True
+            assert slack.service_name == "slack"
+            assert slack.module == "nexus.backends.connectors.slack.connector"
+            assert slack.factory == "PathSlackBackend"
+            assert {d.name for d in slack.runtime_deps} == {"slack-sdk", "token_manager"}
+            assert slack.import_probes == ("slack_sdk",)
+            assert slack.user_scoped is True
+            assert "token_manager_db" in slack.connection_args
+            assert slack.connection_args["provider"].default == "slack"
+            assert "oauth" in slack.capabilities
+            assert "readme_doc" in slack.capabilities
+        finally:
+            reset_store()
 
     def test_pilot_manifest_discovery_does_not_import_optional_sdks_or_impls(self):
         import sys
@@ -1360,18 +1361,25 @@ class TestConnectorPackageIsolationPilot:
             "nexus.backends.connectors.slack.connector",
             "nexus.backends.connectors.slack.transport",
         }
+        before = {name: sys.modules.get(name) for name in forbidden_modules}
         for module_name in forbidden_modules:
             sys.modules.pop(module_name, None)
 
         reset_store()
-        store = get_store()
-        assert store.get("path_s3", kind="connector").metadata_complete is True
-        assert store.get("slack_connector", kind="connector").metadata_complete is True
+        try:
+            store = get_store()
+            assert store.get("path_s3", kind="connector").metadata_complete is True
+            assert store.get("slack_connector", kind="connector").metadata_complete is True
 
-        imported = forbidden_modules.intersection(sys.modules)
-        assert imported == set()
-
-        reset_store()
+            imported = forbidden_modules.intersection(sys.modules)
+            assert imported == set()
+        finally:
+            reset_store()
+            for name, module in before.items():
+                if module is None:
+                    sys.modules.pop(name, None)
+                else:
+                    sys.modules[name] = module
 
 
 class TestMalformedManifestIsolation:

--- a/tests/extensions/test_store.py
+++ b/tests/extensions/test_store.py
@@ -1338,7 +1338,7 @@ class TestConnectorPackageIsolationPilot:
             assert slack.service_name == "slack"
             assert slack.module == "nexus.backends.connectors.slack.connector"
             assert slack.factory == "PathSlackBackend"
-            assert {d.name for d in slack.runtime_deps} == {"slack-sdk", "token_manager"}
+            assert {d.name for d in slack.runtime_deps} == {"slack-sdk"}
             assert slack.import_probes == ("slack_sdk",)
             assert slack.user_scoped is True
             assert "token_manager_db" in slack.connection_args

--- a/tests/extensions/test_store.py
+++ b/tests/extensions/test_store.py
@@ -1283,7 +1283,7 @@ class TestLegacyAdapterMetadataCompleteness:
         reset_store()
         store = get_store()
         # Pick a connector that's only in the legacy inventory (not migrated).
-        m = store.get("path_s3", kind="connector")
+        m = store.get("path_gcs", kind="connector")
         assert m.metadata_complete is False, "legacy adapter must flag records as partial"
         reset_store()
 

--- a/tests/extensions/test_store.py
+++ b/tests/extensions/test_store.py
@@ -1310,6 +1310,70 @@ class TestLegacyAdapterMetadataCompleteness:
         reset_store()
 
 
+class TestConnectorPackageIsolationPilot:
+    """Issue #3964 pilot: S3 and Slack expose metadata-complete manifests
+    without importing optional connector SDKs or implementation modules."""
+
+    def test_s3_and_slack_manifests_are_metadata_complete(self):
+        from nexus.extensions.store import get_store, reset_store
+
+        reset_store()
+        store = get_store()
+
+        s3 = store.get("path_s3", kind="connector")
+        assert s3.metadata_complete is True
+        assert s3.service_name == "s3"
+        assert s3.module == "nexus.backends.storage.path_s3"
+        assert s3.factory == "PathS3Backend"
+        assert {d.name for d in s3.runtime_deps} == {"boto3"}
+        assert s3.import_probes == ("boto3",)
+        assert "bucket_name" in s3.connection_args
+        assert s3.connection_args["bucket_name"].config_key == "bucket"
+        assert "signed_url" in s3.capabilities
+        assert "multipart_upload" in s3.capabilities
+
+        slack = store.get("slack_connector", kind="connector")
+        assert slack.metadata_complete is True
+        assert slack.service_name == "slack"
+        assert slack.module == "nexus.backends.connectors.slack.connector"
+        assert slack.factory == "PathSlackBackend"
+        assert {d.name for d in slack.runtime_deps} == {"slack-sdk", "token_manager"}
+        assert slack.import_probes == ("slack_sdk",)
+        assert slack.user_scoped is True
+        assert "token_manager_db" in slack.connection_args
+        assert slack.connection_args["provider"].default == "slack"
+        assert "oauth" in slack.capabilities
+        assert "readme_doc" in slack.capabilities
+
+        reset_store()
+
+    def test_pilot_manifest_discovery_does_not_import_optional_sdks_or_impls(self):
+        import sys
+
+        from nexus.extensions.store import get_store, reset_store
+
+        forbidden_modules = {
+            "boto3",
+            "slack_sdk",
+            "nexus.backends.storage.path_s3",
+            "nexus.backends.transports.s3_transport",
+            "nexus.backends.connectors.slack.connector",
+            "nexus.backends.connectors.slack.transport",
+        }
+        for module_name in forbidden_modules:
+            sys.modules.pop(module_name, None)
+
+        reset_store()
+        store = get_store()
+        assert store.get("path_s3", kind="connector").metadata_complete is True
+        assert store.get("slack_connector", kind="connector").metadata_complete is True
+
+        imported = forbidden_modules.intersection(sys.modules)
+        assert imported == set()
+
+        reset_store()
+
+
 class TestMalformedManifestIsolation:
     """Regression: a `_manifest.py` whose MANIFEST is the wrong type (dict,
     None, stale class) must not abort discovery for siblings."""

--- a/tests/integration/backends/test_factory_dep_check.py
+++ b/tests/integration/backends/test_factory_dep_check.py
@@ -155,9 +155,7 @@ class TestFactoryDepCheck:
         assert "boto3" in msg
         assert "pip install nexus-fs[s3]" in msg
 
-    def test_slack_missing_sdk_and_token_manager_are_enumerated(
-        self, monkeypatch: pytest.MonkeyPatch
-    ) -> None:
+    def test_slack_missing_sdk_uses_slack_extra_hint(self, monkeypatch: pytest.MonkeyPatch) -> None:
         import importlib.util
 
         real_find_spec = importlib.util.find_spec
@@ -172,11 +170,6 @@ class TestFactoryDepCheck:
             "nexus.backends.base.runtime_deps._nexus_fs_extras_available",
             lambda: True,
         )
-        monkeypatch.setattr(
-            "nexus.backends.base.runtime_deps._service_available",
-            lambda name: name != "token_manager",
-        )
-
         with pytest.raises(MissingDependencyError) as exc_info:
             BackendFactory.create("slack_connector", {"token_manager_db": "tokens.db"})
 
@@ -184,4 +177,4 @@ class TestFactoryDepCheck:
         assert "slack_connector" in msg
         assert "slack_sdk" in msg
         assert "pip install nexus-fs[slack]" in msg
-        assert "service 'token_manager'" in msg
+        assert "service 'token_manager'" not in msg

--- a/tests/integration/backends/test_factory_dep_check.py
+++ b/tests/integration/backends/test_factory_dep_check.py
@@ -39,11 +39,17 @@ class _StubBackend:
 
 @pytest.fixture(autouse=True)
 def _clean_registry() -> Any:
-    # Snapshot + restore so we don't affect other tests in the integration run.
-    names_before = set(ConnectorRegistry.list_available())
+    # Snapshot + restore so real connector registration does not leak across
+    # tests. BackendFactory.create("path_s3", config) triggers optional backend
+    # registration, so restore both the registry contents and the one-shot flag.
+    import nexus.backends as backends_mod
+
+    items_before = dict(ConnectorRegistry._base._items)
+    registered_before = backends_mod._optional_backends_registered
     yield
-    for nm in set(ConnectorRegistry.list_available()) - names_before:
-        ConnectorRegistry._base._items.pop(nm, None)
+    ConnectorRegistry._base._items.clear()
+    ConnectorRegistry._base._items.update(items_before)
+    backends_mod._optional_backends_registered = registered_before
 
 
 class TestFactoryDepCheck:
@@ -110,3 +116,60 @@ class TestFactoryDepCheck:
         msg = str(err)
         assert "definitely_not_a_real_module_xyz" in msg
         assert "definitely_not_a_real_binary_xyz" in msg
+
+    def test_path_s3_missing_boto3_uses_s3_extra_hint(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import importlib.util
+
+        real_find_spec = importlib.util.find_spec
+
+        def fake_find_spec(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "boto3":
+                return None
+            return real_find_spec(name, *args, **kwargs)
+
+        monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+        monkeypatch.setattr(
+            "nexus.backends.base.runtime_deps._nexus_fs_extras_available",
+            lambda: True,
+        )
+
+        with pytest.raises(MissingDependencyError) as exc_info:
+            BackendFactory.create("path_s3", {"bucket": "example"})
+
+        msg = str(exc_info.value)
+        assert "path_s3" in msg
+        assert "boto3" in msg
+        assert "pip install nexus-fs[s3]" in msg
+
+    def test_slack_missing_sdk_and_token_manager_are_enumerated(
+        self, monkeypatch: pytest.MonkeyPatch
+    ) -> None:
+        import importlib.util
+
+        real_find_spec = importlib.util.find_spec
+
+        def fake_find_spec(name: str, *args: Any, **kwargs: Any) -> Any:
+            if name == "slack_sdk":
+                return None
+            return real_find_spec(name, *args, **kwargs)
+
+        monkeypatch.setattr(importlib.util, "find_spec", fake_find_spec)
+        monkeypatch.setattr(
+            "nexus.backends.base.runtime_deps._nexus_fs_extras_available",
+            lambda: True,
+        )
+        monkeypatch.setattr(
+            "nexus.backends.base.runtime_deps._service_available",
+            lambda name: name != "token_manager",
+        )
+
+        with pytest.raises(MissingDependencyError) as exc_info:
+            BackendFactory.create("slack_connector", {"token_manager_db": "tokens.db"})
+
+        msg = str(exc_info.value)
+        assert "slack_connector" in msg
+        assert "slack_sdk" in msg
+        assert "pip install nexus-fs[slack]" in msg
+        assert "service 'token_manager'" in msg

--- a/tests/integration/backends/test_factory_dep_check.py
+++ b/tests/integration/backends/test_factory_dep_check.py
@@ -41,15 +41,27 @@ class _StubBackend:
 def _clean_registry() -> Any:
     # Snapshot + restore so real connector registration does not leak across
     # tests. BackendFactory.create("path_s3", config) triggers optional backend
-    # registration, so restore both the registry contents and the one-shot flag.
+    # registration, so restore the registry contents, one-shot flag, and module
+    # imports that control whether connector decorators rerun.
+    import sys
+
     import nexus.backends as backends_mod
+    from nexus.backends._manifest import CONNECTOR_MANIFEST
 
     items_before = dict(ConnectorRegistry._base._items)
     registered_before = backends_mod._optional_backends_registered
+    modules_before = {
+        entry.module_path: sys.modules.get(entry.module_path) for entry in CONNECTOR_MANIFEST
+    }
     yield
     ConnectorRegistry._base._items.clear()
     ConnectorRegistry._base._items.update(items_before)
     backends_mod._optional_backends_registered = registered_before
+    for module_path, module in modules_before.items():
+        if module is None:
+            sys.modules.pop(module_path, None)
+        else:
+            sys.modules[module_path] = module
 
 
 class TestFactoryDepCheck:

--- a/tests/integration/slim/test_slim_install_smoke.py
+++ b/tests/integration/slim/test_slim_install_smoke.py
@@ -175,6 +175,7 @@ def test_slim_base_connector_metadata_discovery_without_optional_deps(
     """Base slim install lists S3 and Slack metadata without connector extras."""
     script = """
 import sys
+from importlib.metadata import PackageNotFoundError, distribution
 
 for name in (
     "boto3",
@@ -185,6 +186,14 @@ for name in (
     "nexus.backends.connectors.slack.transport",
 ):
     sys.modules.pop(name, None)
+
+for package_name in ("boto3", "slack-sdk"):
+    try:
+        distribution(package_name)
+    except PackageNotFoundError:
+        pass
+    else:
+        sys.exit(f"{package_name} unexpectedly installed in slim base venv")
 
 import nexus
 import nexus.backends

--- a/tests/integration/slim/test_slim_install_smoke.py
+++ b/tests/integration/slim/test_slim_install_smoke.py
@@ -169,6 +169,59 @@ def test_slim_base_module_imports(slim_base_venv: Path, base_module: str) -> Non
     assert "OK" in result.stdout
 
 
+def test_slim_base_connector_metadata_discovery_without_optional_deps(
+    slim_base_venv: Path,
+) -> None:
+    """Base slim install lists S3 and Slack metadata without connector extras."""
+    script = """
+import sys
+
+for name in (
+    "boto3",
+    "slack_sdk",
+    "nexus.backends.storage.path_s3",
+    "nexus.backends.transports.s3_transport",
+    "nexus.backends.connectors.slack.connector",
+    "nexus.backends.connectors.slack.transport",
+):
+    sys.modules.pop(name, None)
+
+import nexus
+import nexus.backends
+from nexus.extensions.store import get_store, reset_store
+
+reset_store()
+store = get_store()
+s3 = store.get("path_s3", kind="connector")
+slack = store.get("slack_connector", kind="connector")
+
+assert s3.metadata_complete is True
+assert s3.service_name == "s3"
+assert "boto3" in {d.name for d in s3.runtime_deps}
+assert slack.metadata_complete is True
+assert slack.service_name == "slack"
+assert "slack-sdk" in {d.name for d in slack.runtime_deps}
+
+for name in (
+    "boto3",
+    "slack_sdk",
+    "nexus.backends.storage.path_s3",
+    "nexus.backends.transports.s3_transport",
+    "nexus.backends.connectors.slack.connector",
+    "nexus.backends.connectors.slack.transport",
+):
+    assert name not in sys.modules, name
+
+print("DISCOVERY OK")
+"""
+    result = run_in_slim_venv(slim_base_venv, script)
+    assert result.returncode == 0, (
+        "slim base connector metadata discovery failed:\n"
+        f"STDOUT:\n{result.stdout}\nSTDERR:\n{result.stderr}"
+    )
+    assert "DISCOVERY OK" in result.stdout
+
+
 @pytest.mark.parametrize(
     "connector_module",
     [


### PR DESCRIPTION
## Summary
- Add metadata-only S3 and Slack connector manifests so extension discovery can enumerate them without importing optional SDKs or implementation modules.
- Refresh the generated extension index and add store coverage for metadata completeness plus no-import discovery.
- Add mount-time dependency hint regressions and slim base-wheel coverage proving S3/Slack metadata is discoverable without connector extras or optional SDK distributions.

## Why
Issue #3964 tracks isolating optional connector dependencies behind installable connector packages. This PR implements the S3 + Slack pilot while leaving the existing runtime registry and mount-time dependency checker unchanged.

## Test Plan
- `.venv/bin/pytest tests/extensions/test_store.py::TestConnectorPackageIsolationPilot tests/extensions/test_index.py -q` -> 10 passed
- `.venv/bin/pytest tests/integration/backends/test_factory_dep_check.py -q` -> 6 passed
- `.venv/bin/python -m nexus.extensions.index verify` -> OK
- `NEXUS_RUNTIME_WHEEL_DIR=/tmp/nexus-runtime-dist .venv/bin/pytest tests/integration/slim/test_slim_install_smoke.py::test_slim_base_connector_metadata_discovery_without_optional_deps -v --override-ini="addopts="` -> 1 passed
- `git diff --check` -> clean

Closes #3964