### PR TITLE
Fix Docker Publish startup health gate

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -223,13 +223,13 @@ jobs:
               docker logs nexus-e2e 2>&1 | tail -200 || true
               exit 1
             fi
-            if curl --max-time 5 -sf http://127.0.0.1:2026/healthz/ready > /dev/null 2>&1; then
+            if curl --max-time 5 -sf http://127.0.0.1:2026/health > /dev/null 2>&1; then
               echo "Nexus is ready (${i}s)"
               break
             fi
             sleep 1
           done
-          if ! curl --max-time 5 -sf http://127.0.0.1:2026/healthz/ready > /dev/null 2>&1; then
+          if ! curl --max-time 5 -sf http://127.0.0.1:2026/health > /dev/null 2>&1; then
             echo "::error::nexus-e2e never became healthy within 180 seconds"
             docker inspect nexus-e2e --format 'exit_code={{.State.ExitCode}} status={{.State.Status}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}} started_at={{.State.StartedAt}} finished_at={{.State.FinishedAt}} error={{json .State.Error}}' || true
             echo "Crash signatures from container logs:"

--- a/Dockerfile
+++ b/Dockerfile
@@ -358,6 +358,6 @@ EXPOSE 2026 2126
 
 # Healthcheck
 HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
-    CMD curl -f http://localhost:${NEXUS_PORT}/healthz/ready || exit 1
+    CMD curl --max-time 5 -f http://localhost:${NEXUS_PORT}/health || exit 1
 
 ENTRYPOINT ["/usr/local/bin/docker-entrypoint.sh"]

--- a/scripts/test_build_perf_e2e.py
+++ b/scripts/test_build_perf_e2e.py
@@ -170,12 +170,12 @@ def main() -> None:
     section("1. INFRA & STATUS")
     # =========================================================================
 
-    step("health endpoint GET /healthz/ready")
+    step("health endpoint GET /health")
     try:
-        resp = urllib.request.urlopen(f"{NEXUS_URL}/healthz/ready", timeout=5)
+        resp = urllib.request.urlopen(f"{NEXUS_URL}/health", timeout=5)
         health = resp.read().decode()
         print(f"    response: {health[:120]!r}", file=sys.stderr, flush=True)
-        check("Health endpoint", "ready" in health)
+        check("Health endpoint", "healthy" in health)
     except Exception as e:
         print(f"    error: {e}", file=sys.stderr, flush=True)
         check("Health endpoint", False, str(e))

--- a/src/nexus/cli/commands/demo.py
+++ b/src/nexus/cli/commands/demo.py
@@ -348,7 +348,7 @@ def _get_nexus_client(config: dict[str, Any]) -> Any:
             from nexus.cli.api_client import NexusApiClient
 
             test_client = NexusApiClient(url=url, api_key=api_key)
-            test_client.get("/healthz/ready")
+            test_client.get("/health")
             logger.info("demo preset: server reachable at %s — using REST API for seeding", url)
             return _RestApiNexusClient(url, api_key)
         except _httpx.HTTPStatusError:
@@ -382,7 +382,7 @@ def _get_nexus_client(config: dict[str, Any]) -> Any:
         from nexus.cli.api_client import NexusApiClient
 
         test_client = NexusApiClient(url=base_url, api_key=api_key)
-        test_client.get("/healthz/ready")
+        test_client.get("/health")
         logger.info("Local server detected at %s — using REST API for demo seeding", base_url)
         return _RestApiNexusClient(base_url, api_key)
     except Exception:

--- a/tests/unit/cli/test_demo_preflight.py
+++ b/tests/unit/cli/test_demo_preflight.py
@@ -13,7 +13,8 @@ def test_remote_demo_preflight_avoids_root_metadata_probe() -> None:
         text.index('if preset in ("shared", "demo"):') : text.index("# Local preset")
     ]
 
-    assert 'test_client.get("/healthz/ready")' in remote_block
+    assert 'test_client.get("/health")' in remote_block
+    assert 'test_client.get("/healthz/ready")' not in remote_block
     assert 'test_client.get("/api/v2/connectors")' not in remote_block
     assert 'test_client.get("/api/v2/files/metadata", params={"path": "/"})' not in remote_block
 

--- a/tests/unit/test_docker_publish_smoke_config.py
+++ b/tests/unit/test_docker_publish_smoke_config.py
@@ -1,0 +1,39 @@
+"""Static guards for Docker Publish smoke-test startup probes."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[2]
+DOCKER_PUBLISH = ROOT / ".github/workflows/docker-publish.yml"
+DOCKERFILE = ROOT / "Dockerfile"
+BUILD_PERF = ROOT / "scripts/test_build_perf_e2e.py"
+
+
+def test_docker_publish_startup_gate_uses_basic_health_probe() -> None:
+    text = DOCKER_PUBLISH.read_text()
+    start_step = text[
+        text.index("- name: Start Nexus edge container") : text.index(
+            "- name: Initialize and extract credentials"
+        )
+    ]
+
+    assert "http://127.0.0.1:2026/health" in start_step
+    assert "/healthz/ready" not in start_step
+
+
+def test_image_healthcheck_uses_bounded_basic_health_probe() -> None:
+    text = DOCKERFILE.read_text()
+    healthcheck = text[text.index("# Healthcheck") : text.index("ENTRYPOINT")]
+
+    assert "curl --max-time 5 -f" in healthcheck
+    assert "/health" in healthcheck
+    assert "/healthz/ready" not in healthcheck
+
+
+def test_build_perf_smoke_uses_basic_health_probe() -> None:
+    text = BUILD_PERF.read_text()
+
+    assert 'step("health endpoint GET /health")' in text
+    assert 'urlopen(f"{NEXUS_URL}/health", timeout=5)' in text
+    assert "/healthz/ready" not in text


### PR DESCRIPTION
## Summary
- Use the basic `/health` endpoint for Docker Publish startup gating instead of the slow `/healthz/ready` probe
- Switch the image HEALTHCHECK and Docker smoke build-perf health probe to `/health`
- Keep demo REST seeding preflight on the same basic health endpoint
- Add static regression tests for the Docker Publish smoke probe configuration

## Tests
- `uv run --frozen python -m pytest tests/unit/cli/test_demo_preflight.py tests/unit/test_docker_publish_smoke_config.py tests/unit/cli/test_demo_seeds.py tests/unit/cli/test_api_client.py tests/unit/cli/test_state.py -q -o addopts=`
- `uvx ruff check src/nexus/cli/commands/demo.py tests/unit/cli/test_demo_preflight.py tests/unit/test_docker_publish_smoke_config.py scripts/test_build_perf_e2e.py`
- `uvx ruff format --check src/nexus/cli/commands/demo.py tests/unit/cli/test_demo_preflight.py tests/unit/test_docker_publish_smoke_config.py scripts/test_build_perf_e2e.py`
- `actionlint .github/workflows/docker-publish.yml`
- `git diff --check`
- YAML parse for `.github/workflows/docker-publish.yml`
