### PR TITLE
Fix Docker Publish container health gate

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -223,15 +223,21 @@ jobs:
               docker logs nexus-e2e 2>&1 | tail -200 || true
               exit 1
             fi
-            if curl --max-time 5 -sf http://127.0.0.1:2026/health > /dev/null 2>&1; then
-              echo "Nexus is ready (${i}s)"
+            if docker exec nexus-e2e curl --max-time 5 -sf http://127.0.0.1:2026/health > /dev/null 2>&1; then
+              echo "Nexus is ready (attempt ${i}/180)"
               break
             fi
             sleep 1
           done
-          if ! curl --max-time 5 -sf http://127.0.0.1:2026/health > /dev/null 2>&1; then
-            echo "::error::nexus-e2e never became healthy within 180 seconds"
+          if ! docker exec nexus-e2e curl --max-time 5 -sf http://127.0.0.1:2026/health > /dev/null 2>&1; then
+            echo "::error::nexus-e2e never became healthy from inside the container"
             docker inspect nexus-e2e --format 'exit_code={{.State.ExitCode}} status={{.State.Status}} health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}} started_at={{.State.StartedAt}} finished_at={{.State.FinishedAt}} error={{json .State.Error}}' || true
+            echo "Container-internal health probe:"
+            docker exec nexus-e2e curl -v --max-time 5 http://127.0.0.1:2026/health || true
+            echo "Host-side health probe:"
+            curl -v --max-time 5 http://127.0.0.1:2026/health || true
+            echo "Container listen sockets:"
+            docker exec nexus-e2e sh -c 'ss -ltnp 2>/dev/null || netstat -ltnp 2>/dev/null || true' || true
             echo "Crash signatures from container logs:"
             docker logs nexus-e2e 2>&1 | grep -E -m 20 'Illegal instruction|Traceback|ERROR:|FATAL:|panic|segmentation fault|core dumped' || true
             echo "Last 200 container log lines:"

--- a/tests/unit/test_docker_publish_smoke_config.py
+++ b/tests/unit/test_docker_publish_smoke_config.py
@@ -18,7 +18,10 @@ def test_docker_publish_startup_gate_uses_basic_health_probe() -> None:
         )
     ]
 
-    assert "http://127.0.0.1:2026/health" in start_step
+    assert (
+        "docker exec nexus-e2e curl --max-time 5 -sf http://127.0.0.1:2026/health"
+    ) in start_step
+    assert "if curl --max-time 5 -sf http://127.0.0.1:2026/health" not in start_step
     assert "/healthz/ready" not in start_step
 
 


### PR DESCRIPTION
## Summary
- Probe Docker Publish startup health from inside `nexus-e2e` with `docker exec` instead of relying on host-side `127.0.0.1`
- Keep host-side curl only as failure diagnostics, alongside container health and listen-socket output
- Add a static regression guard so the startup gate stays container-internal

## Why
The failed post-merge Docker Publish job showed `/health` returning 200 in the container logs, but the host-side wait loop never observed readiness and timed out before credentials, demo seeding, or HERB ran. All downstream smoke commands execute inside `nexus-e2e`, so the readiness gate should verify the same container-internal path.

## Tests
- `uv run --frozen python -m pytest tests/unit/test_docker_publish_smoke_config.py tests/unit/cli/test_demo_preflight.py -q -o addopts=`
- `uvx ruff check tests/unit/test_docker_publish_smoke_config.py`
- `uvx ruff format --check tests/unit/test_docker_publish_smoke_config.py`
- `actionlint .github/workflows/docker-publish.yml`
- `git diff --check`
- YAML parse for `.github/workflows/docker-publish.yml`
