### PR TITLE
chore(cdylib): bump sudocode rev to PR#100, adapt spawn_task_echo

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2111,10 +2111,11 @@ dependencies = [
 [[package]]
 name = "nexus-vfs-client"
 version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=2b67d5b452ea69b8ea4aba1fca3fa73588df60da#2b67d5b452ea69b8ea4aba1fca3fa73588df60da"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=140e5ac#140e5ac309e9bde7d8bd10b3653b75007cebfb47"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
+ "serde_json",
  "tokio",
  "tonic",
  "tonic-build",
@@ -2318,7 +2319,7 @@ dependencies = [
 [[package]]
 name = "plugins"
 version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=2b67d5b452ea69b8ea4aba1fca3fa73588df60da#2b67d5b452ea69b8ea4aba1fca3fa73588df60da"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=140e5ac#140e5ac309e9bde7d8bd10b3653b75007cebfb47"
 dependencies = [
  "serde",
  "serde_json",
@@ -3070,7 +3071,7 @@ dependencies = [
 [[package]]
 name = "runtime"
 version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=2b67d5b452ea69b8ea4aba1fca3fa73588df60da#2b67d5b452ea69b8ea4aba1fca3fa73588df60da"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=140e5ac#140e5ac309e9bde7d8bd10b3653b75007cebfb47"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -3640,7 +3641,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 [[package]]
 name = "telemetry"
 version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=2b67d5b452ea69b8ea4aba1fca3fa73588df60da#2b67d5b452ea69b8ea4aba1fca3fa73588df60da"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=140e5ac#140e5ac309e9bde7d8bd10b3653b75007cebfb47"
 dependencies = [
  "serde",
  "serde_json",

--- a/rust/nexus-cdylib/Cargo.toml
+++ b/rust/nexus-cdylib/Cargo.toml
@@ -63,4 +63,9 @@ pyo3 = { version = "0.27.2", features = ["extension-module"] }
 # (sudocode branch HEAD `2b67d5b`) stays reachable in git history
 # even after sudocode merges, so re-pinning is optional for
 # correctness — only matters for reproducibility audit.
-sudocode-runtime = { package = "runtime", git = "https://github.com/sudoprivacy/sudocode", rev = "2b67d5b452ea69b8ea4aba1fca3fa73588df60da" }
+# Pin to sudocode PR#100 merge — introduces FsBackend trait, spawn_task v2
+# (ConversationRuntime integration), and renames the v1 echo scaffolding
+# to `spawn_task_echo`. Adapter below uses `spawn_task_echo` as the
+# interim body until ApiClient/ToolExecutor factories are wired
+# (tracked as spawn_task v2 full integration).
+sudocode-runtime = { package = "runtime", git = "https://github.com/sudoprivacy/sudocode", rev = "140e5ac" }

--- a/rust/nexus-cdylib/src/lib.rs
+++ b/rust/nexus-cdylib/src/lib.rs
@@ -36,22 +36,33 @@ use services::managed_agent::{
 // ── Sudo-code adapter ──────────────────────────────────────────────────
 //
 // Concrete `SpawnTask<Kernel>` impl that wraps
-// `sudocode_runtime::spawn_task::spawn_task::<K>(...)`. Lives in the
-// cdylib (not services rlib, not in a dedicated adapter crate)
-// because the binary-edge cdylib is the allowed seam for cross-repo
-// runtime deps — services rlib stays runtime-agnostic so the cluster
-// slim binary can ship without sudocode. ManagedAgentService remains
-// the single integration point: this adapter just wires the concrete
-// `SpawnTask<Kernel>` provider on the cdylib (Python wheel) path.
+// `sudocode_runtime::spawn_task::spawn_task_echo::<K>(...)`.
 //
-// Generic-K monomorphisation: `sudocode_runtime::spawn_task::spawn_task`
-// is `pub fn spawn_task<K: KernelAbi + Send + Sync + 'static>(...)`,
-// and `SudoCodeSpawnAdapter` impls `SpawnTask<Kernel>` (concrete
-// kernel, the only K the cdylib path needs). Inside the adapter we
-// call `spawn_task::<Kernel>` so the sudocode side compiles
-// concretely against the same kernel handle the service holds — no
-// per-`sys_read` vtable cost, identical perf to a direct inherent
-// call.
+// Lives in the cdylib (not services rlib, not in a dedicated adapter
+// crate) because the binary-edge cdylib is the allowed seam for
+// cross-repo runtime deps — services rlib stays runtime-agnostic so
+// the cluster slim binary can ship without sudocode.
+//
+// ## v1 echo → v2 ConversationRuntime upgrade path
+//
+// sudocode PR#100 introduced `spawn_task` v2 which drives a full
+// `ConversationRuntime` per-pid. The v2 signature requires
+// `ApiClient + ToolExecutor + SystemPrompt + PermissionPolicy +
+// state_callback` — providers that the cdylib adapter must construct.
+// Until those factories land (tracked as `spawn_task v2 full
+// integration`), the adapter calls `spawn_task_echo` which retains
+// the v1 echo round-trip body. The v2 upgrade is:
+//
+//   1. Add `sudocode_runtime::spawn_task::spawn_task` (7-param) call
+//   2. Construct ApiClient from StartSessionRequest.model label
+//   3. Construct ToolExecutor using KernelFsBackend
+//   4. Build SystemPrompt from VFS `/agents/{name}/config/`
+//   5. Wire state_callback → AgentRegistry::update_state
+//
+// Generic-K monomorphisation: `spawn_task_echo` is generic over
+// `K: KernelAbi + Send + Sync + 'static` and `SudoCodeSpawnAdapter`
+// impls `SpawnTask<Kernel>` — the compiler monomorphises against
+// the concrete kernel type (no per-`sys_read` vtable cost).
 
 struct SudoCodeSpawnHandle(sudocode_runtime::spawn_task::SpawnHandle);
 
@@ -73,7 +84,10 @@ impl SpawnTask<Kernel> for SudoCodeSpawnAdapter {
         kernel: Arc<Kernel>,
         desc: AgentDescriptor,
     ) -> Box<dyn ServiceSpawnHandle> {
-        let handle = sudocode_runtime::spawn_task::spawn_task::<Kernel>(kernel, desc);
+        // v1 echo body — polls /proc/{pid}/chat-with-me and echoes
+        // inbound prompts back. Swapped for the full ConversationRuntime
+        // body once the ApiClient/ToolExecutor factory wiring lands.
+        let handle = sudocode_runtime::spawn_task::spawn_task_echo::<Kernel>(kernel, desc);
         Box::new(SudoCodeSpawnHandle(handle))
     }
 }


### PR DESCRIPTION
## Summary

- Bump `sudocode-runtime` rev pin from `2b67d5b` → `140e5ac` (sudoprivacy/sudocode#100 merge commit)
- Update `SudoCodeSpawnAdapter::spawn` to call `spawn_task_echo` (the v1 echo body renamed in PR#100)
- Document the v2 upgrade path: full `ConversationRuntime` integration requires `ApiClient + ToolExecutor + SystemPrompt + PermissionPolicy` factory wiring at the cdylib adapter level

## Context

sudocode PR#100 introduced:
- `FsBackend` trait + `StdFsBackend` / `KernelFsBackend` / `NexusVfsFsBackend`
- `spawn_task` v2 (7-param, with ConversationRuntime turn-driver loop)
- Renamed old 2-param `spawn_task` → `spawn_task_echo`

This broke the cdylib adapter since it called the old 2-param signature. The fix is minimal: call `spawn_task_echo` which is functionally identical to the previous v1 body.

## Test plan

- [x] `cargo check -p nexus-cdylib` — compiles against new sudocode rev
- [ ] Existing managed-agent e2e tests (echo round-trip unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)