### PR TITLE
Fix Docker health probe readiness hang

### DIFF
--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -571,13 +571,13 @@ wait_for_health() {
     local max="${2:-30}"
     local i
     for i in $(seq 1 "$max"); do
-        if curl -sf "http://localhost:${port}/health" > /dev/null 2>&1; then
+        if curl --max-time 5 -sf "http://localhost:${port}/health" > /dev/null 2>&1; then
             echo -e "${GREEN}✓ Server is ready${NC}"
             return 0
         fi
         sleep 5
     done
-    echo -e "${YELLOW}⚠ Server health check timeout after ${max}s (continuing anyway)${NC}"
+    echo -e "${YELLOW}⚠ Server health check timeout after ${max} attempts (continuing anyway)${NC}"
     return 1
 }
 

--- a/src/nexus/server/api/core/health.py
+++ b/src/nexus/server/api/core/health.py
@@ -4,6 +4,7 @@ Extracted from fastapi_server.py (#1602).
 """
 
 import logging
+import os
 from typing import Any
 
 from fastapi import APIRouter, Depends, Request
@@ -43,17 +44,16 @@ async def health_check(request: Request) -> HealthResponse | Any:
         # Phase H: federation readiness is observed through the
         # DistributedCoordinator HAL trait via the
         # ``nexus_runtime.federation_is_initialized`` module helper.
-        # Treats federation-disabled (no env vars) as ready so the
-        # slim / tests path sails through unchanged.
+        # Treat federation-disabled (no env vars) as ready without
+        # entering the native readiness helper; /health must stay cheap
+        # and non-blocking for Docker health checks.
         _kernel = getattr(nx_fs, "_kernel", None)
         _ready = True
-        if _kernel is not None:
+        if _kernel is not None and os.environ.get("NEXUS_PEERS"):
             try:
                 import nexus_runtime as _nr
 
-                _ready = bool(_nr.federation_is_initialized(_kernel)) or (
-                    not __import__("os").environ.get("NEXUS_PEERS")
-                )
+                _ready = bool(_nr.federation_is_initialized(_kernel))
             except Exception:
                 _ready = True
         if not _ready:

--- a/tests/unit/server/health/test_basic_health.py
+++ b/tests/unit/server/health/test_basic_health.py
@@ -1,0 +1,60 @@
+"""Tests for the public /health endpoint."""
+
+import sys
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nexus.server.api.core.health import router
+
+
+def _make_client(nexus_fs: object | None = None) -> TestClient:
+    app = FastAPI()
+    app.include_router(router)
+    app.state.nexus_fs = nexus_fs
+    app.state.api_key = None
+    app.state.auth_provider = None
+    return TestClient(app)
+
+
+def test_health_skips_federation_probe_when_peers_unset(monkeypatch) -> None:
+    calls = []
+
+    def federation_is_initialized(kernel: object) -> bool:
+        calls.append(kernel)
+        return False
+
+    monkeypatch.delenv("NEXUS_PEERS", raising=False)
+    monkeypatch.setitem(
+        sys.modules,
+        "nexus_runtime",
+        SimpleNamespace(federation_is_initialized=federation_is_initialized),
+    )
+
+    mock_fs = MagicMock()
+    mock_fs._kernel = object()
+
+    resp = _make_client(mock_fs).get("/health")
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "healthy"
+    assert calls == []
+
+
+def test_health_waits_for_federation_when_peers_set(monkeypatch) -> None:
+    monkeypatch.setenv("NEXUS_PEERS", "node-a,node-b")
+    monkeypatch.setitem(
+        sys.modules,
+        "nexus_runtime",
+        SimpleNamespace(federation_is_initialized=lambda _kernel: False),
+    )
+
+    mock_fs = MagicMock()
+    mock_fs._kernel = object()
+
+    resp = _make_client(mock_fs).get("/health")
+
+    assert resp.status_code == 503
+    assert resp.json()["status"] == "starting"

--- a/tests/unit/test_docker_publish_smoke_config.py
+++ b/tests/unit/test_docker_publish_smoke_config.py
@@ -7,6 +7,7 @@ from pathlib import Path
 ROOT = Path(__file__).resolve().parents[2]
 DOCKER_PUBLISH = ROOT / ".github/workflows/docker-publish.yml"
 DOCKERFILE = ROOT / "Dockerfile"
+DOCKER_ENTRYPOINT = ROOT / "dockerfiles/docker-entrypoint.sh"
 BUILD_PERF = ROOT / "scripts/test_build_perf_e2e.py"
 
 
@@ -32,6 +33,17 @@ def test_image_healthcheck_uses_bounded_basic_health_probe() -> None:
     assert "curl --max-time 5 -f" in healthcheck
     assert "/health" in healthcheck
     assert "/healthz/ready" not in healthcheck
+
+
+def test_entrypoint_startup_wait_uses_bounded_basic_health_probe() -> None:
+    text = DOCKER_ENTRYPOINT.read_text()
+    wait_for_health = text[
+        text.index("wait_for_health()") : text.index("load_saved_mounts_if_needed()")
+    ]
+
+    assert 'curl --max-time 5 -sf "http://localhost:${port}/health"' in wait_for_health
+    assert 'curl -sf "http://localhost:${port}/health"' not in wait_for_health
+    assert "/healthz/ready" not in wait_for_health
 
 
 def test_build_perf_smoke_uses_basic_health_probe() -> None:


### PR DESCRIPTION
## Summary
- Skip the native federation readiness helper in `/health` unless `NEXUS_PEERS` is configured.
- Add a timeout to the Docker entrypoint startup health curl so one stuck probe cannot block startup indefinitely.
- Add regression/static tests for the Docker Publish health path.

## Why
The failing Docker Publish log shows curl connecting to `/health` from both inside and outside the container, then timing out with no response. `/health` was still entering `nexus_runtime.federation_is_initialized()` before checking whether federation was disabled, so a synchronous native readiness call could block the event loop in non-federated Docker Publish runs.

## Verification
- `uv run pytest tests/unit/server/health/test_probes.py tests/unit/server/health/test_basic_health.py tests/unit/test_docker_publish_smoke_config.py`
- `uvx ruff check src/nexus/server/api/core/health.py tests/unit/server/health/test_basic_health.py tests/unit/test_docker_publish_smoke_config.py`
- `uvx ruff format --check src/nexus/server/api/core/health.py tests/unit/server/health/test_basic_health.py tests/unit/test_docker_publish_smoke_config.py`
- `bash -n dockerfiles/docker-entrypoint.sh && git diff --check`
