### PR TITLE
fix(server): wrap blocking sys_read calls in asyncio.to_thread

### DIFF
--- a/.pre-commit-hooks/check_file_size.py
+++ b/.pre-commit-hooks/check_file_size.py
@@ -38,6 +38,7 @@ EXCEPTIONS = [
     "src/nexus/bricks/search/daemon.py",  # ~2,300 lines - Issue #3698 additions; split tracked as follow-up
     "src/nexus/bricks/mcp/server.py",  # 2,157 lines - was 2,136 pre-#3731; auth helpers extracted to auth_bridge.py
     "src/nexus/bricks/auth/postgres_profile_store.py",  # 2,009 lines - #3818 read-path additions; split tracked as follow-up
+    "src/nexus/server/api/v2/routers/async_files.py",  # 2,006 lines - asyncio.to_thread wrappers for #4069; split tracked as follow-up
 ]
 
 

--- a/src/nexus/bricks/mcp/connection_manager.py
+++ b/src/nexus/bricks/mcp/connection_manager.py
@@ -17,6 +17,7 @@ Example:
     >>> connections = await manager.list_connections()
 """
 
+import asyncio
 import json
 import logging
 import os
@@ -200,7 +201,7 @@ class MCPConnectionManager:
         """Load existing connections from storage."""
         try:
             if self.filesystem and self.filesystem.access(self.CONNECTIONS_PATH):
-                items = self.filesystem.sys_readdir(self.CONNECTIONS_PATH)
+                items = await asyncio.to_thread(self.filesystem.sys_readdir, self.CONNECTIONS_PATH)
                 for item in items:
                     # Item might be full path, just filename, or dict
                     if isinstance(item, dict):
@@ -211,7 +212,7 @@ class MCPConnectionManager:
                     if item_name.endswith(".json"):
                         path = f"{self.CONNECTIONS_PATH}{item_name}"
                         try:
-                            raw = self.filesystem.sys_read(path)
+                            raw = await asyncio.to_thread(self.filesystem.sys_read, path)
                             data = json.loads(
                                 raw.decode("utf-8") if isinstance(raw, bytes) else str(raw)
                             )
@@ -251,7 +252,7 @@ class MCPConnectionManager:
                 filename = f"{provider}_{user_id.replace('@', '_at_')}.json"
                 path = f"{self.CONNECTIONS_PATH}{filename}"
                 if self.filesystem.access(path):
-                    self.filesystem.sys_unlink(path)
+                    await asyncio.to_thread(self.filesystem.sys_unlink, path)
         except Exception as e:
             logger.warning(f"Failed to delete connection file: {e}")
 

--- a/src/nexus/bricks/mcp/mount.py
+++ b/src/nexus/bricks/mcp/mount.py
@@ -6,6 +6,7 @@ This module provides functionality for mounting external MCP servers
 Based on: https://www.anthropic.com/engineering/code-execution-with-mcp
 """
 
+import asyncio
 import json
 import logging
 from datetime import UTC, datetime
@@ -239,7 +240,7 @@ class MCPMountManager:
                     return False
 
                 # List directories in MCP_TOOLS_PATH
-                items = self._filesystem.sys_readdir(self.MCP_TOOLS_PATH)
+                items = await asyncio.to_thread(self._filesystem.sys_readdir, self.MCP_TOOLS_PATH)
                 for item in items:
                     # Skip files at root level
                     item_path = f"{self.MCP_TOOLS_PATH}{item}"
@@ -247,7 +248,9 @@ class MCPMountManager:
 
                     try:
                         if self._filesystem.access(mount_json_path):
-                            raw_content = self._filesystem.sys_read(mount_json_path)
+                            raw_content = await asyncio.to_thread(
+                                self._filesystem.sys_read, mount_json_path
+                            )
                             content_str = (
                                 raw_content.decode("utf-8")
                                 if isinstance(raw_content, bytes)
@@ -1301,14 +1304,16 @@ class MCPMountManager:
                     return 0
 
                 # List directories in tier_path
-                items = self._filesystem.sys_readdir(tier_path)
+                items = await asyncio.to_thread(self._filesystem.sys_readdir, tier_path)
                 for item in items:
                     item_path = f"{tier_path}{item}"
                     mount_json_path = f"{item_path}/mount.json"
 
                     try:
                         if self._filesystem.access(mount_json_path):
-                            raw_content = self._filesystem.sys_read(mount_json_path)
+                            raw_content = await asyncio.to_thread(
+                                self._filesystem.sys_read, mount_json_path
+                            )
                             content_str = (
                                 raw_content.decode("utf-8")
                                 if isinstance(raw_content, bytes)

--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -6,6 +6,7 @@ Nexus functionality to AI agents and tools using the fastmcp framework.
 
 from __future__ import annotations
 
+import asyncio
 import contextlib
 import contextvars
 import inspect
@@ -449,7 +450,7 @@ async def create_mcp_server(
             File content as string (full file, or section/block subset for markdown)
         """
         nx_instance = _get_nexus_instance(ctx)
-        content = nx_instance.sys_read(path)
+        content = await asyncio.to_thread(nx_instance.sys_read, path)
         content_bytes = content if isinstance(content, bytes) else str(content).encode("utf-8")
 
         # Partial read for markdown files when section is requested.
@@ -497,7 +498,7 @@ async def create_mcp_server(
         nx_instance = _get_nexus_instance(ctx)
         # Permission gate + content fetch for lazy index rebuild.
         try:
-            raw = nx_instance.sys_read(path)
+            raw = await asyncio.to_thread(nx_instance.sys_read, path)
         except Exception as e:
             return tool_error("access_denied", f"Cannot access {path}: {e}")
         content = raw if isinstance(raw, bytes) else str(raw).encode("utf-8")
@@ -604,7 +605,7 @@ async def create_mcp_server(
             Success message or error
         """
         nx_instance = _get_nexus_instance(ctx)
-        nx_instance.sys_unlink(path)
+        await asyncio.to_thread(nx_instance.sys_unlink, path)
         return f"Successfully deleted {path}"
 
     @mcp.tool(
@@ -663,7 +664,9 @@ async def create_mcp_server(
         """
         nx_instance = _get_nexus_instance(ctx)
         try:
-            all_files = nx_instance.sys_readdir(path, recursive=recursive, details=details)
+            all_files = await asyncio.to_thread(
+                nx_instance.sys_readdir, path, recursive=recursive, details=details
+            )
         except FileNotFoundError:
             return tool_error(
                 "not_found",
@@ -722,7 +725,7 @@ async def create_mcp_server(
         # Try to get size if it's a file
         if not is_dir:
             try:
-                content = nx_instance.sys_read(path)
+                content = await asyncio.to_thread(nx_instance.sys_read, path)
                 if isinstance(content, bytes):
                     info_dict["size"] = len(content)
             except Exception as e:
@@ -813,7 +816,7 @@ async def create_mcp_server(
         """
         nx_instance = _get_nexus_instance(ctx)
         try:
-            nx_instance.sys_rename(old_path, new_path)
+            await asyncio.to_thread(nx_instance.sys_rename, old_path, new_path)
         except FileExistsError:
             return tool_error(
                 "invalid_input",
@@ -1539,7 +1542,7 @@ async def create_mcp_server(
         """
         try:
             nx_instance = _get_nexus_instance(ctx)
-            content = nx_instance.sys_read(path)
+            content = await asyncio.to_thread(nx_instance.sys_read, path)
             if isinstance(content, bytes):
                 return content.decode("utf-8", errors="replace")
             return str(content)

--- a/src/nexus/bricks/task_manager/dispatch_consumer.py
+++ b/src/nexus/bricks/task_manager/dispatch_consumer.py
@@ -181,9 +181,12 @@ class TaskDispatchPipeConsumer:
         assert self._nx is not None
         nx = self._nx
 
+        # nx.sys_read() is a synchronous Rust kernel call that blocks for up
+        # to 5s waiting for DT_PIPE data. Run in a worker thread so the
+        # event loop isn't wedged by empty-pipe polls.
         while True:
             try:
-                data = nx.sys_read(_TASK_DISPATCH_PIPE_PATH)
+                data = await asyncio.to_thread(nx.sys_read, _TASK_DISPATCH_PIPE_PATH)
             except NexusFileNotFoundError:
                 logger.debug("[TASK-DISPATCH] pipe closed, consumer exiting")
                 break

--- a/src/nexus/fs/_doctor.py
+++ b/src/nexus/fs/_doctor.py
@@ -254,7 +254,15 @@ async def check_mount_connectivity(mount_point: str, kernel: Any) -> DoctorCheck
 
     start = time.perf_counter()
     try:
-        list(kernel.sys_readdir(mount_point, recursive=False, details=False, context=LOCAL_CONTEXT))
+        list(
+            await asyncio.to_thread(
+                kernel.sys_readdir,
+                mount_point,
+                recursive=False,
+                details=False,
+                context=LOCAL_CONTEXT,
+            )
+        )
         latency_ms = (time.perf_counter() - start) * 1000
         return DoctorCheckResult(
             name=mount_point,

--- a/src/nexus/fs/_tui/__init__.py
+++ b/src/nexus/fs/_tui/__init__.py
@@ -46,7 +46,7 @@ class ContextualNexusFS:
         )
 
     async def read(self, path: str) -> bytes:
-        return cast(bytes, self._kernel.sys_read(path, context=self._ctx))
+        return cast(bytes, await asyncio.to_thread(self._kernel.sys_read, path, context=self._ctx))
 
     def read_range(self, path: str, start: int, end: int) -> bytes:
         return cast(bytes, self._kernel.read_range(path, start, end, context=self._ctx))
@@ -67,7 +67,8 @@ class ContextualNexusFS:
 
         result = cast(
             list[str] | list[dict[str, Any]],
-            self._kernel.sys_readdir(
+            await asyncio.to_thread(
+                self._kernel.sys_readdir,
                 path,
                 recursive=recursive,
                 details=detail,
@@ -86,7 +87,7 @@ class ContextualNexusFS:
         try:
             result = cast(
                 "dict[str, Any] | None",
-                self._kernel.sys_stat(path, context=self._ctx),
+                await asyncio.to_thread(self._kernel.sys_stat, path, context=self._ctx),
             )
             if result is not None:
                 return result
@@ -101,10 +102,10 @@ class ContextualNexusFS:
         self._kernel.rmdir(path, recursive=recursive, context=self._ctx)
 
     async def delete(self, path: str) -> None:
-        self._kernel.sys_unlink(path, context=self._ctx)
+        await asyncio.to_thread(self._kernel.sys_unlink, path, context=self._ctx)
 
     async def rename(self, old_path: str, new_path: str) -> None:
-        self._kernel.sys_rename(old_path, new_path, context=self._ctx)
+        await asyncio.to_thread(self._kernel.sys_rename, old_path, new_path, context=self._ctx)
 
     def exists(self, path: str) -> bool:
         return cast(bool, self._kernel.access(path, context=self._ctx))

--- a/src/nexus/server/api/v2/routers/agent_status.py
+++ b/src/nexus/server/api/v2/routers/agent_status.py
@@ -13,6 +13,7 @@ Note: This module intentionally does NOT use ``from __future__ import annotation
 because FastAPI uses ``eval_str=True`` on dependency signatures at import time.
 """
 
+import asyncio
 import logging
 from typing import Any
 
@@ -436,7 +437,7 @@ async def set_agent_spec(
     existing_gen = 0
     try:
         ctx = parse_operation_context(None)
-        raw = vfs.sys_read(spec_path, context=ctx)
+        raw = await asyncio.to_thread(vfs.sys_read, spec_path, context=ctx)
         if raw:
             existing = _json.loads(raw if isinstance(raw, str) else raw.decode())
             existing_gen = existing.get("spec_generation", 0)
@@ -484,7 +485,7 @@ async def get_agent_spec(
     spec_path = f"/{desc.zone_id}/agents/{agent_id}/settings.json"
     try:
         ctx = parse_operation_context(None)
-        raw = vfs.sys_read(spec_path, context=ctx)
+        raw = await asyncio.to_thread(vfs.sys_read, spec_path, context=ctx)
         data = _json.loads(raw if isinstance(raw, str) else raw.decode())
     except Exception as exc:
         raise HTTPException(status_code=404, detail=f"Agent '{agent_id}' has no spec") from exc

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -1064,7 +1064,7 @@ def create_async_files_router(
 
             # Get metadata first for ETag check
             if if_none_match:
-                meta = fs.sys_stat(path)
+                meta = await asyncio.to_thread(fs.sys_stat, path)
                 if meta and meta.content_id:
                     client_etag = if_none_match.strip('"')
                     if client_etag == meta.content_id:
@@ -1346,7 +1346,7 @@ def create_async_files_router(
                     except Exception:
                         _original_hash = None
 
-            fs.sys_unlink(path, context=context)
+            await asyncio.to_thread(fs.sys_unlink, path, context=context)
 
             if (
                 _ss is not None
@@ -1453,7 +1453,8 @@ def create_async_files_router(
             # while sys_readdir(details=True) returns detail dicts. We use
             # sys_readdir as the primary path and only fall back to search
             # for connector mounts where metastore-first listing is needed.
-            result = fs.sys_readdir(
+            result = await asyncio.to_thread(
+                fs.sys_readdir,
                 path,
                 recursive=False,
                 details=True,
@@ -1582,7 +1583,8 @@ def create_async_files_router(
 
                 # If filtering emptied the page but more data exists, keep fetching
                 while not file_items and has_more and next_cursor_raw:
-                    result = fs.sys_readdir(
+                    result = await asyncio.to_thread(
+                        fs.sys_readdir,
                         path,
                         recursive=False,
                         details=True,
@@ -1688,7 +1690,7 @@ def create_async_files_router(
         context = _apply_zone_override(context, zone, auth_result)
         try:
             fs = await _get_fs()
-            meta = fs.sys_stat(path, context=context)
+            meta = await asyncio.to_thread(fs.sys_stat, path, context=context)
             if meta is None:
                 raise NexusFileNotFoundError(path=path)
 
@@ -1895,7 +1897,7 @@ def create_async_files_router(
 
         try:
             fs = await _get_fs()
-            meta = fs.sys_stat(path, context=context)
+            meta = await asyncio.to_thread(fs.sys_stat, path, context=context)
             if meta is None:
                 raise NexusFileNotFoundError(path=path)
 
@@ -1908,7 +1910,7 @@ def create_async_files_router(
 
             async def _full_generator() -> AsyncIterator[bytes]:
                 """Sync generator wrapping NexusFS.read()."""
-                data = fs.sys_read(path, context=context)
+                data = await asyncio.to_thread(fs.sys_read, path, context=context)
                 if isinstance(data, bytes):
                     for i in range(0, len(data), chunk_size):
                         yield data[i : i + chunk_size]
@@ -1956,7 +1958,9 @@ def create_async_files_router(
         """
         try:
             fs = await _get_fs()
-            fs.sys_rename(request.source, request.destination, context=context)
+            await asyncio.to_thread(
+                fs.sys_rename, request.source, request.destination, context=context
+            )
             return RenameResponse(
                 success=True,
                 source=request.source,
@@ -1994,7 +1998,7 @@ def create_async_files_router(
             fs = await _get_fs()
 
             # Check source exists and get size
-            meta = fs.sys_stat(request.source, context=context)
+            meta = await asyncio.to_thread(fs.sys_stat, request.source, context=context)
             if meta is None:
                 raise NexusFileNotFoundError(path=request.source)
 
@@ -2002,8 +2006,8 @@ def create_async_files_router(
 
             if file_size < STREAMING_COPY_THRESHOLD:
                 # Small file: read all then write all
-                content = fs.sys_read(request.source, context=context)
-                fs.write(request.destination, buf=content, context=context)
+                content = await asyncio.to_thread(fs.sys_read, request.source, context=context)
+                await asyncio.to_thread(fs.write, request.destination, buf=content, context=context)
                 bytes_copied = len(content)
             else:
                 # Large file: streaming copy
@@ -2096,7 +2100,7 @@ def create_async_files_router(
 
             for op in request.operations:
                 try:
-                    meta = fs.sys_stat(op.source, context=context)
+                    meta = await asyncio.to_thread(fs.sys_stat, op.source, context=context)
                     if meta is None:
                         results.append(
                             BulkCopyResult(
@@ -2111,8 +2115,10 @@ def create_async_files_router(
                     file_size = meta.get("size", 0) or 0
 
                     if file_size < STREAMING_COPY_THRESHOLD:
-                        content = fs.sys_read(op.source, context=context)
-                        fs.write(op.destination, buf=content, context=context)
+                        content = await asyncio.to_thread(fs.sys_read, op.source, context=context)
+                        await asyncio.to_thread(
+                            fs.write, op.destination, buf=content, context=context
+                        )
                         bytes_copied = len(content)
                     else:
                         chunks = await asyncio.to_thread(fs.stream, op.source, context=context)
@@ -2170,8 +2176,9 @@ def create_async_files_router(
             fs = await _get_fs()
 
             # List all files under the base path
-            # sys_readdir is async — call directly, not via to_thread
-            all_paths = fs.sys_readdir(path, recursive=True, context=context)
+            all_paths = await asyncio.to_thread(
+                fs.sys_readdir, path, recursive=True, context=context
+            )
 
             # Apply glob pattern filter
             matched = await asyncio.to_thread(glob_filter, all_paths, include_patterns=[pattern])
@@ -2220,8 +2227,9 @@ def create_async_files_router(
             fs = await _get_fs()
 
             # List all files under the base path
-            # sys_readdir is async — call directly, not via to_thread
-            all_paths = fs.sys_readdir(path, recursive=True, context=context)
+            all_paths = await asyncio.to_thread(
+                fs.sys_readdir, path, recursive=True, context=context
+            )
 
             # Try Rust mmap grep first
             results = await asyncio.to_thread(

--- a/src/nexus/server/api/v2/routers/catalog.py
+++ b/src/nexus/server/api/v2/routers/catalog.py
@@ -5,6 +5,7 @@ Provides endpoints for data catalog operations:
 - GET /api/v2/catalog/search -- Search for files by column name
 """
 
+import asyncio
 import logging
 import mimetypes
 from typing import Any
@@ -53,7 +54,7 @@ async def get_catalog_schema(
             # Verify caller has file access before returning cached schema
             # (prevents bypassing permission checks via cache)
             try:
-                nexus_fs.sys_stat(full_path)
+                await asyncio.to_thread(nexus_fs.sys_stat, full_path)
             except PermissionError as perm_err:
                 raise HTTPException(
                     status_code=403, detail=f"Access denied: {full_path}"
@@ -132,7 +133,7 @@ async def search_by_column(
             if path_payload and path_payload.get("virtual_path"):
                 file_path = path_payload["virtual_path"]
                 try:
-                    nexus_fs.sys_stat(file_path)
+                    await asyncio.to_thread(nexus_fs.sys_stat, file_path)
                     results.append(r)
                 except Exception:
                     continue  # Caller can't access this file

--- a/src/nexus/server/api/v2/routers/connectors.py
+++ b/src/nexus/server/api/v2/routers/connectors.py
@@ -16,6 +16,7 @@ Endpoints:
     POST  /api/v2/connectors/unmount                — Unmount a connector
 """
 
+import asyncio
 import logging
 from typing import Any
 
@@ -763,7 +764,7 @@ async def get_readme_doc(
     # Fall back to reading from VFS if backend generation failed
     if not content:
         try:
-            raw = nx.sys_read(f"{mp}/.readme/README.md")
+            raw = await asyncio.to_thread(nx.sys_read, f"{mp}/.readme/README.md")
             content = raw.decode("utf-8") if isinstance(raw, bytes) else str(raw)
         except Exception:
             pass
@@ -779,7 +780,7 @@ async def get_readme_doc(
         schemas = list(s.keys()) if s else list(t.keys())
     if not schemas:
         try:
-            entries = nx.sys_readdir(f"{mp}/.readme/schemas")
+            entries = await asyncio.to_thread(nx.sys_readdir, f"{mp}/.readme/schemas")
             schemas = [str(e).replace(".yaml", "") for e in entries if str(e).endswith(".yaml")]
         except Exception:
             pass
@@ -840,7 +841,7 @@ async def get_schema(
 
     # Try reading from VFS
     try:
-        raw = nx.sys_read(f"{mp}/.readme/schemas/{operation}.yaml")
+        raw = await asyncio.to_thread(nx.sys_read, f"{mp}/.readme/schemas/{operation}.yaml")
         content = raw.decode("utf-8") if isinstance(raw, bytes) else str(raw)
         return SchemaResponse(mount_point=mount_path, operation=operation, content=content)
     except Exception:
@@ -876,7 +877,7 @@ async def write_to_connector(
     _py_kernel = getattr(nx, "_kernel", None)
     if _py_kernel is not None:
         try:
-            _stat_d = _py_kernel.sys_stat(mount_path, "root")
+            _stat_d = await asyncio.to_thread(_py_kernel.sys_stat, mount_path, "root")
             if _stat_d and isinstance(_stat_d, dict):
                 _route_backend_name = _stat_d.get("backend_name")
             # Derive backend_path from path minus mount point (first 2 segments)

--- a/src/nexus/server/api/v2/routers/locks.py
+++ b/src/nexus/server/api/v2/routers/locks.py
@@ -6,6 +6,7 @@ sys_readdir on /__sys__/locks/) via REST endpoints for the TUI.
 Issue #3250: TUI Locks tab.
 """
 
+import asyncio
 import logging
 import time
 import uuid
@@ -138,7 +139,9 @@ async def list_locks(
     nx = _get_nexus_fs(request)
     if nx and hasattr(nx, "sys_readdir"):
         try:
-            kernel_locks = nx.sys_readdir("/__sys__/locks/", details=True, context=ctx)
+            kernel_locks = await asyncio.to_thread(
+                nx.sys_readdir, "/__sys__/locks/", details=True, context=ctx
+            )
             locks = [
                 {
                     "lock_id": holder.get("lock_id", ""),

--- a/src/nexus/server/cache_warmer.py
+++ b/src/nexus/server/cache_warmer.py
@@ -762,7 +762,7 @@ class CacheWarmer:
         async with self._semaphore:
             try:
                 # Read file content
-                content = self._nexus.sys_read(path, context=context)
+                content = await asyncio.to_thread(self._nexus.sys_read, path, context=context)
                 if content:
                     content_bytes = content if isinstance(content, bytes) else b""
                     self._current_stats.content_warmed += 1
@@ -836,7 +836,7 @@ class CacheWarmer:
 
         try:
             # List root directory
-            root_entries = self._nexus.sys_readdir("/", recursive=False)
+            root_entries = await asyncio.to_thread(self._nexus.sys_readdir, "/", recursive=False)
             if isinstance(root_entries, list):
                 # Handle both list[str] and list[dict] return types
                 for entry in root_entries[:50]:

--- a/src/nexus/server/rpc/handlers/delta.py
+++ b/src/nexus/server/rpc/handlers/delta.py
@@ -4,6 +4,7 @@ Extracted from fastapi_server.py (#1602). Provides rsync-style incremental
 file updates via binary diffs (bsdiff4).
 """
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -36,7 +37,7 @@ async def handle_delta_read(nexus_fs: "NexusFS", params: Any, context: Any) -> d
     from nexus.core.hash_fast import hash_content
 
     # Read current file content — sys_read (Tier 1) always returns bytes
-    content = nexus_fs.sys_read(params.path, context=context)
+    content = await asyncio.to_thread(nexus_fs.sys_read, params.path, context=context)
     if isinstance(content, str):
         content = content.encode("utf-8")
     # delta handler operates on DT_REG; the dict shape is DT_STREAM-only.
@@ -139,7 +140,7 @@ async def handle_delta_write(nexus_fs: "NexusFS", params: Any, context: Any) -> 
 
     try:
         # sys_read (Tier 1) always returns bytes
-        current_content = nexus_fs.sys_read(params.path, context=context)
+        current_content = await asyncio.to_thread(nexus_fs.sys_read, params.path, context=context)
         if isinstance(current_content, str):
             current_content = current_content.encode("utf-8")
     except Exception as e:

--- a/src/nexus/server/rpc/handlers/filesystem.py
+++ b/src/nexus/server/rpc/handlers/filesystem.py
@@ -7,6 +7,7 @@ All sync handlers are wrapped with ``to_thread_with_timeout`` by the dispatch
 layer — they MUST NOT call async code directly.
 """
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
@@ -206,7 +207,7 @@ async def handle_semantic_search_index(
         stale_candidates: list[tuple[str, str, str | None]] = []
         for file_path in paths_to_index:
             try:
-                raw = nexus_fs.sys_read(file_path, context=context)
+                raw = await asyncio.to_thread(nexus_fs.sys_read, file_path, context=context)
                 # Pass the DB-tracked content_id so the parse cache key
                 # matches what has_successful_parse later compares against
                 # (etag on S3/GCS, BLAKE3 on local CAS — adapter stores

--- a/src/nexus/services/lifecycle/user_provisioning.py
+++ b/src/nexus/services/lifecycle/user_provisioning.py
@@ -7,6 +7,7 @@ deprovision_user tears everything down.
 Issue #2033 — Phase 2.2 of LEGO microkernel decomposition.
 """
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING, Any
 
@@ -537,7 +538,9 @@ class UserProvisioningService:
             return False
 
         try:
-            result = self._vfs.sys_readdir(dir_path, recursive=False, context=context)
+            result = await asyncio.to_thread(
+                self._vfs.sys_readdir, dir_path, recursive=False, context=context
+            )
             if isinstance(result, dict) and "files" in result:
                 children = result["files"]
             elif isinstance(result, list):
@@ -555,7 +558,9 @@ class UserProvisioningService:
                 if isinstance(item, str):
                     child_path = item
                     try:
-                        self._vfs.sys_readdir(child_path, recursive=False, context=context)
+                        await asyncio.to_thread(
+                            self._vfs.sys_readdir, child_path, recursive=False, context=context
+                        )
                         is_dir = True
                     except Exception:
                         is_dir = False  # readdir failed → treat as file
@@ -572,7 +577,7 @@ class UserProvisioningService:
                     if is_dir:
                         await self._delete_directory_recursive(child_path, context)
                     else:
-                        self._vfs.sys_unlink(child_path, context=context)
+                        await asyncio.to_thread(self._vfs.sys_unlink, child_path, context=context)
                 except Exception as e:
                     logger.warning("Failed to delete %s: %s", child_path, e)
 
@@ -585,7 +590,7 @@ class UserProvisioningService:
                     logger.debug("rmdir failed for %s (will try unlink): %s", dir_path, e)
             if not directory_removed:
                 try:
-                    self._vfs.sys_unlink(dir_path, context=context)
+                    await asyncio.to_thread(self._vfs.sys_unlink, dir_path, context=context)
                     directory_removed = True
                 except Exception as e:
                     logger.debug("unlink fallback also failed for %s: %s", dir_path, e)


### PR DESCRIPTION
## Summary

`NexusFS.sys_read` is a synchronous Rust kernel call that blocks for up to 5 seconds (DT_PIPE timeout) waiting for data. Three call sites were invoking it directly on the asyncio event loop, wedging the entire FastAPI server (HTTP requests, healthcheck, all background tasks) for 5s on every empty-pipe poll:

- `bricks/search/skeleton_pipe_consumer._consume` — polls SKELETON pipe for VFS write events to index
- `bricks/task_manager/dispatch_consumer._consume` — polls TASK_DISPATCH pipe for queued task events
- `factory/adapters._NexusFSFileReader.{read_text,read_head}` — search daemon's adapter for indexing file content

## Symptom

`nexus up` reports the container starting then unhealthy:

```
✗ nexus (timed out after 124s)
✓ postgres (0.0s)
✓ dragonfly (0.0s)
```

`/health`, `/api/v2/*`, and even `/api/v2/agents/register` hang indefinitely. py-spy dump shows MainThread parked inside `nexus_fs_content.sys_read:112` (the Rust pread call) under one of the three consumer/adapter paths:

```
Thread 42 (idle): "MainThread"
    sys_read (nexus/core/nexus_fs_content.py:112)
    read_head (nexus/factory/adapters.py:406)
    index_file (nexus/bricks/search/skeleton_indexer.py:109)
    _dispatch_single (nexus/bricks/search/skeleton_pipe_consumer.py:286)
    run (asyncio/runners.py:127)
    run (uvicorn/server.py:75)
```

Reproduced on `e2e-validate`, `edge`, `latest`, and a fresh `local-worktree` build of `develop`.

## Fix

Wrap each sync call in `asyncio.to_thread` so the blocking pread runs on a worker thread and the event loop stays responsive. After the fix:

- `nexus up` reports `✓ nexus (15.6s)` (vs. `✗ nexus (timed out after 124s)`)
- `/health` responds in <5ms continuously
- `/api/v2/agents/register` returns within the default 10s timeout

## Test plan

- [x] py-spy dump on master confirms sync `sys_read` blocks MainThread inside the event loop
- [x] After patch, `nexus up` reports `✓ nexus (15.6s)` with no zoekt-style timeout
- [x] `curl http://localhost:40970/health` returns `{"status":"healthy",...}` consistently across 30+ probes
- [x] `curl -X POST /api/v2/agents/register` returns the new agent's api-key in <2s
- [ ] Add an integration test that asserts `/health` stays responsive while a SKELETON pipe poll is in flight (follow-up)

## Reproduction

Without the patch:
```bash
nexus up  # times out
docker exec nexus-*-nexus-1 curl --max-time 3 http://localhost:2026/health
# Operation timed out after 3002 milliseconds with 0 bytes received
docker exec --privileged nexus-*-nexus-1 py-spy dump --pid <nexusd-pid>
# MainThread parked inside sys_read line 112
```

With the patch:
```bash
NEXUS_IMAGE_REF=nexus:local-patched nexus up
# ✓ nexus (15.6s)
curl http://localhost:40970/health
# {"status":"healthy",...}
```