### PR TITLE
Fix Docker startup event loop blocking

### DIFF
--- a/dockerfiles/docker-entrypoint.sh
+++ b/dockerfiles/docker-entrypoint.sh
@@ -491,7 +491,7 @@ wait_for_health() {
         sleep 5
     done
     echo -e "${YELLOW}⚠ Server health check timeout after ${max} attempts (continuing anyway)${NC}"
-    return 1
+    return 0
 }
 
 load_saved_mounts_if_needed() {

--- a/src/nexus/factory/adapters.py
+++ b/src/nexus/factory/adapters.py
@@ -246,7 +246,7 @@ class _NexusFSFileReader:
             is_admin=True,
             is_system=True,
         )
-        content_raw = self._nx.sys_read(path, context=admin_ctx)
+        content_raw = await asyncio.to_thread(self._nx.sys_read, path, context=admin_ctx)
 
         # Look up the backend-tracked content_id (``file_paths.content_id``)
         # so the parse cache is keyed with the same string downstream
@@ -258,7 +258,7 @@ class _NexusFSFileReader:
         # of the raw bytes.
         observed_content_id: str | None = None
         try:
-            lookup = self.get_content_hash(path)
+            lookup = await asyncio.to_thread(self.get_content_hash, path)
             if isinstance(lookup, str):
                 observed_content_id = lookup
         except Exception:
@@ -403,7 +403,12 @@ class _NexusFSFileReader:
             is_system=True,
         )
         try:
-            content = await self._nx.sys_read(path, count=max_bytes, context=admin_ctx)
+            content = await asyncio.to_thread(
+                self._nx.sys_read,
+                path,
+                count=max_bytes,
+                context=admin_ctx,
+            )
             if isinstance(content, bytes):
                 return content
             return str(content).encode("utf-8", errors="ignore")

--- a/src/nexus/server/lifespan/permissions.py
+++ b/src/nexus/server/lifespan/permissions.py
@@ -416,15 +416,10 @@ async def _startup_tiger_cache(app: "FastAPI", svc: "LifespanServices") -> list[
                     )
                     app.state.directory_grant_expander = expander
 
-                    # Q3 BackgroundService — kernel auto-calls start()
-                    nx = svc.nexus_fs if hasattr(svc, "nexus_fs") else svc
-                    if hasattr(nx, "sys_setattr"):
-                        nx.sys_setattr(
-                            "/__sys__/services/directory_grant_expander",
-                            service=expander,
-                        )
-                    else:
-                        await expander.start()
+                    # Do not register through sys_setattr here: the kernel
+                    # auto-lifecycle path calls async BackgroundService.start()
+                    # via asyncio.run(), which fails inside FastAPI's loop.
+                    await expander.start()
                     logger.info("DirectoryGrantExpander worker started for large folder grants")
                 except Exception as e:
                     logger.debug("DirectoryGrantExpander startup skipped: %s", e)

--- a/src/nexus/server/lifespan/services.py
+++ b/src/nexus/server/lifespan/services.py
@@ -4,6 +4,7 @@ Extracted from fastapi_server.py (#1602).
 """
 
 import asyncio
+import inspect
 import logging
 import os
 from contextlib import suppress
@@ -117,7 +118,9 @@ async def shutdown_services(app: "FastAPI", svc: "LifespanServices") -> None:
     # Stop DirectoryGrantExpander worker
     if app.state.directory_grant_expander:
         try:
-            app.state.directory_grant_expander.stop()
+            result = app.state.directory_grant_expander.stop()
+            if inspect.isawaitable(result):
+                await result
             logger.info("DirectoryGrantExpander worker stopped")
         except Exception as e:
             logger.warning("Error stopping DirectoryGrantExpander: %s", e, exc_info=True)

--- a/tests/unit/factory/test_adapters.py
+++ b/tests/unit/factory/test_adapters.py
@@ -1,5 +1,7 @@
 """Tests for factory adapters — Issue #2180."""
 
+import asyncio
+import time
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -9,6 +11,43 @@ from nexus.factory.adapters import _NexusFSFileReader
 
 class TestNexusFSFileReader:
     """_NexusFSFileReader adapter tests."""
+
+    @pytest.mark.asyncio
+    async def test_read_text_does_not_block_event_loop_during_sys_read(self) -> None:
+        class BlockingNx:
+            _kernel = MagicMock()
+
+            def sys_read(self, _path: str, **_kwargs: object) -> bytes:
+                time.sleep(0.2)
+                return b"hello world"
+
+            def SessionLocal(self) -> object:
+                raise RuntimeError("database unavailable")
+
+        reader = _NexusFSFileReader(BlockingNx())
+
+        task = asyncio.create_task(reader.read_text("/test.txt"))
+        start = time.perf_counter()
+        await asyncio.sleep(0.02)
+
+        assert time.perf_counter() - start < 0.12
+        assert await task == "hello world"
+
+    @pytest.mark.asyncio
+    async def test_read_head_does_not_block_event_loop_during_sys_read(self) -> None:
+        class BlockingNx:
+            def sys_read(self, _path: str, **_kwargs: object) -> bytes:
+                time.sleep(0.2)
+                return b"hello"
+
+        reader = _NexusFSFileReader(BlockingNx())
+
+        task = asyncio.create_task(reader.read_head("/test.txt", 5))
+        start = time.perf_counter()
+        await asyncio.sleep(0.02)
+
+        assert time.perf_counter() - start < 0.12
+        assert await task == b"hello"
 
     @pytest.mark.asyncio
     async def test_read_text_bytes_decoded(self) -> None:

--- a/tests/unit/server/lifespan/test_permissions_tiger_cache.py
+++ b/tests/unit/server/lifespan/test_permissions_tiger_cache.py
@@ -1,0 +1,94 @@
+"""Tests for permissions lifespan Tiger Cache startup."""
+
+from __future__ import annotations
+
+import asyncio
+import contextlib
+from types import SimpleNamespace
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.server.lifespan.permissions import _startup_tiger_cache
+from nexus.server.lifespan.services import shutdown_services
+
+
+@pytest.mark.asyncio
+async def test_directory_grant_expander_starts_directly_inside_fastapi_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Avoid kernel auto-start, which calls async services via asyncio.run()."""
+
+    started: list[bool] = []
+
+    class FakeDirectoryGrantExpander:
+        def __init__(self, **_kwargs: object) -> None:
+            self.stopped = False
+
+        async def start(self) -> None:
+            started.append(True)
+
+    class FakeNexusFS:
+        _kernel = object()
+
+        def sys_setattr(self, *_args: object, **_kwargs: object) -> None:
+            raise AssertionError("async worker should not use kernel auto-start")
+
+    import nexus.bricks.rebac.cache.tiger.expander as expander_module
+
+    monkeypatch.setattr(
+        expander_module,
+        "DirectoryGrantExpander",
+        FakeDirectoryGrantExpander,
+    )
+    monkeypatch.setenv("NEXUS_ENABLE_TIGER_WORKER", "false")
+
+    tiger_cache = MagicMock()
+    tiger_cache.warm_from_db.return_value = 0
+    app = SimpleNamespace(state=SimpleNamespace(directory_grant_expander=None))
+    svc = SimpleNamespace(
+        nexus_fs=FakeNexusFS(),
+        rebac_manager=SimpleNamespace(_tiger_cache=tiger_cache, engine=object()),
+    )
+
+    tasks = await _startup_tiger_cache(app, svc)
+    try:
+        assert started == [True]
+        assert isinstance(app.state.directory_grant_expander, FakeDirectoryGrantExpander)
+    finally:
+        for task in tasks:
+            task.cancel()
+        with contextlib.suppress(asyncio.CancelledError):
+            await asyncio.gather(*tasks)
+
+
+@pytest.mark.asyncio
+async def test_shutdown_services_awaits_async_directory_grant_expander_stop() -> None:
+    class FakeDirectoryGrantExpander:
+        def __init__(self) -> None:
+            self.stopped = False
+
+        async def stop(self) -> None:
+            self.stopped = True
+
+    expander = FakeDirectoryGrantExpander()
+    app = SimpleNamespace(
+        state=SimpleNamespace(
+            write_observer=None,
+            zoekt_write_observer=None,
+            task_dispatch_consumer=None,
+            skeleton_pipe_consumer=None,
+            workflow_dispatch=None,
+            task_runner=None,
+            scheduler_service=None,
+            _eviction_task=None,
+            sandbox_auth_service=None,
+            search_daemon=None,
+            directory_grant_expander=expander,
+        )
+    )
+    svc = SimpleNamespace(nexus_fs=None)
+
+    await shutdown_services(app, svc)
+
+    assert expander.stopped is True

--- a/tests/unit/test_docker_publish_smoke_config.py
+++ b/tests/unit/test_docker_publish_smoke_config.py
@@ -44,6 +44,10 @@ def test_entrypoint_startup_wait_uses_bounded_basic_health_probe() -> None:
     assert 'curl --max-time 5 -sf "http://localhost:${port}/health"' in wait_for_health
     assert 'curl -sf "http://localhost:${port}/health"' not in wait_for_health
     assert "/healthz/ready" not in wait_for_health
+    assert (
+        'echo -e "${YELLOW}⚠ Server health check timeout after ${max} attempts '
+        '(continuing anyway)${NC}"\n    return 0'
+    ) in wait_for_health
 
 
 def test_build_perf_smoke_uses_basic_health_probe() -> None:


### PR DESCRIPTION
## Summary
- offload NexusFS file-reader sys_read/content-hash calls used by search indexing so startup work does not block the FastAPI event loop
- make the Docker entrypoint health wait match its continue-on-timeout behavior
- start/stop DirectoryGrantExpander directly in the FastAPI loop instead of the kernel asyncio.run auto-lifecycle path

## Verification
- uv run pytest tests/unit/factory/test_adapters.py tests/unit/bricks/search/test_skeleton_pipe_consumer.py tests/unit/test_docker_publish_smoke_config.py tests/unit/server/health/test_basic_health.py tests/unit/server/lifespan/test_permissions_tiger_cache.py
- uvx ruff check src/nexus/factory/adapters.py src/nexus/server/lifespan/permissions.py src/nexus/server/lifespan/services.py tests/unit/factory/test_adapters.py tests/unit/test_docker_publish_smoke_config.py tests/unit/server/lifespan/test_permissions_tiger_cache.py
- uvx ruff format --check src/nexus/factory/adapters.py src/nexus/server/lifespan/permissions.py src/nexus/server/lifespan/services.py tests/unit/factory/test_adapters.py tests/unit/test_docker_publish_smoke_config.py tests/unit/server/lifespan/test_permissions_tiger_cache.py
- bash -n dockerfiles/docker-entrypoint.sh && git diff --check
- docker build -t nexus:local-eventloop-fix .
- local container startup with pgvector Postgres: internal /health returned healthy, admin key was present, and logs had no asyncio.run startup error or entrypoint health timeout