### PR TITLE
Fix Docker Postgres FTS fallback

### DIFF
--- a/alembic/versions/add_pg_textsearch_bm25_index.py
+++ b/alembic/versions/add_pg_textsearch_bm25_index.py
@@ -92,8 +92,9 @@ def upgrade() -> None:
         warnings.warn(
             "Neither pg_search (paradedb) nor pg_textsearch (Tiger Data) "
             "is installed. Skipping BM25 index creation; keyword search "
-            "will fail at query time. Use the bundled paradedb image or "
-            "install one of these extensions manually.",
+            "will degrade to PostgreSQL native FTS at query time. Use the "
+            "bundled paradedb image or install one of these extensions "
+            "manually for true BM25 ranking.",
             stacklevel=2,
         )
         return

--- a/scripts/test_build_perf_e2e.py
+++ b/scripts/test_build_perf_e2e.py
@@ -519,6 +519,8 @@ def main() -> None:
             AUTO_INDEX_MARKER,
             "--path",
             "/workspace/demo/plan.md",
+            "--mode",
+            "keyword",
             "--limit",
             "3",
         )
@@ -561,6 +563,8 @@ def main() -> None:
             "quantum entanglement teleportation",
             "--path",
             "/workspace/demo",
+            "--mode",
+            "keyword",
             "--limit",
             "3",
         )
@@ -586,6 +590,8 @@ def main() -> None:
             "quantum entanglement teleportation",
             "--path",
             "/workspace/demo",
+            "--mode",
+            "keyword",
             "--limit",
             "3",
         )

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1428,13 +1428,36 @@ class SearchDaemon:
         self.last_search_timing = {}
         hybrid_keyword_results: list[SearchResult] = []
         hybrid_keyword_ms = 0.0
+        has_new_backends = self._fts_backend is not None and self._vector_backend is not None
+        backend_attempted = False
 
         try:
             if search_type == "keyword":
+                if has_new_backends:
+                    backend_start = time.perf_counter()
+                    backend_results = await self._search_via_backends(
+                        query,
+                        search_type=search_type,
+                        limit=limit,
+                        path_filter=path_filter,
+                        zone_id=effective_zone_id,
+                    )
+                    backend_ms = (time.perf_counter() - backend_start) * 1000
+                    backend_attempted = True
+                    self.last_search_timing = {
+                        "backend_ms": backend_ms,
+                        "rerank_ms": 0.0,
+                    }
+                    if backend_results:
+                        latency_ms = (time.perf_counter() - start) * 1000
+                        self._track_latency(latency_ms)
+                        await self._attach_path_contexts(backend_results, zone_id=effective_zone_id)
+                        return backend_results
+
                 # Keyword mode should use the daemon's keyword stack first.
-                # The new fts backend is the canonical BM25 path. We still
-                # try `_keyword_search` (Zoekt/BM25S/inline FTS) first when
-                # zone-safe to preserve the existing fast-path semantics.
+                # The new fts backend above is the canonical BM25/native-FTS
+                # path. Fall back to `_keyword_search` only if the backend is
+                # unavailable or returned no hits.
                 keyword_start = time.perf_counter()
                 keyword_results = await self._keyword_search(
                     query,
@@ -1449,9 +1472,11 @@ class SearchDaemon:
                     self._track_latency(latency_ms)
                     await self._attach_path_contexts(keyword_results, zone_id=effective_zone_id)
                     return keyword_results
-            elif search_type == "hybrid":
+            elif search_type == "hybrid" and not has_new_backends:
                 # Make lexical candidates explicit in hybrid mode so exact
                 # matches are not lost before backend semantic ranking.
+                # Post-#3699 backends already run chunk+page keyword legs, so
+                # this legacy prefetch is only needed when they are absent.
                 keyword_start = time.perf_counter()
                 hybrid_keyword_results = await self._keyword_search(
                     query,
@@ -1464,7 +1489,7 @@ class SearchDaemon:
             # Delegate to the new search backends (Issue #3699). The daemon
             # now owns hybrid composition: chunk-BM25 + page-BM25 + dense,
             # fused via the fusion module. SQLite drops the page-BM25 leg.
-            if self._fts_backend is not None and self._vector_backend is not None:
+            if has_new_backends and not backend_attempted:
                 backend_start = time.perf_counter()
                 backend_results = await self._search_via_backends(
                     query,

--- a/src/nexus/bricks/search/pg_fts_backend.py
+++ b/src/nexus/bricks/search/pg_fts_backend.py
@@ -1,8 +1,10 @@
-"""Postgres BM25 backend (Issue #3699).
+"""Postgres full-text search backend (Issue #3699).
 
 Wraps the existing idx_chunks_bm25 pg_textsearch index (true k1+b BM25)
-on document_chunks.chunk_text. Replaces the BM25 leg of txtai_backend
-+ bm25s_search.py for Postgres deployments.
+on document_chunks.chunk_text when the pg_search / pg_textsearch extension is
+available. When the extension is absent, the backend falls back to PostgreSQL's
+built-in ``to_tsvector`` / ``ts_rank_cd`` search so plain pgvector Postgres
+deployments still return keyword and hybrid results.
 
 Two BM25 modes:
   * keyword_search()         — chunk-level (one row per chunk)
@@ -32,6 +34,7 @@ Page-BM25 approach (keyword_search_pages):
 from __future__ import annotations
 
 import logging
+import re
 from collections.abc import Sequence
 from typing import Any
 
@@ -60,6 +63,85 @@ logger = logging.getLogger(__name__)
 # ---------------------------------------------------------------------------
 _BM25_MATCH_OP: str = "@@@"
 _BM25_SCORE_FN: str = "paradedb.score"
+_NATIVE_FTS_TOKEN_RE = re.compile(r"[A-Za-z0-9]+")
+_NATIVE_FTS_STOPWORDS = {
+    "a",
+    "an",
+    "and",
+    "are",
+    "as",
+    "at",
+    "be",
+    "been",
+    "being",
+    "by",
+    "did",
+    "do",
+    "does",
+    "for",
+    "from",
+    "had",
+    "has",
+    "have",
+    "how",
+    "in",
+    "is",
+    "it",
+    "of",
+    "on",
+    "or",
+    "that",
+    "the",
+    "to",
+    "was",
+    "were",
+    "what",
+    "when",
+    "where",
+    "which",
+    "who",
+    "why",
+    "with",
+}
+
+
+def _native_fts_query(query: str) -> str:
+    """Build a broad native Postgres tsquery string for fallback search.
+
+    ``plainto_tsquery`` combines normal text with AND, which is too strict for
+    natural-language questions. A safe OR tsquery keeps fallback recall close
+    to BM25 while PostgreSQL still handles stemming through ``to_tsquery``.
+    """
+    terms: list[str] = []
+    seen: set[str] = set()
+    for match in _NATIVE_FTS_TOKEN_RE.finditer(query.lower()):
+        term = match.group(0)
+        if len(term) < 2 or term in _NATIVE_FTS_STOPWORDS or term in seen:
+            continue
+        seen.add(term)
+        terms.append(term)
+    return " | ".join(terms)
+
+
+def _native_like_patterns(query: str) -> dict[str, str]:
+    escaped = query.replace("\\", "\\\\").replace("%", "\\%").replace("_", "\\_")
+    return {
+        "phrase_pattern": f"%{escaped}%",
+        "heading_pattern": f"#%: {escaped}%",
+    }
+
+
+def _is_missing_bm25_error(exc: BaseException) -> bool:
+    """Return True for pg_search / pg_textsearch not-installed query failures."""
+    orig = getattr(exc, "orig", None)
+    message = str(orig if orig is not None else exc).lower()
+    return (
+        'schema "paradedb" does not exist' in message
+        or "schema paradedb does not exist" in message
+        or "function paradedb.score" in message
+        or ("operator does not exist" in message and "@@@" in message)
+        or 'access method "bm25" does not exist' in message
+    )
 
 
 class PgFtsBackend:
@@ -85,13 +167,33 @@ class PgFtsBackend:
         # aggregation. Keeps us from try/except on every query once we
         # know which path the installed pg_textsearch build supports.
         self._page_cte_supported: bool | None = None
+        # ``None`` = not checked yet, ``True`` = pg_search/pg_textsearch BM25
+        # works, ``False`` = use built-in PostgreSQL FTS fallback.
+        self._bm25_available: bool | None = None
 
     # -------------------------------------------------------------------------
     # Lifecycle
     # -------------------------------------------------------------------------
 
     async def startup(self) -> None:
-        """No-op: pg_textsearch index is maintained by Postgres automatically."""
+        """Detect whether pg_search / pg_textsearch BM25 is available."""
+        try:
+            async with self._engine.connect() as conn:
+                result = await conn.execute(
+                    text("""
+                    SELECT EXISTS (
+                        SELECT 1
+                        FROM pg_am
+                        WHERE amname = 'bm25'
+                    ) AS has_bm25
+                    """)
+                )
+                self._bm25_available = bool(result.scalar())
+        except Exception as exc:
+            logger.debug("PgFtsBackend.startup: BM25 capability probe failed: %s", exc)
+            self._bm25_available = None
+        if self._bm25_available is False:
+            self._page_cte_supported = False
         return None
 
     async def shutdown(self) -> None:
@@ -152,6 +254,32 @@ class PgFtsBackend:
         Returns:
             List of BaseSearchResult ordered by score descending.
         """
+        if self._bm25_available is False:
+            return await self._keyword_search_native(query, path, k, zone_id)
+
+        try:
+            return await self._keyword_search_bm25(query, path, k, zone_id)
+        except (ProgrammingError, DBAPIError) as exc:
+            if not _is_missing_bm25_error(exc):
+                raise
+            logger.warning(
+                "PgFtsBackend.keyword_search: BM25 query failed because "
+                "pg_search/pg_textsearch is unavailable (%s: %s). Falling back "
+                "to built-in PostgreSQL FTS for this process.",
+                type(exc).__name__,
+                exc,
+            )
+            self._bm25_available = False
+            self._page_cte_supported = False
+            return await self._keyword_search_native(query, path, k, zone_id)
+
+    async def _keyword_search_bm25(
+        self,
+        query: str,
+        path: str,
+        k: int,
+        zone_id: str,
+    ) -> list[BaseSearchResult]:
         # NOTE: _BM25_MATCH_OP and _BM25_SCORE_FN are module-level string
         # constants, not user input, so the f-string here does NOT open an
         # SQL-injection surface. The runtime values (query, path, zone_id, k)
@@ -185,6 +313,71 @@ class PgFtsBackend:
                 .all()
             )
 
+        return self._rows_to_results(rows, zone_id=zone_id)
+
+    async def _keyword_search_native(
+        self,
+        query: str,
+        path: str,
+        k: int,
+        zone_id: str,
+    ) -> list[BaseSearchResult]:
+        fts_query = _native_fts_query(query)
+        if not fts_query:
+            return []
+        like_patterns = _native_like_patterns(query)
+
+        sql = text("""
+            WITH q AS (
+              SELECT to_tsquery('english', :fts_query) AS query
+            )
+            SELECT c.chunk_id,
+                   fp.virtual_path AS path,
+                   c.chunk_text,
+                   c.chunk_index,
+                   (
+                     ts_rank_cd(to_tsvector('english', c.chunk_text), q.query)
+                     + CASE
+                         WHEN c.chunk_text ILIKE :heading_pattern ESCAPE '\\' THEN 10.0
+                         ELSE 0.0
+                       END
+                     + CASE
+                         WHEN c.chunk_text ILIKE :phrase_pattern ESCAPE '\\' THEN 1.0
+                         ELSE 0.0
+                       END
+                   ) AS score
+            FROM document_chunks c
+            JOIN file_paths fp ON c.path_id = fp.path_id
+            CROSS JOIN q
+            WHERE to_tsvector('english', c.chunk_text) @@ q.query
+              AND fp.zone_id = :zone_id
+              AND fp.virtual_path LIKE :prefix || '%'
+              AND fp.deleted_at IS NULL
+            ORDER BY score DESC
+            LIMIT :k
+        """)
+        async with self._engine.connect() as conn:
+            rows = (
+                (
+                    await conn.execute(
+                        sql,
+                        {
+                            "fts_query": fts_query,
+                            **like_patterns,
+                            "prefix": path,
+                            "zone_id": zone_id,
+                            "k": k,
+                        },
+                    )
+                )
+                .mappings()
+                .all()
+            )
+
+        return self._rows_to_results(rows, zone_id=zone_id)
+
+    @staticmethod
+    def _rows_to_results(rows: Sequence[Any], *, zone_id: str) -> list[BaseSearchResult]:
         return [
             BaseSearchResult(
                 path=r["path"],
@@ -235,6 +428,9 @@ class PgFtsBackend:
         Returns:
             List of BaseSearchResult (one per path) ordered by score desc.
         """
+        if self._bm25_available is False:
+            return await self._keyword_search_pages_native(query, path, k, zone_id)
+
         if self._page_cte_supported is False:
             # Cached: previous attempt failed — go straight to fallback.
             return await self._keyword_search_pages_fallback(query, path, k, zone_id)
@@ -246,6 +442,18 @@ class PgFtsBackend:
             # in psycopg / asyncpg; DBAPIError is the broader catch for builds
             # that surface the same condition under a different SQLSTATE.
             # Anything else (timeouts, IntegrityError) we re-raise.
+            if _is_missing_bm25_error(exc):
+                logger.warning(
+                    "PgFtsBackend.keyword_search_pages: BM25 query failed "
+                    "because pg_search/pg_textsearch is unavailable (%s: %s). "
+                    "Falling back to built-in PostgreSQL FTS for this process.",
+                    type(exc).__name__,
+                    exc,
+                )
+                self._bm25_available = False
+                self._page_cte_supported = False
+                return await self._keyword_search_pages_native(query, path, k, zone_id)
+
             if self._page_cte_supported is None:
                 logger.warning(
                     "PgFtsBackend.keyword_search_pages: CTE-aggregated BM25 "
@@ -313,6 +521,83 @@ class PgFtsBackend:
                 chunk_text=r["page_text"],
                 score=float(r["score"]),
                 chunk_index=0,  # page-level result has no single chunk_index
+                keyword_score=float(r["score"]),
+                zone_id=zone_id,
+            )
+            for r in rows
+        ]
+
+    async def _keyword_search_pages_native(
+        self,
+        query: str,
+        path: str,
+        k: int,
+        zone_id: str,
+    ) -> list[BaseSearchResult]:
+        fts_query = _native_fts_query(query)
+        if not fts_query:
+            return []
+        like_patterns = _native_like_patterns(query)
+
+        sql = text("""
+            WITH q AS (
+              SELECT to_tsquery('english', :fts_query) AS query
+            ),
+            pages AS (
+              SELECT fp.path_id,
+                     fp.virtual_path,
+                     string_agg(c.chunk_text, ' ' ORDER BY c.chunk_index) AS page_text
+              FROM document_chunks c
+              JOIN file_paths fp ON c.path_id = fp.path_id
+              WHERE fp.zone_id = :zone_id
+                AND fp.virtual_path LIKE :prefix || '%'
+                AND fp.deleted_at IS NULL
+              GROUP BY fp.path_id, fp.virtual_path
+            )
+            SELECT path_id,
+                   virtual_path AS path,
+                   page_text,
+                   (
+                     ts_rank_cd(to_tsvector('english', page_text), q.query)
+                     + CASE
+                         WHEN page_text ILIKE :heading_pattern ESCAPE '\\' THEN 10.0
+                         ELSE 0.0
+                       END
+                     + CASE
+                         WHEN page_text ILIKE :phrase_pattern ESCAPE '\\' THEN 1.0
+                         ELSE 0.0
+                       END
+                   ) AS score
+            FROM pages
+            CROSS JOIN q
+            WHERE to_tsvector('english', page_text) @@ q.query
+            ORDER BY score DESC
+            LIMIT :k
+        """)
+        async with self._engine.connect() as conn:
+            rows = (
+                (
+                    await conn.execute(
+                        sql,
+                        {
+                            "fts_query": fts_query,
+                            **like_patterns,
+                            "prefix": path,
+                            "zone_id": zone_id,
+                            "k": k,
+                        },
+                    )
+                )
+                .mappings()
+                .all()
+            )
+
+        return [
+            BaseSearchResult(
+                path=r["path"],
+                chunk_text=r["page_text"],
+                score=float(r["score"]),
+                chunk_index=0,
                 keyword_score=float(r["score"]),
                 zone_id=zone_id,
             )

--- a/src/nexus/cli/commands/search.py
+++ b/src/nexus/cli/commands/search.py
@@ -673,9 +673,11 @@ def search_index(
             stats: dict[str, Any] = search_svc.semantic_search_stats()
             console.print("\n[bold nexus.value]Index Statistics:[/bold nexus.value]")
             console.print(
-                f"  Total indexed files: [nexus.success]{stats['indexed_files']}[/nexus.success]"
+                f"  Total indexed files: [nexus.success]{stats.get('total_files', stats.get('indexed_files', 0))}[/nexus.success]"
             )
-            console.print(f"  Total chunks: [nexus.success]{stats['total_chunks']}[/nexus.success]")
+            console.print(
+                f"  Total chunks: [nexus.success]{stats.get('total_chunks', 0)}[/nexus.success]"
+            )
 
             nx.close()
         except Exception as e:

--- a/tests/unit/bricks/search/test_daemon_backend_routing.py
+++ b/tests/unit/bricks/search/test_daemon_backend_routing.py
@@ -1,0 +1,68 @@
+"""SearchDaemon routing regressions for post-#3699 backends."""
+
+from __future__ import annotations
+
+from types import MethodType
+from typing import Any
+
+import pytest
+
+
+def _daemon_with_backend_result(search_type_seen: list[str]):
+    from nexus.bricks.search.daemon import SearchDaemon, SearchResult
+
+    daemon = SearchDaemon.__new__(SearchDaemon)
+    daemon._initialized = True
+    daemon._fts_backend = object()
+    daemon._vector_backend = object()
+    daemon._permission_enforcer = None
+    daemon.last_search_timing = {}
+
+    def _track_latency(self, latency_ms: float) -> None:
+        self._last_latency_ms = latency_ms
+
+    async def _attach_path_contexts(self, results: list[SearchResult], *, zone_id: str) -> None:
+        self._last_context_zone = zone_id
+
+    async def _search_via_backends(self, *args: Any, **kwargs: Any) -> list[SearchResult]:
+        search_type_seen.append(kwargs["search_type"])
+        return [
+            SearchResult(
+                path="/backend.md",
+                chunk_text="backend result",
+                score=10.0,
+                chunk_index=0,
+                search_type=kwargs["search_type"],
+            )
+        ]
+
+    async def _keyword_search(self, *args: Any, **kwargs: Any) -> list[SearchResult]:
+        raise AssertionError("legacy keyword path should not run before new backends")
+
+    daemon._track_latency = MethodType(_track_latency, daemon)
+    daemon._attach_path_contexts = MethodType(_attach_path_contexts, daemon)
+    daemon._search_via_backends = MethodType(_search_via_backends, daemon)
+    daemon._keyword_search = MethodType(_keyword_search, daemon)
+    return daemon
+
+
+@pytest.mark.asyncio
+async def test_keyword_search_prefers_new_fts_backend_before_legacy_keyword_stack():
+    seen: list[str] = []
+    daemon = _daemon_with_backend_result(seen)
+
+    results = await daemon.search("Nexus Core", search_type="keyword", limit=1, zone_id="root")
+
+    assert seen == ["keyword"]
+    assert [result.path for result in results] == ["/backend.md"]
+
+
+@pytest.mark.asyncio
+async def test_hybrid_search_does_not_prefetch_legacy_keyword_when_backends_exist():
+    seen: list[str] = []
+    daemon = _daemon_with_backend_result(seen)
+
+    results = await daemon.search("Nexus Core", search_type="hybrid", limit=1, zone_id="root")
+
+    assert seen == ["hybrid"]
+    assert [result.path for result in results] == ["/backend.md"]

--- a/tests/unit/bricks/search/test_pg_fts_backend.py
+++ b/tests/unit/bricks/search/test_pg_fts_backend.py
@@ -22,9 +22,10 @@ import os
 import pytest
 import pytest_asyncio
 from sqlalchemy import text
+from sqlalchemy.exc import ProgrammingError
 from sqlalchemy.ext.asyncio import AsyncEngine, create_async_engine
 
-from nexus.bricks.search.pg_fts_backend import PgFtsBackend
+from nexus.bricks.search.pg_fts_backend import PgFtsBackend, _native_fts_query
 from nexus.bricks.search.protocols import SearchBackend
 
 # ---------------------------------------------------------------------------
@@ -178,6 +179,251 @@ def test_satisfies_protocol():
     mock_engine = MagicMock(spec=AsyncEngine)
     b = PgFtsBackend(engine=mock_engine)
     assert isinstance(b, SearchBackend)
+
+
+class _FakeMappingResult:
+    def __init__(self, rows: list[dict] | None = None, scalar_value: bool | None = None):
+        self._rows = rows or []
+        self._scalar_value = scalar_value
+
+    def mappings(self):
+        return self
+
+    def all(self):
+        return self._rows
+
+    def scalar(self):
+        return self._scalar_value
+
+
+class _FakeConn:
+    def __init__(self, *, bm25_error: Exception | None = None, has_bm25: bool = False):
+        self.bm25_error = bm25_error
+        self.has_bm25 = has_bm25
+        self.calls: list[str] = []
+        self.params: list[dict] = []
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, exc_type, exc, tb):
+        return False
+
+    async def execute(self, statement, params=None):
+        sql = str(statement)
+        self.calls.append(sql)
+        self.params.append(params or {})
+        if "FROM pg_am" in sql:
+            return _FakeMappingResult(scalar_value=self.has_bm25)
+        if "paradedb.score" in sql:
+            if self.bm25_error is not None:
+                raise self.bm25_error
+            return _FakeMappingResult(
+                [
+                    {
+                        "path": "/workspace/demo/herb/products/prod-001.md",
+                        "chunk_text": "Nexus Core pricing is usage-based",
+                        "score": 10.0,
+                        "chunk_index": 0,
+                    }
+                ]
+            )
+        if "string_agg" in sql:
+            return _FakeMappingResult(
+                [
+                    {
+                        "path": "/workspace/demo/herb/products/prod-001.md",
+                        "page_text": "Nexus Core pricing is usage-based",
+                        "score": 0.75,
+                    }
+                ]
+            )
+        return _FakeMappingResult(
+            [
+                {
+                    "path": "/workspace/demo/herb/products/prod-001.md",
+                    "chunk_text": "Nexus Core pricing is usage-based",
+                    "score": 0.75,
+                    "chunk_index": 0,
+                }
+            ]
+        )
+
+
+class _FakeEngine:
+    def __init__(self, conn: _FakeConn):
+        self.conn = conn
+
+    def connect(self):
+        return self.conn
+
+
+def test_native_fts_query_uses_or_terms_for_question_recall():
+    assert (
+        _native_fts_query("Who is the staff engineer working on semantic search quality?")
+        == "staff | engineer | working | semantic | search | quality"
+    )
+
+
+@pytest.mark.asyncio
+async def test_startup_disables_bm25_when_pg_extension_is_absent():
+    conn = _FakeConn(has_bm25=False)
+    backend = PgFtsBackend(engine=_FakeEngine(conn))
+
+    await backend.startup()
+    hits = await backend.keyword_search("Nexus Core", "/workspace/demo/herb", k=5, zone_id="root")
+
+    assert backend._bm25_available is False
+    assert [h.path for h in hits] == ["/workspace/demo/herb/products/prod-001.md"]
+    assert not any("paradedb.score" in sql for sql in conn.calls)
+    assert any("to_tsquery('english', :fts_query)" in sql for sql in conn.calls)
+    assert conn.params[-1]["fts_query"] == "nexus | core"
+
+
+@pytest.mark.asyncio
+async def test_keyword_search_falls_back_to_native_fts_when_bm25_query_fails():
+    bm25_error = ProgrammingError(
+        "SELECT paradedb.score(chunk_id)",
+        {},
+        Exception('schema "paradedb" does not exist'),
+    )
+    conn = _FakeConn(bm25_error=bm25_error)
+    backend = PgFtsBackend(engine=_FakeEngine(conn))
+
+    hits = await backend.keyword_search("Nexus Core", "/workspace/demo/herb", k=5, zone_id="root")
+    second_hits = await backend.keyword_search(
+        "Nexus Core", "/workspace/demo/herb", k=5, zone_id="root"
+    )
+
+    assert [h.path for h in hits] == ["/workspace/demo/herb/products/prod-001.md"]
+    assert [h.path for h in second_hits] == ["/workspace/demo/herb/products/prod-001.md"]
+    assert backend._bm25_available is False
+    assert sum("paradedb.score" in sql for sql in conn.calls) == 1
+    assert sum("to_tsquery('english', :fts_query)" in sql for sql in conn.calls) == 2
+
+
+@pytest.mark.asyncio
+async def test_keyword_search_keeps_unrelated_dbapi_errors_visible():
+    db_error = ProgrammingError(
+        "SELECT paradedb.score(chunk_id)",
+        {},
+        Exception("connection lost while executing query"),
+    )
+    conn = _FakeConn(bm25_error=db_error)
+    backend = PgFtsBackend(engine=_FakeEngine(conn))
+
+    with pytest.raises(ProgrammingError):
+        await backend.keyword_search("Nexus Core", "/workspace/demo/herb", k=5, zone_id="root")
+
+
+@pytest.mark.asyncio
+async def test_keyword_search_pages_uses_native_page_search_without_bm25():
+    conn = _FakeConn(has_bm25=False)
+    backend = PgFtsBackend(engine=_FakeEngine(conn))
+    await backend.startup()
+
+    hits = await backend.keyword_search_pages(
+        "What is the pricing model for Nexus Core?",
+        "/workspace/demo/herb",
+        k=5,
+        zone_id="root",
+    )
+
+    assert [h.path for h in hits] == ["/workspace/demo/herb/products/prod-001.md"]
+    assert hits[0].chunk_text == "Nexus Core pricing is usage-based"
+    assert not any("paradedb.score" in sql for sql in conn.calls)
+    assert any("string_agg" in sql and "ts_rank_cd" in sql for sql in conn.calls)
+
+
+@pytest.mark.asyncio
+async def test_native_fts_live_postgres_herb_quality_without_bm25():
+    """Live plain-Postgres regression for the Docker Publish smoke gate."""
+    url = _get_pg_url()
+    if not url:
+        pytest.skip(
+            "No Postgres URL configured. Set NEXUS_TEST_DATABASE_URL to run live native FTS test."
+        )
+
+    from nexus.cli.commands.demo_data import HERB_CORPUS, HERB_QA_SET
+
+    engine = create_async_engine(url, echo=False)
+    try:
+        async with engine.begin() as conn:
+            await conn.execute(text("DROP TABLE IF EXISTS document_chunks"))
+            await conn.execute(text("DROP TABLE IF EXISTS file_paths"))
+            await conn.execute(
+                text("""
+                CREATE TABLE file_paths (
+                    path_id     TEXT PRIMARY KEY,
+                    zone_id     TEXT NOT NULL,
+                    virtual_path TEXT NOT NULL,
+                    deleted_at  TIMESTAMPTZ,
+                    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+                )
+                """)
+            )
+            await conn.execute(
+                text("""
+                CREATE TABLE document_chunks (
+                    chunk_id     TEXT PRIMARY KEY,
+                    path_id      TEXT NOT NULL REFERENCES file_paths(path_id) ON DELETE CASCADE,
+                    chunk_index  INTEGER NOT NULL,
+                    chunk_text   TEXT NOT NULL,
+                    chunk_tokens INTEGER NOT NULL,
+                    created_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+                )
+                """)
+            )
+            for idx, (path, content, _description) in enumerate(HERB_CORPUS):
+                path_id = f"path-{idx}"
+                await conn.execute(
+                    text("""
+                    INSERT INTO file_paths (path_id, zone_id, virtual_path, deleted_at)
+                    VALUES (:path_id, 'root', :path, NULL)
+                    """),
+                    {"path_id": path_id, "path": path},
+                )
+                await conn.execute(
+                    text("""
+                    INSERT INTO document_chunks
+                        (chunk_id, path_id, chunk_index, chunk_text, chunk_tokens)
+                    VALUES (:chunk_id, :path_id, 0, :content, :tokens)
+                    """),
+                    {
+                        "chunk_id": f"chunk-{idx}",
+                        "path_id": path_id,
+                        "content": content,
+                        "tokens": len(content.split()),
+                    },
+                )
+
+        backend = PgFtsBackend(engine)
+        await backend.startup()
+        backend._bm25_available = False
+
+        readiness = await backend.keyword_search_pages(
+            "Nexus Core",
+            "/workspace/demo/herb",
+            k=1,
+            zone_id="root",
+        )
+        assert [result.path for result in readiness] == [
+            "/workspace/demo/herb/products/prod-001.md"
+        ]
+
+        hits = 0
+        for qa in HERB_QA_SET:
+            results = await backend.keyword_search_pages(
+                qa["question"],
+                "/workspace/demo/herb",
+                k=5,
+                zone_id="root",
+            )
+            hits += int(qa["expected_file"] in {result.path for result in results})
+
+        assert hits >= 7
+    finally:
+        await engine.dispose()
 
 
 @pytest.mark.asyncio

--- a/tests/unit/cli/test_search_index_cli.py
+++ b/tests/unit/cli/test_search_index_cli.py
@@ -1,0 +1,44 @@
+from unittest.mock import MagicMock
+
+import pytest
+from click.testing import CliRunner
+
+from nexus.cli.commands import search as search_module
+from nexus.cli.commands.search import search_index
+
+
+@pytest.fixture(autouse=True)
+def _disable_auto_json(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEXUS_NO_AUTO_JSON", "1")
+
+
+def test_search_index_accepts_daemon_stats_total_files(monkeypatch: pytest.MonkeyPatch) -> None:
+    search_svc = MagicMock()
+    search_svc.semantic_search_index.return_value = {
+        "indexed": {"/workspace/demo/README.md": 3},
+        "total_chunks": 3,
+    }
+    search_svc.semantic_search_stats.return_value = {
+        "backend": "PgFtsBackend",
+        "total_files": 1,
+        "total_chunks": 3,
+    }
+
+    nx = MagicMock()
+    nx.service.return_value = search_svc
+
+    async def _get_filesystem(remote_url: str | None, remote_api_key: str | None):
+        return nx
+
+    monkeypatch.setattr(search_module, "get_filesystem", _get_filesystem)
+
+    result = CliRunner().invoke(
+        search_index,
+        ["/workspace/demo", "--remote-url", "http://127.0.0.1:2026", "--remote-api-key", "k"],
+        catch_exceptions=False,
+    )
+
+    assert result.exit_code == 0
+    assert "Files indexed:" in result.output
+    assert "Total indexed files:" in result.output
+    nx.close.assert_called_once()


### PR DESCRIPTION
## Summary
- Add a native PostgreSQL FTS fallback for `PgFtsBackend` when the Docker Publish database (`pgvector/pgvector:pg16`) does not provide `pg_search` / `pg_textsearch` BM25 operators.
- Route keyword and hybrid searches through the new post-#3699 search backends instead of letting the legacy keyword path override fallback ranking.
- Make Docker build-perf auto-index probes request keyword mode explicitly in the bm25-only Docker stack.
- Fix `nexus search index` stats rendering so daemon-backed stats without `indexed_files` do not turn successful indexing into a CLI error.

## Root Cause
Docker Publish starts Nexus against `pgvector/pgvector:pg16`, which has pgvector but not ParadeDB/`pg_textsearch`. The BM25 backend therefore needed a native Postgres FTS fallback that preserves HERB quality for keyword/hybrid retrieval in that stack.

## Validation
- `uv run pytest tests/unit/cli/test_search_index_cli.py tests/unit/bricks/search/test_daemon_backend_routing.py tests/unit/bricks/search/test_pg_fts_backend.py -q`
- `uvx ruff check src/nexus/bricks/search/pg_fts_backend.py src/nexus/bricks/search/daemon.py src/nexus/cli/commands/search.py tests/unit/bricks/search/test_pg_fts_backend.py tests/unit/bricks/search/test_daemon_backend_routing.py tests/unit/cli/test_search_index_cli.py scripts/test_build_perf_e2e.py alembic/versions/add_pg_textsearch_bm25_index.py`
- `uvx ruff format --check src/nexus/bricks/search/pg_fts_backend.py src/nexus/bricks/search/daemon.py src/nexus/cli/commands/search.py tests/unit/bricks/search/test_pg_fts_backend.py tests/unit/bricks/search/test_daemon_backend_routing.py tests/unit/cli/test_search_index_cli.py scripts/test_build_perf_e2e.py alembic/versions/add_pg_textsearch_bm25_index.py`
- Live `pgvector/pgvector:pg16` regression: `......ssss. [100%]`
- `docker build -t nexus:pgfts-fallback .`
- Fresh local Nexus + `pgvector/pgvector:pg16` Docker smoke: `HERB hit rate 8/8 >= 90%` and `RESULTS: 22 passed, 0 failed`
