### PR TITLE
[codex] Fix develop CI setup and slim wheel dependency

### DIFF
--- a/.github/workflows/demo-memory.yml
+++ b/.github/workflows/demo-memory.yml
@@ -29,6 +29,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
+
 jobs:
   demo-memory:
     name: nexusd demo idle RSS <= 450 MB

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,9 @@ on:
     branches: [main, develop]
   workflow_dispatch:
 
+env:
+  PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
+
 permissions:
   contents: read
   pages: write
@@ -26,7 +29,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3
@@ -35,7 +38,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
 
       - name: Create virtual environment
-        run: uv venv --python 3.13
+        run: uv venv --python 3.14
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test-health.yml
+++ b/.github/workflows/test-health.yml
@@ -5,6 +5,9 @@ on:
     - cron: '0 9 * * 1'  # Monday 9am UTC
   workflow_dispatch:       # Manual trigger
 
+env:
+  PYO3_USE_ABI3_FORWARD_COMPATIBILITY: "1"
+
 concurrency:
   group: test-health-${{ github.ref }}
   cancel-in-progress: true
@@ -20,7 +23,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v5
         with:
-          python-version: "3.13"
+          python-version: "3.14"
 
       - name: Install uv
         uses: astral-sh/setup-uv@v3
@@ -29,7 +32,7 @@ jobs:
           cache-dependency-glob: "pyproject.toml"
 
       - name: Create virtual environment
-        run: uv venv --python 3.13
+        run: uv venv --python 3.14
 
       - name: Build Rust extensions
         uses: ./.github/actions/build-rust-extensions

--- a/packages/nexus-fs/pyproject.toml
+++ b/packages/nexus-fs/pyproject.toml
@@ -43,6 +43,8 @@ dependencies = [
     "platformdirs>=4.0",
     "cryptography>=41.0",
     "httpx>=0.28",
+    # nexus.core imports nexus.lib.io_metrics for read/write/cache counters.
+    "prometheus-client>=0.20.0",
     # Rust kernel (PyKernel + Rust-accelerated primitives). Required at runtime;
     # NexusFS.sys_* and metastore both go through nexus_runtime.PyKernel.
     "nexus-runtime>=0.10,<0.11",
@@ -176,7 +178,7 @@ exclude = [
 #   - postgres_profile_store.py, postgres_migrate.py (server-only SQLAlchemy)
 #   - providers/ subtree (database_key.py, oidc.py import sqlalchemy at top level)
 #   - cache.py (imports cachetools, not a slim dep; not imported by connectors)
-#   - consumer_metrics.py (imports prometheus_client, not a slim dep; not imported by connectors)
+#   - consumer_metrics.py (not imported by connectors)
 "../../src/nexus/bricks/__init__.py" = "nexus/bricks/__init__.py"
 # Ship a slim stub instead of the full search/__init__.py — the real one eagerly
 # imports chunking/search_service/etc. which are excluded from the slim wheel.

--- a/tests/integration/slim/test_slim_wheel_contents.py
+++ b/tests/integration/slim/test_slim_wheel_contents.py
@@ -145,3 +145,16 @@ def test_slim_wheel_nexus_runtime_dep(slim_wheel: Path) -> None:
         "Found Requires-Dist lines:\n"
         + "\n".join(line for line in meta.splitlines() if "Requires-Dist" in line)
     )
+
+
+def test_slim_wheel_prometheus_client_dep(slim_wheel: Path) -> None:
+    """The METADATA must declare prometheus-client for shipped io_metrics imports."""
+    with zipfile.ZipFile(slim_wheel) as zf:
+        meta_files = [n for n in zf.namelist() if n.endswith("METADATA")]
+        assert meta_files, f"no METADATA in {slim_wheel}"
+        meta = zf.read(meta_files[0]).decode("utf-8")
+    assert "Requires-Dist: prometheus-client" in meta, (
+        "slim wheel METADATA missing prometheus-client requirement.\n"
+        "Found Requires-Dist lines:\n"
+        + "\n".join(line for line in meta.splitlines() if "Requires-Dist" in line)
+    )


### PR DESCRIPTION
## Summary
- Move the Documentation workflow from Python 3.13 to Python 3.14 to match the project `requires-python >=3.14` declaration.
- Set `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1` in the Documentation and Demo Memory workflows so `pdf-inspector` can build through PyO3 under Python 3.14 when a wheel is unavailable.
- Apply the same Python 3.14 and PyO3 environment fix to the scheduled Test Health workflow, which had the same stale 3.13 install path.
- Add `prometheus-client` as a base `nexus-fs` slim wheel dependency and pin it with a wheel metadata regression test.

## Root Cause
Documentation was installing the project with Python 3.13 even though `pyproject.toml` now requires Python 3.14 or newer. Demo Memory reached Python 3.14, but dependency sync built `pdf-inspector` from sdist and hit the PyO3 Python 3.14 guard without the forward-compatibility environment variable already used by several other workflows.

The Slim Wheel Smoke failures came from the new `nexus.lib.io_metrics` module. The slim wheel ships `nexus/lib/**`, and `nexus.core.nexus_fs_content` imports `nexus.lib.io_metrics`; that module imports `prometheus_client`, but `nexus-fs` did not declare `prometheus-client` as a base runtime dependency.

## Validation
- `uv run --no-sync pytest tests/integration/slim/test_slim_wheel_contents.py::test_slim_wheel_nexus_runtime_dep tests/integration/slim/test_slim_wheel_contents.py::test_slim_wheel_prometheus_client_dep -q --override-ini=addopts=`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 uv sync --frozen --extra test`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 uv pip install --python /tmp/nexus-ci-docs-venv/bin/python -e ".[dev]"`
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 uv pip install --python /tmp/nexus-ci-docs-venv/bin/python -r packages/nexus-fs/requirements-docs.txt`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/docs.yml .github/workflows/demo-memory.yml .github/workflows/test-health.yml .github/workflows/slim-wheel-smoke.yml`
- `python3`/`tomllib` parse of `packages/nexus-fs/pyproject.toml` and root `pyproject.toml`
- `git diff --check`
- pre-commit hooks run by `git commit`

## Notes
The full local slim CRUD smoke could not complete without the CI-built `nexus-runtime` wheel in `NEXUS_RUNTIME_WHEEL_DIR`; CI builds that wheel before running the slim smoke matrix. The new metadata regression covers the missing dependency that caused both Ubuntu and macOS slim smoke failures.
