### PR TITLE
fix(search): resolve daemon engine via fallback strategies (#4074)

### DIFF
--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -949,16 +949,77 @@ class SearchDaemon:
     # Initialization Methods
     # =========================================================================
 
+    @staticmethod
+    def _resolve_injected_engine(factory: Any) -> tuple[Any, str]:
+        """Resolve the bound engine from an injected async_sessionmaker.
+
+        Issue #4074: the prior single-strategy lookup
+        (``factory.kw["bind"]``) silently returned ``None`` for some
+        factory shapes, leaving ``db_pool_ready=False`` forever and every
+        search request 500-ing. This walks several extraction paths in
+        order of cost:
+
+        1. ``factory.kw["bind"]`` — works for the canonical
+           ``async_sessionmaker(bind=engine, ...)`` shape.
+        2. ``getattr(factory, "bind", None)`` — covers wrappers that
+           expose ``.bind`` directly.
+        3. ``factory().bind`` — constructs a session synchronously
+           and reads its ``bind`` attribute. ``AsyncSession.__init__``
+           does not touch the network, and the ``bind`` attr returns
+           the original ``AsyncEngine`` (unlike ``session.get_bind()``
+           which proxies to the *sync* engine). Safe to run during
+           startup before the pool is warm.
+
+        Returns ``(engine, strategy_name)`` where ``engine`` is ``None``
+        if every strategy failed.
+        """
+        _kw = getattr(factory, "kw", None)
+        if isinstance(_kw, dict):
+            _bind = _kw.get("bind")
+            if _bind is not None:
+                return _bind, "kw['bind']"
+
+        _bind = getattr(factory, "bind", None)
+        if _bind is not None:
+            return _bind, "factory.bind"
+
+        try:
+            _session = factory()
+            _bind = getattr(_session, "bind", None)
+            if _bind is not None:
+                return _bind, "factory().bind"
+        except Exception as exc:  # pragma: no cover — defensive
+            logger.warning(
+                "factory() probe failed during engine resolution: %s",
+                exc,
+            )
+
+        return None, "none"
+
     async def _init_database_pool(self) -> None:
         """Initialize and warm the database connection pool."""
         # If session factory was injected via __init__, skip engine creation
         if self._async_session is not None:
             # Extract engine reference from the injected session factory
-            # so db_pool_ready reports correctly.
-            _bind = getattr(self._async_session, "kw", {}).get("bind")
-            if _bind is not None:
-                self._async_engine = _bind
-            logger.info("Using injected async_session_factory (RecordStoreABC)")
+            # so db_pool_ready reports correctly. Issue #4074: a single
+            # `kw["bind"]` lookup is fragile across SQLAlchemy versions and
+            # factory shapes — when extraction silently failed, the daemon
+            # left `_async_engine = None` and every subsequent search
+            # request errored with "SearchDaemon not initialized".
+            _bind, _strategy = self._resolve_injected_engine(self._async_session)
+            if _bind is None:
+                raise RuntimeError(
+                    "Injected async_session_factory present but engine "
+                    "could not be resolved. Construct the factory with "
+                    "`bind=engine` (or pass the engine positionally to "
+                    "async_sessionmaker), or set NEXUS_DATABASE_URL so the "
+                    "daemon owns its own engine."
+                )
+            self._async_engine = _bind
+            logger.info(
+                "Using injected async_session_factory (RecordStoreABC); engine resolved via %s",
+                _strategy,
+            )
             return
 
         if not self.config.database_url:

--- a/tests/unit/bricks/search/test_daemon_db_pool_init.py
+++ b/tests/unit/bricks/search/test_daemon_db_pool_init.py
@@ -1,0 +1,183 @@
+"""Regression tests for SearchDaemon engine extraction (Issue #4074).
+
+Before the fix, `_init_database_pool` extracted the SQLAlchemy engine via a
+single ``factory.kw["bind"]`` lookup. When that failed silently, the daemon
+left ``_async_engine = None`` and reported ``db_pool_ready: false`` forever
+while every search request 500-ed with "SearchDaemon not initialized".
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import pytest
+
+
+def _daemon_with_factory(factory: Any):
+    from nexus.bricks.search.daemon import DaemonConfig, SearchDaemon
+
+    daemon = SearchDaemon.__new__(SearchDaemon)
+    daemon.config = DaemonConfig()
+    daemon._async_session = factory
+    daemon._async_engine = None
+    daemon._record_store = None
+    daemon._owns_engine = False
+    return daemon
+
+
+def test_resolve_via_kw_bind():
+    from nexus.bricks.search.daemon import SearchDaemon
+
+    sentinel = object()
+
+    class Factory:
+        kw = {"bind": sentinel}
+
+    bind, strategy = SearchDaemon._resolve_injected_engine(Factory())
+    assert bind is sentinel
+    assert strategy == "kw['bind']"
+
+
+def test_resolve_via_factory_bind_attr_when_kw_missing_bind():
+    """Fallback when factory.kw exists but does not contain 'bind'."""
+    from nexus.bricks.search.daemon import SearchDaemon
+
+    sentinel = object()
+
+    class Factory:
+        kw: dict = {}  # bind absent
+        bind = sentinel
+
+    bind, strategy = SearchDaemon._resolve_injected_engine(Factory())
+    assert bind is sentinel
+    assert strategy == "factory.bind"
+
+
+def test_resolve_via_session_bind_when_attrs_missing():
+    """Last-resort: construct a session and read its `bind` attr.
+
+    Note we read ``session.bind`` (the original AsyncEngine), not
+    ``session.get_bind()`` which proxies to the sync Engine.
+    """
+    from nexus.bricks.search.daemon import SearchDaemon
+
+    sentinel = object()
+
+    class _Session:
+        bind = sentinel
+
+    class Factory:
+        # No `kw`, no `bind` attr — must fall back to factory().bind
+        def __call__(self):
+            return _Session()
+
+    bind, strategy = SearchDaemon._resolve_injected_engine(Factory())
+    assert bind is sentinel
+    assert strategy == "factory().bind"
+
+
+def test_resolve_returns_none_when_all_strategies_fail():
+    from nexus.bricks.search.daemon import SearchDaemon
+
+    class Factory:
+        kw: dict = {}
+
+        def __call__(self):
+            raise RuntimeError("cannot construct session")
+
+    bind, strategy = SearchDaemon._resolve_injected_engine(Factory())
+    assert bind is None
+    assert strategy == "none"
+
+
+def test_resolve_skips_kw_bind_when_value_is_none():
+    """If kw['bind'] is None, must fall through, not return None as success."""
+    from nexus.bricks.search.daemon import SearchDaemon
+
+    sentinel = object()
+
+    class Factory:
+        kw = {"bind": None}
+        bind = sentinel
+
+    bind, strategy = SearchDaemon._resolve_injected_engine(Factory())
+    assert bind is sentinel
+    assert strategy == "factory.bind"
+
+
+@pytest.mark.asyncio
+async def test_init_database_pool_assigns_engine_from_kw_bind():
+    """The canonical async_sessionmaker(bind=engine) path still works."""
+    sentinel = object()
+
+    class Factory:
+        kw = {"bind": sentinel}
+
+    daemon = _daemon_with_factory(Factory())
+    await daemon._init_database_pool()
+
+    assert daemon._async_engine is sentinel
+
+
+@pytest.mark.asyncio
+async def test_init_database_pool_assigns_engine_via_session_fallback():
+    """When kw['bind'] is missing, the session fallback succeeds."""
+    sentinel = object()
+
+    class _Session:
+        bind = sentinel
+
+    class Factory:
+        # kw absent entirely (some custom factories don't expose it)
+        def __call__(self):
+            return _Session()
+
+    daemon = _daemon_with_factory(Factory())
+    await daemon._init_database_pool()
+
+    assert daemon._async_engine is sentinel
+
+
+@pytest.mark.asyncio
+async def test_init_database_pool_with_real_async_sessionmaker():
+    """End-to-end with a real SQLAlchemy async_sessionmaker.
+
+    Locks the canonical path — the daemon must extract the AsyncEngine
+    (not the proxied sync Engine) so downstream ``await engine.connect()``
+    calls work.
+    """
+    from sqlalchemy.ext.asyncio import (
+        AsyncEngine,
+        AsyncSession,
+        async_sessionmaker,
+        create_async_engine,
+    )
+
+    engine = create_async_engine("sqlite+aiosqlite:///:memory:")
+    factory = async_sessionmaker(engine, class_=AsyncSession, expire_on_commit=False)
+
+    daemon = _daemon_with_factory(factory)
+    await daemon._init_database_pool()
+
+    assert daemon._async_engine is engine
+    assert isinstance(daemon._async_engine, AsyncEngine)
+
+    await engine.dispose()
+
+
+@pytest.mark.asyncio
+async def test_init_database_pool_raises_when_engine_unresolvable():
+    """Loud failure when no extraction strategy works (Issue #4074)."""
+
+    class Factory:
+        kw: dict = {}
+
+        def __call__(self):
+            raise RuntimeError("no session for you")
+
+    daemon = _daemon_with_factory(Factory())
+
+    with pytest.raises(RuntimeError, match="engine could not be resolved"):
+        await daemon._init_database_pool()
+
+    assert daemon._async_engine is None


### PR DESCRIPTION
## Summary

Closes #4074.

When the search daemon was given an injected ``async_session_factory`` (the path used in production), engine extraction relied on a single ``factory.kw[\"bind\"]`` lookup. When that returned ``None`` for any reason, the daemon silently left ``_async_engine = None``, reported ``db_pool_ready: false`` forever, and 500-ed every search request with ``SearchDaemon not initialized``.

This swaps the lookup for a 3-strategy resolver and converts the silent-degraded path into a loud failure:

1. ``factory.kw[\"bind\"]`` — canonical ``async_sessionmaker`` shape
2. ``getattr(factory, \"bind\", None)`` — wrapper shapes
3. ``factory().bind`` — last resort. Constructs a session synchronously (no DB I/O — ``AsyncSession.__init__`` does not touch the network) and reads its ``bind`` attr. We deliberately use ``session.bind`` (the ``AsyncEngine``) and not ``session.get_bind()`` (which proxies to the *sync* ``Engine`` and would break downstream ``await engine.connect()`` calls).

If every strategy fails, the daemon raises a ``RuntimeError`` with an actionable message instead of leaving the engine null. A daemon with no DB pool serves no traffic; crashing fast lets the orchestrator restart and surfaces the fault to operators immediately.

The third strategy reported as hanging in the issue is sidestepped by avoiding the ``async with factory()`` form — sync ``factory()`` + sync ``.bind`` does not enter the async context manager, so no startup race against pool warmup.

## Test plan
- [x] 9 new unit tests in ``tests/unit/bricks/search/test_daemon_db_pool_init.py`` covering each strategy, the AsyncEngine vs sync Engine distinction, the loud-raise path, and end-to-end with a real SQLAlchemy ``async_sessionmaker``.
- [x] Full ``tests/unit/bricks/search/`` suite green.
- [x] Booted the patched image via ``nexus up --build`` (demo preset). Health endpoint reports ``db_pool_ready: true``, ``daemon_initialized: true``.
- [x] ``scripts/test_build_perf_e2e.py`` against the running stack: **25/25 passed, 0 failed** (HERB hit rate 8/8, permission-filtered search, auto-index on edit, delete propagation, RPC latency p50=1ms).