### PR TITLE
chore(cdylib): bump sudocode rev to PR#119 (sys_watch condvar)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2111,7 +2111,7 @@ dependencies = [
 [[package]]
 name = "nexus-vfs-client"
 version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=140e5ac#140e5ac309e9bde7d8bd10b3653b75007cebfb47"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=7c24866#7c24866557c1c1078a899c9dbc4534f65a2e2755"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -2319,7 +2319,7 @@ dependencies = [
 [[package]]
 name = "plugins"
 version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=140e5ac#140e5ac309e9bde7d8bd10b3653b75007cebfb47"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=7c24866#7c24866557c1c1078a899c9dbc4534f65a2e2755"
 dependencies = [
  "serde",
  "serde_json",
@@ -3071,7 +3071,7 @@ dependencies = [
 [[package]]
 name = "runtime"
 version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=140e5ac#140e5ac309e9bde7d8bd10b3653b75007cebfb47"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=7c24866#7c24866557c1c1078a899c9dbc4534f65a2e2755"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -3641,7 +3641,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 [[package]]
 name = "telemetry"
 version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=140e5ac#140e5ac309e9bde7d8bd10b3653b75007cebfb47"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=7c24866#7c24866557c1c1078a899c9dbc4534f65a2e2755"
 dependencies = [
  "serde",
  "serde_json",

--- a/rust/nexus-cdylib/Cargo.toml
+++ b/rust/nexus-cdylib/Cargo.toml
@@ -63,9 +63,7 @@ pyo3 = { version = "0.27.2", features = ["extension-module"] }
 # (sudocode branch HEAD `2b67d5b`) stays reachable in git history
 # even after sudocode merges, so re-pinning is optional for
 # correctness — only matters for reproducibility audit.
-# Pin to sudocode PR#100 merge — introduces FsBackend trait, spawn_task v2
-# (ConversationRuntime integration), and renames the v1 echo scaffolding
-# to `spawn_task_echo`. Adapter below uses `spawn_task_echo` as the
-# interim body until ApiClient/ToolExecutor factories are wired
-# (tracked as spawn_task v2 full integration).
-sudocode-runtime = { package = "runtime", git = "https://github.com/sudoprivacy/sudocode", rev = "140e5ac" }
+# Pin to sudocode PR#119 merge — spawn_task_echo now uses sys_watch
+# condvar blocking instead of 50ms busy-poll. Near-zero idle CPU,
+# sub-millisecond wake latency on new mailbox data.
+sudocode-runtime = { package = "runtime", git = "https://github.com/sudoprivacy/sudocode", rev = "7c24866" }


### PR DESCRIPTION
## Summary

- Bump `sudocode-runtime` rev from `140e5ac` → `7c24866` (sudoprivacy/sudocode#119 merge)
- `spawn_task_echo` now uses `kernel.sys_watch()` condvar blocking instead of `thread::sleep(50ms)` busy-poll

## Test plan

- [x] `cargo check -p nexus-cdylib` — compiles against new rev

🤖 Generated with [Claude Code](https://claude.com/claude-code)