### PR TITLE
[codex] Add Nexus I/O observability foundation

### DIFF
--- a/docs/operations/nexus-io-observability.md
+++ b/docs/operations/nexus-io-observability.md
@@ -1,0 +1,85 @@
+# Nexus I/O Observability
+
+Issue #4062 adds a shared metrics surface for read, write, cache, ETag, prefetch, batching, coalescing, generation, and FUSE passthrough work.
+
+## Scrape Targets
+
+The FastAPI server exposes Python process metrics at `/metrics`.
+
+The standalone `nexus-fuse` binary exposes FUSE process metrics when started with:
+
+```bash
+nexus-fuse mount /mnt/nexus --url http://localhost:2026 --api-key-file ./key --metrics-addr 127.0.0.1:9464
+```
+
+or:
+
+```bash
+NEXUS_FUSE_METRICS_ADDR=127.0.0.1:9464 nexus-fuse mount /mnt/nexus --url http://localhost:2026 --api-key-file ./key
+```
+
+Prometheus should scrape both targets when both processes are running.
+
+The same `--metrics-addr` flag and `NEXUS_FUSE_METRICS_ADDR` environment variable also work for the `daemon` subcommand.
+
+For the repository Docker observability stack, scrape the API through the Compose service DNS name `nexus-server:2026`. Use `localhost:2026` only when Prometheus runs on the host next to a host-run Nexus API process.
+
+For containerized Prometheus deployments, 127.0.0.1:9464 must be reachable from the Prometheus process or container. If Prometheus runs outside the FUSE process namespace, bind the FUSE metrics listener to a reachable interface and scrape that address instead.
+
+Example scrape jobs:
+
+```yaml
+scrape_configs:
+  - job_name: nexus-api
+    metrics_path: /metrics
+    static_configs:
+      - targets: ["nexus-server:2026"]
+
+  - job_name: nexus-fuse
+    static_configs:
+      - targets: ["127.0.0.1:9464"]
+```
+
+## Metric Questions
+
+| Metric | Question |
+| --- | --- |
+| `nexus_cache_requests_total{tier,result}` | Are reads hitting cache or falling through? |
+| `nexus_cache_hit_ratio{tier}` | Is each cache tier healthy when native cache stats are available? |
+| `nexus_cache_evictions_total{tier,reason}` | Why is cache capacity turning over? |
+| `nexus_cache_bytes_in_use{tier}` | How full is the cache? |
+| `nexus_cache_admission_rejected_total` | Is the admission filter protecting the disk tier? |
+| `nexus_cache_etag_revalidate_total{result}` | Are stale cache entries cheaply revalidating? |
+| `nexus_prefetch_issued_bytes_total` | How much data did prefetch request? |
+| `nexus_prefetch_used_bytes_total` | How much prefetched data was consumed? |
+| `nexus_prefetch_wasted_bytes_total` | How much prefetched data was evicted before use? |
+| `nexus_prefetch_window_size{mount,workspace}` | What bounded-scope prefetch window is active? |
+| `nexus_prefetch_pattern_detected_total{pattern}` | What access patterns are being detected? |
+| `nexus_read_latency_seconds{tier}` | Where is read latency spent? |
+| `nexus_read_bytes_total{tier}` | How much data is served by each tier? |
+| `nexus_read_batch_size` | Are callers using batch reads effectively? |
+| `nexus_fuse_passthrough_used_total` | Is large-read passthrough active? |
+| `nexus_write_coalesce_flush_total{trigger}` | Why are buffered writes flushing? |
+| `nexus_write_coalesce_dirty_bytes` | How many bytes are at durability risk? |
+| `nexus_write_backend_rpc_total` | Did coalescing reduce backend write calls? |
+| `nexus_generation_mismatch_total` | Are cached entries invalidated by generation drift? |
+| `nexus_etag_check_total{result}` | Are ETag checks succeeding, updating, or failing? |
+
+## Label Discipline
+
+Labels are intentionally bounded. Paths, content IDs, ETags, user IDs, and raw file handles are not Prometheus labels. Use structured logs for per-path or per-handle debugging.
+
+`nexus_prefetch_window_size` uses bounded `mount` and `workspace` labels. Until future prefetch work provides bounded operational scopes, these labels default to `default`.
+
+## Current Sources
+
+The foundation slice emits real data for:
+
+- Python read latency and bytes from `NexusFSContent.sys_read`.
+- Python batch size and batch bytes from `NexusFSContent.read_batch`.
+- Python backend write RPC count from `NexusFSContent.sys_write` and `_write_locked`.
+- FUSE SQLite cache hit, miss, stale, and bytes-in-use metrics.
+- FUSE ETag revalidation and ETag check metrics.
+- FUSE read latency, read bytes, and backend write RPC count.
+
+Prefetch, coalescing, generation mismatch, foyer native stats, and passthrough metrics remain zero or absent until their labeled series are first observed or their feature call sites land.

--- a/docs/superpowers/plans/2026-05-07-issue-4062-observability-foundation.md
+++ b/docs/superpowers/plans/2026-05-07-issue-4062-observability-foundation.md
@@ -1,0 +1,1964 @@
+# Issue 4062 Observability Foundation Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Build the #4062 foundation metrics surface for current read, write, batch, SQLite cache, and ETag paths, while defining stable Prometheus recorders for future foyer, prefetch, coalescing, generation, and passthrough work.
+
+**Architecture:** Add a Python Prometheus catalog in `src/nexus/lib/io_metrics.py` and instrument the existing Python I/O wrapper at `src/nexus/core/nexus_fs_content.py`. Add a standalone `nexus-fuse` metrics module and metrics HTTP endpoint so the separate FUSE binary can be scraped independently. Add operator docs and a Grafana dashboard using the same metric names.
+
+**Tech Stack:** Python 3.14, `prometheus_client`, pytest, Rust stable, `nexus-fuse` standalone Cargo crate, stdlib TCP listener for Prometheus text exposition, Grafana JSON provisioning.
+
+---
+
+## File Structure
+
+Create:
+
+- `src/nexus/lib/io_metrics.py`: Prometheus collectors and bounded recorder functions for I/O metrics.
+- `tests/unit/services/test_io_metrics.py`: Unit tests for every Python recorder.
+- `tests/integration/services/test_io_metrics_endpoint.py`: Scrape-level test that the catalog appears in Prometheus output.
+- `tests/unit/core/test_nexus_fs_content_metrics.py`: Python I/O wrapper instrumentation tests with a fake Rust kernel boundary.
+- `nexus-fuse/src/metrics.rs`: Standalone FUSE metrics state, Prometheus text renderer, and tiny HTTP server.
+- `nexus-fuse/tests/metrics_test.rs`: Unit tests for FUSE metrics rendering and HTTP exposition.
+- `docs/operations/nexus-io-observability.md`: Metric-to-question operator documentation.
+- `observability/grafana/provisioning/dashboards/nexus-io-observability.json`: Standard Grafana dashboard.
+
+Modify:
+
+- `src/nexus/core/nexus_fs_content.py`: Record read latency/bytes, batch sizes, batch bytes, and backend write RPCs.
+- `nexus-fuse/src/lib.rs`: Export `metrics`.
+- `nexus-fuse/src/main.rs`: Add `--metrics-addr` / `NEXUS_FUSE_METRICS_ADDR` to `mount` and `daemon`, start the metrics server when present.
+- `nexus-fuse/src/cache.rs`: Record SQLite cache hit/miss/stale and bytes-in-use metrics.
+- `nexus-fuse/src/fs.rs`: Record ETag, read, and write metrics; return read tier from `read_cached()`.
+
+## Task 1: Python Metrics Catalog
+
+**Files:**
+
+- Create: `src/nexus/lib/io_metrics.py`
+- Create: `tests/unit/services/test_io_metrics.py`
+- Create: `tests/integration/services/test_io_metrics_endpoint.py`
+
+- [ ] **Step 1: Write the failing unit tests**
+
+Create `tests/unit/services/test_io_metrics.py`:
+
+```python
+from __future__ import annotations
+
+from prometheus_client import REGISTRY
+
+from nexus.lib import io_metrics
+
+
+def _sample(name: str, **labels: str) -> float:
+    for family in REGISTRY.collect():
+        for sample in family.samples:
+            if sample.name == name and all(sample.labels.get(k) == v for k, v in labels.items()):
+                return float(sample.value)
+    return 0.0
+
+
+def test_record_cache_request_increments_bounded_counter() -> None:
+    before = _sample("nexus_cache_requests_total", tier="sqlite", result="hit")
+    io_metrics.record_cache_request("sqlite", "hit")
+    after = _sample("nexus_cache_requests_total", tier="sqlite", result="hit")
+    assert after == before + 1
+
+
+def test_unknown_cache_labels_collapse_to_other() -> None:
+    before = _sample("nexus_cache_requests_total", tier="other", result="other")
+    io_metrics.record_cache_request("tenant-123", "path-/secret")
+    after = _sample("nexus_cache_requests_total", tier="other", result="other")
+    assert after == before + 1
+
+
+def test_cache_gauges_and_future_counters_update() -> None:
+    io_metrics.set_cache_hit_ratio("sqlite", 0.75)
+    assert _sample("nexus_cache_hit_ratio", tier="sqlite") == 0.75
+
+    io_metrics.set_cache_bytes_in_use("sqlite", 1234)
+    assert _sample("nexus_cache_bytes_in_use", tier="sqlite") == 1234
+
+    before_evictions = _sample(
+        "nexus_cache_evictions_total", tier="sqlite", reason="capacity"
+    )
+    io_metrics.record_cache_eviction("sqlite", "capacity")
+    after_evictions = _sample(
+        "nexus_cache_evictions_total", tier="sqlite", reason="capacity"
+    )
+    assert after_evictions == before_evictions + 1
+
+    before_rejected = _sample("nexus_cache_admission_rejected_total")
+    io_metrics.record_cache_admission_rejected()
+    after_rejected = _sample("nexus_cache_admission_rejected_total")
+    assert after_rejected == before_rejected + 1
+
+
+def test_etag_recorders_update_expected_results() -> None:
+    before_revalidate = _sample("nexus_cache_etag_revalidate_total", result="304")
+    io_metrics.record_cache_etag_revalidate("304")
+    after_revalidate = _sample("nexus_cache_etag_revalidate_total", result="304")
+    assert after_revalidate == before_revalidate + 1
+
+    before_check = _sample("nexus_etag_check_total", result="updated")
+    io_metrics.record_etag_check("updated")
+    after_check = _sample("nexus_etag_check_total", result="updated")
+    assert after_check == before_check + 1
+
+
+def test_prefetch_recorders_update_bounded_metrics() -> None:
+    before_issued = _sample("nexus_prefetch_issued_bytes_total")
+    io_metrics.record_prefetch_issued(10)
+    assert _sample("nexus_prefetch_issued_bytes_total") == before_issued + 10
+
+    before_used = _sample("nexus_prefetch_used_bytes_total")
+    io_metrics.record_prefetch_used(7)
+    assert _sample("nexus_prefetch_used_bytes_total") == before_used + 7
+
+    before_wasted = _sample("nexus_prefetch_wasted_bytes_total")
+    io_metrics.record_prefetch_wasted(3)
+    assert _sample("nexus_prefetch_wasted_bytes_total") == before_wasted + 3
+
+    io_metrics.set_prefetch_window_size(4096, mount="root", workspace="default")
+    assert _sample("nexus_prefetch_window_size", mount="root", workspace="default") == 4096
+
+    before_pattern = _sample("nexus_prefetch_pattern_detected_total", pattern="sequential")
+    io_metrics.record_prefetch_pattern("sequential")
+    after_pattern = _sample("nexus_prefetch_pattern_detected_total", pattern="sequential")
+    assert after_pattern == before_pattern + 1
+
+
+def test_read_metrics_update_bytes_and_histogram_count() -> None:
+    before_bytes = _sample("nexus_read_bytes_total", tier="backend")
+    before_count = _sample("nexus_read_latency_seconds_count", tier="backend")
+    io_metrics.record_read(tier="backend", bytes_read=512, latency_seconds=0.005)
+    assert _sample("nexus_read_bytes_total", tier="backend") == before_bytes + 512
+    assert _sample("nexus_read_latency_seconds_count", tier="backend") == before_count + 1
+
+
+def test_batch_write_and_consistency_recorders_update() -> None:
+    before_batch = _sample("nexus_read_batch_size_count")
+    io_metrics.record_read_batch_size(4)
+    assert _sample("nexus_read_batch_size_count") == before_batch + 1
+
+    before_passthrough = _sample("nexus_fuse_passthrough_used_total")
+    io_metrics.record_fuse_passthrough_used()
+    assert _sample("nexus_fuse_passthrough_used_total") == before_passthrough + 1
+
+    before_flush = _sample("nexus_write_coalesce_flush_total", trigger="time")
+    io_metrics.record_write_coalesce_flush("time")
+    assert _sample("nexus_write_coalesce_flush_total", trigger="time") == before_flush + 1
+
+    io_metrics.set_write_coalesce_dirty_bytes(2048)
+    assert _sample("nexus_write_coalesce_dirty_bytes") == 2048
+
+    before_rpc = _sample("nexus_write_backend_rpc_total")
+    io_metrics.record_write_backend_rpc()
+    assert _sample("nexus_write_backend_rpc_total") == before_rpc + 1
+
+    before_mismatch = _sample("nexus_generation_mismatch_total")
+    io_metrics.record_generation_mismatch()
+    assert _sample("nexus_generation_mismatch_total") == before_mismatch + 1
+```
+
+Create `tests/integration/services/test_io_metrics_endpoint.py`:
+
+```python
+from __future__ import annotations
+
+from prometheus_client import generate_latest
+
+from nexus.lib import io_metrics
+
+
+def test_io_metrics_exposed_via_global_registry() -> None:
+    io_metrics.record_read(tier="backend", bytes_read=1, latency_seconds=0.001)
+    io_metrics.record_cache_request("sqlite", "hit")
+    io_metrics.record_write_backend_rpc()
+
+    body = generate_latest().decode()
+
+    expected_names = [
+        "nexus_cache_requests_total",
+        "nexus_cache_hit_ratio",
+        "nexus_cache_evictions_total",
+        "nexus_cache_bytes_in_use",
+        "nexus_cache_admission_rejected_total",
+        "nexus_cache_etag_revalidate_total",
+        "nexus_prefetch_issued_bytes_total",
+        "nexus_prefetch_used_bytes_total",
+        "nexus_prefetch_wasted_bytes_total",
+        "nexus_prefetch_window_size",
+        "nexus_prefetch_pattern_detected_total",
+        "nexus_read_latency_seconds",
+        "nexus_read_bytes_total",
+        "nexus_read_batch_size",
+        "nexus_fuse_passthrough_used_total",
+        "nexus_write_coalesce_flush_total",
+        "nexus_write_coalesce_dirty_bytes",
+        "nexus_write_backend_rpc_total",
+        "nexus_generation_mismatch_total",
+        "nexus_etag_check_total",
+    ]
+    for name in expected_names:
+        assert name in body
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pytest tests/unit/services/test_io_metrics.py tests/integration/services/test_io_metrics_endpoint.py -v
+```
+
+Expected: FAIL with `ImportError: cannot import name 'io_metrics' from 'nexus.services'`.
+
+- [ ] **Step 3: Implement the Python metrics catalog**
+
+Create `src/nexus/lib/io_metrics.py`:
+
+```python
+"""Prometheus metrics for Nexus read/write/cache hot paths (#4062)."""
+
+from __future__ import annotations
+
+from prometheus_client import Counter, Gauge, Histogram
+
+READ_LATENCY_BUCKETS = (
+    0.0005,
+    0.001,
+    0.0025,
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+)
+
+READ_BATCH_SIZE_BUCKETS = (1, 2, 4, 8, 16, 32, 64, 128, 256, 512)
+
+_CACHE_TIERS = frozenset({"sqlite", "dram", "nvme", "l1", "l2", "other"})
+_CACHE_RESULTS = frozenset({"hit", "miss", "stale", "other"})
+_CACHE_EVICTION_REASONS = frozenset({"capacity", "ttl", "manual", "other"})
+_ETAG_RESULTS = frozenset({"304", "updated", "error", "fallback", "unexpected_304", "other"})
+_PREFETCH_PATTERNS = frozenset({"sequential", "stride", "random", "majority_trend", "other"})
+_READ_TIERS = frozenset(
+    {"backend", "virtual", "error", "batch", "cache", "sqlite", "dram", "nvme", "passthrough", "other"}
+)
+_WRITE_FLUSH_TRIGGERS = frozenset({"time", "bytes", "close", "sync", "snapshot", "other"})
+_SCOPES = frozenset({"default", "root", "local", "server", "fuse", "other"})
+
+
+def _bounded(value: str | None, allowed: frozenset[str], default: str = "other") -> str:
+    normalized = (value or default).strip().lower().replace("-", "_")
+    return normalized if normalized in allowed else default
+
+
+def _nonnegative(value: int | float) -> int | float:
+    return value if value > 0 else 0
+
+
+CACHE_REQUESTS = Counter(
+    "nexus_cache_requests_total",
+    "Total Nexus cache lookup requests.",
+    ["tier", "result"],
+)
+
+CACHE_HIT_RATIO = Gauge(
+    "nexus_cache_hit_ratio",
+    "Current cache hit ratio for a bounded cache tier.",
+    ["tier"],
+)
+
+CACHE_EVICTIONS = Counter(
+    "nexus_cache_evictions_total",
+    "Total Nexus cache evictions.",
+    ["tier", "reason"],
+)
+
+CACHE_BYTES_IN_USE = Gauge(
+    "nexus_cache_bytes_in_use",
+    "Bytes currently held by a bounded cache tier.",
+    ["tier"],
+)
+
+CACHE_ADMISSION_REJECTED = Counter(
+    "nexus_cache_admission_rejected_total",
+    "Total cache admissions rejected by the admission filter.",
+)
+
+CACHE_ETAG_REVALIDATE = Counter(
+    "nexus_cache_etag_revalidate_total",
+    "Total cache ETag revalidation attempts.",
+    ["result"],
+)
+
+PREFETCH_ISSUED_BYTES = Counter(
+    "nexus_prefetch_issued_bytes_total",
+    "Total bytes requested by prefetch.",
+)
+
+PREFETCH_USED_BYTES = Counter(
+    "nexus_prefetch_used_bytes_total",
+    "Total prefetched bytes consumed by foreground reads.",
+)
+
+PREFETCH_WASTED_BYTES = Counter(
+    "nexus_prefetch_wasted_bytes_total",
+    "Total prefetched bytes evicted before use.",
+)
+
+PREFETCH_WINDOW_SIZE = Gauge(
+    "nexus_prefetch_window_size",
+    "Current adaptive prefetch window size for bounded scopes.",
+    ["mount", "workspace"],
+)
+
+PREFETCH_PATTERN_DETECTED = Counter(
+    "nexus_prefetch_pattern_detected_total",
+    "Total detected prefetch access patterns.",
+    ["pattern"],
+)
+
+READ_LATENCY = Histogram(
+    "nexus_read_latency_seconds",
+    "Nexus read latency in seconds.",
+    ["tier"],
+    buckets=READ_LATENCY_BUCKETS,
+)
+
+READ_BYTES = Counter(
+    "nexus_read_bytes_total",
+    "Total Nexus read bytes.",
+    ["tier"],
+)
+
+READ_BATCH_SIZE = Histogram(
+    "nexus_read_batch_size",
+    "Number of paths requested in read_batch calls.",
+    buckets=READ_BATCH_SIZE_BUCKETS,
+)
+
+FUSE_PASSTHROUGH_USED = Counter(
+    "nexus_fuse_passthrough_used_total",
+    "Total FUSE passthrough reads used.",
+)
+
+WRITE_COALESCE_FLUSH = Counter(
+    "nexus_write_coalesce_flush_total",
+    "Total write-coalescing flushes.",
+    ["trigger"],
+)
+
+WRITE_COALESCE_DIRTY_BYTES = Gauge(
+    "nexus_write_coalesce_dirty_bytes",
+    "Current dirty bytes held by write coalescing.",
+)
+
+WRITE_BACKEND_RPC = Counter(
+    "nexus_write_backend_rpc_total",
+    "Total backend write RPCs issued by Nexus I/O paths.",
+)
+
+GENERATION_MISMATCH = Counter(
+    "nexus_generation_mismatch_total",
+    "Total cache invalidations caused by generation mismatch.",
+)
+
+ETAG_CHECKS = Counter(
+    "nexus_etag_check_total",
+    "Total ETag checks by result.",
+    ["result"],
+)
+
+
+def record_cache_request(tier: str, result: str) -> None:
+    CACHE_REQUESTS.labels(
+        tier=_bounded(tier, _CACHE_TIERS),
+        result=_bounded(result, _CACHE_RESULTS),
+    ).inc()
+
+
+def set_cache_hit_ratio(tier: str, ratio: float) -> None:
+    bounded_ratio = max(0.0, min(float(ratio), 1.0))
+    CACHE_HIT_RATIO.labels(tier=_bounded(tier, _CACHE_TIERS)).set(bounded_ratio)
+
+
+def record_cache_eviction(tier: str, reason: str) -> None:
+    CACHE_EVICTIONS.labels(
+        tier=_bounded(tier, _CACHE_TIERS),
+        reason=_bounded(reason, _CACHE_EVICTION_REASONS),
+    ).inc()
+
+
+def set_cache_bytes_in_use(tier: str, bytes_in_use: int) -> None:
+    CACHE_BYTES_IN_USE.labels(tier=_bounded(tier, _CACHE_TIERS)).set(_nonnegative(bytes_in_use))
+
+
+def record_cache_admission_rejected() -> None:
+    CACHE_ADMISSION_REJECTED.inc()
+
+
+def record_cache_etag_revalidate(result: str) -> None:
+    CACHE_ETAG_REVALIDATE.labels(result=_bounded(result, _ETAG_RESULTS)).inc()
+
+
+def record_etag_check(result: str) -> None:
+    ETAG_CHECKS.labels(result=_bounded(result, _ETAG_RESULTS)).inc()
+
+
+def record_prefetch_issued(bytes_count: int) -> None:
+    PREFETCH_ISSUED_BYTES.inc(_nonnegative(bytes_count))
+
+
+def record_prefetch_used(bytes_count: int) -> None:
+    PREFETCH_USED_BYTES.inc(_nonnegative(bytes_count))
+
+
+def record_prefetch_wasted(bytes_count: int) -> None:
+    PREFETCH_WASTED_BYTES.inc(_nonnegative(bytes_count))
+
+
+def set_prefetch_window_size(
+    window_size: int,
+    *,
+    mount: str = "default",
+    workspace: str = "default",
+) -> None:
+    PREFETCH_WINDOW_SIZE.labels(
+        mount=_bounded(mount, _SCOPES, "default"),
+        workspace=_bounded(workspace, _SCOPES, "default"),
+    ).set(_nonnegative(window_size))
+
+
+def record_prefetch_pattern(pattern: str) -> None:
+    PREFETCH_PATTERN_DETECTED.labels(pattern=_bounded(pattern, _PREFETCH_PATTERNS)).inc()
+
+
+def record_read(*, tier: str, bytes_read: int, latency_seconds: float) -> None:
+    safe_tier = _bounded(tier, _READ_TIERS)
+    READ_BYTES.labels(tier=safe_tier).inc(_nonnegative(bytes_read))
+    READ_LATENCY.labels(tier=safe_tier).observe(float(_nonnegative(latency_seconds)))
+
+
+def record_read_batch_size(count: int) -> None:
+    READ_BATCH_SIZE.observe(float(_nonnegative(count)))
+
+
+def record_fuse_passthrough_used() -> None:
+    FUSE_PASSTHROUGH_USED.inc()
+
+
+def record_write_coalesce_flush(trigger: str) -> None:
+    WRITE_COALESCE_FLUSH.labels(trigger=_bounded(trigger, _WRITE_FLUSH_TRIGGERS)).inc()
+
+
+def set_write_coalesce_dirty_bytes(bytes_count: int) -> None:
+    WRITE_COALESCE_DIRTY_BYTES.set(_nonnegative(bytes_count))
+
+
+def record_write_backend_rpc() -> None:
+    WRITE_BACKEND_RPC.inc()
+
+
+def record_generation_mismatch() -> None:
+    GENERATION_MISMATCH.inc()
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run:
+
+```bash
+pytest tests/unit/services/test_io_metrics.py tests/integration/services/test_io_metrics_endpoint.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add src/nexus/lib/io_metrics.py tests/unit/services/test_io_metrics.py tests/integration/services/test_io_metrics_endpoint.py
+git commit -m "feat: add io metrics catalog"
+```
+
+## Task 2: Python I/O Wrapper Instrumentation
+
+**Files:**
+
+- Modify: `src/nexus/core/nexus_fs_content.py:17-18,64-144,521-607,714-855,1481-1726`
+- Create: `tests/unit/core/test_nexus_fs_content_metrics.py`
+
+- [ ] **Step 1: Write failing instrumentation tests**
+
+Create `tests/unit/core/test_nexus_fs_content_metrics.py`:
+
+```python
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from prometheus_client import REGISTRY
+
+from nexus.core.nexus_fs_content import ContentMixin
+
+
+def _sample(name: str, **labels: str) -> float:
+    for family in REGISTRY.collect():
+        for sample in family.samples:
+            if sample.name == name and all(sample.labels.get(k) == v for k, v in labels.items()):
+                return float(sample.value)
+    return 0.0
+
+
+class _Kernel:
+    def __init__(self) -> None:
+        self.sys_read_calls = 0
+        self.sys_write_calls = 0
+
+    def sys_read(self, path: str, _ctx: object, _timeout_ms: int, _offset: int = 0) -> Any:
+        self.sys_read_calls += 1
+        return SimpleNamespace(
+            data=b"abc",
+            post_hook_needed=False,
+            content_id="cid",
+            entry_type=1,
+            stream_next_offset=None,
+        )
+
+    def sys_write(self, path: str, _ctx: object, content: bytes, _offset: int = 0) -> Any:
+        self.sys_write_calls += 1
+        return SimpleNamespace(
+            hit=True,
+            content_id="cid",
+            post_hook_needed=False,
+            version=1,
+            size=len(content),
+            is_new=True,
+            old_content_id=None,
+            old_size=None,
+            old_version=None,
+            old_modified_at_ms=None,
+        )
+
+    def metastore_get_batch(self, paths: list[str]) -> list[Any]:
+        return [
+            SimpleNamespace(
+                size=3,
+                content_id=f"cid-{index}",
+                version=1,
+                modified_at=None,
+            )
+            for index, _path in enumerate(paths)
+        ]
+
+    def _read_batch(self, paths: list[str], _ctx: object) -> list[Any]:
+        return [
+            SimpleNamespace(
+                data=f"b{index}".encode(),
+                content_id=f"cid-{index}",
+            )
+            for index, _path in enumerate(paths)
+        ]
+
+    def hook_count(self, _name: str) -> int:
+        return 0
+
+    def dispatch_post_hooks(self, _name: str, _ctx: object) -> None:
+        return None
+
+
+class _Harness(ContentMixin):
+    def __init__(self) -> None:
+        self._kernel = _Kernel()
+        self._zone_id = "root"
+        self.metadata = SimpleNamespace()
+        self._driver_coordinator = SimpleNamespace()
+
+    def _parse_context(self, context: object | None) -> object | None:
+        return context
+
+    def resolve_read(self, path: str, *, context: object | None = None) -> tuple[bool, bytes | None]:
+        return (False, None)
+
+    def resolve_write(
+        self, path: str, content: bytes, *, context: object | None = None
+    ) -> tuple[bool, dict[str, object] | None]:
+        return (False, None)
+
+    def _build_rust_ctx(self, context: object | None, is_admin: bool) -> object:
+        return object()
+
+    def _get_context_identity(self, context: object | None) -> tuple[str, str | None, bool]:
+        return ("root", None, False)
+
+    def _validate_path(self, path: str) -> str:
+        return path
+
+    def _batch_permission_check(self, paths: list[str], context: object | None) -> set[str]:
+        return set(paths)
+
+    def _dispatch_batch_post_hook(self, _name: str, _ctx: object) -> None:
+        return None
+
+
+class _VirtualHarness(_Harness):
+    def resolve_read(self, path: str, *, context: object | None = None) -> tuple[bool, bytes | None]:
+        return (True, b"virtual")
+
+
+def test_sys_read_records_backend_latency_and_bytes() -> None:
+    harness = _Harness()
+    before_bytes = _sample("nexus_read_bytes_total", tier="backend")
+    before_count = _sample("nexus_read_latency_seconds_count", tier="backend")
+
+    assert harness.sys_read("/file.txt") == b"abc"
+
+    assert _sample("nexus_read_bytes_total", tier="backend") == before_bytes + 3
+    assert _sample("nexus_read_latency_seconds_count", tier="backend") == before_count + 1
+
+
+def test_sys_read_records_virtual_resolver_reads() -> None:
+    harness = _VirtualHarness()
+    before_bytes = _sample("nexus_read_bytes_total", tier="virtual")
+
+    assert harness.sys_read("/__sys__/virtual") == b"virtual"
+
+    assert _sample("nexus_read_bytes_total", tier="virtual") == before_bytes + 7
+
+
+def test_sys_write_records_backend_rpc_when_kernel_hit() -> None:
+    harness = _Harness()
+    before = _sample("nexus_write_backend_rpc_total")
+
+    harness.sys_write("/file.txt", b"abc")
+
+    assert _sample("nexus_write_backend_rpc_total") == before + 1
+
+
+def test_write_locked_records_backend_rpc_when_kernel_hit() -> None:
+    harness = _Harness()
+    before = _sample("nexus_write_backend_rpc_total")
+
+    harness._write_locked("/file.txt", b"abc")
+
+    assert _sample("nexus_write_backend_rpc_total") == before + 1
+
+
+def test_read_batch_records_batch_size_and_batch_bytes() -> None:
+    harness = _Harness()
+    before_size = _sample("nexus_read_batch_size_count")
+    before_bytes = _sample("nexus_read_bytes_total", tier="batch")
+
+    results = harness.read_batch(["/a.txt", "/b.txt"])
+
+    assert [item["content"] for item in results] == [b"b0", b"b1"]
+    assert _sample("nexus_read_batch_size_count") == before_size + 1
+    assert _sample("nexus_read_bytes_total", tier="batch") == before_bytes + 4
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+pytest tests/unit/core/test_nexus_fs_content_metrics.py -v
+```
+
+Expected: FAIL because `src/nexus/core/nexus_fs_content.py` does not record `nexus_read_bytes_total`, `nexus_read_latency_seconds`, `nexus_read_batch_size`, or `nexus_write_backend_rpc_total`.
+
+- [ ] **Step 3: Import the metrics module**
+
+Modify imports in `src/nexus/core/nexus_fs_content.py` near the existing imports:
+
+```python
+import logging
+import time
+from collections.abc import Callable, Iterator
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.exceptions import (
+    ConflictError,
+    NexusFileNotFoundError,
+)
+from nexus.contracts.metadata import FileMetadata
+from nexus.contracts.types import OperationContext
+from nexus.lib.rpc_decorator import rpc_expose
+from nexus.lib import io_metrics
+```
+
+- [ ] **Step 4: Instrument `sys_read()`**
+
+Wrap the existing `sys_read()` body with a timer and record on every return path. Preserve the existing read hook behavior. The resulting method body should follow this structure:
+
+```python
+        start = time.perf_counter()
+        try:
+            context = self._parse_context(context)
+            _handled, _resolve_hint = self.resolve_read(path, context=context)
+            if _handled:
+                content = _resolve_hint or b""
+                if offset or count is not None:
+                    content = (
+                        content[offset : offset + count]
+                        if count is not None
+                        else content[offset:]
+                    )
+                io_metrics.record_read(
+                    tier="virtual",
+                    bytes_read=len(content),
+                    latency_seconds=time.perf_counter() - start,
+                )
+                return content
+
+            _is_admin = (
+                getattr(context, "is_admin", False)
+                if context is not None and not isinstance(context, dict)
+                else (context.get("is_admin", False) if isinstance(context, dict) else False)
+            )
+
+            if self._kernel is None:
+                raise NexusFileNotFoundError(path)
+            _rust_ctx = self._build_rust_ctx(context, _is_admin)
+            _timeout_ms = 5000
+            result = self._kernel.sys_read(path, _rust_ctx, _timeout_ms, offset)
+
+            if result.entry_type == 4:
+                payload = bytes(result.data) if result.data else b""
+                io_metrics.record_read(
+                    tier="backend",
+                    bytes_read=len(payload),
+                    latency_seconds=time.perf_counter() - start,
+                )
+                return {
+                    "data": payload,
+                    "next_offset": result.stream_next_offset or 0,
+                }
+
+            data = result.data or b""
+
+            if offset or count is not None:
+                data = data[offset : offset + count] if count is not None else data[offset:]
+
+            if result.post_hook_needed:
+                zone_id, agent_id, _ = self._get_context_identity(context)
+                from nexus.contracts.vfs_hooks import ReadHookContext
+
+                _read_ctx = ReadHookContext(
+                    path=path,
+                    context=context,
+                    zone_id=zone_id,
+                    agent_id=agent_id,
+                    content=data,
+                    content_id=result.content_id,
+                )
+                self._kernel.dispatch_post_hooks("read", _read_ctx)
+                data = _read_ctx.content or data
+
+            io_metrics.record_read(
+                tier="backend",
+                bytes_read=len(data),
+                latency_seconds=time.perf_counter() - start,
+            )
+            return data
+        except Exception:
+            io_metrics.record_read(
+                tier="error",
+                bytes_read=0,
+                latency_seconds=time.perf_counter() - start,
+            )
+            raise
+```
+
+- [ ] **Step 5: Instrument `sys_write()` and `_write_locked()`**
+
+In `sys_write()`, immediately after `result = self._kernel.sys_write(path, _rust_ctx, buf, offset)`, add:
+
+```python
+        if result.hit:
+            io_metrics.record_write_backend_rpc()
+```
+
+In `_write_locked()`, immediately after `result = self._kernel.sys_write(path, _rust_ctx, buf, offset)`, add the same block:
+
+```python
+        if result.hit:
+            io_metrics.record_write_backend_rpc()
+```
+
+- [ ] **Step 6: Instrument `read_batch()`**
+
+At the start of `read_batch()`, before the empty-list return, record the requested batch size:
+
+```python
+        io_metrics.record_read_batch_size(len(paths))
+        if not paths:
+            return []
+```
+
+Inside the fallback branch where `content = self.read(path, context=context)` succeeds, immediately after `_loaded_bytes += len(content)`, add:
+
+```python
+                    io_metrics.record_read(
+                        tier="batch",
+                        bytes_read=len(content),
+                        latency_seconds=0.0,
+                    )
+```
+
+Inside the Rust-result branch, immediately after `_loaded_bytes += len(content)`, add:
+
+```python
+            io_metrics.record_read(
+                tier="batch",
+                bytes_read=len(content),
+                latency_seconds=0.0,
+            )
+```
+
+Use `latency_seconds=0.0` for per-item batch byte accounting so `nexus_read_bytes_total{tier="batch"}` is accurate without pretending each item has an independent latency measurement.
+
+- [ ] **Step 7: Run tests to verify they pass**
+
+Run:
+
+```bash
+pytest tests/unit/core/test_nexus_fs_content_metrics.py tests/unit/services/test_io_metrics.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+Run:
+
+```bash
+git add src/nexus/core/nexus_fs_content.py tests/unit/core/test_nexus_fs_content_metrics.py
+git commit -m "feat: record python io metrics"
+```
+
+## Task 3: FUSE Metrics Core And Endpoint
+
+**Files:**
+
+- Create: `nexus-fuse/src/metrics.rs`
+- Create: `nexus-fuse/tests/metrics_test.rs`
+- Modify: `nexus-fuse/src/lib.rs:5-9`
+- Modify: `nexus-fuse/src/main.rs:6-220`
+
+- [ ] **Step 1: Write failing FUSE metrics tests**
+
+Create `nexus-fuse/tests/metrics_test.rs`:
+
+```rust
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::time::Duration;
+
+use nexus_fuse::metrics;
+
+#[test]
+fn render_includes_recorded_counter_gauge_and_histogram() {
+    metrics::reset_for_tests();
+
+    metrics::record_cache_request("sqlite", "hit");
+    metrics::set_cache_bytes_in_use("sqlite", 4096);
+    metrics::record_read("cache", 128, Duration::from_millis(2));
+    metrics::record_write_backend_rpc();
+
+    let body = metrics::render();
+
+    assert!(body.contains("nexus_cache_requests_total{tier=\"sqlite\",result=\"hit\"} 1"));
+    assert!(body.contains("nexus_cache_bytes_in_use{tier=\"sqlite\"} 4096"));
+    assert!(body.contains("nexus_read_bytes_total{tier=\"cache\"} 128"));
+    assert!(body.contains("nexus_read_latency_seconds_count{tier=\"cache\"} 1"));
+    assert!(body.contains("nexus_write_backend_rpc_total 1"));
+}
+
+#[test]
+fn unknown_labels_collapse_to_other() {
+    metrics::reset_for_tests();
+
+    metrics::record_cache_request("path-/secret", "tenant-123");
+
+    let body = metrics::render();
+    assert!(body.contains("nexus_cache_requests_total{tier=\"other\",result=\"other\"} 1"));
+}
+
+#[test]
+fn metrics_server_returns_prometheus_text() {
+    metrics::reset_for_tests();
+    metrics::record_write_backend_rpc();
+
+    let server = metrics::start_server("127.0.0.1:0").expect("metrics server should bind");
+    let addr = server.local_addr();
+
+    let mut stream = TcpStream::connect(addr).expect("connect metrics server");
+    stream
+        .write_all(b"GET /metrics HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        .expect("write request");
+
+    let mut body = String::new();
+    stream.read_to_string(&mut body).expect("read response");
+    assert!(body.contains("HTTP/1.1 200 OK"));
+    assert!(body.contains("nexus_write_backend_rpc_total 1"));
+}
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run:
+
+```bash
+cargo test --manifest-path nexus-fuse/Cargo.toml --test metrics_test
+```
+
+Expected: FAIL with `unresolved import nexus_fuse::metrics`.
+
+- [ ] **Step 3: Implement `nexus-fuse/src/metrics.rs`**
+
+Create `nexus-fuse/src/metrics.rs`:
+
+```rust
+//! Prometheus text metrics for the standalone nexus-fuse binary (#4062).
+
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::{SocketAddr, TcpListener};
+use std::sync::{LazyLock, Mutex};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+const READ_LATENCY_BUCKETS: &[f64] = &[
+    0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+];
+
+#[derive(Clone, Debug)]
+struct HistogramState {
+    buckets: &'static [f64],
+    bucket_counts: Vec<u64>,
+    count: u64,
+    sum: f64,
+}
+
+impl HistogramState {
+    fn new(buckets: &'static [f64]) -> Self {
+        Self {
+            buckets,
+            bucket_counts: vec![0; buckets.len()],
+            count: 0,
+            sum: 0.0,
+        }
+    }
+
+    fn observe(&mut self, value: f64) {
+        let safe = if value.is_finite() && value > 0.0 { value } else { 0.0 };
+        self.count += 1;
+        self.sum += safe;
+        for (idx, bucket) in self.buckets.iter().enumerate() {
+            if safe <= *bucket {
+                self.bucket_counts[idx] += 1;
+            }
+        }
+    }
+}
+
+#[derive(Default)]
+struct MetricsState {
+    cache_requests: HashMap<(String, String), u64>,
+    cache_etag_revalidate: HashMap<String, u64>,
+    etag_checks: HashMap<String, u64>,
+    cache_bytes_in_use: HashMap<String, u64>,
+    read_bytes: HashMap<String, u64>,
+    read_latency: HashMap<String, HistogramState>,
+    write_backend_rpc_total: u64,
+}
+
+static METRICS: LazyLock<Mutex<MetricsState>> =
+    LazyLock::new(|| Mutex::new(MetricsState::default()));
+
+pub struct MetricsServer {
+    local_addr: SocketAddr,
+    _thread: JoinHandle<()>,
+}
+
+impl MetricsServer {
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+}
+
+fn bounded(value: &str, allowed: &[&str]) -> String {
+    let normalized = value.trim().to_ascii_lowercase().replace('-', "_");
+    if allowed.iter().any(|item| *item == normalized) {
+        normalized
+    } else {
+        "other".to_string()
+    }
+}
+
+fn cache_tier(value: &str) -> String {
+    bounded(value, &["sqlite", "dram", "nvme", "l1", "l2", "other"])
+}
+
+fn cache_result(value: &str) -> String {
+    bounded(value, &["hit", "miss", "stale", "other"])
+}
+
+fn etag_result(value: &str) -> String {
+    bounded(value, &["304", "updated", "error", "fallback", "unexpected_304", "other"])
+}
+
+fn read_tier(value: &str) -> String {
+    bounded(
+        value,
+        &["backend", "virtual", "error", "batch", "cache", "sqlite", "dram", "nvme", "passthrough", "other"],
+    )
+}
+
+pub fn reset_for_tests() {
+    *METRICS.lock().unwrap() = MetricsState::default();
+}
+
+pub fn record_cache_request(tier: &str, result: &str) {
+    let mut metrics = METRICS.lock().unwrap();
+    *metrics
+        .cache_requests
+        .entry((cache_tier(tier), cache_result(result)))
+        .or_insert(0) += 1;
+}
+
+pub fn record_cache_etag_revalidate(result: &str) {
+    let mut metrics = METRICS.lock().unwrap();
+    *metrics
+        .cache_etag_revalidate
+        .entry(etag_result(result))
+        .or_insert(0) += 1;
+}
+
+pub fn record_etag_check(result: &str) {
+    let mut metrics = METRICS.lock().unwrap();
+    *metrics.etag_checks.entry(etag_result(result)).or_insert(0) += 1;
+}
+
+pub fn set_cache_bytes_in_use(tier: &str, bytes: u64) {
+    let mut metrics = METRICS.lock().unwrap();
+    metrics.cache_bytes_in_use.insert(cache_tier(tier), bytes);
+}
+
+pub fn record_read(tier: &str, bytes: usize, latency: Duration) {
+    let safe_tier = read_tier(tier);
+    let mut metrics = METRICS.lock().unwrap();
+    *metrics.read_bytes.entry(safe_tier.clone()).or_insert(0) += bytes as u64;
+    metrics
+        .read_latency
+        .entry(safe_tier)
+        .or_insert_with(|| HistogramState::new(READ_LATENCY_BUCKETS))
+        .observe(latency.as_secs_f64());
+}
+
+pub fn record_write_backend_rpc() {
+    let mut metrics = METRICS.lock().unwrap();
+    metrics.write_backend_rpc_total += 1;
+}
+
+fn write_counter_line(out: &mut String, name: &str, labels: &str, value: u64) {
+    if labels.is_empty() {
+        out.push_str(&format!("{name} {value}\n"));
+    } else {
+        out.push_str(&format!("{name}{{{labels}}} {value}\n"));
+    }
+}
+
+pub fn render() -> String {
+    let metrics = METRICS.lock().unwrap();
+    let mut out = String::new();
+
+    out.push_str("# TYPE nexus_cache_requests_total counter\n");
+    for ((tier, result), value) in &metrics.cache_requests {
+        write_counter_line(
+            &mut out,
+            "nexus_cache_requests_total",
+            &format!("tier=\"{tier}\",result=\"{result}\""),
+            *value,
+        );
+    }
+
+    out.push_str("# TYPE nexus_cache_bytes_in_use gauge\n");
+    for (tier, value) in &metrics.cache_bytes_in_use {
+        out.push_str(&format!(
+            "nexus_cache_bytes_in_use{{tier=\"{tier}\"}} {value}\n"
+        ));
+    }
+
+    out.push_str("# TYPE nexus_cache_etag_revalidate_total counter\n");
+    for (result, value) in &metrics.cache_etag_revalidate {
+        write_counter_line(
+            &mut out,
+            "nexus_cache_etag_revalidate_total",
+            &format!("result=\"{result}\""),
+            *value,
+        );
+    }
+
+    out.push_str("# TYPE nexus_etag_check_total counter\n");
+    for (result, value) in &metrics.etag_checks {
+        write_counter_line(
+            &mut out,
+            "nexus_etag_check_total",
+            &format!("result=\"{result}\""),
+            *value,
+        );
+    }
+
+    out.push_str("# TYPE nexus_read_bytes_total counter\n");
+    for (tier, value) in &metrics.read_bytes {
+        write_counter_line(
+            &mut out,
+            "nexus_read_bytes_total",
+            &format!("tier=\"{tier}\""),
+            *value,
+        );
+    }
+
+    out.push_str("# TYPE nexus_read_latency_seconds histogram\n");
+    for (tier, histogram) in &metrics.read_latency {
+        for (idx, bucket) in histogram.buckets.iter().enumerate() {
+            out.push_str(&format!(
+                "nexus_read_latency_seconds_bucket{{tier=\"{tier}\",le=\"{bucket}\"}} {}\n",
+                histogram.bucket_counts[idx]
+            ));
+        }
+        out.push_str(&format!(
+            "nexus_read_latency_seconds_bucket{{tier=\"{tier}\",le=\"+Inf\"}} {}\n",
+            histogram.count
+        ));
+        out.push_str(&format!(
+            "nexus_read_latency_seconds_sum{{tier=\"{tier}\"}} {}\n",
+            histogram.sum
+        ));
+        out.push_str(&format!(
+            "nexus_read_latency_seconds_count{{tier=\"{tier}\"}} {}\n",
+            histogram.count
+        ));
+    }
+
+    out.push_str("# TYPE nexus_write_backend_rpc_total counter\n");
+    write_counter_line(
+        &mut out,
+        "nexus_write_backend_rpc_total",
+        "",
+        metrics.write_backend_rpc_total,
+    );
+
+    out
+}
+
+fn handle_client(mut stream: std::net::TcpStream) {
+    let mut buffer = [0_u8; 1024];
+    let _ = stream.read(&mut buffer);
+    let body = render();
+    let response = format!(
+        "HTTP/1.1 200 OK\r\ncontent-type: text/plain; version=0.0.4; charset=utf-8\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    );
+    let _ = stream.write_all(response.as_bytes());
+}
+
+pub fn start_server(addr: &str) -> std::io::Result<MetricsServer> {
+    let listener = TcpListener::bind(addr)?;
+    let local_addr = listener.local_addr()?;
+    let thread = thread::spawn(move || {
+        for stream in listener.incoming().flatten() {
+            handle_client(stream);
+        }
+    });
+    Ok(MetricsServer {
+        local_addr,
+        _thread: thread,
+    })
+}
+```
+
+- [ ] **Step 4: Export the module**
+
+Modify `nexus-fuse/src/lib.rs`:
+
+```rust
+pub mod cache;
+pub mod client;
+pub mod daemon;
+pub mod error;
+pub mod fs;
+pub mod metrics;
+```
+
+- [ ] **Step 5: Add CLI metrics endpoint wiring**
+
+Modify `nexus-fuse/src/main.rs` imports:
+
+```rust
+use clap::{Parser, Subcommand};
+use fuser::MountOption;
+use log::{error, info};
+use nexus_fuse::{cache, client, daemon, fs, metrics};
+use std::path::PathBuf;
+```
+
+Add `metrics_addr` to both `Mount` and `Daemon` command variants:
+
+```rust
+        /// Prometheus metrics bind address, for example 127.0.0.1:9464
+        #[arg(long, env = "NEXUS_FUSE_METRICS_ADDR")]
+        metrics_addr: Option<String>,
+```
+
+Bind the new field in both match arms. In the `Mount` arm, start the server after resolving the API key:
+
+```rust
+            let _metrics_server = if let Some(addr) = metrics_addr.as_deref() {
+                let server = metrics::start_server(addr)?;
+                info!("FUSE metrics listening on {}", server.local_addr());
+                Some(server)
+            } else {
+                None
+            };
+```
+
+In the `Daemon` arm, use the same block before creating `DaemonConfig`. Keep the `_metrics_server` binding in scope for the whole arm so the server thread handle is not dropped.
+
+- [ ] **Step 6: Run tests to verify they pass**
+
+Run:
+
+```bash
+cargo test --manifest-path nexus-fuse/Cargo.toml --test metrics_test
+```
+
+Expected: PASS.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add nexus-fuse/src/metrics.rs nexus-fuse/src/lib.rs nexus-fuse/src/main.rs nexus-fuse/tests/metrics_test.rs
+git commit -m "feat: add nexus-fuse metrics endpoint"
+```
+
+## Task 4: FUSE Cache, ETag, Read, And Write Instrumentation
+
+**Files:**
+
+- Modify: `nexus-fuse/src/cache.rs:8-13,145-205,221-336`
+- Modify: `nexus-fuse/src/fs.rs:3-15,369-440,591-697,900-940`
+
+- [ ] **Step 1: Add failing cache metric tests inside `cache.rs`**
+
+Inside the existing `#[cfg(test)] mod tests` in `nexus-fuse/src/cache.rs`, add:
+
+```rust
+    #[test]
+    fn test_cache_get_records_hit_miss_and_stale_metrics() {
+        crate::metrics::reset_for_tests();
+        let cache = test_cache("metrics");
+
+        assert!(matches!(cache.get("/metrics-miss.txt"), CacheLookup::Miss));
+        assert!(crate::metrics::render()
+            .contains("nexus_cache_requests_total{tier=\"sqlite\",result=\"miss\"} 1"));
+
+        cache.put("/metrics-hit.txt", b"data", Some("etag-1"));
+        assert!(matches!(cache.get("/metrics-hit.txt"), CacheLookup::Hit(_)));
+        assert!(crate::metrics::render()
+            .contains("nexus_cache_requests_total{tier=\"sqlite\",result=\"hit\"} 1"));
+
+        let old_cached_at = FileCache::now().saturating_sub(MAX_CACHE_AGE_SECS + 1);
+        {
+            let conn = cache.conn.lock().unwrap();
+            conn.execute(
+                "UPDATE file_cache SET cached_at = ? WHERE path = ?",
+                params![old_cached_at, "/metrics-hit.txt"],
+            )
+            .unwrap();
+        }
+        assert!(matches!(
+            cache.get("/metrics-hit.txt"),
+            CacheLookup::NeedsRevalidation { .. }
+        ));
+        assert!(crate::metrics::render()
+            .contains("nexus_cache_requests_total{tier=\"sqlite\",result=\"stale\"} 1"));
+    }
+
+    #[test]
+    fn test_cache_put_records_bytes_in_use() {
+        crate::metrics::reset_for_tests();
+        let cache = test_cache("bytes");
+
+        cache.put("/metrics-bytes.txt", b"data", Some("etag-1"));
+
+        assert!(crate::metrics::render().contains("nexus_cache_bytes_in_use{tier=\"sqlite\"} 4"));
+    }
+```
+
+- [ ] **Step 2: Run cache tests to verify they fail**
+
+Run:
+
+```bash
+cargo test --manifest-path nexus-fuse/Cargo.toml cache::tests::test_cache_get_records_hit_miss_and_stale_metrics
+cargo test --manifest-path nexus-fuse/Cargo.toml cache::tests::test_cache_put_records_bytes_in_use
+```
+
+Expected: FAIL because `FileCache::get()` and `FileCache::put()` do not call `crate::metrics`.
+
+- [ ] **Step 3: Instrument `FileCache::get()`, `put()`, and `stats()`**
+
+In `nexus-fuse/src/cache.rs`, add `use crate::metrics;` near the imports.
+
+In `FileCache::get()`, record each result immediately before returning:
+
+```rust
+                            metrics::record_cache_request("sqlite", "hit");
+                            CacheLookup::Hit(CacheEntry { content, etag })
+```
+
+```rust
+                            metrics::record_cache_request("sqlite", "miss");
+                            CacheLookup::Miss
+```
+
+```rust
+                    metrics::record_cache_request("sqlite", "stale");
+                    CacheLookup::NeedsRevalidation { etag }
+```
+
+```rust
+                    metrics::record_cache_request("sqlite", "miss");
+                    CacheLookup::Miss
+```
+
+```rust
+                metrics::record_cache_request("sqlite", "miss");
+                CacheLookup::Miss
+```
+
+In `FileCache::put()`, after a successful insert, call `self.stats()` and update bytes:
+
+```rust
+            let stats = self.stats();
+            metrics::set_cache_bytes_in_use("sqlite", stats.total_size);
+```
+
+In `FileCache::stats()`, before returning `CacheStats`, also set the gauge:
+
+```rust
+        metrics::set_cache_bytes_in_use("sqlite", total_size);
+
+        CacheStats {
+            file_count,
+            total_size,
+        }
+```
+
+- [ ] **Step 4: Run cache tests to verify they pass**
+
+Run:
+
+```bash
+cargo test --manifest-path nexus-fuse/Cargo.toml cache::tests::test_cache_get_records_hit_miss_and_stale_metrics
+cargo test --manifest-path nexus-fuse/Cargo.toml cache::tests::test_cache_put_records_bytes_in_use
+```
+
+Expected: PASS.
+
+- [ ] **Step 5: Instrument `fs.rs` read cache result tiers**
+
+In `nexus-fuse/src/fs.rs`, add `metrics` to the imports:
+
+```rust
+use crate::cache::{CacheLookup, FileCache};
+use crate::client::{FileEntry, NexusClient, ReadResponse};
+use crate::metrics;
+```
+
+Add a result struct above `impl NexusFs`:
+
+```rust
+#[derive(Debug)]
+struct ReadCachedResult {
+    content: Vec<u8>,
+    etag: Option<String>,
+    tier: &'static str,
+}
+```
+
+Change `read_cached()` signature:
+
+```rust
+    fn read_cached(&self, path: &str) -> anyhow::Result<ReadCachedResult> {
+```
+
+Update the hit return:
+
+```rust
+                    return Ok(ReadCachedResult {
+                        content: entry.content,
+                        etag: entry.etag,
+                        tier: "cache",
+                    });
+```
+
+Update the 304 path before returning:
+
+```rust
+                                    metrics::record_cache_etag_revalidate("304");
+                                    metrics::record_etag_check("304");
+                                    return Ok(ReadCachedResult {
+                                        content: entry.content,
+                                        etag: entry.etag,
+                                        tier: "cache",
+                                    });
+```
+
+Update the revalidation-with-content path:
+
+```rust
+                            metrics::record_cache_etag_revalidate("updated");
+                            metrics::record_etag_check("updated");
+                            cache.put(path, &content, etag.as_deref());
+                            return Ok(ReadCachedResult {
+                                content,
+                                etag,
+                                tier: "backend",
+                            });
+```
+
+Update the revalidation error fallback:
+
+```rust
+                            metrics::record_cache_etag_revalidate("fallback");
+                            metrics::record_etag_check("fallback");
+                            if let CacheLookup::Hit(entry) = cache.get(path) {
+                                return Ok(ReadCachedResult {
+                                    content: entry.content,
+                                    etag: entry.etag,
+                                    tier: "cache",
+                                });
+                            }
+                            metrics::record_cache_etag_revalidate("error");
+                            metrics::record_etag_check("error");
+                            return Err(e.into());
+```
+
+Update the normal backend fetch:
+
+```rust
+                Ok(ReadCachedResult {
+                    content,
+                    etag,
+                    tier: "backend",
+                })
+```
+
+Update the unexpected 304 path:
+
+```rust
+                metrics::record_etag_check("unexpected_304");
+                Err(anyhow::anyhow!("Unexpected 304 response"))
+```
+
+- [ ] **Step 6: Update `read_cached()` callers**
+
+In `read()`, replace tuple handling with the struct:
+
+```rust
+        let started_at = std::time::Instant::now();
+
+        let read_result = match self.read_cached(&path) {
+            Ok(result) => result,
+            Err(e) => {
+                metrics::record_read("error", 0, started_at.elapsed());
+                if e.downcast_ref::<crate::error::NexusClientError>()
+                    .map_or(false, |ne| ne.is_not_found())
+                {
+                    reply.error(ENOENT);
+                } else {
+                    error!("read error for {}: {}", path, e);
+                    reply.error(EIO);
+                }
+                return;
+            }
+        };
+
+        let content = read_result.content;
+```
+
+Immediately after calculating and returning the requested slice, record bytes and latency:
+
+```rust
+        if offset >= content.len() {
+            metrics::record_read(read_result.tier, 0, started_at.elapsed());
+            reply.data(&[]);
+        } else {
+            let end = std::cmp::min(offset + size as usize, content.len());
+            let slice = &content[offset..end];
+            metrics::record_read(read_result.tier, slice.len(), started_at.elapsed());
+            reply.data(slice);
+        }
+```
+
+In partial write handling, replace:
+
+```rust
+                Ok((data, _)) => data,
+```
+
+with:
+
+```rust
+                Ok(result) => result.content,
+```
+
+In truncate handling, replace:
+
+```rust
+                    Ok((mut data, _)) => {
+```
+
+with:
+
+```rust
+                    Ok(result) => {
+                        let mut data = result.content;
+```
+
+In both successful `self.client.write` branches in `write()`, add before invalidation:
+
+```rust
+                    metrics::record_write_backend_rpc();
+```
+
+Also add `metrics::record_write_backend_rpc();` for the successful truncate writes in `setattr()` where `self.client.write` reaches the backend.
+
+- [ ] **Step 7: Run focused FUSE tests**
+
+Run:
+
+```bash
+cargo test --manifest-path nexus-fuse/Cargo.toml cache
+cargo test --manifest-path nexus-fuse/Cargo.toml --test metrics_test
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+Run:
+
+```bash
+git add nexus-fuse/src/cache.rs nexus-fuse/src/fs.rs
+git commit -m "feat: instrument nexus-fuse io metrics"
+```
+
+## Task 5: Operator Documentation And Grafana Dashboard
+
+**Files:**
+
+- Create: `docs/operations/nexus-io-observability.md`
+- Create: `observability/grafana/provisioning/dashboards/nexus-io-observability.json`
+
+- [ ] **Step 1: Write docs and dashboard validation tests**
+
+Create `tests/unit/services/test_io_metrics_docs.py`:
+
+```python
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[3]
+DOC = ROOT / "docs" / "operations" / "nexus-io-observability.md"
+DASHBOARD = (
+    ROOT
+    / "observability"
+    / "grafana"
+    / "provisioning"
+    / "dashboards"
+    / "nexus-io-observability.json"
+)
+
+METRIC_NAMES = [
+    "nexus_cache_requests_total",
+    "nexus_cache_hit_ratio",
+    "nexus_cache_evictions_total",
+    "nexus_cache_bytes_in_use",
+    "nexus_cache_admission_rejected_total",
+    "nexus_cache_etag_revalidate_total",
+    "nexus_prefetch_issued_bytes_total",
+    "nexus_prefetch_used_bytes_total",
+    "nexus_prefetch_wasted_bytes_total",
+    "nexus_prefetch_window_size",
+    "nexus_prefetch_pattern_detected_total",
+    "nexus_read_latency_seconds",
+    "nexus_read_bytes_total",
+    "nexus_read_batch_size",
+    "nexus_fuse_passthrough_used_total",
+    "nexus_write_coalesce_flush_total",
+    "nexus_write_coalesce_dirty_bytes",
+    "nexus_write_backend_rpc_total",
+    "nexus_generation_mismatch_total",
+    "nexus_etag_check_total",
+]
+
+
+def test_io_observability_docs_cover_every_metric() -> None:
+    body = DOC.read_text()
+    for metric in METRIC_NAMES:
+        assert metric in body
+
+
+def test_grafana_dashboard_is_valid_and_mentions_core_metrics() -> None:
+    dashboard = json.loads(DASHBOARD.read_text())
+    assert dashboard["uid"] == "nexus-io-observability"
+    assert dashboard["title"] == "Nexus I/O Observability"
+    encoded = json.dumps(dashboard)
+    for metric in [
+        "nexus_read_latency_seconds",
+        "nexus_cache_requests_total",
+        "nexus_etag_check_total",
+        "nexus_write_backend_rpc_total",
+    ]:
+        assert metric in encoded
+```
+
+- [ ] **Step 2: Run docs test to verify it fails**
+
+Run:
+
+```bash
+pytest tests/unit/services/test_io_metrics_docs.py -v
+```
+
+Expected: FAIL because the docs and dashboard files do not exist.
+
+- [ ] **Step 3: Write operator docs**
+
+Create `docs/operations/nexus-io-observability.md`:
+
+```markdown
+# Nexus I/O Observability
+
+Issue #4062 adds a shared metrics surface for read, write, cache, ETag, prefetch, batching, coalescing, generation, and FUSE passthrough work.
+
+## Scrape Targets
+
+The FastAPI server exposes Python process metrics at `/metrics`.
+
+The standalone `nexus-fuse` binary exposes FUSE process metrics when started with:
+
+```bash
+nexus-fuse mount /mnt/nexus --url http://localhost:2026 --api-key-file ./key --metrics-addr 127.0.0.1:9464
+```
+
+or:
+
+```bash
+NEXUS_FUSE_METRICS_ADDR=127.0.0.1:9464 nexus-fuse mount /mnt/nexus --url http://localhost:2026 --api-key-file ./key
+```
+
+Prometheus should scrape both targets when both processes are running.
+
+## Metric Questions
+
+| Metric | Question |
+| --- | --- |
+| `nexus_cache_requests_total{tier,result}` | Are reads hitting cache or falling through? |
+| `nexus_cache_hit_ratio{tier}` | Is each cache tier healthy when native cache stats are available? |
+| `nexus_cache_evictions_total{tier,reason}` | Why is cache capacity turning over? |
+| `nexus_cache_bytes_in_use{tier}` | How full is the cache? |
+| `nexus_cache_admission_rejected_total` | Is the admission filter protecting the disk tier? |
+| `nexus_cache_etag_revalidate_total{result}` | Are stale cache entries cheaply revalidating? |
+| `nexus_prefetch_issued_bytes_total` | How much data did prefetch request? |
+| `nexus_prefetch_used_bytes_total` | How much prefetched data was consumed? |
+| `nexus_prefetch_wasted_bytes_total` | How much prefetched data was evicted before use? |
+| `nexus_prefetch_window_size{mount,workspace}` | What bounded-scope prefetch window is active? |
+| `nexus_prefetch_pattern_detected_total{pattern}` | What access patterns are being detected? |
+| `nexus_read_latency_seconds{tier}` | Where is read latency spent? |
+| `nexus_read_bytes_total{tier}` | How much data is served by each tier? |
+| `nexus_read_batch_size` | Are callers using batch reads effectively? |
+| `nexus_fuse_passthrough_used_total` | Is large-read passthrough active? |
+| `nexus_write_coalesce_flush_total{trigger}` | Why are buffered writes flushing? |
+| `nexus_write_coalesce_dirty_bytes` | How many bytes are at durability risk? |
+| `nexus_write_backend_rpc_total` | Did coalescing reduce backend write calls? |
+| `nexus_generation_mismatch_total` | Are cached entries invalidated by generation drift? |
+| `nexus_etag_check_total{result}` | Are ETag checks succeeding, updating, or failing? |
+
+## Label Discipline
+
+Labels are intentionally bounded. Paths, content IDs, ETags, user IDs, and raw file handles are not Prometheus labels. Use structured logs for per-path or per-handle debugging.
+
+`nexus_prefetch_window_size` uses bounded `mount` and `workspace` labels. Until future prefetch work provides bounded operational scopes, these labels default to `default`.
+
+## Current Sources
+
+The foundation slice emits real data for:
+
+- Python read latency and bytes from `NexusFSContent.sys_read`.
+- Python batch size and batch bytes from `NexusFSContent.read_batch`.
+- Python backend write RPC count from `NexusFSContent.sys_write` and `_write_locked`.
+- FUSE SQLite cache hit, miss, stale, and bytes-in-use metrics.
+- FUSE ETag revalidation and ETag check metrics.
+- FUSE read latency, read bytes, and backend write RPC count.
+
+Prefetch, coalescing, generation mismatch, foyer native stats, and passthrough metrics remain zero until their feature call sites land.
+```
+
+- [ ] **Step 4: Write Grafana dashboard JSON**
+
+Create `observability/grafana/provisioning/dashboards/nexus-io-observability.json` with this compact dashboard:
+
+```json
+{
+  "uid": "nexus-io-observability",
+  "title": "Nexus I/O Observability",
+  "description": "Read, write, cache, ETag, prefetch, coalescing, and passthrough metrics for issue #4062.",
+  "tags": ["nexus", "io", "observability"],
+  "timezone": "browser",
+  "editable": true,
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "label": "Datasource"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Read p95 Latency By Tier",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, tier) (rate(nexus_read_latency_seconds_bucket[5m])))",
+          "legendFormat": "p95 {{tier}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Read Bytes By Tier",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum by (tier) (rate(nexus_read_bytes_total[5m]))",
+          "legendFormat": "{{tier}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "Bps" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Cache Requests",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "expr": "sum by (tier, result) (rate(nexus_cache_requests_total[5m]))",
+          "legendFormat": "{{tier}} {{result}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Derived Cache Hit Percentage",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "targets": [
+        {
+          "expr": "100 * sum by (tier) (rate(nexus_cache_requests_total{result=\"hit\"}[5m])) / clamp_min(sum by (tier) (rate(nexus_cache_requests_total[5m])), 1)",
+          "legendFormat": "{{tier}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "percent" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Cache Bytes In Use",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 16 },
+      "targets": [
+        {
+          "expr": "nexus_cache_bytes_in_use",
+          "legendFormat": "{{tier}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "ETag Checks",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 16 },
+      "targets": [
+        {
+          "expr": "sum by (result) (rate(nexus_etag_check_total[5m]))",
+          "legendFormat": "{{result}}"
+        }
+      ]
+    },
+    {
+      "type": "heatmap",
+      "title": "Read Batch Size",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 16 },
+      "targets": [
+        {
+          "expr": "sum by (le) (rate(nexus_read_batch_size_bucket[5m]))",
+          "legendFormat": "{{le}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Backend Write RPC Rate",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "targets": [
+        {
+          "expr": "rate(nexus_write_backend_rpc_total[5m])",
+          "legendFormat": "write RPC/s"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ops" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Prefetch And Coalescing Reserved",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "targets": [
+        {
+          "expr": "rate(nexus_prefetch_used_bytes_total[5m])",
+          "legendFormat": "prefetch used B/s"
+        },
+        {
+          "expr": "sum by (trigger) (rate(nexus_write_coalesce_flush_total[5m]))",
+          "legendFormat": "flush {{trigger}}"
+        }
+      ]
+    }
+  ]
+}
+```
+
+- [ ] **Step 5: Run docs/dashboard tests**
+
+Run:
+
+```bash
+pytest tests/unit/services/test_io_metrics_docs.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add docs/operations/nexus-io-observability.md observability/grafana/provisioning/dashboards/nexus-io-observability.json tests/unit/services/test_io_metrics_docs.py
+git commit -m "docs: add nexus io observability guide"
+```
+
+## Task 6: Full Verification
+
+**Files:**
+
+- No new files.
+- Validate all files changed by Tasks 1-5.
+
+- [ ] **Step 1: Run Python metrics tests**
+
+Run:
+
+```bash
+pytest tests/unit/services/test_io_metrics.py tests/integration/services/test_io_metrics_endpoint.py tests/unit/core/test_nexus_fs_content_metrics.py tests/unit/services/test_io_metrics_docs.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 2: Run FUSE metrics tests**
+
+Run:
+
+```bash
+cargo test --manifest-path nexus-fuse/Cargo.toml cache
+cargo test --manifest-path nexus-fuse/Cargo.toml --test metrics_test
+```
+
+Expected: PASS.
+
+- [ ] **Step 3: Run formatting checks for touched languages**
+
+Run:
+
+```bash
+ruff format src/nexus/lib/io_metrics.py tests/unit/services/test_io_metrics.py tests/integration/services/test_io_metrics_endpoint.py tests/unit/core/test_nexus_fs_content_metrics.py tests/unit/services/test_io_metrics_docs.py
+cargo fmt --manifest-path nexus-fuse/Cargo.toml
+```
+
+Expected: commands exit 0.
+
+- [ ] **Step 4: Inspect git status**
+
+Run:
+
+```bash
+git status --short
+```
+
+Expected: no unstaged files after the task commits.
+
+- [ ] **Step 5: Final commit if verification changed formatting**
+
+If Step 3 changed files, run:
+
+```bash
+git add src/nexus/lib/io_metrics.py tests/unit/services/test_io_metrics.py tests/integration/services/test_io_metrics_endpoint.py tests/unit/core/test_nexus_fs_content_metrics.py tests/unit/services/test_io_metrics_docs.py nexus-fuse/src/metrics.rs nexus-fuse/src/lib.rs nexus-fuse/src/main.rs nexus-fuse/src/cache.rs nexus-fuse/src/fs.rs
+git commit -m "chore: format io observability changes"
+```
+
+Expected: commit succeeds only when formatting changed files.

--- a/docs/superpowers/specs/2026-05-07-issue-4062-observability-foundation-design.md
+++ b/docs/superpowers/specs/2026-05-07-issue-4062-observability-foundation-design.md
@@ -1,0 +1,220 @@
+# Issue 4062 Observability Foundation Design
+
+**Issue:** [#4062 - Observability: cache, prefetch, and read-path metrics](https://github.com/nexi-lab/nexus/issues/4062)
+
+## Summary
+
+Issue #4062 asks for a shared metrics surface before the cache, prefetch, batching, write-coalescing, and passthrough work lands. The full issue references future features tracked separately in #4053, #4057, #4058, #4059, and #4060, so this design implements the foundation slice:
+
+1. Define the Prometheus metric catalog now.
+2. Wire metrics to current read, write, batch, SQLite cache, and ETag paths.
+3. Provide stable recorder APIs for future foyer, prefetch, coalescing, and passthrough call sites.
+4. Commit a standard Grafana dashboard and metric-to-question documentation.
+
+This slice intentionally does not implement foyer, prefetch, write coalescing, generation numbers, or FUSE passthrough. It makes those follow-up PRs measurable when they land.
+
+## Current Context
+
+The repo already has Python-side Prometheus infrastructure in `src/nexus/server/metrics.py`. That module registers HTTP request metrics and exposes `/metrics` through the existing FastAPI app. Activity metrics follow the same global `prometheus_client.REGISTRY` pattern in `src/nexus/services/activity/metrics.py`, with tests that scrape `generate_latest()`.
+
+The current core read/write hot path crosses through `src/nexus/core/nexus_fs_content.py` into `rust/kernel/src/kernel/io.rs`. The Rust kernel owns routing, permission checks, VFS locks, backend reads/writes, metadata updates, and mutation observers. Python still wraps the public API and is the natural low-risk place to record the current metrics without introducing Prometheus dependencies into the Rust kernel crate.
+
+The standalone `nexus-fuse` crate is excluded from the root Cargo workspace. It has its own SQLite-backed file cache in `nexus-fuse/src/cache.rs`, ETag revalidation in `nexus-fuse/src/fs.rs`, and no existing metrics endpoint. The current cache is not foyer yet; this foundation records the current SQLite behavior using the same tier/result names that the future foyer integration will reuse.
+
+## Non-Goals
+
+This design does not:
+
+- Replace SQLite with foyer (#4053).
+- Add file generations (#4054).
+- Implement the adaptive prefetch crate (#4057).
+- Implement `_read_batch()` beyond existing behavior (#4058).
+- Add write coalescing (#4059).
+- Add FUSE passthrough (#4060).
+- Add raw file paths, handles, workspace IDs, user IDs, or cache keys as Prometheus labels.
+
+## Architecture
+
+### Python Prometheus Catalog
+
+Create `src/nexus/lib/io_metrics.py` as the shared read/write/cache metrics catalog for the server process. It will mirror the existing activity metrics style: module-level `Counter`, `Gauge`, and `Histogram` objects registered on the global Prometheus registry at import time, plus small `record_*` functions used by call sites.
+
+The catalog is intentionally low-cardinality. Prometheus labels are bounded strings such as `tier`, `result`, `trigger`, `pattern`, `operation`, `mount`, and `workspace`. The `mount` and `workspace` labels are normalized to `"default"` unless the call site can provide a bounded operational name. Raw file handles, paths, content IDs, etags, and user IDs are never Prometheus labels.
+
+### Server Read/Write Instrumentation
+
+Instrument `src/nexus/core/nexus_fs_content.py` around public file I/O methods:
+
+- `sys_read()`: observe `nexus_read_latency_seconds{tier}` and increment `nexus_read_bytes_total{tier}`. Current tier mapping:
+  - `backend` for normal kernel reads that return data.
+  - `virtual` for resolver-handled reads.
+  - `error` for failed reads.
+- `read_batch()`: observe `nexus_read_batch_size` with the requested path count. Record per-result bytes under tier `batch`.
+- `sys_write()` and `_write_locked()`: increment `nexus_write_backend_rpc_total` only when `Kernel.sys_write()` returns `hit=True`, because that indicates Rust performed the backend write path. Future write coalescing will move this counter to the actual flush call site.
+
+This keeps the first slice close to the current Python API boundary and avoids deep Rust refactors while still measuring the operational surface users exercise.
+
+### FUSE Metrics
+
+Add `nexus-fuse/src/metrics.rs` with thread-safe counters/histograms backed by atomics and bucket arrays. The crate will expose a Prometheus text endpoint when explicitly enabled by `--metrics-addr` or `NEXUS_FUSE_METRICS_ADDR`. This avoids changing default daemon behavior.
+
+Current FUSE instrumentation:
+
+- `FileCache::get()` records `nexus_cache_requests_total{tier="sqlite", result="hit|miss|stale"}`.
+- `FileCache::put()` and `FileCache::stats()` update `nexus_cache_bytes_in_use{tier="sqlite"}`.
+- `NexusFs::read_cached()` records `nexus_cache_etag_revalidate_total{result="304|updated|error|fallback"}` and `nexus_etag_check_total{result=...}`.
+- `NexusFs::read()` records read latency and bytes with tiers `cache`, `backend`, or `error`.
+- `NexusFs::write()` records `nexus_write_backend_rpc_total` for each client write request that reaches the backend.
+
+The FUSE endpoint will expose the same metric names as the Python server. Operators can scrape either or both processes depending on deployment topology.
+
+### Future Recorder Contract
+
+The foundation module exposes recorders for both current and future features. Recorders tied to future features register their collectors now and update real series only when those feature call sites land:
+
+- `record_cache_request(tier, result)`
+- `set_cache_hit_ratio(tier, ratio)`
+- `record_cache_eviction(tier, reason)`
+- `set_cache_bytes_in_use(tier, bytes)`
+- `record_cache_admission_rejected()`
+- `record_etag_check(result)`
+- `record_prefetch_issued(bytes)`
+- `record_prefetch_used(bytes)`
+- `record_prefetch_wasted(bytes)`
+- `set_prefetch_window_size(window_size, mount="default", workspace="default")`
+- `record_prefetch_pattern(pattern)`
+- `record_read(tier, bytes_read, latency_seconds)`
+- `record_read_batch_size(count)`
+- `record_fuse_passthrough_used()`
+- `record_write_coalesce_flush(trigger)`
+- `set_write_coalesce_dirty_bytes(bytes)`
+- `record_write_backend_rpc()`
+- `record_generation_mismatch()`
+
+Future PRs should call these recorders rather than defining new metric objects. That keeps metric names stable and prevents duplicate collectors.
+
+## Metric Catalog
+
+### Cache
+
+| Metric | Type | Labels | Current Source | Question |
+| --- | --- | --- | --- | --- |
+| `nexus_cache_requests_total` | Counter | `tier`, `result` | `nexus-fuse` SQLite cache | Are reads hitting cache or falling through? |
+| `nexus_cache_hit_ratio` | Gauge | `tier` | Future foyer stats; current dashboard derives hit percentage from `nexus_cache_requests_total` | Is each cache tier healthy? |
+| `nexus_cache_evictions_total` | Counter | `tier`, `reason` | Future foyer stats | Why is cache capacity turning over? |
+| `nexus_cache_bytes_in_use` | Gauge | `tier` | SQLite stats now; foyer stats later | How full is the cache? |
+| `nexus_cache_admission_rejected_total` | Counter | none | Future foyer admission filter | Is TinyLFU protecting the disk tier? |
+| `nexus_cache_etag_revalidate_total` | Counter | `result` | `read_cached()` | Are stale entries cheaply revalidating? |
+
+### Prefetch
+
+| Metric | Type | Labels | Current Source | Question |
+| --- | --- | --- | --- | --- |
+| `nexus_prefetch_issued_bytes_total` | Counter | none | Future prefetch crate | How much data did prefetch request? |
+| `nexus_prefetch_used_bytes_total` | Counter | none | Future prefetch crate | How much prefetched data was consumed? |
+| `nexus_prefetch_wasted_bytes_total` | Counter | none | Future prefetch crate | How much prefetch work was wasted? |
+| `nexus_prefetch_window_size` | Gauge | `mount`, `workspace` | Future prefetch crate | What adaptive window is active for bounded scopes? |
+| `nexus_prefetch_pattern_detected_total` | Counter | `pattern` | Future prefetch crate | What access patterns are being detected? |
+
+`file_handle` is deliberately not a Prometheus label. It is high-cardinality and short-lived. Future prefetch code should log per-handle values as structured log fields when debugging is enabled.
+
+### Read Path
+
+| Metric | Type | Labels | Current Source | Question |
+| --- | --- | --- | --- | --- |
+| `nexus_read_latency_seconds` | Histogram | `tier` | Python server and `nexus-fuse` | Where is read latency spent? |
+| `nexus_read_bytes_total` | Counter | `tier` | Python server and `nexus-fuse` | How much data is served by each tier? |
+| `nexus_read_batch_size` | Histogram | none | `read_batch()` | Are clients using batch reads effectively? |
+| `nexus_fuse_passthrough_used_total` | Counter | none | Future passthrough call site | Is large-read passthrough active? |
+
+Histogram buckets use sub-millisecond through 10-second coverage:
+
+`0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10`
+
+Batch size buckets:
+
+`1, 2, 4, 8, 16, 32, 64, 128, 256, 512`
+
+### Write Path
+
+| Metric | Type | Labels | Current Source | Question |
+| --- | --- | --- | --- | --- |
+| `nexus_write_coalesce_flush_total` | Counter | `trigger` | Future coalescing buffer | Why are buffered writes flushing? |
+| `nexus_write_coalesce_dirty_bytes` | Gauge | none | Future coalescing buffer | How many bytes are at durability risk? |
+| `nexus_write_backend_rpc_total` | Counter | none | Python server and `nexus-fuse` | Did coalescing reduce backend write calls? |
+
+### Consistency
+
+| Metric | Type | Labels | Current Source | Question |
+| --- | --- | --- | --- | --- |
+| `nexus_generation_mismatch_total` | Counter | none | Future generation-aware cache invalidation | Are cached entries invalidated by generation drift? |
+| `nexus_etag_check_total` | Counter | `result` | Current ETag revalidation path | Are ETag checks succeeding, updating, or failing? |
+
+## Structured Logs
+
+Prometheus answers aggregate questions. Slow-path and high-cardinality details go to structured logs:
+
+- Cache miss to backend: `event="nexus.cache_miss_backend"`, `tier`, `path_hash`, `bytes`, `latency_ms`.
+- ETag revalidation: `event="nexus.etag_revalidate"`, `result`, `status`, `path_hash`.
+- Future prefetch reset: `event="nexus.prefetch_reset"`, `file_handle`, `pattern`, `old_window`, `reason`.
+- Future write flush: `event="nexus.write_coalesce_flush"`, `trigger`, `dirty_bytes`, `path_hash`.
+
+`path_hash` is a stable hash of the path for correlation without leaking raw paths into metrics or logs by default.
+
+## Dashboard
+
+Commit `observability/grafana/provisioning/dashboards/nexus-io-observability.json` with panels for:
+
+1. Read p50/p95/p99 latency by tier.
+2. Read bytes by tier.
+3. Cache requests by tier/result.
+4. Cache hit ratio by tier.
+5. Cache bytes in use by tier.
+6. ETag checks by result.
+7. Read batch size distribution.
+8. Write backend RPC rate.
+9. Reserved panels for prefetch efficiency and coalescing flush triggers, showing zero data until those feature metrics are emitted.
+
+The existing `observability/grafana/provisioning/dashboards/dashboards.yml` already provisions dashboards from this directory, so no provisioning change is needed unless the current provider is path-specific.
+
+## Testing
+
+Python tests:
+
+- Add unit tests for every `io_metrics` recorder to prove the metric is registered and updates the expected sample.
+- Add targeted tests around `NexusFSContent.sys_read()`, `read_batch()`, and `_write_locked()` using lightweight fakes/mocks for the Rust kernel boundary.
+- Add an integration-style scrape test using `prometheus_client.generate_latest()` to assert the catalog appears in `/metrics` output after recorder calls.
+
+Rust FUSE tests:
+
+- Add unit tests for the metrics encoder in `nexus-fuse/src/metrics.rs`.
+- Add cache tests asserting `FileCache::get()` records hit, miss, and stale outcomes.
+- Add `read_cached()` tests for ETag result counters where existing mock client infrastructure allows it.
+
+Manual verification:
+
+```bash
+pytest tests/unit/services/test_io_metrics.py -v
+pytest tests/integration/services/test_io_metrics_endpoint.py -v
+cargo test --manifest-path nexus-fuse/Cargo.toml metrics cache
+```
+
+## Risks And Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Duplicate collectors during tests | Follow activity metrics patterns and avoid dynamic collector creation in tests. |
+| Cardinality blow-up | Keep labels bounded; raw handles and paths stay out of Prometheus. |
+| Rust/Python metric mismatch | Use identical metric names and document that server and FUSE are separate scrape targets. |
+| Foundation drifts from future foyer/prefetch work | Expose recorder APIs now and reference them from #4053/#4057/#4059/#4060 implementation plans. |
+| Metrics overhead on hot paths | Record simple counter/histogram observations only; no path hashing unless a structured slow-path log is emitted. |
+
+## Acceptance Criteria Mapping
+
+- All issue-named metrics are defined and exposed through the Python `/metrics` endpoint after import and through the `nexus-fuse` metrics endpoint when the daemon is started with metrics enabled.
+- Current read/write/cache/ETag paths update the metrics that have real sources today.
+- Future metrics have stable recorders and reserved dashboard panels documented as zero until their feature lands.
+- Histograms include sub-millisecond through 10-second buckets.
+- Prometheus labels are bounded; `mount` and `workspace` default to `"default"` until reliable bounded values are available.
+- Dashboard JSON is committed under `observability/grafana/provisioning/dashboards/`.
+- Documentation explains which metric answers which operational question.

--- a/nexus-fuse/benches/fuse_operations.rs
+++ b/nexus-fuse/benches/fuse_operations.rs
@@ -11,19 +11,15 @@
 //!
 //! Run with: cargo bench
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion, BenchmarkId};
+use criterion::{black_box, criterion_group, criterion_main, BenchmarkId, Criterion};
 use nexus_fuse::client::NexusClient;
 use std::time::Duration;
 
 /// Setup test server connection
 fn setup_client() -> NexusClient {
     // Use local test server (must be running)
-    NexusClient::new(
-        "http://localhost:2026",
-        "sk-test-key-123",
-        None,
-    )
-    .expect("Failed to create NexusClient")
+    NexusClient::new("http://localhost:2026", "sk-test-key-123", None)
+        .expect("Failed to create NexusClient")
 }
 
 /// Benchmark file read operations (cached)
@@ -118,7 +114,9 @@ fn bench_write(c: &mut Criterion) {
         b.iter(|| {
             let path = format!("/bench-write-{}.txt", counter);
             counter += 1;
-            client.write(black_box(&path), black_box(&test_content)).unwrap();
+            client
+                .write(black_box(&path), black_box(&test_content))
+                .unwrap();
         });
     });
 
@@ -146,7 +144,9 @@ fn bench_write_sizes(c: &mut Criterion) {
                 b.iter(|| {
                     let path = format!("/bench-write-{}kb-{}.txt", size_kb, counter);
                     counter += 1;
-                    client.write(black_box(&path), black_box(&test_content)).unwrap();
+                    client
+                        .write(black_box(&path), black_box(&test_content))
+                        .unwrap();
                 });
             },
         );
@@ -262,7 +262,9 @@ fn bench_rename(c: &mut Criterion) {
             client.write(&old_path, b"test").unwrap();
 
             // Rename
-            client.rename(black_box(&old_path), black_box(&new_path)).unwrap();
+            client
+                .rename(black_box(&old_path), black_box(&new_path))
+                .unwrap();
 
             // Cleanup
             let _ = client.delete(&new_path);

--- a/nexus-fuse/src/cache.rs
+++ b/nexus-fuse/src/cache.rs
@@ -5,6 +5,7 @@
 
 #![allow(dead_code)]
 
+use crate::metrics;
 use anyhow::{anyhow, Result};
 use log::{debug, error, info, warn};
 use rusqlite::{params, Connection, OptionalExtension};
@@ -136,6 +137,22 @@ impl FileCache {
             .unwrap_or(0)
     }
 
+    #[cfg(test)]
+    pub(crate) fn open_in_memory_for_tests() -> Self {
+        let conn = Connection::open_in_memory().unwrap();
+        Self::open_connection(conn).unwrap()
+    }
+
+    #[cfg(test)]
+    pub(crate) fn set_cached_at_for_tests(&self, path: &str, cached_at: u64) {
+        let conn = self.conn.lock().unwrap();
+        conn.execute(
+            "UPDATE file_cache SET cached_at = ? WHERE path = ?",
+            params![cached_at, path],
+        )
+        .unwrap();
+    }
+
     /// Look up a file in the cache using two-phase metadata-first query (Issue 16A).
     ///
     /// Phase 1: Query only lightweight metadata (etag, cached_at) to determine
@@ -176,11 +193,16 @@ impl FileCache {
                     match content {
                         Some(content) => {
                             debug!("Cache hit for {} (age: {}s)", path, age);
+                            metrics::record_cache_request("sqlite", "hit");
                             CacheLookup::Hit(CacheEntry { content, etag })
                         }
                         None => {
                             // Shouldn't happen (metadata existed but content gone)
-                            debug!("Cache inconsistency for {} — metadata without content", path);
+                            debug!(
+                                "Cache inconsistency for {} — metadata without content",
+                                path
+                            );
+                            metrics::record_cache_request("sqlite", "miss");
                             CacheLookup::Miss
                         }
                     }
@@ -190,18 +212,43 @@ impl FileCache {
                         "Cache stale for {} (age: {}s), needs revalidation",
                         path, age
                     );
+                    metrics::record_cache_request("sqlite", "stale");
                     CacheLookup::NeedsRevalidation { etag }
                 } else {
                     // Stale with no etag — treat as miss
                     debug!("Cache stale for {} with no etag", path);
+                    metrics::record_cache_request("sqlite", "miss");
                     CacheLookup::Miss
                 }
             }
             None => {
                 debug!("Cache miss for {}", path);
+                metrics::record_cache_request("sqlite", "miss");
                 CacheLookup::Miss
             }
         }
+    }
+
+    /// Fetch cached content for an entry that already entered revalidation.
+    ///
+    /// This deliberately bypasses freshness checks and cache request metrics.
+    /// Use it only after `get()` returned `NeedsRevalidation`.
+    pub fn get_entry_for_revalidation(&self, path: &str) -> Option<CacheEntry> {
+        let conn = self.conn.lock().unwrap();
+
+        conn.query_row(
+            "SELECT content, etag FROM file_cache WHERE path = ?",
+            params![path],
+            |row| {
+                Ok(CacheEntry {
+                    content: row.get(0)?,
+                    etag: row.get(1)?,
+                })
+            },
+        )
+        .optional()
+        .ok()
+        .flatten()
     }
 
     /// Get etag for a cached file (for conditional requests).
@@ -232,22 +279,31 @@ impl FileCache {
             return;
         }
 
-        let conn = self.conn.lock().unwrap();
-        let now = Self::now();
+        let inserted = {
+            let conn = self.conn.lock().unwrap();
+            let now = Self::now();
 
-        if let Err(e) = conn.execute(
-            "INSERT OR REPLACE INTO file_cache (path, content, etag, size, cached_at)
-             VALUES (?, ?, ?, ?, ?)",
-            params![path, content, etag, content.len() as i64, now],
-        ) {
-            error!("Failed to cache {}: {}", path, e);
-        } else {
+            match conn.execute(
+                "INSERT OR REPLACE INTO file_cache (path, content, etag, size, cached_at)
+                 VALUES (?, ?, ?, ?, ?)",
+                params![path, content, etag, content.len() as i64, now],
+            ) {
+                Ok(_) => true,
+                Err(e) => {
+                    error!("Failed to cache {}: {}", path, e);
+                    false
+                }
+            }
+        };
+
+        if inserted {
             debug!(
                 "Cached {} ({} bytes, etag: {:?})",
                 path,
                 content.len(),
                 etag
             );
+            self.stats();
         }
     }
 
@@ -268,10 +324,14 @@ impl FileCache {
 
     /// Invalidate a specific path.
     pub fn invalidate(&self, path: &str) {
-        let conn = self.conn.lock().unwrap();
+        {
+            let conn = self.conn.lock().unwrap();
 
-        let _ = conn.execute("DELETE FROM file_cache WHERE path = ?", params![path]);
-        let _ = conn.execute("DELETE FROM metadata_cache WHERE path = ?", params![path]);
+            let _ = conn.execute("DELETE FROM file_cache WHERE path = ?", params![path]);
+            let _ = conn.execute("DELETE FROM metadata_cache WHERE path = ?", params![path]);
+        }
+
+        self.stats();
 
         debug!("Invalidated cache for {}", path);
     }
@@ -334,6 +394,8 @@ impl FileCache {
             })
             .unwrap_or(0);
 
+        metrics::set_cache_bytes_in_use("sqlite", total_size);
+
         CacheStats {
             file_count,
             total_size,
@@ -358,12 +420,29 @@ mod tests {
         FileCache::open_connection(conn).unwrap()
     }
 
+    fn metric_value(rendered: &str, metric: &str) -> Option<u64> {
+        rendered.lines().find_map(|line| {
+            line.strip_prefix(metric)
+                .and_then(|value| value.trim().parse::<u64>().ok())
+        })
+    }
+
+    fn assert_metric_at_least(metric: &str, expected: u64) {
+        let rendered = crate::metrics::render();
+        let actual = metric_value(&rendered, metric).unwrap_or(0);
+        assert!(
+            actual >= expected,
+            "expected {metric}{expected} or greater, got {actual}\n{rendered}"
+        );
+    }
+
     // ──────────────────────────────────────────────────────
     // 1. Basic put / get / invalidate (existing test, kept)
     // ──────────────────────────────────────────────────────
 
     #[test]
     fn test_cache_basic() {
+        let _guard = crate::metrics::test_guard();
         let cache = test_cache("basic");
 
         // Miss on empty cache
@@ -385,12 +464,86 @@ mod tests {
         assert!(matches!(cache.get("/test.txt"), CacheLookup::Miss));
     }
 
+    #[test]
+    fn test_cache_get_records_hit_miss_and_stale_metrics() {
+        let _guard = crate::metrics::test_guard();
+        crate::metrics::reset_for_tests();
+        let cache = test_cache("metrics");
+
+        assert!(matches!(cache.get("/metrics-miss.txt"), CacheLookup::Miss));
+        assert_metric_at_least(
+            "nexus_cache_requests_total{tier=\"sqlite\",result=\"miss\"} ",
+            1,
+        );
+
+        cache.put("/metrics-hit.txt", b"data", Some("etag-1"));
+        assert!(matches!(cache.get("/metrics-hit.txt"), CacheLookup::Hit(_)));
+        assert_metric_at_least(
+            "nexus_cache_requests_total{tier=\"sqlite\",result=\"hit\"} ",
+            1,
+        );
+
+        let old_cached_at = FileCache::now().saturating_sub(MAX_CACHE_AGE_SECS + 1);
+        {
+            let conn = cache.conn.lock().unwrap();
+            conn.execute(
+                "UPDATE file_cache SET cached_at = ? WHERE path = ?",
+                params![old_cached_at, "/metrics-hit.txt"],
+            )
+            .unwrap();
+        }
+        assert!(matches!(
+            cache.get("/metrics-hit.txt"),
+            CacheLookup::NeedsRevalidation { .. }
+        ));
+        assert_metric_at_least(
+            "nexus_cache_requests_total{tier=\"sqlite\",result=\"stale\"} ",
+            1,
+        );
+    }
+
+    #[test]
+    fn test_cache_put_records_bytes_in_use() {
+        let _guard = crate::metrics::test_guard();
+        crate::metrics::reset_for_tests();
+        let cache = test_cache("bytes");
+
+        cache.put("/metrics-bytes.txt", b"data", Some("etag-1"));
+
+        assert_eq!(
+            metric_value(
+                &crate::metrics::render(),
+                "nexus_cache_bytes_in_use{tier=\"sqlite\"} "
+            ),
+            Some(4)
+        );
+    }
+
+    #[test]
+    fn test_cache_invalidate_refreshes_bytes_in_use() {
+        let _guard = crate::metrics::test_guard();
+        crate::metrics::reset_for_tests();
+        let cache = test_cache("invalidate-bytes");
+
+        cache.put("/metrics-invalidated.txt", b"data", Some("etag-1"));
+        cache.invalidate("/metrics-invalidated.txt");
+
+        assert_eq!(
+            metric_value(
+                &crate::metrics::render(),
+                "nexus_cache_bytes_in_use{tier=\"sqlite\"} "
+            ),
+            Some(0)
+        );
+    }
+
     // ──────────────────────────────────────────────────────
     // 2. Put without etag → stale entries become Miss (not NeedsRevalidation)
     // ──────────────────────────────────────────────────────
 
     #[test]
     fn test_put_without_etag() {
+        let _guard = crate::metrics::test_guard();
         let cache = test_cache("no-etag");
         cache.put("/no-etag.txt", b"data", None);
 
@@ -409,6 +562,7 @@ mod tests {
 
     #[test]
     fn test_overwrite_entry() {
+        let _guard = crate::metrics::test_guard();
         let cache = test_cache("overwrite");
         cache.put("/f.txt", b"v1", Some("e1"));
         cache.put("/f.txt", b"v2", Some("e2"));
@@ -428,6 +582,7 @@ mod tests {
 
     #[test]
     fn test_get_etag() {
+        let _guard = crate::metrics::test_guard();
         let cache = test_cache("etag");
         assert_eq!(cache.get_etag("/missing.txt"), None);
 
@@ -444,6 +599,7 @@ mod tests {
 
     #[test]
     fn test_touch_refreshes_entry() {
+        let _guard = crate::metrics::test_guard();
         let cache = test_cache("touch");
         cache.put("/t.txt", b"data", Some("e1"));
 
@@ -462,6 +618,7 @@ mod tests {
 
     #[test]
     fn test_large_file_not_cached() {
+        let _guard = crate::metrics::test_guard();
         let cache = test_cache("large");
         let big = vec![0u8; MAX_FILE_SIZE + 1];
         cache.put("/big.bin", &big, Some("e1"));
@@ -476,6 +633,7 @@ mod tests {
 
     #[test]
     fn test_max_size_file_cached() {
+        let _guard = crate::metrics::test_guard();
         let cache = test_cache("maxsize");
         let data = vec![42u8; MAX_FILE_SIZE];
         cache.put("/exact.bin", &data, Some("e1"));
@@ -492,6 +650,7 @@ mod tests {
 
     #[test]
     fn test_cache_stats() {
+        let _guard = crate::metrics::test_guard();
         let cache = test_cache("stats");
 
         // Ensure clean slate (DB persists on disk between runs)
@@ -513,6 +672,7 @@ mod tests {
 
     #[test]
     fn test_stats_after_invalidation() {
+        let _guard = crate::metrics::test_guard();
         let cache = test_cache("stats-inv");
         cache.put("/x.txt", b"12345", None);
 
@@ -533,6 +693,7 @@ mod tests {
 
     #[test]
     fn test_multiple_independent_paths() {
+        let _guard = crate::metrics::test_guard();
         let cache = test_cache("multi");
         cache.put("/a.txt", b"aaa", Some("ea"));
         cache.put("/b.txt", b"bbb", Some("eb"));
@@ -552,6 +713,7 @@ mod tests {
 
     #[test]
     fn test_empty_content_cached() {
+        let _guard = crate::metrics::test_guard();
         let cache = test_cache("empty");
         cache.put("/empty.txt", b"", Some("e0"));
 
@@ -570,6 +732,7 @@ mod tests {
 
     #[test]
     fn test_binary_content_preserved() {
+        let _guard = crate::metrics::test_guard();
         let cache = test_cache("binary");
         let binary: Vec<u8> = (0..=255).collect();
         cache.put("/bin.dat", &binary, Some("ebin"));
@@ -586,6 +749,7 @@ mod tests {
 
     #[test]
     fn test_concurrent_access() {
+        let _guard = crate::metrics::test_guard();
         use std::sync::Arc;
         use std::thread;
 
@@ -619,6 +783,7 @@ mod tests {
 
     #[test]
     fn test_cleanup_removes_old_entries() {
+        let _guard = crate::metrics::test_guard();
         let cache = test_cache("cleanup");
 
         // Insert an entry, then manually backdate it
@@ -650,6 +815,7 @@ mod tests {
 
     #[test]
     fn test_invalidate_nonexistent_is_noop() {
+        let _guard = crate::metrics::test_guard();
         let cache = test_cache("inv-noop");
         // Should not panic or error
         cache.invalidate("/does-not-exist.txt");

--- a/nexus-fuse/src/client.rs
+++ b/nexus-fuse/src/client.rs
@@ -90,11 +90,15 @@ pub struct NexusClient {
 
 impl NexusClient {
     /// Create a new Nexus client.
-    pub fn new(base_url: &str, api_key: &str, agent_id: Option<String>) -> Result<Self, NexusClientError> {
+    pub fn new(
+        base_url: &str,
+        api_key: &str,
+        agent_id: Option<String>,
+    ) -> Result<Self, NexusClientError> {
         let client = Client::builder()
             .timeout(std::time::Duration::from_secs(30))
             .connect_timeout(std::time::Duration::from_secs(5))
-            .no_proxy()  // Disable proxy to avoid HTTP_PROXY interference
+            .no_proxy() // Disable proxy to avoid HTTP_PROXY interference
             .build()?;
 
         Ok(Self {
@@ -139,7 +143,11 @@ impl NexusClient {
     }
 
     /// Call a JSON-RPC method.
-    fn rpc_call<T: for<'de> Deserialize<'de>>(&self, method: &str, params: Value) -> Result<T, NexusClientError> {
+    fn rpc_call<T: for<'de> Deserialize<'de>>(
+        &self,
+        method: &str,
+        params: Value,
+    ) -> Result<T, NexusClientError> {
         let url = format!("{}/api/nfs/{}", self.base_url, method);
 
         // Build proper JSON-RPC request
@@ -188,11 +196,7 @@ impl NexusClient {
         let url = format!("{}/api/auth/whoami", self.base_url);
         debug!("GET {}", url);
 
-        let resp = self
-            .client
-            .get(&url)
-            .headers(self.headers())
-            .send()?;
+        let resp = self.client.get(&url).headers(self.headers()).send()?;
 
         if !resp.status().is_success() {
             let status = resp.status();
@@ -225,53 +229,62 @@ impl NexusClient {
             files: Vec<DetailedEntry>,
         }
 
-        let result: ListResult = self.rpc_call("list", json!({
-            "path": path,
-            "recursive": false,
-            "details": true
-        }))?;
+        let result: ListResult = self.rpc_call(
+            "list",
+            json!({
+                "path": path,
+                "recursive": false,
+                "details": true
+            }),
+        )?;
 
         // Convert to FileEntry objects - extract immediate children only
         let parent_prefix = if path == "/" { "/" } else { path };
         let mut seen_names = std::collections::HashSet::new();
 
-        let entries = result.files.iter().filter_map(|entry| {
-            // Strip parent prefix to get relative path
-            let relative = if path == "/" {
-                entry.path.strip_prefix('/').unwrap_or(&entry.path)
-            } else {
-                entry.path.strip_prefix(parent_prefix)
-                    .and_then(|s| s.strip_prefix('/'))
-                    .unwrap_or(&entry.path)
-            };
+        let entries = result
+            .files
+            .iter()
+            .filter_map(|entry| {
+                // Strip parent prefix to get relative path
+                let relative = if path == "/" {
+                    entry.path.strip_prefix('/').unwrap_or(&entry.path)
+                } else {
+                    entry
+                        .path
+                        .strip_prefix(parent_prefix)
+                        .and_then(|s| s.strip_prefix('/'))
+                        .unwrap_or(&entry.path)
+                };
 
-            // Get immediate child (first path component)
-            let name = relative.split('/').next()?.to_string();
-            if name.is_empty() {
-                return None;
-            }
+                // Get immediate child (first path component)
+                let name = relative.split('/').next()?.to_string();
+                if name.is_empty() {
+                    return None;
+                }
 
-            // Deduplicate (same directory may appear multiple times from nested files)
-            if !seen_names.insert(name.clone()) {
-                return None;
-            }
+                // Deduplicate (same directory may appear multiple times from nested files)
+                if !seen_names.insert(name.clone()) {
+                    return None;
+                }
 
-            // If there are more path components, this is a directory
-            let is_nested = relative.contains('/');
-            let entry_type = if is_nested || entry.is_directory {
-                "directory".to_string()
-            } else {
-                "file".to_string()
-            };
+                // If there are more path components, this is a directory
+                let is_nested = relative.contains('/');
+                let entry_type = if is_nested || entry.is_directory {
+                    "directory".to_string()
+                } else {
+                    "file".to_string()
+                };
 
-            Some(FileEntry {
-                name,
-                entry_type,
-                size: if is_nested { 0 } else { entry.size },
-                created_at: None,  // Complex type from API, not used
-                updated_at: None,  // Complex type from API, not used
+                Some(FileEntry {
+                    name,
+                    entry_type,
+                    size: if is_nested { 0 } else { entry.size },
+                    created_at: None, // Complex type from API, not used
+                    updated_at: None, // Complex type from API, not used
+                })
             })
-        }).collect();
+            .collect();
 
         Ok(entries)
     }
@@ -285,13 +298,19 @@ impl NexusClient {
     pub fn read(&self, path: &str) -> Result<Vec<u8>, NexusClientError> {
         match self.read_with_etag(path, None)? {
             ReadResponse::Content { content, .. } => Ok(content),
-            ReadResponse::NotModified => Err(NexusClientError::InvalidResponse("Unexpected 304 without etag".to_string())),
+            ReadResponse::NotModified => Err(NexusClientError::InvalidResponse(
+                "Unexpected 304 without etag".to_string(),
+            )),
         }
     }
 
     /// Read file contents with ETag support for conditional requests.
     /// If `if_none_match` is provided and content hasn't changed, returns NotModified.
-    pub fn read_with_etag(&self, path: &str, if_none_match: Option<&str>) -> Result<ReadResponse, NexusClientError> {
+    pub fn read_with_etag(
+        &self,
+        path: &str,
+        if_none_match: Option<&str>,
+    ) -> Result<ReadResponse, NexusClientError> {
         use base64::{engine::general_purpose::STANDARD, Engine};
 
         let url = format!("{}/api/nfs/read", self.base_url);
@@ -365,10 +384,12 @@ impl NexusClient {
             )));
         }
 
-        let result = rpc_resp.result.ok_or_else(|| NexusClientError::InvalidResponse("no result in response".to_string()))?;
-        let content = STANDARD
-            .decode(&result.data)
-            .map_err(|e| NexusClientError::InvalidResponse(format!("base64 decode error: {}", e)))?;
+        let result = rpc_resp.result.ok_or_else(|| {
+            NexusClientError::InvalidResponse("no result in response".to_string())
+        })?;
+        let content = STANDARD.decode(&result.data).map_err(|e| {
+            NexusClientError::InvalidResponse(format!("base64 decode error: {}", e))
+        })?;
 
         Ok(ReadResponse::Content { content, etag })
     }
@@ -378,13 +399,16 @@ impl NexusClient {
         use base64::{engine::general_purpose::STANDARD, Engine};
 
         // API expects {"__type__": "bytes", "data": "base64..."} format
-        let _: Value = self.rpc_call("write", json!({
-            "path": path,
-            "content": {
-                "__type__": "bytes",
-                "data": STANDARD.encode(content)
-            }
-        }))?;
+        let _: Value = self.rpc_call(
+            "write",
+            json!({
+                "path": path,
+                "content": {
+                    "__type__": "bytes",
+                    "data": STANDARD.encode(content)
+                }
+            }),
+        )?;
         Ok(())
     }
 
@@ -402,10 +426,13 @@ impl NexusClient {
 
     /// Rename/move file or directory.
     pub fn rename(&self, old_path: &str, new_path: &str) -> Result<(), NexusClientError> {
-        let _: Value = self.rpc_call("rename", json!({
-            "old_path": old_path,
-            "new_path": new_path
-        }))?;
+        let _: Value = self.rpc_call(
+            "rename",
+            json!({
+                "old_path": old_path,
+                "new_path": new_path
+            }),
+        )?;
         Ok(())
     }
 

--- a/nexus-fuse/src/daemon.rs
+++ b/nexus-fuse/src/daemon.rs
@@ -10,6 +10,7 @@ use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::path::PathBuf;
+use std::time::Instant;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
 use tokio::signal;
@@ -83,11 +84,7 @@ pub struct Daemon {
 impl Daemon {
     /// Create a new daemon instance.
     pub fn new(config: DaemonConfig) -> Result<Self, NexusClientError> {
-        let client = NexusClient::new(
-            &config.nexus_url,
-            &config.api_key,
-            config.agent_id.clone(),
-        )?;
+        let client = NexusClient::new(&config.nexus_url, &config.api_key, config.agent_id.clone())?;
 
         Ok(Self { config, client })
     }
@@ -173,12 +170,7 @@ async fn handle_connection(stream: UnixStream, client: NexusClient) -> anyhow::R
             Ok(request) => handle_request(request, &client).await,
             Err(e) => {
                 error!("Failed to parse JSON-RPC request: {}", e);
-                JsonRpcResponse::error(
-                    None,
-                    -32700,
-                    format!("Parse error: {}", e),
-                    None,
-                )
+                JsonRpcResponse::error(None, -32700, format!("Parse error: {}", e), None)
             }
         };
 
@@ -229,7 +221,12 @@ async fn handle_request(request: JsonRpcRequest, client: &NexusClient) -> JsonRp
         Ok(r) => r,
         Err(e) => {
             error!("Task join error: {}", e);
-            return JsonRpcResponse::error(request.id, -32603, format!("Internal error: {}", e), None);
+            return JsonRpcResponse::error(
+                request.id,
+                -32603,
+                format!("Internal error: {}", e),
+                None,
+            );
         }
     };
 
@@ -248,10 +245,22 @@ async fn handle_request(request: JsonRpcRequest, client: &NexusClient) -> JsonRp
 
 fn handle_read(params: &Value, client: &NexusClient) -> Result<Value, NexusClientError> {
     #[derive(Deserialize)]
-    struct P { path: String }
+    struct P {
+        path: String,
+    }
     let p: P = extract_params(params)?;
 
-    let content = client.read(&p.path)?;
+    let started_at = Instant::now();
+    let content = match client.read(&p.path) {
+        Ok(content) => {
+            crate::metrics::record_read("backend", content.len(), started_at.elapsed());
+            content
+        }
+        Err(error) => {
+            crate::metrics::record_read("error", 0, started_at.elapsed());
+            return Err(error);
+        }
+    };
     let encoded = base64::engine::general_purpose::STANDARD.encode(&content);
 
     Ok(json!({
@@ -268,7 +277,10 @@ fn handle_write(params: &Value, client: &NexusClient) -> Result<Value, NexusClie
         data: String,
     }
     #[derive(Deserialize)]
-    struct P { path: String, content: ContentBytes }
+    struct P {
+        path: String,
+        content: ContentBytes,
+    }
     let p: P = extract_params(params)?;
 
     let content = base64::engine::general_purpose::STANDARD
@@ -276,12 +288,15 @@ fn handle_write(params: &Value, client: &NexusClient) -> Result<Value, NexusClie
         .map_err(|e| NexusClientError::InvalidResponse(format!("Invalid base64: {}", e)))?;
 
     client.write(&p.path, &content)?;
+    crate::metrics::record_write_backend_rpc();
     Ok(json!({}))
 }
 
 fn handle_list(params: &Value, client: &NexusClient) -> Result<Value, NexusClientError> {
     #[derive(Deserialize)]
-    struct P { path: String }
+    struct P {
+        path: String,
+    }
     let p: P = extract_params(params)?;
 
     let files = client.list(&p.path)?;
@@ -290,7 +305,9 @@ fn handle_list(params: &Value, client: &NexusClient) -> Result<Value, NexusClien
 
 fn handle_stat(params: &Value, client: &NexusClient) -> Result<Value, NexusClientError> {
     #[derive(Deserialize)]
-    struct P { path: String }
+    struct P {
+        path: String,
+    }
     let p: P = extract_params(params)?;
 
     let metadata = client.stat(&p.path)?;
@@ -300,7 +317,9 @@ fn handle_stat(params: &Value, client: &NexusClient) -> Result<Value, NexusClien
 
 fn handle_mkdir(params: &Value, client: &NexusClient) -> Result<Value, NexusClientError> {
     #[derive(Deserialize)]
-    struct P { path: String }
+    struct P {
+        path: String,
+    }
     let p: P = extract_params(params)?;
 
     client.mkdir(&p.path)?;
@@ -309,7 +328,9 @@ fn handle_mkdir(params: &Value, client: &NexusClient) -> Result<Value, NexusClie
 
 fn handle_delete(params: &Value, client: &NexusClient) -> Result<Value, NexusClientError> {
     #[derive(Deserialize)]
-    struct P { path: String }
+    struct P {
+        path: String,
+    }
     let p: P = extract_params(params)?;
 
     client.delete(&p.path)?;
@@ -318,7 +339,10 @@ fn handle_delete(params: &Value, client: &NexusClient) -> Result<Value, NexusCli
 
 fn handle_rename(params: &Value, client: &NexusClient) -> Result<Value, NexusClientError> {
     #[derive(Deserialize)]
-    struct P { old_path: String, new_path: String }
+    struct P {
+        old_path: String,
+        new_path: String,
+    }
     let p: P = extract_params(params)?;
 
     client.rename(&p.old_path, &p.new_path)?;
@@ -327,9 +351,99 @@ fn handle_rename(params: &Value, client: &NexusClient) -> Result<Value, NexusCli
 
 fn handle_exists(params: &Value, client: &NexusClient) -> Result<Value, NexusClientError> {
     #[derive(Deserialize)]
-    struct P { path: String }
+    struct P {
+        path: String,
+    }
     let p: P = extract_params(params)?;
 
     let exists = client.exists(&p.path);
     Ok(json!({ "exists": exists }))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use base64::Engine;
+    use mockito::Server;
+
+    fn test_guard() -> std::sync::MutexGuard<'static, ()> {
+        crate::metrics::test_guard()
+    }
+
+    #[test]
+    fn daemon_read_records_backend_metrics_on_success() {
+        let _guard = test_guard();
+        crate::metrics::reset_for_tests();
+        let mut server = Server::new();
+        let payload = base64::engine::general_purpose::STANDARD.encode(b"daemon");
+
+        let _mock = server
+            .mock("POST", "/api/nfs/read")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(format!(
+                r#"{{"jsonrpc":"2.0","id":1,"result":{{"__type__":"bytes","data":"{payload}"}}}}"#
+            ))
+            .create();
+
+        let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+
+        let result = handle_read(&json!({"path": "/daemon.txt"}), &client).unwrap();
+
+        assert_eq!(result["data"], payload);
+        let metrics = crate::metrics::render();
+        assert!(metrics.contains("nexus_read_bytes_total{tier=\"backend\"} 6"));
+        assert!(metrics.contains("nexus_read_latency_seconds_count{tier=\"backend\"} 1"));
+    }
+
+    #[test]
+    fn daemon_read_records_error_metrics_on_failure() {
+        let _guard = test_guard();
+        crate::metrics::reset_for_tests();
+        let mut server = Server::new();
+
+        let _mock = server
+            .mock("POST", "/api/nfs/read")
+            .with_status(500)
+            .with_body("server error")
+            .create();
+
+        let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+
+        let result = handle_read(&json!({"path": "/daemon.txt"}), &client);
+
+        assert!(result.is_err());
+        let metrics = crate::metrics::render();
+        assert!(metrics.contains("nexus_read_bytes_total{tier=\"error\"} 0"));
+        assert!(metrics.contains("nexus_read_latency_seconds_count{tier=\"error\"} 1"));
+    }
+
+    #[test]
+    fn daemon_write_records_backend_rpc_on_success() {
+        let _guard = test_guard();
+        crate::metrics::reset_for_tests();
+        let mut server = Server::new();
+        let payload = base64::engine::general_purpose::STANDARD.encode(b"daemon");
+
+        let _mock = server
+            .mock("POST", "/api/nfs/write")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(r#"{"jsonrpc":"2.0","id":1,"result":{}}"#)
+            .create();
+
+        let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+
+        handle_write(
+            &json!({
+                "path": "/daemon.txt",
+                "content": {"__type__": "bytes", "data": payload}
+            }),
+            &client,
+        )
+        .unwrap();
+
+        assert!(crate::metrics::render().contains("nexus_write_backend_rpc_total 1"));
+    }
 }

--- a/nexus-fuse/src/fs.rs
+++ b/nexus-fuse/src/fs.rs
@@ -2,6 +2,7 @@
 
 use crate::cache::{CacheLookup, FileCache};
 use crate::client::{FileEntry, NexusClient, ReadResponse};
+use crate::metrics;
 use fuser::{
     FileAttr, FileType, Filesystem, ReplyAttr, ReplyData, ReplyDirectory, ReplyEntry, ReplyWrite,
     Request, FUSE_ROOT_ID,
@@ -169,6 +170,13 @@ pub struct NexusFs {
     dir_cache: Mutex<LruCache<u64, (Vec<FileEntry>, SystemTime)>>,
     /// Persistent SQLite cache for file content (optional).
     file_cache: Option<FileCache>,
+}
+
+#[derive(Debug)]
+struct ReadCachedResult {
+    content: Vec<u8>,
+    etag: Option<String>,
+    tier: &'static str,
 }
 
 impl NexusFs {
@@ -375,43 +383,63 @@ impl NexusFs {
     /// 4. If server returns 304 -> touch cache, return cached content
     /// 5. If server returns 200 -> update cache, return new content
     /// 6. If miss -> fetch from server, store in cache
-    fn read_cached(&self, path: &str) -> anyhow::Result<(Vec<u8>, Option<String>)> {
+    fn read_cached(&self, path: &str) -> anyhow::Result<ReadCachedResult> {
         // Check persistent cache first
         if let Some(ref cache) = self.file_cache {
             match cache.get(path) {
                 CacheLookup::Hit(entry) => {
                     debug!("SQLite cache hit for {}", path);
-                    return Ok((entry.content, entry.etag));
+                    return Ok(ReadCachedResult {
+                        content: entry.content,
+                        etag: entry.etag,
+                        tier: "cache",
+                    });
                 }
                 CacheLookup::NeedsRevalidation { etag } => {
                     // Send conditional request
                     debug!("Revalidating cache for {} with etag {}", path, etag);
                     match self.client.read_with_etag(path, Some(&etag)) {
                         Ok(ReadResponse::NotModified) => {
+                            metrics::record_cache_etag_revalidate("304");
+                            metrics::record_etag_check("304");
                             // Touch cache to refresh timestamp
                             cache.touch(path);
-                            // Return cached content - must re-fetch from cache
-                            match cache.get(path) {
-                                CacheLookup::Hit(entry) => {
-                                    return Ok((entry.content, entry.etag));
-                                }
-                                _ => {
-                                    // Cache inconsistency - should not happen
-                                    error!("Cache inconsistency after 304 for {}", path);
-                                }
+                            // Return cached content without recording another cache request.
+                            if let Some(entry) = cache.get_entry_for_revalidation(path) {
+                                return Ok(ReadCachedResult {
+                                    content: entry.content,
+                                    etag: entry.etag,
+                                    tier: "cache",
+                                });
                             }
+                            // Cache inconsistency - should not happen
+                            error!("Cache inconsistency after 304 for {}", path);
                         }
                         Ok(ReadResponse::Content { content, etag }) => {
                             // Update cache with new content
+                            metrics::record_cache_etag_revalidate("updated");
+                            metrics::record_etag_check("updated");
                             cache.put(path, &content, etag.as_deref());
-                            return Ok((content, etag));
+                            return Ok(ReadCachedResult {
+                                content,
+                                etag,
+                                tier: "backend",
+                            });
                         }
                         Err(e) => {
                             // On error, try to use stale cache as fallback
                             debug!("Revalidation failed for {}: {}, using stale cache", path, e);
-                            if let CacheLookup::Hit(entry) = cache.get(path) {
-                                return Ok((entry.content, entry.etag));
+                            if let Some(entry) = cache.get_entry_for_revalidation(path) {
+                                metrics::record_cache_etag_revalidate("fallback");
+                                metrics::record_etag_check("fallback");
+                                return Ok(ReadCachedResult {
+                                    content: entry.content,
+                                    etag: entry.etag,
+                                    tier: "cache",
+                                });
                             }
+                            metrics::record_cache_etag_revalidate("error");
+                            metrics::record_etag_check("error");
                             return Err(e.into());
                         }
                     }
@@ -429,10 +457,15 @@ impl NexusFs {
                 if let Some(ref cache) = self.file_cache {
                     cache.put(path, &content, etag.as_deref());
                 }
-                Ok((content, etag))
+                Ok(ReadCachedResult {
+                    content,
+                    etag,
+                    tier: "backend",
+                })
             }
             Ok(ReadResponse::NotModified) => {
                 // Shouldn't happen without etag, but handle gracefully
+                metrics::record_etag_check("unexpected_304");
                 Err(anyhow::anyhow!("Unexpected 304 response"))
             }
             Err(e) => Err(e.into()),
@@ -604,9 +637,12 @@ impl Filesystem for NexusFs {
         let path = resolve_path!(self, ino, reply);
 
         // Read using SQLite cache with ETag support
-        let content = match self.read_cached(&path) {
-            Ok((data, _etag)) => data,
+        let started_at = std::time::Instant::now();
+
+        let read_result = match self.read_cached(&path) {
+            Ok(result) => result,
             Err(e) => {
+                metrics::record_read("error", 0, started_at.elapsed());
                 if e.downcast_ref::<crate::error::NexusClientError>()
                     .map_or(false, |ne| ne.is_not_found())
                 {
@@ -619,13 +655,22 @@ impl Filesystem for NexusFs {
             }
         };
 
+        let ReadCachedResult {
+            content,
+            etag: _etag,
+            tier,
+        } = read_result;
+
         // Return requested slice
         let offset = offset as usize;
         if offset >= content.len() {
+            metrics::record_read(tier, 0, started_at.elapsed());
             reply.data(&[]);
         } else {
             let end = std::cmp::min(offset + size as usize, content.len());
-            reply.data(&content[offset..end]);
+            let slice = &content[offset..end];
+            metrics::record_read(tier, slice.len(), started_at.elapsed());
+            reply.data(slice);
         }
     }
 
@@ -650,7 +695,7 @@ impl Filesystem for NexusFs {
         if offset != 0 {
             // Read existing content first (use cache if available)
             let existing = match self.read_cached(&path) {
-                Ok((data, _)) => data,
+                Ok(result) => result.content,
                 Err(e) => {
                     error!("partial write: read failed for {}: {}", path, e);
                     reply.error(EIO);
@@ -674,6 +719,7 @@ impl Filesystem for NexusFs {
 
             match self.client.write(&path, &new_content) {
                 Ok(_) => {
+                    metrics::record_write_backend_rpc();
                     self.invalidate_path(&path);
                     reply.written(data.len() as u32);
                 }
@@ -685,6 +731,7 @@ impl Filesystem for NexusFs {
         } else {
             match self.client.write(&path, data) {
                 Ok(_) => {
+                    metrics::record_write_backend_rpc();
                     self.invalidate_path(&path);
                     reply.written(data.len() as u32);
                 }
@@ -716,6 +763,7 @@ impl Filesystem for NexusFs {
         // Create empty file
         match self.client.write(&path, &[]) {
             Ok(_) => {
+                metrics::record_write_backend_rpc();
                 let inode = self.inodes.lock().unwrap().get_or_create(&path);
                 self.invalidate_path(&path);
 
@@ -907,6 +955,7 @@ impl Filesystem for NexusFs {
                 // Truncate to empty
                 match self.client.write(&path, &[]) {
                     Ok(_) => {
+                        metrics::record_write_backend_rpc();
                         self.invalidate_path(&path);
                     }
                     Err(e) => {
@@ -918,10 +967,12 @@ impl Filesystem for NexusFs {
             } else {
                 // Truncate to specific size - read and rewrite (use cache if available)
                 match self.read_cached(&path) {
-                    Ok((mut data, _)) => {
+                    Ok(result) => {
+                        let mut data = result.content;
                         data.resize(new_size as usize, 0);
                         match self.client.write(&path, &data) {
                             Ok(_) => {
+                                metrics::record_write_backend_rpc();
                                 self.invalidate_path(&path);
                             }
                             Err(e) => {
@@ -1045,6 +1096,14 @@ impl Filesystem for NexusFs {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use mockito::{Matcher, Server};
+
+    fn metric_value(rendered: &str, metric: &str) -> Option<u64> {
+        rendered.lines().find_map(|line| {
+            line.strip_prefix(metric)
+                .and_then(|value| value.trim().parse::<u64>().ok())
+        })
+    }
 
     #[test]
     fn test_get_or_create_idempotent() {
@@ -1076,6 +1135,85 @@ mod tests {
         assert_eq!(table.get_path(FUSE_ROOT_ID), Some("/".to_string()));
         assert_eq!(table.get_inode("/"), Some(FUSE_ROOT_ID));
         assert_eq!(table.peek_inode("/"), Some(FUSE_ROOT_ID));
+    }
+
+    #[test]
+    fn read_cached_returns_stale_cache_when_revalidation_errors() {
+        let _guard = crate::metrics::test_guard();
+        crate::metrics::reset_for_tests();
+
+        let mut server = Server::new();
+        let read_mock = server
+            .mock("POST", "/api/nfs/read")
+            .match_header("if-none-match", Matcher::Exact("\"etag-1\"".to_string()))
+            .with_status(500)
+            .with_body("backend unavailable")
+            .create();
+
+        let cache = FileCache::open_in_memory_for_tests();
+        cache.put("/stale.txt", b"stale-data", Some("etag-1"));
+        cache.set_cached_at_for_tests("/stale.txt", 0);
+
+        let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+        let fs = NexusFs::new(client, Some(cache));
+
+        let result = fs.read_cached("/stale.txt").unwrap();
+
+        assert_eq!(result.content, b"stale-data");
+        assert_eq!(result.etag, Some("etag-1".to_string()));
+        assert_eq!(result.tier, "cache");
+        read_mock.assert();
+
+        let rendered = crate::metrics::render();
+        assert!(rendered.contains("nexus_cache_etag_revalidate_total{result=\"fallback\"} 1"));
+        assert!(rendered.contains("nexus_etag_check_total{result=\"fallback\"} 1"));
+        assert!(!rendered.contains("nexus_cache_etag_revalidate_total{result=\"error\"}"));
+        assert!(!rendered.contains("nexus_etag_check_total{result=\"error\"}"));
+    }
+
+    #[test]
+    fn read_cached_not_modified_does_not_record_extra_cache_hit() {
+        let _guard = crate::metrics::test_guard();
+        crate::metrics::reset_for_tests();
+
+        let mut server = Server::new();
+        let read_mock = server
+            .mock("POST", "/api/nfs/read")
+            .match_header("if-none-match", Matcher::Exact("\"etag-1\"".to_string()))
+            .with_status(304)
+            .create();
+
+        let cache = FileCache::open_in_memory_for_tests();
+        cache.put("/not-modified.txt", b"cached-data", Some("etag-1"));
+        cache.set_cached_at_for_tests("/not-modified.txt", 0);
+
+        let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+        let fs = NexusFs::new(client, Some(cache));
+
+        let result = fs.read_cached("/not-modified.txt").unwrap();
+
+        assert_eq!(result.content, b"cached-data");
+        assert_eq!(result.etag, Some("etag-1".to_string()));
+        assert_eq!(result.tier, "cache");
+        read_mock.assert();
+
+        let rendered = crate::metrics::render();
+        assert_eq!(
+            metric_value(
+                &rendered,
+                "nexus_cache_requests_total{tier=\"sqlite\",result=\"stale\"} "
+            ),
+            Some(1)
+        );
+        assert_eq!(
+            metric_value(
+                &rendered,
+                "nexus_cache_requests_total{tier=\"sqlite\",result=\"hit\"} "
+            ),
+            None
+        );
+        assert!(rendered.contains("nexus_cache_etag_revalidate_total{result=\"304\"} 1"));
+        assert!(rendered.contains("nexus_etag_check_total{result=\"304\"} 1"));
     }
 
     /// Root inode must survive even when MAX_INODE_ENTRIES are inserted

--- a/nexus-fuse/src/lib.rs
+++ b/nexus-fuse/src/lib.rs
@@ -7,3 +7,4 @@ pub mod client;
 pub mod daemon;
 pub mod error;
 pub mod fs;
+pub mod metrics;

--- a/nexus-fuse/src/main.rs
+++ b/nexus-fuse/src/main.rs
@@ -4,9 +4,9 @@
 //! fast startup time (<100ms vs ~10s for Python version).
 
 use clap::{Parser, Subcommand};
-use nexus_fuse::{cache, client, daemon, fs};
 use fuser::MountOption;
 use log::{error, info};
+use nexus_fuse::{cache, client, daemon, fs, metrics};
 use std::path::PathBuf;
 
 #[derive(Parser)]
@@ -49,6 +49,10 @@ enum Commands {
         /// Agent ID for file attribution
         #[arg(long, env = "NEXUS_AGENT_ID")]
         agent_id: Option<String>,
+
+        /// Prometheus metrics bind address, for example 127.0.0.1:9464
+        #[arg(long, env = "NEXUS_FUSE_METRICS_ADDR")]
+        metrics_addr: Option<String>,
     },
     /// Run as Unix socket IPC daemon for Python integration
     Daemon {
@@ -71,6 +75,10 @@ enum Commands {
         /// Agent ID for file attribution
         #[arg(long, env = "NEXUS_AGENT_ID")]
         agent_id: Option<String>,
+
+        /// Prometheus metrics bind address, for example 127.0.0.1:9464
+        #[arg(long, env = "NEXUS_FUSE_METRICS_ADDR")]
+        metrics_addr: Option<String>,
     },
     /// Check version
     Version,
@@ -80,10 +88,14 @@ enum Commands {
 ///
 /// Resolution order: --api-key-file > --api-key / NEXUS_API_KEY.
 /// Using --api-key prints a deprecation warning to stderr.
-fn resolve_api_key(api_key: Option<String>, api_key_file: Option<PathBuf>) -> anyhow::Result<String> {
+fn resolve_api_key(
+    api_key: Option<String>,
+    api_key_file: Option<PathBuf>,
+) -> anyhow::Result<String> {
     if let Some(path) = api_key_file {
-        let key = std::fs::read_to_string(&path)
-            .map_err(|e| anyhow::anyhow!("Failed to read API key file {}: {}", path.display(), e))?;
+        let key = std::fs::read_to_string(&path).map_err(|e| {
+            anyhow::anyhow!("Failed to read API key file {}: {}", path.display(), e)
+        })?;
         return Ok(key.trim().to_string());
     }
 
@@ -116,8 +128,16 @@ fn main() -> anyhow::Result<()> {
             allow_other,
             foreground,
             agent_id,
+            metrics_addr,
         } => {
             let api_key = resolve_api_key(api_key, api_key_file)?;
+            let _metrics_server = if let Some(addr) = metrics_addr.as_deref() {
+                let server = metrics::start_server(addr)?;
+                info!("FUSE metrics listening on {}", server.local_addr());
+                Some(server)
+            } else {
+                None
+            };
 
             info!("Nexus FUSE client starting...");
             info!("Server URL: {}", url);
@@ -152,7 +172,10 @@ fn main() -> anyhow::Result<()> {
                     Some(cache)
                 }
                 Err(e) => {
-                    error!("Failed to initialize cache: {} (continuing without cache)", e);
+                    error!(
+                        "Failed to initialize cache: {} (continuing without cache)",
+                        e
+                    );
                     None
                 }
             };
@@ -188,8 +211,16 @@ fn main() -> anyhow::Result<()> {
             api_key_file,
             socket,
             agent_id,
+            metrics_addr,
         } => {
             let api_key = resolve_api_key(api_key, api_key_file)?;
+            let _metrics_server = if let Some(addr) = metrics_addr.as_deref() {
+                let server = metrics::start_server(addr)?;
+                info!("FUSE metrics listening on {}", server.local_addr());
+                Some(server)
+            } else {
+                None
+            };
 
             // Determine socket path
             let socket_path = socket.unwrap_or_else(|| {

--- a/nexus-fuse/src/metrics.rs
+++ b/nexus-fuse/src/metrics.rs
@@ -1,0 +1,664 @@
+//! Prometheus text metrics for the standalone nexus-fuse binary (#4062).
+
+use std::collections::HashMap;
+use std::fmt::Display;
+use std::io::{ErrorKind, Read, Write};
+use std::net::{SocketAddr, TcpListener, TcpStream};
+use std::sync::{
+    atomic::{AtomicBool, Ordering},
+    Arc, LazyLock, Mutex,
+};
+use std::thread::{self, JoinHandle};
+use std::time::Duration;
+
+const READ_LATENCY_BUCKETS: &[f64] = &[
+    0.0005, 0.001, 0.0025, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0,
+];
+const READ_BATCH_SIZE_BUCKETS: &[f64] =
+    &[1.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0, 128.0, 256.0, 512.0];
+
+#[derive(Clone, Debug)]
+struct HistogramState {
+    buckets: &'static [f64],
+    bucket_counts: Vec<u64>,
+    count: u64,
+    sum: f64,
+}
+
+impl HistogramState {
+    fn new(buckets: &'static [f64]) -> Self {
+        Self {
+            buckets,
+            bucket_counts: vec![0; buckets.len()],
+            count: 0,
+            sum: 0.0,
+        }
+    }
+
+    fn observe(&mut self, value: f64) {
+        let safe = if value.is_finite() && value > 0.0 {
+            value
+        } else {
+            0.0
+        };
+        self.count += 1;
+        self.sum += safe;
+        for (idx, bucket) in self.buckets.iter().enumerate() {
+            if safe <= *bucket {
+                self.bucket_counts[idx] += 1;
+            }
+        }
+    }
+}
+
+struct MetricsState {
+    cache_requests: HashMap<(String, String), u64>,
+    cache_hit_ratio: HashMap<String, f64>,
+    cache_evictions: HashMap<(String, String), u64>,
+    cache_etag_revalidate: HashMap<String, u64>,
+    etag_checks: HashMap<String, u64>,
+    cache_bytes_in_use: HashMap<String, u64>,
+    cache_admission_rejected_total: u64,
+    prefetch_issued_bytes_total: u64,
+    prefetch_used_bytes_total: u64,
+    prefetch_wasted_bytes_total: u64,
+    prefetch_window_size: HashMap<(String, String), u64>,
+    prefetch_pattern_detected: HashMap<String, u64>,
+    read_bytes: HashMap<String, u64>,
+    read_latency: HashMap<String, HistogramState>,
+    read_batch_size: HistogramState,
+    fuse_passthrough_used_total: u64,
+    write_coalesce_flush: HashMap<String, u64>,
+    write_coalesce_dirty_bytes: u64,
+    write_backend_rpc_total: u64,
+    generation_mismatch_total: u64,
+}
+
+impl Default for MetricsState {
+    fn default() -> Self {
+        Self {
+            cache_requests: HashMap::new(),
+            cache_hit_ratio: HashMap::new(),
+            cache_evictions: HashMap::new(),
+            cache_etag_revalidate: HashMap::new(),
+            etag_checks: HashMap::new(),
+            cache_bytes_in_use: HashMap::new(),
+            cache_admission_rejected_total: 0,
+            prefetch_issued_bytes_total: 0,
+            prefetch_used_bytes_total: 0,
+            prefetch_wasted_bytes_total: 0,
+            prefetch_window_size: HashMap::new(),
+            prefetch_pattern_detected: HashMap::new(),
+            read_bytes: HashMap::new(),
+            read_latency: HashMap::new(),
+            read_batch_size: HistogramState::new(READ_BATCH_SIZE_BUCKETS),
+            fuse_passthrough_used_total: 0,
+            write_coalesce_flush: HashMap::new(),
+            write_coalesce_dirty_bytes: 0,
+            write_backend_rpc_total: 0,
+            generation_mismatch_total: 0,
+        }
+    }
+}
+
+static METRICS: LazyLock<Mutex<MetricsState>> =
+    LazyLock::new(|| Mutex::new(MetricsState::default()));
+
+#[cfg(test)]
+static TEST_METRICS_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+#[cfg(test)]
+pub(crate) fn test_guard() -> std::sync::MutexGuard<'static, ()> {
+    TEST_METRICS_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+pub struct MetricsServer {
+    local_addr: SocketAddr,
+    shutdown: Arc<AtomicBool>,
+    thread: Option<JoinHandle<()>>,
+}
+
+impl MetricsServer {
+    pub fn local_addr(&self) -> SocketAddr {
+        self.local_addr
+    }
+}
+
+impl Drop for MetricsServer {
+    fn drop(&mut self) {
+        self.shutdown.store(true, Ordering::Relaxed);
+        let _ = TcpStream::connect(self.local_addr);
+        if let Some(thread) = self.thread.take() {
+            let _ = thread.join();
+        }
+    }
+}
+
+fn bounded(value: &str, allowed: &[&str]) -> String {
+    let normalized = value.trim().to_ascii_lowercase().replace('-', "_");
+    if allowed.iter().any(|item| *item == normalized) {
+        normalized
+    } else {
+        "other".to_string()
+    }
+}
+
+fn cache_tier(value: &str) -> String {
+    bounded(value, &["sqlite", "dram", "nvme", "l1", "l2", "other"])
+}
+
+fn cache_result(value: &str) -> String {
+    bounded(value, &["hit", "miss", "stale", "other"])
+}
+
+fn cache_eviction_reason(value: &str) -> String {
+    bounded(value, &["capacity", "ttl", "manual", "other"])
+}
+
+fn etag_result(value: &str) -> String {
+    bounded(
+        value,
+        &[
+            "304",
+            "updated",
+            "error",
+            "fallback",
+            "unexpected_304",
+            "other",
+        ],
+    )
+}
+
+fn prefetch_pattern(value: &str) -> String {
+    bounded(
+        value,
+        &["sequential", "stride", "random", "majority_trend", "other"],
+    )
+}
+
+fn read_tier(value: &str) -> String {
+    bounded(
+        value,
+        &[
+            "backend",
+            "virtual",
+            "error",
+            "batch",
+            "cache",
+            "sqlite",
+            "dram",
+            "nvme",
+            "passthrough",
+            "other",
+        ],
+    )
+}
+
+fn write_flush_trigger(value: &str) -> String {
+    bounded(
+        value,
+        &["time", "bytes", "close", "sync", "snapshot", "other"],
+    )
+}
+
+fn scope(value: &str) -> String {
+    let normalized = value.trim().to_ascii_lowercase().replace('-', "_");
+    if ["default", "root", "local", "server", "fuse"].contains(&normalized.as_str()) {
+        normalized
+    } else {
+        "default".to_string()
+    }
+}
+
+pub fn reset_for_tests() {
+    *METRICS.lock().unwrap() = MetricsState::default();
+}
+
+pub fn record_cache_request(tier: &str, result: &str) {
+    let mut metrics = METRICS.lock().unwrap();
+    *metrics
+        .cache_requests
+        .entry((cache_tier(tier), cache_result(result)))
+        .or_insert(0) += 1;
+}
+
+pub fn set_cache_hit_ratio(tier: &str, ratio: f64) {
+    let mut metrics = METRICS.lock().unwrap();
+    let bounded_ratio = if ratio.is_finite() {
+        ratio.clamp(0.0, 1.0)
+    } else {
+        0.0
+    };
+    metrics
+        .cache_hit_ratio
+        .insert(cache_tier(tier), bounded_ratio);
+}
+
+pub fn record_cache_eviction(tier: &str, reason: &str) {
+    let mut metrics = METRICS.lock().unwrap();
+    *metrics
+        .cache_evictions
+        .entry((cache_tier(tier), cache_eviction_reason(reason)))
+        .or_insert(0) += 1;
+}
+
+pub fn record_cache_etag_revalidate(result: &str) {
+    let mut metrics = METRICS.lock().unwrap();
+    *metrics
+        .cache_etag_revalidate
+        .entry(etag_result(result))
+        .or_insert(0) += 1;
+}
+
+pub fn record_cache_admission_rejected() {
+    let mut metrics = METRICS.lock().unwrap();
+    metrics.cache_admission_rejected_total += 1;
+}
+
+pub fn record_etag_check(result: &str) {
+    let mut metrics = METRICS.lock().unwrap();
+    *metrics.etag_checks.entry(etag_result(result)).or_insert(0) += 1;
+}
+
+pub fn record_prefetch_issued(bytes: usize) {
+    let mut metrics = METRICS.lock().unwrap();
+    metrics.prefetch_issued_bytes_total += bytes as u64;
+}
+
+pub fn record_prefetch_used(bytes: usize) {
+    let mut metrics = METRICS.lock().unwrap();
+    metrics.prefetch_used_bytes_total += bytes as u64;
+}
+
+pub fn record_prefetch_wasted(bytes: usize) {
+    let mut metrics = METRICS.lock().unwrap();
+    metrics.prefetch_wasted_bytes_total += bytes as u64;
+}
+
+pub fn set_prefetch_window_size(window_size: u64, mount: &str, workspace: &str) {
+    let mut metrics = METRICS.lock().unwrap();
+    metrics
+        .prefetch_window_size
+        .insert((scope(mount), scope(workspace)), window_size);
+}
+
+pub fn record_prefetch_pattern(pattern: &str) {
+    let mut metrics = METRICS.lock().unwrap();
+    *metrics
+        .prefetch_pattern_detected
+        .entry(prefetch_pattern(pattern))
+        .or_insert(0) += 1;
+}
+
+pub fn set_cache_bytes_in_use(tier: &str, bytes: u64) {
+    let mut metrics = METRICS.lock().unwrap();
+    metrics.cache_bytes_in_use.insert(cache_tier(tier), bytes);
+}
+
+pub fn record_read(tier: &str, bytes: usize, latency: Duration) {
+    let safe_tier = read_tier(tier);
+    let mut metrics = METRICS.lock().unwrap();
+    *metrics.read_bytes.entry(safe_tier.clone()).or_insert(0) += bytes as u64;
+    metrics
+        .read_latency
+        .entry(safe_tier)
+        .or_insert_with(|| HistogramState::new(READ_LATENCY_BUCKETS))
+        .observe(latency.as_secs_f64());
+}
+
+pub fn record_read_batch_size(count: usize) {
+    let mut metrics = METRICS.lock().unwrap();
+    metrics.read_batch_size.observe(count as f64);
+}
+
+pub fn record_fuse_passthrough_used() {
+    let mut metrics = METRICS.lock().unwrap();
+    metrics.fuse_passthrough_used_total += 1;
+}
+
+pub fn record_write_coalesce_flush(trigger: &str) {
+    let mut metrics = METRICS.lock().unwrap();
+    *metrics
+        .write_coalesce_flush
+        .entry(write_flush_trigger(trigger))
+        .or_insert(0) += 1;
+}
+
+pub fn set_write_coalesce_dirty_bytes(bytes: u64) {
+    let mut metrics = METRICS.lock().unwrap();
+    metrics.write_coalesce_dirty_bytes = bytes;
+}
+
+pub fn record_write_backend_rpc() {
+    let mut metrics = METRICS.lock().unwrap();
+    metrics.write_backend_rpc_total += 1;
+}
+
+pub fn record_generation_mismatch() {
+    let mut metrics = METRICS.lock().unwrap();
+    metrics.generation_mismatch_total += 1;
+}
+
+fn write_sample_line(out: &mut String, name: &str, labels: &str, value: impl Display) {
+    if labels.is_empty() {
+        out.push_str(&format!("{name} {value}\n"));
+    } else {
+        out.push_str(&format!("{name}{{{labels}}} {value}\n"));
+    }
+}
+
+fn write_counter_line(out: &mut String, name: &str, labels: &str, value: u64) {
+    write_sample_line(out, name, labels, value);
+}
+
+fn bucket_label(bucket: f64) -> String {
+    if bucket.fract() == 0.0 {
+        format!("{bucket:.1}")
+    } else {
+        bucket.to_string()
+    }
+}
+
+fn write_histogram(out: &mut String, name: &str, labels: &str, histogram: &HistogramState) {
+    for (idx, bucket) in histogram.buckets.iter().enumerate() {
+        let bucket_labels = if labels.is_empty() {
+            format!("le=\"{}\"", bucket_label(*bucket))
+        } else {
+            format!("{labels},le=\"{}\"", bucket_label(*bucket))
+        };
+        write_counter_line(
+            out,
+            &format!("{name}_bucket"),
+            &bucket_labels,
+            histogram.bucket_counts[idx],
+        );
+    }
+
+    let inf_labels = if labels.is_empty() {
+        "le=\"+Inf\"".to_string()
+    } else {
+        format!("{labels},le=\"+Inf\"")
+    };
+    write_counter_line(out, &format!("{name}_bucket"), &inf_labels, histogram.count);
+    write_sample_line(out, &format!("{name}_sum"), labels, histogram.sum);
+    write_counter_line(out, &format!("{name}_count"), labels, histogram.count);
+}
+
+pub fn render() -> String {
+    let metrics = METRICS.lock().unwrap();
+    let mut out = String::new();
+
+    out.push_str("# TYPE nexus_cache_requests_total counter\n");
+    let mut cache_requests: Vec<_> = metrics.cache_requests.iter().collect();
+    cache_requests.sort_by(|left, right| left.0.cmp(right.0));
+    for ((tier, result), value) in cache_requests {
+        write_counter_line(
+            &mut out,
+            "nexus_cache_requests_total",
+            &format!("tier=\"{tier}\",result=\"{result}\""),
+            *value,
+        );
+    }
+
+    out.push_str("# TYPE nexus_cache_hit_ratio gauge\n");
+    let mut cache_hit_ratio: Vec<_> = metrics.cache_hit_ratio.iter().collect();
+    cache_hit_ratio.sort_by(|left, right| left.0.cmp(right.0));
+    for (tier, value) in cache_hit_ratio {
+        write_sample_line(
+            &mut out,
+            "nexus_cache_hit_ratio",
+            &format!("tier=\"{tier}\""),
+            *value,
+        );
+    }
+
+    out.push_str("# TYPE nexus_cache_evictions_total counter\n");
+    let mut cache_evictions: Vec<_> = metrics.cache_evictions.iter().collect();
+    cache_evictions.sort_by(|left, right| left.0.cmp(right.0));
+    for ((tier, reason), value) in cache_evictions {
+        write_counter_line(
+            &mut out,
+            "nexus_cache_evictions_total",
+            &format!("tier=\"{tier}\",reason=\"{reason}\""),
+            *value,
+        );
+    }
+
+    out.push_str("# TYPE nexus_cache_bytes_in_use gauge\n");
+    let mut cache_bytes_in_use: Vec<_> = metrics.cache_bytes_in_use.iter().collect();
+    cache_bytes_in_use.sort_by(|left, right| left.0.cmp(right.0));
+    for (tier, value) in cache_bytes_in_use {
+        out.push_str(&format!(
+            "nexus_cache_bytes_in_use{{tier=\"{tier}\"}} {value}\n"
+        ));
+    }
+
+    out.push_str("# TYPE nexus_cache_admission_rejected_total counter\n");
+    write_counter_line(
+        &mut out,
+        "nexus_cache_admission_rejected_total",
+        "",
+        metrics.cache_admission_rejected_total,
+    );
+
+    out.push_str("# TYPE nexus_cache_etag_revalidate_total counter\n");
+    let mut cache_etag_revalidate: Vec<_> = metrics.cache_etag_revalidate.iter().collect();
+    cache_etag_revalidate.sort_by(|left, right| left.0.cmp(right.0));
+    for (result, value) in cache_etag_revalidate {
+        write_counter_line(
+            &mut out,
+            "nexus_cache_etag_revalidate_total",
+            &format!("result=\"{result}\""),
+            *value,
+        );
+    }
+
+    out.push_str("# TYPE nexus_prefetch_issued_bytes_total counter\n");
+    write_counter_line(
+        &mut out,
+        "nexus_prefetch_issued_bytes_total",
+        "",
+        metrics.prefetch_issued_bytes_total,
+    );
+
+    out.push_str("# TYPE nexus_prefetch_used_bytes_total counter\n");
+    write_counter_line(
+        &mut out,
+        "nexus_prefetch_used_bytes_total",
+        "",
+        metrics.prefetch_used_bytes_total,
+    );
+
+    out.push_str("# TYPE nexus_prefetch_wasted_bytes_total counter\n");
+    write_counter_line(
+        &mut out,
+        "nexus_prefetch_wasted_bytes_total",
+        "",
+        metrics.prefetch_wasted_bytes_total,
+    );
+
+    out.push_str("# TYPE nexus_prefetch_window_size gauge\n");
+    let mut prefetch_window_size: Vec<_> = metrics.prefetch_window_size.iter().collect();
+    prefetch_window_size.sort_by(|left, right| left.0.cmp(right.0));
+    for ((mount, workspace), value) in prefetch_window_size {
+        write_counter_line(
+            &mut out,
+            "nexus_prefetch_window_size",
+            &format!("mount=\"{mount}\",workspace=\"{workspace}\""),
+            *value,
+        );
+    }
+
+    out.push_str("# TYPE nexus_prefetch_pattern_detected_total counter\n");
+    let mut prefetch_pattern_detected: Vec<_> = metrics.prefetch_pattern_detected.iter().collect();
+    prefetch_pattern_detected.sort_by(|left, right| left.0.cmp(right.0));
+    for (pattern, value) in prefetch_pattern_detected {
+        write_counter_line(
+            &mut out,
+            "nexus_prefetch_pattern_detected_total",
+            &format!("pattern=\"{pattern}\""),
+            *value,
+        );
+    }
+
+    out.push_str("# TYPE nexus_etag_check_total counter\n");
+    let mut etag_checks: Vec<_> = metrics.etag_checks.iter().collect();
+    etag_checks.sort_by(|left, right| left.0.cmp(right.0));
+    for (result, value) in etag_checks {
+        write_counter_line(
+            &mut out,
+            "nexus_etag_check_total",
+            &format!("result=\"{result}\""),
+            *value,
+        );
+    }
+
+    out.push_str("# TYPE nexus_read_bytes_total counter\n");
+    let mut read_bytes: Vec<_> = metrics.read_bytes.iter().collect();
+    read_bytes.sort_by(|left, right| left.0.cmp(right.0));
+    for (tier, value) in read_bytes {
+        write_counter_line(
+            &mut out,
+            "nexus_read_bytes_total",
+            &format!("tier=\"{tier}\""),
+            *value,
+        );
+    }
+
+    out.push_str("# TYPE nexus_read_latency_seconds histogram\n");
+    let mut read_latency: Vec<_> = metrics.read_latency.iter().collect();
+    read_latency.sort_by(|left, right| left.0.cmp(right.0));
+    for (tier, histogram) in read_latency {
+        write_histogram(
+            &mut out,
+            "nexus_read_latency_seconds",
+            &format!("tier=\"{tier}\""),
+            histogram,
+        );
+    }
+
+    out.push_str("# TYPE nexus_read_batch_size histogram\n");
+    write_histogram(
+        &mut out,
+        "nexus_read_batch_size",
+        "",
+        &metrics.read_batch_size,
+    );
+
+    out.push_str("# TYPE nexus_fuse_passthrough_used_total counter\n");
+    write_counter_line(
+        &mut out,
+        "nexus_fuse_passthrough_used_total",
+        "",
+        metrics.fuse_passthrough_used_total,
+    );
+
+    out.push_str("# TYPE nexus_write_coalesce_flush_total counter\n");
+    let mut write_coalesce_flush: Vec<_> = metrics.write_coalesce_flush.iter().collect();
+    write_coalesce_flush.sort_by(|left, right| left.0.cmp(right.0));
+    for (trigger, value) in write_coalesce_flush {
+        write_counter_line(
+            &mut out,
+            "nexus_write_coalesce_flush_total",
+            &format!("trigger=\"{trigger}\""),
+            *value,
+        );
+    }
+
+    out.push_str("# TYPE nexus_write_coalesce_dirty_bytes gauge\n");
+    write_counter_line(
+        &mut out,
+        "nexus_write_coalesce_dirty_bytes",
+        "",
+        metrics.write_coalesce_dirty_bytes,
+    );
+
+    out.push_str("# TYPE nexus_write_backend_rpc_total counter\n");
+    write_counter_line(
+        &mut out,
+        "nexus_write_backend_rpc_total",
+        "",
+        metrics.write_backend_rpc_total,
+    );
+
+    out.push_str("# TYPE nexus_generation_mismatch_total counter\n");
+    write_counter_line(
+        &mut out,
+        "nexus_generation_mismatch_total",
+        "",
+        metrics.generation_mismatch_total,
+    );
+
+    out
+}
+
+fn response(status: &str, body: &str) -> String {
+    format!(
+        "HTTP/1.1 {status}\r\ncontent-type: text/plain; version=0.0.4; charset=utf-8\r\ncontent-length: {}\r\nconnection: close\r\n\r\n{}",
+        body.len(),
+        body
+    )
+}
+
+fn request_is_metrics_scrape(request: &str) -> bool {
+    request.lines().next().and_then(|line| {
+        let mut parts = line.split_whitespace();
+        Some((parts.next()?, parts.next()?))
+    }) == Some(("GET", "/metrics"))
+}
+
+fn handle_client(mut stream: TcpStream) {
+    let _ = stream.set_read_timeout(Some(Duration::from_millis(250)));
+    let mut buffer = [0_u8; 1024];
+    let bytes_read = match stream.read(&mut buffer) {
+        Ok(0) => return,
+        Ok(bytes_read) => bytes_read,
+        Err(error)
+            if matches!(
+                error.kind(),
+                ErrorKind::WouldBlock | ErrorKind::TimedOut | ErrorKind::Interrupted
+            ) =>
+        {
+            return;
+        }
+        Err(_) => return,
+    };
+
+    let request = String::from_utf8_lossy(&buffer[..bytes_read]);
+    let response = if request_is_metrics_scrape(&request) {
+        response("200 OK", &render())
+    } else {
+        response("404 Not Found", "not found\n")
+    };
+    let _ = stream.write_all(response.as_bytes());
+}
+
+pub fn start_server(addr: &str) -> std::io::Result<MetricsServer> {
+    let listener = TcpListener::bind(addr)?;
+    let local_addr = listener.local_addr()?;
+    listener.set_nonblocking(true)?;
+    let shutdown = Arc::new(AtomicBool::new(false));
+    let thread_shutdown = Arc::clone(&shutdown);
+    let thread = thread::spawn(move || {
+        while !thread_shutdown.load(Ordering::Relaxed) {
+            match listener.accept() {
+                Ok((stream, _)) => {
+                    thread::spawn(move || handle_client(stream));
+                }
+                Err(error) if error.kind() == ErrorKind::WouldBlock => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+                Err(_) => {
+                    thread::sleep(Duration::from_millis(10));
+                }
+            }
+        }
+    });
+    Ok(MetricsServer {
+        local_addr,
+        shutdown,
+        thread: Some(thread),
+    })
+}

--- a/nexus-fuse/tests/error_handling_test.rs
+++ b/nexus-fuse/tests/error_handling_test.rs
@@ -67,7 +67,10 @@ fn test_500_maps_to_eio() {
 
     assert!(result.is_err());
     let err = result.unwrap_err();
-    assert!(matches!(err, NexusClientError::ServerError { status: 500, .. }));
+    assert!(matches!(
+        err,
+        NexusClientError::ServerError { status: 500, .. }
+    ));
     assert_eq!(err.to_errno(), libc::EIO);
     assert!(err.is_transient());
 }
@@ -88,7 +91,10 @@ fn test_503_maps_to_server_error() {
 
     assert!(result.is_err());
     let err = result.unwrap_err();
-    assert!(matches!(err, NexusClientError::ServerError { status: 503, .. }));
+    assert!(matches!(
+        err,
+        NexusClientError::ServerError { status: 503, .. }
+    ));
     assert_eq!(err.to_errno(), libc::EIO);
     assert!(err.is_transient());
 }
@@ -348,7 +354,9 @@ fn test_rpc_non_32000_code_with_not_found_message_is_not_enoent() {
         .mock("POST", "/api/nfs/stat")
         .with_status(200)
         .with_header("content-type", "application/json")
-        .with_body(r#"{"jsonrpc":"2.0","id":1,"error":{"code":-1,"message":"Not Found: /missing"}}"#)
+        .with_body(
+            r#"{"jsonrpc":"2.0","id":1,"error":{"code":-1,"message":"Not Found: /missing"}}"#,
+        )
         .create();
 
     let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
@@ -421,5 +429,8 @@ fn test_rpc_internal_error_not_misclassified() {
 
     assert!(result.is_err());
     let err = result.unwrap_err();
-    assert!(!err.is_not_found(), "Internal errors must not be misclassified as NotFound");
+    assert!(
+        !err.is_not_found(),
+        "Internal errors must not be misclassified as NotFound"
+    );
 }

--- a/nexus-fuse/tests/integration_test.rs
+++ b/nexus-fuse/tests/integration_test.rs
@@ -13,12 +13,8 @@ fn test_e2e_with_live_server() {
     println!("\n🧪 Starting E2E test with live Nexus server...\n");
 
     // Create client
-    let client = NexusClient::new(
-        "http://localhost:2026",
-        "sk-test-key-123",
-        None,
-    )
-    .expect("Failed to create client");
+    let client = NexusClient::new("http://localhost:2026", "sk-test-key-123", None)
+        .expect("Failed to create client");
 
     println!("✓ Client created");
 

--- a/nexus-fuse/tests/metrics_test.rs
+++ b/nexus-fuse/tests/metrics_test.rs
@@ -1,0 +1,184 @@
+use std::io::{Read, Write};
+use std::net::TcpStream;
+use std::sync::{LazyLock, Mutex};
+use std::time::Duration;
+
+use nexus_fuse::metrics;
+
+static TEST_LOCK: LazyLock<Mutex<()>> = LazyLock::new(|| Mutex::new(()));
+
+fn test_guard() -> std::sync::MutexGuard<'static, ()> {
+    TEST_LOCK
+        .lock()
+        .unwrap_or_else(|poisoned| poisoned.into_inner())
+}
+
+#[test]
+fn render_includes_recorded_counter_gauge_and_histogram() {
+    let _guard = test_guard();
+    metrics::reset_for_tests();
+
+    metrics::record_cache_request("sqlite", "hit");
+    metrics::set_cache_bytes_in_use("sqlite", 4096);
+    metrics::record_read("cache", 128, Duration::from_millis(2));
+    metrics::record_write_backend_rpc();
+
+    let body = metrics::render();
+
+    assert!(body.contains("nexus_cache_requests_total{tier=\"sqlite\",result=\"hit\"} 1"));
+    assert!(body.contains("nexus_cache_bytes_in_use{tier=\"sqlite\"} 4096"));
+    assert!(body.contains("nexus_read_bytes_total{tier=\"cache\"} 128"));
+    assert!(body.contains("nexus_read_latency_seconds_count{tier=\"cache\"} 1"));
+    assert!(body.contains("nexus_write_backend_rpc_total 1"));
+}
+
+#[test]
+fn render_exposes_full_issue_metric_catalog_after_reset() {
+    let _guard = test_guard();
+    metrics::reset_for_tests();
+
+    let body = metrics::render();
+
+    for metric in [
+        "nexus_cache_requests_total",
+        "nexus_cache_hit_ratio",
+        "nexus_cache_evictions_total",
+        "nexus_cache_bytes_in_use",
+        "nexus_cache_admission_rejected_total",
+        "nexus_cache_etag_revalidate_total",
+        "nexus_prefetch_issued_bytes_total",
+        "nexus_prefetch_used_bytes_total",
+        "nexus_prefetch_wasted_bytes_total",
+        "nexus_prefetch_window_size",
+        "nexus_prefetch_pattern_detected_total",
+        "nexus_read_latency_seconds",
+        "nexus_read_bytes_total",
+        "nexus_read_batch_size",
+        "nexus_fuse_passthrough_used_total",
+        "nexus_write_coalesce_flush_total",
+        "nexus_write_coalesce_dirty_bytes",
+        "nexus_write_backend_rpc_total",
+        "nexus_generation_mismatch_total",
+        "nexus_etag_check_total",
+    ] {
+        assert!(
+            body.contains(metric),
+            "missing metric catalog entry {metric}"
+        );
+    }
+}
+
+#[test]
+fn render_uses_python_compatible_histogram_bucket_labels() {
+    let _guard = test_guard();
+    metrics::reset_for_tests();
+
+    metrics::record_read("backend", 128, Duration::from_secs(12));
+
+    let body = metrics::render();
+
+    assert!(body.contains("nexus_read_latency_seconds_bucket{tier=\"backend\",le=\"1.0\"}"));
+    assert!(body.contains("nexus_read_latency_seconds_bucket{tier=\"backend\",le=\"5.0\"}"));
+    assert!(body.contains("nexus_read_latency_seconds_bucket{tier=\"backend\",le=\"10.0\"}"));
+    assert!(!body.contains("nexus_read_latency_seconds_bucket{tier=\"backend\",le=\"1\"}"));
+    assert!(!body.contains("nexus_read_latency_seconds_bucket{tier=\"backend\",le=\"5\"}"));
+    assert!(!body.contains("nexus_read_latency_seconds_bucket{tier=\"backend\",le=\"10\"}"));
+}
+
+#[test]
+fn prefetch_window_unknown_scopes_default_to_default() {
+    let _guard = test_guard();
+    metrics::reset_for_tests();
+
+    metrics::set_prefetch_window_size(2048, "tenant-123", "path-/secret");
+
+    let body = metrics::render();
+    assert!(
+        body.contains("nexus_prefetch_window_size{mount=\"default\",workspace=\"default\"} 2048")
+    );
+}
+
+#[test]
+fn unknown_labels_collapse_to_other() {
+    let _guard = test_guard();
+    metrics::reset_for_tests();
+
+    metrics::record_cache_request("path-/secret", "tenant-123");
+
+    let body = metrics::render();
+    assert!(body.contains("nexus_cache_requests_total{tier=\"other\",result=\"other\"} 1"));
+}
+
+#[test]
+fn metrics_server_returns_prometheus_text() {
+    let _guard = test_guard();
+    metrics::reset_for_tests();
+    metrics::record_write_backend_rpc();
+
+    let server = metrics::start_server("127.0.0.1:0").expect("metrics server should bind");
+    let addr = server.local_addr();
+
+    let mut stream = TcpStream::connect(addr).expect("connect metrics server");
+    stream
+        .write_all(b"GET /metrics HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        .expect("write request");
+
+    let mut body = String::new();
+    stream.read_to_string(&mut body).expect("read response");
+    assert!(body.contains("HTTP/1.1 200 OK"));
+    assert!(body.contains("nexus_write_backend_rpc_total 1"));
+}
+
+#[test]
+fn idle_client_does_not_block_later_scrape() {
+    let _guard = test_guard();
+    metrics::reset_for_tests();
+    metrics::record_write_backend_rpc();
+
+    let server = metrics::start_server("127.0.0.1:0").expect("metrics server should bind");
+    let addr = server.local_addr();
+
+    let _idle = TcpStream::connect(addr).expect("connect idle client");
+
+    let mut stream = TcpStream::connect(addr).expect("connect scraping client");
+    stream
+        .set_read_timeout(Some(Duration::from_millis(500)))
+        .expect("set scrape read timeout");
+    stream
+        .write_all(b"GET /metrics HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        .expect("write request");
+
+    let mut body = String::new();
+    stream.read_to_string(&mut body).expect("read response");
+    assert!(body.contains("HTTP/1.1 200 OK"));
+    assert!(body.contains("nexus_write_backend_rpc_total 1"));
+}
+
+#[test]
+fn dropping_server_releases_bound_address() {
+    let _guard = test_guard();
+
+    let server = metrics::start_server("127.0.0.1:0").expect("metrics server should bind");
+    let addr = server.local_addr();
+    drop(server);
+
+    let rebound = metrics::start_server(&addr.to_string()).expect("metrics server should rebind");
+    assert_eq!(rebound.local_addr(), addr);
+}
+
+#[test]
+fn server_rejects_non_metrics_paths() {
+    let _guard = test_guard();
+
+    let server = metrics::start_server("127.0.0.1:0").expect("metrics server should bind");
+    let addr = server.local_addr();
+
+    let mut stream = TcpStream::connect(addr).expect("connect metrics server");
+    stream
+        .write_all(b"GET /health HTTP/1.1\r\nHost: localhost\r\n\r\n")
+        .expect("write request");
+
+    let mut body = String::new();
+    stream.read_to_string(&mut body).expect("read response");
+    assert!(!body.contains("HTTP/1.1 200 OK"));
+}

--- a/nexus-fuse/tests/minimal_http_test.rs
+++ b/nexus-fuse/tests/minimal_http_test.rs
@@ -11,7 +11,7 @@ fn test_raw_http_request() {
     let client = Client::builder()
         .timeout(std::time::Duration::from_secs(30))
         .connect_timeout(std::time::Duration::from_secs(5))
-        .http1_only()  // Force HTTP/1.1
+        .http1_only() // Force HTTP/1.1
         .build()
         .expect("Failed to create HTTP client");
 

--- a/observability/grafana/provisioning/dashboards/nexus-io-observability.json
+++ b/observability/grafana/provisioning/dashboards/nexus-io-observability.json
@@ -1,0 +1,164 @@
+{
+  "uid": "nexus-io-observability",
+  "title": "Nexus I/O Observability",
+  "description": "Read, write, cache, ETag, prefetch, coalescing, and passthrough metrics for issue #4062.",
+  "tags": ["nexus", "io", "observability"],
+  "timezone": "browser",
+  "editable": true,
+  "schemaVersion": 39,
+  "version": 1,
+  "refresh": "30s",
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "templating": {
+    "list": [
+      {
+        "name": "datasource",
+        "type": "datasource",
+        "query": "prometheus",
+        "current": {
+          "text": "Prometheus",
+          "value": "prometheus"
+        },
+        "label": "Datasource"
+      }
+    ]
+  },
+  "panels": [
+    {
+      "type": "timeseries",
+      "title": "Read Latency By Tier",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 0 },
+      "targets": [
+        {
+          "expr": "histogram_quantile(0.50, sum by (le, tier) (rate(nexus_read_latency_seconds_bucket[5m])))",
+          "legendFormat": "p50 {{tier}}"
+        },
+        {
+          "expr": "histogram_quantile(0.95, sum by (le, tier) (rate(nexus_read_latency_seconds_bucket[5m])))",
+          "legendFormat": "p95 {{tier}}"
+        },
+        {
+          "expr": "histogram_quantile(0.99, sum by (le, tier) (rate(nexus_read_latency_seconds_bucket[5m])))",
+          "legendFormat": "p99 {{tier}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "s" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Read Bytes By Tier",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 0 },
+      "targets": [
+        {
+          "expr": "sum by (tier) (rate(nexus_read_bytes_total[5m]))",
+          "legendFormat": "{{tier}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "Bps" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Cache Requests",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 8 },
+      "targets": [
+        {
+          "expr": "sum by (tier, result) (rate(nexus_cache_requests_total[5m]))",
+          "legendFormat": "{{tier}} {{result}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Derived Cache Hit Percentage",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 8 },
+      "targets": [
+        {
+          "expr": "100 * (sum by (tier) (rate(nexus_cache_requests_total{result=\"hit\"}[5m])) or on (tier) 0 * sum by (tier) (rate(nexus_cache_requests_total[5m]))) / clamp_min(sum by (tier) (rate(nexus_cache_requests_total[5m])), 1e-9)",
+          "legendFormat": "{{tier}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "percent" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Cache Bytes In Use",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 0, "y": 16 },
+      "targets": [
+        {
+          "expr": "sum by (tier) (nexus_cache_bytes_in_use)",
+          "legendFormat": "{{tier}}"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "bytes" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "ETag Checks",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 8, "y": 16 },
+      "targets": [
+        {
+          "expr": "sum by (result) (rate(nexus_etag_check_total[5m]))",
+          "legendFormat": "{{result}}"
+        }
+      ]
+    },
+    {
+      "type": "heatmap",
+      "title": "Read Batch Size",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 8, "x": 16, "y": 16 },
+      "targets": [
+        {
+          "expr": "sum by (le) (rate(nexus_read_batch_size_bucket[5m]))",
+          "legendFormat": "{{le}}"
+        }
+      ]
+    },
+    {
+      "type": "timeseries",
+      "title": "Backend Write RPC Rate",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 0, "y": 24 },
+      "targets": [
+        {
+          "expr": "sum(rate(nexus_write_backend_rpc_total[5m]))",
+          "legendFormat": "total write RPC/s"
+        }
+      ],
+      "fieldConfig": { "defaults": { "unit": "ops" } }
+    },
+    {
+      "type": "timeseries",
+      "title": "Prefetch And Coalescing Reserved",
+      "datasource": { "type": "prometheus", "uid": "prometheus" },
+      "gridPos": { "h": 8, "w": 12, "x": 12, "y": 24 },
+      "targets": [
+        {
+          "expr": "rate(nexus_prefetch_issued_bytes_total[5m])",
+          "legendFormat": "prefetch issued B/s"
+        },
+        {
+          "expr": "rate(nexus_prefetch_used_bytes_total[5m])",
+          "legendFormat": "prefetch used B/s"
+        },
+        {
+          "expr": "rate(nexus_prefetch_wasted_bytes_total[5m])",
+          "legendFormat": "prefetch wasted B/s"
+        },
+        {
+          "expr": "sum by (trigger) (rate(nexus_write_coalesce_flush_total[5m]))",
+          "legendFormat": "flush {{trigger}}"
+        }
+      ]
+    }
+  ]
+}

--- a/src/nexus/core/nexus_fs_content.py
+++ b/src/nexus/core/nexus_fs_content.py
@@ -27,6 +27,7 @@ from nexus.contracts.exceptions import (
 )
 from nexus.contracts.metadata import FileMetadata
 from nexus.contracts.types import OperationContext
+from nexus.lib import io_metrics
 from nexus.lib.rpc_decorator import rpc_expose
 
 if TYPE_CHECKING:
@@ -90,70 +91,95 @@ class ContentMixin:
                 accept loop. Issue #3699.
         """
 
-        context = self._parse_context(context)
-        _handled, _resolve_hint = self.resolve_read(path, context=context)
-        if _handled:
-            content = _resolve_hint or b""
-            if offset or count is not None:
-                content = (
-                    content[offset : offset + count] if count is not None else content[offset:]
+        start = time.perf_counter()
+        try:
+            context = self._parse_context(context)
+            _handled, _resolve_hint = self.resolve_read(path, context=context)
+            if _handled:
+                content = _resolve_hint or b""
+                if offset or count is not None:
+                    content = (
+                        content[offset : offset + count] if count is not None else content[offset:]
+                    )
+                io_metrics.record_read(
+                    tier="virtual",
+                    bytes_read=len(content),
+                    latency_seconds=time.perf_counter() - start,
                 )
-            return content
+                return content
 
-        _is_admin = (
-            getattr(context, "is_admin", False)
-            if context is not None and not isinstance(context, dict)
-            else (context.get("is_admin", False) if isinstance(context, dict) else False)
-        )
-
-        # ── KERNEL (Rust — pre-hooks + route + backend read + IPC blocking) ──
-        # Rust sys_read handles ALL entry types end-to-end:
-        #   DT_REG: backend read + federation remote fetch
-        #   DT_PIPE: nowait pop → blocking wait (timeout_ms)
-        #   DT_STREAM: offset read → blocking wait (timeout_ms)
-        #
-        # Slim-package mode: ``nexus-fs`` can ship without ``nexus_runtime``,
-        # in which case ``self._kernel`` is None.
-        if self._kernel is None:
-            raise NexusFileNotFoundError(path)
-        _rust_ctx = self._build_rust_ctx(context, _is_admin)
-        # DT_STREAM uses 30s timeout (long-poll); DT_PIPE uses 5s.
-        # The caller's `offset` param doubles as the stream cursor position.
-        # ``timeout_ms=0`` from the caller selects O_NONBLOCK (Issue #3699).
-        _timeout_ms = 5000 if timeout_ms is None else int(timeout_ms)
-        result = self._kernel.sys_read(path, _rust_ctx, _timeout_ms, offset)
-
-        # DT_STREAM: return dict with next_offset for cursor advancement.
-        # This is a Python API contract that callers depend on.
-        if result.entry_type == 4:  # DT_STREAM
-            return {
-                "data": bytes(result.data) if result.data else b"",
-                "next_offset": result.stream_next_offset or 0,
-            }
-
-        # DT_PIPE / DT_REG: return bytes.
-        data = result.data or b""
-
-        if offset or count is not None:
-            data = data[offset : offset + count] if count is not None else data[offset:]
-
-        # POST-INTERCEPT: hooks dispatched via Rust dispatch_post_hooks
-        if result.post_hook_needed:
-            zone_id, agent_id, _ = self._get_context_identity(context)
-            from nexus.contracts.vfs_hooks import ReadHookContext
-
-            _read_ctx = ReadHookContext(
-                path=path,
-                context=context,
-                zone_id=zone_id,
-                agent_id=agent_id,
-                content=data,
-                content_id=result.content_id,
+            _is_admin = (
+                getattr(context, "is_admin", False)
+                if context is not None and not isinstance(context, dict)
+                else (context.get("is_admin", False) if isinstance(context, dict) else False)
             )
-            self._kernel.dispatch_post_hooks("read", _read_ctx)
-            data = _read_ctx.content or data
 
-        return data
+            # ── KERNEL (Rust — pre-hooks + route + backend read + IPC blocking) ──
+            # Rust sys_read handles ALL entry types end-to-end:
+            #   DT_REG: backend read + federation remote fetch
+            #   DT_PIPE: nowait pop → blocking wait (timeout_ms)
+            #   DT_STREAM: offset read → blocking wait (timeout_ms)
+            #
+            # Slim-package mode: ``nexus-fs`` can ship without ``nexus_runtime``,
+            # in which case ``self._kernel`` is None.
+            if self._kernel is None:
+                raise NexusFileNotFoundError(path)
+            _rust_ctx = self._build_rust_ctx(context, _is_admin)
+            # DT_STREAM uses 30s timeout (long-poll); DT_PIPE uses 5s.
+            # The caller's `offset` param doubles as the stream cursor position.
+            # ``timeout_ms=0`` from the caller selects O_NONBLOCK (Issue #3699).
+            _timeout_ms = 5000 if timeout_ms is None else int(timeout_ms)
+            result = self._kernel.sys_read(path, _rust_ctx, _timeout_ms, offset)
+
+            # DT_STREAM: return dict with next_offset for cursor advancement.
+            # This is a Python API contract that callers depend on.
+            if result.entry_type == 4:  # DT_STREAM
+                payload = bytes(result.data) if result.data else b""
+                io_metrics.record_read(
+                    tier="backend",
+                    bytes_read=len(payload),
+                    latency_seconds=time.perf_counter() - start,
+                )
+                return {
+                    "data": payload,
+                    "next_offset": result.stream_next_offset or 0,
+                }
+
+            # DT_PIPE / DT_REG: return bytes.
+            data = result.data or b""
+
+            if offset or count is not None:
+                data = data[offset : offset + count] if count is not None else data[offset:]
+
+            # POST-INTERCEPT: hooks dispatched via Rust dispatch_post_hooks
+            if result.post_hook_needed:
+                zone_id, agent_id, _ = self._get_context_identity(context)
+                from nexus.contracts.vfs_hooks import ReadHookContext
+
+                _read_ctx = ReadHookContext(
+                    path=path,
+                    context=context,
+                    zone_id=zone_id,
+                    agent_id=agent_id,
+                    content=data,
+                    content_id=result.content_id,
+                )
+                self._kernel.dispatch_post_hooks("read", _read_ctx)
+                data = _read_ctx.content or data
+
+            io_metrics.record_read(
+                tier="backend",
+                bytes_read=len(data),
+                latency_seconds=time.perf_counter() - start,
+            )
+            return data
+        except Exception:
+            io_metrics.record_read(
+                tier="error",
+                bytes_read=0,
+                latency_seconds=time.perf_counter() - start,
+            )
+            raise
 
     @rpc_expose(description="Read multiple files in a single RPC call")
     def read_bulk(
@@ -569,6 +595,8 @@ class ContentMixin:
         )
         _rust_ctx = self._build_rust_ctx(context, _is_admin)
         result = self._kernel.sys_write(path, _rust_ctx, buf, offset)
+        if result.hit:
+            io_metrics.record_write_backend_rpc()
 
         # POST-INTERCEPT hooks (Rust handles backend write + metadata + OBSERVE)
         if result.hit and result.post_hook_needed:
@@ -805,6 +833,8 @@ class ContentMixin:
         _rust_ctx = self._build_rust_ctx(context, _is_admin)
 
         result = self._kernel.sys_write(path, _rust_ctx, buf, offset)
+        if result.hit:
+            io_metrics.record_write_backend_rpc()
 
         # Reconstruct old_metadata from Rust result (atomic snapshot taken
         # during write — no TOCTOU gap, no extra PyO3 round-trip).
@@ -1419,6 +1449,7 @@ class ContentMixin:
         for i, (path, content) in enumerate(validated_files):
             r = rust_results[i]
             if r.hit:
+                io_metrics.record_write_backend_rpc()
                 results.append(
                     {
                         "content_id": r.content_id,
@@ -1544,6 +1575,7 @@ class ContentMixin:
             NexusFileNotFoundError: If any path is missing and partial=False.
             NexusPermissionError:   If access is denied and partial=False.
         """
+        io_metrics.record_read_batch_size(len(paths))
         if not paths:
             return []
 
@@ -1647,7 +1679,12 @@ class ContentMixin:
                 # endpoint.
                 try:
                     content = self.read(path, context=context)
-                    _loaded_bytes += len(content)
+                    content_bytes_len = (
+                        len(content.get("data") or b"")
+                        if isinstance(content, dict)
+                        else len(content)
+                    )
+                    _loaded_bytes += content_bytes_len
                     if _loaded_bytes > _MAX_BATCH_READ_BYTES:
                         raise ValueError(
                             f"Batch read aggregate size exceeded "
@@ -1660,7 +1697,7 @@ class ContentMixin:
                             "content_id": meta.content_id if meta else None,
                             "version": meta.version if meta else 0,
                             "modified_at": meta.modified_at if meta else None,
-                            "size": len(content),
+                            "size": content_bytes_len,
                         }
                     )
                     hit_items.append((path, meta))
@@ -1707,6 +1744,11 @@ class ContentMixin:
                 )
                 self._kernel.dispatch_post_hooks("read", _read_ctx)
                 content = _read_ctx.content or content
+
+            io_metrics.record_read_bytes(
+                tier="batch",
+                bytes_read=len(content),
+            )
 
             # Use r.content_id as the primary content_id — it reflects the actual bytes
             # returned by this read, not the pre-read metadata snapshot (which can be

--- a/src/nexus/factory/adapters.py
+++ b/src/nexus/factory/adapters.py
@@ -246,6 +246,8 @@ class _NexusFSFileReader:
             is_admin=True,
             is_system=True,
         )
+        # sys_read blocks the event loop (Rust kernel pread + pipe waits).
+        # Run it in a worker thread.
         content_raw = await asyncio.to_thread(self._nx.sys_read, path, context=admin_ctx)
 
         # Look up the backend-tracked content_id (``file_paths.content_id``)
@@ -403,6 +405,7 @@ class _NexusFSFileReader:
             is_system=True,
         )
         try:
+            # sys_read is synchronous Rust; use a worker thread.
             content = await asyncio.to_thread(
                 self._nx.sys_read,
                 path,

--- a/src/nexus/lib/io_metrics.py
+++ b/src/nexus/lib/io_metrics.py
@@ -1,0 +1,266 @@
+"""Prometheus metrics for Nexus read/write/cache hot paths (#4062)."""
+
+from __future__ import annotations
+
+from prometheus_client import Counter, Gauge, Histogram
+
+READ_LATENCY_BUCKETS = (
+    0.0005,
+    0.001,
+    0.0025,
+    0.005,
+    0.01,
+    0.025,
+    0.05,
+    0.1,
+    0.25,
+    0.5,
+    1.0,
+    2.5,
+    5.0,
+    10.0,
+)
+
+READ_BATCH_SIZE_BUCKETS = (1, 2, 4, 8, 16, 32, 64, 128, 256, 512)
+
+_CACHE_TIERS = frozenset({"sqlite", "dram", "nvme", "l1", "l2", "other"})
+_CACHE_RESULTS = frozenset({"hit", "miss", "stale", "other"})
+_CACHE_EVICTION_REASONS = frozenset({"capacity", "ttl", "manual", "other"})
+_ETAG_RESULTS = frozenset({"304", "updated", "error", "fallback", "unexpected_304", "other"})
+_PREFETCH_PATTERNS = frozenset({"sequential", "stride", "random", "majority_trend", "other"})
+_READ_TIERS = frozenset(
+    {
+        "backend",
+        "virtual",
+        "error",
+        "batch",
+        "cache",
+        "sqlite",
+        "dram",
+        "nvme",
+        "passthrough",
+        "other",
+    }
+)
+_WRITE_FLUSH_TRIGGERS = frozenset({"time", "bytes", "close", "sync", "snapshot", "other"})
+_SCOPES = frozenset({"default", "root", "local", "server", "fuse", "other"})
+
+
+def _bounded(value: str | None, allowed: frozenset[str], default: str = "other") -> str:
+    normalized = (value or default).strip().lower().replace("-", "_")
+    return normalized if normalized in allowed else default
+
+
+def _nonnegative(value: int | float) -> int | float:
+    return value if value > 0 else 0
+
+
+CACHE_REQUESTS = Counter(
+    "nexus_cache_requests_total",
+    "Total Nexus cache lookup requests.",
+    ["tier", "result"],
+)
+
+CACHE_HIT_RATIO = Gauge(
+    "nexus_cache_hit_ratio",
+    "Current cache hit ratio for a bounded cache tier.",
+    ["tier"],
+)
+
+CACHE_EVICTIONS = Counter(
+    "nexus_cache_evictions_total",
+    "Total Nexus cache evictions.",
+    ["tier", "reason"],
+)
+
+CACHE_BYTES_IN_USE = Gauge(
+    "nexus_cache_bytes_in_use",
+    "Bytes currently held by a bounded cache tier.",
+    ["tier"],
+)
+
+CACHE_ADMISSION_REJECTED = Counter(
+    "nexus_cache_admission_rejected_total",
+    "Total cache admissions rejected by the admission filter.",
+)
+
+CACHE_ETAG_REVALIDATE = Counter(
+    "nexus_cache_etag_revalidate_total",
+    "Total cache ETag revalidation attempts.",
+    ["result"],
+)
+
+PREFETCH_ISSUED_BYTES = Counter(
+    "nexus_prefetch_issued_bytes_total",
+    "Total bytes requested by prefetch.",
+)
+
+PREFETCH_USED_BYTES = Counter(
+    "nexus_prefetch_used_bytes_total",
+    "Total prefetched bytes consumed by foreground reads.",
+)
+
+PREFETCH_WASTED_BYTES = Counter(
+    "nexus_prefetch_wasted_bytes_total",
+    "Total prefetched bytes evicted before use.",
+)
+
+PREFETCH_WINDOW_SIZE = Gauge(
+    "nexus_prefetch_window_size",
+    "Current adaptive prefetch window size for bounded scopes.",
+    ["mount", "workspace"],
+)
+
+PREFETCH_PATTERN_DETECTED = Counter(
+    "nexus_prefetch_pattern_detected_total",
+    "Total detected prefetch access patterns.",
+    ["pattern"],
+)
+
+READ_LATENCY = Histogram(
+    "nexus_read_latency_seconds",
+    "Nexus read latency in seconds.",
+    ["tier"],
+    buckets=READ_LATENCY_BUCKETS,
+)
+
+READ_BYTES = Counter(
+    "nexus_read_bytes_total",
+    "Total Nexus read bytes.",
+    ["tier"],
+)
+
+READ_BATCH_SIZE = Histogram(
+    "nexus_read_batch_size",
+    "Number of paths requested in read_batch calls.",
+    buckets=READ_BATCH_SIZE_BUCKETS,
+)
+
+FUSE_PASSTHROUGH_USED = Counter(
+    "nexus_fuse_passthrough_used_total",
+    "Total FUSE passthrough reads used.",
+)
+
+WRITE_COALESCE_FLUSH = Counter(
+    "nexus_write_coalesce_flush_total",
+    "Total write-coalescing flushes.",
+    ["trigger"],
+)
+
+WRITE_COALESCE_DIRTY_BYTES = Gauge(
+    "nexus_write_coalesce_dirty_bytes",
+    "Current dirty bytes held by write coalescing.",
+)
+
+WRITE_BACKEND_RPC = Counter(
+    "nexus_write_backend_rpc_total",
+    "Total backend write RPCs issued by Nexus I/O paths.",
+)
+
+GENERATION_MISMATCH = Counter(
+    "nexus_generation_mismatch_total",
+    "Total cache invalidations caused by generation mismatch.",
+)
+
+ETAG_CHECKS = Counter(
+    "nexus_etag_check_total",
+    "Total ETag checks by result.",
+    ["result"],
+)
+
+
+def record_cache_request(tier: str, result: str) -> None:
+    CACHE_REQUESTS.labels(
+        tier=_bounded(tier, _CACHE_TIERS),
+        result=_bounded(result, _CACHE_RESULTS),
+    ).inc()
+
+
+def set_cache_hit_ratio(tier: str, ratio: float) -> None:
+    bounded_ratio = max(0.0, min(float(ratio), 1.0))
+    CACHE_HIT_RATIO.labels(tier=_bounded(tier, _CACHE_TIERS)).set(bounded_ratio)
+
+
+def record_cache_eviction(tier: str, reason: str) -> None:
+    CACHE_EVICTIONS.labels(
+        tier=_bounded(tier, _CACHE_TIERS),
+        reason=_bounded(reason, _CACHE_EVICTION_REASONS),
+    ).inc()
+
+
+def set_cache_bytes_in_use(tier: str, bytes_in_use: int) -> None:
+    CACHE_BYTES_IN_USE.labels(tier=_bounded(tier, _CACHE_TIERS)).set(_nonnegative(bytes_in_use))
+
+
+def record_cache_admission_rejected() -> None:
+    CACHE_ADMISSION_REJECTED.inc()
+
+
+def record_cache_etag_revalidate(result: str) -> None:
+    CACHE_ETAG_REVALIDATE.labels(result=_bounded(result, _ETAG_RESULTS)).inc()
+
+
+def record_etag_check(result: str) -> None:
+    ETAG_CHECKS.labels(result=_bounded(result, _ETAG_RESULTS)).inc()
+
+
+def record_prefetch_issued(bytes_count: int) -> None:
+    PREFETCH_ISSUED_BYTES.inc(_nonnegative(bytes_count))
+
+
+def record_prefetch_used(bytes_count: int) -> None:
+    PREFETCH_USED_BYTES.inc(_nonnegative(bytes_count))
+
+
+def record_prefetch_wasted(bytes_count: int) -> None:
+    PREFETCH_WASTED_BYTES.inc(_nonnegative(bytes_count))
+
+
+def set_prefetch_window_size(
+    window_size: int,
+    *,
+    mount: str = "default",
+    workspace: str = "default",
+) -> None:
+    PREFETCH_WINDOW_SIZE.labels(
+        mount=_bounded(mount, _SCOPES, "default"),
+        workspace=_bounded(workspace, _SCOPES, "default"),
+    ).set(_nonnegative(window_size))
+
+
+def record_prefetch_pattern(pattern: str) -> None:
+    PREFETCH_PATTERN_DETECTED.labels(pattern=_bounded(pattern, _PREFETCH_PATTERNS)).inc()
+
+
+def record_read(*, tier: str, bytes_read: int, latency_seconds: float) -> None:
+    safe_tier = _bounded(tier, _READ_TIERS)
+    READ_BYTES.labels(tier=safe_tier).inc(_nonnegative(bytes_read))
+    READ_LATENCY.labels(tier=safe_tier).observe(float(_nonnegative(latency_seconds)))
+
+
+def record_read_bytes(*, tier: str, bytes_read: int) -> None:
+    READ_BYTES.labels(tier=_bounded(tier, _READ_TIERS)).inc(_nonnegative(bytes_read))
+
+
+def record_read_batch_size(count: int) -> None:
+    READ_BATCH_SIZE.observe(float(_nonnegative(count)))
+
+
+def record_fuse_passthrough_used() -> None:
+    FUSE_PASSTHROUGH_USED.inc()
+
+
+def record_write_coalesce_flush(trigger: str) -> None:
+    WRITE_COALESCE_FLUSH.labels(trigger=_bounded(trigger, _WRITE_FLUSH_TRIGGERS)).inc()
+
+
+def set_write_coalesce_dirty_bytes(bytes_count: int) -> None:
+    WRITE_COALESCE_DIRTY_BYTES.set(_nonnegative(bytes_count))
+
+
+def record_write_backend_rpc() -> None:
+    WRITE_BACKEND_RPC.inc()
+
+
+def record_generation_mismatch() -> None:
+    GENERATION_MISMATCH.inc()

--- a/src/nexus/services/io_metrics.py
+++ b/src/nexus/services/io_metrics.py
@@ -1,0 +1,7 @@
+"""Compatibility re-export for the Nexus I/O metrics catalog.
+
+The canonical module lives in :mod:`nexus.lib.io_metrics` so kernel-tier
+modules can record I/O metrics without importing from the services tier.
+"""
+
+from nexus.lib.io_metrics import *  # noqa: F403

--- a/tests/integration/services/test_io_metrics_endpoint.py
+++ b/tests/integration/services/test_io_metrics_endpoint.py
@@ -1,0 +1,38 @@
+from __future__ import annotations
+
+from prometheus_client import generate_latest
+
+from nexus.lib import io_metrics
+
+
+def test_io_metrics_exposed_via_global_registry() -> None:
+    io_metrics.record_read(tier="backend", bytes_read=1, latency_seconds=0.001)
+    io_metrics.record_cache_request("sqlite", "hit")
+    io_metrics.record_write_backend_rpc()
+
+    body = generate_latest().decode()
+
+    expected_names = [
+        "nexus_cache_requests_total",
+        "nexus_cache_hit_ratio",
+        "nexus_cache_evictions_total",
+        "nexus_cache_bytes_in_use",
+        "nexus_cache_admission_rejected_total",
+        "nexus_cache_etag_revalidate_total",
+        "nexus_prefetch_issued_bytes_total",
+        "nexus_prefetch_used_bytes_total",
+        "nexus_prefetch_wasted_bytes_total",
+        "nexus_prefetch_window_size",
+        "nexus_prefetch_pattern_detected_total",
+        "nexus_read_latency_seconds",
+        "nexus_read_bytes_total",
+        "nexus_read_batch_size",
+        "nexus_fuse_passthrough_used_total",
+        "nexus_write_coalesce_flush_total",
+        "nexus_write_coalesce_dirty_bytes",
+        "nexus_write_backend_rpc_total",
+        "nexus_generation_mismatch_total",
+        "nexus_etag_check_total",
+    ]
+    for name in expected_names:
+        assert name in body

--- a/tests/unit/core/test_nexus_fs_content_metrics.py
+++ b/tests/unit/core/test_nexus_fs_content_metrics.py
@@ -1,0 +1,370 @@
+from __future__ import annotations
+
+from types import SimpleNamespace
+from typing import Any
+
+from prometheus_client import REGISTRY
+
+from nexus.core.nexus_fs_content import ContentMixin
+
+_OVERSIZED_BATCH_LENGTH = 100 * 1024 * 1024 + 1
+
+
+def _sample(name: str, **labels: str) -> float:
+    for family in REGISTRY.collect():
+        for sample in family.samples:
+            if sample.name == name and all(sample.labels.get(k) == v for k, v in labels.items()):
+                return float(sample.value)
+    return 0.0
+
+
+class _Kernel:
+    def __init__(self) -> None:
+        self.sys_read_calls = 0
+        self.sys_write_calls = 0
+
+    def sys_read(self, path: str, _ctx: object, _timeout_ms: int, _offset: int = 0) -> Any:
+        self.sys_read_calls += 1
+        return SimpleNamespace(
+            data=b"abc",
+            post_hook_needed=False,
+            content_id="cid",
+            entry_type=1,
+            stream_next_offset=None,
+        )
+
+    def sys_write(self, path: str, _ctx: object, content: bytes, _offset: int = 0) -> Any:
+        self.sys_write_calls += 1
+        return SimpleNamespace(
+            hit=True,
+            content_id="cid",
+            post_hook_needed=False,
+            version=1,
+            size=len(content),
+            is_new=True,
+            old_content_id=None,
+            old_size=None,
+            old_version=None,
+            old_modified_at_ms=None,
+        )
+
+    def metastore_get_batch(self, paths: list[str]) -> list[Any]:
+        return [
+            SimpleNamespace(
+                size=3,
+                content_id=f"cid-{index}",
+                version=1,
+                modified_at=None,
+            )
+            for index, _path in enumerate(paths)
+        ]
+
+    def _read_batch(self, paths: list[str], _ctx: object) -> list[Any]:
+        return [
+            SimpleNamespace(
+                data=f"b{index}".encode(),
+                content_id=f"cid-{index}",
+            )
+            for index, _path in enumerate(paths)
+        ]
+
+    def _write_batch(self, files: list[tuple[str, bytes]], _ctx: object) -> list[Any]:
+        return [
+            SimpleNamespace(
+                hit=True,
+                content_id=f"cid-{index}",
+                version=1,
+                size=len(content),
+            )
+            for index, (_path, content) in enumerate(files)
+        ]
+
+    def dispatch_pre_hooks(self, _name: str, _ctx: object) -> None:
+        return None
+
+    def hook_count(self, _name: str) -> int:
+        return 0
+
+    def dispatch_post_hooks(self, _name: str, _ctx: object) -> None:
+        return None
+
+
+class _ErrorKernel(_Kernel):
+    def sys_read(self, path: str, _ctx: object, _timeout_ms: int, _offset: int = 0) -> Any:
+        self.sys_read_calls += 1
+        raise RuntimeError("boom")
+
+
+class _FallbackKernel(_Kernel):
+    def _read_batch(self, paths: list[str], _ctx: object) -> list[Any]:
+        return [
+            SimpleNamespace(
+                data=None,
+                content_id=f"cid-{index}",
+            )
+            for index, _path in enumerate(paths)
+        ]
+
+
+class _MutatingHookKernel(_Kernel):
+    def hook_count(self, name: str) -> int:
+        return 1 if name == "read" else 0
+
+    def dispatch_post_hooks(self, name: str, ctx: object) -> None:
+        if name == "read":
+            ctx.content = b"expanded"
+
+
+class _OversizedBytes(bytes):
+    def __new__(cls) -> _OversizedBytes:
+        return super().__new__(cls, b"x")
+
+    def __len__(self) -> int:
+        return _OVERSIZED_BATCH_LENGTH
+
+
+class _Harness(ContentMixin):
+    def __init__(self) -> None:
+        self._kernel = _Kernel()
+        self._zone_id = "root"
+        self.metadata = SimpleNamespace()
+        self._driver_coordinator = SimpleNamespace()
+
+    def _parse_context(self, context: object | None) -> object | None:
+        return context
+
+    def resolve_read(
+        self, path: str, *, context: object | None = None
+    ) -> tuple[bool, bytes | None]:
+        return (False, None)
+
+    def resolve_write(
+        self, path: str, content: bytes, *, context: object | None = None
+    ) -> tuple[bool, dict[str, object] | None]:
+        return (False, None)
+
+    def _build_rust_ctx(self, context: object | None, is_admin: bool) -> object:
+        return object()
+
+    def _get_context_identity(self, context: object | None) -> tuple[str, str | None, bool]:
+        return ("root", None, False)
+
+    def _validate_path(self, path: str) -> str:
+        return path
+
+    def _batch_permission_check(self, paths: list[str], context: object | None) -> set[str]:
+        return set(paths)
+
+    def _dispatch_batch_post_hook(self, _name: str, _ctx: object) -> None:
+        return None
+
+
+class _VirtualHarness(_Harness):
+    def resolve_read(
+        self, path: str, *, context: object | None = None
+    ) -> tuple[bool, bytes | None]:
+        return (True, b"virtual")
+
+
+class _ErrorHarness(_Harness):
+    def __init__(self) -> None:
+        super().__init__()
+        self._kernel = _ErrorKernel()
+
+
+class _FallbackHarness(_Harness):
+    def __init__(self) -> None:
+        super().__init__()
+        self._kernel = _FallbackKernel()
+
+    def sys_read(
+        self,
+        path: str,
+        *,
+        count: int | None = None,
+        offset: int = 0,
+        context: object | None = None,
+    ) -> bytes | dict[str, object]:
+        return b"fallback"
+
+
+class _InstrumentedFallbackHarness(_Harness):
+    def __init__(self) -> None:
+        super().__init__()
+        self._kernel = _FallbackKernel()
+
+
+class _OversizedFallbackHarness(_FallbackHarness):
+    def sys_read(
+        self,
+        path: str,
+        *,
+        count: int | None = None,
+        offset: int = 0,
+        context: object | None = None,
+    ) -> bytes | dict[str, object]:
+        return _OversizedBytes()
+
+
+class _StreamFallbackHarness(_FallbackHarness):
+    def sys_read(
+        self,
+        path: str,
+        *,
+        count: int | None = None,
+        offset: int = 0,
+        context: object | None = None,
+    ) -> bytes | dict[str, object]:
+        return {"data": b"streamed", "next_offset": 8}
+
+
+class _MutatingHookHarness(_Harness):
+    def __init__(self) -> None:
+        super().__init__()
+        self._kernel = _MutatingHookKernel()
+
+
+def test_sys_read_records_backend_latency_and_bytes() -> None:
+    harness = _Harness()
+    before_bytes = _sample("nexus_read_bytes_total", tier="backend")
+    before_count = _sample("nexus_read_latency_seconds_count", tier="backend")
+
+    assert harness.sys_read("/file.txt") == b"abc"
+
+    assert _sample("nexus_read_bytes_total", tier="backend") == before_bytes + 3
+    assert _sample("nexus_read_latency_seconds_count", tier="backend") == before_count + 1
+
+
+def test_sys_read_records_virtual_resolver_reads() -> None:
+    harness = _VirtualHarness()
+    before_bytes = _sample("nexus_read_bytes_total", tier="virtual")
+
+    assert harness.sys_read("/__sys__/virtual") == b"virtual"
+
+    assert _sample("nexus_read_bytes_total", tier="virtual") == before_bytes + 7
+
+
+def test_sys_read_records_error_tier_metrics() -> None:
+    harness = _ErrorHarness()
+    before_bytes = _sample("nexus_read_bytes_total", tier="error")
+    before_count = _sample("nexus_read_latency_seconds_count", tier="error")
+
+    try:
+        harness.sys_read("/file.txt")
+    except RuntimeError as exc:
+        assert str(exc) == "boom"
+    else:
+        raise AssertionError("sys_read should have raised")
+
+    assert _sample("nexus_read_bytes_total", tier="error") == before_bytes
+    assert _sample("nexus_read_latency_seconds_count", tier="error") == before_count + 1
+
+
+def test_sys_write_records_backend_rpc_when_kernel_hit() -> None:
+    harness = _Harness()
+    before = _sample("nexus_write_backend_rpc_total")
+
+    harness.sys_write("/file.txt", b"abc")
+
+    assert _sample("nexus_write_backend_rpc_total") == before + 1
+
+
+def test_write_locked_records_backend_rpc_when_kernel_hit() -> None:
+    harness = _Harness()
+    before = _sample("nexus_write_backend_rpc_total")
+
+    harness._write_locked("/file.txt", b"abc")
+
+    assert _sample("nexus_write_backend_rpc_total") == before + 1
+
+
+def test_write_batch_records_backend_rpc_for_rust_hits() -> None:
+    harness = _Harness()
+    before = _sample("nexus_write_backend_rpc_total")
+
+    results = harness.write_batch([("/a.txt", b"abc"), ("/b.txt", b"defg")])
+
+    assert [item["size"] for item in results] == [3, 4]
+    assert _sample("nexus_write_backend_rpc_total") == before + 2
+
+
+def test_read_batch_records_batch_size_and_batch_bytes() -> None:
+    harness = _Harness()
+    before_size = _sample("nexus_read_batch_size_count")
+    before_bytes = _sample("nexus_read_bytes_total", tier="batch")
+    before_latency_count = _sample("nexus_read_latency_seconds_count", tier="batch")
+
+    results = harness.read_batch(["/a.txt", "/b.txt"])
+
+    assert [item["content"] for item in results] == [b"b0", b"b1"]
+    assert _sample("nexus_read_batch_size_count") == before_size + 1
+    assert _sample("nexus_read_bytes_total", tier="batch") == before_bytes + 4
+    assert _sample("nexus_read_latency_seconds_count", tier="batch") == before_latency_count
+
+
+def test_read_batch_empty_records_batch_size() -> None:
+    harness = _Harness()
+    before_size = _sample("nexus_read_batch_size_count")
+
+    assert harness.read_batch([]) == []
+
+    assert _sample("nexus_read_batch_size_count") == before_size + 1
+
+
+def test_read_batch_fallback_does_not_record_synthetic_batch_metrics() -> None:
+    harness = _FallbackHarness()
+    before_bytes = _sample("nexus_read_bytes_total", tier="batch")
+    before_latency_count = _sample("nexus_read_latency_seconds_count", tier="batch")
+
+    results = harness.read_batch(["/fallback.txt"])
+
+    assert results[0]["content"] == b"fallback"
+    assert _sample("nexus_read_bytes_total", tier="batch") == before_bytes
+    assert _sample("nexus_read_latency_seconds_count", tier="batch") == before_latency_count
+
+
+def test_read_batch_fallback_does_not_double_count_single_read_metrics() -> None:
+    harness = _InstrumentedFallbackHarness()
+    before_backend_bytes = _sample("nexus_read_bytes_total", tier="backend")
+    before_batch_bytes = _sample("nexus_read_bytes_total", tier="batch")
+
+    results = harness.read_batch(["/fallback.txt"])
+
+    assert results[0]["content"] == b"abc"
+    assert _sample("nexus_read_bytes_total", tier="backend") == before_backend_bytes + 3
+    assert _sample("nexus_read_bytes_total", tier="batch") == before_batch_bytes
+
+
+def test_read_batch_fallback_does_not_record_bytes_when_size_guard_rejects() -> None:
+    harness = _OversizedFallbackHarness()
+    before_bytes = _sample("nexus_read_bytes_total", tier="batch")
+
+    try:
+        harness.read_batch(["/too-large.txt"])
+    except ValueError as exc:
+        assert "Batch read aggregate size exceeded" in str(exc)
+    else:
+        raise AssertionError("read_batch should have raised")
+
+    assert _sample("nexus_read_bytes_total", tier="batch") == before_bytes
+
+
+def test_read_batch_fallback_stream_dict_records_payload_bytes() -> None:
+    harness = _StreamFallbackHarness()
+    before_bytes = _sample("nexus_read_bytes_total", tier="batch")
+
+    results = harness.read_batch(["/stream"])
+
+    assert results[0]["content"] == {"data": b"streamed", "next_offset": 8}
+    assert results[0]["size"] == 8
+    assert _sample("nexus_read_bytes_total", tier="batch") == before_bytes
+
+
+def test_read_batch_records_bytes_after_read_hook_mutates_content() -> None:
+    harness = _MutatingHookHarness()
+    before_bytes = _sample("nexus_read_bytes_total", tier="batch")
+
+    results = harness.read_batch(["/hooked.txt"])
+
+    assert results[0]["content"] == b"expanded"
+    assert _sample("nexus_read_bytes_total", tier="batch") == before_bytes + 8

--- a/tests/unit/services/test_io_metrics.py
+++ b/tests/unit/services/test_io_metrics.py
@@ -1,0 +1,211 @@
+from __future__ import annotations
+
+from prometheus_client import REGISTRY
+
+from nexus.lib import io_metrics
+
+
+def _sample(name: str, **labels: str) -> float:
+    for family in REGISTRY.collect():
+        for sample in family.samples:
+            if sample.name == name and all(sample.labels.get(k) == v for k, v in labels.items()):
+                return float(sample.value)
+    return 0.0
+
+
+def test_record_cache_request_increments_bounded_counter() -> None:
+    before = _sample("nexus_cache_requests_total", tier="sqlite", result="hit")
+    io_metrics.record_cache_request("sqlite", "hit")
+    after = _sample("nexus_cache_requests_total", tier="sqlite", result="hit")
+    assert after == before + 1
+
+
+def test_unknown_cache_labels_collapse_to_other() -> None:
+    before = _sample("nexus_cache_requests_total", tier="other", result="other")
+    io_metrics.record_cache_request("tenant-123", "path-/secret")
+    after = _sample("nexus_cache_requests_total", tier="other", result="other")
+    assert after == before + 1
+
+
+def test_cache_gauges_and_future_counters_update() -> None:
+    io_metrics.set_cache_hit_ratio("sqlite", 0.75)
+    assert _sample("nexus_cache_hit_ratio", tier="sqlite") == 0.75
+
+    io_metrics.set_cache_bytes_in_use("sqlite", 1234)
+    assert _sample("nexus_cache_bytes_in_use", tier="sqlite") == 1234
+
+    before_evictions = _sample("nexus_cache_evictions_total", tier="sqlite", reason="capacity")
+    io_metrics.record_cache_eviction("sqlite", "capacity")
+    after_evictions = _sample("nexus_cache_evictions_total", tier="sqlite", reason="capacity")
+    assert after_evictions == before_evictions + 1
+
+    before_rejected = _sample("nexus_cache_admission_rejected_total")
+    io_metrics.record_cache_admission_rejected()
+    after_rejected = _sample("nexus_cache_admission_rejected_total")
+    assert after_rejected == before_rejected + 1
+
+
+def test_cache_hit_ratio_clamps_to_valid_range() -> None:
+    io_metrics.set_cache_hit_ratio("dram", -0.25)
+    assert _sample("nexus_cache_hit_ratio", tier="dram") == 0.0
+
+    io_metrics.set_cache_hit_ratio("dram", 1.25)
+    assert _sample("nexus_cache_hit_ratio", tier="dram") == 1.0
+
+
+def test_negative_byte_gauge_and_histogram_inputs_clamp_to_zero() -> None:
+    before_issued = _sample("nexus_prefetch_issued_bytes_total")
+    io_metrics.record_prefetch_issued(-10)
+    assert _sample("nexus_prefetch_issued_bytes_total") == before_issued
+
+    before_used = _sample("nexus_prefetch_used_bytes_total")
+    io_metrics.record_prefetch_used(-7)
+    assert _sample("nexus_prefetch_used_bytes_total") == before_used
+
+    before_wasted = _sample("nexus_prefetch_wasted_bytes_total")
+    io_metrics.record_prefetch_wasted(-3)
+    assert _sample("nexus_prefetch_wasted_bytes_total") == before_wasted
+
+    io_metrics.set_cache_bytes_in_use("sqlite", -1234)
+    assert _sample("nexus_cache_bytes_in_use", tier="sqlite") == 0.0
+
+    before_read_bytes = _sample("nexus_read_bytes_total", tier="backend")
+    before_read_count = _sample("nexus_read_latency_seconds_count", tier="backend")
+    before_read_sum = _sample("nexus_read_latency_seconds_sum", tier="backend")
+    io_metrics.record_read(tier="backend", bytes_read=-512, latency_seconds=-0.005)
+    assert _sample("nexus_read_bytes_total", tier="backend") == before_read_bytes
+    assert _sample("nexus_read_latency_seconds_count", tier="backend") == before_read_count + 1
+    assert _sample("nexus_read_latency_seconds_sum", tier="backend") == before_read_sum
+
+    before_batch_count = _sample("nexus_read_batch_size_count")
+    before_batch_sum = _sample("nexus_read_batch_size_sum")
+    io_metrics.record_read_batch_size(-4)
+    assert _sample("nexus_read_batch_size_count") == before_batch_count + 1
+    assert _sample("nexus_read_batch_size_sum") == before_batch_sum
+
+    io_metrics.set_prefetch_window_size(-4096, mount="root", workspace="default")
+    assert _sample("nexus_prefetch_window_size", mount="root", workspace="default") == 0.0
+
+    io_metrics.set_write_coalesce_dirty_bytes(-2048)
+    assert _sample("nexus_write_coalesce_dirty_bytes") == 0.0
+
+
+def test_labeled_gauge_recorders_collapse_to_bounded_labels() -> None:
+    io_metrics.set_cache_hit_ratio("tenant-123", 0.5)
+    assert _sample("nexus_cache_hit_ratio", tier="other") == 0.5
+
+    io_metrics.set_cache_bytes_in_use("path-/secret", 123)
+    assert _sample("nexus_cache_bytes_in_use", tier="other") == 123
+
+    io_metrics.set_prefetch_window_size(2048, mount="tenant-123", workspace="path-/secret")
+    assert _sample("nexus_prefetch_window_size", mount="default", workspace="default") == 2048
+
+
+def test_etag_recorders_update_expected_results() -> None:
+    before_revalidate = _sample("nexus_cache_etag_revalidate_total", result="304")
+    io_metrics.record_cache_etag_revalidate("304")
+    after_revalidate = _sample("nexus_cache_etag_revalidate_total", result="304")
+    assert after_revalidate == before_revalidate + 1
+
+    before_check = _sample("nexus_etag_check_total", result="updated")
+    io_metrics.record_etag_check("updated")
+    after_check = _sample("nexus_etag_check_total", result="updated")
+    assert after_check == before_check + 1
+
+
+def test_prefetch_recorders_update_bounded_metrics() -> None:
+    before_issued = _sample("nexus_prefetch_issued_bytes_total")
+    io_metrics.record_prefetch_issued(10)
+    assert _sample("nexus_prefetch_issued_bytes_total") == before_issued + 10
+
+    before_used = _sample("nexus_prefetch_used_bytes_total")
+    io_metrics.record_prefetch_used(7)
+    assert _sample("nexus_prefetch_used_bytes_total") == before_used + 7
+
+    before_wasted = _sample("nexus_prefetch_wasted_bytes_total")
+    io_metrics.record_prefetch_wasted(3)
+    assert _sample("nexus_prefetch_wasted_bytes_total") == before_wasted + 3
+
+    io_metrics.set_prefetch_window_size(4096, mount="root", workspace="default")
+    assert _sample("nexus_prefetch_window_size", mount="root", workspace="default") == 4096
+
+    before_pattern = _sample("nexus_prefetch_pattern_detected_total", pattern="sequential")
+    io_metrics.record_prefetch_pattern("sequential")
+    after_pattern = _sample("nexus_prefetch_pattern_detected_total", pattern="sequential")
+    assert after_pattern == before_pattern + 1
+
+
+def test_read_metrics_update_bytes_and_histogram_count() -> None:
+    before_bytes = _sample("nexus_read_bytes_total", tier="backend")
+    before_count = _sample("nexus_read_latency_seconds_count", tier="backend")
+    io_metrics.record_read(tier="backend", bytes_read=512, latency_seconds=0.005)
+    assert _sample("nexus_read_bytes_total", tier="backend") == before_bytes + 512
+    assert _sample("nexus_read_latency_seconds_count", tier="backend") == before_count + 1
+
+
+def test_read_bytes_only_metric_does_not_observe_latency() -> None:
+    before_bytes = _sample("nexus_read_bytes_total", tier="batch")
+    before_count = _sample("nexus_read_latency_seconds_count", tier="batch")
+
+    io_metrics.record_read_bytes(tier="batch", bytes_read=512)
+
+    assert _sample("nexus_read_bytes_total", tier="batch") == before_bytes + 512
+    assert _sample("nexus_read_latency_seconds_count", tier="batch") == before_count
+
+
+def test_batch_write_and_consistency_recorders_update() -> None:
+    before_batch = _sample("nexus_read_batch_size_count")
+    io_metrics.record_read_batch_size(4)
+    assert _sample("nexus_read_batch_size_count") == before_batch + 1
+
+    before_passthrough = _sample("nexus_fuse_passthrough_used_total")
+    io_metrics.record_fuse_passthrough_used()
+    assert _sample("nexus_fuse_passthrough_used_total") == before_passthrough + 1
+
+    before_flush = _sample("nexus_write_coalesce_flush_total", trigger="time")
+    io_metrics.record_write_coalesce_flush("time")
+    assert _sample("nexus_write_coalesce_flush_total", trigger="time") == before_flush + 1
+
+    io_metrics.set_write_coalesce_dirty_bytes(2048)
+    assert _sample("nexus_write_coalesce_dirty_bytes") == 2048
+
+    before_rpc = _sample("nexus_write_backend_rpc_total")
+    io_metrics.record_write_backend_rpc()
+    assert _sample("nexus_write_backend_rpc_total") == before_rpc + 1
+
+    before_mismatch = _sample("nexus_generation_mismatch_total")
+    io_metrics.record_generation_mismatch()
+    assert _sample("nexus_generation_mismatch_total") == before_mismatch + 1
+
+
+def test_unknown_labeled_recorders_collapse_to_other() -> None:
+    before_eviction = _sample("nexus_cache_evictions_total", tier="other", reason="other")
+    io_metrics.record_cache_eviction("tenant-123", "path-/secret")
+    after_eviction = _sample("nexus_cache_evictions_total", tier="other", reason="other")
+    assert after_eviction == before_eviction + 1
+
+    before_revalidate = _sample("nexus_cache_etag_revalidate_total", result="other")
+    io_metrics.record_cache_etag_revalidate("path-/secret")
+    after_revalidate = _sample("nexus_cache_etag_revalidate_total", result="other")
+    assert after_revalidate == before_revalidate + 1
+
+    before_check = _sample("nexus_etag_check_total", result="other")
+    io_metrics.record_etag_check("tenant-123")
+    after_check = _sample("nexus_etag_check_total", result="other")
+    assert after_check == before_check + 1
+
+    before_pattern = _sample("nexus_prefetch_pattern_detected_total", pattern="other")
+    io_metrics.record_prefetch_pattern("customer-path")
+    after_pattern = _sample("nexus_prefetch_pattern_detected_total", pattern="other")
+    assert after_pattern == before_pattern + 1
+
+    before_read_bytes = _sample("nexus_read_bytes_total", tier="other")
+    before_read_count = _sample("nexus_read_latency_seconds_count", tier="other")
+    io_metrics.record_read(tier="tenant-123", bytes_read=8, latency_seconds=0.001)
+    assert _sample("nexus_read_bytes_total", tier="other") == before_read_bytes + 8
+    assert _sample("nexus_read_latency_seconds_count", tier="other") == before_read_count + 1
+
+    before_flush = _sample("nexus_write_coalesce_flush_total", trigger="other")
+    io_metrics.record_write_coalesce_flush("path-/secret")
+    after_flush = _sample("nexus_write_coalesce_flush_total", trigger="other")
+    assert after_flush == before_flush + 1

--- a/tests/unit/services/test_io_metrics_docs.py
+++ b/tests/unit/services/test_io_metrics_docs.py
@@ -1,0 +1,147 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[3]
+DOC = ROOT / "docs" / "operations" / "nexus-io-observability.md"
+DASHBOARD = (
+    ROOT
+    / "observability"
+    / "grafana"
+    / "provisioning"
+    / "dashboards"
+    / "nexus-io-observability.json"
+)
+
+METRIC_NAMES = [
+    "nexus_cache_requests_total",
+    "nexus_cache_hit_ratio",
+    "nexus_cache_evictions_total",
+    "nexus_cache_bytes_in_use",
+    "nexus_cache_admission_rejected_total",
+    "nexus_cache_etag_revalidate_total",
+    "nexus_prefetch_issued_bytes_total",
+    "nexus_prefetch_used_bytes_total",
+    "nexus_prefetch_wasted_bytes_total",
+    "nexus_prefetch_window_size",
+    "nexus_prefetch_pattern_detected_total",
+    "nexus_read_latency_seconds",
+    "nexus_read_bytes_total",
+    "nexus_read_batch_size",
+    "nexus_fuse_passthrough_used_total",
+    "nexus_write_coalesce_flush_total",
+    "nexus_write_coalesce_dirty_bytes",
+    "nexus_write_backend_rpc_total",
+    "nexus_generation_mismatch_total",
+    "nexus_etag_check_total",
+]
+
+
+def test_io_observability_docs_cover_every_metric() -> None:
+    body = DOC.read_text()
+    for metric in METRIC_NAMES:
+        assert metric in body
+
+
+def test_io_observability_docs_describe_scraping_and_reserved_series() -> None:
+    body = DOC.read_text()
+    assert "nexus-server:2026" in body
+    assert "`localhost:2026` only when Prometheus runs on the host" in body
+    assert "127.0.0.1:9464 must be reachable" in body
+    assert "daemon" in body
+    assert "--metrics-addr" in body
+    assert "NEXUS_FUSE_METRICS_ADDR" in body
+    assert "remain zero or absent until their labeled series are first observed" in body
+
+
+def test_grafana_dashboard_is_valid_and_mentions_core_metrics() -> None:
+    dashboard = json.loads(DASHBOARD.read_text())
+    assert dashboard["uid"] == "nexus-io-observability"
+    assert dashboard["title"] == "Nexus I/O Observability"
+
+    expressions = [
+        target["expr"] for panel in dashboard["panels"] for target in panel.get("targets", [])
+    ]
+    encoded = "\n".join(expressions)
+    for metric in [
+        "nexus_read_latency_seconds",
+        "nexus_read_bytes_total",
+        "nexus_cache_requests_total",
+        "nexus_cache_bytes_in_use",
+        "nexus_etag_check_total",
+        "nexus_read_batch_size",
+        "nexus_write_backend_rpc_total",
+        "nexus_prefetch_issued_bytes_total",
+        "nexus_prefetch_used_bytes_total",
+        "nexus_prefetch_wasted_bytes_total",
+        "nexus_write_coalesce_flush_total",
+    ]:
+        assert metric in encoded
+
+
+def test_grafana_cache_hit_percentage_uses_low_traffic_safe_denominator() -> None:
+    dashboard = json.loads(DASHBOARD.read_text())
+    hit_panel = next(
+        panel for panel in dashboard["panels"] if panel["title"] == "Derived Cache Hit Percentage"
+    )
+    expr = hit_panel["targets"][0]["expr"]
+
+    assert "clamp_min(sum by (tier) (rate(nexus_cache_requests_total[5m])), 1)" not in expr
+    assert "or on (tier) 0 * sum by (tier)" in expr
+    assert "clamp_min(sum by (tier) (rate(nexus_cache_requests_total[5m])), 1e-9)" in expr
+
+
+def test_grafana_read_latency_panel_includes_quantiles_by_tier() -> None:
+    dashboard = json.loads(DASHBOARD.read_text())
+    latency_panel = next(
+        panel for panel in dashboard["panels"] if panel["title"] == "Read Latency By Tier"
+    )
+
+    expected_targets = {
+        "p50 {{tier}}": "histogram_quantile(0.50, sum by (le, tier) (rate(nexus_read_latency_seconds_bucket[5m])))",
+        "p95 {{tier}}": "histogram_quantile(0.95, sum by (le, tier) (rate(nexus_read_latency_seconds_bucket[5m])))",
+        "p99 {{tier}}": "histogram_quantile(0.99, sum by (le, tier) (rate(nexus_read_latency_seconds_bucket[5m])))",
+    }
+    actual_targets = {target["legendFormat"]: target["expr"] for target in latency_panel["targets"]}
+
+    assert actual_targets == expected_targets
+
+
+def test_grafana_cache_bytes_panel_aggregates_by_tier() -> None:
+    dashboard = json.loads(DASHBOARD.read_text())
+    cache_bytes_panel = next(
+        panel for panel in dashboard["panels"] if panel["title"] == "Cache Bytes In Use"
+    )
+    target = cache_bytes_panel["targets"][0]
+
+    assert target["expr"] == "sum by (tier) (nexus_cache_bytes_in_use)"
+    assert target["legendFormat"] == "{{tier}}"
+
+
+def test_grafana_backend_write_rpc_rate_is_aggregated() -> None:
+    dashboard = json.loads(DASHBOARD.read_text())
+    write_panel = next(
+        panel for panel in dashboard["panels"] if panel["title"] == "Backend Write RPC Rate"
+    )
+    target = write_panel["targets"][0]
+
+    assert target["expr"] == "sum(rate(nexus_write_backend_rpc_total[5m]))"
+    assert target["legendFormat"] == "total write RPC/s"
+
+
+def test_grafana_prefetch_panel_shows_reserved_efficiency_inputs() -> None:
+    dashboard = json.loads(DASHBOARD.read_text())
+    prefetch_panel = next(
+        panel
+        for panel in dashboard["panels"]
+        if panel["title"] == "Prefetch And Coalescing Reserved"
+    )
+    targets = {target["legendFormat"]: target["expr"] for target in prefetch_panel["targets"]}
+
+    assert targets["prefetch issued B/s"] == "rate(nexus_prefetch_issued_bytes_total[5m])"
+    assert targets["prefetch used B/s"] == "rate(nexus_prefetch_used_bytes_total[5m])"
+    assert targets["prefetch wasted B/s"] == "rate(nexus_prefetch_wasted_bytes_total[5m])"
+    assert targets["flush {{trigger}}"] == (
+        "sum by (trigger) (rate(nexus_write_coalesce_flush_total[5m]))"
+    )


### PR DESCRIPTION
## Summary
- Add the shared Nexus I/O metrics catalog and recorders for Python read/write/cache/prefetch/batch/coalescing/FUSE metrics.
- Instrument Python `NexusFSContent` and `nexus-fuse` read, write, cache, ETag, daemon, and metrics endpoint paths with bounded Prometheus labels.
- Add operator docs and a Grafana dashboard for the new I/O observability surface.

## Validation
- `PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1 UV_CACHE_DIR=/tmp/nexus-uv-cache-ba79 uv run pytest tests/unit/services/test_io_metrics.py tests/integration/services/test_io_metrics_endpoint.py tests/unit/core/test_nexus_fs_content_metrics.py tests/unit/services/test_io_metrics_docs.py -v` -> 34 passed
- `PATH=/opt/homebrew/bin:$PATH cargo test --manifest-path nexus-fuse/Cargo.toml cache` -> 20 passed
- `PATH=/opt/homebrew/bin:$PATH cargo test --manifest-path nexus-fuse/Cargo.toml --test metrics_test` -> 9 passed
- `PATH=/opt/homebrew/bin:$PATH cargo test --manifest-path nexus-fuse/Cargo.toml daemon_` -> 3 passed
- `UV_CACHE_DIR=/tmp/nexus-uv-cache-ba79 uv run --extra dev ruff format ...` -> unchanged
- `PATH=/opt/homebrew/bin:$PATH cargo fmt --manifest-path nexus-fuse/Cargo.toml` -> exit 0

## Review Notes
- Final spec review passed with no missing requirements.
- Final code-quality review found no remaining issues.
