### PR TITLE
[codex] fix pay review findings

### DIFF
--- a/alembic/versions/pay_amounts_micro_units.py
+++ b/alembic/versions/pay_amounts_micro_units.py
@@ -1,0 +1,54 @@
+"""Convert Nexus Pay SQL amounts from cents to micro-credits.
+
+Revision ID: pay_amounts_micro_units
+Revises: add_chunks_embedding_halfvec
+Create Date: 2026-05-07
+
+"""
+
+from collections.abc import Sequence
+from typing import Union
+
+import sqlalchemy as sa
+
+from alembic import op
+
+revision: str = "pay_amounts_micro_units"
+down_revision: Union[str, Sequence[str], None] = "add_chunks_embedding_halfvec"
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+PAY_AMOUNT_TABLES = ("payment_transaction_meta", "credit_reservation_meta")
+CENT_TO_MICRO_FACTOR = 10_000
+
+
+def _existing_tables(bind: sa.engine.Connection) -> set[str]:
+    return set(sa.inspect(bind).get_table_names())
+
+
+def upgrade_pay_amounts(bind: sa.engine.Connection) -> None:
+    tables = _existing_tables(bind)
+    for table_name in PAY_AMOUNT_TABLES:
+        if table_name in tables:
+            bind.execute(
+                sa.text(f"UPDATE {table_name} SET amount = amount * :factor"),
+                {"factor": CENT_TO_MICRO_FACTOR},
+            )
+
+
+def downgrade_pay_amounts(bind: sa.engine.Connection) -> None:
+    tables = _existing_tables(bind)
+    for table_name in PAY_AMOUNT_TABLES:
+        if table_name in tables:
+            bind.execute(
+                sa.text(f"UPDATE {table_name} SET amount = amount / :factor"),
+                {"factor": CENT_TO_MICRO_FACTOR},
+            )
+
+
+def upgrade() -> None:
+    upgrade_pay_amounts(op.get_bind())
+
+
+def downgrade() -> None:
+    downgrade_pay_amounts(op.get_bind())

--- a/packages/nexus-api-client/src/sse-client.ts
+++ b/packages/nexus-api-client/src/sse-client.ts
@@ -296,13 +296,13 @@ export class SseClient {
 
       for (const line of block.split("\n")) {
         if (line.startsWith("id:")) {
-          id = line.slice(3).trim();
+          id = parseSseFieldValue(line.slice(3));
         } else if (line.startsWith("event:")) {
-          event = line.slice(6).trim();
+          event = parseSseFieldValue(line.slice(6));
         } else if (line.startsWith("data:")) {
-          data += (data ? "\n" : "") + line.slice(5).trim();
+          data += (data ? "\n" : "") + parseSseFieldValue(line.slice(5));
         } else if (line.startsWith("retry:")) {
-          const val = parseInt(line.slice(6).trim(), 10);
+          const val = parseInt(parseSseFieldValue(line.slice(6)), 10);
           if (!Number.isNaN(val)) retry = val;
         }
       }
@@ -367,4 +367,8 @@ function sleepWithAbort(ms: number, signal: AbortSignal): Promise<boolean> {
 
     signal.addEventListener("abort", onAbort, { once: true });
   });
+}
+
+function parseSseFieldValue(value: string): string {
+  return value.startsWith(" ") ? value.slice(1) : value;
 }

--- a/packages/nexus-api-client/tests/sse-client.test.ts
+++ b/packages/nexus-api-client/tests/sse-client.test.ts
@@ -273,6 +273,33 @@ describe("SseClient", () => {
     expect(events[0]!.data).toBe("line1\nline2");
   });
 
+  it("preserves significant SSE field whitespace after the optional separator space", async () => {
+    const clientRef: { current: SseClient | null } = { current: null };
+    const fetchFn = mockSseFetch(
+      ["id:  id-1  \nevent:  spaced  \ndata:  leading and trailing  \n\n"],
+      clientRef,
+    );
+
+    const client = new SseClient({
+      baseUrl: "http://localhost:2026",
+      apiKey: "test-key",
+      fetch: fetchFn,
+      flushIntervalMs: 10_000,
+    });
+    clientRef.current = client;
+
+    await client.connect("/events");
+
+    const events = client.getBufferedEvents();
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      id: " id-1  ",
+      event: " spaced  ",
+      data: " leading and trailing  ",
+      retry: undefined,
+    });
+  });
+
   it("parses CRLF-terminated SSE events", async () => {
     const clientRef: { current: SseClient | null } = { current: null };
     const fetchFn = mockSseFetch(

--- a/packages/nexus-pay-ts/src/fetch-client.ts
+++ b/packages/nexus-pay-ts/src/fetch-client.ts
@@ -27,6 +27,9 @@ export class FetchClient extends BaseFetchClient {
       timeout: options.timeout,
       maxRetries: options.maxRetries,
       fetch: options.fetch,
+      agentId: options.agentId,
+      subject: options.subject,
+      zoneId: options.zoneId,
       // Disable auto key transform — NexusPay client handles mapping manually
       // to preserve backward compatibility with existing response types
       transformKeys: false,

--- a/packages/nexus-pay-ts/tests/fetch-client.test.ts
+++ b/packages/nexus-pay-ts/tests/fetch-client.test.ts
@@ -63,6 +63,27 @@ describe("FetchClient", () => {
       const headers = new Headers(init.headers);
       expect(headers.get("Content-Type")).toBe("application/json");
     });
+
+    it("forwards configured identity headers to the shared API client", async () => {
+      const identityClient = new FetchClient({
+        apiKey: "nx_test_agent1",
+        baseUrl: "https://api.example.com",
+        maxRetries: 0,
+        agentId: "agent-1",
+        subject: "user:alice",
+        zoneId: "zone-a",
+        fetch: mockFetch,
+      });
+      mockFetch.mockResolvedValueOnce(jsonResponse({ ok: true }));
+
+      await identityClient.get("/test");
+
+      const [, init] = mockFetch.mock.calls[0] as [string, RequestInit];
+      const headers = new Headers(init.headers);
+      expect(headers.get("X-Agent-ID")).toBe("agent-1");
+      expect(headers.get("X-Nexus-Subject")).toBe("user:alice");
+      expect(headers.get("X-Nexus-Zone-ID")).toBe("zone-a");
+    });
   });
 
   // =========================================================================

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1066,6 +1066,35 @@ ignore_imports = [
 ]
 unmatched_ignore_imports_alerting = "warn"
 
+# Contract 3: Explicit top-level package boundary coverage.
+# This complements the layered contract above, which intentionally models the
+# core tier names but does not enumerate every top-level package in src/nexus.
+[[tool.importlinter.contracts]]
+id = "top-level-packages-must-not-import-server"
+name = "Non-server top-level packages must not import server"
+type = "forbidden"
+source_modules = [
+    "nexus.backends",
+    "nexus.contracts",
+    "nexus.core",
+    "nexus.factory",
+    "nexus.fs",
+    "nexus.lib",
+    "nexus.remote",
+    "nexus.security",
+    "nexus.services",
+    "nexus.storage",
+]
+forbidden_modules = ["nexus.server"]
+allow_indirect_imports = true
+# Known lazy direct imports used for optional server-side wiring/debug metadata.
+# Remove entries as these dependencies move behind protocols.
+ignore_imports = [
+    "nexus.factory._system -> nexus.server.observability.observability_subsystem",
+    "nexus.remote.rpc_proxy -> nexus.server._rpc_params_generated",
+]
+unmatched_ignore_imports_alerting = "warn"
+
 [dependency-groups]
 dev = [
     "freezegun>=1.5.5",

--- a/src/nexus/server/api/v2/routers/pay.py
+++ b/src/nexus/server/api/v2/routers/pay.py
@@ -12,17 +12,21 @@ import logging
 import uuid
 from datetime import UTC, datetime, timedelta
 from decimal import Decimal
-from typing import Any
+from typing import Any, Literal
 
-from fastapi import APIRouter, Depends, HTTPException, Request
-from pydantic import BaseModel
+from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, status
+from pydantic import BaseModel, ConfigDict, Field, field_validator
 
+from nexus.bricks.pay.constants import credits_to_micro, micro_to_credits
 from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.server.dependencies import get_operation_context, require_auth
 
 logger = logging.getLogger(__name__)
 
-router = APIRouter(prefix="/api/v2/pay", tags=["payments"])
-audit_router = APIRouter(prefix="/api/v2/audit", tags=["audit"])
+router = APIRouter(prefix="/api/v2/pay", tags=["payments"], dependencies=[Depends(require_auth)])
+audit_router = APIRouter(
+    prefix="/api/v2/audit", tags=["audit"], dependencies=[Depends(require_auth)]
+)
 
 
 # =============================================================================
@@ -110,29 +114,125 @@ def _ensure_tables(record_store: Any) -> None:
         logger.warning("Failed to ensure pay tables: %s", e)
 
 
+def _get_pay_context(auth_result: dict[str, Any] = Depends(require_auth)) -> Any:
+    """Get authenticated operation context for pay routes."""
+    return get_operation_context(auth_result)
+
+
+def _context_agent_id(context: Any) -> str:
+    """Resolve the wallet actor from an operation context."""
+    agent_id = getattr(context, "agent_id", None) or getattr(context, "subject_id", None)
+    if not agent_id:
+        raise HTTPException(status_code=403, detail="Agent identity required")
+    return str(agent_id)
+
+
+def _context_zone_id(context: Any) -> str:
+    return str(getattr(context, "zone_id", None) or ROOT_ZONE_ID)
+
+
+def _normalize_amount(amount: Decimal) -> Decimal:
+    if not amount.is_finite() or amount <= 0:
+        raise ValueError("amount must be a positive decimal")
+    exponent = amount.as_tuple().exponent
+    if not isinstance(exponent, int) or abs(exponent) > 6:
+        raise ValueError("amount must have at most 6 decimal places")
+    return amount
+
+
+def _amount_to_micro(amount: Decimal) -> int:
+    return credits_to_micro(_normalize_amount(amount))
+
+
+def _amount_from_micro(micro: int) -> Decimal:
+    return micro_to_credits(int(micro))
+
+
+def _format_amount(amount: Decimal) -> str:
+    quantized = amount.quantize(Decimal("0.000001"))
+    text = format(quantized, "f").rstrip("0").rstrip(".")
+    if "." not in text:
+        return f"{text}.00"
+    integer, fraction = text.split(".", 1)
+    if len(fraction) == 1:
+        return f"{integer}.{fraction}0"
+    return text
+
+
+def _format_micro_amount(micro: int) -> str:
+    return _format_amount(_amount_from_micro(micro))
+
+
+def _transfer_id_to_int(transfer_id: str | None = None) -> int:
+    if transfer_id:
+        try:
+            value = int(transfer_id)
+            if 0 < value < 2**63:
+                return value
+        except ValueError:
+            pass
+    return uuid.uuid4().int % (2**63)
+
+
 # =============================================================================
 # Request models
 # =============================================================================
 
 
-class TransferRequest(BaseModel):
+class _StrictModel(BaseModel):
+    model_config = ConfigDict(extra="forbid")
+
+
+class _AmountModel(_StrictModel):
+    amount: Decimal = Field(..., gt=Decimal("0"))
+
+    @field_validator("amount")
+    @classmethod
+    def _validate_amount(cls, value: Decimal) -> Decimal:
+        return _normalize_amount(value)
+
+
+class TransferRequest(_AmountModel):
     to: str
-    amount: float
+    memo: str = ""
+    method: Literal["auto", "credits", "x402"] = "auto"
+    idempotency_key: str | None = None
+
+
+class BatchTransferItem(_AmountModel):
+    to: str
     memo: str = ""
 
 
-class ReserveRequest(BaseModel):
-    amount: float
-    purpose: str = ""
+class BatchTransferRequest(_StrictModel):
+    transfers: list[BatchTransferItem] = Field(..., min_length=1, max_length=1000)
 
 
-class PolicyCreateRequest(BaseModel):
+class ReserveRequest(_AmountModel):
+    timeout: int = Field(default=300, ge=1, le=86400)
+    purpose: str = "general"
+    task_id: str | None = None
+
+
+class CommitReservationRequest(_StrictModel):
+    actual_amount: Decimal | None = None
+
+    @field_validator("actual_amount")
+    @classmethod
+    def _validate_actual_amount(cls, value: Decimal | None) -> Decimal | None:
+        return _normalize_amount(value) if value is not None else None
+
+
+class MeterRequest(_AmountModel):
+    event_type: str = "api_call"
+
+
+class PolicyCreateRequest(_StrictModel):
     name: str
-    rules: dict[str, Any] = {}
+    rules: dict[str, Any] = Field(default_factory=dict)
 
 
-class ApprovalRequestBody(BaseModel):
-    amount: float
+class ApprovalRequestBody(_AmountModel):
     purpose: str
 
 
@@ -144,28 +244,35 @@ class ApprovalRequestBody(BaseModel):
 @router.get("/balance")
 async def get_balance(
     _request: Request,
+    context: Any = Depends(_get_pay_context),
     credits: Any = Depends(_get_credits_service),
     record_store: Any = Depends(_get_record_store),
 ) -> dict[str, str]:
     """Get current balance. Uses TigerBeetle if available, unlimited if disabled."""
+    agent_id = _context_agent_id(context)
+    zone_id = _context_zone_id(context)
     try:
-        balance = await credits.get_balance("admin")
-        reserved = (
-            await credits.get_balance_with_reserved("admin")
-            if hasattr(credits, "get_balance_with_reserved")
-            else {"reserved": Decimal(0)}
-        )
-        res_amount = (
-            reserved.get("reserved", Decimal(0)) if isinstance(reserved, dict) else Decimal(0)
-        )
+        if hasattr(credits, "get_balance_with_reserved"):
+            balance_result = await credits.get_balance_with_reserved(agent_id, zone_id)
+            if isinstance(balance_result, tuple):
+                balance, res_amount = balance_result
+            elif isinstance(balance_result, dict):
+                balance = Decimal(str(balance_result.get("available", "0")))
+                res_amount = Decimal(str(balance_result.get("reserved", "0")))
+            else:
+                balance = Decimal(str(balance_result))
+                res_amount = Decimal(0)
+        else:
+            balance = await credits.get_balance(agent_id, zone_id)
+            res_amount = Decimal(0)
         # Disabled mode returns DISABLED_UNLIMITED_BALANCE (999999999)
         # Convert to realistic demo balance by tracking transfers in SQL
         if balance == credits.DISABLED_UNLIMITED_BALANCE:
             raise ValueError("disabled mode")
         return {
-            "available": str(balance),
-            "reserved": str(res_amount),
-            "total": str(balance + res_amount),
+            "available": _format_amount(Decimal(str(balance))),
+            "reserved": _format_amount(Decimal(str(res_amount))),
+            "total": _format_amount(Decimal(str(balance)) + Decimal(str(res_amount))),
         }
     except Exception:
         # Calculate balance from SQL transaction history
@@ -176,11 +283,12 @@ async def get_balance(
             from nexus.storage.models.payments import CreditReservationMeta, PaymentTransactionMeta
 
             with record_store.session_factory() as session:
-                initial_balance = 10000_00  # 10,000 credits in cents
+                initial_balance = credits_to_micro(Decimal("10000"))
                 sent = (
                     session.scalar(
                         select(func.coalesce(func.sum(PaymentTransactionMeta.amount), 0)).where(
-                            PaymentTransactionMeta.from_agent_id == "admin"
+                            PaymentTransactionMeta.from_agent_id == agent_id,
+                            PaymentTransactionMeta.zone_id == zone_id,
                         )
                     )
                     or 0
@@ -188,7 +296,8 @@ async def get_balance(
                 received = (
                     session.scalar(
                         select(func.coalesce(func.sum(PaymentTransactionMeta.amount), 0)).where(
-                            PaymentTransactionMeta.to_agent_id == "admin"
+                            PaymentTransactionMeta.to_agent_id == agent_id,
+                            PaymentTransactionMeta.zone_id == zone_id,
                         )
                     )
                     or 0
@@ -196,18 +305,20 @@ async def get_balance(
                 reserved = (
                     session.scalar(
                         select(func.coalesce(func.sum(CreditReservationMeta.amount), 0)).where(
-                            CreditReservationMeta.status == "pending"
+                            CreditReservationMeta.agent_id == agent_id,
+                            CreditReservationMeta.zone_id == zone_id,
+                            CreditReservationMeta.status == "pending",
                         )
                     )
                     or 0
                 )
 
-                available = (initial_balance - sent + received - reserved) / 100
-                reserved_amt = reserved / 100
+                available = _amount_from_micro(initial_balance - sent + received - reserved)
+                reserved_amt = _amount_from_micro(reserved)
                 return {
-                    "available": f"{available:.2f}",
-                    "reserved": f"{reserved_amt:.2f}",
-                    "total": f"{available + reserved_amt:.2f}",
+                    "available": _format_amount(available),
+                    "reserved": _format_amount(reserved_amt),
+                    "total": _format_amount(available + reserved_amt),
                 }
         except Exception:
             return {"available": "10000.00", "reserved": "0.00", "total": "10000.00"}
@@ -215,19 +326,25 @@ async def get_balance(
 
 @router.get("/can-afford")
 async def can_afford(
-    amount: float,
     _request: Request,
+    amount: Decimal = Query(...),
+    context: Any = Depends(_get_pay_context),
     credits: Any = Depends(_get_credits_service),
 ) -> dict[str, Any]:
     try:
-        balance = await credits.get_balance("admin")
-        available = float(balance)
+        amount = _normalize_amount(amount)
+    except ValueError as exc:
+        raise HTTPException(status_code=422, detail=str(exc)) from exc
+    agent_id = _context_agent_id(context)
+    zone_id = _context_zone_id(context)
+    try:
+        balance = Decimal(str(await credits.get_balance(agent_id, zone_id)))
+        available = balance
     except Exception:
-        available = 999999999.0
+        available = Decimal("999999999")
     return {
         "can_afford": available >= amount,
-        "available": str(available),
-        "requested": str(amount),
+        "amount": _format_amount(amount),
     }
 
 
@@ -295,20 +412,33 @@ async def get_budget(
 # =============================================================================
 
 
-@router.post("/transfer")
+@router.post("/transfer", status_code=status.HTTP_201_CREATED)
 async def transfer(
     body: TransferRequest,
     _request: Request,
+    context: Any = Depends(_get_pay_context),
     record_store: Any = Depends(_get_record_store),
     credits: Any = Depends(_get_credits_service),
+    idempotency_key_header: str | None = Header(None, alias="Idempotency-Key"),
 ) -> dict[str, Any]:
     _ensure_tables(record_store)
     tx_id = str(uuid.uuid4())
     now = datetime.now(UTC)
+    from_agent = _context_agent_id(context)
+    zone_id = _context_zone_id(context)
+    idempotency_key = body.idempotency_key or idempotency_key_header
+    transfer_id: str | None = None
 
     # Attempt real transfer via CreditsService
     try:
-        await credits.transfer("admin", body.to, Decimal(str(body.amount)), memo=body.memo)
+        transfer_id = await credits.transfer(
+            from_agent,
+            body.to,
+            body.amount,
+            memo=body.memo,
+            idempotency_key=idempotency_key,
+            zone_id=zone_id,
+        )
     except Exception as e:
         logger.debug("Credits transfer skipped (disabled mode): %s", e)
 
@@ -319,13 +449,14 @@ async def transfer(
         with record_store.session_factory() as session:
             txn = PaymentTransactionMeta(
                 id=tx_id,
-                from_agent_id="admin",
+                zone_id=zone_id,
+                from_agent_id=from_agent,
                 to_agent_id=body.to,
-                amount=int(body.amount * 100),
+                amount=_amount_to_micro(body.amount),
                 currency="credits",
-                method="credits",
+                method=body.method,
                 memo=body.memo,
-                tigerbeetle_transfer_id=uuid.uuid4().int >> 64,
+                tigerbeetle_transfer_id=_transfer_id_to_int(transfer_id),
                 status="completed",
             )
             session.add(txn)
@@ -335,9 +466,9 @@ async def transfer(
 
     return {
         "id": tx_id,
-        "method": "credits",
-        "amount": f"{body.amount:.2f}",
-        "from_agent": "admin",
+        "method": body.method,
+        "amount": _format_amount(body.amount),
+        "from_agent": from_agent,
         "to_agent": body.to,
         "memo": body.memo,
         "timestamp": now.isoformat(),
@@ -345,12 +476,93 @@ async def transfer(
     }
 
 
+@router.post("/transfer/batch", status_code=status.HTTP_201_CREATED)
+async def transfer_batch(
+    body: BatchTransferRequest,
+    _request: Request,
+    context: Any = Depends(_get_pay_context),
+    record_store: Any = Depends(_get_record_store),
+    credits: Any = Depends(_get_credits_service),
+) -> list[dict[str, Any]]:
+    _ensure_tables(record_store)
+    from_agent = _context_agent_id(context)
+    zone_id = _context_zone_id(context)
+    now = datetime.now(UTC)
+    transfer_ids: list[str | None] = [None] * len(body.transfers)
+
+    try:
+        if hasattr(credits, "transfer_batch"):
+            from nexus.bricks.pay.credits import TransferRequest as CreditsTransferRequest
+
+            credit_transfers = [
+                CreditsTransferRequest(
+                    from_id=from_agent,
+                    to_id=item.to,
+                    amount=item.amount,
+                    memo=item.memo,
+                )
+                for item in body.transfers
+            ]
+            transfer_ids = list(await credits.transfer_batch(credit_transfers, zone_id=zone_id))
+        else:
+            for i, item in enumerate(body.transfers):
+                transfer_ids[i] = await credits.transfer(
+                    from_agent,
+                    item.to,
+                    item.amount,
+                    memo=item.memo,
+                    zone_id=zone_id,
+                )
+    except Exception as e:
+        logger.debug("Credits batch transfer skipped (disabled mode): %s", e)
+
+    receipts: list[dict[str, Any]] = []
+    try:
+        from nexus.storage.models.payments import PaymentTransactionMeta
+
+        with record_store.session_factory() as session:
+            for i, item in enumerate(body.transfers):
+                tx_id = str(uuid.uuid4())
+                txn = PaymentTransactionMeta(
+                    id=tx_id,
+                    zone_id=zone_id,
+                    from_agent_id=from_agent,
+                    to_agent_id=item.to,
+                    amount=_amount_to_micro(item.amount),
+                    currency="credits",
+                    method="credits",
+                    memo=item.memo,
+                    tigerbeetle_transfer_id=_transfer_id_to_int(transfer_ids[i]),
+                    status="completed",
+                )
+                session.add(txn)
+                receipts.append(
+                    {
+                        "id": tx_id,
+                        "method": "credits",
+                        "amount": _format_amount(item.amount),
+                        "from_agent": from_agent,
+                        "to_agent": item.to,
+                        "memo": item.memo,
+                        "timestamp": now.isoformat(),
+                        "tx_hash": None,
+                    }
+                )
+            session.commit()
+    except Exception as e:
+        logger.warning("Failed to record batch transaction in SQL: %s", e)
+
+    return receipts
+
+
 # =============================================================================
 # Transactions (SQL-backed audit trail)
 # =============================================================================
 
 
-def _list_transactions(record_store: Any, limit: int, cursor: str | None) -> dict[str, Any]:
+def _list_transactions(
+    record_store: Any, limit: int, cursor: str | None, zone_id: str | None = None
+) -> dict[str, Any]:
     _ensure_tables(record_store)
     try:
         from sqlalchemy import desc, func, select
@@ -358,13 +570,18 @@ def _list_transactions(record_store: Any, limit: int, cursor: str | None) -> dic
         from nexus.storage.models.payments import PaymentTransactionMeta
 
         with record_store.session_factory() as session:
-            total = session.scalar(select(func.count(PaymentTransactionMeta.id))) or 0
+            total_stmt = select(func.count(PaymentTransactionMeta.id))
+            if zone_id is not None:
+                total_stmt = total_stmt.where(PaymentTransactionMeta.zone_id == zone_id)
+            total = session.scalar(total_stmt) or 0
 
             stmt = (
                 select(PaymentTransactionMeta)
                 .order_by(desc(PaymentTransactionMeta.created_at))
                 .limit(limit)
             )
+            if zone_id is not None:
+                stmt = stmt.where(PaymentTransactionMeta.zone_id == zone_id)
             if cursor:
                 stmt = stmt.offset(int(cursor))
             rows = session.scalars(stmt).all()
@@ -380,7 +597,7 @@ def _list_transactions(record_store: Any, limit: int, cursor: str | None) -> dic
                     "protocol": r.method,
                     "buyer_agent_id": r.from_agent_id,
                     "seller_agent_id": r.to_agent_id,
-                    "amount": f"{r.amount / 100:.2f}",
+                    "amount": _format_micro_amount(r.amount),
                     "currency": r.currency,
                     "status": r.status,
                     "zone_id": r.zone_id,
@@ -415,26 +632,29 @@ def _list_transactions(record_store: Any, limit: int, cursor: str | None) -> dic
 async def list_pay_transactions(
     limit: int = 20,
     cursor: str | None = None,
+    context: Any = Depends(_get_pay_context),
     record_store: Any = Depends(_get_record_store),
 ) -> dict[str, Any]:
-    return _list_transactions(record_store, limit, cursor)
+    return _list_transactions(record_store, limit, cursor, _context_zone_id(context))
 
 
 @audit_router.get("/transactions")
 async def list_audit_transactions(
     limit: int = 20,
     cursor: str | None = None,
+    context: Any = Depends(_get_pay_context),
     record_store: Any = Depends(_get_record_store),
 ) -> dict[str, Any]:
-    return _list_transactions(record_store, limit, cursor)
+    return _list_transactions(record_store, limit, cursor, _context_zone_id(context))
 
 
 @router.get("/transactions/integrity")
 async def verify_integrity(
     _request: Request,
+    context: Any = Depends(_get_pay_context),
     record_store: Any = Depends(_get_record_store),
 ) -> list[dict[str, Any]]:
-    result = _list_transactions(record_store, 100, None)
+    result = _list_transactions(record_store, 100, None, _context_zone_id(context))
     return [
         {"record_id": t["id"], "is_valid": True, "record_hash": t["record_hash"]}
         for t in result["transactions"]
@@ -449,9 +669,12 @@ async def verify_integrity(
 @router.get("/reservations")
 async def list_reservations(
     _request: Request,
+    context: Any = Depends(_get_pay_context),
     record_store: Any = Depends(_get_record_store),
 ) -> list[dict[str, Any]]:
     _ensure_tables(record_store)
+    agent_id = _context_agent_id(context)
+    zone_id = _context_zone_id(context)
     try:
         from sqlalchemy import select
 
@@ -459,12 +682,16 @@ async def list_reservations(
 
         with record_store.session_factory() as session:
             rows = session.scalars(
-                select(CreditReservationMeta).where(CreditReservationMeta.status == "pending")
+                select(CreditReservationMeta).where(
+                    CreditReservationMeta.agent_id == agent_id,
+                    CreditReservationMeta.zone_id == zone_id,
+                    CreditReservationMeta.status == "pending",
+                )
             ).all()
             return [
                 {
                     "id": r.id,
-                    "amount": f"{r.amount / 100:.2f}",
+                    "amount": _format_micro_amount(r.amount),
                     "purpose": r.purpose,
                     "expires_at": r.expires_at.isoformat() if r.expires_at else None,
                     "status": r.status,
@@ -476,27 +703,43 @@ async def list_reservations(
         return []
 
 
-@router.post("/reserve")
+@router.post("/reserve", status_code=status.HTTP_201_CREATED)
 async def reserve(
     body: ReserveRequest,
     _request: Request,
+    context: Any = Depends(_get_pay_context),
     record_store: Any = Depends(_get_record_store),
+    credits: Any = Depends(_get_credits_service),
 ) -> dict[str, Any]:
     _ensure_tables(record_store)
-    res_id = str(uuid.uuid4())
+    agent_id = _context_agent_id(context)
+    zone_id = _context_zone_id(context)
     now = datetime.now(UTC)
+    expires_at = now + timedelta(seconds=body.timeout)
+    try:
+        res_id = await credits.reserve(
+            agent_id,
+            body.amount,
+            timeout_seconds=body.timeout,
+            zone_id=zone_id,
+        )
+    except Exception as e:
+        logger.debug("Credits reservation skipped (disabled mode): %s", e)
+        res_id = str(uuid.uuid4())
     try:
         from nexus.storage.models.payments import CreditReservationMeta
 
         with record_store.session_factory() as session:
             res = CreditReservationMeta(
                 id=res_id,
-                agent_id="admin",
-                amount=int(body.amount * 100),
-                purpose=body.purpose or "manual reservation",
-                tigerbeetle_transfer_id=uuid.uuid4().int >> 64,
+                zone_id=zone_id,
+                agent_id=agent_id,
+                amount=_amount_to_micro(body.amount),
+                purpose=body.purpose or "general",
+                task_id=body.task_id,
+                tigerbeetle_transfer_id=_transfer_id_to_int(res_id),
                 status="pending",
-                expires_at=now + timedelta(hours=1),
+                expires_at=expires_at,
             )
             session.add(res)
             session.commit()
@@ -505,20 +748,25 @@ async def reserve(
 
     return {
         "id": res_id,
-        "amount": f"{body.amount:.2f}",
+        "amount": _format_amount(body.amount),
         "purpose": body.purpose,
-        "expires_at": (now + timedelta(hours=1)).isoformat(),
+        "expires_at": expires_at.isoformat(),
         "status": "pending",
     }
 
 
-@router.post("/reserve/{reservation_id}/commit")
+@router.post("/reserve/{reservation_id}/commit", status_code=status.HTTP_204_NO_CONTENT)
 async def commit_reservation(
     reservation_id: str,
     _request: Request,
+    body: CommitReservationRequest | None = None,
+    context: Any = Depends(_get_pay_context),
     record_store: Any = Depends(_get_record_store),
-) -> dict[str, Any]:
+    credits: Any = Depends(_get_credits_service),
+) -> None:
     _ensure_tables(record_store)
+    agent_id = _context_agent_id(context)
+    zone_id = _context_zone_id(context)
     try:
         from sqlalchemy import select
 
@@ -530,28 +778,38 @@ async def commit_reservation(
             )
             if not res:
                 raise HTTPException(status_code=404, detail="Reservation not found")
+            if res.agent_id != agent_id or res.zone_id != zone_id:
+                raise HTTPException(status_code=403, detail="Reservation owner mismatch")
+            if res.status != "pending":
+                raise HTTPException(status_code=409, detail=f"Reservation already {res.status}")
+            actual_amount = body.actual_amount if body else None
+            if actual_amount is not None and _amount_to_micro(actual_amount) > res.amount:
+                raise HTTPException(
+                    status_code=400, detail="actual_amount cannot exceed reserved amount"
+                )
+            await credits.commit_reservation(reservation_id, actual_amount=actual_amount)
+            if actual_amount is not None:
+                res.amount = _amount_to_micro(actual_amount)
             res.status = "committed"
             session.commit()
-            return {
-                "id": res.id,
-                "amount": f"{res.amount / 100:.2f}",
-                "purpose": res.purpose,
-                "status": "committed",
-                "expires_at": None,
-            }
+            return None
     except HTTPException:
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
-@router.post("/reserve/{reservation_id}/release")
+@router.post("/reserve/{reservation_id}/release", status_code=status.HTTP_204_NO_CONTENT)
 async def release_reservation(
     reservation_id: str,
     _request: Request,
+    context: Any = Depends(_get_pay_context),
     record_store: Any = Depends(_get_record_store),
-) -> dict[str, Any]:
+    credits: Any = Depends(_get_credits_service),
+) -> None:
     _ensure_tables(record_store)
+    agent_id = _context_agent_id(context)
+    zone_id = _context_zone_id(context)
     try:
         from sqlalchemy import select
 
@@ -563,19 +821,53 @@ async def release_reservation(
             )
             if not res:
                 raise HTTPException(status_code=404, detail="Reservation not found")
+            if res.agent_id != agent_id or res.zone_id != zone_id:
+                raise HTTPException(status_code=403, detail="Reservation owner mismatch")
+            if res.status != "pending":
+                raise HTTPException(status_code=409, detail=f"Reservation already {res.status}")
+            await credits.release_reservation(reservation_id)
             res.status = "released"
             session.commit()
-            return {
-                "id": res.id,
-                "amount": f"{res.amount / 100:.2f}",
-                "purpose": res.purpose,
-                "status": "released",
-                "expires_at": None,
-            }
+            return None
     except HTTPException:
         raise
     except Exception as e:
         raise HTTPException(status_code=500, detail=str(e)) from e
+
+
+# =============================================================================
+# Usage Metering
+# =============================================================================
+
+
+@router.post("/meter")
+async def meter(
+    body: MeterRequest,
+    _request: Request,
+    context: Any = Depends(_get_pay_context),
+    record_store: Any = Depends(_get_record_store),
+    credits: Any = Depends(_get_credits_service),
+) -> dict[str, bool]:
+    _ensure_tables(record_store)
+    agent_id = _context_agent_id(context)
+    zone_id = _context_zone_id(context)
+    success = await credits.deduct_fast(agent_id, body.amount, zone_id=zone_id)
+    if success:
+        try:
+            from nexus.storage.models.payments import UsageEvent
+
+            with record_store.session_factory() as session:
+                event = UsageEvent(
+                    zone_id=zone_id,
+                    agent_id=agent_id,
+                    event_type=body.event_type,
+                    amount=_amount_to_micro(body.amount),
+                )
+                session.add(event)
+                session.commit()
+        except Exception as e:
+            logger.warning("Failed to record usage event in SQL: %s", e)
+    return {"success": bool(success)}
 
 
 # =============================================================================

--- a/src/nexus/server/api/v2/routers/pay.py
+++ b/src/nexus/server/api/v2/routers/pay.py
@@ -18,6 +18,7 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Query, Request, s
 from pydantic import BaseModel, ConfigDict, Field, field_validator
 
 from nexus.bricks.pay.constants import credits_to_micro, micro_to_credits
+from nexus.bricks.pay.credits import CreditsError, InsufficientCreditsError, ReservationError
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.server.dependencies import get_operation_context, require_auth
 
@@ -121,7 +122,13 @@ def _get_pay_context(auth_result: dict[str, Any] = Depends(require_auth)) -> Any
 
 def _context_agent_id(context: Any) -> str:
     """Resolve the wallet actor from an operation context."""
-    agent_id = getattr(context, "agent_id", None) or getattr(context, "subject_id", None)
+    agent_id = getattr(context, "agent_id", None)
+    subject_id = getattr(context, "subject_id", None)
+    subject_type = getattr(context, "subject_type", None)
+    is_admin = bool(getattr(context, "is_admin", False))
+    if agent_id and (subject_type == "agent" or is_admin):
+        return str(agent_id)
+    agent_id = subject_id
     if not agent_id:
         raise HTTPException(status_code=403, detail="Agent identity required")
     return str(agent_id)
@@ -174,6 +181,14 @@ def _transfer_id_to_int(transfer_id: str | None = None) -> int:
     return uuid.uuid4().int % (2**63)
 
 
+def _credits_http_exception(exc: CreditsError) -> HTTPException:
+    if isinstance(exc, InsufficientCreditsError):
+        return HTTPException(status_code=402, detail=str(exc))
+    if isinstance(exc, ReservationError):
+        return HTTPException(status_code=409, detail=str(exc))
+    return HTTPException(status_code=502, detail=str(exc))
+
+
 # =============================================================================
 # Request models
 # =============================================================================
@@ -205,7 +220,7 @@ class BatchTransferItem(_AmountModel):
 
 
 class BatchTransferRequest(_StrictModel):
-    transfers: list[BatchTransferItem] = Field(..., min_length=1, max_length=1000)
+    transfers: list[BatchTransferItem] = Field(..., max_length=1000)
 
 
 class ReserveRequest(_AmountModel):
@@ -439,8 +454,8 @@ async def transfer(
             idempotency_key=idempotency_key,
             zone_id=zone_id,
         )
-    except Exception as e:
-        logger.debug("Credits transfer skipped (disabled mode): %s", e)
+    except CreditsError as exc:
+        raise _credits_http_exception(exc) from exc
 
     # Record in SQL
     try:
@@ -513,8 +528,8 @@ async def transfer_batch(
                     memo=item.memo,
                     zone_id=zone_id,
                 )
-    except Exception as e:
-        logger.debug("Credits batch transfer skipped (disabled mode): %s", e)
+    except CreditsError as exc:
+        raise _credits_http_exception(exc) from exc
 
     receipts: list[dict[str, Any]] = []
     try:
@@ -723,9 +738,8 @@ async def reserve(
             timeout_seconds=body.timeout,
             zone_id=zone_id,
         )
-    except Exception as e:
-        logger.debug("Credits reservation skipped (disabled mode): %s", e)
-        res_id = str(uuid.uuid4())
+    except CreditsError as exc:
+        raise _credits_http_exception(exc) from exc
     try:
         from nexus.storage.models.payments import CreditReservationMeta
 
@@ -787,7 +801,10 @@ async def commit_reservation(
                 raise HTTPException(
                     status_code=400, detail="actual_amount cannot exceed reserved amount"
                 )
-            await credits.commit_reservation(reservation_id, actual_amount=actual_amount)
+            try:
+                await credits.commit_reservation(reservation_id, actual_amount=actual_amount)
+            except CreditsError as exc:
+                raise _credits_http_exception(exc) from exc
             if actual_amount is not None:
                 res.amount = _amount_to_micro(actual_amount)
             res.status = "committed"
@@ -825,7 +842,10 @@ async def release_reservation(
                 raise HTTPException(status_code=403, detail="Reservation owner mismatch")
             if res.status != "pending":
                 raise HTTPException(status_code=409, detail=f"Reservation already {res.status}")
-            await credits.release_reservation(reservation_id)
+            try:
+                await credits.release_reservation(reservation_id)
+            except CreditsError as exc:
+                raise _credits_http_exception(exc) from exc
             res.status = "released"
             session.commit()
             return None
@@ -851,7 +871,10 @@ async def meter(
     _ensure_tables(record_store)
     agent_id = _context_agent_id(context)
     zone_id = _context_zone_id(context)
-    success = await credits.deduct_fast(agent_id, body.amount, zone_id=zone_id)
+    try:
+        success = await credits.deduct_fast(agent_id, body.amount, zone_id=zone_id)
+    except CreditsError as exc:
+        raise _credits_http_exception(exc) from exc
     if success:
         try:
             from nexus.storage.models.payments import UsageEvent

--- a/src/nexus/server/api/v2/routers/pay.py
+++ b/src/nexus/server/api/v2/routers/pay.py
@@ -189,6 +189,15 @@ def _credits_http_exception(exc: CreditsError) -> HTTPException:
     return HTTPException(status_code=502, detail=str(exc))
 
 
+def _resolve_transfer_method(method: str) -> str:
+    if method == "x402":
+        raise HTTPException(
+            status_code=400,
+            detail="x402 transfers are not supported by /api/v2/pay/transfer",
+        )
+    return "credits"
+
+
 # =============================================================================
 # Request models
 # =============================================================================
@@ -442,6 +451,7 @@ async def transfer(
     from_agent = _context_agent_id(context)
     zone_id = _context_zone_id(context)
     idempotency_key = body.idempotency_key or idempotency_key_header
+    method = _resolve_transfer_method(body.method)
     transfer_id: str | None = None
 
     # Attempt real transfer via CreditsService
@@ -469,7 +479,7 @@ async def transfer(
                 to_agent_id=body.to,
                 amount=_amount_to_micro(body.amount),
                 currency="credits",
-                method=body.method,
+                method=method,
                 memo=body.memo,
                 tigerbeetle_transfer_id=_transfer_id_to_int(transfer_id),
                 status="completed",
@@ -481,7 +491,7 @@ async def transfer(
 
     return {
         "id": tx_id,
-        "method": body.method,
+        "method": method,
         "amount": _format_amount(body.amount),
         "from_agent": from_agent,
         "to_agent": body.to,
@@ -759,6 +769,14 @@ async def reserve(
             session.commit()
     except Exception as e:
         logger.warning("Failed to create reservation: %s", e)
+        try:
+            await credits.release_reservation(res_id)
+        except Exception as release_error:
+            logger.warning(
+                "Failed to release reservation after SQL persistence failure: %s",
+                release_error,
+            )
+        raise HTTPException(status_code=503, detail="Failed to persist reservation") from e
 
     return {
         "id": res_id,

--- a/tests/migrations/test_pay_amount_units.py
+++ b/tests/migrations/test_pay_amount_units.py
@@ -1,0 +1,37 @@
+"""Regression coverage for Nexus Pay amount-unit migration."""
+
+import importlib.util
+from pathlib import Path
+
+from sqlalchemy import create_engine, text
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+MIGRATION_PATH = PROJECT_ROOT / "alembic" / "versions" / "pay_amounts_micro_units.py"
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("pay_amounts_micro_units", MIGRATION_PATH)
+    assert spec is not None
+    module = importlib.util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+def test_pay_amount_migration_converts_legacy_cent_amounts_to_micro(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'pay.db'}")
+    with engine.begin() as conn:
+        conn.execute(text("CREATE TABLE payment_transaction_meta (amount BIGINT NOT NULL)"))
+        conn.execute(text("CREATE TABLE credit_reservation_meta (amount BIGINT NOT NULL)"))
+        conn.execute(text("INSERT INTO payment_transaction_meta (amount) VALUES (255)"))
+        conn.execute(text("INSERT INTO credit_reservation_meta (amount) VALUES (550)"))
+
+        _load_migration().upgrade_pay_amounts(conn)
+
+        tx_amount = conn.execute(text("SELECT amount FROM payment_transaction_meta")).scalar_one()
+        reservation_amount = conn.execute(
+            text("SELECT amount FROM credit_reservation_meta")
+        ).scalar_one()
+
+    assert tx_amount == 2_550_000
+    assert reservation_amount == 5_500_000

--- a/tests/unit/core/test_import_boundaries.py
+++ b/tests/unit/core/test_import_boundaries.py
@@ -12,12 +12,14 @@ Tier hierarchy (Liedtke minimality):
 """
 
 import ast
+import tomllib
 from pathlib import Path
 
 import pytest
 
 # Project root for src/nexus/
 NEXUS_ROOT = Path(__file__).resolve().parents[3] / "src" / "nexus"
+PROJECT_ROOT = NEXUS_ROOT.parents[1]
 
 
 def _collect_imports(module_path: Path) -> list[tuple[str, int, str]]:
@@ -149,6 +151,43 @@ class TestServicesDoNotImportServer:
         assert violations == [], "Services→Server top-level import violations:\n" + "\n".join(
             f"  - {v}" for v in violations
         )
+
+
+class TestImportLinterPackageCoverage:
+    """Verify import-linter models top-level package boundaries, not just tier names."""
+
+    def test_top_level_server_forbidden_contract_covers_non_server_packages(self):
+        pyproject = tomllib.loads((PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+        contracts = pyproject["tool"]["importlinter"]["contracts"]
+        contract = next(
+            (c for c in contracts if c.get("id") == "top-level-packages-must-not-import-server"),
+            None,
+        )
+        assert contract is not None
+        assert contract["type"] == "forbidden"
+        assert "nexus.server" in contract["forbidden_modules"]
+
+        covered = set(contract["source_modules"])
+        expected = {
+            "nexus.backends",
+            "nexus.contracts",
+            "nexus.core",
+            "nexus.factory",
+            "nexus.fs",
+            "nexus.lib",
+            "nexus.remote",
+            "nexus.security",
+            "nexus.services",
+            "nexus.storage",
+        }
+        assert expected <= covered
+
+
+class TestTypingPackageMarker:
+    """Packaging metadata must match PEP 561 typed-package marker requirements."""
+
+    def test_nexus_namespace_has_py_typed_marker(self):
+        assert (NEXUS_ROOT / "py.typed").is_file()
 
 
 class TestRPCTypesInCore:

--- a/tests/unit/server/routers/test_pay_router.py
+++ b/tests/unit/server/routers/test_pay_router.py
@@ -152,6 +152,7 @@ def test_transfer_requires_auth_and_uses_authenticated_actor_with_decimal_micro_
     body = response.json()
     assert body["from_agent"] == "agent-alice"
     assert body["amount"] == "2.55"
+    assert body["method"] == "credits"
     assert credits.transfer_calls == [
         ("agent-alice", "agent-bob", Decimal("2.55"), "idem-1", "zone-a")
     ]
@@ -162,6 +163,23 @@ def test_transfer_requires_auth_and_uses_authenticated_actor_with_decimal_micro_
         assert txn.from_agent_id == "agent-alice"
         assert txn.zone_id == "zone-a"
         assert txn.amount == 2_550_000
+        assert txn.method == "credits"
+
+
+def test_transfer_rejects_x402_method_without_debiting_credits(tmp_path):
+    client, credits, record_store = _build_client(tmp_path)
+
+    response = client.post(
+        "/api/v2/pay/transfer",
+        json={"to": "agent-bob", "amount": "2.55", "method": "x402"},
+        headers=_headers(),
+    )
+
+    assert response.status_code == 400
+    assert "x402" in response.json()["detail"]
+    assert credits.transfer_calls == []
+    with record_store.session_factory() as session:
+        assert session.scalar(select(func.count(PaymentTransactionMeta.id))) == 0
 
 
 def test_non_admin_user_cannot_debit_x_agent_id_wallet(tmp_path):
@@ -316,3 +334,33 @@ def test_reservation_ledger_failure_returns_error_without_sql_reservation(tmp_pa
     assert "Insufficient balance" in response.json()["detail"]
     with record_store.session_factory() as session:
         assert session.scalar(select(func.count(CreditReservationMeta.id))) == 0
+
+
+def test_reservation_sql_failure_returns_error_and_releases_ledger_reservation(tmp_path):
+    client, credits, record_store = _build_client(tmp_path)
+
+    class FailingSession:
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def add(self, _record):
+            return None
+
+        def commit(self):
+            raise RuntimeError("sql write failed")
+
+    record_store._session_factory = lambda: FailingSession()
+
+    response = client.post(
+        "/api/v2/pay/reserve",
+        json={"amount": "5.50", "timeout": 600, "purpose": "gpu"},
+        headers=_headers(),
+    )
+
+    assert response.status_code == 503
+    assert "Failed to persist reservation" in response.json()["detail"]
+    assert credits.reserve_calls == [("agent-alice", Decimal("5.50"), 600, "zone-a")]
+    assert credits.release_calls == ["123456789"]

--- a/tests/unit/server/routers/test_pay_router.py
+++ b/tests/unit/server/routers/test_pay_router.py
@@ -1,0 +1,211 @@
+from decimal import Decimal
+from typing import Any
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+from sqlalchemy import select
+
+from nexus.server.api.v2.routers import pay as pay_router_module
+from nexus.server.api.v2.routers.pay import router as pay_router
+from nexus.storage.models.payments import CreditReservationMeta, PaymentTransactionMeta, UsageEvent
+from nexus.storage.record_store import SQLAlchemyRecordStore
+
+
+class DummyCredits:
+    DISABLED_UNLIMITED_BALANCE = Decimal("999999999")
+
+    def __init__(self) -> None:
+        self.balance_calls: list[tuple[str, str]] = []
+        self.transfer_calls: list[tuple[str, str, Decimal, str | None, str]] = []
+        self.reserve_calls: list[tuple[str, Decimal, int, str]] = []
+        self.commit_calls: list[tuple[str, Decimal | None]] = []
+        self.release_calls: list[str] = []
+        self.deduct_calls: list[tuple[str, Decimal, str]] = []
+
+    async def get_balance(self, agent_id: str, zone_id: str = "root") -> Decimal:
+        self.balance_calls.append((agent_id, zone_id))
+        return Decimal("100.00")
+
+    async def get_balance_with_reserved(
+        self, agent_id: str, zone_id: str = "root"
+    ) -> tuple[Decimal, Decimal]:
+        self.balance_calls.append((agent_id, zone_id))
+        return Decimal("98.75"), Decimal("1.25")
+
+    async def transfer(
+        self,
+        from_id: str,
+        to_id: str,
+        amount: Decimal,
+        *,
+        memo: str = "",
+        idempotency_key: str | None = None,
+        zone_id: str = "root",
+    ) -> str:
+        self.transfer_calls.append((from_id, to_id, amount, idempotency_key, zone_id))
+        return "tb-transfer-id"
+
+    async def reserve(
+        self,
+        agent_id: str,
+        amount: Decimal,
+        timeout_seconds: int = 300,
+        *,
+        zone_id: str = "root",
+    ) -> str:
+        self.reserve_calls.append((agent_id, amount, timeout_seconds, zone_id))
+        return "123456789"
+
+    async def commit_reservation(
+        self, reservation_id: str, actual_amount: Decimal | None = None
+    ) -> None:
+        self.commit_calls.append((reservation_id, actual_amount))
+
+    async def release_reservation(self, reservation_id: str) -> None:
+        self.release_calls.append(reservation_id)
+
+    async def deduct_fast(
+        self, agent_id: str, amount: Decimal, *, zone_id: str = "root", **_: Any
+    ) -> bool:
+        self.deduct_calls.append((agent_id, amount, zone_id))
+        return True
+
+
+def _build_client(tmp_path) -> tuple[TestClient, DummyCredits, SQLAlchemyRecordStore]:
+    app = FastAPI()
+    app.state.api_key = "secret"
+    app.state.auth_provider = None
+    record_store = SQLAlchemyRecordStore(db_path=tmp_path / "pay.db", create_tables=True)
+    app.state.record_store = record_store
+    credits = DummyCredits()
+    app.dependency_overrides[pay_router_module._get_credits_service] = lambda: credits
+    app.include_router(pay_router)
+    return TestClient(app), credits, record_store
+
+
+def _headers(agent_id: str = "agent-alice", zone_id: str = "zone-a") -> dict[str, str]:
+    return {
+        "Authorization": "Bearer secret",
+        "X-Agent-ID": agent_id,
+        "X-Nexus-Zone-ID": zone_id,
+    }
+
+
+def test_transfer_requires_auth_and_uses_authenticated_actor_with_decimal_micro_units(tmp_path):
+    client, credits, record_store = _build_client(tmp_path)
+
+    unauth = client.post("/api/v2/pay/transfer", json={"to": "agent-bob", "amount": "2.55"})
+    assert unauth.status_code == 401
+
+    response = client.post(
+        "/api/v2/pay/transfer",
+        json={
+            "to": "agent-bob",
+            "amount": "2.55",
+            "memo": "work",
+            "idempotency_key": "idem-1",
+        },
+        headers=_headers(),
+    )
+
+    assert response.status_code == 201
+    body = response.json()
+    assert body["from_agent"] == "agent-alice"
+    assert body["amount"] == "2.55"
+    assert credits.transfer_calls == [
+        ("agent-alice", "agent-bob", Decimal("2.55"), "idem-1", "zone-a")
+    ]
+
+    with record_store.session_factory() as session:
+        txn = session.scalar(select(PaymentTransactionMeta))
+        assert txn is not None
+        assert txn.from_agent_id == "agent-alice"
+        assert txn.zone_id == "zone-a"
+        assert txn.amount == 2_550_000
+
+
+def test_can_afford_returns_contract_amount_for_authenticated_actor(tmp_path):
+    client, credits, _record_store = _build_client(tmp_path)
+
+    response = client.get(
+        "/api/v2/pay/can-afford?amount=4.25",
+        headers=_headers(agent_id="agent-pay"),
+    )
+
+    assert response.status_code == 200
+    assert response.json() == {"can_afford": True, "amount": "4.25"}
+    assert credits.balance_calls == [("agent-pay", "zone-a")]
+
+
+def test_batch_transfer_and_meter_routes_match_exchange_contract(tmp_path):
+    client, credits, record_store = _build_client(tmp_path)
+
+    batch = client.post(
+        "/api/v2/pay/transfer/batch",
+        json={
+            "transfers": [
+                {"to": "agent-bob", "amount": "1.25", "memo": "a"},
+                {"to": "agent-carol", "amount": "0.001", "memo": "b"},
+            ]
+        },
+        headers=_headers(),
+    )
+
+    assert batch.status_code == 201
+    receipts = batch.json()
+    assert [r["from_agent"] for r in receipts] == ["agent-alice", "agent-alice"]
+    assert [r["amount"] for r in receipts] == ["1.25", "0.001"]
+
+    meter = client.post(
+        "/api/v2/pay/meter",
+        json={"amount": "0.001", "event_type": "api_call"},
+        headers=_headers(),
+    )
+
+    assert meter.status_code == 200
+    assert meter.json() == {"success": True}
+    assert credits.deduct_calls == [("agent-alice", Decimal("0.001"), "zone-a")]
+
+    with record_store.session_factory() as session:
+        usages = session.scalars(select(UsageEvent)).all()
+        assert len(usages) == 1
+        assert usages[0].agent_id == "agent-alice"
+        assert usages[0].amount == 1_000
+
+
+def test_reservation_uses_owner_timeout_task_and_enforces_owner_on_commit(tmp_path):
+    client, credits, record_store = _build_client(tmp_path)
+
+    created = client.post(
+        "/api/v2/pay/reserve",
+        json={"amount": "5.50", "timeout": 600, "purpose": "gpu", "task_id": "task-1"},
+        headers=_headers(agent_id="agent-alice"),
+    )
+
+    assert created.status_code == 201
+    reservation_id = created.json()["id"]
+    assert credits.reserve_calls == [("agent-alice", Decimal("5.50"), 600, "zone-a")]
+
+    forbidden = client.post(
+        f"/api/v2/pay/reserve/{reservation_id}/commit",
+        json={"actual_amount": "4.25"},
+        headers=_headers(agent_id="agent-bob"),
+    )
+    assert forbidden.status_code == 403
+
+    committed = client.post(
+        f"/api/v2/pay/reserve/{reservation_id}/commit",
+        json={"actual_amount": "4.25"},
+        headers=_headers(agent_id="agent-alice"),
+    )
+    assert committed.status_code == 204
+    assert credits.commit_calls == [(reservation_id, Decimal("4.25"))]
+
+    with record_store.session_factory() as session:
+        reservation = session.scalar(select(CreditReservationMeta))
+        assert reservation is not None
+        assert reservation.agent_id == "agent-alice"
+        assert reservation.zone_id == "zone-a"
+        assert reservation.amount == 4_250_000
+        assert reservation.task_id == "task-1"
+        assert reservation.status == "committed"

--- a/tests/unit/server/routers/test_pay_router.py
+++ b/tests/unit/server/routers/test_pay_router.py
@@ -1,10 +1,12 @@
 from decimal import Decimal
+from types import SimpleNamespace
 from typing import Any
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
-from sqlalchemy import select
+from sqlalchemy import func, select
 
+from nexus.bricks.pay.credits import CreditsError, InsufficientCreditsError
 from nexus.server.api.v2.routers import pay as pay_router_module
 from nexus.server.api.v2.routers.pay import router as pay_router
 from nexus.storage.models.payments import CreditReservationMeta, PaymentTransactionMeta, UsageEvent
@@ -17,10 +19,14 @@ class DummyCredits:
     def __init__(self) -> None:
         self.balance_calls: list[tuple[str, str]] = []
         self.transfer_calls: list[tuple[str, str, Decimal, str | None, str]] = []
+        self.batch_transfer_calls: list[tuple[int, str]] = []
         self.reserve_calls: list[tuple[str, Decimal, int, str]] = []
         self.commit_calls: list[tuple[str, Decimal | None]] = []
         self.release_calls: list[str] = []
         self.deduct_calls: list[tuple[str, Decimal, str]] = []
+        self.transfer_error: Exception | None = None
+        self.batch_error: Exception | None = None
+        self.reserve_error: Exception | None = None
 
     async def get_balance(self, agent_id: str, zone_id: str = "root") -> Decimal:
         self.balance_calls.append((agent_id, zone_id))
@@ -42,8 +48,16 @@ class DummyCredits:
         idempotency_key: str | None = None,
         zone_id: str = "root",
     ) -> str:
+        if self.transfer_error is not None:
+            raise self.transfer_error
         self.transfer_calls.append((from_id, to_id, amount, idempotency_key, zone_id))
         return "tb-transfer-id"
+
+    async def transfer_batch(self, transfers: list[Any], *, zone_id: str = "root") -> list[str]:
+        if self.batch_error is not None:
+            raise self.batch_error
+        self.batch_transfer_calls.append((len(transfers), zone_id))
+        return [str(1000 + i) for i, _transfer in enumerate(transfers)]
 
     async def reserve(
         self,
@@ -53,6 +67,8 @@ class DummyCredits:
         *,
         zone_id: str = "root",
     ) -> str:
+        if self.reserve_error is not None:
+            raise self.reserve_error
         self.reserve_calls.append((agent_id, amount, timeout_seconds, zone_id))
         return "123456789"
 
@@ -76,6 +92,30 @@ def _build_client(tmp_path) -> tuple[TestClient, DummyCredits, SQLAlchemyRecordS
     app.state.api_key = "secret"
     app.state.auth_provider = None
     record_store = SQLAlchemyRecordStore(db_path=tmp_path / "pay.db", create_tables=True)
+    app.state.record_store = record_store
+    credits = DummyCredits()
+    app.dependency_overrides[pay_router_module._get_credits_service] = lambda: credits
+    app.include_router(pay_router)
+    return TestClient(app), credits, record_store
+
+
+def _build_provider_client(tmp_path) -> tuple[TestClient, DummyCredits, SQLAlchemyRecordStore]:
+    class UserAuthProvider:
+        async def authenticate(self, _token: str) -> SimpleNamespace:
+            return SimpleNamespace(
+                authenticated=True,
+                is_admin=False,
+                subject_type="user",
+                subject_id="user-alice",
+                zone_id="zone-a",
+                inherit_permissions=True,
+                metadata={},
+            )
+
+    app = FastAPI()
+    app.state.api_key = None
+    app.state.auth_provider = UserAuthProvider()
+    record_store = SQLAlchemyRecordStore(db_path=tmp_path / "pay-provider.db", create_tables=True)
     app.state.record_store = record_store
     credits = DummyCredits()
     app.dependency_overrides[pay_router_module._get_credits_service] = lambda: credits
@@ -124,6 +164,24 @@ def test_transfer_requires_auth_and_uses_authenticated_actor_with_decimal_micro_
         assert txn.amount == 2_550_000
 
 
+def test_non_admin_user_cannot_debit_x_agent_id_wallet(tmp_path):
+    client, credits, _record_store = _build_provider_client(tmp_path)
+
+    response = client.post(
+        "/api/v2/pay/transfer",
+        json={"to": "agent-bob", "amount": "2.55"},
+        headers={
+            "Authorization": "Bearer provider-token",
+            "X-Agent-ID": "agent-victim",
+            "X-Nexus-Zone-ID": "zone-a",
+        },
+    )
+
+    assert response.status_code == 201
+    assert response.json()["from_agent"] == "user-alice"
+    assert credits.transfer_calls == [("user-alice", "agent-bob", Decimal("2.55"), None, "zone-a")]
+
+
 def test_can_afford_returns_contract_amount_for_authenticated_actor(tmp_path):
     client, credits, _record_store = _build_client(tmp_path)
 
@@ -155,6 +213,7 @@ def test_batch_transfer_and_meter_routes_match_exchange_contract(tmp_path):
     receipts = batch.json()
     assert [r["from_agent"] for r in receipts] == ["agent-alice", "agent-alice"]
     assert [r["amount"] for r in receipts] == ["1.25", "0.001"]
+    assert credits.batch_transfer_calls == [(2, "zone-a")]
 
     meter = client.post(
         "/api/v2/pay/meter",
@@ -171,6 +230,38 @@ def test_batch_transfer_and_meter_routes_match_exchange_contract(tmp_path):
         assert len(usages) == 1
         assert usages[0].agent_id == "agent-alice"
         assert usages[0].amount == 1_000
+
+
+def test_empty_batch_transfer_matches_sdk_noop_contract(tmp_path):
+    client, credits, record_store = _build_client(tmp_path)
+
+    response = client.post(
+        "/api/v2/pay/transfer/batch",
+        json={"transfers": []},
+        headers=_headers(),
+    )
+
+    assert response.status_code == 201
+    assert response.json() == []
+    assert credits.batch_transfer_calls == [(0, "zone-a")]
+    with record_store.session_factory() as session:
+        assert session.scalar(select(func.count(PaymentTransactionMeta.id))) == 0
+
+
+def test_batch_transfer_ledger_failure_returns_error_without_sql_receipts(tmp_path):
+    client, credits, record_store = _build_client(tmp_path)
+    credits.batch_error = CreditsError("Batch transfer failed")
+
+    response = client.post(
+        "/api/v2/pay/transfer/batch",
+        json={"transfers": [{"to": "agent-bob", "amount": "1.25"}]},
+        headers=_headers(),
+    )
+
+    assert response.status_code == 502
+    assert "Batch transfer failed" in response.json()["detail"]
+    with record_store.session_factory() as session:
+        assert session.scalar(select(func.count(PaymentTransactionMeta.id))) == 0
 
 
 def test_reservation_uses_owner_timeout_task_and_enforces_owner_on_commit(tmp_path):
@@ -209,3 +300,19 @@ def test_reservation_uses_owner_timeout_task_and_enforces_owner_on_commit(tmp_pa
         assert reservation.amount == 4_250_000
         assert reservation.task_id == "task-1"
         assert reservation.status == "committed"
+
+
+def test_reservation_ledger_failure_returns_error_without_sql_reservation(tmp_path):
+    client, credits, record_store = _build_client(tmp_path)
+    credits.reserve_error = InsufficientCreditsError("Insufficient balance to reserve")
+
+    response = client.post(
+        "/api/v2/pay/reserve",
+        json={"amount": "5.50", "timeout": 600, "purpose": "gpu"},
+        headers=_headers(),
+    )
+
+    assert response.status_code == 402
+    assert "Insufficient balance" in response.json()["detail"]
+    with record_store.session_factory() as session:
+        assert session.scalar(select(func.count(CreditReservationMeta.id))) == 0


### PR DESCRIPTION
## Summary

Addresses the review findings around Nexus Pay and related package contracts:

- Require auth for pay/audit routers and derive payment actor/zone from `OperationContext` instead of hard-coded `admin`.
- Align pay server routes with the exchange/SDK contract by adding batch transfer and metering, strict request models, idempotency/timeout/task/actual amount support, and reservation owner checks.
- Use `Decimal` plus micro-credit storage conversion for payment amounts.
- Forward Pay SDK identity headers through the shared API client.
- Preserve significant whitespace in SSE field parsing.
- Add `nexus/py.typed` and a top-level import-linter guard for non-server packages.

## Validation

- `git diff --staged --check`
- `uv run pytest tests/unit/server/routers/test_pay_router.py tests/unit/core/test_import_boundaries.py::TestImportLinterPackageCoverage tests/unit/core/test_import_boundaries.py::TestTypingPackageMarker -q -n 0`
- `npm run lint` in `packages/nexus-api-client`
- `npm test` in `packages/nexus-api-client`
- `npm run lint` in `packages/nexus-pay-ts`
- `npm test` in `packages/nexus-pay-ts`
- pre-commit hooks during commit: EOF, TOML, debug statements, ruff, ruff format, mypy, file size, type-ignore blocker, brick zero-core-imports, and Rust/codegen no-op checks

## Notes

The broader architecture test suite still depends on `nexus_runtime` being available locally; this PR adds focused guard coverage that does not require the Rust runtime wheel.
