### PR TITLE
feat(cdylib): upgrade spawn_task to v2 ConversationRuntime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "api"
+version = "0.1.4"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=49c7615#49c76156f2e257bd950fc17a28fd526d5f0df42b"
+dependencies = [
+ "base64",
+ "reqwest",
+ "runtime",
+ "serde",
+ "serde_json",
+ "telemetry",
+ "tokio",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -639,6 +653,16 @@ name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
+
+[[package]]
+name = "commands"
+version = "0.1.4"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=49c7615#49c76156f2e257bd950fc17a28fd526d5f0df42b"
+dependencies = [
+ "plugins",
+ "runtime",
+ "serde_json",
+]
 
 [[package]]
 name = "compare"
@@ -2089,6 +2113,7 @@ dependencies = [
  "raft 0.1.0",
  "runtime",
  "services",
+ "tools",
  "transport",
 ]
 
@@ -2111,7 +2136,7 @@ dependencies = [
 [[package]]
 name = "nexus-vfs-client"
 version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=7c24866#7c24866557c1c1078a899c9dbc4534f65a2e2755"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=49c7615#49c76156f2e257bd950fc17a28fd526d5f0df42b"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -2319,7 +2344,7 @@ dependencies = [
 [[package]]
 name = "plugins"
 version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=7c24866#7c24866557c1c1078a899c9dbc4534f65a2e2755"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=49c7615#49c76156f2e257bd950fc17a28fd526d5f0df42b"
 dependencies = [
  "serde",
  "serde_json",
@@ -2976,6 +3001,7 @@ checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
 dependencies = [
  "base64",
  "bytes",
+ "futures-channel",
  "futures-core",
  "futures-util",
  "http",
@@ -3071,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "runtime"
 version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=7c24866#7c24866557c1c1078a899c9dbc4534f65a2e2755"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=49c7615#49c76156f2e257bd950fc17a28fd526d5f0df42b"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -3641,7 +3667,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 [[package]]
 name = "telemetry"
 version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=7c24866#7c24866557c1c1078a899c9dbc4534f65a2e2755"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=49c7615#49c76156f2e257bd950fc17a28fd526d5f0df42b"
 dependencies = [
  "serde",
  "serde_json",
@@ -3903,6 +3929,24 @@ dependencies = [
  "prost-types",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "tools"
+version = "0.1.4"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=49c7615#49c76156f2e257bd950fc17a28fd526d5f0df42b"
+dependencies = [
+ "api",
+ "async-trait",
+ "commands",
+ "flate2",
+ "futures",
+ "plugins",
+ "reqwest",
+ "runtime",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -176,7 +176,7 @@ checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 [[package]]
 name = "api"
 version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=49c7615#49c76156f2e257bd950fc17a28fd526d5f0df42b"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=0686ed9#0686ed9bb1b55674d9b298615e212cecb7e8579a"
 dependencies = [
  "base64",
  "reqwest",
@@ -657,7 +657,7 @@ checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 [[package]]
 name = "commands"
 version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=49c7615#49c76156f2e257bd950fc17a28fd526d5f0df42b"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=0686ed9#0686ed9bb1b55674d9b298615e212cecb7e8579a"
 dependencies = [
  "plugins",
  "runtime",
@@ -2136,7 +2136,7 @@ dependencies = [
 [[package]]
 name = "nexus-vfs-client"
 version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=49c7615#49c76156f2e257bd950fc17a28fd526d5f0df42b"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=0686ed9#0686ed9bb1b55674d9b298615e212cecb7e8579a"
 dependencies = [
  "prost",
  "protoc-bin-vendored",
@@ -2344,7 +2344,7 @@ dependencies = [
 [[package]]
 name = "plugins"
 version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=49c7615#49c76156f2e257bd950fc17a28fd526d5f0df42b"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=0686ed9#0686ed9bb1b55674d9b298615e212cecb7e8579a"
 dependencies = [
  "serde",
  "serde_json",
@@ -3097,7 +3097,7 @@ dependencies = [
 [[package]]
 name = "runtime"
 version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=49c7615#49c76156f2e257bd950fc17a28fd526d5f0df42b"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=0686ed9#0686ed9bb1b55674d9b298615e212cecb7e8579a"
 dependencies = [
  "agent-client-protocol",
  "agent-client-protocol-schema",
@@ -3667,7 +3667,7 @@ checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 [[package]]
 name = "telemetry"
 version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=49c7615#49c76156f2e257bd950fc17a28fd526d5f0df42b"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=0686ed9#0686ed9bb1b55674d9b298615e212cecb7e8579a"
 dependencies = [
  "serde",
  "serde_json",
@@ -3934,7 +3934,7 @@ dependencies = [
 [[package]]
 name = "tools"
 version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=49c7615#49c76156f2e257bd950fc17a28fd526d5f0df42b"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=0686ed9#0686ed9bb1b55674d9b298615e212cecb7e8579a"
 dependencies = [
  "api",
  "async-trait",

--- a/rust/nexus-cdylib/Cargo.toml
+++ b/rust/nexus-cdylib/Cargo.toml
@@ -63,7 +63,8 @@ pyo3 = { version = "0.27.2", features = ["extension-module"] }
 # (sudocode branch HEAD `2b67d5b`) stays reachable in git history
 # even after sudocode merges, so re-pinning is optional for
 # correctness — only matters for reproducibility audit.
-# Pin to sudocode PR#119 merge — spawn_task_echo now uses sys_watch
-# condvar blocking instead of 50ms busy-poll. Near-zero idle CPU,
-# sub-millisecond wake latency on new mailbox data.
-sudocode-runtime = { package = "runtime", git = "https://github.com/sudoprivacy/sudocode", rev = "7c24866" }
+# Pin to sudocode PR#121 — spawn_task v2 factory + FsBackend
+# complete migration. `tools::managed_agent::spawn_managed_agent()`
+# drives the full ConversationRuntime per-pid loop.
+sudocode-runtime = { package = "runtime", git = "https://github.com/sudoprivacy/sudocode", rev = "49c7615" }
+sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "49c7615" }

--- a/rust/nexus-cdylib/Cargo.toml
+++ b/rust/nexus-cdylib/Cargo.toml
@@ -66,5 +66,5 @@ pyo3 = { version = "0.27.2", features = ["extension-module"] }
 # Pin to sudocode PR#121 — spawn_task v2 factory + FsBackend
 # complete migration. `tools::managed_agent::spawn_managed_agent()`
 # drives the full ConversationRuntime per-pid loop.
-sudocode-runtime = { package = "runtime", git = "https://github.com/sudoprivacy/sudocode", rev = "49c7615" }
-sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "49c7615" }
+sudocode-runtime = { package = "runtime", git = "https://github.com/sudoprivacy/sudocode", rev = "0686ed9" }
+sudocode-tools = { package = "tools", git = "https://github.com/sudoprivacy/sudocode", rev = "0686ed9" }

--- a/rust/nexus-cdylib/src/lib.rs
+++ b/rust/nexus-cdylib/src/lib.rs
@@ -36,47 +36,34 @@ use services::managed_agent::{
 // ── Sudo-code adapter ──────────────────────────────────────────────────
 //
 // Concrete `SpawnTask<Kernel>` impl that wraps
-// `sudocode_runtime::spawn_task::spawn_task_echo::<K>(...)`.
+// `sudocode_tools::managed_agent::spawn_managed_agent::<K>(...)`.
 //
 // Lives in the cdylib (not services rlib, not in a dedicated adapter
 // crate) because the binary-edge cdylib is the allowed seam for
 // cross-repo runtime deps — services rlib stays runtime-agnostic so
 // the cluster slim binary can ship without sudocode.
 //
-// ## v1 echo → v2 ConversationRuntime upgrade path
-//
-// sudocode PR#100 introduced `spawn_task` v2 which drives a full
-// `ConversationRuntime` per-pid. The v2 signature requires
-// `ApiClient + ToolExecutor + SystemPrompt + PermissionPolicy +
-// state_callback` — providers that the cdylib adapter must construct.
-// Until those factories land (tracked as `spawn_task v2 full
-// integration`), the adapter calls `spawn_task_echo` which retains
-// the v1 echo round-trip body. The v2 upgrade is:
-//
-//   1. Add `sudocode_runtime::spawn_task::spawn_task` (7-param) call
-//   2. Construct ApiClient from StartSessionRequest.model label
-//   3. Construct ToolExecutor using KernelFsBackend
-//   4. Build SystemPrompt from VFS `/agents/{name}/config/`
-//   5. Wire state_callback → AgentRegistry::update_state
-//
-// Generic-K monomorphisation: `spawn_task_echo` is generic over
-// `K: KernelAbi + Send + Sync + 'static` and `SudoCodeSpawnAdapter`
-// impls `SpawnTask<Kernel>` — the compiler monomorphises against
-// the concrete kernel type (no per-`sys_read` vtable cost).
+// v2 ConversationRuntime integration (sudocode PR#121):
+// The factory in `tools::managed_agent` constructs
+// `ProviderRuntimeClient` (ApiClient), `ManagedToolExecutor`
+// (ToolExecutor), `SystemPrompt`, and `PermissionPolicy` from the
+// `AgentDescriptor` metadata, then calls `spawn_task` v2 to launch
+// the full LLM loop. Generic-K monomorphisation: the factory is
+// generic over `K: KernelAbi` and `SudoCodeSpawnAdapter` impls
+// `SpawnTask<Kernel>` — the compiler monomorphises against the
+// concrete kernel type (no per-`sys_read` vtable cost).
 
 struct SudoCodeSpawnHandle(sudocode_runtime::spawn_task::SpawnHandle);
 
 impl ServiceSpawnHandle for SudoCodeSpawnHandle {
     fn abort(&self) {
-        // Idempotent — `HookAbortSignal::abort` flips an
-        // `AtomicBool::store(true, Ordering::Release)` so concurrent
-        // callers (on_terminate observer + an in-flight
-        // `cancel(Session)`) both succeed.
         self.0.abort_signal.abort();
     }
 }
 
-struct SudoCodeSpawnAdapter;
+struct SudoCodeSpawnAdapter {
+    agent_registry: Arc<kernel::core::agents::registry::AgentRegistry>,
+}
 
 impl SpawnTask<Kernel> for SudoCodeSpawnAdapter {
     fn spawn(
@@ -84,10 +71,22 @@ impl SpawnTask<Kernel> for SudoCodeSpawnAdapter {
         kernel: Arc<Kernel>,
         desc: AgentDescriptor,
     ) -> Box<dyn ServiceSpawnHandle> {
-        // v1 echo body — polls /proc/{pid}/chat-with-me and echoes
-        // inbound prompts back. Swapped for the full ConversationRuntime
-        // body once the ApiClient/ToolExecutor factory wiring lands.
-        let handle = sudocode_runtime::spawn_task::spawn_task_echo::<Kernel>(kernel, desc);
+        let pid = desc.pid.clone();
+        let registry = Arc::clone(&self.agent_registry);
+        let state_callback = move |state: sudocode_runtime::spawn_task::AgentLoopState| {
+            use kernel::core::agents::registry::AgentState;
+            let target = match state {
+                sudocode_runtime::spawn_task::AgentLoopState::WarmingUp => AgentState::WarmingUp,
+                sudocode_runtime::spawn_task::AgentLoopState::Ready => AgentState::Ready,
+                sudocode_runtime::spawn_task::AgentLoopState::Busy => AgentState::Busy,
+            };
+            let _ = registry.update_state(&pid, target);
+        };
+        let handle = sudocode_tools::managed_agent::spawn_managed_agent(
+            kernel,
+            desc,
+            state_callback,
+        );
         Box::new(SudoCodeSpawnHandle(handle))
     }
 }
@@ -106,8 +105,10 @@ impl SpawnTask<Kernel> for SudoCodeSpawnAdapter {
 #[pyfunction]
 #[pyo3(name = "nx_managed_agent_install")]
 fn nx_managed_agent_install(py_kernel: PyRef<'_, PyKernel>) -> PyResult<()> {
-    let provider: Arc<dyn SpawnTask<Kernel>> = Arc::new(SudoCodeSpawnAdapter);
-    install_managed_agent_with_spawn(&py_kernel.kernel_arc(), provider)
+    let kernel_arc = py_kernel.kernel_arc();
+    let agent_registry = Arc::clone(kernel_arc.agent_registry());
+    let provider: Arc<dyn SpawnTask<Kernel>> = Arc::new(SudoCodeSpawnAdapter { agent_registry });
+    install_managed_agent_with_spawn(&kernel_arc, provider)
         .map_err(PyRuntimeError::new_err)
 }
 


### PR DESCRIPTION
## Summary

- Replace `spawn_task_echo` (echo-only stub) with the full `ConversationRuntime` loop via `tools::managed_agent::spawn_managed_agent`
- Add `sudocode-tools` dependency (tools crate from sudocode repo)
- `SudoCodeSpawnAdapter` now holds `agent_registry` Arc and constructs a `state_callback` that forwards `AgentLoopState` → `AgentState` transitions to `AgentRegistry::update_state`
- Bump sudocode rev to PR#121 (spawn_task v2 factory + FsBackend complete migration)

## What this enables

After this PR, `managed_agent.start_session_v1` launches a **real LLM agent loop** per-pid instead of an echo stub:
1. Reads prompts from `/proc/{pid}/chat-with-me` via `sys_watch`
2. Drives each prompt through `ConversationRuntime::run_turn()` (Anthropic/OpenAI API)
3. Executes model-requested tools (bash, read_file, write_file, grep, etc.)
4. Writes structured responses back to `chat-with-me`
5. Reports state transitions (WarmingUp → Ready ↔ Busy) to AgentRegistry

## Dependency

Depends on sudoprivacy/sudocode#121 (pinned at rev `49c7615`). Merge order: sudocode PR first, then bump rev in this PR to the merged commit.

## Test plan

- [x] `cargo check -p nexus-cdylib` — compiles cleanly
- [x] Dependency graph resolves correctly (kernel unified to workspace member)
- [ ] CI (Rust fmt + clippy + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)