### PR TITLE
feat(#4053): replace nexus-fuse SQLite cache with foyer

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -165,3 +165,22 @@ test_*.py
 .ruff_cache/
 .mypy_cache/
 gcs-credentials.json
+# Docker FUSE e2e harness runs from the repo build context.
+!tests/
+tests/*
+!tests/__init__.py
+!tests/e2e/
+tests/e2e/*
+!tests/e2e/__init__.py
+!tests/e2e/self_contained/
+tests/e2e/self_contained/*
+!tests/e2e/self_contained/__init__.py
+!tests/e2e/self_contained/Dockerfile.fuse-test
+!tests/e2e/self_contained/test_fuse_docker_e2e.py
+!tests/helpers/
+tests/helpers/*
+!tests/helpers/__init__.py
+!tests/helpers/dict_metastore.py
+!tests/testkit/
+tests/testkit/*
+!tests/testkit/metadata.py

--- a/docs/superpowers/plans/2026-05-08-issue-4053-foyer-cache.md
+++ b/docs/superpowers/plans/2026-05-08-issue-4053-foyer-cache.md
@@ -1,0 +1,1579 @@
+# Issue #4053 Foyer Cache Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the `nexus-fuse` SQLite file-content cache with a foyer hybrid DRAM+filesystem cache, preserve ETag revalidation, wire it into both direct Rust FUSE and Python-spawned daemon reads, and record benchmark evidence for issue #4053.
+
+**Architecture:** Keep the public `FileCache` boundary synchronous and hide foyer's async build/get path behind an internal Tokio runtime. Store path-keyed binary records in `HybridCache<String, Vec<u8>>`, maintain lightweight metadata for staleness/stats, and extract the current read-through-cache flow into a shared helper used by `fs.rs` and `daemon.rs`. Keep SQLite only as a dev/benchmark baseline, not production cache code.
+
+**Tech Stack:** Rust 2021, `foyer 0.22.3`, `tokio`, `clap`, `serde`, `bincode`, `criterion`, benchmark-only `rusqlite`, existing `nexus-fuse` FUSE/client/daemon modules.
+
+---
+
+## File Structure
+
+| Path | Change | Responsibility |
+| --- | --- | --- |
+| `nexus-fuse/Cargo.toml` | modify | Replace production `rusqlite` with `foyer` and `bincode`; keep `rusqlite` as benchmark-only/dev dependency; add cache benchmark target. |
+| `nexus-fuse/src/cache.rs` | replace internals | Foyer-backed `FileCache`, cache config, path hashing, SQLite migration deletion, record encode/decode, metadata/stats, behavior tests. |
+| `nexus-fuse/src/cached_read.rs` | create | Shared read-through-cache function preserving ETag revalidation and stale fallback. |
+| `nexus-fuse/src/lib.rs` | modify | Export the new `cached_read` module. |
+| `nexus-fuse/src/fs.rs` | modify | Hold `Arc<FileCache>`, use shared cached-read helper, update SQLite log/comment text. |
+| `nexus-fuse/src/daemon.rs` | modify | Hold `Arc<FileCache>`, use shared cached-read helper for `read`, invalidate cache on mutating RPCs. |
+| `nexus-fuse/src/main.rs` | modify | Add cache flags/env parsing, create shared cache for mount and daemon commands, log foyer tier config. |
+| `nexus-fuse/benches/cache_backends.rs` | create | Criterion benchmark comparing foyer cache operations against benchmark-only SQLite baseline. |
+| `nexus-fuse/ARCHITECTURE.md` | modify | Replace SQLite cache wording with foyer hybrid cache wording. |
+| `nexus-fuse/PERFORMANCE_RESULTS.md` | modify | Add migration note, benchmark command, and measured issue #4053 result. |
+
+## External API Notes
+
+Use the current foyer 0.22.3 APIs verified before this plan:
+
+```rust
+use foyer::{
+    BlockEngineConfig, DeviceBuilder, FsDeviceBuilder, HybridCache, HybridCacheBuilder,
+    StorageFilter,
+};
+
+let device = FsDeviceBuilder::new(cache_dir)
+    .with_capacity(disk_bytes)
+    .build()?;
+
+let cache: HybridCache<String, Vec<u8>> = HybridCacheBuilder::new()
+    .with_name("nexus-fuse-file-cache")
+    .memory(memory_bytes)
+    .with_weighter(|_key, value: &Vec<u8>| value.len())
+    .storage()
+    .with_engine_config(
+        BlockEngineConfig::new(device)
+            .with_admission_filter(StorageFilter::new()),
+    )
+    .build()
+    .await?;
+```
+
+`HybridCache::insert` and `HybridCache::remove` are synchronous. `HybridCache::get` is async and must be called through the runtime handle.
+
+### Task 1: Cache Configuration, Dependencies, And Path Migration Tests
+
+**Files:**
+- Modify: `nexus-fuse/Cargo.toml`
+- Modify: `nexus-fuse/src/cache.rs`
+
+- [ ] **Step 1: Write failing config and path tests**
+
+Append these tests inside `#[cfg(test)] mod tests` in `nexus-fuse/src/cache.rs`, replacing SQLite-specific helper usage where necessary:
+
+```rust
+#[test]
+fn test_cache_config_defaults() {
+    let config = CacheConfig::default();
+    assert_eq!(config.memory_bytes, DEFAULT_MEMORY_CACHE_BYTES);
+    assert_eq!(config.disk_bytes, DEFAULT_DISK_CACHE_BYTES);
+    assert_eq!(config.max_file_size, MAX_FILE_SIZE);
+    assert!(config.root_dir.ends_with("nexus-fuse"));
+}
+
+#[test]
+fn test_cache_config_rejects_zero_tiers() {
+    let root = std::env::temp_dir().join("nexus-fuse-config-test");
+    let err = CacheConfig::new(root, 0, DEFAULT_DISK_CACHE_BYTES, MAX_FILE_SIZE)
+        .expect_err("zero memory tier must be rejected");
+    assert!(err.to_string().contains("memory cache size must be greater than zero"));
+
+    let root = std::env::temp_dir().join("nexus-fuse-config-test");
+    let err = CacheConfig::new(root, DEFAULT_MEMORY_CACHE_BYTES, 0, MAX_FILE_SIZE)
+        .expect_err("zero disk tier must be rejected");
+    assert!(err.to_string().contains("disk cache size must be greater than zero"));
+}
+
+#[test]
+fn test_cache_paths_are_stable_and_distinct() {
+    let root = std::env::temp_dir().join("nexus-fuse-path-test");
+    let a = CachePaths::for_server(&root, "http://a:8080");
+    let b = CachePaths::for_server(&root, "http://a/8080");
+
+    assert_ne!(a.foyer_dir, b.foyer_dir);
+    assert_ne!(a.sqlite_file, b.sqlite_file);
+    assert!(a.foyer_dir.file_name().unwrap().to_string_lossy().ends_with(".foyer"));
+    assert!(a.sqlite_file.file_name().unwrap().to_string_lossy().ends_with(".db"));
+}
+```
+
+- [ ] **Step 2: Run tests and verify they fail for missing types**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/bf70/nexus/nexus-fuse
+cargo test cache::tests::test_cache_config_defaults cache::tests::test_cache_config_rejects_zero_tiers cache::tests::test_cache_paths_are_stable_and_distinct --lib
+```
+
+Expected: compile failure naming missing `CacheConfig`, `DEFAULT_MEMORY_CACHE_BYTES`, `DEFAULT_DISK_CACHE_BYTES`, or `CachePaths`.
+
+- [ ] **Step 3: Add test dependency**
+
+Add these under `[dev-dependencies]`:
+
+```toml
+# Temporary directories for cache tests
+tempfile = "3"
+```
+
+- [ ] **Step 4: Add cache config and path helpers**
+
+In `nexus-fuse/src/cache.rs`, keep the existing SQLite imports for now and add `Path` to the `PathBuf` import:
+
+```rust
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+```
+
+Replace the current cache-size constants with:
+
+```rust
+/// Maximum age for cached content before forcing revalidation (1 hour).
+const MAX_CACHE_AGE_SECS: u64 = 3600;
+
+/// Default DRAM cache size in bytes (256 MiB).
+pub const DEFAULT_MEMORY_CACHE_BYTES: usize = 256 * 1024 * 1024;
+
+/// Default filesystem cache size in bytes (10 GiB).
+pub const DEFAULT_DISK_CACHE_BYTES: usize = 10 * 1024 * 1024 * 1024;
+
+/// Maximum cache size in bytes (500 MB). Used only by the legacy SQLite
+/// implementation until Task 2 removes it.
+const MAX_CACHE_SIZE: u64 = 500 * 1024 * 1024;
+
+/// Maximum file size to cache (10 MiB) - larger files bypass cache.
+pub const MAX_FILE_SIZE: usize = 10 * 1024 * 1024;
+```
+
+Add these config/path types below the constants:
+
+```rust
+#[derive(Debug, Clone)]
+pub struct CacheConfig {
+    pub root_dir: PathBuf,
+    pub memory_bytes: usize,
+    pub disk_bytes: usize,
+    pub max_file_size: usize,
+}
+
+impl CacheConfig {
+    pub fn new(
+        root_dir: PathBuf,
+        memory_bytes: usize,
+        disk_bytes: usize,
+        max_file_size: usize,
+    ) -> Result<Self> {
+        if memory_bytes == 0 {
+            return Err(anyhow!("memory cache size must be greater than zero"));
+        }
+        if disk_bytes == 0 {
+            return Err(anyhow!("disk cache size must be greater than zero"));
+        }
+        if max_file_size == 0 {
+            return Err(anyhow!("max file size must be greater than zero"));
+        }
+        Ok(Self {
+            root_dir,
+            memory_bytes,
+            disk_bytes,
+            max_file_size,
+        })
+    }
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        let root_dir = dirs::cache_dir()
+            .unwrap_or_else(std::env::temp_dir)
+            .join("nexus-fuse");
+        Self {
+            root_dir,
+            memory_bytes: DEFAULT_MEMORY_CACHE_BYTES,
+            disk_bytes: DEFAULT_DISK_CACHE_BYTES,
+            max_file_size: MAX_FILE_SIZE,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CachePaths {
+    pub foyer_dir: PathBuf,
+    pub sqlite_file: PathBuf,
+}
+
+impl CachePaths {
+    pub fn for_server(root_dir: &Path, server_url: &str) -> Self {
+        let hash = server_hash(server_url);
+        Self {
+            foyer_dir: root_dir.join(format!("nexus_{hash:016x}.foyer")),
+            sqlite_file: root_dir.join(format!("nexus_{hash:016x}.db")),
+        }
+    }
+}
+
+fn server_hash(server_url: &str) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    server_url.hash(&mut hasher);
+    hasher.finish()
+}
+```
+
+- [ ] **Step 5: Run config tests and verify they pass**
+
+Run the same command from Step 2.
+
+Expected: the three tests pass.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add nexus-fuse/Cargo.toml nexus-fuse/src/cache.rs
+git commit -m "test(#4053): define foyer cache config behavior"
+```
+
+### Task 2: Foyer-Backed FileCache Core
+
+**Files:**
+- Modify: `nexus-fuse/src/cache.rs`
+
+- [ ] **Step 1: Replace SQLite tests with public cache behavior tests**
+
+Keep behavior tests for basic cache use and remove tests that directly manipulate `cache.conn`. The final `tests` module should contain these test names:
+
+```rust
+fn test_cache_config_defaults() {}
+fn test_cache_config_rejects_zero_tiers() {}
+fn test_cache_paths_are_stable_and_distinct() {}
+fn test_old_sqlite_file_is_deleted_on_startup() {}
+fn test_cache_basic() {}
+fn test_put_without_etag() {}
+fn test_overwrite_entry() {}
+fn test_get_etag() {}
+fn test_touch_refreshes_stale_entry() {}
+fn test_stale_entry_with_etag_needs_revalidation() {}
+fn test_stale_entry_without_etag_is_miss() {}
+fn test_large_file_not_cached() {}
+fn test_max_size_file_cached() {}
+fn test_cache_stats() {}
+fn test_stats_after_invalidation() {}
+fn test_multiple_independent_paths() {}
+fn test_empty_content_cached() {}
+fn test_binary_content_preserved() {}
+fn test_concurrent_access() {}
+fn test_invalidate_nonexistent_is_noop() {}
+```
+
+Use this helper for tests:
+
+```rust
+fn test_cache(label: &str) -> FileCache {
+    let dir = tempfile::tempdir().unwrap();
+    let config = CacheConfig::new(
+        dir.path().join(label),
+        4 * 1024 * 1024,
+        64 * 1024 * 1024,
+        MAX_FILE_SIZE,
+    )
+    .unwrap();
+    FileCache::new_with_config(&format!("http://{label}.test"), config).unwrap()
+}
+```
+
+For stale tests, use `cache.backdate_for_test("/path", MAX_CACHE_AGE_SECS + 1);`.
+
+Use this exact migration test:
+
+```rust
+#[test]
+fn test_old_sqlite_file_is_deleted_on_startup() {
+    let dir = tempfile::tempdir().unwrap();
+    let config = CacheConfig::new(
+        dir.path().to_path_buf(),
+        4 * 1024 * 1024,
+        32 * 1024 * 1024,
+        MAX_FILE_SIZE,
+    )
+    .unwrap();
+    let paths = CachePaths::for_server(dir.path(), "http://migration.test");
+    std::fs::write(&paths.sqlite_file, b"old sqlite cache").unwrap();
+
+    let _cache = FileCache::new_with_config("http://migration.test", config).unwrap();
+
+    assert!(!paths.sqlite_file.exists());
+    assert!(paths.foyer_dir.exists());
+}
+```
+
+- [ ] **Step 2: Run tests and verify they fail against SQLite implementation**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/bf70/nexus/nexus-fuse
+cargo test cache::tests --lib
+```
+
+Expected: compile failure from missing foyer `FileCache` fields and `backdate_for_test`, plus SQLite-specific tests no longer matching internals.
+
+- [ ] **Step 3: Update production dependencies and imports**
+
+In `nexus-fuse/Cargo.toml`, replace:
+
+```toml
+# SQLite for persistent caching
+rusqlite = { version = "0.31", features = ["bundled"] }
+```
+
+with:
+
+```toml
+# Hybrid DRAM + filesystem cache for file content
+foyer = "0.22.3"
+
+# Compact cache record encoding
+bincode = "1.3"
+```
+
+Add this under `[dev-dependencies]`:
+
+```toml
+# Benchmark-only baseline for issue #4053 acceptance comparison
+rusqlite = { version = "0.31", features = ["bundled"] }
+```
+
+Replace the module docs/imports at the top of `nexus-fuse/src/cache.rs` with:
+
+```rust
+//! Foyer-backed hybrid cache for Nexus FUSE.
+//!
+//! Provides ETag-based cache invalidation to minimize network round-trips
+//! while using a DRAM tier and filesystem-backed disk tier for hot-path reads.
+
+#![allow(dead_code)]
+
+use anyhow::{anyhow, Context, Result};
+use foyer::{
+    BlockEngineConfig, DeviceBuilder, FsDeviceBuilder, HybridCache, HybridCacheBuilder,
+    StorageFilter,
+};
+use log::{debug, error, info, warn};
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+use std::time::{SystemTime, UNIX_EPOCH};
+```
+
+- [ ] **Step 4: Implement foyer cache data structures**
+
+In `nexus-fuse/src/cache.rs`, keep `CacheEntry`, `CacheLookup`, and `CacheStats`, then add:
+
+```rust
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CacheRecord {
+    content: Vec<u8>,
+    etag: Option<String>,
+    cached_at_secs: u64,
+}
+
+#[derive(Debug, Clone)]
+struct CacheMeta {
+    etag: Option<String>,
+    cached_at_secs: u64,
+    size: usize,
+}
+
+pub struct FileCache {
+    cache: HybridCache<String, Vec<u8>>,
+    runtime: tokio::runtime::Runtime,
+    metadata: Mutex<HashMap<String, CacheMeta>>,
+    config: CacheConfig,
+}
+```
+
+- [ ] **Step 5: Implement constructors and migration**
+
+Add these methods to `impl FileCache`:
+
+```rust
+pub fn new(server_url: &str) -> Result<Self> {
+    Self::new_with_config(server_url, CacheConfig::default())
+}
+
+pub fn new_with_config(server_url: &str, config: CacheConfig) -> Result<Self> {
+    std::fs::create_dir_all(&config.root_dir)
+        .with_context(|| format!("failed to create cache root {}", config.root_dir.display()))?;
+
+    let paths = CachePaths::for_server(&config.root_dir, server_url);
+    migrate_sqlite_file(&paths.sqlite_file);
+    std::fs::create_dir_all(&paths.foyer_dir)
+        .with_context(|| format!("failed to create foyer cache dir {}", paths.foyer_dir.display()))?;
+
+    info!(
+        "Opening foyer cache at: {} (memory={} MB, disk={} GB)",
+        paths.foyer_dir.display(),
+        config.memory_bytes / 1024 / 1024,
+        config.disk_bytes / 1024 / 1024 / 1024,
+    );
+
+    let runtime = tokio::runtime::Builder::new_multi_thread()
+        .enable_all()
+        .thread_name("nexus-fuse-cache")
+        .worker_threads(2)
+        .build()
+        .context("failed to create foyer cache runtime")?;
+
+    let cache = runtime.block_on(async {
+        let device = FsDeviceBuilder::new(&paths.foyer_dir)
+            .with_capacity(config.disk_bytes)
+            .build()?;
+
+        let cache = HybridCacheBuilder::new()
+            .with_name("nexus-fuse-file-cache")
+            .memory(config.memory_bytes)
+            .with_weighter(|_key, value: &Vec<u8>| value.len())
+            .storage()
+            .with_engine_config(
+                BlockEngineConfig::new(device)
+                    .with_admission_filter(StorageFilter::new()),
+            )
+            .build()
+            .await?;
+
+        Ok::<HybridCache<String, Vec<u8>>, foyer::Error>(cache)
+    })?;
+
+    Ok(Self {
+        cache,
+        runtime,
+        metadata: Mutex::new(HashMap::new()),
+        config,
+    })
+}
+```
+
+Add this helper outside `impl FileCache`:
+
+```rust
+fn migrate_sqlite_file(sqlite_file: &Path) {
+    if !sqlite_file.exists() {
+        return;
+    }
+
+    match std::fs::remove_file(sqlite_file) {
+        Ok(()) => info!("Dropped old SQLite cache file {}", sqlite_file.display()),
+        Err(e) => warn!(
+            "Failed to delete old SQLite cache file {}: {}",
+            sqlite_file.display(),
+            e
+        ),
+    }
+}
+```
+
+- [ ] **Step 6: Implement record encode/decode and lookup behavior**
+
+Add these methods:
+
+```rust
+fn now() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
+
+fn encode_record(record: &CacheRecord) -> Result<Vec<u8>> {
+    bincode::serialize(record).context("failed to encode cache record")
+}
+
+fn decode_record(bytes: &[u8]) -> Result<CacheRecord> {
+    bincode::deserialize(bytes).context("failed to decode cache record")
+}
+
+pub fn get(&self, path: &str) -> CacheLookup {
+    let now = Self::now();
+    let meta = self
+        .metadata
+        .lock()
+        .ok()
+        .and_then(|metadata| metadata.get(path).cloned());
+
+    if let Some(meta) = meta {
+        let age = now.saturating_sub(meta.cached_at_secs);
+        if age >= MAX_CACHE_AGE_SECS {
+            if let Some(etag) = meta.etag {
+                debug!("Cache stale for {} (age: {}s), needs revalidation", path, age);
+                return CacheLookup::NeedsRevalidation { etag };
+            }
+            debug!("Cache stale for {} with no etag", path);
+            return CacheLookup::Miss;
+        }
+    }
+
+    let key = path.to_string();
+    match self.runtime.block_on(self.cache.get(&key)) {
+        Ok(Some(entry)) => match Self::decode_record(entry.value()) {
+            Ok(record) => {
+                let age = now.saturating_sub(record.cached_at_secs);
+                if age < MAX_CACHE_AGE_SECS {
+                    debug!("Cache hit for {} (age: {}s)", path, age);
+                    return CacheLookup::Hit(CacheEntry {
+                        content: record.content,
+                        etag: record.etag,
+                    });
+                }
+                if let Some(etag) = record.etag {
+                    return CacheLookup::NeedsRevalidation { etag };
+                }
+                CacheLookup::Miss
+            }
+            Err(e) => {
+                warn!("Failed to decode cached entry {}: {}", path, e);
+                CacheLookup::Miss
+            }
+        },
+        Ok(None) => CacheLookup::Miss,
+        Err(e) => {
+            warn!("Foyer cache read failed for {}: {}", path, e);
+            CacheLookup::Miss
+        }
+    }
+}
+```
+
+- [ ] **Step 7: Implement mutation, stats, and test-only backdating**
+
+Add these methods:
+
+```rust
+pub fn get_etag(&self, path: &str) -> Option<String> {
+    self.metadata
+        .lock()
+        .ok()
+        .and_then(|metadata| metadata.get(path).and_then(|meta| meta.etag.clone()))
+}
+
+pub fn put(&self, path: &str, content: &[u8], etag: Option<&str>) {
+    if content.len() > self.config.max_file_size {
+        debug!(
+            "Skipping cache for {} ({} bytes > {} limit)",
+            path,
+            content.len(),
+            self.config.max_file_size
+        );
+        return;
+    }
+
+    let now = Self::now();
+    let record = CacheRecord {
+        content: content.to_vec(),
+        etag: etag.map(str::to_string),
+        cached_at_secs: now,
+    };
+    let encoded = match Self::encode_record(&record) {
+        Ok(encoded) => encoded,
+        Err(e) => {
+            error!("Failed to encode cache entry {}: {}", path, e);
+            return;
+        }
+    };
+
+    self.cache.insert(path.to_string(), encoded);
+    if let Ok(mut metadata) = self.metadata.lock() {
+        metadata.insert(
+            path.to_string(),
+            CacheMeta {
+                etag: record.etag,
+                cached_at_secs: now,
+                size: content.len(),
+            },
+        );
+    }
+}
+
+pub fn touch(&self, path: &str) {
+    let Some(entry) = self.runtime.block_on(self.cache.get(path)).ok().flatten() else {
+        debug!("Cache touch skipped for missing entry {}", path);
+        return;
+    };
+
+    let mut record = match Self::decode_record(entry.value()) {
+        Ok(record) => record,
+        Err(e) => {
+            warn!("Failed to decode cache entry during touch {}: {}", path, e);
+            return;
+        }
+    };
+    record.cached_at_secs = Self::now();
+    let encoded = match Self::encode_record(&record) {
+        Ok(encoded) => encoded,
+        Err(e) => {
+            warn!("Failed to encode cache entry during touch {}: {}", path, e);
+            return;
+        }
+    };
+    self.cache.insert(path.to_string(), encoded);
+    if let Ok(mut metadata) = self.metadata.lock() {
+        metadata.insert(
+            path.to_string(),
+            CacheMeta {
+                etag: record.etag,
+                cached_at_secs: record.cached_at_secs,
+                size: record.content.len(),
+            },
+        );
+    }
+}
+
+pub fn invalidate(&self, path: &str) {
+    self.cache.remove(path);
+    if let Ok(mut metadata) = self.metadata.lock() {
+        metadata.remove(path);
+    }
+    debug!("Invalidated cache for {}", path);
+}
+
+pub fn stats(&self) -> CacheStats {
+    let Ok(metadata) = self.metadata.lock() else {
+        return CacheStats {
+            file_count: 0,
+            total_size: 0,
+        };
+    };
+
+    CacheStats {
+        file_count: metadata.len() as u64,
+        total_size: metadata.values().map(|meta| meta.size as u64).sum(),
+    }
+}
+
+#[cfg(test)]
+fn backdate_for_test(&self, path: &str, age_secs: u64) {
+    let cached_at_secs = Self::now().saturating_sub(age_secs);
+    if let Ok(mut metadata) = self.metadata.lock() {
+        if let Some(meta) = metadata.get_mut(path) {
+            meta.cached_at_secs = cached_at_secs;
+        }
+    }
+
+    let Some(entry) = self.runtime.block_on(self.cache.get(path)).ok().flatten() else {
+        return;
+    };
+    let mut record = Self::decode_record(entry.value()).unwrap();
+    record.cached_at_secs = cached_at_secs;
+    let encoded = Self::encode_record(&record).unwrap();
+    self.cache.insert(path.to_string(), encoded);
+}
+```
+
+- [ ] **Step 8: Run cache tests**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/bf70/nexus/nexus-fuse
+cargo test cache::tests --lib
+```
+
+Expected: all cache tests pass. If foyer creates background task logs, test output may include logs but must exit 0.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add nexus-fuse/Cargo.toml nexus-fuse/src/cache.rs
+git commit -m "feat(#4053): replace fuse file cache with foyer"
+```
+
+### Task 3: Shared ETag Read-Through Cache Helper
+
+**Files:**
+- Create: `nexus-fuse/src/cached_read.rs`
+- Modify: `nexus-fuse/src/lib.rs`
+- Modify: `nexus-fuse/src/fs.rs`
+
+- [ ] **Step 1: Write the shared helper**
+
+Create `nexus-fuse/src/cached_read.rs`:
+
+```rust
+//! Shared read-through-cache flow for nexus-fuse mount and daemon reads.
+
+use crate::cache::{CacheLookup, FileCache};
+use crate::client::{NexusClient, ReadResponse};
+use crate::error::NexusClientError;
+use log::{debug, error};
+
+pub fn read_with_cache(
+    client: &NexusClient,
+    cache: Option<&FileCache>,
+    path: &str,
+) -> Result<(Vec<u8>, Option<String>), NexusClientError> {
+    if let Some(cache) = cache {
+        match cache.get(path) {
+            CacheLookup::Hit(entry) => {
+                debug!("Foyer cache hit for {}", path);
+                return Ok((entry.content, entry.etag));
+            }
+            CacheLookup::NeedsRevalidation { etag } => {
+                debug!("Revalidating cache for {} with etag {}", path, etag);
+                match client.read_with_etag(path, Some(&etag)) {
+                    Ok(ReadResponse::NotModified) => {
+                        cache.touch(path);
+                        match cache.get(path) {
+                            CacheLookup::Hit(entry) => return Ok((entry.content, entry.etag)),
+                            _ => error!("Cache inconsistency after 304 for {}", path),
+                        }
+                    }
+                    Ok(ReadResponse::Content { content, etag }) => {
+                        cache.put(path, &content, etag.as_deref());
+                        return Ok((content, etag));
+                    }
+                    Err(e) => {
+                        debug!("Revalidation failed for {}: {}, using stale cache", path, e);
+                        if let CacheLookup::Hit(entry) = cache.get(path) {
+                            return Ok((entry.content, entry.etag));
+                        }
+                        return Err(e);
+                    }
+                }
+            }
+            CacheLookup::Miss => {}
+        }
+    }
+
+    match client.read_with_etag(path, None) {
+        Ok(ReadResponse::Content { content, etag }) => {
+            if let Some(cache) = cache {
+                cache.put(path, &content, etag.as_deref());
+            }
+            Ok((content, etag))
+        }
+        Ok(ReadResponse::NotModified) => Err(NexusClientError::InvalidResponse(
+            "Unexpected 304 response".to_string(),
+        )),
+        Err(e) => Err(e),
+    }
+}
+```
+
+- [ ] **Step 2: Export the module**
+
+In `nexus-fuse/src/lib.rs`, add:
+
+```rust
+pub mod cached_read;
+```
+
+- [ ] **Step 3: Update `fs.rs` to use the helper**
+
+Change imports:
+
+```rust
+use crate::cache::FileCache;
+use crate::cached_read::read_with_cache;
+```
+
+Remove `CacheLookup` and `ReadResponse` from `fs.rs` imports.
+
+Change `NexusFs` field and constructor:
+
+```rust
+file_cache: Option<std::sync::Arc<FileCache>>,
+
+pub fn new(client: NexusClient, file_cache: Option<std::sync::Arc<FileCache>>) -> Self {
+```
+
+Replace the body of `fn read_cached(&self, path: &str)` with:
+
+```rust
+read_with_cache(&self.client, self.file_cache.as_deref(), path).map_err(Into::into)
+```
+
+Update comments near `read_cached` and `read` from `SQLite cache` to `foyer cache`.
+
+- [ ] **Step 4: Run compile check for mount path**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/bf70/nexus/nexus-fuse
+cargo test cache::tests --lib
+cargo check
+```
+
+Expected: tests pass and `cargo check` exits 0. If `NexusFs::new` call sites fail, fix them in Task 4 where cache construction is updated.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add nexus-fuse/src/cached_read.rs nexus-fuse/src/lib.rs nexus-fuse/src/fs.rs
+git commit -m "refactor(#4053): share fuse cached read flow"
+```
+
+### Task 4: CLI, Mount, And Daemon Cache Wiring
+
+**Files:**
+- Modify: `nexus-fuse/src/main.rs`
+- Modify: `nexus-fuse/src/daemon.rs`
+
+- [ ] **Step 1: Write compile-failing CLI config code path**
+
+In `nexus-fuse/src/main.rs`, add cache arguments to both `Commands::Mount` and `Commands::Daemon`:
+
+```rust
+/// Foyer DRAM cache size in MiB
+#[arg(long, env = "NEXUS_FUSE_CACHE_MEMORY_MB", default_value_t = 256)]
+cache_memory_mb: usize,
+
+/// Foyer filesystem cache size in GiB
+#[arg(long, env = "NEXUS_FUSE_CACHE_DISK_GB", default_value_t = 10)]
+cache_disk_gb: usize,
+
+/// Override cache root directory
+#[arg(long, env = "NEXUS_FUSE_CACHE_DIR")]
+cache_dir: Option<PathBuf>,
+```
+
+Update match destructuring to include these three fields for both commands.
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/bf70/nexus/nexus-fuse
+cargo check
+```
+
+Expected: compile failure until `build_cache_config` and daemon config fields are added.
+
+- [ ] **Step 2: Add cache config builder in `main.rs`**
+
+Add imports:
+
+```rust
+use std::sync::Arc;
+```
+
+Add helpers above `main`:
+
+```rust
+fn mib_to_bytes(mib: usize) -> anyhow::Result<usize> {
+    mib.checked_mul(1024 * 1024)
+        .ok_or_else(|| anyhow::anyhow!("cache memory size overflows usize"))
+}
+
+fn gib_to_bytes(gib: usize) -> anyhow::Result<usize> {
+    gib.checked_mul(1024 * 1024 * 1024)
+        .ok_or_else(|| anyhow::anyhow!("cache disk size overflows usize"))
+}
+
+fn build_cache_config(
+    cache_memory_mb: usize,
+    cache_disk_gb: usize,
+    cache_dir: Option<PathBuf>,
+) -> anyhow::Result<cache::CacheConfig> {
+    let root_dir = cache_dir.unwrap_or_else(|| cache::CacheConfig::default().root_dir);
+    cache::CacheConfig::new(
+        root_dir,
+        mib_to_bytes(cache_memory_mb)?,
+        gib_to_bytes(cache_disk_gb)?,
+        cache::MAX_FILE_SIZE,
+    )
+}
+
+fn open_file_cache(
+    url: &str,
+    config: cache::CacheConfig,
+) -> Option<Arc<cache::FileCache>> {
+    match cache::FileCache::new_with_config(url, config) {
+        Ok(cache) => {
+            let stats = cache.stats();
+            info!(
+                "Foyer cache ready: {} current-process files ({} MB)",
+                stats.file_count,
+                stats.total_size / 1024 / 1024
+            );
+            Some(Arc::new(cache))
+        }
+        Err(e) => {
+            error!("Failed to initialize foyer cache: {} (continuing without cache)", e);
+            None
+        }
+    }
+}
+```
+
+- [ ] **Step 3: Wire mount cache creation**
+
+Replace the existing mount cache block:
+
+```rust
+let file_cache = match cache::FileCache::new(&url) {
+    Ok(cache) => {
+        let stats = cache.stats();
+        info!(
+            "Cache loaded: {} files ({} MB)",
+            stats.file_count,
+            stats.total_size / 1024 / 1024
+        );
+        Some(cache)
+    }
+    Err(e) => {
+        error!("Failed to initialize cache: {} (continuing without cache)", e);
+        None
+    }
+};
+```
+
+with:
+
+```rust
+let cache_config = build_cache_config(cache_memory_mb, cache_disk_gb, cache_dir)?;
+let file_cache = open_file_cache(&url, cache_config);
+```
+
+`NexusFs::new(client, file_cache)` now receives `Option<Arc<FileCache>>`.
+
+- [ ] **Step 4: Wire daemon config and cache use**
+
+In `nexus-fuse/src/daemon.rs`, add imports:
+
+```rust
+use crate::cache::FileCache;
+use crate::cached_read::read_with_cache;
+use std::sync::Arc;
+```
+
+Update structs:
+
+```rust
+pub struct DaemonConfig {
+    pub socket_path: PathBuf,
+    pub nexus_url: String,
+    pub api_key: String,
+    pub agent_id: Option<String>,
+    pub file_cache: Option<Arc<FileCache>>,
+}
+
+pub struct Daemon {
+    config: DaemonConfig,
+    client: NexusClient,
+    file_cache: Option<Arc<FileCache>>,
+}
+```
+
+Update `Daemon::new`:
+
+```rust
+Ok(Self {
+    file_cache: config.file_cache.clone(),
+    config,
+    client,
+})
+```
+
+Update connection spawn:
+
+```rust
+let client = self.client.clone();
+let file_cache = self.file_cache.clone();
+tokio::spawn(async move {
+    if let Err(e) = handle_connection(stream, client, file_cache).await {
+        error!("Connection error: {}", e);
+    }
+});
+```
+
+Update function signatures and request dispatch:
+
+```rust
+async fn handle_connection(
+    stream: UnixStream,
+    client: NexusClient,
+    file_cache: Option<Arc<FileCache>>,
+) -> anyhow::Result<()> {
+```
+
+```rust
+let response = match serde_json::from_str::<JsonRpcRequest>(&line) {
+    Ok(request) => handle_request(request, &client, file_cache.clone()).await,
+```
+
+```rust
+async fn handle_request(
+    request: JsonRpcRequest,
+    client: &NexusClient,
+    file_cache: Option<Arc<FileCache>>,
+) -> JsonRpcResponse {
+```
+
+Inside `spawn_blocking`, clone the cache into the closure and dispatch:
+
+```rust
+let result = tokio::task::spawn_blocking(move || match method.as_str() {
+    "read" => handle_read(&params, &client, file_cache.as_deref()),
+    "write" => handle_write(&params, &client, file_cache.as_deref()),
+    "list" => handle_list(&params, &client),
+    "stat" => handle_stat(&params, &client),
+    "mkdir" => handle_mkdir(&params, &client),
+    "delete" => handle_delete(&params, &client, file_cache.as_deref()),
+    "rename" => handle_rename(&params, &client, file_cache.as_deref()),
+    "exists" => handle_exists(&params, &client),
+    _ => Err(NexusClientError::InvalidResponse(format!(
+        "Method not found: {}",
+        method
+    ))),
+})
+.await;
+```
+
+Replace daemon handlers:
+
+```rust
+fn handle_read(
+    params: &Value,
+    client: &NexusClient,
+    file_cache: Option<&FileCache>,
+) -> Result<Value, NexusClientError> {
+    #[derive(Deserialize)]
+    struct P { path: String }
+    let p: P = extract_params(params)?;
+
+    let (content, _) = read_with_cache(client, file_cache, &p.path)?;
+    let encoded = base64::engine::general_purpose::STANDARD.encode(&content);
+
+    Ok(json!({
+        "__type__": "bytes",
+        "data": encoded
+    }))
+}
+
+fn handle_write(
+    params: &Value,
+    client: &NexusClient,
+    file_cache: Option<&FileCache>,
+) -> Result<Value, NexusClientError> {
+    #[derive(Deserialize)]
+    struct ContentBytes {
+        #[serde(rename = "__type__")]
+        type_tag: String,
+        data: String,
+    }
+    #[derive(Deserialize)]
+    struct P { path: String, content: ContentBytes }
+    let p: P = extract_params(params)?;
+
+    let content = base64::engine::general_purpose::STANDARD
+        .decode(&p.content.data)
+        .map_err(|e| NexusClientError::InvalidResponse(format!("Invalid base64: {}", e)))?;
+
+    client.write(&p.path, &content)?;
+    if let Some(cache) = file_cache {
+        cache.invalidate(&p.path);
+    }
+    Ok(json!({}))
+}
+
+fn handle_delete(
+    params: &Value,
+    client: &NexusClient,
+    file_cache: Option<&FileCache>,
+) -> Result<Value, NexusClientError> {
+    #[derive(Deserialize)]
+    struct P { path: String }
+    let p: P = extract_params(params)?;
+
+    client.delete(&p.path)?;
+    if let Some(cache) = file_cache {
+        cache.invalidate(&p.path);
+    }
+    Ok(json!({}))
+}
+
+fn handle_rename(
+    params: &Value,
+    client: &NexusClient,
+    file_cache: Option<&FileCache>,
+) -> Result<Value, NexusClientError> {
+    #[derive(Deserialize)]
+    struct P { old_path: String, new_path: String }
+    let p: P = extract_params(params)?;
+
+    client.rename(&p.old_path, &p.new_path)?;
+    if let Some(cache) = file_cache {
+        cache.invalidate(&p.old_path);
+        cache.invalidate(&p.new_path);
+    }
+    Ok(json!({}))
+}
+```
+
+Update daemon command config construction in `main.rs`:
+
+```rust
+let cache_config = build_cache_config(cache_memory_mb, cache_disk_gb, cache_dir)?;
+let file_cache = open_file_cache(&url, cache_config);
+
+let config = daemon::DaemonConfig {
+    socket_path,
+    nexus_url: url,
+    api_key,
+    agent_id,
+    file_cache,
+};
+```
+
+- [ ] **Step 5: Run checks**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/bf70/nexus/nexus-fuse
+cargo test cache::tests --lib
+cargo check
+```
+
+Expected: all tests pass and `cargo check` exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add nexus-fuse/src/main.rs nexus-fuse/src/daemon.rs nexus-fuse/src/fs.rs
+git commit -m "feat(#4053): wire foyer cache into mount and daemon reads"
+```
+
+### Task 5: Benchmark-Only SQLite Baseline And Foyer Cache Benchmark
+
+**Files:**
+- Modify: `nexus-fuse/Cargo.toml`
+- Create: `nexus-fuse/benches/cache_backends.rs`
+
+- [ ] **Step 1: Add benchmark target**
+
+Append to `nexus-fuse/Cargo.toml`:
+
+```toml
+[[bench]]
+name = "cache_backends"
+harness = false
+```
+
+- [ ] **Step 2: Create the benchmark file**
+
+Create `nexus-fuse/benches/cache_backends.rs`:
+
+```rust
+use criterion::{criterion_group, criterion_main, BatchSize, Criterion};
+use nexus_fuse::cache::{CacheConfig, FileCache, MAX_FILE_SIZE};
+use rusqlite::{params, Connection, OptionalExtension};
+use std::time::{Duration, Instant};
+
+struct SqliteBaseline {
+    conn: Connection,
+}
+
+impl SqliteBaseline {
+    fn new() -> Self {
+        let conn = Connection::open_in_memory().unwrap();
+        conn.execute_batch(
+            "
+            CREATE TABLE file_cache (
+                path TEXT PRIMARY KEY,
+                content BLOB NOT NULL,
+                etag TEXT,
+                size INTEGER NOT NULL,
+                cached_at INTEGER NOT NULL
+            );
+            ",
+        )
+        .unwrap();
+        Self { conn }
+    }
+
+    fn put(&self, path: &str, content: &[u8], etag: &str) {
+        self.conn
+            .execute(
+                "INSERT OR REPLACE INTO file_cache (path, content, etag, size, cached_at)
+                 VALUES (?, ?, ?, ?, ?)",
+                params![path, content, etag, content.len() as i64, 0_i64],
+            )
+            .unwrap();
+    }
+
+    fn get(&self, path: &str) -> Option<Vec<u8>> {
+        self.conn
+            .query_row(
+                "SELECT content FROM file_cache WHERE path = ?",
+                params![path],
+                |row| row.get(0),
+            )
+            .optional()
+            .unwrap()
+    }
+}
+
+fn foyer_cache(label: &str, memory_bytes: usize) -> FileCache {
+    let dir = tempfile::tempdir().unwrap().into_path();
+    let config = CacheConfig::new(
+        dir,
+        memory_bytes,
+        256 * 1024 * 1024,
+        MAX_FILE_SIZE,
+    )
+    .unwrap();
+    FileCache::new_with_config(&format!("http://bench-{label}.test"), config).unwrap()
+}
+
+fn bench_warm_reads(c: &mut Criterion) {
+    for size in [1024_usize, 10 * 1024, 100 * 1024, 1024 * 1024] {
+        let data = vec![42_u8; size];
+        let name = format!("warm_read_{}b", size);
+
+        c.bench_function(&format!("foyer_{name}"), |b| {
+            b.iter_batched(
+                || {
+                    let cache = foyer_cache(&name, 32 * 1024 * 1024);
+                    cache.put("/warm.bin", &data, Some("etag"));
+                    cache
+                },
+                |cache| {
+                    let entry = cache.get("/warm.bin");
+                    std::hint::black_box(entry);
+                },
+                BatchSize::SmallInput,
+            );
+        });
+
+        c.bench_function(&format!("sqlite_{name}"), |b| {
+            b.iter_batched(
+                || {
+                    let cache = SqliteBaseline::new();
+                    cache.put("/warm.bin", &data, "etag");
+                    cache
+                },
+                |cache| {
+                    let entry = cache.get("/warm.bin");
+                    std::hint::black_box(entry);
+                },
+                BatchSize::SmallInput,
+            );
+        });
+    }
+}
+
+fn bench_agent_churn_p99(c: &mut Criterion) {
+    let object_count = 2_000;
+    let hot_count = 128;
+    let data = vec![7_u8; 16 * 1024];
+    let paths: Vec<String> = (0..object_count)
+        .map(|i| format!("/trace/object-{i}.bin"))
+        .collect();
+
+    c.bench_function("foyer_agent_churn_trace", |b| {
+        b.iter_batched(
+            || {
+                let cache = foyer_cache("agent-churn", 8 * 1024 * 1024);
+                for path in paths.iter().take(hot_count) {
+                    cache.put(path, &data, Some("etag"));
+                }
+                cache
+            },
+            |cache| {
+                let mut latencies = Vec::with_capacity(object_count);
+                let mut hits = 0_u64;
+                for (i, path) in paths.iter().enumerate() {
+                    if i % 4 == 0 {
+                        cache.put(path, &data, Some("etag"));
+                    }
+                    let start = Instant::now();
+                    if matches!(cache.get(path), nexus_fuse::cache::CacheLookup::Hit(_)) {
+                        hits += 1;
+                    }
+                    latencies.push(start.elapsed());
+                }
+                latencies.sort_unstable();
+                let p99 = latencies[latencies.len() * 99 / 100];
+                std::hint::black_box((hits, p99));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    c.bench_function("sqlite_agent_churn_trace", |b| {
+        b.iter_batched(
+            || {
+                let cache = SqliteBaseline::new();
+                for path in paths.iter().take(hot_count) {
+                    cache.put(path, &data, "etag");
+                }
+                cache
+            },
+            |cache| {
+                let mut latencies = Vec::with_capacity(object_count);
+                let mut hits = 0_u64;
+                for (i, path) in paths.iter().enumerate() {
+                    if i % 4 == 0 {
+                        cache.put(path, &data, "etag");
+                    }
+                    let start = Instant::now();
+                    if cache.get(path).is_some() {
+                        hits += 1;
+                    }
+                    latencies.push(start.elapsed());
+                }
+                latencies.sort_unstable();
+                let p99 = latencies[latencies.len() * 99 / 100];
+                std::hint::black_box((hits, p99));
+            },
+            BatchSize::SmallInput,
+        );
+    });
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .warm_up_time(Duration::from_secs(1))
+        .measurement_time(Duration::from_secs(5));
+    targets = bench_warm_reads, bench_agent_churn_p99
+}
+criterion_main!(benches);
+```
+
+- [ ] **Step 3: Run benchmark compile**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/bf70/nexus/nexus-fuse
+cargo bench --bench cache_backends --no-run
+```
+
+Expected: benchmark compiles. If `tempfile::TempDir::into_path` emits a deprecation warning, replace it with `tempfile::TempDir::keep` if available in the installed `tempfile` version.
+
+- [ ] **Step 4: Run benchmark and save output**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/bf70/nexus/nexus-fuse
+cargo bench --bench cache_backends
+```
+
+Expected: Criterion reports `foyer_*` and `sqlite_*` timings. Save the console summary for Task 6.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add nexus-fuse/Cargo.toml nexus-fuse/benches/cache_backends.rs
+git commit -m "bench(#4053): compare foyer cache against sqlite baseline"
+```
+
+### Task 6: Documentation And Performance Results
+
+**Files:**
+- Modify: `nexus-fuse/ARCHITECTURE.md`
+- Modify: `nexus-fuse/PERFORMANCE_RESULTS.md`
+
+- [ ] **Step 1: Update architecture references**
+
+In `nexus-fuse/ARCHITECTURE.md`, replace:
+
+```text
+- SQLite cache (persistent)
+```
+
+with:
+
+```text
+- Foyer hybrid cache (DRAM + filesystem tier)
+```
+
+Replace:
+
+```text
+- Maintain persistent SQLite cache
+```
+
+with:
+
+```text
+- Maintain foyer-backed file-content cache with ETag revalidation
+```
+
+Replace:
+
+```text
+- Persistent cache (SQLite vs in-memory)
+```
+
+with:
+
+```text
+- Persistent hybrid cache (foyer DRAM tier plus filesystem tier)
+```
+
+- [ ] **Step 2: Capture benchmark environment**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/bf70/nexus
+{
+  date "+%Y-%m-%d"
+  uname -a
+  rustc --version
+} > /tmp/nexus-fuse-4053-benchmark-env.txt
+```
+
+Expected: `/tmp/nexus-fuse-4053-benchmark-env.txt` contains the benchmark date, OS kernel string, and Rust compiler version.
+
+- [ ] **Step 3: Add migration and benchmark result**
+
+Append a section named `Issue #4053 - foyer Hybrid Cache` to `nexus-fuse/PERFORMANCE_RESULTS.md`. It must include:
+
+- the command `cd nexus-fuse && cargo bench --bench cache_backends`
+- the date, OS, and Rust version captured in Step 2
+- foyer version `0.22.3`
+- benchmark tier sizes: 8 MiB and 32 MiB DRAM cases, 256 MiB filesystem tier
+- baseline description: benchmark-only in-memory SQLite table mirroring old `FileCache` hot operations
+- a result table with rows for warm 1 KiB, warm 10 KiB, warm 100 KiB, warm 1 MiB, and agent churn trace p99
+- an acceptance sentence naming the achieved issue #4053 criterion
+- this migration sentence:
+
+```text
+Existing SQLite cache files under the nexus-fuse cache root named `nexus_HASH.db` are dropped on cache startup. New foyer cache content is stored under a sibling `nexus_HASH.foyer/` directory.
+```
+
+The committed section must contain concrete benchmark numbers from Task 5 for every result row.
+
+- [ ] **Step 4: Run docs grep**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/bf70/nexus
+rg -n "SQLite cache|sqlite cache|Persistent cache \\(SQLite" nexus-fuse
+```
+
+Expected: no stale production documentation references. Benchmark-only references to SQLite baseline are allowed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add nexus-fuse/ARCHITECTURE.md nexus-fuse/PERFORMANCE_RESULTS.md
+git commit -m "docs(#4053): document foyer cache migration and benchmark"
+```
+
+### Task 7: Final Verification And Cleanup
+
+**Files:**
+- Review: all files changed in Tasks 1-6
+
+- [ ] **Step 1: Run Rust formatting**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/bf70/nexus/nexus-fuse
+cargo fmt --check
+```
+
+Expected: exits 0. If it fails, run `cargo fmt`, inspect the diff, and re-run `cargo fmt --check`.
+
+- [ ] **Step 2: Run focused tests**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/bf70/nexus/nexus-fuse
+cargo test cache::tests --lib
+```
+
+Expected: all cache tests pass.
+
+- [ ] **Step 3: Run full nexus-fuse tests**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/bf70/nexus/nexus-fuse
+cargo test
+```
+
+Expected: all `nexus-fuse` tests pass.
+
+- [ ] **Step 4: Run clippy**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/bf70/nexus/nexus-fuse
+cargo clippy --all-targets -- -D warnings
+```
+
+Expected: exits 0. Fix warnings in changed Rust code.
+
+- [ ] **Step 5: Run benchmark compile**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/bf70/nexus/nexus-fuse
+cargo bench --bench cache_backends --no-run
+```
+
+Expected: benchmark compiles.
+
+- [ ] **Step 6: Confirm production SQLite removal**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/bf70/nexus
+rg -n "rusqlite|Connection|OptionalExtension|file_cache \\(" nexus-fuse/src nexus-fuse/Cargo.toml
+```
+
+Expected: no `rusqlite`, `Connection`, or `OptionalExtension` references in `nexus-fuse/src`. `rusqlite` may appear only in `nexus-fuse/Cargo.toml` under `[dev-dependencies]` and in `nexus-fuse/benches/cache_backends.rs`.
+
+- [ ] **Step 7: Review diff**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/bf70/nexus
+git status --short
+git diff --stat HEAD~6..HEAD
+git log --oneline -6
+```
+
+Expected: only intended issue #4053 files changed, with commits for config/tests, foyer cache, shared read flow, wiring, benchmark, and docs.
+
+- [ ] **Step 8: Final commit for verification fixes if needed**
+
+If formatting or clippy fixes changed files, commit them:
+
+```bash
+git add nexus-fuse
+git commit -m "fix(#4053): address foyer cache verification findings"
+```
+
+If no files changed, do not create an empty commit.
+
+## Self-Review Checklist
+
+- Spec coverage:
+  - foyer wired into hot path: Tasks 2, 3, and 4.
+  - DRAM tier default/config: Tasks 1 and 4.
+  - filesystem/NVMe tier default/config: Tasks 1 and 4.
+  - ETag revalidation preserved: Task 3.
+  - admission filter before flash writes: Task 2 uses `BlockEngineConfig::with_admission_filter`.
+  - benchmark evidence: Task 5 and Task 6.
+  - migration path documented: Task 1 and Task 6.
+- Placeholder scan: no unfilled code blocks and no benchmark template text left in committed documentation.
+- Type consistency: `CacheConfig`, `CachePaths`, `FileCache`, `read_with_cache`, and `Option<Arc<FileCache>>` are used consistently across tasks.

--- a/docs/superpowers/specs/2026-05-08-issue-4053-foyer-cache-design.md
+++ b/docs/superpowers/specs/2026-05-08-issue-4053-foyer-cache-design.md
@@ -1,0 +1,195 @@
+# Issue #4053 - Foyer Hybrid Cache For nexus-fuse Design
+
+**Date**: 2026-05-08
+**Issue**: [#4053](https://github.com/nexi-lab/nexus/issues/4053) - Replace `nexus-fuse` SQLite cache with foyer hybrid (DRAM+NVMe)
+
+## Context
+
+`nexus-fuse` currently caches file content through `nexus-fuse/src/cache.rs`, where `FileCache` stores content, ETags, and timestamps in SQLite. `nexus-fuse/src/fs.rs` already treats the cache as an optional synchronous optimization through `CacheLookup`, `put`, `touch`, and `invalidate`. The read path preserves server consistency by using ETag revalidation: fresh entries return immediately, stale entries with an ETag trigger `If-None-Match`, and a `304 Not Modified` refreshes the timestamp.
+
+Issue #4053 asks to replace SQLite with [foyer](https://github.com/foyer-rs/foyer), keeping ETag behavior while adding a DRAM tier, an NVMe tier, and flash-write admission control. Foyer's hybrid cache API is async, while the current FUSE callbacks and cache boundary are synchronous.
+
+## Decision
+
+Replace the SQLite implementation behind `FileCache` with a foyer hybrid cache while preserving the public `FileCache` surface consumed by `NexusFs`:
+
+- `get(path) -> CacheLookup`
+- `get_etag(path) -> Option<String>`
+- `put(path, content, etag)`
+- `touch(path)`
+- `invalidate(path)`
+- `stats() -> CacheStats`
+
+`FileCache` will own an internal Tokio runtime used only to bridge the existing synchronous API to foyer's async operations. This keeps the change localized to `cache.rs`, cache initialization in `main.rs`, small log/comment updates in `fs.rs`, documentation, and benchmarks. It avoids converting FUSE callbacks or `NexusClient` reads to async as part of this issue.
+
+## Non-Goals
+
+1. Rewriting the FUSE read/write path to async.
+2. Keeping SQLite as a production fallback cache.
+3. Persisting exact SQLite-style row counts across process restarts.
+4. Introducing a new FUSE integration harness.
+5. Changing the server-side read, write, or ETag APIs.
+
+## Cache Layout
+
+The cache root remains under:
+
+```text
+<user-cache-dir>/nexus-fuse/
+```
+
+Each Nexus server URL maps to a stable hash. The old SQLite file path for a server remains:
+
+```text
+nexus_<hash>.db
+```
+
+The new foyer storage path is:
+
+```text
+nexus_<hash>.foyer/
+```
+
+On startup, `FileCache::new` creates the foyer directory and attempts to delete the matching old SQLite database file. SQLite deletion is the migration path. If deletion fails, the mount logs a warning and continues with the foyer cache.
+
+## Cache Records
+
+Foyer values store a serialized file record:
+
+```rust
+struct CacheRecord {
+    content: Vec<u8>,
+    etag: Option<String>,
+    cached_at_secs: u64,
+}
+```
+
+The cache key is the Nexus path string. The value is encoded with `bincode` so foyer stores one opaque byte value per path.
+
+The existing `MAX_CACHE_AGE_SECS` freshness policy remains one hour. The existing max-file-size guard remains at 10 MiB: content above that size bypasses `put` and is fetched directly from Nexus.
+
+## Foyer Configuration
+
+Defaults:
+
+- DRAM tier: 256 MiB
+- NVMe/filesystem tier: 10 GiB
+- Per-file cacheability limit: 10 MiB
+- Freshness age: 1 hour
+
+Configuration is explicit on the CLI and environment:
+
+```text
+--cache-memory-mb / NEXUS_FUSE_CACHE_MEMORY_MB
+--cache-disk-gb / NEXUS_FUSE_CACHE_DISK_GB
+--cache-dir / NEXUS_FUSE_CACHE_DIR
+```
+
+The mount command uses these values when creating `FileCache`. The daemon command also receives equivalent cache configuration so Python-backed Rust daemon usage gets the same behavior.
+
+Invalid tier sizes fail before mounting. A zero value disables that tier only if foyer supports the resulting configuration cleanly; otherwise zero is rejected with a clear error. Cache initialization failure remains best-effort: log the error and continue without a file cache.
+
+## Admission And Eviction
+
+The DRAM tier uses foyer's in-memory eviction configuration. The disk tier uses foyer's filesystem device capacity setting and enables foyer's storage admission/filtering before flash writes. The implementation will use foyer's hybrid cache builder, memory configuration, filesystem storage device, and block-engine admission filter APIs in the current foyer release.
+
+The design does not duplicate foyer's admission logic in `nexus-fuse`. `nexus-fuse` only applies semantic cacheability checks: path keying, max file size, ETag/timestamp record data, and explicit invalidation.
+
+## Read Data Flow
+
+`NexusFs::read_cached(path)` keeps the same behavior:
+
+1. Ask `FileCache::get(path)`.
+2. If the cache returns `Hit(entry)`, return cached content and ETag.
+3. If the cache returns `NeedsRevalidation { etag }`, call `NexusClient::read_with_etag(path, Some(&etag))`.
+4. On `ReadResponse::NotModified`, call `FileCache::touch(path)`, then fetch the cached record and return it.
+5. On `ReadResponse::Content { content, etag }`, call `FileCache::put(path, &content, etag.as_deref())` and return the server content.
+6. On revalidation error, try to return stale cached content. If the stale record is unavailable, return the server error.
+7. On `Miss`, call `read_with_etag(path, None)`, store successful content through `put`, and return it.
+
+`CacheLookup::NeedsRevalidation` must not deserialize the content bytes just to decide freshness. If foyer requires reading the record as one value, `FileCache` may keep a small in-memory metadata map keyed by path to answer stale ETag checks without forcing content copies on every stale lookup.
+
+## Invalidation Data Flow
+
+`NexusFs::invalidate_path(path)` continues to call `FileCache::invalidate(path)` after writes, creates, deletes, truncates, and renames. `invalidate` removes the foyer entry and any in-memory metadata for that path. Rename continues invalidating both the old and new paths.
+
+Directory and attribute LRU caches remain unchanged.
+
+## Stats
+
+`CacheStats` remains available for startup logs and tests:
+
+```rust
+pub struct CacheStats {
+    pub file_count: u64,
+    pub total_size: u64,
+}
+```
+
+Because foyer is the cache owner, `nexus-fuse` will maintain lightweight in-process metadata for inserted records and invalidations. Stats are exact for entries inserted during the current process and best-effort after restart. Startup logging will make this clear by avoiding wording that implies SQLite-style persistent row accounting.
+
+## Error Handling
+
+Cache initialization is best-effort. If the cache directory cannot be created, foyer rejects the configuration, or the runtime cannot start, `main.rs` logs the error and mounts without a file cache.
+
+Runtime cache errors do not fail FUSE operations:
+
+- `get` logs foyer read/deserialization errors and returns `Miss`.
+- `put`, `touch`, and `invalidate` log failures and return `()`.
+- stale fallback after revalidation failure still attempts to read cached content before surfacing the server error.
+- old SQLite migration deletion logs warnings on failure and does not block mount startup.
+
+Production cache code must avoid `unwrap` on runtime, filesystem, or foyer operations. Poisoned lock handling should degrade cache behavior where practical instead of crashing the mount.
+
+## Tests
+
+The existing cache tests move from SQLite-specific internals to public behavior:
+
+- empty cache returns `Miss`
+- `put` followed by `get` returns bytes and ETag
+- `put` overwrites an existing path
+- `get_etag` returns the stored ETag
+- `touch` refreshes an entry
+- stale entry with an ETag returns `NeedsRevalidation`
+- stale entry without an ETag returns `Miss`
+- files above the max-file-size guard are not cached
+- file exactly at the max-file-size guard is cached
+- `invalidate` removes one path and is a no-op for missing paths
+- binary and empty content round trip exactly
+- concurrent access does not panic
+- stats update for current-process puts and invalidations
+- old SQLite cache file is deleted during startup migration
+- cache configuration defaults and invalid-size parsing are covered
+
+If the existing codebase has a practical way to instantiate `NexusFs` with a mock client, add targeted read-path tests for `304 Not Modified`, `200 Content`, and stale fallback. If it does not, keep this issue focused by testing the cache boundary and avoiding a new FUSE harness.
+
+## Benchmark
+
+Add a cache-focused Criterion benchmark under `nexus-fuse/benches` that exercises:
+
+- warm 1 KiB, 10 KiB, 100 KiB, and 1 MiB reads from foyer
+- churn across more keys than the DRAM tier can retain
+- mixed hit/miss workload with ETag-shaped records
+
+For the acceptance comparison, keep a minimal benchmark-only SQLite baseline that mirrors the old `FileCache` hot operations. SQLite must not remain in production cache code, but it may remain as a `dev-dependency` or benchmark-only helper until the acceptance benchmark is recorded. Compare foyer warm reads and churn against that SQLite baseline and document at least one passing criterion: 2x hit-rate on an agent-shaped churn trace or 30% p99 read-latency reduction.
+
+The benchmark result and command will be recorded in `nexus-fuse/PERFORMANCE_RESULTS.md`, including machine, OS, Rust version, foyer version, tier sizes, SQLite baseline details, and the measured hit-rate or p99 latency delta.
+
+## Documentation
+
+Update `nexus-fuse/ARCHITECTURE.md` to replace SQLite cache references with foyer hybrid cache references. Update `nexus-fuse/PERFORMANCE_RESULTS.md` with the benchmark command, result, and migration note:
+
+```text
+Existing SQLite cache files under <cache-dir>/nexus-fuse/nexus_<hash>.db are dropped on upgrade.
+New cache content is stored under <cache-dir>/nexus-fuse/nexus_<hash>.foyer/.
+```
+
+## Acceptance Mapping
+
+- foyer wired into nexus-fuse hot path: `FileCache` becomes foyer-backed while `NexusFs::read_cached` continues using it.
+- DRAM tier configurable, default 256 MiB: CLI/env config passed to `FileCache`.
+- NVMe tier configurable, default 10 GiB: CLI/env config passed to foyer filesystem device capacity.
+- ETag revalidation preserved: `CacheLookup`, `touch`, and read flow remain semantically unchanged.
+- Admission filter active before flash writes: foyer storage admission/filtering enabled in the disk tier.
+- Benchmark evidence: Criterion benchmark plus documented p99 latency or hit-rate result.
+- Migration documented: startup deletes the old SQLite file and docs explain the new foyer directory.

--- a/nexus-fuse/ARCHITECTURE.md
+++ b/nexus-fuse/ARCHITECTURE.md
@@ -23,7 +23,7 @@ Python orchestrates Rust FUSE daemon via Unix socket IPC for 10-100x performance
 │  │  - Unix socket server (/tmp/nexus-fuse.sock)     │       │
 │  │  - Hot path operations (read, write, list, etc)  │       │
 │  │  - HTTP client to Nexus server                   │       │
-│  │  - SQLite cache (persistent)                     │       │
+│  │  - Foyer hybrid cache (DRAM + filesystem tier)   │       │
 │  │  - No permission checks (trusts Python layer)    │       │
 │  └────────────────┬─────────────────────────────────┘       │
 │                   │ HTTPS                                    │
@@ -47,7 +47,7 @@ Python orchestrates Rust FUSE daemon via Unix socket IPC for 10-100x performance
 - Accept JSON-RPC commands from Python
 - Execute NexusClient operations (read, write, list, stat, etc.)
 - Return results as JSON-RPC responses
-- Maintain persistent SQLite cache
+- Maintain foyer-backed file-content cache with ETag revalidation
 - Handle errors and map to errno
 
 **Does NOT handle:**
@@ -199,7 +199,7 @@ class NexusFUSEOperations:
 **Why faster:**
 - No GIL contention (Rust is native, Python uses GIL for I/O)
 - Async I/O (tokio vs synchronous blocking)
-- Persistent cache (SQLite vs in-memory)
+- Persistent hybrid cache (foyer DRAM tier plus filesystem tier)
 - Compiled native code vs interpreted Python
 
 ## Fallback Strategy

--- a/nexus-fuse/Cargo.lock
+++ b/nexus-fuse/Cargo.lock
@@ -148,6 +148,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -173,9 +182,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.2.61"
+version = "1.2.62"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d16d90359e986641506914ba71350897565610e87ce0ad9e6f28569db3dd5c6d"
+checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
@@ -285,6 +294,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "cmsketch"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7ee2cfacbd29706479902b06d75ad8f1362900836aa32799eabc7e004bfd854"
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -326,6 +341,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
+name = "core_affinity"
+version = "0.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a034b3a7b624016c6e13f5df875747cc25f884156aad2abd12b6c46797971342"
+dependencies = [
+ "libc",
+ "num_cpus",
+ "winapi",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -337,7 +363,7 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
- "itertools",
+ "itertools 0.13.0",
  "num-traits",
  "oorandom",
  "page_size",
@@ -357,7 +383,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d8d80a2f4f5b554395e47b5d8305bc3d27813bacb73493eb1001e8f76dae29ea"
 dependencies = [
  "cast",
- "itertools",
+ "itertools 0.13.0",
 ]
 
 [[package]]
@@ -487,6 +513,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
+name = "fastant"
+version = "0.1.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2e825441bfb2d831c47c97d05821552db8832479f44c571b97fededbf0099c07"
+dependencies = [
+ "small_ctor",
+ "web-time",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -497,6 +539,12 @@ name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
+
+[[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
 
 [[package]]
 name = "foldhash"
@@ -511,6 +559,127 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
+]
+
+[[package]]
+name = "foyer"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b0abc0b87814989efa711f9becd9f26969820e2d3905db27d10969c4bd45890"
+dependencies = [
+ "anyhow",
+ "equivalent",
+ "foyer-common",
+ "foyer-memory",
+ "foyer-storage",
+ "foyer-tokio",
+ "futures-util",
+ "mea",
+ "mixtrics",
+ "pin-project",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "foyer-common"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3db80d5dece93adb7ad709c84578794724a9cba342a7e566c3551c7ec626789"
+dependencies = [
+ "anyhow",
+ "bytes",
+ "cfg-if",
+ "foyer-tokio",
+ "mixtrics",
+ "parking_lot",
+ "pin-project",
+ "twox-hash",
+]
+
+[[package]]
+name = "foyer-intrusive-collections"
+version = "0.10.0-dev"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6e4fee46bea69e0596130e3210e65d3424e0ac1e6df3bde6636304bdf1ca4a3b"
+dependencies = [
+ "memoffset",
+]
+
+[[package]]
+name = "foyer-memory"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db907f40a527ca2aa2f40a5f68b32ea58aa70f050cd233518e9ffd402cfba6ce"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "cmsketch",
+ "equivalent",
+ "foyer-common",
+ "foyer-intrusive-collections",
+ "foyer-tokio",
+ "futures-util",
+ "hashbrown 0.16.1",
+ "itertools 0.14.0",
+ "mea",
+ "mixtrics",
+ "parking_lot",
+ "paste",
+ "pin-project",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "foyer-storage"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1983f1db3d0710e9c9d5fc116d9202dccd41a2d1e032572224f1aff5520aa958"
+dependencies = [
+ "allocator-api2",
+ "anyhow",
+ "bytes",
+ "core_affinity",
+ "equivalent",
+ "fastant",
+ "foyer-common",
+ "foyer-memory",
+ "foyer-tokio",
+ "fs4",
+ "futures-core",
+ "futures-util",
+ "hashbrown 0.16.1",
+ "io-uring",
+ "itertools 0.14.0",
+ "libc",
+ "lz4",
+ "mea",
+ "parking_lot",
+ "pin-project",
+ "rand",
+ "tracing",
+ "twox-hash",
+ "zstd",
+]
+
+[[package]]
+name = "foyer-tokio"
+version = "0.22.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6577b05a7ffad0db555aedf00bfe52af818220fc4c1c3a7a12520896fc38627"
+dependencies = [
+ "tokio",
+]
+
+[[package]]
+name = "fs4"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8640e34b88f7652208ce9e88b1a37a2ae95227d84abec377ccd3c5cfeb141ed4"
+dependencies = [
+ "rustix",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -610,9 +779,22 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi",
+ "r-efi 5.3.0",
  "wasip2",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0de51e6874e94e7bf76d726fc5d13ba782deca734ff60d5bb2fb2607c7406555"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi 6.0.0",
+ "wasip2",
+ "wasip3",
 ]
 
 [[package]]
@@ -647,22 +829,33 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
+version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
 dependencies = [
- "foldhash",
+ "foldhash 0.1.5",
 ]
 
 [[package]]
 name = "hashbrown"
-version = "0.17.0"
+version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
 dependencies = [
  "allocator-api2",
  "equivalent",
- "foldhash",
+ "foldhash 0.2.0",
+]
+
+[[package]]
+name = "hashbrown"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
 ]
 
 [[package]]
@@ -679,6 +872,12 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "http"
@@ -892,6 +1091,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "id-arena"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -919,7 +1124,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d466e9454f08e4a911e14806c24e16fba1b4c121d1ea474396f396069cf949d9"
 dependencies = [
  "equivalent",
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
+ "serde",
+ "serde_core",
+]
+
+[[package]]
+name = "io-uring"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d09b98f7eace8982db770e4408e7470b028ce513ac28fecdc6bf4c30fe92b62"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
 ]
 
 [[package]]
@@ -939,6 +1157,15 @@ name = "itertools"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
+name = "itertools"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
 dependencies = [
  "either",
 ]
@@ -1045,6 +1272,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "leb128fmt"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
+
+[[package]]
 name = "libc"
 version = "0.2.186"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1069,6 +1302,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "litemap"
@@ -1097,7 +1336,7 @@ version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a860605968fce16869fd239cf4237a82f3ac470723415db603b0e8b6c8d4fb9"
 dependencies = [
- "hashbrown 0.17.0",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -1105,6 +1344,34 @@ name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "lz4"
+version = "1.28.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a20b523e860d03443e98350ceaac5e71c6ba89aea7d960769ec3ce37f4de5af4"
+dependencies = [
+ "lz4-sys",
+]
+
+[[package]]
+name = "lz4-sys"
+version = "1.11.1+lz4-1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6bd8c0d6c6ed0cd30b3652886bb8711dc4bb01d637a68105a3d5158039b418e6"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "mea"
+version = "0.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6747f54621d156e1b47eb6b25f39a941b9fc347f98f67d25d8881ff99e8ed832"
+dependencies = [
+ "slab",
+]
 
 [[package]]
 name = "memchr"
@@ -1130,6 +1397,16 @@ dependencies = [
  "libc",
  "wasi",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "mixtrics"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb252c728b9d77c6ef9103f0c81524fa0a3d3b161d0a936295d7fbeff6e04c11"
+dependencies = [
+ "itertools 0.14.0",
+ "parking_lot",
 ]
 
 [[package]]
@@ -1163,11 +1440,13 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "base64",
+ "bincode",
  "chrono",
  "clap",
  "criterion",
  "dirs",
  "env_logger",
+ "foyer",
  "fuser",
  "libc",
  "log",
@@ -1177,6 +1456,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "tempfile",
  "thiserror",
  "tokio",
  "url",
@@ -1203,6 +1483,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -1291,10 +1581,36 @@ dependencies = [
 ]
 
 [[package]]
+name = "paste"
+version = "1.0.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+
+[[package]]
+name = "pin-project"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbf0d9e68100b3a7989b4901972f265cd542e560a3a8a724e1e20322f4d06ce9"
+dependencies = [
+ "pin-project-internal",
+]
+
+[[package]]
+name = "pin-project-internal"
+version = "1.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a990e22f43e84855daf260dded30524ef4a9021cc7541c26540500a50b624389"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "pin-project-lite"
@@ -1367,6 +1683,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
 dependencies = [
  "zerocopy",
+]
+
+[[package]]
+name = "prettyplease"
+version = "0.2.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+dependencies = [
+ "proc-macro2",
+ "syn",
 ]
 
 [[package]]
@@ -1457,6 +1783,12 @@ name = "r-efi"
 version = "5.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
+name = "r-efi"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
 name = "rand"
@@ -1667,6 +1999,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfcb3a22ef46e85b45de6ee7e79d063319ebb6594faafcf1c225ea92ab6e9b92"
 dependencies = [
  "semver",
+]
+
+[[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1909,6 +2254,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
 
 [[package]]
+name = "small_ctor"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88414a5ca1f85d82cc34471e975f0f74f6aa54c40f062efa42c0080e7f763f81"
+
+[[package]]
 name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1986,6 +2337,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "2.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2042,9 +2406,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.52.2"
+version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "110a78583f19d5cdb2c5ccf321d1290344e71313c6c37d43520d386027d18386"
+checksum = "8fc7f01b389ac15039e4dc9531aa973a135d7a4135281b12d7c1bc79fd57fffe"
 dependencies = [
  "bytes",
  "libc",
@@ -2173,7 +2537,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
+ "tracing-attributes",
  "tracing-core",
+]
+
+[[package]]
+name = "tracing-attributes"
+version = "0.1.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2192,10 +2568,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
+name = "twox-hash"
+version = "2.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ea3136b675547379c4bd395ca6b938e5ad3c3d20fad76e7fe85f9e0d011419c"
+dependencies = [
+ "rand",
+]
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
@@ -2270,7 +2661,16 @@ version = "1.0.3+wasi-0.2.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen 0.57.1",
+]
+
+[[package]]
+name = "wasip3"
+version = "0.4.0+wasi-0.3.0-rc-2026-01-06"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5428f8bf88ea5ddc08faddef2ac4a67e390b88186c703ce6dbd955e1c145aca5"
+dependencies = [
+ "wit-bindgen 0.51.0",
 ]
 
 [[package]]
@@ -2326,6 +2726,40 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4e0100b01e9f0d03189a92b96772a1fb998639d981193d7dbab487302513441"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "wasm-encoder"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "990065f2fe63003fe337b932cfb5e3b80e0b4d0f5ff650e6985b1048f62c8319"
+dependencies = [
+ "leb128fmt",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasm-metadata"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
+dependencies = [
+ "anyhow",
+ "indexmap",
+ "wasm-encoder",
+ "wasmparser",
+]
+
+[[package]]
+name = "wasmparser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
+dependencies = [
+ "bitflags",
+ "hashbrown 0.15.5",
+ "indexmap",
+ "semver",
 ]
 
 [[package]]
@@ -2452,6 +2886,15 @@ name = "windows-sys"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.59.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
 dependencies = [
  "windows-targets 0.52.6",
 ]
@@ -2614,9 +3057,97 @@ dependencies = [
 
 [[package]]
 name = "wit-bindgen"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+dependencies = [
+ "wit-bindgen-rust-macro",
+]
+
+[[package]]
+name = "wit-bindgen"
 version = "0.57.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
+
+[[package]]
+name = "wit-bindgen-core"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea61de684c3ea68cb082b7a88508a8b27fcc8b797d738bfc99a82facf1d752dc"
+dependencies = [
+ "anyhow",
+ "heck",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-bindgen-rust"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
+dependencies = [
+ "anyhow",
+ "heck",
+ "indexmap",
+ "prettyplease",
+ "syn",
+ "wasm-metadata",
+ "wit-bindgen-core",
+ "wit-component",
+]
+
+[[package]]
+name = "wit-bindgen-rust-macro"
+version = "0.51.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c0f9bfd77e6a48eccf51359e3ae77140a7f50b1e2ebfe62422d8afdaffab17a"
+dependencies = [
+ "anyhow",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "wit-bindgen-core",
+ "wit-bindgen-rust",
+]
+
+[[package]]
+name = "wit-component"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
+dependencies = [
+ "anyhow",
+ "bitflags",
+ "indexmap",
+ "log",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "wasm-encoder",
+ "wasm-metadata",
+ "wasmparser",
+ "wit-parser",
+]
+
+[[package]]
+name = "wit-parser"
+version = "0.244.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
+dependencies = [
+ "anyhow",
+ "id-arena",
+ "indexmap",
+ "log",
+ "semver",
+ "serde",
+ "serde_derive",
+ "serde_json",
+ "unicode-xid",
+ "wasmparser",
+]
 
 [[package]]
 name = "writeable"
@@ -2732,3 +3263,31 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zstd"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e91ee311a569c327171651566e07972200e76fcfe2242a4fa446149a3881c08a"
+dependencies = [
+ "zstd-safe",
+]
+
+[[package]]
+name = "zstd-safe"
+version = "7.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f49c4d5f0abb602a93fb8736af2a4f4dd9512e36f7f570d66e65ff867ed3b9d"
+dependencies = [
+ "zstd-sys",
+]
+
+[[package]]
+name = "zstd-sys"
+version = "2.0.16+zstd.1.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+dependencies = [
+ "cc",
+ "pkg-config",
+]

--- a/nexus-fuse/Cargo.toml
+++ b/nexus-fuse/Cargo.toml
@@ -34,8 +34,11 @@ thiserror = "2"
 # Base64 for content encoding
 base64 = "0.22"
 
-# SQLite for persistent caching
-rusqlite = { version = "0.39", features = ["bundled"] }
+# Hybrid DRAM + filesystem cache for file content
+foyer = "0.22.3"
+
+# Compact cache record encoding
+bincode = "1.3"
 
 # Home directory for cache location
 dirs = "6"
@@ -62,6 +65,12 @@ tokio = { version = "1", features = ["rt", "macros"] }
 # URL parsing
 url = "2.5"
 
+# Temporary directories for cache tests
+tempfile = "3"
+
+# Benchmark-only baseline for issue #4053 acceptance comparison
+rusqlite = { version = "0.39", features = ["bundled"] }
+
 # Test coverage (optional, for CI)
 # Run with: cargo tarpaulin --out Html
 # Or: cargo llvm-cov --html
@@ -71,6 +80,10 @@ criterion = "0.8"
 
 [[bench]]
 name = "fuse_operations"
+harness = false
+
+[[bench]]
+name = "cache_backends"
 harness = false
 
 [profile.release]

--- a/nexus-fuse/PERFORMANCE_RESULTS.md
+++ b/nexus-fuse/PERFORMANCE_RESULTS.md
@@ -21,6 +21,50 @@ uv run nexus serve --port 2026 --api-key sk-test-key-123 --auth-type static &
 open target/criterion/report/index.html
 ```
 
+## Issue #4053 Foyer Cache Benchmark
+
+This section records the cache-backend benchmark used to validate replacing the
+old SQLite file-content cache with the foyer hybrid cache.
+
+**Command:**
+```bash
+cd nexus-fuse && cargo bench --bench cache_backends
+```
+
+**Environment:**
+- Date: 2026-05-08 19:17:41 PDT
+- OS: Darwin KWN9VC2WN4 25.3.0 arm64
+- Rust: rustc 1.95.0 (59807616e 2026-04-14)
+- Foyer: 0.22.3
+
+**Benchmark setup:**
+- Warm reads: 32 MiB foyer DRAM tier, 256 MiB filesystem tier
+- Agent churn trace: 192 objects, 32-object hot set, 64 KiB/object, 2 MiB foyer DRAM tier, 256 MiB filesystem tier
+- SQLite baseline: benchmark-only in-memory table with the same path/content/ETag shape
+- No live Nexus server is required
+
+The p99 values below are computed from Criterion's per-sample operation times
+(`sample.json` sample time divided by sample iterations).
+
+| Workload | Foyer mean | SQLite mean | Mean delta | Foyer p99 sample/op | SQLite p99 sample/op | p99 delta |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Warm read, 1 KiB | 215.6 ns | 1.09 us | 80.1% faster | 222.1 ns | 1.16 us | 80.8% faster |
+| Warm read, 10 KiB | 325.9 ns | 1.54 us | 78.8% faster | 355.3 ns | 1.77 us | 80.0% faster |
+| Warm read, 100 KiB | 2.27 us | 8.27 us | 72.6% faster | 3.14 us | 9.90 us | 68.3% faster |
+| Warm read, 1 MiB | 21.65 us | 85.55 us | 74.7% faster | 45.87 us | 119.59 us | 61.6% faster |
+| Agent churn trace | 27.43 us | 7.28 us | 276.7% slower | 34.01 us | 8.39 us | 305.4% slower |
+
+Acceptance criterion met: the warm-read cache hot path shows at least 61.6%
+p99 read-latency reduction versus the SQLite baseline, exceeding the 30%
+target. The churn trace intentionally exceeds the foyer DRAM hot set and is
+kept as visibility into filesystem-tier behavior; it is not the passing
+criterion for this run.
+
+Existing SQLite cache files under the nexus-fuse cache root are dropped on
+cache startup, including legacy sanitized URL names like `http___host_2026.db`
+and hash names like `nexus_HASH.db`. New foyer cache content is stored under a
+sibling `nexus_HASH.foyer/` directory.
+
 ## Expected vs Actual Performance
 
 ### Startup Latency
@@ -120,9 +164,9 @@ ps aux | grep nexus-fuse
    - Python: Blocking I/O with thread pools
    - Rust: Tokio async runtime (epoll/kqueue)
 
-3. **Persistent Cache**
+3. **Persistent Hybrid Cache**
    - Python: In-memory dict (process lifetime)
-   - Rust: SQLite (persistent across restarts)
+   - Rust: Foyer DRAM tier plus filesystem tier
 
 4. **Zero-Copy Operations**
    - Python: Multiple object allocations per operation

--- a/nexus-fuse/benches/cache_backends.rs
+++ b/nexus-fuse/benches/cache_backends.rs
@@ -1,0 +1,201 @@
+//! Benchmark-only comparison between the foyer-backed file cache and a small
+//! in-memory SQLite baseline.
+//!
+//! Run with: cargo bench --bench cache_backends
+
+use criterion::{
+    black_box, criterion_group, criterion_main, BatchSize, BenchmarkId, Criterion, Throughput,
+};
+use nexus_fuse::cache::{CacheConfig, CacheLookup, FileCache, MAX_FILE_SIZE};
+use rusqlite::{params, Connection, OptionalExtension};
+use std::path::PathBuf;
+use std::time::Duration;
+
+struct SqliteBaseline {
+    conn: Connection,
+}
+
+impl SqliteBaseline {
+    fn new() -> Self {
+        let conn = Connection::open_in_memory().expect("sqlite in-memory cache opens");
+        conn.execute_batch(
+            "CREATE TABLE file_cache (
+                path TEXT PRIMARY KEY NOT NULL,
+                content BLOB NOT NULL,
+                etag TEXT
+            );",
+        )
+        .expect("sqlite cache table is created");
+        Self { conn }
+    }
+
+    fn put(&self, path: &str, content: &[u8], etag: Option<&str>) {
+        self.conn
+            .execute(
+                "INSERT INTO file_cache(path, content, etag)
+                 VALUES (?1, ?2, ?3)
+                 ON CONFLICT(path) DO UPDATE SET
+                    content = excluded.content,
+                    etag = excluded.etag",
+                params![path, content, etag],
+            )
+            .expect("sqlite cache put succeeds");
+    }
+
+    fn get(&self, path: &str) -> Option<Vec<u8>> {
+        self.conn
+            .query_row(
+                "SELECT content FROM file_cache WHERE path = ?1",
+                params![path],
+                |row| row.get(0),
+            )
+            .optional()
+            .expect("sqlite cache get succeeds")
+    }
+}
+
+fn kept_tempdir_path() -> PathBuf {
+    let dir = tempfile::tempdir().expect("temporary cache directory is created");
+    let path = dir.path().to_path_buf();
+    std::mem::forget(dir);
+    path
+}
+
+fn foyer_cache(label: &str, memory_bytes: usize) -> FileCache {
+    let dir = kept_tempdir_path();
+    let config = CacheConfig::new(dir, memory_bytes, 256 * 1024 * 1024, MAX_FILE_SIZE)
+        .expect("foyer cache config is valid");
+    FileCache::new_with_config(&format!("http://bench-{label}.test"), config)
+        .expect("foyer cache opens")
+}
+
+fn payload(size: usize) -> Vec<u8> {
+    (0..size).map(|idx| (idx % 251) as u8).collect()
+}
+
+fn expect_foyer_hit(cache: &FileCache, path: &str) -> Vec<u8> {
+    match cache.get(path, 0) {
+        CacheLookup::Hit(entry) => entry.content,
+        CacheLookup::NeedsRevalidation { .. } => panic!("foyer entry unexpectedly stale"),
+        CacheLookup::Miss => panic!("foyer entry unexpectedly missing"),
+    }
+}
+
+fn bench_warm_reads(c: &mut Criterion) {
+    let mut group = c.benchmark_group("cache_warm_reads");
+
+    for (label, size) in [
+        ("1kib", 1024),
+        ("10kib", 10 * 1024),
+        ("100kib", 100 * 1024),
+        ("1mib", 1024 * 1024),
+    ] {
+        let path = format!("/warm/{label}.bin");
+        let content = payload(size);
+        let foyer = foyer_cache(&format!("warm-{label}"), 32 * 1024 * 1024);
+        let sqlite = SqliteBaseline::new();
+
+        foyer.put(&path, &content, Some("warm-etag"), 0);
+        sqlite.put(&path, &content, Some("warm-etag"));
+
+        group.throughput(Throughput::Bytes(size as u64));
+        group.bench_with_input(
+            BenchmarkId::new("foyer_warm_read", label),
+            &path,
+            |b, path| {
+                b.iter(|| {
+                    let content = expect_foyer_hit(&foyer, black_box(path));
+                    black_box(content);
+                });
+            },
+        );
+        group.bench_with_input(
+            BenchmarkId::new("sqlite_warm_read", label),
+            &path,
+            |b, path| {
+                b.iter(|| {
+                    let content = sqlite.get(black_box(path)).expect("sqlite warm hit");
+                    black_box(content);
+                });
+            },
+        );
+    }
+
+    group.finish();
+}
+
+fn bench_agent_churn(c: &mut Criterion) {
+    const OBJECTS: usize = 192;
+    const HOT_SET: usize = 32;
+    const OBJECT_SIZE: usize = 64 * 1024;
+    const MEMORY_BYTES: usize = HOT_SET * OBJECT_SIZE;
+
+    let paths = (0..OBJECTS)
+        .map(|idx| format!("/agent/object-{idx:04}.bin"))
+        .collect::<Vec<_>>();
+    let content = payload(OBJECT_SIZE);
+    let foyer = foyer_cache("agent-churn", MEMORY_BYTES);
+    let sqlite = SqliteBaseline::new();
+
+    for path in &paths {
+        foyer.put(path, &content, Some("churn-etag"), 0);
+        sqlite.put(path, &content, Some("churn-etag"));
+    }
+
+    let trace = (0..4096)
+        .map(|idx| {
+            if idx % 5 == 0 {
+                (idx * 37) % OBJECTS
+            } else {
+                idx % HOT_SET
+            }
+        })
+        .collect::<Vec<_>>();
+
+    let mut group = c.benchmark_group("cache_agent_churn");
+    group.throughput(Throughput::Bytes(OBJECT_SIZE as u64));
+
+    group.bench_function("foyer_agent_churn", |b| {
+        let mut idx = 0;
+        b.iter_batched(
+            || {
+                let path = &paths[trace[idx % trace.len()]];
+                idx += 1;
+                path
+            },
+            |path| {
+                let content = expect_foyer_hit(&foyer, black_box(path));
+                black_box(content);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.bench_function("sqlite_agent_churn", |b| {
+        let mut idx = 0;
+        b.iter_batched(
+            || {
+                let path = &paths[trace[idx % trace.len()]];
+                idx += 1;
+                path
+            },
+            |path| {
+                let content = sqlite.get(black_box(path)).expect("sqlite churn hit");
+                black_box(content);
+            },
+            BatchSize::SmallInput,
+        );
+    });
+
+    group.finish();
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default()
+        .sample_size(10)
+        .warm_up_time(Duration::from_millis(500))
+        .measurement_time(Duration::from_secs(1));
+    targets = bench_warm_reads, bench_agent_churn
+}
+criterion_main!(benches);

--- a/nexus-fuse/src/cache.rs
+++ b/nexus-fuse/src/cache.rs
@@ -1,26 +1,113 @@
-//! SQLite-based persistent cache for Nexus FUSE.
+//! Foyer-backed hybrid cache for Nexus FUSE.
 //!
 //! Provides ETag-based cache invalidation to minimize network round-trips
-//! while ensuring data consistency with the Nexus server.
+//! while using a DRAM tier and filesystem-backed disk tier for hot-path reads.
 
 #![allow(dead_code)]
 
 use crate::metrics;
-use anyhow::{anyhow, Result};
-use log::{debug, error, info, warn};
-use rusqlite::{params, Connection, OptionalExtension};
-use std::path::PathBuf;
+use anyhow::{anyhow, Context, Result};
+use foyer::{
+    BlockEngineConfig, Code, DeviceBuilder, FsDeviceBuilder, HybridCache, HybridCacheBuilder,
+    StorageFilter,
+};
+use log::{debug, info, warn};
+use std::collections::HashMap;
+use std::future::Future;
+use std::hash::{Hash, Hasher};
+use std::path::{Path, PathBuf};
 use std::sync::Mutex;
 use std::time::{SystemTime, UNIX_EPOCH};
 
 /// Maximum age for cached content before forcing revalidation (1 hour).
 const MAX_CACHE_AGE_SECS: u64 = 3600;
 
-/// Maximum cache size in bytes (500 MB).
-const MAX_CACHE_SIZE: u64 = 500 * 1024 * 1024;
+/// Default DRAM cache size in bytes (256 MiB).
+pub const DEFAULT_MEMORY_CACHE_BYTES: usize = 256 * 1024 * 1024;
 
-/// Maximum file size to cache (10 MB) - larger files bypass cache.
-const MAX_FILE_SIZE: usize = 10 * 1024 * 1024;
+/// Default filesystem cache size in bytes (10 GiB).
+pub const DEFAULT_DISK_CACHE_BYTES: usize = 10 * 1024 * 1024 * 1024;
+
+/// Maximum file size to cache (10 MiB) - larger files bypass cache.
+pub const MAX_FILE_SIZE: usize = 10 * 1024 * 1024;
+
+#[derive(Debug, Clone)]
+pub struct CacheConfig {
+    pub root_dir: PathBuf,
+    pub memory_bytes: usize,
+    pub disk_bytes: usize,
+    pub max_file_size: usize,
+}
+
+impl CacheConfig {
+    pub fn new(
+        root_dir: PathBuf,
+        memory_bytes: usize,
+        disk_bytes: usize,
+        max_file_size: usize,
+    ) -> Result<Self> {
+        if memory_bytes == 0 {
+            return Err(anyhow!("memory cache size must be greater than zero"));
+        }
+        if disk_bytes == 0 {
+            return Err(anyhow!("disk cache size must be greater than zero"));
+        }
+        if max_file_size == 0 {
+            return Err(anyhow!("max file size must be greater than zero"));
+        }
+        Ok(Self {
+            root_dir,
+            memory_bytes,
+            disk_bytes,
+            max_file_size,
+        })
+    }
+}
+
+impl Default for CacheConfig {
+    fn default() -> Self {
+        let root_dir = dirs::cache_dir()
+            .unwrap_or_else(std::env::temp_dir)
+            .join("nexus-fuse");
+        Self {
+            root_dir,
+            memory_bytes: DEFAULT_MEMORY_CACHE_BYTES,
+            disk_bytes: DEFAULT_DISK_CACHE_BYTES,
+            max_file_size: MAX_FILE_SIZE,
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct CachePaths {
+    pub foyer_dir: PathBuf,
+    pub sqlite_file: PathBuf,
+    pub legacy_sqlite_file: PathBuf,
+}
+
+impl CachePaths {
+    pub fn for_server(root_dir: &Path, server_url: &str) -> Self {
+        let hash = server_hash(server_url);
+        Self {
+            foyer_dir: root_dir.join(format!("nexus_{hash:016x}.foyer")),
+            sqlite_file: root_dir.join(format!("nexus_{hash:016x}.db")),
+            legacy_sqlite_file: root_dir.join(format!("{}.db", legacy_server_filename(server_url))),
+        }
+    }
+}
+
+fn server_hash(server_url: &str) -> u64 {
+    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+    server_url.hash(&mut hasher);
+    hasher.finish()
+}
+
+fn legacy_server_filename(server_url: &str) -> String {
+    server_url
+        .chars()
+        .map(|c| if c.is_alphanumeric() { c } else { '_' })
+        .collect()
+}
 
 /// Cache entry for file content.
 #[derive(Debug, Clone)]
@@ -41,101 +128,185 @@ pub enum CacheLookup {
     Miss,
 }
 
-/// Persistent SQLite cache for file content and metadata.
+#[derive(Debug, Clone)]
+struct CacheRecord {
+    content: Vec<u8>,
+    etag: Option<String>,
+    gen: u64,
+    cached_at_secs: u64,
+}
+
+impl Code for CacheRecord {
+    fn encode(&self, writer: &mut impl std::io::Write) -> foyer::Result<()> {
+        self.content.encode(writer)?;
+        self.etag.is_some().encode(writer)?;
+        if let Some(etag) = &self.etag {
+            etag.encode(writer)?;
+        }
+        self.gen.encode(writer)?;
+        self.cached_at_secs.encode(writer)
+    }
+
+    fn decode(reader: &mut impl std::io::Read) -> foyer::Result<Self> {
+        let content = Vec::<u8>::decode(reader)?;
+        let etag = if bool::decode(reader)? {
+            Some(String::decode(reader)?)
+        } else {
+            None
+        };
+        let gen = u64::decode(reader)?;
+        let cached_at_secs = u64::decode(reader)?;
+        Ok(Self {
+            content,
+            etag,
+            gen,
+            cached_at_secs,
+        })
+    }
+
+    fn estimated_size(&self) -> usize {
+        std::mem::size_of::<u64>() * 2
+            + std::mem::size_of::<bool>()
+            + std::mem::size_of::<usize>()
+            + self.content.len()
+            + self
+                .etag
+                .as_ref()
+                .map_or(0, |etag| std::mem::size_of::<usize>() + etag.len())
+    }
+}
+
+#[derive(Debug, Clone)]
+struct CacheMeta {
+    etag: Option<String>,
+    gen: u64,
+    cached_at_secs: u64,
+    size: usize,
+}
+
 pub struct FileCache {
-    conn: Mutex<Connection>,
+    cache: HybridCache<String, CacheRecord>,
+    runtime: CacheRuntime,
+    metadata: Mutex<HashMap<String, CacheMeta>>,
+    config: CacheConfig,
+}
+
+struct CacheRuntime {
+    runtime: Option<tokio::runtime::Runtime>,
+}
+
+impl CacheRuntime {
+    fn new(runtime: tokio::runtime::Runtime) -> Self {
+        Self {
+            runtime: Some(runtime),
+        }
+    }
+
+    fn get(&self) -> &tokio::runtime::Runtime {
+        self.runtime
+            .as_ref()
+            .expect("cache runtime must exist while FileCache is alive")
+    }
+}
+
+impl Drop for CacheRuntime {
+    fn drop(&mut self) {
+        let Some(runtime) = self.runtime.take() else {
+            return;
+        };
+
+        if tokio::runtime::Handle::try_current().is_ok() {
+            std::thread::spawn(move || drop(runtime))
+                .join()
+                .expect("foyer cache runtime drop thread panicked");
+        } else {
+            drop(runtime);
+        }
+    }
+}
+
+fn block_on_foyer<Fut, T>(runtime: &tokio::runtime::Runtime, future: Fut) -> T
+where
+    Fut: Future<Output = T> + Send + 'static,
+    T: Send + 'static,
+{
+    let handle = runtime.handle().clone();
+    if tokio::runtime::Handle::try_current().is_ok() {
+        std::thread::spawn(move || handle.block_on(future))
+            .join()
+            .expect("foyer cache runtime thread panicked")
+    } else {
+        runtime.block_on(future)
+    }
 }
 
 impl FileCache {
-    /// Initialise a cache from an already-opened SQLite connection.
-    fn open_connection(conn: Connection) -> Result<Self> {
-        // Configure SQLite for performance
-        conn.execute_batch(
-            "
-            PRAGMA journal_mode = WAL;
-            PRAGMA synchronous = NORMAL;
-            PRAGMA cache_size = -64000;  -- 64MB cache
-            PRAGMA temp_store = MEMORY;
-            ",
-        )?;
+    pub fn new(server_url: &str) -> Result<Self> {
+        Self::new_with_config(server_url, CacheConfig::default())
+    }
 
-        // Create tables
-        conn.execute_batch(
-            "
-            CREATE TABLE IF NOT EXISTS file_cache (
-                path TEXT PRIMARY KEY,
-                content BLOB NOT NULL,
-                etag TEXT,
-                size INTEGER NOT NULL,
-                gen INTEGER NOT NULL DEFAULT 0,
-                cached_at INTEGER NOT NULL
-            );
+    pub fn new_with_config(server_url: &str, config: CacheConfig) -> Result<Self> {
+        std::fs::create_dir_all(&config.root_dir).with_context(|| {
+            format!("failed to create cache root {}", config.root_dir.display())
+        })?;
 
-            CREATE TABLE IF NOT EXISTS metadata_cache (
-                path TEXT PRIMARY KEY,
-                is_dir INTEGER NOT NULL,
-                size INTEGER NOT NULL,
-                entry_type TEXT NOT NULL,
-                cached_at INTEGER NOT NULL
-            );
+        let paths = CachePaths::for_server(&config.root_dir, server_url);
+        migrate_sqlite_file(&paths.sqlite_file);
+        if paths.legacy_sqlite_file != paths.sqlite_file {
+            migrate_sqlite_file(&paths.legacy_sqlite_file);
+        }
+        std::fs::create_dir_all(&paths.foyer_dir).with_context(|| {
+            format!(
+                "failed to create foyer cache dir {}",
+                paths.foyer_dir.display()
+            )
+        })?;
 
-            CREATE INDEX IF NOT EXISTS idx_file_cache_cached_at ON file_cache(cached_at);
-            CREATE INDEX IF NOT EXISTS idx_file_cache_size ON file_cache(size);
-            ",
-        )?;
-        let _ = conn.execute(
-            "ALTER TABLE file_cache ADD COLUMN gen INTEGER NOT NULL DEFAULT 0",
-            [],
+        info!(
+            "Opening foyer cache at: {} (memory={} MB, disk={} GB)",
+            paths.foyer_dir.display(),
+            config.memory_bytes / 1024 / 1024,
+            config.disk_bytes / 1024 / 1024 / 1024,
         );
 
-        let cache = Self {
-            conn: Mutex::new(conn),
-        };
+        let runtime = tokio::runtime::Builder::new_multi_thread()
+            .enable_all()
+            .thread_name("nexus-fuse-cache")
+            .worker_threads(2)
+            .build()
+            .context("failed to create foyer cache runtime")?;
 
-        // Cleanup old entries on startup
-        if let Err(e) = cache.cleanup() {
-            warn!("Cache cleanup failed: {}", e);
-        }
+        let foyer_dir = paths.foyer_dir.clone();
+        let disk_bytes = config.disk_bytes;
+        let memory_bytes = config.memory_bytes;
+        let cache = block_on_foyer(&runtime, async move {
+            let device = FsDeviceBuilder::new(&foyer_dir)
+                .with_capacity(disk_bytes)
+                .build()?;
 
-        Ok(cache)
+            let cache = HybridCacheBuilder::new()
+                .with_name("nexus-fuse-file-cache")
+                .with_flush_on_close(true)
+                .memory(memory_bytes)
+                .with_weighter(|_key, value: &CacheRecord| value.estimated_size().max(1))
+                .storage()
+                .with_engine_config(
+                    BlockEngineConfig::new(device).with_admission_filter(StorageFilter::new()),
+                )
+                .build()
+                .await?;
+
+            Ok::<HybridCache<String, CacheRecord>, foyer::Error>(cache)
+        })?;
+
+        Ok(Self {
+            cache,
+            runtime: CacheRuntime::new(runtime),
+            metadata: Mutex::new(HashMap::new()),
+            config,
+        })
     }
 
-    /// Create or open a cache database.
-    pub fn new(server_url: &str) -> Result<Self> {
-        let cache_path = Self::cache_path(server_url)?;
-
-        // Ensure cache directory exists
-        if let Some(parent) = cache_path.parent() {
-            std::fs::create_dir_all(parent)?;
-        }
-
-        info!("Opening cache at: {}", cache_path.display());
-
-        let conn = Connection::open(&cache_path)?;
-        Self::open_connection(conn)
-    }
-
-    /// Get cache file path based on server URL.
-    ///
-    /// Uses a hash-based filename (Issue 19A) instead of lossy URL sanitization
-    /// which could collide for URLs differing only in special characters
-    /// (e.g. `http://a:8080` vs `http://a/8080` both became `http___a_8080`).
-    fn cache_path(server_url: &str) -> Result<PathBuf> {
-        use std::collections::hash_map::DefaultHasher;
-        use std::hash::{Hash, Hasher};
-
-        let cache_dir = dirs::cache_dir()
-            .ok_or_else(|| anyhow!("Could not determine cache directory"))?
-            .join("nexus-fuse");
-
-        let mut hasher = DefaultHasher::new();
-        server_url.hash(&mut hasher);
-        let hash = hasher.finish();
-
-        Ok(cache_dir.join(format!("nexus_{:016x}.db", hash)))
-    }
-
-    /// Get current timestamp.
     fn now() -> u64 {
         SystemTime::now()
             .duration_since(UNIX_EPOCH)
@@ -143,284 +314,278 @@ impl FileCache {
             .unwrap_or(0)
     }
 
-    #[cfg(test)]
-    pub(crate) fn open_in_memory_for_tests() -> Self {
-        let conn = Connection::open_in_memory().unwrap();
-        Self::open_connection(conn).unwrap()
+    fn update_metadata(&self, path: &str, record: &CacheRecord) {
+        if let Ok(mut metadata) = self.metadata.lock() {
+            metadata.insert(
+                path.to_string(),
+                CacheMeta {
+                    etag: record.etag.clone(),
+                    gen: record.gen,
+                    cached_at_secs: record.cached_at_secs,
+                    size: record.content.len(),
+                },
+            );
+        }
     }
 
-    #[cfg(test)]
-    pub(crate) fn set_cached_at_for_tests(&self, path: &str, cached_at: u64) {
-        let conn = self.conn.lock().unwrap();
-        conn.execute(
-            "UPDATE file_cache SET cached_at = ? WHERE path = ?",
-            params![cached_at as i64, path],
-        )
-        .unwrap();
+    fn remove_metadata(&self, path: &str) {
+        if let Ok(mut metadata) = self.metadata.lock() {
+            metadata.remove(path);
+        }
     }
 
-    /// Look up a file in the cache using two-phase metadata-first query (Issue 16A).
-    ///
-    /// Phase 1: Query only lightweight metadata (etag, cached_at) to determine
-    ///          freshness without deserializing the (potentially large) BLOB.
-    /// Phase 2: Only fetch content if the entry is fresh; stale entries with an
-    ///          etag return NeedsRevalidation without touching the BLOB column.
+    fn read_record(&self, path: &str) -> Option<CacheRecord> {
+        if let Some(entry) = self.cache.memory().get(path) {
+            let record = entry.value().clone();
+            self.update_metadata(path, &record);
+            return Some(record);
+        }
+
+        let key = path.to_string();
+        let cache = self.cache.clone();
+        match block_on_foyer(self.runtime.get(), async move { cache.get(&key).await }) {
+            Ok(Some(entry)) => {
+                let record = entry.value().clone();
+                self.update_metadata(path, &record);
+                Some(record)
+            }
+            Ok(None) => {
+                self.remove_metadata(path);
+                None
+            }
+            Err(e) => {
+                warn!("Foyer cache read failed for {}: {}", path, e);
+                None
+            }
+        }
+    }
+
     pub fn get(&self, path: &str, gen: u64) -> CacheLookup {
-        let conn = self.conn.lock().unwrap();
         let now = Self::now();
-
-        // Phase 1: metadata-only query — avoids reading the content BLOB
-        let meta: Option<(Option<String>, i64, i64)> = conn
-            .query_row(
-                "SELECT etag, cached_at, gen FROM file_cache WHERE path = ?",
-                params![path],
-                |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?)),
-            )
-            .optional()
+        let meta = self
+            .metadata
+            .lock()
             .ok()
-            .flatten();
+            .and_then(|metadata| metadata.get(path).cloned());
 
-        match meta {
-            Some((etag, cached_at, cached_gen)) => {
-                let cached_gen = cached_gen.max(0) as u64;
-                if cached_gen != gen {
-                    debug!(
-                        "Cache generation mismatch for {} (cached={}, current={})",
-                        path, cached_gen, gen
-                    );
-                    let _ = conn.execute("DELETE FROM file_cache WHERE path = ?", params![path]);
-                    return CacheLookup::Miss;
-                }
+        if let Some(meta) = meta {
+            if meta.gen != gen {
+                debug!(
+                    "Cache generation mismatch for {} (cached={}, current={})",
+                    path, meta.gen, gen
+                );
+                metrics::record_generation_mismatch();
+                self.invalidate(path);
+                metrics::record_cache_request("dram", "miss");
+                return CacheLookup::Miss;
+            }
 
-                let age = now.saturating_sub(cached_at.max(0) as u64);
-
-                if age < MAX_CACHE_AGE_SECS {
-                    // Fresh — Phase 2: fetch content
-                    let content: Option<Vec<u8>> = conn
-                        .query_row(
-                            "SELECT content FROM file_cache WHERE path = ?",
-                            params![path],
-                            |row| row.get(0),
-                        )
-                        .optional()
-                        .ok()
-                        .flatten();
-
-                    match content {
-                        Some(content) => {
-                            debug!("Cache hit for {} (age: {}s)", path, age);
-                            metrics::record_cache_request("sqlite", "hit");
-                            CacheLookup::Hit(CacheEntry { content, etag, gen })
-                        }
-                        None => {
-                            // Shouldn't happen (metadata existed but content gone)
-                            debug!(
-                                "Cache inconsistency for {} — metadata without content",
-                                path
-                            );
-                            metrics::record_cache_request("sqlite", "miss");
-                            CacheLookup::Miss
-                        }
+            let age = now.saturating_sub(meta.cached_at_secs);
+            if age >= MAX_CACHE_AGE_SECS {
+                if meta.etag.is_some() {
+                    let Some(record) = self.read_record(path) else {
+                        debug!("Cache stale for {} but backing record is missing", path);
+                        metrics::record_cache_request("dram", "miss");
+                        return CacheLookup::Miss;
+                    };
+                    if record.gen != gen {
+                        debug!(
+                            "Cache generation mismatch for {} (cached={}, current={})",
+                            path, record.gen, gen
+                        );
+                        metrics::record_generation_mismatch();
+                        self.invalidate(path);
+                        metrics::record_cache_request("dram", "miss");
+                        return CacheLookup::Miss;
                     }
-                } else if let Some(etag) = etag {
-                    // Stale but has etag — can revalidate without fetching content
+                    let Some(etag) = record.etag else {
+                        debug!("Cache stale for {} with no etag in backing record", path);
+                        metrics::record_cache_request("dram", "miss");
+                        return CacheLookup::Miss;
+                    };
                     debug!(
                         "Cache stale for {} (age: {}s), needs revalidation",
                         path, age
                     );
-                    metrics::record_cache_request("sqlite", "stale");
-                    CacheLookup::NeedsRevalidation { etag }
-                } else {
-                    // Stale with no etag — treat as miss
-                    debug!("Cache stale for {} with no etag", path);
-                    metrics::record_cache_request("sqlite", "miss");
-                    CacheLookup::Miss
+                    metrics::record_cache_request("dram", "stale");
+                    return CacheLookup::NeedsRevalidation { etag };
                 }
-            }
-            None => {
-                debug!("Cache miss for {}", path);
-                metrics::record_cache_request("sqlite", "miss");
-                CacheLookup::Miss
+                debug!("Cache stale for {} with no etag", path);
+                metrics::record_cache_request("dram", "miss");
+                return CacheLookup::Miss;
             }
         }
+
+        let Some(record) = self.read_record(path) else {
+            metrics::record_cache_request("dram", "miss");
+            return CacheLookup::Miss;
+        };
+
+        if record.gen != gen {
+            debug!(
+                "Cache generation mismatch for {} (cached={}, current={})",
+                path, record.gen, gen
+            );
+            metrics::record_generation_mismatch();
+            self.invalidate(path);
+            metrics::record_cache_request("dram", "miss");
+            return CacheLookup::Miss;
+        }
+
+        let age = now.saturating_sub(record.cached_at_secs);
+        if age < MAX_CACHE_AGE_SECS {
+            debug!("Cache hit for {} (age: {}s)", path, age);
+            metrics::record_cache_request("dram", "hit");
+            return CacheLookup::Hit(CacheEntry {
+                content: record.content,
+                etag: record.etag,
+                gen: record.gen,
+            });
+        }
+        if let Some(etag) = record.etag {
+            metrics::record_cache_request("dram", "stale");
+            return CacheLookup::NeedsRevalidation { etag };
+        }
+        metrics::record_cache_request("dram", "miss");
+        CacheLookup::Miss
     }
 
-    /// Fetch cached content for an entry that already entered revalidation.
-    ///
-    /// This deliberately bypasses freshness checks and cache request metrics.
-    /// Use it only after `get()` returned `NeedsRevalidation`.
-    pub fn get_entry_for_revalidation(&self, path: &str) -> Option<CacheEntry> {
-        let conn = self.conn.lock().unwrap();
-
-        conn.query_row(
-            "SELECT content, etag, gen FROM file_cache WHERE path = ?",
-            params![path],
-            |row| {
-                let gen: i64 = row.get(2)?;
-                Ok(CacheEntry {
-                    content: row.get(0)?,
-                    etag: row.get(1)?,
-                    gen: gen.max(0) as u64,
-                })
-            },
-        )
-        .optional()
-        .ok()
-        .flatten()
-    }
-
-    /// Get etag for a cached file (for conditional requests).
     pub fn get_etag(&self, path: &str) -> Option<String> {
-        let conn = self.conn.lock().unwrap();
+        if let Some(etag) = self
+            .metadata
+            .lock()
+            .ok()
+            .and_then(|metadata| metadata.get(path).map(|meta| meta.etag.clone()))
+        {
+            return etag;
+        }
 
-        conn.query_row(
-            "SELECT etag FROM file_cache WHERE path = ?",
-            params![path],
-            |row| row.get(0),
-        )
-        .optional()
-        .ok()
-        .flatten()
+        self.read_record(path).and_then(|record| record.etag)
     }
 
-    /// Store file content in the cache.
-    /// Files larger than MAX_FILE_SIZE are not cached.
+    pub fn get_stale(&self, path: &str) -> Option<CacheEntry> {
+        self.read_record(path).map(|record| CacheEntry {
+            content: record.content,
+            etag: record.etag,
+            gen: record.gen,
+        })
+    }
+
     pub fn put(&self, path: &str, content: &[u8], etag: Option<&str>, gen: u64) {
-        // Skip caching large files
-        if content.len() > MAX_FILE_SIZE {
+        if content.len() > self.config.max_file_size {
             debug!(
                 "Skipping cache for {} ({} bytes > {} limit)",
                 path,
                 content.len(),
-                MAX_FILE_SIZE
+                self.config.max_file_size
             );
             return;
         }
 
-        let inserted = {
-            let conn = self.conn.lock().unwrap();
-            let now = Self::now();
+        let now = Self::now();
+        let record = CacheRecord {
+            content: content.to_vec(),
+            etag: etag.map(str::to_string),
+            gen,
+            cached_at_secs: now,
+        };
+        self.cache.insert(path.to_string(), record.clone());
+        if let Ok(mut metadata) = self.metadata.lock() {
+            metadata.insert(
+                path.to_string(),
+                CacheMeta {
+                    etag: record.etag,
+                    gen,
+                    cached_at_secs: now,
+                    size: content.len(),
+                },
+            );
+        }
+        self.stats();
+    }
 
-            let gen = i64::try_from(gen).unwrap_or(i64::MAX);
-            match conn.execute(
-                "INSERT OR REPLACE INTO file_cache (path, content, etag, size, gen, cached_at)
-                 VALUES (?, ?, ?, ?, ?, ?)",
-                params![path, content, etag, content.len() as i64, gen, now as i64],
-            ) {
-                Ok(_) => true,
-                Err(e) => {
-                    error!("Failed to cache {}: {}", path, e);
-                    false
-                }
-            }
+    pub fn touch(&self, path: &str) {
+        let Some(mut record) = self.read_record(path) else {
+            debug!("Cache touch skipped for missing entry {}", path);
+            return;
         };
 
-        if inserted {
-            debug!(
-                "Cached {} ({} bytes, etag: {:?})",
-                path,
-                content.len(),
-                etag
-            );
-            self.stats();
-        }
+        record.cached_at_secs = Self::now();
+        self.cache.insert(path.to_string(), record.clone());
+        self.update_metadata(path, &record);
     }
 
-    /// Mark a cached entry as still valid (update timestamp without re-storing content).
-    pub fn touch(&self, path: &str) {
-        let conn = self.conn.lock().unwrap();
-        let now = Self::now();
-
-        if let Err(e) = conn.execute(
-            "UPDATE file_cache SET cached_at = ? WHERE path = ?",
-            params![now as i64, path],
-        ) {
-            warn!("Failed to touch cache entry {}: {}", path, e);
-        } else {
-            debug!("Touched cache entry {}", path);
-        }
-    }
-
-    /// Invalidate a specific path.
     pub fn invalidate(&self, path: &str) {
-        {
-            let conn = self.conn.lock().unwrap();
-
-            let _ = conn.execute("DELETE FROM file_cache WHERE path = ?", params![path]);
-            let _ = conn.execute("DELETE FROM metadata_cache WHERE path = ?", params![path]);
+        self.cache.remove(path);
+        if let Ok(mut metadata) = self.metadata.lock() {
+            metadata.remove(path);
         }
-
         self.stats();
-
         debug!("Invalidated cache for {}", path);
     }
 
-    /// Cleanup old and oversized cache entries.
-    fn cleanup(&self) -> Result<()> {
-        let conn = self.conn.lock().unwrap();
-        let now = Self::now();
-        let max_age = now.saturating_sub(MAX_CACHE_AGE_SECS * 24); // 24 hours
-
-        // Delete very old entries
-        conn.execute(
-            "DELETE FROM file_cache WHERE cached_at < ?",
-            params![max_age as i64],
-        )?;
-
-        // Check total cache size
-        let total_size: i64 =
-            conn.query_row("SELECT COALESCE(SUM(size), 0) FROM file_cache", [], |row| {
-                row.get(0)
-            })?;
-        let total_size = total_size.max(0) as u64;
-
-        if total_size > MAX_CACHE_SIZE {
-            info!(
-                "Cache size {} MB exceeds limit {} MB, pruning...",
-                total_size / 1024 / 1024,
-                MAX_CACHE_SIZE / 1024 / 1024
-            );
-
-            // Delete oldest entries until under limit
-            conn.execute(
-                "DELETE FROM file_cache WHERE path IN (
-                    SELECT path FROM file_cache ORDER BY cached_at ASC
-                    LIMIT (SELECT COUNT(*) / 2 FROM file_cache)
-                )",
-                [],
-            )?;
-        }
-
-        // Cleanup metadata cache
-        conn.execute(
-            "DELETE FROM metadata_cache WHERE cached_at < ?",
-            params![max_age as i64],
-        )?;
-
-        Ok(())
-    }
-
-    /// Get cache statistics.
     pub fn stats(&self) -> CacheStats {
-        let conn = self.conn.lock().unwrap();
+        let Ok(metadata) = self.metadata.lock() else {
+            metrics::set_cache_bytes_in_use("dram", 0);
+            return CacheStats {
+                file_count: 0,
+                total_size: 0,
+            };
+        };
 
-        let file_count: i64 = conn
-            .query_row("SELECT COUNT(*) FROM file_cache", [], |row| row.get(0))
-            .unwrap_or(0);
-        let file_count = file_count.max(0) as u64;
-
-        let total_size: i64 = conn
-            .query_row("SELECT COALESCE(SUM(size), 0) FROM file_cache", [], |row| {
-                row.get(0)
-            })
-            .unwrap_or(0);
-        let total_size = total_size.max(0) as u64;
-
-        metrics::set_cache_bytes_in_use("sqlite", total_size);
+        let total_size = metadata.values().map(|meta| meta.size as u64).sum();
+        metrics::set_cache_bytes_in_use("dram", total_size);
 
         CacheStats {
-            file_count,
+            file_count: metadata.len() as u64,
             total_size,
+        }
+    }
+
+    #[cfg(test)]
+    pub(crate) fn backdate_for_test(&self, path: &str, age_secs: u64) {
+        let cached_at_secs = Self::now().saturating_sub(age_secs);
+        if let Ok(mut metadata) = self.metadata.lock() {
+            if let Some(meta) = metadata.get_mut(path) {
+                meta.cached_at_secs = cached_at_secs;
+            }
+        }
+
+        let Some(mut record) = self.read_record(path) else {
+            return;
+        };
+        record.cached_at_secs = cached_at_secs;
+        self.cache.insert(path.to_string(), record.clone());
+        self.update_metadata(path, &record);
+    }
+}
+
+impl Drop for FileCache {
+    fn drop(&mut self) {
+        let cache = self.cache.clone();
+        if let Err(e) = block_on_foyer(self.runtime.get(), async move { cache.close().await }) {
+            warn!("Failed to close foyer cache: {}", e);
+        }
+    }
+}
+
+fn migrate_sqlite_file(sqlite_file: &Path) {
+    for path in [
+        sqlite_file.to_path_buf(),
+        sqlite_file.with_extension("db-wal"),
+        sqlite_file.with_extension("db-shm"),
+    ] {
+        if !path.exists() {
+            continue;
+        }
+
+        match std::fs::remove_file(&path) {
+            Ok(()) => info!("Dropped old SQLite cache file {}", path.display()),
+            Err(e) => warn!(
+                "Failed to delete old SQLite cache file {}: {}",
+                path.display(),
+                e
+            ),
         }
     }
 }
@@ -436,10 +601,110 @@ pub struct CacheStats {
 mod tests {
     use super::*;
 
-    /// Helper: create an in-memory cache for testing (no filesystem access).
-    fn test_cache(_label: &str) -> FileCache {
-        let conn = Connection::open_in_memory().unwrap();
-        FileCache::open_connection(conn).unwrap()
+    #[test]
+    fn test_cache_config_defaults() {
+        let config = CacheConfig::default();
+        assert_eq!(config.memory_bytes, DEFAULT_MEMORY_CACHE_BYTES);
+        assert_eq!(config.disk_bytes, DEFAULT_DISK_CACHE_BYTES);
+        assert_eq!(config.max_file_size, MAX_FILE_SIZE);
+        assert!(config.root_dir.ends_with("nexus-fuse"));
+    }
+
+    #[test]
+    fn test_cache_config_rejects_zero_tiers() {
+        let root = std::env::temp_dir().join("nexus-fuse-config-test");
+        let err = CacheConfig::new(root, 0, DEFAULT_DISK_CACHE_BYTES, MAX_FILE_SIZE)
+            .expect_err("zero memory tier must be rejected");
+        assert!(err
+            .to_string()
+            .contains("memory cache size must be greater than zero"));
+
+        let root = std::env::temp_dir().join("nexus-fuse-config-test");
+        let err = CacheConfig::new(root, DEFAULT_MEMORY_CACHE_BYTES, 0, MAX_FILE_SIZE)
+            .expect_err("zero disk tier must be rejected");
+        assert!(err
+            .to_string()
+            .contains("disk cache size must be greater than zero"));
+    }
+
+    #[test]
+    fn test_cache_paths_are_stable_and_distinct() {
+        let root = std::env::temp_dir().join("nexus-fuse-path-test");
+        let a = CachePaths::for_server(&root, "http://a:8080");
+        let b = CachePaths::for_server(&root, "http://a/8080");
+
+        assert_ne!(a.foyer_dir, b.foyer_dir);
+        assert_ne!(a.sqlite_file, b.sqlite_file);
+        assert!(a
+            .foyer_dir
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .ends_with(".foyer"));
+        assert!(a
+            .sqlite_file
+            .file_name()
+            .unwrap()
+            .to_string_lossy()
+            .ends_with(".db"));
+    }
+
+    #[test]
+    fn test_old_sqlite_file_is_deleted_on_startup() {
+        let dir = tempfile::tempdir().unwrap();
+        let config = CacheConfig::new(
+            dir.path().to_path_buf(),
+            4 * 1024 * 1024,
+            32 * 1024 * 1024,
+            MAX_FILE_SIZE,
+        )
+        .unwrap();
+        let paths = CachePaths::for_server(dir.path(), "http://migration.test");
+        std::fs::write(&paths.sqlite_file, b"old sqlite cache").unwrap();
+        std::fs::write(paths.sqlite_file.with_extension("db-wal"), b"old wal").unwrap();
+        std::fs::write(paths.sqlite_file.with_extension("db-shm"), b"old shm").unwrap();
+
+        let _cache = FileCache::new_with_config("http://migration.test", config).unwrap();
+
+        assert!(!paths.sqlite_file.exists());
+        assert!(!paths.sqlite_file.with_extension("db-wal").exists());
+        assert!(!paths.sqlite_file.with_extension("db-shm").exists());
+        assert!(paths.foyer_dir.exists());
+    }
+
+    #[test]
+    fn test_legacy_sanitized_sqlite_file_is_deleted_on_startup() {
+        let dir = tempfile::tempdir().unwrap();
+        let server_url = "http://legacy.example:2026";
+        let config = CacheConfig::new(
+            dir.path().to_path_buf(),
+            4 * 1024 * 1024,
+            32 * 1024 * 1024,
+            MAX_FILE_SIZE,
+        )
+        .unwrap();
+        let legacy_file = CachePaths::for_server(dir.path(), server_url).legacy_sqlite_file;
+        std::fs::write(&legacy_file, b"old sqlite cache").unwrap();
+        std::fs::write(legacy_file.with_extension("db-wal"), b"old wal").unwrap();
+        std::fs::write(legacy_file.with_extension("db-shm"), b"old shm").unwrap();
+
+        let _cache = FileCache::new_with_config(server_url, config).unwrap();
+
+        assert!(!legacy_file.exists());
+        assert!(!legacy_file.with_extension("db-wal").exists());
+        assert!(!legacy_file.with_extension("db-shm").exists());
+    }
+
+    fn test_cache(label: &str) -> FileCache {
+        let dir = tempfile::tempdir().unwrap().keep();
+        let config = CacheConfig::new(
+            dir.join(label),
+            4 * 1024 * 1024,
+            64 * 1024 * 1024,
+            MAX_FILE_SIZE,
+        )
+        .unwrap();
+        FileCache::new_with_config(&format!("http://{label}.test"), config).unwrap()
     }
 
     fn metric_value(rendered: &str, metric: &str) -> Option<u64> {
@@ -457,10 +722,6 @@ mod tests {
             "expected {metric}{expected} or greater, got {actual}\n{rendered}"
         );
     }
-
-    // ──────────────────────────────────────────────────────
-    // 1. Basic put / get / invalidate (existing test, kept)
-    // ──────────────────────────────────────────────────────
 
     #[test]
     fn test_cache_basic() {
@@ -497,7 +758,7 @@ mod tests {
             CacheLookup::Miss
         ));
         assert_metric_at_least(
-            "nexus_cache_requests_total{tier=\"sqlite\",result=\"miss\"} ",
+            "nexus_cache_requests_total{tier=\"dram\",result=\"miss\"} ",
             1,
         );
 
@@ -507,25 +768,17 @@ mod tests {
             CacheLookup::Hit(_)
         ));
         assert_metric_at_least(
-            "nexus_cache_requests_total{tier=\"sqlite\",result=\"hit\"} ",
+            "nexus_cache_requests_total{tier=\"dram\",result=\"hit\"} ",
             1,
         );
 
-        let old_cached_at = FileCache::now().saturating_sub(MAX_CACHE_AGE_SECS + 1);
-        {
-            let conn = cache.conn.lock().unwrap();
-            conn.execute(
-                "UPDATE file_cache SET cached_at = ? WHERE path = ?",
-                params![old_cached_at as i64, "/metrics-hit.txt"],
-            )
-            .unwrap();
-        }
+        cache.backdate_for_test("/metrics-hit.txt", MAX_CACHE_AGE_SECS + 1);
         assert!(matches!(
             cache.get("/metrics-hit.txt", 0),
             CacheLookup::NeedsRevalidation { .. }
         ));
         assert_metric_at_least(
-            "nexus_cache_requests_total{tier=\"sqlite\",result=\"stale\"} ",
+            "nexus_cache_requests_total{tier=\"dram\",result=\"stale\"} ",
             1,
         );
     }
@@ -541,7 +794,7 @@ mod tests {
         assert_eq!(
             metric_value(
                 &crate::metrics::render(),
-                "nexus_cache_bytes_in_use{tier=\"sqlite\"} "
+                "nexus_cache_bytes_in_use{tier=\"dram\"} "
             ),
             Some(4)
         );
@@ -559,19 +812,14 @@ mod tests {
         assert_eq!(
             metric_value(
                 &crate::metrics::render(),
-                "nexus_cache_bytes_in_use{tier=\"sqlite\"} "
+                "nexus_cache_bytes_in_use{tier=\"dram\"} "
             ),
             Some(0)
         );
     }
 
-    // ──────────────────────────────────────────────────────
-    // 2. Put without etag → stale entries become Miss (not NeedsRevalidation)
-    // ──────────────────────────────────────────────────────
-
     #[test]
     fn test_put_without_etag() {
-        let _guard = crate::metrics::test_guard();
         let cache = test_cache("no-etag");
         cache.put("/no-etag.txt", b"data", None, 0);
 
@@ -584,13 +832,8 @@ mod tests {
         }
     }
 
-    // ──────────────────────────────────────────────────────
-    // 3. Overwrite existing entry
-    // ──────────────────────────────────────────────────────
-
     #[test]
     fn test_overwrite_entry() {
-        let _guard = crate::metrics::test_guard();
         let cache = test_cache("overwrite");
         cache.put("/f.txt", b"v1", Some("e1"), 0);
         cache.put("/f.txt", b"v2", Some("e2"), 0);
@@ -604,13 +847,8 @@ mod tests {
         }
     }
 
-    // ──────────────────────────────────────────────────────
-    // 4. get_etag returns stored etag (or None)
-    // ──────────────────────────────────────────────────────
-
     #[test]
     fn test_get_etag() {
-        let _guard = crate::metrics::test_guard();
         let cache = test_cache("etag");
         assert_eq!(cache.get_etag("/missing.txt"), None);
 
@@ -621,47 +859,99 @@ mod tests {
         assert_eq!(cache.get_etag("/no-e.txt"), None);
     }
 
-    // ──────────────────────────────────────────────────────
-    // 5. Touch refreshes timestamp (keeps entry fresh)
-    // ──────────────────────────────────────────────────────
+    #[test]
+    fn test_get_etag_reads_foyer_when_metadata_missing() {
+        let cache = test_cache("etag-fallback");
+        cache.put("/e.txt", b"x", Some("etag-42"), 0);
+        cache.metadata.lock().unwrap().clear();
+
+        assert_eq!(cache.get_etag("/e.txt"), Some("etag-42".to_string()));
+    }
 
     #[test]
-    fn test_touch_refreshes_entry() {
-        let _guard = crate::metrics::test_guard();
+    fn test_get_rebuilds_metadata_from_foyer_record() {
+        let cache = test_cache("metadata-rebuild");
+        cache.put("/e.txt", b"data", Some("etag-42"), 0);
+        cache.metadata.lock().unwrap().clear();
+
+        assert!(matches!(cache.get("/e.txt", 0), CacheLookup::Hit(_)));
+        assert_eq!(cache.get_etag("/e.txt"), Some("etag-42".to_string()));
+    }
+
+    #[test]
+    fn test_touch_refreshes_stale_entry() {
         let cache = test_cache("touch");
         cache.put("/t.txt", b"data", Some("e1"), 0);
+        cache.backdate_for_test("/t.txt", MAX_CACHE_AGE_SECS + 1);
 
-        // Touch should succeed and entry should still be a hit
         cache.touch("/t.txt");
 
         match cache.get("/t.txt", 0) {
-            CacheLookup::Hit(entry) => assert_eq!(entry.content, b"data"),
+            CacheLookup::Hit(entry) => {
+                assert_eq!(entry.content, b"data");
+                assert_eq!(entry.etag, Some("e1".to_string()));
+            }
             _ => panic!("Expected cache hit after touch"),
         }
     }
 
-    // ──────────────────────────────────────────────────────
-    // 6. Large files are NOT cached (>MAX_FILE_SIZE)
-    // ──────────────────────────────────────────────────────
+    #[test]
+    fn test_stale_entry_with_etag_needs_revalidation() {
+        let cache = test_cache("stale-etag");
+        cache.put("/stale.txt", b"data", Some("stale-etag"), 0);
+        cache.backdate_for_test("/stale.txt", MAX_CACHE_AGE_SECS + 1);
+
+        match cache.get("/stale.txt", 0) {
+            CacheLookup::NeedsRevalidation { etag } => assert_eq!(etag, "stale-etag"),
+            _ => panic!("Expected stale entry with etag to require revalidation"),
+        }
+
+        let stale = cache.get_stale("/stale.txt").expect("stale entry exists");
+        assert_eq!(stale.content, b"data");
+        assert_eq!(stale.etag, Some("stale-etag".to_string()));
+    }
+
+    #[test]
+    fn test_stale_metadata_without_foyer_record_is_miss() {
+        let cache = test_cache("stale-metadata-missing-record");
+        cache.put("/missing-record.txt", b"data", Some("stale-etag"), 0);
+
+        cache.cache.remove("/missing-record.txt");
+        {
+            let mut metadata = cache.metadata.lock().unwrap();
+            let meta = metadata
+                .get_mut("/missing-record.txt")
+                .expect("metadata should exist after put");
+            meta.cached_at_secs = FileCache::now().saturating_sub(MAX_CACHE_AGE_SECS + 1);
+        }
+
+        assert!(matches!(
+            cache.get("/missing-record.txt", 0),
+            CacheLookup::Miss
+        ));
+        assert_eq!(cache.get_etag("/missing-record.txt"), None);
+    }
+
+    #[test]
+    fn test_stale_entry_without_etag_is_miss() {
+        let cache = test_cache("stale-no-etag");
+        cache.put("/stale.txt", b"data", None, 0);
+        cache.backdate_for_test("/stale.txt", MAX_CACHE_AGE_SECS + 1);
+
+        assert!(matches!(cache.get("/stale.txt", 0), CacheLookup::Miss));
+    }
 
     #[test]
     fn test_large_file_not_cached() {
-        let _guard = crate::metrics::test_guard();
         let cache = test_cache("large");
         let big = vec![0u8; MAX_FILE_SIZE + 1];
         cache.put("/big.bin", &big, Some("e1"), 0);
 
-        // Should still be a miss — file was too large
         assert!(matches!(cache.get("/big.bin", 0), CacheLookup::Miss));
     }
 
-    // ──────────────────────────────────────────────────────
-    // 7. File exactly at MAX_FILE_SIZE IS cached
-    // ──────────────────────────────────────────────────────
-
     #[test]
     fn test_max_size_file_cached() {
-        let _guard = crate::metrics::test_guard();
         let cache = test_cache("maxsize");
         let data = vec![42u8; MAX_FILE_SIZE];
         cache.put("/exact.bin", &data, Some("e1"), 0);
@@ -672,36 +962,30 @@ mod tests {
         }
     }
 
-    // ──────────────────────────────────────────────────────
-    // 8. Stats report correct counts and sizes
-    // ──────────────────────────────────────────────────────
-
     #[test]
     fn test_cache_stats() {
         let _guard = crate::metrics::test_guard();
         let cache = test_cache("stats");
 
-        // Ensure clean slate (DB persists on disk between runs)
-        cache.invalidate("/stat-a.txt");
-        cache.invalidate("/stat-b.txt");
-        let baseline = cache.stats();
-
         cache.put("/stat-a.txt", b"aaa", Some("e1"), 0);
         cache.put("/stat-b.txt", b"bb", Some("e2"), 0);
 
         let stats = cache.stats();
-        assert_eq!(stats.file_count, baseline.file_count + 2);
-        assert_eq!(stats.total_size, baseline.total_size + 5); // 3 + 2
+        assert_eq!(stats.file_count, 2);
+        assert_eq!(stats.total_size, 5);
     }
 
     #[test]
     fn test_generation_mismatch_invalidates_cache() {
+        let _guard = crate::metrics::test_guard();
+        crate::metrics::reset_for_tests();
         let cache = test_cache("generation-mismatch");
         cache.put("/gen.txt", b"v1", Some("e1"), 1);
 
         assert!(matches!(cache.get("/gen.txt", 1), CacheLookup::Hit(_)));
         assert!(matches!(cache.get("/gen.txt", 2), CacheLookup::Miss));
         assert!(matches!(cache.get("/gen.txt", 2), CacheLookup::Miss));
+        assert_metric_at_least("nexus_generation_mismatch_total ", 1);
     }
 
     #[test]
@@ -715,13 +999,8 @@ mod tests {
         }
     }
 
-    // ──────────────────────────────────────────────────────
-    // 9. Stats after invalidation
-    // ──────────────────────────────────────────────────────
-
     #[test]
     fn test_stats_after_invalidation() {
-        let _guard = crate::metrics::test_guard();
         let cache = test_cache("stats-inv");
         cache.put("/x.txt", b"12345", None, 0);
 
@@ -736,13 +1015,8 @@ mod tests {
         assert_eq!(stats.total_size, 0);
     }
 
-    // ──────────────────────────────────────────────────────
-    // 10. Multiple paths are independent
-    // ──────────────────────────────────────────────────────
-
     #[test]
     fn test_multiple_independent_paths() {
-        let _guard = crate::metrics::test_guard();
         let cache = test_cache("multi");
         cache.put("/a.txt", b"aaa", Some("ea"), 0);
         cache.put("/b.txt", b"bbb", Some("eb"), 0);
@@ -756,13 +1030,8 @@ mod tests {
         assert!(matches!(cache.get("/c.txt", 0), CacheLookup::Hit(_)));
     }
 
-    // ──────────────────────────────────────────────────────
-    // 11. Empty content is valid and cached
-    // ──────────────────────────────────────────────────────
-
     #[test]
     fn test_empty_content_cached() {
-        let _guard = crate::metrics::test_guard();
         let cache = test_cache("empty");
         cache.put("/empty.txt", b"", Some("e0"), 0);
 
@@ -775,13 +1044,8 @@ mod tests {
         }
     }
 
-    // ──────────────────────────────────────────────────────
-    // 12. Binary content is preserved exactly
-    // ──────────────────────────────────────────────────────
-
     #[test]
     fn test_binary_content_preserved() {
-        let _guard = crate::metrics::test_guard();
         let cache = test_cache("binary");
         let binary: Vec<u8> = (0..=255).collect();
         cache.put("/bin.dat", &binary, Some("ebin"), 0);
@@ -792,13 +1056,8 @@ mod tests {
         }
     }
 
-    // ──────────────────────────────────────────────────────
-    // 13. Concurrent access doesn't panic (basic safety check)
-    // ──────────────────────────────────────────────────────
-
     #[test]
     fn test_concurrent_access() {
-        let _guard = crate::metrics::test_guard();
         use std::sync::Arc;
         use std::thread;
 
@@ -826,51 +1085,65 @@ mod tests {
         assert_eq!(stats.file_count, 8);
     }
 
-    // ──────────────────────────────────────────────────────
-    // 14. Cleanup removes very old entries
-    // ──────────────────────────────────────────────────────
-
-    #[test]
-    fn test_cleanup_removes_old_entries() {
-        let _guard = crate::metrics::test_guard();
-        let cache = test_cache("cleanup");
-
-        // Insert an entry, then manually backdate it
-        cache.put("/old.txt", b"old-data", Some("e1"), 0);
-
-        {
-            let conn = cache.conn.lock().unwrap();
-            // Set cached_at to 0 (epoch) so it's very old
-            conn.execute(
-                "UPDATE file_cache SET cached_at = 0 WHERE path = '/old.txt'",
-                [],
-            )
-            .unwrap();
-        }
-
-        // Insert a fresh entry
-        cache.put("/new.txt", b"new-data", Some("e2"), 0);
-
-        // Run cleanup — should remove the backdated entry
-        cache.cleanup().unwrap();
-
-        assert!(matches!(cache.get("/old.txt", 0), CacheLookup::Miss));
-        assert!(matches!(cache.get("/new.txt", 0), CacheLookup::Hit(_)));
-    }
-
-    // ──────────────────────────────────────────────────────
-    // 15. Invalidate on non-existent path is a no-op
-    // ──────────────────────────────────────────────────────
-
     #[test]
     fn test_invalidate_nonexistent_is_noop() {
-        let _guard = crate::metrics::test_guard();
         let cache = test_cache("inv-noop");
-        // Should not panic or error
         cache.invalidate("/does-not-exist.txt");
         assert!(matches!(
             cache.get("/does-not-exist.txt", 0),
             CacheLookup::Miss
         ));
+    }
+
+    #[tokio::test]
+    async fn test_cache_calls_inside_tokio_runtime_do_not_panic() {
+        let cache = test_cache("inside-runtime");
+        cache.put("/runtime.txt", b"data", Some("runtime-etag"), 0);
+
+        match cache.get("/runtime.txt", 0) {
+            CacheLookup::Hit(entry) => assert_eq!(entry.content, b"data"),
+            _ => panic!("Expected cache hit inside tokio runtime"),
+        }
+
+        cache.backdate_for_test("/runtime.txt", MAX_CACHE_AGE_SECS + 1);
+        assert!(matches!(
+            cache.get("/runtime.txt", 0),
+            CacheLookup::NeedsRevalidation { .. }
+        ));
+
+        let stale = cache
+            .get_stale("/runtime.txt")
+            .expect("stale entry should be readable inside runtime");
+        assert_eq!(stale.etag, Some("runtime-etag".to_string()));
+
+        cache.touch("/runtime.txt");
+        assert!(matches!(cache.get("/runtime.txt", 0), CacheLookup::Hit(_)));
+    }
+
+    #[tokio::test]
+    async fn test_cache_drop_inside_tokio_runtime_flushes_to_disk() {
+        let dir = tempfile::tempdir().unwrap().keep();
+        let config = CacheConfig::new(
+            dir.join("flush-on-drop"),
+            4 * 1024 * 1024,
+            64 * 1024 * 1024,
+            MAX_FILE_SIZE,
+        )
+        .unwrap();
+
+        {
+            let cache =
+                FileCache::new_with_config("http://flush-on-drop.test", config.clone()).unwrap();
+            cache.put("/persisted.txt", b"persisted", Some("persisted-etag"), 0);
+        }
+
+        let cache = FileCache::new_with_config("http://flush-on-drop.test", config).unwrap();
+        match cache.get("/persisted.txt", 0) {
+            CacheLookup::Hit(entry) => {
+                assert_eq!(entry.content, b"persisted");
+                assert_eq!(entry.etag, Some("persisted-etag".to_string()));
+            }
+            _ => panic!("Expected cache hit after drop and reopen"),
+        }
     }
 }

--- a/nexus-fuse/src/cached_read.rs
+++ b/nexus-fuse/src/cached_read.rs
@@ -1,0 +1,185 @@
+//! Shared read-through-cache flow for nexus-fuse mount and daemon reads.
+
+use crate::cache::{CacheLookup, FileCache};
+use crate::client::{NexusClient, ReadResponse};
+use crate::error::NexusClientError;
+use log::{debug, error};
+
+#[derive(Debug)]
+pub struct CachedReadResult {
+    pub content: Vec<u8>,
+    pub etag: Option<String>,
+    pub tier: &'static str,
+}
+
+pub fn read_with_cache(
+    client: &NexusClient,
+    cache: Option<&FileCache>,
+    path: &str,
+    gen: u64,
+) -> Result<CachedReadResult, NexusClientError> {
+    if let Some(cache) = cache {
+        match cache.get(path, gen) {
+            CacheLookup::Hit(entry) => {
+                debug!("Foyer cache hit for {}", path);
+                return Ok(CachedReadResult {
+                    content: entry.content,
+                    etag: entry.etag,
+                    tier: "cache",
+                });
+            }
+            CacheLookup::NeedsRevalidation { etag } => {
+                debug!("Revalidating cache for {} with etag {}", path, etag);
+                match client.read_with_etag(path, Some(&etag)) {
+                    Ok(ReadResponse::NotModified) => {
+                        crate::metrics::record_cache_etag_revalidate("304");
+                        crate::metrics::record_etag_check("304");
+                        cache.touch(path);
+                        if let Some(entry) = cache.get_stale(path) {
+                            return Ok(CachedReadResult {
+                                content: entry.content,
+                                etag: entry.etag,
+                                tier: "cache",
+                            });
+                        }
+                        error!("Cache inconsistency after 304 for {}", path);
+                    }
+                    Ok(ReadResponse::Content { content, etag }) => {
+                        crate::metrics::record_cache_etag_revalidate("updated");
+                        crate::metrics::record_etag_check("updated");
+                        cache.put(path, &content, etag.as_deref(), gen);
+                        return Ok(CachedReadResult {
+                            content,
+                            etag,
+                            tier: "backend",
+                        });
+                    }
+                    Err(e) => {
+                        if e.is_transient() {
+                            debug!("Revalidation failed for {}: {}, using stale cache", path, e);
+                            if let Some(entry) = cache.get_stale(path) {
+                                crate::metrics::record_cache_etag_revalidate("fallback");
+                                crate::metrics::record_etag_check("fallback");
+                                return Ok(CachedReadResult {
+                                    content: entry.content,
+                                    etag: entry.etag,
+                                    tier: "cache",
+                                });
+                            }
+                        }
+                        debug!(
+                            "Revalidation failed permanently for {}, invalidating stale cache: {}",
+                            path, e
+                        );
+                        crate::metrics::record_cache_etag_revalidate("error");
+                        crate::metrics::record_etag_check("error");
+                        cache.invalidate(path);
+                        return Err(e);
+                    }
+                }
+            }
+            CacheLookup::Miss => {}
+        }
+    }
+
+    match client.read_with_etag(path, None) {
+        Ok(ReadResponse::Content { content, etag }) => {
+            if let Some(cache) = cache {
+                cache.put(path, &content, etag.as_deref(), gen);
+            }
+            Ok(CachedReadResult {
+                content,
+                etag,
+                tier: "backend",
+            })
+        }
+        Ok(ReadResponse::NotModified) => {
+            crate::metrics::record_etag_check("unexpected_304");
+            Err(NexusClientError::InvalidResponse(
+                "Unexpected 304 response".to_string(),
+            ))
+        }
+        Err(e) => Err(e),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::cache::{CacheConfig, MAX_FILE_SIZE};
+    use mockito::Server;
+
+    fn test_cache(label: &str) -> FileCache {
+        let dir = tempfile::tempdir().unwrap().keep();
+        let config = CacheConfig::new(
+            dir.join(label),
+            4 * 1024 * 1024,
+            64 * 1024 * 1024,
+            MAX_FILE_SIZE,
+        )
+        .unwrap();
+        FileCache::new_with_config(&format!("http://{label}.test"), config).unwrap()
+    }
+
+    #[test]
+    fn not_found_revalidation_does_not_return_stale_content() {
+        let mut server = Server::new();
+        let _mock = server
+            .mock("POST", "/api/nfs/read")
+            .match_header("if-none-match", "\"stale-etag\"")
+            .with_status(404)
+            .with_body("missing")
+            .create();
+        let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+        let cache = test_cache("revalidation-not-found");
+        cache.put("/gone.txt", b"stale", Some("stale-etag"), 0);
+        cache.backdate_for_test("/gone.txt", 3601);
+
+        let err = read_with_cache(&client, Some(&cache), "/gone.txt", 0).unwrap_err();
+
+        assert!(matches!(err, NexusClientError::NotFound(_)));
+        assert!(matches!(cache.get("/gone.txt", 0), CacheLookup::Miss));
+    }
+
+    #[test]
+    fn transient_revalidation_error_returns_stale_content() {
+        let mut server = Server::new();
+        let _mock = server
+            .mock("POST", "/api/nfs/read")
+            .match_header("if-none-match", "\"stale-etag\"")
+            .with_status(503)
+            .with_body("temporarily unavailable")
+            .create();
+        let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+        let cache = test_cache("revalidation-transient");
+        cache.put("/cached.txt", b"stale", Some("stale-etag"), 0);
+        cache.backdate_for_test("/cached.txt", 3601);
+
+        let result = read_with_cache(&client, Some(&cache), "/cached.txt", 0).unwrap();
+
+        assert_eq!(result.content, b"stale");
+        assert_eq!(result.etag.as_deref(), Some("stale-etag"));
+        assert_eq!(result.tier, "cache");
+    }
+
+    #[test]
+    fn malformed_revalidation_response_does_not_return_stale_content() {
+        let mut server = Server::new();
+        let _mock = server
+            .mock("POST", "/api/nfs/read")
+            .match_header("if-none-match", "\"stale-etag\"")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body("not json")
+            .create();
+        let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+        let cache = test_cache("revalidation-malformed");
+        cache.put("/bad.txt", b"stale", Some("stale-etag"), 0);
+        cache.backdate_for_test("/bad.txt", 3601);
+
+        let err = read_with_cache(&client, Some(&cache), "/bad.txt", 0).unwrap_err();
+
+        assert!(matches!(err, NexusClientError::HttpError(_)));
+        assert!(matches!(cache.get("/bad.txt", 0), CacheLookup::Miss));
+    }
+}

--- a/nexus-fuse/src/daemon.rs
+++ b/nexus-fuse/src/daemon.rs
@@ -3,6 +3,8 @@
 //! The daemon listens on a Unix socket and accepts JSON-RPC commands from Python.
 //! This enables Python to orchestrate Rust FUSE operations for 10-100x performance.
 
+use crate::cache::FileCache;
+use crate::cached_read::read_with_cache;
 use crate::client::NexusClient;
 use crate::error::NexusClientError;
 use base64::Engine;
@@ -10,6 +12,7 @@ use log::{debug, error, info, warn};
 use serde::{Deserialize, Serialize};
 use serde_json::{json, Value};
 use std::path::PathBuf;
+use std::sync::Arc;
 use std::time::Instant;
 use tokio::io::{AsyncBufReadExt, AsyncWriteExt, BufReader};
 use tokio::net::{UnixListener, UnixStream};
@@ -18,7 +21,8 @@ use tokio::signal;
 /// JSON-RPC request from Python client.
 #[derive(Debug, Deserialize)]
 struct JsonRpcRequest {
-    jsonrpc: String,
+    #[serde(rename = "jsonrpc")]
+    _jsonrpc: String,
     id: Option<Value>,
     method: String,
     params: Value,
@@ -73,12 +77,14 @@ pub struct DaemonConfig {
     pub nexus_url: String,
     pub api_key: String,
     pub agent_id: Option<String>,
+    pub file_cache: Option<Arc<FileCache>>,
 }
 
 /// Unix socket IPC daemon.
 pub struct Daemon {
     config: DaemonConfig,
     client: NexusClient,
+    file_cache: Option<Arc<FileCache>>,
 }
 
 impl Daemon {
@@ -86,7 +92,11 @@ impl Daemon {
     pub fn new(config: DaemonConfig) -> Result<Self, NexusClientError> {
         let client = NexusClient::new(&config.nexus_url, &config.api_key, config.agent_id.clone())?;
 
-        Ok(Self { config, client })
+        Ok(Self {
+            file_cache: config.file_cache.clone(),
+            config,
+            client,
+        })
     }
 
     /// Start the daemon and listen for connections.
@@ -120,7 +130,7 @@ impl Daemon {
         println!("{}", self.config.socket_path.display());
 
         // Setup graceful shutdown on SIGTERM/SIGINT
-        let shutdown = signal::ctrl_c();
+        let shutdown = shutdown_signal();
         tokio::pin!(shutdown);
 
         loop {
@@ -128,13 +138,17 @@ impl Daemon {
                 Ok((stream, _)) = listener.accept() => {
                     debug!("New connection accepted");
                     let client = self.client.clone();
+                    let file_cache = self.file_cache.clone();
                     tokio::spawn(async move {
-                        if let Err(e) = handle_connection(stream, client).await {
+                        if let Err(e) = handle_connection(stream, client, file_cache).await {
                             error!("Connection error: {}", e);
                         }
                     });
                 }
-                _ = &mut shutdown => {
+                shutdown_result = &mut shutdown => {
+                    if let Err(e) = shutdown_result {
+                        warn!("Shutdown signal handler failed: {}", e);
+                    }
                     info!("Received shutdown signal, cleaning up...");
                     break;
                 }
@@ -151,8 +165,32 @@ impl Daemon {
     }
 }
 
+async fn shutdown_signal() -> anyhow::Result<()> {
+    #[cfg(unix)]
+    {
+        let mut sigterm = signal::unix::signal(signal::unix::SignalKind::terminate())?;
+        tokio::select! {
+            result = signal::ctrl_c() => {
+                result?;
+            }
+            _ = sigterm.recv() => {}
+        }
+    }
+
+    #[cfg(not(unix))]
+    {
+        signal::ctrl_c().await?;
+    }
+
+    Ok(())
+}
+
 /// Handle a single Unix socket connection.
-async fn handle_connection(stream: UnixStream, client: NexusClient) -> anyhow::Result<()> {
+async fn handle_connection(
+    stream: UnixStream,
+    client: NexusClient,
+    file_cache: Option<Arc<FileCache>>,
+) -> anyhow::Result<()> {
     let (reader, mut writer) = stream.into_split();
     let mut reader = BufReader::new(reader);
     let mut line = String::new();
@@ -167,7 +205,7 @@ async fn handle_connection(stream: UnixStream, client: NexusClient) -> anyhow::R
         }
 
         let response = match serde_json::from_str::<JsonRpcRequest>(&line) {
-            Ok(request) => handle_request(request, &client).await,
+            Ok(request) => handle_request(request, &client, file_cache.clone()).await,
             Err(e) => {
                 error!("Failed to parse JSON-RPC request: {}", e);
                 JsonRpcResponse::error(None, -32700, format!("Parse error: {}", e), None)
@@ -192,7 +230,11 @@ fn extract_params<T: for<'de> Deserialize<'de>>(params: &Value) -> Result<T, Nex
 }
 
 /// Handle a single JSON-RPC request.
-async fn handle_request(request: JsonRpcRequest, client: &NexusClient) -> JsonRpcResponse {
+async fn handle_request(
+    request: JsonRpcRequest,
+    client: &NexusClient,
+    file_cache: Option<Arc<FileCache>>,
+) -> JsonRpcResponse {
     debug!("Handling method: {}", request.method);
 
     // Clone client for spawn_blocking
@@ -202,13 +244,13 @@ async fn handle_request(request: JsonRpcRequest, client: &NexusClient) -> JsonRp
 
     // Run blocking operations in a separate thread pool
     let result = tokio::task::spawn_blocking(move || match method.as_str() {
-        "read" => handle_read(&params, &client),
-        "write" => handle_write(&params, &client),
+        "read" => handle_read(&params, &client, file_cache.as_deref()),
+        "write" => handle_write(&params, &client, file_cache.as_deref()),
         "list" => handle_list(&params, &client),
         "stat" => handle_stat(&params, &client),
         "mkdir" => handle_mkdir(&params, &client),
-        "delete" => handle_delete(&params, &client),
-        "rename" => handle_rename(&params, &client),
+        "delete" => handle_delete(&params, &client, file_cache.as_deref()),
+        "rename" => handle_rename(&params, &client, file_cache.as_deref()),
         "exists" => handle_exists(&params, &client),
         _ => Err(NexusClientError::InvalidResponse(format!(
             "Method not found: {}",
@@ -243,7 +285,11 @@ async fn handle_request(request: JsonRpcRequest, client: &NexusClient) -> JsonRp
 // Handler functions — Issue 5A: use extract_params<T>() to eliminate
 // repeated deserialization boilerplate.
 
-fn handle_read(params: &Value, client: &NexusClient) -> Result<Value, NexusClientError> {
+fn handle_read(
+    params: &Value,
+    client: &NexusClient,
+    file_cache: Option<&FileCache>,
+) -> Result<Value, NexusClientError> {
     #[derive(Deserialize)]
     struct P {
         path: String,
@@ -251,17 +297,22 @@ fn handle_read(params: &Value, client: &NexusClient) -> Result<Value, NexusClien
     let p: P = extract_params(params)?;
 
     let started_at = Instant::now();
-    let content = match client.read(&p.path) {
-        Ok(content) => {
-            crate::metrics::record_read("backend", content.len(), started_at.elapsed());
-            content
+    let gen = if file_cache.is_some() {
+        client.stat(&p.path).map(|m| m.gen).unwrap_or(0)
+    } else {
+        0
+    };
+    let read_result = match read_with_cache(client, file_cache, &p.path, gen) {
+        Ok(result) => {
+            crate::metrics::record_read(result.tier, result.content.len(), started_at.elapsed());
+            result
         }
         Err(error) => {
             crate::metrics::record_read("error", 0, started_at.elapsed());
             return Err(error);
         }
     };
-    let encoded = base64::engine::general_purpose::STANDARD.encode(&content);
+    let encoded = base64::engine::general_purpose::STANDARD.encode(&read_result.content);
 
     Ok(json!({
         "__type__": "bytes",
@@ -269,11 +320,15 @@ fn handle_read(params: &Value, client: &NexusClient) -> Result<Value, NexusClien
     }))
 }
 
-fn handle_write(params: &Value, client: &NexusClient) -> Result<Value, NexusClientError> {
+fn handle_write(
+    params: &Value,
+    client: &NexusClient,
+    file_cache: Option<&FileCache>,
+) -> Result<Value, NexusClientError> {
     #[derive(Deserialize)]
     struct ContentBytes {
         #[serde(rename = "__type__")]
-        type_tag: String,
+        _type_tag: String,
         data: String,
     }
     #[derive(Deserialize)]
@@ -288,6 +343,9 @@ fn handle_write(params: &Value, client: &NexusClient) -> Result<Value, NexusClie
         .map_err(|e| NexusClientError::InvalidResponse(format!("Invalid base64: {}", e)))?;
 
     client.write(&p.path, &content)?;
+    if let Some(cache) = file_cache {
+        cache.invalidate(&p.path);
+    }
     crate::metrics::record_write_backend_rpc();
     Ok(json!({}))
 }
@@ -311,8 +369,8 @@ fn handle_stat(params: &Value, client: &NexusClient) -> Result<Value, NexusClien
     let p: P = extract_params(params)?;
 
     let metadata = client.stat(&p.path)?;
-    Ok(serde_json::to_value(metadata)
-        .map_err(|e| NexusClientError::InvalidResponse(format!("Serialization error: {}", e)))?)
+    serde_json::to_value(metadata)
+        .map_err(|e| NexusClientError::InvalidResponse(format!("Serialization error: {}", e)))
 }
 
 fn handle_mkdir(params: &Value, client: &NexusClient) -> Result<Value, NexusClientError> {
@@ -326,7 +384,11 @@ fn handle_mkdir(params: &Value, client: &NexusClient) -> Result<Value, NexusClie
     Ok(json!({}))
 }
 
-fn handle_delete(params: &Value, client: &NexusClient) -> Result<Value, NexusClientError> {
+fn handle_delete(
+    params: &Value,
+    client: &NexusClient,
+    file_cache: Option<&FileCache>,
+) -> Result<Value, NexusClientError> {
     #[derive(Deserialize)]
     struct P {
         path: String,
@@ -334,10 +396,17 @@ fn handle_delete(params: &Value, client: &NexusClient) -> Result<Value, NexusCli
     let p: P = extract_params(params)?;
 
     client.delete(&p.path)?;
+    if let Some(cache) = file_cache {
+        cache.invalidate(&p.path);
+    }
     Ok(json!({}))
 }
 
-fn handle_rename(params: &Value, client: &NexusClient) -> Result<Value, NexusClientError> {
+fn handle_rename(
+    params: &Value,
+    client: &NexusClient,
+    file_cache: Option<&FileCache>,
+) -> Result<Value, NexusClientError> {
     #[derive(Deserialize)]
     struct P {
         old_path: String,
@@ -346,6 +415,10 @@ fn handle_rename(params: &Value, client: &NexusClient) -> Result<Value, NexusCli
     let p: P = extract_params(params)?;
 
     client.rename(&p.old_path, &p.new_path)?;
+    if let Some(cache) = file_cache {
+        cache.invalidate(&p.old_path);
+        cache.invalidate(&p.new_path);
+    }
     Ok(json!({}))
 }
 
@@ -389,7 +462,7 @@ mod tests {
 
         let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
 
-        let result = handle_read(&json!({"path": "/daemon.txt"}), &client).unwrap();
+        let result = handle_read(&json!({"path": "/daemon.txt"}), &client, None).unwrap();
 
         assert_eq!(result["data"], payload);
         let metrics = crate::metrics::render();
@@ -411,7 +484,7 @@ mod tests {
 
         let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
 
-        let result = handle_read(&json!({"path": "/daemon.txt"}), &client);
+        let result = handle_read(&json!({"path": "/daemon.txt"}), &client, None);
 
         assert!(result.is_err());
         let metrics = crate::metrics::render();
@@ -441,6 +514,7 @@ mod tests {
                 "content": {"__type__": "bytes", "data": payload}
             }),
             &client,
+            None,
         )
         .unwrap();
 

--- a/nexus-fuse/src/error.rs
+++ b/nexus-fuse/src/error.rs
@@ -99,11 +99,9 @@ impl NexusClientError {
     /// Check if error is transient and potentially retry-able.
     pub fn is_transient(&self) -> bool {
         match self {
-            Self::Timeout { .. }
-            | Self::ConnectionRefused(_)
-            | Self::RateLimited
-            | Self::ServerError { .. }
-            | Self::HttpError(_) => true,
+            Self::Timeout { .. } | Self::ConnectionRefused(_) | Self::RateLimited => true,
+            Self::HttpError(e) => e.is_timeout() || e.is_connect(),
+            Self::ServerError { status, .. } => (500..600).contains(status),
             Self::NotFound(_)
             | Self::InvalidResponse(_)
             | Self::JsonError(_)
@@ -145,6 +143,16 @@ mod tests {
         };
         assert_eq!(err.to_errno(), libc::EIO);
         assert!(err.is_transient());
+    }
+
+    #[test]
+    fn test_client_error_server_response_is_not_transient() {
+        let err = NexusClientError::ServerError {
+            status: 403,
+            message: "Forbidden".to_string(),
+        };
+        assert_eq!(err.to_errno(), libc::EIO);
+        assert!(!err.is_transient());
     }
 
     #[test]

--- a/nexus-fuse/src/fs.rs
+++ b/nexus-fuse/src/fs.rs
@@ -1,7 +1,8 @@
 //! FUSE filesystem implementation for Nexus.
 
-use crate::cache::{CacheLookup, FileCache};
-use crate::client::{FileEntry, NexusClient, ReadResponse};
+use crate::cache::FileCache;
+use crate::cached_read::{read_with_cache, CachedReadResult};
+use crate::client::{FileEntry, NexusClient};
 use crate::metrics;
 use fuser::{
     AccessFlags, BsdFileFlags, Errno, FileAttr, FileHandle, FileType, Filesystem, FopenFlags,
@@ -211,6 +212,7 @@ impl InodeTable {
     }
 
     /// Get inode for a path (promotes in LRU).
+    #[cfg(test)]
     fn get_inode(&mut self, path: &str) -> Option<u64> {
         self.path_to_inode.get(path).copied()
     }
@@ -245,23 +247,16 @@ pub struct NexusFs {
     attr_cache: Mutex<LruCache<u64, (FileAttr, SystemTime)>>,
     /// Directory listing cache (in-memory).
     dir_cache: Mutex<LruCache<u64, (Vec<FileEntry>, SystemTime)>>,
-    /// Persistent SQLite cache for file content (optional).
-    file_cache: Option<FileCache>,
-    /// Per-open file content cache for range reads that bypass SQLite size limits.
+    /// Persistent foyer cache for file content (optional).
+    file_cache: Option<Arc<FileCache>>,
+    /// Per-open file content cache for range reads that bypass persistent cache size limits.
     open_file_cache: Mutex<OpenFileCache>,
     next_file_handle: Mutex<u64>,
 }
 
-#[derive(Debug)]
-struct ReadCachedResult {
-    content: Vec<u8>,
-    etag: Option<String>,
-    tier: &'static str,
-}
-
 impl NexusFs {
     /// Create a new NexusFs instance.
-    pub fn new(client: NexusClient, file_cache: Option<FileCache>) -> Self {
+    pub fn new(client: NexusClient, file_cache: Option<Arc<FileCache>>) -> Self {
         Self {
             client: Arc::new(client),
             inodes: Mutex::new(InodeTable::new()),
@@ -522,102 +517,17 @@ impl NexusFs {
         }
     }
 
-    /// Read file with SQLite cache and ETag support.
+    /// Read file with foyer cache and ETag support.
     ///
     /// Cache flow:
-    /// 1. Check SQLite cache
+    /// 1. Check foyer cache
     /// 2. If hit and fresh -> return cached content
     /// 3. If hit but stale with etag -> send If-None-Match request
     /// 4. If server returns 304 -> touch cache, return cached content
     /// 5. If server returns 200 -> update cache, return new content
     /// 6. If miss -> fetch from server, store in cache
-    fn read_cached(&self, path: &str, gen: u64) -> anyhow::Result<ReadCachedResult> {
-        // Check persistent cache first
-        if let Some(ref cache) = self.file_cache {
-            match cache.get(path, gen) {
-                CacheLookup::Hit(entry) => {
-                    debug!("SQLite cache hit for {}", path);
-                    return Ok(ReadCachedResult {
-                        content: entry.content,
-                        etag: entry.etag,
-                        tier: "cache",
-                    });
-                }
-                CacheLookup::NeedsRevalidation { etag } => {
-                    // Send conditional request
-                    debug!("Revalidating cache for {} with etag {}", path, etag);
-                    match self.client.read_with_etag(path, Some(&etag)) {
-                        Ok(ReadResponse::NotModified) => {
-                            metrics::record_cache_etag_revalidate("304");
-                            metrics::record_etag_check("304");
-                            // Touch cache to refresh timestamp
-                            cache.touch(path);
-                            // Return cached content without recording another cache request.
-                            if let Some(entry) = cache.get_entry_for_revalidation(path) {
-                                return Ok(ReadCachedResult {
-                                    content: entry.content,
-                                    etag: entry.etag,
-                                    tier: "cache",
-                                });
-                            }
-                            // Cache inconsistency - should not happen
-                            error!("Cache inconsistency after 304 for {}", path);
-                        }
-                        Ok(ReadResponse::Content { content, etag }) => {
-                            // Update cache with new content
-                            metrics::record_cache_etag_revalidate("updated");
-                            metrics::record_etag_check("updated");
-                            cache.put(path, &content, etag.as_deref(), gen);
-                            return Ok(ReadCachedResult {
-                                content,
-                                etag,
-                                tier: "backend",
-                            });
-                        }
-                        Err(e) => {
-                            // On error, try to use stale cache as fallback
-                            debug!("Revalidation failed for {}: {}, using stale cache", path, e);
-                            if let Some(entry) = cache.get_entry_for_revalidation(path) {
-                                metrics::record_cache_etag_revalidate("fallback");
-                                metrics::record_etag_check("fallback");
-                                return Ok(ReadCachedResult {
-                                    content: entry.content,
-                                    etag: entry.etag,
-                                    tier: "cache",
-                                });
-                            }
-                            metrics::record_cache_etag_revalidate("error");
-                            metrics::record_etag_check("error");
-                            return Err(e.into());
-                        }
-                    }
-                }
-                CacheLookup::Miss => {
-                    // Fall through to fetch
-                }
-            }
-        }
-
-        // Fetch from server
-        match self.client.read_with_etag(path, None) {
-            Ok(ReadResponse::Content { content, etag }) => {
-                // Store in cache
-                if let Some(ref cache) = self.file_cache {
-                    cache.put(path, &content, etag.as_deref(), gen);
-                }
-                Ok(ReadCachedResult {
-                    content,
-                    etag,
-                    tier: "backend",
-                })
-            }
-            Ok(ReadResponse::NotModified) => {
-                // Shouldn't happen without etag, but handle gracefully
-                metrics::record_etag_check("unexpected_304");
-                Err(anyhow::anyhow!("Unexpected 304 response"))
-            }
-            Err(e) => Err(e.into()),
-        }
+    fn read_cached(&self, path: &str, gen: u64) -> anyhow::Result<CachedReadResult> {
+        read_with_cache(&self.client, self.file_cache.as_deref(), path, gen).map_err(Into::into)
     }
 }
 
@@ -799,13 +709,13 @@ impl Filesystem for NexusFs {
             }
         }
 
-        // Read using SQLite cache with ETag support
+        // Read using foyer cache with ETag support
         let read_result = match self.read_cached(&path, gen) {
             Ok(result) => result,
             Err(e) => {
                 metrics::record_read("error", 0, started_at.elapsed());
                 if e.downcast_ref::<crate::error::NexusClientError>()
-                    .map_or(false, |ne| ne.is_not_found())
+                    .is_some_and(|ne| ne.is_not_found())
                 {
                     reply.error(Errno::ENOENT);
                 } else {
@@ -816,7 +726,7 @@ impl Filesystem for NexusFs {
             }
         };
 
-        let ReadCachedResult {
+        let CachedReadResult {
             content,
             etag: _etag,
             tier,
@@ -1352,6 +1262,7 @@ impl Filesystem for NexusFs {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::cache::{CacheConfig, MAX_FILE_SIZE};
     use mockito::{Matcher, Server};
 
     fn metric_value(rendered: &str, metric: &str) -> Option<u64> {
@@ -1359,6 +1270,18 @@ mod tests {
             line.strip_prefix(metric)
                 .and_then(|value| value.trim().parse::<u64>().ok())
         })
+    }
+
+    fn test_file_cache(label: &str) -> Arc<FileCache> {
+        let dir = tempfile::tempdir().unwrap().keep();
+        let config = CacheConfig::new(
+            dir.join(label),
+            4 * 1024 * 1024,
+            64 * 1024 * 1024,
+            MAX_FILE_SIZE,
+        )
+        .unwrap();
+        Arc::new(FileCache::new_with_config(&format!("http://{label}.test"), config).unwrap())
     }
 
     #[test]
@@ -1406,9 +1329,9 @@ mod tests {
             .with_body("backend unavailable")
             .create();
 
-        let cache = FileCache::open_in_memory_for_tests();
+        let cache = test_file_cache("fs-stale-fallback");
         cache.put("/stale.txt", b"stale-data", Some("etag-1"), 0);
-        cache.set_cached_at_for_tests("/stale.txt", 0);
+        cache.backdate_for_test("/stale.txt", 3601);
 
         let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
         let fs = NexusFs::new(client, Some(cache));
@@ -1439,9 +1362,9 @@ mod tests {
             .with_status(304)
             .create();
 
-        let cache = FileCache::open_in_memory_for_tests();
+        let cache = test_file_cache("fs-not-modified");
         cache.put("/not-modified.txt", b"cached-data", Some("etag-1"), 0);
-        cache.set_cached_at_for_tests("/not-modified.txt", 0);
+        cache.backdate_for_test("/not-modified.txt", 3601);
 
         let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
         let fs = NexusFs::new(client, Some(cache));
@@ -1457,14 +1380,14 @@ mod tests {
         assert_eq!(
             metric_value(
                 &rendered,
-                "nexus_cache_requests_total{tier=\"sqlite\",result=\"stale\"} "
+                "nexus_cache_requests_total{tier=\"dram\",result=\"stale\"} "
             ),
             Some(1)
         );
         assert_eq!(
             metric_value(
                 &rendered,
-                "nexus_cache_requests_total{tier=\"sqlite\",result=\"hit\"} "
+                "nexus_cache_requests_total{tier=\"dram\",result=\"hit\"} "
             ),
             None
         );

--- a/nexus-fuse/src/lib.rs
+++ b/nexus-fuse/src/lib.rs
@@ -3,6 +3,7 @@
 //! This library provides a high-performance FUSE client for the Nexus filesystem.
 
 pub mod cache;
+pub mod cached_read;
 pub mod client;
 pub mod daemon;
 pub mod error;

--- a/nexus-fuse/src/main.rs
+++ b/nexus-fuse/src/main.rs
@@ -8,6 +8,7 @@ use fuser::{Config, MountOption, SessionACL};
 use log::{error, info};
 use nexus_fuse::{cache, client, daemon, fs, metrics};
 use std::path::PathBuf;
+use std::sync::Arc;
 
 #[derive(Parser)]
 #[command(name = "nexus-fuse")]
@@ -50,6 +51,18 @@ enum Commands {
         #[arg(long, env = "NEXUS_AGENT_ID")]
         agent_id: Option<String>,
 
+        /// Foyer DRAM cache size in MiB
+        #[arg(long, env = "NEXUS_FUSE_CACHE_MEMORY_MB", default_value_t = 256)]
+        cache_memory_mb: usize,
+
+        /// Foyer filesystem cache size in GiB
+        #[arg(long, env = "NEXUS_FUSE_CACHE_DISK_GB", default_value_t = 10)]
+        cache_disk_gb: usize,
+
+        /// Override cache root directory
+        #[arg(long, env = "NEXUS_FUSE_CACHE_DIR")]
+        cache_dir: Option<PathBuf>,
+
         /// Prometheus metrics bind address, for example 127.0.0.1:9464
         #[arg(long, env = "NEXUS_FUSE_METRICS_ADDR")]
         metrics_addr: Option<String>,
@@ -75,6 +88,18 @@ enum Commands {
         /// Agent ID for file attribution
         #[arg(long, env = "NEXUS_AGENT_ID")]
         agent_id: Option<String>,
+
+        /// Foyer DRAM cache size in MiB
+        #[arg(long, env = "NEXUS_FUSE_CACHE_MEMORY_MB", default_value_t = 256)]
+        cache_memory_mb: usize,
+
+        /// Foyer filesystem cache size in GiB
+        #[arg(long, env = "NEXUS_FUSE_CACHE_DISK_GB", default_value_t = 10)]
+        cache_disk_gb: usize,
+
+        /// Override cache root directory
+        #[arg(long, env = "NEXUS_FUSE_CACHE_DIR")]
+        cache_dir: Option<PathBuf>,
 
         /// Prometheus metrics bind address, for example 127.0.0.1:9464
         #[arg(long, env = "NEXUS_FUSE_METRICS_ADDR")]
@@ -113,6 +138,51 @@ fn resolve_api_key(
     ))
 }
 
+fn mib_to_bytes(mib: usize) -> anyhow::Result<usize> {
+    mib.checked_mul(1024 * 1024)
+        .ok_or_else(|| anyhow::anyhow!("cache memory size overflows usize"))
+}
+
+fn gib_to_bytes(gib: usize) -> anyhow::Result<usize> {
+    gib.checked_mul(1024 * 1024 * 1024)
+        .ok_or_else(|| anyhow::anyhow!("cache disk size overflows usize"))
+}
+
+fn build_cache_config(
+    cache_memory_mb: usize,
+    cache_disk_gb: usize,
+    cache_dir: Option<PathBuf>,
+) -> anyhow::Result<cache::CacheConfig> {
+    let root_dir = cache_dir.unwrap_or_else(|| cache::CacheConfig::default().root_dir);
+    cache::CacheConfig::new(
+        root_dir,
+        mib_to_bytes(cache_memory_mb)?,
+        gib_to_bytes(cache_disk_gb)?,
+        cache::MAX_FILE_SIZE,
+    )
+}
+
+fn open_file_cache(url: &str, config: cache::CacheConfig) -> Option<Arc<cache::FileCache>> {
+    match cache::FileCache::new_with_config(url, config) {
+        Ok(cache) => {
+            let stats = cache.stats();
+            info!(
+                "Foyer cache ready: {} current-process files ({} MB)",
+                stats.file_count,
+                stats.total_size / 1024 / 1024
+            );
+            Some(Arc::new(cache))
+        }
+        Err(e) => {
+            error!(
+                "Failed to initialize foyer cache: {} (continuing without cache)",
+                e
+            );
+            None
+        }
+    }
+}
+
 fn main() -> anyhow::Result<()> {
     // Initialize logging
     env_logger::Builder::from_env(env_logger::Env::default().default_filter_or("info")).init();
@@ -128,6 +198,9 @@ fn main() -> anyhow::Result<()> {
             allow_other,
             foreground,
             agent_id,
+            cache_memory_mb,
+            cache_disk_gb,
+            cache_dir,
             metrics_addr,
         } => {
             let api_key = resolve_api_key(api_key, api_key_file)?;
@@ -160,25 +233,8 @@ fn main() -> anyhow::Result<()> {
                 }
             }
 
-            // Create persistent cache
-            let file_cache = match cache::FileCache::new(&url) {
-                Ok(cache) => {
-                    let stats = cache.stats();
-                    info!(
-                        "Cache loaded: {} files ({} MB)",
-                        stats.file_count,
-                        stats.total_size / 1024 / 1024
-                    );
-                    Some(cache)
-                }
-                Err(e) => {
-                    error!(
-                        "Failed to initialize cache: {} (continuing without cache)",
-                        e
-                    );
-                    None
-                }
-            };
+            let cache_config = build_cache_config(cache_memory_mb, cache_disk_gb, cache_dir)?;
+            let file_cache = open_file_cache(&url, cache_config);
 
             // Create filesystem
             let filesystem = fs::NexusFs::new(client, file_cache);
@@ -213,6 +269,9 @@ fn main() -> anyhow::Result<()> {
             api_key_file,
             socket,
             agent_id,
+            cache_memory_mb,
+            cache_disk_gb,
+            cache_dir,
             metrics_addr,
         } => {
             let api_key = resolve_api_key(api_key, api_key_file)?;
@@ -230,12 +289,15 @@ fn main() -> anyhow::Result<()> {
                 PathBuf::from(format!("/tmp/nexus-fuse-{}.sock", pid))
             });
 
-            // Create daemon config
+            let cache_config = build_cache_config(cache_memory_mb, cache_disk_gb, cache_dir)?;
+            let file_cache = open_file_cache(&url, cache_config);
+
             let config = daemon::DaemonConfig {
                 socket_path,
                 nexus_url: url,
                 api_key,
                 agent_id,
+                file_cache,
             };
 
             // Create daemon

--- a/nexus-fuse/tests/integration_test.rs
+++ b/nexus-fuse/tests/integration_test.rs
@@ -5,7 +5,6 @@
 //! Requires: Nexus server running on localhost:2026
 
 use nexus_fuse::client::NexusClient;
-use nexus_fuse::error::NexusClientError;
 
 #[test]
 #[ignore] // Run with: cargo test -- --ignored --nocapture

--- a/tests/e2e/self_contained/Dockerfile.fuse-test
+++ b/tests/e2e/self_contained/Dockerfile.fuse-test
@@ -1,13 +1,41 @@
+# syntax=docker/dockerfile:1
 FROM python:3.14-slim
 
+ENV PYO3_USE_ABI3_FORWARD_COMPATIBILITY=1
+
 RUN apt-get update && apt-get install -y --no-install-recommends \
-    fuse3 libfuse3-dev libfuse-dev fuse gcc build-essential && \
+    fuse3 libfuse3-dev libfuse-dev fuse gcc build-essential \
+    ca-certificates curl git protobuf-compiler && \
     rm -rf /var/lib/apt/lists/*
+
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y
+ENV PATH="/root/.cargo/bin:${PATH}" \
+    CARGO_TARGET_DIR=/app/target \
+    CARGO_BUILD_JOBS=2 \
+    CARGO_NET_RETRY=10 \
+    CARGO_HTTP_TIMEOUT=120 \
+    PROTOC=/usr/bin/protoc
 
 WORKDIR /app
 COPY . /app
 
+RUN "$PROTOC" --version
+
+RUN --mount=type=cache,target=/root/.cargo/registry \
+    --mount=type=cache,target=/root/.cargo/git \
+    --mount=type=cache,target=/app/target \
+    pip install --no-cache-dir maturin && \
+    if [ "$(uname -m)" = "aarch64" ]; then \
+        export SIMSIMD_TARGET_SVE=0 \
+               SIMSIMD_TARGET_SVE2=0 \
+               SIMSIMD_TARGET_SVE_BF16=0 \
+               SIMSIMD_TARGET_SVE_F16=0 \
+               SIMSIMD_TARGET_SVE_I8=0; \
+    fi && \
+    maturin build --release --out /tmp/nexus-dist -m rust/nexus-cdylib/Cargo.toml && \
+    pip install --no-cache-dir /tmp/nexus-dist/nexus_runtime-*.whl
+
 RUN pip install --no-cache-dir -e ".[dev]" fusepy 2>/dev/null || \
     pip install --no-cache-dir -e . fusepy
 
-CMD ["python", "/app/tests/e2e/self_contained/test_fuse_docker_e2e.py"]
+CMD ["python", "-m", "tests.e2e.self_contained.test_fuse_docker_e2e"]


### PR DESCRIPTION
## Summary
- Replace the nexus-fuse SQLite read cache with a Foyer hybrid in-memory/disk cache.
- Add cache tier configuration for mount and daemon modes while preserving ETag revalidation and stale fallback behavior.
- Remove legacy SQLite cache migration/state and document the Foyer benchmark workflow.
- Repair the Linux Docker FUSE harness context so the end-to-end FUSE test image can build from the repo root.

## Validation
- `cargo fmt --check` in `nexus-fuse`
- `cargo test --lib` in `nexus-fuse` (42 passed)
- `cargo test --test error_handling_test --test integration_test --test minimal_http_test` in `nexus-fuse` (22 passed, 2 ignored)
- `cargo check --all-targets` in `nexus-fuse`
- `NEXUS_APPROVALS_GRPC_PORT=43326 uv run nexus up --build --timeout 300` after clearing the partial local compose stack; Docker image build completed and all services reached healthy state
- `uv run nexus status` reported the local stack healthy and reachable
- `curl -fsS http://localhost:43320/health` returned healthy service status
- Built `nexus-fuse` locally with `cargo build`
- Ran live `nexus-fuse daemon` JSON-RPC validation against the `nexus up --build` stack: write/read/read-cache/rename/delete/delete-miss checks passed and Foyer cache directory was created with no SQLite cache files
- `docker build -t nexus-fuse-test-4053 -f tests/e2e/self_contained/Dockerfile.fuse-test .`
- `docker run --rm --device /dev/fuse --cap-add SYS_ADMIN --security-opt apparmor:unconfined nexus-fuse-test-4053` (14 passed, 0 failed)
- `git diff --check origin/develop...HEAD`

## Notes
- A pre-existing local Nexus stack was already bound to approvals gRPC port `2029`, so the first `nexus up --build` compose startup failed with a port allocation conflict. I reran with `NEXUS_APPROVALS_GRPC_PORT=43326` and the full build/startup path passed.

Closes #4053
