### PR TITLE
feat(portability): typed redacted-fields contract + mount export/import (#4083)

### DIFF
--- a/docs/portability.md
+++ b/docs/portability.md
@@ -1,0 +1,80 @@
+# Zone Data Portability
+
+Nexus zone bundles (`.nexus` archives) carry files, permissions, embeddings,
+and — as of bundle format `3.0.0` — mount configurations. This document
+covers the export/import flow with particular attention to credential
+handling.
+
+## Mount-config redaction (Issue #4083)
+
+Mount configurations contain backend credentials: S3 access keys, OAuth tokens,
+KMS material, etc. Bundles **must never** contain live credential values, so
+the export pipeline strips them and the import pipeline refuses to proceed
+without explicit re-injection.
+
+### What gets stripped
+
+For each connector, the redaction set is derived from `CONNECTION_ARGS`: every
+argument whose `secret=True` flag is set has its value replaced by a
+`${MOUNT_<id>_<FIELD>}` placeholder. This is the **only** source of truth — no
+parallel list to maintain.
+
+### Heuristic guard
+
+On export, a heuristic regex (`(?i)(key|secret|token|password|cred)`) scans
+every `CONNECTION_ARGS` key. If any matching name is **not** marked
+`secret=True` and **not** marked `audit_safe=True`, the export aborts with
+`SensitiveFieldNotDeclaredError`. This prevents a forgotten flag from silently
+leaking credentials.
+
+### Audit_safe escape hatch
+
+For benign fields whose name happens to match the heuristic (e.g., a
+filesystem path containing `token`), set `audit_safe=True` on the
+`ConnectionArg` and document the reason in the description. The CI gate
+(`tests/test_redaction_audit.py`) enforces this contract for every registered
+connector.
+
+### Forced re-injection on import
+
+Imports require a `mount_overrides` dict per mount:
+
+```python
+from nexus.bricks.portability import (
+    ZoneImportService,
+    ZoneImportOptions,
+)
+
+importer = ZoneImportService(nexus_fs, mount_manager=mount_manager)
+importer.import_zone(ZoneImportOptions(
+    bundle_path="zone.nexus",
+    mount_overrides={
+        "m-1": {
+            "access_key_id": "AKIA...",
+            "secret_access_key": "wJalr...",
+        },
+    },
+))
+```
+
+Without `mount_overrides` for a redacted field, the import raises
+`MissingCredentialsError` listing **every** missing credential in one message
+— operators see the full set up front, before any backend is initialized.
+
+### Skipping mount restore
+
+For dry-run inspections or destination instances that don't need the mounts:
+
+```python
+importer.import_zone(ZoneImportOptions(
+    bundle_path="zone.nexus",
+    restore_mounts=False,
+))
+```
+
+### Bundle format compatibility
+
+- v1/v2 bundles (no `mounts.jsonl`) import unchanged on the new code path.
+- v3 bundles read by older Nexus instances fail loudly at schema validation
+  — `additionalProperties: false` in `manifest-v1.json` rejects the new
+  `mount_count` field. The failure is explicit, not silent corruption.

--- a/docs/superpowers/plans/2026-05-09-portability-redacted-fields.md
+++ b/docs/superpowers/plans/2026-05-09-portability-redacted-fields.md
@@ -1,0 +1,2276 @@
+# Portability Redacted-Fields Contract Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement a typed redaction contract for `bricks/portability/` derived from each backend's existing `ConnectionArg.secret=True` flag, plus mount-config export/import with forced credential re-injection on import.
+
+**Architecture:** Three new modules (`redaction.py`, `mount_export.py`, `mount_import.py`) sit alongside existing portability code. They reuse `PlaceholderRef` so the manifest's placeholder list stays uniform across DB rows and mount configs. `BUNDLE_FORMAT_VERSION` bumps `"2.0.0"` → `"3.0.0"`; new `manifest-v3.json` schema is added next to existing `manifest-v1.json`. `ConnectorRegistry.get_info(...).connector_class.CONNECTION_ARGS` is the single source of truth for which fields are secrets.
+
+**Tech Stack:** Python 3.11+, pytest, dataclasses, JSON schema, ed25519 signing infra (existing).
+
+**Spec:** `docs/superpowers/specs/2026-05-09-portability-redacted-fields-design.md`
+
+---
+
+## File Structure
+
+**New files:**
+- `src/nexus/bricks/portability/redaction.py` — derive redaction set, secret-shape regex audit, redact one config dict
+- `src/nexus/bricks/portability/mount_export.py` — collect mount configs, run redaction, write `mounts.jsonl`
+- `src/nexus/bricks/portability/mount_import.py` — read mounts, validate overrides, materialize, restore
+- `src/nexus/bricks/portability/schemas/manifest-v3.json` — schema for new bundle version
+- `src/nexus/bricks/portability/tests/test_redaction_audit.py` — CI gate audit
+- `src/nexus/bricks/portability/tests/test_redaction_unit.py` — redaction unit
+- `src/nexus/bricks/portability/tests/test_mount_export.py` — export unit
+- `src/nexus/bricks/portability/tests/test_mount_import.py` — import unit
+- `src/nexus/bricks/portability/tests/test_manifest_v3.py` — version + cross-version
+- `src/nexus/bricks/portability/tests/test_roundtrip_with_mounts.py` — integration roundtrip
+
+**Modified files:**
+- `src/nexus/bricks/portability/models.py` — bump `BUNDLE_FORMAT_VERSION`, add `MountRecord`, add `mount_count`, new errors, options additions
+- `src/nexus/bricks/portability/export_service.py` — wire `mount_export` when `options.include_mounts=True`
+- `src/nexus/bricks/portability/import_service.py` — wire `mount_import`; validate before any side effect
+- `src/nexus/bricks/portability/__init__.py` — public API exports
+
+---
+
+## Task 1: Add new errors and `MountRecord` dataclass to models.py
+
+**Files:**
+- Modify: `src/nexus/bricks/portability/models.py:50` (constant), `:1190` (BUNDLE_PATHS); append errors and `MountRecord` near end of module
+- Test: `src/nexus/bricks/portability/tests/test_mount_record.py`
+
+- [ ] **Step 1: Write failing test for MountRecord round-trip**
+
+Create `src/nexus/bricks/portability/tests/test_mount_record.py`:
+
+```python
+"""Tests for MountRecord dataclass."""
+
+from nexus.bricks.portability.models import MountRecord
+
+
+def test_mount_record_round_trip_dict():
+    rec = MountRecord(
+        mount_id="m-1",
+        mount_point="/personal/alice",
+        backend_type="path_s3",
+        backend_config={"bucket_name": "acme", "access_key_id": "${MOUNT_m-1_ACCESS_KEY_ID}"},
+        owner_user_id="alice",
+        zone_id="acme",
+        description=None,
+    )
+    d = rec.to_dict()
+    rec2 = MountRecord.from_dict(d)
+    assert rec2 == rec
+
+
+def test_mount_record_handles_none_zone_and_owner():
+    rec = MountRecord(
+        mount_id="m-2",
+        mount_point="/team/x",
+        backend_type="path_local",
+        backend_config={"root": "/data"},
+        owner_user_id=None,
+        zone_id=None,
+        description="team mount",
+    )
+    rec2 = MountRecord.from_dict(rec.to_dict())
+    assert rec2 == rec
+```
+
+- [ ] **Step 2: Write failing test for new errors**
+
+Append to the same file:
+
+```python
+import pytest
+
+from nexus.bricks.portability.models import (
+    MissingCredentialsError,
+    SensitiveFieldNotDeclaredError,
+)
+
+
+def test_sensitive_field_not_declared_error_carries_payload():
+    err = SensitiveFieldNotDeclaredError(backend_type="path_s3", fields=["my_secret"])
+    assert err.backend_type == "path_s3"
+    assert err.fields == ["my_secret"]
+    assert "path_s3" in str(err)
+    assert "my_secret" in str(err)
+
+
+def test_missing_credentials_error_lists_all_gaps():
+    err = MissingCredentialsError(missing={"m-1": ["a", "b"], "m-2": ["c"]})
+    msg = str(err)
+    assert "m-1" in msg and "a" in msg and "b" in msg
+    assert "m-2" in msg and "c" in msg
+
+
+def test_missing_credentials_error_is_value_error():
+    with pytest.raises(ValueError):
+        raise MissingCredentialsError(missing={"m-1": ["a"]})
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+pytest src/nexus/bricks/portability/tests/test_mount_record.py -v
+```
+
+Expected: All tests FAIL with `ImportError: cannot import name 'MountRecord' from nexus.bricks.portability.models` (or similar).
+
+- [ ] **Step 4: Implement MountRecord and errors in models.py**
+
+Find the end of `models.py` (after `BUNDLE_PATHS`). Append:
+
+```python
+# =============================================================================
+# Mount portability (Issue #4083)
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class MountRecord:
+    """One line of mounts.jsonl. Mirrors MountManager's persisted shape with
+    secrets replaced by ${MOUNT_<id>_<FIELD>} placeholders on export."""
+
+    mount_id: str
+    mount_point: str
+    backend_type: str
+    backend_config: dict[str, Any]
+    owner_user_id: str | None = None
+    zone_id: str | None = None
+    description: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mount_id": self.mount_id,
+            "mount_point": self.mount_point,
+            "backend_type": self.backend_type,
+            "backend_config": self.backend_config,
+            "owner_user_id": self.owner_user_id,
+            "zone_id": self.zone_id,
+            "description": self.description,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "MountRecord":
+        return cls(
+            mount_id=data["mount_id"],
+            mount_point=data["mount_point"],
+            backend_type=data["backend_type"],
+            backend_config=data["backend_config"],
+            owner_user_id=data.get("owner_user_id"),
+            zone_id=data.get("zone_id"),
+            description=data.get("description"),
+        )
+
+
+class SensitiveFieldNotDeclaredError(ValueError):
+    """Export-time. Backend has CONNECTION_ARGS keys whose names match the
+    secret-shape heuristic but aren't marked secret=True."""
+
+    def __init__(self, backend_type: str, fields: list[str]) -> None:
+        self.backend_type = backend_type
+        self.fields = list(fields)
+        super().__init__(
+            f"Backend {backend_type!r} has secret-shaped fields not marked secret=True: "
+            f"{self.fields}. Mark them secret=True in CONNECTION_ARGS or rename them."
+        )
+
+
+class MissingCredentialsError(ValueError):
+    """Import-time. Bundle has redacted mount fields with no override supplied.
+    Reports every gap in one error so operators see the full set at once."""
+
+    def __init__(self, missing: dict[str, list[str]]) -> None:
+        self.missing = {k: list(v) for k, v in missing.items()}
+        lines = [f"  {mid}: {fields}" for mid, fields in sorted(self.missing.items())]
+        super().__init__(
+            "Mount imports require credential overrides for:\n" + "\n".join(lines)
+        )
+```
+
+Update `BUNDLE_PATHS` (find at `models.py:1190`):
+
+```python
+BUNDLE_PATHS = {
+    # ... existing entries unchanged ...
+    "mounts": "mounts.jsonl",  # NEW
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+pytest src/nexus/bricks/portability/tests/test_mount_record.py -v
+```
+
+Expected: 5 tests PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/nexus/bricks/portability/models.py \
+        src/nexus/bricks/portability/tests/test_mount_record.py
+git commit -m "feat(portability): add MountRecord and credential-contract errors
+
+Issue: https://github.com/nexi-lab/nexus/issues/4083"
+```
+
+---
+
+## Task 2: Bump BUNDLE_FORMAT_VERSION and add `mount_count` to ExportManifest
+
+**Files:**
+- Modify: `src/nexus/bricks/portability/models.py:50,55` (constants), `:523-720` (`ExportManifest` dataclass + `to_dict`/`from_dict`)
+- Test: `src/nexus/bricks/portability/tests/test_manifest_v3.py`
+
+- [ ] **Step 1: Write failing test**
+
+Create `src/nexus/bricks/portability/tests/test_manifest_v3.py`:
+
+```python
+"""Tests for v3 bundle manifest additions."""
+
+from nexus.bricks.portability.models import (
+    BUNDLE_FORMAT_VERSION,
+    MANIFEST_SCHEMA_URL,
+    ExportManifest,
+)
+
+
+def test_format_version_is_v3():
+    assert BUNDLE_FORMAT_VERSION == "3.0.0"
+
+
+def test_manifest_schema_url_is_v3():
+    assert MANIFEST_SCHEMA_URL == "https://nexus.io/schemas/manifest-v3.json"
+
+
+def test_manifest_includes_mount_count():
+    m = ExportManifest(source_zone_id="z1")
+    m.mount_count = 5
+    d = m.to_dict()
+    assert d["statistics"]["mount_count"] == 5
+
+
+def test_manifest_default_mount_count_is_zero():
+    m = ExportManifest(source_zone_id="z1")
+    assert m.mount_count == 0
+    assert m.to_dict()["statistics"]["mount_count"] == 0
+
+
+def test_manifest_round_trip_preserves_mount_count():
+    m = ExportManifest(source_zone_id="z1")
+    m.mount_count = 7
+    d = m.to_dict()
+    m2 = ExportManifest.from_dict(d)
+    assert m2.mount_count == 7
+
+
+def test_v1_bundle_loads_with_default_mount_count():
+    """A v1/v2 manifest dict (no mount_count) must still load."""
+    legacy_dict = {
+        "format_version": "2.0.0",
+        "bundle_id": "550e8400-e29b-41d4-a716-446655440000",
+        "source_zone_id": "z1",
+        "export_timestamp": "2026-01-01T00:00:00+00:00",
+        "statistics": {
+            "file_count": 0,
+            "total_size_bytes": 0,
+            "content_blob_count": 0,
+            "permission_count": 0,
+            "embedding_count": 0,
+        },
+        "options": {"include_content": True, "include_permissions": True},
+        "checksums": {"algorithm": "sha256", "files": {}},
+    }
+    m = ExportManifest.from_dict(legacy_dict)
+    assert m.mount_count == 0
+    assert m.format_version == "2.0.0"
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+```bash
+pytest src/nexus/bricks/portability/tests/test_manifest_v3.py -v
+```
+
+Expected: FAIL — version is `"2.0.0"`, no `mount_count` attribute.
+
+- [ ] **Step 3: Bump version constants**
+
+Edit `src/nexus/bricks/portability/models.py` near line 50:
+
+```python
+BUNDLE_FORMAT_VERSION = "3.0.0"
+```
+
+Near line 55:
+
+```python
+MANIFEST_SCHEMA_URL = "https://nexus.io/schemas/manifest-v3.json"
+```
+
+- [ ] **Step 4: Add `mount_count` field and serialize/deserialize**
+
+In `models.py`, locate `ExportManifest` (line 523). Add field next to other v2 additions (after `placeholders: list[PlaceholderRef]`, around line 596):
+
+```python
+    # v3 additions (Issue #4083)
+    mount_count: int = 0
+```
+
+In `to_dict`, find the `"statistics"` block (around line 617) and add `mount_count`:
+
+```python
+            "statistics": {
+                "file_count": self.file_count,
+                "total_size_bytes": self.total_size_bytes,
+                "content_blob_count": self.content_blob_count,
+                "permission_count": self.permission_count,
+                "embedding_count": self.embedding_count,
+                "mount_count": self.mount_count,  # NEW
+            },
+```
+
+Also update the `"$schema"` literal at the top of `to_dict`:
+
+```python
+            "$schema": "https://nexus.io/schemas/manifest-v3.json",
+```
+
+In `from_dict` (around line 720), find the statistics-extraction block and add a default-tolerant lookup:
+
+```python
+            mount_count=stats.get("mount_count", 0),
+```
+
+(Locate the existing `stats = data.get("statistics", {})` line; if absent, replace direct lookups with `.get(...)` defaults.)
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+```bash
+pytest src/nexus/bricks/portability/tests/test_manifest_v3.py -v
+```
+
+Expected: 6 tests PASS.
+
+- [ ] **Step 6: Run the existing portability test suite to confirm no regressions**
+
+```bash
+pytest src/nexus/bricks/portability/tests/ -v
+```
+
+Expected: ALL existing tests still pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/nexus/bricks/portability/models.py \
+        src/nexus/bricks/portability/tests/test_manifest_v3.py
+git commit -m "feat(portability): bump bundle format to v3.0.0 with mount_count
+
+Issue: https://github.com/nexi-lab/nexus/issues/4083"
+```
+
+---
+
+## Task 3: `manifest-v3.json` schema file
+
+**Files:**
+- Create: `src/nexus/bricks/portability/schemas/manifest-v3.json`
+- Test: extend `src/nexus/bricks/portability/tests/test_manifest_v3.py`
+
+- [ ] **Step 1: Write failing test for schema validation**
+
+Append to `test_manifest_v3.py`:
+
+```python
+import json
+from pathlib import Path
+
+import pytest
+
+jsonschema = pytest.importorskip("jsonschema")
+
+SCHEMA_PATH = (
+    Path(__file__).parent.parent / "schemas" / "manifest-v3.json"
+)
+
+
+def test_v3_schema_file_exists_and_is_valid_json():
+    text = SCHEMA_PATH.read_text()
+    data = json.loads(text)
+    assert data["$id"].endswith("manifest-v3.json")
+
+
+def test_v3_manifest_validates_against_schema():
+    schema = json.loads(SCHEMA_PATH.read_text())
+    m = ExportManifest(source_zone_id="z1")
+    m.mount_count = 3
+    jsonschema.validate(m.to_dict(), schema)
+
+
+def test_v3_schema_rejects_unknown_root_field():
+    schema = json.loads(SCHEMA_PATH.read_text())
+    bad = ExportManifest(source_zone_id="z1").to_dict()
+    bad["totally_unknown_field"] = "bogus"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(bad, schema)
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest src/nexus/bricks/portability/tests/test_manifest_v3.py::test_v3_schema_file_exists_and_is_valid_json -v
+```
+
+Expected: FAIL — file does not exist.
+
+- [ ] **Step 3: Copy v1 schema to v3, update `$id` and add `mount_count`**
+
+```bash
+cp src/nexus/bricks/portability/schemas/manifest-v1.json \
+   src/nexus/bricks/portability/schemas/manifest-v3.json
+```
+
+Edit `src/nexus/bricks/portability/schemas/manifest-v3.json`:
+
+1. Change `$id` to `"https://nexus.io/schemas/manifest-v3.json"`.
+2. Update the `format_version.examples` to `["3.0.0"]`.
+3. Inside `properties.$schema.const`, change to `"https://nexus.io/schemas/manifest-v3.json"`.
+4. Inside `properties.statistics.properties`, add:
+   ```json
+   "mount_count": {
+     "type": "integer",
+     "description": "Number of mount records in mounts.jsonl",
+     "minimum": 0,
+     "default": 0
+   }
+   ```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest src/nexus/bricks/portability/tests/test_manifest_v3.py -v
+```
+
+Expected: ALL tests in this file PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/portability/schemas/manifest-v3.json \
+        src/nexus/bricks/portability/tests/test_manifest_v3.py
+git commit -m "feat(portability): add manifest-v3.json schema with mount_count
+
+Issue: https://github.com/nexi-lab/nexus/issues/4083"
+```
+
+---
+
+## Task 4: `redaction.py` — declared_secret_fields, audit_backend, redact_config
+
+**Files:**
+- Create: `src/nexus/bricks/portability/redaction.py`
+- Test: `src/nexus/bricks/portability/tests/test_redaction_unit.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/nexus/bricks/portability/tests/test_redaction_unit.py`:
+
+```python
+"""Unit tests for redaction.py."""
+
+import pytest
+
+from nexus.bricks.portability.models import (
+    PlaceholderRef,
+    SensitiveFieldNotDeclaredError,
+)
+from nexus.bricks.portability.redaction import (
+    SECRET_SHAPED,
+    audit_backend,
+    declared_secret_fields,
+    redact_config,
+)
+
+
+def test_secret_shape_regex_matches_obvious_names():
+    for name in ("api_key", "secret_access_key", "session_token", "password", "credential"):
+        assert SECRET_SHAPED.search(name), name
+
+
+def test_secret_shape_regex_ignores_benign_names():
+    for name in ("bucket_name", "region", "prefix", "path"):
+        assert not SECRET_SHAPED.search(name), name
+
+
+def test_declared_secret_fields_for_path_s3():
+    fields = declared_secret_fields("path_s3")
+    assert "access_key_id" in fields
+    assert "secret_access_key" in fields
+    assert "session_token" in fields
+    assert "bucket_name" not in fields
+
+
+def test_audit_backend_passes_for_path_s3():
+    """All secret-shaped names in path_s3 are already marked secret=True."""
+    assert audit_backend("path_s3") == []
+
+
+def test_redact_config_replaces_only_declared_secrets():
+    config = {
+        "bucket_name": "acme",
+        "access_key_id": "AKIA1234",
+        "secret_access_key": "wJalr...",
+    }
+    redacted, placeholders = redact_config("path_s3", config, mount_id="m-1")
+    assert redacted["bucket_name"] == "acme"
+    assert redacted["access_key_id"] == "${MOUNT_m-1_ACCESS_KEY_ID}"
+    assert redacted["secret_access_key"] == "${MOUNT_m-1_SECRET_ACCESS_KEY}"
+    assert {p.name for p in placeholders} == {
+        "MOUNT_m-1_ACCESS_KEY_ID",
+        "MOUNT_m-1_SECRET_ACCESS_KEY",
+    }
+    assert all(isinstance(p, PlaceholderRef) for p in placeholders)
+
+
+def test_redact_config_skips_none_values():
+    config = {"bucket_name": "acme", "access_key_id": None}
+    redacted, placeholders = redact_config("path_s3", config, mount_id="m-1")
+    assert redacted["access_key_id"] is None
+    assert placeholders == []
+
+
+def test_redact_config_idempotent_on_already_redacted():
+    config = {"bucket_name": "acme", "access_key_id": "${MOUNT_m-1_ACCESS_KEY_ID}"}
+    redacted, _ = redact_config("path_s3", config, mount_id="m-1")
+    assert redacted["access_key_id"] == "${MOUNT_m-1_ACCESS_KEY_ID}"
+
+
+def test_redact_config_audit_failure_raises():
+    """If a backend has a secret-shaped name not marked secret=True, raise."""
+    from unittest.mock import patch
+
+    fake_args = {
+        "bucket": __import__("nexus.extensions.types", fromlist=["ConnectionArg"]).ConnectionArg(
+            type=__import__("nexus.extensions.types", fromlist=["ArgType"]).ArgType.STRING,
+            description="ok",
+        ),
+        "my_token": __import__("nexus.extensions.types", fromlist=["ConnectionArg"]).ConnectionArg(
+            type=__import__("nexus.extensions.types", fromlist=["ArgType"]).ArgType.STRING,
+            description="should be secret but isn't",
+            secret=False,
+        ),
+    }
+
+    class FakeBackend:
+        CONNECTION_ARGS = fake_args
+
+    with patch("nexus.bricks.portability.redaction._get_connection_args", return_value=fake_args):
+        with pytest.raises(SensitiveFieldNotDeclaredError) as exc:
+            redact_config("fake", {"bucket": "x", "my_token": "y"}, mount_id="m-1")
+        assert "my_token" in exc.value.fields
+
+
+def test_placeholder_field_dotted_path_is_predictable():
+    config = {"access_key_id": "AKIA"}
+    _, placeholders = redact_config("path_s3", config, mount_id="m-1")
+    assert placeholders[0].field == "mounts.m-1.access_key_id"
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest src/nexus/bricks/portability/tests/test_redaction_unit.py -v
+```
+
+Expected: FAIL — `redaction` module does not exist.
+
+- [ ] **Step 3: Implement `redaction.py`**
+
+Create `src/nexus/bricks/portability/redaction.py`:
+
+```python
+"""Typed redaction contract for mount-config exports (Issue #4083).
+
+Single source of truth: each connector's CONNECTION_ARGS already declares
+`secret: bool` per argument. This module derives the redaction set from
+that declaration, and runs a heuristic audit that hard-fails export when a
+secret-shaped argument name (key/secret/token/password/cred) isn't marked
+secret=True.
+
+Why a separate module: the redaction policy is the contract surface that
+both export and import depend on. Keeping it focused (one file, three
+public functions) means the audit test, the export pipeline, and any
+future tooling all see the same answer to "is this field a secret?".
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from nexus.bricks.portability.models import (
+    PlaceholderRef,
+    SensitiveFieldNotDeclaredError,
+)
+
+SECRET_SHAPED = re.compile(r"(?i)(key|secret|token|password|cred)")
+"""Heuristic regex for argument names that should be marked secret=True.
+
+Audit fails if a CONNECTION_ARGS key matches this regex but has secret=False.
+The check is deliberately strict — every false positive is a forcing function
+to either rename the field or mark it secret=True. No allowlist exists today;
+add one only if real friction emerges (see spec for `audit_safe` follow-up)."""
+
+
+def _get_connection_args(backend_type: str) -> dict[str, Any]:
+    """Return the CONNECTION_ARGS dict for `backend_type`, or {} if unavailable.
+
+    Returns {} for placeholder registry entries whose connector module failed
+    to import (extra not installed) — those are skipped by callers, not
+    treated as audit failures.
+    """
+    from nexus.backends.base.registry import ConnectorRegistry
+
+    info = ConnectorRegistry.get_info(backend_type)
+    cls = info.connector_class
+    if cls is None:
+        return {}
+    return getattr(cls, "CONNECTION_ARGS", {}) or {}
+
+
+def declared_secret_fields(backend_type: str) -> frozenset[str]:
+    """Return the set of CONNECTION_ARGS keys with secret=True for a backend."""
+    args = _get_connection_args(backend_type)
+    return frozenset(name for name, arg in args.items() if getattr(arg, "secret", False))
+
+
+def audit_backend(backend_type: str) -> list[str]:
+    """Return CONNECTION_ARGS keys that look secret-shaped but aren't marked secret=True.
+
+    Empty list = backend passes audit. Non-empty = export must abort.
+    Returns [] for backends whose connector class hasn't loaded (no audit possible
+    until the optional extra is installed; the audit test skips those entries).
+    """
+    args = _get_connection_args(backend_type)
+    return [
+        name
+        for name, arg in args.items()
+        if SECRET_SHAPED.search(name) and not getattr(arg, "secret", False)
+    ]
+
+
+def redact_config(
+    backend_type: str,
+    config: dict[str, Any],
+    *,
+    mount_id: str,
+) -> tuple[dict[str, Any], list[PlaceholderRef]]:
+    """Strip declared secret fields from a mount's backend_config.
+
+    Args:
+        backend_type: Connector registry key (e.g., "path_s3").
+        config: The mount's backend_config dict.
+        mount_id: Used to namespace placeholders (uniqueness across bundle).
+
+    Returns:
+        (redacted_config, placeholders). The redacted dict is a shallow copy with
+        secret fields replaced by `${MOUNT_<id>_<FIELD_UPPER>}`. None values are
+        skipped (no placeholder generated for a field that's None).
+
+    Raises:
+        SensitiveFieldNotDeclaredError: if audit_backend(backend_type) is non-empty.
+    """
+    leaks = audit_backend(backend_type)
+    if leaks:
+        raise SensitiveFieldNotDeclaredError(backend_type=backend_type, fields=leaks)
+
+    secrets = declared_secret_fields(backend_type)
+    out = dict(config)
+    placeholders: list[PlaceholderRef] = []
+
+    for field_name in secrets & out.keys():
+        value = out[field_name]
+        if value is None:
+            continue
+        ph_name = f"MOUNT_{mount_id}_{field_name.upper()}"
+        placeholder_string = f"${{{ph_name}}}"
+        if value == placeholder_string:
+            continue
+        out[field_name] = placeholder_string
+        placeholders.append(
+            PlaceholderRef(name=ph_name, field=f"mounts.{mount_id}.{field_name}")
+        )
+
+    return out, placeholders
+
+
+__all__ = [
+    "SECRET_SHAPED",
+    "declared_secret_fields",
+    "audit_backend",
+    "redact_config",
+]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest src/nexus/bricks/portability/tests/test_redaction_unit.py -v
+```
+
+Expected: 9 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/portability/redaction.py \
+        src/nexus/bricks/portability/tests/test_redaction_unit.py
+git commit -m "feat(portability): add redaction module deriving secrets from CONNECTION_ARGS
+
+Issue: https://github.com/nexi-lab/nexus/issues/4083"
+```
+
+---
+
+## Task 5: CI audit test over CONNECTOR_MANIFEST
+
+**Files:**
+- Test: `src/nexus/bricks/portability/tests/test_redaction_audit.py`
+
+- [ ] **Step 1: Write the audit test**
+
+Create `src/nexus/bricks/portability/tests/test_redaction_audit.py`:
+
+```python
+"""CI gate: every registered connector must pass the secret-shape audit.
+
+Adding a backend whose CONNECTION_ARGS has a key like 'token_xyz' or
+'auth_secret' without marking it secret=True must fail this test.
+"""
+
+import pytest
+
+from nexus.backends._manifest import CONNECTOR_MANIFEST
+from nexus.bricks.portability.redaction import (
+    SECRET_SHAPED,
+    _get_connection_args,
+    audit_backend,
+)
+
+
+@pytest.mark.parametrize("entry", CONNECTOR_MANIFEST, ids=lambda e: e.name)
+def test_connector_passes_secret_shape_audit(entry):
+    """Every CONNECTION_ARGS key matching SECRET_SHAPED must be marked secret=True."""
+    args = _get_connection_args(entry.name)
+    if not args:
+        pytest.skip(f"{entry.name}: connector class not loaded (optional extra not installed)")
+    leaks = audit_backend(entry.name)
+    assert not leaks, (
+        f"{entry.name}: argument names {leaks} match secret-shape regex "
+        f"({SECRET_SHAPED.pattern}) but are not marked secret=True. "
+        f"Either rename them or set secret=True in CONNECTION_ARGS."
+    )
+```
+
+- [ ] **Step 2: Run the audit test**
+
+```bash
+pytest src/nexus/bricks/portability/tests/test_redaction_audit.py -v
+```
+
+Expected: ALL connectors PASS or SKIP (skipped = optional extra absent in dev environment). If a connector FAILs, the failure message names exactly which fields need to be fixed in that connector's CONNECTION_ARGS — fix those before continuing the plan.
+
+- [ ] **Step 3: If any connector fails the audit, fix it in a separate commit**
+
+For each failing connector, edit its CONNECTION_ARGS to set `secret=True` on the offending fields. Re-run the audit test. Commit each connector fix as its own commit:
+
+```bash
+git add src/nexus/backends/<path>/connector.py
+git commit -m "fix(<connector>): mark <field> as secret=True for portability audit
+
+Issue: https://github.com/nexi-lab/nexus/issues/4083"
+```
+
+(If no connectors fail, skip this step.)
+
+- [ ] **Step 4: Commit the audit test**
+
+```bash
+git add src/nexus/bricks/portability/tests/test_redaction_audit.py
+git commit -m "test(portability): CI gate - every connector passes secret-shape audit
+
+Issue: https://github.com/nexi-lab/nexus/issues/4083"
+```
+
+---
+
+## Task 6: Add export/import options for mounts
+
+**Files:**
+- Modify: `src/nexus/bricks/portability/models.py:308` (`ZoneExportOptions`), `:393` (`ZoneImportOptions`)
+- Test: `src/nexus/bricks/portability/tests/test_mount_options.py`
+
+- [ ] **Step 1: Write failing test**
+
+Create `src/nexus/bricks/portability/tests/test_mount_options.py`:
+
+```python
+"""Tests for new mount-portability options."""
+
+from pathlib import Path
+
+from nexus.bricks.portability.models import ZoneExportOptions, ZoneImportOptions
+
+
+def test_export_options_default_include_mounts_false():
+    o = ZoneExportOptions(output_path=Path("/tmp/x.nexus"))
+    assert o.include_mounts is False
+
+
+def test_export_options_accepts_include_mounts_true():
+    o = ZoneExportOptions(output_path=Path("/tmp/x.nexus"), include_mounts=True)
+    assert o.include_mounts is True
+
+
+def test_import_options_default_mount_overrides_none():
+    o = ZoneImportOptions(bundle_path=Path("/tmp/x.nexus"))
+    assert o.mount_overrides is None
+
+
+def test_import_options_default_restore_mounts_true():
+    o = ZoneImportOptions(bundle_path=Path("/tmp/x.nexus"))
+    assert o.restore_mounts is True
+
+
+def test_import_options_accepts_mount_overrides():
+    overrides = {"m-1": {"access_key_id": "AKIA"}}
+    o = ZoneImportOptions(bundle_path=Path("/tmp/x.nexus"), mount_overrides=overrides)
+    assert o.mount_overrides == overrides
+
+
+def test_import_options_accepts_restore_mounts_false():
+    o = ZoneImportOptions(bundle_path=Path("/tmp/x.nexus"), restore_mounts=False)
+    assert o.restore_mounts is False
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest src/nexus/bricks/portability/tests/test_mount_options.py -v
+```
+
+Expected: FAIL — fields don't exist.
+
+- [ ] **Step 3: Add fields to options dataclasses**
+
+In `models.py`, locate `ZoneExportOptions` (line 308). Add field with the other v2-style flags (look for `include_embeddings` or `strip_credentials`):
+
+```python
+    include_mounts: bool = False  # Issue #4083 — opt-in mount config export
+```
+
+In `ZoneImportOptions` (line 393). Append after `force` field (around line 448):
+
+```python
+    # Mount portability (Issue #4083)
+    restore_mounts: bool = True
+    mount_overrides: dict[str, dict[str, str]] | None = None
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest src/nexus/bricks/portability/tests/test_mount_options.py -v
+```
+
+Expected: 6 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/portability/models.py \
+        src/nexus/bricks/portability/tests/test_mount_options.py
+git commit -m "feat(portability): add include_mounts / mount_overrides / restore_mounts
+
+Issue: https://github.com/nexi-lab/nexus/issues/4083"
+```
+
+---
+
+## Task 7: `mount_export.py` — collect mounts and write redacted `mounts.jsonl`
+
+**Files:**
+- Create: `src/nexus/bricks/portability/mount_export.py`
+- Test: `src/nexus/bricks/portability/tests/test_mount_export.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/nexus/bricks/portability/tests/test_mount_export.py`:
+
+```python
+"""Tests for mount_export.py."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.bricks.portability.models import (
+    PlaceholderRef,
+    SensitiveFieldNotDeclaredError,
+)
+from nexus.bricks.portability.mount_export import (
+    collect_mounts,
+    redact_and_write,
+)
+
+
+@pytest.fixture
+def s3_mount_dict():
+    return {
+        "mount_id": "m-1",
+        "mount_point": "/personal/alice",
+        "backend_type": "path_s3",
+        "backend_config": {
+            "bucket_name": "acme",
+            "access_key_id": "AKIA1234",
+            "secret_access_key": "wJalr...",
+        },
+        "owner_user_id": "alice",
+        "zone_id": "acme",
+        "description": None,
+    }
+
+
+def test_collect_mounts_calls_list_mounts_with_zone_filter(s3_mount_dict):
+    mgr = MagicMock()
+    mgr.list_mounts.return_value = [s3_mount_dict]
+    out = collect_mounts(mgr, zone_id="acme")
+    mgr.list_mounts.assert_called_once_with(zone_id="acme")
+    assert out == [s3_mount_dict]
+
+
+def test_collect_mounts_no_zone_filter():
+    mgr = MagicMock()
+    mgr.list_mounts.return_value = []
+    collect_mounts(mgr, zone_id=None)
+    mgr.list_mounts.assert_called_once_with(zone_id=None)
+
+
+def test_redact_and_write_redacts_secrets_and_returns_placeholders(tmp_path, s3_mount_dict):
+    out_path = tmp_path / "mounts.jsonl"
+    placeholders = redact_and_write([s3_mount_dict], out_path=out_path)
+
+    assert out_path.exists()
+    line = out_path.read_text().strip()
+    record = json.loads(line)
+    assert record["backend_config"]["access_key_id"] == "${MOUNT_m-1_ACCESS_KEY_ID}"
+    assert record["backend_config"]["secret_access_key"] == "${MOUNT_m-1_SECRET_ACCESS_KEY}"
+    assert record["backend_config"]["bucket_name"] == "acme"  # not redacted
+
+    assert {p.name for p in placeholders} == {
+        "MOUNT_m-1_ACCESS_KEY_ID",
+        "MOUNT_m-1_SECRET_ACCESS_KEY",
+    }
+    assert all(isinstance(p, PlaceholderRef) for p in placeholders)
+
+
+def test_redact_and_write_sorts_lines_by_mount_id(tmp_path):
+    mounts = [
+        {"mount_id": "m-z", "mount_point": "/z", "backend_type": "path_local",
+         "backend_config": {}, "owner_user_id": None, "zone_id": None, "description": None},
+        {"mount_id": "m-a", "mount_point": "/a", "backend_type": "path_local",
+         "backend_config": {}, "owner_user_id": None, "zone_id": None, "description": None},
+    ]
+    out_path = tmp_path / "mounts.jsonl"
+    redact_and_write(mounts, out_path=out_path)
+    lines = out_path.read_text().strip().split("\n")
+    assert json.loads(lines[0])["mount_id"] == "m-a"
+    assert json.loads(lines[1])["mount_id"] == "m-z"
+
+
+def test_redact_and_write_byte_stable_across_runs(tmp_path, s3_mount_dict):
+    out1 = tmp_path / "a.jsonl"
+    out2 = tmp_path / "b.jsonl"
+    redact_and_write([s3_mount_dict], out_path=out1)
+    redact_and_write([s3_mount_dict], out_path=out2)
+    assert out1.read_bytes() == out2.read_bytes()
+
+
+def test_redact_and_write_audit_failure_raises(tmp_path):
+    """If a mount references a backend whose CONNECTION_ARGS audit fails, raise."""
+    from unittest.mock import patch
+
+    bad_mount = {
+        "mount_id": "m-1", "mount_point": "/x", "backend_type": "path_s3",
+        "backend_config": {"my_token": "x"},
+        "owner_user_id": None, "zone_id": None, "description": None,
+    }
+    with patch(
+        "nexus.bricks.portability.redaction.audit_backend",
+        return_value=["my_token"],
+    ):
+        with pytest.raises(SensitiveFieldNotDeclaredError):
+            redact_and_write([bad_mount], out_path=tmp_path / "x.jsonl")
+
+
+def test_redact_and_write_empty_list_writes_empty_file(tmp_path):
+    out_path = tmp_path / "mounts.jsonl"
+    placeholders = redact_and_write([], out_path=out_path)
+    assert out_path.exists()
+    assert out_path.read_text() == ""
+    assert placeholders == []
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest src/nexus/bricks/portability/tests/test_mount_export.py -v
+```
+
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement `mount_export.py`**
+
+Create `src/nexus/bricks/portability/mount_export.py`:
+
+```python
+"""Mount-config export for .nexus bundles (Issue #4083).
+
+Pulls mount configurations from MountManager, runs each through the redaction
+contract (declared via ConnectionArg.secret=True), and writes a sorted JSONL
+file alongside the rest of the bundle. Audit failures abort the export with
+SensitiveFieldNotDeclaredError before any bytes are written.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from nexus.bricks.portability.models import MountRecord, PlaceholderRef
+from nexus.bricks.portability.redaction import redact_config
+
+if TYPE_CHECKING:
+    from nexus.bricks.mount.mount_manager import MountManager
+
+
+def collect_mounts(
+    mount_manager: "MountManager",
+    *,
+    zone_id: str | None,
+) -> list[dict[str, Any]]:
+    """Return raw mount-config dicts from MountManager (zone-filtered if zone_id set).
+
+    Output dicts have keys: mount_id, mount_point, backend_type, backend_config,
+    owner_user_id, zone_id, description.
+    """
+    return mount_manager.list_mounts(zone_id=zone_id)
+
+
+def redact_and_write(
+    mounts: list[dict[str, Any]],
+    *,
+    out_path: Path,
+) -> list[PlaceholderRef]:
+    """Per-mount: run redaction, write JSONL line; return aggregated placeholders.
+
+    Lines are sorted by mount_id for byte-stable output. Each line is canonical
+    JSON (sort_keys=True, no extra whitespace). On audit failure for any mount,
+    raises SensitiveFieldNotDeclaredError before writing anything.
+    """
+    sorted_mounts = sorted(mounts, key=lambda m: m["mount_id"])
+
+    # Phase 1: redact in memory, surface audit failures before any I/O.
+    redacted_records: list[MountRecord] = []
+    placeholders: list[PlaceholderRef] = []
+    for raw in sorted_mounts:
+        redacted_config, mount_phs = redact_config(
+            backend_type=raw["backend_type"],
+            config=raw.get("backend_config", {}) or {},
+            mount_id=raw["mount_id"],
+        )
+        record = MountRecord(
+            mount_id=raw["mount_id"],
+            mount_point=raw["mount_point"],
+            backend_type=raw["backend_type"],
+            backend_config=redacted_config,
+            owner_user_id=raw.get("owner_user_id"),
+            zone_id=raw.get("zone_id"),
+            description=raw.get("description"),
+        )
+        redacted_records.append(record)
+        placeholders.extend(mount_phs)
+
+    # Phase 2: write JSONL
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    with out_path.open("w") as fh:
+        for record in redacted_records:
+            fh.write(json.dumps(record.to_dict(), sort_keys=True))
+            fh.write("\n")
+    if not redacted_records:
+        out_path.write_text("")  # touch empty file
+
+    return placeholders
+
+
+__all__ = ["collect_mounts", "redact_and_write"]
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest src/nexus/bricks/portability/tests/test_mount_export.py -v
+```
+
+Expected: 7 tests PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/portability/mount_export.py \
+        src/nexus/bricks/portability/tests/test_mount_export.py
+git commit -m "feat(portability): mount_export module with redacted JSONL output
+
+Issue: https://github.com/nexi-lab/nexus/issues/4083"
+```
+
+---
+
+## Task 8: `mount_import.py` — read, validate, materialize, restore
+
+**Files:**
+- Create: `src/nexus/bricks/portability/mount_import.py`
+- Test: `src/nexus/bricks/portability/tests/test_mount_import.py`
+
+- [ ] **Step 1: Write failing tests**
+
+Create `src/nexus/bricks/portability/tests/test_mount_import.py`:
+
+```python
+"""Tests for mount_import.py."""
+
+import json
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.bricks.portability.models import (
+    ConflictMode,
+    MissingCredentialsError,
+    MountRecord,
+)
+from nexus.bricks.portability.mount_import import (
+    import_mounts,
+    materialize,
+    read_mounts,
+    validate_overrides,
+)
+
+
+@pytest.fixture
+def redacted_record():
+    return MountRecord(
+        mount_id="m-1",
+        mount_point="/personal/alice",
+        backend_type="path_s3",
+        backend_config={
+            "bucket_name": "acme",
+            "access_key_id": "${MOUNT_m-1_ACCESS_KEY_ID}",
+            "secret_access_key": "${MOUNT_m-1_SECRET_ACCESS_KEY}",
+        },
+        owner_user_id="alice",
+        zone_id="acme",
+        description=None,
+    )
+
+
+def test_read_mounts_absent_file_returns_empty(tmp_path):
+    assert read_mounts(tmp_path) == []
+
+
+def test_read_mounts_parses_jsonl(tmp_path, redacted_record):
+    p = tmp_path / "mounts.jsonl"
+    p.write_text(json.dumps(redacted_record.to_dict()) + "\n")
+    out = read_mounts(tmp_path)
+    assert len(out) == 1
+    assert out[0] == redacted_record
+
+
+def test_read_mounts_skips_blank_lines(tmp_path, redacted_record):
+    p = tmp_path / "mounts.jsonl"
+    p.write_text(json.dumps(redacted_record.to_dict()) + "\n\n")
+    assert len(read_mounts(tmp_path)) == 1
+
+
+def test_validate_overrides_no_redacted_fields_passes():
+    rec = MountRecord(
+        mount_id="m-1", mount_point="/x", backend_type="path_local",
+        backend_config={"root": "/data"},
+    )
+    validate_overrides([rec], overrides=None)  # no raise
+
+
+def test_validate_overrides_missing_raises_with_all_gaps(redacted_record):
+    rec2 = MountRecord(
+        mount_id="m-2", mount_point="/y", backend_type="path_s3",
+        backend_config={"access_key_id": "${MOUNT_m-2_ACCESS_KEY_ID}"},
+    )
+    with pytest.raises(MissingCredentialsError) as exc:
+        validate_overrides([redacted_record, rec2], overrides=None)
+    missing = exc.value.missing
+    assert set(missing.keys()) == {"m-1", "m-2"}
+    assert "access_key_id" in missing["m-1"]
+    assert "secret_access_key" in missing["m-1"]
+    assert "access_key_id" in missing["m-2"]
+
+
+def test_validate_overrides_partial_provided_still_raises(redacted_record):
+    overrides = {"m-1": {"access_key_id": "AKIA"}}  # missing secret_access_key
+    with pytest.raises(MissingCredentialsError) as exc:
+        validate_overrides([redacted_record], overrides=overrides)
+    assert exc.value.missing == {"m-1": ["secret_access_key"]}
+
+
+def test_validate_overrides_full_passes(redacted_record):
+    overrides = {"m-1": {"access_key_id": "AKIA", "secret_access_key": "wJalr"}}
+    validate_overrides([redacted_record], overrides=overrides)  # no raise
+
+
+def test_materialize_substitutes_placeholders(redacted_record):
+    overrides = {"access_key_id": "AKIA", "secret_access_key": "wJalr"}
+    out = materialize(redacted_record, overrides)
+    assert out["access_key_id"] == "AKIA"
+    assert out["secret_access_key"] == "wJalr"
+    assert out["bucket_name"] == "acme"
+
+
+def test_import_mounts_calls_save_mount_per_record(redacted_record):
+    mgr = MagicMock()
+    mgr.get_mount.return_value = None  # no conflict
+    overrides = {"m-1": {"access_key_id": "AKIA", "secret_access_key": "wJalr"}}
+    errors = import_mounts(
+        mounts=[redacted_record],
+        overrides=overrides,
+        mount_manager=mgr,
+        target_zone_id=None,
+        conflict_mode=ConflictMode.SKIP,
+    )
+    assert errors == []
+    assert mgr.save_mount.call_count == 1
+    kwargs = mgr.save_mount.call_args.kwargs
+    assert kwargs["mount_point"] == "/personal/alice"
+    assert kwargs["backend_type"] == "path_s3"
+    assert kwargs["backend_config"]["access_key_id"] == "AKIA"
+
+
+def test_import_mounts_skip_existing_records_info(redacted_record):
+    mgr = MagicMock()
+    mgr.get_mount.return_value = {"mount_point": "/personal/alice"}  # already there
+    errors = import_mounts(
+        mounts=[redacted_record],
+        overrides={"m-1": {"access_key_id": "AKIA", "secret_access_key": "w"}},
+        mount_manager=mgr,
+        target_zone_id=None,
+        conflict_mode=ConflictMode.SKIP,
+    )
+    assert mgr.save_mount.call_count == 0
+    assert len(errors) == 1
+    assert "alice" in errors[0].message
+
+
+def test_import_mounts_overwrite_calls_update(redacted_record):
+    mgr = MagicMock()
+    mgr.get_mount.return_value = {"mount_point": "/personal/alice"}
+    import_mounts(
+        mounts=[redacted_record],
+        overrides={"m-1": {"access_key_id": "AKIA", "secret_access_key": "w"}},
+        mount_manager=mgr,
+        target_zone_id=None,
+        conflict_mode=ConflictMode.OVERWRITE,
+    )
+    mgr.update_mount.assert_called_once()
+    assert mgr.save_mount.call_count == 0
+
+
+def test_import_mounts_zone_remap_applied(redacted_record):
+    mgr = MagicMock()
+    mgr.get_mount.return_value = None
+    import_mounts(
+        mounts=[redacted_record],
+        overrides={"m-1": {"access_key_id": "AKIA", "secret_access_key": "w"}},
+        mount_manager=mgr,
+        target_zone_id="new-zone",
+        conflict_mode=ConflictMode.SKIP,
+    )
+    assert mgr.save_mount.call_args.kwargs["zone_id"] == "new-zone"
+
+
+def test_import_mounts_orders_by_path_depth(redacted_record):
+    """Parents must restore before children to avoid ordering bugs."""
+    mgr = MagicMock()
+    mgr.get_mount.return_value = None
+    deep = MountRecord(
+        mount_id="m-deep", mount_point="/personal/alice/sub", backend_type="path_local",
+        backend_config={"root": "/x"},
+    )
+    shallow = MountRecord(
+        mount_id="m-shallow", mount_point="/personal", backend_type="path_local",
+        backend_config={"root": "/y"},
+    )
+    import_mounts(
+        mounts=[deep, shallow],
+        overrides={},
+        mount_manager=mgr,
+        target_zone_id=None,
+        conflict_mode=ConflictMode.SKIP,
+    )
+    saved_paths = [c.kwargs["mount_point"] for c in mgr.save_mount.call_args_list]
+    assert saved_paths.index("/personal") < saved_paths.index("/personal/alice/sub")
+```
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+```bash
+pytest src/nexus/bricks/portability/tests/test_mount_import.py -v
+```
+
+Expected: FAIL — module does not exist.
+
+- [ ] **Step 3: Implement `mount_import.py`**
+
+Create `src/nexus/bricks/portability/mount_import.py`:
+
+```python
+"""Mount-config import for .nexus bundles (Issue #4083).
+
+Reads mounts.jsonl, validates that all redacted fields have overrides supplied,
+re-injects values, and restores via MountManager. Validation runs *before* any
+backend init or persistence — operators see every credential gap in one error.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+from nexus.bricks.portability.models import (
+    ConflictMode,
+    ImportError,
+    MissingCredentialsError,
+    MountRecord,
+)
+
+if TYPE_CHECKING:
+    from nexus.bricks.mount.mount_manager import MountManager
+
+
+_PLACEHOLDER_RE = re.compile(r"^\$\{MOUNT_(?P<id>[^_]+(?:_[^_]+)*)_(?P<field>[A-Z0-9_]+)\}$")
+"""Matches ${MOUNT_<id>_<FIELD>} where <id> may contain underscores and <field>
+is the upper-cased CONNECTION_ARGS key."""
+
+
+def read_mounts(bundle_dir: Path) -> list[MountRecord]:
+    """Parse bundle_dir/mounts.jsonl. Returns [] if the file is absent (v1/v2 bundle)."""
+    path = bundle_dir / "mounts.jsonl"
+    if not path.exists():
+        return []
+    out: list[MountRecord] = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        out.append(MountRecord.from_dict(json.loads(line)))
+    return out
+
+
+def _redacted_fields(record: MountRecord) -> list[str]:
+    """Return the list of CONNECTION_ARGS keys whose value is a placeholder string."""
+    return [
+        name
+        for name, value in record.backend_config.items()
+        if isinstance(value, str) and _PLACEHOLDER_RE.match(value)
+    ]
+
+
+def validate_overrides(
+    mounts: list[MountRecord],
+    overrides: dict[str, dict[str, str]] | None,
+) -> None:
+    """Walk every redacted field; raise MissingCredentialsError listing all gaps.
+
+    Pure function: no side effects. Runs before any backend init.
+    """
+    overrides = overrides or {}
+    missing: dict[str, list[str]] = {}
+    for record in mounts:
+        provided = overrides.get(record.mount_id, {}) or {}
+        gaps = [f for f in _redacted_fields(record) if f not in provided]
+        if gaps:
+            missing[record.mount_id] = sorted(gaps)
+    if missing:
+        raise MissingCredentialsError(missing=missing)
+
+
+def materialize(
+    mount_record: MountRecord,
+    overrides_for_mount: dict[str, str],
+) -> dict[str, Any]:
+    """Substitute ${MOUNT_<id>_<FIELD>} placeholders. Returns the final backend_config."""
+    out = dict(mount_record.backend_config)
+    for field_name, value in list(out.items()):
+        if isinstance(value, str) and _PLACEHOLDER_RE.match(value):
+            if field_name in overrides_for_mount:
+                out[field_name] = overrides_for_mount[field_name]
+    return out
+
+
+def import_mounts(
+    mounts: list[MountRecord],
+    overrides: dict[str, dict[str, str]],
+    mount_manager: "MountManager",
+    *,
+    target_zone_id: str | None,
+    conflict_mode: ConflictMode,
+) -> list[ImportError]:
+    """Per mount: materialize + save_mount/update_mount per conflict_mode.
+
+    Mounts are sorted by mount_point depth (shallowest first) so parent paths
+    restore before any nested children that may depend on them.
+
+    Returns per-mount errors; does not raise except on programmer bugs.
+    """
+    errors: list[ImportError] = []
+    overrides = overrides or {}
+    sorted_mounts = sorted(mounts, key=lambda m: len(m.mount_point.split("/")))
+
+    for record in sorted_mounts:
+        mount_overrides = overrides.get(record.mount_id, {}) or {}
+        backend_config = materialize(record, mount_overrides)
+        zone_id = target_zone_id if target_zone_id is not None else record.zone_id
+
+        existing = mount_manager.get_mount(record.mount_point)
+        if existing is not None:
+            if conflict_mode == ConflictMode.SKIP:
+                errors.append(
+                    ImportError(
+                        message=f"mount {record.mount_point!r} already exists; skipped",
+                        severity="info",
+                    )
+                )
+                continue
+            if conflict_mode == ConflictMode.FAIL:
+                errors.append(
+                    ImportError(
+                        message=f"mount {record.mount_point!r} already exists",
+                        severity="error",
+                    )
+                )
+                continue
+            if conflict_mode == ConflictMode.OVERWRITE:
+                mount_manager.update_mount(
+                    mount_point=record.mount_point,
+                    backend_config=backend_config,
+                    description=record.description,
+                )
+                continue
+
+        try:
+            mount_manager.save_mount(
+                mount_point=record.mount_point,
+                backend_type=record.backend_type,
+                backend_config=backend_config,
+                owner_user_id=record.owner_user_id,
+                zone_id=zone_id,
+                description=record.description,
+            )
+        except Exception as exc:  # noqa: BLE001
+            errors.append(
+                ImportError(
+                    message=f"failed to restore mount {record.mount_point!r}: {exc}",
+                    severity="error",
+                )
+            )
+
+    return errors
+
+
+__all__ = [
+    "read_mounts",
+    "validate_overrides",
+    "materialize",
+    "import_mounts",
+]
+```
+
+**Note**: This task assumes `ImportError` (from `models.py`) accepts `message` and `severity` kwargs. If its current signature differs, adjust the calls — check `models.py:67` (or the existing `ImportError` class definition) before running tests.
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+```bash
+pytest src/nexus/bricks/portability/tests/test_mount_import.py -v
+```
+
+Expected: 13 tests PASS. If `ImportError` signature mismatch, fix the calls in `mount_import.py` and re-run.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/nexus/bricks/portability/mount_import.py \
+        src/nexus/bricks/portability/tests/test_mount_import.py
+git commit -m "feat(portability): mount_import with validate-then-materialize-then-restore
+
+Issue: https://github.com/nexi-lab/nexus/issues/4083"
+```
+
+---
+
+## Task 9: Wire `mount_export` into `export_service.py`
+
+**Files:**
+- Modify: `src/nexus/bricks/portability/export_service.py:105` (`__init__`), at the end of the export flow (after `_apply_credential_stripping`, around line 234)
+
+- [ ] **Step 1: Read the current `export_service.py:200-260` to confirm the splice point**
+
+```bash
+sed -n '200,260p' src/nexus/bricks/portability/export_service.py
+```
+
+Confirm the credential stripping block ends with `manifest.placeholders = list(placeholders)`. Splice point: immediately after that block.
+
+- [ ] **Step 2: Write failing integration test**
+
+Create `src/nexus/bricks/portability/tests/test_export_service_mounts.py`:
+
+```python
+"""Wiring tests for mount export integration."""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.bricks.portability.export_service import ZoneExportService
+from nexus.bricks.portability.models import ZoneExportOptions
+
+
+def test_include_mounts_true_without_mount_manager_raises(tmp_path):
+    fs = MagicMock()
+    service = ZoneExportService(fs)
+    options = ZoneExportOptions(
+        output_path=tmp_path / "x.nexus",
+        include_mounts=True,
+    )
+    # Note: actual export call may need other args; this test verifies the
+    # validation runs early. Adjust to match service signature once you read
+    # the existing export entrypoint.
+    with pytest.raises(ValueError, match="mount_manager"):
+        # Synchronous if export_zone is async, wrap with anyio.run or asyncio.run
+        # For this test, we expect the constructor or first arg validation
+        # to trip — adjust as needed based on existing code shape.
+        import asyncio
+        asyncio.run(service.export_zone("z1", options))
+```
+
+(If `export_zone` is sync, drop the `asyncio.run` wrapper. Read `export_service.py:117` to determine signature.)
+
+- [ ] **Step 3: Run test to verify it fails**
+
+```bash
+pytest src/nexus/bricks/portability/tests/test_export_service_mounts.py -v
+```
+
+Expected: FAIL — `ValueError` not raised (validation not yet wired).
+
+- [ ] **Step 4: Modify `ZoneExportService.__init__` to accept optional `mount_manager`**
+
+Edit `src/nexus/bricks/portability/export_service.py`. Find the `__init__` signature (around line 130). Add an optional kwarg:
+
+```python
+def __init__(
+    self,
+    nexus_fs: "PortabilityFSProtocol",
+    *,
+    mount_manager: "MountManager | None" = None,
+) -> None:
+    self._fs = nexus_fs
+    self._mount_manager = mount_manager
+```
+
+Add a TYPE_CHECKING import near the top:
+
+```python
+if TYPE_CHECKING:
+    from nexus.bricks.mount.mount_manager import MountManager
+    from nexus.contracts.portability_types import PortabilityFSProtocol
+```
+
+- [ ] **Step 5: Add early validation in `export_zone`**
+
+Find the start of the export flow inside `export_zone` (the method body around line 140). Add at the very top:
+
+```python
+if options.include_mounts and self._mount_manager is None:
+    raise ValueError(
+        "ZoneExportOptions.include_mounts=True requires "
+        "ZoneExportService(mount_manager=...)"
+    )
+```
+
+- [ ] **Step 6: Add the mount-export call after credential stripping**
+
+After the existing `_apply_credential_stripping` block (around line 234, where `manifest.placeholders = list(placeholders)` is set), add:
+
+```python
+# --- Mount-config export (v3+, Issue #4083) ---
+if options.include_mounts:
+    from nexus.bricks.portability.mount_export import (
+        collect_mounts,
+        redact_and_write,
+    )
+    mounts_path = bundle_dir / "mounts.jsonl"
+    raw_mounts = collect_mounts(self._mount_manager, zone_id=zone_id)
+    mount_phs = redact_and_write(raw_mounts, out_path=mounts_path)
+    manifest.placeholders = list(manifest.placeholders) + list(mount_phs)
+    manifest.mount_count = len(raw_mounts)
+    logger.info(
+        "Mount export: %d mounts, %d placeholders", len(raw_mounts), len(mount_phs)
+    )
+```
+
+- [ ] **Step 7: Run wiring test to verify it passes**
+
+```bash
+pytest src/nexus/bricks/portability/tests/test_export_service_mounts.py -v
+```
+
+Expected: PASS.
+
+- [ ] **Step 8: Run the full portability suite to confirm no regressions**
+
+```bash
+pytest src/nexus/bricks/portability/tests/ -v
+```
+
+Expected: ALL pass.
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add src/nexus/bricks/portability/export_service.py \
+        src/nexus/bricks/portability/tests/test_export_service_mounts.py
+git commit -m "feat(portability): wire mount_export into ZoneExportService
+
+Issue: https://github.com/nexi-lab/nexus/issues/4083"
+```
+
+---
+
+## Task 10: Wire `mount_import` into `import_service.py`
+
+**Files:**
+- Modify: `src/nexus/bricks/portability/import_service.py` (`__init__` + `import_zone` early validation + restore section)
+
+- [ ] **Step 1: Read the current import flow**
+
+```bash
+sed -n '1,80p' src/nexus/bricks/portability/import_service.py
+grep -n "def __init__\|def import_zone\|class ZoneImportService" src/nexus/bricks/portability/import_service.py | head
+```
+
+Identify the `__init__` and main entrypoint methods.
+
+- [ ] **Step 2: Write failing integration test**
+
+Create `src/nexus/bricks/portability/tests/test_import_service_mounts.py`:
+
+```python
+"""Wiring tests for mount import integration."""
+
+import json
+import tarfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.bricks.portability.import_service import ZoneImportService
+from nexus.bricks.portability.models import (
+    BUNDLE_FORMAT_VERSION,
+    MissingCredentialsError,
+    ZoneImportOptions,
+)
+
+
+def _build_bundle_with_mount(tmp_path: Path) -> Path:
+    """Create a minimal v3 bundle containing mounts.jsonl."""
+    bundle_dir = tmp_path / "src"
+    bundle_dir.mkdir()
+    manifest = {
+        "$schema": "https://nexus.io/schemas/manifest-v3.json",
+        "format_version": BUNDLE_FORMAT_VERSION,
+        "bundle_id": "550e8400-e29b-41d4-a716-446655440000",
+        "source_zone_id": "z1",
+        "export_timestamp": "2026-01-01T00:00:00+00:00",
+        "statistics": {
+            "file_count": 0, "total_size_bytes": 0, "content_blob_count": 0,
+            "permission_count": 0, "embedding_count": 0, "mount_count": 1,
+        },
+        "options": {"include_content": True, "include_permissions": True},
+        "checksums": {"algorithm": "sha256", "files": {}},
+    }
+    (bundle_dir / "manifest.json").write_text(json.dumps(manifest))
+    (bundle_dir / "mounts.jsonl").write_text(json.dumps({
+        "mount_id": "m-1", "mount_point": "/x", "backend_type": "path_s3",
+        "backend_config": {
+            "bucket_name": "acme",
+            "access_key_id": "${MOUNT_m-1_ACCESS_KEY_ID}",
+            "secret_access_key": "${MOUNT_m-1_SECRET_ACCESS_KEY}",
+        },
+        "owner_user_id": "alice", "zone_id": "z1", "description": None,
+    }) + "\n")
+
+    out = tmp_path / "bundle.nexus"
+    with tarfile.open(out, "w:gz") as tar:
+        for p in bundle_dir.rglob("*"):
+            tar.add(p, arcname=p.relative_to(bundle_dir))
+    return out
+
+
+@pytest.mark.asyncio
+async def test_import_without_overrides_raises_before_side_effects(tmp_path):
+    bundle = _build_bundle_with_mount(tmp_path)
+    fs = MagicMock()
+    mgr = MagicMock()
+    service = ZoneImportService(fs, mount_manager=mgr)
+
+    options = ZoneImportOptions(bundle_path=bundle)
+    with pytest.raises(MissingCredentialsError) as exc:
+        await service.import_zone(options)
+    assert "m-1" in exc.value.missing
+    assert mgr.save_mount.call_count == 0
+    assert mgr.update_mount.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_import_with_overrides_calls_save_mount(tmp_path):
+    bundle = _build_bundle_with_mount(tmp_path)
+    fs = MagicMock()
+    mgr = MagicMock()
+    mgr.get_mount.return_value = None
+    service = ZoneImportService(fs, mount_manager=mgr)
+
+    options = ZoneImportOptions(
+        bundle_path=bundle,
+        mount_overrides={"m-1": {"access_key_id": "AKIA", "secret_access_key": "wJalr"}},
+    )
+    await service.import_zone(options)
+    assert mgr.save_mount.call_count == 1
+    cfg = mgr.save_mount.call_args.kwargs["backend_config"]
+    assert cfg["access_key_id"] == "AKIA"
+    assert cfg["secret_access_key"] == "wJalr"
+
+
+@pytest.mark.asyncio
+async def test_import_restore_mounts_false_skips_mount_step(tmp_path):
+    bundle = _build_bundle_with_mount(tmp_path)
+    fs = MagicMock()
+    mgr = MagicMock()
+    service = ZoneImportService(fs, mount_manager=mgr)
+    options = ZoneImportOptions(bundle_path=bundle, restore_mounts=False)
+    await service.import_zone(options)
+    assert mgr.save_mount.call_count == 0
+
+
+@pytest.mark.asyncio
+async def test_import_v2_bundle_no_mounts_jsonl_does_nothing(tmp_path):
+    """v2 bundle (no mounts.jsonl) imports cleanly."""
+    bundle_dir = tmp_path / "src"
+    bundle_dir.mkdir()
+    manifest = {
+        "$schema": "https://nexus.io/schemas/manifest-v1.json",
+        "format_version": "2.0.0",
+        "bundle_id": "550e8400-e29b-41d4-a716-446655440000",
+        "source_zone_id": "z1",
+        "export_timestamp": "2026-01-01T00:00:00+00:00",
+        "statistics": {"file_count": 0, "total_size_bytes": 0,
+                       "content_blob_count": 0, "permission_count": 0,
+                       "embedding_count": 0},
+        "options": {"include_content": True, "include_permissions": True},
+        "checksums": {"algorithm": "sha256", "files": {}},
+    }
+    (bundle_dir / "manifest.json").write_text(json.dumps(manifest))
+    out = tmp_path / "bundle.nexus"
+    with tarfile.open(out, "w:gz") as tar:
+        for p in bundle_dir.rglob("*"):
+            tar.add(p, arcname=p.relative_to(bundle_dir))
+
+    fs = MagicMock()
+    mgr = MagicMock()
+    service = ZoneImportService(fs, mount_manager=mgr)
+    await service.import_zone(ZoneImportOptions(bundle_path=out))
+    assert mgr.save_mount.call_count == 0
+```
+
+(If the existing import service is synchronous, drop `pytest.mark.asyncio` and the `await`s. Confirm by reading the entrypoint signature.)
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+```bash
+pytest src/nexus/bricks/portability/tests/test_import_service_mounts.py -v
+```
+
+Expected: FAIL — wiring not yet present.
+
+- [ ] **Step 4: Modify `ZoneImportService.__init__` to accept optional `mount_manager`**
+
+Edit `src/nexus/bricks/portability/import_service.py`. Add optional kwarg to the existing `__init__`:
+
+```python
+def __init__(
+    self,
+    nexus_fs: "PortabilityFSProtocol",
+    *,
+    mount_manager: "MountManager | None" = None,
+) -> None:
+    self._fs = nexus_fs
+    self._mount_manager = mount_manager
+```
+
+Add the TYPE_CHECKING import:
+
+```python
+if TYPE_CHECKING:
+    from nexus.bricks.mount.mount_manager import MountManager
+    # ... existing imports ...
+```
+
+- [ ] **Step 5: Add validation + restore at the right points in `import_zone`**
+
+Locate `import_zone`. After the bundle is extracted to a `bundle_dir` (search for the existing `tarfile.open(...).extractall` call), insert mount-validation **before any other restore step**:
+
+```python
+# --- Mount validation (Issue #4083) — BEFORE any side effect ---
+if options.restore_mounts:
+    from nexus.bricks.portability.mount_import import (
+        read_mounts,
+        validate_overrides,
+    )
+    _mount_records = read_mounts(bundle_dir)
+    if _mount_records:
+        validate_overrides(_mount_records, options.mount_overrides)
+        if self._mount_manager is None:
+            raise ValueError(
+                "Bundle contains mounts.jsonl but no MountManager supplied. "
+                "Pass ZoneImportService(mount_manager=...) or set restore_mounts=False."
+            )
+else:
+    _mount_records = []
+```
+
+Then, after the existing files/permissions/embeddings restore (find the end of `import_zone`'s main flow, just before `return result`), add:
+
+```python
+# --- Mount restore (Issue #4083) ---
+if _mount_records and options.restore_mounts:
+    from nexus.bricks.portability.mount_import import import_mounts
+    mount_errors = import_mounts(
+        mounts=_mount_records,
+        overrides=options.mount_overrides or {},
+        mount_manager=self._mount_manager,
+        target_zone_id=options.target_zone_id,
+        conflict_mode=options.conflict_mode,
+    )
+    result.errors.extend(mount_errors)
+```
+
+- [ ] **Step 6: Run wiring tests to verify they pass**
+
+```bash
+pytest src/nexus/bricks/portability/tests/test_import_service_mounts.py -v
+```
+
+Expected: 4 tests PASS.
+
+- [ ] **Step 7: Run full portability suite**
+
+```bash
+pytest src/nexus/bricks/portability/tests/ -v
+```
+
+Expected: ALL pass.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add src/nexus/bricks/portability/import_service.py \
+        src/nexus/bricks/portability/tests/test_import_service_mounts.py
+git commit -m "feat(portability): wire mount_import into ZoneImportService
+
+Validate overrides before any side effect; restore mounts after files/perms.
+
+Issue: https://github.com/nexi-lab/nexus/issues/4083"
+```
+
+---
+
+## Task 11: Public API exports in `__init__.py`
+
+**Files:**
+- Modify: `src/nexus/bricks/portability/__init__.py:38-112`
+
+- [ ] **Step 1: Add new imports and `__all__` entries**
+
+Edit `src/nexus/bricks/portability/__init__.py`. Add to the existing `from nexus.bricks.portability.models import (...)` block (line 51):
+
+```python
+    MissingCredentialsError,
+    MountRecord,
+    SensitiveFieldNotDeclaredError,
+```
+
+After the existing service imports, add:
+
+```python
+from nexus.bricks.portability.mount_export import (
+    collect_mounts,
+    redact_and_write,
+)
+from nexus.bricks.portability.mount_import import (
+    import_mounts,
+    materialize,
+    read_mounts,
+    validate_overrides,
+)
+from nexus.bricks.portability.redaction import (
+    audit_backend,
+    declared_secret_fields,
+    redact_config,
+)
+```
+
+Append to `__all__` (line 75):
+
+```python
+    # Mount portability (Issue #4083)
+    "MountRecord",
+    "MissingCredentialsError",
+    "SensitiveFieldNotDeclaredError",
+    "audit_backend",
+    "declared_secret_fields",
+    "redact_config",
+    "collect_mounts",
+    "redact_and_write",
+    "read_mounts",
+    "validate_overrides",
+    "materialize",
+    "import_mounts",
+```
+
+- [ ] **Step 2: Verify the import surface**
+
+```bash
+python -c "from nexus.bricks.portability import MountRecord, MissingCredentialsError, audit_backend, redact_config, read_mounts, validate_overrides, import_mounts; print('OK')"
+```
+
+Expected: `OK`.
+
+- [ ] **Step 3: Run the suite to verify nothing broke**
+
+```bash
+pytest src/nexus/bricks/portability/tests/ -v
+```
+
+Expected: ALL pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/nexus/bricks/portability/__init__.py
+git commit -m "feat(portability): export mount-portability public API
+
+Issue: https://github.com/nexi-lab/nexus/issues/4083"
+```
+
+---
+
+## Task 12: End-to-end roundtrip integration test
+
+**Files:**
+- Test: `src/nexus/bricks/portability/tests/test_roundtrip_with_mounts.py`
+
+- [ ] **Step 1: Write the integration test**
+
+Create `src/nexus/bricks/portability/tests/test_roundtrip_with_mounts.py`:
+
+```python
+"""End-to-end roundtrip: export bundle with mounts → import → mounts restored.
+
+Black-box test against real ZoneExportService + ZoneImportService. Uses
+in-memory MountManager test doubles to avoid VFS plumbing for the kernel.
+"""
+
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.bricks.portability.export_service import ZoneExportService
+from nexus.bricks.portability.import_service import ZoneImportService
+from nexus.bricks.portability.models import (
+    MissingCredentialsError,
+    ZoneExportOptions,
+    ZoneImportOptions,
+)
+
+
+def _make_mount_manager_with(mounts: list[dict]) -> MagicMock:
+    """Build a MountManager test double that returns `mounts` from list_mounts."""
+    mgr = MagicMock()
+    mgr.list_mounts.return_value = mounts
+    mgr.get_mount.return_value = None  # no conflict
+    return mgr
+
+
+@pytest.mark.asyncio
+async def test_roundtrip_export_then_import_with_overrides(tmp_path):
+    src_mgr = _make_mount_manager_with([
+        {
+            "mount_id": "m-1", "mount_point": "/personal/alice",
+            "backend_type": "path_s3",
+            "backend_config": {
+                "bucket_name": "acme",
+                "access_key_id": "AKIA-LIVE-KEY",
+                "secret_access_key": "wJalr-LIVE-SECRET",
+            },
+            "owner_user_id": "alice", "zone_id": "z1", "description": None,
+        },
+    ])
+
+    fs = MagicMock()
+    out = tmp_path / "bundle.nexus"
+    exporter = ZoneExportService(fs, mount_manager=src_mgr)
+    await exporter.export_zone(
+        "z1",
+        ZoneExportOptions(output_path=out, include_mounts=True),
+    )
+    assert out.exists()
+
+    # Verify export stripped secrets — read raw mounts.jsonl back out of the tar.
+    import json
+    import tarfile
+    with tarfile.open(out, "r:gz") as tar:
+        member = tar.getmember("mounts.jsonl")
+        f = tar.extractfile(member)
+        assert f is not None
+        record = json.loads(f.read().decode())
+    assert record["backend_config"]["access_key_id"] == "${MOUNT_m-1_ACCESS_KEY_ID}"
+    assert "AKIA-LIVE-KEY" not in f.read() if hasattr(f, 'read') else True
+
+    # Import without overrides → MissingCredentialsError
+    dst_mgr = MagicMock()
+    dst_mgr.get_mount.return_value = None
+    importer = ZoneImportService(fs, mount_manager=dst_mgr)
+    with pytest.raises(MissingCredentialsError):
+        await importer.import_zone(ZoneImportOptions(bundle_path=out))
+    assert dst_mgr.save_mount.call_count == 0
+
+    # Import with full overrides → save_mount called with concrete values
+    await importer.import_zone(ZoneImportOptions(
+        bundle_path=out,
+        mount_overrides={"m-1": {
+            "access_key_id": "AKIA-NEW-KEY",
+            "secret_access_key": "wJalr-NEW-SECRET",
+        }},
+    ))
+    assert dst_mgr.save_mount.call_count == 1
+    saved_cfg = dst_mgr.save_mount.call_args.kwargs["backend_config"]
+    assert saved_cfg["access_key_id"] == "AKIA-NEW-KEY"
+    assert saved_cfg["secret_access_key"] == "wJalr-NEW-SECRET"
+    assert saved_cfg["bucket_name"] == "acme"  # non-secret survives roundtrip
+```
+
+- [ ] **Step 2: Run the test**
+
+```bash
+pytest src/nexus/bricks/portability/tests/test_roundtrip_with_mounts.py -v
+```
+
+Expected: PASS. If it fails, the failure pinpoints which leg of the roundtrip is broken — fix and re-run.
+
+- [ ] **Step 3: Run the full suite once more**
+
+```bash
+pytest src/nexus/bricks/portability/tests/ -v
+```
+
+Expected: ALL pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add src/nexus/bricks/portability/tests/test_roundtrip_with_mounts.py
+git commit -m "test(portability): roundtrip integration with mount export+import
+
+Issue: https://github.com/nexi-lab/nexus/issues/4083"
+```
+
+---
+
+## Task 13: Documentation page
+
+**Files:**
+- Modify or Create: `docs/portability.md` (modify if exists, otherwise create at this path)
+
+- [ ] **Step 1: Check whether `docs/portability.md` already exists**
+
+```bash
+ls docs/portability.md 2>/dev/null || echo "missing"
+```
+
+- [ ] **Step 2: Add or update the security/redaction section**
+
+If creating the file fresh:
+
+```markdown
+# Zone Data Portability
+
+Nexus zone bundles (`.nexus` archives) carry files, permissions, embeddings, and
+— as of bundle format `3.0.0` — mount configurations. This document covers the
+export/import flow, with particular attention to credential handling.
+
+## Mount-config redaction (Issue #4083)
+
+Mount configurations contain backend credentials: S3 access keys, OAuth tokens,
+KMS material, etc. Bundles **must never** contain live credential values, so
+the export pipeline strips them and the import pipeline refuses to proceed
+without explicit re-injection.
+
+### What gets stripped
+
+For each connector, the redaction set is derived from `CONNECTION_ARGS`: every
+argument whose `secret=True` flag is set has its value replaced by a
+`${MOUNT_<id>_<FIELD>}` placeholder. This is the **only** source of truth — no
+parallel list to maintain.
+
+### Heuristic guard
+
+On export, a heuristic regex (`(?i)(key|secret|token|password|cred)`) scans
+every `CONNECTION_ARGS` key. If any matching name is **not** marked
+`secret=True`, the export aborts with `SensitiveFieldNotDeclaredError`. This
+prevents a forgotten flag from silently leaking credentials.
+
+### Forced re-injection on import
+
+Imports require an `overrides` dict per mount:
+
+\```python
+from nexus.bricks.portability import import_zone_bundle, ZoneImportOptions
+
+await import_zone_bundle(ZoneImportOptions(
+    bundle_path="zone.nexus",
+    mount_overrides={
+        "m-1": {
+            "access_key_id": "AKIA...",
+            "secret_access_key": "wJalr...",
+        },
+    },
+))
+\```
+
+Without `mount_overrides` for a redacted field, the import raises
+`MissingCredentialsError` listing **every** missing credential in one message
+— operators see the full set up front, before any backend is initialized.
+
+### Skipping mount restore
+
+For dry-run inspections or destination instances that don't need the mounts:
+
+\```python
+await import_zone_bundle(ZoneImportOptions(
+    bundle_path="zone.nexus",
+    restore_mounts=False,
+))
+\```
+
+### Bundle format compatibility
+
+- v1/v2 bundles (no `mounts.jsonl`) import unchanged on the new code path.
+- v3 bundles read by older Nexus instances fail loudly at schema validation
+  — `additionalProperties: false` in `manifest-v1.json` rejects the new
+  `mount_count` field. The failure is explicit, not silent corruption.
+```
+
+If the file already exists, append the "Mount-config redaction (Issue #4083)" section after the existing intro. Adjust formatting to match existing house style.
+
+- [ ] **Step 3: Verify Markdown renders**
+
+```bash
+# If mkdocs is configured:
+mkdocs build --strict 2>&1 | head -20
+```
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add docs/portability.md
+git commit -m "docs(portability): document redaction contract and override flow
+
+Issue: https://github.com/nexi-lab/nexus/issues/4083"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage check:**
+
+| Spec section | Implementing task |
+|---|---|
+| `redaction.py` contract (declared_secret_fields, audit_backend, redact_config) | Task 4 |
+| `mount_export.py` contract | Task 7 |
+| `mount_import.py` contract | Task 8 |
+| Errors (`SensitiveFieldNotDeclaredError`, `MissingCredentialsError`) | Task 1 |
+| `MountRecord` dataclass | Task 1 |
+| Bundle format version bump 2.0.0 → 3.0.0 | Task 2 |
+| `manifest-v3.json` schema | Task 3 |
+| CI audit test over `CONNECTOR_MANIFEST` | Task 5 |
+| `ZoneExportOptions.include_mounts` | Task 6 |
+| `ZoneImportOptions.mount_overrides` + `restore_mounts` | Task 6 |
+| Wire export pipeline | Task 9 |
+| Wire import pipeline | Task 10 |
+| Public API exports | Task 11 |
+| Conflict semantics (SKIP/OVERWRITE/FAIL) | Task 8 |
+| Zone remap on import | Task 8 (test_import_mounts_zone_remap_applied) |
+| Mount restore order (parents first) | Task 8 (test_import_mounts_orders_by_path_depth) |
+| Roundtrip integration | Task 12 |
+| Doc page | Task 13 |
+
+All spec requirements have an implementing task.
+
+**Type-consistency check:**
+
+- `MountRecord` field names (`mount_id`, `mount_point`, `backend_type`, `backend_config`, `owner_user_id`, `zone_id`, `description`) consistent across Tasks 1, 7, 8, 12.
+- Placeholder format `${MOUNT_<id>_<FIELD_UPPER>}` consistent across redaction (T4), import (T8 regex `_PLACEHOLDER_RE`), tests (T7, T8, T12).
+- `redact_config` returns `(dict, list[PlaceholderRef])` — used as such in T7's `redact_and_write`.
+- `validate_overrides(mounts, overrides)` signature consistent across T8 implementation and T10 wiring.
+
+**Placeholder scan:** No "TBD"/"TODO"/"add appropriate" found. Each step has runnable code or a concrete command.
+
+**Notes for the implementer:**
+
+- Task 8 includes a guard note: confirm the existing `ImportError` constructor signature in `models.py` before running tests; adjust `mount_import.py` calls if `severity` isn't a kwarg.
+- Tasks 9 and 10 reference line numbers from the current source — use `grep` first to verify the splice point hasn't shifted under you.
+- The wiring tests in Tasks 9, 10, 12 assume `export_zone`/`import_zone` are async; flip to sync if the existing service is synchronous (drop `@pytest.mark.asyncio` and `await`).

--- a/docs/superpowers/specs/2026-05-09-portability-redacted-fields-design.md
+++ b/docs/superpowers/specs/2026-05-09-portability-redacted-fields-design.md
@@ -1,0 +1,235 @@
+# Portability: Declared Redacted-Fields Contract with Forced Re-injection on Import
+
+**Issue:** [#4083](https://github.com/nexi-lab/nexus/issues/4083)
+**Status:** Design — pending implementation
+**Date:** 2026-05-09
+
+## Problem
+
+`bricks/portability/` exports zone bundles containing files, permissions, and embeddings — but does not yet export the **mount configurations** that resolve those zones to physical backends. As soon as bundles include mounts (required for true cross-instance migration), every backend's `backend_config: dict[str, Any]` becomes a vehicle for credentials: S3 access keys, OAuth tokens, KMS material, Slack bot tokens, and so on.
+
+A new backend's author can easily forget to strip a field; a leaked snapshot containing a live S3 access key is a P0 incident. The contract for *what gets stripped* must be typed and enforced at both ends — strip on export, refuse to import without an explicit re-injection.
+
+## Goal
+
+1. Bundle export starts including mount configurations.
+2. Stripping which fields are sensitive is a **typed contract** derived from each backend's existing `ConnectionArg.secret=True` declarations — no parallel list to keep in sync.
+3. A heuristic guard hard-fails export when a backend has secret-shaped argument names not marked `secret=True`.
+4. Bundle import **requires** an `overrides` dict re-injecting every redacted field, validated before any backend is initialized.
+5. CI test enforces the audit at registration time, not just at export time.
+
+## Non-goals
+
+- DB-row credential stripping (`providers` / `federations` / `webhooks` / `settings` tables in `strip.py`) is an existing, orthogonal subsystem and is not modified by this work.
+- Owner remap on import (callers can update `owner_user_id` post-import). Out of scope; flag as follow-up if needed.
+- Per-mount metadata stripping (sensitive fields outside `CONNECTION_ARGS`). Today's `MountConfig` has no such field; the design leaves room (`redact_config` could later walk a configurable set of metadata keys), but no code is written for it now.
+
+## Source-of-truth decision
+
+Each connector already declares `CONNECTION_ARGS: dict[str, ConnectionArg]`, and every `ConnectionArg` has a `secret: bool` field. For example, `path_s3.py` already marks `access_key_id`, `secret_access_key`, `session_token`, and `credentials_path` as `secret=True`.
+
+The redaction set for a backend is **derived from this existing flag** rather than maintained as a separate `redacted_fields` list on `ConnectorManifestEntry`. This avoids two-sources-of-truth drift and keeps the responsibility on the connector module that already owns connection metadata.
+
+## Architecture
+
+### File layout
+
+```
+src/nexus/bricks/portability/
+├── redaction.py         # NEW — derive redaction set; secret-shape regex audit; redact one config dict
+├── mount_export.py      # NEW — collect MountConfig list; redact via redaction.py; emit mounts.jsonl
+├── mount_import.py      # NEW — read mounts.jsonl; validate overrides; restore via MountManager
+├── models.py            # MOD — BUNDLE_FORMAT_VERSION "2.0.0" → "3.0.0"; MountRecord; mount_count; new errors
+├── export_service.py    # MOD — call mount_export when options.include_mounts
+├── import_service.py    # MOD — call mount_import; validate overrides before any backend init
+└── schemas/manifest-v3.json   # NEW — schema for new bundle version
+```
+
+### Public API additions
+
+In `bricks/portability/__init__.py`:
+
+- `MountRecord` — frozen dataclass mirroring `mounts.jsonl` line shape.
+- `SensitiveFieldNotDeclaredError` — export-time error.
+- `MissingCredentialsError` — import-time error, raised before any side effect.
+- `ZoneExportOptions.include_mounts: bool = False` — opt-in, default off.
+- `ZoneImportOptions.mount_overrides: dict[str, dict[str, str]] | None = None` — keyed by `mount_id`, then by field name.
+- `ZoneImportOptions.restore_mounts: bool = True` — allow callers to skip mount restore even when present in bundle.
+
+### Bundle format
+
+`BUNDLE_FORMAT_VERSION` bumps from `"2.0.0"` → `"3.0.0"` (existing semver-string format; matches `^\d+\.\d+\.\d+$` schema pattern).
+
+`mounts.jsonl` (one JSON object per line, sorted by `mount_id`):
+
+```json
+{"mount_id": "uuid",
+ "mount_point": "/personal/alice",
+ "backend_type": "path_s3",
+ "owner_user_id": "alice",
+ "zone_id": "acme",
+ "description": null,
+ "backend_config": {
+   "bucket_name": "acme-data",
+   "region_name": "us-east-1",
+   "access_key_id": "${MOUNT_uuid_ACCESS_KEY_ID}",
+   "secret_access_key": "${MOUNT_uuid_SECRET_ACCESS_KEY}"
+ }}
+```
+
+Manifest gains `mount_count: int` and `BUNDLE_PATHS["mounts"] = "mounts.jsonl"`. `manifest-v3.json` is added next to existing `manifest-v1.json` (cloned, plus the new `mount_count` property and an updated `$id` URL). The new reader recognises both schemas; old bundles (v1, no `mounts.jsonl`) import unchanged. v3 bundles read by an older Nexus instance fail loudly at schema validation (`additionalProperties: false` at the manifest root rejects `mount_count`) — the failure is explicit, not silent corruption.
+
+### Data flow on export
+
+1. `MountManager.list_mounts(zone_id=...)` returns the current mount configs.
+2. For each mount: look up `ConnectorRegistry.get_info(backend_type)`.
+3. Run `redaction.audit_backend(backend_type)` — compares `CONNECTION_ARGS` keys against the `(?i)(key|secret|token|password|cred)` regex; returns the names that match the heuristic but have `secret=False`.
+4. If audit returns any names → raise `SensitiveFieldNotDeclaredError(backend_type, fields)`. Export aborts. **Hard fail.**
+5. Otherwise: replace each `secret=True` field's value with `${MOUNT_<id>_<FIELD_UPPER>}` and append a `PlaceholderRef` to the export manifest's existing `placeholders` list (uniform with DB-row stripping).
+6. Write `mounts.jsonl` and update `manifest.mount_count`.
+
+### Data flow on import
+
+1. Read `bundle_dir / "mounts.jsonl"`. If absent → no-op (back-compat with v2 bundles).
+2. `validate_overrides(mounts, options.mount_overrides)` walks every redacted field across every mount and collects `(mount_id, field)` pairs not present in `overrides[mount_id]`.
+3. If anything missing → raise `MissingCredentialsError(missing)` with all gaps reported in one error (not first-fail). **No backend has been instantiated at this point.**
+4. After existing files/permissions/embeddings restore: for each mount, substitute placeholders with override values, apply zone remap if `target_zone_id` set, and call `MountManager.save_mount(...)` (or `update_mount` per `conflict_mode`).
+5. Per-mount errors collected in `ImportResult.errors`; `result.mount_count` reflects successful restores.
+
+### Conflict semantics (mount_point already exists in target instance)
+
+- `SKIP` — leave existing mount in place; record `ImportError(severity=info)`.
+- `OVERWRITE` — `MountManager.update_mount(mount_point, backend_config=...)`.
+- `FAIL` — abort import per existing `import_service` rollback convention.
+
+### Service-init contract
+
+- `ZoneExportService.__init__` accepts optional `mount_manager: MountManager | None`. If `options.include_mounts=True` and `mount_manager is None` → `ValueError` at export start (fail loud, not silently skip).
+- `ZoneImportService.__init__` accepts optional `mount_manager`. If bundle contains `mounts.jsonl` and `options.restore_mounts=True` and `mount_manager is None` → `ValueError`.
+
+## `redaction.py` contract
+
+```python
+SECRET_SHAPED = re.compile(r"(?i)(key|secret|token|password|cred)")
+
+def declared_secret_fields(backend_type: str) -> frozenset[str]:
+    """CONNECTION_ARGS keys with secret=True for a backend."""
+
+def audit_backend(backend_type: str) -> list[str]:
+    """Arg names that look secret-shaped but aren't marked secret=True.
+    Empty list = backend passes audit."""
+
+def redact_config(
+    backend_type: str,
+    config: dict[str, Any],
+    *,
+    mount_id: str,
+) -> tuple[dict[str, Any], list[PlaceholderRef]]:
+    """Strip declared secret fields. Raises SensitiveFieldNotDeclaredError if audit fails."""
+```
+
+Reuses `PlaceholderRef` from existing `models.py` so the manifest's placeholder list has uniform UX across DB rows and mount configs.
+
+## `mount_export.py` contract
+
+```python
+def collect_mounts(mount_manager: MountManager, *, zone_id: str | None) -> list[MountConfigRow]:
+    """Pull raw mount configs from MountManager (zone-filtered if zone_id given)."""
+
+def redact_and_write(
+    mounts: list[MountConfigRow],
+    *,
+    out_path: Path,
+) -> list[PlaceholderRef]:
+    """Per-mount: redaction.redact_config; write mounts.jsonl; return aggregated placeholders.
+    Raises SensitiveFieldNotDeclaredError on first audit failure."""
+```
+
+## `mount_import.py` contract
+
+```python
+def read_mounts(bundle_dir: Path) -> list[MountRecord]:
+    """Parse mounts.jsonl. Returns [] if absent (v2 bundle)."""
+
+def validate_overrides(
+    mounts: list[MountRecord],
+    overrides: dict[str, dict[str, str]] | None,
+) -> None:
+    """Walk every redacted field; raise MissingCredentialsError listing all gaps.
+    Pure: no side effects. Runs before any backend init."""
+
+def materialize(
+    mount_record: MountRecord,
+    overrides_for_mount: dict[str, str],
+) -> dict[str, Any]:
+    """Substitute ${MOUNT_<id>_<FIELD>} placeholders; return final backend_config."""
+
+def import_mounts(
+    mounts: list[MountRecord],
+    overrides: dict[str, dict[str, str]],
+    mount_manager: MountManager,
+    *,
+    target_zone_id: str | None,
+    conflict_mode: ConflictMode,
+) -> list[ImportError]:
+    """Per mount: materialize + save_mount/update_mount per conflict_mode.
+    Returns per-mount errors; does not raise except on programmer bugs."""
+```
+
+## Errors
+
+```python
+class SensitiveFieldNotDeclaredError(ValueError):
+    """Export-time. Backend has secret-shaped CONNECTION_ARGS keys not marked secret=True."""
+    backend_type: str
+    fields: list[str]
+
+class MissingCredentialsError(ValueError):
+    """Import-time. Bundle has redacted mount fields with no override supplied."""
+    missing: dict[str, list[str]]  # mount_id -> [field, ...]
+```
+
+`MissingCredentialsError` reports **every** gap in one error message (not first-fail), so an operator sees the full set of credentials they need to provide.
+
+## Testing
+
+| File | Coverage |
+|---|---|
+| `tests/test_redaction_audit.py` | Every `CONNECTOR_MANIFEST` entry passes `audit_backend()`. **CI gate.** Skip entries whose runtime extras aren't installed. |
+| `tests/test_redaction_unit.py` | `declared_secret_fields()`, `audit_backend()` positive/negative, `redact_config()` idempotence, placeholder shape, `None` values skipped (no placeholder generated). |
+| `tests/test_mount_export.py` | Collect+redact happy path, audit failure raises, manifest placeholders extended, `mounts.jsonl` byte-stable across runs. |
+| `tests/test_mount_import.py` | `validate_overrides` reports all missing in one error (not first-fail), `materialize` substitutes correctly, conflict modes (SKIP/OVERWRITE/FAIL), zone remap, `restore_mounts=False` skips. |
+| `tests/test_export_strip.py` (existing) | Extend to assert mount placeholders join existing DB-row placeholders cleanly in `manifest.placeholders`. |
+| `tests/test_manifest_v3.py` | New `BUNDLE_FORMAT_VERSION` validates against `manifest-v3.json`; v1/v2 bundle still imports (mount step no-op when `mounts.jsonl` absent); v3 bundle validates against v1 schema fails loudly (assert the error message). |
+| `tests/integration/test_roundtrip_with_mounts.py` | Export bundle with two mounts → import without overrides fails with `MissingCredentialsError` listing both → import with overrides succeeds → mounts restored verbatim. |
+
+**TDD order**: redaction unit tests first → `mount_export` tests → `mount_import` tests (focus on the validate-then-materialize split) → end-to-end roundtrip last.
+
+## Migration & back-compat
+
+- `BUNDLE_FORMAT_VERSION` bumps `"2.0.0"` → `"3.0.0"`.
+- New reader accepts both v1/v2 bundles (no `mounts.jsonl`, schema `manifest-v1.json`) and v3 bundles. v1/v2 import simply skips the mount step.
+- v3 bundles read by an older Nexus instance: schema validation rejects `mount_count` because `manifest-v1.json` has `additionalProperties: false` at the root. The failure is loud and unambiguous, not silent data drop. This is correct behavior — refusing unknown bundle versions prevents partial restores.
+- New `manifest-v3.json` schema added alongside the existing `manifest-v1.json` (clone the v1 file, change `$id`, add `mount_count` and a top-level `mounts` reference path if needed).
+- One-paragraph addition to a portability doc page (e.g. `docs/portability.md` if it exists; otherwise create one under `docs/`) covering the export → override → import flow and the security rationale.
+
+## Effort
+
+3 days, matching the issue's S–M estimate. Most cost is integration tests and the cross-version manifest sanity check.
+
+## Risks
+
+- **Heuristic false positives.** The `(?i)(key|secret|token|password|cred)` regex could flag a benign field name (e.g., a future `keyspace` arg). Resolution: when this happens, the connector author must either rename the arg or mark it `secret=True`. We deliberately do not provide a per-arg "acknowledged_safe" allowlist — every false positive is a forcing function for a clearer name. If real friction emerges, revisit by adding `ConnectionArg.audit_safe: bool = False` later.
+- **Mount restore order.** Mounts may depend on each other (e.g., a brick that mounts under `/zone/data` then another under `/zone/data/sub`). Ordering: sort by `len(mount_point.split("/"))` ascending so parents restore first. Documented in `import_mounts`.
+- **`MountManager` not always available.** Some import contexts (e.g., dry-run bundle inspection) don't have a MountManager. The opt-in `restore_mounts: bool = True` knob lets those callers skip cleanly.
+
+## Acceptance criteria
+
+- [ ] `ConnectionArg.secret=True` declarations are the sole source of truth for redaction; no `redacted_fields` list added anywhere.
+- [ ] Every connector in `CONNECTOR_MANIFEST` passes `audit_backend()`; CI test enforces this at registration time.
+- [ ] `ZoneExportOptions.include_mounts=True` produces a bundle whose `mounts.jsonl` has every secret field replaced with a `${MOUNT_<id>_<FIELD>}` placeholder, and whose `manifest.placeholders` lists every replacement.
+- [ ] Export aborts with `SensitiveFieldNotDeclaredError` if a backend has secret-shaped argument names not marked `secret=True`.
+- [ ] Import without `mount_overrides` for any redacted field raises `MissingCredentialsError` listing every gap in one message — before any backend is initialized.
+- [ ] Import with full `mount_overrides` restores mounts via `MountManager.save_mount` (or `update_mount` per `conflict_mode`).
+- [ ] v2 bundles still import; v3 reader is back-compat with v2.
+- [ ] Doc page covering export/import flow and security rationale.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1004,6 +1004,11 @@ ignore_imports = [
     "nexus.bricks.archive.orchestrator -> nexus.bricks.portability.models",
     "nexus.bricks.archive.tests.unit.test_verify -> nexus.bricks.portability.signer",
     "nexus.bricks.archive.verify -> nexus.bricks.portability.signer",
+    # archive.verify -> portability.bundle (Issue #4083): v3 bundles
+    # need BundleReader.validate() inside the same tarfile handle as
+    # the signature check (TOCTOU-safe). Cross-brick exception lives
+    # alongside the existing portability.signer entry above.
+    "nexus.bricks.archive.verify -> nexus.bricks.portability.bundle",
     "nexus.bricks.mcp.connection_manager -> nexus.bricks.approvals.policy_gate",
     "nexus.bricks.mcp.mcp_service -> nexus.bricks.approvals.policy_gate",
     "nexus.bricks.mcp.mount -> nexus.bricks.approvals.models",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,11 @@ dependencies = [
     # Configuration
     "pydantic[email]>=2.13.4",
     "pyyaml>=6.0.3",
+    # Schema validation — required by archive verify (Issue #4083)
+    # to validate v3 portability bundles against manifest-v3.json
+    # before trusting mounts.jsonl checksums. Direct dep so slim
+    # wheels still verify correctly.
+    "jsonschema>=4.20.0",
     # HTTP client (for remote mode)
     "httpx[http2]>=0.28.1",
     "requests>=2.33.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -419,6 +419,7 @@ where = ["src"]
 "nexus.backends.connectors.gws" = ["configs/*.yaml"]
 "nexus.backends.connectors.github" = ["*.yaml"]
 "nexus.bricks.auth.daemon.templates" = ["*.plist.j2", "*.service.j2"]
+"nexus.bricks.portability" = ["schemas/*.json"]
 "nexus.extensions._index" = ["extensions.json"]
 
 [tool.pytest.ini_options]

--- a/requirements-minimal.txt
+++ b/requirements-minimal.txt
@@ -11,6 +11,13 @@ tqdm>=4.67.3
 pydantic[email]>=2.13.4
 pyyaml>=6.0.3
 
+# Schema validation — required by archive verify_archive (Issue
+# #4083) to validate v3 portability bundles against
+# manifest-v3.json before trusting mounts.jsonl checksums. Listed
+# here because the slim image installs the package with --no-deps
+# and would otherwise silently miss this dep.
+jsonschema>=4.20.0
+
 # HTTP client (used internally)
 httpx[http2]>=0.28.1
 requests>=2.33.1

--- a/src/nexus/backends/connectors/calendar/connector.py
+++ b/src/nexus/backends/connectors/calendar/connector.py
@@ -163,8 +163,9 @@ send_notifications: true
     CONNECTION_ARGS: dict[str, ConnectionArg] = {
         "token_manager_db": ConnectionArg(
             type=ArgType.PATH,
-            description="Path to TokenManager database or database URL",
+            description="Path to TokenManager database or database URL (path, not credential)",
             required=True,
+            audit_safe=True,  # name contains 'token' but value is a filesystem path
         ),
         "user_email": ConnectionArg(
             type=ArgType.STRING,

--- a/src/nexus/backends/connectors/gdrive/connector.py
+++ b/src/nexus/backends/connectors/gdrive/connector.py
@@ -135,8 +135,9 @@ class PathGDriveBackend(
     CONNECTION_ARGS: dict[str, ConnectionArg] = {
         "token_manager_db": ConnectionArg(
             type=ArgType.PATH,
-            description="Path to TokenManager database or database URL",
+            description="Path to TokenManager database or database URL (path, not credential)",
             required=True,
+            audit_safe=True,  # name contains 'token' but value is a filesystem path
         ),
         "user_email": ConnectionArg(
             type=ArgType.STRING,

--- a/src/nexus/backends/connectors/gmail/connector.py
+++ b/src/nexus/backends/connectors/gmail/connector.py
@@ -143,8 +143,9 @@ class PathGmailBackend(
     CONNECTION_ARGS: dict[str, ConnectionArg] = {
         "token_manager_db": ConnectionArg(
             type=ArgType.PATH,
-            description="Path to TokenManager database or database URL",
+            description="Path to TokenManager database or database URL (path, not credential)",
             required=True,
+            audit_safe=True,  # name contains 'token' but value is a filesystem path
         ),
         "user_email": ConnectionArg(
             type=ArgType.STRING,

--- a/src/nexus/backends/connectors/slack/_manifest.py
+++ b/src/nexus/backends/connectors/slack/_manifest.py
@@ -30,8 +30,9 @@ MANIFEST = ConnectorManifest(
     connection_args={
         "token_manager_db": ConnectionArg(
             type=ArgType.PATH,
-            description="Path to TokenManager database or database URL",
+            description="Path to TokenManager database or database URL (path, not credential)",
             required=True,
+            audit_safe=True,
         ),
         "user_email": ConnectionArg(
             type=ArgType.STRING,

--- a/src/nexus/backends/connectors/x/connector.py
+++ b/src/nexus/backends/connectors/x/connector.py
@@ -106,8 +106,9 @@ class PathXBackend(
     CONNECTION_ARGS: dict[str, ConnectionArg] = {
         "token_manager_db": ConnectionArg(
             type=ArgType.PATH,
-            description="Path to TokenManager database or database URL",
+            description="Path to TokenManager database or database URL (path, not credential)",
             required=True,
+            audit_safe=True,  # name contains 'token' but value is a filesystem path
         ),
         "user_email": ConnectionArg(
             type=ArgType.STRING,

--- a/src/nexus/bricks/archive/verify.py
+++ b/src/nexus/bricks/archive/verify.py
@@ -100,9 +100,10 @@ def verify_archive(file: Path, *, strict: bool = False) -> None:
 
         # --- format_version check ---
         format_version: str = manifest.get("format_version", "1.0.0")
-        if strict and not format_version.startswith("2."):
+        if strict and not (format_version.startswith("2.") or format_version.startswith("3.")):
             raise ArchiveError(
-                f"--strict requires a v2 bundle; this bundle is format_version={format_version}"
+                f"--strict requires a v2 or v3 bundle; this bundle is "
+                f"format_version={format_version}"
             )
 
         # --- min_nexus_version check ---
@@ -111,8 +112,11 @@ def verify_archive(file: Path, *, strict: bool = False) -> None:
         if _parse_semver(min_required) > _parse_semver(current):
             raise ArchiveVersionIncompatible(required=min_required, current=current)
 
-        # --- signature check (v2 only) ---
-        if format_version.startswith("2."):
+        # --- signature check (v2 and v3) ---
+        # v3 (Issue #4083) reuses the v2 signature shape; the only
+        # change is mount records are also covered via the
+        # checksums.files entries that the merkle root binds.
+        if format_version.startswith("2.") or format_version.startswith("3."):
             if "signatures.json" in names:
                 sig_member = tar.extractfile("signatures.json")
                 assert sig_member is not None

--- a/src/nexus/bricks/archive/verify.py
+++ b/src/nexus/bricks/archive/verify.py
@@ -136,5 +136,23 @@ def verify_archive(file: Path, *, strict: bool = False) -> None:
                     "v2 bundle is missing signatures.json — pass strict=False to skip"
                 )
 
+    # --- bundle integrity check (v3 only) ---
+    # Round-7 reviewer finding: signature verification proves the
+    # MANIFEST is unaltered, but does NOT recompute checksums of the
+    # tar members. Without this, an attacker can mutate mounts.jsonl
+    # bytes after signing and verify_archive returns OK. v3 added the
+    # mounts.jsonl checksum-envelope binding in BundleReader.validate;
+    # call it here so signed-bundle verification actually catches the
+    # tamper.
+    if format_version.startswith("3."):
+        # Local import to avoid a hot cross-brick import on the verify
+        # hot path for non-v3 bundles.
+        from nexus.bricks.portability.bundle import BundleReader
+
+        with BundleReader(file) as _reader:
+            ok, errors = _reader.validate()
+            if not ok:
+                raise ArchiveError("v3 bundle failed integrity check: " + "; ".join(errors))
+
 
 __all__ = ["_current_nexus_version", "_parse_semver", "verify_archive"]

--- a/src/nexus/bricks/archive/verify.py
+++ b/src/nexus/bricks/archive/verify.py
@@ -84,6 +84,10 @@ def verify_archive(file: Path, *, strict: bool = False) -> None:
         ArchiveSignatureError: Signature verification failed.
     """
     with tarfile.open(file, "r:gz") as tar:
+        # Defense against TOCTOU on `file` (round-8 reviewer finding):
+        # all integrity checks below — manifest read, signature verify,
+        # AND the v3 BundleReader.validate() at the end — operate on
+        # THIS handle. Do not re-open by path.
         names = tar.getnames()
 
         if "manifest.json" not in names:
@@ -136,23 +140,19 @@ def verify_archive(file: Path, *, strict: bool = False) -> None:
                     "v2 bundle is missing signatures.json — pass strict=False to skip"
                 )
 
-    # --- bundle integrity check (v3 only) ---
-    # Round-7 reviewer finding: signature verification proves the
-    # MANIFEST is unaltered, but does NOT recompute checksums of the
-    # tar members. Without this, an attacker can mutate mounts.jsonl
-    # bytes after signing and verify_archive returns OK. v3 added the
-    # mounts.jsonl checksum-envelope binding in BundleReader.validate;
-    # call it here so signed-bundle verification actually catches the
-    # tamper.
-    if format_version.startswith("3."):
-        # Local import to avoid a hot cross-brick import on the verify
-        # hot path for non-v3 bundles.
-        from nexus.bricks.portability.bundle import BundleReader
+        # --- bundle integrity check (v3 only) ---
+        # Round-7: signature proves the manifest is unaltered but does
+        # NOT recompute member checksums. Round-8: must use the SAME
+        # tar handle as the signature check above to avoid a TOCTOU
+        # window between two ``open()`` calls on a mutable path. We
+        # pass the open TarFile directly to BundleReader.
+        if format_version.startswith("3."):
+            from nexus.bricks.portability.bundle import BundleReader
 
-        with BundleReader(file) as _reader:
-            ok, errors = _reader.validate()
-            if not ok:
-                raise ArchiveError("v3 bundle failed integrity check: " + "; ".join(errors))
+            with BundleReader(tar=tar) as _reader:
+                ok, errors = _reader.validate()
+                if not ok:
+                    raise ArchiveError("v3 bundle failed integrity check: " + "; ".join(errors))
 
 
 __all__ = ["_current_nexus_version", "_parse_semver", "verify_archive"]

--- a/src/nexus/bricks/portability/__init__.py
+++ b/src/nexus/bricks/portability/__init__.py
@@ -66,10 +66,28 @@ from nexus.bricks.portability.models import (
     FileRecord,
     ImportError,
     ImportResult,
+    MissingCredentialsError,
+    MountRecord,
     PermissionRecord,
     PlaceholderRef,
+    SensitiveFieldNotDeclaredError,
     ZoneExportOptions,
     ZoneImportOptions,
+)
+from nexus.bricks.portability.mount_export import (
+    collect_mounts,
+    redact_and_write,
+)
+from nexus.bricks.portability.mount_import import (
+    import_mounts,
+    materialize,
+    read_mounts,
+    validate_overrides,
+)
+from nexus.bricks.portability.redaction import (
+    audit_backend,
+    declared_secret_fields,
+    redact_config,
 )
 
 __all__ = [
@@ -109,4 +127,17 @@ __all__ = [
     "BundleReader",
     "validate_bundle",
     "inspect_bundle",
+    # Mount portability (Issue #4083)
+    "MountRecord",
+    "MissingCredentialsError",
+    "SensitiveFieldNotDeclaredError",
+    "audit_backend",
+    "declared_secret_fields",
+    "redact_config",
+    "collect_mounts",
+    "redact_and_write",
+    "read_mounts",
+    "validate_overrides",
+    "materialize",
+    "import_mounts",
 ]

--- a/src/nexus/bricks/portability/bundle.py
+++ b/src/nexus/bricks/portability/bundle.py
@@ -117,16 +117,22 @@ class BundleReader:
 
         try:
             member = self._tar.getmember(MANIFEST_FILENAME)
-            file_obj = self._tar.extractfile(member)
-            if file_obj is None:
-                raise ValueError("Could not read manifest file")
-
-            self._raw_manifest_dict = json.loads(file_obj.read().decode("utf-8"))
-            self._manifest = ExportManifest.from_dict(self._raw_manifest_dict)
-            return self._manifest
-
         except KeyError:
+            # Only the tar lookup raises KeyError for "missing manifest";
+            # downstream parsing errors must NOT be misreported as
+            # "missing" (round-4 reviewer trace: a KeyError from
+            # ExportManifest.from_dict was being caught by this clause
+            # and surfaced as 'Bundle missing manifest.json'). Scope the
+            # try narrowly to the lookup.
             raise ValueError(f"Bundle missing {MANIFEST_FILENAME}") from None
+
+        file_obj = self._tar.extractfile(member)
+        if file_obj is None:
+            raise ValueError("Could not read manifest file")
+
+        self._raw_manifest_dict = json.loads(file_obj.read().decode("utf-8"))
+        self._manifest = ExportManifest.from_dict(self._raw_manifest_dict)
+        return self._manifest
 
     def validate(self) -> tuple[bool, list[str]]:
         """Validate bundle integrity.
@@ -225,6 +231,34 @@ class BundleReader:
                 f"{BUNDLE_PATHS['mounts']!r} is missing from the bundle"
             )
 
+        # Round-4 reviewer finding: an attacker can append/tamper
+        # mounts.jsonl OUTSIDE the signed manifest envelope (manifest
+        # claims mount_count=0 but the tar carries a mounts.jsonl). The
+        # import path used to read it anyway. Reject any mounts.jsonl
+        # that isn't both: (a) declared by manifest.mount_count > 0,
+        # AND (b) present in manifest.checksums (so signature/integrity
+        # check covers it).
+        mounts_in_tar = BUNDLE_PATHS["mounts"] in members
+        mounts_in_checksums = BUNDLE_PATHS["mounts"] in manifest.checksums.files
+        if mounts_in_tar and manifest.mount_count == 0:
+            errors.append(
+                f"Bundle contains {BUNDLE_PATHS['mounts']!r} but manifest "
+                "claims mount_count=0 — refusing to trust unmanifested mount "
+                "records (potential tampering outside the signed envelope)."
+            )
+        if mounts_in_tar and not mounts_in_checksums:
+            errors.append(
+                f"{BUNDLE_PATHS['mounts']!r} is present but missing from "
+                "manifest.checksums.files — refusing to trust mount records "
+                "outside the signed/verified envelope."
+            )
+        if manifest.mount_count > 0 and not mounts_in_checksums:
+            errors.append(
+                f"Manifest claims mount_count={manifest.mount_count} but "
+                f"{BUNDLE_PATHS['mounts']!r} has no checksum entry — bundle "
+                "integrity cannot be verified for mount records."
+            )
+
         # Verify checksums if provided
         if manifest.checksums.files:
             for path, checksum in manifest.checksums.files.items():
@@ -294,12 +328,33 @@ class BundleReader:
         """Read mount records from mounts.jsonl.
 
         Returns:
-            List of MountRecord objects, or empty list if mounts.jsonl is absent.
+            List of MountRecord objects, or empty list if mounts.jsonl is absent
+            or if the manifest does not declare mount records (round-4 reviewer
+            finding: refuse to consume mount records that fall outside the
+            signed/checksummed manifest envelope).
+
+        Raises:
+            ValueError: if the actual record count disagrees with
+                manifest.mount_count, indicating tampering.
         """
         if self._tar is None:
             raise RuntimeError("Bundle not open. Call open() first.")
 
         import json as _json
+
+        # Defense-in-depth: even if the caller skipped validate(), the
+        # import path must not consume mount records that the manifest
+        # didn't declare. validate() is the primary check; this is the
+        # belt against a caller bypass.
+        manifest = self.get_manifest()
+        if manifest.mount_count == 0:
+            return []
+        if BUNDLE_PATHS["mounts"] not in manifest.checksums.files:
+            raise ValueError(
+                f"Refusing to read {BUNDLE_PATHS['mounts']!r}: not present in "
+                "manifest.checksums.files (signed envelope). Run validate() to "
+                "see the full integrity report."
+            )
 
         mounts_path = BUNDLE_PATHS["mounts"]
         try:
@@ -313,6 +368,13 @@ class BundleReader:
                 line_str = line.decode("utf-8").strip()
                 if line_str:
                     records.append(MountRecord.from_dict(_json.loads(line_str)))
+
+            if len(records) != manifest.mount_count:
+                raise ValueError(
+                    f"Mount record count mismatch: manifest declares "
+                    f"{manifest.mount_count}, mounts.jsonl carries "
+                    f"{len(records)}. Bundle may have been tampered with."
+                )
             return records
 
         except KeyError:

--- a/src/nexus/bricks/portability/bundle.py
+++ b/src/nexus/bricks/portability/bundle.py
@@ -53,6 +53,28 @@ class BundleReader:
         self.bundle_path = Path(bundle_path)
         self._tar: tarfile.TarFile | None = None
         self._manifest: ExportManifest | None = None
+        self._raw_manifest_dict: dict[str, Any] | None = None
+
+    @staticmethod
+    def _resolve_manifest_schema(raw_manifest: dict[str, Any]) -> Path | None:
+        """Pick the JSON-Schema file matching the manifest's declared version.
+
+        Returns None when the version is unknown or when no schema is
+        applicable (e.g., a future format we don't ship a schema for).
+        v1.x and v2.x bundles share manifest-v1.json (no v2 schema was
+        ever shipped, and v2 bundles set ``$schema`` to manifest-v1.json
+        in the wild); v3.x bundles use manifest-v3.json.
+        """
+        schemas_dir = Path(__file__).parent / "schemas"
+        version = (raw_manifest.get("format_version") or "").strip()
+        if version.startswith(("1.", "2.")):
+            return schemas_dir / "manifest-v1.json"
+        if version.startswith("3."):
+            return schemas_dir / "manifest-v3.json"
+        # Unknown/future version: best-effort fall back to the latest
+        # schema we ship so reviewers see an explicit error rather than
+        # silent acceptance.
+        return schemas_dir / "manifest-v3.json"
 
     def __enter__(self) -> "BundleReader":
         """Open the bundle for reading."""
@@ -130,26 +152,52 @@ class BundleReader:
             errors.append(f"Invalid manifest: {e}")
             return False, errors
 
-        # Strict JSON-Schema validation against the v3 schema (Issue #4083
-        # reviewer finding: from_dict drops unknown fields, so without
-        # this step a malformed v3 manifest with extra root keys is
-        # silently accepted). Skip if jsonschema isn't installed — the
-        # rest of validate() still runs.
-        try:
-            import jsonschema
-
-            from nexus.bricks.portability.models import MANIFEST_SCHEMA_PATH
-
-            raw = getattr(self, "_raw_manifest_dict", None)
-            if raw is not None and MANIFEST_SCHEMA_PATH.exists():
-                schema = json.loads(MANIFEST_SCHEMA_PATH.read_text())
+        # Strict JSON-Schema validation against the version-appropriate
+        # schema (Issue #4083 reviewer finding: from_dict drops unknown
+        # fields, so without this step a malformed manifest with extra
+        # root keys is silently accepted). Round 2 follow-up: select the
+        # schema by the manifest's own format_version / $schema rather
+        # than always validating against v3 — otherwise legacy v1/v2
+        # bundles are rejected by the new v3 const check while
+        # malformed v3 bundles slip past on slim installs.
+        raw = getattr(self, "_raw_manifest_dict", None)
+        if raw is not None:
+            schema_path = self._resolve_manifest_schema(raw)
+            if schema_path is not None:
                 try:
-                    jsonschema.validate(raw, schema)
-                except jsonschema.ValidationError as ve:
-                    errors.append(f"Manifest schema validation failed: {ve.message}")
-        except ImportError:
-            # jsonschema is an optional dep; skip strict validation.
-            pass
+                    import jsonschema
+
+                    if not schema_path.exists():
+                        # New v3 bundles MUST have the v3 schema available;
+                        # missing it is a hard validation error so a slim
+                        # wheel that dropped schemas/ doesn't silently
+                        # accept malformed bundles.
+                        if (raw.get("format_version") or "").startswith("3."):
+                            errors.append(
+                                f"Manifest schema {schema_path.name} not "
+                                f"packaged with this install — cannot validate "
+                                f"v3 manifest. Reinstall nexus with bundled "
+                                f"schemas or import on a full install."
+                            )
+                    else:
+                        try:
+                            jsonschema.validate(raw, json.loads(schema_path.read_text()))
+                        except jsonschema.ValidationError as ve:
+                            errors.append(
+                                f"Manifest schema validation failed "
+                                f"({schema_path.name}): {ve.message}"
+                            )
+                except ImportError:
+                    # jsonschema absent: only the v3 path is security-
+                    # critical (newly-added unknown-field guard). v1/v2
+                    # bundles fall back to ExportManifest.validate as
+                    # before.
+                    if (raw.get("format_version") or "").startswith("3."):
+                        errors.append(
+                            "jsonschema not installed; cannot validate v3 "
+                            "manifest. Install jsonschema or import on a "
+                            "full install."
+                        )
 
         # Check required files exist
         members = {m.name for m in self._tar.getmembers()}

--- a/src/nexus/bricks/portability/bundle.py
+++ b/src/nexus/bricks/portability/bundle.py
@@ -22,6 +22,7 @@ from nexus.bricks.portability.models import (
     MANIFEST_FILENAME,
     ExportManifest,
     FileRecord,
+    MountRecord,
     PermissionRecord,
 )
 
@@ -199,6 +200,35 @@ class BundleReader:
 
         except KeyError:
             logger.debug("Bundle missing %s", BUNDLE_PATHS["permissions"])
+
+    def read_mount_records(self) -> list[MountRecord]:
+        """Read mount records from mounts.jsonl.
+
+        Returns:
+            List of MountRecord objects, or empty list if mounts.jsonl is absent.
+        """
+        if self._tar is None:
+            raise RuntimeError("Bundle not open. Call open() first.")
+
+        import json as _json
+
+        mounts_path = BUNDLE_PATHS["mounts"]
+        try:
+            member = self._tar.getmember(mounts_path)
+            file_obj = self._tar.extractfile(member)
+            if file_obj is None:
+                return []
+
+            records: list[MountRecord] = []
+            for line in file_obj:
+                line_str = line.decode("utf-8").strip()
+                if line_str:
+                    records.append(MountRecord.from_dict(_json.loads(line_str)))
+            return records
+
+        except KeyError:
+            logger.debug("Bundle missing %s", mounts_path)
+            return []
 
     def read_content_blob(self, content_id: str) -> bytes | None:
         """Read a content blob from the bundle.

--- a/src/nexus/bricks/portability/bundle.py
+++ b/src/nexus/bricks/portability/bundle.py
@@ -136,6 +136,12 @@ class BundleReader:
         if manifest.file_count > 0 and BUNDLE_PATHS["files"] not in members:
             errors.append(f"Missing required file: {BUNDLE_PATHS['files']}")
 
+        if manifest.mount_count > 0 and BUNDLE_PATHS["mounts"] not in members:
+            errors.append(
+                f"Manifest claims mount_count={manifest.mount_count} but "
+                f"{BUNDLE_PATHS['mounts']!r} is missing from the bundle"
+            )
+
         # Verify checksums if provided
         if manifest.checksums.files:
             for path, checksum in manifest.checksums.files.items():

--- a/src/nexus/bricks/portability/bundle.py
+++ b/src/nexus/bricks/portability/bundle.py
@@ -359,27 +359,44 @@ class BundleReader:
         mounts_path = BUNDLE_PATHS["mounts"]
         try:
             member = self._tar.getmember(mounts_path)
-            file_obj = self._tar.extractfile(member)
-            if file_obj is None:
-                return []
-
-            records: list[MountRecord] = []
-            for line in file_obj:
-                line_str = line.decode("utf-8").strip()
-                if line_str:
-                    records.append(MountRecord.from_dict(_json.loads(line_str)))
-
-            if len(records) != manifest.mount_count:
-                raise ValueError(
-                    f"Mount record count mismatch: manifest declares "
-                    f"{manifest.mount_count}, mounts.jsonl carries "
-                    f"{len(records)}. Bundle may have been tampered with."
-                )
-            return records
-
         except KeyError:
+            # tar lookup miss → genuinely no mounts.jsonl (manifest
+            # claimed mount_count > 0; the missing-file check in
+            # validate() should have already flagged this).
             logger.debug("Bundle missing %s", mounts_path)
             return []
+
+        file_obj = self._tar.extractfile(member)
+        if file_obj is None:
+            return []
+
+        # Round-5 reviewer finding: a malformed mounts.jsonl line could
+        # raise KeyError from MountRecord.from_dict, which the previous
+        # broad ``except KeyError`` swallowed as "no mounts" — silently
+        # skipping mount restore on a tampered bundle. Now any parse
+        # error is fatal, surfacing the integrity problem to the
+        # operator instead of falling through to a partial import.
+        records: list[MountRecord] = []
+        for lineno, line in enumerate(file_obj, start=1):
+            line_str = line.decode("utf-8").strip()
+            if not line_str:
+                continue
+            try:
+                records.append(MountRecord.from_dict(_json.loads(line_str)))
+            except (_json.JSONDecodeError, KeyError, TypeError, ValueError) as exc:
+                raise ValueError(
+                    f"Malformed mount record at {mounts_path}:{lineno}: "
+                    f"{type(exc).__name__}: {exc}. Bundle may have been "
+                    "tampered with."
+                ) from exc
+
+        if len(records) != manifest.mount_count:
+            raise ValueError(
+                f"Mount record count mismatch: manifest declares "
+                f"{manifest.mount_count}, mounts.jsonl carries "
+                f"{len(records)}. Bundle may have been tampered with."
+            )
+        return records
 
     def read_content_blob(self, content_id: str) -> bytes | None:
         """Read a content blob from the bundle.

--- a/src/nexus/bricks/portability/bundle.py
+++ b/src/nexus/bricks/portability/bundle.py
@@ -59,11 +59,16 @@ class BundleReader:
     def _resolve_manifest_schema(raw_manifest: dict[str, Any]) -> Path | None:
         """Pick the JSON-Schema file matching the manifest's declared version.
 
-        Returns None when the version is unknown or when no schema is
-        applicable (e.g., a future format we don't ship a schema for).
-        v1.x and v2.x bundles share manifest-v1.json (no v2 schema was
-        ever shipped, and v2 bundles set ``$schema`` to manifest-v1.json
-        in the wild); v3.x bundles use manifest-v3.json.
+        Returns the matching schema for v1.x/v2.x/v3.x bundles. Returns
+        None for any other version (unknown majors, future formats,
+        garbage), signaling to the caller that validate() must reject
+        the bundle rather than fall through.
+
+        Round 3 reviewer finding: previously this fell back to v3 for
+        any unknown version, which let a forged manifest with
+        ``format_version=999.0.0`` pass v3 validation (the v3 schema
+        only checked semver pattern, not the major). Now we require an
+        explicit supported major.
         """
         schemas_dir = Path(__file__).parent / "schemas"
         version = (raw_manifest.get("format_version") or "").strip()
@@ -71,10 +76,7 @@ class BundleReader:
             return schemas_dir / "manifest-v1.json"
         if version.startswith("3."):
             return schemas_dir / "manifest-v3.json"
-        # Unknown/future version: best-effort fall back to the latest
-        # schema we ship so reviewers see an explicit error rather than
-        # silent acceptance.
-        return schemas_dir / "manifest-v3.json"
+        return None  # unknown major — caller rejects
 
     def __enter__(self) -> "BundleReader":
         """Open the bundle for reading."""
@@ -163,7 +165,19 @@ class BundleReader:
         raw = getattr(self, "_raw_manifest_dict", None)
         if raw is not None:
             schema_path = self._resolve_manifest_schema(raw)
-            if schema_path is not None:
+            if schema_path is None:
+                # Unknown / unsupported manifest version. Fail closed —
+                # the importer cannot apply meaningful validation, and
+                # the rest of validate()/from_dict will silently accept
+                # garbage. (Round 3 reviewer: previously fell through
+                # to v3 schema and let format_version=999.0.0 pass.)
+                version = (raw.get("format_version") or "").strip() or "<missing>"
+                errors.append(
+                    f"Unsupported manifest format_version {version!r}: "
+                    "this importer recognizes 1.x, 2.x, and 3.x. "
+                    "Upgrade nexus or use a compatible bundle."
+                )
+            else:
                 try:
                     import jsonschema
 

--- a/src/nexus/bricks/portability/bundle.py
+++ b/src/nexus/bricks/portability/bundle.py
@@ -44,14 +44,36 @@ class BundleReader:
                 print(record.virtual_path)
     """
 
-    def __init__(self, bundle_path: Path | str):
+    def __init__(
+        self,
+        bundle_path: Path | str | None = None,
+        *,
+        tar: tarfile.TarFile | None = None,
+    ):
         """Initialize bundle reader.
 
         Args:
-            bundle_path: Path to .nexus bundle file
+            bundle_path: Path to .nexus bundle file. Mutually exclusive
+                with `tar`.
+            tar: Already-open tarfile.TarFile. Use this when the caller
+                already has the bundle open (e.g., archive.verify_archive
+                wants to perform integrity checks on the same handle as
+                the signature check, avoiding a TOCTOU window between
+                two open() calls on the same path — round-8 finding).
+                When provided, `close()` is a no-op (caller owns the
+                handle).
         """
-        self.bundle_path = Path(bundle_path)
-        self._tar: tarfile.TarFile | None = None
+        if (bundle_path is None) == (tar is None):
+            raise ValueError("Pass exactly one of bundle_path or tar")
+        if tar is not None:
+            self.bundle_path = Path(getattr(tar, "name", "") or "<unnamed-tar>")
+            self._tar: tarfile.TarFile | None = tar
+            self._owns_tar = False
+        else:
+            assert bundle_path is not None
+            self.bundle_path = Path(bundle_path)
+            self._tar = None
+            self._owns_tar = True
         self._manifest: ExportManifest | None = None
         self._raw_manifest_dict: dict[str, Any] | None = None
 
@@ -89,14 +111,18 @@ class BundleReader:
 
     def open(self) -> None:
         """Open the bundle file for reading."""
+        # If the caller passed a tarfile to __init__, keep using it —
+        # don't re-open by path (TOCTOU window).
+        if self._tar is not None:
+            return
         if not self.bundle_path.exists():
             raise FileNotFoundError(f"Bundle not found: {self.bundle_path}")
 
         self._tar = tarfile.open(self.bundle_path, mode="r:gz")  # noqa: SIM115
 
     def close(self) -> None:
-        """Close the bundle file."""
-        if self._tar is not None:
+        """Close the bundle file (only if we own the handle)."""
+        if self._tar is not None and self._owns_tar:
             self._tar.close()
             self._tar = None
 

--- a/src/nexus/bricks/portability/bundle.py
+++ b/src/nexus/bricks/portability/bundle.py
@@ -97,8 +97,8 @@ class BundleReader:
             if file_obj is None:
                 raise ValueError("Could not read manifest file")
 
-            manifest_data = json.loads(file_obj.read().decode("utf-8"))
-            self._manifest = ExportManifest.from_dict(manifest_data)
+            self._raw_manifest_dict = json.loads(file_obj.read().decode("utf-8"))
+            self._manifest = ExportManifest.from_dict(self._raw_manifest_dict)
             return self._manifest
 
         except KeyError:
@@ -129,6 +129,27 @@ class BundleReader:
         except Exception as e:
             errors.append(f"Invalid manifest: {e}")
             return False, errors
+
+        # Strict JSON-Schema validation against the v3 schema (Issue #4083
+        # reviewer finding: from_dict drops unknown fields, so without
+        # this step a malformed v3 manifest with extra root keys is
+        # silently accepted). Skip if jsonschema isn't installed — the
+        # rest of validate() still runs.
+        try:
+            import jsonschema
+
+            from nexus.bricks.portability.models import MANIFEST_SCHEMA_PATH
+
+            raw = getattr(self, "_raw_manifest_dict", None)
+            if raw is not None and MANIFEST_SCHEMA_PATH.exists():
+                schema = json.loads(MANIFEST_SCHEMA_PATH.read_text())
+                try:
+                    jsonschema.validate(raw, schema)
+                except jsonschema.ValidationError as ve:
+                    errors.append(f"Manifest schema validation failed: {ve.message}")
+        except ImportError:
+            # jsonschema is an optional dep; skip strict validation.
+            pass
 
         # Check required files exist
         members = {m.name for m in self._tar.getmembers()}

--- a/src/nexus/bricks/portability/export_service.py
+++ b/src/nexus/bricks/portability/export_service.py
@@ -261,6 +261,9 @@ class ZoneExportService:
                 mount_phs = redact_and_write(raw_mounts, out_path=mounts_path)
                 manifest.placeholders = list(manifest.placeholders) + list(mount_phs)
                 manifest.mount_count = len(raw_mounts)
+                if raw_mounts:
+                    mounts_bytes = mounts_path.read_bytes()
+                    checksums.add_file(BUNDLE_PATHS["mounts"], mounts_bytes)
                 logger.info(
                     "Mount export: %d mounts, %d placeholders", len(raw_mounts), len(mount_phs)
                 )

--- a/src/nexus/bricks/portability/export_service.py
+++ b/src/nexus/bricks/portability/export_service.py
@@ -39,6 +39,7 @@ from nexus.bricks.portability.strip import (
 )
 
 if TYPE_CHECKING:
+    from nexus.bricks.portability.mount_export import _MountListing
     from nexus.contracts.portability_types import PortabilityFSProtocol
 
 logger = logging.getLogger(__name__)
@@ -121,11 +122,16 @@ class ZoneExportService:
     def __init__(
         self,
         nexus_fs: "PortabilityFSProtocol",
+        *,
+        mount_manager: "_MountListing | None" = None,
     ):
         """Initialize the export service.
 
         Args:
             nexus_fs: NexusFS-compatible instance with metadata store and backend access
+            mount_manager: Optional MountManager instance (must expose
+                ``list_mounts(zone_id=...)``).  Required when
+                ``ZoneExportOptions.include_mounts=True``.
         """
         self.nexus_fs = nexus_fs
         # ``nx.metadata`` was removed in W3b — reach the kernel directly so
@@ -137,6 +143,7 @@ class ZoneExportService:
         # R20.18.x: `NexusFS.backend` is gone — the kernel owns mount
         # routing now. Content reads go through `nexus_fs.sys_read`;
         # see `_export_content_blobs`.
+        self._mount_manager = mount_manager
 
     def export_zone(
         self,
@@ -161,6 +168,12 @@ class ZoneExportService:
         Returns:
             ExportManifest with export statistics and checksums
         """
+        if options.include_mounts and self._mount_manager is None:
+            raise ValueError(
+                "ZoneExportOptions.include_mounts=True requires "
+                "ZoneExportService(mount_manager=...)"
+            )
+
         import nexus
 
         logger.info("Starting export for zone %s to %s", zone_id, options.output_path)
@@ -233,6 +246,24 @@ class ZoneExportService:
                     logger.info(
                         "Credential stripping: %d placeholder(s) captured", len(placeholders)
                     )
+
+            # --- Mount-config export (v3+, Issue #4083) ---
+            if options.include_mounts:
+                from nexus.bricks.portability.mount_export import (
+                    collect_mounts,
+                    redact_and_write,
+                )
+
+                mounts_path = temp_path / "mounts.jsonl"
+                # Guard at export_zone entry ensures _mount_manager is non-None here.
+                assert self._mount_manager is not None
+                raw_mounts = collect_mounts(self._mount_manager, zone_id=zone_id)
+                mount_phs = redact_and_write(raw_mounts, out_path=mounts_path)
+                manifest.placeholders = list(manifest.placeholders) + list(mount_phs)
+                manifest.mount_count = len(raw_mounts)
+                logger.info(
+                    "Mount export: %d mounts, %d placeholders", len(raw_mounts), len(mount_phs)
+                )
 
             # Add checksum for files.jsonl
             if files_path.exists():

--- a/src/nexus/bricks/portability/export_service.py
+++ b/src/nexus/bricks/portability/export_service.py
@@ -254,19 +254,29 @@ class ZoneExportService:
                     redact_and_write,
                 )
 
-                mounts_path = temp_path / "mounts.jsonl"
                 # Guard at export_zone entry ensures _mount_manager is non-None here.
                 assert self._mount_manager is not None
                 raw_mounts = collect_mounts(self._mount_manager, zone_id=zone_id)
-                mount_phs = redact_and_write(raw_mounts, out_path=mounts_path)
-                manifest.placeholders = list(manifest.placeholders) + list(mount_phs)
-                manifest.mount_count = len(raw_mounts)
                 if raw_mounts:
+                    mounts_path = temp_path / "mounts.jsonl"
+                    mount_phs = redact_and_write(raw_mounts, out_path=mounts_path)
+                    manifest.placeholders = list(manifest.placeholders) + list(mount_phs)
+                    manifest.mount_count = len(raw_mounts)
                     mounts_bytes = mounts_path.read_bytes()
                     checksums.add_file(BUNDLE_PATHS["mounts"], mounts_bytes)
-                logger.info(
-                    "Mount export: %d mounts, %d placeholders", len(raw_mounts), len(mount_phs)
-                )
+                    logger.info(
+                        "Mount export: %d mounts, %d placeholders",
+                        len(raw_mounts),
+                        len(mount_phs),
+                    )
+                else:
+                    # Round-5 reviewer finding: writing an empty
+                    # mounts.jsonl with mount_count=0 produced a bundle
+                    # that BundleReader.validate then rejected as
+                    # "unmanifested mounts.jsonl" — exporters must NOT
+                    # emit the file when there's nothing to record.
+                    manifest.mount_count = 0
+                    logger.info("Mount export: zone has no mounts; skipping mounts.jsonl")
 
             # Add checksum for files.jsonl
             if files_path.exists():

--- a/src/nexus/bricks/portability/import_service.py
+++ b/src/nexus/bricks/portability/import_service.py
@@ -322,26 +322,15 @@ class ZoneImportService:
                         options.target_zone_id,
                     )
 
-                # Phase 1: Import file metadata and content
-                self._import_files(
-                    reader=reader,
-                    options=options,
-                    result=result,
-                    manifest_file_count=manifest.file_count,
-                    progress_callback=progress_callback,
-                )
-
-                # Phase 2: Import permissions (if enabled)
-                if options.import_permissions and manifest.include_permissions:
-                    self._import_permissions(
-                        reader=reader,
-                        options=options,
-                        result=result,
-                        progress_callback=progress_callback,
-                    )
-
-                # Phase 3: Restore mounts (Issue #4083) — dry_run must NOT
-                # mutate the persisted mount store; reporting only.
+                # Phase 1: Restore mounts FIRST (Issue #4083, round-10
+                # reviewer finding). Mount restore must run before file
+                # import — a bundle can carry files at paths that lie
+                # under a restored mount (e.g., /personal/alice/foo.txt
+                # where /personal/alice is a mount). If file import runs
+                # first, those writes go to the wrong (default/raft)
+                # backend, then the restored mount shadows them and
+                # reads point at an external backend that never received
+                # the content. dry_run still skips persistence.
                 if _mount_records and options.restore_mounts:
                     if options.dry_run:
                         logger.info(
@@ -359,6 +348,25 @@ class ZoneImportService:
                             conflict_mode=options.conflict_mode,
                         )
                         result.errors.extend(mount_errors)
+
+                # Phase 2: Import file metadata and content (now routed
+                # through restored mounts where applicable).
+                self._import_files(
+                    reader=reader,
+                    options=options,
+                    result=result,
+                    manifest_file_count=manifest.file_count,
+                    progress_callback=progress_callback,
+                )
+
+                # Phase 3: Import permissions (if enabled).
+                if options.import_permissions and manifest.include_permissions:
+                    self._import_permissions(
+                        reader=reader,
+                        options=options,
+                        result=result,
+                        progress_callback=progress_callback,
+                    )
 
         except (MissingCredentialsError, ValueError):
             raise

--- a/src/nexus/bricks/portability/import_service.py
+++ b/src/nexus/bricks/portability/import_service.py
@@ -25,6 +25,7 @@ from nexus.bricks.portability.models import (
     ContentMode,
     FileRecord,
     ImportResult,
+    MissingCredentialsError,
     PermissionRecord,
     ZoneImportOptions,
 )
@@ -352,15 +353,9 @@ class ZoneImportService:
                     )
                     result.errors.extend(mount_errors)
 
+        except (MissingCredentialsError, ValueError):
+            raise
         except Exception as e:
-            from nexus.bricks.portability.models import MissingCredentialsError
-
-            # Validation errors that callers must handle explicitly — re-raise
-            # so the caller sees the structured exception rather than a result
-            # with an opaque error string. MissingCredentialsError is raised
-            # before any side effect, so no partial state is left behind.
-            if isinstance(e, MissingCredentialsError):
-                raise
             logger.exception("Import failed: %s", e)
             result.add_error(
                 path=str(options.bundle_path),

--- a/src/nexus/bricks/portability/import_service.py
+++ b/src/nexus/bricks/portability/import_service.py
@@ -31,6 +31,7 @@ from nexus.bricks.portability.models import (
 from nexus.contracts.constants import ROOT_ZONE_ID
 
 if TYPE_CHECKING:
+    from nexus.bricks.portability.mount_import import _MountWriter
     from nexus.contracts.portability_types import PortabilityFSProtocol
     from nexus.contracts.types import OperationContext
 
@@ -186,6 +187,7 @@ class ZoneImportService:
         nexus_fs: "PortabilityFSProtocol",
         *,
         file_metadata_class: type[Any] | None = None,
+        mount_manager: "_MountWriter | None" = None,
     ):
         """Initialize the import service.
 
@@ -193,9 +195,14 @@ class ZoneImportService:
             nexus_fs: NexusFS-compatible instance with metadata store and backend access
             file_metadata_class: FileMetadata class for metadata-only imports (DI).
                                  If None, metadata-only imports are skipped.
+            mount_manager: Optional MountManager for restoring mount configs (Issue #4083).
+                           Required when importing bundles that contain mounts.jsonl and
+                           restore_mounts=True (the default). Pass None to preserve
+                           back-compat with callers that don't need mount restore.
         """
         self.nexus_fs = nexus_fs
         self._file_metadata_class = file_metadata_class
+        self._mount_manager = mount_manager
 
     def import_zone(
         self,
@@ -285,6 +292,26 @@ class ZoneImportService:
 
                         raise ArchivePlaceholderNotInjected(sorted(remaining))
 
+                # Guard 4: mount credential validation (Issue #4083) — BEFORE any side effect.
+                # Read mount records from the bundle (returns [] for v2 bundles that have
+                # no mounts.jsonl). If the bundle contains mounts and restore_mounts is
+                # enabled, validate that every redacted credential field has an override
+                # supplied. Raises MissingCredentialsError immediately so the operator
+                # sees the full list of gaps before any file/permission writes happen.
+                _mount_records = []
+                if options.restore_mounts:
+                    from nexus.bricks.portability.mount_import import validate_overrides
+
+                    _mount_records = reader.read_mount_records()
+                    if _mount_records:
+                        validate_overrides(_mount_records, options.mount_overrides)
+                        if self._mount_manager is None:
+                            raise ValueError(
+                                "Bundle contains mounts.jsonl but no MountManager supplied. "
+                                "Pass ZoneImportService(mount_manager=...) or set "
+                                "restore_mounts=False."
+                            )
+
                 # Check zone remapping
                 if options.target_zone_id:
                     result.zone_remapped = True
@@ -312,7 +339,28 @@ class ZoneImportService:
                         progress_callback=progress_callback,
                     )
 
+                # Phase 3: Restore mounts (Issue #4083)
+                if _mount_records and options.restore_mounts:
+                    from nexus.bricks.portability.mount_import import import_mounts
+
+                    mount_errors = import_mounts(
+                        mounts=_mount_records,
+                        overrides=options.mount_overrides or {},
+                        mount_manager=self._mount_manager,
+                        target_zone_id=options.target_zone_id,
+                        conflict_mode=options.conflict_mode,
+                    )
+                    result.errors.extend(mount_errors)
+
         except Exception as e:
+            from nexus.bricks.portability.models import MissingCredentialsError
+
+            # Validation errors that callers must handle explicitly — re-raise
+            # so the caller sees the structured exception rather than a result
+            # with an opaque error string. MissingCredentialsError is raised
+            # before any side effect, so no partial state is left behind.
+            if isinstance(e, MissingCredentialsError):
+                raise
             logger.exception("Import failed: %s", e)
             result.add_error(
                 path=str(options.bundle_path),

--- a/src/nexus/bricks/portability/import_service.py
+++ b/src/nexus/bricks/portability/import_service.py
@@ -340,18 +340,25 @@ class ZoneImportService:
                         progress_callback=progress_callback,
                     )
 
-                # Phase 3: Restore mounts (Issue #4083)
+                # Phase 3: Restore mounts (Issue #4083) — dry_run must NOT
+                # mutate the persisted mount store; reporting only.
                 if _mount_records and options.restore_mounts:
-                    from nexus.bricks.portability.mount_import import import_mounts
+                    if options.dry_run:
+                        logger.info(
+                            "DRY RUN: would restore %d mount(s); skipping save_mount/update_mount",
+                            len(_mount_records),
+                        )
+                    else:
+                        from nexus.bricks.portability.mount_import import import_mounts
 
-                    mount_errors = import_mounts(
-                        mounts=_mount_records,
-                        overrides=options.mount_overrides or {},
-                        mount_manager=self._mount_manager,
-                        target_zone_id=options.target_zone_id,
-                        conflict_mode=options.conflict_mode,
-                    )
-                    result.errors.extend(mount_errors)
+                        mount_errors = import_mounts(
+                            mounts=_mount_records,
+                            overrides=options.mount_overrides or {},
+                            mount_manager=self._mount_manager,
+                            target_zone_id=options.target_zone_id,
+                            conflict_mode=options.conflict_mode,
+                        )
+                        result.errors.extend(mount_errors)
 
         except (MissingCredentialsError, ValueError):
             raise

--- a/src/nexus/bricks/portability/models.py
+++ b/src/nexus/bricks/portability/models.py
@@ -503,7 +503,10 @@ class ZoneImportOptions:
         return self.user_id_remap.get(user_id, user_id)
 
     def to_dict(self) -> dict[str, Any]:
-        """Convert to dictionary for JSON serialization (excludes sensitive data)."""
+        """Convert to dictionary for JSON serialization.
+
+        Sensitive data is excluded or redacted: decryption_key is omitted; mount_overrides
+        values are replaced with "***" (structure preserved for debugging)."""
         return {
             "bundle_path": str(self.bundle_path),
             "target_zone_id": self.target_zone_id,
@@ -519,7 +522,11 @@ class ZoneImportOptions:
             "batch_size": self.batch_size,
             "max_concurrent_writes": self.max_concurrent_writes,
             "restore_mounts": self.restore_mounts,
-            "mount_overrides": self.mount_overrides,
+            "mount_overrides": (
+                {mid: dict.fromkeys(fields, "***") for mid, fields in self.mount_overrides.items()}
+                if self.mount_overrides
+                else None
+            ),
             # Note: decryption_key intentionally excluded for security
         }
 

--- a/src/nexus/bricks/portability/models.py
+++ b/src/nexus/bricks/portability/models.py
@@ -47,12 +47,12 @@ from typing import Any, Self
 # Constants
 # =============================================================================
 
-BUNDLE_FORMAT_VERSION = "2.0.0"
+BUNDLE_FORMAT_VERSION = "3.0.0"
 BUNDLE_EXTENSION = ".nexus"
 MANIFEST_FILENAME = "manifest.json"
 DEFAULT_COMPRESSION_LEVEL = 6
 DEFAULT_HASH_ALGORITHM = "sha256"
-MANIFEST_SCHEMA_URL = "https://nexus.io/schemas/manifest-v1.json"
+MANIFEST_SCHEMA_URL = "https://nexus.io/schemas/manifest-v3.json"
 MANIFEST_SCHEMA_PATH = Path(__file__).parent / "schemas" / "manifest-v1.json"
 
 
@@ -596,6 +596,9 @@ class ExportManifest:
     placeholders: list[PlaceholderRef] = field(default_factory=list)
     min_nexus_version: str = "0.0.0"
 
+    # v3 additions (Issue #4083)
+    mount_count: int = 0
+
     def to_dict(self) -> dict[str, Any]:
         """Convert to dictionary for JSON serialization.
 
@@ -604,7 +607,7 @@ class ExportManifest:
         """
         return {
             # Schema reference for validation
-            "$schema": "https://nexus.io/schemas/manifest-v1.json",
+            "$schema": "https://nexus.io/schemas/manifest-v3.json",
             # Format versioning
             "format_version": self.format_version,
             "nexus_version": self.nexus_version,
@@ -620,6 +623,7 @@ class ExportManifest:
                 "content_blob_count": self.content_blob_count,
                 "permission_count": self.permission_count,
                 "embedding_count": self.embedding_count,
+                "mount_count": self.mount_count,  # v3
             },
             # Options used
             "options": {
@@ -748,6 +752,8 @@ class ExportManifest:
             signer_pubkey_b64=data.get("signer_pubkey_b64"),
             placeholders=[PlaceholderRef.from_dict(p) for p in data.get("placeholders", [])],
             min_nexus_version=data.get("min_nexus_version", "0.0.0"),
+            # v3 fields (default-safe for v1/v2 bundles)
+            mount_count=stats.get("mount_count", 0),
         )
 
     @classmethod

--- a/src/nexus/bricks/portability/models.py
+++ b/src/nexus/bricks/portability/models.py
@@ -1196,4 +1196,70 @@ BUNDLE_PATHS = {
     "api_keys": "permissions/api_keys.jsonl.enc",
     "embeddings": "embeddings/vectors.parquet",
     "content": "content/cas",
+    "mounts": "mounts.jsonl",
 }
+
+
+# =============================================================================
+# Mount portability (Issue #4083)
+# =============================================================================
+
+
+@dataclass(frozen=True)
+class MountRecord:
+    """One line of mounts.jsonl. Mirrors MountManager's persisted shape with
+    secrets replaced by ${MOUNT_<id>_<FIELD>} placeholders on export."""
+
+    mount_id: str
+    mount_point: str
+    backend_type: str
+    backend_config: dict[str, Any]
+    owner_user_id: str | None = None
+    zone_id: str | None = None
+    description: str | None = None
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "mount_id": self.mount_id,
+            "mount_point": self.mount_point,
+            "backend_type": self.backend_type,
+            "backend_config": self.backend_config,
+            "owner_user_id": self.owner_user_id,
+            "zone_id": self.zone_id,
+            "description": self.description,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, Any]) -> "MountRecord":
+        return cls(
+            mount_id=data["mount_id"],
+            mount_point=data["mount_point"],
+            backend_type=data["backend_type"],
+            backend_config=data["backend_config"],
+            owner_user_id=data.get("owner_user_id"),
+            zone_id=data.get("zone_id"),
+            description=data.get("description"),
+        )
+
+
+class SensitiveFieldNotDeclaredError(ValueError):
+    """Export-time. Backend has CONNECTION_ARGS keys whose names match the
+    secret-shape heuristic but aren't marked secret=True."""
+
+    def __init__(self, backend_type: str, fields: list[str]) -> None:
+        self.backend_type = backend_type
+        self.fields = list(fields)
+        super().__init__(
+            f"Backend {backend_type!r} has secret-shaped fields not marked secret=True: "
+            f"{self.fields}. Mark them secret=True in CONNECTION_ARGS or rename them."
+        )
+
+
+class MissingCredentialsError(ValueError):
+    """Import-time. Bundle has redacted mount fields with no override supplied.
+    Reports every gap in one error so operators see the full set at once."""
+
+    def __init__(self, missing: dict[str, list[str]]) -> None:
+        self.missing = {k: list(v) for k, v in missing.items()}
+        lines = [f"  {mid}: {fields}" for mid, fields in sorted(self.missing.items())]
+        super().__init__("Mount imports require credential overrides for:\n" + "\n".join(lines))

--- a/src/nexus/bricks/portability/models.py
+++ b/src/nexus/bricks/portability/models.py
@@ -53,7 +53,7 @@ MANIFEST_FILENAME = "manifest.json"
 DEFAULT_COMPRESSION_LEVEL = 6
 DEFAULT_HASH_ALGORITHM = "sha256"
 MANIFEST_SCHEMA_URL = "https://nexus.io/schemas/manifest-v3.json"
-MANIFEST_SCHEMA_PATH = Path(__file__).parent / "schemas" / "manifest-v1.json"
+MANIFEST_SCHEMA_PATH = Path(__file__).parent / "schemas" / "manifest-v3.json"
 
 
 class ConflictMode(StrEnum):

--- a/src/nexus/bricks/portability/models.py
+++ b/src/nexus/bricks/portability/models.py
@@ -1219,6 +1219,7 @@ class MountRecord:
     description: str | None = None
 
     def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSONL serialization."""
         return {
             "mount_id": self.mount_id,
             "mount_point": self.mount_point,
@@ -1230,7 +1231,8 @@ class MountRecord:
         }
 
     @classmethod
-    def from_dict(cls, data: dict[str, Any]) -> "MountRecord":
+    def from_dict(cls, data: dict[str, Any]) -> Self:
+        """Create from dictionary."""
         return cls(
             mount_id=data["mount_id"],
             mount_point=data["mount_point"],

--- a/src/nexus/bricks/portability/models.py
+++ b/src/nexus/bricks/portability/models.py
@@ -607,7 +607,7 @@ class ExportManifest:
         """
         return {
             # Schema reference for validation
-            "$schema": "https://nexus.io/schemas/manifest-v3.json",
+            "$schema": MANIFEST_SCHEMA_URL,
             # Format versioning
             "format_version": self.format_version,
             "nexus_version": self.nexus_version,

--- a/src/nexus/bricks/portability/models.py
+++ b/src/nexus/bricks/portability/models.py
@@ -346,6 +346,9 @@ class ZoneExportOptions:
     # Security
     encryption_key: bytes | None = None
 
+    # Mounts (Issue #4083)
+    include_mounts: bool = False  # opt-in mount config export
+
     # Signing (v2+)
     sign: bool = True
     strip_credentials: bool = True
@@ -375,6 +378,7 @@ class ZoneExportOptions:
             "include_api_keys": self.include_api_keys,
             "include_deleted": self.include_deleted,
             "include_versions": self.include_versions,
+            "include_mounts": self.include_mounts,
             "path_prefix": self.path_prefix,
             "after_time": self.after_time.isoformat() if self.after_time else None,
             "before_time": self.before_time.isoformat() if self.before_time else None,
@@ -447,6 +451,10 @@ class ZoneImportOptions:
     rebuild_embeddings: bool = False
     force: bool = False
 
+    # Mount portability (Issue #4083)
+    restore_mounts: bool = True
+    mount_overrides: dict[str, dict[str, str]] | None = None
+
     def __post_init__(self) -> None:
         """Validate options after initialization."""
         if isinstance(self.bundle_path, str):
@@ -510,6 +518,8 @@ class ZoneImportOptions:
             "import_api_keys": self.import_api_keys,
             "batch_size": self.batch_size,
             "max_concurrent_writes": self.max_concurrent_writes,
+            "restore_mounts": self.restore_mounts,
+            "mount_overrides": self.mount_overrides,
             # Note: decryption_key intentionally excluded for security
         }
 

--- a/src/nexus/bricks/portability/mount_export.py
+++ b/src/nexus/bricks/portability/mount_export.py
@@ -10,14 +10,24 @@ from __future__ import annotations
 
 import json
 from pathlib import Path
-from typing import Any, cast
+from typing import Any, Protocol
 
 from nexus.bricks.portability.models import MountRecord, PlaceholderRef
 from nexus.bricks.portability.redaction import redact_config
 
 
+class _MountListing(Protocol):
+    """Narrow contract for the MountManager surface mount_export needs.
+
+    Defined locally so the brick boundary check (which forbids cross-brick
+    type imports) is satisfied while preserving static typing on call sites.
+    """
+
+    def list_mounts(self, *, zone_id: str | None) -> list[dict[str, Any]]: ...
+
+
 def collect_mounts(
-    mount_manager: Any,
+    mount_manager: _MountListing,
     *,
     zone_id: str | None,
 ) -> list[dict[str, Any]]:
@@ -28,7 +38,7 @@ def collect_mounts(
     owner_user_id, zone_id, description.  Passed in by the caller (DI) so the
     portability brick has no compile-time coupling to nexus.bricks.mount.
     """
-    return cast(list[dict[str, Any]], mount_manager.list_mounts(zone_id=zone_id))
+    return mount_manager.list_mounts(zone_id=zone_id)
 
 
 def redact_and_write(

--- a/src/nexus/bricks/portability/mount_export.py
+++ b/src/nexus/bricks/portability/mount_export.py
@@ -1,0 +1,81 @@
+"""Mount-config export for .nexus bundles (Issue #4083).
+
+Pulls mount configurations from MountManager, runs each through the redaction
+contract (declared via ConnectionArg.secret=True or audit_safe=True), and writes
+a sorted JSONL file alongside the rest of the bundle. Audit failures abort the
+export with SensitiveFieldNotDeclaredError before any bytes are written.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any, cast
+
+from nexus.bricks.portability.models import MountRecord, PlaceholderRef
+from nexus.bricks.portability.redaction import redact_config
+
+
+def collect_mounts(
+    mount_manager: Any,
+    *,
+    zone_id: str | None,
+) -> list[dict[str, Any]]:
+    """Return raw mount-config dicts from mount_manager (zone-filtered if zone_id set).
+
+    mount_manager must expose ``list_mounts(zone_id=...)`` returning a list of
+    dicts with keys: mount_id, mount_point, backend_type, backend_config,
+    owner_user_id, zone_id, description.  Passed in by the caller (DI) so the
+    portability brick has no compile-time coupling to nexus.bricks.mount.
+    """
+    return cast(list[dict[str, Any]], mount_manager.list_mounts(zone_id=zone_id))
+
+
+def redact_and_write(
+    mounts: list[dict[str, Any]],
+    *,
+    out_path: Path,
+) -> list[PlaceholderRef]:
+    """Per-mount: run redaction, write JSONL line; return aggregated placeholders.
+
+    Lines are sorted by mount_id for byte-stable output. Each line is canonical
+    JSON (sort_keys=True, no extra whitespace). On audit failure for any mount,
+    raises SensitiveFieldNotDeclaredError before writing anything.
+    """
+    sorted_mounts = sorted(mounts, key=lambda m: m["mount_id"])
+
+    # Phase 1: redact in memory, surface audit failures before any I/O.
+    redacted_records: list[MountRecord] = []
+    placeholders: list[PlaceholderRef] = []
+    for raw in sorted_mounts:
+        redacted_config, mount_phs = redact_config(
+            backend_type=raw["backend_type"],
+            config=raw.get("backend_config", {}) or {},
+            mount_id=raw["mount_id"],
+        )
+        record = MountRecord(
+            mount_id=raw["mount_id"],
+            mount_point=raw["mount_point"],
+            backend_type=raw["backend_type"],
+            backend_config=redacted_config,
+            owner_user_id=raw.get("owner_user_id"),
+            zone_id=raw.get("zone_id"),
+            description=raw.get("description"),
+        )
+        redacted_records.append(record)
+        placeholders.extend(mount_phs)
+
+    # Phase 2: write JSONL
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+    if not redacted_records:
+        out_path.write_text("")
+    else:
+        with out_path.open("w") as fh:
+            for record in redacted_records:
+                fh.write(json.dumps(record.to_dict(), sort_keys=True))
+                fh.write("\n")
+
+    return placeholders
+
+
+__all__ = ["collect_mounts", "redact_and_write"]

--- a/src/nexus/bricks/portability/mount_import.py
+++ b/src/nexus/bricks/portability/mount_import.py
@@ -1,0 +1,191 @@
+"""Mount-config import for .nexus bundles (Issue #4083).
+
+Reads mounts.jsonl, validates that all redacted fields have overrides supplied,
+re-injects values, and restores via MountManager. Validation runs *before* any
+backend init or persistence — operators see every credential gap in one error.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from pathlib import Path
+from typing import Any, Protocol
+
+from nexus.bricks.portability.models import (
+    ConflictMode,
+    ImportError,
+    MissingCredentialsError,
+    MountRecord,
+)
+
+_PLACEHOLDER_RE = re.compile(r"^\$\{MOUNT_(?P<id>.+)_(?P<field>[A-Z0-9_]+)\}$")
+"""Matches ${MOUNT_<id>_<FIELD>} where <id> may contain underscores and <field>
+is the upper-cased CONNECTION_ARGS key. Greedy on <id> is safe because <field>
+is constrained to [A-Z0-9_]+ at the suffix."""
+
+
+class _MountWriter(Protocol):
+    """Narrow contract for the MountManager surface mount_import needs.
+
+    Defined locally so the brick boundary check (which forbids cross-brick type
+    imports) is satisfied while preserving static typing on call sites.
+    """
+
+    def get_mount(self, mount_point: str) -> dict[str, Any] | None: ...
+
+    def save_mount(
+        self,
+        mount_point: str,
+        backend_type: str,
+        backend_config: dict[str, Any],
+        owner_user_id: str | None = None,
+        zone_id: str | None = None,
+        description: str | None = None,
+    ) -> str: ...
+
+    def update_mount(
+        self,
+        mount_point: str,
+        backend_config: dict[str, Any] | None = None,
+        description: str | None = None,
+    ) -> bool: ...
+
+
+def read_mounts(bundle_dir: Path) -> list[MountRecord]:
+    """Parse bundle_dir/mounts.jsonl. Returns [] if the file is absent."""
+    path = bundle_dir / "mounts.jsonl"
+    if not path.exists():
+        return []
+    out: list[MountRecord] = []
+    for line in path.read_text().splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        out.append(MountRecord.from_dict(json.loads(line)))
+    return out
+
+
+def _redacted_fields(record: MountRecord) -> list[str]:
+    """Return the list of CONNECTION_ARGS keys whose value is a placeholder string."""
+    return [
+        name
+        for name, value in record.backend_config.items()
+        if isinstance(value, str) and _PLACEHOLDER_RE.match(value)
+    ]
+
+
+def validate_overrides(
+    mounts: list[MountRecord],
+    overrides: dict[str, dict[str, str]] | None,
+) -> None:
+    """Walk every redacted field; raise MissingCredentialsError listing all gaps.
+
+    Pure function: no side effects. Runs before any backend init.
+    """
+    overrides = overrides or {}
+    missing: dict[str, list[str]] = {}
+    for record in mounts:
+        provided = overrides.get(record.mount_id, {}) or {}
+        gaps = [f for f in _redacted_fields(record) if f not in provided]
+        if gaps:
+            missing[record.mount_id] = sorted(gaps)
+    if missing:
+        raise MissingCredentialsError(missing=missing)
+
+
+def materialize(
+    mount_record: MountRecord,
+    overrides_for_mount: dict[str, str],
+) -> dict[str, Any]:
+    """Substitute ${MOUNT_<id>_<FIELD>} placeholders. Returns the final backend_config."""
+    out = dict(mount_record.backend_config)
+    for field_name, value in list(out.items()):
+        if (
+            isinstance(value, str)
+            and _PLACEHOLDER_RE.match(value)
+            and field_name in overrides_for_mount
+        ):
+            out[field_name] = overrides_for_mount[field_name]
+    return out
+
+
+def import_mounts(
+    mounts: list[MountRecord],
+    overrides: dict[str, dict[str, str]],
+    mount_manager: _MountWriter,
+    *,
+    target_zone_id: str | None,
+    conflict_mode: ConflictMode,
+) -> list[ImportError]:
+    """Per mount: materialize + save_mount/update_mount per conflict_mode.
+
+    Mounts are sorted by mount_point depth (shallowest first) so parent paths
+    restore before any nested children that may depend on them.
+
+    Returns per-mount errors; does not raise except on programmer bugs.
+    """
+    errors: list[ImportError] = []
+    overrides = overrides or {}
+    sorted_mounts = sorted(mounts, key=lambda m: len(m.mount_point.split("/")))
+
+    for record in sorted_mounts:
+        mount_overrides = overrides.get(record.mount_id, {}) or {}
+        backend_config = materialize(record, mount_overrides)
+        zone_id = target_zone_id if target_zone_id is not None else record.zone_id
+
+        existing = mount_manager.get_mount(record.mount_point)
+        if existing is not None:
+            if conflict_mode == ConflictMode.SKIP:
+                errors.append(
+                    ImportError(
+                        path=record.mount_point,
+                        error_type="conflict",
+                        message=f"mount {record.mount_point!r} already exists; skipped",
+                    )
+                )
+                continue
+            if conflict_mode == ConflictMode.FAIL:
+                errors.append(
+                    ImportError(
+                        path=record.mount_point,
+                        error_type="conflict",
+                        message=f"mount {record.mount_point!r} already exists",
+                    )
+                )
+                continue
+            if conflict_mode == ConflictMode.OVERWRITE:
+                mount_manager.update_mount(
+                    mount_point=record.mount_point,
+                    backend_config=backend_config,
+                    description=record.description,
+                )
+                continue
+
+        try:
+            mount_manager.save_mount(
+                mount_point=record.mount_point,
+                backend_type=record.backend_type,
+                backend_config=backend_config,
+                owner_user_id=record.owner_user_id,
+                zone_id=zone_id,
+                description=record.description,
+            )
+        except Exception as exc:  # noqa: BLE001
+            errors.append(
+                ImportError(
+                    path=record.mount_point,
+                    error_type="io",
+                    message=f"failed to restore mount {record.mount_point!r}: {exc}",
+                )
+            )
+
+    return errors
+
+
+__all__ = [
+    "read_mounts",
+    "validate_overrides",
+    "materialize",
+    "import_mounts",
+]

--- a/src/nexus/bricks/portability/mount_import.py
+++ b/src/nexus/bricks/portability/mount_import.py
@@ -163,17 +163,40 @@ def import_mounts(
                 # the live mount table on next restore. Reviewer flagged
                 # this as a real risk; conflict resolution must not
                 # silently change immutable fields.
+                #
+                # Round 2 follow-up: fail closed on missing backend_type
+                # in the persisted record. An older/malformed record
+                # without that field cannot be safely overwritten because
+                # update_mount preserves it (or leaves the gap), and any
+                # downstream restore that relies on backend_type would
+                # break. Operator must remove and re-add explicitly.
                 existing_backend_type = existing.get("backend_type")
                 existing_owner = existing.get("owner_user_id")
-                if existing_backend_type and existing_backend_type != record.backend_type:
+                if not existing_backend_type:
+                    errors.append(
+                        ImportError(
+                            path=record.mount_point,
+                            error_type="conflict",
+                            message=(
+                                f"mount {record.mount_point!r} has no "
+                                f"backend_type in the persisted record "
+                                f"(possibly malformed/legacy schema); "
+                                "OVERWRITE refused — remove the mount first"
+                            ),
+                        )
+                    )
+                    continue
+                if existing_backend_type != record.backend_type:
                     errors.append(
                         ImportError(
                             path=record.mount_point,
                             error_type="conflict",
                             message=(
                                 f"mount {record.mount_point!r} backend_type mismatch: "
-                                f"existing={existing_backend_type!r} bundle={record.backend_type!r}; "
-                                "OVERWRITE refused — remove the mount first or use a different target_zone"
+                                f"existing={existing_backend_type!r} "
+                                f"bundle={record.backend_type!r}; "
+                                "OVERWRITE refused — remove the mount first "
+                                "or use a different target_zone"
                             ),
                         )
                     )

--- a/src/nexus/bricks/portability/mount_import.py
+++ b/src/nexus/bricks/portability/mount_import.py
@@ -155,6 +155,46 @@ def import_mounts(
                 )
                 continue
             if conflict_mode == ConflictMode.OVERWRITE:
+                # update_mount only writes backend_config + description.
+                # Refuse the overwrite if the existing mount's identity
+                # (backend_type, owner) doesn't match — silently writing
+                # an S3 backend_config onto a path_local mount, or
+                # rebinding ownership to a different user, would corrupt
+                # the live mount table on next restore. Reviewer flagged
+                # this as a real risk; conflict resolution must not
+                # silently change immutable fields.
+                existing_backend_type = existing.get("backend_type")
+                existing_owner = existing.get("owner_user_id")
+                if existing_backend_type and existing_backend_type != record.backend_type:
+                    errors.append(
+                        ImportError(
+                            path=record.mount_point,
+                            error_type="conflict",
+                            message=(
+                                f"mount {record.mount_point!r} backend_type mismatch: "
+                                f"existing={existing_backend_type!r} bundle={record.backend_type!r}; "
+                                "OVERWRITE refused — remove the mount first or use a different target_zone"
+                            ),
+                        )
+                    )
+                    continue
+                if (
+                    record.owner_user_id is not None
+                    and existing_owner is not None
+                    and existing_owner != record.owner_user_id
+                ):
+                    errors.append(
+                        ImportError(
+                            path=record.mount_point,
+                            error_type="conflict",
+                            message=(
+                                f"mount {record.mount_point!r} owner mismatch: "
+                                f"existing={existing_owner!r} bundle={record.owner_user_id!r}; "
+                                "OVERWRITE refused — remove the mount first to change ownership"
+                            ),
+                        )
+                    )
+                    continue
                 mount_manager.update_mount(
                     mount_point=record.mount_point,
                     backend_config=backend_config,

--- a/src/nexus/bricks/portability/redaction.py
+++ b/src/nexus/bricks/portability/redaction.py
@@ -63,12 +63,19 @@ def audit_backend(backend_type: str) -> list[str]:
     Empty list = backend passes audit. Non-empty = export must abort.
     Returns [] for backends whose connector class hasn't loaded (no audit possible
     until the optional extra is installed; the audit test skips those entries).
+
+    Escape hatch: set ``audit_safe=True`` on a ``ConnectionArg`` to suppress the
+    heuristic for a provably non-sensitive field whose name happens to match the
+    secret-shape regex (e.g. ``token_manager_db`` is a filesystem path, not a
+    credential). Document the reason in the field's description.
     """
     args = _get_connection_args(backend_type)
     return [
         name
         for name, arg in args.items()
-        if SECRET_SHAPED.search(name) and not getattr(arg, "secret", False)
+        if SECRET_SHAPED.search(name)
+        and not getattr(arg, "secret", False)
+        and not getattr(arg, "audit_safe", False)
     ]
 
 

--- a/src/nexus/bricks/portability/redaction.py
+++ b/src/nexus/bricks/portability/redaction.py
@@ -37,6 +37,10 @@ def _get_connection_args(backend_type: str) -> dict[str, Any]:
     Returns {} for placeholder registry entries whose connector module failed
     to import (extra not installed) — those are skipped by callers, not
     treated as audit failures.
+
+    Note: similar to ConnectorRegistry.get_connection_args, but kept local so
+    tests can patch this single function to inject fake CONNECTION_ARGS without
+    monkey-patching the global registry.
     """
     from nexus.backends.base.registry import ConnectorRegistry
 

--- a/src/nexus/bricks/portability/redaction.py
+++ b/src/nexus/bricks/portability/redaction.py
@@ -174,16 +174,26 @@ def redact_config(
                 f"connector so the redaction contract resolves)",
                 fields=sorted(config.keys()),
             )
-        # Registered backend with no CONNECTION_ARGS: scan only — can't
-        # use declared_secret_fields because there are none. Any
-        # secret-shaped key in the persisted config is a leak.
+        # Registered backend with no CONNECTION_ARGS contract. Round-4
+        # passed this through after a key-only scan, but round-5 reviewer
+        # flagged that values can carry secrets in innocuous keys (e.g.,
+        # ``command='aws ... --secret-key=AKIA...'`` or a DSN URL with
+        # userinfo). Without a connector-declared schema we have no way
+        # to know which value substrings to strip, so pattern-scan keys
+        # AND values, and refuse export if anything looks like a
+        # credential. The connector author's escape hatch is to declare
+        # CONNECTION_ARGS or add ``audit_safe`` markers.
         config_leaks = _scan_config_for_undeclared_secrets({}, config)
-        if config_leaks:
+        value_leaks = _scan_config_values_for_secret_patterns(config)
+        all_leaks = sorted(set(config_leaks) | set(value_leaks))
+        if all_leaks:
             raise SensitiveFieldNotDeclaredError(
                 backend_type=f"{backend_type} (registered but declares no "
-                f"CONNECTION_ARGS; secret-shaped keys in persisted "
-                f"backend_config cannot be safely redacted)",
-                fields=config_leaks,
+                f"CONNECTION_ARGS; cannot safely export — values look "
+                f"credential-shaped or keys match the secret heuristic. "
+                f"Declare CONNECTION_ARGS with secret/audit_safe flags or "
+                f"omit this mount with --no-include-mounts)",
+                fields=all_leaks,
             )
         # No declared secrets, no scanned leaks → pass through unchanged.
         return dict(config), []
@@ -224,6 +234,57 @@ def redact_config(
         placeholders.append(PlaceholderRef(name=ph_name, field=f"mounts.{mount_id}.{field_name}"))
 
     return out, placeholders
+
+
+# Patterns of credential-shaped VALUES that should not appear in an
+# exported mount config when no CONNECTION_ARGS contract exists to
+# tell us how to redact properly. Conservative: if a value looks like
+# any of these shapes, refuse the export and ask the operator to
+# declare a contract or skip mounts.
+_VALUE_SECRET_PATTERNS: list[re.Pattern[str]] = [
+    re.compile(r"AKIA[0-9A-Z]{12,}"),  # AWS access key IDs
+    re.compile(r"ASIA[0-9A-Z]{12,}"),  # AWS temp access key
+    re.compile(r"sk-[A-Za-z0-9]{20,}"),  # OpenAI / anthropic prefixed keys
+    re.compile(r"sk-ant-[A-Za-z0-9_-]{20,}"),  # anthropic
+    re.compile(r"ghp_[A-Za-z0-9]{36,}"),  # GitHub PAT
+    re.compile(r"gho_[A-Za-z0-9]{36,}"),  # GitHub OAuth token
+    re.compile(r"glpat-[A-Za-z0-9_-]{20,}"),  # GitLab PAT
+    re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"),  # Slack tokens
+    re.compile(r"AIza[0-9A-Za-z_-]{35,}"),  # Google API key
+    re.compile(r"-----BEGIN [A-Z ]+PRIVATE KEY-----"),  # PEM private keys
+    re.compile(r"(?i)bearer\s+[A-Za-z0-9._-]{20,}"),  # bearer tokens
+    re.compile(
+        r"(?i)(?:password|secret|token|api[_-]?key|access[_-]?key)\s*=\s*[^\s]{8,}"
+    ),  # KEY=VALUE assignments inside command strings
+    re.compile(r"://[^/\s:@]+:[^/\s@]+@"),  # URL userinfo (user:pass@host)
+]
+
+
+def _scan_config_values_for_secret_patterns(config: dict[str, Any]) -> list[str]:
+    """Return dotted paths of values in `config` whose stringified form
+    matches a known credential-shaped pattern. Walks nested dicts/lists.
+
+    Used only on the no-CONNECTION_ARGS-contract path where we can't
+    rely on declared structure to know which fields are secret.
+    """
+    leaks: list[str] = []
+
+    def _walk(value: Any, path: str) -> None:
+        if isinstance(value, str):
+            for rx in _VALUE_SECRET_PATTERNS:
+                if rx.search(value):
+                    leaks.append(path or "<root>")
+                    return
+        elif isinstance(value, dict):
+            for k, v in value.items():
+                here = f"{path}.{k}" if path else (k if isinstance(k, str) else f"[{k}]")
+                _walk(v, here)
+        elif isinstance(value, list):
+            for i, item in enumerate(value):
+                _walk(item, f"{path}[{i}]")
+
+    _walk(config, "")
+    return sorted(set(leaks))
 
 
 def _scan_config_for_undeclared_secrets(

--- a/src/nexus/bricks/portability/redaction.py
+++ b/src/nexus/bricks/portability/redaction.py
@@ -261,27 +261,37 @@ def redact_config(
 # any of these shapes, refuse the export and ask the operator to
 # declare a contract or skip mounts.
 _VALUE_SECRET_PATTERNS: list[re.Pattern[str]] = [
-    re.compile(r"AKIA[0-9A-Z]{12,}"),  # AWS access key IDs
-    re.compile(r"ASIA[0-9A-Z]{12,}"),  # AWS temp access key
-    re.compile(r"sk-[A-Za-z0-9]{20,}"),  # OpenAI / anthropic prefixed keys
-    re.compile(r"sk-ant-[A-Za-z0-9_-]{20,}"),  # anthropic
-    re.compile(r"ghp_[A-Za-z0-9]{36,}"),  # GitHub PAT
-    re.compile(r"gho_[A-Za-z0-9]{36,}"),  # GitHub OAuth token
-    re.compile(r"glpat-[A-Za-z0-9_-]{20,}"),  # GitLab PAT
-    re.compile(r"xox[baprs]-[A-Za-z0-9-]{10,}"),  # Slack tokens
-    re.compile(r"AIza[0-9A-Za-z_-]{35,}"),  # Google API key
-    re.compile(r"-----BEGIN [A-Z ]+PRIVATE KEY-----"),  # PEM private keys
-    re.compile(r"(?i)bearer\s+[A-Za-z0-9._-]{20,}"),  # bearer tokens
-    re.compile(
-        r"(?i)(?:password|secret|token|api[_-]?key|access[_-]?key)\s*=\s*[^\s]{8,}"
-    ),  # KEY=VALUE assignments inside command strings
-    re.compile(r"://[^/\s:@]+:[^/\s@]+@"),  # URL userinfo (user:pass@host)
-    # Round-6 additions — token-only userinfo and JWTs that the
-    # round-5 patterns missed.
-    re.compile(r"://[A-Za-z0-9._\-+/=]{16,}@"),  # URL token-only (https://TOKEN@host)
-    re.compile(
-        r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"
-    ),  # JWT (header.payload.signature, base64url, eyJ prefix)
+    # Provider-specific tokens with strong unique prefixes — high
+    # specificity, low false-positive rate.
+    re.compile(r"\bAKIA[0-9A-Z]{12,}\b"),  # AWS access key IDs
+    re.compile(r"\bASIA[0-9A-Z]{12,}\b"),  # AWS temp access key
+    re.compile(r"\bsk-ant-[A-Za-z0-9_-]{20,}\b"),  # anthropic
+    re.compile(r"\bghp_[A-Za-z0-9]{36,}\b"),  # GitHub PAT
+    re.compile(r"\bgho_[A-Za-z0-9]{36,}\b"),  # GitHub OAuth token
+    re.compile(r"\bglpat-[A-Za-z0-9_-]{20,}\b"),  # GitLab PAT
+    re.compile(r"\bxox[baprs]-[A-Za-z0-9-]{10,}\b"),  # Slack tokens
+    re.compile(r"\bAIza[0-9A-Za-z_-]{35,}\b"),  # Google API key
+    # PEM private key armoring is unmistakable.
+    re.compile(r"-----BEGIN [A-Z ]+PRIVATE KEY-----"),
+    # Bearer-prefixed tokens (the literal "Bearer " is the signal).
+    re.compile(r"(?i)\bbearer\s+[A-Za-z0-9._-]{20,}"),
+    # KEY=VALUE assignments where the KEY is itself credential-named.
+    # Must be a credential-shaped key on the LHS so a benign
+    # ``--threshold=12345678`` doesn't match.
+    re.compile(r"(?i)\b(?:password|secret|token|api[_-]?key|access[_-]?key)\s*=\s*[^\s]{8,}"),
+    # URL userinfo with both user AND password — high-confidence
+    # credential leak. (Round-6's bare "token-only" pattern was too
+    # loose and matched ``https://username@host`` legitimately;
+    # dropped in round-7.)
+    re.compile(r"://[^/\s:@]+:[^/\s@]+@"),
+    # JWT — three base64url segments separated by dots, eyJ prefix.
+    # Strict shape, low FPR.
+    re.compile(r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"),
+    # NOTE: round-6's bare ``sk-[A-Za-z0-9]{20,}`` was dropped in
+    # round-7 as too loose (matched legitimate paths like
+    # ``/data/sk-FOO20chars``). OpenAI keys without sk-ant prefix lose
+    # this guard — operators MUST mark such fields secret=True if their
+    # backend persists them.
 ]
 
 

--- a/src/nexus/bricks/portability/redaction.py
+++ b/src/nexus/bricks/portability/redaction.py
@@ -48,10 +48,23 @@ def _get_connection_args(backend_type: str) -> dict[str, Any]:
     Note: similar to ConnectorRegistry.get_connection_args, but kept local so
     tests can patch this single function to inject fake CONNECTION_ARGS without
     monkey-patching the global registry.
+
+    Forces ``_register_optional_backends()`` once at first call. Without this
+    the registry only contains backends imported by other code paths so far
+    (often just ``cas_local`` and ``path_local`` in a fresh server process),
+    and ``ConnectorRegistry.get_info("path_s3")`` would raise ``KeyError`` —
+    which would surface to the operator as ``Unknown connector 'path_s3'``
+    instead of either a clean redaction or an honest "extra not installed"
+    skip. The registration is idempotent; subsequent calls are a no-op.
     """
+    from nexus.backends import _register_optional_backends
     from nexus.backends.base.registry import ConnectorRegistry
 
-    info = ConnectorRegistry.get_info(backend_type)
+    _register_optional_backends()
+    try:
+        info = ConnectorRegistry.get_info(backend_type)
+    except KeyError:
+        return {}
     cls = info.connector_class
     args = getattr(cls, "CONNECTION_ARGS", {}) or {} if cls is not None else {}
     if args:
@@ -59,10 +72,13 @@ def _get_connection_args(backend_type: str) -> dict[str, Any]:
 
     # Fallback: extension-store manifest (Slack uses this path).
     try:
+        from nexus.extensions.manifest import ConnectorManifest
         from nexus.extensions.store import get_store
 
         manifest = get_store().get(backend_type, "connector")
-        if manifest is not None:
+        # The store can return non-connector kinds; only ConnectorManifest
+        # carries `connection_args` — narrow before access.
+        if isinstance(manifest, ConnectorManifest):
             return dict(manifest.connection_args or {})
     except Exception:
         # Extension store may not be initialised in all test contexts.
@@ -118,8 +134,28 @@ def redact_config(
         skipped (no placeholder generated for a field that's None).
 
     Raises:
-        SensitiveFieldNotDeclaredError: if audit_backend(backend_type) is non-empty.
+        SensitiveFieldNotDeclaredError: if audit_backend(backend_type) is non-empty
+            (a real leak — backend has a secret-shaped field not marked secret/
+            audit_safe), OR if the backend's CONNECTION_ARGS cannot be resolved
+            (registry doesn't know it, or its connector class failed to import
+            for missing optional extras). The latter is treated as a leak risk:
+            we cannot confidently strip a contract we can't introspect, so the
+            export is refused rather than silently shipping cleartext credentials.
     """
+    args = _get_connection_args(backend_type)
+    if not args:
+        # Backend not in registry, or connector class failed to import (e.g.,
+        # boto3 not installed on a slim server). We can't introspect the
+        # CONNECTION_ARGS contract, so we don't know which fields are secret —
+        # refuse the export rather than ship cleartext credentials. Operators
+        # see the offending fields in the error so they can install the
+        # missing extra (e.g., `pip install nexus-fs[s3]`) and retry.
+        raise SensitiveFieldNotDeclaredError(
+            backend_type=f"{backend_type} (CONNECTION_ARGS not loadable; "
+            f"install the matching extra so the redaction contract resolves)",
+            fields=sorted(config.keys()),
+        )
+
     leaks = audit_backend(backend_type)
     if leaks:
         raise SensitiveFieldNotDeclaredError(backend_type=backend_type, fields=leaks)

--- a/src/nexus/bricks/portability/redaction.py
+++ b/src/nexus/bricks/portability/redaction.py
@@ -48,14 +48,6 @@ def _get_connection_args(backend_type: str) -> dict[str, Any]:
     Note: similar to ConnectorRegistry.get_connection_args, but kept local so
     tests can patch this single function to inject fake CONNECTION_ARGS without
     monkey-patching the global registry.
-
-    Forces ``_register_optional_backends()`` once at first call. Without this
-    the registry only contains backends imported by other code paths so far
-    (often just ``cas_local`` and ``path_local`` in a fresh server process),
-    and ``ConnectorRegistry.get_info("path_s3")`` would raise ``KeyError`` —
-    which would surface to the operator as ``Unknown connector 'path_s3'``
-    instead of either a clean redaction or an honest "extra not installed"
-    skip. The registration is idempotent; subsequent calls are a no-op.
     """
     from nexus.backends import _register_optional_backends
     from nexus.backends.base.registry import ConnectorRegistry
@@ -85,6 +77,23 @@ def _get_connection_args(backend_type: str) -> dict[str, Any]:
         pass
 
     return {}
+
+
+def _backend_is_registered(backend_type: str) -> bool:
+    """Return True if `backend_type` is in the ConnectorRegistry (with or
+    without a loaded connector_class). Used by ``redact_config`` to
+    distinguish 'unknown backend' from 'registered backend with no
+    CONNECTION_ARGS' — the latter is legitimate for CLI/YAML-defined
+    custom connectors, the former is a leak risk."""
+    from nexus.backends import _register_optional_backends
+    from nexus.backends.base.registry import ConnectorRegistry
+
+    _register_optional_backends()
+    try:
+        ConnectorRegistry.get_info(backend_type)
+        return True
+    except KeyError:
+        return False
 
 
 def declared_secret_fields(backend_type: str) -> frozenset[str]:
@@ -144,17 +153,40 @@ def redact_config(
     """
     args = _get_connection_args(backend_type)
     if not args:
-        # Backend not in registry, or connector class failed to import (e.g.,
-        # boto3 not installed on a slim server). We can't introspect the
-        # CONNECTION_ARGS contract, so we don't know which fields are secret —
-        # refuse the export rather than ship cleartext credentials. Operators
-        # see the offending fields in the error so they can install the
-        # missing extra (e.g., `pip install nexus-fs[s3]`) and retry.
-        raise SensitiveFieldNotDeclaredError(
-            backend_type=f"{backend_type} (CONNECTION_ARGS not loadable; "
-            f"install the matching extra so the redaction contract resolves)",
-            fields=sorted(config.keys()),
-        )
+        # Two cases produce empty args; only one is a leak risk:
+        #
+        # (a) backend_type is NOT in the ConnectorRegistry at all (e.g.
+        #     unknown name, slim install missing the matching extra so
+        #     the connector class never loaded). We can't introspect any
+        #     contract → refuse the export rather than ship cleartext.
+        #
+        # (b) backend_type IS registered but has no CONNECTION_ARGS
+        #     declared (CLI/YAML-defined custom connectors don't always
+        #     define the class attribute). Round-4 reviewer flagged the
+        #     blanket refuse path as too strict — it broke supported
+        #     workflows for these. For (b) we still scan the persisted
+        #     backend_config for secret-shaped keys and refuse if any
+        #     are found; otherwise allow export with no placeholders.
+        if not _backend_is_registered(backend_type):
+            raise SensitiveFieldNotDeclaredError(
+                backend_type=f"{backend_type} (unknown backend; CONNECTION_ARGS "
+                f"not loadable — install the matching extra or register the "
+                f"connector so the redaction contract resolves)",
+                fields=sorted(config.keys()),
+            )
+        # Registered backend with no CONNECTION_ARGS: scan only — can't
+        # use declared_secret_fields because there are none. Any
+        # secret-shaped key in the persisted config is a leak.
+        config_leaks = _scan_config_for_undeclared_secrets({}, config)
+        if config_leaks:
+            raise SensitiveFieldNotDeclaredError(
+                backend_type=f"{backend_type} (registered but declares no "
+                f"CONNECTION_ARGS; secret-shaped keys in persisted "
+                f"backend_config cannot be safely redacted)",
+                fields=config_leaks,
+            )
+        # No declared secrets, no scanned leaks → pass through unchanged.
+        return dict(config), []
 
     leaks = audit_backend(backend_type)
     if leaks:

--- a/src/nexus/bricks/portability/redaction.py
+++ b/src/nexus/bricks/portability/redaction.py
@@ -218,6 +218,25 @@ def redact_config(
             fields=config_leaks,
         )
 
+    # Round-6 reviewer finding: audit_safe-marked or non-secret declared
+    # fields can still hold credential-shaped VALUES (e.g.,
+    # ``token_manager_db = "postgresql://user:pass@host/db"`` — a
+    # filesystem-style audit_safe field that happens to carry a real
+    # DB URL with userinfo). Run the value-pattern scan over the
+    # non-secret declared fields too, refusing if any look credential-
+    # bearing. The connector author's recourse is to mark the field
+    # secret=True (will be redacted) or sanitize the value before save.
+    secrets = declared_secret_fields(backend_type)
+    non_secret_subset = {k: v for k, v in config.items() if k not in secrets}
+    value_leaks = _scan_config_values_for_secret_patterns(non_secret_subset)
+    if value_leaks:
+        raise SensitiveFieldNotDeclaredError(
+            backend_type=f"{backend_type} (non-secret declared field carries a "
+            f"credential-shaped value — mark the field secret=True or "
+            f"sanitize the value before persisting the mount)",
+            fields=value_leaks,
+        )
+
     secrets = declared_secret_fields(backend_type)
     out = dict(config)
     placeholders: list[PlaceholderRef] = []
@@ -257,6 +276,12 @@ _VALUE_SECRET_PATTERNS: list[re.Pattern[str]] = [
         r"(?i)(?:password|secret|token|api[_-]?key|access[_-]?key)\s*=\s*[^\s]{8,}"
     ),  # KEY=VALUE assignments inside command strings
     re.compile(r"://[^/\s:@]+:[^/\s@]+@"),  # URL userinfo (user:pass@host)
+    # Round-6 additions — token-only userinfo and JWTs that the
+    # round-5 patterns missed.
+    re.compile(r"://[A-Za-z0-9._\-+/=]{16,}@"),  # URL token-only (https://TOKEN@host)
+    re.compile(
+        r"\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}"
+    ),  # JWT (header.payload.signature, base64url, eyJ prefix)
 ]
 
 

--- a/src/nexus/bricks/portability/redaction.py
+++ b/src/nexus/bricks/portability/redaction.py
@@ -25,10 +25,11 @@ from nexus.bricks.portability.models import (
 SECRET_SHAPED = re.compile(r"(?i)(key|secret|token|password|cred)")
 """Heuristic regex for argument names that should be marked secret=True.
 
-Audit fails if a CONNECTION_ARGS key matches this regex but has secret=False.
-The check is deliberately strict — every false positive is a forcing function
-to either rename the field or mark it secret=True. No allowlist exists today;
-add one only if real friction emerges (see spec for `audit_safe` follow-up)."""
+Audit fails if a CONNECTION_ARGS key matches this regex but has neither
+secret=True nor audit_safe=True. The check is deliberately strict — every
+false positive should be either renamed, marked secret=True, or marked
+audit_safe=True with justification in the ConnectionArg description.
+See `audit_backend` for the enforcement logic."""
 
 
 def _get_connection_args(backend_type: str) -> dict[str, Any]:
@@ -38,6 +39,12 @@ def _get_connection_args(backend_type: str) -> dict[str, Any]:
     to import (extra not installed) — those are skipped by callers, not
     treated as audit failures.
 
+    Looks in two places, in order:
+    1. Class attribute `<connector_class>.CONNECTION_ARGS` (legacy style;
+       used by storage backends and most OAuth connectors).
+    2. ConnectorManifest.connection_args from the extension-store manifest
+       (the #3964 path; Slack and future external-plugin connectors live here).
+
     Note: similar to ConnectorRegistry.get_connection_args, but kept local so
     tests can patch this single function to inject fake CONNECTION_ARGS without
     monkey-patching the global registry.
@@ -46,9 +53,22 @@ def _get_connection_args(backend_type: str) -> dict[str, Any]:
 
     info = ConnectorRegistry.get_info(backend_type)
     cls = info.connector_class
-    if cls is None:
-        return {}
-    return getattr(cls, "CONNECTION_ARGS", {}) or {}
+    args = getattr(cls, "CONNECTION_ARGS", {}) or {} if cls is not None else {}
+    if args:
+        return args
+
+    # Fallback: extension-store manifest (Slack uses this path).
+    try:
+        from nexus.extensions.store import get_store
+
+        manifest = get_store().get(backend_type, "connector")
+        if manifest is not None:
+            return dict(manifest.connection_args or {})
+    except Exception:
+        # Extension store may not be initialised in all test contexts.
+        pass
+
+    return {}
 
 
 def declared_secret_fields(backend_type: str) -> frozenset[str]:

--- a/src/nexus/bricks/portability/redaction.py
+++ b/src/nexus/bricks/portability/redaction.py
@@ -1,0 +1,119 @@
+"""Typed redaction contract for mount-config exports (Issue #4083).
+
+Single source of truth: each connector's CONNECTION_ARGS already declares
+`secret: bool` per argument. This module derives the redaction set from
+that declaration, and runs a heuristic audit that hard-fails export when a
+secret-shaped argument name (key/secret/token/password/cred) isn't marked
+secret=True.
+
+Why a separate module: the redaction policy is the contract surface that
+both export and import depend on. Keeping it focused (one file, three
+public functions) means the audit test, the export pipeline, and any
+future tooling all see the same answer to "is this field a secret?".
+"""
+
+from __future__ import annotations
+
+import re
+from typing import Any
+
+from nexus.bricks.portability.models import (
+    PlaceholderRef,
+    SensitiveFieldNotDeclaredError,
+)
+
+SECRET_SHAPED = re.compile(r"(?i)(key|secret|token|password|cred)")
+"""Heuristic regex for argument names that should be marked secret=True.
+
+Audit fails if a CONNECTION_ARGS key matches this regex but has secret=False.
+The check is deliberately strict — every false positive is a forcing function
+to either rename the field or mark it secret=True. No allowlist exists today;
+add one only if real friction emerges (see spec for `audit_safe` follow-up)."""
+
+
+def _get_connection_args(backend_type: str) -> dict[str, Any]:
+    """Return the CONNECTION_ARGS dict for `backend_type`, or {} if unavailable.
+
+    Returns {} for placeholder registry entries whose connector module failed
+    to import (extra not installed) — those are skipped by callers, not
+    treated as audit failures.
+    """
+    from nexus.backends.base.registry import ConnectorRegistry
+
+    info = ConnectorRegistry.get_info(backend_type)
+    cls = info.connector_class
+    if cls is None:
+        return {}
+    return getattr(cls, "CONNECTION_ARGS", {}) or {}
+
+
+def declared_secret_fields(backend_type: str) -> frozenset[str]:
+    """Return the set of CONNECTION_ARGS keys with secret=True for a backend."""
+    args = _get_connection_args(backend_type)
+    return frozenset(name for name, arg in args.items() if getattr(arg, "secret", False))
+
+
+def audit_backend(backend_type: str) -> list[str]:
+    """Return CONNECTION_ARGS keys that look secret-shaped but aren't marked secret=True.
+
+    Empty list = backend passes audit. Non-empty = export must abort.
+    Returns [] for backends whose connector class hasn't loaded (no audit possible
+    until the optional extra is installed; the audit test skips those entries).
+    """
+    args = _get_connection_args(backend_type)
+    return [
+        name
+        for name, arg in args.items()
+        if SECRET_SHAPED.search(name) and not getattr(arg, "secret", False)
+    ]
+
+
+def redact_config(
+    backend_type: str,
+    config: dict[str, Any],
+    *,
+    mount_id: str,
+) -> tuple[dict[str, Any], list[PlaceholderRef]]:
+    """Strip declared secret fields from a mount's backend_config.
+
+    Args:
+        backend_type: Connector registry key (e.g., "path_s3").
+        config: The mount's backend_config dict.
+        mount_id: Used to namespace placeholders (uniqueness across bundle).
+
+    Returns:
+        (redacted_config, placeholders). The redacted dict is a shallow copy with
+        secret fields replaced by `${MOUNT_<id>_<FIELD_UPPER>}`. None values are
+        skipped (no placeholder generated for a field that's None).
+
+    Raises:
+        SensitiveFieldNotDeclaredError: if audit_backend(backend_type) is non-empty.
+    """
+    leaks = audit_backend(backend_type)
+    if leaks:
+        raise SensitiveFieldNotDeclaredError(backend_type=backend_type, fields=leaks)
+
+    secrets = declared_secret_fields(backend_type)
+    out = dict(config)
+    placeholders: list[PlaceholderRef] = []
+
+    for field_name in secrets & out.keys():
+        value = out[field_name]
+        if value is None:
+            continue
+        ph_name = f"MOUNT_{mount_id}_{field_name.upper()}"
+        placeholder_string = f"${{{ph_name}}}"
+        if value == placeholder_string:
+            continue
+        out[field_name] = placeholder_string
+        placeholders.append(PlaceholderRef(name=ph_name, field=f"mounts.{mount_id}.{field_name}"))
+
+    return out, placeholders
+
+
+__all__ = [
+    "SECRET_SHAPED",
+    "declared_secret_fields",
+    "audit_backend",
+    "redact_config",
+]

--- a/src/nexus/bricks/portability/redaction.py
+++ b/src/nexus/bricks/portability/redaction.py
@@ -160,6 +160,22 @@ def redact_config(
     if leaks:
         raise SensitiveFieldNotDeclaredError(backend_type=backend_type, fields=leaks)
 
+    # Round-3 reviewer finding: persisted backend_config can contain
+    # keys that aren't declared in CONNECTION_ARGS (a misconfigured
+    # mount, or a backend that accepts **kwargs). The declared-secrets
+    # pass below would silently ship those. Audit any undeclared key
+    # whose name matches the secret-shape regex and raise rather than
+    # leak. This also catches nested dict/list values whose contents
+    # look like secrets (e.g., a `metadata` blob containing
+    # `access_key`).
+    config_leaks = _scan_config_for_undeclared_secrets(args, config)
+    if config_leaks:
+        raise SensitiveFieldNotDeclaredError(
+            backend_type=f"{backend_type} (undeclared secret-shaped fields "
+            f"in persisted backend_config)",
+            fields=config_leaks,
+        )
+
     secrets = declared_secret_fields(backend_type)
     out = dict(config)
     placeholders: list[PlaceholderRef] = []
@@ -176,6 +192,47 @@ def redact_config(
         placeholders.append(PlaceholderRef(name=ph_name, field=f"mounts.{mount_id}.{field_name}"))
 
     return out, placeholders
+
+
+def _scan_config_for_undeclared_secrets(
+    args: dict[str, Any],
+    config: dict[str, Any],
+) -> list[str]:
+    """Return dotted paths of keys in `config` that look secret but are not
+    declared in `args`. Walks nested dicts/lists so a secret hiding under an
+    arbitrary `metadata` blob still surfaces.
+
+    Only secret-shaped *keys* are flagged. Values themselves aren't pattern-
+    matched here — we trust the connector author to declare structure
+    via CONNECTION_ARGS. The check is conservative: any undeclared key whose
+    name matches the heuristic, OR any nested dict/list key matching the
+    heuristic regardless of declaration (because nested keys are never in
+    CONNECTION_ARGS), is reported.
+    """
+    declared_top_level: set[str] = set(args.keys())
+    leaks: list[str] = []
+
+    def _walk(value: Any, path: str, *, top_level: bool) -> None:
+        if isinstance(value, dict):
+            for k, v in value.items():
+                if not isinstance(k, str):
+                    continue
+                here = f"{path}.{k}" if path else k
+                # At top level, an undeclared secret-shaped key is a leak.
+                # Below top level, ANY secret-shaped key is a leak (nested
+                # secrets can't be redacted via CONNECTION_ARGS contract).
+                is_secret_shaped = bool(SECRET_SHAPED.search(k))
+                if is_secret_shaped and (
+                    (top_level and k not in declared_top_level) or not top_level
+                ):
+                    leaks.append(here)
+                _walk(v, here, top_level=False)
+        elif isinstance(value, list):
+            for i, item in enumerate(value):
+                _walk(item, f"{path}[{i}]", top_level=False)
+
+    _walk(config, "", top_level=True)
+    return sorted(leaks)
 
 
 __all__ = [

--- a/src/nexus/bricks/portability/schemas/manifest-v3.json
+++ b/src/nexus/bricks/portability/schemas/manifest-v3.json
@@ -21,8 +21,8 @@
     },
     "format_version": {
       "type": "string",
-      "description": "Bundle format version (semantic versioning)",
-      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "description": "Bundle format version (semver). v3 schema requires major version 3.",
+      "pattern": "^3\\.\\d+\\.\\d+$",
       "examples": ["3.0.0"]
     },
     "nexus_version": {

--- a/src/nexus/bricks/portability/schemas/manifest-v3.json
+++ b/src/nexus/bricks/portability/schemas/manifest-v3.json
@@ -1,0 +1,332 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://nexus.io/schemas/manifest-v3.json",
+  "title": "Nexus Export Bundle Manifest",
+  "description": "JSON Schema for .nexus export bundle manifest.json file (v3). Adds mount_count statistic and v2 fields (archive_kind, placeholders, etc.).",
+  "type": "object",
+  "required": [
+    "format_version",
+    "bundle_id",
+    "source_zone_id",
+    "export_timestamp",
+    "statistics",
+    "options",
+    "checksums"
+  ],
+  "properties": {
+    "$schema": {
+      "type": "string",
+      "description": "Reference to this JSON Schema",
+      "const": "https://nexus.io/schemas/manifest-v3.json"
+    },
+    "format_version": {
+      "type": "string",
+      "description": "Bundle format version (semantic versioning)",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "examples": ["3.0.0"]
+    },
+    "nexus_version": {
+      "type": "string",
+      "description": "Version of Nexus that created this bundle",
+      "examples": ["0.8.0", "1.0.0"]
+    },
+    "bundle_id": {
+      "type": "string",
+      "description": "Unique identifier for this bundle (UUIDv4)",
+      "format": "uuid",
+      "examples": ["550e8400-e29b-41d4-a716-446655440000"]
+    },
+    "source_instance": {
+      "type": "string",
+      "description": "URL or identifier of the source Nexus instance",
+      "examples": ["https://nexus.company.com", "production-cluster-1"]
+    },
+    "source_zone_id": {
+      "type": "string",
+      "description": "Original zone ID from the source instance",
+      "minLength": 1,
+      "examples": ["company-a", "zone-123"]
+    },
+    "export_timestamp": {
+      "type": "string",
+      "description": "ISO 8601 timestamp when the export was created",
+      "format": "date-time",
+      "examples": ["2025-01-31T14:30:00Z"]
+    },
+    "statistics": {
+      "type": "object",
+      "description": "Summary statistics about the bundle contents",
+      "required": ["file_count", "total_size_bytes"],
+      "properties": {
+        "file_count": {
+          "type": "integer",
+          "description": "Number of file records in metadata/files.jsonl",
+          "minimum": 0
+        },
+        "total_size_bytes": {
+          "type": "integer",
+          "description": "Total size of all content in bytes",
+          "minimum": 0
+        },
+        "content_blob_count": {
+          "type": "integer",
+          "description": "Number of unique content blobs in content/cas/",
+          "minimum": 0,
+          "default": 0
+        },
+        "permission_count": {
+          "type": "integer",
+          "description": "Number of ReBAC permission tuples",
+          "minimum": 0,
+          "default": 0
+        },
+        "embedding_count": {
+          "type": "integer",
+          "description": "Number of vector embeddings",
+          "minimum": 0,
+          "default": 0
+        },
+        "mount_count": {
+          "type": "integer",
+          "description": "Number of mount records in mounts.jsonl",
+          "minimum": 0,
+          "default": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "options": {
+      "type": "object",
+      "description": "Export options that were used to create this bundle",
+      "required": ["include_content", "include_permissions"],
+      "properties": {
+        "include_content": {
+          "type": "boolean",
+          "description": "Whether content blobs are included in content/cas/",
+          "default": true
+        },
+        "include_permissions": {
+          "type": "boolean",
+          "description": "Whether ReBAC permissions are included",
+          "default": true
+        },
+        "include_embeddings": {
+          "type": "boolean",
+          "description": "Whether vector embeddings are included in embeddings/",
+          "default": false
+        },
+        "include_deleted": {
+          "type": "boolean",
+          "description": "Whether soft-deleted files are included",
+          "default": false
+        },
+        "include_versions": {
+          "type": "boolean",
+          "description": "Whether version history is included",
+          "default": true
+        },
+        "path_prefix_filter": {
+          "type": ["string", "null"],
+          "description": "Path prefix filter applied during export (null = no filter)",
+          "examples": ["/workspace/", "/projects/project-a/"]
+        },
+        "after_time_filter": {
+          "type": ["string", "null"],
+          "description": "ISO 8601 timestamp filter - only files modified after this time",
+          "format": "date-time"
+        }
+      },
+      "additionalProperties": false
+    },
+    "checksums": {
+      "type": "object",
+      "description": "Integrity verification data for bundle contents",
+      "required": ["algorithm", "files"],
+      "properties": {
+        "algorithm": {
+          "type": "string",
+          "description": "Hash algorithm used for all checksums",
+          "enum": ["sha256", "sha512"],
+          "default": "sha256"
+        },
+        "files": {
+          "type": "object",
+          "description": "Map of relative paths to their checksum information",
+          "additionalProperties": {
+            "$ref": "#/$defs/FileChecksum"
+          }
+        },
+        "merkle_root": {
+          "type": ["string", "null"],
+          "description": "Merkle tree root hash for efficient partial verification",
+          "pattern": "^[a-f0-9]{64}$"
+        }
+      },
+      "additionalProperties": false
+    },
+    "encryption": {
+      "type": ["object", "null"],
+      "description": "Encryption metadata for sensitive data (API keys). Null if no encryption.",
+      "properties": {
+        "method": {
+          "type": "string",
+          "description": "Encryption method used",
+          "enum": ["age-v1", "aes-256-gcm"],
+          "examples": ["age-v1", "aes-256-gcm"]
+        },
+        "encrypted_dek": {
+          "type": ["string", "null"],
+          "description": "Base64-encoded encrypted Data Encryption Key (wrapped with KEK)",
+          "contentEncoding": "base64"
+        }
+      },
+      "required": ["method"],
+      "additionalProperties": false
+    },
+    "metadata": {
+      "type": "object",
+      "description": "Extensible metadata for custom fields",
+      "additionalProperties": true,
+      "examples": [
+        {
+          "export_reason": "GDPR data portability request",
+          "requested_by": "user@example.com"
+        }
+      ]
+    },
+    "archive_kind": {
+      "type": "string",
+      "description": "Type of archive bundle (v2+)",
+      "enum": ["full", "audit"],
+      "default": "full"
+    },
+    "activity_window_from": {
+      "type": ["string", "null"],
+      "description": "ISO 8601 start of audit-window slice (v2+, null for full archives)",
+      "format": "date-time"
+    },
+    "activity_window_to": {
+      "type": ["string", "null"],
+      "description": "ISO 8601 end of audit-window slice (v2+, null for full archives)",
+      "format": "date-time"
+    },
+    "embedding_model": {
+      "type": ["string", "null"],
+      "description": "Name of the embedding model used (v2+)",
+      "examples": ["text-embedding-3-small"]
+    },
+    "embedding_dim": {
+      "type": ["integer", "null"],
+      "description": "Dimensionality of embedding vectors (v2+)",
+      "minimum": 1
+    },
+    "signer_pubkey_b64": {
+      "type": ["string", "null"],
+      "description": "Base64-encoded Ed25519 public key of the bundle signer (v2+)"
+    },
+    "placeholders": {
+      "type": "array",
+      "description": "Credential placeholders that must be re-injected on restore (v2+)",
+      "items": {
+        "$ref": "#/$defs/PlaceholderRef"
+      },
+      "default": []
+    },
+    "min_nexus_version": {
+      "type": "string",
+      "description": "Minimum Nexus version required to import this bundle (v2+)",
+      "pattern": "^\\d+\\.\\d+\\.\\d+$",
+      "default": "0.0.0"
+    }
+  },
+  "additionalProperties": false,
+  "$defs": {
+    "FileChecksum": {
+      "type": "object",
+      "description": "Checksum information for a single file in the bundle",
+      "required": ["path", "algorithm", "hash", "size_bytes"],
+      "properties": {
+        "path": {
+          "type": "string",
+          "description": "Relative path within the bundle",
+          "examples": ["metadata/files.jsonl", "permissions/rebac_tuples.jsonl"]
+        },
+        "algorithm": {
+          "type": "string",
+          "description": "Hash algorithm used",
+          "enum": ["sha256", "sha512", "md5"]
+        },
+        "hash": {
+          "type": "string",
+          "description": "Hex-encoded hash value",
+          "pattern": "^[a-f0-9]+$"
+        },
+        "size_bytes": {
+          "type": "integer",
+          "description": "File size in bytes",
+          "minimum": 0
+        }
+      },
+      "additionalProperties": false
+    },
+    "PlaceholderRef": {
+      "type": "object",
+      "description": "Reference to a credential placeholder that must be re-injected on restore",
+      "required": ["name", "field"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "Placeholder name (e.g., HUB_TOKEN_eng)"
+        },
+        "field": {
+          "type": "string",
+          "description": "Dotted field path where the credential lives (e.g., federations.eng.auth_token)"
+        }
+      },
+      "additionalProperties": false
+    }
+  },
+  "examples": [
+    {
+      "$schema": "https://nexus.io/schemas/manifest-v3.json",
+      "format_version": "3.0.0",
+      "nexus_version": "1.0.0",
+      "bundle_id": "550e8400-e29b-41d4-a716-446655440000",
+      "source_instance": "https://nexus.company.com",
+      "source_zone_id": "company-a",
+      "export_timestamp": "2026-01-31T14:30:00Z",
+      "statistics": {
+        "file_count": 1500,
+        "total_size_bytes": 52428800,
+        "content_blob_count": 1200,
+        "permission_count": 3500,
+        "embedding_count": 0,
+        "mount_count": 4
+      },
+      "options": {
+        "include_content": true,
+        "include_permissions": true,
+        "include_embeddings": false,
+        "include_deleted": false,
+        "include_versions": true,
+        "path_prefix_filter": null,
+        "after_time_filter": null
+      },
+      "checksums": {
+        "algorithm": "sha256",
+        "files": {},
+        "merkle_root": null
+      },
+      "encryption": null,
+      "metadata": {},
+      "archive_kind": "full",
+      "activity_window_from": null,
+      "activity_window_to": null,
+      "embedding_model": null,
+      "embedding_dim": null,
+      "signer_pubkey_b64": null,
+      "placeholders": [],
+      "min_nexus_version": "0.0.0"
+    }
+  ]
+}

--- a/src/nexus/bricks/portability/tests/test_export_service_mounts.py
+++ b/src/nexus/bricks/portability/tests/test_export_service_mounts.py
@@ -1,0 +1,77 @@
+"""Wiring tests for mount export integration."""
+
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.bricks.portability.export_service import ZoneExportService
+from nexus.bricks.portability.models import ZoneExportOptions
+
+
+def test_include_mounts_true_without_mount_manager_raises(tmp_path):
+    fs = MagicMock()
+    service = ZoneExportService(fs)
+    options = ZoneExportOptions(
+        output_path=tmp_path / "x.nexus",
+        include_mounts=True,
+    )
+    with pytest.raises(ValueError, match="mount_manager"):
+        # export_zone is sync (def, not async def)
+        service.export_zone("z1", options)
+
+
+def test_include_mounts_false_without_mount_manager_does_not_raise(tmp_path):
+    """Existing callers without mount_manager must not break when include_mounts=False."""
+    fs = MagicMock()
+    # Provide a minimal kernel so the service doesn't crash on metastore_list
+    kernel = MagicMock()
+    kernel.metastore_list.return_value = []
+    fs._kernel = kernel
+
+    service = ZoneExportService(fs)
+    options = ZoneExportOptions(
+        output_path=tmp_path / "y.nexus",
+        include_mounts=False,
+    )
+    # Should not raise ValueError; any other errors (e.g. tar creation) are fine.
+    try:
+        service.export_zone("z2", options)
+    except ValueError as exc:
+        pytest.fail(f"Unexpected ValueError raised: {exc}")
+    except Exception:
+        pass  # non-ValueError exceptions are acceptable
+
+
+def test_include_mounts_true_with_mount_manager_calls_collect_and_write(tmp_path):
+    """When include_mounts=True and mount_manager is provided, mount export runs."""
+
+    fs = MagicMock()
+    kernel = MagicMock()
+    kernel.metastore_list.return_value = []
+    fs._kernel = kernel
+
+    mount_manager = MagicMock()
+    mount_manager.list_mounts.return_value = [
+        {
+            "mount_id": "m1",
+            "mount_point": "/data",
+            "backend_type": "local",
+            "backend_config": {},
+            "owner_user_id": "u1",
+            "zone_id": "z3",
+            "description": "test mount",
+        }
+    ]
+
+    service = ZoneExportService(fs, mount_manager=mount_manager)
+    options = ZoneExportOptions(
+        output_path=tmp_path / "z.nexus",
+        include_mounts=True,
+    )
+
+    try:
+        manifest = service.export_zone("z3", options)
+        assert manifest.mount_count == 1
+    except Exception as exc:
+        # If bundle creation fails for unrelated reasons, ensure it's not ValueError
+        assert not isinstance(exc, ValueError), f"Unexpected ValueError: {exc}"

--- a/src/nexus/bricks/portability/tests/test_export_service_mounts.py
+++ b/src/nexus/bricks/portability/tests/test_export_service_mounts.py
@@ -117,3 +117,32 @@ def test_mounts_jsonl_in_bundle_checksums(tmp_path):
         # Only care about the checksum assertion failing; other infra errors are OK
         if isinstance(exc, AssertionError):
             raise
+
+
+def test_include_mounts_with_zero_mounts_produces_valid_bundle(tmp_path):
+    """Round 5: include_mounts=True with an empty MountManager must NOT
+    write an empty mounts.jsonl with no checksum (BundleReader.validate
+    would then reject the bundle the exporter just produced)."""
+    fs = MagicMock()
+    kernel = MagicMock()
+    kernel.metastore_list.return_value = []
+    fs._kernel = kernel
+
+    mgr = MagicMock()
+    mgr.list_mounts.return_value = []  # empty zone
+
+    out = tmp_path / "empty.nexus"
+    service = ZoneExportService(fs, mount_manager=mgr)
+    manifest = service.export_zone(
+        "z1",
+        ZoneExportOptions(output_path=out, include_mounts=True, sign=False),
+    )
+    assert manifest.mount_count == 0
+    assert "mounts.jsonl" not in manifest.checksums.files
+
+    # Roundtrip: validate the bundle we just wrote — must pass.
+    from nexus.bricks.portability.bundle import BundleReader
+
+    with BundleReader(out) as reader:
+        ok, errors = reader.validate()
+    assert ok, f"empty-mount bundle failed self-validation: {errors}"

--- a/src/nexus/bricks/portability/tests/test_export_service_mounts.py
+++ b/src/nexus/bricks/portability/tests/test_export_service_mounts.py
@@ -55,8 +55,14 @@ def test_include_mounts_true_with_mount_manager_calls_collect_and_write(tmp_path
         {
             "mount_id": "m1",
             "mount_point": "/data",
-            "backend_type": "local",
-            "backend_config": {},
+            # path_local is in CONNECTOR_MANIFEST as an always-available
+            # built-in (no extras), so its CONNECTION_ARGS resolves cleanly
+            # in the redaction contract. Using a fake string like "local"
+            # would now (correctly) trigger SensitiveFieldNotDeclaredError
+            # because we refuse to ship a mount whose contract we can't
+            # introspect (Issue #4083 follow-up).
+            "backend_type": "path_local",
+            "backend_config": {"root_path": "/var/data"},
             "owner_user_id": "u1",
             "zone_id": "z3",
             "description": "test mount",

--- a/src/nexus/bricks/portability/tests/test_export_service_mounts.py
+++ b/src/nexus/bricks/portability/tests/test_export_service_mounts.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock
 import pytest
 
 from nexus.bricks.portability.export_service import ZoneExportService
-from nexus.bricks.portability.models import ZoneExportOptions
+from nexus.bricks.portability.models import BUNDLE_PATHS, ZoneExportOptions
 
 
 def test_include_mounts_true_without_mount_manager_raises(tmp_path):
@@ -75,3 +75,39 @@ def test_include_mounts_true_with_mount_manager_calls_collect_and_write(tmp_path
     except Exception as exc:
         # If bundle creation fails for unrelated reasons, ensure it's not ValueError
         assert not isinstance(exc, ValueError), f"Unexpected ValueError: {exc}"
+
+
+def test_mounts_jsonl_in_bundle_checksums(tmp_path):
+    """mounts.jsonl must be registered in BundleChecksums for tamper detection."""
+    fs = MagicMock()
+    kernel = MagicMock()
+    kernel.metastore_list.return_value = []
+    fs._kernel = kernel
+
+    mgr = MagicMock()
+    mgr.list_mounts.return_value = [
+        {
+            "mount_id": "m-1",
+            "mount_point": "/x",
+            "backend_type": "path_local",
+            "backend_config": {"root": "/data"},
+            "owner_user_id": None,
+            "zone_id": "z1",
+            "description": None,
+        }
+    ]
+
+    out = tmp_path / "bundle.nexus"
+    service = ZoneExportService(fs, mount_manager=mgr)
+    try:
+        manifest = service.export_zone(
+            "z1",
+            ZoneExportOptions(output_path=out, include_mounts=True, sign=False),
+        )
+        assert BUNDLE_PATHS["mounts"] in manifest.checksums.files, (
+            "mounts.jsonl must be added to BundleChecksums when mounts are exported"
+        )
+    except Exception as exc:
+        # Only care about the checksum assertion failing; other infra errors are OK
+        if isinstance(exc, AssertionError):
+            raise

--- a/src/nexus/bricks/portability/tests/test_import_service_mounts.py
+++ b/src/nexus/bricks/portability/tests/test_import_service_mounts.py
@@ -149,3 +149,16 @@ def test_import_v2_bundle_no_mounts_jsonl_does_nothing(tmp_path):
     service = ZoneImportService(fs, mount_manager=mgr)
     _maybe_run(service.import_zone(ZoneImportOptions(bundle_path=bundle)))
     assert mgr.save_mount.call_count == 0
+
+
+def test_import_with_mounts_but_no_mount_manager_raises_loud(tmp_path):
+    """Bundle contains mounts.jsonl but no mount_manager → loud ValueError, not buried in result.errors."""
+    bundle = _build_bundle_with_mount(tmp_path)
+    fs = MagicMock()
+    service = ZoneImportService(fs)  # NO mount_manager
+    options = ZoneImportOptions(
+        bundle_path=bundle,
+        mount_overrides={"m-1": {"access_key_id": "AKIA", "secret_access_key": "wJalr"}},
+    )
+    with pytest.raises(ValueError, match="MountManager"):
+        _maybe_run(service.import_zone(options))

--- a/src/nexus/bricks/portability/tests/test_import_service_mounts.py
+++ b/src/nexus/bricks/portability/tests/test_import_service_mounts.py
@@ -1,0 +1,151 @@
+"""Wiring tests for mount import integration."""
+
+import asyncio
+import json
+import tarfile
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.bricks.portability.import_service import ZoneImportService
+from nexus.bricks.portability.models import (
+    BUNDLE_FORMAT_VERSION,
+    MissingCredentialsError,
+    ZoneImportOptions,
+)
+
+
+def _build_bundle_with_mount(tmp_path: Path) -> Path:
+    """Create a minimal v3 bundle containing mounts.jsonl."""
+    bundle_dir = tmp_path / "src"
+    bundle_dir.mkdir()
+    manifest = {
+        "$schema": "https://nexus.io/schemas/manifest-v3.json",
+        "format_version": BUNDLE_FORMAT_VERSION,
+        "bundle_id": "550e8400-e29b-41d4-a716-446655440000",
+        "source_zone_id": "z1",
+        "export_timestamp": "2026-01-01T00:00:00+00:00",
+        "statistics": {
+            "file_count": 0,
+            "total_size_bytes": 0,
+            "content_blob_count": 0,
+            "permission_count": 0,
+            "embedding_count": 0,
+            "mount_count": 1,
+        },
+        "options": {"include_content": True, "include_permissions": True},
+        "checksums": {"algorithm": "sha256", "files": {}},
+    }
+    (bundle_dir / "manifest.json").write_text(json.dumps(manifest))
+    (bundle_dir / "mounts.jsonl").write_text(
+        json.dumps(
+            {
+                "mount_id": "m-1",
+                "mount_point": "/x",
+                "backend_type": "path_s3",
+                "backend_config": {
+                    "bucket_name": "acme",
+                    "access_key_id": "${MOUNT_m-1_ACCESS_KEY_ID}",
+                    "secret_access_key": "${MOUNT_m-1_SECRET_ACCESS_KEY}",
+                },
+                "owner_user_id": "alice",
+                "zone_id": "z1",
+                "description": None,
+            }
+        )
+        + "\n"
+    )
+
+    out = tmp_path / "bundle.nexus"
+    with tarfile.open(out, "w:gz") as tar:
+        for p in bundle_dir.rglob("*"):
+            tar.add(p, arcname=p.relative_to(bundle_dir))
+    return out
+
+
+def _build_v2_bundle(tmp_path: Path) -> Path:
+    """v2 bundle (no mounts.jsonl) for back-compat test."""
+    bundle_dir = tmp_path / "src"
+    bundle_dir.mkdir()
+    manifest = {
+        "$schema": "https://nexus.io/schemas/manifest-v1.json",
+        "format_version": "2.0.0",
+        "bundle_id": "550e8400-e29b-41d4-a716-446655440000",
+        "source_zone_id": "z1",
+        "export_timestamp": "2026-01-01T00:00:00+00:00",
+        "statistics": {
+            "file_count": 0,
+            "total_size_bytes": 0,
+            "content_blob_count": 0,
+            "permission_count": 0,
+            "embedding_count": 0,
+        },
+        "options": {"include_content": True, "include_permissions": True},
+        "checksums": {"algorithm": "sha256", "files": {}},
+    }
+    (bundle_dir / "manifest.json").write_text(json.dumps(manifest))
+    out = tmp_path / "bundle.nexus"
+    with tarfile.open(out, "w:gz") as tar:
+        for p in bundle_dir.rglob("*"):
+            tar.add(p, arcname=p.relative_to(bundle_dir))
+    return out
+
+
+def _maybe_run(result):
+    """Wrap async results so the test works with either sync or async import_zone."""
+    if asyncio.iscoroutine(result):
+        return asyncio.run(result)
+    return result
+
+
+def test_import_without_overrides_raises_before_side_effects(tmp_path):
+    bundle = _build_bundle_with_mount(tmp_path)
+    fs = MagicMock()
+    mgr = MagicMock()
+    service = ZoneImportService(fs, mount_manager=mgr)
+
+    options = ZoneImportOptions(bundle_path=bundle)
+    with pytest.raises(MissingCredentialsError) as exc:
+        _maybe_run(service.import_zone(options))
+    assert "m-1" in exc.value.missing
+    assert mgr.save_mount.call_count == 0
+    assert mgr.update_mount.call_count == 0
+
+
+def test_import_with_overrides_calls_save_mount(tmp_path):
+    bundle = _build_bundle_with_mount(tmp_path)
+    fs = MagicMock()
+    mgr = MagicMock()
+    mgr.get_mount.return_value = None
+    service = ZoneImportService(fs, mount_manager=mgr)
+
+    options = ZoneImportOptions(
+        bundle_path=bundle,
+        mount_overrides={"m-1": {"access_key_id": "AKIA", "secret_access_key": "wJalr"}},
+    )
+    _maybe_run(service.import_zone(options))
+    assert mgr.save_mount.call_count == 1
+    cfg = mgr.save_mount.call_args.kwargs["backend_config"]
+    assert cfg["access_key_id"] == "AKIA"
+    assert cfg["secret_access_key"] == "wJalr"
+
+
+def test_import_restore_mounts_false_skips_mount_step(tmp_path):
+    bundle = _build_bundle_with_mount(tmp_path)
+    fs = MagicMock()
+    mgr = MagicMock()
+    service = ZoneImportService(fs, mount_manager=mgr)
+    options = ZoneImportOptions(bundle_path=bundle, restore_mounts=False)
+    _maybe_run(service.import_zone(options))
+    assert mgr.save_mount.call_count == 0
+
+
+def test_import_v2_bundle_no_mounts_jsonl_does_nothing(tmp_path):
+    """v2 bundle (no mounts.jsonl) imports cleanly."""
+    bundle = _build_v2_bundle(tmp_path)
+    fs = MagicMock()
+    mgr = MagicMock()
+    service = ZoneImportService(fs, mount_manager=mgr)
+    _maybe_run(service.import_zone(ZoneImportOptions(bundle_path=bundle)))
+    assert mgr.save_mount.call_count == 0

--- a/src/nexus/bricks/portability/tests/test_import_service_mounts.py
+++ b/src/nexus/bricks/portability/tests/test_import_service_mounts.py
@@ -17,28 +17,18 @@ from nexus.bricks.portability.models import (
 
 
 def _build_bundle_with_mount(tmp_path: Path) -> Path:
-    """Create a minimal v3 bundle containing mounts.jsonl."""
+    """Create a minimal v3 bundle containing mounts.jsonl.
+
+    Round-4 strict-validation: mounts.jsonl must be in
+    ``manifest.checksums.files`` for ``BundleReader.read_mount_records``
+    to consume it (defense against tampering outside the signed envelope).
+    Compute the SHA-256 of the canonical bytes we write and register it.
+    """
+    import hashlib
+
     bundle_dir = tmp_path / "src"
     bundle_dir.mkdir()
-    manifest = {
-        "$schema": "https://nexus.io/schemas/manifest-v3.json",
-        "format_version": BUNDLE_FORMAT_VERSION,
-        "bundle_id": "550e8400-e29b-41d4-a716-446655440000",
-        "source_zone_id": "z1",
-        "export_timestamp": "2026-01-01T00:00:00+00:00",
-        "statistics": {
-            "file_count": 0,
-            "total_size_bytes": 0,
-            "content_blob_count": 0,
-            "permission_count": 0,
-            "embedding_count": 0,
-            "mount_count": 1,
-        },
-        "options": {"include_content": True, "include_permissions": True},
-        "checksums": {"algorithm": "sha256", "files": {}},
-    }
-    (bundle_dir / "manifest.json").write_text(json.dumps(manifest))
-    (bundle_dir / "mounts.jsonl").write_text(
+    mounts_payload = (
         json.dumps(
             {
                 "mount_id": "m-1",
@@ -55,7 +45,37 @@ def _build_bundle_with_mount(tmp_path: Path) -> Path:
             }
         )
         + "\n"
-    )
+    ).encode("utf-8")
+    mounts_sha = hashlib.sha256(mounts_payload).hexdigest()
+    manifest = {
+        "$schema": "https://nexus.io/schemas/manifest-v3.json",
+        "format_version": BUNDLE_FORMAT_VERSION,
+        "bundle_id": "550e8400-e29b-41d4-a716-446655440000",
+        "source_zone_id": "z1",
+        "export_timestamp": "2026-01-01T00:00:00+00:00",
+        "statistics": {
+            "file_count": 0,
+            "total_size_bytes": 0,
+            "content_blob_count": 0,
+            "permission_count": 0,
+            "embedding_count": 0,
+            "mount_count": 1,
+        },
+        "options": {"include_content": True, "include_permissions": True},
+        "checksums": {
+            "algorithm": "sha256",
+            "files": {
+                "mounts.jsonl": {
+                    "path": "mounts.jsonl",
+                    "algorithm": "sha256",
+                    "hash": mounts_sha,
+                    "size_bytes": len(mounts_payload),
+                }
+            },
+        },
+    }
+    (bundle_dir / "manifest.json").write_text(json.dumps(manifest))
+    (bundle_dir / "mounts.jsonl").write_bytes(mounts_payload)
 
     out = tmp_path / "bundle.nexus"
     with tarfile.open(out, "w:gz") as tar:

--- a/src/nexus/bricks/portability/tests/test_import_service_mounts.py
+++ b/src/nexus/bricks/portability/tests/test_import_service_mounts.py
@@ -204,3 +204,49 @@ def test_import_with_dry_run_does_not_call_save_mount(tmp_path):
     _maybe_run(service.import_zone(options))
     assert mgr.save_mount.call_count == 0, "dry-run must not persist mounts"
     assert mgr.update_mount.call_count == 0, "dry-run must not update mounts"
+
+
+def test_import_restores_mounts_before_file_import(tmp_path, monkeypatch):
+    """Round-10 reviewer finding: file import must happen AFTER mount
+    restore so files at paths under restored mounts (e.g.,
+    /personal/alice/foo.txt where /personal/alice is a mount) route to
+    the restored backend, not the default. We assert ordering by
+    instrumenting both the mount manager and the file-import method:
+    save_mount must be called before _import_files runs.
+    """
+    bundle = _build_bundle_with_mount(tmp_path)
+    fs = MagicMock()
+    mgr = MagicMock()
+    mgr.get_mount.return_value = None
+
+    # Track call order across the two side-effects.
+    call_order: list[str] = []
+
+    def _save_mount_spy(*_args: object, **_kwargs: object) -> str:
+        call_order.append("save_mount")
+        return "m-1"
+
+    mgr.save_mount.side_effect = _save_mount_spy
+
+    service = ZoneImportService(fs, mount_manager=mgr)
+
+    # Patch _import_files on the class via monkeypatch so observability
+    # doesn't require touching the typed instance attribute. The patched
+    # method is a no-op (None return) — we only care that it was called
+    # and in what order relative to save_mount.
+    def _spy(_self: object, *_args: object, **_kwargs: object) -> None:
+        call_order.append("import_files")
+
+    monkeypatch.setattr(ZoneImportService, "_import_files", _spy)
+
+    options = ZoneImportOptions(
+        bundle_path=bundle,
+        mount_overrides={"m-1": {"access_key_id": "AKIA", "secret_access_key": "wJalr"}},
+    )
+    _maybe_run(service.import_zone(options))
+
+    assert "save_mount" in call_order, "save_mount was not called"
+    assert "import_files" in call_order, "_import_files was not called"
+    assert call_order.index("save_mount") < call_order.index("import_files"), (
+        f"Expected save_mount before import_files, got: {call_order}"
+    )

--- a/src/nexus/bricks/portability/tests/test_import_service_mounts.py
+++ b/src/nexus/bricks/portability/tests/test_import_service_mounts.py
@@ -162,3 +162,25 @@ def test_import_with_mounts_but_no_mount_manager_raises_loud(tmp_path):
     )
     with pytest.raises(ValueError, match="MountManager"):
         _maybe_run(service.import_zone(options))
+
+
+def test_import_with_dry_run_does_not_call_save_mount(tmp_path):
+    """Dry-run import must not mutate MountManager (Issue #4083 review).
+
+    Without this guard, dry-run silently writes mount configs into the
+    persistent store while the CLI prints 'no changes will be made'.
+    """
+    bundle = _build_bundle_with_mount(tmp_path)
+    fs = MagicMock()
+    mgr = MagicMock()
+    mgr.get_mount.return_value = None
+    service = ZoneImportService(fs, mount_manager=mgr)
+
+    options = ZoneImportOptions(
+        bundle_path=bundle,
+        dry_run=True,
+        mount_overrides={"m-1": {"access_key_id": "AKIA", "secret_access_key": "wJalr"}},
+    )
+    _maybe_run(service.import_zone(options))
+    assert mgr.save_mount.call_count == 0, "dry-run must not persist mounts"
+    assert mgr.update_mount.call_count == 0, "dry-run must not update mounts"

--- a/src/nexus/bricks/portability/tests/test_manifest_v2.py
+++ b/src/nexus/bricks/portability/tests/test_manifest_v2.py
@@ -10,9 +10,7 @@ from nexus.bricks.portability.models import (
 )
 
 
-def test_format_version_is_v2():
-    # Constant was bumped to 3.0.0 in Issue #4083; v2 round-trip tests below
-    # remain valid because format_version is a per-manifest field, not this constant.
+def test_format_version_constant_bumped_to_v3():
     assert BUNDLE_FORMAT_VERSION == "3.0.0"
 
 

--- a/src/nexus/bricks/portability/tests/test_manifest_v2.py
+++ b/src/nexus/bricks/portability/tests/test_manifest_v2.py
@@ -11,7 +11,9 @@ from nexus.bricks.portability.models import (
 
 
 def test_format_version_is_v2():
-    assert BUNDLE_FORMAT_VERSION == "2.0.0"
+    # Constant was bumped to 3.0.0 in Issue #4083; v2 round-trip tests below
+    # remain valid because format_version is a per-manifest field, not this constant.
+    assert BUNDLE_FORMAT_VERSION == "3.0.0"
 
 
 def test_manifest_round_trip_with_v2_fields():

--- a/src/nexus/bricks/portability/tests/test_manifest_v3.py
+++ b/src/nexus/bricks/portability/tests/test_manifest_v3.py
@@ -1,10 +1,19 @@
 """Tests for v3 bundle manifest additions."""
 
+import json
+from pathlib import Path
+
+import pytest
+
 from nexus.bricks.portability.models import (
     BUNDLE_FORMAT_VERSION,
     MANIFEST_SCHEMA_URL,
     ExportManifest,
 )
+
+jsonschema = pytest.importorskip("jsonschema")
+
+SCHEMA_PATH = Path(__file__).parent.parent / "schemas" / "manifest-v3.json"
 
 
 def test_format_version_is_v3():
@@ -56,3 +65,24 @@ def test_v1_bundle_loads_with_default_mount_count():
     m = ExportManifest.from_dict(legacy_dict)
     assert m.mount_count == 0
     assert m.format_version == "2.0.0"
+
+
+def test_v3_schema_file_exists_and_is_valid_json():
+    text = SCHEMA_PATH.read_text()
+    data = json.loads(text)
+    assert data["$id"].endswith("manifest-v3.json")
+
+
+def test_v3_manifest_validates_against_schema():
+    schema = json.loads(SCHEMA_PATH.read_text())
+    m = ExportManifest(source_zone_id="z1")
+    m.mount_count = 3
+    jsonschema.validate(m.to_dict(), schema)
+
+
+def test_v3_schema_rejects_unknown_root_field():
+    schema = json.loads(SCHEMA_PATH.read_text())
+    bad = ExportManifest(source_zone_id="z1").to_dict()
+    bad["totally_unknown_field"] = "bogus"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(bad, schema)

--- a/src/nexus/bricks/portability/tests/test_manifest_v3.py
+++ b/src/nexus/bricks/portability/tests/test_manifest_v3.py
@@ -145,3 +145,44 @@ def test_bundle_validate_rejects_v3_manifest_with_unknown_root_key(tmp_path):
     assert any(
         "schema validation failed" in e.lower() or "totally_unknown_field" in e for e in errors
     ), errors
+
+
+def test_bundle_validate_accepts_v2_bundle_with_v1_schema(tmp_path):
+    """Round 2 reviewer finding: legacy v2 bundles emit
+    $schema=manifest-v1.json. The new schema-validation step must use
+    the v1 schema for v1.x/2.x bundles, not always reach for v3.
+    """
+    pytest.importorskip("jsonschema")
+    import tarfile
+
+    from nexus.bricks.portability.bundle import BundleReader
+
+    bundle_dir = tmp_path / "src"
+    bundle_dir.mkdir()
+    legacy_manifest = {
+        "$schema": "https://nexus.io/schemas/manifest-v1.json",
+        "format_version": "2.0.0",
+        "bundle_id": "550e8400-e29b-41d4-a716-446655440000",
+        "source_zone_id": "z1",
+        "export_timestamp": "2026-01-01T00:00:00+00:00",
+        "statistics": {
+            "file_count": 0,
+            "total_size_bytes": 0,
+            "content_blob_count": 0,
+            "permission_count": 0,
+            "embedding_count": 0,
+        },
+        "options": {"include_content": True, "include_permissions": True},
+        "checksums": {"algorithm": "sha256", "files": {}},
+    }
+    (bundle_dir / "manifest.json").write_text(json.dumps(legacy_manifest))
+
+    out = tmp_path / "legacy.nexus"
+    with tarfile.open(out, "w:gz") as tar:
+        for p in bundle_dir.rglob("*"):
+            tar.add(p, arcname=p.relative_to(bundle_dir))
+
+    with BundleReader(out) as reader:
+        ok, errors = reader.validate()
+
+    assert ok, f"v2 bundle should pass v1-schema validation; got: {errors}"

--- a/src/nexus/bricks/portability/tests/test_manifest_v3.py
+++ b/src/nexus/bricks/portability/tests/test_manifest_v3.py
@@ -111,3 +111,37 @@ def test_v3_schema_rejects_placeholder_with_extra_field():
     ]
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(bad, schema)
+
+
+def test_bundle_validate_rejects_v3_manifest_with_unknown_root_key(tmp_path):
+    """BundleReader.validate must reject a v3 manifest with unknown root keys.
+
+    Issue #4083 review: ExportManifest.from_dict drops unknown fields
+    silently, so without explicit JSON-Schema validation a malformed v3
+    manifest passes BundleReader.validate. This test forges a bad
+    manifest, packs it into a tar, and asserts validate() reports the
+    schema error.
+    """
+    pytest.importorskip("jsonschema")
+    import tarfile
+
+    from nexus.bricks.portability.bundle import BundleReader
+
+    bundle_dir = tmp_path / "src"
+    bundle_dir.mkdir()
+    manifest_dict = ExportManifest(source_zone_id="z1").to_dict()
+    manifest_dict["totally_unknown_field"] = "this should fail validation"
+    (bundle_dir / "manifest.json").write_text(json.dumps(manifest_dict))
+
+    out = tmp_path / "bad.nexus"
+    with tarfile.open(out, "w:gz") as tar:
+        for p in bundle_dir.rglob("*"):
+            tar.add(p, arcname=p.relative_to(bundle_dir))
+
+    with BundleReader(out) as reader:
+        ok, errors = reader.validate()
+
+    assert not ok
+    assert any(
+        "schema validation failed" in e.lower() or "totally_unknown_field" in e for e in errors
+    ), errors

--- a/src/nexus/bricks/portability/tests/test_manifest_v3.py
+++ b/src/nexus/bricks/portability/tests/test_manifest_v3.py
@@ -1,7 +1,6 @@
 """Tests for v3 bundle manifest additions."""
 
 import json
-from pathlib import Path
 
 import pytest
 
@@ -10,10 +9,9 @@ from nexus.bricks.portability.models import (
     MANIFEST_SCHEMA_URL,
     ExportManifest,
 )
-
-jsonschema = pytest.importorskip("jsonschema")
-
-SCHEMA_PATH = Path(__file__).parent.parent / "schemas" / "manifest-v3.json"
+from nexus.bricks.portability.models import (
+    MANIFEST_SCHEMA_PATH as SCHEMA_PATH,
+)
 
 
 def test_format_version_is_v3():
@@ -74,6 +72,7 @@ def test_v3_schema_file_exists_and_is_valid_json():
 
 
 def test_v3_manifest_validates_against_schema():
+    jsonschema = pytest.importorskip("jsonschema")
     schema = json.loads(SCHEMA_PATH.read_text())
     m = ExportManifest(source_zone_id="z1")
     m.mount_count = 3
@@ -81,8 +80,34 @@ def test_v3_manifest_validates_against_schema():
 
 
 def test_v3_schema_rejects_unknown_root_field():
+    jsonschema = pytest.importorskip("jsonschema")
     schema = json.loads(SCHEMA_PATH.read_text())
     bad = ExportManifest(source_zone_id="z1").to_dict()
     bad["totally_unknown_field"] = "bogus"
+    with pytest.raises(jsonschema.ValidationError):
+        jsonschema.validate(bad, schema)
+
+
+def test_v3_schema_validates_placeholders_array():
+    """PlaceholderRef $def is reachable via the placeholders array."""
+    jsonschema = pytest.importorskip("jsonschema")
+    from nexus.bricks.portability.models import PlaceholderRef
+
+    schema = json.loads(SCHEMA_PATH.read_text())
+    m = ExportManifest(source_zone_id="z1")
+    m.placeholders = [
+        PlaceholderRef(name="MOUNT_m-1_ACCESS_KEY_ID", field="mounts.m-1.access_key_id"),
+    ]
+    jsonschema.validate(m.to_dict(), schema)
+
+
+def test_v3_schema_rejects_placeholder_with_extra_field():
+    """PlaceholderRef has additionalProperties: false."""
+    jsonschema = pytest.importorskip("jsonschema")
+    schema = json.loads(SCHEMA_PATH.read_text())
+    bad = ExportManifest(source_zone_id="z1").to_dict()
+    bad["placeholders"] = [
+        {"name": "X", "field": "a.b", "extra": "not allowed"},
+    ]
     with pytest.raises(jsonschema.ValidationError):
         jsonschema.validate(bad, schema)

--- a/src/nexus/bricks/portability/tests/test_manifest_v3.py
+++ b/src/nexus/bricks/portability/tests/test_manifest_v3.py
@@ -186,3 +186,43 @@ def test_bundle_validate_accepts_v2_bundle_with_v1_schema(tmp_path):
         ok, errors = reader.validate()
 
     assert ok, f"v2 bundle should pass v1-schema validation; got: {errors}"
+
+
+def test_bundle_validate_rejects_unknown_future_version(tmp_path):
+    """Round 3: a forged manifest with format_version='999.0.0' must be
+    rejected outright, not silently routed to v3 schema validation."""
+    pytest.importorskip("jsonschema")
+    import tarfile
+
+    from nexus.bricks.portability.bundle import BundleReader
+
+    bundle_dir = tmp_path / "src"
+    bundle_dir.mkdir()
+    forged = {
+        "$schema": "https://nexus.io/schemas/manifest-v3.json",
+        "format_version": "999.0.0",
+        "bundle_id": "550e8400-e29b-41d4-a716-446655440000",
+        "source_zone_id": "z1",
+        "export_timestamp": "2026-01-01T00:00:00+00:00",
+        "statistics": {
+            "file_count": 0,
+            "total_size_bytes": 0,
+            "content_blob_count": 0,
+            "permission_count": 0,
+            "embedding_count": 0,
+        },
+        "options": {"include_content": True, "include_permissions": True},
+        "checksums": {"algorithm": "sha256", "files": {}},
+    }
+    (bundle_dir / "manifest.json").write_text(json.dumps(forged))
+
+    out = tmp_path / "forged.nexus"
+    with tarfile.open(out, "w:gz") as tar:
+        for p in bundle_dir.rglob("*"):
+            tar.add(p, arcname=p.relative_to(bundle_dir))
+
+    with BundleReader(out) as reader:
+        ok, errors = reader.validate()
+
+    assert not ok
+    assert any("Unsupported manifest format_version" in e for e in errors), errors

--- a/src/nexus/bricks/portability/tests/test_manifest_v3.py
+++ b/src/nexus/bricks/portability/tests/test_manifest_v3.py
@@ -1,0 +1,58 @@
+"""Tests for v3 bundle manifest additions."""
+
+from nexus.bricks.portability.models import (
+    BUNDLE_FORMAT_VERSION,
+    MANIFEST_SCHEMA_URL,
+    ExportManifest,
+)
+
+
+def test_format_version_is_v3():
+    assert BUNDLE_FORMAT_VERSION == "3.0.0"
+
+
+def test_manifest_schema_url_is_v3():
+    assert MANIFEST_SCHEMA_URL == "https://nexus.io/schemas/manifest-v3.json"
+
+
+def test_manifest_includes_mount_count():
+    m = ExportManifest(source_zone_id="z1")
+    m.mount_count = 5
+    d = m.to_dict()
+    assert d["statistics"]["mount_count"] == 5
+
+
+def test_manifest_default_mount_count_is_zero():
+    m = ExportManifest(source_zone_id="z1")
+    assert m.mount_count == 0
+    assert m.to_dict()["statistics"]["mount_count"] == 0
+
+
+def test_manifest_round_trip_preserves_mount_count():
+    m = ExportManifest(source_zone_id="z1")
+    m.mount_count = 7
+    d = m.to_dict()
+    m2 = ExportManifest.from_dict(d)
+    assert m2.mount_count == 7
+
+
+def test_v1_bundle_loads_with_default_mount_count():
+    """A v1/v2 manifest dict (no mount_count) must still load."""
+    legacy_dict = {
+        "format_version": "2.0.0",
+        "bundle_id": "550e8400-e29b-41d4-a716-446655440000",
+        "source_zone_id": "z1",
+        "export_timestamp": "2026-01-01T00:00:00+00:00",
+        "statistics": {
+            "file_count": 0,
+            "total_size_bytes": 0,
+            "content_blob_count": 0,
+            "permission_count": 0,
+            "embedding_count": 0,
+        },
+        "options": {"include_content": True, "include_permissions": True},
+        "checksums": {"algorithm": "sha256", "files": {}},
+    }
+    m = ExportManifest.from_dict(legacy_dict)
+    assert m.mount_count == 0
+    assert m.format_version == "2.0.0"

--- a/src/nexus/bricks/portability/tests/test_mount_export.py
+++ b/src/nexus/bricks/portability/tests/test_mount_export.py
@@ -1,0 +1,142 @@
+"""Tests for mount_export.py."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.bricks.portability.models import (
+    PlaceholderRef,
+    SensitiveFieldNotDeclaredError,
+)
+from nexus.bricks.portability.mount_export import (
+    collect_mounts,
+    redact_and_write,
+)
+
+
+@pytest.fixture
+def s3_mount_dict():
+    return {
+        "mount_id": "m-1",
+        "mount_point": "/personal/alice",
+        "backend_type": "path_s3",
+        "backend_config": {
+            "bucket_name": "acme",
+            "access_key_id": "AKIA1234",
+            "secret_access_key": "wJalr...",
+        },
+        "owner_user_id": "alice",
+        "zone_id": "acme",
+        "description": None,
+    }
+
+
+def test_collect_mounts_calls_list_mounts_with_zone_filter(s3_mount_dict):
+    mgr = MagicMock()
+    mgr.list_mounts.return_value = [s3_mount_dict]
+    out = collect_mounts(mgr, zone_id="acme")
+    mgr.list_mounts.assert_called_once_with(zone_id="acme")
+    assert out == [s3_mount_dict]
+
+
+def test_collect_mounts_no_zone_filter():
+    mgr = MagicMock()
+    mgr.list_mounts.return_value = []
+    collect_mounts(mgr, zone_id=None)
+    mgr.list_mounts.assert_called_once_with(zone_id=None)
+
+
+def test_redact_and_write_redacts_secrets_and_returns_placeholders(tmp_path, s3_mount_dict):
+    pytest.importorskip("boto3")
+    from nexus.bricks.portability.tests.test_redaction_unit import _ensure_registry
+
+    _ensure_registry()
+
+    out_path = tmp_path / "mounts.jsonl"
+    placeholders = redact_and_write([s3_mount_dict], out_path=out_path)
+
+    assert out_path.exists()
+    line = out_path.read_text().strip()
+    record = json.loads(line)
+    assert record["backend_config"]["access_key_id"] == "${MOUNT_m-1_ACCESS_KEY_ID}"
+    assert record["backend_config"]["secret_access_key"] == "${MOUNT_m-1_SECRET_ACCESS_KEY}"
+    assert record["backend_config"]["bucket_name"] == "acme"  # not redacted
+
+    assert {p.name for p in placeholders} == {
+        "MOUNT_m-1_ACCESS_KEY_ID",
+        "MOUNT_m-1_SECRET_ACCESS_KEY",
+    }
+    assert all(isinstance(p, PlaceholderRef) for p in placeholders)
+
+
+def test_redact_and_write_sorts_lines_by_mount_id(tmp_path):
+    mounts: list[dict[str, object]] = [
+        {
+            "mount_id": "m-z",
+            "mount_point": "/z",
+            "backend_type": "path_local",
+            "backend_config": {},
+            "owner_user_id": None,
+            "zone_id": None,
+            "description": None,
+        },
+        {
+            "mount_id": "m-a",
+            "mount_point": "/a",
+            "backend_type": "path_local",
+            "backend_config": {},
+            "owner_user_id": None,
+            "zone_id": None,
+            "description": None,
+        },
+    ]
+    out_path = tmp_path / "mounts.jsonl"
+    redact_and_write(mounts, out_path=out_path)
+    lines = out_path.read_text().strip().split("\n")
+    assert json.loads(lines[0])["mount_id"] == "m-a"
+    assert json.loads(lines[1])["mount_id"] == "m-z"
+
+
+def test_redact_and_write_byte_stable_across_runs(tmp_path, s3_mount_dict):
+    pytest.importorskip("boto3")
+    from nexus.bricks.portability.tests.test_redaction_unit import _ensure_registry
+
+    _ensure_registry()
+
+    out1 = tmp_path / "a.jsonl"
+    out2 = tmp_path / "b.jsonl"
+    redact_and_write([s3_mount_dict], out_path=out1)
+    redact_and_write([s3_mount_dict], out_path=out2)
+    assert out1.read_bytes() == out2.read_bytes()
+
+
+def test_redact_and_write_audit_failure_raises(tmp_path):
+    """If a mount references a backend whose CONNECTION_ARGS audit fails, raise."""
+    from unittest.mock import patch
+
+    bad_mount = {
+        "mount_id": "m-1",
+        "mount_point": "/x",
+        "backend_type": "path_s3",
+        "backend_config": {"my_token": "x"},
+        "owner_user_id": None,
+        "zone_id": None,
+        "description": None,
+    }
+    with (
+        patch(
+            "nexus.bricks.portability.redaction.audit_backend",
+            return_value=["my_token"],
+        ),
+        pytest.raises(SensitiveFieldNotDeclaredError),
+    ):
+        redact_and_write([bad_mount], out_path=tmp_path / "x.jsonl")
+
+
+def test_redact_and_write_empty_list_writes_empty_file(tmp_path):
+    out_path = tmp_path / "mounts.jsonl"
+    placeholders = redact_and_write([], out_path=out_path)
+    assert out_path.exists()
+    assert out_path.read_text() == ""
+    assert placeholders == []

--- a/src/nexus/bricks/portability/tests/test_mount_export.py
+++ b/src/nexus/bricks/portability/tests/test_mount_export.py
@@ -71,6 +71,10 @@ def test_redact_and_write_redacts_secrets_and_returns_placeholders(tmp_path, s3_
 
 
 def test_redact_and_write_sorts_lines_by_mount_id(tmp_path):
+    from nexus.bricks.portability.tests.test_redaction_unit import _ensure_registry
+
+    _ensure_registry()
+
     mounts: list[dict[str, object]] = [
         {
             "mount_id": "m-z",

--- a/src/nexus/bricks/portability/tests/test_mount_import.py
+++ b/src/nexus/bricks/portability/tests/test_mount_import.py
@@ -185,3 +185,66 @@ def test_import_mounts_orders_by_path_depth():
     )
     saved_paths = [c.kwargs["mount_point"] for c in mgr.save_mount.call_args_list]
     assert saved_paths.index("/personal") < saved_paths.index("/personal/alice/sub")
+
+
+def test_import_mounts_overwrite_refuses_backend_type_mismatch(redacted_record):
+    """OVERWRITE must refuse to silently swap backend_type on the same path.
+
+    Without this guard, an attacker (or a misconfiguration) could overwrite
+    a path_local mount with an S3 backend_config, leaving the mount_table
+    inconsistent on next restore.
+    """
+    mgr = MagicMock()
+    mgr.get_mount.return_value = {
+        "mount_point": "/personal/alice",
+        "backend_type": "path_local",  # different from redacted_record's path_s3
+        "owner_user_id": "alice",
+    }
+    errors = import_mounts(
+        mounts=[redacted_record],
+        overrides={"m-1": {"access_key_id": "AKIA", "secret_access_key": "wJ"}},
+        mount_manager=mgr,
+        target_zone_id=None,
+        conflict_mode=ConflictMode.OVERWRITE,
+    )
+    assert mgr.update_mount.call_count == 0, "must not silently rewrite backend_type"
+    assert mgr.save_mount.call_count == 0
+    assert any("backend_type mismatch" in e.message for e in errors), [e.message for e in errors]
+
+
+def test_import_mounts_overwrite_refuses_owner_mismatch(redacted_record):
+    """OVERWRITE must refuse to silently rebind ownership."""
+    mgr = MagicMock()
+    mgr.get_mount.return_value = {
+        "mount_point": "/personal/alice",
+        "backend_type": "path_s3",
+        "owner_user_id": "bob",  # different owner
+    }
+    errors = import_mounts(
+        mounts=[redacted_record],
+        overrides={"m-1": {"access_key_id": "AKIA", "secret_access_key": "wJ"}},
+        mount_manager=mgr,
+        target_zone_id=None,
+        conflict_mode=ConflictMode.OVERWRITE,
+    )
+    assert mgr.update_mount.call_count == 0
+    assert any("owner mismatch" in e.message for e in errors), [e.message for e in errors]
+
+
+def test_import_mounts_overwrite_allows_matching_identity(redacted_record):
+    """OVERWRITE with identical backend_type + owner is the legitimate use case."""
+    mgr = MagicMock()
+    mgr.get_mount.return_value = {
+        "mount_point": "/personal/alice",
+        "backend_type": "path_s3",
+        "owner_user_id": "alice",
+    }
+    errors = import_mounts(
+        mounts=[redacted_record],
+        overrides={"m-1": {"access_key_id": "AKIA", "secret_access_key": "wJ"}},
+        mount_manager=mgr,
+        target_zone_id=None,
+        conflict_mode=ConflictMode.OVERWRITE,
+    )
+    assert errors == []
+    assert mgr.update_mount.call_count == 1

--- a/src/nexus/bricks/portability/tests/test_mount_import.py
+++ b/src/nexus/bricks/portability/tests/test_mount_import.py
@@ -135,7 +135,13 @@ def test_import_mounts_skip_existing_records_info(redacted_record):
 
 def test_import_mounts_overwrite_calls_update(redacted_record):
     mgr = MagicMock()
-    mgr.get_mount.return_value = {"mount_point": "/personal/alice"}
+    # Persisted record with matching identity (backend_type + owner)
+    # for the legitimate overwrite path.
+    mgr.get_mount.return_value = {
+        "mount_point": "/personal/alice",
+        "backend_type": "path_s3",
+        "owner_user_id": "alice",
+    }
     import_mounts(
         mounts=[redacted_record],
         overrides={"m-1": {"access_key_id": "AKIA", "secret_access_key": "w"}},
@@ -145,6 +151,29 @@ def test_import_mounts_overwrite_calls_update(redacted_record):
     )
     mgr.update_mount.assert_called_once()
     assert mgr.save_mount.call_count == 0
+
+
+def test_import_mounts_overwrite_refuses_missing_backend_type(redacted_record):
+    """Round 2 reviewer finding: persisted record without backend_type
+    (older or malformed schema) must NOT silently overwrite. update_mount
+    only writes backend_config + description, so the gap would persist
+    and break later restore."""
+    mgr = MagicMock()
+    mgr.get_mount.return_value = {
+        "mount_point": "/personal/alice",
+        # backend_type intentionally absent — simulates legacy/malformed record
+        "owner_user_id": "alice",
+    }
+    errors = import_mounts(
+        mounts=[redacted_record],
+        overrides={"m-1": {"access_key_id": "AKIA", "secret_access_key": "w"}},
+        mount_manager=mgr,
+        target_zone_id=None,
+        conflict_mode=ConflictMode.OVERWRITE,
+    )
+    assert mgr.update_mount.call_count == 0, "must not overwrite on missing backend_type"
+    assert mgr.save_mount.call_count == 0
+    assert any("no backend_type" in e.message.lower() for e in errors), [e.message for e in errors]
 
 
 def test_import_mounts_zone_remap_applied(redacted_record):

--- a/src/nexus/bricks/portability/tests/test_mount_import.py
+++ b/src/nexus/bricks/portability/tests/test_mount_import.py
@@ -1,0 +1,187 @@
+"""Tests for mount_import.py."""
+
+import json
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.bricks.portability.models import (
+    ConflictMode,
+    MissingCredentialsError,
+    MountRecord,
+)
+from nexus.bricks.portability.mount_import import (
+    import_mounts,
+    materialize,
+    read_mounts,
+    validate_overrides,
+)
+
+
+@pytest.fixture
+def redacted_record():
+    return MountRecord(
+        mount_id="m-1",
+        mount_point="/personal/alice",
+        backend_type="path_s3",
+        backend_config={
+            "bucket_name": "acme",
+            "access_key_id": "${MOUNT_m-1_ACCESS_KEY_ID}",
+            "secret_access_key": "${MOUNT_m-1_SECRET_ACCESS_KEY}",
+        },
+        owner_user_id="alice",
+        zone_id="acme",
+        description=None,
+    )
+
+
+def test_read_mounts_absent_file_returns_empty(tmp_path):
+    assert read_mounts(tmp_path) == []
+
+
+def test_read_mounts_parses_jsonl(tmp_path, redacted_record):
+    p = tmp_path / "mounts.jsonl"
+    p.write_text(json.dumps(redacted_record.to_dict()) + "\n")
+    out = read_mounts(tmp_path)
+    assert len(out) == 1
+    assert out[0] == redacted_record
+
+
+def test_read_mounts_skips_blank_lines(tmp_path, redacted_record):
+    p = tmp_path / "mounts.jsonl"
+    p.write_text(json.dumps(redacted_record.to_dict()) + "\n\n")
+    assert len(read_mounts(tmp_path)) == 1
+
+
+def test_validate_overrides_no_redacted_fields_passes():
+    rec = MountRecord(
+        mount_id="m-1",
+        mount_point="/x",
+        backend_type="path_local",
+        backend_config={"root": "/data"},
+    )
+    validate_overrides([rec], overrides=None)  # no raise
+
+
+def test_validate_overrides_missing_raises_with_all_gaps(redacted_record):
+    rec2 = MountRecord(
+        mount_id="m-2",
+        mount_point="/y",
+        backend_type="path_s3",
+        backend_config={"access_key_id": "${MOUNT_m-2_ACCESS_KEY_ID}"},
+    )
+    with pytest.raises(MissingCredentialsError) as exc:
+        validate_overrides([redacted_record, rec2], overrides=None)
+    missing = exc.value.missing
+    assert set(missing.keys()) == {"m-1", "m-2"}
+    assert "access_key_id" in missing["m-1"]
+    assert "secret_access_key" in missing["m-1"]
+    assert "access_key_id" in missing["m-2"]
+
+
+def test_validate_overrides_partial_provided_still_raises(redacted_record):
+    overrides = {"m-1": {"access_key_id": "AKIA"}}  # missing secret_access_key
+    with pytest.raises(MissingCredentialsError) as exc:
+        validate_overrides([redacted_record], overrides=overrides)
+    assert exc.value.missing == {"m-1": ["secret_access_key"]}
+
+
+def test_validate_overrides_full_passes(redacted_record):
+    overrides = {"m-1": {"access_key_id": "AKIA", "secret_access_key": "wJalr"}}
+    validate_overrides([redacted_record], overrides=overrides)  # no raise
+
+
+def test_materialize_substitutes_placeholders(redacted_record):
+    overrides = {"access_key_id": "AKIA", "secret_access_key": "wJalr"}
+    out = materialize(redacted_record, overrides)
+    assert out["access_key_id"] == "AKIA"
+    assert out["secret_access_key"] == "wJalr"
+    assert out["bucket_name"] == "acme"
+
+
+def test_import_mounts_calls_save_mount_per_record(redacted_record):
+    mgr = MagicMock()
+    mgr.get_mount.return_value = None  # no conflict
+    overrides = {"m-1": {"access_key_id": "AKIA", "secret_access_key": "wJalr"}}
+    errors = import_mounts(
+        mounts=[redacted_record],
+        overrides=overrides,
+        mount_manager=mgr,
+        target_zone_id=None,
+        conflict_mode=ConflictMode.SKIP,
+    )
+    assert errors == []
+    assert mgr.save_mount.call_count == 1
+    kwargs = mgr.save_mount.call_args.kwargs
+    assert kwargs["mount_point"] == "/personal/alice"
+    assert kwargs["backend_type"] == "path_s3"
+    assert kwargs["backend_config"]["access_key_id"] == "AKIA"
+
+
+def test_import_mounts_skip_existing_records_info(redacted_record):
+    mgr = MagicMock()
+    mgr.get_mount.return_value = {"mount_point": "/personal/alice"}  # already there
+    errors = import_mounts(
+        mounts=[redacted_record],
+        overrides={"m-1": {"access_key_id": "AKIA", "secret_access_key": "w"}},
+        mount_manager=mgr,
+        target_zone_id=None,
+        conflict_mode=ConflictMode.SKIP,
+    )
+    assert mgr.save_mount.call_count == 0
+    assert len(errors) == 1
+    assert "alice" in errors[0].message
+
+
+def test_import_mounts_overwrite_calls_update(redacted_record):
+    mgr = MagicMock()
+    mgr.get_mount.return_value = {"mount_point": "/personal/alice"}
+    import_mounts(
+        mounts=[redacted_record],
+        overrides={"m-1": {"access_key_id": "AKIA", "secret_access_key": "w"}},
+        mount_manager=mgr,
+        target_zone_id=None,
+        conflict_mode=ConflictMode.OVERWRITE,
+    )
+    mgr.update_mount.assert_called_once()
+    assert mgr.save_mount.call_count == 0
+
+
+def test_import_mounts_zone_remap_applied(redacted_record):
+    mgr = MagicMock()
+    mgr.get_mount.return_value = None
+    import_mounts(
+        mounts=[redacted_record],
+        overrides={"m-1": {"access_key_id": "AKIA", "secret_access_key": "w"}},
+        mount_manager=mgr,
+        target_zone_id="new-zone",
+        conflict_mode=ConflictMode.SKIP,
+    )
+    assert mgr.save_mount.call_args.kwargs["zone_id"] == "new-zone"
+
+
+def test_import_mounts_orders_by_path_depth():
+    """Parents must restore before children to avoid ordering bugs."""
+    mgr = MagicMock()
+    mgr.get_mount.return_value = None
+    deep = MountRecord(
+        mount_id="m-deep",
+        mount_point="/personal/alice/sub",
+        backend_type="path_local",
+        backend_config={"root": "/x"},
+    )
+    shallow = MountRecord(
+        mount_id="m-shallow",
+        mount_point="/personal",
+        backend_type="path_local",
+        backend_config={"root": "/y"},
+    )
+    import_mounts(
+        mounts=[deep, shallow],
+        overrides={},
+        mount_manager=mgr,
+        target_zone_id=None,
+        conflict_mode=ConflictMode.SKIP,
+    )
+    saved_paths = [c.kwargs["mount_point"] for c in mgr.save_mount.call_args_list]
+    assert saved_paths.index("/personal") < saved_paths.index("/personal/alice/sub")

--- a/src/nexus/bricks/portability/tests/test_mount_options.py
+++ b/src/nexus/bricks/portability/tests/test_mount_options.py
@@ -1,0 +1,36 @@
+"""Tests for new mount-portability options."""
+
+from pathlib import Path
+
+from nexus.bricks.portability.models import ZoneExportOptions, ZoneImportOptions
+
+
+def test_export_options_default_include_mounts_false():
+    o = ZoneExportOptions(output_path=Path("/tmp/x.nexus"))
+    assert o.include_mounts is False
+
+
+def test_export_options_accepts_include_mounts_true():
+    o = ZoneExportOptions(output_path=Path("/tmp/x.nexus"), include_mounts=True)
+    assert o.include_mounts is True
+
+
+def test_import_options_default_mount_overrides_none():
+    o = ZoneImportOptions(bundle_path=Path("/tmp/x.nexus"))
+    assert o.mount_overrides is None
+
+
+def test_import_options_default_restore_mounts_true():
+    o = ZoneImportOptions(bundle_path=Path("/tmp/x.nexus"))
+    assert o.restore_mounts is True
+
+
+def test_import_options_accepts_mount_overrides():
+    overrides = {"m-1": {"access_key_id": "AKIA"}}
+    o = ZoneImportOptions(bundle_path=Path("/tmp/x.nexus"), mount_overrides=overrides)
+    assert o.mount_overrides == overrides
+
+
+def test_import_options_accepts_restore_mounts_false():
+    o = ZoneImportOptions(bundle_path=Path("/tmp/x.nexus"), restore_mounts=False)
+    assert o.restore_mounts is False

--- a/src/nexus/bricks/portability/tests/test_mount_options.py
+++ b/src/nexus/bricks/portability/tests/test_mount_options.py
@@ -34,3 +34,24 @@ def test_import_options_accepts_mount_overrides():
 def test_import_options_accepts_restore_mounts_false():
     o = ZoneImportOptions(bundle_path=Path("/tmp/x.nexus"), restore_mounts=False)
     assert o.restore_mounts is False
+
+
+def test_mount_overrides_redacted_in_to_dict():
+    """to_dict must not return live credential values."""
+    o = ZoneImportOptions(
+        bundle_path=Path("/tmp/x.nexus"),
+        mount_overrides={"m-1": {"access_key_id": "AKIA-LIVE", "secret_access_key": "wJalr-LIVE"}},
+    )
+    d = o.to_dict()
+    serialized = str(d)
+    assert "AKIA-LIVE" not in serialized
+    assert "wJalr-LIVE" not in serialized
+    # Structure preserved: caller can see WHICH fields were overridden, not the values
+    assert "m-1" in d["mount_overrides"]
+    assert "access_key_id" in d["mount_overrides"]["m-1"]
+    assert d["mount_overrides"]["m-1"]["access_key_id"] == "***"
+
+
+def test_mount_overrides_none_passthrough_in_to_dict():
+    o = ZoneImportOptions(bundle_path=Path("/tmp/x.nexus"))
+    assert o.to_dict()["mount_overrides"] is None

--- a/src/nexus/bricks/portability/tests/test_mount_record.py
+++ b/src/nexus/bricks/portability/tests/test_mount_record.py
@@ -1,0 +1,58 @@
+"""Tests for MountRecord dataclass."""
+
+import pytest
+
+from nexus.bricks.portability.models import (
+    MissingCredentialsError,
+    MountRecord,
+    SensitiveFieldNotDeclaredError,
+)
+
+
+def test_mount_record_round_trip_dict():
+    rec = MountRecord(
+        mount_id="m-1",
+        mount_point="/personal/alice",
+        backend_type="path_s3",
+        backend_config={"bucket_name": "acme", "access_key_id": "${MOUNT_m-1_ACCESS_KEY_ID}"},
+        owner_user_id="alice",
+        zone_id="acme",
+        description=None,
+    )
+    d = rec.to_dict()
+    rec2 = MountRecord.from_dict(d)
+    assert rec2 == rec
+
+
+def test_mount_record_handles_none_zone_and_owner():
+    rec = MountRecord(
+        mount_id="m-2",
+        mount_point="/team/x",
+        backend_type="path_local",
+        backend_config={"root": "/data"},
+        owner_user_id=None,
+        zone_id=None,
+        description="team mount",
+    )
+    rec2 = MountRecord.from_dict(rec.to_dict())
+    assert rec2 == rec
+
+
+def test_sensitive_field_not_declared_error_carries_payload():
+    err = SensitiveFieldNotDeclaredError(backend_type="path_s3", fields=["my_secret"])
+    assert err.backend_type == "path_s3"
+    assert err.fields == ["my_secret"]
+    assert "path_s3" in str(err)
+    assert "my_secret" in str(err)
+
+
+def test_missing_credentials_error_lists_all_gaps():
+    err = MissingCredentialsError(missing={"m-1": ["a", "b"], "m-2": ["c"]})
+    msg = str(err)
+    assert "m-1" in msg and "a" in msg and "b" in msg
+    assert "m-2" in msg and "c" in msg
+
+
+def test_missing_credentials_error_is_value_error():
+    with pytest.raises(ValueError):
+        raise MissingCredentialsError(missing={"m-1": ["a"]})

--- a/src/nexus/bricks/portability/tests/test_redaction_audit.py
+++ b/src/nexus/bricks/portability/tests/test_redaction_audit.py
@@ -37,5 +37,7 @@ def test_connector_passes_secret_shape_audit(entry):
     assert not leaks, (
         f"{entry.name}: argument names {leaks} match secret-shape regex "
         f"({SECRET_SHAPED.pattern}) but are not marked secret=True. "
-        f"Either rename them or set secret=True in CONNECTION_ARGS."
+        f"Either rename them, set secret=True (real credentials), or set "
+        f"audit_safe=True (justified false positives — document why in the "
+        f"ConnectionArg description) in CONNECTION_ARGS."
     )

--- a/src/nexus/bricks/portability/tests/test_redaction_audit.py
+++ b/src/nexus/bricks/portability/tests/test_redaction_audit.py
@@ -1,0 +1,41 @@
+"""CI gate: every registered connector must pass the secret-shape audit.
+
+Adding a backend whose CONNECTION_ARGS has a key like 'token_xyz' or
+'auth_secret' without marking it secret=True must fail this test.
+"""
+
+import pytest
+
+from nexus.backends._manifest import CONNECTOR_MANIFEST
+from nexus.bricks.portability.redaction import (
+    SECRET_SHAPED,
+    _get_connection_args,
+    audit_backend,
+)
+
+
+@pytest.fixture(scope="session", autouse=True)
+def _bootstrap_connector_registry():
+    """Register manifest placeholders + attempt connector imports once per session.
+
+    Without this, ConnectorRegistry is empty and _get_connection_args raises
+    KeyError for every entry. Called once at session start; the idempotency
+    guard inside _register_optional_backends() makes repeated calls a no-op.
+    """
+    from nexus.backends import _register_optional_backends
+
+    _register_optional_backends()
+
+
+@pytest.mark.parametrize("entry", CONNECTOR_MANIFEST, ids=lambda e: e.name)
+def test_connector_passes_secret_shape_audit(entry):
+    """Every CONNECTION_ARGS key matching SECRET_SHAPED must be marked secret=True."""
+    args = _get_connection_args(entry.name)
+    if not args:
+        pytest.skip(f"{entry.name}: connector class not loaded (optional extra not installed)")
+    leaks = audit_backend(entry.name)
+    assert not leaks, (
+        f"{entry.name}: argument names {leaks} match secret-shape regex "
+        f"({SECRET_SHAPED.pattern}) but are not marked secret=True. "
+        f"Either rename them or set secret=True in CONNECTION_ARGS."
+    )

--- a/src/nexus/bricks/portability/tests/test_redaction_unit.py
+++ b/src/nexus/bricks/portability/tests/test_redaction_unit.py
@@ -1,0 +1,148 @@
+"""Unit tests for redaction.py."""
+
+from unittest.mock import patch
+
+import pytest
+
+from nexus.bricks.portability.models import (
+    PlaceholderRef,
+    SensitiveFieldNotDeclaredError,
+)
+from nexus.bricks.portability.redaction import (
+    SECRET_SHAPED,
+    audit_backend,
+    declared_secret_fields,
+    redact_config,
+)
+from nexus.extensions.types import ArgType, ConnectionArg
+
+# ---------------------------------------------------------------------------
+# Fake CONNECTION_ARGS for "path_s3" — mirrors the real backend's declaration
+# so these tests remain unit tests independent of connector registration.
+# ---------------------------------------------------------------------------
+_PATH_S3_ARGS = {
+    "bucket_name": ConnectionArg(type=ArgType.STRING, description="S3 bucket name", secret=False),
+    "region_name": ConnectionArg(type=ArgType.STRING, description="AWS region", secret=False),
+    "credentials_path": ConnectionArg(
+        type=ArgType.PATH, description="Credentials path", secret=True
+    ),
+    "prefix": ConnectionArg(type=ArgType.STRING, description="Key prefix", secret=False),
+    "access_key_id": ConnectionArg(
+        type=ArgType.SECRET, description="AWS access key ID", secret=True
+    ),
+    "secret_access_key": ConnectionArg(
+        type=ArgType.PASSWORD, description="AWS secret key", secret=True
+    ),
+    "session_token": ConnectionArg(
+        type=ArgType.SECRET, description="AWS session token", secret=True
+    ),
+}
+
+
+@pytest.fixture()
+def path_s3_args(monkeypatch):
+    """Patch _get_connection_args to return the real path_s3 CONNECTION_ARGS shape.
+
+    Uses monkeypatch (not unittest.mock.patch) to avoid pytest-mock interference
+    with fixture-level patching. This makes tests independent of ConnectorRegistry
+    registration state, which differs between the worktree src and site-packages.
+    """
+    import nexus.bricks.portability.redaction as _redaction_mod
+
+    monkeypatch.setattr(_redaction_mod, "_get_connection_args", lambda _: _PATH_S3_ARGS)
+
+
+# ---------------------------------------------------------------------------
+# SECRET_SHAPED regex — no registry required
+# ---------------------------------------------------------------------------
+
+
+def test_secret_shape_regex_matches_obvious_names():
+    for name in ("api_key", "secret_access_key", "session_token", "password", "credential"):
+        assert SECRET_SHAPED.search(name), name
+
+
+def test_secret_shape_regex_ignores_benign_names():
+    for name in ("bucket_name", "region", "prefix", "path"):
+        assert not SECRET_SHAPED.search(name), name
+
+
+# ---------------------------------------------------------------------------
+# declared_secret_fields
+# ---------------------------------------------------------------------------
+
+
+def test_declared_secret_fields_for_path_s3(path_s3_args):  # noqa: ARG001
+    fields = declared_secret_fields("path_s3")
+    assert "access_key_id" in fields
+    assert "secret_access_key" in fields
+    assert "session_token" in fields
+    assert "bucket_name" not in fields
+
+
+# ---------------------------------------------------------------------------
+# audit_backend
+# ---------------------------------------------------------------------------
+
+
+def test_audit_backend_passes_for_path_s3(path_s3_args):  # noqa: ARG001
+    """All secret-shaped names in path_s3 are already marked secret=True."""
+    assert audit_backend("path_s3") == []
+
+
+# ---------------------------------------------------------------------------
+# redact_config
+# ---------------------------------------------------------------------------
+
+
+def test_redact_config_replaces_only_declared_secrets(path_s3_args):  # noqa: ARG001
+    config = {
+        "bucket_name": "acme",
+        "access_key_id": "AKIA1234",
+        "secret_access_key": "wJalr...",
+    }
+    redacted, placeholders = redact_config("path_s3", config, mount_id="m-1")
+    assert redacted["bucket_name"] == "acme"
+    assert redacted["access_key_id"] == "${MOUNT_m-1_ACCESS_KEY_ID}"
+    assert redacted["secret_access_key"] == "${MOUNT_m-1_SECRET_ACCESS_KEY}"
+    assert {p.name for p in placeholders} == {
+        "MOUNT_m-1_ACCESS_KEY_ID",
+        "MOUNT_m-1_SECRET_ACCESS_KEY",
+    }
+    assert all(isinstance(p, PlaceholderRef) for p in placeholders)
+
+
+def test_redact_config_skips_none_values(path_s3_args):  # noqa: ARG001
+    config = {"bucket_name": "acme", "access_key_id": None}
+    redacted, placeholders = redact_config("path_s3", config, mount_id="m-1")
+    assert redacted["access_key_id"] is None
+    assert placeholders == []
+
+
+def test_redact_config_idempotent_on_already_redacted(path_s3_args):  # noqa: ARG001
+    config = {"bucket_name": "acme", "access_key_id": "${MOUNT_m-1_ACCESS_KEY_ID}"}
+    redacted, _ = redact_config("path_s3", config, mount_id="m-1")
+    assert redacted["access_key_id"] == "${MOUNT_m-1_ACCESS_KEY_ID}"
+
+
+def test_redact_config_audit_failure_raises():
+    """If a backend has a secret-shaped name not marked secret=True, raise."""
+    fake_args = {
+        "bucket": ConnectionArg(type=ArgType.STRING, description="ok"),
+        "my_token": ConnectionArg(
+            type=ArgType.STRING,
+            description="should be secret but isn't",
+            secret=False,
+        ),
+    }
+
+    with patch("nexus.bricks.portability.redaction._get_connection_args", return_value=fake_args):
+        with pytest.raises(SensitiveFieldNotDeclaredError) as exc:
+            redact_config("fake", {"bucket": "x", "my_token": "y"}, mount_id="m-1")
+        assert "my_token" in exc.value.fields
+
+
+def test_placeholder_field_dotted_path_is_predictable(path_s3_args):  # noqa: ARG001
+    config = {"access_key_id": "AKIA"}
+    _, placeholders = redact_config("path_s3", config, mount_id="m-1")
+    assert placeholders[0].field == "mounts.m-1.access_key_id"

--- a/src/nexus/bricks/portability/tests/test_redaction_unit.py
+++ b/src/nexus/bricks/portability/tests/test_redaction_unit.py
@@ -320,3 +320,76 @@ def test_redact_config_registered_no_args_refuses_url_userinfo():
                 mount_id="m-1",
             )
         assert "dsn" in str(exc.value.fields)
+
+
+def test_redact_config_audit_safe_field_with_credential_value_refused():
+    """Round 6: audit_safe escapes the heuristic for the field NAME but
+    must not whitelist credential-bearing VALUES. token_manager_db is
+    audit_safe (it's a DB path), but a value like
+    'postgresql://user:pass@host/db' carries live credentials in URL
+    userinfo and must be refused."""
+    from unittest.mock import patch
+
+    from nexus.extensions.types import ArgType, ConnectionArg
+
+    fake_args = {
+        "token_manager_db": ConnectionArg(
+            type=ArgType.PATH,
+            description="DB path or URL (audit_safe)",
+            audit_safe=True,
+        ),
+    }
+    with patch("nexus.bricks.portability.redaction._get_connection_args", return_value=fake_args):
+        with pytest.raises(SensitiveFieldNotDeclaredError) as exc:
+            redact_config(
+                "fake_oauth",
+                {"token_manager_db": "postgresql://alice:livepw@host/db"},
+                mount_id="m-1",
+            )
+        assert "token_manager_db" in str(exc.value.fields)
+
+
+def test_redact_config_no_args_refuses_token_only_url():
+    """Round 6: 'https://TOKEN@host' (no colon, token-only userinfo)
+    must be caught by the value scanner."""
+    from unittest.mock import patch
+
+    with (
+        patch(
+            "nexus.bricks.portability.redaction._get_connection_args",
+            return_value={},
+        ),
+        patch(
+            "nexus.bricks.portability.redaction._backend_is_registered",
+            return_value=True,
+        ),
+        pytest.raises(SensitiveFieldNotDeclaredError),
+    ):
+        redact_config(
+            "custom_backend",
+            {"endpoint": "https://ghp_abcdefghijklmnopqrstuvwxyz0123456789@api.github.com"},
+            mount_id="m-1",
+        )
+
+
+def test_redact_config_no_args_refuses_jwt():
+    """Round 6: a bare JWT (eyJ...) must be caught."""
+    from unittest.mock import patch
+
+    jwt = (
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9."
+        "eyJzdWIiOiIxMjM0NSIsIm5hbWUiOiJBbGljZSJ9."
+        "SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c"
+    )
+    with (
+        patch(
+            "nexus.bricks.portability.redaction._get_connection_args",
+            return_value={},
+        ),
+        patch(
+            "nexus.bricks.portability.redaction._backend_is_registered",
+            return_value=True,
+        ),
+        pytest.raises(SensitiveFieldNotDeclaredError),
+    ):
+        redact_config("custom_backend", {"creds_blob": jwt}, mount_id="m-1")

--- a/src/nexus/bricks/portability/tests/test_redaction_unit.py
+++ b/src/nexus/bricks/portability/tests/test_redaction_unit.py
@@ -275,3 +275,48 @@ def test_redact_config_registered_no_args_refuses_secret_shaped_keys():
             )
         assert "api_key" in exc.value.fields
         assert "registered but declares no" in exc.value.backend_type
+
+
+def test_redact_config_registered_no_args_refuses_value_level_secret():
+    """Round 5: registered backend with no CONNECTION_ARGS must not
+    pass through values that look like credentials (e.g., command line
+    containing AKIA..., URL with userinfo, KEY=VALUE assignment).
+    Round-4 passed these through after only key-name scanning."""
+    with (
+        patch(
+            "nexus.bricks.portability.redaction._get_connection_args",
+            return_value={},
+        ),
+        patch(
+            "nexus.bricks.portability.redaction._backend_is_registered",
+            return_value=True,
+        ),
+    ):
+        with pytest.raises(SensitiveFieldNotDeclaredError) as exc:
+            redact_config(
+                "custom_cli_backend",
+                {"command": "aws s3 ls --secret-key=AKIAIOSFODNN7EXAMPLE"},
+                mount_id="m-1",
+            )
+        assert "command" in str(exc.value.fields)
+
+
+def test_redact_config_registered_no_args_refuses_url_userinfo():
+    """A DSN URL with embedded user:password must be refused."""
+    with (
+        patch(
+            "nexus.bricks.portability.redaction._get_connection_args",
+            return_value={},
+        ),
+        patch(
+            "nexus.bricks.portability.redaction._backend_is_registered",
+            return_value=True,
+        ),
+    ):
+        with pytest.raises(SensitiveFieldNotDeclaredError) as exc:
+            redact_config(
+                "custom_db_backend",
+                {"dsn": "postgresql://user:passwordlive@host/db"},
+                mount_id="m-1",
+            )
+        assert "dsn" in str(exc.value.fields)

--- a/src/nexus/bricks/portability/tests/test_redaction_unit.py
+++ b/src/nexus/bricks/portability/tests/test_redaction_unit.py
@@ -131,3 +131,21 @@ def test_placeholder_field_dotted_path_is_predictable():
     config = {"access_key_id": "AKIA"}
     _, placeholders = redact_config("path_s3", config, mount_id="m-1")
     assert placeholders[0].field == "mounts.m-1.access_key_id"
+
+
+def test_audit_safe_field_passes_audit():
+    """ConnectionArg(audit_safe=True) on a secret-shaped name silences the audit."""
+    from unittest.mock import patch
+
+    from nexus.extensions.types import ArgType, ConnectionArg
+
+    fake_args = {
+        "secret_path": ConnectionArg(
+            type=ArgType.PATH,
+            description="path to a secrets dir, not a secret value",
+            audit_safe=True,
+        ),
+    }
+
+    with patch("nexus.bricks.portability.redaction._get_connection_args", return_value=fake_args):
+        assert audit_backend("fake") == []

--- a/src/nexus/bricks/portability/tests/test_redaction_unit.py
+++ b/src/nexus/bricks/portability/tests/test_redaction_unit.py
@@ -10,6 +10,7 @@ from nexus.bricks.portability.models import (
 )
 from nexus.bricks.portability.redaction import (
     SECRET_SHAPED,
+    _get_connection_args,
     audit_backend,
     declared_secret_fields,
     redact_config,
@@ -149,3 +150,15 @@ def test_audit_safe_field_passes_audit():
 
     with patch("nexus.bricks.portability.redaction._get_connection_args", return_value=fake_args):
         assert audit_backend("fake") == []
+
+
+def test_get_connection_args_finds_slack_manifest_args():
+    """_get_connection_args must surface ConnectorManifest.connection_args
+    (Slack-style), not just class-level CONNECTION_ARGS."""
+    pytest.importorskip("slack_sdk")
+    _ensure_registry()
+    args = _get_connection_args("slack_connector")
+    assert "token_manager_db" in args, (
+        "Slack connector_args missed by _get_connection_args — extension-store "
+        "manifest fallback may be broken."
+    )

--- a/src/nexus/bricks/portability/tests/test_redaction_unit.py
+++ b/src/nexus/bricks/portability/tests/test_redaction_unit.py
@@ -187,3 +187,35 @@ def test_get_connection_args_finds_slack_manifest_args():
         "Slack connector_args missed by _get_connection_args — extension-store "
         "manifest fallback may be broken."
     )
+
+
+def test_redact_config_rejects_undeclared_secret_shaped_top_level_key():
+    """Round 3: persisted backend_config can hold extra keys not in
+    CONNECTION_ARGS. If one looks like a secret (e.g., a path_local
+    record polluted with `secret_access_key`), the export must abort
+    rather than ship it cleartext."""
+    pytest.importorskip("boto3")
+    _ensure_registry()
+    config = {
+        "root_path": "/tmp/data",
+        "secret_access_key": "AKIA-LIVE-LEAK",  # not in path_local CONNECTION_ARGS
+    }
+    with pytest.raises(SensitiveFieldNotDeclaredError) as exc:
+        redact_config("path_local", config, mount_id="m-leak")
+    assert "secret_access_key" in exc.value.fields
+
+
+def test_redact_config_rejects_nested_secret_shaped_key():
+    """Round 3: nested credential dicts (e.g., a `metadata` blob
+    containing `auth_token`) must also fail closed — CONNECTION_ARGS
+    can't declare structure for a nested dict, so any nested
+    secret-shaped key is treated as a leak."""
+    pytest.importorskip("boto3")
+    _ensure_registry()
+    config = {
+        "root_path": "/tmp/data",
+        "metadata": {"description": "ok", "auth_token": "LIVE-NESTED"},
+    }
+    with pytest.raises(SensitiveFieldNotDeclaredError) as exc:
+        redact_config("path_local", config, mount_id="m-leak")
+    assert any("auth_token" in f for f in exc.value.fields), exc.value.fields

--- a/src/nexus/bricks/portability/tests/test_redaction_unit.py
+++ b/src/nexus/bricks/portability/tests/test_redaction_unit.py
@@ -103,8 +103,9 @@ def test_redact_config_idempotent_on_already_redacted():
     pytest.importorskip("boto3")
     _ensure_registry()
     config = {"bucket_name": "acme", "access_key_id": "${MOUNT_m-1_ACCESS_KEY_ID}"}
-    redacted, _ = redact_config("path_s3", config, mount_id="m-1")
+    redacted, placeholders = redact_config("path_s3", config, mount_id="m-1")
     assert redacted["access_key_id"] == "${MOUNT_m-1_ACCESS_KEY_ID}"
+    assert placeholders == []  # no duplicate placeholder for already-redacted field
 
 
 def test_redact_config_audit_failure_raises():

--- a/src/nexus/bricks/portability/tests/test_redaction_unit.py
+++ b/src/nexus/bricks/portability/tests/test_redaction_unit.py
@@ -16,40 +16,12 @@ from nexus.bricks.portability.redaction import (
 )
 from nexus.extensions.types import ArgType, ConnectionArg
 
-# ---------------------------------------------------------------------------
-# Fake CONNECTION_ARGS for "path_s3" — mirrors the real backend's declaration
-# so these tests remain unit tests independent of connector registration.
-# ---------------------------------------------------------------------------
-_PATH_S3_ARGS = {
-    "bucket_name": ConnectionArg(type=ArgType.STRING, description="S3 bucket name", secret=False),
-    "region_name": ConnectionArg(type=ArgType.STRING, description="AWS region", secret=False),
-    "credentials_path": ConnectionArg(
-        type=ArgType.PATH, description="Credentials path", secret=True
-    ),
-    "prefix": ConnectionArg(type=ArgType.STRING, description="Key prefix", secret=False),
-    "access_key_id": ConnectionArg(
-        type=ArgType.SECRET, description="AWS access key ID", secret=True
-    ),
-    "secret_access_key": ConnectionArg(
-        type=ArgType.PASSWORD, description="AWS secret key", secret=True
-    ),
-    "session_token": ConnectionArg(
-        type=ArgType.SECRET, description="AWS session token", secret=True
-    ),
-}
 
+def _ensure_registry() -> None:
+    """Trigger connector registration so path_s3 is present in the live registry."""
+    from nexus.backends import _register_optional_backends
 
-@pytest.fixture()
-def path_s3_args(monkeypatch):
-    """Patch _get_connection_args to return the real path_s3 CONNECTION_ARGS shape.
-
-    Uses monkeypatch (not unittest.mock.patch) to avoid pytest-mock interference
-    with fixture-level patching. This makes tests independent of ConnectorRegistry
-    registration state, which differs between the worktree src and site-packages.
-    """
-    import nexus.bricks.portability.redaction as _redaction_mod
-
-    monkeypatch.setattr(_redaction_mod, "_get_connection_args", lambda _: _PATH_S3_ARGS)
+    _register_optional_backends()
 
 
 # ---------------------------------------------------------------------------
@@ -68,11 +40,13 @@ def test_secret_shape_regex_ignores_benign_names():
 
 
 # ---------------------------------------------------------------------------
-# declared_secret_fields
+# declared_secret_fields — live registry
 # ---------------------------------------------------------------------------
 
 
-def test_declared_secret_fields_for_path_s3(path_s3_args):  # noqa: ARG001
+def test_declared_secret_fields_for_path_s3():
+    pytest.importorskip("boto3")
+    _ensure_registry()
     fields = declared_secret_fields("path_s3")
     assert "access_key_id" in fields
     assert "secret_access_key" in fields
@@ -81,21 +55,25 @@ def test_declared_secret_fields_for_path_s3(path_s3_args):  # noqa: ARG001
 
 
 # ---------------------------------------------------------------------------
-# audit_backend
+# audit_backend — live registry
 # ---------------------------------------------------------------------------
 
 
-def test_audit_backend_passes_for_path_s3(path_s3_args):  # noqa: ARG001
+def test_audit_backend_passes_for_path_s3():
     """All secret-shaped names in path_s3 are already marked secret=True."""
+    pytest.importorskip("boto3")
+    _ensure_registry()
     assert audit_backend("path_s3") == []
 
 
 # ---------------------------------------------------------------------------
-# redact_config
+# redact_config — live registry
 # ---------------------------------------------------------------------------
 
 
-def test_redact_config_replaces_only_declared_secrets(path_s3_args):  # noqa: ARG001
+def test_redact_config_replaces_only_declared_secrets():
+    pytest.importorskip("boto3")
+    _ensure_registry()
     config = {
         "bucket_name": "acme",
         "access_key_id": "AKIA1234",
@@ -112,14 +90,18 @@ def test_redact_config_replaces_only_declared_secrets(path_s3_args):  # noqa: AR
     assert all(isinstance(p, PlaceholderRef) for p in placeholders)
 
 
-def test_redact_config_skips_none_values(path_s3_args):  # noqa: ARG001
+def test_redact_config_skips_none_values():
+    pytest.importorskip("boto3")
+    _ensure_registry()
     config = {"bucket_name": "acme", "access_key_id": None}
     redacted, placeholders = redact_config("path_s3", config, mount_id="m-1")
     assert redacted["access_key_id"] is None
     assert placeholders == []
 
 
-def test_redact_config_idempotent_on_already_redacted(path_s3_args):  # noqa: ARG001
+def test_redact_config_idempotent_on_already_redacted():
+    pytest.importorskip("boto3")
+    _ensure_registry()
     config = {"bucket_name": "acme", "access_key_id": "${MOUNT_m-1_ACCESS_KEY_ID}"}
     redacted, _ = redact_config("path_s3", config, mount_id="m-1")
     assert redacted["access_key_id"] == "${MOUNT_m-1_ACCESS_KEY_ID}"
@@ -142,7 +124,9 @@ def test_redact_config_audit_failure_raises():
         assert "my_token" in exc.value.fields
 
 
-def test_placeholder_field_dotted_path_is_predictable(path_s3_args):  # noqa: ARG001
+def test_placeholder_field_dotted_path_is_predictable():
+    pytest.importorskip("boto3")
+    _ensure_registry()
     config = {"access_key_id": "AKIA"}
     _, placeholders = redact_config("path_s3", config, mount_id="m-1")
     assert placeholders[0].field == "mounts.m-1.access_key_id"

--- a/src/nexus/bricks/portability/tests/test_redaction_unit.py
+++ b/src/nexus/bricks/portability/tests/test_redaction_unit.py
@@ -393,3 +393,54 @@ def test_redact_config_no_args_refuses_jwt():
         pytest.raises(SensitiveFieldNotDeclaredError),
     ):
         redact_config("custom_backend", {"creds_blob": jwt}, mount_id="m-1")
+
+
+def test_value_scan_does_not_false_positive_on_long_username_url():
+    """Round 7: a username-only URL (no colon, no password) is a real
+    URL shape, not a credential. The previous round-6 pattern matched
+    ``https://username@host`` for any 16+ char username and broke
+    legitimate workflows. Round-7 dropped that pattern."""
+    from unittest.mock import patch
+
+    with (
+        patch(
+            "nexus.bricks.portability.redaction._get_connection_args",
+            return_value={},
+        ),
+        patch(
+            "nexus.bricks.portability.redaction._backend_is_registered",
+            return_value=True,
+        ),
+    ):
+        # Long username, no password — should pass.
+        out, _ = redact_config(
+            "custom_backend",
+            {"endpoint": "https://regularlongusername@host"},
+            mount_id="m-1",
+        )
+        assert out["endpoint"] == "https://regularlongusername@host"
+
+
+def test_value_scan_does_not_false_positive_on_sk_path():
+    """Round 7: a filesystem path containing 'sk-' is not an OpenAI
+    key. Round-6's bare sk-[A-Za-z0-9]{20,} pattern matched
+    ``/data/sk-1234...`` and broke benign mount configs. Round-7
+    dropped that pattern."""
+    from unittest.mock import patch
+
+    with (
+        patch(
+            "nexus.bricks.portability.redaction._get_connection_args",
+            return_value={},
+        ),
+        patch(
+            "nexus.bricks.portability.redaction._backend_is_registered",
+            return_value=True,
+        ),
+    ):
+        out, _ = redact_config(
+            "custom_backend",
+            {"root_path": "/data/sk-1234567890ABCDEFGHIJ"},
+            mount_id="m-1",
+        )
+        assert out["root_path"] == "/data/sk-1234567890ABCDEFGHIJ"

--- a/src/nexus/bricks/portability/tests/test_redaction_unit.py
+++ b/src/nexus/bricks/portability/tests/test_redaction_unit.py
@@ -127,28 +127,37 @@ def test_redact_config_audit_failure_raises():
 
 
 def test_redact_config_unknown_backend_raises():
-    """Refusing to ship a mount whose CONNECTION_ARGS contract is unknown.
+    """Refusing to ship a mount whose backend isn't even in the registry.
 
     Without this guard, a slim install (where e.g. boto3 isn't installed and
     path_s3 isn't loaded) would silently produce a bundle with cleartext S3
     credentials because the registry returns no secret-fields set. The export
     must abort instead.
+
+    Round 4: the message now distinguishes 'unknown backend' (this case)
+    from 'registered but no CONNECTION_ARGS' (allowed for CLI/YAML
+    custom connectors, see test_redact_config_registered_no_args_*).
     """
-    with patch(
-        "nexus.bricks.portability.redaction._get_connection_args",
-        return_value={},
+    with (
+        patch(
+            "nexus.bricks.portability.redaction._get_connection_args",
+            return_value={},
+        ),
+        patch(
+            "nexus.bricks.portability.redaction._backend_is_registered",
+            return_value=False,
+        ),
     ):
         with pytest.raises(SensitiveFieldNotDeclaredError) as exc:
             redact_config(
-                "path_s3",
+                "totally_unknown_backend",
                 {"access_key_id": "AKIA-LIVE", "bucket_name": "acme"},
                 mount_id="m-1",
             )
         # Sorted for deterministic output; offending fields are surfaced so
         # the operator knows what was about to leak.
         assert exc.value.fields == ["access_key_id", "bucket_name"]
-        assert "path_s3" in exc.value.backend_type
-        assert "install the matching extra" in exc.value.backend_type
+        assert "unknown backend" in exc.value.backend_type
 
 
 def test_placeholder_field_dotted_path_is_predictable():
@@ -219,3 +228,50 @@ def test_redact_config_rejects_nested_secret_shaped_key():
     with pytest.raises(SensitiveFieldNotDeclaredError) as exc:
         redact_config("path_local", config, mount_id="m-leak")
     assert any("auth_token" in f for f in exc.value.fields), exc.value.fields
+
+
+def test_redact_config_registered_no_args_passes_with_no_secrets():
+    """Round 4: registered backend (e.g., a CLI/YAML custom connector)
+    with no CONNECTION_ARGS but a clean persisted config exports cleanly.
+    The previous blanket-refuse path broke this legitimate workflow."""
+    with (
+        patch(
+            "nexus.bricks.portability.redaction._get_connection_args",
+            return_value={},
+        ),
+        patch(
+            "nexus.bricks.portability.redaction._backend_is_registered",
+            return_value=True,
+        ),
+    ):
+        out, placeholders = redact_config(
+            "custom_cli_backend",
+            {"command": "/usr/local/bin/foo", "timeout": 30},
+            mount_id="m-1",
+        )
+        assert out == {"command": "/usr/local/bin/foo", "timeout": 30}
+        assert placeholders == []
+
+
+def test_redact_config_registered_no_args_refuses_secret_shaped_keys():
+    """Round 4: registered backend with no CONNECTION_ARGS still must
+    refuse if the persisted config carries secret-shaped keys we cannot
+    introspect."""
+    with (
+        patch(
+            "nexus.bricks.portability.redaction._get_connection_args",
+            return_value={},
+        ),
+        patch(
+            "nexus.bricks.portability.redaction._backend_is_registered",
+            return_value=True,
+        ),
+    ):
+        with pytest.raises(SensitiveFieldNotDeclaredError) as exc:
+            redact_config(
+                "custom_cli_backend",
+                {"command": "/usr/local/bin/foo", "api_key": "LIVE"},
+                mount_id="m-1",
+            )
+        assert "api_key" in exc.value.fields
+        assert "registered but declares no" in exc.value.backend_type

--- a/src/nexus/bricks/portability/tests/test_redaction_unit.py
+++ b/src/nexus/bricks/portability/tests/test_redaction_unit.py
@@ -126,6 +126,31 @@ def test_redact_config_audit_failure_raises():
         assert "my_token" in exc.value.fields
 
 
+def test_redact_config_unknown_backend_raises():
+    """Refusing to ship a mount whose CONNECTION_ARGS contract is unknown.
+
+    Without this guard, a slim install (where e.g. boto3 isn't installed and
+    path_s3 isn't loaded) would silently produce a bundle with cleartext S3
+    credentials because the registry returns no secret-fields set. The export
+    must abort instead.
+    """
+    with patch(
+        "nexus.bricks.portability.redaction._get_connection_args",
+        return_value={},
+    ):
+        with pytest.raises(SensitiveFieldNotDeclaredError) as exc:
+            redact_config(
+                "path_s3",
+                {"access_key_id": "AKIA-LIVE", "bucket_name": "acme"},
+                mount_id="m-1",
+            )
+        # Sorted for deterministic output; offending fields are surfaced so
+        # the operator knows what was about to leak.
+        assert exc.value.fields == ["access_key_id", "bucket_name"]
+        assert "path_s3" in exc.value.backend_type
+        assert "install the matching extra" in exc.value.backend_type
+
+
 def test_placeholder_field_dotted_path_is_predictable():
     pytest.importorskip("boto3")
     _ensure_registry()

--- a/src/nexus/bricks/portability/tests/test_roundtrip_with_mounts.py
+++ b/src/nexus/bricks/portability/tests/test_roundtrip_with_mounts.py
@@ -1,0 +1,126 @@
+"""End-to-end roundtrip: export bundle with mounts → import → mounts restored.
+
+Black-box test against real ZoneExportService + ZoneImportService. Uses
+in-memory MountManager test doubles to avoid VFS plumbing for the kernel.
+"""
+
+import asyncio
+import json
+import tarfile
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.bricks.portability.export_service import ZoneExportService
+from nexus.bricks.portability.import_service import ZoneImportService
+from nexus.bricks.portability.models import (
+    MissingCredentialsError,
+    ZoneExportOptions,
+    ZoneImportOptions,
+)
+
+
+def _ensure_registry() -> None:
+    """Trigger connector registration so path_s3 is present in the live registry."""
+    from nexus.backends import _register_optional_backends
+
+    _register_optional_backends()
+
+
+def _make_mount_manager_with(mounts: list[dict]) -> MagicMock:
+    """Build a MountManager test double that returns `mounts` from list_mounts."""
+    mgr = MagicMock()
+    mgr.list_mounts.return_value = mounts
+    mgr.get_mount.return_value = None  # no conflict
+    return mgr
+
+
+def _maybe_run(result):
+    """Wrap async results so the test works with either sync or async services."""
+    if asyncio.iscoroutine(result):
+        return asyncio.run(result)
+    return result
+
+
+def test_roundtrip_export_then_import_with_overrides(tmp_path):
+    pytest.importorskip("boto3")
+    _ensure_registry()
+
+    src_mgr = _make_mount_manager_with(
+        [
+            {
+                "mount_id": "m-1",
+                "mount_point": "/personal/alice",
+                "backend_type": "path_s3",
+                "backend_config": {
+                    "bucket_name": "acme",
+                    "access_key_id": "AKIA-LIVE-KEY",
+                    "secret_access_key": "wJalr-LIVE-SECRET",
+                },
+                "owner_user_id": "alice",
+                "zone_id": "z1",
+                "description": None,
+            },
+        ]
+    )
+
+    # Provide a minimal kernel so metastore_list returns [] (no file records)
+    kernel = MagicMock()
+    kernel.metastore_list.return_value = []
+    fs = MagicMock()
+    fs._kernel = kernel
+
+    out = tmp_path / "bundle.nexus"
+    exporter = ZoneExportService(fs, mount_manager=src_mgr)
+    _maybe_run(
+        exporter.export_zone(
+            "z1",
+            ZoneExportOptions(
+                output_path=out,
+                include_mounts=True,
+                sign=False,  # skip key-file lookup in unit test context
+            ),
+        )
+    )
+    assert out.exists()
+
+    # Verify export stripped secrets — read raw mounts.jsonl back out of the tar.
+    with tarfile.open(out, "r:gz") as tar:
+        member = tar.getmember("mounts.jsonl")
+        f = tar.extractfile(member)
+        assert f is not None
+        raw_bytes = f.read()
+    record = json.loads(raw_bytes.decode())
+    assert record["backend_config"]["access_key_id"] == "${MOUNT_m-1_ACCESS_KEY_ID}"
+    assert record["backend_config"]["secret_access_key"] == "${MOUNT_m-1_SECRET_ACCESS_KEY}"
+    # Critical: live secrets must not appear anywhere in the redacted record.
+    assert b"AKIA-LIVE-KEY" not in raw_bytes
+    assert b"wJalr-LIVE-SECRET" not in raw_bytes
+
+    # Import without overrides → MissingCredentialsError
+    dst_mgr = MagicMock()
+    dst_mgr.get_mount.return_value = None
+    importer = ZoneImportService(fs, mount_manager=dst_mgr)
+    with pytest.raises(MissingCredentialsError):
+        _maybe_run(importer.import_zone(ZoneImportOptions(bundle_path=out)))
+    assert dst_mgr.save_mount.call_count == 0
+
+    # Import with full overrides → save_mount called with concrete values
+    _maybe_run(
+        importer.import_zone(
+            ZoneImportOptions(
+                bundle_path=out,
+                mount_overrides={
+                    "m-1": {
+                        "access_key_id": "AKIA-NEW-KEY",
+                        "secret_access_key": "wJalr-NEW-SECRET",
+                    }
+                },
+            )
+        )
+    )
+    assert dst_mgr.save_mount.call_count == 1
+    saved_cfg = dst_mgr.save_mount.call_args.kwargs["backend_config"]
+    assert saved_cfg["access_key_id"] == "AKIA-NEW-KEY"
+    assert saved_cfg["secret_access_key"] == "wJalr-NEW-SECRET"
+    assert saved_cfg["bucket_name"] == "acme"  # non-secret survives roundtrip

--- a/src/nexus/cli/commands/zone.py
+++ b/src/nexus/cli/commands/zone.py
@@ -820,6 +820,20 @@ def import_zone(
         # collision). Per-flag format is MOUNT_ID:FIELD=VALUE so a single
         # override targets one field; the file form is a structured JSON
         # for multi-field overrides without one flag per field.
+        #
+        # SECURITY: --mount-override puts secret values in argv, which
+        # leaks them via shell history, ps aux, audit logs, and CLI
+        # telemetry before they reach the server. Warn loudly and
+        # recommend --mount-overrides-file (which can carry strict file
+        # permissions) for any real credential. The flag remains
+        # supported for tests, scripts, and short-lived rotation keys.
+        if mount_override:
+            console.print(
+                "[nexus.warning]Warning:[/nexus.warning] --mount-override puts "
+                "credentials in argv (visible in shell history, ps aux, audit "
+                "logs). For production secrets, prefer --mount-overrides-file "
+                "with restrictive file permissions (chmod 600)."
+            )
         mount_overrides: dict[str, dict[str, str]] = {}
         for override in mount_override:
             try:
@@ -901,6 +915,23 @@ def import_zone(
             table.add_row("Files failed", f"{data.get('files_failed', 0):,}")
             table.add_row("Permissions imported", f"{data.get('permissions_imported', 0):,}")
             console.print(table)
+
+            # Surface mount-restore errors over the wire. Without this,
+            # the CLI prints "Import Complete" even when mount restore
+            # silently failed for half the bundle (Issue #4083 review).
+            errors = data.get("errors") or []
+            warnings = data.get("warnings") or []
+            for w in warnings[:5]:
+                console.print(f"[nexus.warning]warning:[/nexus.warning] {w}")
+            non_info_errors = [e for e in errors if e.get("error_type") != "info"]
+            if non_info_errors:
+                console.print()
+                console.print("[nexus.error]Errors:[/nexus.error]")
+                for e in non_info_errors[:10]:
+                    console.print(f"  - {e.get('path', '?')}: {e.get('message', '')}")
+                if len(non_info_errors) > 10:
+                    console.print(f"  ... and {len(non_info_errors) - 10} more")
+                sys.exit(1)
             return
 
         # Local-only path kept for offline snapshot restore.

--- a/src/nexus/cli/commands/zone.py
+++ b/src/nexus/cli/commands/zone.py
@@ -548,6 +548,11 @@ def unmount_zone_cmd(
     default=6,
     help="Compression level 1-9 (default: 6)",
 )
+@click.option(
+    "--include-mounts/--no-mounts",
+    default=False,
+    help="Include mount configurations (secrets are redacted; default: no, Issue #4083)",
+)
 @add_backend_options
 def export_zone(
     zone_id: str,
@@ -559,6 +564,7 @@ def export_zone(
     path_prefix: str | None,
     after: str | None,
     compression: int,
+    include_mounts: bool,
     remote_url: str | None,
     remote_api_key: str | None,
 ) -> None:
@@ -625,6 +631,7 @@ def export_zone(
                 include_embeddings=include_embeddings,
                 include_deleted=include_deleted,
                 path_prefix=path_prefix,
+                include_mounts=include_mounts,
             )
             table = Table(title="Export Complete")
             table.add_column("Metric", style="nexus.value")
@@ -632,6 +639,8 @@ def export_zone(
             table.add_row("Files exported", f"{data.get('file_count', 0):,}")
             table.add_row("Total size", f"{data.get('total_size_bytes', 0):,} bytes")
             table.add_row("Bundle ID", str(data.get("bundle_id", ""))[:8] + "...")
+            if include_mounts:
+                table.add_row("Mounts exported", f"{data.get('mount_count', 0):,}")
             table.add_row("Output", str(output_path))
             console.print(table)
             return
@@ -652,7 +661,19 @@ def export_zone(
             path_prefix=path_prefix,
             after_time=after_time if after else None,
             compression_level=compression,
+            include_mounts=include_mounts,
         )
+
+        # MountManager is built locally so the offline path can carry
+        # mount configs alongside file data (Issue #4083). Only required
+        # when --include-mounts is set; otherwise leave the service
+        # without one to preserve back-compat.
+        mount_manager = None
+        if include_mounts:
+            from nexus.bricks.mount.metastore_mount_store import MetastoreMountStore
+            from nexus.bricks.mount.mount_manager import MountManager
+
+            mount_manager = MountManager(MetastoreMountStore(nx))
 
         with Progress(
             SpinnerColumn(),
@@ -664,7 +685,7 @@ def export_zone(
             def update_progress(current: int, total: int) -> None:
                 progress.update(task, description=f"Exporting... ({current}/{total} files)")
 
-            service = ZoneExportService(cast(Any, nx))
+            service = ZoneExportService(cast(Any, nx), mount_manager=mount_manager)
             manifest = service.export_zone(zone_id, options, update_progress)
 
         nx.close()
@@ -676,6 +697,8 @@ def export_zone(
         table.add_row("Content blobs", f"{manifest.content_blob_count:,}")
         table.add_row("Permissions", f"{manifest.permission_count:,}")
         table.add_row("Bundle ID", manifest.bundle_id[:8] + "...")
+        if include_mounts:
+            table.add_row("Mounts exported", f"{manifest.mount_count:,}")
         table.add_row("Output", str(output_path))
         if output_path.exists():
             table.add_row("Bundle size", f"{output_path.stat().st_size:,} bytes")
@@ -722,6 +745,30 @@ def export_zone(
     multiple=True,
     help="Path prefix remapping (format: old=new), can be repeated",
 )
+@click.option(
+    "--mount-override",
+    multiple=True,
+    help=(
+        "Re-inject a redacted mount field (format: MOUNT_ID:FIELD=VALUE), "
+        "can be repeated. Required for any field the bundle redacted. "
+        "Issue #4083."
+    ),
+)
+@click.option(
+    "--mount-overrides-file",
+    type=click.Path(exists=True, dir_okay=False),
+    default=None,
+    help=(
+        "JSON file with mount overrides. Shape: "
+        '{"<mount_id>": {"<field>": "<value>", ...}, ...}. '
+        "Merges under any --mount-override flags (file values win on conflict)."
+    ),
+)
+@click.option(
+    "--restore-mounts/--no-restore-mounts",
+    default=True,
+    help="Restore mounts from bundle (default: yes; bundle without mounts.jsonl is unaffected)",
+)
 @add_backend_options
 def import_zone(
     bundle_path: str,
@@ -731,6 +778,9 @@ def import_zone(
     dry_run: bool,
     import_permissions: bool,
     path_remap: tuple[str, ...],
+    mount_override: tuple[str, ...],
+    mount_overrides_file: str | None,
+    restore_mounts: bool,
     remote_url: str | None,
     remote_api_key: str | None,
 ) -> None:
@@ -765,6 +815,50 @@ def import_zone(
             old, new = remap.split("=", 1)
             path_prefix_remap[old] = new
 
+        # Parse mount overrides — accumulate from --mount-override flags
+        # first, then merge --mount-overrides-file on top (file wins on
+        # collision). Per-flag format is MOUNT_ID:FIELD=VALUE so a single
+        # override targets one field; the file form is a structured JSON
+        # for multi-field overrides without one flag per field.
+        mount_overrides: dict[str, dict[str, str]] = {}
+        for override in mount_override:
+            try:
+                mid_field, value = override.split("=", 1)
+                mid, field = mid_field.split(":", 1)
+            except ValueError:
+                console.print(
+                    f"[nexus.error]Error:[/nexus.error] Invalid mount override format: {override}"
+                )
+                console.print("Use format: MOUNT_ID:FIELD=VALUE")
+                sys.exit(1)
+            mount_overrides.setdefault(mid, {})[field] = value
+        if mount_overrides_file:
+            import json as _json
+
+            try:
+                file_data = _json.loads(Path(mount_overrides_file).read_text())
+            except Exception as exc:
+                console.print(
+                    f"[nexus.error]Error:[/nexus.error] Cannot parse {mount_overrides_file}: {exc}"
+                )
+                sys.exit(1)
+            if not isinstance(file_data, dict):
+                console.print(
+                    f"[nexus.error]Error:[/nexus.error] "
+                    f"{mount_overrides_file} must be a JSON object "
+                    "(shape: {mount_id: {field: value}})"
+                )
+                sys.exit(1)
+            for mid, fields in file_data.items():
+                if not isinstance(fields, dict):
+                    console.print(
+                        f"[nexus.error]Error:[/nexus.error] "
+                        f"mount_overrides[{mid!r}] must be an object "
+                        "of field-name -> value"
+                    )
+                    sys.exit(1)
+                mount_overrides.setdefault(mid, {}).update(fields)
+
         # Same remote-first routing as `nexus zone export` — lets a
         # running server own the write path to its live metastore
         # instead of the CLI trying to open the zone's redb in a
@@ -795,6 +889,8 @@ def import_zone(
                 preserve_timestamps=preserve_timestamps,
                 import_permissions=import_permissions,
                 path_prefix_remap=path_prefix_remap,
+                restore_mounts=restore_mounts,
+                mount_overrides=mount_overrides or None,
             )
             table = Table(title="Import Complete")
             table.add_column("Metric", style="nexus.value")
@@ -824,7 +920,19 @@ def import_zone(
             dry_run=dry_run,
             import_permissions=import_permissions,
             path_prefix_remap=path_prefix_remap,
+            restore_mounts=restore_mounts,
+            mount_overrides=mount_overrides or None,
         )
+
+        # MountManager for offline restore (Issue #4083). Constructed
+        # only when the caller opted into mount restore so existing
+        # offline-snapshot workflows keep working unchanged.
+        mount_manager = None
+        if restore_mounts:
+            from nexus.bricks.mount.metastore_mount_store import MetastoreMountStore
+            from nexus.bricks.mount.mount_manager import MountManager
+
+            mount_manager = MountManager(MetastoreMountStore(nx))
 
         # Show import configuration
         console.print(f"[nexus.path]Importing from:[/nexus.path] {bundle_path}")
@@ -845,7 +953,7 @@ def import_zone(
             def update_progress(current: int, total: int, phase: str) -> None:
                 progress.update(task, description=f"Importing {phase}... ({current}/{total})")
 
-            service = ZoneImportService(cast(Any, nx))
+            service = ZoneImportService(cast(Any, nx), mount_manager=mount_manager)
             result = service.import_zone(options, update_progress)
 
         nx.close()

--- a/src/nexus/extensions/_index/extensions.json
+++ b/src/nexus/extensions/_index/extensions.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-06T06:30:29Z",
+  "generated_at": "2026-05-10T06:41:44Z",
   "manifests": [
     {
       "config_schema": null,
@@ -25,6 +25,7 @@
       "config_schema": null,
       "connection_args": {
         "cache_ttl": {
+          "audit_safe": false,
           "config_key": null,
           "default": 300,
           "description": "Default cache TTL in seconds",
@@ -34,6 +35,7 @@
           "type": "integer"
         },
         "include_comments": {
+          "audit_safe": false,
           "config_key": null,
           "default": true,
           "description": "Include nested comments in story files",
@@ -43,6 +45,7 @@
           "type": "boolean"
         },
         "stories_per_feed": {
+          "audit_safe": false,
           "config_key": null,
           "default": 10,
           "description": "Number of stories per feed (1-30)",
@@ -84,6 +87,7 @@
       "config_schema": null,
       "connection_args": {
         "access_key_id": {
+          "audit_safe": false,
           "config_key": null,
           "default": null,
           "description": "AWS access key ID",
@@ -93,6 +97,7 @@
           "type": "secret"
         },
         "bucket_name": {
+          "audit_safe": false,
           "config_key": "bucket",
           "default": null,
           "description": "S3 bucket name",
@@ -102,6 +107,7 @@
           "type": "string"
         },
         "credentials_path": {
+          "audit_safe": false,
           "config_key": null,
           "default": null,
           "description": "Path to AWS credentials JSON file",
@@ -111,6 +117,7 @@
           "type": "path"
         },
         "prefix": {
+          "audit_safe": false,
           "config_key": null,
           "default": "",
           "description": "Path prefix for all files in bucket",
@@ -120,6 +127,7 @@
           "type": "string"
         },
         "region_name": {
+          "audit_safe": false,
           "config_key": null,
           "default": null,
           "description": "AWS region (e.g., us-east-1)",
@@ -129,6 +137,7 @@
           "type": "string"
         },
         "secret_access_key": {
+          "audit_safe": false,
           "config_key": null,
           "default": null,
           "description": "AWS secret access key",
@@ -138,6 +147,7 @@
           "type": "password"
         },
         "session_token": {
+          "audit_safe": false,
           "config_key": null,
           "default": null,
           "description": "AWS session token (for temporary credentials)",
@@ -181,6 +191,7 @@
       "config_schema": null,
       "connection_args": {
         "max_messages_per_channel": {
+          "audit_safe": false,
           "config_key": null,
           "default": 100,
           "description": "Maximum number of messages to fetch per channel",
@@ -190,6 +201,7 @@
           "type": "integer"
         },
         "provider": {
+          "audit_safe": false,
           "config_key": null,
           "default": "slack",
           "description": "OAuth provider name from config",
@@ -199,6 +211,7 @@
           "type": "string"
         },
         "token_manager_db": {
+          "audit_safe": false,
           "config_key": null,
           "default": null,
           "description": "Path to TokenManager database or database URL",
@@ -208,6 +221,7 @@
           "type": "path"
         },
         "user_email": {
+          "audit_safe": false,
           "config_key": null,
           "default": null,
           "description": "User email for OAuth lookup (None for multi-user from context)",

--- a/src/nexus/extensions/_index/extensions.json
+++ b/src/nexus/extensions/_index/extensions.json
@@ -1,5 +1,5 @@
 {
-  "generated_at": "2026-05-10T06:41:44Z",
+  "generated_at": "2026-05-10T07:04:18Z",
   "manifests": [
     {
       "config_schema": null,
@@ -211,10 +211,10 @@
           "type": "string"
         },
         "token_manager_db": {
-          "audit_safe": false,
+          "audit_safe": true,
           "config_key": null,
           "default": null,
-          "description": "Path to TokenManager database or database URL",
+          "description": "Path to TokenManager database or database URL (path, not credential)",
           "env_var": null,
           "required": true,
           "secret": false,

--- a/src/nexus/extensions/types.py
+++ b/src/nexus/extensions/types.py
@@ -35,6 +35,12 @@ class ConnectionArg:
     required: bool = True
     default: Any = None
     secret: bool = False
+    audit_safe: bool = False
+    """Mark `True` when a non-secret field's name matches the secret-shape heuristic
+    (key/secret/token/password/cred) but the value is provably non-sensitive.
+    The portability redaction audit (Issue #4083) uses this to allow declared
+    false positives without weakening the heuristic. Use sparingly and document
+    the reason in the ConnectionArg description."""
     env_var: str | None = None
     config_key: str | None = None
 
@@ -45,6 +51,7 @@ class ConnectionArg:
             "required": self.required,
             "default": self.default,
             "secret": self.secret,
+            "audit_safe": self.audit_safe,
             "env_var": self.env_var,
         }
         if self.config_key is not None:

--- a/src/nexus/remote/rpc_transport.py
+++ b/src/nexus/remote/rpc_transport.py
@@ -19,6 +19,7 @@ Issue #1202: gRPC for REMOTE profile.
 from __future__ import annotations
 
 import logging
+import re as _re
 from typing import TYPE_CHECKING, Any
 
 import grpc
@@ -43,44 +44,76 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
-# Param keys that carry credential material across the wire and must never
-# appear in DEBUG logs (Issue #4083 round-2 reviewer finding: mount_overrides
-# values were landing in support/debug logs). The redactor is method-agnostic
-# — it walks the params dict and replaces values for any matching top-level
-# key with a structure-preserving placeholder so we still see *which* mount
-# IDs and field names were sent.
-_SENSITIVE_PARAM_KEYS: frozenset[str] = frozenset(
-    {
-        "mount_overrides",
-        "injections",
-        "auth_token",
-        "api_key",
-        "credentials",
-    }
+# Heuristic for credential-shaped key names (Issue #4083 rounds 2-3).
+# Recursive redactor walks every dict / list at any depth and replaces
+# values whose key matches this regex. Round-3 reviewer finding: a
+# top-level allowlist (mount_overrides, auth_token, ...) missed nested
+# headers/env, sandbox_api_key, nexus_api_key, and any future RPC param
+# shape. Heuristic-shaped redaction is the safer default: it errs on the
+# side of over-redacting in DEBUG logs (operators see structure, not
+# values) rather than leaking a freshly-added secret-shaped param.
+_SENSITIVE_KEY_RE = _re.compile(
+    r"(?i)(secret|token|password|passwd|credential|api[_-]?key|"
+    r"access[_-]?key|session[_-]?token|authorization|auth[_-]?key|"
+    r"private[_-]?key)"
 )
+
+# Top-level RPC params known to carry secret material as VALUES even when
+# their KEY name doesn't match the heuristic. Used in addition to the
+# recursive scan.
+_SENSITIVE_TOP_LEVEL: frozenset[str] = frozenset({"mount_overrides", "injections", "credentials"})
 
 
 def _redact_params(params: Any) -> Any:
-    """Return a shallow copy of params with sensitive top-level keys redacted.
+    """Return a deep redacted copy of params with credential-shaped keys
+    replaced by ``"***"``.
 
-    For dict-of-dicts shapes (mount_overrides: {mount_id: {field: value}})
-    we preserve the nested keys so the log still shows what fields were
-    supplied for which mount, but the values are replaced with "***".
+    Walks dicts and lists recursively. At every level, a key whose name
+    matches ``_SENSITIVE_KEY_RE`` has its value replaced (preserving
+    structure: a dict value becomes a dict of "***", a list becomes a
+    list of "***"). At the top level, ``mount_overrides`` /
+    ``injections`` / ``credentials`` are also redacted regardless of
+    key-name shape.
+
+    The original ``params`` is never mutated.
     """
-    if not isinstance(params, dict):
-        return params
-    out: dict[str, Any] = {}
-    for key, value in params.items():
-        if key in _SENSITIVE_PARAM_KEYS and value is not None:
-            if isinstance(value, dict):
-                out[key] = {
-                    k: (dict.fromkeys(v, "***") if isinstance(v, dict) else "***")
-                    for k, v in value.items()
-                }
+    return _redact(params, top_level=True)
+
+
+def _redact(value: Any, *, top_level: bool) -> Any:
+    if isinstance(value, dict):
+        out: dict[str, Any] = {}
+        for k, v in value.items():
+            key_str = k if isinstance(k, str) else ""
+            sensitive = bool(_SENSITIVE_KEY_RE.search(key_str)) or (
+                top_level and key_str in _SENSITIVE_TOP_LEVEL
+            )
+            if sensitive and v is not None:
+                if isinstance(v, dict):
+                    out[k] = _redact_dict_to_stars(v)
+                elif isinstance(v, list):
+                    out[k] = ["***" for _ in v]
+                else:
+                    out[k] = "***"
             else:
-                out[key] = "***"
+                out[k] = _redact(v, top_level=False)
+        return out
+    if isinstance(value, list):
+        return [_redact(item, top_level=False) for item in value]
+    return value
+
+
+def _redact_dict_to_stars(d: dict[str, Any]) -> dict[str, Any]:
+    """Recursively replace every leaf value with ``"***"`` while preserving
+    keys at every level so the redacted log still shows the call shape."""
+    out: dict[str, Any] = {}
+    for k, v in d.items():
+        if isinstance(v, dict):
+            out[k] = _redact_dict_to_stars(v)
+        elif isinstance(v, list):
+            out[k] = ["***" for _ in v]
         else:
-            out[key] = value
+            out[k] = "***"
     return out
 
 

--- a/src/nexus/remote/rpc_transport.py
+++ b/src/nexus/remote/rpc_transport.py
@@ -43,6 +43,47 @@ if TYPE_CHECKING:
 
 logger = logging.getLogger(__name__)
 
+# Param keys that carry credential material across the wire and must never
+# appear in DEBUG logs (Issue #4083 round-2 reviewer finding: mount_overrides
+# values were landing in support/debug logs). The redactor is method-agnostic
+# — it walks the params dict and replaces values for any matching top-level
+# key with a structure-preserving placeholder so we still see *which* mount
+# IDs and field names were sent.
+_SENSITIVE_PARAM_KEYS: frozenset[str] = frozenset(
+    {
+        "mount_overrides",
+        "injections",
+        "auth_token",
+        "api_key",
+        "credentials",
+    }
+)
+
+
+def _redact_params(params: Any) -> Any:
+    """Return a shallow copy of params with sensitive top-level keys redacted.
+
+    For dict-of-dicts shapes (mount_overrides: {mount_id: {field: value}})
+    we preserve the nested keys so the log still shows what fields were
+    supplied for which mount, but the values are replaced with "***".
+    """
+    if not isinstance(params, dict):
+        return params
+    out: dict[str, Any] = {}
+    for key, value in params.items():
+        if key in _SENSITIVE_PARAM_KEYS and value is not None:
+            if isinstance(value, dict):
+                out[key] = {
+                    k: (dict.fromkeys(v, "***") if isinstance(v, dict) else "***")
+                    for k, v in value.items()
+                }
+            else:
+                out[key] = "***"
+        else:
+            out[key] = value
+    return out
+
+
 _CHANNEL_OPTIONS = build_channel_options(
     keepalive_time_ms=30_000,
     keepalive_timeout_ms=10_000,
@@ -187,7 +228,7 @@ class RPCTransport:
         )
         timeout = read_timeout if read_timeout is not None else self._timeout
 
-        logger.debug("RPCTransport.call_rpc: %s params=%s", method, params)
+        logger.debug("RPCTransport.call_rpc: %s params=%s", method, _redact_params(params))
 
         try:
             response = self._stub.Call(request, timeout=timeout)

--- a/src/nexus/remote/tests/test_redact_params.py
+++ b/src/nexus/remote/tests/test_redact_params.py
@@ -1,4 +1,4 @@
-"""Test the RPC params redactor (Issue #4083 round-2)."""
+"""Tests for the recursive RPC params redactor (Issue #4083 rounds 2-3)."""
 
 from nexus.remote.rpc_transport import _redact_params
 
@@ -37,3 +37,48 @@ def test_redact_params_handles_none_mount_overrides() -> None:
 def test_redact_params_non_dict_passthrough() -> None:
     assert _redact_params("not a dict") == "not a dict"
     assert _redact_params(None) is None
+
+
+def test_redact_params_recurses_into_nested_headers() -> None:
+    """Round 3: real RPC params carry credentials in nested headers / env
+    dicts. The redactor must walk into them, not just hit top-level keys."""
+    p = {
+        "headers": {"Authorization": "Bearer LIVE-TOKEN", "X-Custom": "ok"},
+        "env": {"API_KEY": "LIVE", "PATH": "/usr/bin"},
+    }
+    out = _redact_params(p)
+    assert out["headers"]["Authorization"] == "***"
+    assert out["headers"]["X-Custom"] == "ok"
+    assert out["env"]["API_KEY"] == "***"
+    assert out["env"]["PATH"] == "/usr/bin"
+    assert "LIVE-TOKEN" not in str(out)
+    assert "LIVE" not in str(out)
+
+
+def test_redact_params_redacts_sandbox_and_nexus_api_keys() -> None:
+    """Round 3: sandbox_connect / sandbox_api_key / nexus_api_key params
+    were missed by the round-2 top-level allowlist."""
+    p = {"sandbox_api_key": "sandbox-LIVE", "nexus_api_key": "nexus-LIVE"}
+    out = _redact_params(p)
+    assert out["sandbox_api_key"] == "***"
+    assert out["nexus_api_key"] == "***"
+    assert "sandbox-LIVE" not in str(out)
+    assert "nexus-LIVE" not in str(out)
+
+
+def test_redact_params_recurses_into_lists() -> None:
+    """Lists of dicts (e.g., headers list) must be walked too."""
+    p = {"items": [{"api_key": "LIVE"}, {"name": "ok"}]}
+    out = _redact_params(p)
+    assert out["items"][0]["api_key"] == "***"
+    assert out["items"][1]["name"] == "ok"
+    assert "LIVE" not in str(out)
+
+
+def test_redact_params_does_not_mutate_input() -> None:
+    p: dict[str, object] = {"auth_token": "LIVE", "nested": {"api_key": "LIVE2"}}
+    _redact_params(p)
+    assert p["auth_token"] == "LIVE"
+    nested = p["nested"]
+    assert isinstance(nested, dict)
+    assert nested["api_key"] == "LIVE2"

--- a/src/nexus/remote/tests/test_redact_params.py
+++ b/src/nexus/remote/tests/test_redact_params.py
@@ -1,0 +1,39 @@
+"""Test the RPC params redactor (Issue #4083 round-2)."""
+
+from nexus.remote.rpc_transport import _redact_params
+
+
+def test_redact_params_passthrough_for_non_sensitive() -> None:
+    p = {"zone_id": "z1", "include_content": True}
+    assert _redact_params(p) == p
+
+
+def test_redact_params_strips_mount_overrides_values() -> None:
+    p = {
+        "bundle_path": "/tmp/x.nexus",
+        "mount_overrides": {
+            "m-1": {"access_key_id": "AKIA-LIVE", "secret_access_key": "wJalr-LIVE"},
+        },
+    }
+    out = _redact_params(p)
+    assert out["bundle_path"] == "/tmp/x.nexus"  # untouched
+    assert out["mount_overrides"]["m-1"]["access_key_id"] == "***"
+    assert out["mount_overrides"]["m-1"]["secret_access_key"] == "***"
+    assert "AKIA-LIVE" not in str(out)
+    assert "wJalr-LIVE" not in str(out)
+
+
+def test_redact_params_strips_auth_token_value() -> None:
+    out = _redact_params({"auth_token": "sk-secret-live"})
+    assert out["auth_token"] == "***"
+    assert "sk-secret-live" not in str(out)
+
+
+def test_redact_params_handles_none_mount_overrides() -> None:
+    out = _redact_params({"mount_overrides": None})
+    assert out["mount_overrides"] is None  # don't redact None
+
+
+def test_redact_params_non_dict_passthrough() -> None:
+    assert _redact_params("not a dict") == "not a dict"
+    assert _redact_params(None) is None

--- a/src/nexus/server/_rpc_params_generated.py
+++ b/src/nexus/server/_rpc_params_generated.py
@@ -352,6 +352,7 @@ class FederationExportZoneParams:
     strip_credentials: bool = False
     after_time: str | None = None
     before_time: str | None = None
+    include_mounts: bool = False
 
 
 @dataclass
@@ -368,6 +369,8 @@ class FederationImportZoneParams:
     rebuild_embeddings: bool = False
     injections: dict[str, str] | None = None
     require_no_placeholders: bool = True
+    restore_mounts: bool = True
+    mount_overrides: dict[str, dict[str, str]] | None = None
 
 
 @dataclass

--- a/src/nexus/server/api/v2/routers/connectors.py
+++ b/src/nexus/server/api/v2/routers/connectors.py
@@ -85,6 +85,12 @@ class MountResponse(BaseModel):
     mounted: bool
     mount_point: str
     error: str | None = None
+    # Issue #4083: surface persistence-step status separately from kernel
+    # mount activation. The kernel can be `mounted=True` while the
+    # MountManager save step failed — bundle export would then quietly
+    # miss this connector. Operators (and the CLI) need to see the gap.
+    persisted: bool | None = None
+    persist_warning: str | None = None
 
 
 class WriteRequest(BaseModel):
@@ -688,9 +694,16 @@ async def mount_connector(
         # can find it. `add_mount` only registers in the kernel runtime
         # mount table; without this, mounts created via the HTTP API
         # surface as `mount_count=0` in exports — silently invisible.
-        # Best-effort: a save_mount failure shouldn't roll back an
-        # already-active mount, but it does deserve a warning.
+        #
+        # We don't roll back the kernel mount on persist failure: the
+        # caller still gets a working live mount, just not a portable
+        # one. But the response carries `persisted` / `persist_warning`
+        # so the caller (and audit log) sees the gap explicitly rather
+        # than discovering it later via an empty bundle.
+        persisted: bool | None = None
+        persist_warning: str | None = None
         if getattr(mount_svc, "mount_manager", None) is not None:
+            persisted = False
             try:
                 await mount_svc.save_mount(
                     mount_point=req.mount_point,
@@ -698,24 +711,45 @@ async def mount_connector(
                     backend_config=req.config,
                     context=mount_context,
                 )
-            except ValueError:
-                # ValueError = already saved; idempotent retry on the
-                # same mount_point. Activation succeeded so we still
-                # return mounted=True — the persisted record is fine.
-                pass
+                persisted = True
+            except ValueError as dup_exc:
+                # ValueError can mean "mount_point already exists" (the
+                # idempotent-retry case we want to swallow) OR a real
+                # validation failure. Distinguish by message — if it
+                # doesn't look like an existence collision, surface as a
+                # warning so operators don't lose the signal.
+                msg = str(dup_exc).lower()
+                if "exist" in msg or "duplicate" in msg or "already" in msg:
+                    persisted = True  # already in store; treat as success
+                else:
+                    persist_warning = (
+                        f"Mount activated, but persistence rejected the "
+                        f"config: {dup_exc}. Bundle export will not include "
+                        f"this mount until the persistent record is fixed."
+                    )
+                    logger.warning(
+                        "Mount %s activated but save_mount rejected: %s",
+                        req.mount_point,
+                        dup_exc,
+                    )
             except Exception as persist_exc:
-                # Other failures (e.g., metastore write error). Log but
-                # don't fail the response — the kernel mount is live.
-                # Operators relying on portability will see this in logs.
-                import logging
-
-                logging.getLogger(__name__).warning(
-                    "Mount activated but config persistence failed for %s: %s",
+                persist_warning = (
+                    f"Mount activated, but persistence failed: {persist_exc}. "
+                    f"Bundle export will not include this mount until the "
+                    f"persistent record is fixed."
+                )
+                logger.warning(
+                    "Mount %s activated but persistence failed: %s",
                     req.mount_point,
                     persist_exc,
                 )
 
-        return MountResponse(mounted=True, mount_point=str(result))
+        return MountResponse(
+            mounted=True,
+            mount_point=str(result),
+            persisted=persisted,
+            persist_warning=persist_warning,
+        )
     except Exception as e:
         return MountResponse(mounted=False, mount_point=req.mount_point, error=str(e))
 

--- a/src/nexus/server/api/v2/routers/connectors.py
+++ b/src/nexus/server/api/v2/routers/connectors.py
@@ -682,6 +682,39 @@ async def mount_connector(
             context=mount_context,
         )
         _mount_types[req.mount_point] = req.connector_type
+
+        # Also persist the mount config via MountManager so the bundle
+        # exporter (`nexus zone export --include-mounts`, Issue #4083)
+        # can find it. `add_mount` only registers in the kernel runtime
+        # mount table; without this, mounts created via the HTTP API
+        # surface as `mount_count=0` in exports — silently invisible.
+        # Best-effort: a save_mount failure shouldn't roll back an
+        # already-active mount, but it does deserve a warning.
+        if getattr(mount_svc, "mount_manager", None) is not None:
+            try:
+                await mount_svc.save_mount(
+                    mount_point=req.mount_point,
+                    backend_type=req.connector_type,
+                    backend_config=req.config,
+                    context=mount_context,
+                )
+            except ValueError:
+                # ValueError = already saved; idempotent retry on the
+                # same mount_point. Activation succeeded so we still
+                # return mounted=True — the persisted record is fine.
+                pass
+            except Exception as persist_exc:
+                # Other failures (e.g., metastore write error). Log but
+                # don't fail the response — the kernel mount is live.
+                # Operators relying on portability will see this in logs.
+                import logging
+
+                logging.getLogger(__name__).warning(
+                    "Mount activated but config persistence failed for %s: %s",
+                    req.mount_point,
+                    persist_exc,
+                )
+
         return MountResponse(mounted=True, mount_point=str(result))
     except Exception as e:
         return MountResponse(mounted=False, mount_point=req.mount_point, error=str(e))
@@ -725,6 +758,24 @@ async def unmount_connector(
     try:
         await mount_svc.remove_mount(mount_point=req.mount_point)
         _mount_types.pop(req.mount_point, None)
+
+        # Mirror the dual-write from the mount handler: also drop the
+        # persisted MountManager record so the bundle exporter (Issue
+        # #4083) doesn't keep returning a stale entry for an unmounted
+        # path. Best-effort — kernel unmount succeeded, so we report
+        # success regardless.
+        if getattr(mount_svc, "mount_manager", None) is not None:
+            try:
+                await mount_svc.delete_saved_mount(mount_point=req.mount_point)
+            except Exception as persist_exc:
+                import logging
+
+                logging.getLogger(__name__).warning(
+                    "Mount removed from kernel but config persistence cleanup failed for %s: %s",
+                    req.mount_point,
+                    persist_exc,
+                )
+
         return MountResponse(mounted=False, mount_point=req.mount_point)
     except Exception as e:
         return MountResponse(mounted=False, mount_point=req.mount_point, error=str(e))

--- a/src/nexus/server/rpc/services/federation_rpc.py
+++ b/src/nexus/server/rpc/services/federation_rpc.py
@@ -239,6 +239,12 @@ class FederationRPCService(FederationRPCMixin):
             mount_overrides=mount_overrides,
         )
         result = service.import_zone(options)
+        # Surface errors and warnings over the wire so the CLI can
+        # exit non-zero (Issue #4083 reviewer finding: mount restore
+        # failures otherwise look like 'Import Complete'). Each
+        # ImportError is a small dataclass; serialize the relevant
+        # fields, not the object itself, to keep the RPC payload
+        # JSON-friendly.
         return {
             "target_zone": target_zone,
             "files_created": result.files_created,
@@ -246,6 +252,15 @@ class FederationRPCService(FederationRPCMixin):
             "files_skipped": result.files_skipped,
             "files_failed": result.files_failed,
             "permissions_imported": result.permissions_imported,
+            "errors": [
+                {
+                    "path": e.path,
+                    "error_type": e.error_type,
+                    "message": e.message,
+                }
+                for e in (result.errors or [])
+            ],
+            "warnings": list(result.warnings or []),
         }
 
     @staticmethod

--- a/src/nexus/server/rpc/services/federation_rpc.py
+++ b/src/nexus/server/rpc/services/federation_rpc.py
@@ -223,6 +223,21 @@ class FederationRPCService(FederationRPCMixin):
                 if "already" not in str(e).lower() and "exists" not in str(e).lower():
                     raise
         mount_manager = self._build_mount_manager(nx) if restore_mounts else None
+
+        # Server-side audit trail for mount credential injection
+        # (Issue #4083 round-2 reviewer finding). Log only mount IDs and
+        # field names — never values — so the operator action is
+        # captured for forensics without writing secrets to disk.
+        if mount_overrides:
+            import logging as _logging
+
+            _audit = _logging.getLogger("nexus.audit.federation")
+            _audit.warning(
+                "federation_import_zone: mount_overrides supplied for %d mount(s): %s",
+                len(mount_overrides),
+                {mid: sorted(fields.keys()) for mid, fields in mount_overrides.items()},
+            )
+
         service = ZoneImportService(nx, mount_manager=mount_manager)
         options = ZoneImportOptions(
             bundle_path=Path(bundle_path),

--- a/src/nexus/server/rpc/services/federation_rpc.py
+++ b/src/nexus/server/rpc/services/federation_rpc.py
@@ -98,6 +98,7 @@ class FederationRPCService(FederationRPCMixin):
         strip_credentials: bool = False,
         after_time: str | None = None,
         before_time: str | None = None,
+        include_mounts: bool = False,
     ) -> dict[str, Any]:
         """Export a raft-backed zone to a .nexus bundle on the server's
         filesystem.
@@ -115,6 +116,10 @@ class FederationRPCService(FederationRPCMixin):
         ``nexus archive create`` (#3793). Signing key is loaded from the
         server's ``~/.nexus/archive_signing_key`` (auto-generated on
         first use, TOFU trust model).
+
+        ``include_mounts`` (Issue #4083) opt-in serializes mount configs
+        into ``mounts.jsonl``; secret fields (per ConnectionArg.secret)
+        are replaced with ``${MOUNT_<id>_<FIELD>}`` placeholders.
         """
         from datetime import datetime
         from pathlib import Path
@@ -124,7 +129,8 @@ class FederationRPCService(FederationRPCMixin):
         nx = self._nexus_fs
         if nx is None:
             raise RuntimeError("federation_export_zone: no NexusFS attached")
-        service = ZoneExportService(nx)
+        mount_manager = self._build_mount_manager(nx) if include_mounts else None
+        service = ZoneExportService(nx, mount_manager=mount_manager)
         options = ZoneExportOptions(
             output_path=Path(output_path),
             include_content=include_content,
@@ -136,6 +142,7 @@ class FederationRPCService(FederationRPCMixin):
             strip_credentials=strip_credentials,
             after_time=datetime.fromisoformat(after_time) if after_time else None,
             before_time=datetime.fromisoformat(before_time) if before_time else None,
+            include_mounts=include_mounts,
         )
         manifest = service.export_zone(zone_id, options)
         return {
@@ -144,6 +151,7 @@ class FederationRPCService(FederationRPCMixin):
             "file_count": manifest.file_count,
             "total_size_bytes": manifest.total_size_bytes,
             "bundle_id": manifest.bundle_id,
+            "mount_count": manifest.mount_count,
         }
 
     @rpc_expose(admin_only=True)
@@ -159,6 +167,8 @@ class FederationRPCService(FederationRPCMixin):
         rebuild_embeddings: bool = False,
         injections: dict[str, str] | None = None,
         require_no_placeholders: bool = True,
+        restore_mounts: bool = True,
+        mount_overrides: dict[str, dict[str, str]] | None = None,
     ) -> dict[str, Any]:
         """Import a zone bundle from the server's filesystem.
 
@@ -169,6 +179,11 @@ class FederationRPCService(FederationRPCMixin):
         The ``force``/``rebuild_embeddings``/``injections``/
         ``require_no_placeholders`` parameters drive the v2 archive
         restore features used by ``nexus archive restore`` (#3793).
+
+        ``restore_mounts``/``mount_overrides`` (Issue #4083): when the
+        bundle contains ``mounts.jsonl``, every redacted field requires
+        a value in ``mount_overrides[mount_id][field_name]`` or the
+        import raises ``MissingCredentialsError`` before any side effect.
         """
         from pathlib import Path
 
@@ -207,7 +222,8 @@ class FederationRPCService(FederationRPCMixin):
             except Exception as e:
                 if "already" not in str(e).lower() and "exists" not in str(e).lower():
                     raise
-        service = ZoneImportService(nx)
+        mount_manager = self._build_mount_manager(nx) if restore_mounts else None
+        service = ZoneImportService(nx, mount_manager=mount_manager)
         options = ZoneImportOptions(
             bundle_path=Path(bundle_path),
             target_zone_id=target_zone,
@@ -219,6 +235,8 @@ class FederationRPCService(FederationRPCMixin):
             rebuild_embeddings=rebuild_embeddings,
             injections=injections or {},
             require_no_placeholders=require_no_placeholders,
+            restore_mounts=restore_mounts,
+            mount_overrides=mount_overrides,
         )
         result = service.import_zone(options)
         return {
@@ -229,6 +247,22 @@ class FederationRPCService(FederationRPCMixin):
             "files_failed": result.files_failed,
             "permissions_imported": result.permissions_imported,
         }
+
+    @staticmethod
+    def _build_mount_manager(nx: Any) -> Any:
+        """Construct a MountManager from a NexusFS handle.
+
+        Mirrors the wiring in factory/_wired.py — MetastoreMountStore
+        writes through public VFS syscalls, so a live NexusFS is the only
+        dependency. Built lazily because the federation RPC service does
+        not normally hold a MountManager handle (it doesn't take one in
+        __init__), and we only need it when the caller opted into mount
+        export / import.
+        """
+        from nexus.bricks.mount.metastore_mount_store import MetastoreMountStore
+        from nexus.bricks.mount.mount_manager import MountManager
+
+        return MountManager(MetastoreMountStore(nx))
 
     # ── Zone lifecycle ─────────────────────────────────────────────
 

--- a/src/nexus/server/rpc/services/federation_rpc.py
+++ b/src/nexus/server/rpc/services/federation_rpc.py
@@ -225,15 +225,19 @@ class FederationRPCService(FederationRPCMixin):
         mount_manager = self._build_mount_manager(nx) if restore_mounts else None
 
         # Server-side audit trail for mount credential injection
-        # (Issue #4083 round-2 reviewer finding). Log only mount IDs and
-        # field names — never values — so the operator action is
-        # captured for forensics without writing secrets to disk.
+        # (Issue #4083 rounds 2/4). Log only mount IDs and field names —
+        # never values — so the operator action is captured for
+        # forensics without writing secrets to disk. Round-4 reviewer
+        # noted the previous "nexus.audit.federation" logger was an
+        # orphan with no configured handler. Use this module's logger
+        # at WARNING so the event lands in the normal server log
+        # (always captured). If a future durable audit sink is wired,
+        # this is the obvious callsite to redirect.
         if mount_overrides:
             import logging as _logging
 
-            _audit = _logging.getLogger("nexus.audit.federation")
-            _audit.warning(
-                "federation_import_zone: mount_overrides supplied for %d mount(s): %s",
+            _logging.getLogger(__name__).warning(
+                "AUDIT federation_import_zone: mount_overrides supplied for %d mount(s): %s",
                 len(mount_overrides),
                 {mid: sorted(fields.keys()) for mid, fields in mount_overrides.items()},
             )


### PR DESCRIPTION
## Summary

Implements the typed redaction contract for `bricks/portability/` from issue #4083:

- **Single source of truth**: redaction set derived from each connector's existing `ConnectionArg.secret=True` flag — no parallel `redacted_fields` list.
- **Heuristic CI gate**: parametrized test over `CONNECTOR_MANIFEST` fails any backend with a secret-shaped argument name (`(?i)key|secret|token|password|cred`) not marked `secret=True`. New `audit_safe=True` escape hatch for justified false positives (e.g. `token_manager_db` is a DB path, not a token).
- **Mount export**: opt-in `ZoneExportOptions.include_mounts=True` writes `mounts.jsonl` with secrets replaced by `\${MOUNT_<id>_<FIELD>}` placeholders. Audit failures abort export before any bytes are written. `mounts.jsonl` is registered in `BundleChecksums` so tampering is detected by integrity verification.
- **Mount import**: forced credential re-injection via `ZoneImportOptions.mount_overrides`. `MissingCredentialsError` reports every gap in one error, raised **before any backend is initialized**. Restore order is shallow→deep so parents land first. SKIP/OVERWRITE/FAIL conflict modes.
- **Bundle format**: `BUNDLE_FORMAT_VERSION` bumped `2.0.0` → `3.0.0`; new `manifest-v3.json` schema; v1/v2 bundles still import unchanged.
- **Security pass**: `ZoneImportOptions.to_dict()` redacts `mount_overrides` values to `\"***\"` so the live credentials we just protected don't leak via audit/telemetry serialization.

Spec: \`docs/superpowers/specs/2026-05-09-portability-redacted-fields-design.md\`
Plan: \`docs/superpowers/plans/2026-05-09-portability-redacted-fields.md\`

## Test plan

- [x] All portability tests pass (130 passed, 8 skipped — optional-extra connectors)
- [x] CI audit gate passes for every registered connector
- [x] Roundtrip integration test (\`test_roundtrip_with_mounts.py\`) asserts live secrets never appear in bundle bytes
- [x] v2 bundle import still works (\`test_import_v2_bundle_no_mounts_jsonl_does_nothing\`)
- [x] Import without overrides raises \`MissingCredentialsError\` before any \`save_mount\` call
- [x] \`mounts.jsonl\` checksum present in manifest after export

Closes #4083