### PR TITLE
[codex] fix review follow-ups

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1047,16 +1047,11 @@ ignore_imports = [
     # chunked_upload protocol TYPE_CHECKING import for UploadSession return type
     "nexus.contracts.protocols.chunked_upload -> nexus.bricks.upload.upload_session",
     # --- contracts importing lib (upward — legacy, to be fixed) ---
-    "nexus.contracts.agent_utils -> nexus.storage.models",
     "nexus.contracts -> nexus.lib.validators",
     "nexus.contracts.deployment_profile -> nexus.lib.performance_tuning",
     "nexus.contracts.types -> nexus.storage.read_set",
     # WirableFS TYPE_CHECKING imports (cross-tier wiring contract, #2359)
     "nexus.contracts.wirable_fs -> nexus.storage.record_store",
-    # --- lib importing services (upward — legacy, to be fixed) ---
-    "nexus.lib.permission_utils -> nexus.services.gateway",
-    # --- kernel (core) importing bricks ---
-    "nexus.core.config -> nexus.bricks.workflows.protocol",
     # --- services importing bricks ---
     "nexus.services.workspace.workspace_rpc_service -> nexus.bricks.workspace.workspace_registry",
     "nexus.services.lifecycle.workflow_dispatch_service -> nexus.bricks.workflows.protocol",

--- a/src/nexus/bricks/search/indexing_service.py
+++ b/src/nexus/bricks/search/indexing_service.py
@@ -569,15 +569,28 @@ class IndexingService:
         if not paths:
             return {}
         unique_paths = list(dict.fromkeys(paths))
-        rows: list[Any] = []
+        rows_by_path: dict[str, list[Any]] = {}
         for start in range(0, len(unique_paths), _QUERY_FILE_MODELS_BATCH_SIZE):
             batch = unique_paths[start : start + _QUERY_FILE_MODELS_BATCH_SIZE]
             stmt = select(FilePathModel).where(
                 FilePathModel.virtual_path.in_(batch),
                 FilePathModel.deleted_at.is_(None),
             )
-            rows.extend(session.execute(stmt).scalars().all())
-        return {str(row.virtual_path): row for row in rows}
+            for row in session.execute(stmt).scalars().all():
+                rows_by_path.setdefault(str(row.virtual_path), []).append(row)
+
+        result: dict[str, Any] = {}
+        for path, rows in rows_by_path.items():
+            if len(rows) == 1:
+                result[path] = rows[0]
+                continue
+            zones = sorted(str(getattr(row, "zone_id", "<unknown>")) for row in rows)
+            logger.warning(
+                "[INDEXING-SVC] Skipping %s: ambiguous file_paths rows across zones %s",
+                path,
+                zones,
+            )
+        return result
 
     def _directory_read_concurrency(self) -> int:
         configured = getattr(self._pipeline, "_max_concurrency", None)

--- a/src/nexus/bricks/search/indexing_service.py
+++ b/src/nexus/bricks/search/indexing_service.py
@@ -12,6 +12,7 @@ Key design decisions:
   - Comprehensive error handling with structured logging
 """
 
+import asyncio
 import hashlib
 import logging
 import posixpath
@@ -42,6 +43,9 @@ from nexus.bricks.search.models import DocumentChunkModel, FilePathModel
 from nexus.bricks.search.protocols import FileReaderProtocol
 
 logger = logging.getLogger(__name__)
+
+_DEFAULT_DIRECTORY_READ_CONCURRENCY = 10
+_QUERY_FILE_MODELS_BATCH_SIZE = 500
 
 
 def _looks_like_virtual_readme(path: str) -> bool:
@@ -390,48 +394,83 @@ class IndexingService:
         files_result = await self._file_reader.list_files(path, recursive=True)
         files = files_result.items if hasattr(files_result, "items") else files_result
 
-        # Build (path, content, path_id) tuples, skipping binary files.
-        documents: list[tuple[str, str, str]] = []
+        candidate_paths: list[str] = []
+        for entry in files:
+            file_path = entry if isinstance(entry, str) else entry.get("name", "")
+            if not file_path or file_path.endswith("/"):
+                continue
+            if file_path.endswith(_BINARY_EXTENSIONS):
+                continue
+            candidate_paths.append(file_path)
+
+        if not candidate_paths:
+            return {}
 
         with self._get_session() as session:
-            for entry in files:
-                file_path = entry if isinstance(entry, str) else entry.get("name", "")
-                if not file_path or file_path.endswith("/"):
-                    continue
-                if file_path.endswith(_BINARY_EXTENSIONS):
-                    continue
+            file_models_by_path = self._query_file_models(session, candidate_paths)
 
-                try:
-                    content = await self._read_content(file_path)
-                    file_model = self._query_file_model(session, file_path)
-                    if file_model is not None:
-                        documents.append(
-                            (file_path, content, file_model.path_id),
-                        )
-                    elif _looks_like_virtual_readme(file_path):
-                        # Issue #3728: virtual ``.readme/`` overlay paths
-                        # are served from class metadata at read time.  The
-                        # chunk tables still enforce a FK to file_paths, so
-                        # persist a minimal deterministic row before handing
-                        # the document to the indexing pipeline.
-                        #
-                        # Known limitation: when the connector class
-                        # metadata changes (e.g. a nexus upgrade), the
-                        # synthetic path_id stays the same but the
-                        # embeddings become stale.  Users need to
-                        # re-trigger indexing (remount) to refresh.
+        paths_to_read = [
+            file_path
+            for file_path in candidate_paths
+            if file_path in file_models_by_path or _looks_like_virtual_readme(file_path)
+        ]
+        if not paths_to_read:
+            return {}
+
+        read_concurrency = self._directory_read_concurrency()
+        semaphore = asyncio.Semaphore(read_concurrency)
+
+        async def _read_one(file_path: str) -> tuple[str, str] | None:
+            try:
+                async with semaphore:
+                    return file_path, await self._read_content(file_path)
+            except Exception:
+                logger.warning(
+                    "[INDEXING-SVC] Skipping %s: failed to read or resolve",
+                    file_path,
+                    exc_info=True,
+                )
+                return None
+
+        read_results = await asyncio.gather(*(_read_one(file_path) for file_path in paths_to_read))
+        content_by_path = {
+            file_path: content
+            for result in read_results
+            if result is not None
+            for file_path, content in [result]
+        }
+
+        documents: list[tuple[str, str, str]] = []
+        virtual_readmes: list[tuple[str, str]] = []
+        for file_path in candidate_paths:
+            if file_path not in content_by_path:
+                continue
+            content = content_by_path[file_path]
+            file_model = file_models_by_path.get(file_path)
+            if file_model is not None:
+                documents.append((file_path, content, file_model.path_id))
+            elif _looks_like_virtual_readme(file_path):
+                virtual_readmes.append((file_path, content))
+
+        if virtual_readmes:
+            with self._get_session() as session:
+                for file_path, content in virtual_readmes:
+                    try:
+                        # Issue #3728: virtual ``.readme/`` overlay paths are served
+                        # from class metadata at read time, so synthesize the FK row
+                        # before handing the document to the indexing pipeline.
                         virtual_model = self._ensure_virtual_readme_file_model(
                             session,
                             file_path,
                             content,
                         )
                         documents.append((file_path, content, virtual_model.path_id))
-                except Exception:
-                    logger.warning(
-                        "[INDEXING-SVC] Skipping %s: failed to read or resolve",
-                        file_path,
-                        exc_info=True,
-                    )
+                    except Exception:
+                        logger.warning(
+                            "[INDEXING-SVC] Skipping %s: failed to read or resolve",
+                            file_path,
+                            exc_info=True,
+                        )
 
         if not documents:
             return {}
@@ -520,6 +559,31 @@ class IndexingService:
             FilePathModel.deleted_at.is_(None),
         )
         return session.execute(stmt).scalar_one_or_none()
+
+    @staticmethod
+    def _query_file_models(
+        session: Any,
+        paths: list[str],
+    ) -> dict[str, Any]:
+        """Query file rows for many virtual paths in one round trip."""
+        if not paths:
+            return {}
+        unique_paths = list(dict.fromkeys(paths))
+        rows: list[Any] = []
+        for start in range(0, len(unique_paths), _QUERY_FILE_MODELS_BATCH_SIZE):
+            batch = unique_paths[start : start + _QUERY_FILE_MODELS_BATCH_SIZE]
+            stmt = select(FilePathModel).where(
+                FilePathModel.virtual_path.in_(batch),
+                FilePathModel.deleted_at.is_(None),
+            )
+            rows.extend(session.execute(stmt).scalars().all())
+        return {str(row.virtual_path): row for row in rows}
+
+    def _directory_read_concurrency(self) -> int:
+        configured = getattr(self._pipeline, "_max_concurrency", None)
+        if isinstance(configured, int) and configured > 0:
+            return configured
+        return _DEFAULT_DIRECTORY_READ_CONCURRENCY
 
     @staticmethod
     def _count_chunks(session: Any, path_id: str) -> int:

--- a/src/nexus/factory/adapters.py
+++ b/src/nexus/factory/adapters.py
@@ -245,6 +245,15 @@ class _NexusFSFileReader:
             return await result
         return result
 
+    async def _sys_readdir(self, path: str, **kwargs: Any) -> Any:
+        readdir_fn = self._nx.sys_readdir
+        if inspect.iscoroutinefunction(readdir_fn):
+            return await readdir_fn(path, **kwargs)
+        result = await asyncio.to_thread(readdir_fn, path, **kwargs)
+        if inspect.isawaitable(result):
+            return await result
+        return result
+
     async def read_text(self, path: str) -> str:
         # Read with admin context so the search daemon can index all files
         # regardless of per-user ReBAC permissions.
@@ -356,7 +365,7 @@ class _NexusFSFileReader:
             is_admin=True,
             is_system=True,
         )
-        result = self._nx.sys_readdir(path, recursive=recursive, context=admin_ctx)
+        result = await self._sys_readdir(path, recursive=recursive, context=admin_ctx)
         items: list[Any] = result.items if hasattr(result, "items") else result
         return items
 

--- a/src/nexus/task_manager/dispatch_consumer.py
+++ b/src/nexus/task_manager/dispatch_consumer.py
@@ -80,6 +80,7 @@ class TaskDispatchPipeConsumer:
         acp_service: Any | None = None,
         agent_registry: Any | None = None,
         llm_fn: LLMCallable | None = None,
+        max_worker_starts: int = 16,
     ) -> None:
         self._nx: NexusFS | None = None
         self._task_svc: TaskManagerService | None = None
@@ -88,6 +89,10 @@ class TaskDispatchPipeConsumer:
         self._llm_fn: LLMCallable = llm_fn or _no_llm  # used by copilot review
         self._pipe_ready = False
         self._consumer_task: asyncio.Task[None] | None = None
+        self._max_worker_starts = max(1, max_worker_starts)
+        self._worker_start_semaphore: asyncio.Semaphore | None = None
+        self._worker_tasks: set[asyncio.Task[None]] = set()
+        self._worker_task_ids: set[str] = set()
 
     # ------------------------------------------------------------------
     # Deferred injection
@@ -163,6 +168,13 @@ class TaskDispatchPipeConsumer:
                 await self._consumer_task
 
             self._consumer_task = None
+
+        if self._worker_tasks:
+            for task in list(self._worker_tasks):
+                task.cancel()
+            await asyncio.gather(*self._worker_tasks, return_exceptions=True)
+            self._worker_tasks.clear()
+            self._worker_task_ids.clear()
 
         self._pipe_ready = False
         logger.info("[TASK-DISPATCH] pipe consumer stopped")
@@ -472,5 +484,47 @@ and apply the final task status from your DECISION line.
         for task in dispatchable:
             tid = task.get("id", "?")
             logger.info("[TASK-DISPATCH] unblocked: dispatching task %s", tid)
-            # Schedule worker start as a separate task to avoid blocking the consumer
-            asyncio.create_task(self._start_worker(tid))
+            self._schedule_worker_start(tid)
+
+    def _get_worker_start_semaphore(self) -> asyncio.Semaphore:
+        if self._worker_start_semaphore is None:
+            self._worker_start_semaphore = asyncio.Semaphore(self._max_worker_starts)
+        return self._worker_start_semaphore
+
+    def _schedule_worker_start(self, task_id: str) -> None:
+        if task_id in self._worker_task_ids:
+            logger.debug("[TASK-DISPATCH] worker start already scheduled for task %s", task_id)
+            return
+
+        self._worker_task_ids.add(task_id)
+        task = asyncio.create_task(self._run_scheduled_worker(task_id))
+        self._worker_tasks.add(task)
+
+        def _discard_done(done: asyncio.Task[None]) -> None:
+            self._on_worker_task_done(task_id, done)
+
+        task.add_done_callback(_discard_done)
+
+    async def _run_scheduled_worker(self, task_id: str) -> None:
+        try:
+            async with self._get_worker_start_semaphore():
+                await self._start_worker(task_id)
+        finally:
+            current = asyncio.current_task()
+            if current is not None:
+                self._worker_tasks.discard(current)
+            self._worker_task_ids.discard(task_id)
+
+    def _on_worker_task_done(self, task_id: str, task: asyncio.Task[None]) -> None:
+        self._worker_tasks.discard(task)
+        self._worker_task_ids.discard(task_id)
+        if task.cancelled():
+            return
+        exc = task.exception()
+        if exc is not None:
+            logger.error(
+                "[TASK-DISPATCH] scheduled worker task failed for %s: %s",
+                task_id,
+                exc,
+                exc_info=(type(exc), exc, exc.__traceback__),
+            )

--- a/tests/integration/bricks/search/test_indexing_service.py
+++ b/tests/integration/bricks/search/test_indexing_service.py
@@ -52,6 +52,9 @@ def _mock_session(
     scalar_result = MagicMock()
     scalar_result.scalar_one_or_none.return_value = file_model
     scalar_result.scalar.return_value = chunk_count
+    scalar_result.scalars.return_value.all.return_value = (
+        [file_model] if file_model is not None else []
+    )
     session.execute.return_value = scalar_result
 
     # session.get() used in step 5 to retrieve updated file_model
@@ -88,6 +91,7 @@ def _mock_file_reader(
     reader.read_text = AsyncMock(return_value=content)
     reader.get_searchable_text.return_value = searchable_text
     reader.list_files = AsyncMock(return_value=file_list or [])
+    reader.has_successful_parse = None
 
     return reader
 
@@ -523,7 +527,13 @@ class TestIndexDirectory:
     @pytest.mark.asyncio
     async def test_index_directory_builds_doc_list_and_delegates(self) -> None:
         """list_files returns 3 files; pipeline.index_documents receives 3 tuples."""
-        file_model = _mock_file_model(path_id="pid-x")
+        file_models = [
+            _mock_file_model(path_id="pid-a", virtual_path="a.py"),
+            _mock_file_model(path_id="pid-b", virtual_path="b.py"),
+            _mock_file_model(path_id="pid-c", virtual_path="c.py"),
+        ]
+        session = _mock_session(file_model=file_models[0])
+        session.execute.return_value.scalars.return_value.all.return_value = file_models
         pipeline = _mock_pipeline()
         pipeline.index_documents.return_value = [
             IndexResult(path="a.py", chunks_indexed=2),
@@ -533,7 +543,7 @@ class TestIndexDirectory:
 
         service, _, session, _ = _build_service(
             pipeline=pipeline,
-            file_model=file_model,
+            session=session,
             file_list=["a.py", "b.py", "c.py"],
             content="some content",
             searchable_text=None,
@@ -550,10 +560,63 @@ class TestIndexDirectory:
         pipeline.index_documents.assert_awaited_once()
         docs_arg = pipeline.index_documents.call_args[0][0]
         assert len(docs_arg) == 3
-        # Each tuple is (path, content, path_id)
-        for _path, content, path_id in docs_arg:
+        assert session.execute.call_count == 1
+        expected_path_ids = {"a.py": "pid-a", "b.py": "pid-b", "c.py": "pid-c"}
+        for path, content, path_id in docs_arg:
             assert content == "some content"
-            assert path_id == "pid-x"
+            assert path_id == expected_path_ids[path]
+
+    @pytest.mark.asyncio
+    async def test_index_directory_reads_file_content_with_bounded_concurrency(self) -> None:
+        file_models = [
+            _mock_file_model(path_id=f"pid-{idx}", virtual_path=f"file{idx}.py") for idx in range(4)
+        ]
+        session = _mock_session(file_model=file_models[0])
+        session.execute.return_value.scalars.return_value.all.return_value = file_models
+        pipeline = _mock_pipeline()
+        pipeline._max_concurrency = 2
+        pipeline.index_documents.return_value = [
+            IndexResult(path=model.virtual_path, chunks_indexed=1) for model in file_models
+        ]
+        file_reader = _mock_file_reader(
+            session,
+            file_list=[model.virtual_path for model in file_models],
+            searchable_text=None,
+        )
+
+        active_reads = 0
+        max_active_reads = 0
+
+        async def _read_text(path: str) -> str:
+            nonlocal active_reads, max_active_reads
+            active_reads += 1
+            max_active_reads = max(max_active_reads, active_reads)
+            await asyncio.sleep(0.01)
+            active_reads -= 1
+            return f"content for {path}"
+
+        file_reader.read_text = AsyncMock(side_effect=_read_text)
+        service, _, _, _ = _build_service(
+            pipeline=pipeline,
+            file_reader=file_reader,
+            session=session,
+        )
+
+        await service.index_directory("/")
+
+        assert max_active_reads == 2
+        assert session.execute.call_count == 1
+
+    def test_query_file_models_chunks_large_path_sets(self) -> None:
+        session = MagicMock()
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = []
+        session.execute.return_value = result
+
+        paths = [f"/file-{idx}.txt" for idx in range(1001)]
+
+        assert IndexingService._query_file_models(session, paths) == {}
+        assert session.execute.call_count == 3
 
 
 class TestVirtualReadmeIndexing:

--- a/tests/integration/bricks/search/test_indexing_service.py
+++ b/tests/integration/bricks/search/test_indexing_service.py
@@ -618,6 +618,30 @@ class TestIndexDirectory:
         assert IndexingService._query_file_models(session, paths) == {}
         assert session.execute.call_count == 3
 
+    def test_query_file_models_skips_ambiguous_paths_across_zones(self) -> None:
+        root_model = _mock_file_model(path_id="root-path", virtual_path="/shared/report.md")
+        root_model.zone_id = "root"
+        other_zone_model = _mock_file_model(path_id="other-path", virtual_path="/shared/report.md")
+        other_zone_model.zone_id = "other-zone"
+        unique_model = _mock_file_model(path_id="unique-path", virtual_path="/shared/unique.md")
+        unique_model.zone_id = "root"
+
+        session = MagicMock()
+        result = MagicMock()
+        result.scalars.return_value.all.return_value = [
+            root_model,
+            other_zone_model,
+            unique_model,
+        ]
+        session.execute.return_value = result
+
+        rows = IndexingService._query_file_models(
+            session,
+            ["/shared/report.md", "/shared/unique.md"],
+        )
+
+        assert rows == {"/shared/unique.md": unique_model}
+
 
 class TestVirtualReadmeIndexing:
     """Issue #3728: virtual ``.readme/`` overlay paths have no

--- a/tests/unit/core/test_import_boundaries.py
+++ b/tests/unit/core/test_import_boundaries.py
@@ -182,6 +182,19 @@ class TestImportLinterPackageCoverage:
         }
         assert expected <= covered
 
+    def test_four_tier_layers_baseline_does_not_keep_removed_imports(self):
+        pyproject = tomllib.loads((PROJECT_ROOT / "pyproject.toml").read_text(encoding="utf-8"))
+        contracts = pyproject["tool"]["importlinter"]["contracts"]
+        contract = next((c for c in contracts if c.get("id") == "four-tier-layers"), None)
+        assert contract is not None
+
+        stale_ignores = {
+            "nexus.contracts.agent_utils -> nexus.storage.models",
+            "nexus.lib.permission_utils -> nexus.services.gateway",
+            "nexus.core.config -> nexus.bricks.workflows.protocol",
+        }
+        assert stale_ignores.isdisjoint(set(contract.get("ignore_imports", [])))
+
 
 class TestTypingPackageMarker:
     """Packaging metadata must match PEP 561 typed-package marker requirements."""

--- a/tests/unit/factory/test_adapters.py
+++ b/tests/unit/factory/test_adapters.py
@@ -51,6 +51,22 @@ class TestNexusFSFileReader:
         assert await task == b"hello"
 
     @pytest.mark.asyncio
+    async def test_list_files_does_not_block_event_loop_during_sys_readdir(self) -> None:
+        class BlockingNx:
+            def sys_readdir(self, _path: str, **_kwargs: object) -> list[str]:
+                time.sleep(0.2)
+                return ["/a.txt", "/b.txt"]
+
+        reader = _NexusFSFileReader(BlockingNx())
+
+        task = asyncio.create_task(reader.list_files("/"))
+        start = time.perf_counter()
+        await asyncio.sleep(0.02)
+
+        assert time.perf_counter() - start < 0.12
+        assert await task == ["/a.txt", "/b.txt"]
+
+    @pytest.mark.asyncio
     async def test_read_text_bytes_decoded(self) -> None:
         nx = MagicMock()
         nx.sys_read = MagicMock(return_value=b"hello world")

--- a/tests/unit/task_manager/test_dispatch_consumer.py
+++ b/tests/unit/task_manager/test_dispatch_consumer.py
@@ -93,6 +93,14 @@ class _FakeTaskService:
         return list(self.comments)
 
 
+class _FakeDispatchableTaskService:
+    def __init__(self, task_ids: list[str]) -> None:
+        self.task_ids = task_ids
+
+    async def list_dispatchable_tasks(self) -> list[dict[str, str]]:
+        return [{"id": task_id} for task_id in self.task_ids]
+
+
 class _FakeAcpService:
     def __init__(self, *results: AcpCallResult) -> None:
         self._results = list(results)
@@ -196,6 +204,57 @@ async def test_copilot_review_records_feedback_and_rejects_in_process() -> None:
     assert task_service.task["status"] == "failed"
     assert "curl -X" not in acp_service.calls[0]["prompt"]
     assert "Authorization:" not in acp_service.calls[0]["prompt"]
+
+
+@pytest.mark.asyncio
+async def test_dispatch_unblocked_tasks_tracks_worker_tasks_until_completion() -> None:
+    release = asyncio.Event()
+    started: list[str] = []
+
+    consumer = TaskDispatchPipeConsumer()
+    consumer.set_task_service(cast(Any, _FakeDispatchableTaskService(["task-a", "task-b"])))
+
+    async def _start_worker(task_id: str) -> None:
+        started.append(task_id)
+        await release.wait()
+
+    consumer._start_worker = _start_worker
+
+    await consumer._dispatch_unblocked_tasks()
+    await asyncio.sleep(0)
+
+    try:
+        assert set(started) == {"task-a", "task-b"}
+        assert len(consumer._worker_tasks) == 2
+    finally:
+        release.set()
+        await asyncio.sleep(0)
+
+    assert not consumer._worker_tasks
+
+
+@pytest.mark.asyncio
+async def test_dispatch_unblocked_tasks_bounds_concurrent_worker_starts() -> None:
+    consumer = TaskDispatchPipeConsumer(max_worker_starts=1)
+    consumer.set_task_service(cast(Any, _FakeDispatchableTaskService(["task-a", "task-b"])))
+
+    active = 0
+    max_active = 0
+
+    async def _start_worker(task_id: str) -> None:  # noqa: ARG001
+        nonlocal active, max_active
+        active += 1
+        max_active = max(max_active, active)
+        await asyncio.sleep(0.01)
+        active -= 1
+
+    consumer._start_worker = _start_worker
+
+    await consumer._dispatch_unblocked_tasks()
+    while consumer._worker_tasks:
+        await asyncio.sleep(0.001)
+
+    assert max_active == 1
 
 
 def test_bricks_module_aliases_live_dispatch_consumer() -> None:


### PR DESCRIPTION
## Summary
- Offload sync `sys_readdir` calls from the search file-reader adapter to avoid blocking the event loop.
- Batch directory indexing metadata lookups, chunk large path sets, and read file contents with bounded concurrency.
- Track and bound task dispatch worker-start tasks, with cleanup on stop and async failure logging.
- Remove stale import-linter baseline entries and add regression coverage for these review findings.

## Notes
- Branch is rebased onto current `origin/develop` (`46ec69564`).
- This branch also carries the existing `docs(#4058): TODO markers for upcoming tasks in _read_batch` commit that was already present after the earlier rebase.

## Validation
- `uv run --group dev pytest tests/unit/factory/test_adapters.py tests/integration/bricks/search/test_indexing_service.py tests/unit/task_manager/test_dispatch_consumer.py tests/unit/core/test_import_boundaries.py::TestImportLinterPackageCoverage -q`
- `uv run --with ruff ruff check src/nexus/factory/adapters.py src/nexus/bricks/search/indexing_service.py src/nexus/task_manager/dispatch_consumer.py tests/unit/factory/test_adapters.py tests/integration/bricks/search/test_indexing_service.py tests/unit/task_manager/test_dispatch_consumer.py tests/unit/core/test_import_boundaries.py`
- `uv run --group dev lint-imports --config pyproject.toml`
- `git diff --check origin/develop...HEAD`
