### PR TITLE
[codex] Add FUSE passthrough for large reads

### DIFF
--- a/docs/superpowers/plans/2026-05-12-issue-4060-fuse-passthrough.md
+++ b/docs/superpowers/plans/2026-05-12-issue-4060-fuse-passthrough.md
@@ -1,0 +1,2456 @@
+# Issue #4060 FUSE Passthrough Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add opt-in Linux FUSE passthrough for eligible large reads across direct Rust mounts and Python `use_rust=True` orchestration while preserving hook-sensitive fallbacks.
+
+**Architecture:** Upgrade `nexus-fuse` to a passthrough-capable `fuser`, then keep passthrough concerns in focused Rust modules for config parsing, eligibility, backing-file materialization, and open-handle lifecycle. The direct Rust mount owns FUSE passthrough; Python remains the orchestration layer and launches the Rust-owned mount only when passthrough is requested and the mount is a remote, raw, hook-safe mount. Existing Python FUSE plus Rust IPC daemon remains the fallback path.
+
+**Tech Stack:** Rust 2021, `fuser 0.17`, Linux FUSE passthrough, `globset`, `sha2`, existing `reqwest`/`foyer` cache helpers, Python 3.11+, `subprocess`, `pytest`, `cargo test`, Linux-gated FUSE integration tests.
+
+---
+
+## File Structure
+
+| Path | Change | Responsibility |
+| --- | --- | --- |
+| `nexus-fuse/Cargo.toml` | modify | Upgrade `fuser`, add `globset`, `sha2`, and `hex` for passthrough policy and stable backing keys. |
+| `nexus-fuse/src/lib.rs` | modify | Export the new `passthrough` module. |
+| `nexus-fuse/src/passthrough/mod.rs` | create | Public module boundary for config, policy, backing store, and manager. |
+| `nexus-fuse/src/passthrough/config.rs` | create | CLI/env-ready passthrough config, pattern parsing, threshold defaults, and Linux support detection helpers. |
+| `nexus-fuse/src/passthrough/policy.rs` | create | Eligibility decisions for path patterns, file metadata, access mode, and threshold. |
+| `nexus-fuse/src/passthrough/backing.rs` | create | Materialize immutable local backing files, verify size/etag, and invalidate path-keyed files on mutation. |
+| `nexus-fuse/src/passthrough/manager.rs` | create | Coordinate policy, backing store, active open handles, and fuser backing registration. |
+| `nexus-fuse/src/fs.rs` | modify | Use `&self` filesystem callbacks after the fuser upgrade; call passthrough from `open`; clean handles from `release`; invalidate backing files on writes/deletes/renames/truncates. |
+| `nexus-fuse/src/main.rs` | modify | Add passthrough flags/env vars, build config, pass manager into direct Rust mount, and preserve daemon behavior. |
+| `nexus-fuse/benches/passthrough_read.rs` | create | Criterion-compatible sequential read benchmark harness and documented command for the 1 GiB target. |
+| `src/nexus/fuse/passthrough.py` | create | Python passthrough options, environment parsing, hook-safety snapshot, and Rust mount process launcher. |
+| `src/nexus/fuse/mount.py` | modify | Add public passthrough constructor/function options and route eligible `use_rust=True` mounts to the Rust-owned mount process. |
+| `tests/unit/fuse/test_passthrough_options.py` | create | Python env parsing, command building, fallback, and hook-safety tests. |
+| `nexus-fuse/README.md` | modify | Document opt-in flags, kernel requirement, fallback behavior, and benchmark command. |
+| `nexus-fuse/PERFORMANCE_RESULTS.md` | modify | Record issue #4060 benchmark result or the exact local command used to collect it. |
+
+## External API Notes
+
+Use the current primary sources before editing the fuser integration:
+
+- fuser latest `ReplyOpen` docs: <https://docs.rs/fuser/latest/fuser/struct.ReplyOpen.html>
+- fuser latest `Filesystem` trait docs: <https://docs.rs/fuser/latest/fuser/trait.Filesystem.html>
+- fuser latest `KernelConfig` docs: <https://docs.rs/fuser/latest/fuser/struct.KernelConfig.html>
+- fuser passthrough example source: <https://docs.rs/crate/fuser/latest/source/examples/passthrough.rs>
+- Linux FUSE passthrough kernel docs: <https://docs.kernel.org/filesystems/fuse/fuse-passthrough.html>
+
+The Linux kernel contract is: the daemon registers a backing file, returns its backing id from `OPEN`, and later read/write operations can bypass the daemon for that handle. fuser requires `KernelConfig::set_max_stack_depth(1)` during `Filesystem::init`, and the returned `BackingId` must stay alive until `release`. This plan uses that contract only for read-only regular-file opens.
+
+### Task 1: Upgrade fuser And Preserve Existing Behavior
+
+**Files:**
+- Modify: `nexus-fuse/Cargo.toml`
+- Modify: `nexus-fuse/src/fs.rs`
+- Modify: `nexus-fuse/src/main.rs`
+
+- [ ] **Step 1: Capture the current Rust baseline**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus/nexus-fuse
+cargo test fs::tests --lib
+cargo test cache::tests cached_read::tests daemon::tests --lib
+```
+
+Expected: all selected tests pass before the dependency upgrade. If a selected test fails before edits, stop and record the failing test name in the PR notes because it is not caused by passthrough.
+
+- [ ] **Step 2: Upgrade the fuser dependency**
+
+In `nexus-fuse/Cargo.toml`, replace the FUSE dependency block with:
+
+```toml
+# FUSE filesystem. 0.17 includes the Linux passthrough APIs used by issue #4060.
+fuser = "0.17"
+```
+
+- [ ] **Step 3: Verify the upgrade exposes compile errors before fixing code**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus/nexus-fuse
+cargo check --lib --bin nexus-fuse
+```
+
+Expected: compile failures reference changed `fuser::Filesystem` method receivers, method signatures, fuser option/config types, or `FileAttr` field types. Do not change passthrough logic in this step.
+
+- [ ] **Step 4: Update `NexusFs` callback receivers and fuser value types**
+
+In `nexus-fuse/src/fs.rs`, change every `impl Filesystem for NexusFs` callback receiver from `&mut self` to `&self`.
+
+Use these imports at the top of `fs.rs` after the upgrade compiles the type names:
+
+```rust
+use fuser::{
+    Errno, FileAttr, FileHandle, FileType, Filesystem, FopenFlags, INodeNo, KernelConfig,
+    OpenAccMode, OpenFlags, ReplyAttr, ReplyData, ReplyDirectory, ReplyEntry, ReplyWrite, Request,
+    FUSE_ROOT_ID,
+};
+```
+
+Where fuser 0.17 reports `INodeNo` and `FileHandle` newtypes, unwrap them at method entry and pass raw `u64` values to the existing helpers:
+
+```rust
+let ino = ino.0;
+let fh = fh.0;
+```
+
+Keep `InodeTable` storing raw `u64`; only fuser callback boundaries should know about fuser newtypes. Replace `reply.error(ENOENT)` style calls with fuser errno constants such as `reply.error(Errno::ENOENT)`, `reply.error(Errno::EIO)`, `reply.error(Errno::EISDIR)`, `reply.error(Errno::ENOTDIR)`, and `reply.error(Errno::ENOTEMPTY)`.
+
+- [ ] **Step 5: Convert mount setup in `main.rs` to fuser 0.17 config**
+
+Replace the direct-mount option construction in `nexus-fuse/src/main.rs` with this shape:
+
+```rust
+let mut config = Config::new();
+config
+    .fsname("nexus")
+    .auto_unmount()
+    .default_permissions();
+
+if allow_other {
+    config.allow_other();
+}
+
+info!("Mounting filesystem...");
+if foreground {
+    fuser::mount2(filesystem, &mount_point, &config)?;
+} else {
+    fuser::mount2(filesystem, &mount_point, &config)?;
+}
+```
+
+If fuser 0.17 keeps `MountOption` support in this repository's resolved feature set, keep the existing `Vec<MountOption>` and only update the imports. The pass condition is `cargo check --lib --bin nexus-fuse` succeeding before passthrough modules exist.
+
+- [ ] **Step 6: Re-run behavior tests**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus/nexus-fuse
+cargo check --lib --bin nexus-fuse
+cargo test fs::tests --lib
+cargo test cache::tests cached_read::tests daemon::tests --lib
+```
+
+Expected: commands pass. No passthrough feature is visible yet.
+
+- [ ] **Step 7: Commit the compatibility upgrade**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus
+git add nexus-fuse/Cargo.toml nexus-fuse/Cargo.lock nexus-fuse/src/fs.rs nexus-fuse/src/main.rs
+git commit -m "chore(#4060): upgrade fuser for passthrough support"
+```
+
+Expected: commit succeeds and contains only the compatibility upgrade.
+
+### Task 2: Rust Passthrough Config And Policy
+
+**Files:**
+- Modify: `nexus-fuse/Cargo.toml`
+- Modify: `nexus-fuse/src/lib.rs`
+- Create: `nexus-fuse/src/passthrough/mod.rs`
+- Create: `nexus-fuse/src/passthrough/config.rs`
+- Create: `nexus-fuse/src/passthrough/policy.rs`
+
+- [ ] **Step 1: Add dependencies**
+
+Append these dependencies in `nexus-fuse/Cargo.toml` under `[dependencies]`:
+
+```toml
+# Passthrough path matching and stable backing-file keys
+globset = "0.4"
+sha2 = "0.10"
+hex = "0.4"
+```
+
+- [ ] **Step 2: Create failing config tests**
+
+Create `nexus-fuse/src/passthrough/config.rs` with this test module first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_is_disabled_and_large_read_threshold_is_128k() {
+        let config = PassthroughConfig::default();
+        assert!(!config.enabled);
+        assert_eq!(config.threshold_bytes, 128 * 1024);
+        assert!(!config.require);
+        assert!(config.allow_patterns.is_empty());
+    }
+
+    #[test]
+    fn comma_separated_patterns_trim_empty_segments() {
+        let patterns = parse_pattern_env(" /models/**, ,/datasets/*.bin ,, ");
+        assert_eq!(patterns, vec!["/models/**", "/datasets/*.bin"]);
+    }
+
+    #[test]
+    fn pattern_set_allows_when_no_allow_patterns_are_configured() {
+        let set = PatternSet::new(vec![], vec![]).expect("empty patterns compile");
+        assert!(set.allows("/any/path.bin"));
+    }
+
+    #[test]
+    fn pattern_set_applies_allow_and_deny_patterns() {
+        let set = PatternSet::new(
+            vec!["/datasets/**".to_string()],
+            vec!["/datasets/private/**".to_string()],
+        )
+        .expect("patterns compile");
+
+        assert!(set.allows("/datasets/public/file.bin"));
+        assert!(!set.allows("/other/file.bin"));
+        assert!(!set.allows("/datasets/private/key.bin"));
+    }
+
+    #[test]
+    fn kernel_release_parser_enforces_linux_6_9_floor() {
+        assert!(kernel_release_supports_passthrough("6.9.0"));
+        assert!(kernel_release_supports_passthrough("6.10.1-custom"));
+        assert!(!kernel_release_supports_passthrough("6.8.12"));
+        assert!(!kernel_release_supports_passthrough("5.15.0"));
+        assert!(!kernel_release_supports_passthrough("not-a-version"));
+    }
+}
+```
+
+- [ ] **Step 3: Run config tests and verify they fail**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus/nexus-fuse
+cargo test passthrough::config::tests --lib
+```
+
+Expected: compile failure naming missing `PassthroughConfig`, `parse_pattern_env`, or `PatternSet`.
+
+- [ ] **Step 4: Implement config and pattern parsing**
+
+Replace the body of `nexus-fuse/src/passthrough/config.rs` with:
+
+```rust
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use std::path::PathBuf;
+
+pub const DEFAULT_THRESHOLD_BYTES: u64 = 128 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PassthroughConfig {
+    pub enabled: bool,
+    pub allow_patterns: Vec<String>,
+    pub deny_patterns: Vec<String>,
+    pub threshold_bytes: u64,
+    pub require: bool,
+    pub backing_dir: Option<PathBuf>,
+}
+
+impl Default for PassthroughConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            allow_patterns: Vec::new(),
+            deny_patterns: Vec::new(),
+            threshold_bytes: DEFAULT_THRESHOLD_BYTES,
+            require: false,
+            backing_dir: None,
+        }
+    }
+}
+
+impl PassthroughConfig {
+    pub fn disabled() -> Self {
+        Self::default()
+    }
+
+    pub fn pattern_set(&self) -> Result<PatternSet, globset::Error> {
+        PatternSet::new(self.allow_patterns.clone(), self.deny_patterns.clone())
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct PatternSet {
+    allow: GlobSet,
+    deny: GlobSet,
+    has_allow_patterns: bool,
+}
+
+impl PatternSet {
+    pub fn new(allow_patterns: Vec<String>, deny_patterns: Vec<String>) -> Result<Self, globset::Error> {
+        let allow = build_globset(&allow_patterns)?;
+        let deny = build_globset(&deny_patterns)?;
+
+        Ok(Self {
+            allow,
+            deny,
+            has_allow_patterns: !allow_patterns.is_empty(),
+        })
+    }
+
+    pub fn allows(&self, path: &str) -> bool {
+        if self.deny.is_match(path) {
+            return false;
+        }
+
+        !self.has_allow_patterns || self.allow.is_match(path)
+    }
+}
+
+fn build_globset(patterns: &[String]) -> Result<GlobSet, globset::Error> {
+    let mut builder = GlobSetBuilder::new();
+    for pattern in patterns {
+        builder.add(Glob::new(pattern)?);
+    }
+    builder.build()
+}
+
+pub fn parse_pattern_env(raw: &str) -> Vec<String> {
+    raw.split(',')
+        .map(str::trim)
+        .filter(|segment| !segment.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+pub fn kernel_release_supports_passthrough(release: &str) -> bool {
+    let Some((major, rest)) = release.split_once('.') else {
+        return false;
+    };
+    let minor = rest
+        .split(|ch: char| !ch.is_ascii_digit())
+        .next()
+        .unwrap_or_default();
+
+    let Ok(major) = major.parse::<u32>() else {
+        return false;
+    };
+    let Ok(minor) = minor.parse::<u32>() else {
+        return false;
+    };
+
+    (major, minor) >= (6, 9)
+}
+
+pub fn linux_passthrough_supported() -> bool {
+    if !cfg!(target_os = "linux") {
+        return false;
+    }
+
+    std::fs::read_to_string("/proc/sys/kernel/osrelease")
+        .map(|release| kernel_release_supports_passthrough(release.trim()))
+        .unwrap_or(false)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_is_disabled_and_large_read_threshold_is_128k() {
+        let config = PassthroughConfig::default();
+        assert!(!config.enabled);
+        assert_eq!(config.threshold_bytes, 128 * 1024);
+        assert!(!config.require);
+        assert!(config.allow_patterns.is_empty());
+    }
+
+    #[test]
+    fn comma_separated_patterns_trim_empty_segments() {
+        let patterns = parse_pattern_env(" /models/**, ,/datasets/*.bin ,, ");
+        assert_eq!(patterns, vec!["/models/**", "/datasets/*.bin"]);
+    }
+
+    #[test]
+    fn pattern_set_allows_when_no_allow_patterns_are_configured() {
+        let set = PatternSet::new(vec![], vec![]).expect("empty patterns compile");
+        assert!(set.allows("/any/path.bin"));
+    }
+
+    #[test]
+    fn pattern_set_applies_allow_and_deny_patterns() {
+        let set = PatternSet::new(
+            vec!["/datasets/**".to_string()],
+            vec!["/datasets/private/**".to_string()],
+        )
+        .expect("patterns compile");
+
+        assert!(set.allows("/datasets/public/file.bin"));
+        assert!(!set.allows("/other/file.bin"));
+        assert!(!set.allows("/datasets/private/key.bin"));
+    }
+
+    #[test]
+    fn kernel_release_parser_enforces_linux_6_9_floor() {
+        assert!(kernel_release_supports_passthrough("6.9.0"));
+        assert!(kernel_release_supports_passthrough("6.10.1-custom"));
+        assert!(!kernel_release_supports_passthrough("6.8.12"));
+        assert!(!kernel_release_supports_passthrough("5.15.0"));
+        assert!(!kernel_release_supports_passthrough("not-a-version"));
+    }
+}
+```
+
+- [ ] **Step 5: Create failing policy tests**
+
+Create `nexus-fuse/src/passthrough/policy.rs` with this test module first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::FileMetadata;
+
+    fn metadata(size: u64, is_directory: bool) -> FileMetadata {
+        FileMetadata {
+            size,
+            etag: Some("etag-1".to_string()),
+            modified_at: Some("2026-05-12T00:00:00Z".to_string()),
+            is_directory,
+        }
+    }
+
+    #[test]
+    fn disabled_config_denies_everything() {
+        let config = PassthroughConfig::default();
+        let policy = PassthroughPolicy::new(config).expect("policy builds");
+        let decision = policy.decide("/big.bin", &metadata(1024 * 1024, false), OpenAccess::ReadOnly);
+        assert_eq!(decision, PassthroughDecision::Deny(DenyReason::Disabled));
+    }
+
+    #[test]
+    fn large_read_only_file_with_matching_pattern_is_allowed() {
+        let config = PassthroughConfig {
+            enabled: true,
+            allow_patterns: vec!["/data/**".to_string()],
+            threshold_bytes: 128 * 1024,
+            require: false,
+            deny_patterns: vec![],
+            backing_dir: None,
+        };
+        let policy = PassthroughPolicy::new(config).expect("policy builds");
+        let decision = policy.decide("/data/big.bin", &metadata(1024 * 1024, false), OpenAccess::ReadOnly);
+        assert_eq!(decision, PassthroughDecision::Allow);
+    }
+
+    #[test]
+    fn directories_small_files_and_write_opens_are_denied() {
+        let config = PassthroughConfig {
+            enabled: true,
+            allow_patterns: vec![],
+            threshold_bytes: 128 * 1024,
+            require: false,
+            deny_patterns: vec![],
+            backing_dir: None,
+        };
+        let policy = PassthroughPolicy::new(config).expect("policy builds");
+
+        assert_eq!(
+            policy.decide("/dir", &metadata(0, true), OpenAccess::ReadOnly),
+            PassthroughDecision::Deny(DenyReason::Directory)
+        );
+        assert_eq!(
+            policy.decide("/small.bin", &metadata(1024, false), OpenAccess::ReadOnly),
+            PassthroughDecision::Deny(DenyReason::BelowThreshold)
+        );
+        assert_eq!(
+            policy.decide("/big.bin", &metadata(1024 * 1024, false), OpenAccess::ReadWrite),
+            PassthroughDecision::Deny(DenyReason::NotReadOnly)
+        );
+    }
+}
+```
+
+- [ ] **Step 6: Run policy tests and verify they fail**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus/nexus-fuse
+cargo test passthrough::policy::tests --lib
+```
+
+Expected: compile failure naming missing policy types.
+
+- [ ] **Step 7: Implement policy types**
+
+Replace `nexus-fuse/src/passthrough/policy.rs` with:
+
+```rust
+use crate::client::FileMetadata;
+use crate::passthrough::config::{PassthroughConfig, PatternSet};
+use fuser::{OpenAccMode, OpenFlags};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum OpenAccess {
+    ReadOnly,
+    WriteOnly,
+    ReadWrite,
+}
+
+impl OpenAccess {
+    pub fn from_open_flags(flags: OpenFlags) -> Self {
+        match flags.acc_mode() {
+            OpenAccMode::O_RDONLY => Self::ReadOnly,
+            OpenAccMode::O_WRONLY => Self::WriteOnly,
+            OpenAccMode::O_RDWR => Self::ReadWrite,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DenyReason {
+    Disabled,
+    NotNegotiated,
+    Pattern,
+    Directory,
+    BelowThreshold,
+    NotReadOnly,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum PassthroughDecision {
+    Allow,
+    Deny(DenyReason),
+}
+
+pub struct PassthroughPolicy {
+    config: PassthroughConfig,
+    patterns: PatternSet,
+}
+
+impl PassthroughPolicy {
+    pub fn new(config: PassthroughConfig) -> Result<Self, globset::Error> {
+        let patterns = config.pattern_set()?;
+        Ok(Self { config, patterns })
+    }
+
+    pub fn config(&self) -> &PassthroughConfig {
+        &self.config
+    }
+
+    pub fn decide(
+        &self,
+        path: &str,
+        metadata: &FileMetadata,
+        access: OpenAccess,
+    ) -> PassthroughDecision {
+        if !self.config.enabled {
+            return PassthroughDecision::Deny(DenyReason::Disabled);
+        }
+
+        if metadata.is_directory {
+            return PassthroughDecision::Deny(DenyReason::Directory);
+        }
+
+        if access != OpenAccess::ReadOnly {
+            return PassthroughDecision::Deny(DenyReason::NotReadOnly);
+        }
+
+        if metadata.size < self.config.threshold_bytes {
+            return PassthroughDecision::Deny(DenyReason::BelowThreshold);
+        }
+
+        if !self.patterns.allows(path) {
+            return PassthroughDecision::Deny(DenyReason::Pattern);
+        }
+
+        PassthroughDecision::Allow
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::FileMetadata;
+
+    fn metadata(size: u64, is_directory: bool) -> FileMetadata {
+        FileMetadata {
+            size,
+            etag: Some("etag-1".to_string()),
+            modified_at: Some("2026-05-12T00:00:00Z".to_string()),
+            is_directory,
+        }
+    }
+
+    #[test]
+    fn disabled_config_denies_everything() {
+        let config = PassthroughConfig::default();
+        let policy = PassthroughPolicy::new(config).expect("policy builds");
+        let decision = policy.decide("/big.bin", &metadata(1024 * 1024, false), OpenAccess::ReadOnly);
+        assert_eq!(decision, PassthroughDecision::Deny(DenyReason::Disabled));
+    }
+
+    #[test]
+    fn large_read_only_file_with_matching_pattern_is_allowed() {
+        let config = PassthroughConfig {
+            enabled: true,
+            allow_patterns: vec!["/data/**".to_string()],
+            threshold_bytes: 128 * 1024,
+            require: false,
+            deny_patterns: vec![],
+            backing_dir: None,
+        };
+        let policy = PassthroughPolicy::new(config).expect("policy builds");
+        let decision = policy.decide("/data/big.bin", &metadata(1024 * 1024, false), OpenAccess::ReadOnly);
+        assert_eq!(decision, PassthroughDecision::Allow);
+    }
+
+    #[test]
+    fn directories_small_files_and_write_opens_are_denied() {
+        let config = PassthroughConfig {
+            enabled: true,
+            allow_patterns: vec![],
+            threshold_bytes: 128 * 1024,
+            require: false,
+            deny_patterns: vec![],
+            backing_dir: None,
+        };
+        let policy = PassthroughPolicy::new(config).expect("policy builds");
+
+        assert_eq!(
+            policy.decide("/dir", &metadata(0, true), OpenAccess::ReadOnly),
+            PassthroughDecision::Deny(DenyReason::Directory)
+        );
+        assert_eq!(
+            policy.decide("/small.bin", &metadata(1024, false), OpenAccess::ReadOnly),
+            PassthroughDecision::Deny(DenyReason::BelowThreshold)
+        );
+        assert_eq!(
+            policy.decide("/big.bin", &metadata(1024 * 1024, false), OpenAccess::ReadWrite),
+            PassthroughDecision::Deny(DenyReason::NotReadOnly)
+        );
+    }
+}
+```
+
+- [ ] **Step 8: Wire the module boundary**
+
+Create `nexus-fuse/src/passthrough/mod.rs`:
+
+```rust
+pub mod config;
+pub mod policy;
+
+pub use config::{
+    kernel_release_supports_passthrough, linux_passthrough_supported, parse_pattern_env,
+    PassthroughConfig,
+};
+pub use policy::{DenyReason, OpenAccess, PassthroughDecision, PassthroughPolicy};
+```
+
+Add this line to `nexus-fuse/src/lib.rs`:
+
+```rust
+pub mod passthrough;
+```
+
+- [ ] **Step 9: Run config and policy tests**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus/nexus-fuse
+cargo test passthrough::config::tests passthrough::policy::tests --lib
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 10: Commit config and policy**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus
+git add nexus-fuse/Cargo.toml nexus-fuse/Cargo.lock nexus-fuse/src/lib.rs nexus-fuse/src/passthrough
+git commit -m "feat(#4060): add passthrough config and policy"
+```
+
+Expected: commit succeeds.
+
+### Task 3: Backing Store Materialization
+
+**Files:**
+- Modify: `nexus-fuse/src/passthrough/mod.rs`
+- Create: `nexus-fuse/src/passthrough/backing.rs`
+
+- [ ] **Step 1: Write failing backing-store tests**
+
+Create `nexus-fuse/src/passthrough/backing.rs` with this test module first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn backing_key_is_stable_and_uses_server_path_etag_and_size() {
+        let first = BackingKey::new("http://server", "/data/big.bin", Some("etag-1"), 1024);
+        let second = BackingKey::new("http://server", "/data/big.bin", Some("etag-1"), 1024);
+        let changed = BackingKey::new("http://server", "/data/big.bin", Some("etag-2"), 1024);
+
+        assert_eq!(first.filename(), second.filename());
+        assert_ne!(first.filename(), changed.filename());
+        assert!(first.filename().ends_with(".backing"));
+    }
+
+    #[test]
+    fn backing_store_invalidates_path_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = BackingStore::new(dir.path().to_path_buf()).expect("store");
+        let key = BackingKey::new("http://server", "/data/big.bin", Some("etag-1"), 4);
+        let path = store.path_for_key(&key);
+        fs::write(&path, b"data").expect("write");
+
+        assert!(path.exists());
+        store.invalidate_path("http://server", "/data/big.bin").expect("invalidate");
+        assert!(!path.exists());
+    }
+}
+```
+
+- [ ] **Step 2: Run backing tests and verify they fail**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus/nexus-fuse
+cargo test passthrough::backing::tests --lib
+```
+
+Expected: compile failure naming missing `BackingKey` or `BackingStore`.
+
+- [ ] **Step 3: Implement key and store filesystem operations**
+
+Replace `nexus-fuse/src/passthrough/backing.rs` with:
+
+```rust
+use crate::client::{FileMetadata, NexusClient, ReadResponse};
+use anyhow::{Context, Result};
+use sha2::{Digest, Sha256};
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::os::fd::{AsRawFd, RawFd};
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BackingKey {
+    digest: String,
+    server_url: String,
+    path: String,
+}
+
+impl BackingKey {
+    pub fn new(server_url: &str, path: &str, etag: Option<&str>, size: u64) -> Self {
+        let mut hasher = Sha256::new();
+        hasher.update(server_url.as_bytes());
+        hasher.update([0]);
+        hasher.update(path.as_bytes());
+        hasher.update([0]);
+        hasher.update(etag.unwrap_or("").as_bytes());
+        hasher.update([0]);
+        hasher.update(size.to_le_bytes());
+
+        Self {
+            digest: hex::encode(hasher.finalize()),
+            server_url: server_url.to_string(),
+            path: path.to_string(),
+        }
+    }
+
+    pub fn filename(&self) -> String {
+        format!("{}.backing", self.digest)
+    }
+
+    fn marker_prefix(&self) -> String {
+        let mut hasher = Sha256::new();
+        hasher.update(self.server_url.as_bytes());
+        hasher.update([0]);
+        hasher.update(self.path.as_bytes());
+        hex::encode(hasher.finalize())
+    }
+}
+
+#[derive(Debug)]
+pub struct MaterializedBacking {
+    pub path: PathBuf,
+    pub key: BackingKey,
+    file: File,
+}
+
+impl MaterializedBacking {
+    pub fn file(&self) -> &File {
+        &self.file
+    }
+
+    pub fn raw_fd(&self) -> RawFd {
+        self.file.as_raw_fd()
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BackingStore {
+    root: PathBuf,
+}
+
+impl BackingStore {
+    pub fn new(root: PathBuf) -> Result<Self> {
+        fs::create_dir_all(&root).with_context(|| format!("create passthrough backing dir {}", root.display()))?;
+        Ok(Self { root })
+    }
+
+    pub fn path_for_key(&self, key: &BackingKey) -> PathBuf {
+        self.root.join(key.filename())
+    }
+
+    pub fn materialize(
+        &self,
+        server_url: &str,
+        path: &str,
+        client: &NexusClient,
+        metadata: &FileMetadata,
+    ) -> Result<MaterializedBacking> {
+        let key = BackingKey::new(server_url, path, metadata.etag.as_deref(), metadata.size);
+        let final_path = self.path_for_key(&key);
+
+        if final_path.exists() {
+            let file = OpenOptions::new().read(true).open(&final_path)?;
+            return Ok(MaterializedBacking { path: final_path, key, file });
+        }
+
+        let response = client.read_with_etag(path, None)?;
+        let bytes = match response {
+            ReadResponse::Content { content, .. } => content,
+            ReadResponse::NotModified => anyhow::bail!("server returned 304 while materializing uncached backing file"),
+        };
+
+        if bytes.len() as u64 != metadata.size {
+            anyhow::bail!(
+                "materialized backing size mismatch for {}: expected {}, got {}",
+                path,
+                metadata.size,
+                bytes.len()
+            );
+        }
+
+        let temp_path = final_path.with_extension(format!("{}.tmp", std::process::id()));
+        {
+            let mut file = File::create(&temp_path)?;
+            file.write_all(&bytes)?;
+            file.sync_all()?;
+        }
+        fs::rename(&temp_path, &final_path)?;
+
+        let marker_path = self.root.join(format!("{}.marker", key.marker_prefix()));
+        fs::write(marker_path, final_path.file_name().unwrap().to_string_lossy().as_bytes())?;
+
+        let file = OpenOptions::new().read(true).open(&final_path)?;
+        Ok(MaterializedBacking { path: final_path, key, file })
+    }
+
+    pub fn invalidate_path(&self, server_url: &str, path: &str) -> Result<()> {
+        let marker = BackingKey::new(server_url, path, None, 0).marker_prefix();
+        for entry in fs::read_dir(&self.root)? {
+            let entry = entry?;
+            let file_name = entry.file_name();
+            let file_name = file_name.to_string_lossy();
+            if file_name.starts_with(&marker) || file_name.ends_with(".backing") {
+                let _ = fs::remove_file(entry.path());
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn backing_key_is_stable_and_uses_server_path_etag_and_size() {
+        let first = BackingKey::new("http://server", "/data/big.bin", Some("etag-1"), 1024);
+        let second = BackingKey::new("http://server", "/data/big.bin", Some("etag-1"), 1024);
+        let changed = BackingKey::new("http://server", "/data/big.bin", Some("etag-2"), 1024);
+
+        assert_eq!(first.filename(), second.filename());
+        assert_ne!(first.filename(), changed.filename());
+        assert!(first.filename().ends_with(".backing"));
+    }
+
+    #[test]
+    fn backing_store_invalidates_path_files() {
+        let dir = tempfile::tempdir().expect("tempdir");
+        let store = BackingStore::new(dir.path().to_path_buf()).expect("store");
+        let key = BackingKey::new("http://server", "/data/big.bin", Some("etag-1"), 4);
+        let path = store.path_for_key(&key);
+        fs::write(&path, b"data").expect("write");
+
+        assert!(path.exists());
+        store.invalidate_path("http://server", "/data/big.bin").expect("invalidate");
+        assert!(!path.exists());
+    }
+}
+```
+
+- [ ] **Step 4: Fix marker-based invalidation**
+
+The Step 3 invalidation loop removes all `.backing` files. Replace `BackingStore::invalidate_path` with a path-specific scan that removes only files whose sidecar marker names match the server/path digest:
+
+```rust
+pub fn invalidate_path(&self, server_url: &str, path: &str) -> Result<()> {
+    let path_marker_prefix = BackingKey::new(server_url, path, None, 0).marker_prefix();
+    let mut backing_files = Vec::new();
+
+    for entry in fs::read_dir(&self.root)? {
+        let entry = entry?;
+        let file_name = entry.file_name().to_string_lossy().to_string();
+        if file_name.starts_with(&path_marker_prefix) && file_name.ends_with(".marker") {
+            let backing_name = fs::read_to_string(entry.path()).unwrap_or_default();
+            if !backing_name.trim().is_empty() {
+                backing_files.push(self.root.join(backing_name.trim()));
+            }
+            let _ = fs::remove_file(entry.path());
+        }
+    }
+
+    for backing in backing_files {
+        let _ = fs::remove_file(backing);
+    }
+
+    Ok(())
+}
+```
+
+Also change the marker write in `materialize` so each etag/size variant has a distinct marker:
+
+```rust
+let marker_path = self.root.join(format!("{}-{}.marker", key.marker_prefix(), key.digest));
+fs::write(marker_path, final_path.file_name().unwrap().to_string_lossy().as_bytes())?;
+```
+
+- [ ] **Step 5: Export backing module**
+
+Update `nexus-fuse/src/passthrough/mod.rs`:
+
+```rust
+pub mod backing;
+pub mod config;
+pub mod policy;
+
+pub use backing::{BackingKey, BackingStore, MaterializedBacking};
+pub use config::{
+    kernel_release_supports_passthrough, linux_passthrough_supported, parse_pattern_env,
+    PassthroughConfig,
+};
+pub use policy::{DenyReason, OpenAccess, PassthroughDecision, PassthroughPolicy};
+```
+
+- [ ] **Step 6: Run backing tests**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus/nexus-fuse
+cargo test passthrough::backing::tests --lib
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit backing store**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus
+git add nexus-fuse/src/passthrough/backing.rs nexus-fuse/src/passthrough/mod.rs
+git commit -m "feat(#4060): add passthrough backing store"
+```
+
+Expected: commit succeeds.
+
+### Task 4: Passthrough Manager And Active Handle Tracking
+
+**Files:**
+- Modify: `nexus-fuse/src/passthrough/mod.rs`
+- Create: `nexus-fuse/src/passthrough/manager.rs`
+
+- [ ] **Step 1: Write failing manager tests**
+
+Create `nexus-fuse/src/passthrough/manager.rs` with this test module first:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::FileMetadata;
+    use crate::passthrough::config::PassthroughConfig;
+
+    fn metadata(size: u64) -> FileMetadata {
+        FileMetadata {
+            size,
+            etag: Some("etag-1".to_string()),
+            modified_at: None,
+            is_directory: false,
+        }
+    }
+
+    #[test]
+    fn next_file_handle_is_monotonic_and_never_zero() {
+        let manager = PassthroughManager::new_for_tests(PassthroughConfig {
+            enabled: true,
+            threshold_bytes: 128,
+            allow_patterns: vec![],
+            deny_patterns: vec![],
+            require: false,
+            backing_dir: None,
+        });
+
+        assert_eq!(manager.next_file_handle(), 1);
+        assert_eq!(manager.next_file_handle(), 2);
+    }
+
+    #[test]
+    fn decision_uses_policy() {
+        let manager = PassthroughManager::new_for_tests(PassthroughConfig {
+            enabled: true,
+            threshold_bytes: 128,
+            allow_patterns: vec!["/data/**".to_string()],
+            deny_patterns: vec![],
+            require: false,
+            backing_dir: None,
+        });
+        manager.set_negotiated(true);
+
+        assert_eq!(
+            manager.decide("/data/big.bin", &metadata(1024), OpenAccess::ReadOnly),
+            PassthroughDecision::Allow
+        );
+        assert_eq!(
+            manager.decide("/logs/big.bin", &metadata(1024), OpenAccess::ReadOnly),
+            PassthroughDecision::Deny(DenyReason::Pattern)
+        );
+    }
+}
+```
+
+- [ ] **Step 2: Run manager tests and verify they fail**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus/nexus-fuse
+cargo test passthrough::manager::tests --lib
+```
+
+Expected: compile failure naming missing `PassthroughManager`.
+
+- [ ] **Step 3: Implement manager core**
+
+Replace `nexus-fuse/src/passthrough/manager.rs` with:
+
+```rust
+use crate::client::{FileMetadata, NexusClient};
+use crate::passthrough::backing::{BackingStore, MaterializedBacking};
+use crate::passthrough::config::PassthroughConfig;
+use crate::passthrough::policy::{OpenAccess, PassthroughDecision, PassthroughPolicy};
+use anyhow::Result;
+use fuser::BackingId;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::Mutex;
+
+pub struct ActivePassthrough {
+    pub backing: MaterializedBacking,
+    pub backing_id: BackingId,
+}
+
+pub struct PassthroughManager {
+    server_url: String,
+    policy: PassthroughPolicy,
+    store: BackingStore,
+    next_fh: AtomicU64,
+    negotiated: AtomicBool,
+    active: Mutex<HashMap<u64, ActivePassthrough>>,
+}
+
+impl PassthroughManager {
+    pub fn new(server_url: String, config: PassthroughConfig) -> Result<Self> {
+        let root = config
+            .backing_dir
+            .clone()
+            .unwrap_or_else(default_backing_dir);
+        Ok(Self {
+            server_url,
+            policy: PassthroughPolicy::new(config)?,
+            store: BackingStore::new(root)?,
+            next_fh: AtomicU64::new(1),
+            negotiated: AtomicBool::new(false),
+            active: Mutex::new(HashMap::new()),
+        })
+    }
+
+    #[cfg(test)]
+    pub fn new_for_tests(config: PassthroughConfig) -> Self {
+        let root = tempfile::tempdir().expect("tempdir").into_path();
+        Self::new("http://server".to_string(), config).expect("manager")
+    }
+
+    pub fn next_file_handle(&self) -> u64 {
+        self.next_fh.fetch_add(1, Ordering::Relaxed)
+    }
+
+    pub fn set_negotiated(&self, negotiated: bool) {
+        self.negotiated.store(negotiated, Ordering::Release);
+    }
+
+    pub fn negotiated(&self) -> bool {
+        self.negotiated.load(Ordering::Acquire)
+    }
+
+    pub fn require(&self) -> bool {
+        self.policy.config().require
+    }
+
+    pub fn decide(
+        &self,
+        path: &str,
+        metadata: &FileMetadata,
+        access: OpenAccess,
+    ) -> PassthroughDecision {
+        if !self.negotiated() {
+            return PassthroughDecision::Deny(crate::passthrough::policy::DenyReason::NotNegotiated);
+        }
+        self.policy.decide(path, metadata, access)
+    }
+
+    pub fn materialize(
+        &self,
+        path: &str,
+        client: &NexusClient,
+        metadata: &FileMetadata,
+    ) -> Result<MaterializedBacking> {
+        self.store.materialize(&self.server_url, path, client, metadata)
+    }
+
+    pub fn insert_active(&self, fh: u64, active: ActivePassthrough) {
+        self.active.lock().unwrap().insert(fh, active);
+    }
+
+    pub fn remove_active(&self, fh: u64) -> Option<ActivePassthrough> {
+        self.active.lock().unwrap().remove(&fh)
+    }
+
+    pub fn invalidate_path(&self, path: &str) {
+        if let Err(err) = self.store.invalidate_path(&self.server_url, path) {
+            log::warn!("passthrough backing invalidation failed for {}: {}", path, err);
+        }
+    }
+}
+
+fn default_backing_dir() -> PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join("nexus-fuse")
+        .join("passthrough")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::FileMetadata;
+    use crate::passthrough::config::PassthroughConfig;
+
+    fn metadata(size: u64) -> FileMetadata {
+        FileMetadata {
+            size,
+            etag: Some("etag-1".to_string()),
+            modified_at: None,
+            is_directory: false,
+        }
+    }
+
+    #[test]
+    fn next_file_handle_is_monotonic_and_never_zero() {
+        let manager = PassthroughManager::new_for_tests(PassthroughConfig {
+            enabled: true,
+            threshold_bytes: 128,
+            allow_patterns: vec![],
+            deny_patterns: vec![],
+            require: false,
+            backing_dir: None,
+        });
+
+        assert_eq!(manager.next_file_handle(), 1);
+        assert_eq!(manager.next_file_handle(), 2);
+    }
+
+    #[test]
+    fn decision_uses_policy() {
+        let manager = PassthroughManager::new_for_tests(PassthroughConfig {
+            enabled: true,
+            threshold_bytes: 128,
+            allow_patterns: vec!["/data/**".to_string()],
+            deny_patterns: vec![],
+            require: false,
+            backing_dir: None,
+        });
+        manager.set_negotiated(true);
+
+        assert_eq!(
+            manager.decide("/data/big.bin", &metadata(1024), OpenAccess::ReadOnly),
+            PassthroughDecision::Allow
+        );
+        assert_eq!(
+            manager.decide("/logs/big.bin", &metadata(1024), OpenAccess::ReadOnly),
+            PassthroughDecision::Deny(DenyReason::Pattern)
+        );
+    }
+}
+```
+
+- [ ] **Step 4: Export manager module**
+
+Update `nexus-fuse/src/passthrough/mod.rs`:
+
+```rust
+pub mod backing;
+pub mod config;
+pub mod manager;
+pub mod policy;
+
+pub use backing::{BackingKey, BackingStore, MaterializedBacking};
+pub use config::{
+    kernel_release_supports_passthrough, linux_passthrough_supported, parse_pattern_env,
+    PassthroughConfig,
+};
+pub use manager::{ActivePassthrough, PassthroughManager};
+pub use policy::{DenyReason, OpenAccess, PassthroughDecision, PassthroughPolicy};
+```
+
+- [ ] **Step 5: Run manager tests**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus/nexus-fuse
+cargo test passthrough::manager::tests --lib
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 6: Commit manager**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus
+git add nexus-fuse/src/passthrough/manager.rs nexus-fuse/src/passthrough/mod.rs
+git commit -m "feat(#4060): track passthrough backing handles"
+```
+
+Expected: commit succeeds.
+
+### Task 5: Wire Passthrough Into Direct Rust FUSE Open And Release
+
+**Files:**
+- Modify: `nexus-fuse/src/fs.rs`
+
+- [ ] **Step 1: Add failing `NexusFs` constructor tests**
+
+Append this test in `#[cfg(test)] mod tests` in `nexus-fuse/src/fs.rs`:
+
+```rust
+#[test]
+fn nexus_fs_can_be_constructed_with_passthrough_manager() {
+    use crate::passthrough::{PassthroughConfig, PassthroughManager};
+
+    let client = NexusClient::new("http://localhost:2026", "test-key", None).expect("client");
+    let manager = PassthroughManager::new(
+        "http://localhost:2026".to_string(),
+        PassthroughConfig {
+            enabled: true,
+            allow_patterns: vec!["/data/**".to_string()],
+            deny_patterns: vec![],
+            threshold_bytes: 128 * 1024,
+            require: false,
+            backing_dir: None,
+        },
+    )
+    .expect("manager");
+
+    let fs = NexusFs::new(client, None, Some(Arc::new(manager)));
+    assert!(fs.passthrough_enabled_for_tests());
+}
+```
+
+- [ ] **Step 2: Run the constructor test and verify it fails**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus/nexus-fuse
+cargo test fs::tests::nexus_fs_can_be_constructed_with_passthrough_manager --lib
+```
+
+Expected: compile failure because `NexusFs::new` does not accept a passthrough manager and `passthrough_enabled_for_tests` is missing.
+
+- [ ] **Step 3: Add the passthrough field**
+
+In `nexus-fuse/src/fs.rs`, add this import:
+
+```rust
+use crate::passthrough::{ActivePassthrough, OpenAccess, PassthroughDecision, PassthroughManager};
+```
+
+Change `NexusFs` to include the manager:
+
+```rust
+pub struct NexusFs {
+    client: Arc<NexusClient>,
+    inodes: Mutex<InodeTable>,
+    attr_cache: Mutex<LruCache<u64, (FileAttr, SystemTime)>>,
+    dir_cache: Mutex<LruCache<u64, (Vec<FileEntry>, SystemTime)>>,
+    file_cache: Option<Arc<FileCache>>,
+    passthrough: Option<Arc<PassthroughManager>>,
+}
+```
+
+Replace the constructor with:
+
+```rust
+pub fn new(
+    client: NexusClient,
+    file_cache: Option<Arc<FileCache>>,
+    passthrough: Option<Arc<PassthroughManager>>,
+) -> Self {
+    Self {
+        client: Arc::new(client),
+        inodes: Mutex::new(InodeTable::new()),
+        attr_cache: Mutex::new(LruCache::new(NonZeroUsize::new(10000).unwrap())),
+        dir_cache: Mutex::new(LruCache::new(NonZeroUsize::new(1000).unwrap())),
+        file_cache,
+        passthrough,
+    }
+}
+
+#[cfg(test)]
+fn passthrough_enabled_for_tests(&self) -> bool {
+    self.passthrough.is_some()
+}
+```
+
+- [ ] **Step 4: Update current callers**
+
+In `nexus-fuse/src/main.rs`, temporarily call the constructor with no passthrough:
+
+```rust
+let filesystem = fs::NexusFs::new(client, file_cache, None);
+```
+
+Update any Rust tests or helper constructors with `None` as the third argument.
+
+- [ ] **Step 5: Run the constructor test**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus/nexus-fuse
+cargo test fs::tests::nexus_fs_can_be_constructed_with_passthrough_manager --lib
+```
+
+Expected: test passes.
+
+- [ ] **Step 6: Add passthrough invalidation**
+
+In `NexusFs::invalidate_path`, after the foyer cache invalidation block, add:
+
+```rust
+if let Some(ref passthrough) = self.passthrough {
+    passthrough.invalidate_path(path);
+}
+```
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus/nexus-fuse
+cargo test fs::tests --lib
+```
+
+Expected: all filesystem unit tests pass.
+
+- [ ] **Step 7: Negotiate passthrough during FUSE init**
+
+Add this `init` callback inside `impl Filesystem for NexusFs`:
+
+```rust
+fn init(&self, _req: &Request<'_>, config: &mut KernelConfig) -> Result<(), Errno> {
+    if let Some(ref passthrough) = self.passthrough {
+        match config.set_max_stack_depth(1) {
+            Ok(_previous) => {
+                passthrough.set_negotiated(true);
+                debug!("FUSE passthrough negotiated with max_stack_depth=1");
+            }
+            Err(max_supported) => {
+                passthrough.set_negotiated(false);
+                if passthrough.require() {
+                    error!(
+                        "FUSE passthrough required but max_stack_depth=1 was rejected; max_supported={}",
+                        max_supported
+                    );
+                    return Err(Errno::EOPNOTSUPP);
+                }
+                debug!(
+                    "FUSE passthrough unavailable; max_stack_depth=1 rejected with max_supported={}",
+                    max_supported
+                );
+            }
+        }
+    }
+    Ok(())
+}
+```
+
+- [ ] **Step 8: Implement open-time passthrough registration**
+
+In `nexus-fuse/src/fs.rs`, replace `open` with this fuser 0.17 control flow:
+
+```rust
+fn open(&self, _req: &Request<'_>, ino: INodeNo, flags: OpenFlags, reply: fuser::ReplyOpen) {
+    let ino = ino.0;
+    debug!("open: ino={}", ino);
+
+    let path = resolve_path!(self, ino, reply);
+
+    let metadata = match self.client.stat(&path) {
+        Ok(metadata) => metadata,
+        Err(e) if e.is_not_found() => {
+            reply.error(Errno::ENOENT);
+            return;
+        }
+        Err(e) => {
+            error!("open stat error for {}: {}", path, e);
+            reply.error(Errno::EIO);
+            return;
+        }
+    };
+
+    if metadata.is_directory {
+        reply.error(Errno::EISDIR);
+        return;
+    }
+
+    if let Some(ref passthrough) = self.passthrough {
+        let access = OpenAccess::from_open_flags(flags);
+        match passthrough.decide(&path, &metadata, access) {
+            PassthroughDecision::Allow => match passthrough.materialize(&path, &self.client, &metadata) {
+                Ok(backing) => {
+                    let fh = passthrough.next_file_handle();
+                    match reply.open_backing(backing.file()) {
+                        Ok(backing_id) => {
+                            let active = ActivePassthrough { backing, backing_id };
+                            reply.opened_passthrough(
+                                FileHandle(fh),
+                                FopenFlags::empty(),
+                                &active.backing_id,
+                            );
+                            passthrough.insert_active(fh, active);
+                            return;
+                        }
+                        Err(err) => {
+                            error!("open_backing failed for {}: {}", path, err);
+                            reply.error(Errno::EIO);
+                            return;
+                        }
+                    }
+                }
+                Err(err) => {
+                    error!("passthrough materialization failed for {}: {}", path, err);
+                    reply.error(Errno::EIO);
+                    return;
+                }
+            },
+            PassthroughDecision::Deny(reason) => {
+                debug!("passthrough denied for {}: {:?}", path, reason);
+            }
+        }
+    }
+
+    reply.opened(FileHandle(0), FopenFlags::empty());
+}
+```
+
+If the exact fuser 0.17 API exposes `open_backing` on a reply helper or uses a differently named method for passthrough completion, use the method names from the local rustdoc and keep the same decisions:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus/nexus-fuse
+cargo doc -p nexus-fuse --no-deps
+```
+
+Expected: local docs show the `ReplyOpen` passthrough method names. The finished `open` compiles and only calls passthrough for allowed read-only files.
+
+- [ ] **Step 9: Clean active passthrough handles from release**
+
+In `release`, remove the active handle before `reply.ok()`:
+
+```rust
+if let Some(ref passthrough) = self.passthrough {
+    passthrough.remove_active(fh.0);
+}
+reply.ok();
+```
+
+- [ ] **Step 10: Run Rust checks**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus/nexus-fuse
+cargo check --lib --bin nexus-fuse
+cargo test passthrough::config::tests passthrough::policy::tests passthrough::backing::tests passthrough::manager::tests --lib
+cargo test fs::tests --lib
+```
+
+Expected: all commands pass.
+
+- [ ] **Step 11: Commit FUSE wiring**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus
+git add nexus-fuse/src/fs.rs nexus-fuse/src/main.rs
+git commit -m "feat(#4060): wire passthrough into rust fuse open"
+```
+
+Expected: commit succeeds.
+
+### Task 6: Add Rust CLI Flags, Environment Variables, And Fallback Semantics
+
+**Files:**
+- Modify: `nexus-fuse/src/main.rs`
+
+- [ ] **Step 1: Write failing CLI config tests**
+
+Append this test module to `nexus-fuse/src/main.rs`:
+
+```rust
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_passthrough_config_keeps_disabled_default() {
+        let config = build_passthrough_config(false, Vec::new(), Vec::new(), 128 * 1024, false, None)
+            .expect("config");
+        assert!(!config.enabled);
+        assert_eq!(config.threshold_bytes, 128 * 1024);
+    }
+
+    #[test]
+    fn build_passthrough_config_preserves_patterns_and_require() {
+        let config = build_passthrough_config(
+            true,
+            vec!["/data/**".to_string()],
+            vec!["/data/private/**".to_string()],
+            256 * 1024,
+            true,
+            None,
+        )
+        .expect("config");
+
+        assert!(config.enabled);
+        assert_eq!(config.allow_patterns, vec!["/data/**"]);
+        assert_eq!(config.deny_patterns, vec!["/data/private/**"]);
+        assert_eq!(config.threshold_bytes, 256 * 1024);
+        assert!(config.require);
+    }
+}
+```
+
+- [ ] **Step 2: Run CLI tests and verify they fail**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus/nexus-fuse
+cargo test main::tests --bin nexus-fuse
+```
+
+Expected: compile failure for missing `build_passthrough_config`.
+
+- [ ] **Step 3: Add CLI arguments to `Commands::Mount`**
+
+In the `Mount` variant, add:
+
+```rust
+        /// Enable Linux FUSE passthrough for eligible large reads.
+        #[arg(long, env = "NEXUS_FUSE_PASSTHROUGH", default_value_t = false)]
+        passthrough: bool,
+
+        /// Glob allow pattern for passthrough. Repeat for multiple patterns.
+        #[arg(long = "passthrough-pattern", env = "NEXUS_FUSE_PASSTHROUGH_PATTERNS", value_delimiter = ',')]
+        passthrough_patterns: Vec<String>,
+
+        /// Glob deny pattern for passthrough. Repeat for multiple patterns.
+        #[arg(long = "passthrough-deny-pattern", env = "NEXUS_FUSE_PASSTHROUGH_DENY_PATTERNS", value_delimiter = ',')]
+        passthrough_deny_patterns: Vec<String>,
+
+        /// Minimum file size for passthrough eligibility.
+        #[arg(long, env = "NEXUS_FUSE_PASSTHROUGH_THRESHOLD_BYTES", default_value_t = 128 * 1024)]
+        passthrough_threshold_bytes: u64,
+
+        /// Fail the mount instead of falling back when passthrough is unavailable.
+        #[arg(long, env = "NEXUS_FUSE_PASSTHROUGH_REQUIRE", default_value_t = false)]
+        passthrough_require: bool,
+
+        /// Directory for immutable passthrough backing files.
+        #[arg(long, env = "NEXUS_FUSE_PASSTHROUGH_BACKING_DIR")]
+        passthrough_backing_dir: Option<PathBuf>,
+```
+
+Add matching fields to the `match cli.command` destructuring for `Commands::Mount`.
+
+- [ ] **Step 4: Implement config builder**
+
+Add this helper near `build_cache_config`:
+
+```rust
+fn build_passthrough_config(
+    enabled: bool,
+    allow_patterns: Vec<String>,
+    deny_patterns: Vec<String>,
+    threshold_bytes: u64,
+    require: bool,
+    backing_dir: Option<PathBuf>,
+) -> anyhow::Result<passthrough::PassthroughConfig> {
+    if threshold_bytes == 0 {
+        anyhow::bail!("passthrough threshold must be greater than zero");
+    }
+
+    Ok(passthrough::PassthroughConfig {
+        enabled,
+        allow_patterns,
+        deny_patterns,
+        threshold_bytes,
+        require,
+        backing_dir,
+    })
+}
+```
+
+- [ ] **Step 5: Create manager in the mount command**
+
+Before `NexusFs::new`, build the manager:
+
+```rust
+let passthrough_config = build_passthrough_config(
+    passthrough,
+    passthrough_patterns,
+    passthrough_deny_patterns,
+    passthrough_threshold_bytes,
+    passthrough_require,
+    passthrough_backing_dir,
+)?;
+
+let passthrough_manager = if passthrough_config.enabled {
+    if !passthrough::linux_passthrough_supported() {
+        if passthrough_config.require {
+            anyhow::bail!("FUSE passthrough requires Linux 6.9+ and fuser passthrough support");
+        }
+        None
+    } else {
+        match passthrough::PassthroughManager::new(url.clone(), passthrough_config.clone()) {
+            Ok(manager) => Some(Arc::new(manager)),
+            Err(err) if passthrough_config.require => return Err(err),
+            Err(err) => {
+                warn!("FUSE passthrough disabled: {}", err);
+                None
+            }
+        }
+    }
+} else {
+    None
+};
+
+let filesystem = fs::NexusFs::new(client, file_cache, passthrough_manager);
+```
+
+Import `warn` from `log` if it is not already imported.
+
+- [ ] **Step 6: Run CLI and Rust tests**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus/nexus-fuse
+cargo test main::tests --bin nexus-fuse
+cargo check --lib --bin nexus-fuse
+```
+
+Expected: commands pass.
+
+- [ ] **Step 7: Commit CLI wiring**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus
+git add nexus-fuse/src/main.rs
+git commit -m "feat(#4060): add passthrough mount flags"
+```
+
+Expected: commit succeeds.
+
+### Task 7: Python Passthrough Options And Rust-Owned Mount Launcher
+
+**Files:**
+- Create: `src/nexus/fuse/passthrough.py`
+- Modify: `src/nexus/fuse/mount.py`
+- Test: `tests/unit/fuse/test_passthrough_options.py`
+
+- [ ] **Step 1: Write failing Python option and command tests**
+
+Create `tests/unit/fuse/test_passthrough_options.py`:
+
+```python
+from __future__ import annotations
+
+import os
+from pathlib import Path
+from unittest.mock import MagicMock
+
+from nexus.fuse.passthrough import (
+    PassthroughOptions,
+    RustPassthroughMount,
+    mount_is_passthrough_safe,
+)
+
+
+def test_options_from_env(monkeypatch):
+    monkeypatch.setenv("NEXUS_FUSE_PASSTHROUGH", "true")
+    monkeypatch.setenv("NEXUS_FUSE_PASSTHROUGH_PATTERNS", "/data/**, /models/*.bin")
+    monkeypatch.setenv("NEXUS_FUSE_PASSTHROUGH_DENY_PATTERNS", "/data/private/**")
+    monkeypatch.setenv("NEXUS_FUSE_PASSTHROUGH_THRESHOLD_BYTES", "262144")
+    monkeypatch.setenv("NEXUS_FUSE_PASSTHROUGH_REQUIRE", "1")
+
+    options = PassthroughOptions.from_env()
+
+    assert options.enabled is True
+    assert options.patterns == ["/data/**", "/models/*.bin"]
+    assert options.deny_patterns == ["/data/private/**"]
+    assert options.threshold_bytes == 262144
+    assert options.require is True
+
+
+def test_rust_mount_command_uses_api_key_file(tmp_path: Path):
+    mount = RustPassthroughMount(
+        rust_binary="/usr/bin/nexus-fuse",
+        nexus_url="http://localhost:2026",
+        api_key="sk-test",
+        mount_point=tmp_path / "mnt",
+        options=PassthroughOptions(enabled=True, patterns=["/data/**"], threshold_bytes=131072),
+        agent_id="agent-1",
+    )
+
+    cmd, env, api_key_file = mount.build_command()
+
+    assert cmd[:4] == ["/usr/bin/nexus-fuse", "mount", str(tmp_path / "mnt"), "--url"]
+    assert "sk-test" not in " ".join(cmd)
+    assert "--api-key-file" in cmd
+    assert "--passthrough" in cmd
+    assert cmd.count("--passthrough-pattern") == 1
+    assert "--passthrough-threshold-bytes" in cmd
+    assert env.get("NEXUS_API_KEY") is None
+    assert api_key_file.read_text() == "sk-test"
+    assert oct(api_key_file.stat().st_mode & 0o777) == "0o600"
+
+
+def test_mount_safety_denies_context_and_hook_counts():
+    fs = MagicMock()
+    fs._kernel.hook_count.side_effect = lambda name: 1 if name == "read" else 0
+
+    assert mount_is_passthrough_safe(fs, mode_value="binary", context=None) is False
+    fs._kernel.hook_count.side_effect = lambda name: 0
+    assert mount_is_passthrough_safe(fs, mode_value="smart", context=None) is False
+    assert mount_is_passthrough_safe(fs, mode_value="binary", context=object()) is False
+    assert mount_is_passthrough_safe(fs, mode_value="binary", context=None) is True
+```
+
+- [ ] **Step 2: Run Python tests and verify they fail**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus
+pytest tests/unit/fuse/test_passthrough_options.py -q
+```
+
+Expected: import failure because `nexus.fuse.passthrough` does not exist.
+
+- [ ] **Step 3: Implement Python passthrough helpers**
+
+Create `src/nexus/fuse/passthrough.py`:
+
+```python
+"""Python orchestration helpers for Rust-owned FUSE passthrough mounts."""
+
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+import tempfile
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from nexus.fuse.rust_client import RustFUSEClient
+
+
+def _parse_bool(value: str | None) -> bool:
+    return value is not None and value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _parse_patterns(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [segment.strip() for segment in value.split(",") if segment.strip()]
+
+
+@dataclass(slots=True)
+class PassthroughOptions:
+    enabled: bool = False
+    patterns: list[str] = field(default_factory=list)
+    deny_patterns: list[str] = field(default_factory=list)
+    threshold_bytes: int = 128 * 1024
+    require: bool = False
+    backing_dir: Path | None = None
+
+    @classmethod
+    def from_env(cls) -> "PassthroughOptions":
+        backing_dir = os.environ.get("NEXUS_FUSE_PASSTHROUGH_BACKING_DIR")
+        return cls(
+            enabled=_parse_bool(os.environ.get("NEXUS_FUSE_PASSTHROUGH")),
+            patterns=_parse_patterns(os.environ.get("NEXUS_FUSE_PASSTHROUGH_PATTERNS")),
+            deny_patterns=_parse_patterns(os.environ.get("NEXUS_FUSE_PASSTHROUGH_DENY_PATTERNS")),
+            threshold_bytes=int(os.environ.get("NEXUS_FUSE_PASSTHROUGH_THRESHOLD_BYTES", str(128 * 1024))),
+            require=_parse_bool(os.environ.get("NEXUS_FUSE_PASSTHROUGH_REQUIRE")),
+            backing_dir=Path(backing_dir) if backing_dir else None,
+        )
+
+
+def mount_is_passthrough_safe(nexus_fs: Any, *, mode_value: str, context: Any | None) -> bool:
+    if platform.system() != "Linux":
+        return False
+    if context is not None:
+        return False
+    if mode_value != "binary":
+        return False
+
+    kernel = getattr(nexus_fs, "_kernel", None)
+    hook_count = getattr(kernel, "hook_count", None)
+    if callable(hook_count):
+        for operation in ("read", "stat", "open"):
+            if hook_count(operation):
+                return False
+
+    return True
+
+
+@dataclass(slots=True)
+class RustPassthroughMount:
+    rust_binary: str
+    nexus_url: str
+    api_key: str
+    mount_point: Path
+    options: PassthroughOptions
+    agent_id: str | None = None
+    process: subprocess.Popen[str] | None = None
+    api_key_file: Path | None = None
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        nexus_url: str,
+        api_key: str,
+        mount_point: Path,
+        options: PassthroughOptions,
+        agent_id: str | None,
+    ) -> "RustPassthroughMount":
+        finder = RustFUSEClient.__new__(RustFUSEClient)
+        rust_binary = RustFUSEClient._find_rust_binary(finder)
+        return cls(
+            rust_binary=rust_binary,
+            nexus_url=nexus_url,
+            api_key=api_key,
+            mount_point=mount_point,
+            options=options,
+            agent_id=agent_id,
+        )
+
+    def build_command(self) -> tuple[list[str], dict[str, str], Path]:
+        fd, name = tempfile.mkstemp(prefix="nexus-fuse-api-key-", text=True)
+        api_key_path = Path(name)
+        try:
+            os.write(fd, self.api_key.encode())
+        finally:
+            os.close(fd)
+        api_key_path.chmod(0o600)
+        self.api_key_file = api_key_path
+
+        cmd = [
+            self.rust_binary,
+            "mount",
+            str(self.mount_point),
+            "--url",
+            self.nexus_url,
+            "--api-key-file",
+            str(api_key_path),
+            "--foreground",
+            "--passthrough",
+            "--passthrough-threshold-bytes",
+            str(self.options.threshold_bytes),
+        ]
+
+        for pattern in self.options.patterns:
+            cmd.extend(["--passthrough-pattern", pattern])
+        for pattern in self.options.deny_patterns:
+            cmd.extend(["--passthrough-deny-pattern", pattern])
+        if self.options.require:
+            cmd.append("--passthrough-require")
+        if self.options.backing_dir is not None:
+            cmd.extend(["--passthrough-backing-dir", str(self.options.backing_dir)])
+        if self.agent_id:
+            cmd.extend(["--agent-id", self.agent_id])
+
+        env = dict(os.environ)
+        env.pop("NEXUS_API_KEY", None)
+        return cmd, env, api_key_path
+
+    def start(self) -> None:
+        cmd, env, _api_key_file = self.build_command()
+        self.process = subprocess.Popen(
+            cmd,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+            text=True,
+            env=env,
+        )
+
+    def stop(self) -> None:
+        if self.process and self.process.poll() is None:
+            self.process.terminate()
+            try:
+                self.process.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                self.process.kill()
+                self.process.wait(timeout=5)
+        if self.api_key_file is not None:
+            try:
+                self.api_key_file.unlink()
+            except FileNotFoundError:
+                pass
+            self.api_key_file = None
+```
+
+- [ ] **Step 4: Run Python option tests**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus
+pytest tests/unit/fuse/test_passthrough_options.py -q
+```
+
+Expected: tests pass.
+
+- [ ] **Step 5: Commit Python helper module**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus
+git add src/nexus/fuse/passthrough.py tests/unit/fuse/test_passthrough_options.py
+git commit -m "feat(#4060): add python passthrough mount launcher"
+```
+
+Expected: commit succeeds.
+
+### Task 8: Route Python `use_rust=True` Mounts To Rust-Owned Passthrough
+
+**Files:**
+- Modify: `src/nexus/fuse/mount.py`
+- Modify: `tests/unit/fuse/test_passthrough_options.py`
+
+- [ ] **Step 1: Add failing routing tests**
+
+Append these tests to `tests/unit/fuse/test_passthrough_options.py`:
+
+```python
+from unittest.mock import patch
+
+from nexus.fuse.mount import MountMode, NexusFUSE
+
+
+def test_nexus_fuse_uses_rust_passthrough_launcher_when_safe(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr("nexus.fuse.passthrough.platform.system", lambda: "Linux")
+    fs = MagicMock()
+    fs._base_url = "http://localhost:2026"
+    fs._api_key = "sk-test"
+    fs._kernel.hook_count.return_value = 0
+    mount_point = tmp_path / "mnt"
+    mount_point.mkdir()
+
+    launcher = MagicMock()
+    with patch("nexus.fuse.mount.RustPassthroughMount.create", return_value=launcher):
+        fuse = NexusFUSE(
+            fs,
+            str(mount_point),
+            mode=MountMode.BINARY,
+            use_rust=True,
+            passthrough_enabled=True,
+            passthrough_patterns=["/data/**"],
+        )
+        fuse.mount(foreground=False)
+
+    launcher.start.assert_called_once_with()
+    assert fuse.is_mounted() is True
+
+
+def test_nexus_fuse_falls_back_when_passthrough_not_safe(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr("nexus.fuse.passthrough.platform.system", lambda: "Darwin")
+    fs = MagicMock()
+    fs._base_url = "http://localhost:2026"
+    fs._api_key = "sk-test"
+    mount_point = tmp_path / "mnt"
+    mount_point.mkdir()
+
+    with patch("nexus.fuse.mount.FUSE") as fuse_cls:
+        fuse = NexusFUSE(
+            fs,
+            str(mount_point),
+            mode=MountMode.BINARY,
+            use_rust=True,
+            passthrough_enabled=True,
+        )
+        fuse.mount(foreground=True)
+
+    fuse_cls.assert_called_once()
+```
+
+- [ ] **Step 2: Run routing tests and verify they fail**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus
+pytest tests/unit/fuse/test_passthrough_options.py -q
+```
+
+Expected: constructor argument failure for passthrough options.
+
+- [ ] **Step 3: Extend `NexusFUSE.__init__`**
+
+In `src/nexus/fuse/mount.py`, import helpers:
+
+```python
+from nexus.fuse.passthrough import (
+    PassthroughOptions,
+    RustPassthroughMount,
+    mount_is_passthrough_safe,
+)
+```
+
+Add constructor parameters after `use_rust`:
+
+```python
+        passthrough_enabled: bool | None = None,
+        passthrough_patterns: list[str] | None = None,
+        passthrough_deny_patterns: list[str] | None = None,
+        passthrough_threshold_bytes: int = 128 * 1024,
+        passthrough_require: bool = False,
+        passthrough_backing_dir: str | Path | None = None,
+```
+
+Set fields after `self._use_rust = use_rust`:
+
+```python
+        env_options = PassthroughOptions.from_env()
+        self._passthrough_options = PassthroughOptions(
+            enabled=env_options.enabled if passthrough_enabled is None else passthrough_enabled,
+            patterns=passthrough_patterns if passthrough_patterns is not None else env_options.patterns,
+            deny_patterns=(
+                passthrough_deny_patterns
+                if passthrough_deny_patterns is not None
+                else env_options.deny_patterns
+            ),
+            threshold_bytes=passthrough_threshold_bytes,
+            require=passthrough_require or env_options.require,
+            backing_dir=Path(passthrough_backing_dir) if passthrough_backing_dir else env_options.backing_dir,
+        )
+        self._rust_passthrough_mount: RustPassthroughMount | None = None
+```
+
+- [ ] **Step 4: Route eligible mounts before creating Python FUSE operations**
+
+In `NexusFUSE.mount`, after the mount-point validation and namespace `context` construction, before `NexusFUSEOperations(...)`, add:
+
+```python
+        if self._should_use_rust_passthrough(context):
+            self._start_rust_passthrough_mount()
+            return
+```
+
+Add these methods to `NexusFUSE`:
+
+```python
+    def _should_use_rust_passthrough(self, context: Any | None) -> bool:
+        if not (self._use_rust and self._passthrough_options.enabled):
+            return False
+        if not hasattr(self.nexus_fs, "_base_url") or not hasattr(self.nexus_fs, "_api_key"):
+            if self._passthrough_options.require:
+                raise RuntimeError("FUSE passthrough requires a remote NexusFS with _base_url and _api_key")
+            return False
+        if not mount_is_passthrough_safe(
+            self.nexus_fs,
+            mode_value=self.mode.value,
+            context=context,
+        ):
+            if self._passthrough_options.require:
+                raise RuntimeError("FUSE passthrough is not safe for this mount configuration")
+            return False
+        return True
+
+    def _start_rust_passthrough_mount(self) -> None:
+        self._rust_passthrough_mount = RustPassthroughMount.create(
+            nexus_url=self.nexus_fs._base_url,  # noqa: SLF001
+            api_key=self.nexus_fs._api_key,  # noqa: SLF001
+            mount_point=self.mount_point,
+            options=self._passthrough_options,
+            agent_id=getattr(self.nexus_fs, "_agent_id", self._agent_id),
+        )
+        self._rust_passthrough_mount.start()
+        self._mounted = True
+        self._start_warmup()
+```
+
+- [ ] **Step 5: Stop Rust passthrough process during unmount**
+
+At the end of successful `unmount`, before closing lease coordinator, add:
+
+```python
+            if self._rust_passthrough_mount is not None:
+                self._rust_passthrough_mount.stop()
+                self._rust_passthrough_mount = None
+```
+
+If unmount command fails because the Rust process has already exited, call `stop()` in the exception path before raising.
+
+- [ ] **Step 6: Thread options through `mount_nexus`**
+
+Add the same passthrough parameters to `mount_nexus(...)` and pass them into `NexusFUSE(...)`:
+
+```python
+        passthrough_enabled=passthrough_enabled,
+        passthrough_patterns=passthrough_patterns,
+        passthrough_deny_patterns=passthrough_deny_patterns,
+        passthrough_threshold_bytes=passthrough_threshold_bytes,
+        passthrough_require=passthrough_require,
+        passthrough_backing_dir=passthrough_backing_dir,
+```
+
+- [ ] **Step 7: Run Python routing tests**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus
+pytest tests/unit/fuse/test_passthrough_options.py -q
+```
+
+Expected: tests pass.
+
+- [ ] **Step 8: Run existing FUSE unit tests touched by constructor changes**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus
+pytest tests/unit/fuse/test_rust_available_guard.py tests/unit/fuse/test_rust_fallback.py tests/unit/fuse/test_io_handler.py -q
+```
+
+Expected: selected tests pass.
+
+- [ ] **Step 9: Commit Python routing**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus
+git add src/nexus/fuse/mount.py tests/unit/fuse/test_passthrough_options.py
+git commit -m "feat(#4060): route python passthrough mounts to rust fuse"
+```
+
+Expected: commit succeeds.
+
+### Task 9: Linux-Gated Integration Test And Benchmark Evidence
+
+**Files:**
+- Create: `nexus-fuse/tests/passthrough_integration.rs`
+- Create: `nexus-fuse/benches/passthrough_read.rs`
+- Modify: `nexus-fuse/README.md`
+- Modify: `nexus-fuse/PERFORMANCE_RESULTS.md`
+
+- [ ] **Step 1: Create Linux-gated integration test skeleton**
+
+Create `nexus-fuse/tests/passthrough_integration.rs`:
+
+```rust
+#![cfg(target_os = "linux")]
+
+use std::process::Command;
+
+#[test]
+fn passthrough_kernel_support_probe_is_nonfatal() {
+    let output = Command::new("uname")
+        .arg("-r")
+        .output()
+        .expect("uname");
+    assert!(output.status.success());
+}
+```
+
+- [ ] **Step 2: Run the gated integration test**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus/nexus-fuse
+cargo test --test passthrough_integration
+```
+
+Expected on Linux: test passes. Expected on macOS: Cargo reports the test target has no runnable tests because of `#![cfg(target_os = "linux")]`.
+
+- [ ] **Step 3: Create benchmark harness**
+
+Create `nexus-fuse/benches/passthrough_read.rs`:
+
+```rust
+use criterion::{criterion_group, criterion_main, Criterion};
+
+fn document_passthrough_benchmark(c: &mut Criterion) {
+    c.bench_function("issue_4060_passthrough_command_documented", |b| {
+        b.iter(|| {
+            let command = "dd if=/mnt/nexus/data/one-gib.bin of=/dev/null bs=8M status=progress";
+            criterion::black_box(command);
+        })
+    });
+}
+
+criterion_group!(benches, document_passthrough_benchmark);
+criterion_main!(benches);
+```
+
+Add the bench target to `nexus-fuse/Cargo.toml`:
+
+```toml
+[[bench]]
+name = "passthrough_read"
+harness = false
+```
+
+- [ ] **Step 4: Run the benchmark harness**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus/nexus-fuse
+cargo bench --bench passthrough_read -- --sample-size 10
+```
+
+Expected: Criterion runs the documentation harness successfully. The real throughput run still uses the documented `dd` command against a Linux FUSE mount.
+
+- [ ] **Step 5: Document flags and benchmark procedure**
+
+Append this section to `nexus-fuse/README.md`:
+
+````markdown
+## Linux FUSE Passthrough For Large Reads
+
+Passthrough is opt-in and is intended for raw, read-only large-file workloads on Linux kernels with FUSE passthrough support.
+
+Example:
+
+```bash
+nexus-fuse mount /mnt/nexus \
+  --url "$NEXUS_URL" \
+  --api-key-file "$NEXUS_API_KEY_FILE" \
+  --passthrough \
+  --passthrough-pattern "/data/**" \
+  --passthrough-threshold-bytes 131072
+```
+
+Fallback behavior:
+
+- Without `--passthrough`, reads use the normal userspace path.
+- On unsupported platforms, passthrough is disabled unless `--passthrough-require` is set.
+- Files below the threshold, directories, denied patterns, and write opens use normal userspace reads.
+
+Benchmark:
+
+```bash
+dd if=/mnt/nexus/data/one-gib.bin of=/dev/null bs=8M status=progress
+```
+````
+
+- [ ] **Step 6: Record performance evidence**
+
+Append this section to `nexus-fuse/PERFORMANCE_RESULTS.md`:
+
+````markdown
+## Issue #4060: FUSE Passthrough Large Sequential Reads
+
+Command:
+
+```bash
+dd if=/mnt/nexus/data/one-gib.bin of=/dev/null bs=8M status=progress
+```
+
+Acceptance target: at least 2x the normal userspace read path, with expected throughput near or above 6 GB/s on a supported Linux 6.9+ environment.
+
+Local non-Linux development note: the command is documented here and the Rust/Python unit coverage verifies eligibility, fallback, and command construction. The final PR should include Linux benchmark output from a host with FUSE passthrough enabled.
+````
+
+- [ ] **Step 7: Run documentation and benchmark checks**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus/nexus-fuse
+cargo test --test passthrough_integration
+cargo bench --bench passthrough_read -- --sample-size 10
+```
+
+Expected: commands pass on the local platform with the Linux cfg behavior described above.
+
+- [ ] **Step 8: Commit integration and docs**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus
+git add nexus-fuse/tests/passthrough_integration.rs nexus-fuse/benches/passthrough_read.rs nexus-fuse/Cargo.toml nexus-fuse/README.md nexus-fuse/PERFORMANCE_RESULTS.md
+git commit -m "test(#4060): document passthrough benchmark coverage"
+```
+
+Expected: commit succeeds.
+
+### Task 10: Full Verification And PR Readiness
+
+**Files:**
+- Verify all changed files from Tasks 1-9
+
+- [ ] **Step 1: Run Rust verification**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus/nexus-fuse
+cargo fmt --check
+cargo check --lib --bin nexus-fuse
+cargo test --lib
+cargo test --test passthrough_integration
+```
+
+Expected: all commands pass or the Linux-gated integration target reports no runnable tests on non-Linux.
+
+- [ ] **Step 2: Run Python verification**
+
+Run:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus
+ruff check src/nexus/fuse/passthrough.py src/nexus/fuse/mount.py tests/unit/fuse/test_passthrough_options.py
+pytest tests/unit/fuse/test_passthrough_options.py tests/unit/fuse/test_rust_available_guard.py tests/unit/fuse/test_rust_fallback.py tests/unit/fuse/test_io_handler.py -q
+```
+
+Expected: commands pass.
+
+- [ ] **Step 3: Run end-to-end smoke commands where available**
+
+On a Linux host with FUSE passthrough support:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus/nexus-fuse
+cargo build --release
+mkdir -p /tmp/nexus-passthrough-mnt
+target/release/nexus-fuse mount /tmp/nexus-passthrough-mnt \
+  --url "$NEXUS_URL" \
+  --api-key-file "$NEXUS_API_KEY_FILE" \
+  --passthrough \
+  --passthrough-pattern "/data/**" \
+  --passthrough-threshold-bytes 131072
+```
+
+In a second shell:
+
+```bash
+dd if=/tmp/nexus-passthrough-mnt/data/one-gib.bin of=/dev/null bs=8M status=progress
+fusermount -u /tmp/nexus-passthrough-mnt
+```
+
+Expected: throughput is at least 2x the normal userspace path. Record the output in `nexus-fuse/PERFORMANCE_RESULTS.md` before creating the PR.
+
+- [ ] **Step 4: Confirm fallback behavior**
+
+Run on macOS or any non-Linux host:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus/nexus-fuse
+cargo run -- mount /tmp/nexus-fuse-missing \
+  --url http://localhost:2026 \
+  --api-key test \
+  --passthrough
+```
+
+Expected: mount-point validation fails for the missing directory before any passthrough panic. When run with a real mount point on a non-Linux host and without `--passthrough-require`, logs show passthrough disabled and the userspace path is used.
+
+- [ ] **Step 5: Commit final fixes**
+
+Run only if verification forced formatting or small corrective edits:
+
+```bash
+cd /Users/tafeng/.codex/worktrees/4728/nexus
+git add nexus-fuse src/nexus/fuse tests/unit/fuse
+git commit -m "fix(#4060): polish passthrough verification"
+```
+
+Expected: commit succeeds only when there are final verification edits.
+
+## Coverage Checklist
+
+- Direct Rust mount: `nexus-fuse mount --passthrough` builds a passthrough manager and attempts backing registration only for eligible files.
+- Python `use_rust=True`: passthrough starts a Rust-owned FUSE mount process only for remote, binary, hook-safe mounts.
+- Per-pattern gating: allow and deny globs are tested in Rust and passed from Python to Rust.
+- Graceful fallback: unsupported platform or unsafe Python mount falls back unless `require` is set.
+- Hook semantics: Python hook-sensitive mounts remain on the existing Python FUSE path.
+- Existing daemon path: `nexus-fuse daemon` and Python Rust IPC reads stay unchanged for non-passthrough operation.
+- Benchmark: PR includes the documented Linux throughput command and records the measured result when a supported kernel is available.

--- a/docs/superpowers/specs/2026-05-12-issue-4060-fuse-passthrough-design.md
+++ b/docs/superpowers/specs/2026-05-12-issue-4060-fuse-passthrough-design.md
@@ -1,0 +1,274 @@
+# Issue #4060 - FUSE Passthrough For Large Reads Design
+
+**Date**: 2026-05-12
+**Issue**: [#4060](https://github.com/nexi-lab/nexus/issues/4060) - [P1] FUSE_PASSTHROUGH for large reads (Linux 6.9+)
+
+## Context
+
+`nexus-fuse` currently serves reads through userspace FUSE callbacks. The direct Rust mount path handles `open()` and `read()` in `nexus-fuse/src/fs.rs`; the Python `NexusFUSE(..., use_rust=True)` path still owns the FUSE session in Python and delegates hot operations to the Rust Unix-socket daemon in `nexus-fuse/src/daemon.rs` through `src/nexus/fuse/rust_client.py`.
+
+Linux 6.9 added FUSE passthrough. A FUSE filesystem can register a real backing file with the kernel and return a backing ID in the `OPEN` reply. Subsequent reads for that handle bypass userspace FUSE and are served directly from the backing file. This only works when the process answering FUSE `open()` also negotiates passthrough support and registers the backing file.
+
+The current `nexus-fuse` crate uses `fuser = 0.14`, which does not expose passthrough open replies. Current `fuser` releases expose passthrough through `KernelConfig` and `ReplyOpen` APIs, so this feature requires upgrading `fuser` before wiring passthrough into `NexusFs`.
+
+## Decision
+
+Implement the full issue scope in one PR by making the Rust process the passthrough-capable FUSE owner for both supported paths:
+
+1. Direct `nexus-fuse mount` negotiates passthrough and returns backing IDs for eligible read-only large files.
+2. Python `NexusFUSE(..., use_rust=True)` can launch a Rust-owned `nexus-fuse mount` when passthrough is enabled, instead of constructing Python FUSE callbacks plus the Rust IPC daemon.
+3. The existing Rust IPC daemon remains available for non-passthrough Python acceleration and for platforms or configurations where passthrough is disabled or unsupported.
+
+The design is conservative: passthrough is opt-in, pattern-gated, read-only, Linux-only, and falls back to the existing userspace read path whenever capability negotiation, policy checks, materialization, or backing registration fails.
+
+## Non-Goals
+
+1. Enabling passthrough by default.
+2. Supporting passthrough on macOS or non-Linux platforms.
+3. Allowing passthrough for writable opens.
+4. Allowing passthrough for paths where Nexus must intercept reads for parser, hook, snapshot, workflow, or audit semantics.
+5. Replacing the existing foyer read-through cache for normal userspace reads.
+6. Rewriting remote/cloud storage to use signed direct download URLs in this PR.
+7. Guaranteeing passthrough for every backend. The first implementation uses local materialized backing files.
+
+## Architecture
+
+Add a small passthrough subsystem under `nexus-fuse` with three boundaries:
+
+- `passthrough::config`: CLI/env parsing, glob policy, thresholds, and feature enablement.
+- `passthrough::policy`: kernel capability state plus per-path eligibility checks.
+- `passthrough::backing`: materialized backing-file lifecycle, backing-key selection, open file descriptor ownership, and invalidation.
+
+`NexusFs` owns an optional passthrough manager. During FUSE initialization, it asks `fuser` to enable passthrough and records whether the kernel/session accepted it. During `open()`, `NexusFs` resolves the path, checks policy, materializes a validated local backing file if needed, registers it through the upgraded `fuser` passthrough API, and replies with a backing ID. For ordinary handles it replies exactly as it does today.
+
+The Python mount integration gets a new passthrough branch. When `use_rust=True` and passthrough is requested, Python starts `nexus-fuse mount` as the actual FUSE daemon and supervises its lifecycle. Python still owns credentials, mount orchestration, and fallback behavior. The old Python FUSE plus Rust IPC daemon path remains the fallback when passthrough is off, unsupported, or explicitly not required.
+
+## Configuration
+
+Passthrough is disabled unless the user enables it explicitly.
+
+Rust CLI and environment:
+
+```text
+--passthrough / NEXUS_FUSE_PASSTHROUGH=true
+--passthrough-pattern <glob> / NEXUS_FUSE_PASSTHROUGH_PATTERNS
+--passthrough-threshold-bytes / NEXUS_FUSE_PASSTHROUGH_THRESHOLD_BYTES
+--passthrough-require / NEXUS_FUSE_PASSTHROUGH_REQUIRE=true
+```
+
+Defaults:
+
+- passthrough enabled: false
+- patterns: empty, meaning no file is eligible
+- threshold: 131072 bytes
+- require mode: false
+
+`NEXUS_FUSE_PASSTHROUGH_PATTERNS` is comma-separated. Repeated CLI patterns append to env patterns. If the final allow-pattern set is empty, no file is eligible even when `--passthrough` is set.
+
+Python `NexusFUSE` exposes equivalent constructor and mount options, then passes them to `nexus-fuse mount` when using the Rust-owned passthrough path.
+
+## Eligibility
+
+A file is eligible only when all conditions are true:
+
+1. The platform is Linux.
+2. The FUSE session negotiated passthrough support successfully.
+3. Passthrough is enabled in config.
+4. The virtual path matches at least one configured passthrough allow pattern.
+5. The path does not match a deny policy derived from hook/parser/snapshot/workflow constraints.
+6. `stat` says the entry is a regular file and size is at least the threshold.
+7. The open flags are read-only and do not request truncation, create, append write, or read-write access.
+8. No active read/stat intercept semantics require Nexus to observe this read.
+9. A local backing file can be materialized and validated against the current ETag/content identity.
+
+The safe default is to deny passthrough. Policy code returns a structured reason for ineligibility so tests and logs can distinguish "disabled", "unsupported kernel", "pattern miss", "too small", "write open", "hook sensitive", and "materialization failed".
+
+## Hook And Parser Semantics
+
+The Rust FUSE process must not guess whether Python-side services need interception. Python computes a conservative passthrough policy before launching Rust:
+
+- If read/stat intercept hooks are active globally, passthrough is disabled unless the user supplies a narrower allow-pattern set that Python can mark safe.
+- If parser auto-parse, snapshot observers, workflow triggers, or audit policies require read interception for a path family, Python passes deny patterns for those path families.
+- If Python cannot determine whether a path family is safe, it denies passthrough for that family.
+
+The first PR does not rebuild a dynamic hook-policy RPC. It passes a startup policy snapshot from Python to Rust. This matches the existing mount lifecycle: hook and parser configuration is established before the mount starts. If a later feature supports dynamic hook registration after mount, it must add a policy-update channel or force passthrough off for dynamic mounts.
+
+## Backing Files
+
+Passthrough needs a real local file descriptor. The first implementation materializes eligible files into local immutable backing files under a cache-owned directory.
+
+Backing key:
+
+```text
+hash(server_url, virtual_path, etag_or_content_id, size)
+```
+
+Rules:
+
+- A backing file is opened read-only.
+- The key includes ETag or content identity when available, so stale data is not reused after mutation.
+- Materialization writes to a temporary file, verifies final size, then atomically renames into place.
+- The manager keeps handle state for registered backing files so `release()` can close and unregister state cleanly.
+- Writes, truncates, deletes, renames, and explicit cache invalidations remove affected backing entries.
+- Startup may leave old backing files on disk; a best-effort cleanup can prune files not referenced by the current in-process index.
+
+The existing foyer cache remains the userspace read cache. Backing files are a passthrough-specific representation. The implementation may share the same root directory, but should keep a separate subdirectory to avoid depending on foyer internals.
+
+## Data Flow
+
+### Open
+
+1. Resolve inode to virtual path.
+2. Reject directories with `EISDIR` as today.
+3. Check whether passthrough is enabled, negotiated, and policy-eligible.
+4. If ineligible, return a normal opened handle.
+5. If eligible, materialize or reuse the local backing file.
+6. Register the backing file through `fuser`.
+7. Return the passthrough backing ID in the `OPEN` reply.
+8. If any passthrough step fails, log the reason and return a normal opened handle unless require mode is enabled.
+9. In require mode, return an error when passthrough was requested but cannot be established for an otherwise eligible file.
+
+### Read
+
+Normal handles continue through `NexusFs::read()` and `read_with_cache()`.
+
+Passthrough handles do not call `NexusFs::read()`. The kernel reads from the registered backing file.
+
+### Release
+
+Normal handles behave as they do today.
+
+Passthrough handles release their registered backing state. The backing file may remain on disk for reuse if its key still matches current metadata.
+
+### Invalidation
+
+All mutation paths that call `invalidate_path()` also invalidate passthrough backing entries:
+
+- `write`
+- `create`
+- `unlink`
+- `rename`
+- `setattr` truncate
+- daemon write/delete/rename equivalents where applicable
+
+Rename invalidates both old and new paths.
+
+## Python Integration
+
+`src/nexus/fuse/mount.py` gains passthrough options. When `use_rust=True` and passthrough is enabled, mount orchestration uses a Rust-owned FUSE process:
+
+```text
+nexus-fuse mount <mount_point> --url <url> --api-key-file <file> --passthrough --passthrough-pattern ...
+```
+
+The API key should continue to avoid process-list exposure. Python should prefer `--api-key-file` or a private temporary file over `NEXUS_API_KEY` when launching long-lived mount processes.
+
+Fallback behavior:
+
+- If passthrough is disabled, preserve current behavior for `use_rust`: Python owns the FUSE session and may delegate hot operations to the Rust IPC daemon.
+- If passthrough startup reports unsupported kernel/session and require mode is false, fall back to the current Python FUSE plus Rust IPC daemon path.
+- If require mode is true, fail mount startup with a clear error.
+- If Rust-owned mount starts successfully, Python tracks and terminates that process on unmount.
+
+## Error Handling
+
+Passthrough is an optimization unless require mode is set. Runtime failures degrade to userspace reads:
+
+- unsupported kernel or missing FUSE capability: normal userspace path
+- `fuser` passthrough registration error: normal userspace path
+- materialization download error: normal userspace path
+- ETag/content mismatch after materialization: invalidate backing file and normal userspace path
+- open flags are writable or truncating: normal userspace path
+- path is hook-sensitive: normal userspace path
+
+Logs should include structured reasons at debug or info level, but avoid logging API keys or local backing filenames if those include sensitive path fragments.
+
+## Tests
+
+Most tests do not require a Linux 6.9 FUSE host.
+
+Rust unit tests:
+
+- passthrough config is disabled by default
+- CLI/env pattern parsing handles repeated and comma-separated patterns
+- empty pattern set denies all files
+- threshold defaults to 131072 bytes
+- paths below threshold are denied
+- read-only flags are accepted
+- write, read-write, create, truncate, and append flags are denied
+- unsupported kernel/session denies passthrough
+- path allow-pattern miss denies passthrough
+- deny-pattern match denies passthrough
+- hook-sensitive policy denies passthrough
+- backing key changes when ETag/content identity changes
+- materialization writes through a temporary file and verifies size
+- backing invalidation removes affected path entries
+
+Rust integration-style tests with mocked Nexus HTTP:
+
+- materialization downloads content on miss
+- ETag match reuses an existing backing file
+- ETag/content change creates a new backing file
+- materialization failure falls back to normal open decision
+
+Python tests:
+
+- passthrough-enabled `use_rust=True` selects Rust-owned FUSE mount orchestration
+- passthrough-disabled `use_rust=True` keeps current Python FUSE plus Rust IPC daemon path
+- unsupported Rust startup falls back when require mode is false
+- unsupported Rust startup fails when require mode is true
+- passthrough patterns and threshold are passed to the Rust command
+- API key is passed through file-based credentials, not command-line arguments
+
+Linux-gated FUSE integration:
+
+- skipped unless running on Linux with `/dev/fuse`, mount privileges, and passthrough negotiation support
+- mounts a test filesystem
+- reads an eligible large file and verifies userspace `read()` counter does not increment for passthrough reads
+- reads an ineligible small or hook-sensitive file and verifies userspace `read()` counter increments
+- verifies writes invalidate backing state and subsequent reads see new content
+
+## Benchmark
+
+Record a benchmark under `nexus-fuse/PERFORMANCE_RESULTS.md`:
+
+```text
+1 GiB sequential read, userspace FUSE path
+1 GiB sequential read, passthrough path
+```
+
+The benchmark report must include:
+
+- kernel version
+- distro
+- filesystem for backing cache
+- Rust version
+- `fuser` version
+- `nexus-fuse` command line
+- passthrough threshold and patterns
+- userspace throughput
+- passthrough throughput
+- speedup
+
+Acceptance target: passthrough throughput at least 2x the userspace FUSE path for the same already-materialized blob. The issue target is approximately 6+ GB/s, but the required acceptance gate is the 2x comparison because hardware and cache filesystem strongly affect absolute throughput.
+
+## Acceptance Mapping
+
+- Passthrough enabled for large reads on supported kernels: Rust mount negotiates passthrough and returns backing IDs for eligible opens.
+- Per-pattern gating: allow patterns are required and deny patterns protect hook/parser-sensitive paths.
+- Graceful fallback on kernel < 6.9: unsupported capability disables passthrough unless require mode is set.
+- Benchmark: documented 1 GiB sequential read comparison with at least 2x speedup.
+- Hook semantics preserved: passthrough is denied by default for active read/stat hooks, parser/snapshot/workflow-sensitive paths, writable opens, and ambiguous policy states.
+
+## Implementation Notes
+
+Implementation should proceed TDD-first:
+
+1. Add pure config and policy tests.
+2. Add backing-key and materialization tests.
+3. Upgrade `fuser` and wire capability negotiation.
+4. Wire direct Rust mount passthrough open/release.
+5. Add Python orchestration tests and integration.
+6. Add Linux-gated FUSE integration and benchmark documentation.
+
+Do not start by wiring kernel passthrough APIs directly into `fs.rs`; the policy and backing-file units need tests first so the fallback matrix stays understandable.

--- a/nexus-fuse/Cargo.lock
+++ b/nexus-fuse/Cargo.lock
@@ -163,6 +163,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c4512299f36f043ab09a583e57bceb5a5aab7a73db1805848e8fef3c9e8c78b3"
 
 [[package]]
+name = "block-buffer"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
+dependencies = [
+ "generic-array",
+]
+
+[[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -352,6 +371,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cpufeatures"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "criterion"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -416,6 +444,26 @@ name = "crunchy"
 version = "0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
+name = "crypto-common"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+dependencies = [
+ "generic-array",
+ "typenum",
+]
+
+[[package]]
+name = "digest"
+version = "0.10.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
+dependencies = [
+ "block-buffer",
+ "crypto-common",
+]
 
 [[package]]
 name = "dirs"
@@ -748,6 +796,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "generic-array"
+version = "0.14.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
+dependencies = [
+ "typenum",
+ "version_check",
+]
+
+[[package]]
 name = "getrandom"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -785,6 +843,19 @@ dependencies = [
  "r-efi 6.0.0",
  "wasip2",
  "wasip3",
+]
+
+[[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
 ]
 
 [[package]]
@@ -868,6 +939,12 @@ name = "hermit-abi"
 version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -1438,6 +1515,8 @@ dependencies = [
  "env_logger",
  "foyer",
  "fuser",
+ "globset",
+ "hex",
  "libc",
  "log",
  "lru",
@@ -1446,6 +1525,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "tempfile",
  "thiserror",
  "tokio",
@@ -2198,6 +2278,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "digest",
+]
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2565,6 +2656,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typenum"
+version = "1.20.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "40ce102ab67701b8526c123c1bab5cbe42d7040ccfd0f64af1a385808d2f43de"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2617,6 +2714,12 @@ name = "vcpkg"
 version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
+
+[[package]]
+name = "version_check"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b928f33d975fc6ad9f86c8f283853ad26bdd5b10b7f1542aa2fa15e2289105a"
 
 [[package]]
 name = "walkdir"

--- a/nexus-fuse/Cargo.toml
+++ b/nexus-fuse/Cargo.toml
@@ -66,6 +66,11 @@ libc = "0.2"
 # scheduling primitives used by foyer's hybrid cache.
 tokio = { version = "1", features = ["rt-multi-thread", "net", "io-util", "macros", "signal", "sync", "time"] }
 
+# Passthrough path matching and stable backing-file keys
+globset = "0.4"
+sha2 = "0.10"
+hex = "0.4"
+
 [dev-dependencies]
 # Mocking HTTP requests for tests
 mockito = "1.7"
@@ -99,6 +104,10 @@ harness = false
 
 [[bench]]
 name = "concurrent_read"
+harness = false
+
+[[bench]]
+name = "passthrough_read"
 harness = false
 
 [profile.release]

--- a/nexus-fuse/PERFORMANCE_RESULTS.md
+++ b/nexus-fuse/PERFORMANCE_RESULTS.md
@@ -367,3 +367,20 @@ to reflect the actual measurement, which is what this PR now reports.
 - Rust: rustc 1.95.0
 - reqwest: 0.13 (async, rustls)
 - tokio: 1 (multi-thread, 2 worker threads in the shared HTTP runtime)
+
+## Issue #4060: FUSE Passthrough Large Sequential Reads
+
+Command:
+```bash
+dd if=/mnt/nexus/data/one-gib.bin of=/dev/null bs=8M status=progress
+```
+
+Opt-in Criterion harness:
+```bash
+NEXUS_FUSE_PASSTHROUGH_BENCH_FILE=/mnt/nexus/data/one-gib.bin \
+  cargo bench --bench passthrough_read -- --sample-size 10
+```
+
+Acceptance target: at least 2x the normal userspace read path on a supported Linux 6.9+ environment.
+
+Local non-Linux development note: passthrough throughput was not measured in this commit. The manual command is documented here, and Rust/Python coverage verifies eligibility, fallback, command construction, and the opt-in benchmark harness. The final PR should include Linux benchmark output from a host with FUSE passthrough enabled.

--- a/nexus-fuse/README.md
+++ b/nexus-fuse/README.md
@@ -1,0 +1,37 @@
+# Nexus FUSE
+
+## Linux FUSE Passthrough For Large Reads
+
+Passthrough is opt-in and is intended for raw, read-only large-file workloads on Linux kernels with FUSE passthrough support.
+
+Example:
+
+```bash
+nexus-fuse mount /mnt/nexus \
+  --url "$NEXUS_URL" \
+  --api-key-file "$NEXUS_API_KEY_FILE" \
+  --passthrough \
+  --passthrough-pattern "/data/**" \
+  --passthrough-threshold-bytes 131072
+```
+
+Fallback behavior:
+
+- Without `--passthrough`, reads use the normal userspace path.
+- On unsupported platforms, passthrough is disabled unless `--passthrough-require` is set.
+- Files below the threshold, directories, denied patterns, and write opens use normal userspace reads.
+
+Benchmark:
+
+```bash
+dd if=/mnt/nexus/data/one-gib.bin of=/dev/null bs=8M status=progress
+```
+
+The Criterion bench target is opt-in because it must read from a real mounted
+passthrough file. Without the environment variable below, the target exits after
+printing setup instructions instead of recording meaningless local numbers.
+
+```bash
+NEXUS_FUSE_PASSTHROUGH_BENCH_FILE=/mnt/nexus/data/one-gib.bin \
+  cargo bench --bench passthrough_read -- --sample-size 10
+```

--- a/nexus-fuse/benches/passthrough_read.rs
+++ b/nexus-fuse/benches/passthrough_read.rs
@@ -1,0 +1,39 @@
+use criterion::Criterion;
+use std::env;
+use std::hint::black_box;
+use std::process::Command;
+
+const BENCH_FILE_ENV: &str = "NEXUS_FUSE_PASSTHROUGH_BENCH_FILE";
+
+fn main() {
+    let Some(input_path) = bench_file_from_env() else {
+        eprintln!(
+            "Skipping passthrough read benchmark: set {BENCH_FILE_ENV} to a large file inside a mounted Nexus FUSE passthrough filesystem.\n\
+             Example: {BENCH_FILE_ENV}=/mnt/nexus/data/one-gib.bin cargo bench --bench passthrough_read -- --sample-size 10"
+        );
+        return;
+    };
+
+    let mut criterion = Criterion::default().configure_from_args();
+    criterion.bench_function("issue_4060_passthrough_dd_read", |b| {
+        b.iter(|| {
+            let status = Command::new("dd")
+                .arg(format!("if={input_path}"))
+                .arg("of=/dev/null")
+                .arg("bs=8M")
+                .arg("status=none")
+                .status()
+                .expect("run dd passthrough read benchmark");
+            assert!(status.success(), "dd passthrough read benchmark failed");
+            black_box(status);
+        })
+    });
+    criterion.final_summary();
+}
+
+fn bench_file_from_env() -> Option<String> {
+    env::var(BENCH_FILE_ENV)
+        .ok()
+        .map(|value| value.trim().to_string())
+        .filter(|value| !value.is_empty())
+}

--- a/nexus-fuse/src/client.rs
+++ b/nexus-fuse/src/client.rs
@@ -102,6 +102,23 @@ pub enum ReadResponse {
     NotModified,
 }
 
+/// Response from read operations that decode content directly into a writer.
+#[derive(Debug)]
+pub enum ReadToWriterResponse {
+    /// Content was written into the supplied writer.
+    Content {
+        bytes_written: u64,
+        etag: Option<String>,
+    },
+    /// Content not modified (304 response).
+    NotModified,
+}
+
+enum EncodedReadResponse {
+    Content { data: String, etag: Option<String> },
+    NotModified,
+}
+
 /// Process-wide tokio runtime that drives every NexusClient HTTP
 /// future. Stored in a `OnceLock` so it lives for the entire process
 /// and never drops in an async context (which would panic). One
@@ -247,10 +264,7 @@ impl NexusClient {
             -32004 => NexusClientError::PermissionDenied(message),
             -32005 => NexusClientError::ValidationError(message),
             -32006 => NexusClientError::Conflict(message),
-            other => NexusClientError::InvalidResponse(format!(
-                "RPC error {}: {}",
-                other, message
-            )),
+            other => NexusClientError::InvalidResponse(format!("RPC error {}: {}", other, message)),
         }
     }
 
@@ -320,12 +334,7 @@ impl NexusClient {
         let url = format!("{}/api/auth/whoami", self.base_url);
         debug!("GET {}", url);
 
-        let resp = self
-            .client
-            .get(&url)
-            .headers(self.headers())
-            .send()
-            .await?;
+        let resp = self.client.get(&url).headers(self.headers()).send().await?;
 
         if !resp.status().is_success() {
             let status = resp.status();
@@ -481,6 +490,25 @@ impl NexusClient {
     ) -> Result<ReadResponse, NexusClientError> {
         use base64::{engine::general_purpose::STANDARD, Engine};
 
+        match self
+            .read_encoded_with_etag_async(path, if_none_match)
+            .await?
+        {
+            EncodedReadResponse::Content { data, etag } => {
+                let content = STANDARD.decode(&data).map_err(|e| {
+                    NexusClientError::InvalidResponse(format!("base64 decode error: {}", e))
+                })?;
+                Ok(ReadResponse::Content { content, etag })
+            }
+            EncodedReadResponse::NotModified => Ok(ReadResponse::NotModified),
+        }
+    }
+
+    async fn read_encoded_with_etag_async(
+        &self,
+        path: &str,
+        if_none_match: Option<&str>,
+    ) -> Result<EncodedReadResponse, NexusClientError> {
         let url = format!("{}/api/nfs/read", self.base_url);
 
         let rpc_request = json!({
@@ -511,7 +539,7 @@ impl NexusClient {
         // Handle 304 Not Modified
         if resp.status().as_u16() == 304 {
             debug!("Server returned 304 Not Modified for {}", path);
-            return Ok(ReadResponse::NotModified);
+            return Ok(EncodedReadResponse::NotModified);
         }
 
         if !resp.status().is_success() {
@@ -550,11 +578,10 @@ impl NexusClient {
         let result = rpc_resp.result.ok_or_else(|| {
             NexusClientError::InvalidResponse("no result in response".to_string())
         })?;
-        let content = STANDARD.decode(&result.data).map_err(|e| {
-            NexusClientError::InvalidResponse(format!("base64 decode error: {}", e))
-        })?;
-
-        Ok(ReadResponse::Content { content, etag })
+        Ok(EncodedReadResponse::Content {
+            data: result.data,
+            etag,
+        })
     }
 
     /// Read file contents with ETag support for conditional requests.
@@ -567,12 +594,54 @@ impl NexusClient {
         self.block_on(self.read_with_etag_async(path, if_none_match))
     }
 
-    /// Async core: write.
-    pub async fn write_async(
+    /// Async core: read with optional If-None-Match and decode into a writer.
+    pub async fn read_with_etag_to_writer_async<W: std::io::Write>(
         &self,
         path: &str,
-        content: &[u8],
-    ) -> Result<(), NexusClientError> {
+        if_none_match: Option<&str>,
+        writer: &mut W,
+    ) -> Result<ReadToWriterResponse, NexusClientError> {
+        use base64::engine::general_purpose::STANDARD;
+        use base64::read::DecoderReader;
+        use std::io;
+
+        match self
+            .read_encoded_with_etag_async(path, if_none_match)
+            .await?
+        {
+            EncodedReadResponse::Content { data, etag } => {
+                let mut decoder = DecoderReader::new(data.as_bytes(), &STANDARD);
+                let bytes_written = io::copy(&mut decoder, writer).map_err(|err| {
+                    if err.kind() == io::ErrorKind::InvalidData {
+                        NexusClientError::InvalidResponse(format!("base64 decode error: {}", err))
+                    } else {
+                        NexusClientError::Other(anyhow::anyhow!(
+                            "failed to write read response into writer: {}",
+                            err
+                        ))
+                    }
+                })?;
+                Ok(ReadToWriterResponse::Content {
+                    bytes_written,
+                    etag,
+                })
+            }
+            EncodedReadResponse::NotModified => Ok(ReadToWriterResponse::NotModified),
+        }
+    }
+
+    /// Read file contents with ETag support, decoding directly into a writer.
+    pub fn read_with_etag_to_writer<W: std::io::Write>(
+        &self,
+        path: &str,
+        if_none_match: Option<&str>,
+        writer: &mut W,
+    ) -> Result<ReadToWriterResponse, NexusClientError> {
+        self.block_on(self.read_with_etag_to_writer_async(path, if_none_match, writer))
+    }
+
+    /// Async core: write.
+    pub async fn write_async(&self, path: &str, content: &[u8]) -> Result<(), NexusClientError> {
         use base64::{engine::general_purpose::STANDARD, Engine};
 
         // API expects {"__type__": "bytes", "data": "base64..."} format
@@ -598,9 +667,7 @@ impl NexusClient {
 
     /// Async core: mkdir.
     pub async fn mkdir_async(&self, path: &str) -> Result<(), NexusClientError> {
-        let _: Value = self
-            .rpc_call_async("mkdir", json!({"path": path}))
-            .await?;
+        let _: Value = self.rpc_call_async("mkdir", json!({"path": path})).await?;
         Ok(())
     }
 
@@ -611,9 +678,7 @@ impl NexusClient {
 
     /// Async core: delete.
     pub async fn delete_async(&self, path: &str) -> Result<(), NexusClientError> {
-        let _: Value = self
-            .rpc_call_async("delete", json!({"path": path}))
-            .await?;
+        let _: Value = self.rpc_call_async("delete", json!({"path": path})).await?;
         Ok(())
     }
 
@@ -650,18 +715,13 @@ impl NexusClient {
     /// them into `false`, so callers that need to distinguish
     /// "path is missing" from "you don't have permission to ask" can
     /// see the auth signal (#4056 R4).
-    pub async fn exists_result_async(
-        &self,
-        path: &str,
-    ) -> Result<bool, NexusClientError> {
+    pub async fn exists_result_async(&self, path: &str) -> Result<bool, NexusClientError> {
         #[derive(Deserialize)]
         struct ExistsResult {
             exists: bool,
         }
 
-        let result: ExistsResult = self
-            .rpc_call_async("exists", json!({"path": path}))
-            .await?;
+        let result: ExistsResult = self.rpc_call_async("exists", json!({"path": path})).await?;
         Ok(result.exists)
     }
 
@@ -687,5 +747,86 @@ impl NexusClient {
     /// variant.
     pub fn exists(&self, path: &str) -> bool {
         self.block_on(self.exists_async(path))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::{engine::general_purpose::STANDARD, Engine};
+    use mockito::Server;
+    use std::io;
+
+    #[test]
+    fn read_with_etag_to_writer_decodes_content_into_writer() {
+        let mut server = Server::new();
+        let body = format!(
+            r#"{{"jsonrpc":"2.0","id":1,"result":{{"__type__":"bytes","data":"{}"}}}}"#,
+            STANDARD.encode(b"writer-data")
+        );
+        let _mock = server
+            .mock("POST", "/api/nfs/read")
+            .match_body(mockito::Matcher::Regex(
+                r#""path"\s*:\s*"/data/file.bin""#.to_string(),
+            ))
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_header("etag", r#""etag-1""#)
+            .with_body(body)
+            .create();
+        let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+        let mut output = Vec::new();
+
+        let result = client
+            .read_with_etag_to_writer("/data/file.bin", None, &mut output)
+            .unwrap();
+
+        assert_eq!(output, b"writer-data");
+        match result {
+            ReadToWriterResponse::Content {
+                bytes_written,
+                etag,
+            } => {
+                assert_eq!(bytes_written, b"writer-data".len() as u64);
+                assert_eq!(etag.as_deref(), Some("etag-1"));
+            }
+            ReadToWriterResponse::NotModified => panic!("expected content"),
+        }
+    }
+
+    #[test]
+    fn read_with_etag_to_writer_preserves_writer_errors_as_io_failures() {
+        struct FailingWriter;
+
+        impl io::Write for FailingWriter {
+            fn write(&mut self, _buf: &[u8]) -> io::Result<usize> {
+                Err(io::Error::new(io::ErrorKind::Other, "disk full"))
+            }
+
+            fn flush(&mut self) -> io::Result<()> {
+                Ok(())
+            }
+        }
+
+        let mut server = Server::new();
+        let body = format!(
+            r#"{{"jsonrpc":"2.0","id":1,"result":{{"__type__":"bytes","data":"{}"}}}}"#,
+            STANDARD.encode(b"writer-data")
+        );
+        let _mock = server
+            .mock("POST", "/api/nfs/read")
+            .with_status(200)
+            .with_header("content-type", "application/json")
+            .with_body(body)
+            .create();
+        let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+        let mut output = FailingWriter;
+
+        let err = client
+            .read_with_etag_to_writer("/data/file.bin", None, &mut output)
+            .unwrap_err();
+
+        assert!(matches!(err, NexusClientError::Other(_)));
+        assert_eq!(err.to_errno(), libc::EIO);
     }
 }

--- a/nexus-fuse/src/fs.rs
+++ b/nexus-fuse/src/fs.rs
@@ -4,14 +4,16 @@ use crate::cache::FileCache;
 use crate::cached_read::{read_with_cache, CachedReadResult};
 use crate::client::{FileEntry, NexusClient};
 use crate::metrics;
+use crate::passthrough::{ActivePassthrough, OpenAccess, PassthroughDecision, PassthroughManager};
 use fuser::{
     AccessFlags, BsdFileFlags, Errno, FileAttr, FileHandle, FileType, Filesystem, FopenFlags,
-    Generation, INodeNo, LockOwner, OpenFlags, RenameFlags, ReplyAttr, ReplyData, ReplyDirectory,
-    ReplyEntry, ReplyWrite, ReplyXattr, Request, WriteFlags,
+    Generation, INodeNo, InitFlags, KernelConfig, LockOwner, OpenFlags, RenameFlags, ReplyAttr,
+    ReplyData, ReplyDirectory, ReplyEntry, ReplyWrite, ReplyXattr, Request, WriteFlags,
 };
 use log::{debug, error};
 use lru::LruCache;
 use std::ffi::OsStr;
+use std::io;
 use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
@@ -36,6 +38,9 @@ const MAX_OPEN_FILE_HANDLES: usize = 128;
 
 /// Maximum total bytes retained by open file contents.
 const MAX_OPEN_FILE_CACHE_BYTES: usize = 128 * 1024 * 1024;
+
+/// Maximum stack depth requested for kernel passthrough.
+const PASSTHROUGH_MAX_STACK_DEPTH: u32 = 2;
 
 struct OpenFileCacheEntry {
     path: String,
@@ -262,6 +267,8 @@ pub struct NexusFs {
     dir_cache: Mutex<LruCache<u64, (Vec<FileEntry>, SystemTime)>>,
     /// Persistent foyer cache for file content (optional).
     file_cache: Option<Arc<FileCache>>,
+    /// Optional kernel passthrough manager for large read-only file opens.
+    passthrough: Option<Arc<PassthroughManager>>,
     /// Per-open file content cache for range reads that bypass persistent cache size limits.
     open_file_cache: Mutex<OpenFileCache>,
     next_file_handle: Mutex<u64>,
@@ -269,19 +276,39 @@ pub struct NexusFs {
 
 impl NexusFs {
     /// Create a new NexusFs instance.
-    pub fn new(client: NexusClient, file_cache: Option<Arc<FileCache>>) -> Self {
+    pub fn new(
+        client: NexusClient,
+        file_cache: Option<Arc<FileCache>>,
+        passthrough: Option<Arc<PassthroughManager>>,
+    ) -> Self {
         Self {
             client: Arc::new(client),
             inodes: Mutex::new(InodeTable::new()),
             attr_cache: Mutex::new(LruCache::new(NonZeroUsize::new(10000).unwrap())),
             dir_cache: Mutex::new(LruCache::new(NonZeroUsize::new(1000).unwrap())),
             file_cache,
+            passthrough,
             open_file_cache: Mutex::new(OpenFileCache::new(
                 NonZeroUsize::new(MAX_OPEN_FILE_HANDLES).unwrap(),
                 MAX_OPEN_FILE_CACHE_BYTES,
             )),
             next_file_handle: Mutex::new(1),
         }
+    }
+
+    #[cfg(test)]
+    fn passthrough_enabled_for_tests(&self) -> bool {
+        self.passthrough.is_some()
+    }
+
+    #[cfg(test)]
+    fn passthrough_runtime_failure_is_fatal_for_tests(&self) -> bool {
+        self.passthrough_runtime_failure_is_fatal()
+    }
+
+    #[cfg(test)]
+    fn passthrough_max_stack_depth_for_tests() -> u32 {
+        PASSTHROUGH_MAX_STACK_DEPTH
     }
 
     /// Parse timestamp string to SystemTime.
@@ -349,10 +376,7 @@ impl NexusFs {
     /// #4056 R5: returns the typed NexusClientError on RPC failure so
     /// callers can map it to the correct errno (EACCES/EPERM/etc.)
     /// instead of flattening every error to ENOENT.
-    fn check_is_directory(
-        &self,
-        path: &str,
-    ) -> Result<bool, crate::error::NexusClientError> {
+    fn check_is_directory(&self, path: &str) -> Result<bool, crate::error::NexusClientError> {
         if path == "/" {
             return Ok(true);
         }
@@ -497,18 +521,26 @@ impl NexusFs {
             cache.invalidate(path);
         }
 
+        if let Some(ref passthrough) = self.passthrough {
+            passthrough.invalidate_path(path);
+        }
+
         // Invalidate open-handle content caches for this path.
         self.open_file_cache.lock().unwrap().invalidate_path(path);
     }
 
-    fn allocate_file_handle(&self) -> u64 {
+    fn allocate_file_handle(&self) -> anyhow::Result<u64> {
+        if let Some(ref passthrough) = self.passthrough {
+            return passthrough.next_file_handle();
+        }
+
         let mut next = self.next_file_handle.lock().unwrap();
         let fh = *next;
         *next = next.wrapping_add(1);
         if *next == 0 {
             *next = 1;
         }
-        fh
+        Ok(fh)
     }
 
     fn reply_data_slice(content: &[u8], offset: u64, size: u32, reply: ReplyData) {
@@ -559,9 +591,86 @@ impl NexusFs {
     fn rmw_read(&self, path: &str) -> Result<Vec<u8>, crate::error::NexusClientError> {
         self.client.read(path)
     }
+
+    fn passthrough_runtime_failure_is_fatal(&self) -> bool {
+        self.passthrough
+            .as_ref()
+            .is_some_and(|passthrough| passthrough.require())
+    }
+
+    fn open_userspace(&self, reply: fuser::ReplyOpen) {
+        match self.allocate_file_handle() {
+            Ok(fh) => reply.opened(FileHandle(fh), FopenFlags::empty()),
+            Err(err) => {
+                error!("file handle allocation failed: {}", err);
+                reply.error(Errno::EIO);
+            }
+        }
+    }
+
+    fn reply_passthrough_open_failure<E: std::fmt::Display>(
+        &self,
+        path: &str,
+        operation: &str,
+        err: E,
+        reply: fuser::ReplyOpen,
+    ) {
+        if self.passthrough_runtime_failure_is_fatal() {
+            error!("passthrough {} failed for {}: {}", operation, path, err);
+            reply.error(Errno::EIO);
+        } else {
+            debug!(
+                "passthrough {} failed for {}; falling back to userspace open: {}",
+                operation, path, err
+            );
+            self.open_userspace(reply);
+        }
+    }
 }
 
 impl Filesystem for NexusFs {
+    fn init(&mut self, _req: &Request, config: &mut KernelConfig) -> io::Result<()> {
+        let Some(ref passthrough) = self.passthrough else {
+            return Ok(());
+        };
+
+        let capability_ok = match config.add_capabilities(InitFlags::FUSE_PASSTHROUGH) {
+            Ok(()) => true,
+            Err(unsupported) => {
+                error!(
+                    "kernel passthrough capability not available: {:?}",
+                    unsupported
+                );
+                false
+            }
+        };
+        let stack_depth_ok = match config.set_max_stack_depth(PASSTHROUGH_MAX_STACK_DEPTH) {
+            Ok(_) => true,
+            Err(maximum) => {
+                error!(
+                    "kernel passthrough stack depth negotiation failed; maximum accepted depth={}",
+                    maximum
+                );
+                false
+            }
+        };
+
+        let negotiated = capability_ok && stack_depth_ok;
+        passthrough.set_negotiated(negotiated);
+
+        if negotiated {
+            debug!("kernel passthrough negotiated");
+            Ok(())
+        } else if passthrough.require() {
+            Err(io::Error::new(
+                io::ErrorKind::Other,
+                "kernel passthrough negotiation failed",
+            ))
+        } else {
+            Ok(())
+        }
+    }
+
     fn lookup(&self, _req: &Request, parent: INodeNo, name: &OsStr, reply: ReplyEntry) {
         let name = name.to_string_lossy();
         debug!("lookup: parent={}, name={}", parent, name);
@@ -1254,24 +1363,108 @@ impl Filesystem for NexusFs {
         }
     }
 
-    fn open(&self, _req: &Request, ino: INodeNo, _flags: OpenFlags, reply: fuser::ReplyOpen) {
+    fn open(&self, _req: &Request, ino: INodeNo, flags: OpenFlags, reply: fuser::ReplyOpen) {
         debug!("open: ino={}", ino);
 
         let path = resolve_path!(self, ino.0, reply);
 
-        match self.check_is_directory(&path) {
-            Ok(true) => reply.error(Errno::EISDIR),
-            Ok(false) => {
-                let fh = self.allocate_file_handle();
-                reply.opened(FileHandle(fh), FopenFlags::empty());
+        if self.passthrough.is_none() {
+            match self.check_is_directory(&path) {
+                Ok(true) => reply.error(Errno::EISDIR),
+                Ok(false) => self.open_userspace(reply),
+                Err(e) => {
+                    if !e.is_not_found() && !e.is_permission_denied() {
+                        error!("open stat error for {}: {}", path, e);
+                    }
+                    reply.error(errno_for(&e));
+                }
             }
+            return;
+        }
+
+        let metadata = match self.client.stat(&path) {
+            Ok(metadata) => metadata,
             Err(e) => {
                 if !e.is_not_found() && !e.is_permission_denied() {
                     error!("open stat error for {}: {}", path, e);
                 }
                 reply.error(errno_for(&e));
+                return;
+            }
+        };
+
+        if metadata.is_directory {
+            reply.error(Errno::EISDIR);
+            return;
+        }
+
+        if let Some(ref passthrough) = self.passthrough {
+            let access = OpenAccess::from_open_flags(flags);
+            match passthrough.decide(&path, &metadata, access) {
+                PassthroughDecision::Allow => {
+                    let fh = match self.allocate_file_handle() {
+                        Ok(fh) => fh,
+                        Err(err) => {
+                            self.reply_passthrough_open_failure(
+                                &path,
+                                "file handle allocation",
+                                err,
+                                reply,
+                            );
+                            return;
+                        }
+                    };
+                    let backing = match passthrough.materialize(&path, &self.client, &metadata) {
+                        Ok(backing) => backing,
+                        Err(err) => {
+                            self.reply_passthrough_open_failure(
+                                &path,
+                                "materialization",
+                                err,
+                                reply,
+                            );
+                            return;
+                        }
+                    };
+                    let backing_id = match reply.open_backing(backing.file()) {
+                        Ok(backing_id) => Arc::new(backing_id),
+                        Err(err) => {
+                            self.reply_passthrough_open_failure(
+                                &path,
+                                "backing registration",
+                                err,
+                                reply,
+                            );
+                            return;
+                        }
+                    };
+                    let active = ActivePassthrough {
+                        backing,
+                        backing_id: Arc::clone(&backing_id),
+                    };
+                    if let Err(err) = passthrough.insert_active(fh, active) {
+                        self.reply_passthrough_open_failure(
+                            &path,
+                            &format!("active handle insert for fh={}", fh),
+                            err,
+                            reply,
+                        );
+                        return;
+                    }
+                    reply.opened_passthrough(
+                        FileHandle(fh),
+                        FopenFlags::empty(),
+                        backing_id.as_ref(),
+                    );
+                    return;
+                }
+                PassthroughDecision::Deny(reason) => {
+                    debug!("passthrough denied for {}: {:?}", path, reason);
+                }
             }
         }
+
+        self.open_userspace(reply);
     }
 
     fn opendir(&self, _req: &Request, ino: INodeNo, _flags: OpenFlags, reply: fuser::ReplyOpen) {
@@ -1320,6 +1513,14 @@ impl Filesystem for NexusFs {
     ) {
         if fh.0 != 0 {
             self.open_file_cache.lock().unwrap().remove(fh.0);
+        }
+        if let Some(ref passthrough) = self.passthrough {
+            if let Err(err) = passthrough.remove_active(fh.0) {
+                error!(
+                    "passthrough active handle cleanup failed for fh={}: {}",
+                    fh.0, err
+                );
+            }
         }
         reply.ok();
     }
@@ -1383,6 +1584,52 @@ mod tests {
     }
 
     #[test]
+    fn nexus_fs_can_be_constructed_with_passthrough_manager() {
+        let fs = nexus_fs_with_passthrough_required(false);
+
+        assert!(fs.passthrough_enabled_for_tests());
+    }
+
+    #[test]
+    fn optional_passthrough_runtime_failure_is_not_fatal() {
+        let fs = nexus_fs_with_passthrough_required(false);
+
+        assert!(!fs.passthrough_runtime_failure_is_fatal_for_tests());
+    }
+
+    #[test]
+    fn required_passthrough_runtime_failure_is_fatal() {
+        let fs = nexus_fs_with_passthrough_required(true);
+
+        assert!(fs.passthrough_runtime_failure_is_fatal_for_tests());
+    }
+
+    #[test]
+    fn passthrough_requests_maximum_supported_stack_depth() {
+        assert_eq!(NexusFs::passthrough_max_stack_depth_for_tests(), 2);
+    }
+
+    fn nexus_fs_with_passthrough_required(require: bool) -> NexusFs {
+        use crate::passthrough::{PassthroughConfig, PassthroughManager};
+
+        let client = NexusClient::new("http://localhost:2026", "test-key", None).expect("client");
+        let manager = PassthroughManager::new(
+            "http://localhost:2026".to_string(),
+            PassthroughConfig {
+                enabled: true,
+                allow_patterns: vec!["/data/**".to_string()],
+                deny_patterns: vec![],
+                threshold_bytes: 128 * 1024,
+                require,
+                backing_dir: None,
+            },
+        )
+        .expect("manager");
+
+        NexusFs::new(client, None, Some(Arc::new(manager)))
+    }
+
+    #[test]
     fn test_get_or_create_idempotent() {
         let mut table = InodeTable::new();
         let inode1 = table.get_or_create("/foo/bar");
@@ -1432,7 +1679,7 @@ mod tests {
         cache.backdate_for_test("/stale.txt", 3601);
 
         let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
-        let fs = NexusFs::new(client, Some(cache));
+        let fs = NexusFs::new(client, Some(cache), None);
 
         let result = fs.read_cached("/stale.txt", 0).unwrap();
 
@@ -1465,7 +1712,7 @@ mod tests {
         cache.backdate_for_test("/not-modified.txt", 3601);
 
         let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
-        let fs = NexusFs::new(client, Some(cache));
+        let fs = NexusFs::new(client, Some(cache), None);
 
         let result = fs.read_cached("/not-modified.txt", 0).unwrap();
 
@@ -1686,7 +1933,7 @@ mod tests {
         // through it).
         cache.put("/rmw.txt", b"STALE-CACHED", Some("stale-etag"), 0);
 
-        let fs = NexusFs::new(client, Some(cache.clone()));
+        let fs = NexusFs::new(client, Some(cache.clone()), None);
         let bytes = fs.rmw_read("/rmw.txt").expect("rmw_read");
         assert_eq!(
             bytes, fresh,

--- a/nexus-fuse/src/lib.rs
+++ b/nexus-fuse/src/lib.rs
@@ -10,3 +10,4 @@ pub mod error;
 pub mod fs;
 pub mod hydrate;
 pub mod metrics;
+pub mod passthrough;

--- a/nexus-fuse/src/main.rs
+++ b/nexus-fuse/src/main.rs
@@ -5,8 +5,8 @@
 
 use clap::{Parser, Subcommand};
 use fuser::{Config, MountOption, SessionACL};
-use log::{error, info};
-use nexus_fuse::{cache, client, daemon, fs, metrics};
+use log::{error, info, warn};
+use nexus_fuse::{cache, client, daemon, fs, metrics, passthrough};
 use std::path::PathBuf;
 use std::sync::Arc;
 
@@ -62,6 +62,34 @@ enum Commands {
         /// Override cache root directory
         #[arg(long, env = "NEXUS_FUSE_CACHE_DIR")]
         cache_dir: Option<PathBuf>,
+
+        /// Enable Linux FUSE passthrough for eligible large reads. Can also be set with NEXUS_FUSE_PASSTHROUGH.
+        #[arg(long, default_value_t = false)]
+        passthrough: bool,
+
+        /// Glob allow pattern for passthrough. Repeat for multiple patterns. Appends to NEXUS_FUSE_PASSTHROUGH_PATTERNS.
+        #[arg(long = "passthrough-pattern", value_delimiter = ',')]
+        passthrough_patterns: Vec<String>,
+
+        /// Glob deny pattern for passthrough. Repeat for multiple patterns. Appends to NEXUS_FUSE_PASSTHROUGH_DENY_PATTERNS.
+        #[arg(long = "passthrough-deny-pattern", value_delimiter = ',')]
+        passthrough_deny_patterns: Vec<String>,
+
+        /// Minimum file size for passthrough eligibility.
+        #[arg(
+            long,
+            env = "NEXUS_FUSE_PASSTHROUGH_THRESHOLD_BYTES",
+            default_value_t = passthrough::DEFAULT_THRESHOLD_BYTES
+        )]
+        passthrough_threshold_bytes: u64,
+
+        /// Fail the mount instead of falling back when passthrough is unavailable. Can also be set with NEXUS_FUSE_PASSTHROUGH_REQUIRE.
+        #[arg(long, default_value_t = false)]
+        passthrough_require: bool,
+
+        /// Directory for immutable passthrough backing files.
+        #[arg(long, env = "NEXUS_FUSE_PASSTHROUGH_BACKING_DIR")]
+        passthrough_backing_dir: Option<PathBuf>,
 
         /// Prometheus metrics bind address, for example 127.0.0.1:9464
         #[arg(long, env = "NEXUS_FUSE_METRICS_ADDR")]
@@ -162,6 +190,125 @@ fn build_cache_config(
     )
 }
 
+fn optional_env_value(name: &str) -> anyhow::Result<Option<String>> {
+    match std::env::var(name) {
+        Ok(value) => Ok(Some(value)),
+        Err(std::env::VarError::NotPresent) => Ok(None),
+        Err(std::env::VarError::NotUnicode(_)) => anyhow::bail!("{name} must be valid UTF-8"),
+    }
+}
+
+fn normalize_pattern_values(values: Vec<String>) -> Vec<String> {
+    values
+        .into_iter()
+        .flat_map(|value| passthrough::parse_pattern_env(&value))
+        .collect()
+}
+
+fn merge_passthrough_patterns(env_value: Option<&str>, cli_patterns: Vec<String>) -> Vec<String> {
+    let mut patterns = env_value
+        .map(passthrough::parse_pattern_env)
+        .unwrap_or_default();
+    patterns.extend(normalize_pattern_values(cli_patterns));
+    patterns
+}
+
+fn read_merged_passthrough_patterns(
+    env_name: &str,
+    cli_patterns: Vec<String>,
+) -> anyhow::Result<Vec<String>> {
+    let env_value = optional_env_value(env_name)?;
+    Ok(merge_passthrough_patterns(
+        env_value.as_deref(),
+        cli_patterns,
+    ))
+}
+
+fn parse_bool_env_value(env_name: &str, value: &str) -> anyhow::Result<bool> {
+    match value.trim().to_ascii_lowercase().as_str() {
+        "1" | "true" | "yes" | "on" => Ok(true),
+        "0" | "false" | "no" | "off" => Ok(false),
+        _ => anyhow::bail!("{env_name} must be one of 1/0/true/false/yes/no/on/off"),
+    }
+}
+
+fn bool_flag_with_env(
+    cli_enabled: bool,
+    env_value: Option<&str>,
+    env_name: &str,
+) -> anyhow::Result<bool> {
+    if cli_enabled {
+        return Ok(true);
+    }
+
+    env_value
+        .map(|value| parse_bool_env_value(env_name, value))
+        .unwrap_or(Ok(false))
+}
+
+fn read_bool_flag_with_env(cli_enabled: bool, env_name: &str) -> anyhow::Result<bool> {
+    let env_value = optional_env_value(env_name)?;
+    bool_flag_with_env(cli_enabled, env_value.as_deref(), env_name)
+}
+
+fn build_passthrough_config(
+    enabled: bool,
+    allow_patterns: Vec<String>,
+    deny_patterns: Vec<String>,
+    threshold_bytes: u64,
+    require: bool,
+    backing_dir: Option<PathBuf>,
+) -> anyhow::Result<passthrough::PassthroughConfig> {
+    if threshold_bytes == 0 {
+        anyhow::bail!("passthrough threshold must be greater than zero");
+    }
+
+    let allow_patterns = normalize_pattern_values(allow_patterns);
+    let deny_patterns = normalize_pattern_values(deny_patterns);
+    let enabled = if enabled && allow_patterns.is_empty() {
+        if require {
+            anyhow::bail!("passthrough requires at least one allow pattern");
+        }
+        warn!("FUSE passthrough disabled: at least one passthrough allow pattern is required");
+        false
+    } else {
+        enabled
+    };
+
+    Ok(passthrough::PassthroughConfig {
+        enabled,
+        allow_patterns,
+        deny_patterns,
+        threshold_bytes,
+        require,
+        backing_dir,
+    })
+}
+
+fn create_passthrough_manager(
+    url: &str,
+    config: passthrough::PassthroughConfig,
+) -> anyhow::Result<Option<Arc<passthrough::PassthroughManager>>> {
+    if !config.enabled {
+        return Ok(None);
+    }
+
+    if !config.require && !passthrough::linux_passthrough_supported() {
+        warn!(
+            "FUSE passthrough support was not detected before mount; continuing to FUSE negotiation"
+        );
+    }
+
+    match passthrough::PassthroughManager::new(url.to_string(), config.clone()) {
+        Ok(manager) => Ok(Some(Arc::new(manager))),
+        Err(err) if config.require => Err(err),
+        Err(err) => {
+            warn!("FUSE passthrough disabled: {}", err);
+            Ok(None)
+        }
+    }
+}
+
 fn open_file_cache(
     url: &str,
     api_key: &str,
@@ -217,6 +364,12 @@ fn main() -> anyhow::Result<()> {
             cache_memory_mb,
             cache_disk_gb,
             cache_dir,
+            passthrough,
+            passthrough_patterns,
+            passthrough_deny_patterns,
+            passthrough_threshold_bytes,
+            passthrough_require,
+            passthrough_backing_dir,
             metrics_addr,
         } => {
             let api_key = resolve_api_key(api_key, api_key_file)?;
@@ -251,11 +404,31 @@ fn main() -> anyhow::Result<()> {
             }
 
             let cache_config = build_cache_config(cache_memory_mb, cache_disk_gb, cache_dir)?;
-            let file_cache =
-                open_file_cache(&url, &api_key, agent_id.as_deref(), cache_config);
+            let file_cache = open_file_cache(&url, &api_key, agent_id.as_deref(), cache_config);
+
+            let passthrough = read_bool_flag_with_env(passthrough, "NEXUS_FUSE_PASSTHROUGH")?;
+            let passthrough_require =
+                read_bool_flag_with_env(passthrough_require, "NEXUS_FUSE_PASSTHROUGH_REQUIRE")?;
+            let passthrough_patterns = read_merged_passthrough_patterns(
+                "NEXUS_FUSE_PASSTHROUGH_PATTERNS",
+                passthrough_patterns,
+            )?;
+            let passthrough_deny_patterns = read_merged_passthrough_patterns(
+                "NEXUS_FUSE_PASSTHROUGH_DENY_PATTERNS",
+                passthrough_deny_patterns,
+            )?;
+            let passthrough_config = build_passthrough_config(
+                passthrough,
+                passthrough_patterns,
+                passthrough_deny_patterns,
+                passthrough_threshold_bytes,
+                passthrough_require,
+                passthrough_backing_dir,
+            )?;
+            let passthrough_manager = create_passthrough_manager(&url, passthrough_config)?;
 
             // Create filesystem
-            let filesystem = fs::NexusFs::new(client, file_cache);
+            let filesystem = fs::NexusFs::new(client, file_cache, passthrough_manager);
 
             // Build mount options
             let mut options = Config::default();
@@ -308,8 +481,7 @@ fn main() -> anyhow::Result<()> {
             });
 
             let cache_config = build_cache_config(cache_memory_mb, cache_disk_gb, cache_dir)?;
-            let file_cache =
-                open_file_cache(&url, &api_key, agent_id.as_deref(), cache_config);
+            let file_cache = open_file_cache(&url, &api_key, agent_id.as_deref(), cache_config);
 
             let config = daemon::DaemonConfig {
                 socket_path,
@@ -331,4 +503,138 @@ fn main() -> anyhow::Result<()> {
     }
 
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn build_passthrough_config_keeps_disabled_default() {
+        let config = build_passthrough_config(
+            false,
+            Vec::new(),
+            Vec::new(),
+            passthrough::DEFAULT_THRESHOLD_BYTES,
+            false,
+            None,
+        )
+        .expect("config");
+
+        assert!(!config.enabled);
+        assert_eq!(config.threshold_bytes, passthrough::DEFAULT_THRESHOLD_BYTES);
+    }
+
+    #[test]
+    fn build_passthrough_config_preserves_patterns_and_require() {
+        let config = build_passthrough_config(
+            true,
+            vec!["/data/**".to_string()],
+            vec!["/data/private/**".to_string()],
+            256 * 1024,
+            true,
+            None,
+        )
+        .expect("config");
+
+        assert!(config.enabled);
+        assert_eq!(config.allow_patterns, vec!["/data/**"]);
+        assert_eq!(config.deny_patterns, vec!["/data/private/**"]);
+        assert_eq!(config.threshold_bytes, 256 * 1024);
+        assert!(config.require);
+    }
+
+    #[test]
+    fn build_passthrough_config_rejects_zero_threshold() {
+        let err =
+            build_passthrough_config(true, vec!["/data/**".to_string()], vec![], 0, false, None)
+                .expect_err("zero threshold should fail");
+
+        assert!(err
+            .to_string()
+            .contains("passthrough threshold must be greater than zero"));
+    }
+
+    #[test]
+    fn merge_passthrough_patterns_appends_env_then_cli_and_filters_empty_segments() {
+        let patterns = merge_passthrough_patterns(
+            Some(" /env/**, ,/env-two/** "),
+            vec![
+                " /cli/** ".to_string(),
+                ",".to_string(),
+                "/cli-two/**".to_string(),
+            ],
+        );
+
+        assert_eq!(
+            patterns,
+            vec!["/env/**", "/env-two/**", "/cli/**", "/cli-two/**"]
+        );
+    }
+
+    #[test]
+    fn build_passthrough_config_disables_empty_allow_when_not_required() {
+        let config = build_passthrough_config(true, vec![], vec![], 128 * 1024, false, None)
+            .expect("config");
+
+        assert!(!config.enabled);
+    }
+
+    #[test]
+    fn build_passthrough_config_rejects_empty_allow_when_required() {
+        let err = build_passthrough_config(true, vec![], vec![], 128 * 1024, true, None)
+            .expect_err("required passthrough without allow patterns should fail");
+
+        assert!(err
+            .to_string()
+            .contains("passthrough requires at least one allow pattern"));
+    }
+
+    #[test]
+    fn create_passthrough_manager_skips_disabled_config() {
+        let config = build_passthrough_config(true, vec![], vec![], 128 * 1024, false, None)
+            .expect("config");
+
+        assert!(create_passthrough_manager("http://server", config)
+            .expect("manager")
+            .is_none());
+    }
+
+    #[test]
+    fn create_passthrough_manager_does_not_pre_gate_on_kernel_version() {
+        let backing_dir = tempfile::tempdir().expect("tempdir");
+        let config = build_passthrough_config(
+            true,
+            vec!["/data/**".to_string()],
+            vec![],
+            128 * 1024,
+            false,
+            Some(backing_dir.path().to_path_buf()),
+        )
+        .expect("config");
+
+        assert!(create_passthrough_manager("http://server", config)
+            .expect("manager")
+            .is_some());
+    }
+
+    #[test]
+    fn parse_bool_env_accepts_compatible_values() {
+        assert!(bool_flag_with_env(false, Some("1"), "FLAG").expect("bool"));
+        assert!(bool_flag_with_env(false, Some("yes"), "FLAG").expect("bool"));
+        assert!(bool_flag_with_env(false, Some("on"), "FLAG").expect("bool"));
+        assert!(!bool_flag_with_env(false, Some("0"), "FLAG").expect("bool"));
+        assert!(!bool_flag_with_env(false, Some("no"), "FLAG").expect("bool"));
+        assert!(!bool_flag_with_env(false, Some("off"), "FLAG").expect("bool"));
+        assert!(bool_flag_with_env(true, Some("0"), "FLAG").expect("bool"));
+    }
+
+    #[test]
+    fn parse_bool_env_rejects_unknown_values() {
+        let err = bool_flag_with_env(false, Some("maybe"), "FLAG").expect_err("invalid bool");
+
+        assert!(err
+            .to_string()
+            .contains("FLAG must be one of 1/0/true/false/yes/no/on/off"));
+    }
 }

--- a/nexus-fuse/src/passthrough/backing.rs
+++ b/nexus-fuse/src/passthrough/backing.rs
@@ -1,0 +1,676 @@
+use crate::client::{FileMetadata, NexusClient, ReadToWriterResponse};
+use anyhow::{anyhow, Context};
+use sha2::{Digest, Sha256};
+use std::fs::{self, File, OpenOptions};
+use std::io::Write;
+use std::os::unix::io::{AsRawFd, RawFd};
+use std::path::{Path, PathBuf};
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static NEXT_TEMP_ID: AtomicU64 = AtomicU64::new(0);
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct BackingKey {
+    pub digest: String,
+    pub server_url: String,
+    pub path: String,
+}
+
+impl BackingKey {
+    pub fn new(server_url: &str, path: &str, version_token: &str, size: u64) -> Self {
+        let mut hasher = Sha256::new();
+        hasher.update(server_url.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(path.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(version_token.as_bytes());
+        hasher.update(b"\0");
+        hasher.update(size.to_le_bytes());
+
+        Self {
+            digest: hex::encode(hasher.finalize()),
+            server_url: server_url.to_string(),
+            path: path.to_string(),
+        }
+    }
+
+    pub fn filename(&self) -> String {
+        format!("{}.backing", self.digest)
+    }
+
+    fn marker_prefix(&self) -> String {
+        marker_prefix(&self.server_url, &self.path)
+    }
+}
+
+pub struct MaterializedBacking {
+    pub path: PathBuf,
+    pub key: BackingKey,
+    file: File,
+}
+
+impl MaterializedBacking {
+    pub fn file(&self) -> &File {
+        &self.file
+    }
+
+    pub fn raw_fd(&self) -> RawFd {
+        self.file.as_raw_fd()
+    }
+}
+
+pub struct BackingStore {
+    root: PathBuf,
+}
+
+impl BackingStore {
+    pub fn new(root: impl AsRef<Path>) -> anyhow::Result<Self> {
+        fs::create_dir_all(root.as_ref()).with_context(|| {
+            format!(
+                "failed to create passthrough backing root {}",
+                root.as_ref().display()
+            )
+        })?;
+
+        Ok(Self {
+            root: root.as_ref().to_path_buf(),
+        })
+    }
+
+    pub fn path_for_key(&self, key: &BackingKey) -> PathBuf {
+        self.root.join(key.filename())
+    }
+
+    pub fn materialize(
+        &self,
+        server_url: &str,
+        path: &str,
+        client: &NexusClient,
+        metadata: &FileMetadata,
+    ) -> anyhow::Result<MaterializedBacking> {
+        let version_token = backing_version_token(metadata).ok_or_else(|| {
+            anyhow!("cannot materialize passthrough backing without an etag or generation")
+        })?;
+        let key = BackingKey::new(server_url, path, &version_token, metadata.size);
+        let final_path = self.path_for_key(&key);
+
+        if final_path.exists() {
+            if self.is_reusable_backing(&final_path, &key, metadata.size)? {
+                return self.open_materialized(final_path, key);
+            }
+            self.remove_invalid_backing(&final_path, &key)?;
+        }
+
+        let (temp_path, mut temp_file) = self.create_temp_file(&key)?;
+        let bytes_written = match client.read_with_etag_to_writer(path, None, &mut temp_file) {
+            Ok(ReadToWriterResponse::Content { bytes_written, .. }) => bytes_written,
+            Ok(ReadToWriterResponse::NotModified) => {
+                let _ = fs::remove_file(&temp_path);
+                return Err(anyhow!(
+                    "cannot materialize passthrough backing from not-modified response"
+                ));
+            }
+            Err(err) => {
+                let _ = fs::remove_file(&temp_path);
+                return Err(err.into());
+            }
+        };
+
+        if bytes_written != metadata.size {
+            let _ = fs::remove_file(&temp_path);
+            return Err(anyhow!(
+                "passthrough backing size mismatch for {}: metadata={}, read={}",
+                path,
+                metadata.size,
+                bytes_written
+            ));
+        }
+
+        if let Err(err) = temp_file.sync_all() {
+            let _ = fs::remove_file(&temp_path);
+            return Err(err)
+                .with_context(|| format!("failed to sync temp backing {}", temp_path.display()));
+        }
+        drop(temp_file);
+
+        if let Err(err) = fs::rename(&temp_path, &final_path) {
+            let _ = fs::remove_file(&temp_path);
+            return Err(err).with_context(|| {
+                format!(
+                    "failed to publish passthrough backing {}",
+                    final_path.display()
+                )
+            });
+        }
+        if let Err(err) = self.write_marker(&key) {
+            let _ = fs::remove_file(&final_path);
+            return Err(err);
+        }
+
+        self.open_materialized(final_path, key)
+    }
+
+    pub fn invalidate_path(&self, server_url: &str, path: &str) -> anyhow::Result<()> {
+        let prefix = marker_prefix(server_url, path);
+
+        for entry in fs::read_dir(&self.root)? {
+            let entry = entry?;
+            let marker_path = entry.path();
+            let Some(name) = marker_path.file_name().and_then(|name| name.to_str()) else {
+                continue;
+            };
+            if !name.starts_with(&prefix) || !name.ends_with(".marker") {
+                continue;
+            }
+
+            let backing_filename = fs::read_to_string(&marker_path)?;
+            let backing_filename = backing_filename.trim();
+            if !is_valid_backing_filename(backing_filename) {
+                continue;
+            }
+
+            let backing_path = self.root.join(backing_filename);
+            match fs::remove_file(&backing_path) {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => return Err(err.into()),
+            }
+            match fs::remove_file(&marker_path) {
+                Ok(()) => {}
+                Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+                Err(err) => return Err(err.into()),
+            }
+        }
+
+        Ok(())
+    }
+
+    fn open_materialized(
+        &self,
+        path: PathBuf,
+        key: BackingKey,
+    ) -> anyhow::Result<MaterializedBacking> {
+        let file = File::open(&path)
+            .with_context(|| format!("failed to open backing file {}", path.display()))?;
+        Ok(MaterializedBacking { path, key, file })
+    }
+
+    fn write_marker(&self, key: &BackingKey) -> anyhow::Result<()> {
+        let marker_path = self.marker_path_for(key);
+        let mut marker = OpenOptions::new()
+            .write(true)
+            .create(true)
+            .truncate(true)
+            .open(&marker_path)
+            .with_context(|| format!("failed to create marker {}", marker_path.display()))?;
+        marker.write_all(key.filename().as_bytes())?;
+        marker.sync_all()?;
+        Ok(())
+    }
+
+    fn is_reusable_backing(
+        &self,
+        path: &Path,
+        key: &BackingKey,
+        expected_size: u64,
+    ) -> anyhow::Result<bool> {
+        let metadata = fs::metadata(path)
+            .with_context(|| format!("failed to stat backing file {}", path.display()))?;
+        if !metadata.is_file() || metadata.len() != expected_size {
+            return Ok(false);
+        }
+
+        let marker_path = self.marker_path_for(key);
+        let marker_contents = match fs::read_to_string(&marker_path) {
+            Ok(contents) => contents,
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => return Ok(false),
+            Err(err) => {
+                return Err(err).with_context(|| {
+                    format!("failed to read backing marker {}", marker_path.display())
+                });
+            }
+        };
+
+        Ok(marker_contents.trim() == key.filename())
+    }
+
+    fn remove_invalid_backing(&self, path: &Path, key: &BackingKey) -> anyhow::Result<()> {
+        match fs::remove_file(path) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => {
+                return Err(err).with_context(|| {
+                    format!("failed to remove invalid backing {}", path.display())
+                });
+            }
+        }
+
+        let marker_path = self.marker_path_for(key);
+        match fs::remove_file(&marker_path) {
+            Ok(()) => {}
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => {
+                return Err(err).with_context(|| {
+                    format!(
+                        "failed to remove invalid backing marker {}",
+                        marker_path.display()
+                    )
+                });
+            }
+        }
+        Ok(())
+    }
+
+    fn marker_path_for(&self, key: &BackingKey) -> PathBuf {
+        self.root
+            .join(format!("{}.{}.marker", key.marker_prefix(), key.digest))
+    }
+
+    fn create_temp_file(&self, key: &BackingKey) -> anyhow::Result<(PathBuf, File)> {
+        for _ in 0..1024 {
+            let temp_path = self.temp_path_for(key);
+            match OpenOptions::new()
+                .write(true)
+                .create_new(true)
+                .open(&temp_path)
+            {
+                Ok(file) => return Ok((temp_path, file)),
+                Err(err) if err.kind() == std::io::ErrorKind::AlreadyExists => continue,
+                Err(err) => {
+                    return Err(err).with_context(|| {
+                        format!("failed to create temp backing {}", temp_path.display())
+                    });
+                }
+            }
+        }
+
+        Err(anyhow!(
+            "failed to create unique temp backing for {} after retries",
+            key.filename()
+        ))
+    }
+
+    fn temp_path_for(&self, key: &BackingKey) -> PathBuf {
+        let sequence = NEXT_TEMP_ID.fetch_add(1, Ordering::Relaxed);
+        self.root.join(format!(
+            ".{}.{}.{}.tmp",
+            key.digest,
+            std::process::id(),
+            sequence
+        ))
+    }
+}
+
+fn marker_prefix(server_url: &str, path: &str) -> String {
+    let mut hasher = Sha256::new();
+    hasher.update(server_url.as_bytes());
+    hasher.update(b"\0");
+    hasher.update(path.as_bytes());
+    format!("marker-{}", hex::encode(hasher.finalize()))
+}
+
+fn backing_version_token(metadata: &FileMetadata) -> Option<String> {
+    if let Some(etag) = metadata.etag.as_deref().filter(|etag| !etag.is_empty()) {
+        return Some(format!("etag:{etag}"));
+    }
+    if metadata.gen != 0 {
+        return Some(format!("gen:{}", metadata.gen));
+    }
+    None
+}
+
+fn is_valid_backing_filename(filename: &str) -> bool {
+    filename.ends_with(".backing") && !filename.contains('/') && !filename.contains('\\')
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use base64::{engine::general_purpose::STANDARD, Engine};
+    use mockito::Server;
+    use std::fs;
+    use std::thread;
+
+    #[test]
+    fn backing_key_uses_stable_backing_filename() {
+        let key = BackingKey::new("https://nexus.example", "/data/file.bin", "etag-1", 42);
+        let same = BackingKey::new("https://nexus.example", "/data/file.bin", "etag-1", 42);
+        let changed_etag = BackingKey::new("https://nexus.example", "/data/file.bin", "etag-2", 42);
+
+        assert_eq!(key.filename(), same.filename());
+        assert_ne!(key.filename(), changed_etag.filename());
+        assert!(key.filename().ends_with(".backing"));
+    }
+
+    #[test]
+    fn materialize_writes_backing_file_and_marker() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = BackingStore::new(temp.path()).unwrap();
+        let mut server = Server::new();
+        let _mock = read_mock(&mut server, "/data/file.bin", b"content", 200);
+        let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+        let metadata = metadata("etag-1", 7);
+
+        let materialized = store
+            .materialize(&server.url(), "/data/file.bin", &client, &metadata)
+            .unwrap();
+
+        assert_eq!(fs::read(&materialized.path).unwrap(), b"content");
+        assert_eq!(
+            fs::read_to_string(store.marker_path_for(&materialized.key)).unwrap(),
+            materialized.key.filename()
+        );
+        assert_eq!(materialized.file().metadata().unwrap().len(), 7);
+        assert!(materialized.raw_fd() >= 0);
+    }
+
+    #[test]
+    fn materialize_reuses_valid_existing_backing_file() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = BackingStore::new(temp.path()).unwrap();
+        let mut server = Server::new();
+        let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+        let metadata = metadata("etag-1", 7);
+        let key = BackingKey::new(&server.url(), "/data/file.bin", "etag:etag-1", 7);
+        let backing_path = store.path_for_key(&key);
+        fs::write(&backing_path, b"cached!").unwrap();
+        write_marker(&store, &key, &key.filename());
+        let _unused_mock = server
+            .mock("POST", "/api/nfs/read")
+            .expect(0)
+            .with_status(500)
+            .create();
+
+        let materialized = store
+            .materialize(&server.url(), "/data/file.bin", &client, &metadata)
+            .unwrap();
+
+        assert_eq!(materialized.path, backing_path);
+        assert_eq!(fs::read(&materialized.path).unwrap(), b"cached!");
+    }
+
+    #[test]
+    fn materialize_replaces_existing_backing_with_wrong_size() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = BackingStore::new(temp.path()).unwrap();
+        let mut server = Server::new();
+        let _mock = read_mock(&mut server, "/data/file.bin", b"correct", 200);
+        let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+        let metadata = metadata("etag-1", 7);
+        let key = BackingKey::new(&server.url(), "/data/file.bin", "etag:etag-1", 7);
+        let backing_path = store.path_for_key(&key);
+        fs::write(&backing_path, b"stale").unwrap();
+        write_marker(&store, &key, &key.filename());
+
+        let materialized = store
+            .materialize(&server.url(), "/data/file.bin", &client, &metadata)
+            .unwrap();
+
+        assert_eq!(materialized.path, backing_path);
+        assert_eq!(fs::read(&materialized.path).unwrap(), b"correct");
+    }
+
+    #[test]
+    fn materialize_recovers_existing_backing_without_marker() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = BackingStore::new(temp.path()).unwrap();
+        let mut server = Server::new();
+        let _mock = read_mock(&mut server, "/data/file.bin", b"fresh", 200);
+        let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+        let metadata = metadata("etag-1", 5);
+        let key = BackingKey::new(&server.url(), "/data/file.bin", "etag:etag-1", 5);
+        fs::write(store.path_for_key(&key), b"stale").unwrap();
+
+        let materialized = store
+            .materialize(&server.url(), "/data/file.bin", &client, &metadata)
+            .unwrap();
+
+        assert_eq!(fs::read(&materialized.path).unwrap(), b"fresh");
+        assert_eq!(
+            fs::read_to_string(store.marker_path_for(&key)).unwrap(),
+            key.filename()
+        );
+    }
+
+    #[test]
+    fn materialize_uses_generation_when_etag_is_missing() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = BackingStore::new(temp.path()).unwrap();
+        let mut server = Server::new();
+        let _mock = read_mock(&mut server, "/data/no-etag.bin", b"gen-data", 200);
+        let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+        let mut metadata = metadata("ignored", 8);
+        metadata.etag = None;
+        metadata.gen = 42;
+
+        let materialized = store
+            .materialize(&server.url(), "/data/no-etag.bin", &client, &metadata)
+            .unwrap();
+
+        let expected_key = BackingKey::new(&server.url(), "/data/no-etag.bin", "gen:42", 8);
+        assert_eq!(materialized.path, store.path_for_key(&expected_key));
+        assert_eq!(fs::read(&materialized.path).unwrap(), b"gen-data");
+        assert_eq!(
+            fs::read_to_string(store.marker_path_for(&expected_key)).unwrap(),
+            expected_key.filename()
+        );
+    }
+
+    #[test]
+    fn materialize_rejects_missing_version_token() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = BackingStore::new(temp.path()).unwrap();
+        let server = Server::new();
+        let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+        let mut metadata = metadata("ignored", 5);
+        metadata.etag = None;
+        metadata.gen = 0;
+
+        let err = materialize_err(
+            &store,
+            &server.url(),
+            "/data/no-version.bin",
+            &client,
+            &metadata,
+        );
+
+        assert!(err.to_string().contains("without an etag or generation"));
+    }
+
+    #[test]
+    fn materialize_rejects_not_modified_response() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = BackingStore::new(temp.path()).unwrap();
+        let mut server = Server::new();
+        let _mock = server
+            .mock("POST", "/api/nfs/read")
+            .with_status(304)
+            .create();
+        let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+
+        let err = materialize_err(
+            &store,
+            &server.url(),
+            "/data/file.bin",
+            &client,
+            &metadata("etag-1", 5),
+        );
+
+        assert!(err.to_string().contains("not-modified"));
+    }
+
+    #[test]
+    fn materialize_rejects_size_mismatch() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = BackingStore::new(temp.path()).unwrap();
+        let mut server = Server::new();
+        let _mock = read_mock(&mut server, "/data/file.bin", b"short", 200);
+        let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+
+        let err = materialize_err(
+            &store,
+            &server.url(),
+            "/data/file.bin",
+            &client,
+            &metadata("etag-1", 99),
+        );
+
+        assert!(err.to_string().contains("size mismatch"));
+    }
+
+    #[test]
+    fn materialize_rolls_back_final_backing_when_marker_creation_fails() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = BackingStore::new(temp.path()).unwrap();
+        let mut server = Server::new();
+        let _mock = read_mock(&mut server, "/data/file.bin", b"content", 200);
+        let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+        let key = BackingKey::new(&server.url(), "/data/file.bin", "etag:etag-1", 7);
+        fs::create_dir(store.marker_path_for(&key)).unwrap();
+
+        let err = materialize_err(
+            &store,
+            &server.url(),
+            "/data/file.bin",
+            &client,
+            &metadata("etag-1", 7),
+        );
+
+        assert!(err.to_string().contains("marker"));
+        assert!(!store.path_for_key(&key).exists());
+    }
+
+    #[test]
+    fn temp_paths_are_unique_across_threads() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = std::sync::Arc::new(BackingStore::new(temp.path()).unwrap());
+        let key = BackingKey::new("https://nexus.example", "/data/file.bin", "etag-1", 42);
+
+        let mut handles = Vec::new();
+        for _ in 0..32 {
+            let store = store.clone();
+            let key = key.clone();
+            handles.push(thread::spawn(move || store.temp_path_for(&key)));
+        }
+        let mut paths = handles
+            .into_iter()
+            .map(|handle| handle.join().unwrap())
+            .collect::<Vec<_>>();
+        paths.sort();
+        paths.dedup();
+
+        assert_eq!(paths.len(), 32);
+    }
+
+    #[test]
+    fn invalidate_path_removes_only_matching_path_backings() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = BackingStore::new(temp.path()).unwrap();
+
+        let key = BackingKey::new("https://nexus.example", "/data/file.bin", "etag-1", 42);
+        let other_path_key =
+            BackingKey::new("https://nexus.example", "/data/other.bin", "etag-1", 42);
+
+        let backing_path = store.path_for_key(&key);
+        let other_path = store.path_for_key(&other_path_key);
+        fs::write(&backing_path, b"file").unwrap();
+        fs::write(&other_path, b"other").unwrap();
+        write_marker(&store, &key, &key.filename());
+        write_marker(&store, &other_path_key, &other_path_key.filename());
+
+        store
+            .invalidate_path("https://nexus.example", "/data/file.bin")
+            .unwrap();
+
+        assert!(!backing_path.exists());
+        assert!(other_path.exists());
+    }
+
+    #[test]
+    fn invalidate_path_ignores_prefix_named_non_marker_files() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = BackingStore::new(temp.path()).unwrap();
+
+        let key = BackingKey::new("https://nexus.example", "/data/file.bin", "etag-1", 42);
+        let backing_path = store.path_for_key(&key);
+        fs::write(&backing_path, b"file").unwrap();
+        fs::write(
+            temp.path()
+                .join(format!("{}.not-a-marker", key.marker_prefix())),
+            key.filename(),
+        )
+        .unwrap();
+
+        store
+            .invalidate_path("https://nexus.example", "/data/file.bin")
+            .unwrap();
+
+        assert!(backing_path.exists());
+    }
+
+    #[test]
+    fn invalidate_path_ignores_marker_contents_that_are_not_backing_filenames() {
+        let temp = tempfile::tempdir().unwrap();
+        let store = BackingStore::new(temp.path()).unwrap();
+
+        let key = BackingKey::new("https://nexus.example", "/data/file.bin", "etag-1", 42);
+        let arbitrary_path = temp.path().join("arbitrary.txt");
+        fs::write(&arbitrary_path, b"keep").unwrap();
+        write_marker(&store, &key, "arbitrary.txt");
+
+        store
+            .invalidate_path("https://nexus.example", "/data/file.bin")
+            .unwrap();
+
+        assert!(arbitrary_path.exists());
+    }
+
+    fn write_marker(store: &BackingStore, key: &BackingKey, contents: &str) {
+        fs::write(store.marker_path_for(key), contents).unwrap();
+    }
+
+    fn materialize_err(
+        store: &BackingStore,
+        server_url: &str,
+        path: &str,
+        client: &NexusClient,
+        metadata: &FileMetadata,
+    ) -> anyhow::Error {
+        match store.materialize(server_url, path, client, metadata) {
+            Ok(_) => panic!("expected materialize to fail"),
+            Err(err) => err,
+        }
+    }
+
+    fn metadata(etag: &str, size: u64) -> FileMetadata {
+        FileMetadata {
+            size,
+            gen: 1,
+            etag: Some(etag.to_string()),
+            modified_at: None,
+            is_directory: false,
+        }
+    }
+
+    fn read_mock(
+        server: &mut Server,
+        path: &'static str,
+        content: &[u8],
+        status: usize,
+    ) -> mockito::Mock {
+        let body = format!(
+            r#"{{"jsonrpc":"2.0","id":1,"result":{{"__type__":"bytes","data":"{}"}}}}"#,
+            STANDARD.encode(content)
+        );
+        server
+            .mock("POST", "/api/nfs/read")
+            .match_body(mockito::Matcher::Regex(format!(
+                r#""path"\s*:\s*"{}""#,
+                path
+            )))
+            .with_status(status)
+            .with_header("content-type", "application/json")
+            .with_body(body)
+            .create()
+    }
+}

--- a/nexus-fuse/src/passthrough/config.rs
+++ b/nexus-fuse/src/passthrough/config.rs
@@ -1,0 +1,174 @@
+use globset::{Glob, GlobSet, GlobSetBuilder};
+use std::path::PathBuf;
+
+pub const DEFAULT_THRESHOLD_BYTES: u64 = 128 * 1024;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PassthroughConfig {
+    pub enabled: bool,
+    pub allow_patterns: Vec<String>,
+    pub deny_patterns: Vec<String>,
+    pub threshold_bytes: u64,
+    pub require: bool,
+    pub backing_dir: Option<PathBuf>,
+}
+
+impl Default for PassthroughConfig {
+    fn default() -> Self {
+        Self {
+            enabled: false,
+            allow_patterns: Vec::new(),
+            deny_patterns: Vec::new(),
+            threshold_bytes: DEFAULT_THRESHOLD_BYTES,
+            require: false,
+            backing_dir: None,
+        }
+    }
+}
+
+impl PassthroughConfig {
+    pub fn disabled() -> Self {
+        Self::default()
+    }
+
+    pub fn pattern_set(&self) -> Result<PatternSet, globset::Error> {
+        PatternSet::new(self.allow_patterns.clone(), self.deny_patterns.clone())
+    }
+}
+
+pub struct PatternSet {
+    allow: GlobSet,
+    deny: GlobSet,
+    has_allow_patterns: bool,
+}
+
+impl PatternSet {
+    pub fn new(
+        allow_patterns: Vec<String>,
+        deny_patterns: Vec<String>,
+    ) -> Result<Self, globset::Error> {
+        let has_allow_patterns = !allow_patterns.is_empty();
+        Ok(Self {
+            allow: build_glob_set(&allow_patterns)?,
+            deny: build_glob_set(&deny_patterns)?,
+            has_allow_patterns,
+        })
+    }
+
+    pub fn allows(&self, path: &str) -> bool {
+        !self.deny.is_match(path) && (!self.has_allow_patterns || self.allow.is_match(path))
+    }
+}
+
+fn build_glob_set(patterns: &[String]) -> Result<GlobSet, globset::Error> {
+    let mut builder = GlobSetBuilder::new();
+    for pattern in patterns {
+        builder.add(Glob::new(pattern)?);
+    }
+    builder.build()
+}
+
+pub fn parse_pattern_env(value: &str) -> Vec<String> {
+    value
+        .split(',')
+        .map(str::trim)
+        .filter(|pattern| !pattern.is_empty())
+        .map(ToOwned::to_owned)
+        .collect()
+}
+
+pub fn kernel_release_supports_passthrough(release: &str) -> bool {
+    let mut parts = release.split('.');
+    let Some(major) = parts.next().and_then(|part| part.parse::<u64>().ok()) else {
+        return false;
+    };
+    let Some(minor) = parts.next().and_then(parse_leading_number) else {
+        return false;
+    };
+
+    major > 6 || (major == 6 && minor >= 9)
+}
+
+pub fn linux_passthrough_supported() -> bool {
+    #[cfg(target_os = "linux")]
+    {
+        std::fs::read_to_string("/proc/sys/kernel/osrelease")
+            .map(|release| kernel_release_supports_passthrough(release.trim()))
+            .unwrap_or(false)
+    }
+
+    #[cfg(not(target_os = "linux"))]
+    {
+        false
+    }
+}
+
+fn parse_leading_number(value: &str) -> Option<u64> {
+    let digits: String = value
+        .chars()
+        .take_while(|character| character.is_ascii_digit())
+        .collect();
+
+    if digits.is_empty() {
+        None
+    } else {
+        digits.parse().ok()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn default_config_is_disabled_with_expected_limits() {
+        let config = PassthroughConfig::default();
+
+        assert!(!config.enabled);
+        assert_eq!(config.threshold_bytes, DEFAULT_THRESHOLD_BYTES);
+        assert!(!config.require);
+        assert!(config.allow_patterns.is_empty());
+        assert!(config.deny_patterns.is_empty());
+        assert!(config.backing_dir.is_none());
+        assert_eq!(PassthroughConfig::disabled(), config);
+    }
+
+    #[test]
+    fn parse_pattern_env_trims_empty_segments() {
+        let patterns = parse_pattern_env(" cache/**, ,*.bin,, /mnt/data/** ");
+
+        assert_eq!(patterns, vec!["cache/**", "*.bin", "/mnt/data/**"]);
+    }
+
+    #[test]
+    fn empty_allow_pattern_set_allows_any_path_unless_denied() {
+        let patterns = PatternSet::new(Vec::new(), vec!["/secret/**".to_string()]).unwrap();
+
+        assert!(patterns.allows("/public/file.bin"));
+        assert!(!patterns.allows("/secret/file.bin"));
+    }
+
+    #[test]
+    fn allow_and_deny_globs_control_path_eligibility() {
+        let config = PassthroughConfig {
+            allow_patterns: vec!["/cache/**".to_string(), "*.iso".to_string()],
+            deny_patterns: vec!["/cache/private/**".to_string()],
+            ..Default::default()
+        };
+        let patterns = config.pattern_set().unwrap();
+
+        assert!(patterns.allows("/cache/image.bin"));
+        assert!(patterns.allows("disk.iso"));
+        assert!(!patterns.allows("/cache/private/key.bin"));
+        assert!(!patterns.allows("/other/file.txt"));
+    }
+
+    #[test]
+    fn kernel_release_supports_linux_passthrough_from_6_9() {
+        assert!(kernel_release_supports_passthrough("6.9.0"));
+        assert!(kernel_release_supports_passthrough("6.10.1-custom"));
+        assert!(!kernel_release_supports_passthrough("6.8.12"));
+        assert!(!kernel_release_supports_passthrough("5.15.0"));
+        assert!(!kernel_release_supports_passthrough("not-a-version"));
+    }
+}

--- a/nexus-fuse/src/passthrough/manager.rs
+++ b/nexus-fuse/src/passthrough/manager.rs
@@ -1,0 +1,320 @@
+use crate::client::{FileMetadata, NexusClient};
+use crate::passthrough::backing::{BackingStore, MaterializedBacking};
+use crate::passthrough::config::PassthroughConfig;
+use crate::passthrough::policy::{DenyReason, OpenAccess, PassthroughDecision, PassthroughPolicy};
+use anyhow::{anyhow, Result};
+use fuser::BackingId;
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::{Arc, Mutex, MutexGuard};
+
+const FIRST_FILE_HANDLE: u64 = 1;
+const EXHAUSTED_FILE_HANDLE: u64 = 0;
+
+pub struct ActivePassthrough {
+    pub backing: MaterializedBacking,
+    pub backing_id: Arc<BackingId>,
+}
+
+enum ActiveHandle {
+    Passthrough(ActivePassthrough),
+    #[cfg(test)]
+    Test,
+}
+
+pub struct PassthroughManager {
+    server_url: String,
+    policy: PassthroughPolicy,
+    store: BackingStore,
+    next_fh: AtomicU64,
+    negotiated: AtomicBool,
+    active: Mutex<HashMap<u64, ActiveHandle>>,
+}
+
+impl PassthroughManager {
+    pub fn new(server_url: String, config: PassthroughConfig) -> Result<Self> {
+        let root = config
+            .backing_dir
+            .clone()
+            .unwrap_or_else(default_backing_dir);
+        Ok(Self {
+            server_url,
+            policy: PassthroughPolicy::new(config)?,
+            store: BackingStore::new(root)?,
+            next_fh: AtomicU64::new(FIRST_FILE_HANDLE),
+            negotiated: AtomicBool::new(false),
+            active: Mutex::new(HashMap::new()),
+        })
+    }
+
+    pub fn next_file_handle(&self) -> Result<u64> {
+        let mut current = self.next_fh.load(Ordering::Relaxed);
+        loop {
+            if current == EXHAUSTED_FILE_HANDLE {
+                return Err(anyhow!("passthrough file handle space exhausted"));
+            }
+
+            let next = current.checked_add(1).unwrap_or(EXHAUSTED_FILE_HANDLE);
+            match self.next_fh.compare_exchange_weak(
+                current,
+                next,
+                Ordering::Relaxed,
+                Ordering::Relaxed,
+            ) {
+                Ok(_) => return Ok(current),
+                Err(actual) => current = actual,
+            }
+        }
+    }
+
+    pub fn set_negotiated(&self, negotiated: bool) {
+        self.negotiated.store(negotiated, Ordering::Release);
+    }
+
+    pub fn negotiated(&self) -> bool {
+        self.negotiated.load(Ordering::Acquire)
+    }
+
+    pub fn require(&self) -> bool {
+        self.policy.config().require
+    }
+
+    pub fn decide(
+        &self,
+        path: &str,
+        metadata: &FileMetadata,
+        access: OpenAccess,
+    ) -> PassthroughDecision {
+        if !self.negotiated() {
+            return PassthroughDecision::Deny(DenyReason::NotNegotiated);
+        }
+        self.policy.decide(path, metadata, access)
+    }
+
+    pub fn materialize(
+        &self,
+        path: &str,
+        client: &NexusClient,
+        metadata: &FileMetadata,
+    ) -> Result<MaterializedBacking> {
+        self.store
+            .materialize(&self.server_url, path, client, metadata)
+    }
+
+    pub fn insert_active(&self, fh: u64, active: ActivePassthrough) -> Result<()> {
+        self.insert_active_handle(fh, ActiveHandle::Passthrough(active))
+    }
+
+    pub fn remove_active(&self, fh: u64) -> Result<Option<ActivePassthrough>> {
+        match self.active_lock()?.remove(&fh) {
+            Some(ActiveHandle::Passthrough(active)) => Ok(Some(active)),
+            #[cfg(test)]
+            Some(ActiveHandle::Test) => Ok(None),
+            None => Ok(None),
+        }
+    }
+
+    pub fn invalidate_path(&self, path: &str) {
+        if let Err(err) = self.store.invalidate_path(&self.server_url, path) {
+            log::warn!(
+                "passthrough backing invalidation failed for {}: {}",
+                path,
+                err
+            );
+        }
+    }
+
+    fn insert_active_handle(&self, fh: u64, active: ActiveHandle) -> Result<()> {
+        if fh == EXHAUSTED_FILE_HANDLE {
+            return Err(anyhow!("passthrough file handle 0 is reserved"));
+        }
+
+        let mut active_handles = self.active_lock()?;
+        if active_handles.contains_key(&fh) {
+            return Err(anyhow!("passthrough file handle {} is already active", fh));
+        }
+        active_handles.insert(fh, active);
+        Ok(())
+    }
+
+    fn active_lock(&self) -> Result<MutexGuard<'_, HashMap<u64, ActiveHandle>>> {
+        self.active
+            .lock()
+            .map_err(|_| anyhow!("passthrough active handle map lock poisoned"))
+    }
+
+    #[cfg(test)]
+    fn set_next_file_handle_for_tests(&self, next_fh: u64) {
+        self.next_fh.store(next_fh, Ordering::Relaxed);
+    }
+
+    #[cfg(test)]
+    fn insert_test_active(&self, fh: u64) -> Result<()> {
+        self.insert_active_handle(fh, ActiveHandle::Test)
+    }
+
+    #[cfg(test)]
+    fn remove_test_active(&self, fh: u64) -> Result<bool> {
+        Ok(self.active_lock()?.remove(&fh).is_some())
+    }
+
+    #[cfg(test)]
+    fn contains_active_for_tests(&self, fh: u64) -> Result<bool> {
+        Ok(self.active_lock()?.contains_key(&fh))
+    }
+}
+
+fn default_backing_dir() -> PathBuf {
+    dirs::cache_dir()
+        .unwrap_or_else(std::env::temp_dir)
+        .join("nexus-fuse")
+        .join("passthrough")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::FileMetadata;
+    use crate::passthrough::config::PassthroughConfig;
+    use tempfile::TempDir;
+
+    struct ManagerFixture {
+        manager: PassthroughManager,
+        _backing_dir: TempDir,
+    }
+
+    impl ManagerFixture {
+        fn new(mut config: PassthroughConfig) -> Self {
+            let backing_dir = tempfile::tempdir().expect("tempdir");
+            config.backing_dir = Some(backing_dir.path().to_path_buf());
+            let manager =
+                PassthroughManager::new("http://server".to_string(), config).expect("manager");
+            Self {
+                manager,
+                _backing_dir: backing_dir,
+            }
+        }
+    }
+
+    fn metadata(size: u64) -> FileMetadata {
+        FileMetadata {
+            size,
+            gen: 1,
+            etag: Some("etag-1".to_string()),
+            modified_at: None,
+            is_directory: false,
+        }
+    }
+
+    #[test]
+    fn next_file_handle_is_monotonic_and_never_zero() {
+        let fixture = ManagerFixture::new(PassthroughConfig {
+            enabled: true,
+            threshold_bytes: 128,
+            allow_patterns: vec![],
+            deny_patterns: vec![],
+            require: false,
+            backing_dir: None,
+        });
+        let manager = &fixture.manager;
+
+        assert_eq!(manager.next_file_handle().unwrap(), 1);
+        assert_eq!(manager.next_file_handle().unwrap(), 2);
+    }
+
+    #[test]
+    fn next_file_handle_reports_exhaustion_without_returning_zero() {
+        let fixture = ManagerFixture::new(PassthroughConfig {
+            enabled: true,
+            threshold_bytes: 128,
+            allow_patterns: vec![],
+            deny_patterns: vec![],
+            require: false,
+            backing_dir: None,
+        });
+        let manager = &fixture.manager;
+
+        manager.set_next_file_handle_for_tests(u64::MAX - 1);
+
+        assert_eq!(manager.next_file_handle().unwrap(), u64::MAX - 1);
+        assert_eq!(manager.next_file_handle().unwrap(), u64::MAX);
+        assert!(manager.next_file_handle().is_err());
+        assert!(manager.next_file_handle().is_err());
+    }
+
+    #[test]
+    fn decision_uses_policy() {
+        let fixture = ManagerFixture::new(PassthroughConfig {
+            enabled: true,
+            threshold_bytes: 128,
+            allow_patterns: vec!["/data/**".to_string()],
+            deny_patterns: vec![],
+            require: false,
+            backing_dir: None,
+        });
+        let manager = &fixture.manager;
+        manager.set_negotiated(true);
+
+        assert_eq!(
+            manager.decide("/data/big.bin", &metadata(1024), OpenAccess::ReadOnly),
+            PassthroughDecision::Allow
+        );
+        assert_eq!(
+            manager.decide("/logs/big.bin", &metadata(1024), OpenAccess::ReadOnly),
+            PassthroughDecision::Deny(DenyReason::Pattern)
+        );
+    }
+
+    #[test]
+    fn decision_denies_when_not_negotiated_by_default() {
+        let fixture = ManagerFixture::new(PassthroughConfig {
+            enabled: true,
+            threshold_bytes: 128,
+            allow_patterns: vec!["/data/**".to_string()],
+            deny_patterns: vec![],
+            require: false,
+            backing_dir: None,
+        });
+        let manager = &fixture.manager;
+
+        assert_eq!(
+            manager.decide("/data/big.bin", &metadata(1024), OpenAccess::ReadOnly),
+            PassthroughDecision::Deny(DenyReason::NotNegotiated)
+        );
+    }
+
+    #[test]
+    fn require_reflects_config() {
+        let fixture = ManagerFixture::new(PassthroughConfig {
+            enabled: true,
+            threshold_bytes: 128,
+            allow_patterns: vec![],
+            deny_patterns: vec![],
+            require: true,
+            backing_dir: None,
+        });
+
+        assert!(fixture.manager.require());
+    }
+
+    #[test]
+    fn active_map_tracks_inserted_handles() {
+        let fixture = ManagerFixture::new(PassthroughConfig {
+            enabled: true,
+            threshold_bytes: 128,
+            allow_patterns: vec![],
+            deny_patterns: vec![],
+            require: false,
+            backing_dir: None,
+        });
+        let manager = &fixture.manager;
+
+        manager.insert_test_active(10).unwrap();
+
+        assert!(manager.contains_active_for_tests(10).unwrap());
+        assert!(manager.remove_test_active(10).unwrap());
+        assert!(!manager.contains_active_for_tests(10).unwrap());
+        assert!(!manager.remove_test_active(10).unwrap());
+    }
+}

--- a/nexus-fuse/src/passthrough/mod.rs
+++ b/nexus-fuse/src/passthrough/mod.rs
@@ -1,0 +1,12 @@
+pub mod backing;
+pub mod config;
+pub mod manager;
+pub mod policy;
+
+pub use backing::{BackingKey, BackingStore, MaterializedBacking};
+pub use config::{
+    kernel_release_supports_passthrough, linux_passthrough_supported, parse_pattern_env,
+    PassthroughConfig, DEFAULT_THRESHOLD_BYTES,
+};
+pub use manager::{ActivePassthrough, PassthroughManager};
+pub use policy::{DenyReason, OpenAccess, PassthroughDecision, PassthroughPolicy};

--- a/nexus-fuse/src/passthrough/policy.rs
+++ b/nexus-fuse/src/passthrough/policy.rs
@@ -1,0 +1,213 @@
+use crate::client::FileMetadata;
+use crate::passthrough::config::{PassthroughConfig, PatternSet};
+use fuser::{OpenAccMode, OpenFlags};
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum OpenAccess {
+    ReadOnly,
+    WriteOnly,
+    ReadWrite,
+}
+
+impl OpenAccess {
+    pub fn from_open_flags(flags: OpenFlags) -> Self {
+        match flags.acc_mode() {
+            OpenAccMode::O_RDONLY => Self::ReadOnly,
+            OpenAccMode::O_WRONLY => Self::WriteOnly,
+            OpenAccMode::O_RDWR => Self::ReadWrite,
+        }
+    }
+
+    fn is_read_only(self) -> bool {
+        matches!(self, Self::ReadOnly)
+    }
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum DenyReason {
+    Disabled,
+    NotNegotiated,
+    Pattern,
+    Directory,
+    BelowThreshold,
+    NotReadOnly,
+}
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub enum PassthroughDecision {
+    Allow,
+    Deny(DenyReason),
+}
+
+pub struct PassthroughPolicy {
+    config: PassthroughConfig,
+    patterns: PatternSet,
+}
+
+impl PassthroughPolicy {
+    pub fn new(config: PassthroughConfig) -> Result<Self, globset::Error> {
+        let patterns = config.pattern_set()?;
+        Ok(Self { config, patterns })
+    }
+
+    pub fn config(&self) -> &PassthroughConfig {
+        &self.config
+    }
+
+    pub fn decide(
+        &self,
+        path: &str,
+        metadata: &FileMetadata,
+        access: OpenAccess,
+    ) -> PassthroughDecision {
+        if !self.config.enabled {
+            return PassthroughDecision::Deny(DenyReason::Disabled);
+        }
+
+        if metadata.is_directory {
+            return PassthroughDecision::Deny(DenyReason::Directory);
+        }
+
+        if !access.is_read_only() {
+            return PassthroughDecision::Deny(DenyReason::NotReadOnly);
+        }
+
+        if metadata.size < self.config.threshold_bytes {
+            return PassthroughDecision::Deny(DenyReason::BelowThreshold);
+        }
+
+        if !self.patterns.allows(path) {
+            return PassthroughDecision::Deny(DenyReason::Pattern);
+        }
+
+        PassthroughDecision::Allow
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::client::FileMetadata;
+    use crate::passthrough::config::PassthroughConfig;
+    use fuser::OpenFlags;
+
+    #[test]
+    fn disabled_config_denies_passthrough() {
+        let policy = PassthroughPolicy::new(PassthroughConfig::disabled()).unwrap();
+
+        assert_eq!(
+            policy.decide(
+                "/cache/file.bin",
+                &metadata(false, 256 * 1024),
+                OpenAccess::ReadOnly,
+            ),
+            PassthroughDecision::Deny(DenyReason::Disabled)
+        );
+    }
+
+    #[test]
+    fn large_read_only_file_matching_allow_pattern_is_allowed() {
+        let config = PassthroughConfig {
+            enabled: true,
+            allow_patterns: vec!["/cache/**".to_string()],
+            ..Default::default()
+        };
+        let policy = PassthroughPolicy::new(config).unwrap();
+
+        assert!(policy.config().enabled);
+        assert_eq!(
+            policy.decide(
+                "/cache/file.bin",
+                &metadata(false, 256 * 1024),
+                OpenAccess::ReadOnly,
+            ),
+            PassthroughDecision::Allow
+        );
+    }
+
+    #[test]
+    fn pattern_mismatch_is_denied() {
+        let policy = PassthroughPolicy::new(enabled_config()).unwrap();
+
+        assert_eq!(
+            policy.decide(
+                "/other/file.bin",
+                &metadata(false, 256 * 1024),
+                OpenAccess::ReadOnly,
+            ),
+            PassthroughDecision::Deny(DenyReason::Pattern)
+        );
+    }
+
+    #[test]
+    fn directories_are_denied() {
+        let policy = PassthroughPolicy::new(enabled_config()).unwrap();
+
+        assert_eq!(
+            policy.decide("/cache", &metadata(true, 256 * 1024), OpenAccess::ReadOnly,),
+            PassthroughDecision::Deny(DenyReason::Directory)
+        );
+    }
+
+    #[test]
+    fn files_below_threshold_are_denied() {
+        let policy = PassthroughPolicy::new(enabled_config()).unwrap();
+
+        assert_eq!(
+            policy.decide(
+                "/cache/small.bin",
+                &metadata(false, 127 * 1024),
+                OpenAccess::ReadOnly,
+            ),
+            PassthroughDecision::Deny(DenyReason::BelowThreshold)
+        );
+    }
+
+    #[test]
+    fn write_opens_are_denied() {
+        let policy = PassthroughPolicy::new(enabled_config()).unwrap();
+
+        assert_eq!(
+            policy.decide(
+                "/cache/file.bin",
+                &metadata(false, 256 * 1024),
+                OpenAccess::from_open_flags(OpenFlags(libc::O_RDWR)),
+            ),
+            PassthroughDecision::Deny(DenyReason::NotReadOnly)
+        );
+    }
+
+    #[test]
+    fn open_access_maps_fuser_access_modes() {
+        assert_eq!(
+            OpenAccess::from_open_flags(OpenFlags(libc::O_RDONLY)),
+            OpenAccess::ReadOnly
+        );
+        assert_eq!(
+            OpenAccess::from_open_flags(OpenFlags(libc::O_WRONLY)),
+            OpenAccess::WriteOnly
+        );
+        assert_eq!(
+            OpenAccess::from_open_flags(OpenFlags(libc::O_RDWR)),
+            OpenAccess::ReadWrite
+        );
+    }
+
+    fn enabled_config() -> PassthroughConfig {
+        PassthroughConfig {
+            enabled: true,
+            allow_patterns: vec!["/cache/**".to_string()],
+            ..Default::default()
+        }
+    }
+
+    fn metadata(is_directory: bool, size: u64) -> FileMetadata {
+        FileMetadata {
+            size,
+            gen: 1,
+            etag: None,
+            modified_at: None,
+            is_directory,
+        }
+    }
+}

--- a/nexus-fuse/tests/passthrough_integration.rs
+++ b/nexus-fuse/tests/passthrough_integration.rs
@@ -1,0 +1,49 @@
+#![cfg(target_os = "linux")]
+
+use nexus_fuse::client::FileMetadata;
+use nexus_fuse::passthrough::{
+    kernel_release_supports_passthrough, linux_passthrough_supported, OpenAccess,
+    PassthroughConfig, PassthroughDecision, PassthroughPolicy,
+};
+use std::process::Command;
+
+#[test]
+fn passthrough_kernel_support_probe_uses_project_parser() {
+    let output = Command::new("uname").arg("-r").output().expect("uname");
+    assert!(output.status.success());
+
+    let release = String::from_utf8(output.stdout).expect("utf8 uname release");
+    assert_eq!(
+        linux_passthrough_supported(),
+        kernel_release_supports_passthrough(release.trim())
+    );
+}
+
+#[test]
+fn passthrough_policy_handles_optional_and_required_configs_without_fuse() {
+    let metadata = FileMetadata {
+        size: 1024 * 1024,
+        gen: 1,
+        etag: Some("etag-1".to_string()),
+        modified_at: None,
+        is_directory: false,
+    };
+
+    for require in [false, true] {
+        let policy = PassthroughPolicy::new(PassthroughConfig {
+            enabled: true,
+            allow_patterns: vec!["/data/**".to_string()],
+            deny_patterns: vec![],
+            threshold_bytes: 128 * 1024,
+            require,
+            backing_dir: None,
+        })
+        .expect("passthrough policy");
+
+        assert_eq!(policy.config().require, require);
+        assert_eq!(
+            policy.decide("/data/one-gib.bin", &metadata, OpenAccess::ReadOnly),
+            PassthroughDecision::Allow
+        );
+    }
+}

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -463,6 +463,8 @@ def connect(
         install_remote_kernel_rpc_overrides(nfs, transport)
         cast(Any, nfs)._nexus_remote_call_rpc = transport.call_rpc
         nfs._register_runtime_closeable(transport)
+        nfs._remote_base_url = server_url
+        nfs._remote_api_key = api_key or ""
 
         return nfs
 

--- a/src/nexus/fuse/mount.py
+++ b/src/nexus/fuse/mount.py
@@ -11,7 +11,7 @@ import logging
 import threading
 from enum import Enum
 from pathlib import Path
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, cast
 
 from fuse import FUSE
 
@@ -19,6 +19,11 @@ if TYPE_CHECKING:
     from nexus.core.nexus_fs import NexusFS
 
 from nexus.fuse.operations import NexusFUSEOperations
+from nexus.fuse.passthrough import (
+    PassthroughOptions,
+    RustPassthroughMount,
+    mount_is_passthrough_safe,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -66,6 +71,12 @@ class NexusFUSE:
         owner_id: str | None = None,
         zone_id: str | None = None,
         use_rust: bool = False,
+        passthrough_enabled: bool | None = None,
+        passthrough_patterns: list[str] | None = None,
+        passthrough_deny_patterns: list[str] | None = None,
+        passthrough_threshold_bytes: int | None = None,
+        passthrough_require: bool = False,
+        passthrough_backing_dir: str | Path | None = None,
         lease_manager: Any | None = None,
         file_cache: Any | None = None,
     ) -> None:
@@ -94,6 +105,12 @@ class NexusFUSE:
             owner_id: Human owner ID for the agent (defaults to agent_id).
             zone_id: Zone ID for multi-zone isolation.
             use_rust: Use high-performance Rust FUSE daemon (Issue #1569).
+            passthrough_enabled: Route safe mounts to Rust-owned passthrough.
+            passthrough_patterns: Include patterns for Rust passthrough.
+            passthrough_deny_patterns: Exclude patterns for Rust passthrough.
+            passthrough_threshold_bytes: Minimum passthrough size. Defaults to env.
+            passthrough_require: Raise instead of falling back when unsafe.
+            passthrough_backing_dir: Optional local backing directory.
 
         Note:
             Issue #1076: Cache warmup runs automatically after mount in background.
@@ -110,6 +127,30 @@ class NexusFUSE:
         self._owner_id = owner_id
         self._zone_id = zone_id
         self._use_rust = use_rust
+        env_options = PassthroughOptions.from_env()
+        self._passthrough_options = PassthroughOptions(
+            enabled=env_options.enabled if passthrough_enabled is None else passthrough_enabled,
+            patterns=(
+                passthrough_patterns if passthrough_patterns is not None else env_options.patterns
+            ),
+            deny_patterns=(
+                passthrough_deny_patterns
+                if passthrough_deny_patterns is not None
+                else env_options.deny_patterns
+            ),
+            threshold_bytes=(
+                passthrough_threshold_bytes
+                if passthrough_threshold_bytes is not None
+                else env_options.threshold_bytes
+            ),
+            require=passthrough_require or env_options.require,
+            backing_dir=(
+                Path(passthrough_backing_dir)
+                if passthrough_backing_dir
+                else env_options.backing_dir
+            ),
+        )
+        self._rust_passthrough_mount: RustPassthroughMount | None = None
         self._lease_manager = lease_manager
         self._file_cache = file_cache
         # Generate unique mount ID for lease holder identity (Decision 2A)
@@ -181,6 +222,10 @@ class NexusFUSE:
 
             # A2-B: Try to obtain NamespaceManager for direct visibility checks
             namespace_manager = getattr(self.nexus_fs, "namespace_manager", None)
+
+        if self._should_use_rust_passthrough(context):
+            self._start_rust_passthrough_mount()
+            return
 
         # Create FUSE operations
         # Issue #1771: event_bus via kernel-level _event_bus
@@ -302,6 +347,61 @@ class NexusFUSE:
             # Always enabled - non-blocking, lightweight, reduces first-access latency
             self._start_warmup()
 
+    def _should_use_rust_passthrough(self, context: Any | None) -> bool:
+        if not (self._use_rust and self._passthrough_options.enabled):
+            return False
+        if self._rust_passthrough_credentials() is None:
+            if self._passthrough_options.require:
+                raise RuntimeError(
+                    "FUSE passthrough requires a remote NexusFS with passthrough credentials"
+                )
+            return False
+        if not mount_is_passthrough_safe(
+            self.nexus_fs,
+            mode_value=self.mode.value,
+            context=context,
+        ):
+            if self._passthrough_options.require:
+                raise RuntimeError("FUSE passthrough is not safe for this mount configuration")
+            return False
+        return True
+
+    def _rust_passthrough_credentials(self) -> tuple[str, str] | None:
+        missing = object()
+        remote_fs = cast(Any, self.nexus_fs)
+
+        nexus_url = getattr(remote_fs, "_base_url", missing)
+        if nexus_url is missing:
+            nexus_url = getattr(remote_fs, "_remote_base_url", missing)
+        if nexus_url is missing:
+            return None
+
+        api_key = getattr(remote_fs, "_api_key", missing)
+        if api_key is missing:
+            api_key = getattr(remote_fs, "_remote_api_key", "")
+        if api_key is None:
+            api_key = ""
+
+        return str(nexus_url), str(api_key)
+
+    def _start_rust_passthrough_mount(self) -> None:
+        credentials = self._rust_passthrough_credentials()
+        if credentials is None:
+            raise RuntimeError(
+                "FUSE passthrough requires a remote NexusFS with passthrough credentials"
+            )
+        nexus_url, api_key = credentials
+        self._rust_passthrough_mount = RustPassthroughMount.create(
+            nexus_url=nexus_url,
+            api_key=api_key,
+            mount_point=self.mount_point,
+            options=self._passthrough_options,
+            agent_id=getattr(self.nexus_fs, "_agent_id", self._agent_id),
+        )
+        self._rust_passthrough_mount.start()
+        self._mounted = True
+        self._start_warmup()
+
     def _start_warmup(self) -> None:
         """Start background cache warmup (Issue #1076).
 
@@ -353,6 +453,13 @@ class NexusFUSE:
         self._warmup_thread = threading.Thread(target=warmup_thread, daemon=True)
         self._warmup_thread.start()
 
+    def _stop_rust_passthrough_mount(self) -> None:
+        rust_mount = self._rust_passthrough_mount
+        if rust_mount is None:
+            return
+        rust_mount.stop()
+        self._rust_passthrough_mount = None
+
     def unmount(self) -> None:
         """Unmount the filesystem.
 
@@ -360,6 +467,9 @@ class NexusFUSE:
             RuntimeError: If not mounted
         """
         if not self._mounted:
+            if self._rust_passthrough_mount is not None:
+                self._stop_rust_passthrough_mount()
+                return
             raise RuntimeError("Filesystem is not mounted")
 
         logger.info(f"Unmounting {self.mount_point}")
@@ -401,9 +511,16 @@ class NexusFUSE:
                 if hasattr(coordinator, "close"):
                     coordinator.close()
 
+            self._stop_rust_passthrough_mount()
+
         except subprocess.CalledProcessError as e:
-            logger.error(f"Failed to unmount: {e.stderr.decode()}")
-            raise RuntimeError(f"Failed to unmount: {e.stderr.decode()}") from e
+            stderr = e.stderr.decode()
+            logger.error(f"Failed to unmount: {stderr}")
+            try:
+                self._stop_rust_passthrough_mount()
+            except Exception as stop_error:
+                logger.error(f"Failed to stop Rust passthrough mount: {stop_error}")
+            raise RuntimeError(f"Failed to unmount: {stderr}") from e
 
     def is_mounted(self) -> bool:
         """Check if filesystem is currently mounted.
@@ -450,6 +567,12 @@ def mount_nexus(
     owner_id: str | None = None,
     zone_id: str | None = None,
     use_rust: bool = False,
+    passthrough_enabled: bool | None = None,
+    passthrough_patterns: list[str] | None = None,
+    passthrough_deny_patterns: list[str] | None = None,
+    passthrough_threshold_bytes: int | None = None,
+    passthrough_require: bool = False,
+    passthrough_backing_dir: str | Path | None = None,
     lease_manager: Any | None = None,
     file_cache: Any | None = None,
 ) -> "NexusFUSE":
@@ -477,6 +600,12 @@ def mount_nexus(
         owner_id: Human owner ID for the agent
         zone_id: Zone ID for multi-zone isolation
         use_rust: Use high-performance Rust FUSE daemon (Issue #1569)
+        passthrough_enabled: Route safe mounts to Rust-owned passthrough.
+        passthrough_patterns: Include patterns for Rust passthrough.
+        passthrough_deny_patterns: Exclude patterns for Rust passthrough.
+        passthrough_threshold_bytes: Minimum passthrough size. Defaults to env.
+        passthrough_require: Raise instead of falling back when unsafe.
+        passthrough_backing_dir: Optional local backing directory.
 
     Returns:
         NexusFUSE instance
@@ -516,6 +645,12 @@ def mount_nexus(
         owner_id=owner_id,
         zone_id=zone_id,
         use_rust=use_rust,
+        passthrough_enabled=passthrough_enabled,
+        passthrough_patterns=passthrough_patterns,
+        passthrough_deny_patterns=passthrough_deny_patterns,
+        passthrough_threshold_bytes=passthrough_threshold_bytes,
+        passthrough_require=passthrough_require,
+        passthrough_backing_dir=passthrough_backing_dir,
         lease_manager=lease_manager,
         file_cache=file_cache,
     )

--- a/src/nexus/fuse/passthrough.py
+++ b/src/nexus/fuse/passthrough.py
@@ -1,0 +1,291 @@
+"""Python orchestration helpers for Rust-owned FUSE passthrough mounts."""
+
+from __future__ import annotations
+
+import os
+import platform
+import subprocess
+import tempfile
+import time
+from contextlib import suppress
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+from nexus.fuse.rust_client import RustFUSEClient
+
+_STARTUP_TIMEOUT_SECS = 5.0
+_STARTUP_POLL_INTERVAL_SECS = 0.05
+_STARTUP_LOG_BYTES = 4096
+_PASSTHROUGH_HOOK_OPERATIONS = (
+    "read",
+    "write",
+    "write_batch",
+    "delete",
+    "rename",
+    "copy",
+    "mkdir",
+    "rmdir",
+    "stat",
+    "access",
+    "open",
+)
+_PASSTHROUGH_ENV_PREFIX = "NEXUS_FUSE_PASSTHROUGH"
+
+
+def _parse_bool(value: str | None) -> bool:
+    return value is not None and value.strip().lower() in {"1", "true", "yes", "on"}
+
+
+def _parse_patterns(value: str | None) -> list[str]:
+    if not value:
+        return []
+    return [segment.strip() for segment in value.split(",") if segment.strip()]
+
+
+@dataclass(slots=True)
+class PassthroughOptions:
+    enabled: bool = False
+    patterns: list[str] = field(default_factory=list)
+    deny_patterns: list[str] = field(default_factory=list)
+    threshold_bytes: int = 128 * 1024
+    require: bool = False
+    backing_dir: Path | None = None
+
+    @classmethod
+    def from_env(cls) -> PassthroughOptions:
+        backing_dir = os.environ.get("NEXUS_FUSE_PASSTHROUGH_BACKING_DIR")
+        return cls(
+            enabled=_parse_bool(os.environ.get("NEXUS_FUSE_PASSTHROUGH")),
+            patterns=_parse_patterns(os.environ.get("NEXUS_FUSE_PASSTHROUGH_PATTERNS")),
+            deny_patterns=_parse_patterns(os.environ.get("NEXUS_FUSE_PASSTHROUGH_DENY_PATTERNS")),
+            threshold_bytes=int(
+                os.environ.get("NEXUS_FUSE_PASSTHROUGH_THRESHOLD_BYTES", str(128 * 1024))
+            ),
+            require=_parse_bool(os.environ.get("NEXUS_FUSE_PASSTHROUGH_REQUIRE")),
+            backing_dir=Path(backing_dir) if backing_dir else None,
+        )
+
+
+def mount_is_passthrough_safe(nexus_fs: Any, *, mode_value: str, context: Any | None) -> bool:
+    if platform.system() != "Linux":
+        return False
+    if context is not None:
+        return False
+    if mode_value != "binary":
+        return False
+
+    try:
+        kernel = getattr(nexus_fs, "_kernel", None)
+        if kernel is None:
+            return False
+        hook_count = kernel.hook_count
+    except Exception:
+        return False
+
+    if not callable(hook_count):
+        return False
+
+    try:
+        if any(hook_count(operation) != 0 for operation in _PASSTHROUGH_HOOK_OPERATIONS):
+            return False
+        if int(nexus_fs.mount_hook_count) != 0:
+            return False
+        if int(nexus_fs.unmount_hook_count) != 0:
+            return False
+    except Exception:
+        return False
+
+    return True
+
+
+@dataclass(slots=True)
+class RustPassthroughMount:
+    rust_binary: str
+    nexus_url: str
+    api_key: str
+    mount_point: Path
+    options: PassthroughOptions
+    agent_id: str | None = None
+    process: subprocess.Popen[str] | None = None
+    api_key_file: Path | None = None
+    log_file: Path | None = None
+
+    @classmethod
+    def create(
+        cls,
+        *,
+        nexus_url: str,
+        api_key: str,
+        mount_point: Path,
+        options: PassthroughOptions,
+        agent_id: str | None = None,
+    ) -> RustPassthroughMount:
+        finder = RustFUSEClient.__new__(RustFUSEClient)
+        finder.daemon_process = None
+        finder.socket_path = None
+        finder.sock = None
+        rust_binary = finder._find_rust_binary()
+        return cls(
+            rust_binary=rust_binary,
+            nexus_url=nexus_url,
+            api_key=api_key,
+            mount_point=mount_point,
+            options=options,
+            agent_id=agent_id,
+        )
+
+    def build_command(self) -> tuple[list[str], dict[str, str], Path]:
+        self._remove_api_key_file()
+        api_key_file = self._write_api_key_file()
+
+        cmd = [
+            self.rust_binary,
+            "mount",
+            str(self.mount_point),
+            "--url",
+            self.nexus_url,
+            "--api-key-file",
+            str(api_key_file),
+            "--foreground",
+            "--passthrough",
+            "--passthrough-threshold-bytes",
+            str(self.options.threshold_bytes),
+        ]
+
+        for pattern in self.options.patterns:
+            cmd.extend(["--passthrough-pattern", pattern])
+        for pattern in self.options.deny_patterns:
+            cmd.extend(["--passthrough-deny-pattern", pattern])
+        if self.options.require:
+            cmd.append("--passthrough-require")
+        if self.options.backing_dir is not None:
+            cmd.extend(["--passthrough-backing-dir", str(self.options.backing_dir)])
+        if self.agent_id:
+            cmd.extend(["--agent-id", self.agent_id])
+
+        env = dict(os.environ)
+        for key in list(env):
+            if key == "NEXUS_API_KEY" or key.startswith(_PASSTHROUGH_ENV_PREFIX):
+                env.pop(key, None)
+        return cmd, env, api_key_file
+
+    def start(self) -> None:
+        if self.process is not None:
+            if self.process.poll() is None:
+                raise RuntimeError("Rust passthrough mount is already running")
+            self.process = None
+            self._remove_api_key_file()
+
+        cmd, env, _api_key_file = self.build_command()
+        log_handle = None
+        try:
+            log_file = self._create_log_file()
+            log_handle = log_file.open("w", encoding="utf-8")
+            self.process = subprocess.Popen(
+                cmd,
+                stdout=log_handle,
+                stderr=subprocess.STDOUT,
+                text=True,
+                env=env,
+            )
+            log_handle.close()
+            log_handle = None
+            self._wait_until_mounted()
+        except Exception:
+            if log_handle is not None:
+                log_handle.close()
+            if self.process is not None and self.process.poll() is None:
+                self.stop()
+            else:
+                self.process = None
+                self._remove_api_key_file()
+                self._remove_log_file()
+            raise
+
+    def stop(self) -> None:
+        process = self.process
+        try:
+            if process is not None and process.poll() is None:
+                process.terminate()
+                try:
+                    process.wait(timeout=5)
+                except subprocess.TimeoutExpired:
+                    process.kill()
+                    process.wait(timeout=5)
+        finally:
+            self.process = None
+            self._remove_api_key_file()
+            self._remove_log_file()
+
+    def _wait_until_mounted(self) -> None:
+        deadline = time.monotonic() + _STARTUP_TIMEOUT_SECS
+        while True:
+            if self.mount_point.is_mount():
+                return
+
+            process = self.process
+            if process is None:
+                raise RuntimeError("Rust passthrough mount process was not started")
+
+            exit_code = process.poll()
+            if exit_code is not None:
+                details = self._startup_log_details()
+                raise RuntimeError(
+                    f"Rust passthrough mount exited before mounting "
+                    f"(exit code {exit_code}){details}"
+                )
+
+            if time.monotonic() >= deadline:
+                details = self._startup_log_details()
+                raise RuntimeError(
+                    "Rust passthrough mount did not become ready within "
+                    f"{_STARTUP_TIMEOUT_SECS:.1f}s{details}"
+                )
+
+            time.sleep(_STARTUP_POLL_INTERVAL_SECS)
+
+    def _write_api_key_file(self) -> Path:
+        fd, name = tempfile.mkstemp(prefix="nexus-fuse-api-key-", text=True)
+        api_key_file = Path(name)
+        try:
+            with os.fdopen(fd, "w", encoding="utf-8") as handle:
+                handle.write(self.api_key)
+            api_key_file.chmod(0o600)
+        except BaseException:
+            with suppress(FileNotFoundError):
+                api_key_file.unlink()
+            raise
+
+        self.api_key_file = api_key_file
+        return api_key_file
+
+    def _remove_api_key_file(self) -> None:
+        if self.api_key_file is None:
+            return
+        with suppress(FileNotFoundError):
+            self.api_key_file.unlink()
+        self.api_key_file = None
+
+    def _create_log_file(self) -> Path:
+        self._remove_log_file()
+        fd, name = tempfile.mkstemp(prefix="nexus-fuse-passthrough-", suffix=".log", text=True)
+        os.close(fd)
+        self.log_file = Path(name)
+        return self.log_file
+
+    def _startup_log_details(self) -> str:
+        if self.log_file is None:
+            return ""
+        with suppress(OSError, UnicodeDecodeError):
+            output = self.log_file.read_text(encoding="utf-8")[-_STARTUP_LOG_BYTES:].strip()
+            if output:
+                return f": {output}"
+        return ""
+
+    def _remove_log_file(self) -> None:
+        if self.log_file is None:
+            return
+        with suppress(FileNotFoundError):
+            self.log_file.unlink()
+        self.log_file = None

--- a/tests/unit/fuse/test_passthrough_options.py
+++ b/tests/unit/fuse/test_passthrough_options.py
@@ -1,0 +1,681 @@
+from __future__ import annotations
+
+import subprocess
+import sys
+import types
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+sys.modules.setdefault("nexus_runtime", MagicMock())
+
+from nexus.fuse.mount import MountMode, NexusFUSE, mount_nexus  # noqa: E402
+from nexus.fuse.passthrough import (  # noqa: E402
+    PassthroughOptions,
+    RustPassthroughMount,
+    mount_is_passthrough_safe,
+)
+
+
+def test_options_from_env(monkeypatch):
+    monkeypatch.setenv("NEXUS_FUSE_PASSTHROUGH", "true")
+    monkeypatch.setenv("NEXUS_FUSE_PASSTHROUGH_PATTERNS", "/data/**, /models/*.bin")
+    monkeypatch.setenv("NEXUS_FUSE_PASSTHROUGH_DENY_PATTERNS", "/data/private/**")
+    monkeypatch.setenv("NEXUS_FUSE_PASSTHROUGH_THRESHOLD_BYTES", "262144")
+    monkeypatch.setenv("NEXUS_FUSE_PASSTHROUGH_REQUIRE", "1")
+    monkeypatch.setenv("NEXUS_FUSE_PASSTHROUGH_BACKING_DIR", "/tmp/nexus-passthrough")
+
+    options = PassthroughOptions.from_env()
+
+    assert options.enabled is True
+    assert options.patterns == ["/data/**", "/models/*.bin"]
+    assert options.deny_patterns == ["/data/private/**"]
+    assert options.threshold_bytes == 262144
+    assert options.require is True
+    assert options.backing_dir == Path("/tmp/nexus-passthrough")
+
+
+def test_rust_mount_command_uses_api_key_file(tmp_path: Path, monkeypatch):
+    monkeypatch.setenv("NEXUS_API_KEY", "sk-test")
+    monkeypatch.setenv("NEXUS_FUSE_PASSTHROUGH", "true")
+    monkeypatch.setenv("NEXUS_FUSE_PASSTHROUGH_PATTERNS", "/env/**")
+    monkeypatch.setenv("NEXUS_FUSE_PASSTHROUGH_DENY_PATTERNS", "/env/private/**")
+    monkeypatch.setenv("NEXUS_FUSE_PASSTHROUGH_THRESHOLD_BYTES", "999")
+    monkeypatch.setenv("NEXUS_FUSE_PASSTHROUGH_REQUIRE", "1")
+    monkeypatch.setenv("NEXUS_FUSE_PASSTHROUGH_BACKING_DIR", "/tmp/env-backing")
+    mount = RustPassthroughMount(
+        rust_binary="/usr/bin/nexus-fuse",
+        nexus_url="http://localhost:2026",
+        api_key="sk-test",
+        mount_point=tmp_path / "mnt",
+        options=PassthroughOptions(
+            enabled=True,
+            patterns=["/data/**"],
+            deny_patterns=["/data/private/**"],
+            threshold_bytes=131072,
+        ),
+        agent_id="agent-1",
+    )
+
+    cmd, env, api_key_file = mount.build_command()
+    try:
+        assert cmd[:4] == ["/usr/bin/nexus-fuse", "mount", str(tmp_path / "mnt"), "--url"]
+        assert "sk-test" not in " ".join(cmd)
+        assert "--api-key-file" in cmd
+        assert "--passthrough" in cmd
+        assert cmd.count("--passthrough-pattern") == 1
+        assert cmd[cmd.index("--passthrough-pattern") + 1] == "/data/**"
+        assert cmd.count("--passthrough-deny-pattern") == 1
+        assert cmd[cmd.index("--passthrough-deny-pattern") + 1] == "/data/private/**"
+        assert "--passthrough-threshold-bytes" in cmd
+        assert cmd[cmd.index("--passthrough-threshold-bytes") + 1] == "131072"
+        assert cmd[cmd.index("--agent-id") + 1] == "agent-1"
+        assert "NEXUS_API_KEY" not in env
+        assert not any(key.startswith("NEXUS_FUSE_PASSTHROUGH") for key in env)
+        assert api_key_file.read_text() == "sk-test"
+        assert oct(api_key_file.stat().st_mode & 0o777) == "0o600"
+    finally:
+        mount.stop()
+
+
+def test_mount_safety_denies_context_and_hook_counts(monkeypatch):
+    monkeypatch.setattr("nexus.fuse.passthrough.platform.system", lambda: "Linux")
+    fs = MagicMock()
+    fs.mount_hook_count = 0
+    fs.unmount_hook_count = 0
+
+    fs._kernel.hook_count.side_effect = lambda name: 1 if name == "read" else 0
+    assert mount_is_passthrough_safe(fs, mode_value="binary", context=None) is False
+    fs._kernel.hook_count.side_effect = lambda name: 1 if name == "stat" else 0
+    assert mount_is_passthrough_safe(fs, mode_value="binary", context=None) is False
+    fs._kernel.hook_count.side_effect = lambda name: 1 if name == "open" else 0
+    assert mount_is_passthrough_safe(fs, mode_value="binary", context=None) is False
+    fs._kernel.hook_count.side_effect = lambda name: 0
+    assert mount_is_passthrough_safe(fs, mode_value="smart", context=None) is False
+    assert mount_is_passthrough_safe(fs, mode_value="binary", context=object()) is False
+    assert mount_is_passthrough_safe(fs, mode_value="binary", context=None) is True
+
+
+@pytest.mark.parametrize(
+    "hook_name",
+    [
+        "write",
+        "write_batch",
+        "delete",
+        "rename",
+        "copy",
+        "mkdir",
+        "rmdir",
+        "access",
+    ],
+)
+def test_mount_safety_denies_mutating_and_access_hooks(monkeypatch, hook_name: str):
+    monkeypatch.setattr("nexus.fuse.passthrough.platform.system", lambda: "Linux")
+    fs = MagicMock()
+    fs.mount_hook_count = 0
+    fs.unmount_hook_count = 0
+    fs._kernel.hook_count.side_effect = lambda name: 1 if name == hook_name else 0
+
+    assert mount_is_passthrough_safe(fs, mode_value="binary", context=None) is False
+
+
+@pytest.mark.parametrize("lifecycle_attr", ["mount_hook_count", "unmount_hook_count"])
+def test_mount_safety_denies_lifecycle_hooks(monkeypatch, lifecycle_attr: str):
+    monkeypatch.setattr("nexus.fuse.passthrough.platform.system", lambda: "Linux")
+    fs = MagicMock()
+    fs.mount_hook_count = 0
+    fs.unmount_hook_count = 0
+    setattr(fs, lifecycle_attr, 1)
+    fs._kernel.hook_count.side_effect = lambda name: 0
+
+    assert mount_is_passthrough_safe(fs, mode_value="binary", context=None) is False
+
+
+def test_mount_safety_denies_hook_count_exception_or_missing(monkeypatch):
+    monkeypatch.setattr("nexus.fuse.passthrough.platform.system", lambda: "Linux")
+    raising_fs = MagicMock()
+    raising_fs.mount_hook_count = 0
+    raising_fs.unmount_hook_count = 0
+    raising_fs._kernel.hook_count.side_effect = RuntimeError("hook count unavailable")
+
+    missing_hook_count_fs = SimpleNamespace(
+        _kernel=SimpleNamespace(),
+        mount_hook_count=0,
+        unmount_hook_count=0,
+    )
+
+    assert mount_is_passthrough_safe(raising_fs, mode_value="binary", context=None) is False
+    assert (
+        mount_is_passthrough_safe(missing_hook_count_fs, mode_value="binary", context=None) is False
+    )
+
+
+def test_mount_safety_denies_lifecycle_hook_count_exception(monkeypatch):
+    monkeypatch.setattr("nexus.fuse.passthrough.platform.system", lambda: "Linux")
+
+    class RaisesLifecycleHookCount:
+        _kernel = SimpleNamespace(hook_count=lambda name: 0)
+
+        @property
+        def mount_hook_count(self):
+            raise RuntimeError("mount hook count unavailable")
+
+        @property
+        def unmount_hook_count(self):
+            return 0
+
+    assert (
+        mount_is_passthrough_safe(RaisesLifecycleHookCount(), mode_value="binary", context=None)
+        is False
+    )
+
+
+def test_start_waits_for_mount_and_keeps_process_output_in_log(monkeypatch, tmp_path: Path):
+    mount = RustPassthroughMount(
+        rust_binary="/usr/bin/nexus-fuse",
+        nexus_url="http://localhost:2026",
+        api_key="sk-test",
+        mount_point=tmp_path / "mnt",
+        options=PassthroughOptions(enabled=True, patterns=["/data/**"]),
+    )
+    popen = MagicMock()
+    popen.return_value.poll.return_value = None
+    monkeypatch.setattr("nexus.fuse.passthrough.subprocess.Popen", popen)
+    monkeypatch.setattr(Path, "is_mount", lambda self: True)
+
+    mount.start()
+    try:
+        assert popen.call_args.kwargs["stdout"] is not subprocess.DEVNULL
+        assert popen.call_args.kwargs["stderr"] is subprocess.STDOUT
+        assert mount.log_file is not None
+    finally:
+        mount.stop()
+
+
+def test_start_raises_and_cleans_up_when_process_exits_before_mount(monkeypatch, tmp_path: Path):
+    api_key_file = None
+
+    process = MagicMock()
+    process.poll.return_value = 2
+
+    def popen(cmd, **kwargs):
+        nonlocal api_key_file
+        api_key_file = Path(cmd[cmd.index("--api-key-file") + 1])
+        assert api_key_file.exists()
+        return process
+
+    mount = RustPassthroughMount(
+        rust_binary="/usr/bin/nexus-fuse",
+        nexus_url="http://localhost:2026",
+        api_key="sk-test",
+        mount_point=tmp_path / "mnt",
+        options=PassthroughOptions(enabled=True, patterns=["/data/**"]),
+    )
+    monkeypatch.setattr("nexus.fuse.passthrough.subprocess.Popen", popen)
+    monkeypatch.setattr(Path, "is_mount", lambda self: False)
+
+    with pytest.raises(RuntimeError, match="exited before mounting"):
+        mount.start()
+
+    assert api_key_file is not None
+    assert not api_key_file.exists()
+    assert mount.process is None
+    assert mount.api_key_file is None
+
+
+def test_start_cleans_api_key_file_when_popen_fails(monkeypatch, tmp_path: Path):
+    api_key_file = None
+
+    def raise_from_popen(cmd, **kwargs):
+        nonlocal api_key_file
+        api_key_file = Path(cmd[cmd.index("--api-key-file") + 1])
+        assert api_key_file.exists()
+        raise RuntimeError("failed to start")
+
+    mount = RustPassthroughMount(
+        rust_binary="/usr/bin/nexus-fuse",
+        nexus_url="http://localhost:2026",
+        api_key="sk-test",
+        mount_point=tmp_path / "mnt",
+        options=PassthroughOptions(enabled=True, patterns=["/data/**"]),
+    )
+    monkeypatch.setattr("nexus.fuse.passthrough.subprocess.Popen", raise_from_popen)
+
+    with pytest.raises(RuntimeError, match="failed to start"):
+        mount.start()
+
+    assert api_key_file is not None
+    assert not api_key_file.exists()
+    assert mount.api_key_file is None
+
+
+def test_start_rejects_repeated_start_without_touching_running_mount(tmp_path: Path):
+    api_key_file = tmp_path / "api-key"
+    api_key_file.write_text("sk-test")
+    process = MagicMock()
+    process.poll.return_value = None
+    mount = RustPassthroughMount(
+        rust_binary="/usr/bin/nexus-fuse",
+        nexus_url="http://localhost:2026",
+        api_key="sk-test",
+        mount_point=tmp_path / "mnt",
+        options=PassthroughOptions(enabled=True, patterns=["/data/**"]),
+        process=process,
+        api_key_file=api_key_file,
+    )
+
+    with pytest.raises(RuntimeError, match="already running"):
+        mount.start()
+
+    assert mount.process is process
+    assert mount.api_key_file == api_key_file
+    assert api_key_file.read_text() == "sk-test"
+
+
+def test_stop_cleans_process_and_api_key_file_on_timeout(tmp_path: Path):
+    api_key_file = tmp_path / "api-key"
+    api_key_file.write_text("sk-test")
+    process = MagicMock()
+    process.poll.return_value = None
+    process.wait.side_effect = subprocess.TimeoutExpired(cmd="nexus-fuse", timeout=5)
+    mount = RustPassthroughMount(
+        rust_binary="/usr/bin/nexus-fuse",
+        nexus_url="http://localhost:2026",
+        api_key="sk-test",
+        mount_point=tmp_path / "mnt",
+        options=PassthroughOptions(enabled=True, patterns=["/data/**"]),
+        process=process,
+        api_key_file=api_key_file,
+    )
+
+    try:
+        mount.stop()
+    except subprocess.TimeoutExpired:
+        pass
+
+    assert mount.process is None
+    assert mount.api_key_file is None
+    assert not api_key_file.exists()
+
+
+def test_create_finds_rust_binary_without_starting_daemon(monkeypatch, tmp_path: Path):
+    def fail_start_daemon(self):
+        raise AssertionError("create should not start the Rust daemon")
+
+    monkeypatch.setattr(
+        "nexus.fuse.passthrough.RustFUSEClient._find_rust_binary",
+        lambda self: "/usr/bin/nexus-fuse",
+    )
+    monkeypatch.setattr("nexus.fuse.passthrough.RustFUSEClient._start_daemon", fail_start_daemon)
+
+    mount = RustPassthroughMount.create(
+        nexus_url="http://localhost:2026",
+        api_key="sk-test",
+        mount_point=tmp_path / "mnt",
+        options=PassthroughOptions(enabled=True, patterns=["/data/**"]),
+        agent_id="agent-1",
+    )
+
+    assert mount.rust_binary == "/usr/bin/nexus-fuse"
+    assert mount.agent_id == "agent-1"
+
+
+def test_nexus_fuse_uses_rust_passthrough_launcher_when_safe(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr("nexus.fuse.passthrough.platform.system", lambda: "Linux")
+    fs = MagicMock()
+    fs._base_url = "http://localhost:2026"
+    fs._api_key = "sk-test"
+    fs._kernel.hook_count.return_value = 0
+    fs.mount_hook_count = 0
+    fs.unmount_hook_count = 0
+    mount_point = tmp_path / "mnt"
+    mount_point.mkdir()
+
+    launcher = MagicMock()
+    with (
+        patch("nexus.fuse.mount.RustPassthroughMount.create", return_value=launcher) as create,
+        patch("nexus.fuse.mount.NexusFUSEOperations") as operations_cls,
+        patch("nexus.fuse.mount.FUSE") as fuse_cls,
+        patch.object(NexusFUSE, "_start_warmup"),
+    ):
+        fuse = NexusFUSE(
+            fs,
+            str(mount_point),
+            mode=MountMode.BINARY,
+            use_rust=True,
+            passthrough_enabled=True,
+            passthrough_patterns=["/data/**"],
+        )
+        fuse.mount(foreground=False)
+
+    create.assert_called_once()
+    launcher.start.assert_called_once_with()
+    operations_cls.assert_not_called()
+    fuse_cls.assert_not_called()
+    assert fuse.is_mounted() is True
+
+
+def test_nexus_fuse_uses_remote_profile_passthrough_credentials(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr("nexus.fuse.passthrough.platform.system", lambda: "Linux")
+    fs = SimpleNamespace(
+        _remote_base_url="http://remote.example:2026",
+        _remote_api_key="sk-remote",
+        _kernel=SimpleNamespace(hook_count=lambda _name: 0),
+        mount_hook_count=0,
+        unmount_hook_count=0,
+    )
+    mount_point = tmp_path / "mnt"
+    mount_point.mkdir()
+
+    launcher = MagicMock()
+    with (
+        patch("nexus.fuse.mount.RustPassthroughMount.create", return_value=launcher) as create,
+        patch("nexus.fuse.mount.NexusFUSEOperations") as operations_cls,
+        patch("nexus.fuse.mount.FUSE") as fuse_cls,
+        patch.object(NexusFUSE, "_start_warmup"),
+    ):
+        fuse = NexusFUSE(
+            fs,
+            str(mount_point),
+            mode=MountMode.BINARY,
+            use_rust=True,
+            passthrough_enabled=True,
+        )
+        fuse.mount(foreground=False)
+
+    assert create.call_args.kwargs["nexus_url"] == "http://remote.example:2026"
+    assert create.call_args.kwargs["api_key"] == "sk-remote"
+    launcher.start.assert_called_once_with()
+    operations_cls.assert_not_called()
+    fuse_cls.assert_not_called()
+
+
+def test_nexus_fuse_allows_missing_remote_api_key_as_empty_string(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr("nexus.fuse.passthrough.platform.system", lambda: "Linux")
+    fs = SimpleNamespace(
+        _remote_base_url="http://remote.example:2026",
+        _kernel=SimpleNamespace(hook_count=lambda _name: 0),
+        mount_hook_count=0,
+        unmount_hook_count=0,
+    )
+    mount_point = tmp_path / "mnt"
+    mount_point.mkdir()
+
+    launcher = MagicMock()
+    with (
+        patch("nexus.fuse.mount.RustPassthroughMount.create", return_value=launcher) as create,
+        patch.object(NexusFUSE, "_start_warmup"),
+    ):
+        fuse = NexusFUSE(
+            fs,
+            str(mount_point),
+            mode=MountMode.BINARY,
+            use_rust=True,
+            passthrough_enabled=True,
+        )
+        fuse.mount(foreground=False)
+
+    assert create.call_args.kwargs["api_key"] == ""
+
+
+def test_remote_connect_persists_passthrough_credentials(monkeypatch):
+    import nexus
+
+    cfg = SimpleNamespace(
+        profile="remote",
+        url="http://configured.example:2026",
+        api_key="sk-config",
+        timeout=30,
+        connect_timeout=5,
+    )
+    monkeypatch.setenv("NEXUS_GRPC_TLS", "false")
+    monkeypatch.setattr("nexus.config.load_config", lambda _config: cfg)
+    monkeypatch.setattr(nexus, "_open_local_kernel", lambda _path: MagicMock())
+
+    class FakeTransport:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.call_rpc = MagicMock()
+
+    class FakeNexusFS:
+        def __init__(self, **kwargs):
+            self.kwargs = kwargs
+            self.setattr_calls = []
+            self.closeables = []
+
+        def sys_setattr(self, *args, **kwargs):
+            self.setattr_calls.append((args, kwargs))
+
+        def _register_runtime_closeable(self, closeable):
+            self.closeables.append(closeable)
+
+    monkeypatch.setitem(
+        sys.modules,
+        "nexus.remote.rpc_transport",
+        types.SimpleNamespace(RPCTransport=FakeTransport),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "nexus.contracts.metadata",
+        types.SimpleNamespace(DT_MOUNT="mount"),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "nexus.contracts.types",
+        types.SimpleNamespace(OperationContext=lambda **kwargs: kwargs),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "nexus.core.config",
+        types.SimpleNamespace(PermissionConfig=lambda **kwargs: kwargs),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "nexus.core.nexus_fs",
+        types.SimpleNamespace(NexusFS=FakeNexusFS),
+    )
+    monkeypatch.setitem(
+        sys.modules,
+        "nexus.factory._remote",
+        types.SimpleNamespace(
+            _boot_remote_services=lambda *args, **kwargs: None,
+            install_remote_kernel_rpc_overrides=lambda *args, **kwargs: None,
+        ),
+    )
+
+    nfs = nexus.connect(config={"profile": "remote"})
+
+    assert nfs._remote_base_url == "http://configured.example:2026"
+    assert nfs._remote_api_key == "sk-config"
+
+
+def test_nexus_fuse_falls_back_when_passthrough_not_safe(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr("nexus.fuse.passthrough.platform.system", lambda: "Darwin")
+    fs = MagicMock()
+    fs._base_url = "http://localhost:2026"
+    fs._api_key = "sk-test"
+    mount_point = tmp_path / "mnt"
+    mount_point.mkdir()
+
+    with patch("nexus.fuse.mount.FUSE") as fuse_cls:
+        fuse = NexusFUSE(
+            fs,
+            str(mount_point),
+            mode=MountMode.BINARY,
+            use_rust=True,
+            passthrough_enabled=True,
+        )
+        fuse.mount(foreground=True)
+
+    fuse_cls.assert_called_once()
+
+
+def test_nexus_fuse_passthrough_require_raises_when_unsafe(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr("nexus.fuse.passthrough.platform.system", lambda: "Darwin")
+    fs = MagicMock()
+    fs._base_url = "http://localhost:2026"
+    fs._api_key = "sk-test"
+    mount_point = tmp_path / "mnt"
+    mount_point.mkdir()
+
+    fuse = NexusFUSE(
+        fs,
+        str(mount_point),
+        mode=MountMode.BINARY,
+        use_rust=True,
+        passthrough_enabled=True,
+        passthrough_require=True,
+    )
+
+    with pytest.raises(RuntimeError, match="passthrough is not safe"):
+        fuse.mount(foreground=False)
+
+
+def test_nexus_fuse_passthrough_require_raises_for_local_fs(tmp_path: Path):
+    fs = SimpleNamespace()
+    mount_point = tmp_path / "mnt"
+    mount_point.mkdir()
+
+    fuse = NexusFUSE(
+        fs,
+        str(mount_point),
+        mode=MountMode.BINARY,
+        use_rust=True,
+        passthrough_enabled=True,
+        passthrough_require=True,
+    )
+
+    with pytest.raises(RuntimeError, match="requires a remote NexusFS"):
+        fuse.mount(foreground=False)
+
+
+def test_mount_nexus_threads_passthrough_args_to_nexus_fuse(tmp_path: Path):
+    fs = MagicMock()
+    mount_point = tmp_path / "mnt"
+    backing_dir = tmp_path / "backing"
+
+    with patch("nexus.fuse.mount.NexusFUSE") as fuse_cls:
+        mount_nexus(
+            fs,
+            str(mount_point),
+            mode="binary",
+            foreground=False,
+            passthrough_enabled=True,
+            passthrough_patterns=["/data/**"],
+            passthrough_deny_patterns=["/data/private/**"],
+            passthrough_threshold_bytes=4096,
+            passthrough_require=True,
+            passthrough_backing_dir=backing_dir,
+        )
+
+    fuse_cls.assert_called_once()
+    assert fuse_cls.call_args.kwargs["passthrough_enabled"] is True
+    assert fuse_cls.call_args.kwargs["passthrough_patterns"] == ["/data/**"]
+    assert fuse_cls.call_args.kwargs["passthrough_deny_patterns"] == ["/data/private/**"]
+    assert fuse_cls.call_args.kwargs["passthrough_threshold_bytes"] == 4096
+    assert fuse_cls.call_args.kwargs["passthrough_require"] is True
+    assert fuse_cls.call_args.kwargs["passthrough_backing_dir"] == backing_dir
+    fuse_cls.return_value.mount.assert_called_once_with(
+        foreground=False, allow_other=False, debug=False
+    )
+
+
+def test_nexus_fuse_uses_env_passthrough_threshold_when_not_overridden(monkeypatch):
+    monkeypatch.setenv("NEXUS_FUSE_PASSTHROUGH_THRESHOLD_BYTES", "262144")
+
+    fuse = NexusFUSE(MagicMock(), "/mnt", mode=MountMode.BINARY)
+
+    assert fuse._passthrough_options.threshold_bytes == 262144
+
+
+def test_unmount_stops_rust_passthrough_launcher_on_success(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    run = MagicMock()
+    monkeypatch.setattr("subprocess.run", run)
+    fs = MagicMock()
+    fuse = NexusFUSE(fs, str(tmp_path), mode=MountMode.BINARY)
+    launcher = MagicMock()
+    fuse._rust_passthrough_mount = launcher
+    fuse._mounted = True
+
+    fuse.unmount()
+
+    run.assert_called_once()
+    launcher.stop.assert_called_once_with()
+    assert fuse._rust_passthrough_mount is None
+
+
+def test_unmount_retains_rust_passthrough_launcher_when_stop_fails(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+    monkeypatch.setattr("subprocess.run", MagicMock())
+    fs = MagicMock()
+    fuse = NexusFUSE(fs, str(tmp_path), mode=MountMode.BINARY)
+    launcher = MagicMock()
+    launcher.stop.side_effect = RuntimeError("stop failed")
+    fuse._rust_passthrough_mount = launcher
+    fuse._mounted = True
+
+    with pytest.raises(RuntimeError, match="stop failed"):
+        fuse.unmount()
+
+    launcher.stop.assert_called_once_with()
+    assert fuse._rust_passthrough_mount is launcher
+
+    launcher.stop.side_effect = None
+    fuse.unmount()
+
+    assert launcher.stop.call_count == 2
+    assert fuse._rust_passthrough_mount is None
+
+
+def test_unmount_stops_rust_passthrough_launcher_on_platform_failure(tmp_path: Path, monkeypatch):
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+
+    def fail_unmount(*args, **kwargs):
+        raise subprocess.CalledProcessError(
+            returncode=1,
+            cmd=args[0],
+            stderr=b"busy",
+        )
+
+    monkeypatch.setattr("subprocess.run", fail_unmount)
+    fs = MagicMock()
+    fuse = NexusFUSE(fs, str(tmp_path), mode=MountMode.BINARY)
+    launcher = MagicMock()
+    fuse._rust_passthrough_mount = launcher
+    fuse._mounted = True
+
+    with pytest.raises(RuntimeError, match="busy"):
+        fuse.unmount()
+
+    launcher.stop.assert_called_once_with()
+    assert fuse._rust_passthrough_mount is None
+
+
+def test_unmount_retains_rust_passthrough_launcher_when_platform_and_stop_fail(
+    tmp_path: Path, monkeypatch
+):
+    monkeypatch.setattr("platform.system", lambda: "Linux")
+
+    def fail_unmount(*args, **kwargs):
+        raise subprocess.CalledProcessError(
+            returncode=1,
+            cmd=args[0],
+            stderr=b"busy",
+        )
+
+    monkeypatch.setattr("subprocess.run", fail_unmount)
+    fs = MagicMock()
+    fuse = NexusFUSE(fs, str(tmp_path), mode=MountMode.BINARY)
+    launcher = MagicMock()
+    launcher.stop.side_effect = RuntimeError("stop failed")
+    fuse._rust_passthrough_mount = launcher
+    fuse._mounted = True
+
+    with pytest.raises(RuntimeError, match="busy"):
+        fuse.unmount()
+
+    launcher.stop.assert_called_once_with()
+    assert fuse._rust_passthrough_mount is launcher


### PR DESCRIPTION
Refs #4060

## Summary

- Adds an opt-in Linux FUSE passthrough path in `nexus-fuse` using fuser 0.17 negotiation, pattern/threshold policy, immutable backing-file materialization, active handle tracking, and mutation invalidation.
- Wires Rust CLI/env flags for passthrough, require-mode fallback behavior, deny patterns, thresholds, and backing directory selection.
- Adds Python `NexusFUSE(..., use_rust=True)` passthrough orchestration that launches the Rust-owned mount only when credentials and hook-safety checks allow it, otherwise falling back to the existing Python/Rust daemon path.
- Documents usage and adds an opt-in 1 GiB sequential read benchmark harness. Local macOS verification cannot measure Linux passthrough throughput; the PR records the exact Linux command/harness to run on a Linux 6.9+ host.

## Validation

- `cargo check --lib --bin nexus-fuse`
- `cargo test --lib` (117 passed)
- `cargo test --bin nexus-fuse` (10 passed)
- `cargo test --test passthrough_integration` (0 tests on non-Linux target; Linux-gated test binary built and ran)
- `cargo bench --bench passthrough_read -- --sample-size 10` (opt-in skip path exited 0 without `NEXUS_FUSE_PASSTHROUGH_BENCH_FILE`)
- `rustfmt --check src/fs.rs src/main.rs src/passthrough/backing.rs src/passthrough/config.rs src/passthrough/manager.rs src/passthrough/mod.rs src/passthrough/policy.rs tests/passthrough_integration.rs benches/passthrough_read.rs`
- `.venv/bin/ruff check src/nexus/fuse/passthrough.py src/nexus/fuse/mount.py tests/unit/fuse/test_passthrough_options.py src/nexus/__init__.py`
- `.venv/bin/python -m pytest -o addopts='' tests/unit/fuse/test_passthrough_options.py tests/unit/fuse/test_rust_available_guard.py tests/unit/fuse/test_rust_fallback.py tests/unit/fuse/test_io_handler.py -q` (57 passed)
- pre-commit on commit: passed

## Follow-up Needed Before Merge

- Run the documented 1 GiB sequential read benchmark on a Linux 6.9+ host with FUSE passthrough enabled and paste the measured throughput into `nexus-fuse/PERFORMANCE_RESULTS.md` or the PR thread.