### PR TITLE
[codex] Add per-zone runner isolation

### DIFF
--- a/docs/architecture/zone-runner.md
+++ b/docs/architecture/zone-runner.md
@@ -1,0 +1,73 @@
+# Zone Runner Runtime Isolation
+
+Nexus uses one `ZoneRunner` per active zone inside a Python server process. A
+runner owns an OS thread and an asyncio event loop. Zone-scoped server work is
+submitted to the target zone runner so a slow operation in one zone does not
+park the FastAPI request loop or another zone's loop.
+
+## What Runs On A Zone Runner
+
+Auth, request parsing, and response encoding stay on the FastAPI loop. The
+zone-scoped unit of work runs on the target runner:
+
+- HTTP RPC dispatch
+- gRPC `Call` dispatch
+- direct v2 file, batch, search, connector, event, snapshot, upload, secret,
+  credential, password-vault, and workspace operations that carry a concrete
+  zone
+- background work that already carries a concrete `zone_id`
+
+Root or admin operations without a concrete target zone stay on their current
+loop.
+
+## Target Zone Resolution
+
+The server selects a runner from the first concrete target it can find:
+
+1. explicit `zone`, `zone_id`, or `target_zone_id`
+2. embedded `/zone/<id>/...` path
+3. non-root `OperationContext.zone_id`
+4. no runner for root/global work
+
+Permission checks remain separate. Existing `zone_perms`, ReBAC, and router
+guards still decide whether the caller may access the zone.
+
+## Coroutine Factories
+
+`ZoneRunner.call()` accepts `Callable[[], Awaitable[T]]` rather than an already
+created coroutine. The factory is invoked on the zone loop. This avoids binding
+coroutines, futures, async generators, or async clients to the caller's loop.
+
+## Cross-Zone Discipline
+
+Start work on the caller's zone runner. When work must call another zone,
+explicitly await that zone:
+
+```python
+result = await zone_registry.runner_for(other_zone).call(lambda: do_other_zone_work())
+```
+
+Calling the same runner from inside its own loop executes inline. Calling
+`call_sync()` from inside the owning runner thread raises because it would
+deadlock the loop.
+
+## Limits
+
+Zone runners isolate event loops, not process memory or CPU. These remain shared:
+
+- Python process memory
+- Rust kernel state
+- database servers and pools
+- global singleton objects
+- CPU-bound Python running without its own thread or process offload
+
+Blocking network or filesystem clients still need backend timeouts. Runner
+isolation prevents a slow zone from parking other zone loops; it does not make
+an unbounded blocking call cancellable.
+
+## Shutdown
+
+FastAPI lifespan shutdown stops all zone runners before closing `NexusFS` and
+database engines. Each runner rejects new work, cancels pending asyncio tasks,
+runs `shutdown_asyncgens()`, closes its loop, and joins its thread with a
+bounded timeout.

--- a/docs/superpowers/specs/2026-05-12-issue-4084-zone-runner-design.md
+++ b/docs/superpowers/specs/2026-05-12-issue-4084-zone-runner-design.md
@@ -1,0 +1,347 @@
+# Issue #4084 - Per-Zone Runner Bulkhead Isolation
+
+**Date:** 2026-05-12
+**Issue:** [#4084](https://github.com/nexi-lab/nexus/issues/4084)
+**Scope:** Full issue in one implementation plan
+
+## 1. Context
+
+Nexus already carries zone identity through the server stack with
+`OperationContext.zone_id`, `zone_set`, and `zone_perms`. Multi-zone auth,
+zone-scoped paths, and per-zone permission gates exist. The missing piece is
+runtime isolation inside one Python server process: FastAPI request handlers,
+gRPC `Call`, direct REST v2 handlers, search services, connector calls, and
+kernel syscall wrappers can still share the same server event loop.
+
+The issue proposes a per-zone runner: one OS thread and one asyncio event loop
+per active zone. Zone-scoped work runs on that zone's loop. A slow or wedged
+operation for zone A should not park zone B's loop or the server's main request
+loop.
+
+The codebase layout differs from the issue sketch:
+
+- Server entrypoints live under `src/nexus/server/`, not top-level `server/`.
+- Runtime/factory wiring lives under `src/nexus/factory/` and
+  `src/nexus/server/lifespan/`.
+- The strongest dispatch seams are `server/api/core/rpc.py`,
+  `server/rpc/dispatch.py`, `grpc/servicer.py`, and selected direct v2 REST
+  routers.
+
+## 2. Goals
+
+- Add `ZoneRunner` with `start`, `call`, `call_sync`, and idempotent `stop`.
+- Add `ZoneRegistry` that owns one runner per active zone and can stop all
+  runners.
+- Route existing zone-scoped server paths through the target zone runner,
+  including deprecated HTTP RPC, gRPC `Call`, kernel syscall dispatch, direct
+  REST v2 surfaces, and daemon/background work that carries a concrete
+  `zone_id`.
+- Keep the FastAPI main loop focused on auth, parsing, response encoding, and
+  non-zone-scoped orchestration.
+- Prove with a stress test that a slow zone A operation does not affect zone B
+  median latency.
+- Drain/stop all runners during FastAPI shutdown.
+- Document cross-zone call discipline.
+
+## 3. Non-Goals
+
+- Process-level tenant isolation. This design stays in one Python process.
+- Duplicating `NexusFS` or rebuilding the full service graph per zone.
+- Changing token, ReBAC, or `zone_perms` semantics.
+- Solving blocking CPU-bound Python code. Blocking work still needs explicit
+  thread/process offload inside the zone runner.
+- Making every admin/root operation zone-bound. Root/admin operations without a
+  concrete target zone remain on the main loop unless they operate on a
+  zone-scoped path or explicit zone.
+
+## 4. Architecture
+
+### 4.1 Runtime Module
+
+Create `src/nexus/runtime/zone_runner.py`.
+
+`ZoneRunner` owns:
+
+- `zone_id: str`
+- one daemon OS thread named `nexus-zone-{zone_id}`
+- one asyncio event loop created and run on that thread
+- lifecycle state guarded by a `threading.RLock`
+- a thread-local marker so code can detect when it is already running on the
+  same runner
+
+Public API:
+
+```python
+class ZoneRunner:
+    def __init__(self, zone_id: str): ...
+    def start(self) -> None: ...
+    async def call(self, work: Callable[[], Awaitable[T]]) -> T: ...
+    def call_sync(self, work: Callable[[], Awaitable[T]]) -> T: ...
+    def stop(self) -> None: ...
+```
+
+`call` accepts an awaitable factory, not an already-created coroutine. The
+factory is invoked on the zone loop, which prevents accidental binding of
+coroutines, async generators, clients, or futures to the caller's event loop.
+
+`call_sync` is for synchronous callers outside the owning zone thread. It
+raises a clear `RuntimeError` if called from the owning runner thread, because
+blocking that thread would deadlock the zone loop.
+
+`ZoneRegistry` owns runners:
+
+```python
+class ZoneRegistry:
+    def runner_for(self, zone_id: str) -> ZoneRunner: ...
+    def all(self) -> tuple[ZoneRunner, ...]: ...
+    def stop_all(self) -> None: ...
+```
+
+Runner creation is lazy for the first full implementation: an active zone is a
+zone that receives work in this process. Existing zone discovery can warm known
+zones later, but lazy creation avoids boot-time database coupling and keeps
+root/startup paths simple.
+
+### 4.2 Target Zone Resolution
+
+Add `src/nexus/runtime/zone_resolution.py` with small pure helpers:
+
+- `zone_from_path(value: str) -> str | None`
+- `zone_from_params(params: Any) -> str | None`
+- `target_zone_for_context(context: OperationContext, params: Any | None) -> str | None`
+
+Resolution order:
+
+1. Explicit zone argument or attribute (`zone`, `zone_id`, `target_zone_id`) if
+   present and non-root.
+2. Embedded `/zone/<id>/...` prefix in common path fields (`path`, `src`,
+   `dst`, `old_path`, `new_path`, `files`, batch entries).
+3. `context.zone_id` when it is not `root`.
+4. `None` for root/admin/global operations with no concrete zone.
+
+The resolver does not replace permission checks. Existing gates still decide
+whether the request may target a zone. The resolver only selects the runner.
+
+### 4.3 FastAPI State And Lifespan
+
+Add `zone_registry` to `NexusAppState` and `LifespanServices`.
+
+During `create_app`, initialize:
+
+```python
+app.state.zone_registry = ZoneRegistry()
+```
+
+During shutdown, call `app.state.zone_registry.stop_all()` before `NexusFS`
+engine disposal and close. Shutdown order matters: active zone loops may still
+be holding async generators or service tasks, so runners must stop before the
+kernel/services are torn down.
+
+### 4.4 RPC And gRPC Dispatch
+
+HTTP RPC:
+
+- In `server/api/core/rpc.py`, after auth and zone scoping, resolve the target
+  zone from the scoped params and context.
+- If no concrete zone is found, keep current behavior.
+- If a zone is found, run the actual dispatch through
+  `zone_registry.runner_for(zone).call(lambda: dispatch...)`.
+- Apply this to both kernel syscall dispatch and `dispatch_method`.
+
+gRPC `Call`:
+
+- In `grpc/servicer.py`, `VFSCallDispatcher._dispatch_async` resolves the target
+  zone after params are decoded and scoped.
+- `dispatch_call_sync` already bridges Rust to the FastAPI loop. The FastAPI
+  loop should then hop to the target zone runner for the zone-scoped dispatch.
+- Static-key/auth behavior remains unchanged.
+
+The generic dispatch layer (`server/rpc/dispatch.py`) stays mostly unchanged.
+It remains the dispatcher used inside whichever loop owns the work.
+
+### 4.5 Direct REST v2 Surfaces
+
+Several v2 routers bypass JSON-RPC and call services directly. Full issue scope
+requires explicit runner coverage for zone-scoped endpoints. The implementation
+must audit the following surfaces and wrap every endpoint in those files that
+performs concrete zone work:
+
+- `server/api/v2/routers/async_files.py`: read, write, delete, exists, list,
+  mkdir, metadata, stream, rename, copy, batch read/write, glob, grep.
+- `server/api/v2/routers/batch.py`: batch filesystem operations.
+- `server/api/v2/routers/search.py` and `mobile_search.py`: zone-scoped search
+  and federated search calls.
+- `server/api/v2/routers/connectors.py`: connector mount and connector file
+  operations that carry `zone_id`.
+- `server/api/v2/routers/subscriptions.py` and `events_replay.py`: zone-scoped
+  subscription/event replay reads.
+- `server/api/v2/routers/snapshots.py` and `tus_uploads.py`: snapshot/upload
+  operations tied to a zone.
+- `server/api/v2/routers/secrets.py`, `password_vault.py`, `credentials.py`,
+  and `workspace.py`: zone-scoped service operations where the router derives
+  an `OperationContext` or `zone_id`.
+
+Use a helper such as:
+
+```python
+async def run_zone_scoped(request: Request, zone_id: str | None, work: Callable[[], Awaitable[T]]) -> T:
+    registry = getattr(request.app.state, "zone_registry", None)
+    if registry is None or zone_id is None:
+        return await work()
+    return await registry.runner_for(zone_id).call(work)
+```
+
+This keeps router changes mechanical and preserves existing permission logic.
+
+### 4.6 Same-Runner Reentry
+
+If code already running on zone A calls `runner_for("zone-a").call(...)`, execute
+the factory directly on the current loop. This prevents self-deadlock and keeps
+cross-service calls within the same zone cheap.
+
+If code running on zone A calls zone B, it submits to zone B and awaits that
+future. The documented rule is:
+
+> Start on the caller's zone runner. For cross-zone work, explicitly await the
+> target zone via `ZoneRegistry.runner_for(other_zone).call(...)`.
+
+### 4.7 Failure And Cancellation
+
+- Exceptions raised inside a zone loop propagate to the caller.
+- If the caller task is cancelled, cancel the submitted concurrent future when
+  possible.
+- Stopping a runner rejects new work and cancels/drains pending tasks.
+- Loop shutdown runs `shutdown_asyncgens()` before closing the event loop.
+- Thread join has a bounded timeout and logs if a runner fails to terminate.
+
+The first implementation should not hide exceptions behind wrapper-specific
+types. Existing HTTP/gRPC error mapping should continue to see the original
+exception classes.
+
+### 4.8 Daemon And Background Work
+
+Daemon-managed zone work should use the same registry rather than spawning a
+separate isolation mechanism. Any background consumer, scheduler task, search
+daemon operation, upload cleanup, cache warmup, or connector sync that carries a
+concrete `zone_id` should submit its zone-scoped service call through
+`ZoneRegistry.runner_for(zone_id).call(...)`.
+
+Background work without a concrete zone stays on its existing loop. If the work
+later discovers a target zone from a path or database row, only the discovered
+zone-scoped unit should hop to the runner.
+
+## 5. Testing Strategy
+
+Use TDD for implementation.
+
+### 5.1 Runtime Unit Tests
+
+Create `tests/unit/runtime/test_zone_runner.py`.
+
+Coverage:
+
+- `ZoneRunner.call()` runs work on a different thread and a different loop from
+  the caller.
+- `ZoneRunner.call_sync()` works from synchronous code.
+- Exceptions propagate.
+- `stop()` is idempotent.
+- Calling the same runner from within its own loop executes without deadlock.
+- `call_sync()` from the owning runner thread raises.
+
+Create `tests/unit/runtime/test_zone_registry.py`.
+
+Coverage:
+
+- repeated `runner_for("a")` returns the same runner.
+- different zones get different runners.
+- `all()` returns created runners.
+- `stop_all()` stops every runner and is idempotent.
+
+### 5.2 Dispatch Tests
+
+Add focused tests around the seams rather than full server e2e for every method:
+
+- HTTP RPC kernel syscall uses the target zone runner.
+- HTTP RPC `dispatch_method` uses the target zone runner.
+- gRPC `Call` uses the target zone runner.
+- root/global RPC with no concrete target zone does not create a runner.
+
+Use a fake registry/runner in `app.state.zone_registry` to record calls without
+spawning real threads in all dispatch tests.
+
+### 5.3 REST Router Tests
+
+Add representative tests that prove direct routers do not bypass the runner:
+
+- async files read/write/list
+- batch read/write
+- search
+- connector zone operation
+- subscription or event replay read
+- snapshot or upload zone operation
+
+The goal is not one test per endpoint. The goal is coverage for each direct
+router pattern.
+
+### 5.4 Stress Test
+
+Add `tests/integration/server/test_zone_runner_bulkhead.py`.
+
+Scenario:
+
+- install a test-only route or use a fake service method that sleeps for 10s
+  inside zone A's runner.
+- concurrently issue repeated fast calls for zone B.
+- assert zone B median latency remains low while zone A is sleeping.
+
+Keep this test deterministic by using local sleeps and in-process ASGI clients,
+not real Slack/GitHub/network calls.
+
+### 5.5 Shutdown Test
+
+Add a lifespan test that starts work on two zones, exits the app lifespan, and
+asserts all runners are stopped and their threads are no longer alive.
+
+## 6. Documentation
+
+Add `docs/architecture/zone-runner.md`.
+
+Contents:
+
+- Why runners exist and what they isolate.
+- How target zones are resolved.
+- Cross-zone discipline.
+- Why coroutine factories are required.
+- What is not isolated: CPU-bound Python, process memory, global singleton
+  state, shared database pools, and shared Rust kernel state.
+- Shutdown behavior and operational considerations for many zones.
+
+## 7. Risks And Mitigations
+
+- **Loop-bound objects captured too early.** Mitigation: `ZoneRunner.call`
+  accepts a factory and invokes it on the zone loop.
+- **Hidden one-loop assumptions.** Mitigation: route through dispatch seams
+  first, add direct REST coverage, and document any later audit findings.
+- **Deadlock from sync calls on the owning runner.** Mitigation: detect owning
+  runner thread and raise from `call_sync`.
+- **Memory growth with many zones.** Mitigation: lazy runner creation first;
+  later add idle eviction or caps if measurements require it.
+- **Database/driver loop affinity.** Mitigation: keep existing session factory
+  patterns; do not share async sessions across loops. Router code should create
+  async work inside the target runner.
+- **Cancellation semantics.** Mitigation: caller cancellation cancels the
+  submitted future, but blocking sync code running inside the zone remains
+  bounded only by existing backend timeouts.
+
+## 8. Acceptance Criteria Mapping
+
+- `ZoneRunner` with `start`/`call`/`call_sync`/`stop`: runtime unit tests.
+- `ZoneRegistry` instantiates one runner per active zone touched in the
+  process: registry unit tests and lifespan wiring.
+- All existing zone-scoped server paths route through `runner.call(...)`:
+  dispatch tests, direct REST router tests, and daemon/background tests for
+  zone-carrying work.
+- Stress test: zone A slow op does not affect zone B median latency:
+  `test_zone_runner_bulkhead.py`.
+- Shutdown drains all runners cleanly: lifespan shutdown test.
+- Doc on cross-zone call discipline: `docs/architecture/zone-runner.md`.

--- a/nexus-stack.yml
+++ b/nexus-stack.yml
@@ -141,6 +141,8 @@ services:
       NEXUS_TOKEN_EXCHANGE_ENABLED: ${NEXUS_TOKEN_EXCHANGE_ENABLED:-}
       # Config
       NEXUS_CONFIG_FILE: ${NEXUS_CONFIG_FILE:-/app/configs/config.demo.yaml}
+      # Disabled-by-default admin-only test hooks for live E2E verification.
+      NEXUS_TEST_HOOKS: ${NEXUS_TEST_HOOKS:-false}
       # Cache
       NEXUS_DRAGONFLY_URL: ${NEXUS_DRAGONFLY_URL:-redis://dragonfly:6379}
       NEXUS_CACHE_EMBEDDING_TTL: ${NEXUS_CACHE_EMBEDDING_TTL:-86400}

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -1511,7 +1511,7 @@ class SearchDaemon:
                 zone_id=zone_id,
             )
 
-        return await run_zone_scoped(self._zone_registry, zone_id, _work)
+        return await run_zone_scoped(getattr(self, "_zone_registry", None), zone_id, _work)
 
     async def _search_on_current_loop(
         self,
@@ -1851,7 +1851,7 @@ class SearchDaemon:
         async def _work() -> list[list[Any]]:
             return await self._batch_search_on_current_loop(queries, zone_id=zone_id)
 
-        return await run_zone_scoped(self._zone_registry, zone_id, _work)
+        return await run_zone_scoped(getattr(self, "_zone_registry", None), zone_id, _work)
 
     async def _batch_search_on_current_loop(
         self,
@@ -1965,7 +1965,7 @@ class SearchDaemon:
         async def _work() -> int:
             return await self._index_documents_on_current_loop(documents, zone_id=zone_id)
 
-        return await run_zone_scoped(self._zone_registry, zone_id, _work)
+        return await run_zone_scoped(getattr(self, "_zone_registry", None), zone_id, _work)
 
     async def _index_documents_on_current_loop(
         self,

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -54,6 +54,7 @@ from nexus.bricks.search.mutation_resolver import MutationResolver, ResolvedMuta
 from nexus.bricks.search.results import BaseSearchResult
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.lib.env import get_database_url
+from nexus.server.zone_execution import run_zone_scoped
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncEngine
@@ -208,6 +209,7 @@ class SearchDaemon:
         settings_store: Any | None = None,
         path_context_cache: "PathContextCache | None" = None,
         sqlite_vec_backend: Any | None = None,
+        zone_registry: Any | None = None,
     ):
         """Initialize the search daemon.
 
@@ -229,6 +231,7 @@ class SearchDaemon:
         self._cache_brick = cache_brick
         self._settings_store = settings_store
         self._path_context_cache = path_context_cache
+        self._zone_registry = zone_registry
         # Codex review R6 (high): SANDBOX local sqlite-vec backend so
         # daemon-driven indexing (mutation events → IndexingPipeline)
         # populates the hybrid vector lane. Without this, only the
@@ -541,6 +544,15 @@ class SearchDaemon:
 
         Returns ``(canonical_path, BackfillResult)``.
         """
+
+        async def _work() -> Any:
+            return await self._add_indexed_directory_on_current_loop(zone_id, directory_path)
+
+        return await run_zone_scoped(self._zone_registry, zone_id, _work)
+
+    async def _add_indexed_directory_on_current_loop(
+        self, zone_id: str, directory_path: str
+    ) -> Any:
         from nexus.bricks.search import scope_ops
 
         return await scope_ops.add_indexed_directory(self, zone_id, directory_path)
@@ -551,12 +563,30 @@ class SearchDaemon:
         Used by the registration recovery path so an operator who hit a
         backfill failure can retry without unregister + re-register.
         """
+
+        async def _work() -> Any:
+            return await self._rerun_backfill_for_directory_on_current_loop(zone_id, directory_path)
+
+        return await run_zone_scoped(self._zone_registry, zone_id, _work)
+
+    async def _rerun_backfill_for_directory_on_current_loop(
+        self, zone_id: str, directory_path: str
+    ) -> Any:
         from nexus.bricks.search import scope_ops
 
         return await scope_ops.rerun_backfill_for_directory(self, zone_id, directory_path)
 
     async def remove_indexed_directory(self, zone_id: str, directory_path: str) -> str:
         """Unregister ``directory_path`` from scoped indexing. See scope_ops."""
+
+        async def _work() -> str:
+            return await self._remove_indexed_directory_on_current_loop(zone_id, directory_path)
+
+        return await run_zone_scoped(self._zone_registry, zone_id, _work)
+
+    async def _remove_indexed_directory_on_current_loop(
+        self, zone_id: str, directory_path: str
+    ) -> str:
         from nexus.bricks.search import scope_ops
 
         return await scope_ops.remove_indexed_directory(self, zone_id, directory_path)
@@ -569,6 +599,17 @@ class SearchDaemon:
 
     async def purge_unscoped_embeddings(self, zone_id: str | None = None) -> dict[str, int]:
         """Delete stored embeddings for out-of-scope files. See scope_ops."""
+        if zone_id is None:
+            return await self._purge_unscoped_embeddings_on_current_loop(zone_id)
+
+        async def _work() -> dict[str, int]:
+            return await self._purge_unscoped_embeddings_on_current_loop(zone_id)
+
+        return await run_zone_scoped(self._zone_registry, zone_id, _work)
+
+    async def _purge_unscoped_embeddings_on_current_loop(
+        self, zone_id: str | None = None
+    ) -> dict[str, int]:
         from nexus.bricks.search import scope_ops
 
         return await scope_ops.purge_unscoped_embeddings(self, zone_id)
@@ -1466,6 +1507,40 @@ class SearchDaemon:
         fusion_method: str = "rrf",
         zone_id: str | None = None,
     ) -> list[SearchResult]:
+        if zone_id is None:
+            return await self._search_on_current_loop(
+                query,
+                search_type=search_type,
+                limit=limit,
+                path_filter=path_filter,
+                alpha=alpha,
+                fusion_method=fusion_method,
+                zone_id=zone_id,
+            )
+
+        async def _work() -> list[SearchResult]:
+            return await self._search_on_current_loop(
+                query,
+                search_type=search_type,
+                limit=limit,
+                path_filter=path_filter,
+                alpha=alpha,
+                fusion_method=fusion_method,
+                zone_id=zone_id,
+            )
+
+        return await run_zone_scoped(self._zone_registry, zone_id, _work)
+
+    async def _search_on_current_loop(
+        self,
+        query: str,
+        search_type: Literal["keyword", "semantic", "hybrid"] = "hybrid",
+        limit: int = 10,
+        path_filter: str | None = None,
+        alpha: float = 0.5,
+        fusion_method: str = "rrf",
+        zone_id: str | None = None,
+    ) -> list[SearchResult]:
         """Execute a search query with pre-warmed indexes.
 
         Args:
@@ -1788,6 +1863,20 @@ class SearchDaemon:
         *,
         zone_id: str | None = None,
     ) -> list[list[Any]]:
+        if zone_id is None:
+            return await self._batch_search_on_current_loop(queries, zone_id=zone_id)
+
+        async def _work() -> list[list[Any]]:
+            return await self._batch_search_on_current_loop(queries, zone_id=zone_id)
+
+        return await run_zone_scoped(self._zone_registry, zone_id, _work)
+
+    async def _batch_search_on_current_loop(
+        self,
+        queries: list[dict[str, Any]],
+        *,
+        zone_id: str | None = None,
+    ) -> list[list[Any]]:
         """Batch search: embed N queries in ONE API call.
 
         Powers ``POST /api/v2/search/query/batch`` for benchmarks and bulk
@@ -1883,6 +1972,20 @@ class SearchDaemon:
         return results
 
     async def index_documents(
+        self,
+        documents: list[dict[str, Any]],
+        *,
+        zone_id: str | None = None,
+    ) -> int:
+        if zone_id is None:
+            return await self._index_documents_on_current_loop(documents, zone_id=zone_id)
+
+        async def _work() -> int:
+            return await self._index_documents_on_current_loop(documents, zone_id=zone_id)
+
+        return await run_zone_scoped(self._zone_registry, zone_id, _work)
+
+    async def _index_documents_on_current_loop(
         self,
         documents: list[dict[str, Any]],
         *,

--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -544,11 +544,7 @@ class SearchDaemon:
 
         Returns ``(canonical_path, BackfillResult)``.
         """
-
-        async def _work() -> Any:
-            return await self._add_indexed_directory_on_current_loop(zone_id, directory_path)
-
-        return await run_zone_scoped(self._zone_registry, zone_id, _work)
+        return await self._add_indexed_directory_on_current_loop(zone_id, directory_path)
 
     async def _add_indexed_directory_on_current_loop(
         self, zone_id: str, directory_path: str
@@ -563,11 +559,7 @@ class SearchDaemon:
         Used by the registration recovery path so an operator who hit a
         backfill failure can retry without unregister + re-register.
         """
-
-        async def _work() -> Any:
-            return await self._rerun_backfill_for_directory_on_current_loop(zone_id, directory_path)
-
-        return await run_zone_scoped(self._zone_registry, zone_id, _work)
+        return await self._rerun_backfill_for_directory_on_current_loop(zone_id, directory_path)
 
     async def _rerun_backfill_for_directory_on_current_loop(
         self, zone_id: str, directory_path: str
@@ -578,11 +570,7 @@ class SearchDaemon:
 
     async def remove_indexed_directory(self, zone_id: str, directory_path: str) -> str:
         """Unregister ``directory_path`` from scoped indexing. See scope_ops."""
-
-        async def _work() -> str:
-            return await self._remove_indexed_directory_on_current_loop(zone_id, directory_path)
-
-        return await run_zone_scoped(self._zone_registry, zone_id, _work)
+        return await self._remove_indexed_directory_on_current_loop(zone_id, directory_path)
 
     async def _remove_indexed_directory_on_current_loop(
         self, zone_id: str, directory_path: str
@@ -599,13 +587,7 @@ class SearchDaemon:
 
     async def purge_unscoped_embeddings(self, zone_id: str | None = None) -> dict[str, int]:
         """Delete stored embeddings for out-of-scope files. See scope_ops."""
-        if zone_id is None:
-            return await self._purge_unscoped_embeddings_on_current_loop(zone_id)
-
-        async def _work() -> dict[str, int]:
-            return await self._purge_unscoped_embeddings_on_current_loop(zone_id)
-
-        return await run_zone_scoped(self._zone_registry, zone_id, _work)
+        return await self._purge_unscoped_embeddings_on_current_loop(zone_id)
 
     async def _purge_unscoped_embeddings_on_current_loop(
         self, zone_id: str | None = None

--- a/src/nexus/core/test_hooks.py
+++ b/src/nexus/core/test_hooks.py
@@ -1,82 +1,10 @@
-"""Disabled-by-default runtime hooks for end-to-end stack verification.
-
-These routes are registered only when ``NEXUS_TEST_HOOKS=true``. They are
-still admin-gated because test stacks often run on shared developer machines.
-"""
+"""Core marker for disabled-by-default end-to-end test hooks."""
 
 from __future__ import annotations
 
-import asyncio
-import threading
-import time
 from typing import Any
-
-from fastapi import APIRouter, Depends, HTTPException, Query, Request
-
-from nexus.server.dependencies import require_admin
-from nexus.server.zone_execution import run_zone_scoped
 
 
 def register_test_hooks(nx: Any) -> None:
     """Mark the filesystem instance as having test hooks enabled."""
     nx._test_hooks_registered = True
-
-
-def build_test_hooks_router() -> APIRouter:
-    router = APIRouter(
-        prefix="/api/test-hooks",
-        tags=["test-hooks"],
-        dependencies=[Depends(require_admin)],
-    )
-
-    def _zone_registry(request: Request) -> Any:
-        registry = getattr(request.app.state, "zone_registry", None)
-        if registry is None:
-            raise HTTPException(status_code=503, detail="Zone registry is not initialized")
-        return registry
-
-    @router.get("/zone-runners")
-    async def list_zone_runners(request: Request) -> dict[str, Any]:
-        registry = _zone_registry(request)
-        return {
-            "runners": [
-                {"zone_id": runner.zone_id, "is_alive": runner.is_alive}
-                for runner in registry.all()
-            ],
-        }
-
-    @router.get("/zone-runners/{zone_id}/ping")
-    async def ping_zone_runner(request: Request, zone_id: str) -> dict[str, Any]:
-        registry = _zone_registry(request)
-
-        async def _work() -> dict[str, Any]:
-            return _runner_payload(zone_id, 0.0)
-
-        return await run_zone_scoped(registry, zone_id, _work)
-
-    @router.post("/zone-runners/{zone_id}/sleep")
-    async def sleep_zone_runner(
-        request: Request,
-        zone_id: str,
-        delay_ms: int = Query(default=100, ge=0, le=10_000),
-    ) -> dict[str, Any]:
-        registry = _zone_registry(request)
-
-        async def _work() -> dict[str, Any]:
-            start = time.perf_counter()
-            await asyncio.sleep(delay_ms / 1000)
-            return _runner_payload(zone_id, (time.perf_counter() - start) * 1000)
-
-        return await run_zone_scoped(registry, zone_id, _work)
-
-    return router
-
-
-def _runner_payload(zone_id: str, elapsed_ms: float) -> dict[str, Any]:
-    loop = asyncio.get_running_loop()
-    return {
-        "zone_id": zone_id,
-        "thread_name": threading.current_thread().name,
-        "loop_id": id(loop),
-        "elapsed_ms": elapsed_ms,
-    }

--- a/src/nexus/core/test_hooks.py
+++ b/src/nexus/core/test_hooks.py
@@ -1,0 +1,82 @@
+"""Disabled-by-default runtime hooks for end-to-end stack verification.
+
+These routes are registered only when ``NEXUS_TEST_HOOKS=true``. They are
+still admin-gated because test stacks often run on shared developer machines.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from nexus.server.dependencies import require_admin
+from nexus.server.zone_execution import run_zone_scoped
+
+
+def register_test_hooks(nx: Any) -> None:
+    """Mark the filesystem instance as having test hooks enabled."""
+    nx._test_hooks_registered = True
+
+
+def build_test_hooks_router() -> APIRouter:
+    router = APIRouter(
+        prefix="/api/test-hooks",
+        tags=["test-hooks"],
+        dependencies=[Depends(require_admin)],
+    )
+
+    def _zone_registry(request: Request) -> Any:
+        registry = getattr(request.app.state, "zone_registry", None)
+        if registry is None:
+            raise HTTPException(status_code=503, detail="Zone registry is not initialized")
+        return registry
+
+    @router.get("/zone-runners")
+    async def list_zone_runners(request: Request) -> dict[str, Any]:
+        registry = _zone_registry(request)
+        return {
+            "runners": [
+                {"zone_id": runner.zone_id, "is_alive": runner.is_alive}
+                for runner in registry.all()
+            ],
+        }
+
+    @router.get("/zone-runners/{zone_id}/ping")
+    async def ping_zone_runner(request: Request, zone_id: str) -> dict[str, Any]:
+        registry = _zone_registry(request)
+
+        async def _work() -> dict[str, Any]:
+            return _runner_payload(zone_id, 0.0)
+
+        return await run_zone_scoped(registry, zone_id, _work)
+
+    @router.post("/zone-runners/{zone_id}/sleep")
+    async def sleep_zone_runner(
+        request: Request,
+        zone_id: str,
+        delay_ms: int = Query(default=100, ge=0, le=10_000),
+    ) -> dict[str, Any]:
+        registry = _zone_registry(request)
+
+        async def _work() -> dict[str, Any]:
+            start = time.perf_counter()
+            await asyncio.sleep(delay_ms / 1000)
+            return _runner_payload(zone_id, (time.perf_counter() - start) * 1000)
+
+        return await run_zone_scoped(registry, zone_id, _work)
+
+    return router
+
+
+def _runner_payload(zone_id: str, elapsed_ms: float) -> dict[str, Any]:
+    loop = asyncio.get_running_loop()
+    return {
+        "zone_id": zone_id,
+        "thread_name": threading.current_thread().name,
+        "loop_id": id(loop),
+        "elapsed_ms": elapsed_ms,
+    }

--- a/src/nexus/grpc/server.py
+++ b/src/nexus/grpc/server.py
@@ -139,6 +139,7 @@ async def startup_grpc(app: "FastAPI", _svc: "LifespanServices") -> list[asyncio
         auth_provider=getattr(app.state, "auth_provider", None),
         api_key=api_key,
         subscription_manager=getattr(app.state, "subscription_manager", None),
+        zone_registry=getattr(app.state, "zone_registry", None),
         loop=asyncio.get_running_loop(),
     )
 

--- a/src/nexus/grpc/servicer.py
+++ b/src/nexus/grpc/servicer.py
@@ -47,7 +47,7 @@ from nexus.server._kernel_syscall_dispatch import (
     dispatch_kernel_syscall,
 )
 from nexus.server.protocol import parse_method_params
-from nexus.server.zone_execution import run_zone_scoped
+from nexus.server.zone_execution import context_for_target_zone, run_zone_scoped
 
 logger = logging.getLogger(__name__)
 
@@ -257,6 +257,7 @@ class VFSCallDispatcher:
                     op_context.zone_id if op_context else None,
                 )
                 target_zone = target_zone_for_context(op_context, params_dict)
+                op_context = context_for_target_zone(op_context, target_zone)
 
                 async def _work() -> Any:
                     return await dispatch_kernel_syscall(
@@ -301,6 +302,7 @@ class VFSCallDispatcher:
                 scope_params_for_zone(params, op_context.zone_id)
 
             target_zone = target_zone_for_context(op_context, params)
+            op_context = context_for_target_zone(op_context, target_zone)
 
             async def _work() -> Any:
                 return await dispatch_method(

--- a/src/nexus/grpc/servicer.py
+++ b/src/nexus/grpc/servicer.py
@@ -41,11 +41,13 @@ from nexus.contracts.exceptions import NexusError, NexusPermissionError
 from nexus.contracts.rpc_types import RPCErrorCode
 from nexus.lib.rpc_codec import decode_rpc_message, encode_rpc_message
 from nexus.lib.zone_scoping import ZoneScopingError, scope_params_for_zone
+from nexus.runtime.zone_resolution import target_zone_for_context
 from nexus.server._kernel_syscall_dispatch import (
     KERNEL_SYSCALL_NAMES,
     dispatch_kernel_syscall,
 )
 from nexus.server.protocol import parse_method_params
+from nexus.server.zone_execution import run_zone_scoped
 
 logger = logging.getLogger(__name__)
 
@@ -83,6 +85,7 @@ class VFSCallDispatcher:
         auth_provider: Any = None,
         api_key: str | None = None,
         subscription_manager: Any = None,
+        zone_registry: Any = None,
         loop: asyncio.AbstractEventLoop | None = None,
     ) -> None:
         self._nexus_fs = nexus_fs
@@ -90,6 +93,7 @@ class VFSCallDispatcher:
         self._auth_provider = auth_provider
         self._api_key = api_key
         self._subscription_manager = subscription_manager
+        self._zone_registry = zone_registry
         self._loop = loop or asyncio.get_event_loop()
 
     # ------------------------------------------------------------------
@@ -251,12 +255,21 @@ class VFSCallDispatcher:
                     params_dict.get("path"),
                     op_context.zone_id if op_context else None,
                 )
-                result = await dispatch_kernel_syscall(
-                    self._nexus_fs,
-                    method,
-                    params_dict,
-                    op_context,
-                    subscription_manager=self._subscription_manager,
+                target_zone = target_zone_for_context(op_context, params_dict)
+
+                async def _work() -> Any:
+                    return await dispatch_kernel_syscall(
+                        self._nexus_fs,
+                        method,
+                        params_dict,
+                        op_context,
+                        subscription_manager=self._subscription_manager,
+                    )
+
+                result = await run_zone_scoped(
+                    self._zone_registry,
+                    target_zone,
+                    _work,
                 )
                 return False, encode_rpc_message({"result": result})
 
@@ -286,14 +299,23 @@ class VFSCallDispatcher:
             else:
                 scope_params_for_zone(params, op_context.zone_id)
 
-            result = await dispatch_method(
-                method,
-                params,
-                op_context,
-                nexus_fs=self._nexus_fs,
-                exposed_methods=self._exposed_methods,
-                auth_provider=self._auth_provider,
-                subscription_manager=self._subscription_manager,
+            target_zone = target_zone_for_context(op_context, params)
+
+            async def _work() -> Any:
+                return await dispatch_method(
+                    method,
+                    params,
+                    op_context,
+                    nexus_fs=self._nexus_fs,
+                    exposed_methods=self._exposed_methods,
+                    auth_provider=self._auth_provider,
+                    subscription_manager=self._subscription_manager,
+                )
+
+            result = await run_zone_scoped(
+                self._zone_registry,
+                target_zone,
+                _work,
             )
             return False, encode_rpc_message({"result": result})
 

--- a/src/nexus/grpc/servicer.py
+++ b/src/nexus/grpc/servicer.py
@@ -85,8 +85,9 @@ class VFSCallDispatcher:
         auth_provider: Any = None,
         api_key: str | None = None,
         subscription_manager: Any = None,
-        zone_registry: Any = None,
         loop: asyncio.AbstractEventLoop | None = None,
+        *,
+        zone_registry: Any = None,
     ) -> None:
         self._nexus_fs = nexus_fs
         self._exposed_methods = exposed_methods

--- a/src/nexus/runtime/__init__.py
+++ b/src/nexus/runtime/__init__.py
@@ -1,0 +1,5 @@
+"""Runtime isolation helpers for Nexus server work."""
+
+from nexus.runtime.zone_runner import ZoneRegistry, ZoneRunner
+
+__all__ = ["ZoneRegistry", "ZoneRunner"]

--- a/src/nexus/runtime/zone_resolution.py
+++ b/src/nexus/runtime/zone_resolution.py
@@ -6,8 +6,17 @@ from typing import Any
 from nexus.contracts.constants import ROOT_ZONE_ID
 
 _EXPLICIT_ZONE_ATTRS = ("zone", "zone_id", "target_zone_id")
-_PATH_ATTRS = ("path", "src", "dst", "old_path", "new_path", "prefix")
-_CONTAINER_ATTRS = ("files", "operations")
+_PATH_ATTRS = (
+    "path",
+    "src",
+    "dst",
+    "source",
+    "destination",
+    "old_path",
+    "new_path",
+    "prefix",
+)
+_CONTAINER_ATTRS = ("files", "operations", "renames")
 
 
 def zone_from_path(value: str) -> str | None:
@@ -59,10 +68,10 @@ def _iter_path_values(params: Any) -> Iterable[str]:
         yield from _paths_from_value(value, seen)
     for attr in _CONTAINER_ATTRS:
         value = _read_attr(params, attr)
-        yield from _paths_from_value(value, seen)
+        yield from _paths_from_value(value, seen, container=attr)
 
 
-def _paths_from_value(value: Any, seen: set[int]) -> Iterable[str]:
+def _paths_from_value(value: Any, seen: set[int], *, container: str | None = None) -> Iterable[str]:
     if isinstance(value, str):
         yield value
         return
@@ -74,13 +83,18 @@ def _paths_from_value(value: Any, seen: set[int]) -> Iterable[str]:
         for key in _PATH_ATTRS:
             yield from _paths_from_value(value.get(key), seen)
         for key in _CONTAINER_ATTRS:
-            yield from _paths_from_value(value.get(key), seen)
+            yield from _paths_from_value(value.get(key), seen, container=key)
         return
     if isinstance(value, list | tuple):
         if _already_seen(value, seen):
             return
+        if container == "files" and isinstance(value, tuple) and value:
+            first = value[0]
+            if isinstance(first, str):
+                yield first
+                return
         for item in value:
-            yield from _paths_from_value(item, seen)
+            yield from _paths_from_value(item, seen, container=container)
         return
     if _already_seen(value, seen):
         return
@@ -89,7 +103,7 @@ def _paths_from_value(value: Any, seen: set[int]) -> Iterable[str]:
         yield from _paths_from_value(nested, seen)
     for attr in _CONTAINER_ATTRS:
         nested = getattr(value, attr, None)
-        yield from _paths_from_value(nested, seen)
+        yield from _paths_from_value(nested, seen, container=attr)
 
 
 def _already_seen(value: Any, seen: set[int]) -> bool:

--- a/src/nexus/runtime/zone_resolution.py
+++ b/src/nexus/runtime/zone_resolution.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+from collections.abc import Iterable
+from typing import Any
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+
+_EXPLICIT_ZONE_ATTRS = ("zone", "zone_id", "target_zone_id")
+_PATH_ATTRS = ("path", "src", "dst", "old_path", "new_path", "prefix")
+
+
+def zone_from_path(value: str) -> str | None:
+    if not isinstance(value, str):
+        return None
+    if not value.startswith("/zone/"):
+        return None
+    remainder = value[len("/zone/") :]
+    zone = remainder.split("/", 1)[0]
+    if not zone or zone == ROOT_ZONE_ID:
+        return None
+    return zone
+
+
+def zone_from_params(params: Any) -> str | None:
+    if params is None:
+        return None
+    for attr in _EXPLICIT_ZONE_ATTRS:
+        zone = _read_attr(params, attr)
+        if isinstance(zone, str) and zone and zone != ROOT_ZONE_ID:
+            return zone
+    for value in _iter_path_values(params):
+        zone = zone_from_path(value)
+        if zone is not None:
+            return zone
+    return None
+
+
+def target_zone_for_context(context: Any, params: Any | None) -> str | None:
+    zone = zone_from_params(params)
+    if zone is not None:
+        return zone
+    context_zone = getattr(context, "zone_id", None)
+    if isinstance(context_zone, str) and context_zone and context_zone != ROOT_ZONE_ID:
+        return context_zone
+    return None
+
+
+def _read_attr(value: Any, attr: str) -> Any:
+    if isinstance(value, dict):
+        return value.get(attr)
+    return getattr(value, attr, None)
+
+
+def _iter_path_values(params: Any) -> Iterable[str]:
+    for attr in _PATH_ATTRS:
+        value = _read_attr(params, attr)
+        yield from _paths_from_value(value)
+    files = _read_attr(params, "files")
+    yield from _paths_from_value(files)
+    operations = _read_attr(params, "operations")
+    yield from _paths_from_value(operations)
+
+
+def _paths_from_value(value: Any) -> Iterable[str]:
+    if isinstance(value, str):
+        yield value
+        return
+    if isinstance(value, dict):
+        for key in _PATH_ATTRS:
+            nested = value.get(key)
+            if isinstance(nested, str):
+                yield nested
+        return
+    if isinstance(value, tuple) and value and isinstance(value[0], str):
+        yield value[0]
+        return
+    if isinstance(value, list):
+        for item in value:
+            yield from _paths_from_value(item)
+        return
+    for attr in _PATH_ATTRS:
+        nested = getattr(value, attr, None)
+        if isinstance(nested, str):
+            yield nested

--- a/src/nexus/runtime/zone_resolution.py
+++ b/src/nexus/runtime/zone_resolution.py
@@ -7,6 +7,7 @@ from nexus.contracts.constants import ROOT_ZONE_ID
 
 _EXPLICIT_ZONE_ATTRS = ("zone", "zone_id", "target_zone_id")
 _PATH_ATTRS = ("path", "src", "dst", "old_path", "new_path", "prefix")
+_CONTAINER_ATTRS = ("files", "operations")
 
 
 def zone_from_path(value: str) -> str | None:
@@ -52,33 +53,48 @@ def _read_attr(value: Any, attr: str) -> Any:
 
 
 def _iter_path_values(params: Any) -> Iterable[str]:
+    seen: set[int] = set()
     for attr in _PATH_ATTRS:
         value = _read_attr(params, attr)
-        yield from _paths_from_value(value)
-    files = _read_attr(params, "files")
-    yield from _paths_from_value(files)
-    operations = _read_attr(params, "operations")
-    yield from _paths_from_value(operations)
+        yield from _paths_from_value(value, seen)
+    for attr in _CONTAINER_ATTRS:
+        value = _read_attr(params, attr)
+        yield from _paths_from_value(value, seen)
 
 
-def _paths_from_value(value: Any) -> Iterable[str]:
+def _paths_from_value(value: Any, seen: set[int]) -> Iterable[str]:
     if isinstance(value, str):
         yield value
         return
-    if isinstance(value, dict):
-        for key in _PATH_ATTRS:
-            nested = value.get(key)
-            if isinstance(nested, str):
-                yield nested
+    if value is None or isinstance(value, bytes | bytearray | memoryview):
         return
-    if isinstance(value, tuple) and value and isinstance(value[0], str):
-        yield value[0]
+    if isinstance(value, dict):
+        if _already_seen(value, seen):
+            return
+        for key in _PATH_ATTRS:
+            yield from _paths_from_value(value.get(key), seen)
+        for key in _CONTAINER_ATTRS:
+            yield from _paths_from_value(value.get(key), seen)
         return
     if isinstance(value, list | tuple):
+        if _already_seen(value, seen):
+            return
         for item in value:
-            yield from _paths_from_value(item)
+            yield from _paths_from_value(item, seen)
+        return
+    if _already_seen(value, seen):
         return
     for attr in _PATH_ATTRS:
         nested = getattr(value, attr, None)
-        if isinstance(nested, str):
-            yield nested
+        yield from _paths_from_value(nested, seen)
+    for attr in _CONTAINER_ATTRS:
+        nested = getattr(value, attr, None)
+        yield from _paths_from_value(nested, seen)
+
+
+def _already_seen(value: Any, seen: set[int]) -> bool:
+    value_id = id(value)
+    if value_id in seen:
+        return True
+    seen.add(value_id)
+    return False

--- a/src/nexus/runtime/zone_resolution.py
+++ b/src/nexus/runtime/zone_resolution.py
@@ -74,7 +74,7 @@ def _paths_from_value(value: Any) -> Iterable[str]:
     if isinstance(value, tuple) and value and isinstance(value[0], str):
         yield value[0]
         return
-    if isinstance(value, list):
+    if isinstance(value, list | tuple):
         for item in value:
             yield from _paths_from_value(item)
         return

--- a/src/nexus/runtime/zone_resolution.py
+++ b/src/nexus/runtime/zone_resolution.py
@@ -100,9 +100,14 @@ def _paths_from_value(value: Any, seen: set[int], *, container: str | None = Non
         if container == "operations" and value:
             first = value[0]
             if isinstance(first, str):
-                for index in _OPERATION_PATH_SLOTS.get(first, ()):
-                    if index < len(value):
-                        yield from _paths_from_value(value[index], seen)
+                path_slots = _OPERATION_PATH_SLOTS.get(first)
+                if path_slots is not None:
+                    for index in path_slots:
+                        if index < len(value):
+                            yield from _paths_from_value(value[index], seen)
+                    return
+                for item in value[1:]:
+                    yield from _paths_from_value(item, seen, container=container)
                 return
         for item in value:
             yield from _paths_from_value(item, seen, container=container)

--- a/src/nexus/runtime/zone_resolution.py
+++ b/src/nexus/runtime/zone_resolution.py
@@ -16,7 +16,7 @@ _PATH_ATTRS = (
     "new_path",
     "prefix",
 )
-_CONTAINER_ATTRS = ("files", "operations", "renames")
+_CONTAINER_ATTRS = ("files", "operations", "paths", "renames")
 _OPERATION_PATH_SLOTS = {
     "append": (1,),
     "delete": (1,),

--- a/src/nexus/runtime/zone_resolution.py
+++ b/src/nexus/runtime/zone_resolution.py
@@ -44,15 +44,25 @@ def zone_from_path(value: str) -> str | None:
 def zone_from_params(params: Any) -> str | None:
     if params is None:
         return None
-    for attr in _EXPLICIT_ZONE_ATTRS:
-        zone = _read_attr(params, attr)
-        if isinstance(zone, str) and zone and zone != ROOT_ZONE_ID:
-            return zone
+    explicit_zones = _explicit_zones_from_params(params)
+    if explicit_zones:
+        return next(iter(explicit_zones))
     for value in _iter_path_values(params):
         zone = zone_from_path(value)
         if zone is not None:
             return zone
     return None
+
+
+def zones_from_params(params: Any) -> frozenset[str]:
+    if params is None:
+        return frozenset()
+    zones = set(_explicit_zones_from_params(params))
+    for value in _iter_path_values(params):
+        zone = zone_from_path(value)
+        if zone is not None:
+            zones.add(zone)
+    return frozenset(zones)
 
 
 def target_zone_for_context(context: Any, params: Any | None) -> str | None:
@@ -69,6 +79,15 @@ def _read_attr(value: Any, attr: str) -> Any:
     if isinstance(value, dict):
         return value.get(attr)
     return getattr(value, attr, None)
+
+
+def _explicit_zones_from_params(params: Any) -> tuple[str, ...]:
+    zones: list[str] = []
+    for attr in _EXPLICIT_ZONE_ATTRS:
+        zone = _read_attr(params, attr)
+        if isinstance(zone, str) and zone and zone != ROOT_ZONE_ID:
+            zones.append(zone)
+    return tuple(zones)
 
 
 def _iter_path_values(params: Any) -> Iterable[str]:

--- a/src/nexus/runtime/zone_resolution.py
+++ b/src/nexus/runtime/zone_resolution.py
@@ -18,6 +18,10 @@ _PATH_ATTRS = (
 )
 _CONTAINER_ATTRS = ("files", "operations", "renames")
 _OPERATION_PATH_SLOTS = {
+    "append": (1,),
+    "delete": (1,),
+    "read": (1,),
+    "stat": (1,),
     "write": (1,),
     "rename": (1, 2),
 }
@@ -107,7 +111,8 @@ def _paths_from_value(value: Any, seen: set[int], *, container: str | None = Non
                             yield from _paths_from_value(value[index], seen)
                     return
                 for item in value[1:]:
-                    yield from _paths_from_value(item, seen, container=container)
+                    if not isinstance(item, str):
+                        yield from _paths_from_value(item, seen, container=container)
                 return
         for item in value:
             yield from _paths_from_value(item, seen, container=container)

--- a/src/nexus/runtime/zone_resolution.py
+++ b/src/nexus/runtime/zone_resolution.py
@@ -17,6 +17,10 @@ _PATH_ATTRS = (
     "prefix",
 )
 _CONTAINER_ATTRS = ("files", "operations", "renames")
+_OPERATION_PATH_SLOTS = {
+    "write": (1,),
+    "rename": (1, 2),
+}
 
 
 def zone_from_path(value: str) -> str | None:
@@ -88,10 +92,17 @@ def _paths_from_value(value: Any, seen: set[int], *, container: str | None = Non
     if isinstance(value, list | tuple):
         if _already_seen(value, seen):
             return
-        if container == "files" and isinstance(value, tuple) and value:
+        if container == "files" and value:
             first = value[0]
             if isinstance(first, str):
                 yield first
+                return
+        if container == "operations" and value:
+            first = value[0]
+            if isinstance(first, str):
+                for index in _OPERATION_PATH_SLOTS.get(first, ()):
+                    if index < len(value):
+                        yield from _paths_from_value(value[index], seen)
                 return
         for item in value:
             yield from _paths_from_value(item, seen, container=container)

--- a/src/nexus/runtime/zone_resolution.py
+++ b/src/nexus/runtime/zone_resolution.py
@@ -14,6 +14,8 @@ _PATH_ATTRS = (
     "destination",
     "old_path",
     "new_path",
+    "src_path",
+    "dst_path",
     "prefix",
 )
 _CONTAINER_ATTRS = ("files", "operations", "paths", "renames")

--- a/src/nexus/runtime/zone_runner.py
+++ b/src/nexus/runtime/zone_runner.py
@@ -36,18 +36,24 @@ class ZoneRunner:
         with self._lock:
             if self._closed:
                 raise RuntimeError(f"ZoneRunner {self.zone_id!r} has been stopped")
-            if self._thread is not None and self._thread.is_alive():
-                return
-            self._ready.clear()
-            thread = threading.Thread(
-                target=self._thread_main,
-                name=f"nexus-zone-{self.zone_id}",
-                daemon=True,
-            )
-            self._thread = thread
-            thread.start()
+            thread = self._thread
+            if thread is None or not thread.is_alive():
+                self._ready.clear()
+                thread = threading.Thread(
+                    target=self._thread_main,
+                    name=f"nexus-zone-{self.zone_id}",
+                    daemon=True,
+                )
+                self._thread = thread
+                thread.start()
         self._ready.wait(timeout=5.0)
-        if self._loop is None:
+        with self._lock:
+            loop = self._loop
+            stopped = self._closed
+            thread_alive = thread.is_alive()
+        if stopped:
+            raise RuntimeError(f"ZoneRunner {self.zone_id!r} has been stopped")
+        if loop is None or not thread_alive:
             raise RuntimeError(f"ZoneRunner {self.zone_id!r} did not start")
 
     async def call(self, work: Callable[[], Awaitable[T]]) -> T:

--- a/src/nexus/runtime/zone_runner.py
+++ b/src/nexus/runtime/zone_runner.py
@@ -400,13 +400,20 @@ class ZoneRegistry:
 
     def stop_all(self) -> None:
         with self._lock:
-            runners = tuple(self._runners.values())
-            self._runners.clear()
+            runners = tuple(self._runners.items())
         errors: list[Exception] = []
-        for runner in runners:
+        stopped: list[tuple[str, ZoneRunner]] = []
+        for zone_id, runner in runners:
             try:
                 runner.stop()
             except Exception as exc:
                 errors.append(exc)
+                continue
+            if not runner.is_alive:
+                stopped.append((zone_id, runner))
+        with self._lock:
+            for zone_id, runner in stopped:
+                if self._runners.get(zone_id) is runner:
+                    del self._runners[zone_id]
         if errors:
             raise ExceptionGroup("Failed to stop zone runners", errors)

--- a/src/nexus/runtime/zone_runner.py
+++ b/src/nexus/runtime/zone_runner.py
@@ -5,7 +5,7 @@ import concurrent.futures
 import contextlib
 import logging
 import threading
-from collections.abc import Awaitable, Callable
+from collections.abc import Awaitable, Callable, Coroutine
 from typing import Any, TypeVar
 
 T = TypeVar("T")
@@ -62,12 +62,12 @@ class ZoneRunner:
         if self.is_current_runner():
             return await work()
         await asyncio.to_thread(self.start)
-        loop = self._require_loop()
+        self._before_submit()
 
         async def invoke() -> T:
             return await work()
 
-        submitted = asyncio.run_coroutine_threadsafe(invoke(), loop)
+        submitted = self._submit(invoke)
         try:
             return await asyncio.wrap_future(submitted)
         except asyncio.CancelledError:
@@ -78,12 +78,12 @@ class ZoneRunner:
         if self.is_current_runner():
             raise RuntimeError("call_sync cannot run on owning runner thread")
         self.start()
-        loop = self._require_loop()
+        self._before_submit()
 
         async def invoke() -> T:
             return await work()
 
-        return asyncio.run_coroutine_threadsafe(invoke(), loop).result()
+        return self._submit(invoke).result()
 
     def stop(self) -> None:
         owns_shutdown = False
@@ -159,6 +159,24 @@ class ZoneRunner:
         if loop is None:
             raise RuntimeError(f"ZoneRunner {self.zone_id!r} is not running")
         return loop
+
+    def _before_submit(self) -> None:
+        return None
+
+    def _submit(
+        self,
+        invoke: Callable[[], Coroutine[Any, Any, T]],
+    ) -> concurrent.futures.Future[T]:
+        with self._lock:
+            if self._closed or self._stopping:
+                raise RuntimeError(f"ZoneRunner {self.zone_id!r} has been stopped")
+            loop = self._require_loop()
+            submitted = invoke()
+            try:
+                return asyncio.run_coroutine_threadsafe(submitted, loop)
+            except RuntimeError as exc:
+                submitted.close()
+                raise RuntimeError(f"ZoneRunner {self.zone_id!r} has been stopped") from exc
 
     def _thread_main(self) -> None:
         loop = asyncio.new_event_loop()

--- a/src/nexus/runtime/zone_runner.py
+++ b/src/nexus/runtime/zone_runner.py
@@ -79,13 +79,21 @@ class ZoneRunner:
 
     def stop(self) -> None:
         with self._lock:
-            if self._closed:
+            thread = self._thread
+            if self._closed and not (thread is not None and thread.is_alive()):
                 return
             self._closed = True
             loop = self._loop
-            thread = self._thread
-        if loop is None or thread is None:
+        if thread is None:
             return
+        if loop is None:
+            self._ready.wait(timeout=self._join_timeout)
+            loop = self._loop
+            if loop is None:
+                thread.join(timeout=self._join_timeout)
+                if thread.is_alive():
+                    logger.warning("Zone runner %s thread did not terminate", self.zone_id)
+                return
         if thread is threading.current_thread():
             loop.call_soon(loop.stop)
             return
@@ -116,6 +124,8 @@ class ZoneRunner:
         _CURRENT.runner = self
         self._loop = loop
         self._ready.set()
+        if self._closed:
+            loop.stop()
         try:
             loop.run_forever()
         finally:

--- a/src/nexus/runtime/zone_runner.py
+++ b/src/nexus/runtime/zone_runner.py
@@ -126,8 +126,11 @@ class ZoneRunner:
             return
         join_timeout = self._join_timeout
         try:
-            future = asyncio.run_coroutine_threadsafe(self._cancel_pending(loop), loop)
-            future.result(timeout=self._join_timeout)
+            future = asyncio.run_coroutine_threadsafe(
+                self._cancel_pending(loop, timeout=self._join_timeout),
+                loop,
+            )
+            future.result(timeout=self._join_timeout * 2)
         except (TimeoutError, concurrent.futures.TimeoutError):
             logger.warning("Timed out draining zone runner %s", self.zone_id)
             future.cancel()
@@ -216,10 +219,6 @@ class ZoneRunner:
 
     @staticmethod
     def _mark_task_abandoned(task: asyncio.Task[object]) -> None:
-        with contextlib.suppress(Exception):
-            coro = task.get_coro()
-            if coro is not None:
-                coro.close()
         if hasattr(task, "_log_destroy_pending"):
             task._log_destroy_pending = False
 

--- a/src/nexus/runtime/zone_runner.py
+++ b/src/nexus/runtime/zone_runner.py
@@ -29,6 +29,10 @@ class ZoneRunner:
         self._closed = False
         self._stopping = False
         self._submitted: dict[asyncio.Task[Any], concurrent.futures.Future[Any]] = {}
+        self._pending_submissions: dict[
+            concurrent.futures.Future[Any],
+            Coroutine[Any, Any, Any],
+        ] = {}
 
     @property
     def is_alive(self) -> bool:
@@ -181,8 +185,22 @@ class ZoneRunner:
             loop = self._require_loop()
             external: concurrent.futures.Future[T] = concurrent.futures.Future()
             submitted = invoke()
+            self._pending_submissions[external] = submitted
 
             def schedule() -> None:
+                with self._lock:
+                    pending = self._pending_submissions.pop(external, None)
+                    closed = self._closed or self._stopping
+                if pending is None:
+                    submitted.close()
+                    return
+                if closed:
+                    submitted.close()
+                    if not external.done():
+                        external.set_exception(
+                            RuntimeError(f"ZoneRunner {self.zone_id!r} has been stopped")
+                        )
+                    return
                 try:
                     task = loop.create_task(submitted)
                 except RuntimeError:
@@ -206,6 +224,11 @@ class ZoneRunner:
             def cancel_loop_task(future: concurrent.futures.Future[T]) -> None:
                 if not future.cancelled():
                     return
+                with self._lock:
+                    pending = self._pending_submissions.pop(future, None)
+                if pending is not None:
+                    pending.close()
+                    return
                 task = self._task_for_external(future)
                 if task is None:
                     return
@@ -216,7 +239,10 @@ class ZoneRunner:
             try:
                 loop.call_soon_threadsafe(schedule)
             except RuntimeError as exc:
-                submitted.close()
+                with self._lock:
+                    pending = self._pending_submissions.pop(external, None)
+                if pending is not None:
+                    pending.close()
                 external.set_exception(
                     RuntimeError(f"ZoneRunner {self.zone_id!r} has been stopped")
                 )
@@ -331,6 +357,12 @@ class ZoneRunner:
         with self._lock:
             submitted = list(self._submitted.items())
             self._submitted.clear()
+            pending_submissions = list(self._pending_submissions.items())
+            self._pending_submissions.clear()
+        for external, coroutine in pending_submissions:
+            coroutine.close()
+            if not external.done():
+                external.set_exception(exc)
         for task, external in submitted:
             if not external.done():
                 external.set_exception(exc)

--- a/src/nexus/runtime/zone_runner.py
+++ b/src/nexus/runtime/zone_runner.py
@@ -49,7 +49,7 @@ class ZoneRunner:
                 )
                 self._thread = thread
                 thread.start()
-        self._ready.wait(timeout=5.0)
+        self._ready.wait(timeout=self._join_timeout)
         with self._lock:
             loop = self._loop
             stopped = self._closed
@@ -57,6 +57,10 @@ class ZoneRunner:
         if stopped:
             raise RuntimeError(f"ZoneRunner {self.zone_id!r} has been stopped")
         if loop is None or not thread_alive:
+            with self._lock:
+                self._closed = True
+                self._stopping = thread_alive
+                self._ready.set()
             raise RuntimeError(f"ZoneRunner {self.zone_id!r} did not start")
 
     async def call(self, work: Callable[[], Awaitable[T]]) -> T:
@@ -136,6 +140,7 @@ class ZoneRunner:
             future.result(timeout=self._join_timeout * 2)
         except (TimeoutError, concurrent.futures.TimeoutError):
             logger.warning("Timed out draining zone runner %s", self.zone_id)
+            self._fail_submitted(RuntimeError(f"ZoneRunner {self.zone_id!r} has been stopped"))
             future.cancel()
             future.add_done_callback(self._consume_submitted_result)
             loop.call_soon_threadsafe(loop.stop)
@@ -149,6 +154,7 @@ class ZoneRunner:
         thread.join(timeout=join_timeout)
         if thread.is_alive():
             logger.warning("Zone runner %s thread did not terminate", self.zone_id)
+            self._fail_submitted(RuntimeError(f"ZoneRunner {self.zone_id!r} has been stopped"))
         else:
             with self._lock:
                 self._stopping = False
@@ -239,7 +245,7 @@ class ZoneRunner:
             with contextlib.suppress(BaseException):
                 task.result()
             return
-        if external.cancelled():
+        if external.done():
             with contextlib.suppress(BaseException):
                 task.result()
             return
@@ -264,10 +270,17 @@ class ZoneRunner:
             loop.run_forever()
         finally:
             try:
-                loop.run_until_complete(
-                    self._cancel_pending(loop, stop=False, timeout=self._join_timeout)
-                )
-                loop.run_until_complete(loop.shutdown_asyncgens())
+                try:
+                    loop.run_until_complete(
+                        self._cancel_pending(loop, stop=False, timeout=self._join_timeout)
+                    )
+                    loop.run_until_complete(loop.shutdown_asyncgens())
+                except BaseException:
+                    logger.debug(
+                        "Zone runner %s final cleanup did not complete cleanly",
+                        self.zone_id,
+                        exc_info=True,
+                    )
             finally:
                 _CURRENT.runner = None
                 asyncio.set_event_loop(None)
@@ -313,6 +326,15 @@ class ZoneRunner:
     def _consume_submitted_result(future: concurrent.futures.Future[Any]) -> None:
         with contextlib.suppress(BaseException):
             future.result()
+
+    def _fail_submitted(self, exc: BaseException) -> None:
+        with self._lock:
+            submitted = list(self._submitted.items())
+            self._submitted.clear()
+        for task, external in submitted:
+            if not external.done():
+                external.set_exception(exc)
+            self._mark_task_abandoned(task)
 
     def _mark_task_abandoned(self, task: asyncio.Task[object]) -> None:
         with self._lock:

--- a/src/nexus/runtime/zone_runner.py
+++ b/src/nexus/runtime/zone_runner.py
@@ -27,6 +27,7 @@ class ZoneRunner:
         self._loop: asyncio.AbstractEventLoop | None = None
         self._thread: threading.Thread | None = None
         self._closed = False
+        self._stopping = False
 
     @property
     def is_alive(self) -> bool:
@@ -85,13 +86,30 @@ class ZoneRunner:
         return asyncio.run_coroutine_threadsafe(invoke(), loop).result()
 
     def stop(self) -> None:
+        owns_shutdown = False
         with self._lock:
             thread = self._thread
-            if self._closed and not (thread is not None and thread.is_alive()):
+            if self._closed:
+                stopping = self._stopping
+                if not (stopping and thread is not None and thread.is_alive()):
+                    return
+            else:
+                self._closed = True
+                self._stopping = True
+                self._ready.set()
+                owns_shutdown = True
+            if not owns_shutdown:
+                wait_thread = thread
+            else:
+                loop = self._loop
+        if not owns_shutdown:
+            if wait_thread is not None and wait_thread is not threading.current_thread():
+                wait_thread.join(timeout=self._join_timeout)
                 return
-            self._closed = True
-            loop = self._loop
+            return
         if thread is None:
+            with self._lock:
+                self._stopping = False
             return
         if loop is None:
             self._ready.wait(timeout=self._join_timeout)
@@ -100,6 +118,8 @@ class ZoneRunner:
                 thread.join(timeout=self._join_timeout)
                 if thread.is_alive():
                     logger.warning("Zone runner %s thread did not terminate", self.zone_id)
+                with self._lock:
+                    self._stopping = False
                 return
         if thread is threading.current_thread():
             loop.call_soon(loop.stop)
@@ -119,6 +139,9 @@ class ZoneRunner:
         thread.join(timeout=join_timeout)
         if thread.is_alive():
             logger.warning("Zone runner %s thread did not terminate", self.zone_id)
+        else:
+            with self._lock:
+                self._stopping = False
 
     def is_current_runner(self) -> bool:
         return getattr(_CURRENT, "runner", None) is self
@@ -150,6 +173,8 @@ class ZoneRunner:
                 asyncio.set_event_loop(None)
                 loop.close()
                 self._loop = None
+                with self._lock:
+                    self._stopping = False
 
     async def _cancel_pending(
         self,

--- a/src/nexus/runtime/zone_runner.py
+++ b/src/nexus/runtime/zone_runner.py
@@ -2,10 +2,11 @@ from __future__ import annotations
 
 import asyncio
 import concurrent.futures
+import contextlib
 import logging
 import threading
 from collections.abc import Awaitable, Callable
-from typing import TypeVar
+from typing import Any, TypeVar
 
 T = TypeVar("T")
 
@@ -109,6 +110,8 @@ class ZoneRunner:
             future.result(timeout=self._join_timeout)
         except (TimeoutError, concurrent.futures.TimeoutError):
             logger.warning("Timed out draining zone runner %s", self.zone_id)
+            future.cancel()
+            future.add_done_callback(self._consume_submitted_result)
             loop.call_soon_threadsafe(loop.stop)
             join_timeout += self._join_timeout
         except RuntimeError:
@@ -165,15 +168,35 @@ class ZoneRunner:
             if timeout is None:
                 await asyncio.gather(*tasks, return_exceptions=True)
             else:
-                _, pending = await asyncio.wait(tasks, timeout=timeout)
+                done, pending = await asyncio.wait(tasks, timeout=timeout)
+                for task in done:
+                    with contextlib.suppress(BaseException):
+                        task.result()
                 if pending:
                     logger.warning(
                         "Closing zone runner %s with %d pending task(s)",
                         self.zone_id,
                         len(pending),
                     )
+                    for task in pending:
+                        task.cancel()
+                        self._mark_task_abandoned(task)
         if stop:
             loop.stop()
+
+    @staticmethod
+    def _consume_submitted_result(future: concurrent.futures.Future[Any]) -> None:
+        with contextlib.suppress(BaseException):
+            future.result()
+
+    @staticmethod
+    def _mark_task_abandoned(task: asyncio.Task[object]) -> None:
+        with contextlib.suppress(Exception):
+            coro = task.get_coro()
+            if coro is not None:
+                coro.close()
+        if hasattr(task, "_log_destroy_pending"):
+            task._log_destroy_pending = False
 
 
 class ZoneRegistry:

--- a/src/nexus/runtime/zone_runner.py
+++ b/src/nexus/runtime/zone_runner.py
@@ -399,5 +399,14 @@ class ZoneRegistry:
             return tuple(self._runners.values())
 
     def stop_all(self) -> None:
-        for runner in self.all():
-            runner.stop()
+        with self._lock:
+            runners = tuple(self._runners.values())
+            self._runners.clear()
+        errors: list[Exception] = []
+        for runner in runners:
+            try:
+                runner.stop()
+            except Exception as exc:
+                errors.append(exc)
+        if errors:
+            raise ExceptionGroup("Failed to stop zone runners", errors)

--- a/src/nexus/runtime/zone_runner.py
+++ b/src/nexus/runtime/zone_runner.py
@@ -28,6 +28,7 @@ class ZoneRunner:
         self._thread: threading.Thread | None = None
         self._closed = False
         self._stopping = False
+        self._submitted: dict[asyncio.Task[Any], concurrent.futures.Future[Any]] = {}
 
     @property
     def is_alive(self) -> bool:
@@ -60,6 +61,7 @@ class ZoneRunner:
 
     async def call(self, work: Callable[[], Awaitable[T]]) -> T:
         if self.is_current_runner():
+            self._raise_if_closed()
             return await work()
         await asyncio.to_thread(self.start)
         self._before_submit()
@@ -171,12 +173,84 @@ class ZoneRunner:
             if self._closed or self._stopping:
                 raise RuntimeError(f"ZoneRunner {self.zone_id!r} has been stopped")
             loop = self._require_loop()
+            external: concurrent.futures.Future[T] = concurrent.futures.Future()
             submitted = invoke()
+
+            def schedule() -> None:
+                try:
+                    task = loop.create_task(submitted)
+                except RuntimeError:
+                    submitted.close()
+                    if not external.done():
+                        external.set_exception(
+                            RuntimeError(f"ZoneRunner {self.zone_id!r} has been stopped")
+                        )
+                    logger.debug(
+                        "Zone runner %s rejected submission",
+                        self.zone_id,
+                        exc_info=True,
+                    )
+                    return
+                with self._lock:
+                    self._submitted[task] = external
+                task.add_done_callback(self._complete_submitted)
+                if external.cancelled():
+                    task.cancel()
+
+            def cancel_loop_task(future: concurrent.futures.Future[T]) -> None:
+                if not future.cancelled():
+                    return
+                task = self._task_for_external(future)
+                if task is None:
+                    return
+                with contextlib.suppress(RuntimeError):
+                    loop.call_soon_threadsafe(task.cancel)
+
+            external.add_done_callback(cancel_loop_task)
             try:
-                return asyncio.run_coroutine_threadsafe(submitted, loop)
+                loop.call_soon_threadsafe(schedule)
             except RuntimeError as exc:
                 submitted.close()
+                external.set_exception(
+                    RuntimeError(f"ZoneRunner {self.zone_id!r} has been stopped")
+                )
                 raise RuntimeError(f"ZoneRunner {self.zone_id!r} has been stopped") from exc
+            return external
+
+    def _raise_if_closed(self) -> None:
+        with self._lock:
+            if self._closed or self._stopping:
+                raise RuntimeError(f"ZoneRunner {self.zone_id!r} has been stopped")
+
+    def _task_for_external(
+        self,
+        external: concurrent.futures.Future[Any],
+    ) -> asyncio.Task[Any] | None:
+        with self._lock:
+            for task, submitted_external in self._submitted.items():
+                if submitted_external is external:
+                    return task
+        return None
+
+    def _complete_submitted(self, task: asyncio.Task[Any]) -> None:
+        with self._lock:
+            external = self._submitted.pop(task, None)
+        if external is None:
+            with contextlib.suppress(BaseException):
+                task.result()
+            return
+        if external.cancelled():
+            with contextlib.suppress(BaseException):
+                task.result()
+            return
+        try:
+            result = task.result()
+        except asyncio.CancelledError:
+            external.cancel()
+        except BaseException as exc:
+            external.set_exception(exc)
+        else:
+            external.set_result(result)
 
     def _thread_main(self) -> None:
         loop = asyncio.new_event_loop()
@@ -240,8 +314,11 @@ class ZoneRunner:
         with contextlib.suppress(BaseException):
             future.result()
 
-    @staticmethod
-    def _mark_task_abandoned(task: asyncio.Task[object]) -> None:
+    def _mark_task_abandoned(self, task: asyncio.Task[object]) -> None:
+        with self._lock:
+            external = self._submitted.pop(task, None)
+        if external is not None and not external.done():
+            external.set_exception(RuntimeError(f"ZoneRunner {self.zone_id!r} has been stopped"))
         if hasattr(task, "_log_destroy_pending"):
             task._log_destroy_pending = False
 

--- a/src/nexus/runtime/zone_runner.py
+++ b/src/nexus/runtime/zone_runner.py
@@ -103,15 +103,17 @@ class ZoneRunner:
         if thread is threading.current_thread():
             loop.call_soon(loop.stop)
             return
+        join_timeout = self._join_timeout
         try:
             future = asyncio.run_coroutine_threadsafe(self._cancel_pending(loop), loop)
             future.result(timeout=self._join_timeout)
         except (TimeoutError, concurrent.futures.TimeoutError):
             logger.warning("Timed out draining zone runner %s", self.zone_id)
             loop.call_soon_threadsafe(loop.stop)
+            join_timeout += self._join_timeout
         except RuntimeError:
             return
-        thread.join(timeout=self._join_timeout)
+        thread.join(timeout=join_timeout)
         if thread.is_alive():
             logger.warning("Zone runner %s thread did not terminate", self.zone_id)
 
@@ -136,7 +138,9 @@ class ZoneRunner:
             loop.run_forever()
         finally:
             try:
-                loop.run_until_complete(self._cancel_pending(loop, stop=False))
+                loop.run_until_complete(
+                    self._cancel_pending(loop, stop=False, timeout=self._join_timeout)
+                )
                 loop.run_until_complete(loop.shutdown_asyncgens())
             finally:
                 _CURRENT.runner = None
@@ -149,6 +153,7 @@ class ZoneRunner:
         loop: asyncio.AbstractEventLoop,
         *,
         stop: bool = True,
+        timeout: float | None = None,
     ) -> None:
         current = asyncio.current_task(loop=loop)
         tasks = [
@@ -157,7 +162,16 @@ class ZoneRunner:
         for task in tasks:
             task.cancel()
         if tasks:
-            await asyncio.gather(*tasks, return_exceptions=True)
+            if timeout is None:
+                await asyncio.gather(*tasks, return_exceptions=True)
+            else:
+                _, pending = await asyncio.wait(tasks, timeout=timeout)
+                if pending:
+                    logger.warning(
+                        "Closing zone runner %s with %d pending task(s)",
+                        self.zone_id,
+                        len(pending),
+                    )
         if stop:
             loop.stop()
 

--- a/src/nexus/runtime/zone_runner.py
+++ b/src/nexus/runtime/zone_runner.py
@@ -118,8 +118,9 @@ class ZoneRunner:
                 thread.join(timeout=self._join_timeout)
                 if thread.is_alive():
                     logger.warning("Zone runner %s thread did not terminate", self.zone_id)
-                with self._lock:
-                    self._stopping = False
+                else:
+                    with self._lock:
+                        self._stopping = False
                 return
         if thread is threading.current_thread():
             loop.call_soon(loop.stop)

--- a/src/nexus/runtime/zone_runner.py
+++ b/src/nexus/runtime/zone_runner.py
@@ -61,7 +61,7 @@ class ZoneRunner:
     async def call(self, work: Callable[[], Awaitable[T]]) -> T:
         if self.is_current_runner():
             return await work()
-        self.start()
+        await asyncio.to_thread(self.start)
         loop = self._require_loop()
 
         async def invoke() -> T:
@@ -138,6 +138,11 @@ class ZoneRunner:
             future.add_done_callback(self._consume_submitted_result)
             loop.call_soon_threadsafe(loop.stop)
         except RuntimeError:
+            logger.debug(
+                "Zone runner %s loop unavailable during stop",
+                self.zone_id,
+                exc_info=True,
+            )
             return
         thread.join(timeout=join_timeout)
         if thread.is_alive():

--- a/src/nexus/runtime/zone_runner.py
+++ b/src/nexus/runtime/zone_runner.py
@@ -16,7 +16,7 @@ _CURRENT = threading.local()
 class ZoneRunner:
     """Dedicated thread and asyncio loop for one zone."""
 
-    def __init__(self, zone_id: str, *, join_timeout: float = 5.0) -> None:
+    def __init__(self, zone_id: str, join_timeout: float = 5.0) -> None:
         if not zone_id:
             raise ValueError("zone_id is required")
         self.zone_id = zone_id

--- a/src/nexus/runtime/zone_runner.py
+++ b/src/nexus/runtime/zone_runner.py
@@ -124,7 +124,7 @@ class ZoneRunner:
         if thread is threading.current_thread():
             loop.call_soon(loop.stop)
             return
-        join_timeout = self._join_timeout
+        join_timeout = self._join_timeout * 2
         try:
             future = asyncio.run_coroutine_threadsafe(
                 self._cancel_pending(loop, timeout=self._join_timeout),
@@ -136,7 +136,6 @@ class ZoneRunner:
             future.cancel()
             future.add_done_callback(self._consume_submitted_result)
             loop.call_soon_threadsafe(loop.stop)
-            join_timeout += self._join_timeout
         except RuntimeError:
             return
         thread.join(timeout=join_timeout)

--- a/src/nexus/runtime/zone_runner.py
+++ b/src/nexus/runtime/zone_runner.py
@@ -1,0 +1,172 @@
+from __future__ import annotations
+
+import asyncio
+import concurrent.futures
+import logging
+import threading
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+T = TypeVar("T")
+
+logger = logging.getLogger(__name__)
+_CURRENT = threading.local()
+
+
+class ZoneRunner:
+    """Dedicated thread and asyncio loop for one zone."""
+
+    def __init__(self, zone_id: str, *, join_timeout: float = 5.0) -> None:
+        if not zone_id:
+            raise ValueError("zone_id is required")
+        self.zone_id = zone_id
+        self._join_timeout = join_timeout
+        self._lock = threading.RLock()
+        self._ready = threading.Event()
+        self._loop: asyncio.AbstractEventLoop | None = None
+        self._thread: threading.Thread | None = None
+        self._closed = False
+
+    @property
+    def is_alive(self) -> bool:
+        thread = self._thread
+        return bool(thread and thread.is_alive())
+
+    def start(self) -> None:
+        with self._lock:
+            if self._closed:
+                raise RuntimeError(f"ZoneRunner {self.zone_id!r} has been stopped")
+            if self._thread is not None and self._thread.is_alive():
+                return
+            self._ready.clear()
+            thread = threading.Thread(
+                target=self._thread_main,
+                name=f"nexus-zone-{self.zone_id}",
+                daemon=True,
+            )
+            self._thread = thread
+            thread.start()
+        self._ready.wait(timeout=5.0)
+        if self._loop is None:
+            raise RuntimeError(f"ZoneRunner {self.zone_id!r} did not start")
+
+    async def call(self, work: Callable[[], Awaitable[T]]) -> T:
+        if self.is_current_runner():
+            return await work()
+        self.start()
+        loop = self._require_loop()
+
+        async def invoke() -> T:
+            return await work()
+
+        submitted = asyncio.run_coroutine_threadsafe(invoke(), loop)
+        try:
+            return await asyncio.wrap_future(submitted)
+        except asyncio.CancelledError:
+            submitted.cancel()
+            raise
+
+    def call_sync(self, work: Callable[[], Awaitable[T]]) -> T:
+        if self.is_current_runner():
+            raise RuntimeError("call_sync cannot run on owning runner thread")
+        self.start()
+        loop = self._require_loop()
+
+        async def invoke() -> T:
+            return await work()
+
+        return asyncio.run_coroutine_threadsafe(invoke(), loop).result()
+
+    def stop(self) -> None:
+        with self._lock:
+            if self._closed:
+                return
+            self._closed = True
+            loop = self._loop
+            thread = self._thread
+        if loop is None or thread is None:
+            return
+        if thread is threading.current_thread():
+            loop.call_soon(loop.stop)
+            return
+        try:
+            future = asyncio.run_coroutine_threadsafe(self._cancel_pending(loop), loop)
+            future.result(timeout=self._join_timeout)
+        except (TimeoutError, concurrent.futures.TimeoutError):
+            logger.warning("Timed out draining zone runner %s", self.zone_id)
+            loop.call_soon_threadsafe(loop.stop)
+        except RuntimeError:
+            return
+        thread.join(timeout=self._join_timeout)
+        if thread.is_alive():
+            logger.warning("Zone runner %s thread did not terminate", self.zone_id)
+
+    def is_current_runner(self) -> bool:
+        return getattr(_CURRENT, "runner", None) is self
+
+    def _require_loop(self) -> asyncio.AbstractEventLoop:
+        loop = self._loop
+        if loop is None:
+            raise RuntimeError(f"ZoneRunner {self.zone_id!r} is not running")
+        return loop
+
+    def _thread_main(self) -> None:
+        loop = asyncio.new_event_loop()
+        asyncio.set_event_loop(loop)
+        _CURRENT.runner = self
+        self._loop = loop
+        self._ready.set()
+        try:
+            loop.run_forever()
+        finally:
+            try:
+                loop.run_until_complete(self._cancel_pending(loop, stop=False))
+                loop.run_until_complete(loop.shutdown_asyncgens())
+            finally:
+                _CURRENT.runner = None
+                asyncio.set_event_loop(None)
+                loop.close()
+                self._loop = None
+
+    async def _cancel_pending(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        *,
+        stop: bool = True,
+    ) -> None:
+        current = asyncio.current_task(loop=loop)
+        tasks = [
+            task for task in asyncio.all_tasks(loop) if task is not current and not task.done()
+        ]
+        for task in tasks:
+            task.cancel()
+        if tasks:
+            await asyncio.gather(*tasks, return_exceptions=True)
+        if stop:
+            loop.stop()
+
+
+class ZoneRegistry:
+    """Lazy registry of one ZoneRunner per zone touched in this process."""
+
+    def __init__(self) -> None:
+        self._lock = threading.RLock()
+        self._runners: dict[str, ZoneRunner] = {}
+
+    def runner_for(self, zone_id: str) -> ZoneRunner:
+        if not zone_id:
+            raise ValueError("zone_id is required")
+        with self._lock:
+            runner = self._runners.get(zone_id)
+            if runner is None:
+                runner = ZoneRunner(zone_id)
+                self._runners[zone_id] = runner
+            return runner
+
+    def all(self) -> tuple[ZoneRunner, ...]:
+        with self._lock:
+            return tuple(self._runners.values())
+
+    def stop_all(self) -> None:
+        for runner in self.all():
+            runner.stop()

--- a/src/nexus/server/api/core/rpc.py
+++ b/src/nexus/server/api/core/rpc.py
@@ -42,6 +42,33 @@ router = APIRouter()
 # by ``unscope_internal_path`` in ``path_utils.py``.
 
 
+def _context_allows_target_zone(context: Any, target_zone: str) -> bool:
+    if getattr(context, "is_admin", False):
+        return True
+    if getattr(context, "zone_id", None) == target_zone:
+        return True
+    if target_zone in set(getattr(context, "zone_set", ()) or ()):
+        return True
+    for zone_perm in getattr(context, "zone_perms", ()) or ():
+        if isinstance(zone_perm, (list, tuple)) and zone_perm and zone_perm[0] == target_zone:
+            return True
+    return False
+
+
+def _context_for_target_zone(context: Any, target_zone: str | None) -> Any:
+    if target_zone is None or getattr(context, "zone_id", None) == target_zone:
+        return context
+    if not _context_allows_target_zone(context, target_zone):
+        return context
+    updates: dict[str, Any] = {"zone_id": target_zone}
+    if getattr(context, "is_admin", False):
+        updates["zone_set"] = (target_zone,)
+        updates["zone_perms"] = ((target_zone, "rw"),)
+    for key, value in updates.items():
+        setattr(context, key, value)
+    return context
+
+
 @router.post("/api/nfs/{method}")
 @limiter.limit(RATE_LIMIT_AUTHENTICATED)
 async def rpc_endpoint(
@@ -130,6 +157,7 @@ async def rpc_endpoint(
             scope_params_for_zone(_params_ns, context.zone_id)
             raw_params = vars(_params_ns)
             target_zone = target_zone_for_context(context, raw_params)
+            context = _context_for_target_zone(context, target_zone)
             state = request.app.state
 
             # #4005 round-5: NO early 304 in the kernel branch.
@@ -235,6 +263,7 @@ async def rpc_endpoint(
         # Dispatch method
         _dispatch_start = _time.time()
         target_zone = target_zone_for_context(context, params)
+        context = _context_for_target_zone(context, target_zone)
 
         async def _work() -> Any:
             return await dispatch_method(

--- a/src/nexus/server/api/core/rpc.py
+++ b/src/nexus/server/api/core/rpc.py
@@ -31,7 +31,7 @@ from nexus.server.protocol import (
     parse_method_params,
 )
 from nexus.server.rate_limiting import RATE_LIMIT_AUTHENTICATED, limiter
-from nexus.server.zone_execution import run_zone_scoped
+from nexus.server.zone_execution import context_for_target_zone, run_zone_scoped
 
 logger = logging.getLogger(__name__)
 
@@ -40,33 +40,6 @@ router = APIRouter()
 # Zone-scoping logic is in nexus.lib.zone_scoping (shared with gRPC servicer).
 # The reverse operation (stripping the prefix from results) is handled
 # by ``unscope_internal_path`` in ``path_utils.py``.
-
-
-def _context_allows_target_zone(context: Any, target_zone: str) -> bool:
-    if getattr(context, "is_admin", False):
-        return True
-    if getattr(context, "zone_id", None) == target_zone:
-        return True
-    if target_zone in set(getattr(context, "zone_set", ()) or ()):
-        return True
-    for zone_perm in getattr(context, "zone_perms", ()) or ():
-        if isinstance(zone_perm, (list, tuple)) and zone_perm and zone_perm[0] == target_zone:
-            return True
-    return False
-
-
-def _context_for_target_zone(context: Any, target_zone: str | None) -> Any:
-    if target_zone is None or getattr(context, "zone_id", None) == target_zone:
-        return context
-    if not _context_allows_target_zone(context, target_zone):
-        return context
-    updates: dict[str, Any] = {"zone_id": target_zone}
-    if getattr(context, "is_admin", False):
-        updates["zone_set"] = (target_zone,)
-        updates["zone_perms"] = ((target_zone, "rw"),)
-    for key, value in updates.items():
-        setattr(context, key, value)
-    return context
 
 
 @router.post("/api/nfs/{method}")
@@ -157,7 +130,7 @@ async def rpc_endpoint(
             scope_params_for_zone(_params_ns, context.zone_id)
             raw_params = vars(_params_ns)
             target_zone = target_zone_for_context(context, raw_params)
-            context = _context_for_target_zone(context, target_zone)
+            context = context_for_target_zone(context, target_zone)
             state = request.app.state
 
             # #4005 round-5: NO early 304 in the kernel branch.
@@ -263,7 +236,7 @@ async def rpc_endpoint(
         # Dispatch method
         _dispatch_start = _time.time()
         target_zone = target_zone_for_context(context, params)
-        context = _context_for_target_zone(context, target_zone)
+        context = context_for_target_zone(context, target_zone)
 
         async def _work() -> Any:
             return await dispatch_method(

--- a/src/nexus/server/api/core/rpc.py
+++ b/src/nexus/server/api/core/rpc.py
@@ -23,6 +23,7 @@ from nexus.contracts.exceptions import (
 from nexus.core.hash_fast import hash_content
 from nexus.lib.rpc_codec import decode_rpc_message, encode_rpc_message
 from nexus.lib.zone_scoping import ZoneScopingError, scope_params_for_zone
+from nexus.runtime.zone_resolution import target_zone_for_context
 from nexus.server.dependencies import require_auth
 from nexus.server.protocol import (
     RPCErrorCode,
@@ -30,6 +31,7 @@ from nexus.server.protocol import (
     parse_method_params,
 )
 from nexus.server.rate_limiting import RATE_LIMIT_AUTHENTICATED, limiter
+from nexus.server.zone_execution import run_zone_scoped
 
 logger = logging.getLogger(__name__)
 
@@ -127,6 +129,7 @@ async def rpc_endpoint(
             _params_ns = SimpleNamespace(**raw_params)
             scope_params_for_zone(_params_ns, context.zone_id)
             raw_params = vars(_params_ns)
+            target_zone = target_zone_for_context(context, raw_params)
             state = request.app.state
 
             # #4005 round-5: NO early 304 in the kernel branch.
@@ -138,12 +141,19 @@ async def rpc_endpoint(
             # succeed first, and matching ETags then suppress the body.
             if_none_match = request.headers.get("If-None-Match")
 
-            _dispatch_coro = dispatch_kernel_syscall(
-                state.nexus_fs,
-                method,
-                raw_params,
-                context,
-                subscription_manager=state.subscription_manager,
+            async def _work() -> Any:
+                return await dispatch_kernel_syscall(
+                    state.nexus_fs,
+                    method,
+                    raw_params,
+                    context,
+                    subscription_manager=state.subscription_manager,
+                )
+
+            _dispatch_coro = run_zone_scoped(
+                getattr(state, "zone_registry", None),
+                target_zone,
+                _work,
             )
             if method in _HTTP_TIMEOUT_SAFE_SYSCALLS:
                 _timeout = getattr(state, "operation_timeout", 30.0)
@@ -198,6 +208,7 @@ async def rpc_endpoint(
 
         # Scope paths for zone isolation (prefix with /zone/{zone_id}/)
         scope_params_for_zone(params, context.zone_id)
+        target_zone = target_zone_for_context(context, params)
 
         _setup_elapsed = (_time.time() - _rpc_start) * 1000 - _parse_elapsed
 
@@ -224,14 +235,22 @@ async def rpc_endpoint(
 
         # Dispatch method
         _dispatch_start = _time.time()
-        result = await dispatch_method(
-            method,
-            params,
-            context,
-            nexus_fs=state.nexus_fs,
-            exposed_methods=state.exposed_methods,
-            auth_provider=state.auth_provider,
-            subscription_manager=state.subscription_manager,
+
+        async def _work() -> Any:
+            return await dispatch_method(
+                method,
+                params,
+                context,
+                nexus_fs=state.nexus_fs,
+                exposed_methods=state.exposed_methods,
+                auth_provider=state.auth_provider,
+                subscription_manager=state.subscription_manager,
+            )
+
+        result = await run_zone_scoped(
+            getattr(state, "zone_registry", None),
+            target_zone,
+            _work,
         )
         _dispatch_elapsed = (_time.time() - _dispatch_start) * 1000
 

--- a/src/nexus/server/api/core/rpc.py
+++ b/src/nexus/server/api/core/rpc.py
@@ -208,7 +208,6 @@ async def rpc_endpoint(
 
         # Scope paths for zone isolation (prefix with /zone/{zone_id}/)
         scope_params_for_zone(params, context.zone_id)
-        target_zone = target_zone_for_context(context, params)
 
         _setup_elapsed = (_time.time() - _rpc_start) * 1000 - _parse_elapsed
 
@@ -235,6 +234,7 @@ async def rpc_endpoint(
 
         # Dispatch method
         _dispatch_start = _time.time()
+        target_zone = target_zone_for_context(context, params)
 
         async def _work() -> Any:
             return await dispatch_method(

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -615,10 +615,9 @@ class CopyBulkResponse(BaseModel):
 def create_async_files_router(
     nexus_fs: Any | None = None,
     get_fs: Any | None = None,
+    get_zone_registry: Any | None = None,
 ) -> APIRouter:
     """
-    Create a files router.
-
     Supports two modes:
     1. Direct: Pass nexus_fs instance (for testing)
     2. Lazy: Pass get_fs callable that returns the instance at request time
@@ -627,7 +626,6 @@ def create_async_files_router(
     Args:
         nexus_fs: Initialized NexusFS instance (direct mode)
         get_fs: Callable returning NexusFS (lazy mode)
-
     Returns:
         FastAPI router with file endpoints
     """
@@ -652,6 +650,9 @@ def create_async_files_router(
             status_code=503,
             detail="NexusFS not initialized. Server may still be starting up.",
         )
+
+    def _get_zone_registry() -> Any | None:
+        return get_zone_registry() if get_zone_registry is not None else None
 
     async def get_context(
         auth_result: dict[str, Any] | None = Depends(get_auth_result),

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -1,27 +1,7 @@
 """File Operations REST API endpoints (Phase 4).
 
-Provides file operations using NexusFS via asyncio.to_thread():
-- POST   /write           - Write file content
-- GET    /read            - Read file content
-- DELETE /delete          - Delete file
-- GET    /exists          - Check file existence
-- GET    /list            - List directory contents
-- POST   /mkdir           - Create directory
-- GET    /metadata        - Get file metadata
-- POST   /batch-read      - Batch read multiple files (legacy, lenient)
-- POST   /batch/write     - Atomic batch write (Issue #3700)
-- POST   /batch/read      - Atomic batch read with optional partial mode (Issue #3700)
-- GET    /stream          - Stream file content
-- POST   /rename          - Rename/move file
-- POST   /copy            - Copy file
-- POST   /rename-batch     - Bulk rename/move files
-- POST   /copy-bulk       - Bulk copy files
-- GET    /glob            - Glob pattern search across files
-- GET    /grep            - Regex pattern search within files
-
-Async NexusFS methods (read, write, sys_stat, sys_readdir, sys_unlink,
-access, mkdir) are awaited directly. Sync methods (read_bulk,
-stream, write_stream) use asyncio.to_thread() for thread offloading.
+Provides direct NexusFS-backed REST endpoints for read, write, list,
+metadata, batch file operations, streaming, rename/copy, glob, and grep.
 All operations pass user context for permission enforcement.
 """
 
@@ -30,8 +10,8 @@ import base64
 import functools
 import json
 import logging
-from collections.abc import AsyncIterator, Iterator
-from typing import Any, cast
+from collections.abc import Awaitable, Callable, Iterator
+from typing import Any, TypeVar, cast
 
 from fastapi import APIRouter, Depends, HTTPException, Query, Request, status
 from fastapi.responses import Response, StreamingResponse
@@ -49,13 +29,15 @@ from nexus.contracts.exceptions import (
     NexusPermissionError,
 )
 from nexus.core.path_utils import validate_path as _normalize_path
+from nexus.runtime.zone_resolution import (
+    target_zone_for_context,
+    zone_from_path,
+    zones_from_params,
+)
+from nexus.server.zone_execution import run_zone_scoped
 
 logger = logging.getLogger(__name__)
-
-
-# =============================================================================
-# Zone gate helper (#3785)
-# =============================================================================
+T = TypeVar("T")
 
 
 def _gate_zone(
@@ -123,11 +105,6 @@ def _apply_zone_override(
     if zone is None:
         return context
     return _dc.replace(context, zone_id=zone)
-
-
-# =============================================================================
-# Helpers
-# =============================================================================
 
 
 async def _read_connector_by_physical_path(
@@ -245,6 +222,12 @@ def _metadata_timestamp(meta: Any, name: str) -> str | None:
     return str(value)
 
 
+async def _maybe_await(value: Any) -> Any:
+    if hasattr(value, "__await__"):
+        return await value
+    return value
+
+
 def _encode_read_payload(
     raw: str | bytes,
     encoding: str | None,
@@ -278,11 +261,6 @@ def _to_metadata_response(meta: Any, fallback_path: str) -> "MetadataResponse":
         created_at=_metadata_timestamp(meta, "created_at"),
         modified_at=_metadata_timestamp(meta, "modified_at"),
     )
-
-
-# =============================================================================
-# Request/Response Models
-# =============================================================================
 
 
 class WriteRequest(BaseModel):
@@ -411,10 +389,6 @@ class BatchReadRequest(BaseModel):
 
     paths: list[str] = Field(..., description="List of paths to read")
 
-
-# ---------------------------------------------------------------------------
-# Batch write/read models (Issue #3700)
-# ---------------------------------------------------------------------------
 
 _MAX_BATCH_FILES = 500
 _MAX_BATCH_TOTAL_BYTES = 100 * 1024 * 1024  # 100 MB
@@ -607,11 +581,6 @@ class CopyBulkResponse(BaseModel):
     results: list[BulkCopyResult]
 
 
-# =============================================================================
-# Router Factory
-# =============================================================================
-
-
 def create_async_files_router(
     nexus_fs: Any | None = None,
     get_fs: Any | None = None,
@@ -654,6 +623,22 @@ def create_async_files_router(
     def _get_zone_registry() -> Any | None:
         return get_zone_registry() if get_zone_registry is not None else None
 
+    async def _run_for_context(
+        context: Any,
+        params: Any,
+        work: Callable[[], Awaitable[T]],
+    ) -> T:
+        zones = zones_from_params(params)
+        if len(zones) > 1:
+            raise HTTPException(
+                status_code=400,
+                detail="Mixed-zone operations must be submitted per zone",
+            )
+        target_zone = target_zone_for_context(context, params)
+        if target_zone is None and isinstance(params, str):
+            target_zone = zone_from_path(params)
+        return await run_zone_scoped(_get_zone_registry(), target_zone, work)
+
     async def get_context(
         auth_result: dict[str, Any] | None = Depends(get_auth_result),
     ) -> Any:
@@ -661,10 +646,6 @@ def create_async_files_router(
         if auth_result is None or not auth_result.get("authenticated"):
             raise HTTPException(status_code=401, detail="Authentication required")
         return get_operation_context(auth_result)
-
-    # =============================================================================
-    # Write Endpoint
-    # =============================================================================
 
     @router.post("/write", response_model=WriteResponse)
     async def write_file(
@@ -692,85 +673,90 @@ def create_async_files_router(
         """
         context = _apply_zone_override(context, zone, auth_result, required_perm="w")
         try:
-            fs = await _get_fs()
 
-            # Snapshot tracking setup: validate conflict + capture original state BEFORE write
-            _ss = None
-            _norm_path: str | None = None
-            _original_hash: str | None = None
-            _original_metadata: dict[str, Any] | None = None
-            if transaction_id:
-                _ss = fs.service("snapshot_service") if hasattr(fs, "service") else None
-                if _ss is not None:
-                    _norm_path = _normalize_path(request.path)
-                    _ss.validate_path_available(transaction_id, _norm_path)
-                    # Capture original state for rollback
-                    try:
-                        _orig_meta = fs._kernel.get(_norm_path)
-                        if _orig_meta:
-                            _original_hash = _orig_meta.content_id
-                            _original_metadata = {
-                                "size": _orig_meta.size,
-                                "version": _orig_meta.version,
-                                "modified_at": _orig_meta.modified_at.isoformat()
-                                if _orig_meta.modified_at
-                                else None,
-                                "backend_name": getattr(_orig_meta, "backend_name", None),
-                            }
-                    except Exception:
-                        _original_hash = None
+            async def _work() -> Any:
+                fs = await _get_fs()
+
+                # Snapshot tracking setup: validate conflict + capture original state BEFORE write
+                _ss = None
+                _norm_path: str | None = None
+                _original_hash: str | None = None
+                _original_metadata: dict[str, Any] | None = None
+                if transaction_id:
+                    _ss = fs.service("snapshot_service") if hasattr(fs, "service") else None
+                    if _ss is not None:
+                        _norm_path = _normalize_path(request.path)
+                        _ss.validate_path_available(transaction_id, _norm_path)
+                        # Capture original state for rollback
+                        try:
+                            _orig_meta = fs._kernel.get(_norm_path)
+                            if _orig_meta:
+                                _original_hash = _orig_meta.content_id
+                                _original_metadata = {
+                                    "size": _orig_meta.size,
+                                    "version": _orig_meta.version,
+                                    "modified_at": _orig_meta.modified_at.isoformat()
+                                    if _orig_meta.modified_at
+                                    else None,
+                                    "backend_name": getattr(_orig_meta, "backend_name", None),
+                                }
+                        except Exception:
+                            _original_hash = None
+                    else:
+                        logger.warning(
+                            "txn track: snapshot_service unavailable, skipping txn=%s",
+                            transaction_id,
+                        )
+
+                # Decode content based on encoding
+                if request.encoding == "base64":
+                    content = base64.b64decode(request.content)
                 else:
-                    logger.warning(
-                        "txn track: snapshot_service unavailable, skipping txn=%s", transaction_id
-                    )
+                    content = request.content.encode("utf-8")
 
-            # Decode content based on encoding
-            if request.encoding == "base64":
-                content = base64.b64decode(request.content)
-            else:
-                content = request.content.encode("utf-8")
+                # Build write kwargs with optional write_mode (Issue #2929)
+                write_kwargs: dict[str, Any] = {
+                    "path": request.path,
+                    "buf": content,
+                    "context": context,
+                }
+                # fs.write is async — call directly
+                result = fs.write(**write_kwargs)
 
-            # Build write kwargs with optional write_mode (Issue #2929)
-            write_kwargs: dict[str, Any] = {
-                "path": request.path,
-                "buf": content,
-                "context": context,
-            }
-            # fs.write is async — call directly
-            result = fs.write(**write_kwargs)
+                # Track write in transaction AFTER successful write.
+                # Skip if _write_internal already tracked it (path already in registry).
+                if (
+                    _ss is not None
+                    and _norm_path is not None
+                    and _ss._registry.get_transaction_for_path(_norm_path) != transaction_id
+                ):
+                    try:
+                        _ss.track_write(
+                            transaction_id=transaction_id,
+                            path=_norm_path,
+                            original_hash=_original_hash,
+                            original_metadata=_original_metadata,
+                            new_hash=result.get("content_id"),
+                        )
+                        logger.info("txn tracked write: txn=%s path=%s", transaction_id, _norm_path)
+                    except Exception as _track_err:
+                        logger.warning("txn track write failed: %s", _track_err)
 
-            # Track write in transaction AFTER successful write.
-            # Skip if _write_internal already tracked it (path already in registry).
-            if (
-                _ss is not None
-                and _norm_path is not None
-                and _ss._registry.get_transaction_for_path(_norm_path) != transaction_id
-            ):
-                try:
-                    _ss.track_write(
-                        transaction_id=transaction_id,
-                        path=_norm_path,
-                        original_hash=_original_hash,
-                        original_metadata=_original_metadata,
-                        new_hash=result.get("content_id"),
-                    )
-                    logger.info("txn tracked write: txn=%s path=%s", transaction_id, _norm_path)
-                except Exception as _track_err:
-                    logger.warning("txn track write failed: %s", _track_err)
+                modified = result["modified_at"]
+                if hasattr(modified, "isoformat"):
+                    modified = modified.isoformat()
+                response_data = WriteResponse(
+                    content_id=result["content_id"],
+                    version=result["version"],
+                    size=result["size"],
+                    modified_at=str(modified),
+                )
+                return Response(
+                    content=response_data.model_dump_json(),
+                    media_type="application/json",
+                )
 
-            modified = result["modified_at"]
-            if hasattr(modified, "isoformat"):
-                modified = modified.isoformat()
-            response_data = WriteResponse(
-                content_id=result["content_id"],
-                version=result["version"],
-                size=result["size"],
-                modified_at=str(modified),
-            )
-            return Response(
-                content=response_data.model_dump_json(),
-                media_type="application/json",
-            )
+            return await _run_for_context(context, {"path": request.path, "zone": zone}, _work)
 
         except HTTPException:
             raise
@@ -787,10 +773,6 @@ def create_async_files_router(
         except Exception as e:
             logger.exception(f"Write error: {e}")
             raise HTTPException(status_code=500, detail=str(e)) from e
-
-    # =============================================================================
-    # Read Endpoint
-    # =============================================================================
 
     @router.get("/read", response_model=ReadResponse)
     async def read_file(
@@ -850,252 +832,300 @@ def create_async_files_router(
         if encoding in ("utf8", "utf-8"):
             encoding = None
         try:
-            fs = await _get_fs()
 
-            # Fast path: content-hash (content_id) lookup — used by the diff viewer
-            # to retrieve a historical snapshot stored in CAS.
-            if version:
-                if not transaction_id:
-                    raise HTTPException(
-                        status_code=400,
-                        detail="transaction_id is required when version is specified",
-                    )
-                # --- Zone-ownership check (mirrors snapshots router) ---
-                _snap_svc = getattr(request.app.state, "transactional_snapshot_service", None)
-                if _snap_svc is None:
-                    _snap_svc = getattr(fs, "_snapshot_service", None)
-                if _snap_svc is None:
-                    raise HTTPException(status_code=503, detail="Snapshot service not available")
-                from nexus.contracts.constants import ROOT_ZONE_ID as _ROOT_ZONE_ID
+            async def _work() -> Any:
+                fs = await _get_fs()
 
-                _caller_zone = getattr(context, "zone_id", None) or _ROOT_ZONE_ID
-                _txn_info = await _snap_svc.get_transaction(transaction_id)
-                if _txn_info is None or _txn_info.zone_id != _caller_zone:
-                    raise HTTPException(
-                        status_code=404, detail=f"Transaction not found: {transaction_id}"
-                    )
-                # --- Validate hash belongs to path in this transaction ---
-                _entries = await _snap_svc.list_entries(transaction_id)
-                _matched_entry: Any = None
-                _matched_side: str | None = None  # "original" or "new"
-                for _e in _entries:
-                    if _e.path != path:
-                        continue
-                    if _e.original_hash == version:
-                        _matched_entry, _matched_side = _e, "original"
-                        break
-                    if _e.new_hash == version:
-                        _matched_entry, _matched_side = _e, "new"
-                        break
-                if _matched_entry is None:
-                    raise HTTPException(
-                        status_code=403,
-                        detail=f"version is not recorded for this path in transaction {transaction_id!r}",
-                    )
-                # --- Enforce standard read authorization via the VFS path ---
-                # For *delete* entries the live path no longer exists, so
-                # ``fs.access`` would reject every historical read of a
-                # deleted snapshot — even though the bytes are still in
-                # CAS. Skipping ``access`` would also drop the file-level
-                # READ ACL gate (the only place that runs READ permission
-                # hooks for that path), so a caller who never had file
-                # READ permission could otherwise recover deleted content
-                # via the snapshot endpoint (Issue #3989, codex r10).
-                # Compromise: keep the carve-out only for admins, who are
-                # the intended rollback consumers. Regular callers must
-                # use a write-side snapshot or get a 404 for the
-                # missing live path.
-                _entry_op = getattr(_matched_entry, "operation", None)
-                _is_admin = bool(getattr(context, "is_admin", False))
-                _skip_access = _entry_op == "delete" and _is_admin
-                if not _skip_access:
-                    try:
-                        _accessible = fs.access(path, context=context)
-                    except NexusPermissionError as e:
-                        raise HTTPException(status_code=403, detail=str(e)) from e
-                    if not _accessible:
-                        raise NexusFileNotFoundError(path)
-                _py_kernel = getattr(fs, "_kernel", None)
-                if _py_kernel is None:
-                    raise NexusFileNotFoundError(f"{path} (version {version})")
+                # Fast path: content-hash (content_id) lookup — used by the diff viewer
+                # to retrieve a historical snapshot stored in CAS.
+                if version:
+                    if not transaction_id:
+                        raise HTTPException(
+                            status_code=400,
+                            detail="transaction_id is required when version is specified",
+                        )
+                    # --- Zone-ownership check (mirrors snapshots router) ---
+                    _snap_svc = getattr(request.app.state, "transactional_snapshot_service", None)
+                    if _snap_svc is None:
+                        _snap_svc = getattr(fs, "_snapshot_service", None)
+                    if _snap_svc is None:
+                        raise HTTPException(
+                            status_code=503, detail="Snapshot service not available"
+                        )
+                    from nexus.contracts.constants import ROOT_ZONE_ID as _ROOT_ZONE_ID
 
-                # Use the validated caller zone for all kernel calls — the
-                # snapshot/transaction check above already proved the caller
-                # is authorized for this zone. Hard-coding "root" would route
-                # the read through the wrong mount table for non-root zones
-                # and turn this into a privilege-escalation TOCTOU window
-                # (Issue #3989, codex r3).
-                _caller_zone_kernel = _caller_zone or "root"
-
-                # Resolve the mount that owns ``path`` so we can issue a real
-                # content-addressed read via the Rust kernel. Longest-prefix
-                # match against the caller's visible mount table; the root
-                # mount ("/") is always a valid candidate so files under a
-                # root-only deployment still take the cas_read path.
-                _mount_point: str | None = None
-                try:
-                    _mount_entries = fs.list_mounts(context=context)
-                    _candidates = sorted(
-                        (m["mount_point"] for m in _mount_entries if m.get("mount_point")),
-                        key=len,
-                        reverse=True,
-                    )
-                    for _mp in _candidates:
-                        _mp_norm = _mp.rstrip("/") or "/"
-                        # Root mount matches every absolute path; non-root
-                        # mounts match only if ``path`` equals the mount or
-                        # is a descendant. Without the root special-case,
-                        # production deployments that mount at ``/`` would
-                        # silently skip cas_read for every historical read
-                        # (Issue #3989, codex r4).
-                        if _mp_norm == "/" or path == _mp_norm or path.startswith(_mp_norm + "/"):
-                            _mount_point = _mp_norm
+                    _caller_zone = getattr(context, "zone_id", None) or _ROOT_ZONE_ID
+                    _txn_info = await _snap_svc.get_transaction(transaction_id)
+                    if _txn_info is None or _txn_info.zone_id != _caller_zone:
+                        raise HTTPException(
+                            status_code=404, detail=f"Transaction not found: {transaction_id}"
+                        )
+                    # --- Validate hash belongs to path in this transaction ---
+                    _entries = await _snap_svc.list_entries(transaction_id)
+                    _matched_entry: Any = None
+                    _matched_side: str | None = None  # "original" or "new"
+                    for _e in _entries:
+                        if _e.path != path:
+                            continue
+                        if _e.original_hash == version:
+                            _matched_entry, _matched_side = _e, "original"
                             break
-                except Exception:
-                    _mount_point = None
-
-                # Historical reads are CAS-only. ``cas_read`` keys the
-                # lookup by ``content_id`` at the backend, which is the
-                # only safe way to bind the returned bytes to the
-                # requested ``version`` — including for CDC-chunked
-                # content where reassembled-byte hash != manifest hash.
-                # A live-path fallback ``sys_read_raw`` was tempting for
-                # the "live cid == version" case, but is unsound under an
-                # ABA race (writer flips A→B→A between pre-stat and
-                # read; we'd serve B labeled as A). When cas_read fails
-                # we return 410 — the backend either lacks CAS or has
-                # GC'd the revision (Issue #3989, codex r5).
-                if _mount_point is None or not hasattr(_py_kernel, "cas_read"):
-                    raise HTTPException(
-                        status_code=422,
-                        detail=(
-                            f"Historical version reads require a CAS-capable mount; "
-                            f"no such mount resolved for {path!r}."
-                        ),
-                    )
-
-                # Plumb federation origin hints into ``cas_read`` so chunked
-                # manifests whose blocks live on a peer node (replication
-                # window not yet closed, or peer-only origin) can still
-                # scatter-gather. The hash we're reading was either captured
-                # *before* the in-flight transaction (``original_hash``) or
-                # produced *by* it (``new_hash``); a different node may own
-                # each side, so we collect both candidates:
-                #
-                # 1. If the entry's serialized ``original_metadata`` carries
-                #    a writer address (from the pre-write snapshot), prefer
-                #    it for ``original_hash`` reads — that's the node that
-                #    last produced the *recorded* bytes.
-                # 2. The path's current ``last_writer_address`` is appended
-                #    as a fallback. For ``new_hash`` (post-write) it is the
-                #    direct producer; for ``original_hash`` it is still a
-                #    plausible peer if replication has fanned out at all.
-                #
-                # Origin hints affect *fetch reachability* only — every
-                # fetched chunk is BLAKE3-verified before composition, so
-                # stale/wrong/duplicate addresses can never cause us to
-                # serve corrupt bytes (Issue #3989, codex r6/r7).
-                _origins: list[str] = []
-
-                def _push_origin(addr: object) -> None:
-                    if not isinstance(addr, str):
-                        return
-                    s = addr.strip()
-                    if s and s not in _origins:
-                        _origins.append(s)
-
-                if _matched_side == "original":
-                    _orig_meta_raw = getattr(_matched_entry, "original_metadata", None)
-                    if isinstance(_orig_meta_raw, str) and _orig_meta_raw:
+                        if _e.new_hash == version:
+                            _matched_entry, _matched_side = _e, "new"
+                            break
+                    if _matched_entry is None:
+                        raise HTTPException(
+                            status_code=403,
+                            detail=f"version is not recorded for this path in transaction {transaction_id!r}",
+                        )
+                    # --- Enforce standard read authorization via the VFS path ---
+                    # For *delete* entries the live path no longer exists, so
+                    # ``fs.access`` would reject every historical read of a
+                    # deleted snapshot — even though the bytes are still in
+                    # CAS. Skipping ``access`` would also drop the file-level
+                    # READ ACL gate (the only place that runs READ permission
+                    # hooks for that path), so a caller who never had file
+                    # READ permission could otherwise recover deleted content
+                    # via the snapshot endpoint (Issue #3989, codex r10).
+                    # Compromise: keep the carve-out only for admins, who are
+                    # the intended rollback consumers. Regular callers must
+                    # use a write-side snapshot or get a 404 for the
+                    # missing live path.
+                    _entry_op = getattr(_matched_entry, "operation", None)
+                    _is_admin = bool(getattr(context, "is_admin", False))
+                    _skip_access = _entry_op == "delete" and _is_admin
+                    if not _skip_access:
                         try:
-                            _orig_meta = json.loads(_orig_meta_raw)
-                        except (TypeError, ValueError):
+                            _accessible = fs.access(path, context=context)
+                        except NexusPermissionError as e:
+                            raise HTTPException(status_code=403, detail=str(e)) from e
+                        if not _accessible:
+                            raise NexusFileNotFoundError(path)
+                    _py_kernel = getattr(fs, "_kernel", None)
+                    if _py_kernel is None:
+                        raise NexusFileNotFoundError(f"{path} (version {version})")
+
+                    # Use the validated caller zone for all kernel calls — the
+                    # snapshot/transaction check above already proved the caller
+                    # is authorized for this zone. Hard-coding "root" would route
+                    # the read through the wrong mount table for non-root zones
+                    # and turn this into a privilege-escalation TOCTOU window
+                    # (Issue #3989, codex r3).
+                    _caller_zone_kernel = _caller_zone or "root"
+
+                    # Resolve the mount that owns ``path`` so we can issue a real
+                    # content-addressed read via the Rust kernel. Longest-prefix
+                    # match against the caller's visible mount table; the root
+                    # mount ("/") is always a valid candidate so files under a
+                    # root-only deployment still take the cas_read path.
+                    _mount_point: str | None = None
+                    try:
+                        _mount_entries = fs.list_mounts(context=context)
+                        _candidates = sorted(
+                            (m["mount_point"] for m in _mount_entries if m.get("mount_point")),
+                            key=len,
+                            reverse=True,
+                        )
+                        for _mp in _candidates:
+                            _mp_norm = _mp.rstrip("/") or "/"
+                            # Root mount matches every absolute path; non-root
+                            # mounts match only if ``path`` equals the mount or
+                            # is a descendant. Without the root special-case,
+                            # production deployments that mount at ``/`` would
+                            # silently skip cas_read for every historical read
+                            # (Issue #3989, codex r4).
+                            if (
+                                _mp_norm == "/"
+                                or path == _mp_norm
+                                or path.startswith(_mp_norm + "/")
+                            ):
+                                _mount_point = _mp_norm
+                                break
+                    except Exception:
+                        _mount_point = None
+
+                    # Historical reads are CAS-only. ``cas_read`` keys the
+                    # lookup by ``content_id`` at the backend, which is the
+                    # only safe way to bind the returned bytes to the
+                    # requested ``version`` — including for CDC-chunked
+                    # content where reassembled-byte hash != manifest hash.
+                    # A live-path fallback ``sys_read_raw`` was tempting for
+                    # the "live cid == version" case, but is unsound under an
+                    # ABA race (writer flips A→B→A between pre-stat and
+                    # read; we'd serve B labeled as A). When cas_read fails
+                    # we return 410 — the backend either lacks CAS or has
+                    # GC'd the revision (Issue #3989, codex r5).
+                    if _mount_point is None or not hasattr(_py_kernel, "cas_read"):
+                        raise HTTPException(
+                            status_code=422,
+                            detail=(
+                                f"Historical version reads require a CAS-capable mount; "
+                                f"no such mount resolved for {path!r}."
+                            ),
+                        )
+
+                    # Plumb federation origin hints into ``cas_read`` so chunked
+                    # manifests whose blocks live on a peer node (replication
+                    # window not yet closed, or peer-only origin) can still
+                    # scatter-gather. The hash we're reading was either captured
+                    # *before* the in-flight transaction (``original_hash``) or
+                    # produced *by* it (``new_hash``); a different node may own
+                    # each side, so we collect both candidates:
+                    #
+                    # 1. If the entry's serialized ``original_metadata`` carries
+                    #    a writer address (from the pre-write snapshot), prefer
+                    #    it for ``original_hash`` reads — that's the node that
+                    #    last produced the *recorded* bytes.
+                    # 2. The path's current ``last_writer_address`` is appended
+                    #    as a fallback. For ``new_hash`` (post-write) it is the
+                    #    direct producer; for ``original_hash`` it is still a
+                    #    plausible peer if replication has fanned out at all.
+                    #
+                    # Origin hints affect *fetch reachability* only — every
+                    # fetched chunk is BLAKE3-verified before composition, so
+                    # stale/wrong/duplicate addresses can never cause us to
+                    # serve corrupt bytes (Issue #3989, codex r6/r7).
+                    _origins: list[str] = []
+
+                    def _push_origin(addr: object) -> None:
+                        if not isinstance(addr, str):
+                            return
+                        s = addr.strip()
+                        if s and s not in _origins:
+                            _origins.append(s)
+
+                    if _matched_side == "original":
+                        _orig_meta_raw = getattr(_matched_entry, "original_metadata", None)
+                        if isinstance(_orig_meta_raw, str) and _orig_meta_raw:
+                            try:
+                                _orig_meta = json.loads(_orig_meta_raw)
+                            except (TypeError, ValueError):
+                                _orig_meta = None
+                        elif isinstance(_orig_meta_raw, dict):
+                            _orig_meta = _orig_meta_raw
+                        else:
                             _orig_meta = None
-                    elif isinstance(_orig_meta_raw, dict):
-                        _orig_meta = _orig_meta_raw
-                    else:
-                        _orig_meta = None
-                    if isinstance(_orig_meta, dict):
-                        _push_origin(_orig_meta.get("last_writer_address"))
-                        _push_origin(_orig_meta.get("writer_address"))
+                        if isinstance(_orig_meta, dict):
+                            _push_origin(_orig_meta.get("last_writer_address"))
+                            _push_origin(_orig_meta.get("writer_address"))
 
-                try:
-                    _stat = await asyncio.to_thread(fs.sys_stat, path, context=context)
-                    _push_origin((_stat or {}).get("last_writer_address"))
-                except Exception:
-                    pass
+                    try:
+                        _stat = await asyncio.to_thread(fs.sys_stat, path, context=context)
+                        _push_origin((_stat or {}).get("last_writer_address"))
+                    except Exception:
+                        pass
 
-                try:
-                    raw = await asyncio.to_thread(
-                        functools.partial(
-                            _py_kernel.cas_read,
+                    try:
+                        raw = await asyncio.to_thread(
+                            functools.partial(
+                                _py_kernel.cas_read,
+                                _mount_point,
+                                _caller_zone_kernel,
+                                version,
+                                origins=_origins,
+                            )
+                        )
+                    except Exception as cas_err:
+                        logger.debug(
+                            "cas_read(%s, %s, %s, origins=%s) failed: %s",
                             _mount_point,
                             _caller_zone_kernel,
                             version,
-                            origins=_origins,
+                            _origins,
+                            cas_err,
                         )
+                        raise HTTPException(
+                            status_code=410,
+                            detail=(
+                                f"Historical version {version!r} no longer retrievable at {path!r}: "
+                                "the backend lacks CAS support or this revision has been garbage collected."
+                            ),
+                        ) from cas_err
+
+                    content_v, enc_v = _encode_read_payload(raw, encoding)
+                    resp_v = ReadResponse(content=content_v, encoding=enc_v, content_id=version)
+                    return Response(
+                        content=resp_v.model_dump_json(),
+                        media_type="application/json",
+                        headers={"ETag": f'"{version}"'},
                     )
-                except Exception as cas_err:
-                    logger.debug(
-                        "cas_read(%s, %s, %s, origins=%s) failed: %s",
-                        _mount_point,
-                        _caller_zone_kernel,
-                        version,
-                        _origins,
-                        cas_err,
+
+                # Check If-None-Match header for caching
+                if_none_match = request.headers.get("If-None-Match")
+
+                # Get metadata first for ETag check
+                if if_none_match:
+                    meta = fs.sys_stat(path)
+                    if meta and meta.content_id:
+                        client_etag = if_none_match.strip('"')
+                        if client_etag == meta.content_id:
+                            return Response(
+                                status_code=304,
+                                headers={"ETag": f'"{meta.content_id}"'},
+                            )
+
+                # Issue #3266: For connector display paths (/mnt/*), resolve
+                # virtual_path → physical_path via search service and read
+                # directly from the connector backend. This avoids passing
+                # a backend-relative path into fs.read() which expects VFS paths.
+                connector_content: bytes | None = None
+                if path.startswith("/mnt/"):
+                    search = fs.service("search")
+                    if search is not None:
+                        resolve_fn = getattr(search, "resolve_physical_path", None)
+                        physical: str | None = resolve_fn(path) if resolve_fn else None
+                        if physical:
+                            connector_content = await _read_connector_by_physical_path(
+                                fs,
+                                path,
+                                physical,
+                                context,
+                            )
+
+                if connector_content is not None:
+                    # Connector fast path — apply section filtering before returning.
+                    if section and path.endswith(".md"):
+                        partial = _md_partial_read(fs, path, connector_content, section, block_type)
+                        if partial is not None:
+                            partial_str, partial_enc = _encode_read_payload(partial, encoding)
+                            return Response(
+                                content=ReadResponse(
+                                    content=partial_str, encoding=partial_enc
+                                ).model_dump_json(),
+                                media_type="application/json",
+                            )
+                    content_str, enc_str = _encode_read_payload(connector_content, encoding)
+                    if include_metadata:
+                        resp = ReadResponse(
+                            content=content_str,
+                            encoding=enc_str,
+                            content_id=None,
+                            version=None,
+                            modified_at=None,
+                            size=len(connector_content),
+                        )
+                    else:
+                        resp = ReadResponse(content=content_str, encoding=enc_str)
+                    return Response(
+                        content=resp.model_dump_json(),
+                        media_type="application/json",
                     )
-                    raise HTTPException(
-                        status_code=410,
-                        detail=(
-                            f"Historical version {version!r} no longer retrievable at {path!r}: "
-                            "the backend lacks CAS support or this revision has been garbage collected."
-                        ),
-                    ) from cas_err
 
-                content_v, enc_v = _encode_read_payload(raw, encoding)
-                resp_v = ReadResponse(content=content_v, encoding=enc_v, content_id=version)
-                return Response(
-                    content=resp_v.model_dump_json(),
-                    media_type="application/json",
-                    headers={"ETag": f'"{version}"'},
-                )
+                # Standard VFS read
+                result = fs.read(path, return_metadata=include_metadata, context=context)
 
-            # Check If-None-Match header for caching
-            if_none_match = request.headers.get("If-None-Match")
-
-            # Get metadata first for ETag check
-            if if_none_match:
-                meta = await asyncio.to_thread(fs.sys_stat, path)
-                if meta and meta.content_id:
-                    client_etag = if_none_match.strip('"')
-                    if client_etag == meta.content_id:
-                        return Response(
-                            status_code=304,
-                            headers={"ETag": f'"{meta.content_id}"'},
-                        )
-
-            # Issue #3266: For connector display paths (/mnt/*), resolve
-            # virtual_path → physical_path via search service and read
-            # directly from the connector backend. This avoids passing
-            # a backend-relative path into fs.read() which expects VFS paths.
-            connector_content: bytes | None = None
-            if path.startswith("/mnt/"):
-                search = fs.service("search")
-                if search is not None:
-                    resolve_fn = getattr(search, "resolve_physical_path", None)
-                    physical: str | None = resolve_fn(path) if resolve_fn else None
-                    if physical:
-                        connector_content = await _read_connector_by_physical_path(
-                            fs,
-                            path,
-                            physical,
-                            context,
-                        )
-
-            if connector_content is not None:
-                # Connector fast path — apply section filtering before returning.
+                # --- Markdown partial read (Issue #3718) ---
                 if section and path.endswith(".md"):
-                    partial = _md_partial_read(fs, path, connector_content, section, block_type)
+                    raw_content: bytes
+                    if include_metadata and isinstance(result, dict):
+                        _rc = result["content"]
+                        raw_content = _rc if isinstance(_rc, bytes) else _rc.encode("utf-8")
+                    elif isinstance(result, bytes):
+                        raw_content = result
+                    else:
+                        raw_content = str(result).encode("utf-8")
+
+                    partial = _md_partial_read(fs, path, raw_content, section, block_type)
                     if partial is not None:
                         partial_str, partial_enc = _encode_read_payload(partial, encoding)
                         return Response(
@@ -1104,81 +1134,43 @@ def create_async_files_router(
                             ).model_dump_json(),
                             media_type="application/json",
                         )
-                content_str, enc_str = _encode_read_payload(connector_content, encoding)
-                if include_metadata:
-                    resp = ReadResponse(
-                        content=content_str,
-                        encoding=enc_str,
-                        content_id=None,
-                        version=None,
-                        modified_at=None,
-                        size=len(connector_content),
+                    # Section explicitly requested but not found — don't leak full doc.
+                    # Any explicit section selector that returned None — don't leak full doc.
+                    raise HTTPException(
+                        status_code=404,
+                        detail=f"Section '{section}' not found in {path}",
+                    )
+
+                if include_metadata and isinstance(result, dict):
+                    raw_content_md = result["content"]
+                    file_content, enc_md = _encode_read_payload(raw_content_md, encoding)
+
+                    response_data = ReadResponse(
+                        content=file_content,
+                        encoding=enc_md,
+                        content_id=result.get("content_id"),
+                        version=result.get("version"),
+                        modified_at=result.get("modified_at"),
+                        size=result.get("size"),
+                    )
+                    etag_val = result.get("content_id")
+                    return Response(
+                        content=response_data.model_dump_json(),
+                        media_type="application/json",
+                        headers={"ETag": f'"{etag_val}"'} if etag_val else {},
                     )
                 else:
-                    resp = ReadResponse(content=content_str, encoding=enc_str)
-                return Response(
-                    content=resp.model_dump_json(),
-                    media_type="application/json",
-                )
-
-            # Standard VFS read
-            result = fs.read(path, return_metadata=include_metadata, context=context)
-
-            # --- Markdown partial read (Issue #3718) ---
-            if section and path.endswith(".md"):
-                raw_content: bytes
-                if include_metadata and isinstance(result, dict):
-                    _rc = result["content"]
-                    raw_content = _rc if isinstance(_rc, bytes) else _rc.encode("utf-8")
-                elif isinstance(result, bytes):
-                    raw_content = result
-                else:
-                    raw_content = str(result).encode("utf-8")
-
-                partial = _md_partial_read(fs, path, raw_content, section, block_type)
-                if partial is not None:
-                    partial_str, partial_enc = _encode_read_payload(partial, encoding)
+                    # Simple content response
+                    if isinstance(result, (str, bytes)):
+                        plain, enc_plain = _encode_read_payload(result, encoding)
+                    else:
+                        plain, enc_plain = _encode_read_payload(str(result), encoding)
                     return Response(
-                        content=ReadResponse(
-                            content=partial_str, encoding=partial_enc
-                        ).model_dump_json(),
+                        content=ReadResponse(content=plain, encoding=enc_plain).model_dump_json(),
                         media_type="application/json",
                     )
-                # Section explicitly requested but not found — don't leak full doc.
-                # Any explicit section selector that returned None — don't leak full doc.
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"Section '{section}' not found in {path}",
-                )
 
-            if include_metadata and isinstance(result, dict):
-                raw_content_md = result["content"]
-                file_content, enc_md = _encode_read_payload(raw_content_md, encoding)
-
-                response_data = ReadResponse(
-                    content=file_content,
-                    encoding=enc_md,
-                    content_id=result.get("content_id"),
-                    version=result.get("version"),
-                    modified_at=result.get("modified_at"),
-                    size=result.get("size"),
-                )
-                etag_val = result.get("content_id")
-                return Response(
-                    content=response_data.model_dump_json(),
-                    media_type="application/json",
-                    headers={"ETag": f'"{etag_val}"'} if etag_val else {},
-                )
-            else:
-                # Simple content response
-                if isinstance(result, (str, bytes)):
-                    plain, enc_plain = _encode_read_payload(result, encoding)
-                else:
-                    plain, enc_plain = _encode_read_payload(str(result), encoding)
-                return Response(
-                    content=ReadResponse(content=plain, encoding=enc_plain).model_dump_json(),
-                    media_type="application/json",
-                )
+            return await _run_for_context(context, {"path": path, "zone": zone}, _work)
 
         except HTTPException:
             # Preserve explicit HTTP status codes (e.g., 400 transaction_id
@@ -1198,10 +1190,6 @@ def create_async_files_router(
             logger.exception(f"Read error: {e}")
             raise HTTPException(status_code=500, detail=str(e)) from e
 
-    # =============================================================================
-    # Markdown Structure Endpoint (Issue #3718)
-    # =============================================================================
-
     @router.get("/md-structure")
     async def md_structure(
         path: str = Query(..., description="Path to a markdown file"),
@@ -1213,30 +1201,30 @@ def create_async_files_router(
         ``GET /read?section=...&block_type=...``.
         """
         try:
-            fs = await _get_fs()
-            # Permission gate + content fetch for lazy index rebuild.
-            accessible = await fs.access(path, context=context)
-            if not accessible:
-                raise NexusFileNotFoundError(path)
-            raw = await fs.read(path, context=context)
-            content = (
-                raw
-                if isinstance(raw, bytes)
-                else (raw["content"] if isinstance(raw, dict) else str(raw).encode("utf-8"))
-            )
-            if isinstance(content, str):
-                content = content.encode("utf-8")
-            content_id = _md_get_content_id(fs, path)
-            listing = _md_get_listing(fs, path, content=content, content_id=content_id)
-            if listing is None:
-                raise HTTPException(
-                    status_code=404,
-                    detail=f"No markdown structure available for {path}",
+
+            async def _work() -> Response:
+                fs = await _get_fs()
+                accessible = await fs.access(path, context=context)
+                if not accessible:
+                    raise NexusFileNotFoundError(path)
+                raw = await fs.read(path, context=context)
+                content = (
+                    raw
+                    if isinstance(raw, bytes)
+                    else (raw["content"] if isinstance(raw, dict) else str(raw).encode("utf-8"))
                 )
-            return Response(
-                content=json.dumps(listing),
-                media_type="application/json",
-            )
+                if isinstance(content, str):
+                    content = content.encode("utf-8")
+                content_id = _md_get_content_id(fs, path)
+                listing = _md_get_listing(fs, path, content=content, content_id=content_id)
+                if listing is None:
+                    raise HTTPException(
+                        status_code=404,
+                        detail=f"No markdown structure available for {path}",
+                    )
+                return Response(content=json.dumps(listing), media_type="application/json")
+
+            return await _run_for_context(context, {"path": path}, _work)
         except HTTPException:
             raise
         except NexusPermissionError as e:
@@ -1300,10 +1288,6 @@ def create_async_files_router(
             logger.debug("md structure listing failed for %s", path, exc_info=True)
             return None
 
-    # =============================================================================
-    # Delete Endpoint
-    # =============================================================================
-
     @router.delete("/delete", response_model=DeleteResponse)
     async def delete_file(
         path: str = Query(..., description="Path to delete"),
@@ -1321,50 +1305,54 @@ def create_async_files_router(
         """Delete a file."""
         context = _apply_zone_override(context, zone, auth_result, required_perm="w")
         try:
-            fs = await _get_fs()
 
-            _ss = None
-            _norm_path: str | None = None
-            _original_hash: str | None = None
-            _original_metadata: dict[str, Any] | None = None
-            if transaction_id:
-                _ss = fs.service("snapshot_service") if hasattr(fs, "service") else None
-                if _ss is not None:
-                    _norm_path = _normalize_path(path)
-                    _ss.validate_path_available(transaction_id, _norm_path)
+            async def _work() -> DeleteResponse:
+                fs = await _get_fs()
+
+                _ss = None
+                _norm_path: str | None = None
+                _original_hash: str | None = None
+                _original_metadata: dict[str, Any] | None = None
+                if transaction_id:
+                    _ss = fs.service("snapshot_service") if hasattr(fs, "service") else None
+                    if _ss is not None:
+                        _norm_path = _normalize_path(path)
+                        _ss.validate_path_available(transaction_id, _norm_path)
+                        try:
+                            _orig_meta = fs._kernel.get(_norm_path)
+                            if _orig_meta:
+                                _original_hash = _orig_meta.content_id
+                                _original_metadata = {
+                                    "size": _orig_meta.size,
+                                    "version": _orig_meta.version,
+                                    "modified_at": _orig_meta.modified_at.isoformat()
+                                    if _orig_meta.modified_at
+                                    else None,
+                                    "backend_name": getattr(_orig_meta, "backend_name", None),
+                                }
+                        except Exception:
+                            _original_hash = None
+
+                fs.sys_unlink(path, context=context)
+
+                if (
+                    _ss is not None
+                    and _norm_path is not None
+                    and _ss._registry.get_transaction_for_path(_norm_path) != transaction_id
+                ):
                     try:
-                        _orig_meta = fs._kernel.get(_norm_path)
-                        if _orig_meta:
-                            _original_hash = _orig_meta.content_id
-                            _original_metadata = {
-                                "size": _orig_meta.size,
-                                "version": _orig_meta.version,
-                                "modified_at": _orig_meta.modified_at.isoformat()
-                                if _orig_meta.modified_at
-                                else None,
-                                "backend_name": getattr(_orig_meta, "backend_name", None),
-                            }
-                    except Exception:
-                        _original_hash = None
+                        _ss.track_delete(
+                            transaction_id=transaction_id,
+                            path=_norm_path,
+                            original_hash=_original_hash,
+                            original_metadata=_original_metadata,
+                        )
+                    except Exception as _track_err:
+                        logger.warning("txn track delete failed: %s", _track_err)
 
-            await asyncio.to_thread(fs.sys_unlink, path, context=context)
+                return DeleteResponse(deleted=True, path=path)
 
-            if (
-                _ss is not None
-                and _norm_path is not None
-                and _ss._registry.get_transaction_for_path(_norm_path) != transaction_id
-            ):
-                try:
-                    _ss.track_delete(
-                        transaction_id=transaction_id,
-                        path=_norm_path,
-                        original_hash=_original_hash,
-                        original_metadata=_original_metadata,
-                    )
-                except Exception as _track_err:
-                    logger.warning("txn track delete failed: %s", _track_err)
-
-            return DeleteResponse(deleted=True, path=path)
+            return await _run_for_context(context, {"path": path, "zone": zone}, _work)
 
         except NexusPermissionError as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
@@ -1377,10 +1365,6 @@ def create_async_files_router(
         except Exception as e:
             logger.exception(f"Delete error: {e}")
             raise HTTPException(status_code=500, detail=str(e)) from e
-
-    # =============================================================================
-    # Exists Endpoint
-    # =============================================================================
 
     @router.get("/exists", response_model=ExistsResponse)
     async def file_exists(
@@ -1395,9 +1379,13 @@ def create_async_files_router(
         """Check if a file or directory exists."""
         context = _apply_zone_override(context, zone, auth_result)
         try:
-            fs = await _get_fs()
-            exists = fs.access(path, context=context)
-            return ExistsResponse(exists=exists)
+
+            async def _work() -> ExistsResponse:
+                fs = await _get_fs()
+                exists = fs.access(path, context=context)
+                return ExistsResponse(exists=exists)
+
+            return await _run_for_context(context, {"path": path, "zone": zone}, _work)
 
         except NexusPermissionError as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
@@ -1406,10 +1394,6 @@ def create_async_files_router(
         except Exception as e:
             logger.exception(f"Exists error: {e}")
             raise HTTPException(status_code=500, detail=str(e)) from e
-
-    # =============================================================================
-    # List Directory Endpoint
-    # =============================================================================
 
     @router.get("/list", response_model=ListResponse, response_model_by_alias=True)
     async def list_directory(
@@ -1438,161 +1422,141 @@ def create_async_files_router(
         """
         context = _apply_zone_override(context, zone, auth_result)
         try:
-            fs = await _get_fs()
 
-            # Decode opaque cursor (base64-encoded path)
-            cursor_path: str | None = None
-            if cursor is not None:
-                try:
-                    cursor_path = base64.b64decode(cursor).decode("utf-8")
-                except Exception:
-                    raise HTTPException(status_code=400, detail="Invalid cursor") from None
+            async def _work() -> Any:
+                fs = await _get_fs()
 
-            # Issue #3266: Prefer search service for listing (metastore-first).
-            # Same pattern as the RPC list handler in filesystem.py.
-            # Note: search.list() returns plain paths for dynamic connectors,
-            # while sys_readdir(details=True) returns detail dicts. We use
-            # sys_readdir as the primary path and only fall back to search
-            # for connector mounts where metastore-first listing is needed.
-            result = await asyncio.to_thread(
-                fs.sys_readdir,
-                path,
-                recursive=False,
-                details=True,
-                context=context,
-                limit=limit,
-                cursor=cursor_path,
-            )
+                # Decode opaque cursor (base64-encoded path)
+                cursor_path: str | None = None
+                if cursor is not None:
+                    try:
+                        cursor_path = base64.b64decode(cursor).decode("utf-8")
+                    except Exception:
+                        raise HTTPException(status_code=400, detail="Invalid cursor") from None
 
-            # Issue #3266: If sys_readdir returned nothing for a connector
-            # mount, try the search service (metastore-first listing).
-            result_items = result.items if hasattr(result, "items") else result
-            if not result_items and path.startswith("/mnt/"):
-                search = fs.service("search")
-                if search is not None:
-                    search_result = search.list(
-                        path=path,
-                        recursive=False,
-                        context=context,
-                    )
-                    if search_result:
-                        # Convert plain paths to detail dicts
-                        prefix = path.rstrip("/") + "/"
-                        detail_list = []
-                        for entry in search_result:
-                            entry_path = entry if isinstance(entry, str) else str(entry)
-                            entry_path = entry_path.rstrip("/")
-                            name = entry_path.split("/")[-1] if "/" in entry_path else entry_path
-                            is_dir = entry.endswith("/") if isinstance(entry, str) else False
-                            detail_list.append(
-                                {
-                                    "path": entry_path,
-                                    "name": name,
-                                    "is_directory": is_dir,
-                                    "size": 0,
-                                }
-                            )
-                        result = detail_list
-
-            # Inject mount point parent directories into the listing.
-            # Mount points exist in the VFS router but not in the metastore,
-            # so sys_readdir doesn't return them. We synthesize directory
-            # entries for immediate children of the listed path that are
-            # mount point ancestors.
-            try:
-                mount_svc = fs.service("mount")
-                if mount_svc:
-                    mount_list_result = mount_svc.list_mounts()
-                    if hasattr(mount_list_result, "__await__"):
-                        mounts_raw = await mount_list_result
-                    else:
-                        mounts_raw = mount_list_result
-                    listed_prefix = path.rstrip("/") + "/"
-                    existing_paths = {
-                        (e.get("path", "") if isinstance(e, dict) else str(e)).rstrip("/")
-                        for e in (
-                            result if isinstance(result, list) else getattr(result, "items", [])
-                        )
-                    }
-                    for m in mounts_raw:
-                        mp = (m.get("mount_point", "") if isinstance(m, dict) else str(m)).rstrip(
-                            "/"
-                        )
-                        if not mp.startswith(listed_prefix) and not (
-                            path == "/" and mp.startswith("/")
-                        ):
-                            continue
-                        # Find the immediate child segment
-                        relative = mp.lstrip("/") if path == "/" else mp[len(listed_prefix) :]
-                        child = relative.split("/")[0] if "/" in relative else relative
-                        if not child:
-                            continue
-                        child_path = f"{path.rstrip('/')}/{child}"
-                        if child_path.rstrip("/") not in existing_paths:
-                            synthetic = {
-                                "path": child_path,
-                                "name": child,
-                                "entry_type": 1,
-                                "size": 0,
-                                "is_directory": True,
-                            }
-                            if isinstance(result, list):
-                                result.append(synthetic)
-                            elif hasattr(result, "items"):
-                                result.items.append(synthetic)
-                            existing_paths.add(child_path.rstrip("/"))
-            except Exception:
-                pass  # Best effort — listing still works without mount injection
-
-            prefix = path.rstrip("/") + "/"
-            # The listed path itself (e.g. "/" → empty name) must not appear
-            # in its own listing — that causes infinite recursion in tree UIs.
-            clean_path = path.rstrip("/") or "/"
-
-            # Internal paths stored in the metastore (system config, ReBAC
-            # namespaces) must not leak into user-facing directory listings.
-            _INTERNAL_PREFIXES = ("cfg:", "ns:")
-
-            def _is_visible(entry: dict) -> bool:
-                p = entry.get("path", "")
-                name = p.lstrip("/").split("/")[0] if "/" in p else p.lstrip("/")
-                return p.rstrip("/") != clean_path.rstrip("/") and not name.startswith(
-                    _INTERNAL_PREFIXES
-                )
-
-            # Paginated path: keep advancing until the page has visible items
-            # or there are no more results. This prevents empty pages when
-            # internal entries (cfg:, ns:) consume an entire page.
-            if limit is not None:
-                file_items: list[FileItemResponse] = []
-                # sys_readdir may return a paginated object (with .items,
-                # .has_more, .next_cursor) or a plain list for connector
-                # backends. Normalize to avoid AttributeError.
-                if isinstance(result, list):
-                    _page_items = result
-                    has_more = False
-                    next_cursor_raw = None
-                else:
-                    _page_items = result.items
-                    has_more = result.has_more
-                    next_cursor_raw = result.next_cursor
-
-                # Collect visible items from current page
-                for entry in _page_items:
-                    if _is_visible(entry):
-                        file_items.append(_to_file_item(entry, prefix))
-
-                # If filtering emptied the page but more data exists, keep fetching
-                while not file_items and has_more and next_cursor_raw:
-                    result = await asyncio.to_thread(
-                        fs.sys_readdir,
+                # Issue #3266: Prefer search service for listing (metastore-first).
+                # Same pattern as the RPC list handler in filesystem.py.
+                # Note: search.list() returns plain paths for dynamic connectors,
+                # while sys_readdir(details=True) returns detail dicts. We use
+                # sys_readdir as the primary path and only fall back to search
+                # for connector mounts where metastore-first listing is needed.
+                result = await _maybe_await(
+                    fs.sys_readdir(
                         path,
                         recursive=False,
                         details=True,
                         context=context,
                         limit=limit,
-                        cursor=next_cursor_raw,
+                        cursor=cursor_path,
                     )
+                )
+
+                # Issue #3266: If sys_readdir returned nothing for a connector
+                # mount, try the search service (metastore-first listing).
+                result_items = result.items if hasattr(result, "items") else result
+                if not result_items and path.startswith("/mnt/"):
+                    search = fs.service("search")
+                    if search is not None:
+                        search_result = search.list(
+                            path=path,
+                            recursive=False,
+                            context=context,
+                        )
+                        if search_result:
+                            # Convert plain paths to detail dicts
+                            prefix = path.rstrip("/") + "/"
+                            detail_list = []
+                            for entry in search_result:
+                                entry_path = entry if isinstance(entry, str) else str(entry)
+                                entry_path = entry_path.rstrip("/")
+                                name = (
+                                    entry_path.split("/")[-1] if "/" in entry_path else entry_path
+                                )
+                                is_dir = entry.endswith("/") if isinstance(entry, str) else False
+                                detail_list.append(
+                                    {
+                                        "path": entry_path,
+                                        "name": name,
+                                        "is_directory": is_dir,
+                                        "size": 0,
+                                    }
+                                )
+                            result = detail_list
+
+                # Inject mount point parent directories into the listing.
+                # Mount points exist in the VFS router but not in the metastore,
+                # so sys_readdir doesn't return them. We synthesize directory
+                # entries for immediate children of the listed path that are
+                # mount point ancestors.
+                try:
+                    mount_svc = fs.service("mount")
+                    if mount_svc:
+                        mount_list_result = mount_svc.list_mounts()
+                        if hasattr(mount_list_result, "__await__"):
+                            mounts_raw = await mount_list_result
+                        else:
+                            mounts_raw = mount_list_result
+                        listed_prefix = path.rstrip("/") + "/"
+                        existing_paths = {
+                            (e.get("path", "") if isinstance(e, dict) else str(e)).rstrip("/")
+                            for e in (
+                                result if isinstance(result, list) else getattr(result, "items", [])
+                            )
+                        }
+                        for m in mounts_raw:
+                            mp = (
+                                m.get("mount_point", "") if isinstance(m, dict) else str(m)
+                            ).rstrip("/")
+                            if not mp.startswith(listed_prefix) and not (
+                                path == "/" and mp.startswith("/")
+                            ):
+                                continue
+                            # Find the immediate child segment
+                            relative = mp.lstrip("/") if path == "/" else mp[len(listed_prefix) :]
+                            child = relative.split("/")[0] if "/" in relative else relative
+                            if not child:
+                                continue
+                            child_path = f"{path.rstrip('/')}/{child}"
+                            if child_path.rstrip("/") not in existing_paths:
+                                synthetic = {
+                                    "path": child_path,
+                                    "name": child,
+                                    "entry_type": 1,
+                                    "size": 0,
+                                    "is_directory": True,
+                                }
+                                if isinstance(result, list):
+                                    result.append(synthetic)
+                                elif hasattr(result, "items"):
+                                    result.items.append(synthetic)
+                                existing_paths.add(child_path.rstrip("/"))
+                except Exception:
+                    pass  # Best effort — listing still works without mount injection
+
+                prefix = path.rstrip("/") + "/"
+                # The listed path itself (e.g. "/" → empty name) must not appear
+                # in its own listing — that causes infinite recursion in tree UIs.
+                clean_path = path.rstrip("/") or "/"
+
+                # Internal paths stored in the metastore (system config, ReBAC
+                # namespaces) must not leak into user-facing directory listings.
+                _INTERNAL_PREFIXES = ("cfg:", "ns:")
+
+                def _is_visible(entry: dict) -> bool:
+                    p = entry.get("path", "")
+                    name = p.lstrip("/").split("/")[0] if "/" in p else p.lstrip("/")
+                    return p.rstrip("/") != clean_path.rstrip("/") and not name.startswith(
+                        _INTERNAL_PREFIXES
+                    )
+
+                # Paginated path: keep advancing until the page has visible items
+                # or there are no more results. This prevents empty pages when
+                # internal entries (cfg:, ns:) consume an entire page.
+                if limit is not None:
+                    file_items: list[FileItemResponse] = []
+                    # sys_readdir may return a paginated object (with .items,
+                    # .has_more, .next_cursor) or a plain list for connector
+                    # backends. Normalize to avoid AttributeError.
                     if isinstance(result, list):
                         _page_items = result
                         has_more = False
@@ -1601,24 +1565,54 @@ def create_async_files_router(
                         _page_items = result.items
                         has_more = result.has_more
                         next_cursor_raw = result.next_cursor
+
+                    # Collect visible items from current page
                     for entry in _page_items:
                         if _is_visible(entry):
                             file_items.append(_to_file_item(entry, prefix))
 
-                next_cursor = (
-                    base64.b64encode(next_cursor_raw.encode("utf-8")).decode("ascii")
-                    if next_cursor_raw
-                    else None
-                )
-                return ListResponse(
-                    items=file_items,
-                    has_more=has_more,
-                    next_cursor=next_cursor,
-                )
+                    # If filtering emptied the page but more data exists, keep fetching
+                    while not file_items and has_more and next_cursor_raw:
+                        result = await _maybe_await(
+                            fs.sys_readdir(
+                                path,
+                                recursive=False,
+                                details=True,
+                                context=context,
+                                limit=limit,
+                                cursor=next_cursor_raw,
+                            )
+                        )
+                        if isinstance(result, list):
+                            _page_items = result
+                            has_more = False
+                            next_cursor_raw = None
+                        else:
+                            _page_items = result.items
+                            has_more = result.has_more
+                            next_cursor_raw = result.next_cursor
+                        for entry in _page_items:
+                            if _is_visible(entry):
+                                file_items.append(_to_file_item(entry, prefix))
 
-            # Non-paginated path (backward compat): result is list[dict]
-            file_items = [_to_file_item(entry, prefix) for entry in result if _is_visible(entry)]
-            return ListResponse(items=file_items, has_more=False)
+                    next_cursor = (
+                        base64.b64encode(next_cursor_raw.encode("utf-8")).decode("ascii")
+                        if next_cursor_raw
+                        else None
+                    )
+                    return ListResponse(
+                        items=file_items,
+                        has_more=has_more,
+                        next_cursor=next_cursor,
+                    )
+
+                # Non-paginated path (backward compat): result is list[dict]
+                file_items = [
+                    _to_file_item(entry, prefix) for entry in result if _is_visible(entry)
+                ]
+                return ListResponse(items=file_items, has_more=False)
+
+            return await _run_for_context(context, {"path": path, "zone": zone}, _work)
 
         except HTTPException:
             raise
@@ -1639,10 +1633,6 @@ def create_async_files_router(
             logger.exception(f"List error: {e}")
             raise HTTPException(status_code=500, detail=str(e)) from e
 
-    # =============================================================================
-    # Mkdir Endpoint
-    # =============================================================================
-
     @router.post("/mkdir", status_code=status.HTTP_200_OK)
     async def create_directory(
         request: MkdirRequest,
@@ -1656,10 +1646,18 @@ def create_async_files_router(
         """Create a directory."""
         context = _apply_zone_override(context, zone, auth_result, required_perm="w")
         try:
-            fs = await _get_fs()
-            # fs.mkdir is async — call directly
-            fs.mkdir(request.path, parents=request.parents, context=context)
-            return {"created": True, "path": request.path}
+
+            async def _work() -> dict[str, Any]:
+                fs = await _get_fs()
+                # fs.mkdir is async — call directly
+                fs.mkdir(request.path, parents=request.parents, context=context)
+                return {"created": True, "path": request.path}
+
+            return await _run_for_context(
+                context,
+                {"path": request.path, "zone": zone},
+                _work,
+            )
 
         except NexusPermissionError as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
@@ -1672,10 +1670,6 @@ def create_async_files_router(
         except Exception as e:
             logger.exception(f"Mkdir error: {e}")
             raise HTTPException(status_code=500, detail=str(e)) from e
-
-    # =============================================================================
-    # Metadata Endpoint
-    # =============================================================================
 
     @router.get("/metadata", response_model=MetadataResponse)
     async def get_file_metadata(
@@ -1690,12 +1684,16 @@ def create_async_files_router(
         """Get file or directory metadata."""
         context = _apply_zone_override(context, zone, auth_result)
         try:
-            fs = await _get_fs()
-            meta = await asyncio.to_thread(fs.sys_stat, path, context=context)
-            if meta is None:
-                raise NexusFileNotFoundError(path=path)
 
-            return _to_metadata_response(meta, fallback_path=path)
+            async def _work() -> MetadataResponse:
+                fs = await _get_fs()
+                meta = fs.sys_stat(path, context=context)
+                if meta is None:
+                    raise NexusFileNotFoundError(path=path)
+
+                return _to_metadata_response(meta, fallback_path=path)
+
+            return await _run_for_context(context, {"path": path, "zone": zone}, _work)
 
         except AuthenticationError:
             # Preserve structured re-auth signal (see /list and /read handlers).
@@ -1709,10 +1707,6 @@ def create_async_files_router(
         except Exception as e:
             logger.exception(f"Metadata error: {e}")
             raise HTTPException(status_code=500, detail=str(e)) from e
-
-    # =============================================================================
-    # Batch Read Endpoint
-    # =============================================================================
 
     @router.post("/batch-read")
     async def batch_read_files(
@@ -1732,22 +1726,30 @@ def create_async_files_router(
         """
         context = _apply_zone_override(context, zone, auth_result)
         try:
-            fs = await _get_fs()
-            results = await asyncio.to_thread(fs.read_bulk, request.paths, context=context)
 
-            # Convert bytes to string for JSON response
-            response: dict[str, Any] = {}
-            for path, content in results.items():
-                if content is None:
-                    response[path] = None
-                elif isinstance(content, bytes):
-                    response[path] = {
-                        "content": content.decode("utf-8", errors="replace"),
-                    }
-                else:
-                    response[path] = {"content": content}
+            async def _work() -> dict[str, Any]:
+                fs = await _get_fs()
+                results = await asyncio.to_thread(fs.read_bulk, request.paths, context=context)
 
-            return response
+                # Convert bytes to string for JSON response
+                response: dict[str, Any] = {}
+                for path, content in results.items():
+                    if content is None:
+                        response[path] = None
+                    elif isinstance(content, bytes):
+                        response[path] = {
+                            "content": content.decode("utf-8", errors="replace"),
+                        }
+                    else:
+                        response[path] = {"content": content}
+
+                return response
+
+            return await _run_for_context(
+                context,
+                {"paths": request.paths, "zone": zone},
+                _work,
+            )
 
         except NexusPermissionError as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
@@ -1756,10 +1758,6 @@ def create_async_files_router(
         except Exception as e:
             logger.exception(f"Batch read error: {e}")
             raise HTTPException(status_code=500, detail=str(e)) from e
-
-    # =============================================================================
-    # Batch Write Endpoint (Issue #3700)
-    # =============================================================================
 
     @router.post("/batch/write", response_model=BatchWriteResponse)
     async def batch_write_files(
@@ -1781,21 +1779,27 @@ def create_async_files_router(
         {_MAX_BATCH_TOTAL_BYTES // (1024*1024)} MB total decoded size per request.
         """
         try:
-            fs = await _get_fs()
-            files = [(item.path, base64.b64decode(item.content_base64)) for item in request.files]
-            raw_results = fs.write_batch(files, context=context)
-            return BatchWriteResponse(
-                results=[
-                    BatchWriteResult(
-                        path=r["path"] if "path" in r else files[i][0],
-                        content_id=r.get("content_id"),
-                        version=r.get("version", 0),
-                        modified_at=r.get("modified_at"),
-                        size=r.get("size", 0),
-                    )
-                    for i, r in enumerate(raw_results)
+
+            async def _work() -> BatchWriteResponse:
+                fs = await _get_fs()
+                files = [
+                    (item.path, base64.b64decode(item.content_base64)) for item in request.files
                 ]
-            )
+                raw_results = await _maybe_await(fs.write_batch(files, context=context))
+                return BatchWriteResponse(
+                    results=[
+                        BatchWriteResult(
+                            path=r["path"] if "path" in r else files[i][0],
+                            content_id=r.get("content_id"),
+                            version=r.get("version", 0),
+                            modified_at=r.get("modified_at"),
+                            size=r.get("size", 0),
+                        )
+                        for i, r in enumerate(raw_results)
+                    ]
+                )
+
+            return await _run_for_context(context, request, _work)
         except (NexusPermissionError, AccessDeniedError) as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
         except InvalidPathError as e:
@@ -1803,10 +1807,6 @@ def create_async_files_router(
         except Exception as e:
             logger.exception("Batch write error: %s", e)
             raise HTTPException(status_code=500, detail=str(e)) from e
-
-    # =============================================================================
-    # Batch Read Endpoint v2 (Issue #3700)
-    # =============================================================================
 
     @router.post("/batch/read", response_model=BatchReadResponse)
     async def batch_read_files_v2(
@@ -1824,40 +1824,46 @@ def create_async_files_router(
         per-item success or error for every path.
         """
         try:
-            fs = await _get_fs()
-            raw_results = fs.read_batch(request.paths, partial=request.partial, context=context)
-            # Belt-and-suspenders aggregate size guard (Finding #3).
-            # NexusFS.read_batch() already pre-checks via metadata sizes; this
-            # post-read guard catches any content that slipped through (e.g. from
-            # external-mount fallback paths whose metadata sizes were unknown).
-            _total_read = sum(
-                len(r.get("content", b"")) for r in raw_results if isinstance(r, dict)
-            )
-            if _total_read > _MAX_BATCH_TOTAL_BYTES:
-                raise HTTPException(
-                    status_code=413,
-                    detail=(
-                        f"Batch read response size {_total_read} bytes exceeds "
-                        f"{_MAX_BATCH_TOTAL_BYTES // (1024 * 1024)} MB limit"
-                    ),
+
+            async def _work() -> BatchReadResponse:
+                fs = await _get_fs()
+                raw_results = await _maybe_await(
+                    fs.read_batch(request.paths, partial=request.partial, context=context)
                 )
-            items: list[BatchReadSuccess | BatchReadError] = []
-            for r in raw_results:
-                if "error" in r:
-                    items.append(BatchReadError(type="error", path=r["path"], error=r["error"]))
-                else:
-                    items.append(
-                        BatchReadSuccess(
-                            type="success",
-                            path=r["path"],
-                            content_base64=base64.b64encode(r["content"]).decode(),
-                            content_id=r.get("content_id"),
-                            version=r.get("version", 0),
-                            modified_at=r.get("modified_at"),
-                            size=r.get("size", 0),
-                        )
+                # Belt-and-suspenders aggregate size guard (Finding #3).
+                # NexusFS.read_batch() already pre-checks via metadata sizes; this
+                # post-read guard catches any content that slipped through (e.g. from
+                # external-mount fallback paths whose metadata sizes were unknown).
+                _total_read = sum(
+                    len(r.get("content", b"")) for r in raw_results if isinstance(r, dict)
+                )
+                if _total_read > _MAX_BATCH_TOTAL_BYTES:
+                    raise HTTPException(
+                        status_code=413,
+                        detail=(
+                            f"Batch read response size {_total_read} bytes exceeds "
+                            f"{_MAX_BATCH_TOTAL_BYTES // (1024 * 1024)} MB limit"
+                        ),
                     )
-            return BatchReadResponse(results=items)
+                items: list[BatchReadSuccess | BatchReadError] = []
+                for r in raw_results:
+                    if "error" in r:
+                        items.append(BatchReadError(type="error", path=r["path"], error=r["error"]))
+                    else:
+                        items.append(
+                            BatchReadSuccess(
+                                type="success",
+                                path=r["path"],
+                                content_base64=base64.b64encode(r["content"]).decode(),
+                                content_id=r.get("content_id"),
+                                version=r.get("version", 0),
+                                modified_at=r.get("modified_at"),
+                                size=r.get("size", 0),
+                            )
+                        )
+                return BatchReadResponse(results=items)
+
+            return await _run_for_context(context, request, _work)
         except NexusFileNotFoundError as e:
             raise HTTPException(status_code=404, detail=str(e)) from e
         except (NexusPermissionError, AccessDeniedError) as e:
@@ -1876,10 +1882,6 @@ def create_async_files_router(
             logger.exception("Batch read v2 error: %s", e)
             raise HTTPException(status_code=500, detail=str(e)) from e
 
-    # =============================================================================
-    # Stream Endpoint
-    # =============================================================================
-
     @router.get("/stream", response_model=None)
     async def stream_file(
         request: Request,
@@ -1897,38 +1899,39 @@ def create_async_files_router(
         from nexus.server.range_utils import build_range_response
 
         try:
-            fs = await _get_fs()
-            meta = await asyncio.to_thread(fs.sys_stat, path, context=context)
-            if meta is None:
-                raise NexusFileNotFoundError(path=path)
 
-            def _range_generator(start: int, end: int, cs: int) -> Iterator[bytes]:
-                """Sync generator wrapping NexusFS.read_range()."""
-                data = fs.read_range(path, start, end, context=context)
-                if isinstance(data, bytes):
-                    for i in range(0, len(data), cs):
-                        yield data[i : i + cs]
+            async def _work() -> Response | StreamingResponse:
+                fs = await _get_fs()
+                meta = fs.sys_stat(path, context=context)
+                if meta is None:
+                    raise NexusFileNotFoundError(path=path)
 
-            async def _full_generator() -> AsyncIterator[bytes]:
-                """Sync generator wrapping NexusFS.read()."""
-                data = await asyncio.to_thread(fs.sys_read, path, context=context)
-                if isinstance(data, bytes):
-                    for i in range(0, len(data), chunk_size):
-                        yield data[i : i + chunk_size]
-                else:
-                    raw = str(data).encode("utf-8")
-                    for i in range(0, len(raw), chunk_size):
-                        yield raw[i : i + chunk_size]
+                def _chunks(data: bytes, cs: int) -> Iterator[bytes]:
+                    return (data[i : i + cs] for i in range(0, len(data), cs))
 
-            return build_range_response(
-                request_headers=request.headers,
-                content_generator=_range_generator,
-                full_generator=_full_generator,
-                total_size=meta.size,
-                etag=meta.content_id,
-                content_type=meta.mime_type or "application/octet-stream",
-                filename=path.split("/")[-1],
-            )
+                def _range_generator(start: int, end: int, cs: int) -> Iterator[bytes]:
+                    data = fs.read_range(path, start, end, context=context)
+                    if isinstance(data, bytes):
+                        return _chunks(data, cs)
+                    return iter(())
+
+                def _full_generator() -> Iterator[bytes]:
+                    data = fs.sys_read(path, context=context)
+                    if isinstance(data, bytes):
+                        return _chunks(data, chunk_size)
+                    return _chunks(str(data).encode("utf-8"), chunk_size)
+
+                return build_range_response(
+                    request_headers=request.headers,
+                    content_generator=_range_generator,
+                    full_generator=_full_generator,
+                    total_size=meta.size,
+                    etag=meta.content_id,
+                    content_type=meta.mime_type or "application/octet-stream",
+                    filename=path.split("/")[-1],
+                )
+
+            return await _run_for_context(context, {"path": path}, _work)
 
         except NexusPermissionError as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
@@ -1939,10 +1942,6 @@ def create_async_files_router(
         except Exception as e:
             logger.exception(f"Stream error: {e}")
             raise HTTPException(status_code=500, detail=str(e)) from e
-
-    # =============================================================================
-    # Rename Endpoint
-    # =============================================================================
 
     STREAMING_COPY_THRESHOLD = 10 * 1024 * 1024  # 10 MB
 
@@ -1958,15 +1957,17 @@ def create_async_files_router(
         Works instantly regardless of file size.
         """
         try:
-            fs = await _get_fs()
-            await asyncio.to_thread(
-                fs.sys_rename, request.source, request.destination, context=context
-            )
-            return RenameResponse(
-                success=True,
-                source=request.source,
-                destination=request.destination,
-            )
+
+            async def _work() -> RenameResponse:
+                fs = await _get_fs()
+                fs.sys_rename(request.source, request.destination, context=context)
+                return RenameResponse(
+                    success=True,
+                    source=request.source,
+                    destination=request.destination,
+                )
+
+            return await _run_for_context(context, request, _work)
 
         except NexusPermissionError as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
@@ -1980,10 +1981,6 @@ def create_async_files_router(
             logger.exception(f"Rename error: {e}")
             raise HTTPException(status_code=500, detail=str(e)) from e
 
-    # =============================================================================
-    # Copy Endpoint
-    # =============================================================================
-
     @router.post("/copy", response_model=CopyResponse)
     async def copy_file(
         request: CopyRequest,
@@ -1996,34 +1993,38 @@ def create_async_files_router(
         into memory. Smaller files are read/written in a single operation.
         """
         try:
-            fs = await _get_fs()
 
-            # Check source exists and get size
-            meta = await asyncio.to_thread(fs.sys_stat, request.source, context=context)
-            if meta is None:
-                raise NexusFileNotFoundError(path=request.source)
+            async def _work() -> CopyResponse:
+                fs = await _get_fs()
 
-            file_size = meta.get("size", 0) or 0
+                # Check source exists and get size
+                meta = fs.sys_stat(request.source, context=context)
+                if meta is None:
+                    raise NexusFileNotFoundError(path=request.source)
 
-            if file_size < STREAMING_COPY_THRESHOLD:
-                # Small file: read all then write all
-                content = await asyncio.to_thread(fs.sys_read, request.source, context=context)
-                await asyncio.to_thread(fs.write, request.destination, buf=content, context=context)
-                bytes_copied = len(content)
-            else:
-                # Large file: streaming copy
-                chunks = await asyncio.to_thread(fs.stream, request.source, context=context)
-                result = await asyncio.to_thread(
-                    fs.write_stream, request.destination, chunks, context=context
+                file_size = _metadata_field(meta, "size", 0) or 0
+
+                if file_size < STREAMING_COPY_THRESHOLD:
+                    # Small file: read all then write all
+                    content = fs.sys_read(request.source, context=context)
+                    fs.write(request.destination, buf=content, context=context)
+                    bytes_copied = len(content)
+                else:
+                    # Large file: streaming copy
+                    chunks = await asyncio.to_thread(fs.stream, request.source, context=context)
+                    result = await asyncio.to_thread(
+                        fs.write_stream, request.destination, chunks, context=context
+                    )
+                    bytes_copied = result.get("size", file_size)
+
+                return CopyResponse(
+                    success=True,
+                    source=request.source,
+                    destination=request.destination,
+                    bytes_copied=bytes_copied,
                 )
-                bytes_copied = result.get("size", file_size)
 
-            return CopyResponse(
-                success=True,
-                source=request.source,
-                destination=request.destination,
-                bytes_copied=bytes_copied,
-            )
+            return await _run_for_context(context, request, _work)
 
         except NexusPermissionError as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
@@ -2037,10 +2038,6 @@ def create_async_files_router(
             logger.exception(f"Copy error: {e}")
             raise HTTPException(status_code=500, detail=str(e)) from e
 
-    # =============================================================================
-    # Bulk Rename Endpoint
-    # =============================================================================
-
     @router.post("/rename-batch", response_model=RenameBatchResponse)
     async def rename_batch(
         request: RenameBatchRequest,
@@ -2053,23 +2050,27 @@ def create_async_files_router(
         affect others. Maximum 50 operations per request.
         """
         try:
-            fs = await _get_fs()
-            renames = [(op.source, op.destination) for op in request.operations]
-            raw_results = fs.rename_batch(renames, context=context)
 
-            results: list[BulkRenameResult] = []
-            for op in request.operations:
-                entry = raw_results.get(op.source, {})
-                results.append(
-                    BulkRenameResult(
-                        source=op.source,
-                        destination=op.destination,
-                        success=entry.get("success", False),
-                        error=entry.get("error"),
+            async def _work() -> RenameBatchResponse:
+                fs = await _get_fs()
+                renames = [(op.source, op.destination) for op in request.operations]
+                raw_results = fs.rename_batch(renames, context=context)
+
+                results: list[BulkRenameResult] = []
+                for op in request.operations:
+                    entry = raw_results.get(op.source, {})
+                    results.append(
+                        BulkRenameResult(
+                            source=op.source,
+                            destination=op.destination,
+                            success=entry.get("success", False),
+                            error=entry.get("error"),
+                        )
                     )
-                )
 
-            return RenameBatchResponse(results=results)
+                return RenameBatchResponse(results=results)
+
+            return await _run_for_context(context, request, _work)
 
         except NexusPermissionError as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
@@ -2078,10 +2079,6 @@ def create_async_files_router(
         except Exception as e:
             logger.exception(f"Bulk rename error: {e}")
             raise HTTPException(status_code=500, detail=str(e)) from e
-
-    # =============================================================================
-    # Bulk Copy Endpoint
-    # =============================================================================
 
     @router.post("/copy-bulk", response_model=CopyBulkResponse)
     async def copy_bulk(
@@ -2096,57 +2093,59 @@ def create_async_files_router(
         for files >= 10 MB.
         """
         try:
-            fs = await _get_fs()
-            results: list[BulkCopyResult] = []
 
-            for op in request.operations:
-                try:
-                    meta = await asyncio.to_thread(fs.sys_stat, op.source, context=context)
-                    if meta is None:
+            async def _work() -> CopyBulkResponse:
+                fs = await _get_fs()
+                results: list[BulkCopyResult] = []
+
+                for op in request.operations:
+                    try:
+                        meta = fs.sys_stat(op.source, context=context)
+                        if meta is None:
+                            results.append(
+                                BulkCopyResult(
+                                    source=op.source,
+                                    destination=op.destination,
+                                    success=False,
+                                    error=f"Source not found: {op.source}",
+                                )
+                            )
+                            continue
+
+                        file_size = _metadata_field(meta, "size", 0) or 0
+
+                        if file_size < STREAMING_COPY_THRESHOLD:
+                            content = fs.sys_read(op.source, context=context)
+                            fs.write(op.destination, buf=content, context=context)
+                            bytes_copied = len(content)
+                        else:
+                            chunks = await asyncio.to_thread(fs.stream, op.source, context=context)
+                            write_result = await asyncio.to_thread(
+                                fs.write_stream, op.destination, chunks, context=context
+                            )
+                            bytes_copied = write_result.get("size", file_size)
+
+                        results.append(
+                            BulkCopyResult(
+                                source=op.source,
+                                destination=op.destination,
+                                success=True,
+                                bytes_copied=bytes_copied,
+                            )
+                        )
+                    except Exception as e:
                         results.append(
                             BulkCopyResult(
                                 source=op.source,
                                 destination=op.destination,
                                 success=False,
-                                error=f"Source not found: {op.source}",
+                                error=str(e),
                             )
                         )
-                        continue
 
-                    file_size = meta.get("size", 0) or 0
+                return CopyBulkResponse(results=results)
 
-                    if file_size < STREAMING_COPY_THRESHOLD:
-                        content = await asyncio.to_thread(fs.sys_read, op.source, context=context)
-                        await asyncio.to_thread(
-                            fs.write, op.destination, buf=content, context=context
-                        )
-                        bytes_copied = len(content)
-                    else:
-                        chunks = await asyncio.to_thread(fs.stream, op.source, context=context)
-                        write_result = await asyncio.to_thread(
-                            fs.write_stream, op.destination, chunks, context=context
-                        )
-                        bytes_copied = write_result.get("size", file_size)
-
-                    results.append(
-                        BulkCopyResult(
-                            source=op.source,
-                            destination=op.destination,
-                            success=True,
-                            bytes_copied=bytes_copied,
-                        )
-                    )
-                except Exception as e:
-                    results.append(
-                        BulkCopyResult(
-                            source=op.source,
-                            destination=op.destination,
-                            success=False,
-                            error=str(e),
-                        )
-                    )
-
-            return CopyBulkResponse(results=results)
+            return await _run_for_context(context, request, _work)
 
         except NexusPermissionError as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
@@ -2155,10 +2154,6 @@ def create_async_files_router(
         except Exception as e:
             logger.exception(f"Bulk copy error: {e}")
             raise HTTPException(status_code=500, detail=str(e)) from e
-
-    # =============================================================================
-    # Glob Search Endpoint
-    # =============================================================================
 
     @router.get("/glob", response_model=GlobResponse)
     async def glob_search(
@@ -2174,27 +2169,34 @@ def create_async_files_router(
         fallback to Python fnmatch.
         """
         try:
-            fs = await _get_fs()
 
-            # List all files under the base path
-            all_paths = await asyncio.to_thread(
-                fs.sys_readdir, path, recursive=True, context=context
-            )
+            async def _work() -> GlobResponse:
+                fs = await _get_fs()
 
-            # Apply glob pattern filter
-            matched = await asyncio.to_thread(glob_filter, all_paths, include_patterns=[pattern])
+                # List all files under the base path
+                # sys_readdir is async — call directly, not via to_thread
+                all_paths = await _maybe_await(
+                    fs.sys_readdir(path, recursive=True, context=context)
+                )
 
-            total = len(matched)
-            truncated = total > limit
-            result_paths = matched[:limit]
+                # Apply glob pattern filter
+                matched = await asyncio.to_thread(
+                    glob_filter, all_paths, include_patterns=[pattern]
+                )
 
-            return GlobResponse(
-                matches=result_paths,
-                total=total,
-                truncated=truncated,
-                pattern=pattern,
-                base_path=path,
-            )
+                total = len(matched)
+                truncated = total > limit
+                result_paths = matched[:limit]
+
+                return GlobResponse(
+                    matches=result_paths,
+                    total=total,
+                    truncated=truncated,
+                    pattern=pattern,
+                    base_path=path,
+                )
+
+            return await _run_for_context(context, {"path": path}, _work)
 
         except NexusPermissionError as e:
             raise HTTPException(status_code=403, detail=str(e)) from e
@@ -2203,10 +2205,6 @@ def create_async_files_router(
         except Exception as e:
             logger.exception(f"Glob error: {e}")
             raise HTTPException(status_code=500, detail=str(e)) from e
-
-    # =============================================================================
-    # Grep Search Endpoint
-    # =============================================================================
 
     @router.get("/grep", response_model=GrepResponse)
     async def grep_search(
@@ -2225,76 +2223,81 @@ def create_async_files_router(
         import re
 
         try:
-            fs = await _get_fs()
 
-            # List all files under the base path
-            all_paths = await asyncio.to_thread(
-                fs.sys_readdir, path, recursive=True, context=context
-            )
+            async def _work() -> GrepResponse:
+                fs = await _get_fs()
 
-            # Try Rust mmap grep first
-            results = await asyncio.to_thread(
-                grep_files_mmap, pattern, all_paths, ignore_case, limit
-            )
+                # List all files under the base path
+                # sys_readdir is async — call directly, not via to_thread
+                all_paths = await _maybe_await(
+                    fs.sys_readdir(path, recursive=True, context=context)
+                )
 
-            # Fallback to Python re if Rust is unavailable
-            if results is None:
-                flags = re.IGNORECASE if ignore_case else 0
-                try:
-                    compiled = re.compile(pattern, flags)
-                except re.error as e:
-                    raise HTTPException(
-                        status_code=400, detail=f"Invalid regex pattern: {e}"
-                    ) from e
+                # Try Rust mmap grep first
+                results = await asyncio.to_thread(
+                    grep_files_mmap, pattern, all_paths, ignore_case, limit
+                )
 
-                results = []
-                for file_path in all_paths:
-                    if len(results) >= limit:
-                        break
+                # Fallback to Python re if Rust is unavailable
+                if results is None:
+                    flags = re.IGNORECASE if ignore_case else 0
                     try:
-                        content = fs.read(file_path, context=context)
-                        if isinstance(content, bytes):
-                            content = content.decode("utf-8", errors="replace")
-                        elif isinstance(content, dict):
-                            content = content.get("content", "")
+                        compiled = re.compile(pattern, flags)
+                    except re.error as e:
+                        raise HTTPException(
+                            status_code=400, detail=f"Invalid regex pattern: {e}"
+                        ) from e
+
+                    results = []
+                    for file_path in all_paths:
+                        if len(results) >= limit:
+                            break
+                        try:
+                            content = fs.read(file_path, context=context)
                             if isinstance(content, bytes):
                                 content = content.decode("utf-8", errors="replace")
-                        for line_num, line in enumerate(str(content).splitlines(), 1):
-                            m = compiled.search(line)
-                            if m:
-                                results.append(
-                                    {
-                                        "file": file_path,
-                                        "line": line_num,
-                                        "content": line,
-                                        "match": m.group(0),
-                                    }
-                                )
-                                if len(results) >= limit:
-                                    break
-                    except Exception:
-                        # Skip files that can't be read (binary, permissions, etc.)
-                        continue
+                            elif isinstance(content, dict):
+                                content = content.get("content", "")
+                                if isinstance(content, bytes):
+                                    content = content.decode("utf-8", errors="replace")
+                            for line_num, line in enumerate(str(content).splitlines(), 1):
+                                m = compiled.search(line)
+                                if m:
+                                    results.append(
+                                        {
+                                            "file": file_path,
+                                            "line": line_num,
+                                            "content": line,
+                                            "match": m.group(0),
+                                        }
+                                    )
+                                    if len(results) >= limit:
+                                        break
+                        except Exception:
+                            # Skip files that can't be read (binary, permissions, etc.)
+                            continue
 
-            total = len(results)
-            truncated = total >= limit
-            matches = [
-                GrepMatch(
-                    file=r["file"],
-                    line=r["line"],
-                    content=r["content"],
-                    match=r["match"],
+                total = len(results)
+                truncated = total >= limit
+                matches = [
+                    GrepMatch(
+                        file=r["file"],
+                        line=r["line"],
+                        content=r["content"],
+                        match=r["match"],
+                    )
+                    for r in results[:limit]
+                ]
+
+                return GrepResponse(
+                    matches=matches,
+                    total=total,
+                    truncated=truncated,
+                    pattern=pattern,
+                    base_path=path,
                 )
-                for r in results[:limit]
-            ]
 
-            return GrepResponse(
-                matches=matches,
-                total=total,
-                truncated=truncated,
-                pattern=pattern,
-                base_path=path,
-            )
+            return await _run_for_context(context, {"path": path}, _work)
 
         except HTTPException:
             raise

--- a/src/nexus/server/api/v2/routers/batch.py
+++ b/src/nexus/server/api/v2/routers/batch.py
@@ -109,7 +109,7 @@ def create_batch_router(
         - 30-second timeout per operation
         """
         fs = await _get_fs()
-        executor = BatchExecutor(fs=fs)
+        executor = BatchExecutor(fs=fs, zone_registry=_get_zone_registry())
 
         logger.info(
             "Batch request: %d operations, stop_on_error=%s",

--- a/src/nexus/server/api/v2/routers/batch.py
+++ b/src/nexus/server/api/v2/routers/batch.py
@@ -30,6 +30,7 @@ def create_batch_router(
     nexus_fs: Any | None = None,
     get_fs: Any | None = None,
     get_context_override: Callable[..., Any] | None = None,
+    get_zone_registry: Callable[[], Any | None] | None = None,
 ) -> APIRouter:
     """Create a batch operations router.
 
@@ -42,6 +43,7 @@ def create_batch_router(
         get_fs: Callable returning NexusFS (lazy mode).
         get_context_override: Optional context provider for testing.
             When None, imports auth from fastapi_server.
+        get_zone_registry: Callable returning ZoneRegistry (lazy mode).
 
     Returns:
         FastAPI router with the ``POST /batch`` endpoint.
@@ -60,6 +62,9 @@ def create_batch_router(
             status_code=503,
             detail="NexusFS not initialized. Server may still be starting up.",
         )
+
+    def _get_zone_registry() -> Any | None:
+        return get_zone_registry() if get_zone_registry is not None else None
 
     # Build context dependency: use override if provided, else import from server.
     if get_context_override is not None:

--- a/src/nexus/server/api/v2/routers/connectors.py
+++ b/src/nexus/server/api/v2/routers/connectors.py
@@ -24,6 +24,7 @@ from fastapi import APIRouter, Depends, HTTPException, Request
 from pydantic import BaseModel, Field
 
 from nexus.server.dependencies import require_auth
+from nexus.server.zone_execution import run_zone_scoped
 
 logger = logging.getLogger(__name__)
 
@@ -184,6 +185,17 @@ def _get_mount_service(request: Request) -> Any:
     return svc
 
 
+def _get_zone_registry(request: Request) -> Any | None:
+    return getattr(request.app.state, "zone_registry", None)
+
+
+def _auth_zone(auth_result: dict[str, Any]) -> str | None:
+    from nexus.contracts.constants import ROOT_ZONE_ID
+
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
+    return zone_id if zone_id != ROOT_ZONE_ID else None
+
+
 # ---------------------------------------------------------------------------
 # Discovery endpoints
 # ---------------------------------------------------------------------------
@@ -215,7 +227,7 @@ def list_connectors(_: dict = Depends(require_auth)) -> ConnectorsListResponse:
 @router.get("/available", response_model=list[AvailableConnector])
 async def list_available_connectors(
     request: Request,
-    _: dict = Depends(require_auth),
+    auth_result: dict = Depends(require_auth),
 ) -> list[AvailableConnector]:
     """List connectors with auth and mount status (for TUI Connectors tab)."""
     from nexus.backends import _register_optional_backends
@@ -230,31 +242,34 @@ async def list_available_connectors(
     # (which stores mount_point -> connector_type).
     type_to_mount: dict[str, str] = {ct: mp for mp, ct in _mount_types.items()}
 
-    result = []
-    for info in ConnectorRegistry.list_all():
-        mount_path = type_to_mount.get(info.name)
+    async def _list() -> list[AvailableConnector]:
+        result = []
+        for info in ConnectorRegistry.list_all():
+            mount_path = type_to_mount.get(info.name)
 
-        auth_state = {"auth_status": "unknown", "auth_source": None}
-        if auth_svc is not None:
-            try:
-                auth_state = await auth_svc.get_connector_auth_state(info.service_name)
-            except Exception:
-                logger.debug("Failed to resolve auth state for %s", info.name, exc_info=True)
+            auth_state = {"auth_status": "unknown", "auth_source": None}
+            if auth_svc is not None:
+                try:
+                    auth_state = await auth_svc.get_connector_auth_state(info.service_name)
+                except Exception:
+                    logger.debug("Failed to resolve auth state for %s", info.name, exc_info=True)
 
-        result.append(
-            AvailableConnector(
-                name=info.name,
-                description=info.description,
-                category=info.category,
-                capabilities=sorted(str(c) for c in info.backend_features),
-                user_scoped=info.user_scoped,
-                auth_status=str(auth_state.get("auth_status", "unknown")),
-                auth_source=auth_state.get("auth_source"),
-                mount_path=mount_path,
+            result.append(
+                AvailableConnector(
+                    name=info.name,
+                    description=info.description,
+                    category=info.category,
+                    capabilities=sorted(str(c) for c in info.backend_features),
+                    user_scoped=info.user_scoped,
+                    auth_status=str(auth_state.get("auth_status", "unknown")),
+                    auth_source=auth_state.get("auth_source"),
+                    mount_path=mount_path,
+                )
             )
-        )
 
-    return result
+        return result
+
+    return await run_zone_scoped(_get_zone_registry(request), _auth_zone(auth_result), _list)
 
 
 @router.get("/{name}/capabilities", response_model=ConnectorCapabilitiesResponse)
@@ -290,7 +305,7 @@ _mount_types: dict[str, str] = {}
 async def init_connector_auth(
     req: AuthInitRequest,
     request: Request,
-    _: dict = Depends(require_auth),
+    auth_result: dict = Depends(require_auth),
 ) -> AuthInitResponse:
     """Initiate OAuth flow for a connector. Returns a URL to open in a browser."""
     import secrets
@@ -441,17 +456,23 @@ async def init_connector_auth(
     else:
         raise HTTPException(status_code=400, detail=f"Unsupported OAuth provider: {provider}")
 
-    # Snapshot the current auth state so we can detect a *change* during polling.
-    # Without this, pre-existing auth for the same connector would immediately
-    # report "completed" — a correctness bug for concurrent auth attempts.
-    auth_svc = getattr(request.app.state, "auth_service", None) or nx.service("auth")
-    baseline_status = "unknown"
-    if auth_svc is not None:
-        try:
-            baseline = await auth_svc.get_connector_auth_state(info.service_name)
-            baseline_status = str(baseline.get("auth_status", "unknown"))
-        except Exception:
-            pass
+    async def _baseline_status() -> str:
+        # Snapshot the current auth state so we can detect a *change* during polling.
+        # Without this, pre-existing auth for the same connector would immediately
+        # report "completed" — a correctness bug for concurrent auth attempts.
+        auth_svc = getattr(request.app.state, "auth_service", None) or nx.service("auth")
+        baseline_status = "unknown"
+        if auth_svc is not None:
+            try:
+                baseline = await auth_svc.get_connector_auth_state(info.service_name)
+                baseline_status = str(baseline.get("auth_status", "unknown"))
+            except Exception:
+                pass
+        return baseline_status
+
+    baseline_status = await run_zone_scoped(
+        _get_zone_registry(request), _auth_zone(auth_result), _baseline_status
+    )
 
     # Store pending auth state with the baseline snapshot
     _pending_auth[state_token] = {
@@ -480,7 +501,7 @@ async def init_connector_auth(
 async def get_auth_status(
     state_token: str,
     request: Request,
-    _: dict = Depends(require_auth),
+    auth_result: dict = Depends(require_auth),
 ) -> AuthStatusResponse:
     """Poll for OAuth completion status."""
     import time
@@ -510,44 +531,50 @@ async def get_auth_status(
     nx = _get_nx(request)
     auth_svc = getattr(request.app.state, "auth_service", None) or nx.service("auth")
 
-    if auth_svc is not None:
-        try:
-            from nexus.backends.base.registry import ConnectorRegistry
+    async def _check() -> AuthStatusResponse | None:
+        if auth_svc is not None:
+            try:
+                from nexus.backends.base.registry import ConnectorRegistry
 
-            info = ConnectorRegistry.get_info(connector_name)
-            auth_state = await auth_svc.get_connector_auth_state(info.service_name)
-            status = str(auth_state.get("auth_status", "unknown"))
+                info = ConnectorRegistry.get_info(connector_name)
+                auth_state = await auth_svc.get_connector_auth_state(info.service_name)
+                status = str(auth_state.get("auth_status", "unknown"))
 
-            if status == "authed" and baseline_status != "authed":
-                # Auth state changed to authed — this flow completed.
-                # Invalidate ALL pending tokens for the same connector so
-                # concurrent auth/init calls don't also claim completion.
-                # The losing tokens will get 404 on next poll, which the
-                # TUI handles as "expired — retry".
-                stale = [
-                    k for k, v in _pending_auth.items() if v["connector_name"] == connector_name
-                ]
-                for k in stale:
-                    del _pending_auth[k]
-                return AuthStatusResponse(
-                    status="completed",
-                    connector_name=connector_name,
-                    message="Authentication successful.",
-                )
-            elif status == "expired" and baseline_status != "expired":
-                return AuthStatusResponse(
-                    status="denied",
-                    connector_name=connector_name,
-                    message="Authentication was denied or token expired.",
-                )
-            elif status == "error" and baseline_status != "error":
-                return AuthStatusResponse(
-                    status="error",
-                    connector_name=connector_name,
-                    message="Authentication failed. Check provider configuration.",
-                )
-        except Exception as e:
-            logger.debug("Error checking auth status for %s: %s", connector_name, e)
+                if status == "authed" and baseline_status != "authed":
+                    # Auth state changed to authed — this flow completed.
+                    # Invalidate ALL pending tokens for the same connector so
+                    # concurrent auth/init calls don't also claim completion.
+                    # The losing tokens will get 404 on next poll, which the
+                    # TUI handles as "expired — retry".
+                    stale = [
+                        k for k, v in _pending_auth.items() if v["connector_name"] == connector_name
+                    ]
+                    for k in stale:
+                        del _pending_auth[k]
+                    return AuthStatusResponse(
+                        status="completed",
+                        connector_name=connector_name,
+                        message="Authentication successful.",
+                    )
+                elif status == "expired" and baseline_status != "expired":
+                    return AuthStatusResponse(
+                        status="denied",
+                        connector_name=connector_name,
+                        message="Authentication was denied or token expired.",
+                    )
+                elif status == "error" and baseline_status != "error":
+                    return AuthStatusResponse(
+                        status="error",
+                        connector_name=connector_name,
+                        message="Authentication failed. Check provider configuration.",
+                    )
+            except Exception as e:
+                logger.debug("Error checking auth status for %s: %s", connector_name, e)
+        return None
+
+    checked = await run_zone_scoped(_get_zone_registry(request), _auth_zone(auth_result), _check)
+    if checked is not None:
+        return checked
 
     return AuthStatusResponse(
         status="pending",
@@ -587,232 +614,228 @@ async def mount_connector(
     mount_svc = _get_mount_service(request)
     nx = _get_nx(request)
 
-    # Write readme docs BEFORE mounting — after mount, the path routes to the
-    # connector backend instead of Raft. Writing first puts README.md + schemas
-    # in the Raft metastore where the TUI file explorer can browse them.
-    try:
-        from nexus.backends import BackendFactory
+    async def _mount() -> MountResponse:
+        # Write readme docs BEFORE mounting — after mount, the path routes to the
+        # connector backend instead of Raft. Writing first puts README.md + schemas
+        # in the Raft metastore where the TUI file explorer can browse them.
+        try:
+            from nexus.backends import BackendFactory
 
-        temp_backend = BackendFactory.create(req.connector_type, req.config or {})
-        if hasattr(temp_backend, "generate_readme"):
-            mp = req.mount_point.rstrip("/")
-            # Extract connector name from mount path (e.g., /mnt/gmail → gmail)
-            connector_name = mp.rsplit("/", 1)[-1]
-            # Create /skills/ directory entry via metadata_put so it shows
-            # in root-level readdir. sys_write creates files but the HTTP
-            # readdir doesn't synthesize parent directories from child paths.
-            try:
-                from datetime import UTC, datetime
+            temp_backend = BackendFactory.create(req.connector_type, req.config or {})
+            if hasattr(temp_backend, "generate_readme"):
+                mp = req.mount_point.rstrip("/")
+                # Extract connector name from mount path (e.g., /mnt/gmail → gmail)
+                connector_name = mp.rsplit("/", 1)[-1]
+                # Create /skills/ directory entry via metadata_put so it shows
+                # in root-level readdir. sys_write creates files but the HTTP
+                # readdir doesn't synthesize parent directories from child paths.
+                try:
+                    from datetime import UTC, datetime
 
-                from nexus.contracts.metadata import FileMetadata
+                    from nexus.contracts.metadata import FileMetadata
 
-                meta_store = nx._kernel
-                if meta_store:
-                    for dir_path in [
-                        "/skills",
-                        f"/skills/{connector_name}",
-                        f"/skills/{connector_name}/schemas",
-                    ]:
-                        try:
-                            if not meta_store.get(dir_path):
-                                meta_store.put(
-                                    FileMetadata(
-                                        path=dir_path,
-                                        size=0,
-                                        content_id=None,
-                                        created_at=datetime.now(UTC),
-                                        modified_at=datetime.now(UTC),
-                                        version=1,
-                                        zone_id=mount_context.zone_id,
+                    meta_store = nx._kernel
+                    if meta_store:
+                        for dir_path in [
+                            "/skills",
+                            f"/skills/{connector_name}",
+                            f"/skills/{connector_name}/schemas",
+                        ]:
+                            try:
+                                if not meta_store.get(dir_path):
+                                    meta_store.put(
+                                        FileMetadata(
+                                            path=dir_path,
+                                            size=0,
+                                            content_id=None,
+                                            created_at=datetime.now(UTC),
+                                            modified_at=datetime.now(UTC),
+                                            version=1,
+                                            zone_id=mount_context.zone_id,
+                                        )
                                     )
+                            except Exception:
+                                pass
+                except Exception:
+                    pass
+
+                # Write readme docs OUTSIDE the mount path so they're not shadowed
+                # by the connector backend. /skills/{name}/ stays in the Raft
+                # metastore and is always readable by agents and the TUI.
+                from nexus.backends.connectors.schema_generator import render_connector_readme
+
+                readme_base = f"/skills/{connector_name}"
+                readme_content = render_connector_readme(temp_backend, mp)
+                if readme_content:
+                    nx.write(
+                        f"{readme_base}/README.md",
+                        readme_content.encode("utf-8"),
+                        context=mount_context,
+                    )
+                    # Write individual schema files
+                    schemas = getattr(temp_backend, "SCHEMAS", {})
+                    if schemas and hasattr(temp_backend, "get_doc_generator"):
+                        doc_gen = temp_backend.get_doc_generator()
+                        for op_name, schema_cls in schemas.items():
+                            try:
+                                schema_yaml = doc_gen.generate_schema_yaml(op_name, schema_cls)
+                                nx.write(
+                                    f"{readme_base}/schemas/{op_name}.yaml",
+                                    schema_yaml.encode("utf-8"),
+                                    context=mount_context,
                                 )
-                        except Exception:
-                            pass
-            except Exception:
-                pass
+                            except Exception:
+                                pass
 
-            # Write readme docs OUTSIDE the mount path so they're not shadowed
-            # by the connector backend. /skills/{name}/ stays in the Raft
-            # metastore and is always readable by agents and the TUI.
-            from nexus.backends.connectors.schema_generator import render_connector_readme
+                    # Index readme doc into semantic search
+                    search_svc = getattr(mount_svc, "_search_service", None)
+                    if search_svc:
+                        search_daemon = getattr(search_svc, "_search_daemon", None)
+                        if search_daemon:
+                            import contextlib
 
-            readme_base = f"/skills/{connector_name}"
-            readme_content = render_connector_readme(temp_backend, mp)
-            if readme_content:
-                nx.write(
-                    f"{readme_base}/README.md",
-                    readme_content.encode("utf-8"),
-                    context=mount_context,
-                )
-                # Write individual schema files
-                schemas = getattr(temp_backend, "SCHEMAS", {})
-                if schemas and hasattr(temp_backend, "get_doc_generator"):
-                    doc_gen = temp_backend.get_doc_generator()
-                    for op_name, schema_cls in schemas.items():
-                        try:
-                            schema_yaml = doc_gen.generate_schema_yaml(op_name, schema_cls)
-                            nx.write(
-                                f"{readme_base}/schemas/{op_name}.yaml",
-                                schema_yaml.encode("utf-8"),
-                                context=mount_context,
-                            )
-                        except Exception:
-                            pass
+                            with contextlib.suppress(Exception):
+                                await search_daemon.index_documents(
+                                    [
+                                        {
+                                            "id": f"{readme_base}/README.md",
+                                            "text": readme_content,
+                                            "path": f"{readme_base}/README.md",
+                                        }
+                                    ],
+                                    zone_id=mount_context.zone_id or "default",
+                                )
+        except Exception:
+            pass  # Best effort — mount works without skill docs
 
-                # Index readme doc into semantic search
-                search_svc = getattr(mount_svc, "_search_service", None)
-                if search_svc:
-                    search_daemon = getattr(search_svc, "_search_daemon", None)
-                    if search_daemon:
-                        import contextlib
+        try:
+            result = await mount_svc.add_mount(
+                mount_point=req.mount_point,
+                backend_type=req.connector_type,
+                backend_config=req.config,
+                context=mount_context,
+            )
+            _mount_types[req.mount_point] = req.connector_type
 
-                        with contextlib.suppress(Exception):
-                            await search_daemon.index_documents(
-                                [
-                                    {
-                                        "id": f"{readme_base}/README.md",
-                                        "text": readme_content,
-                                        "path": f"{readme_base}/README.md",
-                                    }
-                                ],
-                                zone_id=mount_context.zone_id or "default",
-                            )
-    except Exception:
-        pass  # Best effort — mount works without skill docs
-
-    try:
-        result = await mount_svc.add_mount(
-            mount_point=req.mount_point,
-            backend_type=req.connector_type,
-            backend_config=req.config,
-            context=mount_context,
-        )
-        _mount_types[req.mount_point] = req.connector_type
-
-        # Also persist the mount config via MountManager so the bundle
-        # exporter (`nexus zone export --include-mounts`, Issue #4083)
-        # can find it. `add_mount` only registers in the kernel runtime
-        # mount table; without this, mounts created via the HTTP API
-        # surface as `mount_count=0` in exports — silently invisible.
-        #
-        # We don't roll back the kernel mount on persist failure: the
-        # caller still gets a working live mount, just not a portable
-        # one. But the response carries `persisted` / `persist_warning`
-        # so the caller (and audit log) sees the gap explicitly rather
-        # than discovering it later via an empty bundle.
-        persisted: bool | None = None
-        persist_warning: str | None = None
-        if getattr(mount_svc, "mount_manager", None) is not None:
-            persisted = False
-            try:
-                await mount_svc.save_mount(
-                    mount_point=req.mount_point,
-                    backend_type=req.connector_type,
-                    backend_config=req.config,
-                    context=mount_context,
-                )
-                persisted = True
-            except ValueError as dup_exc:
-                # ValueError can mean "mount_point already exists" (the
-                # idempotent-retry case we want to swallow) OR a real
-                # validation failure. Distinguish by message — if it
-                # doesn't look like an existence collision, surface as a
-                # warning so operators don't lose the signal.
-                msg = str(dup_exc).lower()
-                if "exist" in msg or "duplicate" in msg or "already" in msg:
-                    persisted = True  # already in store; treat as success
-                else:
+            # Also persist the mount config via MountManager so the bundle
+            # exporter (`nexus zone export --include-mounts`, Issue #4083)
+            # can find it. `add_mount` only registers in the kernel runtime
+            # mount table; without this, mounts created via the HTTP API
+            # surface as `mount_count=0` in exports.
+            persisted: bool | None = None
+            persist_warning: str | None = None
+            if getattr(mount_svc, "mount_manager", None) is not None:
+                persisted = False
+                try:
+                    await mount_svc.save_mount(
+                        mount_point=req.mount_point,
+                        backend_type=req.connector_type,
+                        backend_config=req.config,
+                        context=mount_context,
+                    )
+                    persisted = True
+                except ValueError as dup_exc:
+                    msg = str(dup_exc).lower()
+                    if "exist" in msg or "duplicate" in msg or "already" in msg:
+                        persisted = True
+                    else:
+                        persist_warning = (
+                            f"Mount activated, but persistence rejected the "
+                            f"config: {dup_exc}. Bundle export will not include "
+                            f"this mount until the persistent record is fixed."
+                        )
+                        logger.warning(
+                            "Mount %s activated but save_mount rejected: %s",
+                            req.mount_point,
+                            dup_exc,
+                        )
+                except Exception as persist_exc:
                     persist_warning = (
-                        f"Mount activated, but persistence rejected the "
-                        f"config: {dup_exc}. Bundle export will not include "
-                        f"this mount until the persistent record is fixed."
+                        f"Mount activated, but persistence failed: {persist_exc}. "
+                        f"Bundle export will not include this mount until the "
+                        f"persistent record is fixed."
                     )
                     logger.warning(
-                        "Mount %s activated but save_mount rejected: %s",
+                        "Mount %s activated but persistence failed: %s",
                         req.mount_point,
-                        dup_exc,
+                        persist_exc,
                     )
-            except Exception as persist_exc:
-                persist_warning = (
-                    f"Mount activated, but persistence failed: {persist_exc}. "
-                    f"Bundle export will not include this mount until the "
-                    f"persistent record is fixed."
-                )
-                logger.warning(
-                    "Mount %s activated but persistence failed: %s",
-                    req.mount_point,
-                    persist_exc,
-                )
 
-        return MountResponse(
-            mounted=True,
-            mount_point=str(result),
-            persisted=persisted,
-            persist_warning=persist_warning,
-        )
-    except Exception as e:
-        return MountResponse(mounted=False, mount_point=req.mount_point, error=str(e))
+            return MountResponse(
+                mounted=True,
+                mount_point=str(result),
+                persisted=persisted,
+                persist_warning=persist_warning,
+            )
+        except Exception as e:
+            return MountResponse(mounted=False, mount_point=req.mount_point, error=str(e))
+
+    return await run_zone_scoped(_get_zone_registry(request), mount_context.zone_id, _mount)
 
 
 @router.get("/mounts", response_model=list[MountInfo])
 async def list_mounted_connectors(
     request: Request,
-    _: dict = Depends(require_auth),
+    auth_result: dict = Depends(require_auth),
 ) -> list[MountInfo]:
     """List all mounted connectors with status."""
     mount_svc = _get_mount_service(request)
-    mounts = await mount_svc.list_mounts()
 
-    result = []
-    for m in mounts:
-        mp = m.get("mount_point", "")
-        # All backends are Rust-native — no Python backend metadata
-        # for skill_name/operations.  Use mount-level metadata only.
-        result.append(
-            MountInfo(
-                mount_point=mp,
-                skill_name=None,
-                operations=[],
-                sync_status=m.get("sync_status"),
-                last_sync=m.get("last_sync"),
+    async def _list_mounts() -> list[MountInfo]:
+        mounts = await mount_svc.list_mounts()
+
+        result = []
+        for m in mounts:
+            mp = m.get("mount_point", "")
+            # All backends are Rust-native — no Python backend metadata
+            # for skill_name/operations.  Use mount-level metadata only.
+            result.append(
+                MountInfo(
+                    mount_point=mp,
+                    skill_name=None,
+                    operations=[],
+                    sync_status=m.get("sync_status"),
+                    last_sync=m.get("last_sync"),
+                )
             )
-        )
+        return result
 
-    return result
+    return await run_zone_scoped(_get_zone_registry(request), _auth_zone(auth_result), _list_mounts)
 
 
 @router.post("/unmount", response_model=MountResponse)
 async def unmount_connector(
     req: MountRequest,
     request: Request,
-    _: dict = Depends(require_auth),
+    auth_result: dict = Depends(require_auth),
 ) -> MountResponse:
     """Unmount a connector."""
     mount_svc = _get_mount_service(request)
-    try:
-        await mount_svc.remove_mount(mount_point=req.mount_point)
-        _mount_types.pop(req.mount_point, None)
 
-        # Mirror the dual-write from the mount handler: also drop the
-        # persisted MountManager record so the bundle exporter (Issue
-        # #4083) doesn't keep returning a stale entry for an unmounted
-        # path. Best-effort — kernel unmount succeeded, so we report
-        # success regardless.
-        if getattr(mount_svc, "mount_manager", None) is not None:
-            try:
-                await mount_svc.delete_saved_mount(mount_point=req.mount_point)
-            except Exception as persist_exc:
-                import logging
+    async def _unmount() -> MountResponse:
+        try:
+            await mount_svc.remove_mount(mount_point=req.mount_point)
+            _mount_types.pop(req.mount_point, None)
 
-                logging.getLogger(__name__).warning(
-                    "Mount removed from kernel but config persistence cleanup failed for %s: %s",
-                    req.mount_point,
-                    persist_exc,
-                )
+            # Mirror the dual-write from the mount handler: also drop the
+            # persisted MountManager record so bundle export does not keep a
+            # stale entry for an unmounted path. Best effort: kernel unmount
+            # already succeeded, so still report success.
+            if getattr(mount_svc, "mount_manager", None) is not None:
+                try:
+                    await mount_svc.delete_saved_mount(mount_point=req.mount_point)
+                except Exception as persist_exc:
+                    logger.warning(
+                        "Mount removed from kernel but config persistence cleanup failed for %s: %s",
+                        req.mount_point,
+                        persist_exc,
+                    )
 
-        return MountResponse(mounted=False, mount_point=req.mount_point)
-    except Exception as e:
-        return MountResponse(mounted=False, mount_point=req.mount_point, error=str(e))
+            return MountResponse(mounted=False, mount_point=req.mount_point)
+        except Exception as e:
+            return MountResponse(mounted=False, mount_point=req.mount_point, error=str(e))
+
+    return await run_zone_scoped(_get_zone_registry(request), _auth_zone(auth_result), _unmount)
 
 
 # ---------------------------------------------------------------------------
@@ -824,7 +847,7 @@ async def unmount_connector(
 async def get_readme_doc(
     mount_path: str,
     request: Request,
-    _: dict = Depends(require_auth),
+    auth_result: dict = Depends(require_auth),
 ) -> ReadmeDocResponse:
     """Get README.md and schema list for a mounted connector."""
     if not mount_path.startswith("/"):
@@ -833,44 +856,47 @@ async def get_readme_doc(
     nx = _get_nx(request)
     mp = mount_path.rstrip("/")
 
-    # Skill backend no longer stored in DLC — always None
-    backend = None
+    async def _readme() -> ReadmeDocResponse:
+        # Skill backend no longer stored in DLC — always None
+        backend = None
 
-    # Generate skill doc from backend (preferred — always fresh)
-    content = ""
-    if backend and hasattr(backend, "generate_readme"):
-        import contextlib
+        # Generate skill doc from backend (preferred — always fresh)
+        content = ""
+        if backend and hasattr(backend, "generate_readme"):
+            import contextlib
 
-        with contextlib.suppress(Exception):
-            from nexus.backends.connectors.schema_generator import render_connector_readme
+            with contextlib.suppress(Exception):
+                from nexus.backends.connectors.schema_generator import render_connector_readme
 
-            content = render_connector_readme(backend, mp)
+                content = render_connector_readme(backend, mp)
 
-    # Fall back to reading from VFS if backend generation failed
-    if not content:
-        try:
-            raw = await asyncio.to_thread(nx.sys_read, f"{mp}/.readme/README.md")
-            content = raw.decode("utf-8") if isinstance(raw, bytes) else str(raw)
-        except Exception:
-            pass
+        # Fall back to reading from VFS if backend generation failed
+        if not content:
+            try:
+                raw = await asyncio.to_thread(nx.sys_read, f"{mp}/.readme/README.md")
+                content = raw.decode("utf-8") if isinstance(raw, bytes) else str(raw)
+            except Exception:
+                pass
 
-    if not content:
-        raise HTTPException(status_code=404, detail=f"No skill docs found for {mount_path}")
+        if not content:
+            raise HTTPException(status_code=404, detail=f"No skill docs found for {mount_path}")
 
-    # List schemas — from backend first, then VFS
-    schemas: list[str] = []
-    if backend:
-        s = getattr(backend, "SCHEMAS", {})
-        t = getattr(backend, "OPERATION_TRAITS", {})
-        schemas = list(s.keys()) if s else list(t.keys())
-    if not schemas:
-        try:
-            entries = await asyncio.to_thread(nx.sys_readdir, f"{mp}/.readme/schemas")
-            schemas = [str(e).replace(".yaml", "") for e in entries if str(e).endswith(".yaml")]
-        except Exception:
-            pass
+        # List schemas — from backend first, then VFS
+        schemas: list[str] = []
+        if backend:
+            s = getattr(backend, "SCHEMAS", {})
+            t = getattr(backend, "OPERATION_TRAITS", {})
+            schemas = list(s.keys()) if s else list(t.keys())
+        if not schemas:
+            try:
+                entries = await asyncio.to_thread(nx.sys_readdir, f"{mp}/.readme/schemas")
+                schemas = [str(e).replace(".yaml", "") for e in entries if str(e).endswith(".yaml")]
+            except Exception:
+                pass
 
-    return ReadmeDocResponse(mount_point=mount_path, content=content, schemas=schemas)
+        return ReadmeDocResponse(mount_point=mount_path, content=content, schemas=schemas)
+
+    return await run_zone_scoped(_get_zone_registry(request), _auth_zone(auth_result), _readme)
 
 
 @router.get("/schema/{mount_path:path}/{operation}")
@@ -878,7 +904,7 @@ async def get_schema(
     mount_path: str,
     operation: str,
     request: Request,
-    _: dict = Depends(require_auth),
+    auth_result: dict = Depends(require_auth),
 ) -> SchemaResponse:
     """Get annotated schema for an operation."""
     if not mount_path.startswith("/"):
@@ -887,52 +913,53 @@ async def get_schema(
     nx = _get_nx(request)
     mp = mount_path.rstrip("/")
 
-    # Skill backend no longer stored in DLC — always None
-    backend = None
+    async def _schema() -> SchemaResponse:
+        # Skill backend no longer stored in DLC — always None
+        backend = None
 
-    # Try generating from backend's schema generator
-    if backend:
-        try:
-            generator = getattr(backend, "get_doc_generator", None)
-            if generator:
-                doc_gen = generator()
-                schemas = getattr(backend, "SCHEMAS", {})
-                if operation in schemas:
-                    content = doc_gen.generate_schema_yaml(operation, schemas[operation])
-                    return SchemaResponse(
-                        mount_point=mount_path, operation=operation, content=content
-                    )
-        except Exception:
-            pass
-
-        # For backends with OPERATION_TRAITS but no SCHEMAS (e.g., hand-written docs),
-        # extract the operation section from the full skill doc
-        traits = getattr(backend, "OPERATION_TRAITS", {})
-        if operation in traits:
+        if backend:
             try:
-                from nexus.backends.connectors.schema_generator import render_connector_readme
-
-                full_doc = render_connector_readme(backend, mp)
-                # Find the operation section in the doc
-                op_display = operation.replace("_", " ").title()
-                idx = full_doc.lower().find(op_display.lower())
-                if idx >= 0:
-                    section = full_doc[idx : idx + 500]
-                    return SchemaResponse(
-                        mount_point=mount_path, operation=operation, content=section
-                    )
+                generator = getattr(backend, "get_doc_generator", None)
+                if generator:
+                    doc_gen = generator()
+                    schemas = getattr(backend, "SCHEMAS", {})
+                    if operation in schemas:
+                        content = doc_gen.generate_schema_yaml(operation, schemas[operation])
+                        return SchemaResponse(
+                            mount_point=mount_path, operation=operation, content=content
+                        )
             except Exception:
                 pass
 
-    # Try reading from VFS
-    try:
-        raw = await asyncio.to_thread(nx.sys_read, f"{mp}/.readme/schemas/{operation}.yaml")
-        content = raw.decode("utf-8") if isinstance(raw, bytes) else str(raw)
-        return SchemaResponse(mount_point=mount_path, operation=operation, content=content)
-    except Exception:
-        pass
+            traits = getattr(backend, "OPERATION_TRAITS", {})
+            if operation in traits:
+                try:
+                    from nexus.backends.connectors.schema_generator import render_connector_readme
 
-    raise HTTPException(status_code=404, detail=f"Schema '{operation}' not found for {mount_path}")
+                    full_doc = render_connector_readme(backend, mp)
+                    op_display = operation.replace("_", " ").title()
+                    idx = full_doc.lower().find(op_display.lower())
+                    if idx >= 0:
+                        section = full_doc[idx : idx + 500]
+                        return SchemaResponse(
+                            mount_point=mount_path, operation=operation, content=section
+                        )
+                except Exception:
+                    pass
+
+        # Try reading from VFS
+        try:
+            raw = await asyncio.to_thread(nx.sys_read, f"{mp}/.readme/schemas/{operation}.yaml")
+            content = raw.decode("utf-8") if isinstance(raw, bytes) else str(raw)
+            return SchemaResponse(mount_point=mount_path, operation=operation, content=content)
+        except Exception:
+            pass
+
+        raise HTTPException(
+            status_code=404, detail=f"Schema '{operation}' not found for {mount_path}"
+        )
+
+    return await run_zone_scoped(_get_zone_registry(request), _auth_zone(auth_result), _schema)
 
 
 # ---------------------------------------------------------------------------
@@ -981,40 +1008,48 @@ async def write_to_connector(
         virtual_path=mount_path,
     )
 
-    try:
-        data = req.yaml_content.encode("utf-8")
+    async def _write() -> WriteResponse:
+        try:
+            data = req.yaml_content.encode("utf-8")
 
-        # CLI-backed connectors dispatch YAML operations (send_email, create_draft,
-        # etc.) via write_content() — they must NOT go through nx.write() which
-        # stores to CAS. Gate on the "cli_backed" capability to avoid bypassing
-        # the kernel write path for ordinary path-addressed backends.
+            # CLI-backed connectors dispatch YAML operations (send_email, create_draft,
+            # etc.) via write_content() — they must NOT go through nx.write() which
+            # stores to CAS. Gate on the "cli_backed" capability to avoid bypassing
+            # the kernel write path for ordinary path-addressed backends.
 
-        # All backends are Rust-native now — check if this is a CLI connector
-        # by examining the backend_name pattern.
-        is_cli_connector = _route_backend_name is not None and (
-            "cli" in _route_backend_name or "gws" in _route_backend_name
-        )
-
-        if is_cli_connector and _backend_path:
-            # Write permissions are enforced by the pre-write intercept hooks below.
-            from nexus.contracts.vfs_hooks import WriteHookContext as _WHC
-
-            # Load existing metadata so permission hooks can distinguish
-            # overwrite (check WRITE on file) vs create (check WRITE on parent).
-            _old_meta = nx._kernel.metastore_get(mount_path)
-
-            nx.intercept_pre_write(
-                _WHC(path=mount_path, content=data, context=write_context, old_metadata=_old_meta)
+            # All backends are Rust-native now — check if this is a CLI connector
+            # by examining the backend_name pattern.
+            is_cli_connector = _route_backend_name is not None and (
+                "cli" in _route_backend_name or "gws" in _route_backend_name
             )
 
-            # Write via kernel — Rust backend handles CLI dispatch.
-            result = nx.write(mount_path, data, context=write_context)
-        else:
-            result = nx.write(mount_path, data, context=write_context)
+            if is_cli_connector and _backend_path:
+                # Write permissions are enforced by the pre-write intercept hooks below.
+                from nexus.contracts.vfs_hooks import WriteHookContext as _WHC
 
-        return WriteResponse(
-            success=True,
-            content_id=getattr(result, "content_id", None) if result else None,
-        )
-    except Exception as e:
-        return WriteResponse(success=False, error=str(e))
+                # Load existing metadata so permission hooks can distinguish
+                # overwrite (check WRITE on file) vs create (check WRITE on parent).
+                _old_meta = nx._kernel.metastore_get(mount_path)
+
+                nx.intercept_pre_write(
+                    _WHC(
+                        path=mount_path,
+                        content=data,
+                        context=write_context,
+                        old_metadata=_old_meta,
+                    )
+                )
+
+                # Write via kernel — Rust backend handles CLI dispatch.
+                result = nx.write(mount_path, data, context=write_context)
+            else:
+                result = nx.write(mount_path, data, context=write_context)
+
+            return WriteResponse(
+                success=True,
+                content_id=getattr(result, "content_id", None) if result else None,
+            )
+        except Exception as e:
+            return WriteResponse(success=False, error=str(e))
+
+    return await run_zone_scoped(_get_zone_registry(request), write_context.zone_id, _write)

--- a/src/nexus/server/api/v2/routers/credentials.py
+++ b/src/nexus/server/api/v2/routers/credentials.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel, Field
 
 from nexus.contracts.credential_types import Ability, Capability
 from nexus.server.dependencies import get_operation_context, require_auth
+from nexus.server.zone_execution import run_zone_scoped
 
 logger = logging.getLogger(__name__)
 
@@ -104,6 +105,10 @@ def _get_key_service(request: Request) -> Any:
     return svc
 
 
+def _get_zone_registry(request: Request) -> Any | None:
+    return getattr(request.app.state, "zone_registry", None)
+
+
 def _parse_capabilities(raw: list[CapabilityRequest]) -> list[Capability]:
     """Convert Pydantic models to domain Capability objects."""
     import types
@@ -128,6 +133,7 @@ def _parse_capabilities(raw: list[CapabilityRequest]) -> list[Capability]:
 @router.post("/api/v2/credentials/issue")
 async def issue_credential(
     body: IssueCredentialRequest,
+    request: Request,
     auth_result: dict[str, Any] = Depends(require_auth),
     credential_service: Any = Depends(_get_credential_service),
     key_service: Any = Depends(_get_key_service),
@@ -138,153 +144,183 @@ async def issue_credential(
     subject_id) or be an admin.
     """
     _authorize_agent_credential_access(auth_result, body.agent_id, "issue")
-    # Resolve agent's DID
-    keys = await asyncio.to_thread(key_service.get_active_keys, body.agent_id)
-    if not keys:
-        raise HTTPException(
-            status_code=404,
-            detail=f"No identity found for agent '{body.agent_id}'. Register the agent first.",
-        )
+    ctx = get_operation_context(auth_result)
 
-    subject_did = keys[0].did
+    async def _issue() -> dict[str, Any]:
+        # Resolve agent's DID
+        keys = await asyncio.to_thread(key_service.get_active_keys, body.agent_id)
+        if not keys:
+            raise HTTPException(
+                status_code=404,
+                detail=f"No identity found for agent '{body.agent_id}'. Register the agent first.",
+            )
 
-    try:
-        capabilities = _parse_capabilities(body.capabilities)
-        claims = await asyncio.to_thread(
-            credential_service.issue_credential,
-            body.agent_id,
-            subject_did,
-            capabilities,
-            ttl_seconds=body.ttl_seconds,
-        )
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        subject_did = keys[0].did
 
-    return {
-        "credential_id": claims.credential_id,
-        "issuer_did": claims.issuer_did,
-        "subject_did": claims.subject_did,
-        "capabilities": [cap.to_dict() for cap in claims.capabilities],
-        "issued_at": claims.issued_at,
-        "expires_at": claims.expires_at,
-        "delegation_depth": claims.delegation_depth,
-    }
+        try:
+            capabilities = _parse_capabilities(body.capabilities)
+            claims = await asyncio.to_thread(
+                credential_service.issue_credential,
+                body.agent_id,
+                subject_did,
+                capabilities,
+                ttl_seconds=body.ttl_seconds,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        return {
+            "credential_id": claims.credential_id,
+            "issuer_did": claims.issuer_did,
+            "subject_did": claims.subject_did,
+            "capabilities": [cap.to_dict() for cap in claims.capabilities],
+            "issued_at": claims.issued_at,
+            "expires_at": claims.expires_at,
+            "delegation_depth": claims.delegation_depth,
+        }
+
+    return await run_zone_scoped(_get_zone_registry(request), ctx.zone_id, _issue)
 
 
 @router.post("/api/v2/credentials/verify")
 async def verify_credential(
     body: VerifyCredentialRequest,
-    _auth_result: dict[str, Any] = Depends(require_auth),
+    request: Request,
+    auth_result: dict[str, Any] = Depends(require_auth),
     credential_service: Any = Depends(_get_credential_service),
 ) -> dict:
     """Verify a JWT-VC capability credential.
 
     Returns the parsed claims if valid, or an error if invalid.
     """
-    try:
-        claims = await asyncio.to_thread(
-            credential_service.verify_credential,
-            body.token,
-        )
-    except ValueError as exc:
-        return {"valid": False, "error": str(exc)}
+    ctx = get_operation_context(auth_result)
 
-    return {
-        "valid": True,
-        "credential_id": claims.credential_id,
-        "issuer_did": claims.issuer_did,
-        "subject_did": claims.subject_did,
-        "capabilities": [cap.to_dict() for cap in claims.capabilities],
-        "expires_at": claims.expires_at,
-        "delegation_depth": claims.delegation_depth,
-    }
+    async def _verify() -> dict[str, Any]:
+        try:
+            claims = await asyncio.to_thread(
+                credential_service.verify_credential,
+                body.token,
+            )
+        except ValueError as exc:
+            return {"valid": False, "error": str(exc)}
+
+        return {
+            "valid": True,
+            "credential_id": claims.credential_id,
+            "issuer_did": claims.issuer_did,
+            "subject_did": claims.subject_did,
+            "capabilities": [cap.to_dict() for cap in claims.capabilities],
+            "expires_at": claims.expires_at,
+            "delegation_depth": claims.delegation_depth,
+        }
+
+    return await run_zone_scoped(_get_zone_registry(request), ctx.zone_id, _verify)
 
 
 @router.delete("/api/v2/credentials/{credential_id}")
 async def revoke_credential(
     credential_id: str,
-    _auth_result: dict[str, Any] = Depends(require_auth),
+    request: Request,
+    auth_result: dict[str, Any] = Depends(require_auth),
     credential_service: Any = Depends(_get_credential_service),
 ) -> dict:
     """Revoke a credential by ID."""
-    revoked = await asyncio.to_thread(
-        credential_service.revoke_credential,
-        credential_id,
-    )
+    ctx = get_operation_context(auth_result)
 
-    if not revoked:
-        raise HTTPException(status_code=404, detail="Credential not found")
+    async def _revoke() -> dict[str, Any]:
+        revoked = await asyncio.to_thread(
+            credential_service.revoke_credential,
+            credential_id,
+        )
 
-    return {"revoked": True, "credential_id": credential_id}
+        if not revoked:
+            raise HTTPException(status_code=404, detail="Credential not found")
+
+        return {"revoked": True, "credential_id": credential_id}
+
+    return await run_zone_scoped(_get_zone_registry(request), ctx.zone_id, _revoke)
 
 
 @router.get("/api/v2/credentials/{credential_id}")
 async def get_credential_status(
     credential_id: str,
-    _auth_result: dict[str, Any] = Depends(require_auth),
+    request: Request,
+    auth_result: dict[str, Any] = Depends(require_auth),
     credential_service: Any = Depends(_get_credential_service),
 ) -> dict:
     """Get the status of a credential."""
-    status = await asyncio.to_thread(
-        credential_service.get_credential_status,
-        credential_id,
-    )
+    ctx = get_operation_context(auth_result)
 
-    if status is None:
-        raise HTTPException(status_code=404, detail="Credential not found")
+    async def _get() -> dict[str, Any]:
+        status = await asyncio.to_thread(
+            credential_service.get_credential_status,
+            credential_id,
+        )
 
-    return {
-        "credential_id": status.credential_id,
-        "issuer_did": status.issuer_did,
-        "subject_did": status.subject_did,
-        "subject_agent_id": status.subject_agent_id,
-        "is_active": status.is_active,
-        "created_at": status.created_at.isoformat() if status.created_at else None,
-        "expires_at": status.expires_at.isoformat() if status.expires_at else None,
-        "revoked_at": status.revoked_at.isoformat() if status.revoked_at else None,
-        "delegation_depth": status.delegation_depth,
-        "parent_credential_id": status.parent_credential_id,
-    }
+        if status is None:
+            raise HTTPException(status_code=404, detail="Credential not found")
+
+        return {
+            "credential_id": status.credential_id,
+            "issuer_did": status.issuer_did,
+            "subject_did": status.subject_did,
+            "subject_agent_id": status.subject_agent_id,
+            "is_active": status.is_active,
+            "created_at": status.created_at.isoformat() if status.created_at else None,
+            "expires_at": status.expires_at.isoformat() if status.expires_at else None,
+            "revoked_at": status.revoked_at.isoformat() if status.revoked_at else None,
+            "delegation_depth": status.delegation_depth,
+            "parent_credential_id": status.parent_credential_id,
+        }
+
+    return await run_zone_scoped(_get_zone_registry(request), ctx.zone_id, _get)
 
 
 @router.get("/api/v2/agents/{agent_id}/credentials")
 async def list_agent_credentials(
     agent_id: str,
+    request: Request,
     active_only: bool = True,
     auth_result: dict[str, Any] = Depends(require_auth),
     credential_service: Any = Depends(_get_credential_service),
 ) -> dict:
     """List credentials for an agent."""
     _authorize_agent_credential_access(auth_result, agent_id, "list")
-    credentials = await asyncio.to_thread(
-        credential_service.list_agent_credentials,
-        agent_id,
-        active_only=active_only,
-    )
+    ctx = get_operation_context(auth_result)
 
-    return {
-        "agent_id": agent_id,
-        "count": len(credentials),
-        "credentials": [
-            {
-                "credential_id": c.credential_id,
-                "issuer_did": c.issuer_did,
-                "subject_did": c.subject_did,
-                "is_active": c.is_active,
-                "created_at": c.created_at.isoformat() if c.created_at else None,
-                "expires_at": c.expires_at.isoformat() if c.expires_at else None,
-                "revoked_at": c.revoked_at.isoformat() if c.revoked_at else None,
-                "delegation_depth": c.delegation_depth,
-            }
-            for c in credentials
-        ],
-    }
+    async def _list() -> dict[str, Any]:
+        credentials = await asyncio.to_thread(
+            credential_service.list_agent_credentials,
+            agent_id,
+            active_only=active_only,
+        )
+
+        return {
+            "agent_id": agent_id,
+            "count": len(credentials),
+            "credentials": [
+                {
+                    "credential_id": c.credential_id,
+                    "issuer_did": c.issuer_did,
+                    "subject_did": c.subject_did,
+                    "is_active": c.is_active,
+                    "created_at": c.created_at.isoformat() if c.created_at else None,
+                    "expires_at": c.expires_at.isoformat() if c.expires_at else None,
+                    "revoked_at": c.revoked_at.isoformat() if c.revoked_at else None,
+                    "delegation_depth": c.delegation_depth,
+                }
+                for c in credentials
+            ],
+        }
+
+    return await run_zone_scoped(_get_zone_registry(request), ctx.zone_id, _list)
 
 
 @router.post("/api/v2/credentials/delegate")
 async def delegate_credential(
     body: DelegateCredentialRequest,
-    _auth_result: dict[str, Any] = Depends(require_auth),
+    request: Request,
+    auth_result: dict[str, Any] = Depends(require_auth),
     credential_service: Any = Depends(_get_credential_service),
     key_service: Any = Depends(_get_key_service),
 ) -> dict:
@@ -293,35 +329,40 @@ async def delegate_credential(
     The delegated capabilities must be a subset of the parent credential.
     Caller must own the parent credential (verified by service via token claims).
     """
-    # Resolve delegate's DID
-    keys = await asyncio.to_thread(key_service.get_active_keys, body.delegate_agent_id)
-    if not keys:
-        raise HTTPException(
-            status_code=404,
-            detail=f"No identity found for delegate agent '{body.delegate_agent_id}'.",
-        )
+    ctx = get_operation_context(auth_result)
 
-    delegate_did = keys[0].did
+    async def _delegate() -> dict[str, Any]:
+        # Resolve delegate's DID
+        keys = await asyncio.to_thread(key_service.get_active_keys, body.delegate_agent_id)
+        if not keys:
+            raise HTTPException(
+                status_code=404,
+                detail=f"No identity found for delegate agent '{body.delegate_agent_id}'.",
+            )
 
-    try:
-        capabilities = _parse_capabilities(body.capabilities)
-        claims = await asyncio.to_thread(
-            credential_service.delegate_credential,
-            body.parent_token,
-            body.delegate_agent_id,
-            delegate_did,
-            capabilities,
-            ttl_seconds=body.ttl_seconds,
-        )
-    except ValueError as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
+        delegate_did = keys[0].did
 
-    return {
-        "credential_id": claims.credential_id,
-        "issuer_did": claims.issuer_did,
-        "subject_did": claims.subject_did,
-        "capabilities": [cap.to_dict() for cap in claims.capabilities],
-        "expires_at": claims.expires_at,
-        "delegation_depth": claims.delegation_depth,
-        "parent_credential_id": claims.parent_credential_id,
-    }
+        try:
+            capabilities = _parse_capabilities(body.capabilities)
+            claims = await asyncio.to_thread(
+                credential_service.delegate_credential,
+                body.parent_token,
+                body.delegate_agent_id,
+                delegate_did,
+                capabilities,
+                ttl_seconds=body.ttl_seconds,
+            )
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+
+        return {
+            "credential_id": claims.credential_id,
+            "issuer_did": claims.issuer_did,
+            "subject_did": claims.subject_did,
+            "capabilities": [cap.to_dict() for cap in claims.capabilities],
+            "expires_at": claims.expires_at,
+            "delegation_depth": claims.delegation_depth,
+            "parent_credential_id": claims.parent_credential_id,
+        }
+
+    return await run_zone_scoped(_get_zone_registry(request), ctx.zone_id, _delegate)

--- a/src/nexus/server/api/v2/routers/events_replay.py
+++ b/src/nexus/server/api/v2/routers/events_replay.py
@@ -395,9 +395,13 @@ async def watch_for_changes(
     context = get_operation_context(auth_result)
 
     try:
-        change = await asyncio.to_thread(
-            nexus_fs.sys_watch, path, timeout, recursive=False, context=context
-        )
+
+        async def _work() -> Any:
+            return await asyncio.to_thread(
+                nexus_fs.sys_watch, path, timeout, recursive=False, context=context
+            )
+
+        change = await run_zone_scoped(_get_zone_registry(request), context.zone_id, _work)
         if change is None:
             return {"changes": [], "timeout": True}
         return {"changes": [change], "timeout": False}

--- a/src/nexus/server/api/v2/routers/events_replay.py
+++ b/src/nexus/server/api/v2/routers/events_replay.py
@@ -23,6 +23,7 @@ from fastapi.responses import StreamingResponse
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.exceptions import NexusFileNotFoundError, NexusPermissionError
 from nexus.server.dependencies import get_operation_context, require_auth
+from nexus.server.zone_execution import run_zone_scoped
 
 logger = logging.getLogger(__name__)
 
@@ -61,7 +62,12 @@ def _get_replay_service(request: Request) -> Any:
 
     record_store = getattr(request.app.state, "record_store", None)
     if record_store is None:
-        raise HTTPException(status_code=503, detail="Database not configured")
+        session_factory = getattr(request.app.state, "session_factory", None)
+        if session_factory is None:
+            raise HTTPException(status_code=503, detail="Database not configured")
+        record_store = type(
+            "_SessionFactoryRecordStore", (), {"session_factory": session_factory}
+        )()
 
     from nexus.services.event_log.replay import EventReplayService
 
@@ -71,6 +77,10 @@ def _get_replay_service(request: Request) -> Any:
     )
     request.app.state.replay_service = service
     return service
+
+
+def _get_zone_registry(request: Request) -> Any | None:
+    return getattr(request.app.state, "zone_registry", None)
 
 
 def _get_stream_config(request: Request) -> dict[str, Any]:  # noqa: ARG001
@@ -125,25 +135,28 @@ async def replay_events(
     if event_types:
         parsed_types = [t.strip() for t in event_types.split(",") if t.strip()]
 
-    try:
-        result = service.replay(
-            zone_id=effective_zone,
-            since_revision=since_revision,
-            since_timestamp=since_timestamp,
-            event_types=parsed_types,
-            path_pattern=path_pattern,
-            agent_id=agent_id,
-            limit=limit,
-            cursor=cursor,
-        )
-        return {
-            "events": [ev.to_dict() for ev in result.events],
-            "next_cursor": result.next_cursor,
-            "has_more": result.has_more,
-        }
-    except Exception as e:
-        logger.error("Event replay query error: %s", e, exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to replay events") from e
+    async def _replay() -> dict[str, Any]:
+        try:
+            result = service.replay(
+                zone_id=effective_zone,
+                since_revision=since_revision,
+                since_timestamp=since_timestamp,
+                event_types=parsed_types,
+                path_pattern=path_pattern,
+                agent_id=agent_id,
+                limit=limit,
+                cursor=cursor,
+            )
+            return {
+                "events": [ev.to_dict() for ev in result.events],
+                "next_cursor": result.next_cursor,
+                "has_more": result.has_more,
+            }
+        except Exception as e:
+            logger.error("Event replay query error: %s", e, exc_info=True)
+            raise HTTPException(status_code=500, detail="Failed to replay events") from e
+
+    return await run_zone_scoped(_get_zone_registry(request), effective_zone, _replay)
 
 
 # =============================================================================
@@ -217,18 +230,22 @@ async def stream_events(
             async def _pump_events() -> None:
                 """Background task: pump events from stream into queue."""
                 try:
-                    stream = service.stream(
-                        zone_id=effective_zone,
-                        since_revision=since_revision,
-                        since_timestamp=since_timestamp,
-                        event_types=parsed_types,
-                        path_pattern=path_pattern,
-                        agent_id=agent_id,
-                        poll_interval=1.0,
-                        idle_timeout=idle_timeout,
-                    )
-                    async for event in stream:
-                        await queue.put(event)
+
+                    async def _stream() -> None:
+                        stream = service.stream(
+                            zone_id=effective_zone,
+                            since_revision=since_revision,
+                            since_timestamp=since_timestamp,
+                            event_types=parsed_types,
+                            path_pattern=path_pattern,
+                            agent_id=agent_id,
+                            poll_interval=1.0,
+                            idle_timeout=idle_timeout,
+                        )
+                        async for event in stream:
+                            await queue.put(event)
+
+                    await run_zone_scoped(_get_zone_registry(request), effective_zone, _stream)
                 finally:
                     await queue.put(None)  # sentinel
 
@@ -308,42 +325,45 @@ async def list_events(
     if (not is_admin and auth_zone) or effective_zone is None:
         effective_zone = auth_zone
 
-    try:
-        result = service.list_v1(
-            zone_id=effective_zone,
-            agent_id=agent_id,
-            operation_type=operation_type,
-            path_prefix=path_prefix,
-            since=since,
-            until=until,
-            limit=limit,
-            cursor=cursor,
-        )
+    async def _list() -> dict[str, Any]:
+        try:
+            result = service.list_v1(
+                zone_id=effective_zone,
+                agent_id=agent_id,
+                operation_type=operation_type,
+                path_prefix=path_prefix,
+                since=since,
+                until=until,
+                limit=limit,
+                cursor=cursor,
+            )
 
-        events = [
-            {
-                "event_id": ev.event_id,
-                "type": ev.type,
-                "path": ev.path,
-                "new_path": ev.new_path,
-                "zone_id": ev.zone_id,
-                "agent_id": ev.agent_id,
-                "status": ev.status,
-                "delivered": ev.delivered,
-                "timestamp": ev.timestamp or None,
+            events = [
+                {
+                    "event_id": ev.event_id,
+                    "type": ev.type,
+                    "path": ev.path,
+                    "new_path": ev.new_path,
+                    "zone_id": ev.zone_id,
+                    "agent_id": ev.agent_id,
+                    "status": ev.status,
+                    "delivered": ev.delivered,
+                    "timestamp": ev.timestamp or None,
+                }
+                for ev in result.events
+            ]
+
+            return {
+                "events": events,
+                "next_cursor": result.next_cursor,
+                "has_more": result.has_more,
             }
-            for ev in result.events
-        ]
 
-        return {
-            "events": events,
-            "next_cursor": result.next_cursor,
-            "has_more": result.has_more,
-        }
+        except Exception as e:
+            logger.error("Event log query error: %s", e, exc_info=True)
+            raise HTTPException(status_code=500, detail="Failed to query events") from e
 
-    except Exception as e:
-        logger.error("Event log query error: %s", e, exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to query events") from e
+    return await run_zone_scoped(_get_zone_registry(request), effective_zone, _list)
 
 
 # =============================================================================

--- a/src/nexus/server/api/v2/routers/events_replay.py
+++ b/src/nexus/server/api/v2/routers/events_replay.py
@@ -94,6 +94,19 @@ def _get_stream_config(request: Request) -> dict[str, Any]:  # noqa: ARG001
     }
 
 
+def _schedule_queue_put(request_loop: Any, queue: asyncio.Queue[Any], item: Any) -> None:
+    """Schedule a queue put on the request loop from a zone runner loop."""
+    if request_loop.is_closed():
+        return
+
+    def _put_nowait() -> None:
+        with contextlib.suppress(asyncio.QueueFull):
+            queue.put_nowait(item)
+
+    with contextlib.suppress(RuntimeError):
+        request_loop.call_soon_threadsafe(_put_nowait)
+
+
 # =============================================================================
 # REST replay endpoint
 # =============================================================================
@@ -226,6 +239,7 @@ async def stream_events(
             idle_timeout = config["idle_timeout"]
 
             queue: asyncio.Queue[Any] = asyncio.Queue()
+            request_loop = asyncio.get_running_loop()
 
             async def _pump_events() -> None:
                 """Background task: pump events from stream into queue."""
@@ -243,11 +257,11 @@ async def stream_events(
                             idle_timeout=idle_timeout,
                         )
                         async for event in stream:
-                            await queue.put(event)
+                            _schedule_queue_put(request_loop, queue, event)
 
                     await run_zone_scoped(_get_zone_registry(request), effective_zone, _stream)
                 finally:
-                    await queue.put(None)  # sentinel
+                    _schedule_queue_put(request_loop, queue, None)  # sentinel
 
             pump_task = asyncio.create_task(_pump_events())
 

--- a/src/nexus/server/api/v2/routers/password_vault.py
+++ b/src/nexus/server/api/v2/routers/password_vault.py
@@ -28,9 +28,11 @@ SQLAlchemy I/O in the underlying SecretsService.
 from __future__ import annotations
 
 import logging
-from typing import Any, cast
+from collections.abc import Callable
+from typing import Any, TypeVar, cast
 
-from fastapi import APIRouter, Depends, HTTPException, Query
+from anyio import from_thread
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
 from pydantic import BaseModel, ConfigDict
 
 from nexus.contracts.constants import ROOT_ZONE_ID
@@ -41,6 +43,7 @@ from nexus.contracts.secrets_access import (
     AccessContext,
 )
 from nexus.server.dependencies import require_auth
+from nexus.server.zone_execution import run_zone_scoped
 from nexus.services.password_vault.schema import VaultEntry
 from nexus.services.password_vault.service import (
     PasswordVaultService,
@@ -69,6 +72,7 @@ logger = logging.getLogger(__name__)
 router = APIRouter(prefix="/api/v2/password_vault", tags=["password_vault"])
 
 _MAX_TITLE_LEN = 1024
+T = TypeVar("T")
 
 
 def _validate_title(title: str) -> None:
@@ -122,6 +126,26 @@ def get_password_vault_service() -> PasswordVaultService:
     raise HTTPException(status_code=500, detail="Password vault service not configured")
 
 
+def _get_zone_registry(request: Request) -> Any | None:
+    return getattr(request.app.state, "zone_registry", None)
+
+
+def _auth_zone(auth_result: dict[str, Any]) -> str | None:
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
+    return zone_id if zone_id != ROOT_ZONE_ID else None
+
+
+def _run_zone_scoped_sync(request: Request, zone_id: str | None, work: Callable[[], T]) -> T:
+    zone_registry = _get_zone_registry(request)
+    if zone_registry is None or zone_id is None:
+        return work()
+
+    async def _work() -> T:
+        return work()
+
+    return from_thread.run(run_zone_scoped, zone_registry, zone_id, _work)
+
+
 # --------------------------------------------------------------------------
 # List (no path param — safe to declare first)
 # --------------------------------------------------------------------------
@@ -129,6 +153,7 @@ def get_password_vault_service() -> PasswordVaultService:
 
 @router.get("")
 def list_entries(
+    request: Request,
     access_context: str | None = Query(default=None),
     client_id: str | None = Query(default=None),
     agent_session: str | None = Query(default=None),
@@ -142,7 +167,7 @@ def list_entries(
     subject_type = auth_result.get("subject_type") or "user"
     audit_context = _build_audit_context(access_context, client_id, agent_session)
 
-    try:
+    def _list() -> dict[str, Any]:
         entries = service.list_entries(
             actor_id=actor_id,
             zone_id=zone_id,
@@ -151,6 +176,9 @@ def list_entries(
             audit_context=audit_context,
         )
         return {"entries": [e.model_dump() for e in entries], "count": len(entries)}
+
+    try:
+        return _run_zone_scoped_sync(request, _auth_zone(auth_result), _list)
     except Exception as e:
         logger.error("Failed to list vault entries: %s", e)
         raise HTTPException(status_code=500, detail=f"Failed to list vault entries: {e}") from e
@@ -164,6 +192,7 @@ def list_entries(
 @router.get("/{title:path}/versions")
 def list_versions(
     title: str,
+    request: Request,
     auth_result: dict[str, Any] = Depends(require_auth),
     service: PasswordVaultService = Depends(get_password_vault_service),
 ) -> dict[str, Any]:
@@ -172,13 +201,16 @@ def list_versions(
     subject_id = auth_result.get("subject_id") or "anonymous"
     subject_type = auth_result.get("subject_type") or "user"
 
-    try:
+    def _list_versions() -> dict[str, Any]:
         versions = service.list_versions(
             title,
             subject_id=subject_id,
             subject_type=subject_type,
         )
         return {"title": title, "versions": versions, "count": len(versions)}
+
+    try:
+        return _run_zone_scoped_sync(request, _auth_zone(auth_result), _list_versions)
     except Exception as e:
         logger.error("Failed to list vault entry versions: %s", e)
         raise HTTPException(
@@ -189,6 +221,7 @@ def list_versions(
 @router.post("/{title:path}/restore")
 def restore_entry(
     title: str,
+    request: Request,
     auth_result: dict[str, Any] = Depends(require_auth),
     service: PasswordVaultService = Depends(get_password_vault_service),
 ) -> dict[str, Any]:
@@ -199,7 +232,7 @@ def restore_entry(
     subject_id = auth_result.get("subject_id") or "anonymous"
     subject_type = auth_result.get("subject_type") or "user"
 
-    try:
+    def _restore() -> dict[str, Any]:
         ok = service.restore_entry(
             title,
             actor_id=actor_id,
@@ -210,6 +243,9 @@ def restore_entry(
         if not ok:
             raise HTTPException(status_code=404, detail="Vault entry not found")
         return {"title": title, "restored": True}
+
+    try:
+        return _run_zone_scoped_sync(request, _auth_zone(auth_result), _restore)
     except HTTPException:
         raise
     except Exception as e:
@@ -220,6 +256,7 @@ def restore_entry(
 @router.post("/{title:path}/totp")
 def generate_totp_code(
     title: str,
+    request: Request,
     body: TotpRequest | None = None,
     auth_result: dict[str, Any] = Depends(require_auth),
     service: PasswordVaultService = Depends(get_password_vault_service),
@@ -246,7 +283,7 @@ def generate_totp_code(
     body = body or TotpRequest()
     audit_context = _build_audit_context(body.access_context, body.client_id, body.agent_session)
 
-    try:
+    def _generate() -> dict[str, Any] | None:
         result = service.generate_totp(
             title,
             actor_id=actor_id,
@@ -255,6 +292,11 @@ def generate_totp_code(
             subject_type=subject_type,
             audit_context=audit_context,
         )
+
+        return result
+
+    try:
+        result = _run_zone_scoped_sync(request, _auth_zone(auth_result), _generate)
     except TotpNotConfiguredError as e:
         raise HTTPException(status_code=422, detail="totp_not_configured") from e
     except HTTPException:
@@ -277,6 +319,7 @@ def generate_totp_code(
 def put_entry(
     title: str,
     entry: VaultEntry,
+    request: Request,
     auth_result: dict[str, Any] = Depends(require_auth),
     service: PasswordVaultService = Depends(get_password_vault_service),
 ) -> dict[str, Any]:
@@ -296,7 +339,7 @@ def put_entry(
     subject_id = auth_result.get("subject_id") or "anonymous"
     subject_type = auth_result.get("subject_type") or "user"
 
-    try:
+    def _put() -> dict[str, Any]:
         return service.put_entry(
             entry,
             actor_id=actor_id,
@@ -304,6 +347,9 @@ def put_entry(
             subject_id=subject_id,
             subject_type=subject_type,
         )
+
+    try:
+        return _run_zone_scoped_sync(request, _auth_zone(auth_result), _put)
     except Exception as e:
         logger.error("Failed to put vault entry: %s", e)
         raise HTTPException(status_code=500, detail=f"Failed to put vault entry: {e}") from e
@@ -312,6 +358,7 @@ def put_entry(
 @router.get("/{title:path}")
 def get_entry(
     title: str,
+    request: Request,
     version: int | None = None,
     access_context: str | None = Query(default=None),
     client_id: str | None = Query(default=None),
@@ -327,9 +374,9 @@ def get_entry(
     subject_type = auth_result.get("subject_type") or "user"
     audit_context = _build_audit_context(access_context, client_id, agent_session)
 
-    try:
-        from nexus.bricks.secrets.service import SecretDisabledError
+    from nexus.bricks.secrets.service import SecretDisabledError
 
+    def _get() -> VaultEntry:
         return service.get_entry(
             title,
             version=version,
@@ -339,6 +386,9 @@ def get_entry(
             subject_type=subject_type,
             audit_context=audit_context,
         )
+
+    try:
+        return _run_zone_scoped_sync(request, _auth_zone(auth_result), _get)
     except VaultEntryNotFoundError as e:
         raise HTTPException(status_code=404, detail="Vault entry not found") from e
     except SecretDisabledError as e:
@@ -353,6 +403,7 @@ def get_entry(
 @router.delete("/{title:path}")
 def delete_entry(
     title: str,
+    request: Request,
     auth_result: dict[str, Any] = Depends(require_auth),
     service: PasswordVaultService = Depends(get_password_vault_service),
 ) -> dict[str, Any]:
@@ -363,7 +414,7 @@ def delete_entry(
     subject_id = auth_result.get("subject_id") or "anonymous"
     subject_type = auth_result.get("subject_type") or "user"
 
-    try:
+    def _delete() -> dict[str, Any]:
         ok = service.delete_entry(
             title,
             actor_id=actor_id,
@@ -374,6 +425,9 @@ def delete_entry(
         if not ok:
             raise HTTPException(status_code=404, detail="Vault entry not found")
         return {"title": title, "deleted": True}
+
+    try:
+        return _run_zone_scoped_sync(request, _auth_zone(auth_result), _delete)
     except HTTPException:
         raise
     except Exception as e:

--- a/src/nexus/server/api/v2/routers/search.py
+++ b/src/nexus/server/api/v2/routers/search.py
@@ -35,7 +35,9 @@ from nexus.lib.pagination import build_paginated_list_response
 from nexus.lib.rebac_filter import apply_rebac_filter as _apply_rebac_filter
 from nexus.lib.rebac_filter import compute_rebac_fetch_limit as _compute_rebac_fetch_limit
 from nexus.lib.rebac_filter import rebac_denial_stats as _rebac_denial_stats
+from nexus.runtime.zone_resolution import target_zone_for_context
 from nexus.server.dependencies import require_auth
+from nexus.server.zone_execution import run_zone_scoped
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +96,17 @@ def _get_async_read_session_factory(request: Request) -> Any:
             detail="Async session factory not available (RecordStore not configured)",
         )
     return factory
+
+
+def _get_zone_registry(request: Request) -> Any | None:
+    return getattr(request.app.state, "zone_registry", None)
+
+
+def _auth_target_zone(auth_result: dict[str, Any]) -> str | None:
+    from nexus.contracts.constants import ROOT_ZONE_ID
+
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
+    return zone_id if zone_id != ROOT_ZONE_ID else None
 
 
 # ReBAC filtering helpers are in nexus.lib.rebac_filter (#3731).
@@ -184,7 +197,6 @@ async def search_query(
     record_store: Any = Depends(_get_record_store),
 ) -> dict[str, Any]:
     """Execute a fast search query using the search daemon."""
-    from nexus.bricks.search.query_router import QueryRouter
     from nexus.contracts.constants import ROOT_ZONE_ID
 
     start_time = time.perf_counter()
@@ -219,20 +231,63 @@ async def search_query(
             detail=f"Invalid graph_mode: {graph_mode}. Must be 'none', 'low', 'high', 'dual', or 'auto'",
         )
 
-    # --- Federated search path (Issue #3147) ---
-    if federated:
-        return await _handle_federated_search(
+    target_zone = zone_id if zone_id != ROOT_ZONE_ID else None
+
+    async def _work() -> dict[str, Any]:
+        # --- Federated search path (Issue #3147) ---
+        if federated:
+            return await _handle_federated_search(
+                q=q,
+                search_type=type,
+                limit=limit,
+                path_filter=path,
+                alpha=alpha,
+                fusion_method=fusion,
+                auth_result=auth_result,
+                search_daemon=search_daemon,
+                request=request,
+                zone_filter=frozenset(zone_set) if len(zone_set) > 1 else None,
+            )
+
+        return await _handle_single_zone_search(
+            request=request,
             q=q,
             search_type=type,
             limit=limit,
             path_filter=path,
             alpha=alpha,
             fusion_method=fusion,
+            graph_mode=graph_mode,
             auth_result=auth_result,
             search_daemon=search_daemon,
-            request=request,
-            zone_filter=frozenset(zone_set) if len(zone_set) > 1 else None,
+            async_session_factory=async_session_factory,
+            record_store=record_store,
+            zone_id=zone_id,
+            start_time=start_time,
         )
+
+    return await run_zone_scoped(_get_zone_registry(request), target_zone, _work)
+
+
+async def _handle_single_zone_search(
+    *,
+    request: Request,
+    q: str,
+    search_type: str,
+    limit: int,
+    path_filter: str | None,
+    alpha: float,
+    fusion_method: str,
+    graph_mode: str,
+    auth_result: dict[str, Any],
+    search_daemon: Any,
+    async_session_factory: Any,
+    record_store: Any,
+    zone_id: str,
+    start_time: float,
+) -> dict[str, Any]:
+    """Handle the non-federated search branch."""
+    from nexus.bricks.search.query_router import QueryRouter
 
     # --- Standard single-zone search path ---
     # ReBAC file-level permission enforcer (Decision #17)
@@ -289,9 +344,9 @@ async def search_query(
 
             results = await graph_enhanced_search(
                 query=q,
-                search_type=type,
+                search_type=search_type,
                 limit=fetch_limit,
-                path_filter=path,
+                path_filter=path_filter,
                 alpha=alpha,
                 graph_mode=effective_graph_mode,
                 record_store=record_store,
@@ -312,7 +367,7 @@ async def search_query(
 
             response: dict[str, Any] = {
                 "query": q,
-                "search_type": type,
+                "search_type": search_type,
                 "graph_mode": effective_graph_mode,
                 "results": [_serialize_search_result(r) for r in results],
                 "total": len(results),
@@ -329,11 +384,11 @@ async def search_query(
 
         results = await search_daemon.search(
             query=q,
-            search_type=type,
+            search_type=search_type,
             limit=fetch_limit,
-            path_filter=path,
+            path_filter=path_filter,
             alpha=alpha,
-            fusion_method=fusion,
+            fusion_method=fusion_method,
             zone_id=zone_id,
         )
 
@@ -352,7 +407,7 @@ async def search_query(
 
         response = {
             "query": q,
-            "search_type": type,
+            "search_type": search_type,
             "graph_mode": "none",
             "results": [_serialize_search_result(r) for r in results],
             "total": len(results),
@@ -693,109 +748,116 @@ async def _do_grep_operation(
         sentinel_window, has_enforcer=permission_enforcer is not None
     )
 
-    try:
-        grep_kwargs: dict[str, Any] = {
-            "pattern": pattern,
-            "path": path,
-            "ignore_case": ignore_case,
-            "max_results": fetch_limit,
-            "context": op_context,
-            "before_context": before_context,
-            "after_context": after_context,
-            "invert_match": invert_match,
-            "files": files,
+    target_zone = target_zone_for_context(op_context, {"path": path, "files": files})
+
+    async def _work() -> dict[str, Any]:
+        try:
+            grep_kwargs: dict[str, Any] = {
+                "pattern": pattern,
+                "path": path,
+                "ignore_case": ignore_case,
+                "max_results": fetch_limit,
+                "context": op_context,
+                "before_context": before_context,
+                "after_context": after_context,
+                "invert_match": invert_match,
+                "files": files,
+            }
+            # Issue #3720: only forward block_type when set (backward compat).
+            if block_type is not None:
+                grep_kwargs["block_type"] = block_type
+            raw_results = await search_service.grep(**grep_kwargs)
+        except (ValueError, InvalidPathError) as exc:
+            # Client errors from SearchService:
+            #  * ValueError — invalid regex, size cap exceeded, cross-zone entry
+            #  * InvalidPathError — path traversal segment in ``path`` or ``files``
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except Exception as exc:
+            logger.error("grep failed: %s", exc, exc_info=True)
+            raise HTTPException(
+                status_code=500, detail=f"grep failed: {type(exc).__name__}"
+            ) from exc
+
+        # ReBAC file-level filtering, reusing the same helper as search_query.
+        # SearchService already filters by zone/path via context, so this is
+        # a second-layer guarantee for the HTTP surface.
+        pre_filter_count = len(raw_results)
+
+        # #3731: path_extractor eliminates the _GrepResultShim shim class.
+        filtered_results, filter_ms = _apply_rebac_filter(
+            raw_results,
+            permission_enforcer,
+            auth_result,
+            zone_id,
+            path_extractor=lambda r: r.get("file", ""),
+        )
+        post_filter_count = len(filtered_results)
+
+        # Sentinel detection: if we got at least one result beyond the
+        # window, there's a next page. The sentinel row is not included in
+        # the items we return to the caller.
+        has_more = post_filter_count > window_size
+        # ``total`` reports the best-known count. When has_more is true,
+        # we know at least ``window_size + 1`` exist but the true total
+        # may be larger; we report the observed post-filter count as a
+        # floor. When has_more is false, post_filter_count is the true
+        # total of matches visible to this caller.
+        total = post_filter_count
+        paginated = filtered_results[offset : offset + limit]
+
+        # Codex review of #3701 (review #2 finding #2 + review #3 finding #3):
+        # unscope every result entry's ``file`` so the HTTP response surfaces
+        # user-facing paths (``/docs/a.py``) instead of leaking the internal
+        # zone-scoped storage path (``/zone/<tenant>/docs/a.py``), but ALSO
+        # attach a ``zone_id`` on each item whenever we recovered one from
+        # the internal path. A caller with multi-zone visibility (admin or
+        # cross-zone share recipient) can then distinguish two results that
+        # would otherwise collide onto the same unscoped ``file`` — e.g.
+        # ``/zone/acme/src/x.py`` and ``/zone/beta/src/x.py`` both unscope
+        # to ``/src/x.py``. Without ``zone_id`` the caller cannot safely
+        # round-trip a result back through ``files=[...]``.
+        from nexus.core.path_utils import split_zone_from_internal_path
+
+        annotated: list[dict[str, Any]] = []
+        for r in paginated:
+            out = dict(r)
+            raw_file = r.get("file", "")
+            zone, unscoped = split_zone_from_internal_path(raw_file)
+            out["file"] = unscoped
+            if zone is not None:
+                out["zone_id"] = zone
+            annotated.append(out)
+        paginated = annotated
+
+        # Detect residual ambiguity: if two distinct raw paths collapse to
+        # the same (file, zone_id) tuple we have a lossy response and
+        # surface it in the envelope so callers know round-trip safety is
+        # degraded. This is defence-in-depth — the zone_id fix above
+        # should already disambiguate every normal multi-zone case.
+        _keys = [(it["file"], it.get("zone_id")) for it in paginated]
+        multi_zone_ambiguous = len(set(_keys)) < len(_keys)
+        latency_ms = (time.perf_counter() - start_time) * 1000
+
+        extras: dict[str, Any] = {
+            "latency_ms": round(latency_ms, 2),
+            "latency_breakdown": {
+                "total_ms": round(latency_ms, 2),
+                "permission_filter_ms": round(filter_ms, 2),
+            },
+            **_rebac_denial_stats(pre_filter_count, post_filter_count, window_size),
         }
-        # Issue #3720: only forward block_type when set (backward compat).
-        if block_type is not None:
-            grep_kwargs["block_type"] = block_type
-        raw_results = await search_service.grep(**grep_kwargs)
-    except (ValueError, InvalidPathError) as exc:
-        # Client errors from SearchService:
-        #  * ValueError — invalid regex, size cap exceeded, cross-zone entry
-        #  * InvalidPathError — path traversal segment in ``path`` or ``files``
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-    except Exception as exc:
-        logger.error("grep failed: %s", exc, exc_info=True)
-        raise HTTPException(status_code=500, detail=f"grep failed: {type(exc).__name__}") from exc
+        if multi_zone_ambiguous:
+            extras["multi_zone_ambiguous"] = True
+        return build_paginated_list_response(
+            items=paginated,
+            total=total,
+            offset=offset,
+            limit=limit,
+            extras=extras,
+            has_more=has_more,
+        )
 
-    # ReBAC file-level filtering, reusing the same helper as search_query.
-    # SearchService already filters by zone/path via context, so this is
-    # a second-layer guarantee for the HTTP surface.
-    pre_filter_count = len(raw_results)
-
-    # #3731: path_extractor eliminates the _GrepResultShim shim class.
-    filtered_results, filter_ms = _apply_rebac_filter(
-        raw_results,
-        permission_enforcer,
-        auth_result,
-        zone_id,
-        path_extractor=lambda r: r.get("file", ""),
-    )
-    post_filter_count = len(filtered_results)
-
-    # Sentinel detection: if we got at least one result beyond the
-    # window, there's a next page. The sentinel row is not included in
-    # the items we return to the caller.
-    has_more = post_filter_count > window_size
-    # ``total`` reports the best-known count. When has_more is true,
-    # we know at least ``window_size + 1`` exist but the true total
-    # may be larger; we report the observed post-filter count as a
-    # floor. When has_more is false, post_filter_count is the true
-    # total of matches visible to this caller.
-    total = post_filter_count
-    paginated = filtered_results[offset : offset + limit]
-
-    # Codex review of #3701 (review #2 finding #2 + review #3 finding #3):
-    # unscope every result entry's ``file`` so the HTTP response surfaces
-    # user-facing paths (``/docs/a.py``) instead of leaking the internal
-    # zone-scoped storage path (``/zone/<tenant>/docs/a.py``), but ALSO
-    # attach a ``zone_id`` on each item whenever we recovered one from
-    # the internal path. A caller with multi-zone visibility (admin or
-    # cross-zone share recipient) can then distinguish two results that
-    # would otherwise collide onto the same unscoped ``file`` — e.g.
-    # ``/zone/acme/src/x.py`` and ``/zone/beta/src/x.py`` both unscope
-    # to ``/src/x.py``. Without ``zone_id`` the caller cannot safely
-    # round-trip a result back through ``files=[...]``.
-    from nexus.core.path_utils import split_zone_from_internal_path
-
-    annotated: list[dict[str, Any]] = []
-    for r in paginated:
-        out = dict(r)
-        raw_file = r.get("file", "")
-        zone, unscoped = split_zone_from_internal_path(raw_file)
-        out["file"] = unscoped
-        if zone is not None:
-            out["zone_id"] = zone
-        annotated.append(out)
-    paginated = annotated
-
-    # Detect residual ambiguity: if two distinct raw paths collapse to
-    # the same (file, zone_id) tuple we have a lossy response and
-    # surface it in the envelope so callers know round-trip safety is
-    # degraded. This is defence-in-depth — the zone_id fix above
-    # should already disambiguate every normal multi-zone case.
-    _keys = [(it["file"], it.get("zone_id")) for it in paginated]
-    multi_zone_ambiguous = len(set(_keys)) < len(_keys)
-    latency_ms = (time.perf_counter() - start_time) * 1000
-
-    extras: dict[str, Any] = {
-        "latency_ms": round(latency_ms, 2),
-        "latency_breakdown": {
-            "total_ms": round(latency_ms, 2),
-            "permission_filter_ms": round(filter_ms, 2),
-        },
-        **_rebac_denial_stats(pre_filter_count, post_filter_count, window_size),
-    }
-    if multi_zone_ambiguous:
-        extras["multi_zone_ambiguous"] = True
-    return build_paginated_list_response(
-        items=paginated,
-        total=total,
-        offset=offset,
-        limit=limit,
-        extras=extras,
-        has_more=has_more,
-    )
+    return await run_zone_scoped(_get_zone_registry(request), target_zone, _work)
 
 
 async def _do_glob_operation(
@@ -827,75 +889,82 @@ async def _do_glob_operation(
     op_context = get_operation_context(auth_result)
     permission_enforcer = getattr(request.app.state, "permission_enforcer", None)
 
-    try:
-        all_matches: list[str] = search_service.glob(
-            pattern=pattern, path=path, context=op_context, files=files
+    target_zone = target_zone_for_context(op_context, {"path": path, "files": files})
+
+    async def _work() -> dict[str, Any]:
+        try:
+            all_matches: list[str] = search_service.glob(
+                pattern=pattern, path=path, context=op_context, files=files
+            )
+        except (ValueError, InvalidPathError) as exc:
+            raise HTTPException(status_code=400, detail=str(exc)) from exc
+        except Exception as exc:
+            logger.error("glob failed: %s", exc, exc_info=True)
+            raise HTTPException(
+                status_code=500, detail=f"glob failed: {type(exc).__name__}"
+            ) from exc
+
+        # #3731: path_extractor=identity eliminates the _GlobResultShim shim class.
+        pre_filter_count = len(all_matches)
+        filtered_paths, filter_ms = _apply_rebac_filter(
+            all_matches,
+            permission_enforcer,
+            auth_result,
+            zone_id,
+            path_extractor=lambda p: p,
         )
-    except (ValueError, InvalidPathError) as exc:
-        raise HTTPException(status_code=400, detail=str(exc)) from exc
-    except Exception as exc:
-        logger.error("glob failed: %s", exc, exc_info=True)
-        raise HTTPException(status_code=500, detail=f"glob failed: {type(exc).__name__}") from exc
+        post_filter_count = len(filtered_paths)
 
-    # #3731: path_extractor=identity eliminates the _GlobResultShim shim class.
-    pre_filter_count = len(all_matches)
-    filtered_paths, filter_ms = _apply_rebac_filter(
-        all_matches,
-        permission_enforcer,
-        auth_result,
-        zone_id,
-        path_extractor=lambda p: p,
-    )
-    post_filter_count = len(filtered_paths)
+        total = len(filtered_paths)
+        paginated = filtered_paths[offset : offset + limit]
 
-    total = len(filtered_paths)
-    paginated = filtered_paths[offset : offset + limit]
+        # Codex review of #3701 (review #2 finding #2 + review #3 finding #3):
+        # unscope every glob path so the HTTP response surfaces user-facing
+        # paths and never leaks the internal ``/zone/<tenant>/...`` form,
+        # but also compute a parallel ``item_zones`` list so multi-zone
+        # callers can distinguish colliding unscoped paths (e.g.
+        # ``/zone/acme/src/x.py`` and ``/zone/beta/src/x.py`` both
+        # unscope to ``/src/x.py`` — the zone id is the only round-trip
+        # disambiguator). ``item_zones[i]`` is the zone of ``items[i]``
+        # when one was recovered from the internal prefix, otherwise
+        # ``None``.
+        from nexus.core.path_utils import split_zone_from_internal_path
 
-    # Codex review of #3701 (review #2 finding #2 + review #3 finding #3):
-    # unscope every glob path so the HTTP response surfaces user-facing
-    # paths and never leaks the internal ``/zone/<tenant>/...`` form,
-    # but also compute a parallel ``item_zones`` list so multi-zone
-    # callers can distinguish colliding unscoped paths (e.g.
-    # ``/zone/acme/src/x.py`` and ``/zone/beta/src/x.py`` both
-    # unscope to ``/src/x.py`` — the zone id is the only round-trip
-    # disambiguator). ``item_zones[i]`` is the zone of ``items[i]``
-    # when one was recovered from the internal prefix, otherwise
-    # ``None``.
-    from nexus.core.path_utils import split_zone_from_internal_path
+        item_zones: list[str | None] = []
+        unscoped_items: list[str] = []
+        for p in paginated:
+            zone, unscoped = split_zone_from_internal_path(p)
+            unscoped_items.append(unscoped)
+            item_zones.append(zone)
+        paginated = unscoped_items
 
-    item_zones: list[str | None] = []
-    unscoped_items: list[str] = []
-    for p in paginated:
-        zone, unscoped = split_zone_from_internal_path(p)
-        unscoped_items.append(unscoped)
-        item_zones.append(zone)
-    paginated = unscoped_items
+        # Detect residual ambiguity (two results collapsing onto the same
+        # (path, zone_id) after unscoping) and surface it in the envelope
+        # so callers know round-trip safety is degraded.
+        _keys = list(zip(paginated, item_zones, strict=False))
+        glob_multi_zone_ambiguous = len(set(_keys)) < len(_keys)
+        latency_ms = (time.perf_counter() - start_time) * 1000
 
-    # Detect residual ambiguity (two results collapsing onto the same
-    # (path, zone_id) after unscoping) and surface it in the envelope
-    # so callers know round-trip safety is degraded.
-    _keys = list(zip(paginated, item_zones, strict=False))
-    glob_multi_zone_ambiguous = len(set(_keys)) < len(_keys)
-    latency_ms = (time.perf_counter() - start_time) * 1000
+        extras: dict[str, Any] = {
+            "latency_ms": round(latency_ms, 2),
+            "latency_breakdown": {
+                "total_ms": round(latency_ms, 2),
+                "permission_filter_ms": round(filter_ms, 2),
+            },
+            **_rebac_denial_stats(pre_filter_count, post_filter_count, limit + offset),
+            # Codex review #3 finding #3: parallel zone disambiguation.
+            # ``item_zones[i]`` is the zone id of ``items[i]`` (may be
+            # ``None`` for root-zone paths). Multi-zone callers use this
+            # to round-trip results back through ``files=[...]``.
+            "item_zones": item_zones,
+        }
+        if glob_multi_zone_ambiguous:
+            extras["multi_zone_ambiguous"] = True
+        return build_paginated_list_response(
+            items=paginated, total=total, offset=offset, limit=limit, extras=extras
+        )
 
-    extras: dict[str, Any] = {
-        "latency_ms": round(latency_ms, 2),
-        "latency_breakdown": {
-            "total_ms": round(latency_ms, 2),
-            "permission_filter_ms": round(filter_ms, 2),
-        },
-        **_rebac_denial_stats(pre_filter_count, post_filter_count, limit + offset),
-        # Codex review #3 finding #3: parallel zone disambiguation.
-        # ``item_zones[i]`` is the zone id of ``items[i]`` (may be
-        # ``None`` for root-zone paths). Multi-zone callers use this
-        # to round-trip results back through ``files=[...]``.
-        "item_zones": item_zones,
-    }
-    if glob_multi_zone_ambiguous:
-        extras["multi_zone_ambiguous"] = True
-    return build_paginated_list_response(
-        items=paginated, total=total, offset=offset, limit=limit, extras=extras
-    )
+    return await run_zone_scoped(_get_zone_registry(request), target_zone, _work)
 
 
 def _body_get_int(body: dict[str, Any], key: str, default: int, *, ge: int | None = None) -> int:
@@ -1206,38 +1275,51 @@ async def search_index_documents(
     if not documents:
         raise HTTPException(status_code=400, detail="No documents provided")
 
-    try:
-        count = await search_daemon.index_documents(documents, zone_id=zone_id)
-    except Exception as exc:
-        logger.error("index_documents failed: %s", exc, exc_info=True)
-        raise HTTPException(
-            status_code=500,
-            detail=f"Index persistence failed: {type(exc).__name__}: {exc}",
-        ) from exc
-    return {"status": "indexed", "count": count, "zone_id": zone_id}
+    async def _work() -> dict[str, Any]:
+        try:
+            count = await search_daemon.index_documents(documents, zone_id=zone_id)
+        except Exception as exc:
+            logger.error("index_documents failed: %s", exc, exc_info=True)
+            raise HTTPException(
+                status_code=500,
+                detail=f"Index persistence failed: {type(exc).__name__}: {exc}",
+            ) from exc
+        return {"status": "indexed", "count": count, "zone_id": zone_id}
+
+    return await run_zone_scoped(_get_zone_registry(request), _auth_target_zone(auth_result), _work)
 
 
 @router.post("/refresh")
 async def search_refresh_notify(
+    request: Request,
     path: str = Query(..., description="Path of the changed file"),
     change_type: str = Query("update", description="Type of change: create, update, delete"),
-    _auth_result: dict[str, Any] = Depends(require_auth),
+    auth_result: dict[str, Any] = Depends(require_auth),
     search_daemon: Any = Depends(_get_search_daemon),
 ) -> dict[str, Any]:
     """Notify the search daemon of a file change for index refresh."""
-    await search_daemon.notify_file_change(path, change_type)
-    return {"status": "accepted", "path": path, "change_type": change_type}
+    from nexus.server.dependencies import get_operation_context
+
+    op_context = get_operation_context(auth_result)
+    target_zone = target_zone_for_context(op_context, {"path": path})
+
+    async def _work() -> dict[str, Any]:
+        await search_daemon.notify_file_change(path, change_type)
+        return {"status": "accepted", "path": path, "change_type": change_type}
+
+    return await run_zone_scoped(_get_zone_registry(request), target_zone, _work)
 
 
 @router.post("/expand")
 async def search_expand(
+    request: Request,
     q: str = Query(..., description="Query to expand", min_length=1),
     context: str | None = Query(None, description="Optional context about the collection"),
     model: str = Query("deepseek/deepseek-chat", description="LLM model to use"),
     max_lex: int = Query(2, description="Max lexical variants", ge=0, le=5),
     max_vec: int = Query(2, description="Max vector variants", ge=0, le=5),
     max_hyde: int = Query(2, description="Max HyDE passages", ge=0, le=5),
-    _auth_result: dict[str, Any] = Depends(require_auth),
+    auth_result: dict[str, Any] = Depends(require_auth),
 ) -> dict[str, Any]:
     """Expand a search query using LLM-based query expansion."""
     import os
@@ -1257,50 +1339,53 @@ async def search_expand(
             detail="No API key configured for query expansion (need OPENROUTER_API_KEY or OPENAI_API_KEY)",
         )
 
-    start_time = time.perf_counter()
+    async def _work() -> dict[str, Any]:
+        start_time = time.perf_counter()
 
-    try:
-        if openrouter_key:
-            config = QueryExpansionConfig(
-                model=model,
-                max_lex_variants=max_lex,
-                max_vec_variants=max_vec,
-                max_hyde_passages=max_hyde,
-                timeout=15.0,
-            )
-            expander = OpenRouterQueryExpander(config=config, api_key=openrouter_key)
-        else:
-            # Use OpenAI directly with gpt-4o-mini
-            openai_model = model if "/" not in model else "gpt-4o-mini"
-            config = QueryExpansionConfig(
-                model=openai_model,
-                max_lex_variants=max_lex,
-                max_vec_variants=max_vec,
-                max_hyde_passages=max_hyde,
-                timeout=15.0,
-                fallback_models=[],
-            )
-            expander = OpenAIQueryExpander(config=config, api_key=openai_key)
-        expansions = await expander.expand(q, context=context)
-        await expander.close()
+        try:
+            if openrouter_key:
+                config = QueryExpansionConfig(
+                    model=model,
+                    max_lex_variants=max_lex,
+                    max_vec_variants=max_vec,
+                    max_hyde_passages=max_hyde,
+                    timeout=15.0,
+                )
+                expander = OpenRouterQueryExpander(config=config, api_key=openrouter_key)
+            else:
+                # Use OpenAI directly with gpt-4o-mini
+                openai_model = model if "/" not in model else "gpt-4o-mini"
+                config = QueryExpansionConfig(
+                    model=openai_model,
+                    max_lex_variants=max_lex,
+                    max_vec_variants=max_vec,
+                    max_hyde_passages=max_hyde,
+                    timeout=15.0,
+                    fallback_models=[],
+                )
+                expander = OpenAIQueryExpander(config=config, api_key=openai_key)
+            expansions = await expander.expand(q, context=context)
+            await expander.close()
 
-        latency_ms = (time.perf_counter() - start_time) * 1000
+            latency_ms = (time.perf_counter() - start_time) * 1000
 
-        return {
-            "query": q,
-            "context": context,
-            "model": model,
-            "expansions": [
-                {"type": e.expansion_type.value, "text": e.text, "weight": e.weight}
-                for e in expansions
-            ],
-            "total": len(expansions),
-            "latency_ms": round(latency_ms, 2),
-        }
+            return {
+                "query": q,
+                "context": context,
+                "model": model,
+                "expansions": [
+                    {"type": e.expansion_type.value, "text": e.text, "weight": e.weight}
+                    for e in expansions
+                ],
+                "total": len(expansions),
+                "latency_ms": round(latency_ms, 2),
+            }
 
-    except Exception as e:
-        logger.error("Query expansion error: %s", e, exc_info=True)
-        raise HTTPException(status_code=500, detail="Query expansion failed") from e
+        except Exception as e:
+            logger.error("Query expansion error: %s", e, exc_info=True)
+            raise HTTPException(status_code=500, detail="Query expansion failed") from e
+
+    return await run_zone_scoped(_get_zone_registry(request), _auth_target_zone(auth_result), _work)
 
 
 # =============================================================================

--- a/src/nexus/server/api/v2/routers/secrets.py
+++ b/src/nexus/server/api/v2/routers/secrets.py
@@ -18,17 +18,21 @@ the asyncio event loop during synchronous SQLAlchemy I/O.
 """
 
 import logging
-from typing import Any, cast
+from collections.abc import Callable
+from typing import Any, TypeVar, cast
 
-from fastapi import APIRouter, Depends, HTTPException
+from anyio import from_thread
+from fastapi import APIRouter, Depends, HTTPException, Request
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.contracts.protocols.secrets_audit_log import SecretsAuditLogProtocol
 from nexus.server.dependencies import require_auth
+from nexus.server.zone_execution import run_zone_scoped
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(prefix="/api/v2/secrets", tags=["secrets"])
+T = TypeVar("T")
 
 
 # --------------------------------------------------------------------------
@@ -46,6 +50,26 @@ def get_secrets_audit_logger() -> tuple[SecretsAuditLogProtocol, str]:
     raise HTTPException(status_code=500, detail="Secrets audit not configured")
 
 
+def _get_zone_registry(request: Request) -> Any | None:
+    return getattr(request.app.state, "zone_registry", None)
+
+
+def _auth_zone(auth_result: dict[str, Any]) -> str | None:
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
+    return zone_id if zone_id != ROOT_ZONE_ID else None
+
+
+def _run_zone_scoped_sync(request: Request, zone_id: str | None, work: Callable[[], T]) -> T:
+    zone_registry = _get_zone_registry(request)
+    if zone_registry is None or zone_id is None:
+        return work()
+
+    async def _work() -> T:
+        return work()
+
+    return from_thread.run(run_zone_scoped, zone_registry, zone_id, _work)
+
+
 # --------------------------------------------------------------------------
 # Write / Update
 # --------------------------------------------------------------------------
@@ -56,6 +80,7 @@ def put_secret(
     namespace: str,
     key: str,
     body: dict[str, Any],
+    request: Request,
     auth_result: dict[str, Any] = Depends(require_auth),
     service: Any = Depends(get_secrets_service),
 ) -> dict[str, Any]:
@@ -73,7 +98,7 @@ def put_secret(
     if not value:
         raise HTTPException(status_code=400, detail="value is required")
 
-    try:
+    def _put() -> dict[str, Any]:
         return cast(
             "dict[str, Any]",
             service.put_secret(
@@ -87,6 +112,9 @@ def put_secret(
                 subject_type=subject_type,
             ),
         )
+
+    try:
+        return _run_zone_scoped_sync(request, _auth_zone(auth_result), _put)
     except Exception as e:
         logger.error("Failed to put secret: %s", e)
         raise HTTPException(status_code=500, detail=f"Failed to put secret: {e}") from e
@@ -97,6 +125,7 @@ def update_description(
     namespace: str,
     key: str,
     body: dict[str, Any],
+    request: Request,
     auth_result: dict[str, Any] = Depends(require_auth),
     service: Any = Depends(get_secrets_service),
 ) -> dict[str, Any]:
@@ -110,7 +139,7 @@ def update_description(
     subject_id = auth_result.get("subject_id") or "anonymous"
     subject_type = auth_result.get("subject_type") or "user"
 
-    try:
+    def _update() -> dict[str, Any]:
         success = service.update_description(
             namespace=namespace,
             key=key,
@@ -123,6 +152,9 @@ def update_description(
         if not success:
             raise HTTPException(status_code=404, detail="Secret not found")
         return {"namespace": namespace, "key": key, "description": description}
+
+    try:
+        return _run_zone_scoped_sync(request, _auth_zone(auth_result), _update)
     except HTTPException:
         raise
     except Exception as e:
@@ -139,6 +171,7 @@ def update_description(
 def get_secret(
     namespace: str,
     key: str,
+    request: Request,
     version: int | None = None,
     auth_result: dict[str, Any] = Depends(require_auth),
     service: Any = Depends(get_secrets_service),
@@ -152,9 +185,9 @@ def get_secret(
     subject_id = auth_result.get("subject_id") or "anonymous"
     subject_type = auth_result.get("subject_type") or "user"
 
-    try:
-        from nexus.bricks.secrets.service import SecretDisabledError
+    from nexus.bricks.secrets.service import SecretDisabledError
 
+    def _get() -> dict[str, Any]:
         result = service.get_secret(
             namespace=namespace,
             key=key,
@@ -172,6 +205,9 @@ def get_secret(
             "value": result["value"],
             "version": result["version"],
         }
+
+    try:
+        return _run_zone_scoped_sync(request, _auth_zone(auth_result), _get)
     except HTTPException:
         raise
     except SecretDisabledError as e:
@@ -183,6 +219,7 @@ def get_secret(
 
 @router.get("")
 def list_secrets(
+    request: Request,
     namespace: str | None = None,
     include_deleted: bool = False,
     auth_result: dict[str, Any] = Depends(require_auth),
@@ -195,7 +232,7 @@ def list_secrets(
     subject_id = auth_result.get("subject_id") or "anonymous"
     subject_type = auth_result.get("subject_type") or "user"
 
-    try:
+    def _list() -> dict[str, Any]:
         secrets = service.list_secrets(
             namespace=namespace,
             include_deleted=include_deleted,
@@ -203,6 +240,9 @@ def list_secrets(
             subject_type=subject_type,
         )
         return {"secrets": secrets, "count": len(secrets)}
+
+    try:
+        return _run_zone_scoped_sync(request, _auth_zone(auth_result), _list)
     except Exception as e:
         logger.error("Failed to list secrets: %s", e)
         raise HTTPException(status_code=500, detail=f"Failed to list secrets: {e}") from e
@@ -212,6 +252,7 @@ def list_secrets(
 def list_versions(
     namespace: str,
     key: str,
+    request: Request,
     auth_result: dict[str, Any] = Depends(require_auth),
     service: Any = Depends(get_secrets_service),
 ) -> dict[str, Any]:
@@ -222,7 +263,7 @@ def list_versions(
     subject_id = auth_result.get("subject_id") or "anonymous"
     subject_type = auth_result.get("subject_type") or "user"
 
-    try:
+    def _list_versions() -> dict[str, Any]:
         versions = service.list_versions(
             namespace=namespace,
             key=key,
@@ -230,6 +271,9 @@ def list_versions(
             subject_type=subject_type,
         )
         return {"namespace": namespace, "key": key, "versions": versions, "count": len(versions)}
+
+    try:
+        return _run_zone_scoped_sync(request, _auth_zone(auth_result), _list_versions)
     except Exception as e:
         logger.error("Failed to list versions: %s", e)
         raise HTTPException(status_code=500, detail=f"Failed to list versions: {e}") from e
@@ -244,6 +288,7 @@ def list_versions(
 def delete_secret(
     namespace: str,
     key: str,
+    request: Request,
     auth_result: dict[str, Any] = Depends(require_auth),
     service: Any = Depends(get_secrets_service),
 ) -> dict[str, Any]:
@@ -256,7 +301,7 @@ def delete_secret(
     subject_id = auth_result.get("subject_id") or "anonymous"
     subject_type = auth_result.get("subject_type") or "user"
 
-    try:
+    def _delete() -> dict[str, Any]:
         success = service.delete_secret(
             namespace=namespace,
             key=key,
@@ -268,6 +313,9 @@ def delete_secret(
         if not success:
             raise HTTPException(status_code=404, detail="Secret not found")
         return {"namespace": namespace, "key": key, "deleted": True}
+
+    try:
+        return _run_zone_scoped_sync(request, _auth_zone(auth_result), _delete)
     except HTTPException:
         raise
     except Exception as e:
@@ -279,6 +327,7 @@ def delete_secret(
 def restore_secret(
     namespace: str,
     key: str,
+    request: Request,
     auth_result: dict[str, Any] = Depends(require_auth),
     service: Any = Depends(get_secrets_service),
 ) -> dict[str, Any]:
@@ -291,7 +340,7 @@ def restore_secret(
     subject_id = auth_result.get("subject_id") or "anonymous"
     subject_type = auth_result.get("subject_type") or "user"
 
-    try:
+    def _restore() -> dict[str, Any]:
         success = service.restore_secret(
             namespace=namespace,
             key=key,
@@ -303,6 +352,9 @@ def restore_secret(
         if not success:
             raise HTTPException(status_code=404, detail="Secret not found")
         return {"namespace": namespace, "key": key, "restored": True}
+
+    try:
+        return _run_zone_scoped_sync(request, _auth_zone(auth_result), _restore)
     except HTTPException:
         raise
     except Exception as e:
@@ -315,6 +367,7 @@ def delete_version(
     namespace: str,
     key: str,
     version: int,
+    request: Request,
     auth_result: dict[str, Any] = Depends(require_auth),
     service: Any = Depends(get_secrets_service),
 ) -> dict[str, Any]:
@@ -327,7 +380,7 @@ def delete_version(
     subject_id = auth_result.get("subject_id") or "anonymous"
     subject_type = auth_result.get("subject_type") or "user"
 
-    try:
+    def _delete_version() -> dict[str, Any]:
         success = service.delete_version(
             namespace=namespace,
             key=key,
@@ -342,6 +395,9 @@ def delete_version(
                 status_code=400, detail="Cannot delete version (not found or last version)"
             )
         return {"namespace": namespace, "key": key, "version": version, "deleted": True}
+
+    try:
+        return _run_zone_scoped_sync(request, _auth_zone(auth_result), _delete_version)
     except HTTPException:
         raise
     except Exception as e:
@@ -358,6 +414,7 @@ def delete_version(
 def enable_secret(
     namespace: str,
     key: str,
+    request: Request,
     auth_result: dict[str, Any] = Depends(require_auth),
     service: Any = Depends(get_secrets_service),
 ) -> dict[str, Any]:
@@ -370,7 +427,7 @@ def enable_secret(
     subject_id = auth_result.get("subject_id") or "anonymous"
     subject_type = auth_result.get("subject_type") or "user"
 
-    try:
+    def _enable() -> dict[str, Any]:
         success = service.enable_secret(
             namespace=namespace,
             key=key,
@@ -382,6 +439,9 @@ def enable_secret(
         if not success:
             raise HTTPException(status_code=404, detail="Secret not found")
         return {"namespace": namespace, "key": key, "enabled": True}
+
+    try:
+        return _run_zone_scoped_sync(request, _auth_zone(auth_result), _enable)
     except HTTPException:
         raise
     except Exception as e:
@@ -393,6 +453,7 @@ def enable_secret(
 def disable_secret(
     namespace: str,
     key: str,
+    request: Request,
     auth_result: dict[str, Any] = Depends(require_auth),
     service: Any = Depends(get_secrets_service),
 ) -> dict[str, Any]:
@@ -405,7 +466,7 @@ def disable_secret(
     subject_id = auth_result.get("subject_id") or "anonymous"
     subject_type = auth_result.get("subject_type") or "user"
 
-    try:
+    def _disable() -> dict[str, Any]:
         success = service.disable_secret(
             namespace=namespace,
             key=key,
@@ -417,6 +478,9 @@ def disable_secret(
         if not success:
             raise HTTPException(status_code=404, detail="Secret not found")
         return {"namespace": namespace, "key": key, "enabled": False}
+
+    try:
+        return _run_zone_scoped_sync(request, _auth_zone(auth_result), _disable)
     except HTTPException:
         raise
     except Exception as e:
@@ -433,6 +497,7 @@ def disable_secret(
 @router.post("/batch")
 def batch_put(
     secrets: list[dict[str, Any]],
+    request: Request,
     auth_result: dict[str, Any] = Depends(require_auth),
     service: Any = Depends(get_secrets_service),
 ) -> dict[str, Any]:
@@ -445,7 +510,7 @@ def batch_put(
     subject_id = auth_result.get("subject_id") or "anonymous"
     subject_type = auth_result.get("subject_type") or "user"
 
-    try:
+    def _batch_put() -> dict[str, Any]:
         results = service.batch_put(
             secrets=secrets,
             actor_id=actor_id,
@@ -454,6 +519,9 @@ def batch_put(
             subject_type=subject_type,
         )
         return {"secrets": results, "count": len(results)}
+
+    try:
+        return _run_zone_scoped_sync(request, _auth_zone(auth_result), _batch_put)
     except Exception as e:
         logger.error("Failed to batch put secrets: %s", e)
         raise HTTPException(status_code=500, detail=f"Failed to batch put secrets: {e}") from e
@@ -462,6 +530,7 @@ def batch_put(
 @router.post("/batch/get")
 def batch_get(
     queries: list[dict[str, Any]],
+    request: Request,
     auth_result: dict[str, Any] = Depends(require_auth),
     service: Any = Depends(get_secrets_service),
 ) -> dict[str, Any]:
@@ -474,7 +543,7 @@ def batch_get(
     subject_id = auth_result.get("subject_id") or "anonymous"
     subject_type = auth_result.get("subject_type") or "user"
 
-    try:
+    def _batch_get() -> dict[str, Any]:
         results = service.batch_get(
             queries=queries,
             actor_id=actor_id,
@@ -483,6 +552,9 @@ def batch_get(
             subject_type=subject_type,
         )
         return {"secrets": results, "count": len(results)}
+
+    try:
+        return _run_zone_scoped_sync(request, _auth_zone(auth_result), _batch_get)
     except Exception as e:
         logger.error("Failed to batch get secrets: %s", e)
         raise HTTPException(status_code=500, detail=f"Failed to batch get secrets: {e}") from e

--- a/src/nexus/server/api/v2/routers/snapshots.py
+++ b/src/nexus/server/api/v2/routers/snapshots.py
@@ -19,6 +19,7 @@ from fastapi import APIRouter, Depends, HTTPException, Path, Query, Request
 from pydantic import BaseModel, Field
 
 from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.server.zone_execution import run_zone_scoped
 
 logger = logging.getLogger(__name__)
 
@@ -163,6 +164,10 @@ def _entry_to_response(entry: Any) -> SnapshotEntryResponse:
     )
 
 
+def _get_zone_registry(request: Request) -> Any | None:
+    return getattr(request.app.state, "zone_registry", None)
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -170,45 +175,55 @@ def _entry_to_response(entry: Any) -> SnapshotEntryResponse:
 
 @router.post("", status_code=201, response_model=TransactionResponse)
 async def begin_transaction(
+    request: Request,
     body: BeginTransactionRequest,
     ctx: tuple[Any, str, str | None] = Depends(get_snapshot_context),
 ) -> TransactionResponse:
     """Begin a new transactional snapshot."""
     snapshot_service, zone_id, agent_id = ctx
-    try:
-        info = await snapshot_service.begin(
-            zone_id=zone_id,
-            agent_id=agent_id,
-            description=body.description,
-            ttl_seconds=body.ttl_seconds,
-        )
-        return _to_response(info)
-    except Exception as e:
-        logger.error("Failed to begin transaction: %s", e, exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to begin transaction") from e
+
+    async def _begin() -> TransactionResponse:
+        try:
+            info = await snapshot_service.begin(
+                zone_id=zone_id,
+                agent_id=agent_id,
+                description=body.description,
+                ttl_seconds=body.ttl_seconds,
+            )
+            return _to_response(info)
+        except Exception as e:
+            logger.error("Failed to begin transaction: %s", e, exc_info=True)
+            raise HTTPException(status_code=500, detail="Failed to begin transaction") from e
+
+    return await run_zone_scoped(_get_zone_registry(request), zone_id, _begin)
 
 
 @router.get("", response_model=TransactionListResponse)
 async def list_transactions(
+    request: Request,
     status: str | None = Query(None, description="Filter by status"),
     limit: int = Query(100, ge=1, le=1000),
     ctx: tuple[Any, str, str | None] = Depends(get_snapshot_context),
 ) -> TransactionListResponse:
     """List transactions scoped to the user's zone."""
     snapshot_service, zone_id, _ = ctx
-    try:
-        transactions = await snapshot_service.list_transactions(
-            zone_id=zone_id,
-            status=status,
-            limit=limit,
-        )
-        return TransactionListResponse(
-            transactions=[_to_response(t) for t in transactions],
-            count=len(transactions),
-        )
-    except Exception as e:
-        logger.error("Failed to list transactions: %s", e, exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to list transactions") from e
+
+    async def _list() -> TransactionListResponse:
+        try:
+            transactions = await snapshot_service.list_transactions(
+                zone_id=zone_id,
+                status=status,
+                limit=limit,
+            )
+            return TransactionListResponse(
+                transactions=[_to_response(t) for t in transactions],
+                count=len(transactions),
+            )
+        except Exception as e:
+            logger.error("Failed to list transactions: %s", e, exc_info=True)
+            raise HTTPException(status_code=500, detail="Failed to list transactions") from e
+
+    return await run_zone_scoped(_get_zone_registry(request), zone_id, _list)
 
 
 async def _verify_zone_ownership(snapshot_service: Any, txn_id: str, zone_id: str) -> Any:
@@ -225,23 +240,29 @@ async def _verify_zone_ownership(snapshot_service: Any, txn_id: str, zone_id: st
 
 @router.get("/{txn_id}", response_model=TransactionResponse)
 async def get_transaction(
+    request: Request,
     txn_id: str = Path(..., min_length=1, max_length=36),
     ctx: tuple[Any, str, str | None] = Depends(get_snapshot_context),
 ) -> TransactionResponse:
     """Get details of a specific transaction."""
     snapshot_service, zone_id, _ = ctx
-    try:
-        info = await _verify_zone_ownership(snapshot_service, txn_id, zone_id)
-        return _to_response(info)
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error("Failed to get transaction %s: %s", txn_id, e, exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to get transaction") from e
+
+    async def _get() -> TransactionResponse:
+        try:
+            info = await _verify_zone_ownership(snapshot_service, txn_id, zone_id)
+            return _to_response(info)
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error("Failed to get transaction %s: %s", txn_id, e, exc_info=True)
+            raise HTTPException(status_code=500, detail="Failed to get transaction") from e
+
+    return await run_zone_scoped(_get_zone_registry(request), zone_id, _get)
 
 
 @router.post("/{txn_id}/commit", response_model=TransactionResponse)
 async def commit_transaction(
+    request: Request,
     txn_id: str = Path(..., min_length=1, max_length=36),
     ctx: tuple[Any, str, str | None] = Depends(get_snapshot_context),
 ) -> TransactionResponse:
@@ -253,37 +274,42 @@ async def commit_transaction(
     )
 
     snapshot_service, zone_id, _ = ctx
-    await _verify_zone_ownership(snapshot_service, txn_id, zone_id)
-    try:
-        info = await snapshot_service.commit(txn_id)
-        return _to_response(info)
-    except TransactionNotFoundError as e:
-        raise HTTPException(status_code=404, detail=f"Transaction not found: {txn_id}") from e
-    except TransactionNotActiveError as e:
-        raise HTTPException(status_code=409, detail=str(e)) from e
-    except TransactionConflictError as e:
-        raise HTTPException(
-            status_code=409,
-            detail={
-                "message": str(e),
-                "conflicts": [
-                    {
-                        "path": c.path,
-                        "expected_hash": c.expected_hash,
-                        "current_hash": c.current_hash,
-                        "reason": c.reason,
-                    }
-                    for c in e.conflicts
-                ],
-            },
-        ) from e
-    except Exception as e:
-        logger.error("Failed to commit transaction %s: %s", txn_id, e, exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to commit transaction") from e
+
+    async def _commit() -> TransactionResponse:
+        await _verify_zone_ownership(snapshot_service, txn_id, zone_id)
+        try:
+            info = await snapshot_service.commit(txn_id)
+            return _to_response(info)
+        except TransactionNotFoundError as e:
+            raise HTTPException(status_code=404, detail=f"Transaction not found: {txn_id}") from e
+        except TransactionNotActiveError as e:
+            raise HTTPException(status_code=409, detail=str(e)) from e
+        except TransactionConflictError as e:
+            raise HTTPException(
+                status_code=409,
+                detail={
+                    "message": str(e),
+                    "conflicts": [
+                        {
+                            "path": c.path,
+                            "expected_hash": c.expected_hash,
+                            "current_hash": c.current_hash,
+                            "reason": c.reason,
+                        }
+                        for c in e.conflicts
+                    ],
+                },
+            ) from e
+        except Exception as e:
+            logger.error("Failed to commit transaction %s: %s", txn_id, e, exc_info=True)
+            raise HTTPException(status_code=500, detail="Failed to commit transaction") from e
+
+    return await run_zone_scoped(_get_zone_registry(request), zone_id, _commit)
 
 
 @router.post("/{txn_id}/rollback", response_model=TransactionResponse)
 async def rollback_transaction(
+    request: Request,
     txn_id: str = Path(..., min_length=1, max_length=36),
     ctx: tuple[Any, str, str | None] = Depends(get_snapshot_context),
 ) -> TransactionResponse:
@@ -294,32 +320,41 @@ async def rollback_transaction(
     )
 
     snapshot_service, zone_id, _ = ctx
-    await _verify_zone_ownership(snapshot_service, txn_id, zone_id)
-    try:
-        info = await snapshot_service.rollback(txn_id)
-        return _to_response(info)
-    except TransactionNotFoundError as e:
-        raise HTTPException(status_code=404, detail=f"Transaction not found: {txn_id}") from e
-    except TransactionNotActiveError as e:
-        raise HTTPException(status_code=409, detail=str(e)) from e
-    except Exception as e:
-        logger.error("Failed to rollback transaction %s: %s", txn_id, e, exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to rollback transaction") from e
+
+    async def _rollback() -> TransactionResponse:
+        await _verify_zone_ownership(snapshot_service, txn_id, zone_id)
+        try:
+            info = await snapshot_service.rollback(txn_id)
+            return _to_response(info)
+        except TransactionNotFoundError as e:
+            raise HTTPException(status_code=404, detail=f"Transaction not found: {txn_id}") from e
+        except TransactionNotActiveError as e:
+            raise HTTPException(status_code=409, detail=str(e)) from e
+        except Exception as e:
+            logger.error("Failed to rollback transaction %s: %s", txn_id, e, exc_info=True)
+            raise HTTPException(status_code=500, detail="Failed to rollback transaction") from e
+
+    return await run_zone_scoped(_get_zone_registry(request), zone_id, _rollback)
 
 
 @router.get("/{txn_id}/entries", response_model=list[SnapshotEntryResponse])
 async def list_entries(
+    request: Request,
     txn_id: str = Path(..., min_length=1, max_length=36),
     ctx: tuple[Any, str, str | None] = Depends(get_snapshot_context),
 ) -> list[SnapshotEntryResponse]:
     """List all entries for a transaction."""
     snapshot_service, zone_id, _ = ctx
-    await _verify_zone_ownership(snapshot_service, txn_id, zone_id)
-    try:
-        entries = await snapshot_service.list_entries(txn_id)
-        return [_entry_to_response(e) for e in entries]
-    except HTTPException:
-        raise
-    except Exception as e:
-        logger.error("Failed to list entries for %s: %s", txn_id, e, exc_info=True)
-        raise HTTPException(status_code=500, detail="Failed to list entries") from e
+
+    async def _entries() -> list[SnapshotEntryResponse]:
+        await _verify_zone_ownership(snapshot_service, txn_id, zone_id)
+        try:
+            entries = await snapshot_service.list_entries(txn_id)
+            return [_entry_to_response(e) for e in entries]
+        except HTTPException:
+            raise
+        except Exception as e:
+            logger.error("Failed to list entries for %s: %s", txn_id, e, exc_info=True)
+            raise HTTPException(status_code=500, detail="Failed to list entries") from e
+
+    return await run_zone_scoped(_get_zone_registry(request), zone_id, _entries)

--- a/src/nexus/server/api/v2/routers/subscriptions.py
+++ b/src/nexus/server/api/v2/routers/subscriptions.py
@@ -21,6 +21,7 @@ from fastapi.responses import JSONResponse
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.server.dependencies import require_auth
+from nexus.server.zone_execution import run_zone_scoped
 
 logger = logging.getLogger(__name__)
 
@@ -37,6 +38,15 @@ def _get_subscription_manager(request: Request) -> Any:
     if mgr is None:
         raise HTTPException(status_code=503, detail="Subscription manager not available")
     return mgr
+
+
+def _get_zone_registry(request: Request) -> Any | None:
+    return getattr(request.app.state, "zone_registry", None)
+
+
+def _auth_zone(auth_result: dict[str, Any]) -> str | None:
+    zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
+    return zone_id if zone_id != ROOT_ZONE_ID else None
 
 
 # =============================================================================
@@ -61,16 +71,20 @@ async def create_subscription(
     zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
     created_by = auth_result.get("subject_id")
 
-    subscription = subscription_manager.create(
-        zone_id=zone_id,
-        data=data,
-        created_by=created_by,
-    )
-    return JSONResponse(content=subscription.model_dump(mode="json"), status_code=201)
+    async def _create() -> JSONResponse:
+        subscription = subscription_manager.create(
+            zone_id=zone_id,
+            data=data,
+            created_by=created_by,
+        )
+        return JSONResponse(content=subscription.model_dump(mode="json"), status_code=201)
+
+    return await run_zone_scoped(_get_zone_registry(request), _auth_zone(auth_result), _create)
 
 
 @router.get("")
 async def list_subscriptions(
+    request: Request,
     enabled_only: bool = False,
     limit: int = 100,
     offset: int = 0,
@@ -79,29 +93,38 @@ async def list_subscriptions(
 ) -> JSONResponse:
     """List webhook subscriptions for the current zone."""
     zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
-    subscriptions = subscription_manager.list_subscriptions(
-        zone_id=zone_id,
-        enabled_only=enabled_only,
-        limit=limit,
-        offset=offset,
-    )
-    return JSONResponse(
-        content={"subscriptions": [s.model_dump(mode="json") for s in subscriptions]}
-    )
+
+    async def _list() -> JSONResponse:
+        subscriptions = subscription_manager.list_subscriptions(
+            zone_id=zone_id,
+            enabled_only=enabled_only,
+            limit=limit,
+            offset=offset,
+        )
+        return JSONResponse(
+            content={"subscriptions": [s.model_dump(mode="json") for s in subscriptions]}
+        )
+
+    return await run_zone_scoped(_get_zone_registry(request), _auth_zone(auth_result), _list)
 
 
 @router.get("/{subscription_id}")
 async def get_subscription(
     subscription_id: str,
+    request: Request,
     auth_result: dict[str, Any] = Depends(require_auth),
     subscription_manager: Any = Depends(_get_subscription_manager),
 ) -> JSONResponse:
     """Get a webhook subscription by ID."""
     zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
-    subscription = subscription_manager.get(subscription_id, zone_id)
-    if subscription is None:
-        raise HTTPException(status_code=404, detail="Subscription not found")
-    return JSONResponse(content=subscription.model_dump(mode="json"))
+
+    async def _get() -> JSONResponse:
+        subscription = subscription_manager.get(subscription_id, zone_id)
+        if subscription is None:
+            raise HTTPException(status_code=404, detail="Subscription not found")
+        return JSONResponse(content=subscription.model_dump(mode="json"))
+
+    return await run_zone_scoped(_get_zone_registry(request), _auth_zone(auth_result), _get)
 
 
 @router.patch("/{subscription_id}")
@@ -118,37 +141,50 @@ async def update_subscription(
     data = SubscriptionUpdate(**body)
     zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
 
-    subscription = subscription_manager.update(
-        subscription_id=subscription_id,
-        zone_id=zone_id,
-        data=data,
-    )
-    if subscription is None:
-        raise HTTPException(status_code=404, detail="Subscription not found")
-    return JSONResponse(content=subscription.model_dump(mode="json"))
+    async def _update() -> JSONResponse:
+        subscription = subscription_manager.update(
+            subscription_id=subscription_id,
+            zone_id=zone_id,
+            data=data,
+        )
+        if subscription is None:
+            raise HTTPException(status_code=404, detail="Subscription not found")
+        return JSONResponse(content=subscription.model_dump(mode="json"))
+
+    return await run_zone_scoped(_get_zone_registry(request), _auth_zone(auth_result), _update)
 
 
 @router.delete("/{subscription_id}")
 async def delete_subscription(
     subscription_id: str,
+    request: Request,
     auth_result: dict[str, Any] = Depends(require_auth),
     subscription_manager: Any = Depends(_get_subscription_manager),
 ) -> JSONResponse:
     """Delete a webhook subscription."""
     zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
-    deleted = subscription_manager.delete(subscription_id, zone_id)
-    if not deleted:
-        raise HTTPException(status_code=404, detail="Subscription not found")
-    return JSONResponse(content={"deleted": True})
+
+    async def _delete() -> JSONResponse:
+        deleted = subscription_manager.delete(subscription_id, zone_id)
+        if not deleted:
+            raise HTTPException(status_code=404, detail="Subscription not found")
+        return JSONResponse(content={"deleted": True})
+
+    return await run_zone_scoped(_get_zone_registry(request), _auth_zone(auth_result), _delete)
 
 
 @router.post("/{subscription_id}/test")
 async def test_subscription(
     subscription_id: str,
+    request: Request,
     auth_result: dict[str, Any] = Depends(require_auth),
     subscription_manager: Any = Depends(_get_subscription_manager),
 ) -> JSONResponse:
     """Send a test event to a webhook subscription."""
     zone_id = auth_result.get("zone_id") or ROOT_ZONE_ID
-    result = await subscription_manager.test(subscription_id, zone_id)
-    return JSONResponse(content=result)
+
+    async def _test() -> JSONResponse:
+        result = await subscription_manager.test(subscription_id, zone_id)
+        return JSONResponse(content=result)
+
+    return await run_zone_scoped(_get_zone_registry(request), _auth_zone(auth_result), _test)

--- a/src/nexus/server/api/v2/routers/tus_uploads.py
+++ b/src/nexus/server/api/v2/routers/tus_uploads.py
@@ -19,6 +19,7 @@ from fastapi import APIRouter, Depends, Header, HTTPException, Request, Response
 
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.server.dependencies import require_auth
+from nexus.server.zone_execution import run_zone_scoped
 
 if TYPE_CHECKING:
     from nexus.bricks.upload.chunked_upload_service import ChunkedUploadService
@@ -85,6 +86,10 @@ def _authorize_upload_access(session: Any, auth_result: dict[str, Any]) -> Any:
     if session.zone_id != request_zone or session.user_id != request_user:
         raise HTTPException(status_code=403, detail="Upload session is not owned by caller")
     return ctx
+
+
+def _get_zone_registry(request: Request) -> Any | None:
+    return getattr(request.app.state, "zone_registry", None)
 
 
 def create_tus_uploads_router(
@@ -169,23 +174,26 @@ def create_tus_uploads_router(
         zone_id = ctx.zone_id or ROOT_ZONE_ID
         user_id = ctx.user_id or "anonymous"
 
-        try:
-            session = await service.create_upload(
-                target_path=metadata.get("filename", metadata.get("path", "/uploads/unknown")),
-                upload_length=upload_length,
-                metadata=metadata,
-                zone_id=zone_id,
-                user_id=user_id,
-                context=ctx,
-            )
-        except RuntimeError as e:
-            if "Too many concurrent" in str(e):
-                raise HTTPException(status_code=429, detail=str(e)) from e
-            raise
-        except ValidationError as e:
-            raise HTTPException(status_code=400, detail=str(e)) from e
-        except NexusPermissionError as e:
-            raise HTTPException(status_code=403, detail=str(e)) from e
+        async def _create() -> Any:
+            try:
+                return await service.create_upload(
+                    target_path=metadata.get("filename", metadata.get("path", "/uploads/unknown")),
+                    upload_length=upload_length,
+                    metadata=metadata,
+                    zone_id=zone_id,
+                    user_id=user_id,
+                    context=ctx,
+                )
+            except RuntimeError as e:
+                if "Too many concurrent" in str(e):
+                    raise HTTPException(status_code=429, detail=str(e)) from e
+                raise
+            except ValidationError as e:
+                raise HTTPException(status_code=400, detail=str(e)) from e
+            except NexusPermissionError as e:
+                raise HTTPException(status_code=403, detail=str(e)) from e
+
+        session = await run_zone_scoped(_get_zone_registry(request), ctx.zone_id, _create)
 
         # Build Location URL
         location = str(request.url).rstrip("/") + f"/{session.upload_id}"
@@ -220,13 +228,20 @@ def create_tus_uploads_router(
 
         service = _get_service()
 
-        try:
-            current = await service.get_upload_status(upload_id)
-            ctx = _authorize_upload_access(current, auth_result)
-        except UploadNotFoundError as e:
-            raise HTTPException(status_code=404, detail=f"Upload not found: {upload_id}") from e
-        except UploadExpiredError as e:
-            raise HTTPException(status_code=410, detail=f"Upload expired: {upload_id}") from e
+        from nexus.server.dependencies import get_operation_context
+
+        ctx = get_operation_context(auth_result)
+
+        async def _status_for_chunk() -> Any:
+            try:
+                current = await service.get_upload_status(upload_id)
+                return _authorize_upload_access(current, auth_result)
+            except UploadNotFoundError as e:
+                raise HTTPException(status_code=404, detail=f"Upload not found: {upload_id}") from e
+            except UploadExpiredError as e:
+                raise HTTPException(status_code=410, detail=f"Upload expired: {upload_id}") from e
+
+        ctx = await run_zone_scoped(_get_zone_registry(request), ctx.zone_id, _status_for_chunk)
 
         # Validate Content-Type
         content_type = request.headers.get("Content-Type", "")
@@ -254,32 +269,35 @@ def create_tus_uploads_router(
         # Optional checksum
         checksum_header = request.headers.get("Upload-Checksum")
 
-        try:
-            session = await service.receive_chunk(
-                upload_id=upload_id,
-                offset=offset,
-                chunk_data=chunk_data,
-                checksum_header=checksum_header,
-                context=ctx,
-            )
-        except UploadNotFoundError as e:
-            raise HTTPException(status_code=404, detail=f"Upload not found: {upload_id}") from e
-        except UploadExpiredError as e:
-            raise HTTPException(status_code=410, detail=f"Upload expired: {upload_id}") from e
-        except UploadOffsetMismatchError as e:
-            raise HTTPException(
-                status_code=409,
-                detail=f"Offset mismatch: expected {e.expected_offset}, got {e.received_offset}",
-            ) from e
-        except UploadChecksumMismatchError as e:
-            raise HTTPException(
-                status_code=460,
-                detail=f"Checksum mismatch ({e.algorithm})",
-            ) from e
-        except ValidationError as e:
-            raise HTTPException(status_code=400, detail=str(e)) from e
-        except NexusPermissionError as e:
-            raise HTTPException(status_code=403, detail=str(e)) from e
+        async def _receive() -> Any:
+            try:
+                return await service.receive_chunk(
+                    upload_id=upload_id,
+                    offset=offset,
+                    chunk_data=chunk_data,
+                    checksum_header=checksum_header,
+                    context=ctx,
+                )
+            except UploadNotFoundError as e:
+                raise HTTPException(status_code=404, detail=f"Upload not found: {upload_id}") from e
+            except UploadExpiredError as e:
+                raise HTTPException(status_code=410, detail=f"Upload expired: {upload_id}") from e
+            except UploadOffsetMismatchError as e:
+                raise HTTPException(
+                    status_code=409,
+                    detail=f"Offset mismatch: expected {e.expected_offset}, got {e.received_offset}",
+                ) from e
+            except UploadChecksumMismatchError as e:
+                raise HTTPException(
+                    status_code=460,
+                    detail=f"Checksum mismatch ({e.algorithm})",
+                ) from e
+            except ValidationError as e:
+                raise HTTPException(status_code=400, detail=str(e)) from e
+            except NexusPermissionError as e:
+                raise HTTPException(status_code=403, detail=str(e)) from e
+
+        session = await run_zone_scoped(_get_zone_registry(request), ctx.zone_id, _receive)
 
         headers = {
             "Tus-Resumable": TUS_RESUMABLE,
@@ -295,6 +313,7 @@ def create_tus_uploads_router(
     @router.head("/{upload_id}")
     async def tus_get_offset(
         upload_id: str,
+        request: Request,
         _tus_resumable: str = Depends(_validate_tus_resumable),
         auth_result: dict = Depends(require_auth),
     ) -> Response:
@@ -303,13 +322,21 @@ def create_tus_uploads_router(
 
         service = _get_service()
 
-        try:
-            session = await service.get_upload_status(upload_id)
-            _authorize_upload_access(session, auth_result)
-        except UploadNotFoundError as e:
-            raise HTTPException(status_code=404, detail=f"Upload not found: {upload_id}") from e
-        except UploadExpiredError as e:
-            raise HTTPException(status_code=410, detail=f"Upload expired: {upload_id}") from e
+        from nexus.server.dependencies import get_operation_context
+
+        ctx = get_operation_context(auth_result)
+
+        async def _status() -> Any:
+            try:
+                session = await service.get_upload_status(upload_id)
+                _authorize_upload_access(session, auth_result)
+                return session
+            except UploadNotFoundError as e:
+                raise HTTPException(status_code=404, detail=f"Upload not found: {upload_id}") from e
+            except UploadExpiredError as e:
+                raise HTTPException(status_code=410, detail=f"Upload expired: {upload_id}") from e
+
+        session = await run_zone_scoped(_get_zone_registry(request), ctx.zone_id, _status)
 
         headers = {
             "Tus-Resumable": TUS_RESUMABLE,
@@ -327,6 +354,7 @@ def create_tus_uploads_router(
     @router.delete("/{upload_id}")
     async def tus_terminate(
         upload_id: str,
+        request: Request,
         _tus_resumable: str = Depends(_validate_tus_resumable),
         auth_result: dict = Depends(require_auth),
     ) -> Response:
@@ -335,14 +363,21 @@ def create_tus_uploads_router(
 
         service = _get_service()
 
-        try:
-            session = await service.get_upload_status(upload_id)
-            _authorize_upload_access(session, auth_result)
-            await service.terminate_upload(upload_id)
-        except UploadNotFoundError as e:
-            raise HTTPException(status_code=404, detail=f"Upload not found: {upload_id}") from e
-        except UploadExpiredError as e:
-            raise HTTPException(status_code=410, detail=f"Upload expired: {upload_id}") from e
+        from nexus.server.dependencies import get_operation_context
+
+        ctx = get_operation_context(auth_result)
+
+        async def _terminate() -> None:
+            try:
+                session = await service.get_upload_status(upload_id)
+                _authorize_upload_access(session, auth_result)
+                await service.terminate_upload(upload_id)
+            except UploadNotFoundError as e:
+                raise HTTPException(status_code=404, detail=f"Upload not found: {upload_id}") from e
+            except UploadExpiredError as e:
+                raise HTTPException(status_code=410, detail=f"Upload expired: {upload_id}") from e
+
+        await run_zone_scoped(_get_zone_registry(request), ctx.zone_id, _terminate)
 
         return Response(
             status_code=204,

--- a/src/nexus/server/api/v2/routers/workspace.py
+++ b/src/nexus/server/api/v2/routers/workspace.py
@@ -16,10 +16,12 @@ FastAPI auto-runs sync endpoints in a threadpool.
 
 import json
 import logging
+from collections.abc import Callable
 from datetime import datetime, timedelta
-from typing import Any
+from typing import Any, TypeVar
 
-from fastapi import APIRouter, Depends, HTTPException, status
+from anyio import from_thread
+from fastapi import APIRouter, Depends, HTTPException, Request, status
 from pydantic import BaseModel, Field, field_validator
 from sqlalchemy.exc import IntegrityError
 
@@ -28,6 +30,7 @@ from nexus.server.api.v2.dependencies import (
     _get_require_auth,
     get_workspace_registry,
 )
+from nexus.server.zone_execution import run_zone_scoped
 
 logger = logging.getLogger(__name__)
 
@@ -94,6 +97,7 @@ class WorkspaceListResponse(BaseModel):
 # ---------------------------------------------------------------------------
 
 workspace_router = APIRouter(prefix="/api/v2/registry/workspaces", tags=["registry"])
+T = TypeVar("T")
 
 
 # ---------------------------------------------------------------------------
@@ -170,6 +174,21 @@ def _list_workspace_db_models(registry: Any, *, user_id: str | None = None) -> l
         return list(session.execute(stmt).scalars().all())
 
 
+def _get_zone_registry(request: Request) -> Any | None:
+    return getattr(request.app.state, "zone_registry", None)
+
+
+def _run_zone_scoped_sync(request: Request, zone_id: str | None, work: Callable[[], T]) -> T:
+    zone_registry = _get_zone_registry(request)
+    if zone_registry is None or zone_id is None:
+        return work()
+
+    async def _work() -> T:
+        return work()
+
+    return from_thread.run(run_zone_scoped, zone_registry, zone_id, _work)
+
+
 # ---------------------------------------------------------------------------
 # Endpoints
 # ---------------------------------------------------------------------------
@@ -177,15 +196,21 @@ def _list_workspace_db_models(registry: Any, *, user_id: str | None = None) -> l
 
 @workspace_router.get("", response_model=WorkspaceListResponse)
 def list_workspaces(
+    request: Request,
     auth_result: dict[str, Any] = Depends(_get_require_auth()),
     registry: Any = Depends(get_workspace_registry),
 ) -> WorkspaceListResponse:
     """List workspaces visible to the authenticated caller."""
-    try:
+    context = _get_operation_context(auth_result)
+
+    def _list() -> WorkspaceListResponse:
         user_id = _get_caller_user_id(auth_result)
         db_models = _list_workspace_db_models(registry, user_id=user_id)
         items = [_build_workspace_response(m) for m in db_models]
         return WorkspaceListResponse(items=items, count=len(items))
+
+    try:
+        return _run_zone_scoped_sync(request, context.zone_id, _list)
     except Exception as e:
         logger.error("Failed to list workspaces: %s", e, exc_info=True)
         raise HTTPException(status_code=500, detail="Failed to list workspaces") from e
@@ -194,12 +219,14 @@ def list_workspaces(
 @workspace_router.post("", response_model=WorkspaceResponse, status_code=status.HTTP_201_CREATED)
 def register_workspace(
     request: WorkspaceRegisterRequest,
+    http_request: Request,
     auth_result: dict[str, Any] = Depends(_get_require_auth()),
     registry: Any = Depends(get_workspace_registry),
 ) -> WorkspaceResponse:
     """Register a directory as a workspace."""
-    try:
-        context = _get_operation_context(auth_result)
+    context = _get_operation_context(auth_result)
+
+    def _register() -> WorkspaceResponse:
         ttl = timedelta(seconds=request.ttl_seconds) if request.ttl_seconds else None
 
         registry.register_workspace(
@@ -217,6 +244,8 @@ def register_workspace(
             raise HTTPException(status_code=500, detail="Workspace registered but not found in DB")
         return _build_workspace_response(db_model)
 
+    try:
+        return _run_zone_scoped_sync(http_request, context.zone_id, _register)
     except (ValueError, IntegrityError) as e:
         raise HTTPException(
             status_code=409,
@@ -234,18 +263,23 @@ def register_workspace(
 @workspace_router.get("/{path:path}", response_model=WorkspaceResponse)
 def get_workspace(
     path: str,
+    request: Request,
     auth_result: dict[str, Any] = Depends(_get_require_auth()),
     registry: Any = Depends(get_workspace_registry),
 ) -> WorkspaceResponse:
     """Get workspace configuration by path (ownership-scoped)."""
     path = _normalize_path(path)
-    try:
+    context = _get_operation_context(auth_result)
+
+    def _get() -> WorkspaceResponse:
         user_id = _get_caller_user_id(auth_result)
         db_model = _get_workspace_db_model(registry, path, user_id=user_id)
         if db_model is None:
             raise HTTPException(status_code=404, detail=f"Workspace not found: {path}")
         return _build_workspace_response(db_model)
 
+    try:
+        return _run_zone_scoped_sync(request, context.zone_id, _get)
     except HTTPException:
         raise
     except Exception as e:
@@ -257,12 +291,15 @@ def get_workspace(
 def update_workspace(
     path: str,
     request: ResourceUpdateRequest,
+    http_request: Request,
     auth_result: dict[str, Any] = Depends(_get_require_auth()),
     registry: Any = Depends(get_workspace_registry),
 ) -> WorkspaceResponse:
     """Update workspace name, description, or metadata (ownership-scoped)."""
     path = _normalize_path(path)
-    try:
+    context = _get_operation_context(auth_result)
+
+    def _update() -> WorkspaceResponse:
         user_id = _get_caller_user_id(auth_result)
         db_model = _get_workspace_db_model(registry, path, user_id=user_id)
         if db_model is None:
@@ -280,6 +317,8 @@ def update_workspace(
             raise HTTPException(status_code=500, detail="Workspace updated but not found in DB")
         return _build_workspace_response(db_model)
 
+    try:
+        return _run_zone_scoped_sync(http_request, context.zone_id, _update)
     except ValueError as e:
         raise HTTPException(status_code=404, detail=str(e)) from e
     except HTTPException:
@@ -292,12 +331,15 @@ def update_workspace(
 @workspace_router.delete("/{path:path}")
 def unregister_workspace(
     path: str,
+    request: Request,
     auth_result: dict[str, Any] = Depends(_get_require_auth()),
     registry: Any = Depends(get_workspace_registry),
 ) -> dict[str, Any]:
     """Unregister a workspace (ownership-scoped, does NOT delete files)."""
     path = _normalize_path(path)
-    try:
+    context = _get_operation_context(auth_result)
+
+    def _delete() -> dict[str, Any]:
         user_id = _get_caller_user_id(auth_result)
         db_model = _get_workspace_db_model(registry, path, user_id=user_id)
         if db_model is None:
@@ -308,6 +350,8 @@ def unregister_workspace(
             raise HTTPException(status_code=404, detail=f"Workspace not found: {path}")
         return {"unregistered": True, "path": path}
 
+    try:
+        return _run_zone_scoped_sync(request, context.zone_id, _delete)
     except HTTPException:
         raise
     except Exception as e:

--- a/src/nexus/server/api/v2/versioning.py
+++ b/src/nexus/server/api/v2/versioning.py
@@ -11,9 +11,10 @@ Issue #995: API versioning strategy for breaking changes.
 """
 
 import logging
+from collections.abc import Callable
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any, cast
 
 from starlette.types import ASGIApp, Message, Receive, Scope, Send
 
@@ -76,6 +77,7 @@ def build_v2_registry(
     *,
     nexus_fs_getter: object | None = None,
     chunked_upload_service_getter: object | None = None,
+    zone_registry_getter: object | None = None,
 ) -> RouterRegistry:
     """Import all v2 routers and return a populated registry.
 
@@ -85,6 +87,8 @@ def build_v2_registry(
     Args:
         nexus_fs_getter: Optional callable returning the NexusFS
             instance (used by the async_files factory router).
+        zone_registry_getter: Optional callable returning the ZoneRegistry
+            instance (used by factory routers).
     """
     registry = RouterRegistry()
 
@@ -132,7 +136,10 @@ def build_v2_registry(
     try:
         from nexus.server.api.v2.routers.async_files import create_async_files_router
 
-        async_files_router = create_async_files_router(get_fs=nexus_fs_getter)
+        async_files_router = create_async_files_router(
+            get_fs=nexus_fs_getter,
+            get_zone_registry=zone_registry_getter,
+        )
         registry.add(
             RouterEntry(
                 router=async_files_router,
@@ -270,7 +277,10 @@ def build_v2_registry(
     try:
         from nexus.server.api.v2.routers.batch import create_batch_router
 
-        batch_router = create_batch_router(get_fs=nexus_fs_getter)
+        batch_router = create_batch_router(
+            get_fs=nexus_fs_getter,
+            get_zone_registry=cast("Callable[[], Any | None] | None", zone_registry_getter),
+        )
         registry.add(
             RouterEntry(
                 router=batch_router,

--- a/src/nexus/server/app_state.py
+++ b/src/nexus/server/app_state.py
@@ -37,6 +37,7 @@ class NexusAppState:
     auth_provider: Any = None
     data_dir: str | None = None
     brick_container: Any = None
+    zone_registry: Any = None
 
     # === Deployment config ===
     deployment_profile: str = "full"

--- a/src/nexus/server/batch_executor.py
+++ b/src/nexus/server/batch_executor.py
@@ -16,6 +16,7 @@ References:
 
 import asyncio
 import base64
+import functools
 import logging
 from typing import TYPE_CHECKING, Annotated, Any, Literal
 
@@ -27,6 +28,8 @@ from nexus.contracts.exceptions import (
     NexusFileNotFoundError,
     NexusPermissionError,
 )
+from nexus.runtime.zone_resolution import target_zone_for_context
+from nexus.server.zone_execution import run_zone_scoped
 
 if TYPE_CHECKING:
     from nexus.contracts.types import OperationContext
@@ -208,9 +211,11 @@ class BatchExecutor:
         self,
         fs: Any,
         operation_timeout: float = DEFAULT_OPERATION_TIMEOUT,
+        zone_registry: Any | None = None,
     ) -> None:
         self._fs = fs
         self._timeout = operation_timeout
+        self._zone_registry = zone_registry
 
     async def execute(
         self,
@@ -226,8 +231,11 @@ class BatchExecutor:
 
         for i, op in enumerate(request.operations):
             try:
+                target_zone = target_zone_for_context(context, op)
+                work = functools.partial(self._dispatch, op, context)
+
                 result = await asyncio.wait_for(
-                    self._dispatch(op, context),
+                    run_zone_scoped(self._zone_registry, target_zone, work),
                     timeout=self._timeout,
                 )
                 result.index = i

--- a/src/nexus/server/cache_warmer.py
+++ b/src/nexus/server/cache_warmer.py
@@ -29,6 +29,7 @@ from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
 from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.server.zone_execution import run_zone_scoped
 
 if TYPE_CHECKING:
     from nexus.core.nexus_fs import NexusFS
@@ -422,6 +423,8 @@ class CacheWarmer:
         config: WarmupConfig | None = None,
         file_tracker: FileAccessTracker | None = None,
         local_disk_cache: "LocalDiskCache | None" = None,
+        *,
+        zone_registry: Any | None = None,
     ):
         """Initialize cache warmer.
 
@@ -435,6 +438,7 @@ class CacheWarmer:
         self._config = config or WarmupConfig()
         self._file_tracker = file_tracker
         self._local_disk_cache = local_disk_cache
+        self._zone_registry = zone_registry
 
         # Semaphore for parallel workers
         self._semaphore = asyncio.Semaphore(self._config.parallel_workers)
@@ -454,6 +458,27 @@ class CacheWarmer:
         return self._is_warming
 
     async def warmup_directory(
+        self,
+        path: str,
+        depth: int | None = None,
+        include_content: bool | None = None,
+        max_files: int | None = None,
+        zone_id: str = ROOT_ZONE_ID,
+        context: Any | None = None,
+    ) -> WarmupStats:
+        async def _warm() -> WarmupStats:
+            return await self._warmup_directory_on_current_loop(
+                path,
+                depth=depth,
+                include_content=include_content,
+                max_files=max_files,
+                zone_id=zone_id,
+                context=context,
+            )
+
+        return await run_zone_scoped(self._zone_registry, zone_id, _warm)
+
+    async def _warmup_directory_on_current_loop(
         self,
         path: str,
         depth: int | None = None,
@@ -540,6 +565,25 @@ class CacheWarmer:
         zone_id: str = ROOT_ZONE_ID,
         context: Any | None = None,
     ) -> WarmupStats:
+        async def _warm() -> WarmupStats:
+            return await self._warmup_from_history_on_current_loop(
+                user=user,
+                hours=hours,
+                max_files=max_files,
+                zone_id=zone_id,
+                context=context,
+            )
+
+        return await run_zone_scoped(self._zone_registry, zone_id, _warm)
+
+    async def _warmup_from_history_on_current_loop(
+        self,
+        user: str | None = None,
+        hours: int = 24,
+        max_files: int | None = None,
+        zone_id: str = ROOT_ZONE_ID,
+        context: Any | None = None,
+    ) -> WarmupStats:
         """Pre-cache files based on user's recent access patterns.
 
         Args:
@@ -609,6 +653,21 @@ class CacheWarmer:
         zone_id: str = ROOT_ZONE_ID,
         paths: list[str] | None = None,
     ) -> WarmupStats:
+        async def _warm() -> WarmupStats:
+            return await self._warmup_permissions_on_current_loop(
+                user,
+                zone_id=zone_id,
+                paths=paths,
+            )
+
+        return await run_zone_scoped(self._zone_registry, zone_id, _warm)
+
+    async def _warmup_permissions_on_current_loop(
+        self,
+        user: str,
+        zone_id: str = ROOT_ZONE_ID,
+        paths: list[str] | None = None,
+    ) -> WarmupStats:
         """Pre-cache permission graph for user.
 
         Args:
@@ -665,6 +724,23 @@ class CacheWarmer:
             self._is_warming = False
 
     async def warmup_paths(
+        self,
+        paths: list[str],
+        include_content: bool = False,
+        zone_id: str = ROOT_ZONE_ID,
+        context: Any | None = None,
+    ) -> WarmupStats:
+        async def _warm() -> WarmupStats:
+            return await self._warmup_paths_on_current_loop(
+                paths,
+                include_content=include_content,
+                zone_id=zone_id,
+                context=context,
+            )
+
+        return await run_zone_scoped(self._zone_registry, zone_id, _warm)
+
+    async def _warmup_paths_on_current_loop(
         self,
         paths: list[str],
         include_content: bool = False,
@@ -986,6 +1062,7 @@ async def warmup_on_mount(
     include_content: bool = False,
     max_files: int = 1000,
     zone_id: str = ROOT_ZONE_ID,
+    zone_registry: Any | None = None,
 ) -> WarmupStats:
     """Convenience function: Warm cache after FUSE mount.
 
@@ -1000,7 +1077,7 @@ async def warmup_on_mount(
     Returns:
         WarmupStats
     """
-    warmer = CacheWarmer(nexus_fs)
+    warmer = CacheWarmer(nexus_fs, zone_registry=zone_registry)
     return await warmer.warmup_directory(
         path=mount_path,
         depth=depth,

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -258,6 +258,10 @@ def create_app(
         data_dir=data_dir,
     )
 
+    from nexus.runtime.zone_runner import ZoneRegistry
+
+    app.state.zone_registry = ZoneRegistry()
+
     # Issue #1399: BrickContainer for DI (auth brick + future bricks)
     from nexus.lib.brick_container import BrickContainer
 

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -826,7 +826,7 @@ def _register_routes(app: FastAPI) -> None:
     # Test hooks REST API (Issue #2) — only when NEXUS_TEST_HOOKS=true
     if os.getenv("NEXUS_TEST_HOOKS") == "true":
         try:
-            from nexus.core.test_hooks import build_test_hooks_router
+            from nexus.server.test_hooks import build_test_hooks_router
 
             app.include_router(build_test_hooks_router())
             logger.info("Test hooks routes registered (NEXUS_TEST_HOOKS=true)")

--- a/src/nexus/server/fastapi_server.py
+++ b/src/nexus/server/fastapi_server.py
@@ -844,6 +844,7 @@ def _register_routes(app: FastAPI) -> None:
     v2_registry = build_v2_registry(
         nexus_fs_getter=lambda: app.state.nexus_fs,
         chunked_upload_service_getter=lambda: app.state.chunked_upload_service,
+        zone_registry_getter=lambda: app.state.zone_registry,
     )
     register_v2_routers(app, v2_registry)
     app.add_middleware(VersionHeaderMiddleware)

--- a/src/nexus/server/lifespan/__init__.py
+++ b/src/nexus/server/lifespan/__init__.py
@@ -19,6 +19,7 @@ from contextlib import asynccontextmanager, suppress
 from typing import TYPE_CHECKING
 
 from nexus.server.lifespan.services_container import LifespanServices
+from nexus.server.lifespan.zone_runners import shutdown_zone_runners
 
 if TYPE_CHECKING:
     from fastapi import FastAPI
@@ -328,6 +329,7 @@ async def lifespan(app: "FastAPI") -> AsyncIterator[None]:
     await shutdown_search(app, svc)
     await shutdown_services(app, svc)
     await shutdown_realtime(app, svc)
+    await shutdown_zone_runners(app, svc)
 
     # Stop durable invalidation stream (Issue #3396) — before NexusFS close
     _durable = getattr(app.state, "durable_stream", None)

--- a/src/nexus/server/lifespan/search.py
+++ b/src/nexus/server/lifespan/search.py
@@ -304,6 +304,7 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
             settings_store=_settings_store,
             path_context_cache=path_context_cache,  # Issue #3773
             sqlite_vec_backend=_vec_backend,
+            zone_registry=getattr(app.state, "zone_registry", None),
         )
 
         # Embeddings are now handled by txtai backend (Issue #2663).

--- a/src/nexus/server/lifespan/services_container.py
+++ b/src/nexus/server/lifespan/services_container.py
@@ -40,6 +40,7 @@ class LifespanServices:
     database_url: str | None = None
     record_store: Any = None
     zone_id: str | None = None
+    zone_registry: Any = None
 
     # --- Configuration ---------------------------------------------------
     deployment_profile: str = "full"
@@ -111,6 +112,7 @@ class LifespanServices:
             database_url=getattr(app.state, "database_url", None),
             record_store=getattr(app.state, "record_store", None),
             zone_id=getattr(app.state, "zone_id", None),
+            zone_registry=getattr(app.state, "zone_registry", None),
             agent_registry=(
                 # AgentRegistry is the kernel SSOT — fetch through the
                 # kernel handle when nx is wired; fall back to app.state

--- a/src/nexus/server/lifespan/zone_runners.py
+++ b/src/nexus/server/lifespan/zone_runners.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+import logging
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    from fastapi import FastAPI
+
+    from nexus.server.lifespan.services_container import LifespanServices
+
+logger = logging.getLogger(__name__)
+
+
+async def shutdown_zone_runners(app: "FastAPI", svc: "LifespanServices") -> None:
+    registry = getattr(app.state, "zone_registry", None) or getattr(svc, "zone_registry", None)
+    if registry is None:
+        return
+    try:
+        registry.stop_all()
+        logger.info("Zone runners stopped")
+    except Exception:
+        logger.exception("Failed to stop zone runners")

--- a/src/nexus/server/lifespan/zone_runners.py
+++ b/src/nexus/server/lifespan/zone_runners.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import logging
 from typing import TYPE_CHECKING
 
@@ -16,7 +17,7 @@ async def shutdown_zone_runners(app: "FastAPI", svc: "LifespanServices") -> None
     if registry is None:
         return
     try:
-        registry.stop_all()
+        await asyncio.to_thread(registry.stop_all)
         logger.info("Zone runners stopped")
     except Exception:
         logger.exception("Failed to stop zone runners")

--- a/src/nexus/server/test_hooks.py
+++ b/src/nexus/server/test_hooks.py
@@ -1,0 +1,77 @@
+"""Disabled-by-default FastAPI routes for end-to-end stack verification.
+
+These routes are registered only when ``NEXUS_TEST_HOOKS=true``. They are
+still admin-gated because test stacks often run on shared developer machines.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import threading
+import time
+from typing import Any
+
+from fastapi import APIRouter, Depends, HTTPException, Query, Request
+
+from nexus.server.dependencies import require_admin
+from nexus.server.zone_execution import run_zone_scoped
+
+
+def build_test_hooks_router() -> APIRouter:
+    router = APIRouter(
+        prefix="/api/test-hooks",
+        tags=["test-hooks"],
+        dependencies=[Depends(require_admin)],
+    )
+
+    def _zone_registry(request: Request) -> Any:
+        registry = getattr(request.app.state, "zone_registry", None)
+        if registry is None:
+            raise HTTPException(status_code=503, detail="Zone registry is not initialized")
+        return registry
+
+    @router.get("/zone-runners")
+    async def list_zone_runners(request: Request) -> dict[str, Any]:
+        registry = _zone_registry(request)
+        return {
+            "runners": [
+                {"zone_id": runner.zone_id, "is_alive": runner.is_alive}
+                for runner in registry.all()
+            ],
+        }
+
+    @router.get("/zone-runners/{zone_id}/ping")
+    async def ping_zone_runner(request: Request, zone_id: str) -> dict[str, Any]:
+        registry = _zone_registry(request)
+
+        async def _work() -> dict[str, Any]:
+            return _runner_payload(zone_id, 0.0)
+
+        return await run_zone_scoped(registry, zone_id, _work)
+
+    @router.post("/zone-runners/{zone_id}/sleep")
+    async def sleep_zone_runner(
+        request: Request,
+        zone_id: str,
+        delay_ms: int = Query(default=100, ge=0, le=10_000),
+    ) -> dict[str, Any]:
+        registry = _zone_registry(request)
+
+        async def _work() -> dict[str, Any]:
+            start = time.perf_counter()
+            await asyncio.sleep(delay_ms / 1000)
+            return _runner_payload(zone_id, (time.perf_counter() - start) * 1000)
+
+        return await run_zone_scoped(registry, zone_id, _work)
+
+    return router
+
+
+def _runner_payload(zone_id: str, elapsed_ms: float) -> dict[str, Any]:
+    loop = asyncio.get_running_loop()
+    return {
+        "zone_id": zone_id,
+        "thread_name": threading.current_thread().name,
+        "loop_id": id(loop),
+        "elapsed_ms": elapsed_ms,
+    }

--- a/src/nexus/server/zone_execution.py
+++ b/src/nexus/server/zone_execution.py
@@ -1,0 +1,16 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeVar, cast
+
+T = TypeVar("T")
+
+
+async def run_zone_scoped(
+    zone_registry: Any | None,
+    zone_id: str | None,
+    work: Callable[[], Awaitable[T]],
+) -> T:
+    if zone_registry is None or zone_id is None:
+        return await work()
+    return cast(T, await zone_registry.runner_for(zone_id).call(work))

--- a/src/nexus/server/zone_execution.py
+++ b/src/nexus/server/zone_execution.py
@@ -6,6 +6,33 @@ from typing import Any, TypeVar, cast
 T = TypeVar("T")
 
 
+def context_allows_target_zone(context: Any, target_zone: str) -> bool:
+    if getattr(context, "is_admin", False):
+        return True
+    if getattr(context, "zone_id", None) == target_zone:
+        return True
+    if target_zone in set(getattr(context, "zone_set", ()) or ()):
+        return True
+    for zone_perm in getattr(context, "zone_perms", ()) or ():
+        if isinstance(zone_perm, (list, tuple)) and zone_perm and zone_perm[0] == target_zone:
+            return True
+    return False
+
+
+def context_for_target_zone(context: Any, target_zone: str | None) -> Any:
+    if target_zone is None or getattr(context, "zone_id", None) == target_zone:
+        return context
+    if not context_allows_target_zone(context, target_zone):
+        return context
+    updates: dict[str, Any] = {"zone_id": target_zone}
+    if getattr(context, "is_admin", False):
+        updates["zone_set"] = (target_zone,)
+        updates["zone_perms"] = ((target_zone, "rw"),)
+    for key, value in updates.items():
+        setattr(context, key, value)
+    return context
+
+
 async def run_zone_scoped(
     zone_registry: Any | None,
     zone_id: str | None,

--- a/tests/e2e/self_contained/conftest.py
+++ b/tests/e2e/self_contained/conftest.py
@@ -218,6 +218,8 @@ def running_nexus(tmp_path_factory: pytest.TempPathFactory) -> Iterator[RunningN
         tests can drive admin-gated HTTP endpoints (e.g.
         ``POST /api/v2/auth/keys``) and exercise the ReBACCapabilityAuth
         is_admin bypass on the gRPC path.
+      - ``NEXUS_TEST_HOOKS=true`` — enables admin-only diagnostic routes used
+        by live E2E tests to inspect per-zone runner state.
     """
     if not _docker_available():
         pytest.skip("nexus up requires docker")
@@ -313,6 +315,7 @@ def running_nexus(tmp_path_factory: pytest.TempPathFactory) -> Iterator[RunningN
     up_env["NEXUS_APPROVALS_ADMIN_TOKEN"] = admin_token
     up_env["NEXUS_APPROVALS_DIAG_TOKEN"] = diag_token
     up_env["NEXUS_APPROVALS_GRPC_PORT"] = str(grpc_port)
+    up_env["NEXUS_TEST_HOOKS"] = "true"
     # Mirror the pinned api_key into NEXUS_API_KEY for the docker compose
     # subprocess. ``nexus up`` already derives this from nexus.yaml's
     # ``api_key`` field, but setting it explicitly guards against future

--- a/tests/e2e/self_contained/test_zone_runner_live_e2e.py
+++ b/tests/e2e/self_contained/test_zone_runner_live_e2e.py
@@ -1,0 +1,77 @@
+"""E2E coverage for per-zone runners through ``nexus up --build``."""
+
+from __future__ import annotations
+
+import asyncio
+import statistics
+import time
+import uuid
+
+import httpx
+import pytest
+
+pytestmark = [pytest.mark.e2e, pytest.mark.timeout(900)]
+
+
+def _tag() -> str:
+    return uuid.uuid4().hex[:8]
+
+
+class TestZoneRunnerLive:
+    @pytest.mark.asyncio
+    async def test_file_routes_instantiate_zone_runners_and_bulkhead_fast_zone(
+        self, running_nexus
+    ) -> None:
+        tag = _tag()
+        zone_a = f"za{tag[:6]}"
+        zone_b = f"zb{tag[:6]}"
+        headers = {"Authorization": f"Bearer {running_nexus.admin_api_key}"}
+
+        async with httpx.AsyncClient(
+            base_url=running_nexus.http_url,
+            headers=headers,
+            timeout=20.0,
+        ) as client:
+            hook_check = await client.get("/api/test-hooks/zone-runners")
+            assert hook_check.status_code == 200, (
+                "NEXUS_TEST_HOOKS=true is required for this live zone-runner E2E; "
+                f"got {hook_check.status_code}: {hook_check.text}"
+            )
+
+            for zone in (zone_a, zone_b):
+                path = f"/zone-runner-e2e-{tag}-{zone}.txt"
+                write_resp = await client.post(
+                    f"/api/v2/files/write?zone={zone}",
+                    json={"path": path, "content": f"payload::{zone}::{tag}"},
+                )
+                assert write_resp.status_code == 200, write_resp.text
+
+                read_resp = await client.get(
+                    "/api/v2/files/read",
+                    params={"zone": zone, "path": path},
+                )
+                assert read_resp.status_code == 200, read_resp.text
+                assert read_resp.json()["content"] == f"payload::{zone}::{tag}"
+
+            runners_resp = await client.get("/api/test-hooks/zone-runners")
+            assert runners_resp.status_code == 200, runners_resp.text
+            runner_zones = {r["zone_id"] for r in runners_resp.json()["runners"]}
+            assert {zone_a, zone_b}.issubset(runner_zones)
+
+            slow_task = asyncio.create_task(
+                client.post(f"/api/test-hooks/zone-runners/{zone_a}/sleep?delay_ms=1500")
+            )
+            await asyncio.sleep(0.2)
+
+            latencies: list[float] = []
+            for _ in range(10):
+                start = time.perf_counter()
+                ping_resp = await client.get(f"/api/test-hooks/zone-runners/{zone_b}/ping")
+                latencies.append(time.perf_counter() - start)
+                assert ping_resp.status_code == 200, ping_resp.text
+                assert ping_resp.json()["thread_name"] == f"nexus-zone-{zone_b}"
+
+            slow_resp = await slow_task
+            assert slow_resp.status_code == 200, slow_resp.text
+            assert slow_resp.json()["thread_name"] == f"nexus-zone-{zone_a}"
+            assert statistics.median(latencies) < 0.25

--- a/tests/e2e/self_contained/test_zone_runner_live_e2e.py
+++ b/tests/e2e/self_contained/test_zone_runner_live_e2e.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import asyncio
+import base64
 import statistics
 import time
 import uuid
@@ -15,6 +16,26 @@ pytestmark = [pytest.mark.e2e, pytest.mark.timeout(900)]
 
 def _tag() -> str:
     return uuid.uuid4().hex[:8]
+
+
+async def _rpc_call(
+    client: httpx.AsyncClient,
+    method: str,
+    params: dict[str, object],
+) -> dict[str, object]:
+    response = await client.post(
+        f"/api/nfs/{method}",
+        json={
+            "jsonrpc": "2.0",
+            "id": str(uuid.uuid4()),
+            "method": method,
+            "params": params,
+        },
+    )
+    assert response.status_code == 200, response.text
+    payload = response.json()
+    assert "error" not in payload, payload
+    return payload["result"]
 
 
 class TestZoneRunnerLive:
@@ -75,3 +96,41 @@ class TestZoneRunnerLive:
             assert slow_resp.status_code == 200, slow_resp.text
             assert slow_resp.json()["thread_name"] == f"nexus-zone-{zone_a}"
             assert statistics.median(latencies) < 0.25
+
+    @pytest.mark.asyncio
+    async def test_http_rpc_routes_explicit_zone_paths_through_zone_runners(
+        self, running_nexus
+    ) -> None:
+        tag = _tag()
+        zone_a = f"ra{tag[:6]}"
+        zone_b = f"rb{tag[:6]}"
+        headers = {"Authorization": f"Bearer {running_nexus.admin_api_key}"}
+
+        async with httpx.AsyncClient(
+            base_url=running_nexus.http_url,
+            headers=headers,
+            timeout=20.0,
+        ) as client:
+            for zone in (zone_a, zone_b):
+                path = f"/zone/{zone}/rpc-zone-runner-{tag}.txt"
+                content = f"rpc::{zone}::{tag}"
+
+                write_result = await _rpc_call(
+                    client,
+                    "write",
+                    {"path": path, "content": content},
+                )
+                assert write_result["bytes_written"] == len(content)
+
+                read_result = await _rpc_call(client, "read", {"path": path})
+                assert base64.b64decode(read_result["data"]).decode() == content
+
+            runners_resp = await client.get("/api/test-hooks/zone-runners")
+            assert runners_resp.status_code == 200, runners_resp.text
+            runner_zones = {r["zone_id"] for r in runners_resp.json()["runners"]}
+            assert {zone_a, zone_b}.issubset(runner_zones)
+
+            for zone in (zone_a, zone_b):
+                ping_resp = await client.get(f"/api/test-hooks/zone-runners/{zone}/ping")
+                assert ping_resp.status_code == 200, ping_resp.text
+                assert ping_resp.json()["thread_name"] == f"nexus-zone-{zone}"

--- a/tests/integration/server/test_zone_runner_bulkhead.py
+++ b/tests/integration/server/test_zone_runner_bulkhead.py
@@ -1,0 +1,37 @@
+import asyncio
+import statistics
+import time
+
+import pytest
+
+from nexus.runtime.zone_runner import ZoneRegistry
+
+
+@pytest.mark.asyncio
+async def test_slow_zone_does_not_block_fast_zone_median_latency() -> None:
+    registry = ZoneRegistry()
+    try:
+        slow_started = asyncio.Event()
+
+        async def slow_work() -> str:
+            slow_started.set()
+            await asyncio.sleep(1.0)
+            return "slow"
+
+        async def fast_work() -> str:
+            return "fast"
+
+        slow_task = asyncio.create_task(registry.runner_for("zone-a").call(slow_work))
+        await slow_started.wait()
+
+        latencies: list[float] = []
+        for _ in range(25):
+            start = time.perf_counter()
+            result = await registry.runner_for("zone-b").call(fast_work)
+            latencies.append(time.perf_counter() - start)
+            assert result == "fast"
+
+        assert statistics.median(latencies) < 0.05
+        assert await slow_task == "slow"
+    finally:
+        registry.stop_all()

--- a/tests/integration/services/test_connectors_router.py
+++ b/tests/integration/services/test_connectors_router.py
@@ -30,7 +30,7 @@ def _make_connector_info(
     name: str,
     description: str = "",
     category: str = "storage",
-    capabilities: frozenset[BackendFeature] | None = None,
+    backend_features: frozenset[BackendFeature] | None = None,
     user_scoped: bool = False,
 ) -> ConnectorInfo:
     """Create a minimal ConnectorInfo for testing."""
@@ -42,7 +42,7 @@ def _make_connector_info(
         description=description,
         category=category,
         user_scoped=user_scoped,
-        capabilities=capabilities or frozenset(),
+        backend_features=backend_features or frozenset(),
         service_name=name,
     )
 

--- a/tests/unit/bricks/search/test_daemon_zone_runner.py
+++ b/tests/unit/bricks/search/test_daemon_zone_runner.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import sys
+import types
+from typing import Any
+
+import pytest
+
+
+class _RuntimeStub(types.ModuleType):
+    def __getattr__(self, name: str) -> Any:
+        def _missing(*_args: Any, **_kwargs: Any) -> None:
+            raise RuntimeError(f"nexus_runtime stub called: {name}")
+
+        return _missing
+
+
+sys.modules.setdefault("nexus_runtime", _RuntimeStub("nexus_runtime"))
+
+
+class RaisingRegistry:
+    def runner_for(self, zone_id: str) -> Any:
+        raise AssertionError(f"scope mutation unexpectedly entered zone runner {zone_id}")
+
+
+@pytest.mark.asyncio
+async def test_scope_crud_mutation_stays_on_current_loop(monkeypatch: pytest.MonkeyPatch) -> None:
+    from nexus.bricks.search import scope_ops
+    from nexus.bricks.search.daemon import SearchDaemon
+
+    daemon = SearchDaemon.__new__(SearchDaemon)
+    daemon._zone_registry = RaisingRegistry()
+    calls: list[tuple[Any, str, str]] = []
+
+    async def fake_add_indexed_directory(
+        daemon_arg: Any,
+        zone_id: str,
+        directory_path: str,
+    ) -> tuple[str, str]:
+        calls.append((daemon_arg, zone_id, directory_path))
+        return directory_path, "ok"
+
+    monkeypatch.setattr(scope_ops, "add_indexed_directory", fake_add_indexed_directory)
+
+    result = await daemon.add_indexed_directory("eng", "/docs")
+
+    assert result == ("/docs", "ok")
+    assert calls == [(daemon, "eng", "/docs")]

--- a/tests/unit/core/test_test_hooks.py
+++ b/tests/unit/core/test_test_hooks.py
@@ -1,0 +1,29 @@
+from __future__ import annotations
+
+from fastapi import FastAPI
+from starlette.testclient import TestClient
+
+from nexus.runtime.zone_runner import ZoneRegistry
+from nexus.server.dependencies import require_admin
+
+
+def test_zone_runner_test_hooks_route_work_through_registry() -> None:
+    from nexus.core.test_hooks import build_test_hooks_router
+
+    app = FastAPI()
+    registry = ZoneRegistry()
+    app.state.zone_registry = registry
+    app.dependency_overrides[require_admin] = lambda: {"authenticated": True, "is_admin": True}
+    app.include_router(build_test_hooks_router())
+
+    try:
+        with TestClient(app) as client:
+            response = client.post("/api/test-hooks/zone-runners/unit-zone/sleep?delay_ms=1")
+
+        assert response.status_code == 200
+        payload = response.json()
+        assert payload["zone_id"] == "unit-zone"
+        assert payload["thread_name"] == "nexus-zone-unit-zone"
+        assert any(runner.zone_id == "unit-zone" for runner in registry.all())
+    finally:
+        registry.stop_all()

--- a/tests/unit/core/test_test_hooks.py
+++ b/tests/unit/core/test_test_hooks.py
@@ -8,7 +8,7 @@ from nexus.server.dependencies import require_admin
 
 
 def test_zone_runner_test_hooks_route_work_through_registry() -> None:
-    from nexus.core.test_hooks import build_test_hooks_router
+    from nexus.server.test_hooks import build_test_hooks_router
 
     app = FastAPI()
     registry = ZoneRegistry()

--- a/tests/unit/grpc/test_vfs_call_zone_runner.py
+++ b/tests/unit/grpc/test_vfs_call_zone_runner.py
@@ -61,6 +61,7 @@ async def test_grpc_call_dispatch_runs_in_target_zone_runner() -> None:
     assert is_error is False
     decoded = decode_rpc_message(payload)
     assert decoded["result"]["path"] == "/zone/eng/docs/a.txt"
+    assert decoded["result"]["zone"] == "eng"
     assert registry.zones == ["eng"]
     assert registry.runner.calls == 1
 

--- a/tests/unit/grpc/test_vfs_call_zone_runner.py
+++ b/tests/unit/grpc/test_vfs_call_zone_runner.py
@@ -1,0 +1,64 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeVar
+from unittest.mock import MagicMock
+
+import pytest
+
+from nexus.grpc.servicer import VFSCallDispatcher
+from nexus.lib.rpc_codec import decode_rpc_message, encode_rpc_message
+
+T = TypeVar("T")
+
+
+class RecordingRunner:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def call(self, work: Callable[[], Awaitable[T]]) -> T:
+        self.calls += 1
+        return await work()
+
+
+class RecordingRegistry:
+    def __init__(self) -> None:
+        self.zones: list[str] = []
+        self.runner = RecordingRunner()
+
+    def runner_for(self, zone_id: str) -> RecordingRunner:
+        self.zones.append(zone_id)
+        return self.runner
+
+
+@pytest.mark.asyncio
+async def test_grpc_call_dispatch_runs_in_target_zone_runner() -> None:
+    registry = RecordingRegistry()
+
+    async def echo(path: str, context: Any) -> dict[str, str]:
+        return {"path": path, "zone": context.zone_id or "root"}
+
+    dispatcher = VFSCallDispatcher(
+        nexus_fs=MagicMock(),
+        exposed_methods={"echo": echo},
+        zone_registry=registry,
+    )
+
+    is_error, payload = await dispatcher._dispatch_async(
+        "echo",
+        encode_rpc_message({"path": "/zone/eng/docs/a.txt"}),
+        {
+            "authenticated": True,
+            "subject_type": "user",
+            "subject_id": "alice",
+            "zone_id": "root",
+            "zone_perms": [["eng", "rw"]],
+            "is_admin": False,
+        },
+    )
+
+    assert is_error is False
+    decoded = decode_rpc_message(payload)
+    assert decoded["result"]["path"] == "/zone/eng/docs/a.txt"
+    assert registry.zones == ["eng"]
+    assert registry.runner.calls == 1

--- a/tests/unit/grpc/test_vfs_call_zone_runner.py
+++ b/tests/unit/grpc/test_vfs_call_zone_runner.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable
 from typing import Any, TypeVar
 from unittest.mock import MagicMock
@@ -62,3 +63,21 @@ async def test_grpc_call_dispatch_runs_in_target_zone_runner() -> None:
     assert decoded["result"]["path"] == "/zone/eng/docs/a.txt"
     assert registry.zones == ["eng"]
     assert registry.runner.calls == 1
+
+
+def test_dispatcher_preserves_legacy_positional_loop_argument() -> None:
+    loop = asyncio.new_event_loop()
+    try:
+        dispatcher = VFSCallDispatcher(
+            MagicMock(),
+            {},
+            None,
+            None,
+            None,
+            loop,
+        )
+
+        assert dispatcher._loop is loop
+        assert dispatcher._zone_registry is None
+    finally:
+        loop.close()

--- a/tests/unit/runtime/test_zone_registry.py
+++ b/tests/unit/runtime/test_zone_registry.py
@@ -35,3 +35,21 @@ def test_stop_all_stops_every_runner_and_is_idempotent() -> None:
 
     assert not runner_a.is_alive
     assert not runner_b.is_alive
+
+
+async def _zone_work() -> str:
+    return "ok"
+
+
+def test_stop_all_clears_stopped_runners_for_reuse() -> None:
+    registry = ZoneRegistry()
+    old_runner = registry.runner_for("zone-a")
+    old_runner.start()
+
+    registry.stop_all()
+    new_runner = registry.runner_for("zone-a")
+    try:
+        assert new_runner is not old_runner
+        assert new_runner.call_sync(_zone_work) == "ok"
+    finally:
+        registry.stop_all()

--- a/tests/unit/runtime/test_zone_registry.py
+++ b/tests/unit/runtime/test_zone_registry.py
@@ -1,3 +1,7 @@
+from typing import Any, cast
+
+import pytest
+
 from nexus.runtime.zone_runner import ZoneRegistry
 
 
@@ -53,3 +57,44 @@ def test_stop_all_clears_stopped_runners_for_reuse() -> None:
         assert new_runner.call_sync(_zone_work) == "ok"
     finally:
         registry.stop_all()
+
+
+def test_stop_all_keeps_runner_when_stop_raises() -> None:
+    class FailingRunner:
+        @property
+        def is_alive(self) -> bool:
+            return True
+
+        def stop(self) -> None:
+            raise RuntimeError("stop failed")
+
+    registry = ZoneRegistry()
+    runner = FailingRunner()
+    cast(dict[str, Any], registry._runners)["zone-a"] = runner
+
+    with pytest.raises(ExceptionGroup) as exc_info:
+        registry.stop_all()
+
+    assert "Failed to stop zone runners" in str(exc_info.value)
+    assert registry.runner_for("zone-a") is runner
+
+
+def test_stop_all_keeps_runner_when_stop_returns_but_runner_is_alive() -> None:
+    class StillAliveRunner:
+        stopped = False
+
+        @property
+        def is_alive(self) -> bool:
+            return True
+
+        def stop(self) -> None:
+            self.stopped = True
+
+    registry = ZoneRegistry()
+    runner = StillAliveRunner()
+    cast(dict[str, Any], registry._runners)["zone-a"] = runner
+
+    registry.stop_all()
+
+    assert runner.stopped is True
+    assert registry.runner_for("zone-a") is runner

--- a/tests/unit/runtime/test_zone_registry.py
+++ b/tests/unit/runtime/test_zone_registry.py
@@ -1,0 +1,37 @@
+from nexus.runtime.zone_runner import ZoneRegistry
+
+
+def test_runner_for_reuses_runner_per_zone() -> None:
+    registry = ZoneRegistry()
+    try:
+        first = registry.runner_for("zone-a")
+        second = registry.runner_for("zone-a")
+        other = registry.runner_for("zone-b")
+        assert first is second
+        assert first is not other
+    finally:
+        registry.stop_all()
+
+
+def test_all_returns_created_runners() -> None:
+    registry = ZoneRegistry()
+    try:
+        runner_a = registry.runner_for("zone-a")
+        runner_b = registry.runner_for("zone-b")
+        assert registry.all() == (runner_a, runner_b)
+    finally:
+        registry.stop_all()
+
+
+def test_stop_all_stops_every_runner_and_is_idempotent() -> None:
+    registry = ZoneRegistry()
+    runner_a = registry.runner_for("zone-a")
+    runner_b = registry.runner_for("zone-b")
+    runner_a.start()
+    runner_b.start()
+
+    registry.stop_all()
+    registry.stop_all()
+
+    assert not runner_a.is_alive
+    assert not runner_b.is_alive

--- a/tests/unit/runtime/test_zone_resolution.py
+++ b/tests/unit/runtime/test_zone_resolution.py
@@ -109,6 +109,16 @@ def test_zone_from_params_prefers_write_operation_path_over_content() -> None:
     assert zone_from_params(params) == "eng"
 
 
+def test_zone_from_params_does_not_read_append_operation_content() -> None:
+    params = {"operations": [("append", "/plain/path.txt", "/zone/wrong/content")]}
+    assert zone_from_params(params) is None
+
+
+def test_zone_from_params_prefers_append_operation_path_over_content() -> None:
+    params = {"operations": [("append", "/zone/eng/path.txt", "/zone/wrong/content")]}
+    assert zone_from_params(params) == "eng"
+
+
 def test_zone_from_params_reads_generic_tagged_operation_dict_payload() -> None:
     params = {"operations": [("read", {"path": "/zone/eng/a.txt"})]}
     assert zone_from_params(params) == "eng"

--- a/tests/unit/runtime/test_zone_resolution.py
+++ b/tests/unit/runtime/test_zone_resolution.py
@@ -109,6 +109,21 @@ def test_zone_from_params_prefers_write_operation_path_over_content() -> None:
     assert zone_from_params(params) == "eng"
 
 
+def test_zone_from_params_reads_generic_tagged_operation_dict_payload() -> None:
+    params = {"operations": [("read", {"path": "/zone/eng/a.txt"})]}
+    assert zone_from_params(params) == "eng"
+
+
+def test_zone_from_params_reads_generic_tagged_operation_path_payload() -> None:
+    params = {"operations": [("delete", "/zone/eng/a.txt")]}
+    assert zone_from_params(params) == "eng"
+
+
+def test_zone_from_params_reads_generic_tagged_operation_object_payload() -> None:
+    params = {"operations": [("stat", SimpleNamespace(path="/zone/legal/a.txt"))]}
+    assert zone_from_params(params) == "legal"
+
+
 def test_zone_from_params_handles_cyclic_containers() -> None:
     operations: list[object] = []
     operations.append(operations)

--- a/tests/unit/runtime/test_zone_resolution.py
+++ b/tests/unit/runtime/test_zone_resolution.py
@@ -25,6 +25,16 @@ def test_zone_from_params_reads_nested_batch_paths() -> None:
     assert zone_from_params(params) == "eng"
 
 
+def test_zone_from_params_reads_tuple_file_containers() -> None:
+    params = {"files": (("/zone/eng/a.txt", b"a"),)}
+    assert zone_from_params(params) == "eng"
+
+
+def test_zone_from_params_reads_tuple_operation_containers() -> None:
+    params = {"operations": ({"path": "/zone/legal/a.txt"},)}
+    assert zone_from_params(params) == "legal"
+
+
 def test_target_zone_uses_non_root_context_when_no_path() -> None:
     context = OperationContext(user_id="alice", groups=[], zone_id="eng")
     assert target_zone_for_context(context, None) == "eng"

--- a/tests/unit/runtime/test_zone_resolution.py
+++ b/tests/unit/runtime/test_zone_resolution.py
@@ -6,6 +6,7 @@ from nexus.runtime.zone_resolution import (
     target_zone_for_context,
     zone_from_params,
     zone_from_path,
+    zones_from_params,
 )
 
 
@@ -89,6 +90,11 @@ def test_zone_from_params_reads_paths_container() -> None:
     assert zone_from_params(params) == "eng"
 
 
+def test_zones_from_params_collects_multiple_path_zones() -> None:
+    params = SimpleNamespace(paths=["/zone/eng/a.txt", "/zone/legal/b.txt"])
+    assert zones_from_params(params) == frozenset({"eng", "legal"})
+
+
 def test_zone_from_params_reads_later_paths_container_match() -> None:
     params = SimpleNamespace(paths=["/plain/a.txt", "/zone/legal/b.txt"])
     assert zone_from_params(params) == "legal"
@@ -102,6 +108,11 @@ def test_zone_from_params_reads_dict_paths_container() -> None:
 def test_zone_from_params_does_not_read_file_tuple_content() -> None:
     params = {"files": [("/plain/path.txt", "/zone/wrong/content")]}
     assert zone_from_params(params) is None
+
+
+def test_zones_from_params_does_not_read_batch_file_content() -> None:
+    params = {"files": [("/zone/eng/path.txt", "/zone/wrong/content")]}
+    assert zones_from_params(params) == frozenset({"eng"})
 
 
 def test_zone_from_params_prefers_file_tuple_path_over_content() -> None:

--- a/tests/unit/runtime/test_zone_resolution.py
+++ b/tests/unit/runtime/test_zone_resolution.py
@@ -79,6 +79,21 @@ def test_zone_from_params_reads_renames_container() -> None:
     assert zone_from_params(params) == "legal"
 
 
+def test_zone_from_params_reads_paths_container() -> None:
+    params = SimpleNamespace(paths=["/zone/eng/a.txt", "/zone/eng/b.txt"])
+    assert zone_from_params(params) == "eng"
+
+
+def test_zone_from_params_reads_later_paths_container_match() -> None:
+    params = SimpleNamespace(paths=["/plain/a.txt", "/zone/legal/b.txt"])
+    assert zone_from_params(params) == "legal"
+
+
+def test_zone_from_params_reads_dict_paths_container() -> None:
+    params = {"paths": ["/zone/eng/a.txt"]}
+    assert zone_from_params(params) == "eng"
+
+
 def test_zone_from_params_does_not_read_file_tuple_content() -> None:
     params = {"files": [("/plain/path.txt", "/zone/wrong/content")]}
     assert zone_from_params(params) is None

--- a/tests/unit/runtime/test_zone_resolution.py
+++ b/tests/unit/runtime/test_zone_resolution.py
@@ -74,6 +74,11 @@ def test_zone_from_params_reads_operation_destination_field() -> None:
     assert zone_from_params(params) == "legal"
 
 
+def test_zone_from_params_reads_syscall_src_path_and_dst_path() -> None:
+    params = SimpleNamespace(src_path="/zone/eng/a.txt", dst_path="/zone/eng/b.txt")
+    assert zone_from_params(params) == "eng"
+
+
 def test_zone_from_params_reads_renames_container() -> None:
     params = SimpleNamespace(renames=[("/zone/legal/a.txt", "/zone/legal/b.txt")])
     assert zone_from_params(params) == "legal"
@@ -189,3 +194,14 @@ def test_target_zone_uses_embedded_path_for_root_multizone_context() -> None:
     )
     params = SimpleNamespace(path="/zone/legal/docs/a.txt")
     assert target_zone_for_context(context, params) == "legal"
+
+
+def test_target_zone_uses_syscall_src_path_for_root_multizone_context() -> None:
+    context = OperationContext(
+        user_id="alice",
+        groups=[],
+        zone_id=ROOT_ZONE_ID,
+        zone_perms=(("eng", "rw"), ("legal", "rw")),
+    )
+    params = {"src_path": "/zone/eng/a.txt", "dst_path": "/zone/eng/b.txt"}
+    assert target_zone_for_context(context, params) == "eng"

--- a/tests/unit/runtime/test_zone_resolution.py
+++ b/tests/unit/runtime/test_zone_resolution.py
@@ -89,6 +89,26 @@ def test_zone_from_params_prefers_file_tuple_path_over_content() -> None:
     assert zone_from_params(params) == "eng"
 
 
+def test_zone_from_params_does_not_read_file_list_content() -> None:
+    params = {"files": [["/plain/path.txt", "/zone/wrong/content"]]}
+    assert zone_from_params(params) is None
+
+
+def test_zone_from_params_prefers_file_list_path_over_content() -> None:
+    params = {"files": [["/zone/eng/path.txt", "/zone/wrong/content"]]}
+    assert zone_from_params(params) == "eng"
+
+
+def test_zone_from_params_does_not_read_write_operation_content() -> None:
+    params = {"operations": [("write", "/plain/path.txt", "/zone/wrong/content")]}
+    assert zone_from_params(params) is None
+
+
+def test_zone_from_params_prefers_write_operation_path_over_content() -> None:
+    params = {"operations": [("write", "/zone/eng/path.txt", "/zone/wrong/content")]}
+    assert zone_from_params(params) == "eng"
+
+
 def test_zone_from_params_handles_cyclic_containers() -> None:
     operations: list[object] = []
     operations.append(operations)

--- a/tests/unit/runtime/test_zone_resolution.py
+++ b/tests/unit/runtime/test_zone_resolution.py
@@ -1,0 +1,46 @@
+from types import SimpleNamespace
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.types import OperationContext
+from nexus.runtime.zone_resolution import (
+    target_zone_for_context,
+    zone_from_params,
+    zone_from_path,
+)
+
+
+def test_zone_from_path_reads_zone_prefix() -> None:
+    assert zone_from_path("/zone/eng/docs/a.txt") == "eng"
+    assert zone_from_path("/zone/legal") == "legal"
+    assert zone_from_path("/plain/path.txt") is None
+
+
+def test_zone_from_params_prefers_explicit_zone_attribute() -> None:
+    params = SimpleNamespace(zone_id="ops", path="/zone/eng/docs/a.txt")
+    assert zone_from_params(params) == "ops"
+
+
+def test_zone_from_params_reads_nested_batch_paths() -> None:
+    params = SimpleNamespace(files=[("/zone/eng/a.txt", b"a"), ("/zone/eng/b.txt", b"b")])
+    assert zone_from_params(params) == "eng"
+
+
+def test_target_zone_uses_non_root_context_when_no_path() -> None:
+    context = OperationContext(user_id="alice", groups=[], zone_id="eng")
+    assert target_zone_for_context(context, None) == "eng"
+
+
+def test_target_zone_ignores_root_context_without_concrete_zone() -> None:
+    context = OperationContext(user_id="alice", groups=[], zone_id=ROOT_ZONE_ID)
+    assert target_zone_for_context(context, SimpleNamespace(path="/docs/a.txt")) is None
+
+
+def test_target_zone_uses_embedded_path_for_root_multizone_context() -> None:
+    context = OperationContext(
+        user_id="alice",
+        groups=[],
+        zone_id=ROOT_ZONE_ID,
+        zone_perms=(("eng", "r"), ("legal", "r")),
+    )
+    params = SimpleNamespace(path="/zone/legal/docs/a.txt")
+    assert target_zone_for_context(context, params) == "legal"

--- a/tests/unit/runtime/test_zone_resolution.py
+++ b/tests/unit/runtime/test_zone_resolution.py
@@ -64,6 +64,37 @@ def test_zone_from_params_reads_tagged_operation_tuple_paths() -> None:
     assert zone_from_params(params) == "legal"
 
 
+def test_zone_from_params_reads_operation_source_field() -> None:
+    params = {"operations": [{"source": "/zone/eng/a.txt"}]}
+    assert zone_from_params(params) == "eng"
+
+
+def test_zone_from_params_reads_operation_destination_field() -> None:
+    params = SimpleNamespace(operations=[SimpleNamespace(destination="/zone/legal/b.txt")])
+    assert zone_from_params(params) == "legal"
+
+
+def test_zone_from_params_reads_renames_container() -> None:
+    params = SimpleNamespace(renames=[("/zone/legal/a.txt", "/zone/legal/b.txt")])
+    assert zone_from_params(params) == "legal"
+
+
+def test_zone_from_params_does_not_read_file_tuple_content() -> None:
+    params = {"files": [("/plain/path.txt", "/zone/wrong/content")]}
+    assert zone_from_params(params) is None
+
+
+def test_zone_from_params_prefers_file_tuple_path_over_content() -> None:
+    params = {"files": [("/zone/eng/path.txt", "/zone/wrong/content")]}
+    assert zone_from_params(params) == "eng"
+
+
+def test_zone_from_params_handles_cyclic_containers() -> None:
+    operations: list[object] = []
+    operations.append(operations)
+    assert zone_from_params({"operations": operations}) is None
+
+
 def test_target_zone_uses_non_root_context_when_no_path() -> None:
     context = OperationContext(user_id="alice", groups=[], zone_id="eng")
     assert target_zone_for_context(context, None) == "eng"

--- a/tests/unit/runtime/test_zone_resolution.py
+++ b/tests/unit/runtime/test_zone_resolution.py
@@ -134,6 +134,21 @@ def test_zone_from_params_reads_generic_tagged_operation_object_payload() -> Non
     assert zone_from_params(params) == "legal"
 
 
+def test_zone_from_params_does_not_read_unknown_tagged_operation_strings() -> None:
+    params = {"operations": [("custom", "/plain/path.txt", "/zone/wrong/content")]}
+    assert zone_from_params(params) is None
+
+
+def test_zone_from_params_reads_unknown_tagged_operation_dict_payload() -> None:
+    params = {"operations": [("custom", {"path": "/zone/eng/a.txt"})]}
+    assert zone_from_params(params) == "eng"
+
+
+def test_zone_from_params_reads_unknown_tagged_operation_object_payload() -> None:
+    params = {"operations": [("custom", SimpleNamespace(path="/zone/legal/a.txt"))]}
+    assert zone_from_params(params) == "legal"
+
+
 def test_zone_from_params_handles_cyclic_containers() -> None:
     operations: list[object] = []
     operations.append(operations)

--- a/tests/unit/runtime/test_zone_resolution.py
+++ b/tests/unit/runtime/test_zone_resolution.py
@@ -15,6 +15,13 @@ def test_zone_from_path_reads_zone_prefix() -> None:
     assert zone_from_path("/plain/path.txt") is None
 
 
+def test_zone_from_path_ignores_empty_and_root_paths() -> None:
+    assert zone_from_path("") is None
+    assert zone_from_path("/") is None
+    assert zone_from_path("/zone/") is None
+    assert zone_from_path(f"/zone/{ROOT_ZONE_ID}/docs/a.txt") is None
+
+
 def test_zone_from_params_prefers_explicit_zone_attribute() -> None:
     params = SimpleNamespace(zone_id="ops", path="/zone/eng/docs/a.txt")
     assert zone_from_params(params) == "ops"
@@ -32,6 +39,28 @@ def test_zone_from_params_reads_tuple_file_containers() -> None:
 
 def test_zone_from_params_reads_tuple_operation_containers() -> None:
     params = {"operations": ({"path": "/zone/legal/a.txt"},)}
+    assert zone_from_params(params) == "legal"
+
+
+def test_zone_from_params_reads_nested_dict_container_fields() -> None:
+    params = {"operations": {"files": [("/zone/eng/a.txt", b"a")]}}
+    assert zone_from_params(params) == "eng"
+
+
+def test_zone_from_params_reads_nested_object_container_fields() -> None:
+    params = SimpleNamespace(
+        operations=SimpleNamespace(files=[SimpleNamespace(path="/zone/legal/a.txt")])
+    )
+    assert zone_from_params(params) == "legal"
+
+
+def test_zone_from_params_reads_tagged_operation_tuple_payload() -> None:
+    params = {"operations": [("write", {"path": "/zone/eng/a.txt"})]}
+    assert zone_from_params(params) == "eng"
+
+
+def test_zone_from_params_reads_tagged_operation_tuple_paths() -> None:
+    params = {"operations": [("rename", "/zone/legal/a.txt", "/zone/legal/b.txt")]}
     assert zone_from_params(params) == "legal"
 
 

--- a/tests/unit/runtime/test_zone_runner.py
+++ b/tests/unit/runtime/test_zone_runner.py
@@ -148,6 +148,73 @@ def test_call_sync_waiter_completes_when_loop_is_blocked_during_stop() -> None:
         runner.stop()
 
 
+def test_queued_call_sync_waiter_completes_when_loop_is_blocked_during_stop() -> None:
+    runner = ZoneRunner("zone-a", join_timeout=0.1)
+    blocker_started = threading.Event()
+    queued_started = threading.Event()
+    release_blocker = threading.Event()
+    blocker_results: list[str] = []
+    blocker_errors: list[BaseException] = []
+    queued_results: list[str] = []
+    queued_errors: list[BaseException] = []
+
+    async def blocking_work() -> str:
+        blocker_started.set()
+        release_blocker.wait(2.0)
+        return "blocker-success"
+
+    async def queued_work() -> str:
+        queued_started.set()
+        return "queued-success"
+
+    def call_blocker() -> None:
+        try:
+            blocker_results.append(runner.call_sync(blocking_work))
+        except BaseException as exc:
+            blocker_errors.append(exc)
+
+    def call_queued() -> None:
+        try:
+            queued_results.append(runner.call_sync(queued_work))
+        except BaseException as exc:
+            queued_errors.append(exc)
+
+    blocker = threading.Thread(target=call_blocker)
+    queued = threading.Thread(target=call_queued)
+    blocker.start()
+    try:
+        assert blocker_started.wait(2.0)
+        queued.start()
+        time.sleep(0.05)
+        assert not queued_started.is_set()
+
+        runner.stop()
+        blocker.join(1.0)
+        queued.join(1.0)
+
+        assert not blocker.is_alive()
+        assert not queued.is_alive()
+        assert blocker_results == []
+        assert queued_results == []
+        assert len(blocker_errors) == 1
+        assert len(queued_errors) == 1
+        assert isinstance(blocker_errors[0], RuntimeError)
+        assert isinstance(queued_errors[0], RuntimeError)
+        assert "stopped" in str(blocker_errors[0])
+        assert "stopped" in str(queued_errors[0])
+
+        release_blocker.set()
+        thread = runner._thread
+        if thread is not None:
+            thread.join(2.0)
+        assert not queued_started.is_set()
+    finally:
+        release_blocker.set()
+        blocker.join(2.0)
+        queued.join(2.0)
+        runner.stop()
+
+
 def test_same_runner_call_rejects_after_shutdown_starts() -> None:
     runner = ZoneRunner("zone-a", join_timeout=0.2)
     outer_started = threading.Event()

--- a/tests/unit/runtime/test_zone_runner.py
+++ b/tests/unit/runtime/test_zone_runner.py
@@ -51,6 +51,51 @@ def test_start_uses_daemon_thread_named_for_zone() -> None:
         runner.stop()
 
 
+def test_concurrent_call_waits_for_startup_readiness() -> None:
+    runner = _DelayedStartRunner("zone-a", join_timeout=1.0)
+    start_errors: list[BaseException] = []
+    call_errors: list[BaseException] = []
+    call_results: list[str] = []
+
+    async def work() -> str:
+        return "ok"
+
+    def start_runner() -> None:
+        try:
+            runner.start()
+        except BaseException as exc:
+            start_errors.append(exc)
+
+    def call_runner() -> None:
+        try:
+            call_results.append(runner.call_sync(work))
+        except BaseException as exc:
+            call_errors.append(exc)
+
+    starter = threading.Thread(target=start_runner)
+    caller = threading.Thread(target=call_runner)
+    starter.start()
+    try:
+        assert runner.startup_blocked.wait(2.0)
+        caller.start()
+        caller.join(0.1)
+
+        assert caller.is_alive()
+
+        runner.release_startup.set()
+        starter.join(2.0)
+        caller.join(2.0)
+
+        assert start_errors == []
+        assert call_errors == []
+        assert call_results == ["ok"]
+    finally:
+        runner.release_startup.set()
+        starter.join(2.0)
+        caller.join(2.0)
+        runner.stop()
+
+
 def test_call_sync_runs_from_sync_code() -> None:
     runner = ZoneRunner("zone-a")
 
@@ -201,7 +246,9 @@ def test_stop_during_startup_does_not_strand_runner() -> None:
         stranded = runner.is_alive
         runner.stop()
 
-        assert all(isinstance(exc, RuntimeError) for exc in start_errors)
+        assert len(start_errors) == 1
+        assert isinstance(start_errors[0], RuntimeError)
+        assert "has been stopped" in str(start_errors[0])
         assert not stranded
         assert not runner.is_alive
     finally:

--- a/tests/unit/runtime/test_zone_runner.py
+++ b/tests/unit/runtime/test_zone_runner.py
@@ -275,8 +275,10 @@ def test_stop_terminates_when_pending_task_suppresses_cancellation(
 
         def capture_diagnostic(_loop, context) -> None:
             message = context.get("message", "")
+            exception = context.get("exception")
             task = context.get("task")
-            loop_diagnostics.append(f"{message} {task!r}")
+            future = context.get("future")
+            loop_diagnostics.append(f"{message} {exception!r} {task!r} {future!r}")
 
         loop.set_exception_handler(capture_diagnostic)
         return loop
@@ -316,7 +318,10 @@ def test_stop_terminates_when_pending_task_suppresses_cancellation(
         diagnostics = f"{captured.err}\n{log_messages}\n{loop_diagnostic_messages}"
         assert "Closing zone runner zone-a with" in log_messages
         assert "Task was destroyed but it is pending!" not in diagnostics
+        assert "Task exception was never retrieved" not in diagnostics
         assert "ZoneRunner._cancel_pending" not in diagnostics
+        assert "_cancel_pending" not in diagnostics
+        assert "cannot reuse already awaited coroutine" not in diagnostics
     finally:
         release.set()
         thread = runner._thread

--- a/tests/unit/runtime/test_zone_runner.py
+++ b/tests/unit/runtime/test_zone_runner.py
@@ -111,6 +111,43 @@ def test_call_sync_runs_from_sync_code() -> None:
         runner.stop()
 
 
+def test_call_sync_waiter_completes_when_loop_is_blocked_during_stop() -> None:
+    runner = ZoneRunner("zone-a", join_timeout=0.1)
+    started = threading.Event()
+    release = threading.Event()
+    results: list[str] = []
+    errors: list[BaseException] = []
+
+    async def blocking_work() -> str:
+        started.set()
+        release.wait(2.0)
+        return "bad"
+
+    def call_runner() -> None:
+        try:
+            results.append(runner.call_sync(blocking_work))
+        except BaseException as exc:
+            errors.append(exc)
+
+    caller = threading.Thread(target=call_runner)
+    caller.start()
+    try:
+        assert started.wait(2.0)
+
+        runner.stop()
+        caller.join(1.0)
+
+        assert not caller.is_alive()
+        assert results == []
+        assert len(errors) == 1
+        assert isinstance(errors[0], RuntimeError)
+        assert "stopped" in str(errors[0])
+    finally:
+        release.set()
+        caller.join(2.0)
+        runner.stop()
+
+
 def test_same_runner_call_rejects_after_shutdown_starts() -> None:
     runner = ZoneRunner("zone-a", join_timeout=0.2)
     outer_started = threading.Event()
@@ -496,6 +533,47 @@ def test_stop_wakes_start_waiting_for_readiness() -> None:
         runner.release_startup.set()
         starter.join(2.0)
         runner.stop()
+
+
+def test_start_timeout_closes_runner_before_thread_becomes_ready() -> None:
+    runner = _DelayedStartRunner("zone-a", join_timeout=0.1)
+    start_errors: list[BaseException] = []
+
+    def start_runner() -> None:
+        try:
+            runner.start()
+        except BaseException as exc:
+            start_errors.append(exc)
+
+    starter = threading.Thread(target=start_runner)
+    starter.start()
+    try:
+        assert runner.startup_blocked.wait(2.0)
+        starter.join(0.5)
+
+        assert not starter.is_alive()
+        assert len(start_errors) == 1
+        assert isinstance(start_errors[0], RuntimeError)
+        assert "did not start" in str(start_errors[0])
+
+        runner.release_startup.set()
+        thread = runner._thread
+        if thread is not None:
+            thread.join(2.0)
+
+        assert not runner.is_alive
+        with pytest.raises(RuntimeError, match="stopped"):
+            runner.call_sync(lambda: _return_value("bad"))
+    finally:
+        runner.release_startup.set()
+        starter.join(2.0)
+        if runner.is_alive:
+            loop = runner._loop
+            thread = runner._thread
+            if loop is not None:
+                loop.call_soon_threadsafe(loop.stop)
+            if thread is not None:
+                thread.join(2.0)
 
 
 def test_stop_keeps_stopping_state_when_startup_join_times_out() -> None:

--- a/tests/unit/runtime/test_zone_runner.py
+++ b/tests/unit/runtime/test_zone_runner.py
@@ -189,6 +189,43 @@ def test_stop_is_idempotent() -> None:
     assert not runner.is_alive
 
 
+def test_concurrent_stop_callers_return_without_exceptions() -> None:
+    runner = _BlockingCancelRunner("zone-a", join_timeout=0.5)
+    stop_errors: list[BaseException] = []
+    release_stops = threading.Event()
+
+    def stop_runner() -> None:
+        try:
+            release_stops.wait(2.0)
+            runner.stop()
+        except BaseException as exc:
+            stop_errors.append(exc)
+
+    runner.start()
+    first = threading.Thread(target=stop_runner)
+    second = threading.Thread(target=stop_runner)
+    first.start()
+    second.start()
+    try:
+        release_stops.set()
+        assert runner.first_cleanup_started.wait(2.0)
+        assert runner.second_cleanup_started.wait(2.0)
+        runner.release_cleanup.set()
+
+        first.join(2.0)
+        second.join(2.0)
+
+        assert stop_errors == []
+        assert not first.is_alive()
+        assert not second.is_alive()
+        assert not runner.is_alive
+    finally:
+        runner.release_cleanup.set()
+        first.join(2.0)
+        second.join(2.0)
+        runner.stop()
+
+
 def test_start_after_stop_raises() -> None:
     runner = ZoneRunner("zone-a")
 
@@ -288,6 +325,37 @@ def test_stop_terminates_when_pending_task_suppresses_cancellation(
         runner.stop()
 
 
+def test_stop_wakes_start_waiting_for_readiness() -> None:
+    runner = _DelayedStartRunner("zone-a", join_timeout=0.1)
+    start_errors: list[BaseException] = []
+
+    def start_runner() -> None:
+        try:
+            runner.start()
+        except BaseException as exc:
+            start_errors.append(exc)
+
+    starter = threading.Thread(target=start_runner)
+    starter.start()
+    try:
+        assert runner.startup_blocked.wait(2.0)
+
+        before_stop = time.monotonic()
+        runner.stop()
+        starter.join(0.5)
+        elapsed = time.monotonic() - before_stop
+
+        assert not starter.is_alive()
+        assert elapsed < 0.5
+        assert len(start_errors) == 1
+        assert isinstance(start_errors[0], RuntimeError)
+        assert "has been stopped" in str(start_errors[0])
+    finally:
+        runner.release_startup.set()
+        starter.join(2.0)
+        runner.stop()
+
+
 def test_stop_during_startup_does_not_strand_runner() -> None:
     runner = _DelayedStartRunner("zone-a", join_timeout=0.1)
     start_errors: list[BaseException] = []
@@ -344,3 +412,30 @@ class _DelayedStartRunner(ZoneRunner):
         self.startup_blocked.set()
         self.release_startup.wait(2.0)
         super()._thread_main()
+
+
+class _BlockingCancelRunner(ZoneRunner):
+    def __init__(self, zone_id: str, join_timeout: float = 5.0) -> None:
+        super().__init__(zone_id, join_timeout)
+        self._cleanup_count = 0
+        self._cleanup_count_lock = threading.Lock()
+        self.first_cleanup_started = threading.Event()
+        self.second_cleanup_started = threading.Event()
+        self.release_cleanup = threading.Event()
+
+    async def _cancel_pending(
+        self,
+        loop: asyncio.AbstractEventLoop,
+        *,
+        stop: bool = True,
+        timeout: float | None = None,
+    ) -> None:
+        with self._cleanup_count_lock:
+            self._cleanup_count += 1
+            cleanup_count = self._cleanup_count
+        if cleanup_count == 1:
+            self.first_cleanup_started.set()
+        elif cleanup_count == 2:
+            self.second_cleanup_started.set()
+        await asyncio.to_thread(self.release_cleanup.wait, 2.0)
+        await super()._cancel_pending(loop, stop=stop, timeout=timeout)

--- a/tests/unit/runtime/test_zone_runner.py
+++ b/tests/unit/runtime/test_zone_runner.py
@@ -111,6 +111,48 @@ def test_call_sync_runs_from_sync_code() -> None:
         runner.stop()
 
 
+def test_same_runner_call_rejects_after_shutdown_starts() -> None:
+    runner = ZoneRunner("zone-a", join_timeout=0.2)
+    outer_started = threading.Event()
+    nested_ran = threading.Event()
+    results: list[str] = []
+    errors: list[BaseException] = []
+
+    async def nested_work() -> str:
+        nested_ran.set()
+        return "bad"
+
+    async def outer_work() -> str:
+        outer_started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            with pytest.raises(RuntimeError, match="stopped|shutdown"):
+                await runner.call(nested_work)
+            return "rejected"
+        return "bad"
+
+    def call_runner() -> None:
+        try:
+            results.append(runner.call_sync(outer_work))
+        except BaseException as exc:
+            errors.append(exc)
+
+    caller = threading.Thread(target=call_runner)
+    caller.start()
+    try:
+        assert outer_started.wait(2.0)
+        runner.stop()
+        caller.join(2.0)
+
+        assert results == ["rejected"]
+        assert errors == []
+        assert not nested_ran.is_set()
+    finally:
+        caller.join(2.0)
+        runner.stop()
+
+
 @pytest.mark.asyncio
 async def test_call_propagates_exception() -> None:
     runner = ZoneRunner("zone-a")
@@ -207,6 +249,44 @@ async def test_call_rejects_submission_after_stop_begins(monkeypatch) -> None:
         release_submit.set()
         stopper.join(2.0)
         runner.stop()
+
+
+@pytest.mark.asyncio
+async def test_call_waiter_completes_when_stubborn_work_is_abandoned() -> None:
+    runner = ZoneRunner("zone-a", join_timeout=0.1)
+    started = threading.Event()
+    cancelled = threading.Event()
+    release = threading.Event()
+    stop_errors: list[BaseException] = []
+
+    async def stubborn_work() -> str:
+        started.set()
+        while not release.is_set():
+            try:
+                await asyncio.sleep(0.01)
+            except asyncio.CancelledError:
+                cancelled.set()
+        return "released"
+
+    def stop_runner() -> None:
+        try:
+            assert started.wait(2.0)
+            runner.stop()
+        except BaseException as exc:
+            stop_errors.append(exc)
+
+    task = asyncio.create_task(runner.call(stubborn_work))
+    stopper = threading.Thread(target=stop_runner)
+    stopper.start()
+    try:
+        with pytest.raises((asyncio.CancelledError, RuntimeError), match="|stopped|shutdown"):
+            await asyncio.wait_for(task, timeout=1.0)
+        assert cancelled.wait(2.0)
+        assert stop_errors == []
+    finally:
+        release.set()
+        stopper.join(2.0)
+        await asyncio.to_thread(runner.stop)
 
 
 @pytest.mark.asyncio

--- a/tests/unit/runtime/test_zone_runner.py
+++ b/tests/unit/runtime/test_zone_runner.py
@@ -361,6 +361,55 @@ def test_stop_wakes_start_waiting_for_readiness() -> None:
         runner.stop()
 
 
+def test_stop_keeps_stopping_state_when_startup_join_times_out() -> None:
+    runner = _DelayedStartRunner("zone-a", join_timeout=0.1)
+    start_errors: list[BaseException] = []
+
+    def start_runner() -> None:
+        try:
+            runner.start()
+        except BaseException as exc:
+            start_errors.append(exc)
+
+    starter = threading.Thread(target=start_runner)
+    starter.start()
+    try:
+        assert runner.startup_blocked.wait(2.0)
+
+        runner.stop()
+        thread = runner._thread
+        assert thread is not None
+        assert thread.is_alive()
+        assert runner._stopping
+
+        before_second_stop = time.monotonic()
+        runner.stop()
+        second_stop_duration = time.monotonic() - before_second_stop
+
+        assert second_stop_duration >= runner._join_timeout
+        assert runner._stopping
+
+        runner.release_startup.set()
+        starter.join(2.0)
+        thread.join(2.0)
+
+        assert len(start_errors) == 1
+        assert isinstance(start_errors[0], RuntimeError)
+        assert "has been stopped" in str(start_errors[0])
+        assert not runner.is_alive
+        assert not runner._stopping
+    finally:
+        runner.release_startup.set()
+        starter.join(2.0)
+        if runner.is_alive:
+            loop = runner._loop
+            thread = runner._thread
+            if loop is not None:
+                loop.call_soon_threadsafe(loop.stop)
+            if thread is not None:
+                thread.join(2.0)
+
+
 def test_stop_during_startup_does_not_strand_runner() -> None:
     runner = _DelayedStartRunner("zone-a", join_timeout=0.1)
     start_errors: list[BaseException] = []

--- a/tests/unit/runtime/test_zone_runner.py
+++ b/tests/unit/runtime/test_zone_runner.py
@@ -6,6 +6,15 @@ import pytest
 from nexus.runtime.zone_runner import ZoneRunner
 
 
+def test_join_timeout_can_be_positional() -> None:
+    runner = ZoneRunner("zone-a", 1.0)
+
+    try:
+        assert not runner.is_alive
+    finally:
+        runner.stop()
+
+
 @pytest.mark.asyncio
 async def test_call_runs_on_dedicated_loop_and_thread() -> None:
     runner = ZoneRunner("zone-a")

--- a/tests/unit/runtime/test_zone_runner.py
+++ b/tests/unit/runtime/test_zone_runner.py
@@ -6,6 +6,11 @@ import pytest
 from nexus.runtime.zone_runner import ZoneRunner
 
 
+def test_empty_zone_id_raises() -> None:
+    with pytest.raises(ValueError, match="zone_id is required"):
+        ZoneRunner("")
+
+
 def test_join_timeout_can_be_positional() -> None:
     runner = ZoneRunner("zone-a", 1.0)
 
@@ -33,6 +38,19 @@ async def test_call_runs_on_dedicated_loop_and_thread() -> None:
     assert worker_loop is not caller_loop
 
 
+def test_start_uses_daemon_thread_named_for_zone() -> None:
+    runner = ZoneRunner("zone-a")
+
+    try:
+        runner.start()
+        thread = runner._thread
+        assert thread is not None
+        assert thread.daemon
+        assert thread.name == "nexus-zone-zone-a"
+    finally:
+        runner.stop()
+
+
 def test_call_sync_runs_from_sync_code() -> None:
     runner = ZoneRunner("zone-a")
 
@@ -56,6 +74,33 @@ async def test_call_propagates_exception() -> None:
         with pytest.raises(ValueError, match="boom"):
             await runner.call(work)
     finally:
+        runner.stop()
+
+
+@pytest.mark.asyncio
+async def test_call_cancellation_cancels_submitted_work() -> None:
+    runner = ZoneRunner("zone-a")
+    started = threading.Event()
+    cancelled = threading.Event()
+
+    async def work() -> str:
+        started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+        return "done"
+
+    task = asyncio.create_task(runner.call(work))
+    try:
+        assert await asyncio.to_thread(started.wait, 2.0)
+        task.cancel()
+        with pytest.raises(asyncio.CancelledError):
+            await task
+        assert await asyncio.to_thread(cancelled.wait, 2.0)
+    finally:
+        task.cancel()
         runner.stop()
 
 
@@ -96,5 +141,92 @@ def test_stop_is_idempotent() -> None:
     assert not runner.is_alive
 
 
+def test_start_after_stop_raises() -> None:
+    runner = ZoneRunner("zone-a")
+
+    runner.stop()
+
+    with pytest.raises(RuntimeError, match="ZoneRunner 'zone-a' has been stopped"):
+        runner.start()
+
+
+def test_stop_cancels_pending_tasks() -> None:
+    runner = ZoneRunner("zone-a")
+    started = threading.Event()
+    cancelled = threading.Event()
+
+    async def pending_work() -> None:
+        started.set()
+        try:
+            await asyncio.sleep(60)
+        except asyncio.CancelledError:
+            cancelled.set()
+            raise
+
+    async def schedule_pending_work() -> None:
+        asyncio.create_task(pending_work())
+
+    try:
+        runner.call_sync(schedule_pending_work)
+        assert started.wait(2.0)
+        runner.stop()
+        assert cancelled.wait(2.0)
+        assert not runner.is_alive
+    finally:
+        runner.stop()
+
+
+def test_stop_during_startup_does_not_strand_runner() -> None:
+    runner = _DelayedStartRunner("zone-a", join_timeout=0.1)
+    start_errors: list[BaseException] = []
+
+    def start_runner() -> None:
+        try:
+            runner.start()
+        except BaseException as exc:
+            start_errors.append(exc)
+
+    starter = threading.Thread(target=start_runner)
+    starter.start()
+    try:
+        assert runner.startup_blocked.wait(2.0)
+
+        runner.stop()
+        runner.release_startup.set()
+        starter.join(2.0)
+        runner_thread = runner._thread
+        if runner_thread is not None:
+            runner_thread.join(2.0)
+
+        stranded = runner.is_alive
+        runner.stop()
+
+        assert all(isinstance(exc, RuntimeError) for exc in start_errors)
+        assert not stranded
+        assert not runner.is_alive
+    finally:
+        runner.release_startup.set()
+        starter.join(2.0)
+        if runner.is_alive:
+            loop = runner._loop
+            thread = runner._thread
+            if loop is not None:
+                loop.call_soon_threadsafe(loop.stop)
+            if thread is not None:
+                thread.join(2.0)
+
+
 async def _return_value(value: str) -> str:
     return value
+
+
+class _DelayedStartRunner(ZoneRunner):
+    def __init__(self, zone_id: str, join_timeout: float = 5.0) -> None:
+        super().__init__(zone_id, join_timeout)
+        self.startup_blocked = threading.Event()
+        self.release_startup = threading.Event()
+
+    def _thread_main(self) -> None:
+        self.startup_blocked.set()
+        self.release_startup.wait(2.0)
+        super()._thread_main()

--- a/tests/unit/runtime/test_zone_runner.py
+++ b/tests/unit/runtime/test_zone_runner.py
@@ -153,6 +153,29 @@ async def test_call_cancellation_cancels_submitted_work() -> None:
 
 
 @pytest.mark.asyncio
+async def test_call_cancellation_during_startup_returns_promptly() -> None:
+    runner = _DelayedStartRunner("zone-a", join_timeout=0.1)
+
+    async def work() -> str:
+        return "should-not-run"
+
+    started_at = time.monotonic()
+    task = asyncio.create_task(runner.call(work))
+    try:
+        await asyncio.sleep(0.05)
+        task.cancel()
+
+        with pytest.raises(asyncio.CancelledError):
+            await asyncio.wait_for(task, timeout=0.5)
+
+        assert time.monotonic() - started_at < 1.0
+    finally:
+        task.cancel()
+        runner.release_startup.set()
+        await asyncio.to_thread(runner.stop)
+
+
+@pytest.mark.asyncio
 async def test_same_runner_reentry_does_not_deadlock() -> None:
     runner = ZoneRunner("zone-a")
 

--- a/tests/unit/runtime/test_zone_runner.py
+++ b/tests/unit/runtime/test_zone_runner.py
@@ -1,4 +1,6 @@
 import asyncio
+import gc
+import logging
 import threading
 import time
 
@@ -222,7 +224,27 @@ def test_stop_cancels_pending_tasks() -> None:
         runner.stop()
 
 
-def test_stop_terminates_when_pending_task_suppresses_cancellation() -> None:
+def test_stop_terminates_when_pending_task_suppresses_cancellation(
+    capsys,
+    caplog,
+    monkeypatch,
+) -> None:
+    caplog.set_level(logging.WARNING, logger="nexus.runtime.zone_runner")
+    loop_diagnostics: list[str] = []
+    new_event_loop = asyncio.new_event_loop
+
+    def tracked_event_loop() -> asyncio.AbstractEventLoop:
+        loop = new_event_loop()
+
+        def capture_diagnostic(_loop, context) -> None:
+            message = context.get("message", "")
+            task = context.get("task")
+            loop_diagnostics.append(f"{message} {task!r}")
+
+        loop.set_exception_handler(capture_diagnostic)
+        return loop
+
+    monkeypatch.setattr(asyncio, "new_event_loop", tracked_event_loop)
     runner = ZoneRunner("zone-a", join_timeout=0.1)
     started = threading.Event()
     cancelled = threading.Event()
@@ -250,6 +272,14 @@ def test_stop_terminates_when_pending_task_suppresses_cancellation() -> None:
         assert cancelled.wait(2.0)
         assert stop_duration < 1.0
         assert not runner.is_alive
+        gc.collect()
+        captured = capsys.readouterr()
+        log_messages = "\n".join(record.getMessage() for record in caplog.records)
+        loop_diagnostic_messages = "\n".join(loop_diagnostics)
+        diagnostics = f"{captured.err}\n{log_messages}\n{loop_diagnostic_messages}"
+        assert "Closing zone runner zone-a with" in log_messages
+        assert "Task was destroyed but it is pending!" not in diagnostics
+        assert "ZoneRunner._cancel_pending" not in diagnostics
     finally:
         release.set()
         thread = runner._thread

--- a/tests/unit/runtime/test_zone_runner.py
+++ b/tests/unit/runtime/test_zone_runner.py
@@ -1,0 +1,91 @@
+import asyncio
+import threading
+
+import pytest
+
+from nexus.runtime.zone_runner import ZoneRunner
+
+
+@pytest.mark.asyncio
+async def test_call_runs_on_dedicated_loop_and_thread() -> None:
+    runner = ZoneRunner("zone-a")
+    caller_loop = asyncio.get_running_loop()
+    caller_thread = threading.get_ident()
+
+    async def work() -> tuple[int, asyncio.AbstractEventLoop]:
+        return threading.get_ident(), asyncio.get_running_loop()
+
+    try:
+        worker_thread, worker_loop = await runner.call(work)
+    finally:
+        runner.stop()
+
+    assert worker_thread != caller_thread
+    assert worker_loop is not caller_loop
+
+
+def test_call_sync_runs_from_sync_code() -> None:
+    runner = ZoneRunner("zone-a")
+
+    async def work() -> str:
+        return "ok"
+
+    try:
+        assert runner.call_sync(work) == "ok"
+    finally:
+        runner.stop()
+
+
+@pytest.mark.asyncio
+async def test_call_propagates_exception() -> None:
+    runner = ZoneRunner("zone-a")
+
+    async def work() -> str:
+        raise ValueError("boom")
+
+    try:
+        with pytest.raises(ValueError, match="boom"):
+            await runner.call(work)
+    finally:
+        runner.stop()
+
+
+@pytest.mark.asyncio
+async def test_same_runner_reentry_does_not_deadlock() -> None:
+    runner = ZoneRunner("zone-a")
+
+    async def nested() -> str:
+        return await runner.call(lambda: _return_value("nested-ok"))
+
+    try:
+        assert await runner.call(nested) == "nested-ok"
+    finally:
+        runner.stop()
+
+
+def test_call_sync_from_owner_thread_raises() -> None:
+    runner = ZoneRunner("zone-a")
+
+    async def work() -> str:
+        with pytest.raises(RuntimeError, match="call_sync cannot run on owning runner thread"):
+            runner.call_sync(lambda: _return_value("bad"))
+        return "ok"
+
+    try:
+        assert runner.call_sync(work) == "ok"
+    finally:
+        runner.stop()
+
+
+def test_stop_is_idempotent() -> None:
+    runner = ZoneRunner("zone-a")
+    runner.start()
+
+    runner.stop()
+    runner.stop()
+
+    assert not runner.is_alive
+
+
+async def _return_value(value: str) -> str:
+    return value

--- a/tests/unit/runtime/test_zone_runner.py
+++ b/tests/unit/runtime/test_zone_runner.py
@@ -176,6 +176,40 @@ async def test_call_cancellation_during_startup_returns_promptly() -> None:
 
 
 @pytest.mark.asyncio
+async def test_call_rejects_submission_after_stop_begins(monkeypatch) -> None:
+    runner = ZoneRunner("zone-a")
+    pre_submit = threading.Event()
+    release_submit = threading.Event()
+    work_ran = threading.Event()
+
+    def pause_before_submit() -> None:
+        pre_submit.set()
+        release_submit.wait(2.0)
+
+    async def work() -> str:
+        work_ran.set()
+        return "bad"
+
+    def stop_while_call_is_paused() -> None:
+        pre_submit.wait(2.0)
+        runner.stop()
+        release_submit.set()
+
+    monkeypatch.setattr(runner, "_before_submit", pause_before_submit)
+    stopper = threading.Thread(target=stop_while_call_is_paused)
+    stopper.start()
+    task = asyncio.create_task(runner.call(work))
+    try:
+        with pytest.raises(RuntimeError, match="stopped|shutdown"):
+            await asyncio.wait_for(task, timeout=3.0)
+        assert not work_ran.is_set()
+    finally:
+        release_submit.set()
+        stopper.join(2.0)
+        runner.stop()
+
+
+@pytest.mark.asyncio
 async def test_same_runner_reentry_does_not_deadlock() -> None:
     runner = ZoneRunner("zone-a")
 

--- a/tests/unit/runtime/test_zone_runner.py
+++ b/tests/unit/runtime/test_zone_runner.py
@@ -1,5 +1,6 @@
 import asyncio
 import threading
+import time
 
 import pytest
 
@@ -218,6 +219,42 @@ def test_stop_cancels_pending_tasks() -> None:
         assert cancelled.wait(2.0)
         assert not runner.is_alive
     finally:
+        runner.stop()
+
+
+def test_stop_terminates_when_pending_task_suppresses_cancellation() -> None:
+    runner = ZoneRunner("zone-a", join_timeout=0.1)
+    started = threading.Event()
+    cancelled = threading.Event()
+    release = threading.Event()
+
+    async def stubborn_work() -> None:
+        started.set()
+        while not release.is_set():
+            try:
+                await asyncio.sleep(0.01)
+            except asyncio.CancelledError:
+                cancelled.set()
+
+    async def schedule_stubborn_work() -> None:
+        asyncio.create_task(stubborn_work())
+
+    try:
+        runner.call_sync(schedule_stubborn_work)
+        assert started.wait(2.0)
+
+        before_stop = time.monotonic()
+        runner.stop()
+        stop_duration = time.monotonic() - before_stop
+
+        assert cancelled.wait(2.0)
+        assert stop_duration < 1.0
+        assert not runner.is_alive
+    finally:
+        release.set()
+        thread = runner._thread
+        if thread is not None:
+            thread.join(2.0)
         runner.stop()
 
 

--- a/tests/unit/server/api/v2/test_remaining_zone_runner_surfaces.py
+++ b/tests/unit/server/api/v2/test_remaining_zone_runner_surfaces.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
+import asyncio
 from collections.abc import Awaitable, Callable
 from typing import Any, TypeVar
 
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
+import nexus.server.api.v2.routers.events_replay as events_replay_module
 from nexus.server.api.v2.routers.credentials import router as credentials_router
 from nexus.server.api.v2.routers.events_replay import router as events_router
 from nexus.server.api.v2.routers.events_replay import watch_router
@@ -52,6 +54,13 @@ class _Event:
         return {"event_id": "evt-1", "zone_id": "eng"}
 
 
+class _StreamEvent:
+    sequence_number = 7
+
+    def to_dict(self) -> dict[str, Any]:
+        return {"event_id": "stream-1", "zone_id": "eng", "sequence_number": 7}
+
+
 class _ReplayResult:
     events = [_Event()]
     next_cursor = None
@@ -62,6 +71,12 @@ class FakeReplayService:
     def replay(self, **kwargs: Any) -> _ReplayResult:
         assert kwargs["zone_id"] == "eng"
         return _ReplayResult()
+
+
+class FakeStreamReplayService:
+    async def stream(self, **kwargs: Any):
+        assert kwargs["zone_id"] == "eng"
+        yield _StreamEvent()
 
 
 class FakeWatchFs:
@@ -139,6 +154,45 @@ def test_replay_events_runs_in_requested_zone_runner() -> None:
     assert response.status_code == 200
     assert response.json()["events"] == [{"event_id": "evt-1", "zone_id": "eng"}]
     assert registry.zones == ["eng"]
+
+
+def test_stream_events_delivers_event_from_auth_zone_runner() -> None:
+    registry = RecordingRegistry()
+    app = FastAPI()
+    app.state.replay_service = FakeStreamReplayService()
+    app.state.zone_registry = registry
+    app.dependency_overrides[require_auth] = _auth
+    app.include_router(events_router)
+
+    with TestClient(app) as client, client.stream("GET", "/api/v2/events/stream") as response:
+        lines = list(response.iter_lines())
+
+    assert response.status_code == 200
+    assert "event: event" in lines
+    assert any('"event_id": "stream-1"' in line for line in lines)
+    assert registry.zones == ["eng"]
+
+
+def test_stream_queue_handoff_uses_request_loop_threadsafe_callback() -> None:
+    class RecordingLoop:
+        def __init__(self) -> None:
+            self.callbacks: list[tuple[Callable[..., Any], tuple[Any, ...]]] = []
+
+        def is_closed(self) -> bool:
+            return False
+
+        def call_soon_threadsafe(self, callback: Callable[..., Any], *args: Any) -> None:
+            self.callbacks.append((callback, args))
+
+    loop = RecordingLoop()
+    queue: Any = asyncio.Queue()
+
+    events_replay_module._schedule_queue_put(loop, queue, "event")
+
+    assert len(loop.callbacks) == 1
+    callback, args = loop.callbacks[0]
+    callback(*args)
+    assert queue.get_nowait() == "event"
 
 
 def test_watch_for_changes_runs_in_auth_zone_runner() -> None:

--- a/tests/unit/server/api/v2/test_remaining_zone_runner_surfaces.py
+++ b/tests/unit/server/api/v2/test_remaining_zone_runner_surfaces.py
@@ -1,0 +1,145 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeVar
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nexus.server.api.v2.routers.credentials import router as credentials_router
+from nexus.server.api.v2.routers.events_replay import router as events_router
+from nexus.server.api.v2.routers.subscriptions import router as subscriptions_router
+from nexus.server.dependencies import require_auth
+
+T = TypeVar("T")
+
+
+class RecordingRunner:
+    async def call(self, work: Callable[[], Awaitable[T]]) -> T:
+        return await work()
+
+
+class RecordingRegistry:
+    def __init__(self) -> None:
+        self.zones: list[str] = []
+
+    def runner_for(self, zone_id: str) -> RecordingRunner:
+        self.zones.append(zone_id)
+        return RecordingRunner()
+
+
+class _Dumpable:
+    def __init__(self, **values: Any) -> None:
+        self._values = values
+
+    def model_dump(self, *, mode: str = "python") -> dict[str, Any]:  # noqa: ARG002
+        return dict(self._values)
+
+
+class FakeSubscriptionManager:
+    def create(self, *, zone_id: str, data: Any, created_by: str | None) -> _Dumpable:  # noqa: ARG002
+        return _Dumpable(
+            subscription_id="sub-1",
+            zone_id=zone_id,
+            created_by=created_by,
+            enabled=True,
+        )
+
+
+class _Event:
+    def to_dict(self) -> dict[str, Any]:
+        return {"event_id": "evt-1", "zone_id": "eng"}
+
+
+class _ReplayResult:
+    events = [_Event()]
+    next_cursor = None
+    has_more = False
+
+
+class FakeReplayService:
+    def replay(self, **kwargs: Any) -> _ReplayResult:
+        assert kwargs["zone_id"] == "eng"
+        return _ReplayResult()
+
+
+class _CredentialStatus:
+    credential_id = "cred-1"
+    issuer_did = "did:nexus:issuer"
+    subject_did = "did:nexus:alice"
+    is_active = True
+    created_at = None
+    expires_at = None
+    revoked_at = None
+    delegation_depth = 0
+
+
+class FakeCredentialService:
+    def list_agent_credentials(
+        self, agent_id: str, *, active_only: bool
+    ) -> list[_CredentialStatus]:
+        assert agent_id == "alice"
+        assert active_only is True
+        return [_CredentialStatus()]
+
+
+def _auth() -> dict[str, Any]:
+    return {
+        "authenticated": True,
+        "subject_type": "user",
+        "subject_id": "alice",
+        "zone_id": "eng",
+        "zone_perms": [["eng", "rw"]],
+        "is_admin": False,
+    }
+
+
+def test_create_subscription_runs_in_auth_zone_runner() -> None:
+    registry = RecordingRegistry()
+    app = FastAPI()
+    app.state.subscription_manager = FakeSubscriptionManager()
+    app.state.zone_registry = registry
+    app.dependency_overrides[require_auth] = _auth
+    app.include_router(subscriptions_router)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v2/subscriptions",
+            json={"event_types": ["file_write"], "url": "https://example.com/hook"},
+        )
+
+    assert response.status_code == 201
+    assert response.json()["zone_id"] == "eng"
+    assert registry.zones == ["eng"]
+
+
+def test_replay_events_runs_in_requested_zone_runner() -> None:
+    registry = RecordingRegistry()
+    app = FastAPI()
+    app.state.replay_service = FakeReplayService()
+    app.state.zone_registry = registry
+    app.dependency_overrides[require_auth] = _auth
+    app.include_router(events_router)
+
+    with TestClient(app) as client:
+        response = client.get("/api/v2/events/replay", params={"zone_id": "eng"})
+
+    assert response.status_code == 200
+    assert response.json()["events"] == [{"event_id": "evt-1", "zone_id": "eng"}]
+    assert registry.zones == ["eng"]
+
+
+def test_list_agent_credentials_runs_in_auth_zone_runner() -> None:
+    registry = RecordingRegistry()
+    app = FastAPI()
+    app.state.credential_service = FakeCredentialService()
+    app.state.zone_registry = registry
+    app.dependency_overrides[require_auth] = _auth
+    app.include_router(credentials_router)
+
+    with TestClient(app) as client:
+        response = client.get("/api/v2/agents/alice/credentials")
+
+    assert response.status_code == 200
+    assert response.json()["count"] == 1
+    assert registry.zones == ["eng"]

--- a/tests/unit/server/api/v2/test_remaining_zone_runner_surfaces.py
+++ b/tests/unit/server/api/v2/test_remaining_zone_runner_surfaces.py
@@ -8,6 +8,7 @@ from fastapi.testclient import TestClient
 
 from nexus.server.api.v2.routers.credentials import router as credentials_router
 from nexus.server.api.v2.routers.events_replay import router as events_router
+from nexus.server.api.v2.routers.events_replay import watch_router
 from nexus.server.api.v2.routers.subscriptions import router as subscriptions_router
 from nexus.server.dependencies import require_auth
 
@@ -61,6 +62,17 @@ class FakeReplayService:
     def replay(self, **kwargs: Any) -> _ReplayResult:
         assert kwargs["zone_id"] == "eng"
         return _ReplayResult()
+
+
+class FakeWatchFs:
+    def sys_watch(
+        self, path: str, timeout: float, *, recursive: bool, context: Any
+    ) -> dict[str, Any]:
+        assert path == "/workspace"
+        assert timeout == 0.1
+        assert recursive is False
+        assert context.zone_id == "eng"
+        return {"path": path, "type": "write"}
 
 
 class _CredentialStatus:
@@ -126,6 +138,25 @@ def test_replay_events_runs_in_requested_zone_runner() -> None:
 
     assert response.status_code == 200
     assert response.json()["events"] == [{"event_id": "evt-1", "zone_id": "eng"}]
+    assert registry.zones == ["eng"]
+
+
+def test_watch_for_changes_runs_in_auth_zone_runner() -> None:
+    registry = RecordingRegistry()
+    app = FastAPI()
+    app.state.nexus_fs = FakeWatchFs()
+    app.state.zone_registry = registry
+    app.dependency_overrides[require_auth] = _auth
+    app.include_router(watch_router)
+
+    with TestClient(app) as client:
+        response = client.get("/api/v2/watch", params={"path": "/workspace", "timeout": 0.1})
+
+    assert response.status_code == 200
+    assert response.json() == {
+        "changes": [{"path": "/workspace", "type": "write"}],
+        "timeout": False,
+    }
     assert registry.zones == ["eng"]
 
 

--- a/tests/unit/server/api/v2/test_search_zone_runner.py
+++ b/tests/unit/server/api/v2/test_search_zone_runner.py
@@ -1,0 +1,62 @@
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeVar
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nexus.server.api.v2.routers.search import router
+from nexus.server.dependencies import require_auth
+
+T = TypeVar("T")
+
+
+class RecordingRunner:
+    async def call(self, work: Callable[[], Awaitable[T]]) -> T:
+        return await work()
+
+
+class RecordingRegistry:
+    def __init__(self) -> None:
+        self.zones: list[str] = []
+
+    def runner_for(self, zone_id: str) -> RecordingRunner:
+        self.zones.append(zone_id)
+        return RecordingRunner()
+
+
+class FakeSearchDaemon:
+    is_initialized = True
+
+    async def search(self, **kwargs: Any) -> list[Any]:
+        return []
+
+    def get_health(self) -> dict[str, Any]:
+        return {"status": "healthy"}
+
+    def get_stats(self) -> dict[str, Any]:
+        return {}
+
+
+def test_search_query_runs_in_auth_zone_runner() -> None:
+    registry = RecordingRegistry()
+    app = FastAPI()
+    app.state.search_daemon = FakeSearchDaemon()
+    app.state.record_store = object()
+    app.state.async_read_session_factory = object()
+    app.state.permission_enforcer = None
+    app.state.zone_registry = registry
+    app.dependency_overrides[require_auth] = lambda: {
+        "authenticated": True,
+        "subject_type": "user",
+        "subject_id": "alice",
+        "zone_id": "eng",
+        "zone_perms": [["eng", "r"]],
+        "is_admin": False,
+    }
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        response = client.get("/api/v2/search/query", params={"q": "hello"})
+
+    assert response.status_code in (200, 503)
+    assert registry.zones == ["eng"]

--- a/tests/unit/server/api/v2/test_zone_registry_router_wiring.py
+++ b/tests/unit/server/api/v2/test_zone_registry_router_wiring.py
@@ -1,0 +1,72 @@
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nexus.server.api.v2.routers.async_files import create_async_files_router
+from nexus.server.api.v2.routers.batch import create_batch_router
+from nexus.server.dependencies import get_auth_result
+
+
+class RecordingRegistry:
+    def __init__(self) -> None:
+        self.requested: list[str] = []
+
+    def runner_for(self, zone_id: str) -> object:
+        self.requested.append(zone_id)
+        return InlineRunner()
+
+
+class InlineRunner:
+    async def call(self, work):
+        return await work()
+
+
+def _auth() -> dict[str, object]:
+    return {
+        "authenticated": True,
+        "subject_id": "alice",
+        "subject_type": "user",
+        "zone_id": "eng",
+        "zone_perms": [["eng", "rw"]],
+        "is_admin": False,
+    }
+
+
+def test_async_files_router_uses_zone_registry_getter_for_list() -> None:
+    registry = RecordingRegistry()
+    fs = MagicMock()
+    fs.sys_readdir.return_value = []
+    app = FastAPI()
+    app.include_router(create_async_files_router(nexus_fs=fs, get_zone_registry=lambda: registry))
+    app.dependency_overrides[get_auth_result] = _auth
+
+    with TestClient(app) as client:
+        response = client.get("/list", params={"path": "/docs"})
+
+    assert response.status_code == 200
+    assert registry.requested == ["eng"]
+
+
+def test_batch_router_uses_zone_registry_getter_for_path_operation() -> None:
+    registry = RecordingRegistry()
+    fs = MagicMock()
+    fs.read.return_value = b"hello"
+    app = FastAPI()
+    app.include_router(
+        create_batch_router(
+            nexus_fs=fs,
+            get_zone_registry=lambda: registry,
+            get_context_override=lambda: MagicMock(zone_id="eng", groups=[], is_admin=False),
+        ),
+        prefix="/api/v2",
+    )
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/v2/batch",
+            json={"operations": [{"op": "read", "path": "/docs/a.txt"}]},
+        )
+
+    assert response.status_code == 200
+    assert registry.requested == ["eng"]

--- a/tests/unit/server/api/v2/test_zone_registry_router_wiring.py
+++ b/tests/unit/server/api/v2/test_zone_registry_router_wiring.py
@@ -22,6 +22,52 @@ class InlineRunner:
         return await work()
 
 
+class AssertingRunner:
+    def __init__(self, fs: "StreamFs") -> None:
+        self._fs = fs
+
+    async def call(self, work):
+        self._fs.in_runner = True
+        try:
+            return await work()
+        finally:
+            self._fs.in_runner = False
+
+
+class StreamRegistry(RecordingRegistry):
+    def __init__(self, fs: "StreamFs") -> None:
+        super().__init__()
+        self._fs = fs
+
+    def runner_for(self, zone_id: str) -> object:
+        self.requested.append(zone_id)
+        return AssertingRunner(self._fs)
+
+
+class StreamMeta:
+    size = 5
+    content_id = "etag"
+    mime_type = "text/plain"
+
+
+class StreamFs:
+    def __init__(self) -> None:
+        self.in_runner = False
+        self.sys_read_inside_runner = False
+        self.read_range_inside_runner = False
+
+    def sys_stat(self, path: str, *, context: object) -> StreamMeta:
+        return StreamMeta()
+
+    def sys_read(self, path: str, *, context: object) -> bytes:
+        self.sys_read_inside_runner = self.in_runner
+        return b"hello"
+
+    def read_range(self, path: str, start: int, end: int, *, context: object) -> bytes:
+        self.read_range_inside_runner = self.in_runner
+        return b"hello"[start : end + 1]
+
+
 def _auth() -> dict[str, object]:
     return {
         "authenticated": True,
@@ -70,3 +116,57 @@ def test_batch_router_uses_zone_registry_getter_for_path_operation() -> None:
 
     assert response.status_code == 200
     assert registry.requested == ["eng"]
+
+
+def test_async_files_batch_read_rejects_mixed_zone_request_before_runner() -> None:
+    registry = RecordingRegistry()
+    fs = MagicMock()
+    app = FastAPI()
+    app.include_router(create_async_files_router(nexus_fs=fs, get_zone_registry=lambda: registry))
+    app.dependency_overrides[get_auth_result] = _auth
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/batch/read",
+            json={"paths": ["/zone/eng/a.txt", "/zone/legal/b.txt"]},
+        )
+
+    assert response.status_code == 400
+    assert response.json()["detail"] == "Mixed-zone operations must be submitted per zone"
+    assert registry.requested == []
+
+
+def test_async_files_stream_reads_full_content_inside_zone_runner() -> None:
+    fs = StreamFs()
+    registry = StreamRegistry(fs)
+    app = FastAPI()
+    app.include_router(create_async_files_router(nexus_fs=fs, get_zone_registry=lambda: registry))
+    app.dependency_overrides[get_auth_result] = _auth
+
+    with TestClient(app) as client:
+        response = client.get("/stream", params={"path": "/docs/a.txt"})
+
+    assert response.status_code == 200
+    assert response.content == b"hello"
+    assert registry.requested == ["eng"]
+    assert fs.sys_read_inside_runner is True
+
+
+def test_async_files_stream_reads_range_inside_zone_runner() -> None:
+    fs = StreamFs()
+    registry = StreamRegistry(fs)
+    app = FastAPI()
+    app.include_router(create_async_files_router(nexus_fs=fs, get_zone_registry=lambda: registry))
+    app.dependency_overrides[get_auth_result] = _auth
+
+    with TestClient(app) as client:
+        response = client.get(
+            "/stream",
+            params={"path": "/docs/a.txt"},
+            headers={"Range": "bytes=1-3"},
+        )
+
+    assert response.status_code == 206
+    assert response.content == b"ell"
+    assert registry.requested == ["eng"]
+    assert fs.read_range_inside_runner is True

--- a/tests/unit/server/lifespan/test_zone_runner_shutdown_integration.py
+++ b/tests/unit/server/lifespan/test_zone_runner_shutdown_integration.py
@@ -1,0 +1,23 @@
+from types import SimpleNamespace
+
+import pytest
+
+from nexus.runtime.zone_runner import ZoneRegistry
+from nexus.server.lifespan.services_container import LifespanServices
+from nexus.server.lifespan.zone_runners import shutdown_zone_runners
+
+
+@pytest.mark.asyncio
+async def test_lifespan_shutdown_stops_started_zone_threads() -> None:
+    registry = ZoneRegistry()
+    runner_a = registry.runner_for("zone-a")
+    runner_b = registry.runner_for("zone-b")
+    runner_a.start()
+    runner_b.start()
+    app = SimpleNamespace(state=SimpleNamespace(zone_registry=registry))
+    svc = LifespanServices(zone_registry=registry)
+
+    await shutdown_zone_runners(app, svc)
+
+    assert not runner_a.is_alive
+    assert not runner_b.is_alive

--- a/tests/unit/server/lifespan/test_zone_runner_shutdown_integration.py
+++ b/tests/unit/server/lifespan/test_zone_runner_shutdown_integration.py
@@ -17,7 +17,10 @@ async def test_lifespan_shutdown_stops_started_zone_threads() -> None:
     app = SimpleNamespace(state=SimpleNamespace(zone_registry=registry))
     svc = LifespanServices(zone_registry=registry)
 
-    await shutdown_zone_runners(app, svc)
+    try:
+        await shutdown_zone_runners(app, svc)
 
-    assert not runner_a.is_alive
-    assert not runner_b.is_alive
+        assert not runner_a.is_alive
+        assert not runner_b.is_alive
+    finally:
+        registry.stop_all()

--- a/tests/unit/server/lifespan/test_zone_runners_lifespan.py
+++ b/tests/unit/server/lifespan/test_zone_runners_lifespan.py
@@ -1,3 +1,4 @@
+import threading
 from types import SimpleNamespace
 
 import pytest
@@ -32,3 +33,34 @@ def test_lifespan_services_extracts_zone_registry() -> None:
     svc = LifespanServices.from_app(app)
 
     assert svc.zone_registry is registry
+
+
+@pytest.mark.asyncio
+async def test_shutdown_zone_runners_offloads_stop_all_from_event_loop_thread() -> None:
+    event_loop_thread_id = threading.get_ident()
+    stop_all_thread_id: int | None = None
+
+    class ThreadRecordingRegistry:
+        def stop_all(self) -> None:
+            nonlocal stop_all_thread_id
+            stop_all_thread_id = threading.get_ident()
+
+    registry = ThreadRecordingRegistry()
+    app = SimpleNamespace(state=SimpleNamespace(zone_registry=registry))
+    svc = LifespanServices(zone_registry=registry)
+
+    await shutdown_zone_runners(app, svc)
+
+    assert stop_all_thread_id is not None
+    assert stop_all_thread_id != event_loop_thread_id
+
+
+@pytest.mark.asyncio
+async def test_shutdown_zone_runners_uses_service_registry_fallback() -> None:
+    registry = RecordingRegistry()
+    app = SimpleNamespace(state=SimpleNamespace(zone_registry=None))
+    svc = LifespanServices(zone_registry=registry)
+
+    await shutdown_zone_runners(app, svc)
+
+    assert registry.stopped is True

--- a/tests/unit/server/lifespan/test_zone_runners_lifespan.py
+++ b/tests/unit/server/lifespan/test_zone_runners_lifespan.py
@@ -1,0 +1,34 @@
+from types import SimpleNamespace
+
+import pytest
+
+from nexus.server.lifespan.services_container import LifespanServices
+from nexus.server.lifespan.zone_runners import shutdown_zone_runners
+
+
+class RecordingRegistry:
+    def __init__(self) -> None:
+        self.stopped = False
+
+    def stop_all(self) -> None:
+        self.stopped = True
+
+
+@pytest.mark.asyncio
+async def test_shutdown_zone_runners_stops_registry_from_app_state() -> None:
+    registry = RecordingRegistry()
+    app = SimpleNamespace(state=SimpleNamespace(zone_registry=registry))
+    svc = LifespanServices(zone_registry=registry)
+
+    await shutdown_zone_runners(app, svc)
+
+    assert registry.stopped is True
+
+
+def test_lifespan_services_extracts_zone_registry() -> None:
+    registry = RecordingRegistry()
+    app = SimpleNamespace(state=SimpleNamespace(nexus_fs=None, zone_registry=registry))
+
+    svc = LifespanServices.from_app(app)
+
+    assert svc.zone_registry is registry

--- a/tests/unit/server/lifespan/test_zone_runners_lifespan.py
+++ b/tests/unit/server/lifespan/test_zone_runners_lifespan.py
@@ -3,6 +3,7 @@ from types import SimpleNamespace
 
 import pytest
 
+from nexus.runtime.zone_runner import ZoneRegistry
 from nexus.server.lifespan.services_container import LifespanServices
 from nexus.server.lifespan.zone_runners import shutdown_zone_runners
 
@@ -13,6 +14,10 @@ class RecordingRegistry:
 
     def stop_all(self) -> None:
         self.stopped = True
+
+
+async def _zone_work() -> str:
+    return "ok"
 
 
 @pytest.mark.asyncio
@@ -64,3 +69,20 @@ async def test_shutdown_zone_runners_uses_service_registry_fallback() -> None:
     await shutdown_zone_runners(app, svc)
 
     assert registry.stopped is True
+
+
+@pytest.mark.asyncio
+async def test_shutdown_zone_runners_leaves_registry_reusable() -> None:
+    registry = ZoneRegistry()
+    old_runner = registry.runner_for("eng")
+    old_runner.start()
+    app = SimpleNamespace(state=SimpleNamespace(zone_registry=registry))
+    svc = LifespanServices(zone_registry=registry)
+
+    await shutdown_zone_runners(app, svc)
+    new_runner = registry.runner_for("eng")
+    try:
+        assert new_runner is not old_runner
+        assert await new_runner.call(_zone_work) == "ok"
+    finally:
+        registry.stop_all()

--- a/tests/unit/server/lifespan/test_zone_runners_lifespan.py
+++ b/tests/unit/server/lifespan/test_zone_runners_lifespan.py
@@ -1,3 +1,4 @@
+import logging
 import threading
 from types import SimpleNamespace
 
@@ -14,6 +15,11 @@ class RecordingRegistry:
 
     def stop_all(self) -> None:
         self.stopped = True
+
+
+class RaisingRegistry:
+    def stop_all(self) -> None:
+        raise RuntimeError("stop failed")
 
 
 async def _zone_work() -> str:
@@ -86,3 +92,17 @@ async def test_shutdown_zone_runners_leaves_registry_reusable() -> None:
         assert await new_runner.call(_zone_work) == "ok"
     finally:
         registry.stop_all()
+
+
+@pytest.mark.asyncio
+async def test_shutdown_zone_runners_logs_and_continues_when_stop_fails(
+    caplog: pytest.LogCaptureFixture,
+) -> None:
+    app = SimpleNamespace(state=SimpleNamespace(zone_registry=RaisingRegistry()))
+    svc = LifespanServices()
+
+    with caplog.at_level(logging.ERROR):
+        await shutdown_zone_runners(app, svc)
+
+    assert "Failed to stop zone runners" in caplog.text
+    assert "stop failed" in caplog.text

--- a/tests/unit/server/test_rpc_zone_runner.py
+++ b/tests/unit/server/test_rpc_zone_runner.py
@@ -70,6 +70,7 @@ def test_http_rpc_auto_dispatch_runs_in_target_zone_runner() -> None:
         )
 
     assert response.status_code == 200
+    assert response.json()["result"]["zone"] == "eng"
     assert registry.zones == ["eng"]
     assert registry.runner.calls == 1
 
@@ -130,5 +131,6 @@ def test_http_rpc_kernel_copy_runs_in_target_zone_runner(monkeypatch: pytest.Mon
         )
 
     assert response.status_code == 200
+    assert response.json()["result"]["zone"] == "eng"
     assert registry.zones == ["eng"]
     assert registry.runner.calls == 1

--- a/tests/unit/server/test_rpc_zone_runner.py
+++ b/tests/unit/server/test_rpc_zone_runner.py
@@ -1,0 +1,73 @@
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import Any, TypeVar
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nexus.lib.rpc_codec import encode_rpc_message
+from nexus.server.api.core.rpc import router
+from nexus.server.dependencies import require_auth
+
+T = TypeVar("T")
+
+
+class RecordingRunner:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def call(self, work: Callable[[], Awaitable[T]]) -> T:
+        self.calls += 1
+        return await work()
+
+
+class RecordingRegistry:
+    def __init__(self) -> None:
+        self.zones: list[str] = []
+        self.runner = RecordingRunner()
+
+    def runner_for(self, zone_id: str) -> RecordingRunner:
+        self.zones.append(zone_id)
+        return self.runner
+
+
+def test_http_rpc_auto_dispatch_runs_in_target_zone_runner() -> None:
+    registry = RecordingRegistry()
+    app = FastAPI()
+    app.state.nexus_fs = MagicMock()
+    app.state.auth_provider = None
+    app.state.subscription_manager = None
+    app.state.zone_registry = registry
+
+    async def echo(path: str, context: Any) -> dict[str, str]:
+        return {"path": path, "zone": context.zone_id or "root"}
+
+    app.state.exposed_methods = {"echo": echo}
+    app.dependency_overrides[require_auth] = lambda: {
+        "authenticated": True,
+        "subject_type": "user",
+        "subject_id": "alice",
+        "zone_id": "root",
+        "zone_perms": [["eng", "rw"]],
+        "is_admin": False,
+    }
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/nfs/echo",
+            content=encode_rpc_message(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "echo",
+                    "params": {"path": "/zone/eng/docs/a.txt"},
+                }
+            ),
+        )
+
+    assert response.status_code == 200
+    assert registry.zones == ["eng"]
+    assert registry.runner.calls == 1

--- a/tests/unit/server/test_rpc_zone_runner.py
+++ b/tests/unit/server/test_rpc_zone_runner.py
@@ -4,6 +4,7 @@ from collections.abc import Awaitable, Callable
 from typing import Any, TypeVar
 from unittest.mock import MagicMock
 
+import pytest
 from fastapi import FastAPI
 from fastapi.testclient import TestClient
 
@@ -64,6 +65,66 @@ def test_http_rpc_auto_dispatch_runs_in_target_zone_runner() -> None:
                     "id": 1,
                     "method": "echo",
                     "params": {"path": "/zone/eng/docs/a.txt"},
+                }
+            ),
+        )
+
+    assert response.status_code == 200
+    assert registry.zones == ["eng"]
+    assert registry.runner.calls == 1
+
+
+def test_http_rpc_kernel_copy_runs_in_target_zone_runner(monkeypatch: pytest.MonkeyPatch) -> None:
+    registry = RecordingRegistry()
+    app = FastAPI()
+    app.state.nexus_fs = MagicMock()
+    app.state.auth_provider = None
+    app.state.subscription_manager = None
+    app.state.zone_registry = registry
+    app.state.operation_timeout = 30.0
+    app.state.exposed_methods = {}
+
+    async def fake_dispatch_kernel_syscall(
+        nexus_fs: Any,
+        method: str,
+        raw_params: dict[str, Any],
+        context: Any,
+        *,
+        subscription_manager: Any = None,
+    ) -> dict[str, Any]:
+        return {
+            "method": method,
+            "src_path": raw_params["src_path"],
+            "dst_path": raw_params["dst_path"],
+            "zone": context.zone_id or "root",
+        }
+
+    monkeypatch.setattr(
+        "nexus.server._kernel_syscall_dispatch.dispatch_kernel_syscall",
+        fake_dispatch_kernel_syscall,
+    )
+    app.dependency_overrides[require_auth] = lambda: {
+        "authenticated": True,
+        "subject_type": "user",
+        "subject_id": "alice",
+        "zone_id": "root",
+        "zone_perms": [["eng", "rw"], ["legal", "rw"]],
+        "is_admin": False,
+    }
+    app.include_router(router)
+
+    with TestClient(app) as client:
+        response = client.post(
+            "/api/nfs/sys_copy",
+            content=encode_rpc_message(
+                {
+                    "jsonrpc": "2.0",
+                    "id": 1,
+                    "method": "sys_copy",
+                    "params": {
+                        "src_path": "/zone/eng/a.txt",
+                        "dst_path": "/zone/eng/b.txt",
+                    },
                 }
             ),
         )

--- a/tests/unit/server/test_zone_execution.py
+++ b/tests/unit/server/test_zone_execution.py
@@ -1,0 +1,60 @@
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+import pytest
+
+from nexus.server.zone_execution import run_zone_scoped
+
+T = TypeVar("T")
+
+
+class RecordingRunner:
+    def __init__(self) -> None:
+        self.calls = 0
+
+    async def call(self, work: Callable[[], Awaitable[T]]) -> T:
+        self.calls += 1
+        return await work()
+
+
+class RecordingRegistry:
+    def __init__(self) -> None:
+        self.requested: list[str] = []
+        self.runner = RecordingRunner()
+
+    def runner_for(self, zone_id: str) -> RecordingRunner:
+        self.requested.append(zone_id)
+        return self.runner
+
+
+@pytest.mark.asyncio
+async def test_run_zone_scoped_uses_runner_for_concrete_zone() -> None:
+    registry = RecordingRegistry()
+
+    async def work() -> str:
+        return "ok"
+
+    result = await run_zone_scoped(registry, "eng", work)
+
+    assert result == "ok"
+    assert registry.requested == ["eng"]
+    assert registry.runner.calls == 1
+
+
+@pytest.mark.asyncio
+async def test_run_zone_scoped_runs_inline_without_registry() -> None:
+    async def work() -> str:
+        return "inline"
+
+    assert await run_zone_scoped(None, "eng", work) == "inline"
+
+
+@pytest.mark.asyncio
+async def test_run_zone_scoped_runs_inline_without_target_zone() -> None:
+    registry = RecordingRegistry()
+
+    async def work() -> str:
+        return "global"
+
+    assert await run_zone_scoped(registry, None, work) == "global"
+    assert registry.requested == []


### PR DESCRIPTION
## Summary

Closes #4084.

This PR adds per-zone runner isolation so work for each zone is executed on a dedicated thread with its own asyncio event loop. It wires the runner registry into the server lifecycle and routes the zone-aware surfaces through `run_zone_scoped`, including HTTP RPC, gRPC Call RPC, async file routes, batch operations, search, connectors, credentials, secrets, subscriptions, snapshots, workspace, and remaining v2 zone surfaces.

## Root Cause

Zone-isolated API requests were still sharing process-level async execution paths. A slow or blocked zone operation could therefore affect unrelated zone work. During live stack validation, HTTP RPC also exposed a context mismatch: explicit `/zone/<id>/...` paths routed to the correct runner but kept `OperationContext.zone_id` as `root`, causing cross-zone permission failures. That is fixed by aligning the operation context with the authorized target zone before dispatch.

## Validation

- `/Users/tafeng/.local/bin/uv run --with ruff ruff format src/nexus/server/api/core/rpc.py tests/unit/server/test_rpc_zone_runner.py tests/e2e/self_contained/test_zone_runner_live_e2e.py`
- `/Users/tafeng/.local/bin/uv run --with ruff ruff check src/nexus/server/api/core/rpc.py tests/unit/server/test_rpc_zone_runner.py tests/e2e/self_contained/test_zone_runner_live_e2e.py`
- `/Users/tafeng/.local/bin/uv run mypy src/nexus/server/api/core/rpc.py`
- `/Users/tafeng/.local/bin/uv run pytest -q -n0 tests/unit/server/test_rpc_zone_runner.py`
- `/Users/tafeng/.local/bin/uv run pytest -q -n0 tests/unit/runtime tests/unit/server/test_zone_execution.py tests/unit/server/test_rpc_zone_runner.py tests/unit/grpc/test_vfs_call_zone_runner.py tests/unit/server/lifespan/test_zone_runners_lifespan.py tests/unit/server/lifespan/test_zone_runner_shutdown_integration.py tests/integration/server/test_zone_runner_bulkhead.py tests/unit/core/test_test_hooks.py`
- `PATH="/usr/local/bin:$PATH" NEXUS_TEST_HOOKS=true /Users/tafeng/.local/bin/uv run pytest -q -n0 tests/e2e/self_contained/test_zone_runner_live_e2e.py`

The live self-contained E2E exercises `nexus up --build` against the Docker stack and verifies runner creation, per-zone thread names, HTTP RPC write/read routing, and bulkhead behavior while another zone is held.
