### PR TITLE
[codex] Add remote hub admin CLI

### DIFF
--- a/.github/actions/build-rust-extensions/action.yml
+++ b/.github/actions/build-rust-extensions/action.yml
@@ -71,6 +71,7 @@ runs:
       uses: Swatinem/rust-cache@v2
       with:
         shared-key: "${{ inputs.rust-cache-shared-key }}-${{ runner.os }}"
+        cache-bin: false
         workspaces: |
           rust/nexus-cdylib
           rust/raft

--- a/docs/hub-deploy.md
+++ b/docs/hub-deploy.md
@@ -57,19 +57,38 @@ reverse proxy before exposing it to the internet (see §6).
 
 ## 2. Token lifecycle
 
-- **Create** — `nexus hub token create --name <name> --zone <zone> [--admin] [--expires 90d]`.
-  The raw token (`sk-…`) is printed once.
-- **List** — `nexus hub token list [--show-revoked] [--json]`.
-- **Revoke** — `nexus hub token revoke <name|key_id>` (soft-delete).
+- **Create locally** — `nexus hub token create --name <name> --zone <zone> [--admin] [--expires 90d]`.
+  Use `--zones eng:rw,ops:r` for multi-zone tokens or `--zones-glob 'team-*'`
+  to resolve active zones at mint time. The raw token (`sk-…`) is printed once.
+- **List locally** — `nexus hub token list [--show-revoked] [--json]`.
+- **Revoke locally** — `nexus hub token revoke <name|key_id>` (soft-delete).
+- **Remote admin** — after creating a bootstrap admin token on the hub host,
+  pass `--remote <hub-url>` and `--admin-token <sk-admin>` to `token create`,
+  `token list`, `token revoke`, or `status`. Host URLs are normalized to
+  `/mcp`, so `https://nexus.example.com` and `https://nexus.example.com/mcp`
+  both work. `NEXUS_HUB_ADMIN_TOKEN` may be used instead of repeating
+  `--admin-token`.
 
 The auth identity cache has a 60-second TTL, so a revoked token may remain
 usable for up to 60 seconds. Plan rotations around this window.
 
+Example remote flow:
+
+```bash
+# On the hub host:
+nexus hub token create --name root --admin --zone root
+
+# From an operator workstation:
+export NEXUS_HUB_ADMIN_TOKEN=sk-...
+nexus hub token list --remote https://nexus.example.com --json
+nexus hub status --remote https://nexus.example.com
+```
+
 ## 3. Zone model (MVP)
 
-Each token is scoped to **one** zone (`--zone`). Requests made with the
-token only see files and indexes in that zone. Multi-zone-per-token is
-tracked as a follow-up to #3784.
+Each token is scoped to one or more zones. Requests made with the token
+only see files and indexes in its allowed zones. `--zone` is kept as a
+single-zone alias; prefer `--zones <zone[:perms],...>` for new scripts.
 
 List zones: `nexus hub zone list`.
 
@@ -156,7 +175,6 @@ with any standard volume backup tool.
 
 Tracked as follow-up issues to #3784:
 
-- Multi-zone tokens
-- Remote admin CLI (admin over MCP with a bootstrap token)
+- Prometheus `/metrics` endpoint
 - Richer `hub status` (Zoekt/txtai queue depth, per-zone breakdown)
 - Kubernetes/Helm deploy

--- a/docs/superpowers/plans/2026-05-13-issue-3872-remote-hub-admin.md
+++ b/docs/superpowers/plans/2026-05-13-issue-3872-remote-hub-admin.md
@@ -1,0 +1,1094 @@
+# Issue #3872 Remote Hub Admin Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Implement full remote hub token administration over MCP for `create`, `list`, `revoke`, and `status`.
+
+**Architecture:** Add hub-specific admin RPC handlers on the `nexusd` server so remote behavior can reuse the same multi-zone token semantics as the local hub CLI. Register one MCP tool, `nexus_hub_admin`, that delegates to those RPCs using the request bearer token. Add a synchronous streamable-HTTP MCP client for the `nexus hub` CLI when `--remote` is provided.
+
+**Tech Stack:** Python, Click, FastMCP, SQLAlchemy, pytest, httpx streamable HTTP, existing Nexus gRPC RPC dispatch.
+
+---
+
+## File Structure
+
+- Create `src/nexus/server/rpc/handlers/hub_admin.py`: server-side hub token create/list/revoke/status handlers, protected by `require_admin`.
+- Modify `src/nexus/server/rpc/dispatch.py`: register hub admin RPC handlers.
+- Modify `src/nexus/server/_rpc_param_overrides.py`: add typed param dataclasses for hub admin RPCs.
+- Create `src/nexus/bricks/mcp/hub_admin_tool.py`: register and implement `nexus_hub_admin`.
+- Modify `src/nexus/bricks/mcp/server.py`: register the new MCP tool after `_get_nexus_instance` is defined.
+- Create `src/nexus/cli/commands/_hub_remote.py`: normalize MCP URLs, call `tools/call`, parse MCP results, and raise Click errors.
+- Modify `src/nexus/cli/commands/hub.py`: add `--remote` and `--admin-token` to token create/list/revoke and status, dispatch to remote path, preserve local behavior.
+- Modify `docs/hub-deploy.md`: document remote admin flow and remove the follow-up marker.
+- Add tests:
+  - `tests/unit/server/rpc/handlers/test_hub_admin.py`
+  - `tests/unit/bricks/mcp/test_hub_admin_tool.py`
+  - `tests/unit/cli/test_hub_remote.py`
+  - update existing hub CLI tests only where shared Click signatures require it.
+
+---
+
+### Task 1: Hub Admin RPC Handler
+
+**Files:**
+- Create: `tests/unit/server/rpc/handlers/test_hub_admin.py`
+- Create: `src/nexus/server/rpc/handlers/hub_admin.py`
+- Modify: `src/nexus/server/rpc/dispatch.py`
+- Modify: `src/nexus/server/_rpc_param_overrides.py`
+
+- [ ] **Step 1: Write failing tests for server-side hub token operations**
+
+Create `tests/unit/server/rpc/handlers/test_hub_admin.py` with tests covering:
+
+```python
+from __future__ import annotations
+
+from dataclasses import dataclass
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+from sqlalchemy import create_engine, select
+from sqlalchemy.orm import sessionmaker
+
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.exceptions import NexusPermissionError
+from nexus.server.rpc.handlers import hub_admin
+from nexus.storage.models import APIKeyModel, APIKeyZoneModel, Base, ZoneModel
+
+
+@dataclass
+class Params:
+    def __init__(self, **kwargs: Any) -> None:
+        for key, value in kwargs.items():
+            setattr(self, key, value)
+
+
+def _provider(tmp_path):
+    engine = create_engine(f"sqlite:///{tmp_path / 'hub_admin.db'}")
+    Base.metadata.create_all(engine)
+    Session = sessionmaker(bind=engine, future=True, expire_on_commit=False)
+    with Session() as session, session.begin():
+        for zone_id in ("root", "eng", "ops"):
+            session.add(ZoneModel(zone_id=zone_id, name=zone_id, phase="Active"))
+    return SimpleNamespace(session_factory=Session)
+
+
+def test_create_token_writes_multi_zone_permissions(tmp_path):
+    provider = _provider(tmp_path)
+    result = hub_admin.handle_admin_hub_token_create(
+        provider,
+        Params(
+            name="alice",
+            zones=[
+                {"zone_id": "eng", "permissions": "rw"},
+                {"zone_id": "ops", "permissions": "r"},
+            ],
+            zones_glob=None,
+            is_admin=False,
+            expires=None,
+            user_id=None,
+        ),
+        SimpleNamespace(is_admin=True),
+    )
+    assert result["token"].startswith("sk-")
+    assert result["name"] == "alice"
+    assert result["zones"] == ["eng", "ops"]
+    with provider.session_factory() as session:
+        rows = session.execute(
+            select(APIKeyZoneModel.zone_id, APIKeyZoneModel.permissions)
+        ).all()
+    assert rows == [("eng", "rw"), ("ops", "r")]
+
+
+def test_list_tokens_returns_local_json_shape(tmp_path):
+    provider = _provider(tmp_path)
+    hub_admin.handle_admin_hub_token_create(
+        provider,
+        Params(name="alice", zones=[{"zone_id": "eng", "permissions": "rw"}], zones_glob=None, is_admin=True, expires=None, user_id=None),
+        SimpleNamespace(is_admin=True),
+    )
+    result = hub_admin.handle_admin_hub_token_list(
+        provider,
+        Params(show_revoked=False),
+        SimpleNamespace(is_admin=True),
+    )
+    assert result["tokens"][0]["name"] == "alice"
+    assert result["tokens"][0]["zones"] == ["eng"]
+    assert set(result["tokens"][0]) >= {"key_id", "name", "zone", "zones", "admin", "created", "last_used", "revoked", "revoked_at"}
+
+
+def test_revoke_token_accepts_name_and_sets_revoked_at(tmp_path):
+    provider = _provider(tmp_path)
+    hub_admin.handle_admin_hub_token_create(
+        provider,
+        Params(name="alice", zones=[{"zone_id": "eng", "permissions": "rw"}], zones_glob=None, is_admin=False, expires=None, user_id=None),
+        SimpleNamespace(is_admin=True),
+    )
+    result = hub_admin.handle_admin_hub_token_revoke(
+        provider,
+        Params(identifier="alice"),
+        SimpleNamespace(is_admin=True),
+    )
+    assert result["revoked"] is True
+    with provider.session_factory() as session:
+        row = session.scalar(select(APIKeyModel).where(APIKeyModel.name == "alice"))
+    assert row is not None
+    assert bool(row.revoked) is True
+    assert row.revoked_at is not None
+
+
+def test_non_admin_rejected(tmp_path):
+    provider = _provider(tmp_path)
+    with pytest.raises(NexusPermissionError):
+        hub_admin.handle_admin_hub_token_list(
+            provider,
+            Params(show_revoked=False),
+            SimpleNamespace(is_admin=False),
+        )
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+uv run pytest tests/unit/server/rpc/handlers/test_hub_admin.py -q
+```
+
+Expected: FAIL because `nexus.server.rpc.handlers.hub_admin` does not exist.
+
+- [ ] **Step 3: Implement hub admin handlers**
+
+Create `src/nexus/server/rpc/handlers/hub_admin.py` with:
+
+```python
+"""Hub admin RPC handlers for remote `nexus hub` operations (#3872)."""
+
+from __future__ import annotations
+
+import os
+import re
+import time
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+from sqlalchemy import func, select
+
+from nexus.server.rpc.handlers.admin import require_admin, require_database_auth
+from nexus.storage.api_key_ops import create_api_key, get_primary_zones_for_keys
+from nexus.storage.models import APIKeyModel, APIKeyZoneModel, ZoneModel
+
+_DURATION_RE = re.compile(r"^(\d+)([dhm])$")
+
+
+def _parse_duration(text: str) -> timedelta:
+    match = _DURATION_RE.match(text.strip())
+    if not match:
+        raise ValueError(f"invalid duration {text!r}: expected Nd / Nh / Nm (e.g. 90d)")
+    value, unit = int(match.group(1)), match.group(2)
+    return {"d": timedelta(days=value), "h": timedelta(hours=value), "m": timedelta(minutes=value)}[unit]
+
+
+def _iso(dt: datetime | None) -> str:
+    return dt.isoformat() if dt else "-"
+
+
+def _iso_or_none(dt: datetime | None) -> str | None:
+    return dt.isoformat() if dt else None
+
+
+def _zone_entries(raw: list[dict[str, Any]]) -> list[tuple[str, str]]:
+    entries: list[tuple[str, str]] = []
+    for item in raw:
+        zone_id = str(item.get("zone_id", "")).strip()
+        permissions = str(item.get("permissions") or "rw").strip()
+        if not zone_id:
+            raise ValueError("zone_id must not be empty")
+        entries.append((zone_id, permissions))
+    return entries
+
+
+def _resolve_zones(session: Any, params: Any) -> list[tuple[str, str]]:
+    zones_glob = getattr(params, "zones_glob", None)
+    raw_zones = getattr(params, "zones", None) or []
+    if zones_glob and raw_zones:
+        raise ValueError("zones and zones_glob are mutually exclusive")
+    if zones_glob:
+        active = session.execute(
+            select(ZoneModel)
+            .where(ZoneModel.phase == "Active")
+            .where(ZoneModel.deleted_at.is_(None))
+        ).scalars().all()
+        matched = sorted(z.zone_id for z in active if fnmatch.fnmatch(z.zone_id, zones_glob))
+        if not matched:
+            known = sorted(z.zone_id for z in active)
+            raise ValueError(
+                f"zones_glob {zones_glob!r}: no active zones match. "
+                f"Active zones: {', '.join(known) or '(none)'}."
+            )
+        return [(zone_id, "rw") for zone_id in matched]
+    entries = _zone_entries(raw_zones)
+    if not entries:
+        raise ValueError("zones must contain at least one entry")
+    return entries
+
+
+def _ensure_bootstrap_zones(session: Any, zones: list[tuple[str, str]]) -> None:
+    any_zone = session.execute(select(ZoneModel).limit(1)).scalars().first()
+    if any_zone is not None:
+        return
+    for zone_id, _permissions in zones:
+        if not session.scalar(select(ZoneModel).where(ZoneModel.zone_id == zone_id)):
+            session.add(ZoneModel(zone_id=zone_id, name=zone_id, phase="Active"))
+    session.flush()
+
+
+def _token_zones_by_key(session: Any, key_ids: list[str]) -> dict[str, list[str]]:
+    if not key_ids:
+        return {}
+    rows = session.execute(
+        select(APIKeyZoneModel.key_id, APIKeyZoneModel.zone_id)
+        .where(APIKeyZoneModel.key_id.in_(key_ids))
+        .order_by(APIKeyZoneModel.granted_at.asc(), APIKeyZoneModel.zone_id.asc())
+    ).all()
+    zones_by_key: dict[str, list[str]] = {key_id: [] for key_id in key_ids}
+    for key_id, zone_id in rows:
+        zones_by_key.setdefault(key_id, []).append(zone_id)
+    return zones_by_key
+
+
+def _tokens_payload(session: Any, rows: list[APIKeyModel]) -> list[dict[str, Any]]:
+    key_ids = [row.key_id for row in rows]
+    zones_by_key = _token_zones_by_key(session, key_ids)
+    primary_by_key = get_primary_zones_for_keys(session, key_ids) if key_ids else {}
+    payload = []
+    for row in rows:
+        zones = zones_by_key.get(row.key_id, [])
+        primary = primary_by_key.get(row.key_id)
+        if zones and primary in zones:
+            zones = [primary] + sorted(zone for zone in zones if zone != primary)
+        elif not zones and primary:
+            zones = [primary]
+        payload.append(
+            {
+                "key_id": row.key_id,
+                "name": row.name,
+                "zone": primary,
+                "zones": zones,
+                "admin": bool(row.is_admin),
+                "created": _iso(row.created_at),
+                "last_used": _iso(row.last_used_at),
+                "revoked": bool(row.revoked),
+                "revoked_at": _iso(row.revoked_at),
+            }
+        )
+    return payload
+
+
+def handle_admin_hub_token_create(auth_provider: Any, params: Any, context: Any) -> dict[str, Any]:
+    require_admin(context)
+    require_database_auth(auth_provider)
+    expires_at = None
+    if getattr(params, "expires", None):
+        expires_at = datetime.now(UTC) + _parse_duration(params.expires)
+    with auth_provider.session_factory() as session, session.begin():
+        existing = session.execute(
+            select(APIKeyModel)
+            .where(APIKeyModel.name == params.name)
+            .where(APIKeyModel.revoked == 0)
+        ).scalars().first()
+        if existing is not None:
+            raise ValueError(
+                f"token named {params.name!r} already exists (key_id={existing.key_id})"
+            )
+        zones = _resolve_zones(session, params)
+        _ensure_bootstrap_zones(session, zones)
+        key_id, raw_key = create_api_key(
+            session,
+            user_id=getattr(params, "user_id", None) or params.name,
+            name=params.name,
+            zones=zones,
+            is_admin=bool(getattr(params, "is_admin", False)),
+            expires_at=expires_at,
+        )
+    return {
+        "key_id": key_id,
+        "token": raw_key,
+        "name": params.name,
+        "zones": [zone_id for zone_id, _permissions in zones],
+        "admin": bool(getattr(params, "is_admin", False)),
+        "expires_at": expires_at.isoformat() if expires_at else None,
+    }
+
+
+def handle_admin_hub_token_list(auth_provider: Any, params: Any, context: Any) -> dict[str, Any]:
+    require_admin(context)
+    require_database_auth(auth_provider)
+    with auth_provider.session_factory() as session:
+        stmt = select(APIKeyModel).order_by(APIKeyModel.created_at.desc())
+        if not getattr(params, "show_revoked", False):
+            stmt = stmt.where(APIKeyModel.revoked == 0)
+        rows = list(session.execute(stmt).scalars().all())
+        return {"tokens": _tokens_payload(session, rows)}
+
+
+def handle_admin_hub_token_revoke(auth_provider: Any, params: Any, context: Any) -> dict[str, Any]:
+    require_admin(context)
+    require_database_auth(auth_provider)
+    identifier = params.identifier
+    with auth_provider.session_factory() as session, session.begin():
+        matches = list(
+            session.execute(
+                select(APIKeyModel)
+                .where(APIKeyModel.revoked == 0)
+                .where(
+                    (APIKeyModel.key_id == identifier)
+                    | (APIKeyModel.key_id.startswith(identifier))
+                    | (APIKeyModel.name == identifier)
+                )
+            ).scalars().all()
+        )
+        if not matches:
+            raise FileNotFoundError(f"no active token matches {identifier!r}")
+        if len(matches) > 1:
+            names = ", ".join(f"{match.name} ({match.key_id})" for match in matches)
+            raise ValueError(f"ambiguous: {len(matches)} tokens match {identifier!r} - {names}")
+        row = matches[0]
+        row.revoked = 1
+        row.revoked_at = datetime.now(UTC)
+        return {"key_id": row.key_id, "name": row.name, "revoked": True}
+```
+
+Also add the status helpers in the same file by reusing the local status shapes:
+
+```python
+def _read_redis_stats() -> dict[str, Any]:
+    url = os.environ.get("NEXUS_REDIS_URL") or os.environ.get("DRAGONFLY_URL")
+    if not url:
+        return {"qps_5m": None, "connections": None, "redis": "n/a"}
+    try:
+        import redis
+    except ImportError:
+        return {"qps_5m": None, "connections": None, "redis": "n/a"}
+    try:
+        client = redis.from_url(url, socket_timeout=2)
+        client.ping()
+        now_min = int(time.time()) // 60
+        total = sum(int(v) for v in client.mget([f"nexus:hub:qps:{now_min - i}" for i in range(5)]) if v is not None)
+        active = client.scard(f"nexus:hub:active:{now_min}")
+        return {"qps_5m": round(total / 300.0, 2), "connections": int(active), "redis": "ok"}
+    except Exception:
+        return {"qps_5m": None, "connections": None, "redis": "n/a"}
+
+
+def handle_admin_hub_status(auth_provider: Any, params: Any, context: Any) -> dict[str, Any]:
+    require_admin(context)
+    require_database_auth(auth_provider)
+    endpoint = getattr(params, "endpoint", None) or "remote"
+    profile = os.environ.get("NEXUS_PROFILE", "full")
+    with auth_provider.session_factory() as session:
+        active = session.execute(select(func.count()).select_from(APIKeyModel).where(APIKeyModel.revoked == 0)).scalar() or 0
+        revoked = session.execute(select(func.count()).select_from(APIKeyModel).where(APIKeyModel.revoked == 1)).scalar() or 0
+        payload = {
+            "endpoint": endpoint,
+            "profile": profile,
+            "postgres": "ok",
+            "tokens": {"active": int(active), "revoked": int(revoked)},
+            **_read_redis_stats(),
+        }
+        if getattr(params, "detail", False):
+            zone_ids = [
+                str(zone_id)
+                for zone_id in session.execute(
+                    select(ZoneModel.zone_id)
+                    .where(ZoneModel.phase == "Active")
+                    .where(ZoneModel.deleted_at.is_(None))
+                    .order_by(ZoneModel.zone_id.asc())
+                ).scalars().all()
+            ]
+            rows = list(session.execute(select(APIKeyModel).order_by(APIKeyModel.created_at.desc())).scalars().all())
+            payload.update(
+                {
+                    "detail": True,
+                    "zones": [{"zone_id": zone_id, "clients": None, "qps_5m": None} for zone_id in zone_ids],
+                    "tokens_detail": [
+                        {
+                            "key_id": token["key_id"],
+                            "name": token["name"],
+                            "zones": token["zones"],
+                            "admin": token["admin"],
+                            "created": token["created"] if token["created"] != "-" else None,
+                            "last_seen": token["last_used"] if token["last_used"] != "-" else None,
+                            "revoked": token["revoked"],
+                            "revoked_at": token["revoked_at"] if token["revoked_at"] != "-" else None,
+                        }
+                        for token in _tokens_payload(session, rows)
+                    ],
+                    "rate_limits": {"window_seconds": 300, "hits_by_tier": {"anonymous": None, "authenticated": None, "premium": None}},
+                    "search": {"zones": [{"zone_id": zone_id, "zoekt_index_size_bytes": None, "zoekt_index_size_display": None, "zoekt_last_indexed": None, "txtai_queue_depth": None, "last_indexed": None} for zone_id in zone_ids]},
+                }
+            )
+        return payload
+```
+
+- [ ] **Step 4: Register RPC params and dispatch entries**
+
+In `src/nexus/server/_rpc_param_overrides.py`, add dataclasses:
+
+```python
+@dataclass
+class AdminHubTokenCreateParams:
+    name: str
+    zones: list[dict[str, Any]] = field(default_factory=list)
+    zones_glob: str | None = None
+    is_admin: bool = False
+    expires: str | None = None
+    user_id: str | None = None
+
+
+@dataclass
+class AdminHubTokenListParams:
+    show_revoked: bool = False
+
+
+@dataclass
+class AdminHubTokenRevokeParams:
+    identifier: str
+
+
+@dataclass
+class AdminHubStatusParams:
+    endpoint: str | None = None
+    detail: bool = False
+```
+
+Add to `OVERRIDE_METHOD_PARAMS`:
+
+```python
+"admin_hub_token_create": AdminHubTokenCreateParams,
+"admin_hub_token_list": AdminHubTokenListParams,
+"admin_hub_token_revoke": AdminHubTokenRevokeParams,
+"admin_hub_status": AdminHubStatusParams,
+```
+
+In `src/nexus/server/rpc/dispatch.py`, import the four handlers and add dispatch entries with `pass_auth_provider=True`.
+
+- [ ] **Step 5: Verify GREEN**
+
+Run:
+
+```bash
+uv run pytest tests/unit/server/rpc/handlers/test_hub_admin.py -q
+```
+
+Expected: PASS.
+
+---
+
+### Task 2: MCP Hub Admin Tool
+
+**Files:**
+- Create: `tests/unit/bricks/mcp/test_hub_admin_tool.py`
+- Create: `src/nexus/bricks/mcp/hub_admin_tool.py`
+- Modify: `src/nexus/bricks/mcp/server.py`
+- Modify: `src/nexus/config/tool_profiles.yaml`
+
+- [ ] **Step 1: Write failing MCP tool tests**
+
+Create `tests/unit/bricks/mcp/test_hub_admin_tool.py`:
+
+```python
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+from unittest.mock import Mock
+
+import pytest
+
+from nexus.bricks.mcp.server import create_mcp_server
+from tests.unit.bricks.mcp.test_mcp_server_tools import get_tool, tool_exists
+
+
+@pytest.mark.asyncio
+async def test_nexus_hub_admin_tool_registered():
+    server = await create_mcp_server(nx=Mock())
+    assert tool_exists(server, "nexus_hub_admin")
+
+
+@pytest.mark.asyncio
+async def test_nexus_hub_admin_list_delegates_to_remote_service():
+    service = Mock()
+    service.admin_hub_token_list.return_value = {"tokens": []}
+    nx = Mock()
+    nx.service.return_value = service
+    server = await create_mcp_server(nx=nx)
+    tool = get_tool(server, "nexus_hub_admin")
+    result = await tool.fn(action="list_tokens", arguments={"show_revoked": True})
+    assert json.loads(result) == {"tokens": []}
+    service.admin_hub_token_list.assert_called_once_with(show_revoked=True)
+
+
+@pytest.mark.asyncio
+async def test_nexus_hub_admin_permission_error_has_403_status():
+    from nexus.contracts.exceptions import NexusPermissionError
+
+    service = Mock()
+    service.admin_hub_token_list.side_effect = NexusPermissionError("Admin privileges required")
+    nx = Mock()
+    nx.service.return_value = service
+    server = await create_mcp_server(nx=nx)
+    tool = get_tool(server, "nexus_hub_admin")
+    result = await tool.fn(action="list_tokens", arguments={})
+    payload = json.loads(result)
+    assert payload["error"]["status"] == 403
+    assert "Admin privileges required" in payload["error"]["message"]
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+uv run pytest tests/unit/bricks/mcp/test_hub_admin_tool.py -q
+```
+
+Expected: FAIL because `nexus_hub_admin` is not registered.
+
+- [ ] **Step 3: Implement MCP registration helper**
+
+Create `src/nexus/bricks/mcp/hub_admin_tool.py`:
+
+```python
+"""MCP hub-admin tool registration (#3872)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Callable
+
+from fastmcp import Context
+
+from nexus.contracts.exceptions import NexusPermissionError
+
+
+def _admin_service(nx_instance: Any) -> Any:
+    if not hasattr(nx_instance, "service"):
+        raise RuntimeError("Nexus service registry is unavailable")
+    service = nx_instance.service("mcp")
+    if service is None:
+        raise RuntimeError("Remote admin service is unavailable")
+    return service
+
+
+def _json_error(status: int, message: str) -> str:
+    return json.dumps({"error": {"status": status, "message": message}}, indent=2)
+
+
+def register_hub_admin_tool(mcp: Any, get_nexus_instance: Callable[[Context | None], Any]) -> None:
+    @mcp.tool(
+        annotations={
+            "readOnlyHint": False,
+            "destructiveHint": True,
+            "idempotentHint": False,
+            "openWorldHint": True,
+        }
+    )
+    async def nexus_hub_admin(
+        action: str,
+        arguments: dict[str, Any] | None = None,
+        ctx: Context | None = None,
+    ) -> str:
+        """Administer Nexus hub tokens. Requires an admin bearer token."""
+        args = arguments or {}
+        nx_instance = get_nexus_instance(ctx)
+        service = _admin_service(nx_instance)
+        try:
+            if action == "create_token":
+                result = service.admin_hub_token_create(**args)
+            elif action == "list_tokens":
+                result = service.admin_hub_token_list(**args)
+            elif action == "revoke_token":
+                result = service.admin_hub_token_revoke(**args)
+            elif action == "status":
+                result = service.admin_hub_status(**args)
+            else:
+                return _json_error(400, f"unknown hub admin action: {action}")
+            return json.dumps(result, indent=2, default=str)
+        except NexusPermissionError as exc:
+            return _json_error(403, str(exc))
+        except FileNotFoundError as exc:
+            return _json_error(404, str(exc))
+        except ValueError as exc:
+            return _json_error(400, str(exc))
+```
+
+In `src/nexus/bricks/mcp/server.py`, import and call after `mcp = FastMCP(name)` and after `_get_nexus_instance` exists:
+
+```python
+from nexus.bricks.mcp.hub_admin_tool import register_hub_admin_tool
+
+register_hub_admin_tool(mcp, _get_nexus_instance)
+```
+
+In `src/nexus/config/tool_profiles.yaml`, add `nexus_hub_admin` to the `full` profile tools list.
+
+- [ ] **Step 4: Verify GREEN**
+
+Run:
+
+```bash
+uv run pytest tests/unit/bricks/mcp/test_hub_admin_tool.py -q
+```
+
+Expected: PASS.
+
+---
+
+### Task 3: Remote Hub CLI Client
+
+**Files:**
+- Create: `tests/unit/cli/test_hub_remote.py`
+- Create: `src/nexus/cli/commands/_hub_remote.py`
+
+- [ ] **Step 1: Write failing helper tests**
+
+Create `tests/unit/cli/test_hub_remote.py` with helper-level tests:
+
+```python
+from __future__ import annotations
+
+import json
+from unittest.mock import Mock
+
+import pytest
+from click import ClickException
+
+from nexus.cli.commands import _hub_remote
+
+
+def test_normalize_remote_url_appends_mcp_path():
+    assert _hub_remote.normalize_mcp_url("https://nexus.example.com") == "https://nexus.example.com/mcp"
+    assert _hub_remote.normalize_mcp_url("https://nexus.example.com/") == "https://nexus.example.com/mcp"
+    assert _hub_remote.normalize_mcp_url("https://nexus.example.com/mcp") == "https://nexus.example.com/mcp"
+
+
+def test_extract_tool_payload_parses_text_json():
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "result": {"content": [{"type": "text", "text": json.dumps({"tokens": []})}]},
+    }
+    assert _hub_remote.extract_tool_payload(payload) == {"tokens": []}
+
+
+def test_extract_tool_payload_raises_for_403_error():
+    payload = {
+        "jsonrpc": "2.0",
+        "id": 2,
+        "result": {
+            "content": [
+                {"type": "text", "text": json.dumps({"error": {"status": 403, "message": "Admin privileges required"}})}
+            ]
+        },
+    }
+    with pytest.raises(ClickException, match="Admin privileges required"):
+        _hub_remote.extract_tool_payload(payload)
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+uv run pytest tests/unit/cli/test_hub_remote.py -q
+```
+
+Expected: FAIL because `_hub_remote` does not exist.
+
+- [ ] **Step 3: Implement remote MCP client helper**
+
+Create `src/nexus/cli/commands/_hub_remote.py`:
+
+```python
+"""Remote MCP client helpers for `nexus hub` (#3872)."""
+
+from __future__ import annotations
+
+import json
+from typing import Any
+from urllib.parse import urlparse, urlunparse
+
+import click
+import httpx
+
+
+def normalize_mcp_url(remote: str) -> str:
+    parsed = urlparse(remote)
+    if parsed.scheme not in {"http", "https"} or not parsed.netloc:
+        raise click.ClickException(f"invalid --remote URL: {remote!r}")
+    path = parsed.path.rstrip("/")
+    if path in {"", "/"}:
+        path = "/mcp"
+    return urlunparse(parsed._replace(path=path, params="", query="", fragment=""))
+
+
+def extract_tool_payload(payload: dict[str, Any]) -> dict[str, Any]:
+    if "error" in payload:
+        raise click.ClickException(str(payload["error"].get("message", payload["error"])))
+    result = payload.get("result") or {}
+    content = result.get("content") or []
+    text = ""
+    if content and isinstance(content[0], dict):
+        text = str(content[0].get("text", ""))
+    if not text:
+        raise click.ClickException("remote hub admin returned an empty MCP response")
+    try:
+        data = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise click.ClickException(f"remote hub admin returned invalid JSON: {text[:200]}") from exc
+    if isinstance(data, dict) and "error" in data:
+        err = data["error"]
+        raise click.ClickException(str(err.get("message", err)))
+    if not isinstance(data, dict):
+        raise click.ClickException("remote hub admin returned a non-object response")
+    return data
+
+
+def call_hub_admin(
+    remote: str,
+    admin_token: str,
+    action: str,
+    arguments: dict[str, Any] | None = None,
+    *,
+    timeout: float = 30.0,
+) -> dict[str, Any]:
+    url = normalize_mcp_url(remote)
+    headers = {
+        "Authorization": f"Bearer {admin_token}",
+        "Content-Type": "application/json",
+        "Accept": "application/json, text/event-stream",
+    }
+    init_body = {
+        "jsonrpc": "2.0",
+        "id": 1,
+        "method": "initialize",
+        "params": {
+            "protocolVersion": "2024-11-05",
+            "capabilities": {},
+            "clientInfo": {"name": "nexus-hub-cli", "version": "1"},
+        },
+    }
+    try:
+        with httpx.Client(timeout=timeout) as client:
+            with client.stream("POST", url, headers=headers, json=init_body) as resp:
+                if resp.status_code in (401, 403):
+                    raise click.ClickException(f"remote hub admin rejected credentials ({resp.status_code})")
+                resp.raise_for_status()
+                session_id = resp.headers.get("mcp-session-id") or resp.headers.get("Mcp-Session-Id")
+                for _line in resp.iter_lines():
+                    pass
+            if not session_id:
+                raise click.ClickException("remote MCP endpoint did not return mcp-session-id")
+            session_headers = {**headers, "Mcp-Session-Id": session_id}
+            client.post(
+                url,
+                headers=session_headers,
+                json={"jsonrpc": "2.0", "method": "notifications/initialized"},
+            )
+            body = {
+                "jsonrpc": "2.0",
+                "id": 2,
+                "method": "tools/call",
+                "params": {
+                    "name": "nexus_hub_admin",
+                    "arguments": {"action": action, "arguments": arguments or {}},
+                },
+            }
+            with client.stream("POST", url, headers=session_headers, json=body) as resp:
+                if resp.status_code in (401, 403):
+                    raise click.ClickException(f"remote hub admin rejected credentials ({resp.status_code})")
+                resp.raise_for_status()
+                for line in resp.iter_lines():
+                    if line.startswith("data: "):
+                        return extract_tool_payload(json.loads(line[6:]))
+    except httpx.HTTPError as exc:
+        raise click.ClickException(f"remote hub admin request failed for {url}: {exc}") from exc
+    raise click.ClickException("remote hub admin returned no MCP data event")
+```
+
+- [ ] **Step 4: Verify GREEN**
+
+Run:
+
+```bash
+uv run pytest tests/unit/cli/test_hub_remote.py -q
+```
+
+Expected: PASS.
+
+---
+
+### Task 4: Wire Remote Flags Into Hub CLI
+
+**Files:**
+- Modify: `src/nexus/cli/commands/hub.py`
+- Modify: `tests/unit/cli/test_hub_remote.py`
+
+- [ ] **Step 1: Write failing CLI tests**
+
+Extend `tests/unit/cli/test_hub_remote.py`:
+
+```python
+from click.testing import CliRunner
+from nexus.cli.commands.hub import hub
+
+
+def test_remote_token_list_uses_mcp_client(monkeypatch):
+    seen = {}
+    def fake_call(remote, admin_token, action, arguments=None):
+        seen.update({"remote": remote, "admin_token": admin_token, "action": action, "arguments": arguments})
+        return {"tokens": [{"key_id": "kid_1234567890", "name": "alice", "zone": "eng", "zones": ["eng"], "admin": False, "created": "-", "last_used": "-", "revoked": False, "revoked_at": "-"}]}
+    monkeypatch.setattr("nexus.cli.commands.hub.call_hub_admin", fake_call)
+    result = CliRunner().invoke(hub, ["token", "list", "--remote", "https://nexus.example.com", "--admin-token", "sk-admin", "--json"])
+    assert result.exit_code == 0, result.output
+    assert seen["action"] == "list_tokens"
+    assert seen["arguments"] == {"show_revoked": False}
+    assert json.loads(result.output)["tokens"][0]["name"] == "alice"
+
+
+def test_remote_token_create_sends_zones_and_prints_token(monkeypatch):
+    seen = {}
+    def fake_call(remote, admin_token, action, arguments=None):
+        seen.update({"action": action, "arguments": arguments})
+        return {"key_id": "kid", "token": "sk-created", "name": "alice", "zones": ["eng"], "admin": True, "expires_at": None}
+    monkeypatch.setattr("nexus.cli.commands.hub.call_hub_admin", fake_call)
+    result = CliRunner().invoke(hub, ["token", "create", "--name", "alice", "--zones", "eng:rwx", "--admin", "--remote", "https://nexus.example.com", "--admin-token", "sk-admin"])
+    assert result.exit_code == 0, result.output
+    assert seen["action"] == "create_token"
+    assert seen["arguments"]["zones"] == [{"zone_id": "eng", "permissions": "rwx"}]
+    assert "sk-created" in result.output
+
+
+def test_remote_requires_admin_token(monkeypatch):
+    result = CliRunner().invoke(hub, ["token", "list", "--remote", "https://nexus.example.com"])
+    assert result.exit_code == 1
+    assert "--admin-token" in result.output
+```
+
+- [ ] **Step 2: Run tests and verify RED**
+
+Run:
+
+```bash
+uv run pytest tests/unit/cli/test_hub_remote.py -q
+```
+
+Expected: FAIL because `hub.py` has no remote options.
+
+- [ ] **Step 3: Add remote option helpers and dispatch**
+
+In `src/nexus/cli/commands/hub.py`:
+
+```python
+from nexus.cli.commands._hub_remote import call_hub_admin, normalize_mcp_url
+```
+
+Add helpers near `_parse_zones_csv`:
+
+```python
+def _remote_options(func: Any) -> Any:
+    func = click.option("--admin-token", envvar="NEXUS_HUB_ADMIN_TOKEN", help="Admin bearer token for --remote.")(func)
+    func = click.option("--remote", help="Remote MCP hub URL. Host URLs are normalized to /mcp.")(func)
+    return func
+
+
+def _require_remote_token(remote: str | None, admin_token: str | None) -> None:
+    if remote and not admin_token:
+        raise click.ClickException("--admin-token is required when --remote is used")
+
+
+def _zones_for_remote(zones: list[str | tuple[str, str]]) -> list[dict[str, str]]:
+    out = []
+    for entry in zones:
+        if isinstance(entry, tuple):
+            out.append({"zone_id": entry[0], "permissions": entry[1]})
+        else:
+            out.append({"zone_id": entry, "permissions": "rw"})
+    return out
+```
+
+Apply `@_remote_options` to `token_create`, `token_list`, `token_revoke`, and `hub_status`. Add `remote` and `admin_token` parameters to each function.
+
+At the start of `token_create`, after mutual-exclusion validation and duration validation:
+
+```python
+if remote:
+    _require_remote_token(remote, admin_token)
+    if zones_glob is not None:
+        remote_zones = []
+    elif zones_csv is not None:
+        remote_zones = _zones_for_remote(_parse_zones_csv(zones_csv))
+    else:
+        remote_zones = _zones_for_remote([z.strip() for z in zone_alias.split(",") if z.strip()] if zone_alias else [])
+    result = call_hub_admin(
+        remote,
+        admin_token or "",
+        "create_token",
+        {
+            "name": name,
+            "zones": remote_zones,
+            "zones_glob": zones_glob,
+            "is_admin": is_admin,
+            "expires": expires,
+            "user_id": user_id,
+        },
+    )
+    click.echo(f"key_id: {result['key_id']}")
+    click.echo(f"token:  {result['token']}")
+    click.echo("")
+    click.echo("Save this token now - it will not be shown again.")
+    return
+```
+
+At the start of `token_list`:
+
+```python
+if remote:
+    _require_remote_token(remote, admin_token)
+    payload = call_hub_admin(remote, admin_token or "", "list_tokens", {"show_revoked": show_revoked})
+    _emit_token_list_payload(payload, as_json=as_json)
+    return
+```
+
+Extract the existing local token list rendering into `_emit_token_list_payload(payload, as_json)` so remote and local share output.
+
+At the start of `token_revoke`:
+
+```python
+if remote:
+    _require_remote_token(remote, admin_token)
+    result = call_hub_admin(remote, admin_token or "", "revoke_token", {"identifier": identifier})
+    click.echo(f"revoked {result['name']} ({result['key_id']}). Effective within 60s (auth cache TTL).")
+    return
+```
+
+At the start of `hub_status`:
+
+```python
+if remote:
+    _require_remote_token(remote, admin_token)
+    payload = call_hub_admin(
+        remote,
+        admin_token or "",
+        "status",
+        {"detail": detail, "endpoint": normalize_mcp_url(remote)},
+    )
+    if as_json:
+        click.echo(_json.dumps(payload, indent=2))
+    else:
+        _emit_base_status_text(payload)
+        if detail:
+            _emit_detail_status_text(payload)
+    if payload.get("postgres") != "ok":
+        raise SystemExit(2)
+    return
+```
+
+- [ ] **Step 4: Verify GREEN**
+
+Run:
+
+```bash
+uv run pytest tests/unit/cli/test_hub_remote.py tests/unit/cli/test_hub.py tests/unit/cli/test_hub_token_list_primary_alias.py -q
+```
+
+Expected: PASS.
+
+---
+
+### Task 5: Documentation and Integration Tests
+
+**Files:**
+- Modify: `docs/hub-deploy.md`
+- Create or modify: `tests/e2e/self_contained/cli/test_hub_flow.py`
+
+- [ ] **Step 1: Write or extend skipped e2e coverage**
+
+Add an e2e test guarded by existing environment variables:
+
+```python
+def test_hub_remote_token_list_over_mcp(hub_cli_env: dict[str, str]) -> None:
+    admin_token = _require("NEXUS_ADMIN_KEY")
+    mcp_base_url = _mcp_url()
+    result = _run(
+        ["hub", "token", "list", "--remote", mcp_base_url, "--admin-token", admin_token, "--json"],
+        env={k: v for k, v in hub_cli_env.items() if k != "NEXUS_DATABASE_URL"},
+    )
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert "tokens" in payload
+```
+
+This test must skip cleanly when a live hub stack is absent.
+
+- [ ] **Step 2: Update docs**
+
+In `docs/hub-deploy.md`:
+
+- Add a subsection under token lifecycle:
+
+```markdown
+Remote administration:
+
+1. Create the bootstrap admin token locally on the hub host:
+   `nexus hub token create --name root --admin --zone root`.
+2. From a workstation, point at the MCP endpoint:
+   `nexus hub token list --remote https://nexus.example.com --admin-token sk-...`.
+3. `NEXUS_HUB_ADMIN_TOKEN` may be used instead of repeating `--admin-token`.
+```
+
+- Replace the "Remote admin CLI" follow-up bullet with implemented wording.
+
+- [ ] **Step 3: Run focused tests**
+
+Run:
+
+```bash
+uv run pytest tests/unit/server/rpc/handlers/test_hub_admin.py tests/unit/bricks/mcp/test_hub_admin_tool.py tests/unit/cli/test_hub_remote.py tests/unit/cli/test_hub.py tests/unit/cli/test_hub_token_list_primary_alias.py -q
+```
+
+Expected: PASS.
+
+- [ ] **Step 4: Run lint/format on touched Python files**
+
+Run:
+
+```bash
+uv run ruff check src/nexus/server/rpc/handlers/hub_admin.py src/nexus/bricks/mcp/hub_admin_tool.py src/nexus/bricks/mcp/server.py src/nexus/cli/commands/_hub_remote.py src/nexus/cli/commands/hub.py tests/unit/server/rpc/handlers/test_hub_admin.py tests/unit/bricks/mcp/test_hub_admin_tool.py tests/unit/cli/test_hub_remote.py
+uv run ruff format --check src/nexus/server/rpc/handlers/hub_admin.py src/nexus/bricks/mcp/hub_admin_tool.py src/nexus/bricks/mcp/server.py src/nexus/cli/commands/_hub_remote.py src/nexus/cli/commands/hub.py tests/unit/server/rpc/handlers/test_hub_admin.py tests/unit/bricks/mcp/test_hub_admin_tool.py tests/unit/cli/test_hub_remote.py
+```
+
+Expected: PASS. If formatting fails, run `uv run ruff format ...` and rerun the check.
+
+---
+
+## Plan Self-Review
+
+Spec coverage:
+
+- Remote `create`, `list`, `revoke`, and `status` are covered by Tasks 1, 3, and 4.
+- MCP-side admin tool is covered by Task 2.
+- Non-admin rejection is covered by Tasks 1 and 2.
+- Local behavior preservation is covered by rerunning existing hub CLI tests.
+- Documentation is covered by Task 5.
+
+Deferred-work scan:
+
+- No unresolved markers or deferred implementation notes remain.
+
+Type consistency:
+
+- RPC method names use the `admin_hub_*` prefix throughout params, dispatch, MCP tool calls, and CLI remote calls.
+- CLI action names use `create_token`, `list_tokens`, `revoke_token`, and `status` throughout.

--- a/docs/superpowers/specs/2026-05-13-issue-3872-remote-hub-admin-design.md
+++ b/docs/superpowers/specs/2026-05-13-issue-3872-remote-hub-admin-design.md
@@ -1,0 +1,265 @@
+# Issue #3872 - Remote Hub Admin CLI Design
+
+**Issue**: [#3872](https://github.com/nexi-lab/nexus/issues/3872) - remote admin CLI for hub mode
+
+**Follows**: [#3784](https://github.com/nexi-lab/nexus/issues/3784) - hub mode
+
+## Summary
+
+Hub token administration currently requires direct database access through
+`NEXUS_DATABASE_URL`, so `nexus hub token ...` must run on the hub host. Issue
+#3872 adds an over-the-wire admin path for operators who have an admin bearer
+token and want to manage hub tokens from a workstation.
+
+The implementation should ship the full scope in one PR:
+
+- `nexus hub token create --remote https://nexus.example.com --admin-token sk-...`
+- `nexus hub token list --remote https://nexus.example.com --admin-token sk-...`
+- `nexus hub token revoke <name|key_id> --remote ... --admin-token ...`
+- `nexus hub status --remote https://nexus.example.com --admin-token sk-...`
+- MCP-side admin RPC/tool coverage protected by the resolved request
+  `is_admin` identity.
+
+The remote path is MCP-only. `--remote https://host` normalizes to
+`https://host/mcp`; an explicit `https://host/mcp` is accepted unchanged.
+
+## Current State
+
+`src/nexus/cli/commands/hub.py` implements the local `nexus hub` UX by opening
+a SQLAlchemy session through `get_session_factory()`. The local token commands
+already handle:
+
+- token creation with `--zones`, `--zone`, `--zones-glob`, `--admin`,
+  `--expires`, and `--user-id`;
+- token listing with table and JSON output;
+- token revocation by exact key ID, key ID prefix, or name;
+- hub status with base and detailed output.
+
+The server already has admin RPC handlers in
+`src/nexus/server/rpc/handlers/admin.py` for `admin_create_key`,
+`admin_list_keys`, `admin_get_key`, `admin_revoke_key`, and
+`admin_update_key`. Those handlers call `require_admin(context)` before
+touching auth state. The MCP server in `src/nexus/bricks/mcp/server.py`
+already resolves per-request bearer tokens into remote `NexusFS` instances for
+data-plane tools, but it does not expose a hub-specific admin tool.
+
+## Goals
+
+1. Preserve the local DB-backed `nexus hub` behavior when `--remote` is not
+   provided.
+2. Add remote token create/list/revoke/status over the MCP HTTP endpoint.
+3. Reuse the existing server-side admin authorization rule: the bearer used as
+   `--admin-token` must resolve to `is_admin=True`.
+4. Keep remote output compatible with local output, including JSON shape for
+   scripts.
+5. Return a clear forbidden response for non-admin tokens.
+
+## Non-Goals
+
+- No direct workstation access to the hub RPC or gRPC port.
+- No new REST admin endpoints.
+- No remote support for `nexus hub token zones add/remove/show`; the issue
+  acceptance covers create, list, revoke, and status.
+- No change to bootstrap: the first admin token is still minted locally.
+
+## Proposed Architecture
+
+Add a single MCP tool named `nexus_hub_admin` that accepts an `action` string
+and an action-specific argument object. The tool runs inside the MCP frontend
+request context, uses the request bearer token to create a remote Nexus
+connection, and delegates admin operations to the existing remote admin RPCs.
+
+For example:
+
+```json
+{
+  "action": "list_tokens",
+  "arguments": {"show_revoked": false}
+}
+```
+
+Remote CLI commands call this MCP tool through a lightweight streamable-HTTP
+client rather than through `RPCTransport`. This keeps the operator-facing
+network requirement aligned with hub deployment docs: the workstation only
+needs the public MCP endpoint and the bootstrap admin token.
+
+## MCP Tool Contract
+
+Tool name: `nexus_hub_admin`
+
+Arguments:
+
+- `action`: one of `create_token`, `list_tokens`, `revoke_token`, `status`
+- `arguments`: JSON object with the action payload
+
+Responses are JSON strings so the CLI can parse them deterministically.
+
+`create_token` arguments:
+
+- `name`: token name
+- `zones`: list of zone grants, each `{"zone_id": "...", "permissions": "rw"}`
+- `zones_glob`: optional glob pattern resolved on the server
+- `is_admin`: boolean
+- `expires`: optional CLI duration string such as `90d`, `24h`, or `30m`
+- `user_id`: optional token owner
+
+`create_token` response:
+
+- `key_id`
+- `token`
+- `name`
+- `zones`
+- `admin`
+- `expires_at`
+
+`list_tokens` arguments:
+
+- `show_revoked`: boolean
+
+`list_tokens` response:
+
+- `tokens`: list of token records using the existing local JSON keys:
+  `key_id`, `name`, `zone`, `zones`, `admin`, `created`, `last_used`,
+  `revoked`, `revoked_at`
+
+`revoke_token` arguments:
+
+- `identifier`: token name, exact key ID, or key ID prefix
+
+`revoke_token` response:
+
+- `key_id`
+- `name`
+- `revoked`: true
+
+`status` arguments:
+
+- `detail`: boolean
+
+`status` response:
+
+- same base keys as local `hub status --json`: `endpoint`, `profile`,
+  `postgres`, `redis`, `tokens`, `connections`, and `qps_5m`
+- includes the same detail keys as local `hub status --detail --json` when
+  `detail` is true and the remote server can collect them
+
+## Authorization
+
+The MCP tool must derive authority from the incoming MCP request bearer. It
+must not accept an admin token inside the tool arguments.
+
+The request flow is:
+
+1. CLI sends `Authorization: Bearer <admin-token>` to the MCP `/mcp` endpoint.
+2. MCP HTTP middleware stores the bearer in the existing request context var.
+3. `nexus_hub_admin` resolves a remote `NexusFS` for that bearer using the
+   existing per-request connection logic.
+4. The tool calls `nx.admin.*` remote methods, which reach server-side admin
+   RPC handlers.
+5. Server-side `require_admin(context)` rejects non-admin tokens.
+
+The remote CLI should translate permission failures into a user-facing
+`ClickException` whose message includes that admin privileges are required. In
+wire-level integration tests, the non-admin MCP call must surface a forbidden
+admin failure. Depending on FastMCP transport semantics, this may be a
+JSON-RPC tool error envelope rather than an HTTP status on the `tools/call`
+request, but the rejection must come from the server-side admin check.
+
+## CLI UX
+
+Add shared options:
+
+- `--remote URL`: MCP hub URL. If the path is absent or `/`, append `/mcp`.
+- `--admin-token TOKEN`: admin bearer token. Also read from
+  `NEXUS_HUB_ADMIN_TOKEN` for non-interactive use.
+
+Remote mode activates when `--remote` is provided. In remote mode,
+`--admin-token` is required.
+
+Examples:
+
+```bash
+nexus hub token list --remote https://nexus.example.com --admin-token sk-admin
+nexus hub token create --remote https://nexus.example.com --admin-token sk-admin \
+  --name alice --zones eng:rw,ops:r --expires 90d
+nexus hub token revoke alice --remote https://nexus.example.com --admin-token sk-admin
+nexus hub status --remote https://nexus.example.com --admin-token sk-admin
+```
+
+The local path remains unchanged:
+
+```bash
+NEXUS_DATABASE_URL=postgresql://... nexus hub token list
+```
+
+## Data Flow
+
+```mermaid
+sequenceDiagram
+    participant CLI as nexus hub CLI
+    participant MCP as MCP frontend
+    participant RPC as nexusd RPC server
+    participant DB as auth database
+
+    CLI->>MCP: tools/call nexus_hub_admin<br/>Authorization: Bearer sk-admin
+    MCP->>RPC: admin_* RPC using sk-admin as auth token
+    RPC->>RPC: require_admin(context)
+    RPC->>DB: create/list/revoke/status token data
+    DB-->>RPC: token rows
+    RPC-->>MCP: admin result
+    MCP-->>CLI: JSON tool result
+    CLI-->>CLI: render local-compatible output
+```
+
+## Error Handling
+
+- Missing `--admin-token` in remote mode: CLI error before network call.
+- Invalid remote URL: CLI error before network call.
+- MCP connection failure: CLI error naming the remote endpoint.
+- Non-admin token: admin permission error from the server-side RPC path.
+- Invalid action payload: MCP tool returns an invalid-input error.
+- Ambiguous revoke identifier: same behavior as local revoke, with a clear
+  ambiguous-token error.
+
+## Testing
+
+Tests should be written first.
+
+Unit coverage:
+
+- remote URL normalization helper;
+- remote CLI payloads for create/list/revoke/status;
+- remote CLI output parity for JSON and table output;
+- missing `--admin-token` fails before any network call;
+- MCP tool is registered and delegates to admin RPC paths;
+- MCP admin tool rejects non-admin context through existing admin checks.
+
+Integration coverage:
+
+- streamable-HTTP MCP call with an admin token can list tokens;
+- streamable-HTTP MCP call with a non-admin token receives a forbidden admin
+  failure.
+
+Manual/e2e coverage:
+
+- `nexus hub token list --remote https://... --admin-token sk-...` returns the
+  same JSON shape as local `nexus hub token list --json`.
+- `create`, `revoke`, and `status` work from a workstation with no
+  `NEXUS_DATABASE_URL` set.
+
+## Documentation
+
+Update `docs/hub-deploy.md`:
+
+- mark remote admin CLI as implemented;
+- show bootstrap flow: create one admin token locally, then operate remotely;
+- document `--remote`, `--admin-token`, and `NEXUS_HUB_ADMIN_TOKEN`;
+- keep the warning that the first admin token still requires direct hub-host DB
+  access.
+
+## Open Decisions Resolved
+
+- Full issue scope lands in one PR.
+- Remote admin is MCP-only.
+- URL normalization accepts host-level URLs and appends `/mcp`.
+- `token zones add/remove/show` remains local-only for this PR.

--- a/src/nexus/bricks/mcp/hub_admin_tool.py
+++ b/src/nexus/bricks/mcp/hub_admin_tool.py
@@ -1,0 +1,69 @@
+"""MCP hub-admin tool registration (#3872)."""
+
+from __future__ import annotations
+
+import json
+from collections.abc import Callable
+from typing import Any
+
+from fastmcp import Context
+
+from nexus.contracts.exceptions import NexusError, NexusPermissionError
+
+
+def _json_error(status: int, message: str) -> str:
+    return json.dumps({"error": {"status": status, "message": message}}, indent=2)
+
+
+def _admin_service(nx_instance: Any) -> Any:
+    if not hasattr(nx_instance, "service"):
+        raise RuntimeError("Nexus service registry is unavailable")
+    service = nx_instance.service("mcp")
+    if service is None:
+        raise RuntimeError("Remote admin service is unavailable")
+    return service
+
+
+def register_hub_admin_tool(
+    mcp: Any,
+    get_nexus_instance: Callable[[Context | None], Any],
+) -> None:
+    """Register the hub admin MCP tool on a FastMCP server."""
+
+    @mcp.tool(
+        annotations={
+            "readOnlyHint": False,
+            "destructiveHint": True,
+            "idempotentHint": False,
+            "openWorldHint": True,
+        }
+    )
+    async def nexus_hub_admin(
+        action: str,
+        arguments: dict[str, Any] | None = None,
+        ctx: Context | None = None,
+    ) -> str:
+        """Administer Nexus hub tokens. Requires an admin bearer token."""
+        args = arguments or {}
+        nx_instance = get_nexus_instance(ctx)
+        service = _admin_service(nx_instance)
+        try:
+            if action == "create_token":
+                result = service.admin_hub_token_create(**args)
+            elif action == "list_tokens":
+                result = service.admin_hub_token_list(**args)
+            elif action == "revoke_token":
+                result = service.admin_hub_token_revoke(**args)
+            elif action == "status":
+                result = service.admin_hub_status(**args)
+            else:
+                return _json_error(400, f"unknown hub admin action: {action}")
+            return json.dumps(result, indent=2, default=str)
+        except NexusPermissionError as exc:
+            return _json_error(403, str(exc))
+        except NexusError as exc:
+            return _json_error(exc.status_code, str(exc))
+        except FileNotFoundError as exc:
+            return _json_error(404, str(exc))
+        except ValueError as exc:
+            return _json_error(400, str(exc))

--- a/src/nexus/bricks/mcp/server.py
+++ b/src/nexus/bricks/mcp/server.py
@@ -259,6 +259,10 @@ async def create_mcp_server(
     # Create FastMCP server
     mcp = FastMCP(name)
 
+    from nexus.bricks.mcp.hub_admin_tool import register_hub_admin_tool
+
+    register_hub_admin_tool(mcp, _get_nexus_instance)
+
     # Add health check endpoint for HTTP transports
     # This is added here so it's available when the server is created via create_mcp_server()
     # The CLI command will also add it, but having it here ensures it works in all cases

--- a/src/nexus/cli/commands/_hub_remote.py
+++ b/src/nexus/cli/commands/_hub_remote.py
@@ -83,8 +83,9 @@ def _initialize(client: httpx.Client, url: str, headers: dict[str, str]) -> str:
         session_id_raw = response.headers.get("mcp-session-id") or response.headers.get(
             "Mcp-Session-Id"
         )
-        for _line in response.iter_lines():
-            pass
+        payload = _read_json_rpc_data_event(response, expected_id=1)
+        if payload is not None and payload.get("error") is not None:
+            raise HubRemoteError(_json_rpc_error_message(payload["error"]))
     if not isinstance(session_id_raw, str) or not session_id_raw:
         raise HubRemoteError("remote hub MCP initialize did not return a session id")
     return session_id_raw
@@ -107,10 +108,24 @@ def _post_json_rpc(
 ) -> dict[str, Any]:
     with client.stream("POST", url, headers=headers, json=envelope) as response:
         response.raise_for_status()
-        for line in response.iter_lines():
-            if line.startswith("data: "):
-                return _decode_sse_json(line)
+        payload = _read_json_rpc_data_event(response, expected_id=envelope.get("id"))
+        if payload is not None:
+            return payload
     raise HubRemoteError("remote hub MCP response did not include a data event")
+
+
+def _read_json_rpc_data_event(
+    response: httpx.Response,
+    *,
+    expected_id: Any,
+) -> dict[str, Any] | None:
+    for line in response.iter_lines():
+        if not line.startswith("data: "):
+            continue
+        payload = _decode_sse_json(line)
+        if payload.get("error") is not None or payload.get("id") == expected_id:
+            return payload
+    return None
 
 
 def _decode_sse_json(line: str) -> dict[str, Any]:
@@ -125,9 +140,7 @@ def _decode_sse_json(line: str) -> dict[str, Any]:
 
 def _extract_tool_payload(envelope: dict[str, Any]) -> dict[str, Any]:
     if envelope.get("error") is not None:
-        error = envelope["error"]
-        message = (error.get("message") or str(error)) if isinstance(error, dict) else str(error)
-        raise HubRemoteError(message)
+        raise HubRemoteError(_json_rpc_error_message(envelope["error"]))
 
     result = envelope.get("result")
     if not isinstance(result, dict):
@@ -154,3 +167,7 @@ def _extract_tool_payload(envelope: dict[str, Any]) -> dict[str, Any]:
     if not isinstance(payload, dict):
         raise HubRemoteError("remote hub MCP tool returned non-object JSON")
     return payload
+
+
+def _json_rpc_error_message(error: Any) -> str:
+    return (error.get("message") or str(error)) if isinstance(error, dict) else str(error)

--- a/src/nexus/config/tool_profiles.yaml
+++ b/src/nexus/config/tool_profiles.yaml
@@ -59,5 +59,6 @@ profiles:
       - nexus_discovery_list_servers
       - nexus_discovery_get_tool_details
       - nexus_discovery_load_tools
+      - nexus_hub_admin
 
 default_profile: minimal

--- a/src/nexus/fuse/lease_coordinator.py
+++ b/src/nexus/fuse/lease_coordinator.py
@@ -62,6 +62,9 @@ _DEFAULT_LEASE_TTL = 30.0
 # Default timeout for lease acquisition (non-blocking for hot path)
 _LEASE_ACQUIRE_TIMEOUT = 5.0
 
+# Maximum time to wait for coordinator-owned background tasks to acknowledge close.
+_LOOP_SHUTDOWN_TIMEOUT = 2.0
+
 
 class FUSELeaseCoordinator:
     """Lease-aware cache coordinator for FUSE operations.
@@ -137,14 +140,45 @@ class FUSELeaseCoordinator:
         ready = threading.Event()
 
         def _run_loop() -> None:
-            self._lease_loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(self._lease_loop)
+            loop = asyncio.new_event_loop()
+            self._lease_loop = loop
+            asyncio.set_event_loop(loop)
             ready.set()
-            self._lease_loop.run_forever()
+            try:
+                loop.run_forever()
+            finally:
+                self._cancel_pending_loop_tasks(loop)
+                loop.run_until_complete(loop.shutdown_asyncgens())
+                loop.close()
 
         self._lease_thread = threading.Thread(target=_run_loop, daemon=True, name="fuse-lease-loop")
         self._lease_thread.start()
         ready.wait(timeout=2.0)
+
+    @staticmethod
+    def _cancel_pending_loop_tasks(loop: asyncio.AbstractEventLoop) -> None:
+        """Cancel tasks spawned on the coordinator-owned event loop before close."""
+        pending = [task for task in asyncio.all_tasks(loop) if not task.done()]
+        if not pending:
+            return
+
+        for task in pending:
+            task.cancel()
+
+        done, still_pending = loop.run_until_complete(
+            asyncio.wait(pending, timeout=_LOOP_SHUTDOWN_TIMEOUT)
+        )
+        for task in done:
+            try:
+                task.result()
+            except asyncio.CancelledError:
+                pass
+            except Exception:
+                pass
+        for task in still_pending:
+            if hasattr(task, "_log_destroy_pending"):
+                task._log_destroy_pending = False
+            logger.debug("[FUSE-LEASE] Pending task suppressed during close: %r", task)
 
     def _register_revocation_callback(self) -> None:
         """Register callback so lease revocations clear our validity cache + L1 cache.
@@ -556,5 +590,5 @@ class FUSELeaseCoordinator:
         if self._lease_loop is not None and not self._lease_loop.is_closed():
             self._lease_loop.call_soon_threadsafe(self._lease_loop.stop)
         if self._lease_thread is not None:
-            self._lease_thread.join(timeout=2.0)
+            self._lease_thread.join(timeout=_LOOP_SHUTDOWN_TIMEOUT + 1.0)
         logger.debug("[FUSE-LEASE] Coordinator closed (holder=%s)", self._holder_id)

--- a/src/nexus/lib/lease.py
+++ b/src/nexus/lib/lease.py
@@ -591,6 +591,8 @@ class LocalLeaseManager:
         self._closed = True
         if self._sweep_task is not None and not self._sweep_task.done():
             try:
+                if hasattr(self._sweep_task, "_log_destroy_pending"):
+                    self._sweep_task._log_destroy_pending = False
                 self._sweep_task.cancel()
                 await self._sweep_task
             except (asyncio.CancelledError, RuntimeError):

--- a/tests/e2e/self_contained/cli/test_hub_flow.py
+++ b/tests/e2e/self_contained/cli/test_hub_flow.py
@@ -176,6 +176,32 @@ def test_hub_end_to_end_token_lifecycle(hub_cli_env: dict[str, str]) -> None:
         _run(["hub", "token", "revoke", token_name], env=hub_cli_env)
 
 
+def test_hub_remote_token_list_over_mcp(hub_cli_env: dict[str, str]) -> None:
+    """List hub tokens remotely through the MCP admin tool (#3872)."""
+    admin_token = _require("NEXUS_ADMIN_KEY")
+    mcp_base_url = _mcp_url()
+    env = dict(hub_cli_env)
+    env.pop("NEXUS_DATABASE_URL", None)
+
+    result = _run(
+        [
+            "hub",
+            "token",
+            "list",
+            "--remote",
+            mcp_base_url,
+            "--admin-token",
+            admin_token,
+            "--json",
+        ],
+        env=env,
+    )
+
+    assert result.returncode == 0, result.stderr
+    payload = json.loads(result.stdout)
+    assert "tokens" in payload
+
+
 def test_hub_multi_zone_token_lifecycle(hub_cli_env: dict[str, str]) -> None:
     """e2e: create multi-zone token, list, mutate zones, refuse last-zone removal (#3785).
 

--- a/tests/unit/bricks/mcp/test_hub_admin_tool.py
+++ b/tests/unit/bricks/mcp/test_hub_admin_tool.py
@@ -1,0 +1,81 @@
+"""Tests for the MCP hub admin tool (#3872)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import Mock
+
+import pytest
+
+from nexus.bricks.mcp.server import create_mcp_server
+from tests.unit.bricks.mcp.test_mcp_server_tools import get_tool, tool_exists
+
+
+@pytest.mark.asyncio
+async def test_nexus_hub_admin_tool_registered():
+    server = await create_mcp_server(nx=Mock())
+
+    assert tool_exists(server, "nexus_hub_admin")
+
+
+@pytest.mark.asyncio
+async def test_nexus_hub_admin_list_delegates_to_remote_service():
+    service = Mock()
+    service.admin_hub_token_list.return_value = {"tokens": []}
+    nx = Mock()
+    nx.service.return_value = service
+    server = await create_mcp_server(nx=nx)
+
+    tool = get_tool(server, "nexus_hub_admin")
+    result = await tool.fn(action="list_tokens", arguments={"show_revoked": True})
+
+    assert json.loads(result) == {"tokens": []}
+    service.admin_hub_token_list.assert_called_once_with(show_revoked=True)
+
+
+@pytest.mark.asyncio
+async def test_nexus_hub_admin_permission_error_has_403_status():
+    from nexus.contracts.exceptions import NexusPermissionError
+
+    service = Mock()
+    service.admin_hub_token_list.side_effect = NexusPermissionError("Admin privileges required")
+    nx = Mock()
+    nx.service.return_value = service
+    server = await create_mcp_server(nx=nx)
+
+    tool = get_tool(server, "nexus_hub_admin")
+    result = await tool.fn(action="list_tokens", arguments={})
+
+    payload = json.loads(result)
+    assert payload["error"]["status"] == 403
+    assert "Admin privileges required" in payload["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_nexus_hub_admin_validation_error_has_400_status():
+    from nexus.contracts.exceptions import ValidationError
+
+    service = Mock()
+    service.admin_hub_token_create.side_effect = ValidationError("zones must not be empty")
+    nx = Mock()
+    nx.service.return_value = service
+    server = await create_mcp_server(nx=nx)
+
+    tool = get_tool(server, "nexus_hub_admin")
+    result = await tool.fn(action="create_token", arguments={})
+
+    payload = json.loads(result)
+    assert payload["error"]["status"] == 400
+    assert "zones must not be empty" in payload["error"]["message"]
+
+
+@pytest.mark.asyncio
+async def test_nexus_hub_admin_unknown_action_has_400_status():
+    server = await create_mcp_server(nx=Mock())
+
+    tool = get_tool(server, "nexus_hub_admin")
+    result = await tool.fn(action="bogus", arguments={})
+
+    payload = json.loads(result)
+    assert payload["error"]["status"] == 400
+    assert "unknown hub admin action" in payload["error"]["message"]

--- a/tests/unit/cli/test_hub_remote.py
+++ b/tests/unit/cli/test_hub_remote.py
@@ -23,6 +23,88 @@ def test_normalize_remote_url_appends_mcp_path():
     )
 
 
+def test_call_hub_admin_tool_stops_after_initialize_data_event(monkeypatch):
+    calls = []
+
+    class FakeResponse:
+        def __init__(self, *, headers=None, lines=None, fail_on_extra_iter=False):
+            self.headers = headers or {}
+            self._lines = lines or []
+            self._fail_on_extra_iter = fail_on_extra_iter
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def raise_for_status(self):
+            return None
+
+        def iter_lines(self):
+            yield from self._lines
+            if self._fail_on_extra_iter:
+                raise AssertionError("initialize stream was drained past the data event")
+
+    class FakeClient:
+        def __init__(self, timeout):
+            self.timeout = timeout
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *args):
+            return False
+
+        def stream(self, method, url, headers, json):
+            calls.append((method, json["method"]))
+            if json["method"] == "initialize":
+                return FakeResponse(
+                    headers={"mcp-session-id": "session-1"},
+                    lines=[
+                        'data: {"jsonrpc":"2.0","id":1,"result":{"protocolVersion":"2024-11-05"}}'
+                    ],
+                    fail_on_extra_iter=True,
+                )
+            return FakeResponse(
+                lines=[
+                    "data: "
+                    + json_module.dumps(
+                        {
+                            "jsonrpc": "2.0",
+                            "id": 2,
+                            "result": {
+                                "content": [
+                                    {"type": "text", "text": json_module.dumps({"tokens": []})}
+                                ]
+                            },
+                        }
+                    )
+                ]
+            )
+
+        def post(self, url, headers, json):
+            calls.append(("POST", json["method"]))
+            return FakeResponse()
+
+    json_module = json
+    monkeypatch.setattr(_hub_remote.httpx, "Client", FakeClient)
+
+    result = _hub_remote.call_hub_admin_tool(
+        "https://nexus.example.com",
+        "sk-admin",
+        "nexus_hub_token_list",
+        {"show_revoked": False},
+    )
+
+    assert result == {"tokens": []}
+    assert calls == [
+        ("POST", "initialize"),
+        ("POST", "notifications/initialized"),
+        ("POST", "tools/call"),
+    ]
+
+
 def test_remote_list_requires_admin_token(monkeypatch):
     monkeypatch.delenv("NEXUS_HUB_ADMIN_TOKEN", raising=False)
 

--- a/tests/unit/fuse/test_fuse_lease_coherence.py
+++ b/tests/unit/fuse/test_fuse_lease_coherence.py
@@ -6,6 +6,9 @@ mutations occur.  Uses SystemClock for real-time coordination since
 the coordinator's validity cache uses time.monotonic() directly.
 """
 
+import asyncio
+from collections.abc import Iterator
+
 import pytest
 
 from nexus.fuse.cache import FUSECacheManager
@@ -14,13 +17,17 @@ from nexus.lib.lease import LocalLeaseManager, SystemClock
 
 
 @pytest.fixture()
-def shared_lease_manager() -> LocalLeaseManager:
+def shared_lease_manager() -> Iterator[LocalLeaseManager]:
     """Shared lease manager used by both mounts.
 
     Uses SystemClock (not ManualClock) because the coordinator's local
     validity cache compares against time.monotonic() directly.
     """
-    return LocalLeaseManager(zone_id="test-zone", clock=SystemClock(), sweep_interval=3600.0)
+    manager = LocalLeaseManager(zone_id="test-zone", clock=SystemClock(), sweep_interval=3600.0)
+    try:
+        yield manager
+    finally:
+        asyncio.run(manager.close())
 
 
 def _make_coordinator(

--- a/tests/unit/fuse/test_fuse_lease_coordinator.py
+++ b/tests/unit/fuse/test_fuse_lease_coordinator.py
@@ -13,6 +13,7 @@ import pytest
 from nexus.contracts.protocols.lease import Lease, LeaseState
 from nexus.fuse.cache import FUSECacheManager
 from nexus.fuse.lease_coordinator import FUSELeaseCoordinator
+from nexus.lib.lease import LocalLeaseManager, SystemClock
 
 
 @pytest.fixture()
@@ -377,6 +378,34 @@ class TestCoordinatorWithLeaseManager:
 
 class TestCoordinatorLifecycle:
     """Tests for event loop thread lifecycle."""
+
+    def test_close_cancels_tasks_owned_by_lease_loop(self, bare_cache: FUSECacheManager) -> None:
+        lease_manager = LocalLeaseManager(
+            zone_id="test",
+            clock=SystemClock(),
+            sweep_interval=3600.0,
+        )
+        coord = FUSELeaseCoordinator(
+            cache=bare_cache,
+            lease_manager=lease_manager,
+            holder_id="mount-x",
+        )
+
+        coord.lease_gated_get(
+            path="/file.txt",
+            cache_get=lambda: coord.get_attr("/file.txt"),
+            cache_set=lambda value: coord.cache_attr("/file.txt", value),
+            fetch_fn=lambda: {"st_size": 1},
+        )
+        sweep_task = lease_manager._sweep_task
+        assert sweep_task is not None
+        assert not sweep_task.done()
+
+        coord.close()
+
+        assert sweep_task.done()
+        assert coord._lease_loop is not None
+        assert coord._lease_loop.is_closed()
 
     def test_close_is_idempotent(self, bare_cache: FUSECacheManager) -> None:
         mock_mgr = MagicMock()

--- a/tests/unit/integration/test_lease_aware_cache.py
+++ b/tests/unit/integration/test_lease_aware_cache.py
@@ -9,6 +9,7 @@ Tests the interaction between LeaseManager and cache layers:
 
 from __future__ import annotations
 
+from collections.abc import AsyncIterator
 from pathlib import Path
 
 import pytest
@@ -38,8 +39,12 @@ def clock() -> ManualClock:
 
 
 @pytest.fixture()
-def mgr(clock: ManualClock) -> LocalLeaseManager:
-    return LocalLeaseManager(zone_id=ZONE, clock=clock, sweep_interval=999.0)
+async def mgr(clock: ManualClock) -> AsyncIterator[LocalLeaseManager]:
+    manager = LocalLeaseManager(zone_id=ZONE, clock=clock, sweep_interval=999.0)
+    try:
+        yield manager
+    finally:
+        await manager.close()
 
 
 @pytest.fixture()

--- a/tests/unit/lib/test_lease.py
+++ b/tests/unit/lib/test_lease.py
@@ -8,6 +8,7 @@ callbacks, lifecycle, stats, and the service wrapper.
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
 
 import pytest
 
@@ -34,8 +35,12 @@ def clock() -> ManualClock:
 
 
 @pytest.fixture()
-def mgr(clock: ManualClock) -> LocalLeaseManager:
-    return LocalLeaseManager(zone_id="test", clock=clock, sweep_interval=999.0)
+async def mgr(clock: ManualClock) -> AsyncIterator[LocalLeaseManager]:
+    manager = LocalLeaseManager(zone_id="test", clock=clock, sweep_interval=999.0)
+    try:
+        yield manager
+    finally:
+        await manager.close()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/lib/test_lease_concurrency.py
+++ b/tests/unit/lib/test_lease_concurrency.py
@@ -13,6 +13,7 @@ Tested scenarios:
 from __future__ import annotations
 
 import asyncio
+from collections.abc import AsyncIterator
 
 import pytest
 
@@ -34,8 +35,12 @@ def clock() -> ManualClock:
 
 
 @pytest.fixture()
-def mgr(clock: ManualClock) -> LocalLeaseManager:
-    return LocalLeaseManager(zone_id="test", clock=clock, sweep_interval=999.0)
+async def mgr(clock: ManualClock) -> AsyncIterator[LocalLeaseManager]:
+    manager = LocalLeaseManager(zone_id="test", clock=clock, sweep_interval=999.0)
+    try:
+        yield manager
+    finally:
+        await manager.close()
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Add server-side `admin_hub_*` RPC handlers for remote hub token create/list/revoke/status, protected by admin database auth.
- Register the `nexus_hub_admin` MCP tool and wire `nexus hub token create/list/revoke` plus `nexus hub status` to `--remote`/`--admin-token`.
- Fix `nexus up --build` with MCP add-on profiles so the MCP sidecar uses the locally built image instead of pulling `nexus-server:latest`.
- Document the remote admin flow and add focused unit coverage plus a guarded e2e test.

Fixes #3872.

## Test Plan
- `uv run pytest tests/unit/server/rpc/handlers/test_hub_admin.py tests/unit/bricks/mcp/test_hub_admin_tool.py tests/unit/cli/test_hub_remote.py tests/unit/cli/test_hub.py tests/unit/cli/test_hub_token_list_primary_alias.py tests/unit/cli/test_stack.py::TestUpCommand::test_build_with_addon_profiles_uses_local_image_ref -q`
- `uv run --extra dev ruff check src/nexus/cli/commands/stack.py tests/unit/cli/test_stack.py src/nexus/server/rpc/handlers/hub_admin.py src/nexus/bricks/mcp/hub_admin_tool.py src/nexus/bricks/mcp/server.py src/nexus/cli/commands/_hub_remote.py src/nexus/cli/commands/hub.py tests/unit/server/rpc/handlers/test_hub_admin.py tests/unit/bricks/mcp/test_hub_admin_tool.py tests/unit/cli/test_hub_remote.py tests/e2e/self_contained/cli/test_hub_flow.py`
- `uv run --extra dev ruff format --check src/nexus/cli/commands/stack.py tests/unit/cli/test_stack.py src/nexus/server/rpc/handlers/hub_admin.py src/nexus/bricks/mcp/hub_admin_tool.py src/nexus/bricks/mcp/server.py src/nexus/cli/commands/_hub_remote.py src/nexus/cli/commands/hub.py tests/unit/server/rpc/handlers/test_hub_admin.py tests/unit/bricks/mcp/test_hub_admin_tool.py tests/unit/cli/test_hub_remote.py tests/e2e/self_contained/cli/test_hub_flow.py`
- `uv run --extra dev mypy src/nexus/cli/commands/stack.py src/nexus/server/rpc/handlers/hub_admin.py src/nexus/bricks/mcp/hub_admin_tool.py src/nexus/cli/commands/_hub_remote.py`
- `nexus up --build` from a temp project initialized with `--with mcp`, using isolated MCP and approvals ports.
- Live remote checks against that stack: MCP health, `hub status --remote`, `hub token list --remote`, `hub token create --remote`, `hub token revoke --remote`, `hub token list --show-revoked --remote`, `hub status --detail --remote`, and non-admin remote-admin denial.
- `NEXUS_DATABASE_URL=postgresql://postgres:nexus@localhost:57212/nexus NEXUS_ADMIN_KEY=<admin> MCP_HTTP_URL=http://localhost:60091 uv run pytest tests/e2e/self_contained/cli/test_hub_flow.py::test_hub_remote_token_list_over_mcp -q`
