### PR TITLE
[codex] Fix develop CI smoke failures

### DIFF
--- a/.github/actions/build-rust-extensions/action.yml
+++ b/.github/actions/build-rust-extensions/action.yml
@@ -32,10 +32,11 @@ runs:
       # as a 3-part semver.  Post-21 protoc releases report 2-part versions
       # ("libprotoc 27.5"), which the parser rejects as "No suitable protoc
       # (>= 3.1.0) found in PATH" even though 27.x is newer than 3.1.
-      # Download the last 3.x-style release (3.20.3) directly from GitHub
-      # and prepend it to PATH.  arduino/setup-protoc@v3 can't find 3.x
-      # releases (fails with "unable to get latest version"), so we do it
-      # manually.  Idempotent: if protoc 3.x is already on PATH we skip.
+      # Download 3.20.3 where a native asset exists.  Protobuf never shipped
+      # a 3.x macOS arm64 asset, so macOS-ARM64 uses grpcio-tools' native
+      # bundled compiler with a tiny --version wrapper that keeps
+      # protobuf-build on its legacy parser path while all real invocations
+      # execute the native compiler.
       run: |
         set -euo pipefail
         if protoc --version 2>/dev/null | grep -qE 'libprotoc 3\.[0-9]+\.[0-9]+'; then
@@ -43,25 +44,39 @@ runs:
           protoc --version
           exit 0
         fi
+        PROTOC_VERSION="3.20.3"
+        USE_GRPC_TOOLS_PROTOC=""
         case "${{ runner.os }}-${{ runner.arch }}" in
           Linux-X64)   ASSET="protoc-3.20.3-linux-x86_64.zip" ;;
           Linux-ARM64) ASSET="protoc-3.20.3-linux-aarch_64.zip" ;;
           macOS-X64)   ASSET="protoc-3.20.3-osx-x86_64.zip" ;;
-          # No osx-aarch_64 asset in 3.x releases — fall back to the
-          # x86_64 build, which runs under Rosetta2 (enabled by default
-          # on macos-latest / M1 runners).
-          macOS-ARM64) ASSET="protoc-3.20.3-osx-x86_64.zip" ;;
+          macOS-ARM64) USE_GRPC_TOOLS_PROTOC="1" ;;
           *) echo "Unsupported: ${{ runner.os }}-${{ runner.arch }}" && exit 1 ;;
         esac
-        curl --fail --show-error --silent --location \
-          --retry 5 --retry-all-errors --retry-delay 2 \
-          -o /tmp/protoc.zip \
-          "https://github.com/protocolbuffers/protobuf/releases/download/v3.20.3/${ASSET}"
-        mkdir -p "${RUNNER_TOOL_CACHE}/protoc/3.20.3"
-        unzip -q /tmp/protoc.zip -d "${RUNNER_TOOL_CACHE}/protoc/3.20.3"
-        chmod +x "${RUNNER_TOOL_CACHE}/protoc/3.20.3/bin/protoc"
-        echo "${RUNNER_TOOL_CACHE}/protoc/3.20.3/bin" >> "${GITHUB_PATH}"
-        "${RUNNER_TOOL_CACHE}/protoc/3.20.3/bin/protoc" --version
+        TOOL_DIR="${RUNNER_TOOL_CACHE}/protoc/${PROTOC_VERSION}/${{ runner.os }}-${{ runner.arch }}"
+        mkdir -p "${TOOL_DIR}"
+        if [ -n "${USE_GRPC_TOOLS_PROTOC}" ]; then
+          python -m pip install "grpcio-tools>=1.80,<2"
+          mkdir -p "${TOOL_DIR}/bin"
+          cat > "${TOOL_DIR}/bin/protoc" <<'EOF'
+        #!/usr/bin/env bash
+        set -euo pipefail
+        if [ "${1:-}" = "--version" ]; then
+          echo "libprotoc 3.20.3"
+          exit 0
+        fi
+        exec python -m grpc_tools.protoc "$@"
+        EOF
+        else
+          curl --fail --show-error --silent --location \
+            --retry 5 --retry-all-errors --retry-delay 2 \
+            -o /tmp/protoc.zip \
+            "https://github.com/protocolbuffers/protobuf/releases/download/v${PROTOC_VERSION}/${ASSET}"
+          unzip -q /tmp/protoc.zip -d "${TOOL_DIR}"
+        fi
+        chmod +x "${TOOL_DIR}/bin/protoc"
+        echo "${TOOL_DIR}/bin" >> "${GITHUB_PATH}"
+        "${TOOL_DIR}/bin/protoc" --version
       shell: bash
 
     - name: Install Rust toolchain

--- a/src/nexus/server/rpc/handlers/filesystem.py
+++ b/src/nexus/server/rpc/handlers/filesystem.py
@@ -100,11 +100,10 @@ def handle_search(nexus_fs: "NexusFS", params: Any, context: Any) -> dict[str, A
 async def handle_semantic_search_index(
     nexus_fs: "NexusFS", params: Any, _context: Any
 ) -> dict[str, Any]:
-    """Index documents for semantic search via the SearchDaemon's txtai backend.
+    """Index documents for semantic search via the SearchDaemon indexing pipeline.
 
     Single indexing path: reads files via NexusFS, upserts through the daemon's
-    txtai backend which stores embeddings + BM25 tokens in pgvector. No separate
-    document_chunks table needed — txtai is the single source of truth.
+    IndexingPipeline, and persists chunks into the active search stores.
 
     Falls back to the SearchService pipeline if the daemon is unavailable.
     """
@@ -119,9 +118,12 @@ async def handle_semantic_search_index(
     if search is None:
         raise ValueError("SearchService required for semantic search")
 
-    # Prefer single-path indexing through the SearchDaemon's txtai backend.
+    # Prefer single-path indexing through the current SearchDaemon pipeline.
+    # The legacy txtai-era ``_backend`` field was removed when pg_fts/pgvector
+    # became the canonical backend stack; ``_indexing_pipeline`` is now the
+    # readiness signal for explicit RPC indexing.
     daemon = getattr(search, "_search_daemon", None)
-    if daemon is not None and getattr(daemon, "_backend", None) is not None:
+    if daemon is not None and getattr(daemon, "_indexing_pipeline", None) is not None:
         context = _context
         zone_id = getattr(context, "zone_id", None) or "root"
 

--- a/tests/unit/ci/test_build_rust_extensions_action.py
+++ b/tests/unit/ci/test_build_rust_extensions_action.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from pathlib import Path
+
+
+def test_macos_arm64_uses_native_protoc_with_legacy_version_wrapper() -> None:
+    action = Path(".github/actions/build-rust-extensions/action.yml").read_text()
+
+    assert 'macOS-ARM64) USE_GRPC_TOOLS_PROTOC="1"' in action
+    assert 'python -m pip install "grpcio-tools>=1.80,<2"' in action
+    assert "python -m grpc_tools.protoc" in action
+    assert 'echo "libprotoc 3.20.3"' in action
+    assert 'macOS-ARM64) ASSET="protoc-3.20.3-osx-x86_64.zip"' not in action

--- a/tests/unit/server/rpc/handlers/test_semantic_search_index.py
+++ b/tests/unit/server/rpc/handlers/test_semantic_search_index.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import sys
+from types import SimpleNamespace
+from typing import Any
+
+import pytest
+
+from nexus.server.rpc.handlers.filesystem import handle_semantic_search_index
+
+
+class _Rows:
+    def __init__(self, rows: list[tuple[str, str | None]]) -> None:
+        self._rows = rows
+
+    def fetchall(self) -> list[tuple[str, str | None]]:
+        return self._rows
+
+    def fetchone(self) -> tuple[str | None] | None:
+        if not self._rows:
+            return None
+        return (self._rows[0][1],)
+
+
+class _Session:
+    async def __aenter__(self) -> "_Session":
+        return self
+
+    async def __aexit__(self, *args: object) -> None:
+        return None
+
+    async def execute(self, _statement: Any, _params: dict[str, Any]) -> _Rows:
+        return _Rows([("/workspace/demo/herb/products/prod-001.md", "hash-1")])
+
+
+class _Daemon:
+    def __init__(self) -> None:
+        self._indexing_pipeline = object()
+        self._async_session = _Session
+        self.indexed: list[tuple[list[dict[str, Any]], str | None]] = []
+
+    async def index_documents(
+        self, documents: list[dict[str, Any]], *, zone_id: str | None = None
+    ) -> int:
+        self.indexed.append((documents, zone_id))
+        return len(documents)
+
+    async def delete_documents(self, _ids: list[str], *, zone_id: str | None = None) -> int:
+        return 0
+
+
+class _SearchService:
+    def __init__(self, daemon: _Daemon) -> None:
+        self._search_daemon = daemon
+
+    async def ainitialize_semantic_search(self, **_kwargs: Any) -> None:
+        raise AssertionError("current daemon indexing pipeline should be used")
+
+
+class _NexusFs:
+    def __init__(self, search: _SearchService) -> None:
+        self._search = search
+
+    def service(self, name: str) -> _SearchService | None:
+        return self._search if name == "search" else None
+
+    def sys_read(self, _path: str, *, context: Any) -> bytes:
+        assert context.zone_id == "root"
+        return b"Nexus Core SKU catalog details"
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_index_uses_daemon_pipeline_without_legacy_backend(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("nexus.factory._semantic_search._resolve_parse_fn", lambda _nx: None)
+    monkeypatch.setattr(
+        "nexus.factory.adapters._apply_parse_transform_with_status",
+        lambda _nx, _path, raw, *, parse_fn, content_id: (raw.decode(), "plain"),
+    )
+    monkeypatch.setitem(sys.modules, "sqlalchemy", SimpleNamespace(text=lambda sql: sql))
+
+    daemon = _Daemon()
+    result = await handle_semantic_search_index(
+        _NexusFs(_SearchService(daemon)),
+        SimpleNamespace(path="/workspace/demo", recursive=True),
+        SimpleNamespace(zone_id="root"),
+    )
+
+    assert result["total_files"] == 1
+    assert result["total_chunks"] == 1
+    assert daemon.indexed == [
+        (
+            [
+                {
+                    "id": "/workspace/demo/herb/products/prod-001.md",
+                    "text": "Nexus Core SKU catalog details",
+                    "path": "/workspace/demo/herb/products/prod-001.md",
+                }
+            ],
+            "root",
+        )
+    ]


### PR DESCRIPTION
## Summary

Fixes the two develop-branch CI smoke failures by addressing the macOS ARM64 Rust wheel build path and the Docker E2E search-index seeding path.

## What changed

- Updated the Rust extension composite action so macOS ARM64 uses native `grpcio-tools` protoc with a `libprotoc 3.20.3` compatibility wrapper instead of the unavailable/fragile 3.x macOS ARM64 protobuf asset path.
- Updated `handle_semantic_search_index` to detect the current SearchDaemon `_indexing_pipeline` instead of the removed legacy `_backend` field, so explicit RPC indexing uses the active daemon pipeline.
- Added regression coverage for the macOS ARM64 action branch and the daemon-backed semantic search indexing path.

## Root cause

- `raft-proto`'s `protobuf-build` expects a 3-part `libprotoc 3.x.y` version string, while newer protoc releases report post-21 versions that its parser rejects. Protobuf 3.x did not ship a native macOS ARM64 asset.
- The Docker smoke calls `nexus search index /workspace/demo`; that RPC path still checked the old txtai-era daemon `_backend` field after the search stack moved to `_indexing_pipeline`/pg_fts/pgvector.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 /Users/tafeng/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/unit/server/rpc/handlers/test_semantic_search_index.py tests/unit/ci/test_build_rust_extensions_action.py -q --override-ini=addopts=`
- Composite action YAML parse check
- Composite action shell syntax check for macOS ARM64 and Linux X64 substitutions
- Protoc wrapper smoke check
- Commit hooks: YAML, ruff, ruff format, mypy, and repo-specific checks

Docker E2E could not be run locally because this environment has no Docker/Podman/Colima/nerdctl installed.
