### PR TITLE
[codex] Fix search daemon loop ownership

### DIFF
--- a/src/nexus/bricks/search/daemon.py
+++ b/src/nexus/bricks/search/daemon.py
@@ -36,10 +36,11 @@ import json
 import logging
 import os
 import time
+from collections.abc import Awaitable, Callable
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Literal
+from typing import TYPE_CHECKING, Any, Literal, TypeVar
 
 from sqlalchemy import text as sa_text
 
@@ -54,7 +55,8 @@ from nexus.bricks.search.mutation_resolver import MutationResolver, ResolvedMuta
 from nexus.bricks.search.results import BaseSearchResult
 from nexus.contracts.constants import ROOT_ZONE_ID
 from nexus.lib.env import get_database_url
-from nexus.server.zone_execution import run_zone_scoped
+
+T = TypeVar("T")
 
 if TYPE_CHECKING:
     from sqlalchemy.ext.asyncio import AsyncEngine
@@ -251,6 +253,7 @@ class SearchDaemon:
         self._embedding_provider: Any = None
         self._record_store: Any | None = None  # SQLAlchemyRecordStore fallback
         self._owns_engine = False  # True only when we created the engine ourselves
+        self._owner_loop: asyncio.AbstractEventLoop | None = None
 
         # Accept injected session factory from RecordStoreABC
         if async_session_factory is not None:
@@ -699,6 +702,7 @@ class SearchDaemon:
 
         start_time = time.perf_counter()
         logger.info("Starting SearchDaemon - pre-warming indexes...")
+        self._owner_loop = asyncio.get_running_loop()
 
         # Initialize database pool
         await self._init_database_pool()
@@ -940,6 +944,7 @@ class SearchDaemon:
                     )
         self._async_engine = None
         self._async_session = None
+        self._owner_loop = None
 
         # Dispose loop-local path-context engines we created lazily. Only
         # engines whose origin loop is the current running loop can actually
@@ -1511,7 +1516,7 @@ class SearchDaemon:
                 zone_id=zone_id,
             )
 
-        return await run_zone_scoped(getattr(self, "_zone_registry", None), zone_id, _work)
+        return await self._run_on_owner_loop(_work)
 
     async def _search_on_current_loop(
         self,
@@ -1851,7 +1856,7 @@ class SearchDaemon:
         async def _work() -> list[list[Any]]:
             return await self._batch_search_on_current_loop(queries, zone_id=zone_id)
 
-        return await run_zone_scoped(getattr(self, "_zone_registry", None), zone_id, _work)
+        return await self._run_on_owner_loop(_work)
 
     async def _batch_search_on_current_loop(
         self,
@@ -1965,7 +1970,29 @@ class SearchDaemon:
         async def _work() -> int:
             return await self._index_documents_on_current_loop(documents, zone_id=zone_id)
 
-        return await run_zone_scoped(getattr(self, "_zone_registry", None), zone_id, _work)
+        return await self._run_on_owner_loop(_work)
+
+    async def _run_on_owner_loop(self, work: Callable[[], Awaitable[T]]) -> T:
+        """Run DB-backed daemon work on the loop that owns asyncpg resources."""
+        owner_loop = getattr(self, "_owner_loop", None)
+        current_loop = asyncio.get_running_loop()
+        if (
+            owner_loop is None
+            or owner_loop is current_loop
+            or not owner_loop.is_running()
+            or owner_loop.is_closed()
+        ):
+            return await work()
+
+        async def _invoke() -> T:
+            return await work()
+
+        submitted = asyncio.run_coroutine_threadsafe(_invoke(), owner_loop)
+        try:
+            return await asyncio.wrap_future(submitted)
+        except asyncio.CancelledError:
+            submitted.cancel()
+            raise
 
     async def _index_documents_on_current_loop(
         self,

--- a/src/nexus/server/rpc/handlers/filesystem.py
+++ b/src/nexus/server/rpc/handlers/filesystem.py
@@ -7,7 +7,6 @@ All sync handlers are wrapped with ``to_thread_with_timeout`` by the dispatch
 layer — they MUST NOT call async code directly.
 """
 
-import asyncio
 import logging
 from typing import TYPE_CHECKING, Any, cast
 
@@ -124,6 +123,24 @@ async def handle_semantic_search_index(
     # readiness signal for explicit RPC indexing.
     daemon = getattr(search, "_search_daemon", None)
     if daemon is not None and getattr(daemon, "_indexing_pipeline", None) is not None:
+        run_on_owner_loop = getattr(daemon, "_run_on_owner_loop", None)
+        if callable(run_on_owner_loop):
+            import asyncio
+
+            owner_loop = getattr(daemon, "_owner_loop", None)
+            current_loop = asyncio.get_running_loop()
+            if (
+                owner_loop is not None
+                and owner_loop is not current_loop
+                and owner_loop.is_running()
+                and not owner_loop.is_closed()
+            ):
+
+                async def _rerun_on_owner_loop() -> dict[str, Any]:
+                    return await handle_semantic_search_index(nexus_fs, params, _context)
+
+                return cast(dict[str, Any], await run_on_owner_loop(_rerun_on_owner_loop))
+
         context = _context
         zone_id = getattr(context, "zone_id", None) or "root"
 

--- a/tests/unit/bricks/search/test_daemon_zone_runner.py
+++ b/tests/unit/bricks/search/test_daemon_zone_runner.py
@@ -1,6 +1,8 @@
 from __future__ import annotations
 
+import asyncio
 import sys
+import threading
 import types
 from typing import Any
 
@@ -46,3 +48,37 @@ async def test_scope_crud_mutation_stays_on_current_loop(monkeypatch: pytest.Mon
 
     assert result == ("/docs", "ok")
     assert calls == [(daemon, "eng", "/docs")]
+
+
+@pytest.mark.asyncio
+async def test_search_with_zone_stays_on_daemon_owner_loop() -> None:
+    from nexus.bricks.search.daemon import SearchDaemon
+    from nexus.runtime.zone_runner import ZoneRegistry
+
+    daemon = SearchDaemon.__new__(SearchDaemon)
+    daemon._owner_loop = asyncio.get_running_loop()
+    daemon._zone_registry = ZoneRegistry()
+    seen: list[tuple[asyncio.AbstractEventLoop, int, str | None]] = []
+
+    async def fake_search_on_current_loop(
+        query: str,
+        *,
+        search_type: str,
+        limit: int,
+        path_filter: str | None,
+        alpha: float,
+        fusion_method: str,
+        zone_id: str | None,
+    ) -> list[str]:
+        seen.append((asyncio.get_running_loop(), threading.get_ident(), zone_id))
+        return [query, search_type, str(limit), str(path_filter), str(alpha), fusion_method]
+
+    daemon._search_on_current_loop = fake_search_on_current_loop
+
+    try:
+        result = await daemon.search("sku", zone_id="default")
+    finally:
+        daemon._zone_registry.stop_all()
+
+    assert result == ["sku", "hybrid", "10", "None", "0.5", "rrf"]
+    assert seen == [(daemon._owner_loop, threading.get_ident(), "default")]

--- a/tests/unit/server/rpc/handlers/test_semantic_search_index.py
+++ b/tests/unit/server/rpc/handlers/test_semantic_search_index.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import sys
 from types import SimpleNamespace
 from typing import Any
@@ -37,16 +38,27 @@ class _Daemon:
     def __init__(self) -> None:
         self._indexing_pipeline = object()
         self._async_session = _Session
+        self._owner_loop: asyncio.AbstractEventLoop | None = None
         self.indexed: list[tuple[list[dict[str, Any]], str | None]] = []
+        self.index_loops: list[asyncio.AbstractEventLoop] = []
 
     async def index_documents(
         self, documents: list[dict[str, Any]], *, zone_id: str | None = None
     ) -> int:
+        self.index_loops.append(asyncio.get_running_loop())
         self.indexed.append((documents, zone_id))
         return len(documents)
 
     async def delete_documents(self, _ids: list[str], *, zone_id: str | None = None) -> int:
         return 0
+
+    async def _run_on_owner_loop(self, work: Any) -> Any:
+        owner_loop = self._owner_loop
+        current_loop = asyncio.get_running_loop()
+        if owner_loop is None or owner_loop is current_loop:
+            return await work()
+        submitted = asyncio.run_coroutine_threadsafe(work(), owner_loop)
+        return await asyncio.wrap_future(submitted)
 
 
 class _SearchService:
@@ -101,3 +113,36 @@ async def test_semantic_search_index_uses_daemon_pipeline_without_legacy_backend
             "root",
         )
     ]
+
+
+@pytest.mark.asyncio
+async def test_semantic_search_index_runs_daemon_work_on_owner_loop(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    from nexus.runtime.zone_runner import ZoneRunner
+
+    monkeypatch.setattr("nexus.factory._semantic_search._resolve_parse_fn", lambda _nx: None)
+    monkeypatch.setattr(
+        "nexus.factory.adapters._apply_parse_transform_with_status",
+        lambda _nx, _path, raw, *, parse_fn, content_id: (raw.decode(), "plain"),
+    )
+    monkeypatch.setitem(sys.modules, "sqlalchemy", SimpleNamespace(text=lambda sql: sql))
+
+    owner_loop = asyncio.get_running_loop()
+    daemon = _Daemon()
+    daemon._owner_loop = owner_loop
+    runner = ZoneRunner("root")
+
+    try:
+        result = await runner.call(
+            lambda: handle_semantic_search_index(
+                _NexusFs(_SearchService(daemon)),
+                SimpleNamespace(path="/workspace/demo", recursive=True),
+                SimpleNamespace(zone_id="root"),
+            )
+        )
+    finally:
+        runner.stop()
+
+    assert result["total_files"] == 1
+    assert daemon.index_loops == [owner_loop]


### PR DESCRIPTION
## Summary

Follow-up fix for the develop Docker Publish E2E failure after #4113 merged.

The failing job is `Docker Publish / E2E edge smoke tests` in run `25885829806`, job `76078990088`.

## Root cause

The failure moved past the previous build/indexing patch and now fails in `Run build perf e2e` during `nexus search query`. The job log shows repeated errors like:

```text
RuntimeError: Task <Task pending ... ZoneRunner.call ...> got Future <Future pending ...> attached to a different loop
```

The gRPC dispatcher runs zone-scoped RPC work on a `ZoneRunner` event loop, but `SearchDaemon` creates its PostgreSQL asyncpg/SQLAlchemy search backends during daemon startup on the FastAPI owner loop. `semantic_search`, `batch_search`, and explicit `search index` then re-entered the zone runner and touched asyncpg resources from the wrong loop.

The seed step also reported `Files indexed=0`; that path was using the daemon async session inside the RPC index handler before calling `index_documents`, so it was exposed to the same cross-loop ownership problem.

## What changed

- Track the `SearchDaemon` owner event loop at startup.
- Route DB-backed daemon search, batch search, and explicit document indexing back to the daemon owner loop while keeping `zone_id` filtering intact.
- Route the daemon-backed `semantic_search_index` RPC path onto the owner loop before it touches the daemon async session.
- Added regressions proving zone-scoped search and explicit index work stay on the daemon owner loop instead of entering a zone runner with asyncpg resources.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 /Users/tafeng/.cache/codex-runtimes/codex-primary-runtime/dependencies/python/bin/python3 -m pytest tests/unit/bricks/search/test_daemon_zone_runner.py tests/unit/server/rpc/handlers/test_semantic_search_index.py -q --override-ini=addopts=`
- `git diff --check`

Docker E2E was not run locally because this machine still has no Docker/Podman/Colima/nerdctl available.
