### PR TITLE
refactor(kernel): delete /__xattr__/ path intercept — Tier 2 is the formal API

### DIFF
--- a/docs/architecture/KERNEL-ARCHITECTURE.md
+++ b/docs/architecture/KERNEL-ARCHITECTURE.md
@@ -265,6 +265,7 @@ Tier 2 methods compose Tier 1 syscalls — concrete implementations in `NexusFil
 | Half | Examples | Addressing |
 |------|----------|-----------|
 | **VFS half** (POSIX-aligned) | `mkdir()`, `rmdir()`, `read()`, `write()`, `append()`, `edit()`, `write_batch()`, `access()`, `is_directory()`, `lock()`, `locked()`, `glob()`, `grep()`, `service()` | Path-addressed, delegates to `sys_*`. `glob`/`grep` are search-tier convenience (PR #3921), composing `sys_readdir` + filter/regex |
+| **Xattr** (extended attributes) | `get_xattr(path, key)`, `set_xattr(path, key, value)`, `get_xattr_bulk(paths, key)` | Direct metastore `get_file_metadata`/`set_file_metadata` — no hooks, no routing, no permission gate. Rust `KernelConvenience` trait |
 | **HDFS half** (driver-level) | `read_content()`, `write_content()`, `stream()`, `stream_range()`, `write_stream()` | Hash-addressed (etag/CAS), direct to ObjectStoreABC |
 
 The HDFS half bypasses path resolution and metadata lookup — CAS is a driver

--- a/docs/architecture/syscall-design.md
+++ b/docs/architecture/syscall-design.md
@@ -232,6 +232,7 @@ Tier 2 convenience (not kernel syscalls):
 - `access` → Tier 2 (derives from `sys_stat`)
 - `is_directory` → Tier 2 (derives from `sys_stat`)
 - `rmdir` → Tier 2 (delegates to `sys_unlink`)
+- `get_xattr(path, key)` / `set_xattr(path, key, value)` / `get_xattr_bulk(paths, key)` → Tier 2 (Rust `KernelConvenience` trait, direct metastore — no hooks, no permission gate)
 - `glob` → Tier 2 (composes `sys_readdir` + filter). Search-tier logic (PR #3921)
 - `grep` → Tier 2 (composes `sys_readdir` + `sys_read` + regex). Search-tier logic (PR #3921)
 
@@ -470,3 +471,4 @@ collapse is a **refactoring** that changes the boundary, not the logic.
 | §7.3, §7.6 | 2026-04-23 | §7 collapse roadmap fully completed: `_backend_read` deleted, sys_write metadata in Rust, PIPE/STREAM dispatched in Rust, advisory locks in Rust, connectors via gRPC. All "Remaining" items → Done (#1817, #1960). |
 | §6.1 | 2026-04-26 | Rust/Python boundary status: hook dispatch (2+N crossings), service lifecycle (4 crossings, stdlib-only), zero-crossing syscalls, pure Rust pillar dispatch. Eliminated: sys_write IPC pre-check (redundant metadata.get), sys_stat py.import("datetime") → chrono. |
 | §2, §4, §5 | 2026-05-07 | sys_setattr: DT_REG create (upsert) + content_id/size/version/created_at_ms/owner_id params. sys_stat: owner_id in StatResult. sys_write: file-must-exist contract. glob/grep: Tier 2 convenience (search-tier, PR #3921). Tier 1 surface: 8 syscalls (read, write, stat, setattr, unlink, rename, copy, readdir). |
+| §5 | 2026-05-15 | Delete `/__xattr__/` path intercept from sys_read/sys_write — redundant with Tier 2 `get_xattr`/`set_xattr` (KernelConvenience). Document xattr as Tier 2 convenience. |

--- a/rust/contracts/src/constants.rs
+++ b/rust/contracts/src/constants.rs
@@ -56,12 +56,6 @@ pub fn is_system_path(path: &str) -> bool {
     path.starts_with(SYSTEM_PATH_PREFIX)
 }
 
-/// Kernel-reserved virtual path prefix for xattr (extended attribute)
-/// access via syscalls. `sys_read("/__xattr__/{key}/{path}")` reads the
-/// xattr `key` from `path`; `sys_write("/__xattr__/{key}/{path}", value)`
-/// sets it. Routed internally — never hits backends or hooks.
-pub const XATTR_PATH_PREFIX: &str = "/__xattr__/";
-
 /// Kernel-reserved virtual path prefix for advisory lock enumeration.
 /// `readdir("/__sys__/locks")` enumerates active advisory locks via
 /// `LockManager::list_locks` — admin-only, analogous to `/proc/locks`.

--- a/rust/contracts/src/lib.rs
+++ b/rust/contracts/src/lib.rs
@@ -13,7 +13,7 @@ pub mod write_coalescing;
 
 pub use constants::{
     env, is_system_path, BLAKE3_EMPTY, LOCKS_PATH_PREFIX, MAX_GRPC_MESSAGE_BYTES, ROOT_ZONE_ID,
-    SHARE_REGISTRY_PREFIX, SYSTEM_PATH_PREFIX, VFS_ROOT, XATTR_PATH_PREFIX,
+    SHARE_REGISTRY_PREFIX, SYSTEM_PATH_PREFIX, VFS_ROOT,
 };
 pub use lock_state::{
     HolderInfo, LockAcquireResult, LockEntry, LockInfo, LockMode, LockState, Locks,

--- a/rust/kernel/src/kernel/io.rs
+++ b/rust/kernel/src/kernel/io.rs
@@ -298,11 +298,6 @@ impl Kernel {
 
         let _ = self.flush_due_write_buffer();
 
-        // 1a. Xattr virtual path interception: /__xattr__/{key}/{path}
-        if let Some(rest) = path.strip_prefix(contracts::XATTR_PATH_PREFIX) {
-            return self.handle_xattr_read(rest);
-        }
-
         // 1b. Trie-resolved virtual paths (§11 trie resolution)
         if self.trie.lookup(path).is_some() {
             return Err(not_found());
@@ -341,10 +336,6 @@ impl Kernel {
         let not_found = || KernelError::FileNotFound(path.to_string());
 
         validate_path_fast(path)?;
-
-        if let Some(rest) = path.strip_prefix(contracts::XATTR_PATH_PREFIX) {
-            return self.handle_xattr_read(rest);
-        }
 
         if self.trie.lookup(path).is_some() {
             return Err(not_found());
@@ -825,12 +816,6 @@ impl Kernel {
         validate_path_fast(path)?;
 
         let _ = self.flush_due_write_buffer();
-
-        // 1a. Xattr virtual path interception: /__xattr__/{key}/{path}
-        // Short-circuits to metastore set_file_metadata without hooks/routing.
-        if let Some(rest) = path.strip_prefix(contracts::XATTR_PATH_PREFIX) {
-            return self.handle_xattr_write(rest, content);
-        }
 
         // 1b. Trie-resolved virtual paths (§11 trie resolution)
         if self.trie.lookup(path).is_some() {
@@ -3690,87 +3675,6 @@ impl Kernel {
             next_cursor,
             has_more,
         }
-    }
-
-    // ── Xattr virtual path handlers ──────────────────────────────────
-
-    /// Parse `rest` = `"{key}/{actual_path}"` from an `/__xattr__/` read,
-    /// route to the correct per-mount metastore, and return the value.
-    fn handle_xattr_read(&self, rest: &str) -> Result<SysReadResult, KernelError> {
-        let (key, actual_path) = Self::parse_xattr_rest(rest)?;
-        let route = self
-            .vfs_router
-            .route(actual_path, contracts::ROOT_ZONE_ID)
-            .map_err(|_| KernelError::FileNotFound(actual_path.to_string()))?;
-        let value = self
-            .with_metastore_route(&route, |ms| ms.get_file_metadata(actual_path, key))
-            .ok_or_else(|| KernelError::IOError("no metastore wired".into()))?
-            .map_err(|e| {
-                KernelError::IOError(format!("xattr read({actual_path}, {key}): {e:?}"))
-            })?;
-        match value {
-            Some(v) => Ok(SysReadResult {
-                data: Some(v.into_bytes()),
-                post_hook_needed: false,
-                content_id: None,
-                gen: 0,
-                entry_type: DT_REG,
-                stream_next_offset: None,
-            }),
-            None => Err(KernelError::FileNotFound(format!(
-                "xattr {key} not found on {actual_path}"
-            ))),
-        }
-    }
-
-    /// Parse `rest` = `"{key}/{actual_path}"` from an `/__xattr__/` write,
-    /// route to the correct per-mount metastore, and set the value.
-    fn handle_xattr_write(
-        &self,
-        rest: &str,
-        content: &[u8],
-    ) -> Result<SysWriteResult, KernelError> {
-        let (key, actual_path) = Self::parse_xattr_rest(rest)?;
-        let value = std::str::from_utf8(content)
-            .map_err(|e| KernelError::IOError(format!("xattr value not utf-8: {e}")))?
-            .to_string();
-        let route = self
-            .vfs_router
-            .route(actual_path, contracts::ROOT_ZONE_ID)
-            .map_err(|_| KernelError::FileNotFound(actual_path.to_string()))?;
-        self.with_metastore_route(&route, |ms| ms.set_file_metadata(actual_path, key, value))
-            .ok_or_else(|| KernelError::IOError("no metastore wired".into()))?
-            .map_err(|e| {
-                KernelError::IOError(format!("xattr write({actual_path}, {key}): {e:?}"))
-            })?;
-        Ok(SysWriteResult {
-            hit: true,
-            content_id: None,
-            post_hook_needed: false,
-            version: 0,
-            gen: 0,
-            size: content.len() as u64,
-            is_new: false,
-            old_content_id: None,
-            old_size: None,
-            old_version: None,
-            old_modified_at_ms: None,
-        })
-    }
-
-    /// Split `"key/rest/of/path"` into `("key", "/rest/of/path")`.
-    fn parse_xattr_rest(rest: &str) -> Result<(&str, &str), KernelError> {
-        let idx = rest.find('/').ok_or_else(|| {
-            KernelError::InvalidPath("xattr path must be /__xattr__/{key}/{path}".into())
-        })?;
-        let key = &rest[..idx];
-        let actual_path = &rest[idx..]; // includes leading '/'
-        if key.is_empty() || actual_path.len() < 2 {
-            return Err(KernelError::InvalidPath(
-                "xattr path must be /__xattr__/{key}/{path}".into(),
-            ));
-        }
-        Ok((key, actual_path))
     }
 }
 


### PR DESCRIPTION
## Summary

- Delete redundant `/__xattr__/{key}/{path}` inline intercept from `sys_read`/`sys_write`
- Tier 2 `get_xattr`/`set_xattr`/`get_xattr_bulk` (KernelConvenience trait) is the formal API with zero callers using the path encoding
- **5 files changed, 4 insertions, 103 deletions**

### Deleted
- `XATTR_PATH_PREFIX` constant from `contracts/constants.rs`
- `handle_xattr_read`, `handle_xattr_write`, `parse_xattr_rest` from `io.rs`
- 3 `strip_prefix` call sites in `sys_read_single`, `sys_read_content_only`, `sys_write_with_link_depth`

### Updated
- `KERNEL-ARCHITECTURE.md` §2.3: document xattr as Tier 2 convenience
- `syscall-design.md` §5: add xattr to Tier 2 list + changelog entry

## Test plan
- [x] `cargo check -p kernel` — clean
- [x] `cargo test -p kernel --lib` — 435/435 passed
- [x] `grep __xattr__ src/ tests/` — zero callers in Python
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)