### PR TITLE
chore: require kernel team review for all Rust changes

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,5 +1,5 @@
-# Kernel team — auto-assign kernel lead as reviewer.
-# Any PR touching these paths requires elfenlieds7 approval to merge.
+# Kernel team — auto-assign kernel team as reviewer.
+# Any PR touching these paths requires kernel team (@elfenlieds7) approval to merge.
 # GitHub enforces this when "Require review from Code Owners" is enabled
 # in branch protection rules for the develop branch.
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,22 @@
-# Kernel team — auto-assign kernel lead as reviewer
+# Kernel team — auto-assign kernel lead as reviewer.
+# Any PR touching these paths requires elfenlieds7 approval to merge.
+# GitHub enforces this when "Require review from Code Owners" is enabled
+# in branch protection rules for the develop branch.
+
+# Rust crates — ALL Rust code requires kernel team review
+/rust/                    @elfenlieds7
+/Cargo.toml               @elfenlieds7
+/Cargo.lock               @elfenlieds7
+
+# Python kernel boundary
 /src/nexus/core/          @elfenlieds7
 /src/nexus/raft/          @elfenlieds7
 /src/nexus/contracts/     @elfenlieds7
 /src/nexus/lib/           @elfenlieds7
+
+# Codegen + stubs (kernel ABI surface)
+/scripts/codegen_kernel_abi.py  @elfenlieds7
+/stubs/                   @elfenlieds7
+
+# Architecture docs
 /docs/architecture/       @elfenlieds7

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+## Summary
+<!-- 1-3 bullet points -->
+
+## Test plan
+<!-- How was this tested? -->
+
+---
+
+> **Kernel Review Gate**: PRs touching `rust/`, `Cargo.toml`, `Cargo.lock`,
+> `scripts/codegen_kernel_abi.py`, or `stubs/` require **kernel team (@elfenlieds7) approval**
+> before merge (CODEOWNERS enforced). Do NOT add new crates or dependencies
+> to `rust/kernel/` without kernel team design review. Do NOT bypass syscalls
+> by calling ObjectStore/Metastore directly. Read `docs/architecture/KERNEL-ARCHITECTURE.md`.


### PR DESCRIPTION
## Summary

- Expand CODEOWNERS to cover `/rust/`, `/Cargo.toml`, `/Cargo.lock`, `/scripts/codegen_kernel_abi.py`, `/stubs/`
- Branch protection already enabled: `require_code_owner_reviews=true` on develop

Any PR touching Rust code now requires @elfenlieds7 approval before merge.

Motivated by recent boundary violations (PR #4103 nexus-prefetch, PR #4106 write coalescing) where non-kernel devs introduced dependency reversals and driver bypasses.

## Test plan

- [x] No code changes — CODEOWNERS only

🤖 Generated with [Claude Code](https://claude.com/claude-code)