### PR TITLE
[codex] fix sandbox CLI/RPC verification

### DIFF
--- a/src/nexus/cli/commands/status.py
+++ b/src/nexus/cli/commands/status.py
@@ -105,7 +105,7 @@ def _server_health(
                 return result
             # Detailed endpoint may require admin auth — fall back to
             # the public /health endpoint so we still report "healthy".
-            if resp.status_code in (401, 403):
+            if resp.status_code in (401, 403, 404):
                 return public_health(client)
             return {"status": "error", "http_status": resp.status_code}
     except Exception:

--- a/src/nexus/core/nexus_fs.py
+++ b/src/nexus/core/nexus_fs.py
@@ -5,7 +5,7 @@ import builtins
 import contextlib
 import inspect
 import logging
-from collections.abc import Callable
+from collections.abc import Callable, Generator
 from pathlib import Path
 from typing import Any
 
@@ -114,6 +114,14 @@ class NexusFS(  # type: ignore[misc]
     - Content integrity (hash verification)
     - Efficient storage
     """
+
+    def __await__(self) -> Generator[Any, None, "NexusFS"]:
+        """Allow ``await nexus.connect(...)`` compatibility for async callers."""
+
+        async def _identity() -> "NexusFS":
+            return self
+
+        return _identity().__await__()
 
     def __init__(
         self,

--- a/tests/integration/cli/test_cli_quickstart.py
+++ b/tests/integration/cli/test_cli_quickstart.py
@@ -9,22 +9,12 @@ from click.testing import CliRunner
 
 from nexus.cli.commands import LazyCommandGroup, register_all_commands
 from nexus.cli.main import main
-from nexus.raft import zone_manager
 
 
 def test_local_cli_quickstart_persists_across_invocations(
     tmp_path: Path,
-    monkeypatch,
 ) -> None:
     """The local CLI quickstart should work from a source checkout."""
-
-    def _raise_missing_full_build(*args, **kwargs):
-        raise RuntimeError(
-            "ZoneManager requires PyO3 build with --features full. "
-            "Build with: maturin develop -m rust/raft/Cargo.toml --features full"
-        )
-
-    monkeypatch.setattr(zone_manager, "ZoneManager", _raise_missing_full_build)
 
     runner = CliRunner()
     workspace = tmp_path / "cli-demo"

--- a/tests/integration/test_sandbox_boot.py
+++ b/tests/integration/test_sandbox_boot.py
@@ -28,6 +28,7 @@ shared tmp SQLite file across concurrent workers.
 from __future__ import annotations
 
 import time
+from importlib.util import find_spec
 from pathlib import Path
 
 import httpx
@@ -173,17 +174,43 @@ def _resolve_search_service(nx: object) -> object | None:
 
 
 @pytest.mark.asyncio
-async def test_sandbox_default_does_not_instantiate_sqlite_vec_backend(
+async def test_sandbox_default_vector_search_matches_optional_deps(
     tmp_path: Path,
 ) -> None:
-    """SANDBOX default config has enable_vector_search=False, so the
-    optional local sqlite-vec backend must NOT be wired into SearchService.
+    """SANDBOX vector search is default-on when optional deps exist.
+
+    Without the [sandbox] extra, the same boot path must degrade to
+    keyword-only search instead of failing startup.
     """
+    deps_available = find_spec("sqlite_vec") is not None and (
+        find_spec("fastembed") is not None or find_spec("litellm") is not None
+    )
+
     nx = await nexus.connect(config=_sandbox_config(tmp_path))
     try:
         svc = _resolve_search_service(nx)
         assert svc is not None
-        # Default SANDBOX: enable_vector_search=False -> no backend wired.
+        backend = getattr(svc, "_sqlite_vec_backend", None)
+        if deps_available:
+            assert backend is not None
+        else:
+            assert backend is None
+    finally:
+        nx.close()
+
+
+@pytest.mark.asyncio
+async def test_sandbox_vector_search_opt_out_does_not_wire_backend(
+    tmp_path: Path,
+) -> None:
+    """Explicit enable_vector_search=False keeps SANDBOX keyword-only."""
+    cfg = _sandbox_config(tmp_path)
+    cfg["enable_vector_search"] = False
+
+    nx = await nexus.connect(config=cfg)
+    try:
+        svc = _resolve_search_service(nx)
+        assert svc is not None
         assert getattr(svc, "_sqlite_vec_backend", None) is None
     finally:
         nx.close()

--- a/tests/unit/cli/test_json_contract.py
+++ b/tests/unit/cli/test_json_contract.py
@@ -53,13 +53,13 @@ def _has_adhoc_json(cmd: click.Command) -> bool:
 
 # Modules known to use add_output_options
 _UNIFIED_MODULES = [
-    ("nexus.cli.commands.directory", "ls_cmd"),
+    ("nexus.cli.commands.directory", "list_files"),
     ("nexus.cli.commands.directory", "tree"),
     ("nexus.cli.commands.file_ops", "cat"),
-    ("nexus.cli.commands.search", "glob_cmd"),
-    ("nexus.cli.commands.search", "grep_cmd"),
+    ("nexus.cli.commands.search", "glob"),
+    ("nexus.cli.commands.search", "grep"),
     ("nexus.cli.commands.inspect", "info"),
-    ("nexus.cli.commands.zone", "zone_list"),
+    ("nexus.cli.commands.zone", "list_zones_cmd"),
     ("nexus.cli.commands.status", "status"),
     ("nexus.cli.commands.doctor", "doctor"),
     # Q1 sweep — newly migrated modules

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -83,6 +83,29 @@ class TestServerHealth:
         assert result == {"status": "healthy", "service": "nexus-rpc"}
         assert mock_client.get.call_count == 2
 
+    @patch("httpx.Client")
+    def test_falls_back_to_public_health_when_detailed_route_missing(
+        self, mock_client_cls: MagicMock
+    ) -> None:
+        """SANDBOX filters /health/detailed; status should still use /health."""
+        mock_client = MagicMock()
+        detailed_resp = MagicMock(status_code=404)
+        fallback_resp = MagicMock(status_code=200)
+        fallback_resp.json.return_value = {"status": "healthy", "service": "nexus-rpc"}
+        mock_client.get.side_effect = [detailed_resp, fallback_resp]
+        mock_client.__enter__ = lambda s: mock_client
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client_cls.return_value = mock_client
+
+        result = _server_health("http://localhost:2026", api_key="sk-test")
+
+        assert result is not None
+        assert result["status"] == "healthy"
+        assert [call.args[0] for call in mock_client.get.call_args_list] == [
+            "http://localhost:2026/health/detailed",
+            "http://localhost:2026/health",
+        ]
+
 
 # ---------------------------------------------------------------------------
 # _collect_status

--- a/tests/unit/core/test_nexus_fs_awaitable.py
+++ b/tests/unit/core/test_nexus_fs_awaitable.py
@@ -1,0 +1,21 @@
+"""Awaitable compatibility for NexusFS handles."""
+
+from __future__ import annotations
+
+import pytest
+
+from tests.testkit import make_test_nexus
+
+
+@pytest.mark.asyncio
+async def test_nexus_fs_await_returns_self(tmp_path) -> None:
+    """Existing integration paths use ``await nexus.connect(...)``.
+
+    ``nexus.connect`` is synchronous today, but the returned filesystem
+    handle must remain await-compatible so async callers keep working.
+    """
+    nx = make_test_nexus(tmp_path)
+    try:
+        assert await nx is nx
+    finally:
+        nx.close()


### PR DESCRIPTION
## Summary

- Make `NexusFS` await-compatible so existing async call sites using `await nexus.connect(...)` keep working while `nexus.connect()` remains synchronous.
- Refresh sandbox quickstart and boot tests for the current runtime shape: no Python `nexus.raft.zone_manager` shim, SANDBOX vector search default-on when optional deps are installed, and explicit vector-search opt-out coverage.
- Fix `nexus status --url ...` for SANDBOX by falling back from `/health/detailed` to public `/health` when the detailed route is filtered out with 404.
- Update CLI JSON contract symbols to point at live Click command objects.

## Root Cause

The sandbox verification sweep exposed stale test assumptions and one CLI status edge case:

- Integration tests still expected `await nexus.connect(...)` to work even though `nexus.connect()` returns a synchronous `NexusFS` handle.
- The quickstart test imported the deleted Python `ZoneManager` shim even though federation orchestration moved into Rust/kernel/RPC paths.
- The SANDBOX vector-search test still expected default-off, while current config/factory behavior is default-on when `[sandbox]` deps are available.
- `nexus status` treated a SANDBOX-filtered `/health/detailed` 404 as unhealthy instead of falling back to `/health`.

## Validation

- `uv run pytest -rs tests/unit/cli tests/unit/remote tests/unit/daemon/test_sandbox_flags.py tests/unit/daemon/test_sandbox_bootstrap.py tests/unit/core/test_nexus_fs_awaitable.py tests/unit/test_config_sandbox.py tests/unit/test_connect_env_propagation.py tests/integration/test_connect_quickstart.py tests/integration/test_sandbox_boot.py`  
  `994 passed, 1 skipped, 11 warnings`
- `uv run pytest -rs tests/unit/grpc tests/unit/server/test_rpc_admin_only.py tests/unit/server/test_federation_rpc_gating.py tests/unit/server/test_rpc_method_security.py tests/unit/server/test_rpc_parity.py tests/unit/server/rpc tests/unit/server/health tests/unit/server/test_sandbox_route_allowlist.py tests/e2e/self_contained/test_features_endpoint.py`  
  `90 passed, 50 warnings`
- `uv run ruff check src/nexus/core/nexus_fs.py src/nexus/cli/commands/status.py tests/unit/core/test_nexus_fs_awaitable.py tests/integration/test_connect_quickstart.py tests/integration/test_sandbox_boot.py tests/unit/cli/test_json_contract.py tests/unit/cli/test_status.py`  
  `All checks passed`
- Pre-commit on commit: trailing whitespace, EOF, merge conflict, ruff, ruff format, mypy, file-size, type-ignore, brick import, and Rust/codegen skip checks passed.
- Post-commit smoke with absolute uv path: `uv run pytest -rs tests/unit/core/test_nexus_fs_awaitable.py tests/integration/test_connect_quickstart.py tests/unit/cli/test_status.py`  
  `16 passed`

## Remaining Tracked Gaps

- #4147 tracks the remaining CLI JSON contract skip for the missing advertised `memory.query` command.
- #4148 tracks live SANDBOX typed gRPC `Ping` returning `UNAUTHENTICATED` in no-auth mode.

Related: #4126, #4146.
