### PR TITLE
refactor(cluster): nexus-cluster production-ready slimdown + correctness fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1969,8 +1969,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.11.0",
- "simdutf8",
- "simsimd",
  "string-interner",
  "tempfile",
  "tokio",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2012,6 +2012,7 @@ dependencies = [
  "base64",
  "blake3",
  "bloomfilter",
+ "contracts",
  "crc32fast",
  "dashmap",
  "encoding_rs",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2245,7 +2245,6 @@ dependencies = [
  "gethostname",
  "kernel",
  "raft 0.1.0",
- "services",
  "tokio",
  "tonic 0.14.6",
  "tracing",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1945,7 +1945,6 @@ dependencies = [
  "crc32fast",
  "criterion",
  "dashmap",
- "encoding_rs",
  "fastcdc",
  "futures",
  "futures-util",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,75 +3,38 @@
 version = 4
 
 [[package]]
-name = "adler2"
-version = "2.0.1"
+name = "aead"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
-
-[[package]]
-name = "agent-client-protocol"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2af62fb84df2af0f933d8f5fd78b843fa5eb0ec5a48fa1b528c41951d0bbe36c"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
 dependencies = [
- "agent-client-protocol-derive",
- "agent-client-protocol-schema",
- "anyhow",
- "futures",
- "futures-concurrency",
- "jsonrpcmsg",
- "rmcp",
- "rustc-hash",
- "schemars 1.2.1",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
- "uuid",
+ "crypto-common 0.1.7",
+ "generic-array",
 ]
 
 [[package]]
-name = "agent-client-protocol-derive"
-version = "0.11.0"
+name = "aes"
+version = "0.8.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce42c2d3c048c12897eef2e577dfff1e3355c632c9f1625cc953b9df48b44631"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
 dependencies = [
- "proc-macro2",
- "quote",
- "syn",
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
 ]
 
 [[package]]
-name = "agent-client-protocol-schema"
-version = "0.12.0"
+name = "aes-gcm"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "49bae57dad1c28a362fbdcf7bab0583316a02b45a70792109fced55780a3b63c"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
 dependencies = [
- "anyhow",
- "derive_more",
- "schemars 1.2.1",
- "serde",
- "serde_json",
- "serde_with",
- "strum",
- "tracing",
-]
-
-[[package]]
-name = "agent-client-protocol-tokio"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e1572b219f22c4b3be0f20f934c8b6f1d1457126ce72923c4f6608f96153b65"
-dependencies = [
- "agent-client-protocol",
- "futures",
- "serde",
- "serde_json",
- "shell-words",
- "tokio",
- "tokio-util",
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
 ]
 
 [[package]]
@@ -183,20 +146,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
-name = "api"
-version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=7f48278#7f482787dc953da709e346fe68cd12018e33d53b"
-dependencies = [
- "base64",
- "reqwest 0.12.28",
- "runtime",
- "serde",
- "serde_json",
- "telemetry",
- "tokio",
-]
-
-[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -299,7 +248,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
- "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -318,14 +266,11 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -344,7 +289,6 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -363,7 +307,7 @@ dependencies = [
  "futures",
  "futures-util",
  "globset",
- "hmac",
+ "hmac 0.13.0",
  "kernel",
  "lib",
  "libc",
@@ -371,21 +315,20 @@ dependencies = [
  "memchr",
  "memmap2",
  "parking_lot",
- "prost 0.14.3",
- "pyo3",
+ "prost",
  "rayon",
  "rcgen",
  "redb",
  "regex",
- "reqwest 0.13.3",
+ "reqwest",
  "roaring",
  "serde",
  "serde_json",
- "sha2 0.11.0",
+ "sha2",
  "simdutf8",
  "tempfile",
  "tokio",
- "tonic 0.14.6",
+ "tonic",
  "tracing",
  "uuid",
 ]
@@ -574,10 +517,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
- "js-sys",
  "num-traits",
- "serde",
- "wasm-bindgen",
  "windows-link",
 ]
 
@@ -606,6 +546,16 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
+]
+
+[[package]]
+name = "cipher"
+version = "0.4.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
+dependencies = [
+ "crypto-common 0.1.7",
+ "inout",
 ]
 
 [[package]]
@@ -680,16 +630,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "commands"
-version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=7f48278#7f482787dc953da709e346fe68cd12018e33d53b"
-dependencies = [
- "plugins",
- "runtime",
- "serde_json",
-]
-
-[[package]]
 name = "compare"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -733,15 +673,6 @@ version = "0.1.0"
 dependencies = [
  "parking_lot",
  "serde",
-]
-
-[[package]]
-name = "convert_case"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
-dependencies = [
- "unicode-segmentation",
 ]
 
 [[package]]
@@ -870,6 +801,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
+ "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -883,46 +815,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
+]
+
+[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
-]
-
-[[package]]
-name = "darling"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
-dependencies = [
- "darling_core",
- "darling_macro",
-]
-
-[[package]]
-name = "darling_core"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
-dependencies = [
- "ident_case",
- "proc-macro2",
- "quote",
- "strsim",
- "syn",
-]
-
-[[package]]
-name = "darling_macro"
-version = "0.23.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
-dependencies = [
- "darling_core",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -966,30 +873,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
- "serde_core",
-]
-
-[[package]]
-name = "derive_more"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
-dependencies = [
- "derive_more-impl",
-]
-
-[[package]]
-name = "derive_more-impl"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
-dependencies = [
- "convert_case",
- "proc-macro2",
- "quote",
- "rustc_version",
- "syn",
- "unicode-xid",
 ]
 
 [[package]]
@@ -1000,6 +883,7 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
+ "subtle",
 ]
 
 [[package]]
@@ -1030,12 +914,6 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
-name = "dyn-clone"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -1102,15 +980,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
-name = "fdeflate"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
-dependencies = [
- "simd-adler32",
-]
-
-[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1137,16 +1006,6 @@ dependencies = [
  "lz4_flex",
  "tempfile",
  "xxhash-rust",
-]
-
-[[package]]
-name = "flate2"
-version = "1.1.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
 ]
 
 [[package]]
@@ -1217,19 +1076,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "futures-concurrency"
-version = "7.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
-dependencies = [
- "fixedbitset",
- "futures-core",
- "futures-lite",
- "pin-project",
- "smallvec",
-]
-
-[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1251,19 +1097,6 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
 
 [[package]]
 name = "futures-macro"
@@ -1390,10 +1223,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "glob"
-version = "0.3.3"
+name = "ghash"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
+]
 
 [[package]]
 name = "globset"
@@ -1420,7 +1257,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.14.0",
+ "indexmap",
  "slab",
  "tokio",
  "tokio-util",
@@ -1437,12 +1274,6 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
-
-[[package]]
-name = "hashbrown"
-version = "0.12.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1486,10 +1317,13 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hex"
-version = "0.4.3"
+name = "hmac"
+version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest 0.10.7",
+]
 
 [[package]]
 name = "hmac"
@@ -1589,7 +1423,6 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
- "webpki-roots",
 ]
 
 [[package]]
@@ -1622,7 +1455,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2 0.6.3",
+ "socket2",
  "tokio",
  "tower-service",
  "tracing",
@@ -1741,12 +1574,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
-name = "ident_case"
-version = "1.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
-
-[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1768,32 +1595,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "image"
-version = "0.25.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
-dependencies = [
- "bytemuck",
- "byteorder-lite",
- "moxcms",
- "num-traits",
- "png",
- "zune-core",
- "zune-jpeg",
-]
-
-[[package]]
-name = "indexmap"
-version = "1.9.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
-dependencies = [
- "autocfg",
- "hashbrown 0.12.3",
- "serde",
-]
-
-[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1803,6 +1604,15 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
+]
+
+[[package]]
+name = "inout"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
+dependencies = [
+ "generic-array",
 ]
 
 [[package]]
@@ -1922,16 +1732,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonrpcmsg"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d833a15225c779251e13929203518c2ff26e2fe0f322d584b213f4f4dad37bd"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "kernel"
 version = "0.10.0"
 dependencies = [
@@ -1949,7 +1749,7 @@ dependencies = [
  "futures",
  "futures-util",
  "globset",
- "hmac",
+ "hmac 0.13.0",
  "lib",
  "libc",
  "lru",
@@ -1957,36 +1757,25 @@ dependencies = [
  "memmap2",
  "mimalloc",
  "parking_lot",
- "prost 0.14.3",
+ "prost",
  "protoc-bin-vendored",
- "pyo3",
  "rayon",
  "rcgen",
  "redb",
  "regex",
- "reqwest 0.13.3",
+ "reqwest",
  "roaring",
  "serde",
  "serde_json",
- "sha2 0.11.0",
+ "sha2",
  "string-interner",
  "tempfile",
  "tokio",
- "tonic 0.14.6",
+ "tonic",
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
  "uuid",
-]
-
-[[package]]
-name = "keyring"
-version = "3.6.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
-dependencies = [
- "log",
- "zeroize",
 ]
 
 [[package]]
@@ -2008,36 +1797,28 @@ dependencies = [
  "ahash",
  "base64",
  "blake3",
- "bloomfilter",
  "contracts",
  "crc32fast",
  "dashmap",
- "encoding_rs",
  "getrandom 0.4.2",
  "globset",
- "lru",
  "memchr",
- "memmap2",
  "parking_lot",
  "pem",
  "proptest",
- "pyo3",
- "rayon",
  "rcgen",
  "regex",
  "regex-syntax",
  "roaring",
  "serde",
  "serde_json",
- "sha2 0.11.0",
- "simdutf8",
- "simsimd",
+ "sha2",
  "string-interner",
  "tempfile",
  "thiserror 2.0.18",
  "time",
  "tokio",
- "tonic 0.14.6",
+ "tonic",
  "tracing",
 ]
 
@@ -2181,16 +1962,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
-name = "miniz_oxide"
-version = "0.8.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
-dependencies = [
- "adler2",
- "simd-adler32",
-]
-
-[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2202,35 +1973,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "moxcms"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
-dependencies = [
- "num-traits",
- "pxfm",
-]
-
-[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
-
-[[package]]
-name = "nexus-cdylib"
-version = "0.10.0"
-dependencies = [
- "backends",
- "kernel",
- "lib",
- "pyo3",
- "raft 0.1.0",
- "runtime",
- "services",
- "tools",
- "transport",
-]
 
 [[package]]
 name = "nexus-cluster"
@@ -2244,23 +1990,23 @@ dependencies = [
  "kernel",
  "raft 0.1.0",
  "tokio",
- "tonic 0.14.6",
+ "tonic",
  "tracing",
  "tracing-subscriber",
  "transport",
 ]
 
 [[package]]
-name = "nexus-vfs-client"
-version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=7f48278#7f482787dc953da709e346fe68cd12018e33d53b"
+name = "nexus-vault"
+version = "0.1.0"
 dependencies = [
- "prost 0.13.5",
- "protoc-bin-vendored",
- "serde_json",
+ "anyhow",
+ "clap",
+ "services",
  "tokio",
- "tonic 0.13.1",
- "tonic-build 0.13.1",
+ "tonic",
+ "tracing",
+ "tracing-subscriber",
 ]
 
 [[package]]
@@ -2344,6 +2090,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
+
+[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2358,12 +2110,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2389,12 +2135,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pastey"
-version = "0.2.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
-
-[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2412,23 +2152,13 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
-dependencies = [
- "fixedbitset",
- "indexmap 2.14.0",
-]
-
-[[package]]
-name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
 ]
 
 [[package]]
@@ -2486,32 +2216,16 @@ dependencies = [
 ]
 
 [[package]]
-name = "plugins"
-version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=7f48278#7f482787dc953da709e346fe68cd12018e33d53b"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "png"
-version = "0.18.1"
+name = "polyval"
+version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
 dependencies = [
- "bitflags 2.11.1",
- "crc32fast",
- "fdeflate",
- "flate2",
- "miniz_oxide",
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
 ]
-
-[[package]]
-name = "portable-atomic"
-version = "1.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -2599,42 +2313,12 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
-dependencies = [
- "bytes",
- "prost-derive 0.13.5",
-]
-
-[[package]]
-name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive 0.14.3",
-]
-
-[[package]]
-name = "prost-build"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
-dependencies = [
- "heck",
- "itertools 0.14.0",
- "log",
- "multimap",
- "once_cell",
- "petgraph 0.7.1",
- "prettyplease",
- "prost 0.13.5",
- "prost-types 0.13.5",
- "regex",
- "syn",
- "tempfile",
+ "prost-derive",
 ]
 
 [[package]]
@@ -2647,28 +2331,15 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "multimap",
- "petgraph 0.8.3",
+ "petgraph",
  "prettyplease",
- "prost 0.14.3",
- "prost-types 0.14.3",
+ "prost",
+ "prost-types",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
  "syn",
  "tempfile",
-]
-
-[[package]]
-name = "prost-derive"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
-dependencies = [
- "anyhow",
- "itertools 0.14.0",
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -2686,20 +2357,11 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
-dependencies = [
- "prost 0.13.5",
-]
-
-[[package]]
-name = "prost-types"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost 0.14.3",
+ "prost",
 ]
 
 [[package]]
@@ -2817,71 +2479,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "pxfm"
-version = "0.1.29"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
-
-[[package]]
-name = "pyo3"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
-dependencies = [
- "hashbrown 0.16.1",
- "libc",
- "once_cell",
- "portable-atomic",
- "pyo3-build-config",
- "pyo3-ffi",
- "pyo3-macros",
-]
-
-[[package]]
-name = "pyo3-build-config"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
-dependencies = [
- "target-lexicon",
-]
-
-[[package]]
-name = "pyo3-ffi"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
-dependencies = [
- "libc",
- "pyo3-build-config",
-]
-
-[[package]]
-name = "pyo3-macros"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
-dependencies = [
- "proc-macro2",
- "pyo3-macros-backend",
- "quote",
- "syn",
-]
-
-[[package]]
-name = "pyo3-macros-backend"
-version = "0.28.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
-dependencies = [
- "heck",
- "proc-macro2",
- "pyo3-build-config",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2910,7 +2507,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2 0.6.3",
+ "socket2",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2948,7 +2545,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2 0.6.3",
+ "socket2",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2989,24 +2586,23 @@ dependencies = [
  "mimalloc",
  "parking_lot",
  "pem",
- "prost 0.14.3",
+ "prost",
  "protobuf",
  "protoc-bin-vendored",
- "pyo3",
  "raft 0.7.0",
  "rand 0.10.1",
  "rcgen",
  "redb",
  "serde",
  "serde_json",
- "sha2 0.11.0",
+ "sha2",
  "slog",
  "tempfile",
  "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-test",
- "tonic 0.14.6",
+ "tonic",
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
@@ -3178,26 +2774,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ref-cast"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
-dependencies = [
- "ref-cast-impl",
-]
-
-[[package]]
-name = "ref-cast-impl"
-version = "1.0.25"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3225,46 +2801,6 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
-
-[[package]]
-name = "reqwest"
-version = "0.12.28"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
-dependencies = [
- "base64",
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "js-sys",
- "log",
- "percent-encoding",
- "pin-project-lite",
- "quinn",
- "rustls",
- "rustls-pki-types",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper",
- "tokio",
- "tokio-rustls",
- "tower",
- "tower-http",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "webpki-roots",
-]
 
 [[package]]
 name = "reqwest"
@@ -3321,41 +2857,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rmcp"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
-dependencies = [
- "async-trait",
- "base64",
- "chrono",
- "futures",
- "pastey",
- "pin-project-lite",
- "rmcp-macros",
- "schemars 1.2.1",
- "serde",
- "serde_json",
- "thiserror 2.0.18",
- "tokio",
- "tokio-util",
- "tracing",
-]
-
-[[package]]
-name = "rmcp-macros"
-version = "1.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "serde_json",
- "syn",
-]
-
-[[package]]
 name = "roaring"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3363,34 +2864,6 @@ checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
-]
-
-[[package]]
-name = "runtime"
-version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=7f48278#7f482787dc953da709e346fe68cd12018e33d53b"
-dependencies = [
- "agent-client-protocol",
- "agent-client-protocol-schema",
- "agent-client-protocol-tokio",
- "async-trait",
- "axum",
- "base64",
- "futures",
- "glob",
- "image",
- "kernel",
- "keyring",
- "nexus-vfs-client",
- "plugins",
- "regex",
- "serde",
- "serde_json",
- "sha2 0.10.9",
- "telemetry",
- "tokio",
- "tower-http",
- "walkdir",
 ]
 
 [[package]]
@@ -3550,44 +3023,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "schemars"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
-dependencies = [
- "chrono",
- "dyn-clone",
- "ref-cast",
- "schemars_derive",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars_derive"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde_derive_internals",
- "syn",
-]
-
-[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3659,17 +3094,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_derive_internals"
-version = "0.29.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3706,40 +3130,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "serde_with"
-version = "3.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
-dependencies = [
- "base64",
- "chrono",
- "hex",
- "indexmap 1.9.3",
- "indexmap 2.14.0",
- "schemars 0.9.0",
- "schemars 1.2.1",
- "serde_core",
- "serde_json",
- "serde_with_macros",
- "time",
-]
-
-[[package]]
-name = "serde_with_macros"
-version = "3.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
-dependencies = [
- "darling",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "services"
 version = "0.1.0"
 dependencies = [
+ "aes-gcm",
  "async-trait",
  "axum",
  "base32",
@@ -3749,16 +3143,23 @@ dependencies = [
  "dashmap",
  "fjall",
  "futures",
+ "hmac 0.12.1",
  "kernel",
  "libc",
  "parking_lot",
- "pyo3",
+ "prost",
+ "prost-types",
+ "protoc-bin-vendored",
  "redb",
  "serde",
  "serde_json",
+ "sha1",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
+ "tonic",
+ "tonic-prost",
+ "tonic-prost-build",
  "tower",
  "tracing",
  "uuid",
@@ -3788,17 +3189,6 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
-dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
@@ -3818,12 +3208,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "shell-words"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
-
-[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3840,12 +3224,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "simd-adler32"
-version = "0.3.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
-
-[[package]]
 name = "simd_cesu8"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3860,15 +3238,6 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
-
-[[package]]
-name = "simsimd"
-version = "6.5.16"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f4fb3bc3cdce07a7d7d4caa4c54f8aa967f6be41690482b54b24100a2253fa70"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "siphasher"
@@ -3899,16 +3268,6 @@ name = "smallvec"
 version = "1.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
-
-[[package]]
-name = "socket2"
-version = "0.5.10"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
-dependencies = [
- "libc",
- "windows-sys 0.52.0",
-]
 
 [[package]]
 name = "socket2"
@@ -3952,27 +3311,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
-name = "strum"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
-dependencies = [
- "strum_macros",
-]
-
-[[package]]
-name = "strum_macros"
-version = "0.28.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
-dependencies = [
- "heck",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4007,21 +3345,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
-]
-
-[[package]]
-name = "target-lexicon"
-version = "0.13.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
-
-[[package]]
-name = "telemetry"
-version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=7f48278#7f482787dc953da709e346fe68cd12018e33d53b"
-dependencies = [
- "serde",
- "serde_json",
 ]
 
 [[package]]
@@ -4170,10 +3493,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
- "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2 0.6.3",
+ "socket2",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -4222,18 +3544,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tokio-tungstenite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
-dependencies = [
- "futures-util",
- "log",
- "tokio",
- "tungstenite",
-]
-
-[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4241,39 +3551,9 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
- "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
-]
-
-[[package]]
-name = "tonic"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
-dependencies = [
- "async-trait",
- "axum",
- "base64",
- "bytes",
- "h2",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-timeout",
- "hyper-util",
- "percent-encoding",
- "pin-project",
- "prost 0.13.5",
- "socket2 0.5.10",
- "tokio",
- "tokio-stream",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
 ]
 
 [[package]]
@@ -4295,7 +3575,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2 0.6.3",
+ "socket2",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -4304,20 +3584,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "tonic-build"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
-dependencies = [
- "prettyplease",
- "proc-macro2",
- "prost-build 0.13.5",
- "prost-types 0.13.5",
- "quote",
- "syn",
 ]
 
 [[package]]
@@ -4339,8 +3605,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
- "prost 0.14.3",
- "tonic 0.14.6",
+ "prost",
+ "tonic",
 ]
 
 [[package]]
@@ -4351,30 +3617,12 @@ checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build 0.14.3",
- "prost-types 0.14.3",
+ "prost-build",
+ "prost-types",
  "quote",
  "syn",
  "tempfile",
- "tonic-build 0.14.6",
-]
-
-[[package]]
-name = "tools"
-version = "0.1.4"
-source = "git+https://github.com/sudoprivacy/sudocode?rev=7f48278#7f482787dc953da709e346fe68cd12018e33d53b"
-dependencies = [
- "api",
- "async-trait",
- "commands",
- "flate2",
- "futures",
- "plugins",
- "reqwest 0.12.28",
- "runtime",
- "serde",
- "serde_json",
- "tokio",
+ "tonic-build",
 ]
 
 [[package]]
@@ -4385,7 +3633,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.14.0",
+ "indexmap",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -4432,7 +3680,6 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -4492,6 +3739,8 @@ dependencies = [
 name = "transport"
 version = "0.1.0"
 dependencies = [
+ "backends",
+ "base64",
  "chrono",
  "contracts",
  "dashmap",
@@ -4499,17 +3748,16 @@ dependencies = [
  "kernel",
  "lib",
  "parking_lot",
- "prost 0.14.3",
- "pyo3",
+ "prost",
  "raft 0.1.0",
  "rcgen",
  "serde",
  "serde_json",
- "sha2 0.11.0",
+ "sha2",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tonic 0.14.6",
+ "tonic",
  "tracing",
  "uuid",
 ]
@@ -4519,22 +3767,6 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
-
-[[package]]
-name = "tungstenite"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
-dependencies = [
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.9.4",
- "sha1",
- "thiserror 2.0.18",
-]
 
 [[package]]
 name = "twox-hash"
@@ -4567,16 +3799,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.7",
+ "subtle",
+]
 
 [[package]]
 name = "untrusted"
@@ -4761,7 +3997,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap 2.14.0",
+ "indexmap",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4787,7 +4023,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap 2.14.0",
+ "indexmap",
  "semver",
 ]
 
@@ -4816,15 +4052,6 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
-dependencies = [
- "rustls-pki-types",
-]
-
-[[package]]
-name = "webpki-roots"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -5109,7 +4336,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap 2.14.0",
+ "indexmap",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -5140,7 +4367,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "serde",
  "serde_derive",
@@ -5159,7 +4386,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap 2.14.0",
+ "indexmap",
  "log",
  "semver",
  "serde",
@@ -5316,18 +4543,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zune-core"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
-
-[[package]]
-name = "zune-jpeg"
-version = "0.5.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
-dependencies = [
- "zune-core",
-]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,38 +3,75 @@
 version = 4
 
 [[package]]
-name = "aead"
-version = "0.5.2"
+name = "adler2"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+
+[[package]]
+name = "agent-client-protocol"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af62fb84df2af0f933d8f5fd78b843fa5eb0ec5a48fa1b528c41951d0bbe36c"
 dependencies = [
- "crypto-common 0.1.7",
- "generic-array",
+ "agent-client-protocol-derive",
+ "agent-client-protocol-schema",
+ "anyhow",
+ "futures",
+ "futures-concurrency",
+ "jsonrpcmsg",
+ "rmcp",
+ "rustc-hash",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "uuid",
 ]
 
 [[package]]
-name = "aes"
-version = "0.8.4"
+name = "agent-client-protocol-derive"
+version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+checksum = "ce42c2d3c048c12897eef2e577dfff1e3355c632c9f1625cc953b9df48b44631"
 dependencies = [
- "cfg-if",
- "cipher",
- "cpufeatures 0.2.17",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
-name = "aes-gcm"
-version = "0.10.3"
+name = "agent-client-protocol-schema"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+checksum = "49bae57dad1c28a362fbdcf7bab0583316a02b45a70792109fced55780a3b63c"
 dependencies = [
- "aead",
- "aes",
- "cipher",
- "ctr",
- "ghash",
- "subtle",
+ "anyhow",
+ "derive_more",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "serde_with",
+ "strum",
+ "tracing",
+]
+
+[[package]]
+name = "agent-client-protocol-tokio"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e1572b219f22c4b3be0f20f934c8b6f1d1457126ce72923c4f6608f96153b65"
+dependencies = [
+ "agent-client-protocol",
+ "futures",
+ "serde",
+ "serde_json",
+ "shell-words",
+ "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -146,6 +183,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f202df86484c868dbad7eaa557ef785d5c66295e41b460ef922eca0723b842c"
 
 [[package]]
+name = "api"
+version = "0.1.4"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=7f48278#7f482787dc953da709e346fe68cd12018e33d53b"
+dependencies = [
+ "base64",
+ "reqwest 0.12.28",
+ "runtime",
+ "serde",
+ "serde_json",
+ "telemetry",
+ "tokio",
+]
+
+[[package]]
 name = "arrayref"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,6 +299,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "31b698c5f9a010f6573133b09e0de5408834d0c82f8d7475a89fc1867a71cd90"
 dependencies = [
  "axum-core",
+ "base64",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -266,11 +318,14 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -289,6 +344,7 @@ dependencies = [
  "sync_wrapper",
  "tower-layer",
  "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -307,7 +363,7 @@ dependencies = [
  "futures",
  "futures-util",
  "globset",
- "hmac 0.13.0",
+ "hmac",
  "kernel",
  "lib",
  "libc",
@@ -315,20 +371,21 @@ dependencies = [
  "memchr",
  "memmap2",
  "parking_lot",
- "prost",
+ "prost 0.14.3",
+ "pyo3",
  "rayon",
  "rcgen",
  "redb",
  "regex",
- "reqwest",
+ "reqwest 0.13.3",
  "roaring",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "simdutf8",
  "tempfile",
  "tokio",
- "tonic",
+ "tonic 0.14.6",
  "tracing",
  "uuid",
 ]
@@ -517,7 +574,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c673075a2e0e5f4a1dde27ce9dee1ea4558c7ffe648f576438a20ca1d2acc4b0"
 dependencies = [
  "iana-time-zone",
+ "js-sys",
  "num-traits",
+ "serde",
+ "wasm-bindgen",
  "windows-link",
 ]
 
@@ -546,16 +606,6 @@ checksum = "57663b653d948a338bfb3eeba9bb2fd5fcfaecb9e199e87e1eda4d9e8b240fd9"
 dependencies = [
  "ciborium-io",
  "half",
-]
-
-[[package]]
-name = "cipher"
-version = "0.4.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "773f3b9af64447d2ce9850330c473515014aa235e6a783b02db81ff39e4a3dad"
-dependencies = [
- "crypto-common 0.1.7",
- "inout",
 ]
 
 [[package]]
@@ -630,6 +680,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "commands"
+version = "0.1.4"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=7f48278#7f482787dc953da709e346fe68cd12018e33d53b"
+dependencies = [
+ "plugins",
+ "runtime",
+ "serde_json",
+]
+
+[[package]]
 name = "compare"
 version = "0.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -673,6 +733,15 @@ version = "0.1.0"
 dependencies = [
  "parking_lot",
  "serde",
+]
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
 ]
 
 [[package]]
@@ -801,7 +870,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
 dependencies = [
  "generic-array",
- "rand_core 0.6.4",
  "typenum",
 ]
 
@@ -815,21 +883,46 @@ dependencies = [
 ]
 
 [[package]]
-name = "ctr"
-version = "0.9.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
-dependencies = [
- "cipher",
-]
-
-[[package]]
 name = "ctutils"
 version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7d5515a3834141de9eafb9717ad39eea8247b5674e6066c404e8c4b365d2a29e"
 dependencies = [
  "cmov",
+]
+
+[[package]]
+name = "darling"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "25ae13da2f202d56bd7f91c25fba009e7717a1e4a1cc98a76d844b65ae912e9d"
+dependencies = [
+ "darling_core",
+ "darling_macro",
+]
+
+[[package]]
+name = "darling_core"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9865a50f7c335f53564bb694ef660825eb8610e0a53d3e11bf1b0d3df31e03b0"
+dependencies = [
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim",
+ "syn",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac3984ec7bd6cfa798e62b4a642426a5be0e68f9401cfc2a01e3fa9ea2fcdb8d"
+dependencies = [
+ "darling_core",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -873,6 +966,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
 dependencies = [
  "powerfmt",
+ "serde_core",
+]
+
+[[package]]
+name = "derive_more"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d751e9e49156b02b44f9c1815bcb94b984cdcc4396ecc32521c739452808b134"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "2.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
+dependencies = [
+ "convert_case",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -883,7 +1000,6 @@ checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer 0.10.4",
  "crypto-common 0.1.7",
- "subtle",
 ]
 
 [[package]]
@@ -914,6 +1030,12 @@ name = "dunce"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
+
+[[package]]
+name = "dyn-clone"
+version = "1.0.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
 name = "either"
@@ -980,6 +1102,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "fdeflate"
+version = "0.3.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e6853b52649d4ac5c0bd02320cddc5ba956bdb407c4b75a2c6b75bf51500f8c"
+dependencies = [
+ "simd-adler32",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1006,6 +1137,16 @@ dependencies = [
  "lz4_flex",
  "tempfile",
  "xxhash-rust",
+]
+
+[[package]]
+name = "flate2"
+version = "1.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+dependencies = [
+ "crc32fast",
+ "miniz_oxide",
 ]
 
 [[package]]
@@ -1076,6 +1217,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-concurrency"
+version = "7.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175cd8cca9e1d45b87f18ffa75088f2099e3c4fe5e2f83e42de112560bea8ea6"
+dependencies = [
+ "fixedbitset",
+ "futures-core",
+ "futures-lite",
+ "pin-project",
+ "smallvec",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1097,6 +1251,19 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -1223,14 +1390,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "ghash"
-version = "0.5.1"
+name = "glob"
+version = "0.3.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
-dependencies = [
- "opaque-debug",
- "polyval",
-]
+checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
 name = "globset"
@@ -1257,7 +1420,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap",
+ "indexmap 2.14.0",
  "slab",
  "tokio",
  "tokio-util",
@@ -1274,6 +1437,12 @@ dependencies = [
  "crunchy",
  "zerocopy",
 ]
+
+[[package]]
+name = "hashbrown"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
@@ -1317,13 +1486,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
-name = "hmac"
-version = "0.12.1"
+name = "hex"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
-dependencies = [
- "digest 0.10.7",
-]
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
@@ -1423,6 +1589,7 @@ dependencies = [
  "tokio",
  "tokio-rustls",
  "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -1455,7 +1622,7 @@ dependencies = [
  "libc",
  "percent-encoding",
  "pin-project-lite",
- "socket2",
+ "socket2 0.6.3",
  "tokio",
  "tower-service",
  "tracing",
@@ -1574,6 +1741,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3d3067d79b975e8844ca9eb072e16b31c3c1c36928edf9c6789548c524d0d954"
 
 [[package]]
+name = "ident_case"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1595,6 +1768,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "image"
+version = "0.25.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85ab80394333c02fe689eaf900ab500fbd0c2213da414687ebf995a65d5a6104"
+dependencies = [
+ "bytemuck",
+ "byteorder-lite",
+ "moxcms",
+ "num-traits",
+ "png",
+ "zune-core",
+ "zune-jpeg",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.9.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
+dependencies = [
+ "autocfg",
+ "hashbrown 0.12.3",
+ "serde",
+]
+
+[[package]]
 name = "indexmap"
 version = "2.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1604,15 +1803,6 @@ dependencies = [
  "hashbrown 0.17.1",
  "serde",
  "serde_core",
-]
-
-[[package]]
-name = "inout"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "879f10e63c20629ecabbb64a8010319738c66a5cd0c29b02d63d272b03751d01"
-dependencies = [
- "generic-array",
 ]
 
 [[package]]
@@ -1732,6 +1922,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonrpcmsg"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d833a15225c779251e13929203518c2ff26e2fe0f322d584b213f4f4dad37bd"
+dependencies = [
+ "serde",
+ "serde_json",
+]
+
+[[package]]
 name = "kernel"
 version = "0.10.0"
 dependencies = [
@@ -1750,7 +1950,7 @@ dependencies = [
  "futures",
  "futures-util",
  "globset",
- "hmac 0.13.0",
+ "hmac",
  "lib",
  "libc",
  "lru",
@@ -1758,27 +1958,38 @@ dependencies = [
  "memmap2",
  "mimalloc",
  "parking_lot",
- "prost",
+ "prost 0.14.3",
  "protoc-bin-vendored",
+ "pyo3",
  "rayon",
  "rcgen",
  "redb",
  "regex",
- "reqwest",
+ "reqwest 0.13.3",
  "roaring",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "simdutf8",
  "simsimd",
  "string-interner",
  "tempfile",
  "tokio",
- "tonic",
+ "tonic 0.14.6",
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
  "uuid",
+]
+
+[[package]]
+name = "keyring"
+version = "3.6.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eebcc3aff044e5944a8fbaf69eb277d11986064cba30c468730e8b9909fb551c"
+dependencies = [
+ "log",
+ "zeroize",
 ]
 
 [[package]]
@@ -1800,27 +2011,35 @@ dependencies = [
  "ahash",
  "base64",
  "blake3",
+ "bloomfilter",
  "crc32fast",
  "dashmap",
+ "encoding_rs",
  "getrandom 0.4.2",
  "globset",
+ "lru",
  "memchr",
+ "memmap2",
  "parking_lot",
  "pem",
  "proptest",
+ "pyo3",
+ "rayon",
  "rcgen",
  "regex",
  "regex-syntax",
  "roaring",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
+ "simdutf8",
+ "simsimd",
  "string-interner",
  "tempfile",
  "thiserror 2.0.18",
  "time",
  "tokio",
- "tonic",
+ "tonic 0.14.6",
  "tracing",
 ]
 
@@ -1964,6 +2183,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
+name = "miniz_oxide"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+dependencies = [
+ "adler2",
+ "simd-adler32",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1975,10 +2204,35 @@ dependencies = [
 ]
 
 [[package]]
+name = "moxcms"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb85c154ba489f01b25c0d36ae69a87e4a1c73a72631fc6c0eb6dde34a73e44b"
+dependencies = [
+ "num-traits",
+ "pxfm",
+]
+
+[[package]]
 name = "multimap"
 version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+
+[[package]]
+name = "nexus-cdylib"
+version = "0.10.0"
+dependencies = [
+ "backends",
+ "kernel",
+ "lib",
+ "pyo3",
+ "raft 0.1.0",
+ "runtime",
+ "services",
+ "tools",
+ "transport",
+]
 
 [[package]]
 name = "nexus-cluster"
@@ -1993,23 +2247,23 @@ dependencies = [
  "raft 0.1.0",
  "services",
  "tokio",
- "tonic",
+ "tonic 0.14.6",
  "tracing",
  "tracing-subscriber",
  "transport",
 ]
 
 [[package]]
-name = "nexus-vault"
-version = "0.1.0"
+name = "nexus-vfs-client"
+version = "0.1.4"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=7f48278#7f482787dc953da709e346fe68cd12018e33d53b"
 dependencies = [
- "anyhow",
- "clap",
- "services",
+ "prost 0.13.5",
+ "protoc-bin-vendored",
+ "serde_json",
  "tokio",
- "tonic",
- "tracing",
- "tracing-subscriber",
+ "tonic 0.13.1",
+ "tonic-build 0.13.1",
 ]
 
 [[package]]
@@ -2093,12 +2347,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
 
 [[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
-
-[[package]]
 name = "openssl-probe"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2113,6 +2361,12 @@ dependencies = [
  "libc",
  "winapi",
 ]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -2138,6 +2392,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "pastey"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c5a797f0e07bdf071d15742978fc3128ec6c22891c31a3a931513263904c982a"
+
+[[package]]
 name = "pem"
 version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2155,13 +2415,23 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+dependencies = [
+ "fixedbitset",
+ "indexmap 2.14.0",
+]
+
+[[package]]
+name = "petgraph"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
 ]
 
 [[package]]
@@ -2219,16 +2489,32 @@ dependencies = [
 ]
 
 [[package]]
-name = "polyval"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+name = "plugins"
+version = "0.1.4"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=7f48278#7f482787dc953da709e346fe68cd12018e33d53b"
 dependencies = [
- "cfg-if",
- "cpufeatures 0.2.17",
- "opaque-debug",
- "universal-hash",
+ "serde",
+ "serde_json",
 ]
+
+[[package]]
+name = "png"
+version = "0.18.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60769b8b31b2a9f263dae2776c37b1b28ae246943cf719eb6946a1db05128a61"
+dependencies = [
+ "bitflags 2.11.1",
+ "crc32fast",
+ "fdeflate",
+ "flate2",
+ "miniz_oxide",
+]
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "potential_utf"
@@ -2316,12 +2602,42 @@ dependencies = [
 
 [[package]]
 name = "prost"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+dependencies = [
+ "bytes",
+ "prost-derive 0.13.5",
+]
+
+[[package]]
+name = "prost"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2ea70524a2f82d518bce41317d0fae74151505651af45faf1ffbd6fd33f0568"
 dependencies = [
  "bytes",
- "prost-derive",
+ "prost-derive 0.14.3",
+]
+
+[[package]]
+name = "prost-build"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+dependencies = [
+ "heck",
+ "itertools 0.14.0",
+ "log",
+ "multimap",
+ "once_cell",
+ "petgraph 0.7.1",
+ "prettyplease",
+ "prost 0.13.5",
+ "prost-types 0.13.5",
+ "regex",
+ "syn",
+ "tempfile",
 ]
 
 [[package]]
@@ -2334,15 +2650,28 @@ dependencies = [
  "itertools 0.14.0",
  "log",
  "multimap",
- "petgraph",
+ "petgraph 0.8.3",
  "prettyplease",
- "prost",
- "prost-types",
+ "prost 0.14.3",
+ "prost-types 0.14.3",
  "pulldown-cmark",
  "pulldown-cmark-to-cmark",
  "regex",
  "syn",
  "tempfile",
+]
+
+[[package]]
+name = "prost-derive"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+dependencies = [
+ "anyhow",
+ "itertools 0.14.0",
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -2360,11 +2689,20 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+dependencies = [
+ "prost 0.13.5",
+]
+
+[[package]]
+name = "prost-types"
 version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8991c4cbdb8bc5b11f0b074ffe286c30e523de90fee5ba8132f1399f23cb3dd7"
 dependencies = [
- "prost",
+ "prost 0.14.3",
 ]
 
 [[package]]
@@ -2482,6 +2820,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "pxfm"
+version = "0.1.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0c5ccf5294c6ccd63a74f1565028353830a9c2f5eb0c682c355c471726a6e3f"
+
+[[package]]
+name = "pyo3"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
+dependencies = [
+ "hashbrown 0.16.1",
+ "libc",
+ "once_cell",
+ "portable-atomic",
+ "pyo3-build-config",
+ "pyo3-ffi",
+ "pyo3-macros",
+]
+
+[[package]]
+name = "pyo3-build-config"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
+dependencies = [
+ "target-lexicon",
+]
+
+[[package]]
+name = "pyo3-ffi"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
+dependencies = [
+ "libc",
+ "pyo3-build-config",
+]
+
+[[package]]
+name = "pyo3-macros"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
+dependencies = [
+ "proc-macro2",
+ "pyo3-macros-backend",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "pyo3-macros-backend"
+version = "0.28.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "pyo3-build-config",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "quick-error"
 version = "1.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2510,7 +2913,7 @@ dependencies = [
  "quinn-udp",
  "rustc-hash",
  "rustls",
- "socket2",
+ "socket2 0.6.3",
  "thiserror 2.0.18",
  "tokio",
  "tracing",
@@ -2548,7 +2951,7 @@ dependencies = [
  "cfg_aliases",
  "libc",
  "once_cell",
- "socket2",
+ "socket2 0.6.3",
  "tracing",
  "windows-sys 0.60.2",
 ]
@@ -2589,23 +2992,24 @@ dependencies = [
  "mimalloc",
  "parking_lot",
  "pem",
- "prost",
+ "prost 0.14.3",
  "protobuf",
  "protoc-bin-vendored",
+ "pyo3",
  "raft 0.7.0",
  "rand 0.10.1",
  "rcgen",
  "redb",
  "serde",
  "serde_json",
- "sha2",
+ "sha2 0.11.0",
  "slog",
  "tempfile",
  "thiserror 2.0.18",
  "time",
  "tokio",
  "tokio-test",
- "tonic",
+ "tonic 0.14.6",
  "tonic-prost",
  "tonic-prost-build",
  "tracing",
@@ -2777,6 +3181,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2804,6 +3228,46 @@ name = "regex-syntax"
 version = "0.8.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
+
+[[package]]
+name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64",
+ "bytes",
+ "futures-channel",
+ "futures-core",
+ "futures-util",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
 
 [[package]]
 name = "reqwest"
@@ -2860,6 +3324,41 @@ dependencies = [
 ]
 
 [[package]]
+name = "rmcp"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e12ca9067b5ebfbd5b3fcdc4acfceb81aa7d5ab2a879dff7cb75d22434276aad"
+dependencies = [
+ "async-trait",
+ "base64",
+ "chrono",
+ "futures",
+ "pastey",
+ "pin-project-lite",
+ "rmcp-macros",
+ "schemars 1.2.1",
+ "serde",
+ "serde_json",
+ "thiserror 2.0.18",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
+name = "rmcp-macros"
+version = "1.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7caa6743cc0888e433105fe1bc551a7f607940b126a37bc97b478e86064627eb"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "serde_json",
+ "syn",
+]
+
+[[package]]
 name = "roaring"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2867,6 +3366,34 @@ checksum = "1dedc5658c6ecb3bdb5ef5f3295bb9253f42dcf3fd1402c03f6b1f7659c3c4a9"
 dependencies = [
  "bytemuck",
  "byteorder",
+]
+
+[[package]]
+name = "runtime"
+version = "0.1.4"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=7f48278#7f482787dc953da709e346fe68cd12018e33d53b"
+dependencies = [
+ "agent-client-protocol",
+ "agent-client-protocol-schema",
+ "agent-client-protocol-tokio",
+ "async-trait",
+ "axum",
+ "base64",
+ "futures",
+ "glob",
+ "image",
+ "kernel",
+ "keyring",
+ "nexus-vfs-client",
+ "plugins",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha2 0.10.9",
+ "telemetry",
+ "tokio",
+ "tower-http",
+ "walkdir",
 ]
 
 [[package]]
@@ -3026,6 +3553,44 @@ dependencies = [
 ]
 
 [[package]]
+name = "schemars"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "chrono",
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn",
+]
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3097,6 +3662,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_derive_internals"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "serde_json"
 version = "1.0.149"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3133,10 +3709,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "serde_with"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f05839ce67618e14a09b286535c0d9c94e85ef25469b0e13cb4f844e5593eb19"
+dependencies = [
+ "base64",
+ "chrono",
+ "hex",
+ "indexmap 1.9.3",
+ "indexmap 2.14.0",
+ "schemars 0.9.0",
+ "schemars 1.2.1",
+ "serde_core",
+ "serde_json",
+ "serde_with_macros",
+ "time",
+]
+
+[[package]]
+name = "serde_with_macros"
+version = "3.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cf2ebbe86054f9b45bc3881e865683ccfaccce97b9b4cb53f3039d67f355a334"
+dependencies = [
+ "darling",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "services"
 version = "0.1.0"
 dependencies = [
- "aes-gcm",
  "async-trait",
  "axum",
  "base32",
@@ -3146,23 +3752,16 @@ dependencies = [
  "dashmap",
  "fjall",
  "futures",
- "hmac 0.12.1",
  "kernel",
  "libc",
  "parking_lot",
- "prost",
- "prost-types",
- "protoc-bin-vendored",
+ "pyo3",
  "redb",
  "serde",
  "serde_json",
- "sha1",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tonic",
- "tonic-prost",
- "tonic-prost-build",
  "tower",
  "tracing",
  "uuid",
@@ -3192,6 +3791,17 @@ dependencies = [
 
 [[package]]
 name = "sha2"
+version = "0.10.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "digest 0.10.7",
+]
+
+[[package]]
+name = "sha2"
 version = "0.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "446ba717509524cb3f22f17ecc096f10f4822d76ab5c0b9822c5f9c284e825f4"
@@ -3211,6 +3821,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shell-words"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc6fe69c597f9c37bfeeeeeb33da3530379845f10be461a66d16d03eca2ded77"
+
+[[package]]
 name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3225,6 +3841,12 @@ dependencies = [
  "errno",
  "libc",
 ]
+
+[[package]]
+name = "simd-adler32"
+version = "0.3.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
 
 [[package]]
 name = "simd_cesu8"
@@ -3283,6 +3905,16 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3a766e1110788c36f4fa1c2b71b387a7815aa65f88ce0229841826633d93723e"
@@ -3323,6 +3955,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
 name = "subtle"
 version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3357,6 +4010,21 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn",
+]
+
+[[package]]
+name = "target-lexicon"
+version = "0.13.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
+
+[[package]]
+name = "telemetry"
+version = "0.1.4"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=7f48278#7f482787dc953da709e346fe68cd12018e33d53b"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -3505,9 +4173,10 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.3",
  "tokio-macros",
  "windows-sys 0.61.2",
 ]
@@ -3556,6 +4225,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite",
+]
+
+[[package]]
 name = "tokio-util"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3563,9 +4244,39 @@ checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
 dependencies = [
  "bytes",
  "futures-core",
+ "futures-io",
  "futures-sink",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "tonic"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e581ba15a835f4d9ea06c55ab1bd4dce26fc53752c69a04aac00703bfb49ba9"
+dependencies = [
+ "async-trait",
+ "axum",
+ "base64",
+ "bytes",
+ "h2",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-timeout",
+ "hyper-util",
+ "percent-encoding",
+ "pin-project",
+ "prost 0.13.5",
+ "socket2 0.5.10",
+ "tokio",
+ "tokio-stream",
+ "tower",
+ "tower-layer",
+ "tower-service",
+ "tracing",
 ]
 
 [[package]]
@@ -3587,7 +4298,7 @@ dependencies = [
  "hyper-util",
  "percent-encoding",
  "pin-project",
- "socket2",
+ "socket2 0.6.3",
  "sync_wrapper",
  "tokio",
  "tokio-rustls",
@@ -3596,6 +4307,20 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tonic-build"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eac6f67be712d12f0b41328db3137e0d0757645d8904b4cb7d51cd9c2279e847"
+dependencies = [
+ "prettyplease",
+ "proc-macro2",
+ "prost-build 0.13.5",
+ "prost-types 0.13.5",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -3617,8 +4342,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "50849f68853be452acf590cde0b146665b8d507b3b8af17261df47e02c209ea0"
 dependencies = [
  "bytes",
- "prost",
- "tonic",
+ "prost 0.14.3",
+ "tonic 0.14.6",
 ]
 
 [[package]]
@@ -3629,12 +4354,30 @@ checksum = "654e5643eff75d7f8c99197ce1440ed19a3474eada74c12bbac488b2cafdae27"
 dependencies = [
  "prettyplease",
  "proc-macro2",
- "prost-build",
- "prost-types",
+ "prost-build 0.14.3",
+ "prost-types 0.14.3",
  "quote",
  "syn",
  "tempfile",
- "tonic-build",
+ "tonic-build 0.14.6",
+]
+
+[[package]]
+name = "tools"
+version = "0.1.4"
+source = "git+https://github.com/sudoprivacy/sudocode?rev=7f48278#7f482787dc953da709e346fe68cd12018e33d53b"
+dependencies = [
+ "api",
+ "async-trait",
+ "commands",
+ "flate2",
+ "futures",
+ "plugins",
+ "reqwest 0.12.28",
+ "runtime",
+ "serde",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -3645,7 +4388,7 @@ checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap",
+ "indexmap 2.14.0",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -3692,6 +4435,7 @@ version = "0.1.44"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
+ "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -3751,8 +4495,6 @@ dependencies = [
 name = "transport"
 version = "0.1.0"
 dependencies = [
- "backends",
- "base64",
  "chrono",
  "contracts",
  "dashmap",
@@ -3760,17 +4502,17 @@ dependencies = [
  "kernel",
  "lib",
  "parking_lot",
- "prost",
+ "prost 0.14.3",
+ "pyo3",
  "raft 0.1.0",
  "rcgen",
  "serde",
  "serde_json",
- "services",
- "sha2",
+ "sha2 0.11.0",
  "tempfile",
  "thiserror 2.0.18",
  "tokio",
- "tonic",
+ "tonic 0.14.6",
  "tracing",
  "uuid",
 ]
@@ -3780,6 +4522,22 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.4",
+ "sha1",
+ "thiserror 2.0.18",
+]
 
 [[package]]
 name = "twox-hash"
@@ -3812,20 +4570,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6e4313cd5fcd3dad5cafa179702e2b244f760991f45397d14d4ebf38247da75"
 
 [[package]]
+name = "unicode-segmentation"
+version = "1.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9629274872b2bfaf8d66f5f15725007f635594914870f65218920345aa11aa8c"
+
+[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
-
-[[package]]
-name = "universal-hash"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
-dependencies = [
- "crypto-common 0.1.7",
- "subtle",
-]
 
 [[package]]
 name = "untrusted"
@@ -4010,7 +4764,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bb0e353e6a2fbdc176932bbaab493762eb1255a7900fe0fea1a2f96c296cc909"
 dependencies = [
  "anyhow",
- "indexmap",
+ "indexmap 2.14.0",
  "wasm-encoder",
  "wasmparser",
 ]
@@ -4036,7 +4790,7 @@ checksum = "47b807c72e1bac69382b3a6fb3dbe8ea4c0ed87ff5629b8685ae6b9a611028fe"
 dependencies = [
  "bitflags 2.11.1",
  "hashbrown 0.15.5",
- "indexmap",
+ "indexmap 2.14.0",
  "semver",
 ]
 
@@ -4065,6 +4819,15 @@ name = "webpki-root-certs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f31141ce3fc3e300ae89b78c0dd67f9708061d1d2eda54b8209346fd6be9a92c"
+dependencies = [
+ "rustls-pki-types",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -4349,7 +5112,7 @@ checksum = "b7c566e0f4b284dd6561c786d9cb0142da491f46a9fbed79ea69cdad5db17f21"
 dependencies = [
  "anyhow",
  "heck",
- "indexmap",
+ "indexmap 2.14.0",
  "prettyplease",
  "syn",
  "wasm-metadata",
@@ -4380,7 +5143,7 @@ checksum = "9d66ea20e9553b30172b5e831994e35fbde2d165325bec84fc43dbf6f4eb9cb2"
 dependencies = [
  "anyhow",
  "bitflags 2.11.1",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "serde",
  "serde_derive",
@@ -4399,7 +5162,7 @@ checksum = "ecc8ac4bc1dc3381b7f59c34f00b67e18f910c2c0f50015669dde7def656a736"
 dependencies = [
  "anyhow",
  "id-arena",
- "indexmap",
+ "indexmap 2.14.0",
  "log",
  "semver",
  "serde",
@@ -4556,3 +5319,18 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zune-core"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb8a0807f7c01457d0379ba880ba6322660448ddebc890ce29bb64da71fb40f9"
+
+[[package]]
+name = "zune-jpeg"
+version = "0.5.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27bc9d5b815bc103f142aa054f561d9187d191692ec7c2d1e2b4737f8dbd7296"
+dependencies = [
+ "zune-core",
+]

--- a/rust/contracts/src/constants.rs
+++ b/rust/contracts/src/constants.rs
@@ -109,3 +109,39 @@ pub mod env {
 /// mirror (`nexus.contracts.constants.MAX_GRPC_MESSAGE_BYTES`) and
 /// this constant in lockstep.
 pub const MAX_GRPC_MESSAGE_BYTES: usize = 64 * 1024 * 1024;
+
+// ── gRPC server hardening defaults ─────────────────────────────────
+//
+// Conservative production defaults shared by every tonic gRPC server
+// nexus runs (raft transport, witness, VFS). Sized for federation
+// traffic patterns: dozens of concurrent peer streams + intermittent
+// VFS client RPCs. Tune via runtime config when a workload demands
+// otherwise; the defaults stay here to keep ad-hoc Server::builder
+// sites from drifting apart.
+
+/// Maximum concurrent HTTP/2 streams the server will accept per
+/// connection. 1024 is comfortably above any expected per-peer
+/// concurrency (raft heartbeat / append / snapshot share one
+/// connection per peer); cap exists to fail closed under runaway
+/// stream creation rather than exhausting the server allocator.
+pub const GRPC_MAX_CONCURRENT_STREAMS: u32 = 1024;
+
+/// HTTP/2 keepalive ping interval. Servers send a PING every
+/// `GRPC_HTTP2_KEEPALIVE_INTERVAL_SECS` so an idle TCP connection
+/// dropped by an intermediate NAT / load balancer is detected
+/// quickly instead of hanging until the next RPC. 30s matches the
+/// gRPC default-server recommendation.
+pub const GRPC_HTTP2_KEEPALIVE_INTERVAL_SECS: u64 = 30;
+
+/// HTTP/2 keepalive PING ack deadline. If no PONG arrives within
+/// `GRPC_HTTP2_KEEPALIVE_TIMEOUT_SECS` of the PING, the connection
+/// is considered dead and torn down. 10s gives a slow peer one
+/// full retry window without holding a half-dead connection open
+/// indefinitely.
+pub const GRPC_HTTP2_KEEPALIVE_TIMEOUT_SECS: u64 = 10;
+
+/// TCP-level keepalive on each accepted connection (sent at the
+/// kernel socket layer). Catches half-open connections the HTTP/2
+/// layer can't reach (e.g. when the peer process disappears
+/// silently without RST). 60s aligns with common Linux defaults.
+pub const GRPC_TCP_KEEPALIVE_SECS: u64 = 60;

--- a/rust/kernel/Cargo.toml
+++ b/rust/kernel/Cargo.toml
@@ -20,7 +20,6 @@ blake3 = { workspace = true }
 fastcdc = { workspace = true }
 string-interner = { workspace = true }
 roaring = { workspace = true }
-encoding_rs = "0.8.35"
 rayon = "1.11"
 bloomfilter = "3.0"
 libc = "0.2"

--- a/rust/kernel/Cargo.toml
+++ b/rust/kernel/Cargo.toml
@@ -30,8 +30,6 @@ parking_lot = "0.12"
 redb = "4"
 uuid = { version = "1", features = ["v4"] }
 lru = "0.18"
-simdutf8 = "0.1"
-simsimd = "6"
 crc32fast = { workspace = true }
 tonic = { workspace = true }
 prost = { workspace = true }

--- a/rust/kernel/src/kernel/convenience.rs
+++ b/rust/kernel/src/kernel/convenience.rs
@@ -8,12 +8,17 @@
 //! overrides with optimized direct paths where the composition
 //! overhead matters.
 
+use std::any::Any;
+use std::sync::Arc;
+
 use super::{
     Kernel, KernelError, OperationContext, StatResult, SysMkdirResult, SysReadResult,
-    SysRmdirResult, SysUnlinkResult, SysWriteResult,
+    SysRmdirResult, SysSetAttrResult, SysUnlinkResult, SysWriteResult,
 };
+use crate::abc::object_store::ObjectStore;
 use crate::abi::KernelAbi;
-use crate::meta_store::{DT_EXTERNAL_STORAGE, DT_MOUNT};
+use crate::meta_store::{MetaStore, DT_EXTERNAL_STORAGE, DT_MOUNT};
+use crate::ROOT_ZONE_ID;
 
 // ── KernelConvenience trait ──────────────────────────────────────────
 
@@ -64,6 +69,43 @@ pub trait KernelConvenience: KernelAbi {
         recursive: bool,
     ) -> Result<SysUnlinkResult, KernelError> {
         self.sys_unlink(path, ctx, recursive)
+    }
+
+    /// Tier 2 mount — composes `sys_setattr(DT_MOUNT, …)`.
+    ///
+    /// Replaces the 21-positional-argument `sys_setattr` call shape
+    /// (most positions are forced to `None`/`0` for DT_MOUNT) with a
+    /// builder-style [`MountOptions`]. Every parameter that is
+    /// definitionally inert for `DT_MOUNT` (capacity, FDs, mime,
+    /// content_id, modified_at_ms, version, created_at_ms,
+    /// link_target) is fixed at its no-op default here, leaving the
+    /// caller to specify only mount-relevant fields. Behaviour is
+    /// bit-identical to the equivalent `sys_setattr(DT_MOUNT, …)`
+    /// call.
+    fn mount(&self, path: &str, opts: MountOptions<'_>) -> Result<SysSetAttrResult, KernelError> {
+        self.sys_setattr(
+            path,
+            DT_MOUNT as i32,
+            opts.backend_name,
+            opts.backend,
+            opts.metastore,
+            opts.raft_backend,
+            opts.io_profile,
+            opts.zone_id,
+            opts.is_external,
+            0,    // capacity (DT_PIPE / DT_STREAM only)
+            None, // read_fd
+            None, // write_fd
+            None, // mime_type
+            None, // modified_at_ms
+            None, // content_id
+            None, // size
+            None, // version
+            None, // created_at_ms
+            None, // link_target (DT_LINK only)
+            opts.source,
+            opts.remote_metastore,
+        )
     }
 
     /// Tier 2 single-file read — composes `sys_read`.
@@ -175,6 +217,122 @@ pub trait KernelConvenience: KernelAbi {
             .into_iter()
             .map(|opt| opt.is_some())
             .collect()
+    }
+}
+
+// ── MountOptions ─────────────────────────────────────────────────────
+
+/// Builder-style parameters for [`KernelConvenience::mount`].
+///
+/// Carries the DT_MOUNT-relevant subset of `sys_setattr` arguments
+/// in a single value so callers do not thread 21 positional args
+/// (most of which are `None` for DT_MOUNT) through every mount
+/// site. Field semantics match `sys_setattr`'s DT_MOUNT branch
+/// 1-for-1; this struct is purely a call-site ergonomics wrapper
+/// and adds no kernel surface.
+///
+/// Construct via [`MountOptions::new`] and chain `with_*` setters
+/// for the fields that differ from the kernel-default
+/// owning-local-mount template.
+///
+/// ```ignore
+/// use std::sync::Arc;
+/// use kernel::kernel::convenience::{KernelConvenience, MountOptions};
+/// kernel.mount(
+///     "/scratch",
+///     MountOptions::new("local").with_backend(backend),
+/// )?;
+/// ```
+pub struct MountOptions<'a> {
+    backend_name: &'a str,
+    backend: Option<Arc<dyn ObjectStore>>,
+    metastore: Option<Arc<dyn MetaStore>>,
+    raft_backend: Option<Box<dyn Any + Send + Sync>>,
+    io_profile: &'a str,
+    zone_id: &'a str,
+    is_external: bool,
+    source: Option<&'a str>,
+    remote_metastore: Option<Arc<dyn MetaStore>>,
+}
+
+impl<'a> MountOptions<'a> {
+    /// Owning-local-mount template carrying `backend_name` (driver
+    /// label, e.g. `"local"`, `"memory"`, `"s3"`).
+    ///
+    /// Defaults: no backend handle, no metastore handle, no raft
+    /// backend, `"memory"` io_profile, root zone, not external,
+    /// no federation source, no remote metastore. Override the
+    /// fields that differ via the chainable `with_*` setters.
+    pub fn new(backend_name: &'a str) -> Self {
+        Self {
+            backend_name,
+            backend: None,
+            metastore: None,
+            raft_backend: None,
+            io_profile: "memory",
+            zone_id: ROOT_ZONE_ID,
+            is_external: false,
+            source: None,
+            remote_metastore: None,
+        }
+    }
+
+    /// Attach an owning `ObjectStore` (required for owning mounts;
+    /// federation join-mode mounts leave this unset).
+    pub fn with_backend(mut self, backend: Arc<dyn ObjectStore>) -> Self {
+        self.backend = Some(backend);
+        self
+    }
+
+    /// Attach a per-mount metastore. Default = the kernel's global
+    /// metastore handles this mount.
+    pub fn with_metastore(mut self, metastore: Arc<dyn MetaStore>) -> Self {
+        self.metastore = Some(metastore);
+        self
+    }
+
+    /// Attach a raft backend handle (federation use only). Erased
+    /// to `Box<dyn Any>` to keep the kernel crate free of raft
+    /// types.
+    pub fn with_raft_backend(mut self, raft_backend: Box<dyn Any + Send + Sync>) -> Self {
+        self.raft_backend = Some(raft_backend);
+        self
+    }
+
+    /// Override the io_profile label. Default = `"memory"`.
+    pub fn with_io_profile(mut self, io_profile: &'a str) -> Self {
+        self.io_profile = io_profile;
+        self
+    }
+
+    /// Override the zone id. Default = `ROOT_ZONE_ID` (`"root"`).
+    pub fn with_zone(mut self, zone_id: &'a str) -> Self {
+        self.zone_id = zone_id;
+        self
+    }
+
+    /// Mark this mount as external storage (DT_EXTERNAL_STORAGE
+    /// semantics).
+    pub fn external(mut self) -> Self {
+        self.is_external = true;
+        self
+    }
+
+    /// Mark this as a federation join-mode mount with the given
+    /// leader address (`host:port`). The mount entry then points
+    /// at a remote zone rather than creating one locally.
+    pub fn with_source(mut self, source: &'a str) -> Self {
+        self.source = Some(source);
+        self
+    }
+
+    /// Attach a remote metastore (federation: produced by the
+    /// object-store provider when the backend is remote). Installed
+    /// on the VFS route entry so remote reads resolve through the
+    /// correct metastore.
+    pub fn with_remote_metastore(mut self, remote_metastore: Arc<dyn MetaStore>) -> Self {
+        self.remote_metastore = Some(remote_metastore);
+        self
     }
 }
 

--- a/rust/lib/Cargo.toml
+++ b/rust/lib/Cargo.toml
@@ -26,6 +26,11 @@ transport = [
 ]
 
 [dependencies]
+# Constants SSOT — pulled unconditionally because the crate is
+# zero-dep-cost (only `pub const` definitions). transport_primitives
+# uses it for the gRPC server-hardening defaults; other modules may
+# reach for it as the constants set grows.
+contracts = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 ahash = { workspace = true }

--- a/rust/lib/src/transport_primitives/mod.rs
+++ b/rust/lib/src/transport_primitives/mod.rs
@@ -13,6 +13,7 @@ mod error;
 mod peer;
 mod peer_blob_client;
 mod pool;
+mod server_limits;
 mod tofu;
 
 pub use channel::create_channel;
@@ -21,4 +22,5 @@ pub use error::{Result, TransportError};
 pub use peer::{hostname_to_node_id, NodeAddress, PeerAddress};
 pub use peer_blob_client::{NoopPeerBlobClient, PeerBlobClient, PeerBlobResult};
 pub use pool::ConnectionPool;
+pub use server_limits::apply_server_limits;
 pub use tofu::{TofuError, TofuResult, TofuTrustStore, TrustedZone};

--- a/rust/lib/src/transport_primitives/server_limits.rs
+++ b/rust/lib/src/transport_primitives/server_limits.rs
@@ -1,0 +1,36 @@
+//! Hardening defaults for every tonic gRPC server in nexus.
+//!
+//! Centralizes the production-sane settings — max-concurrent-streams,
+//! HTTP/2 keepalive, TCP keepalive — so individual Server::builder
+//! sites in raft / transport don't drift apart. Source values live in
+//! `contracts::constants`; this module only translates them into the
+//! tonic builder API.
+
+use std::time::Duration;
+
+use contracts::constants::{
+    GRPC_HTTP2_KEEPALIVE_INTERVAL_SECS, GRPC_HTTP2_KEEPALIVE_TIMEOUT_SECS,
+    GRPC_MAX_CONCURRENT_STREAMS, GRPC_TCP_KEEPALIVE_SECS,
+};
+use tonic::transport::Server;
+
+/// Apply nexus's standard gRPC server hardening to a fresh
+/// `tonic::transport::Server::builder()`. Returns the same builder so
+/// callers can chain TLS / extra-services / `.add_service(...)` on top.
+///
+/// Sets:
+///   * `max_concurrent_streams`     — cap per-connection HTTP/2 streams
+///   * `http2_keepalive_interval`   — server PING cadence
+///   * `http2_keepalive_timeout`    — PING ack deadline
+///   * `tcp_keepalive`              — socket-level dead-peer detection
+pub fn apply_server_limits(builder: Server) -> Server {
+    builder
+        .max_concurrent_streams(Some(GRPC_MAX_CONCURRENT_STREAMS))
+        .http2_keepalive_interval(Some(Duration::from_secs(
+            GRPC_HTTP2_KEEPALIVE_INTERVAL_SECS,
+        )))
+        .http2_keepalive_timeout(Some(Duration::from_secs(
+            GRPC_HTTP2_KEEPALIVE_TIMEOUT_SECS,
+        )))
+        .tcp_keepalive(Some(Duration::from_secs(GRPC_TCP_KEEPALIVE_SECS)))
+}

--- a/rust/profiles/cluster/Cargo.toml
+++ b/rust/profiles/cluster/Cargo.toml
@@ -23,11 +23,11 @@ contracts = { workspace = true }
 # HTTP stack so the binary stays at the sudowork target size.
 kernel = { workspace = true }
 backends = { workspace = true, default-features = false, features = ["driver-path-local", "driver-remote"] }
-# VFS gRPC server — pure Rust content I/O on a separate port.
-# No python feature — cluster binary has zero PyO3.
+# VFS gRPC server (port 2028) + auth provider (NoAuth — mTLS is the
+# cluster-internal authentication boundary). No python feature;
+# cluster binary has zero PyO3 and never pulls the services
+# post-syscall-hooks tier.
 transport = { workspace = true }
-# Auth provider for VFS gRPC (NoAuth — mTLS is the boundary).
-services = { workspace = true }
 
 tonic = { workspace = true }
 anyhow = "1"

--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -418,7 +418,7 @@ async fn run_daemon(common: CommonArgs) -> Result<()> {
 
     // Build VFS gRPC service as tonic Routes — co-hosted on the raft
     // port via ZoneManager. Uses NoAuth (mTLS is the boundary).
-    let vfs_auth: Arc<dyn services::auth::AuthProvider> = Arc::new(services::auth::NoAuth);
+    let vfs_auth: Arc<dyn transport::auth::AuthProvider> = Arc::new(transport::auth::NoAuth);
     let vfs_routes = transport::grpc::build_vfs_routes(
         Arc::clone(&kernel),
         vfs_auth,

--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -25,8 +25,8 @@ use backends::storage::path_local::PathLocalBackend;
 use clap::{Parser, Subcommand};
 use kernel::abc::object_store::ObjectStore;
 use kernel::abi::KernelAbi;
+use kernel::kernel::convenience::{KernelConvenience, MountOptions};
 use kernel::kernel::Kernel;
-use kernel::meta_store::DT_MOUNT;
 
 use nexus_raft::distributed_coordinator::{
     bootstrap_or_join_zone, read_or_mint_node_id, validate_bootstrap_mode,
@@ -387,29 +387,7 @@ async fn run_daemon(common: CommonArgs) -> Result<()> {
             .with_context(|| format!("PathLocalBackend init at {}", root_fs.display()))?,
     );
     kernel
-        .sys_setattr(
-            "/",
-            DT_MOUNT as i32,
-            "local",
-            Some(backend),
-            None,
-            None,
-            "memory",
-            contracts::ROOT_ZONE_ID,
-            false,
-            0,
-            None,
-            None,
-            None, // mime_type
-            None, // modified_at_ms
-            None, // content_id
-            None, // size
-            None, // version
-            None, // created_at_ms
-            None, // link_target
-            None, // source
-            None, // remote_metastore
-        )
+        .mount("/", MountOptions::new("local").with_backend(backend))
         .map_err(|e| anyhow::anyhow!("mount / via path_local: {:?}", e))?;
     tracing::info!(
         root_fs = %root_fs.display(),
@@ -601,28 +579,11 @@ fn run_mount(
         local_root.ok_or_else(|| anyhow::anyhow!("--root is required for driver `{driver}`"))?;
     let backend = build_local_backend(driver, root)?;
     kernel
-        .sys_setattr(
+        .mount(
             mount_point,
-            DT_MOUNT as i32,
-            backend_name,
-            Some(backend),
-            None,
-            None,
-            "memory",
-            zone,
-            false,
-            0,
-            None, // read_fd
-            None, // write_fd
-            None, // mime_type
-            None, // modified_at_ms
-            None, // content_id
-            None, // size
-            None, // version
-            None, // created_at_ms
-            None, // link_target
-            None, // source
-            None, // remote_metastore
+            MountOptions::new(backend_name)
+                .with_backend(backend)
+                .with_zone(zone),
         )
         .map_err(|e| anyhow::anyhow!("mount {mount_point}: {:?}", e))?;
     println!(

--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -143,33 +143,50 @@ enum Cmd {
     },
 }
 
-#[tokio::main(flavor = "multi_thread", worker_threads = 2)]
-async fn main() -> Result<()> {
+fn main() -> Result<()> {
     install_tracing();
     let args = Args::parse();
-    match args.cmd {
-        None => run_daemon(args.common).await,
-        Some(Cmd::Share {
-            path,
-            zone_id,
-            parent_zone,
-        }) => run_share(args.common, &parent_zone, &path, &zone_id).await,
-        Some(Cmd::Join {
-            peer_addr,
-            remote_zone_id,
-            local_path,
-            parent_zone,
-        }) => {
-            run_join(
-                args.common,
-                &peer_addr,
-                &remote_zone_id,
-                &local_path,
-                &parent_zone,
-            )
-            .await
-        }
-    }
+    // Size the multi-thread runtime against the host: federation
+    // gRPC + raft IO is IO-bound, so the kernel `available_parallelism`
+    // estimate (logical cores under cgroup / affinity constraints) is
+    // the right target. Falls back to 2 — the previous hard-coded
+    // worker count — when the platform can't report a value (e.g.
+    // bare-metal probes that aren't WASI-style sandboxed but lack
+    // `_SC_NPROCESSORS_ONLN`).
+    let workers = std::thread::available_parallelism()
+        .map(std::num::NonZeroUsize::get)
+        .unwrap_or(2);
+    tokio::runtime::Builder::new_multi_thread()
+        .worker_threads(workers)
+        .enable_all()
+        .thread_name("nexusd-cluster")
+        .build()
+        .context("build tokio runtime")?
+        .block_on(async move {
+            match args.cmd {
+                None => run_daemon(args.common).await,
+                Some(Cmd::Share {
+                    path,
+                    zone_id,
+                    parent_zone,
+                }) => run_share(args.common, &parent_zone, &path, &zone_id).await,
+                Some(Cmd::Join {
+                    peer_addr,
+                    remote_zone_id,
+                    local_path,
+                    parent_zone,
+                }) => {
+                    run_join(
+                        args.common,
+                        &peer_addr,
+                        &remote_zone_id,
+                        &local_path,
+                        &parent_zone,
+                    )
+                    .await
+                }
+            }
+        })
 }
 
 /// Bundle returned by [`open_zone_manager`].  Carries the opaque

--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -462,8 +462,38 @@ async fn run_daemon(common: CommonArgs) -> Result<()> {
     });
 
     wait_for_shutdown().await;
-    topology_handle.abort();
     tracing::info!("nexusd-cluster shutting down");
+
+    // Stop the convergence loop first — it's a best-effort reconciler,
+    // safe to abort mid-tick.
+    topology_handle.abort();
+
+    // Drain ZoneManager: signal gRPC + zone transport loops to exit
+    // their serve_with_shutdown paths so in-flight raft messages drain
+    // cleanly. ZoneManager::shutdown() is synchronous and uses an
+    // internal bridge_block_on; call it from spawn_blocking so we
+    // don't trigger "Cannot drop a runtime" / nested-runtime panics.
+    //
+    // 10s cap matches typical k8s preStop / SIGTERM grace windows —
+    // if tonic hasn't finished draining by then, force-drop and exit
+    // rather than hang the pod.
+    //
+    // TODO(leader-transfer): on graceful shutdown of a leader we could
+    // proactively transfer leadership before drain, sparing the cluster
+    // one election round. raft-rs's `MsgTransferLeader` is not exposed
+    // through our wrapper today, and `propose_conf_change(RemoveNode,
+    // self_id)` would permanently demote the node — wrong semantics
+    // for a restart-and-rejoin cycle. Out of scope for this PR; needs
+    // a dedicated commitment-timeline test plan.
+    let zm_for_drain = zm.clone();
+    let drain = tokio::task::spawn_blocking(move || {
+        zm_for_drain.shutdown();
+    });
+    match tokio::time::timeout(Duration::from_secs(10), drain).await {
+        Ok(Ok(())) => tracing::info!("ZoneManager drain complete"),
+        Ok(Err(join_err)) => tracing::warn!(?join_err, "ZoneManager drain task panicked"),
+        Err(_) => tracing::warn!("ZoneManager drain exceeded 10s — forcing exit"),
+    }
 
     // Drop Kernel (which owns a nested tokio Runtime) on a blocking
     // thread — dropping it inside the current async context panics with

--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -24,7 +24,6 @@ use anyhow::{Context, Result};
 use backends::storage::path_local::PathLocalBackend;
 use clap::{Parser, Subcommand};
 use kernel::abc::object_store::ObjectStore;
-use kernel::abi::KernelAbi;
 use kernel::kernel::convenience::{KernelConvenience, MountOptions};
 use kernel::kernel::Kernel;
 
@@ -142,40 +141,6 @@ enum Cmd {
         #[arg(long, default_value = "root")]
         parent_zone: String,
     },
-
-    /// Mount a backend at `<path>` via DLC (offline — daemon must be stopped).
-    ///
-    /// Only `--type=path_local` works in this binary because that is
-    /// the sole driver compiled in.  Other types produce a clean
-    /// "driver `X` not compiled into this binary" error from the
-    /// factory.
-    Mount {
-        /// Mount point inside the cluster's VFS (e.g. `/scratch`).
-        path: String,
-        /// Driver type — currently only `path_local` is compiled in.
-        #[arg(long = "type", default_value = "path_local")]
-        driver: String,
-        /// Host filesystem directory the mount serves (required for
-        /// `path_local`).  No default — the operator names the
-        /// directory explicitly to avoid shadowing the boot mount.
-        #[arg(long)]
-        root: Option<PathBuf>,
-        /// Backend name label.  Defaults to `local`.
-        #[arg(long, default_value = "local")]
-        backend_name: String,
-        /// Zone id for the new mount; defaults to root.
-        #[arg(long, default_value = "root")]
-        zone: String,
-    },
-
-    /// Unmount a previously-mounted path (offline — daemon must be stopped).
-    ///
-    /// Drops the DT_MOUNT entry and its routing/dcache state via
-    /// `Kernel::sys_unlink`, mirroring the Python `unmount()` shim.
-    Unmount {
-        /// Mount point to drop (e.g. `/scratch`).
-        path: String,
-    },
 }
 
 #[tokio::main(flavor = "multi_thread", worker_threads = 2)]
@@ -204,21 +169,6 @@ async fn main() -> Result<()> {
             )
             .await
         }
-        Some(Cmd::Mount {
-            path,
-            driver,
-            root,
-            backend_name,
-            zone,
-        }) => run_mount(
-            args.common,
-            &path,
-            &driver,
-            root.as_deref(),
-            &backend_name,
-            &zone,
-        ),
-        Some(Cmd::Unmount { path }) => run_unmount(args.common, &path),
     }
 }
 
@@ -540,79 +490,6 @@ async fn run_share(
         "Shared '{}' from zone '{}' as new zone '{}' ({} entries copied)",
         path, parent_zone, new_zone_id, copied
     );
-    Ok(())
-}
-
-/// Construct an `ObjectStore` for a driver name + local-root the cluster
-/// binary's compiled-in feature set actually supports.  The match below
-/// will grow as more `driver-*` features land in `Cargo.toml`.
-fn build_local_backend(driver: &str, root: &std::path::Path) -> Result<Arc<dyn ObjectStore>> {
-    match driver {
-        "path_local" => {
-            std::fs::create_dir_all(root)
-                .with_context(|| format!("create mount root {}", root.display()))?;
-            let b = PathLocalBackend::new(root, /* fsync */ false)
-                .with_context(|| format!("PathLocalBackend init at {}", root.display()))?;
-            Ok(Arc::new(b) as Arc<dyn ObjectStore>)
-        }
-        other => anyhow::bail!(
-            "driver `{}` not compiled into this binary (cluster binary ships only path_local)",
-            other
-        ),
-    }
-}
-
-fn run_mount(
-    common: CommonArgs,
-    mount_point: &str,
-    driver: &str,
-    local_root: Option<&std::path::Path>,
-    backend_name: &str,
-    zone: &str,
-) -> Result<()> {
-    // Open ZoneManager offline so the mount entry is written through
-    // the same redb file the daemon will reload on next start.  Same
-    // pattern as the `share` / `join` subcommands.
-    let _bundle = open_zone_manager(&common, None)?;
-    let kernel = Arc::new(Kernel::new());
-    let root =
-        local_root.ok_or_else(|| anyhow::anyhow!("--root is required for driver `{driver}`"))?;
-    let backend = build_local_backend(driver, root)?;
-    kernel
-        .mount(
-            mount_point,
-            MountOptions::new(backend_name)
-                .with_backend(backend)
-                .with_zone(zone),
-        )
-        .map_err(|e| anyhow::anyhow!("mount {mount_point}: {:?}", e))?;
-    println!(
-        "Mounted '{}' (zone='{}', driver='{}', root='{}')",
-        mount_point,
-        zone,
-        driver,
-        root.display()
-    );
-    Ok(())
-}
-
-fn run_unmount(common: CommonArgs, mount_point: &str) -> Result<()> {
-    let _bundle = open_zone_manager(&common, None)?;
-    let kernel = Arc::new(Kernel::new());
-    let ctx = contracts::OperationContext::new(
-        /* user_id */ "operator", /* zone_id */ "root", /* is_admin */ true,
-        /* agent_id */ None, /* is_system */ true,
-    );
-    let res = KernelAbi::sys_unlink(&*kernel, mount_point, &ctx, /* recursive */ false)
-        .map_err(|e| anyhow::anyhow!("unmount {mount_point}: {:?}", e))?;
-    if res.hit {
-        println!(
-            "Unmounted '{}' (entry_type={})",
-            mount_point, res.entry_type
-        );
-    } else {
-        anyhow::bail!("'{}' is not a mount point on this node", mount_point);
-    }
     Ok(())
 }
 

--- a/rust/raft/src/transport/certgen.rs
+++ b/rust/raft/src/transport/certgen.rs
@@ -14,6 +14,22 @@ use rcgen::{
 use std::net::{Ipv4Addr, Ipv6Addr};
 use std::path::{Path, PathBuf};
 
+/// Validity window for a node certificate.
+///
+/// 90 days follows the Let's Encrypt convention — short enough that an
+/// expired-cert incident drives rotation discipline, long enough that
+/// routine ops don't churn certs. The CA outlives node certs (see
+/// `CA_VALIDITY_DAYS`); operators rotate node certs by redeploying the
+/// daemon, which re-runs the Day-1 bootstrap.
+const NODE_CERT_VALIDITY_DAYS: i64 = 90;
+
+/// Validity window for the cluster CA. Long-lived by design — every
+/// node cert in the cluster chains to this CA, so rotating it requires
+/// reissuing all node certs. 10 years lines up with public-CA
+/// long-lived-root conventions (DigiCert / ISRG Root X1 / Amazon Root
+/// CA all sit at 10-20y).
+const CA_VALIDITY_DAYS: i64 = 365 * 10;
+
 /// Generate a node certificate signed by the cluster CA.
 ///
 /// Returns `(node_cert_pem, node_key_pem)` as PEM-encoded bytes.
@@ -23,7 +39,7 @@ use std::path::{Path, PathBuf};
 /// - CN: `nexus-zone-{zone_id}-node-{node_id}`
 /// - SANs: localhost, 127.0.0.1, ::1
 /// - Extended Key Usage: serverAuth + clientAuth (mTLS)
-/// - Validity: 365 days
+/// - Validity: see `NODE_CERT_VALIDITY_DAYS`
 pub fn generate_node_cert(
     node_id: u64,
     zone_id: &str,
@@ -102,10 +118,9 @@ pub fn generate_node_cert(
     // Not a CA
     params.is_ca = IsCa::NoCa;
 
-    // Validity: 365 days (matches Python default)
     let now = time::OffsetDateTime::now_utc();
     params.not_before = now;
-    params.not_after = now + time::Duration::days(365);
+    params.not_after = now + time::Duration::days(NODE_CERT_VALIDITY_DAYS);
 
     // Sign with CA
     let node_cert = params
@@ -143,7 +158,7 @@ pub fn generate_zone_ca(zone_id: &str) -> Result<(Vec<u8>, Vec<u8>), String> {
     ];
     let now = time::OffsetDateTime::now_utc();
     params.not_before = now;
-    params.not_after = now + time::Duration::days(365 * 10);
+    params.not_after = now + time::Duration::days(CA_VALIDITY_DAYS);
 
     let cert = params
         .self_signed(&key)

--- a/rust/raft/src/transport/server.rs
+++ b/rust/raft/src/transport/server.rs
@@ -153,7 +153,8 @@ impl RaftGrpcServer {
             blob_fetcher_slot: self.blob_fetcher_slot.clone(),
         };
 
-        let mut builder = tonic::transport::Server::builder();
+        let mut builder =
+            lib::transport_primitives::apply_server_limits(tonic::transport::Server::builder());
         if let Some(ref tls) = self.config.tls {
             let identity = tonic::transport::Identity::from_pem(&tls.cert_pem, &tls.key_pem);
             let client_ca = tonic::transport::Certificate::from_pem(&tls.ca_pem);
@@ -210,7 +211,8 @@ impl RaftGrpcServer {
             blob_fetcher_slot: self.blob_fetcher_slot.clone(),
         };
 
-        let mut builder = tonic::transport::Server::builder();
+        let mut builder =
+            lib::transport_primitives::apply_server_limits(tonic::transport::Server::builder());
         if let Some(ref tls) = self.config.tls {
             let identity = tonic::transport::Identity::from_pem(&tls.cert_pem, &tls.key_pem);
             let client_ca = tonic::transport::Certificate::from_pem(&tls.ca_pem);
@@ -1683,7 +1685,8 @@ impl RaftWitnessServer {
             registry: self.registry.clone(),
         };
 
-        let mut builder = tonic::transport::Server::builder();
+        let mut builder =
+            lib::transport_primitives::apply_server_limits(tonic::transport::Server::builder());
         if let Some(ref tls) = self.config.tls {
             let identity = tonic::transport::Identity::from_pem(&tls.cert_pem, &tls.key_pem);
             let client_ca = tonic::transport::Certificate::from_pem(&tls.ca_pem);

--- a/rust/services/Cargo.toml
+++ b/rust/services/Cargo.toml
@@ -44,9 +44,6 @@ kernel = { workspace = true }
 # syscalls (the same path Python takes), never via direct cross-crate
 # imports. See `services/src/lib.rs` for the rationale.
 redb = "4"
-# `tonic::Status` is the error type in `auth::AuthProvider::resolve`.
-# Workspace dep — same version as transport / raft.
-tonic = { workspace = true }
 # Tasks engine storage backend.
 fjall = "3"
 # `acp::subprocess` calls libc::dup() to hand kernel-side OwnedFds

--- a/rust/services/Cargo.toml
+++ b/rust/services/Cargo.toml
@@ -43,6 +43,11 @@ kernel = { workspace = true }
 # backend or raft-replicated behaviour reach it through `kernel.sys_*`
 # syscalls (the same path Python takes), never via direct cross-crate
 # imports. See `services/src/lib.rs` for the rationale.
+# tonic — used by `password_vault::PasswordVaultService` (and any
+# future Rust gRPC service in this crate) for `Request` / `Response` /
+# `Status` types. Unconditional because each service module is
+# feature-gated, but tonic itself is shared infrastructure for them.
+tonic = { workspace = true }
 redb = "4"
 # Tasks engine storage backend.
 fjall = "3"

--- a/rust/services/src/lib.rs
+++ b/rust/services/src/lib.rs
@@ -18,7 +18,7 @@
 //!   audit/           — AuditHook (NativeInterceptHook) + factory
 //!   managed_agent/   — ManagedAgentService (mailbox + workspace hooks
 //!                      plus session lifecycle for AgentKind::MANAGED)
-//!   python/          — `#[cfg(feature = "python")]` PyO3 sub-module
+//!   tasks/           — durable task queue engine (fjall-backed)
 //! ```
 //!
 //! ## Hard invariant: `services` ⊥ `backends`
@@ -40,11 +40,8 @@
 //! ```
 
 // AcpService — subprocess + ACP-over-stdio host for
-// `AgentKind::UNMANAGED` agents (claude / codex / …).  Currently
-// pyo3-laden internally, so the per-service gate also requires the
-// `python` feature; once the pyo3-coupling is unwound it becomes
-// `service-acp`-only.
-#[cfg(all(feature = "service-acp", feature = "python"))]
+// `AgentKind::UNMANAGED` agents (claude / codex / gemini / …).
+#[cfg(feature = "service-acp")]
 pub mod acp;
 #[cfg(feature = "service-agents")]
 pub mod agents;
@@ -56,15 +53,9 @@ pub mod audit;
 // `get_session_v1` lifecycle for `AgentKind::MANAGED` agents.
 #[cfg(feature = "service-managed-agent")]
 pub mod managed_agent;
-// `tasks` lives in this crate so the runtime ships a single Python
-// wheel; `services::python::register` exposes the PyTaskEngine /
-// PyTaskRecord / PyQueueStats pyclasses.  Internal pyo3 use today, so
-// the per-service gate also requires `python`.
-#[cfg(all(feature = "service-tasks", feature = "python"))]
+// Durable task queue engine (fjall-backed).
+#[cfg(feature = "service-tasks")]
 pub mod tasks;
-// `permission` module deleted — PermissionProvider trait removed in
-// kernel primitive integrity audit. Enforcement runs via
-// NativeInterceptHook chain (dispatch_native_pre).
 // Matrix Client-Server v3 adapter — exposes nexus chat-with-me
 // DT_STREAMs as Matrix rooms so stock chat clients (Element /
 // FluffyChat / Cinny) participate in nexus conversations through the

--- a/rust/services/src/lib.rs
+++ b/rust/services/src/lib.rs
@@ -18,7 +18,7 @@
 //!   audit/           — AuditHook (NativeInterceptHook) + factory
 //!   managed_agent/   — ManagedAgentService (mailbox + workspace hooks
 //!                      plus session lifecycle for AgentKind::MANAGED)
-//!   tasks/           — durable task queue engine (fjall-backed)
+//!   python/          — `#[cfg(feature = "python")]` PyO3 sub-module
 //! ```
 //!
 //! ## Hard invariant: `services` ⊥ `backends`
@@ -39,14 +39,12 @@
 //!                          +--- backends     (peer; never crosses to services)
 //! ```
 
-// Rust-native authentication providers (ApiKeyAuth / NoAuth / JwtAuth).
-// Always compiled — no feature gate. The transport tier consumes
-// `Arc<dyn AuthProvider>` to resolve bearer tokens.
-pub mod auth;
-
 // AcpService — subprocess + ACP-over-stdio host for
-// `AgentKind::UNMANAGED` agents (claude / codex / gemini / …).
-#[cfg(feature = "service-acp")]
+// `AgentKind::UNMANAGED` agents (claude / codex / …).  Currently
+// pyo3-laden internally, so the per-service gate also requires the
+// `python` feature; once the pyo3-coupling is unwound it becomes
+// `service-acp`-only.
+#[cfg(all(feature = "service-acp", feature = "python"))]
 pub mod acp;
 #[cfg(feature = "service-agents")]
 pub mod agents;
@@ -58,9 +56,15 @@ pub mod audit;
 // `get_session_v1` lifecycle for `AgentKind::MANAGED` agents.
 #[cfg(feature = "service-managed-agent")]
 pub mod managed_agent;
-// Durable task queue engine (fjall-backed).
-#[cfg(feature = "service-tasks")]
+// `tasks` lives in this crate so the runtime ships a single Python
+// wheel; `services::python::register` exposes the PyTaskEngine /
+// PyTaskRecord / PyQueueStats pyclasses.  Internal pyo3 use today, so
+// the per-service gate also requires `python`.
+#[cfg(all(feature = "service-tasks", feature = "python"))]
 pub mod tasks;
+// `permission` module deleted — PermissionProvider trait removed in
+// kernel primitive integrity audit. Enforcement runs via
+// NativeInterceptHook chain (dispatch_native_pre).
 // Matrix Client-Server v3 adapter — exposes nexus chat-with-me
 // DT_STREAMs as Matrix rooms so stock chat clients (Element /
 // FluffyChat / Cinny) participate in nexus conversations through the

--- a/rust/transport/Cargo.toml
+++ b/rust/transport/Cargo.toml
@@ -20,9 +20,6 @@ contracts = { workspace = true }
 # rlib; the cdylib pulls them via its own kernel dep.
 kernel = { workspace = true }
 backends = { workspace = true, default-features = false, features = ["driver-path-local", "driver-remote"] }
-# `services::auth::AuthProvider` trait consumed by grpc.rs for auth
-# resolution. No feature flags — auth module is always compiled.
-services = { workspace = true }
 # `lib::transport_primitives` (TLS / pool / addressing / TOFU /
 # PeerBlobClient trait) lives behind lib's `transport` feature.
 lib = { workspace = true, features = ["transport"] }

--- a/rust/transport/src/auth.rs
+++ b/rust/transport/src/auth.rs
@@ -1,4 +1,4 @@
-//! `services::auth` — Rust-native authentication providers.
+//! `transport::auth` — Rust-native authentication providers.
 //!
 //! | Provider     | Use case                           |
 //! |--------------|------------------------------------|
@@ -7,6 +7,11 @@
 //!
 //! The trait is consumed by `transport::grpc::VfsServiceImpl` via
 //! `Arc<dyn AuthProvider>`, so the gRPC server has zero PyO3 coupling.
+//! Lives in `transport` (not `services`) because auth is a property of
+//! the network surface: it sits between the wire and the kernel, gates
+//! token-bearing requests, and is consumed only by the gRPC server. The
+//! `services` crate is post-syscall hooks (audit / agents / tasks) and
+//! has no reason to know about bearer tokens.
 
 use std::sync::Arc;
 

--- a/rust/transport/src/auth.rs
+++ b/rust/transport/src/auth.rs
@@ -1,71 +1,36 @@
-//! `transport::auth` — Rust-native authentication providers.
+//! `transport::auth` — `AuthProvider` trait + the kernel-default
+//! `NoAuth` impl.
 //!
-//! | Provider     | Use case                           |
-//! |--------------|------------------------------------|
-//! | `ApiKeyAuth` | Static API key (HMAC-CT compare)   |
-//! | `NoAuth`     | Cluster-internal (no token needed) |
+//! ## Why this lives in `transport`, not `services`
 //!
-//! The trait is consumed by `transport::grpc::VfsServiceImpl` via
-//! `Arc<dyn AuthProvider>`, so the gRPC server has zero PyO3 coupling.
-//! Lives in `transport` (not `services`) because auth is a property of
-//! the network surface: it sits between the wire and the kernel, gates
-//! token-bearing requests, and is consumed only by the gRPC server. The
-//! `services` crate is post-syscall hooks (audit / agents / tasks) and
-//! has no reason to know about bearer tokens.
-
-use std::sync::Arc;
+//! The `AuthProvider` trait is consumed by
+//! `transport::grpc::VfsServiceImpl` to gate token-bearing requests
+//! before they reach the kernel. By the Rust convention of "trait
+//! owner = primary consumer", the trait belongs to `transport`.
+//! `NoAuth` ships alongside the trait because it is the
+//! kernel-default all-pass policy: `nexusd-cluster` runs it directly
+//! (mTLS is the boundary), so cluster has no reason to pull a
+//! services-tier crate just to find it.
+//!
+//! ## Where future auth impls go
+//!
+//! Anything beyond kernel-default all-pass (API-key gateways, JWT,
+//! OIDC, mTLS-claim mapping, …) is a property of the deployment-tier
+//! service that introduces it. Those impls live in `services/<their
+//! folder>/auth.rs` and `impl transport::auth::AuthProvider for …`
+//! through the workspace orphan-rule relaxation. They DO NOT
+//! retroactively belong here.
 
 use kernel::kernel::OperationContext;
-
-// ── Trait ───────────────────────────────────────────────────────────
 
 /// Resolve a bearer token into an `OperationContext`.
 pub trait AuthProvider: Send + Sync + 'static {
     fn resolve(&self, token: &str) -> Result<OperationContext, tonic::Status>;
 }
 
-/// Convenience alias.
-pub type AuthProviderRef = Arc<dyn AuthProvider>;
-
-// ── ApiKeyAuth ──────────────────────────────────────────────────────
-
-/// Constant-time HMAC comparison against a static API key.
-pub struct ApiKeyAuth {
-    expected: Arc<str>,
-}
-
-impl ApiKeyAuth {
-    pub fn new(key: impl Into<Arc<str>>) -> Self {
-        Self {
-            expected: key.into(),
-        }
-    }
-}
-
-impl AuthProvider for ApiKeyAuth {
-    fn resolve(&self, token: &str) -> Result<OperationContext, tonic::Status> {
-        if token.is_empty() {
-            return Err(tonic::Status::unauthenticated("Authentication required"));
-        }
-        if subtle_eq(self.expected.as_bytes(), token.as_bytes()) {
-            Ok(OperationContext::new(
-                "api-key-user",
-                "root",
-                true,
-                None,
-                false,
-            ))
-        } else {
-            Err(tonic::Status::unauthenticated("Invalid API key"))
-        }
-    }
-}
-
-// ── NoAuth ──────────────────────────────────────────────────────────
-
-/// Cluster-internal: every request is treated as admin with no token
-/// validation. Used by `nexusd-cluster` where mTLS is the only
-/// authentication boundary.
+/// Kernel-default all-pass policy. Every request becomes a
+/// system-level admin context regardless of the supplied token.
+/// `nexusd-cluster` uses this directly — mTLS is the boundary.
 pub struct NoAuth;
 
 impl AuthProvider for NoAuth {
@@ -80,57 +45,33 @@ impl AuthProvider for NoAuth {
     }
 }
 
-// ── Helpers ─────────────────────────────────────────────────────────
-
-/// Constant-time byte equality.
-fn subtle_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    let mut diff = 0u8;
-    for (x, y) in a.iter().zip(b.iter()) {
-        diff |= x ^ y;
-    }
-    diff == 0
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
 
-    #[test]
-    fn api_key_auth_accepts_matching_key() {
-        let auth = ApiKeyAuth::new("test-key-123");
-        let ctx = auth.resolve("test-key-123").unwrap();
-        assert_eq!(ctx.user_id, "api-key-user");
-        assert!(ctx.is_admin);
+    /// Reject helper used in tests to exercise the rejection branch
+    /// of consumer code without dragging a real auth backend into the
+    /// transport crate.
+    struct RejectAll;
+    impl AuthProvider for RejectAll {
+        fn resolve(&self, _token: &str) -> Result<OperationContext, tonic::Status> {
+            Err(tonic::Status::unauthenticated("rejected"))
+        }
     }
 
     #[test]
-    fn api_key_auth_rejects_wrong_key() {
-        let auth = ApiKeyAuth::new("test-key-123");
-        assert!(auth.resolve("wrong-key").is_err());
-    }
-
-    #[test]
-    fn api_key_auth_rejects_empty_token() {
-        let auth = ApiKeyAuth::new("test-key-123");
-        assert!(auth.resolve("").is_err());
-    }
-
-    #[test]
-    fn no_auth_always_succeeds() {
+    fn no_auth_returns_admin_context_for_any_token() {
         let auth = NoAuth;
-        let ctx = auth.resolve("").unwrap();
-        assert_eq!(ctx.user_id, "cluster-internal");
-        assert!(ctx.is_admin);
-        assert!(ctx.is_system);
+        for token in ["", "any-token-here", "x"] {
+            let ctx = auth.resolve(token).unwrap();
+            assert_eq!(ctx.user_id, "cluster-internal");
+            assert!(ctx.is_admin);
+            assert!(ctx.is_system);
+        }
     }
 
     #[test]
-    fn no_auth_ignores_any_token() {
-        let auth = NoAuth;
-        let ctx = auth.resolve("any-token-here").unwrap();
-        assert_eq!(ctx.user_id, "cluster-internal");
+    fn reject_all_helper_rejects() {
+        assert!(RejectAll.resolve("anything").is_err());
     }
 }

--- a/rust/transport/src/grpc.rs
+++ b/rust/transport/src/grpc.rs
@@ -1406,6 +1406,7 @@ mod tests {
     use std::sync::Mutex as StdMutex;
 
     use kernel::abc::object_store::{ObjectStore, StorageError, WriteResult};
+    use kernel::kernel::convenience::{KernelConvenience, MountOptions};
     use kernel::kernel::vfs_proto::{
         nexus_vfs_service_server::NexusVfsService, BatchReadItemRequest, BatchReadRequest,
         BatchWriteItemRequest, BatchWriteRequest, StatRequest,
@@ -1465,30 +1466,13 @@ mod tests {
     fn kernel_with_mem_backend() -> Kernel {
         let k = Kernel::new();
         let backend: std::sync::Arc<dyn ObjectStore> = std::sync::Arc::new(MemBackend::default());
-        k.sys_setattr(
+        k.mount(
             "/",
-            2,
-            "mem",
-            Some(backend),
-            None,
-            None,
-            "",
-            kernel::ROOT_ZONE_ID,
-            false,
-            0,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
-            None,
+            MountOptions::new("mem")
+                .with_backend(backend)
+                .with_io_profile(""),
         )
-        .expect("kernel_with_mem_backend: sys_setattr DT_MOUNT");
+        .expect("kernel_with_mem_backend: mount DT_MOUNT");
         k
     }
 

--- a/rust/transport/src/grpc.rs
+++ b/rust/transport/src/grpc.rs
@@ -1,7 +1,7 @@
 //! Rust-native gRPC server for `NexusVFSService`.
 //!
 //! Owns the :2028 socket via tonic. Auth is handled by
-//! `services::auth::AuthProvider` (pure Rust).
+//! `transport::auth::AuthProvider` (pure Rust).
 //!
 //! Per-RPC architecture:
 //!
@@ -16,7 +16,7 @@ use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::time::Instant;
 
-use services::auth::AuthProvider;
+use crate::auth::AuthProvider;
 use tokio::sync::oneshot;
 use tonic::{transport::Server, Request, Response, Status};
 
@@ -130,7 +130,7 @@ impl VfsServiceImpl {
     pub(crate) fn for_test(kernel: Arc<Kernel>) -> Self {
         Self {
             kernel,
-            auth: Arc::new(services::auth::ApiKeyAuth::new("test-key")),
+            auth: Arc::new(crate::auth::ApiKeyAuth::new("test-key")),
             server_started_at: Instant::now(),
             server_version: Arc::from("test"),
             started_secs: Arc::new(AtomicU64::new(0)),

--- a/rust/transport/src/grpc.rs
+++ b/rust/transport/src/grpc.rs
@@ -1108,8 +1108,7 @@ pub fn spawn(
 
     let routes = build_vfs_routes(kernel, auth, cfg.max_message_bytes, &cfg.server_version);
 
-    let mut server_builder = Server::builder()
-        .max_concurrent_streams(Some(1024))
+    let mut server_builder = lib::transport_primitives::apply_server_limits(Server::builder())
         .timeout(std::time::Duration::from_secs(60));
 
     if let Some(tls) = cfg.tls {

--- a/rust/transport/src/grpc.rs
+++ b/rust/transport/src/grpc.rs
@@ -130,7 +130,7 @@ impl VfsServiceImpl {
     pub(crate) fn for_test(kernel: Arc<Kernel>) -> Self {
         Self {
             kernel,
-            auth: Arc::new(crate::auth::ApiKeyAuth::new("test-key")),
+            auth: Arc::new(crate::auth::NoAuth),
             server_started_at: Instant::now(),
             server_version: Arc::from("test"),
             started_secs: Arc::new(AtomicU64::new(0)),

--- a/rust/transport/src/lib.rs
+++ b/rust/transport/src/lib.rs
@@ -30,10 +30,10 @@
 //! wrappers wrap it directly — re-exported here under
 //! [`vfs::RpcTransport`] for the canonical out-bound name.
 
-/// Rust-native auth providers (`AuthProvider` / `NoAuth` / `ApiKeyAuth`)
-/// consumed by `transport::grpc::VfsServiceImpl`. Always compiled — no
-/// feature gate. Lives in `transport` because auth is a wire-surface
-/// concern, not a post-syscall hook.
+/// `AuthProvider` trait + kernel-default `NoAuth` impl. Consumed by
+/// `transport::grpc::VfsServiceImpl`. Other auth impls (API-key,
+/// JWT, OIDC, …) live in the deployment-tier service that introduces
+/// them, not here.
 pub mod auth;
 /// Federation peer client — only used by `PyFederationClient` (Python deployment).
 #[cfg(feature = "python")]

--- a/rust/transport/src/lib.rs
+++ b/rust/transport/src/lib.rs
@@ -6,7 +6,8 @@
 //!   envelope helpers.
 //! * Out-bound (driver-side clients): peer-blob fetch client
 //!   implementing `lib::transport_primitives::PeerBlobClient`,
-//!   federation peer client for discover/join flows.
+//!   federation peer client (`PyFederationClient`) for discover/join
+//!   flows.
 //!
 //! Module layout:
 //!
@@ -16,6 +17,8 @@
 //!   ipc.rs          — IPC message envelope helpers
 //!   peer_blob.rs    — peer-blob fetch client (out-bound)
 //!   federation.rs   — federation peer client (out-bound)
+//!   python/
+//!     mod.rs        — register() + install_transport_wiring
 //! ```
 //!
 //! Direction: `transport -> {kernel, lib, raft, services}`. Transport
@@ -27,14 +30,21 @@
 //! wrappers wrap it directly — re-exported here under
 //! [`vfs::RpcTransport`] for the canonical out-bound name.
 
-/// Federation peer client — discover/join RPCs for cross-zone membership.
+/// Rust-native auth providers (`AuthProvider` / `NoAuth` / `ApiKeyAuth`)
+/// consumed by `transport::grpc::VfsServiceImpl`. Always compiled — no
+/// feature gate. Lives in `transport` because auth is a wire-surface
+/// concern, not a post-syscall hook.
+pub mod auth;
+/// Federation peer client — only used by `PyFederationClient` (Python deployment).
+#[cfg(feature = "python")]
 pub mod federation;
-/// Generic `Call` RPC dispatcher — JSON in, kernel syscall, JSON out.
-pub mod call_dispatch;
 /// VFS gRPC server (in-bound). Always compiled — zero PyO3 coupling.
 pub mod grpc;
 pub mod ipc;
 pub mod peer_blob;
+
+#[cfg(feature = "python")]
+pub mod python;
 
 /// Out-bound VFS gRPC client. Re-exported from `kernel::rpc_transport`
 /// where the type is declared (kernel-internal `RemoteMetaStore`

--- a/rust/transport/src/lib.rs
+++ b/rust/transport/src/lib.rs
@@ -35,16 +35,14 @@
 /// JWT, OIDC, …) live in the deployment-tier service that introduces
 /// them, not here.
 pub mod auth;
-/// Federation peer client — only used by `PyFederationClient` (Python deployment).
-#[cfg(feature = "python")]
+/// Federation peer client — discover/join RPCs for cross-zone membership.
 pub mod federation;
+/// Generic `Call` RPC dispatcher — JSON in, kernel syscall, JSON out.
+pub mod call_dispatch;
 /// VFS gRPC server (in-bound). Always compiled — zero PyO3 coupling.
 pub mod grpc;
 pub mod ipc;
 pub mod peer_blob;
-
-#[cfg(feature = "python")]
-pub mod python;
 
 /// Out-bound VFS gRPC client. Re-exported from `kernel::rpc_transport`
 /// where the type is declared (kernel-internal `RemoteMetaStore`


### PR DESCRIPTION
## Summary

Tightens `nexus-cluster` (`rust/profiles/cluster/`) along two axes — **size** (drop dead deps + dead code) and **production-readiness** (tokio scaling, TLS rotation cadence, gRPC server hardening, graceful drain) — while honoring six principles: 简化 contract / 架构正确 / SSOT / DRY / Rust-first / perf.

16 small, single-concern commits, each independently green. No squash on merge.

## Commit table

| # | Phase | Commit | What |
|---|---|---|---|
| 1 | **A1** | `refactor(transport): move auth module from services to transport` | Auth is a wire-surface concern, not a post-syscall hook. `AuthProvider` trait now lives where its consumer (`transport::grpc::VfsServiceImpl`) lives. |
| 2 | **A2** | `refactor(cluster): drop services crate dependency` | Cluster no longer touches anything in `services`; saves a transitive dep tree. |
| 3 | **A3** | `refactor(transport): drop dead ApiKeyAuth — keep auth surface to trait + NoAuth` | ApiKeyAuth had zero production consumers (only tests). Future auth impls (API-key gateway, JWT, OIDC) belong with the service that introduces them. |
| 4 | fix | `fix(raft): add owner_id: None to test FileMetadata init` | Defensive — kernel grew `FileMetadata.owner_id`; raft test missed the catch-up. |
| 5 | fix | `fix(services): migrate managed_agent procfs tests to Tier 2 read/write` | Defensive — `sys_read_one` / `sys_write_one` were deleted by #4150 in favour of the Tier 2 `KernelConvenience::read` / `::write` helpers. |
| 6 | **H1** | `feat(kernel): Tier 2 mount() helper + MountOptions builder` | Composes `sys_setattr(DT_MOUNT, ...)`. Same pattern as the Tier 2 `read()` / `unlink()` helpers from #4150. Builder-style `MountOptions` carries only the DT_MOUNT-relevant subset of `sys_setattr`'s 21 args. |
| 7 | **H2** | `refactor: adopt Kernel::mount() at all in-tree DT_MOUNT sites` | 3 sites migrated (cluster ×2 + transport test). Side effect: fixes the `--tests` mode compile error in `transport/src/grpc.rs` where the test helper still used the pre-#4150 17-arg `sys_setattr` shape. |
| 8 | **G1** | `fix(cluster): delete broken run_mount / run_unmount subcommands` | These subcommands never worked: fresh `Kernel::new()` has a tempfile metastore that drops at exit, so the DT_MOUNT entry never persisted. Zero callers (verified across `.py .sh .yml .md`). Legitimate use cases already covered by `NEXUS_FEDERATION_MOUNTS` env (boot-time) and `share` / `join` subcommands (federation, persisted via raft). |
| 9 | fix | `fix(backends): drop orphan doc comment above delete_content` | Defensive — develop hygiene; clippy's `empty_line_after_doc_comments` fires under `-D warnings`. |
| 10 | **C1** | `feat(cluster): size tokio runtime by available_parallelism` | Replace `#[tokio::main(worker_threads = 2)]` with a manual `Runtime::Builder` sized to `available_parallelism()` (cgroup/affinity-aware). No env / CLI flag — kernel view of host capacity is the SSOT. |
| 11 | **D1** | `feat(raft): node TLS cert validity 365d -> 90d` | Industry-standard Let's Encrypt model — short enough to drive rotation discipline, long enough to keep ops cadence sane. CA stays at 10y. |
| 12 | **E1** | `feat(contracts+lib): gRPC server hardening constants + apply helper` | `GRPC_MAX_CONCURRENT_STREAMS = 1024`, `GRPC_HTTP2_KEEPALIVE_INTERVAL_SECS = 30`, `GRPC_HTTP2_KEEPALIVE_TIMEOUT_SECS = 10`, `GRPC_TCP_KEEPALIVE_SECS = 60`. Shared helper in `lib::transport_primitives::apply_server_limits`. |
| 13 | **E2** | `feat(transport+raft): apply gRPC server hardening at every builder site` | 4 sites: VFS gRPC server + raft `serve` / `serve_with_shutdown` / witness. Before: only VFS had a `max_concurrent_streams(1024)` hardcoded magic; raft servers had no keepalive at all. |
| 14 | **F1** | `feat(cluster): graceful drain on SIGTERM via ZoneManager::shutdown()` | Wires `zm.shutdown()` on SIGTERM (signals tonic `serve_with_shutdown` + zone transport loops) with a 10s timeout cap. Leader-transfer is intentionally deferred (raft-rs `MsgTransferLeader` plumbing is non-trivial; `propose_conf_change(RemoveNode, self_id)` has wrong semantics for restart-and-rejoin). |
| 15 | **B2.1** | `chore(kernel): drop dead 'encoding_rs' workspace dep` | 0 usages workspace-wide. Dropping removes a ~400 KB stripped-release contribution from every consumer. |
| 16 | **B2.2** | `chore(kernel): drop dead 'simdutf8' and 'simsimd' workspace deps` | Only used by `lib::python::*` (already correctly gated). Kernel declared them unconditionally → every Python-free consumer paid the build/link cost for nothing. |

## What this PR does NOT do (out of scope)

- **`panic = abort` / `lto = fat` per-package** — Cargo doesn't allow these in `[profile.release.package.foo]` overrides; workspace-wide would affect cdylib too. Skipped honestly.
- **Health/readiness/metrics HTTP endpoints** — no current k8s/lb deployment; Helm chart targets the hub topology, not nexusd-cluster.
- **Config file / JSON logging / snapshot CLI / TLS cert-rotation CLI** — keep contract simple; 90-day default rotates by daemon restart.
- **Leader transfer on shutdown** — correctness rabbit hole; raft-rs API plumbing needs a dedicated PR + commitment-timeline tests. TODO in `F1` commit body.
- **Larger feature-gating** (`memmap2` / shm code, `bloomfilter` / cas_engine) — these have real usages in kernel/src; their gating is a design exercise belonging in a follow-up PR.
- **services::python ↔ kernel/python coupling** — `services/python/mod.rs` imports `kernel::generated_kernel_abi_pyo3::PyKernel`; per kernel-team direction, don't extend the kernel/python surface as a workaround. Source-level decoupling is a separate refactor.

## Test plan

- [x] `cargo check --workspace --tests` — clean locally
- [x] `cargo clippy -p nexus-cluster -- -D warnings` — clean
- [x] `cargo build --release -p nexus-cluster --bin nexusd-cluster` — clean (Windows 9.62 MiB; Linux CI gate measures the real number)
- [ ] CI: cluster-binary-build (linux/macos/windows)
- [ ] CI: Rust Lint and Test
- [ ] CI: Federation E2E (docker)
- [ ] CI: Slim wheel smoke
- [ ] Manual: SIGTERM produces `ZoneManager drain complete` log line on a running daemon

## Risks + mitigations

| Risk | Mitigation |
|---|---|
| Rebase silently reverts our changes on no-conflict files | Verified post-rebase `git diff origin/develop...HEAD` against staged state; pinned commits look correct. |
| 90-day TLS too short for air-gapped use | Restart-rotates from Day-1 bootstrap. If a use case surfaces, expose `--tls-validity-days`. |
| gRPC keepalive too aggressive for slow networks | Constants are conservative defaults; tune via follow-up runtime config. |
| Graceful drain race vs raft fsync | `zm.shutdown()` signals zone transport loops first; raft apply has its own fsync-per-entry. 10s timeout caps hang. |

🤖 Generated with [Claude Code](https://claude.com/claude-code)