### PR TITLE
fix(raft): share_subtree_core owns leader precondition + wait_for_leader SSOT

### DIFF
--- a/rust/profiles/cluster/src/main.rs
+++ b/rust/profiles/cluster/src/main.rs
@@ -549,26 +549,10 @@ async fn run_share(
             .map_err(|e| anyhow::anyhow!("create_zone({}): {}", new_zone_id, e))?;
     }
 
-    // ``share_subtree_core`` is a leader-required raft proposal
-    // against ``parent_zone``.  The freshly-opened ZoneManager has
-    // not finished election yet, so without this wait we hit
-    // ``NotLeader { leader_hint: Some(self_id) }`` — surfaced today
-    // during cross-machine smoke (PR #4014 follow-up).  10 s covers
-    // a few election timeouts; if we still are not leader, quorum
-    // for ``parent_zone`` is unreachable and the operator must
-    // resolve that before retrying.
-    let parent_handle = zm.get_zone(parent_zone).ok_or_else(|| {
-        anyhow::anyhow!("share: parent zone '{}' not found in storage", parent_zone)
-    })?;
-    if !parent_handle.wait_for_leader(std::time::Duration::from_secs(10)) {
-        anyhow::bail!(
-            "share: did not become leader of '{}' within 10s (leader hint: {:?}); \
-             quorum for parent zone is unreachable from this node",
-            parent_zone,
-            parent_handle.leader_id(),
-        );
-    }
-
+    // No leader-wait dance here — ``share_subtree_core`` owns its
+    // leadership precondition internally (waits on ``new_zone_id``,
+    // the actual write target).  Reads on ``parent_zone`` are local
+    // sequential-consistency, no leader required.
     let copied = zm
         .share_subtree_core(parent_zone, path, new_zone_id)
         .map_err(|e| anyhow::anyhow!("share_subtree: {}", e))?;

--- a/rust/raft/src/raft/node.rs
+++ b/rust/raft/src/raft/node.rs
@@ -746,6 +746,29 @@ impl<S: StateMachine + 'static> ZoneConsensus<S> {
         }
     }
 
+    /// Block until this node becomes leader of the zone, or `timeout`
+    /// elapses.  Returns `true` if leader, `false` on timeout.
+    ///
+    /// SSOT for the "is_leader poll with sleep" primitive — both
+    /// `ZoneHandle::wait_for_leader` and any raft-internal helper that
+    /// must wait for self-election (e.g. `share_subtree_core` after a
+    /// fresh `create_zone`) call into here.  Keeps the polling shape
+    /// (atomic read + 50 ms sleep) in one place, identical to the
+    /// atomic that `submit_to_channel` checks — so a successful
+    /// `wait_for_leader` return is guaranteed to see `is_leader()=true`
+    /// at the next propose, modulo leadership being lost cluster-wide
+    /// (impossible for a 1-voter zone, normal retry path otherwise).
+    pub fn wait_for_leader(&self, timeout: std::time::Duration) -> bool {
+        let deadline = std::time::Instant::now() + timeout;
+        while std::time::Instant::now() < deadline {
+            if self.is_leader() {
+                return true;
+            }
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+        self.is_leader()
+    }
+
     /// Get the current term (atomic read, no channel).
     pub fn term(&self) -> u64 {
         self.cached_term.load(Ordering::Relaxed)

--- a/rust/raft/src/zone_handle.rs
+++ b/rust/raft/src/zone_handle.rs
@@ -70,25 +70,13 @@ impl ZoneHandle {
     /// Block until this node becomes leader of the zone, or the
     /// timeout elapses.  Returns `true` if leader, `false` on timeout.
     ///
-    /// `is_leader()` is an atomic read on a cached value updated by
-    /// the raft driver thread, so the poll is cheap (no channel, no
-    /// lock).  Used by leader-required raft proposals (e.g.
-    /// ``share_subtree_core`` invoked from offline operator
-    /// subcommands) that open a fresh ZoneManager and must wait for
-    /// election to settle before issuing a propose.
-    ///
-    /// Sleep interval is 50 ms — small enough that even a snappy
-    /// ~150 ms election window is caught quickly, large enough that
-    /// the polling cost is invisible.
+    /// Thin delegation to `ZoneConsensus::wait_for_leader` — the SSOT
+    /// for the "is_leader poll with sleep" primitive lives there so
+    /// raft-internal helpers (e.g. `share_subtree_core`) which hold a
+    /// `ZoneConsensus<S>` rather than a `ZoneHandle` can use the same
+    /// shape without duplicating the loop.
     pub fn wait_for_leader(&self, timeout: std::time::Duration) -> bool {
-        let deadline = std::time::Instant::now() + timeout;
-        while std::time::Instant::now() < deadline {
-            if self.node.is_leader() {
-                return true;
-            }
-            std::thread::sleep(std::time::Duration::from_millis(50));
-        }
-        self.node.is_leader()
+        self.node.wait_for_leader(timeout)
     }
 
     pub fn commit_index(&self) -> u64 {

--- a/rust/raft/src/zone_manager.rs
+++ b/rust/raft/src/zone_manager.rs
@@ -1173,6 +1173,32 @@ impl ZoneManager {
             ))
         })?;
 
+        // share_subtree_core writes (`propose_set_metadata`) target
+        // ``new_node``, which is leader-required.  ``parent_node`` is
+        // only read via ``with_state_machine`` (sequential-consistency
+        // local read — no leader needed).  Offline callers (e.g.
+        // ``nexusd-cluster share``) hit this immediately after
+        // ``create_zone``: the new 1-voter raft tick driver has not
+        // yet run its election cycle, so the first propose lands
+        // before ``cached_role`` is set to ``LEADER`` and fails with
+        // ``NotLeader { leader_hint: Some(self_id) }``.  Wait once,
+        // here, so every caller (offline CLI, online RPC, future
+        // binding) is safe by construction — single SSOT for this
+        // precondition rather than per-caller defensive waits.
+        //
+        // 10 s covers ~60 election windows; a 1-voter zone that has
+        // not elected itself within that timeframe means the raft
+        // tick driver did not start, which is a fatal bug worth
+        // failing loud about.
+        if !new_node.wait_for_leader(std::time::Duration::from_secs(10)) {
+            return Err(RaftError::Raft(format!(
+                "share_subtree_core: new zone '{}' did not elect self as leader \
+                 within 10s (leader hint: {:?}); raft tick driver may not be running",
+                new_zone_id,
+                new_node.leader_id(),
+            )));
+        }
+
         let normalized_prefix = prefix.trim_end_matches('/').to_string();
         if normalized_prefix.is_empty() && prefix != "/" {
             return Err(RaftError::InvalidState(format!(
@@ -1536,6 +1562,49 @@ mod tests {
             }
             Ok(_) => panic!("expected ZoneAlreadyExistsWithDifferentMembership, got Ok"),
         }
+    }
+
+    #[test]
+    fn test_share_subtree_core_after_fresh_create_no_notleader_race() {
+        // Regression: ``share_subtree_core`` writes (``propose_set_metadata``)
+        // target the freshly-created ``new_zone`` raft group.  Before the
+        // SSOT wait moved into the helper, callers had to ``wait_for_leader``
+        // themselves between ``create_zone`` and ``share_subtree_core``;
+        // forgetting that (or waiting on the wrong zone, like the offline
+        // ``nexusd-cluster share`` CLI did against ``parent_zone``) raced the
+        // raft election and surfaced as ``NotLeader { leader_hint:
+        // Some(self_id) }`` ~400 ms into the call.  This pin keeps the
+        // contract: the helper owns its leadership precondition, so
+        // back-to-back ``create_zone`` + ``share_subtree_core`` on a
+        // single-node cluster must succeed without external waits.
+        let (zm, _dir) = make_zm(1);
+        // Seed a parent zone with one entry under ``/shared`` so the
+        // share copies something non-trivial — the propose path against
+        // ``new_zone`` is what we're really exercising.
+        let parent = zm
+            .create_zone(contracts::ROOT_ZONE_ID, vec![])
+            .expect("root create");
+        assert!(
+            parent.wait_for_leader(std::time::Duration::from_secs(5)),
+            "root must elect itself as 1-voter leader"
+        );
+        let meta = encode_file_metadata("/shared", DT_DIR, contracts::ROOT_ZONE_ID, "");
+        let handle = zm.rt().handle().clone();
+        let root_node = zm
+            .registry
+            .get_node(contracts::ROOT_ZONE_ID)
+            .expect("root node");
+        propose_set_metadata(&handle, &root_node, "/shared", meta).expect("seed /shared");
+
+        // Fresh shared zone — created immediately before the share call
+        // so the raft tick driver has had no time to elect.  Under the
+        // old contract this raced and returned NotLeader.
+        zm.create_zone("sharedzone", vec![])
+            .expect("shared zone create");
+        let copied = zm
+            .share_subtree_core(contracts::ROOT_ZONE_ID, "/shared", "sharedzone")
+            .expect("share_subtree_core must wait for new_zone leader internally");
+        assert!(copied >= 1, "at least the /shared root entry copied");
     }
 
     #[test]

--- a/rust/raft/src/zone_meta_store.rs
+++ b/rust/raft/src/zone_meta_store.rs
@@ -523,6 +523,7 @@ mod tests {
             last_writer_address: Some("nexus-1:2126".to_string()),
             target_zone_id: None,
             link_target: None,
+            owner_id: None,
         };
 
         store.put(path, meta.clone()).expect("put from runtime");


### PR DESCRIPTION
## Summary

- `share_subtree_core` writes target the **freshly-created `new_zone`**, not the parent zone — the parent is read-only via `with_state_machine` (sequential-consistency local read, no leader required).  Callers (offline `nexusd-cluster share`, future RPC handlers) hit a race between `create_zone` and the first propose: raft tick has not yet run `become_leader`, `cached_role` is still `FOLLOWER`, and the propose fails with `NotLeader { leader_hint: Some(self_id) }` ~400 ms in.
- Bake the leader precondition **into `share_subtree_core` itself** rather than have every caller re-implement the wait — single SSOT, no boundary leak between CLI orchestration and raft internals.
- Hoist `wait_for_leader` from `ZoneHandle` to `ZoneConsensus<S>` so the raft-internal helper can reuse the same primitive (same atomic, same shape) that `submit_to_channel` checks.  `ZoneHandle::wait_for_leader` becomes a thin delegate — public API unchanged.
- Drop the parent-zone wait from `run_share` (it targeted the wrong raft group; the previous fix in PR #4014 / task #22 patched the symptom one layer too high).

## Architectural verification (raft usage contract)

| # | Contract point | Result |
|---|---|---|
| C1 | `submit_to_channel` requires `is_leader()=true` on submitting node | ✓ wait ensures it |
| C2 | `wait_for_leader` + `submit_to_channel` share the same `cached_role` atomic | ✓ — SSOT now on `ZoneConsensus<S>` |
| C3 | `with_state_machine` is sequential-consistency local read, no leader required | ✓ — parent wait was redundant |
| C4 | API symmetry — both `ZoneHandle` and raft-internal helpers can use the primitive | ✓ — hoisted to `ZoneConsensus<S>` |
| C5 | 1-voter zone always elects self within ~150 ms (raft tick guarantee) | ✓ — 10 s timeout is fail-loud margin |
| C6 | No race between successful wait and next propose | ✓ — 1-voter has no failover; multi-voter is the normal "retry on NotLeader" pattern |

## Verification

**Layer 1 — Rust unit + lib tests**
- `cargo test -p raft@0.1.0 --features grpc --lib` → 172 passed (171 existing + 1 new regression pin `test_share_subtree_core_after_fresh_create_no_notleader_race`).
- `cargo check -p nexus-cluster` → clean.

**Layer 2 — Real-binary offline share on Windows**
- Pre-fix: `nexusd-cluster share / --zone-id sharedzone ...` failed at ~400 ms with `share_subtree: not leader, leader hint: Some(self_id)`.
- Post-fix: same command succeeds in 349 ms (37 ms redb open + 37 ms root reload + ~270 ms new_zone election & propose & shutdown).

## Test plan

- [x] `cargo test -p raft@0.1.0 --features grpc --lib`
- [x] `cargo check -p nexus-cluster`
- [x] Build release binary + offline share end-to-end on Windows
- [ ] CI: Linux + macOS + Windows cluster-binary builds + federation E2E
- [ ] Cross-machine smoke (Win shares + Mac joins via federation VPN) — independent of this PR; runs after merge

## Commits (preserve granular history)

1. `fix(test): zone_meta_store — add missing owner_id field` (pre-existing test compile error on develop tip)
2. `refactor(raft): hoist wait_for_leader SSOT to ZoneConsensus`
3. `fix(raft): share_subtree_core owns its leader precondition` (+ regression test)
4. `refactor(cluster): drop run_share's redundant parent leader wait`
