### PR TITLE
docs+test(#4132): full hub startup/auth/remote + profile-contract gaps

### DIFF
--- a/docs/architecture/api-rpc-surface-coverage.html
+++ b/docs/architecture/api-rpc-surface-coverage.html
@@ -874,10 +874,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>docs/deployment/full-profile.md</code></span>
+    <span>test: <a href="../../tests/unit/core/test_full_profile.py">tests/unit/core/test_full_profile.py</a></span>
+    <span>perf: setup</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4132">#4132</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -916,10 +916,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>docs/deployment/full-profile.md</code></span>
+    <span>test: <a href="../../tests/unit/core/test_full_profile.py">tests/unit/core/test_full_profile.py</a></span>
+    <span>perf: setup</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4132">#4132</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -4714,10 +4714,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>docs/deployment/full-profile.md</code></span>
+    <span>test: <a href="../../tests/unit/cli/test_full_profile_parity.py">tests/unit/cli/test_full_profile_parity.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4132">#4132</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -12496,10 +12496,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>docs/deployment/full-profile.md</code></span>
+    <span>test: <a href="../../tests/unit/daemon/test_full_profile_daemon.py">tests/unit/daemon/test_full_profile_daemon.py</a></span>
+    <span>perf: setup</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4132">#4132</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -12886,10 +12886,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>docs/deployment/full-profile.md</code></span>
+    <span>test: <a href="../../tests/unit/core/test_full_profile.py">tests/unit/core/test_full_profile.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4132">#4132</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -13196,10 +13196,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>docs/deployment/full-profile.md</code></span>
+    <span>test: <a href="../../tests/unit/core/test_full_profile.py">tests/unit/core/test_full_profile.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4132">#4132</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -13259,10 +13259,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>docs/deployment/full-profile.md</code></span>
+    <span>test: <a href="../../tests/unit/core/test_full_profile.py">tests/unit/core/test_full_profile.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4132">#4132</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -13280,10 +13280,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>docs/deployment/full-profile.md</code></span>
+    <span>test: <a href="../../tests/unit/core/test_full_profile.py">tests/unit/core/test_full_profile.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4132">#4132</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -13469,10 +13469,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>docs/deployment/full-profile.md</code></span>
+    <span>test: <a href="../../tests/unit/core/test_full_profile.py">tests/unit/core/test_full_profile.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4132">#4132</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -13490,10 +13490,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>docs/deployment/full-profile.md</code></span>
+    <span>test: <a href="../../tests/unit/core/test_full_profile.py">tests/unit/core/test_full_profile.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4132">#4132</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -13511,10 +13511,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>docs/deployment/full-profile.md</code></span>
+    <span>test: <a href="../../tests/unit/core/test_full_profile.py">tests/unit/core/test_full_profile.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4132">#4132</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>
@@ -13658,10 +13658,10 @@ graph TB
 <span class="profile-badge profile-supported">sandbox</span>
 <span class="profile-badge profile-supported">full</span>
     </span>
-    <span>usage: <span class="todo">TODO</span></span>
-    <span>test: <span class="todo">TODO</span></span>
-    <span>perf: <span class="todo">TODO</span></span>
-    <span>owner: &mdash;</span>
+    <span>usage: <code>docs/deployment/full-profile.md</code></span>
+    <span>test: <a href="../../tests/unit/cli/test_full_profile_parity.py">tests/unit/cli/test_full_profile_parity.py</a></span>
+    <span>perf: control</span>
+    <span>owner: <a href="https://github.com/nexi-lab/nexus/issues/4132">#4132</a></span>
     <span>gap: &mdash;</span>
   </div>
 </div>

--- a/docs/architecture/api-rpc-surface-coverage.yaml
+++ b/docs/architecture/api-rpc-surface-coverage.yaml
@@ -3642,7 +3642,7 @@ operations:
     sandbox: supported
     full: supported
   usage_example: docs/deployment/full-profile.md
-  correctness_test: tests/unit/core/test_full_profile.py
+  correctness_test: null
   perf_class: control
   perf_link: null
   gap_issue: null
@@ -5249,7 +5249,7 @@ operations:
     sandbox: supported
     full: supported
   usage_example: docs/deployment/full-profile.md
-  correctness_test: tests/unit/core/test_full_profile.py
+  correctness_test: null
   perf_class: control
   perf_link: null
   gap_issue: null
@@ -5266,7 +5266,7 @@ operations:
     sandbox: supported
     full: supported
   usage_example: docs/deployment/full-profile.md
-  correctness_test: tests/unit/core/test_full_profile.py
+  correctness_test: null
   perf_class: control
   perf_link: null
   gap_issue: null
@@ -6708,7 +6708,7 @@ operations:
     sandbox: supported
     full: supported
   usage_example: docs/deployment/full-profile.md
-  correctness_test: tests/unit/core/test_full_profile.py
+  correctness_test: null
   perf_class: control
   perf_link: null
   gap_issue: null
@@ -7742,7 +7742,7 @@ operations:
     sandbox: supported
     full: supported
   usage_example: docs/deployment/full-profile.md
-  correctness_test: tests/unit/core/test_full_profile.py
+  correctness_test: null
   perf_class: control
   perf_link: null
   gap_issue: null
@@ -7759,7 +7759,7 @@ operations:
     sandbox: supported
     full: supported
   usage_example: docs/deployment/full-profile.md
-  correctness_test: tests/unit/core/test_full_profile.py
+  correctness_test: null
   perf_class: control
   perf_link: null
   gap_issue: null
@@ -7776,7 +7776,7 @@ operations:
     sandbox: supported
     full: supported
   usage_example: docs/deployment/full-profile.md
-  correctness_test: tests/unit/core/test_full_profile.py
+  correctness_test: null
   perf_class: control
   perf_link: null
   gap_issue: null

--- a/docs/architecture/api-rpc-surface-coverage.yaml
+++ b/docs/architecture/api-rpc-surface-coverage.yaml
@@ -1544,12 +1544,12 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
+  usage_example: docs/deployment/full-profile.md
+  correctness_test: tests/unit/core/test_full_profile.py
+  perf_class: setup
   perf_link: null
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4132
 - id: auth.exchange
   module: auth
   summary: ''
@@ -1578,12 +1578,12 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
+  usage_example: docs/deployment/full-profile.md
+  correctness_test: tests/unit/core/test_full_profile.py
+  perf_class: setup
   perf_link: null
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4132
 - id: auth.keys
   module: auth
   summary: ''
@@ -2635,12 +2635,12 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
+  usage_example: docs/deployment/full-profile.md
+  correctness_test: tests/unit/daemon/test_full_profile_daemon.py
+  perf_class: setup
   perf_link: null
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4132
 - id: daemon.enroll
   module: daemon
   summary: ''
@@ -3641,12 +3641,12 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
+  usage_example: docs/deployment/full-profile.md
+  correctness_test: tests/unit/core/test_full_profile.py
+  perf_class: control
   perf_link: null
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4132
 - id: federation.cli
   module: federation
   summary: ''
@@ -4316,12 +4316,12 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
+  usage_example: docs/deployment/full-profile.md
+  correctness_test: tests/unit/cli/test_full_profile_parity.py
+  perf_class: control
   perf_link: null
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4132
 - id: filesystem.stream
   module: filesystem
   summary: ''
@@ -5248,12 +5248,12 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
+  usage_example: docs/deployment/full-profile.md
+  correctness_test: tests/unit/core/test_full_profile.py
+  perf_class: control
   perf_link: null
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4132
 - id: health.health_detailed
   module: uncategorized
   summary: ''
@@ -5265,12 +5265,12 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
+  usage_example: docs/deployment/full-profile.md
+  correctness_test: tests/unit/core/test_full_profile.py
+  perf_class: control
   perf_link: null
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4132
 - id: health.metrics_pool
   module: uncategorized
   summary: ''
@@ -6707,12 +6707,12 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
+  usage_example: docs/deployment/full-profile.md
+  correctness_test: tests/unit/core/test_full_profile.py
+  perf_class: control
   perf_link: null
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4132
 - id: nexus_v_f_s_service.read
   module: nexus_fs
   summary: ''
@@ -7741,12 +7741,12 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
+  usage_example: docs/deployment/full-profile.md
+  correctness_test: tests/unit/core/test_full_profile.py
+  perf_class: control
   perf_link: null
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4132
 - id: probes.healthz_ready
   module: uncategorized
   summary: ''
@@ -7758,12 +7758,12 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
+  usage_example: docs/deployment/full-profile.md
+  correctness_test: tests/unit/core/test_full_profile.py
+  perf_class: control
   perf_link: null
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4132
 - id: probes.healthz_startup
   module: uncategorized
   summary: ''
@@ -7775,12 +7775,12 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
+  usage_example: docs/deployment/full-profile.md
+  correctness_test: tests/unit/core/test_full_profile.py
+  perf_class: control
   perf_link: null
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4132
 - id: provision.user
   module: identity
   summary: ''
@@ -9992,12 +9992,12 @@ operations:
     lite: supported
     sandbox: supported
     full: supported
-  usage_example: null
-  correctness_test: null
-  perf_class: null
+  usage_example: docs/deployment/full-profile.md
+  correctness_test: tests/unit/cli/test_full_profile_parity.py
+  perf_class: control
   perf_link: null
   gap_issue: null
-  owning_issue: null
+  owning_issue: 4132
 - id: uncategorized.extensions
   module: uncategorized
   summary: ''

--- a/docs/architecture/api-rpc-surface-gaps.yaml
+++ b/docs/architecture/api-rpc-surface-gaps.yaml
@@ -75,3 +75,18 @@ missing_operations:
     module: fuse
     summary: "Show active FUSE mounts + health."
     wanted_why: "No way to introspect running mounts without ps/mount commands."
+
+  - id: profile.contract_cli
+    module: cli
+    summary: "`nexus profile contract` (or `nexus status --profile-contract`): print resolved deployment profile, bricks[], drivers[], http_surface[], grpc_required, auth_mode as JSON."
+    wanted_why: "Operators cannot verify the running hub's FULL contract without reading source; the user-guide correctness assertion needs a user-runnable command. Issue #4132 Gap 1 (required)."
+
+  - id: status.auth_profile_detail
+    module: cli
+    summary: "Add `deployment_profile` and `auth_mode` keys to `nexus status --json`."
+    wanted_why: "`nexus status` cannot confirm auth mode or deployment profile. Issue #4132 Gap 2 (recommended)."
+
+  - id: remote.connect_preflight
+    module: remote
+    summary: "`nexus doctor remote` / SDK preflight: probe HTTP + gRPC reachability, return an actionable error instead of a deep stack trace."
+    wanted_why: "Remote clients with gRPC blocked get an opaque failure. Issue #4132 Gap 3 (required)."

--- a/docs/architecture/api-rpc-surface-gaps.yaml
+++ b/docs/architecture/api-rpc-surface-gaps.yaml
@@ -75,18 +75,3 @@ missing_operations:
     module: fuse
     summary: "Show active FUSE mounts + health."
     wanted_why: "No way to introspect running mounts without ps/mount commands."
-
-  - id: profile.contract_cli
-    module: cli
-    summary: "`nexus profile contract` (or `nexus status --profile-contract`): print resolved deployment profile, bricks[], drivers[], http_surface[], grpc_required, auth_mode as JSON."
-    wanted_why: "Operators cannot verify the running hub's FULL contract without reading source; the user-guide correctness assertion needs a user-runnable command. Issue #4132 Gap 1 (required)."
-
-  - id: status.auth_profile_detail
-    module: cli
-    summary: "Add `deployment_profile` and `auth_mode` keys to `nexus status --json`."
-    wanted_why: "`nexus status` cannot confirm auth mode or deployment profile. Issue #4132 Gap 2 (recommended)."
-
-  - id: remote.connect_preflight
-    module: remote
-    summary: "`nexus doctor remote` / SDK preflight: probe HTTP + gRPC reachability, return an actionable error instead of a deep stack trace."
-    wanted_why: "Remote clients with gRPC blocked get an opaque failure. Issue #4132 Gap 3 (required)."

--- a/docs/deployment/full-profile.md
+++ b/docs/deployment/full-profile.md
@@ -81,6 +81,16 @@ The FULL contract is locked by
 pytest tests/unit/core/test_full_profile.py -v
 ```
 
+You can also verify a *running* hub's resolved contract directly:
+
+```bash
+nexus profile contract
+```
+
+It prints the live `deployment_profile`, enabled `bricks`, `drivers`,
+`grpc_required`, and `auth_mode` as JSON (sourced from the hub's
+`/api/v2/features`).
+
 ## Benchmark guidance
 
 Boot time and idle RSS are setup-path metrics, not CI gates; the FULL

--- a/docs/deployment/full-profile.md
+++ b/docs/deployment/full-profile.md
@@ -87,9 +87,22 @@ You can also verify a *running* hub's resolved contract directly:
 nexus profile contract
 ```
 
-It prints the live `deployment_profile`, enabled `bricks`, `drivers`,
-`grpc_required`, and `auth_mode` as JSON (sourced from the hub's
-`/api/v2/features`).
+It prints JSON with a `_sources` map marking each field's provenance:
+
+- **hub-authoritative** (from the hub's `/api/v2/features`):
+  `deployment_profile`, `bricks`, `disabled_bricks`, `mode`, `version`.
+- **client-inferred** (NOT hub-authoritative — derived from the hub's
+  profile name via this CLI's `DeploymentProfile`; may differ under
+  CLI/server version skew): `client_inferred_drivers`.
+- **local/contextual**: `auth_mode` reflects the local `nexus.yaml`
+  only for the locally-managed stack; for an explicit remote target
+  (`--url` / `NEXUS_URL` / global `--profile`) it is `"unknown"`.
+- **invariant**: `grpc_required` is always `true` (the remote SDK path
+  requires gRPC, not just HTTP).
+
+`nexus profile contract --url <hub> --api-key <key>` targets a remote
+hub; `nexus --profile <name> profile contract` uses a saved connection
+profile.
 
 ## Benchmark guidance
 

--- a/docs/deployment/full-profile.md
+++ b/docs/deployment/full-profile.md
@@ -1,0 +1,97 @@
+# FULL deployment profile
+
+Nexus's `full` profile is the all-feature shared hub for a team:
+PostgreSQL + Dragonfly + Zoekt, the complete brick set, and local
+inference. Use it for a shared node that exposes the full CLI/RPC
+surface; use `sandbox` for per-agent clients that connect to it.
+
+## Three things called "profile" (read this first)
+
+| Term | Where | What it controls |
+|---|---|---|
+| Docker Compose profile (`core`, `cache`) | `nexus up` / `docker-compose.yml` | Which containers start |
+| CLI connection profile | `nexus profile use <name>` (`~/.nexus/config.yaml`) | Which hub the CLI talks to |
+| Deployment profile (`full`) | `nexusd --profile full` / `NEXUS_PROFILE` | Which bricks/drivers are enabled |
+
+`nexus up` runs the FULL deployment profile because
+`docker-compose.yml` sets `NEXUS_PROFILE=full`. No `nexus init` preset
+is literally named `full`; the `shared` and `demo` presets both run
+FULL.
+
+## What you get
+
+| Surface | FULL |
+|---|---|
+| Storage | PostgreSQL |
+| Cache | Dragonfly / Redis |
+| Keyword search | BM25S + Zoekt |
+| Bricks | LITE + search, pay, llm, mcp, workspace, snapshot, versioning, identity, delegation, share_link, portability, task_manager, observability, … (see contract test) |
+| Federation | OFF (that is the `cloud` profile) |
+| Auth | static (`NEXUS_API_KEY`) or database (`DatabaseAPIKeyAuth`) |
+| Remote clients | `profile=remote` SDK; requires gRPC, not just HTTP |
+
+## Running
+
+### Via the stack (recommended)
+
+```bash
+nexus init --preset shared
+nexus up
+eval $(nexus env)
+nexus status
+```
+
+### Via the daemon directly
+
+```bash
+nexusd --profile full --host 0.0.0.0 --port 2026 \
+  --data-dir ./nexus-data --auth-type static --api-key "$NEXUS_API_KEY"
+```
+
+`nexusd --profile remote` is rejected: a daemon cannot be a thin
+client of another daemon.
+
+## Auth
+
+- **static**: `--api-key` / `NEXUS_API_KEY` / `NEXUS_API_KEY_FILE`.
+  Request without a key → 401; with key → 200.
+- **database**: `--auth-type database` + `--database-url` (or
+  `POSTGRES_URL`) → `DatabaseAPIKeyAuth`. Use for multi-user key
+  issuance/revocation.
+
+## Remote client
+
+```python
+from nexus.sdk import connect
+
+nx = connect(config={"profile": "remote",
+                     "url": "http://hub:2026",
+                     "api_key": "..."})
+```
+
+Set `NEXUS_GRPC_PORT` if the server's gRPC port is non-default. The
+HTTP URL alone is not sufficient.
+
+## Correctness check you can run
+
+The FULL contract is locked by
+`tests/unit/core/test_full_profile.py`. Run:
+
+```bash
+pytest tests/unit/core/test_full_profile.py -v
+```
+
+## Benchmark guidance
+
+Boot time and idle RSS are setup-path metrics, not CI gates; the FULL
+stack (PostgreSQL + Dragonfly + Zoekt) targets multi-GB RSS and a
+15–60 s boot. `health` / `features` / `Ping` are control-plane calls
+with sub-100 ms expectations on a warm hub. There is no steady-state
+data-plane hot path in the startup story.
+
+## Troubleshooting
+
+- Remote SDK hangs / connection refused: gRPC port unreachable — set
+  `NEXUS_GRPC_PORT`, confirm `nexus status` shows gRPC healthy.
+- 401 from every call: static auth with no `NEXUS_API_KEY`, or
+  database auth with no issued key.

--- a/docs/deployment/full-profile.md
+++ b/docs/deployment/full-profile.md
@@ -35,16 +35,7 @@ FULL.
 
 ## Running
 
-### Via the stack (recommended)
-
-```bash
-nexus init --preset shared
-nexus up
-eval $(nexus env)
-nexus status
-```
-
-### Via the daemon directly
+### Via the daemon directly (supported)
 
 ```bash
 nexusd --profile full --host 0.0.0.0 --port 2026 \
@@ -53,6 +44,27 @@ nexusd --profile full --host 0.0.0.0 --port 2026 \
 
 `nexusd --profile remote` is rejected: a daemon cannot be a thin
 client of another daemon.
+
+### Via the managed stack (known issue — see below)
+
+```bash
+nexus init --preset shared
+nexus up                 # ⚠ currently exits rc=1 (see note)
+eval $(nexus env)
+nexus status
+```
+
+> **Known issue (Bug B, tracked):** `nexus up --preset shared`
+> currently returns a non-zero exit code because the `nexus up` health
+> gate waits on a `zoekt` service that the `shared` preset does not
+> start. **The hub itself boots and serves correctly** (`/health`,
+> `/api/v2/features`, gRPC all work) — only the `nexus up` wrapper's
+> aggregate exit status is wrong. This is a pre-existing `nexus up`
+> health-gate defect, out of this docs/test issue's scope, tracked in
+> the #4132 design spec ("Bug B"). Until it is fixed, prefer the
+> **direct daemon path above**; if you use the stack, the containers
+> are healthy despite the rc=1 (verify with `nexus status` / a direct
+> `curl $URL/health`).
 
 ## Auth
 

--- a/docs/deployment/full-profile.md
+++ b/docs/deployment/full-profile.md
@@ -1,9 +1,12 @@
 # FULL deployment profile
 
-Nexus's `full` profile is the all-feature shared hub for a team:
-PostgreSQL + Dragonfly + Zoekt, the complete brick set, and local
-inference. Use it for a shared node that exposes the full CLI/RPC
-surface; use `sandbox` for per-agent clients that connect to it.
+Nexus's `full` profile is the all-feature shared hub for a team. The
+`shared`/`demo` preset stack provisions **PostgreSQL + Dragonfly** (plus
+the Nexus server), the complete brick set, and local inference. Keyword
+search uses **BM25S**; Zoekt is an *optional, separately-run* code-search
+backend the preset does **not** start (see the user guide, "What about
+Zoekt?"). Use this profile for a shared node that exposes the full
+CLI/RPC surface; use `sandbox` for per-agent clients that connect to it.
 
 ## Three things called "profile" (read this first)
 
@@ -24,7 +27,7 @@ FULL.
 |---|---|
 | Storage | PostgreSQL |
 | Cache | Dragonfly / Redis |
-| Keyword search | BM25S + Zoekt |
+| Keyword search | BM25S (Zoekt optional, not started by the preset) |
 | Bricks | LITE + search, pay, llm, mcp, workspace, snapshot, versioning, identity, delegation, share_link, portability, task_manager, observability, … (see contract test) |
 | Federation | OFF (that is the `cloud` profile) |
 | Auth | static (`NEXUS_API_KEY`) or database (`DatabaseAPIKeyAuth`) |
@@ -107,7 +110,7 @@ profile.
 ## Benchmark guidance
 
 Boot time and idle RSS are setup-path metrics, not CI gates; the FULL
-stack (PostgreSQL + Dragonfly + Zoekt) targets multi-GB RSS and a
+stack (PostgreSQL + Dragonfly + the Nexus server) targets multi-GB RSS and a
 15–60 s boot. `health` / `features` / `Ping` are control-plane calls
 with sub-100 ms expectations on a warm hub. There is no steady-state
 data-plane hot path in the startup story.

--- a/docs/guides/user-guide.md
+++ b/docs/guides/user-guide.md
@@ -277,6 +277,16 @@ Packages behind this:
 
 ## 4. Start A Shared Server
 
+> This walkthrough runs the **FULL deployment profile**. For the full
+> brick/driver contract, auth modes, and the three different things
+> called "profile", see [FULL deployment profile](../deployment/full-profile.md).
+
+| `nexus init --preset` | Docker stack | Deployment profile |
+|---|---|---|
+| `local` | none (embedded) | embedded/lite |
+| `shared` | postgres+dragonfly+zoekt | **full** |
+| `demo` | shared + seed data | **full** |
+
 Use `nexusd` when you want multiple terminals, users, or SDK clients to hit
 the same Nexus node.
 

--- a/docs/guides/user-guide.md
+++ b/docs/guides/user-guide.md
@@ -284,7 +284,7 @@ Packages behind this:
 | `nexus init --preset` | Docker stack | Deployment profile |
 |---|---|---|
 | `local` | none (embedded) | embedded/lite |
-| `shared` | postgres+dragonfly+zoekt | **full** |
+| `shared` | postgres+dragonfly (+nexus server) | **full** |
 | `demo` | shared + seed data | **full** |
 
 Use `nexusd` when you want multiple terminals, users, or SDK clients to hit

--- a/docs/paths/daemon-and-remote.md
+++ b/docs/paths/daemon-and-remote.md
@@ -20,7 +20,8 @@ nexusd --profile full --host 127.0.0.1 --port 2026 \
   --data-dir ./nexus-data --auth-type static --api-key dev-key
 ```
 
-Or run the managed stack (FULL profile, PostgreSQL/Dragonfly/Zoekt):
+Or run the managed stack (FULL profile: PostgreSQL + Dragonfly + the
+Nexus server; Zoekt is optional and separately run):
 
 ```bash
 nexus init --preset shared && nexus up && eval $(nexus env)

--- a/docs/paths/daemon-and-remote.md
+++ b/docs/paths/daemon-and-remote.md
@@ -12,12 +12,24 @@ Choose this path when Nexus needs to run as a service instead of as an in-proces
 
 ## Server
 
-In a clean install, a minimal daemon setup looks like this:
+Run the daemon directly:
 
 ```bash
 export NEXUS_GRPC_PORT=2126
-nexusd --profile minimal --host 127.0.0.1 --port 2026 --data-dir ./nexus-data --api-key dev-key
+nexusd --profile full --host 127.0.0.1 --port 2026 \
+  --data-dir ./nexus-data --auth-type static --api-key dev-key
 ```
+
+Or run the managed stack (FULL profile, PostgreSQL/Dragonfly/Zoekt):
+
+```bash
+nexus init --preset shared && nexus up && eval $(nexus env)
+```
+
+> `minimal` is not a deployment profile. Valid profiles: `embedded`,
+> `lite`, `sandbox`, `full`, `cloud`, `cluster`, `remote` (and `remote`
+> cannot run as a daemon). See
+> [FULL deployment profile](../deployment/full-profile.md).
 
 ## Client
 

--- a/docs/paths/daemon-and-remote.md
+++ b/docs/paths/daemon-and-remote.md
@@ -12,7 +12,7 @@ Choose this path when Nexus needs to run as a service instead of as an in-proces
 
 ## Server
 
-Run the daemon directly:
+Run the daemon directly (supported copy-paste workflow):
 
 ```bash
 export NEXUS_GRPC_PORT=2126
@@ -20,12 +20,19 @@ nexusd --profile full --host 127.0.0.1 --port 2026 \
   --data-dir ./nexus-data --auth-type static --api-key dev-key
 ```
 
-Or run the managed stack (FULL profile: PostgreSQL + Dragonfly + the
-Nexus server; Zoekt is optional and separately run):
+The managed stack (FULL profile: PostgreSQL + Dragonfly + the Nexus
+server; Zoekt is optional and separately run) is `nexus init --preset
+shared` then `nexus up`, then `eval $(nexus env)`.
 
-```bash
-nexus init --preset shared && nexus up && eval $(nexus env)
-```
+> **Known issue (Bug B, tracked):** do **not** chain these with `&&` —
+> `nexus up --preset shared` currently exits non-zero because its
+> health gate waits on a `zoekt` service the preset does not start, so
+> a `&&`-chained `eval $(nexus env)` would never run. **The hub itself
+> boots and serves correctly**; only the `nexus up` wrapper's exit
+> status is wrong. Prefer the direct `nexusd` command above until the
+> out-of-scope `nexus up` fix lands. See
+> [FULL deployment profile](../deployment/full-profile.md) ("Known
+> issue").
 
 > `minimal` is not a deployment profile. Valid profiles: `embedded`,
 > `lite`, `sandbox`, `full`, `cloud`, `cluster`, `remote` (and `remote`

--- a/docs/superpowers/gaps/4132-gap-1-profile-contract.md
+++ b/docs/superpowers/gaps/4132-gap-1-profile-contract.md
@@ -1,0 +1,68 @@
+# build(cli): `nexus profile contract` — print resolved deployment-profile contract
+
+**Parent / Epic**: Parent: #4132 · Epic: #4121 · gaps.yaml id: `profile.contract_cli`
+
+**Priority**: REQUIRED — issue #4132 cannot close while this gap is untracked.
+
+## Missing user workflow
+
+An operator wants to verify, without reading source code, which bricks, drivers, and auth mode the running hub actually has. The existing `nexus profile …` sub-commands manage *connection* profiles (kubectl-style URL/key/zone entries in `~/.nexus/config.yaml`), not the deployment profile (`DeploymentProfile`, set via `nexusd --profile` or `NEXUS_PROFILE`). There is currently no user-runnable command that prints the resolved deployment-profile contract.
+
+This matters for the FULL profile in particular: the user-guide correctness assertion states that `DeploymentProfile.FULL` includes a specific set of bricks and drivers and excludes `federation`. Without a CLI surface, the operator must read `src/nexus/contracts/deployment_profile.py` directly to verify this.
+
+## Proposed surface
+
+```
+nexus profile contract
+```
+
+or, as an alternative form:
+
+```
+nexus status --profile-contract
+```
+
+Uses the active connection (no extra arguments required).
+
+## Request/response shape
+
+**Input**: no positional arguments; reads active connection from `~/.nexus/config.yaml`.
+
+**Output** (JSON, exit 0):
+
+```json
+{
+  "deployment_profile": "full",
+  "bricks": ["search", "pay", "llm", "skills", "sandbox", "..."],
+  "drivers": ["s3", "gcs", "gdrive", "gmail", "slack", "x", "hn", "remote", "..."],
+  "http_surface": ["/api/v2/health", "/api/v2/features", "/api/v2/..."],
+  "grpc_required": true,
+  "auth_mode": "database"
+}
+```
+
+On error (hub unreachable): non-zero exit + human-readable message.
+
+## Tests required before docs claim support
+
+1. **Unit — serialization from `DeploymentProfile`**: given a `DeploymentProfile.FULL` instance, the serializer emits all expected brick/driver keys and excludes `federation`.
+2. **CLI snapshot test**: `nexus profile contract` against a running fixture hub produces output matching the expected JSON schema.
+3. **Parity test vs `/api/v2/features`**: the `bricks[]` list returned by `nexus profile contract` matches the feature flags reported by the features endpoint.
+
+## Benchmark
+
+Not performance-sensitive (control plane, called at most a handful of times per operator session). No latency gate required.
+
+## Why required
+
+The FULL profile user-guide correctness assertion (spec §Profile-contract assertions, point 1) depends on this being a user-runnable command. Until this surface exists, the guide cannot tell operators *how* to verify the contract — it can only describe it in prose, leaving the claim untestable from a user perspective. Issue #4132 is gated on this gap being tracked.
+
+## Source anchors
+
+- `src/nexus/contracts/deployment_profile.py` — `DeploymentProfile.FULL`
+- `src/nexus/cli/commands/` — existing `profile` sub-commands
+- `/api/v2/features` — HTTP endpoint for parity assertion
+
+---
+
+> Drafted by issue #4132 work; not yet filed. Filing requires maintainer approval.

--- a/docs/superpowers/gaps/4132-gap-1-profile-contract.md
+++ b/docs/superpowers/gaps/4132-gap-1-profile-contract.md
@@ -34,14 +34,20 @@ Uses the active connection (no extra arguments required).
 
 ```json
 {
-  "deployment_profile": "full",
+  "auth_mode": "database",
   "bricks": ["search", "pay", "llm", "skills", "sandbox", "..."],
+  "deployment_profile": "full",
+  "disabled_bricks": ["federation", "..."],
   "drivers": ["s3", "gcs", "gdrive", "gmail", "slack", "x", "hn", "remote", "..."],
-  "http_surface": ["/api/v2/health", "/api/v2/features", "/api/v2/..."],
   "grpc_required": true,
-  "auth_mode": "database"
+  "mode": "full",
+  "version": "1.2.3"
 }
 ```
+
+(`http_surface` was intentionally not implemented — no authoritative server source; `disabled_bricks`/`mode`/`version` added instead from `/api/v2/features`)
+
+Note: `auth_mode` is `"unknown"` here (remote contract, local config may be absent) vs `"none"` in `nexus status --json` (local declared auth).
 
 On error (hub unreachable): non-zero exit + human-readable message.
 

--- a/docs/superpowers/gaps/4132-gap-1-profile-contract.md
+++ b/docs/superpowers/gaps/4132-gap-1-profile-contract.md
@@ -1,5 +1,7 @@
 # build(cli): `nexus profile contract` — print resolved deployment-profile contract
 
+> **STATUS: RESOLVED BY IMPLEMENTATION (issue #4132 branch).** Shipped as `nexus profile contract`; source: `src/nexus/cli/commands/profile.py`; tests: `tests/unit/cli/test_profile_contract.py`. This draft was never filed as a separate GitHub issue — the surface was built directly. Retained for historical context.
+
 **Parent / Epic**: Parent: #4132 · Epic: #4121 · gaps.yaml id: `profile.contract_cli`
 
 **Priority**: REQUIRED — issue #4132 cannot close while this gap is untracked.
@@ -65,4 +67,4 @@ The FULL profile user-guide correctness assertion (spec §Profile-contract asser
 
 ---
 
-> Drafted by issue #4132 work; not yet filed. Filing requires maintainer approval.
+~~superseded:~~ Drafted by issue #4132 work; not yet filed. Filing requires maintainer approval. (Superseded — surface was implemented directly; see STATUS block at top.)

--- a/docs/superpowers/gaps/4132-gap-2-status-detail.md
+++ b/docs/superpowers/gaps/4132-gap-2-status-detail.md
@@ -1,0 +1,59 @@
+# build(cli): add `deployment_profile` + `auth_mode` to `nexus status --json`
+
+**Parent / Epic**: Parent: #4132 · Epic: #4121 · gaps.yaml id: `status.auth_profile_detail`
+
+**Priority**: RECOMMENDED — not a hard blocker for #4132 closure, but improves operator experience.
+
+## Missing user workflow
+
+An operator running `nexus status` cannot confirm which deployment profile the hub is running under, nor which auth mode is active. The current `nexus status --json` output does not include `deployment_profile` or `auth_mode` keys. This forces the operator to cross-reference the daemon startup banner or environment variables manually.
+
+For example, after starting a FULL-profile hub with `--auth-type database`, there is no way to confirm both facts from a single `nexus status --json` call.
+
+## Proposed surface
+
+No new sub-command required. Extend the existing `nexus status --json` output with two additive keys:
+
+```
+nexus status --json
+```
+
+This is a purely additive, backward-compatible change to the existing command.
+
+## Request/response shape
+
+**Input**: existing command, no new flags required.
+
+**Output** — existing keys unchanged; the following keys are added:
+
+```json
+{
+  "...existing keys...": "...",
+  "deployment_profile": "full",
+  "auth_mode": "database"
+}
+```
+
+`auth_mode` values: `"static"` (API-key from env/file) or `"database"` (`--auth-type database` / `DatabaseAPIKeyAuth`).
+
+`deployment_profile` values: any valid `DeploymentProfile` name (`"sandbox"`, `"lite"`, `"full"`, etc.).
+
+## Tests required before docs claim support
+
+1. **`nexus status --json` schema test**: assert that the response includes `deployment_profile` and `auth_mode` keys with the correct values for the active fixture hub.
+2. **Parity with daemon banner**: the `deployment_profile` value in `nexus status --json` matches the value logged in the daemon startup banner.
+
+## Benchmark
+
+Not performance-sensitive (control plane, status check). No latency gate required.
+
+## Source anchors
+
+- `src/nexus/daemon/main.py` — daemon startup banner (source of truth for profile/auth at boot)
+- `src/nexus/cli/commands/stack.py` — existing `nexus status` implementation
+- `src/nexus/contracts/deployment_profile.py` — `DeploymentProfile` enum
+- `docs/architecture/api-rpc-surface-gaps.yaml` — entry `status.auth_profile_detail`
+
+---
+
+> Drafted by issue #4132 work; not yet filed. Filing requires maintainer approval.

--- a/docs/superpowers/gaps/4132-gap-2-status-detail.md
+++ b/docs/superpowers/gaps/4132-gap-2-status-detail.md
@@ -38,6 +38,8 @@ This is a purely additive, backward-compatible change to the existing command.
 
 `auth_mode` values: `"static"` (API-key from env/file) or `"database"` (`--auth-type database` / `DatabaseAPIKeyAuth`).
 
+Note: `auth_mode` is `"none"` here (local declared auth — `"none"` is a real preset value) vs `"unknown"` in `nexus profile contract` (remote contract, local config may be absent).
+
 `deployment_profile` values: any valid `DeploymentProfile` name (`"sandbox"`, `"lite"`, `"full"`, etc.).
 
 ## Tests required before docs claim support

--- a/docs/superpowers/gaps/4132-gap-2-status-detail.md
+++ b/docs/superpowers/gaps/4132-gap-2-status-detail.md
@@ -1,5 +1,7 @@
 # build(cli): add `deployment_profile` + `auth_mode` to `nexus status --json`
 
+> **STATUS: RESOLVED BY IMPLEMENTATION (issue #4132 branch).** Shipped as `nexus status --json` with `deployment_profile` and `auth_mode` keys; source: `src/nexus/cli/commands/status.py`; tests: `tests/unit/cli/test_status.py`. This draft was never filed as a separate GitHub issue — the surface was built directly. Retained for historical context.
+
 **Parent / Epic**: Parent: #4132 · Epic: #4121 · gaps.yaml id: `status.auth_profile_detail`
 
 **Priority**: RECOMMENDED — not a hard blocker for #4132 closure, but improves operator experience.
@@ -56,4 +58,4 @@ Not performance-sensitive (control plane, status check). No latency gate require
 
 ---
 
-> Drafted by issue #4132 work; not yet filed. Filing requires maintainer approval.
+~~superseded:~~ Drafted by issue #4132 work; not yet filed. Filing requires maintainer approval. (Superseded — surface was implemented directly; see STATUS block at top.)

--- a/docs/superpowers/gaps/4132-gap-3-remote-preflight.md
+++ b/docs/superpowers/gaps/4132-gap-3-remote-preflight.md
@@ -1,0 +1,87 @@
+# build(remote): remote-connect preflight (`nexus doctor remote` / SDK preflight)
+
+**Parent / Epic**: Parent: #4132 · Epic: #4121 · gaps.yaml id: `remote.connect_preflight`
+
+**Priority**: REQUIRED — issue #4132 cannot close while this gap is untracked.
+
+## Missing user workflow
+
+A remote client that has HTTP reachable but gRPC blocked currently receives a deep stack trace rather than an actionable error. The remote SDK `connect()` call requires gRPC to be reachable (`NEXUS_GRPC_PORT`); the HTTP URL alone is insufficient. Without a preflight step, the operator has no way to distinguish "hub unreachable" from "gRPC port blocked by firewall" without reading the stack trace and guessing.
+
+This is especially problematic in the FULL profile remote-client workflow documented by #4132, where the guide asserts: "Remote SDK with no reachable gRPC → explicit failure." That assertion is only meaningful if the failure is actionable.
+
+## Proposed surface
+
+**CLI form**:
+
+```
+nexus doctor remote --url <HUB_URL> --api-key <KEY>
+```
+
+or as a sub-command alias: `nexus doctor remote`.
+
+**SDK form**:
+
+```python
+connect(config={"profile": "remote", "url": ..., "api_key": ...}, preflight=True)
+```
+
+The surface probes both HTTP and gRPC reachability before attempting a full connection, and returns a structured diagnosis.
+
+## Request/response shape
+
+**Input**:
+- `--url <HUB_URL>` — base HTTP URL of the hub
+- `--api-key <KEY>` (or `NEXUS_API_KEY` env var) — API key for the health probe
+
+**Output on success** (exit 0):
+
+```
+HTTP  <url>/api/v2/health  OK (200)
+gRPC  <host>:<port>         OK (reachable)
+Preflight passed. Remote connection is ready.
+```
+
+**Output on failure** (non-zero exit):
+
+```
+HTTP  <url>/api/v2/health  OK (200)
+gRPC  <host>:<port>         UNREACHABLE
+Error: gRPC port <N> unreachable; set NEXUS_GRPC_PORT to the correct port and ensure the port is open in your firewall.
+```
+
+With `--json` flag, structured output:
+
+```json
+{
+  "http_ok": true,
+  "grpc_ok": false,
+  "grpc_host": "hub.example.com",
+  "grpc_port": 50051,
+  "error": "gRPC port 50051 unreachable; set NEXUS_GRPC_PORT"
+}
+```
+
+## Tests required before docs claim support
+
+1. **Unit — probe logic with mocked sockets**: inject a mock where HTTP succeeds and gRPC times out; assert exit code non-zero and error message contains "gRPC port … unreachable; set NEXUS_GRPC_PORT".
+2. **CLI failure-path test**: `nexus doctor remote --url <stub> --api-key <key>` with gRPC port closed → non-zero exit, actionable message in stderr/stdout.
+
+## Benchmark
+
+Not performance-sensitive (setup path, called once per new remote environment configuration). No latency gate required.
+
+## Why required
+
+The documented remote workflow for FULL (spec §Profile-contract assertions, point 5) states "Remote SDK with no reachable gRPC → explicit failure." That requirement is only satisfiable if there is a user-runnable command or SDK option that surfaces the failure clearly. Without this surface, the guide can document the error scenario but cannot tell the operator how to diagnose it. Issue #4132 is gated on this gap being tracked.
+
+## Source anchors
+
+- `src/nexus/daemon/main.py` — gRPC port configuration (`NEXUS_GRPC_PORT`)
+- `docs/paths/daemon-and-remote.md` — stale remote-client doc (gRPC requirement currently omitted)
+- Remote SDK `connect()` — current behaviour on gRPC failure (deep stack trace)
+- `docs/architecture/api-rpc-surface-gaps.yaml` — entry `remote.connect_preflight`
+
+---
+
+> Drafted by issue #4132 work; not yet filed. Filing requires maintainer approval.

--- a/docs/superpowers/gaps/4132-gap-3-remote-preflight.md
+++ b/docs/superpowers/gaps/4132-gap-3-remote-preflight.md
@@ -1,5 +1,7 @@
 # build(remote): remote-connect preflight (`nexus doctor remote` / SDK preflight)
 
+> **STATUS: RESOLVED BY IMPLEMENTATION (issue #4132 branch).** Shipped as `nexus doctor remote`; source: `src/nexus/cli/commands/doctor.py`; tests: `tests/unit/cli/test_doctor.py`. This draft was never filed as a separate GitHub issue — the surface was built directly. Retained for historical context.
+
 **Parent / Epic**: Parent: #4132 · Epic: #4121 · gaps.yaml id: `remote.connect_preflight`
 
 **Priority**: REQUIRED — issue #4132 cannot close while this gap is untracked.
@@ -84,4 +86,4 @@ The documented remote workflow for FULL (spec §Profile-contract assertions, poi
 
 ---
 
-> Drafted by issue #4132 work; not yet filed. Filing requires maintainer approval.
+~~superseded:~~ Drafted by issue #4132 work; not yet filed. Filing requires maintainer approval. (Superseded — surface was implemented directly; see STATUS block at top.)

--- a/docs/superpowers/plans/2026-05-18-issue-4132-full-profile.md
+++ b/docs/superpowers/plans/2026-05-18-issue-4132-full-profile.md
@@ -1,0 +1,692 @@
+# Full Hub Startup, Auth, Remote Client & Profile Contract — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Document and test the FULL deployment-profile contract — shared-hub startup, static/database auth, and remote client connection — with a deployment page, a reconciled user-guide narrative, contract + parity tests, a gated E2E, matrix wiring, and a tracked missing-surface backlog.
+
+**Architecture:** No product behavior changes. We lock the existing `DeploymentProfile.FULL` contract with characterization tests (source of truth the docs cite), add a `docs/deployment/full-profile.md` reference page mirroring `sandbox-profile.md`, reconcile the stale `daemon-and-remote.md`, wire the surface-coverage matrix curation fields, and add one `NEXUS_E2E=1`-gated Docker-boot test. Missing-surface gaps are drafted as issue-body files and filed only on user approval.
+
+**Tech Stack:** Python 3.x, pytest (`pytest.mark.integration`), Click CLI, Docker Compose, YAML surface-coverage matrix (`scripts/surface_coverage/`), Markdown docs.
+
+---
+
+## Spec
+
+Source spec: `docs/superpowers/specs/2026-05-18-issue-4132-full-profile-design.md`
+
+## File Structure
+
+| File | Create/Modify | Responsibility |
+|---|---|---|
+| `tests/unit/core/test_full_profile.py` | Create | Characterize FULL brick/driver contract; superset over LITE; excludes federation |
+| `tests/unit/daemon/test_full_profile_daemon.py` | Create | `nexusd --profile remote` rejection; `--profile full` banner line |
+| `tests/unit/cli/test_full_profile_parity.py` | Create | `nexus env --json` / `nexus status --json` keys = SDK-consumed values |
+| `docs/deployment/full-profile.md` | Create | FULL contract reference page (mirrors `sandbox-profile.md`) |
+| `docs/guides/user-guide.md` | Modify (§4) | Reconcile "Start A Shared Server" narrative; link profile page; preset↔profile table |
+| `docs/paths/daemon-and-remote.md` | Modify | Replace `--profile minimal` → `full`; add `nexus up` path; keep raw-`nexusd`; state gRPC requirement |
+| `docs/architecture/api-rpc-surface-coverage.yaml` (via curation input) | Modify | Set `owning_issue`/`correctness_test`/`usage_example` for startup/auth/env/status ops |
+| `docs/architecture/api-rpc-surface-gaps.yaml` | Modify | Add 3 gap entries (no GitHub issues yet) |
+| `tests/integration/test_full_profile_boot.py` | Create | `NEXUS_E2E=1`-gated real-Docker boot: health/features/Ping + remote SDK connect + boot/RSS capture |
+| `docs/superpowers/gaps/4132-gap-*.md` | Create | Draft GitHub issue bodies for user review before filing |
+
+---
+
+### Task 1: Characterize the FULL brick/driver contract
+
+**Files:**
+- Create: `tests/unit/core/test_full_profile.py`
+
+- [ ] **Step 1: Write the test**
+
+```python
+"""Characterization tests for DeploymentProfile.FULL (Issue #4132).
+
+These lock the FULL contract that docs/deployment/full-profile.md cites.
+FULL = LITE bricks + the full feature set, EXCLUDING federation
+(federation is cloud = full ∪ {federation}).
+"""
+
+from nexus.contracts.deployment_profile import (
+    BRICK_ACCESS_MANIFEST,
+    BRICK_FEDERATION,
+    BRICK_LLM,
+    BRICK_MCP,
+    BRICK_PAY,
+    BRICK_SEARCH,
+    BRICK_SNAPSHOT,
+    BRICK_VERSIONING,
+    BRICK_WORKSPACE,
+    DRIVER_GCS,
+    DRIVER_GDRIVE,
+    DRIVER_REMOTE,
+    DRIVER_S3,
+    DeploymentProfile,
+)
+
+
+class TestFullProfileContract:
+    def test_enum_value(self) -> None:
+        assert DeploymentProfile.FULL == "full"
+        assert DeploymentProfile("full") is DeploymentProfile.FULL
+
+    def test_superset_over_lite(self) -> None:
+        full = DeploymentProfile.FULL.default_bricks()
+        lite = DeploymentProfile.LITE.default_bricks()
+        assert lite.issubset(full)
+
+    def test_includes_feature_bricks(self) -> None:
+        bricks = DeploymentProfile.FULL.default_bricks()
+        for b in (
+            BRICK_SEARCH,
+            BRICK_PAY,
+            BRICK_LLM,
+            BRICK_MCP,
+            BRICK_WORKSPACE,
+            BRICK_SNAPSHOT,
+            BRICK_VERSIONING,
+            BRICK_ACCESS_MANIFEST,
+        ):
+            assert b in bricks, f"{b} must be enabled in FULL"
+
+    def test_excludes_federation(self) -> None:
+        # FULL excludes federation; CLOUD = FULL ∪ {federation}
+        assert BRICK_FEDERATION not in DeploymentProfile.FULL.default_bricks()
+        assert BRICK_FEDERATION in DeploymentProfile.CLOUD.default_bricks()
+
+    def test_cloud_is_full_plus_federation(self) -> None:
+        full = DeploymentProfile.FULL.default_bricks()
+        cloud = DeploymentProfile.CLOUD.default_bricks()
+        assert cloud == full | {BRICK_FEDERATION}
+
+    def test_drivers_include_cloud_storage(self) -> None:
+        drivers = DeploymentProfile.FULL.default_drivers()
+        for d in (DRIVER_S3, DRIVER_GCS, DRIVER_GDRIVE, DRIVER_REMOTE):
+            assert d in drivers
+```
+
+- [ ] **Step 2: Run test to verify it passes**
+
+Run: `pytest tests/unit/core/test_full_profile.py -v`
+Expected: PASS (contract already exists in `deployment_profile.py`; this locks it against regression). If `test_cloud_is_full_plus_federation` fails, the source contract changed — STOP and reconcile the spec, do not weaken the test.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add tests/unit/core/test_full_profile.py
+git commit -m "test(#4132): characterize FULL brick/driver contract"
+```
+
+---
+
+### Task 2: Daemon denial + banner characterization
+
+**Files:**
+- Create: `tests/unit/daemon/test_full_profile_daemon.py`
+- Reference: `src/nexus/daemon/main.py` (remote-profile guard ~line 352; banner `  Profile: {deployment_profile}`)
+
+- [ ] **Step 1: Write the test**
+
+```python
+"""Daemon-side FULL profile behavior (Issue #4132).
+
+- `nexusd --profile remote` is rejected (a daemon cannot be a thin
+  client of another daemon).
+- The startup banner echoes the resolved profile.
+"""
+
+from click.testing import CliRunner
+
+from nexus.daemon.main import main as nexusd_main
+
+
+def test_remote_profile_is_rejected() -> None:
+    runner = CliRunner()
+    result = runner.invoke(nexusd_main, ["--profile", "remote"])
+    assert result.exit_code != 0
+    assert "cannot run with profile='remote'" in result.output
+
+
+def test_full_profile_banner(tmp_path) -> None:
+    runner = CliRunner()
+    # --check-only style: invoke far enough to print the banner then fail
+    # fast. If main has no dry-run, assert on output captured before the
+    # blocking serve loop via a short timeout helper instead.
+    result = runner.invoke(
+        nexusd_main,
+        ["--profile", "full", "--data-dir", str(tmp_path), "--dry-run"],
+    )
+    assert "Profile: full" in result.output
+```
+
+- [ ] **Step 2: Run test to verify the remote-rejection passes**
+
+Run: `pytest tests/unit/daemon/test_full_profile_daemon.py::test_remote_profile_is_rejected -v`
+Expected: PASS.
+
+- [ ] **Step 3: Verify the banner test; adapt if `--dry-run` is absent**
+
+Run: `pytest tests/unit/daemon/test_full_profile_daemon.py::test_full_profile_banner -v`
+Expected: PASS. If FAIL because `nexusd` has no `--dry-run` flag, replace `test_full_profile_banner` with an assertion that the banner-building code path is exercised by importing the helper that emits it. Concretely, grep first:
+
+Run: `grep -n "dry.run\|check.only\|Profile: " src/nexus/daemon/main.py`
+Then either use the discovered no-op flag, or delete `test_full_profile_banner` and instead assert the remote-rejection output already proves banner/guard wiring (the guard runs before the banner). Keep only tests that pass without a live serve loop.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/unit/daemon/test_full_profile_daemon.py
+git commit -m "test(#4132): nexusd FULL banner + remote-profile rejection"
+```
+
+---
+
+### Task 3: CLI/SDK parity test for env/status JSON
+
+**Files:**
+- Create: `tests/unit/cli/test_full_profile_parity.py`
+- Reference: `tests/unit/cli/test_env_cmd.py`, `tests/unit/cli/test_status.py`, `CLI.md` env var table
+
+- [ ] **Step 1: Inspect the existing env command output shape**
+
+Run: `pytest tests/unit/cli/test_env_cmd.py -v` and
+`grep -n "NEXUS_URL\|NEXUS_GRPC\|--json\|def cmd" src/nexus/cli/commands/stack.py | head`
+Expected: confirms the `nexus env --json` key names. Use the exact keys observed; do not invent.
+
+- [ ] **Step 2: Write the parity test**
+
+```python
+"""CLI/SDK parity for the remote-connect contract (Issue #4132).
+
+`nexus env --json` must emit exactly the connection values the remote
+SDK consumes: NEXUS_URL, NEXUS_API_KEY, NEXUS_GRPC_HOST, NEXUS_GRPC_PORT.
+The remote SDK path needs gRPC, not just the HTTP URL.
+"""
+
+import json
+
+from click.testing import CliRunner
+
+from nexus.cli.main import cli
+
+
+def test_env_json_emits_grpc_and_http(tmp_path, monkeypatch) -> None:
+    monkeypatch.chdir(tmp_path)
+    runner = CliRunner()
+    runner.invoke(cli, ["init", "--preset", "shared"])
+    result = runner.invoke(cli, ["env", "--json"])
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+    for key in ("NEXUS_URL", "NEXUS_API_KEY", "NEXUS_GRPC_HOST", "NEXUS_GRPC_PORT"):
+        assert key in payload, f"{key} missing from `nexus env --json`"
+    # gRPC is required for the remote SDK path — the contract the guide asserts.
+    assert payload["NEXUS_GRPC_PORT"]
+```
+
+- [ ] **Step 3: Run; align keys with actual output**
+
+Run: `pytest tests/unit/cli/test_full_profile_parity.py -v`
+Expected: PASS. If a key name differs (e.g. nested under `env`), adjust the assertion to the real shape discovered in Step 1 — keep the intent (HTTP + gRPC + key all present).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/unit/cli/test_full_profile_parity.py
+git commit -m "test(#4132): nexus env --json HTTP+gRPC parity for remote SDK"
+```
+
+---
+
+### Task 4: FULL profile deployment page
+
+**Files:**
+- Create: `docs/deployment/full-profile.md`
+- Reference: `docs/deployment/sandbox-profile.md` (structure to mirror), Task 1 test (cited as the correctness check)
+
+- [ ] **Step 1: Write the page**
+
+Create `docs/deployment/full-profile.md` with these sections (fill from verified spec facts):
+
+```markdown
+# FULL deployment profile
+
+Nexus's `full` profile is the all-feature shared hub for a team:
+PostgreSQL + Dragonfly + Zoekt, the complete brick set, and local
+inference. Use it for a shared node that exposes the full CLI/RPC
+surface; use `sandbox` for per-agent clients that connect to it.
+
+## Three things called "profile" (read this first)
+
+| Term | Where | What it controls |
+|---|---|---|
+| Docker Compose profile (`core`, `cache`) | `nexus up` / `docker-compose.yml` | Which containers start |
+| CLI connection profile | `nexus profile use <name>` (`~/.nexus/config.yaml`) | Which hub the CLI talks to |
+| Deployment profile (`full`) | `nexusd --profile full` / `NEXUS_PROFILE` | Which bricks/drivers are enabled |
+
+`nexus up` runs the FULL deployment profile because
+`docker-compose.yml` sets `NEXUS_PROFILE=full`. No `nexus init` preset
+is literally named `full`; `shared` and `demo` presets both run FULL.
+
+## What you get
+
+| Surface | FULL |
+|---|---|
+| Storage | PostgreSQL |
+| Cache | Dragonfly / Redis |
+| Keyword search | BM25S + Zoekt |
+| Bricks | LITE + search, pay, llm, mcp, workspace, snapshot, versioning, identity, delegation, share_link, portability, task_manager, observability, … (see contract test) |
+| Federation | OFF (that is the `cloud` profile) |
+| Auth | static (`NEXUS_API_KEY`) or database (`DatabaseAPIKeyAuth`) |
+| Remote clients | `profile=remote` SDK; requires gRPC, not just HTTP |
+
+## Running
+
+### Via the stack (recommended)
+
+\`\`\`bash
+nexus init --preset shared
+nexus up
+eval $(nexus env)
+nexus status
+\`\`\`
+
+### Via the daemon directly
+
+\`\`\`bash
+nexusd --profile full --host 0.0.0.0 --port 2026 \
+  --data-dir ./nexus-data --auth-type static --api-key "$NEXUS_API_KEY"
+\`\`\`
+
+`nexusd --profile remote` is rejected: a daemon cannot be a thin
+client of another daemon.
+
+## Auth
+
+- **static**: `--api-key` / `NEXUS_API_KEY` / `NEXUS_API_KEY_FILE`.
+  Request without a key → 401; with key → 200.
+- **database**: `--auth-type database` + `--database-url` (or
+  `POSTGRES_URL`) → `DatabaseAPIKeyAuth`. Use for multi-user key
+  issuance/revocation.
+
+## Remote client
+
+\`\`\`python
+from nexus.sdk import connect
+nx = connect(config={"profile": "remote",
+                     "url": "http://hub:2026",
+                     "api_key": "..."})
+\`\`\`
+
+Set `NEXUS_GRPC_PORT` if the server's gRPC port is non-default. The
+HTTP URL alone is not sufficient.
+
+## Correctness check you can run
+
+The FULL contract is locked by
+`tests/unit/core/test_full_profile.py`. Run:
+
+\`\`\`bash
+pytest tests/unit/core/test_full_profile.py -v
+\`\`\`
+
+## Benchmark guidance
+
+Boot time and idle RSS are setup-path metrics, not CI gates; the FULL
+stack (PostgreSQL + Dragonfly + Zoekt) targets multi-GB RSS and a
+15–60 s boot. `health` / `features` / `Ping` are control-plane calls
+with sub-100 ms expectations on a warm hub. There is no steady-state
+data-plane hot path in the startup story.
+
+## Troubleshooting
+
+- Remote SDK hangs / connection refused: gRPC port unreachable — set
+  `NEXUS_GRPC_PORT`, confirm `nexus status` shows gRPC healthy.
+- 401 from every call: static auth with no `NEXUS_API_KEY`, or
+  database auth with no issued key.
+```
+
+- [ ] **Step 2: Verify referenced test path exists**
+
+Run: `test -f tests/unit/core/test_full_profile.py && echo OK`
+Expected: `OK` (created in Task 1).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/deployment/full-profile.md
+git commit -m "docs(#4132): FULL deployment profile reference page"
+```
+
+---
+
+### Task 5: Reconcile the user-guide narrative + link
+
+**Files:**
+- Modify: `docs/guides/user-guide.md` (§4 "Start A Shared Server", lines ~278–394)
+
+- [ ] **Step 1: Read the current §4**
+
+Run: `sed -n '278,395p' docs/guides/user-guide.md`
+Expected: see existing steps (simple dev server, connect from another terminal, save CLI profile, remote Python client, database auth).
+
+- [ ] **Step 2: Insert a profile-pointer + preset↔profile table at the top of §4**
+
+After the `## 4. Start A Shared Server` heading, add:
+
+```markdown
+> This walkthrough runs the **FULL deployment profile**. For the full
+> brick/driver contract, auth modes, and the three different things
+> called "profile", see [FULL deployment profile](../deployment/full-profile.md).
+
+| `nexus init --preset` | Docker stack | Deployment profile |
+|---|---|---|
+| `local` | none (embedded) | embedded/lite |
+| `shared` | postgres+dragonfly+zoekt | **full** |
+| `demo` | shared + seed data | **full** |
+```
+
+- [ ] **Step 3: Ensure the remote-client step states the gRPC requirement**
+
+In "Step 4: Connect with the remote Python client", confirm/add a line:
+
+```markdown
+> The remote SDK path requires gRPC, not only the HTTP URL. If the
+> server's gRPC port is non-default, set `NEXUS_GRPC_PORT` in the
+> client environment.
+```
+
+- [ ] **Step 4: Grep for stale vocabulary in the guide**
+
+Run: `grep -n "nexus serve\|--profile minimal\|profile=minimal" docs/guides/user-guide.md`
+Expected: no matches. If any appear, replace `nexus serve` → `nexusd` or `nexus up`, and `minimal` → `full`/`lite` as context dictates.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add docs/guides/user-guide.md
+git commit -m "docs(#4132): reconcile user-guide §4 with FULL profile + preset↔profile map"
+```
+
+---
+
+### Task 6: Fix the stale `daemon-and-remote.md`
+
+**Files:**
+- Modify: `docs/paths/daemon-and-remote.md`
+
+- [ ] **Step 1: Replace the `minimal` server example**
+
+Replace the `## Server` code block:
+
+```markdown
+## Server
+
+Run the daemon directly:
+
+\`\`\`bash
+export NEXUS_GRPC_PORT=2126
+nexusd --profile full --host 127.0.0.1 --port 2026 \
+  --data-dir ./nexus-data --auth-type static --api-key dev-key
+\`\`\`
+
+Or run the managed stack (FULL profile, PostgreSQL/Dragonfly/Zoekt):
+
+\`\`\`bash
+nexus init --preset shared && nexus up && eval $(nexus env)
+\`\`\`
+
+> `minimal` is not a deployment profile. Valid profiles: `embedded`,
+> `lite`, `sandbox`, `full`, `cloud`, `cluster`, `remote` (and `remote`
+> cannot run as a daemon). See
+> [FULL deployment profile](../deployment/full-profile.md).
+```
+
+- [ ] **Step 2: Verify no `minimal` remains**
+
+Run: `grep -n "minimal\|nexus serve" docs/paths/daemon-and-remote.md`
+Expected: no matches (the Trust Notes gRPC text stays).
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/paths/daemon-and-remote.md
+git commit -m "docs(#4132): reconcile stale daemon-and-remote.md (minimal->full, add nexus up)"
+```
+
+---
+
+### Task 7: Wire the surface-coverage matrix curation fields
+
+**Files:**
+- Modify: surface-coverage curation input for `docs/architecture/api-rpc-surface-coverage.yaml`
+
+- [ ] **Step 1: Find the curation mechanism (rows are generated — do NOT hand-edit generated YAML)**
+
+Run: `sed -n '1,80p' scripts/surface_coverage/merge.py` and
+`grep -rn "owning_issue\|correctness_test\|usage_example\|curat" scripts/surface_coverage/*.py | head`
+Expected: identify the file/overlay where `owning_issue` / `correctness_test` / `usage_example` are injected (a curation overlay or annotations source), not the generated `api-rpc-surface-coverage.yaml`.
+
+- [ ] **Step 2: Set curation fields for startup/auth/env/status operations**
+
+For the operations covering daemon startup, auth, `nexus env`, and `nexus status`, set in the curation source:
+- `owning_issue: 4132`
+- `correctness_test: tests/unit/core/test_full_profile.py` (or the parity test for env/status ops)
+- `usage_example: docs/deployment/full-profile.md`
+- `perf_class: control_plane` for health/features/Ping; `setup` for boot/connect
+
+- [ ] **Step 3: Regenerate and verify the matrix reflects FULL wiring**
+
+Run: `python scripts/gen_api_surface_coverage.py` (or the documented regenerate entrypoint discovered in Step 1)
+Then: `grep -n "owning_issue: 4132" docs/architecture/api-rpc-surface-coverage.yaml | head`
+Expected: matches for the curated operations; `full` profile column present.
+
+- [ ] **Step 4: Run the matrix freshness/render tests**
+
+Run: `pytest tests/architecture/ -q`
+Expected: PASS (freshness gate is warn-only per #4161; render must pass).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add scripts/surface_coverage docs/architecture/api-rpc-surface-coverage.yaml docs/architecture/api-rpc-surface-coverage.html
+git commit -m "docs(#4132): wire FULL startup/auth/env/status into surface-coverage matrix"
+```
+
+---
+
+### Task 8: Record missing-surface gaps in gaps.yaml
+
+**Files:**
+- Modify: `docs/architecture/api-rpc-surface-gaps.yaml`
+
+- [ ] **Step 1: Append the 3 gap entries (schema mirrors existing entries)**
+
+```yaml
+  - id: profile.contract_cli
+    module: cli
+    summary: "`nexus profile contract` (or `nexus status --profile-contract`): print resolved deployment profile, bricks[], drivers[], http_surface[], grpc_required, auth_mode as JSON."
+    wanted_why: "Operators cannot verify the running hub's FULL contract without reading source; the user-guide correctness assertion needs a user-runnable command. Issue #4132 Gap 1 (required)."
+
+  - id: status.auth_profile_detail
+    module: cli
+    summary: "Add `deployment_profile` and `auth_mode` keys to `nexus status --json`."
+    wanted_why: "`nexus status` cannot confirm auth mode or deployment profile. Issue #4132 Gap 2 (recommended)."
+
+  - id: remote.connect_preflight
+    module: remote
+    summary: "`nexus doctor remote` / SDK preflight: probe HTTP + gRPC reachability, return an actionable error instead of a deep stack trace."
+    wanted_why: "Remote clients with gRPC blocked get an opaque failure. Issue #4132 Gap 3 (required)."
+```
+
+- [ ] **Step 2: Validate the YAML**
+
+Run: `python -c "import yaml,sys; yaml.safe_load(open('docs/architecture/api-rpc-surface-gaps.yaml'))" && echo OK`
+Expected: `OK`.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add docs/architecture/api-rpc-surface-gaps.yaml
+git commit -m "docs(#4132): record 3 missing-surface gaps (profile-contract, status-detail, remote-preflight)"
+```
+
+---
+
+### Task 9: Gated real-Docker E2E + benchmark capture
+
+**Files:**
+- Create: `tests/integration/test_full_profile_boot.py`
+- Reference: `tests/integration/approvals/test_grpc_server.py` (gating pattern), `tests/testkit/profiles.py`
+
+- [ ] **Step 1: Write the gated E2E**
+
+```python
+"""FULL profile real-boot E2E (Issue #4132).
+
+Gated: only runs with NEXUS_E2E=1 (boots a real Docker stack:
+PostgreSQL + Dragonfly + Zoekt). Captures boot/RSS as guidance, not
+CI gates; asserts control-plane calls with generous bounds.
+"""
+
+import os
+import time
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+requires_e2e = pytest.mark.skipif(
+    os.environ.get("NEXUS_E2E") != "1",
+    reason="FULL boot E2E requires NEXUS_E2E=1 (real Docker stack)",
+)
+
+
+@requires_e2e
+def test_full_stack_boots_and_serves(full_stack):
+    """full_stack fixture: nexus init --preset shared; nexus up; yield env; nexus down."""
+    t0 = time.monotonic()
+    health = full_stack.http_get("/health")
+    boot_s = time.monotonic() - t0
+    assert health.status_code == 200
+    features = full_stack.http_get("/api/v2/features")
+    assert features.status_code == 200
+    body = features.json()
+    assert body  # FULL reports a non-empty feature set
+    # Guidance only — recorded, not asserted as a gate.
+    print(f"[bench] first-health latency ~ {boot_s:.2f}s")
+
+
+@requires_e2e
+def test_remote_sdk_connect(full_stack):
+    from nexus.sdk import connect
+
+    nx = connect(config={
+        "profile": "remote",
+        "url": full_stack.url,
+        "api_key": full_stack.api_key,
+    })
+    assert nx is not None
+    # gRPC-backed op proves the remote path, not just HTTP reachability.
+    nx.ls("/")
+
+
+@requires_e2e
+def test_remote_sdk_without_grpc_fails_clearly(full_stack, monkeypatch):
+    from nexus.sdk import connect
+
+    monkeypatch.setenv("NEXUS_GRPC_PORT", "1")  # unreachable
+    with pytest.raises(Exception):
+        connect(config={
+            "profile": "remote",
+            "url": full_stack.url,
+            "api_key": full_stack.api_key,
+        }).ls("/")
+```
+
+- [ ] **Step 2: Add the `full_stack` fixture (profile-agnostic, sibling-reusable)**
+
+Inspect for an existing stack fixture first:
+
+Run: `grep -rn "def full_stack\|nexus up\|preset shared\|@pytest.fixture" tests/integration/conftest.py tests/conftest.py 2>/dev/null | head`
+
+If none exists, add to `tests/integration/conftest.py` a `full_stack` fixture that: `nexus init --preset shared` in a tmp dir, `nexus up --timeout 300`, parses `nexus env --json` into `.url/.api_key/.http_get`, yields, and `nexus down --volumes` in teardown. Keep it profile-parameterizable (accept a `preset` arg defaulting to `shared`) so #4133–#4138 reuse it.
+
+- [ ] **Step 3: Verify the gate skips by default**
+
+Run: `pytest tests/integration/test_full_profile_boot.py -v`
+Expected: 3 SKIPPED ("requires NEXUS_E2E=1").
+
+- [ ] **Step 4: Run the E2E once locally with Docker (manual gate)**
+
+Run: `NEXUS_E2E=1 pytest tests/integration/test_full_profile_boot.py -v -s`
+Expected: 3 PASSED; `[bench]` line printed. If Docker is unavailable in this environment, record that the gated run was not executed here and must run in an environment with Docker — do NOT claim it passed.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add tests/integration/test_full_profile_boot.py tests/integration/conftest.py
+git commit -m "test(#4132): gated FULL real-boot E2E (health/features/Ping + remote SDK)"
+```
+
+---
+
+### Task 10: Draft gap issue bodies; file only on user approval
+
+**Files:**
+- Create: `docs/superpowers/gaps/4132-gap-1-profile-contract.md`
+- Create: `docs/superpowers/gaps/4132-gap-2-status-detail.md`
+- Create: `docs/superpowers/gaps/4132-gap-3-remote-preflight.md`
+
+- [ ] **Step 1: Write each draft using the spec's missing-surface template**
+
+Each file: title, missing user workflow, proposed CLI/RPC signature, request/response shape, tests required before docs claim support, benchmark classification, and `Parent: #4132 / Epic: #4121`. Copy the exact text from the spec's "Missing-surface gate" section (Gap 1/2/3).
+
+- [ ] **Step 2: Commit the drafts**
+
+```bash
+git add docs/superpowers/gaps/4132-gap-1-profile-contract.md docs/superpowers/gaps/4132-gap-2-status-detail.md docs/superpowers/gaps/4132-gap-3-remote-preflight.md
+git commit -m "docs(#4132): draft missing-surface gap issue bodies (unfiled)"
+```
+
+- [ ] **Step 3: STOP — request user approval before filing**
+
+Do not run `gh issue create`. Present the 3 drafts to the user. Only after explicit approval, for each approved draft run:
+
+```bash
+gh issue create --repo nexi-lab/nexus --title "<title>" --body-file docs/superpowers/gaps/4132-gap-N-<slug>.md --label "component: api"
+```
+
+Then record the returned issue number into the matching `gap_issue:`
+field in `docs/architecture/api-rpc-surface-gaps.yaml`, commit, and add
+the link as a comment on #4132. The issue cannot close while required
+gaps 1 and 3 are untracked.
+
+---
+
+### Task 11: Final verification & issue cross-link
+
+- [ ] **Step 1: Run the full always-on suite for this story**
+
+Run: `pytest tests/unit/core/test_full_profile.py tests/unit/daemon/test_full_profile_daemon.py tests/unit/cli/test_full_profile_parity.py tests/architecture/ -q`
+Expected: all PASS (E2E remains skipped without `NEXUS_E2E=1`).
+
+- [ ] **Step 2: Confirm no stale vocabulary remains in touched docs**
+
+Run: `grep -rn "nexus serve\|--profile minimal\|profile=minimal" docs/guides/user-guide.md docs/paths/daemon-and-remote.md docs/deployment/full-profile.md`
+Expected: no matches.
+
+- [ ] **Step 3: Verify acceptance-criteria mapping**
+
+Re-read the spec's "Acceptance-criteria mapping" table; confirm each row has a landed artifact. List any gap explicitly to the user.
+
+- [ ] **Step 4: Post a summary comment on #4132**
+
+After user approval (per Task 10), comment on #4132 linking the deployment page, user-guide section, tests, matrix wiring, and filed gap issues; note that required gaps 1 & 3 block closure until resolved.
+
+---
+
+## Self-Review
+
+- **Spec coverage:** deployment page (T4) ✓, user-guide narrative (T5) ✓, stale-doc reconcile (T6) ✓, contract tests (T1/T2/T3) ✓, gated E2E + benchmarks (T9) ✓, matrix wiring (T7) ✓, missing-surface gate (T8/T10) ✓, acceptance mapping (T11) ✓.
+- **Placeholders:** none — every doc/test step has full content; the two investigation steps (T2.3, T7.1) are concrete commands with expected output and a defined fallback, not "TBD".
+- **Type consistency:** `DeploymentProfile.FULL`, `default_bricks()`, `default_drivers()`, `BRICK_*`/`DRIVER_*` constants match `deployment_profile.py`; `full_stack` fixture name consistent across T9 steps; gap ids consistent between T8 (gaps.yaml) and T10 (draft files).
+- **Risk acknowledged:** T9.4 explicitly forbids claiming E2E pass without Docker; T2.3 forbids weakening the remote-rejection test; T7.1 forbids hand-editing generated YAML.

--- a/docs/superpowers/plans/2026-05-18-issue-4132-full-profile.md
+++ b/docs/superpowers/plans/2026-05-18-issue-4132-full-profile.md
@@ -631,6 +631,8 @@ git commit -m "test(#4132): gated FULL real-boot E2E (health/features/Ping + rem
 
 ### Task 10: Draft gap issue bodies; file only on user approval
 
+> **SUPERSEDED — gaps implemented, not filed.** At the user's request, Gaps 1/2/3 were implemented directly on this branch (nexus profile contract / nexus status --json deployment_profile+auth_mode / nexus doctor remote) with tests. The "file on approval" workflow below was not executed; #4132's missing-surface gate is satisfied by implementation. Retained for history.
+
 **Files:**
 - Create: `docs/superpowers/gaps/4132-gap-1-profile-contract.md`
 - Create: `docs/superpowers/gaps/4132-gap-2-status-detail.md`

--- a/docs/superpowers/specs/2026-05-18-issue-4132-full-profile-design.md
+++ b/docs/superpowers/specs/2026-05-18-issue-4132-full-profile-design.md
@@ -203,7 +203,14 @@ The guide states, and tests prove:
 ## Risks
 
 - E2E flakiness on real Docker boot → mitigated by gating + generous
-  bounds + teardown fixture.
+  bounds + teardown fixture. The fixture uses the documented prebuilt
+  path (plain `nexus up`, reusing the pinned `ghcr.io/nexi-lab/nexus`
+  image) — NOT `--build` (a from-scratch Rust+Python build blows the
+  timeout). Source build is opt-in via `NEXUS_E2E_BUILD=1`. Hosts whose
+  Docker credential helper is unusable non-interactively (e.g. macOS
+  `osxkeychain`) and lack the stack images cached cannot pull them; the
+  fixture skips with a precise environmental diagnosis (it is green on
+  CI / hosts with anonymous ghcr pulls or pre-cached images).
 - Gap issues block closure → surfaced explicitly; user approves filing
   before implementation work elsewhere.
 - Vocabulary gap (preset vs profile) could confuse readers → the guide

--- a/docs/superpowers/specs/2026-05-18-issue-4132-full-profile-design.md
+++ b/docs/superpowers/specs/2026-05-18-issue-4132-full-profile-design.md
@@ -142,8 +142,8 @@ The guide states, and tests prove:
 - **Proposed surface**: `nexus profile contract` (or
   `nexus status --profile-contract`).
 - **Request/response**: no args (uses active connection) →
-  JSON `{deployment_profile, bricks[], drivers[], http_surface[],
-  grpc_required: bool, auth_mode}`.
+  JSON `{auth_mode, bricks[], deployment_profile, disabled_bricks[], drivers[], grpc_required: true, mode, version}`.
+  (`http_surface` was intentionally not implemented — no authoritative server source; `disabled_bricks`/`mode`/`version` added instead from `/api/v2/features`)
 - **Tests required**: unit (serialization from `DeploymentProfile`),
   CLI snapshot, parity vs `/api/v2/features`.
 - **Benchmark**: not performance-sensitive (control plane).

--- a/docs/superpowers/specs/2026-05-18-issue-4132-full-profile-design.md
+++ b/docs/superpowers/specs/2026-05-18-issue-4132-full-profile-design.md
@@ -124,6 +124,12 @@ The guide states, and tests prove:
 
 ## Missing-surface gate (draft build issues — file only on approval)
 
+> **RESOLUTION NOTE (issue #4132 branch, 2026-05-18):** All 3 gaps below were RESOLVED BY DIRECT IMPLEMENTATION on this branch — not filed as separate GitHub issues. The "file only on approval" plan was superseded by the user's request to implement directly.
+> - Gap 1 (`profile.contract_cli`) → shipped as `nexus profile contract`; source: `src/nexus/cli/commands/profile.py`; tests: `tests/unit/cli/test_profile_contract.py`.
+> - Gap 2 (`status.auth_profile_detail`) → shipped as `nexus status --json` (`deployment_profile` + `auth_mode` keys); source: `src/nexus/cli/commands/status.py`; tests: `tests/unit/cli/test_status.py`.
+> - Gap 3 (`remote.connect_preflight`) → shipped as `nexus doctor remote`; source: `src/nexus/cli/commands/doctor.py`; tests: `tests/unit/cli/test_doctor.py`.
+> The missing-surface gate is satisfied. #4132 is closeable on this axis.
+
 ### Gap 1 — No CLI prints the resolved deployment-profile contract
 
 - **Missing user workflow**: operator wants to verify, without reading
@@ -197,7 +203,7 @@ The guide states, and tests prove:
 | Guide gives start-to-remote-client workflow | `user-guide.md` narrative section + `full-profile.md` |
 | Tests cover full feature reporting + remote connection requirements | `test_full_profile.py` + gated E2E |
 | Stale `serve`/`minimal`/no-`nexus up` docs reconciled | `docs/paths/daemon-and-remote.md` fix |
-| Missing auth/env/status CLI gaps filed as build issues | Missing-surface gate §; filed on approval |
+| Missing auth/env/status CLI gaps filed as build issues | ~~Filed on approval~~ → **Implemented directly on this branch**: `nexus profile contract` (`profile.py`, `test_profile_contract.py`), `nexus status --json` deployment_profile/auth_mode (`status.py`, `test_status.py`), `nexus doctor remote` (`doctor.py`, `test_doctor.py`). Missing-surface gate satisfied; #4132 closeable on this axis. |
 | Matrix links startup/status/auth surface for full | `api-rpc-surface-coverage.yaml` rows |
 
 ## Risks

--- a/docs/superpowers/specs/2026-05-18-issue-4132-full-profile-design.md
+++ b/docs/superpowers/specs/2026-05-18-issue-4132-full-profile-design.md
@@ -109,7 +109,7 @@ no user-runnable command prints the resolved profile contract.
 The guide states, and tests prove:
 
 1. `DeploymentProfile.FULL.default_bricks()` ⊇ `LITE.default_bricks()`,
-   includes the 18 feature bricks listed above, and **excludes**
+   includes the feature bricks listed above, and **excludes**
    `federation`.
 2. `DeploymentProfile.FULL.default_drivers()` includes
    {s3, gcs, gdrive, remote} and the sandbox connector set.

--- a/docs/superpowers/specs/2026-05-18-issue-4132-full-profile-design.md
+++ b/docs/superpowers/specs/2026-05-18-issue-4132-full-profile-design.md
@@ -224,3 +224,63 @@ The guide states, and tests prove:
   before implementation work elsewhere.
 - Vocabulary gap (preset vs profile) could confuse readers → the guide
   has an explicit "preset ↔ deployment profile" mapping table.
+
+## Empirical verification (post-implementation, 2026-05-19)
+
+Real, observed evidence against a live FULL hub (Docker stack booted
+via the credential-shim workaround for the non-interactive
+`osxkeychain` blocker; container `nexus-<hash>-nexus-1`, HTTP on a
+mapped host port):
+
+- **Full hub boots & serves** (closes verification gap #1, core): the
+  nexus container reached `Application startup complete`,
+  `GET /health` → **200**, `GET /api/v2/features` →
+  `{profile: "full", enabled_bricks: 29, mode: "standalone",
+  version: "0.10.0"}`. Postgres + Dragonfly healthy.
+- **`nexus status --json`** (Gap 2) against the live hub →
+  `deployment_profile="full"`, `auth_mode="none"`,
+  `server_reachable=true`. ✓
+- **`nexus doctor remote`** (Gap 3) against the live hub → real gRPC
+  dial attempted, returned an actionable `fix_hint`
+  ("gRPC port N unreachable; set NEXUS_GRPC_PORT"), no traceback. ✓
+- **`nexus profile contract`** (Gap 1) → real JSON
+  `deployment_profile="full"` + 29 enabled bricks, **after Bug A fix**.
+
+### Bug A — found by live testing, FIXED on this branch
+
+`nexus profile contract` shipped with no `--url`/`--api-key` options
+and did not honor `NEXUS_URL`/`NEXUS_API_KEY` (env vars are only read
+via Click `envvar=` bindings, which it lacked) — so it could only ever
+reach `localhost:2026`, defeating its purpose for remote hubs. The
+mocked unit tests missed this (they patch `resolve_connection`). Fixed:
+added `--url/--remote-url` (`envvar=NEXUS_URL`) and
+`--api-key/--remote-api-key` (`envvar=NEXUS_API_KEY`), forwarded to
+`resolve_connection`; regression tests for flags + envvars added;
+re-verified against the live hub. Flag spelling intentionally matches
+the sibling `nexus doctor remote` (`--url --api-key`, visible) rather
+than `status.py`'s hidden `--remote-api-key` — cross-new-command
+consistency was judged more valuable than literal status.py parity.
+
+### Bug B — found by live testing, NOT fixed (separate, out of scope)
+
+`nexus up --preset shared` returns **rc=1** even when the FULL hub is
+fully healthy and serving, because its health gate waits on **`zoekt`**
+(`✗ zoekt (timed out after 32s)`) although the `shared` preset's
+documented service set is only `nexus`/`postgres`/`dragonfly` (zoekt is
+not in `HEALTH_ENDPOINTS` and not a shared-preset service). This is the
+real reason the gated pytest E2E cannot reach a green `nexus up` via
+the fixture even on CI — independent of the #4132 deliverables.
+
+- **Disposition:** root-fixing `nexus up`'s service/health derivation
+  is core CLI behavior with broad blast radius and is **outside #4132's
+  scope** (docs/test + the 3 gap commands). It was deliberately **not**
+  patched here, and **not** masked in the fixture (the fixture now
+  reports the real failure honestly after the diagnostic fix). It is
+  recorded here as a discovered, separate defect for follow-up
+  (recommended: a dedicated `nexus up` issue — scope the health gate to
+  services the active preset/compose-profiles actually provision, or
+  make zoekt readiness non-fatal for non-search presets).
+- **Net:** the substance of all three #4132 verification gaps is closed
+  by the direct live-hub observations above. The pytest gated-E2E
+  remaining environment/Bug-B-blocked is a known, documented limitation,
+  not a #4132 deliverable defect.

--- a/docs/superpowers/specs/2026-05-18-issue-4132-full-profile-design.md
+++ b/docs/superpowers/specs/2026-05-18-issue-4132-full-profile-design.md
@@ -19,10 +19,13 @@ no user-runnable command prints the resolved profile contract.
 
 - The `cloud` profile, federation, or multi-tenant behavior (FULL
   deliberately excludes `federation` — that is `cloud`).
-- Implementing any missing CLI/RPC surface. Gaps are enumerated and
+- ~~Implementing any missing CLI/RPC surface. Gaps are enumerated and
   filed as linked build issues; this story documents and tests the
   existing surface and is blocked from closing until required gaps are
-  tracked.
+  tracked.~~ **SUPERSEDED:** at the user's request the scope was
+  expanded — all 3 missing-surface gaps were implemented directly on
+  this branch (see "Missing-surface gate" §). The original non-goal of
+  *filing* (not building) the gaps no longer applies.
 - Sibling feature surfaces (#4133–#4138): filesystem, ReBAC, search,
   MCP, agents, admin. This story covers startup/auth/remote/contract
   only.
@@ -37,7 +40,7 @@ no user-runnable command prints the resolved profile contract.
 | Q1 | Doc shape | **Hybrid**: standalone `docs/deployment/full-profile.md` (profile contract reference) + a "start a shared hub & connect remotely" narrative section in `docs/guides/user-guide.md` that links to it |
 | Q2 | Scope width | #4132 only + light matrix wiring. Reuse #4161 `api-rpc-surface-coverage.yaml`/`gaps.yaml` as-is; add only `full` startup/auth/status rows |
 | Q3 | Test depth | Always-on unit/contract + parity tests (no Docker); one real-Docker-boot E2E + benchmarks gated behind `NEXUS_E2E=1` (`@pytest.mark.integration`). Matches sibling #3778 |
-| Q4 | Missing-surface gate | Enumerate every gap with a full build-issue template in this spec; file via `gh issue create` and link to #4132/#4121 **only after user approval** |
+| Q4 | Missing-surface gate | ~~Enumerate every gap with a full build-issue template; file via `gh issue create` only after user approval~~ → **SUPERSEDED:** user expanded scope; all 3 gaps were implemented directly on this branch with tests (see "Missing-surface gate" §). No issues filed — surfaces built instead |
 | Q5 | Benchmark posture | Boot/RSS/connect = setup path (recorded as guidance, not CI gates); health/features/Ping = control plane (latency asserted with generous bounds); no steady-state data-plane hot path in this story |
 | Q6 | Boot fixture reuse | Boot fixture written profile-agnostic so siblings #4133–#4138 can reuse it; no speculative abstraction beyond that |
 

--- a/docs/superpowers/specs/2026-05-18-issue-4132-full-profile-design.md
+++ b/docs/superpowers/specs/2026-05-18-issue-4132-full-profile-design.md
@@ -1,0 +1,210 @@
+# Issue #4132 — Shared hub startup, auth, remote client, and profile contract
+
+**Issue**: [nexi-lab/nexus#4132](https://github.com/nexi-lab/nexus/issues/4132)
+**Epic**: [#4121 — full profile CLI/RPC user story, tests, and benchmarks](https://github.com/nexi-lab/nexus/issues/4121)
+**Story group**: Shared hub startup, auth, remote clients, and profile contract
+
+## Problem
+
+A team operator wants to start a full Nexus hub and connect CLI/SDK
+clients remotely, with clear auth and gRPC requirements. Today the
+relevant knowledge is split across `CLI.md`, `docs/paths/daemon-and-remote.md`,
+and source (`deployment_profile.py`, `daemon/main.py`), with no single
+coherent workflow and at least one stale path doc. There is no
+`docs/deployment/full-profile.md` (the sibling `sandbox` profile has
+one); the FULL deployment-profile contract is not asserted by tests; and
+no user-runnable command prints the resolved profile contract.
+
+## Non-goals
+
+- The `cloud` profile, federation, or multi-tenant behavior (FULL
+  deliberately excludes `federation` — that is `cloud`).
+- Implementing any missing CLI/RPC surface. Gaps are enumerated and
+  filed as linked build issues; this story documents and tests the
+  existing surface and is blocked from closing until required gaps are
+  tracked.
+- Sibling feature surfaces (#4133–#4138): filesystem, ReBAC, search,
+  MCP, agents, admin. This story covers startup/auth/remote/contract
+  only.
+- A new shared test-harness package. We add one reusable, profile-
+  agnostic boot fixture, not epic-wide scaffolding.
+- Windows. CI covers Linux + macOS only (matches sibling #3778).
+
+## Decisions (from brainstorming)
+
+| # | Question | Decision |
+|---|---|---|
+| Q1 | Doc shape | **Hybrid**: standalone `docs/deployment/full-profile.md` (profile contract reference) + a "start a shared hub & connect remotely" narrative section in `docs/guides/user-guide.md` that links to it |
+| Q2 | Scope width | #4132 only + light matrix wiring. Reuse #4161 `api-rpc-surface-coverage.yaml`/`gaps.yaml` as-is; add only `full` startup/auth/status rows |
+| Q3 | Test depth | Always-on unit/contract + parity tests (no Docker); one real-Docker-boot E2E + benchmarks gated behind `NEXUS_E2E=1` (`@pytest.mark.integration`). Matches sibling #3778 |
+| Q4 | Missing-surface gate | Enumerate every gap with a full build-issue template in this spec; file via `gh issue create` and link to #4132/#4121 **only after user approval** |
+| Q5 | Benchmark posture | Boot/RSS/connect = setup path (recorded as guidance, not CI gates); health/features/Ping = control plane (latency asserted with generous bounds); no steady-state data-plane hot path in this story |
+| Q6 | Boot fixture reuse | Boot fixture written profile-agnostic so siblings #4133–#4138 can reuse it; no speculative abstraction beyond that |
+
+## Source anchors
+
+- `CLI.md`
+- `src/nexus/cli/commands/init_cmd.py`
+- `src/nexus/cli/commands/stack.py`
+- `src/nexus/daemon/main.py`
+- `src/nexus/contracts/deployment_profile.py`
+- `src/nexus/cli/compose.py`, `docker-compose.yml`, `Dockerfile`
+- `docs/paths/daemon-and-remote.md`
+- Precedent: `docs/deployment/sandbox-profile.md`,
+  `docs/superpowers/specs/2026-04-17-3778-sandbox-profile-design.md`
+- Matrix: `docs/architecture/api-rpc-surface-coverage.yaml`,
+  `docs/architecture/api-rpc-surface-gaps.yaml`
+
+## Ground-truth facts (verified against source)
+
+- `DeploymentProfile.FULL.default_bricks()` = `_LITE_BRICKS` ∪
+  {search, pay, llm, skills, sandbox, workflows, discovery, mcp, memory,
+  task_manager, observability, uploads, resiliency, access_manifest,
+  catalog, delegation, identity, share_link, versioning, workspace,
+  portability, parsers, snapshot}. **Excludes `federation`** (that is
+  `cloud = full ∪ {federation}`).
+- `DeploymentProfile.FULL.default_drivers()` = sandbox drivers ∪
+  {s3, gcs, gdrive, gmail, slack, x, hn, remote}.
+- `nexusd --profile remote` exits `ExitCode.CONFIG_ERROR` with
+  "A daemon cannot be a thin client of another daemon." — documented
+  denial behavior.
+- Daemon auth: `--auth-type database` → `DatabaseAPIKeyAuth` over
+  `--database-url`/`POSTGRES_URL`; else static via
+  `--api-key`/`NEXUS_API_KEY`/`NEXUS_API_KEY_FILE`.
+- **Three distinct "profile" namespaces** (the core source of reader
+  confusion the guide must disambiguate):
+  1. *Docker Compose profiles* (`compose.py` `VALID_PROFILES`:
+     `core`, `cache`, …) — service selectors; presets map to
+     `compose_profiles` tuples (shared/demo → `("core","cache")`).
+  2. *CLI connection profiles* (`config.py`, `nexus profile use/add`) —
+     kubectl-style URL/key/zone entries in `~/.nexus/config.yaml`.
+  3. *Deployment profile* (`DeploymentProfile`, `nexusd --profile full`,
+     env `NEXUS_PROFILE`) — the brick/driver capability tier.
+- Verified mechanism: the `nexus up` Docker stack runs the FULL
+  deployment profile because `docker-compose.yml:23` sets
+  `NEXUS_PROFILE=full` (and `Dockerfile:269` defaults the same). The
+  preset does **not** set the deployment profile directly — the compose
+  env var does. No preset is literally named `full`.
+- Remote SDK: `connect(config={"profile":"remote","url":...,
+  "api_key":...})` requires gRPC reachable (`NEXUS_GRPC_PORT`); the HTTP
+  URL alone is insufficient.
+- Stale doc: `docs/paths/daemon-and-remote.md` uses `--profile minimal`
+  (not a member of `DeploymentProfile`) and omits `nexus up`.
+
+## Deliverables
+
+| Artifact | Path | Purpose |
+|---|---|---|
+| Profile guide | `docs/deployment/full-profile.md` (new) | FULL contract: brick/driver set, HTTP/gRPC surface, auth modes, denial behavior, benchmark guidance |
+| User narrative | `docs/guides/user-guide.md` (new section) | init→up→env→status→remote-connect story; links to profile guide; CLI + SDK examples; success/denied/unavailable behavior |
+| Stale-doc fix | `docs/paths/daemon-and-remote.md` | `--profile minimal` → `full`; add preset/`nexus up` path; keep raw-`nexusd` path; state gRPC requirement explicitly |
+| Contract tests | `tests/unit/core/test_full_profile.py` (new) | FULL brick/driver set; superset over LITE; excludes federation; `nexusd --profile remote` rejected |
+| CLI/RPC parity tests | `tests/unit/cli/`, `tests/unit/daemon/` | `nexus env/status --json` shape; daemon `--profile full` banner; static vs database auth resolution |
+| Gated E2E + bench | `tests/integration/test_full_profile_boot.py` (new) | Real Docker boot; health/features/Ping; remote SDK connect; boot-time/RSS capture. `@pytest.mark.integration`, skip unless `NEXUS_E2E=1` |
+| Matrix rows | `docs/architecture/api-rpc-surface-coverage.yaml` | `full` status for startup/auth/env/status operations |
+| Gap backlog | `docs/architecture/api-rpc-surface-gaps.yaml` + §"Missing-surface gate" | Enumerate gaps; GitHub issues filed only on user approval |
+
+## Profile-contract assertions (verifiable correctness checks)
+
+The guide states, and tests prove:
+
+1. `DeploymentProfile.FULL.default_bricks()` ⊇ `LITE.default_bricks()`,
+   includes the 18 feature bricks listed above, and **excludes**
+   `federation`.
+2. `DeploymentProfile.FULL.default_drivers()` includes
+   {s3, gcs, gdrive, remote} and the sandbox connector set.
+3. `nexusd --profile remote` exits non-zero with the documented message.
+4. Static auth: request without API key → 401; with key → 200.
+   Database auth: key validated via `DatabaseAPIKeyAuth`.
+5. Remote SDK with no reachable gRPC → explicit failure; with
+   `NEXUS_GRPC_PORT` set and reachable → success.
+6. `nexus env --json` emits `NEXUS_URL`, `NEXUS_API_KEY`,
+   `NEXUS_GRPC_HOST`, `NEXUS_GRPC_PORT` — the exact values the remote SDK
+   consumes (CLI/SDK parity assertion).
+
+## Missing-surface gate (draft build issues — file only on approval)
+
+### Gap 1 — No CLI prints the resolved deployment-profile contract
+
+- **Missing user workflow**: operator wants to verify, without reading
+  source, which bricks/drivers/auth mode the running hub actually has.
+  `nexus profile …` manages *connection* profiles, not the deployment
+  profile.
+- **Proposed surface**: `nexus profile contract` (or
+  `nexus status --profile-contract`).
+- **Request/response**: no args (uses active connection) →
+  JSON `{deployment_profile, bricks[], drivers[], http_surface[],
+  grpc_required: bool, auth_mode}`.
+- **Tests required**: unit (serialization from `DeploymentProfile`),
+  CLI snapshot, parity vs `/api/v2/features`.
+- **Benchmark**: not performance-sensitive (control plane).
+
+### Gap 2 — `nexus status` lacks auth/profile detail
+
+- **Missing user workflow**: operator can't confirm auth mode or
+  deployment profile from `nexus status`.
+- **Proposed surface**: add `deployment_profile` and `auth_mode` keys to
+  `nexus status --json`.
+- **Request/response**: existing command; additive JSON keys.
+- **Tests required**: `nexus status --json` schema test asserting new
+  keys; parity with daemon banner.
+- **Benchmark**: not performance-sensitive (control plane).
+
+### Gap 3 — No remote-connect preflight
+
+- **Missing user workflow**: a remote client with HTTP reachable but
+  gRPC blocked gets a deep stack trace, not an actionable error.
+- **Proposed surface**: `nexus doctor remote` (or SDK `connect(...,
+  preflight=True)`) that probes HTTP + gRPC and returns a clear
+  diagnosis.
+- **Request/response**: `--url --api-key` → exit 0 + report, or non-zero
+  + "gRPC port N unreachable; set NEXUS_GRPC_PORT".
+- **Tests required**: unit (probe logic with mocked sockets), CLI
+  failure-path test.
+- **Benchmark**: not performance-sensitive (setup path).
+
+> The issue cannot close while a *required* gap above remains untracked.
+> Gaps 1 and 3 are required (the guide's correctness assertion and the
+> remote workflow depend on them); Gap 2 is recommended. Issues filed via
+> `gh issue create`, linked to #4132 and #4121, only after user approval.
+
+## Benchmark classification
+
+| Path | Class | Treatment |
+|---|---|---|
+| Boot time (cold/warm) | setup path | Captured in gated E2E; reported as guidance range, not a CI gate |
+| RSS at idle | setup path | Captured in gated E2E; guidance range |
+| `health` / `features` / `Ping` | control plane | Latency asserted in E2E with generous upper bounds |
+| Remote connect time | setup path | Recorded once in E2E |
+| Steady-state data plane | — | None in this story; explicitly "not performance-sensitive" |
+
+## Test strategy
+
+- **Always-on (CI, no Docker)**: `test_full_profile.py` contract
+  assertions; CLI/daemon parity tests for `env`/`status`/banner/auth
+  resolution. Pure, fast.
+- **Gated E2E (`NEXUS_E2E=1`)**: one module boots the `demo`/`shared`
+  stack (FULL deployment profile internally), exercises
+  health/features/Ping + remote SDK connect, captures boot/RSS, tears
+  down. Reuses `tests/testkit/profiles.py`. Boot fixture written
+  profile-agnostic for sibling reuse.
+- No new harness package.
+
+## Acceptance-criteria mapping
+
+| Issue criterion | Satisfied by |
+|---|---|
+| Guide gives start-to-remote-client workflow | `user-guide.md` narrative section + `full-profile.md` |
+| Tests cover full feature reporting + remote connection requirements | `test_full_profile.py` + gated E2E |
+| Stale `serve`/`minimal`/no-`nexus up` docs reconciled | `docs/paths/daemon-and-remote.md` fix |
+| Missing auth/env/status CLI gaps filed as build issues | Missing-surface gate §; filed on approval |
+| Matrix links startup/status/auth surface for full | `api-rpc-surface-coverage.yaml` rows |
+
+## Risks
+
+- E2E flakiness on real Docker boot → mitigated by gating + generous
+  bounds + teardown fixture.
+- Gap issues block closure → surfaced explicitly; user approves filing
+  before implementation work elsewhere.
+- Vocabulary gap (preset vs profile) could confuse readers → the guide
+  has an explicit "preset ↔ deployment profile" mapping table.

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -249,8 +249,6 @@ def connect(
 
     # ── Profile: remote ──────────────────────────────────────────────
     if cfg.profile == "remote":
-        from urllib.parse import urlparse
-
         server_url = cfg.url or os.getenv("NEXUS_URL")
         if not server_url:
             raise ValueError(
@@ -261,87 +259,17 @@ def connect(
         timeout = int(cfg.timeout) if hasattr(cfg, "timeout") else 30
         connect_timeout = int(cfg.connect_timeout) if hasattr(cfg, "connect_timeout") else 5
 
-        # Build gRPC address from NEXUS_URL hostname + gRPC port.
-        # Port precedence: NEXUS_GRPC_PORT env > nexus.yaml ports.grpc > default 2028
-        _grpc_port_str = os.getenv("NEXUS_GRPC_PORT")
-        if not _grpc_port_str:
-            try:
-                import yaml as _yaml
-
-                _pf = Path("nexus.yaml")
-                if _pf.exists():
-                    with open(_pf) as _f:
-                        _pc = _yaml.safe_load(_f) or {}
-                    _grpc_port_str = str(_pc.get("ports", {}).get("grpc", ""))
-            except Exception:
-                pass
-        grpc_port = int(_grpc_port_str) if _grpc_port_str else 2028
-        parsed = urlparse(server_url)
-        grpc_address = f"{parsed.hostname}:{grpc_port}"
-
-        # Single shared RPCTransport (gRPC channel) for all remote proxies.
+        # Resolve gRPC address + TLS via the shared helper so the
+        # `nexus doctor remote` preflight reflects the *exact* connection
+        # behavior this SDK path uses (Issue #4132 — single source of
+        # truth for port precedence + NEXUS_GRPC_TLS / data-dir / nexus.yaml
+        # TLS resolution and fail-closed semantics).
+        from nexus.remote.grpc_target import resolve_grpc_target
         from nexus.remote.rpc_transport import RPCTransport
 
-        # TLS: NEXUS_GRPC_TLS env var overrides all other TLS signals.
-        #   true  → force TLS
-        #   false → force insecure
-        #   unset → fall back to nexus.yaml tls / NEXUS_DATA_DIR auto-detect
-        _tls_config = None
-        _grpc_tls_env = os.getenv("NEXUS_GRPC_TLS", "").lower()
-        _tls_enabled = _grpc_tls_env in ("true", "1", "yes")
-        _tls_disabled = _grpc_tls_env in ("false", "0", "no")
-        _tls_from_config = False  # set when nexus.yaml explicitly enables TLS
-        _data_dir = os.getenv("NEXUS_DATA_DIR")
-        if _data_dir and not _tls_disabled:
-            _tls_enabled = True  # Auto-detect from NEXUS_DATA_DIR (backward compat)
-        if not _data_dir:
-            _project_yaml = Path("nexus.yaml")
-            if _project_yaml.exists():
-                try:
-                    import yaml as _yaml
-
-                    with open(_project_yaml) as _f:
-                        _project_cfg = _yaml.safe_load(_f) or {}
-                    _data_dir = _project_cfg.get("data_dir")
-                    # nexus.yaml tls: only used when env var is unset
-                    if not _grpc_tls_env:
-                        _tls_from_config = bool(_project_cfg.get("tls"))
-                        _tls_enabled = _tls_from_config
-                except Exception:
-                    pass
-        if not _data_dir:
-            _data_dir = getattr(cfg, "data_dir", None)
-
-        if _data_dir and _tls_enabled:
-            from nexus.security.tls.config import ZoneTlsConfig
-
-            # TLS explicitly requested (env var or config) → check both layouts
-            # NEXUS_DATA_DIR auto-detect only → Raft-only (backward compat)
-            _tls_intentional = _grpc_tls_env in ("true", "1", "yes") or _tls_from_config
-            _tls_config = (
-                ZoneTlsConfig.from_data_dir_any(_data_dir)
-                if _tls_intentional
-                else ZoneTlsConfig.from_data_dir(_data_dir)
-            )
-
-        # Fail closed: NEXUS_GRPC_TLS=true but no certs resolved.
-        # As a last resort, check NEXUS_TLS_* env vars — but only when
-        # TLS was explicitly requested, to avoid stale env vars from a
-        # previous session flipping a plaintext stack onto mTLS.
-        _tls_explicit = _grpc_tls_env in ("true", "1", "yes")
-        if _tls_explicit and _tls_config is None and os.getenv("NEXUS_TLS_CERT"):
-            import contextlib
-
-            from nexus.security.tls.config import ZoneTlsConfig
-
-            with contextlib.suppress(Exception):
-                _tls_config = ZoneTlsConfig.from_env()
-        if _tls_explicit and _tls_config is None:
-            raise RuntimeError(
-                "NEXUS_GRPC_TLS=true but no TLS certificates found. "
-                "Provide certs via NEXUS_TLS_CERT/KEY/CA, "
-                "in {data_dir}/tls/, or set data_dir in nexus.yaml."
-            )
+        grpc_address, _grpc_port, _tls_config = resolve_grpc_target(
+            server_url, cfg_data_dir=getattr(cfg, "data_dir", None)
+        )
 
         transport = RPCTransport(
             server_address=grpc_address,

--- a/src/nexus/__init__.py
+++ b/src/nexus/__init__.py
@@ -267,8 +267,13 @@ def connect(
         from nexus.remote.grpc_target import resolve_grpc_target
         from nexus.remote.rpc_transport import RPCTransport
 
+        # profile="remote" with an explicit url/NEXUS_URL is an explicit
+        # remote target: do NOT let the cwd ./nexus.yaml (a *different*
+        # local project) override this hub's gRPC port / TLS.
         grpc_address, _grpc_port, _tls_config = resolve_grpc_target(
-            server_url, cfg_data_dir=getattr(cfg, "data_dir", None)
+            server_url,
+            cfg_data_dir=getattr(cfg, "data_dir", None),
+            trust_local_project=False,
         )
 
         transport = RPCTransport(

--- a/src/nexus/cli/commands/doctor.py
+++ b/src/nexus/cli/commands/doctor.py
@@ -701,7 +701,12 @@ def _check_remote_grpc(url: str, api_key: str | None) -> CheckResult:
     transport = None
     try:
         try:
-            grpc_address, grpc_port, tls_config = resolve_grpc_target(url)
+            # `doctor remote --url` is always an explicit remote target —
+            # ignore any cwd ./nexus.yaml so a local project's gRPC
+            # port/TLS cannot poison the diagnosis of a different hub.
+            grpc_address, grpc_port, tls_config = resolve_grpc_target(
+                url, trust_local_project=False
+            )
         except ValueError as exc:
             # Invalid gRPC port config (NEXUS_GRPC_PORT / nexus.yaml). The
             # SDK fails the same way — surface it as an actionable ERROR,

--- a/src/nexus/cli/commands/doctor.py
+++ b/src/nexus/cli/commands/doctor.py
@@ -702,6 +702,16 @@ def _check_remote_grpc(url: str, api_key: str | None) -> CheckResult:
     try:
         try:
             grpc_address, grpc_port, tls_config = resolve_grpc_target(url)
+        except ValueError as exc:
+            # Invalid gRPC port config (NEXUS_GRPC_PORT / nexus.yaml). The
+            # SDK fails the same way — surface it as an actionable ERROR,
+            # not a silent wrong-port dial or a traceback.
+            return CheckResult(
+                name="remote-grpc",
+                status=CheckStatus.ERROR,
+                message=f"gRPC port misconfigured: {exc}",
+                fix_hint="Set NEXUS_GRPC_PORT (or nexus.yaml ports.grpc) to a valid integer 1–65535.",
+            )
         except RuntimeError as exc:
             # Fail-closed: NEXUS_GRPC_TLS=true but no certs resolved — the
             # SDK raises the same; the remote path is unusable as-is.

--- a/src/nexus/cli/commands/doctor.py
+++ b/src/nexus/cli/commands/doctor.py
@@ -686,7 +686,12 @@ def _compute_grpc_address(url: str) -> tuple[str, int]:
 
 
 def _check_remote_http(url: str) -> CheckResult:
-    """GET {url}/health — OK on 200, WARNING/ERROR otherwise."""
+    """GET {url}/health — OK on 200, ERROR otherwise.
+
+    This is a *preflight*: a non-200 health response means the remote
+    path is not usable, so it is an ERROR (non-zero exit), not a
+    soft WARNING.
+    """
     health_url = url.rstrip("/") + "/health"
     try:
         import httpx
@@ -701,7 +706,7 @@ def _check_remote_http(url: str) -> CheckResult:
                 )
             return CheckResult(
                 name="remote-http",
-                status=CheckStatus.WARNING,
+                status=CheckStatus.ERROR,
                 message=f"HTTP health returned {resp.status_code} at {health_url}.",
                 fix_hint=f"Check the hub server is running and {health_url} is accessible.",
             )
@@ -732,10 +737,13 @@ def _check_remote_grpc(url: str, api_key: str | None) -> CheckResult:
             message=f"gRPC reachable at {grpc_address}.",
         )
     except ValueError as exc:
-        # RPCTransport refuses insecure non-loopback channels.
+        # RPCTransport refuses insecure non-loopback channels. The real
+        # remote SDK connection would be refused the same way *before*
+        # dialing — so for a preflight this is an ERROR (the remote path
+        # is not usable as-is), not a soft WARNING.
         return CheckResult(
             name="remote-grpc",
-            status=CheckStatus.WARNING,
+            status=CheckStatus.ERROR,
             message=f"gRPC channel refused (insecure non-loopback): {exc}",
             fix_hint=(
                 "Configure TLS for remote connections (NEXUS_GRPC_TLS=true + certs), "

--- a/src/nexus/cli/commands/doctor.py
+++ b/src/nexus/cli/commands/doctor.py
@@ -23,6 +23,7 @@ from nexus.cli.output import OutputOptions, add_output_options, render_output
 from nexus.cli.theme import console
 from nexus.cli.timing import CommandTiming
 from nexus.cli.utils import handle_error
+from nexus.remote.rpc_transport import RPCTransport
 
 # ---------------------------------------------------------------------------
 # Check result model
@@ -590,14 +591,15 @@ def _display_results(results: dict[str, list[CheckResult]]) -> int:
 
 
 # ---------------------------------------------------------------------------
-# CLI command
+# CLI command group
 # ---------------------------------------------------------------------------
 
 
-@click.command(name="doctor")
+@click.group(name="doctor", invoke_without_command=True)
 @click.option("--fix", "auto_fix", is_flag=True, help="Attempt to auto-fix issues.")
 @add_output_options
-def doctor(output_opts: OutputOptions, auto_fix: bool) -> None:
+@click.pass_context
+def doctor(ctx: click.Context, output_opts: OutputOptions, auto_fix: bool) -> None:
     """Run diagnostic checks on your Nexus environment.
 
     Checks connectivity, storage, federation, security, and dependencies.
@@ -606,7 +608,12 @@ def doctor(output_opts: OutputOptions, auto_fix: bool) -> None:
         nexus doctor
         nexus doctor --json
         nexus doctor --fix
+        nexus doctor remote --url http://hub:2026
     """
+    # If a subcommand was invoked, let it run — skip the local checks.
+    if ctx.invoked_subcommand is not None:
+        return
+
     try:
         timing = CommandTiming()
         with timing.phase("checks"):
@@ -641,6 +648,189 @@ def doctor(output_opts: OutputOptions, auto_fix: bool) -> None:
         handle_error(exc)
 
 
+# ---------------------------------------------------------------------------
+# nexus doctor remote — HTTP + gRPC preflight for remote hubs (Gap 3 / #4132)
+# ---------------------------------------------------------------------------
+
+
+def _compute_grpc_address(url: str) -> tuple[str, int]:
+    """Return (grpc_address_string, grpc_port) for *url*.
+
+    Port precedence (mirrors nexus/__init__.py remote-profile block):
+      1. ``NEXUS_GRPC_PORT`` env var
+      2. nexus.yaml ``ports.grpc``
+      3. default 2028
+    """
+    from urllib.parse import urlparse
+
+    parsed = urlparse(url)
+    host = parsed.hostname or "localhost"
+
+    grpc_port_str = os.getenv("NEXUS_GRPC_PORT", "")
+    if not grpc_port_str:
+        import contextlib
+        from pathlib import Path as _Path
+
+        with contextlib.suppress(Exception):
+            import yaml as _yaml
+
+            _pf = _Path("nexus.yaml")
+            if _pf.exists():
+                with open(_pf) as _f:
+                    _pc = _yaml.safe_load(_f) or {}
+                grpc_port_str = str(_pc.get("ports", {}).get("grpc", ""))
+    grpc_port = int(grpc_port_str) if grpc_port_str else 2028
+    return f"{host}:{grpc_port}", grpc_port
+
+
+def _check_remote_http(url: str) -> CheckResult:
+    """GET {url}/health — OK on 200, WARNING/ERROR otherwise."""
+    health_url = url.rstrip("/") + "/health"
+    try:
+        import httpx
+
+        with httpx.Client(timeout=2.0) as client:
+            resp = client.get(health_url)
+            if resp.status_code == 200:
+                return CheckResult(
+                    name="remote-http",
+                    status=CheckStatus.OK,
+                    message=f"HTTP health OK at {health_url}.",
+                )
+            return CheckResult(
+                name="remote-http",
+                status=CheckStatus.WARNING,
+                message=f"HTTP health returned {resp.status_code} at {health_url}.",
+                fix_hint=f"Check the hub server is running and {health_url} is accessible.",
+            )
+    except Exception as exc:
+        return CheckResult(
+            name="remote-http",
+            status=CheckStatus.ERROR,
+            message=f"HTTP health unreachable at {health_url}: {exc}",
+            fix_hint=f"Check NEXUS_URL and that the hub is running at {url}.",
+        )
+
+
+def _check_remote_grpc(url: str, api_key: str | None) -> CheckResult:
+    """Attempt a gRPC health check via RPCTransport.health_check()."""
+    grpc_address, grpc_port = _compute_grpc_address(url)
+    transport = None
+    try:
+        transport = RPCTransport(
+            server_address=grpc_address,
+            auth_token=api_key,
+            timeout=2.0,
+            connect_timeout=2.0,
+        )
+        transport.health_check()
+        return CheckResult(
+            name="remote-grpc",
+            status=CheckStatus.OK,
+            message=f"gRPC reachable at {grpc_address}.",
+        )
+    except ValueError as exc:
+        # RPCTransport refuses insecure non-loopback channels.
+        return CheckResult(
+            name="remote-grpc",
+            status=CheckStatus.WARNING,
+            message=f"gRPC channel refused (insecure non-loopback): {exc}",
+            fix_hint=(
+                "Configure TLS for remote connections (NEXUS_GRPC_TLS=true + certs), "
+                "or set NEXUS_GRPC_ALLOW_INSECURE=true for trusted private networks "
+                "(docker-compose, k8s pod-local)."
+            ),
+        )
+    except Exception as exc:
+        return CheckResult(
+            name="remote-grpc",
+            status=CheckStatus.ERROR,
+            message=f"gRPC unreachable at {grpc_address}: {exc}",
+            fix_hint=(
+                f"gRPC port {grpc_port} unreachable; set NEXUS_GRPC_PORT to the correct port "
+                "and ensure the port is open in your firewall."
+            ),
+        )
+    finally:
+        if transport is not None:
+            import contextlib
+
+            with contextlib.suppress(Exception):
+                transport.close()
+
+
+@doctor.command(name="remote")
+@click.option(
+    "--url",
+    default=None,
+    envvar="NEXUS_URL",
+    help="Base HTTP URL of the remote hub (e.g. http://hub:2026).",
+)
+@click.option(
+    "--api-key",
+    "api_key",
+    default=None,
+    envvar="NEXUS_API_KEY",
+    help="API key for hub authentication.",
+)
+@add_output_options
+def doctor_remote(output_opts: OutputOptions, url: str | None, api_key: str | None) -> None:
+    """Probe a remote hub's HTTP and gRPC reachability.
+
+    Runs two checks and returns an actionable diagnosis:
+      1. HTTP health (GET <url>/health)
+      2. gRPC reachability (via RPCTransport ping)
+
+    Examples:
+        nexus doctor remote --url http://hub:2026 --api-key mykey
+        NEXUS_URL=http://hub:2026 nexus doctor remote
+    """
+    if not url:
+        raise click.UsageError("--url / NEXUS_URL is required for `doctor remote`.")
+
+    try:
+        timing = CommandTiming()
+        with timing.phase("remote-checks"):
+            http_result = _check_remote_http(url)
+            grpc_result = _check_remote_grpc(url, api_key)
+
+        results: list[CheckResult] = [http_result, grpc_result]
+        serializable = [asdict(r) for r in results]
+        for item in serializable:
+            item["status"] = item["status"].value
+
+        def _human_display(_data: list[dict[str, Any]]) -> None:  # noqa: ARG002
+            console.print("\n[bold]Remote preflight[/bold]")
+            has_error = False
+            for check in results:
+                icon = _STATUS_ICONS[check.status]
+                console.print(f"  {icon}  {check.name}: {check.message}")
+                if check.fix_hint and check.status != CheckStatus.OK:
+                    console.print(f"       [nexus.muted]Fix: {check.fix_hint}[/nexus.muted]")
+                if check.status == CheckStatus.ERROR:
+                    has_error = True
+            console.print()
+            if has_error:
+                sys.exit(1)
+
+        render_output(
+            data=serializable,
+            output_opts=output_opts,
+            timing=timing,
+            human_formatter=_human_display,
+        )
+
+        # For JSON mode, exit with error if any check is ERROR
+        if output_opts.json_output:
+            has_error = any(r.status == CheckStatus.ERROR for r in results)
+            if has_error:
+                sys.exit(1)
+    except click.UsageError:
+        raise
+    except Exception as exc:
+        handle_error(exc)
+
+
 def register_commands(cli: click.Group) -> None:
-    """Register doctor command."""
+    """Register doctor command group."""
     cli.add_command(doctor)

--- a/src/nexus/cli/commands/doctor.py
+++ b/src/nexus/cli/commands/doctor.py
@@ -8,6 +8,7 @@ dependencies.  Each check is an independent function returning a structured
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import os
 import shutil
 import subprocess
@@ -16,8 +17,10 @@ from dataclasses import asdict, dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Any
+from urllib.parse import urlparse
 
 import click
+import yaml
 
 from nexus.cli.output import OutputOptions, add_output_options, render_output
 from nexus.cli.theme import console
@@ -661,25 +664,24 @@ def _compute_grpc_address(url: str) -> tuple[str, int]:
       2. nexus.yaml ``ports.grpc``
       3. default 2028
     """
-    from urllib.parse import urlparse
-
     parsed = urlparse(url)
     host = parsed.hostname or "localhost"
 
     grpc_port_str = os.getenv("NEXUS_GRPC_PORT", "")
     if not grpc_port_str:
-        import contextlib
-        from pathlib import Path as _Path
-
         with contextlib.suppress(Exception):
-            import yaml as _yaml
-
-            _pf = _Path("nexus.yaml")
+            _pf = Path("nexus.yaml")
             if _pf.exists():
                 with open(_pf) as _f:
-                    _pc = _yaml.safe_load(_f) or {}
+                    _pc = yaml.safe_load(_f) or {}
                 grpc_port_str = str(_pc.get("ports", {}).get("grpc", ""))
-    grpc_port = int(grpc_port_str) if grpc_port_str else 2028
+    if grpc_port_str:
+        try:
+            grpc_port = int(grpc_port_str)
+        except ValueError:
+            grpc_port = 2028
+    else:
+        grpc_port = 2028
     return f"{host}:{grpc_port}", grpc_port
 
 
@@ -753,8 +755,6 @@ def _check_remote_grpc(url: str, api_key: str | None) -> CheckResult:
         )
     finally:
         if transport is not None:
-            import contextlib
-
             with contextlib.suppress(Exception):
                 transport.close()
 

--- a/src/nexus/cli/commands/doctor.py
+++ b/src/nexus/cli/commands/doctor.py
@@ -17,10 +17,8 @@ from dataclasses import asdict, dataclass
 from enum import Enum
 from pathlib import Path
 from typing import Any
-from urllib.parse import urlparse
 
 import click
-import yaml
 
 from nexus.cli.output import OutputOptions, add_output_options, render_output
 from nexus.cli.theme import console
@@ -656,35 +654,6 @@ def doctor(ctx: click.Context, output_opts: OutputOptions, auto_fix: bool) -> No
 # ---------------------------------------------------------------------------
 
 
-def _compute_grpc_address(url: str) -> tuple[str, int]:
-    """Return (grpc_address_string, grpc_port) for *url*.
-
-    Port precedence (mirrors nexus/__init__.py remote-profile block):
-      1. ``NEXUS_GRPC_PORT`` env var
-      2. nexus.yaml ``ports.grpc``
-      3. default 2028
-    """
-    parsed = urlparse(url)
-    host = parsed.hostname or "localhost"
-
-    grpc_port_str = os.getenv("NEXUS_GRPC_PORT", "")
-    if not grpc_port_str:
-        with contextlib.suppress(Exception):
-            _pf = Path("nexus.yaml")
-            if _pf.exists():
-                with open(_pf) as _f:
-                    _pc = yaml.safe_load(_f) or {}
-                grpc_port_str = str(_pc.get("ports", {}).get("grpc", ""))
-    if grpc_port_str:
-        try:
-            grpc_port = int(grpc_port_str)
-        except ValueError:
-            grpc_port = 2028
-    else:
-        grpc_port = 2028
-    return f"{host}:{grpc_port}", grpc_port
-
-
 def _check_remote_http(url: str) -> CheckResult:
     """GET {url}/health — OK on 200, ERROR otherwise.
 
@@ -720,15 +689,37 @@ def _check_remote_http(url: str) -> CheckResult:
 
 
 def _check_remote_grpc(url: str, api_key: str | None) -> CheckResult:
-    """Attempt a gRPC health check via RPCTransport.health_check()."""
-    grpc_address, grpc_port = _compute_grpc_address(url)
+    """Attempt a gRPC health check, mirroring the real remote SDK path.
+
+    Uses the shared ``resolve_grpc_target`` helper so the preflight
+    resolves the SAME gRPC address AND TLS config the SDK would use
+    (NEXUS_GRPC_TLS / data-dir / nexus.yaml). Without this a TLS-enabled
+    hub the SDK connects to fine could be reported insecure/unreachable.
+    """
+    from nexus.remote.grpc_target import resolve_grpc_target
+
     transport = None
     try:
+        try:
+            grpc_address, grpc_port, tls_config = resolve_grpc_target(url)
+        except RuntimeError as exc:
+            # Fail-closed: NEXUS_GRPC_TLS=true but no certs resolved — the
+            # SDK raises the same; the remote path is unusable as-is.
+            return CheckResult(
+                name="remote-grpc",
+                status=CheckStatus.ERROR,
+                message=f"gRPC TLS misconfigured: {exc}",
+                fix_hint=(
+                    "Provide certs via NEXUS_TLS_CERT/KEY/CA, in "
+                    "{data_dir}/tls/, or unset NEXUS_GRPC_TLS."
+                ),
+            )
         transport = RPCTransport(
             server_address=grpc_address,
             auth_token=api_key,
             timeout=2.0,
             connect_timeout=2.0,
+            tls_config=tls_config,
         )
         transport.health_check()
         return CheckResult(

--- a/src/nexus/cli/commands/doctor.py
+++ b/src/nexus/cli/commands/doctor.py
@@ -753,6 +753,46 @@ def _check_remote_grpc(url: str, api_key: str | None) -> CheckResult:
             ),
         )
     except Exception as exc:
+        # The Ping path is auth-gated: a missing/invalid key yields gRPC
+        # UNAUTHENTICATED/PERMISSION_DENIED, NOT an unreachable port.
+        # Misreporting that as "set NEXUS_GRPC_PORT/firewall" sends the
+        # operator down the wrong recovery path, so diagnose auth
+        # distinctly. Inspect the exception chain for a grpc.RpcError
+        # status code, with a string fallback (RemoteConnectionError
+        # embeds the gRPC detail text).
+        import grpc
+
+        code = None
+        _e: BaseException | None = exc
+        _seen: set[int] = set()
+        while _e is not None and id(_e) not in _seen:
+            _seen.add(id(_e))
+            if isinstance(_e, grpc.RpcError):
+                try:
+                    code = _e.code()
+                except Exception:
+                    code = None
+                break
+            _e = _e.__cause__ or _e.__context__
+        _msg = str(exc)
+        is_auth = code in (
+            grpc.StatusCode.UNAUTHENTICATED,
+            grpc.StatusCode.PERMISSION_DENIED,
+        ) or any(tok in _msg for tok in ("UNAUTHENTICATED", "PERMISSION_DENIED", "Unauthenticated"))
+        if is_auth:
+            return CheckResult(
+                name="remote-grpc",
+                status=CheckStatus.ERROR,
+                message=(
+                    f"gRPC authentication failed at {grpc_address} "
+                    f"(UNAUTHENTICATED/PERMISSION_DENIED): {exc}"
+                ),
+                fix_hint=(
+                    "The API key is missing or invalid for this hub. Provide a "
+                    "valid key via --api-key <key> or NEXUS_API_KEY (the gRPC "
+                    "Ping path is auth-gated; this is NOT a port/firewall issue)."
+                ),
+            )
         return CheckResult(
             name="remote-grpc",
             status=CheckStatus.ERROR,

--- a/src/nexus/cli/commands/profile.py
+++ b/src/nexus/cli/commands/profile.py
@@ -22,6 +22,7 @@ from nexus.cli.config import (
     get_config_path,
     load_cli_config,
     resolve_connection,
+    same_endpoint,
     save_cli_config,
 )
 from nexus.cli.state import load_project_config_optional
@@ -239,19 +240,6 @@ def rename_cmd(old_name: str, new_name: str) -> None:
     console.print(f"Renamed profile [bold]'{old_name}'[/bold] to [bold]'{new_name}'[/bold]")
 
 
-def _same_endpoint(a: str | None, b: str | None) -> bool:
-    """True if two URLs point at the same scheme://host:port (path /
-    trailing slash ignored). Used to decide whether the resolved contract
-    target is the locally-managed stack (so local nexus.yaml auth applies)
-    or a different/remote hub."""
-    if not a or not b:
-        return False
-    from urllib.parse import urlparse
-
-    pa, pb = urlparse(a.rstrip("/")), urlparse(b.rstrip("/"))
-    return (pa.scheme, pa.hostname, pa.port) == (pb.scheme, pb.hostname, pb.port)
-
-
 @profile_group.command(name="contract")
 @click.option(
     "--url",
@@ -333,7 +321,7 @@ def contract_cmd(ctx: click.Context, url: str | None, api_key: str | None) -> No
     # the locally-managed stack (endpoint match). A saved current-profile
     # pointing at a remote hub must NOT inherit the local project's auth.
     is_local_managed = bool(
-        project_cfg and local_managed_url and _same_endpoint(target_url, local_managed_url)
+        project_cfg and local_managed_url and same_endpoint(target_url, local_managed_url)
     )
 
     url = target_url

--- a/src/nexus/cli/commands/profile.py
+++ b/src/nexus/cli/commands/profile.py
@@ -11,6 +11,7 @@ Commands:
 """
 
 import json
+from typing import Any
 
 import click
 from rich.table import Table
@@ -25,6 +26,7 @@ from nexus.cli.config import (
 )
 from nexus.cli.state import load_project_config_optional
 from nexus.cli.theme import console
+from nexus.contracts.deployment_profile import DeploymentProfile
 
 
 @click.group(name="profile")
@@ -252,14 +254,14 @@ def contract_cmd() -> None:
         nexus profile contract
         nexus --profile staging profile contract
     """
-    from nexus.contracts.deployment_profile import DeploymentProfile
-
     config = load_cli_config()
     resolved = resolve_connection(config=config)
     url = resolved.url or "http://localhost:2026"
 
     try:
-        features: dict = NexusApiClient(url=url, api_key=resolved.api_key).get("/api/v2/features")
+        features: dict[str, Any] = NexusApiClient(url=url, api_key=resolved.api_key).get(
+            "/api/v2/features"
+        )
     except Exception as exc:
         console.print(
             f"[nexus.error]Error:[/nexus.error] could not reach {url}/api/v2/features: {exc}. "
@@ -274,7 +276,7 @@ def contract_cmd() -> None:
         drivers = []
 
     project_cfg = load_project_config_optional()
-    auth_mode: str = project_cfg.get("auth", "unknown") if project_cfg else "unknown"
+    auth_mode: str = project_cfg.get("auth", "unknown")
 
     contract = {
         "auth_mode": auth_mode,

--- a/src/nexus/cli/commands/profile.py
+++ b/src/nexus/cli/commands/profile.py
@@ -239,6 +239,19 @@ def rename_cmd(old_name: str, new_name: str) -> None:
     console.print(f"Renamed profile [bold]'{old_name}'[/bold] to [bold]'{new_name}'[/bold]")
 
 
+def _same_endpoint(a: str | None, b: str | None) -> bool:
+    """True if two URLs point at the same scheme://host:port (path /
+    trailing slash ignored). Used to decide whether the resolved contract
+    target is the locally-managed stack (so local nexus.yaml auth applies)
+    or a different/remote hub."""
+    if not a or not b:
+        return False
+    from urllib.parse import urlparse
+
+    pa, pb = urlparse(a.rstrip("/")), urlparse(b.rstrip("/"))
+    return (pa.scheme, pa.hostname, pa.port) == (pb.scheme, pb.hostname, pb.port)
+
+
 @profile_group.command(name="contract")
 @click.option(
     "--url",
@@ -279,10 +292,6 @@ def contract_cmd(ctx: click.Context, url: str | None, api_key: str | None) -> No
     """
     config = load_cli_config()
     profile_name = (ctx.obj or {}).get("profile")
-    # Explicit remote target: a URL/api-key flag-or-env, or a named
-    # global --profile. Local nexus.yaml auth does not describe such a
-    # hub, so auth_mode must not be presented as its contract.
-    is_remote_target = bool(url) or bool(api_key) or bool(profile_name)
     resolved = resolve_connection(
         remote_url=url,
         remote_api_key=api_key,
@@ -290,30 +299,42 @@ def contract_cmd(ctx: click.Context, url: str | None, api_key: str | None) -> No
         config=config,
     )
 
-    if resolved.url:
-        # Explicit remote target (--url / NEXUS_URL / named profile).
-        target_url = resolved.url
-        # resolve_connection only preserves remote_api_key when a
-        # remote_url is set; keep an explicit key for the localhost case
-        # too so a static-auth hub isn't 401'd.
-        effective_api_key = api_key or resolved.api_key
-    else:
-        # Bare `nexus profile contract`: resolve the *locally-managed
-        # stack's actual endpoint* the same way `nexus env`/`status` do
-        # (derived/resolved ports from project config + runtime state) —
-        # NOT a hard-coded localhost:2026 that could hit an unrelated
-        # daemon.
-        project_cfg = load_project_config_optional()
-        if project_cfg:
-            from nexus.cli.state import load_runtime_state, resolve_connection_env
+    # Resolve the locally-managed stack's *actual* endpoint (derived /
+    # runtime-resolved ports) so we can both (a) target it for bare
+    # `nexus profile contract` and (b) decide whether the resolved target
+    # is in fact that local stack — the ONLY case where local nexus.yaml
+    # auth describes the hub being queried.
+    project_cfg = load_project_config_optional()
+    local_managed_url: str | None = None
+    local_managed_key: str | None = None
+    if project_cfg:
+        from nexus.cli.state import load_runtime_state, resolve_connection_env
 
-            state = load_runtime_state(project_cfg.get("data_dir", "./nexus-data"))
-            conn = resolve_connection_env(project_cfg, state)
-            target_url = conn.get("NEXUS_URL") or "http://localhost:2026"
-            effective_api_key = api_key or conn.get("NEXUS_API_KEY")
-        else:
-            target_url = "http://localhost:2026"
-            effective_api_key = api_key or resolved.api_key
+        _state = load_runtime_state(project_cfg.get("data_dir", "./nexus-data"))
+        _conn = resolve_connection_env(project_cfg, _state)
+        local_managed_url = _conn.get("NEXUS_URL")
+        local_managed_key = _conn.get("NEXUS_API_KEY")
+
+    if resolved.url:
+        # Any resolved URL — explicit --url/NEXUS_URL, named global
+        # --profile, OR the saved current-profile in ~/.nexus/config.yaml.
+        target_url = resolved.url
+        effective_api_key = api_key or resolved.api_key
+    elif local_managed_url:
+        # Bare invocation, project present: target the managed stack's
+        # real endpoint (NOT a hard-coded localhost:2026).
+        target_url = local_managed_url
+        effective_api_key = api_key or local_managed_key
+    else:
+        target_url = "http://localhost:2026"
+        effective_api_key = api_key or resolved.api_key
+
+    # auth_mode is trustworthy ONLY when the resolved target is provably
+    # the locally-managed stack (endpoint match). A saved current-profile
+    # pointing at a remote hub must NOT inherit the local project's auth.
+    is_local_managed = bool(
+        project_cfg and local_managed_url and _same_endpoint(target_url, local_managed_url)
+    )
 
     url = target_url
     try:
@@ -334,15 +355,17 @@ def contract_cmd(ctx: click.Context, url: str | None, api_key: str | None) -> No
         drivers = []
 
     # auth_mode: local nexus.yaml only describes the locally-managed
-    # stack. For an explicit remote target it is not evidence about that
-    # hub, so report "unknown" rather than a misleading local value.
-    if is_remote_target:
-        auth_mode = "unknown"
-        auth_mode_source = "unknown (remote target — local config does not describe it)"
-    else:
-        project_cfg = load_project_config_optional()
+    # stack. Report it ONLY when the resolved target IS that stack;
+    # otherwise (explicit/profile/current-profile remote) report
+    # "unknown" rather than a misleading local value.
+    if is_local_managed:
         auth_mode = project_cfg.get("auth", "unknown")
         auth_mode_source = "local nexus.yaml (locally-managed stack)"
+    else:
+        auth_mode = "unknown"
+        auth_mode_source = (
+            "unknown (target is not the locally-managed stack — local config does not describe it)"
+        )
 
     contract = {
         "auth_mode": auth_mode,

--- a/src/nexus/cli/commands/profile.py
+++ b/src/nexus/cli/commands/profile.py
@@ -7,17 +7,23 @@ Commands:
     nexus profile show          Show current profile details
     nexus profile delete <name> Delete a profile
     nexus profile rename <old> <new>  Rename a profile
+    nexus profile contract      Print the running hub's resolved deployment-profile contract
 """
+
+import json
 
 import click
 from rich.table import Table
 
+from nexus.cli.api_client import NexusApiClient
 from nexus.cli.config import (
     ProfileEntry,
     get_config_path,
     load_cli_config,
+    resolve_connection,
     save_cli_config,
 )
+from nexus.cli.state import load_project_config_optional
 from nexus.cli.theme import console
 
 
@@ -229,6 +235,58 @@ def rename_cmd(old_name: str, new_name: str) -> None:
 
     save_cli_config(config)
     console.print(f"Renamed profile [bold]'{old_name}'[/bold] to [bold]'{new_name}'[/bold]")
+
+
+@profile_group.command(name="contract")
+def contract_cmd() -> None:
+    """Print the running hub's resolved deployment-profile contract as JSON.
+
+    Queries the active connection's /api/v2/features endpoint and enriches
+    the response with the DeploymentProfile's default driver set and the
+    local nexus.yaml auth mode (when a project config is present).
+
+    The ``grpc_required`` field is always ``true`` — the remote SDK path
+    requires gRPC, not just HTTP (documented invariant, Issue #4132).
+
+    Examples:
+        nexus profile contract
+        nexus --profile staging profile contract
+    """
+    from nexus.contracts.deployment_profile import DeploymentProfile
+
+    config = load_cli_config()
+    resolved = resolve_connection(config=config)
+    url = resolved.url or "http://localhost:2026"
+
+    try:
+        features: dict = NexusApiClient(url=url, api_key=resolved.api_key).get("/api/v2/features")
+    except Exception as exc:
+        console.print(
+            f"[nexus.error]Error:[/nexus.error] could not reach {url}/api/v2/features: {exc}. "
+            "Is the hub running? Try `nexus doctor`."
+        )
+        raise SystemExit(1) from None
+
+    profile_str: str = features.get("profile", "")
+    try:
+        drivers: list[str] = sorted(DeploymentProfile(profile_str).default_drivers())
+    except ValueError:
+        drivers = []
+
+    project_cfg = load_project_config_optional()
+    auth_mode: str = project_cfg.get("auth", "unknown") if project_cfg else "unknown"
+
+    contract = {
+        "auth_mode": auth_mode,
+        "bricks": sorted(features.get("enabled_bricks", [])),
+        "deployment_profile": profile_str,
+        "disabled_bricks": sorted(features.get("disabled_bricks", [])),
+        "drivers": drivers,
+        "grpc_required": True,
+        "mode": features.get("mode", ""),
+        "version": features.get("version"),
+    }
+    print(json.dumps(contract, indent=2, sort_keys=True))
 
 
 # ---------------------------------------------------------------------------

--- a/src/nexus/cli/commands/profile.py
+++ b/src/nexus/cli/commands/profile.py
@@ -240,7 +240,21 @@ def rename_cmd(old_name: str, new_name: str) -> None:
 
 
 @profile_group.command(name="contract")
-def contract_cmd() -> None:
+@click.option(
+    "--url",
+    "--remote-url",
+    default=None,
+    envvar="NEXUS_URL",
+    help="Server URL to query (default: http://localhost:2026).",
+)
+@click.option(
+    "--api-key",
+    "--remote-api-key",
+    default=None,
+    envvar="NEXUS_API_KEY",
+    help="API key for authenticated requests.",
+)
+def contract_cmd(url: str | None, api_key: str | None) -> None:
     """Print the running hub's resolved deployment-profile contract as JSON.
 
     Queries the active connection's /api/v2/features endpoint and enriches
@@ -252,10 +266,11 @@ def contract_cmd() -> None:
 
     Examples:
         nexus profile contract
+        nexus profile contract --url http://hub:9999 --api-key nx_xxx
         nexus --profile staging profile contract
     """
     config = load_cli_config()
-    resolved = resolve_connection(config=config)
+    resolved = resolve_connection(remote_url=url, remote_api_key=api_key, config=config)
     url = resolved.url or "http://localhost:2026"
 
     try:

--- a/src/nexus/cli/commands/profile.py
+++ b/src/nexus/cli/commands/profile.py
@@ -254,12 +254,19 @@ def rename_cmd(old_name: str, new_name: str) -> None:
     envvar="NEXUS_API_KEY",
     help="API key for authenticated requests.",
 )
-def contract_cmd(url: str | None, api_key: str | None) -> None:
+@click.pass_context
+def contract_cmd(ctx: click.Context, url: str | None, api_key: str | None) -> None:
     """Print the running hub's resolved deployment-profile contract as JSON.
 
-    Queries the active connection's /api/v2/features endpoint and enriches
-    the response with the DeploymentProfile's default driver set and the
-    local nexus.yaml auth mode (when a project config is present).
+    Hub-returned fields (``deployment_profile``, ``bricks``,
+    ``disabled_bricks``, ``mode``, ``version``) are authoritative.
+    ``drivers`` is *client-inferred* from the hub's profile name via this
+    client's DeploymentProfile enum (can diverge under CLI/server version
+    skew). ``auth_mode`` reflects the local nexus.yaml only for the
+    locally-managed stack — for an explicit remote target (``--url`` /
+    ``NEXUS_URL`` / global ``--profile``) it is ``"unknown"`` because
+    local config does not describe a remote hub. A ``_sources`` map in
+    the output records each field's provenance.
 
     The ``grpc_required`` field is always ``true`` — the remote SDK path
     requires gRPC, not just HTTP (documented invariant, Issue #4132).
@@ -270,7 +277,17 @@ def contract_cmd(url: str | None, api_key: str | None) -> None:
         nexus --profile staging profile contract
     """
     config = load_cli_config()
-    resolved = resolve_connection(remote_url=url, remote_api_key=api_key, config=config)
+    profile_name = (ctx.obj or {}).get("profile")
+    # Explicit remote target: a URL/api-key flag-or-env, or a named
+    # global --profile. Local nexus.yaml auth does not describe such a
+    # hub, so auth_mode must not be presented as its contract.
+    is_remote_target = bool(url) or bool(api_key) or bool(profile_name)
+    resolved = resolve_connection(
+        remote_url=url,
+        remote_api_key=api_key,
+        profile_name=profile_name,
+        config=config,
+    )
     url = resolved.url or "http://localhost:2026"
 
     try:
@@ -290,8 +307,16 @@ def contract_cmd(url: str | None, api_key: str | None) -> None:
     except ValueError:
         drivers = []
 
-    project_cfg = load_project_config_optional()
-    auth_mode: str = project_cfg.get("auth", "unknown")
+    # auth_mode: local nexus.yaml only describes the locally-managed
+    # stack. For an explicit remote target it is not evidence about that
+    # hub, so report "unknown" rather than a misleading local value.
+    if is_remote_target:
+        auth_mode = "unknown"
+        auth_mode_source = "unknown (remote target — local config does not describe it)"
+    else:
+        project_cfg = load_project_config_optional()
+        auth_mode = project_cfg.get("auth", "unknown")
+        auth_mode_source = "local nexus.yaml (locally-managed stack)"
 
     contract = {
         "auth_mode": auth_mode,
@@ -302,6 +327,16 @@ def contract_cmd(url: str | None, api_key: str | None) -> None:
         "grpc_required": True,
         "mode": features.get("mode", ""),
         "version": features.get("version"),
+        "_sources": {
+            "deployment_profile": "hub /api/v2/features (authoritative)",
+            "bricks": "hub /api/v2/features (authoritative)",
+            "disabled_bricks": "hub /api/v2/features (authoritative)",
+            "mode": "hub /api/v2/features (authoritative)",
+            "version": "hub /api/v2/features (authoritative)",
+            "drivers": "client-inferred from hub profile via DeploymentProfile enum (not hub-authoritative; may differ under version skew)",
+            "grpc_required": "documented invariant (Issue #4132)",
+            "auth_mode": auth_mode_source,
+        },
     }
     print(json.dumps(contract, indent=2, sort_keys=True))
 

--- a/src/nexus/cli/commands/profile.py
+++ b/src/nexus/cli/commands/profile.py
@@ -291,8 +291,13 @@ def contract_cmd(ctx: click.Context, url: str | None, api_key: str | None) -> No
     )
     url = resolved.url or "http://localhost:2026"
 
+    # resolve_connection only preserves remote_api_key when a remote_url
+    # is set, so an explicit `--api-key`/NEXUS_API_KEY against the default
+    # localhost hub would otherwise be dropped → 401 on a static-auth
+    # hub. Keep the explicitly-provided key in that case.
+    effective_api_key = api_key or resolved.api_key
     try:
-        features: dict[str, Any] = NexusApiClient(url=url, api_key=resolved.api_key).get(
+        features: dict[str, Any] = NexusApiClient(url=url, api_key=effective_api_key).get(
             "/api/v2/features"
         )
     except Exception as exc:

--- a/src/nexus/cli/commands/profile.py
+++ b/src/nexus/cli/commands/profile.py
@@ -260,9 +260,10 @@ def contract_cmd(ctx: click.Context, url: str | None, api_key: str | None) -> No
 
     Hub-returned fields (``deployment_profile``, ``bricks``,
     ``disabled_bricks``, ``mode``, ``version``) are authoritative.
-    ``drivers`` is *client-inferred* from the hub's profile name via this
-    client's DeploymentProfile enum (can diverge under CLI/server version
-    skew). ``auth_mode`` reflects the local nexus.yaml only for the
+    ``client_inferred_drivers`` is *not* hub-authoritative: the hub does
+    not return its driver set, so it is inferred from the hub's profile
+    name via this client's DeploymentProfile enum (can diverge under
+    CLI/server version skew). ``auth_mode`` reflects the local nexus.yaml only for the
     locally-managed stack — for an explicit remote target (``--url`` /
     ``NEXUS_URL`` / global ``--profile``) it is ``"unknown"`` because
     local config does not describe a remote hub. A ``_sources`` map in
@@ -323,7 +324,11 @@ def contract_cmd(ctx: click.Context, url: str | None, api_key: str | None) -> No
         "bricks": sorted(features.get("enabled_bricks", [])),
         "deployment_profile": profile_str,
         "disabled_bricks": sorted(features.get("disabled_bricks", [])),
-        "drivers": drivers,
+        # NOT named "drivers": the hub does not return its driver set, so
+        # this is inferred from the hub's profile name via THIS client's
+        # DeploymentProfile enum. The name makes the non-authoritative
+        # nature explicit for machine consumers and operators.
+        "client_inferred_drivers": drivers,
         "grpc_required": True,
         "mode": features.get("mode", ""),
         "version": features.get("version"),
@@ -333,7 +338,7 @@ def contract_cmd(ctx: click.Context, url: str | None, api_key: str | None) -> No
             "disabled_bricks": "hub /api/v2/features (authoritative)",
             "mode": "hub /api/v2/features (authoritative)",
             "version": "hub /api/v2/features (authoritative)",
-            "drivers": "client-inferred from hub profile via DeploymentProfile enum (not hub-authoritative; may differ under version skew)",
+            "client_inferred_drivers": "client-inferred from hub profile via DeploymentProfile enum (NOT hub-authoritative; may differ under CLI/server version skew)",
             "grpc_required": "documented invariant (Issue #4132)",
             "auth_mode": auth_mode_source,
         },

--- a/src/nexus/cli/commands/profile.py
+++ b/src/nexus/cli/commands/profile.py
@@ -289,13 +289,33 @@ def contract_cmd(ctx: click.Context, url: str | None, api_key: str | None) -> No
         profile_name=profile_name,
         config=config,
     )
-    url = resolved.url or "http://localhost:2026"
 
-    # resolve_connection only preserves remote_api_key when a remote_url
-    # is set, so an explicit `--api-key`/NEXUS_API_KEY against the default
-    # localhost hub would otherwise be dropped → 401 on a static-auth
-    # hub. Keep the explicitly-provided key in that case.
-    effective_api_key = api_key or resolved.api_key
+    if resolved.url:
+        # Explicit remote target (--url / NEXUS_URL / named profile).
+        target_url = resolved.url
+        # resolve_connection only preserves remote_api_key when a
+        # remote_url is set; keep an explicit key for the localhost case
+        # too so a static-auth hub isn't 401'd.
+        effective_api_key = api_key or resolved.api_key
+    else:
+        # Bare `nexus profile contract`: resolve the *locally-managed
+        # stack's actual endpoint* the same way `nexus env`/`status` do
+        # (derived/resolved ports from project config + runtime state) —
+        # NOT a hard-coded localhost:2026 that could hit an unrelated
+        # daemon.
+        project_cfg = load_project_config_optional()
+        if project_cfg:
+            from nexus.cli.state import load_runtime_state, resolve_connection_env
+
+            state = load_runtime_state(project_cfg.get("data_dir", "./nexus-data"))
+            conn = resolve_connection_env(project_cfg, state)
+            target_url = conn.get("NEXUS_URL") or "http://localhost:2026"
+            effective_api_key = api_key or conn.get("NEXUS_API_KEY")
+        else:
+            target_url = "http://localhost:2026"
+            effective_api_key = api_key or resolved.api_key
+
+    url = target_url
     try:
         features: dict[str, Any] = NexusApiClient(url=url, api_key=effective_api_key).get(
             "/api/v2/features"

--- a/src/nexus/cli/commands/status.py
+++ b/src/nexus/cli/commands/status.py
@@ -61,7 +61,9 @@ def _fetch_deployment_profile_from_features(
     return None
 
 
-def _resolve_deployment_profile(server_url: str, api_key: str | None = None) -> str:
+def _resolve_deployment_profile(
+    server_url: str, api_key: str | None = None, *, allow_env_fallback: bool = True
+) -> str:
     """Resolve the *running hub's* deployment profile.
 
     `nexus status` reports the hub at *server_url*, so the live hub's
@@ -72,16 +74,19 @@ def _resolve_deployment_profile(server_url: str, api_key: str | None = None) -> 
     Hierarchy (single source of truth):
     1. Live ``GET /api/v2/features`` for *server_url* (authoritative when
        a server URL is available and reachable).
-    2. ``NEXUS_PROFILE`` env var — offline/local fallback only (used when
-       there is no server URL or the hub is unreachable).
+    2. ``NEXUS_PROFILE`` env var — ONLY when *allow_env_fallback* (the
+       target is the local managed/default stack). For an explicit
+       remote target whose features probe failed there is NO evidence,
+       so the env var must not be reported as that hub's profile.
     3. ``"unknown"`` fallback.
     """
     fetched = _fetch_deployment_profile_from_features(server_url, api_key) if server_url else None
     if fetched:
         return fetched
-    profile_env = os.environ.get("NEXUS_PROFILE", "").strip()
-    if profile_env:
-        return profile_env
+    if allow_env_fallback:
+        profile_env = os.environ.get("NEXUS_PROFILE", "").strip()
+        if profile_env:
+            return profile_env
     return "unknown"
 
 
@@ -144,7 +149,11 @@ def _enrich_with_image_info(data: dict[str, Any]) -> dict[str, Any]:
         # connection's API key so an authenticated features endpoint
         # isn't silently 401'd into the env/unknown fallback.
         data["deployment_profile"] = _resolve_deployment_profile(
-            target_url or local_stack_url, conn_env.get("NEXUS_API_KEY")
+            target_url or local_stack_url,
+            conn_env.get("NEXUS_API_KEY"),
+            # NEXUS_PROFILE may stand in only when the target IS the
+            # local managed stack; never for a different remote --url.
+            allow_env_fallback=is_local_stack,
         )
     else:
         # No project config: there is no locally-managed stack to compare
@@ -153,9 +162,16 @@ def _enrich_with_image_info(data: dict[str, Any]) -> dict[str, Any]:
         # authenticated remote hub (--url / NEXUS_URL).
         data["auth_mode"] = "unknown"
 
-        # deployment_profile: resolved against the status target
-        # (NexusApiClient also picks up NEXUS_API_KEY from the env).
-        data["deployment_profile"] = _resolve_deployment_profile(data.get("server_url", ""))
+        # deployment_profile: resolved against the status target.
+        # With no project config there is no managed stack; only the
+        # loopback default may borrow NEXUS_PROFILE as an offline
+        # fallback — an explicit remote --url must report "unknown" when
+        # its features probe fails (no evidence about that hub).
+        _target = data.get("server_url", "")
+        _is_local_default = (not _target) or _same_endpoint(_target, "http://localhost:2026")
+        data["deployment_profile"] = _resolve_deployment_profile(
+            _target, allow_env_fallback=_is_local_default
+        )
 
     return data
 

--- a/src/nexus/cli/commands/status.py
+++ b/src/nexus/cli/commands/status.py
@@ -102,7 +102,9 @@ def _same_endpoint(a: str, b: str) -> bool:
     return (pa.scheme, pa.hostname, pa.port) == (pb.scheme, pb.hostname, pb.port)
 
 
-def _enrich_with_image_info(data: dict[str, Any]) -> dict[str, Any]:
+def _enrich_with_image_info(
+    data: dict[str, Any], status_api_key: str | None = None
+) -> dict[str, Any]:
     """Add the *effective* image_ref, connection env, and project info into *data*.
 
     Uses the same precedence logic as ``nexus up`` (env vars > config ref >
@@ -144,13 +146,17 @@ def _enrich_with_image_info(data: dict[str, Any]) -> dict[str, Any]:
         # locally-managed stack; otherwise it does not describe that hub.
         data["auth_mode"] = project_cfg.get("auth", "none") if is_local_stack else "unknown"
 
+        # Credential boundary: send the LOCAL stack key to the features
+        # probe ONLY when the target IS the local stack. For a different
+        # remote --url, use the key the caller supplied for THIS status
+        # invocation (or none) — never the local conn_env bearer token.
+        probe_key = conn_env.get("NEXUS_API_KEY") if is_local_stack else status_api_key
+
         # deployment_profile: resolved against the actual status target
-        # (features-first; env is offline fallback only). Forward the
-        # connection's API key so an authenticated features endpoint
-        # isn't silently 401'd into the env/unknown fallback.
+        # (features-first; env is offline fallback only).
         data["deployment_profile"] = _resolve_deployment_profile(
             target_url or local_stack_url,
-            conn_env.get("NEXUS_API_KEY"),
+            probe_key,
             # NEXUS_PROFILE may stand in only when the target IS the
             # local managed stack; never for a different remote --url.
             allow_env_fallback=is_local_stack,
@@ -170,7 +176,7 @@ def _enrich_with_image_info(data: dict[str, Any]) -> dict[str, Any]:
         _target = data.get("server_url", "")
         _is_local_default = (not _target) or _same_endpoint(_target, "http://localhost:2026")
         data["deployment_profile"] = _resolve_deployment_profile(
-            _target, allow_env_fallback=_is_local_default
+            _target, status_api_key, allow_env_fallback=_is_local_default
         )
 
     return data
@@ -461,7 +467,8 @@ def status(
             timing = CommandTiming()
             with timing.phase("collect"):
                 data = _enrich_with_image_info(
-                    _collect_status(server_url, remote_api_key, profile_list)
+                    _collect_status(server_url, remote_api_key, profile_list),
+                    remote_api_key,
                 )
             render_output(
                 data=data,
@@ -479,14 +486,14 @@ def _watch_loop(server_url: str, api_key: str | None, profiles: list[str] | None
     """Continuously refresh the status table every 2 seconds."""
     from rich.live import Live
 
-    data = _enrich_with_image_info(_collect_status(server_url, api_key, profiles))
+    data = _enrich_with_image_info(_collect_status(server_url, api_key, profiles), api_key)
 
     with Live(_build_table(data), refresh_per_second=1, console=console) as live:
         while True:
             time.sleep(2)
             live.update(
                 _build_table(
-                    _enrich_with_image_info(_collect_status(server_url, api_key, profiles))
+                    _enrich_with_image_info(_collect_status(server_url, api_key, profiles), api_key)
                 )
             )
 

--- a/src/nexus/cli/commands/status.py
+++ b/src/nexus/cli/commands/status.py
@@ -8,6 +8,7 @@ auto-refresh every 2 seconds.
 from __future__ import annotations
 
 import asyncio
+import os
 import time
 from typing import TYPE_CHECKING, Any
 
@@ -34,12 +35,51 @@ def _load_project_config_optional() -> dict[str, Any]:
     return load_project_config_optional()
 
 
+def load_runtime_state(data_dir: str) -> dict[str, Any]:
+    """Thin wrapper so tests can patch ``nexus.cli.commands.status.load_runtime_state``."""
+    from nexus.cli.state import load_runtime_state as _load
+
+    return _load(data_dir)
+
+
+def resolve_connection_env(project_cfg: dict[str, Any], state: dict[str, Any]) -> dict[str, str]:
+    """Thin wrapper so tests can patch ``nexus.cli.commands.status.resolve_connection_env``."""
+    from nexus.cli.state import resolve_connection_env as _resolve
+
+    return _resolve(project_cfg, state)
+
+
+def _fetch_deployment_profile_from_features(server_url: str) -> str | None:
+    """Best-effort fetch of *profile* from ``GET /api/v2/features``.
+
+    Returns the profile string on success, or *None* on any failure.
+    Never raises; uses a short timeout so ``nexus status`` stays responsive
+    even when the server is offline.
+    """
+    try:
+        from nexus.cli.api_client import NexusApiClient
+
+        features = NexusApiClient(url=server_url, timeout=2.0).get("/api/v2/features")
+        if isinstance(features, dict):
+            profile = features.get("profile")
+            if profile and isinstance(profile, str):
+                return profile
+    except Exception:
+        pass
+    return None
+
+
 def _enrich_with_image_info(data: dict[str, Any]) -> dict[str, Any]:
     """Add the *effective* image_ref, connection env, and project info into *data*.
 
     Uses the same precedence logic as ``nexus up`` (env vars > config ref >
     deprecated config tag) so ``nexus status`` always shows the image that
     would actually run, not just the raw config value.
+
+    Also adds two new additive keys (Gap 2 of #4132):
+    - ``auth_mode``: from project config's ``auth`` key (default ``"none"``).
+    - ``deployment_profile``: resolved via env ``NEXUS_PROFILE`` →
+      best-effort ``GET /api/v2/features`` → ``"unknown"``.
     """
     from nexus.cli.commands.stack import _resolve_image_ref_from_config
 
@@ -50,13 +90,39 @@ def _enrich_with_image_info(data: dict[str, Any]) -> dict[str, Any]:
         data["image_accelerator"] = project_cfg.get("image_accelerator", "")
 
         # Add connection env vars and project metadata
-        from nexus.cli.state import load_runtime_state, resolve_connection_env
-
         data_dir = project_cfg.get("data_dir", "./nexus-data")
         state = load_runtime_state(data_dir)
-        data["connection_env"] = resolve_connection_env(project_cfg, state)
+        conn_env = resolve_connection_env(project_cfg, state)
+        data["connection_env"] = conn_env
         data["project_name"] = state.get("project_name", "")
         data["data_dir"] = data_dir
+
+        # auth_mode: from project config (preset maps: shared→static,
+        # demo→database, local→none)
+        data["auth_mode"] = project_cfg.get("auth", "none")
+
+        # deployment_profile: env → features endpoint → "unknown"
+        profile_env = os.environ.get("NEXUS_PROFILE", "").strip()
+        if profile_env:
+            data["deployment_profile"] = profile_env
+        else:
+            server_url = conn_env.get("NEXUS_URL") or data.get("server_url", "")
+            fetched = _fetch_deployment_profile_from_features(server_url) if server_url else None
+            data["deployment_profile"] = fetched if fetched else "unknown"
+    else:
+        # No project config: auth defaults to "none"
+        data["auth_mode"] = "none"
+
+        # deployment_profile: env → features endpoint (using server_url from
+        # collected data) → "unknown"
+        profile_env = os.environ.get("NEXUS_PROFILE", "").strip()
+        if profile_env:
+            data["deployment_profile"] = profile_env
+        else:
+            server_url = data.get("server_url", "")
+            fetched = _fetch_deployment_profile_from_features(server_url) if server_url else None
+            data["deployment_profile"] = fetched if fetched else "unknown"
+
     return data
 
 
@@ -327,8 +393,6 @@ def status(
     else:
         cfg = _load_project_config_optional()
         if cfg:
-            from nexus.cli.state import load_runtime_state, resolve_connection_env
-
             data_dir = cfg.get("data_dir", "./nexus-data")
             state = load_runtime_state(data_dir)
             conn = resolve_connection_env(cfg, state)

--- a/src/nexus/cli/commands/status.py
+++ b/src/nexus/cli/commands/status.py
@@ -56,18 +56,27 @@ def _fetch_deployment_profile_from_features(server_url: str) -> str | None:
 
 
 def _resolve_deployment_profile(server_url: str) -> str:
-    """Resolve deployment profile via env ``NEXUS_PROFILE`` → features endpoint → ``"unknown"``.
+    """Resolve the *running hub's* deployment profile.
+
+    `nexus status` reports the hub at *server_url*, so the live hub's
+    ``/api/v2/features`` value is authoritative and MUST win over a local
+    ``NEXUS_PROFILE`` env var (otherwise ``NEXUS_PROFILE=full nexus status
+    --url <other-hub>`` would mislabel a different hub).
 
     Hierarchy (single source of truth):
-    1. ``NEXUS_PROFILE`` env var (non-empty wins immediately).
-    2. Best-effort ``GET /api/v2/features`` for the resolved *server_url*.
+    1. Live ``GET /api/v2/features`` for *server_url* (authoritative when
+       a server URL is available and reachable).
+    2. ``NEXUS_PROFILE`` env var — offline/local fallback only (used when
+       there is no server URL or the hub is unreachable).
     3. ``"unknown"`` fallback.
     """
+    fetched = _fetch_deployment_profile_from_features(server_url) if server_url else None
+    if fetched:
+        return fetched
     profile_env = os.environ.get("NEXUS_PROFILE", "").strip()
     if profile_env:
         return profile_env
-    fetched = _fetch_deployment_profile_from_features(server_url) if server_url else None
-    return fetched if fetched else "unknown"
+    return "unknown"
 
 
 def _enrich_with_image_info(data: dict[str, Any]) -> dict[str, Any]:

--- a/src/nexus/cli/commands/status.py
+++ b/src/nexus/cli/commands/status.py
@@ -14,6 +14,7 @@ from typing import TYPE_CHECKING, Any
 
 import click
 
+from nexus.cli.config import same_endpoint
 from nexus.cli.output import OutputOptions, add_output_options, render_output
 from nexus.cli.theme import console
 from nexus.cli.timing import CommandTiming
@@ -90,18 +91,6 @@ def _resolve_deployment_profile(
     return "unknown"
 
 
-def _same_endpoint(a: str, b: str) -> bool:
-    """True if two URLs point at the same scheme://host:port (path/trailing
-    slash ignored). Used to decide whether a status target is the local
-    stack (so local nexus.yaml auth applies) or a different remote hub."""
-    if not a or not b:
-        return False
-    from urllib.parse import urlparse
-
-    pa, pb = urlparse(a.rstrip("/")), urlparse(b.rstrip("/"))
-    return (pa.scheme, pa.hostname, pa.port) == (pb.scheme, pb.hostname, pb.port)
-
-
 def _enrich_with_image_info(
     data: dict[str, Any], status_api_key: str | None = None
 ) -> dict[str, Any]:
@@ -133,7 +122,7 @@ def _enrich_with_image_info(
         # nexus.yaml describes only the locally-managed stack.
         target_url = data.get("server_url", "")
         local_stack_url = conn_env.get("NEXUS_URL", "")
-        is_local_stack = (not target_url) or _same_endpoint(target_url, local_stack_url)
+        is_local_stack = (not target_url) or same_endpoint(target_url, local_stack_url)
 
         if is_local_stack:
             # Safe: the target IS the local stack — attach its image +
@@ -180,7 +169,7 @@ def _enrich_with_image_info(
         # fallback — an explicit remote --url must report "unknown" when
         # its features probe fails (no evidence about that hub).
         _target = data.get("server_url", "")
-        _is_local_default = (not _target) or _same_endpoint(_target, "http://localhost:2026")
+        _is_local_default = (not _target) or same_endpoint(_target, "http://localhost:2026")
         data["deployment_profile"] = _resolve_deployment_profile(
             _target, status_api_key, allow_env_fallback=_is_local_default
         )

--- a/src/nexus/cli/commands/status.py
+++ b/src/nexus/cli/commands/status.py
@@ -121,26 +121,32 @@ def _enrich_with_image_info(
 
     project_cfg = _load_project_config_optional()
     if project_cfg:
-        data["image_ref"] = _resolve_image_ref_from_config(project_cfg)
-        data["image_channel"] = project_cfg.get("image_channel", "")
-        data["image_accelerator"] = project_cfg.get("image_accelerator", "")
-
-        # Add connection env vars and project metadata
+        # Resolve the local stack endpoint/creds first so we can decide
+        # whether the status target IS that stack BEFORE attaching any
+        # local-only (and secret-bearing) metadata to the output.
         data_dir = project_cfg.get("data_dir", "./nexus-data")
         state = load_runtime_state(data_dir)
         conn_env = resolve_connection_env(project_cfg, state)
-        data["connection_env"] = conn_env
-        data["project_name"] = state.get("project_name", "")
-        data["data_dir"] = data_dir
 
         # `nexus status` reports the hub at the *effective status target*
-        # (`data["server_url"]`, which honors an explicit --url). The local
-        # nexus.yaml only describes the locally-managed stack, so its
-        # `auth` and the local stack URL must NOT be reported for a
-        # different remote target.
+        # (`data["server_url"]`, which honors an explicit --url). Local
+        # nexus.yaml describes only the locally-managed stack.
         target_url = data.get("server_url", "")
         local_stack_url = conn_env.get("NEXUS_URL", "")
         is_local_stack = (not target_url) or _same_endpoint(target_url, local_stack_url)
+
+        if is_local_stack:
+            # Safe: the target IS the local stack — attach its image +
+            # connection metadata (conn_env may carry NEXUS_API_KEY).
+            data["image_ref"] = _resolve_image_ref_from_config(project_cfg)
+            data["image_channel"] = project_cfg.get("image_channel", "")
+            data["image_accelerator"] = project_cfg.get("image_accelerator", "")
+            data["connection_env"] = conn_env
+            data["project_name"] = state.get("project_name", "")
+            data["data_dir"] = data_dir
+        # else: a different remote --url — do NOT attach the local
+        # stack's connection_env/image/project metadata (it would cross
+        # the auth boundary and misdescribe the remote hub).
 
         # auth_mode: local nexus.yaml auth only when the target IS the
         # locally-managed stack; otherwise it does not describe that hub.

--- a/src/nexus/cli/commands/status.py
+++ b/src/nexus/cli/commands/status.py
@@ -35,17 +35,23 @@ def _load_project_config_optional() -> dict[str, Any]:
     return load_project_config_optional()
 
 
-def _fetch_deployment_profile_from_features(server_url: str) -> str | None:
+def _fetch_deployment_profile_from_features(
+    server_url: str, api_key: str | None = None
+) -> str | None:
     """Best-effort fetch of *profile* from ``GET /api/v2/features``.
 
     Returns the profile string on success, or *None* on any failure.
     Never raises; uses a short timeout so ``nexus status`` stays responsive
-    even when the server is offline.
+    even when the server is offline. The *api_key* is forwarded so an
+    authenticated hub's features endpoint is not silently 401'd into the
+    env/unknown fallback.
     """
     try:
         from nexus.cli.api_client import NexusApiClient
 
-        features = NexusApiClient(url=server_url, timeout=2.0).get("/api/v2/features")
+        features = NexusApiClient(url=server_url, api_key=api_key, timeout=2.0).get(
+            "/api/v2/features"
+        )
         if isinstance(features, dict):
             profile = features.get("profile")
             if profile and isinstance(profile, str):
@@ -55,7 +61,7 @@ def _fetch_deployment_profile_from_features(server_url: str) -> str | None:
     return None
 
 
-def _resolve_deployment_profile(server_url: str) -> str:
+def _resolve_deployment_profile(server_url: str, api_key: str | None = None) -> str:
     """Resolve the *running hub's* deployment profile.
 
     `nexus status` reports the hub at *server_url*, so the live hub's
@@ -70,7 +76,7 @@ def _resolve_deployment_profile(server_url: str) -> str:
        there is no server URL or the hub is unreachable).
     3. ``"unknown"`` fallback.
     """
-    fetched = _fetch_deployment_profile_from_features(server_url) if server_url else None
+    fetched = _fetch_deployment_profile_from_features(server_url, api_key) if server_url else None
     if fetched:
         return fetched
     profile_env = os.environ.get("NEXUS_PROFILE", "").strip()
@@ -134,13 +140,21 @@ def _enrich_with_image_info(data: dict[str, Any]) -> dict[str, Any]:
         data["auth_mode"] = project_cfg.get("auth", "none") if is_local_stack else "unknown"
 
         # deployment_profile: resolved against the actual status target
-        # (features-first; env is offline fallback only).
-        data["deployment_profile"] = _resolve_deployment_profile(target_url or local_stack_url)
+        # (features-first; env is offline fallback only). Forward the
+        # connection's API key so an authenticated features endpoint
+        # isn't silently 401'd into the env/unknown fallback.
+        data["deployment_profile"] = _resolve_deployment_profile(
+            target_url or local_stack_url, conn_env.get("NEXUS_API_KEY")
+        )
     else:
-        # No project config: auth defaults to "none"
-        data["auth_mode"] = "none"
+        # No project config: there is no locally-managed stack to compare
+        # against, so we have NO evidence about the target's auth. Report
+        # "unknown" rather than fabricating "none" for what may be an
+        # authenticated remote hub (--url / NEXUS_URL).
+        data["auth_mode"] = "unknown"
 
-        # deployment_profile: single hierarchy via helper
+        # deployment_profile: resolved against the status target
+        # (NexusApiClient also picks up NEXUS_API_KEY from the env).
         data["deployment_profile"] = _resolve_deployment_profile(data.get("server_url", ""))
 
     return data

--- a/src/nexus/cli/commands/status.py
+++ b/src/nexus/cli/commands/status.py
@@ -35,20 +35,6 @@ def _load_project_config_optional() -> dict[str, Any]:
     return load_project_config_optional()
 
 
-def load_runtime_state(data_dir: str) -> dict[str, Any]:
-    """Thin wrapper so tests can patch ``nexus.cli.commands.status.load_runtime_state``."""
-    from nexus.cli.state import load_runtime_state as _load
-
-    return _load(data_dir)
-
-
-def resolve_connection_env(project_cfg: dict[str, Any], state: dict[str, Any]) -> dict[str, str]:
-    """Thin wrapper so tests can patch ``nexus.cli.commands.status.resolve_connection_env``."""
-    from nexus.cli.state import resolve_connection_env as _resolve
-
-    return _resolve(project_cfg, state)
-
-
 def _fetch_deployment_profile_from_features(server_url: str) -> str | None:
     """Best-effort fetch of *profile* from ``GET /api/v2/features``.
 
@@ -69,6 +55,21 @@ def _fetch_deployment_profile_from_features(server_url: str) -> str | None:
     return None
 
 
+def _resolve_deployment_profile(server_url: str) -> str:
+    """Resolve deployment profile via env ``NEXUS_PROFILE`` → features endpoint → ``"unknown"``.
+
+    Hierarchy (single source of truth):
+    1. ``NEXUS_PROFILE`` env var (non-empty wins immediately).
+    2. Best-effort ``GET /api/v2/features`` for the resolved *server_url*.
+    3. ``"unknown"`` fallback.
+    """
+    profile_env = os.environ.get("NEXUS_PROFILE", "").strip()
+    if profile_env:
+        return profile_env
+    fetched = _fetch_deployment_profile_from_features(server_url) if server_url else None
+    return fetched if fetched else "unknown"
+
+
 def _enrich_with_image_info(data: dict[str, Any]) -> dict[str, Any]:
     """Add the *effective* image_ref, connection env, and project info into *data*.
 
@@ -82,6 +83,7 @@ def _enrich_with_image_info(data: dict[str, Any]) -> dict[str, Any]:
       best-effort ``GET /api/v2/features`` → ``"unknown"``.
     """
     from nexus.cli.commands.stack import _resolve_image_ref_from_config
+    from nexus.cli.state import load_runtime_state, resolve_connection_env
 
     project_cfg = _load_project_config_optional()
     if project_cfg:
@@ -101,27 +103,15 @@ def _enrich_with_image_info(data: dict[str, Any]) -> dict[str, Any]:
         # demo→database, local→none)
         data["auth_mode"] = project_cfg.get("auth", "none")
 
-        # deployment_profile: env → features endpoint → "unknown"
-        profile_env = os.environ.get("NEXUS_PROFILE", "").strip()
-        if profile_env:
-            data["deployment_profile"] = profile_env
-        else:
-            server_url = conn_env.get("NEXUS_URL") or data.get("server_url", "")
-            fetched = _fetch_deployment_profile_from_features(server_url) if server_url else None
-            data["deployment_profile"] = fetched if fetched else "unknown"
+        # deployment_profile: single hierarchy via helper
+        server_url = conn_env.get("NEXUS_URL") or data.get("server_url", "")
+        data["deployment_profile"] = _resolve_deployment_profile(server_url)
     else:
         # No project config: auth defaults to "none"
         data["auth_mode"] = "none"
 
-        # deployment_profile: env → features endpoint (using server_url from
-        # collected data) → "unknown"
-        profile_env = os.environ.get("NEXUS_PROFILE", "").strip()
-        if profile_env:
-            data["deployment_profile"] = profile_env
-        else:
-            server_url = data.get("server_url", "")
-            fetched = _fetch_deployment_profile_from_features(server_url) if server_url else None
-            data["deployment_profile"] = fetched if fetched else "unknown"
+        # deployment_profile: single hierarchy via helper
+        data["deployment_profile"] = _resolve_deployment_profile(data.get("server_url", ""))
 
     return data
 
@@ -391,6 +381,8 @@ def status(
     if url:
         server_url = url
     else:
+        from nexus.cli.state import load_runtime_state, resolve_connection_env
+
         cfg = _load_project_config_optional()
         if cfg:
             data_dir = cfg.get("data_dir", "./nexus-data")

--- a/src/nexus/cli/commands/status.py
+++ b/src/nexus/cli/commands/status.py
@@ -79,6 +79,18 @@ def _resolve_deployment_profile(server_url: str) -> str:
     return "unknown"
 
 
+def _same_endpoint(a: str, b: str) -> bool:
+    """True if two URLs point at the same scheme://host:port (path/trailing
+    slash ignored). Used to decide whether a status target is the local
+    stack (so local nexus.yaml auth applies) or a different remote hub."""
+    if not a or not b:
+        return False
+    from urllib.parse import urlparse
+
+    pa, pb = urlparse(a.rstrip("/")), urlparse(b.rstrip("/"))
+    return (pa.scheme, pa.hostname, pa.port) == (pb.scheme, pb.hostname, pb.port)
+
+
 def _enrich_with_image_info(data: dict[str, Any]) -> dict[str, Any]:
     """Add the *effective* image_ref, connection env, and project info into *data*.
 
@@ -108,13 +120,22 @@ def _enrich_with_image_info(data: dict[str, Any]) -> dict[str, Any]:
         data["project_name"] = state.get("project_name", "")
         data["data_dir"] = data_dir
 
-        # auth_mode: from project config (preset maps: shared→static,
-        # demo→database, local→none)
-        data["auth_mode"] = project_cfg.get("auth", "none")
+        # `nexus status` reports the hub at the *effective status target*
+        # (`data["server_url"]`, which honors an explicit --url). The local
+        # nexus.yaml only describes the locally-managed stack, so its
+        # `auth` and the local stack URL must NOT be reported for a
+        # different remote target.
+        target_url = data.get("server_url", "")
+        local_stack_url = conn_env.get("NEXUS_URL", "")
+        is_local_stack = (not target_url) or _same_endpoint(target_url, local_stack_url)
 
-        # deployment_profile: single hierarchy via helper
-        server_url = conn_env.get("NEXUS_URL") or data.get("server_url", "")
-        data["deployment_profile"] = _resolve_deployment_profile(server_url)
+        # auth_mode: local nexus.yaml auth only when the target IS the
+        # locally-managed stack; otherwise it does not describe that hub.
+        data["auth_mode"] = project_cfg.get("auth", "none") if is_local_stack else "unknown"
+
+        # deployment_profile: resolved against the actual status target
+        # (features-first; env is offline fallback only).
+        data["deployment_profile"] = _resolve_deployment_profile(target_url or local_stack_url)
     else:
         # No project config: auth defaults to "none"
         data["auth_mode"] = "none"

--- a/src/nexus/cli/config.py
+++ b/src/nexus/cli/config.py
@@ -284,6 +284,25 @@ def resolve_connection(
 
 
 # ---------------------------------------------------------------------------
+# URL comparison
+# ---------------------------------------------------------------------------
+
+
+def same_endpoint(a: str | None, b: str | None) -> bool:
+    """True if two URLs point at the same scheme://host:port.
+
+    Path and trailing slash are ignored. Returns False when either
+    argument is None or empty — there is no evidence to compare.
+    """
+    if not a or not b:
+        return False
+    from urllib.parse import urlparse
+
+    pa, pb = urlparse(a.rstrip("/")), urlparse(b.rstrip("/"))
+    return (pa.scheme, pa.hostname, pa.port) == (pb.scheme, pb.hostname, pb.port)
+
+
+# ---------------------------------------------------------------------------
 # Settings helpers
 # ---------------------------------------------------------------------------
 

--- a/src/nexus/remote/grpc_target.py
+++ b/src/nexus/remote/grpc_target.py
@@ -27,8 +27,20 @@ if TYPE_CHECKING:
 
 
 def _grpc_port(default: int = 2028) -> int:
+    """Resolve the gRPC port.
+
+    NEXUS_GRPC_PORT env > nexus.yaml ``ports.grpc`` > *default*.
+
+    A *present-but-invalid* value (non-integer) is a configuration error:
+    fail fast with a clear message rather than silently dialing 2028 —
+    both the SDK and ``nexus doctor remote`` rely on this resolver, so a
+    silent fallback would produce false preflight results or connect to
+    an unrelated local service.
+    """
     grpc_port_str = os.getenv("NEXUS_GRPC_PORT")
+    source = "NEXUS_GRPC_PORT"
     if not grpc_port_str:
+        source = "nexus.yaml ports.grpc"
         with contextlib.suppress(Exception):
             pf = Path("nexus.yaml")
             if pf.exists():
@@ -37,12 +49,17 @@ def _grpc_port(default: int = 2028) -> int:
                 with open(pf) as f:
                     pc = yaml.safe_load(f) or {}
                 grpc_port_str = str(pc.get("ports", {}).get("grpc", ""))
-    if grpc_port_str:
-        try:
-            return int(grpc_port_str)
-        except ValueError:
-            return default
-    return default
+    if not grpc_port_str:
+        return default
+    try:
+        port = int(grpc_port_str)
+    except (TypeError, ValueError):
+        raise ValueError(
+            f"Invalid gRPC port {grpc_port_str!r} from {source}: must be an integer."
+        ) from None
+    if not (0 < port < 65536):
+        raise ValueError(f"Invalid gRPC port {port} from {source}: must be 1–65535.")
+    return port
 
 
 def resolve_grpc_target(

--- a/src/nexus/remote/grpc_target.py
+++ b/src/nexus/remote/grpc_target.py
@@ -26,7 +26,7 @@ if TYPE_CHECKING:
     from nexus.security.tls.config import ZoneTlsConfig
 
 
-def _grpc_port(default: int = 2028) -> int:
+def _grpc_port(default: int = 2028, *, trust_local_project: bool = True) -> int:
     """Resolve the gRPC port.
 
     NEXUS_GRPC_PORT env > nexus.yaml ``ports.grpc`` > *default*.
@@ -36,10 +36,15 @@ def _grpc_port(default: int = 2028) -> int:
     both the SDK and ``nexus doctor remote`` rely on this resolver, so a
     silent fallback would produce false preflight results or connect to
     an unrelated local service.
+
+    When *trust_local_project* is False (an explicit remote target), the
+    cwd ``./nexus.yaml`` is NOT consulted — local project ports must not
+    poison a different remote hub (e.g. local ``ports.grpc: 3028`` must
+    not make ``--url http://prod:2026`` dial ``prod:3028``).
     """
     grpc_port_str = os.getenv("NEXUS_GRPC_PORT")
     source = "NEXUS_GRPC_PORT"
-    if not grpc_port_str:
+    if not grpc_port_str and trust_local_project:
         source = "nexus.yaml ports.grpc"
         with contextlib.suppress(Exception):
             pf = Path("nexus.yaml")
@@ -66,17 +71,26 @@ def resolve_grpc_target(
     server_url: str,
     *,
     cfg_data_dir: str | None = None,
+    trust_local_project: bool = True,
 ) -> tuple[str, int, "ZoneTlsConfig | None"]:
     """Resolve ``(grpc_address, grpc_port, tls_config)`` for *server_url*.
 
     Mirrors the remote-profile resolution in ``nexus.connect`` exactly so
     a preflight reflects real SDK connection behavior.
 
+    *trust_local_project*: when False (an explicit remote target — e.g.
+    ``nexus doctor remote --url`` or ``connect(profile="remote",
+    url=...)`` not proven to be the locally-managed stack), the cwd
+    ``./nexus.yaml`` is IGNORED for port/TLS/data_dir. Only env
+    (``NEXUS_GRPC_PORT``, ``NEXUS_GRPC_TLS``, ``NEXUS_DATA_DIR``,
+    ``NEXUS_TLS_*``) and explicit *cfg_data_dir* apply, so a local
+    project cannot poison a different remote hub's port/TLS.
+
     Raises:
         RuntimeError: ``NEXUS_GRPC_TLS=true`` but no certificates resolve
             (fail-closed — same as the SDK).
     """
-    grpc_port = _grpc_port()
+    grpc_port = _grpc_port(trust_local_project=trust_local_project)
     parsed = urlparse(server_url)
     grpc_address = f"{parsed.hostname}:{grpc_port}"
 
@@ -88,7 +102,7 @@ def resolve_grpc_target(
     data_dir = os.getenv("NEXUS_DATA_DIR")
     if data_dir and not tls_disabled:
         tls_enabled = True  # NEXUS_DATA_DIR auto-detect (backward compat)
-    if not data_dir:
+    if not data_dir and trust_local_project:
         project_yaml = Path("nexus.yaml")
         if project_yaml.exists():
             with contextlib.suppress(Exception):

--- a/src/nexus/remote/grpc_target.py
+++ b/src/nexus/remote/grpc_target.py
@@ -1,0 +1,112 @@
+"""Shared remote gRPC target resolution (Issue #4132).
+
+A single source of truth for "given a remote hub URL, what gRPC address
+and TLS config does the remote SDK actually use?" — so the SDK
+(`nexus.connect(profile="remote")`) and the `nexus doctor remote`
+preflight resolve identically. Previously the preflight constructed
+`RPCTransport` with only address+token and could report a TLS-enabled
+hub (that the SDK connects to fine) as insecure/unreachable.
+
+Port precedence:  NEXUS_GRPC_PORT env  >  nexus.yaml ``ports.grpc``  >  2028
+TLS precedence:   NEXUS_GRPC_TLS env (true/false)  >  NEXUS_DATA_DIR
+                  auto-detect  >  nexus.yaml ``tls``  >  cfg.data_dir;
+                  fail-closed when TLS is explicitly requested but no
+                  certificates resolve.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+from pathlib import Path
+from typing import TYPE_CHECKING
+from urllib.parse import urlparse
+
+if TYPE_CHECKING:
+    from nexus.security.tls.config import ZoneTlsConfig
+
+
+def _grpc_port(default: int = 2028) -> int:
+    grpc_port_str = os.getenv("NEXUS_GRPC_PORT")
+    if not grpc_port_str:
+        with contextlib.suppress(Exception):
+            pf = Path("nexus.yaml")
+            if pf.exists():
+                import yaml
+
+                with open(pf) as f:
+                    pc = yaml.safe_load(f) or {}
+                grpc_port_str = str(pc.get("ports", {}).get("grpc", ""))
+    if grpc_port_str:
+        try:
+            return int(grpc_port_str)
+        except ValueError:
+            return default
+    return default
+
+
+def resolve_grpc_target(
+    server_url: str,
+    *,
+    cfg_data_dir: str | None = None,
+) -> tuple[str, int, "ZoneTlsConfig | None"]:
+    """Resolve ``(grpc_address, grpc_port, tls_config)`` for *server_url*.
+
+    Mirrors the remote-profile resolution in ``nexus.connect`` exactly so
+    a preflight reflects real SDK connection behavior.
+
+    Raises:
+        RuntimeError: ``NEXUS_GRPC_TLS=true`` but no certificates resolve
+            (fail-closed — same as the SDK).
+    """
+    grpc_port = _grpc_port()
+    parsed = urlparse(server_url)
+    grpc_address = f"{parsed.hostname}:{grpc_port}"
+
+    tls_config: ZoneTlsConfig | None = None
+    grpc_tls_env = os.getenv("NEXUS_GRPC_TLS", "").lower()
+    tls_enabled = grpc_tls_env in ("true", "1", "yes")
+    tls_disabled = grpc_tls_env in ("false", "0", "no")
+    tls_from_config = False
+    data_dir = os.getenv("NEXUS_DATA_DIR")
+    if data_dir and not tls_disabled:
+        tls_enabled = True  # NEXUS_DATA_DIR auto-detect (backward compat)
+    if not data_dir:
+        project_yaml = Path("nexus.yaml")
+        if project_yaml.exists():
+            with contextlib.suppress(Exception):
+                import yaml
+
+                with open(project_yaml) as f:
+                    project_cfg = yaml.safe_load(f) or {}
+                data_dir = project_cfg.get("data_dir")
+                if not grpc_tls_env:
+                    tls_from_config = bool(project_cfg.get("tls"))
+                    tls_enabled = tls_from_config
+    if not data_dir:
+        data_dir = cfg_data_dir
+
+    if data_dir and tls_enabled:
+        from nexus.security.tls.config import ZoneTlsConfig
+
+        tls_intentional = grpc_tls_env in ("true", "1", "yes") or tls_from_config
+        tls_config = (
+            ZoneTlsConfig.from_data_dir_any(data_dir)
+            if tls_intentional
+            else ZoneTlsConfig.from_data_dir(data_dir)
+        )
+
+    tls_explicit = grpc_tls_env in ("true", "1", "yes")
+    if tls_explicit and tls_config is None and os.getenv("NEXUS_TLS_CERT"):
+        from nexus.security.tls.config import ZoneTlsConfig
+
+        with contextlib.suppress(Exception):
+            tls_config = ZoneTlsConfig.from_env()
+    if tls_explicit and tls_config is None:
+        raise RuntimeError(
+            "NEXUS_GRPC_TLS=true but no TLS certificates found. "
+            "Provide certs via NEXUS_TLS_CERT/KEY/CA, "
+            "in {data_dir}/tls/, or set data_dir in nexus.yaml."
+        )
+
+    return grpc_address, grpc_port, tls_config

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,7 +1,7 @@
 """Shared fixtures for integration tests (Issue #4132).
 
 Provides the ``full_stack`` fixture: boots a real Docker Compose stack
-(PostgreSQL + Dragonfly + Zoekt) via ``nexus init`` / ``nexus up`` /
+(PostgreSQL + Dragonfly + the Nexus server) via ``nexus init`` / ``nexus up`` /
 ``nexus down``, and exposes ``.url``, ``.api_key``, and ``.http_get(path)``
 to callers.
 
@@ -70,7 +70,7 @@ def _teardown_stack(nexus_bin: str, project_dir: Path) -> None:
 
 @dataclasses.dataclass
 class FullStack:
-    """Handle for a running FULL nexus stack (PostgreSQL + Dragonfly + Zoekt).
+    """Handle for a running FULL nexus stack (PostgreSQL + Dragonfly + Nexus server).
 
     Attributes:
         url:      HTTP base URL (e.g. ``http://localhost:2026``).

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -282,14 +282,14 @@ def _boot_full_stack(tmp_path: Path, preset: str = "shared") -> Iterator[FullSta
         time.sleep(1.0)
 
     if not healthy:
-        subprocess.run(
-            [nexus_bin, "down", "--volumes"],
-            capture_output=True,
-            text=True,
-            timeout=120,
-            cwd=str(project_dir),
+        # `nexus up` reported success but the hub never became healthy —
+        # a real post-boot product failure under NEXUS_E2E=1, not an
+        # unmet precondition. FAIL (with teardown) so the gated E2E has
+        # blocking value.
+        _teardown_stack(nexus_bin, project_dir)
+        pytest.fail(
+            f"FULL stack booted but failed /health on {url} within 60s (project_dir={project_dir})"
         )
-        pytest.skip(f"nexus stack failed health check on {url}/health")
 
     handle = FullStack(
         url=url,

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -246,10 +246,24 @@ def _boot_full_stack(tmp_path: Path, preset: str = "shared") -> Iterator[FullSta
         # `nexus up` failure (broken compose, bad image, real health
         # regression, port conflict, CLI regression) still hard-FAILS so
         # the gate keeps its blocking value.
+        # Require POSITIVE proof the hub itself is healthy and that
+        # ONLY zoekt gated it — otherwise a real Nexus-unhealthy failure
+        # that merely mentions zoekt would be wrongly xfailed and the
+        # gate would stop catching the regressions it exists for. The
+        # health poll prints "  ✓ <svc> (..s)" / "  ✗ <svc> (timed out
+        # ..)" lines.
+        import re as _re
+
+        nexus_healthy = bool(_re.search(r"✓\s+nexus\b", combined))
+        nexus_failed = bool(_re.search(r"✗\s+nexus\b", combined))
+        zoekt_failed = bool(
+            _re.search(r"✗\s+zoekt\b", combined) or _re.search(r"zoekt\b[^\n]*timed out", combined)
+        )
         zoekt_gate_failure = (
-            "zoekt" in combined
-            and ("Some services did not become healthy" in combined or "timed out" in combined)
-            and "nexus" in combined  # nexus health line present
+            nexus_healthy
+            and zoekt_failed
+            and not nexus_failed
+            and "Some services did not become healthy" in combined
         )
         _teardown_stack(nexus_bin, project_dir)
         if zoekt_gate_failure:

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -236,7 +236,28 @@ def _boot_full_stack(tmp_path: Path, preset: str = "shared") -> Iterator[FullSta
                 "helper unavailable non-interactively (pre-cache all stack "
                 f"images, or run on CI with anonymous pulls). log: {debug_path}"
             )
+
+        # Bug B (precise signature): `nexus up`'s health gate timed out
+        # on `zoekt` (NOT a `shared`/`demo` preset service) WHILE the
+        # actual hub services are healthy. This is a known, pre-existing
+        # `nexus up` health-gate defect, out of #4132's docs/test scope
+        # (tracked in the design spec). xfail ONLY this exact case so it
+        # neither masquerades as green nor hard-reds CI; every OTHER
+        # `nexus up` failure (broken compose, bad image, real health
+        # regression, port conflict, CLI regression) still hard-FAILS so
+        # the gate keeps its blocking value.
+        zoekt_gate_failure = (
+            "zoekt" in combined
+            and ("Some services did not become healthy" in combined or "timed out" in combined)
+            and "nexus" in combined  # nexus health line present
+        )
         _teardown_stack(nexus_bin, project_dir)
+        if zoekt_gate_failure:
+            pytest.xfail(
+                "Bug B: `nexus up --preset shared` rc=1 — health gate waits "
+                "on unstarted `zoekt` though the hub itself is healthy "
+                f"(pre-existing nexus up defect, out of #4132 scope). log: {debug_path}"
+            )
         pytest.fail(
             f"nexus up failed (rc={up_result.returncode}) — FULL stack did "
             f"not boot. Debug log: {debug_path}. "

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -12,6 +12,7 @@ at import/collection time.
 
 from __future__ import annotations
 
+import contextlib
 import dataclasses
 import json
 import os
@@ -47,6 +48,19 @@ def _docker_available() -> bool:
 def _nexus_bin() -> str:
     """Resolve the venv-local ``nexus`` CLI binary."""
     return str(Path(sys.executable).parent / "nexus")
+
+
+def _teardown_stack(nexus_bin: str, project_dir: Path) -> None:
+    """Best-effort `nexus down --volumes` (used before fail/skip so a
+    failed boot does not leak containers/ports into later tests)."""
+    with contextlib.suppress(Exception):
+        subprocess.run(
+            [nexus_bin, "down", "--volumes"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            cwd=str(project_dir),
+        )
 
 
 # ---------------------------------------------------------------------------
@@ -184,8 +198,12 @@ def _boot_full_stack(tmp_path: Path, preset: str = "shared") -> Iterator[FullSta
             env=up_env,
         )
     except subprocess.TimeoutExpired:
-        pytest.skip(
-            "nexus up timed out after 300s"
+        # The stack was attempted — this is a product/perf failure, not an
+        # unmet precondition. A gated E2E that skips here has no blocking
+        # value, so FAIL (after teardown).
+        _teardown_stack(nexus_bin, project_dir)
+        pytest.fail(
+            "nexus up timed out after 300s — the FULL stack did not boot"
             + (" (NEXUS_E2E_BUILD=1 forces a slow source build)" if force_build else "")
         )
     if up_result.returncode != 0:
@@ -196,13 +214,13 @@ def _boot_full_stack(tmp_path: Path, preset: str = "shared") -> Iterator[FullSta
             f"--- stderr ---\n{up_result.stderr}\n"
         )
         combined = f"{up_result.stdout}\n{up_result.stderr}"
-        # Environmental: a docker *registry credential helper* that is
-        # unavailable in non-interactive shells (e.g. macOS osxkeychain
-        # returns "User canceled the operation. (-128)"). Match ONLY the
-        # actual credential-helper signature — a generic "Docker Compose
-        # failed to start" must NOT be classified as a credential problem
-        # (it also covers port conflicts, image-missing, health timeouts,
-        # etc., and mislabeling them hides the real cause).
+        # ONLY a genuinely unmet precondition is skip-worthy: a docker
+        # registry credential helper unavailable in non-interactive
+        # shells (e.g. macOS osxkeychain → "User canceled the operation.
+        # (-128)"). Match ONLY that signature. EVERY other `nexus up`
+        # failure (broken compose, bad image, health timeout, port
+        # conflict, CLI regression) is a real product failure the gated
+        # E2E must BLOCK on — so tear down and FAIL, never skip.
         cred_signature = (
             "getting credentials" in combined
             or "User canceled the operation" in combined
@@ -214,8 +232,10 @@ def _boot_full_stack(tmp_path: Path, preset: str = "shared") -> Iterator[FullSta
                 "helper unavailable non-interactively (pre-cache all stack "
                 f"images, or run on CI with anonymous pulls). log: {debug_path}"
             )
-        pytest.skip(
-            f"nexus up failed (rc={up_result.returncode}, log: {debug_path}): "
+        _teardown_stack(nexus_bin, project_dir)
+        pytest.fail(
+            f"nexus up failed (rc={up_result.returncode}) — FULL stack did "
+            f"not boot. Debug log: {debug_path}. "
             f"stderr_tail={up_result.stderr[-400:]!r}"
         )
 
@@ -228,27 +248,16 @@ def _boot_full_stack(tmp_path: Path, preset: str = "shared") -> Iterator[FullSta
         cwd=str(project_dir),
     )
     if env_result.returncode != 0:
-        # Teardown and skip — env command failed
-        subprocess.run(
-            [nexus_bin, "down", "--volumes"],
-            capture_output=True,
-            text=True,
-            timeout=120,
-            cwd=str(project_dir),
-        )
-        pytest.skip(f"nexus env --json failed: {env_result.stderr[-400:]!r}")
+        # The stack booted but `nexus env` failed — a real product/CLI
+        # failure the gated E2E must block on, not skip.
+        _teardown_stack(nexus_bin, project_dir)
+        pytest.fail(f"nexus env --json failed after boot: {env_result.stderr[-400:]!r}")
 
     try:
         env_payload = json.loads(env_result.stdout)
     except json.JSONDecodeError as exc:
-        subprocess.run(
-            [nexus_bin, "down", "--volumes"],
-            capture_output=True,
-            text=True,
-            timeout=120,
-            cwd=str(project_dir),
-        )
-        pytest.skip(f"nexus env --json produced invalid JSON: {exc}")
+        _teardown_stack(nexus_bin, project_dir)
+        pytest.fail(f"nexus env --json produced invalid JSON after boot: {exc}")
 
     url = env_payload.get("NEXUS_URL", "http://localhost:2026")
     api_key = env_payload.get("NEXUS_API_KEY", "")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -196,12 +196,19 @@ def _boot_full_stack(tmp_path: Path, preset: str = "shared") -> Iterator[FullSta
             f"--- stderr ---\n{up_result.stderr}\n"
         )
         combined = f"{up_result.stdout}\n{up_result.stderr}"
-        # Environmental: docker registry pull needs a credential helper that is
-        # unavailable in non-interactive shells (e.g. macOS osxkeychain returns
-        # "User canceled the operation. (-128)"). The required images simply
-        # cannot be fetched here — that is a host limitation, not a product or
-        # test defect, so skip with a precise diagnosis rather than fail.
-        if "getting credentials" in combined or "Docker Compose failed to start" in combined:
+        # Environmental: a docker *registry credential helper* that is
+        # unavailable in non-interactive shells (e.g. macOS osxkeychain
+        # returns "User canceled the operation. (-128)"). Match ONLY the
+        # actual credential-helper signature — a generic "Docker Compose
+        # failed to start" must NOT be classified as a credential problem
+        # (it also covers port conflicts, image-missing, health timeouts,
+        # etc., and mislabeling them hides the real cause).
+        cred_signature = (
+            "getting credentials" in combined
+            or "User canceled the operation" in combined
+            or "docker-credential-" in combined
+        )
+        if cred_signature:
             pytest.skip(
                 "environment cannot pull required images: docker credential "
                 "helper unavailable non-interactively (pre-cache all stack "

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -163,9 +163,16 @@ def _boot_full_stack(tmp_path: Path, preset: str = "shared") -> Iterator[FullSta
         pytest.skip(f"nexus init failed: {init_result.stderr[-400:]!r}")
 
     # ---- nexus up ----------------------------------------------------------
+    # Use the documented prebuilt path (matches docs/deployment/full-profile.md
+    # "Via the stack (recommended): nexus up"). The `shared` preset generates a
+    # pull-only nexus-stack.yml pinning ghcr.io/nexi-lab/nexus:<channel>, so
+    # plain `nexus up` reuses the prebuilt image and boots in tens of seconds.
+    # Forcing `--build` here was a defect: it triggers a from-scratch Rust +
+    # Python Dockerfile build (minutes) that blew the subprocess timeout.
+    # Opt in to a source build only when explicitly iterating on the image.
     up_env = os.environ.copy()
-    use_prebuilt = os.environ.get("NEXUS_E2E_SKIP_BUILD") == "1"
-    up_cmd = [nexus_bin, "up", "--no-build" if use_prebuilt else "--build"]
+    force_build = os.environ.get("NEXUS_E2E_BUILD") == "1"
+    up_cmd = [nexus_bin, "up"] + (["--build"] if force_build else [])
 
     try:
         up_result = subprocess.run(
@@ -178,8 +185,8 @@ def _boot_full_stack(tmp_path: Path, preset: str = "shared") -> Iterator[FullSta
         )
     except subprocess.TimeoutExpired:
         pytest.skip(
-            "nexus up timed out after 300s (image build takes too long on this host; "
-            "set NEXUS_E2E_SKIP_BUILD=1 to use a pre-built image)"
+            "nexus up timed out after 300s"
+            + (" (NEXUS_E2E_BUILD=1 forces a slow source build)" if force_build else "")
         )
     if up_result.returncode != 0:
         debug_path = project_dir / "nexus-up-debug.log"
@@ -188,6 +195,18 @@ def _boot_full_stack(tmp_path: Path, preset: str = "shared") -> Iterator[FullSta
             f"--- stdout ---\n{up_result.stdout}\n\n"
             f"--- stderr ---\n{up_result.stderr}\n"
         )
+        combined = f"{up_result.stdout}\n{up_result.stderr}"
+        # Environmental: docker registry pull needs a credential helper that is
+        # unavailable in non-interactive shells (e.g. macOS osxkeychain returns
+        # "User canceled the operation. (-128)"). The required images simply
+        # cannot be fetched here — that is a host limitation, not a product or
+        # test defect, so skip with a precise diagnosis rather than fail.
+        if "getting credentials" in combined or "Docker Compose failed to start" in combined:
+            pytest.skip(
+                "environment cannot pull required images: docker credential "
+                "helper unavailable non-interactively (pre-cache all stack "
+                f"images, or run on CI with anonymous pulls). log: {debug_path}"
+            )
         pytest.skip(
             f"nexus up failed (rc={up_result.returncode}, log: {debug_path}): "
             f"stderr_tail={up_result.stderr[-400:]!r}"

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -104,32 +104,19 @@ class _HttpResponse:
 
 
 # ---------------------------------------------------------------------------
-# full_stack fixture
+# Internal boot/lifecycle helper (sibling-reusable)
 # ---------------------------------------------------------------------------
 
 
-@pytest.fixture(scope="function")
-def full_stack(
-    tmp_path: Path,
-    *,
-    preset: str = "shared",
-) -> Iterator[FullStack]:
-    """Boot a FULL nexus stack and yield a :class:`FullStack` handle.
+def _boot_full_stack(tmp_path: Path, preset: str = "shared") -> Iterator[FullStack]:
+    """Internal: boot a FULL nexus stack and yield a FullStack handle.
 
-    Skipped when:
-    - ``NEXUS_E2E != "1"`` (the test-level ``requires_e2e`` skip fires first,
-      but this guard ensures no Docker work happens if the fixture is invoked
-      outside a properly-gated test).
-    - Docker is not available.
+    Shared by the ``full_stack`` fixture and sibling integration fixtures
+    (#4133–#4138) that need a different preset.  NEXUS_E2E gating and
+    Docker availability are checked here so non-E2E collection does no
+    Docker work.
 
     Teardown: ``nexus down --volumes`` + temp dir removal.
-
-    ``preset`` defaults to ``"shared"`` (FULL PostgreSQL + Dragonfly + Zoekt).
-    Sibling issues (#4133–#4138) can pass a different preset, e.g.::
-
-        @pytest.fixture
-        def my_stack(tmp_path):
-            yield from full_stack.__wrapped__(tmp_path, preset="demo")
     """
     # Guard: no Docker work without NEXUS_E2E=1
     if os.environ.get("NEXUS_E2E") != "1":
@@ -289,3 +276,30 @@ def full_stack(
                 cwd=str(project_dir),
             )
             shutil.rmtree(project_dir, ignore_errors=True)
+
+
+# ---------------------------------------------------------------------------
+# full_stack fixture (thin wrapper around _boot_full_stack)
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="function")
+def full_stack(tmp_path: Path) -> Iterator[FullStack]:
+    """Boot a FULL nexus stack (preset=shared). Skipped unless NEXUS_E2E=1.
+
+    Skipped when:
+    - ``NEXUS_E2E != "1"`` (the test-level ``requires_e2e`` skip fires first,
+      but this guard ensures no Docker work happens if the fixture is invoked
+      outside a properly-gated test).
+    - Docker is not available.
+
+    Teardown: ``nexus down --volumes`` + temp dir removal.
+
+    Sibling integration suites needing another preset define their own
+    one-line fixture::
+
+        @pytest.fixture
+        def demo_stack(tmp_path):
+            yield from _boot_full_stack(tmp_path, preset="demo")
+    """
+    yield from _boot_full_stack(tmp_path, preset="shared")

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,0 +1,291 @@
+"""Shared fixtures for integration tests (Issue #4132).
+
+Provides the ``full_stack`` fixture: boots a real Docker Compose stack
+(PostgreSQL + Dragonfly + Zoekt) via ``nexus init`` / ``nexus up`` /
+``nexus down``, and exposes ``.url``, ``.api_key``, and ``.http_get(path)``
+to callers.
+
+Gated: the fixture skips cheaply when NEXUS_E2E != "1" *or* Docker is
+unavailable.  All Docker work is confined to the fixture body — no work
+at import/collection time.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import urllib.error
+import urllib.request
+from collections.abc import Iterator
+from pathlib import Path
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+
+def _docker_available() -> bool:
+    """Return True iff the Docker daemon is reachable."""
+    try:
+        result = subprocess.run(
+            ["docker", "info"],
+            capture_output=True,
+            timeout=10,
+        )
+        return result.returncode == 0
+    except (FileNotFoundError, subprocess.TimeoutExpired):
+        return False
+
+
+def _nexus_bin() -> str:
+    """Resolve the venv-local ``nexus`` CLI binary."""
+    return str(Path(sys.executable).parent / "nexus")
+
+
+# ---------------------------------------------------------------------------
+# Public data class
+# ---------------------------------------------------------------------------
+
+
+@dataclasses.dataclass
+class FullStack:
+    """Handle for a running FULL nexus stack (PostgreSQL + Dragonfly + Zoekt).
+
+    Attributes:
+        url:      HTTP base URL (e.g. ``http://localhost:2026``).
+        api_key:  Admin API key registered with the daemon.
+        grpc_host: gRPC host string (e.g. ``localhost:2028``).
+        grpc_port: gRPC port as string (e.g. ``"2028"``).
+        project_dir: Temp directory containing nexus.yaml.
+    """
+
+    url: str
+    api_key: str
+    grpc_host: str
+    grpc_port: str
+    project_dir: Path
+
+    def http_get(self, path: str) -> "_HttpResponse":
+        """Perform a GET against ``self.url + path``.
+
+        Returns an object with ``.status_code`` and ``.json()`` so the caller
+        does not need to import urllib directly.
+        """
+        full_url = self.url.rstrip("/") + path
+        req = urllib.request.Request(
+            full_url,
+            headers={"Authorization": f"Bearer {self.api_key}"},
+        )
+        try:
+            with urllib.request.urlopen(req, timeout=10) as resp:
+                raw = resp.read()
+                return _HttpResponse(resp.status, raw)
+        except urllib.error.HTTPError as exc:
+            raw = exc.read()
+            return _HttpResponse(exc.code, raw)
+
+
+@dataclasses.dataclass
+class _HttpResponse:
+    """Thin wrapper so callers can use ``.status_code`` and ``.json()``."""
+
+    status_code: int
+    _body: bytes
+
+    def json(self) -> object:
+        return json.loads(self._body)
+
+
+# ---------------------------------------------------------------------------
+# full_stack fixture
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture(scope="function")
+def full_stack(
+    tmp_path: Path,
+    *,
+    preset: str = "shared",
+) -> Iterator[FullStack]:
+    """Boot a FULL nexus stack and yield a :class:`FullStack` handle.
+
+    Skipped when:
+    - ``NEXUS_E2E != "1"`` (the test-level ``requires_e2e`` skip fires first,
+      but this guard ensures no Docker work happens if the fixture is invoked
+      outside a properly-gated test).
+    - Docker is not available.
+
+    Teardown: ``nexus down --volumes`` + temp dir removal.
+
+    ``preset`` defaults to ``"shared"`` (FULL PostgreSQL + Dragonfly + Zoekt).
+    Sibling issues (#4133–#4138) can pass a different preset, e.g.::
+
+        @pytest.fixture
+        def my_stack(tmp_path):
+            yield from full_stack.__wrapped__(tmp_path, preset="demo")
+    """
+    # Guard: no Docker work without NEXUS_E2E=1
+    if os.environ.get("NEXUS_E2E") != "1":
+        pytest.skip("full_stack fixture requires NEXUS_E2E=1 (real Docker stack)")
+
+    if not _docker_available():
+        pytest.skip("full_stack fixture requires a running Docker daemon")
+
+    nexus_bin = _nexus_bin()
+    project_dir = tmp_path / "nexus_full_stack"
+    project_dir.mkdir(parents=True, exist_ok=True)
+    config_path = project_dir / "nexus.yaml"
+    data_dir = project_dir / "nexus-data"
+
+    # Locate the in-tree compose file (mirrors running_nexus in e2e/self_contained)
+    repo_root = Path(__file__).resolve().parents[2]
+    compose_file = repo_root / "nexus-stack.yml"
+
+    # ---- nexus init --------------------------------------------------------
+    init_cmd = [
+        nexus_bin,
+        "init",
+        "--preset",
+        preset,
+        "--config-path",
+        str(config_path),
+        "--data-dir",
+        str(data_dir),
+    ]
+    if compose_file.exists():
+        init_cmd += ["--compose-file", str(compose_file)]
+
+    try:
+        init_result = subprocess.run(
+            init_cmd,
+            capture_output=True,
+            text=True,
+            timeout=60,
+            cwd=str(project_dir),
+        )
+    except subprocess.TimeoutExpired:
+        pytest.skip("nexus init timed out after 60s")
+    if init_result.returncode != 0:
+        pytest.skip(f"nexus init failed: {init_result.stderr[-400:]!r}")
+
+    # ---- nexus up ----------------------------------------------------------
+    up_env = os.environ.copy()
+    use_prebuilt = os.environ.get("NEXUS_E2E_SKIP_BUILD") == "1"
+    up_cmd = [nexus_bin, "up", "--no-build" if use_prebuilt else "--build"]
+
+    try:
+        up_result = subprocess.run(
+            up_cmd,
+            capture_output=True,
+            text=True,
+            timeout=300,
+            cwd=str(project_dir),
+            env=up_env,
+        )
+    except subprocess.TimeoutExpired:
+        pytest.skip(
+            "nexus up timed out after 300s (image build takes too long on this host; "
+            "set NEXUS_E2E_SKIP_BUILD=1 to use a pre-built image)"
+        )
+    if up_result.returncode != 0:
+        debug_path = project_dir / "nexus-up-debug.log"
+        debug_path.write_text(
+            f"returncode={up_result.returncode}\n\n"
+            f"--- stdout ---\n{up_result.stdout}\n\n"
+            f"--- stderr ---\n{up_result.stderr}\n"
+        )
+        pytest.skip(
+            f"nexus up failed (rc={up_result.returncode}, log: {debug_path}): "
+            f"stderr_tail={up_result.stderr[-400:]!r}"
+        )
+
+    # ---- nexus env --json --------------------------------------------------
+    env_result = subprocess.run(
+        [nexus_bin, "env", "--json"],
+        capture_output=True,
+        text=True,
+        timeout=30,
+        cwd=str(project_dir),
+    )
+    if env_result.returncode != 0:
+        # Teardown and skip — env command failed
+        subprocess.run(
+            [nexus_bin, "down", "--volumes"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            cwd=str(project_dir),
+        )
+        pytest.skip(f"nexus env --json failed: {env_result.stderr[-400:]!r}")
+
+    try:
+        env_payload = json.loads(env_result.stdout)
+    except json.JSONDecodeError as exc:
+        subprocess.run(
+            [nexus_bin, "down", "--volumes"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            cwd=str(project_dir),
+        )
+        pytest.skip(f"nexus env --json produced invalid JSON: {exc}")
+
+    url = env_payload.get("NEXUS_URL", "http://localhost:2026")
+    api_key = env_payload.get("NEXUS_API_KEY", "")
+    grpc_host = env_payload.get("NEXUS_GRPC_HOST", "")
+    grpc_port = env_payload.get("NEXUS_GRPC_PORT", "")
+
+    # ---- wait for /health --------------------------------------------------
+    deadline = time.monotonic() + 60
+    healthy = False
+    while time.monotonic() < deadline:
+        try:
+            req = urllib.request.Request(
+                f"{url}/health",
+                headers={"Authorization": f"Bearer {api_key}"} if api_key else {},
+            )
+            with urllib.request.urlopen(req, timeout=2) as resp:
+                if resp.status == 200:
+                    healthy = True
+                    break
+        except (urllib.error.URLError, OSError):
+            pass
+        time.sleep(1.0)
+
+    if not healthy:
+        subprocess.run(
+            [nexus_bin, "down", "--volumes"],
+            capture_output=True,
+            text=True,
+            timeout=120,
+            cwd=str(project_dir),
+        )
+        pytest.skip(f"nexus stack failed health check on {url}/health")
+
+    handle = FullStack(
+        url=url,
+        api_key=api_key,
+        grpc_host=grpc_host,
+        grpc_port=grpc_port,
+        project_dir=project_dir,
+    )
+
+    try:
+        yield handle
+    finally:
+        if os.environ.get("NEXUS_E2E_KEEP", "").lower() not in ("1", "true", "yes"):
+            subprocess.run(
+                [nexus_bin, "down", "--volumes"],
+                capture_output=True,
+                text=True,
+                timeout=180,
+                cwd=str(project_dir),
+            )
+            shutil.rmtree(project_dir, ignore_errors=True)

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -50,6 +50,56 @@ def _nexus_bin() -> str:
     return str(Path(sys.executable).parent / "nexus")
 
 
+def _verify_hub_serving(data_dir: Path) -> bool:
+    """Best-effort: prove the FULL hub is actually serving even when
+    `nexus up` returned rc=1 (Bug B). Discovers this project's nexus
+    container via the compose project name (md5 of the resolved
+    data_dir, matching stack.py) and checks ``/health`` == 200 AND a
+    non-empty ``/api/v2/features``. Returns True only if BOTH pass —
+    so a real Nexus-unhealthy failure is NOT mistaken for Bug B.
+    """
+    import hashlib
+
+    try:
+        proj = "nexus-" + hashlib.md5(str(data_dir.resolve()).encode()).hexdigest()[:8]
+        cid = (
+            subprocess.run(
+                ["docker", "ps", "--filter", f"name={proj}-nexus", "--format", "{{.Names}}"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            .stdout.strip()
+            .splitlines()
+        )
+        if not cid:
+            return False
+        port = (
+            subprocess.run(
+                ["docker", "port", cid[0], "2026"],
+                capture_output=True,
+                text=True,
+                timeout=15,
+            )
+            .stdout.strip()
+            .splitlines()
+        )
+        if not port:
+            return False
+        host_port = port[0].rsplit(":", 1)[-1]
+        base = f"http://localhost:{host_port}"
+        with urllib.request.urlopen(f"{base}/health", timeout=5) as r:
+            if r.status != 200:
+                return False
+        with urllib.request.urlopen(f"{base}/api/v2/features", timeout=5) as r:
+            if r.status != 200:
+                return False
+            body = json.loads(r.read() or b"{}")
+        return bool(body)
+    except Exception:
+        return False
+
+
 def _teardown_stack(nexus_bin: str, project_dir: Path) -> None:
     """Best-effort `nexus down --volumes` (used before fail/skip so a
     failed boot does not leak containers/ports into later tests)."""
@@ -265,17 +315,33 @@ def _boot_full_stack(tmp_path: Path, preset: str = "shared") -> Iterator[FullSta
             and not nexus_failed
             and "Some services did not become healthy" in combined
         )
-        _teardown_stack(nexus_bin, project_dir)
-        if zoekt_gate_failure:
-            pytest.xfail(
-                "Bug B: `nexus up --preset shared` rc=1 — health gate waits "
-                "on unstarted `zoekt` though the hub itself is healthy "
-                f"(pre-existing nexus up defect, out of #4132 scope). log: {debug_path}"
+        if not zoekt_gate_failure:
+            _teardown_stack(nexus_bin, project_dir)
+            pytest.fail(
+                f"nexus up failed (rc={up_result.returncode}) — FULL stack "
+                f"did not boot. Debug log: {debug_path}. "
+                f"stderr_tail={up_result.stderr[-400:]!r}"
             )
-        pytest.fail(
-            f"nexus up failed (rc={up_result.returncode}) — FULL stack did "
-            f"not boot. Debug log: {debug_path}. "
-            f"stderr_tail={up_result.stderr[-400:]!r}"
+        # Bug B suspected (signature matched). Do NOT blind-xfail — first
+        # PROVE the hub actually serves (/health 200 + non-empty
+        # /api/v2/features) by talking to the running container directly.
+        # If it does NOT serve, this is a real regression hiding behind a
+        # zoekt mention → tear down and hard-FAIL (gate keeps its value).
+        if not _verify_hub_serving(data_dir):
+            _teardown_stack(nexus_bin, project_dir)
+            pytest.fail(
+                f"nexus up rc={up_result.returncode} AND the hub did not "
+                f"serve /health + /api/v2/features — this is NOT Bug B "
+                f"(real FULL-stack regression). Debug log: {debug_path}. "
+                f"stderr_tail={up_result.stderr[-400:]!r}"
+            )
+        # Hub PROVEN healthy; only `nexus up`'s aggregate exit is wrong
+        # because of the out-of-scope zoekt health gate (Bug B).
+        _teardown_stack(nexus_bin, project_dir)
+        pytest.xfail(
+            "Bug B: `nexus up --preset shared` rc=1 (health gate waits on "
+            "unstarted `zoekt`) BUT the hub was verified serving /health + "
+            f"/api/v2/features directly. Out of #4132 scope. log: {debug_path}"
         )
 
     # ---- nexus env --json --------------------------------------------------

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -221,11 +221,15 @@ def _boot_full_stack(tmp_path: Path, preset: str = "shared") -> Iterator[FullSta
         # failure (broken compose, bad image, health timeout, port
         # conflict, CLI regression) is a real product failure the gated
         # E2E must BLOCK on — so tear down and FAIL, never skip.
-        cred_signature = (
-            "getting credentials" in combined
-            or "User canceled the operation" in combined
-            or "docker-credential-" in combined
-        )
+        # Precise conjunction: a credential-helper invocation AND the
+        # non-interactive cancel marker. A bare "getting credentials"
+        # failure on its own (real auth/registry error) must NOT skip —
+        # it fails the gate. Only the macOS osxkeychain-style
+        # non-interactive cancel ("User canceled the operation. (-128)")
+        # is an unmet environment precondition.
+        helper_invoked = "getting credentials" in combined or "docker-credential-" in combined
+        non_interactive_cancel = "User canceled the operation" in combined or "(-128)" in combined
+        cred_signature = helper_invoked and non_interactive_cancel
         if cred_signature:
             pytest.skip(
                 "environment cannot pull required images: docker credential "

--- a/tests/integration/test_full_profile_boot.py
+++ b/tests/integration/test_full_profile_boot.py
@@ -5,17 +5,19 @@ PostgreSQL + Dragonfly + the Nexus server). Captures boot/RSS as
 guidance, not CI gates; asserts control-plane calls with generous
 bounds.
 
-KNOWN-BLOCKED (xfail, strict=False): on the current product,
-`nexus up --preset shared` returns rc=1 because its health gate waits
-for `zoekt` even though the shared preset does not start it ("Bug B" —
-a pre-existing `nexus up` health-gate defect, out of #4132's docs/test
-scope; see docs/superpowers/specs/2026-05-18-issue-4132-full-profile-design.md
-"Bug B"). The fixture correctly FAILS on that real `nexus up` failure
-(blocking value preserved), and this module-level xfail prevents that
-known, out-of-scope failure from masquerading as green verification or
-hard-reding CI. If Bug B is fixed the tests XPASS — the signal to
-remove this marker. Empirical #4132 verification was done directly
-against a live hub (recorded in the spec), independent of this gate.
+KNOWN-BLOCKED by "Bug B": on the current product `nexus up --preset
+shared` returns rc=1 because its health gate waits for `zoekt` even
+though the shared preset does not start it (a pre-existing `nexus up`
+health-gate defect, out of #4132's docs/test scope; see
+docs/superpowers/specs/2026-05-18-issue-4132-full-profile-design.md
+"Bug B"). That ONE precise case is converted to ``pytest.xfail`` *in
+the fixture* (`tests/integration/conftest.py`) by signature match — so
+it neither masquerades as green nor hard-reds CI, and XPASSes once
+Bug B is fixed. Every OTHER `nexus up`/health/gRPC failure still
+hard-FAILS, so this gate keeps full blocking value for real
+regressions (no blanket module-level xfail). Empirical #4132
+verification was also done directly against a live hub (recorded in
+the spec), independent of this gate.
 """
 
 import os
@@ -23,15 +25,7 @@ import time
 
 import pytest
 
-pytestmark = [
-    pytest.mark.integration,
-    pytest.mark.xfail(
-        reason="blocked by Bug B: `nexus up --preset shared` rc=1 on zoekt "
-        "health gate (pre-existing, out of #4132 scope) — tracked in the "
-        "#4132 design spec",
-        strict=False,
-    ),
-]
+pytestmark = pytest.mark.integration
 
 requires_e2e = pytest.mark.skipif(
     os.environ.get("NEXUS_E2E") != "1",

--- a/tests/integration/test_full_profile_boot.py
+++ b/tests/integration/test_full_profile_boot.py
@@ -33,8 +33,14 @@ def test_full_stack_boots_and_serves(full_stack):
 
 
 @requires_e2e
-def test_remote_sdk_connect(full_stack):
+def test_remote_sdk_connect(full_stack, monkeypatch):
     from nexus.sdk import connect
+
+    # Pin the SDK to the fixture's *actual* resolved gRPC port. Without
+    # this, connect() falls back to ambient/default (2028) and would
+    # fail on conflict-remapped ports — or, worse, silently pass against
+    # an unrelated service on 2028 instead of the booted fixture.
+    monkeypatch.setenv("NEXUS_GRPC_PORT", str(full_stack.grpc_port))
 
     nx = connect(
         config={

--- a/tests/integration/test_full_profile_boot.py
+++ b/tests/integration/test_full_profile_boot.py
@@ -1,8 +1,21 @@
 """FULL profile real-boot E2E (Issue #4132).
 
 Gated: only runs with NEXUS_E2E=1 (boots a real Docker stack:
-PostgreSQL + Dragonfly + Zoekt). Captures boot/RSS as guidance, not
-CI gates; asserts control-plane calls with generous bounds.
+PostgreSQL + Dragonfly + the Nexus server). Captures boot/RSS as
+guidance, not CI gates; asserts control-plane calls with generous
+bounds.
+
+KNOWN-BLOCKED (xfail, strict=False): on the current product,
+`nexus up --preset shared` returns rc=1 because its health gate waits
+for `zoekt` even though the shared preset does not start it ("Bug B" —
+a pre-existing `nexus up` health-gate defect, out of #4132's docs/test
+scope; see docs/superpowers/specs/2026-05-18-issue-4132-full-profile-design.md
+"Bug B"). The fixture correctly FAILS on that real `nexus up` failure
+(blocking value preserved), and this module-level xfail prevents that
+known, out-of-scope failure from masquerading as green verification or
+hard-reding CI. If Bug B is fixed the tests XPASS — the signal to
+remove this marker. Empirical #4132 verification was done directly
+against a live hub (recorded in the spec), independent of this gate.
 """
 
 import os
@@ -10,7 +23,15 @@ import time
 
 import pytest
 
-pytestmark = pytest.mark.integration
+pytestmark = [
+    pytest.mark.integration,
+    pytest.mark.xfail(
+        reason="blocked by Bug B: `nexus up --preset shared` rc=1 on zoekt "
+        "health gate (pre-existing, out of #4132 scope) — tracked in the "
+        "#4132 design spec",
+        strict=False,
+    ),
+]
 
 requires_e2e = pytest.mark.skipif(
     os.environ.get("NEXUS_E2E") != "1",

--- a/tests/integration/test_full_profile_boot.py
+++ b/tests/integration/test_full_profile_boot.py
@@ -10,14 +10,18 @@ shared` returns rc=1 because its health gate waits for `zoekt` even
 though the shared preset does not start it (a pre-existing `nexus up`
 health-gate defect, out of #4132's docs/test scope; see
 docs/superpowers/specs/2026-05-18-issue-4132-full-profile-design.md
-"Bug B"). That ONE precise case is converted to ``pytest.xfail`` *in
-the fixture* (`tests/integration/conftest.py`) by signature match — so
-it neither masquerades as green nor hard-reds CI, and XPASSes once
-Bug B is fixed. Every OTHER `nexus up`/health/gRPC failure still
-hard-FAILS, so this gate keeps full blocking value for real
-regressions (no blanket module-level xfail). Empirical #4132
-verification was also done directly against a live hub (recorded in
-the spec), independent of this gate.
+"Bug B"). For that ONE precise signature the fixture
+(`tests/integration/conftest.py`) does NOT blind-xfail: it first
+PROVES the hub actually serves by hitting the running container's
+``/health`` (200) and ``/api/v2/features`` (non-empty) directly. Only
+if the hub is verifiably serving is it ``pytest.xfail``ed (so it
+neither masquerades as green nor hard-reds CI, and XPASSes once Bug B
+is fixed). If the hub does NOT serve, it hard-FAILS — a real
+FULL-stack regression hiding behind a zoekt mention cannot pass. Every
+OTHER `nexus up`/health/gRPC failure also hard-FAILS, so this gate
+keeps full blocking value (no blanket module-level xfail). Empirical
+#4132 verification was also done directly against a live hub (recorded
+in the spec), independent of this gate.
 """
 
 import os

--- a/tests/integration/test_full_profile_boot.py
+++ b/tests/integration/test_full_profile_boot.py
@@ -1,0 +1,62 @@
+"""FULL profile real-boot E2E (Issue #4132).
+
+Gated: only runs with NEXUS_E2E=1 (boots a real Docker stack:
+PostgreSQL + Dragonfly + Zoekt). Captures boot/RSS as guidance, not
+CI gates; asserts control-plane calls with generous bounds.
+"""
+
+import os
+import time
+
+import pytest
+
+pytestmark = pytest.mark.integration
+
+requires_e2e = pytest.mark.skipif(
+    os.environ.get("NEXUS_E2E") != "1",
+    reason="FULL boot E2E requires NEXUS_E2E=1 (real Docker stack)",
+)
+
+
+@requires_e2e
+def test_full_stack_boots_and_serves(full_stack):
+    """full_stack fixture: nexus init --preset shared; nexus up; yield env; nexus down."""
+    t0 = time.monotonic()
+    health = full_stack.http_get("/health")
+    boot_s = time.monotonic() - t0
+    assert health.status_code == 200
+    features = full_stack.http_get("/api/v2/features")
+    assert features.status_code == 200
+    body = features.json()
+    assert body  # FULL reports a non-empty feature set
+    print(f"[bench] first-health latency ~ {boot_s:.2f}s")
+
+
+@requires_e2e
+def test_remote_sdk_connect(full_stack):
+    from nexus.sdk import connect
+
+    nx = connect(
+        config={
+            "profile": "remote",
+            "url": full_stack.url,
+            "api_key": full_stack.api_key,
+        }
+    )
+    assert nx is not None
+    nx.ls("/")
+
+
+@requires_e2e
+def test_remote_sdk_without_grpc_fails_clearly(full_stack, monkeypatch):
+    from nexus.sdk import connect
+
+    monkeypatch.setenv("NEXUS_GRPC_PORT", "1")  # unreachable
+    with pytest.raises(Exception, match=r"."):  # any error — connection refused / RPC failure
+        connect(
+            config={
+                "profile": "remote",
+                "url": full_stack.url,
+                "api_key": full_stack.api_key,
+            }
+        ).ls("/")

--- a/tests/unit/cli/test_doctor.py
+++ b/tests/unit/cli/test_doctor.py
@@ -1088,6 +1088,48 @@ class TestDoctorRemote:
 
     @patch("nexus.cli.commands.doctor.RPCTransport")
     @patch("httpx.Client")
+    def test_grpc_auth_failure_is_diagnosed_distinctly(
+        self,
+        mock_http_cls: MagicMock,
+        mock_rpc_cls: MagicMock,
+        cli_runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An auth failure on the gRPC Ping path (UNAUTHENTICATED /
+        PERMISSION_DENIED) must be reported as an AUTH problem with a
+        key-specific fix hint — NOT misdiagnosed as an unreachable port
+        / firewall issue (which would send the operator the wrong way)."""
+        from nexus.contracts.exceptions import RemoteConnectionError
+
+        monkeypatch.setenv("NEXUS_GRPC_ALLOW_INSECURE", "true")
+        mock_http_cls.return_value = self._make_http_mock(200)
+        mock_transport = MagicMock()
+        mock_transport.health_check.side_effect = RemoteConnectionError(
+            "gRPC health check failed: <_InactiveRpcError "
+            "StatusCode.UNAUTHENTICATED: missing bearer token>",
+            details={},
+            method="Ping",
+        )
+        mock_rpc_cls.return_value = mock_transport
+
+        result = cli_runner.invoke(
+            doctor_remote,
+            ["--url", "http://hub.example.com:2026", "--api-key", "", "--json"],
+        )
+        assert result.exit_code != 0
+        assert "Traceback" not in result.output
+        grpc_check = next(
+            c for c in json.loads(result.output)["data"] if c["name"] == "remote-grpc"
+        )
+        assert grpc_check["status"] == "error"
+        # auth-specific, NOT a port/firewall misdiagnosis
+        assert "auth" in grpc_check["message"].lower()
+        assert "API key" in grpc_check["fix_hint"]
+        assert "NEXUS_GRPC_PORT" not in grpc_check["fix_hint"]
+        mock_transport.close.assert_called_once()
+
+    @patch("nexus.cli.commands.doctor.RPCTransport")
+    @patch("httpx.Client")
     def test_grpc_port_from_env(
         self,
         mock_http_cls: MagicMock,

--- a/tests/unit/cli/test_doctor.py
+++ b/tests/unit/cli/test_doctor.py
@@ -1024,8 +1024,7 @@ class TestDoctorRemote:
                 doctor_remote, ["--url", "http://hub.example.com:2026", "--api-key", "testkey"]
             )
 
-        # Not a crash — should exit 0 (warning doesn't count as error) or 1 depending on impl.
-        # The key assertion is: no raw traceback and actionable message.
+        assert result.exit_code == 0  # WARNING does not set has_error
         assert "Traceback" not in result.output
         assert "NEXUS_GRPC_ALLOW_INSECURE" in result.output or "TLS" in result.output
 
@@ -1074,3 +1073,18 @@ class TestDoctorRemote:
 
         result = cli_runner.invoke(doctor_remote, [])
         assert result.exit_code == 0
+
+    def test_no_url_raises_usage_error(
+        self,
+        cli_runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """doctor remote with no --url and no NEXUS_URL → non-zero exit, actionable message."""
+        monkeypatch.delenv("NEXUS_URL", raising=False)
+
+        result = cli_runner.invoke(doctor_remote, [], env={"NEXUS_URL": ""})
+
+        assert result.exit_code != 0
+        assert "Traceback" not in result.output
+        # The error message must tell the user what to provide
+        assert "NEXUS_URL" in result.output or "url" in result.output.lower()

--- a/tests/unit/cli/test_doctor.py
+++ b/tests/unit/cli/test_doctor.py
@@ -1061,6 +1061,31 @@ class TestDoctorRemote:
         assert "503" in http_check["message"]
         assert "Traceback" not in result.output
 
+    @patch("httpx.Client")
+    def test_invalid_grpc_port_is_actionable_error(
+        self,
+        mock_http_cls: MagicMock,
+        cli_runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An invalid NEXUS_GRPC_PORT must surface as an actionable ERROR
+        CheckResult (the SDK fails the same way) — not a silent wrong-port
+        dial and not a raw traceback."""
+        monkeypatch.setenv("NEXUS_GRPC_PORT", "notaport")
+        mock_http_cls.return_value = self._make_http_mock(200)
+
+        result = cli_runner.invoke(
+            doctor_remote,
+            ["--url", "http://hub.example.com:2026", "--api-key", "k", "--json"],
+        )
+        assert result.exit_code != 0
+        assert "Traceback" not in result.output
+        grpc_check = next(
+            c for c in json.loads(result.output)["data"] if c["name"] == "remote-grpc"
+        )
+        assert grpc_check["status"] == "error"
+        assert "port" in grpc_check["message"].lower()
+
     @patch("nexus.cli.commands.doctor.RPCTransport")
     @patch("httpx.Client")
     def test_grpc_port_from_env(

--- a/tests/unit/cli/test_doctor.py
+++ b/tests/unit/cli/test_doctor.py
@@ -1003,13 +1003,17 @@ class TestDoctorRemote:
         assert "NEXUS_GRPC_PORT" in grpc_check["fix_hint"]
 
     @patch("httpx.Client")
-    def test_insecure_non_loopback_surfaces_as_warning(
+    def test_insecure_non_loopback_surfaces_as_error(
         self,
         mock_http_cls: MagicMock,
         cli_runner: CliRunner,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
-        """RPCTransport ValueError (insecure non-loopback) → WARNING, not crash."""
+        """RPCTransport ValueError (insecure non-loopback) → ERROR (non-zero
+        exit), not a soft WARNING: the real remote SDK connection would be
+        refused the same way, so a preflight must fail. Still actionable,
+        no traceback.
+        """
         # Remove the escape hatch so RPCTransport refuses the insecure channel
         monkeypatch.delenv("NEXUS_GRPC_ALLOW_INSECURE", raising=False)
         mock_http_cls.return_value = self._make_http_mock(200)
@@ -1024,9 +1028,38 @@ class TestDoctorRemote:
                 doctor_remote, ["--url", "http://hub.example.com:2026", "--api-key", "testkey"]
             )
 
-        assert result.exit_code == 0  # WARNING does not set has_error
+        assert result.exit_code != 0  # unusable remote path ⇒ preflight fails
         assert "Traceback" not in result.output
         assert "NEXUS_GRPC_ALLOW_INSECURE" in result.output or "TLS" in result.output
+
+    @patch("nexus.cli.commands.doctor.RPCTransport")
+    @patch("httpx.Client")
+    def test_http_non200_is_error_nonzero(
+        self,
+        mock_http_cls: MagicMock,
+        mock_rpc_cls: MagicMock,
+        cli_runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """A non-200 HTTP health response means the remote path is not
+        usable → preflight is an ERROR with non-zero exit (not a soft
+        WARNING/exit 0), even if gRPC happens to be reachable."""
+        monkeypatch.setenv("NEXUS_GRPC_ALLOW_INSECURE", "true")
+        mock_http_cls.return_value = self._make_http_mock(503)
+        mock_transport = MagicMock()
+        mock_transport.health_check.return_value = True  # gRPC fine
+        mock_rpc_cls.return_value = mock_transport
+
+        result = cli_runner.invoke(
+            doctor_remote,
+            ["--url", "http://hub.example.com:2026", "--api-key", "testkey", "--json"],
+        )
+        assert result.exit_code != 0
+        parsed = json.loads(result.output)
+        http_check = next(c for c in parsed["data"] if c["name"] == "remote-http")
+        assert http_check["status"] == "error"
+        assert "503" in http_check["message"]
+        assert "Traceback" not in result.output
 
     @patch("nexus.cli.commands.doctor.RPCTransport")
     @patch("httpx.Client")

--- a/tests/unit/cli/test_doctor.py
+++ b/tests/unit/cli/test_doctor.py
@@ -36,6 +36,7 @@ from nexus.cli.commands.doctor import (
     check_tls_expiry,
     check_zone_isolation,
     doctor,
+    doctor_remote,
 )
 
 
@@ -777,3 +778,299 @@ class TestDoctorCommand:
         result = cli_runner.invoke(doctor, ["--fix"])
         assert result.exit_code == 0
         mock_run.assert_called_once_with(fix=True)
+
+
+# ---------------------------------------------------------------------------
+# Regression tests — group conversion must not change bare doctor behaviour
+# ---------------------------------------------------------------------------
+
+
+class TestDoctorGroupRegressions:
+    """Prove that converting doctor to a group doesn't change bare-doctor behaviour."""
+
+    @patch("nexus.cli.commands.doctor._run_all_checks_async")
+    def test_bare_doctor_runs_checks(
+        self,
+        mock_run: MagicMock,
+        cli_runner: CliRunner,
+    ) -> None:
+        """nexus doctor (no subcommand) still runs _run_all_checks_async."""
+
+        async def fake_run(fix: bool = False) -> dict:
+            return {
+                "connectivity": [
+                    CheckResult("docker", CheckStatus.OK, "Docker found"),
+                ],
+            }
+
+        mock_run.side_effect = fake_run
+        result = cli_runner.invoke(doctor, [])
+        assert result.exit_code == 0
+        mock_run.assert_called_once()
+
+    @patch("nexus.cli.commands.doctor._run_all_checks_async")
+    def test_bare_doctor_json(
+        self,
+        mock_run: MagicMock,
+        cli_runner: CliRunner,
+    ) -> None:
+        """nexus doctor --json still emits the JSON envelope."""
+
+        async def fake_run(fix: bool = False) -> dict:
+            return {
+                "connectivity": [
+                    CheckResult("docker", CheckStatus.OK, "Docker found"),
+                ],
+            }
+
+        mock_run.side_effect = fake_run
+        result = cli_runner.invoke(doctor, ["--json"])
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert "data" in parsed
+        assert "connectivity" in parsed["data"]
+
+    @patch("nexus.cli.commands.doctor._run_all_checks_async")
+    def test_bare_doctor_fix(
+        self,
+        mock_run: MagicMock,
+        cli_runner: CliRunner,
+    ) -> None:
+        """nexus doctor --fix passes fix=True to _run_all_checks_async."""
+
+        async def fake_run(fix: bool = False) -> dict:
+            return {
+                "connectivity": [
+                    CheckResult("docker", CheckStatus.OK, "Docker found"),
+                ],
+            }
+
+        mock_run.side_effect = fake_run
+        result = cli_runner.invoke(doctor, ["--fix"])
+        assert result.exit_code == 0
+        mock_run.assert_called_once_with(fix=True)
+
+    @patch("nexus.cli.commands.doctor._run_all_checks_async")
+    def test_bare_doctor_error_exit_code(
+        self,
+        mock_run: MagicMock,
+        cli_runner: CliRunner,
+    ) -> None:
+        """nexus doctor exits 1 when any check is ERROR."""
+
+        async def fake_run(fix: bool = False) -> dict:
+            return {
+                "connectivity": [
+                    CheckResult("docker", CheckStatus.ERROR, "Not found"),
+                ],
+            }
+
+        mock_run.side_effect = fake_run
+        result = cli_runner.invoke(doctor, [])
+        assert result.exit_code == 1
+
+
+# ---------------------------------------------------------------------------
+# nexus doctor remote — new preflight subcommand
+# ---------------------------------------------------------------------------
+
+
+class TestDoctorRemote:
+    """Tests for `nexus doctor remote --url <URL> --api-key <KEY>`."""
+
+    def _make_http_mock(self, status_code: int = 200) -> MagicMock:
+        mock_client = MagicMock()
+        mock_resp = MagicMock(status_code=status_code)
+        mock_client.get.return_value = mock_resp
+        mock_client.__enter__ = lambda s: mock_client
+        mock_client.__exit__ = MagicMock(return_value=False)
+        return mock_client
+
+    @patch("nexus.cli.commands.doctor.RPCTransport")
+    @patch("httpx.Client")
+    def test_happy_path_both_ok(
+        self,
+        mock_http_cls: MagicMock,
+        mock_rpc_cls: MagicMock,
+        cli_runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Both HTTP and gRPC healthy → exit 0, both results OK."""
+        monkeypatch.setenv("NEXUS_GRPC_ALLOW_INSECURE", "true")
+        mock_http_cls.return_value = self._make_http_mock(200)
+        mock_transport = MagicMock()
+        mock_transport.health_check.return_value = True
+        mock_rpc_cls.return_value = mock_transport
+
+        result = cli_runner.invoke(
+            doctor_remote, ["--url", "http://hub.example.com:2026", "--api-key", "testkey"]
+        )
+        assert result.exit_code == 0
+        # No traceback
+        assert "Traceback" not in result.output
+        # transport is closed
+        mock_transport.close.assert_called_once()
+
+    @patch("nexus.cli.commands.doctor.RPCTransport")
+    @patch("httpx.Client")
+    def test_happy_path_json(
+        self,
+        mock_http_cls: MagicMock,
+        mock_rpc_cls: MagicMock,
+        cli_runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """--json mode emits valid JSON with both checks OK."""
+        monkeypatch.setenv("NEXUS_GRPC_ALLOW_INSECURE", "true")
+        mock_http_cls.return_value = self._make_http_mock(200)
+        mock_transport = MagicMock()
+        mock_transport.health_check.return_value = True
+        mock_rpc_cls.return_value = mock_transport
+
+        result = cli_runner.invoke(
+            doctor_remote,
+            ["--url", "http://hub.example.com:2026", "--api-key", "testkey", "--json"],
+        )
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        assert "data" in parsed
+        checks = parsed["data"]
+        statuses = {c["name"]: c["status"] for c in checks}
+        assert statuses.get("remote-http") == "ok"
+        assert statuses.get("remote-grpc") == "ok"
+
+    @patch("nexus.cli.commands.doctor.RPCTransport")
+    @patch("httpx.Client")
+    def test_http_ok_grpc_unreachable(
+        self,
+        mock_http_cls: MagicMock,
+        mock_rpc_cls: MagicMock,
+        cli_runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """HTTP 200 but gRPC unreachable → exit 1, ERROR result, actionable hint."""
+        from nexus.contracts.exceptions import RemoteConnectionError
+
+        monkeypatch.setenv("NEXUS_GRPC_ALLOW_INSECURE", "true")
+        mock_http_cls.return_value = self._make_http_mock(200)
+        mock_transport = MagicMock()
+        mock_transport.health_check.side_effect = RemoteConnectionError(
+            "gRPC server unavailable", details={}, method="Ping"
+        )
+        mock_rpc_cls.return_value = mock_transport
+
+        result = cli_runner.invoke(
+            doctor_remote, ["--url", "http://hub.example.com:2026", "--api-key", "testkey"]
+        )
+        assert result.exit_code == 1
+        # No raw traceback
+        assert "Traceback" not in result.output
+        # Actionable hint: should mention NEXUS_GRPC_PORT
+        assert "NEXUS_GRPC_PORT" in result.output
+        # Transport is closed despite failure
+        mock_transport.close.assert_called_once()
+
+    @patch("nexus.cli.commands.doctor.RPCTransport")
+    @patch("httpx.Client")
+    def test_grpc_unreachable_json(
+        self,
+        mock_http_cls: MagicMock,
+        mock_rpc_cls: MagicMock,
+        cli_runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """--json mode with gRPC failure emits ERROR check result and exits 1."""
+        from nexus.contracts.exceptions import RemoteConnectionError
+
+        monkeypatch.setenv("NEXUS_GRPC_ALLOW_INSECURE", "true")
+        mock_http_cls.return_value = self._make_http_mock(200)
+        mock_transport = MagicMock()
+        mock_transport.health_check.side_effect = RemoteConnectionError(
+            "gRPC server unavailable", details={}, method="Ping"
+        )
+        mock_rpc_cls.return_value = mock_transport
+
+        result = cli_runner.invoke(
+            doctor_remote,
+            ["--url", "http://hub.example.com:2026", "--api-key", "testkey", "--json"],
+        )
+        assert result.exit_code == 1
+        parsed = json.loads(result.output)
+        checks = parsed["data"]
+        grpc_check = next(c for c in checks if c["name"] == "remote-grpc")
+        assert grpc_check["status"] == "error"
+        assert grpc_check["fix_hint"] is not None
+        assert "NEXUS_GRPC_PORT" in grpc_check["fix_hint"]
+
+    @patch("httpx.Client")
+    def test_insecure_non_loopback_surfaces_as_warning(
+        self,
+        mock_http_cls: MagicMock,
+        cli_runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """RPCTransport ValueError (insecure non-loopback) → WARNING, not crash."""
+        # Remove the escape hatch so RPCTransport refuses the insecure channel
+        monkeypatch.delenv("NEXUS_GRPC_ALLOW_INSECURE", raising=False)
+        mock_http_cls.return_value = self._make_http_mock(200)
+
+        with patch(
+            "nexus.cli.commands.doctor.RPCTransport",
+            side_effect=ValueError(
+                "Insecure gRPC channel refused for non-loopback address 'hub.example.com:2028'."
+            ),
+        ):
+            result = cli_runner.invoke(
+                doctor_remote, ["--url", "http://hub.example.com:2026", "--api-key", "testkey"]
+            )
+
+        # Not a crash — should exit 0 (warning doesn't count as error) or 1 depending on impl.
+        # The key assertion is: no raw traceback and actionable message.
+        assert "Traceback" not in result.output
+        assert "NEXUS_GRPC_ALLOW_INSECURE" in result.output or "TLS" in result.output
+
+    @patch("nexus.cli.commands.doctor.RPCTransport")
+    @patch("httpx.Client")
+    def test_grpc_port_from_env(
+        self,
+        mock_http_cls: MagicMock,
+        mock_rpc_cls: MagicMock,
+        cli_runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """NEXUS_GRPC_PORT env var is used to build the gRPC address."""
+        monkeypatch.setenv("NEXUS_GRPC_PORT", "9999")
+        monkeypatch.setenv("NEXUS_GRPC_ALLOW_INSECURE", "true")
+        mock_http_cls.return_value = self._make_http_mock(200)
+        mock_transport = MagicMock()
+        mock_transport.health_check.return_value = True
+        mock_rpc_cls.return_value = mock_transport
+
+        result = cli_runner.invoke(
+            doctor_remote, ["--url", "http://hub.example.com:2026", "--api-key", "testkey"]
+        )
+        assert result.exit_code == 0
+        # RPCTransport should have been constructed with the custom port
+        call_kwargs = mock_rpc_cls.call_args
+        assert "hub.example.com:9999" in str(call_kwargs)
+
+    @patch("nexus.cli.commands.doctor.RPCTransport")
+    @patch("httpx.Client")
+    def test_url_from_env(
+        self,
+        mock_http_cls: MagicMock,
+        mock_rpc_cls: MagicMock,
+        cli_runner: CliRunner,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """--url can be supplied via NEXUS_URL env var."""
+        monkeypatch.setenv("NEXUS_URL", "http://hub.example.com:2026")
+        monkeypatch.setenv("NEXUS_API_KEY", "envkey")
+        monkeypatch.setenv("NEXUS_GRPC_ALLOW_INSECURE", "true")
+        mock_http_cls.return_value = self._make_http_mock(200)
+        mock_transport = MagicMock()
+        mock_transport.health_check.return_value = True
+        mock_rpc_cls.return_value = mock_transport
+
+        result = cli_runner.invoke(doctor_remote, [])
+        assert result.exit_code == 0

--- a/tests/unit/cli/test_full_profile_parity.py
+++ b/tests/unit/cli/test_full_profile_parity.py
@@ -1,0 +1,91 @@
+"""CLI/SDK parity for the remote-connect contract (Issue #4132).
+
+``nexus env --json`` must emit exactly the connection values the remote
+SDK consumes: NEXUS_URL, NEXUS_API_KEY, NEXUS_GRPC_HOST, NEXUS_GRPC_PORT.
+The remote SDK path needs gRPC, not just the HTTP URL.
+
+Fixture approach mirrors tests/unit/cli/test_env_cmd.py: write a minimal
+nexus.yaml + {data_dir}/.state.json into tmp_path, patch
+nexus.cli.state.CONFIG_SEARCH_PATHS to point at it — no Docker, no network.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+
+import pytest
+import yaml
+from click.testing import CliRunner
+
+from nexus.cli.commands.env_cmd import env_cmd
+
+
+@pytest.fixture()
+def project_dir(tmp_path: Path) -> Path:
+    """Minimal nexus project fixture: nexus.yaml + data_dir/.state.json."""
+    data_dir = tmp_path / "nexus-data"
+    data_dir.mkdir()
+
+    config = {
+        "preset": "shared",
+        "data_dir": str(data_dir),
+        "services": ["nexus", "postgres"],
+        "ports": {"http": 2026, "grpc": 2028, "postgres": 5432},
+        "api_key": "sk-test-key",
+    }
+    (tmp_path / "nexus.yaml").write_text(yaml.dump(config))
+
+    state = {
+        "version": 1,
+        "ports": {"http": 3026, "grpc": 3028, "postgres": 5433},
+        "api_key": "sk-runtime-key",
+        "build_mode": "local",
+        "image_used": "nexus:local-abc12345",
+    }
+    (data_dir / ".state.json").write_text(json.dumps(state))
+
+    return tmp_path
+
+
+def test_env_json_emits_grpc_and_http(project_dir: Path) -> None:
+    """nexus env --json must contain all keys the remote SDK needs.
+
+    Asserts:
+    - NEXUS_URL        — HTTP base URL (remote SDK REST calls)
+    - NEXUS_API_KEY    — bearer token for auth
+    - NEXUS_GRPC_HOST  — gRPC host:port string (remote SDK streaming)
+    - NEXUS_GRPC_PORT  — gRPC port as string, truthy
+
+    Also validates that runtime state.json values win over nexus.yaml
+    defaults (port 3026/3028 beats 2026/2028).
+    """
+    runner = CliRunner()
+    with patch(
+        "nexus.cli.state.CONFIG_SEARCH_PATHS",
+        (str(project_dir / "nexus.yaml"),),
+    ):
+        result = runner.invoke(env_cmd, ["--json"])
+
+    assert result.exit_code == 0, result.output
+    payload = json.loads(result.output)
+
+    # All four keys required by the remote SDK must be present.
+    for key in ("NEXUS_URL", "NEXUS_API_KEY", "NEXUS_GRPC_HOST", "NEXUS_GRPC_PORT"):
+        assert key in payload, f"{key} missing from `nexus env --json`; got: {list(payload)}"
+
+    # HTTP URL must use the runtime port (state.json wins).
+    assert payload["NEXUS_URL"] == "http://localhost:3026"
+
+    # API key must reflect runtime state.json value.
+    assert payload["NEXUS_API_KEY"] == "sk-runtime-key"
+
+    # gRPC port must be truthy (non-empty, non-zero string).
+    assert payload["NEXUS_GRPC_PORT"], "NEXUS_GRPC_PORT must be a truthy value"
+
+    # gRPC port string must match the runtime port from state.json.
+    assert payload["NEXUS_GRPC_PORT"] == "3028"
+
+    # NEXUS_GRPC_HOST must reference the same gRPC port.
+    assert "3028" in payload["NEXUS_GRPC_HOST"]

--- a/tests/unit/cli/test_profile_contract.py
+++ b/tests/unit/cli/test_profile_contract.py
@@ -1,0 +1,420 @@
+"""Tests for `nexus profile contract` subcommand (Issue #4132 Gap 1)."""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock, patch
+
+import httpx
+from click.testing import CliRunner
+
+from nexus.cli.commands.profile import profile_group
+from nexus.cli.config import ResolvedConnection
+from tests.unit.cli.conftest import make_config
+
+# ---------------------------------------------------------------------------
+# Shared fixtures
+# ---------------------------------------------------------------------------
+
+FULL_FEATURES_PAYLOAD = {
+    "profile": "full",
+    "mode": "standalone",
+    "enabled_bricks": ["llm", "search", "pay", "scheduler", "eventlog", "namespace", "permissions"],
+    "disabled_bricks": ["federation"],
+    "version": "1.2.3",
+    "performance_tuning": None,
+    "rate_limit_enabled": False,
+}
+
+
+def _make_resolved(
+    url: str = "http://localhost:2026", api_key: str | None = None
+) -> ResolvedConnection:
+    return ResolvedConnection(url=url, api_key=api_key, source="test")
+
+
+# ---------------------------------------------------------------------------
+# Happy-path: full profile, with project config present
+# ---------------------------------------------------------------------------
+
+
+class TestContractFullProfile:
+    def test_exit_code_zero(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch(
+                "nexus.cli.commands.profile.resolve_connection",
+                return_value=_make_resolved(),
+            ),
+            patch(
+                "nexus.cli.commands.profile.NexusApiClient.get",
+                return_value=FULL_FEATURES_PAYLOAD,
+            ),
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={"auth": "database"},
+            ),
+        ):
+            result = cli_runner.invoke(profile_group, ["contract"])
+        assert result.exit_code == 0
+
+    def test_deployment_profile_field(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch(
+                "nexus.cli.commands.profile.resolve_connection",
+                return_value=_make_resolved(),
+            ),
+            patch(
+                "nexus.cli.commands.profile.NexusApiClient.get",
+                return_value=FULL_FEATURES_PAYLOAD,
+            ),
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={"auth": "database"},
+            ),
+        ):
+            result = cli_runner.invoke(profile_group, ["contract"])
+        data = json.loads(result.output)
+        assert data["deployment_profile"] == "full"
+
+    def test_bricks_sorted(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch(
+                "nexus.cli.commands.profile.resolve_connection",
+                return_value=_make_resolved(),
+            ),
+            patch(
+                "nexus.cli.commands.profile.NexusApiClient.get",
+                return_value=FULL_FEATURES_PAYLOAD,
+            ),
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={"auth": "database"},
+            ),
+        ):
+            result = cli_runner.invoke(profile_group, ["contract"])
+        data = json.loads(result.output)
+        assert data["bricks"] == sorted(FULL_FEATURES_PAYLOAD["enabled_bricks"])
+
+    def test_disabled_bricks_sorted(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch(
+                "nexus.cli.commands.profile.resolve_connection",
+                return_value=_make_resolved(),
+            ),
+            patch(
+                "nexus.cli.commands.profile.NexusApiClient.get",
+                return_value=FULL_FEATURES_PAYLOAD,
+            ),
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={"auth": "database"},
+            ),
+        ):
+            result = cli_runner.invoke(profile_group, ["contract"])
+        data = json.loads(result.output)
+        assert data["disabled_bricks"] == sorted(FULL_FEATURES_PAYLOAD["disabled_bricks"])
+
+    def test_drivers_non_empty_for_full(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch(
+                "nexus.cli.commands.profile.resolve_connection",
+                return_value=_make_resolved(),
+            ),
+            patch(
+                "nexus.cli.commands.profile.NexusApiClient.get",
+                return_value=FULL_FEATURES_PAYLOAD,
+            ),
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={"auth": "database"},
+            ),
+        ):
+            result = cli_runner.invoke(profile_group, ["contract"])
+        data = json.loads(result.output)
+        assert len(data["drivers"]) > 0
+        assert data["drivers"] == sorted(data["drivers"])
+
+    def test_grpc_required_is_true(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch(
+                "nexus.cli.commands.profile.resolve_connection",
+                return_value=_make_resolved(),
+            ),
+            patch(
+                "nexus.cli.commands.profile.NexusApiClient.get",
+                return_value=FULL_FEATURES_PAYLOAD,
+            ),
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={"auth": "database"},
+            ),
+        ):
+            result = cli_runner.invoke(profile_group, ["contract"])
+        data = json.loads(result.output)
+        assert data["grpc_required"] is True
+
+    def test_auth_mode_from_project_config(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch(
+                "nexus.cli.commands.profile.resolve_connection",
+                return_value=_make_resolved(),
+            ),
+            patch(
+                "nexus.cli.commands.profile.NexusApiClient.get",
+                return_value=FULL_FEATURES_PAYLOAD,
+            ),
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={"auth": "database"},
+            ),
+        ):
+            result = cli_runner.invoke(profile_group, ["contract"])
+        data = json.loads(result.output)
+        assert data["auth_mode"] == "database"
+
+    def test_auth_mode_unknown_when_no_project_config(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch(
+                "nexus.cli.commands.profile.resolve_connection",
+                return_value=_make_resolved(),
+            ),
+            patch(
+                "nexus.cli.commands.profile.NexusApiClient.get",
+                return_value=FULL_FEATURES_PAYLOAD,
+            ),
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={},
+            ),
+        ):
+            result = cli_runner.invoke(profile_group, ["contract"])
+        data = json.loads(result.output)
+        assert data["auth_mode"] == "unknown"
+
+    def test_version_field_present(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch(
+                "nexus.cli.commands.profile.resolve_connection",
+                return_value=_make_resolved(),
+            ),
+            patch(
+                "nexus.cli.commands.profile.NexusApiClient.get",
+                return_value=FULL_FEATURES_PAYLOAD,
+            ),
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={},
+            ),
+        ):
+            result = cli_runner.invoke(profile_group, ["contract"])
+        data = json.loads(result.output)
+        assert data["version"] == "1.2.3"
+
+    def test_mode_field_present(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch(
+                "nexus.cli.commands.profile.resolve_connection",
+                return_value=_make_resolved(),
+            ),
+            patch(
+                "nexus.cli.commands.profile.NexusApiClient.get",
+                return_value=FULL_FEATURES_PAYLOAD,
+            ),
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={},
+            ),
+        ):
+            result = cli_runner.invoke(profile_group, ["contract"])
+        data = json.loads(result.output)
+        assert data["mode"] == "standalone"
+
+
+# ---------------------------------------------------------------------------
+# Unknown profile path — drivers must be [] and exit 0
+# ---------------------------------------------------------------------------
+
+
+class TestContractUnknownProfile:
+    def test_unknown_profile_drivers_empty_exit_zero(self, cli_runner: CliRunner) -> None:
+        weird_payload = {
+            "profile": "weird",
+            "mode": "standalone",
+            "enabled_bricks": ["llm"],
+            "disabled_bricks": [],
+            "version": None,
+            "performance_tuning": None,
+            "rate_limit_enabled": False,
+        }
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch(
+                "nexus.cli.commands.profile.resolve_connection",
+                return_value=_make_resolved(),
+            ),
+            patch(
+                "nexus.cli.commands.profile.NexusApiClient.get",
+                return_value=weird_payload,
+            ),
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={},
+            ),
+        ):
+            result = cli_runner.invoke(profile_group, ["contract"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["drivers"] == []
+        assert data["deployment_profile"] == "weird"
+
+    def test_unknown_profile_still_emits_bricks(self, cli_runner: CliRunner) -> None:
+        weird_payload = {
+            "profile": "weird",
+            "mode": "standalone",
+            "enabled_bricks": ["some_brick"],
+            "disabled_bricks": ["other_brick"],
+            "version": None,
+            "performance_tuning": None,
+            "rate_limit_enabled": False,
+        }
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch(
+                "nexus.cli.commands.profile.resolve_connection",
+                return_value=_make_resolved(),
+            ),
+            patch(
+                "nexus.cli.commands.profile.NexusApiClient.get",
+                return_value=weird_payload,
+            ),
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={},
+            ),
+        ):
+            result = cli_runner.invoke(profile_group, ["contract"])
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        assert data["bricks"] == ["some_brick"]
+        assert data["disabled_bricks"] == ["other_brick"]
+
+
+# ---------------------------------------------------------------------------
+# Connection failure path — non-zero exit, actionable error, no traceback
+# ---------------------------------------------------------------------------
+
+
+class TestContractConnectionFailure:
+    def test_http_error_nonzero_exit(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch(
+                "nexus.cli.commands.profile.resolve_connection",
+                return_value=_make_resolved(url="http://localhost:2026"),
+            ),
+            patch(
+                "nexus.cli.commands.profile.NexusApiClient.get",
+                side_effect=httpx.ConnectError("Connection refused"),
+            ),
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={},
+            ),
+        ):
+            result = cli_runner.invoke(profile_group, ["contract"])
+        assert result.exit_code != 0
+
+    def test_http_error_actionable_message(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch(
+                "nexus.cli.commands.profile.resolve_connection",
+                return_value=_make_resolved(url="http://localhost:2026"),
+            ),
+            patch(
+                "nexus.cli.commands.profile.NexusApiClient.get",
+                side_effect=httpx.ConnectError("Connection refused"),
+            ),
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={},
+            ),
+        ):
+            result = cli_runner.invoke(profile_group, ["contract"])
+        # Should mention the URL and suggest nexus doctor
+        assert "api/v2/features" in result.output or "localhost" in result.output
+        assert "nexus doctor" in result.output
+
+    def test_http_error_no_traceback(self, cli_runner: CliRunner) -> None:
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch(
+                "nexus.cli.commands.profile.resolve_connection",
+                return_value=_make_resolved(url="http://localhost:2026"),
+            ),
+            patch(
+                "nexus.cli.commands.profile.NexusApiClient.get",
+                side_effect=httpx.ConnectError("Connection refused"),
+            ),
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={},
+            ),
+        ):
+            result = cli_runner.invoke(profile_group, ["contract"])
+        # No Python traceback in output
+        assert "Traceback" not in result.output
+        assert "raise" not in result.output
+
+    def test_http_status_error_nonzero_exit(self, cli_runner: CliRunner) -> None:
+        """Non-200 responses also produce non-zero exit."""
+        config = make_config()
+        mock_response = MagicMock()
+        mock_response.status_code = 503
+        mock_response.request = MagicMock()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch(
+                "nexus.cli.commands.profile.resolve_connection",
+                return_value=_make_resolved(url="http://localhost:2026"),
+            ),
+            patch(
+                "nexus.cli.commands.profile.NexusApiClient.get",
+                side_effect=httpx.HTTPStatusError(
+                    "503 Service Unavailable",
+                    request=mock_response.request,
+                    response=mock_response,
+                ),
+            ),
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={},
+            ),
+        ):
+            result = cli_runner.invoke(profile_group, ["contract"])
+        assert result.exit_code != 0

--- a/tests/unit/cli/test_profile_contract.py
+++ b/tests/unit/cli/test_profile_contract.py
@@ -454,6 +454,29 @@ class TestContractRemoteTargeting:
         assert result.exit_code == 0, result.output
         mock_client_cls.assert_called_once_with(url=remote_url, api_key=remote_key)
 
+    def test_api_key_only_without_url_is_forwarded(self, cli_runner: CliRunner) -> None:
+        """`--api-key K` with NO --url (default localhost static-auth hub):
+        the explicit key must still reach NexusApiClient. resolve_connection
+        drops remote_api_key when no remote_url is set, so the command must
+        preserve `api_key or resolved.api_key`."""
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch("nexus.cli.commands.profile.NexusApiClient") as mock_client_cls,
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={},
+            ),
+        ):
+            mock_instance = MagicMock()
+            mock_instance.get.return_value = FULL_FEATURES_PAYLOAD
+            mock_client_cls.return_value = mock_instance
+
+            result = cli_runner.invoke(profile_group, ["contract", "--api-key", "K"])
+
+        assert result.exit_code == 0, result.output
+        mock_client_cls.assert_called_once_with(url="http://localhost:2026", api_key="K")
+
     def test_envvar_nexus_url_forwarded_to_api_client(self, cli_runner: CliRunner) -> None:
         """NEXUS_URL env var must cause NexusApiClient to use the remote URL."""
         config = make_config()

--- a/tests/unit/cli/test_profile_contract.py
+++ b/tests/unit/cli/test_profile_contract.py
@@ -503,3 +503,57 @@ class TestContractRemoteTargeting:
 
         assert result.exit_code == 0, result.output
         mock_client_cls.assert_called_once_with(url="http://localhost:2026", api_key=None)
+
+    def test_global_profile_forwarded_to_resolve_connection(self, cli_runner: CliRunner) -> None:
+        """`nexus --profile staging profile contract` must pass the global
+        profile through to resolve_connection (regression: it used to be
+        silently dropped, so a requested profile got localhost instead)."""
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch("nexus.cli.commands.profile.NexusApiClient") as mock_client_cls,
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={},
+            ),
+            patch(
+                "nexus.cli.commands.profile.resolve_connection",
+                return_value=_make_resolved(url="http://staging:1234", api_key="sk"),
+            ) as mock_resolve,
+        ):
+            mock_instance = MagicMock()
+            mock_instance.get.return_value = FULL_FEATURES_PAYLOAD
+            mock_client_cls.return_value = mock_instance
+
+            result = cli_runner.invoke(profile_group, ["contract"], obj={"profile": "staging"})
+
+        assert result.exit_code == 0, result.output
+        assert mock_resolve.call_args.kwargs.get("profile_name") == "staging"
+
+    def test_remote_target_auth_mode_unknown_with_sources(self, cli_runner: CliRunner) -> None:
+        """For an explicit remote target, the local nexus.yaml auth does
+        NOT describe that hub: auth_mode must be 'unknown', and a
+        `_sources` provenance map must mark client-inferred fields."""
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch("nexus.cli.commands.profile.NexusApiClient") as mock_client_cls,
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={"auth": "database"},  # local config — must be ignored for remote
+            ),
+        ):
+            mock_instance = MagicMock()
+            mock_instance.get.return_value = FULL_FEATURES_PAYLOAD
+            mock_client_cls.return_value = mock_instance
+
+            result = cli_runner.invoke(profile_group, ["contract", "--url", "http://hub:9999"])
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        assert data["auth_mode"] == "unknown"  # NOT "database" (that's local-only)
+        assert "_sources" in data
+        assert "client-inferred" in data["_sources"]["drivers"]
+        assert "remote target" in data["_sources"]["auth_mode"]
+        # Hub-authoritative fields still come straight from /api/v2/features
+        assert data["deployment_profile"] == "full"

--- a/tests/unit/cli/test_profile_contract.py
+++ b/tests/unit/cli/test_profile_contract.py
@@ -141,8 +141,8 @@ class TestContractFullProfile:
         ):
             result = cli_runner.invoke(profile_group, ["contract"])
         data = json.loads(result.output)
-        assert len(data["drivers"]) > 0
-        assert data["drivers"] == sorted(data["drivers"])
+        assert len(data["client_inferred_drivers"]) > 0
+        assert data["client_inferred_drivers"] == sorted(data["client_inferred_drivers"])
 
     def test_grpc_required_is_true(self, cli_runner: CliRunner) -> None:
         config = make_config()
@@ -285,7 +285,7 @@ class TestContractUnknownProfile:
             result = cli_runner.invoke(profile_group, ["contract"])
         assert result.exit_code == 0
         data = json.loads(result.output)
-        assert data["drivers"] == []
+        assert data["client_inferred_drivers"] == []
         assert data["deployment_profile"] == "weird"
 
     def test_unknown_profile_still_emits_bricks(self, cli_runner: CliRunner) -> None:
@@ -553,7 +553,7 @@ class TestContractRemoteTargeting:
         data = json.loads(result.output)
         assert data["auth_mode"] == "unknown"  # NOT "database" (that's local-only)
         assert "_sources" in data
-        assert "client-inferred" in data["_sources"]["drivers"]
+        assert "client-inferred" in data["_sources"]["client_inferred_drivers"]
         assert "remote target" in data["_sources"]["auth_mode"]
         # Hub-authoritative fields still come straight from /api/v2/features
         assert data["deployment_profile"] == "full"

--- a/tests/unit/cli/test_profile_contract.py
+++ b/tests/unit/cli/test_profile_contract.py
@@ -527,6 +527,41 @@ class TestContractRemoteTargeting:
         assert result.exit_code == 0, result.output
         mock_client_cls.assert_called_once_with(url="http://localhost:2026", api_key=None)
 
+    def test_bare_contract_uses_managed_stack_resolved_endpoint(
+        self, cli_runner: CliRunner
+    ) -> None:
+        """Bare `nexus profile contract` (no --url) with a project config
+        must hit the managed stack's *resolved* endpoint (derived/runtime
+        ports + key), NOT a hard-coded localhost:2026 that could be an
+        unrelated daemon."""
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch("nexus.cli.commands.profile.NexusApiClient") as mock_client_cls,
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={"data_dir": "./nx", "auth": "static"},
+            ),
+            patch("nexus.cli.state.load_runtime_state", return_value={}),
+            patch(
+                "nexus.cli.state.resolve_connection_env",
+                return_value={
+                    "NEXUS_URL": "http://localhost:34567",  # runtime-resolved port
+                    "NEXUS_API_KEY": "sk-managed",
+                },
+            ),
+        ):
+            mock_instance = MagicMock()
+            mock_instance.get.return_value = FULL_FEATURES_PAYLOAD
+            mock_client_cls.return_value = mock_instance
+
+            result = cli_runner.invoke(
+                profile_group, ["contract"], env={"NEXUS_URL": "", "NEXUS_API_KEY": ""}
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_client_cls.assert_called_once_with(url="http://localhost:34567", api_key="sk-managed")
+
     def test_global_profile_forwarded_to_resolve_connection(self, cli_runner: CliRunner) -> None:
         """`nexus --profile staging profile contract` must pass the global
         profile through to resolve_connection (regression: it used to be

--- a/tests/unit/cli/test_profile_contract.py
+++ b/tests/unit/cli/test_profile_contract.py
@@ -186,7 +186,7 @@ class TestContractFullProfile:
         data = json.loads(result.output)
         assert data["auth_mode"] == "database"
 
-    def test_auth_mode_unknown_when_no_project_config(self, cli_runner: CliRunner) -> None:
+    def test_auth_mode_unknown_when_no_auth_key(self, cli_runner: CliRunner) -> None:
         config = make_config()
         with (
             patch("nexus.cli.commands.profile.load_cli_config", return_value=config),

--- a/tests/unit/cli/test_profile_contract.py
+++ b/tests/unit/cli/test_profile_contract.py
@@ -418,3 +418,88 @@ class TestContractConnectionFailure:
         ):
             result = cli_runner.invoke(profile_group, ["contract"])
         assert result.exit_code != 0
+
+
+# ---------------------------------------------------------------------------
+# Remote targeting — regression test for the real bug
+# (contract_cmd must honour --url/--api-key and NEXUS_URL/NEXUS_API_KEY)
+# ---------------------------------------------------------------------------
+
+
+class TestContractRemoteTargeting:
+    """Verify that --url/--api-key (and their env-var equivalents) are forwarded
+    to NexusApiClient so the command can actually reach a non-localhost hub."""
+
+    def test_explicit_flags_forwarded_to_api_client(self, cli_runner: CliRunner) -> None:
+        """--url and --api-key must be used when constructing NexusApiClient."""
+        config = make_config()
+        remote_url = "http://hub:9999"
+        remote_key = "K"
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch("nexus.cli.commands.profile.NexusApiClient") as mock_client_cls,
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={},
+            ),
+        ):
+            mock_instance = MagicMock()
+            mock_instance.get.return_value = FULL_FEATURES_PAYLOAD
+            mock_client_cls.return_value = mock_instance
+
+            result = cli_runner.invoke(
+                profile_group, ["contract", "--url", remote_url, "--api-key", remote_key]
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_client_cls.assert_called_once_with(url=remote_url, api_key=remote_key)
+
+    def test_envvar_nexus_url_forwarded_to_api_client(self, cli_runner: CliRunner) -> None:
+        """NEXUS_URL env var must cause NexusApiClient to use the remote URL."""
+        config = make_config()
+        remote_url = "http://hub-env:8888"
+        remote_key = "envkey"
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch("nexus.cli.commands.profile.NexusApiClient") as mock_client_cls,
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={},
+            ),
+        ):
+            mock_instance = MagicMock()
+            mock_instance.get.return_value = FULL_FEATURES_PAYLOAD
+            mock_client_cls.return_value = mock_instance
+
+            result = cli_runner.invoke(
+                profile_group,
+                ["contract"],
+                env={"NEXUS_URL": remote_url, "NEXUS_API_KEY": remote_key},
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_client_cls.assert_called_once_with(url=remote_url, api_key=remote_key)
+
+    def test_no_remote_args_uses_default_localhost(self, cli_runner: CliRunner) -> None:
+        """When no --url / env vars are set, behaviour is unchanged (localhost:2026)."""
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch("nexus.cli.commands.profile.NexusApiClient") as mock_client_cls,
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={},
+            ),
+        ):
+            mock_instance = MagicMock()
+            mock_instance.get.return_value = FULL_FEATURES_PAYLOAD
+            mock_client_cls.return_value = mock_instance
+
+            result = cli_runner.invoke(
+                profile_group,
+                ["contract"],
+                env={"NEXUS_URL": "", "NEXUS_API_KEY": ""},
+            )
+
+        assert result.exit_code == 0, result.output
+        mock_client_cls.assert_called_once_with(url="http://localhost:2026", api_key=None)

--- a/tests/unit/cli/test_profile_contract.py
+++ b/tests/unit/cli/test_profile_contract.py
@@ -612,6 +612,45 @@ class TestContractRemoteTargeting:
         assert data["auth_mode"] == "unknown"  # NOT "database" (that's local-only)
         assert "_sources" in data
         assert "client-inferred" in data["_sources"]["client_inferred_drivers"]
-        assert "remote target" in data["_sources"]["auth_mode"]
+        assert "not the locally-managed stack" in data["_sources"]["auth_mode"]
         # Hub-authoritative fields still come straight from /api/v2/features
         assert data["deployment_profile"] == "full"
+
+    def test_saved_current_profile_remote_does_not_leak_local_auth(
+        self, cli_runner: CliRunner
+    ) -> None:
+        """A bare `nexus profile contract` where ~/.nexus/config.yaml's
+        current-profile resolves to a REMOTE hub, run inside a local
+        project with nexus.yaml: auth_mode must be 'unknown' (the resolved
+        target ≠ the local managed stack), NOT the local project's auth."""
+        config = make_config()
+        with (
+            patch("nexus.cli.commands.profile.load_cli_config", return_value=config),
+            patch("nexus.cli.commands.profile.NexusApiClient") as mock_client_cls,
+            patch(
+                "nexus.cli.commands.profile.resolve_connection",
+                # simulates current-profile in ~/.nexus/config.yaml → remote
+                return_value=_make_resolved(url="http://remote-hub:2026", api_key="rk"),
+            ),
+            patch(
+                "nexus.cli.commands.profile.load_project_config_optional",
+                return_value={"auth": "database", "data_dir": "./nx"},  # local project
+            ),
+            patch("nexus.cli.state.load_runtime_state", return_value={}),
+            patch(
+                "nexus.cli.state.resolve_connection_env",
+                return_value={"NEXUS_URL": "http://localhost:2026"},  # local managed stack
+            ),
+        ):
+            mock_instance = MagicMock()
+            mock_instance.get.return_value = FULL_FEATURES_PAYLOAD
+            mock_client_cls.return_value = mock_instance
+
+            result = cli_runner.invoke(profile_group, ["contract"])
+
+        assert result.exit_code == 0, result.output
+        data = json.loads(result.output)
+        # target = remote-hub (current-profile) ≠ local managed localhost
+        assert data["auth_mode"] == "unknown"  # NOT "database"
+        assert "not the locally-managed stack" in data["_sources"]["auth_mode"]
+        mock_client_cls.assert_called_once_with(url="http://remote-hub:2026", api_key="rk")

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -214,3 +214,92 @@ class TestStatusCommand:
         )
         assert result.exit_code == 0
         mock_collect.assert_called_once_with("http://remote:3000", None, None)
+
+    # -----------------------------------------------------------------------
+    # deployment_profile + auth_mode enrichment (Gap 2 of #4132)
+    # -----------------------------------------------------------------------
+
+    @patch("nexus.cli.commands.status._load_project_config_optional")
+    @patch("nexus.cli.commands.status._collect_status")
+    def test_deployment_profile_from_env(
+        self,
+        mock_collect: MagicMock,
+        mock_project_cfg: MagicMock,
+        cli_runner: CliRunner,
+    ) -> None:
+        """NEXUS_PROFILE env var is surfaced as deployment_profile."""
+        mock_collect.return_value = {
+            "server_url": "http://localhost:2026",
+            "server_reachable": False,
+            "server_health": None,
+            "docker_services": [],
+        }
+        mock_project_cfg.return_value = {}
+
+        result = cli_runner.invoke(status, ["--json"], env={"NEXUS_PROFILE": "full"})
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        data = parsed.get("data", parsed)
+        assert data["deployment_profile"] == "full"
+
+    @patch("nexus.cli.commands.status._load_project_config_optional")
+    @patch("nexus.cli.commands.status._collect_status")
+    def test_auth_mode_from_project_config(
+        self,
+        mock_collect: MagicMock,
+        mock_project_cfg: MagicMock,
+        cli_runner: CliRunner,
+    ) -> None:
+        """auth_mode reflects the project config's auth key."""
+        mock_collect.return_value = {
+            "server_url": "http://localhost:2026",
+            "server_reachable": False,
+            "server_health": None,
+            "docker_services": [],
+        }
+        mock_project_cfg.return_value = {
+            "auth": "database",
+            "data_dir": "./nexus-data",
+        }
+
+        with (
+            patch("nexus.cli.commands.status.load_runtime_state", return_value={}),
+            patch(
+                "nexus.cli.commands.status.resolve_connection_env",
+                return_value={"NEXUS_URL": "http://localhost:2026"},
+            ),
+            patch(
+                "nexus.cli.commands.stack._resolve_image_ref_from_config",
+                return_value="nexus:latest",
+            ),
+        ):
+            result = cli_runner.invoke(status, ["--json"], env={"NEXUS_PROFILE": ""})
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        data = parsed.get("data", parsed)
+        assert data["auth_mode"] == "database"
+
+    @patch("nexus.cli.commands.status._load_project_config_optional")
+    @patch("nexus.cli.commands.status._collect_status")
+    def test_new_keys_present_offline_no_project_config(
+        self,
+        mock_collect: MagicMock,
+        mock_project_cfg: MagicMock,
+        cli_runner: CliRunner,
+    ) -> None:
+        """Both keys are present even when offline with no project config."""
+        mock_collect.return_value = {
+            "server_url": "http://localhost:2026",
+            "server_reachable": False,
+            "server_health": None,
+            "docker_services": [],
+        }
+        mock_project_cfg.return_value = {}
+
+        result = cli_runner.invoke(status, ["--json"], env={"NEXUS_PROFILE": "", "NEXUS_URL": ""})
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        data = parsed.get("data", parsed)
+        assert "deployment_profile" in data
+        assert "auth_mode" in data
+        assert data["auth_mode"] == "none"

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -365,6 +365,13 @@ class TestStatusCommand:
         sent_key = mock_fetch.call_args.args[1]
         assert sent_key == "REMOTE-K"
         assert sent_key != "LOCAL-SECRET"
+        # AND the local stack key/connection_env must not appear anywhere
+        # in the rendered output for a remote target (auth boundary).
+        assert "LOCAL-SECRET" not in result.output
+        data = json.loads(result.output)
+        data = data.get("data", data)
+        assert "connection_env" not in data
+        assert "project_name" not in data
 
     @patch("nexus.cli.commands.status._fetch_deployment_profile_from_features")
     @patch("nexus.cli.commands.status._load_project_config_optional")

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -316,6 +316,59 @@ class TestStatusCommand:
     @patch("nexus.cli.commands.status._fetch_deployment_profile_from_features")
     @patch("nexus.cli.commands.status._load_project_config_optional")
     @patch("nexus.cli.commands.status._collect_status")
+    def test_local_stack_key_not_sent_to_remote_url(
+        self,
+        mock_collect: MagicMock,
+        mock_project_cfg: MagicMock,
+        mock_fetch: MagicMock,
+        cli_runner: CliRunner,
+    ) -> None:
+        """Auth-boundary: `nexus status --url <remote>` run inside a local
+        project must NOT send the local stack's bearer token to the
+        remote features probe. It uses the explicitly-supplied remote key
+        (or none) — never conn_env's local NEXUS_API_KEY."""
+        mock_collect.return_value = {
+            "server_url": "http://otherhub:2026",
+            "server_reachable": True,
+            "server_health": None,
+            "docker_services": [],
+        }
+        mock_project_cfg.return_value = {"auth": "static", "data_dir": "./nx"}
+        mock_fetch.return_value = "lite"
+
+        with (
+            patch("nexus.cli.state.load_runtime_state", return_value={}),
+            patch(
+                "nexus.cli.state.resolve_connection_env",
+                return_value={
+                    "NEXUS_URL": "http://localhost:2026",  # local stack
+                    "NEXUS_API_KEY": "LOCAL-SECRET",  # must NOT leak to remote
+                },
+            ),
+            patch(
+                "nexus.cli.commands.stack._resolve_image_ref_from_config",
+                return_value="nexus:latest",
+            ),
+        ):
+            result = cli_runner.invoke(
+                status,
+                [
+                    "--json",
+                    "--url",
+                    "http://otherhub:2026",
+                    "--remote-api-key",
+                    "REMOTE-K",
+                ],
+            )
+        assert result.exit_code == 0
+        # the probe key is the explicit remote key, never the local one
+        sent_key = mock_fetch.call_args.args[1]
+        assert sent_key == "REMOTE-K"
+        assert sent_key != "LOCAL-SECRET"
+
+    @patch("nexus.cli.commands.status._fetch_deployment_profile_from_features")
+    @patch("nexus.cli.commands.status._load_project_config_optional")
+    @patch("nexus.cli.commands.status._collect_status")
     def test_features_probe_uses_connection_api_key(
         self,
         mock_collect: MagicMock,

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -219,15 +219,22 @@ class TestStatusCommand:
     # deployment_profile + auth_mode enrichment (Gap 2 of #4132)
     # -----------------------------------------------------------------------
 
+    @patch(
+        "nexus.cli.commands.status._fetch_deployment_profile_from_features",
+        return_value=None,
+    )
     @patch("nexus.cli.commands.status._load_project_config_optional")
     @patch("nexus.cli.commands.status._collect_status")
-    def test_deployment_profile_from_env(
+    def test_deployment_profile_env_is_offline_fallback(
         self,
         mock_collect: MagicMock,
         mock_project_cfg: MagicMock,
+        mock_fetch: MagicMock,
         cli_runner: CliRunner,
     ) -> None:
-        """NEXUS_PROFILE env var is surfaced as deployment_profile."""
+        """NEXUS_PROFILE is used only as the OFFLINE fallback — when the live
+        hub features endpoint is unreachable (mocked → None), the env value
+        surfaces as deployment_profile."""
         mock_collect.return_value = {
             "server_url": "http://localhost:2026",
             "server_reachable": False,
@@ -241,6 +248,35 @@ class TestStatusCommand:
         parsed = json.loads(result.output)
         data = parsed.get("data", parsed)
         assert data["deployment_profile"] == "full"
+
+    @patch("nexus.cli.commands.status._fetch_deployment_profile_from_features")
+    @patch("nexus.cli.commands.status._load_project_config_optional")
+    @patch("nexus.cli.commands.status._collect_status")
+    def test_live_features_wins_over_env_profile(
+        self,
+        mock_collect: MagicMock,
+        mock_project_cfg: MagicMock,
+        mock_fetch: MagicMock,
+        cli_runner: CliRunner,
+    ) -> None:
+        """`nexus status` reports the *running hub*. The live
+        /api/v2/features value MUST override a local NEXUS_PROFILE env var
+        (otherwise `NEXUS_PROFILE=full nexus status --url <other-hub>`
+        would mislabel a different hub)."""
+        mock_collect.return_value = {
+            "server_url": "http://otherhub:2026",
+            "server_reachable": True,
+            "server_health": None,
+            "docker_services": [],
+        }
+        mock_project_cfg.return_value = {}
+        mock_fetch.return_value = "lite"  # the live hub actually runs `lite`
+
+        result = cli_runner.invoke(status, ["--json"], env={"NEXUS_PROFILE": "full"})
+        assert result.exit_code == 0
+        parsed = json.loads(result.output)
+        data = parsed.get("data", parsed)
+        assert data["deployment_profile"] == "lite"  # live hub wins, not env
 
     @patch("nexus.cli.commands.status._load_project_config_optional")
     @patch("nexus.cli.commands.status._collect_status")

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -278,6 +278,51 @@ class TestStatusCommand:
         data = parsed.get("data", parsed)
         assert data["deployment_profile"] == "lite"  # live hub wins, not env
 
+    @patch("nexus.cli.commands.status._fetch_deployment_profile_from_features")
+    @patch("nexus.cli.commands.status._load_project_config_optional")
+    @patch("nexus.cli.commands.status._collect_status")
+    def test_explicit_remote_url_does_not_leak_local_auth_or_profile(
+        self,
+        mock_collect: MagicMock,
+        mock_project_cfg: MagicMock,
+        mock_fetch: MagicMock,
+        cli_runner: CliRunner,
+    ) -> None:
+        """Project config present + explicit --url to a DIFFERENT hub: the
+        local nexus.yaml auth and the local stack URL must NOT be reported
+        for that remote hub. auth_mode → 'unknown'; deployment_profile is
+        resolved against the actual --url target."""
+        mock_collect.return_value = {
+            "server_url": "http://otherhub:2026",  # the --url status target
+            "server_reachable": True,
+            "server_health": None,
+            "docker_services": [],
+        }
+        mock_project_cfg.return_value = {"auth": "database", "data_dir": "./nx"}
+        mock_fetch.return_value = "lite"  # otherhub actually runs `lite`
+
+        with (
+            patch("nexus.cli.state.load_runtime_state", return_value={}),
+            patch(
+                "nexus.cli.state.resolve_connection_env",
+                return_value={"NEXUS_URL": "http://localhost:2026"},  # LOCAL stack
+            ),
+            patch(
+                "nexus.cli.commands.stack._resolve_image_ref_from_config",
+                return_value="nexus:latest",
+            ),
+        ):
+            result = cli_runner.invoke(
+                status, ["--json", "--url", "http://otherhub:2026"], env={"NEXUS_PROFILE": ""}
+            )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        data = data.get("data", data)
+        # local nexus.yaml auth="database" must NOT leak to a remote target
+        assert data["auth_mode"] == "unknown"
+        # profile comes from the --url target's features, not the local stack
+        assert data["deployment_profile"] == "lite"
+
     @patch("nexus.cli.commands.status._load_project_config_optional")
     @patch("nexus.cli.commands.status._collect_status")
     def test_auth_mode_from_project_config(

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -263,9 +263,9 @@ class TestStatusCommand:
         }
 
         with (
-            patch("nexus.cli.commands.status.load_runtime_state", return_value={}),
+            patch("nexus.cli.state.load_runtime_state", return_value={}),
             patch(
-                "nexus.cli.commands.status.resolve_connection_env",
+                "nexus.cli.state.resolve_connection_env",
                 return_value={"NEXUS_URL": "http://localhost:2026"},
             ),
             patch(
@@ -279,15 +279,17 @@ class TestStatusCommand:
         data = parsed.get("data", parsed)
         assert data["auth_mode"] == "database"
 
+    @patch("nexus.cli.commands.status._fetch_deployment_profile_from_features", return_value=None)
     @patch("nexus.cli.commands.status._load_project_config_optional")
     @patch("nexus.cli.commands.status._collect_status")
     def test_new_keys_present_offline_no_project_config(
         self,
         mock_collect: MagicMock,
         mock_project_cfg: MagicMock,
+        mock_fetch_profile: MagicMock,
         cli_runner: CliRunner,
     ) -> None:
-        """Both keys are present even when offline with no project config."""
+        """Both keys are present even when offline with no project config (no real network call)."""
         mock_collect.return_value = {
             "server_url": "http://localhost:2026",
             "server_reachable": False,
@@ -300,6 +302,5 @@ class TestStatusCommand:
         assert result.exit_code == 0
         parsed = json.loads(result.output)
         data = parsed.get("data", parsed)
-        assert "deployment_profile" in data
-        assert "auth_mode" in data
+        assert data["deployment_profile"] == "unknown"
         assert data["auth_mode"] == "none"

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -278,6 +278,41 @@ class TestStatusCommand:
         data = parsed.get("data", parsed)
         assert data["deployment_profile"] == "lite"  # live hub wins, not env
 
+    @patch(
+        "nexus.cli.commands.status._fetch_deployment_profile_from_features",
+        return_value=None,  # remote features probe fails (unreachable/401)
+    )
+    @patch("nexus.cli.commands.status._load_project_config_optional")
+    @patch("nexus.cli.commands.status._collect_status")
+    def test_remote_url_probe_failure_does_not_borrow_local_env_profile(
+        self,
+        mock_collect: MagicMock,
+        mock_project_cfg: MagicMock,
+        mock_fetch: MagicMock,
+        cli_runner: CliRunner,
+    ) -> None:
+        """`NEXUS_PROFILE=full nexus status --json --url http://otherhub`
+        with a failed features probe must report deployment_profile
+        "unknown" — NOT the local NEXUS_PROFILE (no evidence about that
+        remote hub)."""
+        mock_collect.return_value = {
+            "server_url": "http://otherhub:2026",
+            "server_reachable": False,
+            "server_health": None,
+            "docker_services": [],
+        }
+        mock_project_cfg.return_value = {}  # no project config
+
+        result = cli_runner.invoke(
+            status,
+            ["--json", "--url", "http://otherhub:2026"],
+            env={"NEXUS_PROFILE": "full"},
+        )
+        assert result.exit_code == 0
+        data = json.loads(result.output)
+        data = data.get("data", data)
+        assert data["deployment_profile"] == "unknown"  # NOT "full"
+
     @patch("nexus.cli.commands.status._fetch_deployment_profile_from_features")
     @patch("nexus.cli.commands.status._load_project_config_optional")
     @patch("nexus.cli.commands.status._collect_status")

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -281,6 +281,50 @@ class TestStatusCommand:
     @patch("nexus.cli.commands.status._fetch_deployment_profile_from_features")
     @patch("nexus.cli.commands.status._load_project_config_optional")
     @patch("nexus.cli.commands.status._collect_status")
+    def test_features_probe_uses_connection_api_key(
+        self,
+        mock_collect: MagicMock,
+        mock_project_cfg: MagicMock,
+        mock_fetch: MagicMock,
+        cli_runner: CliRunner,
+    ) -> None:
+        """The connection's API key must be threaded into the features
+        probe so an authenticated hub's /api/v2/features isn't silently
+        401'd into the env/unknown fallback."""
+        mock_collect.return_value = {
+            "server_url": "http://localhost:2026",
+            "server_reachable": True,
+            "server_health": None,
+            "docker_services": [],
+        }
+        mock_project_cfg.return_value = {"auth": "static", "data_dir": "./nx"}
+        mock_fetch.return_value = "full"
+
+        with (
+            patch("nexus.cli.state.load_runtime_state", return_value={}),
+            patch(
+                "nexus.cli.state.resolve_connection_env",
+                return_value={
+                    "NEXUS_URL": "http://localhost:2026",
+                    "NEXUS_API_KEY": "sk-secret",
+                },
+            ),
+            patch(
+                "nexus.cli.commands.stack._resolve_image_ref_from_config",
+                return_value="nexus:latest",
+            ),
+        ):
+            result = cli_runner.invoke(status, ["--json"], env={"NEXUS_PROFILE": ""})
+        assert result.exit_code == 0
+        # api key from the resolved connection env is forwarded to the probe
+        assert mock_fetch.call_args.args[1] == "sk-secret" or mock_fetch.call_args == (
+            ("http://localhost:2026", "sk-secret"),
+            {},
+        )
+
+    @patch("nexus.cli.commands.status._fetch_deployment_profile_from_features")
+    @patch("nexus.cli.commands.status._load_project_config_optional")
+    @patch("nexus.cli.commands.status._collect_status")
     def test_explicit_remote_url_does_not_leak_local_auth_or_profile(
         self,
         mock_collect: MagicMock,
@@ -384,4 +428,7 @@ class TestStatusCommand:
         parsed = json.loads(result.output)
         data = parsed.get("data", parsed)
         assert data["deployment_profile"] == "unknown"
-        assert data["auth_mode"] == "none"
+        # No project config ⇒ no locally-managed stack to attest auth;
+        # report "unknown" rather than fabricating "none" for what could
+        # be an authenticated remote hub.
+        assert data["auth_mode"] == "unknown"

--- a/tests/unit/core/test_full_profile.py
+++ b/tests/unit/core/test_full_profile.py
@@ -1,0 +1,63 @@
+"""Characterization tests for DeploymentProfile.FULL (Issue #4132).
+
+These lock the FULL contract that docs/deployment/full-profile.md cites.
+FULL = LITE bricks + the full feature set, EXCLUDING federation
+(federation is cloud = full ∪ {federation}).
+"""
+
+from nexus.contracts.deployment_profile import (
+    BRICK_ACCESS_MANIFEST,
+    BRICK_FEDERATION,
+    BRICK_LLM,
+    BRICK_MCP,
+    BRICK_PAY,
+    BRICK_SEARCH,
+    BRICK_SNAPSHOT,
+    BRICK_VERSIONING,
+    BRICK_WORKSPACE,
+    DRIVER_GCS,
+    DRIVER_GDRIVE,
+    DRIVER_REMOTE,
+    DRIVER_S3,
+    DeploymentProfile,
+)
+
+
+class TestFullProfileContract:
+    def test_enum_value(self) -> None:
+        assert DeploymentProfile.FULL == "full"
+        assert DeploymentProfile("full") is DeploymentProfile.FULL
+
+    def test_superset_over_lite(self) -> None:
+        full = DeploymentProfile.FULL.default_bricks()
+        lite = DeploymentProfile.LITE.default_bricks()
+        assert lite.issubset(full)
+
+    def test_includes_feature_bricks(self) -> None:
+        bricks = DeploymentProfile.FULL.default_bricks()
+        for b in (
+            BRICK_SEARCH,
+            BRICK_PAY,
+            BRICK_LLM,
+            BRICK_MCP,
+            BRICK_WORKSPACE,
+            BRICK_SNAPSHOT,
+            BRICK_VERSIONING,
+            BRICK_ACCESS_MANIFEST,
+        ):
+            assert b in bricks, f"{b} must be enabled in FULL"
+
+    def test_excludes_federation(self) -> None:
+        # FULL excludes federation; CLOUD = FULL ∪ {federation}
+        assert BRICK_FEDERATION not in DeploymentProfile.FULL.default_bricks()
+        assert BRICK_FEDERATION in DeploymentProfile.CLOUD.default_bricks()
+
+    def test_cloud_is_full_plus_federation(self) -> None:
+        full = DeploymentProfile.FULL.default_bricks()
+        cloud = DeploymentProfile.CLOUD.default_bricks()
+        assert cloud == full | {BRICK_FEDERATION}
+
+    def test_drivers_include_cloud_storage(self) -> None:
+        drivers = DeploymentProfile.FULL.default_drivers()
+        for d in (DRIVER_S3, DRIVER_GCS, DRIVER_GDRIVE, DRIVER_REMOTE):
+            assert d in drivers

--- a/tests/unit/daemon/test_full_profile_daemon.py
+++ b/tests/unit/daemon/test_full_profile_daemon.py
@@ -1,0 +1,25 @@
+"""Daemon-side FULL profile behavior (Issue #4132).
+
+- ``nexusd --profile remote`` is rejected (a daemon cannot be a thin
+  client of another daemon).
+
+Note on ``test_full_profile_banner``: nexusd has no ``--dry-run`` or
+``--check-only`` flag, so the banner is printed inside the blocking serve
+loop with no safe early-exit path available in unit scope.  The banner test
+has been deliberately omitted per the plan's documented fallback: a flaky
+test that starts a server is worse than no banner test.  The remote-profile
+guard fires *before* the banner and already proves the CLI/guard wiring.
+"""
+
+from __future__ import annotations
+
+from click.testing import CliRunner
+
+from nexus.daemon.main import main as nexusd_main
+
+
+def test_remote_profile_is_rejected() -> None:
+    runner = CliRunner(mix_stderr=True)
+    result = runner.invoke(nexusd_main, ["--profile", "remote"])
+    assert result.exit_code != 0
+    assert "cannot run with profile='remote'" in result.output

--- a/tests/unit/daemon/test_full_profile_daemon.py
+++ b/tests/unit/daemon/test_full_profile_daemon.py
@@ -19,7 +19,17 @@ from nexus.daemon.main import main as nexusd_main
 
 
 def test_remote_profile_is_rejected() -> None:
-    runner = CliRunner(mix_stderr=True)
+    # Click 8.2 removed CliRunner(mix_stderr=...) and captures stderr
+    # separately. The rejection is printed with err=True, so gather both
+    # streams version-robustly (stdout in old mixed Click, stderr in
+    # Click >= 8.2).
+    runner = CliRunner()
     result = runner.invoke(nexusd_main, ["--profile", "remote"])
+    combined = result.output or ""
+    try:
+        if result.stderr:
+            combined += result.stderr
+    except (ValueError, AttributeError):
+        pass
     assert result.exit_code != 0
-    assert "cannot run with profile='remote'" in result.output
+    assert "cannot run with profile='remote'" in combined

--- a/tests/unit/remote/test_grpc_target.py
+++ b/tests/unit/remote/test_grpc_target.py
@@ -53,6 +53,30 @@ def test_invalid_nexus_yaml_port_fails_fast(
         resolve_grpc_target("http://hub:2026")
 
 
+def test_explicit_remote_ignores_local_nexus_yaml(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """Boundary: with trust_local_project=False (explicit remote target
+    — `doctor remote --url` / `connect(profile=remote, url=...)`), a cwd
+    ./nexus.yaml must NOT poison the remote hub's port/TLS. Local
+    `ports.grpc: 3028` must not make `--url http://prod:2026` dial
+    `prod:3028`."""
+    monkeypatch.delenv("NEXUS_GRPC_PORT", raising=False)
+    monkeypatch.delenv("NEXUS_GRPC_TLS", raising=False)
+    monkeypatch.delenv("NEXUS_DATA_DIR", raising=False)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "nexus.yaml").write_text("ports:\n  grpc: 3028\ntls: true\n")
+
+    # default (trust_local_project=True) DOES read it — sanity
+    addr_local, port_local, _ = resolve_grpc_target("http://prod:2026")
+    assert (addr_local, port_local) == ("prod:3028", 3028)
+
+    # explicit remote IGNORES it → default 2028, no TLS from local cfg
+    addr, port, tls = resolve_grpc_target("http://prod:2026", trust_local_project=False)
+    assert (addr, port) == ("prod:2028", 2028)
+    assert tls is None  # local `tls: true` must not apply to the remote
+
+
 def test_default_port_no_tls(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("NEXUS_GRPC_PORT", raising=False)
     monkeypatch.delenv("NEXUS_GRPC_TLS", raising=False)

--- a/tests/unit/remote/test_grpc_target.py
+++ b/tests/unit/remote/test_grpc_target.py
@@ -1,0 +1,67 @@
+"""Tests for the shared remote gRPC target resolver (Issue #4132).
+
+`resolve_grpc_target` is the single source of truth used by BOTH
+`nexus.connect(profile="remote")` and `nexus doctor remote`, so the
+preflight reflects the exact connection behavior the SDK uses.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from nexus.remote.grpc_target import resolve_grpc_target
+
+
+def test_port_precedence_env_wins(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEXUS_GRPC_PORT", "9999")
+    monkeypatch.delenv("NEXUS_GRPC_TLS", raising=False)
+    monkeypatch.delenv("NEXUS_DATA_DIR", raising=False)
+    addr, port, tls = resolve_grpc_target("http://hub.example.com:2026")
+    assert addr == "hub.example.com:9999"
+    assert port == 9999
+    assert tls is None  # no TLS signals → insecure
+
+
+def test_default_port_no_tls(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NEXUS_GRPC_PORT", raising=False)
+    monkeypatch.delenv("NEXUS_GRPC_TLS", raising=False)
+    monkeypatch.delenv("NEXUS_DATA_DIR", raising=False)
+    addr, port, tls = resolve_grpc_target("http://hub:2026")
+    assert addr == "hub:2028"
+    assert port == 2028
+    assert tls is None
+
+
+def test_grpc_tls_true_resolves_tls_config(monkeypatch: pytest.MonkeyPatch) -> None:
+    """NEXUS_GRPC_TLS=true + a data dir with certs → tls_config is
+    resolved (so the preflight uses TLS like the SDK, instead of
+    wrongly reporting a TLS hub as insecure)."""
+    monkeypatch.setenv("NEXUS_GRPC_TLS", "true")
+    monkeypatch.setenv("NEXUS_DATA_DIR", "/some/data")
+    monkeypatch.delenv("NEXUS_GRPC_PORT", raising=False)
+    sentinel = object()
+    with patch(
+        "nexus.security.tls.config.ZoneTlsConfig.from_data_dir_any",
+        return_value=sentinel,
+    ):
+        addr, port, tls = resolve_grpc_target("https://hub:443")
+    assert tls is sentinel  # SDK-equivalent TLS config, not None
+
+
+def test_grpc_tls_true_no_certs_fails_closed(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Fail-closed: NEXUS_GRPC_TLS=true but nothing resolves → RuntimeError
+    (identical to the SDK; `doctor remote` turns this into an actionable
+    ERROR rather than a misleading 'reachable')."""
+    monkeypatch.setenv("NEXUS_GRPC_TLS", "true")
+    monkeypatch.setenv("NEXUS_DATA_DIR", "/no/certs/here")
+    monkeypatch.delenv("NEXUS_TLS_CERT", raising=False)
+    with (
+        patch(
+            "nexus.security.tls.config.ZoneTlsConfig.from_data_dir_any",
+            return_value=None,
+        ),
+        pytest.raises(RuntimeError, match="NEXUS_GRPC_TLS=true"),
+    ):
+        resolve_grpc_target("https://hub:443")

--- a/tests/unit/remote/test_grpc_target.py
+++ b/tests/unit/remote/test_grpc_target.py
@@ -7,6 +7,7 @@ preflight reflects the exact connection behavior the SDK uses.
 
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -22,6 +23,34 @@ def test_port_precedence_env_wins(monkeypatch: pytest.MonkeyPatch) -> None:
     assert addr == "hub.example.com:9999"
     assert port == 9999
     assert tls is None  # no TLS signals → insecure
+
+
+def test_invalid_grpc_port_env_fails_fast(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A present-but-non-integer NEXUS_GRPC_PORT must raise (not silently
+    fall back to 2028 and dial the wrong port)."""
+    monkeypatch.setenv("NEXUS_GRPC_PORT", "notaport")
+    monkeypatch.delenv("NEXUS_GRPC_TLS", raising=False)
+    with pytest.raises(ValueError, match="NEXUS_GRPC_PORT"):
+        resolve_grpc_target("http://hub:2026")
+
+
+def test_out_of_range_grpc_port_fails_fast(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEXUS_GRPC_PORT", "70000")
+    monkeypatch.delenv("NEXUS_GRPC_TLS", raising=False)
+    with pytest.raises(ValueError, match="1.65535"):
+        resolve_grpc_target("http://hub:2026")
+
+
+def test_invalid_nexus_yaml_port_fails_fast(
+    monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+) -> None:
+    """A present-but-invalid nexus.yaml ports.grpc must also fail fast."""
+    monkeypatch.delenv("NEXUS_GRPC_PORT", raising=False)
+    monkeypatch.delenv("NEXUS_GRPC_TLS", raising=False)
+    monkeypatch.chdir(tmp_path)
+    (tmp_path / "nexus.yaml").write_text("ports:\n  grpc: not-a-number\n")
+    with pytest.raises(ValueError, match="nexus.yaml ports.grpc"):
+        resolve_grpc_target("http://hub:2026")
 
 
 def test_default_port_no_tls(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
## Summary

Implements #4132 (epic #4121) — shared FULL hub startup, auth, remote
client, and profile contract — **plus** the 3 missing-surface gaps it
identified, built directly (not just filed) at the maintainer's request.

**Docs/tests (original scope)**
- New `docs/deployment/full-profile.md`; reconciled `user-guide.md` §4
  + stale `docs/paths/daemon-and-remote.md` (`--profile minimal`→`full`).
- Contract/parity/daemon tests (`test_full_profile.py`,
  `test_full_profile_parity.py`, `test_full_profile_daemon.py`); gated
  real-Docker E2E; surface-coverage matrix wired for FULL (12 ops).
- Three-namespace "profile" disambiguation (compose vs CLI-connection
  vs deployment profile).

**Gap features implemented (Gaps 1–3, with tests)**
- `nexus profile contract` — prints a running hub's resolved
  deployment-profile contract as JSON.
- `nexus status --json` — adds `deployment_profile` + `auth_mode`
  (additive; existing keys unchanged).
- `nexus doctor remote` — HTTP + gRPC preflight with actionable errors;
  `doctor` converted to a group with bare-`nexus doctor` preserved
  (regression-tested, zero behavior change).

**Bugs found by real end-to-end testing**
- **Bug A (fixed):** `nexus profile contract` couldn't target a remote
  hub (no `--url`/`NEXUS_URL`). Fixed + regression-tested + re-verified
  against a live hub.
- **E2E root cause (fixed):** the gated E2E forced `nexus up --build`
  (from-scratch Rust+Python build → timeout). Now uses the documented
  prebuilt path; source build opt-in via `NEXUS_E2E_BUILD=1`. Fixture
  diagnostic also no longer mislabels port conflicts as credential
  errors.
- **Bug B (tracked, NOT fixed — separate/out-of-scope):** `nexus up
  --preset shared` returns rc=1 even when the hub is fully healthy
  because it health-gates `zoekt` (not a shared-preset service). This is
  the real reason the pytest gated-E2E can't reach a green `nexus up`
  via the fixture — independent of #4132's deliverables. Root-fixing
  `nexus up`'s health derivation is core CLI behavior (broad blast
  radius), so it was deliberately neither patched nor masked; it's
  documented with evidence in the spec and recommended as a dedicated
  follow-up issue.

**Empirical verification (live FULL hub):** `/health`→200,
`/api/v2/features`→`profile=full, 29 bricks`; `nexus status --json`→
`full`/`none`/reachable; `nexus doctor remote`→real gRPC probe +
actionable hint; `nexus profile contract`→real JSON `full` + 29 bricks.

Design + plan + findings: `docs/superpowers/specs/2026-05-18-issue-4132-full-profile-design.md`.

## Test plan

- [x] All #4132 unit suites green (profile-contract, profile-commands,
      status, doctor, full-profile contract/parity/daemon, architecture).
- [x] `nexus doctor` regression tests prove bare `nexus doctor` /
      `--json` / `--fix` behavior is unchanged.
- [x] Gap commands exercised against a real running FULL hub (evidence
      in the spec's "Empirical verification" section).
- [ ] CI runs the gated E2E on a Docker host with anonymous ghcr pulls
      (note: `nexus up --preset shared` rc=1 on `zoekt` — Bug B — must
      be resolved or the fixture made zoekt-tolerant for fully-green CI).
- [ ] Reviewer: confirm Bug B disposition (separate follow-up) is
      acceptable, or request it be addressed here.