### PR TITLE
fix(cli): 3 minor review findings from PR #4166

### DIFF
--- a/src/nexus/cli/commands/doctor.py
+++ b/src/nexus/cli/commands/doctor.py
@@ -24,7 +24,6 @@ from nexus.cli.output import OutputOptions, add_output_options, render_output
 from nexus.cli.theme import console
 from nexus.cli.timing import CommandTiming
 from nexus.cli.utils import handle_error
-from nexus.remote.rpc_transport import RPCTransport
 
 # ---------------------------------------------------------------------------
 # Check result model
@@ -729,6 +728,8 @@ def _check_remote_grpc(url: str, api_key: str | None) -> CheckResult:
                     "{data_dir}/tls/, or unset NEXUS_GRPC_TLS."
                 ),
             )
+        from nexus.remote.rpc_transport import RPCTransport
+
         transport = RPCTransport(
             server_address=grpc_address,
             auth_token=api_key,

--- a/src/nexus/cli/commands/status.py
+++ b/src/nexus/cli/commands/status.py
@@ -63,7 +63,11 @@ def _fetch_deployment_profile_from_features(
 
 
 def _resolve_deployment_profile(
-    server_url: str, api_key: str | None = None, *, allow_env_fallback: bool = True
+    server_url: str,
+    api_key: str | None = None,
+    *,
+    allow_env_fallback: bool = True,
+    prefetched_profile: str | None = None,
 ) -> str:
     """Resolve the *running hub's* deployment profile.
 
@@ -71,6 +75,9 @@ def _resolve_deployment_profile(
     ``/api/v2/features`` value is authoritative and MUST win over a local
     ``NEXUS_PROFILE`` env var (otherwise ``NEXUS_PROFILE=full nexus status
     --url <other-hub>`` would mislabel a different hub).
+
+    When *prefetched_profile* is provided (from ``_collect_status_async``),
+    it is used directly instead of making a redundant HTTP call.
 
     Hierarchy (single source of truth):
     1. Live ``GET /api/v2/features`` for *server_url* (authoritative when
@@ -81,7 +88,9 @@ def _resolve_deployment_profile(
        so the env var must not be reported as that hub's profile.
     3. ``"unknown"`` fallback.
     """
-    fetched = _fetch_deployment_profile_from_features(server_url, api_key) if server_url else None
+    fetched = prefetched_profile
+    if fetched is None and server_url:
+        fetched = _fetch_deployment_profile_from_features(server_url, api_key)
     if fetched:
         return fetched
     if allow_env_fallback:
@@ -155,6 +164,7 @@ def _enrich_with_image_info(
             # NEXUS_PROFILE may stand in only when the target IS the
             # local managed stack; never for a different remote --url.
             allow_env_fallback=is_local_stack,
+            prefetched_profile=data.pop("_features_profile", None),
         )
     else:
         # No project config: there is no locally-managed stack to compare
@@ -171,7 +181,10 @@ def _enrich_with_image_info(
         _target = data.get("server_url", "")
         _is_local_default = (not _target) or same_endpoint(_target, "http://localhost:2026")
         data["deployment_profile"] = _resolve_deployment_profile(
-            _target, status_api_key, allow_env_fallback=_is_local_default
+            _target,
+            status_api_key,
+            allow_env_fallback=_is_local_default,
+            prefetched_profile=data.pop("_features_profile", None),
         )
 
     return data
@@ -249,15 +262,21 @@ async def _collect_status_async(
     api_key: str | None = None,
     profiles: list[str] | None = None,
 ) -> dict[str, Any]:
-    """Collect all status data concurrently."""
+    """Collect all status data concurrently.
+
+    Runs health, docker, and features probes in parallel so the
+    features call (used for deployment_profile) does not add latency.
+    """
     health_task = asyncio.to_thread(_server_health, server_url, api_key)
     docker_task = asyncio.to_thread(_docker_services, profiles)
-    health, docker = await asyncio.gather(health_task, docker_task)
+    features_task = asyncio.to_thread(_fetch_deployment_profile_from_features, server_url, api_key)
+    health, docker, features_profile = await asyncio.gather(health_task, docker_task, features_task)
     return {
         "server_url": server_url,
         "server_reachable": health is not None,
         "server_health": health,
         "docker_services": docker,
+        "_features_profile": features_profile,
     }
 
 

--- a/src/nexus/cli/config.py
+++ b/src/nexus/cli/config.py
@@ -288,18 +288,25 @@ def resolve_connection(
 # ---------------------------------------------------------------------------
 
 
+_DEFAULT_PORTS: dict[str, int] = {"http": 80, "https": 443}
+
+
 def same_endpoint(a: str | None, b: str | None) -> bool:
     """True if two URLs point at the same scheme://host:port.
 
     Path and trailing slash are ignored. Returns False when either
     argument is None or empty — there is no evidence to compare.
+    Normalizes default ports (http→80, https→443) so that
+    ``http://localhost`` and ``http://localhost:80`` compare equal.
     """
     if not a or not b:
         return False
     from urllib.parse import urlparse
 
     pa, pb = urlparse(a.rstrip("/")), urlparse(b.rstrip("/"))
-    return (pa.scheme, pa.hostname, pa.port) == (pb.scheme, pb.hostname, pb.port)
+    port_a = pa.port or _DEFAULT_PORTS.get(pa.scheme, 0)
+    port_b = pb.port or _DEFAULT_PORTS.get(pb.scheme, 0)
+    return (pa.scheme, pa.hostname, port_a) == (pb.scheme, pb.hostname, port_b)
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/cli/test_doctor.py
+++ b/tests/unit/cli/test_doctor.py
@@ -886,7 +886,7 @@ class TestDoctorRemote:
         mock_client.__exit__ = MagicMock(return_value=False)
         return mock_client
 
-    @patch("nexus.cli.commands.doctor.RPCTransport")
+    @patch("nexus.remote.rpc_transport.RPCTransport")
     @patch("httpx.Client")
     def test_happy_path_both_ok(
         self,
@@ -911,7 +911,7 @@ class TestDoctorRemote:
         # transport is closed
         mock_transport.close.assert_called_once()
 
-    @patch("nexus.cli.commands.doctor.RPCTransport")
+    @patch("nexus.remote.rpc_transport.RPCTransport")
     @patch("httpx.Client")
     def test_happy_path_json(
         self,
@@ -939,7 +939,7 @@ class TestDoctorRemote:
         assert statuses.get("remote-http") == "ok"
         assert statuses.get("remote-grpc") == "ok"
 
-    @patch("nexus.cli.commands.doctor.RPCTransport")
+    @patch("nexus.remote.rpc_transport.RPCTransport")
     @patch("httpx.Client")
     def test_http_ok_grpc_unreachable(
         self,
@@ -970,7 +970,7 @@ class TestDoctorRemote:
         # Transport is closed despite failure
         mock_transport.close.assert_called_once()
 
-    @patch("nexus.cli.commands.doctor.RPCTransport")
+    @patch("nexus.remote.rpc_transport.RPCTransport")
     @patch("httpx.Client")
     def test_grpc_unreachable_json(
         self,
@@ -1019,7 +1019,7 @@ class TestDoctorRemote:
         mock_http_cls.return_value = self._make_http_mock(200)
 
         with patch(
-            "nexus.cli.commands.doctor.RPCTransport",
+            "nexus.remote.rpc_transport.RPCTransport",
             side_effect=ValueError(
                 "Insecure gRPC channel refused for non-loopback address 'hub.example.com:2028'."
             ),
@@ -1032,7 +1032,7 @@ class TestDoctorRemote:
         assert "Traceback" not in result.output
         assert "NEXUS_GRPC_ALLOW_INSECURE" in result.output or "TLS" in result.output
 
-    @patch("nexus.cli.commands.doctor.RPCTransport")
+    @patch("nexus.remote.rpc_transport.RPCTransport")
     @patch("httpx.Client")
     def test_http_non200_is_error_nonzero(
         self,
@@ -1086,7 +1086,7 @@ class TestDoctorRemote:
         assert grpc_check["status"] == "error"
         assert "port" in grpc_check["message"].lower()
 
-    @patch("nexus.cli.commands.doctor.RPCTransport")
+    @patch("nexus.remote.rpc_transport.RPCTransport")
     @patch("httpx.Client")
     def test_grpc_auth_failure_is_diagnosed_distinctly(
         self,
@@ -1128,7 +1128,7 @@ class TestDoctorRemote:
         assert "NEXUS_GRPC_PORT" not in grpc_check["fix_hint"]
         mock_transport.close.assert_called_once()
 
-    @patch("nexus.cli.commands.doctor.RPCTransport")
+    @patch("nexus.remote.rpc_transport.RPCTransport")
     @patch("httpx.Client")
     def test_grpc_port_from_env(
         self,
@@ -1153,7 +1153,7 @@ class TestDoctorRemote:
         call_kwargs = mock_rpc_cls.call_args
         assert "hub.example.com:9999" in str(call_kwargs)
 
-    @patch("nexus.cli.commands.doctor.RPCTransport")
+    @patch("nexus.remote.rpc_transport.RPCTransport")
     @patch("httpx.Client")
     def test_url_from_env(
         self,

--- a/tests/unit/cli/test_status.py
+++ b/tests/unit/cli/test_status.py
@@ -90,20 +90,26 @@ class TestServerHealth:
 
 
 class TestCollectStatus:
+    @patch("nexus.cli.commands.status._fetch_deployment_profile_from_features", return_value=None)
     @patch("nexus.cli.commands.status._docker_services", return_value=[])
     @patch("nexus.cli.commands.status._server_health", return_value=None)
-    def test_server_unreachable(self, mock_health: MagicMock, mock_docker: MagicMock) -> None:
+    def test_server_unreachable(
+        self, mock_health: MagicMock, mock_docker: MagicMock, mock_features: MagicMock
+    ) -> None:
         data = _collect_status("http://localhost:2026")
         assert data["server_reachable"] is False
         assert data["server_health"] is None
         assert data["docker_services"] == []
 
+    @patch("nexus.cli.commands.status._fetch_deployment_profile_from_features", return_value=None)
     @patch(
         "nexus.cli.commands.status._docker_services",
         return_value=[{"Name": "nexus-server", "State": "running"}],
     )
     @patch("nexus.cli.commands.status._server_health", return_value={"status": "healthy"})
-    def test_server_reachable(self, mock_health: MagicMock, mock_docker: MagicMock) -> None:
+    def test_server_reachable(
+        self, mock_health: MagicMock, mock_docker: MagicMock, mock_features: MagicMock
+    ) -> None:
         data = _collect_status("http://localhost:2026")
         assert data["server_reachable"] is True
         assert len(data["docker_services"]) == 1


### PR DESCRIPTION
## Summary

Post-merge review of PR #4166 (windoliver) found 3 minor issues. No architecture violations — all CLI tier.

- **Commit 1**: Lazy-import `RPCTransport` in `doctor.py` — `nexus doctor` (local checks) no longer loads gRPC and its transitive deps at import time
- **Commit 2**: `same_endpoint()` normalizes default ports (http→80, https→443) — fixes `http://localhost` vs `http://localhost:80` comparing unequal, which caused `auth_mode` to report `"unknown"` for the local stack
- **Commit 3**: Parallelize `/api/v2/features` probe in `nexus status` — the deployment_profile HTTP call now runs concurrently with `/health/detailed` + `docker compose ps` instead of sequentially, removing up to 2s of serial latency per invocation

## Test plan

- [x] `tests/unit/cli/test_status.py` — 21 tests pass (updated mocks for parallel features probe)
- [x] All pre-commit hooks pass (ruff, mypy, ruff-format)
- [x] No kernel changes — pure CLI tier

🤖 Generated with [Claude Code](https://claude.com/claude-code)