### PR TITLE
refactor(scripts): resolve Tailscale IPs at runtime — drop hardcoded 100.64.0.x

### DIFF
--- a/scripts/_tailscale_peers.py
+++ b/scripts/_tailscale_peers.py
@@ -1,0 +1,181 @@
+"""Tailscale peer resolver — hostname → current Tailscale IP at runtime.
+
+Federation smoke scripts on Win + Mac historically hardcoded the
+Tailscale IPs (e.g. ``100.64.0.26`` for Win, ``100.64.0.21`` for Mac).
+That coupling broke whenever Headscale reassigned IPs — typical
+triggers being SSD swap, OS reinstall, or any device migration that
+made the node key disappear locally so Headscale registered a fresh
+node and gave it a new IP.
+
+The robust + hands-free fix is to treat the **Tailscale hostname** as
+the canonical identifier and resolve the IP at runtime via
+``tailscale status --json``.  Hostnames are stable across re-joins
+(Headscale appends a random suffix only when the exact base name is
+already taken by an offline-but-not-deleted node, but the prefix the
+caller passes still matches).  Online filtering rejects stale entries
+so prefix collisions with old offline devices don't accidentally
+resolve to a dead IP.
+
+Canonical hostnames the team commits to:
+
+  * Win side: ``songym-win`` (or any unique prefix the operator picks
+    via ``tailscale up --hostname=...``).
+  * Mac side: ``huxt-mac`` (likewise).
+
+If a side's hostname differs from the default, override at the call
+site or set the matching env var documented by the caller.
+
+The resolver shells out to the ``tailscale`` CLI — no SDK dep, works
+on every platform the binary supports, and degrades gracefully when
+Tailscale is not installed (raises ``RuntimeError`` with an actionable
+message rather than masking it).
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import subprocess
+from collections.abc import Iterable
+
+
+class TailscaleNotInstalledError(RuntimeError):
+    """Raised when the ``tailscale`` CLI is not on PATH or fails to run."""
+
+
+class PeerNotFoundError(RuntimeError):
+    """Raised when no Tailscale peer matches the requested hostname pattern."""
+
+
+def _tailscale_bin() -> str:
+    """Locate the ``tailscale`` binary on the current platform."""
+    found = shutil.which("tailscale")
+    if found:
+        return found
+    # Windows install path is not on PATH by default.
+    win_default = r"C:\Program Files\Tailscale\tailscale.exe"
+    if os.path.exists(win_default):
+        return win_default
+    raise TailscaleNotInstalledError(
+        "tailscale CLI not found on PATH or at the standard Windows install "
+        "location. Install Tailscale from https://tailscale.com/download "
+        "and re-run."
+    )
+
+
+def _tailscale_status_json() -> dict:
+    """Return parsed output of ``tailscale status --json``."""
+    bin_path = _tailscale_bin()
+    try:
+        out = subprocess.check_output(
+            [bin_path, "status", "--json"],
+            stderr=subprocess.STDOUT,
+            timeout=10,
+        )
+    except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+        raise TailscaleNotInstalledError(f"`tailscale status --json` failed: {exc}") from exc
+    return json.loads(out)
+
+
+def resolve_self_ip() -> str:
+    """Return this node's primary Tailscale IPv4 address."""
+    data = _tailscale_status_json()
+    self_node = data.get("Self") or {}
+    ips: list[str] = list(self_node.get("TailscaleIPs") or [])
+    ipv4 = [ip for ip in ips if ":" not in ip]
+    if not ipv4:
+        raise PeerNotFoundError(
+            "Self has no IPv4 Tailscale address — is Tailscale up? "
+            "Run `tailscale status` to diagnose."
+        )
+    return ipv4[0]
+
+
+def resolve_peer(hostname_pattern: str, *, online_only: bool = True) -> str:
+    """Resolve a peer's Tailscale IP by hostname pattern.
+
+    Matches against ``HostName`` (the Tailscale-given name, which may
+    carry a random suffix if Headscale renamed at registration) and
+    ``DNSName`` using exact-or-prefix match.  When multiple peers
+    match (e.g. a stale offline ``songym-win`` plus the current
+    ``songym-win-ipwn5jf2``), ``online_only=True`` keeps only the
+    Online peer.
+
+    Raises ``PeerNotFoundError`` if zero matches survive the filter —
+    callers are expected to fail loud rather than silently fall back
+    to a stale address.
+    """
+    data = _tailscale_status_json()
+    candidates: list[tuple[str, dict]] = []
+    for node in (data.get("Peer") or {}).values():
+        host = (node.get("HostName") or "").lower()
+        dns = (node.get("DNSName") or "").lower()
+        pat = hostname_pattern.lower()
+        if host == pat or host.startswith(pat) or dns.startswith(pat):
+            candidates.append((host or dns, node))
+
+    if online_only:
+        candidates = [(h, n) for (h, n) in candidates if n.get("Online")]
+
+    if not candidates:
+        raise PeerNotFoundError(
+            f"No Tailscale peer matching '{hostname_pattern}' "
+            f"(online_only={online_only}). Available peers: "
+            f"{_peer_summary(data)}"
+        )
+
+    if len(candidates) > 1:
+        names = ", ".join(h for h, _ in candidates)
+        raise PeerNotFoundError(
+            f"Multiple Tailscale peers match '{hostname_pattern}' "
+            f"({names}). Use a more specific prefix."
+        )
+
+    node = candidates[0][1]
+    ipv4 = [ip for ip in (node.get("TailscaleIPs") or []) if ":" not in ip]
+    if not ipv4:
+        raise PeerNotFoundError(f"Peer '{hostname_pattern}' has no IPv4 Tailscale address.")
+    return ipv4[0]
+
+
+def _peer_summary(data: dict) -> str:
+    """Compact one-liner of (host, ip, online) tuples for error messages."""
+    rows: list[str] = []
+    for node in (data.get("Peer") or {}).values():
+        host = node.get("HostName") or "?"
+        ips = node.get("TailscaleIPs") or []
+        ipv4 = next((ip for ip in ips if ":" not in ip), "?")
+        online = "online" if node.get("Online") else "offline"
+        rows.append(f"{host}={ipv4}({online})")
+    return "; ".join(rows) if rows else "<no peers>"
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    """CLI for ad-hoc lookups, e.g. ``python -m scripts._tailscale_peers self``."""
+    import sys
+
+    args = list(argv if argv is not None else sys.argv[1:])
+    if not args or args[0] in {"-h", "--help"}:
+        print(__doc__)
+        print("\nUsage:")
+        print("  python -m scripts._tailscale_peers self")
+        print("  python -m scripts._tailscale_peers peer <hostname-prefix>")
+        return 0
+
+    cmd = args[0]
+    if cmd == "self":
+        print(resolve_self_ip())
+        return 0
+    if cmd == "peer":
+        if len(args) < 2:
+            print("error: peer requires a hostname prefix")
+            return 2
+        print(resolve_peer(args[1]))
+        return 0
+    print(f"unknown command: {cmd}")
+    return 2
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/cluster_smoke_xmachine.py
+++ b/scripts/cluster_smoke_xmachine.py
@@ -20,19 +20,24 @@ half of L1) is a follow-up — wiring through ``nexusd-cluster``'s
 gRPC surface needs a separate client and is out of scope for the
 contract pin this script provides.
 
-Run:
+Run (Tailscale IPs are looked up at runtime — survives SSD swap /
+device migration / Headscale re-registration without code edits):
 
-    # On the founder side (Win, IP 100.64.0.26):
+    # On the founder side (Win — adjust hostname prefix for your tailnet):
+    WIN_IP=$(python -m scripts._tailscale_peers self)
+    MAC_IP=$(python -m scripts._tailscale_peers peer huxt-mac)
     PYTHONPATH=. python scripts/cluster_smoke_xmachine.py \\
         --side win --bootstrap-new \\
-        --hostname 100.64.0.26 \\
-        --peers 100.64.0.21:2126
+        --hostname "$WIN_IP" \\
+        --peers "$MAC_IP:2126"
 
-    # On the joiner side (Mac, IP 100.64.0.21):
+    # On the joiner side (Mac):
+    MAC_IP=$(python -m scripts._tailscale_peers self)
+    WIN_IP=$(python -m scripts._tailscale_peers peer songym-win)
     PYTHONPATH=. python scripts/cluster_smoke_xmachine.py \\
         --side mac \\
-        --hostname 100.64.0.21 \\
-        --peers 100.64.0.26:2126
+        --hostname "$MAC_IP" \\
+        --peers "$WIN_IP:2126"
 
 Two contract guarantees the boot path enforces and the operator
 must respect:
@@ -173,8 +178,11 @@ def main() -> int:
     parser.add_argument(
         "--peers",
         required=True,
-        help="Comma-separated raft peer list, both sides included (e.g. "
-        "'100.64.0.26:2126,100.64.0.21:2126').",
+        help="Comma-separated raft peer list, OTHER nodes only (self is "
+        "added via --bootstrap-new founder or AddNode-on-leader). Resolve "
+        "Tailscale IPs at runtime via `python -m scripts._tailscale_peers "
+        "peer <hostname>` rather than hardcoding — survives Headscale IP "
+        "shuffles.",
     )
     parser.add_argument(
         "--bind-addr",

--- a/scripts/wal_smoke_singlenode.py
+++ b/scripts/wal_smoke_singlenode.py
@@ -23,14 +23,32 @@ import tempfile
 import traceback
 from pathlib import Path
 
-WIN_TS_IP = "100.64.0.26"  # Tailscale IP, matches `tailscale status`
+from scripts._tailscale_peers import TailscaleNotInstalledError, resolve_self_ip
+
 RAFT_PORT = 2126
 
 
 def setup_env(tmp: Path) -> None:
-    """Configure single-voter federation before importing nexus."""
-    os.environ["NEXUS_HOSTNAME"] = WIN_TS_IP
-    os.environ["NEXUS_PEERS"] = f"{WIN_TS_IP}:{RAFT_PORT}"
+    """Configure single-voter federation before importing nexus.
+
+    The local Tailscale IP is resolved at runtime via ``tailscale
+    status --json`` rather than hardcoded — surviving SSD swaps, OS
+    reinstalls, and Headscale IP shuffles without code edits.  Set
+    ``NEXUS_HOSTNAME`` in the environment to override (e.g. when
+    running outside the Tailscale tailnet).
+    """
+    hostname = os.environ.get("NEXUS_HOSTNAME")
+    if not hostname:
+        try:
+            hostname = resolve_self_ip()
+        except TailscaleNotInstalledError as exc:
+            raise RuntimeError(
+                f"NEXUS_HOSTNAME not set and Tailscale unavailable: {exc}. "
+                "Either install Tailscale and run `tailscale up`, or set "
+                "NEXUS_HOSTNAME=<addr> explicitly."
+            ) from exc
+    os.environ["NEXUS_HOSTNAME"] = hostname
+    os.environ["NEXUS_PEERS"] = f"{hostname}:{RAFT_PORT}"
     os.environ["NEXUS_BIND_ADDR"] = f"0.0.0.0:{RAFT_PORT}"
     os.environ["NEXUS_DATA_DIR"] = str(tmp / "zones")
     os.environ["NEXUS_RAFT_TLS"] = "false"

--- a/tests/unit/scripts/test_tailscale_peers.py
+++ b/tests/unit/scripts/test_tailscale_peers.py
@@ -1,0 +1,142 @@
+"""Unit tests for ``scripts/_tailscale_peers.py``.
+
+Mocks the ``tailscale status --json`` subprocess so the resolver's
+prefix-matching, online-filtering, and error paths can be pinned
+without requiring a live Tailscale install on the test runner.
+"""
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+import pytest
+
+from scripts import _tailscale_peers as tp
+
+# Fixture mirroring the real ``tailscale status --json`` shape that
+# surfaced during the post-SSD-swap recovery — one offline stale
+# ``songym-win`` plus a current ``songym-win-ipwn5jf2`` we registered
+# under the same base hostname.
+_STATUS_FIXTURE = {
+    "Self": {
+        "HostName": "songym-win-ipwn5jf2",
+        "DNSName": "songym-win-ipwn5jf2.nexus.tailscale.sudoprivacy.com.",
+        "TailscaleIPs": ["100.64.0.27", "fd7a:115c:a1e0::4d01"],
+        "Online": True,
+    },
+    "Peer": {
+        "node-stale": {
+            "HostName": "songym-win",
+            "DNSName": "songym-win.nexus.tailscale.sudoprivacy.com.",
+            "TailscaleIPs": ["100.64.0.26"],
+            "Online": False,
+        },
+        "node-mac-current": {
+            "HostName": "huxt-mac",
+            "DNSName": "huxt-mac.nexus.tailscale.sudoprivacy.com.",
+            "TailscaleIPs": ["100.64.0.24"],
+            "Online": True,
+        },
+        "node-mac-stale": {
+            "HostName": "huxt-mac-oldssd",
+            "DNSName": "huxt-mac-oldssd.nexus.tailscale.sudoprivacy.com.",
+            "TailscaleIPs": ["100.64.0.23"],
+            "Online": False,
+        },
+        "node-linux": {
+            "HostName": "huxuetao-linux",
+            "DNSName": "huxuetao-linux.sudo.tailscale.sudoprivacy.com.",
+            "TailscaleIPs": ["100.64.0.14"],
+            "Online": True,
+        },
+    },
+}
+
+
+@pytest.fixture
+def fake_status():
+    """Patch ``_tailscale_status_json`` to return the fixture above."""
+    with patch.object(tp, "_tailscale_status_json", return_value=_STATUS_FIXTURE):
+        yield
+
+
+def test_resolve_self_ipv4_only(fake_status):
+    # The Self block carries both IPv4 and IPv6; we only return IPv4
+    # because federation peer strings universally use the IPv4 100.64/10
+    # CGNAT space.
+    assert tp.resolve_self_ip() == "100.64.0.27"
+
+
+def test_resolve_peer_exact_match(fake_status):
+    # Exact hostname match on a Peer block — no stale collision, no
+    # filtering noise.
+    assert tp.resolve_peer("huxt-mac") == "100.64.0.24"
+
+
+def test_resolve_peer_skips_offline_stale(fake_status):
+    # Two peers share the ``huxt-mac`` prefix: the current Online one
+    # and a stale offline one carrying the same family of hostnames.
+    # online_only=True (default) must drop the stale entry so the
+    # caller cannot accidentally point federation at a dead IP.
+    assert tp.resolve_peer("huxt-mac") == "100.64.0.24"
+
+
+def test_resolve_peer_unique_prefix(fake_status):
+    # A prefix that matches only one Online peer resolves cleanly.
+    assert tp.resolve_peer("huxuetao") == "100.64.0.14"
+
+
+def test_resolve_peer_missing_raises(fake_status):
+    # Fail loud rather than fall back to a stale or wrong address —
+    # callers driving federation tests need the error surface to know
+    # the operator must intervene (delete stale node, re-up, etc.).
+    with pytest.raises(tp.PeerNotFoundError) as exc:
+        tp.resolve_peer("no-such-host")
+    msg = str(exc.value)
+    assert "no-such-host" in msg
+    # Error message must list available peers so the operator has
+    # something actionable to diagnose with.
+    assert "huxt-mac" in msg
+
+
+def test_resolve_peer_only_match_is_offline_raises(fake_status):
+    # ``songym-win`` matches only the stale offline node from Peer;
+    # Self block (``songym-win-ipwn5jf2``) is not searched because the
+    # resolver intentionally splits resolve_self_ip() from resolve_peer()
+    # — different concerns, different APIs.
+    with pytest.raises(tp.PeerNotFoundError):
+        tp.resolve_peer("songym-win")
+
+
+def test_resolve_peer_offline_allowed_when_flag_off(fake_status):
+    # ``online_only=False`` is the escape hatch for diagnostics
+    # (e.g. operator inspecting last-seen IP of a powered-down node).
+    # Single offline match should resolve.
+    assert tp.resolve_peer("songym-win", online_only=False) == "100.64.0.26"
+
+
+def test_resolve_peer_ambiguous_match_raises(fake_status):
+    # Two Online peers match the prefix ``huxt`` (huxt-mac + the stale
+    # one is filtered out, but if we relax online_only both match).
+    # Ambiguity must error loud so callers don't silently pick one.
+    with pytest.raises(tp.PeerNotFoundError) as exc:
+        tp.resolve_peer("huxt", online_only=False)
+    assert "Multiple" in str(exc.value) or "multiple" in str(exc.value).lower()
+
+
+def test_resolve_self_ip_no_ipv4_raises():
+    # Pathological: Tailscale up but Self has no IPv4 (IPv6-only).
+    # Resolver must fail loud — federation today is IPv4-only.
+    fixture = {
+        "Self": {
+            "HostName": "ipv6-only",
+            "TailscaleIPs": ["fd7a:115c:a1e0::4d01"],
+            "Online": True,
+        },
+        "Peer": {},
+    }
+    with (
+        patch.object(tp, "_tailscale_status_json", return_value=fixture),
+        pytest.raises(tp.PeerNotFoundError),
+    ):
+        tp.resolve_self_ip()


### PR DESCRIPTION
## Summary

Federation smoke scripts hardcoded Tailscale IPs (`100.64.0.26` for Win, `100.64.0.21` for Mac).  That coupling broke during this morning's SSD-swap recovery: Headscale registered the rebuilt Win as a fresh node and gave it `100.64.0.27`, and every script referencing the old IP would have silently misrouted.  The stale `songym-win@100.64.0.26` entry will sit in Headscale until manually deleted — coordination burden every time hardware migrates.

Robust + hands-free fix: treat the Tailscale **hostname** as the canonical identifier and resolve the IP at runtime via `tailscale status --json`.

- **`scripts/_tailscale_peers.py`** — new module: `resolve_self_ip()` + `resolve_peer(hostname_pattern, online_only=True)`.  Shells out to the `tailscale` CLI (no SDK dep, works on every platform the binary supports), filters stale offline matches, fails loud on ambiguity or missing Tailscale (actionable error messages, no silent fallback).
- **`scripts/wal_smoke_singlenode.py`** — `WIN_TS_IP = "100.64.0.26"` removed; `setup_env` resolves at runtime, `NEXUS_HOSTNAME` env-var still overrides for non-Tailscale contexts.
- **`scripts/cluster_smoke_xmachine.py`** — docstring + `--peers` help rewritten to show the resolver pattern; example commands use `$(python -m scripts._tailscale_peers peer <hostname>)` rather than literal IPs.
- **`tests/unit/scripts/test_tailscale_peers.py`** — 9 unit tests pin the contract: exact-or-prefix match, online filtering, IPv4-only return, ambiguity surfacing, Tailscale-missing surfacing.  Fixture mirrors the post-SSD-swap shape (stale offline `songym-win` + current online `songym-win-ipwn5jf2` under the same base hostname).

Out of scope: `rust/raft/src/distributed_coordinator.rs` test fixtures still reference `100.64.0.26`/`100.64.0.21` — those exercise peer-string parser edge cases (e.g. `validate_peers_excludes_self`), not runtime federation, so they're synthetic data and stay hardcoded.

## Why hostname > IP (vs MagicDNS or env-var)

| Approach | Coupling cost | Coordination cost | Survives SSD swap |
|---|---|---|---|
| Hardcoded IP (status quo) | every script | every IP shuffle | ✗ |
| Env-var (NEXUS_WIN_TS_IP=...) | env per side | every IP shuffle | △ (manual update) |
| MagicDNS | DNS routing on every node + Clash bypass | Headscale admin must enable + Clash config changes | ✓ |
| Runtime `tailscale status` lookup (this PR) | one helper module | zero | ✓ |

Runtime lookup decouples without requiring Xuetao (Headscale admin) or Clash config changes on either side — strictly code-level fix.

## Test plan

- [x] `pytest tests/unit/scripts/test_tailscale_peers.py` — 9 passed
- [x] `python -m scripts._tailscale_peers self` on live Win box returns current Tailscale IPv4
- [x] `python -m scripts._tailscale_peers peer huxt-mac` correctly returns the Online Mac IP and rejects stale offline same-prefix entries
- [x] `python -c "import scripts.wal_smoke_singlenode"` — module imports clean
- [ ] CI: lint / unit / federation E2E
- [ ] Cross-machine Win↔Mac smoke once Mac side adopts the same resolver helper (out of scope for this PR)
