### PR TITLE
fix(test_workflow_guards): explicit UTF-8 read of workflow YAML

### DIFF
--- a/tests/unit/ci/test_workflow_guards.py
+++ b/tests/unit/ci/test_workflow_guards.py
@@ -23,7 +23,13 @@ ROOT = Path(__file__).resolve().parents[3]
 
 
 def _load_workflow(name: str) -> dict[str, Any]:
-    raw = (ROOT / ".github/workflows" / name).read_text()
+    # ``encoding="utf-8"`` is required: ``Path.read_text()`` defaults to
+    # ``locale.getencoding()`` which is GBK on a zh-CN Windows host. Several
+    # workflow files contain U+2014 ``—`` (em-dash) in comments / step
+    # ``name:`` fields, and a GBK decode raises ``UnicodeDecodeError`` long
+    # before ``yaml.safe_load`` ever sees the bytes. CI runners are Linux
+    # (UTF-8 default), so the locale mismatch only bites local Windows runs.
+    raw = (ROOT / ".github/workflows" / name).read_text(encoding="utf-8")
     # GitHub Actions reserves the ``on:`` key. ``yaml.safe_load`` parses it
     # as the Python boolean ``True`` by default. We don't read it in these
     # tests, but document the gotcha so future readers don't trip on it.


### PR DESCRIPTION
## Summary

One-line follow-up to #4157. `Path.read_text()` in `tests/unit/ci/test_workflow_guards.py` was relying on `locale.getencoding()` — UTF-8 on Linux CI (passes) but GBK on a zh-CN Windows host (fails on the U+2014 em-dash in `docker-publish.yml`).

```python
raw = (ROOT / ".github/workflows" / name).read_text(encoding="utf-8")
```

In-place comment explains the trap so a future cleanup pass doesn't strip the kwarg as "obviously redundant".

## Validation

- Local zh-CN Windows + `~/.nexus/nexus_env` python 3.13.12:
  `pytest tests/unit/ci/test_workflow_guards.py -q` → `2 passed` (was 2 failed with `UnicodeDecodeError`).
- CI is Linux/UTF-8; behavior unchanged there.

## Adjacent (not in this PR)

Quick grep found ~15 more `read_text()` calls in `tests/unit/` without explicit `encoding=` — most read tmp_path fixtures that won't hit non-ASCII, but a few read repo YAML / source files and have the same latent bug:

- `tests/unit/cli/test_init_cmd.py` (reads `nexus.yaml`)
- `tests/unit/cli/test_stack.py` (reads `nexus-stack.yml`)
- `tests/unit/cli/test_stack_db_pool_env.py` (reads `docker-compose.yml`)
- `tests/unit/cli/test_demo_preflight.py`, `tests/unit/contracts/test_contracts.py`, `tests/unit/backends/test_manifest.py` (read source files)

Out of scope here to keep the PR narrow; a follow-up sweep is justified if anyone else hits this on a non-UTF-8 locale.
