### PR TITLE
[codex] Add storage write health probe

### DIFF
--- a/nexus-fuse/src/cache.rs
+++ b/nexus-fuse/src/cache.rs
@@ -22,6 +22,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// Maximum age for cached content before forcing revalidation (1 hour).
 const MAX_CACHE_AGE_SECS: u64 = 3600;
 
+/// Maximum age for stale content fallback after a transient revalidation error.
+const MAX_STALE_FALLBACK_AGE_SECS: u64 = MAX_CACHE_AGE_SECS * 24;
+
 /// Default DRAM cache size in bytes (256 MiB).
 pub const DEFAULT_MEMORY_CACHE_BYTES: usize = 256 * 1024 * 1024;
 
@@ -521,7 +524,18 @@ impl FileCache {
     }
 
     pub fn get_stale(&self, path: &str) -> Option<CacheEntry> {
-        self.read_record(path).map(|record| CacheEntry {
+        let record = self.read_record(path)?;
+        let age = Self::now().saturating_sub(record.cached_at_secs);
+        if age > MAX_STALE_FALLBACK_AGE_SECS {
+            debug!(
+                "Cache stale fallback expired for {} (age: {}s, limit: {}s)",
+                path, age, MAX_STALE_FALLBACK_AGE_SECS
+            );
+            self.invalidate(path);
+            return None;
+        }
+
+        Some(CacheEntry {
             content: record.content,
             etag: record.etag,
             gen: record.gen,

--- a/nexus-fuse/src/cached_read.rs
+++ b/nexus-fuse/src/cached_read.rs
@@ -171,6 +171,29 @@ mod tests {
         assert_eq!(result.tier, "cache");
     }
 
+    #[test]
+    fn expired_stale_entry_is_not_returned_on_transient_revalidation_error() {
+        let mut server = Server::new();
+        let _mock = server
+            .mock("POST", "/api/nfs/read")
+            .match_header("if-none-match", "\"stale-etag\"")
+            .with_status(503)
+            .with_body("temporarily unavailable")
+            .create();
+        let client = NexusClient::new(&server.url(), "test-key", None).unwrap();
+        let cache = test_cache("revalidation-expired-stale");
+        cache.put("/cached.txt", b"too-old", Some("stale-etag"), 0);
+        cache.backdate_for_test("/cached.txt", 3600 * 24 + 1);
+
+        let err = read_with_cache(&client, Some(&cache), "/cached.txt", 0).unwrap_err();
+
+        assert!(matches!(
+            err,
+            NexusClientError::ServerError { status: 503, .. }
+        ));
+        assert!(matches!(cache.get("/cached.txt", 0), CacheLookup::Miss));
+    }
+
     /// #4056 R5: Conflict (-32006) is technically `is_transient()` so the
     /// caller can retry with a fresh generation, but it carries an
     /// explicit "your view is stale" signal — serving the cached bytes

--- a/nexus-fuse/src/daemon.rs
+++ b/nexus-fuse/src/daemon.rs
@@ -205,9 +205,7 @@ async fn handle_connection(
         }
 
         let response = match serde_json::from_str::<JsonRpcRequest>(&line) {
-            Ok(request) => {
-                handle_request(request, &client, file_cache.clone()).await
-            }
+            Ok(request) => handle_request(request, &client, file_cache.clone()).await,
             Err(e) => {
                 error!("Failed to parse JSON-RPC request: {}", e);
                 JsonRpcResponse::error(None, -32700, format!("Parse error: {}", e), None)
@@ -391,10 +389,7 @@ fn handle_stat(params: &Value, client: &NexusClient) -> Result<Value, NexusClien
         .map_err(|e| NexusClientError::InvalidResponse(format!("Serialization error: {}", e)))
 }
 
-fn handle_mkdir(
-    params: &Value,
-    client: &NexusClient,
-) -> Result<Value, NexusClientError> {
+fn handle_mkdir(params: &Value, client: &NexusClient) -> Result<Value, NexusClientError> {
     #[derive(Deserialize)]
     struct P {
         path: String,

--- a/src/nexus/server/health/probes.py
+++ b/src/nexus/server/health/probes.py
@@ -1,31 +1,50 @@
 """Kubernetes-style health probe endpoints (#2168, #3063).
 
-Three lightweight probes for k8s ``livenessProbe``, ``readinessProbe``,
-and ``startupProbe`` configuration:
+Lightweight probes for k8s ``livenessProbe``, ``readinessProbe``, and
+``startupProbe`` configuration, plus an opt-in storage write probe:
 
 * ``GET /healthz/live``    — always 200 (event-loop alive)
 * ``GET /healthz/ready``   — 200 when the server can serve traffic
 * ``GET /healthz/startup`` — 200 when all lifespan phases are done
+* ``GET /healthz/storage`` — 200 when live storage accepts write/read/delete
 
-All probes are **zero-I/O, in-memory only** and exempt from rate limiting.
+The k8s probes are **zero-I/O, in-memory only** and exempt from rate limiting.
+The storage probe is explicitly I/O-based and opt-in by virtue of its separate
+endpoint.
 
 Failure policy (Issue #3063):
 - Liveness: fails open (200) — avoids restart loops from transient probe bugs.
 - Readiness: fails closed (503) — a broken instance should not receive traffic.
 - Startup: fails closed (503) — Kubernetes should keep waiting/restarting.
+- Storage: fails closed (503) — write-path failure should be visible to operators.
 """
 
+import asyncio
 import logging
+import os
+from threading import Lock
 from typing import Any
+from uuid import uuid4
 
-from fastapi import APIRouter, Request
+from fastapi import APIRouter, Depends, Request
 from fastapi.responses import JSONResponse
 
+from nexus.contracts.constants import ROOT_ZONE_ID
+from nexus.contracts.types import OperationContext
+from nexus.server.dependencies import require_admin
 from nexus.server.rate_limiting import limiter
 
 logger = logging.getLogger(__name__)
 
 router = APIRouter(tags=["probes"])
+_STORAGE_PROBE_PAYLOAD = b"nexus-healthz-storage-probe"
+_STORAGE_PROBE_TIMEOUT_SECONDS = 2.0
+_storage_probe_lock = Lock()
+
+
+class _StorageProbeInProgress(RuntimeError):
+    pass
+
 
 # ---------------------------------------------------------------------------
 # Helpers
@@ -73,6 +92,64 @@ def _check_db_pool(request: Request) -> tuple[bool, str]:
         return True, ""
     except Exception:
         return True, ""
+
+
+def _storage_probe_timeout_seconds() -> float:
+    raw = os.environ.get("NEXUS_HEALTHZ_STORAGE_TIMEOUT_SECONDS")
+    if raw is None:
+        return _STORAGE_PROBE_TIMEOUT_SECONDS
+    try:
+        return max(float(raw), 0.1)
+    except ValueError:
+        logger.warning(
+            "Invalid NEXUS_HEALTHZ_STORAGE_TIMEOUT_SECONDS=%r; using default %.1fs",
+            raw,
+            _STORAGE_PROBE_TIMEOUT_SECONDS,
+        )
+        return _STORAGE_PROBE_TIMEOUT_SECONDS
+
+
+def _storage_probe_context() -> OperationContext:
+    return OperationContext(
+        user_id="system",
+        groups=[],
+        is_admin=True,
+        is_system=True,
+        zone_id=ROOT_ZONE_ID,
+    )
+
+
+def _run_storage_round_trip(nx_fs: Any) -> None:
+    if not _storage_probe_lock.acquire(blocking=False):
+        raise _StorageProbeInProgress("storage probe already in progress")
+
+    try:
+        probe_path = f"/__healthz__/{uuid4().hex}"
+        context = _storage_probe_context()
+        probe_error: Exception | None = None
+
+        try:
+            nx_fs.write(path=probe_path, buf=_STORAGE_PROBE_PAYLOAD, context=context)
+            readback = nx_fs.read(probe_path, context=context)
+            if readback != _STORAGE_PROBE_PAYLOAD:
+                raise RuntimeError("storage probe readback mismatch")
+        except Exception as exc:
+            probe_error = exc
+            raise
+        finally:
+            try:
+                nx_fs.sys_unlink(probe_path, context=context)
+            except Exception as cleanup_exc:
+                if probe_error is None:
+                    raise RuntimeError(
+                        f"storage probe cleanup failed: {cleanup_exc}"
+                    ) from cleanup_exc
+                logger.warning(
+                    "Storage health probe cleanup failed after probe error",
+                    exc_info=True,
+                )
+    finally:
+        _storage_probe_lock.release()
 
 
 # ---------------------------------------------------------------------------
@@ -167,4 +244,53 @@ async def startup(request: Request) -> JSONResponse:
         return JSONResponse(
             status_code=503,
             content={"status": "error", "reason": "unexpected_probe_error"},
+        )
+
+
+@router.get("/healthz/storage", dependencies=[Depends(require_admin)])
+@limiter.exempt
+async def storage(request: Request) -> JSONResponse:
+    """Storage probe — write/read/delete through the live NexusFS path."""
+    nx_fs = getattr(request.app.state, "nexus_fs", None)
+    if nx_fs is None:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "status": "unhealthy",
+                "reason": "nexus_fs_unavailable",
+            },
+        )
+
+    try:
+        await asyncio.wait_for(
+            asyncio.to_thread(_run_storage_round_trip, nx_fs),
+            timeout=_storage_probe_timeout_seconds(),
+        )
+        return JSONResponse({"status": "healthy"})
+    except _StorageProbeInProgress:
+        return JSONResponse(
+            status_code=503,
+            content={
+                "status": "unhealthy",
+                "reason": "storage_probe_in_progress",
+            },
+        )
+    except TimeoutError:
+        logger.warning("Storage health probe timed out")
+        return JSONResponse(
+            status_code=503,
+            content={
+                "status": "unhealthy",
+                "reason": "storage_probe_timeout",
+            },
+        )
+    except Exception as exc:
+        logger.warning("Storage health probe failed: %s", exc)
+        return JSONResponse(
+            status_code=503,
+            content={
+                "status": "unhealthy",
+                "reason": "storage_probe_failed",
+                "error": str(exc),
+            },
         )

--- a/tests/unit/cli/test_stack_sandbox.py
+++ b/tests/unit/cli/test_stack_sandbox.py
@@ -31,6 +31,13 @@ def runner() -> CliRunner:
     return CliRunner()
 
 
+def _isolated_sandbox_env(tmp_path: Path, **extra: str) -> dict[str, str]:
+    """Environment for sandbox-up tests that intentionally omit --data-dir."""
+    home = tmp_path / "home"
+    home.mkdir(exist_ok=True)
+    return {"PATH": "/usr/bin", "HOME": str(home), **extra}
+
+
 # ---------------------------------------------------------------------------
 # Happy-path tests
 # ---------------------------------------------------------------------------
@@ -48,6 +55,7 @@ class TestSandboxShortcutHappyPath:
         with (
             patch("shutil.which", return_value=fake_nexusd),
             patch("subprocess.run", return_value=mock_proc) as mock_run,
+            patch.dict("os.environ", _isolated_sandbox_env(tmp_path), clear=True),
         ):
             result = runner.invoke(up, ["--profile", "sandbox", "--workspace", ws])
 
@@ -75,6 +83,7 @@ class TestSandboxShortcutHappyPath:
         with (
             patch("shutil.which", return_value=fake_nexusd),
             patch("subprocess.run", return_value=mock_proc) as mock_run,
+            patch.dict("os.environ", _isolated_sandbox_env(tmp_path), clear=True),
         ):
             result = runner.invoke(
                 up,
@@ -115,6 +124,7 @@ class TestSandboxShortcutHappyPath:
         with (
             patch("shutil.which", return_value=None),
             patch("subprocess.run", return_value=mock_proc) as mock_run,
+            patch.dict("os.environ", _isolated_sandbox_env(tmp_path), clear=True),
         ):
             result = runner.invoke(up, ["--profile", "sandbox", "--workspace", ws])
 
@@ -138,13 +148,14 @@ class TestSandboxShortcutHappyPath:
         with (
             patch("shutil.which", return_value=fake_nexusd),
             patch("subprocess.run", return_value=mock_proc) as mock_run,
-            patch(
+            patch.dict(
                 "os.environ",
-                {
-                    **__import__("os").environ,
-                    "NEXUS_HUB_URL": "grpc://hub.env.example.com:50051",
-                    "NEXUS_HUB_TOKEN": "envtoken",
-                },
+                _isolated_sandbox_env(
+                    tmp_path,
+                    NEXUS_HUB_URL="grpc://hub.env.example.com:50051",
+                    NEXUS_HUB_TOKEN="envtoken",
+                ),
+                clear=True,
             ),
         ):
             result = runner.invoke(up, ["--profile", "sandbox", "--workspace", ws])

--- a/tests/unit/server/health/test_storage_probe.py
+++ b/tests/unit/server/health/test_storage_probe.py
@@ -1,0 +1,177 @@
+"""Tests for the storage health probe."""
+
+from concurrent.futures import ThreadPoolExecutor
+from threading import Event, Lock
+from time import sleep
+from unittest.mock import MagicMock
+
+from fastapi import FastAPI
+from fastapi.testclient import TestClient
+
+from nexus.server.health.probes import router
+
+_STORAGE_AUTH_HEADERS = {"Authorization": "Bearer test-storage-key"}
+
+
+def _make_storage_app() -> FastAPI:
+    app = FastAPI()
+    app.include_router(router)
+    app.state.startup_tracker = None
+    app.state.nexus_fs = None
+    app.state.api_key = "test-storage-key"
+    app.state.auth_provider = None
+    return app
+
+
+def test_storage_probe_requires_admin_auth() -> None:
+    client = TestClient(_make_storage_app())
+
+    resp = client.get("/healthz/storage")
+
+    assert resp.status_code == 401
+
+
+def test_storage_probe_succeeds_when_round_trip_succeeds() -> None:
+    app = _make_storage_app()
+    mock_fs = MagicMock()
+    mock_fs.read.return_value = b"nexus-healthz-storage-probe"
+    app.state.nexus_fs = mock_fs
+
+    client = TestClient(app)
+    resp = client.get("/healthz/storage", headers=_STORAGE_AUTH_HEADERS)
+
+    assert resp.status_code == 200
+    assert resp.json()["status"] == "healthy"
+
+    write_kwargs = mock_fs.write.call_args.kwargs
+    probe_path = write_kwargs["path"]
+    context = write_kwargs["context"]
+    assert probe_path.startswith("/__healthz__/")
+    assert write_kwargs["buf"] == b"nexus-healthz-storage-probe"
+    assert context.is_system is True
+
+    mock_fs.read.assert_called_once_with(probe_path, context=context)
+    mock_fs.sys_unlink.assert_called_once_with(probe_path, context=context)
+
+
+def test_storage_probe_503_when_nexus_fs_missing() -> None:
+    client = TestClient(_make_storage_app())
+
+    resp = client.get("/healthz/storage", headers=_STORAGE_AUTH_HEADERS)
+
+    assert resp.status_code == 503
+    assert resp.json() == {
+        "status": "unhealthy",
+        "reason": "nexus_fs_unavailable",
+    }
+
+
+def test_storage_probe_503_when_storage_write_fails() -> None:
+    app = _make_storage_app()
+    mock_fs = MagicMock()
+    mock_fs.write.side_effect = OSError(28, "No space left on device")
+    app.state.nexus_fs = mock_fs
+
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/healthz/storage", headers=_STORAGE_AUTH_HEADERS)
+
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["status"] == "unhealthy"
+    assert body["reason"] == "storage_probe_failed"
+    assert "No space left on device" in body["error"]
+
+
+def test_storage_probe_503_when_readback_does_not_match() -> None:
+    app = _make_storage_app()
+    mock_fs = MagicMock()
+    mock_fs.read.return_value = b"wrong"
+    app.state.nexus_fs = mock_fs
+
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/healthz/storage", headers=_STORAGE_AUTH_HEADERS)
+
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["status"] == "unhealthy"
+    assert body["reason"] == "storage_probe_failed"
+    assert body["error"] == "storage probe readback mismatch"
+    mock_fs.sys_unlink.assert_called_once()
+
+
+def test_storage_probe_cleanup_runs_after_read_failure() -> None:
+    app = _make_storage_app()
+    mock_fs = MagicMock()
+    mock_fs.read.side_effect = RuntimeError("read failed")
+    app.state.nexus_fs = mock_fs
+
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/healthz/storage", headers=_STORAGE_AUTH_HEADERS)
+
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["reason"] == "storage_probe_failed"
+    assert body["error"] == "read failed"
+    mock_fs.sys_unlink.assert_called_once()
+
+
+def test_storage_probe_503_when_cleanup_fails_after_successful_readback() -> None:
+    app = _make_storage_app()
+    mock_fs = MagicMock()
+    mock_fs.read.return_value = b"nexus-healthz-storage-probe"
+    mock_fs.sys_unlink.side_effect = RuntimeError("delete failed")
+    app.state.nexus_fs = mock_fs
+
+    client = TestClient(app, raise_server_exceptions=False)
+    resp = client.get("/healthz/storage", headers=_STORAGE_AUTH_HEADERS)
+
+    assert resp.status_code == 503
+    body = resp.json()
+    assert body["status"] == "unhealthy"
+    assert body["reason"] == "storage_probe_failed"
+    assert body["error"] == "storage probe cleanup failed: delete failed"
+
+
+def test_storage_probe_503_when_probe_already_in_progress(monkeypatch) -> None:
+    app = _make_storage_app()
+    mock_fs = MagicMock()
+    write_started = Event()
+    release_write = Event()
+    counter_lock = Lock()
+    write_calls = 0
+
+    def blocking_write(**_: object) -> None:
+        nonlocal write_calls
+        with counter_lock:
+            write_calls += 1
+        write_started.set()
+        release_write.wait(timeout=5)
+
+    mock_fs.write.side_effect = blocking_write
+    mock_fs.read.return_value = b"nexus-healthz-storage-probe"
+    app.state.nexus_fs = mock_fs
+    monkeypatch.setenv("NEXUS_HEALTHZ_STORAGE_TIMEOUT_SECONDS", "0.2")
+
+    client1 = TestClient(app, raise_server_exceptions=False)
+    client2 = TestClient(app, raise_server_exceptions=False)
+    with ThreadPoolExecutor(max_workers=1) as executor:
+        first_probe = executor.submit(
+            client1.get,
+            "/healthz/storage",
+            headers=_STORAGE_AUTH_HEADERS,
+        )
+        assert write_started.wait(timeout=1)
+
+        resp = client2.get("/healthz/storage", headers=_STORAGE_AUTH_HEADERS)
+        sleep(0.3)
+        release_write.set()
+        first_resp = first_probe.result(timeout=2)
+
+    assert first_resp.status_code == 503
+    assert first_resp.json()["reason"] == "storage_probe_timeout"
+    assert resp.status_code == 503
+    assert resp.json() == {
+        "status": "unhealthy",
+        "reason": "storage_probe_in_progress",
+    }
+    assert write_calls == 1


### PR DESCRIPTION
## Summary
- Adds an admin-protected `/healthz/storage` endpoint that performs a bounded write/read/delete round trip through `nexus_fs`.
- Adds a single-flight guard so hung storage probes do not start additional backend write probes.
- Limits Foyer stale-cache fallback to the prior 24-hour cleanup window and fixes `.dockerignore` whitespace from review.
- Adds unit coverage for storage probe auth, in-progress behavior, storage failures, cleanup failures, and expired stale fallback behavior.

Closes #4171

## Validation
- `PYTHONPATH=src:tests /opt/anaconda3/bin/python -m pytest -n0 tests/unit/server/health tests/unit/server/test_sandbox_route_allowlist.py tests/unit/server/test_app_state.py -q` -> 46 passed
- `/opt/anaconda3/bin/python -m ruff check src/nexus/server/health/probes.py tests/unit/server/health/test_probes.py` -> All checks passed
- `cargo fmt --manifest-path nexus-fuse/Cargo.toml --check` -> passed
- `git diff --check 5698d0026af0725e78c94d47cf69cc29a056fa62` -> passed

## Notes
`cargo test --manifest-path nexus-fuse/Cargo.toml expired_stale_entry_is_not_returned_on_transient_revalidation_error --no-run` is blocked in this local environment before crate compilation because `fuser` cannot find `pkg-config`/FUSE (`pkg-config` command not found).
