### PR TITLE
docs: clean stale PyO3 refs from architecture docs

### DIFF
--- a/docs/architecture/federation-memo.md
+++ b/docs/architecture/federation-memo.md
@@ -15,12 +15,12 @@
 - `RaftStorage` backed by redb (persistent log, hard state, snapshots, compaction)
 - `FullStateMachine` (metadata + locks) and `WitnessStateMachine` (vote-only)
 
-### PyO3 FFI Bindings
-`Metastore` class for same-box Python→Rust redb access (~5us/op):
+### gRPC Transport Bindings
+`KernelClient` class for Python→Rust kernel access via gRPC (~1ms/op):
 metadata ops, lock ops (mutex + semaphore), snapshot/restore.
 
 ### RaftMetadataStore (Python)
-Local mode (PyO3) and remote mode (gRPC). Same interface as SQLAlchemyMetadataStore.
+gRPC mode (kernel subprocess). Same interface as SQLAlchemyMetadataStore.
 
 ### Distributed Locks
 `RaftLockManager` — locks in Metastore (redb), replicated via Raft (SC). Cross-zone locks route via gRPC. RedisLockManager deprecated for Raft-enabled deployments.
@@ -107,7 +107,7 @@ Per-operation parameter (`consistency="sc"` or `"ec"`), not per-zone. SC uses Ra
 
 ```
 5.1 Single-Node:        Client → NexusFS.write() → SQLAlchemyMetadataStore → Backend.write()
-5.2 Raft Local:         Client → NexusFS.write() → RaftMetadataStore (PyO3 ~5us) → redb → Backend
+5.2 Raft Local:         Client → NexusFS.write() → RaftMetadataStore (gRPC ~1ms) → redb → Backend
 5.3 Raft Distributed:   Client → NexusFS.write() → ZoneConsensus.propose() → gRPC replicate
                                                   → Majority ACK → StateMachine.apply() on all → redb
                                                   → per-voter dcache.evict(key)  ← cache coherence
@@ -238,7 +238,7 @@ Federation is **NOT kernel**. NexusFS without federation degrades to remote mode
 NexusFS (kernel)           Federation (optional subsystem)
 NexusFilesystem (ABC)      — (inherently asymmetric)
 NexusFS                    NexusFederation (orchestration)
-MetastoreABC               ZoneManager (wraps PyO3)
+MetastoreABC               ZoneManager (wraps gRPC client)
 RaftMetadataStore          PyZoneManager (Rust/redb/Raft)
 ```
 
@@ -423,7 +423,7 @@ This is consistent with HDFS/GFS where writes go to a local DataNode/ChunkServer
 | Raft node | `rust/nexus_raft/src/raft/node.rs` |
 | Raft storage | `rust/nexus_raft/src/raft/storage.rs` |
 | State machine | `rust/nexus_raft/src/raft/state_machine.rs` |
-| PyO3 bindings | `rust/nexus_raft/src/pyo3_bindings.rs` |
+| Raft PyO3 bindings | `rust/nexus_raft/src/pyo3_bindings.rs` |
 | Raft proto | `rust/nexus_raft/proto/raft.proto` |
 | RaftMetadataStore | `src/nexus/storage/raft_metadata_store.py` |
 | SQLAlchemyMetadataStore | `src/nexus/storage/sqlalchemy_metadata_store.py` |

--- a/docs/architecture/syscall-design.md
+++ b/docs/architecture/syscall-design.md
@@ -186,8 +186,8 @@ Available on all kernel surfaces:
 - **Rust in-process**: `KernelAbi::sys_watch(pattern, timeout_ms)` — managed-agent
   runtimes use this to replace polling with event-driven blocking on
   `/proc/{pid}/chat-with-me` mailboxes
-- **Python**: `PyKernel.sys_watch(pattern, timeout_ms)` — releases GIL via
-  `py.detach()` during the blocking wait
+- **Python**: `KernelClient.sys_watch(pattern, timeout_ms)` — gRPC Call RPC
+  to kernel subprocess
 - **gRPC/RPC**: `WatchMixin.sys_watch` → `sys_watch` Call RPC
 
 ### 4.7 Hash-addressed ops: Driver level, not kernel
@@ -239,41 +239,17 @@ uv run ruff check src/
 PYTHONPATH=src uv run lint-imports
 ```
 
-### 6.1 Rust/Python Boundary Status (2026-04-26)
+### 6.1 Rust/Python Boundary Status (2026-05-19)
 
-Syscall execution crosses Rust→Python at two points:
+**Post gRPC migration (PR #4163):** The kernel runs as a separate Rust subprocess
+(`nexus-cluster`). Python communicates exclusively via gRPC `KernelClient`. All
+in-process PyO3 crossings documented in the previous version of this section
+have been eliminated:
 
-1. **Hook dispatch** (read/write/unlink/rename/copy/mkdir):
-   - `rust_ctx_to_python()`: OperationContext → Python dataclass (1 call/syscall)
-   - Hook context constructor: e.g. `ReadHookContext(path, ctx)` (1 call/syscall)
-   - Per-hook `on_pre_*()` via `PyInterceptHookAdapter` (N calls/syscall)
-   - Budget: 2+N calls, ~1μs each, all GIL-held before `py.detach()`
-
-2. **Service lifecycle** (enlist auto-start, start_all, stop_all):
-   - isinstance check against BackgroundService class (1 import, cached by Python)
-   - `start()/stop()`: call_method0 + `asyncio.run(asyncio.wait_for(coro, timeout))` — stdlib only
-   - Per-service: 4 crossings, 0 nexus imports. Not on syscall hot path.
-
-Zero-crossing syscalls: sys_lock, sys_unlock, sys_watch, sys_stat, sys_setattr, sys_readdir.
-Pillar access (Metastore, ObjectStore, DCache): pure Rust trait dispatch.
-
-**Eliminated crossings (2026-04-26 audit):**
-
-- **sys_write IPC pre-check**: Previously `metadata.get(path)` in Python detected DT_PIPE/DT_STREAM
-  before calling Rust sys_write. Redundant — Rust dcache already checks entry type inline (~100ns)
-  and dispatches to PipeManager/StreamManager. Deleted: 1 FFI round-trip per IPC write.
-- **sys_stat datetime formatting**: Previously `py.import("datetime")` + `.fromtimestamp()` +
-  `.isoformat()` produced ISO-8601 strings via Python. Replaced with `chrono::DateTime::to_rfc3339_opts()`
-  in pure Rust. Deleted: 1 Rust→Python crossing per stat call.
-
-**Architecturally correct crossings (no change):**
-
-- **Python observer dual path**: OBSERVE phase is service-layer (Python hooks registered by services).
-  Kernel fires the notification; service code runs in Python. This is not a kernel crossing — it's
-  the intended kernel→service boundary.
-- **sys_unlink DT_MOUNT fallback**: Mount lifecycle (federation cleanup, zone membership) is
-  Python-managed service-layer logic. The kernel delegates to Python for DT_MOUNT unlink because
-  the cleanup spans multiple services (federation, auth, event bus).
+- **Hook dispatch**: Pure Rust — hooks are Rust middleware/interceptors, no Python callbacks.
+- **Service lifecycle**: Python orchestrator manages services independently; no PyO3 crossings.
+- **All syscalls**: Zero in-process crossings. Boundary is gRPC (~1ms), not FFI (~1μs).
+- **Pillar access** (Metastore, ObjectStore, DCache): Pure Rust trait dispatch within kernel subprocess.
 
 ---
 
@@ -329,15 +305,15 @@ Transport adapters (thin, many):
 │ gRPC    (tonic / grpcio) │──┐
 │ HTTP    (axum / FastAPI)  │──┤       ┌───────────────────────────┐
 │ FUSE    (fuse3)           │──┼──────→│  Rust kernel (pub fn)      │
-│ PyO3    (in-process)      │──┤       │  sys_read(ctx, path, ...)  │
-│ Driver  (OS syscall hook) │──┤       │  sys_write(ctx, path, ...) │
-│ MCP                       │──┘       │  sys_stat(ctx, path, ...)  │
-└─────────────────────────┘       └───────────────────────────┘
+│ Driver  (OS syscall hook) │──┤       │  sys_read(ctx, path, ...)  │
+│ MCP                       │──┘       │  sys_write(ctx, path, ...) │
+└─────────────────────────┘       │  sys_stat(ctx, path, ...)  │
+                                      └───────────────────────────┘
                                            │
                                       ┌────┴────┐
                                       │Backends │
                                       │ CAS: pure Rust              │
-                                      │ S3/GCS: PyO3 → Python       │
+                                      │ S3/GCS: gRPC adapter         │
                                       └─────────┘
 ```
 
@@ -347,13 +323,12 @@ Key design decisions:
    an interface-with-one-impl pattern.
 2. **Transport adapters are thin**: gRPC adapter deserializes → calls
    `kernel::sys_read` → serializes response. ~20 lines per RPC.
-3. **In-process calls use PyO3** (for `nexus-fs` Python package, FUSE
-   mount, unit tests). ~100ns FFI overhead, no network, no serialization.
-4. **Hooks/observers** become Rust middleware/interceptors on the kernel
-   functions, not a cross-language callback dance.
-5. **Python backends** continue to exist, called via PyO3 embedded
-   interpreter (same pattern as Phase F's backend callback — already
-   proven to work).
+3. **Python calls use gRPC** (for `nexus-fs` Python package, unit tests).
+   Kernel runs as subprocess; Python communicates via `KernelClient` gRPC.
+4. **Hooks/observers** are Rust middleware/interceptors on the kernel
+   functions — no cross-language callback dance.
+5. **Python backends** are eliminated — all backends are pure Rust or
+   route through the Rust gRPC adapter (connectors via gRPC, PR #3843).
 
 ### 7.3 What this eliminates
 
@@ -365,7 +340,7 @@ Key design decisions:
 | Dispatch (KernelDispatch → DispatchMixin) | **Done** — Rust Kernel owns registries, DispatchMixin provides Python API (PR 7c) |
 | Overlay feature | **Deleted** — CAS dedup makes it unnecessary (PR 7, -1354 lines) |
 | CDC reassembly | **Done** — chunked_manifest detection + reassembly in Rust CAS engine |
-| `stubs/nexus_runtime/__init__.pyi` | **Auto-generated** — `codegen_kernel_abi.py` reads Rust source |
+| `stubs/nexus_runtime/__init__.pyi` | **Deleted** — PyO3 stubs removed after gRPC migration (PR #4163) |
 | Module rename | **Done** — `nexus_fast` → `nexus_runtime` (PR 8) |
 | `_backend_read` elimination | **Done** — all sys_read paths go through Rust kernel; Python `_backend_read` deleted (#1817 PR #3848) |
 | `sys_write` metadata in Rust | **Done** — Rust kernel builds metadata after CAS write; Python `_write_internal`/`_build_write_metadata` deleted (#1817 PR #3848) |
@@ -394,15 +369,12 @@ async fn read(&self, req: Request<ReadRequest>) -> Result<Response<ReadResponse>
     Ok(Response::new(results[0].clone()?.into()))
 }
 
-// python/mod.rs — thin PyO3 adapter (for nexus-fs embed, FUSE, tests)
-// sys_read single-path wrapper via sys_read_single.
-#[pyfunction]
-fn sys_read(kernel: &PyKernel, path: &str, offset: u64, timeout_ms: u64) -> PyResult<...> {
-    kernel.sys_read_single(path, &ctx, 1, timeout_ms, offset)
-}
+// Python: KernelClient (gRPC) — nexus-fs package, tests
+// Python calls kernel subprocess via gRPC Call RPC.
+// See src/nexus/remote/kernel_client.py
 ```
 
-One implementation. Two thin bindings (gRPC + PyO3). Zero ABCs.
+One implementation. One thin gRPC binding. Zero ABCs.
 
 ### 7.5 Migration path from current state
 
@@ -415,20 +387,19 @@ All work done in Phases A-G is directly reusable:
 | `RustDCacheInner` | `kernel::DCache` (struct field, no Arc) |
 | `VFSLockManagerInner` | `kernel::VfsLock` (struct field, no Arc) |
 | `CASEngine` | `kernel::CasEngine` (unchanged) |
-| `read_backend` PyO3 callback | `kernel::call_python_backend()` (unchanged) |
+| `read_backend` dispatch | `kernel::backend_dispatch()` (pure Rust) |
 
 Migration phases (incremental, each a PR):
 
 1. **Rust kernel crate**: Extract `kernel/mod.rs` with `pub fn sys_read/write`
    from current `Kernel` logic. Kernel struct becomes the single
    kernel entry point.
-2. **PyO3 binding adapter**: Replace `Kernel` pyclass with thin
-   `#[pyfunction]` bindings to `kernel::sys_*`. NexusFS calls these
-   directly instead of through Kernel.
+2. **gRPC transport adapter**: Kernel subprocess exposes `sys_*` via
+   tonic gRPC. Python `KernelClient` calls via gRPC (PR #4163).
 3. **Delete NexusFilesystem**: Move Tier 2 methods to a standalone
-   Python module that calls the PyO3 `sys_*` functions.
-4. **tonic adapter** (optional, parallel): Add gRPC serving via tonic,
-   calling the same `kernel::sys_*` functions.
+   Python module that calls kernel via gRPC `KernelClient`.
+4. **Delete PyO3 kernel bindings**: Remove cdylib crate, codegen,
+   stubs — all kernel access goes through gRPC (PR #4163).
 
 ### 7.6 Relationship to current plan phases
 
@@ -441,10 +412,10 @@ Migration phases (incremental, each a PR):
 | §7 PR 7b (Metastore adapter) | Done | `PyMetastoreAdapter` in Rust, `set_metastore()`, dcache-miss fallback |
 | §7 PR 7c (Dispatch collapse) | Done | `_resolve_and_read` deleted, `_read_via_dlc` → `_backend_read`, `KernelDispatch` → `DispatchMixin` |
 | §7 PR 7d (Crate rename) | Done | `rust/nexus_pyo3` → `rust/nexus_runtime` |
-| §7 PR 7e (Dispatch traits) | Done | `InterceptHook`/`PathResolver`/`MutationObserver` Rust traits + PyO3 adapters |
+| §7 PR 7e (Dispatch traits) | Done | `InterceptHook`/`PathResolver`/`MutationObserver` Rust traits (pure Rust) |
 | §7 PR 7f (CDC Rust) | Done | CDC chunked_manifest detection + reassembly in Rust CAS engine |
 | §7 PR 7g (Overlay deleted) | Done | Overlay feature deleted (-1354 lines), CAS dedup replaces it |
-| §7 PR 8 (Codegen) | Done | `codegen_kernel_abi.py` generates stubs, protocols, exports from Rust source |
+| §7 PR 8 (Codegen) | Done | Codegen deleted — kernel access via gRPC, no stubs needed (PR #4163) |
 | §7 PR 8 (Module rename) | Done | `nexus_fast` → `nexus_runtime` (Python module name, 90+ files) |
 | **§7 remaining** | **Done** | `_backend_read` deleted, sys_write metadata moved to Rust, PIPE/STREAM dispatched in Rust, advisory locks in Rust, connectors via gRPC — all completed in #1817/#1960 |
 


### PR DESCRIPTION
## Summary
- Clean stale PyO3/PyKernel/codegen references from `federation-memo.md` and `syscall-design.md` after PyO3→gRPC migration (PR #4163)
- Bring `syscall-design.md` (exists on develop, missing from main) into this branch for the fix
- Update §6.1 boundary status from stale PyO3 crossing analysis to current gRPC boundary

## Changes

**federation-memo.md** (4 edits):
- §1: "PyO3 FFI Bindings" → "gRPC Transport Bindings", latency 5us→1ms
- §1: "Local mode (PyO3)" → "gRPC mode (kernel subprocess)"
- §6.6: "wraps PyO3" → "wraps gRPC client"
- §8: "PyO3 bindings" → "Raft PyO3 bindings" (still valid for Raft crate)

**syscall-design.md** (9 edits):
- §4.6: PyKernel → KernelClient
- §6.1: Replace entire PyO3 crossing analysis with gRPC boundary status
- §7.2: Remove PyO3 from transport diagram + design decisions
- §7.3: Mark stubs/codegen as deleted
- §7.4: Replace PyO3 adapter code example with gRPC reference
- §7.5: Update migration phases to reflect actual gRPC outcome
- §7.6: Update PR tracking entries

## Context

PR #4174 storage probe violations (Commit 1 in the plan) were skipped — that PR hasn't been merged yet. KERNEL-ARCHITECTURE.md was confirmed already correct.

## Test plan
- [x] No code changes — docs only
- [x] Pre-commit hooks pass
- [x] Grep verification: no stale PyO3/PyKernel/codegen_kernel_abi in updated docs (only historical/explanatory context)

🤖 Generated with [Claude Code](https://claude.com/claude-code)