### PR TITLE
fix: kernel boundary violations in storage probe + async_files

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,13 @@ repos:
         files: \.py$
         pass_filenames: true
 
+      - id: check-kernel-leak
+        name: Kernel Boundary Leak Check
+        entry: python .pre-commit-hooks/check_kernel_leak.py
+        language: python
+        files: ^src/nexus/(server|bricks)/.*\.py$
+        pass_filenames: false
+
       - id: extensions-index-verify
         name: Verify extensions.json is up to date
         entry: bash -c 'PYTHONPATH=src python -m nexus.extensions.index verify'

--- a/.pre-commit-hooks/check_kernel_leak.py
+++ b/.pre-commit-hooks/check_kernel_leak.py
@@ -1,0 +1,76 @@
+#!/usr/bin/env python3
+"""Pre-commit hook: block NexusFS._kernel access from service tier.
+
+Service-tier code (server/, bricks/) must interact with the kernel
+exclusively through public syscall methods (sys_read, sys_write,
+sys_stat, etc.).  Reaching into fs._kernel or nx._kernel bypasses
+the gRPC boundary and breaks the kernel contract.
+
+Allowed callers:
+- factory/ — DI wiring passes nx._kernel to service constructors
+- core/    — kernel implementation owns _kernel
+- fs/      — kernel adapter layer
+- tests/   — test fixtures may mock _kernel
+- cli/     — comments referencing _kernel (not calls)
+"""
+
+import re
+import sys
+from pathlib import Path
+
+# Directories where ._kernel access on an *external* object is forbidden.
+# self._kernel = own attribute is always OK (e.g. FederationRPC stores
+# its own kernel ref as self._kernel — that's DI, not boundary leak).
+GUARDED_DIRS = (
+    Path("src") / "nexus" / "server",
+    Path("src") / "nexus" / "bricks",
+)
+
+# Pattern: something._kernel that is NOT self._kernel
+# Matches: fs._kernel, nx._kernel, nexus_fs._kernel, svc.nexus_fs._kernel
+# Skips:   self._kernel (own attribute, OK)
+_LEAK_RE = re.compile(r"(?<!self)\._kernel\b")
+
+# Skip comment-only lines and suppressed lines
+_COMMENT_RE = re.compile(r"^\s*#")
+_SUPPRESS_RE = re.compile(r"#\s*kernel-leak-ok\b")
+
+
+def _check_file(path: Path) -> list[str]:
+    errors: list[str] = []
+    try:
+        text = path.read_text(encoding="utf-8")
+    except Exception:
+        return errors
+    for lineno, line in enumerate(text.splitlines(), start=1):
+        if _COMMENT_RE.match(line):
+            continue
+        if _SUPPRESS_RE.search(line):
+            continue
+        if _LEAK_RE.search(line):
+            errors.append(f"{path}:{lineno}: {line.strip()}")
+    return errors
+
+
+def main() -> int:
+    errors: list[str] = []
+    for guarded_dir in GUARDED_DIRS:
+        if not guarded_dir.exists():
+            continue
+        for py_file in guarded_dir.rglob("*.py"):
+            # Skip test files inside bricks/
+            if "/tests/" in str(py_file):
+                continue
+            errors.extend(_check_file(py_file))
+    if errors:
+        print("ERROR: NexusFS._kernel accessed from service tier.")
+        print("Use public fs.sys_*() methods instead.\n")
+        for e in errors:
+            print(f"  {e}")
+        print(f"\n{len(errors)} violation(s) found.")
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/src/nexus/bricks/mount/mount_service.py
+++ b/src/nexus/bricks/mount/mount_service.py
@@ -711,13 +711,10 @@ class MountService:
         if not self._check_permission(mount_point, "read", context):
             return None
 
-        _rust_kernel = getattr(self.nexus_fs, "_kernel", None) if self.nexus_fs else None
+        if not self.nexus_fs:
+            return None
         try:
-            _has_mount = (
-                _rust_kernel.sys_stat(mount_point, "root").get("entry_type") == 2
-                if _rust_kernel
-                else False
-            )
+            _has_mount = self.nexus_fs.sys_stat(mount_point).get("entry_type") == 2
         except Exception:
             _has_mount = False
         if _has_mount:
@@ -735,11 +732,10 @@ class MountService:
         Returns:
             True if mount exists
         """
-        _rust_kernel = getattr(self.nexus_fs, "_kernel", None) if self.nexus_fs else None
-        if not _rust_kernel:
+        if not self.nexus_fs:
             return False
         try:
-            return _rust_kernel.sys_stat(mount_point, "root").get("entry_type") == 2
+            return self.nexus_fs.sys_stat(mount_point).get("entry_type") == 2
         except Exception:
             return False
 

--- a/src/nexus/bricks/mount/mount_service.py
+++ b/src/nexus/bricks/mount/mount_service.py
@@ -313,27 +313,22 @@ class MountService:
         # Create directory entries for mount point AND parent directories
         # via sync metadata_put.
         if self.nexus_fs is not None and hasattr(self.nexus_fs, "metadata"):
-            from nexus.contracts.constants import ROOT_ZONE_ID
             from nexus.contracts.metadata import DT_DIR, DT_MOUNT
-            from nexus.lib.context_utils import get_zone_id
 
             if entry_type is None:
                 entry_type = DT_MOUNT
-
-            zone_id = get_zone_id(context) if context else "default"
 
             parts = mount_point.rstrip("/").split("/")
             for i in range(2, len(parts) + 1):
                 dir_path = "/".join(parts[:i])
                 try:
-                    existing = self.nexus_fs._kernel.access(dir_path, ROOT_ZONE_ID)
+                    existing = self.nexus_fs.access(dir_path)
                     if existing:
                         continue
                     is_mount_point = i == len(parts)
-                    self.nexus_fs._kernel.sys_setattr(
+                    self.nexus_fs.sys_setattr(
                         dir_path,
                         entry_type=entry_type if is_mount_point else DT_DIR,
-                        zone_id=zone_id,
                     )
                     logger.info(f"Created directory entry: {dir_path}")
                 except Exception as e:
@@ -597,15 +592,12 @@ class MountService:
         zone_id = get_zone_id(context)
 
         # --- NexusFS-based cleanup ---
-        if self.nexus_fs is not None and getattr(self.nexus_fs, "_kernel", None) is not None:
-            kernel = self.nexus_fs._kernel
+        if self.nexus_fs is not None:
             # Delete all metadata entries (mount point + children)
             try:
                 dir_prefix = mount_point if mount_point.endswith("/") else mount_point + "/"
-                child_entries = kernel.metastore_list_paginated(dir_prefix, True, 100000, None)[
-                    "items"
-                ]
-                paths_to_delete = [entry.path for entry in child_entries] if child_entries else []
+                child_paths = self.nexus_fs.sys_readdir(dir_prefix, recursive=True)
+                paths_to_delete = list(child_paths) if child_paths else []
                 paths_to_delete.append(mount_point)  # Include mount point itself
                 for path in paths_to_delete:
                     with contextlib.suppress(Exception):

--- a/src/nexus/bricks/portability/import_service.py
+++ b/src/nexus/bricks/portability/import_service.py
@@ -470,7 +470,7 @@ class ZoneImportService:
         target_zone_id = options.target_zone_id or record.zone_id
 
         # Check if file already exists
-        existing = self.nexus_fs._kernel.sys_stat(remapped_path, ROOT_ZONE_ID)
+        existing = self.nexus_fs.sys_stat(remapped_path)
 
         if existing is not None:
             # Handle conflict
@@ -625,14 +625,13 @@ class ZoneImportService:
             _modified_at = record.updated_at if options.preserve_timestamps else None
 
             # Store metadata via sys_setattr DT_REG upsert
-            self.nexus_fs._kernel.sys_setattr(
+            self.nexus_fs.sys_setattr(
                 path,
                 entry_type=0,  # DT_REG upsert
                 content_id=record.content_id,
                 size=record.size_bytes,
                 mime_type=record.file_type,
                 version=record.current_version if options.preserve_ids else 1,
-                zone_id=ROOT_ZONE_ID,
                 created_at_ms=int(_created_at.timestamp() * 1000) if _created_at else None,
                 modified_at_ms=int(_modified_at.timestamp() * 1000) if _modified_at else None,
             )

--- a/src/nexus/bricks/search/skeleton_pipe_consumer.py
+++ b/src/nexus/bricks/search/skeleton_pipe_consumer.py
@@ -196,10 +196,11 @@ class SkeletonPipeConsumer:
             if self._nx is not None and self._pipe_ready:
                 with contextlib.suppress(Exception):
                     # sys_unlink signals consumer to exit (NexusFileNotFoundError)
-                    from nexus_runtime import PyOperationContext
+                    from nexus.contracts.types import OperationContext
 
-                    self._nx._kernel.sys_unlink(
-                        _SKELETON_PIPE_PATH, PyOperationContext(is_system=True)
+                    self._nx.sys_unlink(
+                        _SKELETON_PIPE_PATH,
+                        context=OperationContext(user_id="system", groups=[], is_system=True),
                     )
             try:
                 await asyncio.wait_for(asyncio.shield(self._consumer_task), timeout=5.0)

--- a/src/nexus/bricks/share_link/share_link_service.py
+++ b/src/nexus/bricks/share_link/share_link_service.py
@@ -207,7 +207,7 @@ class ShareLinkService:
             # Determine resource type
             resource_type = "file"
             if self._nexus_fs.access(normalized_path):
-                stat = self._nexus_fs._kernel.sys_stat(normalized_path, ROOT_ZONE_ID)
+                stat = self._nexus_fs.sys_stat(normalized_path)
                 if stat and stat.get("is_directory", False):
                     resource_type = "directory"
 

--- a/src/nexus/contracts/wirable_fs.py
+++ b/src/nexus/contracts/wirable_fs.py
@@ -28,15 +28,13 @@ class WirableFS(Protocol):
     Do NOT use ``isinstance()`` checks in hot paths.
 
     Note: NexusFS no longer exposes a global ``backend`` property;
-    all I/O is routed through ``router.route(path).backend``. Post-W3
-    the ``metadata`` proxy field is gone too — services that need the
-    metastore reach it via ``self._kernel`` (a ``PyKernel`` exposing
-    the ``metastore_*`` PyO3 surface).
+    all I/O is routed through ``router.route(path).backend``. Post-gRPC
+    the ``metadata`` proxy field is gone too — services interact with
+    the kernel exclusively through public ``sys_*()`` methods on NexusFS.
     """
 
     def sys_read(self, path: str, **kwargs: Any) -> bytes: ...
 
-    _kernel: Any  # PyKernel — the metastore SSOT post-W3
     _record_store: "RecordStoreABC | None"
     _init_cred: "OperationContext | None"
     _config: Any

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -110,53 +110,17 @@ def _apply_zone_override(
 async def _read_connector_by_physical_path(
     fs: Any,
     display_path: str,
-    physical_path: str,
+    physical_path: str,  # noqa: ARG001 — kept for signature compat
     context: Any,
 ) -> bytes | None:
-    """Read connector file by resolving display path → physical backend path.
+    """Read connector file via kernel sys_read.
 
-    Routes through the mount point's connector backend using the raw
-    physical_path, not the human-readable display_path. Returns None
-    if routing fails so the caller can fall back to standard fs.read().
+    The kernel's mount LPM handles connector routing internally —
+    service tier should not resolve router/backend/physical_path manually.
+    Returns None if the read fails so the caller can fall back.
     """
     try:
-        parts = display_path.split("/")
-        if len(parts) >= 3:
-            mount_point = "/".join(parts[:3])
-            router = getattr(fs, "router", None) or getattr(fs, "path_router", None)
-            route_fn = getattr(router, "route", None)
-            route = route_fn(mount_point) if callable(route_fn) else None
-            if route is not None:
-                from nexus.contracts.types import OperationContext
-
-                read_context = OperationContext(
-                    user_id=getattr(context, "user_id", "anonymous"),
-                    groups=getattr(context, "groups", []),
-                    zone_id=getattr(context, "zone_id", None),
-                    zone_set=getattr(context, "zone_set", ()),
-                    zone_perms=getattr(context, "zone_perms", ()),
-                    is_admin=getattr(context, "is_admin", False),
-                    is_system=getattr(context, "is_system", False),
-                    backend_path=physical_path,
-                    virtual_path=display_path,
-                    mount_path=mount_point,
-                )
-                content = route.backend.read_content("", context=read_context)
-                if isinstance(content, bytes):
-                    return content
-                return bytes(content) if content else None
-            if callable(route_fn):
-                return None
-
-        # Fallback for newer kernels that can read the display path directly.
-        py_kernel = getattr(fs, "_kernel", None)
-        if py_kernel is None:
-            return None
-
-        try:
-            content = py_kernel.sys_read_raw(display_path, getattr(context, "zone_id", "root"))
-        except Exception:
-            return None
+        content = fs.sys_read(display_path, context=context)
         if isinstance(content, bytes):
             return content
         return bytes(content) if content else None

--- a/src/nexus/server/api/v2/routers/async_files.py
+++ b/src/nexus/server/api/v2/routers/async_files.py
@@ -690,16 +690,14 @@ def create_async_files_router(
                         _ss.validate_path_available(transaction_id, _norm_path)
                         # Capture original state for rollback
                         try:
-                            _orig_meta = fs._kernel.sys_stat(
-                                _norm_path, getattr(fs, "_zone_id", "root")
-                            )
+                            _orig_meta = fs.sys_stat(_norm_path, context=context)
                             if _orig_meta:
-                                _original_hash = _orig_meta.content_id
+                                _original_hash = _orig_meta.get("content_id")
                                 _original_metadata = {
-                                    "size": _orig_meta.size,
-                                    "version": _orig_meta.version,
-                                    "modified_at_ms": _orig_meta.modified_at_ms,
-                                    "backend_name": getattr(_orig_meta, "backend_name", None),
+                                    "size": _orig_meta.get("size"),
+                                    "version": _orig_meta.get("version"),
+                                    "modified_at_ms": _orig_meta.get("modified_at_ms"),
+                                    "backend_name": _orig_meta.get("backend_name"),
                                 }
                         except Exception:
                             _original_hash = None
@@ -1339,16 +1337,14 @@ def create_async_files_router(
                         _norm_path = _normalize_path(path)
                         _ss.validate_path_available(transaction_id, _norm_path)
                         try:
-                            _orig_meta = fs._kernel.sys_stat(
-                                _norm_path, getattr(fs, "_zone_id", "root")
-                            )
+                            _orig_meta = fs.sys_stat(_norm_path, context=context)
                             if _orig_meta:
-                                _original_hash = _orig_meta.content_id
+                                _original_hash = _orig_meta.get("content_id")
                                 _original_metadata = {
-                                    "size": _orig_meta.size,
-                                    "version": _orig_meta.version,
-                                    "modified_at_ms": _orig_meta.modified_at_ms,
-                                    "backend_name": getattr(_orig_meta, "backend_name", None),
+                                    "size": _orig_meta.get("size"),
+                                    "version": _orig_meta.get("version"),
+                                    "modified_at_ms": _orig_meta.get("modified_at_ms"),
+                                    "backend_name": _orig_meta.get("backend_name"),
                                 }
                         except Exception:
                             _original_hash = None

--- a/src/nexus/server/api/v2/routers/connectors.py
+++ b/src/nexus/server/api/v2/routers/connectors.py
@@ -630,32 +630,21 @@ async def mount_connector(
                 # in root-level readdir. sys_write creates files but the HTTP
                 # readdir doesn't synthesize parent directories from child paths.
                 try:
-                    from datetime import UTC, datetime
+                    from nexus.contracts.metadata import DT_DIR
 
-                    from nexus.contracts.metadata import FileMetadata
-
-                    meta_store = nx._kernel
-                    if meta_store:
-                        for dir_path in [
-                            "/skills",
-                            f"/skills/{connector_name}",
-                            f"/skills/{connector_name}/schemas",
-                        ]:
-                            try:
-                                if not meta_store.get(dir_path):
-                                    meta_store.put(
-                                        FileMetadata(
-                                            path=dir_path,
-                                            size=0,
-                                            content_id=None,
-                                            created_at=datetime.now(UTC),
-                                            modified_at=datetime.now(UTC),
-                                            version=1,
-                                            zone_id=mount_context.zone_id,
-                                        )
-                                    )
-                            except Exception:
-                                pass
+                    for dir_path in [
+                        "/skills",
+                        f"/skills/{connector_name}",
+                        f"/skills/{connector_name}/schemas",
+                    ]:
+                        try:
+                            if not nx.sys_stat(dir_path):
+                                nx.sys_setattr(
+                                    dir_path,
+                                    entry_type=DT_DIR,
+                                )
+                        except Exception:
+                            pass
                 except Exception:
                     pass
 
@@ -1029,7 +1018,7 @@ async def write_to_connector(
 
                 # Load existing metadata so permission hooks can distinguish
                 # overwrite (check WRITE on file) vs create (check WRITE on parent).
-                _old_meta = nx._kernel.sys_stat(mount_path, ROOT_ZONE_ID)
+                _old_meta = nx.sys_stat(mount_path)
 
                 nx.intercept_pre_write(
                     _WHC(

--- a/src/nexus/server/auth/oauth_init.py
+++ b/src/nexus/server/auth/oauth_init.py
@@ -65,7 +65,7 @@ def initialize_oauth_provider(nexus_fs: "NexusFS", auth_provider: Any) -> None:
         try:
             from nexus.storage.auth_stores.metastore_settings_store import MetastoreSettingsStore
 
-            _settings_store = MetastoreSettingsStore(nexus_fs._kernel)
+            _settings_store = MetastoreSettingsStore(nexus_fs)
         except Exception:
             pass
         oauth_crypto = OAuthCrypto(encryption_key=_oauth_enc_key, settings_store=_settings_store)

--- a/src/nexus/server/health/probes.py
+++ b/src/nexus/server/health/probes.py
@@ -129,8 +129,8 @@ def _run_storage_round_trip(nx_fs: Any) -> None:
         probe_error: Exception | None = None
 
         try:
-            nx_fs.write(path=probe_path, buf=_STORAGE_PROBE_PAYLOAD, context=context)
-            readback = nx_fs.read(probe_path, context=context)
+            nx_fs.sys_write(probe_path, _STORAGE_PROBE_PAYLOAD, context=context)
+            readback = nx_fs.sys_read(probe_path, context=context)
             if readback != _STORAGE_PROBE_PAYLOAD:
                 raise RuntimeError("storage probe readback mismatch")
         except Exception as exc:

--- a/src/nexus/server/lifespan/permissions.py
+++ b/src/nexus/server/lifespan/permissions.py
@@ -412,7 +412,7 @@ async def _startup_tiger_cache(app: "FastAPI", svc: "LifespanServices") -> list[
                     expander = DirectoryGrantExpander(
                         engine=_rebac_engine,
                         tiger_cache=tiger_cache,
-                        metadata_store=svc.nexus_fs._kernel,
+                        metadata_store=svc.nexus_fs,
                     )
                     app.state.directory_grant_expander = expander
 

--- a/src/nexus/server/lifespan/search.py
+++ b/src/nexus/server/lifespan/search.py
@@ -230,7 +230,7 @@ async def startup_search(app: "FastAPI", svc: "LifespanServices") -> list[asynci
         with contextlib.suppress(ImportError, AttributeError):
             from nexus.storage.auth_stores.metastore_settings_store import MetastoreSettingsStore
 
-            _settings_store = MetastoreSettingsStore(svc.nexus_fs._kernel)
+            _settings_store = MetastoreSettingsStore(svc.nexus_fs)
 
         # Issue #2188: Create ZoektClient + embedding provider via DI
         _zoekt_client = None

--- a/src/nexus/server/lifespan/services.py
+++ b/src/nexus/server/lifespan/services.py
@@ -200,7 +200,7 @@ def _startup_key_service(app: "FastAPI", svc: "LifespanServices") -> None:
                     MetastoreSettingsStore,
                 )
 
-                _identity_settings_store = MetastoreSettingsStore(svc.nexus_fs._kernel)
+                _identity_settings_store = MetastoreSettingsStore(svc.nexus_fs)
             except Exception:
                 pass
             _identity_oauth_crypto = OAuthCrypto(

--- a/src/nexus/storage/auth_stores/metastore_settings_store.py
+++ b/src/nexus/storage/auth_stores/metastore_settings_store.py
@@ -20,7 +20,6 @@ import json
 from typing import Any
 
 from nexus.contracts.auth_store_types import SystemSettingDTO
-from nexus.contracts.constants import ROOT_ZONE_ID
 
 _CFG_PREFIX = "/settings/"
 
@@ -28,17 +27,17 @@ _CFG_PREFIX = "/settings/"
 class MetastoreSettingsStore:
     """SystemSettingsStoreProtocol implementation backed by the kernel.
 
-    Accepts either a bare ``PyKernel`` (post-W3b factory wiring) or a
-    legacy ``RustMetastoreProxy`` shim — the constructor unwraps to the
-    kernel handle and dispatches to ``kernel.metastore_*`` directly.
+    Accepts a ``NexusFS`` (or any object exposing ``sys_stat`` / ``sys_setattr``)
+    and routes through the public syscall API.  Settings are stored at
+    ``/settings/{key}`` in the root zone — no zone_id needed since the
+    kernel resolves root-zone paths by default.
     """
 
-    def __init__(self, metastore: Any) -> None:
-        self._metastore = metastore
-        self._kernel = metastore
+    def __init__(self, nexus_fs: Any) -> None:
+        self._fs = nexus_fs
 
     def get_setting(self, key: str) -> SystemSettingDTO | None:
-        stat = self._kernel.sys_stat(f"{_CFG_PREFIX}{key}", ROOT_ZONE_ID)
+        stat = self._fs.sys_stat(f"{_CFG_PREFIX}{key}")
         if stat is None or not stat.get("content_id"):
             return None
         try:
@@ -64,10 +63,9 @@ class MetastoreSettingsStore:
         if description is not None:
             payload["d"] = description
         json_payload = json.dumps(payload)
-        self._kernel.sys_setattr(
+        self._fs.sys_setattr(
             f"{_CFG_PREFIX}{key}",
             entry_type=0,  # DT_REG upsert
             content_id=json_payload,
             size=0,
-            zone_id=ROOT_ZONE_ID,
         )

--- a/tests/unit/bricks/mount/test_mount_core_service.py
+++ b/tests/unit/bricks/mount/test_mount_core_service.py
@@ -28,17 +28,11 @@ def _mock_nexus_fs(*, permission_ok: bool = True) -> MagicMock:
     rebac_svc.rebac_check_sync.return_value = permission_ok
     rebac_svc.rebac_delete_object_tuples_sync.return_value = 0
     nx.service.return_value = rebac_svc
-    # kernel mocks (post-C10a/C11: mount_service routes through
-    # access, metastore_list_paginated, sys_unlink instead of the
-    # legacy metastore ABIs)
-    nx._kernel.metastore_list_paginated.return_value = {
-        "items": [],
-        "has_more": False,
-        "next_cursor": None,
-        "total_count": 0,
-    }
-    nx._kernel.access.return_value = False
-    nx._kernel.sys_unlink.return_value = {}
+    # Public API mocks (post-C10a/C11: mount_service routes through
+    # NexusFS public API instead of _kernel internals)
+    nx.sys_readdir.return_value = []
+    nx.access.return_value = True
+    nx.sys_unlink.return_value = {}
     nx._record_store = None
     return nx
 
@@ -118,7 +112,19 @@ class TestAddMountRollback:
     def test_mkdir_failure_is_best_effort_no_rollback(self) -> None:
         """metadata.put failure is non-critical -- mount stays active (best effort)."""
         service, nx = _build_service()
-        nx._kernel.sys_setattr.side_effect = RuntimeError("Metastore down")
+        # access returns False → _setup_mount_point tries to create dirs
+        nx.access.return_value = False
+        # First sys_setattr call (mount registration in add_mount_sync) succeeds;
+        # subsequent calls (directory creation in _setup_mount_point) fail.
+        _call_count = 0
+
+        def _setattr_side_effect(*args, **kwargs):
+            nonlocal _call_count
+            _call_count += 1
+            if _call_count > 1:
+                raise RuntimeError("Metastore down")
+
+        nx.sys_setattr.side_effect = _setattr_side_effect
 
         # metadata.put fails but is caught in _setup_mount_point -- mount succeeds
         result = service.add_mount_sync(
@@ -225,7 +231,7 @@ class TestRemoveMountErrorCollection:
     def test_metadata_failure_does_not_block_permission_cleanup(self) -> None:
         """Even if metadata list fails, permission cleanup still runs."""
         service, nx = _build_service()
-        nx._kernel.metastore_list_paginated.side_effect = RuntimeError("metadata DB error")
+        nx.sys_readdir.side_effect = RuntimeError("metadata DB error")
 
         result = service.remove_mount_sync("/mnt/test")
 
@@ -237,7 +243,7 @@ class TestRemoveMountErrorCollection:
         """Multiple cleanup failures are all reported in result["errors"]."""
         service, nx = _build_service()
         # Metadata list_paginated failure
-        nx._kernel.metastore_list_paginated.side_effect = RuntimeError("metadata failure")
+        nx.sys_readdir.side_effect = RuntimeError("metadata failure")
         # Directory-index cleanup is now a no-op (W1.5: kernel doesn't expose
         # ``delete_directory_entries_recursive``); the side-effect is no
         # longer reachable but kept here as a documentation marker.

--- a/tests/unit/server/health/test_storage_probe.py
+++ b/tests/unit/server/health/test_storage_probe.py
@@ -34,7 +34,7 @@ def test_storage_probe_requires_admin_auth() -> None:
 def test_storage_probe_succeeds_when_round_trip_succeeds() -> None:
     app = _make_storage_app()
     mock_fs = MagicMock()
-    mock_fs.read.return_value = b"nexus-healthz-storage-probe"
+    mock_fs.sys_read.return_value = b"nexus-healthz-storage-probe"
     app.state.nexus_fs = mock_fs
 
     client = TestClient(app)
@@ -43,14 +43,15 @@ def test_storage_probe_succeeds_when_round_trip_succeeds() -> None:
     assert resp.status_code == 200
     assert resp.json()["status"] == "healthy"
 
-    write_kwargs = mock_fs.write.call_args.kwargs
-    probe_path = write_kwargs["path"]
-    context = write_kwargs["context"]
+    call_args = mock_fs.sys_write.call_args
+    probe_path = call_args.args[0]
+    probe_data = call_args.args[1]
+    context = call_args.kwargs["context"]
     assert probe_path.startswith("/__healthz__/")
-    assert write_kwargs["buf"] == b"nexus-healthz-storage-probe"
+    assert probe_data == b"nexus-healthz-storage-probe"
     assert context.is_system is True
 
-    mock_fs.read.assert_called_once_with(probe_path, context=context)
+    mock_fs.sys_read.assert_called_once_with(probe_path, context=context)
     mock_fs.sys_unlink.assert_called_once_with(probe_path, context=context)
 
 
@@ -69,7 +70,7 @@ def test_storage_probe_503_when_nexus_fs_missing() -> None:
 def test_storage_probe_503_when_storage_write_fails() -> None:
     app = _make_storage_app()
     mock_fs = MagicMock()
-    mock_fs.write.side_effect = OSError(28, "No space left on device")
+    mock_fs.sys_write.side_effect = OSError(28, "No space left on device")
     app.state.nexus_fs = mock_fs
 
     client = TestClient(app, raise_server_exceptions=False)
@@ -85,7 +86,7 @@ def test_storage_probe_503_when_storage_write_fails() -> None:
 def test_storage_probe_503_when_readback_does_not_match() -> None:
     app = _make_storage_app()
     mock_fs = MagicMock()
-    mock_fs.read.return_value = b"wrong"
+    mock_fs.sys_read.return_value = b"wrong"
     app.state.nexus_fs = mock_fs
 
     client = TestClient(app, raise_server_exceptions=False)
@@ -102,7 +103,7 @@ def test_storage_probe_503_when_readback_does_not_match() -> None:
 def test_storage_probe_cleanup_runs_after_read_failure() -> None:
     app = _make_storage_app()
     mock_fs = MagicMock()
-    mock_fs.read.side_effect = RuntimeError("read failed")
+    mock_fs.sys_read.side_effect = RuntimeError("read failed")
     app.state.nexus_fs = mock_fs
 
     client = TestClient(app, raise_server_exceptions=False)
@@ -118,7 +119,7 @@ def test_storage_probe_cleanup_runs_after_read_failure() -> None:
 def test_storage_probe_503_when_cleanup_fails_after_successful_readback() -> None:
     app = _make_storage_app()
     mock_fs = MagicMock()
-    mock_fs.read.return_value = b"nexus-healthz-storage-probe"
+    mock_fs.sys_read.return_value = b"nexus-healthz-storage-probe"
     mock_fs.sys_unlink.side_effect = RuntimeError("delete failed")
     app.state.nexus_fs = mock_fs
 
@@ -140,15 +141,15 @@ def test_storage_probe_503_when_probe_already_in_progress(monkeypatch) -> None:
     counter_lock = Lock()
     write_calls = 0
 
-    def blocking_write(**_: object) -> None:
+    def blocking_write(*_args: object, **_kwargs: object) -> None:
         nonlocal write_calls
         with counter_lock:
             write_calls += 1
         write_started.set()
         release_write.wait(timeout=5)
 
-    mock_fs.write.side_effect = blocking_write
-    mock_fs.read.return_value = b"nexus-healthz-storage-probe"
+    mock_fs.sys_write.side_effect = blocking_write
+    mock_fs.sys_read.return_value = b"nexus-healthz-storage-probe"
     app.state.nexus_fs = mock_fs
     monkeypatch.setenv("NEXUS_HEALTHZ_STORAGE_TIMEOUT_SECONDS", "0.2")
 

--- a/tests/unit/services/test_mount_service.py
+++ b/tests/unit/services/test_mount_service.py
@@ -44,15 +44,7 @@ def mock_nexus_fs():
     fs.mkdir = MagicMock()
     fs.sys_write = MagicMock()
     fs.sys_unlink = MagicMock()
-    fs._kernel.sys_unlink = MagicMock()
-    fs._kernel.metastore_list_paginated = MagicMock(
-        return_value={
-            "items": [],
-            "has_more": False,
-            "next_cursor": None,
-            "total_count": 0,
-        }
-    )
+    fs.sys_readdir = MagicMock(return_value=[])
     fs.rebac_add_tuple = MagicMock()
     fs.rebac_check = MagicMock(return_value=True)
     fs.rebac_delete_object_tuples = MagicMock(return_value=0)
@@ -223,7 +215,7 @@ class TestRemoveMount:
     def test_remove_mount_handles_cleanup_errors(self, mount_service, mock_nexus_fs):
         """Errors during cleanup are reported but don't fail the removal."""
         mount_service._driver_coordinator.unmount.return_value = True
-        mock_nexus_fs._kernel.metastore_list_paginated.side_effect = RuntimeError("DB error")
+        mock_nexus_fs.sys_readdir.side_effect = RuntimeError("DB error")
 
         result = asyncio.run(mount_service.remove_mount("/mnt/test"))
 
@@ -304,19 +296,17 @@ class TestGetMount:
 
     def test_get_mount_found(self, mount_service, mock_nexus_fs):
         """Getting an existing mount returns its details."""
-        mock_nexus_fs._kernel = MagicMock()
-        mock_nexus_fs._kernel.sys_stat.return_value = {"entry_type": 2}
+        mock_nexus_fs.sys_stat = MagicMock(return_value={"entry_type": 2})
 
         result = asyncio.run(mount_service.get_mount("/mnt/test"))
 
         assert result is not None
         assert result["mount_point"] == "/mnt/test"
-        mock_nexus_fs._kernel.sys_stat.assert_called_once_with("/mnt/test", "root")
+        mock_nexus_fs.sys_stat.assert_called_once_with("/mnt/test")
 
     def test_get_mount_not_found(self, mount_service, mock_nexus_fs):
         """Getting a non-existent mount returns None."""
-        mock_nexus_fs._kernel = MagicMock()
-        mock_nexus_fs._kernel.sys_stat.return_value = {"entry_type": 0}
+        mock_nexus_fs.sys_stat = MagicMock(return_value={"entry_type": 0})
 
         result = asyncio.run(mount_service.get_mount("/mnt/nonexistent"))
         assert result is None
@@ -332,15 +322,13 @@ class TestHasMount:
 
     def test_has_mount_true(self, mount_service, mock_nexus_fs):
         """has_mount returns True for existing mount."""
-        mock_nexus_fs._kernel = MagicMock()
-        mock_nexus_fs._kernel.sys_stat.return_value = {"entry_type": 2}
+        mock_nexus_fs.sys_stat = MagicMock(return_value={"entry_type": 2})
         assert asyncio.run(mount_service.has_mount("/mnt/test")) is True
-        mock_nexus_fs._kernel.sys_stat.assert_called_once_with("/mnt/test", "root")
+        mock_nexus_fs.sys_stat.assert_called_once_with("/mnt/test")
 
     def test_has_mount_false(self, mount_service, mock_nexus_fs):
         """has_mount returns False for non-existent mount."""
-        mock_nexus_fs._kernel = MagicMock()
-        mock_nexus_fs._kernel.sys_stat.return_value = {"entry_type": 0}
+        mock_nexus_fs.sys_stat = MagicMock(return_value={"entry_type": 0})
         assert asyncio.run(mount_service.has_mount("/mnt/nonexistent")) is False
 
 
@@ -425,15 +413,15 @@ class TestGrantMountOwnerPermission:
     def test_creates_directory_entry(self, mount_service, mock_nexus_fs, operation_context):
         """Mount point directory entries are created via _setup_mount_point."""
         # access returns False → dirs don't exist yet, so sys_setattr is called
-        mock_nexus_fs._kernel.access.return_value = False
+        mock_nexus_fs.access = MagicMock(return_value=False)
         mount_service._setup_mount_point("/mnt/test", operation_context)
         # sys_setattr called for /mnt and /mnt/test
-        assert mock_nexus_fs._kernel.sys_setattr.call_count == 2
+        assert mock_nexus_fs.sys_setattr.call_count == 2
 
     def test_handles_mkdir_error(self, mount_service, mock_nexus_fs, operation_context):
         """Errors creating directory do not prevent permission grant."""
-        mock_nexus_fs._kernel.access.return_value = False
-        mock_nexus_fs._kernel.sys_setattr.side_effect = RuntimeError("put failed")
+        mock_nexus_fs.access = MagicMock(return_value=False)
+        mock_nexus_fs.sys_setattr.side_effect = RuntimeError("put failed")
 
         # Should not raise — errors in directory creation are logged but not fatal
         mount_service._setup_mount_point("/mnt/test", operation_context)


### PR DESCRIPTION
## Summary
Fix 5 kernel boundary violations from PR #4173/#4174 audit + systematically eliminate all 13 `_kernel` leaks from service tier + add CI guard.

## Commits (6)

### 1. `fix(#4174): storage probe — use Tier 1 syscalls only`
- `nx_fs.write()` → `nx_fs.sys_write()`, `nx_fs.read()` → `nx_fs.sys_read()`

### 2. `fix(#4173): OCC rollback — use public fs.sys_stat() not fs._kernel`
- 2x `fs._kernel.sys_stat(path, zone_id)` → `fs.sys_stat(path, context=context)`

### 3. `fix(#4173): connector read — use fs.sys_read() not backend/kernel bypass`
- Delete 40-line triple-fallback, replace with single `fs.sys_read()`

### 4. `ci: add pre-commit hook to block NexusFS._kernel access`
- New `check_kernel_leak.py` blocks `foo._kernel` in `server/` and `bricks/`
- `self._kernel` (own DI attribute) is allowed; `fs._kernel` is blocked

### 5. `fix: eliminate 13 NexusFS._kernel leaks from service tier`
- MetastoreSettingsStore: accept NexusFS, not raw kernel (3 callers)
- permissions.py: pass nexus_fs to DirectoryGrantExpander
- connectors.py: kernel.get() → sys_stat(), kernel.sys_stat() → sys_stat()
- share_link: sys_stat via public API
- skeleton_pipe: sys_unlink via public API
- mount_service: access/sys_setattr/metastore_list_paginated → public API
- import_service: sys_stat/sys_setattr via public API

### 6. `fix: remove _kernel from WirableFilesystem contract`
- Delete `_kernel: Any` from Protocol — closes the root cause (IDE autocomplete)

## Verification
- [x] `python3 .pre-commit-hooks/check_kernel_leak.py` → 0 violations
- [x] All pre-commit hooks pass (ruff, mypy, brick imports, kernel leak check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)